### PR TITLE
feat(specs): Venture browser specification suite

### DIFF
--- a/code/specs/BR01-venture-browser.md
+++ b/code/specs/BR01-venture-browser.md
@@ -1,0 +1,514 @@
+# BR01 — Venture: A Cross-Platform Native Web Browser
+
+## Overview
+
+Venture is a cross-platform native web browser built entirely from educational
+packages in the coding-adventures monorepo. Rather than embedding a massive
+rendering engine like Chromium or Gecko, Venture is a **thin orchestrator** — a
+shell that wires together a pipeline of small, focused crates that each handle
+one step of turning a URL into pixels on screen.
+
+**Venture v0.1** targets feature parity with **NCSA Mosaic 1.0** (1993), the
+browser that made the World Wide Web accessible to ordinary people.
+
+### Why Mosaic?
+
+NCSA Mosaic was released on **April 22, 1993** by Marc Andreessen and Eric Bina
+at the University of Illinois at Urbana-Champaign. Before Mosaic, web browsers
+existed — Tim Berners-Lee's WorldWideWeb (1990), ViolaWWW (1992), Erwise
+(1992) — but they were academic tools used almost exclusively by researchers.
+
+Mosaic changed everything:
+
+- **Inline images** — previous browsers opened images in separate windows.
+  Mosaic rendered `<img>` tags directly in the document flow, making pages
+  visually rich for the first time.
+- **Proportional fonts** — earlier browsers used monospace text exclusively.
+  Mosaic used Times New Roman and other proportional typefaces, making pages
+  feel like printed documents.
+- **Friendly GUI** — toolbar buttons for Back, Forward, Home, and Reload. A
+  URL bar you could type into. A status bar showing loading progress. These
+  conventions survive unchanged in every browser today.
+- **Cross-platform** — versions shipped for X Window System (Unix), Macintosh,
+  and Windows, bringing the web to every desktop.
+
+Mosaic was the **Macintosh moment** for the web. Within 18 months of its
+release, web traffic went from 0.1% of internet backbone traffic to 97%.
+Andreessen left UIUC to co-found Netscape, and the browser wars began.
+
+Venture v0.1 recreates this experience using the coding-adventures package
+ecosystem. The web in 1993 was simple enough that a single developer can
+understand the entire stack — from TCP socket to rendered pixel — and that is
+exactly the educational goal.
+
+## Where It Fits
+
+Venture sits at the top of the stack. It is a **program** (not a library) that
+consumes nearly every layer of the coding-adventures package ecosystem:
+
+```
+Layer 7 — Programs
+  └── BR01 Venture Browser  ← you are here
+
+Layer 6 — Platform Paint VMs
+  ├── P2D06 paint-vm-direct2d (Windows)
+  ├── P2D07 paint-vm-gdi (Windows fallback)
+  └── P2D08 paint-vm-cairo (Linux, future)
+
+Layer 5 — Layout & Paint Translation
+  ├── layout-block
+  ├── layout-to-paint
+  └── document-ast-to-layout
+
+Layer 4 — Document Model
+  ├── document-ast
+  ├── layout-ir
+  └── paint-instructions
+
+Layer 3 — Protocol Parsers
+  ├── http1.0-lexer / http1.0-parser / http1.0-client
+  └── html1.0-lexer / html1.0-parser
+
+Layer 2 — Network Primitives
+  ├── tcp-client
+  └── frame-extractor
+
+Layer 1 — Data Formats
+  ├── url-parser
+  └── text-measure-directwrite
+```
+
+Every box is a separate crate. Improving any crate automatically improves the
+browser. Adding CSS support in the future means adding a `css-lexer`,
+`css-parser`, and updating `document-ast-to-layout` — Venture itself barely
+changes.
+
+## Concepts
+
+### The Browser as a Pipeline
+
+A web browser is fundamentally a **data transformation pipeline**. A URL goes
+in, pixels come out. Each stage transforms one representation into the next:
+
+```
+URL (string)
+  │
+  ▼
+url-parser ──────────────────► ParsedUrl { scheme, host, port, path }
+  │
+  ▼
+tcp-client ──────────────────► TcpStream (raw bytes)
+  │
+  ▼
+http1.0-client ──────────────► HttpResponse { status, headers, body }
+  │
+  ▼
+html1.0-parser ──────────────► DocumentNode (tree of elements & text)
+  │
+  ▼
+document-ast-to-layout ──────► LayoutNode (styled tree with fonts/colors)
+  │
+  ▼
+layout-block ────────────────► PositionedNode (x, y, width, height for each node)
+  │
+  ▼
+layout-to-paint ─────────────► PaintScene (list of draw commands)
+  │
+  ▼
+paint-vm-direct2d ───────────► Pixels on screen
+```
+
+This pipeline architecture means:
+
+1. **Each stage is independently testable.** You can unit-test the HTML parser
+   without a network connection. You can test layout without a window.
+2. **Each stage is independently replaceable.** Swap `paint-vm-direct2d` for
+   `paint-vm-metal` and you have macOS support — no other code changes.
+3. **The browser shell is trivial.** It just calls each stage in sequence and
+   manages user interaction (clicks, scrolling, navigation).
+
+### Navigation Model
+
+A browser's navigation state is two stacks and a pointer:
+
+```
+     back_stack          current_url         forward_stack
+    ┌──────────┐                             ┌──────────┐
+    │ page_1   │        page_3               │ page_4   │
+    │ page_2   │                             │ page_5   │
+    └──────────┘                             └──────────┘
+
+    Navigate to X:  push current → back_stack, clear forward_stack, current = X
+    Back:           push current → forward_stack, current = back_stack.pop()
+    Forward:        push current → back_stack, current = forward_stack.pop()
+    Home:           navigate to home_url (same as Navigate)
+    Reload:         re-fetch current_url, re-run pipeline
+```
+
+This is the same model every browser uses today. The back and forward stacks
+are `Vec<String>` — just lists of URLs.
+
+### Hit-Testing
+
+When the user clicks somewhere in the content area, the browser needs to
+determine what they clicked on. This is **hit-testing**: given an (x, y) screen
+coordinate, find the element at that position.
+
+During the layout-to-paint stage, each link gets recorded as a `LinkRegion`:
+
+```rust
+struct LinkRegion {
+    rect: Rect,         // bounding box in content coordinates
+    url: String,        // destination URL
+}
+```
+
+On mouse click:
+1. Adjust click position by scroll offset: `content_y = click_y + scroll_y`
+2. Linear scan through link regions (fine for Mosaic-era page complexity)
+3. If a region contains the point → navigate to that URL
+4. If no region matches → do nothing
+
+### Scrolling
+
+The content of a web page is typically taller than the window. Scrolling shifts
+which portion of the content is visible:
+
+```
+                    ┌─────────────────┐
+                    │  viewport_height │
+    scroll_y = 0 → │  ╔═══════════╗  │ ← visible region
+                    │  ║           ║  │
+                    │  ║  content  ║  │
+                    │  ║           ║  │
+                    │  ╚═══════════╝  │
+                    │                 │
+                    │  (more content  │
+                    │   below...)     │
+                    │                 │
+                    │content_height   │
+                    └─────────────────┘
+
+Scroll down → scroll_y increases → viewport slides down the content
+Clamped to: 0 <= scroll_y <= max(0, content_height - viewport_height)
+```
+
+Implementation: apply `scroll_y` as a negative Y translation to the entire
+PaintScene before rendering. The paint VM sees pre-translated coordinates.
+
+## Architecture
+
+### Full Pipeline Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     Venture Browser (BR01)                       │
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │                 Thin Orchestrator Shell                    │   │
+│  │  - Win32 message loop          - Navigation state         │   │
+│  │  - UI chrome (URL bar, toolbar) - Scroll management       │   │
+│  │  - Link hit-testing            - Bookmarks                │   │
+│  └──────────────────────────────────────────────────────────┘   │
+│                              │                                    │
+│                              ▼                                    │
+│  ┌────────────────── Pipeline Packages ─────────────────────┐   │
+│  │                                                            │   │
+│  │  url-parser → tcp-client → frame-extractor                │   │
+│  │                  → http1.0-lexer → http1.0-parser         │   │
+│  │                      → html1.0-lexer → html1.0-parser     │   │
+│  │                          → document-ast                    │   │
+│  │                              → document-ast-to-layout      │   │
+│  │                                  → layout-block            │   │
+│  │                                      → layout-to-paint     │   │
+│  │                                          → paint-vm-direct2d│  │
+│  └────────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+Every box in the pipeline is a separate crate. Improving any crate improves
+the browser.
+
+### Platform Abstraction
+
+The browser itself has a thin platform layer. Only Windows is implemented for
+v0.1; macOS and Linux are future work.
+
+| Platform | Window              | Rendering                                     | Text Measurement           |
+|----------|---------------------|-----------------------------------------------|----------------------------|
+| Windows  | Win32 CreateWindowExW | paint-vm-direct2d (P2D06) or paint-vm-gdi (P2D07) | text-measure-directwrite  |
+| macOS    | Cocoa NSWindow (future) | paint-vm-metal (exists, partial)            | text-measure-coretext (future) |
+| Linux    | GTK/X11 (future)    | paint-vm-cairo (P2D08, future)                | text-measure-pango (future) |
+
+### Win32 Window Structure
+
+```
+┌─────────────────────────────────────────┐
+│ Venture - http://info.cern.ch/          │  ← Window title = page title + URL
+├─────────────────────────────────────────┤
+│ [Back] [Fwd] [Home] [Reload] │ URL bar │  ← Toolbar + EDIT control
+├─────────────────────────────────────────┤
+│                                         │
+│  World Wide Web                         │  ← Content area (Direct2D render target)
+│                                         │
+│  The WorldWideWeb (W3) is a wide-area   │    Scrollable via WM_MOUSEWHEEL
+│  hypermedia information retrieval        │
+│  initiative aiming to give universal     │
+│  access to a large universe of           │
+│  documents.                              │
+│                                         │
+│  Everything there is online about W3    │  ← Blue underlined = unvisited link
+│  is linked directly or indirectly to    │
+│  this document...                       │
+│                                         │
+├─────────────────────────────────────────┤
+│ Done                                    │  ← Status bar: loading / hovered link URL
+└─────────────────────────────────────────┘
+```
+
+The window is composed of standard Win32 controls:
+
+- **Title bar**: `SetWindowTextW` — updated to show page title and URL.
+- **Toolbar**: child `HWND`s — BUTTON controls for Back, Forward, Home, Reload.
+- **URL bar**: EDIT control. User presses Enter → navigate.
+- **Content area**: owner-drawn region. Venture creates a Direct2D render target
+  over this area and paints the PaintScene into it on `WM_PAINT`.
+- **Status bar**: STATIC control at the bottom. Shows "Loading...", "Done", or
+  the URL of the link under the cursor.
+
+### Loading a Page — Full Sequence
+
+When the user enters a URL or clicks a link, this is everything that happens:
+
+```
+User action (Enter key / link click)
+  │
+  ├─ 1. Push current URL to back_stack, clear forward_stack
+  │
+  ├─ 2. Show "Loading..." in status bar
+  │
+  ├─ 3. url_parser::parse(url_string) → ParsedUrl
+  │     - Resolve relative URLs against current page base URL
+  │
+  ├─ 4. http1_0_client::get(parsed_url) → HttpResponse
+  │     - Internally: tcp_client::connect → send request → frame_extractor
+  │     - Returns: status code, headers, body bytes
+  │
+  ├─ 5. Check Content-Type header:
+  │     - "text/html" → proceed to step 6
+  │     - "image/*"   → display standalone image
+  │     - other       → show raw text in monospace
+  │
+  ├─ 6. html1_0_parser::parse(response.body) → DocumentNode tree
+  │
+  ├─ 7. document_ast_to_layout(doc, mosaic_theme) → LayoutNode tree
+  │     - Apply Mosaic-era font/color defaults
+  │     - Annotate links with destination URLs
+  │
+  ├─ 8. layout_block(layout, viewport_width, measurer) → PositionedNode tree
+  │     - Compute x, y, width, height for every node
+  │     - Text shaping via text-measure-directwrite
+  │
+  ├─ 9. layout_to_paint(positioned, device_pixel_ratio) → PaintScene
+  │     - Convert layout tree to flat list of paint instructions
+  │
+  ├─ 10. Store PaintScene + Vec<LinkRegion> for hit-testing
+  │
+  ├─ 11. InvalidateRect(hwnd) → triggers WM_PAINT
+  │      → paint_vm_direct2d::render(scene, render_target)
+  │
+  └─ 12. Show "Done" in status bar
+```
+
+### Link Handling
+
+During `document-ast-to-layout`, each `<a href="...">` is annotated with both
+its destination URL and a color/underline style:
+
+- **Unvisited links**: `#0000EE` (blue) with underline
+- **Visited links**: `#551A8B` (purple) with underline
+
+Visited URLs are tracked in a `HashSet<String>` for the lifetime of the
+session (not persisted in v0.1).
+
+On **WM_MOUSEMOVE**:
+1. Hit-test mouse position against link regions
+2. If hovering a link: show URL in status bar, set cursor to `IDC_HAND`
+3. If not hovering: show "Done" in status bar, set cursor to `IDC_ARROW`
+
+On **WM_LBUTTONDOWN**:
+1. Hit-test mouse position against link regions
+2. If a link was clicked: resolve relative URL against current page, navigate
+
+### Image Loading
+
+When the HTML parser encounters `<img src="photo.gif">`:
+
+1. The `DocumentNode` tree contains an `ImageNode { src, alt }`.
+2. During layout, the image source URL is resolved against the page base URL.
+3. A separate `http1_0_client::get()` call fetches the image data.
+4. The `image` crate decodes the data (GIF or JPEG for v0.1) into pixels.
+5. The pixel data becomes a `PaintImage` instruction in the `PaintScene`.
+6. If the image fails to load: render the alt text inside a bordered box
+   (the classic "broken image" experience).
+
+For v0.1, images are loaded synchronously (blocking the UI). Asynchronous
+image loading is a future enhancement.
+
+Supported formats: **GIF** and **JPEG** (via the `image` crate). BMP is
+already implemented in the repo (`image-codec-bmp`) but was rare on the 1993
+web.
+
+### Scrolling
+
+- Track `scroll_y: f64` offset, starting at 0.0.
+- On `WM_MOUSEWHEEL`: adjust `scroll_y` by delta, clamp to
+  `[0, max(0, content_height - viewport_height)]`.
+- Apply `scroll_y` as a negative Y translation before rendering — wrap the
+  entire PaintScene in a `PaintGroup` with a translate transform.
+- Scrollbar: native Win32 scrollbar via `SetScrollInfo` / `WM_VSCROLL`,
+  reflecting current scroll position and content height.
+
+### Mosaic-Era Theme Defaults
+
+Venture v0.1 uses styling that matches the original Mosaic look and feel:
+
+```rust
+DocumentTheme {
+    body_font: "Times New Roman",
+    body_font_size: 14.0,
+    heading_font: "Times New Roman",
+    heading_sizes: [24.0, 20.0, 18.0, 16.0, 14.0, 12.0],  // h1..h6
+    heading_bold: true,
+    code_font: "Courier New",
+    code_font_size: 13.0,
+    line_height: 1.4,
+    paragraph_spacing: 12.0,
+    link_color: "#0000EE",
+    visited_link_color: "#551A8B",
+    background_color: "#C0C0C0",  // the iconic Mosaic gray
+}
+```
+
+The gray background (`#C0C0C0`) is the most immediately recognizable Mosaic
+trait. Modern browsers default to white, but in 1993 the gray matched the
+system window color and felt "native."
+
+### Bookmarks
+
+- **Storage**: `%APPDATA%\Venture\bookmarks.json` (Windows),
+  `~/.venture/bookmarks.json` (Unix).
+- **Format**: JSON array of `{ "title": "...", "url": "..." }` objects.
+- **UI**: Menu bar → Bookmarks → "Add Bookmark" / list of saved bookmarks.
+- For v0.1, bookmarks are a **flat list** — no folders or hierarchy.
+
+### View Source
+
+- **Trigger**: Ctrl+U or menu View → Source.
+- Opens a **new window** showing the raw HTML text of the current page.
+- Implementation: wrap the raw HTML in a synthetic `<pre>` document and run it
+  through the same rendering pipeline. The "source" window is just another
+  Venture window with a fabricated document.
+
+### Dependencies (Cargo.toml)
+
+```toml
+[dependencies]
+url-parser             = { path = "../../../packages/rust/url-parser" }
+tcp-client             = { path = "../../../packages/rust/tcp-client" }
+frame-extractor        = { path = "../../../packages/rust/frame-extractor" }
+http1_0_lexer          = { path = "../../../packages/rust/http1.0-lexer" }
+http1_0_parser         = { path = "../../../packages/rust/http1.0-parser" }
+http1_0_client         = { path = "../../../packages/rust/http1.0-client" }
+html1_0_lexer          = { path = "../../../packages/rust/html1.0-lexer" }
+html1_0_parser         = { path = "../../../packages/rust/html1.0-parser" }
+document_ast           = { path = "../../../packages/rust/document-ast" }
+document_ast_to_layout = { path = "../../../packages/rust/document-ast-to-layout" }
+layout_ir              = { path = "../../../packages/rust/layout-ir" }
+layout_block           = { path = "../../../packages/rust/layout-block" }
+layout_to_paint        = { path = "../../../packages/rust/layout-to-paint" }
+paint_instructions     = { path = "../../../packages/rust/paint-instructions" }
+paint_vm_direct2d      = { path = "../../../packages/rust/paint-vm-direct2d" }
+text_measure_directwrite = { path = "../../../packages/rust/text-measure-directwrite" }
+windows                = { version = "0.58", features = ["..."] }
+image                  = "0.25"  # GIF and JPEG decoding
+```
+
+## Testing Strategy
+
+### Unit Tests
+
+1. **Navigation model** — Verify back/forward/home stack transitions:
+   - Navigate A → B → C, then Back → verify current=B, forward=[C]
+   - Forward → verify current=C, forward=[]
+   - Navigate A → B → C, Back, Navigate D → verify forward stack cleared
+
+2. **Link hit-testing** — Given a known set of `LinkRegion`s and a click
+   coordinate, verify the correct link (or no link) is returned.
+
+3. **Scroll offset clamping** — Verify scroll_y stays within bounds:
+   - Cannot go negative
+   - Cannot exceed `content_height - viewport_height`
+   - Content shorter than viewport → scroll_y stays at 0
+
+4. **URL resolution** — Relative URLs resolved correctly against page base:
+   - `href="page2.html"` on `http://example.com/dir/page1.html`
+     → `http://example.com/dir/page2.html`
+
+5. **Bookmark persistence** — Add/remove bookmarks, verify JSON round-trip.
+
+### Integration Tests
+
+6. **Canned HTML rendering** — Load a known HTML file, run it through the full
+   pipeline, verify the resulting `PaintScene` contains expected instructions
+   (e.g., text at expected positions, link with expected color).
+
+7. **Live page load** — Load `http://info.cern.ch/` (the first web page, still
+   online), verify it renders without panic and produces a non-empty PaintScene.
+
+8. **Image loading** — Load an HTML page with an `<img>` tag, verify the
+   PaintScene contains a `PaintImage` instruction with correct dimensions.
+
+### Visual Tests
+
+9. **Screenshot comparison** — Render known pages and compare against reference
+   screenshots of original NCSA Mosaic. This is not pixel-perfect matching but
+   a qualitative check that the rendering "looks right."
+
+### Manual Test Scenarios
+
+10. **Full navigation flow** — Open Venture, navigate to info.cern.ch, click
+    links, use Back/Forward, add a bookmark, view source.
+
+## Scope
+
+### In Scope (Venture v0.1)
+
+- URL bar navigation with Enter key
+- Back, Forward, Home, Reload toolbar buttons
+- HTML 1.0 rendering via the full pipeline
+- Vertical scrolling with mouse wheel and scrollbar
+- Link clicking with hit-testing and navigation
+- Inline images (GIF, JPEG) loaded synchronously
+- Unvisited/visited link colors (blue/purple)
+- Bookmarks: add, list, click to navigate
+- View Source (Ctrl+U)
+- Status bar: "Loading..." / "Done" / hovered link URL
+- Window title: page title + URL
+- Windows platform only (Direct2D primary, GDI fallback)
+
+### Out of Scope (Future Versions)
+
+- Multiple windows or tabs
+- Printing
+- HTTPS / TLS
+- HTML forms (`<form>`, `<input>`)
+- JavaScript
+- CSS (beyond inline Mosaic-era defaults)
+- Download manager
+- HTTP cache
+- Proxy configuration
+- Find in page (Ctrl+F)
+- History persistence across sessions (in-memory only for v0.1)
+- Asynchronous image loading
+- macOS platform layer (Cocoa + Metal)
+- Linux platform layer (GTK + Cairo)

--- a/code/specs/NET00-url-parser.md
+++ b/code/specs/NET00-url-parser.md
@@ -1,0 +1,344 @@
+# NET00 — URL Parser
+
+## Overview
+
+A URL (Uniform Resource Locator) is a string that tells you **where** something
+is on the internet and **how** to get it. Every time you type an address into a
+browser, click a link, or fetch an API — the first step is always the same:
+parse the URL.
+
+This package parses URLs according to RFC 1738 (1994), the specification that
+Mosaic and early web browsers used. It is deliberately simple — no
+Internationalized Domain Names, no `data:` URIs, no WHATWG URL Standard
+complexity. Just the fundamentals.
+
+**Analogy:** A URL is like a postal address:
+
+```
+  http://alice:secret@www.example.com:8080/docs/page.html?q=hello#section2
+  └─┬─┘ └────┬─────┘└──────┬───────┘└─┬─┘└─────┬───────┘└──┬───┘└───┬───┘
+ scheme  userinfo        host       port     path         query   fragment
+
+  scheme   = "how to deliver"    (http = web, ftp = file transfer)
+  host     = "which building"    (www.example.com)
+  port     = "which door"        (8080, defaults to 80 for http)
+  path     = "which room inside" (/docs/page.html)
+  query    = "what to ask for"   (?q=hello)
+  fragment = "which paragraph"   (#section2) — client-side only, never sent to server
+  userinfo = "credentials"       (alice:secret) — rare today, common in early web
+```
+
+## Where It Fits
+
+```
+User types "http://info.cern.ch/hypertext/WWW/TheProject.html"
+     │
+     ▼
+url-parser (NET00) ← THIS PACKAGE
+     │  Url { scheme: "http", host: "info.cern.ch",
+     │        port: 80, path: "/hypertext/WWW/TheProject.html" }
+     ▼
+tcp-client (NET01) — connect to info.cern.ch:80
+     │
+     ▼
+http1.0-client (NET05) — GET /hypertext/WWW/TheProject.html HTTP/1.0
+```
+
+**Depends on:** nothing (std only)
+**Depended on by:** http1.0-client (NET05), Venture browser (BR01)
+
+---
+
+## Concepts
+
+### What Is a URL?
+
+RFC 1738 defines the generic URL syntax:
+
+```
+<scheme>://<authority>/<path>?<query>#<fragment>
+```
+
+Where `<authority>` breaks down further:
+
+```
+<userinfo>@<host>:<port>
+```
+
+Not all parts are required. The minimal URL is just `scheme:path`, like
+`mailto:alice@example.com`. For HTTP URLs, the host is required but everything
+else has defaults.
+
+### Absolute vs. Relative URLs
+
+An **absolute URL** contains a scheme and a host — it stands alone:
+
+```
+http://www.example.com/docs/page.html
+```
+
+A **relative URL** is interpreted against a **base URL** — the URL of the
+current page:
+
+```
+Base:     http://www.example.com/docs/page.html
+Relative: ../images/photo.gif
+Resolved: http://www.example.com/images/photo.gif
+```
+
+Relative URLs were critical in early HTML. Almost every `<img src="...">` and
+`<a href="...">` used a relative path. The resolution algorithm is:
+
+1. If the relative URL has a scheme, it is already absolute — use it directly.
+2. If it starts with `//`, inherit only the scheme from base.
+3. If it starts with `/`, inherit scheme + authority, replace path.
+4. Otherwise, merge: take the base path up to the last `/`, append relative.
+5. Normalize: collapse `//` to `/`, resolve `.` and `..` segments.
+
+### Percent-Encoding
+
+URLs can only contain a limited set of ASCII characters. Anything else must be
+**percent-encoded**: the byte value written as `%XX` in hexadecimal.
+
+```
+Space      → %20
+Question   → %3F  (when literal, not as query delimiter)
+日本語     → %E6%97%A5%E6%9C%AC%E8%AA%9E  (UTF-8 bytes, each percent-encoded)
+```
+
+The **unreserved characters** that do NOT need encoding are:
+
+```
+A-Z  a-z  0-9  -  _  .  ~
+```
+
+Everything else is either a **reserved delimiter** (`/`, `?`, `#`, `@`, `:`)
+with special meaning in the URL structure, or must be percent-encoded.
+
+---
+
+## Public API
+
+```rust
+/// A parsed URL with all components separated.
+///
+/// All string fields are percent-decoded. The `raw` field preserves the
+/// original input for round-tripping.
+pub struct Url {
+    pub scheme: String,          // "http", "ftp", "mailto" — lowercased
+    pub userinfo: Option<String>, // "alice:secret" or None
+    pub host: Option<String>,     // "www.example.com" — lowercased
+    pub port: Option<u16>,        // explicit port, or None (use scheme default)
+    pub path: String,             // "/docs/page.html" — always starts with / for http
+    pub query: Option<String>,    // "q=hello&lang=en" — without the leading ?
+    pub fragment: Option<String>, // "section2" — without the leading #
+    raw: String,                  // original input, preserved verbatim
+}
+
+impl Url {
+    /// Parse an absolute URL string.
+    ///
+    /// Returns Err if the string is not a valid absolute URL (must have a
+    /// scheme). For relative URLs, use `resolve()` instead.
+    pub fn parse(input: &str) -> Result<Url, UrlError> { ... }
+
+    /// Resolve a relative URL against this URL as the base.
+    ///
+    /// Implements the RFC 1738 / RFC 1808 relative resolution algorithm:
+    /// - "http://other.com/x" → absolute, returned as-is
+    /// - "//other.com/x" → inherits scheme
+    /// - "/x" → inherits scheme + authority
+    /// - "x" → merges with base path
+    /// - "../x" → merges and resolves parent traversal
+    pub fn resolve(&self, relative: &str) -> Result<Url, UrlError> { ... }
+
+    /// The effective port — explicit port if set, otherwise scheme default.
+    ///
+    /// Returns 80 for http, 21 for ftp, 443 for https, None for unknown.
+    pub fn effective_port(&self) -> Option<u16> { ... }
+
+    /// The authority string: [userinfo@]host[:port]
+    pub fn authority(&self) -> String { ... }
+
+    /// Serialize back to a URL string.
+    ///
+    /// Percent-encodes components as needed. The result is a valid URL that
+    /// round-trips through parse().
+    pub fn to_string(&self) -> String { ... }
+}
+
+/// Percent-decode a string: "%20" → " ", "%E6%97%A5" → "日"
+pub fn percent_decode(input: &str) -> Result<String, UrlError> { ... }
+
+/// Percent-encode a string for use in a URL path or query.
+pub fn percent_encode(input: &str) -> String { ... }
+```
+
+### Error Types
+
+```rust
+pub enum UrlError {
+    /// No scheme found (e.g., "www.example.com" without "http://")
+    MissingScheme,
+
+    /// Scheme contains invalid characters (must be [a-z][a-z0-9+.-]*)
+    InvalidScheme,
+
+    /// Port is not a valid u16 (e.g., "http://host:99999")
+    InvalidPort,
+
+    /// Percent-encoding is malformed (e.g., "%GG", "%2" truncated)
+    InvalidPercentEncoding,
+
+    /// Empty host in an authority-based URL ("http:///path")
+    EmptyHost,
+
+    /// Relative URL cannot be resolved without a base
+    RelativeWithoutBase,
+}
+```
+
+---
+
+## Scheme Defaults
+
+| Scheme | Default Port | Authority Required? |
+|--------|-------------|-------------------|
+| http   | 80          | Yes               |
+| https  | 443         | Yes               |
+| ftp    | 21          | Yes               |
+| mailto | —           | No (path is email)|
+
+For Venture v0.1, only `http` is used. But the parser handles any scheme
+generically so it can grow.
+
+---
+
+## Parsing Algorithm
+
+The URL is parsed left-to-right in a single pass, no backtracking:
+
+```
+Input: "http://alice:secret@www.example.com:8080/docs/page.html?q=hello#sec2"
+
+Step 1: Find "://" → scheme = "http"
+        Remaining: "alice:secret@www.example.com:8080/docs/page.html?q=hello#sec2"
+
+Step 2: Find "#" from the right → fragment = "sec2"
+        Remaining: "alice:secret@www.example.com:8080/docs/page.html?q=hello"
+
+Step 3: Find "?" → query = "q=hello"
+        Remaining: "alice:secret@www.example.com:8080/docs/page.html"
+
+Step 4: Find first "/" → path = "/docs/page.html"
+        Remaining: "alice:secret@www.example.com:8080"
+
+Step 5: Find "@" → userinfo = "alice:secret"
+        Remaining: "www.example.com:8080"
+
+Step 6: Find last ":" → port = 8080
+        Remaining: "www.example.com"
+
+Step 7: host = "www.example.com" (lowercased)
+```
+
+**Edge cases:**
+- IPv6 addresses: `http://[::1]:8080/` — brackets delimit the host
+- Empty path: `http://host` → path defaults to `/`
+- Trailing slash: `http://host/` and `http://host` are different URLs
+  (the former has path `/`, the latter has an implied `/`)
+
+---
+
+## Relative Resolution Algorithm
+
+Given base URL `B` and relative reference `R`:
+
+```
+if R has scheme:
+    return R (already absolute)
+
+if R starts with "//":
+    result.scheme = B.scheme
+    result.authority = R.authority
+    result.path = R.path
+    return result
+
+result.scheme = B.scheme
+result.authority = B.authority
+
+if R starts with "/":
+    result.path = R.path
+else:
+    result.path = merge(B.path, R.path)
+
+result.path = remove_dot_segments(result.path)
+result.query = R.query
+result.fragment = R.fragment
+return result
+```
+
+The `merge()` function:
+- Take everything in `B.path` up to and including the last `/`
+- Append `R.path`
+- Example: base `/a/b/c` + relative `d` = `/a/b/d`
+
+The `remove_dot_segments()` function:
+- `/a/b/../c` → `/a/c`
+- `/a/./b` → `/a/b`
+- `/a/b/../../c` → `/c`
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+1. **Basic parsing:** scheme, host, port, path for common URLs
+2. **All components:** URLs with every field populated
+3. **Missing components:** URLs with only scheme+host, scheme+host+path, etc.
+4. **Percent-encoding:** decode `%20`, `%2F`, multi-byte UTF-8 sequences
+5. **Percent-encoding roundtrip:** encode then decode returns original
+6. **Invalid URLs:** missing scheme, bad port, malformed percent-encoding
+7. **Case normalization:** scheme and host are lowercased
+
+### Relative Resolution Tests
+
+8. **Same directory:** `"photo.gif"` against `"http://host/dir/page.html"`
+9. **Parent directory:** `"../other/file"` against a nested base
+10. **Absolute path:** `"/root/file"` against any base
+11. **Scheme-relative:** `"//other.com/path"` inherits scheme
+12. **Already absolute:** `"http://other.com"` ignores base entirely
+13. **Dot segment removal:** `"/a/b/../c"` → `"/a/c"`
+14. **Empty relative:** `""` returns the base URL without fragment
+15. **Fragment-only:** `"#sec"` returns base URL with new fragment
+
+### Historical Tests
+
+16. **Real Mosaic-era URLs:** parse actual URLs from archived 1993 web pages
+17. **CERN info.cern.ch:** `http://info.cern.ch/hypertext/WWW/TheProject.html`
+
+---
+
+## Scope
+
+**In scope:**
+- RFC 1738 URL parsing (http, https, ftp, mailto schemes)
+- Relative URL resolution (RFC 1808)
+- Percent-encoding and decoding
+- Scheme and host case normalization
+
+**Out of scope:**
+- WHATWG URL Standard (the modern browser spec — much more complex)
+- Internationalized Domain Names (IDN / punycode)
+- `data:` and `blob:` URIs
+- URL template expansion (RFC 6570)
+- Query string key=value parsing (that is application logic, not URL syntax)
+
+---
+
+## Implementation Languages
+
+This package will be implemented in:
+- **Rust** (primary, for Venture browser)
+- Future: all 9 languages following the standard pattern

