### PR TITLE
[codex] feat(java): add activation, loss, matrix, and wave packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
       needs_perl: ${{ steps.toolchains.outputs.needs_perl }}
       needs_haskell: ${{ steps.toolchains.outputs.needs_haskell }}
       needs_dotnet: ${{ steps.toolchains.outputs.needs_dotnet }}
+      needs_java: ${{ steps.toolchains.outputs.needs_java }}
+      needs_kotlin: ${{ steps.toolchains.outputs.needs_kotlin }}
       diff_base: ${{ steps.diff-base.outputs.base }}
       is_main: ${{ steps.detect-main.outputs.is_main }}
     steps:
@@ -140,7 +142,10 @@ jobs:
               'needs_lua=true' \
               'needs_perl=true' \
               'needs_haskell=true' \
-              'needs_dotnet=true' >> "$GITHUB_OUTPUT"
+              'needs_haskell=true' \
+              'needs_dotnet=true' \
+              'needs_java=true' \
+              'needs_kotlin=true' >> "$GITHUB_OUTPUT"
           else
             printf '%s\n' \
               'needs_python=${{ steps.detect.outputs.needs_python }}' \
@@ -152,7 +157,10 @@ jobs:
               'needs_lua=${{ steps.detect.outputs.needs_lua }}' \
               'needs_perl=${{ steps.detect.outputs.needs_perl }}' \
               'needs_haskell=${{ steps.detect.outputs.needs_haskell }}' \
-              'needs_dotnet=${{ steps.detect.outputs.needs_dotnet }}' >> "$GITHUB_OUTPUT"
+              'needs_haskell=${{ steps.detect.outputs.needs_haskell }}' \
+              'needs_dotnet=${{ steps.detect.outputs.needs_dotnet }}' \
+              'needs_java=${{ steps.detect.outputs.needs_java }}' \
+              'needs_kotlin=${{ steps.detect.outputs.needs_kotlin }}' >> "$GITHUB_OUTPUT"
           fi
 
       - name: Upload build plan
@@ -288,6 +296,31 @@ jobs:
         with:
           elixir-version: '1.16'
           otp-version: '26.0'
