### PR TITLE
[codex] port in-memory data store to Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ tests prove the behavior
 
 Today the repo contains:
 
-- 1503 package directories
+- 1513 package directories
 - 122 program directories
 - 9 implementation languages
 

--- a/code/packages/go/hash-map/BUILD
+++ b/code/packages/go/hash-map/BUILD
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/hash-map/BUILD_windows
+++ b/code/packages/go/hash-map/BUILD_windows
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/hash-map/go.mod
+++ b/code/packages/go/hash-map/go.mod
@@ -1,0 +1,3 @@
+module github.com/adhithyan15/coding-adventures/code/packages/go/hash-map
+
+go 1.23

--- a/code/packages/go/hash-map/hash_map.go
+++ b/code/packages/go/hash-map/hash_map.go
@@ -1,0 +1,118 @@
+package hashmap
+
+import (
+	"bytes"
+	"sort"
+)
+
+type Entry[V any] struct {
+	Key   []byte
+	Value V
+}
+
+type HashMap[V any] struct {
+	entries map[string]Entry[V]
+}
+
+func New[V any]() *HashMap[V] {
+	return &HashMap[V]{entries: make(map[string]Entry[V])}
+}
+
+func (m *HashMap[V]) Clone() *HashMap[V] {
+	if m == nil {
+		return New[V]()
+	}
+	clone := New[V]()
+	for _, entry := range m.entries {
+		clone.entries[string(entry.Key)] = Entry[V]{
+			Key:   cloneBytes(entry.Key),
+			Value: entry.Value,
+		}
+	}
+	return clone
+}
+
+func (m *HashMap[V]) Set(key []byte, value V) {
+	if m.entries == nil {
+		m.entries = make(map[string]Entry[V])
+	}
+	keyCopy := cloneBytes(key)
+	m.entries[string(keyCopy)] = Entry[V]{Key: keyCopy, Value: value}
+}
+
+func (m *HashMap[V]) Get(key []byte) (V, bool) {
+	if m == nil || m.entries == nil {
+		var zero V
+		return zero, false
+	}
+	entry, ok := m.entries[string(key)]
+	if !ok {
+		var zero V
+		return zero, false
+	}
+	return entry.Value, true
+}
+
+func (m *HashMap[V]) Delete(key []byte) bool {
+	if m == nil || m.entries == nil {
+		return false
+	}
+	keyStr := string(key)
+	if _, ok := m.entries[keyStr]; !ok {
+		return false
+	}
+	delete(m.entries, keyStr)
+	return true
+}
+
+func (m *HashMap[V]) Has(key []byte) bool {
+	if m == nil || m.entries == nil {
+		return false
+	}
+	_, ok := m.entries[string(key)]
+	return ok
+}
+
+func (m *HashMap[V]) Size() int {
+	if m == nil || m.entries == nil {
+		return 0
+	}
+	return len(m.entries)
+}
+
+func (m *HashMap[V]) Keys() [][]byte {
+	entries := m.Entries()
+	keys := make([][]byte, 0, len(entries))
+	for _, entry := range entries {
+		keys = append(keys, cloneBytes(entry.Key))
+	}
+	return keys
+}
+
+func (m *HashMap[V]) Entries() []Entry[V] {
+	if m == nil || m.entries == nil {
+		return nil
+	}
+	entries := make([]Entry[V], 0, len(m.entries))
+	for _, entry := range m.entries {
+		entries = append(entries, Entry[V]{
+			Key:   cloneBytes(entry.Key),
+			Value: entry.Value,
+		})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return bytes.Compare(entries[i].Key, entries[j].Key) < 0
+	})
+	return entries
+}
+
+func (m *HashMap[V]) Clear() {
+	m.entries = make(map[string]Entry[V])
+}
+
+func cloneBytes(data []byte) []byte {
+	if data == nil {
+		return nil
+	}
+	return append([]byte(nil), data...)
+}

--- a/code/packages/go/hash-map/hash_map_test.go
+++ b/code/packages/go/hash-map/hash_map_test.go
@@ -1,0 +1,37 @@
+package hashmap
+
+import "testing"
+
+func TestHashMapBasicOperations(t *testing.T) {
+	m := New[int]()
+	m.Set([]byte("alpha"), 1)
+	m.Set([]byte("beta"), 2)
+	m.Set([]byte("beta"), 3)
+
+	if got, ok := m.Get([]byte("alpha")); !ok || got != 1 {
+		t.Fatalf("expected alpha=1, got %v %v", got, ok)
+	}
+	if got, ok := m.Get([]byte("beta")); !ok || got != 3 {
+		t.Fatalf("expected beta=3, got %v %v", got, ok)
+	}
+	if !m.Has([]byte("alpha")) || m.Size() != 2 {
+		t.Fatalf("unexpected map state: has alpha=%v size=%d", m.Has([]byte("alpha")), m.Size())
+	}
+	if !m.Delete([]byte("alpha")) || m.Has([]byte("alpha")) {
+		t.Fatal("delete failed")
+	}
+	keys := m.Keys()
+	if len(keys) != 1 || string(keys[0]) != "beta" {
+		t.Fatalf("unexpected keys: %q", keys)
+	}
+}
+
+func TestHashMapClone(t *testing.T) {
+	m := New[string]()
+	m.Set([]byte("x"), "1")
+	clone := m.Clone()
+	clone.Set([]byte("y"), "2")
+	if m.Has([]byte("y")) {
+		t.Fatal("clone should not mutate original")
+	}
+}

--- a/code/packages/go/hash-set/BUILD
+++ b/code/packages/go/hash-set/BUILD
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/hash-set/BUILD_windows
+++ b/code/packages/go/hash-set/BUILD_windows
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/hash-set/go.mod
+++ b/code/packages/go/hash-set/go.mod
@@ -1,0 +1,3 @@
+module github.com/adhithyan15/coding-adventures/code/packages/go/hash-set
+
+go 1.23

