### PR TITLE
feat(perl): add Perl 5.40 support and trig package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
       needs_typescript: ${{ steps.detect.outputs.needs_typescript }}
       needs_rust: ${{ steps.detect.outputs.needs_rust }}
       needs_elixir: ${{ steps.detect.outputs.needs_elixir }}
+      needs_perl: ${{ steps.detect.outputs.needs_perl }}
       diff_base: ${{ steps.diff-base.outputs.base }}
       is_main: ${{ steps.detect-main.outputs.is_main }}
     steps:
@@ -181,6 +182,17 @@ jobs:
           elixir-version: '1.16'
           otp-version: '26.0'
 
+      - name: Set up Perl
+        if: needs.detect.outputs.needs_perl == 'true'
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: '5.40'
+
+      - name: Install Perl test deps
+        if: needs.detect.outputs.needs_perl == 'true'
+        shell: bash
+        run: cpanm --quiet --notest Test2::Suite
+
       - name: Install test runners
         shell: bash
         run: |
@@ -215,6 +227,9 @@ jobs:
           if [ "${{ needs.detect.outputs.needs_elixir }}" = "true" ]; then
             echo "Elixir: $(elixir --version)"
             echo "Mix: $(mix --version)"
+          fi
+          if [ "${{ needs.detect.outputs.needs_perl }}" = "true" ]; then
+            echo "Perl: $(perl --version | head -2)"
           fi
 
       # ── Download build plan (skip discovery in build job) ─────

--- a/code/packages/perl/trig/BUILD
+++ b/code/packages/perl/trig/BUILD
@@ -1,0 +1,1 @@
+prove -l t/

--- a/code/packages/perl/trig/CHANGELOG.md
+++ b/code/packages/perl/trig/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/).
+
+## [0.1.0] - 2026-03-22
+
+### Added
+
+- Initial implementation of trigonometric functions from first principles
+- `sin_taylor` — sine via Maclaurin series (20 terms)
+- `cos_taylor` — cosine via Maclaurin series (20 terms)
+- `radians` — degree to radian conversion
+- `degrees` — radian to degree conversion
+- `PI` constant to full double-precision accuracy
+- Range reduction to [-pi, pi] for accuracy with large inputs
+- Comprehensive test suite (special values, symmetry, Pythagorean identity, large inputs, conversions)

--- a/code/packages/perl/trig/README.md
+++ b/code/packages/perl/trig/README.md
@@ -1,0 +1,44 @@
+# trig
+
+Trigonometric functions implemented from first principles using Taylor (Maclaurin) series. No math library is used — everything is built from basic arithmetic.
+
+## Layer
+
+**PHY00** — this is a leaf package with no dependencies. It is used by the `wave` package.
+
+## What it does
+
+This package implements `sin_taylor` and `cos_taylor` by summing terms of their Maclaurin series expansions. Range reduction normalizes inputs to [-pi, pi] before evaluation, ensuring accuracy even for very large angles.
+
+## API
+
+| Function            | Description                                      |
+|---------------------|--------------------------------------------------|
+| `PI`                | Pi constant to double-precision accuracy         |
+| `sin_taylor($x)`    | Sine of x (radians) via Maclaurin series         |
+| `cos_taylor($x)`    | Cosine of x (radians) via Maclaurin series       |
+| `radians($deg)`     | Convert degrees to radians                       |
+| `degrees($rad)`     | Convert radians to degrees                       |
+
+## Usage
+
+```perl
+use CodingAdventures::Trig qw(sin_taylor cos_taylor radians degrees PI);
+
+say sin_taylor(PI / 2);      # 1.0
+say cos_taylor(0);            # 1.0
+say sin_taylor(radians(30));  # 0.5
+say degrees(PI);              # 180.0
+```
+
+## How it works
+
+The Maclaurin series for sine is:
+
+    sin(x) = x - x^3/3! + x^5/5! - x^7/7! + ...
+
+Each term is computed iteratively from the previous term to avoid large intermediate factorials:
+
+    term_{n+1} = term_n * (-x^2) / ((2n+2)(2n+3))
+
+Cosine follows the same pattern with even powers. Twenty terms are computed, yielding full double-precision accuracy for any input.

--- a/code/packages/perl/trig/cpanfile
+++ b/code/packages/perl/trig/cpanfile
@@ -1,0 +1,5 @@
+requires 'perl', '5.040';
+
+on 'test' => sub {
+    requires 'Test2::V0';
+};

