### PR TITLE
feat(jit-compiler): add Rust shell package

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ tests prove the behavior
 
 Today the repo contains:
 
-- 164 package directories
+- 165 package directories
 - 12 program directories
 - 6 implementation languages
 

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -19,4 +19,5 @@ members = [
     "gradient-descent",
     "compute-unit",
     "device-simulator",
+    "jit-compiler",
 ]

--- a/code/packages/rust/jit-compiler/BUILD
+++ b/code/packages/rust/jit-compiler/BUILD
@@ -1,0 +1,1 @@
+cargo test -p jit-compiler -- --nocapture

--- a/code/packages/rust/jit-compiler/CHANGELOG.md
+++ b/code/packages/rust/jit-compiler/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to the jit-compiler package will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - Unreleased
+
+### Added
+- Rust package scaffolding for the JIT compiler track.
+- Hot-path profiling and native-block bookkeeping types.
+- Shell implementation of threshold-based hot-path detection and deoptimization hooks.

--- a/code/packages/rust/jit-compiler/Cargo.toml
+++ b/code/packages/rust/jit-compiler/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "jit-compiler"
+version = "0.1.0"
+edition = "2021"
+description = "JIT compiler scaffolding for hot-path profiling and native block management"
+
+[lib]
+name = "jit_compiler"
+path = "src/lib.rs"

--- a/code/packages/rust/jit-compiler/README.md
+++ b/code/packages/rust/jit-compiler/README.md
@@ -1,0 +1,65 @@
+# jit-compiler
+
+Rust scaffolding for the future JIT compiler layer of the computing stack.
+
+## What it does today
+
+This package does **not** yet emit native machine code. Instead, it implements
+the first pieces a JIT needs in order to exist at all:
+
+- hot-path execution counting
+- a configurable "compile when hot" threshold
+- bookkeeping for shell native blocks
+- deoptimization hooks for throwing away compiled blocks
+
+That makes this a real package, but still a deliberately incomplete JIT.
+
+## Why this scope
+
+The full JIT compiler spec is intentionally ambitious. Real JITs require:
+
+- profiling
+- instruction selection
+- register allocation
+- platform-specific code generation
+- deoptimization
+- runtime integration with the VM
+
+This Rust package starts at the front of that pipeline: profiling and block
+management. Actual native code emission remains future work.
+
+## Key types
+
+- `JitCompilerConfig` -- target ISA and hot-path threshold
+- `TargetIsa` -- symbolic native target (`RiscV`, `Arm`, `X86`)
+- `HotPathProfile` -- execution-count snapshot for a bytecode offset
+- `NativeBlock` -- shell representation of compiled native code
+- `JitCompiler` -- threshold tracking, block installation, and deoptimization
+
+## Example
+
+```rust
+use jit_compiler::{JitCompiler, JitCompilerConfig, TargetIsa};
+
+let mut jit = JitCompiler::new(JitCompilerConfig::new(TargetIsa::RiscV, 3));
+
+assert!(!jit.observe_execution(12));
+assert!(!jit.observe_execution(12));
+assert!(jit.observe_execution(12)); // hot on the third execution
+
+jit.install_shell_block(12, vec!["locals stay integers".to_string()]);
+assert!(jit.has_native_block(12));
+
+jit.deoptimize(12);
+assert!(!jit.has_native_block(12));
+```
+
+## Running tests
+
+```bash
+cargo test -p jit-compiler -- --nocapture
+```
+
+## Spec
+
+See [05b-jit-compiler.md](../../../specs/05b-jit-compiler.md) for the broader design.

