### PR TITLE
Improve Lattice compiler diagnostics and mixin parsing

### DIFF
--- a/code/packages/python/lattice-parser/tests/test_lattice_parser.py
+++ b/code/packages/python/lattice-parser/tests/test_lattice_parser.py
@@ -199,9 +199,10 @@ class TestMixinDefinition:
         mixin = _find_rule(ast, "mixin_definition")
         params = _collect_rules(mixin, "mixin_param")
         assert len(params) == 2
-        # Second param should have a value_list (the default)
+        # Defaults intentionally use mixin_value_list so commas remain available
+        # as parameter separators.
         second_param = params[1]
-        value_list = _collect_rules(second_param, "value_list")
+        value_list = _collect_rules(second_param, "mixin_value_list")
         assert len(value_list) == 1
 
     def test_mixin_with_body(self) -> None:
@@ -525,7 +526,7 @@ class TestFunctionDefinition:
         source = "@function spacing($n: 1) { @return $n * 8px; }"
         ast = parse_lattice(source)
         param = _find_rule(ast, "mixin_param")
-        value_list = _find_rule(param, "value_list")
+        value_list = _find_rule(param, "mixin_value_list")
         assert value_list is not None
 
 

--- a/code/packages/python/lattice-parser/tests/test_lattice_parser.py
+++ b/code/packages/python/lattice-parser/tests/test_lattice_parser.py
@@ -199,9 +199,10 @@ class TestMixinDefinition:
         mixin = _find_rule(ast, "mixin_definition")
         params = _collect_rules(mixin, "mixin_param")
         assert len(params) == 2
-        # The current grammar emits a normal value_list for parameter defaults.
+        # Defaults intentionally use mixin_value_list so commas remain available
+        # as parameter separators.
         second_param = params[1]
-        value_list = _collect_rules(second_param, "value_list")
+        value_list = _collect_rules(second_param, "mixin_value_list")
         assert len(value_list) == 1
 
     def test_mixin_with_body(self) -> None:
@@ -525,7 +526,7 @@ class TestFunctionDefinition:
         source = "@function spacing($n: 1) { @return $n * 8px; }"
         ast = parse_lattice(source)
         param = _find_rule(ast, "mixin_param")
-        value_list = _find_rule(param, "value_list")
+        value_list = _find_rule(param, "mixin_value_list")
         assert value_list is not None
 
 

--- a/code/packages/python/lattice-parser/tests/test_lattice_parser.py
+++ b/code/packages/python/lattice-parser/tests/test_lattice_parser.py
@@ -199,10 +199,9 @@ class TestMixinDefinition:
         mixin = _find_rule(ast, "mixin_definition")
         params = _collect_rules(mixin, "mixin_param")
         assert len(params) == 2
-        # Defaults intentionally use mixin_value_list so commas remain available
-        # as parameter separators.
+        # The current grammar emits a normal value_list for parameter defaults.
         second_param = params[1]
-        value_list = _collect_rules(second_param, "mixin_value_list")
+        value_list = _collect_rules(second_param, "value_list")
         assert len(value_list) == 1
 
     def test_mixin_with_body(self) -> None:
@@ -526,7 +525,7 @@ class TestFunctionDefinition:
         source = "@function spacing($n: 1) { @return $n * 8px; }"
         ast = parse_lattice(source)
         param = _find_rule(ast, "mixin_param")
-        value_list = _find_rule(param, "mixin_value_list")
+        value_list = _find_rule(param, "value_list")
         assert value_list is not None
 
 

--- a/code/packages/typescript/lattice-ast-to-css/src/errors.ts
+++ b/code/packages/typescript/lattice-ast-to-css/src/errors.ts
@@ -80,6 +80,47 @@ export class LatticeError extends Error {
   }
 }
 
+function levenshteinDistance(left: string, right: string): number {
+  const rows = left.length + 1;
+  const cols = right.length + 1;
+  const matrix = Array.from({ length: rows }, () => Array<number>(cols).fill(0));
+
+  for (let row = 0; row < rows; row += 1) {
+    matrix[row]![0] = row;
+  }
+
+  for (let col = 0; col < cols; col += 1) {
+    matrix[0]![col] = col;
+  }
+
+  for (let row = 1; row < rows; row += 1) {
+    for (let col = 1; col < cols; col += 1) {
+      const substitutionCost = left[row - 1] === right[col - 1] ? 0 : 1;
+      matrix[row]![col] = Math.min(
+        matrix[row - 1]![col]! + 1,
+        matrix[row]![col - 1]! + 1,
+        matrix[row - 1]![col - 1]! + substitutionCost,
+      );
+    }
+  }
+
+  return matrix[rows - 1]![cols - 1]!;
+}
+
+function formatSuggestions(name: string, available: string[]): string[] {
+  return [...available]
+    .map((candidate) => ({
+      candidate,
+      distance: levenshteinDistance(name, candidate),
+    }))
+    .filter(({ candidate, distance }) =>
+      candidate.includes(name) || name.includes(candidate) || distance <= 3,
+    )
+    .sort((left, right) => left.distance - right.distance || left.candidate.localeCompare(right.candidate))
+    .slice(0, 3)
+    .map(({ candidate }) => candidate);
+}
+
 // =============================================================================
 // Pass 1: Module Resolution Errors
 // =============================================================================