--- a/code/packages/perl/trig/lib/CodingAdventures/Trig.pm
+++ b/code/packages/perl/trig/lib/CodingAdventures/Trig.pm
@@ -1,0 +1,255 @@
+use v5.40;
+
+# ---------------------------------------------------------------------------
+# CodingAdventures::Trig — Trigonometric functions from first principles
+# ---------------------------------------------------------------------------
+
+=head1 NAME
+
+CodingAdventures::Trig - Trigonometric functions from first principles
+
+=head1 DESCRIPTION
+
+This module implements sine and cosine using B<Taylor series> (specifically,
+Maclaurin series -- Taylor series centered at zero).  No math library is used;
+everything is built from addition, multiplication, and division alone.
+
+=head2 Why Taylor series?
+
+Any "smooth" function can be approximated near a point by a polynomial.  The
+idea, due to Brook Taylor (1715), is:
+
+    f(x) = f(0) + f'(0)*x + f''(0)*x^2/2! + f'''(0)*x^3/3! + ...
+
+When centered at zero this is called a B<Maclaurin series>.  For sine and
+cosine the derivatives cycle through a simple pattern, giving us concrete
+formulas we can compute with just arithmetic.
+
+=head2 How accurate is this?
+
+With 20 terms and range reduction to [-pi, pi], we achieve accuracy matching
+IEEE 754 double-precision (~15 decimal digits) for all inputs, including very
+large ones like sin(1000*pi).
+
+=cut
+
+package CodingAdventures::Trig;
+use Exporter 'import';
+
+our @EXPORT_OK = qw(PI sin_taylor cos_taylor radians degrees);
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Pi to full double-precision accuracy.  This is the ratio of a circle's
+# circumference to its diameter -- the most important constant in
+# trigonometry.  We hard-code it here rather than computing it so that every
+# other function in the module can use it without circular imports.
+
+use constant PI => 3.141592653589793;
+
+# Two-pi comes up constantly in range reduction (see below).  A full
+# rotation around the unit circle is 2*pi radians, so adding or subtracting
+# 2*pi from an angle doesn't change its sine or cosine.
+
+use constant TWO_PI => 2 * PI;
+
+
+# ---------------------------------------------------------------------------
+# Range Reduction
+# ---------------------------------------------------------------------------
+
+=head2 Range reduction
+
+The Taylor series converges for I<any> real number, but converges B<faster>
+when x is small.  If someone passes in x = 1000*pi, the raw series would
+need hundreds of terms to cancel out the enormous intermediate values.  By
+first reducing x into [-pi, pi], 20 terms are more than enough.
+
+Since sin and cos are B<periodic> with period 2*pi:
+
+    sin(x) = sin(x - 2*pi*k)    for any integer k
+
+we use Perl's modulo operator to bring x into [0, 2*pi), then shift by -pi
+to land in [-pi, pi).
+
+=cut
+
+sub _range_reduce($x) {
+    # Step 1: bring x into [0, 2*pi) using the modulo operator.
+    # Perl's fmod (%) can return negative values for negative inputs,
+    # so we adjust to ensure non-negative results.
+    $x = $x - TWO_PI * int($x / TWO_PI);
+
+    # Ensure x is in [0, 2*pi) — handle negative remainders.
+    $x += TWO_PI if $x < 0;
+
+    # Step 2: shift from [0, 2*pi) to [-pi, pi).
+    # Values greater than pi get wrapped to the negative side.
+    $x -= TWO_PI if $x > PI;
+
+    return $x;
+}
+
+
+# ---------------------------------------------------------------------------
+# Sine — The Maclaurin Series
+# ---------------------------------------------------------------------------
+
+=head2 sin_taylor($x)
+
+Compute the sine of C<$x> (in radians) using the Maclaurin series.
+
+The Maclaurin series for sine:
+
+    sin(x) = x - x^3/3! + x^5/5! - x^7/7! + ...
+
+Written with sigma notation:
+
+             inf
+    sin(x) = SUM  (-1)^n * x^(2n+1) / (2n+1)!
+             n=0
+
+B<Computing iteratively (the key trick):>
+
+Rather than computing each term from scratch (which would require computing
+large factorials and large powers), we compute each term B<from the previous
+one>.  The ratio of consecutive terms simplifies to:
+
+    term_{n+1} = term_n * (-x^2) / ((2n+2) * (2n+3))
+
+This is beautiful: each new term is just the old term multiplied by a small
+fraction.  No factorials, no large powers -- just one multiply and one
+divide per iteration.
+
+=cut
+
+sub sin_taylor($x) {
+    # --- Range reduction first ---
+    # Bring x into [-pi, pi] so the series converges rapidly.
+    $x = _range_reduce($x);
+
+    # --- Series computation ---
+    # The first term (n=0) of the Maclaurin series for sin is simply x.
+    my $term  = $x;    # current term: (-1)^n * x^(2n+1) / (2n+1)!
+    my $total = $x;    # running sum of all terms so far
+
+    # We'll compute 20 terms total (n=0 through n=19).  In practice the
+    # series converges well before 20 terms for inputs in [-pi, pi], but
+    # extra terms cost almost nothing and guarantee full precision.
+    for my $n (1 .. 19) {
+        # Compute the multiplier to go from term_{n-1} to term_n:
+        #
+        #   term_n = term_{n-1} * (-x^2) / ((2n) * (2n+1))
+        my $denominator = (2 * $n) * (2 * $n + 1);
+        $term = $term * (-$x * $x) / $denominator;
+        $total += $term;
+    }
+
+    return $total;
+}
+
+
+# ---------------------------------------------------------------------------
+# Cosine — The Maclaurin Series
+# ---------------------------------------------------------------------------
+
+=head2 cos_taylor($x)
+
+Compute the cosine of C<$x> (in radians) using the Maclaurin series.
+
+The Maclaurin series for cosine:
+
+    cos(x) = 1 - x^2/2! + x^4/4! - x^6/6! + ...
+
+The iterative recurrence:
+
+    term_{n+1} = term_n * (-x^2) / ((2n+1) * (2n+2))
+
+Almost identical to sine -- only the denominator indices shift by one.
+This makes sense: cosine uses even powers (0, 2, 4, ...) while sine uses
+odd powers (1, 3, 5, ...).
+
+=cut
+
+sub cos_taylor($x) {
+    # --- Range reduction first ---
+    $x = _range_reduce($x);
+
+    # --- Series computation ---
+    # The first term (n=0) of the Maclaurin series for cos is 1.
+    my $term  = 1.0;   # current term: (-1)^n * x^(2n) / (2n)!
+    my $total = 1.0;   # running sum
+
+    for my $n (1 .. 19) {
+        # Going from term at index (n-1) to term at index n:
+        #
+        #   term_n = term_{n-1} * (-x^2) / ((2n-1) * (2n))
+        my $denominator = (2 * $n - 1) * (2 * $n);
+        $term = $term * (-$x * $x) / $denominator;
+        $total += $term;
+    }
+
+    return $total;
+}
+
+
+# ---------------------------------------------------------------------------
+# Degree / Radian Conversion
+# ---------------------------------------------------------------------------
+
+=head2 radians($deg)
+
+Convert an angle from degrees to radians.
+
+Degrees are a human convenience (360 per full turn, inherited from
+Babylonian base-60 arithmetic).  Radians are the I<natural> unit for
+angles in mathematics: one radian is the angle subtended by an arc whose
+length equals the radius.  A full circle is 2*pi radians.
+
+The conversion is straightforward:
+
+    radians = degrees * (pi / 180)
+
+=cut
+
+sub radians($deg) {
+    return $deg * PI / 180;
+}
+
+
+=head2 degrees($rad)
+
+Convert an angle from radians to degrees.
+
+This is simply the inverse of the C<radians()> function:
+
+    degrees = radians * (180 / pi)
+
+=cut
+
+sub degrees($rad) {
+    return $rad * 180 / PI;
+}
+
+
+1;  # Perl modules must return a true value
+
+__END__
+
+=head1 SYNOPSIS
+
+    use CodingAdventures::Trig qw(sin_taylor cos_taylor radians degrees PI);
+
+    say sin_taylor(PI / 2);      # 1.0
+    say cos_taylor(0);            # 1.0
+    say sin_taylor(radians(30));  # 0.5
+    say degrees(PI);              # 180.0
+
+=head1 SEE ALSO
+
+L<CodingAdventures::Wave> -- wave physics package that uses this module
+
+=cut

