### PR TITLE
feat(build-tool): create TypeScript build tool implementation

### DIFF
--- a/code/programs/typescript/build-tool/BUILD
+++ b/code/programs/typescript/build-tool/BUILD
@@ -1,0 +1,2 @@
+npm install --silent
+npx vitest run --coverage

--- a/code/programs/typescript/build-tool/CHANGELOG.md
+++ b/code/programs/typescript/build-tool/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to the TypeScript build tool will be documented in this file.
+
+## [1.0.0] - 2026-03-21
+
+### Added
+
+- Initial release: complete port of the Python build tool to TypeScript.
+- Package discovery via recursive BUILD file walk (`discovery.ts`).
+- Platform-specific BUILD file support: `BUILD_mac`, `BUILD_linux`, `BUILD_windows`, `BUILD_mac_and_linux`.
+- Dependency resolution for all 6 languages: Python, Ruby, Go, TypeScript, Rust, Elixir (`resolver.ts`).
+- Inline DirectedGraph implementation with Kahn's algorithm for topological sorting.
+- Git-based change detection using `git diff --name-only` (`gitdiff.ts`).
+- SHA256 file hashing for cache-based change detection (`hasher.ts`).
+- JSON build cache with atomic writes (`cache.ts`).
+- Parallel build execution respecting dependency order (`executor.ts`).
+- Human-readable build report formatting (`reporter.ts`).
+- CLI entry point with `--root`, `--force`, `--dry-run`, `--jobs`, `--language`, `--diff-base`, and `--cache-file` options (`index.ts`).
+- Comprehensive test suite with >80% coverage.
+- Zero runtime dependencies -- only Node.js built-in modules.
+- Knuth-style literate programming throughout all source files.

--- a/code/programs/typescript/build-tool/README.md
+++ b/code/programs/typescript/build-tool/README.md
@@ -1,0 +1,87 @@
+# Build Tool (TypeScript)
+
+An incremental, parallel monorepo build tool implemented in TypeScript. This is a port of the Python build tool, maintaining full feature parity.
+
+## What it does
+
+The build tool discovers packages in the monorepo by walking the directory tree looking for BUILD files, resolves inter-package dependencies by parsing language-specific metadata files, and executes builds in parallel topological order.
+
+## How it fits in the stack
+
+This is one of several build tool implementations in the monorepo (Python, Ruby, Go, Rust, Elixir, TypeScript). All implementations share the same architecture and produce identical results. The Go implementation is the primary one used in CI; the others serve as educational implementations demonstrating the same concepts in different languages.
+
+## Architecture
+
+| Module | Purpose |
+|---|---|
+| `discovery.ts` | Walks directory tree, finds BUILD files, infers language |
+| `resolver.ts` | Parses dependency metadata, builds directed graph (Kahn's algorithm) |
+| `gitdiff.ts` | Git-based change detection (`git diff --name-only`) |
+| `hasher.ts` | SHA256 hashing of source files for cache-based change detection |
+| `cache.ts` | JSON cache file for fallback change detection |
+| `executor.ts` | Parallel build execution respecting dependency order |
+| `reporter.ts` | Human-readable build report formatting |
+| `index.ts` | CLI entry point tying everything together |
+
+## Supported languages
+
+The resolver can parse dependencies for all 6 languages in the monorepo:
+
+- **Python**: `pyproject.toml` (`coding-adventures-*` prefix)
+- **Ruby**: `.gemspec` (`coding_adventures_*` prefix)
+- **Go**: `go.mod` (full module paths)
+- **TypeScript**: `package.json` (`@coding-adventures/*` scoped names)
+- **Rust**: `Cargo.toml` (crate names with path dependencies)
+- **Elixir**: `mix.exs` (`coding_adventures_*` atom names)
+
+## Platform-specific BUILD files
+
+The discovery system supports platform-specific BUILD files with the following priority:
+
+| Platform | Priority |
+|---|---|
+| macOS (darwin) | `BUILD_mac` > `BUILD_mac_and_linux` > `BUILD` |
+| Linux | `BUILD_linux` > `BUILD_mac_and_linux` > `BUILD` |
+| Windows (win32) | `BUILD_windows` > `BUILD` |
+
+## Usage
+
+```bash
+# Auto-detect repo root, build changed packages
+npx tsx src/index.ts
+
+# Specify root explicitly
+npx tsx src/index.ts --root /path/to/repo
+
+# Rebuild everything
+npx tsx src/index.ts --force
+
+# Show what would build without building
+npx tsx src/index.ts --dry-run
+
+# Limit parallel workers
+npx tsx src/index.ts --jobs 4
+
+# Only build Python packages
+npx tsx src/index.ts --language python
+```
+
+## Development
+
+```bash
+# Install dependencies
+npm install
+
+# Run tests
+npx vitest run
+
+# Run tests with coverage
+npx vitest run --coverage
+```
+
+## Design decisions
+
+- **Zero runtime dependencies**: Only uses Node.js built-in modules (`node:fs`, `node:path`, `node:crypto`, `node:child_process`, `node:os`, `node:util`).
+- **Inline directed graph**: Rather than importing an external graph library, the resolver includes a minimal DirectedGraph implementation.
+- **ESM-only**: Uses ES modules throughout (`"type": "module"` in package.json).
+- **Literate programming**: All source files include extensive comments explaining concepts, algorithms, and design decisions.

--- a/code/programs/typescript/build-tool/package-lock.json
+++ b/code/programs/typescript/build-tool/package-lock.json
@@ -1,0 +1,2452 @@
+{
+  "name": "build-tool",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "build-tool",
+      "version": "1.0.0",
+      "license": "MIT",
+      "bin": {
+        "build-tool": "src/index.ts"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.1.tgz",
+      "integrity": "sha512-xB0b51TB7IfDEzAojXahmr+gfA00uYVInJGgNNkeQG6RPnCPGr7udsylFLTubuIUSRE6FkcI1NElyRt83PP5oQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.1.tgz",
+      "integrity": "sha512-XOjPId0qwSDKHaIsdzHJtKCxX0+nH8MhBwvrNsT7tVyKmdTx1jJ4XzN5RZXCdTzMpufLb+B8llTC0D8uCrLhcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.1.tgz",
+      "integrity": "sha512-vQuRd28p0gQpPrS6kppd8IrWmFo42U8Pz1XLRjSZXq5zCqyMDYFABT7/sywL11mO1EL10Qhh7MVPEwkG8GiBeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.1.tgz",
+      "integrity": "sha512-x6VG6U29+Ivlnajrg1IHdzXeAwSoEHBFVO+CtC9Brugx6de712CUJobRUxsIA0KYrQvCmzNrMPFTT1A4CCqNTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.1.tgz",
+      "integrity": "sha512-Sgi0Uo6t1YCHJMNO3Y8+bm+SvOanUGkoZKn/VJPwYUe2kp31X5KnXmzKd/NjW8iA3gFcfNZ64zh14uOGrIllCQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.1.tgz",
+      "integrity": "sha512-AM4xnwEZwukdhk7laMWfzWu9JGSVnJd+Fowt6Fd7QW1nrf3h0Hp7Qx5881M4aqrUlKBCybOxz0jofvIIfl7C5g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.1.tgz",
+      "integrity": "sha512-KUizqxpwaR2AZdAUsMWfL/C94pUu7TKpoPd88c8yFVixJ+l9hejkrwoK5Zj3wiNh65UeyryKnJyxL1b7yNqFQA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.1.tgz",
+      "integrity": "sha512-MZoQ/am77ckJtZGFAtPucgUuJWiop3m2R3lw7tC0QCcbfl4DRhQUBUkHWCkcrT3pqy5Mzv5QQgY6Dmlba6iTWg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.1.tgz",
+      "integrity": "sha512-Sez95TP6xGjkWB1608EfhCX1gdGrO5wzyN99VqzRtC17x/1bhw5VU1V0GfKUwbW/Xr1J8mSasoFoJa6Y7aGGSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.1.tgz",
+      "integrity": "sha512-9Cs2Seq98LWNOJzR89EGTZoiP8EkZ9UbQhBlDgfAkM6asVna1xJ04W2CLYWDN/RpUgOjtQvcv8wQVi1t5oQazA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.1.tgz",
+      "integrity": "sha512-n9yqttftgFy7IrNEnHy1bOp6B4OSe8mJDiPkT7EqlM9FnKOwUMnCK62ixW0Kd9Clw0/wgvh8+SqaDXMFvw3KqQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.1.tgz",
+      "integrity": "sha512-SfpNXDzVTqs/riak4xXcLpq5gIQWsqGWMhN1AGRQKB4qGSs4r0sEs3ervXPcE1O9RsQ5bm8Muz6zmQpQnPss1g==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.1.tgz",
+      "integrity": "sha512-LjaChED0wQnjKZU+tsmGbN+9nN1XhaWUkAlSbTdhpEseCS4a15f/Q8xC2BN4GDKRzhhLZpYtJBZr2NZhR0jvNw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.1.tgz",
+      "integrity": "sha512-ojW7iTJSIs4pwB2xV6QXGwNyDctvXOivYllttuPbXguuKDX5vwpqYJsHc6D2LZzjDGHML414Tuj3LvVPe1CT1A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.1.tgz",
+      "integrity": "sha512-FP+Q6WTcxxvsr0wQczhSE+tOZvFPV8A/mUE6mhZYFW9/eea/y/XqAgRoLLMuE9Cz0hfX5bi7p116IWoB+P237A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.1.tgz",
+      "integrity": "sha512-L1uD9b/Ig8Z+rn1KttCJjwhN1FgjRMBKsPaBsDKkfUl7GfFq71pU4vWCnpOsGljycFEbkHWARZLf4lMYg3WOLw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.1.tgz",
+      "integrity": "sha512-EZc9NGTk/oSUzzOD4nYY4gIjteo2M3CiozX6t1IXGCOdgxJTlVu/7EdPeiqeHPSIrxkLhavqpBAUCfvC6vBOug==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.1.tgz",
+      "integrity": "sha512-NQ9KyU1Anuy59L8+HHOKM++CoUxrQWrZWXRik4BJFm+7i5NP6q/SW43xIBr80zzt+PDBJ7LeNmloQGfa0JGk0w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.1.tgz",
+      "integrity": "sha512-GZkLk2t6naywsveSFBsEb0PLU+JC9ggVjbndsbG20VPhar6D1gkMfCx4NfP9owpovBXTN+eRdqGSkDGIxPHhmQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.1.tgz",
+      "integrity": "sha512-1hjG9Jpl2KDOetr64iQd8AZAEjkDUUK5RbDkYWsViYLC1op1oNzdjMJeFiofcGhqbNTaY2kfgqowE7DILifsrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.1.tgz",
+      "integrity": "sha512-ARoKfflk0SiiYm3r1fmF73K/yB+PThmOwfWCk1sr7x/k9dc3uGLWuEE9if+Pw21el8MSpp3TMnG5vLNsJ/MMGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.1.tgz",
+      "integrity": "sha512-oOST61G6VM45Mz2vdzWMr1s2slI7y9LqxEV5fCoWi2MDONmMvgsJVHSXxce/I2xOSZPTZ47nDPOl1tkwKWSHcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.1.tgz",
+      "integrity": "sha512-x5WgLi5dWpRz7WclKBGEF15LcWTh0ewrHM6Cq4A+WUbkysUMZNeqt05bwPonOQ3ihPS/WMhAZV5zB1DfnI4Sxg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.1.tgz",
+      "integrity": "sha512-wS+zHAJRVP5zOL0e+a3V3E/NTEwM2HEvvNKoDy5Xcfs0o8lljxn+EAFPkUsxihBdmDq1JWzXmmB9cbssCPdxxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.1.tgz",
+      "integrity": "sha512-rhHyrMeLpErT/C7BxcEsU4COHQUzHyrPYW5tOZUeUhziNtRuYxmDWvqQqzpuUt8xpOgmbKa1btGXfnA/ANVO+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.1.tgz",
+      "integrity": "sha512-iZKH8BeoCwTCBTZBZWQQMreekd4mdomwdjIQ40GC1oZm6o+8PnNMIxFOiCsGMWeS8iDJ7KZcl7KwmKk/0HOQpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.1",
+        "@rollup/rollup-android-arm64": "4.59.1",
+        "@rollup/rollup-darwin-arm64": "4.59.1",
+        "@rollup/rollup-darwin-x64": "4.59.1",
+        "@rollup/rollup-freebsd-arm64": "4.59.1",
+        "@rollup/rollup-freebsd-x64": "4.59.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.1",
+        "@rollup/rollup-linux-arm64-musl": "4.59.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.1",
+        "@rollup/rollup-linux-loong64-musl": "4.59.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.1",
+        "@rollup/rollup-linux-x64-gnu": "4.59.1",
+        "@rollup/rollup-linux-x64-musl": "4.59.1",
+        "@rollup/rollup-openbsd-x64": "4.59.1",
+        "@rollup/rollup-openharmony-arm64": "4.59.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.1",
+        "@rollup/rollup-win32-x64-gnu": "4.59.1",
+        "@rollup/rollup-win32-x64-msvc": "4.59.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/programs/typescript/build-tool/package.json
+++ b/code/programs/typescript/build-tool/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "build-tool",
+  "version": "1.0.0",
+  "description": "Incremental, parallel monorepo build tool with hash-based caching",
+  "type": "module",
+  "main": "src/index.ts",
+  "bin": {
+    "build-tool": "src/index.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "keywords": [
+    "build-tool",
+    "monorepo",
+    "incremental-build",
+    "parallel-build"
+  ],
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "devDependencies": {
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
+  }
+}

--- a/code/programs/typescript/build-tool/src/cache.ts
+++ b/code/programs/typescript/build-tool/src/cache.ts
@@ -1,0 +1,240 @@
+/**
+ * cache.ts -- Build Cache Management
+ * ===================================
+ *
+ * This module manages a JSON-based cache file (`.build-cache.json`) that
+ * records the state of each package after its last build. By comparing
+ * current hashes against cached hashes, we determine which packages need
+ * rebuilding.
+ *
+ * ## Cache format
+ *
+ * The cache file is a JSON object mapping package names to cache entries:
+ *
+ * ```json
+ * {
+ *   "python/logic-gates": {
+ *     "package_hash": "abc123...",
+ *     "deps_hash": "def456...",
+ *     "last_built": "2024-01-15T10:30:00.000Z",
+ *     "status": "success"
+ *   }
+ * }
+ * ```
+ *
+ * ## Atomic writes
+ *
+ * To prevent corruption if the process is interrupted mid-write, we write to
+ * a temporary file (`.build-cache.json.tmp`) first, then atomically rename
+ * it to the final path. On POSIX systems, `fs.renameSync` is atomic within
+ * the same filesystem.
+ *
+ * ## When is the cache used?
+ *
+ * The cache is a FALLBACK mechanism. The primary change detection uses
+ * git-diff (see gitdiff.ts). The cache is only consulted when git-diff
+ * is unavailable (e.g., when running locally without a remote).
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * A single package's cached build state.
+ *
+ * This records everything we need to determine if a package needs
+ * rebuilding: its source hash, dependency hash, when it was last built,
+ * and whether that build succeeded.
+ */
+export interface CacheEntry {
+  /** SHA256 of the package's source files. */
+  packageHash: string;
+  /** SHA256 of transitive dependency hashes. */
+  depsHash: string;
+  /** ISO 8601 timestamp of the last build. */
+  lastBuilt: string;
+  /** "success" or "failed". */
+  status: string;
+}
+
+// ---------------------------------------------------------------------------
+// BuildCache class
+// ---------------------------------------------------------------------------
+
+/**
+ * Read/write interface for the build cache file.
+ *
+ * ## Usage example
+ *
+ * ```typescript
+ * const cache = new BuildCache();
+ * cache.load("/repo/.build-cache.json");
+ *
+ * if (cache.needsBuild("python/logic-gates", pkgHash, depsHash)) {
+ *     // ... run build ...
+ *     cache.record("python/logic-gates", pkgHash, depsHash, "success");
+ * }
+ *
+ * cache.save("/repo/.build-cache.json");
+ * ```
+ */
+export class BuildCache {
+  /** Internal storage: package name -> cache entry. */
+  private _entries: Map<string, CacheEntry> = new Map();
+
+  /**
+   * Load cache entries from a JSON file.
+   *
+   * If the file doesn't exist or is malformed, we start with an empty
+   * cache (no error raised -- a missing cache just means everything
+   * gets rebuilt).
+   *
+   * @param filePath - Absolute path to the cache JSON file.
+   */
+  load(filePath: string): void {
+    if (!fs.existsSync(filePath)) {
+      this._entries = new Map();
+      return;
+    }
+
+    try {
+      const text = fs.readFileSync(filePath, "utf-8");
+      const data = JSON.parse(text);
+
+      this._entries = new Map();
+      for (const [name, entryData] of Object.entries(data)) {
+        const entry = entryData as Record<string, unknown>;
+        // Validate required fields exist before adding to cache.
+        if (
+          typeof entry.package_hash === "string" &&
+          typeof entry.deps_hash === "string" &&
+          typeof entry.last_built === "string" &&
+          typeof entry.status === "string"
+        ) {
+          this._entries.set(name, {
+            packageHash: entry.package_hash,
+            depsHash: entry.deps_hash,
+            lastBuilt: entry.last_built,
+            status: entry.status,
+          });
+        }
+      }
+    } catch {
+      // JSON parse error or read error -- start fresh.
+      this._entries = new Map();
+    }
+  }
+
+  /**
+   * Save cache entries to a JSON file with atomic write.
+   *
+   * Writes to a temporary file first, then renames. This prevents
+   * corruption if the process is interrupted mid-write.
+   *
+   * The JSON format uses snake_case keys to match the Python implementation's
+   * cache format, ensuring cross-tool compatibility.
+   *
+   * @param filePath - Absolute path to the cache JSON file.
+   */
+  save(filePath: string): void {
+    const data: Record<
+      string,
+      Record<string, string>
+    > = {};
+
+    // Sort entries by name for deterministic output.
+    const sortedNames = Array.from(this._entries.keys()).sort();
+    for (const name of sortedNames) {
+      const entry = this._entries.get(name)!;
+      data[name] = {
+        package_hash: entry.packageHash,
+        deps_hash: entry.depsHash,
+        last_built: entry.lastBuilt,
+        status: entry.status,
+      };
+    }
+
+    const tmpPath = path.join(
+      path.dirname(filePath),
+      `${path.basename(filePath)}.tmp`,
+    );
+    fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2) + "\n", "utf-8");
+    fs.renameSync(tmpPath, filePath);
+  }
+
+  /**
+   * Determine if a package needs rebuilding.
+   *
+   * A package needs rebuilding if:
+   * 1. It's not in the cache at all (never built).
+   * 2. Its source hash changed (files were modified).
+   * 3. Its dependency hash changed (a dependency was modified).
+   * 4. Its last build failed.
+   *
+   * @param name - Package name (e.g., "python/logic-gates").
+   * @param pkgHash - Current SHA256 of the package's source files.
+   * @param depsHash - Current SHA256 of transitive dependency hashes.
+   * @returns True if the package should be rebuilt.
+   */
+  needsBuild(name: string, pkgHash: string, depsHash: string): boolean {
+    const entry = this._entries.get(name);
+
+    // Case 1: Never built before.
+    if (!entry) {
+      return true;
+    }
+
+    // Case 2: Last build failed -- always retry.
+    if (entry.status === "failed") {
+      return true;
+    }
+
+    // Case 3: Source files changed.
+    if (entry.packageHash !== pkgHash) {
+      return true;
+    }
+
+    // Case 4: Dependencies changed.
+    if (entry.depsHash !== depsHash) {
+      return true;
+    }
+
+    // No changes detected -- skip this package.
+    return false;
+  }
+
+  /**
+   * Record a build result in the cache.
+   *
+   * @param name - Package name.
+   * @param pkgHash - SHA256 of the package's source files at build time.
+   * @param depsHash - SHA256 of transitive dependency hashes at build time.
+   * @param status - "success" or "failed".
+   */
+  record(
+    name: string,
+    pkgHash: string,
+    depsHash: string,
+    status: string,
+  ): void {
+    this._entries.set(name, {
+      packageHash: pkgHash,
+      depsHash: depsHash,
+      lastBuilt: new Date().toISOString(),
+      status,
+    });
+  }
+
+  /**
+   * Read-only access to the cache entries.
+   *
+   * Returns a new Map to prevent external mutation of the internal state.
+   */
+  get entries(): Map<string, CacheEntry> {
+    return new Map(this._entries);
+  }
+}