--- a/code/packages/go/hash-set/hash_set.go
+++ b/code/packages/go/hash-set/hash_set.go
@@ -1,0 +1,148 @@
+package hashset
+
+import (
+	"bytes"
+	"sort"
+)
+
+type HashSet struct {
+	items map[string][]byte
+}
+
+func New() *HashSet {
+	return &HashSet{items: make(map[string][]byte)}
+}
+
+func (s *HashSet) Clone() *HashSet {
+	if s == nil {
+		return New()
+	}
+	clone := New()
+	for _, item := range s.items {
+		clone.items[string(item)] = cloneBytes(item)
+	}
+	return clone
+}
+
+func (s *HashSet) Add(item []byte) bool {
+	if s.items == nil {
+		s.items = make(map[string][]byte)
+	}
+	key := string(item)
+	_, exists := s.items[key]
+	if !exists {
+		s.items[key] = cloneBytes(item)
+	}
+	return !exists
+}
+
+func (s *HashSet) Remove(item []byte) bool {
+	if s == nil || s.items == nil {
+		return false
+	}
+	key := string(item)
+	if _, exists := s.items[key]; !exists {
+		return false
+	}
+	delete(s.items, key)
+	return true
+}
+
+func (s *HashSet) Contains(item []byte) bool {
+	if s == nil || s.items == nil {
+		return false
+	}
+	_, ok := s.items[string(item)]
+	return ok
+}
+
+func (s *HashSet) Size() int {
+	if s == nil || s.items == nil {
+		return 0
+	}
+	return len(s.items)
+}
+
+func (s *HashSet) IsEmpty() bool {
+	return s.Size() == 0
+}
+
+func (s *HashSet) ToSlice() [][]byte {
+	if s == nil || s.items == nil {
+		return nil
+	}
+	values := make([][]byte, 0, len(s.items))
+	for _, item := range s.items {
+		values = append(values, cloneBytes(item))
+	}
+	sort.Slice(values, func(i, j int) bool {
+		return bytes.Compare(values[i], values[j]) < 0
+	})
+	return values
+}
+
+func (s *HashSet) Union(other *HashSet) *HashSet {
+	result := New()
+	for _, item := range s.ToSlice() {
+		result.Add(item)
+	}
+	for _, item := range other.ToSlice() {
+		result.Add(item)
+	}
+	return result
+}
+
+func (s *HashSet) Intersection(other *HashSet) *HashSet {
+	result := New()
+	for _, item := range s.ToSlice() {
+		if other.Contains(item) {
+			result.Add(item)
+		}
+	}
+	return result
+}
+
+func (s *HashSet) Difference(other *HashSet) *HashSet {
+	result := New()
+	for _, item := range s.ToSlice() {
+		if !other.Contains(item) {
+			result.Add(item)
+		}
+	}
+	return result
+}
+
+func (s *HashSet) SymmetricDifference(other *HashSet) *HashSet {
+	left := s.Difference(other)
+	right := other.Difference(s)
+	return left.Union(right)
+}
+
+func (s *HashSet) IsSubset(other *HashSet) bool {
+	for _, item := range s.ToSlice() {
+		if !other.Contains(item) {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *HashSet) IsSuperset(other *HashSet) bool {
+	return other.IsSubset(s)
+}
+
+func (s *HashSet) IsDisjoint(other *HashSet) bool {
+	for _, item := range s.ToSlice() {
+		if other.Contains(item) {
+			return false
+		}
+	}
+	return true
+}
+
+func cloneBytes(data []byte) []byte {
+	if data == nil {
+		return nil
+	}
+	return append([]byte(nil), data...)
+}

--- a/code/packages/go/hash-set/hash_set_test.go
+++ b/code/packages/go/hash-set/hash_set_test.go
@@ -1,0 +1,25 @@
+package hashset
+
+import "testing"
+
+func TestHashSetOperations(t *testing.T) {
+	s := New()
+	if !s.Add([]byte("a")) || !s.Add([]byte("b")) || s.Add([]byte("a")) {
+		t.Fatal("unexpected add behavior")
+	}
+	if !s.Contains([]byte("a")) || s.Size() != 2 {
+		t.Fatal("expected set membership")
+	}
+	other := New()
+	other.Add([]byte("b"))
+	other.Add([]byte("c"))
+	if got := s.Intersection(other).ToSlice(); len(got) != 1 || string(got[0]) != "b" {
+		t.Fatalf("unexpected intersection: %q", got)
+	}
+	if got := s.Union(other).ToSlice(); len(got) != 3 {
+		t.Fatalf("unexpected union: %q", got)
+	}
+	if !s.Remove([]byte("a")) || s.Contains([]byte("a")) {
+		t.Fatal("remove failed")
+	}
+}

--- a/code/packages/go/heap/BUILD
+++ b/code/packages/go/heap/BUILD
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/heap/BUILD_windows
+++ b/code/packages/go/heap/BUILD_windows
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/heap/go.mod
+++ b/code/packages/go/heap/go.mod
@@ -1,0 +1,3 @@
+module github.com/adhithyan15/coding-adventures/code/packages/go/heap
+
+go 1.23

--- a/code/packages/go/heap/min_heap.go
+++ b/code/packages/go/heap/min_heap.go
@@ -1,0 +1,94 @@
+package heap
+
+type MinHeap[T any] struct {
+	items []T
+	less  func(a, b T) bool
+}
+
+func NewMinHeap[T any](less func(a, b T) bool) *MinHeap[T] {
+	return &MinHeap[T]{items: make([]T, 0), less: less}
+}
+
+func (h *MinHeap[T]) Clone() *MinHeap[T] {
+	if h == nil {
+		return nil
+	}
+	clone := &MinHeap[T]{
+		items: append([]T(nil), h.items...),
+		less:  h.less,
+	}
+	return clone
+}
+
+func (h *MinHeap[T]) Len() int {
+	if h == nil {
+		return 0
+	}
+	return len(h.items)
+}
+
+func (h *MinHeap[T]) Push(value T) {
+	if h.less == nil {
+		panic("heap: missing comparator")
+	}
+	h.items = append(h.items, value)
+	h.up(len(h.items) - 1)
+}
+
+func (h *MinHeap[T]) Peek() (T, bool) {
+	var zero T
+	if h == nil || len(h.items) == 0 {
+		return zero, false
+	}
+	return h.items[0], true
+}
+
+func (h *MinHeap[T]) Pop() (T, bool) {
+	var zero T
+	if h == nil || len(h.items) == 0 {
+		return zero, false
+	}
+	root := h.items[0]
+	last := len(h.items) - 1
+	h.items[0] = h.items[last]
+	h.items = h.items[:last]
+	if len(h.items) > 0 {
+		h.down(0)
+	}
+	return root, true
+}
+
+func (h *MinHeap[T]) Clear() {
+	h.items = nil
+}
+
+func (h *MinHeap[T]) up(index int) {
+	for index > 0 {
+		parent := (index - 1) / 2
+		if !h.less(h.items[index], h.items[parent]) {
+			break
+		}
+		h.items[index], h.items[parent] = h.items[parent], h.items[index]
+		index = parent
+	}
+}
+
+func (h *MinHeap[T]) down(index int) {
+	for {
+		left := 2*index + 1
+		right := left + 1
+		smallest := index
+
+		if left < len(h.items) && h.less(h.items[left], h.items[smallest]) {
+			smallest = left
+		}
+		if right < len(h.items) && h.less(h.items[right], h.items[smallest]) {
+			smallest = right
+		}
+		if smallest == index {
+			return
+		}
+		h.items[index], h.items[smallest] = h.items[smallest], h.items[index]
+		index = smallest
+	}
+}

--- a/code/packages/go/heap/min_heap_test.go
+++ b/code/packages/go/heap/min_heap_test.go
@@ -1,0 +1,23 @@
+package heap
+
+import "testing"
+
+func TestMinHeap(t *testing.T) {
+	h := NewMinHeap(func(a, b int) bool { return a < b })
+	h.Push(3)
+	h.Push(1)
+	h.Push(2)
+
+	if h.Len() != 3 {
+		t.Fatalf("expected 3, got %d", h.Len())
+	}
+	if top, ok := h.Peek(); !ok || top != 1 {
+		t.Fatalf("expected min 1, got %v %v", top, ok)
+	}
+	if val, ok := h.Pop(); !ok || val != 1 {
+		t.Fatalf("expected pop 1, got %v %v", val, ok)
+	}
+	if val, ok := h.Pop(); !ok || val != 2 {
+		t.Fatalf("expected pop 2, got %v %v", val, ok)
+	}
+}

--- a/code/packages/go/hyperloglog/BUILD
+++ b/code/packages/go/hyperloglog/BUILD
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/hyperloglog/BUILD_windows
+++ b/code/packages/go/hyperloglog/BUILD_windows
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/hyperloglog/go.mod
+++ b/code/packages/go/hyperloglog/go.mod
@@ -1,0 +1,3 @@
+module github.com/adhithyan15/coding-adventures/code/packages/go/hyperloglog
+
+go 1.23

--- a/code/packages/go/hyperloglog/hyperloglog.go
+++ b/code/packages/go/hyperloglog/hyperloglog.go
@@ -1,0 +1,134 @@
+package hyperloglog
+
+import (
+	"crypto/sha1"
+	"encoding/binary"
+	"math"
+	"math/bits"
+)
+
+const defaultPrecision = 10
+
+type HyperLogLog struct {
+	precision uint8
+	registers []uint8
+}
+
+func New() *HyperLogLog {
+	return NewWithPrecision(defaultPrecision)
+}
+
+func NewWithPrecision(precision uint8) *HyperLogLog {
+	if precision < 4 || precision > 16 {
+		precision = defaultPrecision
+	}
+	return &HyperLogLog{
+		precision: precision,
+		registers: make([]uint8, 1<<precision),
+	}
+}
+
+func (h *HyperLogLog) Clone() *HyperLogLog {
+	if h == nil {
+		return New()
+	}
+	clone := &HyperLogLog{
+		precision: h.precision,
+		registers: append([]uint8(nil), h.registers...),
+	}
+	return clone
+}
+
+func (h *HyperLogLog) Add(value []byte) bool {
+	if h == nil {
+		return false
+	}
+	hash := hash64(value)
+	index := int(hash >> (64 - h.precision))
+	w := hash << h.precision
+	rank := uint8(bits.LeadingZeros64(w) + 1)
+	if rank > h.registers[index] {
+		h.registers[index] = rank
+		return true
+	}
+	return false
+}
+
+func (h *HyperLogLog) Merge(other *HyperLogLog) {
+	if h == nil || other == nil {
+		return
+	}
+	if h.precision != other.precision {
+		panic("hyperloglog: precision mismatch")
+	}
+	for i := range h.registers {
+		if other.registers[i] > h.registers[i] {
+			h.registers[i] = other.registers[i]
+		}
+	}
+}
+
+func (h *HyperLogLog) Count() uint64 {
+	if h == nil {
+		return 0
+	}
+	m := float64(len(h.registers))
+	if m == 0 {
+		return 0
+	}
+
+	var sum float64
+	zeros := 0
+	for _, register := range h.registers {
+		sum += math.Exp2(-float64(register))
+		if register == 0 {
+			zeros++
+		}
+	}
+
+	alpha := h.alpha()
+	estimate := alpha * m * m / sum
+
+	if estimate <= 2.5*m && zeros > 0 {
+		estimate = m * math.Log(m/float64(zeros))
+	}
+
+	if estimate < 0 {
+		return 0
+	}
+	return uint64(estimate + 0.5)
+}
+
+func (h *HyperLogLog) Equal(other *HyperLogLog) bool {
+	if h == nil || other == nil {
+		return h == other
+	}
+	if h.precision != other.precision || len(h.registers) != len(other.registers) {
+		return false
+	}
+	for i := range h.registers {
+		if h.registers[i] != other.registers[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func (h *HyperLogLog) alpha() float64 {
+	m := len(h.registers)
+	switch m {
+	case 16:
+		return 0.673
+	case 32:
+		return 0.697
+	case 64:
+		return 0.709
+	default:
+		return 0.7213 / (1 + 1.079/float64(m))
+	}
+}
+
+func hash64(value []byte) uint64 {
+	sum := sha1.Sum(value)
+	return binary.BigEndian.Uint64(sum[:8])
+}

--- a/code/packages/go/hyperloglog/hyperloglog_test.go
+++ b/code/packages/go/hyperloglog/hyperloglog_test.go
@@ -1,0 +1,17 @@
+package hyperloglog
+
+import "testing"
+
+func TestHyperLogLog(t *testing.T) {
+	h := New()
+	for i := 0; i < 1000; i++ {
+		h.Add([]byte{byte(i >> 8), byte(i)})
+	}
+	if got := h.Count(); got < 800 || got > 1200 {
+		t.Fatalf("unexpected approximate count: %d", got)
+	}
+	clone := h.Clone()
+	if !h.Equal(clone) {
+		t.Fatal("expected clone equality")
+	}
+}

--- a/code/packages/go/in-memory-data-store-engine/BUILD
+++ b/code/packages/go/in-memory-data-store-engine/BUILD
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/in-memory-data-store-engine/BUILD_windows
+++ b/code/packages/go/in-memory-data-store-engine/BUILD_windows
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/in-memory-data-store-engine/commands.go
+++ b/code/packages/go/in-memory-data-store-engine/commands.go
@@ -619,11 +619,11 @@ func cmdSelect(store *Store, args [][]byte) (*Store, resp.Value) {
 	if len(args) != 1 {
 		return store, errValue("ERR wrong number of arguments for 'SELECT'")
 	}
-	dbIndex, err := parseInt64(args[0])
+	dbIndex, err := parseInt(args[0])
 	if err != nil {
 		return store, errValue(err.Error())
 	}
-	return store.Select(int(dbIndex)), okValue()
+	return store.Select(dbIndex), okValue()
 }
 
 func cmdFlushDB(store *Store, args [][]byte) (*Store, resp.Value) {
@@ -685,6 +685,14 @@ func wrongTypeValue() resp.Value {
 
 func parseInt64(data []byte) (int64, error) {
 	value, err := strconv.ParseInt(string(data), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("ERR value is not an integer or out of range")
+	}
+	return value, nil
+}
+
+func parseInt(data []byte) (int, error) {
+	value, err := strconv.Atoi(string(data))
 	if err != nil {
 		return 0, fmt.Errorf("ERR value is not an integer or out of range")
 	}

--- a/code/packages/go/in-memory-data-store-engine/commands.go
+++ b/code/packages/go/in-memory-data-store-engine/commands.go
@@ -1,0 +1,815 @@
+package datastoreengine
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	hashmap "github.com/adhithyan15/coding-adventures/code/packages/go/hash-map"
+	hashset "github.com/adhithyan15/coding-adventures/code/packages/go/hash-set"
+	hyperloglog "github.com/adhithyan15/coding-adventures/code/packages/go/hyperloglog"
+	resp "github.com/adhithyan15/coding-adventures/code/packages/go/resp-protocol"
+)
+
+func registerBuiltinCommands(engine *DataStoreEngine) {
+	register := func(name string, mutating bool, skipLazyExpire bool, handler CommandHandler) {
+		engine.RegisterCommand(name, mutating, skipLazyExpire, handler)
+	}
+
+	register("PING", false, true, cmdPing)
+	register("ECHO", false, true, cmdEcho)
+	register("SET", true, false, cmdSet)
+	register("GET", false, false, cmdGet)
+	register("DEL", true, false, cmdDel)
+	register("EXISTS", false, false, cmdExists)
+	register("TYPE", false, false, cmdType)
+	register("RENAME", true, false, cmdRename)
+	register("INCR", true, false, cmdIncr)
+	register("DECR", true, false, cmdDecr)
+	register("INCRBY", true, false, cmdIncrBy)
+	register("DECRBY", true, false, cmdDecrBy)
+	register("APPEND", true, false, cmdAppend)
+	register("HSET", true, false, cmdHSet)
+	register("HGET", false, false, cmdHGet)
+	register("HDEL", true, false, cmdHDel)
+	register("HGETALL", false, false, cmdHGetAll)
+	register("HLEN", false, false, cmdHLen)
+	register("HEXISTS", false, false, cmdHExists)
+	register("HKEYS", false, false, cmdHKeys)
+	register("HVALS", false, false, cmdHVals)
+	register("SADD", true, false, cmdSAdd)
+	register("SREM", true, false, cmdSRem)
+	register("SISMEMBER", false, false, cmdSIsMember)
+	register("SMEMBERS", false, false, cmdSMembers)
+	register("SCARD", false, false, cmdSCard)
+	register("PFADD", true, false, cmdPFAdd)
+	register("PFCOUNT", false, false, cmdPFCount)
+	register("PFMERGE", true, false, cmdPFMerge)
+	register("EXPIRE", true, false, cmdExpire)
+	register("EXPIREAT", true, false, cmdExpireAt)
+	register("TTL", false, false, cmdTTL)
+	register("PTTL", false, false, cmdPTTL)
+	register("PERSIST", true, false, cmdPersist)
+	register("SELECT", true, true, cmdSelect)
+	register("FLUSHDB", true, true, cmdFlushDB)
+	register("FLUSHALL", true, true, cmdFlushAll)
+	register("DBSIZE", false, true, cmdDBSize)
+	register("INFO", false, true, cmdInfo)
+	register("KEYS", false, false, cmdKeys)
+}
+
+func dispatch(store *Store, parts [][]byte) (*Store, resp.Value) {
+	if len(parts) == 0 {
+		return store, errValue("ERR empty command")
+	}
+	engine := FromStore(store)
+	return engine.Store(), engine.ExecuteParts(parts)
+}
+
+func isMutating(parts [][]byte) bool {
+	if len(parts) == 0 {
+		return false
+	}
+	switch strings.ToUpper(string(parts[0])) {
+	case "SET", "DEL", "RENAME", "INCR", "DECR", "INCRBY", "DECRBY", "APPEND",
+		"HSET", "HDEL", "SADD", "SREM", "PFADD", "PFMERGE", "EXPIRE", "EXPIREAT",
+		"PERSIST", "SELECT", "FLUSHDB", "FLUSHALL":
+		return true
+	default:
+		return false
+	}
+}
+
+func cmdPing(store *Store, args [][]byte) (*Store, resp.Value) {
+	switch len(args) {
+	case 0:
+		return store, resp.SimpleString("PONG")
+	case 1:
+		return store, resp.BulkString(cloneBytes(args[0]))
+	default:
+		return store, errValue("ERR wrong number of arguments for 'PING'")
+	}
+}
+
+func cmdEcho(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) != 1 {
+		return store, errValue("ERR wrong number of arguments for 'ECHO'")
+	}
+	return store, resp.BulkString(cloneBytes(args[0]))
+}
+
+func cmdSet(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) < 2 {
+		return store, errValue("ERR wrong number of arguments for 'SET'")
+	}
+	key := cloneBytes(args[0])
+	value := cloneBytes(args[1])
+	var expiresAt *uint64
+	nx := false
+	xx := false
+	for i := 2; i < len(args); {
+		switch strings.ToUpper(string(args[i])) {
+		case "EX":
+			if i+1 >= len(args) {
+				return store, errValue("ERR syntax error")
+			}
+			seconds, err := parseInt64(args[i+1])
+			if err != nil {
+				return store, errValue(err.Error())
+			}
+			expiresAt = expirationFromSeconds(seconds)
+			i += 2
+		case "PX":
+			if i+1 >= len(args) {
+				return store, errValue("ERR syntax error")
+			}
+			millis, err := parseInt64(args[i+1])
+			if err != nil {
+				return store, errValue(err.Error())
+			}
+			expiresAt = expirationFromMillis(millis)
+			i += 2
+		case "NX":
+			nx = true
+			i++
+		case "XX":
+			xx = true
+			i++
+		default:
+			return store, errValue("ERR syntax error")
+		}
+	}
+	if nx && xx {
+		return store, errValue("ERR syntax error")
+	}
+	exists := store.Exists(key)
+	if nx && exists {
+		return store, resp.NullBulkString()
+	}
+	if xx && !exists {
+		return store, resp.NullBulkString()
+	}
+	return store.Set(key, NewStringEntry(value, expiresAt)), okValue()
+}
+
+func cmdGet(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) != 1 {
+		return store, errValue("ERR wrong number of arguments for 'GET'")
+	}
+	entry, ok := store.Get(args[0])
+	if !ok {
+		return store, resp.NullBulkString()
+	}
+	if entry.Type != EntryTypeString {
+		return store, wrongTypeValue()
+	}
+	return store, resp.BulkString(entry.Value.([]byte))
+}
+
+func cmdDel(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) == 0 {
+		return store, errValue("ERR wrong number of arguments for 'DEL'")
+	}
+	removed := int64(0)
+	for _, key := range args {
+		if store.Exists(key) {
+			removed++
+			store = store.Delete(key)
+		}
+	}
+	return store, resp.Integer(removed)
+}
+
+func cmdExists(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) == 0 {
+		return store, errValue("ERR wrong number of arguments for 'EXISTS'")
+	}
+	count := int64(0)
+	for _, key := range args {
+		if store.Exists(key) {
+			count++
+		}
+	}
+	return store, resp.Integer(count)
+}
+
+func cmdType(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) != 1 {
+		return store, errValue("ERR wrong number of arguments for 'TYPE'")
+	}
+	if entryType, ok := store.TypeOf(args[0]); ok {
+		return store, resp.SimpleString(entryType.String())
+	}
+	return store, resp.SimpleString("none")
+}
+
+func cmdRename(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) != 2 {
+		return store, errValue("ERR wrong number of arguments for 'RENAME'")
+	}
+	entry, ok := store.Get(args[0])
+	if !ok {
+		return store, errValue("ERR no such key")
+	}
+	store = store.Delete(args[0])
+	store = store.Set(cloneBytes(args[1]), entry)
+	return store, okValue()
+}
+
+func cmdIncr(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) != 1 {
+		return store, errValue("ERR wrong number of arguments for 'INCR'")
+	}
+	return cmdIncrBy(store, [][]byte{args[0], []byte("1")})
+}
+
+func cmdDecr(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) != 1 {
+		return store, errValue("ERR wrong number of arguments for 'DECR'")
+	}
+	return cmdIncrBy(store, [][]byte{args[0], []byte("-1")})
+}
+
+func cmdIncrBy(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) != 2 {
+		return store, errValue("ERR wrong number of arguments for 'INCRBY'")
+	}
+	delta, err := parseInt64(args[1])
+	if err != nil {
+		return store, errValue(err.Error())
+	}
+	return adjustInteger(store, args[0], delta)
+}
+
+func cmdDecrBy(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) != 2 {
+		return store, errValue("ERR wrong number of arguments for 'DECRBY'")
+	}
+	delta, err := parseInt64(args[1])
+	if err != nil {
+		return store, errValue(err.Error())
+	}
+	return adjustInteger(store, args[0], -delta)
+}
+
+func cmdAppend(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) != 2 {
+		return store, errValue("ERR wrong number of arguments for 'APPEND'")
+	}
+	key := cloneBytes(args[0])
+	suffix := args[1]
+	value := []byte{}
+	var expiresAt *uint64
+	if entry, ok := store.Get(args[0]); ok {
+		if entry.Type != EntryTypeString {
+			return store, wrongTypeValue()
+		}
+		value = append([]byte(nil), entry.Value.([]byte)...)
+		expiresAt = entry.ExpiresAt
+	}
+	value = append(value, suffix...)
+	return store.Set(key, NewStringEntry(value, expiresAt)), resp.Integer(int64(len(value)))
+}
+
+func cmdHSet(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) < 3 || len(args)%2 == 0 {
+		return store, errValue("ERR wrong number of arguments for 'HSET'")
+	}
+	key := cloneBytes(args[0])
+	expiresAt := currentExpiry(store, key)
+	m, _, _ := getOrCreateHash(store, key, expiresAt)
+	added := int64(0)
+	for i := 1; i < len(args); i += 2 {
+		field := cloneBytes(args[i])
+		value := cloneBytes(args[i+1])
+		if !m.Has(field) {
+			added++
+		}
+		m.Set(field, value)
+	}
+	return store.Set(key, NewHashEntry(m, expiresAt)), resp.Integer(added)
+}
+
+func cmdHGet(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) != 2 {
+		return store, errValue("ERR wrong number of arguments for 'HGET'")
+	}
+	entry, ok := store.Get(args[0])
+	if !ok {
+		return store, resp.NullBulkString()
+	}
+	if entry.Type != EntryTypeHash {
+		return store, wrongTypeValue()
+	}
+	m := entry.Value.(*hashmap.HashMap[[]byte])
+	value, ok := m.Get(args[1])
+	if !ok {
+		return store, resp.NullBulkString()
+	}
+	return store, resp.BulkString(value)
+}
+
+func cmdHDel(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) < 2 {
+		return store, errValue("ERR wrong number of arguments for 'HDEL'")
+	}
+	entry, ok := store.Get(args[0])
+	if !ok {
+		return store, resp.Integer(0)
+	}
+	if entry.Type != EntryTypeHash {
+		return store, wrongTypeValue()
+	}
+	m := entry.Value.(*hashmap.HashMap[[]byte]).Clone()
+	removed := int64(0)
+	for _, field := range args[1:] {
+		if m.Delete(field) {
+			removed++
+		}
+	}
+	return store.Set(args[0], NewHashEntry(m, entry.ExpiresAt)), resp.Integer(removed)
+}
+
+func cmdHGetAll(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) != 1 {
+		return store, errValue("ERR wrong number of arguments for 'HGETALL'")
+	}
+	entry, ok := store.Get(args[0])
+	if !ok {
+		return store, resp.Array(nil)
+	}
+	if entry.Type != EntryTypeHash {
+		return store, wrongTypeValue()
+	}
+	m := entry.Value.(*hashmap.HashMap[[]byte])
+	values := make([]resp.Value, 0, m.Size()*2)
+	for _, kv := range m.Entries() {
+		values = append(values, resp.BulkString(kv.Key), resp.BulkString(kv.Value))
+	}
+	return store, resp.Array(values)
+}
+
+func cmdHLen(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) != 1 {
+		return store, errValue("ERR wrong number of arguments for 'HLEN'")
+	}
+	entry, ok := store.Get(args[0])
+	if !ok {
+		return store, resp.Integer(0)
+	}
+	if entry.Type != EntryTypeHash {
+		return store, wrongTypeValue()
+	}
+	return store, resp.Integer(int64(entry.Value.(*hashmap.HashMap[[]byte]).Size()))
+}
+
+func cmdHExists(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) != 2 {
+		return store, errValue("ERR wrong number of arguments for 'HEXISTS'")
+	}
+	entry, ok := store.Get(args[0])
+	if !ok {
+		return store, resp.Integer(0)
+	}
+	if entry.Type != EntryTypeHash {
+		return store, wrongTypeValue()
+	}
+	if entry.Value.(*hashmap.HashMap[[]byte]).Has(args[1]) {
+		return store, resp.Integer(1)
+	}
+	return store, resp.Integer(0)
+}
+
+func cmdHKeys(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) != 1 {
+		return store, errValue("ERR wrong number of arguments for 'HKEYS'")
+	}
+	entry, ok := store.Get(args[0])
+	if !ok {
+		return store, resp.Array(nil)
+	}
+	if entry.Type != EntryTypeHash {
+		return store, wrongTypeValue()
+	}
+	values := make([]resp.Value, 0)
+	for _, key := range entry.Value.(*hashmap.HashMap[[]byte]).Keys() {
+		values = append(values, resp.BulkString(key))
+	}
+	return store, resp.Array(values)
+}
+
+func cmdHVals(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) != 1 {
+		return store, errValue("ERR wrong number of arguments for 'HVALS'")
+	}
+	entry, ok := store.Get(args[0])
+	if !ok {
+		return store, resp.Array(nil)
+	}
+	if entry.Type != EntryTypeHash {
+		return store, wrongTypeValue()
+	}
+	values := make([]resp.Value, 0)
+	for _, kv := range entry.Value.(*hashmap.HashMap[[]byte]).Entries() {
+		values = append(values, resp.BulkString(kv.Value))
+	}
+	return store, resp.Array(values)
+}
+
+func cmdSAdd(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) < 2 {
+		return store, errValue("ERR wrong number of arguments for 'SADD'")
+	}
+	key := cloneBytes(args[0])
+	expiresAt := currentExpiry(store, key)
+	set, _, _ := getOrCreateSet(store, key, expiresAt)
+	added := int64(0)
+	for _, member := range args[1:] {
+		if set.Add(member) {
+			added++
+		}
+	}
+	return store.Set(key, NewSetEntry(set, expiresAt)), resp.Integer(added)
+}
+
+func cmdSRem(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) < 2 {
+		return store, errValue("ERR wrong number of arguments for 'SREM'")
+	}
+	entry, ok := store.Get(args[0])
+	if !ok {
+		return store, resp.Integer(0)
+	}
+	if entry.Type != EntryTypeSet {
+		return store, wrongTypeValue()
+	}
+	set := entry.Value.(*hashset.HashSet).Clone()
+	removed := int64(0)
+	for _, member := range args[1:] {
+		if set.Remove(member) {
+			removed++
+		}
+	}
+	return store.Set(args[0], NewSetEntry(set, entry.ExpiresAt)), resp.Integer(removed)
+}
+
+func cmdSIsMember(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) != 2 {
+		return store, errValue("ERR wrong number of arguments for 'SISMEMBER'")
+	}
+	entry, ok := store.Get(args[0])
+	if !ok {
+		return store, resp.Integer(0)
+	}
+	if entry.Type != EntryTypeSet {
+		return store, wrongTypeValue()
+	}
+	if entry.Value.(*hashset.HashSet).Contains(args[1]) {
+		return store, resp.Integer(1)
+	}
+	return store, resp.Integer(0)
+}
+
+func cmdSMembers(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) != 1 {
+		return store, errValue("ERR wrong number of arguments for 'SMEMBERS'")
+	}
+	entry, ok := store.Get(args[0])
+	if !ok {
+		return store, resp.Array(nil)
+	}
+	if entry.Type != EntryTypeSet {
+		return store, wrongTypeValue()
+	}
+	values := make([]resp.Value, 0)
+	for _, member := range entry.Value.(*hashset.HashSet).ToSlice() {
+		values = append(values, resp.BulkString(member))
+	}
+	return store, resp.Array(values)
+}
+
+func cmdSCard(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) != 1 {
+		return store, errValue("ERR wrong number of arguments for 'SCARD'")
+	}
+	entry, ok := store.Get(args[0])
+	if !ok {
+		return store, resp.Integer(0)
+	}
+	if entry.Type != EntryTypeSet {
+		return store, wrongTypeValue()
+	}
+	return store, resp.Integer(int64(entry.Value.(*hashset.HashSet).Size()))
+}
+
+func cmdPFAdd(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) < 2 {
+		return store, errValue("ERR wrong number of arguments for 'PFADD'")
+	}
+	key := cloneBytes(args[0])
+	expiresAt := currentExpiry(store, key)
+	hll, _, _ := getOrCreateHLL(store, key, expiresAt)
+	changed := false
+	for _, value := range args[1:] {
+		changed = hll.Add(value) || changed
+	}
+	return store.Set(key, NewHLLEntry(hll, expiresAt)), resp.Integer(boolToInt64(changed))
+}
+
+func cmdPFCount(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) == 0 {
+		return store, errValue("ERR wrong number of arguments for 'PFCOUNT'")
+	}
+	if len(args) == 1 {
+		entry, ok := store.Get(args[0])
+		if !ok {
+			return store, resp.Integer(0)
+		}
+		if entry.Type != EntryTypeHLL {
+			return store, wrongTypeValue()
+		}
+		return store, resp.Integer(int64(entry.Value.(*hyperloglog.HyperLogLog).Count()))
+	}
+	merged := hyperloglog.New()
+	for _, key := range args {
+		entry, ok := store.Get(key)
+		if !ok {
+			continue
+		}
+		if entry.Type != EntryTypeHLL {
+			return store, wrongTypeValue()
+		}
+		merged.Merge(entry.Value.(*hyperloglog.HyperLogLog))
+	}
+	return store, resp.Integer(int64(merged.Count()))
+}
+
+func cmdPFMerge(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) < 2 {
+		return store, errValue("ERR wrong number of arguments for 'PFMERGE'")
+	}
+	dst := cloneBytes(args[0])
+	merged := hyperloglog.New()
+	var expiresAt *uint64
+	for _, key := range args[1:] {
+		entry, ok := store.Get(key)
+		if !ok {
+			continue
+		}
+		if entry.Type != EntryTypeHLL {
+			return store, wrongTypeValue()
+		}
+		merged.Merge(entry.Value.(*hyperloglog.HyperLogLog))
+		if expiresAt == nil {
+			expiresAt = entry.ExpiresAt
+		}
+	}
+	return store.Set(dst, NewHLLEntry(merged, expiresAt)), okValue()
+}
+
+func cmdExpire(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) != 2 {
+		return store, errValue("ERR wrong number of arguments for 'EXPIRE'")
+	}
+	seconds, err := parseInt64(args[1])
+	if err != nil {
+		return store, errValue(err.Error())
+	}
+	return setExpiry(store, args[0], expirationFromSeconds(seconds))
+}
+
+func cmdExpireAt(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) != 2 {
+		return store, errValue("ERR wrong number of arguments for 'EXPIREAT'")
+	}
+	ts, err := parseInt64(args[1])
+	if err != nil {
+		return store, errValue(err.Error())
+	}
+	return setExpiry(store, args[0], expirationFromUnixSeconds(ts))
+}
+
+func cmdTTL(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) != 1 {
+		return store, errValue("ERR wrong number of arguments for 'TTL'")
+	}
+	return store, resp.Integer(ttlSeconds(store, args[0]))
+}
+
+func cmdPTTL(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) != 1 {
+		return store, errValue("ERR wrong number of arguments for 'PTTL'")
+	}
+	return store, resp.Integer(ttlMillis(store, args[0]))
+}
+
+func cmdPersist(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) != 1 {
+		return store, errValue("ERR wrong number of arguments for 'PERSIST'")
+	}
+	entry, ok := store.Get(args[0])
+	if !ok || entry.ExpiresAt == nil {
+		return store, resp.Integer(0)
+	}
+	entry.ExpiresAt = nil
+	return store.Set(args[0], entry), resp.Integer(1)
+}
+
+func cmdSelect(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) != 1 {
+		return store, errValue("ERR wrong number of arguments for 'SELECT'")
+	}
+	dbIndex, err := parseInt64(args[0])
+	if err != nil {
+		return store, errValue(err.Error())
+	}
+	return store.Select(int(dbIndex)), okValue()
+}
+
+func cmdFlushDB(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) != 0 {
+		return store, errValue("ERR wrong number of arguments for 'FLUSHDB'")
+	}
+	return store.FlushDB(), okValue()
+}
+
+func cmdFlushAll(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) != 0 {
+		return store, errValue("ERR wrong number of arguments for 'FLUSHALL'")
+	}
+	return store.FlushAll(), okValue()
+}
+
+func cmdDBSize(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) != 0 {
+		return store, errValue("ERR wrong number of arguments for 'DBSIZE'")
+	}
+	return store, resp.Integer(int64(store.DBSize()))
+}
+
+func cmdInfo(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) > 1 {
+		return store, errValue("ERR wrong number of arguments for 'INFO'")
+	}
+	info := fmt.Sprintf(
+		"# Keyspace\nactive_db:%d\nkeys:%d\n",
+		store.ActiveDB,
+		store.DBSize(),
+	)
+	return store, resp.BulkString([]byte(info))
+}
+
+func cmdKeys(store *Store, args [][]byte) (*Store, resp.Value) {
+	if len(args) != 1 {
+		return store, errValue("ERR wrong number of arguments for 'KEYS'")
+	}
+	keys := store.Keys(args[0])
+	values := make([]resp.Value, 0, len(keys))
+	for _, key := range keys {
+		values = append(values, resp.BulkString(key))
+	}
+	return store, resp.Array(values)
+}
+
+func okValue() resp.Value {
+	return resp.SimpleString("OK")
+}
+
+func errValue(message string) resp.Value {
+	return resp.ErrorValue(message)
+}
+
+func wrongTypeValue() resp.Value {
+	return resp.ErrorValue("WRONGTYPE Operation against a key holding the wrong kind of value")
+}
+
+func parseInt64(data []byte) (int64, error) {
+	value, err := strconv.ParseInt(string(data), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("ERR value is not an integer or out of range")
+	}
+	return value, nil
+}
+
+func parseFloat64(data []byte) (float64, error) {
+	value, err := strconv.ParseFloat(string(data), 64)
+	if err != nil {
+		return 0, fmt.Errorf("ERR value is not a valid float")
+	}
+	return value, nil
+}
+
+func boolToInt64(value bool) int64 {
+	if value {
+		return 1
+	}
+	return 0
+}
+
+func currentExpiry(store *Store, key []byte) *uint64 {
+	if entry, ok := store.Get(key); ok {
+		return entry.ExpiresAt
+	}
+	return nil
+}
+
+func setExpiry(store *Store, key []byte, expiresAt *uint64) (*Store, resp.Value) {
+	entry, ok := store.Get(key)
+	if !ok {
+		return store, resp.Integer(0)
+	}
+	entry.ExpiresAt = expiresAt
+	return store.Set(key, entry), resp.Integer(1)
+}
+
+func expirationFromSeconds(seconds int64) *uint64 {
+	return expirationFromMillis(seconds * 1000)
+}
+
+func expirationFromUnixSeconds(seconds int64) *uint64 {
+	return expirationFromMillis(seconds * 1000)
+}
+
+func expirationFromMillis(millis int64) *uint64 {
+	next := int64(currentTimeMs()) + millis
+	if next < 0 {
+		next = 0
+	}
+	value := uint64(next)
+	return &value
+}
+
+func ttlMillis(store *Store, key []byte) int64 {
+	entry, ok := store.Get(key)
+	if !ok {
+		return -2
+	}
+	if entry.ExpiresAt == nil {
+		return -1
+	}
+	delta := int64(*entry.ExpiresAt) - int64(currentTimeMs())
+	if delta < 0 {
+		return -2
+	}
+	return delta
+}
+
+func ttlSeconds(store *Store, key []byte) int64 {
+	millis := ttlMillis(store, key)
+	if millis < 0 {
+		return millis
+	}
+	return millis / 1000
+}
+
+func adjustInteger(store *Store, key []byte, delta int64) (*Store, resp.Value) {
+	entry, ok := store.Get(key)
+	var current int64
+	var expiresAt *uint64
+	if ok {
+		if entry.Type != EntryTypeString {
+			return store, wrongTypeValue()
+		}
+		value, err := strconv.ParseInt(string(entry.Value.([]byte)), 10, 64)
+		if err != nil {
+			return store, errValue("ERR value is not an integer or out of range")
+		}
+		current = value
+		expiresAt = entry.ExpiresAt
+	}
+	current += delta
+	return store.Set(key, NewStringEntry([]byte(strconv.FormatInt(current, 10)), expiresAt)), resp.Integer(current)
+}
+
+func getOrCreateHash(store *Store, key []byte, expiresAt *uint64) (*hashmap.HashMap[[]byte], Entry, bool) {
+	entry, ok := store.Get(key)
+	if !ok {
+		return hashmap.New[[]byte](), Entry{}, false
+	}
+	if entry.Type != EntryTypeHash {
+		panic("WRONGTYPE")
+	}
+	return entry.Value.(*hashmap.HashMap[[]byte]).Clone(), entry, true
+}
+
+func getOrCreateSet(store *Store, key []byte, expiresAt *uint64) (*hashset.HashSet, Entry, bool) {
+	entry, ok := store.Get(key)
+	if !ok {
+		return hashset.New(), Entry{}, false
+	}
+	if entry.Type != EntryTypeSet {
+		panic("WRONGTYPE")
+	}
+	return entry.Value.(*hashset.HashSet).Clone(), entry, true
+}
+
+func getOrCreateHLL(store *Store, key []byte, expiresAt *uint64) (*hyperloglog.HyperLogLog, Entry, bool) {
+	entry, ok := store.Get(key)
+	if !ok {
+		return hyperloglog.New(), Entry{}, false
+	}
+	if entry.Type != EntryTypeHLL {
+		panic("WRONGTYPE")
+	}
+	return entry.Value.(*hyperloglog.HyperLogLog).Clone(), entry, true
+}

