### PR TITLE
spec(fpga): FPGA abstraction — logic gates update, block RAM, FPGA fabric

### DIFF
--- a/code/specs/10-logic-gates.md
+++ b/code/specs/10-logic-gates.md
@@ -43,9 +43,257 @@ AND(a, b) = NOT(NAND(a, b))
 OR(a, b)  = NAND(NOT(a), NOT(b))
 ```
 
+### Sequential logic
+
+The gates above are "combinational" — output depends only on current inputs. Sequential
+logic adds **memory** through feedback (wiring a gate's output back to its input).
+
+From feedback, we build the entire memory hierarchy:
+
+```
+SR Latch          → raw 1-bit memory (2 cross-coupled NOR gates)
+D Latch           → controlled 1-bit memory (SR + enable signal)
+D Flip-Flop       → edge-triggered 1-bit memory (2 D latches, master-slave)
+Register          → N-bit word storage (N flip-flops in parallel)
+Shift Register    → serial-to-parallel converter (chained flip-flops)
+Counter           → binary counting (register + incrementer)
+```
+
+#### SR Latch
+
+Two NOR gates cross-coupled — each gate's output feeds into the other's input. This
+creates two stable states that persist even after inputs change.
+
+```
+S  R  | Q    Q_bar  | Action
+------+-------------+----------------------------------
+0  0  | Q    Q_bar  | Hold — remember previous state
+1  0  | 1    0      | Set — store a 1
+0  1  | 0    1      | Reset — store a 0
+1  1  | 0    0      | Invalid — both outputs forced low
+```
+
+#### D Latch
+
+Solves the SR latch's invalid state problem by deriving S and R from a single data
+input D. An enable signal controls when the latch is transparent vs. opaque.
+
+```
+D  E  | Q    Q_bar  | Action
+------+-------------+----------------------------------
+X  0  | Q    Q_bar  | Hold — latch is opaque
+0  1  | 0    1      | Store 0 — transparent
+1  1  | 1    0      | Store 1 — transparent
+```
+
+#### D Flip-Flop
+
+Master-slave configuration: two D latches in series with opposite enables. Data is
+captured at the **rising edge** of the clock (transition from 0→1). This prevents
+data races in pipelined circuits.
+
+```
+         ┌────────────┐          ┌────────────┐
+  Data ──┤ D Latch    ├──────────┤ D Latch    ├── Q
+         │ (Master)   │          │ (Slave)    │
+  CLK' ──┤ Enable     │   CLK ──┤ Enable     │
+         └────────────┘          └────────────┘
+```
+
+#### Register, Shift Register, Counter
+
+- **Register**: N flip-flops in parallel sharing a clock — captures an N-bit word simultaneously.
+- **Shift Register**: Chain of flip-flops where each output feeds the next input. Bits shift one position per clock cycle.
+- **Counter**: Register + incrementer (chain of half-adders with carry_in=1). Counts up on each clock cycle, wraps on overflow.
+
+### Combinational circuits
+
+Between primitive gates and full arithmetic circuits, there is a family of
+**combinational building blocks** used everywhere in digital design — CPUs, FPGAs,
+memory controllers, bus arbiters. These circuits have no memory; output depends only
+on current inputs.
+
+#### Multiplexer (MUX)
+
+A multiplexer is a **selector switch**. It takes N data inputs and a set of select
+lines, and routes exactly one input to the output. Think of it as a railroad switch
+that directs one of several trains onto a single track.
+
+**2-to-1 MUX** — the simplest case:
+
+```
+         ┌──────────┐
+  D0 ────┤          │
+         │   MUX    ├──── Output
+  D1 ────┤          │
+         └────┬─────┘
+              │
+  Sel ────────┘
+
+  Sel = 0 → Output = D0
+  Sel = 1 → Output = D1
+```
+
+Truth table:
+
+```
+Sel  D0  D1  │ Output
+─────────────┼───────
+ 0    0   X  │   0       D0 selected
+ 0    1   X  │   1       D0 selected
+ 1    X   0  │   0       D1 selected
+ 1    X   1  │   1       D1 selected
+```
+
+Built from gates: `Output = OR(AND(D0, NOT(Sel)), AND(D1, Sel))`
+
+**4-to-1 MUX** — uses 2 select lines:
+
+```
+         ┌──────────┐
+  D0 ────┤          │
+  D1 ────┤   MUX    ├──── Output
+  D2 ────┤          │
+  D3 ────┤          │
+         └───┬──┬───┘
+             │  │
+  S0 ────────┘  │
+  S1 ───────────┘
+
+  S1 S0 = 00 → Output = D0
+  S1 S0 = 01 → Output = D1
+  S1 S0 = 10 → Output = D2
+  S1 S0 = 11 → Output = D3
+```
+
+Built from three 2:1 MUXes or directly from AND/OR gates.
+
+**Why MUX matters everywhere:**
+- In FPGAs, a K-input LUT is literally a 2^K-to-1 MUX with the truth table stored in SRAM
+- In CPUs, MUXes select between register file outputs, ALU inputs, and forwarded values
+- In memory, MUXes route data to/from the correct bank
+
+**N-to-1 MUX** — generalizes to any power-of-2 size using ⌈log₂(N)⌉ select lines.
+Can be built recursively from 2:1 MUXes:
+
+```
+8:1 MUX = two 4:1 MUXes feeding a 2:1 MUX
+4:1 MUX = two 2:1 MUXes feeding a 2:1 MUX
+```
+
+#### Demultiplexer (DEMUX)
+
+The inverse of a MUX: one data input, N outputs, select lines choose which output
+receives the data. All other outputs are 0.
+
+**1-to-4 DEMUX:**
+
+```
+  Sel  │ Y0  Y1  Y2  Y3
+  ─────┼─────────────────
+  00   │  D   0   0   0
+  01   │  0   D   0   0
+  10   │  0   0   D   0
+  11   │  0   0   0   D
+```
+
+Used in memory address decoding: the address bits select which memory chip/bank
+receives the read/write signal.
+
+#### Decoder
+
+A decoder converts an N-bit binary input into a one-hot output — exactly one of
+2^N output lines is 1, the rest are 0. It's a DEMUX with the data input hardwired to 1.
+
+**2-to-4 Decoder:**
+
+```
+  A1  A0  │ Y0  Y1  Y2  Y3
+  ────────┼─────────────────
+   0   0  │  1   0   0   0
+   0   1  │  0   1   0   0
+   1   0  │  0   0   1   0
+   1   1  │  0   0   0   1
+```
+
+Built from AND and NOT gates:
+
+```
+Y0 = AND(NOT(A1), NOT(A0))
+Y1 = AND(NOT(A1), A0)
+Y2 = AND(A1, NOT(A0))
+Y3 = AND(A1, A0)
+```
+
+Used everywhere: instruction decoding in CPUs (opcode → control signals), memory chip
+select, interrupt priority encoding.
+
+**3-to-8 Decoder:** same pattern with 3 inputs, 8 outputs. Each output is an AND of
+all 3 input bits (or their complements).
+
+#### Encoder
+
+The inverse of a decoder: 2^N input lines (one-hot), N-bit binary output.
+
+**4-to-2 Encoder:**
+
+```
+  I0  I1  I2  I3  │ A1  A0
+  ────────────────┼────────
+   1   0   0   0  │  0   0
+   0   1   0   0  │  0   1
+   0   0   1   0  │  1   0
+   0   0   0   1  │  1   1
+```
+
+**Priority Encoder** — handles the case where multiple inputs are active. The
+highest-priority active input wins, and a "valid" output indicates whether any
+input is active at all.
+
+**4-to-2 Priority Encoder** (I3 = highest priority):
+
+```
+  I0  I1  I2  I3  │ A1  A0  Valid
+  ────────────────┼─────────────
+   0   0   0   0  │  X   X    0     No input active
+   1   0   0   0  │  0   0    1     I0 wins
+   X   1   0   0  │  0   1    1     I1 wins over I0
+   X   X   1   0  │  1   0    1     I2 wins over I0,I1
+   X   X   X   1  │  1   1    1     I3 always wins
+```
+
+Used in interrupt controllers (which interrupt fires when multiple arrive
+simultaneously?) and in FPGA carry chain logic.
+
+#### Tri-state buffer
+
+A tri-state buffer has three possible output states: 0, 1, or **high-impedance (Z)**.
+High-impedance means the output is electrically disconnected — as if the wire were cut.
+
+```
+  Data  Enable │ Output
+  ─────────────┼───────
+    0      0   │   Z      Disconnected
+    1      0   │   Z      Disconnected
+    0      1   │   0      Active low
+    1      1   │   1      Active high
+```
+
+Why this matters: in a shared bus (like a memory data bus), multiple devices connect
+to the same wires. Only one device can drive the bus at a time. Tri-state buffers let
+each device disconnect when it's not its turn, preventing electrical conflicts.
+
+In FPGAs, tri-state buffers appear in I/O blocks where pins can be configured as
+inputs (high-Z) or outputs (driven).
+
+**Modeling Z in software:** we represent high-impedance as `None` (Python), `nil`
+(Ruby), or a special sentinel value. The output type becomes `int | None` where `None`
+means high-impedance.
+
 ## Public API
 
 ```python