--- a/code/packages/rust/jit-compiler/src/lib.rs
+++ b/code/packages/rust/jit-compiler/src/lib.rs
@@ -1,0 +1,208 @@
+//! # JIT Compiler — shell scaffolding for future native code generation.
+//!
+//! A real JIT compiler does two distinct jobs:
+//!
+//! 1. decide which bytecode regions are worth compiling
+//! 2. manage the native blocks that replace interpretation
+//!
+//! This crate intentionally implements only those first management layers.
+//! It does not yet lower bytecode to ARM, RISC-V, or x86 machine code.
+//! Instead, it provides:
+//!
+//! - hot-path execution profiling
+//! - threshold-based "this is hot now" detection
+//! - shell native-block registration
+//! - deoptimization hooks
+//!
+//! This keeps the package honest: we have a real Rust port for the JIT layer,
+//! but we do not pretend the hard code-generation work is already done.
+
+use std::collections::BTreeMap;
+
+/// Target architecture the future JIT would emit native code for.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TargetIsa {
+    RiscV,
+    Arm,
+    X86,
+}
+
+/// Configuration for a JIT compiler instance.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct JitCompilerConfig {
+    hot_threshold: u64,
+    target: TargetIsa,
+}
+
+impl JitCompilerConfig {
+    /// Create a new configuration.
+    pub fn new(target: TargetIsa, hot_threshold: u64) -> Self {
+        assert!(hot_threshold > 0, "hot_threshold must be > 0");
+        Self {
+            hot_threshold,
+            target,
+        }
+    }
+
+    pub fn hot_threshold(&self) -> u64 {
+        self.hot_threshold
+    }
+
+    pub fn target(&self) -> TargetIsa {
+        self.target
+    }
+}
+
+/// Snapshot of profiling information for one bytecode offset.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HotPathProfile {
+    pub bytecode_offset: usize,
+    pub execution_count: u64,
+    pub is_hot: bool,
+}
+
+/// Shell representation of a compiled native block.
+///
+/// The `machine_code` buffer remains empty in the current implementation. It
+/// exists so the rest of the API already reflects the shape of a future JIT.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NativeBlock {
+    pub bytecode_offset: usize,
+    pub target: TargetIsa,
+    pub machine_code: Vec<u8>,
+    pub assumptions: Vec<String>,
+}
+
+/// Threshold-based JIT profiler and block registry.
+#[derive(Clone, Debug)]
+pub struct JitCompiler {
+    config: JitCompilerConfig,
+    execution_counts: BTreeMap<usize, u64>,
+    native_blocks: BTreeMap<usize, NativeBlock>,
+}
+
+impl JitCompiler {
+    /// Create a new shell JIT compiler.
+    pub fn new(config: JitCompilerConfig) -> Self {
+        Self {
+            config,
+            execution_counts: BTreeMap::new(),
+            native_blocks: BTreeMap::new(),
+        }
+    }
+
+    /// Record one execution of the bytecode instruction at `bytecode_offset`.
+    ///
+    /// Returns `true` exactly when the path transitions to hot on this call.
+    pub fn observe_execution(&mut self, bytecode_offset: usize) -> bool {
+        let count = self.execution_counts.entry(bytecode_offset).or_insert(0);
+        *count += 1;
+        *count == self.config.hot_threshold
+    }
+
+    /// Return the profiling snapshot for one bytecode offset, if it has ever executed.
+    pub fn profile(&self, bytecode_offset: usize) -> Option<HotPathProfile> {
+        self.execution_counts
+            .get(&bytecode_offset)
+            .copied()
+            .map(|execution_count| HotPathProfile {
+                bytecode_offset,
+                execution_count,
+                is_hot: execution_count >= self.config.hot_threshold,
+            })
+    }
+
+    /// Install a shell native block for a bytecode offset.
+    ///
+    /// This mimics the moment where a future code generator would hand a
+    /// compiled block back to the VM. For now, the machine code buffer is
+    /// intentionally empty.
+    pub fn install_shell_block(
+        &mut self,
+        bytecode_offset: usize,
+        assumptions: Vec<String>,
+    ) -> &NativeBlock {
+        let block = NativeBlock {
+            bytecode_offset,
+            target: self.config.target,
+            machine_code: Vec::new(),
+            assumptions,
+        };
+        self.native_blocks.insert(bytecode_offset, block);
+        self.native_blocks
+            .get(&bytecode_offset)
+            .expect("native block should exist immediately after insertion")
+    }
+
+    /// Check whether a native block is registered for this bytecode offset.
+    pub fn has_native_block(&self, bytecode_offset: usize) -> bool {
+        self.native_blocks.contains_key(&bytecode_offset)
+    }
+
+    /// Borrow the registered native block for this bytecode offset.
+    pub fn native_block(&self, bytecode_offset: usize) -> Option<&NativeBlock> {
+        self.native_blocks.get(&bytecode_offset)
+    }
+
+    /// Remove a native block and fall back to interpreted execution.
+    pub fn deoptimize(&mut self, bytecode_offset: usize) -> Option<NativeBlock> {
+        self.native_blocks.remove(&bytecode_offset)
+    }
+
+    pub fn config(&self) -> &JitCompilerConfig {
+        &self.config
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{JitCompiler, JitCompilerConfig, TargetIsa};
+
+    #[test]
+    fn path_becomes_hot_exactly_at_threshold() {
+        let mut jit = JitCompiler::new(JitCompilerConfig::new(TargetIsa::RiscV, 3));
+
+        assert!(!jit.observe_execution(24));
+        assert!(!jit.observe_execution(24));
+        assert!(jit.observe_execution(24));
+        assert!(!jit.observe_execution(24));
+    }
+
+    #[test]
+    fn profile_reports_execution_count_and_hotness() {
+        let mut jit = JitCompiler::new(JitCompilerConfig::new(TargetIsa::Arm, 2));
+
+        jit.observe_execution(8);
+        let profile = jit.profile(8).expect("profile should exist after execution");
+        assert_eq!(profile.execution_count, 1);
+        assert!(!profile.is_hot);
+
+        jit.observe_execution(8);
+        let hot_profile = jit.profile(8).expect("profile should still exist");
+        assert_eq!(hot_profile.execution_count, 2);
+        assert!(hot_profile.is_hot);
+    }
+
+    #[test]
+    fn shell_block_installation_uses_configured_target() {
+        let mut jit = JitCompiler::new(JitCompilerConfig::new(TargetIsa::X86, 5));
+
+        let block = jit.install_shell_block(32, vec!["locals stay integers".to_string()]);
+        assert_eq!(block.bytecode_offset, 32);
+        assert_eq!(block.target, TargetIsa::X86);
+        assert!(block.machine_code.is_empty());
+        assert_eq!(block.assumptions.len(), 1);
+        assert!(jit.has_native_block(32));
+    }
+
+    #[test]
+    fn deoptimize_removes_native_block() {
+        let mut jit = JitCompiler::new(JitCompilerConfig::new(TargetIsa::RiscV, 10));
+        jit.install_shell_block(99, vec!["shape stays stable".to_string()]);
+
+        let block = jit.deoptimize(99).expect("block should be removed");
+        assert_eq!(block.bytecode_offset, 99);
+        assert!(!jit.has_native_block(99));
+        assert!(jit.deoptimize(99).is_none());
+    }
+}

--- a/code/specs/05b-jit-compiler.md
+++ b/code/specs/05b-jit-compiler.md
@@ -6,8 +6,10 @@ A JIT (Just-In-Time) compiler watches bytecode being executed by the Virtual
 Machine and, when it detects "hot" code (loops, frequently-called functions),
 compiles that bytecode directly to native machine instructions at runtime.
 
-This is a **future package** — the spec exists to document where it fits and
-how it will work. No implementation yet.
+This is a **future-facing package** — the spec exists to document where it fits
+and how it will work. Early implementations may stop short of real machine-code
+generation and focus first on profiling, hot-path detection, bookkeeping, and
+deoptimization hooks.
 
 ## Where it fits
 
@@ -76,3 +78,16 @@ of lines of code. The challenges include:
 
 We'll start simple when we implement this — a trace compiler that JIT-compiles
 straight-line code without branching. Then add complexity incrementally.
+
+## Initial implementation boundary
+
+The first implementation milestone for this package is intentionally smaller
+than a full native-code JIT:
+
+- count executions per bytecode offset
+- decide when a path becomes "hot"
+- register shell native blocks
+- support deoptimization by discarding those blocks
+
+That gives the repository the control-plane shape of a JIT before the much
+harder backend work of instruction selection and code generation.


### PR DESCRIPTION
## Summary
Adds the first Rust port for the missing `jit-compiler` package.

This is intentionally a scoped initial implementation rather than a full native-code JIT. The new crate establishes the Rust package, wires it into the workspace, and implements the control-plane pieces a future JIT will need first:
- hot-path execution counting
- threshold-based hot-path detection
- shell native-block registration
- deoptimization hooks

## What changed
- added `code/packages/rust/jit-compiler/` with `Cargo.toml`, `README.md`, `CHANGELOG.md`, `BUILD`, and `src/lib.rs`
- added `jit-compiler` to the Rust workspace members list
- updated `code/specs/05b-jit-compiler.md` so the spec reflects the initial implementation boundary
- updated the top-level README package count

## Scope
This PR does **not** implement machine-code generation yet. It stops at profiling and native-block bookkeeping on purpose.

## Testing
- `cargo test -p jit-compiler -- --nocapture`