--- a/code/packages/go/in-memory-data-store-engine/engine.go
+++ b/code/packages/go/in-memory-data-store-engine/engine.go
@@ -1,0 +1,130 @@
+package datastoreengine
+
+import (
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	datastoreprotocol "github.com/adhithyan15/coding-adventures/code/packages/go/in-memory-data-store-protocol"
+	resp "github.com/adhithyan15/coding-adventures/code/packages/go/resp-protocol"
+)
+
+type CommandHandler func(store *Store, args [][]byte) (*Store, resp.Value)
+
+type CommandRegistration struct {
+	Handler        CommandHandler
+	Mutating       bool
+	SkipLazyExpire bool
+}
+
+type DataStoreBackend interface {
+	ExecuteFrame(frame datastoreprotocol.CommandFrame) resp.Value
+	ExecuteParts(parts [][]byte) resp.Value
+	Store() *Store
+	ActiveExpireAll()
+}
+
+type DataStoreEngine struct {
+	mu       sync.Mutex
+	store    *Store
+	commands map[string]CommandRegistration
+	frozen   atomic.Bool
+}
+
+func New() *DataStoreEngine {
+	engine := &DataStoreEngine{
+		store:    NewStore(),
+		commands: make(map[string]CommandRegistration),
+	}
+	registerBuiltinCommands(engine)
+	return engine
+}
+
+func FromStore(store *Store) *DataStoreEngine {
+	engine := &DataStoreEngine{
+		store:    store.Clone(),
+		commands: make(map[string]CommandRegistration),
+	}
+	registerBuiltinCommands(engine)
+	return engine
+}
+
+func (e *DataStoreEngine) RegisterCommand(name string, mutating bool, skipLazyExpire bool, handler CommandHandler) {
+	if e.frozen.Load() {
+		panic("cannot register commands on a frozen engine")
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.commands[strings.ToUpper(name)] = CommandRegistration{
+		Handler:        handler,
+		Mutating:       mutating,
+		SkipLazyExpire: skipLazyExpire,
+	}
+}
+
+func (e *DataStoreEngine) Freeze() {
+	e.frozen.Store(true)
+}
+
+func (e *DataStoreEngine) IsFrozen() bool {
+	return e.frozen.Load()
+}
+
+func (e *DataStoreEngine) ExecuteFrame(frame datastoreprotocol.CommandFrame) resp.Value {
+	_, response := e.executeWithDB(e.currentDB(), frame.Command, frame.Args, true)
+	return response
+}
+
+func (e *DataStoreEngine) ExecuteParts(parts [][]byte) resp.Value {
+	frame, ok := datastoreprotocol.FromParts(parts)
+	if !ok {
+		return resp.ErrorValue("ERR empty command")
+	}
+	return e.ExecuteFrame(frame)
+}
+
+func (e *DataStoreEngine) Store() *Store {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.store.Clone()
+}
+
+func (e *DataStoreEngine) ActiveExpireAll() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.store = e.store.ActiveExpireAll()
+}
+
+func (e *DataStoreEngine) executeWithDB(dbIndex int, command string, args [][]byte, recordAOF bool) (int, resp.Value) {
+	e.mu.Lock()
+	registration, ok := e.commands[strings.ToUpper(command)]
+	if !ok {
+		e.mu.Unlock()
+		return dbIndex, resp.ErrorValue("ERR unknown command '" + strings.ToUpper(command) + "'")
+	}
+
+	store := e.store.Clone().WithActiveDB(dbIndex)
+	e.mu.Unlock()
+
+	if !registration.SkipLazyExpire && len(args) > 0 {
+		store = store.ExpireLazy(args[0])
+	}
+
+	newStore, response := registration.Handler(store, args)
+	if newStore == nil {
+		newStore = store
+	}
+
+	e.mu.Lock()
+	e.store = newStore
+	activeDB := newStore.ActiveDB
+	e.mu.Unlock()
+
+	return activeDB, response
+}
+
+func (e *DataStoreEngine) currentDB() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.store.ActiveDB
+}