+# === Primitive Gates ===
 # All functions take int (0 or 1) and return int (0 or 1)
 
 def NOT(a: int) -> int: ...
@@ -65,16 +313,65 @@ def nand_xor(a: int, b: int) -> int: ...
 # Multi-input variants
 def AND_N(*inputs: int) -> int: ...  # AND with N inputs
 def OR_N(*inputs: int) -> int: ...   # OR with N inputs
+
+# === Sequential Logic ===
+
+def sr_latch(set_: int, reset: int, q: int = 0, q_bar: int = 1) -> tuple[int, int]: ...
+def d_latch(data: int, enable: int, q: int = 0, q_bar: int = 1) -> tuple[int, int]: ...
+def d_flip_flop(data: int, clock: int, ...) -> tuple[int, int, dict[str, int]]: ...
+def register(data: list[int], clock: int, ...) -> tuple[list[int], list[dict[str, int]]]: ...
+def shift_register(serial_in: int, clock: int, ...) -> tuple[list[int], int, list[dict[str, int]]]: ...
+def counter(clock: int, reset: int = 0, ...) -> tuple[list[int], dict]: ...
+
+# === Combinational Circuits ===
+
+def mux2(d0: int, d1: int, sel: int) -> int: ...
+    # 2-to-1 multiplexer: sel=0 → d0, sel=1 → d1
+
+def mux4(d0: int, d1: int, d2: int, d3: int, sel: list[int]) -> int: ...
+    # 4-to-1 multiplexer: sel is [s0, s1]
+
+def mux8(inputs: list[int], sel: list[int]) -> int: ...
+    # 8-to-1 multiplexer: sel is [s0, s1, s2]
+
+def mux_n(inputs: list[int], sel: list[int]) -> int: ...
+    # N-to-1 multiplexer (N must be power of 2)
+
+def demux(data: int, sel: list[int], n_outputs: int) -> list[int]: ...
+    # 1-to-N demultiplexer: routes data to selected output, others are 0
+
+def decoder(inputs: list[int]) -> list[int]: ...
+    # N-to-2^N decoder: input is N bits, output is 2^N bits (one-hot)
+
+def encoder(inputs: list[int]) -> list[int]: ...
+    # 2^N-to-N encoder: one-hot input, binary output
+
+def priority_encoder(inputs: list[int]) -> tuple[list[int], int]: ...
+    # Priority encoder: returns (binary_output, valid_flag)
+    # Highest-index active input wins
+
+def tri_state(data: int, enable: int) -> int | None: ...
+    # Tri-state buffer: enable=1 → data, enable=0 → None (high-Z)
 ```
 
 ## Data Flow
 
 ```
