### PR TITLE
[codex] ci(jvm): add toolchain detection and stabilize Windows Gradle builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
       needs_perl: ${{ steps.toolchains.outputs.needs_perl }}
       needs_haskell: ${{ steps.toolchains.outputs.needs_haskell }}
       needs_dotnet: ${{ steps.toolchains.outputs.needs_dotnet }}
+      needs_java: ${{ steps.toolchains.outputs.needs_java }}
+      needs_kotlin: ${{ steps.toolchains.outputs.needs_kotlin }}
       diff_base: ${{ steps.diff-base.outputs.base }}
       is_main: ${{ steps.detect-main.outputs.is_main }}
     steps:
@@ -140,7 +142,10 @@ jobs:
               'needs_lua=true' \
               'needs_perl=true' \
               'needs_haskell=true' \
-              'needs_dotnet=true' >> "$GITHUB_OUTPUT"
+              'needs_haskell=true' \
+              'needs_dotnet=true' \
+              'needs_java=true' \
+              'needs_kotlin=true' >> "$GITHUB_OUTPUT"
           else
             printf '%s\n' \
               'needs_python=${{ steps.detect.outputs.needs_python }}' \
@@ -152,7 +157,10 @@ jobs:
               'needs_lua=${{ steps.detect.outputs.needs_lua }}' \
               'needs_perl=${{ steps.detect.outputs.needs_perl }}' \
               'needs_haskell=${{ steps.detect.outputs.needs_haskell }}' \
-              'needs_dotnet=${{ steps.detect.outputs.needs_dotnet }}' >> "$GITHUB_OUTPUT"
+              'needs_haskell=${{ steps.detect.outputs.needs_haskell }}' \
+              'needs_dotnet=${{ steps.detect.outputs.needs_dotnet }}' \
+              'needs_java=${{ steps.detect.outputs.needs_java }}' \
+              'needs_kotlin=${{ steps.detect.outputs.needs_kotlin }}' >> "$GITHUB_OUTPUT"
           fi
 
       - name: Upload build plan
@@ -288,6 +296,31 @@ jobs:
         with:
           elixir-version: '1.16'
           otp-version: '26.0'