--- a/code/specs/NET01-tcp-client.md
+++ b/code/specs/NET01-tcp-client.md
@@ -1,0 +1,552 @@
+# NET01 — TCP Client
+
+## Overview
+
+A TCP client is the fundamental building block for any networked application. It
+opens a connection to a remote machine, sends bytes, receives bytes, and closes
+the connection. Every web browser, email client, chat program, and database
+driver starts with a TCP client.
+
+This package wraps Rust's `std::net::TcpStream` with ergonomic defaults:
+timeouts, buffering, and clean error handling. It is protocol-agnostic — it
+knows nothing about HTTP, SMTP, or Redis. It just moves bytes reliably between
+two machines. Higher-level packages (NET05 http1.0-client, DT25 mini-redis)
+build application protocols on top of this foundation.
+
+**Analogy: A telephone call.**
+
+```
+Making a TCP connection is like making a phone call:
+
+1. DIAL (DNS + connect)
+   You look up "Grandma" in your contacts → 555-0123 (DNS resolution)
+   You dial the number and wait for it to ring   (TCP three-way handshake)
+   If nobody picks up after 30 seconds, you hang up (connect timeout)
+
+2. TALK (read/write)
+   You say "Hello, Grandma!"                      (write_all)
+   You listen for her response                     (read_line)
+   If she goes silent for 30 seconds, you ask
+   "Are you still there?"                          (read timeout)
+
+3. HANG UP (shutdown/close)
+   You say "Goodbye" and hang up                   (shutdown + close)
+   Half-close: you can say "I'm done talking"
+   but keep listening for her last words            (shutdown(Write))
+```
+
+## Where It Fits
+
+```
+User types "http://info.cern.ch/hypertext/WWW/TheProject.html"
+     │
+     ▼
+url-parser (NET00) — parse into scheme, host, port, path
+     │  Url { scheme: "http", host: "info.cern.ch",
+     │        port: 80, path: "/hypertext/WWW/TheProject.html" }
+     ▼
+tcp-client (NET01) ← THIS PACKAGE
+     │  TcpConnection to info.cern.ch:80
+     │  (raw byte stream — no HTTP knowledge)
+     ▼
+frame-extractor (NET02) — extract HTTP frames from byte stream
+     │
+     ▼
+http1.0-lexer (NET03) — tokenize HTTP response
+     │
+     ▼
+http1.0-parser (NET04) — parse into structured response
+     │
+     ▼
+http1.0-client (NET05) — high-level "fetch this URL" API
+```
+
+**Depends on:** nothing (std only)
+**Depended on by:** http1.0-client (NET05), future SMTP/FTP clients, RESP protocol (DT23)
+
+**Important:** This package uses real OS sockets via `std::net`. It is NOT
+related to the D17 simulated network stack, which is an educational simulation
+of TCP/IP internals. This package calls into the operating system's actual
+networking APIs.
+
+---
+
+## Concepts
+
+### Why TCP (vs UDP)?
+
+The internet offers two main transport protocols:
+
+```
+TCP (Transmission Control Protocol)         UDP (User Datagram Protocol)
+─────────────────────────────────           ──────────────────────────────
+Reliable: every byte arrives                Best-effort: packets can be lost
+Ordered: bytes arrive in send order         Unordered: packets may arrive jumbled
+Connection-oriented: dial first, then talk  Connectionless: just send packets
+Flow control: won't overwhelm receiver      No flow control
+Slower to start (handshake)                 No handshake overhead
+
+Used by: HTTP, SMTP, FTP, SSH, Redis       Used by: DNS, video streaming, games
+```
+
+TCP is the right choice for protocols where **every byte matters and order
+matters**. When a web browser fetches a page, a missing or reordered byte would
+corrupt the HTML. TCP guarantees that the bytes arrive completely and in order,
+or the connection fails with an error — there is no silent data loss.
+
+### The Connection Lifecycle
+
+A TCP connection goes through four phases:
+
+```
+Phase 1: DNS Resolution
+  "info.cern.ch" → 188.184.21.108
+  The hostname is a human-readable alias. The OS resolver
+  (or /etc/hosts) translates it to an IP address.
+  This can fail: the domain might not exist, the DNS
+  server might be unreachable, or resolution might time out.
+
+Phase 2: TCP Connect (Three-Way Handshake)
+  Client → Server:  SYN        "I want to connect"
+  Server → Client:  SYN-ACK    "OK, I accept"
+  Client → Server:  ACK        "Great, we're connected"
+
+  This establishes the connection. It can fail if the server
+  is not listening (ConnectionRefused), the network is down,
+  or the handshake takes too long (Timeout).
+
+Phase 3: Data Transfer (Read/Write)
+  Once connected, both sides can send and receive bytes at
+  any time. TCP is full-duplex — reading and writing happen
+  independently.
+
+  Reads can block until data arrives, or time out.
+  Writes can block if the send buffer is full, or time out.
+
+Phase 4: Shutdown and Close
+  Either side can initiate shutdown:
+  - shutdown(Write) → "I'm done sending" (half-close)
+  - drop/close → fully close the connection
+
+  A clean shutdown lets the other side read any remaining
+  data before the connection is torn down.
+```
+
+### Buffered I/O: Why You Need It
+
+TCP is a **byte stream**, not a message stream. When you call `read()` on a raw
+`TcpStream`, you might get 1 byte, or 1000 bytes, or any amount — it depends on
+how the OS batched the network packets.
+
+```
+What the server sends (logically):     "HTTP/1.0 200 OK\r\n"
+What raw read() might return:          "HTTP/1"  then  ".0 200"  then  " OK\r\n"
+```
+
+This makes raw `read()` painful to use. You would need to manually accumulate
+bytes in a buffer and scan for delimiters. **BufReader** solves this:
+
+```
+BufReader wraps TcpStream and adds an internal buffer (default: 8 KiB).
+It reads large chunks from the OS and serves them to your code in
+convenient pieces:
+
+  read_line()       → reads until \n, returns the whole line
+  read_until(b)     → reads until delimiter byte b appears
+  read_exact(n)     → reads exactly n bytes, blocking until all arrive
+
+Without buffering, reading 100 lines means 100+ system calls.
+With buffering, it might be just 1-2 system calls, with the rest
+served from the in-memory buffer.
+```
+
+Similarly, **BufWriter** batches small writes into larger chunks before flushing
+to the OS, reducing the number of system calls and avoiding tiny TCP packets.
+
+### Timeouts: Connect vs Read vs Write
+
+Three different things can time out, and they need independent settings:
+
+```
+Connect timeout (default: 30s)
+  How long to wait for the TCP handshake to complete.
+  If a server is down or firewalled, the OS might wait
+  minutes before giving up. A 30s timeout is reasonable.
+
+Read timeout (default: 30s)
+  How long to wait for data after calling read().
+  A well-behaved server should respond promptly, but
+  a slow or overloaded server might stall. Without a
+  read timeout, your program hangs forever.
+
+Write timeout (default: 30s)
+  How long to wait for the OS to accept your data.
+  This usually completes instantly (data goes to the
+  OS send buffer), but can block if the buffer is full
+  because the remote side is not reading.
+```
+
+### Half-Close: "I'm Done Talking, But Still Listening"
+
+TCP connections are full-duplex: data flows in both directions independently.
+A **half-close** shuts down one direction while keeping the other open:
+
+```
+Normal close:
+  Client: shutdown(Write) + shutdown(Read)  → connection fully closed
+
+Half-close:
+  Client: shutdown(Write)                   → "I have nothing more to send"
+  Server: reads remaining data, sends final response
+  Client: reads the final response
+  Client: connection fully closed when both sides are done
+
+Why this matters:
+  HTTP/1.0 uses this pattern. The client sends the request,
+  then signals "I'm done" with a half-close. The server reads
+  the complete request, sends the response, and closes. Without
+  half-close, the server would not know when the request ends.
+```
+
+---
+
+## Public API
+
+```rust
+use std::time::Duration;
+
+// ─── Connection Options ───────────────────────────────────────────────
+
+/// Configuration for establishing a TCP connection.
+///
+/// All timeouts default to 30 seconds. The buffer size defaults to 8192
+/// bytes (8 KiB), which is a good balance between memory usage and
+/// system call reduction.
+///
+/// # Example
+///
+/// ```rust
+/// let opts = ConnectOptions::default()
+///     .connect_timeout(Duration::from_secs(10))
+///     .read_timeout(Duration::from_secs(60));
+/// ```
+pub struct ConnectOptions {
+    /// Maximum time to wait for the TCP handshake to complete.
+    /// Default: 30 seconds.
+    pub connect_timeout: Duration,
+
+    /// Maximum time to wait for data when reading.
+    /// Default: 30 seconds. Set to None for no timeout (blocks forever).
+    pub read_timeout: Option<Duration>,
+
+    /// Maximum time to wait when writing data.
+    /// Default: 30 seconds. Set to None for no timeout (blocks forever).
+    pub write_timeout: Option<Duration>,
+
+    /// Size of the internal read and write buffers in bytes.
+    /// Default: 8192 (8 KiB).
+    pub buffer_size: usize,
+}
+
+impl Default for ConnectOptions {
+    fn default() -> Self {
+        ConnectOptions {
+            connect_timeout: Duration::from_secs(30),
+            read_timeout: Some(Duration::from_secs(30)),
+            write_timeout: Some(Duration::from_secs(30)),
+            buffer_size: 8192,
+        }
+    }
+}
+
+// ─── Connect ──────────────────────────────────────────────────────────
+
+/// Establish a TCP connection to the given host and port.
+///
+/// This function:
+/// 1. Resolves the hostname to one or more IP addresses using the OS
+///    DNS resolver (via `std::net::ToSocketAddrs`).
+/// 2. Attempts to connect to each resolved address in order, using
+///    the configured connect timeout.
+/// 3. Configures read/write timeouts on the resulting socket.
+/// 4. Wraps the socket in buffered reader/writer.
+///
+/// # Arguments
+///
+/// * `host` — A hostname ("info.cern.ch") or IP address ("93.184.216.34")
+/// * `port` — The TCP port number (e.g., 80 for HTTP, 25 for SMTP)
+/// * `options` — Connection configuration (timeouts, buffer size)
+///
+/// # Example
+///
+/// ```rust
+/// let conn = connect("info.cern.ch", 80, ConnectOptions::default())?;
+/// conn.write_all(b"GET / HTTP/1.0\r\nHost: info.cern.ch\r\n\r\n")?;
+/// let response = conn.read_line()?;
+/// ```
+pub fn connect(
+    host: &str,
+    port: u16,
+    options: ConnectOptions,
+) -> Result<TcpConnection, TcpError> { ... }
+
+// ─── TcpConnection ───────────────────────────────────────────────────
+
+/// A TCP connection with buffered I/O and configured timeouts.
+///
+/// TcpConnection wraps a `TcpStream` in a `BufReader` and `BufWriter`
+/// for efficient, line-oriented or chunk-oriented communication.
+///
+/// The connection is automatically closed when dropped.
+pub struct TcpConnection { /* internal: BufReader<TcpStream>, BufWriter<TcpStream> */ }
+
+impl TcpConnection {
+    /// Read bytes until a newline (`\n`) is found.
+    ///
+    /// Returns the line INCLUDING the trailing `\n` (and `\r\n` if
+    /// present). Returns an empty string at EOF (remote closed).
+    ///
+    /// This is the workhorse for line-oriented protocols like HTTP/1.0,
+    /// SMTP, and RESP.
+    ///
+    /// # Errors
+    ///
+    /// Returns `TcpError::Timeout` if no data arrives within the read
+    /// timeout. Returns `TcpError::ConnectionReset` if the remote side
+    /// closed unexpectedly.
+    pub fn read_line(&mut self) -> Result<String, TcpError> { ... }
+
+    /// Read exactly `n` bytes from the connection.
+    ///
+    /// Blocks until all `n` bytes have been received. This is useful
+    /// for protocols that specify an exact content length (e.g.,
+    /// HTTP Content-Length header).
+    ///
+    /// # Errors
+    ///
+    /// Returns `TcpError::UnexpectedEof` if the connection closes
+    /// before `n` bytes are read.
+    pub fn read_exact(&mut self, n: usize) -> Result<Vec<u8>, TcpError> { ... }
+
+    /// Read bytes until the given delimiter byte is found.
+    ///
+    /// Returns all bytes up to AND including the delimiter.
+    /// Useful for protocols with custom delimiters (e.g., RESP uses
+    /// `\r\n`, null-terminated strings use `\0`).
+    pub fn read_until(&mut self, delimiter: u8) -> Result<Vec<u8>, TcpError> { ... }
+
+    /// Write all bytes to the connection.
+    ///
+    /// Buffers the data internally and flushes when the buffer is full
+    /// or when `flush()` is called explicitly. For request/response
+    /// protocols, call `flush()` after writing the complete request
+    /// to ensure it is actually sent.
+    ///
+    /// # Errors
+    ///
+    /// Returns `TcpError::BrokenPipe` if the remote side has closed
+    /// the connection.
+    pub fn write_all(&mut self, data: &[u8]) -> Result<(), TcpError> { ... }
+
+    /// Flush the write buffer, sending all buffered data to the network.
+    ///
+    /// You MUST call this after writing a complete message. Without
+    /// flushing, data may sit in the BufWriter and never reach the
+    /// server.
+    pub fn flush(&mut self) -> Result<(), TcpError> { ... }
+
+    /// Shut down the write half of the connection (half-close).
+    ///
+    /// Signals to the remote side that no more data will be sent.
+    /// The read half remains open — you can still read responses.
+    ///
+    /// This is equivalent to calling `shutdown(Shutdown::Write)` on
+    /// the underlying socket.
+    pub fn shutdown_write(&mut self) -> Result<(), TcpError> { ... }
+
+    /// Returns the remote address (IP and port) of this connection.
+    pub fn peer_addr(&self) -> Result<std::net::SocketAddr, TcpError> { ... }
+
+    /// Returns the local address (IP and port) of this connection.
+    pub fn local_addr(&self) -> Result<std::net::SocketAddr, TcpError> { ... }
+}
+```
+
+### Error Types
+
+```rust
+/// Errors that can occur during TCP connection and communication.
+///
+/// Each variant corresponds to a specific failure mode. Application
+/// code should match on these to decide how to recover.
+pub enum TcpError {
+    /// DNS resolution failed — the hostname could not be resolved
+    /// to any IP address.
+    ///
+    /// Common causes: typo in hostname, no internet connection,
+    /// DNS server unreachable.
+    DnsResolutionFailed {
+        host: String,
+        message: String,
+    },
+
+    /// The remote server actively refused the connection.
+    ///
+    /// This means the server is reachable but nothing is listening
+    /// on the requested port. The server's OS sent a TCP RST packet.
+    ConnectionRefused {
+        addr: String,
+    },
+
+    /// The connection or read/write operation timed out.
+    ///
+    /// The `phase` field distinguishes where the timeout occurred:
+    /// - "connect" — TCP handshake did not complete in time
+    /// - "read" — no data received within the read timeout
+    /// - "write" — send buffer did not drain within the write timeout
+    Timeout {
+        phase: String,
+        duration: Duration,
+    },
+
+    /// The connection was reset by the remote side.
+    ///
+    /// The server closed the connection unexpectedly (TCP RST),
+    /// typically because the server process crashed or was killed.
+    ConnectionReset,
+
+    /// The write half of the connection is broken.
+    ///
+    /// You tried to write to a connection that the remote side has
+    /// already closed. This is the "you hung up on me" error.
+    BrokenPipe,
+
+    /// The connection closed before the expected amount of data
+    /// was received.
+    ///
+    /// Returned by `read_exact()` when the connection closes before
+    /// `n` bytes have been read.
+    UnexpectedEof {
+        expected: usize,
+        received: usize,
+    },
+
+    /// A low-level I/O error not covered by the specific variants above.
+    ///
+    /// Wraps `std::io::Error` for edge cases like permission denied,
+    /// address already in use, etc.
+    IoError(std::io::Error),
+}
+```
+
+---
+
+## DNS Resolution
+
+DNS resolution is handled by `std::net::ToSocketAddrs`, which calls the
+operating system's resolver. This means it respects `/etc/hosts`, the system DNS
+configuration, and local DNS caches.
+
+```
+connect("info.cern.ch", 80, opts)
+
+Step 1: "info.cern.ch:80".to_socket_addrs()
+  → [188.184.21.108:80, 2001:1458:d00:3c::100:47:80]  (IPv4 + IPv6)
+
+Step 2: Try each address in order:
+  → Try 188.184.21.108:80 with connect_timeout
+  → If that fails, try 2001:1458:d00:3c::100:47:80
+  → If all fail, return the last error
+```
+
+The `host` parameter can also be a raw IP address:
+
+```
+connect("127.0.0.1", 6379, opts)   // no DNS lookup needed
+connect("::1", 6379, opts)          // IPv6 loopback, no DNS lookup
+```
+
+---
+
+## Testing Strategy
+
+### Echo Server Tests
+
+Spin up a `std::net::TcpListener` on localhost in the test, then connect
+to it with the TCP client. This tests real socket behavior without
+needing external services.
+
+1. **Connect and disconnect:** verify connection succeeds to a listening port
+2. **Write and read back:** send bytes, echo server returns them, verify match
+3. **read_line:** send "Hello\r\nWorld\r\n", verify two lines read correctly
+4. **read_exact:** send exactly 100 bytes, read_exact(100), verify match
+5. **read_until:** send "key:value\0next", read_until(0), verify returns "key:value\0"
+6. **Large data transfer:** send and receive 1 MiB of data, verify integrity
+7. **Multiple exchanges:** request-response-request-response pattern
+
+### Timeout Tests
+
+8. **Connect timeout:** attempt to connect to a non-routable address (e.g.,
+   `10.255.255.1:1`) with a short timeout, verify `TcpError::Timeout`
+9. **Read timeout:** connect to echo server that never sends, verify timeout
+10. **Write timeout:** fill the send buffer until it blocks (harder to test
+    reliably, may need OS-specific tuning)
+
+### Error Tests
+
+11. **Connection refused:** connect to a port with no listener, verify
+    `TcpError::ConnectionRefused`
+12. **DNS failure:** connect to "this.host.does.not.exist.example", verify
+    `TcpError::DnsResolutionFailed`
+13. **Connection reset:** server closes abruptly (RST), verify
+    `TcpError::ConnectionReset` on next read
+14. **Broken pipe:** server closes connection, client writes, verify
+    `TcpError::BrokenPipe`
+15. **Unexpected EOF:** server sends 50 bytes then closes, client calls
+    `read_exact(100)`, verify `TcpError::UnexpectedEof`
+
+### Half-Close Tests
+
+16. **Client half-close:** client calls `shutdown_write()`, server reads EOF,
+    server sends final message, client reads it successfully
+17. **Server half-close:** server shuts down write, client reads EOF, client
+    can still write (server reads it)
+
+### Edge Cases
+
+18. **Empty read_line at EOF:** connection closed cleanly, read_line returns
+    empty string
+19. **Zero-byte write:** `write_all(b"")` succeeds without error
+20. **Peer address:** `peer_addr()` returns the correct remote address
+21. **Flush semantics:** data is not sent until `flush()` is called (verify
+    with a server that checks timing)
+
+---
+
+## Scope
+
+**In scope:**
+- TCP connect with configurable timeout
+- DNS resolution via `std::net::ToSocketAddrs`
+- Buffered reading: `read_line()`, `read_exact()`, `read_until()`
+- Buffered writing: `write_all()`, `flush()`
+- Read and write timeouts
+- Graceful shutdown (half-close with `shutdown_write()`)
+- Structured error types with actionable information
+
+**Out of scope:**
+- TLS/SSL encryption (that will be a separate NET-layer package)
+- Connection pooling (belongs in higher-level clients)
+- Async / non-blocking I/O (this is synchronous, blocking I/O)
+- Unix domain sockets (different address family, different use case)
+- UDP (different protocol entirely — see concepts section)
+- HTTP or any application-level protocol (this is protocol-agnostic)
+- The D17 simulated network stack (that is educational; this uses real OS sockets)
+
+---
+
+## Implementation Languages
+
+This package will be implemented in:
+- **Rust** (primary, for the Venture browser pipeline)
+- Future: other languages as needed for educational comparison

--- a/code/specs/NET02-frame-extractor.md
+++ b/code/specs/NET02-frame-extractor.md
@@ -1,0 +1,568 @@
+# NET02 — Frame Extractor
+
+## Overview
+
+TCP gives you a **byte stream** — a continuous flow of bytes with no message
+boundaries. But protocols need **discrete messages**. HTTP needs to know where
+headers end and the body begins. IRC needs to know where one command ends and the
+next starts. RESP (the Redis protocol) needs to know how many bytes a bulk
+string contains.
+
+This package solves the fundamental problem: **how do you carve messages out of
+a continuous byte stream?**
+
+**Analogy:** TCP is like a garden hose — water flows continuously with no
+natural divisions. But your protocol needs discrete cups of water. The frame
+extractor is the **cup** — it collects bytes from the stream until a complete
+message is ready, then hands you that message and starts collecting the next
+one.
+
+```
+Garden Hose (TCP byte stream):
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~>
+
+Frame Extractor (the cup):
+  [cup 1: "GET / HTTP/1.0\r\n\r\n"]  [cup 2: "Hello, World!"]  [cup 3: ...]
+```
+
+Different protocols use different rules for where one message ends and the next
+begins. This package provides **four strategies** for frame extraction, each
+matching a common pattern found across network protocols:
+
+| Strategy          | Rule                          | Used By                          |
+|-------------------|-------------------------------|----------------------------------|
+| Delimiter         | Read until a byte pattern     | IRC (`\r\n`), HTTP headers       |
+| Length-Prefixed   | Read exactly N bytes          | HTTP body, WebSocket, RESP       |
+| Read-to-End       | Read until EOF                | HTTP/1.0 body (no Content-Length)|
+| Composite         | Chain strategies sequentially | HTTP response (headers + body)   |
+
+The IRC framing package (`irc-framing`) already solves this problem for IRC
+specifically — it uses CRLF delimiters with a 512-byte maximum. This package is
+the **generic** version that works for any framing protocol. Think of
+`irc-framing` as a specialized cup (exactly 512ml, CRLF-shaped) and this package
+as a cup factory that can produce any size and shape.
+
+---
+
+## Where It Fits
+
+```
+tcp-client (NET01) → frame-extractor (NET02) → http1.0-lexer (NET03)
+                          ↑
+                      THIS PACKAGE
+
+The flow for an HTTP/1.0 request:
+
+  1. tcp-client opens a socket to the server
+  2. Server sends back a stream of bytes
+  3. frame-extractor carves that stream into:
+     a. The header block (everything up to \r\n\r\n)
+     b. The body (next Content-Length bytes, or read-to-end)
+  4. http1.0-lexer parses the headers into structured data
+```
+
+**Depends on:** nothing (std only — operates on `impl BufRead`)
+**Depended on by:** http1.0-client (NET05), Venture browser (BR01)
+**Also reusable by:** RESP protocol (DT23), WebSocket framing, any line protocol
+
+---
+
+## Concepts
+
+### What Is a "Frame"?
+
+A **frame** is the protocol's unit of data. Different protocols call it
+different things — a "message," a "packet," a "line," a "chunk" — but the idea
+is the same: a contiguous sequence of bytes that carries one logical unit of
+meaning.
+
+```
+Protocol        Frame                          Boundary Rule
+──────────────────────────────────────────────────────────────
+IRC             "PRIVMSG #ch :hello\r\n"       CRLF delimiter, max 512 bytes
+HTTP headers    "HTTP/1.0 200 OK\r\n...\r\n"   Double-CRLF delimiter
+HTTP body       "<html>...</html>"              Content-Length bytes, or EOF
+RESP            "$5\r\nhello\r\n"               Length prefix (the "5")
+```
+
+### The Three Fundamental Framing Patterns
+
+Every protocol in existence uses one of three patterns (or a combination):
+
+#### Pattern 1: Delimiter-Based
+
+Read bytes until you see a **sentinel value** — a special byte sequence that
+means "end of message." The delimiter itself is never part of the message
+content (or if it is, the protocol has an escaping mechanism).
+
+```
+Bytes on the wire:     H E L L O \r \n W O R L D \r \n
+                       ─────────────── ───────────────
+                        Frame 1          Frame 2
+                              ↑ delimiter      ↑ delimiter
+```
+
+**Used by:** IRC, SMTP, HTTP status lines, HTTP headers, POP3, FTP control
+channel, syslog, and virtually every "line protocol."
+
+**Danger:** What if the delimiter never arrives? A malicious or buggy sender
+could transmit gigabytes without ever sending `\r\n`. That is why delimiter
+strategies need a **max_length** safety limit — if we have read more than N
+bytes without finding the delimiter, we stop and return an error.
+
+#### Pattern 2: Length-Prefixed
+
+The sender tells you **in advance** how many bytes the message contains. You
+read exactly that many bytes and you are done.
+
+```
+HTTP Response:
+  "Content-Length: 13\r\n\r\n"   ← header (extracted by delimiter strategy)
+  "Hello, World!"                ← body: exactly 13 bytes
+  ─────────────── 
+   Frame (13 bytes)
+```
+
+This is the most efficient pattern — no scanning, no ambiguity. You know
+exactly when the message ends before you start reading it.
+
+**Used by:** HTTP body (Content-Length), WebSocket payload, RESP bulk strings,
+binary protocols with fixed headers.
+
+#### Pattern 3: Read-to-End (EOF)
+
+The simplest possible strategy: read everything until the connection closes.
+There is no delimiter, no length prefix — the message boundary IS the
+connection boundary.
+
+```
+Server sends:    <html><body>Hello</body></html>
+Server closes:   [TCP FIN]
+Client:          "The message is everything I received."
+```
+
+This was common in HTTP/1.0 when servers did not send a Content-Length header.
+The client simply read until the server closed the connection. The obvious
+downside: **you cannot send multiple messages** on the same connection, because
+the only way to signal "end of message" is to close the connection entirely.
+
+**Used by:** HTTP/1.0 body (when no Content-Length), some file transfer
+protocols.
+
+### Composing Strategies: The HTTP Example
+
+Real protocols often use **multiple framing strategies** in sequence. HTTP is
+the perfect example:
+
+```
+HTTP/1.0 200 OK\r\n                    ┐
+Content-Type: text/html\r\n            │ Phase 1: DelimiterStrategy("\r\n\r\n")
+Content-Length: 45\r\n                  │   → extracts the header block
+\r\n                                    ┘
+<html><body>Hello, World!</body></html>   Phase 2: LengthPrefixedStrategy(45)
+                                            → extracts the body (exactly 45 bytes)
+```
+
+The **CompositeStrategy** chains these two steps:
+
+1. **Phase 1:** Use `DelimiterStrategy` with `\r\n\r\n` to extract the raw
+   header block. This gives us a `Vec<u8>` containing all the headers.
+
+2. **Parse headers:** The caller (not the frame extractor) parses the header
+   block to find the `Content-Length` value. This is protocol-specific logic
+   that does not belong in the generic framing library.
+
+3. **Phase 2:** Use `LengthPrefixedStrategy(content_length)` to extract exactly
+   that many bytes for the body. If there is no Content-Length header, fall back
+   to `ReadToEndStrategy` — read until the server closes the connection.
+
+```
+fn extract_http_response(reader: &mut dyn BufRead) -> Result<(Vec<u8>, Vec<u8>), FrameError> {
+    // Phase 1: Extract headers
+    let mut header_strategy = DelimiterStrategy {
+        delimiter: b"\r\n\r\n".to_vec(),
+        max_length: Some(8192),   // 8 KB header limit (Apache default)
+        include_delimiter: false,
+    };
+    let headers = header_strategy.extract(reader)?;
+
+    // Phase 2: Parse Content-Length (protocol-specific, done by caller)
+    let content_length = parse_content_length(&headers);
+
+    // Phase 3: Extract body
+    let body = match content_length {
+        Some(len) => {
+            let mut body_strategy = LengthPrefixedStrategy { length: len };
+            body_strategy.extract(reader)?
+        }
+        None => {
+            let mut eof_strategy = ReadToEndStrategy { max_length: Some(1_048_576) };
+            eof_strategy.extract(reader)?
+        }
+    };
+
+    Ok((headers, body))
+}
+```
+
+This composition pattern is the reason the frame extractor exists as a generic
+library rather than being hardcoded into each protocol implementation.
+
+---
+
+## Public API
+
+```rust
+use std::io::BufRead;
+
+// ─────────────────────────────────────────────
+// Errors
+// ─────────────────────────────────────────────
+
+/// Everything that can go wrong when extracting a frame.
+///
+/// These errors distinguish between "the data is wrong" (protocol violation)
+/// and "the pipe is broken" (I/O failure). This matters because protocol
+/// violations might be recoverable (skip and try the next frame) while I/O
+/// failures usually are not.
+pub enum FrameError {
+    /// We read max_length bytes without finding the delimiter.
+    ///
+    /// This usually means either:
+    /// - The sender is not following the protocol (missing CRLF)
+    /// - The sender is malicious (trying to exhaust our memory)
+    /// - max_length is set too low for the protocol
+    DelimiterNotFound,
+
+    /// The connection closed before we got a complete frame.
+    ///
+    /// For LengthPrefixedStrategy: we expected N bytes but got fewer.
+    /// For DelimiterStrategy: the stream ended without the delimiter.
+    UnexpectedEof,
+
+    /// The frame exceeded the configured maximum length.
+    ///
+    /// Used by ReadToEndStrategy when a max_length limit is set.
+    MaxLengthExceeded,
+
+    /// An underlying I/O error occurred (disk failure, network error, etc.)
+    IoError(std::io::Error),
+}
+
+// ─────────────────────────────────────────────
+// Trait
+// ─────────────────────────────────────────────
+
+/// A strategy for extracting one complete frame from a byte stream.
+///
+/// Each call to `extract()` reads exactly one frame and returns it as a
+/// `Vec<u8>`. The reader's position is advanced past the frame (and past
+/// any delimiter), so the next call to `extract()` — on this or any other
+/// strategy — picks up right where the last one left off.
+///
+/// This is the core abstraction. By programming against `dyn FrameStrategy`,
+/// protocol implementations can swap framing strategies without changing
+/// their parsing logic.
+pub trait FrameStrategy {
+    /// Read one complete frame from the stream.
+    ///
+    /// Blocks until a complete frame is available, an error occurs, or EOF
+    /// is reached (which may or may not be an error depending on the
+    /// strategy).
+    fn extract(&mut self, reader: &mut dyn BufRead) -> Result<Vec<u8>, FrameError>;
+}
+
+// ─────────────────────────────────────────────
+// Strategy 1: Delimiter
+// ─────────────────────────────────────────────
+
+/// Extract a frame by reading until a delimiter byte sequence is found.
+///
+/// This is the most common framing strategy. Line protocols use `\r\n`,
+/// HTTP uses `\r\n\r\n` to separate headers from body, and some binary
+/// protocols use null bytes.
+///
+/// ## Example
+///
+/// ```rust
+/// use std::io::Cursor;
+///
+/// let data = b"HELLO\r\nWORLD\r\n";
+/// let mut reader = Cursor::new(data.to_vec());
+///
+/// let mut strategy = DelimiterStrategy {
+///     delimiter: b"\r\n".to_vec(),
+///     max_length: Some(512),
+///     include_delimiter: false,
+/// };
+///
+/// let frame1 = strategy.extract(&mut reader).unwrap();
+/// assert_eq!(frame1, b"HELLO");
+///
+/// let frame2 = strategy.extract(&mut reader).unwrap();
+/// assert_eq!(frame2, b"WORLD");
+/// ```
+pub struct DelimiterStrategy {
+    /// The byte sequence that marks the end of a frame.
+    ///
+    /// Common values:
+    /// - `b"\r\n".to_vec()`       — line protocols (IRC, SMTP)
+    /// - `b"\r\n\r\n".to_vec()`   — HTTP header/body boundary
+    /// - `b"\0".to_vec()`          — null-terminated protocols
+    pub delimiter: Vec<u8>,
+
+    /// Maximum number of bytes to read before giving up.
+    ///
+    /// If `None`, there is no limit (dangerous for untrusted input!).
+    /// If `Some(n)`, returns `FrameError::DelimiterNotFound` after reading
+    /// `n` bytes without finding the delimiter.
+    pub max_length: Option<usize>,
+
+    /// Whether to include the delimiter in the returned frame.
+    ///
+    /// - `false` (typical): "HELLO\r\n" → returns b"HELLO"
+    /// - `true`  (rare):    "HELLO\r\n" → returns b"HELLO\r\n"
+    ///
+    /// The delimiter is consumed from the stream in both cases — setting
+    /// this to `false` just strips it from the output.
+    pub include_delimiter: bool,
+}
+
+impl FrameStrategy for DelimiterStrategy { ... }
+
+// ─────────────────────────────────────────────
+// Strategy 2: Length-Prefixed
+// ─────────────────────────────────────────────
+
+/// Extract a frame by reading exactly `length` bytes.
+///
+/// The caller already knows how many bytes to read — typically from a
+/// previously parsed header (like HTTP's Content-Length) or a protocol-
+/// defined length field.
+///
+/// ## Example
+///
+/// ```rust
+/// use std::io::Cursor;
+///
+/// let data = b"Hello, World!Extra bytes";
+/// let mut reader = Cursor::new(data.to_vec());
+///
+/// let mut strategy = LengthPrefixedStrategy { length: 13 };
+///
+/// let frame = strategy.extract(&mut reader).unwrap();
+/// assert_eq!(frame, b"Hello, World!");
+/// // Reader is now positioned at "Extra bytes"
+/// ```
+pub struct LengthPrefixedStrategy {
+    /// Exact number of bytes to read.
+    ///
+    /// Returns `FrameError::UnexpectedEof` if the stream ends before
+    /// `length` bytes have been read.
+    pub length: usize,
+}
+
+impl FrameStrategy for LengthPrefixedStrategy { ... }
+
+// ─────────────────────────────────────────────
+// Strategy 3: Read-to-End
+// ─────────────────────────────────────────────
+
+/// Extract a frame by reading all remaining bytes until EOF.
+///
+/// This is the simplest strategy — the message boundary is the connection
+/// boundary. Used when the sender closes the connection to signal "end of
+/// message."
+///
+/// ## Example
+///
+/// ```rust
+/// use std::io::Cursor;
+///
+/// let data = b"<html><body>Hello</body></html>";
+/// let mut reader = Cursor::new(data.to_vec());
+///
+/// let mut strategy = ReadToEndStrategy { max_length: Some(1_048_576) };
+///
+/// let frame = strategy.extract(&mut reader).unwrap();
+/// assert_eq!(frame, b"<html><body>Hello</body></html>");
+/// ```
+pub struct ReadToEndStrategy {
+    /// Maximum number of bytes to read before returning an error.
+    ///
+    /// If `None`, there is no limit (dangerous for untrusted input!).
+    /// If `Some(n)`, returns `FrameError::MaxLengthExceeded` after reading
+    /// `n` bytes without reaching EOF.
+    ///
+    /// A typical default: 1 MB (`1_048_576`) for HTTP bodies, or 10 MB for
+    /// file downloads.
+    pub max_length: Option<usize>,
+}
+
+impl FrameStrategy for ReadToEndStrategy { ... }
+
+// ─────────────────────────────────────────────
+// Strategy 4: Composite
+// ─────────────────────────────────────────────
+
+/// Chain multiple strategies sequentially, extracting one frame per strategy.
+///
+/// Each strategy in the list extracts one frame from the stream, in order.
+/// The returned `Vec<Vec<u8>>` contains one entry per strategy.
+///
+/// This is how multi-phase protocols like HTTP work:
+/// 1. DelimiterStrategy("\r\n\r\n") extracts the header block
+/// 2. LengthPrefixedStrategy(content_length) extracts the body
+///
+/// ## Example
+///
+/// ```rust
+/// let mut composite = CompositeStrategy {
+///     strategies: vec![
+///         Box::new(DelimiterStrategy {
+///             delimiter: b"\r\n\r\n".to_vec(),
+///             max_length: Some(8192),
+///             include_delimiter: false,
+///         }),
+///         Box::new(LengthPrefixedStrategy { length: 13 }),
+///     ],
+/// };
+///
+/// let frames = composite.extract_all(&mut reader)?;
+/// // frames[0] = header block
+/// // frames[1] = body (13 bytes)
+/// ```
+pub struct CompositeStrategy {
+    /// The strategies to apply in order.
+    ///
+    /// Each strategy is consumed once: the first extracts one frame, then
+    /// the second extracts the next frame from wherever the first left off.
+    strategies: Vec<Box<dyn FrameStrategy>>,
+}
+
+impl CompositeStrategy {
+    /// Extract one frame per strategy, returning all frames.
+    ///
+    /// If any strategy fails, the error is returned immediately and no
+    /// further strategies are attempted.
+    pub fn extract_all(&mut self, reader: &mut dyn BufRead) -> Result<Vec<Vec<u8>>, FrameError> {
+        ...
+    }
+}
+```
+
+### Design Decisions
+
+**Why `BufRead` and not `Read`?** Delimiter-based framing requires peeking at
+bytes without consuming them. `BufRead` provides `fill_buf()` for exactly this.
+If we took a raw `Read`, we would need our own internal buffer — duplicating
+what `BufReader` already provides. By accepting `BufRead`, we let the caller
+choose the buffer size and we stay simple.
+
+**Why `Vec<u8>` and not `&[u8]`?** The extracted frame must outlive the read
+buffer. When using a `BufReader`, the internal buffer may be reused for the next
+read, so we cannot return a borrow into it. Owned `Vec<u8>` is the safe choice.
+
+**Why mutable strategies?** A `CompositeStrategy` consumes its inner strategies
+as it runs. Even simple strategies might want internal scratch buffers in the
+future. `&mut self` keeps that door open.
+
+---
+
+## Testing Strategy
+
+All tests use in-memory `Cursor<Vec<u8>>` buffers to simulate TCP streams.
+No actual network I/O is needed.
+
+### DelimiterStrategy Tests
+
+1. **Single frame, CRLF:** `b"HELLO\r\n"` → extracts `b"HELLO"`
+2. **Multiple frames:** `b"A\r\nB\r\nC\r\n"` → three calls yield A, B, C
+3. **Include delimiter:** same input with `include_delimiter: true` → `b"HELLO\r\n"`
+4. **Multi-byte delimiter:** `b"headers\r\n\r\nbody"` with `\r\n\r\n` → `b"headers"`
+5. **Null delimiter:** `b"hello\0world\0"` with `\0` → `b"hello"`, `b"world"`
+6. **Max length exceeded:** 1000 bytes with no delimiter, `max_length: 512` → `DelimiterNotFound`
+7. **Max length exact fit:** delimiter appears at exactly max_length → success
+8. **Empty frame:** `b"\r\n"` → extracts `b""` (empty vec)
+9. **Delimiter at start:** `b"\r\nHELLO\r\n"` → first frame is empty, second is "HELLO"
+10. **EOF without delimiter:** `b"HELLO"` (no trailing CRLF) → `UnexpectedEof`
+11. **Empty input:** empty buffer → `UnexpectedEof`
+
+### LengthPrefixedStrategy Tests
+
+12. **Exact read:** 13 bytes from a 13-byte buffer → success
+13. **Read from longer buffer:** 5 bytes from a 100-byte buffer → only first 5 bytes returned, reader advances by 5
+14. **Unexpected EOF:** request 100 bytes from 50-byte buffer → `UnexpectedEof`
+15. **Zero-length:** `length: 0` → returns empty `Vec<u8>`, reader does not advance
+16. **Sequential reads:** two `LengthPrefixedStrategy` calls (5 bytes, then 3 bytes) from an 8-byte buffer
+
+### ReadToEndStrategy Tests
+
+17. **Read all:** 100-byte buffer, no max → returns all 100 bytes
+18. **Max length enforced:** 100-byte buffer, `max_length: 50` → `MaxLengthExceeded`
+19. **Empty input:** empty buffer → returns empty `Vec<u8>` (EOF is not an error for this strategy)
+20. **Max length with exact fit:** 50-byte buffer, `max_length: 50` → success (boundary condition)
+
+### CompositeStrategy Tests
+
+21. **HTTP-style:** delimiter + length-prefixed → two frames (headers, body)
+22. **Triple chain:** three delimiter strategies on three-line input → three frames
+23. **First strategy fails:** first strategy errors → returns error, second never runs
+24. **Second strategy fails:** first succeeds, second encounters unexpected EOF → error
+
+### Partial Feed Tests (Simulating Chunked TCP)
+
+Real TCP streams do not deliver all bytes at once. Data arrives in unpredictable
+chunks. These tests use a custom `SlowReader` that yields a few bytes per
+`read()` call to ensure strategies handle partial reads correctly.
+
+25. **Delimiter across chunks:** delimiter `\r\n` split across two reads (`"HEL"` then `"LO\r\nWORLD"`)
+26. **Length-prefixed across chunks:** 10 bytes requested, delivered in 3 + 4 + 3 byte reads
+27. **Read-to-end across chunks:** multiple small reads before EOF
+
+### Edge Cases
+
+28. **Very long delimiter:** 16-byte delimiter (unusual but valid)
+29. **Binary data:** frames containing null bytes, high bytes (0xFF), all byte values
+30. **Large frame:** 1 MB frame to verify no artificial internal limits beyond max_length
+31. **Overlapping delimiter patterns:** data containing partial delimiter matches (e.g., `\r` without `\n` when delimiter is `\r\n`)
+
+---
+
+## Scope
+
+**In scope:**
+- `DelimiterStrategy` — read until a byte pattern appears
+- `LengthPrefixedStrategy` — read exactly N bytes
+- `ReadToEndStrategy` — read all bytes until EOF
+- `CompositeStrategy` — chain strategies sequentially
+- `FrameError` error types with descriptive variants
+- Safety limits (max_length) to prevent unbounded memory use
+- Operates on `impl BufRead` for composability
+
+**Out of scope:**
+- **Stateful buffering** — The `irc-framing` package uses a `feed(bytes)` /
+  `frames()` pattern with an internal buffer that accumulates bytes across
+  multiple feeds. That is needed for event-driven / async architectures. This
+  package uses synchronous blocking reads from `BufRead` — simpler, and
+  sufficient for our HTTP/1.0 client.
+- **Async I/O** — No `tokio`, no `async-std`, no futures. This package is
+  purely synchronous. An async version could wrap these strategies behind
+  `AsyncBufRead`, but that is a separate package.
+- **Protocol-specific parsing** — This package extracts raw byte frames. It
+  does NOT parse HTTP headers, decode WebSocket opcodes, or interpret RESP type
+  prefixes. That is the job of the protocol layer above (NET03, etc.).
+- **WebSocket frame decoding** — WebSocket has its own binary framing format
+  (opcode, mask bit, payload length in 1/2/8 bytes). Decoding that format is
+  protocol-specific parsing, not generic framing.
+- **Chunked transfer encoding** — HTTP/1.1's chunked encoding is a complex
+  stateful protocol on top of framing. Out of scope for this package and for
+  our HTTP/1.0 client.
+
+---
+
+## Implementation Languages
+
+This package will be implemented in:
+- **Rust** (primary, for the Venture browser networking stack)
+- Future: all 9 languages following the standard pattern

--- a/code/specs/NET03-http1.0-lexer.md
+++ b/code/specs/NET03-http1.0-lexer.md
@@ -1,0 +1,526 @@
+# NET03 — HTTP/1.0 Lexer
+
+## Overview
+
+HTTP/1.0 is a **text-based protocol** — requests and responses are plain ASCII
+text with a rigid but simple structure. Before we can understand what an HTTP
+message *means* (is this a redirect? does it have a JSON body?), we need to
+break the raw bytes into meaningful pieces. That is the lexer's job.
+
+**Analogy:** Imagine you receive a letter in a foreign language. Before you can
+translate it, you need to identify the individual words, the punctuation marks,
+the paragraph breaks. You don't need to understand the meaning yet — you just
+need to know where one word ends and the next begins. The HTTP lexer does
+exactly this: it takes a stream of bytes and identifies the *tokens* — method,
+URI, version, status code, headers, body — without interpreting their meaning.
+
+```
+Raw bytes on the wire:              What the lexer sees:
+                                    
+GET /index.html HTTP/1.0\r\n       [Method: "GET"]
+Host: www.example.com\r\n          [RequestUri: "/index.html"]
+User-Agent: Venture/0.1\r\n        [Version: "HTTP/1.0"]
+\r\n                                [HeaderName: "Host"]
+                                    [HeaderValue: "www.example.com"]
+                                    [HeaderName: "User-Agent"]
+                                    [HeaderValue: "Venture/0.1"]
+                                    [Body: (empty)]
+                                    [Eof]
+```
+
+### Historical Context
+
+HTTP was invented by **Tim Berners-Lee** at CERN in 1989, alongside HTML and
+URLs — the three pillars of the World Wide Web. The first version, HTTP/0.9
+(1991), was breathtakingly simple. The entire protocol was one line:
+
+```
+GET /path\r\n
+```
+
+The server responded with the raw HTML body and closed the connection. No
+headers. No status codes. No content types. If you asked for a page and it
+didn't exist, the server just closed the connection with no explanation.
+
+**HTTP/1.0** (RFC 1945, May 1996) changed everything. It added:
+
+- **Status codes** — the server tells you *what happened* (200 OK, 404 Not
+  Found, 301 Moved Permanently)
+- **Headers** — metadata about the request and response (Content-Type,
+  Content-Length, User-Agent)
+- **Methods beyond GET** — POST for sending data, HEAD for metadata-only
+  requests
+- **Version negotiation** — the client declares which HTTP version it speaks
+
+This was the protocol that **Mosaic** and early **Netscape Navigator** used to
+fetch web pages. Every page load was a separate TCP connection: connect, send
+request, receive response, disconnect. Simple but expensive — a page with 10
+images meant 11 TCP connections.
+
+HTTP/1.0 is the sweet spot for learning: complex enough to be a real protocol,
+simple enough to implement in a weekend. It has no chunked encoding, no
+persistent connections, no trailers — just clean request-response pairs.
+
+---
+
+## Where It Fits
+
+```
+tcp-client (NET01) → frame-extractor (NET02) → http1.0-lexer (NET03) → http1.0-parser (NET04)
+                                                     ↑
+                                                 THIS PACKAGE
+
+The flow for an HTTP/1.0 response:
+
+  1. tcp-client opens a socket and sends a request
+  2. Server sends back a stream of bytes
+  3. frame-extractor carves the stream into a complete HTTP message
+  4. http1.0-lexer tokenizes those bytes into structured tokens
+  5. http1.0-parser (next layer) interprets the tokens into a typed
+     Request/Response struct with semantic meaning
+```
+
+**Depends on:** Nothing. Operates on `&[u8]` — raw byte slices.
+
+**Depended on by:** `http1.0-parser` (NET04), which consumes the token stream
+and produces a typed HTTP request or response structure.
+
+---
+
+## Concepts
+
+### The HTTP/1.0 Wire Format
+
+HTTP messages are plain text (well, ASCII) with a very specific structure. Let's
+trace through a full request and response to see every byte.
+
+#### Request Format
+
+```
+Method SP Request-URI SP HTTP-Version CRLF
+Header-Name: Header-Value CRLF
+Header-Name: Header-Value CRLF
+CRLF
+[body]
+```
+
+Where `SP` is a single space (0x20) and `CRLF` is carriage-return + line-feed
+(0x0D 0x0A). Here's a concrete example with every byte labeled:
+
+```
+G  E  T  SP /  i  n  d  e  x  .  h  t  m  l  SP H  T  T  P  /  1  .  0  CR LF
+H  o  s  t  :  SP w  w  w  .  e  x  a  m  p  l  e  .  c  o  m  CR LF
+U  s  e  r  -  A  g  e  n  t  :  SP V  e  n  t  u  r  e  /  0  .  1  CR LF
+CR LF
+```
+
+The blank line (CRLF immediately after the last header's CRLF) signals the end
+of the header section. Everything after it is the body. For GET requests, the
+body is typically empty.
+
+#### Response Format
+
+```
+HTTP-Version SP Status-Code SP Reason-Phrase CRLF
+Header-Name: Header-Value CRLF
+Header-Name: Header-Value CRLF
+CRLF
+[body]
+```
+
+Example:
+
+```
+HTTP/1.0 200 OK\r\n
+Content-Type: text/html\r\n
+Content-Length: 45\r\n
+\r\n
+<html><body><h1>Hello, World!</h1></body></html>
+```
+
+### How Requests and Responses Differ
+
+The first line is the giveaway:
+
+| Message   | First line starts with | Structure                               |
+|-----------|------------------------|-----------------------------------------|
+| Request   | A method (GET, POST..) | Method SP URI SP Version CRLF           |
+| Response  | "HTTP/"                | Version SP Status-Code SP Reason CRLF   |
+
+The lexer detects which kind of message it's looking at by examining the first
+bytes. If they spell out `HTTP/`, it's a response. Otherwise, it's a request
+starting with a method name.
+
+### Header Lines
+
+After the first line, both requests and responses share the same header format:
+
+```
+Field-Name ":" OWS Field-Value OWS CRLF
+```
+
+Where `OWS` means "optional whitespace" — zero or more spaces or tabs. In
+practice, most servers send exactly one space after the colon:
+
+```
+Content-Type: text/html
+```
+
+But the lexer must tolerate variations:
+
+```
+Content-Type:text/html           ← no space (valid)
+Content-Type:   text/html        ← extra spaces (valid)
+Content-Type:\ttext/html         ← tab (valid)
+```
+
+Header names are case-insensitive per the spec (`Content-Type` and
+`content-type` mean the same thing), but the lexer preserves the original
+casing as-is. Case normalization is the parser's job.
+
+### The Body
+
+Everything after the blank line (`\r\n\r\n`) is the body. The lexer captures it
+as raw bytes without interpretation. The body might be HTML, an image, JSON, or
+nothing at all. The lexer doesn't care — it just captures the bytes.
+
+### CRLF Tolerance
+
+The spec says lines end with `\r\n` (CRLF), but in the wild you will encounter
+bare `\n` (LF) — especially from Unix-based servers or hand-crafted test data.
+Robustness principle (Postel's Law): "Be conservative in what you send, be
+liberal in what you accept." The lexer accepts both `\r\n` and bare `\n` as line
+terminators.
+
+---
+
+## Public API
+
+The public API is intentionally minimal. Two functions, one token type, one error
+type.
+
+### Token Type
+
+```rust
+/// A single token extracted from an HTTP/1.0 message.
+///
+/// Tokens represent the syntactic atoms of the HTTP wire format.
+/// They carry no semantic meaning — the parser layer interprets
+/// what the tokens mean.
+///
+/// # Example
+///
+/// Lexing the request `GET / HTTP/1.0\r\nHost: localhost\r\n\r\n` produces:
+///
+/// ```text
+/// [Method("GET"), RequestUri("/"), Version("HTTP/1.0"),
+///  HeaderName("Host"), HeaderValue("localhost"), Body([]), Eof]
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub enum HttpToken {
+    /// HTTP method: GET, POST, HEAD, PUT, DELETE, LINK, UNLINK.
+    ///
+    /// RFC 1945 defines GET, HEAD, and POST. Extension methods
+    /// (PUT, DELETE, LINK, UNLINK) are also recognized.
+    Method(String),
+
+    /// The Request-URI: the resource being requested.
+    ///
+    /// Examples: "/", "/index.html", "/images/photo.gif"
+    /// Can be an absolute URI or an absolute path.
+    RequestUri(String),
+
+    /// The HTTP version string, e.g. "HTTP/1.0".
+    ///
+    /// Appears in both request lines (third field) and
+    /// response status lines (first field).
+    Version(String),
+
+    /// Three-digit integer status code from a response.
+    ///
+    /// Examples: 200, 301, 404, 500
+    StatusCode(u16),
+
+    /// Human-readable reason phrase from a response status line.
+    ///
+    /// Examples: "OK", "Moved Permanently", "Not Found"
+    ReasonPhrase(String),
+
+    /// Header field name (left side of the colon).
+    ///
+    /// Preserved exactly as received — no case normalization.
+    /// Examples: "Content-Type", "Host", "User-Agent"
+    HeaderName(String),
+
+    /// Header field value (right side of the colon).
+    ///
+    /// Leading and trailing whitespace is trimmed.
+    /// Examples: "text/html", "www.example.com", "1234"
+    HeaderValue(String),
+
+    /// The message body as raw bytes.
+    ///
+    /// Everything after the blank line (\r\n\r\n) that ends the
+    /// header section. May be empty (zero-length Vec).
+    Body(Vec<u8>),
+
+    /// Signals the end of the token stream.
+    Eof,
+}
+```
+
+### Error Type
+
+```rust
+/// Errors that can occur during HTTP/1.0 lexing.
+///
+/// Each variant carries a human-readable message describing
+/// what went wrong, suitable for diagnostic output.
+#[derive(Debug, Clone, PartialEq)]
+pub enum HttpLexError {
+    /// The method token is not a valid HTTP method.
+    /// e.g., "G3T /index.html HTTP/1.0"
+    InvalidMethod(String),
+
+    /// The status code is not a valid 3-digit integer in [100, 599].
+    /// e.g., "HTTP/1.0 999 Oops" or "HTTP/1.0 abc OK"
+    InvalidStatusCode(String),
+
+    /// The version string doesn't match "HTTP/x.y" format.
+    /// e.g., "GET / HTZP/1.0"
+    InvalidVersion(String),
+
+    /// A header line doesn't contain a colon separator.
+    /// e.g., "Content-Type text/html" (missing colon)
+    MalformedHeaderLine(String),
+
+    /// The input ended unexpectedly before a complete message
+    /// could be lexed.
+    /// e.g., "GET /index.html" (no version, no CRLF)
+    UnexpectedEof,
+}
+```
+
+### Lexing Functions
+
+```rust
+/// Tokenize an HTTP/1.0 request from raw bytes.
+///
+/// Expects a byte slice containing a complete HTTP request:
+/// request line, headers, blank line, and optional body.
+///
+/// # Example
+///
+/// ```rust
+/// let input = b"GET / HTTP/1.0\r\nHost: localhost\r\n\r\n";
+/// let tokens = lex_request(input)?;
+/// assert_eq!(tokens[0], HttpToken::Method("GET".into()));
+/// assert_eq!(tokens[1], HttpToken::RequestUri("/".into()));
+/// assert_eq!(tokens[2], HttpToken::Version("HTTP/1.0".into()));
+/// ```
+///
+/// # Errors
+///
+/// Returns `HttpLexError` if the input is malformed:
+/// - `InvalidMethod` if the method is not a recognized token
+/// - `InvalidVersion` if the version string is malformed
+/// - `MalformedHeaderLine` if a header lacks a colon
+/// - `UnexpectedEof` if the input is truncated
+pub fn lex_request(input: &[u8]) -> Result<Vec<HttpToken>, HttpLexError>
+
+/// Tokenize an HTTP/1.0 response from raw bytes.
+///
+/// Expects a byte slice containing a complete HTTP response:
+/// status line, headers, blank line, and optional body.
+///
+/// # Example
+///
+/// ```rust
+/// let input = b"HTTP/1.0 200 OK\r\nContent-Length: 5\r\n\r\nHello";
+/// let tokens = lex_response(input)?;
+/// assert_eq!(tokens[0], HttpToken::Version("HTTP/1.0".into()));
+/// assert_eq!(tokens[1], HttpToken::StatusCode(200));
+/// assert_eq!(tokens[2], HttpToken::ReasonPhrase("OK".into()));
+/// ```
+///
+/// # Errors
+///
+/// Returns `HttpLexError` if the input is malformed:
+/// - `InvalidVersion` if the version string is malformed
+/// - `InvalidStatusCode` if the status code isn't a valid integer
+/// - `MalformedHeaderLine` if a header lacks a colon
+/// - `UnexpectedEof` if the input is truncated
+pub fn lex_response(input: &[u8]) -> Result<Vec<HttpToken>, HttpLexError>
+```
+
+---
+
+## Lexing Algorithm
+
+The lexer works in sequential **phases**, consuming bytes from front to back.
+No backtracking is needed — HTTP/1.0's wire format is designed to be parsed in
+a single pass.
+
+### Phase 1: First Line Detection
+
+Look at the first non-whitespace bytes of the input:
+
+```
+Does it start with "HTTP/"?
+  ├─ Yes → This is a response. Parse a status line.
+  └─ No  → This is a request. Parse a request line.
+```
+
+Since the two public functions (`lex_request` and `lex_response`) already know
+which type they expect, this detection is implicit — but the internal machinery
+is the same.
+
+### Phase 2a: Request Line (for requests)
+
+```
+GET /index.html HTTP/1.0\r\n
+^^^                          → Method: scan until SP
+    ^^^^^^^^^^^              → Request-URI: scan until SP
+                ^^^^^^^^     → Version: scan until CRLF
+```
+
+1. Scan forward from the start, collecting bytes until the first space → Method
+2. Skip the space, collect bytes until the next space → Request-URI
+3. Skip the space, collect bytes until CRLF → Version
+4. Advance past the CRLF
+
+### Phase 2b: Status Line (for responses)
+
+```
+HTTP/1.0 200 OK\r\n
+^^^^^^^^             → Version: scan until SP
+         ^^^         → Status-Code: scan until SP, parse as u16
+             ^^      → Reason-Phrase: scan until CRLF
+```
+
+1. Collect bytes until the first space → Version
+2. Skip the space, collect bytes until the next space → Status-Code (parse as
+   integer, must be 100-599)
+3. Skip the space, collect bytes until CRLF → Reason-Phrase
+4. Advance past the CRLF
+
+### Phase 3: Headers
+
+Repeatedly read lines until we hit an empty line (just CRLF):
+
+```
+Content-Type: text/html\r\n     → HeaderName("Content-Type"), HeaderValue("text/html")
+Content-Length: 1234\r\n         → HeaderName("Content-Length"), HeaderValue("1234")
+\r\n                             → (empty line — stop reading headers)
+```
+
+For each header line:
+
+1. Scan until `:` → HeaderName
+2. Skip the colon and any optional whitespace (spaces, tabs)
+3. Collect remaining bytes until CRLF, trim trailing whitespace → HeaderValue
+4. Emit HeaderName and HeaderValue tokens
+
+If a line has no colon, emit `MalformedHeaderLine` error.
+
+### Phase 4: Body
+
+Everything after the blank line is the body:
+
+1. Collect all remaining bytes into a `Vec<u8>`
+2. Emit `Body(bytes)` — even if empty (zero bytes)
+3. Emit `Eof`
+
+### Tolerance Rules
+
+Following Postel's Law ("be liberal in what you accept"):
+
+| Situation                      | Behavior                              |
+|--------------------------------|---------------------------------------|
+| `\n` instead of `\r\n`        | Accept bare LF as a line terminator   |
+| Leading whitespace before line | Strip and continue                    |
+| Extra spaces around header `:` | Trim whitespace from header values    |
+| Trailing whitespace in values  | Trim it                               |
+
+---
+
+## Testing Strategy
+
+### Unit Tests by Phase
+
+**Request line parsing:**
+- Standard `GET / HTTP/1.0\r\n` request
+- All RFC 1945 methods: GET, HEAD, POST
+- Extension methods: PUT, DELETE
+- Long URIs with query strings and fragments
+- Missing version → `UnexpectedEof`
+- Invalid method characters → `InvalidMethod`
+
+**Status line parsing:**
+- Common status codes: 200 OK, 301 Moved, 404 Not Found, 500 Server Error
+- Three-digit boundary: 100, 599
+- Non-numeric status code → `InvalidStatusCode`
+- Out-of-range status code (e.g., 600) → `InvalidStatusCode`
+- Empty reason phrase (just status code + CRLF)
+- Multi-word reason phrase: "Moved Permanently"
+
+**Header parsing:**
+- Single header
+- Multiple headers
+- Header with no space after colon: `Host:localhost`
+- Header with extra spaces: `Host:   localhost`
+- Header with tab after colon
+- Empty header value: `X-Empty:`
+- Missing colon → `MalformedHeaderLine`
+- Header value with colons (e.g., timestamps): `Date: Mon, 01 Jan 1996 00:00:00 GMT`
+
+**Body parsing:**
+- Non-empty body (HTML, plain text)
+- Empty body (CRLF CRLF followed by nothing)
+- Binary body (bytes > 127)
+
+**CRLF tolerance:**
+- Request with `\n` only (bare LF)
+- Mixed `\r\n` and `\n` in the same message
+- Leading whitespace before the first line
+
+### Integration Tests
+
+- Full request: method + URI + version + multiple headers + body
+- Full response: version + status + reason + headers + body
+- Real-world captures: lex actual HTTP/1.0 messages captured from
+  well-known servers
+
+### Edge Cases
+
+- Empty input → `UnexpectedEof`
+- Input that is only whitespace → `UnexpectedEof`
+- Header with value containing a colon (split on first colon only)
+- Very long header values (> 8KB)
+- Reason phrase with special characters
+
+---
+
+## Scope
+
+### In Scope
+
+- Tokenization of HTTP/1.0 requests (RFC 1945 Section 5)
+- Tokenization of HTTP/1.0 responses (RFC 1945 Section 6)
+- CRLF and bare-LF tolerance
+- Whitespace tolerance around header values
+- Leading whitespace tolerance before first line
+- All standard HTTP/1.0 methods (GET, HEAD, POST)
+- Extension methods (PUT, DELETE, LINK, UNLINK)
+
+### Out of Scope
+
+- **HTTP/1.1 features:** chunked transfer encoding, persistent connections
+  (keep-alive), the `Host` header requirement, trailers, 100-continue
+- **HTTP/2 and HTTP/3:** binary framing, multiplexing, HPACK, QPACK
+- **HTTPS/TLS:** encryption is a transport concern, not a lexing concern
+- **Header value interpretation:** parsing `Content-Type: text/html; charset=utf-8`
+  into type/subtype/parameters is the parser's job
+- **Body decoding:** decompression (gzip, deflate), charset conversion
+- **Request routing:** mapping URIs to handlers
+- **Connection management:** opening/closing TCP sockets

--- a/code/specs/NET04-http1.0-parser.md
+++ b/code/specs/NET04-http1.0-parser.md
@@ -1,0 +1,549 @@
+# NET04 — HTTP/1.0 Parser
+
+## Overview
+
+The HTTP/1.0 lexer (NET03) reads raw bytes and produces **tokens** — method,
+URI, version, header names and values, status codes. The lexer knows syntax: it
+knows where one token ends and the next begins. But it does not know what the
+tokens **mean**.
+
+That is the parser's job. The parser consumes a stream of `HttpToken` values
+from the lexer and assembles them into **semantic structures**: `HttpRequest` and
+`HttpResponse`. It understands that a `Content-Type` header describes the body
+format, that status 301 means "go somewhere else," and that a HEAD response has
+no body regardless of what the headers claim.
+
+**Analogy:** The lexer is like a mail room clerk who opens envelopes and
+separates the address, stamp, and letter. The parser is the reader who
+understands what the letter says — "this is a redirect, go to this other
+address" or "here is the HTML page you requested."
+
+```
+Mail Room Clerk (Lexer):
+  Envelope → [Address] [Stamp] [Letter]
+  "I found three pieces. I don't know what they mean."
+
+Reader (Parser):
+  [Address: 301 Moved] [Letter: Location: https://new-site.com]
+  "This is a redirect. The content has moved to a new address."
+```
+
+The lexer/parser split follows the same architecture used throughout this repo
+(see 02-lexer.md and 03-parser.md for the general pattern). The lexer handles
+the messy byte-level details; the parser reasons about protocol semantics on
+clean, typed tokens.
+
+---
+
+## Where It Fits
+
+```
+http1.0-lexer (NET03) → http1.0-parser (NET04) → http1.0-client (NET05)
+                              ↑ THIS PACKAGE
+```
+
+The flow for a complete HTTP/1.0 exchange:
+
+```
+  1. tcp-client (NET01) opens a connection to the server
+  2. frame-extractor (NET02) carves the byte stream into header block + body
+  3. http1.0-lexer (NET03) tokenizes the header block into HttpToken values
+  4. http1.0-parser (NET04) assembles tokens into HttpRequest / HttpResponse
+     ↑ THIS STEP
+  5. http1.0-client (NET05) uses the parsed response to follow redirects,
+     render HTML, or report errors
+```
+
+**Depends on:** http1.0-lexer (NET03) — for `HttpToken` types
+**Depended on by:** http1.0-client (NET05), Venture browser (BR01)
+
+---
+
+## Concepts
+
+### Tokens In, Structs Out
+
+The parser's job is straightforward: walk through an ordered list of tokens and
+build a struct. Think of it like reading a form — you see "Name:" followed by
+"Alice," so you fill in `name = "Alice"`. The tokens arrive in protocol-defined
+order:
+
+```
+Response tokens (in order):
+  [Version: HTTP/1.0] [Status: 200] [Reason: OK]
+  [HeaderName: Content-Type] [HeaderValue: text/html]
+  [HeaderName: Content-Length] [HeaderValue: 45]
+  [Body: <html>...</html>]
+
+Parsed into:
+  HttpResponse {
+      version: Http10,
+      status: 200,
+      reason: "OK",
+      headers: [("Content-Type", "text/html"), ("Content-Length", "45")],
+      body: b"<html>...</html>",
+  }
+```
+
+### Header Semantics
+
+HTTP headers are **case-insensitive** key-value pairs. The header name
+`Content-Type`, `content-type`, and `CONTENT-TYPE` all refer to the same
+header. The parser preserves the original casing in storage but provides
+case-insensitive lookup methods.
+
+A single response may contain **multiple headers with the same name**. Per
+RFC 1945 (HTTP/1.0), this is valid — the values should be treated as if they
+were a single header joined by commas. The parser stores all headers in
+order and lets the caller decide how to handle duplicates.
+
+```
+Set-Cookie: session=abc123
+Set-Cookie: theme=dark
+
+Stored as: [("Set-Cookie", "session=abc123"), ("Set-Cookie", "theme=dark")]
+Lookup "Set-Cookie" → returns "session=abc123" (first match)
+```
+
+### Content-Type Parsing
+
+The `Content-Type` header packs two pieces of information into one value:
+the **media type** (what kind of data) and optional **parameters** (how
+it is encoded):
+
+```
+Content-Type: text/html; charset=utf-8
+              ─────────  ──────────────
+              media type   parameter
+
+Content-Type: application/json
+              ────────────────
+              media type (no parameters)
+
+Content-Type: text/html; charset=iso-8859-1; boundary=something
+              ─────────  ─────────────────── ──────────────────
+              media type  first parameter      second parameter
+```
+
+The parser extracts the media type and the `charset` parameter (if present).
+Other parameters are ignored — they are rarely used in HTTP/1.0 practice.
+
+### Status Code Categories
+
+HTTP status codes follow a numbering convention where the first digit tells
+you the **category** of response:
+
+```
+Category    Range    Meaning              HTTP/1.0 Examples
+─────────────────────────────────────────────────────────────
+1xx         100–199  Informational        (not used in practice)
+2xx         200–299  Success              200 OK
+3xx         300–399  Redirect             301 Moved Permanently
+                                          302 Found
+4xx         400–499  Client error         400 Bad Request
+                                          403 Forbidden
+                                          404 Not Found
+5xx         500–599  Server error         500 Internal Server Error
+                                          503 Service Unavailable
+```
+
+The parser provides an `is_redirect()` helper that checks for status codes
+301, 302, 303, and 307 — the four codes that mean "the resource you want
+is at a different URL."
+
+### Body Size Determination
+
+In HTTP/1.0, figuring out how many bytes the body contains is not always
+straightforward. The parser applies these rules in order:
+
+```
+Rule 1: Is this a HEAD response, or status 204/304?
+  → Yes: body is empty, regardless of headers.
+
+Rule 2: Is there a Content-Length header?
+  → Yes: body is exactly Content-Length bytes.
+
+Rule 3: Neither of the above?
+  → Body extends until the server closes the connection.
+     (This is HTTP/1.0's default behavior — no keep-alive.)
+```
+
+This is simpler than HTTP/1.1, which adds chunked transfer encoding. In
+HTTP/1.0, the server simply closes the connection when done sending.
+
+---
+
+## Public API
+
+```rust
+// ─────────────────────────────────────────────
+// Core Structs
+// ─────────────────────────────────────────────
+
+/// A parsed HTTP request (client → server).
+///
+/// Built from a sequence of HttpToken values produced by the lexer.
+/// Contains all the information needed to understand what the client
+/// is asking for.
+///
+/// ## Example
+///
+/// ```rust
+/// let request = parse_request(&tokens)?;
+/// println!("Client wants: {} {}", request.method, request.uri);
+/// // "Client wants: GET /index.html"
+/// ```
+pub struct HttpRequest {
+    /// The HTTP method: GET, POST, HEAD, etc.
+    ///
+    /// HTTP/1.0 defines three methods:
+    /// - GET:  "Give me this resource"
+    /// - POST: "Accept this data"
+    /// - HEAD: "Give me just the headers for this resource"
+    pub method: String,
+
+    /// The resource being requested: "/index.html", "/api/users", etc.
+    pub uri: String,
+
+    /// The HTTP version. Always Http10 for this parser.
+    pub version: HttpVersion,
+
+    /// Request headers as ordered key-value pairs.
+    ///
+    /// Headers are stored in the order they appeared in the request.
+    /// Multiple headers with the same name are stored as separate entries.
+    pub headers: Vec<(String, String)>,
+
+    /// The request body, if any.
+    ///
+    /// GET and HEAD requests typically have empty bodies.
+    /// POST requests carry their payload here.
+    pub body: Vec<u8>,
+}
+
+/// A parsed HTTP response (server → client).
+///
+/// Built from a sequence of HttpToken values produced by the lexer.
+/// Contains the status code, headers, body, and convenience methods
+/// for common operations like redirect detection and content-type
+/// inspection.
+///
+/// ## Example
+///
+/// ```rust
+/// let response = parse_response(&tokens)?;
+/// if response.is_redirect() {
+///     println!("Follow redirect to: {}", response.location().unwrap());
+/// } else if response.is_html() {
+///     println!("Got {} bytes of HTML", response.body.len());
+/// }
+/// ```
+pub struct HttpResponse {
+    /// The HTTP version. Always Http10 for this parser.
+    pub version: HttpVersion,
+
+    /// The three-digit status code: 200, 301, 404, 500, etc.
+    pub status: u16,
+
+    /// The human-readable reason phrase: "OK", "Not Found", etc.
+    ///
+    /// This exists for debugging and logging. Code should branch on
+    /// the numeric status code, not the reason phrase — servers are
+    /// free to send any text here.
+    pub reason: String,
+
+    /// Response headers as ordered key-value pairs.
+    pub headers: Vec<(String, String)>,
+
+    /// The response body as raw bytes.
+    ///
+    /// For text responses, decode using the charset from Content-Type.
+    /// For binary responses (images, etc.), use the bytes directly.
+    pub body: Vec<u8>,
+}
+
+/// The HTTP version. HTTP/1.0 is the only version this parser handles.
+pub enum HttpVersion {
+    Http10,
+}
+
+// ─────────────────────────────────────────────
+// Convenience Methods
+// ─────────────────────────────────────────────
+
+impl HttpResponse {
+    /// Case-insensitive header lookup. Returns the value of the first
+    /// header whose name matches (ignoring ASCII case).
+    ///
+    /// ## Example
+    ///
+    /// ```rust
+    /// // All of these find the same header:
+    /// response.header("Content-Type");
+    /// response.header("content-type");
+    /// response.header("CONTENT-TYPE");
+    /// ```
+    pub fn header(&self, name: &str) -> Option<&str>
+
+    /// Parse the Content-Type header into (media_type, charset).
+    ///
+    /// Extracts the media type and optional charset parameter from
+    /// the Content-Type header value.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// // "text/html; charset=utf-8" → ("text/html", Some("utf-8"))
+    /// // "application/json"         → ("application/json", None)
+    /// // No Content-Type header     → None
+    /// ```
+    pub fn content_type(&self) -> Option<(String, Option<String>)>
+
+    /// Content-Length as usize, if the header is present and contains
+    /// a valid non-negative integer.
+    ///
+    /// Returns None if the header is missing or contains a non-numeric
+    /// value (which is a server bug, but not our problem to fix).
+    pub fn content_length(&self) -> Option<usize>
+
+    /// Is this response a redirect?
+    ///
+    /// Returns true for status codes 301, 302, 303, and 307 — the
+    /// four codes that mean "look somewhere else."
+    ///
+    /// ```
+    /// 301 Moved Permanently  — "This page has moved forever"
+    /// 302 Found              — "This page has moved temporarily"
+    /// 303 See Other          — "Go GET this other URL instead"
+    /// 307 Temporary Redirect — "Same as 302 but keep the method"
+    /// ```
+    pub fn is_redirect(&self) -> bool
+
+    /// The Location header value, used with redirects.
+    ///
+    /// When is_redirect() is true, this tells you where to go next.
+    /// Returns None if the header is missing (a buggy redirect).
+    pub fn location(&self) -> Option<&str>
+
+    /// Is the response body HTML?
+    ///
+    /// Returns true if the Content-Type media type starts with
+    /// "text/html". This is a convenience for browser-like clients
+    /// that need to decide whether to render or download.
+    pub fn is_html(&self) -> bool
+}
+
+// ─────────────────────────────────────────────
+// Parser Functions
+// ─────────────────────────────────────────────
+
+/// Parse a sequence of tokens into an HttpRequest.
+///
+/// Expects tokens in this order:
+///   [Method] [Uri] [Version] ([HeaderName] [HeaderValue])* [Body]?
+///
+/// Returns an error if required tokens are missing or malformed.
+///
+/// ## Example
+///
+/// ```rust
+/// let tokens = lexer::tokenize_request(b"GET / HTTP/1.0\r\nHost: example.com\r\n\r\n")?;
+/// let request = parse_request(&tokens)?;
+/// assert_eq!(request.method, "GET");
+/// assert_eq!(request.uri, "/");
+/// ```
+pub fn parse_request(tokens: &[HttpToken]) -> Result<HttpRequest, HttpParseError>
+
+/// Parse a sequence of tokens into an HttpResponse.
+///
+/// Expects tokens in this order:
+///   [Version] [Status] [Reason] ([HeaderName] [HeaderValue])* [Body]?
+///
+/// Returns an error if required tokens are missing or malformed.
+///
+/// ## Example
+///
+/// ```rust
+/// let tokens = lexer::tokenize_response(raw_bytes)?;
+/// let response = parse_response(&tokens)?;
+/// assert_eq!(response.status, 200);
+/// assert_eq!(response.reason, "OK");
+/// ```
+pub fn parse_response(tokens: &[HttpToken]) -> Result<HttpResponse, HttpParseError>
+
+// ─────────────────────────────────────────────
+// Errors
+// ─────────────────────────────────────────────
+
+/// Everything that can go wrong when parsing HTTP tokens.
+///
+/// These errors indicate that the token stream does not match the
+/// expected structure of an HTTP message. The lexer already validated
+/// syntax (well-formed tokens), so these are semantic errors — the
+/// tokens are individually valid but do not form a coherent message.
+pub enum HttpParseError {
+    /// The token stream has no method token (e.g., empty input).
+    MissingMethod,
+
+    /// A method was found but no URI followed it.
+    MissingUri,
+
+    /// Method and URI were found but no version followed.
+    MissingVersion,
+
+    /// The status code is not a valid three-digit integer.
+    ///
+    /// HTTP status codes must be in the range 100–599.
+    InvalidStatusCode,
+
+    /// The Content-Type header value could not be parsed.
+    ///
+    /// This means the media type portion is empty or malformed,
+    /// e.g., "; charset=utf-8" (no media type before the semicolon).
+    MalformedContentType,
+}
+```
+
+### Design Decisions
+
+**Why `Vec<(String, String)>` for headers instead of `HashMap`?** Three
+reasons:
+
+1. **Order preservation.** Some protocols care about header order (proxies
+   may reorder, but we should not lose information).
+2. **Duplicate headers.** A `HashMap` would silently drop duplicates.
+   `Set-Cookie` appears multiple times in practice.
+3. **Simplicity.** Linear scan over a few dozen headers is faster than
+   hashing for realistic HTTP/1.0 response sizes.
+
+**Why `Vec<u8>` for the body instead of `String`?** HTTP bodies can be
+binary (images, compressed content). Using `Vec<u8>` is correct for all
+content types. Text bodies can be decoded by the caller using the charset
+from `content_type()`.
+
+**Why separate `parse_request` and `parse_response`?** Requests and
+responses have different token structures (method/uri/version vs.
+version/status/reason). A single `parse()` function would need a flag or
+enum to distinguish them, adding complexity for no benefit.
+
+---
+
+## Testing Strategy
+
+All tests operate on pre-constructed token slices — no network I/O, no
+lexer dependency at test time. This isolates parser logic from lexer
+behavior.
+
+### Happy Path
+
+1. **200 OK with body** — Parse a standard response with Content-Type,
+   Content-Length, and an HTML body. Verify all fields are populated
+   correctly.
+2. **301 redirect with Location** — Parse a redirect response. Verify
+   `is_redirect()` returns true and `location()` returns the target URL.
+3. **404 Not Found** — Parse an error response. Verify status is 404 and
+   `is_redirect()` returns false.
+4. **200 with no Content-Length** — Body determined by EOF (the `body`
+   field contains everything the lexer provided after headers). Verify
+   the body is captured correctly.
+5. **GET request** — Parse a simple GET request with Host header.
+6. **POST request with body** — Parse a POST request carrying form data.
+
+### Header Handling
+
+7. **Case-insensitive lookup** — Set header as "Content-Type", look up as
+   "content-type", "CONTENT-TYPE", and "Content-type". All must return the
+   same value.
+8. **Multiple headers with same name** — Two "Set-Cookie" headers. Verify
+   both are stored. Verify `header()` returns the first one.
+9. **No headers** — Response with status line and body but zero headers.
+   Verify `header()` returns None for any name.
+10. **Header with empty value** — `X-Empty:` (value is empty string).
+    Verify it is stored and retrievable.
+
+### Content-Type Parsing
+
+11. **With charset** — `text/html; charset=utf-8` →
+    `("text/html", Some("utf-8"))`.
+12. **Without charset** — `application/json` →
+    `("application/json", None)`.
+13. **With extra parameters** — `text/html; charset=iso-8859-1; boundary=x`
+    → `("text/html", Some("iso-8859-1"))`. The boundary parameter is
+    ignored.
+14. **Case variations** — `Text/HTML; Charset=UTF-8` — media type and
+    charset should be case-preserved but correctly extracted.
+15. **No Content-Type header** — `content_type()` returns `None`.
+
+### Redirect Detection
+
+16. **301 is redirect** — `is_redirect()` returns true.
+17. **302 is redirect** — `is_redirect()` returns true.
+18. **303 is redirect** — `is_redirect()` returns true.
+19. **307 is redirect** — `is_redirect()` returns true.
+20. **200 is not redirect** — `is_redirect()` returns false.
+21. **Location on non-redirect** — A 200 response with a Location header.
+    `location()` still returns the value (it is just a header lookup), but
+    `is_redirect()` returns false.
+
+### Body Rules
+
+22. **HEAD response has no body** — Even if Content-Length is present, a
+    HEAD response should have an empty body.
+23. **204 No Content** — Body is empty regardless of headers.
+24. **304 Not Modified** — Body is empty regardless of headers.
+
+### Error Cases
+
+25. **Empty token list** — `parse_request` returns `MissingMethod`.
+26. **Method only** — `parse_request` returns `MissingUri`.
+27. **Method and URI only** — `parse_request` returns `MissingVersion`.
+28. **Invalid status code** — Status token of "abc" returns
+    `InvalidStatusCode`.
+29. **Status code out of range** — Status token of "999" returns
+    `InvalidStatusCode`.
+
+### Real-World Responses
+
+30. **Captured 200 from archive.org** — A real HTTP/1.0 response captured
+    from a live server, tokenized and parsed. Verify headers and body
+    match expected values.
+31. **Captured 301 from archive.org** — A real redirect response. Verify
+    `is_redirect()` and `location()` work correctly on real-world data.
+
+---
+
+## Scope
+
+**In scope:**
+- Parsing `HttpToken` streams into `HttpRequest` and `HttpResponse` structs
+- Case-insensitive header lookup
+- Content-Type parsing (media type and charset extraction)
+- Status code category helpers (redirect detection, HTML detection)
+- Content-Length extraction
+- Body size rules for HEAD, 204, and 304 responses
+- Descriptive error types for malformed token streams
+
+**Out of scope:**
+- **HTTP/1.1 features** — Chunked transfer encoding, keep-alive connections,
+  trailers. HTTP/1.1 is a substantially more complex protocol; this parser
+  handles only HTTP/1.0.
+- **Cookie parsing** — The `Set-Cookie` header has its own complex grammar
+  (expires, path, domain, secure, httponly). A dedicated cookie parser
+  belongs in a separate package.
+- **Authentication headers** — `WWW-Authenticate` and `Authorization` have
+  scheme-specific formats (Basic, Digest, Bearer). Parsing these is out of
+  scope.
+- **Caching headers** — `Cache-Control`, `ETag`, `If-Modified-Since`, etc.
+  These are HTTP/1.1 concepts with limited relevance to HTTP/1.0.
+- **Multipart bodies** — `multipart/form-data` has its own boundary-based
+  framing. This parser treats the body as an opaque `Vec<u8>`.
+- **Content decoding** — gzip, deflate, or charset conversion. The parser
+  gives you raw bytes; decoding is the caller's responsibility.
+
+---
+
+## Implementation Languages
+
+This package will be implemented in:
+- **Rust** (primary, for the Venture browser networking stack)
+- Future: all 9 languages following the standard pattern

--- a/code/specs/NET05-http1.0-client.md
+++ b/code/specs/NET05-http1.0-client.md
@@ -1,0 +1,320 @@
+# NET05 — HTTP/1.0 Client
+
+## Overview
+
+The HTTP/1.0 client is a thin orchestrator — roughly 100 lines of glue code that
+wires together five independent packages into a complete HTTP client. It does
+almost nothing on its own. Instead, it sequences calls through a pipeline of
+single-purpose packages, each handling one layer of the problem:
+
+| Step | Package              | Responsibility                          |
+|------|----------------------|-----------------------------------------|
+| 1    | url-parser (NET00)   | Parse URL into scheme, host, port, path |
+| 2    | tcp-client (NET01)   | Open a TCP socket to the server         |
+| 3    | *(inline)*           | Write the HTTP request line + headers   |
+| 4    | frame-extractor (NET02) | Extract header frame, then body      |
+| 5    | http1.0-lexer (NET03)   | Tokenize the raw response bytes      |
+| 6    | http1.0-parser (NET04)  | Build a structured HttpResponse      |
+
+This is the unix-pipe philosophy made concrete: each package does one thing
+well, and the client simply connects them in sequence.
+
+## Where It Fits
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                      Application Code                                │
+│                  calls http1_client::get(url)                        │
+└──────────────────────────┬───────────────────────────────────────────┘
+                           │
+┌──────────────────────────▼───────────────────────────────────────────┐
+│                  HTTP/1.0 Client (NET05)                             │
+│          ~100 lines of orchestration glue                            │
+│                                                                      │
+│  ┌──────────┐  ┌──────────┐  ┌───────────────┐  ┌────────┐  ┌─────┐│
+│  │url-parser│→ │tcp-client│→ │frame-extractor│→ │ lexer  │→ │parse││
+│  │  NET00   │  │  NET01   │  │    NET02      │  │ NET03  │  │NET04││
+│  └──────────┘  └──────────┘  └───────────────┘  └────────┘  └─────┘│
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+NET05 is the first package in the networking stack where a user can make an
+actual HTTP request with a single function call. Everything below it is
+plumbing; this is the faucet.
+
+### Dependency Tree
+
+```
+http1.0-client (NET05)
+├── url-parser (NET00)
+├── tcp-client (NET01)
+├── frame-extractor (NET02)
+├── http1.0-lexer (NET03)
+└── http1.0-parser (NET04)
+```
+
+## Concepts
+
+### 1. The Pipeline — Step by Step
+
+This is the full journey of an HTTP/1.0 GET request. Every step maps to a
+package boundary, so you can test and reason about each one independently.
+
+```
+User calls: http1_client::get("http://info.cern.ch/hypertext/WWW/TheProject.html")
+
+Step 1: url-parser (NET00)
+        "http://info.cern.ch/hypertext/WWW/TheProject.html"
+        → Url { scheme: "http", host: "info.cern.ch", port: 80, path: "/hypertext/WWW/TheProject.html" }
+
+Step 2: tcp-client (NET01)
+        connect("info.cern.ch", 80, default_options)
+        → TcpConnection (live socket)
+
+Step 3: Write request
+        TcpConnection.write_all(b"GET /hypertext/WWW/TheProject.html HTTP/1.0\r\nHost: info.cern.ch\r\nUser-Agent: Venture/0.1\r\n\r\n")
+        TcpConnection.shutdown_write() — signal we're done sending
+
+Step 4: frame-extractor (NET02)
+        Phase A: DelimiterStrategy("\r\n\r\n").extract(conn) → header bytes
+        Phase B: Parse Content-Length from raw headers, or fall back to ReadToEnd
+        Phase C: LengthPrefixedStrategy(len).extract(conn) → body bytes
+                 OR ReadToEndStrategy.extract(conn) → body bytes
+
+Step 5: http1.0-lexer (NET03)
+        lex_response(&raw_bytes) → Vec<HttpToken>
+
+Step 6: http1.0-parser (NET04)
+        parse_response(&tokens) → HttpResponse { status: 200, headers: [...], body: b"<html>..." }
+
+Step 7: Redirect following (if status is 301 or 302)
+        Extract Location header → resolve against base URL → go to Step 1
+        Max 5 redirects to prevent infinite loops
+
+Return: HttpResponse to caller
+```
+
+### 2. Request Construction
+
+HTTP/1.0 requests are simple text. The client constructs them by string
+formatting — no serialization library needed:
+
+```
+GET <path> HTTP/1.0\r\n
+Host: <host>\r\n
+User-Agent: Venture/0.1\r\n
+Accept: */*\r\n
+\r\n
+```
+
+The blank line (`\r\n\r\n`) terminates the headers and signals "no request
+body." For GET requests, there is never a body.
+
+### 3. Connection Lifecycle
+
+HTTP/1.0 is one-request-per-connection. The full lifecycle is:
+
+1. Open TCP connection
+2. Send request
+3. Call `shutdown_write()` to signal we are done sending
+4. Read the complete response
+5. Connection closes (server closes its end after responding)
+
+There is no keep-alive, no pipelining, no multiplexing. One socket, one
+request, one response, done. This simplicity is why we start with HTTP/1.0
+rather than 1.1.
+
+### 4. Redirect Following
+
+Some URLs respond with a redirect instead of content. The HTTP/1.0 status
+codes that trigger redirect following:
+
+- **301 Moved Permanently** — the resource has a new canonical URL
+- **302 Found** — the resource is temporarily at a different URL
+
+Both include a `Location` header with the new URL. The client:
+
+1. Extracts the `Location` header value
+2. Resolves it against the base URL (the `Location` may be relative, e.g.,
+   `/other-page` instead of `http://example.com/other-page`)
+3. Starts the pipeline over from Step 1 with the new URL
+4. Caps at 5 total redirects to prevent infinite loops
+
+### 5. Why This Is ~100 Lines
+
+All the complexity lives in the five dependency packages:
+
+- URL parsing? NET00 handles it.
+- TCP sockets? NET01 handles it.
+- Framing (knowing where headers end and body begins)? NET02 handles it.
+- Tokenizing HTTP? NET03 handles it.
+- Building structured responses? NET04 handles it.
+
+The client just calls them in order. This is the payoff of the unix-pipe
+architecture: the integration layer is trivial because the components are
+well-defined.
+
+## Public API
+
+### Rust
+
+```rust
+use std::time::Duration;
+
+/// An HTTP/1.0 client that orchestrates the NET00–NET04 pipeline.
+///
+/// All configuration has sensible defaults. For most use cases, the
+/// free function `get()` is sufficient — you only need `HttpClient`
+/// if you want to customize timeouts, user-agent, or redirect limits.
+pub struct HttpClient {
+    /// Maximum number of redirects to follow before returning
+    /// TooManyRedirects. Default: 5.
+    max_redirects: usize,
+
+    /// The User-Agent header sent with every request.
+    /// Default: "Venture/0.1".
+    user_agent: String,
+
+    /// How long to wait for the TCP connection to establish.
+    /// Default: 30 seconds.
+    connect_timeout: Duration,
+
+    /// How long to wait for data during response reading.
+    /// Default: 30 seconds.
+    read_timeout: Duration,
+}
+
+impl HttpClient {
+    /// Create a new client with default settings.
+    pub fn new() -> Self;
+
+    /// Perform an HTTP/1.0 GET request.
+    ///
+    /// This runs the full pipeline: parse URL → connect → send request →
+    /// extract frames → lex → parse → follow redirects if needed.
+    pub fn get(&self, url: &str) -> Result<HttpResponse, HttpClientError>;
+}
+
+/// Convenience function: perform a GET with default options.
+///
+/// Equivalent to `HttpClient::new().get(url)`.
+pub fn get(url: &str) -> Result<HttpResponse, HttpClientError>;
+```
+
+### Error Types
+
+Every error wraps the underlying package error so the caller can inspect
+exactly what went wrong and at which pipeline stage:
+
+```rust
+pub enum HttpClientError {
+    /// URL parsing failed (NET00).
+    UrlError(url_parser::UrlError),
+
+    /// TCP connection failed (NET01).
+    ConnectionError(tcp_client::ConnectionError),
+
+    /// Frame extraction failed (NET02).
+    FrameError(frame_extractor::FrameError),
+
+    /// Lexing failed (NET03).
+    LexError(http1_lexer::LexError),
+
+    /// Parsing failed (NET04).
+    ParseError(http1_parser::ParseError),
+
+    /// Followed too many redirects (default limit: 5).
+    TooManyRedirects { limit: usize },
+
+    /// The URL scheme is not "http". HTTPS is out of scope for NET05.
+    UnsupportedScheme(String),
+}
+```
+
+## Testing Strategy
+
+### 1. Integration — Full Pipeline
+
+Spin up a localhost `TcpListener` that serves a canned HTTP/1.0 response:
+`"HTTP/1.0 200 OK\r\nContent-Length: 5\r\n\r\nhello"`. Call
+`http1_client::get("http://127.0.0.1:<port>/")` and verify the returned
+`HttpResponse` has status 200 and body `b"hello"`.
+
+### 2. Redirect Following
+
+Server returns `302 Found` with `Location: http://127.0.0.1:<port>/target`.
+The `/target` endpoint returns `200 OK`. Verify the client follows the redirect
+and returns the final 200 response.
+
+### 3. Redirect Loop Detection
+
+Server always returns `302 Found` pointing back to itself. Verify the client
+returns `HttpClientError::TooManyRedirects` after 5 attempts.
+
+### 4. Relative Redirect Resolution
+
+Server returns `302 Found` with `Location: /other` (a relative path). Verify
+the client resolves it against the original URL and follows it correctly.
+
+### 5. No Content-Length (Read to End)
+
+Server sends response headers without `Content-Length`, writes body bytes, then
+closes the connection. Verify the client reads the complete body using the
+read-to-end fallback strategy.
+
+### 6. Connection Refused
+
+Attempt to connect to a port with no listener. Verify the client returns
+`HttpClientError::ConnectionError`.
+
+### 7. DNS Failure
+
+Attempt to connect to `"nonexistent.invalid"`. Verify the client returns
+`HttpClientError::ConnectionError` (DNS resolution is part of TCP connect).
+
+### 8. Large Response
+
+Server sends a 1 MB body. Verify the client receives the complete body without
+truncation or corruption.
+
+### 9. Real-World Smoke Test
+
+`GET http://info.cern.ch/` — the first website ever published. Verify a 200
+response with an HTML body. This test is `#[ignore]` by default (requires
+network access) but runnable via `cargo test -- --ignored`.
+
+## Scope
+
+### In Scope
+
+- HTTP/1.0 GET requests
+- Request line and header construction
+- Pipeline orchestration (NET00 → NET01 → NET02 → NET03 → NET04)
+- Redirect following (301, 302) with configurable limit
+- Configurable timeouts and user-agent
+- Error propagation from all pipeline stages
+
+### Out of Scope
+
+- POST, PUT, DELETE, or any method with a request body
+- HTTP/1.1 (chunked encoding, persistent connections, pipelining)
+- HTTPS / TLS — a future NET06 TLS package would slot between NET01 and NET02
+- Cookies, authentication, caching
+- Proxy support
+- Connection pooling
+- Async I/O
+- Request body sending
+
+### Future: HTTP/1.1 Client
+
+A future `http1.1-client` would swap in `http1.1-lexer` / `http1.1-parser`
+and add:
+
+- **Chunked transfer encoding** — body arrives in length-prefixed chunks
+  rather than a single Content-Length block
+- **Persistent connections** — reuse the same TCP socket for multiple requests
+  (keep-alive is the default in 1.1)
+- **Host header requirement** — mandatory in 1.1 (we already send it, but 1.0
+  servers may ignore it)
+- **`Connection: close` signaling** — explicitly request one-shot behavior
+  when keep-alive is not desired

--- a/code/specs/P2D06-paint-vm-native-backends.md
+++ b/code/specs/P2D06-paint-vm-native-backends.md
@@ -1,0 +1,499 @@
+# P2D06 — Paint VM Native Backends: Direct2D, GDI, Cairo
+
+## Overview
+
+This spec covers three Rust crates that render PaintScene (P2D00) instructions
+through native platform rendering APIs on Windows and Linux. Each crate plugs
+into the PaintVM dispatch-table architecture (P2D01) — it registers handlers for
+the 10 instruction kinds and translates them into the platform's drawing calls.
+
+Think of it like hiring three different sign painters. You hand each of them the
+same blueprint (a PaintScene). One works in oil paint (Direct2D — rich, modern,
+GPU-accelerated). One works in house paint (GDI — available everywhere, gets the
+job done, but no fine detail). One works in watercolor (Cairo — beautiful on
+Linux, cross-platform, mature). The blueprint is identical; the tools and
+techniques differ.
+
+```
+                        PaintScene (P2D00)
+                             |
+                             v
+                    PaintVM dispatch (P2D01)
+                   /         |         \
+                  v          v          v
+            Direct2D       GDI        Cairo
+            (P2D06)      (P2D07)     (P2D08)
+            Windows      Windows      Linux
+            modern       fallback     future
+```
+
+The existing Metal backend (`paint-metal`) already demonstrates this pattern for
+macOS/iOS. These three crates complete the picture for Windows and Linux:
+
+| Crate              | Platform      | API           | Status          |
+|--------------------|---------------|---------------|-----------------|
+| paint-metal        | macOS / iOS   | Metal GPU     | Partial (exists)|
+| paint-vm-direct2d  | Windows       | Direct2D      | This spec       |
+| paint-vm-gdi       | Windows       | GDI (Win32)   | This spec       |
+| paint-vm-cairo     | Linux / GTK   | Cairo + Pango | Design only     |
+
+---
+
+## Where It Fits
+
+```
+Layer 0 (data)       paint-instructions    PaintScene, PaintInstruction, PixelContainer
+Layer 1 (VM)         paint-vm              dispatch-table VM framework
+Layer 2 (backends)   paint-vm-canvas       TypeScript — browser Canvas2D
+                     paint-vm-svg          TypeScript — SVG string output
+                     paint-metal           Rust — Apple Metal GPU
+                  →  paint-vm-direct2d     Rust — Windows Direct2D  ← THIS SPEC
+                  →  paint-vm-gdi          Rust — Windows GDI       ← THIS SPEC
+                  →  paint-vm-cairo        Rust — Linux Cairo       ← THIS SPEC (design only)
+Layer 3 (codecs)     paint-codec-png       PixelContainer ↔ PNG bytes
+```
+
+Every backend depends on `paint-instructions` for the PaintScene/PaintInstruction
+types and `PixelContainer` for pixel output. The backends do NOT depend on each
+other — they are siblings, not a chain.
+
+The coordinate system across all backends is **top-left origin, Y-down**. This
+matches Direct2D natively, matches GDI natively, and matches Cairo natively. No
+coordinate flipping is needed (unlike Metal, which is Y-up and requires a
+projection matrix flip).
+
+---
+
+## Concepts
+
+### The Handler Pattern
+
+Each backend implements the same 10 handlers. A handler is a function that takes
+one instruction and a platform-specific rendering context, then issues the
+platform's drawing calls. This is the same pattern used in `paint-metal`:
+
+```rust
+fn handle_rect(instruction: &PaintRect, ctx: &mut PlatformContext) {
+    // Translate PaintRect fields into platform API calls
+}
+```
+
+The dispatch function matches on the `PaintInstruction` enum:
+
+```rust
+fn dispatch(instruction: &PaintInstruction, ctx: &mut PlatformContext) {
+    match instruction {
+        PaintInstruction::Rect(r)      => handle_rect(r, ctx),
+        PaintInstruction::Ellipse(e)   => handle_ellipse(e, ctx),
+        PaintInstruction::Path(p)      => handle_path(p, ctx),
+        PaintInstruction::GlyphRun(g)  => handle_glyph_run(g, ctx),
+        PaintInstruction::Group(g)     => handle_group(g, ctx),   // recurses
+        PaintInstruction::Layer(l)     => handle_layer(l, ctx),   // recurses
+        PaintInstruction::Line(l)      => handle_line(l, ctx),
+        PaintInstruction::Clip(c)      => handle_clip(c, ctx),    // recurses
+        PaintInstruction::Gradient(g)  => handle_gradient(g, ctx),
+        PaintInstruction::Image(i)     => handle_image(i, ctx),
+    }
+}
+```
+
+Container instructions — `group`, `layer`, and `clip` — hold child instructions.
+Their handlers set up context (push transform, push layer, set clip region), then
+recursively call `dispatch` on each child, then tear down context (pop transform,
+pop layer, restore clip). This is a pre-order tree walk:
+
+```
+group (transform=[translate 100, 0])
+  ├── rect (fill=red, x=0, y=0, w=50, h=50)
+  └── group (transform=[rotate 45deg])
+        └── ellipse (fill=blue, cx=0, cy=0, rx=30, ry=20)
+
+Dispatch order:
+  1. handle_group → push transform [translate 100,0]
+  2.   handle_rect → draw red rect at (100,0) in world space
+  3.   handle_group → push transform [rotate 45deg] (compounds with parent)
+  4.     handle_ellipse → draw blue ellipse, rotated 45deg, translated (100,0)
+  5.   pop transform [rotate 45deg]
+  6. pop transform [translate 100,0]
+```
+
+### COM and Direct2D Initialization
+
+Direct2D is a COM (Component Object Model) API. COM is Microsoft's way of
+providing language-neutral interfaces to system services. In practice, it means:
+
+1. You create "factory" objects that manufacture other objects.
+2. Every object is reference-counted (like `Arc` in Rust).
+3. Methods return `HRESULT` error codes instead of using exceptions.
+
+The `windows` crate wraps all of this in safe Rust. The initialization sequence:
+
+```rust
+// Step 1: Create the Direct2D factory (entry point to all of Direct2D)
+let d2d_factory: ID2D1Factory = D2D1CreateFactory(
+    D2D1_FACTORY_TYPE_SINGLE_THREADED,
+    None,  // factory options
+)?;
+
+// Step 2: Create the DirectWrite factory (for text rendering)
+let dwrite_factory: IDWriteFactory = DWriteCreateFactory(
+    DWRITE_FACTORY_TYPE_SHARED,
+)?;
+
+// Step 3: Create a render target (where pixels go)
+// Option A: Window (HWND) render target — draws directly to a window
+let render_target: ID2D1HwndRenderTarget = d2d_factory.CreateHwndRenderTarget(
+    &render_target_properties,
+    &hwnd_render_target_properties,  // includes the HWND and pixel size
+)?;
+
+// Option B: Bitmap render target — draws to an offscreen bitmap
+let bitmap_target: ID2D1BitmapRenderTarget =
+    render_target.CreateCompatibleRenderTarget(
+        Some(&D2D_SIZE_F { width: w, height: h }),
+        None, None,
+        D2D1_COMPATIBLE_RENDER_TARGET_OPTIONS_NONE,
+    )?;
+```
+
+Think of the factory as a hardware store. You go there to buy brushes, canvases,
+and geometry templates. The render target is the canvas you actually paint on.
+
+### GDI Device Context
+
+GDI predates COM. It uses a simpler model: you get a **device context** (HDC),
+which is an opaque handle to a drawing surface. You select objects (pens,
+brushes, fonts) "into" the DC, draw with them, then select them back out.
+
+```rust
+// GDI's "select in, draw, select out" pattern:
+let old_brush = SelectObject(hdc, new_brush);
+Rectangle(hdc, left, top, right, bottom);
+SelectObject(hdc, old_brush);
+DeleteObject(new_brush);
+```
+
+This is like a physical painting station: you clip a brush onto the easel
+(SelectObject), paint with it (Rectangle), then swap it out and put the old
+brush back. You must clean up (DeleteObject) or you leak GDI handles — a
+classic Windows bug that causes mysterious rendering failures after ~10,000
+leaked handles.
+
+### Cairo Context
+
+Cairo uses a **stateful context** model similar to HTML Canvas. You set state
+(color, line width, transform), define a path, then stroke or fill it:
+
+```c
+cairo_set_source_rgb(cr, 1.0, 0.0, 0.0);   // red
+cairo_rectangle(cr, 10, 20, 100, 50);       // define path
+cairo_fill(cr);                              // consume path, fill it
+```
+
+Cairo's `cairo_save()` / `cairo_restore()` pair saves and restores the entire
+graphics state (transform, clip, color, line width) — exactly like
+Canvas2D's `save()` / `restore()`, and exactly what PaintGroup and PaintClip
+need.
+
+### Color Parsing
+
+All three backends need to convert PaintInstruction's color representation
+(CSS-style strings: `#rrggbb`, `#rrggbbaa`, named colors like `red`) into
+platform-native color structs:
+
+| Platform  | Color type                                    | Components        |
+|-----------|-----------------------------------------------|-------------------|
+| Direct2D  | `D2D1_COLOR_F { r, g, b, a }`                | f32, 0.0..1.0     |
+| GDI       | `COLORREF` (0x00BBGGRR)                       | u8, note BGR order |
+| Cairo     | `cairo_set_source_rgba(cr, r, g, b, a)`       | f64, 0.0..1.0     |
+
+Note GDI's quirk: the byte order is **BGR**, not RGB. The hex color `#FF8800`
+(orange) becomes `COLORREF(0x000088FF)`. This has been a source of subtle bugs
+in Windows programs for 30 years.
+
+---
+
+## Public API
+
+### Shared Entry Points
+
+All three crates expose the same two public functions, following the pattern
+established by `paint-metal`:
+
+```rust
+/// Render a PaintScene to the given platform render target.
+///
+/// This is the immediate-mode path: every instruction in the scene
+/// is dispatched to its handler, which issues drawing calls against
+/// the platform API through the render target.
+pub fn render(scene: &PaintScene, target: &mut T) { ... }
+
+/// Render a PaintScene to an offscreen pixel buffer.
+///
+/// Creates a temporary offscreen render target, renders the scene,
+/// then copies the result into a PixelContainer (RGBA8, premultiplied).
+/// The `scale` parameter controls DPI scaling (1.0 = 96 DPI on Windows).
+pub fn render_to_pixels(scene: &PaintScene, scale: f64) -> PixelContainer { ... }
+```
+
+The `render_to_pixels` function is the primary integration point for testing and
+for the codec pipeline (render → PixelContainer → PNG via paint-codec-png).
+
+### P2D06 — paint-vm-direct2d
+
+**Crate:** `paint-vm-direct2d`
+**Platform:** Windows (requires Windows 7+)
+**Dependencies:** `windows` crate with features:
+- `Win32_Graphics_Direct2D`
+- `Win32_Graphics_Direct2D_Common`
+- `Win32_Graphics_DirectWrite`
+- `Win32_Graphics_Imaging`
+
+**Context type:** `ID2D1HwndRenderTarget` (windowed) or `ID2D1BitmapRenderTarget` (offscreen)
+
+#### Handler Mapping
+
+| Instruction  | Direct2D API                                                                        |
+|-------------|--------------------------------------------------------------------------------------|
+| rect        | `FillRectangle` / `DrawRectangle` with `ID2D1SolidColorBrush`; use `ID2D1RoundedRectangleGeometry` when `corner_radius > 0` |
+| ellipse     | `FillEllipse` / `DrawEllipse`                                                       |
+| path        | `ID2D1PathGeometry` with `ID2D1GeometrySink`: `BeginFigure`, `AddLine`, `AddBezier`, `EndFigure` map directly to PaintPath segments (MoveTo, LineTo, BezierTo, Close) |
+| glyph_run   | `DrawGlyphRun` using `IDWriteFactory` + `IDWriteTextFormat` for font selection      |
+| group       | `GetTransform` / `SetTransform` (save current, multiply by `PaintGroup.transform`, restore after children) |
+| layer       | `PushLayer` / `PopLayer` with `ID2D1Layer` for offscreen compositing with opacity   |
+| line        | `DrawLine` with `ID2D1StrokeStyle` for line caps                                    |
+| clip        | `PushAxisAlignedClip` / `PopAxisAlignedClip` (axis-aligned rect clip)               |
+| gradient    | `CreateLinearGradientBrush` / `CreateRadialGradientBrush` with `ID2D1GradientStopCollection` for stop colors/positions |
+| image       | `CreateBitmapFromMemory` (load RGBA8 `PixelContainer` data into `ID2D1Bitmap`) then `DrawBitmap` |
+
+#### COM Initialization Sequence
+
+```
+D2D1CreateFactory(SINGLE_THREADED)
+    → ID2D1Factory
+         |
+         ├── CreateHwndRenderTarget(hwnd, size)
+         |       → ID2D1HwndRenderTarget
+         |
+         └── (or) CreateWicBitmapRenderTarget(bitmap)
+                 → ID2D1RenderTarget (offscreen)
+
+DWriteCreateFactory(SHARED)
+    → IDWriteFactory
+         └── CreateTextFormat(font_family, size, weight, style)
+                 → IDWriteTextFormat
+```
+
+Every frame follows the `BeginDraw` / `EndDraw` protocol:
+
+```rust
+render_target.BeginDraw();
+render_target.Clear(&background_color);
+for instruction in &scene.instructions {
+    dispatch(instruction, &mut ctx);
+}
+render_target.EndDraw(None, None)?;
+```
+
+If `EndDraw` returns `D2DERR_RECREATE_TARGET`, the render target (and all
+device-dependent resources like brushes and bitmaps) must be recreated. This
+happens when the GPU driver resets, the display mode changes, or the window
+moves to a different monitor. The crate handles this by discarding all cached
+resources and re-initializing.
+
+### P2D07 — paint-vm-gdi
+
+**Crate:** `paint-vm-gdi`
+**Platform:** Windows (all versions, back to Win95 in theory)
+**Dependencies:** `windows` crate with features:
+- `Win32_Graphics_Gdi`
+- `Win32_UI_WindowsAndMessaging`
+
+**Context type:** `GdiContext { hdc: HDC, width: u32, height: u32 }`
+
+#### Handler Mapping
+
+| Instruction  | GDI API                                                                              |
+|-------------|--------------------------------------------------------------------------------------|
+| rect        | `Rectangle()` with `HBRUSH` from `CreateSolidBrush`, or `FillRect()`               |
+| ellipse     | `Ellipse()`                                                                          |
+| path        | `BeginPath` / `MoveToEx` / `LineTo` / `PolyBezierTo` / `EndPath` / `StrokeAndFillPath` |
+| glyph_run   | `ExtTextOutW` with `HFONT` from `CreateFontW`                                      |
+| group       | `SaveDC` / `RestoreDC` + `SetWorldTransform` for the 2x3 affine matrix             |
+| layer       | `CreateCompatibleDC` + `CreateCompatibleBitmap` → render children offscreen → `AlphaBlend` back to main DC |
+| line        | `MoveToEx` / `LineTo` with `HPEN` from `CreatePen`                                 |
+| clip        | `IntersectClipRect`                                                                  |
+| gradient    | `GradientFill` (axis-aligned linear only; radial gradients fall back to solid color at the midpoint) |
+| image       | `CreateDIBSection` → copy `PixelContainer` RGBA data → `AlphaBlend` or `StretchBlt` |
+
+#### GDI Resource Management
+
+GDI requires explicit cleanup of every created object. Failure to call
+`DeleteObject` leaks GDI handles, and Windows has a system-wide limit of
+~10,000 per process. The crate uses RAII wrappers:
+
+```rust
+/// RAII wrapper for a GDI object. Calls DeleteObject on drop.
+struct GdiObject<T>(T);
+
+impl<T> Drop for GdiObject<T> {
+    fn drop(&mut self) {
+        unsafe { DeleteObject(self.0); }
+    }
+}
+```
+
+#### Limitations vs Direct2D
+
+GDI is the fallback renderer for situations where Direct2D is unavailable
+(remote desktop sessions, very old hardware, headless servers). It has
+significant limitations:
+
+| Capability            | Direct2D        | GDI                       |
+|----------------------|-----------------|---------------------------|
+| Path antialiasing    | Yes (built-in)  | No (jagged edges)         |
+| Radial gradients     | Yes             | No (falls back to solid)  |
+| Blend modes          | Full set        | SRC_OVER only             |
+| Hardware acceleration| Yes (GPU)       | No (CPU only)             |
+| Subpixel positioning | Yes             | No (integer coordinates)  |
+| Layer opacity        | Native          | Manual (offscreen blit)   |
+| Rounded rectangles   | Native geometry | Manual (RoundRect or arcs)|
+
+### P2D08 — paint-vm-cairo (Design Only)
+
+**Crate:** `paint-vm-cairo`
+**Platform:** Linux (GTK), BSDs, macOS (via Homebrew)
+**Dependencies:** `cairo-rs` crate, `pango` crate (for text)
+**Status:** Design only. Implementation deferred until Linux platform support begins.
+
+**Context type:** `cairo::Context` (wraps `*mut cairo_t`)
+
+#### Handler Mapping
+
+| Instruction  | Cairo API                                                                            |
+|-------------|--------------------------------------------------------------------------------------|
+| rect        | `cairo_rectangle` + `cairo_fill` / `cairo_stroke`; rounded corners via four `cairo_arc` calls at corners |
+| ellipse     | `cairo_save` + `cairo_scale` (to squash a circle into an ellipse) + `cairo_arc` + `cairo_restore` |
+| path        | `cairo_move_to`, `cairo_line_to`, `cairo_curve_to` (cubic bezier), `cairo_arc`, `cairo_close_path` |
+| glyph_run   | `pango_cairo_show_layout` via `PangoLayout` for shaped, positioned text             |
+| group       | `cairo_save` / `cairo_restore` + `cairo_transform` (multiply current matrix)        |
+| layer       | `cairo_push_group` / `cairo_pop_group_to_source` + `cairo_paint_with_alpha`         |
+| line        | `cairo_move_to` + `cairo_line_to` + `cairo_stroke`                                  |
+| clip        | `cairo_rectangle` + `cairo_clip`                                                     |
+| gradient    | `cairo_pattern_create_linear` / `cairo_pattern_create_radial` + `cairo_pattern_add_color_stop_rgba` |
+| image       | `cairo_image_surface_create_for_data` (wrap RGBA8 `PixelContainer`) + `cairo_set_source_surface` + `cairo_paint` |
+
+Cairo's state-stack model (`save`/`restore`) maps cleanly to PaintGroup and
+PaintClip, just as Canvas2D does in the TypeScript backend. The Cairo backend
+should be the simplest of the three to implement when the time comes.
+
+---
+
+## Testing Strategy
+
+### 1. Per-Handler Unit Tests
+
+Construct a minimal PaintScene containing a single instruction type, render it
+to a `PixelContainer` via `render_to_pixels`, then verify specific pixels:
+
+```rust
+#[test]
+fn red_rect_at_origin() {
+    let scene = PaintScene {
+        width: 100.0,
+        height: 100.0,
+        instructions: vec![
+            PaintInstruction::Rect(PaintRect {
+                x: 0.0, y: 0.0, width: 50.0, height: 50.0,
+                fill: Some("#ff0000".into()),
+                ..Default::default()
+            }),
+        ],
+    };
+    let pixels = render_to_pixels(&scene, 1.0);
+    // Pixel at (25, 25) should be red
+    assert_eq!(pixels.get(25, 25), [255, 0, 0, 255]);
+    // Pixel at (75, 75) should be transparent/background
+    assert_eq!(pixels.get(75, 75), [0, 0, 0, 0]);
+}
+```
+
+One test per instruction kind, covering: filled, stroked, both, edge-at-boundary.
+
+### 2. Golden Image Tests
+
+Render a set of reference PaintScenes (stored as JSON fixtures) and compare the
+output pixel-by-pixel against known-good PNG files. Allow a per-pixel tolerance
+of +/- 2 in each channel to account for antialiasing differences across GPU
+drivers.
+
+Golden images are committed to the repo under `code/fixtures/golden/paint-vm/`.
+
+### 3. Cross-Backend Comparison
+
+Render the same PaintScene through Direct2D and through the existing Canvas
+backend (via paint-vm-canvas in a headless browser). Compare the two
+PixelContainers with a structural similarity metric (SSIM > 0.95). This catches
+semantic errors where a handler produces plausible-looking but incorrect output.
+
+### 4. Stress Tests
+
+- **Large scene:** 10,000 rects with random positions and colors — must complete
+  within 500ms on an integrated GPU.
+- **Deep nesting:** 100 levels of nested groups — must not stack overflow.
+- **Many gradients:** 1,000 gradient instructions with 10 stops each — must not
+  leak GPU resources.
+
+### 5. Edge Cases
+
+- Empty scene (zero instructions) — must produce a blank PixelContainer.
+- Zero-size rect (width=0 or height=0) — must not crash, should be a no-op.
+- Fully transparent fill (`#00000000`) — must not produce visible pixels.
+- Scene with only container instructions (groups with no leaves) — must not crash.
+- Invalid gradient stop positions (e.g., all at 0.0) — must not crash, behavior
+  is implementation-defined.
+
+---
+
+## Scope
+
+### In Scope
+
+- All 10 PaintVM instruction handlers for Direct2D (P2D06) and GDI (P2D07).
+- Cairo handler mapping and design (P2D08) — design only, no implementation.
+- `render()` and `render_to_pixels()` public API for Direct2D and GDI.
+- COM initialization and teardown for Direct2D.
+- RAII resource management for GDI handles.
+- Color parsing (CSS hex → platform color structs).
+- Per-handler unit tests and golden image tests.
+
+### Out of Scope
+
+- **Animated rendering / frame loops** — the backends render single frames on
+  demand. Continuous rendering is the window manager's responsibility (BR01).
+- **Input handling** — mouse, keyboard, touch. That belongs to the platform
+  shell, not the paint backend.
+- **Window management** — creating windows, handling resize, DPI changes. The
+  render target is provided by the caller; backends do not own windows.
+- **Font loading / management** — backends use system fonts via DirectWrite or
+  Pango. Custom font loading is a separate concern.
+- **PDF output** — Cairo can render to PDF surfaces, but that is a separate
+  backend (not covered here).
+
+### Venture v0.1 Minimum Viable Set
+
+For the initial Venture browser (HTML 1.0 rendering), only a subset of handlers
+is required. The rest can be stubs that log a warning and skip the instruction:
+
+| Handler    | v0.1 Status | Why                                          |
+|-----------|-------------|----------------------------------------------|
+| rect      | Required    | Background colors, borders, block elements   |
+| glyph_run | Required    | All text rendering                           |
+| group     | Required    | Transform stacking for layout                |
+| line      | Required    | Underlines, borders, `<hr>`                  |
+| clip      | Required    | Overflow clipping                            |
+| image     | Required    | `<img>` elements                             |
+| ellipse   | Deferred    | Not used in HTML 1.0                         |
+| path      | Deferred    | Not used in HTML 1.0                         |
+| gradient  | Deferred    | CSS gradients are post-HTML 1.0              |
+| layer     | Deferred    | Opacity compositing is post-HTML 1.0         |

--- a/code/specs/TE04-html1.0-lexer.md
+++ b/code/specs/TE04-html1.0-lexer.md
@@ -1,0 +1,773 @@
+# TE04 — HTML 1.0 Lexer
+
+## Overview
+
+HTML was invented by Tim Berners-Lee in 1989-1991 at CERN, the European
+particle physics laboratory in Geneva. Berners-Lee needed a way for physicists
+to share documents with hyperlinks between them — click a reference in one paper
+and jump to another paper on a different computer. He combined two existing ideas:
+SGML (a complex document markup standard used by the publishing industry) and
+hypertext (clickable links between documents, a concept from Ted Nelson in the
+1960s). The result was HTML: a deliberately simplified subset of SGML with a few
+dozen tags and a forgiving parser.
+
+The first version of HTML had just 18 tags. By 1993, when Marc Andreessen's NCSA
+Mosaic browser shipped and brought the Web to the general public, a few more had
+been added — `<img>` for images, `<br>` for line breaks, `<hr>` for horizontal
+rules. This early tag set was never formally standardised as an RFC. The first
+formal specification was HTML 2.0 (RFC 1866, November 1995), which codified what
+browsers already understood. But the tag set that Mosaic understood is
+well-documented, and that is what this lexer targets.
+
+### HTML Is Not XML
+
+This is the single most important thing to understand before implementing an HTML
+lexer, and it is why `html1.0-lexer` is a **separate package** from the existing
+`xml-lexer` in this repo.
+
+XML was created in 1998 as a strict, machine-friendly subset of SGML. HTML
+predates XML by nearly a decade. The two languages look superficially similar —
+angle brackets, tag names, attributes — but their rules are fundamentally
+different:
+
+| Property | XML | HTML |
+|---|---|---|
+| Tag closure | Required: `<br/>` | Optional: `<br>` is valid |
+| Case sensitivity | Yes: `<P>` != `<p>` | No: `<P>` = `<p>` |
+| Attribute quoting | Required: `src="x"` | Optional: `src=x` is valid |
+| Entity declarations | Must be declared in DTD | Built-in: `&amp;`, `&lt;`, etc. |
+| Error handling | Fatal: parser aborts | Tolerant: parser recovers and continues |
+| Self-closing syntax | `<br/>` required for void elements | `<br>` sufficient; `<br/>` also accepted |
+
+The XML lexer in this repo rejects malformed input. The HTML lexer **never**
+rejects input. Real-world HTML from 1993 was full of unclosed tags, mismatched
+nesting, bare ampersands, and unquoted attributes. Mosaic rendered all of it.
+This lexer must do the same.
+
+### The Mail-Sorting Analogy
+
+Think of the HTML lexer as a mail room worker sorting incoming packages. The
+worker's job is simple: look at each piece of mail and put it in the right bin.
+
+- A piece of mail in an angle-bracket envelope (`<p>`) goes in the **tag** bin.
+- A piece of mail with an ampersand stamp (`&amp;`) goes in the **entity** bin,
+  gets decoded, and the decoded content goes in the **text** bin.
+- Everything else goes straight in the **text** bin.
+
+The mail room worker does not read the letters. They do not decide whether a
+`<p>` should be followed by a `</p>`, or whether `<img>` can appear inside
+`<title>`. That is the job of the parser (TE05), who reads the sorted bins and
+builds the document tree. The lexer just sorts.
+
+---
+
+## Where It Fits
+
+```
+html1.0-lexer (TE04) <-- THIS PACKAGE
+     |  Vec<HtmlToken>
+     v
+html1.0-parser (TE05) -- builds DOM tree from token stream
+     |
+     v
+document-ast (TE00) -- universal document IR
+```
+
+**Depends on:** nothing (pure string processing, zero external dependencies)
+
+**Depended on by:** `html1.0-parser` (TE05)
+
+**Follows the pattern of:** `xml-lexer`, `css-lexer`, `javascript-lexer` in this
+repo — each language has a separate lexer package that produces tokens, and a
+separate parser package that builds a tree from those tokens.
+
+---
+
+## Concepts
+
+### What Is a Lexer?
+
+A lexer (also called a tokenizer or scanner) is the first stage of any language
+processor. Its job is to take a flat string of characters and break it into
+meaningful chunks called **tokens**.
+
+Consider this analogy: imagine you are reading a sentence in a foreign language.
+Before you can understand the grammar (parsing), you must first identify where
+each word begins and ends (lexing). In English, words are separated by spaces.
+In HTML, tokens are separated by structural characters like `<`, `>`, `&`, and
+`=`.
+
+```
+Input:   <p class="intro">Hello &amp; world</p>
+
+Lexer output (tokens):
+  1. StartTag { name: "p", attributes: [("class", "intro")], self_closing: false }
+  2. Text("Hello & world")
+  3. EndTag { name: "p" }
+```
+
+Notice three things:
+
+1. The angle brackets, quotes, and attribute syntax have been consumed — the
+   tokens carry structured data, not raw syntax.
+2. The entity `&amp;` has been decoded to `&` — the text token contains the
+   final character, not the escape sequence.
+3. The lexer does not know or care that `<p>` opens a paragraph. It just
+   recognises that `<p class="intro">` is a start tag with one attribute.
+
+### What Is a State Machine?
+
+The HTML lexer is implemented as a **finite state machine**. This is a
+programming pattern where the code is always in exactly one "state", and each
+input character causes a transition to the same or a different state.
+
+Think of it like a vending machine. The machine is in one state at a time:
+"waiting for money", "waiting for selection", "dispensing product". Each input
+(coin inserted, button pressed) transitions it to the next state. The machine
+does not need to remember its entire history — only its current state and the
+current input.
+
+The HTML lexer has these states:
+
+```
+                    +----------+
+    text chars      |          |   '<'
+   +--------------->|   Data   |----------> TagOpen
+   |                |          |
+   |                +----------+
+   |                     |
+   |                     | '&'
+   |                     v
+   |                EntityRef ---- ';' --> back to Data (decoded char appended to text)
+   |
+   |
+TagOpen
+   |
+   +-- '/' --> EndTagOpen --> TagName (collecting close tag name)
+   +-- '!' --> MarkupDecl --> Comment or DOCTYPE
+   +-- letter --> TagName (collecting open tag name)
+                    |
+                    +-- whitespace --> BeforeAttrName
+                    +-- '>' --> emit StartTag, go to Data
+                    +-- '/' --> SelfClosingTag --> '>' --> emit, go to Data
+
+BeforeAttrName
+   +-- letter --> AttrName (collecting attribute name)
+   +-- '>' --> emit StartTag, go to Data
+   +-- '/' --> SelfClosingTag
+
+AttrName
+   +-- '=' --> BeforeAttrValue
+   +-- whitespace --> BeforeAttrName (attribute with no value)
+   +-- '>' --> emit StartTag, go to Data
+
+BeforeAttrValue
+   +-- '"' --> AttrValueDoubleQuoted
+   +-- "'" --> AttrValueSingleQuoted
+   +-- other --> AttrValueUnquoted (read until whitespace or '>')
+```
+
+Each state is a function (or a match arm in Rust) that reads one character,
+decides what to do with it, and transitions to the next state.
+
+---
+
+## Token Types
+
+The lexer produces a stream of `HtmlToken` values. There are exactly six
+variants, mirroring the six kinds of "thing" you can encounter in an HTML
+document:
+
+```rust
+/// A single token produced by the HTML 1.0 lexer.
+///
+/// The lexer is error-tolerant: it always produces tokens, never errors.
+/// Malformed input is handled gracefully — see the "Error Tolerance"
+/// section of the spec for the exact recovery rules.
+#[derive(Debug, Clone, PartialEq)]
+pub enum HtmlToken {
+    /// An opening tag, possibly with attributes.
+    ///
+    /// Examples:
+    ///   <p>                → StartTag { name: "p", attributes: [], self_closing: false }
+    ///   <img src="x.gif"> → StartTag { name: "img", attributes: [("src", "x.gif")], self_closing: false }
+    ///   <br/>              → StartTag { name: "br", attributes: [], self_closing: true }
+    StartTag {
+        name: String,                          // always lowercased: "p", "h1", "img"
+        attributes: Vec<(String, String)>,     // (name, value) pairs, names lowercased
+        self_closing: bool,                    // true for <br/> or <img ... />
+    },
+
+    /// A closing tag.
+    ///
+    /// Examples:
+    ///   </p>  → EndTag { name: "p" }
+    ///   </P>  → EndTag { name: "p" }   (case-normalised)
+    EndTag {
+        name: String,  // always lowercased
+    },
+
+    /// Raw text content between tags, with entities already decoded.
+    ///
+    /// Examples:
+    ///   "Hello world"       → Text("Hello world")
+    ///   "Hello &amp; world" → Text("Hello & world")   (entity decoded)
+    Text(String),
+
+    /// An HTML comment.
+    ///
+    /// Example:
+    ///   <!-- TODO: fix this --> → Comment(" TODO: fix this ")
+    Comment(String),
+
+    /// A DOCTYPE declaration.
+    ///
+    /// Example:
+    ///   <!DOCTYPE html> → Doctype("html")
+    Doctype(String),
+
+    /// Signals the end of input. Always the last token in the stream.
+    Eof,
+}
+```
+
+### Why These Six?
+
+Every character in an HTML document belongs to exactly one of these categories.
+There is no seventh thing. You are either inside a tag, between tags, inside a
+comment, inside a DOCTYPE, or at the end of the file. This exhaustive
+partitioning is what makes the lexer a complete front-end: the parser never needs
+to look at raw characters — it only sees tokens.
+
+---
+
+## Entity Decoding
+
+HTML uses **entities** (also called character references) to represent characters
+that have special meaning in the syntax or that cannot be typed directly on a
+keyboard. The entity `&amp;` means "the literal ampersand character `&`", because
+a bare `&` would otherwise start an entity reference.
+
+### Named Entities
+
+HTML 1.0 has exactly five named entities. These are the only ones the lexer must
+recognise:
+
+| Entity | Character | Code Point | Why It Exists |
+|--------|-----------|-----------|---------------|
+| `&amp;`  | & | U+0026 | Bare `&` starts entity references |
+| `&lt;`   | < | U+003C | Bare `<` starts tags |
+| `&gt;`   | > | U+003E | Symmetry with `&lt;`; also useful in attributes |
+| `&quot;` | " | U+0022 | Bare `"` ends attribute values |
+| `&nbsp;` | (non-breaking space) | U+00A0 | Prevents word-wrap between words |
+
+### Numeric Character References
+
+In addition to named entities, HTML supports numeric references that specify a
+Unicode code point directly:
+
+- **Decimal:** `&#60;` means "the character at code point 60 decimal", which is
+  `<` (U+003C).
+- **Hexadecimal:** `&#x3C;` (or `&#X3c;` — the `x` and hex digits are
+  case-insensitive) means "the character at code point 3C hex", which is also
+  `<` (U+003C).
+
+### Unknown Entities
+
+Unknown named entities pass through literally. If the lexer encounters `&foo;`,
+it does not recognise `foo` as a named entity, so it emits the text `&foo;`
+unchanged. This matches Mosaic's behaviour — early browsers did not crash or
+strip unknown entities.
+
+### Unterminated Entities
+
+If the lexer encounters `&amp` without a trailing semicolon, it treats the entire
+sequence as literal text: `&amp`. The semicolon is required for entity
+recognition.
+
+---
+
+## Error Tolerance
+
+The HTML lexer **never fails**. It always produces a token stream. This is a
+fundamental design requirement — not a nice-to-have. Real-world HTML from the
+1990s was full of errors, and Mosaic rendered all of it. The lexer follows
+Postel's Law: "Be conservative in what you send, liberal in what you accept."
+
+Here are the specific recovery rules:
+
+| Malformed Input | Recovery | Output |
+|---|---|---|
+| Bare `<` not followed by letter, `/`, or `!` | Treat as literal text | `Text("<")` |
+| Unterminated tag `<p` at EOF | Emit tag with what we have | `StartTag { name: "p", ... }` |
+| Unterminated attribute value `<a href="foo` at EOF | Close value at EOF | `StartTag { name: "a", attributes: [("href", "foo")] }` |
+| Unterminated comment `<!-- hello` at EOF | Close comment at EOF | `Comment(" hello")` |
+| Unterminated entity `&amp` (no semicolon) | Treat as literal text | `Text("&amp")` |
+| Null byte (`\0`) in input | Replace with U+FFFD | Replacement character in output |
+| `</` not followed by letter | Treat `</` as literal text | `Text("</")` |
+
+The guiding principle is: **do not lose information**. If the lexer cannot
+interpret a character sequence as markup, it emits it as text. The user sees the
+raw characters rather than having content silently dropped.
+
+---
+
+## Public API
+
+The package exposes two ways to tokenize HTML: a convenience function that
+returns all tokens at once, and a streaming iterator for large documents.
+
+### Convenience Function
+
+```rust
+/// Tokenize an HTML string into a sequence of tokens.
+///
+/// This is the simplest way to use the lexer. It reads the entire input and
+/// returns a `Vec` of all tokens. The last token is always `HtmlToken::Eof`.
+///
+/// The lexer is error-tolerant: it NEVER returns `Err`. Malformed input is
+/// handled gracefully and produces the best-effort token stream.
+///
+/// # Example
+///
+/// ```rust
+/// use html1_lexer::{tokenize, HtmlToken};
+///
+/// let tokens = tokenize("<p>Hello &amp; world</p>");
+/// assert_eq!(tokens, vec![
+///     HtmlToken::StartTag {
+///         name: "p".into(),
+///         attributes: vec![],
+///         self_closing: false,
+///     },
+///     HtmlToken::Text("Hello & world".into()),
+///     HtmlToken::EndTag { name: "p".into() },
+///     HtmlToken::Eof,
+/// ]);
+/// ```
+pub fn tokenize(input: &str) -> Vec<HtmlToken> { ... }
+```
+
+### Streaming Iterator
+
+```rust
+/// A streaming HTML tokenizer.
+///
+/// The iterator yields tokens one at a time without buffering the entire
+/// token stream in memory. This is important for large documents — a multi-
+/// megabyte HTML file should not require a multi-megabyte Vec allocation
+/// just to get the first token.
+///
+/// # Example
+///
+/// ```rust
+/// use html1_lexer::{HtmlLexer, HtmlToken};
+///
+/// let mut lexer = HtmlLexer::new("<p>Hello</p>");
+/// assert_eq!(lexer.next(), Some(HtmlToken::StartTag {
+///     name: "p".into(),
+///     attributes: vec![],
+///     self_closing: false,
+/// }));
+/// assert_eq!(lexer.next(), Some(HtmlToken::Text("Hello".into())));
+/// assert_eq!(lexer.next(), Some(HtmlToken::EndTag { name: "p".into() }));
+/// assert_eq!(lexer.next(), Some(HtmlToken::Eof));
+/// assert_eq!(lexer.next(), None);  // exhausted after Eof
+/// ```
+pub struct HtmlLexer<'a> {
+    // Internal fields: input slice, current position, current state, etc.
+    // These are private implementation details.
+}
+
+impl<'a> HtmlLexer<'a> {
+    /// Create a new lexer for the given HTML input string.
+    pub fn new(input: &'a str) -> Self { ... }
+}
+
+impl<'a> Iterator for HtmlLexer<'a> {
+    type Item = HtmlToken;
+
+    /// Returns the next token, or `None` after `Eof` has been yielded.
+    ///
+    /// The iterator yields `Some(HtmlToken::Eof)` exactly once at the end
+    /// of input, then returns `None` on all subsequent calls.
+    fn next(&mut self) -> Option<HtmlToken> { ... }
+}
+```
+
+### Design Rationale
+
+**Why both `tokenize` and `HtmlLexer`?** Most callers just want all the tokens
+and will use `tokenize`. But the streaming API exists for two reasons:
+
+1. **Memory efficiency.** A parser processing a 10 MB HTML file does not need to
+   allocate 10 MB of tokens upfront. It can consume tokens one at a time.
+
+2. **Early termination.** A caller searching for the `<title>` tag can stop
+   iteration as soon as it finds `</title>`, without tokenizing the rest of the
+   document.
+
+**Why does `tokenize` return a `Vec` and not an iterator?** Because `Vec` is
+the simplest API for the common case. Callers who need an iterator can call
+`.into_iter()` on the `Vec`, or use `HtmlLexer` directly.
+
+---
+
+## The Lexer vs. The Parser
+
+The **lexer** (this package, TE04) answers: "What are the tokens?"
+
+```
+Input:  <p class="intro">Hello &amp; world</p>
+
+Output: [
+    StartTag("p", [("class", "intro")], false),
+    Text("Hello & world"),
+    EndTag("p"),
+    Eof,
+]
+```
+
+The **parser** (TE05, a future package) answers: "What is the tree structure?"
+
+```
+ParagraphElement
+  class="intro"
+  children:
+    TextNode("Hello & world")
+```
+
+The parser knows things the lexer does not:
+
+- `<p>` opens a paragraph and `</p>` closes it.
+- `<p>one<p>two` means two paragraphs (the second `<p>` implicitly closes the
+  first).
+- `<img>` is void — it never has a closing tag, even without `/>`.
+- `<b>` inside `<title>` is literal text, not a tag.
+
+The lexer knows **nothing** about tag semantics. It does not know which tags are
+void, which can nest, or what attributes mean. It just finds tokens in the
+character stream. This separation of concerns makes both the lexer and the parser
+simpler, more testable, and independently reusable.
+
+---
+
+## Case Normalisation
+
+HTML is case-insensitive for tag names and attribute names. The lexer normalises
+all tag names and attribute names to **lowercase** during tokenization:
+
+```
+<P>           → StartTag { name: "p", ... }
+<IMG SRC="x"> → StartTag { name: "img", attributes: [("src", "x")], ... }
+</BODY>       → EndTag { name: "body" }
+```
+
+Attribute **values** are NOT normalised — they are preserved exactly as written:
+
+```
+<a href="Page.HTML"> → StartTag { name: "a", attributes: [("href", "Page.HTML")], ... }
+```
+
+This matches how every browser has handled HTML since the beginning: tag names
+and attribute names are case-insensitive, but attribute values are
+case-sensitive (because URLs, filenames, and CSS class names are
+case-sensitive).
+
+---
+
+## HTML 1.0 Tag Inventory
+
+For reference, here are the tags that the Mosaic-era Web understood. The lexer
+does not use this list — it tokenizes ANY tag name — but the parser (TE05) will
+use it for semantic decisions.
+
+### Block-Level Tags
+
+| Tag | Purpose | Closing Tag |
+|-----|---------|-------------|
+| `<html>` | Document root | `</html>` |
+| `<head>` | Document metadata container | `</head>` |
+| `<body>` | Document content container | `</body>` |
+| `<title>` | Document title (in head) | `</title>` |
+| `<h1>`...`<h6>` | Section headings | `</h1>`...`</h6>` |
+| `<p>` | Paragraph | `</p>` (often omitted) |
+| `<ul>` | Unordered list | `</ul>` |
+| `<ol>` | Ordered list | `</ol>` |
+| `<li>` | List item | `</li>` (often omitted) |
+| `<dl>` | Definition list | `</dl>` |
+| `<dt>` | Definition term | `</dt>` (often omitted) |
+| `<dd>` | Definition description | `</dd>` (often omitted) |
+| `<pre>` | Preformatted text | `</pre>` |
+| `<blockquote>` | Block quotation | `</blockquote>` |
+| `<address>` | Contact information | `</address>` |
+| `<hr>` | Horizontal rule | None (void element) |
+
+### Inline Tags
+
+| Tag | Purpose | Closing Tag |
+|-----|---------|-------------|
+| `<a>` | Anchor (hyperlink) | `</a>` |
+| `<img>` | Image | None (void element) |
+| `<br>` | Line break | None (void element) |
+| `<em>` | Emphasis (italic) | `</em>` |
+| `<strong>` | Strong emphasis (bold) | `</strong>` |
+| `<code>` | Inline code | `</code>` |
+| `<b>` | Bold | `</b>` |
+| `<i>` | Italic | `</i>` |
+| `<tt>` | Teletype (monospace) | `</tt>` |
+| `<cite>` | Citation | `</cite>` |
+| `<var>` | Variable | `</var>` |
+| `<kbd>` | Keyboard input | `</kbd>` |
+| `<samp>` | Sample output | `</samp>` |
+
+---
+
+## Testing Strategy
+
+### 1. Basic Tags
+
+Verify that simple opening and closing tags are tokenized correctly:
+
+```rust
+tokenize("<p>")       // → [StartTag("p", [], false), Eof]
+tokenize("</p>")      // → [EndTag("p"), Eof]
+tokenize("<br>")       // → [StartTag("br", [], false), Eof]
+tokenize("<br/>")      // → [StartTag("br", [], true), Eof]
+tokenize("<img src=\"x\">")  // → [StartTag("img", [("src","x")], false), Eof]
+```
+
+### 2. Attributes
+
+Test all attribute value styles and edge cases:
+
+- Double-quoted: `<a href="http://example.com">`
+- Single-quoted: `<a href='http://example.com'>`
+- Unquoted: `<a href=http://example.com>`
+- Boolean (no value): `<option selected>`
+- Multiple attributes: `<img src="x.gif" alt="photo" width=100>`
+- Attribute with empty value: `<input value="">`
+
+### 3. Entities
+
+Test all five named entities plus numeric references:
+
+- `&amp;` decodes to `&`
+- `&lt;` decodes to `<`
+- `&gt;` decodes to `>`
+- `&quot;` decodes to `"`
+- `&nbsp;` decodes to U+00A0
+- `&#60;` decodes to `<` (decimal)
+- `&#x3C;` decodes to `<` (hex)
+- `&#X3c;` decodes to `<` (hex, case-insensitive)
+- `&foo;` passes through as `&foo;` (unknown entity)
+
+### 4. Text
+
+- Plain text with no markup
+- Text with entities mixed in
+- Whitespace-only text (spaces, tabs, newlines)
+- Text immediately adjacent to tags: `<b>bold</b>text`
+
+### 5. Comments
+
+- Standard comment: `<!-- hello -->`
+- Empty comment: `<!---->`
+- Comment with dashes: `<!-- -- -->`
+- Comment with no spaces: `<!--hello-->`
+
+### 6. Doctype
+
+- Standard: `<!DOCTYPE html>`
+- Lowercase: `<!doctype HTML>`
+- With extra content: `<!DOCTYPE html SYSTEM "about:legacy-compat">`
+
+### 7. Case Insensitivity
+
+- `<P>` produces `StartTag { name: "p" }`
+- `<IMG SRC="x">` produces `StartTag { name: "img", attributes: [("src", "x")] }`
+- `</BODY>` produces `EndTag { name: "body" }`
+- Attribute values preserve case: `<a HREF="Page.HTML">` → `("href", "Page.HTML")`
+
+### 8. Error Tolerance
+
+- Bare `<` not followed by valid tag start: `a < b` → `[Text("a < b"), Eof]`
+- Unterminated tag at EOF: `<p` → `[StartTag("p", [], false), Eof]`
+- Unterminated attribute value: `<a href="foo` → `[StartTag("a", [("href","foo")]), Eof]`
+- Unterminated comment: `<!-- hello` → `[Comment(" hello"), Eof]`
+- Unterminated entity: `&amp` → `[Text("&amp"), Eof]`
+- Null bytes: `hello\0world` → `[Text("hello\u{FFFD}world"), Eof]`
+
+### 9. Real HTML
+
+Tokenize actual HTML from the earliest web pages:
+
+- The CERN info page (`http://info.cern.ch/`, archived 1993)
+- The original Mosaic "What's New" page
+- Hand-crafted HTML that exercises all Mosaic-era features
+
+These integration tests verify that the lexer handles real-world markup, not just
+synthetic test cases.
+
+### 10. Empty Input
+
+- Empty string `""` produces `[Eof]`
+- Whitespace-only `"   "` produces `[Text("   "), Eof]`
+
+### 11. Streaming Iterator
+
+- `HtmlLexer` produces the same tokens as `tokenize` for all test cases
+- After yielding `Eof`, `next()` returns `None` on all subsequent calls
+- Large input (multi-MB) does not cause excessive memory allocation — verify
+  with a memory-bounded test
+
+---
+
+## Scope
+
+### In Scope
+
+- All HTML 1.0 era tokenization (tags, attributes, text, comments, doctype)
+- Case normalisation (tag and attribute names lowercased)
+- Entity decoding (5 named entities + decimal and hex numeric references)
+- Error tolerance (never fails, always produces tokens)
+- Streaming iterator API for memory-efficient processing
+- Null byte replacement with U+FFFD
+
+### Out of Scope
+
+- **Tag semantics** — which tags self-close, which can nest, which are void.
+  That is the parser's job (TE05).
+- **CDATA sections** — HTML has no CDATA. That is an XML concept.
+- **Processing instructions** (`<?xml ...?>`) — that is XML, not HTML.
+- **Script/style content** (`<script>`, `<style>`) — these were not part of
+  HTML 1.0. They arrive with HTML 2.0+ and require special "raw text" lexer
+  states. A future `html2.0-lexer` will handle them.
+- **Character encoding detection** — the lexer assumes its input is valid UTF-8.
+  Encoding sniffing (reading `<meta charset>` or BOM) is a separate concern.
+- **Named entities beyond the core 5** — HTML 2.0 and later added hundreds of
+  named entities (`&eacute;`, `&mdash;`, etc.). A future `html2.0-lexer` will
+  include the full entity table.
+
+---
+
+## Implementation Languages
+
+This package will be implemented in:
+
+- **Rust** (primary, for use in the Venture browser pipeline)
+- Future: all 9 languages following the standard pattern in this repo
+
+### Package Layout (Rust)
+
+```
+code/packages/rust/html1-lexer/
+  src/
+    lib.rs          -- public API: tokenize(), HtmlLexer, HtmlToken
+    token.rs        -- HtmlToken enum definition
+    lexer.rs        -- HtmlLexer state machine implementation
+    entities.rs     -- entity decoding (5 named + numeric)
+  Cargo.toml        -- { name = "html1-lexer" }
+  BUILD
+  README.md
+  CHANGELOG.md
+```
+
+---
+
+## Worked Examples
+
+### Example 1: Simple Document
+
+```
+Input:
+  <!DOCTYPE html>
+  <html>
+  <head><title>Hello</title></head>
+  <body>
+  <h1>Welcome</h1>
+  <p>This is a <a href="page2.html">link</a>.</p>
+  </body>
+  </html>
+
+Token stream:
+  Doctype("html")
+  Text("\n")
+  StartTag { name: "html", attributes: [], self_closing: false }
+  Text("\n")
+  StartTag { name: "head", attributes: [], self_closing: false }
+  StartTag { name: "title", attributes: [], self_closing: false }
+  Text("Hello")
+  EndTag { name: "title" }
+  EndTag { name: "head" }
+  Text("\n")
+  StartTag { name: "body", attributes: [], self_closing: false }
+  Text("\n")
+  StartTag { name: "h1", attributes: [], self_closing: false }
+  Text("Welcome")
+  EndTag { name: "h1" }
+  Text("\n")
+  StartTag { name: "p", attributes: [], self_closing: false }
+  Text("This is a ")
+  StartTag { name: "a", attributes: [("href", "page2.html")], self_closing: false }
+  Text("link")
+  EndTag { name: "a" }
+  Text(".")
+  EndTag { name: "p" }
+  Text("\n")
+  EndTag { name: "body" }
+  Text("\n")
+  EndTag { name: "html" }
+  Eof
+```
+
+### Example 2: Sloppy 1993-Era HTML
+
+```
+Input:
+  <HTML>
+  <BODY BGCOLOR=white>
+  <H1>My Cool Page</H1>
+  <P>Welcome to my page! Click <A HREF=links.html>here</A> for links.
+  <P>Here is a picture:<BR>
+  <IMG SRC=cool.gif ALT="My photo">
+  <HR>
+  <ADDRESS>webmaster@example.com</ADDRESS>
+  </BODY></HTML>
+
+Token stream:
+  StartTag { name: "html", attributes: [], self_closing: false }
+  Text("\n")
+  StartTag { name: "body", attributes: [("bgcolor", "white")], self_closing: false }
+  Text("\n")
+  StartTag { name: "h1", attributes: [], self_closing: false }
+  Text("My Cool Page")
+  EndTag { name: "h1" }
+  Text("\n")
+  StartTag { name: "p", attributes: [], self_closing: false }
+  Text("Welcome to my page! Click ")
+  StartTag { name: "a", attributes: [("href", "links.html")], self_closing: false }
+  Text("here")
+  EndTag { name: "a" }
+  Text(" for links.\n")
+  StartTag { name: "p", attributes: [], self_closing: false }
+  Text("Here is a picture:")
+  StartTag { name: "br", attributes: [], self_closing: false }
+  Text("\n")
+  StartTag { name: "img", attributes: [("src", "cool.gif"), ("alt", "My photo")], self_closing: false }
+  Text("\n")
+  StartTag { name: "hr", attributes: [], self_closing: false }
+  Text("\n")
+  StartTag { name: "address", attributes: [], self_closing: false }
+  Text("webmaster@example.com")
+  EndTag { name: "address" }
+  Text("\n")
+  EndTag { name: "body" }
+  EndTag { name: "html" }
+  Eof
+```
+
+Notice: the second `<P>` has no closing `</P>`. The lexer does not care — it
+just emits `StartTag("p")`. The parser (TE05) will handle implicit closing.
+Also note that `BGCOLOR=white` uses an unquoted attribute value, and all tag
+names are uppercased in the source but lowercased in the tokens.

--- a/code/specs/TE05-html1.0-parser.md
+++ b/code/specs/TE05-html1.0-parser.md
@@ -1,0 +1,643 @@
+# TE05 — HTML 1.0 Parser
+
+## Overview
+
+The HTML 1.0 lexer (TE04) breaks raw HTML text into tokens — start tags, end
+tags, text, comments, doctypes. But tokens alone are flat. A sequence of tokens
+like `StartTag("ul"), StartTag("li"), Text("A"), EndTag("li"), EndTag("ul")` does
+not convey that `"A"` is *inside* a list item that is *inside* an unordered list.
+That hierarchical structure — the tree — is what the parser builds.
+
+This package is the **tree builder**. It consumes the flat token stream from
+`html1.0-lexer` (TE04) and produces a `DocumentNode` tree using the node types
+defined in `document-ast` (TE00). It understands tag semantics: which tags can
+nest inside which, which tags implicitly close their predecessors, and how each
+HTML element maps to a DocumentAST node.
+
+### Historical Context
+
+HTML 1.0 was born in the Mosaic era (1993). Marc Andreessen's NCSA Mosaic was
+the first graphical web browser to reach a wide audience, and it had one
+overriding design principle: **never crash on bad input**. The HTML that Mosaic
+encountered was written by physicists, not programmers. Tags were unclosed,
+nesting was wrong, `<body>` was often missing entirely. Mosaic rendered all of
+it, because a browser that refused to display a page was a browser nobody used.
+
+This permissiveness was later codified as **Postel's Law** (RFC 793, originally
+about TCP): *"Be conservative in what you send, be liberal in what you accept."*
+The HTML 1.0 parser embodies this principle. It never fails. It never returns an
+error. Given any string — valid HTML, garbled HTML, or no HTML at all — it
+produces a well-formed DocumentAST tree.
+
+### The Construction Foreman Analogy
+
+Think of the parser as a construction foreman building a house from a delivery
+of materials (tokens). The lexer is the truck driver who delivers labelled boxes:
+"start wall", "add window", "end wall", "start roof". The foreman's job is to
+assemble these into a standing structure.
+
+But the delivery manifest is often wrong. Sometimes the "end wall" box never
+arrives — the foreman closes the wall anyway when the roof materials show up,
+because a roof cannot sit inside a wall. Sometimes a "start wall" box arrives
+when there is already an open wall — the foreman finishes the first wall before
+starting the second. Sometimes boxes arrive with labels the foreman does not
+recognise — they get set aside, but the contents (text, images) are still used.
+
+The foreman never sends the truck back. The house always gets built.
+
+### The 22 Tags
+
+HTML 1.0 (the Mosaic subset) defined 22 tags. These are the only tags the parser
+understands semantically. Any other tag is treated as unknown — silently ignored,
+but its children are still processed.
+
+**Structure tags** (document scaffolding):
+
+    html, head, title, body
+
+**Block-level tags** (things that stack vertically on the page):
+
+    h1, h2, h3, h4, h5, h6, p, ul, ol, li, pre, blockquote, hr, br
+
+**Inline tags** (things that flow within a line of text):
+
+    a, img, b, i, em, strong, code
+
+The distinction between block and inline matters for implicit close rules (see
+below). A block element like `<ul>` can contain other blocks and inlines. An
+inline element like `<b>` should only contain other inlines and text.
+
+---
+
+## Where It Fits
+
+```
+html1.0-lexer (TE04) → html1.0-parser (TE05) → document-ast (TE00)
+                             ↑ THIS PACKAGE         ↓
+                                              document-ast-to-layout (UI06)
+                                                     ↓
+                                              layout-block → layout-to-paint → PaintVM
+```
+
+**Depends on:** `html1.0-lexer` (TE04) for tokenization, `document-ast` (TE00)
+for the output tree types.
+
+**Depended on by:** The Venture browser (BR01), which uses this parser to turn
+downloaded HTML pages into renderable document trees.
+
+**Follows the pattern of:** `commonmark-parser` in this repo. Both parsers
+produce the same output type (`DocumentNode` from TE00) but consume different
+input formats. CommonMark parses Markdown syntax; this parser parses HTML syntax.
+The shared output type means downstream consumers (layout, rendering, export) do
+not need to know which input format produced the tree.
+
+---
+
+## Concepts
+
+### What Is a Parser?
+
+A parser is the second stage of a language processor, after the lexer. Where the
+lexer answers "what are the words?", the parser answers "what is the sentence
+structure?" In linguistic terms, the lexer performs *lexical analysis* and the
+parser performs *syntactic analysis*.
+
+Consider this analogy: you receive a telegram (remember, it is 1993). The
+telegraph operator has already decoded the Morse code into letters and grouped
+them into words — that is the lexer's job. Now you, the reader, must understand
+the sentence structure. "MEETING CANCELLED STOP ARRIVE TUESDAY STOP" — two
+sentences, separated by STOP markers. The parser groups words into sentences and
+sentences into a message.
+
+For HTML, the parser groups tokens into a tree:
+
+```
+Input tokens:
+  StartTag("html")
+  StartTag("body")
+  StartTag("p")
+  Text("Hello, ")
+  StartTag("b")
+  Text("world")
+  EndTag("b")
+  EndTag("p")
+  EndTag("body")
+  EndTag("html")
+
+Parser output (tree):
+  DocumentNode
+  └── ParagraphNode
+      ├── TextNode("Hello, ")
+      └── StrongNode
+          └── TextNode("world")
+```
+
+Notice that the structure tags (`html`, `body`) do not appear in the output tree.
+They are scaffolding — the parser uses them to understand document structure, but
+the DocumentAST represents *content*, not HTML syntax.
+
+### Tag → DocumentAST Mapping
+
+This is the core of the parser. Each HTML tag maps to a specific DocumentAST node
+type from TE00. This table is the Rosetta Stone between the HTML world and the
+DocumentAST world:
+
+| HTML Tag | DocumentAST Node | Notes |
+|----------|-----------------|-------|
+| `h1`–`h6` | `HeadingNode { level: 1..6 }` | Level extracted from tag name |
+| `p` | `ParagraphNode` | |
+| `ul` | `ListNode { ordered: false, tight: false }` | Unordered list |
+| `ol` | `ListNode { ordered: true, tight: false }` | Ordered list |
+| `li` | `ListItemNode` | |
+| `pre` | `CodeBlockNode { language: None }` | Whitespace is preserved verbatim |
+| `blockquote` | `BlockQuoteNode` | |
+| `hr` | `ThematicBreakNode` | Self-closing, no children |
+| `br` | `LineBreakNode` | Self-closing, no children |
+| `a` | `LinkNode { destination: href, title: None }` | `href` attribute becomes destination |
+| `img` | `ImageNode { destination: src, alt: alt }` | `src` → destination, `alt` → description |
+| `b` | `StrongNode` | Alias for `strong` |
+| `strong` | `StrongNode` | Semantic strong emphasis |
+| `i` | `EmphasisNode` | Alias for `em` |
+| `em` | `EmphasisNode` | Semantic emphasis |
+| `code` | `CodeSpanNode` | Inline code |
+| *(text)* | `TextNode` | Plain character data |
+
+A few things to notice:
+
+1. **`<b>` and `<strong>` produce the same node.** In 1993, `<b>` meant "bold"
+   (a visual instruction) and `<strong>` meant "strong emphasis" (a semantic
+   instruction). DocumentAST is semantic, so both map to `StrongNode`. Same for
+   `<i>` and `<em>` → `EmphasisNode`.
+
+2. **`<hr>` and `<br>` are self-closing.** They have no children and no end tag.
+   The parser must recognise them as void elements and never push them onto the
+   open-elements stack.
+
+3. **`<pre>` preserves whitespace.** In all other contexts, the parser may
+   collapse runs of whitespace. Inside `<pre>`, every space, tab, and newline
+   must be preserved exactly as it appears in the source.
+
+4. **`<a>` extracts the `href` attribute.** The parser must dig into the
+   token's attribute list to find the destination URL. Similarly, `<img>` needs
+   both `src` and `alt`.
+
+### Implicit Close Rules
+
+This is what makes HTML parsing genuinely interesting — and genuinely different
+from parsing a well-structured language like XML or JSON.
+
+In XML, every start tag must have a matching end tag. In HTML 1.0, end tags are
+often optional. The parser must infer when elements close based on context. These
+are called **implicit close rules**.
+
+Think of it like a conversation. In English, you do not always say "end of
+sentence" — the listener infers it from context. When someone says "I went to the
+store. Then I went home.", the period implicitly closes the first sentence before
+the second one begins. HTML works the same way with certain tags.
+
+The rules for HTML 1.0:
+
+**Rule 1: `<p>` closes any open `<p>`.**
+
+A paragraph cannot contain another paragraph. When the parser encounters a new
+`<p>` start tag while a `<p>` is already open, it implicitly closes the open one.
+
+```html
+<p>First paragraph
+<p>Second paragraph
+```
+
+Produces:
+
+```
+├── ParagraphNode
+│   └── TextNode("First paragraph\n")
+├── ParagraphNode
+│   └── TextNode("Second paragraph\n")
+```
+
+**Rule 2: `<li>` closes any open `<li>`.**
+
+List items behave like paragraphs — a new `<li>` closes the previous one.
+
+```html
+<ul>
+  <li>Alpha
+  <li>Beta
+  <li>Gamma
+</ul>
+```
+
+Produces:
+
+```
+ListNode { ordered: false }
+├── ListItemNode
+│   └── TextNode("Alpha\n  ")
+├── ListItemNode
+│   └── TextNode("Beta\n  ")
+├── ListItemNode
+│   └── TextNode("Gamma\n")
+```
+
+**Rule 3: `<h1>`–`<h6>` close any open `<p>`.**
+
+A heading is a block element that forces any open paragraph to close.
+
+```html
+<p>Some text
+<h1>A Heading</h1>
+```
+
+Produces:
+
+```
+├── ParagraphNode
+│   └── TextNode("Some text\n")
+├── HeadingNode { level: 1 }
+│   └── TextNode("A Heading")
+```
+
+**Rule 4: Block elements close any open `<p>`.**
+
+Any block-level start tag (`<ul>`, `<ol>`, `<blockquote>`, `<pre>`, `<hr>`)
+implicitly closes an open `<p>`, because block elements cannot nest inside
+paragraphs.
+
+```html
+<p>Before the list
+<ul><li>Item</li></ul>
+```
+
+Produces:
+
+```
+├── ParagraphNode
+│   └── TextNode("Before the list\n")
+├── ListNode { ordered: false }
+│   └── ListItemNode
+│       └── TextNode("Item")
+```
+
+**Rule 5: `</body>` and `</html>` close all open elements.**
+
+These end tags signal the end of the document. Any elements still on the open
+stack are implicitly closed in reverse order.
+
+### Error Recovery
+
+The parser **never fails**. This is a hard requirement, not a nice-to-have. Any
+string of bytes, no matter how malformed, must produce a valid DocumentAST tree.
+Here are the specific recovery strategies:
+
+**Unknown tags: silently ignored, children processed.**
+
+```html
+<blink>This text is visible</blink>
+```
+
+The parser does not recognise `<blink>` (it is not one of the 22 tags). It
+ignores the start and end tags but processes the text content normally, appending
+it to the current open element.
+
+**Missing `<html>`, `<head>`, `<body>`: implied.**
+
+```html
+<h1>Hello</h1>
+```
+
+There is no `<html>` or `<body>` wrapper. The parser implies them — all content
+is treated as body content. The output is exactly the same as if `<html><body>`
+had been present.
+
+**Missing close tags: closed at end of parent or document.**
+
+```html
+<ul><li>One<li>Two</ul>
+```
+
+The `<li>` elements are never explicitly closed. Rule 2 closes the first `<li>`
+when the second starts, and `</ul>` closes the second `<li>` because it closes
+its parent.
+
+**Overlapping tags: simplified adoption agency.**
+
+```html
+<b><i>bold italic</b> just italic?</i>
+```
+
+Strictly, the nesting is wrong — `</b>` closes before `</i>`, but `<i>` was
+opened inside `<b>`. The simplified adoption agency algorithm handles this: when
+`</b>` is encountered, the parser closes `<i>` first (because it is inner), then
+closes `<b>`. The remaining ` just italic?` text is appended to the parent.
+
+**Duplicate `<body>` or `<head>`: ignored, content merged.**
+
+```html
+<body><p>First</p></body><body><p>Second</p></body>
+```
+
+The second `<body>` tag is ignored. Its contents are merged into the first body.
+
+**Text outside `<body>`: treated as body content.**
+
+```html
+<html>Some text<body><p>More text</p></body></html>
+```
+
+"Some text" appears before `<body>`. The parser treats it as body content.
+
+---
+
+## Public API
+
+The parser exposes two functions. Both produce DocumentAST types from TE00.
+
+### `parse` — Parse a Complete HTML Document
+
+```rust
+/// Parse a complete HTML document into a DocumentAST.
+///
+/// The input is an HTML string. The function tokenizes it (via html1.0-lexer)
+/// and builds the tree in one pass.
+///
+/// # Examples
+///
+/// ```
+/// use html1_parser::parse;
+///
+/// let doc = parse("<html><body><p>Hello</p></body></html>");
+/// // doc is a DocumentNode containing one ParagraphNode with text "Hello"
+/// ```
+///
+/// The parser never fails. Any input produces a valid tree:
+///
+/// ```
+/// let doc = parse("not even html at all");
+/// // doc is a DocumentNode containing a single TextNode
+/// ```
+pub fn parse(input: &str) -> DocumentNode
+```
+
+### `parse_fragment` — Parse an HTML Fragment
+
+```rust
+/// Parse an HTML fragment (without <html>/<body> wrapper).
+/// Returns the block-level children as a vec.
+///
+/// This is useful when parsing a snippet of HTML that does not represent
+/// a complete document — for example, the body of an HTTP response where
+/// the structure tags are missing, or a user-authored HTML chunk.
+///
+/// # Examples
+///
+/// ```
+/// use html1_parser::parse_fragment;
+///
+/// let blocks = parse_fragment("<p>One</p><p>Two</p>");
+/// // blocks is a Vec<BlockNode> with two ParagraphNodes
+/// ```
+pub fn parse_fragment(input: &str) -> Vec<BlockNode>
+```
+
+The output types — `DocumentNode`, `BlockNode`, `InlineNode`, `HeadingNode`,
+`ParagraphNode`, `TextNode`, and all others — are defined in the `document-ast`
+crate (TE00). This parser does not define any new AST types. It only builds
+trees from existing types.
+
+### Tree-Building Algorithm
+
+The parser uses a single-pass, stack-based algorithm. Here is the procedure in
+full:
+
+```
+PROCEDURE build_tree(tokens):
+    stack ← [DocumentNode]          -- the root is always on the stack
+    for each token in tokens:
+        match token:
+            StartTag(name, attrs):
+                apply_implicit_close_rules(name, stack)
+                node ← map_tag_to_ast_node(name, attrs)
+                if node is a void element (hr, br, img):
+                    append node to stack.top()
+                else:
+                    append node to stack.top()
+                    push node onto stack
+            EndTag(name):
+                pop_until_matching(name, stack)
+            Text(content):
+                append TextNode(content) to stack.top()
+            Comment:
+                skip
+            Doctype:
+                skip
+            Eof:
+                pop all remaining elements from stack
+    return stack[0]                  -- the DocumentNode root
+
+PROCEDURE apply_implicit_close_rules(new_tag, stack):
+    if new_tag is "p" and stack.top() is <p>:
+        pop stack                    -- Rule 1
+    if new_tag is "li" and stack.top() is <li>:
+        pop stack                    -- Rule 2
+    if new_tag is heading(h1-h6) and stack.top() is <p>:
+        pop stack                    -- Rule 3
+    if new_tag is block-level and stack.top() is <p>:
+        pop stack                    -- Rule 4
+
+PROCEDURE pop_until_matching(name, stack):
+    scan stack from top for element matching name
+    if found:
+        pop all elements above it (closing them)
+        pop the matching element itself
+    if not found:
+        ignore the end tag           -- no matching open element
+```
+
+The key insight is that the stack represents the current path from the root to
+the deepest open element. When we append a child node to `stack.top()`, we are
+adding it to whatever element is currently "open" — i.e., the one whose start
+tag we saw most recently without a corresponding end tag.
+
+### Worked Example
+
+Let us trace the algorithm through a complete document:
+
+```html
+<html><body><h1>Title</h1><p>Hello <b>world</b></p></body></html>
+```
+
+The lexer produces these tokens:
+
+```
+StartTag("html"), StartTag("body"), StartTag("h1"), Text("Title"),
+EndTag("h1"), StartTag("p"), Text("Hello "), StartTag("b"),
+Text("world"), EndTag("b"), EndTag("p"), EndTag("body"), EndTag("html")
+```
+
+Trace:
+
+| Step | Token | Stack (tag names) | Action |
+|------|-------|-------------------|--------|
+| 0 | — | `[Document]` | Initial state |
+| 1 | `StartTag("html")` | `[Document]` | Structure tag, no AST node pushed |
+| 2 | `StartTag("body")` | `[Document]` | Structure tag, no AST node pushed |
+| 3 | `StartTag("h1")` | `[Document, Heading(1)]` | Push HeadingNode |
+| 4 | `Text("Title")` | `[Document, Heading(1)]` | Append TextNode to Heading |
+| 5 | `EndTag("h1")` | `[Document]` | Pop Heading |
+| 6 | `StartTag("p")` | `[Document, Paragraph]` | Push ParagraphNode |
+| 7 | `Text("Hello ")` | `[Document, Paragraph]` | Append TextNode to Paragraph |
+| 8 | `StartTag("b")` | `[Document, Paragraph, Strong]` | Push StrongNode |
+| 9 | `Text("world")` | `[Document, Paragraph, Strong]` | Append TextNode to Strong |
+| 10 | `EndTag("b")` | `[Document, Paragraph]` | Pop Strong |
+| 11 | `EndTag("p")` | `[Document]` | Pop Paragraph |
+| 12 | `EndTag("body")` | `[Document]` | Structure tag, close all |
+| 13 | `EndTag("html")` | `[Document]` | Structure tag, close all |
+
+Final tree:
+
+```
+DocumentNode
+├── HeadingNode { level: 1 }
+│   └── TextNode("Title")
+└── ParagraphNode
+    ├── TextNode("Hello ")
+    └── StrongNode
+        └── TextNode("world")
+```
+
+---
+
+## Testing Strategy
+
+### 1. Basic Document Structure
+
+Parse `<html><body><p>Hello</p></body></html>` and verify the tree has a
+DocumentNode root containing a single ParagraphNode with a TextNode child.
+
+### 2. All Heading Levels
+
+Parse `<h1>One</h1>` through `<h6>Six</h6>` and verify each produces a
+HeadingNode with the correct `level` field (1 through 6).
+
+### 3. Lists
+
+Parse `<ul><li>A</li><li>B</li></ul>` and verify it produces a
+`ListNode { ordered: false }` with two `ListItemNode` children, each containing
+a TextNode.
+
+Parse `<ol><li>First</li><li>Second</li></ol>` and verify `ordered: true`.
+
+### 4. Links
+
+Parse `<a href="http://example.com">click</a>` and verify it produces a
+`LinkNode { destination: "http://example.com", title: None }` containing a
+TextNode.
+
+### 5. Images
+
+Parse `<img src="photo.gif" alt="Photo">` and verify it produces an
+`ImageNode { destination: "photo.gif", alt: "Photo" }`. Verify it is treated as
+a void element (no children, no end tag needed).
+
+### 6. Inline Formatting Equivalence
+
+Verify that `<b>bold</b>` and `<strong>strong</strong>` both produce a
+`StrongNode`. Verify that `<i>italic</i>` and `<em>emphasis</em>` both produce
+an `EmphasisNode`.
+
+### 7. Implicit Close — Paragraphs
+
+Parse `<p>one<p>two` (no close tags) and verify the tree contains two separate
+ParagraphNodes, not a paragraph nested inside a paragraph.
+
+### 8. Implicit Close — List Items
+
+Parse `<ul><li>A<li>B<li>C</ul>` and verify three separate ListItemNodes.
+
+### 9. Missing Body
+
+Parse `<h1>Hello</h1>` (no `<html>`, no `<body>`) and verify it works identically
+to `<html><body><h1>Hello</h1></body></html>`.
+
+### 10. Unknown Tags
+
+Parse `<blink>text</blink>` and verify the text content is preserved (as a
+TextNode in the current element) and no error is raised.
+
+### 11. Nested Formatting
+
+Parse `<b><i>bold italic</i></b>` and verify it produces a StrongNode containing
+an EmphasisNode containing a TextNode.
+
+### 12. Pre Blocks — Whitespace Preservation
+
+Parse `<pre>  spaces\n  preserved  </pre>` and verify the TextNode child
+preserves all whitespace exactly as written.
+
+### 13. Entities in Attributes
+
+Parse `<a href="page?a=1&amp;b=2">link</a>` and verify the destination is
+`"page?a=1&b=2"` (entity decoded by the lexer, preserved by the parser).
+
+### 14. Round-Trip Consistency
+
+Parse an HTML document, emit it back to HTML via a `document-ast-to-html`
+renderer, then parse the output again. Verify the two DocumentAST trees are
+structurally identical.
+
+### 15. Real Mosaic-Era Pages
+
+Parse archived 1993 HTML from `info.cern.ch` (the first web server). These pages
+use the exact tag set this parser supports and exercise real-world error recovery
+patterns.
+
+### 16. Overlapping Tags
+
+Parse `<b><i>text</b></i>` and verify the parser recovers gracefully — the text
+content must not be lost, and the resulting tree must be well-formed.
+
+### 17. Empty Document
+
+Parse `""` (empty string) and verify the result is a DocumentNode with no
+children.
+
+### 18. Text-Only Document
+
+Parse `"Just some text, no tags at all."` and verify the result is a DocumentNode
+containing a single TextNode.
+
+---
+
+## Scope
+
+### In Scope
+
+- The 22-tag HTML 1.0 / Mosaic subset listed above
+- Implicit close rules for `<p>`, `<li>`, headings, and block elements
+- Error recovery for all forms of malformed HTML (never fail, never crash)
+- Full mapping from HTML tags to DocumentAST node types (TE00)
+- Void element handling (`<hr>`, `<br>`, `<img>`)
+- Attribute extraction (`href` from `<a>`, `src` and `alt` from `<img>`)
+- Whitespace preservation inside `<pre>` blocks
+- Structure tag (`<html>`, `<head>`, `<title>`, `<body>`) handling and implication
+
+### Out of Scope
+
+- **HTML 2.0+ tags**: `<table>`, `<form>`, `<input>`, `<select>`, `<textarea>`,
+  `<div>`, `<span>`, `<font>`, and all tags introduced after the Mosaic era.
+  These will be handled by future parser versions (TE06+).
+- **CSS**: Neither `style` attributes nor `<style>` elements. CSS did not exist
+  in 1993 (CSS1 was published in 1996).
+- **JavaScript**: No `<script>` element processing. JavaScript did not exist
+  in 1993 (Brendan Eich created it in 1995).
+- **Character encoding detection**: The parser operates on Rust `&str` (UTF-8).
+  Encoding detection is a transport-layer concern, not a parsing concern.
+- **DOM API**: This parser builds a static, immutable AST. It does not provide
+  `getElementById`, `querySelector`, event listeners, or any interactive DOM
+  functionality. The output is a data structure, not a live object model.
+- **Full HTML5 parsing algorithm**: The HTML5 spec defines an extremely detailed
+  tree-building algorithm with dozens of insertion modes. That algorithm handles
+  the full complexity of modern HTML. This parser implements only the subset
+  relevant to the 22-tag Mosaic era, using simplified versions of the same
+  principles.

--- a/code/specs/UI10-layout-rust-port.md
+++ b/code/specs/UI10-layout-rust-port.md
@@ -1,0 +1,516 @@
+# UI10 — Layout Pipeline Rust Port
+
+## Overview
+
+The layout pipeline — layout-ir (UI02), layout-block (UI07), layout-to-paint
+(UI04), document-ast-to-layout (UI06), and layout-text-measure-estimated (UI09)
+— currently exists only in TypeScript. All five packages are **pure
+computation**: no I/O, no platform dependencies, no event loops. They transform
+data structures into other data structures.
+
+The Venture browser is a native Rust binary. It needs these same algorithms in
+Rust so it can lay out and paint HTML 1.0 content without embedding a JavaScript
+runtime. This spec covers porting all five packages, plus adding a new
+Windows-specific text measurer backed by DirectWrite.
+
+The porting is mechanical. The TypeScript originals are imperative, loop-heavy
+code with no async, no closures over mutable state, and no prototype chains.
+Every function takes explicit arguments and returns explicit results. This
+translates to Rust almost line-for-line.
+
+---
+
+## Where It Fits
+
+```
+                          TypeScript side             Rust side (this spec)
+                          ──────────────             ─────────────────────
+  HTML 1.0 parser ──┐
+  CommonMark parser ─┤
+                     ▼
+  DocumentAST ──► document-ast-to-layout ──► LayoutNode tree
+                     (UI06)                      │
+                                                 ▼
+                                          layout-block (UI07)
+                                           + TextMeasurer
+                                                 │
+                                                 ▼
+                                          PositionedNode tree
+                                                 │
+                                                 ▼
+                                          layout-to-paint (UI04)
+                                                 │
+                                                 ▼
+                                            PaintScene
+                                                 │
+                                                 ▼
+                                           paint-vm (Rust)
+                                                 │
+                                                 ▼
+                                              pixels
+```
+
+The Rust ports mirror the TypeScript packages exactly. Same types, same
+algorithms, same test vectors. The only new code is `text-measure-directwrite`,
+which calls the Windows DirectWrite API for real font metrics.
+
+---
+
+## Concepts
+
+### Why port instead of FFI?
+
+Calling TypeScript from Rust would require embedding a JS engine (V8, Deno,
+quickjs). That defeats the purpose of a native browser. The layout pipeline is
+small (~2,000 lines of TypeScript total across all five packages) and
+algorithmic. A direct port is simpler, faster, and produces a single static
+binary with no runtime dependencies.
+
+### What stays the same
+
+- **Types.** `LayoutNode`, `PositionedNode`, `TextMetrics`, `Display`,
+  `PaintScene`, `PaintCommand` — all map 1:1 to Rust structs and enums.
+- **Algorithms.** Block layout, inline wrapping, margin collapsing, paint-scene
+  generation — all are the same imperative loops.
+- **Extension bags.** The `ext` map stays as `HashMap<String, serde_json::Value>`.
+  This preserves the open-schema design where each algorithm reads what it needs
+  and ignores the rest.
+- **Test vectors.** Every TypeScript test case ports to a Rust `#[test]`.
+
+### What changes
+
+- **Ownership.** TypeScript passes trees by reference with shared ownership. Rust
+  uses owned trees (`Vec<LayoutNode>`) for the input and builds new owned trees
+  for the output. No `Rc`, no `RefCell` — the algorithms are tree-in, tree-out.
+- **Trait instead of interface.** `TextMeasurer` becomes a Rust trait. The
+  estimated measurer and DirectWrite measurer both implement it.
+- **No `any`.** TypeScript's `any` in ext bags becomes `serde_json::Value`, which
+  is typed at runtime but checked at access time. Helper methods like
+  `ext_f64(node, "block", "marginTop")` wrap the lookup-and-cast pattern.
+
+---
+
+## Public API
+
+### Crate 1: `layout-ir` (port of UI02)
+
+The foundation crate. Defines the core types that every other crate depends on.
+
+```rust
+// --- Display enum ---
+
+/// How a node participates in layout.
+///
+/// Think of this like the CSS `display` property, but simpler. In HTML 1.0,
+/// every element is either Block (headings, paragraphs, lists) or Inline
+/// (text runs, links, emphasis). The other variants exist for future layout
+/// algorithms (flexbox, grid) but are not used by layout-block.
+pub enum Display {
+    Block,
+    Inline,
+    Flex,
+    Grid,
+    None,
+}
+
+// --- LayoutNode ---
+
+/// A node in the layout input tree.
+///
+/// This is what producers (document-ast-to-layout, mosaic-ir-to-layout) build.
+/// It describes *what* to lay out, not *where* it goes. The layout algorithm
+/// reads this tree and produces a PositionedNode tree with resolved coordinates.
+///
+/// Extension properties live in `ext`. For example, a block-layout node might
+/// carry `ext["block"]["marginTop"] = 12.0`. The layout-block algorithm reads
+/// those; layout-flexbox would ignore them. This keeps the core type small and
+/// algorithm-agnostic.
+pub struct LayoutNode {
+    pub display: Display,
+    pub children: Vec<LayoutNode>,
+    pub content: Option<String>,
+    pub ext: HashMap<String, serde_json::Value>,
+    pub width: Option<f64>,
+    pub height: Option<f64>,
+    pub min_width: Option<f64>,
+    pub max_width: Option<f64>,
+}
+
+// --- PositionedNode ---
+
+/// A node in the layout output tree, with resolved position and size.
+///
+/// Every field is concrete — no Options, no unknowns. The layout algorithm has
+/// decided where this node goes and how big it is.
+pub struct PositionedNode {
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+    pub children: Vec<PositionedNode>,
+    pub content: Option<String>,
+    pub ext: HashMap<String, serde_json::Value>,
+}
+
+// --- TextMeasurer trait ---
+
+/// Measures text for layout purposes.
+///
+/// The layout algorithm calls this whenever it encounters a text node and needs
+/// to know how wide and tall the text will be at a given font size, constrained
+/// to a maximum width (for line wrapping).
+///
+/// Two implementations exist:
+/// - `EstimatedMeasurer` — zero-dependency, uses average character widths.
+///   Deterministic and fast. Used in tests and on platforms without font APIs.
+/// - `DirectWriteMeasurer` — calls Windows DirectWrite for real font metrics.
+///   Used in the Venture browser on Windows.
+pub trait TextMeasurer {
+    fn measure(&self, text: &str, font_ref: &str, font_size: f64, max_width: f64) -> TextMetrics;
+}
+
+/// The result of measuring a block of text.
+pub struct TextMetrics {
+    pub width: f64,
+    pub height: f64,
+    pub line_count: usize,
+}
+```
+
+**Location:** `code/packages/rust/layout-ir/`
+
+---
+
+### Crate 2: `layout-block` (port of UI07)
+
+Block and inline flow layout — the layout algorithm used for document content.
+
+```rust
+/// Lay out a tree of LayoutNodes using block-and-inline flow.
+///
+/// This is the layout algorithm that web browsers use for normal document flow:
+///
+/// - **Block-level children** stack vertically. Each block child gets the full
+///   `available_width` (minus its own margins/padding). Its height is determined
+///   by its content.
+///
+/// - **Inline-level children** flow left-to-right within a line. When the
+///   accumulated width exceeds `available_width`, the line wraps. Text nodes
+///   are measured using the `measurer` to determine how many words fit on each
+///   line.
+///
+/// - **Margin collapsing:** When two adjacent block elements have margins, the
+///   space between them is the *larger* of the two margins, not the sum. This
+///   matches CSS behavior and prevents double-spacing between paragraphs.
+///
+/// - **Padding and borders** are read from `ext["block"]`:
+///   `paddingTop`, `paddingRight`, `paddingBottom`, `paddingLeft`,
+///   `borderTopWidth`, `borderRightWidth`, `borderBottomWidth`, `borderLeftWidth`.
+///
+/// The function returns a PositionedNode tree with resolved x, y, width, height
+/// for every node.
+pub fn layout_block(
+    node: &LayoutNode,
+    available_width: f64,
+    measurer: &dyn TextMeasurer,
+) -> PositionedNode
+```
+
+**Location:** `code/packages/rust/layout-block/`
+
+---
+
+### Crate 3: `layout-to-paint` (port of UI04)
+
+Converts the positioned layout tree into a flat list of paint instructions.
+
+```rust
+/// Convert a positioned layout tree into a PaintScene.
+///
+/// This is the bridge between layout (which knows about boxes and text) and
+/// painting (which knows about rectangles, colors, and glyph runs).
+///
+/// The conversion is a depth-first tree walk. For each PositionedNode:
+///
+///   1. If ext["paint"]["backgroundColor"] is set → emit a PaintRect for the
+///      background, filling the node's bounding box.
+///
+///   2. If ext["paint"]["borderWidth"] > 0 → emit PaintRect commands for each
+///      border edge (top, right, bottom, left) with the border color.
+///
+///   3. If the node has `content` (a text leaf) → emit a PaintGlyphRun with
+///      the text, position, font, and color from ext["paint"].
+///
+///   4. If ext["paint"]["opacity"] < 1.0 → wrap the node's commands in a
+///      PaintLayer with the given opacity.
+///
+///   5. Recurse into children.
+///
+/// The `device_pixel_ratio` scales all coordinates from logical units to
+/// physical pixels. On a 2x Retina display, pass 2.0; on a standard display,
+/// pass 1.0.
+pub fn layout_to_paint(
+    root: &PositionedNode,
+    device_pixel_ratio: f64,
+) -> PaintScene
+
+/// A scene is an ordered list of paint commands.
+pub struct PaintScene {
+    pub commands: Vec<PaintCommand>,
+}
+
+/// A single paint instruction.
+pub enum PaintCommand {
+    /// Fill a rectangle with a solid color.
+    Rect {
+        x: f64, y: f64, width: f64, height: f64,
+        color: String,
+        corner_radius: f64,
+    },
+    /// Draw a run of text glyphs.
+    GlyphRun {
+        x: f64, y: f64,
+        text: String,
+        font: String,
+        font_size: f64,
+        color: String,
+    },
+    /// Begin an opacity group. All commands until the matching PopLayer
+    /// are composited at the given opacity.
+    PushLayer { opacity: f64 },
+    /// End an opacity group.
+    PopLayer,
+}
+```
+
+**Location:** `code/packages/rust/layout-to-paint/`
+
+---
+
+### Crate 4: `document-ast-to-layout` (port of UI06)
+
+Converts a DocumentAST (the output of commonmark-parser or html1.0-parser) into
+a LayoutNode tree ready for block layout.
+
+```rust
+/// Convert a document tree into a layout tree.
+///
+/// The `theme` controls all visual properties: fonts, sizes, colors, spacing.
+/// This keeps the conversion pure — no hard-coded magic numbers, no reading
+/// from CSS files, no platform queries. Everything comes from the theme.
+///
+/// Mapping from document nodes to layout nodes:
+///
+///   DocumentNode         → LayoutNode
+///   ─────────────          ──────────
+///   Heading(level)       → Block, font = theme.heading_font,
+///                           size = theme.heading_sizes[level - 1],
+///                           marginBottom = theme.paragraph_spacing
+///   Paragraph            → Block, font = theme.body_font,
+///                           size = theme.body_font_size,
+///                           marginBottom = theme.paragraph_spacing
+///   Text(string)         → Inline leaf with content = string
+///   Link(href)           → Inline, ext["paint"]["color"] = theme.link_color
+///   Emphasis             → Inline, ext["paint"]["fontStyle"] = "italic"
+///   Strong               → Inline, ext["paint"]["fontWeight"] = "bold"
+///   CodeBlock(lang, src) → Block, font = theme.code_font,
+///                           size = theme.code_font_size,
+///                           ext["paint"]["backgroundColor"] = "#E8E8E8"
+///   InlineCode(src)      → Inline, font = theme.code_font,
+///                           size = theme.code_font_size
+///   List(ordered, items) → Block with indentation,
+///                           each item gets a bullet/number prefix
+///   HorizontalRule       → Block, height = 1.0,
+///                           ext["paint"]["backgroundColor"] = "#808080"
+///
+pub fn document_to_layout(
+    doc: &DocumentNode,
+    theme: &DocumentTheme,
+) -> LayoutNode
+
+/// Visual theme for document rendering.
+///
+/// These defaults produce something close to NCSA Mosaic (1993): Times New
+/// Roman body text, gray background, blue links, purple visited links.
+pub struct DocumentTheme {
+    pub body_font: String,
+    pub body_font_size: f64,
+    pub heading_font: String,
+    pub heading_sizes: [f64; 6],
+    pub code_font: String,
+    pub code_font_size: f64,
+    pub line_height: f64,
+    pub paragraph_spacing: f64,
+    pub link_color: String,
+    pub visited_link_color: String,
+    pub background_color: String,
+}
+
+impl Default for DocumentTheme {
+    fn default() -> Self {
+        Self {
+            body_font: "Times New Roman".into(),
+            body_font_size: 14.0,
+            heading_font: "Times New Roman".into(),
+            heading_sizes: [24.0, 20.0, 18.0, 16.0, 14.0, 12.0],
+            code_font: "Courier New".into(),
+            code_font_size: 13.0,
+            line_height: 1.4,
+            paragraph_spacing: 12.0,
+            link_color: "#0000EE".into(),
+            visited_link_color: "#551A8B".into(),
+            background_color: "#C0C0C0".into(),
+        }
+    }
+}
+```
+
+**Location:** `code/packages/rust/document-ast-to-layout/`
+
+---
+
+### Crate 5: `text-measure-directwrite` (new, Windows-specific)
+
+Native Windows text measurement implementing the `TextMeasurer` trait. This is
+the only crate in the set that has platform dependencies.
+
+```rust
+/// Real text measurement using Windows DirectWrite.
+///
+/// DirectWrite is the modern Windows text rendering API. It handles font
+/// fallback, complex scripts (Arabic, CJK), ligatures, and kerning. We use
+/// it here for a single purpose: given a string, a font, a size, and a
+/// max width, how wide and tall is the resulting text block?
+///
+/// Internally:
+///   1. Create an IDWriteFactory (cached for the lifetime of the measurer).
+///   2. For each (font_ref, font_size) pair, create an IDWriteTextFormat
+///      (cached in a HashMap).
+///   3. For each measure() call, create an IDWriteTextLayout with the text
+///      and max_width constraint.
+///   4. Call GetMetrics() to read width, height, and lineCount.
+///   5. Return TextMetrics.
+///
+/// The IDWriteTextLayout is not cached — it is cheap to create and specific
+/// to each (text, maxWidth) pair.
+pub struct DirectWriteMeasurer {
+    factory: /* IDWriteFactory COM pointer */,
+    format_cache: HashMap<(String, OrderedFloat<f64>), /* IDWriteTextFormat */>,
+}
+
+impl TextMeasurer for DirectWriteMeasurer {
+    fn measure(&self, text: &str, font_ref: &str, font_size: f64, max_width: f64) -> TextMetrics;
+}
+```
+
+This crate also re-exports an `EstimatedMeasurer` — a port of
+layout-text-measure-estimated (UI09) — as a zero-dependency fallback:
+
+```rust
+/// Estimated text measurement using average character widths.
+///
+/// This is a port of the TypeScript layout-text-measure-estimated package.
+/// It uses a table of average character widths (as a fraction of font size)
+/// to estimate text dimensions without any platform font API.
+///
+/// The estimates are rough but deterministic. A monospace font at 13px gives
+/// ~7.8px per character. A proportional font at 14px gives ~6.5px per
+/// character on average. These numbers come from measuring common fonts on
+/// Windows and macOS and averaging the results.
+///
+/// Primary use cases:
+/// - Unit tests (deterministic, no platform dependency)
+/// - Fallback on platforms without a native text API
+/// - Server-side rendering where fonts are unavailable
+pub struct EstimatedMeasurer;
+
+impl TextMeasurer for EstimatedMeasurer {
+    fn measure(&self, text: &str, font_ref: &str, font_size: f64, max_width: f64) -> TextMetrics;
+}
+```
+
+**Location:** `code/packages/rust/text-measure-directwrite/`
+
+---
+
+## Testing Strategy
+
+### Port TypeScript tests 1:1
+
+Every existing TypeScript test case becomes a Rust `#[test]`. The test name,
+input, and expected output stay the same. This is the primary correctness
+guarantee: if the Rust port produces the same output as the TypeScript original
+for every test vector, the port is correct.
+
+### Use EstimatedMeasurer for deterministic tests
+
+All layout tests use `EstimatedMeasurer`, not `DirectWriteMeasurer`. This makes
+tests deterministic across platforms and CI environments. The estimated measurer
+produces the same numbers on Windows, macOS, and Linux.
+
+### Float tolerance
+
+Layout produces `f64` coordinates. Comparing floats for exact equality is
+fragile. All assertions use an epsilon of `1e-6`:
+
+```rust
+fn assert_close(actual: f64, expected: f64) {
+    assert!((actual - expected).abs() < 1e-6,
+        "expected {expected}, got {actual}");
+}
+```
+
+### Cross-validation with TypeScript
+
+For a set of representative inputs (a simple paragraph, a heading + paragraph, a
+nested list, a code block), run both the TypeScript and Rust pipelines and
+compare the PositionedNode trees field-by-field. This catches semantic drift
+where individual tests pass but the overall behavior diverges.
+
+### DirectWrite-specific tests
+
+The DirectWrite measurer gets its own test suite that:
+
+1. Measures known strings ("Hello, world!" in Times New Roman 14px) and checks
+   that width and height are within reasonable bounds (not zero, not absurdly
+   large).
+2. Verifies that line wrapping occurs: a long string with `max_width = 100.0`
+   should produce `line_count > 1`.
+3. Compares against the estimated measurer to ensure they agree within 20% for
+   common Latin text. (They will diverge for CJK or complex scripts, and that is
+   expected.)
+
+These tests are gated behind `#[cfg(target_os = "windows")]` since DirectWrite
+is Windows-only.
+
+---
+
+## Scope
+
+### In scope
+
+- Rust port of `layout-ir` (UI02) — core types and traits
+- Rust port of `layout-block` (UI07) — block + inline flow layout
+- Rust port of `layout-to-paint` (UI04) — positioned tree to paint scene
+- Rust port of `document-ast-to-layout` (UI06) — document AST to layout tree
+- Rust port of `layout-text-measure-estimated` (UI09) — zero-dep text measurer
+- New crate: `text-measure-directwrite` — Windows DirectWrite text measurer
+- 1:1 test ports from TypeScript to Rust
+- Cross-validation test harness
+
+### Out of scope
+
+- **layout-flexbox (UI03):** Not needed for HTML 1.0 content. Block + inline
+  flow covers everything in the HTML 1.0 spec (headings, paragraphs, lists,
+  preformatted text, horizontal rules, links, images).
+- **layout-grid (UI08):** Same reason — no CSS Grid in HTML 1.0.
+- **CSS property resolution:** The Venture browser uses `DocumentTheme` directly,
+  not a CSS cascade. CSS support is a separate future effort.
+- **Animation / transitions:** Static layout only. The Venture browser does not
+  animate layout changes.
+- **Incremental relayout:** Every layout pass processes the full tree. For HTML
+  1.0 documents (which are small), this is fast enough. Incremental relayout is
+  an optimization for a future spec.
+- **Non-Windows text measurement:** CoreText (macOS), FreeType/HarfBuzz (Linux)
+  measurers are future crates. The EstimatedMeasurer covers non-Windows platforms
+  for now.


### PR DESCRIPTION
## Summary

- Adds 11 specification documents for **Venture**, a cross-platform native web browser targeting NCSA Mosaic 1.0 (1993) feature parity
- Architecture follows unix-pipe philosophy: each capability is its own crate, and the browser is a thin orchestrator wiring them together
- Venture targets the existing PaintVM abstraction, making it cross-platform (Windows via Direct2D/GDI, macOS via Metal, Linux via Cairo)

### Specs added

**Networking (6 specs):**
- `NET00` URL parser (RFC 1738)
- `NET01` Generic TCP client
- `NET02` Generic frame extractor (delimiter/length/read-to-end strategies)
- `NET03` HTTP/1.0 lexer
- `NET04` HTTP/1.0 parser
- `NET05` HTTP/1.0 client (thin orchestrator wiring NET00-04)

**Document parsing (2 specs):**
- `TE04` HTML 1.0 lexer (state-machine tokenizer)
- `TE05` HTML 1.0 parser (tree builder → DocumentAST)

**Rendering (1 spec):**
- `P2D06` Paint VM native backends (Direct2D, GDI, Cairo)

**Layout (1 spec):**
- `UI10` Layout pipeline Rust port (layout-ir, layout-block, layout-to-paint, document-ast-to-layout, text-measure-directwrite)

**Integration (1 spec):**
- `BR01` Venture browser program

## Test plan

- [ ] Review each spec for completeness, accuracy, and consistency with existing specs
- [ ] Verify spec numbering doesn't conflict with existing specs
- [ ] Verify pipeline diagram in each spec correctly references upstream/downstream packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)