### PR TITLE
feat(specs): IRC system specification suite — Russian Nesting Doll architecture

### DIFF
--- a/code/specs/irc-architecture.md
+++ b/code/specs/irc-architecture.md
@@ -1,0 +1,227 @@
+# IRC System Architecture
+
+## Overview
+
+This document describes the architecture for a full IRC (Internet Relay Chat) server and client
+ecosystem built across all supported languages in this repository. IRC is a text-based chat
+protocol defined in RFC 1459 (1993) and updated by RFCs 2810–2813. Its simplicity makes it an
+ideal vehicle for learning deep systems concepts: protocol parsing, byte-stream framing, event
+loops, OS syscalls, and eventually, unikernel operating system design.
+
+The system is built as a **Russian Nesting Doll**: each layer exposes a stable interface to the
+layer above, and can be replaced with a deeper implementation without touching any other layer.
+The IRC application logic is written once. The network substrate beneath it is peeled back,
+layer by layer, until — in Rust — the IRC server boots on bare metal with no operating system.
+
+---
+
+## The Russian Nesting Doll
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  irc-server                                                     │
+│  Channel state, nick table, command dispatch (RFC 1459)         │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │  irc-proto                                                │  │
+│  │  Parse/serialize IRC messages. Pure function, no I/O.     │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │  irc-framing                                              │  │
+│  │  Byte stream → \r\n-delimited frames. Pure, buffered.     │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │  irc-net  [THE DOLL — implementation swapped per phase]   │  │
+│  │  ┌─────────────────────────────────────────────────────┐  │  │
+│  │  │  Level 1: stdlib (socket + thread per connection)   │  │  │
+│  │  │  ┌───────────────────────────────────────────────┐  │  │  │
+│  │  │  │  Level 2: selectors / mio (event loop)        │  │  │  │
+│  │  │  │  ┌─────────────────────────────────────────┐  │  │  │  │
+│  │  │  │  │  Level 3: epoll / kqueue (raw syscalls) │  │  │  │  │
+│  │  │  │  │  ┌───────────────────────────────────┐  │  │  │  │  │
+│  │  │  │  │  │  Level 4: smoltcp (userspace TCP) │  │  │  │  │  │
+│  │  │  │  │  │  ┌─────────────────────────────┐  │  │  │  │  │  │
+│  │  │  │  │  │  │  Level 5: virtio-net / NIC  │  │  │  │  │  │  │
+│  │  │  │  │  │  │  (Unikernel, no OS at all)  │  │  │  │  │  │  │
+│  │  │  │  │  │  └─────────────────────────────┘  │  │  │  │  │  │
+│  │  │  │  │  └───────────────────────────────────┘  │  │  │  │  │
+│  │  │  │  └─────────────────────────────────────────┘  │  │  │  │
+│  │  │  └───────────────────────────────────────────────┘  │  │  │
+│  │  └─────────────────────────────────────────────────────┘  │  │
+│  └───────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+The critical rule: **`irc-server` never imports any `irc-net` package**. The server sees only
+`ConnId`, `Message`, and `Handler` — abstract types with no I/O. The `ircd` program is the only
+place that wires the doll together and picks which `irc-net` implementation to use.
+
+---
+
+## Stable Interfaces (The Seams)
+
+These types and protocols are defined once and shared across all `irc-net-*` specs. They never
+change as implementations are swapped.
+
+```python
+from __future__ import annotations
+from typing import Protocol, NewType, Iterator
+from dataclasses import dataclass
+
+# --- irc-proto boundary ---
+
+@dataclass
+class Message:
+    prefix: str | None       # "nick!user@host" or "server.name" or None
+    command: str             # "PRIVMSG", "001", "JOIN", etc.
+    params: list[str]        # all params, including trailing
+
+# --- irc-net boundary ---
+
+ConnId = NewType('ConnId', int)
+
+class Connection(Protocol):
+    @property
+    def id(self) -> ConnId: ...
+    @property
+    def peer_addr(self) -> tuple[str, int]: ...
+    def read(self) -> bytes: ...           # b"" signals connection closed
+    def write(self, data: bytes) -> None: ...
+    def close(self) -> None: ...
+
+class Listener(Protocol):
+    def accept(self) -> Connection: ...
+    def close(self) -> None: ...
+
+class Handler(Protocol):
+    def on_connect(self, conn_id: ConnId) -> None: ...
+    def on_message(self, conn_id: ConnId, msg: Message) -> None: ...
+    def on_disconnect(self, conn_id: ConnId) -> None: ...
+
+class EventLoop(Protocol):
+    def run(self, listener: Listener, handler: Handler) -> None: ...
+```
+
+---
+
+## Package Map
+
+| Package | Type | Purpose | Depends On |
+|---|---|---|---|
+| `irc-proto` | library | Parse/serialize IRC messages | nothing |
+| `irc-framing` | library | Byte buffer → \r\n frames | nothing |
+| `irc-server` | library | IRC state machine, command dispatch | `irc-proto` |
+| `irc-net-stdlib` | library | Level 1 network impl: threads | nothing |
+| `irc-net-selectors` | library | Level 2: OS selector / mio event loop | nothing |
+| `irc-net-epoll` | library | Level 3: raw epoll/kqueue syscalls | nothing |
+| `irc-net-smoltcp` | library | Level 4: userspace TCP (Rust only) | nothing |
+| `ircd` | program | Wires all packages; owns CLI and config | all above |
+
+Each `irc-net-*` package implements the same `Connection`, `Listener`, `EventLoop` interfaces.
+The program selects which one to use at compile time (or via a flag).
+
+---
+
+## Language Rollout
+
+### Phase 1 — Python prototype
+
+Python first. The goal is a working IRC server you can connect to with WeeChat before touching
+any other language. All packages implemented with typed Python (`from __future__ import
+annotations`, `mypy --strict`). Network layer: `irc-net-stdlib` using `socket` and `threading`.
+
+### Phase 2 — All primary languages
+
+Port all packages to Go, TypeScript, Ruby, Elixir, Rust, Kotlin, and Swift. Each language uses
+`irc-net-stdlib` as its starting network implementation. Focus: the IRC logic is identical across
+all languages. The interfaces enforce this.
+
+### Phase 3 — C# and F#
+
+C# and F# join here. They get the full, clean architecture from day one — no legacy
+implementation to refactor. F# is a natural fit for `irc-proto` (discriminated unions for
+commands, pattern matching on message structure).
+
+### Phase 4 — Peeling the doll
+
+Language by language, start replacing `irc-net-stdlib` with deeper implementations. Python goes
+to `irc-net-selectors` (Python `selectors` module). Go goes to `irc-net-epoll` (`x/sys/unix`).
+Rust goes all the way.
+
+---
+
+## Doll Depth by Language
+
+| Level | Python | Go | TypeScript | Ruby | Elixir | Rust | Kotlin | Swift | C# | F# |
+|---|---|---|---|---|---|---|---|---|---|---|
+| stdlib (threads) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| selectors / mio | ✓ | ✓ | ✓ | — | — | ✓ | — | — | — | — |
+| epoll / kqueue | ✓ (Linux) | ✓ | — | — | — | ✓ | — | — | — | — |
+| smoltcp (userspace TCP) | — | — | — | — | — | ✓ | — | — | — | — |
+| unikernel / bare metal | — | — | — | — | — | ✓ | — | — | — | — |
+
+---
+
+## The Unikernel Vision (Long-Term Rust Path)
+
+The end state for the Rust implementation is an IRC server that **is** the operating system.
+No Linux. No Windows. No syscall boundary between application and kernel. One ELF binary that
+boots directly on a hypervisor (QEMU, KVM, or Firecracker).
+
+```
+┌─────────────────────────────────────────────────────┐
+│  ircd  (IRC application — unchanged from Phase 2)   │
+├─────────────────────────────────────────────────────┤
+│  irc-net-smoltcp  (userspace TCP/IP stack)          │
+├─────────────────────────────────────────────────────┤
+│  virtio-net driver  (talks directly to virtual NIC) │
+├─────────────────────────────────────────────────────┤
+│  MMIO / PCI  (hypervisor exposes these registers)   │
+├─────────────────────────────────────────────────────┤
+│  KVM / Firecracker / QEMU hypervisor                │
+├─────────────────────────────────────────────────────┤
+│  Physical hardware                                  │
+└─────────────────────────────────────────────────────┘
+```
+
+The IRC application code never changes. Only the layers beneath `irc-net` are replaced.
+This is the nesting doll principle taken to its logical conclusion.
+
+Key Rust techniques required:
+- `#![no_std]` and `#![no_main]` — no standard library, no OS entry point
+- Custom global allocator (`linked_list_allocator` or `buddy_system_allocator`)
+- Custom panic handler (log to serial port, halt)
+- `x86_64-unknown-none` build target
+- `smoltcp` for TCP/IP (designed for `no_std`)
+- `virtio-net` descriptor ring implementation for NIC access
+- Boot via Multiboot2 header + GRUB, or `rust-osdev/bootloader` crate
+
+See `irc-unikernel.md` for the full spec.
+
+---
+
+## Swap-out Plan for irc-net
+
+| Phase | irc-net implementation | What you learn |
+|---|---|---|
+| 1 | `irc-net-stdlib` (threads) | IRC protocol, framing, server state |
+| 2 | `irc-net-selectors` (event loop) | Reactor pattern, readiness model, non-blocking I/O |
+| 3 | `irc-net-epoll` (raw syscalls) | `epoll_create1`, `epoll_ctl`, `epoll_wait`, edge-triggered bugs |
+| 4 | `irc-net-smoltcp` (userspace TCP) | What an OS TCP stack does; smoltcp Interface, SocketSet |
+| 5 | Unikernel | Boot sequence, allocators, virtio-net, bare metal networking |
+
+Because the `Connection` / `Listener` / `EventLoop` interfaces are stable, each phase is a
+drop-in replacement. The IRC logic — thousands of lines across all languages — never changes.
+
+---
+
+## Related Specs
+
+- [irc-proto.md](irc-proto.md) — Message parsing and serialization
+- [irc-framing.md](irc-framing.md) — Byte stream framing
+- [irc-server.md](irc-server.md) — IRC state machine and command dispatch
+- [irc-net-stdlib.md](irc-net-stdlib.md) — Level 1: stdlib sockets + threads
+- [irc-net-selectors.md](irc-net-selectors.md) — Level 2: event-driven I/O
+- [irc-net-epoll.md](irc-net-epoll.md) — Level 3: raw epoll/kqueue syscalls
+- [irc-net-smoltcp.md](irc-net-smoltcp.md) — Level 4: userspace TCP (Rust)
+- [irc-unikernel.md](irc-unikernel.md) — Level 5: bare metal unikernel (Rust)
+- [ircd.md](ircd.md) — The server program

--- a/code/specs/irc-framing.md
+++ b/code/specs/irc-framing.md
@@ -1,0 +1,228 @@
+# irc-framing — Byte Stream to Line Frames
+
+## Overview
+
+`irc-framing` solves a fundamental TCP problem: TCP is a **byte stream**, not a message stream.
+When you call `recv()` on a socket, you may receive half a message, one full message, or three
+messages and the start of a fourth. There is no inherent concept of a "message boundary" at the
+TCP layer.
+
+IRC defines its own message boundary: every message ends with `\r\n` (carriage return + line
+feed). The `Framer` holds an internal byte buffer, accepts raw bytes as they arrive, and yields
+complete `\r\n`-terminated lines one at a time. The parser (`irc-proto`) never has to deal with
+partial data.
+
+This package is pure: no sockets, no threads, no I/O. It is a stateful buffer transformer.
+
+---
+
+## Layer Position
+
+```
+irc-proto   ← receives complete, \r\n-stripped lines; calls parse()
+     ↑
+irc-framing ← THIS PACKAGE: feed(bytes) / frames() → Iterator[bytes]
+     ↑
+irc-net     ← calls conn.read() and feeds raw bytes upward
+```
+
+`irc-framing` knows nothing about IRC message structure. It only knows about `\r\n` boundaries
+and the 512-byte maximum line length defined in RFC 1459.
+
+---
+
+## Concepts
+
+### The Partial Read Problem
+
+Consider a client sending:
+
+```
+NICK alice\r\nUSER alice 0 * :Alice Smith\r\n
+```
+
+The OS may deliver this in any of these chunks:
+
+```
+recv 1: b"NICK al"
+recv 2: b"ice\r\nUSER alice 0 * :Ali"
+recv 3: b"ce Smith\r\n"
+```
+
+After each `recv`, we `feed()` the bytes to the framer. After recv 1 and 2, no complete line is
+available. After recv 3, two complete lines can be yielded:
+- `b"NICK alice"`
+- `b"USER alice 0 * :Alice Smith"`
+
+### The Multi-Frame Read
+
+The opposite case: a small receive buffer returns multiple complete lines at once. The framer
+must yield them all, in order, before the next `feed()`.
+
+### The 512-Byte Limit
+
+RFC 1459 specifies a maximum line length of 512 bytes **including the CRLF**. Lines longer than
+510 bytes of content must be truncated. The framer enforces this: if the internal buffer grows
+beyond 512 bytes without encountering a `\r\n`, the accumulated bytes are discarded and the
+framer resets its internal state for that line. This prevents memory exhaustion from malformed
+or malicious clients.
+
+### Buffer Strategy
+
+The framer maintains a `bytearray` as its internal accumulation buffer. Appending bytes to a
+`bytearray` is O(1) amortized. Scanning for `\r\n` and slicing out the frame is O(n) in the
+frame length, which is bounded by 512.
+
+A ring buffer would be more memory-efficient for high-throughput scenarios, but a `bytearray` is
+correct, simple, and fast enough for IRC traffic volumes.
+
+---
+
+## Public API
+
+```python
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+
+class Framer:
+    """Stateful byte-stream-to-line-frame converter.
+
+    Feed raw bytes from the socket using feed(). Then iterate frames() to
+    get each complete \\r\\n-terminated line, with the \\r\\n stripped.
+
+    The Framer is NOT thread-safe. Each connection should have its own Framer.
+
+    Example usage:
+        framer = Framer()
+        while True:
+            data = conn.read()
+            if not data:
+                break
+            framer.feed(data)
+            for line in framer.frames():
+                msg = parse(line.decode('utf-8', errors='replace'))
+                handle(msg)
+    """
+
+    def feed(self, data: bytes) -> None:
+        """Append raw bytes to the internal buffer.
+
+        Should be called immediately after each socket read.
+        data may be any length, including zero bytes (which is a no-op).
+        """
+        ...
+
+    def frames(self) -> Iterator[bytes]:
+        """Yield complete lines from the buffer, with \\r\\n stripped.
+
+        Yields zero or more complete frames accumulated since the last call.
+        Partial lines (no \\r\\n yet) are held in the buffer until the next feed().
+        Lines exceeding 510 bytes of content are discarded (not yielded).
+
+        This method is a generator; it is safe to call it after every feed().
+        """
+        ...
+
+    def reset(self) -> None:
+        """Discard all buffered data.
+
+        Call this when a connection is closed or restarted, to ensure no
+        stale bytes from one connection bleed into the next.
+        """
+        ...
+
+    @property
+    def buffer_size(self) -> int:
+        """Number of bytes currently held in the internal buffer.
+
+        Useful for monitoring and testing.
+        """
+        ...
+```
+
+---
+
+## Internal State Machine
+
+The framer can be thought of as a simple state machine with two states:
+
+```
+        feed(data)
+            │
+            ▼
+    ┌───────────────┐   found \r\n     ┌──────────────────────┐
+    │  ACCUMULATING │ ──────────────→  │  YIELD frame, reset  │
+    │  (waiting for │                  │  position to 0, loop │
+    │   \r\n)       │ ←────────────────└──────────────────────┘
+    └───────────────┘   more data in buffer
+            │
+            │ buffer_size >= 512, no \r\n found
+            ▼
+    ┌───────────────┐
+    │  DISCARD line │  (reset buffer, continue)
+    └───────────────┘
+```
+
+Implementation note: a single linear scan of the buffer looking for `b'\r\n'` (or just `b'\n'`
+for leniency with clients that send only LF) is sufficient. RFC 1459 requires `\r\n` but many
+clients only send `\n`. Accept both; strip both.
+
+---
+
+## Handling LF-only Clients
+
+Some IRC clients (particularly simple bots) terminate lines with `\n` only rather than `\r\n`.
+The framer should accept both:
+- `\r\n` → strip both characters, yield frame
+- `\n` (no preceding `\r`) → strip `\n`, yield frame
+- A lone `\r` is not a frame boundary; it is treated as part of the data
+
+---
+
+## Test Strategy
+
+Tests live in `tests/`. Coverage target: 98%+.
+
+### Core frame extraction
+
+- **Single complete frame**: `feed(b"NICK alice\r\n")` → `frames()` yields `b"NICK alice"`
+- **Multiple frames in one feed**: `feed(b"NICK a\r\nUSER a 0 * :A\r\n")` → yields both lines
+- **Split across feeds**: `feed(b"NICK al")` → no frames; `feed(b"ice\r\n")` → yields `b"NICK alice"`
+- **Split CRLF across feeds**: `feed(b"NICK alice\r")` → no frames; `feed(b"\n")` → yields frame
+- **Three feeds one frame**: `feed(b"NI")`, `feed(b"CK")`, `feed(b" a\r\n")` → `b"NICK a"`
+- **Empty feed**: `feed(b"")` → `frames()` yields nothing
+- **Multiple frames then partial**: `feed(b"A\r\nB\r\nC")` → yields `b"A"`, `b"B"`; `b"C"` held
+
+### Max length enforcement
+
+- **Exactly 510 bytes of content + CRLF**: yields the frame normally
+- **511 bytes of content + CRLF**: frame is discarded, not yielded
+- **512+ bytes no CRLF**: buffer grows to limit, discarded; next valid frame after yields normally
+- **Two short frames after an overlong line**: overlong discarded; both short frames yielded
+
+### LF-only handling
+
+- `feed(b"NICK alice\n")` → yields `b"NICK alice"`
+- `feed(b"NICK alice\r\n")` → yields `b"NICK alice"` (CRLF stripped, not just LF)
+
+### Reset
+
+- `feed(b"NICK al")` → `reset()` → `feed(b"USER a\r\n")` → only `b"USER a"` is yielded
+
+### buffer_size property
+
+- After `feed(b"hello")`, `buffer_size == 5`
+- After `frames()` extracts a complete frame, `buffer_size` reflects only remaining bytes
+
+---
+
+## Future Extensions
+
+- **Tagged message support (IRCv3)**: IRC tags can precede the `:prefix` and can be large. The
+  512-byte limit applies only to the non-tag portion. A future `TaggedFramer` would parse the
+  tag section separately and apply the 8192-byte tag limit defined by IRCv3.
+- **Zero-copy variant**: for very high throughput, a ring buffer implementation would avoid
+  copying bytes when yielding frames. The API would yield `memoryview` slices rather than `bytes`.
+- **Metrics hook**: an optional callback `on_overlong(size: int) -> None` for monitoring.

