### PR TITLE
Port clock, block-ram, and fpga packages to Swift

### DIFF
--- a/code/packages/swift/block-ram/BUILD
+++ b/code/packages/swift/block-ram/BUILD
@@ -1,0 +1,1 @@
+if command -v xcrun >/dev/null 2>&1; then xcrun swift test --enable-code-coverage --verbose; else swift test --enable-code-coverage --verbose; fi

--- a/code/packages/swift/block-ram/BUILD_windows
+++ b/code/packages/swift/block-ram/BUILD_windows
@@ -1,0 +1,1 @@
+echo Swift is not available on Windows CI -- skipping build

--- a/code/packages/swift/block-ram/CHANGELOG.md
+++ b/code/packages/swift/block-ram/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial release porting `SRAM`, `RAM`, and `BRAM` from TypeScript to Swift.

--- a/code/packages/swift/block-ram/Package.swift
+++ b/code/packages/swift/block-ram/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version: 5.9
+// ============================================================================
+// Package.swift — Block RAM
+// ============================================================================
+
+import PackageDescription
+
+let package = Package(
+    name: "block-ram",
+    products: [
+        .library(name: "BlockRAM", targets: ["BlockRAM"]),
+    ],
+    dependencies: [
+        .package(path: "../logic_gates"),
+    ],
+    targets: [
+        .target(
+            name: "BlockRAM",
+            dependencies: [
+                .product(name: "LogicGates", package: "logic_gates"),
+            ]
+        ),
+        .testTarget(
+            name: "BlockRAMTests",
+            dependencies: ["BlockRAM"]
+        ),
+    ]
+)

--- a/code/packages/swift/block-ram/README.md
+++ b/code/packages/swift/block-ram/README.md
@@ -1,0 +1,9 @@
+# Block RAM
+
+SRAM cells, arrays, and synchronous RAM modules for FPGA and CPU memory.
+
+This package provides:
+- `SRAMCell`: single-bit gate-level storage
+- `SRAMArray`: 2D grid of SRAM cells
+- `SinglePortRAM`, `DualPortRAM`: synchronous memory modules
+- `ConfigurableBRAM`: FPGA-style reconfigurable Block RAM

--- a/code/packages/swift/block-ram/Sources/BlockRAM/BRAM.swift
+++ b/code/packages/swift/block-ram/Sources/BlockRAM/BRAM.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+public class ConfigurableBRAM {
+    private let _totalBits: Int
+    private var _width: Int
+    private var _depth: Int
+    private var _ram: DualPortRAM
+
+    public init(totalBits: Int = 18432, width: Int = 8) throws {
+        guard totalBits >= 1 else { throw BlockRAMError.invalidArgument("totalBits must be >= 1") }
+        guard width >= 1 else { throw BlockRAMError.invalidArgument("width must be >= 1") }
+        guard totalBits % width == 0 else { throw BlockRAMError.invalidArgument("width \(width) does not evenly divide totalBits \(totalBits)") }
+
+        self._totalBits = totalBits
+        self._width = width
+        self._depth = totalBits / width
+        self._ram = try DualPortRAM(depth: self._depth, width: self._width)
+    }
+
+    public func reconfigure(width: Int) throws {
+        guard width >= 1 else { throw BlockRAMError.invalidArgument("width must be >= 1") }
+        guard _totalBits % width == 0 else { throw BlockRAMError.invalidArgument("width \(width) does not evenly divide totalBits \(_totalBits)") }
+
+        self._width = width
+        self._depth = self._totalBits / width
+        self._ram = try DualPortRAM(depth: self._depth, width: self._width)
+    }
+
+    public func tickA(clock: Bit, address: Int, dataIn: [Bit], writeEnable: Bit) throws -> [Bit] {
+        let zeros = Array(repeating: 0, count: _width)
+        let (outA, _) = try _ram.tick(
+            clock: clock,
+            addressA: address, dataInA: dataIn, writeEnableA: writeEnable,
+            addressB: 0, dataInB: zeros, writeEnableB: 0
+        )
+        return outA
+    }
+
+    public func tickB(clock: Bit, address: Int, dataIn: [Bit], writeEnable: Bit) throws -> [Bit] {
+        let zeros = Array(repeating: 0, count: _width)
+        let (_, outB) = try _ram.tick(
+            clock: clock,
+            addressA: 0, dataInA: zeros, writeEnableA: 0,
+            addressB: address, dataInB: dataIn, writeEnableB: writeEnable
+        )
+        return outB
+    }
+
+    public var depth: Int { return _depth }
+    public var width: Int { return _width }
+    public var totalBits: Int { return _totalBits }
+}