+
+      # ── Java / Kotlin ──────────────────────────────────────────
+      #
+      # Both Java and Kotlin packages use Gradle and JDK 21.
+      # A single JDK + Gradle setup covers both languages since
+      # Kotlin/JVM runs on the same JVM.
+
+      - name: Set up JDK 21
+        if: needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true'
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Set up Gradle
+        if: needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true'
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Disable long-lived Gradle services on Windows CI
+        if: (needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true') && runner.os == 'Windows'
+        shell: bash
+        run: |
+          {
+            echo 'GRADLE_OPTS=-Dorg.gradle.daemon=false -Dorg.gradle.vfs.watch=false'
+          } >> "$GITHUB_ENV"
 
       - name: Install cpanm and test dependencies (Perl)
         if: needs.detect.outputs.needs_perl == 'true' && runner.os != 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,8 +142,8 @@ jobs:
               'needs_lua=true' \
               'needs_perl=true' \
               'needs_haskell=true' \
-              'needs_haskell=true' \
-              'needs_dotnet=true' \
+              'needs_dotnet=true' >> "$GITHUB_OUTPUT"
+            printf '%s\n' \
               'needs_java=true' \
               'needs_kotlin=true' >> "$GITHUB_OUTPUT"
           else
@@ -157,8 +157,8 @@ jobs:
               'needs_lua=${{ steps.detect.outputs.needs_lua }}' \
               'needs_perl=${{ steps.detect.outputs.needs_perl }}' \
               'needs_haskell=${{ steps.detect.outputs.needs_haskell }}' \
-              'needs_haskell=${{ steps.detect.outputs.needs_haskell }}' \
-              'needs_dotnet=${{ steps.detect.outputs.needs_dotnet }}' \
+              'needs_dotnet=${{ steps.detect.outputs.needs_dotnet }}' >> "$GITHUB_OUTPUT"
+            printf '%s\n' \
               'needs_java=${{ steps.detect.outputs.needs_java }}' \
               'needs_kotlin=${{ steps.detect.outputs.needs_kotlin }}' >> "$GITHUB_OUTPUT"
           fi

--- a/code/packages/java/activation-functions/.gitignore
+++ b/code/packages/java/activation-functions/.gitignore
@@ -1,0 +1,2 @@
+gradle-build/
+.gradle/

--- a/code/packages/java/activation-functions/BUILD
+++ b/code/packages/java/activation-functions/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/activation-functions/CHANGELOG.md
+++ b/code/packages/java/activation-functions/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog — activation-functions (Java)
+
+All notable changes to this package are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [0.1.0] — 2026-04-04
+
+### Added
+- Initial implementation of Java activation-functions package.
+- Sigmoid, ReLU, Tanh with derivatives.
+- JUnit 5 test suite with parity vectors from ML04 spec.

--- a/code/packages/java/activation-functions/README.md
+++ b/code/packages/java/activation-functions/README.md
@@ -1,0 +1,24 @@
+# activation-functions (Java)
+
+Non-linear activation functions for neural networks: Sigmoid, ReLU, and Tanh with derivatives for backpropagation.
+
+## Where It Fits
+
+- **Layer:** ML04 (leaf package, zero dependencies)
+- **Spec:** `code/specs/ML04-activation-functions.md`
+
+## Usage
+
+```java
+import com.codingadventures.activationfunctions.ActivationFunctions;
+
+double output = ActivationFunctions.sigmoid(0.0);    // 0.5
+double grad = ActivationFunctions.sigmoidDerivative(0.0); // 0.25
+double activated = ActivationFunctions.relu(-3.0);    // 0.0
+```
+
+## Running Tests
+
+```bash
+gradle test
+```

--- a/code/packages/java/activation-functions/build.gradle.kts
+++ b/code/packages/java/activation-functions/build.gradle.kts
@@ -1,0 +1,18 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/activation-functions/settings.gradle.kts
+++ b/code/packages/java/activation-functions/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "activation-functions"

--- a/code/packages/java/activation-functions/src/main/java/com/codingadventures/activationfunctions/ActivationFunctions.java
+++ b/code/packages/java/activation-functions/src/main/java/com/codingadventures/activationfunctions/ActivationFunctions.java
@@ -1,0 +1,86 @@
+// ============================================================================
+// ActivationFunctions.java — Non-Linear Transforms for Neural Networks
+// ============================================================================
+//
+// Activation functions introduce non-linearity into neural networks.  Without
+// them, stacking multiple linear layers collapses into a single linear
+// transformation — the network could only learn straight lines.
+//
+// This module implements three fundamental activation functions:
+//
+//   ┌──────────┬──────────────┬──────────────────────────────────────────┐
+//   │ Function │ Range        │ Intuition                                │
+//   ├──────────┼──────────────┼──────────────────────────────────────────┤
+//   │ Sigmoid  │ (0, 1)       │ Maps any real number to a probability    │
+//   │ ReLU     │ [0, ∞)       │ Kills negatives, passes positives       │
+//   │ Tanh     │ (-1, 1)      │ Like sigmoid but zero-centred            │
+//   └──────────┴──────────────┴──────────────────────────────────────────┘
+//
+// Each function has a companion derivative for use in backpropagation.
+// All functions are pure scalar operations: one double in, one double out.
+//
+// Layer: ML04 (machine-learning layer 4 — leaf package, zero dependencies)
+// Spec:  code/specs/ML04-activation-functions.md
+// ============================================================================
+
+package com.codingadventures.activationfunctions;
+
+/**
+ * Activation functions and their derivatives for neural networks.
+ *
+ * <p>All methods are pure, stateless scalar operations.</p>
+ */
+public final class ActivationFunctions {
+
+    private ActivationFunctions() {}
+
+    // ========================================================================
+    // Sigmoid: σ(x) = 1 / (1 + e^(-x))
+    // ========================================================================
+
+    /**
+     * Compute sigmoid: σ(x) = 1 / (1 + e^(-x))
+     *
+     * <p>Clamps to 0.0/1.0 for |x| > 709 to avoid overflow.</p>
+     */
+    public static double sigmoid(double x) {
+        if (x < -709.0) return 0.0;
+        if (x > 709.0) return 1.0;
+        return 1.0 / (1.0 + Math.exp(-x));
+    }
+
+    /** Derivative: σ'(x) = σ(x) · (1 − σ(x)) */
+    public static double sigmoidDerivative(double x) {
+        double s = sigmoid(x);
+        return s * (1.0 - s);
+    }
+
+    // ========================================================================
+    // ReLU: max(0, x)
+    // ========================================================================
+
+    /** Compute ReLU: max(0, x) */
+    public static double relu(double x) {
+        return Math.max(0.0, x);
+    }
+
+    /** Derivative: 1 if x > 0, 0 otherwise (0 at x=0 by convention). */
+    public static double reluDerivative(double x) {
+        return x > 0.0 ? 1.0 : 0.0;
+    }
+
+    // ========================================================================
+    // Tanh: (e^x - e^(-x)) / (e^x + e^(-x))
+    // ========================================================================
+
+    /** Compute tanh(x). */
+    public static double tanh(double x) {
+        return Math.tanh(x);
+    }
+
+    /** Derivative: tanh'(x) = 1 − tanh²(x) */
+    public static double tanhDerivative(double x) {
+        double t = Math.tanh(x);
+        return 1.0 - t * t;
+    }
+}

--- a/code/packages/java/activation-functions/src/test/java/com/codingadventures/activationfunctions/ActivationFunctionsTest.java
+++ b/code/packages/java/activation-functions/src/test/java/com/codingadventures/activationfunctions/ActivationFunctionsTest.java
@@ -1,0 +1,124 @@
+package com.codingadventures.activationfunctions;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ActivationFunctionsTest {
+
+    private static final double EPS = 1e-10;
+
+    // ========================================================================
+    // Sigmoid Tests
+    // ========================================================================
+
+    @Test void sigmoidAtZero() { assertEquals(0.5, ActivationFunctions.sigmoid(0.0), EPS); }
+    @Test void sigmoidPositive() { assertEquals(0.7310585786300049, ActivationFunctions.sigmoid(1.0), EPS); }
+    @Test void sigmoidNegative() { assertEquals(0.2689414213699951, ActivationFunctions.sigmoid(-1.0), EPS); }
+    @Test void sigmoidLargePositive() { assertEquals(0.9999546021312976, ActivationFunctions.sigmoid(10.0), 1e-8); }
+    @Test void sigmoidOverflowNeg() { assertEquals(0.0, ActivationFunctions.sigmoid(-710.0)); }
+    @Test void sigmoidOverflowPos() { assertEquals(1.0, ActivationFunctions.sigmoid(710.0)); }
+
+    @Test
+    void sigmoidSymmetry() {
+        double[] values = {0.5, 1.0, 2.0, 5.0, 10.0};
+        for (double x : values) {
+            assertEquals(
+                ActivationFunctions.sigmoid(-x),
+                1.0 - ActivationFunctions.sigmoid(x),
+                EPS, "Symmetry failed at x=" + x);
+        }
+    }
+
+    @Test
+    void sigmoidRange() {
+        double[] values = {-100, -10, -1, 0, 1, 10, 100};
+        for (double x : values) {
+            double s = ActivationFunctions.sigmoid(x);
+            assertTrue(s >= 0.0 && s <= 1.0, "Out of range at x=" + x);
+        }
+    }
+
+    // ========================================================================
+    // Sigmoid Derivative Tests
+    // ========================================================================
+
+    @Test void sigmoidDerivAtZero() { assertEquals(0.25, ActivationFunctions.sigmoidDerivative(0.0), EPS); }
+    @Test void sigmoidDerivAtOne() { assertEquals(0.19661193324148185, ActivationFunctions.sigmoidDerivative(1.0), EPS); }
+    @Test void sigmoidDerivSaturated() { assertEquals(0.0000453978, ActivationFunctions.sigmoidDerivative(10.0), 1e-8); }
+
+    @Test
+    void sigmoidDerivNonNegative() {
+        double[] values = {-10, -1, 0, 1, 10};
+        for (double x : values) {
+            assertTrue(ActivationFunctions.sigmoidDerivative(x) >= 0.0);
+        }
+    }
+
+    // ========================================================================
+    // ReLU Tests
+    // ========================================================================
+
+    @Test void reluPositive() { assertEquals(5.0, ActivationFunctions.relu(5.0)); }
+    @Test void reluNegative() { assertEquals(0.0, ActivationFunctions.relu(-3.0)); }
+    @Test void reluZero() { assertEquals(0.0, ActivationFunctions.relu(0.0)); }
+
+    @Test
+    void reluIdempotence() {
+        double[] values = {-5, -1, 0, 1, 5};
+        for (double x : values) {
+            double r = ActivationFunctions.relu(x);
+            assertEquals(r, ActivationFunctions.relu(r), EPS);
+        }
+    }
+
+    // ========================================================================
+    // ReLU Derivative Tests
+    // ========================================================================
+
+    @Test void reluDerivPositive() { assertEquals(1.0, ActivationFunctions.reluDerivative(5.0)); }
+    @Test void reluDerivNegative() { assertEquals(0.0, ActivationFunctions.reluDerivative(-3.0)); }
+    @Test void reluDerivZero() { assertEquals(0.0, ActivationFunctions.reluDerivative(0.0)); }
+
+    // ========================================================================
+    // Tanh Tests
+    // ========================================================================
+
+    @Test void tanhAtZero() { assertEquals(0.0, ActivationFunctions.tanh(0.0), EPS); }
+    @Test void tanhPositive() { assertEquals(0.7615941559557649, ActivationFunctions.tanh(1.0), EPS); }
+    @Test void tanhNegative() { assertEquals(-0.7615941559557649, ActivationFunctions.tanh(-1.0), EPS); }
+
+    @Test
+    void tanhOddSymmetry() {
+        double[] values = {0.5, 1.0, 2.0, 5.0};
+        for (double x : values) {
+            assertEquals(
+                ActivationFunctions.tanh(-x),
+                -ActivationFunctions.tanh(x),
+                EPS, "Odd symmetry failed at x=" + x);
+        }
+    }
+
+    @Test
+    void tanhRange() {
+        double[] values = {-100, -10, -1, 0, 1, 10, 100};
+        for (double x : values) {
+            double t = ActivationFunctions.tanh(x);
+            assertTrue(t >= -1.0 && t <= 1.0, "Out of range at x=" + x);
+        }
+    }
+
+    // ========================================================================
+    // Tanh Derivative Tests
+    // ========================================================================
+
+    @Test void tanhDerivAtZero() { assertEquals(1.0, ActivationFunctions.tanhDerivative(0.0), EPS); }
+    @Test void tanhDerivAtOne() { assertEquals(0.4199743416140261, ActivationFunctions.tanhDerivative(1.0), EPS); }
+
+    @Test
+    void tanhDerivNonNegative() {
+        double[] values = {-10, -1, 0, 1, 10};
+        for (double x : values) {
+            assertTrue(ActivationFunctions.tanhDerivative(x) >= 0.0);
+        }
+    }
+}

--- a/code/packages/java/loss-functions/.gitignore
+++ b/code/packages/java/loss-functions/.gitignore
@@ -1,0 +1,2 @@
+gradle-build/
+.gradle/

--- a/code/packages/java/loss-functions/BUILD
+++ b/code/packages/java/loss-functions/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/loss-functions/CHANGELOG.md
+++ b/code/packages/java/loss-functions/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog — loss-functions (Java)
+
+All notable changes to this package are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [0.1.0] — 2026-04-04
+
+### Added
+- Initial implementation of Java loss-functions package.
+- `LossFunctions.mse()` — Mean Squared Error.
+- `LossFunctions.mae()` — Mean Absolute Error.
+- `LossFunctions.bce()` — Binary Cross-Entropy with epsilon clamping.
+- `LossFunctions.cce()` — Categorical Cross-Entropy with epsilon clamping.
+- `LossFunctions.mseDerivative()` — MSE gradient.
+- `LossFunctions.maeDerivative()` — MAE gradient.
+- `LossFunctions.bceDerivative()` — BCE gradient.
+- `LossFunctions.cceDerivative()` — CCE gradient.
+- Input validation (empty arrays, length mismatch).
+- JUnit 5 test suite with parity vectors from ML01 spec.

--- a/code/packages/java/loss-functions/README.md
+++ b/code/packages/java/loss-functions/README.md
@@ -1,0 +1,38 @@
+# loss-functions (Java)
+
+Fundamental error functions for machine learning: MSE, MAE, BCE, and CCE with derivatives for backpropagation.
+
+## What It Does
+
+| Function | Task | Formula |
+|----------|------|---------|
+| MSE | Regression | (1/n) sum((y - y_hat)^2) |
+| MAE | Regression | (1/n) sum(abs(y - y_hat)) |
+| BCE | Binary classification | -(1/n) sum(y log(y_hat) + (1-y) log(1-y_hat)) |
+| CCE | Multi-class classification | -(1/n) sum(y log(y_hat)) |
+
+Each function has a corresponding derivative for use in gradient descent.
+
+## Where It Fits
+
+- **Layer:** ML01 (leaf package, zero dependencies)
+- **Spec:** `code/specs/ML01-loss-functions.md`
+- **Used by:** Gradient descent, neural network training loops
+
+## Usage
+
+```java
+import com.codingadventures.lossfunctions.LossFunctions;
+
+double[] yTrue = {1.0, 0.0, 0.0};
+double[] yPred = {0.9, 0.1, 0.2};
+
+double loss = LossFunctions.mse(yTrue, yPred);       // 0.02
+double[] grad = LossFunctions.mseDerivative(yTrue, yPred);
+```
+
+## Running Tests
+
+```bash
+gradle test
+```

--- a/code/packages/java/loss-functions/build.gradle.kts
+++ b/code/packages/java/loss-functions/build.gradle.kts
@@ -1,0 +1,18 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/loss-functions/settings.gradle.kts
+++ b/code/packages/java/loss-functions/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "loss-functions"

--- a/code/packages/java/loss-functions/src/main/java/com/codingadventures/lossfunctions/LossFunctions.java
+++ b/code/packages/java/loss-functions/src/main/java/com/codingadventures/lossfunctions/LossFunctions.java
@@ -1,0 +1,243 @@
+// ============================================================================
+// LossFunctions.java — Fundamental Error Functions for Machine Learning
+// ============================================================================
+//
+// Loss functions measure how far a model's predictions are from the true
+// values.  During training, the optimizer (gradient descent) uses the loss
+// to decide which direction to adjust the model's weights.
+//
+// This module implements four standard loss functions plus their derivatives:
+//
+//   ┌───────────────┬────────────┬─────────────────────────────────────────┐
+//   │ Function      │ Task       │ Intuition                               │
+//   ├───────────────┼────────────┼─────────────────────────────────────────┤
+//   │ MSE           │ Regression │ Squares errors — big mistakes hurt a lot│
+//   │ MAE           │ Regression │ Absolute errors — treats all equally    │
+//   │ BCE           │ Binary     │ Log-loss for yes/no predictions         │
+//   │ CCE           │ Multi-cls  │ Log-loss for one-hot category vectors   │
+//   └───────────────┴────────────┴─────────────────────────────────────────┘
+//
+// Why build loss from scratch?
+// ----------------------------
+// Every ML framework (PyTorch, TensorFlow, etc.) ships these as built-in
+// functions.  By implementing them from first principles we see that they
+// are just simple arithmetic over arrays — no magic.
+//
+// Layer: ML01 (machine-learning layer 1 — leaf package, zero dependencies)
+// Spec:  code/specs/ML01-loss-functions.md
+// ============================================================================
+
+package com.codingadventures.lossfunctions;
+
+/**
+ * Namespace for loss functions and their derivatives.
+ *
+ * <p>All methods are pure and stateless — they take two equal-length arrays
+ * of {@code double} and return either a scalar loss or an array of gradients.</p>
+ */
+public final class LossFunctions {
+
+    private LossFunctions() {}
+
+    // ========================================================================
+    // Epsilon Clamping
+    // ========================================================================
+    //
+    // BCE and CCE use log(ŷ).  If ŷ is exactly 0 or 1, the logarithm is
+    // undefined (−∞) or the denominator in the BCE derivative is zero.
+    // We clamp predictions into [ε, 1−ε] to avoid this.  The standard
+    // choice across frameworks is ε = 1e-7.
+    // ========================================================================
+
+    private static final double EPSILON = 1e-7;
+
+    private static double clamp(double v) {
+        return Math.min(Math.max(v, EPSILON), 1.0 - EPSILON);
+    }
+
+    // ========================================================================
+    // Input Validation
+    // ========================================================================
+
+    private static void validate(double[] yTrue, double[] yPred) {
+        if (yTrue.length == 0) {
+            throw new IllegalArgumentException("yTrue must not be empty");
+        }
+        if (yTrue.length != yPred.length) {
+            throw new IllegalArgumentException(
+                "yTrue and yPred must have equal length (got "
+                + yTrue.length + " vs " + yPred.length + ")");
+        }
+    }
+
+    // ========================================================================
+    // Mean Squared Error (MSE)
+    // ========================================================================
+    //
+    // MSE = (1/n) Σ (yᵢ − ŷᵢ)²
+    //
+    // Squaring the difference means:
+    //   • Errors are always positive (no cancellation between +/−).
+    //   • Large errors are penalised quadratically — an error of 2 costs
+    //     4× as much as an error of 1.
+    //
+    // This makes MSE sensitive to outliers, which is desirable when big
+    // mistakes are truly worse (e.g. predicting house prices).
+    // ========================================================================
+
+    /**
+     * Compute Mean Squared Error between true labels and predictions.
+     *
+     * @param yTrue ground truth values
+     * @param yPred model predictions (same length as yTrue)
+     * @return the average squared difference
+     */
+    public static double mse(double[] yTrue, double[] yPred) {
+        validate(yTrue, yPred);
+        double sum = 0.0;
+        for (int i = 0; i < yTrue.length; i++) {
+            double diff = yTrue[i] - yPred[i];
+            sum += diff * diff;
+        }
+        return sum / yTrue.length;
+    }
+
+    /**
+     * Derivative of MSE with respect to each prediction ŷᵢ.
+     *
+     * <p>d(MSE)/d(ŷᵢ) = (2/n)(ŷᵢ − yᵢ)</p>
+     */
+    public static double[] mseDerivative(double[] yTrue, double[] yPred) {
+        validate(yTrue, yPred);
+        double n = yTrue.length;
+        double[] grad = new double[yTrue.length];
+        for (int i = 0; i < yTrue.length; i++) {
+            grad[i] = 2.0 * (yPred[i] - yTrue[i]) / n;
+        }
+        return grad;
+    }
+
+    // ========================================================================
+    // Mean Absolute Error (MAE)
+    // ========================================================================
+    //
+    // MAE = (1/n) Σ |yᵢ − ŷᵢ|
+    //
+    // Unlike MSE, MAE treats all errors linearly — an error of 2 costs
+    // exactly 2× as much as an error of 1.  This makes MAE more robust
+    // to outliers but harder to optimise.
+    // ========================================================================
+
+    /**
+     * Compute Mean Absolute Error between true labels and predictions.
+     */
+    public static double mae(double[] yTrue, double[] yPred) {
+        validate(yTrue, yPred);
+        double sum = 0.0;
+        for (int i = 0; i < yTrue.length; i++) {
+            sum += Math.abs(yTrue[i] - yPred[i]);
+        }
+        return sum / yTrue.length;
+    }
+
+    /**
+     * Derivative of MAE with respect to each prediction ŷᵢ.
+     *
+     * <p>d(MAE)/d(ŷᵢ) = (1/n) sign(ŷᵢ − yᵢ)</p>
+     */
+    public static double[] maeDerivative(double[] yTrue, double[] yPred) {
+        validate(yTrue, yPred);
+        double n = yTrue.length;
+        double[] grad = new double[yTrue.length];
+        for (int i = 0; i < yTrue.length; i++) {
+            double diff = yPred[i] - yTrue[i];
+            if (diff > 0) grad[i] = 1.0 / n;
+            else if (diff < 0) grad[i] = -1.0 / n;
+            else grad[i] = 0.0;
+        }
+        return grad;
+    }
+
+    // ========================================================================
+    // Binary Cross-Entropy (BCE)
+    // ========================================================================
+    //
+    // BCE = −(1/n) Σ [ yᵢ·log(ŷᵢ) + (1−yᵢ)·log(1−ŷᵢ) ]
+    //
+    // Cross-entropy comes from information theory.  It measures how many
+    // extra bits you'd need to encode outcomes from the true distribution
+    // using a code optimised for the predicted distribution.
+    // ========================================================================
+
+    /**
+     * Compute Binary Cross-Entropy loss.
+     *
+     * <p>Predictions are clamped to [ε, 1−ε] to avoid log(0).</p>
+     */
+    public static double bce(double[] yTrue, double[] yPred) {
+        validate(yTrue, yPred);
+        double sum = 0.0;
+        for (int i = 0; i < yTrue.length; i++) {
+            double p = clamp(yPred[i]);
+            sum += yTrue[i] * Math.log(p) + (1.0 - yTrue[i]) * Math.log(1.0 - p);
+        }
+        return -sum / yTrue.length;
+    }
+
+    /**
+     * Derivative of BCE with respect to each prediction ŷᵢ.
+     *
+     * <p>d(BCE)/d(ŷᵢ) = (1/n) · (ŷᵢ − yᵢ) / (ŷᵢ · (1 − ŷᵢ))</p>
+     */
+    public static double[] bceDerivative(double[] yTrue, double[] yPred) {
+        validate(yTrue, yPred);
+        double n = yTrue.length;
+        double[] grad = new double[yTrue.length];
+        for (int i = 0; i < yTrue.length; i++) {
+            double p = clamp(yPred[i]);
+            grad[i] = (p - yTrue[i]) / (p * (1.0 - p)) / n;
+        }
+        return grad;
+    }
+
+    // ========================================================================
+    // Categorical Cross-Entropy (CCE)
+    // ========================================================================
+    //
+    // CCE = −(1/n) Σ yᵢ·log(ŷᵢ)
+    //
+    // CCE generalises BCE to more than two classes.  yTrue is a one-hot
+    // vector and yPred is a probability distribution over all classes.
+    // ========================================================================
+
+    /**
+     * Compute Categorical Cross-Entropy loss.
+     *
+     * <p>Predictions are clamped to [ε, 1−ε] to avoid log(0).</p>
+     */
+    public static double cce(double[] yTrue, double[] yPred) {
+        validate(yTrue, yPred);
+        double sum = 0.0;
+        for (int i = 0; i < yTrue.length; i++) {
+            double p = clamp(yPred[i]);
+            sum += yTrue[i] * Math.log(p);
+        }
+        return -sum / yTrue.length;
+    }
+
+    /**
+     * Derivative of CCE with respect to each prediction ŷᵢ.
+     *
+     * <p>d(CCE)/d(ŷᵢ) = −(1/n) · yᵢ / ŷᵢ</p>
+     */
+    public static double[] cceDerivative(double[] yTrue, double[] yPred) {
+        validate(yTrue, yPred);
+        double n = yTrue.length;
+        double[] grad = new double[yTrue.length];
+        for (int i = 0; i < yTrue.length; i++) {
+            double p = clamp(yPred[i]);
+            grad[i] = -yTrue[i] / p / n;
+        }
+        return grad;
+    }
+}

--- a/code/packages/java/loss-functions/src/test/java/com/codingadventures/lossfunctions/LossFunctionsTest.java
+++ b/code/packages/java/loss-functions/src/test/java/com/codingadventures/lossfunctions/LossFunctionsTest.java
@@ -1,0 +1,199 @@
+package com.codingadventures.lossfunctions;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class LossFunctionsTest {
+
+    private static final double TOL = 1e-7;
+
+    // ========================================================================
+    // MSE Tests
+    // ========================================================================
+
+    @Test
+    void testMSEParityVector() {
+        // From spec: y_true=[1,0,0], y_pred=[0.9,0.1,0.2] → 0.02
+        double result = LossFunctions.mse(
+            new double[]{1.0, 0.0, 0.0},
+            new double[]{0.9, 0.1, 0.2});
+        assertEquals(0.02, result, TOL);
+    }
+
+    @Test
+    void testMSEPerfectPrediction() {
+        double result = LossFunctions.mse(
+            new double[]{1.0, 2.0, 3.0},
+            new double[]{1.0, 2.0, 3.0});
+        assertEquals(0.0, result, TOL);
+    }
+
+    @Test
+    void testMSESymmetry() {
+        double[] a = {1.0, 2.0, 3.0};
+        double[] b = {1.5, 2.5, 3.5};
+        assertEquals(LossFunctions.mse(a, b), LossFunctions.mse(b, a), TOL);
+    }
+
+    @Test
+    void testMSEDerivative() {
+        double[] grad = LossFunctions.mseDerivative(
+            new double[]{1.0, 0.0, 0.0},
+            new double[]{0.9, 0.1, 0.2});
+        assertArrayEquals(new double[]{-2.0/30.0, 2.0/30.0, 4.0/30.0}, grad, TOL);
+    }
+
+    @Test
+    void testMSEDerivativeSignConvention() {
+        double[] grad = LossFunctions.mseDerivative(new double[]{0.0}, new double[]{1.0});
+        assertTrue(grad[0] > 0.0);
+    }
+
+    // ========================================================================
+    // MAE Tests
+    // ========================================================================
+
+    @Test
+    void testMAEParityVector() {
+        double result = LossFunctions.mae(
+            new double[]{1.0, 0.0, 0.0},
+            new double[]{0.9, 0.1, 0.2});
+        assertEquals(0.1333333333, result, TOL);
+    }
+
+    @Test
+    void testMAEPerfectPrediction() {
+        double result = LossFunctions.mae(
+            new double[]{1.0, 2.0, 3.0},
+            new double[]{1.0, 2.0, 3.0});
+        assertEquals(0.0, result, TOL);
+    }
+
+    @Test
+    void testMAEDerivative() {
+        double[] grad = LossFunctions.maeDerivative(
+            new double[]{1.0, 0.0, 0.0},
+            new double[]{0.9, 0.1, 0.2});
+        assertArrayEquals(new double[]{-1.0/3.0, 1.0/3.0, 1.0/3.0}, grad, TOL);
+    }
+
+    @Test
+    void testMAEDerivativeAtZero() {
+        double[] grad = LossFunctions.maeDerivative(new double[]{1.0}, new double[]{1.0});
+        assertEquals(0.0, grad[0], TOL);
+    }
+
+    // ========================================================================
+    // BCE Tests
+    // ========================================================================
+
+    @Test
+    void testBCEParityVector() {
+        double result = LossFunctions.bce(
+            new double[]{1.0, 0.0, 1.0},
+            new double[]{0.9, 0.1, 0.8});
+        assertEquals(0.1446215275, result, 1e-6);
+    }
+
+    @Test
+    void testBCENonNegative() {
+        double result = LossFunctions.bce(
+            new double[]{1.0, 0.0, 1.0},
+            new double[]{0.5, 0.5, 0.5});
+        assertTrue(result >= 0.0);
+    }
+
+    @Test
+    void testBCEDerivativeFinite() {
+        double[] grad = LossFunctions.bceDerivative(
+            new double[]{1.0, 0.0},
+            new double[]{0.9, 0.1});
+        for (double g : grad) {
+            assertFalse(Double.isNaN(g));
+            assertFalse(Double.isInfinite(g));
+        }
+    }
+
+    @Test
+    void testBCEHandlesEdgePredictions() {
+        double result = LossFunctions.bce(new double[]{1.0, 0.0}, new double[]{0.0, 1.0});
+        assertFalse(Double.isNaN(result));
+        assertFalse(Double.isInfinite(result));
+    }
+
+    // ========================================================================
+    // CCE Tests
+    // ========================================================================
+
+    @Test
+    void testCCEParityVector() {
+        double result = LossFunctions.cce(
+            new double[]{1.0, 0.0, 0.0},
+            new double[]{0.8, 0.1, 0.1});
+        assertEquals(0.07438118, result, 1e-5);
+    }
+
+    @Test
+    void testCCEOnlyCorrectClassContributes() {
+        double loss1 = LossFunctions.cce(
+            new double[]{1.0, 0.0, 0.0}, new double[]{0.8, 0.1, 0.1});
+        double loss2 = LossFunctions.cce(
+            new double[]{1.0, 0.0, 0.0}, new double[]{0.8, 0.05, 0.15});
+        assertEquals(loss1, loss2, TOL);
+    }
+
+    @Test
+    void testCCENonNegative() {
+        double result = LossFunctions.cce(
+            new double[]{0.0, 1.0, 0.0},
+            new double[]{0.1, 0.7, 0.2});
+        assertTrue(result >= 0.0);
+    }
+
+    @Test
+    void testCCEDerivative() {
+        double[] grad = LossFunctions.cceDerivative(
+            new double[]{1.0, 0.0, 0.0},
+            new double[]{0.8, 0.1, 0.1});
+        assertTrue(grad[0] < 0.0);
+        assertEquals(0.0, grad[1], 1e-5);
+        assertEquals(0.0, grad[2], 1e-5);
+    }
+
+    @Test
+    void testCCEHandlesZeroPredictions() {
+        double result = LossFunctions.cce(new double[]{1.0, 0.0}, new double[]{0.0, 1.0});
+        assertFalse(Double.isNaN(result));
+        assertFalse(Double.isInfinite(result));
+    }
+
+    // ========================================================================
+    // Validation Tests
+    // ========================================================================
+
+    @Test
+    void testEmptyArrayThrows() {
+        assertThrows(IllegalArgumentException.class, () ->
+            LossFunctions.mse(new double[]{}, new double[]{}));
+    }
+
+    @Test
+    void testMismatchedLengthThrows() {
+        assertThrows(IllegalArgumentException.class, () ->
+            LossFunctions.mse(new double[]{1.0}, new double[]{1.0, 2.0}));
+    }
+
+    // ========================================================================
+    // Single Element Tests
+    // ========================================================================
+
+    @Test
+    void testSingleElementMSE() {
+        assertEquals(0.25, LossFunctions.mse(new double[]{1.0}, new double[]{0.5}), TOL);
+    }
+
+    @Test
+    void testSingleElementMAE() {
+        assertEquals(0.5, LossFunctions.mae(new double[]{1.0}, new double[]{0.5}), TOL);
+    }
+}

--- a/code/packages/java/matrix/.gitignore
+++ b/code/packages/java/matrix/.gitignore
@@ -1,0 +1,2 @@
+gradle-build/
+.gradle/

--- a/code/packages/java/matrix/BUILD
+++ b/code/packages/java/matrix/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/matrix/CHANGELOG.md
+++ b/code/packages/java/matrix/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog — matrix (Java)
+
+All notable changes to this package are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [0.1.0] — 2026-04-04
+
+### Added
+- Initial implementation of Java matrix package.
+- Immutable `Matrix` class with 2D array constructor.
+- Factory methods: `fromScalar`, `fromArray`, `zeros`.
+- Element-wise `add`, `subtract`, `addScalar`, `subtractScalar`.
+- `scale` for scalar multiplication.
+- `transpose` and `dot` (matrix multiplication).
+- Value-based `equals` and `hashCode`.

--- a/code/packages/java/matrix/README.md
+++ b/code/packages/java/matrix/README.md
@@ -1,0 +1,19 @@
+# matrix (Java)
+
+Immutable matrix mathematics library for machine learning. ML03.
+
+## Usage
+
+```java
+import com.codingadventures.matrix.Matrix;
+
+Matrix a = new Matrix(new double[][]{{1, 2}, {3, 4}});
+Matrix b = new Matrix(new double[][]{{5, 6}, {7, 8}});
+Matrix c = a.dot(b);  // [[19, 22], [43, 50]]
+```
+
+## Running Tests
+
+```bash
+gradle test
+```

--- a/code/packages/java/matrix/build.gradle.kts
+++ b/code/packages/java/matrix/build.gradle.kts
@@ -1,0 +1,18 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/matrix/settings.gradle.kts
+++ b/code/packages/java/matrix/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "matrix"

--- a/code/packages/java/matrix/src/main/java/com/codingadventures/matrix/Matrix.java
+++ b/code/packages/java/matrix/src/main/java/com/codingadventures/matrix/Matrix.java
@@ -1,0 +1,217 @@
+// ============================================================================
+// Matrix.java — Matrix Mathematics Library
+// ============================================================================
+//
+// A matrix is a rectangular grid of numbers arranged in rows and columns.
+// Matrices are the fundamental data structure of linear algebra and the
+// computational backbone of neural networks.
+//
+// This class provides an immutable Matrix type with:
+//   • Factory methods from scalars, 1D arrays, or 2D arrays
+//   • Element-wise add/subtract (matrix-matrix and matrix-scalar)
+//   • Scalar multiplication (scale)
+//   • Transpose (swap rows and columns)
+//   • Dot product (true matrix multiplication)
+//
+// Layer: ML03 (machine-learning layer 3 — leaf package, zero dependencies)
+// Spec:  code/specs/ML03-matrix.md
+// ============================================================================
+
+package com.codingadventures.matrix;
+
+import java.util.Arrays;
+
+/**
+ * An immutable matrix of double values.
+ *
+ * <p>All arithmetic operations return new {@code Matrix} instances — the
+ * original is never mutated.</p>
+ */
+public final class Matrix {
+
+    private final double[][] data;
+    private final int rows;
+    private final int cols;
+
+    // ========================================================================
+    // Constructor
+    // ========================================================================
+
+    /** Create a matrix from a 2D array (deep-copied). */
+    public Matrix(double[][] data) {
+        if (data.length == 0 || data[0].length == 0) {
+            throw new IllegalArgumentException("Matrix must have at least one row and column");
+        }
+        this.rows = data.length;
+        this.cols = data[0].length;
+        this.data = new double[rows][cols];
+        for (int i = 0; i < rows; i++) {
+            if (data[i].length != cols) {
+                throw new IllegalArgumentException(
+                    "Row " + i + " has " + data[i].length + " columns, expected " + cols);
+            }
+            System.arraycopy(data[i], 0, this.data[i], 0, cols);
+        }
+    }
+
+    // ========================================================================
+    // Factories
+    // ========================================================================
+
+    /** Create a 1x1 matrix from a scalar. */
+    public static Matrix fromScalar(double value) {
+        return new Matrix(new double[][]{{value}});
+    }
+
+    /** Create a 1xN matrix (row vector) from a 1D array. */
+    public static Matrix fromArray(double[] array) {
+        if (array.length == 0) throw new IllegalArgumentException("Array must not be empty");
+        return new Matrix(new double[][]{array.clone()});
+    }
+
+    /** Create an MxN matrix filled with zeros. */
+    public static Matrix zeros(int rows, int cols) {
+        if (rows <= 0 || cols <= 0) throw new IllegalArgumentException("Dimensions must be positive");
+        double[][] data = new double[rows][cols];
+        return new Matrix(data);
+    }
+
+    // ========================================================================
+    // Accessors
+    // ========================================================================
+
+    public int getRows() { return rows; }
+    public int getCols() { return cols; }
+
+    /** Return a deep copy of the underlying data. */
+    public double[][] getData() {
+        double[][] copy = new double[rows][cols];
+        for (int i = 0; i < rows; i++) {
+            System.arraycopy(data[i], 0, copy[i], 0, cols);
+        }
+        return copy;
+    }
+
+    /** Access element at (row, col). */
+    public double get(int row, int col) { return data[row][col]; }
+
+    // ========================================================================
+    // Element-wise Arithmetic
+    // ========================================================================
+
+    /** Add two matrices element-wise. */
+    public Matrix add(Matrix other) {
+        checkDimensions(other, "add");
+        double[][] result = new double[rows][cols];
+        for (int i = 0; i < rows; i++)
+            for (int j = 0; j < cols; j++)
+                result[i][j] = data[i][j] + other.data[i][j];
+        return new Matrix(result);
+    }
+
+    /** Subtract another matrix element-wise. */
+    public Matrix subtract(Matrix other) {
+        checkDimensions(other, "subtract");
+        double[][] result = new double[rows][cols];
+        for (int i = 0; i < rows; i++)
+            for (int j = 0; j < cols; j++)
+                result[i][j] = data[i][j] - other.data[i][j];
+        return new Matrix(result);
+    }
+
+    /** Add a scalar to every element. */
+    public Matrix addScalar(double scalar) {
+        double[][] result = new double[rows][cols];
+        for (int i = 0; i < rows; i++)
+            for (int j = 0; j < cols; j++)
+                result[i][j] = data[i][j] + scalar;
+        return new Matrix(result);
+    }
+
+    /** Subtract a scalar from every element. */
+    public Matrix subtractScalar(double scalar) {
+        return addScalar(-scalar);
+    }
+
+    // ========================================================================
+    // Scale
+    // ========================================================================
+
+    /** Multiply every element by a scalar. */
+    public Matrix scale(double scalar) {
+        double[][] result = new double[rows][cols];
+        for (int i = 0; i < rows; i++)
+            for (int j = 0; j < cols; j++)
+                result[i][j] = data[i][j] * scalar;
+        return new Matrix(result);
+    }
+
+    // ========================================================================
+    // Transpose
+    // ========================================================================
+
+    /** Swap rows and columns: M×N becomes N×M. */
+    public Matrix transpose() {
+        double[][] result = new double[cols][rows];
+        for (int i = 0; i < rows; i++)
+            for (int j = 0; j < cols; j++)
+                result[j][i] = data[i][j];
+        return new Matrix(result);
+    }
+
+    // ========================================================================
+    // Dot Product (Matrix Multiplication)
+    // ========================================================================
+
+    /**
+     * Matrix multiplication: (M×K) · (K×N) = (M×N).
+     *
+     * <p>C[i][j] = Σ(k) A[i][k] * B[k][j]</p>
+     */
+    public Matrix dot(Matrix other) {
+        if (cols != other.rows) {
+            throw new IllegalArgumentException(
+                "Dot dimension mismatch: " + rows + "×" + cols + " · " + other.rows + "×" + other.cols);
+        }
+        double[][] result = new double[rows][other.cols];
+        for (int i = 0; i < rows; i++)
+            for (int j = 0; j < other.cols; j++) {
+                double sum = 0.0;
+                for (int k = 0; k < cols; k++)
+                    sum += data[i][k] * other.data[k][j];
+                result[i][j] = sum;
+            }
+        return new Matrix(result);
+    }
+
+    // ========================================================================
+    // Helpers
+    // ========================================================================
+
+    private void checkDimensions(Matrix other, String op) {
+        if (rows != other.rows || cols != other.cols) {
+            throw new IllegalArgumentException(
+                op + " dimension mismatch: " + rows + "×" + cols + " vs " + other.rows + "×" + other.cols);
+        }
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!(obj instanceof Matrix other)) return false;
+        if (rows != other.rows || cols != other.cols) return false;
+        return Arrays.deepEquals(data, other.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.deepHashCode(data);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder("Matrix(");
+        sb.append(rows).append("×").append(cols).append(")");
+        return sb.toString();
+    }
+}

--- a/code/packages/java/matrix/src/test/java/com/codingadventures/matrix/MatrixTest.java
+++ b/code/packages/java/matrix/src/test/java/com/codingadventures/matrix/MatrixTest.java
@@ -1,0 +1,181 @@
+package com.codingadventures.matrix;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class MatrixTest {
+
+    private static final double EPS = 1e-10;
+
+    // ========================================================================
+    // Initialization
+    // ========================================================================
+
+    @Test void fromScalar() {
+        Matrix m = Matrix.fromScalar(5.0);
+        assertEquals(1, m.getRows());
+        assertEquals(1, m.getCols());
+        assertEquals(5.0, m.get(0, 0));
+    }
+
+    @Test void fromArray() {
+        Matrix m = Matrix.fromArray(new double[]{1, 2, 3});
+        assertEquals(1, m.getRows());
+        assertEquals(3, m.getCols());
+        assertEquals(2.0, m.get(0, 1));
+    }
+
+    @Test void from2DArray() {
+        Matrix m = new Matrix(new double[][]{{1, 2}, {3, 4}});
+        assertEquals(2, m.getRows());
+        assertEquals(2, m.getCols());
+        assertEquals(3.0, m.get(1, 0));
+    }
+
+    @Test void zeros() {
+        Matrix m = Matrix.zeros(3, 2);
+        assertEquals(3, m.getRows());
+        assertEquals(2, m.getCols());
+        for (int i = 0; i < 3; i++)
+            for (int j = 0; j < 2; j++)
+                assertEquals(0.0, m.get(i, j));
+    }
+
+    @Test void raggedArrayThrows() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new Matrix(new double[][]{{1, 2}, {3}}));
+    }
+
+    // ========================================================================
+    // Addition
+    // ========================================================================
+
+    @Test void addMatrices() {
+        Matrix a = new Matrix(new double[][]{{1, 2}, {3, 4}});
+        Matrix b = new Matrix(new double[][]{{5, 6}, {7, 8}});
+        Matrix c = a.add(b);
+        assertEquals(new Matrix(new double[][]{{6, 8}, {10, 12}}), c);
+    }
+
+    @Test void addScalar() {
+        Matrix m = new Matrix(new double[][]{{1, 2}, {3, 4}});
+        assertEquals(new Matrix(new double[][]{{11, 12}, {13, 14}}), m.addScalar(10));
+    }
+
+    @Test void addDimensionMismatch() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new Matrix(new double[][]{{1, 2}}).add(new Matrix(new double[][]{{1}, {2}})));
+    }
+
+    // ========================================================================
+    // Subtraction
+    // ========================================================================
+
+    @Test void subtractMatrices() {
+        Matrix a = new Matrix(new double[][]{{5, 6}, {7, 8}});
+        Matrix b = new Matrix(new double[][]{{1, 2}, {3, 4}});
+        assertEquals(new Matrix(new double[][]{{4, 4}, {4, 4}}), a.subtract(b));
+    }
+
+    @Test void subtractSelf() {
+        Matrix a = new Matrix(new double[][]{{1, 2}, {3, 4}});
+        assertEquals(Matrix.zeros(2, 2), a.subtract(a));
+    }
+
+    @Test void subtractScalar() {
+        Matrix m = new Matrix(new double[][]{{10, 20}});
+        assertEquals(new Matrix(new double[][]{{5, 15}}), m.subtractScalar(5));
+    }
+
+    // ========================================================================
+    // Scale
+    // ========================================================================
+
+    @Test void scale() {
+        Matrix m = new Matrix(new double[][]{{1, 2}, {3, 4}});
+        assertEquals(new Matrix(new double[][]{{2, 4}, {6, 8}}), m.scale(2));
+    }
+
+    @Test void scaleByZero() {
+        Matrix m = new Matrix(new double[][]{{1, 2}});
+        assertEquals(Matrix.zeros(1, 2), m.scale(0));
+    }
+
+    // ========================================================================
+    // Transpose
+    // ========================================================================
+
+    @Test void transposeRectangular() {
+        Matrix m = new Matrix(new double[][]{{1, 2, 3}, {4, 5, 6}});
+        Matrix t = m.transpose();
+        assertEquals(3, t.getRows());
+        assertEquals(2, t.getCols());
+        assertEquals(new Matrix(new double[][]{{1, 4}, {2, 5}, {3, 6}}), t);
+    }
+
+    @Test void doubleTranspose() {
+        Matrix m = new Matrix(new double[][]{{1, 2, 3}, {4, 5, 6}});
+        assertEquals(m, m.transpose().transpose());
+    }
+
+    // ========================================================================
+    // Dot Product
+    // ========================================================================
+
+    @Test void dot2x2() {
+        Matrix a = new Matrix(new double[][]{{1, 2}, {3, 4}});
+        Matrix b = new Matrix(new double[][]{{5, 6}, {7, 8}});
+        assertEquals(new Matrix(new double[][]{{19, 22}, {43, 50}}), a.dot(b));
+    }
+
+    @Test void dotNonSquare() {
+        Matrix a = new Matrix(new double[][]{{1, 2, 3}});
+        Matrix b = new Matrix(new double[][]{{4}, {5}, {6}});
+        Matrix c = a.dot(b);
+        assertEquals(1, c.getRows());
+        assertEquals(1, c.getCols());
+        assertEquals(32.0, c.get(0, 0), EPS);
+    }
+
+    @Test void dotIdentity() {
+        Matrix a = new Matrix(new double[][]{{1, 2}, {3, 4}});
+        Matrix eye = new Matrix(new double[][]{{1, 0}, {0, 1}});
+        assertEquals(a, a.dot(eye));
+        assertEquals(a, eye.dot(a));
+    }
+
+    @Test void dotDimensionMismatch() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new Matrix(new double[][]{{1, 2}}).dot(new Matrix(new double[][]{{1, 2}})));
+    }
+
+    // ========================================================================
+    // Equality & Immutability
+    // ========================================================================
+
+    @Test void equality() {
+        Matrix a = new Matrix(new double[][]{{1, 2}, {3, 4}});
+        Matrix b = new Matrix(new double[][]{{1, 2}, {3, 4}});
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test void inequality() {
+        assertNotEquals(
+            new Matrix(new double[][]{{1, 2}}),
+            new Matrix(new double[][]{{1, 3}}));
+    }
+
+    @Test void immutability() {
+        Matrix a = new Matrix(new double[][]{{1, 2}, {3, 4}});
+        a.add(new Matrix(new double[][]{{10, 20}, {30, 40}}));
+        assertEquals(1.0, a.get(0, 0));
+    }
+
+    @Test void getDataReturnsCopy() {
+        Matrix m = new Matrix(new double[][]{{1, 2}});
+        double[][] copy = m.getData();
+        copy[0][0] = 999;
+        assertEquals(1.0, m.get(0, 0));
+    }
+}