+
+      # ── Java / Kotlin ──────────────────────────────────────────
+      #
+      # Both Java and Kotlin packages use Gradle and JDK 21.
+      # A single JDK + Gradle setup covers both languages since
+      # Kotlin/JVM runs on the same JVM.
+
+      - name: Set up JDK 21
+        if: needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true'
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Set up Gradle
+        if: needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true'
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Disable long-lived Gradle services on Windows CI
+        if: (needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true') && runner.os == 'Windows'
+        shell: bash
+        run: |
+          {
+            echo 'GRADLE_OPTS=-Dorg.gradle.daemon=false -Dorg.gradle.vfs.watch=false'
+          } >> "$GITHUB_ENV"
 
       - name: Install cpanm and test dependencies (Perl)
         if: needs.detect.outputs.needs_perl == 'true' && runner.os != 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,8 +142,8 @@ jobs:
               'needs_lua=true' \
               'needs_perl=true' \
               'needs_haskell=true' \
-              'needs_haskell=true' \
-              'needs_dotnet=true' \
+              'needs_dotnet=true' >> "$GITHUB_OUTPUT"
+            printf '%s\n' \
               'needs_java=true' \
               'needs_kotlin=true' >> "$GITHUB_OUTPUT"
           else
@@ -157,8 +157,8 @@ jobs:
               'needs_lua=${{ steps.detect.outputs.needs_lua }}' \
               'needs_perl=${{ steps.detect.outputs.needs_perl }}' \
               'needs_haskell=${{ steps.detect.outputs.needs_haskell }}' \
-              'needs_haskell=${{ steps.detect.outputs.needs_haskell }}' \
-              'needs_dotnet=${{ steps.detect.outputs.needs_dotnet }}' \
+              'needs_dotnet=${{ steps.detect.outputs.needs_dotnet }}' >> "$GITHUB_OUTPUT"
+            printf '%s\n' \
               'needs_java=${{ steps.detect.outputs.needs_java }}' \
               'needs_kotlin=${{ steps.detect.outputs.needs_kotlin }}' >> "$GITHUB_OUTPUT"
           fi

--- a/code/programs/go/build-tool/detect_languages_test.go
+++ b/code/programs/go/build-tool/detect_languages_test.go
@@ -18,7 +18,7 @@ func TestAllToolchainsConstant(t *testing.T) {
 	expected := map[string]bool{
 		"python": true, "ruby": true, "go": true,
 		"typescript": true, "rust": true, "elixir": true, "lua": true, "perl": true,
-		"swift": true, "haskell": true, "dotnet": true,
+		"swift": true, "java": true, "kotlin": true, "haskell": true, "dotnet": true,
 	}
 	if len(allToolchains) != len(expected) {
 		t.Errorf("allToolchains has %d entries, want %d", len(allToolchains), len(expected))
@@ -220,6 +220,8 @@ func TestToolchainForPackageLanguage(t *testing.T) {
 		"csharp":  "dotnet",
 		"fsharp":  "dotnet",
 		"dotnet":  "dotnet",
+		"java":    "java",
+		"kotlin":  "kotlin",
 		"python":  "python",
 		"swift":   "swift",
 		"unknown": "unknown",

--- a/code/programs/go/build-tool/internal/executor/executor.go
+++ b/code/programs/go/build-tool/internal/executor/executor.go
@@ -426,12 +426,22 @@ func buildResourceKeys(pkg discovery.Package, pathToPkg map[string]string) []str
 // buildResourceKeysForOS is the testable version of buildResourceKeys that
 // accepts an explicit OS name. This allows tests to verify Windows-specific
 // lock key behaviour on non-Windows hosts.
-func buildResourceKeysForOS(pkg discovery.Package, pathToPkg map[string]string, _ string) []string {
+func buildResourceKeysForOS(pkg discovery.Package, pathToPkg map[string]string, goos string) []string {
 	keys := map[string]bool{
 		pkg.Name: true,
 	}
 
 	for _, command := range pkg.BuildCommands {
+		if goos == "windows" && isGradleCommand(command) {
+			// Windows runners showed long-lived Java/Gradle processes when multiple
+			// independent JVM packages were launched together. Serialize Gradle-backed
+			// Java/Kotlin builds there the same way we already protect other shared
+			// package-manager state such as Hex and LuaRocks.
+			if pkg.Language == "java" || pkg.Language == "kotlin" {
+				keys["global:gradle-windows-runner"] = true
+			}
+		}
+
 		if pkg.Language == "elixir" && strings.Contains(command, "mix deps.get") {
 			// Hex persists a shared cache under ~/.hex, which is not safe for
 			// concurrent writes across packages in CI.
@@ -468,4 +478,34 @@ func buildResourceKeysForOS(pkg discovery.Package, pathToPkg map[string]string, 
 		result = append(result, key)
 	}
 	return result
+}
+
+func isGradleCommand(command string) bool {
+	trimmed := strings.TrimSpace(command)
+	if trimmed == "" {
+		return false
+	}
+
+	for _, prefix := range []string{
+		"gradle ",
+		"gradle\t",
+		"gradlew ",
+		"gradlew\t",
+		"gradlew.bat ",
+		"gradlew.bat\t",
+		"./gradlew ",
+		"./gradlew\t",
+		".\\gradlew ",
+		".\\gradlew\t",
+	} {
+		if strings.HasPrefix(trimmed, prefix) {
+			return true
+		}
+	}
+
+	return trimmed == "gradle" ||
+		trimmed == "gradlew" ||
+		trimmed == "gradlew.bat" ||
+		trimmed == "./gradlew" ||
+		trimmed == ".\\gradlew"
 }

--- a/code/programs/go/build-tool/internal/executor/executor_test.go
+++ b/code/programs/go/build-tool/internal/executor/executor_test.go
@@ -434,6 +434,69 @@ func TestBuildResourceKeysIncludesGlobalLuaRocksLockForLuaRemovesOnLinux(t *test
 	}
 }
 
+func TestBuildResourceKeysIncludesGlobalGradleLockForJavaOnWindows(t *testing.T) {
+	root := makeFixture(t, map[string]string{
+		"pkg/BUILD": "gradle test",
+	})
+
+	pkg := discovery.Package{
+		Name:          "java/pkg",
+		Path:          filepath.Join(root, "pkg"),
+		BuildCommands: []string{"gradle test"},
+		Language:      "java",
+	}
+
+	keys := buildResourceKeysForOS(pkg, map[string]string{
+		filepath.Join(root, "pkg"): "java/pkg",
+	}, "windows")
+	joined := strings.Join(keys, ",")
+	if !strings.Contains(joined, "global:gradle-windows-runner") {
+		t.Fatalf("expected keys to include global gradle lock on Windows, got %v", keys)
+	}
+}
+
+func TestBuildResourceKeysSkipsGlobalGradleLockForJavaOnLinux(t *testing.T) {
+	root := makeFixture(t, map[string]string{
+		"pkg/BUILD": "gradle test",
+	})
+
+	pkg := discovery.Package{
+		Name:          "java/pkg",
+		Path:          filepath.Join(root, "pkg"),
+		BuildCommands: []string{"gradle test"},
+		Language:      "java",
+	}
+
+	keys := buildResourceKeysForOS(pkg, map[string]string{
+		filepath.Join(root, "pkg"): "java/pkg",
+	}, "linux")
+	joined := strings.Join(keys, ",")
+	if strings.Contains(joined, "global:gradle-windows-runner") {
+		t.Fatalf("did not expect Windows-only gradle lock on Linux, got %v", keys)
+	}
+}
+
+func TestBuildResourceKeysIncludesGlobalGradleLockForGradleWrapperOnWindows(t *testing.T) {
+	root := makeFixture(t, map[string]string{
+		"pkg/BUILD_windows": "gradlew.bat assembleDebug",
+	})
+
+	pkg := discovery.Package{
+		Name:          "kotlin/pkg",
+		Path:          filepath.Join(root, "pkg"),
+		BuildCommands: []string{"gradlew.bat assembleDebug"},
+		Language:      "kotlin",
+	}
+
+	keys := buildResourceKeysForOS(pkg, map[string]string{
+		filepath.Join(root, "pkg"): "kotlin/pkg",
+	}, "windows")
+	joined := strings.Join(keys, ",")
+	if !strings.Contains(joined, "global:gradle-windows-runner") {
+		t.Fatalf("expected wrapper-based builds to include global gradle lock on Windows, got %v", keys)
+	}
+}
+
 func TestExecuteBuildsSerializesSharedBuildResources(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("uses shell commands that are only asserted on Unix runners")

--- a/code/programs/go/build-tool/internal/gitdiff/ci_workflow.go
+++ b/code/programs/go/build-tool/internal/gitdiff/ci_workflow.go
@@ -58,11 +58,13 @@ var ciWorkflowToolchainMarkers = map[string][]string{
 	"java": {
 		"needs_java", "setup-java", "java-version", "java --version",
 		"temurin", "set up jdk", "set up gradle", "setup-gradle",
+		"disable long-lived gradle services",
 		"gradle_opts", "org.gradle.daemon", "org.gradle.vfs.watch",
 	},
 	"kotlin": {
 		"needs_kotlin", "setup-java", "java-version",
 		"temurin", "set up jdk", "set up gradle", "setup-gradle",
+		"disable long-lived gradle services",
 		"gradle_opts", "org.gradle.daemon", "org.gradle.vfs.watch",
 	},
 	"dotnet": {
@@ -234,6 +236,8 @@ func isToolchainScopedStructuralLine(content string) bool {
 		strings.HasPrefix(content, "shell:"),
 		strings.HasPrefix(content, "with:"),
 		strings.HasPrefix(content, "env:"),
+		strings.HasPrefix(content, "{"),
+		strings.HasPrefix(content, "}"),
 		strings.HasPrefix(content, "else"),
 		strings.HasPrefix(content, "fi"),
 		strings.HasPrefix(content, "then"),

--- a/code/programs/go/build-tool/internal/gitdiff/ci_workflow.go
+++ b/code/programs/go/build-tool/internal/gitdiff/ci_workflow.go
@@ -55,6 +55,16 @@ var ciWorkflowToolchainMarkers = map[string][]string{
 		"needs_haskell", "haskell-actions/setup", "ghc-version", "cabal-version",
 		"ghc --version", "cabal --version", "set up haskell",
 	},
+	"java": {
+		"needs_java", "setup-java", "java-version", "java --version",
+		"temurin", "set up jdk", "set up gradle", "setup-gradle",
+		"gradle_opts", "org.gradle.daemon", "org.gradle.vfs.watch",
+	},
+	"kotlin": {
+		"needs_kotlin", "setup-java", "java-version",
+		"temurin", "set up jdk", "set up gradle", "setup-gradle",
+		"gradle_opts", "org.gradle.daemon", "org.gradle.vfs.watch",
+	},
 	"dotnet": {
 		"needs_dotnet", "setup-dotnet", "dotnet-version", "dotnet --version",
 		"set up .net",

--- a/code/programs/go/build-tool/internal/gitdiff/ci_workflow_test.go
+++ b/code/programs/go/build-tool/internal/gitdiff/ci_workflow_test.go
@@ -23,6 +23,31 @@ func TestAnalyzeCIWorkflowPatchAllowsToolchainScopedDotnetChanges(t *testing.T) 
 	}
 }
 
+func TestAnalyzeCIWorkflowPatchAllowsSharedJVMToolchainChanges(t *testing.T) {
+	patch := `
+@@ -314,0 +315,11 @@
++      - name: Set up JDK 21
++        if: needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true'
++        uses: actions/setup-java@v4
++        with:
++          distribution: 'temurin'
++          java-version: '21'
++      - name: Set up Gradle
++        if: needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true'
++        uses: gradle/actions/setup-gradle@v4
+`
+
+	change := AnalyzeCIWorkflowPatch(patch)
+	if change.RequiresFullRebuild {
+		t.Fatalf("expected JVM toolchain change to stay incremental")
+	}
+
+	got := SortedToolchains(change.Toolchains)
+	if len(got) != 2 || got[0] != "java" || got[1] != "kotlin" {
+		t.Fatalf("expected java and kotlin toolchains, got %v", got)
+	}
+}
+
 func TestAnalyzeCIWorkflowPatchIgnoresCommentOnlyChanges(t *testing.T) {
 	patch := `
 @@ -316,2 +316,2 @@

--- a/code/programs/go/build-tool/internal/gitdiff/ci_workflow_test.go
+++ b/code/programs/go/build-tool/internal/gitdiff/ci_workflow_test.go
@@ -25,7 +25,7 @@ func TestAnalyzeCIWorkflowPatchAllowsToolchainScopedDotnetChanges(t *testing.T) 
 
 func TestAnalyzeCIWorkflowPatchAllowsSharedJVMToolchainChanges(t *testing.T) {
 	patch := `
-@@ -314,0 +315,11 @@
+@@ -314,0 +315,17 @@
 +      - name: Set up JDK 21
 +        if: needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true'
 +        uses: actions/setup-java@v4
@@ -35,6 +35,13 @@ func TestAnalyzeCIWorkflowPatchAllowsSharedJVMToolchainChanges(t *testing.T) {
 +      - name: Set up Gradle
 +        if: needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true'
 +        uses: gradle/actions/setup-gradle@v4
++      - name: Disable long-lived Gradle services on Windows CI
++        if: (needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true') && runner.os == 'Windows'
++        shell: bash
++        run: |
++          {
++            echo 'GRADLE_OPTS=-Dorg.gradle.daemon=false -Dorg.gradle.vfs.watch=false'
++          } >> "$GITHUB_ENV"
 `
 
 	change := AnalyzeCIWorkflowPatch(patch)

--- a/code/programs/go/build-tool/main.go
+++ b/code/programs/go/build-tool/main.go
@@ -481,7 +481,7 @@ func run() int {
 
 // allToolchains is the canonical list of build toolchains we may need in CI.
 // The order is stable and matches the order used in CI setup.
-var allToolchains = []string{"python", "ruby", "go", "typescript", "rust", "elixir", "lua", "perl", "swift", "haskell", "dotnet"}
+var allToolchains = []string{"python", "ruby", "go", "typescript", "rust", "elixir", "lua", "perl", "swift", "java", "kotlin", "haskell", "dotnet"}
 
 func toolchainForPackageLanguage(language string) string {
 	switch language {

--- a/lessons.md
+++ b/lessons.md
@@ -156,6 +156,28 @@ This redirects Gradle's output to `gradle-build/` instead of `build/`. Also add 
 - [ ] `layout.buildDirectory = file("gradle-build")` in build.gradle.kts
 - [ ] BUILD file exists for the monorepo build tool
 - [ ] `gradle-build/` in .gitignore
+- [ ] Do NOT use `java { toolchain { languageVersion.set(...) } }` — let Gradle use the running JDK
+
+---
+
+### 2026-04-04: Java toolchain block causes CI failure when JDK is not pre-installed
+
+Using `java { toolchain { languageVersion.set(JavaLanguageVersion.of(21)) } }` in `build.gradle.kts` causes Gradle to search for a JDK 21 installation matching that exact version. If the CI runner doesn't have JDK 21 pre-installed and toolchain auto-provisioning isn't configured, the build fails with "Cannot find a Java installation on your machine."
+
+**Solution:** Do NOT specify an explicit Java toolchain version. Let Gradle use whatever JDK is on the PATH (set up by `actions/setup-java` in CI). This matches the lesson from the hello-world programs.
+
+---
+
+### 2026-04-04: CI detect outputs must use steps.toolchains, not steps.detect
+
+The CI workflow has a "Normalize toolchain requirements" step (id: `toolchains`) that sits between the detect step and the job outputs. On main branch pushes, it forces all languages to `true` for the full rebuild. On other branches, it passes through the detect outputs.
+
+When adding a new language to CI, you must add it in THREE places:
+1. `allLanguages` in the build tool (`main.go`)
+2. The detect job `outputs:` section (using `steps.toolchains.outputs.needs_<lang>`)
+3. The `steps.toolchains` normalization step — in BOTH the `is_main=true` branch AND the `else` branch
+
+If you only add it to `outputs:` using `steps.detect.outputs` instead of `steps.toolchains.outputs`, the validator will fail with: "detect outputs for forced main full builds are not normalized through steps.toolchains."
 
 ---
 


### PR DESCRIPTION
## Summary

Extract the JVM-specific CI/build-tool work out of PR #506 so it can land independently of the Swift/Java/Kotlin package additions.

This PR:
- teaches CI/build-plan detection about `java` and `kotlin`
- installs JDK 21 + Gradle only when JVM work is actually needed
- disables long-lived Gradle daemon/file-watching behavior on Windows CI
- serializes Gradle-backed Java/Kotlin builds on Windows in the Go build tool to avoid shared-runner contention
- documents the JVM CI lessons in `lessons.md`

## Why

PR #506 mixes shared CI changes with new Swift/Java/Kotlin packages. Because `.github/workflows/ci.yml` is a shared CI file, that PR fans out into a very large Windows build. The Windows run was not broadly stuck on Kotlin; it eventually narrowed to a long-lived `java/wave` build with orphaned `java` processes left behind when GitHub cancelled the job.

Landing the JVM infra separately reduces the blast radius for the follow-up language PRs and gives Windows CI a much smaller, more defensible surface area.

## Validation

- `go test ./...` in `code/programs/go/build-tool`

## Follow-up

After this lands, the replacement package PRs can be split by language:
- Swift from `main`
- Java from this JVM CI base
- Kotlin from this JVM CI base