--- a/code/specs/irc-net-epoll.md
+++ b/code/specs/irc-net-epoll.md
@@ -1,0 +1,501 @@
+# irc-net-epoll — Level 3: Raw epoll / kqueue Syscalls
+
+## Overview
+
+`irc-net-epoll` is the third layer of the Russian Nesting Doll. It replaces the `selectors`
+module abstraction with direct calls to the OS's native I/O event notification mechanism:
+`epoll` on Linux, `kqueue` on macOS/BSD.
+
+By removing the `selectors` abstraction, you see exactly what syscalls are being made and why
+the abstraction exists. You learn what `epoll_create1`, `epoll_ctl`, and `epoll_wait` do, what
+edge-triggered mode means and how to use it correctly, and why libraries like `libuv`, `mio`,
+and `netpoll` were written.
+
+The `Connection`, `Listener`, `EventLoop`, and `Handler` interfaces are unchanged. The `ircd`
+program swaps implementations by changing one import.
+
+---
+
+## Layer Position
+
+```
+ircd (program)
+    ↓
+irc-net-epoll           ← THIS SPEC: direct epoll/kqueue syscalls
+    ↓
+epoll (Linux) / kqueue (macOS/BSD) — kernel interface
+    ↓
+Kernel TCP stack
+```
+
+---
+
+## Concepts
+
+### Why epoll Exists
+
+Early Unix servers used `select()`. It takes a bitset of file descriptors and returns another
+bitset indicating which are ready. Problems:
+- Maximum 1024 fds (FD_SETSIZE)
+- O(N) scan of the entire bitset on every call
+- The bitset must be re-initialized from scratch on every call
+
+`poll()` improved on `select()` by using an array instead of a bitset (no 1024 limit, no
+reinitialization) but was still O(N) in the number of watched fds.
+
+`epoll` (Linux 2.5.44, 2002) solved the O(N) problem. The kernel maintains a persistent
+interest set. You register fds once with `epoll_ctl`. On each `epoll_wait` call, the kernel
+returns **only** the fds that are ready — O(ready) not O(watched). A server with 100,000 idle
+connections and 10 active ones returns 10 events, not 100,000.
+
+`kqueue` (BSD/macOS, 2000) has the same design with a different API.
+
+### The Three epoll Syscalls
+
+```c
+// Create an epoll instance. Returns an fd that represents the interest set.
+// EPOLL_CLOEXEC: close the epoll fd on exec() — good practice.
+int epfd = epoll_create1(EPOLL_CLOEXEC);
+
+// Add, modify, or remove an fd from the interest set.
+struct epoll_event ev = {
+    .events = EPOLLIN,      // interested in readability
+    .data.fd = sock_fd,     // user data returned with each event
+};
+epoll_ctl(epfd, EPOLL_CTL_ADD, sock_fd, &ev);
+epoll_ctl(epfd, EPOLL_CTL_MOD, sock_fd, &ev);  // change interest
+epoll_ctl(epfd, EPOLL_CTL_DEL, sock_fd, NULL);  // remove
+
+// Wait for events. Returns number of ready fds.
+struct epoll_event events[MAX_EVENTS];
+int n = epoll_wait(epfd, events, MAX_EVENTS, timeout_ms);
+for (int i = 0; i < n; i++) {
+    int fd = events[i].data.fd;
+    uint32_t flags = events[i].events;
+    // flags & EPOLLIN → readable; flags & EPOLLOUT → writable
+}
+```
+
+### Event Flags
+
+| Flag | Meaning |
+|---|---|
+| `EPOLLIN` | fd is readable (data available or new connection on listener) |
+| `EPOLLOUT` | fd is writable (send buffer has space) |
+| `EPOLLERR` | Error condition (always monitored, even if not requested) |
+| `EPOLLHUP` | Hang-up (peer closed connection) |
+| `EPOLLET` | **Edge-triggered** mode (see below) |
+| `EPOLLONESHOT` | Remove after one event; must re-arm with `EPOLL_CTL_MOD` |
+| `EPOLLRDHUP` | Peer shut down writing (half-close) |
+
+### Level-Triggered vs Edge-Triggered (Critical)
+
+**Level-triggered (LT)** is the default. The kernel reports a fd as ready on every
+`epoll_wait` call as long as the condition holds. If you don't read all available data,
+it reports the fd as ready again next iteration. Safe and simple.
+
+**Edge-triggered (ET)** reports a fd exactly once when its state *changes* from not-ready
+to ready. If you receive 1000 bytes and only read 500, epoll will NOT report that fd as ready
+again until new data arrives. To use ET mode correctly, you must drain the socket completely
+after each notification — loop `recv()` until it returns `EAGAIN` or `EWOULDBLOCK`.
+
+```python
+# Edge-triggered: MUST drain until EAGAIN
+while True:
+    try:
+        data = sock.recv(4096)
+        if not data:
+            break  # Connection closed
+        framer.feed(data)
+    except BlockingIOError:
+        break      # EAGAIN: no more data available right now
+```
+
+Forgetting to drain with ET mode is one of the most common bugs in epoll-based servers.
+The `selectors` module uses LT by default, which is why it does not require this loop.
+
+### The eventfd Trick (Wakeup)
+
+`epoll_wait` blocks the calling thread. To stop the event loop from another thread (e.g. on
+shutdown), you need a way to wake it up. The standard solution is an `eventfd` or `pipe`:
+
+```python
+import os
+# Create a pipe; add the read end to epoll
+r_fd, w_fd = os.pipe()
+epoll.register(r_fd, select.EPOLLIN)
+
+# To wake up the event loop from another thread:
+os.write(w_fd, b"\x00")
+
+# In the event loop, when r_fd is readable: it's a shutdown signal
+```
+
+---
+
+## Platform Split
+
+| OS | Mechanism | Python API | Go API | Rust API |
+|---|---|---|---|---|
+| Linux | `epoll` | `select.epoll()` | `golang.org/x/sys/unix` | `libc::epoll_*` |
+| macOS/BSD | `kqueue` | `select.kqueue()` + `select.kevent()` | `golang.org/x/sys/unix` | `libc::kqueue`, `libc::kevent` |
+| Windows | IOCP | `select.select()` (fallback) | `internal/poll` | `windows-sys` |
+
+Windows uses a fundamentally different model (completion-based IOCP vs readiness-based epoll).
+For this spec, Windows support is limited to the `selectors` abstraction. The raw epoll/kqueue
+implementation is Linux/macOS only.
+
+Use build tags / conditional compilation to select the correct implementation:
+- Python: `if sys.platform == 'linux': use epoll else: use kqueue`
+- Go: `//go:build linux` and `//go:build darwin`
+- Rust: `#[cfg(target_os = "linux")]` and `#[cfg(target_os = "macos")]`
+
+---
+
+## Python Implementation
+
+```python
+from __future__ import annotations
+
+import os
+import select
+import socket
+import sys
+
+from irc_framing import Framer
+from irc_proto import Message, parse, serialize
+
+
+if sys.platform != "linux":
+    raise ImportError("irc-net-epoll requires Linux (epoll)")
+
+
+class EpollConnection:
+    def __init__(self, sock: socket.socket, addr: tuple[str, int], conn_id: ConnId) -> None:
+        self._sock = sock
+        self._addr = addr
+        self._id = conn_id
+        self._write_buf = bytearray()
+        self.framer = Framer()
+        sock.setblocking(False)
+
+    @property
+    def id(self) -> ConnId:
+        return self._id
+
+    @property
+    def peer_addr(self) -> tuple[str, int]:
+        return self._addr
+
+    def fileno(self) -> int:
+        return self._sock.fileno()
+
+    def recv_all(self) -> bytes:
+        """Drain all available data (required for edge-triggered mode)."""
+        chunks: list[bytes] = []
+        while True:
+            try:
+                chunk = self._sock.recv(4096)
+                if not chunk:
+                    return b""      # connection closed
+                chunks.append(chunk)
+            except BlockingIOError:
+                break               # EAGAIN: all data read
+        return b"".join(chunks)
+
+    def enqueue(self, data: bytes) -> None:
+        self._write_buf.extend(data)
+
+    def flush(self) -> bool:
+        """Try to send queued data. Returns True if buffer empty."""
+        while self._write_buf:
+            try:
+                sent = self._sock.send(self._write_buf)
+                del self._write_buf[:sent]
+            except BlockingIOError:
+                return False        # EAGAIN: send buffer full
+        return True
+
+    def close(self) -> None:
+        try:
+            self._sock.close()
+        except OSError:
+            pass
+
+
+class EpollEventLoop:
+    """Event loop using Linux epoll in edge-triggered mode."""
+
+    _MAXEVENTS = 64
+
+    def __init__(self) -> None:
+        self._conns: dict[int, EpollConnection] = {}   # fd → conn
+        self._id_to_fd: dict[ConnId, int] = {}
+        self._next_id = 1
+        self._running = False
+
+    def run(self, listener: EpollListener, handler: Handler) -> None:
+        self._running = True
+
+        # Create epoll instance
+        ep = select.epoll()
+
+        # Wakeup pipe for graceful shutdown
+        r_fd, w_fd = os.pipe()
+        os.set_inheritable(r_fd, False)
+        os.set_inheritable(w_fd, False)
+        self._wakeup_w = w_fd
+
+        # Register listener and wakeup pipe in edge-triggered mode
+        # EPOLLIN | EPOLLET: edge-triggered readability
+        ep.register(listener.fileno(), select.EPOLLIN | select.EPOLLET)
+        ep.register(r_fd, select.EPOLLIN)
+
+        while self._running:
+            try:
+                events = ep.poll(timeout=1.0, maxevents=self._MAXEVENTS)
+            except InterruptedError:
+                continue
+
+            for fd, event_mask in events:
+                if fd == r_fd:
+                    # Shutdown signal
+                    self._running = False
+                    break
+
+                if fd == listener.fileno():
+                    # One or more new connections (must drain due to ET)
+                    while True:
+                        try:
+                            conn = listener.accept_conn(ConnId(self._next_id))
+                            self._next_id += 1
+                            self._conns[conn.fileno()] = conn
+                            self._id_to_fd[conn.id] = conn.fileno()
+                            ep.register(
+                                conn.fileno(),
+                                select.EPOLLIN | select.EPOLLET,
+                            )
+                            handler.on_connect(conn.id)
+                        except BlockingIOError:
+                            break   # no more pending connections
+                    continue
+
+                conn = self._conns.get(fd)
+                if conn is None:
+                    continue
+
+                if event_mask & (select.EPOLLERR | select.EPOLLHUP):
+                    self._close_conn(ep, conn, handler)
+                    continue
+
+                if event_mask & select.EPOLLIN:
+                    data = conn.recv_all()
+                    if not data:
+                        self._close_conn(ep, conn, handler)
+                        continue
+                    conn.framer.feed(data)
+                    for frame in conn.framer.frames():
+                        msg = parse(frame.decode("utf-8", errors="replace"))
+                        responses = handler.on_message(conn.id, msg)
+                        self._dispatch(ep, responses)
+
+                if event_mask & select.EPOLLOUT:
+                    drained = conn.flush()
+                    if drained:
+                        ep.modify(fd, select.EPOLLIN | select.EPOLLET)
+
+        ep.close()
+        os.close(r_fd)
+        os.close(w_fd)
+
+    def stop(self) -> None:
+        self._running = False
+        if hasattr(self, "_wakeup_w"):
+            os.write(self._wakeup_w, b"\x00")
+
+    def _dispatch(
+        self,
+        ep: select.epoll,
+        responses: list[tuple[ConnId, Message]],
+    ) -> None:
+        for target_id, msg in responses:
+            fd = self._id_to_fd.get(target_id)
+            if fd is None:
+                continue
+            conn = self._conns.get(fd)
+            if conn is None:
+                continue
+            conn.enqueue(serialize(msg))
+            # Arm for writability to flush the buffer
+            ep.modify(fd, select.EPOLLIN | select.EPOLLOUT | select.EPOLLET)
+
+    def _close_conn(
+        self,
+        ep: select.epoll,
+        conn: EpollConnection,
+        handler: Handler,
+    ) -> None:
+        ep.unregister(conn.fileno())
+        responses = handler.on_disconnect(conn.id)
+        self._dispatch(ep, responses)
+        conn.close()
+        del self._conns[conn.fileno()]
+        self._id_to_fd.pop(conn.id, None)
+```
+
+---
+
+## Go Implementation Sketch
+
+```go
+//go:build linux
+
+package ircdepoll
+
+import (
+    "golang.org/x/sys/unix"
+    "net"
+)
+
+func runEpoll(ln net.Listener, handler Handler) error {
+    epfd, err := unix.EpollCreate1(unix.EPOLL_CLOEXEC)
+    if err != nil {
+        return err
+    }
+    defer unix.Close(epfd)
+
+    lnFd := listenerFd(ln)
+    if err := unix.EpollCtl(epfd, unix.EPOLL_CTL_ADD, lnFd, &unix.EpollEvent{
+        Events: unix.EPOLLIN | unix.EPOLLET,
+        Fd:     int32(lnFd),
+    }); err != nil {
+        return err
+    }
+
+    events := make([]unix.EpollEvent, 64)
+    for {
+        n, err := unix.EpollWait(epfd, events, 1000 /* ms */)
+        if err != nil {
+            if err == unix.EINTR {
+                continue
+            }
+            return err
+        }
+        for i := 0; i < n; i++ {
+            fd := int(events[i].Fd)
+            ev := events[i].Events
+            if fd == lnFd {
+                acceptAll(epfd, ln, handler)
+            } else {
+                handleConn(epfd, fd, ev, handler)
+            }
+        }
+    }
+}
+```
+
+---
+
+## Rust Implementation Sketch
+
+```rust
+use libc::{
+    epoll_create1, epoll_ctl, epoll_event, epoll_wait,
+    EPOLL_CLOEXEC, EPOLL_CTL_ADD, EPOLL_CTL_DEL, EPOLLET, EPOLLIN,
+};
+
+fn run_epoll(listener_fd: i32, handler: &mut dyn Handler) {
+    let epfd = unsafe { epoll_create1(EPOLL_CLOEXEC) };
+    assert!(epfd >= 0);
+
+    let mut ev = epoll_event {
+        events: (EPOLLIN | EPOLLET) as u32,
+        u64: listener_fd as u64,
+    };
+    unsafe { epoll_ctl(epfd, EPOLL_CTL_ADD, listener_fd, &mut ev) };
+
+    let mut events = vec![epoll_event { events: 0, u64: 0 }; 64];
+    loop {
+        let n = unsafe {
+            epoll_wait(epfd, events.as_mut_ptr(), events.len() as i32, 1000)
+        };
+        for i in 0..n as usize {
+            let fd = events[i].u64 as i32;
+            if fd == listener_fd {
+                accept_all(epfd, listener_fd, handler);
+            } else {
+                handle_conn(epfd, fd, events[i].events, handler);
+            }
+        }
+    }
+}
+```
+
+---
+
+## kqueue (macOS/BSD) Sketch
+
+```python
+import select
+
+kq = select.kqueue()
+
+# Register listener for readability
+kq.control([
+    select.kevent(
+        listener_fd,
+        filter=select.KQ_FILTER_READ,
+        flags=select.KQ_EV_ADD | select.KQ_EV_ENABLE,
+    )
+], 0)
+
+# Wait for events
+events = kq.control(None, 64, timeout=1.0)
+for event in events:
+    fd = event.ident
+    if event.filter == select.KQ_FILTER_READ:
+        if fd == listener_fd:
+            accept_new_connection()
+        else:
+            read_from_connection(fd)
+    elif event.filter == select.KQ_FILTER_WRITE:
+        flush_write_buffer(fd)
+```
+
+---
+
+## What You Learn at This Layer
+
+| Question | Answer revealed here |
+|---|---|
+| Why does `selectors` exist? | To hide the platform difference between `epoll` and `kqueue` |
+| What is EAGAIN? | The kernel's way of saying "no more data without blocking" |
+| Why must ET mode drain? | The kernel fires once per state change; unread data is invisible until new data arrives |
+| What is `EPOLLONESHOT`? | An alternative to ET: fire once, manually re-arm with `EPOLL_CTL_MOD` |
+| What is `eventfd`? | A kernel object that can be included in epoll's interest set for cross-thread signaling |
+| Why does nginx use multiple workers? | `epoll_wait` is not shared across processes without `EPOLLEXCLUSIVE` |
+
+---
+
+## Test Strategy
+
+Same interface contract tests as `irc-net-stdlib` and `irc-net-selectors`. Additional tests:
+
+- **ET drain correctness**: send 512 KB to a connection in a tight loop. Verify all data is
+  received. This would fail if the event loop doesn't drain correctly in ET mode.
+- **Edge-triggered EPOLLOUT**: fill a connection's send buffer. Verify the event loop buffers
+  and retries rather than crashing or losing data.
+- **EAGAIN on accept**: simulate rapid burst of connections (> 64 simultaneous). Verify all are
+  accepted (the listener accept loop drains until EAGAIN).
+- **Linux-only**: test suite is skipped on macOS/Windows unless kqueue variant is present.
+
+---
+
+## Future: Peeling to irc-net-smoltcp
+
+At this level, we are calling OS TCP syscalls directly. The kernel is still managing the TCP
+state machine (SYN/SYN-ACK/ACK handshake, retransmission, flow control, congestion control).
+
+The next layer, `irc-net-smoltcp`, removes the OS TCP stack entirely. `smoltcp` implements
+TCP/IP in pure Rust userspace. The kernel is bypassed for all TCP logic — only raw Ethernet
+frames cross the kernel boundary (via a TUN/TAP device or a raw socket).