--- a/code/packages/java/wave/.gitignore
+++ b/code/packages/java/wave/.gitignore
@@ -1,0 +1,2 @@
+gradle-build/
+.gradle/

--- a/code/packages/java/wave/BUILD
+++ b/code/packages/java/wave/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/wave/CHANGELOG.md
+++ b/code/packages/java/wave/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog — wave (Java)
+
+## [0.1.0] — 2026-04-04
+
+### Added
+- Initial implementation: Wave class with amplitude, frequency, phase.
+- Derived properties: period, angularFrequency.
+- evaluate(t) for displacement computation.
+- Input validation.

--- a/code/packages/java/wave/README.md
+++ b/code/packages/java/wave/README.md
@@ -1,0 +1,13 @@
+# wave (Java)
+
+Simple harmonic wave model: y(t) = A sin(2*pi*f*t + phi). PHY01.
+
+## Usage
+
+```java
+import com.codingadventures.wave.Wave;
+
+Wave w = new Wave(1.0, 440.0);
+double value = w.evaluate(0.25);
+double period = w.period();
+```

--- a/code/packages/java/wave/build.gradle.kts
+++ b/code/packages/java/wave/build.gradle.kts
@@ -1,0 +1,18 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/wave/settings.gradle.kts
+++ b/code/packages/java/wave/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "wave"