--- a/code/packages/swift/block-ram/Sources/BlockRAM/RAM.swift
+++ b/code/packages/swift/block-ram/Sources/BlockRAM/RAM.swift
@@ -1,0 +1,161 @@
+import Foundation
+
+public enum ReadMode {
+    case readFirst
+    case writeFirst
+    case noChange
+}
+
+public class SinglePortRAM {
+    private let _depth: Int
+    private let _width: Int
+    private let _readMode: ReadMode
+    private let _array: SRAMArray
+    private var _prevClock: Bit = 0
+    private var _lastRead: [Bit]
+
+    public init(depth: Int, width: Int, readMode: ReadMode = .readFirst) throws {
+        guard depth >= 1 else { throw BlockRAMError.invalidArgument("depth must be >= 1") }
+        guard width >= 1 else { throw BlockRAMError.invalidArgument("width must be >= 1") }
+
+        self._depth = depth
+        self._width = width
+        self._readMode = readMode
+        self._array = try SRAMArray(rows: depth, cols: width)
+        self._lastRead = Array(repeating: 0, count: width)
+    }
+
+    public func tick(clock: Bit, address: Int, dataIn: [Bit], writeEnable: Bit) throws -> [Bit] {
+        try _validateAddress(address, name: "address")
+        try _validateData(dataIn, name: "dataIn")
+
+        let risingEdge = _prevClock == 0 && clock == 1
+        _prevClock = clock
+
+        if !risingEdge {
+            return _lastRead
+        }
+
+        if writeEnable == 0 {
+            _lastRead = try _array.read(row: address)
+            return _lastRead
+        }
+
+        switch _readMode {
+        case .readFirst:
+            _lastRead = try _array.read(row: address)
+            try _array.write(row: address, data: dataIn)
+            return _lastRead
+        case .writeFirst:
+            try _array.write(row: address, data: dataIn)
+            _lastRead = dataIn
+            return _lastRead
+        case .noChange:
+            try _array.write(row: address, data: dataIn)
+            return _lastRead
+        }
+    }
+
+    public var depth: Int { return _depth }
+    public var width: Int { return _width }
+
+    public func dump() throws -> [[Bit]] {
+        return try (0..<_depth).map { try _array.read(row: $0) }
+    }
+
+    private func _validateAddress(_ address: Int, name: String) throws {
+        guard address >= 0 && address < _depth else {
+            throw BlockRAMError.outOfRange("\(name) \(address) out of range [0, \(_depth - 1)]")
+        }
+    }
+
+    private func _validateData(_ dataIn: [Bit], name: String) throws {
+        guard dataIn.count == _width else {
+            throw BlockRAMError.invalidArgument("\(name) length \(dataIn.count) does not match width \(_width)")
+        }
+    }
+}
+
+public class DualPortRAM {
+    private let _depth: Int
+    private let _width: Int
+    private let _readModeA: ReadMode
+    private let _readModeB: ReadMode
+    private let _array: SRAMArray
+    private var _prevClock: Bit = 0
+    private var _lastReadA: [Bit]
+    private var _lastReadB: [Bit]
+
+    public init(depth: Int, width: Int, readModeA: ReadMode = .readFirst, readModeB: ReadMode = .readFirst) throws {
+        guard depth >= 1 else { throw BlockRAMError.invalidArgument("depth must be >= 1") }
+        guard width >= 1 else { throw BlockRAMError.invalidArgument("width must be >= 1") }
+
+        self._depth = depth
+        self._width = width
+        self._readModeA = readModeA
+        self._readModeB = readModeB
+        self._array = try SRAMArray(rows: depth, cols: width)
+        self._lastReadA = Array(repeating: 0, count: width)
+        self._lastReadB = Array(repeating: 0, count: width)
+    }
+
+    public func tick(clock: Bit, addressA: Int, dataInA: [Bit], writeEnableA: Bit, addressB: Int, dataInB: [Bit], writeEnableB: Bit) throws -> ([Bit], [Bit]) {
+        try _validateAddress(addressA, name: "addressA")
+        try _validateAddress(addressB, name: "addressB")
+        try _validateData(dataInA, name: "dataInA")
+        try _validateData(dataInB, name: "dataInB")
+
+        let risingEdge = _prevClock == 0 && clock == 1
+        _prevClock = clock
+
+        if !risingEdge {
+            return (_lastReadA, _lastReadB)
+        }
+
+        if writeEnableA == 1 && writeEnableB == 1 && addressA == addressB {
+            throw BlockRAMError.writeCollision(address: addressA)
+        }
+
+        let outA = try _processPort(address: addressA, dataIn: dataInA, writeEnable: writeEnableA, readMode: _readModeA, lastRead: _lastReadA)
+        _lastReadA = outA
+
+        let outB = try _processPort(address: addressB, dataIn: dataInB, writeEnable: writeEnableB, readMode: _readModeB, lastRead: _lastReadB)
+        _lastReadB = outB
+
+        return (outA, outB)
+    }
+
+    public var depth: Int { return _depth }
+    public var width: Int { return _width }
+
+    private func _processPort(address: Int, dataIn: [Bit], writeEnable: Bit, readMode: ReadMode, lastRead: [Bit]) throws -> [Bit] {
+        if writeEnable == 0 {
+            return try _array.read(row: address)
+        }
+
+        switch readMode {
+        case .readFirst:
+            let result = try _array.read(row: address)
+            try _array.write(row: address, data: dataIn)
+            return result
+        case .writeFirst:
+            try _array.write(row: address, data: dataIn)
+            return dataIn
+        case .noChange:
+            try _array.write(row: address, data: dataIn)
+            return lastRead
+        }
+    }
+
+    private func _validateAddress(_ address: Int, name: String) throws {
+        guard address >= 0 && address < _depth else {
+            throw BlockRAMError.outOfRange("\(name) \(address) out of range [0, \(_depth - 1)]")
+        }
+    }
+
+    private func _validateData(_ dataIn: [Bit], name: String) throws {
+        guard dataIn.count == _width else {
+            throw BlockRAMError.invalidArgument("\(name) length \(dataIn.count) does not match width \(_width)")
+        }
+    }
+}

--- a/code/packages/swift/block-ram/Sources/BlockRAM/RAM.swift
+++ b/code/packages/swift/block-ram/Sources/BlockRAM/RAM.swift
@@ -116,36 +116,45 @@ public class DualPortRAM {
             throw BlockRAMError.writeCollision(address: addressA)
         }
 
-        let outA = try _processPort(address: addressA, dataIn: dataInA, writeEnable: writeEnableA, readMode: _readModeA, lastRead: _lastReadA)
+        let currentA = try _array.read(row: addressA)
+        let currentB = try _array.read(row: addressB)
+
+        let outA: [Bit]
+        if writeEnableA == 0 {
+            outA = currentA
+        } else {
+            switch _readModeA {
+            case .readFirst: outA = currentA
+            case .writeFirst: outA = dataInA
+            case .noChange: outA = _lastReadA
+            }
+        }
         _lastReadA = outA
 
-        let outB = try _processPort(address: addressB, dataIn: dataInB, writeEnable: writeEnableB, readMode: _readModeB, lastRead: _lastReadB)
+        let outB: [Bit]
+        if writeEnableB == 0 {
+            outB = currentB
+        } else {
+            switch _readModeB {
+            case .readFirst: outB = currentB
+            case .writeFirst: outB = dataInB
+            case .noChange: outB = _lastReadB
+            }
+        }
         _lastReadB = outB
+
+        if writeEnableA == 1 {
+            try _array.write(row: addressA, data: dataInA)
+        }
+        if writeEnableB == 1 {
+            try _array.write(row: addressB, data: dataInB)
+        }
 
         return (outA, outB)
     }
 
     public var depth: Int { return _depth }
     public var width: Int { return _width }