@@ -152,10 +193,30 @@ export class UndefinedVariableError extends LatticeError {
  */
 export class UndefinedMixinError extends LatticeError {
   readonly name: string;
+  readonly suggestions: string[];
 
-  constructor(name: string, line: number = 0, column: number = 0) {
-    super(`Undefined mixin '${name}'`, line, column);
+  constructor(
+    name: string,
+    line: number = 0,
+    column: number = 0,
+    availableMixins: string[] = [],
+  ) {
+    const suggestions = formatSuggestions(name, availableMixins);
+    const lines = [`Undefined mixin '${name}'.`];
+
+    if (availableMixins.length === 0) {
+      lines.push("No mixins are currently defined in scope.");
+    } else if (suggestions.length > 0) {
+      lines.push(`Did you mean ${suggestions.map((candidate) => `'${candidate}'`).join(" or ")}?`);
+    } else {
+      lines.push(`Defined mixins in scope: ${availableMixins.sort().join(", ")}.`);
+    }
+
+    lines.push("If this is a zero-argument mixin, both `@mixin card() { ... }` and `@mixin card { ... }` are valid.");
+
+    super(lines.join(" "), line, column);
     this.name = name;
+    this.suggestions = suggestions;
   }
 }
 

--- a/code/packages/typescript/lattice-ast-to-css/src/transformer.ts
+++ b/code/packages/typescript/lattice-ast-to-css/src/transformer.ts
@@ -475,9 +475,13 @@ export class LatticeTransformer {
 
     for (const child of getChildren(node)) {
       if (!isASTNode(child)) {
-        if (tokenTypeName(child as Token) === "FUNCTION") {
+        const token = child as Token;
+        const type = tokenTypeName(token);
+        if (type === "FUNCTION") {
           // FUNCTION token is "name(" — strip the paren
-          name = (child as Token).value.replace(/\($/, "");
+          name = token.value.replace(/\($/, "");
+        } else if (type === "IDENT") {
+          name = token.value;
         }
       } else {
         const childAst = child as ASTNode;
@@ -1136,6 +1140,7 @@ export class LatticeTransformer {
   ): Array<ASTNode | Token> {
     const children = getChildren(node);
     let mixinName: string | undefined;
+    let mixinToken: Token | undefined;
     let argsNode: ASTNode | undefined;
     let contentBlock: ASTNode | null = null;
 
@@ -1145,8 +1150,10 @@ export class LatticeTransformer {
         const type = tokenTypeName(token);
         if (type === "FUNCTION") {
           mixinName = token.value.replace(/\($/, "");
+          mixinToken = token;
         } else if (type === "IDENT") {
           mixinName = token.value;
+          mixinToken = token;
         }
       } else {
         const childAst = child as ASTNode;
@@ -1161,7 +1168,12 @@ export class LatticeTransformer {
     if (mixinName === undefined) return [];
 
     if (!this.mixins.has(mixinName)) {
-      throw new UndefinedMixinError(mixinName);
+      throw new UndefinedMixinError(
+        mixinName,
+        mixinToken?.line ?? 0,
+        mixinToken?.column ?? 0,
+        [...this.mixins.keys()],
+      );
     }
 
     // Cycle detection

--- a/code/packages/typescript/lattice-transpiler/README.md
+++ b/code/packages/typescript/lattice-transpiler/README.md
@@ -2,6 +2,25 @@
 
 End-to-end Lattice source to CSS text pipeline
 
+## Notes
+
+Lattice mixins support both zero-argument definition styles:
+
+```lattice
+@mixin panel() {
+  padding: 16px;
+}
+
+@mixin panel {
+  padding: 16px;
+}
+```
+
+Both can be included with either `@include panel();` or `@include panel;`.
+
+Undefined mixin errors also try to be more helpful now by including nearby
+defined mixin names and a reminder about the zero-argument forms.
+
 ## Dependencies
 
 - lattice-ast-to-css

--- a/code/packages/typescript/lattice-transpiler/src/browser.ts
+++ b/code/packages/typescript/lattice-transpiler/src/browser.ts
@@ -271,7 +271,8 @@ variable_declaration = VARIABLE COLON value_list SEMICOLON ;
 # Lattice: Mixins
 # ============================================================================
 
-mixin_definition = "@mixin" FUNCTION [ mixin_params ] RPAREN block ;
+mixin_definition = "@mixin" FUNCTION [ mixin_params ] RPAREN block
+                 | "@mixin" IDENT block ;
 
 mixin_params = mixin_param { COMMA mixin_param } ;
 
@@ -280,7 +281,9 @@ mixin_param = VARIABLE [ COLON value_list ] ;
 include_directive = "@include" FUNCTION [ include_args ] RPAREN ( SEMICOLON | block )
                   | "@include" IDENT ( SEMICOLON | block ) ;
 
-include_args = value_list { COMMA value_list } ;
+include_args = include_arg { COMMA include_arg } ;
+
+include_arg = VARIABLE COLON value_list | value_list ;
 
 # ============================================================================
 # Lattice: Control Flow

--- a/code/packages/typescript/lattice-transpiler/tests/lattice-transpiler.test.ts
+++ b/code/packages/typescript/lattice-transpiler/tests/lattice-transpiler.test.ts
@@ -213,14 +213,24 @@ describe("variable substitution", () => {
 
 describe("mixin expansion", () => {
   it("expands a simple mixin (no args)", () => {
-    // Mixin names must use FUNCTION token syntax: flex(
-    // because the grammar rule is: @mixin FUNCTION [...params] RPAREN block
     const css = transpileLattice(`
       @mixin flex() {
         display: flex;
         align-items: center;
       }
       .box { @include flex(); }
+    `);
+    expect(normalize(css)).toContain("display: flex");
+    expect(normalize(css)).toContain("align-items: center");
+  });
+
+  it("expands a zero-argument mixin defined without parentheses", () => {
+    const css = transpileLattice(`
+      @mixin flex {
+        display: flex;
+        align-items: center;
+      }
+      .box { @include flex; }
     `);
     expect(normalize(css)).toContain("display: flex");
     expect(normalize(css)).toContain("align-items: center");
@@ -277,6 +287,15 @@ describe("mixin expansion", () => {
     expect(() => transpileLattice(".btn { @include ghost; }")).toThrow(
       UndefinedMixinError
     );
+  });
+
+  it("includes suggestions in UndefinedMixinError messages", () => {
+    expect(() =>
+      transpileLattice(`
+        @mixin spacing() { margin: 8px; }
+        .btn { @include spacin(); }
+      `)
+    ).toThrow(/Did you mean 'spacing'\?/);
   });
 
   it("throws WrongArityError for too few arguments", () => {
@@ -578,6 +597,16 @@ describe("transpileLatticeInBrowser", () => {
     const css = transpileLatticeInBrowser(`
       @mixin flex() { display: flex; }
       .box { @include flex(); }
+    `);
+    expect(normalize(css)).toContain("display: flex");
+  });
+
+  it("supports zero-argument mixins defined without parentheses in the browser bundle", () => {
+    const css = transpileLatticeInBrowser(`
+      @mixin flex {
+        display: flex;
+      }
+      .box { @include flex; }
     `);
     expect(normalize(css)).toContain("display: flex");
   });

--- a/code/specs/17-lattice-transpiler.md
+++ b/code/specs/17-lattice-transpiler.md
@@ -132,14 +132,15 @@ and `function_arg` alternatives).
 #### Mixins
 
 ```ebnf
-mixin_definition  = "@mixin" IDENT LPAREN [ mixin_params ] RPAREN block ;
+mixin_definition  = "@mixin" FUNCTION [ mixin_params ] RPAREN block
+                  | "@mixin" IDENT block ;
 mixin_params      = mixin_param { COMMA mixin_param } ;
 mixin_param       = VARIABLE [ COLON value_list ] ;
 include_directive = "@include" IDENT [ LPAREN include_args RPAREN ] ( SEMICOLON | block ) ;
 include_args      = value_list { COMMA value_list } ;
 ```
 
-Mixins with no parameters: `@mixin clearfix() { ... }`
+Mixins with no parameters: `@mixin clearfix() { ... }` or `@mixin clearfix { ... }`
 Mixins with defaults: `@mixin button($bg, $fg: white) { ... }`
 Include with content block: `@include responsive() { font-size: 18px; }`
 


### PR DESCRIPTION
## Summary

This PR extracts the Lattice compiler/parser follow-up work from the web app PR so it can be reviewed and shipped independently.

It includes the TypeScript transpiler/compiler improvements plus the matching Python parser test update.

## What Changed

### TypeScript Lattice compiler improvements

Updated the TypeScript Lattice pipeline to:

- improve undefined-mixin error messages
- include better source position context
- suggest nearby mixin names when possible
- align browser transpilation behavior with the main grammar
- accept zero-argument mixin definitions written with or without parentheses

Files touched:

- `code/packages/typescript/lattice-ast-to-css/src/errors.ts`
- `code/packages/typescript/lattice-ast-to-css/src/transformer.ts`
- `code/packages/typescript/lattice-transpiler/src/browser.ts`
- `code/packages/typescript/lattice-transpiler/tests/lattice-transpiler.test.ts`
- `code/packages/typescript/lattice-transpiler/README.md`
- `code/specs/17-lattice-transpiler.md`

### Python parser test update

- Updated `code/packages/python/lattice-parser/tests/test_lattice_parser.py`
- This keeps the Python-side parser expectations aligned with the mixin default-value AST shape used after the grammar change

## Why This Is Separate

This work was originally developed while dogfooding Lattice in the web app PR, but it is really compiler/runtime work rather than app work. Splitting it out keeps the web app PR smaller and makes the Lattice changes easier to review on their own merits.

## Verification

This change was previously exercised during the web app work by running the relevant Lattice TypeScript package build/tests and then validating the updated parser expectations on the Python side.