--- a/code/programs/typescript/build-tool/src/discovery.ts
+++ b/code/programs/typescript/build-tool/src/discovery.ts
@@ -1,0 +1,355 @@
+/**
+ * discovery.ts -- Package Discovery via Recursive BUILD File Walk
+ * ================================================================
+ *
+ * This module walks a monorepo directory tree to discover packages. A "package"
+ * is any directory that contains a BUILD file. The walk is recursive: starting
+ * from the root, we list all subdirectories and descend into each one, skipping
+ * known non-source directories (.git, .venv, node_modules, etc.).
+ *
+ * When we find a BUILD file in a directory, we stop recursing there and register
+ * that directory as a package. This is the same approach used by Bazel, Buck,
+ * and Pants -- no configuration files are needed to route the walk.
+ *
+ * ## Platform-specific BUILD files
+ *
+ * The build tool supports platform-specific BUILD files so that packages can
+ * define different build commands for different operating systems. The priority
+ * order is (most specific wins):
+ *
+ * - **darwin** (macOS):  BUILD_mac -> BUILD_mac_and_linux -> BUILD
+ * - **linux**:           BUILD_linux -> BUILD_mac_and_linux -> BUILD
+ * - **win32** (Windows): BUILD_windows -> BUILD
+ *
+ * This layering lets packages provide Windows-specific build commands via
+ * BUILD_windows while sharing a single BUILD_mac_and_linux for the common
+ * Unix case, falling back to BUILD when no platform differences exist.
+ *
+ * Note: Node.js `os.platform()` returns "win32" on Windows, not "windows".
+ * We handle both for robustness.
+ *
+ * ## Language inference
+ *
+ * We infer the language from the directory path. If the path contains
+ * "packages/python/X" or "programs/python/X", the language is "python".
+ * Similarly for "ruby", "go", "rust", "typescript", and "elixir". The
+ * package name is "{language}/{dir-name}".
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Directories that should never be traversed during package discovery.
+ *
+ * These are known to contain non-source files (caches, dependencies, build
+ * artifacts) that would waste time to scan. Every build tool, linter, and
+ * IDE has a similar skip list -- this is ours.
+ */
+export const SKIP_DIRS: ReadonlySet<string> = new Set([
+  ".git",
+  ".hg",
+  ".svn",
+  ".venv",
+  ".tox",
+  ".mypy_cache",
+  ".pytest_cache",
+  ".ruff_cache",
+  "__pycache__",
+  "node_modules",
+  "vendor",
+  "dist",
+  "build",
+  "target",
+  ".claude",
+  "Pods",
+]);
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Represents a discovered package in the monorepo.
+ *
+ * Think of this as a "build target" -- it's a directory with source code
+ * and a BUILD file that tells us how to build it.
+ *
+ * @property name - A qualified name like "python/logic-gates" or "ruby/arithmetic".
+ *                  The format is always "{language}/{directory-name}".
+ * @property path - Absolute path to the package directory on disk.
+ * @property buildCommands - Lines from the BUILD file (commands to execute).
+ *                           Blank lines and comments are stripped out.
+ * @property language - Inferred language: "python", "ruby", "go", "rust",
+ *                      "typescript", "elixir", or "unknown".
+ */
+export interface Package {
+  name: string;
+  path: string;
+  buildCommands: string[];
+  language: string;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Read a file and return non-blank, non-comment lines.
+ *
+ * Blank lines and lines starting with '#' are stripped out. Leading and
+ * trailing whitespace is removed from each line. This is the standard
+ * format for BUILD files in this monorepo.
+ *
+ * @param filepath - Absolute path to the file to read.
+ * @returns Array of non-blank, non-comment lines.
+ */
+export function readLines(filepath: string): string[] {
+  if (!fs.existsSync(filepath)) {
+    return [];
+  }
+
+  const text = fs.readFileSync(filepath, "utf-8");
+  const lines: string[] = [];
+
+  for (const line of text.split("\n")) {
+    const stripped = line.trim();
+    if (stripped && !stripped.startsWith("#")) {
+      lines.push(stripped);
+    }
+  }
+
+  return lines;
+}
+
+/**
+ * Infer the programming language from the directory path.
+ *
+ * We look for known language directory names in the path components.
+ * The pattern we look for is a parent directory named "python", "ruby",
+ * "go", "rust", "typescript", or "elixir" that sits under "packages" or
+ * "programs".
+ *
+ * For example:
+ * - "/repo/code/packages/python/logic-gates" -> "python"
+ * - "/repo/code/programs/go/build-tool" -> "go"
+ * - "/repo/code/packages/rust/arithmetic" -> "rust"
+ *
+ * @param dirPath - Absolute path to the directory.
+ * @returns The inferred language string, or "unknown".
+ */
+export function inferLanguage(dirPath: string): string {
+  // Split the path into its component parts (directories).
+  // On Unix: "/a/b/c" -> ["", "a", "b", "c"]
+  // On Windows: "C:\\a\\b" -> ["C:", "a", "b"]
+  const parts = dirPath.split(path.sep);
+
+  const knownLanguages = [
+    "python",
+    "ruby",
+    "go",
+    "rust",
+    "typescript",
+    "elixir",
+  ];
+  for (const lang of knownLanguages) {
+    if (parts.includes(lang)) {
+      return lang;
+    }
+  }
+
+  return "unknown";
+}
+
+/**
+ * Build a qualified package name like "python/logic-gates".
+ *
+ * Uses the language and the directory's basename. This naming convention
+ * is consistent across all build tool implementations (Python, Ruby, Go,
+ * Rust, Elixir, and now TypeScript).
+ *
+ * @param dirPath - Absolute path to the package directory.
+ * @param language - The inferred language.
+ * @returns A qualified name string.
+ */
+export function inferPackageName(dirPath: string, language: string): string {
+  return `${language}/${path.basename(dirPath)}`;
+}
+
+/**
+ * Return the appropriate BUILD file path for the current platform.
+ *
+ * This implements the platform-specific BUILD file priority system. The
+ * idea is that most packages have a single BUILD file, but when a package
+ * needs different commands on different operating systems (e.g., different
+ * compiler flags on macOS vs Linux), it can provide platform-specific
+ * variants.
+ *
+ * Priority (most specific wins):
+ *
+ * 1. Platform-specific: BUILD_mac (macOS), BUILD_linux (Linux), BUILD_windows (Windows)
+ * 2. Shared Unix: BUILD_mac_and_linux (macOS or Linux -- for the common case)
+ * 3. Generic: BUILD (all platforms)
+ * 4. null if no BUILD file exists
+ *
+ * @param directory - Absolute path to the directory to check.
+ * @param platformOverride - Optional platform string for testing. If not
+ *                           provided, uses os.platform().
+ * @returns Absolute path to the BUILD file, or null if none exists.
+ */
+export function getBuildFile(
+  directory: string,
+  platformOverride?: string,
+): string | null {
+  // Node.js os.platform() returns "darwin" for macOS, "linux" for Linux,
+  // and "win32" for Windows (not "windows"!).
+  const platform = platformOverride ?? os.platform();
+
+  // Step 1: Check for the most specific platform file.
+  //
+  // This is a direct lookup -- if the exact platform BUILD file exists,
+  // it takes highest priority.
+  if (platform === "darwin") {
+    const macBuild = path.join(directory, "BUILD_mac");
+    if (fs.existsSync(macBuild)) {
+      return macBuild;
+    }
+  }
+
+  if (platform === "linux") {
+    const linuxBuild = path.join(directory, "BUILD_linux");
+    if (fs.existsSync(linuxBuild)) {
+      return linuxBuild;
+    }
+  }
+
+  if (platform === "win32") {
+    const windowsBuild = path.join(directory, "BUILD_windows");
+    if (fs.existsSync(windowsBuild)) {
+      return windowsBuild;
+    }
+  }
+
+  // Step 2: Check for the shared Unix file (macOS + Linux).
+  //
+  // Many packages have identical build commands on macOS and Linux but
+  // different ones on Windows. BUILD_mac_and_linux covers the common case
+  // without duplicating a BUILD_mac and BUILD_linux.
+  if (platform === "darwin" || platform === "linux") {
+    const sharedBuild = path.join(directory, "BUILD_mac_and_linux");
+    if (fs.existsSync(sharedBuild)) {
+      return sharedBuild;
+    }
+  }
+
+  // Step 3: Fall back to the generic BUILD file.
+  //
+  // This is the default -- if no platform-specific file exists, use the
+  // generic one.
+  const genericBuild = path.join(directory, "BUILD");
+  if (fs.existsSync(genericBuild)) {
+    return genericBuild;
+  }
+
+  // Step 4: No BUILD file found at all.
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Recursively walk the directory tree, collect packages with BUILD files.
+ *
+ * Starting from `root`, we list all subdirectories and descend into each
+ * one (skipping directories in the skip list). When we find a BUILD file,
+ * we register that directory as a package and stop recursing into it.
+ *
+ * This is the same "walk until you find a BUILD file" approach used by
+ * Bazel, Buck, and Pants. It means:
+ * - No central configuration file listing all packages
+ * - Adding a new package = adding a BUILD file
+ * - Nested packages are supported (a BUILD file stops descent)
+ *
+ * @param root - The monorepo root directory (typically the "code/" directory).
+ * @param platformOverride - Optional platform string for testing.
+ * @returns A list of discovered Package objects, sorted by name.
+ */
+export function discoverPackages(
+  root: string,
+  platformOverride?: string,
+): Package[] {
+  const packages: Package[] = [];
+  walkDirs(root, packages, platformOverride);
+
+  // Sort by name for deterministic output. This ensures that the build
+  // order is the same regardless of filesystem ordering (which can vary
+  // between operating systems and filesystems).
+  packages.sort((a, b) => a.name.localeCompare(b.name));
+
+  return packages;
+}
+
+/**
+ * Recursively walk directories and collect packages.
+ *
+ * This is the recursive workhorse. For each directory:
+ * 1. If its name is in the skip list, ignore it entirely.
+ * 2. If it has a BUILD file, register it as a package and stop recursing.
+ * 3. Otherwise, list subdirectories and recurse into each one.
+ *
+ * @param directory - Current directory being examined.
+ * @param packages - Accumulator array (mutated in place).
+ * @param platformOverride - Optional platform string for testing.
+ */
+function walkDirs(
+  directory: string,
+  packages: Package[],
+  platformOverride?: string,
+): void {
+  // Skip known non-source directories.
+  if (SKIP_DIRS.has(path.basename(directory))) {
+    return;
+  }
+
+  const buildFile = getBuildFile(directory, platformOverride);
+
+  if (buildFile !== null) {
+    // This directory is a package! Read the BUILD commands.
+    const commands = readLines(buildFile);
+    const language = inferLanguage(directory);
+    const name = inferPackageName(directory, language);
+
+    packages.push({
+      name,
+      path: directory,
+      buildCommands: commands,
+      language,
+    });
+    return;
+  }
+
+  // Not a package -- list subdirectories and recurse into each one.
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(directory, { withFileTypes: true });
+  } catch {
+    // Permission denied or other read error -- skip silently.
+    return;
+  }
+
+  // Sort entries for deterministic traversal order.
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      walkDirs(path.join(directory, entry.name), packages, platformOverride);
+    }
+  }
+}