--- a/code/packages/java/wave/src/main/java/com/codingadventures/wave/Wave.java
+++ b/code/packages/java/wave/src/main/java/com/codingadventures/wave/Wave.java
@@ -1,0 +1,64 @@
+// ============================================================================
+// Wave.java — Simple Harmonic Wave Model
+// ============================================================================
+//
+// y(t) = A · sin(2π·f·t + φ)
+//
+// A sinusoidal wave is the fundamental building block of signal processing.
+// Every signal — from AM radio to 5G — is a combination of sine waves.
+//
+// Layer: PHY01 (physics layer 1 — leaf package, zero dependencies)
+// Spec:  code/specs/PHY01-wave.md
+// ============================================================================
+
+package com.codingadventures.wave;
+
+/**
+ * An immutable sinusoidal wave: y(t) = A · sin(2π·f·t + φ).
+ */
+public final class Wave {
+
+    private final double amplitude;
+    private final double frequency;
+    private final double phase;
+
+    /**
+     * Create a new wave.
+     *
+     * @param amplitude peak displacement (must be >= 0)
+     * @param frequency cycles per second in Hz (must be > 0)
+     * @param phase starting offset in radians
+     */
+    public Wave(double amplitude, double frequency, double phase) {
+        if (amplitude < 0) throw new IllegalArgumentException("Amplitude must be non-negative");
+        if (frequency <= 0) throw new IllegalArgumentException("Frequency must be positive");
+        this.amplitude = amplitude;
+        this.frequency = frequency;
+        this.phase = phase;
+    }
+
+    /** Create a wave with zero phase. */
+    public Wave(double amplitude, double frequency) {
+        this(amplitude, frequency, 0.0);
+    }
+
+    public double getAmplitude() { return amplitude; }
+    public double getFrequency() { return frequency; }
+    public double getPhase() { return phase; }
+
+    /** Period: time for one complete cycle. T = 1/f */
+    public double period() { return 1.0 / frequency; }
+
+    /** Angular frequency in radians per second. ω = 2π·f */
+    public double angularFrequency() { return 2.0 * Math.PI * frequency; }
+
+    /**
+     * Evaluate the wave at time t (seconds).
+     *
+     * @param t time in seconds
+     * @return displacement y(t) = A · sin(2π·f·t + φ)
+     */
+    public double evaluate(double t) {
+        return amplitude * Math.sin(2.0 * Math.PI * frequency * t + phase);
+    }
+}