--- a/code/packages/go/in-memory-data-store-engine/engine_test.go
+++ b/code/packages/go/in-memory-data-store-engine/engine_test.go
@@ -1,0 +1,75 @@
+package datastoreengine
+
+import (
+	"testing"
+
+	resp "github.com/adhithyan15/coding-adventures/code/packages/go/resp-protocol"
+)
+
+func TestStringAndDatabaseCommands(t *testing.T) {
+	engine := New()
+
+	if got := engine.ExecuteParts([][]byte{[]byte("PING")}); got.Kind != resp.SimpleStringKind || got.Text != "PONG" {
+		t.Fatalf("unexpected ping response: %#v", got)
+	}
+
+	if got := engine.ExecuteParts([][]byte{[]byte("SET"), []byte("hello"), []byte("world")}); got.Kind != resp.SimpleStringKind || got.Text != "OK" {
+		t.Fatalf("unexpected set response: %#v", got)
+	}
+
+	if got := engine.ExecuteParts([][]byte{[]byte("GET"), []byte("hello")}); got.Kind != resp.BulkStringKind || string(got.Bulk) != "world" {
+		t.Fatalf("unexpected get response: %#v", got)
+	}
+
+	if got := engine.ExecuteParts([][]byte{[]byte("INCRBY"), []byte("counter"), []byte("5")}); got.Kind != resp.IntegerKind || got.Integer != 5 {
+		t.Fatalf("unexpected incrby response: %#v", got)
+	}
+
+	if got := engine.ExecuteParts([][]byte{[]byte("APPEND"), []byte("hello"), []byte("!")}); got.Kind != resp.IntegerKind || got.Integer != 6 {
+		t.Fatalf("unexpected append response: %#v", got)
+	}
+}
+
+func TestHashSetAndHyperLogLogCommands(t *testing.T) {
+	engine := New()
+
+	if got := engine.ExecuteParts([][]byte{
+		[]byte("HSET"), []byte("profile"), []byte("name"), []byte("Ada"), []byte("lang"), []byte("Go"),
+	}); got.Kind != resp.IntegerKind || got.Integer != 2 {
+		t.Fatalf("unexpected hset response: %#v", got)
+	}
+	if got := engine.ExecuteParts([][]byte{[]byte("HGET"), []byte("profile"), []byte("name")}); got.Kind != resp.BulkStringKind || string(got.Bulk) != "Ada" {
+		t.Fatalf("unexpected hget response: %#v", got)
+	}
+	if got := engine.ExecuteParts([][]byte{[]byte("SADD"), []byte("tags"), []byte("a"), []byte("b"), []byte("a")}); got.Kind != resp.IntegerKind || got.Integer != 2 {
+		t.Fatalf("unexpected sadd response: %#v", got)
+	}
+	if got := engine.ExecuteParts([][]byte{[]byte("SMEMBERS"), []byte("tags")}); got.Kind != resp.ArrayKind || len(got.Array) != 2 {
+		t.Fatalf("unexpected smembers response: %#v", got)
+	}
+	if got := engine.ExecuteParts([][]byte{[]byte("PFADD"), []byte("visitors"), []byte("one"), []byte("two"), []byte("one")}); got.Kind != resp.IntegerKind {
+		t.Fatalf("unexpected pfadd response: %#v", got)
+	}
+	if got := engine.ExecuteParts([][]byte{[]byte("PFCOUNT"), []byte("visitors")}); got.Kind != resp.IntegerKind || got.Integer == 0 {
+		t.Fatalf("unexpected pfcount response: %#v", got)
+	}
+}
+
+func TestSelectAndFlushCommands(t *testing.T) {
+	engine := New()
+	if got := engine.ExecuteParts([][]byte{[]byte("SELECT"), []byte("3")}); got.Kind != resp.SimpleStringKind || got.Text != "OK" {
+		t.Fatalf("unexpected select response: %#v", got)
+	}
+	if got := engine.ExecuteParts([][]byte{[]byte("SET"), []byte("dbkey"), []byte("value")}); got.Kind != resp.SimpleStringKind {
+		t.Fatalf("unexpected set response: %#v", got)
+	}
+	if got := engine.ExecuteParts([][]byte{[]byte("DBSIZE")}); got.Kind != resp.IntegerKind || got.Integer != 1 {
+		t.Fatalf("unexpected dbsize response: %#v", got)
+	}
+	if got := engine.ExecuteParts([][]byte{[]byte("FLUSHDB")}); got.Kind != resp.SimpleStringKind {
+		t.Fatalf("unexpected flushdb response: %#v", got)
+	}
+	if got := engine.ExecuteParts([][]byte{[]byte("DBSIZE")}); got.Kind != resp.IntegerKind || got.Integer != 0 {
+		t.Fatalf("unexpected dbsize after flush: %#v", got)
+	}
+}