-Input:  one or two integers, each either 0 or 1
-Output: one integer, either 0 or 1
+Primitive gates:
+  Input:  one or two integers, each either 0 or 1
+  Output: one integer, either 0 or 1
+
+Sequential logic:
+  Input:  data bits + clock/enable signals + previous state
+  Output: new output bits + new internal state
+
+Combinational circuits:
+  Input:  data bits + select/control bits
+  Output: selected/decoded/encoded bits
 ```
 
 Inputs outside {0, 1} should raise a ValueError with a clear message.
+Tri-state buffer returns `None` for high-impedance state.
 
 ## Test Strategy
 
@@ -94,8 +391,30 @@ Additional tests:
 - Verify invalid inputs (2, -1, "a") raise ValueError
 - Verify type hints are correct with mypy/pyright
 
+Sequential logic tests:
+- SR latch: all truth table entries including hold and invalid states
+- D latch: transparent mode (enable=1) and opaque mode (enable=0)
+- D flip-flop: rising edge capture, verify data doesn't leak through during hold
+- Register: store and retrieve N-bit words, verify all bits captured simultaneously
+- Shift register: shift in a known pattern, verify serial and parallel outputs
+- Counter: count from 0 to max, verify overflow/wrap-around, verify reset
+
+Combinational circuit tests:
+- MUX2: exhaustive truth table (8 rows: 2 data × 1 select × 2 values each)
+- MUX4: verify each select combination routes the correct input
+- MUX8/MUX_N: verify select line routing for all positions
+- DEMUX: verify data appears on correct output, all others are 0
+- Decoder: verify one-hot output for all input combinations
+- Encoder: verify binary output for all valid one-hot inputs
+- Priority encoder: verify highest-priority input wins, valid flag correct
+- Tri-state: verify output matches data when enabled, returns None when disabled
+- Edge cases: MUX with all-0 inputs, all-1 inputs, decoder with all-0 input
+
 ## Future Extensions
 
 - **Gate delay simulation**: Model propagation delay through gates (useful for understanding timing in real circuits)
 - **Circuit visualization**: Render gate diagrams
 - **Gate count tracking**: Count how many primitive gates a complex circuit uses
+- **Barrel shifter**: Shift by arbitrary amounts in one step using MUX tree
+- **Comparator**: N-bit equality and magnitude comparison using XNOR gates
+- **Parity generator/checker**: XOR tree for error detection

--- a/code/specs/F00-block-ram.md
+++ b/code/specs/F00-block-ram.md
@@ -1,0 +1,417 @@
+# F00 — Block RAM
+
+## Overview
+
+Block RAM provides hardware-level read/write memory arrays built from logic gates. Unlike the existing ROM package (which is read-only) and the memory-controller package (which manages address spaces in software), this package models actual physical storage circuits — the kind etched into silicon in every CPU cache, FPGA, and SRAM chip.
+
+The fundamental storage element is the **SRAM cell**: six transistors (modeled as gates) that hold one bit indefinitely as long as power is supplied. From this single cell, we build arrays, address decoders, and complete RAM modules with single-port and dual-port interfaces.
+
+This package is a prerequisite for the FPGA abstraction (where Block RAM tiles are a key resource) and is also useful for CPU cache simulation, register file modeling, and any design that needs fast, hardware-accurate writable storage.
+
+## Layer Position
+
+```
+Logic Gates → [YOU ARE HERE] → FPGA (as Block RAM tiles)
+                             → CPU Cache (as SRAM arrays)
+                             → Register Files (as small, fast arrays)
+```
+
+**Input from:** Logic gates (AND, OR, NOT, NOR — for cell construction), combinational circuits (decoder, MUX — for address decoding and data routing).
+**Output to:** FPGA package (provides configurable BRAM tiles), CPU internals (cache data/tag arrays).
+
+## Concepts
+
+### How does a circuit "remember"?
+
+Memory requires **feedback** — wiring a gate's output back into its own input. The logic-gates package already demonstrates this with the SR latch (two cross-coupled NOR gates). Block RAM scales this idea from one bit to millions.
+
+The hierarchy:
+
+```
+SRAM Cell (1 bit)     → the atom of memory
+    │
+SRAM Array (N×M)      → grid of cells with row/column addressing
+    │
+RAM Module             → array + address decoder + read/write logic + I/O buffers
+    │
+Dual-Port RAM          → two independent ports (simultaneous read/write)
+    │
+Configurable BRAM      → width/depth reconfiguration (FPGA-style)
+```
+
+### The SRAM Cell — 6 Transistors That Hold One Bit
+
+In real hardware, an SRAM (Static Random-Access Memory) cell uses 6 transistors:
+- 2 cross-coupled inverters forming a bistable latch (holds the bit)
+- 2 access transistors controlled by the word line (gates read/write access)
+
+```
+                     Bit Line (BL)      Bit Line Bar (BL_bar)
+                         │                      │
+                    ┌────┴────┐            ┌────┴────┐
+                    │ Access  │            │ Access  │
+  Word Line ────────┤ Transistor          │ Transistor
+                    │  (N1)   │            │  (N2)   │
+                    └────┬────┘            └────┬────┘
+                         │                      │
+                    ┌────┴────┐            ┌────┴────┐
+                    │         ├────────────┤         │
+                    │  INV1   │            │  INV2   │
+                    │         ├────────────┤         │
+                    └─────────┘            └─────────┘
+                     (NOT gate)            (NOT gate)
+                       Q                     Q_bar
+```
+
+How it works:
+- **Hold**: Word line = 0. Access transistors are off. The two inverters form a feedback loop — each one's output drives the other's input. The cell holds its state indefinitely. This is identical to the SR latch concept from logic-gates.
+- **Read**: Word line = 1. Access transistors turn on, connecting the internal nodes to the bit lines. The sense amplifier detects the voltage difference between BL and BL_bar to determine the stored value.
+- **Write**: Word line = 1, and the write driver forces BL and BL_bar to the desired values. The external drive is stronger than the internal inverters, overriding the stored state.
+
+In our simulation, we model this at the gate level: the cross-coupled inverters use NOT gates, and the access transistors use AND gates (AND(data, enable) models a transistor passing data when enabled).
+
+### Why SRAM and Not DRAM?
+
+| Property | SRAM | DRAM |
+|----------|------|------|
+| Transistors per bit | 6 | 1 + capacitor |
+| Speed | Fast (sub-nanosecond) | Slower (tens of ns) |
+| Refresh needed | No | Yes (capacitor leaks) |
+| Cost per bit | High | Low |
+| Used in | Cache, registers, FPGA BRAM | Main memory (DDR4/5) |
+
+We model SRAM because it's what FPGAs and CPU caches use. DRAM would require modeling capacitor charge decay and refresh cycles, which is a separate concern.
+
+### SRAM Array — From One Cell to a Grid
+
+A RAM chip is a 2D grid of SRAM cells. To access a specific cell:
+
+1. **Row decoder** — converts the row address bits into a one-hot word line signal. Only one row is active at a time.
+2. **Column MUX** — selects which columns are read/written when the array is wider than the data bus.
+
+```
+                     Column 0   Column 1   Column 2   Column 3
+                        │          │          │          │
+  Row 0 (WL0) ─────── [Cell]     [Cell]     [Cell]     [Cell]
+                        │          │          │          │
+  Row 1 (WL1) ─────── [Cell]     [Cell]     [Cell]     [Cell]
+                        │          │          │          │
+  Row 2 (WL2) ─────── [Cell]     [Cell]     [Cell]     [Cell]
+                        │          │          │          │
+  Row 3 (WL3) ─────── [Cell]     [Cell]     [Cell]     [Cell]
+                        │          │          │          │
+                     Bit Line 0 Bit Line 1 Bit Line 2 Bit Line 3
+                        │          │          │          │
+                     ┌──┴──────────┴──────────┴──────────┴──┐
+                     │           Column MUX / Sense Amps     │
+                     └──────────────────┬───────────────────┘
+                                        │
+                                    Data Out
+```
+
+Address structure for a 4-row × 4-column array:
+- Address bits [1:0] → row decoder (selects word line)
+- No column MUX needed if all 4 columns are read simultaneously (4-bit wide output)
+- If we want a 1-bit output, address bits [3:2] → column MUX
+
+### Single-Port RAM
+
+The simplest complete RAM module. One address port, one data bus. Each cycle you can do ONE operation: read OR write.
+
+```
+                ┌──────────────────────────┐
+  Address ──────┤                          │
+                │     Single-Port RAM      │
+  Data In ──────┤                          ├──── Data Out
+                │     (rows × width)       │
+  Write En ─────┤                          │
+                │                          │
+  Clock ────────┤                          │
+                └──────────────────────────┘
+```
+
+Interface:
+- **Address** (N bits): selects which row to access
+- **Data In** (M bits): data to write
+- **Write Enable** (1 bit): 0 = read, 1 = write
+- **Clock** (1 bit): operations happen on rising edge
+- **Data Out** (M bits): data read from the selected address
+
+Behavior:
+- **Read** (WE=0): Data Out = contents of row at Address
+- **Write** (WE=1): row at Address = Data In; Data Out = undefined (or previous value)
+
+### Dual-Port RAM
+
+Two completely independent ports (A and B), each with its own address, data, and write enable. Both ports can operate simultaneously — you can read from port A and write via port B in the same cycle, even at different addresses.
+
+```
+  ┌────────────────────────────────────────────┐
+  │               Dual-Port RAM                │
+  │                                            │
+  │  Port A                      Port B        │
+  │  ┌──────┐                   ┌──────┐       │
+  │  │Addr A│                   │Addr B│       │
+  │  │Din  A│   (shared array)  │Din  B│       │
+  │  │WE   A│                   │WE   B│       │
+  │  │Clk  A│                   │Clk  B│       │
+  │  │Dout A│                   │Dout B│       │
+  │  └──────┘                   └──────┘       │
+  └────────────────────────────────────────────┘
+```
+
+**Why dual-port matters for FPGAs:**
+FPGAs use dual-port BRAM everywhere. A common pattern: one port writes data from
+a producer (e.g., ADC samples), the other port reads data for a consumer (e.g.,
+FFT engine). The two can operate at different clock rates (asynchronous dual-port).
+
+**Write collision:** if both ports write to the same address simultaneously, the
+result is undefined. Our simulation detects this and raises an error.
+
+### Configurable Width and Depth
+
+FPGA Block RAMs can be configured with different aspect ratios from the same
+physical storage. An 18 Kbit BRAM can be configured as:
+
+```
+Configuration    │ Depth    Width    Total bits
+─────────────────┼──────────────────────────────
+  16K × 1        │  16384      1       16384
+   8K × 2        │   8192      2       16384
+   4K × 4        │   4096      4       16384
+   2K × 8 (byte) │   2048      8       16384
+   1K × 16       │   1024     16       16384
+  512 × 32 (word)│    512     32       16384
+```
+
+The total storage is fixed; you trade depth for width. This is achieved by
+changing how the address decoder and column MUX are configured — the underlying
+SRAM cells don't change at all.
+
+### Read Modes
+
+Real BRAMs support two read modes that affect what Data Out shows during a write:
+
+1. **Read-first**: Data Out shows the OLD value at the address being written (read happens before write in the same cycle)
+2. **Write-first** (or "read-after-write"): Data Out shows the NEW value being written
+3. **No-change**: Data Out retains its previous value during writes (saves power)
+
+Our simulation supports all three modes via a configuration parameter.
+
+## Public API
+
+```python
+# === Low-Level: SRAM Cell ===
+
+class SRAMCell:
+    """Single-bit storage element modeled at the gate level."""
+
+    def __init__(self) -> None: ...
+
+    def read(self, word_line: int) -> int | None: ...
+        # word_line=1: return stored bit. word_line=0: return None (not selected)
+
+    def write(self, word_line: int, bit_line: int) -> None: ...
+        # word_line=1: store bit_line value. word_line=0: no effect
+
+    @property
+    def value(self) -> int: ...
+        # Current stored value (for inspection/debugging)
+
+
+# === Mid-Level: SRAM Array ===
+
+class SRAMArray:
+    """2D grid of SRAM cells with row/column addressing."""
+
+    def __init__(self, rows: int, cols: int) -> None: ...
+        # rows × cols grid. rows must be power of 2.
+
+    def read(self, row: int) -> list[int]: ...
+        # Read all columns of the given row
+
+    def write(self, row: int, data: list[int]) -> None: ...
+        # Write data to the given row (len(data) must equal cols)
+
+    @property
+    def shape(self) -> tuple[int, int]: ...
+        # (rows, cols)
+
+
+# === High-Level: RAM Modules ===
+
+class ReadMode(Enum):
+    READ_FIRST = "read_first"
+    WRITE_FIRST = "write_first"
+    NO_CHANGE = "no_change"
+
+class SinglePortRAM:
+    """Single-port synchronous RAM."""
+
+    def __init__(
+        self,
+        depth: int,            # Number of addressable words
+        width: int,            # Bits per word
+        read_mode: ReadMode = ReadMode.READ_FIRST,
+    ) -> None: ...
+
+    def tick(
+        self,
+        clock: int,
+        address: list[int],    # Address bits (LSB first)
+        data_in: list[int],    # Data to write (width bits, LSB first)
+        write_enable: int,     # 0 = read, 1 = write
+    ) -> list[int]: ...
+        # Returns data_out (width bits). Operation happens on rising edge.
+
+    @property
+    def depth(self) -> int: ...
+    @property
+    def width(self) -> int: ...
+
+    def dump(self) -> list[list[int]]: ...
+        # Return all contents for inspection
+
+
+class DualPortRAM:
+    """True dual-port synchronous RAM."""
+
+    def __init__(
+        self,
+        depth: int,
+        width: int,
+        read_mode_a: ReadMode = ReadMode.READ_FIRST,
+        read_mode_b: ReadMode = ReadMode.READ_FIRST,
+    ) -> None: ...
+
+    def tick(
+        self,
+        clock: int,
+        # Port A
+        address_a: list[int],
+        data_in_a: list[int],
+        write_enable_a: int,
+        # Port B
+        address_b: list[int],
+        data_in_b: list[int],
+        write_enable_b: int,
+    ) -> tuple[list[int], list[int]]: ...
+        # Returns (data_out_a, data_out_b)
+        # Raises WriteCollisionError if both ports write to same address
+
+    @property
+    def depth(self) -> int: ...
+    @property
+    def width(self) -> int: ...
+
+
+class WriteCollisionError(Exception):
+    """Raised when both ports write to the same address simultaneously."""
+    address: int
+
+
+# === FPGA-Style Configurable BRAM ===
+
+class ConfigurableBRAM:
+    """Block RAM with configurable aspect ratio.
+
+    Total storage is fixed at initialization. Width and depth can be
+    reconfigured as long as width × depth = total_bits.
+    """
+
+    def __init__(
+        self,
+        total_bits: int = 18432,  # 18 Kbit (Xilinx BRAM18 size)
+        width: int = 8,
+        dual_port: bool = True,
+    ) -> None: ...
+
+    def reconfigure(self, width: int) -> None: ...
+        # Change aspect ratio. depth = total_bits // width.
+        # Clears all stored data.
+
+    # Port A and Port B interfaces (same as DualPortRAM when dual_port=True)
+    def tick_a(self, clock: int, address: list[int], data_in: list[int], write_enable: int) -> list[int]: ...
+    def tick_b(self, clock: int, address: list[int], data_in: list[int], write_enable: int) -> list[int]: ...
+
+    @property
+    def depth(self) -> int: ...
+    @property
+    def width(self) -> int: ...
+    @property
+    def total_bits(self) -> int: ...
+```
+
+## Data Flow
+
+```
+SRAM Cell:
+  Input:  word_line (0 or 1), bit_line (0 or 1 for write)
+  Output: stored bit (0 or 1) or None (not selected)
+
+SRAM Array:
+  Input:  row index (int), data (list of bits for write)
+  Output: list of bits (one per column)
+
+RAM Modules:
+  Input:  clock, address (list of bits), data_in (list of bits), write_enable
+  Output: data_out (list of bits)
+```
+
+All bit lists are LSB-first (least significant bit at index 0), consistent with
+the arithmetic package convention.
+
+## Test Strategy
+
+### SRAM Cell
+- Write 0, read back → 0
+- Write 1, read back → 1
+- Read with word_line=0 → None (not selected)
+- Write with word_line=0 → no change to stored value
+- Verify initial state is defined (0)
+- Overwrite: write 1, verify, write 0, verify
+
+### SRAM Array
+- Write a row, read it back → same data
+- Write different data to different rows, read each → correct data per row
+- Read a row that was never written → all zeros (initial state)
+- Write partial row → error (data length must match cols)
+- Invalid row index → error
+
+### SinglePortRAM
+- Write address 0, read address 0 → written data
+- Write multiple addresses, read each → correct data
+- Read-first mode: during write, data_out = old value
+- Write-first mode: during write, data_out = new value
+- No-change mode: during write, data_out = previous read value
+- Operations only happen on rising edge (clock=0→1)
+- Address width matches depth (e.g., depth=1024 → 10 address bits)
+
+### DualPortRAM
+- Port A writes, Port B reads same address → correct data
+- Port A reads, Port B writes different address → independent
+- Simultaneous reads from both ports at different addresses → both correct
+- Write collision: both ports write same address → WriteCollisionError
+- Both ports read same address simultaneously → both get same data
+
+### ConfigurableBRAM
+- Default configuration: 18Kbit, 8-bit wide, 2304 deep
+- Reconfigure to 16-bit wide → depth halves, data clears
+- Reconfigure to 32-bit wide → depth quarters
+- Invalid reconfiguration (width doesn't divide total_bits) → error
+- Dual-port operations work after reconfiguration
+
+### Edge Cases
+- Depth = 1 (single-word RAM)
+- Width = 1 (single-bit RAM)
+- Maximum address (last row)
+- All-zeros data, all-ones data
+
+## Future Extensions
+
+- **DRAM simulation**: Model capacitor-based storage with refresh cycles
+- **CAM (Content-Addressable Memory)**: Search by content instead of address (used in CPU TLBs)
+- **FIFO**: First-in-first-out buffer built from dual-port RAM + read/write pointers
+- **Asynchronous dual-port**: Ports running at different clock frequencies
+- **ECC (Error-Correcting Code)**: Detect and correct single-bit errors using Hamming codes
+- **Memory initialization from file**: Load RAM contents from a hex/binary file at construction

--- a/code/specs/F01-fpga.md
+++ b/code/specs/F01-fpga.md
@@ -1,0 +1,910 @@
+# F01 — FPGA (Field-Programmable Gate Array)
+
+## Overview
+
+An FPGA is a chip full of logic gates, memory, and wires — but unlike a CPU or GPU where the circuits are permanently etched in silicon, an FPGA's circuits are **programmable**. You upload a configuration file (called a **bitstream**) and the chip reconfigures itself to implement whatever digital circuit you described. Seconds later, you can upload a different bitstream and the same chip becomes a completely different circuit.
+
+This is the "programmable hardware" layer of the computing stack. Where our existing packages model fixed-function circuits (an adder is always an adder, an ALU always performs the same operations), the FPGA package lets you define circuits at runtime through configuration.
+
+**Why FPGAs matter:**
+- **Prototyping** — test a chip design on an FPGA before spending millions on ASIC fabrication
+- **Acceleration** — FPGAs can implement custom hardware accelerators for specific workloads (video encoding, network packet processing, ML inference) that outperform general-purpose CPUs
+- **Reconfigurability** — the same hardware can be repurposed for different tasks by loading different bitstreams
+- **Education** — understanding FPGAs teaches you how ALL digital circuits work, because you must build them from scratch
+
+**The key insight:** a Look-Up Table (LUT) storing a truth table is functionally identical to a logic gate — but which gate it implements is determined by the truth table contents, not by its physical structure. A 4-input LUT loaded with `[0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0]` is an AND gate. Reload it with `[0,1,1,0,1,0,0,1,1,0,0,1,0,1,1,0]` and it becomes an XOR gate. Same silicon, different function. **A truth table is a program.**
+
+## Layer Position
+
+```
+Logic Gates → Combinational (MUX, decoder) → Block RAM → [YOU ARE HERE]
+                                                          ↑
+                                              Clock ──────┘
+                                              Arithmetic ──┘ (carry chains)
+```
+
+**Input from:**
+- logic-gates: primitive gates (for building LUT internals), sequential logic (flip-flops in CLBs)
+- logic-gates/combinational: MUX (core of LUT selection), decoder (address decoding)
+- block-ram: SRAM arrays (for configuration memory and Block RAM tiles)
+- clock: clock distribution to all sequential elements
+- arithmetic: carry chain logic for fast addition within CLBs
+
+**Output to:** User designs — any digital circuit described by a configuration/bitstream.
+
+## Concepts
+
+### What makes hardware "programmable"?
+
+Consider a 2-input AND gate built from transistors. It always computes AND. The function is physically wired into the silicon — you cannot change it without fabricating a new chip.
+
+Now consider this alternative: instead of hardwiring the AND truth table into transistors, what if we **stored** the truth table in a small memory (4 SRAM cells for a 2-input function) and used a MUX to look up the answer?
+
+```
+Traditional AND gate:          Programmable "gate" (2-input LUT):
+
+  a ──┐                           Truth table in SRAM:
+      │D──── output                  Address  Value
+  b ──┘                              00       0     ← AND(0,0)
+                                     01       0     ← AND(0,1)
+  Fixed forever.                     10       0     ← AND(1,0)
+                                     11       1     ← AND(1,1)
+
+                                   a ──┐
+                                       ├── address → [SRAM] → MUX → output
+                                   b ──┘
+
+                                   Reprogram SRAM → different function!
+```
+
+To change the 2-input LUT from AND to OR, we just rewrite the SRAM:
+
+```
+  Address  AND   OR    XOR   NAND
+  00       0     0     0     1
+  01       0     1     1     1
+  10       0     1     1     1
+  11       1     1     0     0
+```
+
+Same silicon, four different functions. This is the core idea behind FPGAs.
+
+### Look-Up Table (LUT) — the atom of programmable logic
+
+A K-input LUT can implement **any** boolean function of K variables. It has:
+- K input signals
+- 2^K SRAM cells storing the truth table
+- A 2^K-to-1 MUX tree that selects the output based on the inputs
+
+```
+4-Input LUT (the most common in modern FPGAs):
+
+                  SRAM (16 cells)
+                  ┌───────────┐
+  Configuration   │ Cell  0   │──┐
+  (bitstream      │ Cell  1   │──┤
+   writes these)  │ Cell  2   │──┤    ┌─────────────┐
+                  │ Cell  3   │──┼────┤             │
+                  │ Cell  4   │──┤    │   16-to-1   │
+                  │ Cell  5   │──┤    │     MUX     ├──── Output (F)
+                  │ Cell  6   │──┤    │    Tree     │
+                  │ Cell  7   │──┤    │             │
+                  │ Cell  8   │──┤    │             │
+                  │ Cell  9   │──┤    └──┬──┬──┬──┬─┘
+                  │ Cell 10   │──┤       │  │  │  │
+                  │ Cell 11   │──┤       I0 I1 I2 I3
+                  │ Cell 12   │──┤
+                  │ Cell 13   │──┤       (4 input signals
+                  │ Cell 14   │──┤        used as MUX
+                  │ Cell 15   │──┘        select lines)
+                  └───────────┘
+
+  I3 I2 I1 I0 = 0000 → Output = Cell[0]
+  I3 I2 I1 I0 = 0001 → Output = Cell[1]
+  ...
+  I3 I2 I1 I0 = 1111 → Output = Cell[15]
+```
+
+The MUX tree is built from 2:1 MUXes (from our logic-gates combinational module):
+
+```
+16-to-1 MUX tree for a 4-input LUT:
+
+  Level 1 (I0 selects):      Level 2 (I1 selects):    Level 3 (I2):   Level 4 (I3):
+  Cell[0]  ─┐                     ┌─────┐                ┌───┐
+  Cell[1]  ─┤─ MUX → ────────────┤     │                │   │
+  Cell[2]  ─┐                     │ MUX ├── ─────────────┤   │
+  Cell[3]  ─┤─ MUX → ────────────┤     │                │MUX├── ──┐
+  Cell[4]  ─┐                     └─────┘                │   │     │
+  Cell[5]  ─┤─ MUX → ────────────┐                      │   │     │   ┌───┐
+  Cell[6]  ─┐                     │ MUX ├── ─────────────┤   │     │   │   │
+  Cell[7]  ─┤─ MUX → ────────────┘                      └───┘     ├───┤MUX├── F
+  Cell[8]  ─┐                     ┌─────┐                ┌───┐     │   │   │
+  Cell[9]  ─┤─ MUX → ────────────┤     │                │   │     │   └───┘
+  Cell[10] ─┐                     │ MUX ├── ─────────────┤   │     │
+  Cell[11] ─┤─ MUX → ────────────┤     │                │MUX├── ──┘
+  Cell[12] ─┐                     └─────┘                │   │
+  Cell[13] ─┤─ MUX → ────────────┐                      │   │
+  Cell[14] ─┐                     │ MUX ├── ─────────────┤   │
+  Cell[15] ─┤─ MUX → ────────────┘                      └───┘
+             ↑                       ↑                      ↑           ↑
+            I0                      I1                     I2          I3
+```
+
+**LUT size tradeoffs:**
+
+| K (inputs) | SRAM cells | Can implement | Used in |
+|------------|-----------|---------------|---------|
+| 2 | 4 | Any 2-variable function | (too small for modern use) |
+| 3 | 8 | Any 3-variable function | Early FPGAs (Xilinx XC2000, 1985) |
+| 4 | 16 | Any 4-variable function | Common (Xilinx Spartan, Altera Cyclone) |
+| 5 | 32 | Any 5-variable function | Xilinx Virtex-5 |
+| 6 | 64 | Any 6-variable function | Modern FPGAs (Xilinx UltraScale, Intel Agilex) |
+
+Larger LUTs can implement more complex functions in a single block but waste
+SRAM when the function is simple. FPGAs typically use 6-input LUTs that can
+also be configured as two independent 5-input LUTs sharing inputs.
+
+### Configurable Logic Block (CLB) — the building block
+
+A CLB groups multiple LUTs with flip-flops, carry chains, and local MUXes
+into a reusable tile. This is the repeated unit that fills most of the FPGA fabric.
+
+A typical CLB (simplified Xilinx-style):
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                         CLB (Configurable Logic Block)               │
+│                                                                      │
+│  ┌──────────────────────────────────────────────────────────────┐    │
+│  │                    Slice 0                                    │    │
+│  │                                                               │    │
+│  │  Inputs ────→ [LUT A (4-in)] ──┬──→ [MUX] ──→ Output A      │    │
+│  │                                │       ↑                      │    │
+│  │                                │    sel (config)              │    │
+│  │                                │                              │    │
+│  │                                └──→ [D-FF] ──→ Output A_reg  │    │
+│  │                                       ↑                       │    │
+│  │                                      CLK                      │    │
+│  │                                                               │    │
+│  │  Inputs ────→ [LUT B (4-in)] ──┬──→ [MUX] ──→ Output B      │    │
+│  │                                │       ↑                      │    │
+│  │                                └──→ [D-FF] ──→ Output B_reg  │    │
+│  │                                                               │    │
+│  │           Carry In ──→ [Carry Chain] ──→ Carry Out            │    │
+│  └──────────────────────────────────────────────────────────────┘    │
+│                                                                      │
+│  ┌──────────────────────────────────────────────────────────────┐    │
+│  │                    Slice 1 (same structure)                   │    │
+│  └──────────────────────────────────────────────────────────────┘    │
+│                                                                      │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+Each CLB contains:
+- **2 Slices**, each with:
+  - **2 LUTs** (4 or 6 inputs each) — the combinational logic
+  - **2 D flip-flops** — for registered (synchronous) outputs
+  - **2 output MUXes** — select between LUT output (combinational) or flip-flop output (registered)
+  - **Carry chain** — fast carry propagation for arithmetic (avoids slow routing)
+- **Local routing MUXes** — connect LUTs within the CLB to each other
+
+The output MUX is crucial: it lets each LUT output be either:
+1. **Combinational** — the raw LUT output, available immediately
+2. **Registered** — the LUT output captured by a flip-flop on the clock edge, available one cycle later
+
+This is how you build both combinational circuits (like an adder) and sequential circuits (like a state machine) from the same hardware.
+
+**The carry chain** deserves special attention. When building an N-bit adder, the carry must ripple from bit 0 to bit N-1. If the carry had to travel through the general routing fabric, it would be slow. Instead, FPGAs provide a dedicated carry chain — a hardwired fast path between adjacent CLBs that propagates carry in a fraction of the time.
+
+```
+CLB[0]                    CLB[1]                    CLB[2]
+┌──────────┐              ┌──────────┐              ┌──────────┐
+│ LUT: bit 0│              │ LUT: bit 2│              │ LUT: bit 4│
+│ LUT: bit 1│              │ LUT: bit 3│              │ LUT: bit 5│
+│     ↓     │              │     ↓     │              │     ↓     │
+│ Carry Out ├──(fast)──────┤ Carry Out ├──(fast)──────┤ Carry Out ├──→
+└──────────┘              └──────────┘              └──────────┘
+```
+
+### Routing Fabric — the programmable interconnect
+
+The routing fabric is what makes an FPGA truly flexible. It connects CLBs to each
+other, to Block RAM, and to I/O blocks. Without it, each CLB would be an isolated
+island.
+
+The fabric consists of:
+
+1. **Wire segments** — horizontal and vertical tracks running between CLBs
+2. **Switch matrices** — programmable crossbar switches at the intersections of wire segments. SRAM bits control which connections are made.
+3. **Connection boxes** — connect CLB inputs/outputs to nearby wire segments
+
+```
+           Wire Segments (horizontal)
+         ════════════════════════════════════
+              │          │          │
+  ┌───────┐  │  ┌────┐  │  ┌────┐  │  ┌───────┐
+  │  CLB  ├──┤──┤ SM ├──┤──┤ SM ├──┤──┤  CLB  │
+  │ (0,0) │  │  └────┘  │  └────┘  │  │ (0,1) │
+  └───┬───┘  │     │    │     │    │  └───┬───┘
+      │      │     │    │     │    │      │
+  ════│══════│═════│════│═════│════│══════│════  ← Wire Segments (vertical)
+      │      │     │    │     │    │      │
+  ┌───┴───┐  │  ┌──┴─┐  │  ┌──┴─┐  │  ┌───┴───┐
+  │  CLB  ├──┤──┤ SM ├──┤──┤ SM ├──┤──┤  CLB  │
+  │ (1,0) │  │  └────┘  │  └────┘  │  │ (1,1) │
+  └───────┘  │          │          │  └───────┘
+         ════════════════════════════════════
+
+  SM = Switch Matrix (programmable crossbar)
+```
+
+**Modeling the routing fabric as a directed graph:**
+
+This is where our existing `directed-graph` library comes in. The routing fabric is
+naturally a graph:
+
+- **Nodes**: CLB output pins, CLB input pins, BRAM ports, I/O pins, wire segment endpoints
+- **Edges**: active connections through switch matrices and connection boxes
+
+When the FPGA is configured, the bitstream determines which switch matrix connections
+are active. This defines the graph edges. Signal propagation follows the graph edges.
+
+```python
+from directed_graph import DirectedGraph
+
+fabric = DirectedGraph()
+# CLB(0,0) LUT_A output connects to CLB(0,1) LUT_B input 2
+fabric.add_edge("clb_0_0.lut_a.out", "clb_0_1.lut_b.in2")
+# CLB(0,1) LUT_B output connects to CLB(1,1) LUT_A input 0
+fabric.add_edge("clb_0_1.lut_b.out", "clb_1_1.lut_a.in0")
+```
+
+The graph enables:
+- **Connectivity validation** — is every CLB input driven by exactly one source?
+- **Combinational loop detection** — `has_cycle()` on the combinational-only subgraph
+- **Critical path analysis** — longest path through the graph (determines max clock frequency)
+- **Topological ordering** — `topological_sort()` gives a valid signal evaluation order
+
+### Switch Matrix — the crossbar
+
+A switch matrix is a programmable crossbar that connects wire segments at routing
+intersections. Each crossing point has a **pass transistor** (modeled as an AND gate)
+controlled by an SRAM configuration bit.
+
+```
+4×4 Switch Matrix:
+
+  North[0] ─── ──┬──── ──┬──── ──┬──── ── East[0]
+                  │       │       │
+  North[1] ─── ──┼──── ──┼──── ──┼──── ── East[1]
+                  │       │       │
+  North[2] ─── ──┼──── ──┼──── ──┼──── ── East[2]
+                  │       │       │
+  North[3] ─── ──┼──── ──┼──── ──┼──── ── East[3]
+                  │       │       │
+            South[0] South[1] South[2] South[3]
+
+  Each crossing point (┼) is controlled by an SRAM bit:
+    SRAM = 1 → connection made (signal passes through)
+    SRAM = 0 → no connection (wires are isolated)
+```
+
+A switch matrix with W wires on each side has up to W² crossing points, but
+typically only a subset are connectable (to save area). Real FPGAs use
+**Wilton** or **Universal** switch box topologies that guarantee routability
+with fewer switches.
+
+### I/O Blocks — connecting to the outside world
+
+I/O blocks sit at the edges of the FPGA fabric, connecting internal signals to
+physical package pins. Each I/O block can be configured as:
+
+- **Input** — external signal drives internal logic (with optional input flip-flop for synchronization)
+- **Output** — internal signal drives the pin (with optional output flip-flop)
+- **Bidirectional** — tri-state buffer controls direction (using the tri-state buffer from logic-gates)
+
+```
+┌───────────────────────────────────────┐
+│              I/O Block                │
+│                                       │
+│  Internal ──→ [Output FF] ──→ [Tri-state] ──→ Pin
+│  Signal                         ↑
+│                              OE (output enable)
+│
+│  Internal ←── [Input FF] ←─────────────── Pin
+│  Signal
+│                                       │
+│  Direction: SRAM config bit           │
+└───────────────────────────────────────┘
+```
+
+### Configuration Memory and Bitstream
+
+Every programmable element in the FPGA — every LUT truth table entry, every switch
+matrix connection, every I/O direction, every MUX select — is controlled by an
+SRAM cell. The collection of all these SRAM cells is the **configuration memory**.
+
+The **bitstream** is a binary file that contains the values for every configuration
+SRAM cell. Loading a bitstream programs the FPGA.
+
+```
+Bitstream structure (simplified):
+
+┌──────────────────────────────────────────────┐
+│ Header                                        │
+│   Device ID, bitstream length, checksum       │
+├──────────────────────────────────────────────┤
+│ CLB Configuration                             │
+│   For each CLB:                               │
+│     LUT A truth table (16 bits for 4-LUT)     │
+│     LUT B truth table (16 bits)               │
+│     FF enable bits (2 bits)                   │
+│     Output MUX select bits (2 bits)           │
+│     Carry chain config (2 bits)               │
+├──────────────────────────────────────────────┤
+│ Routing Configuration                         │
+│   For each switch matrix:                     │
+│     Connection bits (one per crossing point)  │
+│   For each connection box:                    │
+│     Input/output pin connection bits          │
+├──────────────────────────────────────────────┤
+│ BRAM Contents                                 │
+│   Initial values for each Block RAM tile      │
+├──────────────────────────────────────────────┤
+│ I/O Configuration                             │
+│   For each I/O block:                         │
+│     Direction (input/output/bidirectional)     │
+│     Pull-up/pull-down enable                  │
+│     Slew rate, drive strength                 │
+└──────────────────────────────────────────────┘
+```
+
+In our simulation, we use a **JSON configuration format** instead of a raw binary
+bitstream. This is more readable and debuggable while being semantically equivalent.
+
+### Place and Route — from design to physical layout
+
+In real FPGA toolchains, the designer writes HDL (Verilog/VHDL), which is
+synthesized into a netlist of LUTs and flip-flops, then:
+
+1. **Place** — assign each LUT/FF to a specific CLB location on the chip
+2. **Route** — find paths through the switch matrices to connect them
+
+Our simulator skips synthesis (the user directly specifies LUT truth tables in
+the JSON config) but does implement a simple placer and router:
+
+- **Placement**: assign logical blocks to physical CLB coordinates
+- **Routing**: use the directed graph to find paths between connected blocks, configuring switch matrices along the way
+
+### Timing Model
+
+Every signal path through the FPGA has a propagation delay:
+- **LUT delay** — time for inputs to propagate through the MUX tree (~0.3 ns in modern FPGAs)
+- **Routing delay** — time for signal to travel through switch matrices and wire segments (~0.1-2 ns depending on distance)
+- **Setup time** — time a flip-flop input must be stable before the clock edge
+
+The **critical path** is the longest combinational delay between any two flip-flops
+(or between an input and a flip-flop). It determines the maximum clock frequency:
+
+```
+Max frequency = 1 / (longest_path_delay + setup_time)
+```
+
+Our simulator computes delays by summing LUT and routing delays along each path
+in the routing graph.
+
+## JSON Configuration Format
+
+Instead of a binary bitstream, designs are specified in JSON:
+
+```json
+{
+  "device": {
+    "name": "CinchFPGA-Mini",
+    "rows": 4,
+    "cols": 4,
+    "lut_inputs": 4,
+    "bram_tiles": 2,
+    "bram_bits": 18432,
+    "io_pins": 16
+  },
+
+  "clbs": {
+    "clb_0_0": {
+      "lut_a": {
+        "truth_table": [0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0],
+        "comment": "4-input AND gate"
+      },
+      "lut_b": {
+        "truth_table": [0,1,1,0,1,0,0,1,1,0,0,1,0,1,1,0],
+        "comment": "4-input XOR gate"
+      },
+      "ff_a": { "enabled": true, "reset_value": 0 },
+      "ff_b": { "enabled": false },
+      "output_mux_a": "registered",
+      "output_mux_b": "combinational",
+      "carry_in": "external"
+    }
+  },
+
+  "routing": [
+    { "from": "io_pin_0", "to": "clb_0_0.lut_a.in0" },
+    { "from": "io_pin_1", "to": "clb_0_0.lut_a.in1" },
+    { "from": "clb_0_0.lut_a.out", "to": "clb_0_1.lut_a.in0" },
+    { "from": "clb_0_0.ff_a.out", "to": "io_pin_8" }
+  ],
+
+  "bram": {
+    "bram_0": {
+      "width": 8,
+      "initial_contents": [0, 0, 0, 255, 128, 64]
+    }
+  },
+
+  "io": {
+    "io_pin_0":  { "direction": "input",  "name": "A" },
+    "io_pin_1":  { "direction": "input",  "name": "B" },
+    "io_pin_8":  { "direction": "output", "name": "Result" }
+  },
+
+  "clock": {
+    "frequency_mhz": 100,
+    "source": "io_pin_15"
+  }
+}
+```
+
+## Worked Examples
+
+### Example 1: Single LUT as AND gate
+
+The simplest possible FPGA design: one LUT implementing a 2-input AND gate.
+
+**Configuration:**
+```json
+{
+  "device": { "name": "CinchFPGA-Mini", "rows": 2, "cols": 2, "lut_inputs": 4 },
+  "clbs": {
+    "clb_0_0": {
+      "lut_a": {
+        "truth_table": [0,0,0,1, 0,0,0,0, 0,0,0,0, 0,0,0,0],
+        "comment": "AND(in0, in1) — only inputs 0,1 used; inputs 2,3 tied to 0"
+      }
+    }
+  },
+  "routing": [
+    { "from": "io_pin_0", "to": "clb_0_0.lut_a.in0" },
+    { "from": "io_pin_1", "to": "clb_0_0.lut_a.in1" },
+    { "from": "clb_0_0.lut_a.out", "to": "io_pin_4" }
+  ],
+  "io": {
+    "io_pin_0": { "direction": "input",  "name": "A" },
+    "io_pin_1": { "direction": "input",  "name": "B" },
+    "io_pin_4": { "direction": "output", "name": "Y" }
+  }
+}
+```
+
+**The graph built from this configuration:**
+```
+io_pin_0 ("A") ──→ clb_0_0.lut_a.in0 ──→ clb_0_0.lut_a.out ──→ io_pin_4 ("Y")
+                                              ↑
+io_pin_1 ("B") ──→ clb_0_0.lut_a.in1 ────────┘
+```
+
+**Simulation:**
+```python
+fpga = FPGA.from_json("and_gate.json")
+result = fpga.simulate(
+    inputs={"A": [0, 0, 1, 1], "B": [0, 1, 0, 1]},
+    cycles=4
+)
+assert result.outputs["Y"] == [[0], [0], [0], [1]]
+```
+
+### Example 2: 4-bit Ripple-Carry Adder
+
+Each bit of the adder uses one CLB (2 LUTs: one for sum, one for carry).
+
+```
+Bit 0:  LUT_A computes Sum0 = XOR(A0, B0, Cin)
+        LUT_B computes Carry0 = majority(A0, B0, Cin)
+
+Bit 1:  LUT_A computes Sum1 = XOR(A1, B1, Carry0)
+        LUT_B computes Carry1 = majority(A1, B1, Carry0)
+
+...and so on for bits 2 and 3.
+```
+
+**The graph for a 4-bit adder:**
+```
+A0 ──→ CLB_0.lut_a ──→ Sum0
+B0 ──→ CLB_0.lut_a
+Cin ──→ CLB_0.lut_a
+A0 ──→ CLB_0.lut_b ──→ Carry0 ──(carry chain)──→ CLB_1.lut_a
+B0 ──→ CLB_0.lut_b                                CLB_1.lut_b
+Cin ──→ CLB_0.lut_b
+
+A1 ──→ CLB_1.lut_a ──→ Sum1
+B1 ──→ CLB_1.lut_a
+       CLB_1.lut_b ──→ Carry1 ──(carry chain)──→ CLB_2 ...
+
+A2 ──→ CLB_2.lut_a ──→ Sum2
+...
+
+A3 ──→ CLB_3.lut_a ──→ Sum3
+       CLB_3.lut_b ──→ Cout
+```
+
+**Simulation (5 + 3 = 8):**
+```python
+fpga = FPGA.from_json("adder_4bit.json")
+result = fpga.simulate(
+    inputs={
+        "A0": [1], "A1": [0], "A2": [1], "A3": [0],  # A = 0101 = 5
+        "B0": [1], "B1": [1], "B2": [0], "B3": [0],  # B = 0011 = 3
+        "Cin": [0]
+    },
+    cycles=1
+)
+# Sum = 1000 = 8, Cout = 0
+assert result.outputs["Sum0"] == [[0]]
+assert result.outputs["Sum1"] == [[0]]
+assert result.outputs["Sum2"] == [[0]]
+assert result.outputs["Sum3"] == [[1]]
+assert result.outputs["Cout"] == [[0]]
+```
+
+### Example 3: Traffic Light State Machine
+
+A sequential circuit that cycles through Red → Green → Yellow → Red, advancing
+on each clock cycle. This uses LUTs for next-state logic and flip-flops for
+state storage.
+
+```
+State encoding:
+  Red    = 00
+  Green  = 01
+  Yellow = 10
+
+Next-state logic:
+  00 → 01 (Red → Green)
+  01 → 10 (Green → Yellow)
+  10 → 00 (Yellow → Red)
+  11 → 00 (invalid → Red, safe default)
+
+LUT_A (next_state[0]):         LUT_B (next_state[1]):
+  state1 state0 │ next0         state1 state0 │ next1
+  ──────────────┼──────         ──────────────┼──────
+    0      0    │   1             0      0    │   0
+    0      1    │   0             0      1    │   1
+    1      0    │   0             1      0    │   0
+    1      1    │   0             1      1    │   0
+```
+
+Both LUTs have their outputs registered (through flip-flops), creating the
+feedback loop: current state → LUT → next state → flip-flop → current state
+on next clock cycle.
+
+**The graph:**
+```
+clb_0_0.ff_a.out ──→ clb_0_0.lut_a.in0 ──→ clb_0_0.ff_a ──→ (feedback)
+clb_0_0.ff_b.out ──→ clb_0_0.lut_a.in1         ↓
+                                            io_pin_4 (Red)
+clb_0_0.ff_a.out ──→ clb_0_0.lut_b.in0 ──→ clb_0_0.ff_b ──→ (feedback)
+clb_0_0.ff_b.out ──→ clb_0_0.lut_b.in1         ↓
+                                            io_pin_5 (Green)
+                                            io_pin_6 (Yellow)
+```
+
+This example demonstrates the core FPGA capability: implementing sequential
+circuits (state machines) by routing flip-flop outputs back to LUT inputs.
+
+## Public API
+
+```python
+from enum import Enum
+from dataclasses import dataclass
+
+
+# ═══════════════════════════════════════════════════════════════
+# Core Primitives
+# ═══════════════════════════════════════════════════════════════
+
+class LUT:
+    """K-input Look-Up Table — the atom of programmable logic.
+
+    Stores a truth table in SRAM and uses a MUX tree to select
+    the output based on input signals. Can implement ANY boolean
+    function of K variables.
+    """
+
+    def __init__(self, k: int = 4, truth_table: list[int] | None = None) -> None: ...
+        # k: number of inputs (2-6). truth_table: 2^k entries, each 0 or 1.
+        # If truth_table is None, all entries default to 0.
+
+    def configure(self, truth_table: list[int]) -> None: ...
+        # Load a new truth table (reprogram the LUT)
+
+    def evaluate(self, inputs: list[int]) -> int: ...
+        # Compute output for given inputs by indexing into truth table
+
+    @property
+    def k(self) -> int: ...
+    @property
+    def truth_table(self) -> list[int]: ...
+
+
+class Slice:
+    """One slice of a CLB: 2 LUTs + 2 flip-flops + output MUXes + carry chain."""
+
+    def __init__(self, lut_inputs: int = 4) -> None: ...
+
+    def configure(
+        self,
+        lut_a_table: list[int],
+        lut_b_table: list[int],
+        ff_a_enabled: bool = False,
+        ff_b_enabled: bool = False,
+        carry_enabled: bool = False,
+    ) -> None: ...
+
+    def evaluate(
+        self,
+        inputs_a: list[int],
+        inputs_b: list[int],
+        clock: int,
+        carry_in: int = 0,
+    ) -> "SliceOutput": ...
+
+
+@dataclass
+class SliceOutput:
+    output_a: int          # LUT A result (combinational or registered)
+    output_b: int          # LUT B result (combinational or registered)
+    carry_out: int         # Carry chain output
+
+
+class CLB:
+    """Configurable Logic Block — contains 2 slices."""
+
+    def __init__(self, lut_inputs: int = 4) -> None: ...
+
+    @property
+    def slice0(self) -> Slice: ...
+    @property
+    def slice1(self) -> Slice: ...
+
+    def evaluate(
+        self,
+        slice0_inputs_a: list[int],
+        slice0_inputs_b: list[int],
+        slice1_inputs_a: list[int],
+        slice1_inputs_b: list[int],
+        clock: int,
+        carry_in: int = 0,
+    ) -> "CLBOutput": ...
+
+
+@dataclass
+class CLBOutput:
+    slice0: SliceOutput
+    slice1: SliceOutput
+
+
+class SwitchMatrix:
+    """Programmable routing crossbar.
+
+    Connects wire segments at routing intersections.
+    Each crossing point is controlled by an SRAM configuration bit.
+    """
+
+    def __init__(self, width: int) -> None: ...
+        # width: number of wires on each side
+
+    def configure(self, connections: list[tuple[str, str]]) -> None: ...
+        # Set which input-output pairs are connected.
+        # e.g., [("north_0", "east_2"), ("south_1", "west_3")]
+
+    def route(self, signals: dict[str, int]) -> dict[str, int]: ...
+        # Given input signals, compute output signals based on connections
+
+
+class IODirection(Enum):
+    INPUT = "input"
+    OUTPUT = "output"
+    BIDIRECTIONAL = "bidirectional"
+
+
+class IOBlock:
+    """Bidirectional I/O pad with optional flip-flops."""
+
+    def __init__(self, direction: IODirection = IODirection.INPUT) -> None: ...
+
+    def configure(
+        self,
+        direction: IODirection,
+        input_ff: bool = False,
+        output_ff: bool = False,
+    ) -> None: ...
+
+    def drive_external(self, value: int) -> None: ...
+        # Set external pin value (for input mode)
+
+    def drive_internal(self, value: int) -> None: ...
+        # Set internal signal value (for output mode)
+
+    def read(self, clock: int = 0) -> int | None: ...
+        # Read the value (from external for input, from internal for output)
+        # Returns None if high-impedance (bidirectional, not driving)
+
+
+# ═══════════════════════════════════════════════════════════════
+# FPGA Fabric
+# ═══════════════════════════════════════════════════════════════
+
+@dataclass
+class DeviceConfig:
+    """FPGA device parameters."""
+    name: str = "CinchFPGA-Mini"
+    rows: int = 4                  # CLB grid rows
+    cols: int = 4                  # CLB grid columns
+    lut_inputs: int = 4            # K-input LUTs
+    slices_per_clb: int = 2
+    bram_tiles: int = 2            # Number of Block RAM tiles
+    bram_bits_per_tile: int = 18432  # 18 Kbit per tile
+    io_pins: int = 16
+
+
+@dataclass
+class TimingReport:
+    """Timing analysis results."""
+    critical_path: list[str]       # Node IDs along the longest path
+    critical_path_delay_ns: float  # Total delay in nanoseconds
+    max_frequency_mhz: float       # 1 / (delay + setup_time)
+    lut_delay_ns: float = 0.3      # Per-LUT delay
+    routing_delay_ns: float = 0.5  # Per-hop routing delay
+    setup_time_ns: float = 0.1     # FF setup time
+
+
+@dataclass
+class SimResult:
+    """Simulation output."""
+    outputs: dict[str, list[list[int]]]  # pin_name → per-cycle output values
+    timing: TimingReport
+    cycle_count: int
+
+
+class FPGA:
+    """Complete FPGA fabric: CLBs + BRAMs + I/O + routing.
+
+    This is the top-level class. Create it from a JSON configuration
+    file, then simulate with input stimulus.
+    """
+
+    def __init__(self, config: DeviceConfig) -> None: ...
+
+    @classmethod
+    def from_json(cls, path: str) -> "FPGA": ...
+        # Load device config and design from a JSON file
+
+    @classmethod
+    def from_dict(cls, config: dict) -> "FPGA": ...
+        # Load from a Python dict (same schema as JSON)
+
+    def configure(self, design: dict) -> None: ...
+        # Apply a design configuration (LUT tables, routing, I/O)
+        # Validates: no undriven inputs, no combinational loops, etc.
+
+    def simulate(
+        self,
+        inputs: dict[str, list[int]],
+        cycles: int,
+    ) -> SimResult: ...
+        # Run simulation for N clock cycles with given input stimulus.
+        # inputs: pin_name → list of values (one per cycle, or single value held constant)
+        # Returns outputs for each cycle.
+
+    def analyze_timing(self) -> TimingReport: ...
+        # Static timing analysis — find critical path and max frequency
+
+    @property
+    def routing_graph(self) -> "DirectedGraph": ...
+        # The directed graph representing all active routes
+
+    @property
+    def clbs(self) -> dict[str, CLB]: ...
+    @property
+    def brams(self) -> dict[str, "ConfigurableBRAM"]: ...
+    @property
+    def io_blocks(self) -> dict[str, IOBlock]: ...
+
+    def utilization(self) -> dict[str, str]: ...
+        # Report: how many CLBs/LUTs/FFs/BRAMs are used vs. available
+        # e.g., {"luts": "12/32 (37.5%)", "ffs": "4/32 (12.5%)", ...}
+```
+
+## Data Flow
+
+```
+Configuration phase:
+  Input:  JSON config file (device params + LUT tables + routing + I/O)
+  Process: build CLBs, load LUT truth tables, configure routing graph,
+           set up I/O blocks, initialize BRAMs
+  Output: configured FPGA ready for simulation
+
+Simulation phase (per clock cycle):
+  1. Read external inputs from I/O blocks
+  2. Evaluate all CLBs in topological order (from routing graph)
+  3. Propagate signals through routing fabric
+  4. Clock all flip-flops (capture LUT outputs)
+  5. Drive output I/O pins
+  6. Record outputs
+
+Timing analysis:
+  Input:  configured routing graph with delay annotations
+  Process: find longest combinational path (modified BFS/DFS on routing graph)
+  Output: TimingReport with critical path and max frequency
+```
+
+## Test Strategy
+
+### LUT Tests
+- 2-input LUT: configure as AND, verify all 4 input combinations
+- 4-input LUT: configure as XOR, verify all 16 input combinations
+- Reconfigure: load AND table, verify, load OR table, verify same LUT now computes OR
+- Empty LUT (all zeros): all inputs produce 0
+- Full LUT (all ones): all inputs produce 1
+- Invalid truth table length → error
+- Invalid input values → error
+
+### CLB Tests
+- Combinational mode: LUT output goes directly to CLB output
+- Registered mode: LUT output captured by FF on clock edge, output delayed by one cycle
+- Carry chain: verify carry propagates between LUT A and LUT B within a slice
+- Carry chain across CLBs: verify carry propagates between adjacent CLBs
+- Both slices independent: verify slice 0 and slice 1 operate independently
+
+### Routing Tests
+- Direct connection: CLB A output → CLB B input, verify signal propagates
+- Multi-hop route: A → switch matrix → B → switch matrix → C
+- Fan-out: one output drives multiple inputs
+- No fan-in violation: each input driven by exactly one source
+- Undriven input detection: error if any CLB input has no source
+- Combinational loop detection: error if routing creates a cycle with no flip-flop
+
+### I/O Block Tests
+- Input mode: external value propagates to internal
+- Output mode: internal value drives pin
+- Bidirectional: switch between input and output
+- With input FF: value delayed by one clock cycle
+- High-impedance: bidirectional pin not driving → None
+
+### FPGA Integration Tests
+- AND gate example (Example 1): verify correct outputs for all input combinations
+- 4-bit adder (Example 2): verify addition for several test vectors including overflow
+- State machine (Example 3): verify correct state transitions over multiple cycles
+- Timing analysis: verify critical path matches expected longest path
+- Utilization report: verify counts are accurate
+- Invalid configuration detection: missing routes, loops, width mismatches
+
+### Edge Cases
+- Minimum FPGA: 1×1 grid, 1 I/O pin
+- All LUTs unused (configured but no routing)
+- BRAM read and write in same cycle (verify read mode behavior)
+- Clock frequency = 0 (combinational-only design, no FFs)
+- Maximum fan-out from a single CLB output
+
+## Future Extensions
+
+- **DSP slices** — hardwired multiply-accumulate blocks (like Xilinx DSP48)
+- **PLL / clock management tiles** — frequency synthesis, phase alignment, multiple clock domains
+- **Partial reconfiguration** — change part of the FPGA while the rest keeps running
+- **HDL synthesis** — accept a subset of Verilog/VHDL, synthesize to LUT/routing configuration
+- **Bitstream generation** — produce actual binary bitstreams (not just JSON)
+- **Floorplanning visualization** — render the CLB grid with utilization heat map
+- **Power estimation** — estimate dynamic and static power based on toggle rates and routing length
+- **Multi-die / chiplet FPGAs** — model modern FPGAs that use multiple interconnected silicon dies
+- **Hard processor cores** — model FPGAs with embedded ARM/RISC-V cores (like Xilinx Zynq)
+- **SerDes / high-speed transceivers** — model multi-gigabit serial I/O (for networking, PCIe)


### PR DESCRIPTION
## Summary

- **Updated `code/specs/10-logic-gates.md`** — added sequential logic documentation and new combinational circuits (MUX, DEMUX, decoder, encoder, priority encoder, tri-state buffer) with truth tables and ASCII diagrams
- **New `code/specs/F00-block-ram.md`** — hardware-level writable memory: SRAM cell, SRAM array, single/dual-port RAM, configurable BRAM
- **New `code/specs/F01-fpga.md`** — complete FPGA abstraction: LUTs, CLBs, routing fabric (modeled as directed graph), switch matrices, I/O blocks, JSON configuration format, timing model, three worked examples (AND gate, 4-bit adder, traffic light state machine)

Dependency chain: `logic-gates` (MUX/decoder) → `block-ram` (SRAM) → `fpga`

## Test plan

- [ ] Review spec accuracy against real FPGA architectures (Xilinx/Intel)
- [ ] Verify JSON configuration examples are valid JSON
- [ ] Verify truth tables are correct for all combinational circuits
- [ ] Verify worked examples produce expected outputs
- [ ] Confirm dependency chain is correct and doesn't create cycles
- [ ] Review Public API for all three specs — ensure idiomatic Python

🤖 Generated with [Claude Code](https://claude.com/claude-code)