--- a/code/packages/java/wave/src/test/java/com/codingadventures/wave/WaveTest.java
+++ b/code/packages/java/wave/src/test/java/com/codingadventures/wave/WaveTest.java
@@ -1,0 +1,75 @@
+package com.codingadventures.wave;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class WaveTest {
+
+    private static final double EPS = 1e-10;
+
+    @Test void construction() {
+        Wave w = new Wave(1.0, 440.0);
+        assertEquals(1.0, w.getAmplitude());
+        assertEquals(440.0, w.getFrequency());
+        assertEquals(0.0, w.getPhase());
+    }
+
+    @Test void constructionWithPhase() {
+        Wave w = new Wave(2.0, 100.0, Math.PI / 2);
+        assertEquals(Math.PI / 2, w.getPhase(), EPS);
+    }
+
+    @Test void period() {
+        assertEquals(0.25, new Wave(1.0, 4.0).period(), EPS);
+    }
+
+    @Test void angularFrequency() {
+        assertEquals(2 * Math.PI, new Wave(1.0, 1.0).angularFrequency(), EPS);
+    }
+
+    @Test void zeroCrossing() {
+        assertEquals(0.0, new Wave(1.0, 1.0).evaluate(0.0), EPS);
+    }
+
+    @Test void peak() {
+        assertEquals(3.0, new Wave(3.0, 1.0).evaluate(0.25), 1e-9);
+    }
+
+    @Test void periodicity() {
+        Wave w = new Wave(2.0, 5.0);
+        double t = 0.123;
+        assertEquals(w.evaluate(t), w.evaluate(t + w.period()), 1e-9);
+    }
+
+    @Test void phaseShift() {
+        assertEquals(1.0, new Wave(1.0, 1.0, Math.PI / 2).evaluate(0.0), 1e-9);
+    }
+
+    @Test void trough() {
+        assertEquals(-2.0, new Wave(2.0, 1.0).evaluate(0.75), 1e-9);
+    }
+
+    @Test void zeroAmplitude() {
+        assertEquals(0.0, new Wave(0.0, 1.0).evaluate(0.5), EPS);
+    }
+
+    @Test void oppositePhase() {
+        Wave w1 = new Wave(1.0, 1.0, 0.0);
+        Wave w2 = new Wave(1.0, 1.0, Math.PI);
+        assertEquals(0.0, w1.evaluate(0.3) + w2.evaluate(0.3), 1e-9);
+    }
+
+    @Test void negativeAmplitudeThrows() {
+        assertThrows(IllegalArgumentException.class, () -> new Wave(-1.0, 1.0));
+    }
+
+    @Test void zeroFrequencyThrows() {
+        assertThrows(IllegalArgumentException.class, () -> new Wave(1.0, 0.0));
+    }
+
+    @Test void highFrequency() {
+        Wave w = new Wave(1.0, 1000.0);
+        assertEquals(0.001, w.period(), EPS);
+        assertEquals(1.0, w.evaluate(0.00025), 1e-8);
+    }
+}