--- a/code/packages/go/in-memory-data-store-engine/go.mod
+++ b/code/packages/go/in-memory-data-store-engine/go.mod
@@ -1,0 +1,21 @@
+module github.com/adhithyan15/coding-adventures/code/packages/go/in-memory-data-store-engine
+
+go 1.23
+
+require (
+	github.com/adhithyan15/coding-adventures/code/packages/go/hash-map v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/hash-set v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/heap v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/hyperloglog v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/skip-list v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/in-memory-data-store-protocol v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/resp-protocol v0.0.0
+)
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/hash-map => ../hash-map
+replace github.com/adhithyan15/coding-adventures/code/packages/go/hash-set => ../hash-set
+replace github.com/adhithyan15/coding-adventures/code/packages/go/heap => ../heap
+replace github.com/adhithyan15/coding-adventures/code/packages/go/hyperloglog => ../hyperloglog
+replace github.com/adhithyan15/coding-adventures/code/packages/go/skip-list => ../skip-list
+replace github.com/adhithyan15/coding-adventures/code/packages/go/in-memory-data-store-protocol => ../in-memory-data-store-protocol
+replace github.com/adhithyan15/coding-adventures/code/packages/go/resp-protocol => ../resp-protocol

--- a/code/packages/go/in-memory-data-store-engine/types.go
+++ b/code/packages/go/in-memory-data-store-engine/types.go
@@ -1,0 +1,598 @@
+package datastoreengine
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"sort"
+	"time"
+
+	"github.com/adhithyan15/coding-adventures/code/packages/go/hash-map"
+	"github.com/adhithyan15/coding-adventures/code/packages/go/hash-set"
+	"github.com/adhithyan15/coding-adventures/code/packages/go/heap"
+	"github.com/adhithyan15/coding-adventures/code/packages/go/hyperloglog"
+	"github.com/adhithyan15/coding-adventures/code/packages/go/skip-list"
+)
+
+type EntryType string
+
+const (
+	EntryTypeString EntryType = "string"
+	EntryTypeHash   EntryType = "hash"
+	EntryTypeList   EntryType = "list"
+	EntryTypeSet    EntryType = "set"
+	EntryTypeZSet   EntryType = "zset"
+	EntryTypeHLL    EntryType = "hll"
+)
+
+func (t EntryType) String() string {
+	return string(t)
+}
+
+type SortedEntry struct {
+	Score  float64
+	Member []byte
+}
+
+type SortedSet struct {
+	members  *hashmap.HashMap[float64]
+	ordering *skiplist.SkipList[SortedEntry]
+}
+
+func NewSortedSet() *SortedSet {
+	return &SortedSet{
+		members: hashmap.New[float64](),
+		ordering: skiplist.New(func(a, b SortedEntry) bool {
+			if a.Score != b.Score {
+				return a.Score < b.Score
+			}
+			return bytes.Compare(a.Member, b.Member) < 0
+		}),
+	}
+}
+
+func (s *SortedSet) Clone() *SortedSet {
+	if s == nil {
+		return NewSortedSet()
+	}
+	clone := NewSortedSet()
+	for _, entry := range s.OrderedEntries() {
+		clone.Insert(entry.Score, entry.Member)
+	}
+	return clone
+}
+
+func (s *SortedSet) Len() int {
+	if s == nil {
+		return 0
+	}
+	return s.members.Size()
+}
+
+func (s *SortedSet) IsEmpty() bool {
+	return s.Len() == 0
+}
+
+func (s *SortedSet) Contains(member []byte) bool {
+	return s != nil && s.members.Has(member)
+}
+
+func (s *SortedSet) Score(member []byte) (float64, bool) {
+	if s == nil {
+		return 0, false
+	}
+	return s.members.Get(member)
+}
+
+func (s *SortedSet) Insert(score float64, member []byte) bool {
+	if math.IsNaN(score) {
+		panic("sorted set score cannot be NaN")
+	}
+	if s == nil {
+		return false
+	}
+	isNew := !s.members.Has(member)
+	if oldScore, ok := s.members.Get(member); ok {
+		_ = s.ordering.Delete(SortedEntry{Score: oldScore, Member: cloneBytes(member)})
+	}
+	s.members.Set(member, score)
+	s.ordering.Insert(SortedEntry{Score: score, Member: cloneBytes(member)})
+	return isNew
+}
+
+func (s *SortedSet) Remove(member []byte) bool {
+	if s == nil {
+		return false
+	}
+	oldScore, ok := s.members.Get(member)
+	if !ok {
+		return false
+	}
+	_ = s.ordering.Delete(SortedEntry{Score: oldScore, Member: cloneBytes(member)})
+	return s.members.Delete(member)
+}
+
+func (s *SortedSet) Rank(member []byte) (int, bool) {
+	if s == nil {
+		return 0, false
+	}
+	target := cloneBytes(member)
+	for i, entry := range s.ordering.ToSlice() {
+		if bytes.Equal(entry.Member, target) {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+func (s *SortedSet) OrderedEntries() []SortedEntry {
+	if s == nil {
+		return nil
+	}
+	return cloneSortedEntries(s.ordering.ToSlice())
+}
+
+func (s *SortedSet) RangeByIndex(start, end int) []SortedEntry {
+	entries := s.OrderedEntries()
+	if len(entries) == 0 {
+		return nil
+	}
+	n := len(entries)
+	if start < 0 {
+		start = n + start
+	}
+	if end < 0 {
+		end = n + end
+	}
+	if start < 0 || end < 0 || start >= n || start > end || end >= n {
+		return nil
+	}
+	return cloneSortedEntries(entries[start : end+1])
+}
+
+func (s *SortedSet) RangeByScore(min, max float64) []SortedEntry {
+	if math.IsNaN(min) || math.IsNaN(max) {
+		panic("sorted set score cannot be NaN")
+	}
+	result := make([]SortedEntry, 0)
+	for _, entry := range s.OrderedEntries() {
+		if entry.Score >= min && entry.Score <= max {
+			result = append(result, entry)
+		}
+	}
+	return result
+}
+
+func (s *SortedSet) Equal(other *SortedSet) bool {
+	left := s.OrderedEntries()
+	right := other.OrderedEntries()
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i].Score != right[i].Score || !bytes.Equal(left[i].Member, right[i].Member) {
+			return false
+		}
+	}
+	return true
+}
+
+type Entry struct {
+	Type      EntryType
+	Value     any
+	ExpiresAt *uint64
+}
+
+func NewStringEntry(value []byte, expiresAt *uint64) Entry {
+	return Entry{Type: EntryTypeString, Value: cloneBytes(value), ExpiresAt: cloneExpiry(expiresAt)}
+}
+
+func NewHashEntry(value *hashmap.HashMap[[]byte], expiresAt *uint64) Entry {
+	return Entry{Type: EntryTypeHash, Value: value.Clone(), ExpiresAt: cloneExpiry(expiresAt)}
+}
+
+func NewListEntry(value [][]byte, expiresAt *uint64) Entry {
+	return Entry{Type: EntryTypeList, Value: cloneByteSlices(value), ExpiresAt: cloneExpiry(expiresAt)}
+}
+
+func NewSetEntry(value *hashset.HashSet, expiresAt *uint64) Entry {
+	return Entry{Type: EntryTypeSet, Value: value.Clone(), ExpiresAt: cloneExpiry(expiresAt)}
+}
+
+func NewZSetEntry(value *SortedSet, expiresAt *uint64) Entry {
+	return Entry{Type: EntryTypeZSet, Value: value.Clone(), ExpiresAt: cloneExpiry(expiresAt)}
+}
+
+func NewHLLEntry(value *hyperloglog.HyperLogLog, expiresAt *uint64) Entry {
+	return Entry{Type: EntryTypeHLL, Value: value.Clone(), ExpiresAt: cloneExpiry(expiresAt)}
+}
+
+func (e Entry) Clone() Entry {
+	switch e.Type {
+	case EntryTypeString:
+		return NewStringEntry(e.Value.([]byte), e.ExpiresAt)
+	case EntryTypeHash:
+		return NewHashEntry(e.Value.(*hashmap.HashMap[[]byte]), e.ExpiresAt)
+	case EntryTypeList:
+		return NewListEntry(e.Value.([][]byte), e.ExpiresAt)
+	case EntryTypeSet:
+		return NewSetEntry(e.Value.(*hashset.HashSet), e.ExpiresAt)
+	case EntryTypeZSet:
+		return NewZSetEntry(e.Value.(*SortedSet), e.ExpiresAt)
+	case EntryTypeHLL:
+		return NewHLLEntry(e.Value.(*hyperloglog.HyperLogLog), e.ExpiresAt)
+	default:
+		return e
+	}
+}
+
+func (e Entry) String() string {
+	return fmt.Sprintf("Entry{%s}", e.Type)
+}
+
+func cloneExpiry(expiresAt *uint64) *uint64 {
+	if expiresAt == nil {
+		return nil
+	}
+	value := *expiresAt
+	return &value
+}
+
+func cloneByteSlices(values [][]byte) [][]byte {
+	if values == nil {
+		return nil
+	}
+	result := make([][]byte, len(values))
+	for i, value := range values {
+		result[i] = cloneBytes(value)
+	}
+	return result
+}
+
+func cloneSortedEntries(values []SortedEntry) []SortedEntry {
+	if values == nil {
+		return nil
+	}
+	result := make([]SortedEntry, len(values))
+	for i, value := range values {
+		result[i] = SortedEntry{Score: value.Score, Member: cloneBytes(value.Member)}
+	}
+	return result
+}
+
+func cloneBytes(value []byte) []byte {
+	if value == nil {
+		return nil
+	}
+	return append([]byte(nil), value...)
+}
+
+type ttlEntry struct {
+	ExpiresAt uint64
+	Key       []byte
+}
+
+func ttlLess(left, right ttlEntry) bool {
+	if left.ExpiresAt != right.ExpiresAt {
+		return left.ExpiresAt < right.ExpiresAt
+	}
+	return bytes.Compare(left.Key, right.Key) < 0
+}
+
+const defaultDBCount = 16
+
+type Database struct {
+	entries *hashmap.HashMap[Entry]
+	ttlHeap *heap.MinHeap[ttlEntry]
+}
+
+func NewDatabase() Database {
+	return Database{
+		entries: hashmap.New[Entry](),
+		ttlHeap: heap.NewMinHeap(ttlLess),
+	}
+}
+
+func (db Database) Clone() Database {
+	clone := NewDatabase()
+	for _, entry := range db.entries.Entries() {
+		clone.entries.Set(entry.Key, entry.Value.Clone())
+	}
+	clone.ttlHeap = db.ttlHeap.Clone()
+	return clone
+}
+
+func (db *Database) Get(key []byte) (Entry, bool) {
+	if db == nil || db.entries == nil {
+		return Entry{}, false
+	}
+	entry, ok := db.entries.Get(key)
+	if !ok {
+		return Entry{}, false
+	}
+	if entry.ExpiresAt != nil && currentTimeMs() >= *entry.ExpiresAt {
+		return Entry{}, false
+	}
+	return entry.Clone(), true
+}
+
+func (db *Database) Set(key []byte, entry Entry) {
+	if db.entries == nil {
+		db.entries = hashmap.New[Entry]()
+	}
+	if db.ttlHeap == nil {
+		db.ttlHeap = heap.NewMinHeap(ttlLess)
+	}
+	if entry.ExpiresAt != nil {
+		db.ttlHeap.Push(ttlEntry{ExpiresAt: *entry.ExpiresAt, Key: cloneBytes(key)})
+	}
+	db.entries.Set(key, entry.Clone())
+}
+
+func (db *Database) Delete(key []byte) bool {
+	if db.entries == nil {
+		return false
+	}
+	return db.entries.Delete(key)
+}
+
+func (db *Database) Exists(key []byte) bool {
+	_, ok := db.Get(key)
+	return ok
+}
+
+func (db *Database) TypeOf(key []byte) (EntryType, bool) {
+	entry, ok := db.Get(key)
+	if !ok {
+		return "", false
+	}
+	return entry.Type, true
+}
+
+func (db *Database) Keys(pattern []byte) [][]byte {
+	if db.entries == nil {
+		return nil
+	}
+	keys := make([][]byte, 0)
+	for _, key := range db.entries.Keys() {
+		if globMatch(pattern, key) {
+			keys = append(keys, key)
+		}
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return bytes.Compare(keys[i], keys[j]) < 0
+	})
+	return keys
+}
+
+func (db *Database) DBSize() int {
+	if db.entries == nil {
+		return 0
+	}
+	count := 0
+	for _, key := range db.entries.Keys() {
+		if db.Exists(key) {
+			count++
+		}
+	}
+	return count
+}
+
+func (db *Database) ExpireLazy(key []byte) {
+	if db.entries == nil {
+		return
+	}
+	entry, ok := db.entries.Get(key)
+	if !ok || entry.ExpiresAt == nil {
+		return
+	}
+	if currentTimeMs() >= *entry.ExpiresAt {
+		db.entries.Delete(key)
+	}
+}
+
+func (db *Database) ActiveExpire() {
+	if db.ttlHeap == nil {
+		return
+	}
+	now := currentTimeMs()
+	for {
+		entry, ok := db.ttlHeap.Peek()
+		if !ok || entry.ExpiresAt > now {
+			return
+		}
+		popped, _ := db.ttlHeap.Pop()
+		current, ok := db.entries.Get(popped.Key)
+		if ok && current.ExpiresAt != nil && *current.ExpiresAt == popped.ExpiresAt {
+			db.entries.Delete(popped.Key)
+		}
+	}
+}
+
+func (db *Database) Clear() {
+	db.entries.Clear()
+	db.ttlHeap.Clear()
+}
+
+type Store struct {
+	Databases []Database
+	ActiveDB  int
+}
+
+func NewStore() *Store {
+	databases := make([]Database, defaultDBCount)
+	for i := range databases {
+		databases[i] = NewDatabase()
+	}
+	return &Store{Databases: databases}
+}
+
+func (s *Store) Clone() *Store {
+	if s == nil {
+		return NewStore()
+	}
+	clone := &Store{
+		Databases: make([]Database, len(s.Databases)),
+		ActiveDB:  s.ActiveDB,
+	}
+	for i := range s.Databases {
+		clone.Databases[i] = s.Databases[i].Clone()
+	}
+	return clone
+}
+
+func (s *Store) WithActiveDB(activeDB int) *Store {
+	if s == nil {
+		return NewStore().WithActiveDB(activeDB)
+	}
+	clone := s.Clone()
+	clone.ActiveDB = clamp(activeDB, 0, len(clone.Databases)-1)
+	return clone
+}
+
+func (s *Store) Select(activeDB int) *Store {
+	return s.WithActiveDB(activeDB)
+}
+
+func (s *Store) CurrentDB() *Database {
+	return &s.Databases[s.ActiveDB]
+}
+
+func (s *Store) CurrentDBValue() Database {
+	return s.Databases[s.ActiveDB]
+}
+
+func (s *Store) Get(key []byte) (Entry, bool) {
+	return s.CurrentDB().Get(key)
+}
+
+func (s *Store) Set(key []byte, entry Entry) *Store {
+	clone := s.Clone()
+	clone.CurrentDB().Set(key, entry)
+	return clone
+}
+
+func (s *Store) Delete(key []byte) *Store {
+	clone := s.Clone()
+	clone.CurrentDB().Delete(key)
+	return clone
+}
+
+func (s *Store) Exists(key []byte) bool {
+	return s.CurrentDB().Exists(key)
+}
+
+func (s *Store) Keys(pattern []byte) [][]byte {
+	return s.CurrentDB().Keys(pattern)
+}
+
+func (s *Store) TypeOf(key []byte) (EntryType, bool) {
+	return s.CurrentDB().TypeOf(key)
+}
+
+func (s *Store) DBSize() int {
+	return s.CurrentDB().DBSize()
+}
+
+func (s *Store) ExpireLazy(key []byte) *Store {
+	clone := s.Clone()
+	clone.CurrentDB().ExpireLazy(key)
+	return clone
+}
+
+func (s *Store) ActiveExpire() *Store {
+	clone := s.Clone()
+	clone.CurrentDB().ActiveExpire()
+	return clone
+}
+
+func (s *Store) ActiveExpireAll() *Store {
+	clone := s.Clone()
+	for i := range clone.Databases {
+		clone.Databases[i].ActiveExpire()
+	}
+	return clone
+}
+
+func (s *Store) FlushDB() *Store {
+	clone := s.Clone()
+	clone.Databases[clone.ActiveDB] = NewDatabase()
+	return clone
+}
+
+func (s *Store) FlushAll() *Store {
+	clone := s.Clone()
+	for i := range clone.Databases {
+		clone.Databases[i] = NewDatabase()
+	}
+	return clone
+}
+
+func (s *Store) Clear() *Store {
+	clone := s.Clone()
+	for i := range clone.Databases {
+		clone.Databases[i].Clear()
+	}
+	clone.ActiveDB = 0
+	return clone
+}
+
+func currentTimeMs() uint64 {
+	return uint64(time.Now().UnixMilli())
+}
+
+func clamp(value, minValue, maxValue int) int {
+	if value < minValue {
+		return minValue
+	}
+	if value > maxValue {
+		return maxValue
+	}
+	return value
+}
+
+func globMatch(pattern, text []byte) bool {
+	return globMatchInner(pattern, text)
+}
+
+func globMatchInner(pattern, text []byte) bool {
+	if len(pattern) == 0 {
+		return len(text) == 0
+	}
+	switch pattern[0] {
+	case '*':
+		return globMatchInner(pattern[1:], text) || (len(text) > 0 && globMatchInner(pattern, text[1:]))
+	case '?':
+		return len(text) > 0 && globMatchInner(pattern[1:], text[1:])
+	case '[':
+		if end := bytes.IndexByte(pattern, ']'); end > 0 {
+			if len(text) == 0 {
+				return false
+			}
+			class := pattern[1:end]
+			if classContains(class, text[0]) {
+				return globMatchInner(pattern[end+1:], text[1:])
+			}
+			return false
+		}
+		fallthrough
+	default:
+		return len(text) > 0 && pattern[0] == text[0] && globMatchInner(pattern[1:], text[1:])
+	}
+}
+
+func classContains(class []byte, value byte) bool {
+	for i := 0; i < len(class); i++ {
+		if i+2 < len(class) && class[i+1] == '-' {
+			if class[i] <= value && value <= class[i+2] {
+				return true
+			}
+			i += 2
+			continue
+		}
+		if class[i] == value {
+			return true
+		}
+	}
+	return false
+}