-
-    private func _processPort(address: Int, dataIn: [Bit], writeEnable: Bit, readMode: ReadMode, lastRead: [Bit]) throws -> [Bit] {
-        if writeEnable == 0 {
-            return try _array.read(row: address)
-        }
-
-        switch readMode {
-        case .readFirst:
-            let result = try _array.read(row: address)
-            try _array.write(row: address, data: dataIn)
-            return result
-        case .writeFirst:
-            try _array.write(row: address, data: dataIn)
-            return dataIn
-        case .noChange:
-            try _array.write(row: address, data: dataIn)
-            return lastRead
-        }
-    }
 
     private func _validateAddress(_ address: Int, name: String) throws {
         guard address >= 0 && address < _depth else {

--- a/code/packages/swift/block-ram/Sources/BlockRAM/SRAM.swift
+++ b/code/packages/swift/block-ram/Sources/BlockRAM/SRAM.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// Single-bit storage element modeled at the gate level.
+public class SRAMCell {
+    private var _value: Bit = 0
+
+    public init() {}
+
+    /// Read the stored bit if the cell is selected.
+    public func read(wordLine: Bit) -> Bit? {
+        guard wordLine == 1 else { return nil }
+        return _value
+    }
+
+    /// Write a bit to the cell if selected.
+    public func write(wordLine: Bit, bitLine: Bit) {
+        if wordLine == 1 {
+            _value = bitLine
+        }
+    }
+
+    public var value: Bit { return _value }
+}
+
+/// 2D grid of SRAM cells with row/column addressing.
+public class SRAMArray {
+    private let _rows: Int
+    private let _cols: Int
+    private let _cells: [[SRAMCell]]
+
+    public init(rows: Int, cols: Int) throws {
+        guard rows >= 1 else { throw BlockRAMError.invalidArgument("rows must be >= 1, got \(rows)") }
+        guard cols >= 1 else { throw BlockRAMError.invalidArgument("cols must be >= 1, got \(cols)") }
+
+        self._rows = rows
+        self._cols = cols
+        
+        var cells = [[SRAMCell]]()
+        for _ in 0..<rows {
+            var row = [SRAMCell]()
+            for _ in 0..<cols {
+                row.append(SRAMCell())
+            }
+            cells.append(row)
+        }
+        self._cells = cells
+    }
+
+    public func read(row: Int) throws -> [Bit] {
+        try _validateRow(row)
+        return _cells[row].map { $0.read(wordLine: 1)! }
+    }
+
+    public func write(row: Int, data: [Bit]) throws {
+        try _validateRow(row)
+        guard data.count == _cols else {
+            throw BlockRAMError.invalidArgument("data length \(data.count) does not match cols \(_cols)")
+        }
+        
+        for col in 0..<data.count {
+            _cells[row][col].write(wordLine: 1, bitLine: data[col])
+        }
+    }
+
+    public var shape: (Int, Int) {
+        return (_rows, _cols)
+    }
+
+    private func _validateRow(_ row: Int) throws {
+        guard row >= 0 && row < _rows else {
+            throw BlockRAMError.outOfRange("row \(row) out of range [0, \(_rows - 1)]")
+        }
+    }
+}

--- a/code/packages/swift/block-ram/Sources/BlockRAM/Types.swift
+++ b/code/packages/swift/block-ram/Sources/BlockRAM/Types.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public typealias Bit = Int
+
+public enum BlockRAMError: Error, Equatable {
+    case invalidArgument(String)
+    case outOfRange(String)
+    case writeCollision(address: Int)
+}

--- a/code/packages/swift/block-ram/Tests/BlockRAMTests/BlockRAMTests.swift
+++ b/code/packages/swift/block-ram/Tests/BlockRAMTests/BlockRAMTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import BlockRAM
+
+final class BlockRAMTests: XCTestCase {
+    
+    func testSRAMCell() {
+        let cell = SRAMCell()
+        XCTAssertEqual(cell.value, 0)
+        XCTAssertNil(cell.read(wordLine: 0))
+        XCTAssertEqual(cell.read(wordLine: 1), 0)
+        
+        cell.write(wordLine: 1, bitLine: 1)
+        XCTAssertEqual(cell.value, 1)
+        
+        cell.write(wordLine: 0, bitLine: 0)
+        XCTAssertEqual(cell.value, 1) // Should remain 1 because wordLine is 0
+    }
+    
+    func testSRAMArray() throws {
+        let array = try SRAMArray(rows: 4, cols: 4)
+        try array.write(row: 0, data: [1, 0, 1, 0])
+        try array.write(row: 1, data: [0, 1, 0, 1])
+        
+        XCTAssertEqual(try array.read(row: 0), [1, 0, 1, 0])
+        XCTAssertEqual(try array.read(row: 1), [0, 1, 0, 1])
+        XCTAssertEqual(try array.read(row: 2), [0, 0, 0, 0])
+    }
+    
+    func testSinglePortRAM() throws {
+        let ram = try SinglePortRAM(depth: 16, width: 8, readMode: .readFirst)
+        
+        XCTAssertEqual(ram.depth, 16)
+        XCTAssertEqual(ram.width, 8)
+        
+        // Write 11110000 to address 0
+        _ = try ram.tick(clock: 0, address: 0, dataIn: [1,1,1,1,0,0,0,0], writeEnable: 1)
+        let outA = try ram.tick(clock: 1, address: 0, dataIn: [1,1,1,1,0,0,0,0], writeEnable: 1)
+        XCTAssertEqual(outA, [0,0,0,0,0,0,0,0]) // readFirst returns old value
+        
+        // Read address 0
+        _ = try ram.tick(clock: 0, address: 0, dataIn: [0,0,0,0,0,0,0,0], writeEnable: 0)
+        let outB = try ram.tick(clock: 1, address: 0, dataIn: [0,0,0,0,0,0,0,0], writeEnable: 0)
+        XCTAssertEqual(outB, [1,1,1,1,0,0,0,0])
+    }
+
+    func testDualPortRAM() throws {
+        let ram = try DualPortRAM(depth: 16, width: 8)
+        
+        // Write A to 0, Read B from 0
+        _ = try ram.tick(clock: 0, addressA: 0, dataInA: [1,1,1,1,1,1,1,1], writeEnableA: 1, addressB: 0, dataInB: [0,0,0,0,0,0,0,0], writeEnableB: 0)
+        let (outA, outB) = try ram.tick(clock: 1, addressA: 0, dataInA: [1,1,1,1,1,1,1,1], writeEnableA: 1, addressB: 0, dataInB: [0,0,0,0,0,0,0,0], writeEnableB: 0)
+        XCTAssertEqual(outA, [0,0,0,0,0,0,0,0])
+        XCTAssertEqual(outB, [0,0,0,0,0,0,0,0]) // readFirst on B as well
+        
+        // Next cycle read from B
+        _ = try ram.tick(clock: 0, addressA: 0, dataInA: [0,0,0,0,0,0,0,0], writeEnableA: 0, addressB: 0, dataInB: [0,0,0,0,0,0,0,0], writeEnableB: 0)
+        let (_, outB2) = try ram.tick(clock: 1, addressA: 0, dataInA: [0,0,0,0,0,0,0,0], writeEnableA: 0, addressB: 0, dataInB: [0,0,0,0,0,0,0,0], writeEnableB: 0)
+        XCTAssertEqual(outB2, [1,1,1,1,1,1,1,1])
+    }
+
+    func testConfigurableBRAM() throws {
+        let bram = try ConfigurableBRAM(totalBits: 64, width: 8)
+        XCTAssertEqual(bram.depth, 8)
+        
+        try bram.reconfigure(width: 4)
+        XCTAssertEqual(bram.depth, 16)
+        
+        _ = try bram.tickA(clock: 0, address: 2, dataIn: [1,0,1,0], writeEnable: 1)
+        _ = try bram.tickA(clock: 1, address: 2, dataIn: [1,0,1,0], writeEnable: 1)
+        
+        _ = try bram.tickB(clock: 0, address: 2, dataIn: [0,0,0,0], writeEnable: 0)
+        let outB = try bram.tickB(clock: 1, address: 2, dataIn: [0,0,0,0], writeEnable: 0)
+        XCTAssertEqual(outB, [1,0,1,0])
+    }
+}

--- a/code/packages/swift/clock/BUILD
+++ b/code/packages/swift/clock/BUILD
@@ -1,0 +1,1 @@
+if command -v xcrun >/dev/null 2>&1; then xcrun swift test --enable-code-coverage --verbose; else swift test --enable-code-coverage --verbose; fi

--- a/code/packages/swift/clock/BUILD_windows
+++ b/code/packages/swift/clock/BUILD_windows
@@ -1,0 +1,1 @@
+echo Swift is not available on Windows CI -- skipping build

--- a/code/packages/swift/clock/CHANGELOG.md
+++ b/code/packages/swift/clock/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial release porting `Clock`, `ClockDivider`, and `MultiPhaseClock` from TypeScript to Swift.

--- a/code/packages/swift/clock/Package.swift
+++ b/code/packages/swift/clock/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version: 5.9
+// ============================================================================
+// Package.swift — Clock
+// ============================================================================
+
+import PackageDescription
+
+let package = Package(
+    name: "clock",
+    products: [
+        .library(name: "Clock", targets: ["Clock"]),
+    ],
+    dependencies: [
+    ],
+    targets: [
+        .target(
+            name: "Clock",
+            dependencies: [
+            ]
+        ),
+        .testTarget(
+            name: "ClockTests",
+            dependencies: ["Clock"]
+        ),
+    ]
+)

--- a/code/packages/swift/clock/README.md
+++ b/code/packages/swift/clock/README.md
@@ -1,0 +1,17 @@
+# Clock
+
+System clock generator — the heartbeat of every digital circuit.
+
+This package simulates the system clock that drives all sequential logic in a computer. It provides:
+
+- `Clock`: A square-wave generator that alternates between 0 and 1
+- `ClockDivider`: Derives slower clocks from a fast master clock
+- `MultiPhaseClock`: Generates multiple non-overlapping clock phases
+
+## Installation
+
+Add this package to your `Package.swift` dependencies.
+
+## Usage
+
+See the provided tests for examples.

--- a/code/packages/swift/clock/Sources/Clock/Clock.swift
+++ b/code/packages/swift/clock/Sources/Clock/Clock.swift
@@ -1,0 +1,174 @@
+import Foundation
+
+/// Core errors for Clock package
+public enum ClockError: Error, Equatable {
+    case invalidDivisor(Int)
+    case invalidPhases(Int)
+    case listenerNotFound
+}
+
+/// Record of a clock transition.
+public struct ClockEdge: Equatable {
+    public let cycle: Int
+    public let value: Int
+    public let isRising: Bool
+    public let isFalling: Bool
+}
+
+/// A function that receives clock edges.
+public typealias ClockListener = (ClockEdge) -> Void
+
+/// Unique identifier for unregistering listeners.
+public typealias ClockListenerToken = UUID
+
+/// System clock generator.
+public class Clock {
+    public let frequencyHz: Int
+    public private(set) var cycle: Int = 0
+    public private(set) var value: Int = 0
+    private var _tickCount: Int = 0
+    private var _listeners: [ClockListenerToken: ClockListener] = [:]
+
+    public init(frequencyHz: Int = 1_000_000) {
+        self.frequencyHz = frequencyHz
+    }
+
+    @discardableResult
+    public func tick() -> ClockEdge {
+        let oldValue = self.value
+        self.value = 1 - self.value
+        self._tickCount += 1
+
+        let isRising = oldValue == 0 && self.value == 1
+        let isFalling = oldValue == 1 && self.value == 0
+
+        if isRising {
+            self.cycle += 1
+        }
+
+        let edge = ClockEdge(
+            cycle: self.cycle,
+            value: self.value,
+            isRising: isRising,
+            isFalling: isFalling
+        )
+
+        for listener in _listeners.values {
+            listener(edge)
+        }
+
+        return edge
+    }
+
+    public func fullCycle() -> (ClockEdge, ClockEdge) {
+        let rising = self.tick()
+        let falling = self.tick()
+        return (rising, falling)
+    }
+
+    public func run(cycles: Int) -> [ClockEdge] {
+        var edges: [ClockEdge] = []
+        edges.reserveCapacity(cycles * 2)
+        for _ in 0..<cycles {
+            let (r, f) = self.fullCycle()
+            edges.append(r)
+            edges.append(f)
+        }
+        return edges
+    }
+
+    @discardableResult
+    public func registerListener(_ callback: @escaping ClockListener) -> ClockListenerToken {
+        let token = UUID()
+        _listeners[token] = callback
+        return token
+    }
+
+    public func unregisterListener(_ token: ClockListenerToken) throws {
+        guard _listeners.removeValue(forKey: token) != nil else {
+            throw ClockError.listenerNotFound
+        }
+    }
+
+    public func reset() {
+        self.cycle = 0
+        self.value = 0
+        self._tickCount = 0
+    }
+
+    public var periodNs: Double {
+        return 1e9 / Double(frequencyHz)
+    }
+
+    public var totalTicks: Int {
+        return self._tickCount
+    }
+}
+
+/// Divides a clock frequency by an integer factor.
+public class ClockDivider {
+    public let source: Clock
+    public let divisor: Int
+    public let output: Clock
+    private var _counter: Int = 0
+    private var listenerToken: ClockListenerToken?
+
+    public init(source: Clock, divisor: Int) throws {
+        guard divisor >= 2 else {
+            throw ClockError.invalidDivisor(divisor)
+        }
+        self.source = source
+        self.divisor = divisor
+        self.output = Clock(frequencyHz: source.frequencyHz / divisor)
+        
+        self.listenerToken = self.source.registerListener { [weak self] edge in
+            self?._onEdge(edge)
+        }
+    }
+
+    private func _onEdge(_ edge: ClockEdge) {
+        if edge.isRising {
+            self._counter += 1
+            if self._counter >= self.divisor {
+                self._counter = 0
+                self.output.tick() // rising
+                self.output.tick() // falling
+            }
+        }
+    }
+}
+
+/// Generates multiple clock phases from a single source.
+public class MultiPhaseClock {
+    public let source: Clock
+    public let phases: Int
+    public private(set) var activePhase: Int = 0
+    private var _phaseValues: [Int]
+    private var listenerToken: ClockListenerToken?
+
+    public init(source: Clock, phases: Int = 4) throws {
+        guard phases >= 2 else {
+            throw ClockError.invalidPhases(phases)
+        }
+        self.source = source
+        self.phases = phases
+        self._phaseValues = Array(repeating: 0, count: phases)
+        
+        self.listenerToken = self.source.registerListener { [weak self] edge in
+            self?._onEdge(edge)
+        }
+    }
+
+    private func _onEdge(_ edge: ClockEdge) {
+        if edge.isRising {
+            self._phaseValues = Array(repeating: 0, count: phases)
+            self._phaseValues[self.activePhase] = 1
+            self.activePhase = (self.activePhase + 1) % self.phases
+        }
+    }
+
+    public func getPhase(_ index: Int) -> Int {
+        guard index >= 0 && index < phases else { return 0 }
+        return self._phaseValues[index]
+    }
+}

--- a/code/packages/swift/clock/Tests/ClockTests/ClockTests.swift
+++ b/code/packages/swift/clock/Tests/ClockTests/ClockTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+@testable import Clock
+
+final class ClockTests: XCTestCase {
+    
+    func testClockInitialization() {
+        let clock = Clock(frequencyHz: 2_000_000) // 2 MHz
+        XCTAssertEqual(clock.frequencyHz, 2_000_000)
+        XCTAssertEqual(clock.cycle, 0)
+        XCTAssertEqual(clock.value, 0)
+        XCTAssertEqual(clock.totalTicks, 0)
+        XCTAssertEqual(clock.periodNs, 500.0)
+    }
+
+    func testClockTick() {
+        let clock = Clock()
+        
+        let edge1 = clock.tick()
+        XCTAssertEqual(edge1.value, 1)
+        XCTAssertEqual(edge1.isRising, true)
+        XCTAssertEqual(edge1.isFalling, false)
+        XCTAssertEqual(edge1.cycle, 1)
+        XCTAssertEqual(clock.cycle, 1)
+        XCTAssertEqual(clock.totalTicks, 1)
+        
+        let edge2 = clock.tick()
+        XCTAssertEqual(edge2.value, 0)
+        XCTAssertEqual(edge2.isRising, false)
+        XCTAssertEqual(edge2.isFalling, true)
+        XCTAssertEqual(edge2.cycle, 1)
+        XCTAssertEqual(clock.cycle, 1)
+        XCTAssertEqual(clock.totalTicks, 2)
+    }
+
+    func testClockRun() {
+        let clock = Clock()
+        let edges = clock.run(cycles: 3)
+        XCTAssertEqual(edges.count, 6)
+        XCTAssertEqual(clock.cycle, 3)
+        XCTAssertEqual(clock.totalTicks, 6)
+    }
+
+    func testClockListener() {
+        let clock = Clock()
+        var receivedEdges: [ClockEdge] = []
+        
+        let token = clock.registerListener { edge in
+            receivedEdges.append(edge)
+        }
+        
+        clock.run(cycles: 1)
+        XCTAssertEqual(receivedEdges.count, 2)
+        XCTAssertEqual(receivedEdges[0].isRising, true)
+        XCTAssertEqual(receivedEdges[1].isFalling, true)
+        
+        do {
+            try clock.unregisterListener(token)
+        } catch {
+            XCTFail("Should not throw")
+        }
+        
+        clock.run(cycles: 1)
+        XCTAssertEqual(receivedEdges.count, 2) // Should not increase
+    }
+
+    func testUnregisterUnknownListener() {
+        let clock = Clock()
+        XCTAssertThrowsError(try clock.unregisterListener(UUID())) { error in
+            XCTAssertEqual(error as? ClockError, ClockError.listenerNotFound)
+        }
+    }
+
+    func testClockReset() {
+        let clock = Clock()
+        clock.run(cycles: 5)
+        XCTAssertEqual(clock.cycle, 5)
+        XCTAssertEqual(clock.totalTicks, 10)
+        
+        clock.reset()
+        XCTAssertEqual(clock.cycle, 0)
+        XCTAssertEqual(clock.totalTicks, 0)
+        XCTAssertEqual(clock.value, 0)
+    }
+    
+    func testClockDivider() throws {
+        let master = Clock(frequencyHz: 1_000)
+        let divider = try ClockDivider(source: master, divisor: 4)
+        
+        XCTAssertEqual(divider.output.frequencyHz, 250)
+        
+        master.run(cycles: 4)
+        XCTAssertEqual(divider.output.cycle, 1) // 4 master cycles = 1 divided cycle
+        XCTAssertEqual(divider.output.totalTicks, 2)
+        
+        master.run(cycles: 8)
+        XCTAssertEqual(divider.output.cycle, 3)
+    }
+
+    func testClockDividerInvalidDivisor() {
+        let master = Clock()
+        XCTAssertThrowsError(try ClockDivider(source: master, divisor: 1)) { error in
+            XCTAssertEqual(error as? ClockError, ClockError.invalidDivisor(1))
+        }
+    }
+
+    func testMultiPhaseClock() throws {
+        let master = Clock()
+        let multi = try MultiPhaseClock(source: master, phases: 4)
+        
+        XCTAssertEqual(multi.phases, 4)
+        XCTAssertEqual(multi.activePhase, 0)
+        
+        for p in 0..<4 {
+            XCTAssertEqual(multi.getPhase(p), 0)
+        }
+        
+        master.tick() // Rising edge 1
+        XCTAssertEqual(multi.getPhase(0), 1)
+        XCTAssertEqual(multi.getPhase(1), 0)
+        master.tick() // Falling edge 1
+        
+        master.tick() // Rising edge 2
+        XCTAssertEqual(multi.getPhase(0), 0)
+        XCTAssertEqual(multi.getPhase(1), 1)
+    }
+
+    func testMultiPhaseClockInvalidPhases() {
+        let master = Clock()
+        XCTAssertThrowsError(try MultiPhaseClock(source: master, phases: 1)) { error in
+            XCTAssertEqual(error as? ClockError, ClockError.invalidPhases(1))
+        }
+    }
+}

--- a/code/packages/swift/fpga/BUILD
+++ b/code/packages/swift/fpga/BUILD
@@ -1,0 +1,1 @@
+if command -v xcrun >/dev/null 2>&1; then xcrun swift test --enable-code-coverage --verbose; else swift test --enable-code-coverage --verbose; fi

--- a/code/packages/swift/fpga/BUILD_windows
+++ b/code/packages/swift/fpga/BUILD_windows
@@ -1,0 +1,1 @@
+echo Swift is not available on Windows CI -- skipping build

--- a/code/packages/swift/fpga/CHANGELOG.md
+++ b/code/packages/swift/fpga/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial release porting FPGA abstraction from TypeScript to Swift.

--- a/code/packages/swift/fpga/Package.swift
+++ b/code/packages/swift/fpga/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version: 5.9
+// ============================================================================
+// Package.swift — FPGA
+// ============================================================================
+
+import PackageDescription
+
+let package = Package(
+    name: "fpga",
+    products: [
+        .library(name: "FPGA", targets: ["FPGA"]),
+    ],
+    dependencies: [
+        .package(path: "../logic_gates"),
+        .package(path: "../block-ram")
+    ],
+    targets: [
+        .target(
+            name: "FPGA",
+            dependencies: [
+                .product(name: "LogicGates", package: "logic_gates"),
+                .product(name: "BlockRAM", package: "block-ram")
+            ]
+        ),
+        .testTarget(
+            name: "FPGATests",
+            dependencies: ["FPGA"]
+        ),
+    ]
+)

--- a/code/packages/swift/fpga/README.md
+++ b/code/packages/swift/fpga/README.md
@@ -1,0 +1,4 @@
+# FPGA
+
+FPGA — Field-Programmable Gate Array abstraction.
+Provides LUTs, CLBs, routing fabric, I/O blocks, and bitstream configuration.

--- a/code/packages/swift/fpga/Sources/FPGA/Bitstream.swift
+++ b/code/packages/swift/fpga/Sources/FPGA/Bitstream.swift
@@ -1,0 +1,64 @@
+import Foundation
+import LogicGates
+
+public struct SliceConfig {
+    public let lutA: [Bit]
+    public let lutB: [Bit]
+    public let ffAEnabled: Bool
+    public let ffBEnabled: Bool
+    public let carryEnabled: Bool
+
+    public init(lutA: [Bit], lutB: [Bit], ffAEnabled: Bool, ffBEnabled: Bool, carryEnabled: Bool) {
+        self.lutA = lutA
+        self.lutB = lutB
+        self.ffAEnabled = ffAEnabled
+        self.ffBEnabled = ffBEnabled
+        self.carryEnabled = carryEnabled
+    }
+}
+
+public struct CLBConfig {
+    public let slice0: SliceConfig
+    public let slice1: SliceConfig
+
+    public init(slice0: SliceConfig, slice1: SliceConfig) {
+        self.slice0 = slice0
+        self.slice1 = slice1
+    }
+}
+
+public struct RouteConfig {
+    public let source: String
+    public let destination: String
+
+    public init(source: String, destination: String) {
+        self.source = source
+        self.destination = destination
+    }
+}
+
+public struct IOConfig {
+    public let mode: String
+
+    public init(mode: String) {
+        self.mode = mode
+    }
+}
+
+public class Bitstream {
+    public let clbs: [String: CLBConfig]
+    public let routing: [String: [RouteConfig]]
+    public let io: [String: IOConfig]
+    public let lutK: Int
+
+    public init(clbs: [String: CLBConfig] = [:], routing: [String: [RouteConfig]] = [:], io: [String: IOConfig] = [:], lutK: Int = 4) {
+        self.clbs = clbs
+        self.routing = routing
+        self.io = io
+        self.lutK = lutK
+    }
+
+    public static func empty(lutK: Int = 4) -> Bitstream {
+        return Bitstream(clbs: [:], routing: [:], io: [:], lutK: lutK)
+    }
+}

--- a/code/packages/swift/fpga/Sources/FPGA/CLB.swift
+++ b/code/packages/swift/fpga/Sources/FPGA/CLB.swift
@@ -1,0 +1,48 @@
+import Foundation
+import LogicGates
+
+public struct CLBOutput: Equatable {
+    public let slice0: SliceOutput
+    public let slice1: SliceOutput
+}
+
+public class CLB {
+    private let _slice0: Slice
+    private let _slice1: Slice
+    private let _k: Int
+
+    public init(lutInputs: Int = 4) throws {
+        self._slice0 = try Slice(lutInputs: lutInputs)
+        self._slice1 = try Slice(lutInputs: lutInputs)
+        self._k = lutInputs
+    }
+
+    public var slice0: Slice { return _slice0 }
+    public var slice1: Slice { return _slice1 }
+    public var k: Int { return _k }
+
+    public func evaluate(
+        slice0InputsA: [Bit],
+        slice0InputsB: [Bit],
+        slice1InputsA: [Bit],
+        slice1InputsB: [Bit],
+        clock: Bit,
+        carryIn: Bit = 0
+    ) throws -> CLBOutput {
+        let out0 = try _slice0.evaluate(
+            inputsA: slice0InputsA,
+            inputsB: slice0InputsB,
+            clock: clock,
+            carryIn: carryIn
+        )
+
+        let out1 = try _slice1.evaluate(
+            inputsA: slice1InputsA,
+            inputsB: slice1InputsB,
+            clock: clock,
+            carryIn: out0.carryOut
+        )
+
+        return CLBOutput(slice0: out0, slice1: out1)
+    }
+}

--- a/code/packages/swift/fpga/Sources/FPGA/Fabric.swift
+++ b/code/packages/swift/fpga/Sources/FPGA/Fabric.swift
@@ -1,0 +1,115 @@
+import Foundation
+import LogicGates
+
+public class FPGA {
+    private let _bitstream: Bitstream
+    private var _clbs: [String: CLB] = [:]
+    private var _switches: [String: SwitchMatrix] = [:]
+    private var _ios: [String: IOBlock] = [:]
+
+    public init(bitstream: Bitstream) throws {
+        self._bitstream = bitstream
+        try _configure(bs: bitstream)
+    }
+
+    private func _configure(bs: Bitstream) throws {
+        for (name, clbCfg) in bs.clbs {
+            let clb = try CLB(lutInputs: bs.lutK)
+
+            try clb.slice0.configure(
+                lutATable: clbCfg.slice0.lutA,
+                lutBTable: clbCfg.slice0.lutB,
+                ffAEnabled: clbCfg.slice0.ffAEnabled,
+                ffBEnabled: clbCfg.slice0.ffBEnabled,
+                carryEnabled: clbCfg.slice0.carryEnabled
+            )
+            
+            try clb.slice1.configure(
+                lutATable: clbCfg.slice1.lutA,
+                lutBTable: clbCfg.slice1.lutB,
+                ffAEnabled: clbCfg.slice1.ffAEnabled,
+                ffBEnabled: clbCfg.slice1.ffBEnabled,
+                carryEnabled: clbCfg.slice1.carryEnabled
+            )
+
+            _clbs[name] = clb
+        }
+
+        for (swName, routes) in bs.routing {
+            var ports = Set<String>()
+            for route in routes {
+                ports.insert(route.source)
+                ports.insert(route.destination)
+            }
+
+            if !ports.isEmpty {
+                let sm = try SwitchMatrix(ports: ports)
+                for route in routes {
+                    try sm.connect(source: route.source, destination: route.destination)
+                }
+                _switches[swName] = sm
+            }
+        }
+
+        for (pinName, ioCfg) in bs.io {
+            let mode = IOMode(rawValue: ioCfg.mode) ?? .input
+            _ios[pinName] = try IOBlock(name: pinName, mode: mode)
+        }
+    }
+
+    public func evaluateCLB(
+        clbName: String,
+        slice0InputsA: [Bit],
+        slice0InputsB: [Bit],
+        slice1InputsA: [Bit],
+        slice1InputsB: [Bit],
+        clock: Bit,
+        carryIn: Bit = 0
+    ) throws -> CLBOutput {
+        guard let clb = _clbs[clbName] else {
+            throw FPGAError.notFound("CLB \(clbName) not found")
+        }
+
+        return try clb.evaluate(
+            slice0InputsA: slice0InputsA,
+            slice0InputsB: slice0InputsB,
+            slice1InputsA: slice1InputsA,
+            slice1InputsB: slice1InputsB,
+            clock: clock,
+            carryIn: carryIn
+        )
+    }
+
+    public func route(switchName: String, signals: [String: Bit]) throws -> [String: Bit] {
+        guard let sm = _switches[switchName] else {
+            throw FPGAError.notFound("Switch matrix \(switchName) not found")
+        }
+        return sm.route(inputs: signals)
+    }
+
+    public func setInput(pinName: String, value: Bit) throws {
+        guard let io = _ios[pinName] else {
+            throw FPGAError.notFound("I/O pin \(pinName) not found")
+        }
+        try io.drivePad(value: value)
+    }
+
+    public func readOutput(pinName: String) throws -> Bit? {
+        guard let io = _ios[pinName] else {
+            throw FPGAError.notFound("I/O pin \(pinName) not found")
+        }
+        return try io.readPad()
+    }
+
+    public func driveOutput(pinName: String, value: Bit) throws {
+        guard let io = _ios[pinName] else {
+            throw FPGAError.notFound("I/O pin \(pinName) not found")
+        }
+        try io.driveInternal(value: value)
+    }
+
+    public var clbs: [String: CLB] { return _clbs }
+    public var switches: [String: SwitchMatrix] { return _switches }
+    public var ios: [String: IOBlock] { return _ios }
+    public var bitstream: Bitstream { return _bitstream }
+}

--- a/code/packages/swift/fpga/Sources/FPGA/IOBlock.swift
+++ b/code/packages/swift/fpga/Sources/FPGA/IOBlock.swift
@@ -1,0 +1,61 @@
+import Foundation
+import LogicGates
+
+public enum IOMode: String {
+    case input = "input"
+    case output = "output"
+    case tristate = "tristate"
+}
+
+public class IOBlock {
+    private let _name: String
+    private var _mode: IOMode
+    private var _padValue: Bit = 0
+    private var _internalValue: Bit = 0
+
+    public init(name: String, mode: IOMode = .input) throws {
+        guard !name.isEmpty else {
+            throw FPGAError.invalidArgument("name must be a non-empty string")
+        }
+        self._name = name
+        self._mode = mode
+    }
+
+    public func configure(mode: IOMode) {
+        self._mode = mode
+    }
+
+    public func drivePad(value: Bit) throws {
+        guard value == 0 || value == 1 else {
+            throw FPGAError.invalidArgument("value must be 0 or 1, got \(value)")
+        }
+        self._padValue = value
+    }
+
+    public func driveInternal(value: Bit) throws {
+        guard value == 0 || value == 1 else {
+            throw FPGAError.invalidArgument("value must be 0 or 1, got \(value)")
+        }
+        self._internalValue = value
+    }
+
+    public func readInternal() -> Bit {
+        if _mode == .input {
+            return _padValue
+        }
+        return _internalValue
+    }
+
+    public func readPad() throws -> Bit? {
+        if _mode == .input {
+            return _padValue
+        }
+        if _mode == .tristate {
+            return try triState(data: _internalValue, enable: 0)
+        }
+        return try triState(data: _internalValue, enable: 1)
+    }
+
+    public var name: String { return _name }
+    public var mode: IOMode { return _mode }
+}

--- a/code/packages/swift/fpga/Sources/FPGA/LUT.swift
+++ b/code/packages/swift/fpga/Sources/FPGA/LUT.swift
@@ -1,0 +1,47 @@
+import Foundation
+import LogicGates
+import BlockRAM
+
+/// K-input Look-Up Table -- the atom of programmable logic.
+public class LUT {
+    private let _k: Int
+    private let _size: Int
+    private let _sram: [SRAMCell]
+
+    public init(k: Int = 4, truthTable: [Bit]? = nil) throws {
+        guard k >= 2 && k <= 6 else { throw FPGAError.invalidArgument("k must be between 2 and 6, got \(k)") }
+        self._k = k
+        self._size = 1 << k
+        self._sram = (0..<_size).map { _ in SRAMCell() }
+        
+        if let tt = truthTable {
+            try configure(truthTable: tt)
+        }
+    }
+
+    public func configure(truthTable: [Bit]) throws {
+        guard truthTable.count == _size else {
+            throw FPGAError.invalidArgument("truthTable length \(truthTable.count) does not match 2^k = \(_size)")
+        }
+        for i in 0..<truthTable.count {
+            _sram[i].write(wordLine: 1, bitLine: truthTable[i])
+        }
+    }
+
+    public func evaluate(inputs: [Bit]) throws -> Bit {
+        guard inputs.count == _k else {
+            throw FPGAError.invalidArgument("inputs length \(inputs.count) does not match k = \(_k)")
+        }
+        
+        var data: [Bit] = []
+        data.reserveCapacity(_size)
+        for cell in _sram {
+            data.append(cell.read(wordLine: 1) ?? 0)
+        }
+        
+        return try muxN(inputs: data, sel: inputs)
+    }
+
+    public var k: Int { return _k }
+    public var truthTable: [Bit] { return _sram.map { $0.read(wordLine: 1) ?? 0 } }
+}

--- a/code/packages/swift/fpga/Sources/FPGA/Slice.swift
+++ b/code/packages/swift/fpga/Sources/FPGA/Slice.swift
@@ -1,0 +1,103 @@
+import Foundation
+import LogicGates
+import BlockRAM
+
+public struct SliceOutput: Equatable {
+    public let outputA: Bit
+    public let outputB: Bit
+    public let carryOut: Bit
+}
+
+public class Slice {
+    private let _lutA: LUT
+    private let _lutB: LUT
+    private let _k: Int
+
+    private var _ffAState: FlipFlopState
+    private var _ffBState: FlipFlopState
+
+    private var _ffAEnabled: Bool = false
+    private var _ffBEnabled: Bool = false
+    private var _carryEnabled: Bool = false
+
+    public init(lutInputs: Int = 4) throws {
+        self._lutA = try LUT(k: lutInputs)
+        self._lutB = try LUT(k: lutInputs)
+        self._k = lutInputs
+        self._ffAState = FlipFlopState(q: 0, qBar: 1, masterQ: 0)
+        self._ffBState = FlipFlopState(q: 0, qBar: 1, masterQ: 0)
+    }
+
+    public func configure(
+        lutATable: [Bit],
+        lutBTable: [Bit],
+        ffAEnabled: Bool = false,
+        ffBEnabled: Bool = false,
+        carryEnabled: Bool = false
+    ) throws {
+        try _lutA.configure(truthTable: lutATable)
+        try _lutB.configure(truthTable: lutBTable)
+        self._ffAEnabled = ffAEnabled
+        self._ffBEnabled = ffBEnabled
+        self._carryEnabled = carryEnabled
+
+        // Reset flip-flop state on reconfiguration
+        self._ffAState = FlipFlopState(q: 0, qBar: 1, masterQ: 0)
+        self._ffBState = FlipFlopState(q: 0, qBar: 1, masterQ: 0)
+    }
+
+    public func evaluate(
+        inputsA: [Bit],
+        inputsB: [Bit],
+        clock: Bit,
+        carryIn: Bit = 0
+    ) throws -> SliceOutput {
+        // Evaluate LUTs
+        let lutAOut = try _lutA.evaluate(inputs: inputsA)
+        let lutBOut = try _lutB.evaluate(inputs: inputsB)
+
+        // Flip-flop A
+        let outputA: Bit
+        if _ffAEnabled {
+            let newState = try dFlipFlop(
+                data: lutAOut, clock: clock,
+                q: _ffAState.q, qBar: _ffAState.qBar,
+                masterQ: _ffAState.masterQ, masterQBar: 1 - _ffAState.masterQ
+            )
+            self._ffAState = newState
+            outputA = try mux2(d0: lutAOut, d1: newState.q, sel: 1)
+        } else {
+            outputA = lutAOut
+        }
+
+        // Flip-flop B
+        let outputB: Bit
+        if _ffBEnabled {
+            let newState = try dFlipFlop(
+                data: lutBOut, clock: clock,
+                q: _ffBState.q, qBar: _ffBState.qBar,
+                masterQ: _ffBState.masterQ, masterQBar: 1 - _ffBState.masterQ
+            )
+            self._ffBState = newState
+            outputB = try mux2(d0: lutBOut, d1: newState.q, sel: 1)
+        } else {
+            outputB = lutBOut
+        }
+
+        // Carry chain
+        let carryOut: Bit
+        if _carryEnabled {
+            let term1 = try andGate(lutAOut, lutBOut)
+            let term2 = try andGate(carryIn, try xorGate(lutAOut, lutBOut))
+            carryOut = try orGate(term1, term2)
+        } else {
+            carryOut = 0
+        }
+
+        return SliceOutput(outputA: outputA, outputB: outputB, carryOut: carryOut)
+    }
+
+    public var lutA: LUT { return _lutA }
+    public var lutB: LUT { return _lutB }
+    public var k: Int { return _k }
+}

--- a/code/packages/swift/fpga/Sources/FPGA/SwitchMatrix.swift
+++ b/code/packages/swift/fpga/Sources/FPGA/SwitchMatrix.swift
@@ -1,0 +1,63 @@
+import Foundation
+import LogicGates
+
+public class SwitchMatrix {
+    private let _ports: Set<String>
+    private var _connections: [String: String] = [:]
+
+    public init(ports: Set<String>) throws {
+        guard !ports.isEmpty else {
+            throw FPGAError.invalidArgument("ports must be non-empty")
+        }
+        for p in ports {
+            guard !p.isEmpty else {
+                throw FPGAError.invalidArgument("port names must be non-empty strings")
+            }
+        }
+        self._ports = ports
+    }
+
+    public func connect(source: String, destination: String) throws {
+        guard _ports.contains(source) else {
+            throw FPGAError.invalidArgument("unknown source port: \(source)")
+        }
+        guard _ports.contains(destination) else {
+            throw FPGAError.invalidArgument("unknown destination port: \(destination)")
+        }
+        guard source != destination else {
+            throw FPGAError.invalidArgument("cannot connect port \(source) to itself")
+        }
+        if let existing = _connections[destination] {
+            throw FPGAError.invalidArgument("destination \(destination) already connected to \(existing)")
+        }
+        _connections[destination] = source
+    }
+
+    public func disconnect(destination: String) throws {
+        guard _ports.contains(destination) else {
+            throw FPGAError.invalidArgument("unknown port: \(destination)")
+        }
+        guard _connections[destination] != nil else {
+            throw FPGAError.invalidArgument("port \(destination) is not connected")
+        }
+        _connections.removeValue(forKey: destination)
+    }
+
+    public func clear() {
+        _connections.removeAll()
+    }
+
+    public func route(inputs: [String: Bit]) -> [String: Bit] {
+        var outputs: [String: Bit] = [:]
+        for (dest, src) in _connections {
+            if let val = inputs[src] {
+                outputs[dest] = val
+            }
+        }
+        return outputs
+    }
+
+    public var ports: Set<String> { return _ports }
+    public var connections: [String: String] { return _connections }
+    public var connectionCount: Int { return _connections.count }
+}

--- a/code/packages/swift/fpga/Sources/FPGA/Types.swift
+++ b/code/packages/swift/fpga/Sources/FPGA/Types.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public typealias Bit = Int
+
+public enum FPGAError: Error, Equatable {
+    case invalidArgument(String)
+    case outOfRange(String)
+    case notFound(String)
+}

--- a/code/packages/swift/fpga/Tests/FPGATests/FPGATests.swift
+++ b/code/packages/swift/fpga/Tests/FPGATests/FPGATests.swift
@@ -34,18 +34,15 @@ final class FPGATests: XCTestCase {
         let slice = try Slice(lutInputs: 4)
         var andTt = Array(repeating: 0, count: 16)
         andTt[3] = 1
-        var xorTt = Array(repeating: 0, count: 16)
-        xorTt[1] = 1
-        xorTt[2] = 1
         
-        try slice.configure(lutATable: andTt, lutBTable: xorTt, carryEnabled: true)
+        try slice.configure(lutATable: andTt, lutBTable: andTt, carryEnabled: true)
         
         // A AND B (generate)
         var out = try slice.evaluate(inputsA: [1, 1, 0, 0], inputsB: [1, 1, 0, 0], clock: 0)
         XCTAssertEqual(out.carryOut, 1)
         
-        // A XOR B with carryIn=1 (propagate)
-        out = try slice.evaluate(inputsA: [1, 1, 0, 0], inputsB: [1, 0, 0, 0], clock: 0, carryIn: 1)
+        // A=1, B=0 with carryIn=1 (propagate)
+        out = try slice.evaluate(inputsA: [1, 1, 0, 0], inputsB: [0, 0, 0, 0], clock: 0, carryIn: 1)
         XCTAssertEqual(out.carryOut, 1)
     }
 

--- a/code/packages/swift/fpga/Tests/FPGATests/FPGATests.swift
+++ b/code/packages/swift/fpga/Tests/FPGATests/FPGATests.swift
@@ -1,0 +1,86 @@
+import XCTest
+@testable import FPGA
+
+final class FPGATests: XCTestCase {
+    
+    func testLUT() throws {
+        let andTable = Array(repeating: 0, count: 16)
+        var tt = andTable
+        tt[3] = 1 // I0=1, I1=1 -> 3
+        
+        let lut = try LUT(k: 4, truthTable: tt)
+        XCTAssertEqual(try lut.evaluate(inputs: [0, 0, 0, 0]), 0)
+        XCTAssertEqual(try lut.evaluate(inputs: [1, 1, 0, 0]), 1)
+        XCTAssertEqual(try lut.evaluate(inputs: [0, 1, 0, 0]), 0)
+    }
+
+    func testSliceCombinational() throws {
+        let slice = try Slice(lutInputs: 4)
+        
+        var andTt = Array(repeating: 0, count: 16)
+        andTt[3] = 1
+        var xorTt = Array(repeating: 0, count: 16)
+        xorTt[1] = 1
+        xorTt[2] = 1
+        
+        try slice.configure(lutATable: andTt, lutBTable: xorTt)
+        
+        let out = try slice.evaluate(inputsA: [1, 1, 0, 0], inputsB: [1, 0, 0, 0], clock: 0)
+        XCTAssertEqual(out.outputA, 1) // AND
+        XCTAssertEqual(out.outputB, 1) // XOR
+    }
+
+    func testSliceCarry() throws {
+        let slice = try Slice(lutInputs: 4)
+        var andTt = Array(repeating: 0, count: 16)
+        andTt[3] = 1
+        var xorTt = Array(repeating: 0, count: 16)
+        xorTt[1] = 1
+        xorTt[2] = 1
+        
+        try slice.configure(lutATable: andTt, lutBTable: xorTt, carryEnabled: true)
+        
+        // A AND B (generate)
+        var out = try slice.evaluate(inputsA: [1, 1, 0, 0], inputsB: [1, 1, 0, 0], clock: 0)
+        XCTAssertEqual(out.carryOut, 1)
+        
+        // A XOR B with carryIn=1 (propagate)
+        out = try slice.evaluate(inputsA: [1, 1, 0, 0], inputsB: [1, 0, 0, 0], clock: 0, carryIn: 1)
+        XCTAssertEqual(out.carryOut, 1)
+    }
+
+    func testSwitchMatrix() throws {
+        let sm = try SwitchMatrix(ports: ["north", "south", "east", "clbOut"])
+        try sm.connect(source: "clbOut", destination: "east")
+        try sm.connect(source: "north", destination: "south")
+        
+        let routed = sm.route(inputs: ["clbOut": 1, "north": 0])
+        XCTAssertEqual(routed["east"], 1)
+        XCTAssertEqual(routed["south"], 0)
+        XCTAssertNil(routed["north"])
+    }
+
+    func testIOBlock() throws {
+        let io = try IOBlock(name: "pinA", mode: .input)
+        try io.drivePad(value: 1)
+        XCTAssertEqual(io.readInternal(), 1)
+        
+        io.configure(mode: .output)
+        try io.driveInternal(value: 0)
+        XCTAssertEqual(try io.readPad(), 0)
+        
+        io.configure(mode: .tristate)
+        try io.driveInternal(value: 1)
+        XCTAssertNil(try io.readPad())
+    }
+
+    func testFabric() throws {
+        let bstream = Bitstream(
+            io: ["testOut": IOConfig(mode: "output")]
+        )
+        
+        let fpga = try FPGA(bitstream: bstream)
+        try fpga.driveOutput(pinName: "testOut", value: 1)
+        XCTAssertEqual(try fpga.readOutput(pinName: "testOut"), 1)
+    }
+}

--- a/code/packages/swift/logic_gates/Sources/LogicGates/Sequential.swift
+++ b/code/packages/swift/logic_gates/Sources/LogicGates/Sequential.swift
@@ -368,7 +368,7 @@ public func shiftRegister(
 
     let n = q.count
     // Build the input chain: serialIn → q[0]'s D, q[0] → q[1]'s D, ...
-    var data = [serialIn] + q.dropLast()
+    let data = [serialIn] + q.dropLast()
 
     var newQ: [Int] = []
     var states: [FlipFlopState] = []

--- a/code/packages/swift/transistors/Sources/Transistors/CMOSGates.swift
+++ b/code/packages/swift/transistors/Sources/Transistors/CMOSGates.swift
@@ -409,7 +409,7 @@ public struct CMOSXor {
     public var circuit: CircuitParams { nand1.circuit }
 
     public func evaluate(va: Double, vb: Double) -> GateOutput {
-        let vdd = circuit.vdd
+
         // Build XOR from NAND: XOR(A,B) = NAND(NAND(A, NAND(A,B)), NAND(B, NAND(A,B)))
         let abNand = nand1.evaluate(va: va, vb: vb)
         let v_ab = abNand.voltage


### PR DESCRIPTION
This PR ports the third batch of computing stack packages to Swift: clock, block-ram, and fpga.