--- a/code/programs/go/build-tool/detect_languages_test.go
+++ b/code/programs/go/build-tool/detect_languages_test.go
@@ -18,7 +18,7 @@ func TestAllToolchainsConstant(t *testing.T) {
 	expected := map[string]bool{
 		"python": true, "ruby": true, "go": true,
 		"typescript": true, "rust": true, "elixir": true, "lua": true, "perl": true,
-		"swift": true, "haskell": true, "dotnet": true,
+		"swift": true, "java": true, "kotlin": true, "haskell": true, "dotnet": true,
 	}
 	if len(allToolchains) != len(expected) {
 		t.Errorf("allToolchains has %d entries, want %d", len(allToolchains), len(expected))
@@ -220,6 +220,8 @@ func TestToolchainForPackageLanguage(t *testing.T) {
 		"csharp":  "dotnet",
 		"fsharp":  "dotnet",
 		"dotnet":  "dotnet",
+		"java":    "java",
+		"kotlin":  "kotlin",
 		"python":  "python",
 		"swift":   "swift",
 		"unknown": "unknown",

--- a/code/programs/go/build-tool/internal/executor/executor.go
+++ b/code/programs/go/build-tool/internal/executor/executor.go
@@ -426,12 +426,22 @@ func buildResourceKeys(pkg discovery.Package, pathToPkg map[string]string) []str
 // buildResourceKeysForOS is the testable version of buildResourceKeys that
 // accepts an explicit OS name. This allows tests to verify Windows-specific
 // lock key behaviour on non-Windows hosts.
-func buildResourceKeysForOS(pkg discovery.Package, pathToPkg map[string]string, _ string) []string {
+func buildResourceKeysForOS(pkg discovery.Package, pathToPkg map[string]string, goos string) []string {
 	keys := map[string]bool{
 		pkg.Name: true,
 	}
 
 	for _, command := range pkg.BuildCommands {
+		if goos == "windows" && isGradleCommand(command) {
+			// Windows runners showed long-lived Java/Gradle processes when multiple
+			// independent JVM packages were launched together. Serialize Gradle-backed
+			// Java/Kotlin builds there the same way we already protect other shared
+			// package-manager state such as Hex and LuaRocks.
+			if pkg.Language == "java" || pkg.Language == "kotlin" {
+				keys["global:gradle-windows-runner"] = true
+			}
+		}
+
 		if pkg.Language == "elixir" && strings.Contains(command, "mix deps.get") {
 			// Hex persists a shared cache under ~/.hex, which is not safe for
 			// concurrent writes across packages in CI.
@@ -468,4 +478,34 @@ func buildResourceKeysForOS(pkg discovery.Package, pathToPkg map[string]string, 
 		result = append(result, key)
 	}
 	return result
+}
+
+func isGradleCommand(command string) bool {
+	trimmed := strings.TrimSpace(command)
+	if trimmed == "" {
+		return false
+	}
+
+	for _, prefix := range []string{
+		"gradle ",
+		"gradle\t",
+		"gradlew ",
+		"gradlew\t",
+		"gradlew.bat ",
+		"gradlew.bat\t",
+		"./gradlew ",
+		"./gradlew\t",
+		".\\gradlew ",
+		".\\gradlew\t",
+	} {
+		if strings.HasPrefix(trimmed, prefix) {
+			return true
+		}
+	}
+
+	return trimmed == "gradle" ||
+		trimmed == "gradlew" ||
+		trimmed == "gradlew.bat" ||
+		trimmed == "./gradlew" ||
+		trimmed == ".\\gradlew"
 }

--- a/code/programs/go/build-tool/internal/executor/executor_test.go
+++ b/code/programs/go/build-tool/internal/executor/executor_test.go
@@ -434,6 +434,69 @@ func TestBuildResourceKeysIncludesGlobalLuaRocksLockForLuaRemovesOnLinux(t *test
 	}
 }
 
+func TestBuildResourceKeysIncludesGlobalGradleLockForJavaOnWindows(t *testing.T) {
+	root := makeFixture(t, map[string]string{
+		"pkg/BUILD": "gradle test",
+	})
+
+	pkg := discovery.Package{
+		Name:          "java/pkg",
+		Path:          filepath.Join(root, "pkg"),
+		BuildCommands: []string{"gradle test"},
+		Language:      "java",
+	}
+
+	keys := buildResourceKeysForOS(pkg, map[string]string{
+		filepath.Join(root, "pkg"): "java/pkg",
+	}, "windows")
+	joined := strings.Join(keys, ",")
+	if !strings.Contains(joined, "global:gradle-windows-runner") {
+		t.Fatalf("expected keys to include global gradle lock on Windows, got %v", keys)
+	}
+}
+
+func TestBuildResourceKeysSkipsGlobalGradleLockForJavaOnLinux(t *testing.T) {
+	root := makeFixture(t, map[string]string{
+		"pkg/BUILD": "gradle test",
+	})
+
+	pkg := discovery.Package{
+		Name:          "java/pkg",
+		Path:          filepath.Join(root, "pkg"),
+		BuildCommands: []string{"gradle test"},
+		Language:      "java",
+	}
+
+	keys := buildResourceKeysForOS(pkg, map[string]string{
+		filepath.Join(root, "pkg"): "java/pkg",
+	}, "linux")
+	joined := strings.Join(keys, ",")
+	if strings.Contains(joined, "global:gradle-windows-runner") {
+		t.Fatalf("did not expect Windows-only gradle lock on Linux, got %v", keys)
+	}
+}
+
+func TestBuildResourceKeysIncludesGlobalGradleLockForGradleWrapperOnWindows(t *testing.T) {
+	root := makeFixture(t, map[string]string{
+		"pkg/BUILD_windows": "gradlew.bat assembleDebug",
+	})
+
+	pkg := discovery.Package{
+		Name:          "kotlin/pkg",
+		Path:          filepath.Join(root, "pkg"),
+		BuildCommands: []string{"gradlew.bat assembleDebug"},
+		Language:      "kotlin",
+	}
+
+	keys := buildResourceKeysForOS(pkg, map[string]string{
+		filepath.Join(root, "pkg"): "kotlin/pkg",
+	}, "windows")
+	joined := strings.Join(keys, ",")
+	if !strings.Contains(joined, "global:gradle-windows-runner") {
+		t.Fatalf("expected wrapper-based builds to include global gradle lock on Windows, got %v", keys)
+	}
+}
+
 func TestExecuteBuildsSerializesSharedBuildResources(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("uses shell commands that are only asserted on Unix runners")

--- a/code/programs/go/build-tool/internal/gitdiff/ci_workflow.go
+++ b/code/programs/go/build-tool/internal/gitdiff/ci_workflow.go
@@ -58,11 +58,13 @@ var ciWorkflowToolchainMarkers = map[string][]string{
 	"java": {
 		"needs_java", "setup-java", "java-version", "java --version",
 		"temurin", "set up jdk", "set up gradle", "setup-gradle",
+		"disable long-lived gradle services",
 		"gradle_opts", "org.gradle.daemon", "org.gradle.vfs.watch",
 	},
 	"kotlin": {
 		"needs_kotlin", "setup-java", "java-version",
 		"temurin", "set up jdk", "set up gradle", "setup-gradle",
+		"disable long-lived gradle services",
 		"gradle_opts", "org.gradle.daemon", "org.gradle.vfs.watch",
 	},
 	"dotnet": {
@@ -234,6 +236,8 @@ func isToolchainScopedStructuralLine(content string) bool {
 		strings.HasPrefix(content, "shell:"),
 		strings.HasPrefix(content, "with:"),
 		strings.HasPrefix(content, "env:"),
+		strings.HasPrefix(content, "{"),
+		strings.HasPrefix(content, "}"),
 		strings.HasPrefix(content, "else"),
 		strings.HasPrefix(content, "fi"),
 		strings.HasPrefix(content, "then"),

--- a/code/programs/go/build-tool/internal/gitdiff/ci_workflow.go
+++ b/code/programs/go/build-tool/internal/gitdiff/ci_workflow.go
@@ -55,6 +55,16 @@ var ciWorkflowToolchainMarkers = map[string][]string{
 		"needs_haskell", "haskell-actions/setup", "ghc-version", "cabal-version",
 		"ghc --version", "cabal --version", "set up haskell",
 	},
+	"java": {
+		"needs_java", "setup-java", "java-version", "java --version",
+		"temurin", "set up jdk", "set up gradle", "setup-gradle",
+		"gradle_opts", "org.gradle.daemon", "org.gradle.vfs.watch",
+	},
+	"kotlin": {
+		"needs_kotlin", "setup-java", "java-version",
+		"temurin", "set up jdk", "set up gradle", "setup-gradle",
+		"gradle_opts", "org.gradle.daemon", "org.gradle.vfs.watch",
+	},
 	"dotnet": {
 		"needs_dotnet", "setup-dotnet", "dotnet-version", "dotnet --version",
 		"set up .net",

--- a/code/programs/go/build-tool/internal/gitdiff/ci_workflow_test.go
+++ b/code/programs/go/build-tool/internal/gitdiff/ci_workflow_test.go
@@ -23,6 +23,31 @@ func TestAnalyzeCIWorkflowPatchAllowsToolchainScopedDotnetChanges(t *testing.T) 
 	}
 }
 
+func TestAnalyzeCIWorkflowPatchAllowsSharedJVMToolchainChanges(t *testing.T) {
+	patch := `
+@@ -314,0 +315,11 @@
++      - name: Set up JDK 21
++        if: needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true'
++        uses: actions/setup-java@v4
++        with:
++          distribution: 'temurin'
++          java-version: '21'
++      - name: Set up Gradle
++        if: needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true'
++        uses: gradle/actions/setup-gradle@v4
+`
+
+	change := AnalyzeCIWorkflowPatch(patch)
+	if change.RequiresFullRebuild {
+		t.Fatalf("expected JVM toolchain change to stay incremental")
+	}
+
+	got := SortedToolchains(change.Toolchains)
+	if len(got) != 2 || got[0] != "java" || got[1] != "kotlin" {
+		t.Fatalf("expected java and kotlin toolchains, got %v", got)
+	}
+}
+
 func TestAnalyzeCIWorkflowPatchIgnoresCommentOnlyChanges(t *testing.T) {
 	patch := `
 @@ -316,2 +316,2 @@

--- a/code/programs/go/build-tool/internal/gitdiff/ci_workflow_test.go
+++ b/code/programs/go/build-tool/internal/gitdiff/ci_workflow_test.go
@@ -25,7 +25,7 @@ func TestAnalyzeCIWorkflowPatchAllowsToolchainScopedDotnetChanges(t *testing.T) 
 
 func TestAnalyzeCIWorkflowPatchAllowsSharedJVMToolchainChanges(t *testing.T) {
 	patch := `
-@@ -314,0 +315,11 @@
+@@ -314,0 +315,17 @@
 +      - name: Set up JDK 21
 +        if: needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true'
 +        uses: actions/setup-java@v4
@@ -35,6 +35,13 @@ func TestAnalyzeCIWorkflowPatchAllowsSharedJVMToolchainChanges(t *testing.T) {
 +      - name: Set up Gradle
 +        if: needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true'
 +        uses: gradle/actions/setup-gradle@v4
++      - name: Disable long-lived Gradle services on Windows CI
++        if: (needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true') && runner.os == 'Windows'
++        shell: bash
++        run: |
++          {
++            echo 'GRADLE_OPTS=-Dorg.gradle.daemon=false -Dorg.gradle.vfs.watch=false'
++          } >> "$GITHUB_ENV"
 `
 
 	change := AnalyzeCIWorkflowPatch(patch)

--- a/code/programs/go/build-tool/main.go
+++ b/code/programs/go/build-tool/main.go
@@ -481,7 +481,7 @@ func run() int {
 
 // allToolchains is the canonical list of build toolchains we may need in CI.
 // The order is stable and matches the order used in CI setup.
-var allToolchains = []string{"python", "ruby", "go", "typescript", "rust", "elixir", "lua", "perl", "swift", "haskell", "dotnet"}
+var allToolchains = []string{"python", "ruby", "go", "typescript", "rust", "elixir", "lua", "perl", "swift", "java", "kotlin", "haskell", "dotnet"}
 
 func toolchainForPackageLanguage(language string) string {
 	switch language {

--- a/lessons.md
+++ b/lessons.md
@@ -156,6 +156,28 @@ This redirects Gradle's output to `gradle-build/` instead of `build/`. Also add 
 - [ ] `layout.buildDirectory = file("gradle-build")` in build.gradle.kts
 - [ ] BUILD file exists for the monorepo build tool
 - [ ] `gradle-build/` in .gitignore
+- [ ] Do NOT use `java { toolchain { languageVersion.set(...) } }` — let Gradle use the running JDK
+
+---
+
+### 2026-04-04: Java toolchain block causes CI failure when JDK is not pre-installed
+
+Using `java { toolchain { languageVersion.set(JavaLanguageVersion.of(21)) } }` in `build.gradle.kts` causes Gradle to search for a JDK 21 installation matching that exact version. If the CI runner doesn't have JDK 21 pre-installed and toolchain auto-provisioning isn't configured, the build fails with "Cannot find a Java installation on your machine."
+
+**Solution:** Do NOT specify an explicit Java toolchain version. Let Gradle use whatever JDK is on the PATH (set up by `actions/setup-java` in CI). This matches the lesson from the hello-world programs.
+
+---
+
+### 2026-04-04: CI detect outputs must use steps.toolchains, not steps.detect
+
+The CI workflow has a "Normalize toolchain requirements" step (id: `toolchains`) that sits between the detect step and the job outputs. On main branch pushes, it forces all languages to `true` for the full rebuild. On other branches, it passes through the detect outputs.
+
+When adding a new language to CI, you must add it in THREE places:
+1. `allLanguages` in the build tool (`main.go`)
+2. The detect job `outputs:` section (using `steps.toolchains.outputs.needs_<lang>`)
+3. The `steps.toolchains` normalization step — in BOTH the `is_main=true` branch AND the `else` branch
+
+If you only add it to `outputs:` using `steps.detect.outputs` instead of `steps.toolchains.outputs`, the validator will fail with: "detect outputs for forced main full builds are not normalized through steps.toolchains."
 
 ---
 


### PR DESCRIPTION
## Summary

Split the Java portion of PR #506 into its own package PR, stacked on top of the JVM CI/build-tool extraction in #525.

This PR adds four Java packages:
- `activation-functions`
- `loss-functions`
- `matrix`
- `wave`

## Why this split

The package code is kept separate from the JVM CI changes so we can validate the Gradle/toolchain path independently from the actual Java implementations.

## Notes

- Base branch: `codex/pr506-jvm-ci` (PR #525)
- The shared `ML04` activation-functions spec is split separately in the Swift PR (#529)

## Validation

- `gradle test` in `code/packages/java/activation-functions`
- `gradle test` in `code/packages/java/loss-functions`
- `gradle test` in `code/packages/java/matrix`
- `gradle test` in `code/packages/java/wave`

During local parallel verification, Gradle also emitted daemon socket timeout noise before succeeding, which lines up with the Windows CI contention addressed in #525.