--- a/code/packages/go/in-memory-data-store-protocol/BUILD
+++ b/code/packages/go/in-memory-data-store-protocol/BUILD
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/in-memory-data-store-protocol/BUILD_windows
+++ b/code/packages/go/in-memory-data-store-protocol/BUILD_windows
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/in-memory-data-store-protocol/go.mod
+++ b/code/packages/go/in-memory-data-store-protocol/go.mod
@@ -1,0 +1,7 @@
+module github.com/adhithyan15/coding-adventures/code/packages/go/in-memory-data-store-protocol
+
+go 1.23
+
+require github.com/adhithyan15/coding-adventures/code/packages/go/resp-protocol v0.0.0
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/resp-protocol => ../resp-protocol

--- a/code/packages/go/in-memory-data-store-protocol/protocol.go
+++ b/code/packages/go/in-memory-data-store-protocol/protocol.go
@@ -1,0 +1,108 @@
+package datastoreprotocol
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	resp "github.com/adhithyan15/coding-adventures/code/packages/go/resp-protocol"
+)
+
+type CommandFrame struct {
+	Command string
+	Args    [][]byte
+}
+
+func NewCommandFrame(command string, args [][]byte) CommandFrame {
+	return CommandFrame{Command: strings.ToUpper(command), Args: cloneArgs(args)}
+}
+
+func FromParts(parts [][]byte) (CommandFrame, bool) {
+	if len(parts) == 0 {
+		return CommandFrame{}, false
+	}
+	return CommandFrame{
+		Command: asciiUpper(parts[0]),
+		Args:    cloneArgs(parts[1:]),
+	}, true
+}
+
+func FrameFromResp(value resp.Value) (CommandFrame, bool) {
+	if value.Kind != resp.ArrayKind || value.Nil || len(value.Array) == 0 {
+		return CommandFrame{}, false
+	}
+
+	parts := make([][]byte, 0, len(value.Array))
+	for _, item := range value.Array {
+		switch item.Kind {
+		case resp.SimpleStringKind:
+			parts = append(parts, []byte(item.Text))
+		case resp.BulkStringKind:
+			if item.Nil {
+				return CommandFrame{}, false
+			}
+			parts = append(parts, cloneBytes(item.Bulk))
+		case resp.IntegerKind:
+			parts = append(parts, []byte(strconv.FormatInt(item.Integer, 10)))
+		default:
+			return CommandFrame{}, false
+		}
+	}
+	return FromParts(parts)
+}
+
+func ProtocolError(message string) resp.Value {
+	return resp.ErrorValue(message)
+}
+
+func MapDecodeError(err error) error {
+	return fmt.Errorf("invalid RESP payload: %w", err)
+}
+
+func asciiUpper(data []byte) string {
+	return strings.ToUpper(string(data))
+}
+
+func cloneArgs(args [][]byte) [][]byte {
+	if args == nil {
+		return nil
+	}
+	result := make([][]byte, len(args))
+	for i, arg := range args {
+		result[i] = cloneBytes(arg)
+	}
+	return result
+}
+
+func cloneBytes(data []byte) []byte {
+	if data == nil {
+		return nil
+	}
+	return append([]byte(nil), data...)
+}
+
+func ParseFrameText(parts []string) CommandFrame {
+	args := make([][]byte, 0, len(parts)-1)
+	for _, part := range parts[1:] {
+		args = append(args, []byte(part))
+	}
+	return NewCommandFrame(parts[0], args)
+}
+
+func FormatFrame(frame CommandFrame) string {
+	rendered := make([]string, 0, len(frame.Args)+1)
+	rendered = append(rendered, frame.Command)
+	for _, arg := range frame.Args {
+		rendered = append(rendered, string(arg))
+	}
+	return strings.Join(rendered, " ")
+}
+
+func EncodeFrame(frame CommandFrame) (resp.Value, error) {
+	items := make([]resp.Value, 0, len(frame.Args)+1)
+	items = append(items, resp.BulkString([]byte(frame.Command)))
+	for _, arg := range frame.Args {
+		items = append(items, resp.BulkString(arg))
+	}
+	return resp.Array(items), nil
+}

--- a/code/packages/go/in-memory-data-store-protocol/protocol_test.go
+++ b/code/packages/go/in-memory-data-store-protocol/protocol_test.go
@@ -1,0 +1,22 @@
+package datastoreprotocol
+
+import (
+	"testing"
+
+	resp "github.com/adhithyan15/coding-adventures/code/packages/go/resp-protocol"
+)
+
+func TestFrameFromResp(t *testing.T) {
+	value := resp.Array([]resp.Value{
+		resp.BulkString([]byte("set")),
+		resp.BulkString([]byte("k")),
+		resp.Integer(1),
+	})
+	frame, ok := FrameFromResp(value)
+	if !ok {
+		t.Fatal("expected frame")
+	}
+	if frame.Command != "SET" || len(frame.Args) != 2 || string(frame.Args[1]) != "1" {
+		t.Fatalf("unexpected frame: %#v", frame)
+	}
+}

--- a/code/packages/go/in-memory-data-store/BUILD
+++ b/code/packages/go/in-memory-data-store/BUILD
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/in-memory-data-store/BUILD_windows
+++ b/code/packages/go/in-memory-data-store/BUILD_windows
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/in-memory-data-store/data_store.go
+++ b/code/packages/go/in-memory-data-store/data_store.go
@@ -1,0 +1,35 @@
+package datastore
+
+import (
+	datastoreengine "github.com/adhithyan15/coding-adventures/code/packages/go/in-memory-data-store-engine"
+	datastoreprotocol "github.com/adhithyan15/coding-adventures/code/packages/go/in-memory-data-store-protocol"
+	resp "github.com/adhithyan15/coding-adventures/code/packages/go/resp-protocol"
+)
+
+type DataStore struct {
+	backend datastoreengine.DataStoreBackend
+}
+
+func New() *DataStore {
+	return &DataStore{backend: datastoreengine.New()}
+}
+
+func FromStore(store *datastoreengine.Store) *DataStore {
+	return &DataStore{backend: datastoreengine.FromStore(store)}
+}
+
+func (s *DataStore) ExecuteFrame(frame datastoreprotocol.CommandFrame) resp.Value {
+	return s.backend.ExecuteFrame(frame)
+}
+
+func (s *DataStore) ExecuteParts(parts [][]byte) resp.Value {
+	return s.backend.ExecuteParts(parts)
+}
+
+func (s *DataStore) Store() *datastoreengine.Store {
+	return s.backend.Store()
+}
+
+func (s *DataStore) ActiveExpireAll() {
+	s.backend.ActiveExpireAll()
+}

--- a/code/packages/go/in-memory-data-store/data_store_test.go
+++ b/code/packages/go/in-memory-data-store/data_store_test.go
@@ -1,0 +1,16 @@
+package datastore
+
+import (
+	"testing"
+
+	datastoreprotocol "github.com/adhithyan15/coding-adventures/code/packages/go/in-memory-data-store-protocol"
+	resp "github.com/adhithyan15/coding-adventures/code/packages/go/resp-protocol"
+)
+
+func TestDataStorePipeline(t *testing.T) {
+	store := New()
+	frame := datastoreprotocol.NewCommandFrame("PING", nil)
+	if got := store.ExecuteFrame(frame); got.Kind != resp.SimpleStringKind || got.Text != "PONG" {
+		t.Fatalf("unexpected ping response: %#v", got)
+	}
+}

--- a/code/packages/go/in-memory-data-store/go.mod
+++ b/code/packages/go/in-memory-data-store/go.mod
@@ -1,0 +1,23 @@
+module github.com/adhithyan15/coding-adventures/code/packages/go/in-memory-data-store
+
+go 1.23
+
+require (
+	github.com/adhithyan15/coding-adventures/code/packages/go/hash-map v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/hash-set v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/heap v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/hyperloglog v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/in-memory-data-store-engine v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/in-memory-data-store-protocol v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/resp-protocol v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/skip-list v0.0.0
+)
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/hash-map => ../hash-map
+replace github.com/adhithyan15/coding-adventures/code/packages/go/hash-set => ../hash-set
+replace github.com/adhithyan15/coding-adventures/code/packages/go/heap => ../heap
+replace github.com/adhithyan15/coding-adventures/code/packages/go/hyperloglog => ../hyperloglog
+replace github.com/adhithyan15/coding-adventures/code/packages/go/in-memory-data-store-engine => ../in-memory-data-store-engine
+replace github.com/adhithyan15/coding-adventures/code/packages/go/in-memory-data-store-protocol => ../in-memory-data-store-protocol
+replace github.com/adhithyan15/coding-adventures/code/packages/go/resp-protocol => ../resp-protocol
+replace github.com/adhithyan15/coding-adventures/code/packages/go/skip-list => ../skip-list