--- a/code/packages/perl/trig/t/01-trig.t
+++ b/code/packages/perl/trig/t/01-trig.t
@@ -1,0 +1,157 @@
+use v5.40;
+use Test2::V0;
+
+# ---------------------------------------------------------------------------
+# Tests for CodingAdventures::Trig
+#
+# These tests verify our from-scratch Taylor series implementations of sin
+# and cos against known mathematical identities and special values.  We use
+# an absolute tolerance of 1e-10 throughout.
+# ---------------------------------------------------------------------------
+
+use CodingAdventures::Trig qw(sin_taylor cos_taylor radians degrees PI);
+
+# Tolerance used for all approximate comparisons.
+my $TOL = 1e-10;
+
+# Helper: check that a value is approximately equal to an expected value.
+sub approx_is($got, $expected, $msg) {
+    ok(abs($got - $expected) < $TOL, $msg // "expected $expected, got $got");
+}
+
+
+# ---------------------------------------------------------------------------
+# Special values — sin
+# ---------------------------------------------------------------------------
+
+subtest 'sin special values' => sub {
+    is(sin_taylor(0), 0, 'sin(0) is exactly 0');
+
+    approx_is(sin_taylor(PI / 2), 1.0, 'sin(pi/2) = 1');
+    approx_is(sin_taylor(PI), 0.0, 'sin(pi) = 0');
+    approx_is(sin_taylor(3 * PI / 2), -1.0, 'sin(3*pi/2) = -1');
+    approx_is(sin_taylor(2 * PI), 0.0, 'sin(2*pi) = 0');
+
+    # Common reference angles
+    approx_is(sin_taylor(PI / 6), 0.5, 'sin(pi/6) = 0.5');
+    approx_is(sin_taylor(PI / 4), 0.7071067811865476, 'sin(pi/4) = sqrt(2)/2');
+    approx_is(sin_taylor(PI / 3), 0.8660254037844386, 'sin(pi/3) = sqrt(3)/2');
+};
+
+
+# ---------------------------------------------------------------------------
+# Special values — cos
+# ---------------------------------------------------------------------------
+
+subtest 'cos special values' => sub {
+    is(cos_taylor(0), 1.0, 'cos(0) is exactly 1');
+
+    approx_is(cos_taylor(PI / 2), 0.0, 'cos(pi/2) = 0');
+    approx_is(cos_taylor(PI), -1.0, 'cos(pi) = -1');
+    approx_is(cos_taylor(3 * PI / 2), 0.0, 'cos(3*pi/2) = 0');
+    approx_is(cos_taylor(2 * PI), 1.0, 'cos(2*pi) = 1');
+
+    # Common reference angles
+    approx_is(cos_taylor(PI / 6), 0.8660254037844386, 'cos(pi/6) = sqrt(3)/2');
+    approx_is(cos_taylor(PI / 4), 0.7071067811865476, 'cos(pi/4) = sqrt(2)/2');
+    approx_is(cos_taylor(PI / 3), 0.5, 'cos(pi/3) = 0.5');
+};
+
+
+# ---------------------------------------------------------------------------
+# Symmetry properties
+# ---------------------------------------------------------------------------
+
+subtest 'sin is odd: sin(-x) = -sin(x)' => sub {
+    for my $x (0.5, 1.0, 1.5, 2.0, 2.7, PI / 4, PI / 3) {
+        approx_is(sin_taylor(-$x), -sin_taylor($x),
+                  "sin(-$x) = -sin($x)");
+    }
+};
+
+subtest 'cos is even: cos(-x) = cos(x)' => sub {
+    for my $x (0.5, 1.0, 1.5, 2.0, 2.7, PI / 4, PI / 3) {
+        approx_is(cos_taylor(-$x), cos_taylor($x),
+                  "cos(-$x) = cos($x)");
+    }
+};
+
+
+# ---------------------------------------------------------------------------
+# Pythagorean identity: sin^2(x) + cos^2(x) = 1
+# ---------------------------------------------------------------------------
+
+subtest 'Pythagorean identity' => sub {
+    my @test_angles = (
+        0, PI / 6, PI / 4, PI / 3, PI / 2, PI,
+        3 * PI / 2, 2 * PI, -1.0, -2.5, 0.1, 3.0, 5.5,
+    );
+
+    for my $x (@test_angles) {
+        my $s = sin_taylor($x);
+        my $c = cos_taylor($x);
+        approx_is($s * $s + $c * $c, 1.0,
+                  "sin^2($x) + cos^2($x) = 1");
+    }
+};
+
+
+# ---------------------------------------------------------------------------
+# Large inputs (tests range reduction)
+# ---------------------------------------------------------------------------
+
+subtest 'large inputs' => sub {
+    approx_is(sin_taylor(1000 * PI), 0.0, 'sin(1000*pi) = 0');
+    approx_is(cos_taylor(1000 * PI), 1.0, 'cos(1000*pi) = 1');
+
+    # sin(100) should satisfy the Pythagorean identity
+    my $s = sin_taylor(100);
+    my $c = cos_taylor(100);
+    approx_is($s * $s + $c * $c, 1.0, 'Pythagorean identity at x=100');
+
+    # sin(-100) = -sin(100)
+    approx_is(sin_taylor(-100), -sin_taylor(100), 'sin(-100) = -sin(100)');
+};
+
+
+# ---------------------------------------------------------------------------
+# Degree / Radian conversions
+# ---------------------------------------------------------------------------
+
+subtest 'degree/radian conversion' => sub {
+    approx_is(radians(180), PI, '180 degrees = pi radians');
+    approx_is(radians(90), PI / 2, '90 degrees = pi/2 radians');
+    approx_is(radians(360), 2 * PI, '360 degrees = 2*pi radians');
+    is(radians(0), 0.0, '0 degrees = 0 radians');
+
+    approx_is(degrees(PI), 180.0, 'pi radians = 180 degrees');
+    approx_is(degrees(PI / 2), 90.0, 'pi/2 radians = 90 degrees');
+    is(degrees(0), 0.0, '0 radians = 0 degrees');
+};
+
+subtest 'round-trip conversions' => sub {
+    for my $deg (0, 30, 45, 60, 90, 120, 180, 270, 360) {
+        approx_is(degrees(radians($deg)), $deg,
+                  "degrees(radians($deg)) = $deg");
+    }
+
+    for my $rad (0, PI / 6, PI / 4, PI / 3, PI / 2, PI, 2 * PI) {
+        approx_is(radians(degrees($rad)), $rad,
+                  "radians(degrees($rad)) = $rad");
+    }
+};
+
+
+# ---------------------------------------------------------------------------
+# Integration: sin and cos with degree input
+# ---------------------------------------------------------------------------
+
+subtest 'sin/cos with degree input' => sub {
+    approx_is(sin_taylor(radians(30)), 0.5, 'sin(30 degrees) = 0.5');
+    approx_is(cos_taylor(radians(60)), 0.5, 'cos(60 degrees) = 0.5');
+    approx_is(sin_taylor(radians(45)), 0.7071067811865476,
+              'sin(45 degrees) = sqrt(2)/2');
+};
+
+
+done_testing;

--- a/code/programs/go/build-tool/detect_languages_test.go
+++ b/code/programs/go/build-tool/detect_languages_test.go
@@ -15,7 +15,7 @@ import (
 func TestAllLanguagesConstant(t *testing.T) {
 	expected := map[string]bool{
 		"python": true, "ruby": true, "go": true,
-		"typescript": true, "rust": true, "elixir": true,
+		"typescript": true, "rust": true, "elixir": true, "perl": true,
 	}
 	if len(allLanguages) != len(expected) {
 		t.Errorf("allLanguages has %d entries, want %d", len(allLanguages), len(expected))

--- a/code/programs/go/build-tool/internal/resolver/resolver.go
+++ b/code/programs/go/build-tool/internal/resolver/resolver.go
@@ -379,6 +379,44 @@ func parseElixirDeps(pkg discovery.Package, knownNames map[string]string) []stri
 	return internalDeps
 }
 
+// parsePerlDeps extracts internal dependencies from a Perl cpanfile.
+//
+// Perl cpanfiles declare dependencies like:
+//
+//	requires 'CodingAdventures::LogicGates';
+//
+// We look for lines referencing the CodingAdventures:: namespace and map
+// them to internal package names via the knownNames table.
+func parsePerlDeps(pkg discovery.Package, knownNames map[string]string) []string {
+	cpanfile := filepath.Join(pkg.Path, "cpanfile")
+	data, err := os.ReadFile(cpanfile)
+	if err != nil {
+		return nil
+	}
+
+	text := string(data)
+	var internalDeps []string
+
+	// Match: requires 'CodingAdventures::SomeName' or requires "CodingAdventures::SomeName"
+	re := regexp.MustCompile(`requires\s+['"]CodingAdventures::([A-Za-z0-9:]+)['"]`)
+	for _, line := range strings.Split(text, "\n") {
+		trimmed := strings.TrimSpace(line)
+		for _, match := range re.FindAllStringSubmatch(trimmed, -1) {
+			if len(match) < 2 {
+				continue
+			}
+			// Convert CodingAdventures::ModuleName to lowercase lookup key
+			// e.g. "LogicGates" → "codingadventures::logicgates"
+			moduleName := strings.ToLower("codingadventures::" + match[1])
+			if pkgName, ok := knownNames[moduleName]; ok {
+				internalDeps = append(internalDeps, pkgName)
+			}
+		}
+	}
+
+	return internalDeps
+}
+
 // buildKnownNames creates a mapping from ecosystem-specific dependency names
 // to our internal package names.
 //
@@ -436,6 +474,20 @@ func buildKnownNames(packages []discovery.Package) map[string]string {
 			// Elixir mix names replace hyphens with underscores: "logic-gates" → "coding_adventures_logic_gates"
 			appName := "coding_adventures_" + strings.ReplaceAll(strings.ToLower(filepath.Base(pkg.Path)), "-", "_")
 			known[appName] = pkg.Name
+
+		case "perl":
+			// Perl module names use CamelCase: "logic-gates" → "CodingAdventures::LogicGates"
+			// We map the kebab-case directory name to the Perl namespace.
+			dirName := strings.ToLower(filepath.Base(pkg.Path))
+			// Build the CodingAdventures::PascalCase module name from kebab-case dir.
+			parts := strings.Split(dirName, "-")
+			for i, part := range parts {
+				if len(part) > 0 {
+					parts[i] = strings.ToUpper(part[:1]) + part[1:]
+				}
+			}
+			perlName := "codingadventures::" + strings.ToLower(strings.Join(parts, ""))
+			known[perlName] = pkg.Name
 		}
 	}
 
@@ -479,6 +531,8 @@ func ResolveDependencies(packages []discovery.Package) *directedgraph.Graph {
 			deps = parseRustDeps(pkg, knownNames)
 		case "elixir":
 			deps = parseElixirDeps(pkg, knownNames)
+		case "perl":
+			deps = parsePerlDeps(pkg, knownNames)
 		}
 
 		for _, depName := range deps {

--- a/code/programs/go/build-tool/main.go
+++ b/code/programs/go/build-tool/main.go
@@ -379,7 +379,7 @@ func run() int {
 
 // allLanguages is the canonical list of supported languages in the monorepo.
 // The order is stable and matches the order used in CI toolchain setup.
-var allLanguages = []string{"python", "ruby", "go", "typescript", "rust", "elixir"}
+var allLanguages = []string{"python", "ruby", "go", "typescript", "rust", "elixir", "perl"}
 
 // sharedPrefixes are path prefixes that, when changed, mean ALL languages
 // need rebuilding. These are cross-cutting concerns:

--- a/code/specs/perl-port.md
+++ b/code/specs/perl-port.md
@@ -1,0 +1,437 @@
+# Perl Port Specification
+
+## Overview
+
+Port the entire coding-adventures monorepo to Perl, making it the 7th supported
+language alongside Python, Ruby, Go, Rust, TypeScript, and Elixir.
+
+**Target:** Perl 5.40+ (native `class` syntax, subroutine signatures, `try/catch`)
+
+---
+
+## Motivation
+
+Perl is one of the foundational scripting languages — it pioneered many of the
+ideas that Python, Ruby, and JavaScript later adopted (regular expressions as
+first-class citizens, CPAN as the model for package repositories, "There's More
+Than One Way To Do It" philosophy). Adding Perl to the monorepo:
+
+1. Exercises Perl's modern features (native `class` from 5.38+, signatures from
+   5.36+, `try/catch` from 5.40+) which are largely unknown to developers who
+   only know "legacy" Perl.
+2. Tests portability of algorithms across a 7th paradigm (Perl's unique blend of
+   procedural, OO, and functional styles).
+3. Provides a practical exploration of Perl's package management ecosystem
+   (CPAN, cpanm, cpanfile, Carton, Dist::Zilla).
+
+---
+
+## Perl Tooling Stack
+
+| Concern            | Tool              | Equivalent in Python    |
+|--------------------|-------------------|------------------------|
+| Runtime            | Perl 5.40+ (mise) | Python 3.12+ (mise)    |
+| Package repository | CPAN (MetaCPAN)   | PyPI                   |
+| Dep declaration    | `cpanfile`        | `pyproject.toml`       |
+| Lock file          | `cpanfile.snapshot`| `uv.lock`              |
+| Installer          | `cpanm` / `cpm`   | `uv` / `pip`           |
+| Build/release      | Dist::Zilla       | hatchling              |
+| Testing            | Test2::V0 + prove | pytest                 |
+| Linting            | Perl::Critic      | ruff                   |
+| Formatting         | Perl::Tidy        | ruff format / black     |
+| OOP                | native `class`    | built-in classes       |
+| Type constraints   | Type::Tiny        | type hints + mypy      |
+| Coverage           | Devel::Cover      | pytest-cov             |
+
+---
+
+## Package Structure
+
+Every Perl package follows this layout:
+
+```
+code/packages/perl/package-name/
+  BUILD                           # Test command (prove -l t/)
+  README.md                       # Package documentation
+  CHANGELOG.md                    # Keep a Changelog format
+  cpanfile                        # Dependencies
+  lib/
+    CodingAdventures/
+      PackageName.pm              # Main module
+      PackageName/
+        SubModule.pm              # Sub-modules (if needed)
+  t/
+    01-basic.t                    # Tests (Test2::V0)
+    02-advanced.t
+```
+
+### Naming Convention
+
+- **Directory:** `code/packages/perl/package-name/` (kebab-case)
+- **Module namespace:** `CodingAdventures::PackageName` (CamelCase)
+- **CPAN distribution name:** `CodingAdventures-PackageName`
+
+### BUILD File Patterns
+
+Standalone package (no internal deps):
+```
+prove -l t/
+```
+
+Package with internal dependencies:
+```
+prove -l -I ../dep-a/lib -I ../dep-b/lib t/
+```
+
+### cpanfile Pattern
+
+```perl
+requires 'perl', '5.040';
+
+on 'test' => sub {
+    requires 'Test2::V0';
+};
+```
+
+---
+
+## Perl Idioms & Patterns
+
+### Pure Function Modules
+
+For packages that are collections of functions (trig, matrix, logic-gates):
+
+```perl
+use v5.40;
+
+package CodingAdventures::Trig;
+use Exporter 'import';
+our @EXPORT_OK = qw(sin_taylor cos_taylor tan_taylor PI deg_to_rad rad_to_deg);
+
+use constant PI => 3.141592653589793;
+
+# ---------------------------------------------------------------------------
+# Range Reduction
+# ---------------------------------------------------------------------------
+#
+# The Taylor series converges for any x, but converges *faster* when x is
+# small. We normalize x into [-pi, pi] by subtracting multiples of 2*pi.
+# This doesn't change the value of sin/cos because they're periodic.
+
+sub _range_reduce($x) {
+    my $TWO_PI = 2 * PI;
+    $x -= $TWO_PI * int($x / $TWO_PI + 0.5);
+    return $x;
+}
+
+sub sin_taylor($x, $terms = 20) {
+    $x = _range_reduce($x);
+    my $result = 0;
+    my $power  = $x;
+    my $fact   = 1;
+    for my $n (0 .. $terms - 1) {
+        $result += ((-1) ** $n) * $power / $fact;
+        $power  *= $x * $x;
+        $fact   *= (2 * $n + 2) * (2 * $n + 3);
+    }
+    return $result;
+}
+```
+
+### Native Class Syntax (Perl 5.38+)
+
+For packages that model objects (wave, cache, cpu-simulator):
+
+```perl
+use v5.40;
+use feature 'class';
+
+class CodingAdventures::Wave {
+    field $amplitude  :param :reader;
+    field $frequency  :param :reader;
+    field $wavelength :param :reader;
+    field $phase      :param :reader = 0;
+
+    method period() {
+        return 1.0 / $frequency;
+    }
+
+    method velocity() {
+        return $frequency * $wavelength;
+    }
+
+    method displacement($x, $t) {
+        my $angular_freq = 2 * CodingAdventures::Trig::PI * $frequency;
+        my $wave_number  = 2 * CodingAdventures::Trig::PI / $wavelength;
+        return $amplitude * CodingAdventures::Trig::sin_taylor(
+            $wave_number * $x - $angular_freq * $t + $phase
+        );
+    }
+}
+```
+
+### Tests with Test2::V0
+
+```perl
+use v5.40;
+use Test2::V0;
+
+use lib '../trig/lib';
+use CodingAdventures::Trig qw(sin_taylor cos_taylor PI);
+
+subtest 'sin(0) = 0' => sub {
+    is(sin_taylor(0), 0, 'sin(0) should be 0');
+};
+
+subtest 'sin(pi/2) approximates 1' => sub {
+    ok(abs(sin_taylor(PI / 2) - 1.0) < 1e-10,
+       'sin(pi/2) should be 1 within 1e-10');
+};
+
+subtest 'Pythagorean identity' => sub {
+    for my $angle (0, 0.5, 1.0, 1.5, 2.0, PI, PI / 4) {
+        my $s = sin_taylor($angle);
+        my $c = cos_taylor($angle);
+        ok(abs($s**2 + $c**2 - 1.0) < 1e-10,
+           "sin^2 + cos^2 = 1 for angle $angle");
+    }
+};
+
+done_testing;
+```
+
+### Literate Programming with POD
+
+All Perl modules use POD (Plain Old Documentation) interleaved with code:
+
+```perl
+=head1 NAME
+
+CodingAdventures::Trig - Trigonometric functions from first principles
+
+=head1 DESCRIPTION
+
+This module implements sine and cosine using B<Taylor series> (specifically,
+Maclaurin series -- Taylor series centered at zero). No math library is used;
+everything is built from addition, multiplication, and division alone.
+
+=head2 Why Taylor series?
+
+Any "smooth" function can be approximated near a point by a polynomial. The
+idea, due to Brook Taylor (1715), is:
+
+    f(x) = f(0) + f'(0)*x + f''(0)*x^2/2! + f'''(0)*x^3/3! + ...
+
+When centered at zero this is called a B<Maclaurin series>. For sine and
+cosine the derivatives cycle through a simple pattern, giving us concrete
+formulas we can compute with just arithmetic.
+
+=cut
+
+# Implementation follows...
+```
+
+Additionally, inline `#` comments explain logic step-by-step, with truth
+tables, ASCII diagrams, and worked examples — matching the literate style
+used in all other languages.
+
+---
+
+## Build Tool Integration
+
+### Files to Modify
+
+1. **`code/programs/go/build-tool/main.go`**
+   - Add `"perl"` to the `allLanguages` slice
+
+2. **`code/programs/go/build-tool/detect_languages_test.go`**
+   - Add `"perl": true` to the expected languages map
+
+3. **`code/programs/go/build-tool/internal/resolver/resolver.go`**
+   - Add `case "perl":` to `buildKnownNames()`:
+     ```go
+     case "perl":
+         cpanName := "codingadventures-" + strings.ReplaceAll(
+             strings.ToLower(filepath.Base(pkg.Path)), "-", "")
+         known[cpanName] = pkg.Name
+     ```
+   - Add `case "perl":` to the dependency parsing switch
+   - Add `parsePerlDeps()` function to parse `cpanfile` for
+     `requires 'CodingAdventures::...'` lines
+
+4. **`code/programs/go/build-tool/internal/resolver/resolver_test.go`**
+   - Add Perl test cases for name mapping and dependency parsing
+
+5. **`.github/workflows/build.yml`** (or equivalent)
+   - Add Perl setup: `shogo82148/actions-setup-perl@v1` with `perl-version: '5.40'`
+   - Install test deps: `cpanm Test2::V0 Devel::Cover`
+
+6. **`mise.toml`**
+   - Add `perl = "5.40"`
+
+---
+
+## Porting Order
+
+Packages are ordered by dependency layer — leaf packages first, then packages
+that depend on them. Within each phase, packages can be ported in any order
+(they are independent of each other).
+
+### Phase 0: Infrastructure Setup
+- Install Perl 5.40+ via mise
+- Install tooling (cpanm, Test2::V0, Devel::Cover, Perl::Critic, Perl::Tidy)
+- Update build tool for Perl support
+- Create shared `.perlcriticrc` and `.perltidyrc`
+
+### Phase 1: Standalone Leaf Packages (11 packages)
+
+| # | Package | Module | Description |
+|---|---------|--------|-------------|
+| 1.1 | trig | CodingAdventures::Trig | Taylor series sin/cos/tan |
+| 1.2 | wave | CodingAdventures::Wave | Wave physics (depends on trig) |
+| 1.3 | progress-bar | CodingAdventures::ProgressBar | Terminal progress display |
+| 1.4 | clock | CodingAdventures::Clock | Cycle-accurate clock |
+| 1.5 | display | CodingAdventures::Display | Output utilities |
+| 1.6 | tree | CodingAdventures::Tree | AST node representation |
+| 1.7 | grammar-tools | CodingAdventures::GrammarTools | Grammar file utilities |
+| 1.8 | fp-arithmetic | CodingAdventures::FPArithmetic | IEEE 754 floats |
+| 1.9 | matrix | CodingAdventures::Matrix | Linear algebra |
+| 1.10 | directed-graph | CodingAdventures::DirectedGraph | Graph + topological sort |
+| 1.11 | brainfuck | CodingAdventures::Brainfuck | Brainfuck interpreter |
+
+### Phase 2: Core Infrastructure (6 packages)
+
+| # | Package | Module | Deps |
+|---|---------|--------|------|
+| 2.1 | state-machine | CodingAdventures::StateMachine | directed-graph |
+| 2.2 | logic-gates | CodingAdventures::LogicGates | (none) |
+| 2.3 | transistors | CodingAdventures::Transistors | (none) |
+| 2.4 | activation-functions | CodingAdventures::ActivationFunctions | (none) |
+| 2.5 | loss-functions | CodingAdventures::LossFunctions | (none) |
+| 2.6 | gradient-descent | CodingAdventures::GradientDescent | (none) |
+
+### Phase 3: Hardware Stack (9 packages)
+
+| # | Package | Module | Deps |
+|---|---------|--------|------|
+| 3.1 | arithmetic | CodingAdventures::Arithmetic | logic-gates |
+| 3.2 | block-ram | CodingAdventures::BlockRAM | logic-gates |
+| 3.3 | cpu-simulator | CodingAdventures::CPUSimulator | arithmetic, logic-gates |
+| 3.4 | branch-predictor | CodingAdventures::BranchPredictor | state-machine |
+| 3.5 | hazard-detection | CodingAdventures::HazardDetection | (none) |
+| 3.6 | cache | CodingAdventures::Cache | clock |
+| 3.7 | cpu-pipeline | CodingAdventures::CPUPipeline | (none) |
+| 3.8 | core | CodingAdventures::Core | cache, branch-predictor, hazard-detection, cpu-pipeline |
+| 3.9 | fpga | CodingAdventures::FPGA | logic-gates, block-ram |
+
+### Phase 4: Compiler Infrastructure (6 packages)
+
+| # | Package | Module | Deps |
+|---|---------|--------|------|
+| 4.1 | lexer | CodingAdventures::Lexer | grammar-tools |
+| 4.2 | parser | CodingAdventures::Parser | lexer, tree |
+| 4.3 | virtual-machine | CodingAdventures::VirtualMachine | (none) |
+| 4.4 | bytecode-compiler | CodingAdventures::BytecodeCompiler | tree, virtual-machine |
+| 4.5 | assembler | CodingAdventures::Assembler | cpu-simulator |
+| 4.6 | cli-builder | CodingAdventures::CLIBuilder | directed-graph, state-machine |
+
+### Phase 5: Language Lexers & Parsers (17 packages)
+
+All depend on `lexer` and/or `parser`:
+- json-lexer, json-parser
+- toml-lexer, toml-parser
+- css-lexer, css-parser
+- xml-lexer
+- python-lexer, python-parser
+- ruby-lexer, ruby-parser
+- javascript-lexer, javascript-parser
+- typescript-lexer, typescript-parser
+- starlark-lexer, starlark-parser
+
+### Phase 6: ISA Simulators (7 packages)
+
+| # | Package | Module | Deps |
+|---|---------|--------|------|
+| 6.1 | intel4004-simulator | CodingAdventures::Intel4004Simulator | virtual-machine |
+| 6.2 | jvm-simulator | CodingAdventures::JVMSimulator | virtual-machine |
+| 6.3 | clr-simulator | CodingAdventures::CLRSimulator | virtual-machine |
+| 6.4 | riscv-simulator | CodingAdventures::RISCVSimulator | cpu-simulator |
+| 6.5 | arm-simulator | CodingAdventures::ARMSimulator | cpu-simulator |
+| 6.6 | wasm-simulator | CodingAdventures::WASMSimulator | virtual-machine |
+| 6.7 | intel4004-gatelevel | CodingAdventures::Intel4004GateLevel | logic-gates, arithmetic |
+
+### Phase 7: ML Stack (6 packages)
+
+| # | Package | Module | Deps |
+|---|---------|--------|------|
+| 7.1 | perceptron | CodingAdventures::Perceptron | activation-functions |
+| 7.2 | blas-library | CodingAdventures::BLAS | matrix |
+| 7.3 | ml-framework-core | CodingAdventures::MLFramework::Core | matrix, activation-functions, loss-functions, gradient-descent |
+| 7.4 | ml-framework-keras | CodingAdventures::MLFramework::Keras | ml-framework-core |
+| 7.5 | ml-framework-tf | CodingAdventures::MLFramework::TF | ml-framework-core, ml-framework-keras |
+| 7.6 | ml-framework-torch | CodingAdventures::MLFramework::Torch | ml-framework-core |
+
+### Phase 8: GPU/Accelerator Stack (6 packages)
+
+gpu-core, parallel-execution-engine, compute-unit, device-simulator,
+compute-runtime, vendor-api-simulators
+
+### Phase 9: System Software Stack (11 packages)
+
+interrupt-handler, rom-bios, bootloader, os-kernel, device-driver-framework,
+virtual-memory, process-manager, file-system, ipc, network-stack, system-board
+
+### Phase 10: Lisp & Starlark Compilers (8 packages)
+
+lisp-lexer, lisp-parser, lisp-vm, lisp-compiler, starlark-compiler,
+starlark-interpreter, starlark-vm, starlark-ast-to-bytecode-compiler
+
+### Phase 11: Garbage Collector & JIT (2 packages)
+
+garbage-collector, jit-compiler
+
+### Phase 12: Programs (7+ programs)
+
+build-tool, scaffold-generator, unix-tools, celsius-to-fahrenheit-predictor,
+house-price-predictor, mansion-classifier, space-launch-predictor
+
+---
+
+## Verification Checklist
+
+For each package:
+- [ ] `prove -l t/` passes all tests
+- [ ] `perl -c lib/CodingAdventures/PackageName.pm` compiles cleanly
+- [ ] Coverage via Devel::Cover exceeds 80% (95%+ for libraries)
+- [ ] `perlcritic lib/` passes at severity 3+
+- [ ] BUILD file works from clean state
+- [ ] Build tool discovers the package
+- [ ] README.md documents purpose, usage, and examples
+- [ ] CHANGELOG.md records initial release
+- [ ] Literate programming style with POD and inline comments
+
+For the overall port:
+- [ ] `./build-tool --force` builds all Perl packages
+- [ ] CI workflow includes Perl in the language matrix
+- [ ] All ~96 packages + 7 programs ported and passing
+
+---
+
+## Package Count
+
+| Phase | Count | Description |
+|-------|-------|-------------|
+| 0 | 0 | Infrastructure setup |
+| 1 | 11 | Standalone leaf packages |
+| 2 | 6 | Core infrastructure |
+| 3 | 9 | Hardware stack |
+| 4 | 6 | Compiler infrastructure |
+| 5 | 17 | Language lexers/parsers |
+| 6 | 7 | ISA simulators |
+| 7 | 6 | ML stack |
+| 8 | 6 | GPU/accelerator |
+| 9 | 11 | System software |
+| 10 | 8 | Lisp & Starlark compilers |
+| 11 | 2 | GC & JIT |
+| 12 | 7+ | Programs |
+| **Total** | **~96 packages + 7 programs** | |

--- a/mise.toml
+++ b/mise.toml
@@ -2,3 +2,4 @@
 go = "latest"
 ruby = "3.4"
 rust = "stable"
+perl = "5.40"


### PR DESCRIPTION
## Summary

- Adds Perl 5.40+ as the 7th supported language in the monorepo
- Infrastructure: mise.toml, build tool resolver, CI workflow with `shogo82148/actions-setup-perl@v1`
- First Perl package: `trig` — Taylor series sin/cos from first principles
- Includes the full Perl port specification at `code/specs/perl-port.md` covering all 96 packages + 7 programs

## Test plan

- [x] `prove -l t/` passes all trig tests locally (Perl 5.40.2)
- [x] `perl -c lib/CodingAdventures/Trig.pm` compiles cleanly
- [x] Build tool compiles and all 11 test packages pass (`go test ./...`)
- [ ] CI detects Perl and installs the toolchain
- [ ] CI runs `prove -l t/` for the trig package

🤖 Generated with [Claude Code](https://claude.com/claude-code)