### PR TITLE
feat(build-tool): Windows shell execution in Go and Elixir executors

### DIFF
--- a/code/programs/elixir/build-tool/lib/build_tool/executor.ex
+++ b/code/programs/elixir/build-tool/lib/build_tool/executor.ex
@@ -319,10 +319,17 @@ defmodule BuildTool.Executor do
     # We use stderr_to_stdout: true so that System.cmd captures both streams.
     # This matches the Go implementation which captures both stdout and stderr
     # from the shell command.
+    #
+    # On Windows, we use "cmd /C" instead of "sh -c" to invoke the shell.
+    # This is the same approach used by the Rust build tool. Python's
+    # subprocess.run(shell=True) and Node's child_process.exec() handle this
+    # automatically, but Elixir's System.cmd requires explicit selection.
+    {shell, shell_flag} = shell_command()
+
     {all_output, final_status, final_code} =
       Enum.reduce_while(pkg.build_commands, {[], "built", 0}, fn command,
                                                                   {output_acc, _status, _code} ->
-        case System.cmd("sh", ["-c", command],
+        case System.cmd(shell, [shell_flag, command],
                cd: pkg.path,
                stderr_to_stdout: true
              ) do
@@ -362,4 +369,24 @@ defmodule BuildTool.Executor do
     |> MapSet.to_list()
     |> Enum.any?(fn dep -> MapSet.member?(failed_packages, dep) end)
   end
+
+  # ---------------------------------------------------------------------------
+  # Shell command selection
+  # ---------------------------------------------------------------------------
+  #
+  # Returns the platform-appropriate shell and flag for executing BUILD
+  # commands. On Windows, this is {"cmd", "/C"}; on Unix, {"sh", "-c"}.
+  #
+  # This is the same approach used by the Rust build tool (which uses
+  # cfg!(target_os = "windows") to select between cmd and sh). Python's
+  # subprocess.run(shell=True) and Node's child_process.exec() handle this
+  # automatically, but Elixir's System.cmd requires explicit selection.
+
+  defp shell_command do
+    shell_command_for_os(:os.type())
+  end
+
+  @doc false
+  def shell_command_for_os({:win32, _}), do: {"cmd", "/C"}
+  def shell_command_for_os(_), do: {"sh", "-c"}
 end

--- a/code/programs/elixir/build-tool/test/executor_test.exs
+++ b/code/programs/elixir/build-tool/test/executor_test.exs
@@ -172,6 +172,24 @@ defmodule BuildTool.ExecutorTest do
   end
 
   # ---------------------------------------------------------------------------
+  # Shell command selection (platform-specific)
+  # ---------------------------------------------------------------------------
+
+  describe "shell_command_for_os/1" do
+    test "returns sh -c for Unix (darwin)" do
+      assert Executor.shell_command_for_os({:unix, :darwin}) == {"sh", "-c"}
+    end
+
+    test "returns sh -c for Unix (linux)" do
+      assert Executor.shell_command_for_os({:unix, :linux}) == {"sh", "-c"}
+    end
+
+    test "returns cmd /C for Windows" do
+      assert Executor.shell_command_for_os({:win32, :nt}) == {"cmd", "/C"}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # Cache integration
   # ---------------------------------------------------------------------------
 

--- a/code/programs/go/build-tool/internal/executor/executor.go
+++ b/code/programs/go/build-tool/internal/executor/executor.go
@@ -41,6 +41,7 @@ package executor
 import (
 	"fmt"
 	"os/exec"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -67,14 +68,15 @@ type BuildResult struct {
 // This is because BUILD files are scripts: later commands may depend on
 // earlier ones (e.g., "install dependencies" before "run tests").
 //
-// We use os/exec with shell execution (sh -c) so that BUILD commands can
-// use shell features like pipes, redirects, and environment variables.
+// We use os/exec with shell execution so that BUILD commands can use
+// shell features like pipes, redirects, and environment variables.
+// On Windows, we use "cmd /C"; on Unix, "sh -c".
 func runPackageBuild(pkg discovery.Package) BuildResult {
 	start := time.Now()
 	var allStdout, allStderr []string
 
 	for _, command := range pkg.BuildCommands {
-		cmd := exec.Command("sh", "-c", command)
+		cmd := shellCommand(command)
 		cmd.Dir = pkg.Path
 
 		var stdout, stderr strings.Builder
@@ -111,6 +113,28 @@ func runPackageBuild(pkg discovery.Package) BuildResult {
 		Stderr:      strings.Join(allStderr, ""),
 		ReturnCode:  0,
 	}
+}
+
+// shellCommand returns an exec.Cmd that runs the given command string in
+// the platform-appropriate shell. On Windows this is "cmd /C command"; on
+// Unix (macOS, Linux) it is "sh -c command".
+//
+// This is the same approach used by the Rust build tool (which uses
+// cfg!(target_os = "windows") to select between cmd and sh). Python's
+// subprocess.run(shell=True) and Node's child_process.exec() handle this
+// automatically, but Go requires explicit selection.
+func shellCommand(command string) *exec.Cmd {
+	return shellCommandForOS(command, runtime.GOOS)
+}
+
+// shellCommandForOS is the testable version of shellCommand that accepts
+// an explicit OS name. This allows tests to verify Windows behavior on
+// non-Windows hosts.
+func shellCommandForOS(command string, goos string) *exec.Cmd {
+	if goos == "windows" {
+		return exec.Command("cmd", "/C", command)
+	}
+	return exec.Command("sh", "-c", command)
 }
 
 // ExecuteBuilds runs BUILD commands for packages respecting dependency order.

--- a/code/programs/go/build-tool/internal/executor/executor_test.go
+++ b/code/programs/go/build-tool/internal/executor/executor_test.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	directedgraph "github.com/adhithyan15/coding-adventures/code/packages/go/directed-graph"
@@ -24,6 +25,48 @@ func makeFixture(t *testing.T, tree map[string]string) string {
 		}
 	}
 	return root
+}
+
+// ---------------------------------------------------------------------------
+// Tests for shellCommandForOS
+// ---------------------------------------------------------------------------
+
+func TestShellCommandForOSUnix(t *testing.T) {
+	// On Unix (darwin, linux), shellCommandForOS should use "sh -c".
+	cmd := shellCommandForOS("echo hello", "darwin")
+	if cmd.Path == "" {
+		t.Fatal("expected non-empty path")
+	}
+	if cmd.Args[0] != "sh" || cmd.Args[1] != "-c" || cmd.Args[2] != "echo hello" {
+		t.Fatalf("expected sh -c 'echo hello', got %v", cmd.Args)
+	}
+
+	cmd = shellCommandForOS("echo hello", "linux")
+	if cmd.Args[0] != "sh" || cmd.Args[1] != "-c" {
+		t.Fatalf("expected sh -c on linux, got %v", cmd.Args)
+	}
+}
+
+func TestShellCommandForOSWindows(t *testing.T) {
+	// On Windows, shellCommandForOS should use "cmd /C".
+	cmd := shellCommandForOS("echo hello", "windows")
+	if cmd.Args[0] != "cmd" || cmd.Args[1] != "/C" || cmd.Args[2] != "echo hello" {
+		t.Fatalf("expected cmd /C 'echo hello', got %v", cmd.Args)
+	}
+}
+
+func TestShellCommandUsesCurrentOS(t *testing.T) {
+	// shellCommand (no OS parameter) should use the current platform.
+	cmd := shellCommand("echo test")
+	if runtime.GOOS == "windows" {
+		if cmd.Args[0] != "cmd" {
+			t.Fatalf("expected cmd on windows, got %v", cmd.Args[0])
+		}
+	} else {
+		if cmd.Args[0] != "sh" {
+			t.Fatalf("expected sh on unix, got %v", cmd.Args[0])
+		}
+	}
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Go executor: extract `shellCommand()` / `shellCommandForOS()` helpers that use `runtime.GOOS` to select between `cmd /C` (Windows) and `sh -c` (Unix)
- Elixir executor: extract `shell_command()` / `shell_command_for_os()` helpers that use `:os.type()` for the same platform detection
- 3 new Go tests + 3 new Elixir tests for shell command selection
- The other 4 build tools (Python, Ruby, TypeScript, Rust) are already cross-platform and need no changes

## Context

Phase 2 of Windows CI support (#96). Phase 1 added `BUILD_windows` and `BUILD_mac_and_linux` file support to all 6 build tools. This phase ensures executor modules use the correct shell on each platform.

## Why only Go and Elixir?

| Language | Mechanism | Cross-platform? |
|----------|-----------|-----------------|
| Python | `subprocess.run(shell=True)` | Yes — auto-selects shell |
| Ruby | `Open3.capture3(string)` | Yes — auto-selects shell |
| TypeScript | `child_process.exec()` | Yes — auto-selects shell |
| Rust | `cfg!(target_os = "windows")` | Yes — already implemented |
| **Go** | `exec.Command("sh", "-c", ...)` | **No — hardcoded** |
| **Elixir** | `System.cmd("sh", ["-c", ...])` | **No — hardcoded** |

## Test plan

- [x] Go: `go test ./internal/executor/ -v` — all pass including 3 new shell command tests
- [x] Elixir: `mix test` — all 105 tests pass including 3 new shell command tests
- [ ] CI passes on Linux and macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)