--- a/code/packages/go/resp-protocol/BUILD
+++ b/code/packages/go/resp-protocol/BUILD
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/resp-protocol/BUILD_windows
+++ b/code/packages/go/resp-protocol/BUILD_windows
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/resp-protocol/go.mod
+++ b/code/packages/go/resp-protocol/go.mod
@@ -1,0 +1,3 @@
+module github.com/adhithyan15/coding-adventures/code/packages/go/resp-protocol
+
+go 1.23

--- a/code/packages/go/resp-protocol/resp.go
+++ b/code/packages/go/resp-protocol/resp.go
@@ -198,17 +198,17 @@ func decodeValue(data []byte, offset int) (Value, int, error) {
 		if err != nil {
 			return Value{}, offset, err
 		}
-		length, parseErr := strconv.ParseInt(string(line), 10, 64)
+		length, parseErr := strconv.Atoi(string(line))
 		if parseErr != nil {
 			return Value{}, offset, &DecodeError{Message: fmt.Sprintf("invalid bulk length: %v", parseErr)}
 		}
 		if length < 0 {
 			return NullBulkString(), next, nil
 		}
-		end := next + int(length)
-		if end+2 > len(data) {
+		if length > len(data)-next-2 {
 			return Value{}, offset, io.ErrUnexpectedEOF
 		}
+		end := next + length
 		bulk := append([]byte(nil), data[next:end]...)
 		if !bytes.Equal(data[end:end+2], []byte("\r\n")) {
 			return Value{}, offset, &DecodeError{Message: "bulk string missing CRLF"}
@@ -219,7 +219,7 @@ func decodeValue(data []byte, offset int) (Value, int, error) {
 		if err != nil {
 			return Value{}, offset, err
 		}
-		count, parseErr := strconv.ParseInt(string(line), 10, 64)
+		count, parseErr := strconv.Atoi(string(line))
 		if parseErr != nil {
 			return Value{}, offset, &DecodeError{Message: fmt.Sprintf("invalid array length: %v", parseErr)}
 		}
@@ -228,7 +228,7 @@ func decodeValue(data []byte, offset int) (Value, int, error) {
 		}
 		items := make([]Value, 0, count)
 		cursor := next
-		for i := int64(0); i < count; i++ {
+		for i := 0; i < count; i++ {
 			item, n, err := decodeValue(data, cursor)
 			if err != nil {
 				return Value{}, offset, err

--- a/code/packages/go/resp-protocol/resp.go
+++ b/code/packages/go/resp-protocol/resp.go
@@ -1,0 +1,353 @@
+package resp
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+)
+
+type Kind int
+
+const (
+	SimpleStringKind Kind = iota
+	ErrorKind
+	IntegerKind
+	BulkStringKind
+	ArrayKind
+)
+
+type Value struct {
+	Kind    Kind
+	Text    string
+	Integer int64
+	Bulk    []byte
+	Array   []Value
+	Nil     bool
+}
+
+func SimpleString(text string) Value {
+	return Value{Kind: SimpleStringKind, Text: text}
+}
+
+func ErrorValue(message string) Value {
+	return Value{Kind: ErrorKind, Text: message}
+}
+
+func Integer(value int64) Value {
+	return Value{Kind: IntegerKind, Integer: value}
+}
+
+func BulkString(value []byte) Value {
+	if value == nil {
+		return Value{Kind: BulkStringKind, Nil: true}
+	}
+	return Value{Kind: BulkStringKind, Bulk: append([]byte(nil), value...)}
+}
+
+func NullBulkString() Value {
+	return Value{Kind: BulkStringKind, Nil: true}
+}
+
+func Array(values []Value) Value {
+	if values == nil {
+		return Value{Kind: ArrayKind, Nil: true}
+	}
+	return Value{Kind: ArrayKind, Array: cloneValues(values)}
+}
+
+func NullArray() Value {
+	return Value{Kind: ArrayKind, Nil: true}
+}
+
+func (v Value) Clone() Value {
+	switch v.Kind {
+	case BulkStringKind:
+		if v.Nil {
+			return NullBulkString()
+		}
+		return BulkString(v.Bulk)
+	case ArrayKind:
+		if v.Nil {
+			return NullArray()
+		}
+		return Array(v.Array)
+	default:
+		return v
+	}
+}
+
+func Encode(value Value) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := encodeValue(&buf, value); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func EncodeMany(values []Value) ([]byte, error) {
+	var buf bytes.Buffer
+	for _, value := range values {
+		if err := encodeValue(&buf, value); err != nil {
+			return nil, err
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+func encodeValue(buf *bytes.Buffer, value Value) error {
+	switch value.Kind {
+	case SimpleStringKind:
+		buf.WriteByte('+')
+		buf.WriteString(value.Text)
+		buf.WriteString("\r\n")
+	case ErrorKind:
+		buf.WriteByte('-')
+		buf.WriteString(value.Text)
+		buf.WriteString("\r\n")
+	case IntegerKind:
+		buf.WriteByte(':')
+		buf.WriteString(strconv.FormatInt(value.Integer, 10))
+		buf.WriteString("\r\n")
+	case BulkStringKind:
+		if value.Nil {
+			buf.WriteString("$-1\r\n")
+			return nil
+		}
+		buf.WriteByte('$')
+		buf.WriteString(strconv.Itoa(len(value.Bulk)))
+		buf.WriteString("\r\n")
+		buf.Write(value.Bulk)
+		buf.WriteString("\r\n")
+	case ArrayKind:
+		if value.Nil {
+			buf.WriteString("*-1\r\n")
+			return nil
+		}
+		buf.WriteByte('*')
+		buf.WriteString(strconv.Itoa(len(value.Array)))
+		buf.WriteString("\r\n")
+		for _, item := range value.Array {
+			if err := encodeValue(buf, item); err != nil {
+				return err
+			}
+		}
+	default:
+		return fmt.Errorf("resp: unknown kind %d", value.Kind)
+	}
+	return nil
+}
+
+type DecodeError struct {
+	Message string
+}
+
+func (e *DecodeError) Error() string {
+	return e.Message
+}
+
+func DecodeAll(data []byte) ([]Value, error) {
+	var values []Value
+	offset := 0
+	for offset < len(data) {
+		value, next, err := decodeValue(data, offset)
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, value)
+		offset = next
+	}
+	return values, nil
+}
+
+func DecodeOne(data []byte) (Value, int, error) {
+	return decodeValue(data, 0)
+}
+
+func decodeValue(data []byte, offset int) (Value, int, error) {
+	if offset >= len(data) {
+		return Value{}, offset, io.EOF
+	}
+
+	switch data[offset] {
+	case '+':
+		line, next, err := readLine(data, offset+1)
+		if err != nil {
+			return Value{}, offset, err
+		}
+		return SimpleString(string(line)), next, nil
+	case '-':
+		line, next, err := readLine(data, offset+1)
+		if err != nil {
+			return Value{}, offset, err
+		}
+		return ErrorValue(string(line)), next, nil
+	case ':':
+		line, next, err := readLine(data, offset+1)
+		if err != nil {
+			return Value{}, offset, err
+		}
+		n, parseErr := strconv.ParseInt(string(line), 10, 64)
+		if parseErr != nil {
+			return Value{}, offset, &DecodeError{Message: fmt.Sprintf("invalid integer: %v", parseErr)}
+		}
+		return Integer(n), next, nil
+	case '$':
+		line, next, err := readLine(data, offset+1)
+		if err != nil {
+			return Value{}, offset, err
+		}
+		length, parseErr := strconv.ParseInt(string(line), 10, 64)
+		if parseErr != nil {
+			return Value{}, offset, &DecodeError{Message: fmt.Sprintf("invalid bulk length: %v", parseErr)}
+		}
+		if length < 0 {
+			return NullBulkString(), next, nil
+		}
+		end := next + int(length)
+		if end+2 > len(data) {
+			return Value{}, offset, io.ErrUnexpectedEOF
+		}
+		bulk := append([]byte(nil), data[next:end]...)
+		if !bytes.Equal(data[end:end+2], []byte("\r\n")) {
+			return Value{}, offset, &DecodeError{Message: "bulk string missing CRLF"}
+		}
+		return BulkString(bulk), end + 2, nil
+	case '*':
+		line, next, err := readLine(data, offset+1)
+		if err != nil {
+			return Value{}, offset, err
+		}
+		count, parseErr := strconv.ParseInt(string(line), 10, 64)
+		if parseErr != nil {
+			return Value{}, offset, &DecodeError{Message: fmt.Sprintf("invalid array length: %v", parseErr)}
+		}
+		if count < 0 {
+			return NullArray(), next, nil
+		}
+		items := make([]Value, 0, count)
+		cursor := next
+		for i := int64(0); i < count; i++ {
+			item, n, err := decodeValue(data, cursor)
+			if err != nil {
+				return Value{}, offset, err
+			}
+			items = append(items, item)
+			cursor = n
+		}
+		return Array(items), cursor, nil
+	default:
+		return Value{}, offset, &DecodeError{Message: fmt.Sprintf("unknown RESP prefix %q", data[offset])}
+	}
+}
+
+func readLine(data []byte, offset int) ([]byte, int, error) {
+	end := bytes.Index(data[offset:], []byte("\r\n"))
+	if end < 0 {
+		return nil, offset, io.ErrUnexpectedEOF
+	}
+	end += offset
+	line := append([]byte(nil), data[offset:end]...)
+	return line, end + 2, nil
+}
+
+func cloneValues(values []Value) []Value {
+	result := make([]Value, len(values))
+	for i, value := range values {
+		result[i] = value.Clone()
+	}
+	return result
+}
+
+func MustEncode(value Value) []byte {
+	data, err := Encode(value)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}
+
+func MustDecodeAll(data []byte) []Value {
+	values, err := DecodeAll(data)
+	if err != nil {
+		panic(err)
+	}
+	return values
+}
+
+func (k Kind) String() string {
+	switch k {
+	case SimpleStringKind:
+		return "simple_string"
+	case ErrorKind:
+		return "error"
+	case IntegerKind:
+		return "integer"
+	case BulkStringKind:
+		return "bulk_string"
+	case ArrayKind:
+		return "array"
+	default:
+		return fmt.Sprintf("kind(%d)", int(k))
+	}
+}
+
+func (v Value) String() string {
+	switch v.Kind {
+	case SimpleStringKind:
+		return fmt.Sprintf("SimpleString(%q)", v.Text)
+	case ErrorKind:
+		return fmt.Sprintf("Error(%q)", v.Text)
+	case IntegerKind:
+		return fmt.Sprintf("Integer(%d)", v.Integer)
+	case BulkStringKind:
+		if v.Nil {
+			return "BulkString(nil)"
+		}
+		return fmt.Sprintf("BulkString(%q)", string(v.Bulk))
+	case ArrayKind:
+		if v.Nil {
+			return "Array(nil)"
+		}
+		return fmt.Sprintf("Array(%v)", v.Array)
+	default:
+		return fmt.Sprintf("Value(kind=%d)", v.Kind)
+	}
+}
+
+func Equal(left, right Value) bool {
+	if left.Kind != right.Kind || left.Nil != right.Nil {
+		return false
+	}
+	switch left.Kind {
+	case SimpleStringKind, ErrorKind:
+		return left.Text == right.Text
+	case IntegerKind:
+		return left.Integer == right.Integer
+	case BulkStringKind:
+		return bytes.Equal(left.Bulk, right.Bulk)
+	case ArrayKind:
+		if len(left.Array) != len(right.Array) {
+			return false
+		}
+		for i := range left.Array {
+			if !Equal(left.Array[i], right.Array[i]) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+func IsError(value Value) bool {
+	return value.Kind == ErrorKind
+}
+
+func Errorf(format string, args ...any) Value {
+	return ErrorValue(fmt.Sprintf(format, args...))
+}
+
+var ErrProtocol = errors.New("protocol error")

--- a/code/packages/go/resp-protocol/resp_test.go
+++ b/code/packages/go/resp-protocol/resp_test.go
@@ -1,0 +1,34 @@
+package resp
+
+import "testing"
+
+func TestEncodeDecodeRoundTrip(t *testing.T) {
+	values := []Value{
+		SimpleString("OK"),
+		ErrorValue("ERR boom"),
+		Integer(42),
+		BulkString([]byte("hello")),
+		Array([]Value{BulkString([]byte("PING")), BulkString([]byte("world"))}),
+		NullBulkString(),
+		NullArray(),
+	}
+
+	encoded, err := EncodeMany(values)
+	if err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+
+	decoded, err := DecodeAll(encoded)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+
+	if len(decoded) != len(values) {
+		t.Fatalf("expected %d values, got %d", len(values), len(decoded))
+	}
+	for i := range values {
+		if !Equal(values[i], decoded[i]) {
+			t.Fatalf("value %d mismatch: want %#v got %#v", i, values[i], decoded[i])
+		}
+	}
+}

--- a/code/packages/go/skip-list/BUILD
+++ b/code/packages/go/skip-list/BUILD
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/skip-list/BUILD_windows
+++ b/code/packages/go/skip-list/BUILD_windows
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/skip-list/go.mod
+++ b/code/packages/go/skip-list/go.mod
@@ -1,0 +1,3 @@
+module github.com/adhithyan15/coding-adventures/code/packages/go/skip-list
+
+go 1.23

--- a/code/packages/go/skip-list/skip_list.go
+++ b/code/packages/go/skip-list/skip_list.go
@@ -1,0 +1,237 @@
+package skiplist
+
+import (
+	"math/rand"
+)
+
+const (
+	defaultMaxLevel = 16
+	defaultSeed     = 1
+)
+
+type node[T any] struct {
+	value   T
+	forward []*node[T]
+}
+
+type SkipList[T any] struct {
+	head   *node[T]
+	level  int
+	length int
+	less   func(a, b T) bool
+	rng    *rand.Rand
+}
+
+func New[T any](less func(a, b T) bool) *SkipList[T] {
+	head := &node[T]{forward: make([]*node[T], defaultMaxLevel)}
+	return &SkipList[T]{
+		head:  head,
+		level: 1,
+		less:  less,
+		rng:   rand.New(rand.NewSource(defaultSeed)),
+	}
+}
+
+func (s *SkipList[T]) Clone() *SkipList[T] {
+	if s == nil {
+		return nil
+	}
+	clone := New(s.less)
+	for _, value := range s.ToSlice() {
+		clone.Insert(value)
+	}
+	return clone
+}
+
+func (s *SkipList[T]) Len() int {
+	if s == nil {
+		return 0
+	}
+	return s.length
+}
+
+func (s *SkipList[T]) Size() int {
+	return s.Len()
+}
+
+func (s *SkipList[T]) IsEmpty() bool {
+	return s.Len() == 0
+}
+
+func (s *SkipList[T]) Contains(value T) bool {
+	_, found := s.find(value)
+	return found
+}
+
+func (s *SkipList[T]) Insert(value T) bool {
+	update := make([]*node[T], defaultMaxLevel)
+	current := s.head
+
+	for level := s.level - 1; level >= 0; level-- {
+		for current.forward[level] != nil && s.less(current.forward[level].value, value) {
+			current = current.forward[level]
+		}
+		update[level] = current
+	}
+
+	next := current.forward[0]
+	if next != nil && s.equal(next.value, value) {
+		next.value = value
+		return false
+	}
+
+	newLevel := s.randomLevel()
+	if newLevel > s.level {
+		for i := s.level; i < newLevel; i++ {
+			update[i] = s.head
+		}
+		s.level = newLevel
+	}
+
+	n := &node[T]{value: value, forward: make([]*node[T], newLevel)}
+	for i := 0; i < newLevel; i++ {
+		n.forward[i] = update[i].forward[i]
+		update[i].forward[i] = n
+	}
+	s.length++
+	return true
+}
+
+func (s *SkipList[T]) Delete(value T) bool {
+	update := make([]*node[T], defaultMaxLevel)
+	current := s.head
+
+	for level := s.level - 1; level >= 0; level-- {
+		for current.forward[level] != nil && s.less(current.forward[level].value, value) {
+			current = current.forward[level]
+		}
+		update[level] = current
+	}
+
+	target := current.forward[0]
+	if target == nil || !s.equal(target.value, value) {
+		return false
+	}
+
+	for i := 0; i < s.level; i++ {
+		if update[i].forward[i] != target {
+			break
+		}
+		update[i].forward[i] = target.forward[i]
+	}
+
+	for s.level > 1 && s.head.forward[s.level-1] == nil {
+		s.level--
+	}
+	s.length--
+	return true
+}
+
+func (s *SkipList[T]) Rank(value T) int {
+	rank := 0
+	for _, item := range s.ToSlice() {
+		if s.less(item, value) {
+			rank++
+			continue
+		}
+		break
+	}
+	return rank
+}
+
+func (s *SkipList[T]) KthSmallest(k int) (T, bool) {
+	var zero T
+	if k <= 0 || k > s.Len() {
+		return zero, false
+	}
+	items := s.ToSlice()
+	return items[k-1], true
+}
+
+func (s *SkipList[T]) Min() (T, bool) {
+	var zero T
+	if s == nil || s.head.forward[0] == nil {
+		return zero, false
+	}
+	return s.head.forward[0].value, true
+}
+
+func (s *SkipList[T]) Max() (T, bool) {
+	var zero T
+	if s == nil || s.head.forward[0] == nil {
+		return zero, false
+	}
+	current := s.head.forward[0]
+	for current.forward[0] != nil {
+		current = current.forward[0]
+	}
+	return current.value, true
+}
+
+func (s *SkipList[T]) ToSlice() []T {
+	if s == nil {
+		return nil
+	}
+	values := make([]T, 0, s.length)
+	for current := s.head.forward[0]; current != nil; current = current.forward[0] {
+		values = append(values, current.value)
+	}
+	return values
+}
+
+func (s *SkipList[T]) Range(min, max T, inclusive bool) []T {
+	values := s.ToSlice()
+	result := make([]T, 0)
+	for _, value := range values {
+		if inclusive {
+			if !s.less(value, min) && !s.less(max, value) {
+				result = append(result, value)
+			}
+			continue
+		}
+		if s.less(min, value) && s.less(value, max) {
+			result = append(result, value)
+		}
+	}
+	return result
+}
+
+func (s *SkipList[T]) FirstGreaterOrEqual(value T) (T, bool) {
+	var zero T
+	for _, item := range s.ToSlice() {
+		if !s.less(item, value) {
+			return item, true
+		}
+	}
+	return zero, false
+}
+
+func (s *SkipList[T]) Equal(a, b T) bool {
+	return s.equal(a, b)
+}
+
+func (s *SkipList[T]) equal(a, b T) bool {
+	return !s.less(a, b) && !s.less(b, a)
+}
+
+func (s *SkipList[T]) find(value T) (*node[T], bool) {
+	current := s.head
+	for level := s.level - 1; level >= 0; level-- {
+		for current.forward[level] != nil && s.less(current.forward[level].value, value) {
+			current = current.forward[level]
+		}
+	}
+	current = current.forward[0]
+	if current != nil && s.equal(current.value, value) {
+		return current, true
+	}
+	return nil, false
+}
+
+func (s *SkipList[T]) randomLevel() int {
+	level := 1
+	for level < defaultMaxLevel && s.rng.Intn(2) == 0 {
+		level++
+	}
+	return level
+}

--- a/code/packages/go/skip-list/skip_list_test.go
+++ b/code/packages/go/skip-list/skip_list_test.go
@@ -1,0 +1,25 @@
+package skiplist
+
+import "testing"
+
+func TestSkipListBasicOperations(t *testing.T) {
+	list := New(func(a, b int) bool { return a < b })
+	if !list.Insert(5) || !list.Insert(2) || !list.Insert(8) || list.Insert(5) {
+		t.Fatal("unexpected insert behavior")
+	}
+	if !list.Contains(2) || list.Len() != 3 {
+		t.Fatalf("unexpected state: contains(2)=%v len=%d", list.Contains(2), list.Len())
+	}
+	if got := list.ToSlice(); len(got) != 3 || got[0] != 2 || got[2] != 8 {
+		t.Fatalf("unexpected order: %v", got)
+	}
+	if got, ok := list.KthSmallest(2); !ok || got != 5 {
+		t.Fatalf("expected kth=5, got %v %v", got, ok)
+	}
+	if rank := list.Rank(6); rank != 2 {
+		t.Fatalf("expected rank 2, got %d", rank)
+	}
+	if !list.Delete(5) || list.Contains(5) {
+		t.Fatal("delete failed")
+	}
+}

--- a/code/packages/go/tree-set/BUILD
+++ b/code/packages/go/tree-set/BUILD
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/tree-set/BUILD_windows
+++ b/code/packages/go/tree-set/BUILD_windows
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/tree-set/go.mod
+++ b/code/packages/go/tree-set/go.mod
@@ -1,0 +1,7 @@
+module github.com/adhithyan15/coding-adventures/code/packages/go/tree-set
+
+go 1.23
+
+require github.com/adhithyan15/coding-adventures/code/packages/go/skip-list v0.0.0
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/skip-list => ../skip-list

--- a/code/packages/go/tree-set/tree_set.go
+++ b/code/packages/go/tree-set/tree_set.go
@@ -1,0 +1,174 @@
+package treeset
+
+import (
+	"cmp"
+
+	"github.com/adhithyan15/coding-adventures/code/packages/go/skip-list"
+)
+
+type TreeSet[T cmp.Ordered] struct {
+	backend *skiplist.SkipList[T]
+}
+
+func New[T cmp.Ordered]() *TreeSet[T] {
+	return &TreeSet[T]{backend: skiplist.New(func(a, b T) bool { return cmp.Compare(a, b) < 0 })}
+}
+
+func FromList[T cmp.Ordered](values []T) *TreeSet[T] {
+	set := New[T]()
+	for _, value := range values {
+		set.Insert(value)
+	}
+	return set
+}
+
+func (s *TreeSet[T]) Clone() *TreeSet[T] {
+	if s == nil {
+		return New[T]()
+	}
+	return &TreeSet[T]{backend: s.backend.Clone()}
+}
+
+func (s *TreeSet[T]) Len() int {
+	return s.backend.Len()
+}
+
+func (s *TreeSet[T]) IsEmpty() bool {
+	return s.Len() == 0
+}
+
+func (s *TreeSet[T]) Contains(value T) bool {
+	return s.backend.Contains(value)
+}
+
+func (s *TreeSet[T]) Min() (T, bool) {
+	return s.backend.Min()
+}
+
+func (s *TreeSet[T]) Max() (T, bool) {
+	return s.backend.Max()
+}
+
+func (s *TreeSet[T]) Insert(value T) bool {
+	return s.backend.Insert(value)
+}
+
+func (s *TreeSet[T]) Remove(value T) bool {
+	return s.backend.Delete(value)
+}
+
+func (s *TreeSet[T]) Delete(value T) bool {
+	return s.Remove(value)
+}
+
+func (s *TreeSet[T]) Rank(value T) int {
+	return s.backend.Rank(value)
+}
+
+func (s *TreeSet[T]) KthSmallest(k int) (T, bool) {
+	return s.backend.KthSmallest(k)
+}
+
+func (s *TreeSet[T]) ToSlice() []T {
+	return s.backend.ToSlice()
+}
+
+func (s *TreeSet[T]) Range(min, max T, inclusive bool) []T {
+	return s.backend.Range(min, max, inclusive)
+}
+
+func (s *TreeSet[T]) Predecessor(value T) (T, bool) {
+	var zero T
+	values := s.ToSlice()
+	var found bool
+	for _, item := range values {
+		if cmp.Compare(item, value) < 0 {
+			zero = item
+			found = true
+			continue
+		}
+		break
+	}
+	return zero, found
+}
+
+func (s *TreeSet[T]) Successor(value T) (T, bool) {
+	var zero T
+	for _, item := range s.ToSlice() {
+		if cmp.Compare(item, value) > 0 {
+			return item, true
+		}
+	}
+	return zero, false
+}
+
+func (s *TreeSet[T]) Union(other *TreeSet[T]) *TreeSet[T] {
+	result := New[T]()
+	for _, value := range s.ToSlice() {
+		result.Insert(value)
+	}
+	for _, value := range other.ToSlice() {
+		result.Insert(value)
+	}
+	return result
+}
+
+func (s *TreeSet[T]) Intersection(other *TreeSet[T]) *TreeSet[T] {
+	result := New[T]()
+	for _, value := range s.ToSlice() {
+		if other.Contains(value) {
+			result.Insert(value)
+		}
+	}
+	return result
+}
+
+func (s *TreeSet[T]) Difference(other *TreeSet[T]) *TreeSet[T] {
+	result := New[T]()
+	for _, value := range s.ToSlice() {
+		if !other.Contains(value) {
+			result.Insert(value)
+		}
+	}
+	return result
+}
+
+func (s *TreeSet[T]) SymmetricDifference(other *TreeSet[T]) *TreeSet[T] {
+	return s.Difference(other).Union(other.Difference(s))
+}
+
+func (s *TreeSet[T]) IsSubset(other *TreeSet[T]) bool {
+	for _, value := range s.ToSlice() {
+		if !other.Contains(value) {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *TreeSet[T]) IsSuperset(other *TreeSet[T]) bool {
+	return other.IsSubset(s)
+}
+
+func (s *TreeSet[T]) IsDisjoint(other *TreeSet[T]) bool {
+	for _, value := range s.ToSlice() {
+		if other.Contains(value) {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *TreeSet[T]) Equals(other *TreeSet[T]) bool {
+	left := s.ToSlice()
+	right := other.ToSlice()
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/code/packages/go/tree-set/tree_set_test.go
+++ b/code/packages/go/tree-set/tree_set_test.go
@@ -1,0 +1,22 @@
+package treeset
+
+import "testing"
+
+func TestTreeSet(t *testing.T) {
+	set := FromList([]int{7, 3, 9, 1, 5, 3})
+	if got := set.ToSlice(); len(got) != 5 || got[0] != 1 || got[4] != 9 {
+		t.Fatalf("unexpected ordering: %v", got)
+	}
+	if rank := set.Rank(7); rank != 3 {
+		t.Fatalf("expected rank 3, got %d", rank)
+	}
+	if kth, ok := set.KthSmallest(3); !ok || kth != 5 {
+		t.Fatalf("expected kth=5, got %v %v", kth, ok)
+	}
+	if pred, ok := set.Predecessor(7); !ok || pred != 5 {
+		t.Fatalf("expected predecessor 5, got %v %v", pred, ok)
+	}
+	if succ, ok := set.Successor(7); !ok || succ != 9 {
+		t.Fatalf("expected successor 9, got %v %v", succ, ok)
+	}
+}


### PR DESCRIPTION
This PR ports the in-memory data store stack to Go using the new generic composition layer.

What changed:
- Added `resp-protocol` for RESP framing and decoding.
- Added Go-native `hash-map`, `hash-set`, `heap`, `skip-list`, `hyperloglog`, and `tree-set` packages.
- Added `in-memory-data-store-protocol` for RESP-to-command framing.
- Added `in-memory-data-store-engine` with registry-driven command execution and single-node store state.
- Added `in-memory-data-store` as the thin composition layer on top of protocol + engine.

Validation:
- `go test ./...` in each new Go package.
- `git diff --check`.

This is the first Go pass for the datastore stack; the broader tree/graph layering and additional commands can follow in later PRs.