--- a/code/specs/irc-net-selectors.md
+++ b/code/specs/irc-net-selectors.md
@@ -1,0 +1,349 @@
+# irc-net-selectors — Level 2: Event-Driven I/O (Reactor Pattern)
+
+## Overview
+
+`irc-net-selectors` is the second layer of the Russian Nesting Doll. It replaces the
+one-thread-per-connection model of `irc-net-stdlib` with a **single-threaded event loop**
+that can handle thousands of connections using OS readiness notifications.
+
+The key insight: most IRC connections are idle most of the time. A server with 10,000 connected
+clients has 9,990 connections doing nothing at any given moment. Allocating a thread (and its
+8 MB stack) for each idle connection wastes memory. Instead, one thread registers interest in
+all file descriptors (fds) and asks the OS: "wake me up when any of them have data."
+
+This is the **reactor pattern**. It is the foundation of every high-performance network server:
+Node.js, nginx, Redis, Erlang's scheduler, and `tokio` are all reactors underneath.
+
+`irc-net-selectors` implements the same `Connection`, `Listener`, `EventLoop`, and `Handler`
+interfaces defined in `irc-net-stdlib`. The `ircd` program swaps implementations by changing
+one import. The IRC logic is untouched.
+
+---
+
+## Layer Position
+
+```
+ircd (program)
+    ↓
+irc-net-selectors       ← THIS SPEC: event loop using OS selector
+    ↓
+OS selector (select/poll/epoll/kqueue — abstracted by language stdlib)
+    ↓
+Kernel TCP stack
+```
+
+This layer still uses the OS selector abstraction (Python `selectors`, Go `net.Listener` +
+goroutine pool, Rust `mio`). The raw epoll/kqueue syscalls are exposed in the next layer
+(`irc-net-epoll`).
+
+---
+
+## Concepts
+
+### The Readiness Model
+
+In the thread model, each thread blocks on `recv()`, waiting for data. In the readiness model,
+a single thread asks the OS a different question:
+
+> "Which of these file descriptors are ready to be read without blocking?"
+
+The OS maintains readiness state for every open fd. When data arrives on a socket, the kernel
+marks it as readable. The selector returns a list of ready fds. The event loop reads from each
+one, then loops back to ask again.
+
+```
+event loop
+    │
+    ▼
+selector.select(timeout=1.0)   ← blocks until at least one fd is ready
+    │
+    ├── fd 5 is readable → read from connection 5
+    ├── fd 12 is readable → read from connection 12
+    └── fd 3 is readable → this is the listener → accept() new connection
+    │
+    ▼
+selector.select(timeout=1.0)   ← repeat
+```
+
+### Level-Triggered vs Edge-Triggered
+
+The OS selector has two notification modes:
+
+- **Level-triggered** (default in `select()`, `poll()`, `epoll` LT mode): the selector keeps
+  returning a fd as ready as long as there is unread data. Safe: if you don't read all the data,
+  the fd stays in the ready set and you'll process it next iteration.
+
+- **Edge-triggered** (epoll `EPOLLET`): the selector notifies once when readiness *changes* (from
+  not-ready to ready). You MUST drain all available data in one shot (loop until `EAGAIN`),
+  otherwise you'll never be notified again. Faster but requires careful implementation.
+
+The `selectors` module uses level-triggered by default. `irc-net-epoll` introduces edge-triggered
+mode.
+
+### Non-blocking Writes
+
+In the single-threaded model, blocking on a write would freeze the entire event loop. Writes
+should use non-blocking mode and, if the send buffer is full (`EAGAIN`), queue the data for
+later. For IRC servers with modest traffic, writes rarely block — but the implementation must
+handle it.
+
+A simple write buffer per connection:
+
+```python
+pending_writes: dict[ConnId, bytearray] = {}
+
+def send_to(conn_id: ConnId, data: bytes) -> None:
+    pending_writes[conn_id].extend(data)
+    sel.modify(fds[conn_id], selectors.EVENT_READ | selectors.EVENT_WRITE)
+
+# in the event loop, when a fd is writable:
+buf = pending_writes[conn_id]
+sent = conn.sock.send(buf)
+del buf[:sent]
+if not buf:
+    sel.modify(fds[conn_id], selectors.EVENT_READ)  # stop watching for writes
+```
+
+---
+
+## Public API
+
+The interfaces are identical to those in `irc-net-stdlib`. Only the concrete class names differ.
+
+```python
+from __future__ import annotations
+
+import selectors
+import socket
+import threading
+from collections.abc import Iterator
+
+from irc_framing import Framer
+from irc_proto import Message, parse, serialize
+
+
+class SelectorsConnection:
+    """A non-blocking TCP connection managed by the selector event loop."""
+
+    def __init__(self, sock: socket.socket, addr: tuple[str, int], conn_id: ConnId) -> None:
+        self._sock = sock
+        self._addr = addr
+        self._id = conn_id
+        self._write_buf = bytearray()
+        self._framer = Framer()
+        sock.setblocking(False)
+
+    @property
+    def id(self) -> ConnId: ...
+
+    @property
+    def peer_addr(self) -> tuple[str, int]: ...
+
+    def read_available(self) -> bytes:
+        """Read all available data without blocking. Returns b"" on close."""
+        chunks: list[bytes] = []
+        while True:
+            try:
+                chunk = self._sock.recv(4096)
+                if not chunk:
+                    return b""
+                chunks.append(chunk)
+            except BlockingIOError:
+                break
+        return b"".join(chunks)
+
+    def enqueue_write(self, data: bytes) -> None:
+        """Queue bytes for writing. Actual send happens in the event loop."""
+        self._write_buf.extend(data)
+
+    def flush_writes(self) -> bool:
+        """Attempt to send buffered data. Returns True if buffer drained."""
+        if not self._write_buf:
+            return True
+        try:
+            sent = self._sock.send(self._write_buf)
+            del self._write_buf[:sent]
+        except BlockingIOError:
+            pass
+        return len(self._write_buf) == 0
+
+    def close(self) -> None: ...
+
+
+class SelectorsListener:
+    def __init__(self, host: str, port: int) -> None:
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._sock.setblocking(False)
+        self._sock.bind((host, port))
+        self._sock.listen(128)
+
+    def fileno(self) -> int:
+        return self._sock.fileno()
+
+    def accept_connection(self, next_id: ConnId) -> SelectorsConnection:
+        sock, addr = self._sock.accept()
+        return SelectorsConnection(sock, addr, next_id)
+
+    def close(self) -> None: ...
+
+
+class SelectorsEventLoop:
+    """Single-threaded event loop using Python's selectors module.
+
+    Handles thousands of connections with one thread by using OS readiness
+    notifications. No thread spawned per connection.
+    """
+
+    def __init__(self) -> None:
+        self._running = False
+        self._conns: dict[ConnId, SelectorsConnection] = {}
+        self._next_id = 1
+
+    def run(self, listener: SelectorsListener, handler: Handler) -> None: ...
+
+    def stop(self) -> None:
+        self._running = False
+```
+
+---
+
+## Event Loop Internals
+
+```python
+def run(self, listener: SelectorsListener, handler: Handler) -> None:
+    self._running = True
+    sel = selectors.DefaultSelector()
+
+    # Register the listener socket for read events (new connections)
+    sel.register(listener.fileno(), selectors.EVENT_READ, data="listener")
+
+    while self._running:
+        events = sel.select(timeout=1.0)
+        for key, mask in events:
+
+            if key.data == "listener":
+                # New connection
+                conn_id = ConnId(self._next_id)
+                self._next_id += 1
+                conn = listener.accept_connection(conn_id)
+                self._conns[conn_id] = conn
+                sel.register(conn.fileno(), selectors.EVENT_READ, data=conn_id)
+                handler.on_connect(conn_id)
+
+            else:
+                conn_id: ConnId = key.data
+                conn = self._conns[conn_id]
+
+                if mask & selectors.EVENT_READ:
+                    data = conn.read_available()
+                    if not data:
+                        # Connection closed
+                        sel.unregister(conn.fileno())
+                        responses = handler.on_disconnect(conn_id)
+                        self._dispatch(responses)
+                        conn.close()
+                        del self._conns[conn_id]
+                        continue
+                    conn._framer.feed(data)
+                    for frame in conn._framer.frames():
+                        msg = parse(frame.decode("utf-8", errors="replace"))
+                        responses = handler.on_message(conn_id, msg)
+                        self._dispatch(responses)
+
+                if mask & selectors.EVENT_WRITE:
+                    drained = conn.flush_writes()
+                    if drained:
+                        # No more pending writes; stop watching for writability
+                        sel.modify(conn.fileno(), selectors.EVENT_READ, data=conn_id)
+
+    sel.close()
+
+def _dispatch(self, responses: list[tuple[ConnId, Message]]) -> None:
+    for target_id, msg in responses:
+        target = self._conns.get(target_id)
+        if target:
+            target.enqueue_write(serialize(msg))
+            # Register for write readiness if not already
+            sel.modify(target.fileno(),
+                       selectors.EVENT_READ | selectors.EVENT_WRITE,
+                       data=target_id)
+```
+
+Key observation: because the event loop is single-threaded, `handler.on_message()` is always
+called from the same thread. **No server lock needed.** This eliminates the bottleneck from
+`irc-net-stdlib`.
+
+---
+
+## Language Mappings
+
+| Language | Selector API | Notes |
+|---|---|---|
+| Python | `selectors.DefaultSelector` | Uses `epoll` on Linux, `kqueue` on macOS, `select` on Windows |
+| Go | `net.Listener` + goroutine-per-conn + channel fan-out | Go's runtime has its own poller under goroutines; "selectors" in Go means goroutine pool |
+| TypeScript (Node) | Already single-threaded event loop | `net.createServer()` with `on('data')` callbacks IS the reactor |
+| Rust | `mio::Poll` | Direct epoll/kqueue abstraction; no async runtime |
+| Ruby | `IO.select` or `nio4r` gem | Ruby GIL makes this more important than Go goroutines |
+
+### Go Note
+
+Go's goroutines are not OS threads; the runtime multiplexes them onto a small thread pool using
+its own internal poller (which uses `epoll` on Linux). A goroutine-per-connection in Go is
+already more efficient than a thread-per-connection in Python. "Level 2" for Go means using
+explicit channel-based fan-out rather than per-goroutine locks, or using `net.Poller` directly.
+
+### Node.js Note
+
+Node.js is inherently single-threaded and event-driven. The `irc-net-stdlib` TypeScript
+implementation already used the event loop (no threads). For TypeScript, "Level 2" means
+explicitly structuring the code around the event loop (`EventEmitter`, `Readable` streams)
+rather than using higher-level abstractions like `readline`.
+
+---
+
+## Trade-offs vs irc-net-stdlib
+
+| Concern | stdlib | selectors |
+|---|---|---|
+| Concurrency model | One thread per connection | Single thread, OS multiplexing |
+| Memory per connection | ~8 MB (stack) | ~few KB (write buffer, framer) |
+| Scalability | ~1,000 connections | ~10,000–100,000 connections |
+| Complexity | Simple: threads are familiar | Moderate: callback/event discipline needed |
+| Latency | Low (thread runs immediately) | Low (selector returns quickly) |
+| Handler thread safety | Requires lock | None needed (single thread) |
+| Write blocking | Blocks calling thread | Buffered; event loop retries |
+
+---
+
+## Test Strategy
+
+Use the same test suite as `irc-net-stdlib` — the echo server, concurrent connections, and
+graceful shutdown tests. The interface contract is identical; only the mechanism differs.
+
+### Additional tests for selectors
+
+- **No threads spawned**: after connecting 100 clients, assert `threading.active_count()` is 1
+  (only the main thread).
+- **Write backpressure**: create a slow-consumer connection (don't read from it). Send it 1 MB
+  of data. Verify the event loop does not block and other connections continue operating normally.
+- **Selector re-registration**: verify that after a write buffer is drained, the fd is removed
+  from `EVENT_WRITE` interest (prevents busy-loop).
+- **Rapid connect/disconnect**: connect and immediately disconnect 1000 connections. Verify no
+  resource leaks (`len(self._conns) == 0` after all disconnects).
+
+---
+
+## Future: Peeling to irc-net-epoll
+
+The `selectors` module is an abstraction over the OS's native event notification:
+- On Linux: `epoll`
+- On macOS/BSD: `kqueue`
+- On Windows: `select` (limited)
+
+The next layer (`irc-net-epoll`) removes this abstraction and calls `epoll_create1`,
+`epoll_ctl`, and `epoll_wait` directly. The interface remains the same. The swap is one import
+change in `ircd`.
+
+What you learn by peeling: why the `selectors` abstraction exists, what `EPOLLIN`, `EPOLLOUT`,
+and `EPOLLET` mean at the syscall level, and what bugs edge-triggered mode introduces.

--- a/code/specs/irc-net-smoltcp.md
+++ b/code/specs/irc-net-smoltcp.md
@@ -1,0 +1,297 @@
+# irc-net-smoltcp — Level 4: Userspace TCP via smoltcp (Rust Only)
+
+## Overview
+
+`irc-net-smoltcp` is the fourth layer of the Russian Nesting Doll and the deepest layer
+available before the unikernel. It bypasses the OS TCP stack entirely.
+
+In all previous layers, the Linux kernel managed TCP: the SYN/SYN-ACK/ACK handshake,
+retransmission timers, sliding window flow control, congestion control (CUBIC, BBR), and
+TIME_WAIT state. Our code called `recv()` and `send()` — the kernel did the rest.
+
+Here, the kernel does nothing but forward raw Ethernet frames. **smoltcp** — a TCP/IP stack
+written in pure Rust, designed for `no_std` environments — implements every TCP and IP layer
+behaviour in userspace. The IRC application code is completely unchanged. Only the network layer
+below the `Connection` interface is replaced.
+
+This spec is **Rust only**. Python, Go, and other languages cannot reach this level because
+their runtimes are tightly coupled to the OS TCP stack.
+
+---
+
+## Layer Position
+
+```
+ircd (program)
+    ↓
+irc-net-smoltcp         ← THIS SPEC: userspace TCP via smoltcp
+    ↓
+smoltcp (TCP/IP in userspace)
+    ↓
+TUN/TAP device (testing) or raw socket (production)
+    ↓
+Kernel: forwards Ethernet frames, nothing more
+```
+
+In the unikernel (next layer), the TUN/TAP device is replaced by a virtio-net driver that
+communicates directly with the hypervisor's virtual NIC, bypassing the kernel entirely.
+
+---
+
+## Concepts
+
+### What a Userspace TCP Stack Does
+
+The OS kernel provides two things for TCP networking:
+1. A TCP/IP protocol implementation (connection state machine, retransmission, etc.)
+2. An API to access it (BSD socket calls: `socket`, `bind`, `listen`, `accept`, `recv`, `send`)
+
+A userspace TCP stack provides item (1) without item (2). It reads raw bytes from the network
+device, parses Ethernet/IP/TCP headers itself, and calls your application code directly.
+
+Benefits of a userspace TCP stack:
+- **No syscall overhead** per `recv`/`send` call (critical in unikernel mode)
+- **Deterministic behaviour** (no kernel scheduler interference)
+- **Full control** over TCP parameters (initial window size, congestion algorithm, timeouts)
+- **`no_std` compatible** (required for bare-metal/unikernel operation)
+
+### smoltcp Architecture
+
+```
+Application code (your IRC server)
+    ↓ TcpSocket::recv() / TcpSocket::send()
+SocketSet  ← holds all active TCP sockets
+    ↓ Interface::poll()
+smoltcp IP/TCP layer  ← parses/generates headers; manages state machines
+    ↓ Device trait
+TUN/TAP device (Linux) or virtio-net (unikernel)
+    ↓
+Raw Ethernet frames on the wire
+```
+
+The key API entry point is `Interface::poll()`. You call it in a tight loop (or after each
+network event). It:
+1. Reads available Ethernet frames from the device
+2. Demultiplexes them to the correct TCP socket
+3. Advances TCP state machines (retransmission, ACKs, connection establishment)
+4. Calls application code when data is ready or when new connections arrive
+
+### smoltcp Key Types
+
+```rust
+use smoltcp::iface::{Config, Interface, SocketSet};
+use smoltcp::socket::tcp::{Socket as TcpSocket, SocketBuffer};
+use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr, Ipv4Address};
+use smoltcp::time::Instant;
+
+// A device represents the "wire" — where Ethernet frames come and go.
+// smoltcp provides a TunTapInterface for Linux development and testing.
+// In the unikernel, you write your own Device implementation over virtio-net.
+use smoltcp::phy::{Device, TunTapInterface, Medium};
+```
+
+### TUN vs TAP
+
+| Feature | TUN | TAP |
+|---|---|---|
+| Layer | Network (IP) | Data link (Ethernet) |
+| Frames | IP packets | Ethernet frames |
+| Use with smoltcp | Not directly (smoltcp expects Ethernet) | Yes — smoltcp operates at Layer 2 |
+| Setup | `ip tuntap add mode tun` | `ip tuntap add mode tap` |
+
+smoltcp requires a TAP device on Linux (it speaks Ethernet). The test harness creates a TAP
+interface, assigns it an IP address, and the IRC server binds to that address.
+
+---
+
+## smoltcp Event Loop
+
+```rust
+use smoltcp::iface::{Config, Interface, SocketSet};
+use smoltcp::phy::{TunTapInterface, Medium};
+use smoltcp::socket::tcp::{Socket as TcpSocket, SocketBuffer, State};
+use smoltcp::time::Instant;
+use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr, Ipv4Address};
+use std::collections::HashMap;
+
+const LISTEN_PORT: u16 = 6667;
+const BUF_SIZE: usize = 65536;
+
+fn run(handler: &mut dyn Handler) {
+    // 1. Open the TAP device (must already exist: `ip tuntap add dev tap0 mode tap`)
+    let mut device = TunTapInterface::new("tap0", Medium::Ethernet).unwrap();
+
+    // 2. Configure the interface
+    let config = Config::new(EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).into());
+    let mut iface = Interface::new(config, &mut device, Instant::now());
+    iface.update_ip_addrs(|ip_addrs| {
+        ip_addrs.push(IpCidr::new(IpAddress::v4(192, 168, 69, 1), 24)).unwrap();
+    });
+
+    // 3. Create a listening socket
+    let mut sockets = SocketSet::new(vec![]);
+    let listener_handle = {
+        let rx_buf = SocketBuffer::new(vec![0u8; BUF_SIZE]);
+        let tx_buf = SocketBuffer::new(vec![0u8; BUF_SIZE]);
+        let mut sock = TcpSocket::new(rx_buf, tx_buf);
+        sock.listen(LISTEN_PORT).unwrap();
+        sockets.add(sock)
+    };
+
+    let mut conn_map: HashMap<smoltcp::socket::SocketHandle, ConnState> = HashMap::new();
+    let mut next_id: u32 = 0;
+
+    loop {
+        // 4. Advance smoltcp state machines; read/write device frames
+        let timestamp = Instant::now();
+        iface.poll(timestamp, &mut device, &mut sockets);
+
+        // 5. Check the listener socket for new connections
+        {
+            let sock = sockets.get_mut::<TcpSocket>(listener_handle);
+            if sock.state() == State::Established && !conn_map.contains_key(&listener_handle) {
+                // New connection accepted
+                let conn_id = ConnId(next_id);
+                next_id += 1;
+                conn_map.insert(listener_handle, ConnState::new(conn_id));
+                handler.on_connect(conn_id);
+
+                // Create a new listening socket to accept the next connection
+                // (smoltcp: one TcpSocket = one connection once established)
+                let rx_buf = SocketBuffer::new(vec![0u8; BUF_SIZE]);
+                let tx_buf = SocketBuffer::new(vec![0u8; BUF_SIZE]);
+                let mut new_listener = TcpSocket::new(rx_buf, tx_buf);
+                new_listener.listen(LISTEN_PORT).unwrap();
+                sockets.add(new_listener);
+            }
+        }
+
+        // 6. Poll all established connections for data
+        for (handle, state) in conn_map.iter_mut() {
+            let sock = sockets.get_mut::<TcpSocket>(*handle);
+            if sock.can_recv() {
+                let mut buf = [0u8; 4096];
+                let n = sock.recv_slice(&mut buf).unwrap();
+                state.framer.feed(&buf[..n]);
+                for frame in state.framer.frames() {
+                    if let Ok(msg) = parse(std::str::from_utf8(&frame).unwrap_or("")) {
+                        let responses = handler.on_message(state.conn_id, msg);
+                        for (target_id, resp) in responses {
+                            // find the handle for target_id and write to it
+                            enqueue_write(&mut sockets, &conn_map, target_id, serialize(&resp));
+                        }
+                    }
+                }
+            }
+            if !sock.is_open() {
+                let responses = handler.on_disconnect(state.conn_id);
+                // dispatch responses...
+            }
+        }
+
+        // 7. Determine when to call poll() next (smoltcp's timer)
+        let wait_duration = iface.poll_delay(Instant::now(), &sockets);
+        std::thread::sleep(wait_duration.unwrap_or(smoltcp::time::Duration::from_millis(1)));
+    }
+}
+```
+
+### Key Difference from epoll: The Poll Model
+
+With epoll, the kernel notifies us when data arrives. We are passive — we wait for the OS.
+
+With smoltcp, **we drive the TCP state machine**. We call `Interface::poll()` ourselves, on
+a schedule. smoltcp tells us the next deadline (via `poll_delay()`), and we sleep until then.
+This is the completion model vs the readiness model: instead of "wake me when ready," we say
+"I'll check back in Xms."
+
+In the unikernel, this poll loop replaces the OS entirely. There is no scheduler to sleep in —
+the poll loop spins until the NIC interrupt fires.
+
+---
+
+## Mapping smoltcp to the Stable Interfaces
+
+smoltcp's `TcpSocket` is not an fd. It cannot be `close()`d in the POSIX sense. The mapping
+requires a wrapper:
+
+```rust
+pub struct SmoltcpConnection {
+    handle: smoltcp::socket::SocketHandle,
+    id: ConnId,
+    peer_addr: (String, u16),
+    write_buf: Vec<u8>,
+}
+
+impl SmoltcpConnection {
+    /// Called by the event loop to flush pending writes into the socket buffer.
+    pub fn flush(&mut self, sockets: &mut SocketSet) {
+        let sock = sockets.get_mut::<TcpSocket>(self.handle);
+        while !self.write_buf.is_empty() && sock.can_send() {
+            let sent = sock.send_slice(&self.write_buf).unwrap_or(0);
+            self.write_buf.drain(..sent);
+        }
+    }
+}
+```
+
+The `EventLoop` holds the `SocketSet` and `Interface`. The `Connection` protocol is satisfied
+by `SmoltcpConnection`, which delegates to the socket via the event loop's `SocketSet`.
+
+---
+
+## Testing with TUN/TAP
+
+### Setup (Linux only)
+
+```bash
+# Create a TAP device (requires root or CAP_NET_ADMIN)
+sudo ip tuntap add dev tap0 mode tap user $USER
+sudo ip addr add 192.168.69.2/24 dev tap0
+sudo ip link set tap0 up
+
+# The IRC server binds to 192.168.69.1 via smoltcp
+# Connect a real IRC client from the host:
+weechat -r "/connect 192.168.69.1 6667"
+```
+
+### Integration Test
+
+The test harness:
+1. Creates a TAP device via `ioctl` (no sudo needed in tests with user namespace)
+2. Starts the smoltcp event loop in a thread
+3. Opens a real `TcpStream` to `192.168.69.1:6667` from the host kernel
+4. Sends IRC registration messages
+5. Asserts the welcome sequence is received
+6. Sends `JOIN #test` and `PRIVMSG #test :hello`
+7. Verifies the echo is received
+
+This tests the full stack: host kernel → TAP → smoltcp → irc-framing → irc-proto → irc-server.
+
+---
+
+## What You Learn at This Layer
+
+| Question | Answer revealed here |
+|---|---|
+| What does the OS kernel do for TCP? | Everything: handshake, retransmission, flow control — now you do it |
+| What is the TCP state machine? | smoltcp's `State` enum: `Listen`, `SynReceived`, `Established`, `FinWait1`, etc. |
+| What is a socket buffer? | `SocketBuffer` — you size it explicitly; the OS normally hides this |
+| What is `poll_delay()`? | The time until the next TCP timer fires (retransmission timeout, keepalive, etc.) |
+| What are Ethernet frames? | The raw bytes that flow over the TAP device; smoltcp parses ARP, IPv4, TCP headers |
+| Why does `no_std` matter? | smoltcp works here; it will also work in the unikernel where `std` is unavailable |
+
+---
+
+## Future: Peeling to the Unikernel
+
+In this layer, the TAP device is still managed by the Linux kernel. To remove the kernel
+entirely:
+
+1. Replace `TunTapInterface` with a custom `Device` implementation that reads/writes virtio-net
+   descriptor rings directly.
+2. Remove all `std::thread::sleep` calls — the poll loop runs continuously, woken by NIC interrupts.
+3. Compile with `#![no_std]`, `#![no_main]`, and a custom allocator.
+4. Boot as a VM image.
+
+See `irc-unikernel.md` for the full spec.

--- a/code/specs/irc-net-stdlib.md
+++ b/code/specs/irc-net-stdlib.md
@@ -1,0 +1,357 @@
+# irc-net-stdlib — Level 1: Standard Library Sockets + Threads
+
+## Overview
+
+`irc-net-stdlib` is the first and outermost layer of the Russian Nesting Doll. It implements the
+stable `Connection`, `Listener`, and `EventLoop` interfaces using only each language's standard
+library: OS-managed TCP sockets and one thread per accepted connection.
+
+This is the simplest possible implementation. It is not the most efficient — one thread per
+connection does not scale beyond a few thousand connections. But it requires no third-party
+dependencies, works on all platforms, and is correct. Every language port starts here.
+
+Once this layer is working, `irc-net-selectors` peels back the first layer of the doll.
+
+---
+
+## Layer Position
+
+```
+ircd (program)
+    ↓ calls run()
+irc-net-stdlib          ← THIS SPEC: Connection, Listener, EventLoop
+    ↓ OS manages
+TCP sockets (kernel)
+    ↓
+Physical network
+```
+
+---
+
+## The Stable Interfaces
+
+These interfaces are defined here and shared across all `irc-net-*` specs. They do not change
+as implementations are swapped. The `ircd` program imports only these types, never a concrete
+implementation class directly.
+
+```python
+from __future__ import annotations
+
+from typing import Protocol, NewType
+
+
+ConnId = NewType('ConnId', int)
+
+
+class Connection(Protocol):
+    """A single accepted TCP connection.
+
+    read() returns raw bytes from the socket.
+    Returns b"" when the connection has been closed by the peer.
+    write() sends bytes to the peer. May block if the send buffer is full.
+    close() closes the connection. Safe to call multiple times.
+    """
+
+    @property
+    def id(self) -> ConnId: ...
+
+    @property
+    def peer_addr(self) -> tuple[str, int]: ...
+
+    def read(self) -> bytes: ...
+
+    def write(self, data: bytes) -> None: ...
+
+    def close(self) -> None: ...
+
+
+class Listener(Protocol):
+    """A bound, listening TCP socket.
+
+    accept() blocks until a new connection arrives, then returns a Connection.
+    close() stops accepting new connections.
+    """
+
+    def accept(self) -> Connection: ...
+
+    def close(self) -> None: ...
+
+
+class Handler(Protocol):
+    """The IRC server's interface to the network layer.
+
+    The EventLoop calls these methods as events occur.
+    Implementations must be thread-safe if the EventLoop uses multiple threads.
+    """
+
+    def on_connect(self, conn_id: ConnId) -> None: ...
+
+    def on_message(self, conn_id: ConnId, msg: Message) -> None: ...
+
+    def on_disconnect(self, conn_id: ConnId) -> None: ...
+
+
+class EventLoop(Protocol):
+    """Drives the server: accepts connections and dispatches messages.
+
+    run() blocks until the server is shut down (e.g. via stop()).
+    """
+
+    def run(self, listener: Listener, handler: Handler) -> None: ...
+
+    def stop(self) -> None: ...
+```
+
+---
+
+## Concepts
+
+### Thread-per-Connection Model
+
+The simplest possible concurrent server: the main thread accepts connections in a loop.
+For each accepted connection, it spawns a new thread. That thread reads lines in a loop,
+calls the handler, and exits when the connection closes.
+
+```
+main thread                    worker thread (one per connection)
+────────────                   ──────────────────────────────────
+listener.accept() ──────────→  while True:
+                                   data = conn.read()       # blocks here
+                                   if not data: break
+                                   framer.feed(data)
+                                   for frame in framer.frames():
+                                       msg = parse(frame)
+                                       responses = handler.on_message(conn.id, msg)
+                                       for (target_id, resp) in responses:
+                                           target_conn.write(serialize(resp))
+                               handler.on_disconnect(conn.id)
+```
+
+### Shared Connection Map
+
+All threads need access to `target_conn` to fan out channel messages to other users. The
+`EventLoop` maintains a thread-safe map of `ConnId → Connection`. Access is protected by a lock.
+
+```python
+import threading
+
+conn_map: dict[ConnId, Connection] = {}
+conn_lock = threading.Lock()
+```
+
+The `write()` calls in the worker thread acquire the lock on the target connection (or on the
+map) before sending. This prevents interleaved writes when two threads fan out to the same
+connection simultaneously.
+
+### Thread Safety Contract
+
+`IRCServer` (from `irc-server`) is **not** thread-safe. With a thread-per-connection model,
+multiple threads will call `handler.on_message()` concurrently. The `EventLoop` must serialize
+these calls with a lock:
+
+```python
+server_lock = threading.Lock()
+
+def handle_message(conn_id: ConnId, msg: Message) -> None:
+    with server_lock:
+        responses = handler.on_message(conn_id, msg)
+    # send responses outside the lock
+    for target_id, resp in responses:
+        send_to(target_id, serialize(resp))
+```
+
+This lock is a global bottleneck. IRC traffic is mostly idle, so this is acceptable for stdlib.
+The event-loop implementations (`irc-net-selectors` and below) avoid this by being single-threaded.
+
+---
+
+## Implementation
+
+### Python
+
+```python
+from __future__ import annotations
+
+import socket
+import threading
+from typing import Iterator
+
+from irc_framing import Framer
+from irc_proto import Message, parse, serialize
+
+
+class StdlibConnection:
+    _next_id: int = 0
+    _lock: threading.Lock = threading.Lock()
+
+    def __init__(self, sock: socket.socket, addr: tuple[str, int]) -> None:
+        with StdlibConnection._lock:
+            StdlibConnection._next_id += 1
+            self._id = ConnId(StdlibConnection._next_id)
+        self._sock = sock
+        self._addr = addr
+
+    @property
+    def id(self) -> ConnId:
+        return self._id
+
+    @property
+    def peer_addr(self) -> tuple[str, int]:
+        return self._addr
+
+    def read(self) -> bytes:
+        try:
+            return self._sock.recv(4096)
+        except OSError:
+            return b""
+
+    def write(self, data: bytes) -> None:
+        self._sock.sendall(data)
+
+    def close(self) -> None:
+        try:
+            self._sock.close()
+        except OSError:
+            pass
+
+
+class StdlibListener:
+    def __init__(self, host: str, port: int) -> None:
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._sock.bind((host, port))
+        self._sock.listen(128)
+
+    def accept(self) -> StdlibConnection:
+        sock, addr = self._sock.accept()
+        return StdlibConnection(sock, addr)
+
+    def close(self) -> None:
+        self._sock.close()
+
+
+class StdlibEventLoop:
+    def __init__(self) -> None:
+        self._running = False
+        self._conns: dict[ConnId, StdlibConnection] = {}
+        self._conns_lock = threading.Lock()
+        self._server_lock = threading.Lock()
+
+    def run(self, listener: StdlibListener, handler: Handler) -> None:
+        self._running = True
+        while self._running:
+            conn = listener.accept()
+            with self._conns_lock:
+                self._conns[conn.id] = conn
+            t = threading.Thread(
+                target=self._handle_conn,
+                args=(conn, handler),
+                daemon=True,
+            )
+            t.start()
+
+    def stop(self) -> None:
+        self._running = False
+
+    def _handle_conn(self, conn: StdlibConnection, handler: Handler) -> None:
+        framer = Framer()
+        with self._server_lock:
+            handler.on_connect(conn.id)
+        try:
+            while True:
+                data = conn.read()
+                if not data:
+                    break
+                framer.feed(data)
+                for frame in framer.frames():
+                    msg = parse(frame.decode("utf-8", errors="replace"))
+                    with self._server_lock:
+                        responses = handler.on_message(conn.id, msg)
+                    self._send_responses(responses)
+        finally:
+            with self._server_lock:
+                responses = handler.on_disconnect(conn.id)
+            self._send_responses(responses)
+            with self._conns_lock:
+                self._conns.pop(conn.id, None)
+            conn.close()
+
+    def _send_responses(self, responses: list[tuple[ConnId, Message]]) -> None:
+        for target_id, resp in responses:
+            with self._conns_lock:
+                target = self._conns.get(target_id)
+            if target:
+                target.write(serialize(resp))
+```
+
+### Language Mappings
+
+| Language | Listener | Connection | Thread |
+|---|---|---|---|
+| Python | `socket.socket.accept()` | `socket.socket` | `threading.Thread` |
+| Go | `net.Listen("tcp", addr)` | `net.Conn` | goroutine |
+| TypeScript (Node) | `net.createServer()` | `net.Socket` | event loop (Node is single-threaded) |
+| Ruby | `TCPServer.new` | `TCPSocket` | `Thread.new` |
+| Elixir | `:gen_tcp.listen` | `:gen_tcp` socket | lightweight process (`spawn`) |
+| Rust | `std::net::TcpListener` | `std::net::TcpStream` | `std::thread::spawn` |
+| Kotlin | `java.net.ServerSocket` | `java.net.Socket` | coroutine or `Thread` |
+| Swift | `Network.framework NWListener` | `NWConnection` | `DispatchQueue` |
+| C# | `System.Net.Sockets.TcpListener` | `TcpClient` | `Task` / `async-await` |
+| F# | same as C# | same as C# | `async` computation expression |
+
+Node.js / TypeScript note: Node's event loop makes the stdlib implementation effectively
+single-threaded. No explicit thread management is needed, but write calls must be careful not
+to block.
+
+---
+
+## Trade-offs
+
+| Concern | Impact | Mitigation |
+|---|---|---|
+| One thread per connection | ~8 MB stack per thread; limits to ~1000 connections | Acceptable for IRC; next doll peels this |
+| Global server lock | Serializes all IRC logic | IRCServer is fast; lock held briefly |
+| Blocking `recv` | Thread blocks while waiting for data | Fine; threads are cheap for low-concurrency |
+| No backpressure | Slow client can fill send buffer | `sendall` blocks sender thread; natural backpressure |
+
+---
+
+## Test Strategy
+
+Tests must verify the interface contract, not the implementation internals. Use the same tests
+for all `irc-net-*` implementations.
+
+### Echo server test (implementation-agnostic)
+
+Create a minimal `EchoHandler` that reflects every message back to the sender. Start the event
+loop in a thread. Connect a real TCP socket. Send `PING :test\r\n`. Assert the response is
+`PONG :test\r\n`. Disconnect. Verify `on_disconnect` was called.
+
+### Concurrent connections
+
+Connect 20 clients simultaneously. Each sends `NICK client_N\r\nUSER ...\r\nJOIN #test\r\n`.
+Verify each receives a welcome sequence and the NAMES list grows with each join. All on stdlib
+threads.
+
+### Graceful shutdown
+
+Start the server. Connect 5 clients. Call `stop()`. Verify the listener closes and the program
+exits cleanly (no hanging threads).
+
+### Write serialization
+
+Connect two clients to the same channel. Have client A send 50 PRIVMSG messages rapidly.
+Verify client B receives all 50 messages in order (no interleaving / corruption).
+
+---
+
+## Future: Peeling This Layer
+
+When ready to move to `irc-net-selectors`, the steps are:
+
+1. Implement `SelectorsConnection`, `SelectorsListener`, `SelectorsEventLoop` in `irc-net-selectors`.
+2. Verify they pass the same echo server and concurrency tests.
+3. In `ircd`, swap `StdlibEventLoop` for `SelectorsEventLoop` (one line change in the wiring).
+4. Run integration tests with a real IRC client. Nothing else changes.
+
+The `ircd` program, `irc-server`, `irc-framing`, and `irc-proto` are untouched.

--- a/code/specs/irc-proto.md
+++ b/code/specs/irc-proto.md
@@ -1,0 +1,234 @@
+# irc-proto — IRC Message Parsing and Serialization
+
+## Overview
+
+`irc-proto` is a pure library with no I/O, no threads, and no side effects. It converts between
+the raw text lines of the IRC protocol and structured `Message` values, and back again.
+
+Every other package in the IRC system depends on `irc-proto`'s `Message` type, but `irc-proto`
+itself depends on nothing. This makes it the ideal starting point for any new language port: get
+the parser right first, test it exhaustively, and the rest of the stack has a solid foundation.
+
+---
+
+## Layer Position
+
+```
+irc-server   ← consumes Message values, produces Message values to send
+     ↑
+irc-proto    ← THIS PACKAGE: parse(line) → Message, serialize(msg) → bytes
+     ↑
+irc-framing  ← feeds complete \r\n-stripped lines upward
+```
+
+`irc-proto` knows nothing about connections, sockets, threads, or buffers. It operates on
+`str` (incoming) and returns `bytes` (outgoing). The framer handles the byte ↔ str boundary.
+
+---
+
+## Concepts
+
+### The IRC Message Format (RFC 1459)
+
+An IRC message is a single line of text terminated by `\r\n`. The maximum length including the
+terminator is 512 bytes. The format is:
+
+```
+[:prefix SPACE] COMMAND [SPACE param]* [SPACE COLON trailing] CR LF
+```
+
+Breaking this down:
+
+```
+:nick!user@host PRIVMSG #general :Hello, world!\r\n
+ ───────────────  ───────  ────────  ──────────────
+    prefix        command   param      trailing param
+```
+
+- **prefix** — Optional. Always starts with `:`. Can be a server name (`irc.example.com`) or a
+  full nick mask (`nick!user@host`). Identifies who sent the message.
+- **command** — Required. Either a word (`PRIVMSG`, `JOIN`) or a 3-digit numeric (`001`, `433`).
+  Commands from clients have no prefix. Commands from servers have a server-name prefix.
+- **params** — Zero to 15 space-separated values. The last param may be prefixed with `:` to
+  allow spaces within it (the "trailing" param). All params are collected into a flat list.
+
+### Examples
+
+```
+# Client sends (no prefix):
+NICK alice\r\n
+USER alice 0 * :Alice Smith\r\n
+JOIN #general\r\n
+PRIVMSG #general :Hello everyone!\r\n
+PING :server1\r\n
+QUIT :Goodbye\r\n
+
+# Server sends (with prefix):
+:irc.local 001 alice :Welcome to the IRC network, alice!\r\n
+:irc.local 353 alice = #general :alice bob carol\r\n
+:alice!alice@127.0.0.1 JOIN #general\r\n
+:irc.local PING :irc.local\r\n
+```
+
+### Parsing Rules
+
+1. If the line starts with `:`, everything up to the first space is the prefix (strip the `:`).
+2. The next token (space-delimited) is the command. Normalize to uppercase.
+3. Remaining tokens are params. If a token starts with `:`, it and everything after it (including
+   spaces) is the trailing param — the last param in the list.
+4. Maximum 15 params. Any beyond are silently dropped.
+5. Commands are case-insensitive (`join` == `JOIN`). Numerics are three-digit strings (`"001"`).
+
+---
+
+## Public API
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Message:
+    """A single parsed IRC protocol message.
+
+    prefix is None for client-originated messages.
+    command is always uppercase (or a 3-digit numeric string).
+    params includes the trailing param as the last element (no colon prefix).
+    """
+    prefix: str | None
+    command: str
+    params: list[str] = field(default_factory=list)
+
+
+class ParseError(Exception):
+    """Raised when a line cannot be parsed as an IRC message."""
+
+
+def parse(line: str) -> Message:
+    """Parse a single IRC message line into a Message.
+
+    The line should already have the trailing \\r\\n stripped.
+    Raises ParseError if the line is empty or malformed.
+
+    Examples:
+        >>> parse("NICK alice")
+        Message(prefix=None, command='NICK', params=['alice'])
+
+        >>> parse(":irc.local 001 alice :Welcome!")
+        Message(prefix='irc.local', command='001', params=['alice', 'Welcome!'])
+
+        >>> parse(":alice!alice@host PRIVMSG #chan :hello world")
+        Message(prefix='alice!alice@host', command='PRIVMSG', params=['#chan', 'hello world'])
+    """
+    ...
+
+
+def serialize(msg: Message) -> bytes:
+    """Serialize a Message back to IRC wire format.
+
+    Returns CRLF-terminated bytes ready to write to a socket.
+    Params containing spaces are automatically written as trailing params (with ':' prefix).
+    If prefix is set, it is prepended with ':'.
+
+    Examples:
+        >>> serialize(Message(None, 'NICK', ['alice']))
+        b'NICK alice\\r\\n'
+
+        >>> serialize(Message('irc.local', '001', ['alice', 'Welcome!']))
+        b':irc.local 001 alice :Welcome!\\r\\n'
+    """
+    ...
+```
+
+---
+
+## Numeric Reply Reference
+
+Servers send numeric replies to indicate success or error conditions. These are 3-digit strings
+used as the `command` field of a `Message`. Important numerics:
+
+| Numeric | Name | Meaning |
+|---|---|---|
+| `001` | RPL_WELCOME | Successful registration — sent first after NICK+USER |
+| `002` | RPL_YOURHOST | Server version info |
+| `003` | RPL_CREATED | Server creation date |
+| `004` | RPL_MYINFO | Server capabilities summary |
+| `251` | RPL_LUSERCLIENT | Number of users/servers |
+| `353` | RPL_NAMREPLY | List of nicks in a channel (response to NAMES or JOIN) |
+| `366` | RPL_ENDOFNAMES | End of NAMES list |
+| `372` | RPL_MOTD | Line of the Message of the Day |
+| `375` | RPL_MOTDSTART | Start of MOTD |
+| `376` | RPL_ENDOFMOTD | End of MOTD |
+| `401` | ERR_NOSUCHNICK | No such nick or channel |
+| `403` | ERR_NOSUCHCHANNEL | No such channel |
+| `411` | ERR_NORECIPIENT | No recipient given |
+| `412` | ERR_NOTEXTTOSEND | No text to send |
+| `421` | ERR_UNKNOWNCOMMAND | Unknown command |
+| `431` | ERR_NONICKNAMEGIVEN | No nickname given |
+| `432` | ERR_ERRONEUSNICKNAME | Invalid characters in nick |
+| `433` | ERR_NICKNAMEINUSE | Nick already taken |
+| `441` | ERR_USERNOTINCHANNEL | User not in that channel |
+| `442` | ERR_NOTONCHANNEL | You are not on that channel |
+| `451` | ERR_NOTREGISTERED | Must register first (NICK + USER) |
+| `461` | ERR_NEEDMOREPARAMS | Not enough parameters |
+| `462` | ERR_ALREADYREGISTRED | Already registered |
+| `482` | ERR_CHANOPRIVSNEEDED | Channel operator privileges needed |
+
+---
+
+## Parsing Edge Cases
+
+| Input | Expected behaviour |
+|---|---|
+| `""` (empty line) | Raise `ParseError` |
+| `"PING"` (no params) | `Message(None, 'PING', [])` |
+| `":server PING"` | `Message('server', 'PING', [])` |
+| `"join #foo"` | `Message(None, 'JOIN', ['#foo'])` — command uppercased |
+| `"PRIVMSG #c :hello world"` | trailing includes spaces: `params=['#c', 'hello world']` |
+| `"PRIVMSG #c :"` | empty trailing is valid: `params=['#c', '']` |
+| `":pre CMD a b c d e f g h i j k l m n o"` | 16 params — drop last, keep 15 |
+| Line > 510 bytes (excl. CRLF) | Accept and parse; framer enforces max length upstream |
+
+---
+
+## Test Strategy
+
+Tests live in the package's `tests/` directory. Coverage target: 98%+.
+
+### Parsing tests
+
+- **Happy path**: one test per example in the "Examples" section above
+- **No prefix**: `"NICK alice"` → `Message(None, 'NICK', ['alice'])`
+- **Server prefix**: `":irc.local 001 alice :Welcome"` → correct prefix, command, params
+- **Numeric command**: `":srv 433 * nick :Nick in use"` → command is `"433"` (string)
+- **Trailing with spaces**: `"PRIVMSG #c :hello world"` → `params=['#c', 'hello world']`
+- **Empty trailing**: `"PRIVMSG #c :"` → `params=['#c', '']`
+- **No params**: `"QUIT"` → `Message(None, 'QUIT', [])`
+- **Command case normalization**: `"join #foo"` produces `command='JOIN'`
+- **15-param cap**: construct a line with 16 params; verify only 15 returned
+- **Empty line**: `parse("")` raises `ParseError`
+- **Whitespace-only line**: `parse("   ")` raises `ParseError`
+- **Full nick mask prefix**: `":alice!alice@127.0.0.1 QUIT :bye"` → correct prefix
+
+### Serialization tests
+
+- **Round-trip**: `parse(line)` then `serialize(msg).decode().rstrip('\r\n')` equals the original
+  line for a representative set of well-formed inputs
+- **CRLF termination**: every `serialize()` result ends with `b'\r\n'`
+- **Prefix emission**: message with prefix serializes as `":prefix COMMAND ...\r\n"`
+- **No prefix**: message without prefix serializes without leading `:`
+- **Trailing param**: param containing a space is automatically written with `:` prefix
+- **Multiple params**: `Message(None, 'MODE', ['#foo', '+o', 'alice'])` → `b'MODE #foo +o alice\r\n'`
+
+---
+
+## Future Extensions
+
+- **IRCv3 tags**: messages can have `@key=value;key2=value2` tag blocks before the prefix.
+  The parser should be extended to extract these into a separate `tags: dict[str, str]` field.
+- **ISUPPORT (005)**: servers advertise protocol capabilities. A capability parser could be
+  added as a separate module within `irc-proto`.
+- **Strict mode**: an optional flag to `parse()` that rejects lines exceeding 512 bytes rather
+  than accepting them (for use in conformance testing).

--- a/code/specs/irc-server.md
+++ b/code/specs/irc-server.md
@@ -1,0 +1,409 @@
+# irc-server — IRC State Machine
+
+## Overview
+
+`irc-server` is the IRC state machine. It tracks connected clients, registered nicks, channels,
+and channel membership. It receives `Message` values from the network layer (via `irc-proto`)
+and returns lists of `(ConnId, Message)` pairs describing what to send to which connection.
+
+This package has **no I/O**. It does not know what sockets are. It does not read or write bytes.
+It is a pure state machine that transforms events into responses. The `ircd` program is
+responsible for driving it: reading from the network, calling the server methods, and writing the
+returned messages back to the appropriate connections.
+
+`irc-server` depends only on `irc-proto` (for the `Message` type). No other dependencies.
+
+---
+
+## Layer Position
+
+```
+ircd (program)    ← drives the event loop; calls server methods, sends responses
+     ↓
+irc-server        ← THIS PACKAGE: IRC state machine
+     ↓
+irc-proto         ← Message type; parse() and serialize()
+```
+
+The `ircd` program sits above `irc-server` in the call stack: it calls `on_connect`,
+`on_message`, and `on_disconnect`, then takes the returned messages and hands them to the
+network layer to write. `irc-server` never calls out to anything.
+
+---
+
+## Concepts
+
+### Connection Lifecycle
+
+A TCP connection goes through these phases:
+
+```
+TCP connect → on_connect() called
+    → client must send NICK then USER (in any order)
+    → once both received: registration complete → welcome sequence sent
+    → normal operation: JOIN, PART, PRIVMSG, etc.
+TCP close  → on_disconnect() called → server cleans up client state
+```
+
+Clients that send any command other than `NICK`, `USER`, `CAP`, or `QUIT` before completing
+registration receive `451 ERR_NOTREGISTERED`.
+
+### Nick Registration Handshake
+
+```
+Client → NICK alice
+Client → USER alice 0 * :Alice Smith
+Server → :irc.local 001 alice :Welcome to the IRC Network, alice!
+Server → :irc.local 002 alice :Your host is irc.local, running version 1.0
+Server → :irc.local 003 alice :This server was created today
+Server → :irc.local 004 alice irc.local 1.0 o o
+Server → :irc.local 375 alice :- irc.local Message of the Day -
+Server → :irc.local 372 alice :- Welcome to this IRC server.
+Server → :irc.local 376 alice :End of /MOTD command.
+```
+
+NICK and USER can arrive in either order. Registration completes when both have been received.
+
+### Channel Lifecycle
+
+- A channel is created implicitly when the first user JOINs it.
+- The first user to join a channel becomes a channel operator (`@` prefix in NAMES).
+- A channel is destroyed when its last member PARTs or QUITs.
+- Channel names must start with `#` (or `&` for local channels, though `#` is the standard).
+
+### Operator Model
+
+- The first user to join a channel is granted operator status (`mode +o`).
+- Operators can KICK users, set channel MODE, and use INVITE.
+- Server operators (OPER command) have global privileges.
+
+---
+
+## State Model
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import NewType
+
+ConnId = NewType('ConnId', int)
+
+
+@dataclass
+class Client:
+    """Represents a connected client, registered or not."""
+    id: ConnId
+    nick: str | None = None          # None until NICK received
+    username: str | None = None      # None until USER received
+    realname: str | None = None      # None until USER received
+    hostname: str = "unknown"        # set from peer address at connect time
+    registered: bool = False         # True after both NICK and USER received
+    channels: set[str] = field(default_factory=set)   # channel names (lowercase)
+    away_message: str | None = None  # set by AWAY, cleared by AWAY with no args
+    is_oper: bool = False            # set by OPER command
+
+
+@dataclass
+class ChannelMember:
+    """A client's membership in a channel, including their mode flags."""
+    client: Client
+    is_operator: bool = False        # +o
+    has_voice: bool = False          # +v
+
+
+@dataclass
+class Channel:
+    """A named chat room."""
+    name: str                        # always lowercase; includes '#'
+    topic: str = ""
+    members: dict[ConnId, ChannelMember] = field(default_factory=dict)
+    modes: set[str] = field(default_factory=set)   # channel mode flags (e.g. 'n', 't', 'm')
+    invite_list: set[str] = field(default_factory=set)  # nicks invited (for +i channels)
+    ban_list: list[str] = field(default_factory=list)   # ban masks
+
+
+@dataclass
+class ServerState:
+    """The complete mutable state of an IRC server."""
+    server_name: str
+    version: str
+    motd: list[str]
+    clients: dict[ConnId, Client] = field(default_factory=dict)
+    nicks: dict[str, ConnId] = field(default_factory=dict)     # lowercase nick → ConnId
+    channels: dict[str, Channel] = field(default_factory=dict) # lowercase name → Channel
+    oper_password: str = ""
+```
+
+---
+
+## Public API
+
+```python
+from __future__ import annotations
+
+from typing import Protocol
+from irc_proto import Message
+
+
+Response = tuple[ConnId, Message]
+
+
+class Handler(Protocol):
+    """The interface that irc-server exposes to the ircd program.
+
+    Each method returns a list of (ConnId, Message) pairs.
+    The ircd program serializes each Message and sends it to the corresponding ConnId.
+    """
+
+    def on_connect(self, conn_id: ConnId, host: str) -> list[Response]:
+        """Called when a new TCP connection is established.
+
+        host is the peer's IP address string (used to populate the client's hostname).
+        Returns an empty list — no messages are sent until registration completes.
+        """
+        ...
+
+    def on_message(self, conn_id: ConnId, msg: Message) -> list[Response]:
+        """Called when a complete IRC message arrives from a client.
+
+        Returns zero or more (ConnId, Message) pairs.
+        Some commands (PRIVMSG to a channel) fan out to many ConnIds.
+        Some commands (PING) return a single response to the sender.
+        Some commands (QUIT) return messages to other clients and none to the sender.
+        """
+        ...
+
+    def on_disconnect(self, conn_id: ConnId) -> list[Response]:
+        """Called when a TCP connection closes (gracefully or not).
+
+        Removes the client from all channels, notifies channel members,
+        and cleans up the nick table. Returns QUIT notifications for channel members.
+        """
+        ...
+
+
+class IRCServer:
+    """Concrete IRC state machine. Implements Handler.
+
+    Thread safety: IRCServer is NOT thread-safe. If the network layer uses multiple
+    threads, access to IRCServer must be serialized with a lock in the ircd program.
+    """
+
+    def __init__(
+        self,
+        server_name: str,
+        version: str = "1.0",
+        motd: list[str] | None = None,
+        oper_password: str = "",
+    ) -> None: ...
+
+    def on_connect(self, conn_id: ConnId, host: str) -> list[Response]: ...
+    def on_message(self, conn_id: ConnId, msg: Message) -> list[Response]: ...
+    def on_disconnect(self, conn_id: ConnId) -> list[Response]: ...
+```
+
+---
+
+## Command Reference (Full RFC 1459 Set)
+
+### Registration Commands
+
+| Command | Params | Before Registration | Behaviour |
+|---|---|---|---|
+| `NICK` | `<nickname>` | Allowed | Set/change nickname. Fails with 433 if nick in use, 432 if invalid characters |
+| `USER` | `<user> <mode> <unused> :<realname>` | Allowed | Set username and realname. Ignored after registration (462). |
+| `PASS` | `<password>` | Allowed | Server password. Must come before NICK/USER. Not implemented in basic server. |
+| `CAP` | subcommand | Allowed | Capability negotiation (IRCv3). Basic server replies `CAP * ACK :` or ignores. |
+| `QUIT` | `[:<message>]` | Allowed | Disconnect. Broadcasts QUIT to all shared channels. |
+
+### Messaging Commands
+
+| Command | Params | Behaviour |
+|---|---|---|
+| `PRIVMSG` | `<target> :<text>` | Send to nick or channel. Target must exist (401/403 if not). |
+| `NOTICE` | `<target> :<text>` | Like PRIVMSG but never generates an auto-reply. |
+
+### Channel Commands
+
+| Command | Params | Behaviour |
+|---|---|---|
+| `JOIN` | `<channel>[,<channel>]` | Join one or more channels. Creates channel if new. Sends JOIN to all members. Follows with 353 NAMES and 366 ENDOFNAMES. |
+| `PART` | `<channel>[,<channel>] [:<message>]` | Leave channel(s). Sends PART to all members. Destroys channel if empty. |
+| `NAMES` | `[<channel>]` | List nicks in a channel (or all channels if no arg). 353 + 366. |
+| `LIST` | `[<channel>]` | List channels with member counts and topics. 321 + 322 rows + 323. |
+| `TOPIC` | `<channel> [:<topic>]` | Get or set channel topic. Get: 332 (topic) or 331 (no topic). Set: requires operator if +t mode. |
+| `INVITE` | `<nick> <channel>` | Invite nick to channel. Requires operator status. Sends INVITE to target. |
+| `KICK` | `<channel> <nick> [:<reason>]` | Remove nick from channel. Requires operator status. Sends KICK to all. |
+| `MODE` | `<target> [<modestring> [params]]` | Get or set channel/user modes. See mode table below. |
+
+### Server Commands
+
+| Command | Params | Behaviour |
+|---|---|---|
+| `PING` | `:<server>` | Server or client keepalive. Server replies `PONG :<server>`. |
+| `PONG` | `:<server>` | Response to PING. Clients send this; server resets their ping timer. |
+| `AWAY` | `[:<message>]` | Set away message (with text) or return from away (no text). 306/305. |
+| `WHO` | `[<mask>]` | List users matching mask. 352 rows + 315. |
+| `WHOIS` | `<nick>` | Detail about a user. 311, 312, 319, 301 (if away), 318. |
+| `OPER` | `<name> <password>` | Gain IRC operator status. 381 on success, 464 on failure. |
+| `KILL` | `<nick> :<reason>` | (Oper only) Disconnect a user. |
+| `WALLOPS` | `:<message>` | (Oper only) Broadcast to all opers. |
+
+### Channel Modes
+
+| Mode | Symbol | Meaning |
+|---|---|---|
+| No external messages | `+n` | Only channel members can send PRIVMSG to the channel |
+| Topic protection | `+t` | Only operators can change the topic |
+| Moderated | `+m` | Only voiced users (+v) and operators can speak |
+| Invite only | `+i` | Only invited users can join |
+| Key (password) | `+k <key>` | Joining requires the correct key |
+| Limit | `+l <count>` | Maximum member count |
+| Operator | `+o <nick>` | Grant/revoke operator status |
+| Voice | `+v <nick>` | Grant/revoke voice in moderated channels |
+| Ban | `+b <mask>` | Ban mask (nick!user@host glob) |
+
+### User Modes
+
+| Mode | Symbol | Meaning |
+|---|---|---|
+| Invisible | `+i` | User not shown in WHO unless in shared channel |
+| Oper | `+o` | IRC operator (set by OPER command) |
+| Wallops | `+w` | Receive WALLOPS messages |
+| Away | `+a` | User is away (set implicitly by AWAY command) |
+
+---
+
+## Registration Flow (Detail)
+
+```
+TCP connect
+    server: [internal] creates Client(id=conn_id, registered=False)
+    server: [no response]
+
+Client: NICK alice
+    server: validates nick (no spaces, starts with letter or _)
+    server: checks nick not in use
+    server: stores client.nick = "alice"
+    server: [no response yet — waiting for USER]
+
+Client: USER alice 0 * :Alice Smith
+    server: stores client.username = "alice", client.realname = "Alice Smith"
+    server: client.registered = True
+    server: registers nick in nicks table
+    server: sends welcome sequence:
+        :server 001 alice :Welcome to the IRC Network, alice!
+        :server 002 alice :Your host is irc.local, running version 1.0
+        :server 003 alice :This server was created <date>
+        :server 004 alice irc.local 1.0 o o
+        :server 251 alice :There are N users on 1 server
+        :server 375 alice :- irc.local Message of the Day -
+        :server 372 alice :- <motd line> -
+        :server 376 alice :End of /MOTD command.
+```
+
+---
+
+## Channel JOIN Flow (Detail)
+
+```
+Client: JOIN #general
+    server: channel name must start with # (or &)
+    server: if channel doesn't exist:
+        create Channel(name="#general")
+        add client as member with is_operator=True
+    server: if channel exists:
+        check ban list — if matched: 474 ERR_BANNEDFROMCHAN
+        check invite-only mode — if +i and not invited: 473 ERR_INVITEONLYCHAN
+        check key mode — if +k and wrong key: 475 ERR_BADCHANNELKEY
+        check limit mode — if +l and at limit: 471 ERR_CHANNELISFULL
+        add client as member
+    server: broadcasts JOIN to ALL channel members (including the joiner):
+        :alice!alice@host JOIN #general    (sent to all members)
+    server: sends topic (if set):
+        :server 332 alice #general :Topic text    (if topic exists)
+        :server 331 alice #general :No topic set  (if no topic)
+    server: sends NAMES list:
+        :server 353 alice = #general :@bob alice carol
+        :server 366 alice #general :End of /NAMES list.
+```
+
+---
+
+## Nick Validation Rules
+
+A valid nickname:
+- Length: 1–9 characters (RFC 1459 limit; some servers allow up to 30)
+- First character: letter (`A-Z`, `a-z`) or special (`_`, `[`, `]`, `\`, `` ` ``, `^`, `{`, `}`, `|`)
+- Remaining characters: any of the above, plus digits (`0-9`) and `-`
+- Must not conflict with an existing nick (case-insensitive comparison)
+
+Invalid nick → `432 ERR_ERRONEUSNICKNAME`. Nick in use → `433 ERR_NICKNAMEINUSE`.
+
+---
+
+## Test Strategy
+
+Tests live in `tests/`. Coverage target: 95%+.
+
+### Registration
+
+- NICK then USER → welcome sequence sent; client marked registered
+- USER then NICK → same result (order should not matter)
+- Duplicate NICK → 433 returned; original nick unchanged
+- Invalid nick characters → 432 returned
+- Command before registration → 451 ERR_NOTREGISTERED
+- QUIT before registration → connection cleaned up, no crash
+
+### Channel Operations
+
+- JOIN creates channel, sender becomes operator
+- Second JOIN: sender added as non-operator; all existing members notified
+- JOIN sends correct NAMES list with `@` prefix for operators
+- PART removes member; remaining members notified
+- PART of last member destroys channel
+- PRIVMSG to channel: delivered to all members except sender
+- PRIVMSG to nick: delivered to target; 401 if no such nick
+
+### NICK Change
+
+- Registered client changes nick: 433 if in use, else nick updated
+- NICK change while in channels: all channel members receive `:old!u@h NICK new`
+- Nick table updated atomically (old nick freed, new nick registered)
+
+### Error Conditions
+
+- PRIVMSG with no params → 411 ERR_NORECIPIENT
+- PRIVMSG with no text → 412 ERR_NOTEXTTOSEND
+- PRIVMSG to non-existent channel → 403 ERR_NOSUCHCHANNEL
+- JOIN invalid channel name (no `#`) → 403 ERR_NOSUCHCHANNEL
+- KICK non-member → 441 ERR_USERNOTINCHANNEL
+- KICK without operator → 482 ERR_CHANOPRIVSNEEDED
+- MODE without operator → 482 ERR_CHANOPRIVSNEEDED
+
+### Disconnect Cleanup
+
+- Client in 3 channels disconnects → QUIT sent to all unique channel members
+- Nick freed in nick table
+- Client removed from all channel member lists
+- Empty channels destroyed
+
+### AWAY
+
+- AWAY :Gone → client.away_message set; 306 RPL_NOWAWAY
+- AWAY (no text) → away cleared; 305 RPL_UNAWAY
+- WHOIS on away user → includes 301 RPL_AWAY with message
+
+---
+
+## Future Extensions
+
+- **Server linking**: multiple servers connected as a network (RFC 2813). Requires server-to-server
+  protocol and global nick/channel state propagation. Out of scope for v1.
+- **IRCv3 capabilities**: SASL authentication, message tags, account tracking. Can be layered
+  on top of the existing command dispatch without restructuring the state machine.
+- **Persistence**: channels and their topics currently vanish when the server restarts. A future
+  extension could serialize `ServerState` to disk on shutdown.
+- **Rate limiting**: per-client message rate limiting to prevent flood attacks. The `Client` struct
+  would gain a token bucket or sliding window counter.