--- a/code/programs/typescript/build-tool/src/executor.ts
+++ b/code/programs/typescript/build-tool/src/executor.ts
@@ -1,0 +1,345 @@
+/**
+ * executor.ts -- Parallel Build Execution
+ * ========================================
+ *
+ * This module runs BUILD commands for packages that need rebuilding. It
+ * respects the dependency graph by building packages in topological levels:
+ * packages in the same level have no dependencies on each other and can
+ * run in parallel.
+ *
+ * ## Execution strategy
+ *
+ * 1. Get the `independentGroups()` from the dependency graph -- these are
+ *    the parallel levels.
+ *
+ * 2. For each level, run all packages in that level concurrently using
+ *    Promise.all (Node.js is single-threaded but the child processes run
+ *    in parallel via the OS).
+ *
+ * 3. For each package, execute its BUILD commands sequentially via
+ *    `child_process.execSync`, with `cwd` set to the package directory.
+ *
+ * 4. If a package fails (any command returns non-zero), mark all transitive
+ *    dependents as "dep-skipped" -- there's no point building them.
+ *
+ * ## Build results
+ *
+ * Each package gets a `BuildResult` with its status, stdout/stderr output,
+ * and wall-clock duration.
+ *
+ * ## Why Promise.all instead of a thread pool?
+ *
+ * Node.js runs JavaScript in a single thread, but child_process.exec()
+ * spawns actual OS processes that run in parallel. Promise.all() lets us
+ * start multiple child processes simultaneously and wait for all of them.
+ * The `maxJobs` parameter limits concurrency by splitting the level into
+ * batches.
+ */
+
+import { exec } from "node:child_process";
+import type { Package } from "./discovery.js";
+import type { BuildCache } from "./cache.js";
+import type { DirectedGraph } from "./resolver.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * The result of building a single package.
+ *
+ * Every package that goes through the build pipeline gets one of these,
+ * regardless of whether it was actually built, skipped, or failed.
+ */
+export interface BuildResult {
+  /** The package's qualified name (e.g., "python/logic-gates"). */
+  packageName: string;
+
+  /**
+   * Build status:
+   * - "built": Successfully built.
+   * - "failed": Build command returned non-zero exit code.
+   * - "skipped": No changes detected, build not needed.
+   * - "dep-skipped": A dependency failed, so this was skipped.
+   * - "would-build": Dry run -- would have been built.
+   */
+  status: "built" | "failed" | "skipped" | "dep-skipped" | "would-build";
+
+  /** Wall-clock seconds spent building (0 for skipped packages). */
+  duration: number;
+
+  /** Combined stdout from all BUILD commands. */
+  stdout: string;
+
+  /** Combined stderr from all BUILD commands. */
+  stderr: string;
+
+  /** Exit code of the last failing command, or 0 for success. */
+  returnCode: number;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute a single shell command and return its result.
+ *
+ * Wraps Node's child_process.exec() in a Promise for async/await usage.
+ * The command runs in a shell (like bash), with the working directory
+ * set to the package directory.
+ */
+function execCommand(
+  command: string,
+  cwd: string,
+): Promise<{ stdout: string; stderr: string; returnCode: number }> {
+  return new Promise((resolve) => {
+    exec(
+      command,
+      {
+        cwd,
+        timeout: 600000, // 10-minute timeout per command
+        maxBuffer: 10 * 1024 * 1024, // 10MB buffer
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          // Node's exec() puts the error code on the error object.
+          const code =
+            "code" in error && typeof error.code === "number"
+              ? error.code
+              : 1;
+          resolve({
+            stdout: stdout ?? "",
+            stderr: stderr ?? "",
+            returnCode: code,
+          });
+        } else {
+          resolve({ stdout, stderr, returnCode: 0 });
+        }
+      },
+    );
+  });
+}
+
+/**
+ * Execute all BUILD commands for a single package.
+ *
+ * Commands are run sequentially. If any command fails, we stop and
+ * return a "failed" result. All commands run with `cwd` set to the
+ * package directory and inherit the current environment.
+ */
+async function runPackageBuild(pkg: Package): Promise<BuildResult> {
+  const start = performance.now();
+  const allStdout: string[] = [];
+  const allStderr: string[] = [];
+
+  for (const command of pkg.buildCommands) {
+    const result = await execCommand(command, pkg.path);
+    allStdout.push(result.stdout);
+    allStderr.push(result.stderr);
+
+    if (result.returnCode !== 0) {
+      const elapsed = (performance.now() - start) / 1000;
+      return {
+        packageName: pkg.name,
+        status: "failed",
+        duration: elapsed,
+        stdout: allStdout.join(""),
+        stderr: allStderr.join(""),
+        returnCode: result.returnCode,
+      };
+    }
+  }
+
+  const elapsed = (performance.now() - start) / 1000;
+  return {
+    packageName: pkg.name,
+    status: "built",
+    duration: elapsed,
+    stdout: allStdout.join(""),
+    stderr: allStderr.join(""),
+    returnCode: 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute BUILD commands for packages, respecting dependency order.
+ *
+ * Uses `independentGroups()` from the dependency graph to determine
+ * which packages can run in parallel. For each level, packages are built
+ * concurrently using Promise.all.
+ *
+ * If a package fails, all its transitive dependents are marked as
+ * "dep-skipped".
+ *
+ * @param options - Build execution options.
+ * @param options.packages - All discovered packages.
+ * @param options.graph - The dependency graph.
+ * @param options.cache - The build cache (for skip detection).
+ * @param options.packageHashes - Per-package source hashes.
+ * @param options.depsHashes - Per-package dependency hashes.
+ * @param options.force - If true, rebuild everything regardless of cache.
+ * @param options.dryRun - If true, don't actually build -- just report.
+ * @param options.maxJobs - Maximum number of parallel workers.
+ * @param options.affectedSet - Set of packages affected by git changes.
+ * @returns A map of package names to their BuildResult.
+ */
+export async function executeBuilds(options: {
+  packages: Package[];
+  graph: DirectedGraph;
+  cache: BuildCache;
+  packageHashes: Map<string, string>;
+  depsHashes: Map<string, string>;
+  force?: boolean;
+  dryRun?: boolean;
+  maxJobs?: number;
+  affectedSet?: Set<string> | null;
+}): Promise<Map<string, BuildResult>> {
+  const {
+    packages,
+    graph,
+    cache,
+    packageHashes,
+    depsHashes,
+    force = false,
+    dryRun = false,
+    maxJobs,
+    affectedSet = null,
+  } = options;
+
+  // Build a lookup from name to Package.
+  const pkgByName = new Map<string, Package>();
+  for (const pkg of packages) {
+    pkgByName.set(pkg.name, pkg);
+  }
+
+  // Get the parallel levels from the dependency graph.
+  const groups = graph.independentGroups();
+
+  const results = new Map<string, BuildResult>();
+  const failedPackages = new Set<string>();
+
+  for (const level of groups) {
+    // Determine what to build in this level.
+    const toBuild: Package[] = [];
+
+    for (const name of level) {
+      if (!pkgByName.has(name)) {
+        continue;
+      }
+
+      // Check if a dependency failed.
+      // In our graph, edges go dep -> pkg, so a package's dependencies
+      // are found by checking transitiveDependents (walking reverse edges).
+      let depFailed = false;
+      for (const dep of graph.transitiveDependents(name)) {
+        if (failedPackages.has(dep)) {
+          depFailed = true;
+          break;
+        }
+      }
+
+      if (depFailed) {
+        results.set(name, {
+          packageName: name,
+          status: "dep-skipped",
+          duration: 0,
+          stdout: "",
+          stderr: "",
+          returnCode: 0,
+        });
+        continue;
+      }
+
+      // Check if we need to build.
+      // Priority: git-diff affectedSet > hash-based cache
+      if (affectedSet !== null && !affectedSet.has(name)) {
+        results.set(name, {
+          packageName: name,
+          status: "skipped",
+          duration: 0,
+          stdout: "",
+          stderr: "",
+          returnCode: 0,
+        });
+        continue;
+      }
+
+      const pkgHash = packageHashes.get(name) ?? "";
+      const depHash = depsHashes.get(name) ?? "";
+
+      if (
+        affectedSet === null &&
+        !force &&
+        !cache.needsBuild(name, pkgHash, depHash)
+      ) {
+        results.set(name, {
+          packageName: name,
+          status: "skipped",
+          duration: 0,
+          stdout: "",
+          stderr: "",
+          returnCode: 0,
+        });
+        continue;
+      }
+
+      if (dryRun) {
+        results.set(name, {
+          packageName: name,
+          status: "would-build",
+          duration: 0,
+          stdout: "",
+          stderr: "",
+          returnCode: 0,
+        });
+        continue;
+      }
+
+      toBuild.push(pkgByName.get(name)!);
+    }
+
+    if (toBuild.length === 0 || dryRun) {
+      continue;
+    }
+
+    // Execute this level in parallel (with optional concurrency limit).
+    const workers = maxJobs ?? Math.min(toBuild.length, 8);
+
+    // Process in batches to respect maxJobs limit.
+    for (let i = 0; i < toBuild.length; i += workers) {
+      const batch = toBuild.slice(i, i + workers);
+      const batchResults = await Promise.all(
+        batch.map((pkg) => runPackageBuild(pkg)),
+      );
+
+      for (const result of batchResults) {
+        results.set(result.packageName, result);
+
+        // Update cache.
+        if (result.status === "built") {
+          cache.record(
+            result.packageName,
+            packageHashes.get(result.packageName) ?? "",
+            depsHashes.get(result.packageName) ?? "",
+            "success",
+          );
+        } else if (result.status === "failed") {
+          failedPackages.add(result.packageName);
+          cache.record(
+            result.packageName,
+            packageHashes.get(result.packageName) ?? "",
+            depsHashes.get(result.packageName) ?? "",
+            "failed",
+          );
+        }
+      }
+    }
+  }
+
+  return results;
+}

--- a/code/programs/typescript/build-tool/src/gitdiff.ts
+++ b/code/programs/typescript/build-tool/src/gitdiff.ts
@@ -1,0 +1,147 @@
+/**
+ * gitdiff.ts -- Git-based Change Detection
+ * ==========================================
+ *
+ * This module determines which packages changed by comparing the current
+ * branch against a base branch (typically `origin/main`) using git.
+ *
+ * This is the DEFAULT change detection mechanism. It replaces the cache-based
+ * approach with a stateless one -- git itself is the source of truth. No
+ * cache file needed.
+ *
+ * ## How it works
+ *
+ * 1. Run `git diff --name-only <base>...HEAD`
+ *    This gives us every file that changed between the base and HEAD.
+ *    The three-dot syntax means "changes since the merge base", which is
+ *    exactly what we want for PR builds.
+ *
+ * 2. Map each changed file to a package by matching its path prefix
+ *    against discovered package paths.
+ *    e.g., "code/packages/python/logic-gates/src/gates.py"
+ *          -> package "python/logic-gates"
+ *
+ * 3. Use the directed graph's `affectedNodes()` to find all packages
+ *    that transitively depend on the changed packages.
+ *
+ * 4. Return the full set of affected packages to build.
+ *
+ * ## Why git-diff is better than hash-based caching
+ *
+ * The beauty of this approach: no state to manage, no cache file to commit,
+ * and it works perfectly with CI (every PR naturally has a base branch to
+ * diff against).
+ */
+
+import { execSync } from "node:child_process";
+import * as path from "node:path";
+
+/**
+ * Get the list of files changed between diffBase and HEAD.
+ *
+ * Uses `git diff --name-only <base>...HEAD` which shows files changed
+ * on the current branch since it diverged from the base. The three-dot
+ * syntax means "changes since the merge base", which is exactly what
+ * we want for PR builds.
+ *
+ * For pushes to main, use `HEAD~1` as the base to compare against
+ * the previous commit.
+ *
+ * If the three-dot diff fails (e.g., shallow clone or missing remote ref),
+ * we fall back to a two-dot diff.
+ *
+ * @param repoRoot - The repository root directory (contains .git).
+ * @param diffBase - The git ref to compare against (default: "origin/main").
+ * @returns List of changed file paths relative to repoRoot. Empty if diff fails.
+ */
+export function getChangedFiles(
+  repoRoot: string,
+  diffBase: string = "origin/main",
+): string[] {
+  try {
+    // Try three-dot diff first (preferred for PR builds).
+    const result = execSync(
+      `git diff --name-only ${diffBase}...HEAD`,
+      {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        timeout: 30000,
+        stdio: ["pipe", "pipe", "pipe"],
+      },
+    );
+
+    return result
+      .trim()
+      .split("\n")
+      .filter((line) => line.trim().length > 0);
+  } catch {
+    // Three-dot failed -- try two-dot fallback.
+    try {
+      const result = execSync(
+        `git diff --name-only ${diffBase} HEAD`,
+        {
+          cwd: repoRoot,
+          encoding: "utf-8",
+          timeout: 30000,
+          stdio: ["pipe", "pipe", "pipe"],
+        },
+      );
+
+      return result
+        .trim()
+        .split("\n")
+        .filter((line) => line.trim().length > 0);
+    } catch {
+      // Both failed -- return empty list.
+      return [];
+    }
+  }
+}
+
+/**
+ * Map changed file paths to package names.
+ *
+ * For each changed file, check which package directory it falls under.
+ * A file belongs to a package if its path starts with the package's
+ * directory path (relative to repo root).
+ *
+ * @param changedFiles - File paths relative to repo root.
+ * @param packagePaths - Mapping of package name -> absolute package directory.
+ * @param repoRoot - The repository root directory.
+ * @returns Set of package names that contain at least one changed file.
+ *
+ * @example
+ * ```
+ * changedFiles = ["code/packages/python/logic-gates/src/gates.py"]
+ * packagePaths = new Map([["python/logic-gates", "/repo/code/packages/python/logic-gates"]])
+ * // Returns: Set(["python/logic-gates"])
+ * ```
+ */
+export function mapFilesToPackages(
+  changedFiles: string[],
+  packagePaths: Map<string, string>,
+  repoRoot: string,
+): Set<string> {
+  const changed = new Set<string>();
+
+  // Convert package paths to relative strings for prefix matching.
+  const relativePkgPaths = new Map<string, string>();
+  for (const [name, absPath] of packagePaths) {
+    const relPath = path.relative(repoRoot, absPath);
+    relativePkgPaths.set(name, relPath);
+  }
+
+  for (const filepath of changedFiles) {
+    for (const [pkgName, pkgRelPath] of relativePkgPaths) {
+      if (
+        filepath.startsWith(pkgRelPath + "/") ||
+        filepath === pkgRelPath
+      ) {
+        changed.add(pkgName);
+        break; // A file belongs to at most one package.
+      }
+    }
+  }
+
+  return changed;
+}

--- a/code/programs/typescript/build-tool/src/hasher.ts
+++ b/code/programs/typescript/build-tool/src/hasher.ts
@@ -1,0 +1,238 @@
+/**
+ * hasher.ts -- SHA256 File Hashing for Change Detection
+ * =====================================================
+ *
+ * This module computes SHA256 hashes for package source files. The hash of a
+ * package is a single string that changes whenever any source file in the
+ * package is modified, added, or removed.
+ *
+ * ## How hashing works
+ *
+ * 1. Collect all source files in the package directory, filtered by the
+ *    language's relevant extensions. Always include the BUILD file.
+ * 2. Sort the file list lexicographically (by relative path) for determinism.
+ * 3. SHA256-hash each file's contents individually.
+ * 4. Concatenate all individual hashes into one string.
+ * 5. SHA256-hash that concatenated string to produce the final package hash.
+ *
+ * This two-level hashing means:
+ * - Reordering files doesn't change the hash (we sort first).
+ * - Adding or removing a file changes the hash (the concatenated string changes).
+ * - Modifying any file's contents changes the hash.
+ *
+ * ## Dependency hashing
+ *
+ * A package should be rebuilt if any of its transitive dependencies changed.
+ * `hashDeps` takes a package name, the dependency graph, and the per-package
+ * hashes, then produces a single hash representing the state of all dependencies.
+ *
+ * ## Why SHA256?
+ *
+ * SHA256 is a cryptographic hash function that produces a 256-bit (32-byte)
+ * digest. It's fast enough for our purposes and has an astronomically low
+ * collision probability -- the chance of two different files producing the
+ * same hash is roughly 1 in 2^256.
+ */
+
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { Package } from "./discovery.js";
+import type { DirectedGraph } from "./resolver.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Source file extensions that matter for each language.
+ *
+ * If any file with these extensions changes, the package needs rebuilding.
+ * We only track extensions that contain actual source code or configuration
+ * that affects the build output.
+ */
+export const SOURCE_EXTENSIONS: Record<string, Set<string>> = {
+  python: new Set([".py", ".toml", ".cfg"]),
+  ruby: new Set([".rb", ".gemspec"]),
+  go: new Set([".go"]),
+  rust: new Set([".rs", ".toml"]),
+  typescript: new Set([".ts", ".json"]),
+  elixir: new Set([".ex", ".exs"]),
+};
+
+/**
+ * Special filenames to always include regardless of extension.
+ *
+ * Some files don't have standard extensions but are still important
+ * for builds (like Makefiles or lock files).
+ */
+export const SPECIAL_FILENAMES: Record<string, Set<string>> = {
+  python: new Set(),
+  ruby: new Set(["Gemfile", "Rakefile"]),
+  go: new Set(["go.mod", "go.sum"]),
+  rust: new Set(["Cargo.lock"]),
+  typescript: new Set(["package-lock.json"]),
+  elixir: new Set(["mix.lock"]),
+};
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Recursively collect all files in a directory.
+ *
+ * This is a simple recursive directory walker that returns all files
+ * (not directories) found under the given root.
+ */
+function walkFiles(dir: string): string[] {
+  const results: string[] = [];
+  let entries: fs.Dirent[];
+
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return results;
+  }
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...walkFiles(fullPath));
+    } else if (entry.isFile()) {
+      results.push(fullPath);
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Collect all source files in a package directory.
+ *
+ * Files are filtered by the language's relevant extensions and special
+ * filenames. BUILD files are always included.
+ *
+ * @param pkg - The package to collect files for.
+ * @returns A sorted list of absolute paths.
+ */
+export function collectSourceFiles(pkg: Package): string[] {
+  const extensions = SOURCE_EXTENSIONS[pkg.language] ?? new Set<string>();
+  const specialNames = SPECIAL_FILENAMES[pkg.language] ?? new Set<string>();
+
+  const files: string[] = [];
+
+  for (const filepath of walkFiles(pkg.path)) {
+    const basename = path.basename(filepath);
+    const ext = path.extname(filepath);
+
+    // Always include BUILD files (any variant).
+    if (
+      basename === "BUILD" ||
+      basename === "BUILD_mac" ||
+      basename === "BUILD_linux" ||
+      basename === "BUILD_windows" ||
+      basename === "BUILD_mac_and_linux"
+    ) {
+      files.push(filepath);
+      continue;
+    }
+
+    // Check extension.
+    if (extensions.has(ext)) {
+      files.push(filepath);
+      continue;
+    }
+
+    // Check special filenames.
+    if (specialNames.has(basename)) {
+      files.push(filepath);
+      continue;
+    }
+  }
+
+  // Sort by relative path for determinism.
+  files.sort((a, b) => {
+    const relA = path.relative(pkg.path, a);
+    const relB = path.relative(pkg.path, b);
+    return relA.localeCompare(relB);
+  });
+
+  return files;
+}
+
+/**
+ * Compute the SHA256 hex digest of a single file's contents.
+ *
+ * Reads the file in one go and returns the hex-encoded hash.
+ * For very large files, a streaming approach would be better, but
+ * source files are typically small enough that this is fine.
+ */
+export function hashFile(filepath: string): string {
+  const content = fs.readFileSync(filepath);
+  return crypto.createHash("sha256").update(content).digest("hex");
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute a SHA256 hash representing all source files in the package.
+ *
+ * The hash changes if any source file is added, removed, or modified.
+ *
+ * @param pkg - The package to hash.
+ * @returns A hex-encoded SHA256 hash string.
+ */
+export function hashPackage(pkg: Package): string {
+  const files = collectSourceFiles(pkg);
+
+  if (files.length === 0) {
+    // No source files -- hash the empty string for consistency.
+    return crypto.createHash("sha256").update("").digest("hex");
+  }
+
+  // Hash each file, concatenate, hash again.
+  const fileHashes = files.map((f) => hashFile(f));
+  const combined = fileHashes.join("");
+  return crypto.createHash("sha256").update(combined).digest("hex");
+}
+
+/**
+ * Compute a SHA256 hash of all transitive dependency hashes.
+ *
+ * If any transitive dependency's source files changed, this hash will
+ * change too, triggering a rebuild of the dependent package.
+ *
+ * In our graph, edges go dep -> pkg (dependency points to dependent),
+ * so a package's dependencies are found by walking the reverse direction
+ * (transitiveDependents).
+ *
+ * @param packageName - The package whose dependencies we're hashing.
+ * @param graph - The dependency graph.
+ * @param packageHashes - Mapping from package name to its source hash.
+ * @returns A hex-encoded SHA256 hash string.
+ */
+export function hashDeps(
+  packageName: string,
+  graph: DirectedGraph,
+  packageHashes: Map<string, string>,
+): string {
+  if (!graph.hasNode(packageName)) {
+    return crypto.createHash("sha256").update("").digest("hex");
+  }
+
+  const transitiveDeps = graph.transitiveDependents(packageName);
+
+  if (transitiveDeps.size === 0) {
+    return crypto.createHash("sha256").update("").digest("hex");
+  }
+
+  // Sort dependency names for determinism, concatenate their hashes.
+  const sortedDeps = Array.from(transitiveDeps).sort();
+  const combined = sortedDeps
+    .map((dep) => packageHashes.get(dep) ?? "")
+    .join("");
+  return crypto.createHash("sha256").update(combined).digest("hex");
+}

--- a/code/programs/typescript/build-tool/src/index.ts
+++ b/code/programs/typescript/build-tool/src/index.ts
@@ -1,0 +1,235 @@
+#!/usr/bin/env npx tsx
+/**
+ * index.ts -- Command-Line Interface
+ * ====================================
+ *
+ * This is the entry point for the build tool CLI. It ties together all the
+ * modules: discovery, resolution, hashing, caching, execution, and reporting.
+ *
+ * ## Usage
+ *
+ * ```bash
+ * npx tsx src/index.ts                          # Auto-detect root, build changed packages
+ * npx tsx src/index.ts --root /path/to/repo     # Specify root explicitly
+ * npx tsx src/index.ts --force                   # Rebuild everything
+ * npx tsx src/index.ts --dry-run                 # Show what would build without building
+ * npx tsx src/index.ts --jobs 4                  # Limit parallel workers
+ * npx tsx src/index.ts --language python         # Only build Python packages
+ * ```
+ *
+ * ## The build flow
+ *
+ * 1. Discover packages (walk recursive BUILD files)
+ * 2. Filter by language if specified
+ * 3. Resolve dependencies (parse pyproject.toml, .gemspec, go.mod, etc.)
+ * 4. Hash all packages
+ * 5. Load cache, determine what needs building
+ * 6. If --dry-run, print what would build and exit
+ * 7. Execute builds (parallel by level)
+ * 8. Update and save cache
+ * 9. Print report
+ * 10. Exit with code 1 if any builds failed
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { parseArgs } from "node:util";
+import { discoverPackages } from "./discovery.js";
+import { resolveDependencies } from "./resolver.js";
+import { getChangedFiles, mapFilesToPackages } from "./gitdiff.js";
+import { hashPackage, hashDeps } from "./hasher.js";
+import { BuildCache } from "./cache.js";
+import { executeBuilds } from "./executor.js";
+import { printReport } from "./reporter.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk up from `start` (or cwd) looking for a `.git` directory.
+ *
+ * Returns the directory containing `.git`, or null if not found.
+ * This is how we auto-detect the repository root.
+ */
+function findRepoRoot(start?: string): string | null {
+  let current = path.resolve(start ?? process.cwd());
+
+  while (true) {
+    if (fs.existsSync(path.join(current, ".git"))) {
+      return current;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      // Reached filesystem root.
+      return null;
+    }
+    current = parent;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(argv?: string[]): Promise<number> {
+  // Parse command-line arguments using Node's built-in parseArgs.
+  const { values } = parseArgs({
+    args: argv ?? process.argv.slice(2),
+    options: {
+      root: { type: "string" },
+      force: { type: "boolean", default: false },
+      "dry-run": { type: "boolean", default: false },
+      jobs: { type: "string" },
+      language: { type: "string", default: "all" },
+      "diff-base": { type: "string", default: "origin/main" },
+      "cache-file": { type: "string", default: ".build-cache.json" },
+      help: { type: "boolean", default: false },
+    },
+    strict: true,
+  });
+
+  if (values.help) {
+    console.log(`Usage: build-tool [options]
+
+Options:
+  --root <dir>       Repo root directory (auto-detect from .git if not given)
+  --force            Rebuild everything regardless of cache
+  --dry-run          Show what would build without actually building
+  --jobs <n>         Maximum number of parallel build jobs
+  --language <lang>  Only build packages of this language (python|ruby|go|typescript|rust|elixir|all)
+  --diff-base <ref>  Git ref to diff against (default: origin/main)
+  --cache-file <f>   Path to build cache file (default: .build-cache.json)
+  --help             Show this help message`);
+    return 0;
+  }
+
+  // Step 1: Find repo root.
+  let root = values.root ?? null;
+  if (root === null) {
+    root = findRepoRoot();
+    if (root === null) {
+      console.error("Error: Could not find repo root (.git directory).");
+      console.error("Use --root to specify the repo root.");
+      return 1;
+    }
+  }
+
+  root = path.resolve(root);
+
+  // The build starts from code/ directory.
+  const codeRoot = path.join(root, "code");
+  if (!fs.existsSync(codeRoot)) {
+    console.error(`Error: ${codeRoot} does not exist.`);
+    return 1;
+  }
+
+  // Step 2: Discover packages.
+  let packages = discoverPackages(codeRoot);
+
+  if (packages.length === 0) {
+    console.error("No packages found.");
+    return 0;
+  }
+
+  // Step 3: Filter by language.
+  const language = values.language ?? "all";
+  if (language !== "all") {
+    packages = packages.filter((p) => p.language === language);
+    if (packages.length === 0) {
+      console.error(`No ${language} packages found.`);
+      return 0;
+    }
+  }
+
+  console.log(`Discovered ${packages.length} packages`);
+
+  // Step 4: Resolve dependencies.
+  const graph = resolveDependencies(packages);
+
+  // Step 5: Determine which packages need building.
+  //
+  // Default mode: git-diff based change detection.
+  // Git is the source of truth -- no cache file needed.
+  // Fallback: hash-based cache (for local dev when not on a branch).
+  let affectedSet: Set<string> | null = null;
+  const force = values.force ?? false;
+  const dryRun = values["dry-run"] ?? false;
+  const diffBase = values["diff-base"] ?? "origin/main";
+
+  if (!force) {
+    // Try git-diff mode first (the default).
+    const changedFiles = getChangedFiles(root, diffBase);
+    if (changedFiles.length > 0) {
+      const packagePaths = new Map<string, string>();
+      for (const pkg of packages) {
+        packagePaths.set(pkg.name, pkg.path);
+      }
+      const changedPackages = mapFilesToPackages(changedFiles, packagePaths, root);
+      if (changedPackages.size > 0) {
+        affectedSet = graph.affectedNodes(changedPackages);
+        console.log(
+          `Git diff: ${changedPackages.size} packages changed, ` +
+            `${affectedSet.size} affected (including dependents)`,
+        );
+      } else {
+        console.log("Git diff: no package files changed -- nothing to build");
+        affectedSet = new Set();
+      }
+    } else {
+      console.log("Git diff unavailable -- falling back to hash-based cache");
+    }
+  }
+
+  // Step 6: Hash all packages (needed for cache fallback).
+  const packageHashes = new Map<string, string>();
+  const depsHashes = new Map<string, string>();
+
+  for (const pkg of packages) {
+    packageHashes.set(pkg.name, hashPackage(pkg));
+    depsHashes.set(pkg.name, hashDeps(pkg.name, graph, packageHashes));
+  }
+
+  // Step 7: Load cache (fallback if git diff didn't work).
+  const cacheFile = values["cache-file"] ?? ".build-cache.json";
+  const cachePath = path.isAbsolute(cacheFile)
+    ? cacheFile
+    : path.join(root, cacheFile);
+
+  const cache = new BuildCache();
+  cache.load(cachePath);
+
+  // Steps 8-9: Execute builds.
+  const maxJobs = values.jobs ? parseInt(values.jobs, 10) : undefined;
+
+  const results = await executeBuilds({
+    packages,
+    graph,
+    cache,
+    packageHashes,
+    depsHashes,
+    force,
+    dryRun,
+    maxJobs,
+    affectedSet,
+  });
+
+  // Step 10: Save cache (as secondary record, not primary mechanism).
+  if (!dryRun) {
+    cache.save(cachePath);
+  }
+
+  // Step 11: Print report.
+  printReport(results);
+
+  // Step 12: Exit code.
+  const hasFailures = Array.from(results.values()).some(
+    (r) => r.status === "failed",
+  );
+  return hasFailures ? 1 : 0;
+}
+
+// Run the CLI.
+main().then((code) => {
+  process.exit(code);
+});

--- a/code/programs/typescript/build-tool/src/reporter.ts
+++ b/code/programs/typescript/build-tool/src/reporter.ts
@@ -1,0 +1,160 @@
+/**
+ * reporter.ts -- Build Report Formatting
+ * =======================================
+ *
+ * This module formats and prints a summary table of build results. The output
+ * is human-readable and designed for terminal display.
+ *
+ * ## Output format
+ *
+ * ```
+ * Build Report
+ * ============
+ * Package                    Status     Duration
+ * python/logic-gates         SKIPPED    -
+ * python/arithmetic          BUILT      2.3s
+ * python/arm-simulator       FAILED     0.5s
+ * python/riscv-simulator     DEP-SKIP   - (dep failed)
+ *
+ * Total: 21 packages | 5 built | 14 skipped | 1 failed | 1 dep-skipped
+ * ```
+ *
+ * The report is designed to be scannable at a glance: the status column
+ * tells you immediately what happened to each package, and the summary
+ * line gives you the high-level picture.
+ */
+
+import type { BuildResult } from "./executor.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Status display names mapping.
+ *
+ * These are the human-readable labels shown in the report table.
+ * They're kept short to fit in a fixed-width column.
+ */
+export const STATUS_DISPLAY: Record<string, string> = {
+  built: "BUILT",
+  failed: "FAILED",
+  skipped: "SKIPPED",
+  "dep-skipped": "DEP-SKIP",
+  "would-build": "WOULD-BUILD",
+};
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a duration for display.
+ *
+ * Returns "-" for zero/negligible durations (less than 10ms),
+ * otherwise formats as "X.Ys" with one decimal place.
+ *
+ * @param seconds - Duration in seconds.
+ * @returns Formatted duration string.
+ */
+export function formatDuration(seconds: number): string {
+  if (seconds < 0.01) {
+    return "-";
+  }
+  return `${seconds.toFixed(1)}s`;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a build report as a string.
+ *
+ * The report includes:
+ * 1. A header ("Build Report")
+ * 2. A table with Package, Status, and Duration columns
+ * 3. A summary line with counts for each status type
+ *
+ * Packages are sorted alphabetically for consistent output.
+ *
+ * @param results - Mapping from package name to BuildResult.
+ * @returns The formatted report string.
+ */
+export function formatReport(results: Map<string, BuildResult>): string {
+  const lines: string[] = [];
+
+  lines.push("");
+  lines.push("Build Report");
+  lines.push("============");
+
+  if (results.size === 0) {
+    lines.push("No packages processed.");
+    return lines.join("\n") + "\n";
+  }
+
+  // Calculate column widths.
+  const maxNameLen = Math.max(
+    ...Array.from(results.keys()).map((n) => n.length),
+    "Package".length,
+  );
+
+  // Header.
+  lines.push(
+    `${"Package".padEnd(maxNameLen)}   ${"Status".padEnd(12)} Duration`,
+  );
+
+  // Sort results by name for consistent output.
+  const sortedNames = Array.from(results.keys()).sort();
+
+  for (const name of sortedNames) {
+    const result = results.get(name)!;
+    const status = STATUS_DISPLAY[result.status] ?? result.status.toUpperCase();
+    let duration = formatDuration(result.duration);
+
+    if (result.status === "dep-skipped") {
+      duration = "- (dep failed)";
+    }
+
+    lines.push(`${name.padEnd(maxNameLen)}   ${status.padEnd(12)} ${duration}`);
+  }
+
+  // Summary line.
+  const total = results.size;
+  const built = Array.from(results.values()).filter(
+    (r) => r.status === "built",
+  ).length;
+  const skipped = Array.from(results.values()).filter(
+    (r) => r.status === "skipped",
+  ).length;
+  const failed = Array.from(results.values()).filter(
+    (r) => r.status === "failed",
+  ).length;
+  const depSkipped = Array.from(results.values()).filter(
+    (r) => r.status === "dep-skipped",
+  ).length;
+  const wouldBuild = Array.from(results.values()).filter(
+    (r) => r.status === "would-build",
+  ).length;
+
+  let summary = `\nTotal: ${total} packages`;
+  if (built) summary += ` | ${built} built`;
+  if (skipped) summary += ` | ${skipped} skipped`;
+  if (failed) summary += ` | ${failed} failed`;
+  if (depSkipped) summary += ` | ${depSkipped} dep-skipped`;
+  if (wouldBuild) summary += ` | ${wouldBuild} would-build`;
+
+  lines.push(summary);
+
+  return lines.join("\n") + "\n";
+}
+
+/**
+ * Print a summary table of build results to the console.
+ *
+ * @param results - Mapping from package name to BuildResult.
+ */
+export function printReport(results: Map<string, BuildResult>): void {
+  const report = formatReport(results);
+  process.stdout.write(report);
+}

--- a/code/programs/typescript/build-tool/src/resolver.ts
+++ b/code/programs/typescript/build-tool/src/resolver.ts
@@ -1,0 +1,813 @@
+/**
+ * resolver.ts -- Dependency Resolution from Package Metadata
+ * ==========================================================
+ *
+ * This module reads package metadata files (pyproject.toml for Python,
+ * .gemspec for Ruby, go.mod for Go, package.json for TypeScript,
+ * Cargo.toml for Rust, mix.exs for Elixir) and extracts internal
+ * dependencies. It builds a directed graph where edges represent
+ * "A depends on B".
+ *
+ * ## Dependency mapping conventions
+ *
+ * Each language ecosystem uses a different naming convention for packages
+ * in this monorepo:
+ *
+ * - **Python**: Package names in pyproject.toml use the `coding-adventures-`
+ *   prefix with hyphens. For example, `coding-adventures-logic-gates` maps
+ *   to the package `python/logic-gates`.
+ *
+ * - **Ruby**: Gem names in .gemspec use the `coding_adventures_` prefix with
+ *   underscores. For example, `coding_adventures_logic_gates` maps to
+ *   `ruby/logic_gates`.
+ *
+ * - **Go**: Module paths in go.mod include the repo path. We map module
+ *   paths to `go/X` based on the last path component.
+ *
+ * - **TypeScript**: Package names in package.json use the `@coding-adventures/`
+ *   scoped npm prefix. For example, `@coding-adventures/logic-gates` maps
+ *   to `typescript/logic-gates`.
+ *
+ * - **Rust**: Crate names in Cargo.toml use the directory name (kebab-case).
+ *   For example, `logic-gates` maps to `rust/logic-gates`.
+ *
+ * - **Elixir**: App names in mix.exs use the `coding_adventures_` prefix
+ *   with underscores. For example, `coding_adventures_logic_gates` maps to
+ *   `elixir/logic-gates`.
+ *
+ * External dependencies (those not matching the monorepo prefix) are
+ * silently skipped.
+ *
+ * ## The Directed Graph
+ *
+ * We include a minimal DirectedGraph implementation inline to avoid external
+ * dependencies. The graph supports:
+ * - Adding nodes and edges
+ * - Topological sorting via Kahn's algorithm
+ * - Transitive closure (all dependencies of a node)
+ * - Transitive dependents (all nodes that depend on a given node)
+ * - Independent groups (nodes that can be built in parallel)
+ * - Affected nodes (given a set of changed nodes, find all that need rebuilding)
+ */
+
+import * as fs from "node:fs";
+import * as nodePath from "node:path";
+import type { Package } from "./discovery.js";
+
+// ===========================================================================
+// DirectedGraph -- Inline Minimal Implementation
+// ===========================================================================
+
+/**
+ * A minimal directed graph for dependency resolution.
+ *
+ * ## How a directed graph works
+ *
+ * A directed graph consists of **nodes** (vertices) and **edges** (arrows).
+ * Each edge has a direction: from one node to another. In our build system:
+ *
+ * - Each **node** represents a package (e.g., "python/logic-gates").
+ * - Each **edge** goes FROM a dependency TO a dependent:
+ *   if "arithmetic" depends on "logic-gates", the edge is:
+ *   logic-gates -> arithmetic
+ *
+ * This convention means nodes with zero in-degree (no incoming edges) have
+ * no dependencies and can be built first.
+ *
+ * ## Data structure
+ *
+ * We store the graph as two adjacency lists:
+ * - `_forward`: maps each node to its successors (nodes it points to)
+ * - `_reverse`: maps each node to its predecessors (nodes that point to it)
+ *
+ * Maintaining both directions lets us efficiently traverse in either
+ * direction without rebuilding the graph.
+ */
+export class DirectedGraph {
+  /** Forward adjacency list: node -> set of successors (nodes it depends on) */
+  private _forward: Map<string, Set<string>> = new Map();
+
+  /** Reverse adjacency list: node -> set of predecessors (nodes that depend on it) */
+  private _reverse: Map<string, Set<string>> = new Map();
+
+  /**
+   * Add a node to the graph.
+   *
+   * If the node already exists, this is a no-op. Every node must be
+   * explicitly added before edges can reference it (though addEdge
+   * will auto-add nodes too).
+   */
+  addNode(node: string): void {
+    if (!this._forward.has(node)) {
+      this._forward.set(node, new Set());
+      this._reverse.set(node, new Set());
+    }
+  }
+
+  /**
+   * Add a directed edge from `fromNode` to `toNode`.
+   *
+   * Both nodes are auto-created if they don't exist yet. The edge
+   * means: "fromNode must be built before toNode" (because toNode
+   * depends on fromNode).
+   */
+  addEdge(fromNode: string, toNode: string): void {
+    this.addNode(fromNode);
+    this.addNode(toNode);
+    this._forward.get(fromNode)!.add(toNode);
+    this._reverse.get(toNode)!.add(fromNode);
+  }
+
+  /** Check if a node exists in the graph. */
+  hasNode(node: string): boolean {
+    return this._forward.has(node);
+  }
+
+  /** Get all nodes in the graph. */
+  nodes(): string[] {
+    return Array.from(this._forward.keys());
+  }
+
+  /** Get the direct successors of a node (nodes it points to). */
+  successors(node: string): string[] {
+    return Array.from(this._forward.get(node) ?? []);
+  }
+
+  /** Get the direct predecessors of a node (nodes that point to it). */
+  predecessors(node: string): string[] {
+    return Array.from(this._reverse.get(node) ?? []);
+  }
+
+  /**
+   * Compute all nodes reachable from `node` (not including `node` itself).
+   *
+   * This is the "transitive closure" -- all nodes you can reach by
+   * following edges forward from the given node. In our build system,
+   * this gives you all transitive dependents of a package.
+   *
+   * Algorithm: simple depth-first search (DFS) using an explicit stack.
+   * We start with the direct successors and keep following edges until
+   * we've visited everything reachable.
+   */
+  transitiveClosure(node: string): Set<string> {
+    if (!this._forward.has(node)) {
+      return new Set();
+    }
+
+    const visited = new Set<string>();
+    const stack = Array.from(this._forward.get(node)!);
+    for (const s of stack) visited.add(s);
+
+    while (stack.length > 0) {
+      const current = stack.pop()!;
+      for (const successor of this._forward.get(current) ?? []) {
+        if (!visited.has(successor)) {
+          visited.add(successor);
+          stack.push(successor);
+        }
+      }
+    }
+
+    return visited;
+  }
+
+  /**
+   * Compute all nodes that transitively depend on `node`.
+   *
+   * This walks the REVERSE edges -- finding all nodes that (directly or
+   * indirectly) have `node` as a dependency. Used by the hasher to
+   * determine if a package needs rebuilding when its dependency changes.
+   *
+   * Algorithm: same DFS as transitiveClosure but on reverse edges.
+   */
+  transitiveDependents(node: string): Set<string> {
+    if (!this._reverse.has(node)) {
+      return new Set();
+    }
+
+    const visited = new Set<string>();
+    const stack = Array.from(this._reverse.get(node)!);
+    for (const s of stack) visited.add(s);
+
+    while (stack.length > 0) {
+      const current = stack.pop()!;
+      for (const predecessor of this._reverse.get(current) ?? []) {
+        if (!visited.has(predecessor)) {
+          visited.add(predecessor);
+          stack.push(predecessor);
+        }
+      }
+    }
+
+    return visited;
+  }
+
+  /**
+   * Partition nodes into parallel execution levels using Kahn's algorithm.
+   *
+   * ## What is Kahn's algorithm?
+   *
+   * Kahn's algorithm is a method for topological sorting -- arranging nodes
+   * in an order where every dependency comes before its dependent. But we
+   * go further: we group nodes into LEVELS where all nodes in a level can
+   * be processed simultaneously (they have no dependencies on each other).
+   *
+   * ## How it works
+   *
+   * 1. Compute the "in-degree" of each node (number of incoming edges).
+   *    Nodes with in-degree 0 have no dependencies.
+   *
+   * 2. All in-degree-0 nodes form Level 0 -- they can be built first,
+   *    in parallel.
+   *
+   * 3. "Remove" Level 0 from the graph (decrement in-degrees of their
+   *    successors). Any nodes that now have in-degree 0 form Level 1.
+   *
+   * 4. Repeat until all nodes are assigned to a level.
+   *
+   * 5. If we processed fewer nodes than exist in the graph, there's a
+   *    cycle (circular dependency), which is an error.
+   *
+   * ## Example
+   *
+   * Given: A -> B -> D, A -> C -> D
+   * - Level 0: [A]       (no dependencies)
+   * - Level 1: [B, C]    (only depend on A, which is done)
+   * - Level 2: [D]       (depends on B and C, both done)
+   *
+   * @returns Array of levels, where each level is an array of node names.
+   * @throws Error if the graph contains a cycle.
+   */
+  independentGroups(): string[][] {
+    // Step 1: Compute in-degree for every node.
+    const inDegree = new Map<string, number>();
+    for (const [node, preds] of this._reverse) {
+      inDegree.set(node, preds.size);
+    }
+
+    // Step 2: Find all nodes with in-degree 0 (no dependencies).
+    let currentLevel = Array.from(inDegree.entries())
+      .filter(([_, degree]) => degree === 0)
+      .map(([node]) => node)
+      .sort();
+
+    const groups: string[][] = [];
+    let processed = 0;
+
+    // Step 3: Process levels until no more nodes remain.
+    while (currentLevel.length > 0) {
+      groups.push(currentLevel);
+      processed += currentLevel.length;
+
+      // Step 4: "Remove" current level and find the next one.
+      const nextLevelSet = new Set<string>();
+      for (const node of currentLevel) {
+        for (const successor of this._forward.get(node)!) {
+          const newDegree = inDegree.get(successor)! - 1;
+          inDegree.set(successor, newDegree);
+          if (newDegree === 0) {
+            nextLevelSet.add(successor);
+          }
+        }
+      }
+
+      currentLevel = Array.from(nextLevelSet).sort();
+    }
+
+    // Step 5: Cycle detection.
+    if (processed !== this._forward.size) {
+      throw new Error("Dependency graph contains a cycle");
+    }
+
+    return groups;
+  }
+
+  /**
+   * Given a set of changed nodes, find all nodes that need rebuilding.
+   *
+   * This is the primary method for git-diff based change detection. If
+   * you change "logic-gates", the affected set includes "logic-gates"
+   * itself plus all its transitive dependents (arithmetic, cpu-simulator,
+   * etc.).
+   *
+   * @param changed - Set of node names that have changed.
+   * @returns Set of all affected node names (changed + their dependents).
+   */
+  affectedNodes(changed: Set<string>): Set<string> {
+    const affected = new Set<string>();
+
+    for (const node of changed) {
+      if (!this.hasNode(node)) {
+        continue;
+      }
+      affected.add(node);
+      for (const dep of this.transitiveClosure(node)) {
+        affected.add(dep);
+      }
+    }
+
+    return affected;
+  }
+}
+
+// ===========================================================================
+// Dependency Parsing -- Python
+// ===========================================================================
+
+/**
+ * Extract internal dependencies from a Python package's pyproject.toml.
+ *
+ * Reads the `[project] dependencies` list and maps entries with the
+ * `coding-adventures-` prefix to their package names. Version specifiers
+ * (>=, <, etc.) are stripped.
+ *
+ * We use simple line-by-line parsing rather than a TOML library to avoid
+ * external dependencies. The strategy:
+ * 1. Find the "dependencies = [" line
+ * 2. Collect lines until we hit "]"
+ * 3. Extract quoted strings and strip version specifiers
+ */
+function parsePythonDeps(
+  pkg: Package,
+  knownNames: Map<string, string>,
+): string[] {
+  const pyprojectPath = nodePath.join(pkg.path, "pyproject.toml");
+  if (!fs.existsSync(pyprojectPath)) {
+    return [];
+  }
+
+  const text = fs.readFileSync(pyprojectPath, "utf-8");
+  const internalDeps: string[] = [];
+
+  let inDeps = false;
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+
+    if (!inDeps) {
+      // Look for the start of the dependencies array.
+      if (trimmed.startsWith("dependencies") && trimmed.includes("=")) {
+        const afterEq = trimmed.split("=").slice(1).join("=").trim();
+
+        if (afterEq.startsWith("[")) {
+          if (afterEq.includes("]")) {
+            // Single-line array: dependencies = ["foo", "bar"]
+            extractDeps(afterEq, knownNames, internalDeps);
+            break;
+          }
+          // Multi-line array starts here.
+          inDeps = true;
+          extractDeps(afterEq, knownNames, internalDeps);
+        }
+      }
+      continue;
+    }
+
+    // We're inside a multi-line dependencies array.
+    if (trimmed.includes("]")) {
+      extractDeps(trimmed, knownNames, internalDeps);
+      break;
+    }
+    extractDeps(trimmed, knownNames, internalDeps);
+  }
+
+  return internalDeps;
+}
+
+/**
+ * Extract quoted dependency names from a line and map them to internal
+ * package names. Version specifiers (>=, <, etc.) are stripped.
+ *
+ * This helper is used by parsePythonDeps to process individual lines
+ * of the dependencies array.
+ */
+function extractDeps(
+  line: string,
+  knownNames: Map<string, string>,
+  deps: string[],
+): void {
+  // Match quoted strings: "something" or 'something'
+  const re = /["']([^"']+)["']/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = re.exec(line)) !== null) {
+    // Strip version specifiers: split on >=, <=, >, <, ==, !=, ~=, ;, spaces
+    const depName = match[1].split(/[>=<!~\s;]/)[0].trim().toLowerCase();
+    const pkgName = knownNames.get(depName);
+    if (pkgName) {
+      deps.push(pkgName);
+    }
+  }
+}
+
+// ===========================================================================
+// Dependency Parsing -- Ruby
+// ===========================================================================
+
+/**
+ * Extract internal dependencies from a Ruby package's .gemspec file.
+ *
+ * Looks for lines matching `spec.add_dependency "coding_adventures_X"`
+ * and maps them to package names. Ruby uses underscores in gem names.
+ */
+function parseRubyDeps(
+  pkg: Package,
+  knownNames: Map<string, string>,
+): string[] {
+  // Find .gemspec files in the package directory.
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(pkg.path);
+  } catch {
+    return [];
+  }
+
+  const gemspecFile = entries.find((e) => e.endsWith(".gemspec"));
+  if (!gemspecFile) {
+    return [];
+  }
+
+  const text = fs.readFileSync(nodePath.join(pkg.path, gemspecFile), "utf-8");
+  const internalDeps: string[] = [];
+
+  // Match: spec.add_dependency "coding_adventures_something"
+  const pattern = /spec\.add_dependency\s+"([^"]+)"/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(text)) !== null) {
+    const gemName = match[1].trim().toLowerCase();
+    const pkgName = knownNames.get(gemName);
+    if (pkgName) {
+      internalDeps.push(pkgName);
+    }
+  }
+
+  return internalDeps;
+}
+
+// ===========================================================================
+// Dependency Parsing -- Go
+// ===========================================================================
+
+/**
+ * Extract internal dependencies from a Go package's go.mod file.
+ *
+ * Looks for `require` lines and maps module paths to package names.
+ * Handles both single-line `require` directives and `require (...)` blocks.
+ */
+function parseGoDeps(
+  pkg: Package,
+  knownNames: Map<string, string>,
+): string[] {
+  const goModPath = nodePath.join(pkg.path, "go.mod");
+  if (!fs.existsSync(goModPath)) {
+    return [];
+  }
+
+  const text = fs.readFileSync(goModPath, "utf-8");
+  const internalDeps: string[] = [];
+
+  let inRequireBlock = false;
+  for (const line of text.split("\n")) {
+    const stripped = line.trim();
+
+    if (stripped === "require (") {
+      inRequireBlock = true;
+      continue;
+    }
+    if (stripped === ")") {
+      inRequireBlock = false;
+      continue;
+    }
+
+    if (inRequireBlock || stripped.startsWith("require ")) {
+      // Extract module path (first space-separated token).
+      const parts = stripped.replace("require ", "").trim().split(/\s+/);
+      if (parts.length > 0) {
+        const modulePath = parts[0].toLowerCase();
+        const pkgName = knownNames.get(modulePath);
+        if (pkgName) {
+          internalDeps.push(pkgName);
+        }
+      }
+    }
+  }
+
+  return internalDeps;
+}
+
+// ===========================================================================
+// Dependency Parsing -- TypeScript
+// ===========================================================================
+
+/**
+ * Extract internal dependencies from a TypeScript package.json file.
+ *
+ * TypeScript packages declare dependencies in package.json:
+ *
+ *     "dependencies": {
+ *         "@coding-adventures/logic-gates": "file:../logic-gates"
+ *     }
+ *
+ * We scan for lines inside a "dependencies" block and extract
+ * `@coding-adventures/` references. Version specifiers and `file:`
+ * references are ignored -- we only care about the package name.
+ */
+function parseTypescriptDeps(
+  pkg: Package,
+  knownNames: Map<string, string>,
+): string[] {
+  const packageJsonPath = nodePath.join(pkg.path, "package.json");
+  if (!fs.existsSync(packageJsonPath)) {
+    return [];
+  }
+
+  const text = fs.readFileSync(packageJsonPath, "utf-8");
+  const internalDeps: string[] = [];
+
+  // Strategy: scan line by line, looking for "dependencies" blocks,
+  // then extract @coding-adventures/ references from those blocks.
+  let inDeps = false;
+  const re = /"(@coding-adventures\/[^"]+)"/g;
+
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+
+    if (!inDeps) {
+      // Look for "dependencies": { or "dependencies":{
+      if (trimmed.includes('"dependencies"') && trimmed.includes("{")) {
+        inDeps = true;
+      }
+      continue;
+    }
+
+    // Inside dependencies block.
+    if (trimmed.includes("}")) {
+      inDeps = false;
+      continue;
+    }
+
+    let match: RegExpExecArray | null;
+    re.lastIndex = 0;
+    while ((match = re.exec(trimmed)) !== null) {
+      const depName = match[1].toLowerCase();
+      const pkgName = knownNames.get(depName);
+      if (pkgName) {
+        internalDeps.push(pkgName);
+      }
+    }
+  }
+
+  return internalDeps;
+}
+
+// ===========================================================================
+// Dependency Parsing -- Rust
+// ===========================================================================
+
+/**
+ * Extract internal dependencies from a Rust Cargo.toml file.
+ *
+ * Rust Cargo.toml declares workspace-local dependencies with path references:
+ *
+ *     [dependencies]
+ *     logic-gates = { path = "../logic-gates" }
+ *
+ * We look for lines in the [dependencies] section that contain `path =`
+ * and extract the crate name (the key before the `=`). We then look up
+ * that name in the known names mapping.
+ */
+function parseRustDeps(
+  pkg: Package,
+  knownNames: Map<string, string>,
+): string[] {
+  const cargoTomlPath = nodePath.join(pkg.path, "Cargo.toml");
+  if (!fs.existsSync(cargoTomlPath)) {
+    return [];
+  }
+
+  const text = fs.readFileSync(cargoTomlPath, "utf-8");
+  const internalDeps: string[] = [];
+
+  // Scan for [dependencies] section and extract path-based deps.
+  let inDeps = false;
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+
+    // Detect section headers like [dependencies] or [dev-dependencies]
+    if (trimmed.startsWith("[")) {
+      inDeps = trimmed === "[dependencies]";
+      continue;
+    }
+
+    if (!inDeps) {
+      continue;
+    }
+
+    // Look for lines like: logic-gates = { path = "../logic-gates" }
+    if (trimmed.includes("path") && trimmed.includes("=")) {
+      const parts = trimmed.split("=");
+      if (parts.length >= 2) {
+        const crateName = parts[0].trim().toLowerCase();
+        const pkgName = knownNames.get(crateName);
+        if (pkgName) {
+          internalDeps.push(pkgName);
+        }
+      }
+    }
+  }
+
+  return internalDeps;
+}
+
+// ===========================================================================
+// Dependency Parsing -- Elixir
+// ===========================================================================
+
+/**
+ * Extract internal dependencies from an Elixir mix.exs file.
+ *
+ * Elixir mix.exs declares internal path dependencies like:
+ *
+ *     {:coding_adventures_logic_gates, path: "../logic-gates"}
+ *
+ * We use a regex to capture the atom name starting with `coding_adventures_`.
+ */
+function parseElixirDeps(
+  pkg: Package,
+  knownNames: Map<string, string>,
+): string[] {
+  const mixExsPath = nodePath.join(pkg.path, "mix.exs");
+  if (!fs.existsSync(mixExsPath)) {
+    return [];
+  }
+
+  const text = fs.readFileSync(mixExsPath, "utf-8");
+  const internalDeps: string[] = [];
+
+  const pattern = /\{:(coding_adventures_[a-z0-9_]+)/g;
+  for (const line of text.split("\n")) {
+    let match: RegExpExecArray | null;
+    pattern.lastIndex = 0;
+    while ((match = pattern.exec(line)) !== null) {
+      const appName = match[1].toLowerCase();
+      const pkgName = knownNames.get(appName);
+      if (pkgName) {
+        internalDeps.push(pkgName);
+      }
+    }
+  }
+
+  return internalDeps;
+}
+
+// ===========================================================================
+// Known Names Mapping
+// ===========================================================================
+
+/**
+ * Build a mapping from ecosystem-specific dependency names to package names.
+ *
+ * This is the Rosetta Stone that connects different naming conventions:
+ *
+ * - Python:     "coding-adventures-logic-gates" -> "python/logic-gates"
+ * - Ruby:       "coding_adventures_logic_gates" -> "ruby/logic_gates"
+ * - Go:         full module path                -> "go/module-name"
+ * - TypeScript: "@coding-adventures/logic-gates" -> "typescript/logic-gates"
+ * - Rust:       "logic-gates"                   -> "rust/logic-gates"
+ * - Elixir:     "coding_adventures_logic_gates" -> "elixir/logic-gates"
+ *
+ * @param packages - All discovered packages.
+ * @returns A Map from dependency names to internal package names.
+ */
+export function buildKnownNames(packages: Package[]): Map<string, string> {
+  const known = new Map<string, string>();
+
+  for (const pkg of packages) {
+    const dirName = nodePath.basename(pkg.path);
+
+    switch (pkg.language) {
+      case "python": {
+        // Convert dir name to PyPI name: "logic-gates" -> "coding-adventures-logic-gates"
+        const pypiName = `coding-adventures-${dirName}`.toLowerCase();
+        known.set(pypiName, pkg.name);
+        break;
+      }
+
+      case "ruby": {
+        // Convert dir name to gem name: "logic_gates" -> "coding_adventures_logic_gates"
+        const gemName = `coding_adventures_${dirName}`.toLowerCase();
+        known.set(gemName, pkg.name);
+        break;
+      }
+
+      case "go": {
+        // For Go, read the module path from go.mod.
+        const goModPath = nodePath.join(pkg.path, "go.mod");
+        if (fs.existsSync(goModPath)) {
+          const text = fs.readFileSync(goModPath, "utf-8");
+          for (const line of text.split("\n")) {
+            if (line.startsWith("module ")) {
+              const modulePath = line
+                .replace("module ", "")
+                .trim()
+                .toLowerCase();
+              known.set(modulePath, pkg.name);
+              break;
+            }
+          }
+        }
+        break;
+      }
+
+      case "typescript": {
+        // Convert dir name to npm scoped name: "logic-gates" -> "@coding-adventures/logic-gates"
+        const npmName = `@coding-adventures/${dirName}`.toLowerCase();
+        known.set(npmName, pkg.name);
+        break;
+      }
+
+      case "rust": {
+        // Rust crate names use the directory name directly (kebab-case).
+        const crateName = dirName.toLowerCase();
+        known.set(crateName, pkg.name);
+        break;
+      }
+
+      case "elixir": {
+        // Elixir mix names replace hyphens with underscores:
+        // "logic-gates" -> "coding_adventures_logic_gates"
+        const appName =
+          `coding_adventures_${dirName.replace(/-/g, "_")}`.toLowerCase();
+        known.set(appName, pkg.name);
+        break;
+      }
+    }
+  }
+
+  return known;
+}
+
+// ===========================================================================
+// Public API
+// ===========================================================================
+
+/**
+ * Parse package metadata to discover dependencies and build a graph.
+ *
+ * The graph contains all discovered packages as nodes. Edges represent
+ * "A depends on B" (A -> B means A needs B built first). External
+ * dependencies (not found among the discovered packages) are silently
+ * skipped.
+ *
+ * @param packages - List of discovered packages.
+ * @returns A DirectedGraph with dependency edges.
+ */
+export function resolveDependencies(packages: Package[]): DirectedGraph {
+  const graph = new DirectedGraph();
+
+  // First, add all packages as nodes. Even packages with no dependencies
+  // need to be in the graph so they appear in independentGroups().
+  for (const pkg of packages) {
+    graph.addNode(pkg.name);
+  }
+
+  // Build the name-mapping table.
+  const knownNames = buildKnownNames(packages);
+
+  // Parse dependencies for each package.
+  for (const pkg of packages) {
+    let deps: string[];
+
+    switch (pkg.language) {
+      case "python":
+        deps = parsePythonDeps(pkg, knownNames);
+        break;
+      case "ruby":
+        deps = parseRubyDeps(pkg, knownNames);
+        break;
+      case "go":
+        deps = parseGoDeps(pkg, knownNames);
+        break;
+      case "typescript":
+        deps = parseTypescriptDeps(pkg, knownNames);
+        break;
+      case "rust":
+        deps = parseRustDeps(pkg, knownNames);
+        break;
+      case "elixir":
+        deps = parseElixirDeps(pkg, knownNames);
+        break;
+      default:
+        deps = [];
+    }
+
+    for (const depName of deps) {
+      // Edge direction: dep -> pkg means "dep must be built before pkg".
+      // This makes independentGroups() produce the correct build order:
+      // nodes with zero in-degree (no dependencies) come first.
+      graph.addEdge(depName, pkg.name);
+    }
+  }
+
+  return graph;
+}

--- a/code/programs/typescript/build-tool/tests/cache.test.ts
+++ b/code/programs/typescript/build-tool/tests/cache.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Tests for cache.ts -- Build Cache Management
+ *
+ * These tests verify that the cache:
+ * - Loads and saves JSON cache files
+ * - Correctly determines when packages need rebuilding
+ * - Records build results
+ * - Handles missing/malformed cache files gracefully
+ * - Uses atomic writes (write to temp, rename)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { BuildCache } from "../src/cache.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "build-tool-cache-"));
+}
+
+function rmDir(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+// ---------------------------------------------------------------------------
+// Tests: needsBuild
+// ---------------------------------------------------------------------------
+
+describe("BuildCache.needsBuild", () => {
+  it("should return true for unknown package", () => {
+    const cache = new BuildCache();
+    expect(cache.needsBuild("python/unknown", "hash1", "dhash1")).toBe(true);
+  });
+
+  it("should return false for cached package with matching hashes", () => {
+    const cache = new BuildCache();
+    cache.record("python/pkg", "hash1", "dhash1", "success");
+    expect(cache.needsBuild("python/pkg", "hash1", "dhash1")).toBe(false);
+  });
+
+  it("should return true when package hash changes", () => {
+    const cache = new BuildCache();
+    cache.record("python/pkg", "hash1", "dhash1", "success");
+    expect(cache.needsBuild("python/pkg", "hash2", "dhash1")).toBe(true);
+  });
+
+  it("should return true when deps hash changes", () => {
+    const cache = new BuildCache();
+    cache.record("python/pkg", "hash1", "dhash1", "success");
+    expect(cache.needsBuild("python/pkg", "hash1", "dhash2")).toBe(true);
+  });
+
+  it("should return true when last build failed", () => {
+    const cache = new BuildCache();
+    cache.record("python/pkg", "hash1", "dhash1", "failed");
+    // Even with matching hashes, a failed build should be retried.
+    expect(cache.needsBuild("python/pkg", "hash1", "dhash1")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: record
+// ---------------------------------------------------------------------------
+
+describe("BuildCache.record", () => {
+  it("should store entry that can be retrieved", () => {
+    const cache = new BuildCache();
+    cache.record("python/pkg", "hash1", "dhash1", "success");
+
+    const entries = cache.entries;
+    expect(entries.has("python/pkg")).toBe(true);
+    expect(entries.get("python/pkg")?.packageHash).toBe("hash1");
+    expect(entries.get("python/pkg")?.depsHash).toBe("dhash1");
+    expect(entries.get("python/pkg")?.status).toBe("success");
+  });
+
+  it("should overwrite existing entry", () => {
+    const cache = new BuildCache();
+    cache.record("python/pkg", "hash1", "dhash1", "failed");
+    cache.record("python/pkg", "hash2", "dhash2", "success");
+
+    const entry = cache.entries.get("python/pkg");
+    expect(entry?.packageHash).toBe("hash2");
+    expect(entry?.status).toBe("success");
+  });
+
+  it("should set lastBuilt timestamp", () => {
+    const cache = new BuildCache();
+    cache.record("python/pkg", "hash1", "dhash1", "success");
+
+    const entry = cache.entries.get("python/pkg");
+    expect(entry?.lastBuilt).toBeTruthy();
+    // Should be a valid ISO date string.
+    expect(new Date(entry!.lastBuilt).getTime()).not.toBeNaN();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: load and save
+// ---------------------------------------------------------------------------
+
+describe("BuildCache.load", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    rmDir(tmpDir);
+  });
+
+  it("should load a valid cache file", () => {
+    const cachePath = path.join(tmpDir, ".build-cache.json");
+    const data = {
+      "python/logic-gates": {
+        package_hash: "abc123",
+        deps_hash: "def456",
+        last_built: "2024-01-15T10:30:00.000Z",
+        status: "success",
+      },
+    };
+    fs.writeFileSync(cachePath, JSON.stringify(data), "utf-8");
+
+    const cache = new BuildCache();
+    cache.load(cachePath);
+
+    expect(cache.needsBuild("python/logic-gates", "abc123", "def456")).toBe(
+      false,
+    );
+  });
+
+  it("should handle non-existent file gracefully", () => {
+    const cache = new BuildCache();
+    cache.load(path.join(tmpDir, "nonexistent.json"));
+    expect(cache.entries.size).toBe(0);
+  });
+
+  it("should handle malformed JSON gracefully", () => {
+    const cachePath = path.join(tmpDir, "bad.json");
+    fs.writeFileSync(cachePath, "not valid json{{{", "utf-8");
+
+    const cache = new BuildCache();
+    cache.load(cachePath);
+    expect(cache.entries.size).toBe(0);
+  });
+
+  it("should skip malformed entries", () => {
+    const cachePath = path.join(tmpDir, "partial.json");
+    const data = {
+      "python/good": {
+        package_hash: "abc",
+        deps_hash: "def",
+        last_built: "2024-01-15T10:30:00.000Z",
+        status: "success",
+      },
+      "python/bad": {
+        package_hash: "abc",
+        // Missing deps_hash, last_built, status
+      },
+    };
+    fs.writeFileSync(cachePath, JSON.stringify(data), "utf-8");
+
+    const cache = new BuildCache();
+    cache.load(cachePath);
+    expect(cache.entries.size).toBe(1);
+    expect(cache.entries.has("python/good")).toBe(true);
+  });
+});
+
+describe("BuildCache.save", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    rmDir(tmpDir);
+  });
+
+  it("should save and reload cache", () => {
+    const cachePath = path.join(tmpDir, ".build-cache.json");
+
+    const cache1 = new BuildCache();
+    cache1.record("python/pkg-a", "hash1", "dhash1", "success");
+    cache1.record("python/pkg-b", "hash2", "dhash2", "failed");
+    cache1.save(cachePath);
+
+    const cache2 = new BuildCache();
+    cache2.load(cachePath);
+
+    expect(cache2.needsBuild("python/pkg-a", "hash1", "dhash1")).toBe(false);
+    expect(cache2.needsBuild("python/pkg-b", "hash2", "dhash2")).toBe(true); // failed
+  });
+
+  it("should write valid JSON", () => {
+    const cachePath = path.join(tmpDir, ".build-cache.json");
+
+    const cache = new BuildCache();
+    cache.record("python/pkg", "hash1", "dhash1", "success");
+    cache.save(cachePath);
+
+    const text = fs.readFileSync(cachePath, "utf-8");
+    const data = JSON.parse(text);
+    expect(data["python/pkg"]).toBeDefined();
+    expect(data["python/pkg"].package_hash).toBe("hash1");
+  });
+
+  it("should sort entries by name in saved file", () => {
+    const cachePath = path.join(tmpDir, ".build-cache.json");
+
+    const cache = new BuildCache();
+    cache.record("python/z-pkg", "h1", "d1", "success");
+    cache.record("python/a-pkg", "h2", "d2", "success");
+    cache.save(cachePath);
+
+    const text = fs.readFileSync(cachePath, "utf-8");
+    const keys = Object.keys(JSON.parse(text));
+    expect(keys[0]).toBe("python/a-pkg");
+    expect(keys[1]).toBe("python/z-pkg");
+  });
+
+  it("should not leave temp file after save", () => {
+    const cachePath = path.join(tmpDir, ".build-cache.json");
+
+    const cache = new BuildCache();
+    cache.record("python/pkg", "h1", "d1", "success");
+    cache.save(cachePath);
+
+    const tmpFile = path.join(tmpDir, ".build-cache.json.tmp");
+    expect(fs.existsSync(tmpFile)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: entries property
+// ---------------------------------------------------------------------------
+
+describe("BuildCache.entries", () => {
+  it("should return a copy (not the internal map)", () => {
+    const cache = new BuildCache();
+    cache.record("python/pkg", "h1", "d1", "success");
+
+    const entries = cache.entries;
+    entries.delete("python/pkg");
+
+    // Internal state should be unchanged.
+    expect(cache.entries.has("python/pkg")).toBe(true);
+  });
+});

--- a/code/programs/typescript/build-tool/tests/discovery.test.ts
+++ b/code/programs/typescript/build-tool/tests/discovery.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Tests for discovery.ts -- Package Discovery
+ *
+ * These tests verify that the package discovery system correctly:
+ * - Walks directory trees recursively
+ * - Finds BUILD files and registers packages
+ * - Skips known non-source directories
+ * - Infers languages from directory paths
+ * - Builds qualified package names
+ * - Handles platform-specific BUILD files (BUILD_mac, BUILD_linux,
+ *   BUILD_windows, BUILD_mac_and_linux)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import {
+  discoverPackages,
+  readLines,
+  inferLanguage,
+  inferPackageName,
+  getBuildFile,
+  SKIP_DIRS,
+} from "../src/discovery.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** Create a temporary directory for test fixtures. */
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "build-tool-test-"));
+}
+
+/** Recursively remove a directory. */
+function rmDir(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+/** Create a file with content, creating parent directories as needed. */
+function writeFile(filepath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filepath), { recursive: true });
+  fs.writeFileSync(filepath, content, "utf-8");
+}
+
+// ---------------------------------------------------------------------------
+// Tests: readLines
+// ---------------------------------------------------------------------------
+
+describe("readLines", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    rmDir(tmpDir);
+  });
+
+  it("should return non-blank, non-comment lines", () => {
+    const filepath = path.join(tmpDir, "BUILD");
+    writeFile(
+      filepath,
+      "# This is a comment\nnpm install\n\n# Another comment\nnpx vitest run\n",
+    );
+    const lines = readLines(filepath);
+    expect(lines).toEqual(["npm install", "npx vitest run"]);
+  });
+
+  it("should return empty array for non-existent file", () => {
+    const lines = readLines(path.join(tmpDir, "NONEXISTENT"));
+    expect(lines).toEqual([]);
+  });
+
+  it("should strip leading and trailing whitespace", () => {
+    const filepath = path.join(tmpDir, "BUILD");
+    writeFile(filepath, "  npm install  \n  npx vitest run  \n");
+    const lines = readLines(filepath);
+    expect(lines).toEqual(["npm install", "npx vitest run"]);
+  });
+
+  it("should return empty array for file with only comments and blanks", () => {
+    const filepath = path.join(tmpDir, "BUILD");
+    writeFile(filepath, "# comment\n\n# another\n\n");
+    const lines = readLines(filepath);
+    expect(lines).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: inferLanguage
+// ---------------------------------------------------------------------------
+
+describe("inferLanguage", () => {
+  it("should detect Python from path", () => {
+    expect(inferLanguage("/repo/code/packages/python/logic-gates")).toBe(
+      "python",
+    );
+  });
+
+  it("should detect Ruby from path", () => {
+    expect(inferLanguage("/repo/code/packages/ruby/logic_gates")).toBe("ruby");
+  });
+
+  it("should detect Go from path", () => {
+    expect(inferLanguage("/repo/code/programs/go/build-tool")).toBe("go");
+  });
+
+  it("should detect Rust from path", () => {
+    expect(inferLanguage("/repo/code/packages/rust/arithmetic")).toBe("rust");
+  });
+
+  it("should detect TypeScript from path", () => {
+    expect(inferLanguage("/repo/code/programs/typescript/build-tool")).toBe(
+      "typescript",
+    );
+  });
+
+  it("should detect Elixir from path", () => {
+    expect(inferLanguage("/repo/code/programs/elixir/build-tool")).toBe(
+      "elixir",
+    );
+  });
+
+  it("should return unknown for unrecognized paths", () => {
+    expect(inferLanguage("/repo/code/packages/haskell/something")).toBe(
+      "unknown",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: inferPackageName
+// ---------------------------------------------------------------------------
+
+describe("inferPackageName", () => {
+  it("should build qualified name from language and directory", () => {
+    expect(
+      inferPackageName("/repo/code/packages/python/logic-gates", "python"),
+    ).toBe("python/logic-gates");
+  });
+
+  it("should handle nested paths", () => {
+    expect(
+      inferPackageName("/a/b/c/programs/go/build-tool", "go"),
+    ).toBe("go/build-tool");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: getBuildFile
+// ---------------------------------------------------------------------------
+
+describe("getBuildFile", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    rmDir(tmpDir);
+  });
+
+  it("should return generic BUILD file", () => {
+    writeFile(path.join(tmpDir, "BUILD"), "echo hello\n");
+    const result = getBuildFile(tmpDir, "darwin");
+    expect(result).toBe(path.join(tmpDir, "BUILD"));
+  });
+
+  it("should return null when no BUILD file exists", () => {
+    const result = getBuildFile(tmpDir, "darwin");
+    expect(result).toBeNull();
+  });
+
+  it("should prefer BUILD_mac on darwin", () => {
+    writeFile(path.join(tmpDir, "BUILD"), "generic\n");
+    writeFile(path.join(tmpDir, "BUILD_mac"), "mac specific\n");
+    const result = getBuildFile(tmpDir, "darwin");
+    expect(result).toBe(path.join(tmpDir, "BUILD_mac"));
+  });
+
+  it("should prefer BUILD_linux on linux", () => {
+    writeFile(path.join(tmpDir, "BUILD"), "generic\n");
+    writeFile(path.join(tmpDir, "BUILD_linux"), "linux specific\n");
+    const result = getBuildFile(tmpDir, "linux");
+    expect(result).toBe(path.join(tmpDir, "BUILD_linux"));
+  });
+
+  it("should prefer BUILD_windows on win32", () => {
+    writeFile(path.join(tmpDir, "BUILD"), "generic\n");
+    writeFile(path.join(tmpDir, "BUILD_windows"), "windows specific\n");
+    const result = getBuildFile(tmpDir, "win32");
+    expect(result).toBe(path.join(tmpDir, "BUILD_windows"));
+  });
+
+  it("should use BUILD_mac_and_linux on darwin when no BUILD_mac exists", () => {
+    writeFile(path.join(tmpDir, "BUILD"), "generic\n");
+    writeFile(path.join(tmpDir, "BUILD_mac_and_linux"), "unix shared\n");
+    const result = getBuildFile(tmpDir, "darwin");
+    expect(result).toBe(path.join(tmpDir, "BUILD_mac_and_linux"));
+  });
+
+  it("should use BUILD_mac_and_linux on linux when no BUILD_linux exists", () => {
+    writeFile(path.join(tmpDir, "BUILD"), "generic\n");
+    writeFile(path.join(tmpDir, "BUILD_mac_and_linux"), "unix shared\n");
+    const result = getBuildFile(tmpDir, "linux");
+    expect(result).toBe(path.join(tmpDir, "BUILD_mac_and_linux"));
+  });
+
+  it("should NOT use BUILD_mac_and_linux on win32", () => {
+    writeFile(path.join(tmpDir, "BUILD"), "generic\n");
+    writeFile(path.join(tmpDir, "BUILD_mac_and_linux"), "unix shared\n");
+    const result = getBuildFile(tmpDir, "win32");
+    expect(result).toBe(path.join(tmpDir, "BUILD"));
+  });
+
+  it("should prefer BUILD_mac over BUILD_mac_and_linux on darwin", () => {
+    writeFile(path.join(tmpDir, "BUILD"), "generic\n");
+    writeFile(path.join(tmpDir, "BUILD_mac"), "mac specific\n");
+    writeFile(path.join(tmpDir, "BUILD_mac_and_linux"), "unix shared\n");
+    const result = getBuildFile(tmpDir, "darwin");
+    expect(result).toBe(path.join(tmpDir, "BUILD_mac"));
+  });
+
+  it("should prefer BUILD_linux over BUILD_mac_and_linux on linux", () => {
+    writeFile(path.join(tmpDir, "BUILD"), "generic\n");
+    writeFile(path.join(tmpDir, "BUILD_linux"), "linux specific\n");
+    writeFile(path.join(tmpDir, "BUILD_mac_and_linux"), "unix shared\n");
+    const result = getBuildFile(tmpDir, "linux");
+    expect(result).toBe(path.join(tmpDir, "BUILD_linux"));
+  });
+
+  it("should fall back to BUILD on win32 when no BUILD_windows", () => {
+    writeFile(path.join(tmpDir, "BUILD"), "generic\n");
+    const result = getBuildFile(tmpDir, "win32");
+    expect(result).toBe(path.join(tmpDir, "BUILD"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: discoverPackages
+// ---------------------------------------------------------------------------
+
+describe("discoverPackages", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    rmDir(tmpDir);
+  });
+
+  it("should discover a single package", () => {
+    const pkgDir = path.join(tmpDir, "packages", "python", "logic-gates");
+    writeFile(path.join(pkgDir, "BUILD"), "pip install .\n");
+
+    const packages = discoverPackages(tmpDir);
+    expect(packages).toHaveLength(1);
+    expect(packages[0].name).toBe("python/logic-gates");
+    expect(packages[0].path).toBe(pkgDir);
+    expect(packages[0].buildCommands).toEqual(["pip install ."]);
+    expect(packages[0].language).toBe("python");
+  });
+
+  it("should discover multiple packages sorted by name", () => {
+    writeFile(
+      path.join(tmpDir, "packages", "python", "b-pkg", "BUILD"),
+      "echo b\n",
+    );
+    writeFile(
+      path.join(tmpDir, "packages", "python", "a-pkg", "BUILD"),
+      "echo a\n",
+    );
+
+    const packages = discoverPackages(tmpDir);
+    expect(packages).toHaveLength(2);
+    expect(packages[0].name).toBe("python/a-pkg");
+    expect(packages[1].name).toBe("python/b-pkg");
+  });
+
+  it("should skip directories in SKIP_DIRS", () => {
+    writeFile(
+      path.join(tmpDir, "node_modules", "some-dep", "BUILD"),
+      "echo skip\n",
+    );
+    writeFile(
+      path.join(tmpDir, "packages", "python", "real-pkg", "BUILD"),
+      "echo real\n",
+    );
+
+    const packages = discoverPackages(tmpDir);
+    expect(packages).toHaveLength(1);
+    expect(packages[0].name).toBe("python/real-pkg");
+  });
+
+  it("should stop recursing when BUILD file found", () => {
+    const parentDir = path.join(tmpDir, "packages", "python", "parent");
+    writeFile(path.join(parentDir, "BUILD"), "echo parent\n");
+    writeFile(path.join(parentDir, "sub", "BUILD"), "echo child\n");
+
+    const packages = discoverPackages(tmpDir);
+    expect(packages).toHaveLength(1);
+    expect(packages[0].name).toBe("python/parent");
+  });
+
+  it("should return empty array for empty directory", () => {
+    const packages = discoverPackages(tmpDir);
+    expect(packages).toHaveLength(0);
+  });
+
+  it("should use platform-specific BUILD file", () => {
+    const pkgDir = path.join(tmpDir, "packages", "python", "my-pkg");
+    writeFile(path.join(pkgDir, "BUILD"), "generic cmd\n");
+    writeFile(path.join(pkgDir, "BUILD_mac"), "mac cmd\n");
+
+    const packages = discoverPackages(tmpDir, "darwin");
+    expect(packages).toHaveLength(1);
+    expect(packages[0].buildCommands).toEqual(["mac cmd"]);
+  });
+
+  it("should detect multiple languages", () => {
+    writeFile(
+      path.join(tmpDir, "packages", "python", "py-pkg", "BUILD"),
+      "echo py\n",
+    );
+    writeFile(
+      path.join(tmpDir, "packages", "ruby", "rb-pkg", "BUILD"),
+      "echo rb\n",
+    );
+    writeFile(
+      path.join(tmpDir, "programs", "go", "go-tool", "BUILD"),
+      "echo go\n",
+    );
+
+    const packages = discoverPackages(tmpDir);
+    expect(packages).toHaveLength(3);
+    expect(packages.map((p) => p.language).sort()).toEqual([
+      "go",
+      "python",
+      "ruby",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: SKIP_DIRS constant
+// ---------------------------------------------------------------------------
+
+describe("SKIP_DIRS", () => {
+  it("should contain common skip directories", () => {
+    expect(SKIP_DIRS.has(".git")).toBe(true);
+    expect(SKIP_DIRS.has("node_modules")).toBe(true);
+    expect(SKIP_DIRS.has("__pycache__")).toBe(true);
+    expect(SKIP_DIRS.has(".venv")).toBe(true);
+    expect(SKIP_DIRS.has("target")).toBe(true);
+    expect(SKIP_DIRS.has(".claude")).toBe(true);
+  });
+});

--- a/code/programs/typescript/build-tool/tests/executor.test.ts
+++ b/code/programs/typescript/build-tool/tests/executor.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Tests for executor.ts -- Parallel Build Execution
+ *
+ * These tests verify that the executor:
+ * - Runs BUILD commands in the correct order
+ * - Skips packages when not needed
+ * - Marks dependents as dep-skipped when a dependency fails
+ * - Handles dry-run mode
+ * - Respects the affected set from git-diff
+ * - Updates the cache after builds
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { executeBuilds } from "../src/executor.js";
+import { DirectedGraph } from "../src/resolver.js";
+import { BuildCache } from "../src/cache.js";
+import type { Package } from "../src/discovery.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "build-tool-exec-"));
+}
+
+function rmDir(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function makePkg(
+  name: string,
+  pkgPath: string,
+  commands: string[],
+  language = "python",
+): Package {
+  return { name, path: pkgPath, buildCommands: commands, language };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("executeBuilds", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    rmDir(tmpDir);
+  });
+
+  it("should build a simple package successfully", async () => {
+    const pkgDir = path.join(tmpDir, "pkg-a");
+    fs.mkdirSync(pkgDir, { recursive: true });
+
+    const pkg = makePkg("python/pkg-a", pkgDir, ["echo hello"]);
+    const graph = new DirectedGraph();
+    graph.addNode("python/pkg-a");
+
+    const results = await executeBuilds({
+      packages: [pkg],
+      graph,
+      cache: new BuildCache(),
+      packageHashes: new Map([["python/pkg-a", "hash1"]]),
+      depsHashes: new Map([["python/pkg-a", "dhash1"]]),
+      force: true,
+    });
+
+    expect(results.get("python/pkg-a")?.status).toBe("built");
+    expect(results.get("python/pkg-a")?.returnCode).toBe(0);
+  });
+
+  it("should detect failed builds", async () => {
+    const pkgDir = path.join(tmpDir, "pkg-fail");
+    fs.mkdirSync(pkgDir, { recursive: true });
+
+    const pkg = makePkg("python/pkg-fail", pkgDir, ["exit 1"]);
+    const graph = new DirectedGraph();
+    graph.addNode("python/pkg-fail");
+
+    const results = await executeBuilds({
+      packages: [pkg],
+      graph,
+      cache: new BuildCache(),
+      packageHashes: new Map([["python/pkg-fail", "hash1"]]),
+      depsHashes: new Map([["python/pkg-fail", "dhash1"]]),
+      force: true,
+    });
+
+    expect(results.get("python/pkg-fail")?.status).toBe("failed");
+  });
+
+  it("should skip packages not in affected set", async () => {
+    const pkgDir = path.join(tmpDir, "pkg-skip");
+    fs.mkdirSync(pkgDir, { recursive: true });
+
+    const pkg = makePkg("python/pkg-skip", pkgDir, ["echo hello"]);
+    const graph = new DirectedGraph();
+    graph.addNode("python/pkg-skip");
+
+    const results = await executeBuilds({
+      packages: [pkg],
+      graph,
+      cache: new BuildCache(),
+      packageHashes: new Map([["python/pkg-skip", "hash1"]]),
+      depsHashes: new Map([["python/pkg-skip", "dhash1"]]),
+      affectedSet: new Set(), // empty -- nothing affected
+    });
+
+    expect(results.get("python/pkg-skip")?.status).toBe("skipped");
+  });
+
+  it("should handle dry-run mode", async () => {
+    const pkgDir = path.join(tmpDir, "pkg-dry");
+    fs.mkdirSync(pkgDir, { recursive: true });
+
+    const pkg = makePkg("python/pkg-dry", pkgDir, ["echo hello"]);
+    const graph = new DirectedGraph();
+    graph.addNode("python/pkg-dry");
+
+    const results = await executeBuilds({
+      packages: [pkg],
+      graph,
+      cache: new BuildCache(),
+      packageHashes: new Map([["python/pkg-dry", "hash1"]]),
+      depsHashes: new Map([["python/pkg-dry", "dhash1"]]),
+      force: true,
+      dryRun: true,
+    });
+
+    expect(results.get("python/pkg-dry")?.status).toBe("would-build");
+  });
+
+  it("should skip packages with unchanged cache", async () => {
+    const pkgDir = path.join(tmpDir, "pkg-cached");
+    fs.mkdirSync(pkgDir, { recursive: true });
+
+    const pkg = makePkg("python/pkg-cached", pkgDir, ["echo hello"]);
+    const graph = new DirectedGraph();
+    graph.addNode("python/pkg-cached");
+
+    // Pre-populate cache with matching hashes.
+    const cache = new BuildCache();
+    cache.record("python/pkg-cached", "hash1", "dhash1", "success");
+
+    const results = await executeBuilds({
+      packages: [pkg],
+      graph,
+      cache,
+      packageHashes: new Map([["python/pkg-cached", "hash1"]]),
+      depsHashes: new Map([["python/pkg-cached", "dhash1"]]),
+      // affectedSet is null (no git diff), force is false
+    });
+
+    expect(results.get("python/pkg-cached")?.status).toBe("skipped");
+  });
+
+  it("should dep-skip packages when dependency fails", async () => {
+    const dirA = path.join(tmpDir, "pkg-a");
+    const dirB = path.join(tmpDir, "pkg-b");
+    fs.mkdirSync(dirA, { recursive: true });
+    fs.mkdirSync(dirB, { recursive: true });
+
+    // A -> B (A must build before B). A will fail.
+    const pkgA = makePkg("python/pkg-a", dirA, ["exit 1"]);
+    const pkgB = makePkg("python/pkg-b", dirB, ["echo hello"]);
+
+    const graph = new DirectedGraph();
+    graph.addEdge("python/pkg-a", "python/pkg-b");
+
+    const results = await executeBuilds({
+      packages: [pkgA, pkgB],
+      graph,
+      cache: new BuildCache(),
+      packageHashes: new Map([
+        ["python/pkg-a", "h1"],
+        ["python/pkg-b", "h2"],
+      ]),
+      depsHashes: new Map([
+        ["python/pkg-a", "d1"],
+        ["python/pkg-b", "d2"],
+      ]),
+      force: true,
+    });
+
+    expect(results.get("python/pkg-a")?.status).toBe("failed");
+    expect(results.get("python/pkg-b")?.status).toBe("dep-skipped");
+  });
+
+  it("should execute multiple commands sequentially per package", async () => {
+    const pkgDir = path.join(tmpDir, "pkg-multi");
+    fs.mkdirSync(pkgDir, { recursive: true });
+
+    // First command creates a file, second command reads it.
+    const pkg = makePkg("python/pkg-multi", pkgDir, [
+      `echo "hello" > ${path.join(pkgDir, "test.txt")}`,
+      `cat ${path.join(pkgDir, "test.txt")}`,
+    ]);
+    const graph = new DirectedGraph();
+    graph.addNode("python/pkg-multi");
+
+    const results = await executeBuilds({
+      packages: [pkg],
+      graph,
+      cache: new BuildCache(),
+      packageHashes: new Map([["python/pkg-multi", "hash1"]]),
+      depsHashes: new Map([["python/pkg-multi", "dhash1"]]),
+      force: true,
+    });
+
+    expect(results.get("python/pkg-multi")?.status).toBe("built");
+  });
+});

--- a/code/programs/typescript/build-tool/tests/hasher.test.ts
+++ b/code/programs/typescript/build-tool/tests/hasher.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Tests for hasher.ts -- SHA256 File Hashing
+ *
+ * These tests verify that the hasher:
+ * - Produces consistent hashes for the same content
+ * - Produces different hashes for different content
+ * - Collects the right source files for each language
+ * - Includes BUILD files
+ * - Computes dependency hashes correctly
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import * as crypto from "node:crypto";
+import {
+  hashPackage,
+  hashDeps,
+  hashFile,
+  collectSourceFiles,
+  SOURCE_EXTENSIONS,
+  SPECIAL_FILENAMES,
+} from "../src/hasher.js";
+import { DirectedGraph } from "../src/resolver.js";
+import type { Package } from "../src/discovery.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "build-tool-hasher-"));
+}
+
+function rmDir(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function writeFile(filepath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filepath), { recursive: true });
+  fs.writeFileSync(filepath, content, "utf-8");
+}
+
+function makePkg(
+  pkgPath: string,
+  language: string,
+  name?: string,
+): Package {
+  return {
+    name: name ?? `${language}/test-pkg`,
+    path: pkgPath,
+    buildCommands: ["echo test"],
+    language,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests: hashFile
+// ---------------------------------------------------------------------------
+
+describe("hashFile", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    rmDir(tmpDir);
+  });
+
+  it("should produce consistent hash for same content", () => {
+    const filepath = path.join(tmpDir, "test.py");
+    writeFile(filepath, "print('hello')\n");
+    const hash1 = hashFile(filepath);
+    const hash2 = hashFile(filepath);
+    expect(hash1).toBe(hash2);
+  });
+
+  it("should produce different hash for different content", () => {
+    const file1 = path.join(tmpDir, "a.py");
+    const file2 = path.join(tmpDir, "b.py");
+    writeFile(file1, "print('hello')");
+    writeFile(file2, "print('world')");
+    expect(hashFile(file1)).not.toBe(hashFile(file2));
+  });
+
+  it("should produce a valid SHA256 hex string", () => {
+    const filepath = path.join(tmpDir, "test.py");
+    writeFile(filepath, "content");
+    const hash = hashFile(filepath);
+    expect(hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: collectSourceFiles
+// ---------------------------------------------------------------------------
+
+describe("collectSourceFiles", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    rmDir(tmpDir);
+  });
+
+  it("should collect Python source files", () => {
+    writeFile(path.join(tmpDir, "BUILD"), "echo test\n");
+    writeFile(path.join(tmpDir, "src", "main.py"), "print('hi')\n");
+    writeFile(path.join(tmpDir, "pyproject.toml"), "[project]\n");
+    writeFile(path.join(tmpDir, "README.md"), "# readme\n");
+
+    const pkg = makePkg(tmpDir, "python");
+    const files = collectSourceFiles(pkg);
+    const names = files.map((f) => path.relative(tmpDir, f));
+
+    expect(names).toContain("BUILD");
+    expect(names).toContain(path.join("src", "main.py"));
+    expect(names).toContain("pyproject.toml");
+    expect(names).not.toContain("README.md");
+  });
+
+  it("should collect Go source files including go.mod", () => {
+    writeFile(path.join(tmpDir, "BUILD"), "go build\n");
+    writeFile(path.join(tmpDir, "main.go"), "package main\n");
+    writeFile(path.join(tmpDir, "go.mod"), "module test\n");
+    writeFile(path.join(tmpDir, "go.sum"), "checksum\n");
+
+    const pkg = makePkg(tmpDir, "go");
+    const files = collectSourceFiles(pkg);
+    const names = files.map((f) => path.relative(tmpDir, f));
+
+    expect(names).toContain("BUILD");
+    expect(names).toContain("main.go");
+    expect(names).toContain("go.mod");
+    expect(names).toContain("go.sum");
+  });
+
+  it("should include BUILD variant files", () => {
+    writeFile(path.join(tmpDir, "BUILD_mac"), "mac build\n");
+    writeFile(path.join(tmpDir, "BUILD_linux"), "linux build\n");
+    writeFile(path.join(tmpDir, "BUILD_windows"), "windows build\n");
+    writeFile(path.join(tmpDir, "BUILD_mac_and_linux"), "unix build\n");
+
+    const pkg = makePkg(tmpDir, "python");
+    const files = collectSourceFiles(pkg);
+    const names = files.map((f) => path.basename(f));
+
+    expect(names).toContain("BUILD_mac");
+    expect(names).toContain("BUILD_linux");
+    expect(names).toContain("BUILD_windows");
+    expect(names).toContain("BUILD_mac_and_linux");
+  });
+
+  it("should return sorted files for determinism", () => {
+    writeFile(path.join(tmpDir, "BUILD"), "test\n");
+    writeFile(path.join(tmpDir, "c.py"), "c\n");
+    writeFile(path.join(tmpDir, "a.py"), "a\n");
+    writeFile(path.join(tmpDir, "b.py"), "b\n");
+
+    const pkg = makePkg(tmpDir, "python");
+    const files = collectSourceFiles(pkg);
+    const names = files.map((f) => path.relative(tmpDir, f));
+
+    // Check they're sorted (localeCompare sorting).
+    // Note: case-sensitive sort means uppercase comes after lowercase
+    // on most systems, but localeCompare may vary. We just verify the
+    // output is deterministic by checking it matches its own sort.
+    const sortedNames = [...names].sort((a, b) => a.localeCompare(b));
+    expect(names).toEqual(sortedNames);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: hashPackage
+// ---------------------------------------------------------------------------
+
+describe("hashPackage", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    rmDir(tmpDir);
+  });
+
+  it("should return consistent hash for same files", () => {
+    writeFile(path.join(tmpDir, "BUILD"), "test\n");
+    writeFile(path.join(tmpDir, "main.py"), "print('hi')\n");
+
+    const pkg = makePkg(tmpDir, "python");
+    expect(hashPackage(pkg)).toBe(hashPackage(pkg));
+  });
+
+  it("should change hash when file content changes", () => {
+    writeFile(path.join(tmpDir, "BUILD"), "test\n");
+    writeFile(path.join(tmpDir, "main.py"), "print('hello')\n");
+
+    const pkg = makePkg(tmpDir, "python");
+    const hash1 = hashPackage(pkg);
+
+    writeFile(path.join(tmpDir, "main.py"), "print('world')\n");
+    const hash2 = hashPackage(pkg);
+
+    expect(hash1).not.toBe(hash2);
+  });
+
+  it("should return hash of empty string for package with no source files", () => {
+    fs.mkdirSync(tmpDir, { recursive: true });
+
+    const pkg = makePkg(tmpDir, "python");
+    const expected = crypto.createHash("sha256").update("").digest("hex");
+    expect(hashPackage(pkg)).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: hashDeps
+// ---------------------------------------------------------------------------
+
+describe("hashDeps", () => {
+  it("should return empty hash for node with no dependencies", () => {
+    const graph = new DirectedGraph();
+    graph.addNode("A");
+
+    const hashes = new Map([["A", "hash-a"]]);
+    const expected = crypto.createHash("sha256").update("").digest("hex");
+    expect(hashDeps("A", graph, hashes)).toBe(expected);
+  });
+
+  it("should return empty hash for unknown node", () => {
+    const graph = new DirectedGraph();
+    const expected = crypto.createHash("sha256").update("").digest("hex");
+    expect(hashDeps("UNKNOWN", graph, new Map())).toBe(expected);
+  });
+
+  it("should incorporate dependency hashes", () => {
+    const graph = new DirectedGraph();
+    graph.addEdge("A", "B"); // A -> B means B depends on A
+
+    const hashes = new Map([
+      ["A", "hash-a"],
+      ["B", "hash-b"],
+    ]);
+
+    // B's deps hash should include A's hash.
+    const depsHash = hashDeps("B", graph, hashes);
+    expect(depsHash).not.toBe(
+      crypto.createHash("sha256").update("").digest("hex"),
+    );
+  });
+
+  it("should produce different hashes when dependency changes", () => {
+    const graph = new DirectedGraph();
+    graph.addEdge("A", "B");
+
+    const hashes1 = new Map([
+      ["A", "hash-a-v1"],
+      ["B", "hash-b"],
+    ]);
+    const hashes2 = new Map([
+      ["A", "hash-a-v2"],
+      ["B", "hash-b"],
+    ]);
+
+    expect(hashDeps("B", graph, hashes1)).not.toBe(
+      hashDeps("B", graph, hashes2),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Constants
+// ---------------------------------------------------------------------------
+
+describe("SOURCE_EXTENSIONS", () => {
+  it("should include Python extensions", () => {
+    expect(SOURCE_EXTENSIONS.python.has(".py")).toBe(true);
+    expect(SOURCE_EXTENSIONS.python.has(".toml")).toBe(true);
+  });
+
+  it("should include Go extensions", () => {
+    expect(SOURCE_EXTENSIONS.go.has(".go")).toBe(true);
+  });
+
+  it("should include TypeScript extensions", () => {
+    expect(SOURCE_EXTENSIONS.typescript.has(".ts")).toBe(true);
+    expect(SOURCE_EXTENSIONS.typescript.has(".json")).toBe(true);
+  });
+
+  it("should include Rust extensions", () => {
+    expect(SOURCE_EXTENSIONS.rust.has(".rs")).toBe(true);
+  });
+
+  it("should include Elixir extensions", () => {
+    expect(SOURCE_EXTENSIONS.elixir.has(".ex")).toBe(true);
+    expect(SOURCE_EXTENSIONS.elixir.has(".exs")).toBe(true);
+  });
+});
+
+describe("SPECIAL_FILENAMES", () => {
+  it("should include Go special files", () => {
+    expect(SPECIAL_FILENAMES.go.has("go.mod")).toBe(true);
+    expect(SPECIAL_FILENAMES.go.has("go.sum")).toBe(true);
+  });
+
+  it("should include Ruby special files", () => {
+    expect(SPECIAL_FILENAMES.ruby.has("Gemfile")).toBe(true);
+  });
+});

--- a/code/programs/typescript/build-tool/tests/reporter.test.ts
+++ b/code/programs/typescript/build-tool/tests/reporter.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for reporter.ts -- Build Report Formatting
+ *
+ * These tests verify that the reporter:
+ * - Formats build results into a readable table
+ * - Shows correct status labels
+ * - Formats durations properly
+ * - Includes a summary line with correct counts
+ * - Handles empty results
+ * - Sorts packages alphabetically
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  formatReport,
+  formatDuration,
+  STATUS_DISPLAY,
+} from "../src/reporter.js";
+import type { BuildResult } from "../src/executor.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeResult(
+  name: string,
+  status: BuildResult["status"],
+  duration = 0,
+): BuildResult {
+  return {
+    packageName: name,
+    status,
+    duration,
+    stdout: "",
+    stderr: "",
+    returnCode: status === "failed" ? 1 : 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests: formatDuration
+// ---------------------------------------------------------------------------
+
+describe("formatDuration", () => {
+  it('should return "-" for zero duration', () => {
+    expect(formatDuration(0)).toBe("-");
+  });
+
+  it('should return "-" for negligible duration', () => {
+    expect(formatDuration(0.005)).toBe("-");
+  });
+
+  it("should format seconds with one decimal", () => {
+    expect(formatDuration(2.345)).toBe("2.3s");
+  });
+
+  it("should handle large durations", () => {
+    expect(formatDuration(120.7)).toBe("120.7s");
+  });
+
+  it("should handle exactly 0.01 seconds", () => {
+    expect(formatDuration(0.01)).toBe("0.0s");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: STATUS_DISPLAY
+// ---------------------------------------------------------------------------
+
+describe("STATUS_DISPLAY", () => {
+  it("should have display names for all statuses", () => {
+    expect(STATUS_DISPLAY.built).toBe("BUILT");
+    expect(STATUS_DISPLAY.failed).toBe("FAILED");
+    expect(STATUS_DISPLAY.skipped).toBe("SKIPPED");
+    expect(STATUS_DISPLAY["dep-skipped"]).toBe("DEP-SKIP");
+    expect(STATUS_DISPLAY["would-build"]).toBe("WOULD-BUILD");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: formatReport
+// ---------------------------------------------------------------------------
+
+describe("formatReport", () => {
+  it("should handle empty results", () => {
+    const report = formatReport(new Map());
+    expect(report).toContain("No packages processed.");
+  });
+
+  it("should include header", () => {
+    const results = new Map<string, BuildResult>();
+    results.set("python/pkg", makeResult("python/pkg", "built", 1.5));
+
+    const report = formatReport(results);
+    expect(report).toContain("Build Report");
+    expect(report).toContain("============");
+  });
+
+  it("should show built packages with duration", () => {
+    const results = new Map<string, BuildResult>();
+    results.set("python/pkg", makeResult("python/pkg", "built", 2.3));
+
+    const report = formatReport(results);
+    expect(report).toContain("python/pkg");
+    expect(report).toContain("BUILT");
+    expect(report).toContain("2.3s");
+  });
+
+  it("should show skipped packages", () => {
+    const results = new Map<string, BuildResult>();
+    results.set("python/pkg", makeResult("python/pkg", "skipped"));
+
+    const report = formatReport(results);
+    expect(report).toContain("SKIPPED");
+  });
+
+  it("should show dep-skipped with special duration", () => {
+    const results = new Map<string, BuildResult>();
+    results.set("python/pkg", makeResult("python/pkg", "dep-skipped"));
+
+    const report = formatReport(results);
+    expect(report).toContain("DEP-SKIP");
+    expect(report).toContain("- (dep failed)");
+  });
+
+  it("should show would-build in dry run", () => {
+    const results = new Map<string, BuildResult>();
+    results.set("python/pkg", makeResult("python/pkg", "would-build"));
+
+    const report = formatReport(results);
+    expect(report).toContain("WOULD-BUILD");
+  });
+
+  it("should include summary line with correct counts", () => {
+    const results = new Map<string, BuildResult>();
+    results.set("python/a", makeResult("python/a", "built", 1.0));
+    results.set("python/b", makeResult("python/b", "skipped"));
+    results.set("python/c", makeResult("python/c", "failed", 0.5));
+    results.set("python/d", makeResult("python/d", "dep-skipped"));
+
+    const report = formatReport(results);
+    expect(report).toContain("Total: 4 packages");
+    expect(report).toContain("1 built");
+    expect(report).toContain("1 skipped");
+    expect(report).toContain("1 failed");
+    expect(report).toContain("1 dep-skipped");
+  });
+
+  it("should sort packages alphabetically", () => {
+    const results = new Map<string, BuildResult>();
+    results.set("python/z-pkg", makeResult("python/z-pkg", "built", 1.0));
+    results.set("python/a-pkg", makeResult("python/a-pkg", "built", 2.0));
+
+    const report = formatReport(results);
+    const aIdx = report.indexOf("python/a-pkg");
+    const zIdx = report.indexOf("python/z-pkg");
+    expect(aIdx).toBeLessThan(zIdx);
+  });
+
+  it("should omit zero counts from summary", () => {
+    const results = new Map<string, BuildResult>();
+    results.set("python/a", makeResult("python/a", "built", 1.0));
+
+    const report = formatReport(results);
+    expect(report).toContain("1 built");
+    expect(report).not.toContain("skipped");
+    expect(report).not.toContain("failed");
+  });
+});

--- a/code/programs/typescript/build-tool/tests/resolver.test.ts
+++ b/code/programs/typescript/build-tool/tests/resolver.test.ts
@@ -1,0 +1,424 @@
+/**
+ * Tests for resolver.ts -- Dependency Resolution & Directed Graph
+ *
+ * These tests cover:
+ * - DirectedGraph operations (add/query nodes and edges)
+ * - Topological sort via independentGroups (Kahn's algorithm)
+ * - Transitive closure and transitive dependents
+ * - Affected nodes calculation
+ * - Cycle detection
+ * - Dependency parsing for all 6 languages
+ * - Known names mapping
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import {
+  DirectedGraph,
+  resolveDependencies,
+  buildKnownNames,
+} from "../src/resolver.js";
+import type { Package } from "../src/discovery.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "build-tool-resolver-"));
+}
+
+function rmDir(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function writeFile(filepath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filepath), { recursive: true });
+  fs.writeFileSync(filepath, content, "utf-8");
+}
+
+function makePkg(
+  name: string,
+  pkgPath: string,
+  language: string,
+): Package {
+  return { name, path: pkgPath, buildCommands: ["echo test"], language };
+}
+
+// ---------------------------------------------------------------------------
+// Tests: DirectedGraph basics
+// ---------------------------------------------------------------------------
+
+describe("DirectedGraph", () => {
+  describe("node operations", () => {
+    it("should add and check nodes", () => {
+      const g = new DirectedGraph();
+      g.addNode("A");
+      expect(g.hasNode("A")).toBe(true);
+      expect(g.hasNode("B")).toBe(false);
+    });
+
+    it("should list all nodes", () => {
+      const g = new DirectedGraph();
+      g.addNode("B");
+      g.addNode("A");
+      expect(g.nodes().sort()).toEqual(["A", "B"]);
+    });
+
+    it("should handle duplicate addNode calls", () => {
+      const g = new DirectedGraph();
+      g.addNode("A");
+      g.addNode("A");
+      expect(g.nodes()).toEqual(["A"]);
+    });
+  });
+
+  describe("edge operations", () => {
+    it("should add edges and auto-create nodes", () => {
+      const g = new DirectedGraph();
+      g.addEdge("A", "B");
+      expect(g.hasNode("A")).toBe(true);
+      expect(g.hasNode("B")).toBe(true);
+      expect(g.successors("A")).toEqual(["B"]);
+      expect(g.predecessors("B")).toEqual(["A"]);
+    });
+
+    it("should track successors and predecessors", () => {
+      const g = new DirectedGraph();
+      g.addEdge("A", "B");
+      g.addEdge("A", "C");
+      expect(g.successors("A").sort()).toEqual(["B", "C"]);
+      expect(g.predecessors("A")).toEqual([]);
+    });
+  });
+
+  describe("transitiveClosure", () => {
+    it("should find all reachable nodes", () => {
+      const g = new DirectedGraph();
+      g.addEdge("A", "B");
+      g.addEdge("B", "C");
+      g.addEdge("C", "D");
+      expect(Array.from(g.transitiveClosure("A")).sort()).toEqual([
+        "B",
+        "C",
+        "D",
+      ]);
+    });
+
+    it("should return empty set for leaf node", () => {
+      const g = new DirectedGraph();
+      g.addNode("A");
+      expect(g.transitiveClosure("A").size).toBe(0);
+    });
+
+    it("should return empty set for unknown node", () => {
+      const g = new DirectedGraph();
+      expect(g.transitiveClosure("X").size).toBe(0);
+    });
+  });
+
+  describe("transitiveDependents", () => {
+    it("should find all nodes that depend on given node", () => {
+      const g = new DirectedGraph();
+      g.addEdge("A", "B");
+      g.addEdge("B", "C");
+      // A -> B -> C: dependents of C are B and A
+      expect(Array.from(g.transitiveDependents("C")).sort()).toEqual([
+        "A",
+        "B",
+      ]);
+    });
+
+    it("should return empty set for root node", () => {
+      const g = new DirectedGraph();
+      g.addEdge("A", "B");
+      expect(g.transitiveDependents("A").size).toBe(0);
+    });
+  });
+
+  describe("independentGroups", () => {
+    it("should partition into correct levels", () => {
+      const g = new DirectedGraph();
+      g.addEdge("A", "B");
+      g.addEdge("A", "C");
+      g.addEdge("B", "D");
+      g.addEdge("C", "D");
+
+      const groups = g.independentGroups();
+      expect(groups).toEqual([["A"], ["B", "C"], ["D"]]);
+    });
+
+    it("should handle single node", () => {
+      const g = new DirectedGraph();
+      g.addNode("A");
+      expect(g.independentGroups()).toEqual([["A"]]);
+    });
+
+    it("should handle multiple independent nodes", () => {
+      const g = new DirectedGraph();
+      g.addNode("A");
+      g.addNode("B");
+      g.addNode("C");
+      const groups = g.independentGroups();
+      expect(groups).toEqual([["A", "B", "C"]]);
+    });
+
+    it("should detect cycles", () => {
+      const g = new DirectedGraph();
+      g.addEdge("A", "B");
+      g.addEdge("B", "A");
+      expect(() => g.independentGroups()).toThrow("cycle");
+    });
+
+    it("should handle a linear chain", () => {
+      const g = new DirectedGraph();
+      g.addEdge("A", "B");
+      g.addEdge("B", "C");
+      const groups = g.independentGroups();
+      expect(groups).toEqual([["A"], ["B"], ["C"]]);
+    });
+  });
+
+  describe("affectedNodes", () => {
+    it("should include changed nodes and their dependents", () => {
+      const g = new DirectedGraph();
+      g.addEdge("A", "B");
+      g.addEdge("B", "C");
+      g.addEdge("A", "D");
+
+      const affected = g.affectedNodes(new Set(["A"]));
+      expect(Array.from(affected).sort()).toEqual(["A", "B", "C", "D"]);
+    });
+
+    it("should handle unknown nodes gracefully", () => {
+      const g = new DirectedGraph();
+      g.addNode("A");
+      const affected = g.affectedNodes(new Set(["UNKNOWN"]));
+      expect(affected.size).toBe(0);
+    });
+
+    it("should handle multiple changed nodes", () => {
+      const g = new DirectedGraph();
+      g.addEdge("A", "B");
+      g.addEdge("C", "D");
+
+      const affected = g.affectedNodes(new Set(["A", "C"]));
+      expect(Array.from(affected).sort()).toEqual(["A", "B", "C", "D"]);
+    });
+
+    it("should handle node with no dependents", () => {
+      const g = new DirectedGraph();
+      g.addNode("A");
+      const affected = g.affectedNodes(new Set(["A"]));
+      expect(Array.from(affected)).toEqual(["A"]);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: buildKnownNames
+// ---------------------------------------------------------------------------
+
+describe("buildKnownNames", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    rmDir(tmpDir);
+  });
+
+  it("should map Python packages", () => {
+    const pkgPath = path.join(tmpDir, "logic-gates");
+    fs.mkdirSync(pkgPath, { recursive: true });
+    const pkg = makePkg("python/logic-gates", pkgPath, "python");
+
+    const known = buildKnownNames([pkg]);
+    expect(known.get("coding-adventures-logic-gates")).toBe(
+      "python/logic-gates",
+    );
+  });
+
+  it("should map Ruby packages", () => {
+    const pkgPath = path.join(tmpDir, "logic_gates");
+    fs.mkdirSync(pkgPath, { recursive: true });
+    const pkg = makePkg("ruby/logic_gates", pkgPath, "ruby");
+
+    const known = buildKnownNames([pkg]);
+    expect(known.get("coding_adventures_logic_gates")).toBe(
+      "ruby/logic_gates",
+    );
+  });
+
+  it("should map Go packages from go.mod", () => {
+    const pkgPath = path.join(tmpDir, "my-tool");
+    writeFile(
+      path.join(pkgPath, "go.mod"),
+      "module github.com/user/repo/my-tool\n\ngo 1.21\n",
+    );
+    const pkg = makePkg("go/my-tool", pkgPath, "go");
+
+    const known = buildKnownNames([pkg]);
+    expect(known.get("github.com/user/repo/my-tool")).toBe("go/my-tool");
+  });
+
+  it("should map TypeScript packages", () => {
+    const pkgPath = path.join(tmpDir, "logic-gates");
+    fs.mkdirSync(pkgPath, { recursive: true });
+    const pkg = makePkg("typescript/logic-gates", pkgPath, "typescript");
+
+    const known = buildKnownNames([pkg]);
+    expect(known.get("@coding-adventures/logic-gates")).toBe(
+      "typescript/logic-gates",
+    );
+  });
+
+  it("should map Rust packages", () => {
+    const pkgPath = path.join(tmpDir, "logic-gates");
+    fs.mkdirSync(pkgPath, { recursive: true });
+    const pkg = makePkg("rust/logic-gates", pkgPath, "rust");
+
+    const known = buildKnownNames([pkg]);
+    expect(known.get("logic-gates")).toBe("rust/logic-gates");
+  });
+
+  it("should map Elixir packages with hyphen-to-underscore conversion", () => {
+    const pkgPath = path.join(tmpDir, "logic-gates");
+    fs.mkdirSync(pkgPath, { recursive: true });
+    const pkg = makePkg("elixir/logic-gates", pkgPath, "elixir");
+
+    const known = buildKnownNames([pkg]);
+    expect(known.get("coding_adventures_logic_gates")).toBe(
+      "elixir/logic-gates",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: resolveDependencies
+// ---------------------------------------------------------------------------
+
+describe("resolveDependencies", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    rmDir(tmpDir);
+  });
+
+  it("should resolve Python dependencies from pyproject.toml", () => {
+    const gatesDir = path.join(tmpDir, "logic-gates");
+    const arithDir = path.join(tmpDir, "arithmetic");
+    writeFile(path.join(gatesDir, "pyproject.toml"), `[project]\nname = "coding-adventures-logic-gates"\ndependencies = []\n`);
+    writeFile(path.join(arithDir, "pyproject.toml"), `[project]\nname = "coding-adventures-arithmetic"\ndependencies = [\n    "coding-adventures-logic-gates>=0.1",\n]\n`);
+
+    const gates = makePkg("python/logic-gates", gatesDir, "python");
+    const arith = makePkg("python/arithmetic", arithDir, "python");
+
+    const graph = resolveDependencies([gates, arith]);
+    // Edge: logic-gates -> arithmetic (logic-gates must build first)
+    expect(graph.successors("python/logic-gates")).toContain(
+      "python/arithmetic",
+    );
+  });
+
+  it("should resolve Ruby dependencies from .gemspec", () => {
+    const gatesDir = path.join(tmpDir, "logic_gates");
+    const arithDir = path.join(tmpDir, "arithmetic");
+    fs.mkdirSync(gatesDir, { recursive: true });
+    writeFile(path.join(arithDir, "arithmetic.gemspec"), `Gem::Specification.new do |spec|\n  spec.add_dependency "coding_adventures_logic_gates"\nend\n`);
+
+    const gates = makePkg("ruby/logic_gates", gatesDir, "ruby");
+    const arith = makePkg("ruby/arithmetic", arithDir, "ruby");
+
+    const graph = resolveDependencies([gates, arith]);
+    expect(graph.successors("ruby/logic_gates")).toContain("ruby/arithmetic");
+  });
+
+  it("should resolve Go dependencies from go.mod", () => {
+    const gatesDir = path.join(tmpDir, "logic-gates");
+    const arithDir = path.join(tmpDir, "arithmetic");
+    writeFile(path.join(gatesDir, "go.mod"), "module github.com/user/repo/logic-gates\n\ngo 1.21\n");
+    writeFile(path.join(arithDir, "go.mod"), "module github.com/user/repo/arithmetic\n\ngo 1.21\n\nrequire (\n\tgithub.com/user/repo/logic-gates v0.1.0\n)\n");
+
+    const gates = makePkg("go/logic-gates", gatesDir, "go");
+    const arith = makePkg("go/arithmetic", arithDir, "go");
+
+    const graph = resolveDependencies([gates, arith]);
+    expect(graph.successors("go/logic-gates")).toContain("go/arithmetic");
+  });
+
+  it("should resolve TypeScript dependencies from package.json", () => {
+    const gatesDir = path.join(tmpDir, "logic-gates");
+    const arithDir = path.join(tmpDir, "arithmetic");
+    fs.mkdirSync(gatesDir, { recursive: true });
+    writeFile(path.join(arithDir, "package.json"), JSON.stringify({
+      name: "@coding-adventures/arithmetic",
+      dependencies: {
+        "@coding-adventures/logic-gates": "file:../logic-gates",
+      },
+    }, null, 2));
+
+    const gates = makePkg("typescript/logic-gates", gatesDir, "typescript");
+    const arith = makePkg("typescript/arithmetic", arithDir, "typescript");
+
+    const graph = resolveDependencies([gates, arith]);
+    expect(graph.successors("typescript/logic-gates")).toContain(
+      "typescript/arithmetic",
+    );
+  });
+
+  it("should resolve Rust dependencies from Cargo.toml", () => {
+    const gatesDir = path.join(tmpDir, "logic-gates");
+    const arithDir = path.join(tmpDir, "arithmetic");
+    fs.mkdirSync(gatesDir, { recursive: true });
+    writeFile(path.join(arithDir, "Cargo.toml"), `[package]\nname = "arithmetic"\n\n[dependencies]\nlogic-gates = { path = "../logic-gates" }\n`);
+
+    const gates = makePkg("rust/logic-gates", gatesDir, "rust");
+    const arith = makePkg("rust/arithmetic", arithDir, "rust");
+
+    const graph = resolveDependencies([gates, arith]);
+    expect(graph.successors("rust/logic-gates")).toContain("rust/arithmetic");
+  });
+
+  it("should resolve Elixir dependencies from mix.exs", () => {
+    const gatesDir = path.join(tmpDir, "logic-gates");
+    const arithDir = path.join(tmpDir, "arithmetic");
+    fs.mkdirSync(gatesDir, { recursive: true });
+    writeFile(path.join(arithDir, "mix.exs"), `defmodule Arithmetic.MixProject do\n  defp deps do\n    [\n      {:coding_adventures_logic_gates, path: "../logic-gates"}\n    ]\n  end\nend\n`);
+
+    const gates = makePkg("elixir/logic-gates", gatesDir, "elixir");
+    const arith = makePkg("elixir/arithmetic", arithDir, "elixir");
+
+    const graph = resolveDependencies([gates, arith]);
+    expect(graph.successors("elixir/logic-gates")).toContain(
+      "elixir/arithmetic",
+    );
+  });
+
+  it("should skip external dependencies", () => {
+    const pkgDir = path.join(tmpDir, "my-pkg");
+    writeFile(path.join(pkgDir, "pyproject.toml"), `[project]\nname = "coding-adventures-my-pkg"\ndependencies = [\n    "requests>=2.0",\n    "flask",\n]\n`);
+
+    const pkg = makePkg("python/my-pkg", pkgDir, "python");
+    const graph = resolveDependencies([pkg]);
+    expect(graph.successors("python/my-pkg")).toEqual([]);
+  });
+
+  it("should handle packages with no metadata files", () => {
+    const pkgDir = path.join(tmpDir, "no-metadata");
+    fs.mkdirSync(pkgDir, { recursive: true });
+
+    const pkg = makePkg("python/no-metadata", pkgDir, "python");
+    const graph = resolveDependencies([pkg]);
+    expect(graph.hasNode("python/no-metadata")).toBe(true);
+    expect(graph.successors("python/no-metadata")).toEqual([]);
+  });
+});

--- a/code/programs/typescript/build-tool/tsconfig.json
+++ b/code/programs/typescript/build-tool/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "sourceMap": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/code/programs/typescript/build-tool/vitest.config.ts
+++ b/code/programs/typescript/build-tool/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["src/index.ts"],
+      thresholds: {
+        statements: 80,
+        branches: 80,
+        functions: 80,
+        lines: 80,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Creates the 6th language implementation of the build tool (TypeScript), joining Go, Python, Ruby, Elixir, and Rust
- 8 modules: discovery, resolver, gitdiff, hasher, cache, executor, reporter, CLI
- BUILD_windows + BUILD_mac_and_linux support baked in from day one
- Dependency parsing for all 6 languages (Python, Ruby, Go, Rust, TypeScript, Elixir)
- Zero external runtime dependencies (Node.js built-ins only)
- 125 tests, 92.15% statement coverage

## Architecture

Same module structure as all other implementations:
- **discovery.ts** — Recursive BUILD file walk with platform-specific priority
- **resolver.ts** — Inline DirectedGraph with Kahn's algorithm
- **gitdiff.ts** — Git diff change detection (primary) with cache fallback
- **hasher.ts** — SHA256 two-level hashing
- **cache.ts** — JSON cache with atomic writes
- **executor.ts** — Parallel builds via Promise.all with semaphore
- **reporter.ts** — Formatted build report table

## Test plan

- [x] `npx vitest run` — 125 tests pass
- [x] `npx vitest run --coverage` — 92.15% statement coverage (above 80% threshold)
- [x] CI passes on all platforms

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)