### PR TITLE
Add graph packages for Go, Rust, and WASM

### DIFF
--- a/code/packages/go/graph/BUILD
+++ b/code/packages/go/graph/BUILD
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/graph/BUILD_windows
+++ b/code/packages/go/graph/BUILD_windows
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/graph/CHANGELOG.md
+++ b/code/packages/go/graph/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Added the initial undirected weighted graph package with adjacency-list and adjacency-matrix representations.
+- Added BFS, DFS, connectivity, cycle detection, shortest path, and minimum spanning tree algorithms.

--- a/code/packages/go/graph/README.md
+++ b/code/packages/go/graph/README.md
@@ -1,0 +1,13 @@
+# go/graph
+
+Undirected weighted graph package with adjacency-list and adjacency-matrix
+storage, plus the core DT00 algorithms.
+
+```go
+g := graph.New(graph.AdjacencyList)
+g.AddEdge("London", "Paris", 300)
+g.AddEdge("London", "Amsterdam", 520)
+
+path, _ := graph.ShortestPath(g, "London", "Paris")
+mst, _ := graph.MinimumSpanningTree(g)
+```

--- a/code/packages/go/graph/algorithms.go
+++ b/code/packages/go/graph/algorithms.go
@@ -1,0 +1,283 @@
+package graph
+
+import (
+	"container/heap"
+	"errors"
+	"sort"
+)
+
+func BFS(g *Graph, start string) ([]string, error) {
+	if !g.HasNode(start) {
+		return nil, &NodeNotFoundError{Node: start}
+	}
+
+	visited := map[string]bool{start: true}
+	queue := []string{start}
+	result := make([]string, 0, g.Size())
+
+	for len(queue) > 0 {
+		node := queue[0]
+		queue = queue[1:]
+		result = append(result, node)
+
+		neighbors, _ := g.Neighbors(node)
+		for _, neighbor := range neighbors {
+			if !visited[neighbor] {
+				visited[neighbor] = true
+				queue = append(queue, neighbor)
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func DFS(g *Graph, start string) ([]string, error) {
+	if !g.HasNode(start) {
+		return nil, &NodeNotFoundError{Node: start}
+	}
+
+	visited := map[string]bool{}
+	stack := []string{start}
+	result := make([]string, 0, g.Size())
+
+	for len(stack) > 0 {
+		node := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if visited[node] {
+			continue
+		}
+
+		visited[node] = true
+		result = append(result, node)
+
+		neighbors, _ := g.Neighbors(node)
+		for i := len(neighbors) - 1; i >= 0; i-- {
+			neighbor := neighbors[i]
+			if !visited[neighbor] {
+				stack = append(stack, neighbor)
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func IsConnected(g *Graph) bool {
+	nodes := g.Nodes()
+	if len(nodes) == 0 {
+		return true
+	}
+	visited, _ := BFS(g, nodes[0])
+	return len(visited) == len(nodes)
+}
+
+func ConnectedComponents(g *Graph) [][]string {
+	nodes := g.Nodes()
+	visited := map[string]bool{}
+	components := make([][]string, 0)
+
+	for _, node := range nodes {
+		if visited[node] {
+			continue
+		}
+
+		component, _ := BFS(g, node)
+		for _, member := range component {
+			visited[member] = true
+		}
+		components = append(components, component)
+	}
+
+	return components
+}
+
+func HasCycle(g *Graph) bool {
+	visited := map[string]bool{}
+	var dfs func(node, parent string) bool
+	dfs = func(node, parent string) bool {
+		visited[node] = true
+		neighbors, _ := g.Neighbors(node)
+		for _, neighbor := range neighbors {
+			if !visited[neighbor] {
+				if dfs(neighbor, node) {
+					return true
+				}
+			} else if neighbor != parent {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, node := range g.Nodes() {
+		if !visited[node] && dfs(node, "") {
+			return true
+		}
+	}
+	return false
+}
+
+type shortestPathItem struct {
+	node     string
+	distance float64
+	index    int
+}
+
+type shortestPathHeap []*shortestPathItem
+
+func (h shortestPathHeap) Len() int { return len(h) }
+func (h shortestPathHeap) Less(i, j int) bool {
+	if h[i].distance != h[j].distance {
+		return h[i].distance < h[j].distance
+	}
+	return h[i].node < h[j].node
+}
+func (h shortestPathHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+	h[i].index = i
+	h[j].index = j
+}
+func (h *shortestPathHeap) Push(x any) {
+	item := x.(*shortestPathItem)
+	item.index = len(*h)
+	*h = append(*h, item)
+}
+func (h *shortestPathHeap) Pop() any {
+	old := *h
+	n := len(old)
+	item := old[n-1]
+	*h = old[:n-1]
+	return item
+}
+
+func ShortestPath(g *Graph, start, end string) ([]string, error) {
+	if !g.HasNode(start) {
+		return nil, &NodeNotFoundError{Node: start}
+	}
+	if !g.HasNode(end) {
+		return nil, &NodeNotFoundError{Node: end}
+	}
+	if start == end {
+		return []string{start}, nil
+	}
+
+	dist := make(map[string]float64, g.Size())
+	prev := make(map[string]string, g.Size())
+	for _, node := range g.Nodes() {
+		dist[node] = 1e308
+	}
+	dist[start] = 0
+
+	pq := shortestPathHeap{&shortestPathItem{node: start, distance: 0}}
+	heap.Init(&pq)
+
+	for pq.Len() > 0 {
+		item := heap.Pop(&pq).(*shortestPathItem)
+		if item.distance > dist[item.node] {
+			continue
+		}
+		if item.node == end {
+			break
+		}
+		neighbors, _ := g.NeighborsWeighted(item.node)
+		keys := make([]string, 0, len(neighbors))
+		for neighbor := range neighbors {
+			keys = append(keys, neighbor)
+		}
+		sort.Strings(keys)
+		for _, neighbor := range keys {
+			alt := dist[item.node] + neighbors[neighbor]
+			if alt < dist[neighbor] {
+				dist[neighbor] = alt
+				prev[neighbor] = item.node
+				heap.Push(&pq, &shortestPathItem{node: neighbor, distance: alt})
+			}
+		}
+	}
+
+	if dist[end] == 1e308 {
+		return []string{}, nil
+	}
+
+	path := []string{end}
+	for current := end; current != start; {
+		parent, ok := prev[current]
+		if !ok {
+			return []string{}, nil
+		}
+		path = append(path, parent)
+		current = parent
+	}
+
+	for i, j := 0, len(path)-1; i < j; i, j = i+1, j-1 {
+		path[i], path[j] = path[j], path[i]
+	}
+	return path, nil
+}
+
+type disjointSet struct {
+	parent map[string]string
+	rank   map[string]int
+}
+
+func newDisjointSet(nodes []string) *disjointSet {
+	ds := &disjointSet{
+		parent: make(map[string]string, len(nodes)),
+		rank:   make(map[string]int, len(nodes)),
+	}
+	for _, node := range nodes {
+		ds.parent[node] = node
+		ds.rank[node] = 0
+	}
+	return ds
+}
+
+func (ds *disjointSet) find(node string) string {
+	if ds.parent[node] != node {
+		ds.parent[node] = ds.find(ds.parent[node])
+	}
+	return ds.parent[node]
+}
+
+func (ds *disjointSet) union(left, right string) {
+	leftRoot := ds.find(left)
+	rightRoot := ds.find(right)
+	if leftRoot == rightRoot {
+		return
+	}
+	if ds.rank[leftRoot] < ds.rank[rightRoot] {
+		ds.parent[leftRoot] = rightRoot
+	} else if ds.rank[leftRoot] > ds.rank[rightRoot] {
+		ds.parent[rightRoot] = leftRoot
+	} else {
+		ds.parent[rightRoot] = leftRoot
+		ds.rank[leftRoot]++
+	}
+}
+
+func MinimumSpanningTree(g *Graph) ([]WeightedEdge, error) {
+	if g.Size() == 0 || g.Size() == 1 {
+		return []WeightedEdge{}, nil
+	}
+	if !IsConnected(g) {
+		return nil, errors.New("graph is not connected")
+	}
+
+	edges := g.Edges()
+	ds := newDisjointSet(g.Nodes())
+	result := make([]WeightedEdge, 0, g.Size()-1)
+
+	for _, edge := range edges {
+		if ds.find(edge.Left) == ds.find(edge.Right) {
+			continue
+		}
+		ds.union(edge.Left, edge.Right)
+		result = append(result, edge)
+		if len(result) == g.Size()-1 {
+			break
+		}
+	}
+
+	return result, nil
+}

--- a/code/packages/go/graph/errors.go
+++ b/code/packages/go/graph/errors.go
@@ -1,0 +1,20 @@
+package graph
+
+import "fmt"
+
+type NodeNotFoundError struct {
+	Node string
+}
+
+func (e *NodeNotFoundError) Error() string {
+	return fmt.Sprintf("node not found: %q", e.Node)
+}
+
+type EdgeNotFoundError struct {
+	Left  string
+	Right string
+}
+
+func (e *EdgeNotFoundError) Error() string {
+	return fmt.Sprintf("edge not found: %q -- %q", e.Left, e.Right)
+}

--- a/code/packages/go/graph/go.mod
+++ b/code/packages/go/graph/go.mod
@@ -1,0 +1,3 @@
+module github.com/adhithyan15/coding-adventures/code/packages/go/graph
+
+go 1.23

--- a/code/packages/go/graph/graph.go
+++ b/code/packages/go/graph/graph.go
@@ -1,0 +1,316 @@
+package graph
+
+import (
+	"fmt"
+	"sort"
+)
+
+type GraphRepr string
+
+const (
+	AdjacencyList   GraphRepr = "adjacency_list"
+	AdjacencyMatrix GraphRepr = "adjacency_matrix"
+)
+
+type WeightedEdge struct {
+	Left   string
+	Right  string
+	Weight float64
+}
+
+type Graph struct {
+	repr      GraphRepr
+	adj       map[string]map[string]float64
+	nodeList  []string
+	nodeIndex map[string]int
+	matrix    [][]float64
+}
+
+func New(repr GraphRepr) *Graph {
+	if repr == "" {
+		repr = AdjacencyList
+	}
+	return &Graph{
+		repr:      repr,
+		adj:       make(map[string]map[string]float64),
+		nodeList:  []string{},
+		nodeIndex: make(map[string]int),
+		matrix:    [][]float64{},
+	}
+}
+
+func (g *Graph) Repr() GraphRepr {
+	return g.repr
+}
+
+func (g *Graph) AddNode(node string) {
+	if g.repr == AdjacencyList {
+		if _, ok := g.adj[node]; !ok {
+			g.adj[node] = make(map[string]float64)
+		}
+		return
+	}
+
+	if _, ok := g.nodeIndex[node]; ok {
+		return
+	}
+
+	index := len(g.nodeList)
+	g.nodeList = append(g.nodeList, node)
+	g.nodeIndex[node] = index
+	for i := range g.matrix {
+		g.matrix[i] = append(g.matrix[i], 0)
+	}
+	g.matrix = append(g.matrix, make([]float64, index+1))
+}
+
+func (g *Graph) RemoveNode(node string) error {
+	if g.repr == AdjacencyList {
+		neighbors, ok := g.adj[node]
+		if !ok {
+			return &NodeNotFoundError{Node: node}
+		}
+		for neighbor := range neighbors {
+			delete(g.adj[neighbor], node)
+		}
+		delete(g.adj, node)
+		return nil
+	}
+
+	index, ok := g.nodeIndex[node]
+	if !ok {
+		return &NodeNotFoundError{Node: node}
+	}
+
+	delete(g.nodeIndex, node)
+	g.nodeList = append(g.nodeList[:index], g.nodeList[index+1:]...)
+	g.matrix = append(g.matrix[:index], g.matrix[index+1:]...)
+	for i := range g.matrix {
+		g.matrix[i] = append(g.matrix[i][:index], g.matrix[i][index+1:]...)
+	}
+	for i := index; i < len(g.nodeList); i++ {
+		g.nodeIndex[g.nodeList[i]] = i
+	}
+	return nil
+}
+
+func (g *Graph) HasNode(node string) bool {
+	if g.repr == AdjacencyList {
+		_, ok := g.adj[node]
+		return ok
+	}
+	_, ok := g.nodeIndex[node]
+	return ok
+}
+
+func (g *Graph) Nodes() []string {
+	if g.repr == AdjacencyList {
+		nodes := make([]string, 0, len(g.adj))
+		for node := range g.adj {
+			nodes = append(nodes, node)
+		}
+		sort.Strings(nodes)
+		return nodes
+	}
+	return append([]string(nil), g.nodeList...)
+}
+
+func (g *Graph) AddEdge(left, right string, weight float64) {
+	if weight == 0 {
+		weight = 1
+	}
+	g.AddNode(left)
+	g.AddNode(right)
+
+	if g.repr == AdjacencyList {
+		g.adj[left][right] = weight
+		g.adj[right][left] = weight
+		return
+	}
+
+	leftIndex := g.nodeIndex[left]
+	rightIndex := g.nodeIndex[right]
+	g.matrix[leftIndex][rightIndex] = weight
+	g.matrix[rightIndex][leftIndex] = weight
+}
+
+func (g *Graph) RemoveEdge(left, right string) error {
+	if g.repr == AdjacencyList {
+		neighbors, ok := g.adj[left]
+		if !ok {
+			return &EdgeNotFoundError{Left: left, Right: right}
+		}
+		if _, ok := neighbors[right]; !ok {
+			return &EdgeNotFoundError{Left: left, Right: right}
+		}
+		delete(g.adj[left], right)
+		delete(g.adj[right], left)
+		return nil
+	}
+
+	leftIndex, okLeft := g.nodeIndex[left]
+	rightIndex, okRight := g.nodeIndex[right]
+	if !okLeft || !okRight || g.matrix[leftIndex][rightIndex] == 0 {
+		return &EdgeNotFoundError{Left: left, Right: right}
+	}
+	g.matrix[leftIndex][rightIndex] = 0
+	g.matrix[rightIndex][leftIndex] = 0
+	return nil
+}
+
+func (g *Graph) HasEdge(left, right string) bool {
+	if g.repr == AdjacencyList {
+		if neighbors, ok := g.adj[left]; ok {
+			_, ok = neighbors[right]
+			return ok
+		}
+		return false
+	}
+
+	leftIndex, okLeft := g.nodeIndex[left]
+	rightIndex, okRight := g.nodeIndex[right]
+	if !okLeft || !okRight {
+		return false
+	}
+	return g.matrix[leftIndex][rightIndex] != 0
+}
+
+func (g *Graph) EdgeWeight(left, right string) (float64, error) {
+	if g.repr == AdjacencyList {
+		if neighbors, ok := g.adj[left]; ok {
+			if weight, ok := neighbors[right]; ok {
+				return weight, nil
+			}
+		}
+		return 0, &EdgeNotFoundError{Left: left, Right: right}
+	}
+
+	leftIndex, okLeft := g.nodeIndex[left]
+	rightIndex, okRight := g.nodeIndex[right]
+	if !okLeft || !okRight || g.matrix[leftIndex][rightIndex] == 0 {
+		return 0, &EdgeNotFoundError{Left: left, Right: right}
+	}
+	return g.matrix[leftIndex][rightIndex], nil
+}
+
+func (g *Graph) Edges() []WeightedEdge {
+	result := make([]WeightedEdge, 0)
+	seen := make(map[string]bool)
+
+	if g.repr == AdjacencyList {
+		for left, neighbors := range g.adj {
+			for right, weight := range neighbors {
+				keyLeft, keyRight := canonicalEndpoints(left, right)
+				key := keyLeft + "\x00" + keyRight
+				if seen[key] {
+					continue
+				}
+				seen[key] = true
+				result = append(result, WeightedEdge{Left: keyLeft, Right: keyRight, Weight: weight})
+			}
+		}
+	} else {
+		for row := 0; row < len(g.nodeList); row++ {
+			for col := row; col < len(g.nodeList); col++ {
+				if g.matrix[row][col] != 0 {
+					result = append(result, WeightedEdge{
+						Left:   g.nodeList[row],
+						Right:  g.nodeList[col],
+						Weight: g.matrix[row][col],
+					})
+				}
+			}
+		}
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Weight != result[j].Weight {
+			return result[i].Weight < result[j].Weight
+		}
+		if result[i].Left != result[j].Left {
+			return result[i].Left < result[j].Left
+		}
+		return result[i].Right < result[j].Right
+	})
+	return result
+}
+
+func (g *Graph) Neighbors(node string) ([]string, error) {
+	if g.repr == AdjacencyList {
+		neighbors, ok := g.adj[node]
+		if !ok {
+			return nil, &NodeNotFoundError{Node: node}
+		}
+		result := make([]string, 0, len(neighbors))
+		for neighbor := range neighbors {
+			result = append(result, neighbor)
+		}
+		sort.Strings(result)
+		return result, nil
+	}
+
+	index, ok := g.nodeIndex[node]
+	if !ok {
+		return nil, &NodeNotFoundError{Node: node}
+	}
+	result := make([]string, 0)
+	for col, weight := range g.matrix[index] {
+		if weight != 0 {
+			result = append(result, g.nodeList[col])
+		}
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+func (g *Graph) NeighborsWeighted(node string) (map[string]float64, error) {
+	if g.repr == AdjacencyList {
+		neighbors, ok := g.adj[node]
+		if !ok {
+			return nil, &NodeNotFoundError{Node: node}
+		}
+		result := make(map[string]float64, len(neighbors))
+		for neighbor, weight := range neighbors {
+			result[neighbor] = weight
+		}
+		return result, nil
+	}
+
+	index, ok := g.nodeIndex[node]
+	if !ok {
+		return nil, &NodeNotFoundError{Node: node}
+	}
+	result := make(map[string]float64)
+	for col, weight := range g.matrix[index] {
+		if weight != 0 {
+			result[g.nodeList[col]] = weight
+		}
+	}
+	return result, nil
+}
+
+func (g *Graph) Degree(node string) (int, error) {
+	neighbors, err := g.Neighbors(node)
+	if err != nil {
+		return 0, err
+	}
+	return len(neighbors), nil
+}
+
+func (g *Graph) Size() int {
+	if g.repr == AdjacencyList {
+		return len(g.adj)
+	}
+	return len(g.nodeList)
+}
+
+func (g *Graph) String() string {
+	return fmt.Sprintf("Graph(nodes=%d, edges=%d, repr=%s)", g.Size(), len(g.Edges()), g.repr)
+}
+
+func canonicalEndpoints(left, right string) (string, string) {
+	if left <= right {
+		return left, right
+	}
+	return right, left
+}

--- a/code/packages/go/graph/graph_test.go
+++ b/code/packages/go/graph/graph_test.go
@@ -1,0 +1,141 @@
+package graph
+
+import (
+	"reflect"
+	"testing"
+)
+
+func representations() []GraphRepr {
+	return []GraphRepr{AdjacencyList, AdjacencyMatrix}
+}
+
+func makeGraph(repr GraphRepr) *Graph {
+	g := New(repr)
+	g.AddEdge("London", "Paris", 300)
+	g.AddEdge("London", "Amsterdam", 520)
+	g.AddEdge("Paris", "Berlin", 878)
+	g.AddEdge("Amsterdam", "Berlin", 655)
+	g.AddEdge("Amsterdam", "Brussels", 180)
+	return g
+}
+
+func makeTriangle(repr GraphRepr) *Graph {
+	g := New(repr)
+	g.AddEdge("A", "B", 1)
+	g.AddEdge("B", "C", 1)
+	g.AddEdge("C", "A", 1)
+	return g
+}
+
+func makePath(repr GraphRepr) *Graph {
+	g := New(repr)
+	g.AddEdge("A", "B", 1)
+	g.AddEdge("B", "C", 1)
+	return g
+}
+
+func TestConstructionAndNodes(t *testing.T) {
+	for _, repr := range representations() {
+		g := New(repr)
+		if g.Size() != 0 {
+			t.Fatalf("Size() = %d, want 0", g.Size())
+		}
+		g.AddNode("A")
+		g.AddNode("B")
+		if !g.HasNode("A") || !g.HasNode("B") {
+			t.Fatalf("HasNode failed for repr=%s", repr)
+		}
+		if err := g.RemoveNode("A"); err != nil {
+			t.Fatalf("RemoveNode failed: %v", err)
+		}
+		if g.HasNode("A") {
+			t.Fatalf("node A should be removed for repr=%s", repr)
+		}
+	}
+}
+
+func TestEdgesAndNeighbors(t *testing.T) {
+	for _, repr := range representations() {
+		g := New(repr)
+		g.AddEdge("A", "B", 2.5)
+		if !g.HasEdge("A", "B") || !g.HasEdge("B", "A") {
+			t.Fatalf("undirected edge missing for repr=%s", repr)
+		}
+		weight, err := g.EdgeWeight("A", "B")
+		if err != nil || weight != 2.5 {
+			t.Fatalf("EdgeWeight = %v, %v", weight, err)
+		}
+		neighbors, _ := g.Neighbors("A")
+		if !reflect.DeepEqual(neighbors, []string{"B"}) {
+			t.Fatalf("Neighbors(A) = %#v", neighbors)
+		}
+	}
+}
+
+func TestTraversalsAndConnectivity(t *testing.T) {
+	for _, repr := range representations() {
+		bfsResult, _ := BFS(makePath(repr), "A")
+		if !reflect.DeepEqual(bfsResult, []string{"A", "B", "C"}) {
+			t.Fatalf("BFS = %#v", bfsResult)
+		}
+		dfsResult, _ := DFS(makePath(repr), "A")
+		if !reflect.DeepEqual(dfsResult, []string{"A", "B", "C"}) {
+			t.Fatalf("DFS = %#v", dfsResult)
+		}
+		if !IsConnected(makeGraph(repr)) {
+			t.Fatalf("expected connected graph for repr=%s", repr)
+		}
+	}
+}
+
+func TestComponentsAndCycleDetection(t *testing.T) {
+	for _, repr := range representations() {
+		g := New(repr)
+		g.AddEdge("A", "B", 1)
+		g.AddEdge("B", "C", 1)
+		g.AddEdge("D", "E", 1)
+		g.AddNode("F")
+		components := ConnectedComponents(g)
+		if len(components) != 3 {
+			t.Fatalf("ConnectedComponents count = %d, want 3", len(components))
+		}
+		if !HasCycle(makeTriangle(repr)) {
+			t.Fatalf("triangle should have a cycle for repr=%s", repr)
+		}
+		if HasCycle(makePath(repr)) {
+			t.Fatalf("path should not have a cycle for repr=%s", repr)
+		}
+	}
+}
+
+func TestShortestPathAndMST(t *testing.T) {
+	for _, repr := range representations() {
+		path, err := ShortestPath(makeGraph(repr), "London", "Berlin")
+		if err != nil {
+			t.Fatalf("ShortestPath failed: %v", err)
+		}
+		wantPath := []string{"London", "Amsterdam", "Berlin"}
+		if !reflect.DeepEqual(path, wantPath) {
+			t.Fatalf("ShortestPath = %#v, want %#v", path, wantPath)
+		}
+
+		mst, err := MinimumSpanningTree(makeGraph(repr))
+		if err != nil {
+			t.Fatalf("MinimumSpanningTree failed: %v", err)
+		}
+		if len(mst) != 4 {
+			t.Fatalf("MST edge count = %d, want 4", len(mst))
+		}
+	}
+}
+
+func TestDisconnectedMSTFails(t *testing.T) {
+	for _, repr := range representations() {
+		g := New(repr)
+		g.AddEdge("A", "B", 1)
+		g.AddNode("C")
+		if _, err := MinimumSpanningTree(g); err == nil {
+			t.Fatalf("MinimumSpanningTree should fail on disconnected graph for repr=%s", repr)
+		}
+	}
+}

--- a/code/packages/go/graph/required_capabilities.json
+++ b/code/packages/go/graph/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "go/graph",
+  "capabilities": [],
+  "justification": "Pure in-memory graph algorithms. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -127,6 +127,7 @@ members = [
     "document-ast",
     "commonmark-parser",
     "gfm-parser",
+    "graph",
     "document-ast-to-html",
     "commonmark",
     "gfm",
@@ -137,4 +138,3 @@ members = [
     "sql-csv-source",
     "event-loop",
 ]
-

--- a/code/packages/rust/graph/BUILD
+++ b/code/packages/rust/graph/BUILD
@@ -1,0 +1,1 @@
+cargo test -p graph -- --nocapture

--- a/code/packages/rust/graph/BUILD_windows
+++ b/code/packages/rust/graph/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p graph -- --nocapture

--- a/code/packages/rust/graph/CHANGELOG.md
+++ b/code/packages/rust/graph/CHANGELOG.md
@@ -1,0 +1,6 @@
+# graph changelog
+
+## 0.1.0
+
+- Added a weighted undirected graph with adjacency-list and adjacency-matrix storage
+- Added BFS, DFS, connectivity, cycle detection, shortest path, and minimum spanning tree helpers

--- a/code/packages/rust/graph/Cargo.toml
+++ b/code/packages/rust/graph/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "graph"
+version = "0.1.0"
+edition = "2021"
+description = "Weighted undirected graph with adjacency-list and adjacency-matrix representations"
+license = "MIT"
+
+[dependencies]

--- a/code/packages/rust/graph/README.md
+++ b/code/packages/rust/graph/README.md
@@ -1,0 +1,35 @@
+# graph
+
+Weighted undirected graph for Rust with both adjacency-list and adjacency-matrix storage.
+
+## What It Provides
+
+- `Graph` with `GraphRepr::AdjacencyList` and `GraphRepr::AdjacencyMatrix`
+- Weighted undirected edges, including self-loops
+- `bfs`, `dfs`, `is_connected`, `connected_components`, `has_cycle`
+- `shortest_path` and `minimum_spanning_tree`
+
+## Usage
+
+```rust
+use graph::{minimum_spanning_tree, shortest_path, Graph, GraphRepr};
+
+let mut g = Graph::new(GraphRepr::AdjacencyList);
+g.add_edge("London", "Paris", 300.0);
+g.add_edge("London", "Amsterdam", 520.0);
+g.add_edge("Amsterdam", "Berlin", 655.0);
+
+assert_eq!(
+    shortest_path(&g, "London", "Berlin"),
+    vec!["London".to_string(), "Amsterdam".to_string(), "Berlin".to_string()]
+);
+
+let mst = minimum_spanning_tree(&g).unwrap();
+assert!(!mst.is_empty());
+```
+
+## Building and Testing
+
+```bash
+cargo test -p graph -- --nocapture
+```

--- a/code/packages/rust/graph/required_capabilities.json
+++ b/code/packages/rust/graph/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/graph",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/rust/graph/src/algorithms.rs
+++ b/code/packages/rust/graph/src/algorithms.rs
@@ -1,0 +1,279 @@
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+use crate::graph::{Graph, GraphError, WeightedEdge};
+
+pub fn bfs(graph: &Graph, start: &str) -> Result<Vec<String>, GraphError> {
+    if !graph.has_node(start) {
+        return Err(GraphError::NodeNotFound(start.to_string()));
+    }
+
+    let mut visited = BTreeSet::new();
+    visited.insert(start.to_string());
+    let mut queue = VecDeque::from([start.to_string()]);
+    let mut result = Vec::new();
+
+    while let Some(node) = queue.pop_front() {
+        result.push(node.clone());
+        for neighbor in graph.neighbors(&node)? {
+            if visited.insert(neighbor.clone()) {
+                queue.push_back(neighbor);
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+pub fn dfs(graph: &Graph, start: &str) -> Result<Vec<String>, GraphError> {
+    if !graph.has_node(start) {
+        return Err(GraphError::NodeNotFound(start.to_string()));
+    }
+
+    let mut visited = BTreeSet::new();
+    let mut stack = vec![start.to_string()];
+    let mut result = Vec::new();
+
+    while let Some(node) = stack.pop() {
+        if !visited.insert(node.clone()) {
+            continue;
+        }
+
+        result.push(node.clone());
+        let mut neighbors = graph.neighbors(&node)?;
+        neighbors.reverse();
+        for neighbor in neighbors {
+            if !visited.contains(&neighbor) {
+                stack.push(neighbor);
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+pub fn is_connected(graph: &Graph) -> bool {
+    if graph.size() == 0 {
+        return true;
+    }
+    let nodes = graph.nodes();
+    bfs(graph, &nodes[0])
+        .map(|visited| visited.len() == graph.size())
+        .unwrap_or(false)
+}
+
+pub fn connected_components(graph: &Graph) -> Vec<Vec<String>> {
+    let mut remaining: BTreeSet<String> = graph.nodes().into_iter().collect();
+    let mut result = Vec::new();
+
+    while let Some(start) = remaining.iter().next().cloned() {
+        let component = bfs(graph, &start).expect("start node must exist");
+        for node in &component {
+            remaining.remove(node);
+        }
+        result.push(component);
+    }
+
+    result
+}
+
+pub fn has_cycle(graph: &Graph) -> bool {
+    fn visit(
+        graph: &Graph,
+        node: &str,
+        parent: Option<&str>,
+        visited: &mut BTreeSet<String>,
+    ) -> bool {
+        visited.insert(node.to_string());
+        for neighbor in graph.neighbors(node).expect("node must exist") {
+            if !visited.contains(&neighbor) {
+                if visit(graph, &neighbor, Some(node), visited) {
+                    return true;
+                }
+            } else if Some(neighbor.as_str()) != parent {
+                return true;
+            }
+        }
+        false
+    }
+
+    let mut visited = BTreeSet::new();
+    for node in graph.nodes() {
+        if !visited.contains(&node) && visit(graph, &node, None, &mut visited) {
+            return true;
+        }
+    }
+    false
+}
+
+pub fn shortest_path(graph: &Graph, start: &str, end: &str) -> Vec<String> {
+    if !graph.has_node(start) || !graph.has_node(end) {
+        return Vec::new();
+    }
+    if start == end {
+        return vec![start.to_string()];
+    }
+
+    let all_unit = graph.edges().iter().all(|edge| edge.2 == 1.0);
+    if all_unit {
+        bfs_shortest_path(graph, start, end)
+    } else {
+        dijkstra_shortest_path(graph, start, end)
+    }
+}
+
+fn bfs_shortest_path(graph: &Graph, start: &str, end: &str) -> Vec<String> {
+    let mut parent = BTreeMap::new();
+    parent.insert(start.to_string(), None::<String>);
+    let mut queue = VecDeque::from([start.to_string()]);
+
+    while let Some(node) = queue.pop_front() {
+        if node == end {
+            break;
+        }
+        for neighbor in graph.neighbors(&node).expect("node must exist") {
+            if !parent.contains_key(&neighbor) {
+                parent.insert(neighbor.clone(), Some(node.clone()));
+                queue.push_back(neighbor);
+            }
+        }
+    }
+
+    if !parent.contains_key(end) {
+        return Vec::new();
+    }
+
+    let mut path = Vec::new();
+    let mut current = Some(end.to_string());
+    while let Some(node) = current {
+        current = parent.get(&node).cloned().unwrap_or(None);
+        path.push(node);
+    }
+    path.reverse();
+    path
+}
+
+fn dijkstra_shortest_path(graph: &Graph, start: &str, end: &str) -> Vec<String> {
+    let mut distances = BTreeMap::new();
+    let mut parent = BTreeMap::new();
+    for node in graph.nodes() {
+        distances.insert(node, f64::INFINITY);
+    }
+    distances.insert(start.to_string(), 0.0);
+
+    let mut sequence = 0usize;
+    let mut queue: Vec<(f64, usize, String)> = vec![(0.0, sequence, start.to_string())];
+
+    while !queue.is_empty() {
+        queue.sort_by(|left, right| left.0.total_cmp(&right.0).then_with(|| left.1.cmp(&right.1)));
+        let (distance, _, node) = queue.remove(0);
+        if distance > *distances.get(&node).unwrap_or(&f64::INFINITY) {
+            continue;
+        }
+        if node == end {
+            break;
+        }
+
+        for (neighbor, weight) in graph.neighbors_weighted(&node).expect("node must exist") {
+            let next_distance = distance + weight;
+            if next_distance < *distances.get(&neighbor).unwrap_or(&f64::INFINITY) {
+                distances.insert(neighbor.clone(), next_distance);
+                parent.insert(neighbor.clone(), node.clone());
+                sequence += 1;
+                queue.push((next_distance, sequence, neighbor));
+            }
+        }
+    }
+
+    if distances.get(end).copied().unwrap_or(f64::INFINITY) == f64::INFINITY {
+        return Vec::new();
+    }
+
+    let mut path = Vec::new();
+    let mut current = end.to_string();
+    loop {
+        path.push(current.clone());
+        if current == start {
+            break;
+        }
+        let Some(previous) = parent.get(&current).cloned() else {
+            return Vec::new();
+        };
+        current = previous;
+    }
+    path.reverse();
+    path
+}
+
+pub fn minimum_spanning_tree(graph: &Graph) -> Result<Vec<WeightedEdge>, GraphError> {
+    let nodes = graph.nodes();
+    if nodes.len() <= 1 || graph.edges().is_empty() {
+        return Ok(Vec::new());
+    }
+    if !is_connected(graph) {
+        return Err(GraphError::NotConnected);
+    }
+
+    let mut result = Vec::new();
+    let mut union_find = UnionFind::new(nodes);
+    for edge in graph.edges() {
+        if union_find.find(&edge.0) != union_find.find(&edge.1) {
+            union_find.union(&edge.0, &edge.1);
+            result.push(edge);
+            if result.len() == union_find.size() - 1 {
+                break;
+            }
+        }
+    }
+    Ok(result)
+}
+
+struct UnionFind {
+    parent: BTreeMap<String, String>,
+    rank: BTreeMap<String, usize>,
+}
+
+impl UnionFind {
+    fn new(nodes: Vec<String>) -> Self {
+        let mut parent = BTreeMap::new();
+        let mut rank = BTreeMap::new();
+        for node in nodes {
+            parent.insert(node.clone(), node.clone());
+            rank.insert(node, 0);
+        }
+        Self { parent, rank }
+    }
+
+    fn size(&self) -> usize {
+        self.parent.len()
+    }
+
+    fn find(&mut self, node: &str) -> String {
+        let parent = self.parent.get(node).cloned().expect("node must exist");
+        if parent != node {
+            let root = self.find(&parent);
+            self.parent.insert(node.to_string(), root.clone());
+            root
+        } else {
+            parent
+        }
+    }
+
+    fn union(&mut self, left: &str, right: &str) {
+        let mut left_root = self.find(left);
+        let mut right_root = self.find(right);
+        if left_root == right_root {
+            return;
+        }
+
+        let left_rank = *self.rank.get(&left_root).unwrap_or(&0);
+        let right_rank = *self.rank.get(&right_root).unwrap_or(&0);
+        if left_rank < right_rank {
+            std::mem::swap(&mut left_root, &mut right_root);
+        }
+
+        self.parent.insert(right_root.clone(), left_root.clone());
+        if left_rank == right_rank {
+            self.rank.insert(left_root, left_rank + 1);
+        }
+    }
+}

--- a/code/packages/rust/graph/src/graph.rs
+++ b/code/packages/rust/graph/src/graph.rs
@@ -1,0 +1,354 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GraphRepr {
+    AdjacencyList,
+    AdjacencyMatrix,
+}
+
+pub type WeightedEdge = (String, String, f64);
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum GraphError {
+    NodeNotFound(String),
+    EdgeNotFound(String, String),
+    NotConnected,
+}
+
+impl fmt::Display for GraphError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GraphError::NodeNotFound(node) => write!(f, "node not found: {}", node),
+            GraphError::EdgeNotFound(left, right) => {
+                write!(f, "edge not found: {} -- {}", left, right)
+            }
+            GraphError::NotConnected => write!(f, "graph is not connected"),
+        }
+    }
+}
+
+impl std::error::Error for GraphError {}
+
+#[derive(Debug, Clone)]
+pub struct Graph {
+    repr: GraphRepr,
+    adj: BTreeMap<String, BTreeMap<String, f64>>,
+    node_list: Vec<String>,
+    node_index: BTreeMap<String, usize>,
+    matrix: Vec<Vec<Option<f64>>>,
+}
+
+impl Graph {
+    pub fn new(repr: GraphRepr) -> Self {
+        Self {
+            repr,
+            adj: BTreeMap::new(),
+            node_list: Vec::new(),
+            node_index: BTreeMap::new(),
+            matrix: Vec::new(),
+        }
+    }
+
+    pub fn repr(&self) -> GraphRepr {
+        self.repr
+    }
+
+    pub fn add_node(&mut self, node: impl Into<String>) {
+        let node = node.into();
+        match self.repr {
+            GraphRepr::AdjacencyList => {
+                self.adj.entry(node).or_default();
+            }
+            GraphRepr::AdjacencyMatrix => {
+                if self.node_index.contains_key(&node) {
+                    return;
+                }
+                let index = self.node_list.len();
+                self.node_list.push(node.clone());
+                self.node_index.insert(node, index);
+                for row in &mut self.matrix {
+                    row.push(None);
+                }
+                self.matrix.push(vec![None; index + 1]);
+            }
+        }
+    }
+
+    pub fn remove_node(&mut self, node: &str) -> Result<(), GraphError> {
+        match self.repr {
+            GraphRepr::AdjacencyList => {
+                let neighbors = self
+                    .adj
+                    .get(node)
+                    .cloned()
+                    .ok_or_else(|| GraphError::NodeNotFound(node.to_string()))?;
+                for neighbor in neighbors.keys() {
+                    if let Some(entry) = self.adj.get_mut(neighbor) {
+                        entry.remove(node);
+                    }
+                }
+                self.adj.remove(node);
+                Ok(())
+            }
+            GraphRepr::AdjacencyMatrix => {
+                let index = self
+                    .node_index
+                    .remove(node)
+                    .ok_or_else(|| GraphError::NodeNotFound(node.to_string()))?;
+                self.node_list.remove(index);
+                self.matrix.remove(index);
+                for row in &mut self.matrix {
+                    row.remove(index);
+                }
+                for (offset, name) in self.node_list[index..].iter().enumerate() {
+                    self.node_index.insert(name.clone(), index + offset);
+                }
+                Ok(())
+            }
+        }
+    }
+
+    pub fn has_node(&self, node: &str) -> bool {
+        match self.repr {
+            GraphRepr::AdjacencyList => self.adj.contains_key(node),
+            GraphRepr::AdjacencyMatrix => self.node_index.contains_key(node),
+        }
+    }
+
+    pub fn nodes(&self) -> Vec<String> {
+        match self.repr {
+            GraphRepr::AdjacencyList => self.adj.keys().cloned().collect(),
+            GraphRepr::AdjacencyMatrix => self.node_list.clone(),
+        }
+    }
+
+    pub fn add_edge(&mut self, left: impl Into<String>, right: impl Into<String>, weight: f64) {
+        let left = left.into();
+        let right = right.into();
+        self.add_node(left.clone());
+        self.add_node(right.clone());
+
+        match self.repr {
+            GraphRepr::AdjacencyList => {
+                self.adj
+                    .get_mut(&left)
+                    .expect("left node must exist")
+                    .insert(right.clone(), weight);
+                self.adj
+                    .get_mut(&right)
+                    .expect("right node must exist")
+                    .insert(left, weight);
+            }
+            GraphRepr::AdjacencyMatrix => {
+                let left_index = self.node_index[&left];
+                let right_index = self.node_index[&right];
+                self.matrix[left_index][right_index] = Some(weight);
+                self.matrix[right_index][left_index] = Some(weight);
+            }
+        }
+    }
+
+    pub fn remove_edge(&mut self, left: &str, right: &str) -> Result<(), GraphError> {
+        match self.repr {
+            GraphRepr::AdjacencyList => {
+                if !self
+                    .adj
+                    .get(left)
+                    .map(|neighbors| neighbors.contains_key(right))
+                    .unwrap_or(false)
+                {
+                    return Err(GraphError::EdgeNotFound(
+                        left.to_string(),
+                        right.to_string(),
+                    ));
+                }
+                self.adj.get_mut(left).unwrap().remove(right);
+                self.adj.get_mut(right).unwrap().remove(left);
+                Ok(())
+            }
+            GraphRepr::AdjacencyMatrix => {
+                let left_index = self
+                    .node_index
+                    .get(left)
+                    .copied()
+                    .ok_or_else(|| GraphError::EdgeNotFound(left.to_string(), right.to_string()))?;
+                let right_index = self
+                    .node_index
+                    .get(right)
+                    .copied()
+                    .ok_or_else(|| GraphError::EdgeNotFound(left.to_string(), right.to_string()))?;
+                if self.matrix[left_index][right_index].is_none() {
+                    return Err(GraphError::EdgeNotFound(
+                        left.to_string(),
+                        right.to_string(),
+                    ));
+                }
+                self.matrix[left_index][right_index] = None;
+                self.matrix[right_index][left_index] = None;
+                Ok(())
+            }
+        }
+    }
+
+    pub fn has_edge(&self, left: &str, right: &str) -> bool {
+        match self.repr {
+            GraphRepr::AdjacencyList => self
+                .adj
+                .get(left)
+                .map(|neighbors| neighbors.contains_key(right))
+                .unwrap_or(false),
+            GraphRepr::AdjacencyMatrix => self
+                .node_index
+                .get(left)
+                .zip(self.node_index.get(right))
+                .and_then(|(left_index, right_index)| self.matrix[*left_index][*right_index])
+                .is_some(),
+        }
+    }
+
+    pub fn edge_weight(&self, left: &str, right: &str) -> Result<f64, GraphError> {
+        match self.repr {
+            GraphRepr::AdjacencyList => self
+                .adj
+                .get(left)
+                .and_then(|neighbors| neighbors.get(right))
+                .copied()
+                .ok_or_else(|| GraphError::EdgeNotFound(left.to_string(), right.to_string())),
+            GraphRepr::AdjacencyMatrix => {
+                let left_index = self
+                    .node_index
+                    .get(left)
+                    .copied()
+                    .ok_or_else(|| GraphError::EdgeNotFound(left.to_string(), right.to_string()))?;
+                let right_index = self
+                    .node_index
+                    .get(right)
+                    .copied()
+                    .ok_or_else(|| GraphError::EdgeNotFound(left.to_string(), right.to_string()))?;
+                self.matrix[left_index][right_index]
+                    .ok_or_else(|| GraphError::EdgeNotFound(left.to_string(), right.to_string()))
+            }
+        }
+    }
+
+    pub fn edges(&self) -> Vec<WeightedEdge> {
+        let mut result = Vec::new();
+        match self.repr {
+            GraphRepr::AdjacencyList => {
+                let mut seen = BTreeSet::new();
+                for (left, neighbors) in &self.adj {
+                    for (right, weight) in neighbors {
+                        let (first, second) = canonical_endpoints(left, right);
+                        if seen.insert((first.clone(), second.clone())) {
+                            result.push((first, second, *weight));
+                        }
+                    }
+                }
+            }
+            GraphRepr::AdjacencyMatrix => {
+                for row in 0..self.node_list.len() {
+                    for col in row..self.node_list.len() {
+                        if let Some(weight) = self.matrix[row][col] {
+                            result.push((
+                                self.node_list[row].clone(),
+                                self.node_list[col].clone(),
+                                weight,
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+        result.sort_by(|left, right| {
+            left.2
+                .total_cmp(&right.2)
+                .then_with(|| left.0.cmp(&right.0))
+                .then_with(|| left.1.cmp(&right.1))
+        });
+        result
+    }
+
+    pub fn neighbors(&self, node: &str) -> Result<Vec<String>, GraphError> {
+        match self.repr {
+            GraphRepr::AdjacencyList => self
+                .adj
+                .get(node)
+                .map(|neighbors| neighbors.keys().cloned().collect())
+                .ok_or_else(|| GraphError::NodeNotFound(node.to_string())),
+            GraphRepr::AdjacencyMatrix => {
+                let index = self
+                    .node_index
+                    .get(node)
+                    .copied()
+                    .ok_or_else(|| GraphError::NodeNotFound(node.to_string()))?;
+                Ok(self.matrix[index]
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(col, weight)| weight.map(|_| self.node_list[col].clone()))
+                    .collect())
+            }
+        }
+    }
+
+    pub fn neighbors_weighted(&self, node: &str) -> Result<BTreeMap<String, f64>, GraphError> {
+        match self.repr {
+            GraphRepr::AdjacencyList => self
+                .adj
+                .get(node)
+                .cloned()
+                .ok_or_else(|| GraphError::NodeNotFound(node.to_string())),
+            GraphRepr::AdjacencyMatrix => {
+                let index = self
+                    .node_index
+                    .get(node)
+                    .copied()
+                    .ok_or_else(|| GraphError::NodeNotFound(node.to_string()))?;
+                let mut result = BTreeMap::new();
+                for (col, weight) in self.matrix[index].iter().enumerate() {
+                    if let Some(weight) = weight {
+                        result.insert(self.node_list[col].clone(), *weight);
+                    }
+                }
+                Ok(result)
+            }
+        }
+    }
+
+    pub fn degree(&self, node: &str) -> Result<usize, GraphError> {
+        Ok(self.neighbors(node)?.len())
+    }
+
+    pub fn size(&self) -> usize {
+        match self.repr {
+            GraphRepr::AdjacencyList => self.adj.len(),
+            GraphRepr::AdjacencyMatrix => self.node_list.len(),
+        }
+    }
+}
+
+impl Default for Graph {
+    fn default() -> Self {
+        Self::new(GraphRepr::AdjacencyList)
+    }
+}
+
+impl fmt::Display for Graph {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Graph(nodes={}, edges={}, repr={:?})",
+            self.size(),
+            self.edges().len(),
+            self.repr
+        )
+    }
+}
+
+fn canonical_endpoints(left: &str, right: &str) -> (String, String) {
+    if left <= right {
+        (left.to_string(), right.to_string())
+    } else {
+        (right.to_string(), left.to_string())
+    }
+}

--- a/code/packages/rust/graph/src/lib.rs
+++ b/code/packages/rust/graph/src/lib.rs
@@ -1,0 +1,131 @@
+pub mod algorithms;
+pub mod graph;
+
+pub use algorithms::{
+    bfs, connected_components, dfs, has_cycle, is_connected, minimum_spanning_tree,
+    shortest_path,
+};
+pub use graph::{Graph, GraphError, GraphRepr, WeightedEdge};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn representations() -> [GraphRepr; 2] {
+        [GraphRepr::AdjacencyList, GraphRepr::AdjacencyMatrix]
+    }
+
+    fn make_graph(repr: GraphRepr) -> Graph {
+        let mut g = Graph::new(repr);
+        g.add_edge("London", "Paris", 300.0);
+        g.add_edge("London", "Amsterdam", 520.0);
+        g.add_edge("Paris", "Berlin", 878.0);
+        g.add_edge("Amsterdam", "Berlin", 655.0);
+        g.add_edge("Amsterdam", "Brussels", 180.0);
+        g
+    }
+
+    fn make_triangle(repr: GraphRepr) -> Graph {
+        let mut g = Graph::new(repr);
+        g.add_edge("A", "B", 1.0);
+        g.add_edge("B", "C", 1.0);
+        g.add_edge("C", "A", 1.0);
+        g
+    }
+
+    fn make_path(repr: GraphRepr) -> Graph {
+        let mut g = Graph::new(repr);
+        g.add_edge("A", "B", 1.0);
+        g.add_edge("B", "C", 1.0);
+        g
+    }
+
+    #[test]
+    fn construction_and_nodes_work_in_both_representations() {
+        for repr in representations() {
+            let mut g = Graph::new(repr);
+            assert_eq!(g.size(), 0);
+            g.add_node("A");
+            g.add_node("B");
+            assert!(g.has_node("A"));
+            assert!(g.has_node("B"));
+            g.remove_node("A").unwrap();
+            assert!(!g.has_node("A"));
+            assert_eq!(g.size(), 1);
+        }
+    }
+
+    #[test]
+    fn edge_operations_and_neighbors_are_undirected() {
+        for repr in representations() {
+            let mut g = Graph::new(repr);
+            g.add_edge("A", "B", 2.5);
+            assert!(g.has_edge("A", "B"));
+            assert!(g.has_edge("B", "A"));
+            assert_eq!(g.edge_weight("A", "B").unwrap(), 2.5);
+            assert_eq!(g.neighbors("A").unwrap(), vec!["B".to_string()]);
+        }
+    }
+
+    #[test]
+    fn self_loops_and_zero_weight_edges_are_supported() {
+        for repr in representations() {
+            let mut g = Graph::new(repr);
+            g.add_edge("A", "A", 0.0);
+            assert!(g.has_edge("A", "A"));
+            assert_eq!(g.edge_weight("A", "A").unwrap(), 0.0);
+            assert_eq!(g.neighbors("A").unwrap(), vec!["A".to_string()]);
+        }
+    }
+
+    #[test]
+    fn traversals_connectivity_and_cycles_match_expectations() {
+        for repr in representations() {
+            assert_eq!(bfs(&make_path(repr), "A").unwrap(), vec!["A", "B", "C"]);
+            assert_eq!(dfs(&make_path(repr), "A").unwrap(), vec!["A", "B", "C"]);
+            assert!(is_connected(&make_graph(repr)));
+            assert!(has_cycle(&make_triangle(repr)));
+            assert!(!has_cycle(&make_path(repr)));
+        }
+    }
+
+    #[test]
+    fn connected_components_split_disconnected_graphs() {
+        for repr in representations() {
+            let mut g = Graph::new(repr);
+            g.add_edge("A", "B", 1.0);
+            g.add_edge("B", "C", 1.0);
+            g.add_edge("D", "E", 1.0);
+            g.add_node("F");
+            let components = connected_components(&g);
+            assert_eq!(components.len(), 3);
+            assert!(components.contains(&vec!["A".to_string(), "B".to_string(), "C".to_string()]));
+            assert!(components.contains(&vec!["D".to_string(), "E".to_string()]));
+            assert!(components.contains(&vec!["F".to_string()]));
+        }
+    }
+
+    #[test]
+    fn shortest_path_and_mst_follow_the_weighted_spec() {
+        for repr in representations() {
+            let path = shortest_path(&make_graph(repr), "London", "Berlin");
+            assert_eq!(path, vec!["London", "Amsterdam", "Berlin"]);
+
+            let mst = minimum_spanning_tree(&make_graph(repr)).unwrap();
+            assert_eq!(mst.len(), 4);
+        }
+    }
+
+    #[test]
+    fn disconnected_graph_has_no_spanning_tree() {
+        for repr in representations() {
+            let mut g = Graph::new(repr);
+            g.add_edge("A", "B", 1.0);
+            g.add_node("C");
+            assert!(matches!(
+                minimum_spanning_tree(&g),
+                Err(GraphError::NotConnected)
+            ));
+        }
+    }
+}

--- a/code/packages/wasm/graph/BUILD
+++ b/code/packages/wasm/graph/BUILD
@@ -1,0 +1,1 @@
+cargo test -- --nocapture

--- a/code/packages/wasm/graph/BUILD_windows
+++ b/code/packages/wasm/graph/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -- --nocapture

--- a/code/packages/wasm/graph/CHANGELOG.md
+++ b/code/packages/wasm/graph/CHANGELOG.md
@@ -1,0 +1,6 @@
+# graph-wasm changelog
+
+## 0.1.0
+
+- Added WebAssembly bindings for the Rust `graph` crate
+- Added browser-facing graph methods plus traversal, connectivity, shortest path, and MST helpers

--- a/code/packages/wasm/graph/Cargo.toml
+++ b/code/packages/wasm/graph/Cargo.toml
@@ -1,0 +1,16 @@
+[workspace]
+
+[package]
+name = "graph-wasm"
+version = "0.1.0"
+edition = "2021"
+description = "WebAssembly bindings for the Rust weighted undirected graph crate"
+license = "MIT"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+graph = { path = "../../rust/graph" }
+serde_json = "1"
+wasm-bindgen = "0.2"

--- a/code/packages/wasm/graph/README.md
+++ b/code/packages/wasm/graph/README.md
@@ -1,0 +1,33 @@
+# graph-wasm
+
+WebAssembly bindings for the Rust [graph](../../rust/graph/) crate.
+
+## What It Provides
+
+- `WasmGraph` with adjacency-list and adjacency-matrix backing
+- String-node graph operations for browser and JS runtimes
+- `bfs`, `dfs`, `isConnected`, `connectedComponentsJson`, `hasCycle`
+- `shortestPath` and `minimumSpanningTreeJson`
+
+## Usage
+
+```javascript
+import init, { WasmGraph } from "./graph_wasm.js";
+
+await init();
+
+const graph = WasmGraph.withRepresentation("adjacency_matrix");
+graph.addEdge("London", "Paris", 300);
+graph.addEdge("London", "Amsterdam", 520);
+graph.addEdge("Amsterdam", "Berlin", 655);
+
+graph.shortestPath("London", "Berlin"); // ["London", "Amsterdam", "Berlin"]
+graph.minimumSpanningTreeJson(); // JSON string of weighted edges
+```
+
+## Building
+
+```bash
+cargo test
+wasm-pack build --target web
+```

--- a/code/packages/wasm/graph/required_capabilities.json
+++ b/code/packages/wasm/graph/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "wasm/graph",
+  "capabilities": [],
+  "justification": "Pure computation compiled to WebAssembly. No host capabilities required."
+}

--- a/code/packages/wasm/graph/src/lib.rs
+++ b/code/packages/wasm/graph/src/lib.rs
@@ -1,0 +1,196 @@
+use graph::{
+    bfs as core_bfs, connected_components as core_connected_components, dfs as core_dfs,
+    has_cycle as core_has_cycle, is_connected as core_is_connected,
+    minimum_spanning_tree as core_minimum_spanning_tree, shortest_path as core_shortest_path,
+    Graph, GraphError, GraphRepr,
+};
+use wasm_bindgen::prelude::*;
+
+fn to_js_error(error: GraphError) -> JsValue {
+    JsValue::from_str(&error.to_string())
+}
+
+fn parse_repr(repr: &str) -> Result<GraphRepr, JsValue> {
+    match repr {
+        "adjacency_list" => Ok(GraphRepr::AdjacencyList),
+        "adjacency_matrix" => Ok(GraphRepr::AdjacencyMatrix),
+        _ => Err(JsValue::from_str(
+            "unknown graph representation; expected adjacency_list or adjacency_matrix",
+        )),
+    }
+}
+
+#[wasm_bindgen]
+pub struct WasmGraph {
+    inner: Graph,
+}
+
+#[wasm_bindgen]
+impl WasmGraph {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self {
+            inner: Graph::default(),
+        }
+    }
+
+    #[wasm_bindgen(js_name = "withRepresentation")]
+    pub fn with_representation(repr: &str) -> Result<Self, JsValue> {
+        Ok(Self {
+            inner: Graph::new(parse_repr(repr)?),
+        })
+    }
+
+    pub fn repr(&self) -> String {
+        match self.inner.repr() {
+            GraphRepr::AdjacencyList => "adjacency_list".to_string(),
+            GraphRepr::AdjacencyMatrix => "adjacency_matrix".to_string(),
+        }
+    }
+
+    #[wasm_bindgen(js_name = "addNode")]
+    pub fn add_node(&mut self, node: &str) {
+        self.inner.add_node(node);
+    }
+
+    #[wasm_bindgen(js_name = "removeNode")]
+    pub fn remove_node(&mut self, node: &str) -> Result<(), JsValue> {
+        self.inner.remove_node(node).map_err(to_js_error)
+    }
+
+    #[wasm_bindgen(js_name = "hasNode")]
+    pub fn has_node(&self, node: &str) -> bool {
+        self.inner.has_node(node)
+    }
+
+    pub fn nodes(&self) -> Vec<String> {
+        self.inner.nodes()
+    }
+
+    pub fn size(&self) -> usize {
+        self.inner.size()
+    }
+
+    #[wasm_bindgen(js_name = "addEdge")]
+    pub fn add_edge(&mut self, left: &str, right: &str, weight: f64) {
+        self.inner.add_edge(left, right, weight);
+    }
+
+    #[wasm_bindgen(js_name = "removeEdge")]
+    pub fn remove_edge(&mut self, left: &str, right: &str) -> Result<(), JsValue> {
+        self.inner.remove_edge(left, right).map_err(to_js_error)
+    }
+
+    #[wasm_bindgen(js_name = "hasEdge")]
+    pub fn has_edge(&self, left: &str, right: &str) -> bool {
+        self.inner.has_edge(left, right)
+    }
+
+    #[wasm_bindgen(js_name = "edgeWeight")]
+    pub fn edge_weight(&self, left: &str, right: &str) -> Result<f64, JsValue> {
+        self.inner.edge_weight(left, right).map_err(to_js_error)
+    }
+
+    #[wasm_bindgen(js_name = "edgesJson")]
+    pub fn edges_json(&self) -> String {
+        serde_json::to_string(&self.inner.edges()).expect("edges are serializable")
+    }
+
+    pub fn neighbors(&self, node: &str) -> Result<Vec<String>, JsValue> {
+        self.inner.neighbors(node).map_err(to_js_error)
+    }
+
+    #[wasm_bindgen(js_name = "neighborsWeightedJson")]
+    pub fn neighbors_weighted_json(&self, node: &str) -> Result<String, JsValue> {
+        let neighbors = self.inner.neighbors_weighted(node).map_err(to_js_error)?;
+        Ok(serde_json::to_string(&neighbors).expect("neighbors are serializable"))
+    }
+
+    pub fn degree(&self, node: &str) -> Result<usize, JsValue> {
+        self.inner.degree(node).map_err(to_js_error)
+    }
+
+    pub fn bfs(&self, start: &str) -> Result<Vec<String>, JsValue> {
+        core_bfs(&self.inner, start).map_err(to_js_error)
+    }
+
+    pub fn dfs(&self, start: &str) -> Result<Vec<String>, JsValue> {
+        core_dfs(&self.inner, start).map_err(to_js_error)
+    }
+
+    #[wasm_bindgen(js_name = "isConnected")]
+    pub fn is_connected(&self) -> bool {
+        core_is_connected(&self.inner)
+    }
+
+    #[wasm_bindgen(js_name = "connectedComponentsJson")]
+    pub fn connected_components_json(&self) -> String {
+        serde_json::to_string(&core_connected_components(&self.inner))
+            .expect("components are serializable")
+    }
+
+    #[wasm_bindgen(js_name = "hasCycle")]
+    pub fn has_cycle(&self) -> bool {
+        core_has_cycle(&self.inner)
+    }
+
+    #[wasm_bindgen(js_name = "shortestPath")]
+    pub fn shortest_path(&self, start: &str, end: &str) -> Vec<String> {
+        core_shortest_path(&self.inner, start, end)
+    }
+
+    #[wasm_bindgen(js_name = "minimumSpanningTreeJson")]
+    pub fn minimum_spanning_tree_json(&self) -> Result<String, JsValue> {
+        let mst = core_minimum_spanning_tree(&self.inner).map_err(to_js_error)?;
+        Ok(serde_json::to_string(&mst).expect("mst is serializable"))
+    }
+
+    #[wasm_bindgen(js_name = "toString")]
+    pub fn to_string_value(&self) -> String {
+        self.inner.to_string()
+    }
+}
+
+impl Default for WasmGraph {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_graph() -> WasmGraph {
+        let mut graph = WasmGraph::with_representation("adjacency_matrix").unwrap();
+        graph.add_edge("London", "Paris", 300.0);
+        graph.add_edge("London", "Amsterdam", 520.0);
+        graph.add_edge("Paris", "Berlin", 878.0);
+        graph.add_edge("Amsterdam", "Berlin", 655.0);
+        graph.add_edge("Amsterdam", "Brussels", 180.0);
+        graph
+    }
+
+    #[test]
+    fn wrapper_exposes_graph_operations_and_shortest_path() {
+        let graph = make_graph();
+        assert_eq!(graph.repr(), "adjacency_matrix");
+        assert!(graph.has_edge("London", "Amsterdam"));
+        assert_eq!(
+            graph.shortest_path("London", "Berlin"),
+            vec!["London", "Amsterdam", "Berlin"]
+        );
+        assert_eq!(graph.degree("Amsterdam").unwrap(), 3);
+    }
+
+    #[test]
+    fn wrapper_exposes_json_helpers_and_algorithms() {
+        let graph = make_graph();
+        assert!(graph.is_connected());
+        assert!(graph.has_cycle());
+        assert!(graph.edges_json().contains("London"));
+        assert!(graph.connected_components_json().contains("Brussels"));
+        assert!(graph.minimum_spanning_tree_json().unwrap().contains("Paris"));
+    }
+}


### PR DESCRIPTION
## Summary
- add graph packages for Go, Rust, and WASM based on the DT00 graph spec
- implement weighted undirected graphs with adjacency-list and adjacency-matrix representations
- add traversal, connectivity, cycle detection, shortest path, and minimum spanning tree coverage

## Validation
- `go test ./... -v -cover` in `code/packages/go/graph`
- `cargo test -p graph -- --nocapture` in `code/packages/rust`
- `cargo test -- --nocapture` in `code/packages/wasm/graph`