--- a/code/specs/irc-unikernel.md
+++ b/code/specs/irc-unikernel.md
@@ -1,0 +1,521 @@
+# LibOS / Unikernel Framework
+
+## Overview
+
+A **Unikernel** (also called a **Library OS** or **LibOS**) is a single-address-space machine
+image that bundles an application with only the OS components it actually needs. There is no
+general-purpose kernel, no multi-user isolation, no shell, no `/proc`. There is just your
+application and a minimal set of OS services linked directly into the same binary.
+
+This document specifies a **modular LibOS framework** written in Rust for the
+`x86_64-unknown-none` target. It is structured as a menu of composable modules: you include
+only what your application requires. An HTTP server needs networking. A batch data processor
+needs storage but not networking. A key-value store might need both. An IRC server needs
+networking but not storage.
+
+The framework is not IRC-specific. IRC is the application that first drove this work, but every
+module is general-purpose. Swap the application, swap the modules you need, and you have a
+different unikernel.
+
+---
+
+## The Nesting Doll in Full
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Application  (IRC server, HTTP server, database, or anything)  │
+├─────────────────────────────────────────────────────────────────┤
+│  LibOS Module Layer  (include only what you need)               │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐       │
+│  │ Network  │  │ Storage  │  │  Timer   │  │  Serial  │       │
+│  │ (smoltcp)│  │ (virtio  │  │ (HPET/  │  │  (UART)  │       │
+│  │          │  │  blk)    │  │  APIC)   │  │          │       │
+│  └────┬─────┘  └────┬─────┘  └──────────┘  └──────────┘       │
+│       │              │                                          │
+│  ┌────┴─────┐  ┌────┴─────┐                                    │
+│  │  NIC     │  │  Disk    │                                    │
+│  │  Driver  │  │  Driver  │                                    │
+│  └──────────┘  └──────────┘                                    │
+├─────────────────────────────────────────────────────────────────┤
+│  Core Layer  (always required)                                  │
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │  Boot  →  Allocator  →  Panic Handler  →  Interrupts    │   │
+│  └──────────────────────────────────────────────────────────┘   │
+├─────────────────────────────────────────────────────────────────┤
+│  Hardware Interface                                             │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │  virtio-net  │  virtio-blk  │  PCI bus  │  UART  │  APIC │  │
+│  └───────────────────────────────────────────────────────────┘  │
+├─────────────────────────────────────────────────────────────────┤
+│  Hypervisor  (QEMU / KVM / Firecracker / Cloud Hypervisor)     │
+├─────────────────────────────────────────────────────────────────┤
+│  Physical hardware                                              │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Module Catalogue
+
+Each module is a Rust crate (or feature flag within a crate). Modules declare their
+dependencies. The application's `Cargo.toml` pulls in only what it needs.
+
+### Core Modules (always required)
+
+These are not optional. Every unikernel needs them.
+
+| Module | Crate / feature | Provides |
+|---|---|---|
+| **boot** | `libos-boot` | x86-64 entry point, stack setup, BSS zeroing, Multiboot2 parsing |
+| **allocator** | `libos-alloc` | Global heap allocator; implements `GlobalAlloc` |
+| **panic** | `libos-panic` | `#[panic_handler]`; writes to serial if available, then halts |
+| **interrupts** | `libos-interrupts` | IDT setup, basic exception handlers (page fault, double fault, etc.) |
+
+### Optional Modules
+
+Include only what your application uses.
+
+| Module | Crate / feature | Provides | Depends on |
+|---|---|---|---|
+| **serial** | `libos-serial` | UART 16550 driver; `serial_print!` macro for debugging | boot |
+| **timer** | `libos-timer` | HPET or APIC timer; `sleep_ms()`, `Instant::now()` | interrupts |
+| **pci** | `libos-pci` | PCI bus enumeration; finds devices by vendor/device ID | boot |
+| **network** | `libos-net` | smoltcp integration; `TcpListener`, `TcpStream` abstractions | pci, timer |
+| **nic-virtio** | `libos-nic-virtio` | virtio-net driver; implements `smoltcp::phy::Device` | pci |
+| **nic-e1000** | `libos-nic-e1000` | Intel e1000 driver (for QEMU `-net nic,model=e1000`) | pci |
+| **storage** | `libos-storage` | Block device abstraction; `read_block()`, `write_block()` | pci |
+| **blk-virtio** | `libos-blk-virtio` | virtio-blk driver; implements `Storage` | pci |
+| **fs-fat** | `libos-fs-fat` | FAT32 filesystem on top of a block device | storage |
+
+### Composing Modules
+
+An application specifies its LibOS composition in `Cargo.toml`:
+
+```toml
+[dependencies]
+# Core (always)
+libos-boot = "0.1"
+libos-alloc = "0.1"
+libos-panic = "0.1"
+libos-interrupts = "0.1"
+
+# IRC server needs: serial (debug), timer (smoltcp), PCI, network, virtio-net NIC
+libos-serial = "0.1"
+libos-timer = "0.1"
+libos-pci = "0.1"
+libos-net = "0.1"
+libos-nic-virtio = "0.1"
+
+# IRC server does NOT need: storage, block driver, filesystem
+# → Those crates are simply not listed
+```
+
+A batch data processor that reads from disk and writes results, but never touches the network:
+
+```toml
+[dependencies]
+libos-boot = "0.1"
+libos-alloc = "0.1"
+libos-panic = "0.1"
+libos-interrupts = "0.1"
+libos-serial = "0.1"
+libos-pci = "0.1"
+libos-storage = "0.1"
+libos-blk-virtio = "0.1"
+libos-fs-fat = "0.1"
+# No libos-net, libos-nic-virtio, libos-timer
+```
+
+---
+
+## Core Module Specs
+
+### boot
+
+Responsibilities:
+- Define `_start` (the ELF entry point, called directly by GRUB or the bootloader)
+- Set up the stack (`mov rsp, STACK_TOP`)
+- Zero the `.bss` segment (C guarantees this; we must do it ourselves)
+- Parse the Multiboot2 info structure to find the memory map
+- Call `libos_main(memory_map: &MemoryMap)` — the application's entry point
+
+```rust
+// The application provides this:
+extern "C" fn libos_main(memory_map: &MemoryMap) -> !;
+
+// The boot module calls it after setup:
+#[no_mangle]
+pub unsafe extern "C" fn _start() -> ! {
+    // ... stack setup, BSS zero, multiboot parse ...
+    libos_main(&memory_map);
+}
+```
+
+### allocator
+
+A pluggable global heap allocator. The `libos-alloc` crate provides a linked-list allocator
+by default and a bump allocator as an alternative (faster, but cannot free).
+
+```rust
+use libos_alloc::LinkedListAllocator;
+
+#[global_allocator]
+static ALLOCATOR: LinkedListAllocator = LinkedListAllocator::new();
+
+// Call this once from libos_main() after learning the heap region from the memory map:
+pub fn init_heap(start: usize, size: usize) {
+    unsafe { ALLOCATOR.init(start, size); }
+}
+```
+
+The heap region is determined from the Multiboot2 memory map: find the largest contiguous
+free region above the end of the kernel image.
+
+### panic
+
+```rust
+use core::panic::PanicInfo;
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    // Attempt to write to serial port (may not be initialized yet)
+    serial_println!("KERNEL PANIC: {}", info);
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+```
+
+### interrupts
+
+Sets up the x86-64 Interrupt Descriptor Table (IDT) with handlers for:
+- Breakpoint exception (`#BP`) — useful for debugging
+- Page fault (`#PF`) — logs address and flags, then halts
+- Double fault — catches stack overflow and other fatal errors; halts
+- General protection fault (`#GP`) — logs and halts
+- Hardware interrupts (IRQ) — delegated to registered handlers
+
+```rust
+pub fn init() {
+    IDT.load();
+    // Initialize the 8259 PIC or x2APIC
+    unsafe { PICS.lock().initialize() };
+    x86_64::instructions::interrupts::enable();
+}
+
+// Modules register interrupt handlers:
+pub fn register_irq(irq: u8, handler: fn()) {
+    IRQ_HANDLERS.lock()[irq as usize] = Some(handler);
+}
+```
+
+---
+
+## Optional Module Specs
+
+### serial
+
+UART 16550 driver. The serial port at I/O address `0x3F8` (COM1) is always available in QEMU
+and Firecracker. It is the primary debug output channel.
+
+```rust
+pub fn init() {
+    // Configure UART: 115200 baud, 8N1
+    unsafe {
+        outb(COM1 + 1, 0x00);   // Disable interrupts
+        outb(COM1 + 3, 0x80);   // Enable DLAB (baud rate divisor mode)
+        outb(COM1 + 0, 0x01);   // Divisor low byte: 115200 baud
+        outb(COM1 + 1, 0x00);   // Divisor high byte
+        outb(COM1 + 3, 0x03);   // 8 bits, no parity, 1 stop bit
+        outb(COM1 + 2, 0xC7);   // Enable FIFO, clear, 14-byte threshold
+    }
+}
+
+pub fn write_byte(byte: u8) {
+    while (unsafe { inb(COM1 + 5) } & 0x20) == 0 {}  // wait for empty
+    unsafe { outb(COM1, byte); }
+}
+
+// Macro for formatted output:
+macro_rules! serial_println {
+    ($($arg:tt)*) => { /* write to serial */ };
+}
+```
+
+### timer
+
+Provides time measurement and sleeping. Two backends:
+
+- **HPET** (High Precision Event Timer): preferred. Discovered via ACPI.
+- **PIT** (Programmable Interval Timer, 8253): fallback. Always available.
+
+```rust
+pub trait Timer {
+    fn now_ns(&self) -> u64;          // nanoseconds since boot
+    fn sleep_ns(&self, ns: u64);      // block until elapsed
+}
+
+pub struct Instant(u64);  // nanoseconds since boot
+
+impl Instant {
+    pub fn now() -> Self { Self(TIMER.now_ns()) }
+    pub fn elapsed(&self) -> Duration { Duration::from_nanos(TIMER.now_ns() - self.0) }
+}
+```
+
+smoltcp requires an `Instant` type. The `libos-timer` module provides one that satisfies
+smoltcp's `Instant` trait.
+
+### pci
+
+Enumerates the PCI bus and provides device discovery.
+
+```rust
+pub struct PciDevice {
+    pub bus: u8,
+    pub device: u8,
+    pub function: u8,
+    pub vendor_id: u16,
+    pub device_id: u16,
+    pub bar: [u32; 6],   // Base Address Registers
+}
+
+pub fn enumerate() -> Vec<PciDevice> { ... }
+
+pub fn find(vendor_id: u16, device_id: u16) -> Option<PciDevice> {
+    enumerate().into_iter().find(|d| d.vendor_id == vendor_id && d.device_id == device_id)
+}
+```
+
+### network (libos-net)
+
+A high-level networking API built on smoltcp. Hides the `Interface` / `SocketSet` complexity.
+
+```rust
+pub struct TcpListener { /* ... */ }
+pub struct TcpStream { /* ... */ }
+
+impl TcpListener {
+    pub fn bind(addr: IpEndpoint) -> Result<Self, Error> { ... }
+    pub fn accept(&mut self) -> Option<TcpStream> { ... }
+}
+
+impl TcpStream {
+    pub fn read(&mut self, buf: &mut [u8]) -> Result<usize, Error> { ... }
+    pub fn write(&mut self, buf: &[u8]) -> Result<usize, Error> { ... }
+    pub fn close(self) { ... }
+}
+
+/// Must be called in the main loop to advance smoltcp state machines.
+pub fn poll() {
+    IFACE.lock().poll(Instant::now(), &mut *DEVICE.lock(), &mut *SOCKETS.lock());
+}
+```
+
+The `libos-net` module's `TcpListener` and `TcpStream` implement the same `Listener` and
+`Connection` protocols from `irc-net-stdlib`. This means `ircd` compiles unchanged — the
+unikernel swap is purely at the module composition level.
+
+### nic-virtio
+
+virtio-net driver. Implements smoltcp's `Device` trait over virtio descriptor rings.
+
+```rust
+pub struct VirtioNet {
+    rx_queue: Virtqueue,
+    tx_queue: Virtqueue,
+    mac: EthernetAddress,
+}
+
+impl smoltcp::phy::Device for VirtioNet {
+    type RxToken<'a> = VirtioRxToken<'a>;
+    type TxToken<'a> = VirtioTxToken<'a>;
+
+    fn receive(&mut self, timestamp: Instant) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
+        // Check used ring for received frames
+    }
+
+    fn transmit(&mut self, timestamp: Instant) -> Option<Self::TxToken<'_>> {
+        // Return a token that writes to the TX descriptor ring on consume()
+    }
+
+    fn capabilities(&self) -> DeviceCapabilities {
+        let mut caps = DeviceCapabilities::default();
+        caps.max_transmission_unit = 1514;
+        caps.medium = Medium::Ethernet;
+        caps
+    }
+}
+```
+
+### storage (libos-storage)
+
+A block device abstraction:
+
+```rust
+pub trait BlockDevice {
+    fn block_size(&self) -> usize;
+    fn read_block(&mut self, block_idx: u64, buf: &mut [u8]) -> Result<(), Error>;
+    fn write_block(&mut self, block_idx: u64, buf: &[u8]) -> Result<(), Error>;
+}
+```
+
+### blk-virtio
+
+Implements `BlockDevice` using virtio-blk descriptor rings. Structurally identical to
+`nic-virtio` but for disk I/O.
+
+### fs-fat
+
+FAT32 filesystem on top of any `BlockDevice`. Provides file open/read/write/close:
+
+```rust
+pub struct FatFs<D: BlockDevice> { ... }
+
+impl<D: BlockDevice> FatFs<D> {
+    pub fn open(&mut self, path: &str) -> Result<File, Error> { ... }
+    pub fn read(&mut self, file: &mut File, buf: &mut [u8]) -> Result<usize, Error> { ... }
+    pub fn write(&mut self, file: &mut File, buf: &[u8]) -> Result<usize, Error> { ... }
+}
+```
+
+---
+
+## Boot Sequence (Generic)
+
+```
+VM start
+    │
+GRUB / rust-osdev/bootloader
+    Load ELF into memory
+    Set up protected / long mode
+    Pass Multiboot2 info → jump to _start()
+    │
+_start() [libos-boot]
+    Set RSP to STACK_TOP
+    Zero BSS
+    Parse memory map from Multiboot2
+    Call libos_main()
+    │
+libos_main() [application-defined]
+    init_heap(heap_start, heap_size)   [libos-alloc]
+    serial::init()                     [libos-serial, if included]
+    interrupts::init()                 [libos-interrupts]
+    timer::init()                      [libos-timer, if included]
+    pci::enumerate()                   [libos-pci, if included]
+    nic = VirtioNet::init(pci_dev)     [libos-nic-virtio, if included]
+    net::init(nic, ip_config)          [libos-net, if included]
+    // ... any other modules ...
+    application_main()                 [application code]
+```
+
+---
+
+## Application Entry Points
+
+### IRC server
+
+```rust
+fn application_main() -> ! {
+    let mut server = IRCServer::new("irc.local", vec!["Welcome.".into()]);
+    let listener = TcpListener::bind(IpEndpoint::new(IpAddress::v4(0, 0, 0, 0), 6667)).unwrap();
+    loop {
+        net::poll();  // advance smoltcp
+        if let Some(stream) = listener.accept() {
+            // handle IRC connection (single-threaded: handle one at a time, or maintain a list)
+        }
+    }
+}
+```
+
+### Minimal "hello world" unikernel (no network, no storage)
+
+```rust
+// Cargo.toml: only libos-boot, libos-alloc, libos-panic, libos-serial
+
+fn application_main() -> ! {
+    serial_println!("Hello from bare metal!");
+    loop {
+        x86_64::instructions::hlt();
+    }
+}
+```
+
+### HTTP file server (network + storage + FAT)
+
+```rust
+// Cargo.toml: all core + libos-net, libos-nic-virtio, libos-storage, libos-blk-virtio, libos-fs-fat
+
+fn application_main() -> ! {
+    let disk = VirtioBlk::init(pci::find(VIRTIO_VENDOR, VIRTIO_BLK_DEVICE).unwrap());
+    let fs = FatFs::new(disk);
+    let listener = TcpListener::bind(/* :80 */);
+    loop {
+        net::poll();
+        if let Some(stream) = listener.accept() {
+            serve_http(stream, &mut fs);
+        }
+    }
+}
+```
+
+---
+
+## Build System
+
+```toml
+# .cargo/config.toml
+[build]
+target = "x86_64-unknown-none"
+
+[unstable]
+build-std = ["core", "alloc", "compiler_builtins"]
+build-std-features = ["compiler-builtins-mem"]
+```
+
+```bash
+# Build
+cargo build --target x86_64-unknown-none --release
+
+# Create bootable disk image (using rust-osdev/bootimage)
+cargo bootimage
+
+# Run in QEMU (with virtio-net for applications that need networking)
+qemu-system-x86_64 \
+    -kernel target/x86_64-unknown-none/release/myapp \
+    -nographic \
+    -serial stdio \
+    -netdev tap,id=net0,ifname=tap0,script=no,downscript=no \
+    -device virtio-net-pci,netdev=net0 \
+    -m 128M
+
+# Run without networking (pure compute / storage app)
+qemu-system-x86_64 \
+    -kernel target/x86_64-unknown-none/release/myapp \
+    -nographic \
+    -serial stdio \
+    -m 32M
+```
+
+---
+
+## Development Milestones
+
+| Milestone | Modules | Test |
+|---|---|---|
+| M1: Bare metal boot | boot, panic, serial | "hello" appears on serial console |
+| M2: Heap | + alloc | `Vec::new()` and `String::from()` work |
+| M3: Interrupts | + interrupts | Timer ticks appear on serial; page faults caught |
+| M4: PCI | + pci | PCI devices enumerated and logged |
+| M5: NIC | + nic-virtio | virtio-net initialized; MAC address printed |
+| M6: Network | + network | Ping from host succeeds; TCP connection established |
+| M7: Application | application code | IRC / HTTP / etc. working over virtio-net |
+| M8: Storage | + blk-virtio | Block reads/writes work |
+| M9: Filesystem | + fs-fat | Files read from FAT32 disk image |
+
+---
+
+## Related Specs
+
+- [irc-architecture.md](irc-architecture.md) — IRC system overview
+- [irc-net-smoltcp.md](irc-net-smoltcp.md) — Userspace TCP (the `libos-net` module's engine)

--- a/code/specs/ircd.md
+++ b/code/specs/ircd.md
@@ -1,0 +1,336 @@
+# ircd — The IRC Server Program
+
+## Overview
+
+`ircd` is the program that wires all packages together. It is the only place in the system
+that knows about the specific `irc-net-*` implementation being used. Everything else — the IRC
+logic, framing, and parsing — is isolated in packages with stable interfaces.
+
+`ircd` is not a library. It is an executable. Its job is small:
+1. Parse CLI arguments and build a configuration
+2. Create a `Listener` from the chosen `irc-net-*` implementation
+3. Create an `IRCServer` from `irc-server`
+4. Wire them together through a `DriverHandler` adapter
+5. Call `EventLoop.run()` and block until shutdown
+
+Because `ircd` is thin, porting it to a new language is fast. The work is in the packages.
+
+---
+
+## Layer Position
+
+```
+ircd                    ← THIS SPEC: the program; wires all packages
+    ├── irc-server      (IRC state machine)
+    ├── irc-proto       (parsing/serialization)
+    ├── irc-framing     (byte stream → frames)
+    └── irc-net-*       (chosen network implementation)
+```
+
+---
+
+## CLI Interface
+
+```
+ircd [OPTIONS]
+
+Options:
+  --host HOST          IP address to listen on (default: 0.0.0.0)
+  --port PORT          TCP port to listen on (default: 6667)
+  --server-name NAME   IRC server name sent in responses (default: irc.local)
+  --motd TEXT          Message of the Day (default: "Welcome.")
+  --net-impl IMPL      Network implementation to use (default: stdlib)
+                       Choices: stdlib, selectors, epoll, smoltcp
+  --oper-pass PASS     IRC operator password for OPER command (default: none)
+  --max-conns N        Maximum simultaneous connections (default: unlimited)
+  --help               Show this help message and exit
+  --version            Show version and exit
+```
+
+Example:
+```bash
+ircd --host 0.0.0.0 --port 6667 --server-name irc.example.com \
+     --motd "Welcome to my IRC server." --net-impl selectors
+```
+
+---
+
+## Configuration
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Config:
+    host: str = "0.0.0.0"
+    port: int = 6667
+    server_name: str = "irc.local"
+    motd: list[str] = field(default_factory=lambda: ["Welcome."])
+    net_impl: str = "stdlib"
+    oper_password: str = ""
+    max_connections: int | None = None
+
+
+def parse_args(argv: list[str]) -> Config:
+    """Parse sys.argv[1:] into a Config.
+
+    Raises SystemExit with an error message on invalid arguments.
+    """
+    ...
+```
+
+---
+
+## Wiring: The DriverHandler Adapter
+
+`IRCServer` (from `irc-server`) implements the `Handler` protocol. But the `EventLoop` calls
+`on_connect`, `on_message`, and `on_disconnect` with `ConnId` values, while `IRCServer` returns
+`list[tuple[ConnId, Message]]` responses that need to be written to the network.
+
+The `DriverHandler` adapter sits between them:
+
+```python
+from __future__ import annotations
+
+from irc_framing import Framer
+from irc_net_stdlib import StdlibConnection, EventLoop  # or whichever impl
+from irc_proto import Message, parse, serialize
+from irc_server import IRCServer, ConnId
+
+
+class DriverHandler:
+    """Adapts IRCServer to the EventLoop.Handler protocol.
+
+    Responsibilities:
+    - Maintains per-connection Framer instances
+    - Calls IRCServer methods and dispatches responses
+    - Serializes access to IRCServer (if the event loop is multi-threaded)
+    - Handles encoding errors gracefully
+    """
+
+    def __init__(self, server: IRCServer, send_fn: SendFn) -> None:
+        self._server = server
+        self._send = send_fn          # callable: (ConnId, bytes) -> None
+        self._framers: dict[ConnId, Framer] = {}
+
+    def on_connect(self, conn_id: ConnId, host: str) -> None:
+        self._framers[conn_id] = Framer()
+        responses = self._server.on_connect(conn_id, host)
+        self._dispatch(responses)
+
+    def on_data(self, conn_id: ConnId, data: bytes) -> None:
+        """Called by the event loop when raw bytes arrive."""
+        framer = self._framers.get(conn_id)
+        if framer is None:
+            return
+        framer.feed(data)
+        for frame in framer.frames():
+            try:
+                msg = parse(frame.decode("utf-8", errors="replace"))
+            except Exception:
+                continue   # malformed message; skip
+            responses = self._server.on_message(conn_id, msg)
+            self._dispatch(responses)
+
+    def on_disconnect(self, conn_id: ConnId) -> None:
+        self._framers.pop(conn_id, None)
+        responses = self._server.on_disconnect(conn_id)
+        self._dispatch(responses)
+
+    def _dispatch(self, responses: list[tuple[ConnId, Message]]) -> None:
+        for target_id, msg in responses:
+            self._send(target_id, serialize(msg))
+
+
+# Type alias for the send callback
+from typing import Callable
+SendFn = Callable[[ConnId, bytes], None]
+```
+
+---
+
+## Main Entry Point
+
+```python
+from __future__ import annotations
+
+import signal
+import sys
+
+from irc_net_stdlib import StdlibEventLoop, StdlibListener
+from irc_server import IRCServer
+
+
+def make_event_loop(net_impl: str) -> tuple[object, object]:
+    """Construct the appropriate Listener and EventLoop for net_impl."""
+    if net_impl == "stdlib":
+        from irc_net_stdlib import StdlibEventLoop, StdlibListener
+        return StdlibListener, StdlibEventLoop
+    elif net_impl == "selectors":
+        from irc_net_selectors import SelectorsEventLoop, SelectorsListener
+        return SelectorsListener, SelectorsEventLoop
+    elif net_impl == "epoll":
+        from irc_net_epoll import EpollEventLoop, EpollListener
+        return EpollListener, EpollEventLoop
+    else:
+        print(f"Unknown net-impl: {net_impl}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main(argv: list[str] | None = None) -> None:
+    config = parse_args(argv or sys.argv[1:])
+
+    ListenerClass, EventLoopClass = make_event_loop(config.net_impl)
+
+    listener = ListenerClass(config.host, config.port)
+    event_loop = EventLoopClass()
+
+    server = IRCServer(
+        server_name=config.server_name,
+        motd=config.motd,
+        oper_password=config.oper_password,
+    )
+
+    handler = DriverHandler(server, send_fn=event_loop.send_to)
+
+    # Graceful shutdown on SIGINT / SIGTERM
+    def shutdown(signum: int, frame: object) -> None:
+        print("\nShutting down...", flush=True)
+        event_loop.stop()
+
+    signal.signal(signal.SIGINT, shutdown)
+    signal.signal(signal.SIGTERM, shutdown)
+
+    print(f"ircd listening on {config.host}:{config.port} [{config.net_impl}]", flush=True)
+    event_loop.run(listener, handler)
+    listener.close()
+    print("ircd stopped.", flush=True)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+---
+
+## Graceful Shutdown
+
+On SIGINT or SIGTERM:
+1. `event_loop.stop()` signals the event loop to exit its run loop
+2. The event loop sends `ERROR :Server shutting down` to all connected clients
+3. The event loop closes all connection sockets
+4. `listener.close()` closes the listening socket
+5. The program exits with code 0
+
+The `ERROR` message is required by RFC 1459 when a server disconnects a client.
+
+---
+
+## Startup Validation
+
+Before calling `event_loop.run()`, `ircd` validates the configuration:
+
+```python
+def validate_config(config: Config) -> None:
+    """Raise ValueError with a descriptive message if config is invalid."""
+    if not 1 <= config.port <= 65535:
+        raise ValueError(f"Port must be 1–65535, got {config.port}")
+    if not config.server_name:
+        raise ValueError("Server name must not be empty")
+    if config.max_connections is not None and config.max_connections < 1:
+        raise ValueError("max-connections must be at least 1")
+```
+
+Port binding failures (address already in use, permission denied for ports < 1024) are caught
+at listener construction and reported with a clear message before exit.
+
+---
+
+## Language Mappings
+
+| Language | CLI parsing | Signal handling | Entry point |
+|---|---|---|---|
+| Python | `argparse` | `signal.signal` | `if __name__ == "__main__"` |
+| Go | `flag` package | `signal.Notify` | `func main()` |
+| TypeScript | `process.argv`, `minimist` | `process.on('SIGINT')` | top-level module |
+| Ruby | `OptionParser` | `Signal.trap` | executable script |
+| Elixir | `OptionParser` | `System.at_exit` | `mix run` / escript |
+| Rust | `clap` | `ctrlc` crate | `fn main()` |
+| Kotlin | `kotlinx.cli` | `Runtime.getRuntime().addShutdownHook` | `fun main()` |
+| Swift | `ArgumentParser` | `signal(SIGINT, ...)` | `@main struct` |
+| C# | `System.CommandLine` | `Console.CancelKeyPress` | `static void Main()` |
+| F# | `Argu` | `Console.CancelKeyPress` | `[<EntryPoint>] let main` |
+
+---
+
+## Test Strategy
+
+### Unit tests
+
+- `parse_args`: valid args, missing required args, invalid port number, unknown net-impl
+- `validate_config`: port out of range, empty server name, zero max-connections
+- `DriverHandler`: feed raw bytes, verify correct IRCServer methods called; verify responses
+  dispatched to correct ConnIds; verify framer per-connection isolation
+
+### Integration tests
+
+The integration test suite starts a real `ircd` process and connects with raw TCP sockets.
+It does not depend on any IRC client library — it sends and parses raw protocol text.
+
+```python
+def test_registration() -> None:
+    """Full registration flow over a real TCP socket."""
+    with socket.create_connection(("127.0.0.1", 6667), timeout=5) as s:
+        s.sendall(b"NICK testbot\r\nUSER testbot 0 * :Test Bot\r\n")
+        buf = b""
+        while b"376" not in buf:  # wait for end of MOTD
+            buf += s.recv(4096)
+        assert b"001" in buf
+        assert b"testbot" in buf
+
+
+def test_channel_message() -> None:
+    """Two clients in a channel; message delivered to both."""
+    with socket.create_connection(("127.0.0.1", 6667)) as a, \
+         socket.create_connection(("127.0.0.1", 6667)) as b:
+        register(a, "alice")
+        register(b, "bob")
+        a.sendall(b"JOIN #test\r\n")
+        b.sendall(b"JOIN #test\r\n")
+        wait_for(a, "366")   # end of names
+        wait_for(b, "366")
+        a.sendall(b"PRIVMSG #test :hello\r\n")
+        response = recv_until(b, "PRIVMSG")
+        assert b"hello" in response
+```
+
+### End-to-end test with WeeChat
+
+Manual test script:
+```
+1. Start ircd on port 6667
+2. Open WeeChat: /connect localhost 6667
+3. Verify: welcome message received, MOTD displayed
+4. /join #test
+5. Open second WeeChat session, join #test
+6. Send messages from both sessions; verify delivery
+7. /quit from one session; verify QUIT notice in other
+8. Kill ircd with Ctrl-C; verify WeeChat shows disconnect
+```
+
+---
+
+## Related Specs
+
+- [irc-architecture.md](irc-architecture.md) — System overview and layer diagram
+- [irc-proto.md](irc-proto.md) — Message parsing and serialization
+- [irc-framing.md](irc-framing.md) — Byte stream framing
+- [irc-server.md](irc-server.md) — IRC state machine
+- [irc-net-stdlib.md](irc-net-stdlib.md) — Default network implementation
+- [irc-net-selectors.md](irc-net-selectors.md) — Event-driven network implementation
+- [irc-net-epoll.md](irc-net-epoll.md) — Raw syscall implementation
+- [irc-net-smoltcp.md](irc-net-smoltcp.md) — Userspace TCP (Rust)
+- [irc-unikernel.md](irc-unikernel.md) — Bare metal unikernel (Rust)


### PR DESCRIPTION
## Summary

- Adds 10 spec documents defining the complete IRC server architecture across all supported languages
- Establishes a Russian Nesting Doll layer model: each layer has a stable interface and a swappable implementation, from stdlib TCP all the way to a bare-metal unikernel
- Defines stable `Connection`/`Listener`/`EventLoop` interfaces that never change as implementations are peeled back
- Captures the long-term unikernel vision as a generic, modular LibOS framework (not IRC-specific)

## Specs added

| File | Purpose |
|---|---|
| `irc-architecture.md` | System overview, layer diagram, language rollout, unikernel vision |
| `irc-proto.md` | RFC 1459 message parsing/serialization — pure, no I/O |
| `irc-framing.md` | Byte stream → CRLF frames — pure, buffered |
| `irc-server.md` | IRC state machine — full RFC 1459 command set |
| `irc-net-stdlib.md` | Level 1: stdlib sockets + threads; defines stable interfaces |
| `irc-net-selectors.md` | Level 2: single-threaded reactor (Python selectors / mio) |
| `irc-net-epoll.md` | Level 3: raw epoll/kqueue syscalls |
| `irc-net-smoltcp.md` | Level 4: userspace TCP via smoltcp (Rust only) |
| `irc-unikernel.md` | Level 5: generic modular LibOS framework (boot, alloc, net, storage, etc.) |
| `ircd.md` | The program: wiring, CLI, DriverHandler adapter, integration tests |

## Test plan

- [ ] Specs are consistent — `ConnId`, `Message`, `Handler` types match across all 10 docs
- [ ] `irc-architecture.md` links to all other specs
- [ ] Unikernel milestone table is traceable from M1 (serial hello) to M7 (IRC over virtio-net)
- [ ] All Python pseudocode uses full type annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)