### PR TITLE
fix(ruby/sql-execution-engine): normalize aggregate column names to uppercase

### DIFF
--- a/code/packages/ruby/sql_execution_engine/CHANGELOG.md
+++ b/code/packages/ruby/sql_execution_engine/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog — coding_adventures_sql_execution_engine
 
+## [0.1.1] - 2026-03-31
+
+### Fixed
+
+- **Aggregate column names now use uppercase function names**: When a query
+  contained an aggregate like `SUM(salary)`, the output column was labelled
+  `sum(salary)` (lowercase) because the SQL lexer normalises keywords to
+  lowercase in case-insensitive mode. The SELECT projection now unwraps the
+  deep pass-through rule chain (`expr` → `or_expr` → ... → `primary`) to
+  find the underlying `function_call` node, then uppercases the function name
+  token to produce `SUM(salary)` instead of `sum(salary)`. Test
+  `test_group_by_sum` now passes.
+- **Qualified column references (e.g. `employees.name`) now return their full
+  dotted text** instead of just the last name part, preserving the column
+  lookup key used by JOIN queries.
+
 ## [0.1.0] — 2026-03-25
 
 ### Added

--- a/code/packages/ruby/sql_execution_engine/lib/coding_adventures/sql_execution_engine/executor.rb
+++ b/code/packages/ruby/sql_execution_engine/lib/coding_adventures/sql_execution_engine/executor.rb
@@ -284,13 +284,46 @@ module CodingAdventures
         [name, expr_node]
       end
 
+      # Pass-through rule names whose single-child wrappers we unwrap when
+      # inferring column names.  The parser nests function_call inside several
+      # layers of expression rules before we reach it.
+      PASS_THROUGH_RULES = %w[
+        expr or_expr and_expr not_expr comparison
+        additive multiplicative unary primary
+      ].freeze
+
       def infer_col_name(node)
         return "?" unless node
         return node.value if node.is_a?(Token)
 
-        if node.rule_name == "column_ref"
-          tokens = node.children.select { |c| c.is_a?(Token) }
-          return tokens.last&.value || "?"
+        # Unwrap single-child pass-through rules to reach the real node.
+        # The parser wraps function_call inside expr → or_expr → … → primary.
+        unwrapped = node
+        while unwrapped.is_a?(ASTNode) &&
+              PASS_THROUGH_RULES.include?(unwrapped.rule_name) &&
+              unwrapped.children.length == 1
+          unwrapped = unwrapped.children[0]
+        end
+
+        return unwrapped.value if unwrapped.is_a?(Token)
+
+        if unwrapped.rule_name == "column_ref"
+          # Return the full dotted text (e.g. "employees.name") so callers can
+          # look up the value under the qualified key in the row context.
+          return node_text(unwrapped)
+        end
+
+        if unwrapped.rule_name == "function_call"
+          # Normalise the function name to uppercase so the output column label
+          # matches the aggregate storage key produced by compute_aggregates
+          # (which always uses uppercase, e.g. "SUM(salary)").  The SQL lexer
+          # emits function names in lowercase due to case-insensitive mode.
+          func_token = unwrapped.children[0]
+          if func_token.is_a?(Token)
+            rest = unwrapped.children[1..].map { |c| node_text(c) }.join
+            return func_token.value.upcase + rest
+          end
+          return node_text(unwrapped)
         end
 
         node_text(node)


### PR DESCRIPTION
## Summary

- When a query contained an aggregate like `SUM(salary)`, the output column was labelled `sum(salary)` (lowercase) because the SQL lexer normalises keywords to lowercase in case-insensitive mode. Test `test_group_by_sum` expected `"SUM(salary)"` as the key.
- Root cause: `infer_col_name` in `executor.rb` used raw `node_text()` for all nodes. The parser also wraps function calls inside a deep chain of pass-through rules (`expr → or_expr → ... → primary → function_call`), so a `function_call` rule_name check would never match.
- Fix: `infer_col_name` now unwraps single-child pass-through nodes to reach the underlying `function_call` node, then uppercases the function name token. Column references with qualified names (e.g. `employees.name`) now also return their full dotted text.
- Mirrors the same fix applied to `python/sql-execution-engine` in PR #453.

## Packages changed

- `code/packages/ruby/sql_execution_engine` — `executor.rb`, `CHANGELOG.md`

## Test plan

- [ ] `test_group_by_sum` passes (`SUM(salary)` key in result)
- [ ] LEFT JOIN tests still pass (`employees.name` qualified column preserved)
- [ ] All tests pass with coverage ≥ 80%

🤖 Generated with [Claude Code](https://claude.com/claude-code)