### PR TITLE
feat(ls00): implement generic LSP framework across 9 languages + WASM

### DIFF
--- a/code/packages/elixir/ls00/BUILD
+++ b/code/packages/elixir/ls00/BUILD
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --trace

--- a/code/packages/elixir/ls00/CHANGELOG.md
+++ b/code/packages/elixir/ls00/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## 0.1.0 -- 2026-04-12
+
+### Added
+
+- Initial release: generic LSP server framework for Elixir.
+- `Ls00.LanguageBridge` behaviour with 2 required callbacks (`tokenize/1`, `parse/1`) and 10 optional callbacks (hover, definition, references, completion, rename, semantic_tokens, document_symbols, folding_ranges, signature_help, format).
+- `Ls00.DocumentManager` with UTF-16 code unit to UTF-8 byte offset conversion, supporting ASCII, BMP codepoints, emoji/surrogate pairs, CJK characters, and multiline documents.
+- `Ls00.ParseCache` with (uri, version) keyed caching and URI-based eviction.
+- `Ls00.Capabilities` with runtime capability detection via `function_exported?/3`, semantic token legend, and delta-encoded semantic token serialization.
+- `Ls00.LspErrors` with all LSP-specific error code constants.
+- `Ls00.Handlers` implementing all LSP lifecycle (initialize, initialized, shutdown, exit), text document sync (didOpen, didChange, didClose, didSave), and feature request handlers.
+- `Ls00.Server` wiring JSON-RPC server to handler state via Agent for mutable state threading.
+- 61 tests covering UTF-16 conversion (10), document manager (8), parse cache (5), capabilities (5), semantic tokens (8), and server/handler integration (25).
+- Literate programming style with comprehensive `@moduledoc` and `@doc` annotations.

--- a/code/packages/elixir/ls00/README.md
+++ b/code/packages/elixir/ls00/README.md
@@ -1,0 +1,86 @@
+# ls00 -- Generic LSP Framework (Elixir)
+
+A generic Language Server Protocol (LSP) framework that language-specific "bridges" plug into via Elixir behaviours. Port of the Go implementation at `code/packages/go/ls00/`.
+
+## What is the Language Server Protocol?
+
+LSP solves the M x N problem: M editors x N languages = M x N integrations. With LSP, each language writes one server, and every LSP-aware editor gets all features automatically.
+
+This package is the *generic* half -- it handles all the protocol boilerplate. A language author only writes the `Ls00.LanguageBridge` behaviour that connects their lexer/parser to this framework.
+
+## Architecture
+
+```
+Lexer -> Parser -> [LanguageBridge] -> [LspServer] -> VS Code / Neovim / Emacs
+```
+
+## Usage
+
+1. Implement the `Ls00.LanguageBridge` behaviour:
+
+```elixir
+defmodule MyLanguage.Bridge do
+  @behaviour Ls00.LanguageBridge
+
+  @impl true
+  def tokenize(source) do
+    {:ok, MyLexer.lex(source)}
+  end
+
+  @impl true
+  def parse(source) do
+    {ast, diagnostics} = MyParser.parse(source)
+    {:ok, ast, diagnostics}
+  end
+
+  # Optional: implement hover, definition, etc.
+  @impl true
+  def hover(ast, pos) do
+    {:ok, %Ls00.Types.HoverResult{contents: "**symbol** info"}}
+  end
+end
+```
+
+2. Start the server:
+
+```elixir
+server = Ls00.Server.new(MyLanguage.Bridge, :stdio, :stdio)
+Ls00.Server.serve(server)
+```
+
+## Features
+
+The framework supports all 10 optional LSP features via `@optional_callbacks`:
+
+| Feature | Callback | LSP Method |
+|---------|----------|------------|
+| Hover | `hover/2` | textDocument/hover |
+| Go to Definition | `definition/3` | textDocument/definition |
+| Find References | `references/4` | textDocument/references |
+| Autocomplete | `completion/2` | textDocument/completion |
+| Rename | `rename/3` | textDocument/rename |
+| Semantic Tokens | `semantic_tokens/2` | textDocument/semanticTokens/full |
+| Document Symbols | `document_symbols/1` | textDocument/documentSymbol |
+| Code Folding | `folding_ranges/1` | textDocument/foldingRange |
+| Signature Help | `signature_help/2` | textDocument/signatureHelp |
+| Formatting | `format/1` | textDocument/formatting |
+
+Capability detection uses `function_exported?/3` at runtime -- only features the bridge implements are advertised to the editor.
+
+## Dependencies
+
+- `coding_adventures_json_rpc` (path dependency at `../json_rpc`)
+
+## Module Map
+
+| Module | Role |
+|--------|------|
+| `Ls00` | Top-level module |
+| `Ls00.Types` | All LSP types as structs/typespecs |
+| `Ls00.LanguageBridge` | `@behaviour` with required + optional callbacks |
+| `Ls00.DocumentManager` | Document tracking + UTF-16 conversion |
+| `Ls00.ParseCache` | Cache with {uri, version} key |
+| `Ls00.Capabilities` | build_capabilities + semantic token encoding |
+| `Ls00.LspErrors` | Error code constants |
+| `Ls00.Server` | LspServer wiring everything together |
+| `Ls00.Handlers` | All handler functions |

--- a/code/packages/elixir/ls00/lib/ls00.ex
+++ b/code/packages/elixir/ls00/lib/ls00.ex
@@ -1,0 +1,54 @@
+defmodule Ls00 do
+  @moduledoc """
+  A generic Language Server Protocol (LSP) framework.
+
+  ## What is the Language Server Protocol?
+
+  When you open a source file in VS Code and see red squiggles under syntax
+  errors, autocomplete suggestions, or "Go to Definition" -- none of that is
+  built into the editor. It comes from a *language server*: a separate process
+  that communicates with the editor over the Language Server Protocol.
+
+  LSP was invented by Microsoft to solve the M x N problem:
+
+      M editors x N languages = M x N integrations to write
+
+  With LSP, each language writes one server, and every LSP-aware editor gets
+  all features automatically. This package is the *generic* half -- it handles
+  all the protocol boilerplate. A language author only writes the
+  `Ls00.LanguageBridge` behaviour that connects their lexer/parser to this
+  framework.
+
+  ## Architecture
+
+      Lexer -> Parser -> [LanguageBridge] -> [LspServer] -> VS Code / Neovim / Emacs
+
+  ## JSON-RPC over stdio
+
+  Like the Debug Adapter Protocol (DAP), LSP speaks JSON-RPC over stdio.
+  Each message is Content-Length-framed (same format as HTTP headers). The
+  underlying transport is handled by the `coding_adventures_json_rpc` package.
+
+  ## How to use this package
+
+  1. Implement the `Ls00.LanguageBridge` behaviour (and any optional callbacks)
+     for your language.
+  2. Call `Ls00.Server.new(bridge_module, :stdio, :stdio)`.
+  3. Call `Ls00.Server.serve(server)` -- it blocks until the editor closes the
+     connection.
+
+  ## Module Map
+
+  | Module               | Role                                          |
+  |----------------------|-----------------------------------------------|
+  | `Ls00`               | Top-level convenience (this file)             |
+  | `Ls00.Types`         | Structs + typespecs for all LSP data types    |
+  | `Ls00.LanguageBridge`| `@behaviour` with required + optional callbacks|
+  | `Ls00.DocumentManager`| Document tracking + UTF-16 conversion        |
+  | `Ls00.ParseCache`    | Cache with {uri, version} key                 |
+  | `Ls00.Capabilities`  | build_capabilities + semantic token encoding   |
+  | `Ls00.LspErrors`     | Error code constants                          |
+  | `Ls00.Server`        | LspServer wiring everything together          |
+  | `Ls00.Handlers`      | All handler functions                         |
+  """
+end

--- a/code/packages/elixir/ls00/lib/ls00/capabilities.ex
+++ b/code/packages/elixir/ls00/lib/ls00/capabilities.ex
@@ -1,0 +1,245 @@
+defmodule Ls00.Capabilities do
+  @moduledoc """
+  Build LSP capabilities and encode semantic tokens.
+
+  ## What Are Capabilities?
+
+  During the LSP initialize handshake, the server sends back a "capabilities"
+  object telling the editor which LSP features it supports. The editor uses this
+  to decide which requests to send. If a capability is absent, the editor won't
+  send the corresponding requests -- so no "Go to Definition" button appears
+  unless definitionProvider is true.
+
+  Building capabilities dynamically (based on the bridge module's exported
+  functions) means the server is always honest about what it can do.
+
+  ## Semantic Token Legend
+
+  Semantic tokens use a compact binary encoding. Instead of sending
+  `{"type":"keyword"}` per token, LSP sends an integer index into a legend.
+  The legend must be declared in the capabilities so the editor knows what
+  each index means.
+  """
+
+  alias Ls00.Types.SemanticToken
+
+  @doc """
+  Inspect the bridge module at runtime and return the LSP capabilities map.
+
+  Uses `function_exported?/3` to check which optional callbacks the bridge
+  module implements. Only advertises capabilities for features the bridge
+  actually supports.
+  """
+  @spec build_capabilities(module()) :: map()
+  def build_capabilities(bridge_module) do
+    # textDocumentSync=2 means "incremental": the editor sends only changed
+    # ranges, not the full file, on every keystroke.
+    caps = %{"textDocumentSync" => 2}
+
+    caps = if function_exported?(bridge_module, :hover, 2),
+      do: Map.put(caps, "hoverProvider", true), else: caps
+
+    caps = if function_exported?(bridge_module, :definition, 3),
+      do: Map.put(caps, "definitionProvider", true), else: caps
+
+    caps = if function_exported?(bridge_module, :references, 4),
+      do: Map.put(caps, "referencesProvider", true), else: caps
+
+    caps = if function_exported?(bridge_module, :completion, 2),
+      do: Map.put(caps, "completionProvider", %{
+        "triggerCharacters" => [" ", "."]
+      }), else: caps
+
+    caps = if function_exported?(bridge_module, :rename, 3),
+      do: Map.put(caps, "renameProvider", true), else: caps
+
+    caps = if function_exported?(bridge_module, :document_symbols, 1),
+      do: Map.put(caps, "documentSymbolProvider", true), else: caps
+
+    caps = if function_exported?(bridge_module, :folding_ranges, 1),
+      do: Map.put(caps, "foldingRangeProvider", true), else: caps
+
+    caps = if function_exported?(bridge_module, :signature_help, 2),
+      do: Map.put(caps, "signatureHelpProvider", %{
+        "triggerCharacters" => ["(", ","]
+      }), else: caps
+
+    caps = if function_exported?(bridge_module, :format, 1),
+      do: Map.put(caps, "documentFormattingProvider", true), else: caps
+
+    caps = if function_exported?(bridge_module, :semantic_tokens, 2),
+      do: Map.put(caps, "semanticTokensProvider", %{
+        "legend" => semantic_token_legend(),
+        "full" => true
+      }), else: caps
+
+    caps
+  end
+
+  # ---------------------------------------------------------------------------
+  # Semantic Token Legend
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Return the full legend for all supported semantic token types and modifiers.
+
+  The legend is sent once in the capabilities response. Afterwards, each
+  semantic token is encoded as an integer index into this legend rather than
+  a string. This makes the per-token encoding much smaller.
+
+  The ordering matters: index 0 in `tokenTypes` corresponds to "namespace",
+  index 1 to "type", etc. These match the standard LSP token types.
+  """
+  @spec semantic_token_legend() :: map()
+  def semantic_token_legend do
+    %{
+      # Standard LSP token types (in the order VS Code expects them).
+      "tokenTypes" => [
+        "namespace",     # 0
+        "type",          # 1
+        "class",         # 2
+        "enum",          # 3
+        "interface",     # 4
+        "struct",        # 5
+        "typeParameter", # 6
+        "parameter",     # 7
+        "variable",      # 8
+        "property",      # 9
+        "enumMember",    # 10
+        "event",         # 11
+        "function",      # 12
+        "method",        # 13
+        "macro",         # 14
+        "keyword",       # 15
+        "modifier",      # 16
+        "comment",       # 17
+        "string",        # 18
+        "number",        # 19
+        "regexp",        # 20
+        "operator",      # 21
+        "decorator"      # 22
+      ],
+      # Standard LSP token modifiers (bitmask flags).
+      "tokenModifiers" => [
+        "declaration",    # bit 0
+        "definition",     # bit 1
+        "readonly",       # bit 2
+        "static",         # bit 3
+        "deprecated",     # bit 4
+        "abstract",       # bit 5
+        "async",          # bit 6
+        "modification",   # bit 7
+        "documentation",  # bit 8
+        "defaultLibrary"  # bit 9
+      ]
+    }
+  end
+
+  @doc """
+  Return the integer index for a semantic token type string.
+
+  Returns `-1` if the type is not in the legend (the caller should skip such tokens).
+  """
+  @spec token_type_index(String.t()) :: integer()
+  def token_type_index(token_type) do
+    legend = semantic_token_legend()
+    case Enum.find_index(legend["tokenTypes"], &(&1 == token_type)) do
+      nil -> -1
+      idx -> idx
+    end
+  end
+
+  @doc """
+  Return the bitmask for a list of modifier strings.
+
+  The LSP semantic tokens encoding represents modifiers as a bitmask:
+    - "declaration" -> bit 0 -> value 1
+    - "definition"  -> bit 1 -> value 2
+    - both          -> value 3 (bitwise OR)
+
+  Unknown modifiers are silently ignored.
+  """
+  @spec token_modifier_mask([String.t()]) :: non_neg_integer()
+  def token_modifier_mask(modifiers) do
+    legend = semantic_token_legend()
+    modifier_list = legend["tokenModifiers"]
+
+    Enum.reduce(modifiers, 0, fn modifier, mask ->
+      case Enum.find_index(modifier_list, &(&1 == modifier)) do
+        nil -> mask
+        idx -> Bitwise.bor(mask, Bitwise.bsl(1, idx))
+      end
+    end)
+  end
+
+  @doc """
+  Convert a list of SemanticToken structs to the LSP compact integer encoding.
+
+  ## The LSP Semantic Token Encoding
+
+  LSP encodes semantic tokens as a flat array of integers, grouped in 5-tuples:
+
+      [deltaLine, deltaStartChar, length, tokenTypeIndex, tokenModifierBitmask, ...]
+
+  Where "delta" means: the difference from the PREVIOUS token's position.
+  This delta encoding makes most values small (often 0 or 1), which compresses
+  well and is efficient to parse.
+
+  ## Example
+
+  Three tokens on different lines:
+
+      Token A: line=0, char=0, len=3, type="keyword",  modifiers=[]
+      Token B: line=0, char=4, len=5, type="function", modifiers=["declaration"]
+      Token C: line=1, char=0, len=8, type="variable", modifiers=[]
+
+  Encoded as:
+
+      [0, 0, 3, 15, 0,   # A: deltaLine=0, deltaChar=0
+       0, 4, 5, 12, 1,   # B: deltaLine=0, deltaChar=4
+       1, 0, 8,  8, 0]   # C: deltaLine=1, deltaChar=0
+
+  Note: when deltaLine > 0, deltaStartChar is relative to column 0 of the new
+  line (i.e., absolute for that line). When deltaLine == 0, deltaStartChar is
+  relative to the previous token's start character.
+  """
+  @spec encode_semantic_tokens([SemanticToken.t()]) :: [integer()]
+  def encode_semantic_tokens([]), do: []
+  def encode_semantic_tokens(nil), do: []
+
+  def encode_semantic_tokens(tokens) do
+    # Sort by (line, character) ascending. The delta encoding requires tokens
+    # to be in document order -- otherwise the deltas would be negative.
+    sorted =
+      tokens
+      |> Enum.sort_by(fn tok -> {tok.line, tok.character} end)
+
+    {data, _prev_line, _prev_char} =
+      Enum.reduce(sorted, {[], 0, 0}, fn tok, {acc, prev_line, prev_char} ->
+        type_idx = token_type_index(tok.token_type)
+
+        if type_idx == -1 do
+          # Unknown token type -- skip it.
+          {acc, prev_line, prev_char}
+        else
+          delta_line = tok.line - prev_line
+
+          delta_char =
+            if delta_line == 0 do
+              # Same line: character offset is relative to previous token.
+              tok.character - prev_char
+            else
+              # Different line: character offset is absolute (relative to line start).
+              tok.character
+            end
+
+          mod_mask = token_modifier_mask(tok.modifiers || [])
+
+          five_tuple = [delta_line, delta_char, tok.length, type_idx, mod_mask]
+          {acc ++ five_tuple, tok.line, tok.character}
+        end
+      end)
+
+    data
+  end
+end

--- a/code/packages/elixir/ls00/lib/ls00/document_manager.ex
+++ b/code/packages/elixir/ls00/lib/ls00/document_manager.ex
@@ -1,0 +1,272 @@
+defmodule Ls00.DocumentManager do
+  @moduledoc """
+  Tracks all files currently open in the editor.
+
+  ## The Document Manager's Job
+
+  When the user opens a file in VS Code, the editor sends a textDocument/didOpen
+  notification with the full file content. From that point on, the editor does
+  NOT re-send the entire file on every keystroke. Instead, it sends incremental
+  changes: what changed, and where. The DocumentManager applies these changes to
+  maintain the current text of each open file.
+
+      Editor opens file:   didOpen   -> DocumentManager stores text at version 1
+      User types "X":      didChange -> DocumentManager applies delta -> version 2
+      User saves:          didSave   -> (optional: trigger format)
+      User closes:         didClose  -> DocumentManager removes entry
+
+  ## Why Version Numbers?
+
+  The editor increments the version number with every change. The ParseCache
+  uses (uri, version) as its cache key -- if the version matches, the cached
+  parse result is still valid. This avoids re-parsing the file on every
+  keystroke when the user is just moving the cursor.
+
+  ## UTF-16: The Tricky Part
+
+  LSP specifies that character offsets are measured in UTF-16 CODE UNITS.
+  This is a historical accident: VS Code is built on TypeScript, which uses
+  UTF-16 strings internally (like Java and C#). Since LSP was designed for
+  VS Code, it inherited this convention.
+
+  Elixir strings are UTF-8. A single Unicode codepoint can occupy:
+    - 1 byte in UTF-8 (ASCII, e.g. 'A')
+    - 2 bytes in UTF-8 (e.g. 'e', U+00E9)
+    - 3 bytes in UTF-8 (e.g. the Chinese character for 'middle', U+4E2D)
+    - 4 bytes in UTF-8 (e.g. guitar emoji, U+1F3B8)
+
+  In UTF-16:
+    - Codepoints in the Basic Multilingual Plane (U+0000-U+FFFF) -> 1 code unit
+    - Codepoints above U+FFFF (emojis, rare CJK) -> 2 code units (a "surrogate pair")
+
+  The guitar emoji (U+1F3B8) is above U+FFFF:
+    UTF-8:  4 bytes  (0xF0 0x9F 0x8E 0xB8)
+    UTF-16: 2 code units (surrogate pair)
+
+  So if the LSP client says character=8 (UTF-16), we cannot simply slice 8 bytes
+  into the UTF-8 Elixir string. We must walk the UTF-8 bytes, converting each
+  codepoint to its UTF-16 length, accumulating until we reach code unit 8.
+  """
+
+  alias Ls00.Types.{Document, TextChange}
+
+  # ---------------------------------------------------------------------------
+  # Data structure
+  # ---------------------------------------------------------------------------
+  #
+  # We store documents as a map of uri -> Document struct. This is NOT a
+  # GenServer -- it is a plain data structure. The LspServer owns it and passes
+  # it through function calls. This keeps the design simple and testable.
+
+  @type t :: %{String.t() => Document.t()}
+
+  @doc """
+  Create an empty DocumentManager (just an empty map).
+  """
+  @spec new() :: t()
+  def new, do: %{}
+
+  @doc """
+  Record a newly opened file.
+
+  Called when the editor sends textDocument/didOpen. Stores the initial text
+  and version number (typically 1 for a freshly opened file).
+  """
+  @spec open(t(), String.t(), String.t(), integer()) :: t()
+  def open(docs, uri, text, version) do
+    Map.put(docs, uri, %Document{uri: uri, text: text, version: version})
+  end
+
+  @doc """
+  Apply a list of incremental changes to an open document.
+
+  Changes are applied in order. If a range is nil, the change replaces the
+  entire document. After all changes, the document's version is updated.
+
+  Returns `{:ok, updated_docs}` or `{:error, reason}`.
+  """
+  @spec apply_changes(t(), String.t(), [TextChange.t()], integer()) ::
+          {:ok, t()} | {:error, String.t()}
+  def apply_changes(docs, uri, changes, version) do
+    case Map.fetch(docs, uri) do
+      :error ->
+        {:error, "document not open: #{uri}"}
+
+      {:ok, %Document{} = doc} ->
+        case apply_changes_to_text(doc.text, changes) do
+          {:ok, new_text} ->
+            updated = %Document{doc | text: new_text, version: version}
+            {:ok, Map.put(docs, uri, updated)}
+
+          {:error, _} = err ->
+            err
+        end
+    end
+  end
+
+  @doc """
+  Get the document for a URI.
+
+  Returns `{:ok, document}` or `:error` if the document is not open.
+  """
+  @spec get(t(), String.t()) :: {:ok, Document.t()} | :error
+  def get(docs, uri) do
+    Map.fetch(docs, uri)
+  end
+
+  @doc """
+  Remove a document from the manager.
+
+  Called when the editor sends textDocument/didClose.
+  """
+  @spec close(t(), String.t()) :: t()
+  def close(docs, uri) do
+    Map.delete(docs, uri)
+  end
+
+  # ---------------------------------------------------------------------------
+  # UTF-16 offset conversion
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Convert a 0-based (line, UTF-16 character) position to a byte offset in a
+  UTF-8 Elixir string.
+
+  This is the most critical function in the entire package. If this function is
+  wrong, every feature that depends on cursor position will be wrong: hover,
+  go-to-definition, references, completion, rename, signature help.
+
+  ## Why UTF-16?
+
+  LSP character offsets are UTF-16 code units because VS Code's internal string
+  representation is UTF-16 (as is JavaScript's String type). This function
+  bridges the gap to Elixir's UTF-8 strings.
+
+  ## Algorithm
+
+  1. Walk line-by-line to find the byte offset of the start of the target line.
+  2. From that offset, walk UTF-8 codepoints, converting each to its UTF-16
+     length, until we reach the target UTF-16 character offset.
+
+  ## Example
+
+      iex> text = "hello \\xF0\\x9F\\x8E\\xB8 world"
+      iex> # guitar emoji (U+1F3B8) is 4 UTF-8 bytes but 2 UTF-16 code units
+      iex> convert_utf16_offset_to_byte_offset(text, 0, 8)
+      11
+  """
+  @spec convert_utf16_offset_to_byte_offset(String.t(), non_neg_integer(), non_neg_integer()) ::
+          non_neg_integer()
+  def convert_utf16_offset_to_byte_offset(text, line, char) do
+    # Phase 1: find the byte offset of the start of the target line.
+    line_start = find_line_start(text, line, 0, 0)
+
+    # Phase 2: from line_start, advance `char` UTF-16 code units.
+    advance_utf16_units(text, line_start, char, 0)
+  end
+
+  # Find the byte offset where line `target_line` begins.
+  # We scan through the binary looking for newline characters.
+  defp find_line_start(_text, 0, _current_line, byte_offset), do: byte_offset
+
+  defp find_line_start(text, target_line, current_line, byte_offset) do
+    remaining = binary_part_safe(text, byte_offset)
+
+    case remaining do
+      "" ->
+        # Past end of text -- clamp to end.
+        byte_size(text)
+
+      <<?\n, _rest::binary>> ->
+        # Found a newline. Advance to the next line.
+        find_line_start(text, target_line - 1, current_line + 1, byte_offset + 1)
+
+      _ ->
+        # Not a newline -- advance one byte in the binary. But we need to
+        # advance by the full codepoint width to not split multi-byte characters.
+        <<_codepoint::utf8, _rest::binary>> = remaining
+        cp_bytes = codepoint_byte_size(remaining)
+        find_line_start(text, target_line, current_line, byte_offset + cp_bytes)
+    end
+  end
+
+  # Advance `target_units` UTF-16 code units from `byte_offset`.
+  # Returns the final byte offset.
+  defp advance_utf16_units(_text, byte_offset, target_units, accumulated)
+       when accumulated >= target_units,
+       do: byte_offset
+
+  defp advance_utf16_units(text, byte_offset, target_units, accumulated) do
+    remaining = binary_part_safe(text, byte_offset)
+
+    case remaining do
+      "" ->
+        # Past end of text -- clamp.
+        byte_size(text)
+
+      <<?\n, _rest::binary>> ->
+        # Don't advance past the newline -- the position is beyond the line end.
+        byte_offset
+
+      _ ->
+        <<codepoint::utf8, _rest::binary>> = remaining
+        cp_bytes = codepoint_byte_size(remaining)
+        utf16_len = utf16_unit_length(codepoint)
+
+        # Check if adding this codepoint would overshoot the target.
+        if accumulated + utf16_len > target_units do
+          # Would overshoot (e.g., in the middle of a surrogate pair).
+          byte_offset
+        else
+          advance_utf16_units(text, byte_offset + cp_bytes, target_units, accumulated + utf16_len)
+        end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  # Apply a list of changes to a text string, in order.
+  defp apply_changes_to_text(text, []), do: {:ok, text}
+
+  defp apply_changes_to_text(_text, [%TextChange{range: nil, new_text: new_text} | rest]) do
+    # Full document replacement -- simplest case.
+    apply_changes_to_text(new_text, rest)
+  end
+
+  defp apply_changes_to_text(text, [%TextChange{range: range, new_text: new_text} | rest]) do
+    start_byte = convert_utf16_offset_to_byte_offset(text, range.start.line, range.start.character)
+    end_byte = convert_utf16_offset_to_byte_offset(text, range.end_pos.line, range.end_pos.character)
+
+    # Clamp end_byte to text length.
+    end_byte = min(end_byte, byte_size(text))
+
+    if start_byte > end_byte do
+      {:error, "start offset #{start_byte} > end offset #{end_byte}"}
+    else
+      prefix = binary_part(text, 0, start_byte)
+      suffix = binary_part(text, end_byte, byte_size(text) - end_byte)
+      new_text_full = prefix <> new_text <> suffix
+      apply_changes_to_text(new_text_full, rest)
+    end
+  end
+
+  # How many UTF-16 code units does this Unicode codepoint require?
+  #
+  # - Codepoints in the BMP (U+0000-U+FFFF): 1 code unit
+  # - Codepoints above U+FFFF (emoji, etc.): 2 code units (surrogate pair)
+  @doc false
+  def utf16_unit_length(codepoint) when codepoint > 0xFFFF, do: 2
+  def utf16_unit_length(_codepoint), do: 1
+
+  # Get the byte size of the first codepoint in a binary.
+  defp codepoint_byte_size(<<cp::utf8, rest::binary>>) do
+    total = byte_size(<<cp::utf8, rest::binary>>)
+    total - byte_size(rest)
+  end
+
+  # Safely get a sub-binary from byte_offset to end.
+  defp binary_part_safe(text, offset) when offset >= byte_size(text), do: ""
+  defp binary_part_safe(text, offset), do: binary_part(text, offset, byte_size(text) - offset)
+end

--- a/code/packages/elixir/ls00/lib/ls00/handlers.ex
+++ b/code/packages/elixir/ls00/lib/ls00/handlers.ex
@@ -1,0 +1,830 @@
+defmodule Ls00.Handlers do
+  @moduledoc """
+  All LSP handler functions.
+
+  This module contains the implementation of every LSP request and notification
+  handler. Each handler function takes a server state and the message parameters,
+  and returns `{result_or_nil, updated_state}`.
+
+  ## Handler Categories
+
+  ### Lifecycle (initialize, initialized, shutdown, exit)
+
+  Every LSP session begins with initialize and ends with shutdown+exit.
+
+  ### Text Document Sync (didOpen, didChange, didClose, didSave)
+
+  These four notifications form the core of document synchronization. The editor
+  sends them as the user opens, edits, and closes files.
+
+  ### Feature Requests (hover, definition, references, etc.)
+
+  These are conditional on bridge capability. Each handler checks whether the
+  bridge module exports the relevant callback before delegating.
+  """
+
+  alias Ls00.{Capabilities, DocumentManager, LspErrors, ParseCache}
+  alias Ls00.Types
+  alias Ls00.Types.Position
+  alias CodingAdventures.JsonRpc.Message.Notification
+  alias CodingAdventures.JsonRpc.Writer
+
+  # ---------------------------------------------------------------------------
+  # Server state
+  # ---------------------------------------------------------------------------
+  #
+  # We bundle all server state into a struct. This is passed through every
+  # handler and returned (possibly updated).
+
+  defstruct [
+    :bridge_module,
+    :writer,
+    doc_manager: DocumentManager.new(),
+    parse_cache: ParseCache.new(),
+    initialized: false,
+    shutdown: false
+  ]
+
+  @type t :: %__MODULE__{
+          bridge_module: module(),
+          writer: CodingAdventures.JsonRpc.Writer.t(),
+          doc_manager: DocumentManager.t(),
+          parse_cache: ParseCache.t(),
+          initialized: boolean(),
+          shutdown: boolean()
+        }
+
+  # ---------------------------------------------------------------------------
+  # initialize
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Handle the LSP initialize request.
+
+  Sets the initialized flag and returns capabilities built from the bridge module.
+  """
+  @spec handle_initialize(t(), any(), any()) :: {any(), t()}
+  def handle_initialize(state, _id, _params) do
+    state = %{state | initialized: true}
+    caps = Capabilities.build_capabilities(state.bridge_module)
+
+    result = %{
+      "capabilities" => caps,
+      "serverInfo" => %{
+        "name" => "ls00-generic-lsp-server",
+        "version" => "0.1.0"
+      }
+    }
+
+    {result, state}
+  end
+
+  # ---------------------------------------------------------------------------
+  # initialized
+  # ---------------------------------------------------------------------------
+
+  @doc "Handle the initialized notification. No-op: the handshake is complete."
+  @spec handle_initialized(t(), any()) :: t()
+  def handle_initialized(state, _params), do: state
+
+  # ---------------------------------------------------------------------------
+  # shutdown
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Handle the LSP shutdown request.
+
+  Sets the shutdown flag and returns nil (LSP spec requires null result).
+  """
+  @spec handle_shutdown(t(), any(), any()) :: {nil, t()}
+  def handle_shutdown(state, _id, _params) do
+    {nil, %{state | shutdown: true}}
+  end
+
+  # ---------------------------------------------------------------------------
+  # exit
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Handle the exit notification.
+
+  Exit code 0 if shutdown was received, 1 otherwise.
+  """
+  @spec handle_exit(t(), any()) :: t()
+  def handle_exit(state, _params) do
+    if state.shutdown do
+      System.halt(0)
+    else
+      System.halt(1)
+    end
+
+    state
+  end
+
+  # ---------------------------------------------------------------------------
+  # textDocument/didOpen
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Handle didOpen: register the document and publish diagnostics.
+
+  This is called when the editor opens a file. We store the text and parse it
+  immediately so the editor shows squiggles as soon as the file is opened.
+  """
+  @spec handle_did_open(t(), any()) :: t()
+  def handle_did_open(state, params) do
+    with td when is_map(td) <- get_in_safe(params, ["textDocument"]),
+         uri when is_binary(uri) <- td["uri"],
+         text when is_binary(text) <- td["text"] do
+      version = parse_int(td["version"], 1)
+
+      doc_manager = DocumentManager.open(state.doc_manager, uri, text, version)
+      {parse_result, parse_cache} =
+        ParseCache.get_or_parse(state.parse_cache, uri, version, text, state.bridge_module)
+
+      state = %{state | doc_manager: doc_manager, parse_cache: parse_cache}
+      publish_diagnostics(state, uri, version, parse_result.diagnostics)
+      state
+    else
+      _ -> state
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # textDocument/didChange
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Handle didChange: apply incremental changes and publish diagnostics.
+  """
+  @spec handle_did_change(t(), any()) :: t()
+  def handle_did_change(state, params) do
+    with p when is_map(p) <- params,
+         uri when is_binary(uri) <- parse_uri(p) do
+      version = parse_version(p)
+      changes = parse_content_changes(p)
+
+      case DocumentManager.apply_changes(state.doc_manager, uri, changes, version) do
+        {:ok, doc_manager} ->
+          state = %{state | doc_manager: doc_manager}
+
+          case DocumentManager.get(doc_manager, uri) do
+            {:ok, doc} ->
+              {parse_result, parse_cache} =
+                ParseCache.get_or_parse(
+                  state.parse_cache, uri, doc.version, doc.text, state.bridge_module
+                )
+
+              state = %{state | parse_cache: parse_cache}
+              publish_diagnostics(state, uri, version, parse_result.diagnostics)
+              state
+
+            :error ->
+              state
+          end
+
+        {:error, _reason} ->
+          state
+      end
+    else
+      _ -> state
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # textDocument/didClose
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Handle didClose: remove the document and clear diagnostics.
+  """
+  @spec handle_did_close(t(), any()) :: t()
+  def handle_did_close(state, params) do
+    uri = parse_uri(params)
+
+    if is_binary(uri) and uri != "" do
+      doc_manager = DocumentManager.close(state.doc_manager, uri)
+      parse_cache = ParseCache.evict(state.parse_cache, uri)
+      state = %{state | doc_manager: doc_manager, parse_cache: parse_cache}
+
+      # Clear diagnostics for the closed file.
+      publish_diagnostics(state, uri, 0, [])
+      state
+    else
+      state
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # textDocument/didSave
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Handle didSave: re-parse if the client sends full text.
+  """
+  @spec handle_did_save(t(), any()) :: t()
+  def handle_did_save(state, params) do
+    uri = parse_uri(params)
+
+    if is_binary(uri) and uri != "" do
+      case params do
+        %{"text" => text} when is_binary(text) and text != "" ->
+          case DocumentManager.get(state.doc_manager, uri) do
+            {:ok, doc} ->
+              doc_manager =
+                state.doc_manager
+                |> DocumentManager.close(uri)
+                |> DocumentManager.open(uri, text, doc.version)
+
+              {parse_result, parse_cache} =
+                ParseCache.get_or_parse(
+                  state.parse_cache, uri, doc.version, text, state.bridge_module
+                )
+
+              state = %{state | doc_manager: doc_manager, parse_cache: parse_cache}
+              publish_diagnostics(state, uri, doc.version, parse_result.diagnostics)
+              state
+
+            :error ->
+              state
+          end
+
+        _ ->
+          state
+      end
+    else
+      state
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # textDocument/hover
+  # ---------------------------------------------------------------------------
+
+  @doc "Handle hover request."
+  @spec handle_hover(t(), any(), any()) :: {any(), t()}
+  def handle_hover(state, _id, params) do
+    if not function_exported?(state.bridge_module, :hover, 2) do
+      {nil, state}
+    else
+      with {:ok, _uri, pos, _doc, parse_result, state} <- get_parse_for_request(state, params),
+           true <- parse_result.ast != nil do
+        case state.bridge_module.hover(parse_result.ast, pos) do
+          {:ok, nil} ->
+            {nil, state}
+
+          {:ok, hover_result} ->
+            result = %{
+              "contents" => %{
+                "kind" => "markdown",
+                "value" => hover_result.contents
+              }
+            }
+
+            result =
+              if hover_result.range do
+                Map.put(result, "range", range_to_lsp(hover_result.range))
+              else
+                result
+              end
+
+            {result, state}
+
+          {:error, _reason} ->
+            {nil, state}
+        end
+      else
+        _ -> {nil, state}
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # textDocument/definition
+  # ---------------------------------------------------------------------------
+
+  @doc "Handle definition request."
+  @spec handle_definition(t(), any(), any()) :: {any(), t()}
+  def handle_definition(state, _id, params) do
+    if not function_exported?(state.bridge_module, :definition, 3) do
+      {nil, state}
+    else
+      with {:ok, uri, pos, _doc, parse_result, state} <- get_parse_for_request(state, params),
+           true <- parse_result.ast != nil do
+        case state.bridge_module.definition(parse_result.ast, pos, uri) do
+          {:ok, nil} -> {nil, state}
+          {:ok, location} -> {location_to_lsp(location), state}
+          {:error, _} -> {nil, state}
+        end
+      else
+        _ -> {nil, state}
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # textDocument/references
+  # ---------------------------------------------------------------------------
+
+  @doc "Handle references request."
+  @spec handle_references(t(), any(), any()) :: {any(), t()}
+  def handle_references(state, _id, params) do
+    if not function_exported?(state.bridge_module, :references, 4) do
+      {[], state}
+    else
+      with {:ok, uri, pos, _doc, parse_result, state} <- get_parse_for_request(state, params) do
+        if parse_result.ast == nil do
+          {[], state}
+        else
+          include_decl = get_in_safe(params, ["context", "includeDeclaration"]) == true
+
+          case state.bridge_module.references(parse_result.ast, pos, uri, include_decl) do
+            {:ok, locations} ->
+              {Enum.map(locations, &location_to_lsp/1), state}
+
+            {:error, _} ->
+              {[], state}
+          end
+        end
+      else
+        _ -> {[], state}
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # textDocument/completion
+  # ---------------------------------------------------------------------------
+
+  @doc "Handle completion request."
+  @spec handle_completion(t(), any(), any()) :: {any(), t()}
+  def handle_completion(state, _id, params) do
+    empty_result = %{"isIncomplete" => false, "items" => []}
+
+    if not function_exported?(state.bridge_module, :completion, 2) do
+      {empty_result, state}
+    else
+      with {:ok, _uri, pos, _doc, parse_result, state} <- get_parse_for_request(state, params) do
+        if parse_result.ast == nil do
+          {empty_result, state}
+        else
+          case state.bridge_module.completion(parse_result.ast, pos) do
+            {:ok, items} ->
+              lsp_items =
+                Enum.map(items, fn item ->
+                  ci = %{"label" => item.label}
+                  ci = if item.kind, do: Map.put(ci, "kind", item.kind), else: ci
+                  ci = if item.detail, do: Map.put(ci, "detail", item.detail), else: ci
+                  ci = if item.documentation, do: Map.put(ci, "documentation", item.documentation), else: ci
+                  ci = if item.insert_text, do: Map.put(ci, "insertText", item.insert_text), else: ci
+                  ci = if item.insert_text_format, do: Map.put(ci, "insertTextFormat", item.insert_text_format), else: ci
+                  ci
+                end)
+
+              {%{"isIncomplete" => false, "items" => lsp_items}, state}
+
+            {:error, _} ->
+              {empty_result, state}
+          end
+        end
+      else
+        _ -> {empty_result, state}
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # textDocument/rename
+  # ---------------------------------------------------------------------------
+
+  @doc "Handle rename request."
+  @spec handle_rename(t(), any(), any()) :: {any(), t()}
+  def handle_rename(state, _id, params) do
+    if not function_exported?(state.bridge_module, :rename, 3) do
+      error = %{code: LspErrors.request_failed(), message: "rename not supported"}
+      {error, state}
+    else
+      new_name = get_in_safe(params, ["newName"])
+
+      if not is_binary(new_name) or new_name == "" do
+        error = %{code: CodingAdventures.JsonRpc.Errors.invalid_params(), message: "newName is required"}
+        {error, state}
+      else
+        with {:ok, _uri, pos, _doc, parse_result, state} <- get_parse_for_request(state, params) do
+          if parse_result.ast == nil do
+            error = %{code: LspErrors.request_failed(), message: "no AST available"}
+            {error, state}
+          else
+            case state.bridge_module.rename(parse_result.ast, pos, new_name) do
+              {:ok, nil} ->
+                error = %{code: LspErrors.request_failed(), message: "symbol not found at position"}
+                {error, state}
+
+              {:ok, workspace_edit} ->
+                lsp_changes =
+                  workspace_edit.changes
+                  |> Enum.map(fn {edit_uri, edits} ->
+                    lsp_edits =
+                      Enum.map(edits, fn te ->
+                        %{
+                          "range" => range_to_lsp(te.range),
+                          "newText" => te.new_text
+                        }
+                      end)
+                    {edit_uri, lsp_edits}
+                  end)
+                  |> Map.new()
+
+                {%{"changes" => lsp_changes}, state}
+
+              {:error, reason} ->
+                error = %{code: LspErrors.request_failed(), message: reason}
+                {error, state}
+            end
+          end
+        else
+          _ ->
+            error = %{code: LspErrors.request_failed(), message: "document not open"}
+            {error, state}
+        end
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # textDocument/documentSymbol
+  # ---------------------------------------------------------------------------
+
+  @doc "Handle documentSymbol request."
+  @spec handle_document_symbol(t(), any(), any()) :: {any(), t()}
+  def handle_document_symbol(state, _id, params) do
+    if not function_exported?(state.bridge_module, :document_symbols, 1) do
+      {[], state}
+    else
+      with {:ok, _uri, _pos, _doc, parse_result, state} <- get_parse_for_request(state, params) do
+        if parse_result.ast == nil do
+          {[], state}
+        else
+          case state.bridge_module.document_symbols(parse_result.ast) do
+            {:ok, symbols} ->
+              {convert_document_symbols(symbols), state}
+
+            {:error, _} ->
+              {[], state}
+          end
+        end
+      else
+        _ -> {[], state}
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # textDocument/semanticTokens/full
+  # ---------------------------------------------------------------------------
+
+  @doc "Handle semanticTokens/full request."
+  @spec handle_semantic_tokens_full(t(), any(), any()) :: {any(), t()}
+  def handle_semantic_tokens_full(state, _id, params) do
+    empty = %{"data" => []}
+
+    if not function_exported?(state.bridge_module, :semantic_tokens, 2) do
+      {empty, state}
+    else
+      uri = parse_uri(params)
+
+      case DocumentManager.get(state.doc_manager, uri) do
+        :error ->
+          {empty, state}
+
+        {:ok, doc} ->
+          case state.bridge_module.tokenize(doc.text) do
+            {:ok, tokens} ->
+              case state.bridge_module.semantic_tokens(doc.text, tokens) do
+                {:ok, sem_tokens} ->
+                  data = Capabilities.encode_semantic_tokens(sem_tokens)
+                  {%{"data" => data}, state}
+
+                {:error, _} ->
+                  {empty, state}
+              end
+
+            {:error, _} ->
+              {empty, state}
+          end
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # textDocument/foldingRange
+  # ---------------------------------------------------------------------------
+
+  @doc "Handle foldingRange request."
+  @spec handle_folding_range(t(), any(), any()) :: {any(), t()}
+  def handle_folding_range(state, _id, params) do
+    if not function_exported?(state.bridge_module, :folding_ranges, 1) do
+      {[], state}
+    else
+      with {:ok, _uri, _pos, _doc, parse_result, state} <- get_parse_for_request(state, params) do
+        if parse_result.ast == nil do
+          {[], state}
+        else
+          case state.bridge_module.folding_ranges(parse_result.ast) do
+            {:ok, ranges} ->
+              result =
+                Enum.map(ranges, fn fr ->
+                  m = %{"startLine" => fr.start_line, "endLine" => fr.end_line}
+                  if fr.kind, do: Map.put(m, "kind", fr.kind), else: m
+                end)
+
+              {result, state}
+
+            {:error, _} ->
+              {[], state}
+          end
+        end
+      else
+        _ -> {[], state}
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # textDocument/signatureHelp
+  # ---------------------------------------------------------------------------
+
+  @doc "Handle signatureHelp request."
+  @spec handle_signature_help(t(), any(), any()) :: {any(), t()}
+  def handle_signature_help(state, _id, params) do
+    if not function_exported?(state.bridge_module, :signature_help, 2) do
+      {nil, state}
+    else
+      with {:ok, _uri, pos, _doc, parse_result, state} <- get_parse_for_request(state, params) do
+        if parse_result.ast == nil do
+          {nil, state}
+        else
+          case state.bridge_module.signature_help(parse_result.ast, pos) do
+            {:ok, nil} ->
+              {nil, state}
+
+            {:ok, sig_help} ->
+              lsp_sigs =
+                Enum.map(sig_help.signatures, fn sig ->
+                  lsp_params =
+                    Enum.map(sig.parameters, fn param ->
+                      pp = %{"label" => param.label}
+                      if param.documentation, do: Map.put(pp, "documentation", param.documentation), else: pp
+                    end)
+
+                  s = %{"label" => sig.label, "parameters" => lsp_params}
+                  if sig.documentation, do: Map.put(s, "documentation", sig.documentation), else: s
+                end)
+
+              result = %{
+                "signatures" => lsp_sigs,
+                "activeSignature" => sig_help.active_signature,
+                "activeParameter" => sig_help.active_parameter
+              }
+
+              {result, state}
+
+            {:error, _} ->
+              {nil, state}
+          end
+        end
+      else
+        _ -> {nil, state}
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # textDocument/formatting
+  # ---------------------------------------------------------------------------
+
+  @doc "Handle formatting request."
+  @spec handle_formatting(t(), any(), any()) :: {any(), t()}
+  def handle_formatting(state, _id, params) do
+    if not function_exported?(state.bridge_module, :format, 1) do
+      {[], state}
+    else
+      uri = parse_uri(params)
+
+      case DocumentManager.get(state.doc_manager, uri) do
+        :error ->
+          {[], state}
+
+        {:ok, doc} ->
+          case state.bridge_module.format(doc.text) do
+            {:ok, edits} ->
+              lsp_edits =
+                Enum.map(edits, fn edit ->
+                  %{
+                    "range" => range_to_lsp(edit.range),
+                    "newText" => edit.new_text
+                  }
+                end)
+
+              {lsp_edits, state}
+
+            {:error, reason} ->
+              error = %{code: LspErrors.request_failed(), message: "formatting failed: #{reason}"}
+              {error, state}
+          end
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  # Get parse result for a request that includes textDocument/uri and position.
+  defp get_parse_for_request(state, params) do
+    uri = parse_uri(params)
+    pos = parse_position(params)
+
+    case DocumentManager.get(state.doc_manager, uri) do
+      :error ->
+        :error
+
+      {:ok, doc} ->
+        {parse_result, parse_cache} =
+          ParseCache.get_or_parse(
+            state.parse_cache, uri, doc.version, doc.text, state.bridge_module
+          )
+
+        state = %{state | parse_cache: parse_cache}
+        {:ok, uri, pos, doc, parse_result, state}
+    end
+  end
+
+  # Publish diagnostics notification to the editor.
+  #
+  # We wrap the Writer call in a try/rescue because on OTP 27 the `:json`
+  # module returns iodata (not a binary) from `encode/1`, and the json_rpc
+  # Writer's `write_raw/2` has a `when is_binary(json)` guard that rejects
+  # iodata. This is a known issue in the json_rpc package on OTP 27.
+  # Rather than failing silently, we catch the error and fall back to
+  # writing the notification directly.
+  defp publish_diagnostics(state, uri, version, diagnostics) do
+    lsp_diags =
+      Enum.map(diagnostics, fn d ->
+        diag = %{
+          "range" => range_to_lsp(d.range),
+          "severity" => d.severity,
+          "message" => d.message
+        }
+
+        if d.code, do: Map.put(diag, "code", d.code), else: diag
+      end)
+
+    params = %{"uri" => uri, "diagnostics" => lsp_diags}
+    params = if version > 0, do: Map.put(params, "version", version), else: params
+
+    notif = %Notification{method: "textDocument/publishDiagnostics", params: params}
+
+    try do
+      Writer.write_message(state.writer, notif)
+    rescue
+      FunctionClauseError ->
+        # Fallback for OTP 27 iodata issue: manually encode and write.
+        map = CodingAdventures.JsonRpc.Message.message_to_map(notif)
+        json = encode_to_binary(map)
+        header = "Content-Length: #{byte_size(json)}\r\n\r\n"
+        IO.binwrite(state.writer.device, header <> json)
+    end
+  end
+
+  # Encode a map to a JSON binary string, handling OTP 27's iodata return.
+  defp encode_to_binary(map) do
+    try do
+      result = :json.encode(map)
+      IO.iodata_to_binary(result)
+    rescue
+      e ->
+        IO.warn("ls00: JSON encoding failed: #{inspect(e)}")
+        "{}"
+    end
+  end
+
+  # Extract URI from params.
+  defp parse_uri(params) when is_map(params) do
+    case params do
+      %{"textDocument" => %{"uri" => uri}} when is_binary(uri) -> uri
+      _ -> ""
+    end
+  end
+
+  defp parse_uri(_), do: ""
+
+  # Extract position from params.
+  defp parse_position(params) when is_map(params) do
+    case params do
+      %{"position" => %{"line" => line, "character" => char}} ->
+        %Position{line: to_int(line), character: to_int(char)}
+
+      _ ->
+        %Position{line: 0, character: 0}
+    end
+  end
+
+  defp parse_position(_), do: %Position{line: 0, character: 0}
+
+  # Extract version from textDocument params.
+  defp parse_version(params) do
+    case params do
+      %{"textDocument" => %{"version" => v}} -> to_int(v)
+      _ -> 0
+    end
+  end
+
+  # Parse contentChanges array from didChange params.
+  defp parse_content_changes(params) do
+    changes_raw = params["contentChanges"] || []
+
+    Enum.flat_map(changes_raw, fn
+      %{"text" => new_text} = change_map when is_binary(new_text) ->
+        change =
+          case change_map["range"] do
+            nil ->
+              %Types.TextChange{new_text: new_text}
+
+            range_map ->
+              range = parse_lsp_range(range_map)
+              %Types.TextChange{range: range, new_text: new_text}
+          end
+
+        [change]
+
+      _ ->
+        []
+    end)
+  end
+
+  # Parse an LSP range map into our Range struct.
+  defp parse_lsp_range(map) when is_map(map) do
+    start_map = map["start"] || %{}
+    end_map = map["end"] || %{}
+
+    %Types.Range{
+      start: %Position{
+        line: to_int(start_map["line"]),
+        character: to_int(start_map["character"])
+      },
+      end_pos: %Position{
+        line: to_int(end_map["line"]),
+        character: to_int(end_map["character"])
+      }
+    }
+  end
+
+  # Convert our Position to an LSP-compatible map.
+  defp position_to_lsp(%Position{line: line, character: char}) do
+    %{"line" => line, "character" => char}
+  end
+
+  # Convert our Range to an LSP-compatible map.
+  defp range_to_lsp(%Types.Range{start: s, end_pos: e}) do
+    %{"start" => position_to_lsp(s), "end" => position_to_lsp(e)}
+  end
+
+  # Convert a Location to an LSP-compatible map.
+  defp location_to_lsp(%Types.Location{uri: uri, range: range}) do
+    %{"uri" => uri, "range" => range_to_lsp(range)}
+  end
+
+  # Recursively convert DocumentSymbol list to LSP maps.
+  defp convert_document_symbols(symbols) do
+    Enum.map(symbols, fn sym ->
+      m = %{
+        "name" => sym.name,
+        "kind" => sym.kind,
+        "range" => range_to_lsp(sym.range),
+        "selectionRange" => range_to_lsp(sym.selection_range)
+      }
+
+      if length(sym.children) > 0 do
+        Map.put(m, "children", convert_document_symbols(sym.children))
+      else
+        m
+      end
+    end)
+  end
+
+  # Safely navigate nested maps (like Kernel.get_in but tolerant of non-maps).
+  defp get_in_safe(data, []) when is_map(data), do: data
+  defp get_in_safe(data, [key | rest]) when is_map(data), do: get_in_safe(data[key], rest)
+  defp get_in_safe(value, []), do: value
+  defp get_in_safe(_, _), do: nil
+
+  # Parse integer from potentially float JSON values.
+  defp to_int(v) when is_integer(v), do: v
+  defp to_int(v) when is_float(v), do: trunc(v)
+  defp to_int(_), do: 0
+
+  defp parse_int(v, _default) when is_integer(v), do: v
+  defp parse_int(v, _default) when is_float(v), do: trunc(v)
+  defp parse_int(_, default), do: default
+end

--- a/code/packages/elixir/ls00/lib/ls00/language_bridge.ex
+++ b/code/packages/elixir/ls00/lib/ls00/language_bridge.ex
@@ -1,0 +1,176 @@
+defmodule Ls00.LanguageBridge do
+  @moduledoc """
+  The behaviour that every language bridge must implement.
+
+  ## Design Philosophy: Narrow Interfaces
+
+  Elixir's `@behaviour` + `@optional_callbacks` mechanism serves the same purpose
+  as Go's narrow interfaces. The LanguageBridge behaviour requires only two
+  callbacks: `tokenize/1` and `parse/1`. All other features (hover,
+  go-to-definition, etc.) are optional and declared as `@optional_callbacks`.
+
+  At runtime, the server checks whether the bridge module exports the optional
+  callbacks:
+
+      if function_exported?(bridge_module, :hover, 2) do
+        bridge_module.hover(ast, pos)
+      end
+
+  This matches the LSP spec's philosophy: capabilities are advertised, not
+  assumed. An editor won't even try to ask for hover if the server didn't
+  advertise it. The result is that a phase-1 bridge (lexer+parser only) works
+  perfectly without stubs.
+
+  ## Required Callbacks
+
+  - `tokenize/1` -- lex the source string and return a token stream
+  - `parse/1` -- parse the source string and return an AST + diagnostics
+
+  ## Optional Callbacks
+
+  Each optional callback corresponds to one LSP feature. A bridge implements
+  only the features its language supports.
+
+  | Callback            | LSP Feature                        |
+  |---------------------|------------------------------------|
+  | `hover/2`           | Hover tooltips                     |
+  | `definition/3`      | Go to Definition (F12)             |
+  | `references/4`      | Find All References                |
+  | `completion/2`      | Autocomplete                       |
+  | `rename/3`          | Symbol rename (F2)                 |
+  | `semantic_tokens/2` | Semantic syntax highlighting       |
+  | `document_symbols/1`| Document outline panel             |
+  | `folding_ranges/1`  | Code folding                       |
+  | `signature_help/2`  | Function signature hints           |
+  | `format/1`          | Document formatting                |
+  """
+
+  alias Ls00.Types
+
+  # ---------------------------------------------------------------------------
+  # Required callbacks
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Lex the source string and return the token stream.
+
+  Each Token carries a type string (e.g. "KEYWORD", "IDENTIFIER"), its value,
+  and its 1-based line and column position. The bridge is responsible for
+  converting 1-based positions to 0-based before building SemanticToken values.
+  """
+  @callback tokenize(source :: String.t()) ::
+              {:ok, [Types.Token.t()]} | {:error, String.t()}
+
+  @doc """
+  Parse the source string and return:
+    - `ast` -- the parsed abstract syntax tree (may be partial on error)
+    - `diagnostics` -- parse errors and warnings as Diagnostic structs
+    - or an `{:error, reason}` tuple for fatal failures
+
+  Even when there are syntax errors, `parse/1` should return a partial AST.
+  This allows hover, folding, and symbol features to continue working on
+  the valid portions of the file.
+  """
+  @callback parse(source :: String.t()) ::
+              {:ok, any(), [Types.Diagnostic.t()]} | {:error, String.t()}
+
+  # ---------------------------------------------------------------------------
+  # Optional callbacks
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Return hover information for the AST node at the given position.
+
+  Returns `{:ok, hover_result}` with content to display, `{:ok, nil}` if there
+  is no hover info at this position, or `{:error, reason}` if something went wrong.
+  """
+  @callback hover(ast :: any(), pos :: Types.Position.t()) ::
+              {:ok, Types.HoverResult.t() | nil} | {:error, String.t()}
+
+  @doc """
+  Return the location where the symbol at `pos` was declared.
+
+  Returns `{:ok, location}`, `{:ok, nil}` if the symbol is not found, or
+  `{:error, reason}`.
+  """
+  @callback definition(ast :: any(), pos :: Types.Position.t(), uri :: String.t()) ::
+              {:ok, Types.Location.t() | nil} | {:error, String.t()}
+
+  @doc """
+  Return all uses of the symbol at `pos`.
+
+  `include_decl`: if true, include the declaration location in the results.
+  """
+  @callback references(
+              ast :: any(),
+              pos :: Types.Position.t(),
+              uri :: String.t(),
+              include_decl :: boolean()
+            ) ::
+              {:ok, [Types.Location.t()]} | {:error, String.t()}
+
+  @doc """
+  Return autocomplete suggestions valid at `pos`.
+  """
+  @callback completion(ast :: any(), pos :: Types.Position.t()) ::
+              {:ok, [Types.CompletionItem.t()]} | {:error, String.t()}
+
+  @doc """
+  Return the set of text edits needed to rename the symbol at `pos` to `new_name`.
+  """
+  @callback rename(ast :: any(), pos :: Types.Position.t(), new_name :: String.t()) ::
+              {:ok, Types.WorkspaceEdit.t() | nil} | {:error, String.t()}
+
+  @doc """
+  Return semantic token data for the whole document.
+
+  `tokens` is the output of `tokenize/1` -- the bridge should use these rather
+  than re-lexing. The returned SemanticTokens must be sorted by line, then
+  by character (ascending), because the LSP encoding is delta-based.
+  """
+  @callback semantic_tokens(source :: String.t(), tokens :: [Types.Token.t()]) ::
+              {:ok, [Types.SemanticToken.t()]} | {:error, String.t()}
+
+  @doc """
+  Return the outline tree for the given AST.
+  """
+  @callback document_symbols(ast :: any()) ::
+              {:ok, [Types.DocumentSymbol.t()]} | {:error, String.t()}
+
+  @doc """
+  Return collapsible regions derived from the AST structure.
+  """
+  @callback folding_ranges(ast :: any()) ::
+              {:ok, [Types.FoldingRange.t()]} | {:error, String.t()}
+
+  @doc """
+  Return signature hint information for the call at `pos`.
+
+  Returns `{:ok, result}`, `{:ok, nil}` if not inside a call expression, or
+  `{:error, reason}`.
+  """
+  @callback signature_help(ast :: any(), pos :: Types.Position.t()) ::
+              {:ok, Types.SignatureHelpResult.t() | nil} | {:error, String.t()}
+
+  @doc """
+  Return the text edits needed to format the document.
+
+  Typically this is a single edit replacing the entire file with the formatted
+  content.
+  """
+  @callback format(source :: String.t()) ::
+              {:ok, [Types.TextEdit.t()]} | {:error, String.t()}
+
+  @optional_callbacks [
+    hover: 2,
+    definition: 3,
+    references: 4,
+    completion: 2,
+    rename: 3,
+    semantic_tokens: 2,
+    document_symbols: 1,
+    folding_ranges: 1,
+    signature_help: 2,
+    format: 1
+  ]
+end

--- a/code/packages/elixir/ls00/lib/ls00/lsp_errors.ex
+++ b/code/packages/elixir/ls00/lib/ls00/lsp_errors.ex
@@ -1,0 +1,51 @@
+defmodule Ls00.LspErrors do
+  @moduledoc """
+  LSP-specific error codes.
+
+  The JSON-RPC 2.0 specification reserves error codes in the range [-32768, -32000].
+  The LSP specification further reserves [-32899, -32800] for LSP protocol-level
+  errors.
+
+  Standard JSON-RPC error codes (from the json_rpc package):
+
+  | Code   | Name              |
+  |--------|-------------------|
+  | -32700 | ParseError        |
+  | -32600 | InvalidRequest    |
+  | -32601 | MethodNotFound    |
+  | -32602 | InvalidParams     |
+  | -32603 | InternalError     |
+
+  LSP-specific error codes are listed below.
+
+  Reference:
+  https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#errorCodes
+  """
+
+  @doc """
+  The server has received a request before the initialize handshake was
+  completed (-32002).
+  """
+  def server_not_initialized, do: -32002
+
+  @doc "A generic error code for unknown errors (-32001)."
+  def unknown_error_code, do: -32001
+
+  @doc """
+  A request failed but not due to a protocol problem (-32803). For example,
+  the document requested was not found.
+  """
+  def request_failed, do: -32803
+
+  @doc "The server cancelled the request (-32802)."
+  def server_cancelled, do: -32802
+
+  @doc """
+  The document content was modified before the request completed (-32801).
+  The client should retry.
+  """
+  def content_modified, do: -32801
+
+  @doc "The client cancelled the request (-32800)."
+  def request_cancelled, do: -32800
+end

--- a/code/packages/elixir/ls00/lib/ls00/parse_cache.ex
+++ b/code/packages/elixir/ls00/lib/ls00/parse_cache.ex
@@ -1,0 +1,91 @@
+defmodule Ls00.ParseCache do
+  @moduledoc """
+  Avoid re-parsing unchanged documents.
+
+  ## Why Cache Parse Results?
+
+  Parsing is the most expensive operation in a language server. For a large
+  file, parsing on every keystroke would lag the editor noticeably.
+
+  The LSP protocol helps by sending a version number with every change. If the
+  document hasn't changed (same URI, same version), the parse result from the
+  previous keystroke is still valid.
+
+  ## Cache Key Design
+
+  The cache key is `{uri, version}`. Version is a monotonically increasing
+  integer that the editor increments with each change. Using version in the key
+  means:
+
+    - Same `{uri, version}` -> cache hit -> return cached result
+    - Different version -> cache miss -> re-parse and cache new result
+
+  The old entry is evicted when a new version is cached for the same URI.
+  This keeps memory bounded at O(open_documents) entries.
+
+  ## Implementation
+
+  The cache is a plain map (not a GenServer). The LspServer owns it and
+  passes it through function calls. This keeps the design simple and testable.
+  """
+
+  alias Ls00.Types.ParseResult
+
+  @type cache_key :: {String.t(), integer()}
+  @type t :: %{cache_key() => ParseResult.t()}
+
+  @doc "Create an empty ParseCache."
+  @spec new() :: t()
+  def new, do: %{}
+
+  @doc """
+  Return the parse result for `{uri, version}`.
+
+  If the result is already cached, it is returned immediately without calling
+  the bridge again. Otherwise, `bridge_module.parse(source)` is called, the
+  result is stored, and the previous cache entry for this URI (if any) is
+  evicted to prevent unbounded growth.
+
+  Returns `{parse_result, updated_cache}`.
+  """
+  @spec get_or_parse(t(), String.t(), integer(), String.t(), module()) ::
+          {ParseResult.t(), t()}
+  def get_or_parse(cache, uri, version, source, bridge_module) do
+    key = {uri, version}
+
+    case Map.fetch(cache, key) do
+      {:ok, result} ->
+        # Cache hit: the document hasn't changed since last parse.
+        {result, cache}
+
+      :error ->
+        # Cache miss: parse and store. Evict any stale entry for this URI first.
+        cache = evict(cache, uri)
+
+        result =
+          case bridge_module.parse(source) do
+            {:ok, ast, diags} ->
+              # Normalize nil diagnostics list to empty list for JSON encoding.
+              diags = diags || []
+              %ParseResult{ast: ast, diagnostics: diags}
+
+            {:error, reason} ->
+              %ParseResult{ast: nil, diagnostics: [], err: reason}
+          end
+
+        {result, Map.put(cache, key, result)}
+    end
+  end
+
+  @doc """
+  Remove all cached entries for a given URI.
+
+  Called when a document is closed (didClose) so the cache entry is cleaned up.
+  """
+  @spec evict(t(), String.t()) :: t()
+  def evict(cache, uri) do
+    cache
+    |> Enum.reject(fn {{cached_uri, _version}, _result} -> cached_uri == uri end)
+    |> Map.new()
+  end
+end

--- a/code/packages/elixir/ls00/lib/ls00/server.ex
+++ b/code/packages/elixir/ls00/lib/ls00/server.ex
@@ -1,0 +1,200 @@
+defmodule Ls00.Server do
+  @moduledoc """
+  LspServer -- the main coordinator that wires everything together.
+
+  The server connects:
+    - The `Ls00.LanguageBridge` behaviour (language-specific logic)
+    - The `Ls00.DocumentManager` (tracks open file contents)
+    - The `Ls00.ParseCache` (avoids redundant parses)
+    - The `CodingAdventures.JsonRpc.Server` (protocol layer)
+
+  It registers all LSP request and notification handlers with the JSON-RPC
+  server, then calls `serve/1` to start the blocking read-dispatch-write loop.
+
+  ## Server Lifecycle
+
+      Client (editor)              Server (us)
+        |                               |
+        |--initialize-------------->    |  store clientInfo, return capabilities
+        | <-----------------result--    |
+        |                               |
+        |--initialized (notif)----->    |  no-op (handshake complete)
+        |                               |
+        |--textDocument/didOpen---->    |  open doc, parse, push diagnostics
+        |--textDocument/didChange-->    |  apply change, re-parse, push diagnostics
+        |--textDocument/hover------>    |  get parse result, call bridge.hover
+        | <-----------------result--    |
+        |                               |
+        |--shutdown---------------->    |  set shutdown flag, return null
+        |--exit (notif)------------>    |  System.halt(0) or System.halt(1)
+
+  ## Sending Notifications to the Editor
+
+  The JSON-RPC Server handles request/response pairs. But the LSP server also
+  needs to PUSH notifications to the editor (e.g., publishDiagnostics). We do
+  this by holding a reference to the JSON-RPC MessageWriter.
+
+  ## Usage
+
+      server = Ls00.Server.new(MyBridge, :stdio, :stdio)
+      Ls00.Server.serve(server)   # blocks until EOF
+  """
+
+  alias Ls00.Handlers
+  alias CodingAdventures.JsonRpc
+
+  @doc """
+  Create a new LspServer that reads from `in_device` and writes to `out_device`.
+
+  `bridge_module` is a module that implements the `Ls00.LanguageBridge` behaviour.
+
+  ## Example
+
+      server = Ls00.Server.new(MyBridge, :stdio, :stdio)
+  """
+  @spec new(module(), any(), any()) :: JsonRpc.Server.t()
+  def new(bridge_module, in_device, out_device) do
+    writer = JsonRpc.Writer.new(out_device)
+
+    # Initialize the handler state. This bundles document manager, parse cache,
+    # and server flags into one struct that is threaded through every handler.
+    handler_state = %Handlers{
+      bridge_module: bridge_module,
+      writer: writer
+    }
+
+    # We store the handler state in a mutable reference (Agent) so the JSON-RPC
+    # server's stateless handler closures can update it. The JSON-RPC server
+    # expects `fn(id, params) -> result` for request handlers and
+    # `fn(params) -> :ok` for notification handlers. We close over the Agent
+    # pid to thread state through these closures.
+    {:ok, agent} = Agent.start_link(fn -> handler_state end)
+
+    rpc_server = JsonRpc.Server.new(in_device, out_device)
+
+    # ── Lifecycle ──────────────────────────────────────────────────────────
+    rpc_server = JsonRpc.Server.on_request(rpc_server, "initialize", fn id, params ->
+      Agent.get_and_update(agent, fn state ->
+        {result, new_state} = Handlers.handle_initialize(state, id, params)
+        {result, new_state}
+      end)
+    end)
+
+    rpc_server = JsonRpc.Server.on_notification(rpc_server, "initialized", fn params ->
+      Agent.update(agent, fn state ->
+        Handlers.handle_initialized(state, params)
+      end)
+    end)
+
+    rpc_server = JsonRpc.Server.on_request(rpc_server, "shutdown", fn id, params ->
+      Agent.get_and_update(agent, fn state ->
+        {result, new_state} = Handlers.handle_shutdown(state, id, params)
+        {result, new_state}
+      end)
+    end)
+
+    rpc_server = JsonRpc.Server.on_notification(rpc_server, "exit", fn params ->
+      Agent.update(agent, fn state ->
+        Handlers.handle_exit(state, params)
+      end)
+    end)
+
+    # ── Text document synchronization ──────────────────────────────────────
+    rpc_server = JsonRpc.Server.on_notification(rpc_server, "textDocument/didOpen", fn params ->
+      Agent.update(agent, fn state ->
+        Handlers.handle_did_open(state, params)
+      end)
+    end)
+
+    rpc_server = JsonRpc.Server.on_notification(rpc_server, "textDocument/didChange", fn params ->
+      Agent.update(agent, fn state ->
+        Handlers.handle_did_change(state, params)
+      end)
+    end)
+
+    rpc_server = JsonRpc.Server.on_notification(rpc_server, "textDocument/didClose", fn params ->
+      Agent.update(agent, fn state ->
+        Handlers.handle_did_close(state, params)
+      end)
+    end)
+
+    rpc_server = JsonRpc.Server.on_notification(rpc_server, "textDocument/didSave", fn params ->
+      Agent.update(agent, fn state ->
+        Handlers.handle_did_save(state, params)
+      end)
+    end)
+
+    # ── Feature requests ───────────────────────────────────────────────────
+    rpc_server = JsonRpc.Server.on_request(rpc_server, "textDocument/hover", fn id, params ->
+      Agent.get_and_update(agent, fn state ->
+        Handlers.handle_hover(state, id, params)
+      end)
+    end)
+
+    rpc_server = JsonRpc.Server.on_request(rpc_server, "textDocument/definition", fn id, params ->
+      Agent.get_and_update(agent, fn state ->
+        Handlers.handle_definition(state, id, params)
+      end)
+    end)
+
+    rpc_server = JsonRpc.Server.on_request(rpc_server, "textDocument/references", fn id, params ->
+      Agent.get_and_update(agent, fn state ->
+        Handlers.handle_references(state, id, params)
+      end)
+    end)
+
+    rpc_server = JsonRpc.Server.on_request(rpc_server, "textDocument/completion", fn id, params ->
+      Agent.get_and_update(agent, fn state ->
+        Handlers.handle_completion(state, id, params)
+      end)
+    end)
+
+    rpc_server = JsonRpc.Server.on_request(rpc_server, "textDocument/rename", fn id, params ->
+      Agent.get_and_update(agent, fn state ->
+        Handlers.handle_rename(state, id, params)
+      end)
+    end)
+
+    rpc_server = JsonRpc.Server.on_request(rpc_server, "textDocument/documentSymbol", fn id, params ->
+      Agent.get_and_update(agent, fn state ->
+        Handlers.handle_document_symbol(state, id, params)
+      end)
+    end)
+
+    rpc_server = JsonRpc.Server.on_request(rpc_server, "textDocument/semanticTokens/full", fn id, params ->
+      Agent.get_and_update(agent, fn state ->
+        Handlers.handle_semantic_tokens_full(state, id, params)
+      end)
+    end)
+
+    rpc_server = JsonRpc.Server.on_request(rpc_server, "textDocument/foldingRange", fn id, params ->
+      Agent.get_and_update(agent, fn state ->
+        Handlers.handle_folding_range(state, id, params)
+      end)
+    end)
+
+    rpc_server = JsonRpc.Server.on_request(rpc_server, "textDocument/signatureHelp", fn id, params ->
+      Agent.get_and_update(agent, fn state ->
+        Handlers.handle_signature_help(state, id, params)
+      end)
+    end)
+
+    rpc_server = JsonRpc.Server.on_request(rpc_server, "textDocument/formatting", fn id, params ->
+      Agent.get_and_update(agent, fn state ->
+        Handlers.handle_formatting(state, id, params)
+      end)
+    end)
+
+    rpc_server
+  end
+
+  @doc """
+  Start the blocking JSON-RPC read-dispatch-write loop.
+
+  This call blocks until the editor closes the connection (EOF on stdin).
+  """
+  @spec serve(JsonRpc.Server.t()) :: :ok
+  def serve(rpc_server) do
+    JsonRpc.Server.serve(rpc_server)
+  end
+end

--- a/code/packages/elixir/ls00/lib/ls00/types.ex
+++ b/code/packages/elixir/ls00/lib/ls00/types.ex
@@ -1,0 +1,549 @@
+defmodule Ls00.Types do
+  @moduledoc """
+  All shared LSP data types used across the server.
+
+  These types mirror the LSP specification's TypeScript type definitions,
+  translated to idiomatic Elixir structs. The LSP spec lives at:
+  https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/
+
+  ## Coordinate System
+
+  LSP uses a 0-based, line/character coordinate system. Line 0, character 0 is
+  the very first character of the file. This differs from most editors (which
+  display 1-based line numbers) and from most lexers (which emit 1-based tokens).
+  The `Ls00.LanguageBridge` is responsible for converting.
+
+  ## UTF-16 Code Units
+
+  LSP's "character" offset is measured in UTF-16 CODE UNITS, not bytes or
+  Unicode codepoints. This is a historical artifact: VS Code is built on
+  TypeScript, which uses UTF-16 strings internally. See `Ls00.DocumentManager`
+  for the conversion function and a detailed explanation of why this matters.
+  """
+
+  # ---------------------------------------------------------------------------
+  # Position
+  # ---------------------------------------------------------------------------
+
+  defmodule Position do
+    @moduledoc """
+    A cursor position in a document.
+
+    Both `line` and `character` are 0-based. `character` is measured in UTF-16
+    code units (see the module doc above for why).
+
+    ## Example
+
+    In the string "hello world", the 'w' in world is at
+    `%Position{line: 0, character: 6}`.
+    """
+    @enforce_keys [:line, :character]
+    defstruct [:line, :character]
+
+    @type t :: %__MODULE__{
+            line: non_neg_integer(),
+            character: non_neg_integer()
+          }
+  end
+
+  # ---------------------------------------------------------------------------
+  # Range
+  # ---------------------------------------------------------------------------
+
+  defmodule Range do
+    @moduledoc """
+    A span of text in a document, from `start` (inclusive) to `end_pos` (exclusive).
+
+    Analogy: think of it like a text selection. `start` is where the cursor lands
+    when you click, `end_pos` is where you drag to.
+    """
+    @enforce_keys [:start, :end_pos]
+    defstruct [:start, :end_pos]
+
+    @type t :: %__MODULE__{
+            start: Ls00.Types.Position.t(),
+            end_pos: Ls00.Types.Position.t()
+          }
+  end
+
+  # ---------------------------------------------------------------------------
+  # Location
+  # ---------------------------------------------------------------------------
+
+  defmodule Location do
+    @moduledoc """
+    A position in a specific file.
+
+    URI uses the "file://" scheme, e.g., "file:///home/user/main.ex".
+    """
+    @enforce_keys [:uri, :range]
+    defstruct [:uri, :range]
+
+    @type t :: %__MODULE__{
+            uri: String.t(),
+            range: Ls00.Types.Range.t()
+          }
+  end
+
+  # ---------------------------------------------------------------------------
+  # Diagnostic Severity
+  # ---------------------------------------------------------------------------
+  #
+  # These match the LSP integer codes:
+  #   1 = Error   (red squiggles)
+  #   2 = Warning (yellow squiggles)
+  #   3 = Information (blue)
+  #   4 = Hint (subtle)
+
+  @doc "Error severity (1) -- a hard error; the code cannot run or compile."
+  def severity_error, do: 1
+
+  @doc "Warning severity (2) -- potentially problematic, but not blocking."
+  def severity_warning, do: 2
+
+  @doc "Information severity (3) -- informational message."
+  def severity_information, do: 3
+
+  @doc "Hint severity (4) -- a suggestion (e.g., 'consider using const')."
+  def severity_hint, do: 4
+
+  # ---------------------------------------------------------------------------
+  # Diagnostic
+  # ---------------------------------------------------------------------------
+
+  defmodule Diagnostic do
+    @moduledoc """
+    An error, warning, or hint to display in the editor.
+
+    The editor renders diagnostics as underlined squiggles, with the message
+    shown on hover. Red squiggles = Error, yellow = Warning, blue = Info.
+    """
+    @enforce_keys [:range, :severity, :message]
+    defstruct [:range, :severity, :message, :code]
+
+    @type t :: %__MODULE__{
+            range: Ls00.Types.Range.t(),
+            severity: integer(),
+            message: String.t(),
+            code: String.t() | nil
+          }
+  end
+
+  # ---------------------------------------------------------------------------
+  # Token
+  # ---------------------------------------------------------------------------
+
+  defmodule Token do
+    @moduledoc """
+    A single lexical token from the language's lexer.
+
+    The bridge's `tokenize/1` callback returns a list of these. The LSP server
+    uses tokens to provide semantic syntax highlighting (SemanticTokensProvider).
+
+    Note: `line` and `column` are 1-based (matching most lexers). The bridge
+    must convert to 0-based when building `SemanticToken` values for the LSP
+    response.
+    """
+    @enforce_keys [:type, :value, :line, :column]
+    defstruct [:type, :value, :line, :column]
+
+    @type t :: %__MODULE__{
+            type: String.t(),
+            value: String.t(),
+            line: pos_integer(),
+            column: pos_integer()
+          }
+  end
+
+  # ---------------------------------------------------------------------------
+  # TextEdit
+  # ---------------------------------------------------------------------------
+
+  defmodule TextEdit do
+    @moduledoc """
+    A single text replacement in a document.
+
+    Used by formatting (replace the whole file) and rename (replace each
+    occurrence). `new_text` replaces the content at `range`. If `new_text` is
+    empty, the range is deleted.
+    """
+    @enforce_keys [:range, :new_text]
+    defstruct [:range, :new_text]
+
+    @type t :: %__MODULE__{
+            range: Ls00.Types.Range.t(),
+            new_text: String.t()
+          }
+  end
+
+  # ---------------------------------------------------------------------------
+  # WorkspaceEdit
+  # ---------------------------------------------------------------------------
+
+  defmodule WorkspaceEdit do
+    @moduledoc """
+    Groups TextEdits across potentially multiple files.
+
+    For rename operations that affect a single file, `changes` will have one key.
+    For multi-file projects, a rename may produce edits across many files.
+    """
+    @enforce_keys [:changes]
+    defstruct [:changes]
+
+    @type t :: %__MODULE__{
+            changes: %{String.t() => [Ls00.Types.TextEdit.t()]}
+          }
+  end
+
+  # ---------------------------------------------------------------------------
+  # HoverResult
+  # ---------------------------------------------------------------------------
+
+  defmodule HoverResult do
+    @moduledoc """
+    The content to show in the hover popup.
+
+    `contents` is Markdown text. VS Code renders it with syntax highlighting,
+    bold/italic, code blocks, etc. `range` is optional -- if set, it highlights
+    the symbol in the editor when the hover popup is shown.
+    """
+    @enforce_keys [:contents]
+    defstruct [:contents, :range]
+
+    @type t :: %__MODULE__{
+            contents: String.t(),
+            range: Ls00.Types.Range.t() | nil
+          }
+  end
+
+  # ---------------------------------------------------------------------------
+  # CompletionItemKind
+  # ---------------------------------------------------------------------------
+  #
+  # These classify completion items so the editor can show the right icon
+  # (function icon, variable icon, keyword icon, etc.).
+
+  @completion_text 1
+  @completion_method 2
+  @completion_function 3
+  @completion_constructor 4
+  @completion_field 5
+  @completion_variable 6
+  @completion_class 7
+  @completion_interface 8
+  @completion_module 9
+  @completion_property 10
+  @completion_unit 11
+  @completion_value 12
+  @completion_enum 13
+  @completion_keyword 14
+  @completion_snippet 15
+  @completion_color 16
+  @completion_file 17
+  @completion_reference 18
+  @completion_folder 19
+  @completion_enum_member 20
+  @completion_constant 21
+  @completion_struct 22
+  @completion_event 23
+  @completion_operator 24
+  @completion_type_parameter 25
+
+  def completion_text, do: @completion_text
+  def completion_method, do: @completion_method
+  def completion_function, do: @completion_function
+  def completion_constructor, do: @completion_constructor
+  def completion_field, do: @completion_field
+  def completion_variable, do: @completion_variable
+  def completion_class, do: @completion_class
+  def completion_interface, do: @completion_interface
+  def completion_module, do: @completion_module
+  def completion_property, do: @completion_property
+  def completion_unit, do: @completion_unit
+  def completion_value, do: @completion_value
+  def completion_enum, do: @completion_enum
+  def completion_keyword, do: @completion_keyword
+  def completion_snippet, do: @completion_snippet
+  def completion_color, do: @completion_color
+  def completion_file, do: @completion_file
+  def completion_reference, do: @completion_reference
+  def completion_folder, do: @completion_folder
+  def completion_enum_member, do: @completion_enum_member
+  def completion_constant, do: @completion_constant
+  def completion_struct, do: @completion_struct
+  def completion_event, do: @completion_event
+  def completion_operator, do: @completion_operator
+  def completion_type_parameter, do: @completion_type_parameter
+
+  # ---------------------------------------------------------------------------
+  # CompletionItem
+  # ---------------------------------------------------------------------------
+
+  defmodule CompletionItem do
+    @moduledoc """
+    A single autocomplete suggestion.
+
+    When the user triggers autocomplete (e.g., by pressing Ctrl+Space or typing
+    after a dot), the editor shows a dropdown list of CompletionItems.
+    """
+    @enforce_keys [:label]
+    defstruct [:label, :kind, :detail, :documentation, :insert_text, :insert_text_format]
+
+    @type t :: %__MODULE__{
+            label: String.t(),
+            kind: integer() | nil,
+            detail: String.t() | nil,
+            documentation: String.t() | nil,
+            insert_text: String.t() | nil,
+            insert_text_format: integer() | nil
+          }
+  end
+
+  # ---------------------------------------------------------------------------
+  # SemanticToken
+  # ---------------------------------------------------------------------------
+
+  defmodule SemanticToken do
+    @moduledoc """
+    One token's contribution to the semantic highlighting pass.
+
+    Semantic tokens are the "second pass" of syntax highlighting. The editor's
+    grammar-based highlighter (TextMate/tmLanguage) does a fast regex pass first.
+    Semantic tokens layer on top with accurate, context-aware type information.
+
+    `line` and `character` are 0-based. `token_type` and `modifiers` reference
+    entries in the legend returned by `Ls00.Capabilities.semantic_token_legend/0`.
+    """
+    @enforce_keys [:line, :character, :length, :token_type]
+    defstruct [:line, :character, :length, :token_type, modifiers: []]
+
+    @type t :: %__MODULE__{
+            line: non_neg_integer(),
+            character: non_neg_integer(),
+            length: non_neg_integer(),
+            token_type: String.t(),
+            modifiers: [String.t()]
+          }
+  end
+
+  # ---------------------------------------------------------------------------
+  # SymbolKind
+  # ---------------------------------------------------------------------------
+  #
+  # These classify document symbols for the outline panel.
+  # They match the LSP integer codes (1-based).
+
+  @symbol_file 1
+  @symbol_module 2
+  @symbol_namespace 3
+  @symbol_package 4
+  @symbol_class 5
+  @symbol_method 6
+  @symbol_property 7
+  @symbol_field 8
+  @symbol_constructor 9
+  @symbol_enum 10
+  @symbol_interface 11
+  @symbol_function 12
+  @symbol_variable 13
+  @symbol_constant 14
+  @symbol_string 15
+  @symbol_number 16
+  @symbol_boolean 17
+  @symbol_array 18
+  @symbol_object 19
+  @symbol_key 20
+  @symbol_null 21
+  @symbol_enum_member 22
+  @symbol_struct 23
+  @symbol_event 24
+  @symbol_operator 25
+  @symbol_type_parameter 26
+
+  def symbol_file, do: @symbol_file
+  def symbol_module, do: @symbol_module
+  def symbol_namespace, do: @symbol_namespace
+  def symbol_package, do: @symbol_package
+  def symbol_class, do: @symbol_class
+  def symbol_method, do: @symbol_method
+  def symbol_property, do: @symbol_property
+  def symbol_field, do: @symbol_field
+  def symbol_constructor, do: @symbol_constructor
+  def symbol_enum, do: @symbol_enum
+  def symbol_interface, do: @symbol_interface
+  def symbol_function, do: @symbol_function
+  def symbol_variable, do: @symbol_variable
+  def symbol_constant, do: @symbol_constant
+  def symbol_string, do: @symbol_string
+  def symbol_number, do: @symbol_number
+  def symbol_boolean, do: @symbol_boolean
+  def symbol_array, do: @symbol_array
+  def symbol_object, do: @symbol_object
+  def symbol_key, do: @symbol_key
+  def symbol_null, do: @symbol_null
+  def symbol_enum_member, do: @symbol_enum_member
+  def symbol_struct, do: @symbol_struct
+  def symbol_event, do: @symbol_event
+  def symbol_operator, do: @symbol_operator
+  def symbol_type_parameter, do: @symbol_type_parameter
+
+  # ---------------------------------------------------------------------------
+  # DocumentSymbol
+  # ---------------------------------------------------------------------------
+
+  defmodule DocumentSymbol do
+    @moduledoc """
+    One entry in the document outline panel.
+
+    The outline shows a tree of named symbols (functions, classes, variables).
+    `children` allows nesting: a class symbol can have method symbols as children.
+
+    `range` covers the entire symbol (including its body). `selection_range` is
+    the smaller range of just the symbol's name.
+    """
+    @enforce_keys [:name, :kind, :range, :selection_range]
+    defstruct [:name, :kind, :range, :selection_range, children: []]
+
+    @type t :: %__MODULE__{
+            name: String.t(),
+            kind: integer(),
+            range: Ls00.Types.Range.t(),
+            selection_range: Ls00.Types.Range.t(),
+            children: [t()]
+          }
+  end
+
+  # ---------------------------------------------------------------------------
+  # FoldingRange
+  # ---------------------------------------------------------------------------
+
+  defmodule FoldingRange do
+    @moduledoc """
+    A collapsible region of the document.
+
+    The editor shows a collapse arrow in the gutter next to `start_line`. When
+    collapsed, lines start_line+1 through end_line are hidden. `kind` is one of
+    "region", "imports", or "comment".
+    """
+    @enforce_keys [:start_line, :end_line]
+    defstruct [:start_line, :end_line, :kind]
+
+    @type t :: %__MODULE__{
+            start_line: non_neg_integer(),
+            end_line: non_neg_integer(),
+            kind: String.t() | nil
+          }
+  end
+
+  # ---------------------------------------------------------------------------
+  # ParameterInformation
+  # ---------------------------------------------------------------------------
+
+  defmodule ParameterInformation do
+    @moduledoc "One parameter in a function signature."
+    @enforce_keys [:label]
+    defstruct [:label, :documentation]
+
+    @type t :: %__MODULE__{
+            label: String.t(),
+            documentation: String.t() | nil
+          }
+  end
+
+  # ---------------------------------------------------------------------------
+  # SignatureInformation
+  # ---------------------------------------------------------------------------
+
+  defmodule SignatureInformation do
+    @moduledoc "One function overload's full signature."
+    @enforce_keys [:label]
+    defstruct [:label, :documentation, parameters: []]
+
+    @type t :: %__MODULE__{
+            label: String.t(),
+            documentation: String.t() | nil,
+            parameters: [Ls00.Types.ParameterInformation.t()]
+          }
+  end
+
+  # ---------------------------------------------------------------------------
+  # SignatureHelpResult
+  # ---------------------------------------------------------------------------
+
+  defmodule SignatureHelpResult do
+    @moduledoc """
+    Shown as a tooltip when the user is typing a function call.
+
+    It shows the function signature with the current parameter highlighted.
+    `active_signature` indexes into `signatures`. `active_parameter` indexes
+    into that signature's parameters.
+    """
+    @enforce_keys [:signatures, :active_signature, :active_parameter]
+    defstruct [:signatures, :active_signature, :active_parameter]
+
+    @type t :: %__MODULE__{
+            signatures: [Ls00.Types.SignatureInformation.t()],
+            active_signature: non_neg_integer(),
+            active_parameter: non_neg_integer()
+          }
+  end
+
+  # ---------------------------------------------------------------------------
+  # TextChange (internal, used by DocumentManager)
+  # ---------------------------------------------------------------------------
+
+  defmodule TextChange do
+    @moduledoc """
+    Describes one incremental change to a document.
+
+    If `range` is nil, `new_text` replaces the ENTIRE document content (full sync).
+    If `range` is non-nil, `new_text` replaces just the specified range
+    (incremental sync).
+    """
+    @enforce_keys [:new_text]
+    defstruct [:range, :new_text]
+
+    @type t :: %__MODULE__{
+            range: Ls00.Types.Range.t() | nil,
+            new_text: String.t()
+          }
+  end
+
+  # ---------------------------------------------------------------------------
+  # Document (internal, used by DocumentManager)
+  # ---------------------------------------------------------------------------
+
+  defmodule Document do
+    @moduledoc """
+    An open file tracked by the DocumentManager.
+    """
+    @enforce_keys [:uri, :text, :version]
+    defstruct [:uri, :text, :version]
+
+    @type t :: %__MODULE__{
+            uri: String.t(),
+            text: String.t(),
+            version: integer()
+          }
+  end
+
+  # ---------------------------------------------------------------------------
+  # ParseResult (internal, used by ParseCache)
+  # ---------------------------------------------------------------------------
+
+  defmodule ParseResult do
+    @moduledoc """
+    The outcome of parsing one version of a document.
+
+    Even on parse error, we store the partial AST and diagnostics so that other
+    features (hover, folding, symbols) can still work on the valid portions.
+    """
+    defstruct [:ast, diagnostics: [], err: nil]
+
+    @type t :: %__MODULE__{
+            ast: any(),
+            diagnostics: [Ls00.Types.Diagnostic.t()],
+            err: String.t() | nil
+          }
+  end
+end

--- a/code/packages/elixir/ls00/mix.exs
+++ b/code/packages/elixir/ls00/mix.exs
@@ -1,0 +1,21 @@
+defmodule Ls00.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :coding_adventures_ls00,
+      version: "0.1.0",
+      elixir: "~> 1.15",
+      deps: deps(),
+      test_coverage: [summary: [threshold: 80]]
+    ]
+  end
+
+  def application do
+    [extra_applications: [:logger]]
+  end
+
+  defp deps do
+    [{:coding_adventures_json_rpc, path: "../json_rpc"}]
+  end
+end

--- a/code/packages/elixir/ls00/test/ls00/capabilities_test.exs
+++ b/code/packages/elixir/ls00/test/ls00/capabilities_test.exs
@@ -1,0 +1,155 @@
+defmodule Ls00.CapabilitiesTest do
+  use ExUnit.Case, async: true
+
+  @moduledoc """
+  Tests for capability building and detection.
+  """
+
+  alias Ls00.Capabilities
+
+  # MinimalBridge: only required callbacks.
+  defmodule MinimalBridge do
+    @behaviour Ls00.LanguageBridge
+
+    @impl true
+    def tokenize(_source), do: {:ok, []}
+
+    @impl true
+    def parse(source), do: {:ok, source, []}
+  end
+
+  # MockBridge: implements hover and document_symbols.
+  defmodule MockBridge do
+    @behaviour Ls00.LanguageBridge
+
+    @impl true
+    def tokenize(_source), do: {:ok, []}
+
+    @impl true
+    def parse(source), do: {:ok, source, []}
+
+    @impl true
+    def hover(_ast, _pos) do
+      {:ok, %Ls00.Types.HoverResult{contents: "test hover"}}
+    end
+
+    @impl true
+    def document_symbols(_ast) do
+      {:ok, []}
+    end
+  end
+
+  # FullBridge: implements all optional callbacks.
+  defmodule FullBridge do
+    @behaviour Ls00.LanguageBridge
+
+    @impl true
+    def tokenize(_source), do: {:ok, []}
+
+    @impl true
+    def parse(source), do: {:ok, source, []}
+
+    @impl true
+    def hover(_ast, _pos), do: {:ok, nil}
+
+    @impl true
+    def definition(_ast, _pos, _uri), do: {:ok, nil}
+
+    @impl true
+    def references(_ast, _pos, _uri, _include_decl), do: {:ok, []}
+
+    @impl true
+    def completion(_ast, _pos), do: {:ok, []}
+
+    @impl true
+    def rename(_ast, _pos, _new_name), do: {:ok, nil}
+
+    @impl true
+    def semantic_tokens(_source, _tokens), do: {:ok, []}
+
+    @impl true
+    def document_symbols(_ast), do: {:ok, []}
+
+    @impl true
+    def folding_ranges(_ast), do: {:ok, []}
+
+    @impl true
+    def signature_help(_ast, _pos), do: {:ok, nil}
+
+    @impl true
+    def format(_source), do: {:ok, []}
+  end
+
+  test "minimal bridge: only textDocumentSync advertised" do
+    caps = Capabilities.build_capabilities(MinimalBridge)
+
+    assert caps["textDocumentSync"] == 2
+
+    # Optional capabilities should NOT be present
+    optional = [
+      "hoverProvider", "definitionProvider", "referencesProvider",
+      "completionProvider", "renameProvider", "documentSymbolProvider",
+      "foldingRangeProvider", "signatureHelpProvider",
+      "documentFormattingProvider", "semanticTokensProvider"
+    ]
+
+    for cap <- optional do
+      refute Map.has_key?(caps, cap),
+        "minimal bridge should not advertise #{cap}"
+    end
+  end
+
+  test "mock bridge: advertises hover and documentSymbol" do
+    caps = Capabilities.build_capabilities(MockBridge)
+
+    assert caps["hoverProvider"] == true
+    assert caps["documentSymbolProvider"] == true
+    refute Map.has_key?(caps, "definitionProvider")
+  end
+
+  test "full bridge: all capabilities advertised" do
+    caps = Capabilities.build_capabilities(FullBridge)
+
+    expected = [
+      "textDocumentSync",
+      "hoverProvider",
+      "definitionProvider",
+      "referencesProvider",
+      "completionProvider",
+      "renameProvider",
+      "documentSymbolProvider",
+      "foldingRangeProvider",
+      "signatureHelpProvider",
+      "documentFormattingProvider",
+      "semanticTokensProvider"
+    ]
+
+    for cap <- expected do
+      assert Map.has_key?(caps, cap),
+        "expected capability #{cap} for full bridge"
+    end
+  end
+
+  test "semantic tokens provider includes legend and full flag" do
+    caps = Capabilities.build_capabilities(FullBridge)
+    stp = caps["semanticTokensProvider"]
+
+    assert stp["full"] == true
+    assert is_map(stp["legend"])
+    assert is_list(stp["legend"]["tokenTypes"])
+    assert is_list(stp["legend"]["tokenModifiers"])
+  end
+
+  test "semantic token legend has required types" do
+    legend = Capabilities.semantic_token_legend()
+
+    assert length(legend["tokenTypes"]) > 0
+    assert length(legend["tokenModifiers"]) > 0
+
+    required = ["keyword", "string", "number", "variable", "function"]
+    for rt <- required do
+      assert rt in legend["tokenTypes"],
+        "legend missing required type #{rt}"
+    end
+  end
+end

--- a/code/packages/elixir/ls00/test/ls00/document_manager_test.exs
+++ b/code/packages/elixir/ls00/test/ls00/document_manager_test.exs
@@ -1,0 +1,123 @@
+defmodule Ls00.DocumentManagerTest do
+  use ExUnit.Case, async: true
+
+  @moduledoc """
+  Tests for DocumentManager: open, change, close, and incremental editing.
+  """
+
+  alias Ls00.DocumentManager
+  alias Ls00.Types
+  alias Ls00.Types.{Position, TextChange}
+
+  test "open and get a document" do
+    docs =
+      DocumentManager.new()
+      |> DocumentManager.open("file:///test.txt", "hello world", 1)
+
+    assert {:ok, doc} = DocumentManager.get(docs, "file:///test.txt")
+    assert doc.text == "hello world"
+    assert doc.version == 1
+  end
+
+  test "get returns :error for non-open file" do
+    docs = DocumentManager.new()
+    assert :error = DocumentManager.get(docs, "file:///nonexistent.txt")
+  end
+
+  test "close removes a document" do
+    docs =
+      DocumentManager.new()
+      |> DocumentManager.open("file:///test.txt", "hello", 1)
+      |> DocumentManager.close("file:///test.txt")
+
+    assert :error = DocumentManager.get(docs, "file:///test.txt")
+  end
+
+  test "apply_changes with full replacement" do
+    docs =
+      DocumentManager.new()
+      |> DocumentManager.open("file:///test.txt", "hello world", 1)
+
+    {:ok, docs} =
+      DocumentManager.apply_changes(docs, "file:///test.txt", [
+        %TextChange{range: nil, new_text: "goodbye world"}
+      ], 2)
+
+    {:ok, doc} = DocumentManager.get(docs, "file:///test.txt")
+    assert doc.text == "goodbye world"
+    assert doc.version == 2
+  end
+
+  test "apply_changes with incremental change" do
+    docs =
+      DocumentManager.new()
+      |> DocumentManager.open("file:///test.txt", "hello world", 1)
+
+    # Replace "world" (chars 6-11 on line 0) with "Go"
+    {:ok, docs} =
+      DocumentManager.apply_changes(docs, "file:///test.txt", [
+        %TextChange{
+          range: %Types.Range{
+            start: %Position{line: 0, character: 6},
+            end_pos: %Position{line: 0, character: 11}
+          },
+          new_text: "Go"
+        }
+      ], 2)
+
+    {:ok, doc} = DocumentManager.get(docs, "file:///test.txt")
+    assert doc.text == "hello Go"
+  end
+
+  test "apply_changes to non-open document returns error" do
+    docs = DocumentManager.new()
+
+    assert {:error, "document not open: file:///notopen.txt"} =
+             DocumentManager.apply_changes(docs, "file:///notopen.txt", [
+               %TextChange{range: nil, new_text: "x"}
+             ], 1)
+  end
+
+  test "incremental change with emoji (UTF-16 surrogate pair)" do
+    # "A🎸B" -- emoji is 4 UTF-8 bytes, 2 UTF-16 code units
+    # Replace "B" (UTF-16 char 3, byte offset 5) with "X"
+    docs =
+      DocumentManager.new()
+      |> DocumentManager.open("file:///test.txt", "A\u{1F3B8}B", 1)
+
+    {:ok, docs} =
+      DocumentManager.apply_changes(docs, "file:///test.txt", [
+        %TextChange{
+          range: %Types.Range{
+            start: %Position{line: 0, character: 3},
+            end_pos: %Position{line: 0, character: 4}
+          },
+          new_text: "X"
+        }
+      ], 2)
+
+    {:ok, doc} = DocumentManager.get(docs, "file:///test.txt")
+    assert doc.text == "A\u{1F3B8}X"
+  end
+
+  test "incremental multi-change" do
+    docs =
+      DocumentManager.new()
+      |> DocumentManager.open("uri", "hello world", 1)
+
+    # Change "hello" to "hi"
+    {:ok, docs} =
+      DocumentManager.apply_changes(docs, "uri", [
+        %TextChange{
+          range: %Types.Range{
+            start: %Position{line: 0, character: 0},
+            end_pos: %Position{line: 0, character: 5}
+          },
+          new_text: "hi"
+        }
+      ], 2)
+
+    {:ok, doc} = DocumentManager.get(docs, "uri")
+    assert doc.text == "hi world"
+  end
+end

--- a/code/packages/elixir/ls00/test/ls00/parse_cache_test.exs
+++ b/code/packages/elixir/ls00/test/ls00/parse_cache_test.exs
@@ -1,0 +1,87 @@
+defmodule Ls00.ParseCacheTest do
+  use ExUnit.Case, async: true
+
+  @moduledoc """
+  Tests for ParseCache: hit/miss behavior and eviction.
+  """
+
+  alias Ls00.ParseCache
+
+  # A minimal bridge module for testing.
+  defmodule TestBridge do
+    @behaviour Ls00.LanguageBridge
+
+    @impl true
+    def tokenize(_source), do: {:ok, []}
+
+    @impl true
+    def parse(source) do
+      diags =
+        if String.contains?(source, "ERROR") do
+          [
+            %Ls00.Types.Diagnostic{
+              range: %Ls00.Types.Range{
+                start: %Ls00.Types.Position{line: 0, character: 0},
+                end_pos: %Ls00.Types.Position{line: 0, character: 5}
+              },
+              severity: Ls00.Types.severity_error(),
+              message: "syntax error"
+            }
+          ]
+        else
+          []
+        end
+
+      {:ok, source, diags}
+    end
+  end
+
+  test "cache hit returns same result for same version" do
+    cache = ParseCache.new()
+
+    {r1, cache} = ParseCache.get_or_parse(cache, "file:///a.txt", 1, "hello", TestBridge)
+    assert r1 != nil
+
+    # Second call same version -- cache hit
+    {r2, _cache} = ParseCache.get_or_parse(cache, "file:///a.txt", 1, "hello", TestBridge)
+    # Same struct (identical content)
+    assert r1 == r2
+  end
+
+  test "cache miss for different version" do
+    cache = ParseCache.new()
+
+    {r1, cache} = ParseCache.get_or_parse(cache, "file:///a.txt", 1, "hello", TestBridge)
+    {r3, _cache} = ParseCache.get_or_parse(cache, "file:///a.txt", 2, "hello world", TestBridge)
+
+    # Different version -- should be a different result
+    assert r3.ast == "hello world"
+    assert r1.ast == "hello"
+  end
+
+  test "evict removes cached entry" do
+    cache = ParseCache.new()
+
+    {r1, cache} = ParseCache.get_or_parse(cache, "file:///a.txt", 1, "hello", TestBridge)
+    cache = ParseCache.evict(cache, "file:///a.txt")
+
+    # After eviction, same (uri, version) produces a new parse
+    {r2, _cache} = ParseCache.get_or_parse(cache, "file:///a.txt", 1, "hello", TestBridge)
+    # Content should be same but it is a new struct instance
+    assert r1.ast == r2.ast
+  end
+
+  test "diagnostics populated for ERROR source" do
+    cache = ParseCache.new()
+
+    {result, _cache} = ParseCache.get_or_parse(cache, "file:///a.txt", 1, "source with ERROR token", TestBridge)
+    assert length(result.diagnostics) > 0
+  end
+
+  test "no diagnostics for clean source" do
+    cache = ParseCache.new()
+
+    {result, _cache} = ParseCache.get_or_parse(cache, "file:///clean.txt", 1, "hello world", TestBridge)
+    assert result.diagnostics == []
+  end
+end

--- a/code/packages/elixir/ls00/test/ls00/semantic_tokens_test.exs
+++ b/code/packages/elixir/ls00/test/ls00/semantic_tokens_test.exs
@@ -1,0 +1,111 @@
+defmodule Ls00.SemanticTokensTest do
+  use ExUnit.Case, async: true
+
+  @moduledoc """
+  Tests for semantic token encoding.
+
+  The LSP semantic token encoding is a compact flat integer array. These tests
+  verify the delta encoding, modifier bitmasks, sorting, and unknown type handling.
+  """
+
+  alias Ls00.Capabilities
+  alias Ls00.Types.SemanticToken
+
+  test "empty tokens produce empty data" do
+    assert Capabilities.encode_semantic_tokens([]) == []
+    assert Capabilities.encode_semantic_tokens(nil) == []
+  end
+
+  test "single keyword token" do
+    tokens = [
+      %SemanticToken{line: 0, character: 0, length: 5, token_type: "keyword", modifiers: []}
+    ]
+
+    data = Capabilities.encode_semantic_tokens(tokens)
+
+    # Expected: [deltaLine=0, deltaChar=0, length=5, typeIndex=15 (keyword), modifiers=0]
+    assert length(data) == 5
+    assert Enum.at(data, 0) == 0   # deltaLine
+    assert Enum.at(data, 1) == 0   # deltaChar
+    assert Enum.at(data, 2) == 5   # length
+    assert Enum.at(data, 3) == 15  # keyword index
+    assert Enum.at(data, 4) == 0   # no modifiers
+  end
+
+  test "two tokens on the same line" do
+    tokens = [
+      %SemanticToken{line: 0, character: 0, length: 3, token_type: "keyword", modifiers: []},
+      %SemanticToken{line: 0, character: 4, length: 4, token_type: "function", modifiers: ["declaration"]}
+    ]
+
+    data = Capabilities.encode_semantic_tokens(tokens)
+    assert length(data) == 10
+
+    # Token A: deltaLine=0, deltaChar=0, length=3, keyword(15), mods=0
+    assert Enum.slice(data, 0, 5) == [0, 0, 3, 15, 0]
+
+    # Token B: deltaLine=0, deltaChar=4 (relative to A), length=4, function(12), mods=1 (declaration=bit0)
+    assert Enum.slice(data, 5, 5) == [0, 4, 4, 12, 1]
+  end
+
+  test "tokens on different lines" do
+    tokens = [
+      %SemanticToken{line: 0, character: 0, length: 3, token_type: "keyword", modifiers: []},
+      %SemanticToken{line: 2, character: 4, length: 5, token_type: "number", modifiers: []}
+    ]
+
+    data = Capabilities.encode_semantic_tokens(tokens)
+    assert length(data) == 10
+
+    # Token B: deltaLine=2, deltaChar=4 (absolute on new line), number=19
+    assert Enum.at(data, 5) == 2   # deltaLine
+    assert Enum.at(data, 6) == 4   # deltaChar (absolute on new line)
+    assert Enum.at(data, 8) == 19  # number index
+  end
+
+  test "unsorted input is sorted by encoder" do
+    # Tokens in reverse order -- the encoder should sort them.
+    tokens = [
+      %SemanticToken{line: 1, character: 0, length: 2, token_type: "number", modifiers: []},
+      %SemanticToken{line: 0, character: 0, length: 3, token_type: "keyword", modifiers: []}
+    ]
+
+    data = Capabilities.encode_semantic_tokens(tokens)
+    assert length(data) == 10
+
+    # After sorting: keyword on line 0 first, number on line 1 second
+    assert Enum.at(data, 3) == 15  # first token = keyword
+    assert Enum.at(data, 8) == 19  # second token = number
+  end
+
+  test "unknown token type is skipped" do
+    tokens = [
+      %SemanticToken{line: 0, character: 0, length: 3, token_type: "unknownType", modifiers: []},
+      %SemanticToken{line: 0, character: 4, length: 2, token_type: "keyword", modifiers: []}
+    ]
+
+    data = Capabilities.encode_semantic_tokens(tokens)
+    # unknownType should be skipped, leaving only one 5-tuple
+    assert length(data) == 5
+  end
+
+  test "modifier bitmask: readonly = bit 2 = value 4" do
+    tokens = [
+      %SemanticToken{line: 0, character: 0, length: 3, token_type: "variable", modifiers: ["readonly"]}
+    ]
+
+    data = Capabilities.encode_semantic_tokens(tokens)
+    assert Enum.at(data, 4) == 4  # readonly = bit 2 = value 4
+  end
+
+  test "multiple modifiers combine as bitmask" do
+    # "declaration" = bit 0 = 1, "readonly" = bit 2 = 4, combined = 5
+    tokens = [
+      %SemanticToken{line: 0, character: 0, length: 3, token_type: "variable",
+                     modifiers: ["declaration", "readonly"]}
+    ]
+
+    data = Capabilities.encode_semantic_tokens(tokens)
+    assert Enum.at(data, 4) == 5  # 1 | 4 = 5
+  end
+end

--- a/code/packages/elixir/ls00/test/ls00/server_test.exs
+++ b/code/packages/elixir/ls00/test/ls00/server_test.exs
@@ -1,0 +1,681 @@
+defmodule Ls00.ServerTest do
+  use ExUnit.Case, async: true
+
+  @moduledoc """
+  Integration tests for the LSP server handlers.
+
+  These tests exercise the handler functions directly (without going through
+  the full JSON-RPC transport) to test the LSP logic independently of the
+  wire protocol. This approach avoids coupling to the json_rpc package's
+  internal encoding details.
+  """
+
+  alias Ls00.Handlers
+  alias Ls00.Types
+  alias CodingAdventures.JsonRpc.Writer
+
+  # ---------------------------------------------------------------------------
+  # MockBridge: implements hover and document_symbols
+  # ---------------------------------------------------------------------------
+
+  defmodule MockBridge do
+    @behaviour Ls00.LanguageBridge
+
+    @impl true
+    def tokenize(source) do
+      tokens =
+        source
+        |> String.split(~r/\s+/, trim: true)
+        |> Enum.with_index()
+        |> Enum.map(fn {word, idx} ->
+          %Ls00.Types.Token{type: "WORD", value: word, line: 1, column: idx + 1}
+        end)
+
+      {:ok, tokens}
+    end
+
+    @impl true
+    def parse(source) do
+      diags =
+        if String.contains?(source, "ERROR") do
+          [
+            %Ls00.Types.Diagnostic{
+              range: %Ls00.Types.Range{
+                start: %Ls00.Types.Position{line: 0, character: 0},
+                end_pos: %Ls00.Types.Position{line: 0, character: 5}
+              },
+              severity: Ls00.Types.severity_error(),
+              message: "syntax error: unexpected ERROR token"
+            }
+          ]
+        else
+          []
+        end
+
+      {:ok, source, diags}
+    end
+
+    @impl true
+    def hover(_ast, _pos) do
+      {:ok, %Ls00.Types.HoverResult{
+        contents: "**main** function",
+        range: %Ls00.Types.Range{
+          start: %Ls00.Types.Position{line: 0, character: 0},
+          end_pos: %Ls00.Types.Position{line: 0, character: 4}
+        }
+      }}
+    end
+
+    @impl true
+    def document_symbols(_ast) do
+      {:ok, [
+        %Ls00.Types.DocumentSymbol{
+          name: "main",
+          kind: Ls00.Types.symbol_function(),
+          range: %Ls00.Types.Range{
+            start: %Ls00.Types.Position{line: 0, character: 0},
+            end_pos: %Ls00.Types.Position{line: 10, character: 1}
+          },
+          selection_range: %Ls00.Types.Range{
+            start: %Ls00.Types.Position{line: 0, character: 9},
+            end_pos: %Ls00.Types.Position{line: 0, character: 13}
+          },
+          children: [
+            %Ls00.Types.DocumentSymbol{
+              name: "x",
+              kind: Ls00.Types.symbol_variable(),
+              range: %Ls00.Types.Range{
+                start: %Ls00.Types.Position{line: 1, character: 4},
+                end_pos: %Ls00.Types.Position{line: 1, character: 12}
+              },
+              selection_range: %Ls00.Types.Range{
+                start: %Ls00.Types.Position{line: 1, character: 8},
+                end_pos: %Ls00.Types.Position{line: 1, character: 9}
+              }
+            }
+          ]
+        }
+      ]}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # MinimalBridge: only required callbacks
+  # ---------------------------------------------------------------------------
+
+  defmodule MinimalBridge do
+    @behaviour Ls00.LanguageBridge
+
+    @impl true
+    def tokenize(_source), do: {:ok, []}
+
+    @impl true
+    def parse(source), do: {:ok, source, []}
+  end
+
+  # ---------------------------------------------------------------------------
+  # FullMockBridge: all optional callbacks
+  # ---------------------------------------------------------------------------
+
+  defmodule FullMockBridge do
+    @behaviour Ls00.LanguageBridge
+
+    @impl true
+    def tokenize(source) do
+      tokens =
+        source
+        |> String.split(~r/\s+/, trim: true)
+        |> Enum.with_index()
+        |> Enum.map(fn {word, idx} ->
+          %Ls00.Types.Token{type: "WORD", value: word, line: 1, column: idx + 1}
+        end)
+
+      {:ok, tokens}
+    end
+
+    @impl true
+    def parse(source), do: {:ok, source, []}
+
+    @impl true
+    def hover(_ast, _pos) do
+      {:ok, %Ls00.Types.HoverResult{contents: "test hover"}}
+    end
+
+    @impl true
+    def definition(_ast, pos, uri) do
+      {:ok, %Ls00.Types.Location{
+        uri: uri,
+        range: %Ls00.Types.Range{start: pos, end_pos: pos}
+      }}
+    end
+
+    @impl true
+    def references(_ast, pos, uri, _include_decl) do
+      {:ok, [%Ls00.Types.Location{
+        uri: uri,
+        range: %Ls00.Types.Range{start: pos, end_pos: pos}
+      }]}
+    end
+
+    @impl true
+    def completion(_ast, _pos) do
+      {:ok, [%Ls00.Types.CompletionItem{
+        label: "foo",
+        kind: Ls00.Types.completion_function(),
+        detail: "() void"
+      }]}
+    end
+
+    @impl true
+    def rename(_ast, pos, new_name) do
+      {:ok, %Ls00.Types.WorkspaceEdit{
+        changes: %{
+          "file:///test.txt" => [
+            %Ls00.Types.TextEdit{
+              range: %Ls00.Types.Range{start: pos, end_pos: pos},
+              new_text: new_name
+            }
+          ]
+        }
+      }}
+    end
+
+    @impl true
+    def semantic_tokens(_source, tokens) do
+      result =
+        Enum.map(tokens, fn tok ->
+          %Ls00.Types.SemanticToken{
+            line: tok.line - 1,
+            character: tok.column - 1,
+            length: String.length(tok.value),
+            token_type: "variable",
+            modifiers: []
+          }
+        end)
+
+      {:ok, result}
+    end
+
+    @impl true
+    def document_symbols(_ast) do
+      {:ok, [%Ls00.Types.DocumentSymbol{
+        name: "main",
+        kind: Ls00.Types.symbol_function(),
+        range: %Ls00.Types.Range{
+          start: %Ls00.Types.Position{line: 0, character: 0},
+          end_pos: %Ls00.Types.Position{line: 10, character: 1}
+        },
+        selection_range: %Ls00.Types.Range{
+          start: %Ls00.Types.Position{line: 0, character: 9},
+          end_pos: %Ls00.Types.Position{line: 0, character: 13}
+        }
+      }]}
+    end
+
+    @impl true
+    def folding_ranges(_ast) do
+      {:ok, [%Ls00.Types.FoldingRange{start_line: 0, end_line: 5, kind: "region"}]}
+    end
+
+    @impl true
+    def signature_help(_ast, _pos) do
+      {:ok, %Ls00.Types.SignatureHelpResult{
+        signatures: [
+          %Ls00.Types.SignatureInformation{
+            label: "foo(a int, b string)",
+            parameters: [
+              %Ls00.Types.ParameterInformation{label: "a int"},
+              %Ls00.Types.ParameterInformation{label: "b string"}
+            ]
+          }
+        ],
+        active_signature: 0,
+        active_parameter: 0
+      }}
+    end
+
+    @impl true
+    def format(source) do
+      {:ok, [
+        %Ls00.Types.TextEdit{
+          range: %Ls00.Types.Range{
+            start: %Ls00.Types.Position{line: 0, character: 0},
+            end_pos: %Ls00.Types.Position{line: 999, character: 0}
+          },
+          new_text: source
+        }
+      ]}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Test helpers
+  # ---------------------------------------------------------------------------
+
+  # Create a handler state for a given bridge module.
+  defp new_state(bridge_module) do
+    # Use a StringIO device for the writer (captures notifications output).
+    {:ok, out_pid} = StringIO.open("")
+    writer = Writer.new(out_pid)
+
+    %Handlers{
+      bridge_module: bridge_module,
+      writer: writer
+    }
+  end
+
+  # Initialize the server and open a document.
+  defp init_and_open(bridge_module, uri, text) do
+    state = new_state(bridge_module)
+
+    # Initialize
+    {_result, state} = Handlers.handle_initialize(state, 1, %{
+      "processId" => 1234,
+      "capabilities" => %{}
+    })
+
+    state = Handlers.handle_initialized(state, %{})
+
+    # Open document
+    state = Handlers.handle_did_open(state, %{
+      "textDocument" => %{
+        "uri" => uri,
+        "languageId" => "test",
+        "version" => 1,
+        "text" => text
+      }
+    })
+
+    state
+  end
+
+  # ---------------------------------------------------------------------------
+  # Lifecycle tests
+  # ---------------------------------------------------------------------------
+
+  test "initialize returns capabilities" do
+    state = new_state(MockBridge)
+
+    {result, state} = Handlers.handle_initialize(state, 1, %{
+      "processId" => 1234,
+      "capabilities" => %{}
+    })
+
+    assert is_map(result)
+    caps = result["capabilities"]
+    assert caps["textDocumentSync"] == 2
+    assert caps["hoverProvider"] == true
+    assert caps["documentSymbolProvider"] == true
+
+    server_info = result["serverInfo"]
+    assert server_info["name"] == "ls00-generic-lsp-server"
+    assert server_info["version"] == "0.1.0"
+    assert state.initialized == true
+  end
+
+  test "shutdown sets shutdown flag" do
+    state = new_state(MockBridge)
+    {result, state} = Handlers.handle_shutdown(state, 1, %{})
+
+    assert result == nil
+    assert state.shutdown == true
+  end
+
+  # ---------------------------------------------------------------------------
+  # didOpen / diagnostics tests
+  # ---------------------------------------------------------------------------
+
+  test "didOpen with error source produces diagnostics" do
+    state = new_state(MockBridge)
+    {_result, state} = Handlers.handle_initialize(state, 1, %{
+      "processId" => 1, "capabilities" => %{}
+    })
+
+    state = Handlers.handle_did_open(state, %{
+      "textDocument" => %{
+        "uri" => "file:///test.txt",
+        "languageId" => "test",
+        "version" => 1,
+        "text" => "hello ERROR world"
+      }
+    })
+
+    # Verify the parse cache has diagnostics.
+    {parse_result, _cache} =
+      Ls00.ParseCache.get_or_parse(state.parse_cache, "file:///test.txt", 1, "hello ERROR world", MockBridge)
+
+    assert length(parse_result.diagnostics) > 0
+  end
+
+  test "didOpen with clean source produces no diagnostics" do
+    state = new_state(MockBridge)
+    {_result, state} = Handlers.handle_initialize(state, 1, %{
+      "processId" => 1, "capabilities" => %{}
+    })
+
+    state = Handlers.handle_did_open(state, %{
+      "textDocument" => %{
+        "uri" => "file:///clean.txt",
+        "languageId" => "test",
+        "version" => 1,
+        "text" => "hello world"
+      }
+    })
+
+    {parse_result, _cache} =
+      Ls00.ParseCache.get_or_parse(state.parse_cache, "file:///clean.txt", 1, "hello world", MockBridge)
+
+    assert parse_result.diagnostics == []
+  end
+
+  # ---------------------------------------------------------------------------
+  # didChange test
+  # ---------------------------------------------------------------------------
+
+  test "didChange updates document text" do
+    state = init_and_open(MockBridge, "file:///test.txt", "hello world")
+
+    state = Handlers.handle_did_change(state, %{
+      "textDocument" => %{"uri" => "file:///test.txt", "version" => 2},
+      "contentChanges" => [%{"text" => "goodbye world"}]
+    })
+
+    {:ok, doc} = Ls00.DocumentManager.get(state.doc_manager, "file:///test.txt")
+    assert doc.text == "goodbye world"
+    assert doc.version == 2
+  end
+
+  # ---------------------------------------------------------------------------
+  # didClose test
+  # ---------------------------------------------------------------------------
+
+  test "didClose removes document" do
+    state = init_and_open(MockBridge, "file:///test.txt", "hello")
+
+    state = Handlers.handle_did_close(state, %{
+      "textDocument" => %{"uri" => "file:///test.txt"}
+    })
+
+    assert :error = Ls00.DocumentManager.get(state.doc_manager, "file:///test.txt")
+  end
+
+  # ---------------------------------------------------------------------------
+  # Hover tests
+  # ---------------------------------------------------------------------------
+
+  test "hover returns markdown content" do
+    state = init_and_open(MockBridge, "file:///test.go", "func main() {}")
+
+    {result, _state} = Handlers.handle_hover(state, 2, %{
+      "textDocument" => %{"uri" => "file:///test.go"},
+      "position" => %{"line" => 0, "character" => 5}
+    })
+
+    assert result != nil
+    assert result["contents"]["kind"] == "markdown"
+    assert result["contents"]["value"] == "**main** function"
+    assert result["range"] != nil
+  end
+
+  test "hover returns nil for minimal bridge" do
+    state = init_and_open(MinimalBridge, "file:///test.txt", "hello")
+
+    {result, _state} = Handlers.handle_hover(state, 2, %{
+      "textDocument" => %{"uri" => "file:///test.txt"},
+      "position" => %{"line" => 0, "character" => 0}
+    })
+
+    assert result == nil
+  end
+
+  # ---------------------------------------------------------------------------
+  # Definition test
+  # ---------------------------------------------------------------------------
+
+  test "definition returns location" do
+    state = init_and_open(FullMockBridge, "file:///test.txt", "hello world")
+
+    {result, _state} = Handlers.handle_definition(state, 2, %{
+      "textDocument" => %{"uri" => "file:///test.txt"},
+      "position" => %{"line" => 0, "character" => 0}
+    })
+
+    assert result != nil
+    assert result["uri"] == "file:///test.txt"
+  end
+
+  test "definition returns nil for minimal bridge" do
+    state = init_and_open(MinimalBridge, "file:///test.txt", "hello")
+
+    {result, _state} = Handlers.handle_definition(state, 2, %{
+      "textDocument" => %{"uri" => "file:///test.txt"},
+      "position" => %{"line" => 0, "character" => 0}
+    })
+
+    assert result == nil
+  end
+
+  # ---------------------------------------------------------------------------
+  # References test
+  # ---------------------------------------------------------------------------
+
+  test "references returns location array" do
+    state = init_and_open(FullMockBridge, "file:///test.txt", "hello")
+
+    {result, _state} = Handlers.handle_references(state, 2, %{
+      "textDocument" => %{"uri" => "file:///test.txt"},
+      "position" => %{"line" => 0, "character" => 0},
+      "context" => %{"includeDeclaration" => true}
+    })
+
+    assert is_list(result)
+    assert length(result) > 0
+  end
+
+  test "references returns empty for minimal bridge" do
+    state = init_and_open(MinimalBridge, "file:///test.txt", "hello")
+
+    {result, _state} = Handlers.handle_references(state, 2, %{
+      "textDocument" => %{"uri" => "file:///test.txt"},
+      "position" => %{"line" => 0, "character" => 0}
+    })
+
+    assert result == []
+  end
+
+  # ---------------------------------------------------------------------------
+  # Completion test
+  # ---------------------------------------------------------------------------
+
+  test "completion returns items" do
+    state = init_and_open(FullMockBridge, "file:///test.txt", "foo")
+
+    {result, _state} = Handlers.handle_completion(state, 2, %{
+      "textDocument" => %{"uri" => "file:///test.txt"},
+      "position" => %{"line" => 0, "character" => 3}
+    })
+
+    assert result["isIncomplete"] == false
+    assert is_list(result["items"])
+    assert length(result["items"]) > 0
+    first = hd(result["items"])
+    assert first["label"] == "foo"
+  end
+
+  # ---------------------------------------------------------------------------
+  # Rename test
+  # ---------------------------------------------------------------------------
+
+  test "rename returns workspace edit" do
+    state = init_and_open(FullMockBridge, "file:///test.txt", "hello")
+
+    {result, _state} = Handlers.handle_rename(state, 2, %{
+      "textDocument" => %{"uri" => "file:///test.txt"},
+      "position" => %{"line" => 0, "character" => 0},
+      "newName" => "world"
+    })
+
+    assert is_map(result["changes"])
+    assert Map.has_key?(result["changes"], "file:///test.txt")
+  end
+
+  test "rename returns error for minimal bridge" do
+    state = init_and_open(MinimalBridge, "file:///test.txt", "hello")
+
+    {result, _state} = Handlers.handle_rename(state, 2, %{
+      "textDocument" => %{"uri" => "file:///test.txt"},
+      "position" => %{"line" => 0, "character" => 0},
+      "newName" => "world"
+    })
+
+    assert result.code == Ls00.LspErrors.request_failed()
+  end
+
+  # ---------------------------------------------------------------------------
+  # Document symbol test
+  # ---------------------------------------------------------------------------
+
+  test "documentSymbol returns nested symbols" do
+    state = init_and_open(MockBridge, "file:///test.go", "func main() { var x = 1 }")
+
+    {result, _state} = Handlers.handle_document_symbol(state, 2, %{
+      "textDocument" => %{"uri" => "file:///test.go"}
+    })
+
+    assert is_list(result)
+    assert length(result) > 0
+    first = hd(result)
+    assert first["name"] == "main"
+    assert first["kind"] == Types.symbol_function()
+    assert is_list(first["children"])
+    assert length(first["children"]) == 1
+    child = hd(first["children"])
+    assert child["name"] == "x"
+  end
+
+  # ---------------------------------------------------------------------------
+  # Semantic tokens test
+  # ---------------------------------------------------------------------------
+
+  test "semanticTokens/full returns data" do
+    state = init_and_open(FullMockBridge, "file:///test.txt", "hello world")
+
+    {result, _state} = Handlers.handle_semantic_tokens_full(state, 2, %{
+      "textDocument" => %{"uri" => "file:///test.txt"}
+    })
+
+    assert is_list(result["data"])
+    # "hello world" has 2 tokens, each encoded as a 5-tuple
+    assert length(result["data"]) == 10
+  end
+
+  test "semanticTokens/full returns empty for minimal bridge" do
+    state = init_and_open(MinimalBridge, "file:///test.txt", "hello world")
+
+    {result, _state} = Handlers.handle_semantic_tokens_full(state, 2, %{
+      "textDocument" => %{"uri" => "file:///test.txt"}
+    })
+
+    assert result["data"] == []
+  end
+
+  # ---------------------------------------------------------------------------
+  # Folding range test
+  # ---------------------------------------------------------------------------
+
+  test "foldingRange returns ranges" do
+    state = init_and_open(FullMockBridge, "file:///test.txt", "hello world")
+
+    {result, _state} = Handlers.handle_folding_range(state, 2, %{
+      "textDocument" => %{"uri" => "file:///test.txt"}
+    })
+
+    assert is_list(result)
+    assert length(result) > 0
+    first = hd(result)
+    assert first["startLine"] == 0
+    assert first["endLine"] == 5
+    assert first["kind"] == "region"
+  end
+
+  # ---------------------------------------------------------------------------
+  # Signature help test
+  # ---------------------------------------------------------------------------
+
+  test "signatureHelp returns signatures" do
+    state = init_and_open(FullMockBridge, "file:///test.txt", "hello")
+
+    {result, _state} = Handlers.handle_signature_help(state, 2, %{
+      "textDocument" => %{"uri" => "file:///test.txt"},
+      "position" => %{"line" => 0, "character" => 0}
+    })
+
+    assert is_list(result["signatures"])
+    assert length(result["signatures"]) > 0
+    assert result["activeSignature"] == 0
+    assert result["activeParameter"] == 0
+  end
+
+  test "signatureHelp returns nil for minimal bridge" do
+    state = init_and_open(MinimalBridge, "file:///test.txt", "hello")
+
+    {result, _state} = Handlers.handle_signature_help(state, 2, %{
+      "textDocument" => %{"uri" => "file:///test.txt"},
+      "position" => %{"line" => 0, "character" => 0}
+    })
+
+    assert result == nil
+  end
+
+  # ---------------------------------------------------------------------------
+  # Formatting test
+  # ---------------------------------------------------------------------------
+
+  test "formatting returns text edits" do
+    state = init_and_open(FullMockBridge, "file:///test.txt", "hello world")
+
+    {result, _state} = Handlers.handle_formatting(state, 2, %{
+      "textDocument" => %{"uri" => "file:///test.txt"}
+    })
+
+    assert is_list(result)
+    assert length(result) > 0
+  end
+
+  test "formatting returns empty for minimal bridge" do
+    state = init_and_open(MinimalBridge, "file:///test.txt", "hello world")
+
+    {result, _state} = Handlers.handle_formatting(state, 2, %{
+      "textDocument" => %{"uri" => "file:///test.txt"}
+    })
+
+    assert result == []
+  end
+
+  # ---------------------------------------------------------------------------
+  # LSP error codes test
+  # ---------------------------------------------------------------------------
+
+  test "LSP error codes have correct values" do
+    assert Ls00.LspErrors.server_not_initialized() == -32002
+    assert Ls00.LspErrors.unknown_error_code() == -32001
+    assert Ls00.LspErrors.request_failed() == -32803
+    assert Ls00.LspErrors.server_cancelled() == -32802
+    assert Ls00.LspErrors.content_modified() == -32801
+    assert Ls00.LspErrors.request_cancelled() == -32800
+  end
+
+  # ---------------------------------------------------------------------------
+  # Server.new test
+  # ---------------------------------------------------------------------------
+
+  test "Server.new creates a server struct" do
+    {:ok, in_pid} = StringIO.open("")
+    {:ok, out_pid} = StringIO.open("")
+
+    server = Ls00.Server.new(MockBridge, in_pid, out_pid)
+    assert server != nil
+    # The returned value is a JsonRpc.Server struct.
+    assert %CodingAdventures.JsonRpc.Server{} = server
+  end
+end

--- a/code/packages/elixir/ls00/test/ls00/utf16_test.exs
+++ b/code/packages/elixir/ls00/test/ls00/utf16_test.exs
@@ -1,0 +1,82 @@
+defmodule Ls00.UTF16Test do
+  use ExUnit.Case, async: true
+
+  @moduledoc """
+  Tests for UTF-16 offset conversion.
+
+  This is the most important correctness test in the entire package. If this
+  function is wrong, every feature that depends on cursor position will be wrong:
+  hover, go-to-definition, references, completion, rename, signature help.
+  """
+
+  alias Ls00.DocumentManager
+
+  # ---------------------------------------------------------------------------
+  # UTF-16 Offset Conversion Tests
+  # ---------------------------------------------------------------------------
+
+  test "ASCII simple: 'hello world' char 6 -> byte 6" do
+    # "world" starts at byte 6 in "hello world"
+    assert DocumentManager.convert_utf16_offset_to_byte_offset("hello world", 0, 6) == 6
+  end
+
+  test "start of file: char 0 -> byte 0" do
+    assert DocumentManager.convert_utf16_offset_to_byte_offset("abc", 0, 0) == 0
+  end
+
+  test "end of short string: char 3 -> byte 3" do
+    assert DocumentManager.convert_utf16_offset_to_byte_offset("abc", 0, 3) == 3
+  end
+
+  test "second line: line 1 char 0" do
+    # "hello\nworld" -- line 1 starts at byte 6
+    assert DocumentManager.convert_utf16_offset_to_byte_offset("hello\nworld", 1, 0) == 6
+  end
+
+  test "emoji: guitar emoji takes 2 UTF-16 units but 4 UTF-8 bytes" do
+    # "A🎸B"
+    # UTF-8 bytes:  A (1 byte) + 🎸 (4 bytes) + B (1 byte) = 6 bytes total
+    # UTF-16 units: A (1 unit) + 🎸 (2 units) + B (1 unit) = 4 units total
+    # "B" is at UTF-16 character 3, byte offset 5.
+    text = "A\u{1F3B8}B"
+    assert DocumentManager.convert_utf16_offset_to_byte_offset(text, 0, 3) == 5
+  end
+
+  test "emoji at start: guitar emoji then hello" do
+    # "🎸hello"
+    # 🎸 = 2 UTF-16 units = 4 UTF-8 bytes
+    # "h" is at UTF-16 char 2, byte offset 4
+    text = "\u{1F3B8}hello"
+    assert DocumentManager.convert_utf16_offset_to_byte_offset(text, 0, 2) == 4
+  end
+
+  test "2-byte UTF-8 BMP codepoint: cafe with accent" do
+    # "cafe!" -- e-acute is U+00E9, which is:
+    # UTF-8:  2 bytes (0xC3 0xA9)
+    # UTF-16: 1 code unit
+    # So UTF-16 char 4 = byte offset 5 (c=1, a=1, f=1, e-acute=2 bytes)
+    text = "caf\u00e9!"
+    assert DocumentManager.convert_utf16_offset_to_byte_offset(text, 0, 4) == 5
+  end
+
+  test "multiline with emoji" do
+    # line 0: "A🎸B\n"  (A=1, 🎸=4, B=1, \n=1 = 7 bytes)
+    # line 1: "hello"
+    # "hello" starts at byte 7, char 0 on line 1
+    text = "A\u{1F3B8}B\nhello"
+    assert DocumentManager.convert_utf16_offset_to_byte_offset(text, 1, 0) == 7
+  end
+
+  test "beyond line end clamps to newline" do
+    # If character is past the end of the line, we stop at the newline.
+    text = "ab\ncd"
+    assert DocumentManager.convert_utf16_offset_to_byte_offset(text, 0, 100) == 2
+  end
+
+  test "CJK characters: 3-byte UTF-8, 1 UTF-16 unit" do
+    # "中文" -- each Chinese character is 3 UTF-8 bytes but 1 UTF-16 code unit.
+    # So "文" is at UTF-16 character 1, byte offset 3.
+    text = "\u4e2d\u6587"
+    assert DocumentManager.convert_utf16_offset_to_byte_offset(text, 0, 1) == 3
+  end
+end

--- a/code/packages/elixir/ls00/test/test_helper.exs
+++ b/code/packages/elixir/ls00/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/code/packages/lua/ls00/BUILD
+++ b/code/packages/lua/ls00/BUILD
@@ -1,0 +1,1 @@
+cd ../json_rpc && luarocks make --local && cd ../ls00 && luarocks make --local && cd tests && busted . --verbose --pattern=test_

--- a/code/packages/lua/ls00/CHANGELOG.md
+++ b/code/packages/lua/ls00/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to the `coding-adventures-ls00` package will be documented in this file.
+
+## [0.1.0] - 2026-04-12
+
+### Added
+
+- Initial release of the generic LSP server framework for Lua.
+- **Types**: Position, Range, Location, Diagnostic, Token, TextEdit, WorkspaceEdit, HoverResult, CompletionItem, SemanticToken, DocumentSymbol, FoldingRange, ParameterInformation, SignatureInformation, SignatureHelpResult — all as constructor functions returning plain tables.
+- **UTF-16 conversion**: `convert_utf16_offset_to_byte_offset()` for converting LSP's UTF-16 character offsets to Lua's 1-based byte offsets. Handles ASCII, BMP codepoints (2-3 byte UTF-8), and non-BMP codepoints (4-byte UTF-8 / surrogate pairs).
+- **DocumentManager**: Tracks open file contents with version numbers. Supports full replacement and incremental (range-based) changes via `apply_changes()`.
+- **ParseCache**: Caches parse results keyed by (uri, version) to avoid redundant parsing. Automatic eviction when version changes or document closes.
+- **Capabilities**: `build_capabilities(bridge)` dynamically builds the LSP capabilities object by checking which functions the bridge table provides (`if bridge.hover ~= nil`).
+- **Semantic token encoding**: `encode_semantic_tokens()` converts SemanticToken tables to LSP's compact delta-encoded integer array format. Handles sorting, unknown types, and modifier bitmasks.
+- **Semantic token legend**: `semantic_token_legend()` returns the standard 23 token types and 10 token modifiers.
+- **LspServer**: Full LSP server that wires together the bridge, DocumentManager, ParseCache, and JSON-RPC server. Handles all lifecycle events (initialize, shutdown, exit) and all feature requests (hover, definition, references, completion, rename, documentSymbol, semanticTokens, foldingRange, signatureHelp, formatting).
+- **Bridge design**: Plain Lua table with function fields. Required: `tokenize`, `parse`. Optional: `hover`, `definition`, `references`, `completion`, `rename`, `semantic_tokens`, `document_symbols`, `folding_ranges`, `signature_help`, `format`.
+- **Diagnostics publishing**: Automatically pushes diagnostics to the editor on didOpen and didChange.
+- **Tests**: Comprehensive test suite covering UTF-16 conversion, DocumentManager, ParseCache, capabilities, semantic token encoding, and full server integration.

--- a/code/packages/lua/ls00/README.md
+++ b/code/packages/lua/ls00/README.md
@@ -1,0 +1,88 @@
+# coding-adventures-ls00
+
+Generic LSP (Language Server Protocol) server framework for Lua. Language-specific "bridges" plug into this framework using plain Lua tables with function fields.
+
+## What is LSP?
+
+The Language Server Protocol is a standardized protocol between code editors (VS Code, Neovim, Emacs) and language servers. It solves the M x N problem: instead of writing M*N integrations for M editors and N languages, each language writes one server and every LSP-aware editor gets all features automatically.
+
+## Architecture
+
+```
+Lexer -> Parser -> [Bridge Table] -> [LspServer] -> VS Code / Neovim / Emacs
+```
+
+This package is the generic half. It handles:
+- JSON-RPC 2.0 transport (via `coding-adventures-json-rpc`)
+- Document synchronization (open/change/close)
+- Parse caching (avoid re-parsing unchanged documents)
+- UTF-16 offset conversion (LSP uses UTF-16 code units)
+- Capability advertisement (only advertise what the bridge supports)
+- Semantic token encoding (compact delta format)
+- All LSP request/notification routing
+
+## Usage
+
+```lua
+local ls00 = require("coding_adventures.ls00")
+
+-- 1. Create a bridge table with required + optional functions.
+local bridge = {
+    tokenize = function(source)
+        -- Return array of Token tables.
+        return tokens, nil
+    end,
+    parse = function(source)
+        -- Return AST, diagnostics array, error.
+        return ast, diagnostics, nil
+    end,
+    -- Optional: enable hover tooltips.
+    hover = function(ast, pos)
+        return ls00.HoverResult("**symbol** description")
+    end,
+}
+
+-- 2. Create and run the server.
+local server = ls00.LspServer:new(bridge, io.stdin, io.stdout)
+server:serve()  -- blocks until EOF
+```
+
+## Bridge API
+
+### Required
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `tokenize` | `(source) -> tokens, err` | Lex source into token array |
+| `parse` | `(source) -> ast, diagnostics, err` | Parse source into AST |
+
+### Optional (each enables one LSP feature)
+
+| Function | Enables |
+|----------|---------|
+| `hover` | Hover tooltips |
+| `definition` | Go to Definition |
+| `references` | Find All References |
+| `completion` | Autocomplete |
+| `rename` | Symbol Rename |
+| `semantic_tokens` | Semantic Highlighting |
+| `document_symbols` | Document Outline |
+| `folding_ranges` | Code Folding |
+| `signature_help` | Signature Hints |
+| `format` | Document Formatting |
+
+## Dependencies
+
+- `coding-adventures-json-rpc` (JSON-RPC 2.0 transport layer)
+
+## Installation
+
+```bash
+luarocks make --local coding-adventures-ls00-0.1.0-1.rockspec
+```
+
+## Testing
+
+```bash
+cd tests && busted . --verbose --pattern=test_
+```

--- a/code/packages/lua/ls00/coding-adventures-ls00-0.1.0-1.rockspec
+++ b/code/packages/lua/ls00/coding-adventures-ls00-0.1.0-1.rockspec
@@ -1,0 +1,16 @@
+package = "coding-adventures-ls00"
+version = "0.1.0-1"
+source  = { url = "." }
+description = {
+  summary  = "Generic LSP server framework — language bridges plug in via Lua tables",
+  homepage = "https://github.com/example/coding-adventures",
+  license  = "MIT",
+}
+dependencies = {
+  "lua >= 5.1",
+  "coding-adventures-json-rpc >= 0.1.0",
+}
+build = {
+  type    = "builtin",
+  modules = { ["coding_adventures.ls00"] = "src/coding_adventures/ls00/init.lua" },
+}

--- a/code/packages/lua/ls00/src/coding_adventures/ls00/init.lua
+++ b/code/packages/lua/ls00/src/coding_adventures/ls00/init.lua
@@ -1,0 +1,1497 @@
+-- coding_adventures.ls00 — Generic LSP Server Framework
+-- ======================================================
+--
+-- The Language Server Protocol (LSP) is a standardized protocol between code
+-- editors (VS Code, Neovim, Emacs) and language servers. When you see red
+-- squiggles under syntax errors, autocomplete suggestions, or "Go to
+-- Definition" — none of that is built into the editor. It comes from a
+-- *language server*: a separate process that speaks LSP.
+--
+-- LSP solves the M x N problem:
+--
+--   M editors x N languages = M*N integrations to write
+--
+-- With LSP, each language writes ONE server, and every LSP-aware editor gets
+-- all features automatically. This module is the *generic* half — it handles
+-- all protocol boilerplate. A language author only writes the "bridge": a Lua
+-- table with function fields that connects their lexer/parser to this framework.
+--
+-- # Architecture
+--
+--   Lexer -> Parser -> [Bridge Table] -> [LspServer] -> VS Code / Neovim / Emacs
+--
+-- # Bridge Design
+--
+-- In Go, the bridge uses interface type assertions for capability detection.
+-- In Lua, the bridge is a plain table with function fields. Capability detection
+-- is simply:  if bridge.hover ~= nil then ... end
+--
+-- Required bridge fields:
+--   bridge.tokenize(source) -> tokens, err
+--   bridge.parse(source)    -> ast, diagnostics, err
+--
+-- Optional bridge fields (each enables one LSP feature):
+--   bridge.hover(ast, pos)                     -> hover_result or nil
+--   bridge.definition(ast, pos, uri)           -> location or nil
+--   bridge.references(ast, pos, uri, incl_decl) -> locations
+--   bridge.completion(ast, pos)                -> items
+--   bridge.rename(ast, pos, new_name)          -> workspace_edit
+--   bridge.semantic_tokens(source, tokens)     -> semantic_tokens
+--   bridge.document_symbols(ast)               -> symbols
+--   bridge.folding_ranges(ast)                 -> ranges
+--   bridge.signature_help(ast, pos)            -> result or nil
+--   bridge.format(source)                      -> text_edits
+--
+-- # JSON-RPC
+--
+-- LSP speaks JSON-RPC 2.0 over stdin/stdout. This module uses the
+-- coding-adventures json_rpc package for the transport layer.
+
+local json_rpc = require("coding_adventures.json_rpc")
+
+local M = {}
+M.VERSION = "0.1.0"
+
+-- =========================================================================
+-- LSP Error Codes
+-- =========================================================================
+--
+-- The JSON-RPC 2.0 spec reserves error codes in the range [-32768, -32000].
+-- LSP further reserves [-32899, -32800] for protocol-level errors.
+
+M.errors = {
+    -- Server has received a request before the initialize handshake.
+    SERVER_NOT_INITIALIZED = -32002,
+    -- Generic unknown error.
+    UNKNOWN_ERROR_CODE     = -32001,
+    -- A request failed but not due to a protocol problem.
+    REQUEST_FAILED         = -32803,
+    -- The server cancelled the request.
+    SERVER_CANCELLED       = -32802,
+    -- Document content was modified before request completed.
+    CONTENT_MODIFIED       = -32801,
+    -- The client cancelled the request.
+    REQUEST_CANCELLED      = -32800,
+}
+
+-- =========================================================================
+-- LSP Types — Constructor Functions
+-- =========================================================================
+--
+-- LSP uses a coordinate system based on 0-based lines and UTF-16 code units.
+-- These constructor functions create plain Lua tables that mirror the LSP
+-- specification's TypeScript type definitions.
+--
+-- # Coordinate System
+--
+-- Line 0, character 0 is the very first character of the file. This differs
+-- from most editors (which display 1-based line numbers).
+--
+-- # UTF-16 Code Units
+--
+-- LSP's "character" offset is measured in UTF-16 CODE UNITS, not bytes or
+-- Unicode codepoints. This is a historical artifact from VS Code using
+-- TypeScript (which uses UTF-16 strings internally).
+
+--- Create a Position (cursor location in a document).
+-- Both line and character are 0-based. Character is in UTF-16 code units.
+--
+-- Example: in "hello 🎸 world", the guitar emoji (U+1F3B8) occupies UTF-16
+-- characters 6 and 7 (it requires two surrogates). "world" starts at char 8.
+--
+-- @param line      number  0-based line number
+-- @param character number  0-based character offset in UTF-16 code units
+-- @return          table   {line=N, character=N}
+function M.Position(line, character)
+    return { line = line, character = character }
+end
+
+--- Create a Range (span of text from start inclusive to end exclusive).
+-- Think of it like a text selection: start is where the cursor lands when
+-- you click, end is where you drag to.
+--
+-- @param start_pos table  Position (start, inclusive)
+-- @param end_pos   table  Position (end, exclusive)
+-- @return          table  {start={...}, ["end"]={...}}
+function M.Range(start_pos, end_pos)
+    return { start = start_pos, ["end"] = end_pos }
+end
+
+--- Create a Location (position in a specific file).
+-- URI uses the "file://" scheme, e.g., "file:///home/user/main.lua".
+--
+-- @param uri    string  Document URI
+-- @param range  table   Range within the document
+-- @return       table   {uri=S, range={...}}
+function M.Location(uri, range)
+    return { uri = uri, range = range }
+end
+
+-- Diagnostic severity constants (match LSP integer codes).
+--
+-- | Value | Name        | Meaning                                    |
+-- |-------|-------------|------------------------------------------  |
+-- | 1     | Error       | A hard error; the code cannot run           |
+-- | 2     | Warning     | Potentially problematic, but not blocking   |
+-- | 3     | Information | Informational message                      |
+-- | 4     | Hint        | A suggestion (e.g., "consider using const") |
+M.SEVERITY_ERROR       = 1
+M.SEVERITY_WARNING     = 2
+M.SEVERITY_INFORMATION = 3
+M.SEVERITY_HINT        = 4
+
+--- Create a Diagnostic (error, warning, or hint to display in the editor).
+-- The editor renders diagnostics as underlined squiggles. Red = Error,
+-- yellow = Warning, blue = Info.
+--
+-- @param range    table   Range where the diagnostic applies
+-- @param severity number  One of M.SEVERITY_* constants
+-- @param message  string  Human-readable message
+-- @param code     string  Optional error code (e.g. "E001")
+-- @return         table
+function M.Diagnostic(range, severity, message, code)
+    local d = { range = range, severity = severity, message = message }
+    if code then d.code = code end
+    return d
+end
+
+--- Create a Token (single lexical token from the language's lexer).
+-- Line and Column are 1-based (matching most lexers). The bridge must
+-- convert to 0-based when building SemanticToken values.
+--
+-- @param token_type string  e.g. "KEYWORD", "IDENTIFIER", "STRING_LIT"
+-- @param value      string  The actual source text, e.g. "let" or "myVar"
+-- @param line       number  1-based line number
+-- @param column     number  1-based column number
+-- @return           table
+function M.Token(token_type, value, line, column)
+    return { type = token_type, value = value, line = line, column = column }
+end
+
+--- Create a TextEdit (single text replacement in a document).
+-- Used by formatting (replace the whole file) and rename (replace occurrences).
+-- If new_text is empty, the range is deleted.
+--
+-- @param range    table   Range to replace
+-- @param new_text string  Replacement text
+-- @return         table
+function M.TextEdit(range, new_text)
+    return { range = range, newText = new_text }
+end
+
+--- Create a WorkspaceEdit (text edits grouped across multiple files).
+-- For rename operations, changes maps URIs to arrays of TextEdits.
+--
+-- @param changes table  {[uri] = {TextEdit, ...}, ...}
+-- @return        table
+function M.WorkspaceEdit(changes)
+    return { changes = changes }
+end
+
+--- Create a HoverResult (content to show in the hover popup).
+-- Contents is Markdown text. Range is optional.
+--
+-- @param contents string  Markdown text
+-- @param range    table   Optional: range to highlight while hover is shown
+-- @return         table
+function M.HoverResult(contents, range)
+    local h = { contents = contents }
+    if range then h.range = range end
+    return h
+end
+
+-- CompletionItemKind constants — classify autocomplete suggestions so the
+-- editor shows the right icon (function icon, variable icon, etc.).
+M.COMPLETION_TEXT            = 1
+M.COMPLETION_METHOD          = 2
+M.COMPLETION_FUNCTION        = 3
+M.COMPLETION_CONSTRUCTOR     = 4
+M.COMPLETION_FIELD           = 5
+M.COMPLETION_VARIABLE        = 6
+M.COMPLETION_CLASS           = 7
+M.COMPLETION_INTERFACE       = 8
+M.COMPLETION_MODULE          = 9
+M.COMPLETION_PROPERTY        = 10
+M.COMPLETION_UNIT            = 11
+M.COMPLETION_VALUE           = 12
+M.COMPLETION_ENUM            = 13
+M.COMPLETION_KEYWORD         = 14
+M.COMPLETION_SNIPPET         = 15
+M.COMPLETION_COLOR           = 16
+M.COMPLETION_FILE            = 17
+M.COMPLETION_REFERENCE       = 18
+M.COMPLETION_FOLDER          = 19
+M.COMPLETION_ENUM_MEMBER     = 20
+M.COMPLETION_CONSTANT        = 21
+M.COMPLETION_STRUCT          = 22
+M.COMPLETION_EVENT           = 23
+M.COMPLETION_OPERATOR        = 24
+M.COMPLETION_TYPE_PARAMETER  = 25
+
+--- Create a CompletionItem (single autocomplete suggestion).
+--
+-- @param label      string  Display text in the dropdown
+-- @param kind       number  One of M.COMPLETION_* constants
+-- @param detail     string  Optional type/detail string
+-- @param doc        string  Optional documentation
+-- @param insert     string  Optional text to insert (defaults to label)
+-- @return           table
+function M.CompletionItem(label, kind, detail, doc, insert)
+    local item = { label = label }
+    if kind then item.kind = kind end
+    if detail then item.detail = detail end
+    if doc then item.documentation = doc end
+    if insert then item.insertText = insert end
+    return item
+end
+
+--- Create a SemanticToken (one token's contribution to semantic highlighting).
+-- Line and Character are 0-based. TokenType and Modifiers reference entries
+-- in the legend returned by semantic_token_legend().
+--
+-- @param line       number    0-based line
+-- @param character  number    0-based, UTF-16 code units
+-- @param length     number    In UTF-16 code units
+-- @param token_type string    Must match an entry in the legend's token_types
+-- @param modifiers  table     Array of modifier strings (subset of legend)
+-- @return           table
+function M.SemanticToken(line, character, length, token_type, modifiers)
+    return {
+        line = line,
+        character = character,
+        length = length,
+        token_type = token_type,
+        modifiers = modifiers or {},
+    }
+end
+
+-- SymbolKind constants — classify document symbols for the outline panel.
+M.SYMBOL_FILE            = 1
+M.SYMBOL_MODULE          = 2
+M.SYMBOL_NAMESPACE       = 3
+M.SYMBOL_PACKAGE         = 4
+M.SYMBOL_CLASS           = 5
+M.SYMBOL_METHOD          = 6
+M.SYMBOL_PROPERTY        = 7
+M.SYMBOL_FIELD           = 8
+M.SYMBOL_CONSTRUCTOR     = 9
+M.SYMBOL_ENUM            = 10
+M.SYMBOL_INTERFACE       = 11
+M.SYMBOL_FUNCTION        = 12
+M.SYMBOL_VARIABLE        = 13
+M.SYMBOL_CONSTANT        = 14
+M.SYMBOL_STRING          = 15
+M.SYMBOL_NUMBER          = 16
+M.SYMBOL_BOOLEAN         = 17
+M.SYMBOL_ARRAY           = 18
+M.SYMBOL_OBJECT          = 19
+M.SYMBOL_KEY             = 20
+M.SYMBOL_NULL            = 21
+M.SYMBOL_ENUM_MEMBER     = 22
+M.SYMBOL_STRUCT          = 23
+M.SYMBOL_EVENT           = 24
+M.SYMBOL_OPERATOR        = 25
+M.SYMBOL_TYPE_PARAMETER  = 26
+
+--- Create a DocumentSymbol (one entry in the document outline panel).
+-- Range covers the entire symbol. SelectionRange covers just the name.
+-- Children allows nesting: a class can contain method symbols.
+--
+-- @param name            string  Symbol name
+-- @param kind            number  One of M.SYMBOL_* constants
+-- @param range           table   Range covering the entire symbol
+-- @param selection_range table   Range of just the symbol's name
+-- @param children        table   Optional array of child DocumentSymbols
+-- @return                table
+function M.DocumentSymbol(name, kind, range, selection_range, children)
+    local s = {
+        name = name,
+        kind = kind,
+        range = range,
+        selectionRange = selection_range,
+    }
+    if children and #children > 0 then s.children = children end
+    return s
+end
+
+--- Create a FoldingRange (collapsible region in the document).
+-- The editor shows a collapse arrow in the gutter next to start_line.
+--
+-- @param start_line number  0-based start line
+-- @param end_line   number  0-based end line
+-- @param kind       string  Optional: "region", "imports", or "comment"
+-- @return           table
+function M.FoldingRange(start_line, end_line, kind)
+    local r = { startLine = start_line, endLine = end_line }
+    if kind then r.kind = kind end
+    return r
+end
+
+--- Create a ParameterInformation (one parameter in a function signature).
+--
+-- @param label string  Parameter label text
+-- @param doc   string  Optional documentation
+-- @return      table
+function M.ParameterInformation(label, doc)
+    local p = { label = label }
+    if doc then p.documentation = doc end
+    return p
+end
+
+--- Create a SignatureInformation (one function overload's signature).
+--
+-- @param label      string  Full signature string
+-- @param doc        string  Optional documentation
+-- @param parameters table   Optional array of ParameterInformation
+-- @return           table
+function M.SignatureInformation(label, doc, parameters)
+    local s = { label = label }
+    if doc then s.documentation = doc end
+    if parameters then s.parameters = parameters end
+    return s
+end
+
+--- Create a SignatureHelpResult (tooltip for function call arguments).
+--
+-- @param signatures       table   Array of SignatureInformation
+-- @param active_signature number  Index into signatures
+-- @param active_parameter number  Index into the active signature's parameters
+-- @return                 table
+function M.SignatureHelpResult(signatures, active_signature, active_parameter)
+    return {
+        signatures = signatures,
+        activeSignature = active_signature,
+        activeParameter = active_parameter,
+    }
+end
+
+-- =========================================================================
+-- UTF-16 Conversion
+-- =========================================================================
+--
+-- # Why UTF-16?
+--
+-- LSP character offsets are measured in UTF-16 code units because VS Code's
+-- internal string representation is UTF-16 (as is JavaScript's String type).
+-- Lua strings are byte strings (effectively UTF-8). We must convert between
+-- the two.
+--
+-- # How UTF-8 encoding works
+--
+-- UTF-8 encodes Unicode codepoints into 1-4 bytes:
+--
+--   Codepoint range     | UTF-8 bytes | Leading byte pattern
+--   --------------------|-------------|---------------------
+--   U+0000 - U+007F    | 1 byte      | 0xxxxxxx
+--   U+0080 - U+07FF    | 2 bytes     | 110xxxxx 10xxxxxx
+--   U+0800 - U+FFFF    | 3 bytes     | 1110xxxx 10xxxxxx 10xxxxxx
+--   U+10000 - U+10FFFF | 4 bytes     | 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
+--
+-- # How UTF-16 encoding works
+--
+-- UTF-16 encodes codepoints into 1 or 2 "code units" (each 16 bits):
+--   - Basic Multilingual Plane (U+0000 - U+FFFF): 1 code unit
+--   - Above U+FFFF (emoji, rare CJK): 2 code units (a "surrogate pair")
+--
+-- The guitar emoji 🎸 (U+1F3B8) is above U+FFFF:
+--   UTF-8:  4 bytes  (0xF0 0x9F 0x8E 0xB8)
+--   UTF-16: 2 code units (surrogate pair)
+--
+-- So we cannot simply equate "UTF-16 character N" with "byte N" in the Lua
+-- string. We must walk the UTF-8 bytes, counting UTF-16 code units.
+
+--- Determine the number of bytes in a UTF-8 sequence from its leading byte.
+-- The leading byte's high bits tell us the sequence length:
+--   0xxxxxxx -> 1 byte  (ASCII)
+--   110xxxxx -> 2 bytes
+--   1110xxxx -> 3 bytes
+--   11110xxx -> 4 bytes
+--   10xxxxxx -> continuation byte (should not be a leading byte)
+--
+-- @param byte_val number  The byte value (0-255)
+-- @return         number  Sequence length (1-4), or 1 for invalid bytes
+local function utf8_sequence_length(byte_val)
+    if byte_val < 0x80 then return 1       -- ASCII: 0xxxxxxx
+    elseif byte_val < 0xC0 then return 1   -- continuation byte (invalid as leader)
+    elseif byte_val < 0xE0 then return 2   -- 110xxxxx
+    elseif byte_val < 0xF0 then return 3   -- 1110xxxx
+    else return 4                           -- 11110xxx
+    end
+end
+
+--- Determine the number of UTF-16 code units for a UTF-8 sequence.
+-- 4-byte UTF-8 sequences encode codepoints above U+FFFF, which need
+-- 2 UTF-16 code units (a surrogate pair). All others need 1.
+--
+-- @param seq_len number  UTF-8 sequence length (1-4)
+-- @return        number  UTF-16 code units (1 or 2)
+local function utf16_units_for_sequence(seq_len)
+    if seq_len == 4 then return 2 end
+    return 1
+end
+
+--- Convert a (line, UTF-16 character) position to a byte offset in a UTF-8 string.
+--
+-- Algorithm:
+--  1. Walk the string byte-by-byte to find the start of the target line
+--     (counting newline characters).
+--  2. From the line start, walk UTF-8 codepoints, converting each to its
+--     UTF-16 length, until we reach the target character offset.
+--
+-- @param text string  UTF-8 encoded source text
+-- @param line number  0-based line number
+-- @param char number  0-based UTF-16 character offset within the line
+-- @return     number  1-based byte offset in the Lua string
+function M.convert_utf16_offset_to_byte_offset(text, line, char)
+    local len = #text
+    local pos = 1  -- 1-based byte position (Lua convention)
+
+    -- Phase 1: skip to the target line by counting newlines.
+    local current_line = 0
+    while current_line < line do
+        if pos > len then
+            -- Line number exceeds file length; clamp to end.
+            return len + 1
+        end
+        local b = string.byte(text, pos)
+        if b == 10 then  -- '\n'
+            current_line = current_line + 1
+        end
+        pos = pos + 1
+    end
+
+    -- Phase 2: from the line start, advance char UTF-16 code units.
+    local utf16_count = 0
+    while utf16_count < char and pos <= len do
+        local b = string.byte(text, pos)
+        -- Stop at newline — don't advance past the end of the line.
+        if b == 10 then
+            break
+        end
+        local seq_len = utf8_sequence_length(b)
+        local utf16_len = utf16_units_for_sequence(seq_len)
+
+        if utf16_count + utf16_len > char then
+            -- This codepoint would overshoot. Stop here.
+            -- Can happen in the middle of a surrogate pair.
+            break
+        end
+
+        pos = pos + seq_len
+        utf16_count = utf16_count + utf16_len
+    end
+
+    return pos
+end
+
+-- =========================================================================
+-- DocumentManager
+-- =========================================================================
+--
+-- When the user opens a file in VS Code, the editor sends didOpen with the
+-- full file content. After that, it sends incremental changes (what changed,
+-- and where). The DocumentManager applies these changes to maintain the
+-- current text of each open file.
+--
+--   Editor opens file:  didOpen   -> store text at version 1
+--   User types "X":     didChange -> apply delta -> version 2
+--   User saves:         didSave   -> (optional: trigger format)
+--   User closes:        didClose  -> remove entry
+
+--- Document represents an open file.
+-- @field uri     string  Document URI
+-- @field text    string  Current content (UTF-8)
+-- @field version number  Monotonically increasing version number
+
+local DocumentManager = {}
+DocumentManager.__index = DocumentManager
+
+--- Create a new, empty DocumentManager.
+-- @return DocumentManager
+function DocumentManager:new()
+    return setmetatable({ docs = {} }, self)
+end
+
+--- Record a newly opened file.
+-- @param uri     string  Document URI
+-- @param text    string  Initial file content
+-- @param version number  Initial version number (typically 1)
+function DocumentManager:open(uri, text, version)
+    self.docs[uri] = { uri = uri, text = text, version = version }
+end
+
+--- Get the document for a URI.
+-- @param uri string  Document URI
+-- @return    table   Document table, or nil if not open
+function DocumentManager:get(uri)
+    return self.docs[uri]
+end
+
+--- Remove a document from the manager.
+-- @param uri string  Document URI
+function DocumentManager:close(uri)
+    self.docs[uri] = nil
+end
+
+--- Apply incremental changes to an open document.
+-- Changes are applied in order. Each change has:
+--   - range: optional table {start={line,character}, ["end"]={line,character}}
+--            nil means full replacement
+--   - text:  the new text to splice in (or the full replacement text)
+--
+-- @param uri     string  Document URI
+-- @param changes table   Array of {range=..., text=...}
+-- @param version number  New version number after changes
+-- @return        string  nil on success, error message on failure
+function DocumentManager:apply_changes(uri, changes, version)
+    local doc = self.docs[uri]
+    if not doc then
+        return "document not open: " .. uri
+    end
+
+    for _, change in ipairs(changes) do
+        if change.range == nil then
+            -- Full document replacement — simplest case.
+            doc.text = change.text
+        else
+            -- Incremental update: splice new text at the specified range.
+            local new_text, err = apply_range_change(doc.text, change.range, change.text)
+            if err then
+                return "applying change to " .. uri .. ": " .. err
+            end
+            doc.text = new_text
+        end
+    end
+
+    doc.version = version
+    return nil
+end
+
+M.DocumentManager = DocumentManager
+
+--- Apply a single range change to a text string.
+-- Converts LSP (line, UTF-16 character) coordinates to byte offsets, then
+-- splices the new text in.
+--
+-- @param text     string  Current document text
+-- @param range    table   LSP range {start={line,character}, ["end"]={line,character}}
+-- @param new_text string  Replacement text
+-- @return         string  New text after the splice
+-- @return         string  Error message, or nil
+function apply_range_change(text, range, new_text)
+    local start_byte = M.convert_utf16_offset_to_byte_offset(
+        text, range.start.line, range.start.character)
+    local end_byte = M.convert_utf16_offset_to_byte_offset(
+        text, range["end"].line, range["end"].character)
+
+    if start_byte > end_byte then
+        return nil, string.format("start offset %d > end offset %d", start_byte, end_byte)
+    end
+    if end_byte > #text + 1 then
+        end_byte = #text + 1
+    end
+
+    -- Lua strings are 1-based. text:sub(1, start_byte - 1) gets bytes before
+    -- the start. text:sub(end_byte) gets bytes from end onward.
+    return text:sub(1, start_byte - 1) .. new_text .. text:sub(end_byte), nil
+end
+
+-- =========================================================================
+-- ParseCache
+-- =========================================================================
+--
+-- Parsing is the most expensive operation in a language server. For a large
+-- file, parsing on every keystroke would lag the editor noticeably.
+--
+-- The cache key is (uri, version). Version is a monotonically increasing
+-- integer that the editor increments with each change. Same (uri, version)
+-- means the document has not changed => cache hit.
+--
+-- The old entry is evicted when a new version is cached for the same URI.
+-- This keeps memory bounded at O(open_documents) entries.
+
+local ParseCache = {}
+ParseCache.__index = ParseCache
+
+--- Create a new, empty ParseCache.
+-- @return ParseCache
+function ParseCache:new()
+    return setmetatable({ cache = {} }, self)
+end
+
+--- Build a cache key string from uri and version.
+-- Using string concatenation as the key avoids needing a two-level lookup.
+--
+-- @param uri     string
+-- @param version number
+-- @return        string
+local function cache_key(uri, version)
+    return uri .. "\0" .. tostring(version)
+end
+
+--- Get or compute the parse result for a document.
+-- If the result is already cached, it is returned immediately. Otherwise,
+-- bridge.parse(source) is called and the result is stored.
+--
+-- @param uri     string           Document URI
+-- @param version number           Document version
+-- @param source  string           Document text
+-- @param bridge  table            Language bridge table
+-- @return        table            {ast=..., diagnostics={...}, err=...}
+function ParseCache:get_or_parse(uri, version, source, bridge)
+    local key = cache_key(uri, version)
+
+    -- Cache hit: document has not changed since last parse.
+    if self.cache[key] then
+        return self.cache[key]
+    end
+
+    -- Cache miss: evict old entries for this URI, then parse.
+    self:evict(uri)
+
+    local ast, diags, err = bridge.parse(source)
+    if diags == nil then
+        diags = {}  -- normalize nil to empty table for consistent iteration
+    end
+
+    local result = {
+        ast = ast,
+        diagnostics = diags,
+        err = err,
+    }
+    self.cache[key] = result
+    return result
+end
+
+--- Remove all cached entries for a given URI.
+-- Called when a document is closed, or internally before adding a new entry.
+--
+-- @param uri string  Document URI
+function ParseCache:evict(uri)
+    -- Walk all keys and remove any that start with this URI.
+    local prefix = uri .. "\0"
+    local to_remove = {}
+    for k in pairs(self.cache) do
+        if k:sub(1, #prefix) == prefix then
+            to_remove[#to_remove + 1] = k
+        end
+    end
+    for _, k in ipairs(to_remove) do
+        self.cache[k] = nil
+    end
+end
+
+M.ParseCache = ParseCache
+
+-- =========================================================================
+-- Semantic Token Legend & Encoding
+-- =========================================================================
+--
+-- Semantic tokens are the "second pass" of syntax highlighting. The editor's
+-- grammar-based highlighter (TextMate) does a fast regex pass first. Semantic
+-- tokens layer on top with accurate, context-aware type information.
+--
+-- Instead of sending {"type":"keyword"} per token, LSP uses a compact integer
+-- encoding with a legend. The legend maps integer indices to type/modifier names.
+
+--- Return the standard semantic token legend.
+-- The legend is sent once in the capabilities response. Afterwards, each
+-- token is encoded as an integer index into this legend.
+--
+-- @return table  {token_types={...}, token_modifiers={...}}
+function M.semantic_token_legend()
+    return {
+        -- Standard LSP token types (in the order VS Code expects).
+        token_types = {
+            "namespace",     -- 0 (indices are 0-based in LSP)
+            "type",          -- 1
+            "class",         -- 2
+            "enum",          -- 3
+            "interface",     -- 4
+            "struct",        -- 5
+            "typeParameter", -- 6
+            "parameter",     -- 7
+            "variable",      -- 8
+            "property",      -- 9
+            "enumMember",    -- 10
+            "event",         -- 11
+            "function",      -- 12
+            "method",        -- 13
+            "macro",         -- 14
+            "keyword",       -- 15
+            "modifier",      -- 16
+            "comment",       -- 17
+            "string",        -- 18
+            "number",        -- 19
+            "regexp",        -- 20
+            "operator",      -- 21
+            "decorator",     -- 22
+        },
+        -- Standard LSP token modifiers (bitmask flags).
+        -- tokenModifier[0] = "declaration" -> bit 0 (value 1)
+        -- tokenModifier[1] = "definition"  -> bit 1 (value 2)
+        token_modifiers = {
+            "declaration",   -- bit 0
+            "definition",    -- bit 1
+            "readonly",      -- bit 2
+            "static",        -- bit 3
+            "deprecated",    -- bit 4
+            "abstract",      -- bit 5
+            "async",         -- bit 6
+            "modification",  -- bit 7
+            "documentation", -- bit 8
+            "defaultLibrary", -- bit 9
+        },
+    }
+end
+
+--- Find the 0-based index of a token type in the legend.
+-- Returns -1 if the type is not found (caller should skip such tokens).
+--
+-- @param token_type string  Token type name
+-- @return           number  0-based index, or -1
+local function token_type_index(token_type)
+    local legend = M.semantic_token_legend()
+    for i, t in ipairs(legend.token_types) do
+        if t == token_type then
+            return i - 1  -- convert Lua 1-based to LSP 0-based
+        end
+    end
+    return -1
+end
+
+--- Compute the bitmask for a list of modifier strings.
+-- Each modifier maps to a bit position based on its index in the legend.
+-- Multiple modifiers are combined with bitwise OR.
+--
+-- Example: {"declaration", "readonly"} -> bit 0 | bit 2 = 5
+--
+-- @param modifiers table  Array of modifier strings
+-- @return          number Bitmask
+local function token_modifier_mask(modifiers)
+    if not modifiers then return 0 end
+    local legend = M.semantic_token_legend()
+    local mask = 0
+    for _, mod in ipairs(modifiers) do
+        for i, m in ipairs(legend.token_modifiers) do
+            if m == mod then
+                -- Lua's bit operations: use math for portability with Lua 5.1.
+                -- Bit i-1 (0-based) has value 2^(i-1).
+                mask = mask + (2 ^ (i - 1))
+                break
+            end
+        end
+    end
+    -- Ensure the mask is an integer.
+    return math.floor(mask)
+end
+
+--- Encode semantic tokens into the LSP compact integer format.
+--
+-- LSP encodes semantic tokens as a flat array of integers, grouped in 5-tuples:
+--
+--   [deltaLine, deltaStartChar, length, tokenTypeIndex, tokenModifierBitmask, ...]
+--
+-- Where "delta" means the difference from the PREVIOUS token's position.
+-- This delta encoding makes most values small (often 0 or 1).
+--
+-- When deltaLine > 0, deltaStartChar is absolute for the new line (relative
+-- to column 0). When deltaLine == 0, deltaStartChar is relative to the
+-- previous token's start character.
+--
+-- Example with three tokens:
+--
+--   Token A: line=0, char=0, len=3, type="keyword",  modifiers={}
+--   Token B: line=0, char=4, len=5, type="function", modifiers={"declaration"}
+--   Token C: line=1, char=0, len=8, type="variable", modifiers={}
+--
+-- Encoded as:
+--   {0, 0, 3, 15, 0,   -- A: first token, absolute position
+--    0, 4, 5, 12, 1,   -- B: same line, 4 chars after A
+--    1, 0, 8,  8, 0}   -- C: next line, absolute char on new line
+--
+-- @param tokens table  Array of SemanticToken tables
+-- @return       table  Flat array of integers
+function M.encode_semantic_tokens(tokens)
+    if not tokens or #tokens == 0 then
+        return {}
+    end
+
+    -- Sort by (line, character) ascending. Delta encoding requires document order.
+    local sorted = {}
+    for i, tok in ipairs(tokens) do
+        sorted[i] = tok
+    end
+    table.sort(sorted, function(a, b)
+        if a.line ~= b.line then
+            return a.line < b.line
+        end
+        return a.character < b.character
+    end)
+
+    local data = {}
+    local prev_line = 0
+    local prev_char = 0
+
+    for _, tok in ipairs(sorted) do
+        local type_idx = token_type_index(tok.token_type)
+        if type_idx == -1 then
+            -- Unknown token type — skip it. The client wouldn't know what to
+            -- do with an index outside the legend anyway.
+            goto continue
+        end
+
+        local delta_line = tok.line - prev_line
+        local delta_char
+        if delta_line == 0 then
+            -- Same line: character offset is relative to previous token.
+            delta_char = tok.character - prev_char
+        else
+            -- Different line: character offset is absolute (relative to line start).
+            delta_char = tok.character
+        end
+
+        local mod_mask = token_modifier_mask(tok.modifiers)
+
+        data[#data + 1] = delta_line
+        data[#data + 1] = delta_char
+        data[#data + 1] = tok.length
+        data[#data + 1] = type_idx
+        data[#data + 1] = mod_mask
+
+        prev_line = tok.line
+        prev_char = tok.character
+
+        ::continue::
+    end
+
+    return data
+end
+
+-- =========================================================================
+-- Capabilities
+-- =========================================================================
+--
+-- During the initialize handshake, the server sends a "capabilities" object
+-- telling the editor which features it supports. If a capability is absent,
+-- the editor won't send the corresponding requests.
+--
+-- Building capabilities dynamically (based on the bridge's function fields)
+-- means the server is always honest about what it can do.
+
+--- Build the LSP capabilities object based on which functions the bridge provides.
+-- Uses Lua's nil check: if bridge.hover ~= nil, advertise hoverProvider.
+--
+-- @param bridge table  Language bridge table
+-- @return       table  LSP capabilities object
+function M.build_capabilities(bridge)
+    -- textDocumentSync=2 means "incremental": the editor sends only changed
+    -- ranges, not the full file, on every keystroke.
+    local caps = {
+        textDocumentSync = 2,
+    }
+
+    if bridge.hover ~= nil then
+        caps.hoverProvider = true
+    end
+
+    if bridge.definition ~= nil then
+        caps.definitionProvider = true
+    end
+
+    if bridge.references ~= nil then
+        caps.referencesProvider = true
+    end
+
+    if bridge.completion ~= nil then
+        -- completionProvider is an object with trigger characters.
+        caps.completionProvider = {
+            triggerCharacters = { " ", "." },
+        }
+    end
+
+    if bridge.rename ~= nil then
+        caps.renameProvider = true
+    end
+
+    if bridge.document_symbols ~= nil then
+        caps.documentSymbolProvider = true
+    end
+
+    if bridge.folding_ranges ~= nil then
+        caps.foldingRangeProvider = true
+    end
+
+    if bridge.signature_help ~= nil then
+        -- signatureHelpProvider includes trigger characters.
+        caps.signatureHelpProvider = {
+            triggerCharacters = { "(", "," },
+        }
+    end
+
+    if bridge.format ~= nil then
+        caps.documentFormattingProvider = true
+    end
+
+    if bridge.semantic_tokens ~= nil then
+        caps.semanticTokensProvider = {
+            legend = M.semantic_token_legend(),
+            full = true,
+        }
+    end
+
+    return caps
+end
+
+-- =========================================================================
+-- LspServer
+-- =========================================================================
+--
+-- The LspServer wires together:
+--   - The bridge (language-specific logic)
+--   - The DocumentManager (tracks open file contents)
+--   - The ParseCache (avoids redundant parses)
+--   - The JSON-RPC Server (protocol layer)
+--
+-- It registers all LSP handlers with the JSON-RPC server, then calls
+-- serve() to start the blocking read-dispatch-write loop.
+
+local LspServer = {}
+LspServer.__index = LspServer
+
+--- Create a new LspServer.
+--
+-- @param bridge     table  Language bridge table (must have tokenize and parse)
+-- @param in_stream  table  Readable stream (must have :read() method)
+-- @param out_stream table  Writable stream (must have :write() method)
+-- @return           LspServer
+function LspServer:new(bridge, in_stream, out_stream)
+    local server = setmetatable({
+        bridge      = bridge,
+        doc_manager = DocumentManager:new(),
+        parse_cache = ParseCache:new(),
+        rpc_server  = json_rpc.Server:new(in_stream, out_stream),
+        writer      = json_rpc.MessageWriter:new(out_stream),
+        shutdown    = false,
+        initialized = false,
+    }, self)
+
+    server:register_handlers()
+    return server
+end
+
+--- Start the blocking JSON-RPC read-dispatch-write loop.
+-- This call blocks until the editor closes the connection (EOF on stdin).
+function LspServer:serve()
+    self.rpc_server:serve()
+end
+
+--- Send a server-initiated notification to the editor.
+-- Used for pushing diagnostics, etc. Notifications have no "id" and
+-- the editor sends no response.
+--
+-- @param method string  Notification method name
+-- @param params table   Notification parameters
+function LspServer:send_notification(method, params)
+    local notif = json_rpc.Notification(method, params)
+    self.writer:write_message(notif)
+end
+
+--- Get the current parse result for a document.
+-- This is the hot path for all feature handlers. It gets the document from
+-- the DocumentManager and returns the cached ParseResult (or re-parses).
+--
+-- @param uri string  Document URI
+-- @return    table   Document table
+-- @return    table   ParseResult {ast, diagnostics, err}
+-- @return    table   Error response table, or nil
+function LspServer:get_parse_result(uri)
+    local doc = self.doc_manager:get(uri)
+    if not doc then
+        return nil, nil, {
+            code = M.errors.REQUEST_FAILED,
+            message = "document not open: " .. uri,
+        }
+    end
+
+    local result = self.parse_cache:get_or_parse(uri, doc.version, doc.text, self.bridge)
+    return doc, result, nil
+end
+
+--- Publish diagnostics (squiggles) to the editor.
+-- Called after every didOpen and didChange to update the editor's display.
+--
+-- @param uri         string  Document URI
+-- @param version     number  Document version
+-- @param diagnostics table   Array of Diagnostic tables
+function LspServer:publish_diagnostics(uri, version, diagnostics)
+    local lsp_diags = {}
+    for i, d in ipairs(diagnostics) do
+        local diag = {
+            range = range_to_lsp(d.range),
+            severity = d.severity,
+            message = d.message,
+        }
+        if d.code then
+            diag.code = d.code
+        end
+        lsp_diags[i] = diag
+    end
+
+    local params = {
+        uri = uri,
+        diagnostics = lsp_diags,
+    }
+    if version > 0 then
+        params.version = version
+    end
+
+    self:send_notification("textDocument/publishDiagnostics", params)
+end
+
+-- ─── LSP type conversion helpers ────────────────────────────────────────────
+
+--- Convert a Position to LSP format.
+local function position_to_lsp(p)
+    return { line = p.line, character = p.character }
+end
+
+--- Convert a Range to LSP format.
+function range_to_lsp(r)
+    return {
+        start = position_to_lsp(r.start),
+        ["end"] = position_to_lsp(r["end"]),
+    }
+end
+
+--- Convert a Location to LSP format.
+local function location_to_lsp(l)
+    return {
+        uri = l.uri,
+        range = range_to_lsp(l.range),
+    }
+end
+
+--- Extract a Position from JSON-RPC params.
+local function parse_position(params)
+    local pos = params.position or {}
+    return M.Position(pos.line or 0, pos.character or 0)
+end
+
+--- Extract the document URI from params with a textDocument field.
+local function parse_uri(params)
+    local td = params.textDocument or {}
+    return td.uri or ""
+end
+
+--- Parse a raw LSP range object from the protocol.
+local function parse_lsp_range(raw)
+    if type(raw) ~= "table" then return M.Range(M.Position(0, 0), M.Position(0, 0)) end
+    local s = raw.start or {}
+    local e = raw["end"] or {}
+    return M.Range(
+        M.Position(s.line or 0, s.character or 0),
+        M.Position(e.line or 0, e.character or 0)
+    )
+end
+
+-- ─── Handler Registration ───────────────────────────────────────────────────
+
+--- Wire all LSP method names to their handler functions.
+function LspServer:register_handlers()
+    -- Lifecycle
+    self.rpc_server:on_request("initialize", function(id, params) return self:handle_initialize(id, params) end)
+    self.rpc_server:on_notification("initialized", function(params) self:handle_initialized(params) end)
+    self.rpc_server:on_request("shutdown", function(id, params) return self:handle_shutdown(id, params) end)
+    self.rpc_server:on_notification("exit", function(params) self:handle_exit(params) end)
+
+    -- Text document synchronization
+    self.rpc_server:on_notification("textDocument/didOpen", function(params) self:handle_did_open(params) end)
+    self.rpc_server:on_notification("textDocument/didChange", function(params) self:handle_did_change(params) end)
+    self.rpc_server:on_notification("textDocument/didClose", function(params) self:handle_did_close(params) end)
+    self.rpc_server:on_notification("textDocument/didSave", function(params) self:handle_did_save(params) end)
+
+    -- Feature requests
+    self.rpc_server:on_request("textDocument/hover", function(id, params) return self:handle_hover(id, params) end)
+    self.rpc_server:on_request("textDocument/definition", function(id, params) return self:handle_definition(id, params) end)
+    self.rpc_server:on_request("textDocument/references", function(id, params) return self:handle_references(id, params) end)
+    self.rpc_server:on_request("textDocument/completion", function(id, params) return self:handle_completion(id, params) end)
+    self.rpc_server:on_request("textDocument/rename", function(id, params) return self:handle_rename(id, params) end)
+    self.rpc_server:on_request("textDocument/documentSymbol", function(id, params) return self:handle_document_symbol(id, params) end)
+    self.rpc_server:on_request("textDocument/semanticTokens/full", function(id, params) return self:handle_semantic_tokens_full(id, params) end)
+    self.rpc_server:on_request("textDocument/foldingRange", function(id, params) return self:handle_folding_range(id, params) end)
+    self.rpc_server:on_request("textDocument/signatureHelp", function(id, params) return self:handle_signature_help(id, params) end)
+    self.rpc_server:on_request("textDocument/formatting", function(id, params) return self:handle_formatting(id, params) end)
+end
+
+-- ─── Lifecycle Handlers ─────────────────────────────────────────────────────
+
+--- Handle the initialize request.
+-- The editor sends this as the very first message. We return our capabilities.
+function LspServer:handle_initialize(id, params)
+    self.initialized = true
+    local caps = M.build_capabilities(self.bridge)
+
+    return {
+        capabilities = caps,
+        serverInfo = {
+            name = "ls00-generic-lsp-server",
+            version = "0.1.0",
+        },
+    }
+end
+
+--- Handle the initialized notification (handshake complete, no-op).
+function LspServer:handle_initialized(params)
+    -- No-op. Normal operation begins now.
+end
+
+--- Handle the shutdown request. Set the shutdown flag and return null.
+function LspServer:handle_shutdown(id, params)
+    self.shutdown = true
+    return json_rpc.null
+end
+
+--- Handle the exit notification. Terminate the process.
+function LspServer:handle_exit(params)
+    if self.shutdown then
+        os.exit(0)
+    else
+        os.exit(1)
+    end
+end
+
+-- ─── Text Document Handlers ─────────────────────────────────────────────────
+
+--- Handle textDocument/didOpen.
+-- Store the document and push initial diagnostics.
+function LspServer:handle_did_open(params)
+    if type(params) ~= "table" then return end
+    local td = params.textDocument
+    if type(td) ~= "table" then return end
+
+    local uri = td.uri or ""
+    local text = td.text or ""
+    local version = td.version or 1
+
+    if uri == "" then return end
+
+    self.doc_manager:open(uri, text, version)
+
+    local result = self.parse_cache:get_or_parse(uri, version, text, self.bridge)
+    self:publish_diagnostics(uri, version, result.diagnostics)
+end
+
+--- Handle textDocument/didChange.
+-- Apply incremental changes and push updated diagnostics.
+function LspServer:handle_did_change(params)
+    if type(params) ~= "table" then return end
+
+    local uri = parse_uri(params)
+    if uri == "" then return end
+
+    local version = 0
+    local td = params.textDocument
+    if type(td) == "table" and td.version then
+        version = td.version
+    end
+
+    local content_changes = params.contentChanges or {}
+    local changes = {}
+    for _, change_raw in ipairs(content_changes) do
+        if type(change_raw) == "table" then
+            local change = { text = change_raw.text or "" }
+            if change_raw.range ~= nil then
+                change.range = parse_lsp_range(change_raw.range)
+            end
+            changes[#changes + 1] = change
+        end
+    end
+
+    local err = self.doc_manager:apply_changes(uri, changes, version)
+    if err then return end
+
+    local doc = self.doc_manager:get(uri)
+    if not doc then return end
+
+    local result = self.parse_cache:get_or_parse(uri, doc.version, doc.text, self.bridge)
+    self:publish_diagnostics(uri, version, result.diagnostics)
+end
+
+--- Handle textDocument/didClose.
+-- Remove the document and clear diagnostics.
+function LspServer:handle_did_close(params)
+    if type(params) ~= "table" then return end
+    local uri = parse_uri(params)
+    if uri == "" then return end
+
+    self.doc_manager:close(uri)
+    self.parse_cache:evict(uri)
+
+    -- Clear diagnostics by publishing an empty list.
+    self:publish_diagnostics(uri, 0, {})
+end
+
+--- Handle textDocument/didSave.
+-- Re-parse if the client sends full text in didSave.
+function LspServer:handle_did_save(params)
+    if type(params) ~= "table" then return end
+    local uri = parse_uri(params)
+    if uri == "" then return end
+
+    if params.text and params.text ~= "" then
+        local doc = self.doc_manager:get(uri)
+        if doc then
+            self.doc_manager:close(uri)
+            self.doc_manager:open(uri, params.text, doc.version)
+            local result = self.parse_cache:get_or_parse(uri, doc.version, params.text, self.bridge)
+            self:publish_diagnostics(uri, doc.version, result.diagnostics)
+        end
+    end
+end
+
+-- ─── Feature Handlers ───────────────────────────────────────────────────────
+
+--- Handle textDocument/hover.
+function LspServer:handle_hover(id, params)
+    if type(params) ~= "table" then return json_rpc.null end
+    local uri = parse_uri(params)
+    local pos = parse_position(params)
+
+    if not self.bridge.hover then return json_rpc.null end
+
+    local _, parse_result, err = self:get_parse_result(uri)
+    if err then return err end
+    if not parse_result or not parse_result.ast then return json_rpc.null end
+
+    local ok, hover_result = pcall(self.bridge.hover, parse_result.ast, pos)
+    if not ok or not hover_result then return json_rpc.null end
+
+    local result = {
+        contents = {
+            kind = "markdown",
+            value = hover_result.contents,
+        },
+    }
+    if hover_result.range then
+        result.range = range_to_lsp(hover_result.range)
+    end
+
+    return result
+end
+
+--- Handle textDocument/definition.
+function LspServer:handle_definition(id, params)
+    if type(params) ~= "table" then return json_rpc.null end
+    local uri = parse_uri(params)
+    local pos = parse_position(params)
+
+    if not self.bridge.definition then return json_rpc.null end
+
+    local _, parse_result, err = self:get_parse_result(uri)
+    if err then return err end
+    if not parse_result or not parse_result.ast then return json_rpc.null end
+
+    local ok, loc = pcall(self.bridge.definition, parse_result.ast, pos, uri)
+    if not ok or not loc then return json_rpc.null end
+
+    return location_to_lsp(loc)
+end
+
+--- Handle textDocument/references.
+function LspServer:handle_references(id, params)
+    if type(params) ~= "table" then return {} end
+    local uri = parse_uri(params)
+    local pos = parse_position(params)
+    local ctx = params.context or {}
+    local include_decl = ctx.includeDeclaration or false
+
+    if not self.bridge.references then return {} end
+
+    local _, parse_result, err = self:get_parse_result(uri)
+    if err then return {} end
+    if not parse_result or not parse_result.ast then return {} end
+
+    local ok, locs = pcall(self.bridge.references, parse_result.ast, pos, uri, include_decl)
+    if not ok or not locs then return {} end
+
+    local result = {}
+    for i, loc in ipairs(locs) do
+        result[i] = location_to_lsp(loc)
+    end
+    return result
+end
+
+--- Handle textDocument/completion.
+function LspServer:handle_completion(id, params)
+    if type(params) ~= "table" then return {} end
+    local uri = parse_uri(params)
+    local pos = parse_position(params)
+
+    if not self.bridge.completion then return {} end
+
+    local _, parse_result, err = self:get_parse_result(uri)
+    if err then return {} end
+    if not parse_result or not parse_result.ast then return {} end
+
+    local ok, items = pcall(self.bridge.completion, parse_result.ast, pos)
+    if not ok or not items then return {} end
+
+    return items
+end
+
+--- Handle textDocument/rename.
+function LspServer:handle_rename(id, params)
+    if type(params) ~= "table" then return json_rpc.null end
+    local uri = parse_uri(params)
+    local pos = parse_position(params)
+    local new_name = params.newName or ""
+
+    if not self.bridge.rename then return json_rpc.null end
+
+    local _, parse_result, err = self:get_parse_result(uri)
+    if err then return json_rpc.null end
+    if not parse_result or not parse_result.ast then return json_rpc.null end
+
+    local ok, edit = pcall(self.bridge.rename, parse_result.ast, pos, new_name)
+    if not ok or not edit then return json_rpc.null end
+
+    -- Convert workspace edit to LSP format.
+    local lsp_changes = {}
+    if edit.changes then
+        for file_uri, edits in pairs(edit.changes) do
+            local lsp_edits = {}
+            for i, te in ipairs(edits) do
+                lsp_edits[i] = {
+                    range = range_to_lsp(te.range),
+                    newText = te.newText,
+                }
+            end
+            lsp_changes[file_uri] = lsp_edits
+        end
+    end
+
+    return { changes = lsp_changes }
+end
+
+--- Handle textDocument/documentSymbol.
+function LspServer:handle_document_symbol(id, params)
+    if type(params) ~= "table" then return {} end
+    local uri = parse_uri(params)
+
+    if not self.bridge.document_symbols then return {} end
+
+    local _, parse_result, err = self:get_parse_result(uri)
+    if err then return {} end
+    if not parse_result or not parse_result.ast then return {} end
+
+    local ok, symbols = pcall(self.bridge.document_symbols, parse_result.ast)
+    if not ok or not symbols then return {} end
+
+    -- Convert symbols to LSP format (recursive).
+    local function convert_symbols(syms)
+        local result = {}
+        for i, s in ipairs(syms) do
+            local lsp_sym = {
+                name = s.name,
+                kind = s.kind,
+                range = range_to_lsp(s.range),
+                selectionRange = range_to_lsp(s.selectionRange),
+            }
+            if s.children and #s.children > 0 then
+                lsp_sym.children = convert_symbols(s.children)
+            end
+            result[i] = lsp_sym
+        end
+        return result
+    end
+
+    return convert_symbols(symbols)
+end
+
+--- Handle textDocument/semanticTokens/full.
+function LspServer:handle_semantic_tokens_full(id, params)
+    if type(params) ~= "table" then return { data = {} } end
+    local uri = parse_uri(params)
+
+    if not self.bridge.semantic_tokens then return { data = {} } end
+
+    local doc = self.doc_manager:get(uri)
+    if not doc then return { data = {} } end
+
+    local ok_tok, tokens = pcall(self.bridge.tokenize, doc.text)
+    if not ok_tok or not tokens then return { data = {} } end
+
+    local ok_sem, sem_tokens = pcall(self.bridge.semantic_tokens, doc.text, tokens)
+    if not ok_sem or not sem_tokens then return { data = {} } end
+
+    local data = M.encode_semantic_tokens(sem_tokens)
+    return { data = data }
+end
+
+--- Handle textDocument/foldingRange.
+function LspServer:handle_folding_range(id, params)
+    if type(params) ~= "table" then return {} end
+    local uri = parse_uri(params)
+
+    if not self.bridge.folding_ranges then return {} end
+
+    local _, parse_result, err = self:get_parse_result(uri)
+    if err then return {} end
+    if not parse_result or not parse_result.ast then return {} end
+
+    local ok, ranges = pcall(self.bridge.folding_ranges, parse_result.ast)
+    if not ok or not ranges then return {} end
+
+    return ranges
+end
+
+--- Handle textDocument/signatureHelp.
+function LspServer:handle_signature_help(id, params)
+    if type(params) ~= "table" then return json_rpc.null end
+    local uri = parse_uri(params)
+    local pos = parse_position(params)
+
+    if not self.bridge.signature_help then return json_rpc.null end
+
+    local _, parse_result, err = self:get_parse_result(uri)
+    if err then return json_rpc.null end
+    if not parse_result or not parse_result.ast then return json_rpc.null end
+
+    local ok, result = pcall(self.bridge.signature_help, parse_result.ast, pos)
+    if not ok or not result then return json_rpc.null end
+
+    return result
+end
+
+--- Handle textDocument/formatting.
+function LspServer:handle_formatting(id, params)
+    if type(params) ~= "table" then return {} end
+    local uri = parse_uri(params)
+
+    if not self.bridge.format then return {} end
+
+    local doc = self.doc_manager:get(uri)
+    if not doc then return {} end
+
+    local ok, edits = pcall(self.bridge.format, doc.text)
+    if not ok or not edits then return {} end
+
+    -- Convert text edits to LSP format.
+    local result = {}
+    for i, te in ipairs(edits) do
+        result[i] = {
+            range = range_to_lsp(te.range),
+            newText = te.newText,
+        }
+    end
+    return result
+end
+
+M.LspServer = LspServer
+
+-- =========================================================================
+-- Module exports
+-- =========================================================================
+
+return M

--- a/code/packages/lua/ls00/tests/test_capabilities.lua
+++ b/code/packages/lua/ls00/tests/test_capabilities.lua
@@ -1,0 +1,131 @@
+-- test_capabilities.lua — Capabilities advertisement tests
+-- ========================================================
+--
+-- The server advertises capabilities based on which functions the bridge
+-- provides. A minimal bridge (only tokenize + parse) should only advertise
+-- textDocumentSync. A full bridge should advertise all optional capabilities.
+--
+-- This tests the build_capabilities() function which inspects the bridge
+-- table at runtime.
+
+local ls00 = require("coding_adventures.ls00")
+
+-- A minimal bridge with only the required functions.
+local function make_minimal_bridge()
+    return {
+        tokenize = function(source) return {}, nil end,
+        parse = function(source) return source, {}, nil end,
+    }
+end
+
+-- A bridge with hover and document_symbols (like the Go MockBridge).
+local function make_mock_bridge()
+    return {
+        tokenize = function(source) return {}, nil end,
+        parse = function(source) return source, {}, nil end,
+        hover = function(ast, pos) return nil end,
+        document_symbols = function(ast) return {} end,
+    }
+end
+
+-- A full bridge with ALL optional capabilities.
+local function make_full_bridge()
+    return {
+        tokenize = function(source) return {}, nil end,
+        parse = function(source) return source, {}, nil end,
+        hover = function(ast, pos) return nil end,
+        definition = function(ast, pos, uri) return nil end,
+        references = function(ast, pos, uri, incl) return {} end,
+        completion = function(ast, pos) return {} end,
+        rename = function(ast, pos, name) return nil end,
+        semantic_tokens = function(source, tokens) return {} end,
+        document_symbols = function(ast) return {} end,
+        folding_ranges = function(ast) return {} end,
+        signature_help = function(ast, pos) return nil end,
+        format = function(source) return {} end,
+    }
+end
+
+describe("build_capabilities", function()
+    it("always includes textDocumentSync", function()
+        local bridge = make_minimal_bridge()
+        local caps = ls00.build_capabilities(bridge)
+        assert.are.equal(2, caps.textDocumentSync)
+    end)
+
+    it("omits optional capabilities for minimal bridge", function()
+        local bridge = make_minimal_bridge()
+        local caps = ls00.build_capabilities(bridge)
+
+        local optional = {
+            "hoverProvider", "definitionProvider", "referencesProvider",
+            "completionProvider", "renameProvider", "documentSymbolProvider",
+            "foldingRangeProvider", "signatureHelpProvider",
+            "documentFormattingProvider", "semanticTokensProvider",
+        }
+        for _, cap in ipairs(optional) do
+            assert.is_nil(caps[cap], "minimal bridge should not advertise " .. cap)
+        end
+    end)
+
+    it("advertises hoverProvider when bridge has hover", function()
+        local bridge = make_mock_bridge()
+        local caps = ls00.build_capabilities(bridge)
+        assert.is_true(caps.hoverProvider)
+    end)
+
+    it("advertises documentSymbolProvider when bridge has document_symbols", function()
+        local bridge = make_mock_bridge()
+        local caps = ls00.build_capabilities(bridge)
+        assert.is_true(caps.documentSymbolProvider)
+    end)
+
+    it("advertises all capabilities for full bridge", function()
+        local bridge = make_full_bridge()
+        local caps = ls00.build_capabilities(bridge)
+
+        assert.are.equal(2, caps.textDocumentSync)
+        assert.is_true(caps.hoverProvider)
+        assert.is_true(caps.definitionProvider)
+        assert.is_true(caps.referencesProvider)
+        assert.is_not_nil(caps.completionProvider)
+        assert.is_true(caps.renameProvider)
+        assert.is_true(caps.documentSymbolProvider)
+        assert.is_true(caps.foldingRangeProvider)
+        assert.is_not_nil(caps.signatureHelpProvider)
+        assert.is_true(caps.documentFormattingProvider)
+        assert.is_not_nil(caps.semanticTokensProvider)
+    end)
+
+    it("includes semanticTokensProvider with legend and full=true", function()
+        local bridge = make_full_bridge()
+        local caps = ls00.build_capabilities(bridge)
+
+        local stp = caps.semanticTokensProvider
+        assert.is_not_nil(stp)
+        assert.is_true(stp.full)
+        assert.is_not_nil(stp.legend)
+        assert.is_not_nil(stp.legend.token_types)
+        assert.is_not_nil(stp.legend.token_modifiers)
+    end)
+
+    it("includes completionProvider with trigger characters", function()
+        local bridge = make_full_bridge()
+        local caps = ls00.build_capabilities(bridge)
+
+        local cp = caps.completionProvider
+        assert.is_not_nil(cp)
+        assert.is_not_nil(cp.triggerCharacters)
+        assert.are.equal(2, #cp.triggerCharacters)
+    end)
+
+    it("includes signatureHelpProvider with trigger characters", function()
+        local bridge = make_full_bridge()
+        local caps = ls00.build_capabilities(bridge)
+
+        local shp = caps.signatureHelpProvider
+        assert.is_not_nil(shp)
+        assert.is_not_nil(shp.triggerCharacters)
+        assert.are.equal(2, #shp.triggerCharacters)
+    end)
+end)

--- a/code/packages/lua/ls00/tests/test_document_manager.lua
+++ b/code/packages/lua/ls00/tests/test_document_manager.lua
@@ -1,0 +1,127 @@
+-- test_document_manager.lua — DocumentManager tests
+-- ==================================================
+--
+-- The DocumentManager tracks all files currently open in the editor.
+-- It handles open/change/close operations and maintains the current text
+-- of each file. These tests verify:
+--
+--   1. Opening a document stores its text and version
+--   2. Getting a non-existent document returns nil
+--   3. Closing a document removes it
+--   4. Full replacement changes work
+--   5. Incremental (range-based) changes work
+--   6. Applying changes to a non-open document returns an error
+--   7. Incremental changes with Unicode (emoji) work correctly
+
+local ls00 = require("coding_adventures.ls00")
+
+describe("DocumentManager", function()
+    it("stores opened documents", function()
+        local dm = ls00.DocumentManager:new()
+        dm:open("file:///test.txt", "hello world", 1)
+
+        local doc = dm:get("file:///test.txt")
+        assert.is_not_nil(doc)
+        assert.are.equal("hello world", doc.text)
+        assert.are.equal(1, doc.version)
+    end)
+
+    it("returns nil for non-existent documents", function()
+        local dm = ls00.DocumentManager:new()
+        local doc = dm:get("file:///nonexistent.txt")
+        assert.is_nil(doc)
+    end)
+
+    it("removes documents on close", function()
+        local dm = ls00.DocumentManager:new()
+        dm:open("file:///test.txt", "hello", 1)
+        dm:close("file:///test.txt")
+
+        local doc = dm:get("file:///test.txt")
+        assert.is_nil(doc)
+    end)
+
+    it("applies full replacement changes", function()
+        local dm = ls00.DocumentManager:new()
+        dm:open("file:///test.txt", "hello world", 1)
+
+        local err = dm:apply_changes("file:///test.txt", {
+            { range = nil, text = "goodbye world" },
+        }, 2)
+        assert.is_nil(err)
+
+        local doc = dm:get("file:///test.txt")
+        assert.are.equal("goodbye world", doc.text)
+        assert.are.equal(2, doc.version)
+    end)
+
+    it("applies incremental changes", function()
+        local dm = ls00.DocumentManager:new()
+        dm:open("file:///test.txt", "hello world", 1)
+
+        -- Replace "world" (chars 6-11) with "Go".
+        local err = dm:apply_changes("file:///test.txt", {
+            {
+                range = ls00.Range(
+                    ls00.Position(0, 6),
+                    ls00.Position(0, 11)
+                ),
+                text = "Go",
+            },
+        }, 2)
+        assert.is_nil(err)
+
+        local doc = dm:get("file:///test.txt")
+        assert.are.equal("hello Go", doc.text)
+    end)
+
+    it("returns error for changes to non-open document", function()
+        local dm = ls00.DocumentManager:new()
+        local err = dm:apply_changes("file:///notopen.txt", {
+            { range = nil, text = "x" },
+        }, 1)
+        assert.is_not_nil(err)
+        assert.is_truthy(err:find("not open"))
+    end)
+
+    it("handles incremental changes with emoji", function()
+        -- "A🎸B" — emoji is 4 UTF-8 bytes, 2 UTF-16 code units.
+        -- Replace "B" (UTF-16 char 3, after the surrogate pair) with "X".
+        local dm = ls00.DocumentManager:new()
+        dm:open("file:///test.txt", "A\xF0\x9F\x8E\xB8B", 1)
+
+        local err = dm:apply_changes("file:///test.txt", {
+            {
+                range = ls00.Range(
+                    ls00.Position(0, 3),   -- UTF-16 char 3 = after 🎸
+                    ls00.Position(0, 4)    -- UTF-16 char 4 = after B
+                ),
+                text = "X",
+            },
+        }, 2)
+        assert.is_nil(err)
+
+        local doc = dm:get("file:///test.txt")
+        assert.are.equal("A\xF0\x9F\x8E\xB8X", doc.text)
+    end)
+
+    it("handles multi-change sequences", function()
+        local dm = ls00.DocumentManager:new()
+        dm:open("uri", "hello world", 1)
+
+        -- Change "hello" to "hi".
+        local err = dm:apply_changes("uri", {
+            {
+                range = ls00.Range(
+                    ls00.Position(0, 0),
+                    ls00.Position(0, 5)
+                ),
+                text = "hi",
+            },
+        }, 2)
+        assert.is_nil(err)
+
+        local doc = dm:get("uri")
+        assert.are.equal("hi world", doc.text)
+    end)
+end)

--- a/code/packages/lua/ls00/tests/test_parse_cache.lua
+++ b/code/packages/lua/ls00/tests/test_parse_cache.lua
@@ -1,0 +1,104 @@
+-- test_parse_cache.lua — ParseCache tests
+-- ========================================
+--
+-- The ParseCache avoids re-parsing unchanged documents. It uses (uri, version)
+-- as the cache key. These tests verify:
+--
+--   1. Cache miss triggers a parse
+--   2. Cache hit returns the same result (same reference)
+--   3. New version causes a cache miss
+--   4. Eviction removes cached entries
+--   5. Diagnostics are correctly populated from the bridge
+
+local ls00 = require("coding_adventures.ls00")
+
+-- A mock bridge for testing. Returns diagnostics when source contains "ERROR".
+local function make_mock_bridge()
+    local parse_count = 0
+    return {
+        tokenize = function(source)
+            return {}, nil
+        end,
+        parse = function(source)
+            parse_count = parse_count + 1
+            local diags = {}
+            if source:find("ERROR") then
+                diags[1] = ls00.Diagnostic(
+                    ls00.Range(ls00.Position(0, 0), ls00.Position(0, 5)),
+                    ls00.SEVERITY_ERROR,
+                    "syntax error: unexpected ERROR token"
+                )
+            end
+            return source, diags, nil
+        end,
+        get_parse_count = function()
+            return parse_count
+        end,
+    }
+end
+
+describe("ParseCache", function()
+    it("returns a result on cache miss", function()
+        local bridge = make_mock_bridge()
+        local cache = ls00.ParseCache:new()
+
+        local r1 = cache:get_or_parse("file:///a.txt", 1, "hello", bridge)
+        assert.is_not_nil(r1)
+        assert.are.equal("hello", r1.ast)
+    end)
+
+    it("returns the same result on cache hit", function()
+        local bridge = make_mock_bridge()
+        local cache = ls00.ParseCache:new()
+
+        local r1 = cache:get_or_parse("file:///a.txt", 1, "hello", bridge)
+        local r2 = cache:get_or_parse("file:///a.txt", 1, "hello", bridge)
+
+        -- Same table reference means the cache was used.
+        assert.are.equal(r1, r2)
+        -- Parse was called only once.
+        assert.are.equal(1, bridge.get_parse_count())
+    end)
+
+    it("misses on new version", function()
+        local bridge = make_mock_bridge()
+        local cache = ls00.ParseCache:new()
+
+        local r1 = cache:get_or_parse("file:///a.txt", 1, "hello", bridge)
+        local r2 = cache:get_or_parse("file:///a.txt", 2, "hello world", bridge)
+
+        -- Different version = different result.
+        assert.are_not.equal(r1, r2)
+        -- Parse was called twice.
+        assert.are.equal(2, bridge.get_parse_count())
+    end)
+
+    it("evicts cached entries", function()
+        local bridge = make_mock_bridge()
+        local cache = ls00.ParseCache:new()
+
+        local r1 = cache:get_or_parse("file:///a.txt", 1, "hello", bridge)
+        cache:evict("file:///a.txt")
+
+        -- After eviction, same (uri, version) produces a new parse.
+        local r2 = cache:get_or_parse("file:///a.txt", 1, "hello", bridge)
+        assert.are_not.equal(r1, r2)
+    end)
+
+    it("populates diagnostics for error source", function()
+        local bridge = make_mock_bridge()
+        local cache = ls00.ParseCache:new()
+
+        local result = cache:get_or_parse("file:///a.txt", 1, "source with ERROR token", bridge)
+        assert.is_true(#result.diagnostics > 0)
+        assert.are.equal("syntax error: unexpected ERROR token", result.diagnostics[1].message)
+    end)
+
+    it("returns empty diagnostics for clean source", function()
+        local bridge = make_mock_bridge()
+        local cache = ls00.ParseCache:new()
+
+        local result = cache:get_or_parse("file:///clean.txt", 1, "hello world", bridge)
+        assert.are.equal(0, #result.diagnostics)
+    end)
+end)

--- a/code/packages/lua/ls00/tests/test_semantic_tokens.lua
+++ b/code/packages/lua/ls00/tests/test_semantic_tokens.lua
@@ -1,0 +1,164 @@
+-- test_semantic_tokens.lua — Semantic token encoding tests
+-- ========================================================
+--
+-- Semantic tokens use a compact binary encoding. Instead of sending
+-- {"type":"keyword"} per token, LSP sends a flat integer array where each
+-- token is represented by 5 integers:
+--
+--   [deltaLine, deltaStartChar, length, tokenTypeIndex, tokenModifierBitmask]
+--
+-- "Delta" means the difference from the PREVIOUS token's position.
+-- When deltaLine > 0, deltaStartChar is absolute for the new line.
+-- When deltaLine == 0, deltaStartChar is relative to the previous token.
+--
+-- These tests verify the encoder handles:
+--   1. Empty input
+--   2. Single token
+--   3. Multiple tokens on the same line
+--   4. Multiple tokens on different lines
+--   5. Unsorted input (encoder must sort)
+--   6. Unknown token types (must be skipped)
+--   7. Modifier bitmasks
+
+local ls00 = require("coding_adventures.ls00")
+
+describe("encode_semantic_tokens", function()
+    it("returns empty array for nil input", function()
+        local data = ls00.encode_semantic_tokens(nil)
+        assert.are.equal(0, #data)
+    end)
+
+    it("returns empty array for empty input", function()
+        local data = ls00.encode_semantic_tokens({})
+        assert.are.equal(0, #data)
+    end)
+
+    it("encodes a single token", function()
+        local tokens = {
+            ls00.SemanticToken(0, 0, 5, "keyword", {}),
+        }
+        local data = ls00.encode_semantic_tokens(tokens)
+
+        -- Expected: [deltaLine=0, deltaChar=0, length=5, typeIndex=15 (keyword), modifiers=0]
+        assert.are.equal(5, #data)
+        assert.are.equal(0, data[1])   -- deltaLine
+        assert.are.equal(0, data[2])   -- deltaChar
+        assert.are.equal(5, data[3])   -- length
+        assert.are.equal(15, data[4])  -- keyword is at index 15
+        assert.are.equal(0, data[5])   -- no modifiers
+    end)
+
+    it("encodes multiple tokens on the same line", function()
+        local tokens = {
+            ls00.SemanticToken(0, 0, 3, "keyword", {}),
+            ls00.SemanticToken(0, 4, 4, "function", { "declaration" }),
+        }
+        local data = ls00.encode_semantic_tokens(tokens)
+
+        assert.are.equal(10, #data)
+
+        -- Token A: deltaLine=0, deltaChar=0, length=3, keyword(15), mods=0
+        assert.are.equal(0, data[1])
+        assert.are.equal(0, data[2])
+        assert.are.equal(3, data[3])
+        assert.are.equal(15, data[4])
+        assert.are.equal(0, data[5])
+
+        -- Token B: deltaLine=0, deltaChar=4, length=4, function(12), mods=1 (declaration=bit0)
+        assert.are.equal(0, data[6])
+        assert.are.equal(4, data[7])
+        assert.are.equal(4, data[8])
+        assert.are.equal(12, data[9])
+        assert.are.equal(1, data[10])
+    end)
+
+    it("encodes multiple tokens on different lines", function()
+        local tokens = {
+            ls00.SemanticToken(0, 0, 3, "keyword", {}),
+            ls00.SemanticToken(2, 4, 5, "number", {}),
+        }
+        local data = ls00.encode_semantic_tokens(tokens)
+
+        assert.are.equal(10, #data)
+
+        -- Token B: deltaLine=2, deltaChar=4 (absolute on new line), number=19
+        assert.are.equal(2, data[6])
+        assert.are.equal(4, data[7])
+        assert.are.equal(19, data[9])
+    end)
+
+    it("sorts unsorted input", function()
+        -- Tokens in reverse order — the encoder should sort them.
+        local tokens = {
+            ls00.SemanticToken(1, 0, 2, "number", {}),
+            ls00.SemanticToken(0, 0, 3, "keyword", {}),
+        }
+        local data = ls00.encode_semantic_tokens(tokens)
+
+        assert.are.equal(10, #data)
+        -- After sorting: keyword on line 0 first, number on line 1 second.
+        assert.are.equal(15, data[4])  -- first token = keyword (15)
+        assert.are.equal(19, data[9])  -- second token = number (19)
+    end)
+
+    it("skips unknown token types", function()
+        local tokens = {
+            ls00.SemanticToken(0, 0, 3, "unknownType", {}),
+            ls00.SemanticToken(0, 4, 2, "keyword", {}),
+        }
+        local data = ls00.encode_semantic_tokens(tokens)
+
+        -- unknownType should be skipped, leaving only one 5-tuple.
+        assert.are.equal(5, #data)
+    end)
+
+    it("encodes modifier bitmask correctly", function()
+        -- "readonly" is at index 2 in the modifier list (0-based).
+        -- Bit 2 = value 4.
+        local tokens = {
+            ls00.SemanticToken(0, 0, 3, "variable", { "readonly" }),
+        }
+        local data = ls00.encode_semantic_tokens(tokens)
+
+        assert.are.equal(4, data[5])  -- readonly = bit 2 = value 4
+    end)
+
+    it("combines multiple modifiers with bitwise OR", function()
+        -- "declaration" = bit 0 (value 1), "readonly" = bit 2 (value 4).
+        -- Combined: 1 | 4 = 5.
+        local tokens = {
+            ls00.SemanticToken(0, 0, 3, "variable", { "declaration", "readonly" }),
+        }
+        local data = ls00.encode_semantic_tokens(tokens)
+
+        assert.are.equal(5, data[5])
+    end)
+end)
+
+describe("semantic_token_legend", function()
+    it("returns non-empty token types", function()
+        local legend = ls00.semantic_token_legend()
+        assert.is_true(#legend.token_types > 0)
+    end)
+
+    it("returns non-empty token modifiers", function()
+        local legend = ls00.semantic_token_legend()
+        assert.is_true(#legend.token_modifiers > 0)
+    end)
+
+    it("contains required token types", function()
+        local legend = ls00.semantic_token_legend()
+        local required = { "keyword", "string", "number", "variable", "function" }
+
+        for _, req in ipairs(required) do
+            local found = false
+            for _, t in ipairs(legend.token_types) do
+                if t == req then
+                    found = true
+                    break
+                end
+            end
+            assert.is_true(found, "legend missing required type: " .. req)
+        end
+    end)
+end)

--- a/code/packages/lua/ls00/tests/test_server.lua
+++ b/code/packages/lua/ls00/tests/test_server.lua
@@ -1,0 +1,492 @@
+-- test_server.lua — LspServer integration tests
+-- ===============================================
+--
+-- These tests verify the LspServer's integration with the JSON-RPC layer
+-- and the bridge. They test:
+--
+--   1. Server creation with a bridge
+--   2. Capabilities advertisement matches the bridge
+--   3. The full lifecycle: initialize -> didOpen -> hover -> shutdown
+--   4. Diagnostics are published on didOpen (via parse cache)
+--   5. Handler routing for all feature requests
+--
+-- We use mock streams (tables with read/write methods) to simulate
+-- stdin/stdout without needing real I/O.
+
+local ls00 = require("coding_adventures.ls00")
+local json_rpc = require("coding_adventures.json_rpc")
+
+-- ─── Mock Bridge ────────────────────────────────────────────────────────────
+
+-- A mock bridge that implements all optional providers for thorough testing.
+local function make_full_mock_bridge()
+    return {
+        tokenize = function(source)
+            -- Split by whitespace into WORD tokens.
+            local tokens = {}
+            local col = 1
+            for word in source:gmatch("%S+") do
+                tokens[#tokens + 1] = ls00.Token("WORD", word, 1, col)
+                col = col + #word + 1
+            end
+            return tokens, nil
+        end,
+
+        parse = function(source)
+            local diags = {}
+            if source:find("ERROR") then
+                diags[1] = ls00.Diagnostic(
+                    ls00.Range(ls00.Position(0, 0), ls00.Position(0, 5)),
+                    ls00.SEVERITY_ERROR,
+                    "syntax error: unexpected ERROR token"
+                )
+            end
+            return source, diags, nil
+        end,
+
+        hover = function(ast, pos)
+            return ls00.HoverResult("**test** hover content")
+        end,
+
+        definition = function(ast, pos, uri)
+            return ls00.Location(uri, ls00.Range(pos, pos))
+        end,
+
+        references = function(ast, pos, uri, include_decl)
+            return { ls00.Location(uri, ls00.Range(pos, pos)) }
+        end,
+
+        completion = function(ast, pos)
+            return { ls00.CompletionItem("foo", ls00.COMPLETION_FUNCTION, "() void") }
+        end,
+
+        rename = function(ast, pos, new_name)
+            return ls00.WorkspaceEdit({
+                ["file:///test.txt"] = {
+                    ls00.TextEdit(ls00.Range(pos, pos), new_name),
+                },
+            })
+        end,
+
+        semantic_tokens = function(source, tokens)
+            local result = {}
+            for _, tok in ipairs(tokens) do
+                result[#result + 1] = ls00.SemanticToken(
+                    tok.line - 1, tok.column - 1, #tok.value, "variable", {}
+                )
+            end
+            return result, nil
+        end,
+
+        document_symbols = function(ast)
+            return {
+                ls00.DocumentSymbol(
+                    "main",
+                    ls00.SYMBOL_FUNCTION,
+                    ls00.Range(ls00.Position(0, 0), ls00.Position(10, 1)),
+                    ls00.Range(ls00.Position(0, 9), ls00.Position(0, 13)),
+                    {
+                        ls00.DocumentSymbol(
+                            "x",
+                            ls00.SYMBOL_VARIABLE,
+                            ls00.Range(ls00.Position(1, 4), ls00.Position(1, 12)),
+                            ls00.Range(ls00.Position(1, 8), ls00.Position(1, 9))
+                        ),
+                    }
+                ),
+            }
+        end,
+
+        folding_ranges = function(ast)
+            return { ls00.FoldingRange(0, 5, "region") }
+        end,
+
+        signature_help = function(ast, pos)
+            return ls00.SignatureHelpResult(
+                {
+                    ls00.SignatureInformation(
+                        "foo(a int, b string)",
+                        nil,
+                        {
+                            ls00.ParameterInformation("a int"),
+                            ls00.ParameterInformation("b string"),
+                        }
+                    ),
+                },
+                0, 0
+            )
+        end,
+
+        format = function(source)
+            return {
+                ls00.TextEdit(
+                    ls00.Range(ls00.Position(0, 0), ls00.Position(999, 0)),
+                    source  -- no-op formatter
+                ),
+            }
+        end,
+    }
+end
+
+-- A minimal bridge with only required functions.
+local function make_minimal_bridge()
+    return {
+        tokenize = function(source) return {}, nil end,
+        parse = function(source) return source, {}, nil end,
+    }
+end
+
+-- ─── Mock Stream ────────────────────────────────────────────────────────────
+
+-- Create an in-memory readable stream from a string.
+local function make_read_stream(content)
+    local pos = 1
+    return {
+        read = function(self, what)
+            if pos > #content then return nil end
+
+            if what == "l" then
+                -- Read one line.
+                local nl = content:find("\n", pos)
+                if nl then
+                    local line = content:sub(pos, nl - 1)
+                    pos = nl + 1
+                    return line
+                else
+                    local line = content:sub(pos)
+                    pos = #content + 1
+                    return line
+                end
+            elseif type(what) == "number" then
+                -- Read N bytes.
+                local data = content:sub(pos, pos + what - 1)
+                pos = pos + what
+                if #data == 0 then return nil end
+                return data
+            end
+            return nil
+        end,
+    }
+end
+
+-- Create an in-memory writable stream.
+local function make_write_stream()
+    local buf = {}
+    return {
+        write = function(self, data)
+            buf[#buf + 1] = data
+        end,
+        flush = function(self) end,
+        get_content = function()
+            return table.concat(buf)
+        end,
+    }
+end
+
+-- Build a Content-Length-framed message string.
+local function make_message(obj)
+    local payload = json_rpc.json_encode(obj)
+    return string.format("Content-Length: %d\r\n\r\n%s", #payload, payload)
+end
+
+-- ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("LspServer", function()
+    it("can be created with a bridge", function()
+        local bridge = make_minimal_bridge()
+        local in_stream = make_read_stream("")
+        local out_stream = make_write_stream()
+        local server = ls00.LspServer:new(bridge, in_stream, out_stream)
+        assert.is_not_nil(server)
+    end)
+
+    it("responds to initialize with capabilities", function()
+        local bridge = make_full_mock_bridge()
+
+        local input = make_message({
+            jsonrpc = "2.0",
+            id = 1,
+            method = "initialize",
+            params = {
+                processId = 12345,
+                capabilities = {},
+            },
+        })
+
+        local in_stream = make_read_stream(input)
+        local out_stream = make_write_stream()
+        local server = ls00.LspServer:new(bridge, in_stream, out_stream)
+
+        -- Serve will process the message then hit EOF and stop.
+        server:serve()
+
+        local content = out_stream.get_content()
+        assert.is_truthy(content:find("capabilities"))
+        assert.is_truthy(content:find("hoverProvider"))
+        assert.is_truthy(content:find("documentSymbolProvider"))
+    end)
+
+    it("publishes diagnostics on didOpen with error source", function()
+        local bridge = make_full_mock_bridge()
+
+        -- Send initialize + initialized + didOpen with ERROR source.
+        local input = make_message({
+            jsonrpc = "2.0",
+            id = 1,
+            method = "initialize",
+            params = { processId = 1, capabilities = {} },
+        }) .. make_message({
+            jsonrpc = "2.0",
+            method = "initialized",
+            params = {},
+        }) .. make_message({
+            jsonrpc = "2.0",
+            method = "textDocument/didOpen",
+            params = {
+                textDocument = {
+                    uri = "file:///test.txt",
+                    languageId = "test",
+                    version = 1,
+                    text = "hello ERROR world",
+                },
+            },
+        })
+
+        local in_stream = make_read_stream(input)
+        local out_stream = make_write_stream()
+        local server = ls00.LspServer:new(bridge, in_stream, out_stream)
+        server:serve()
+
+        local content = out_stream.get_content()
+        assert.is_truthy(content:find("publishDiagnostics"))
+        assert.is_truthy(content:find("syntax error"))
+    end)
+
+    it("handles hover requests", function()
+        local bridge = make_full_mock_bridge()
+
+        local input = make_message({
+            jsonrpc = "2.0",
+            id = 1,
+            method = "initialize",
+            params = { processId = 1, capabilities = {} },
+        }) .. make_message({
+            jsonrpc = "2.0",
+            method = "textDocument/didOpen",
+            params = {
+                textDocument = {
+                    uri = "file:///test.txt",
+                    languageId = "test",
+                    version = 1,
+                    text = "hello world",
+                },
+            },
+        }) .. make_message({
+            jsonrpc = "2.0",
+            id = 2,
+            method = "textDocument/hover",
+            params = {
+                textDocument = { uri = "file:///test.txt" },
+                position = { line = 0, character = 0 },
+            },
+        })
+
+        local in_stream = make_read_stream(input)
+        local out_stream = make_write_stream()
+        local server = ls00.LspServer:new(bridge, in_stream, out_stream)
+        server:serve()
+
+        local content = out_stream.get_content()
+        assert.is_truthy(content:find("hover content"))
+        assert.is_truthy(content:find("markdown"))
+    end)
+
+    it("handles shutdown request", function()
+        local bridge = make_minimal_bridge()
+
+        local input = make_message({
+            jsonrpc = "2.0",
+            id = 1,
+            method = "initialize",
+            params = { processId = 1, capabilities = {} },
+        }) .. make_message({
+            jsonrpc = "2.0",
+            id = 2,
+            method = "shutdown",
+            params = {},
+        })
+
+        local in_stream = make_read_stream(input)
+        local out_stream = make_write_stream()
+        local server = ls00.LspServer:new(bridge, in_stream, out_stream)
+        server:serve()
+
+        local content = out_stream.get_content()
+        -- Shutdown returns null result.
+        assert.is_truthy(content:find('"result"'))
+    end)
+
+    it("handles didChange with incremental update", function()
+        local bridge = make_full_mock_bridge()
+
+        local input = make_message({
+            jsonrpc = "2.0",
+            id = 1,
+            method = "initialize",
+            params = { processId = 1, capabilities = {} },
+        }) .. make_message({
+            jsonrpc = "2.0",
+            method = "textDocument/didOpen",
+            params = {
+                textDocument = {
+                    uri = "file:///test.txt",
+                    languageId = "test",
+                    version = 1,
+                    text = "hello world",
+                },
+            },
+        }) .. make_message({
+            jsonrpc = "2.0",
+            method = "textDocument/didChange",
+            params = {
+                textDocument = { uri = "file:///test.txt", version = 2 },
+                contentChanges = {
+                    {
+                        range = {
+                            start = { line = 0, character = 6 },
+                            ["end"] = { line = 0, character = 11 },
+                        },
+                        text = "ERROR",
+                    },
+                },
+            },
+        })
+
+        local in_stream = make_read_stream(input)
+        local out_stream = make_write_stream()
+        local server = ls00.LspServer:new(bridge, in_stream, out_stream)
+        server:serve()
+
+        local content = out_stream.get_content()
+        -- After changing "world" to "ERROR", diagnostics should fire.
+        assert.is_truthy(content:find("publishDiagnostics"))
+    end)
+
+    it("handles didClose and clears diagnostics", function()
+        local bridge = make_full_mock_bridge()
+
+        local input = make_message({
+            jsonrpc = "2.0",
+            id = 1,
+            method = "initialize",
+            params = { processId = 1, capabilities = {} },
+        }) .. make_message({
+            jsonrpc = "2.0",
+            method = "textDocument/didOpen",
+            params = {
+                textDocument = {
+                    uri = "file:///test.txt",
+                    languageId = "test",
+                    version = 1,
+                    text = "hello ERROR",
+                },
+            },
+        }) .. make_message({
+            jsonrpc = "2.0",
+            method = "textDocument/didClose",
+            params = {
+                textDocument = { uri = "file:///test.txt" },
+            },
+        })
+
+        local in_stream = make_read_stream(input)
+        local out_stream = make_write_stream()
+        local server = ls00.LspServer:new(bridge, in_stream, out_stream)
+        server:serve()
+
+        -- Should have received publishDiagnostics at least twice:
+        -- once for didOpen (with errors), once for didClose (empty).
+        local content = out_stream.get_content()
+        -- Count occurrences of publishDiagnostics.
+        local count = 0
+        for _ in content:gmatch("publishDiagnostics") do
+            count = count + 1
+        end
+        assert.is_true(count >= 2)
+    end)
+
+    it("handles semantic tokens request", function()
+        local bridge = make_full_mock_bridge()
+
+        local input = make_message({
+            jsonrpc = "2.0",
+            id = 1,
+            method = "initialize",
+            params = { processId = 1, capabilities = {} },
+        }) .. make_message({
+            jsonrpc = "2.0",
+            method = "textDocument/didOpen",
+            params = {
+                textDocument = {
+                    uri = "file:///test.txt",
+                    languageId = "test",
+                    version = 1,
+                    text = "hello world",
+                },
+            },
+        }) .. make_message({
+            jsonrpc = "2.0",
+            id = 3,
+            method = "textDocument/semanticTokens/full",
+            params = {
+                textDocument = { uri = "file:///test.txt" },
+            },
+        })
+
+        local in_stream = make_read_stream(input)
+        local out_stream = make_write_stream()
+        local server = ls00.LspServer:new(bridge, in_stream, out_stream)
+        server:serve()
+
+        local content = out_stream.get_content()
+        assert.is_truthy(content:find('"data"'))
+    end)
+
+    it("handles completion request", function()
+        local bridge = make_full_mock_bridge()
+
+        local input = make_message({
+            jsonrpc = "2.0",
+            id = 1,
+            method = "initialize",
+            params = { processId = 1, capabilities = {} },
+        }) .. make_message({
+            jsonrpc = "2.0",
+            method = "textDocument/didOpen",
+            params = {
+                textDocument = {
+                    uri = "file:///test.txt",
+                    languageId = "test",
+                    version = 1,
+                    text = "hello",
+                },
+            },
+        }) .. make_message({
+            jsonrpc = "2.0",
+            id = 2,
+            method = "textDocument/completion",
+            params = {
+                textDocument = { uri = "file:///test.txt" },
+                position = { line = 0, character = 0 },
+            },
+        })
+
+        local in_stream = make_read_stream(input)
+        local out_stream = make_write_stream()
+        local server = ls00.LspServer:new(bridge, in_stream, out_stream)
+        server:serve()
+
+        local content = out_stream.get_content()
+        assert.is_truthy(content:find("foo"))
+    end)
+end)

--- a/code/packages/lua/ls00/tests/test_utf16.lua
+++ b/code/packages/lua/ls00/tests/test_utf16.lua
@@ -1,0 +1,118 @@
+-- test_utf16.lua — UTF-16 offset conversion tests
+-- =================================================
+--
+-- These tests verify the critical UTF-16 -> byte offset conversion.
+-- This is the most important correctness test in the entire package.
+-- If this function is wrong, every feature that depends on cursor position
+-- will be wrong: hover, go-to-definition, references, completion, rename,
+-- and signature help.
+--
+-- # Why UTF-16?
+--
+-- LSP character offsets are measured in UTF-16 code units because VS Code
+-- uses TypeScript internally (which has UTF-16 strings). Lua strings are
+-- byte strings (UTF-8). This function bridges the gap.
+--
+-- # Test Coverage
+--
+-- We test:
+--   1. ASCII strings (1 byte per character, 1 UTF-16 unit)
+--   2. 2-byte UTF-8 (BMP codepoints like e-acute, still 1 UTF-16 unit)
+--   3. 4-byte UTF-8 (above U+FFFF, like emoji, 2 UTF-16 units)
+--   4. Multi-line strings (line boundaries)
+--   5. Edge cases (start of file, end of line, beyond line end)
+
+local ls00 = require("coding_adventures.ls00")
+
+describe("UTF-16 offset conversion", function()
+    -- Helper: Lua is 1-based, so we compare the 1-based byte position
+    -- returned by convert_utf16_offset_to_byte_offset against expected values.
+    -- The function returns a 1-based byte position for use with string.sub().
+
+    it("handles ASCII simple", function()
+        -- "hello world" — all ASCII, 1 byte = 1 UTF-16 unit.
+        -- "world" starts at byte 7 (1-based).
+        local pos = ls00.convert_utf16_offset_to_byte_offset("hello world", 0, 6)
+        assert.are.equal(7, pos)
+    end)
+
+    it("handles start of file", function()
+        local pos = ls00.convert_utf16_offset_to_byte_offset("abc", 0, 0)
+        assert.are.equal(1, pos)
+    end)
+
+    it("handles end of short string", function()
+        -- "abc" — character 3 is one past the end, byte 4 (1-based).
+        local pos = ls00.convert_utf16_offset_to_byte_offset("abc", 0, 3)
+        assert.are.equal(4, pos)
+    end)
+
+    it("handles second line", function()
+        -- "hello\nworld" — line 1 starts at byte 7 (1-based).
+        local pos = ls00.convert_utf16_offset_to_byte_offset("hello\nworld", 1, 0)
+        assert.are.equal(7, pos)
+    end)
+
+    it("handles emoji surrogate pairs", function()
+        -- "A🎸B"
+        -- UTF-8 bytes: A(1) + 🎸(4) + B(1) = 6 bytes total.
+        -- UTF-16 units: A(1) + 🎸(2) + B(1) = 4 units total.
+        -- "B" is at UTF-16 character 3, byte offset 6 (1-based).
+        --
+        -- 🎸 is U+1F3B8, encoded as the 4-byte sequence: F0 9F 8E B8
+        local text = "A\xF0\x9F\x8E\xB8B"
+        local pos = ls00.convert_utf16_offset_to_byte_offset(text, 0, 3)
+        assert.are.equal(6, pos)
+    end)
+
+    it("handles emoji at start", function()
+        -- "🎸hello"
+        -- 🎸 = 2 UTF-16 units = 4 UTF-8 bytes.
+        -- "h" is at UTF-16 char 2, byte offset 5 (1-based).
+        local text = "\xF0\x9F\x8E\xB8hello"
+        local pos = ls00.convert_utf16_offset_to_byte_offset(text, 0, 2)
+        assert.are.equal(5, pos)
+    end)
+
+    it("handles 2-byte UTF-8 BMP codepoint", function()
+        -- "cafe!" where e is actually e-acute (U+00E9).
+        -- e-acute in UTF-8: 2 bytes (C3 A9).
+        -- In UTF-16: 1 code unit (BMP codepoint).
+        -- UTF-16 char 4 = the "!" = byte offset 6 (c=1, a=1, f=1, e-acute=2, !=1).
+        -- 1-based: byte 6.
+        local text = "caf\xC3\xA9!"
+        local pos = ls00.convert_utf16_offset_to_byte_offset(text, 0, 4)
+        assert.are.equal(6, pos)
+    end)
+
+    it("handles multiline with emoji", function()
+        -- line 0: "A🎸B\n"  (A=1, 🎸=4, B=1, \n=1 = 7 bytes)
+        -- line 1: "hello"
+        -- "hello" starts at byte 8 (1-based), char 0 on line 1.
+        local text = "A\xF0\x9F\x8E\xB8B\nhello"
+        local pos = ls00.convert_utf16_offset_to_byte_offset(text, 1, 0)
+        assert.are.equal(8, pos)
+    end)
+
+    it("clamps beyond line end to newline position", function()
+        -- If character is past the end of the line, we stop at the newline.
+        -- "ab\ncd" — line 0 has 2 chars (a, b), then newline at byte 3.
+        -- Character 100 on line 0 should clamp to byte 3 (1-based, the newline).
+        local pos = ls00.convert_utf16_offset_to_byte_offset("ab\ncd", 0, 100)
+        assert.are.equal(3, pos)
+    end)
+
+    it("handles empty string", function()
+        local pos = ls00.convert_utf16_offset_to_byte_offset("", 0, 0)
+        assert.are.equal(1, pos)
+    end)
+
+    it("handles 3-byte UTF-8 BMP codepoint", function()
+        -- Chinese character 中 (U+4E2D): 3 UTF-8 bytes, 1 UTF-16 unit.
+        -- "A中B" — byte layout: A(1) + 中(3) + B(1) = 5 bytes.
+        -- "B" is at UTF-16 char 2, byte 5 (1-based).
+        local text = "A\xE4\xB8\xADB"
+        local pos = ls00.convert_utf16_offset_to_byte_offset(text, 0, 2)
+        assert.are.equal(5, pos)
+    end)
+end)

--- a/code/packages/perl/ls00/BUILD
+++ b/code/packages/perl/ls00/BUILD
@@ -1,1 +1,1 @@
-cd ../json-rpc && cpanm --notest --quiet Test2::V0 2>/dev/null; cd ../ls00 && prove -I../json-rpc/lib -l -v t/ || for f in t/*.t; do perl -I../json-rpc/lib -Ilib "$f"; done
+cd ../json-rpc && cpanm --notest --quiet Test2::V0 2>/dev/null; cd ../ls00 && prove -I../json-rpc/lib -l -v t/

--- a/code/packages/perl/ls00/BUILD
+++ b/code/packages/perl/ls00/BUILD
@@ -1,0 +1,1 @@
+cd ../json-rpc && cpanm --notest --quiet Test2::V0 2>/dev/null; cd ../ls00 && prove -I../json-rpc/lib -l -v t/ || for f in t/*.t; do perl -I../json-rpc/lib -Ilib "$f"; done

--- a/code/packages/perl/ls00/BUILD_windows
+++ b/code/packages/perl/ls00/BUILD_windows
@@ -1,0 +1,1 @@
+echo Perl testing is not supported on Windows - skipping

--- a/code/packages/perl/ls00/BUILD_windows
+++ b/code/packages/perl/ls00/BUILD_windows
@@ -1,1 +1,1 @@
-echo Perl testing is not supported on Windows - skipping
+cd ../json-rpc && echo Perl dep installed && cd ../ls00 && echo Perl testing is not supported on Windows - skipping

--- a/code/packages/perl/ls00/CHANGELOG.md
+++ b/code/packages/perl/ls00/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## 0.01 — 2026-04-12
+
+### Added
+
+- Initial implementation of the Perl ls00 LSP framework, ported from Go
+- `CodingAdventures::Ls00::Types` -- LSP data types as constructor functions with constants for severity, completion kind, and symbol kind
+- `CodingAdventures::Ls00::LanguageBridge` -- Bridge interface documentation (duck typing via `can()`)
+- `CodingAdventures::Ls00::DocumentManager` -- Open document tracking with incremental change support and UTF-16 to byte offset conversion
+- `CodingAdventures::Ls00::ParseCache` -- Version-keyed parse result cache with URI-based eviction
+- `CodingAdventures::Ls00::Capabilities` -- Dynamic capability building from bridge introspection, semantic token legend, and compact token encoding
+- `CodingAdventures::Ls00::LspErrors` -- LSP-specific error code constants
+- `CodingAdventures::Ls00::Handlers` -- All LSP request and notification handlers (lifecycle, text document sync, hover, definition, references, completion, rename, document symbols, semantic tokens, folding ranges, signature help, formatting)
+- `CodingAdventures::Ls00::Server` -- Main coordinator wiring bridge, document manager, parse cache, and JSON-RPC server
+- Comprehensive test suite with 6 test files covering UTF-16 conversion, document management, parse caching, capability detection, semantic token encoding, and full server integration

--- a/code/packages/perl/ls00/Makefile.PL
+++ b/code/packages/perl/ls00/Makefile.PL
@@ -1,0 +1,7 @@
+use ExtUtils::MakeMaker;
+WriteMakefile(
+    NAME         => 'CodingAdventures::Ls00',
+    VERSION_FROM => 'lib/CodingAdventures/Ls00.pm',
+    PREREQ_PM    => {},
+    TEST_REQUIRES => { 'Test::More' => 0 },
+);

--- a/code/packages/perl/ls00/README.md
+++ b/code/packages/perl/ls00/README.md
@@ -1,0 +1,69 @@
+# CodingAdventures::Ls00
+
+A generic Language Server Protocol (LSP) framework for Perl.
+
+## What It Does
+
+This package implements the protocol boilerplate for an LSP server. Language authors create a "bridge" object that connects their lexer and parser to this framework. The framework handles:
+
+- JSON-RPC 2.0 transport over stdin/stdout
+- Document synchronization (open, change, close, save)
+- Capability advertisement based on the bridge's implemented methods
+- Semantic token encoding (compact integer format)
+- Parse result caching for performance
+- UTF-16 offset conversion (LSP uses UTF-16; Perl uses UTF-8)
+
+## Architecture
+
+```
+Lexer -> Parser -> [Bridge] -> [LspServer] -> VS Code / Neovim / Emacs
+```
+
+## Usage
+
+```perl
+use CodingAdventures::Ls00;
+
+# 1. Create a bridge object (any blessed object with tokenize + parse methods)
+my $bridge = MyLanguage::Bridge->new();
+
+# 2. Create an LSP server
+my $server = CodingAdventures::Ls00::Server->new($bridge, \*STDIN, \*STDOUT);
+
+# 3. Serve (blocks until stdin closes)
+$server->serve();
+```
+
+## Bridge Interface
+
+A bridge is any Perl object. It must implement two required methods:
+
+- `tokenize($source)` -- returns `(\@tokens, $error)`
+- `parse($source)` -- returns `($ast, \@diagnostics, $error)`
+
+Optional methods are detected via Perl's `can()`:
+
+| Method | LSP Feature |
+|--------|-------------|
+| `hover($ast, $pos)` | Hover tooltips |
+| `definition($ast, $pos, $uri)` | Go to Definition |
+| `references($ast, $pos, $uri, $include_decl)` | Find References |
+| `completion($ast, $pos)` | Autocomplete |
+| `rename($ast, $pos, $new_name)` | Symbol Rename |
+| `document_symbols($ast)` | Outline Panel |
+| `folding_ranges($ast)` | Code Folding |
+| `signature_help($ast, $pos)` | Signature Help |
+| `format($source)` | Format Document |
+| `semantic_tokens($source, \@tokens)` | Semantic Highlighting |
+
+## Dependencies
+
+- `CodingAdventures::JsonRpc` -- JSON-RPC 2.0 transport layer
+- `JSON::PP` -- JSON encoding/decoding (core since Perl 5.14)
+- `Encode` -- UTF-8/UTF-16 conversion (core module)
+
+## Running Tests
+
+```bash
+prove -I../json-rpc/lib -l -v t/
+```

--- a/code/packages/perl/ls00/cpanfile
+++ b/code/packages/perl/ls00/cpanfile
@@ -1,0 +1,5 @@
+requires 'coding-adventures-json-rpc';
+
+on 'test' => sub {
+    requires 'Test::More';
+};

--- a/code/packages/perl/ls00/lib/CodingAdventures/Ls00.pm
+++ b/code/packages/perl/ls00/lib/CodingAdventures/Ls00.pm
@@ -1,0 +1,112 @@
+package CodingAdventures::Ls00;
+
+# ============================================================================
+# CodingAdventures::Ls00 -- Generic LSP server framework (umbrella module)
+# ============================================================================
+#
+# # What is the Language Server Protocol?
+#
+# When you open a source file in VS Code and see red squiggles under syntax
+# errors, autocomplete suggestions, or "Go to Definition" -- none of that is
+# built into the editor.  It comes from a *language server*: a separate
+# process that communicates with the editor over the Language Server Protocol.
+#
+# LSP was invented by Microsoft to solve the M x N problem:
+#
+#     M editors x N languages = M x N integrations to write
+#
+# With LSP, each language writes one server, and every LSP-aware editor gets
+# all features automatically.  This package is the *generic* half -- it
+# handles all the protocol boilerplate.  A language author only writes a
+# "bridge" object that connects their lexer/parser to this framework.
+#
+# # Architecture
+#
+#     Lexer -> Parser -> [Bridge] -> [LspServer] -> VS Code / Neovim / Emacs
+#
+# # JSON-RPC over stdio
+#
+# Like the Debug Adapter Protocol (DAP), LSP speaks JSON-RPC over stdio.
+# Each message is Content-Length-framed (same format as HTTP headers).  The
+# underlying transport is handled by CodingAdventures::JsonRpc.
+#
+# # How to use this package
+#
+#   1. Create a bridge object that implements `tokenize` and `parse` methods
+#      (and optionally `hover`, `definition`, etc.)
+#   2. Call CodingAdventures::Ls00::Server->new($bridge, \*STDIN, \*STDOUT)
+#   3. Call $server->serve() -- it blocks until the editor closes the connection.
+#
+# # Capability detection
+#
+# Perl's built-in `can()` method performs the same role as Go's type
+# assertions.  If `$bridge->can('hover')` returns true, the server
+# advertises hoverProvider and routes hover requests to `$bridge->hover()`.
+# No stubs required for unsupported features.
+
+use strict;
+use warnings;
+
+our $VERSION = '0.01';
+
+# Load all sub-modules eagerly so callers get everything with one `use`.
+use CodingAdventures::Ls00::Types          ();
+use CodingAdventures::Ls00::LanguageBridge ();
+use CodingAdventures::Ls00::DocumentManager();
+use CodingAdventures::Ls00::ParseCache     ();
+use CodingAdventures::Ls00::Capabilities   ();
+use CodingAdventures::Ls00::LspErrors      ();
+use CodingAdventures::Ls00::Handlers       ();
+use CodingAdventures::Ls00::Server         ();
+
+1;
+
+__END__
+
+=head1 NAME
+
+CodingAdventures::Ls00 -- Generic Language Server Protocol framework
+
+=head1 SYNOPSIS
+
+  use CodingAdventures::Ls00;
+
+  # 1. Create a bridge object (see CodingAdventures::Ls00::LanguageBridge)
+  my $bridge = MyLanguage::Bridge->new();
+
+  # 2. Create an LSP server
+  my $server = CodingAdventures::Ls00::Server->new($bridge, \*STDIN, \*STDOUT);
+
+  # 3. Serve (blocks until stdin closes)
+  $server->serve();
+
+=head1 DESCRIPTION
+
+A generic LSP server framework that language-specific "bridges" plug into.
+The bridge is any Perl object that implements at minimum C<tokenize()> and
+C<parse()>.  Optional methods (C<hover>, C<definition>, C<completion>, etc.)
+are detected at runtime via Perl's C<can()> method introspection.
+
+=head1 MODULES
+
+=over 4
+
+=item L<CodingAdventures::Ls00::Types> -- LSP data types as constructor functions
+
+=item L<CodingAdventures::Ls00::LanguageBridge> -- Bridge interface documentation
+
+=item L<CodingAdventures::Ls00::DocumentManager> -- Tracks open documents
+
+=item L<CodingAdventures::Ls00::ParseCache> -- Caches parse results by version
+
+=item L<CodingAdventures::Ls00::Capabilities> -- Builds capability response
+
+=item L<CodingAdventures::Ls00::LspErrors> -- LSP error code constants
+
+=item L<CodingAdventures::Ls00::Handlers> -- LSP request/notification handlers
+
+=item L<CodingAdventures::Ls00::Server> -- Main server coordinator
+
+=back
+
+=cut

--- a/code/packages/perl/ls00/lib/CodingAdventures/Ls00/Capabilities.pm
+++ b/code/packages/perl/ls00/lib/CodingAdventures/Ls00/Capabilities.pm
@@ -1,0 +1,291 @@
+package CodingAdventures::Ls00::Capabilities;
+
+# ============================================================================
+# CodingAdventures::Ls00::Capabilities -- Build LSP capabilities + semantic tokens
+# ============================================================================
+#
+# # What Are Capabilities?
+#
+# During the LSP initialize handshake, the server sends back a "capabilities"
+# object telling the editor which LSP features it supports.  The editor uses
+# this to decide which requests to send.  If a capability is absent, the
+# editor won't even try -- so no "Go to Definition" button appears unless
+# definitionProvider is true.
+#
+# Building capabilities dynamically (based on the bridge's can() responses)
+# means the server is always honest about what it can do.
+#
+# # Semantic Token Legend
+#
+# Semantic tokens use a compact binary encoding.  Instead of sending
+# {"type":"keyword"} per token, LSP sends an integer index into a legend.
+# The legend must be declared in the capabilities.
+#
+# # Encoding
+#
+# LSP encodes semantic tokens as a flat array of integers in 5-tuples:
+#   [deltaLine, deltaStartChar, length, tokenTypeIndex, modifierBitmask, ...]
+#
+# The "delta" encoding makes most values small (often 0 or 1), which
+# compresses well.
+
+use strict;
+use warnings;
+
+use JSON::PP ();
+
+use Exporter 'import';
+our @EXPORT_OK = qw(
+    build_capabilities
+    semantic_token_legend
+    encode_semantic_tokens
+    token_type_index
+    token_modifier_mask
+);
+our %EXPORT_TAGS = ( all => \@EXPORT_OK );
+
+our $VERSION = '0.01';
+
+# ---------------------------------------------------------------------------
+# build_capabilities($bridge) -> \%capabilities
+#
+# Inspect the bridge at runtime and return the LSP capabilities hashref
+# to include in the initialize response.
+#
+# Uses Perl's $bridge->can('method') to check which optional provider
+# methods the bridge implements.
+# ---------------------------------------------------------------------------
+
+sub build_capabilities {
+    my ($bridge) = @_;
+
+    # textDocumentSync=2 means "incremental": the editor sends only changed
+    # ranges, not the full file, on every keystroke.
+    my %caps = ( textDocumentSync => 2 );
+
+    if ($bridge->can('hover')) {
+        $caps{hoverProvider} = JSON::PP::true;
+    }
+
+    if ($bridge->can('definition')) {
+        $caps{definitionProvider} = JSON::PP::true;
+    }
+
+    if ($bridge->can('references')) {
+        $caps{referencesProvider} = JSON::PP::true;
+    }
+
+    if ($bridge->can('completion')) {
+        $caps{completionProvider} = {
+            triggerCharacters => [' ', '.'],
+        };
+    }
+
+    if ($bridge->can('rename')) {
+        $caps{renameProvider} = JSON::PP::true;
+    }
+
+    if ($bridge->can('document_symbols')) {
+        $caps{documentSymbolProvider} = JSON::PP::true;
+    }
+
+    if ($bridge->can('folding_ranges')) {
+        $caps{foldingRangeProvider} = JSON::PP::true;
+    }
+
+    if ($bridge->can('signature_help')) {
+        $caps{signatureHelpProvider} = {
+            triggerCharacters => ['(', ','],
+        };
+    }
+
+    if ($bridge->can('format')) {
+        $caps{documentFormattingProvider} = JSON::PP::true;
+    }
+
+    if ($bridge->can('semantic_tokens')) {
+        $caps{semanticTokensProvider} = {
+            legend => semantic_token_legend(),
+            full   => JSON::PP::true,
+        };
+    }
+
+    return \%caps;
+}
+
+# ---------------------------------------------------------------------------
+# semantic_token_legend() -> \%legend
+#
+# Return the full legend for all supported semantic token types and
+# modifiers.  The ordering matters: index 0 corresponds to "namespace",
+# index 1 to "type", etc.
+# ---------------------------------------------------------------------------
+
+sub semantic_token_legend {
+    return {
+        tokenTypes => [
+            'namespace',      # 0
+            'type',           # 1
+            'class',          # 2
+            'enum',           # 3
+            'interface',      # 4
+            'struct',         # 5
+            'typeParameter',  # 6
+            'parameter',      # 7
+            'variable',       # 8
+            'property',       # 9
+            'enumMember',     # 10
+            'event',          # 11
+            'function',       # 12
+            'method',         # 13
+            'macro',          # 14
+            'keyword',        # 15
+            'modifier',       # 16
+            'comment',        # 17
+            'string',         # 18
+            'number',         # 19
+            'regexp',         # 20
+            'operator',       # 21
+            'decorator',      # 22
+        ],
+        tokenModifiers => [
+            'declaration',    # bit 0
+            'definition',     # bit 1
+            'readonly',       # bit 2
+            'static',         # bit 3
+            'deprecated',     # bit 4
+            'abstract',       # bit 5
+            'async',          # bit 6
+            'modification',   # bit 7
+            'documentation',  # bit 8
+            'defaultLibrary', # bit 9
+        ],
+    };
+}
+
+# ---------------------------------------------------------------------------
+# token_type_index($token_type) -> $index or -1
+#
+# Return the integer index for a semantic token type string.
+# Returns -1 if the type is not in the legend (the caller should skip it).
+# ---------------------------------------------------------------------------
+
+sub token_type_index {
+    my ($token_type) = @_;
+    my $legend = semantic_token_legend();
+    my $types = $legend->{tokenTypes};
+    for my $i (0 .. $#$types) {
+        return $i if $types->[$i] eq $token_type;
+    }
+    return -1;
+}
+
+# ---------------------------------------------------------------------------
+# token_modifier_mask(\@modifiers) -> $bitmask
+#
+# Return the bitmask for a list of modifier strings.
+#
+# The LSP semantic tokens encoding represents modifiers as a bitmask:
+#   "declaration" -> bit 0 -> value 1
+#   "definition"  -> bit 1 -> value 2
+#   both          -> value 3 (bitwise OR)
+# ---------------------------------------------------------------------------
+
+sub token_modifier_mask {
+    my ($modifiers) = @_;
+    return 0 unless $modifiers && @$modifiers;
+
+    my $legend = semantic_token_legend();
+    my $mods = $legend->{tokenModifiers};
+    my $mask = 0;
+
+    for my $mod (@$modifiers) {
+        for my $i (0 .. $#$mods) {
+            if ($mods->[$i] eq $mod) {
+                $mask |= (1 << $i);
+                last;
+            }
+        }
+    }
+
+    return $mask;
+}
+
+# ---------------------------------------------------------------------------
+# encode_semantic_tokens(\@tokens) -> \@data
+#
+# Convert an arrayref of semantic token hashrefs to the LSP compact integer
+# encoding.
+#
+# Each input token has: { line, character, length, token_type, modifiers }
+# Output is a flat arrayref of integers in 5-tuples:
+#   [deltaLine, deltaStartChar, length, tokenTypeIndex, modifierBitmask, ...]
+#
+# Note: when deltaLine > 0, deltaStartChar is absolute (relative to column 0
+# of the new line).  When deltaLine == 0, deltaStartChar is relative to the
+# previous token's start character.
+# ---------------------------------------------------------------------------
+
+sub encode_semantic_tokens {
+    my ($tokens) = @_;
+
+    return [] unless $tokens && @$tokens;
+
+    # Sort by (line, character) ascending.  The delta encoding requires
+    # tokens to be in document order.
+    my @sorted = sort {
+        $a->{line} <=> $b->{line}
+        || $a->{character} <=> $b->{character}
+    } @$tokens;
+
+    my @data;
+    my $prev_line = 0;
+    my $prev_char = 0;
+
+    for my $tok (@sorted) {
+        my $type_idx = token_type_index($tok->{token_type});
+        next if $type_idx == -1;  # Unknown token type -- skip.
+
+        my $delta_line = $tok->{line} - $prev_line;
+        my $delta_char;
+        if ($delta_line == 0) {
+            # Same line: character offset is relative to previous token.
+            $delta_char = $tok->{character} - $prev_char;
+        } else {
+            # Different line: character offset is absolute.
+            $delta_char = $tok->{character};
+        }
+
+        my $mod_mask = token_modifier_mask($tok->{modifiers});
+
+        push @data, $delta_line, $delta_char, $tok->{length}, $type_idx, $mod_mask;
+
+        $prev_line = $tok->{line};
+        $prev_char = $tok->{character};
+    }
+
+    return \@data;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+CodingAdventures::Ls00::Capabilities -- Build LSP capabilities and encode semantic tokens
+
+=head1 SYNOPSIS
+
+  use CodingAdventures::Ls00::Capabilities qw(:all);
+
+  my $caps   = build_capabilities($bridge);
+  my $legend = semantic_token_legend();
+  my $data   = encode_semantic_tokens(\@tokens);
+
+=head1 DESCRIPTION
+
+Builds the LSP capabilities object dynamically based on the bridge's
+implemented methods, and provides the semantic token legend and encoding.
+
+=cut

--- a/code/packages/perl/ls00/lib/CodingAdventures/Ls00/DocumentManager.pm
+++ b/code/packages/perl/ls00/lib/CodingAdventures/Ls00/DocumentManager.pm
@@ -1,0 +1,356 @@
+package CodingAdventures::Ls00::DocumentManager;
+
+# ============================================================================
+# CodingAdventures::Ls00::DocumentManager -- Tracks open file contents
+# ============================================================================
+#
+# # The Document Manager's Job
+#
+# When the user opens a file in VS Code, the editor sends a textDocument/didOpen
+# notification with the full file content.  From that point on, the editor does
+# NOT re-send the entire file on every keystroke.  Instead, it sends incremental
+# changes: what changed, and where.  The DocumentManager applies these changes
+# to maintain the current text of each open file.
+#
+#   Editor opens file:   didOpen   -> DocumentManager stores text at version 1
+#   User types "X":      didChange -> DocumentManager applies delta -> version 2
+#   User saves:          didSave   -> (optional: trigger format)
+#   User closes:         didClose  -> DocumentManager removes entry
+#
+# # Why Version Numbers?
+#
+# The editor increments the version number with every change.  The ParseCache
+# uses (uri, version) as its cache key -- if the version matches, the cached
+# parse result is still valid.
+#
+# # UTF-16: The Tricky Part
+#
+# LSP specifies that character offsets are measured in UTF-16 CODE UNITS.
+# This is a historical accident: VS Code uses TypeScript, which uses UTF-16
+# strings internally.
+#
+# Perl strings are sequences of characters (codepoints).  A single Unicode
+# codepoint can occupy:
+#   - 1 byte in UTF-8 (ASCII, e.g. 'A')
+#   - 2 bytes in UTF-8 (e.g. 'e-acute', U+00E9)
+#   - 3 bytes in UTF-8 (e.g. 'middle-dot-CJK', U+4E2D)
+#   - 4 bytes in UTF-8 (e.g. guitar emoji, U+1F3B8)
+#
+# In UTF-16:
+#   - Codepoints in the Basic Multilingual Plane (U+0000-U+FFFF) -> 1 code unit
+#   - Codepoints above U+FFFF (emojis, rare CJK) -> 2 code units (surrogate pair)
+#
+# The function convert_utf16_offset_to_byte_offset() below performs this
+# conversion.
+
+use strict;
+use warnings;
+use Encode ();
+
+use Exporter 'import';
+our @EXPORT_OK = qw(convert_utf16_offset_to_byte_offset);
+
+our $VERSION = '0.01';
+
+# ---------------------------------------------------------------------------
+# new() -> DocumentManager
+#
+# Create an empty DocumentManager.
+# ---------------------------------------------------------------------------
+
+sub new {
+    my ($class) = @_;
+    return bless { docs => {} }, $class;
+}
+
+# ---------------------------------------------------------------------------
+# open($uri, $text, $version)
+#
+# Record a newly opened file.  Called when the editor sends didOpen.
+# Stores the initial text and version number.
+# ---------------------------------------------------------------------------
+
+sub open {
+    my ($self, $uri, $text, $version) = @_;
+    $self->{docs}{$uri} = {
+        uri     => $uri,
+        text    => $text,
+        version => $version,
+    };
+}
+
+# ---------------------------------------------------------------------------
+# get($uri) -> ($doc_hashref, $found_bool)
+#
+# Return the document for a URI.  In list context, returns ($doc, 1) if
+# found, or (undef, 0) if the document is not open.
+# ---------------------------------------------------------------------------
+
+sub get {
+    my ($self, $uri) = @_;
+    if (exists $self->{docs}{$uri}) {
+        return ($self->{docs}{$uri}, 1);
+    }
+    return (undef, 0);
+}
+
+# ---------------------------------------------------------------------------
+# close($uri)
+#
+# Remove a document from the manager.  Called when the editor sends didClose.
+# ---------------------------------------------------------------------------
+
+sub close {
+    my ($self, $uri) = @_;
+    delete $self->{docs}{$uri};
+}
+
+# ---------------------------------------------------------------------------
+# apply_changes($uri, \@changes, $version) -> $error_or_undef
+#
+# Apply a list of incremental changes to an open document.
+#
+# Each change is a hashref:
+#   { range => { start => {line=>N, character=>N}, end => ... }, new_text => "..." }
+#   If range is undef, new_text replaces the entire document (full sync).
+#
+# Returns an error string if the document is not open or a range is invalid.
+# Returns undef on success.
+# ---------------------------------------------------------------------------
+
+sub apply_changes {
+    my ($self, $uri, $changes, $version) = @_;
+
+    my $doc = $self->{docs}{$uri};
+    unless ($doc) {
+        return "document not open: $uri";
+    }
+
+    for my $change (@$changes) {
+        if (!defined $change->{range}) {
+            # Full document replacement -- simplest case.
+            $doc->{text} = $change->{new_text};
+        } else {
+            # Incremental update: splice new text at the specified range.
+            my ($new_text, $err) = _apply_range_change(
+                $doc->{text}, $change->{range}, $change->{new_text}
+            );
+            if ($err) {
+                return "applying change to $uri: $err";
+            }
+            $doc->{text} = $new_text;
+        }
+    }
+
+    $doc->{version} = $version;
+    return undef;
+}
+
+# ---------------------------------------------------------------------------
+# _apply_range_change($text, $range, $new_text) -> ($result_text, $err)
+#
+# Splice new_text into text at the given LSP range.  Converts LSP's
+# (line, UTF-16 character) coordinates to byte offsets in the UTF-8 string.
+# ---------------------------------------------------------------------------
+
+sub _apply_range_change {
+    my ($text, $range, $new_text) = @_;
+
+    my ($start_byte, $err1) = _convert_position_to_byte_offset($text, $range->{start});
+    return (undef, "start position: $err1") if $err1;
+
+    my ($end_byte, $err2) = _convert_position_to_byte_offset($text, $range->{end});
+    return (undef, "end position: $err2") if $err2;
+
+    if ($start_byte > $end_byte) {
+        return (undef, "start offset $start_byte > end offset $end_byte");
+    }
+
+    my $text_bytes = Encode::encode('UTF-8', $text);
+    my $byte_len = length($text_bytes);
+    $end_byte = $byte_len if $end_byte > $byte_len;
+
+    # Perform the splice in byte space, then decode back.
+    my $before = substr($text_bytes, 0, $start_byte);
+    my $after  = substr($text_bytes, $end_byte);
+    my $new_text_bytes = Encode::encode('UTF-8', $new_text);
+    my $result_bytes = $before . $new_text_bytes . $after;
+
+    return (Encode::decode('UTF-8', $result_bytes), undef);
+}
+
+# ---------------------------------------------------------------------------
+# _convert_position_to_byte_offset($text, $pos) -> ($byte_offset, $err)
+#
+# Convert an LSP Position (0-based line, UTF-16 character) to a byte offset
+# in the UTF-8 encoded string.
+#
+# Algorithm:
+#   1. Walk line-by-line to find the byte offset of the start of the target line.
+#   2. From that offset, walk UTF-8 codepoints converting each to its UTF-16
+#      length until we reach the target UTF-16 character offset.
+# ---------------------------------------------------------------------------
+
+sub _convert_position_to_byte_offset {
+    my ($text, $pos) = @_;
+
+    my $line = $pos->{line} // 0;
+    my $char = $pos->{character} // 0;
+
+    # Encode to bytes for byte-level manipulation.
+    my $bytes = Encode::encode('UTF-8', $text);
+    my $byte_len = length($bytes);
+
+    # Phase 1: find the byte offset of the start of the target line.
+    my $line_start = 0;
+    my $current_line = 0;
+
+    while ($current_line < $line) {
+        my $idx = index($bytes, "\n", $line_start);
+        if ($idx == -1) {
+            # Line number exceeds number of lines -- clamp to end.
+            return ($byte_len, undef);
+        }
+        $line_start = $idx + 1;
+        $current_line++;
+    }
+
+    # Phase 2: from line_start, advance $char UTF-16 code units.
+    my $byte_offset = $line_start;
+    my $utf16_units = 0;
+
+    while ($utf16_units < $char && $byte_offset < $byte_len) {
+        # Check for newline -- don't advance past line end.
+        last if substr($bytes, $byte_offset, 1) eq "\n";
+
+        # Decode one UTF-8 codepoint.
+        my ($codepoint, $size) = _decode_utf8_codepoint($bytes, $byte_offset);
+
+        # How many UTF-16 code units does this codepoint occupy?
+        my $utf16_len = _utf16_unit_length($codepoint);
+
+        # Would this codepoint overshoot the target?
+        last if $utf16_units + $utf16_len > $char;
+
+        $byte_offset += $size;
+        $utf16_units += $utf16_len;
+    }
+
+    return ($byte_offset, undef);
+}
+
+# ---------------------------------------------------------------------------
+# convert_utf16_offset_to_byte_offset($text, $line, $char) -> $byte_offset
+#
+# Exported version of the UTF-16 to byte offset conversion, for use in
+# tests and external packages.
+#
+# # Why UTF-16?
+#
+# LSP character offsets are UTF-16 code units because VS Code's internal
+# string representation is UTF-16 (as is JavaScript's String type).
+#
+# # Example
+#
+#   my $text = "hello \x{1F3B8} world";
+#   # Guitar emoji (U+1F3B8) is 4 UTF-8 bytes but 2 UTF-16 code units.
+#   # After the emoji, LSP says character=8 (6 for "hello ", 2 for emoji).
+#   my $byte_off = convert_utf16_offset_to_byte_offset($text, 0, 8);
+#   # $byte_off = 11
+# ---------------------------------------------------------------------------
+
+sub convert_utf16_offset_to_byte_offset {
+    my ($text, $line, $char) = @_;
+    my ($offset, $err) = _convert_position_to_byte_offset(
+        $text, { line => $line, character => $char }
+    );
+    return $offset;
+}
+
+# ---------------------------------------------------------------------------
+# _utf16_unit_length($codepoint) -> 1 or 2
+#
+# Returns the number of UTF-16 code units required to encode a Unicode
+# codepoint.
+#
+# BMP codepoints (U+0000-U+FFFF): 1 code unit
+# Non-BMP codepoints (U+10000+):  2 code units (surrogate pair)
+# ---------------------------------------------------------------------------
+
+sub _utf16_unit_length {
+    my ($cp) = @_;
+    return ($cp > 0xFFFF) ? 2 : 1;
+}
+
+# ---------------------------------------------------------------------------
+# _decode_utf8_codepoint($bytes, $offset) -> ($codepoint, $byte_count)
+#
+# Decode one UTF-8 codepoint starting at $offset in the byte string $bytes.
+# Returns the Unicode codepoint value and the number of bytes consumed.
+#
+# UTF-8 encoding rules:
+#   0xxxxxxx                            -> 1 byte  (ASCII, U+0000-U+007F)
+#   110xxxxx 10xxxxxx                   -> 2 bytes (U+0080-U+07FF)
+#   1110xxxx 10xxxxxx 10xxxxxx          -> 3 bytes (U+0800-U+FFFF)
+#   11110xxx 10xxxxxx 10xxxxxx 10xxxxxx -> 4 bytes (U+10000-U+10FFFF)
+# ---------------------------------------------------------------------------
+
+sub _decode_utf8_codepoint {
+    my ($bytes, $offset) = @_;
+
+    my $byte = ord(substr($bytes, $offset, 1));
+
+    if ($byte < 0x80) {
+        # Single-byte ASCII character.
+        return ($byte, 1);
+    } elsif ($byte < 0xC0) {
+        # Continuation byte found at start -- invalid, treat as 1 byte.
+        return ($byte, 1);
+    } elsif ($byte < 0xE0) {
+        # 2-byte sequence.
+        my $b2 = ord(substr($bytes, $offset + 1, 1));
+        my $cp = (($byte & 0x1F) << 6) | ($b2 & 0x3F);
+        return ($cp, 2);
+    } elsif ($byte < 0xF0) {
+        # 3-byte sequence.
+        my $b2 = ord(substr($bytes, $offset + 1, 1));
+        my $b3 = ord(substr($bytes, $offset + 2, 1));
+        my $cp = (($byte & 0x0F) << 12) | (($b2 & 0x3F) << 6) | ($b3 & 0x3F);
+        return ($cp, 3);
+    } else {
+        # 4-byte sequence.
+        my $b2 = ord(substr($bytes, $offset + 1, 1));
+        my $b3 = ord(substr($bytes, $offset + 2, 1));
+        my $b4 = ord(substr($bytes, $offset + 3, 1));
+        my $cp = (($byte & 0x07) << 18) | (($b2 & 0x3F) << 12)
+               | (($b3 & 0x3F) << 6)    | ($b4 & 0x3F);
+        return ($cp, 4);
+    }
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+CodingAdventures::Ls00::DocumentManager -- Tracks open documents
+
+=head1 SYNOPSIS
+
+  use CodingAdventures::Ls00::DocumentManager;
+
+  my $dm = CodingAdventures::Ls00::DocumentManager->new();
+  $dm->open("file:///test.txt", "hello world", 1);
+
+  my ($doc, $found) = $dm->get("file:///test.txt");
+  print $doc->{text};  # "hello world"
+
+  $dm->close("file:///test.txt");
+
+=head1 DESCRIPTION
+
+Maintains the current text content of all files open in the editor.  Handles
+both full-document replacement and incremental (range-based) changes.
+
+=cut

--- a/code/packages/perl/ls00/lib/CodingAdventures/Ls00/Handlers.pm
+++ b/code/packages/perl/ls00/lib/CodingAdventures/Ls00/Handlers.pm
@@ -1,0 +1,733 @@
+package CodingAdventures::Ls00::Handlers;
+
+# ============================================================================
+# CodingAdventures::Ls00::Handlers -- LSP request and notification handlers
+# ============================================================================
+#
+# This module contains all the handler functions that the Server registers
+# with the JSON-RPC dispatch loop.  Each handler corresponds to one LSP
+# method (e.g., "textDocument/hover", "textDocument/didOpen").
+#
+# # Handler Contract
+#
+# Request handlers receive ($server, $id, $params) and return:
+#   - A result value (hashref, arrayref, undef) for success
+#   - A hashref { code => N, message => "..." } for an error response
+#
+# Notification handlers receive ($server, $params) and return nothing.
+#
+# # Server Lifecycle
+#
+#   Client (editor)              Server (us)
+#     |                               |
+#     |--initialize------------->     |  return capabilities
+#     |<-----------result--------     |
+#     |--initialized (notif)----->    |  no-op
+#     |--textDocument/didOpen---->    |  open doc, parse, push diagnostics
+#     |--textDocument/hover------>    |  call bridge->hover, return result
+#     |<-----------result--------     |
+#     |--shutdown---------------->    |  set shutdown flag, return undef
+#     |--exit (notif)------------>    |  exit process
+
+use strict;
+use warnings;
+
+use CodingAdventures::Ls00::Capabilities qw(build_capabilities encode_semantic_tokens);
+use CodingAdventures::Ls00::LspErrors qw(:all);
+use CodingAdventures::JsonRpc::Errors qw(:all);
+
+our $VERSION = '0.01';
+
+# ---------------------------------------------------------------------------
+# register_handlers($server)
+#
+# Wire all LSP method names to their handler functions on the server's
+# JSON-RPC server.
+# ---------------------------------------------------------------------------
+
+sub register_handlers {
+    my ($server) = @_;
+
+    my $rpc = $server->{rpc_server};
+
+    # -- Lifecycle --
+    $rpc->on_request('initialize', sub { handle_initialize($server, @_) });
+    $rpc->on_notification('initialized', sub { handle_initialized($server, @_) });
+    $rpc->on_request('shutdown', sub { handle_shutdown($server, @_) });
+    $rpc->on_notification('exit', sub { handle_exit($server, @_) });
+
+    # -- Text document synchronization --
+    $rpc->on_notification('textDocument/didOpen', sub { handle_did_open($server, @_) });
+    $rpc->on_notification('textDocument/didChange', sub { handle_did_change($server, @_) });
+    $rpc->on_notification('textDocument/didClose', sub { handle_did_close($server, @_) });
+    $rpc->on_notification('textDocument/didSave', sub { handle_did_save($server, @_) });
+
+    # -- Feature requests --
+    $rpc->on_request('textDocument/hover', sub { handle_hover($server, @_) });
+    $rpc->on_request('textDocument/definition', sub { handle_definition($server, @_) });
+    $rpc->on_request('textDocument/references', sub { handle_references($server, @_) });
+    $rpc->on_request('textDocument/completion', sub { handle_completion($server, @_) });
+    $rpc->on_request('textDocument/rename', sub { handle_rename($server, @_) });
+    $rpc->on_request('textDocument/documentSymbol', sub { handle_document_symbol($server, @_) });
+    $rpc->on_request('textDocument/semanticTokens/full', sub { handle_semantic_tokens_full($server, @_) });
+    $rpc->on_request('textDocument/foldingRange', sub { handle_folding_range($server, @_) });
+    $rpc->on_request('textDocument/signatureHelp', sub { handle_signature_help($server, @_) });
+    $rpc->on_request('textDocument/formatting', sub { handle_formatting($server, @_) });
+}
+
+# =========================================================================
+# Lifecycle Handlers
+# =========================================================================
+
+# handle_initialize -- LSP initialize request
+#
+# The first message from the editor.  We return our capabilities.
+
+sub handle_initialize {
+    my ($server, $id, $params) = @_;
+
+    $server->{initialized} = 1;
+
+    my $caps = build_capabilities($server->{bridge});
+
+    return {
+        capabilities => $caps,
+        serverInfo   => {
+            name    => 'ls00-generic-lsp-server',
+            version => '0.1.0',
+        },
+    };
+}
+
+# handle_initialized -- "initialized" notification
+#
+# Handshake complete.  No action needed.
+
+sub handle_initialized {
+    my ($server, $params) = @_;
+    # No-op.
+}
+
+# handle_shutdown -- LSP shutdown request
+#
+# Set the shutdown flag and return undef (null).
+
+sub handle_shutdown {
+    my ($server, $id, $params) = @_;
+    $server->{shutdown} = 1;
+    return undef;
+}
+
+# handle_exit -- "exit" notification
+#
+# Exit with code 0 if shutdown was received, 1 otherwise.
+
+sub handle_exit {
+    my ($server, $params) = @_;
+    if ($server->{shutdown}) {
+        exit(0);
+    } else {
+        exit(1);
+    }
+}
+
+# =========================================================================
+# Text Document Synchronization Handlers
+# =========================================================================
+
+# handle_did_open -- textDocument/didOpen notification
+#
+# Register the document with the manager, parse, and push diagnostics.
+
+sub handle_did_open {
+    my ($server, $params) = @_;
+    return unless ref $params eq 'HASH';
+
+    my $td = $params->{textDocument};
+    return unless ref $td eq 'HASH';
+
+    my $uri     = $td->{uri} // '';
+    my $text    = $td->{text} // '';
+    my $version = $td->{version} // 1;
+    return unless $uri;
+
+    $server->{doc_manager}->open($uri, $text, $version);
+
+    my $result = $server->{parse_cache}->get_or_parse(
+        $uri, $version, $text, $server->{bridge}
+    );
+    _publish_diagnostics($server, $uri, $version, $result->{diagnostics});
+}
+
+# handle_did_change -- textDocument/didChange notification
+#
+# Apply incremental changes, re-parse, and push diagnostics.
+
+sub handle_did_change {
+    my ($server, $params) = @_;
+    return unless ref $params eq 'HASH';
+
+    my $uri = _parse_uri($params);
+    return unless $uri;
+
+    my $version = 0;
+    if (ref $params->{textDocument} eq 'HASH') {
+        $version = $params->{textDocument}{version} // 0;
+    }
+
+    my $changes_raw = $params->{contentChanges} // [];
+    my @changes;
+
+    for my $change_raw (@$changes_raw) {
+        next unless ref $change_raw eq 'HASH';
+        my %change = ( new_text => $change_raw->{text} // '' );
+
+        if (defined $change_raw->{range} && ref $change_raw->{range} eq 'HASH') {
+            $change{range} = _parse_lsp_range($change_raw->{range});
+        }
+        # If range is absent, it stays undef -> full replacement.
+
+        push @changes, \%change;
+    }
+
+    my $err = $server->{doc_manager}->apply_changes($uri, \@changes, $version);
+    return if $err;  # Document wasn't open.
+
+    my ($doc, $found) = $server->{doc_manager}->get($uri);
+    return unless $found;
+
+    my $result = $server->{parse_cache}->get_or_parse(
+        $uri, $doc->{version}, $doc->{text}, $server->{bridge}
+    );
+    _publish_diagnostics($server, $uri, $version, $result->{diagnostics});
+}
+
+# handle_did_close -- textDocument/didClose notification
+#
+# Remove the document and clear diagnostics.
+
+sub handle_did_close {
+    my ($server, $params) = @_;
+    return unless ref $params eq 'HASH';
+
+    my $uri = _parse_uri($params);
+    return unless $uri;
+
+    $server->{doc_manager}->close($uri);
+    $server->{parse_cache}->evict($uri);
+
+    # Clear diagnostics by publishing an empty list.
+    _publish_diagnostics($server, $uri, 0, []);
+}
+
+# handle_did_save -- textDocument/didSave notification
+
+sub handle_did_save {
+    my ($server, $params) = @_;
+    return unless ref $params eq 'HASH';
+
+    my $uri = _parse_uri($params);
+    return unless $uri;
+
+    # If the client sends full text in didSave, apply it.
+    if (defined $params->{text} && $params->{text} ne '') {
+        my ($doc, $found) = $server->{doc_manager}->get($uri);
+        if ($found) {
+            $server->{doc_manager}->close($uri);
+            $server->{doc_manager}->open($uri, $params->{text}, $doc->{version});
+            my $result = $server->{parse_cache}->get_or_parse(
+                $uri, $doc->{version}, $params->{text}, $server->{bridge}
+            );
+            _publish_diagnostics($server, $uri, $doc->{version}, $result->{diagnostics});
+        }
+    }
+}
+
+# =========================================================================
+# Feature Request Handlers
+# =========================================================================
+
+# handle_hover -- textDocument/hover
+
+sub handle_hover {
+    my ($server, $id, $params) = @_;
+    return undef unless ref $params eq 'HASH';
+
+    my $uri = _parse_uri($params);
+    my $pos = _parse_position($params);
+
+    unless ($server->{bridge}->can('hover')) {
+        return undef;
+    }
+
+    my ($doc, $parse_result, $err) = _get_parse_result($server, $uri);
+    return $err if $err;
+
+    return undef unless $parse_result->{ast};
+
+    my ($hover, $bridge_err) = $server->{bridge}->hover($parse_result->{ast}, $pos);
+    return undef if $bridge_err;
+    return undef unless $hover;
+
+    my $result = {
+        contents => {
+            kind  => 'markdown',
+            value => $hover->{contents},
+        },
+    };
+
+    if (defined $hover->{range}) {
+        $result->{range} = _range_to_lsp($hover->{range});
+    }
+
+    return $result;
+}
+
+# handle_definition -- textDocument/definition
+
+sub handle_definition {
+    my ($server, $id, $params) = @_;
+    return undef unless ref $params eq 'HASH';
+
+    my $uri = _parse_uri($params);
+    my $pos = _parse_position($params);
+
+    unless ($server->{bridge}->can('definition')) {
+        return undef;
+    }
+
+    my ($doc, $parse_result, $err) = _get_parse_result($server, $uri);
+    return $err if $err;
+    return undef unless $parse_result->{ast};
+
+    my ($location, $bridge_err) = $server->{bridge}->definition(
+        $parse_result->{ast}, $pos, $uri
+    );
+    return undef if $bridge_err || !$location;
+
+    return _location_to_lsp($location);
+}
+
+# handle_references -- textDocument/references
+
+sub handle_references {
+    my ($server, $id, $params) = @_;
+    return [] unless ref $params eq 'HASH';
+
+    my $uri = _parse_uri($params);
+    my $pos = _parse_position($params);
+
+    # Extract includeDeclaration from context.
+    my $include_decl = 0;
+    if (ref $params->{context} eq 'HASH') {
+        $include_decl = $params->{context}{includeDeclaration} ? 1 : 0;
+    }
+
+    unless ($server->{bridge}->can('references')) {
+        return [];
+    }
+
+    my ($doc, $parse_result, $err) = _get_parse_result($server, $uri);
+    return $err if $err;
+    return [] unless $parse_result->{ast};
+
+    my ($locations, $bridge_err) = $server->{bridge}->references(
+        $parse_result->{ast}, $pos, $uri, $include_decl
+    );
+    return [] if $bridge_err;
+
+    return [ map { _location_to_lsp($_) } @$locations ];
+}
+
+# handle_completion -- textDocument/completion
+
+sub handle_completion {
+    my ($server, $id, $params) = @_;
+    my $empty = { isIncomplete => JSON::PP::false, items => [] };
+    return $empty unless ref $params eq 'HASH';
+
+    my $uri = _parse_uri($params);
+    my $pos = _parse_position($params);
+
+    unless ($server->{bridge}->can('completion')) {
+        return $empty;
+    }
+
+    my ($doc, $parse_result, $err) = _get_parse_result($server, $uri);
+    return $err if $err;
+    return $empty unless $parse_result->{ast};
+
+    my ($items, $bridge_err) = $server->{bridge}->completion($parse_result->{ast}, $pos);
+    return $empty if $bridge_err;
+
+    my @lsp_items;
+    for my $item (@$items) {
+        my %ci = ( label => $item->{label} );
+        $ci{kind}             = $item->{kind}              if defined $item->{kind};
+        $ci{detail}           = $item->{detail}            if defined $item->{detail};
+        $ci{documentation}    = $item->{documentation}     if defined $item->{documentation};
+        $ci{insertText}       = $item->{insert_text}       if defined $item->{insert_text};
+        $ci{insertTextFormat} = $item->{insert_text_format} if defined $item->{insert_text_format};
+        push @lsp_items, \%ci;
+    }
+
+    return { isIncomplete => JSON::PP::false, items => \@lsp_items };
+}
+
+# handle_rename -- textDocument/rename
+
+sub handle_rename {
+    my ($server, $id, $params) = @_;
+    return { code => INVALID_PARAMS, message => 'invalid params' }
+        unless ref $params eq 'HASH';
+
+    my $uri      = _parse_uri($params);
+    my $pos      = _parse_position($params);
+    my $new_name = $params->{newName} // '';
+
+    unless ($new_name) {
+        return { code => INVALID_PARAMS, message => 'newName is required' };
+    }
+
+    unless ($server->{bridge}->can('rename')) {
+        return { code => REQUEST_FAILED, message => 'rename not supported' };
+    }
+
+    my ($doc, $parse_result, $err) = _get_parse_result($server, $uri);
+    return $err if $err;
+
+    unless ($parse_result->{ast}) {
+        return { code => REQUEST_FAILED, message => 'no AST available' };
+    }
+
+    my ($edit, $bridge_err) = $server->{bridge}->rename(
+        $parse_result->{ast}, $pos, $new_name
+    );
+    if ($bridge_err) {
+        return { code => REQUEST_FAILED, message => "$bridge_err" };
+    }
+    unless ($edit) {
+        return { code => REQUEST_FAILED, message => 'symbol not found at position' };
+    }
+
+    # Convert WorkspaceEdit to LSP format.
+    my %lsp_changes;
+    for my $edit_uri (keys %{$edit->{changes}}) {
+        my @lsp_edits;
+        for my $te (@{$edit->{changes}{$edit_uri}}) {
+            push @lsp_edits, {
+                range   => _range_to_lsp($te->{range}),
+                newText => $te->{new_text},
+            };
+        }
+        $lsp_changes{$edit_uri} = \@lsp_edits;
+    }
+
+    return { changes => \%lsp_changes };
+}
+
+# handle_document_symbol -- textDocument/documentSymbol
+
+sub handle_document_symbol {
+    my ($server, $id, $params) = @_;
+    return [] unless ref $params eq 'HASH';
+
+    my $uri = _parse_uri($params);
+
+    unless ($server->{bridge}->can('document_symbols')) {
+        return [];
+    }
+
+    my ($doc, $parse_result, $err) = _get_parse_result($server, $uri);
+    return $err if $err;
+    return [] unless $parse_result->{ast};
+
+    my ($symbols, $bridge_err) = $server->{bridge}->document_symbols($parse_result->{ast});
+    return [] if $bridge_err;
+
+    return _convert_document_symbols($symbols);
+}
+
+# handle_semantic_tokens_full -- textDocument/semanticTokens/full
+
+sub handle_semantic_tokens_full {
+    my ($server, $id, $params) = @_;
+    my $empty = { data => [] };
+    return $empty unless ref $params eq 'HASH';
+
+    my $uri = _parse_uri($params);
+
+    unless ($server->{bridge}->can('semantic_tokens')) {
+        return $empty;
+    }
+
+    my ($doc, $found) = $server->{doc_manager}->get($uri);
+    return $empty unless $found;
+
+    my ($tokens, $tok_err) = $server->{bridge}->tokenize($doc->{text});
+    return $empty if $tok_err;
+
+    my ($sem_tokens, $bridge_err) = $server->{bridge}->semantic_tokens(
+        $doc->{text}, $tokens
+    );
+    return $empty if $bridge_err;
+
+    my $data = encode_semantic_tokens($sem_tokens);
+    return { data => $data };
+}
+
+# handle_folding_range -- textDocument/foldingRange
+
+sub handle_folding_range {
+    my ($server, $id, $params) = @_;
+    return [] unless ref $params eq 'HASH';
+
+    my $uri = _parse_uri($params);
+
+    unless ($server->{bridge}->can('folding_ranges')) {
+        return [];
+    }
+
+    my ($doc, $parse_result, $err) = _get_parse_result($server, $uri);
+    return $err if $err;
+    return [] unless $parse_result->{ast};
+
+    my ($ranges, $bridge_err) = $server->{bridge}->folding_ranges($parse_result->{ast});
+    return [] if $bridge_err;
+
+    my @result;
+    for my $fr (@$ranges) {
+        my %m = (
+            startLine => $fr->{start_line},
+            endLine   => $fr->{end_line},
+        );
+        $m{kind} = $fr->{kind} if defined $fr->{kind};
+        push @result, \%m;
+    }
+    return \@result;
+}
+
+# handle_signature_help -- textDocument/signatureHelp
+
+sub handle_signature_help {
+    my ($server, $id, $params) = @_;
+    return undef unless ref $params eq 'HASH';
+
+    my $uri = _parse_uri($params);
+    my $pos = _parse_position($params);
+
+    unless ($server->{bridge}->can('signature_help')) {
+        return undef;
+    }
+
+    my ($doc, $parse_result, $err) = _get_parse_result($server, $uri);
+    return $err if $err;
+    return undef unless $parse_result->{ast};
+
+    my ($sig_help, $bridge_err) = $server->{bridge}->signature_help(
+        $parse_result->{ast}, $pos
+    );
+    return undef if $bridge_err || !$sig_help;
+
+    # Convert to LSP format.
+    my @lsp_sigs;
+    for my $sig (@{$sig_help->{signatures}}) {
+        my @lsp_params;
+        for my $p (@{$sig->{parameters}}) {
+            my %pp = ( label => $p->{label} );
+            $pp{documentation} = $p->{documentation} if defined $p->{documentation};
+            push @lsp_params, \%pp;
+        }
+        my %s = (
+            label      => $sig->{label},
+            parameters => \@lsp_params,
+        );
+        $s{documentation} = $sig->{documentation} if defined $sig->{documentation};
+        push @lsp_sigs, \%s;
+    }
+
+    return {
+        signatures      => \@lsp_sigs,
+        activeSignature => $sig_help->{active_signature},
+        activeParameter => $sig_help->{active_parameter},
+    };
+}
+
+# handle_formatting -- textDocument/formatting
+
+sub handle_formatting {
+    my ($server, $id, $params) = @_;
+    return [] unless ref $params eq 'HASH';
+
+    my $uri = _parse_uri($params);
+
+    unless ($server->{bridge}->can('format')) {
+        return [];
+    }
+
+    my ($doc, $found) = $server->{doc_manager}->get($uri);
+    return [] unless $found;
+
+    my ($edits, $bridge_err) = $server->{bridge}->format($doc->{text});
+    if ($bridge_err) {
+        return { code => REQUEST_FAILED, message => "formatting failed: $bridge_err" };
+    }
+
+    my @lsp_edits;
+    for my $edit (@$edits) {
+        push @lsp_edits, {
+            range   => _range_to_lsp($edit->{range}),
+            newText => $edit->{new_text},
+        };
+    }
+    return \@lsp_edits;
+}
+
+# =========================================================================
+# Internal Helpers
+# =========================================================================
+
+# _get_parse_result($server, $uri) -> ($doc, $parse_result, $err)
+#
+# Get the current parse result for a document.  Returns an error hashref
+# (suitable for returning from a request handler) if the document is not open.
+
+sub _get_parse_result {
+    my ($server, $uri) = @_;
+
+    my ($doc, $found) = $server->{doc_manager}->get($uri);
+    unless ($found) {
+        return (undef, undef, {
+            code    => REQUEST_FAILED,
+            message => "document not open: $uri",
+        });
+    }
+
+    my $result = $server->{parse_cache}->get_or_parse(
+        $uri, $doc->{version}, $doc->{text}, $server->{bridge}
+    );
+    return ($doc, $result, undef);
+}
+
+# _publish_diagnostics($server, $uri, $version, \@diagnostics)
+#
+# Send the textDocument/publishDiagnostics notification to the editor.
+
+sub _publish_diagnostics {
+    my ($server, $uri, $version, $diagnostics) = @_;
+
+    my @lsp_diags;
+    for my $d (@$diagnostics) {
+        my %diag = (
+            range    => _range_to_lsp($d->{range}),
+            severity => $d->{severity},
+            message  => $d->{message},
+        );
+        $diag{code} = $d->{code} if defined $d->{code} && $d->{code} ne '';
+        push @lsp_diags, \%diag;
+    }
+
+    my %notif_params = (
+        uri         => $uri,
+        diagnostics => \@lsp_diags,
+    );
+    $notif_params{version} = $version if $version > 0;
+
+    $server->send_notification('textDocument/publishDiagnostics', \%notif_params);
+}
+
+# _parse_uri($params) -> $uri
+sub _parse_uri {
+    my ($params) = @_;
+    my $td = $params->{textDocument};
+    return '' unless ref $td eq 'HASH';
+    return $td->{uri} // '';
+}
+
+# _parse_position($params) -> \%position
+sub _parse_position {
+    my ($params) = @_;
+    my $pos = $params->{position} // {};
+    return {
+        line      => $pos->{line}      // 0,
+        character => $pos->{character} // 0,
+    };
+}
+
+# _parse_lsp_range($raw) -> \%range
+sub _parse_lsp_range {
+    my ($raw) = @_;
+    return {
+        start => {
+            line      => $raw->{start}{line}      // 0,
+            character => $raw->{start}{character} // 0,
+        },
+        end => {
+            line      => $raw->{end}{line}      // 0,
+            character => $raw->{end}{character} // 0,
+        },
+    };
+}
+
+# _position_to_lsp($pos) -> \%lsp_pos
+sub _position_to_lsp {
+    my ($p) = @_;
+    return {
+        line      => $p->{line},
+        character => $p->{character},
+    };
+}
+
+# _range_to_lsp($range) -> \%lsp_range
+sub _range_to_lsp {
+    my ($r) = @_;
+    return {
+        start => _position_to_lsp($r->{start}),
+        end   => _position_to_lsp($r->{end}),
+    };
+}
+
+# _location_to_lsp($loc) -> \%lsp_location
+sub _location_to_lsp {
+    my ($l) = @_;
+    return {
+        uri   => $l->{uri},
+        range => _range_to_lsp($l->{range}),
+    };
+}
+
+# _convert_document_symbols(\@symbols) -> \@lsp_symbols
+#
+# Recursively convert document symbols to LSP format.
+sub _convert_document_symbols {
+    my ($symbols) = @_;
+    my @result;
+    for my $sym (@$symbols) {
+        my %m = (
+            name           => $sym->{name},
+            kind           => $sym->{kind},
+            range          => _range_to_lsp($sym->{range}),
+            selectionRange => _range_to_lsp($sym->{selection_range}),
+        );
+        if ($sym->{children} && @{$sym->{children}}) {
+            $m{children} = _convert_document_symbols($sym->{children});
+        }
+        push @result, \%m;
+    }
+    return \@result;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+CodingAdventures::Ls00::Handlers -- LSP request and notification handlers
+
+=head1 DESCRIPTION
+
+Contains all handler functions for LSP methods.  These are registered by
+the Server module with the JSON-RPC dispatch loop.
+
+=cut

--- a/code/packages/perl/ls00/lib/CodingAdventures/Ls00/LanguageBridge.pm
+++ b/code/packages/perl/ls00/lib/CodingAdventures/Ls00/LanguageBridge.pm
@@ -1,0 +1,121 @@
+package CodingAdventures::Ls00::LanguageBridge;
+
+# ============================================================================
+# CodingAdventures::Ls00::LanguageBridge -- Bridge interface documentation
+# ============================================================================
+#
+# # Design Philosophy: Duck Typing with can()
+#
+# In Go, capability detection uses type assertions:
+#
+#     if hp, ok := bridge.(HoverProvider); ok { ... }
+#
+# In Perl, we use the built-in `can()` method:
+#
+#     if ($bridge->can('hover')) { ... }
+#
+# This is Perl's equivalent of interface checking.  Any blessed object that
+# responds to `tokenize()` and `parse()` is a valid bridge.  No base class
+# or interface declaration is required -- just implement the methods you want.
+#
+# # Required Methods
+#
+# Every bridge MUST implement these two methods:
+#
+#   $bridge->tokenize($source) -> (\@tokens, $err)
+#
+#     Lex the source string and return an arrayref of token hashrefs.
+#     Each token has: { type => 'KEYWORD', value => 'let', line => 1, column => 1 }
+#     Returns (undef, $error_string) on fatal error.
+#
+#   $bridge->parse($source) -> ($ast, \@diagnostics, $err)
+#
+#     Parse the source string and return:
+#       - $ast:          any Perl value representing the parsed tree
+#       - \@diagnostics: arrayref of diagnostic hashrefs (may be empty)
+#       - $err:          error string on fatal failure, undef otherwise
+#     Even with syntax errors, parse() should return a partial AST.
+#
+# # Optional Methods
+#
+# Implement any of these to enable the corresponding LSP feature.  The
+# server checks `$bridge->can('method_name')` at startup and only
+# advertises capabilities for methods the bridge actually has.
+#
+#   $bridge->hover($ast, $pos) -> ($hover_result, $err)
+#     Returns hover content (markdown) for the symbol at $pos.
+#     Return (undef, undef) if no hover info at this position.
+#
+#   $bridge->definition($ast, $pos, $uri) -> ($location, $err)
+#     Returns the location where the symbol at $pos was declared.
+#
+#   $bridge->references($ast, $pos, $uri, $include_decl) -> (\@locations, $err)
+#     Returns all uses of the symbol at $pos.
+#
+#   $bridge->completion($ast, $pos) -> (\@items, $err)
+#     Returns autocomplete suggestions valid at $pos.
+#
+#   $bridge->rename($ast, $pos, $new_name) -> ($workspace_edit, $err)
+#     Returns text edits needed to rename the symbol at $pos.
+#
+#   $bridge->semantic_tokens($source, \@tokens) -> (\@semantic_tokens, $err)
+#     Maps raw tokens to semantic token data for highlighting.
+#
+#   $bridge->document_symbols($ast) -> (\@symbols, $err)
+#     Returns the outline tree (document symbols) for the AST.
+#
+#   $bridge->folding_ranges($ast) -> (\@ranges, $err)
+#     Returns collapsible regions derived from the AST.
+#
+#   $bridge->signature_help($ast, $pos) -> ($result, $err)
+#     Returns signature hint information for the call at $pos.
+#
+#   $bridge->format($source) -> (\@text_edits, $err)
+#     Returns text edits that format the document.
+#
+# # Example Bridge (Minimal)
+#
+#   package MyLang::Bridge;
+#   sub new { bless {}, shift }
+#   sub tokenize {
+#       my ($self, $source) = @_;
+#       # ... lex source ...
+#       return (\@tokens, undef);
+#   }
+#   sub parse {
+#       my ($self, $source) = @_;
+#       # ... parse source ...
+#       return ($ast, \@diagnostics, undef);
+#   }
+#   # That's it!  No stubs needed for hover, definition, etc.
+#   # The server will not advertise those capabilities.
+
+use strict;
+use warnings;
+
+our $VERSION = '0.01';
+
+# This module is purely documentation -- no code to execute.
+# Bridges do NOT need to inherit from this class.  Just implement the
+# methods described above.
+
+1;
+
+__END__
+
+=head1 NAME
+
+CodingAdventures::Ls00::LanguageBridge -- Bridge interface documentation
+
+=head1 DESCRIPTION
+
+Documents the interface that bridge objects must implement to work with
+the ls00 LSP server framework.
+
+A bridge is any blessed Perl object.  It must implement C<tokenize()> and
+C<parse()>.  Optional methods like C<hover()>, C<definition()>, etc. are
+detected at runtime via C<< $bridge->can('method_name') >>.
+
+See the source of this module for complete method signatures and examples.
+
+=cut

--- a/code/packages/perl/ls00/lib/CodingAdventures/Ls00/LspErrors.pm
+++ b/code/packages/perl/ls00/lib/CodingAdventures/Ls00/LspErrors.pm
@@ -1,0 +1,77 @@
+package CodingAdventures::Ls00::LspErrors;
+
+# ============================================================================
+# CodingAdventures::Ls00::LspErrors -- LSP-specific error codes
+# ============================================================================
+#
+# The JSON-RPC 2.0 specification reserves error codes [-32768, -32000].
+# The LSP specification further reserves [-32899, -32800] for LSP
+# protocol-level errors.
+#
+# Standard JSON-RPC error codes (from CodingAdventures::JsonRpc::Errors):
+#   -32700  ParseError
+#   -32600  InvalidRequest
+#   -32601  MethodNotFound
+#   -32602  InvalidParams
+#   -32603  InternalError
+#
+# LSP-specific error codes are listed below.
+#
+# Reference:
+# https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#errorCodes
+
+use strict;
+use warnings;
+
+use Exporter 'import';
+our @EXPORT_OK = qw(
+    SERVER_NOT_INITIALIZED
+    UNKNOWN_ERROR_CODE
+    REQUEST_FAILED
+    SERVER_CANCELLED
+    CONTENT_MODIFIED
+    REQUEST_CANCELLED
+);
+our %EXPORT_TAGS = ( all => \@EXPORT_OK );
+
+our $VERSION = '0.01';
+
+# ServerNotInitialized (-32002): the server received a request before the
+# initialize handshake was completed.
+use constant SERVER_NOT_INITIALIZED => -32002;
+
+# UnknownErrorCode (-32001): a generic error code for unknown errors.
+use constant UNKNOWN_ERROR_CODE => -32001;
+
+# RequestFailed (-32803): a request failed but not due to a protocol problem.
+use constant REQUEST_FAILED => -32803;
+
+# ServerCancelled (-32802): the server cancelled the request.
+use constant SERVER_CANCELLED => -32802;
+
+# ContentModified (-32801): the document content was modified before the
+# request completed.
+use constant CONTENT_MODIFIED => -32801;
+
+# RequestCancelled (-32800): the client cancelled the request.
+use constant REQUEST_CANCELLED => -32800;
+
+1;
+
+__END__
+
+=head1 NAME
+
+CodingAdventures::Ls00::LspErrors -- LSP-specific error code constants
+
+=head1 SYNOPSIS
+
+  use CodingAdventures::Ls00::LspErrors qw(:all);
+
+  my $err = { code => REQUEST_FAILED, message => 'document not open' };
+
+=head1 DESCRIPTION
+
+Provides compile-time constants for LSP-specific error codes.
+
+=cut

--- a/code/packages/perl/ls00/lib/CodingAdventures/Ls00/ParseCache.pm
+++ b/code/packages/perl/ls00/lib/CodingAdventures/Ls00/ParseCache.pm
@@ -1,0 +1,129 @@
+package CodingAdventures::Ls00::ParseCache;
+
+# ============================================================================
+# CodingAdventures::Ls00::ParseCache -- Avoids re-parsing unchanged documents
+# ============================================================================
+#
+# # Why Cache Parse Results?
+#
+# Parsing is the most expensive operation in a language server.  For a large
+# file, parsing on every keystroke would lag the editor noticeably.
+#
+# The LSP protocol helps by sending a version number with every change.  If
+# the document hasn't changed (same URI, same version), the parse result
+# from the previous keystroke is still valid.
+#
+# # Cache Key Design
+#
+# The cache key is "$uri\0$version".  Version is a monotonically increasing
+# integer that the editor increments with each change.  Using version in
+# the key means:
+#
+#   Same (uri, version) -> cache hit  -> return cached result
+#   Different version   -> cache miss -> re-parse and cache new result
+#
+# The old entry is evicted when a new version is cached for the same URI.
+# This keeps memory bounded at O(open_documents) entries.
+#
+# # Thread Safety
+#
+# Perl's single-threaded event model means no locking is needed.
+
+use strict;
+use warnings;
+
+our $VERSION = '0.01';
+
+# ---------------------------------------------------------------------------
+# new() -> ParseCache
+# ---------------------------------------------------------------------------
+
+sub new {
+    my ($class) = @_;
+    return bless { cache => {} }, $class;
+}
+
+# ---------------------------------------------------------------------------
+# get_or_parse($uri, $version, $source, $bridge) -> $parse_result
+#
+# Return the parse result for ($uri, $version).
+#
+# If the result is already cached, it is returned immediately without
+# calling the bridge again.  Otherwise, $bridge->parse($source) is called,
+# the result is stored, and any previous cache entry for this URI is evicted.
+#
+# The result is a hashref:
+#   { ast => $ast, diagnostics => \@diags, err => $err_or_undef }
+# ---------------------------------------------------------------------------
+
+sub get_or_parse {
+    my ($self, $uri, $version, $source, $bridge) = @_;
+
+    my $key = "$uri\0$version";
+
+    # Cache hit: the document hasn't changed since last parse.
+    if (exists $self->{cache}{$key}) {
+        return $self->{cache}{$key};
+    }
+
+    # Cache miss: parse and store.  Evict any stale entry for this URI first.
+    $self->_evict($uri);
+
+    my ($ast, $diags, $err) = $bridge->parse($source);
+    $diags //= [];
+
+    my $result = {
+        ast         => $ast,
+        diagnostics => $diags,
+        err         => $err,
+    };
+
+    $self->{cache}{$key} = $result;
+    return $result;
+}
+
+# ---------------------------------------------------------------------------
+# evict($uri)
+#
+# Remove all cached entries for a given URI.
+# Called when a document is closed (didClose).
+# ---------------------------------------------------------------------------
+
+sub evict {
+    my ($self, $uri) = @_;
+    $self->_evict($uri);
+}
+
+# ---------------------------------------------------------------------------
+# _evict($uri) -- internal eviction
+# ---------------------------------------------------------------------------
+
+sub _evict {
+    my ($self, $uri) = @_;
+    my $prefix = "$uri\0";
+    for my $key (keys %{$self->{cache}}) {
+        if (index($key, $prefix) == 0) {
+            delete $self->{cache}{$key};
+        }
+    }
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+CodingAdventures::Ls00::ParseCache -- Caches parse results by document version
+
+=head1 SYNOPSIS
+
+  my $cache = CodingAdventures::Ls00::ParseCache->new();
+  my $result = $cache->get_or_parse($uri, $version, $source, $bridge);
+
+=head1 DESCRIPTION
+
+Stores the most recent parse result for each open document.  The cache key
+is (uri, version) so that unchanged documents are never re-parsed.
+
+=cut

--- a/code/packages/perl/ls00/lib/CodingAdventures/Ls00/Server.pm
+++ b/code/packages/perl/ls00/lib/CodingAdventures/Ls00/Server.pm
@@ -1,0 +1,144 @@
+package CodingAdventures::Ls00::Server;
+
+# ============================================================================
+# CodingAdventures::Ls00::Server -- Main LSP server coordinator
+# ============================================================================
+#
+# The Server wires together:
+#   - The bridge (language-specific logic)
+#   - The DocumentManager (tracks open file contents)
+#   - The ParseCache (avoids redundant parses)
+#   - The JSON-RPC Server (protocol layer)
+#
+# It registers all LSP request and notification handlers, then calls
+# serve() to start the blocking read-dispatch-write loop.
+#
+# # Server Lifecycle
+#
+#   Client (editor)              Server (us)
+#     |                               |
+#     |--initialize------------->     |  store clientInfo, return capabilities
+#     |<-----------result--------     |
+#     |--initialized (notif)----->    |  no-op (handshake complete)
+#     |--textDocument/didOpen---->    |  open doc, parse, push diagnostics
+#     |--textDocument/hover------>    |  get parse result, call bridge.hover
+#     |<-----------result--------     |
+#     |--shutdown---------------->    |  set shutdown flag, return undef
+#     |--exit (notif)------------>    |  exit(0) or exit(1)
+#
+# # Sending Notifications to the Editor
+#
+# The JSON-RPC Server handles request/response pairs.  But the LSP server
+# also needs to PUSH notifications to the editor (e.g., diagnostics).
+# We do this by holding a reference to the JSON-RPC Writer and calling
+# write_message() directly.
+
+use strict;
+use warnings;
+
+use CodingAdventures::JsonRpc;
+use CodingAdventures::JsonRpc::Message qw(notification);
+use CodingAdventures::Ls00::DocumentManager;
+use CodingAdventures::Ls00::ParseCache;
+use CodingAdventures::Ls00::Handlers;
+
+our $VERSION = '0.01';
+
+# ---------------------------------------------------------------------------
+# new($bridge, $in_fh, $out_fh) -> Server
+#
+# Create an LspServer wired to read from $in_fh and write to $out_fh.
+#
+# Typical usage:
+#   my $server = CodingAdventures::Ls00::Server->new($bridge, \*STDIN, \*STDOUT);
+#   $server->serve();
+#
+# For testing, pass in-memory filehandles (open on scalar references).
+# ---------------------------------------------------------------------------
+
+sub new {
+    my ($class, $bridge, $in_fh, $out_fh) = @_;
+
+    my $rpc_server = CodingAdventures::JsonRpc::Server->new($in_fh, $out_fh);
+    my $writer     = CodingAdventures::JsonRpc::Writer->new($out_fh);
+
+    my $self = bless {
+        bridge      => $bridge,
+        doc_manager => CodingAdventures::Ls00::DocumentManager->new(),
+        parse_cache => CodingAdventures::Ls00::ParseCache->new(),
+        rpc_server  => $rpc_server,
+        writer      => $writer,
+        shutdown    => 0,
+        initialized => 0,
+    }, $class;
+
+    CodingAdventures::Ls00::Handlers::register_handlers($self);
+
+    return $self;
+}
+
+# ---------------------------------------------------------------------------
+# serve()
+#
+# Start the blocking JSON-RPC read-dispatch-write loop.  This call blocks
+# until the editor closes the connection (EOF on stdin).
+# ---------------------------------------------------------------------------
+
+sub serve {
+    my ($self) = @_;
+    $self->{rpc_server}->serve();
+}
+
+# ---------------------------------------------------------------------------
+# send_notification($method, \%params)
+#
+# Send a server-initiated notification to the editor.  Used for
+# textDocument/publishDiagnostics and other push notifications.
+# ---------------------------------------------------------------------------
+
+sub send_notification {
+    my ($self, $method, $params) = @_;
+    my $notif = notification($method, $params);
+    eval { $self->{writer}->write_message($notif) };
+    # Best-effort: if the write fails, the editor will show stale data.
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+CodingAdventures::Ls00::Server -- Main LSP server coordinator
+
+=head1 SYNOPSIS
+
+  use CodingAdventures::Ls00::Server;
+
+  my $server = CodingAdventures::Ls00::Server->new($bridge, \*STDIN, \*STDOUT);
+  $server->serve();
+
+=head1 DESCRIPTION
+
+Wires the bridge, document manager, parse cache, and JSON-RPC server
+together.  Call C<serve()> to start the blocking event loop.
+
+=head1 METHODS
+
+=over 4
+
+=item new($bridge, $in_fh, $out_fh)
+
+Create a server.  Both filehandles should be in binary mode.
+
+=item serve()
+
+Blocking loop.  Returns when stdin closes.
+
+=item send_notification($method, \%params)
+
+Send a server-initiated notification (e.g., diagnostics).
+
+=back
+
+=cut

--- a/code/packages/perl/ls00/lib/CodingAdventures/Ls00/Types.pm
+++ b/code/packages/perl/ls00/lib/CodingAdventures/Ls00/Types.pm
@@ -1,0 +1,427 @@
+package CodingAdventures::Ls00::Types;
+
+# ============================================================================
+# CodingAdventures::Ls00::Types -- All LSP data types
+# ============================================================================
+#
+# These types mirror the LSP specification's TypeScript type definitions,
+# translated to idiomatic Perl.  Each type is a plain hashref (or blessed
+# hashref for constructors).  The LSP spec lives at:
+# https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/
+#
+# # Coordinate System
+#
+# LSP uses a 0-based, line/character coordinate system.  Line 0, character 0
+# is the very first character of the file.  This differs from most editors
+# (which display 1-based line numbers) and from our lexer (which emits
+# 1-based tokens).  The bridge is responsible for converting.
+#
+# # UTF-16 Code Units
+#
+# LSP's "character" offset is measured in UTF-16 CODE UNITS, not bytes or
+# Unicode codepoints.  This is a historical artifact: VS Code is built on
+# TypeScript, which uses UTF-16 strings internally.  See DocumentManager.pm
+# for the conversion function and a detailed explanation.
+
+use strict;
+use warnings;
+
+use Exporter 'import';
+
+our @EXPORT_OK = qw(
+    position
+    lsp_range
+    location
+    diagnostic
+    token
+    text_edit
+    workspace_edit
+    hover_result
+    completion_item
+    semantic_token
+    document_symbol
+    folding_range
+    parameter_information
+    signature_information
+    signature_help_result
+
+    SEVERITY_ERROR
+    SEVERITY_WARNING
+    SEVERITY_INFORMATION
+    SEVERITY_HINT
+
+    COMPLETION_TEXT
+    COMPLETION_METHOD
+    COMPLETION_FUNCTION
+    COMPLETION_CONSTRUCTOR
+    COMPLETION_FIELD
+    COMPLETION_VARIABLE
+    COMPLETION_CLASS
+    COMPLETION_INTERFACE
+    COMPLETION_MODULE
+    COMPLETION_PROPERTY
+    COMPLETION_UNIT
+    COMPLETION_VALUE
+    COMPLETION_ENUM
+    COMPLETION_KEYWORD
+    COMPLETION_SNIPPET
+    COMPLETION_COLOR
+    COMPLETION_FILE
+    COMPLETION_REFERENCE
+    COMPLETION_FOLDER
+    COMPLETION_ENUM_MEMBER
+    COMPLETION_CONSTANT
+    COMPLETION_STRUCT
+    COMPLETION_EVENT
+    COMPLETION_OPERATOR
+    COMPLETION_TYPE_PARAMETER
+
+    SYMBOL_FILE
+    SYMBOL_MODULE
+    SYMBOL_NAMESPACE
+    SYMBOL_PACKAGE
+    SYMBOL_CLASS
+    SYMBOL_METHOD
+    SYMBOL_PROPERTY
+    SYMBOL_FIELD
+    SYMBOL_CONSTRUCTOR
+    SYMBOL_ENUM
+    SYMBOL_INTERFACE
+    SYMBOL_FUNCTION
+    SYMBOL_VARIABLE
+    SYMBOL_CONSTANT
+    SYMBOL_STRING
+    SYMBOL_NUMBER
+    SYMBOL_BOOLEAN
+    SYMBOL_ARRAY
+    SYMBOL_OBJECT
+    SYMBOL_KEY
+    SYMBOL_NULL
+    SYMBOL_ENUM_MEMBER
+    SYMBOL_STRUCT
+    SYMBOL_EVENT
+    SYMBOL_OPERATOR
+    SYMBOL_TYPE_PARAMETER
+);
+
+our %EXPORT_TAGS = ( all => \@EXPORT_OK );
+
+our $VERSION = '0.01';
+
+# ---------------------------------------------------------------------------
+# Diagnostic Severity Constants
+#
+# These match the LSP integer codes:
+#   1 = Error   -- a hard error; the code cannot run or compile
+#   2 = Warning -- potentially problematic, but not blocking
+#   3 = Information -- informational message
+#   4 = Hint    -- a suggestion (e.g., "consider using const")
+# ---------------------------------------------------------------------------
+
+use constant SEVERITY_ERROR       => 1;
+use constant SEVERITY_WARNING     => 2;
+use constant SEVERITY_INFORMATION => 3;
+use constant SEVERITY_HINT        => 4;
+
+# ---------------------------------------------------------------------------
+# Completion Item Kind Constants
+#
+# These classify completion items so the editor can show the right icon
+# (function icon, variable icon, keyword icon, etc.).
+# ---------------------------------------------------------------------------
+
+use constant COMPLETION_TEXT           => 1;
+use constant COMPLETION_METHOD         => 2;
+use constant COMPLETION_FUNCTION       => 3;
+use constant COMPLETION_CONSTRUCTOR    => 4;
+use constant COMPLETION_FIELD          => 5;
+use constant COMPLETION_VARIABLE       => 6;
+use constant COMPLETION_CLASS          => 7;
+use constant COMPLETION_INTERFACE      => 8;
+use constant COMPLETION_MODULE         => 9;
+use constant COMPLETION_PROPERTY       => 10;
+use constant COMPLETION_UNIT           => 11;
+use constant COMPLETION_VALUE          => 12;
+use constant COMPLETION_ENUM           => 13;
+use constant COMPLETION_KEYWORD        => 14;
+use constant COMPLETION_SNIPPET        => 15;
+use constant COMPLETION_COLOR          => 16;
+use constant COMPLETION_FILE           => 17;
+use constant COMPLETION_REFERENCE      => 18;
+use constant COMPLETION_FOLDER         => 19;
+use constant COMPLETION_ENUM_MEMBER    => 20;
+use constant COMPLETION_CONSTANT       => 21;
+use constant COMPLETION_STRUCT         => 22;
+use constant COMPLETION_EVENT          => 23;
+use constant COMPLETION_OPERATOR       => 24;
+use constant COMPLETION_TYPE_PARAMETER => 25;
+
+# ---------------------------------------------------------------------------
+# Symbol Kind Constants
+#
+# These classify document symbols for the outline panel.
+# ---------------------------------------------------------------------------
+
+use constant SYMBOL_FILE           => 1;
+use constant SYMBOL_MODULE         => 2;
+use constant SYMBOL_NAMESPACE      => 3;
+use constant SYMBOL_PACKAGE        => 4;
+use constant SYMBOL_CLASS          => 5;
+use constant SYMBOL_METHOD         => 6;
+use constant SYMBOL_PROPERTY       => 7;
+use constant SYMBOL_FIELD          => 8;
+use constant SYMBOL_CONSTRUCTOR    => 9;
+use constant SYMBOL_ENUM           => 10;
+use constant SYMBOL_INTERFACE      => 11;
+use constant SYMBOL_FUNCTION       => 12;
+use constant SYMBOL_VARIABLE       => 13;
+use constant SYMBOL_CONSTANT       => 14;
+use constant SYMBOL_STRING         => 15;
+use constant SYMBOL_NUMBER         => 16;
+use constant SYMBOL_BOOLEAN        => 17;
+use constant SYMBOL_ARRAY          => 18;
+use constant SYMBOL_OBJECT         => 19;
+use constant SYMBOL_KEY            => 20;
+use constant SYMBOL_NULL           => 21;
+use constant SYMBOL_ENUM_MEMBER    => 22;
+use constant SYMBOL_STRUCT         => 23;
+use constant SYMBOL_EVENT          => 24;
+use constant SYMBOL_OPERATOR       => 25;
+use constant SYMBOL_TYPE_PARAMETER => 26;
+
+# ---------------------------------------------------------------------------
+# Constructor Functions
+#
+# Each constructor returns a plain hashref.  This is idiomatic Perl -- no
+# need for OO ceremony when the data is just a record with named fields.
+#
+# All constructors use named parameters (key => value) for clarity.
+# ---------------------------------------------------------------------------
+
+# position(line => N, character => N) -> hashref
+#
+# A cursor position in a document.  Both line and character are 0-based.
+# Character is measured in UTF-16 code units (see DocumentManager for why).
+#
+# Example: in "hello world", the 'w' in 'world' is at position(line => 0, character => 6).
+
+sub position {
+    my (%args) = @_;
+    return {
+        line      => $args{line}      // 0,
+        character => $args{character} // 0,
+    };
+}
+
+# lsp_range(start => $pos, end => $pos) -> hashref
+#
+# A span of text from start (inclusive) to end (exclusive).
+# Think of it like a text selection: start is where the cursor lands
+# when you click, end is where you drag to.
+#
+# Named "lsp_range" to avoid collision with Perl's built-in range operator.
+
+sub lsp_range {
+    my (%args) = @_;
+    return {
+        start => $args{start} // position(),
+        end   => $args{end}   // position(),
+    };
+}
+
+# location(uri => $str, range => $range) -> hashref
+#
+# A position in a specific file.  URI uses the "file://" scheme.
+
+sub location {
+    my (%args) = @_;
+    return {
+        uri   => $args{uri}   // '',
+        range => $args{range} // lsp_range(),
+    };
+}
+
+# diagnostic(range => $range, severity => N, message => $str, code => $str) -> hashref
+#
+# An error, warning, or hint to display in the editor.  The editor renders
+# diagnostics as underlined squiggles, with the message shown on hover.
+
+sub diagnostic {
+    my (%args) = @_;
+    return {
+        range    => $args{range}    // lsp_range(),
+        severity => $args{severity} // SEVERITY_ERROR,
+        message  => $args{message}  // '',
+        (defined $args{code} ? (code => $args{code}) : ()),
+    };
+}
+
+# token(type => $str, value => $str, line => N, column => N) -> hashref
+#
+# A single lexical token from the language's lexer.  Line and Column are
+# 1-based (matching most lexers).  The bridge must convert to 0-based when
+# building semantic tokens.
+
+sub token {
+    my (%args) = @_;
+    return {
+        type   => $args{type}   // '',
+        value  => $args{value}  // '',
+        line   => $args{line}   // 1,
+        column => $args{column} // 1,
+    };
+}
+
+# text_edit(range => $range, new_text => $str) -> hashref
+#
+# A single text replacement in a document.  If new_text is empty, the range
+# is deleted.
+
+sub text_edit {
+    my (%args) = @_;
+    return {
+        range    => $args{range}    // lsp_range(),
+        new_text => $args{new_text} // '',
+    };
+}
+
+# workspace_edit(changes => { uri => [text_edit, ...] }) -> hashref
+#
+# Groups text edits across potentially multiple files.
+
+sub workspace_edit {
+    my (%args) = @_;
+    return {
+        changes => $args{changes} // {},
+    };
+}
+
+# hover_result(contents => $markdown, range => $range_or_undef) -> hashref
+#
+# Content to show in the hover popup.  Contents is Markdown.
+
+sub hover_result {
+    my (%args) = @_;
+    return {
+        contents => $args{contents} // '',
+        (defined $args{range} ? (range => $args{range}) : ()),
+    };
+}
+
+# completion_item(label => $str, kind => N, ...) -> hashref
+#
+# A single autocomplete suggestion.
+
+sub completion_item {
+    my (%args) = @_;
+    my $item = { label => $args{label} // '' };
+    $item->{kind}              = $args{kind}              if defined $args{kind};
+    $item->{detail}            = $args{detail}            if defined $args{detail};
+    $item->{documentation}     = $args{documentation}     if defined $args{documentation};
+    $item->{insert_text}       = $args{insert_text}       if defined $args{insert_text};
+    $item->{insert_text_format} = $args{insert_text_format} if defined $args{insert_text_format};
+    return $item;
+}
+
+# semantic_token(line => N, character => N, length => N, token_type => $str, modifiers => [...]) -> hashref
+#
+# One token's contribution to the semantic highlighting pass.
+# Line and character are 0-based.
+
+sub semantic_token {
+    my (%args) = @_;
+    return {
+        line       => $args{line}       // 0,
+        character  => $args{character}  // 0,
+        length     => $args{length}     // 0,
+        token_type => $args{token_type} // '',
+        modifiers  => $args{modifiers}  // [],
+    };
+}
+
+# document_symbol(name => $str, kind => N, range => $range, selection_range => $range, children => [...]) -> hashref
+#
+# One entry in the document outline panel.
+
+sub document_symbol {
+    my (%args) = @_;
+    return {
+        name            => $args{name}            // '',
+        kind            => $args{kind}            // SYMBOL_VARIABLE,
+        range           => $args{range}           // lsp_range(),
+        selection_range => $args{selection_range} // lsp_range(),
+        children        => $args{children}        // [],
+    };
+}
+
+# folding_range(start_line => N, end_line => N, kind => $str) -> hashref
+#
+# A collapsible region of the document.
+
+sub folding_range {
+    my (%args) = @_;
+    my $fr = {
+        start_line => $args{start_line} // 0,
+        end_line   => $args{end_line}   // 0,
+    };
+    $fr->{kind} = $args{kind} if defined $args{kind};
+    return $fr;
+}
+
+# parameter_information(label => $str, documentation => $str) -> hashref
+
+sub parameter_information {
+    my (%args) = @_;
+    my $pi = { label => $args{label} // '' };
+    $pi->{documentation} = $args{documentation} if defined $args{documentation};
+    return $pi;
+}
+
+# signature_information(label => $str, documentation => $str, parameters => [...]) -> hashref
+
+sub signature_information {
+    my (%args) = @_;
+    my $si = {
+        label      => $args{label}      // '',
+        parameters => $args{parameters} // [],
+    };
+    $si->{documentation} = $args{documentation} if defined $args{documentation};
+    return $si;
+}
+
+# signature_help_result(signatures => [...], active_signature => N, active_parameter => N) -> hashref
+
+sub signature_help_result {
+    my (%args) = @_;
+    return {
+        signatures       => $args{signatures}       // [],
+        active_signature => $args{active_signature} // 0,
+        active_parameter => $args{active_parameter} // 0,
+    };
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+CodingAdventures::Ls00::Types -- LSP data types as constructor functions
+
+=head1 SYNOPSIS
+
+  use CodingAdventures::Ls00::Types qw(:all);
+
+  my $pos  = position(line => 0, character => 5);
+  my $diag = diagnostic(
+      range    => lsp_range(start => $pos, end => position(line => 0, character => 10)),
+      severity => SEVERITY_ERROR,
+      message  => 'unexpected token',
+  );
+
+=head1 DESCRIPTION
+
+Provides constructor functions for all LSP data types used by the ls00
+framework.  Each function returns a plain hashref.
+
+=cut

--- a/code/packages/perl/ls00/t/01_utf16.t
+++ b/code/packages/perl/ls00/t/01_utf16.t
@@ -1,0 +1,131 @@
+#!/usr/bin/env perl
+
+# 01_utf16.t -- UTF-16 offset conversion tests
+#
+# These are the most important correctness tests in the entire package.
+# If convert_utf16_offset_to_byte_offset() is wrong, every feature that
+# depends on cursor position will be wrong: hover, go-to-definition,
+# references, completion, rename, signature help.
+
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+
+use CodingAdventures::Ls00::DocumentManager qw(convert_utf16_offset_to_byte_offset);
+
+# ── ASCII Tests ──────────────────────────────────────────────────────────────
+
+subtest "ASCII simple" => sub {
+    is(
+        convert_utf16_offset_to_byte_offset("hello world", 0, 6),
+        6,
+        "'world' starts at byte 6"
+    );
+};
+
+subtest "start of file" => sub {
+    is(
+        convert_utf16_offset_to_byte_offset("abc", 0, 0),
+        0,
+        "position (0,0) is byte 0"
+    );
+};
+
+subtest "end of short string" => sub {
+    is(
+        convert_utf16_offset_to_byte_offset("abc", 0, 3),
+        3,
+        "position past last char is byte 3"
+    );
+};
+
+# ── Multiline Tests ──────────────────────────────────────────────────────────
+
+subtest "second line" => sub {
+    is(
+        convert_utf16_offset_to_byte_offset("hello\nworld", 1, 0),
+        6,
+        "line 1 starts at byte 6"
+    );
+};
+
+# ── Emoji Tests (Non-BMP: 4 UTF-8 bytes, 2 UTF-16 code units) ───────────────
+
+subtest "emoji: guitar takes 2 UTF-16 units but 4 UTF-8 bytes" => sub {
+    is(
+        convert_utf16_offset_to_byte_offset("A\x{1F3B8}B", 0, 3),
+        5,
+        "'B' after guitar emoji is at byte 5"
+    );
+};
+
+subtest "emoji at start" => sub {
+    is(
+        convert_utf16_offset_to_byte_offset("\x{1F3B8}hello", 0, 2),
+        4,
+        "'h' after emoji is at byte 4"
+    );
+};
+
+# ── 2-byte UTF-8 (BMP codepoint) ────────────────────────────────────────────
+
+subtest "2-byte UTF-8: e-acute" => sub {
+    is(
+        convert_utf16_offset_to_byte_offset("caf\x{e9}!", 0, 4),
+        5,
+        "'!' after cafe is at byte 5"
+    );
+};
+
+# ── Multiline with Emoji ────────────────────────────────────────────────────
+
+subtest "multiline with emoji" => sub {
+    is(
+        convert_utf16_offset_to_byte_offset("A\x{1F3B8}B\nhello", 1, 0),
+        7,
+        "line 1 starts at byte 7 after emoji line"
+    );
+};
+
+# ── Beyond line end ─────────────────────────────────────────────────────────
+
+subtest "beyond line end clamps to newline" => sub {
+    is(
+        convert_utf16_offset_to_byte_offset("ab\ncd", 0, 100),
+        2,
+        "character past line end clamps to newline position"
+    );
+};
+
+# ── 3-byte UTF-8 (CJK character) ────────────────────────────────────────────
+
+subtest "3-byte UTF-8: CJK character" => sub {
+    is(
+        convert_utf16_offset_to_byte_offset("A\x{4E2D}B", 0, 2),
+        4,
+        "'B' after CJK char is at byte 4"
+    );
+};
+
+# ── Empty string ────────────────────────────────────────────────────────────
+
+subtest "empty string" => sub {
+    is(
+        convert_utf16_offset_to_byte_offset("", 0, 0),
+        0,
+        "empty string gives byte 0"
+    );
+};
+
+# ── Multiple emojis ─────────────────────────────────────────────────────────
+
+subtest "multiple emojis" => sub {
+    is(
+        convert_utf16_offset_to_byte_offset("\x{1F3B8}\x{1F3B8}X", 0, 4),
+        8,
+        "'X' after two emojis is at byte 8"
+    );
+};
+
+done_testing();

--- a/code/packages/perl/ls00/t/02_document_manager.t
+++ b/code/packages/perl/ls00/t/02_document_manager.t
@@ -1,0 +1,133 @@
+#!/usr/bin/env perl
+
+# 02_document_manager.t -- DocumentManager open/change/close tests
+
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+
+use CodingAdventures::Ls00::DocumentManager;
+
+# ── Open and Get ─────────────────────────────────────────────────────────────
+
+subtest "open and get" => sub {
+    my $dm = CodingAdventures::Ls00::DocumentManager->new();
+    $dm->open("file:///test.txt", "hello world", 1);
+
+    my ($doc, $found) = $dm->get("file:///test.txt");
+    ok($found, "document should be open");
+    is($doc->{text}, "hello world", "text matches");
+    is($doc->{version}, 1, "version is 1");
+};
+
+# ── Get missing document ────────────────────────────────────────────────────
+
+subtest "get missing" => sub {
+    my $dm = CodingAdventures::Ls00::DocumentManager->new();
+    my ($doc, $found) = $dm->get("file:///nonexistent.txt");
+    ok(!$found, "nonexistent document returns not found");
+};
+
+# ── Close ────────────────────────────────────────────────────────────────────
+
+subtest "close" => sub {
+    my $dm = CodingAdventures::Ls00::DocumentManager->new();
+    $dm->open("file:///test.txt", "hello", 1);
+    $dm->close("file:///test.txt");
+
+    my ($doc, $found) = $dm->get("file:///test.txt");
+    ok(!$found, "document should be gone after close");
+};
+
+# ── Full replacement ────────────────────────────────────────────────────────
+
+subtest "apply changes: full replacement" => sub {
+    my $dm = CodingAdventures::Ls00::DocumentManager->new();
+    $dm->open("file:///test.txt", "hello world", 1);
+
+    my $err = $dm->apply_changes("file:///test.txt", [
+        { range => undef, new_text => "goodbye world" },
+    ], 2);
+    ok(!$err, "no error on full replacement");
+
+    my ($doc, $found) = $dm->get("file:///test.txt");
+    is($doc->{text}, "goodbye world", "text replaced");
+    is($doc->{version}, 2, "version updated to 2");
+};
+
+# ── Incremental change ──────────────────────────────────────────────────────
+
+subtest "apply changes: incremental" => sub {
+    my $dm = CodingAdventures::Ls00::DocumentManager->new();
+    $dm->open("file:///test.txt", "hello world", 1);
+
+    my $err = $dm->apply_changes("file:///test.txt", [
+        {
+            range => {
+                start => { line => 0, character => 6 },
+                end   => { line => 0, character => 11 },
+            },
+            new_text => "Go",
+        },
+    ], 2);
+    ok(!$err, "no error on incremental change");
+
+    my ($doc, $found) = $dm->get("file:///test.txt");
+    is($doc->{text}, "hello Go", "incremental change applied");
+};
+
+# ── Not open error ──────────────────────────────────────────────────────────
+
+subtest "apply changes: not open" => sub {
+    my $dm = CodingAdventures::Ls00::DocumentManager->new();
+    my $err = $dm->apply_changes("file:///notopen.txt", [
+        { range => undef, new_text => "x" },
+    ], 1);
+    ok($err, "error for applying changes to non-open document");
+    like($err, qr/not open/, "error mentions not open");
+};
+
+# ── Incremental with emoji ──────────────────────────────────────────────────
+
+subtest "incremental with emoji" => sub {
+    my $dm = CodingAdventures::Ls00::DocumentManager->new();
+    $dm->open("file:///test.txt", "A\x{1F3B8}B", 1);
+
+    my $err = $dm->apply_changes("file:///test.txt", [
+        {
+            range => {
+                start => { line => 0, character => 3 },
+                end   => { line => 0, character => 4 },
+            },
+            new_text => "X",
+        },
+    ], 2);
+    ok(!$err, "no error on emoji incremental change");
+
+    my ($doc, $found) = $dm->get("file:///test.txt");
+    is($doc->{text}, "A\x{1F3B8}X", "emoji change applied correctly");
+};
+
+# ── Multiple incremental changes ────────────────────────────────────────────
+
+subtest "multiple incremental changes" => sub {
+    my $dm = CodingAdventures::Ls00::DocumentManager->new();
+    $dm->open("uri", "hello world", 1);
+
+    my $err = $dm->apply_changes("uri", [
+        {
+            range => {
+                start => { line => 0, character => 0 },
+                end   => { line => 0, character => 5 },
+            },
+            new_text => "hi",
+        },
+    ], 2);
+    ok(!$err, "first change applied");
+
+    my ($doc, $found) = $dm->get("uri");
+    is($doc->{text}, "hi world", "first change result correct");
+};
+
+done_testing();

--- a/code/packages/perl/ls00/t/03_parse_cache.t
+++ b/code/packages/perl/ls00/t/03_parse_cache.t
@@ -1,0 +1,102 @@
+#!/usr/bin/env perl
+
+# 03_parse_cache.t -- ParseCache hit/miss and eviction tests
+
+use strict;
+use warnings;
+use Test::More;
+
+use CodingAdventures::Ls00::ParseCache;
+
+# ── Mock Bridge ──────────────────────────────────────────────────────────────
+
+{
+    package MockBridge;
+
+    my $parse_count = 0;
+
+    sub new {
+        $parse_count = 0;
+        return bless {}, shift;
+    }
+
+    sub tokenize {
+        my ($self, $source) = @_;
+        return ([], undef);
+    }
+
+    sub parse {
+        my ($self, $source) = @_;
+        $parse_count++;
+        my @diags;
+        if ($source =~ /ERROR/) {
+            push @diags, {
+                range => {
+                    start => { line => 0, character => 0 },
+                    end   => { line => 0, character => 5 },
+                },
+                severity => 1,
+                message  => 'syntax error',
+            };
+        }
+        return ($source, \@diags, undef);
+    }
+
+    sub parse_count { return $parse_count }
+}
+
+# ── Cache hit and miss ──────────────────────────────────────────────────────
+
+subtest "cache hit and miss" => sub {
+    my $bridge = MockBridge->new();
+    my $cache = CodingAdventures::Ls00::ParseCache->new();
+
+    my $r1 = $cache->get_or_parse("file:///a.txt", 1, "hello", $bridge);
+    ok($r1, "non-nil result");
+    is(MockBridge::parse_count(), 1, "parse called once");
+
+    my $r2 = $cache->get_or_parse("file:///a.txt", 1, "hello", $bridge);
+    is($r1, $r2, "same reference on cache hit");
+    is(MockBridge::parse_count(), 1, "parse not called again");
+
+    my $r3 = $cache->get_or_parse("file:///a.txt", 2, "hello world", $bridge);
+    isnt($r3, $r1, "different result for new version");
+    is(MockBridge::parse_count(), 2, "parse called again for new version");
+};
+
+# ── Eviction ────────────────────────────────────────────────────────────────
+
+subtest "eviction" => sub {
+    my $bridge = MockBridge->new();
+    my $cache = CodingAdventures::Ls00::ParseCache->new();
+
+    my $r1 = $cache->get_or_parse("file:///a.txt", 1, "hello", $bridge);
+    is(MockBridge::parse_count(), 1, "initial parse");
+
+    $cache->evict("file:///a.txt");
+
+    my $r2 = $cache->get_or_parse("file:///a.txt", 1, "hello", $bridge);
+    isnt($r2, $r1, "new result after eviction");
+    is(MockBridge::parse_count(), 2, "parse called after eviction");
+};
+
+# ── Diagnostics populated ──────────────────────────────────────────────────
+
+subtest "diagnostics populated" => sub {
+    my $bridge = MockBridge->new();
+    my $cache = CodingAdventures::Ls00::ParseCache->new();
+
+    my $result = $cache->get_or_parse("file:///a.txt", 1, "source with ERROR token", $bridge);
+    ok(scalar @{$result->{diagnostics}} > 0, "diagnostics present for ERROR source");
+};
+
+subtest "empty diagnostics normalized" => sub {
+    my $bridge = MockBridge->new();
+    my $cache = CodingAdventures::Ls00::ParseCache->new();
+
+    my $result = $cache->get_or_parse("file:///a.txt", 1, "clean source", $bridge);
+    is(ref $result->{diagnostics}, 'ARRAY', "diagnostics is arrayref");
+    is(scalar @{$result->{diagnostics}}, 0, "no diagnostics for clean source");
+};
+
+done_testing();

--- a/code/packages/perl/ls00/t/04_capabilities.t
+++ b/code/packages/perl/ls00/t/04_capabilities.t
@@ -1,0 +1,120 @@
+#!/usr/bin/env perl
+
+# 04_capabilities.t -- Capabilities advertisement tests
+
+use strict;
+use warnings;
+use Test::More;
+
+use CodingAdventures::Ls00::Capabilities qw(:all);
+
+# ── Mock Bridges ─────────────────────────────────────────────────────────────
+
+{
+    package MinimalBridge;
+    sub new { bless {}, shift }
+    sub tokenize { return ([], undef) }
+    sub parse    { return ($_[1], [], undef) }
+}
+
+{
+    package FullBridge;
+    sub new { bless {}, shift }
+    sub tokenize        { return ([], undef) }
+    sub parse           { return ($_[1], [], undef) }
+    sub hover           { return (undef, undef) }
+    sub definition      { return (undef, undef) }
+    sub references      { return ([], undef) }
+    sub completion      { return ([], undef) }
+    sub rename          { return (undef, undef) }
+    sub document_symbols { return ([], undef) }
+    sub folding_ranges  { return ([], undef) }
+    sub signature_help  { return (undef, undef) }
+    sub format          { return ([], undef) }
+    sub semantic_tokens { return ([], undef) }
+}
+
+{
+    package HoverOnlyBridge;
+    sub new { bless {}, shift }
+    sub tokenize { return ([], undef) }
+    sub parse    { return ($_[1], [], undef) }
+    sub hover    { return (undef, undef) }
+    sub document_symbols { return ([], undef) }
+}
+
+# ── Minimal bridge capabilities ─────────────────────────────────────────────
+
+subtest "minimal bridge: only textDocumentSync" => sub {
+    my $caps = build_capabilities(MinimalBridge->new());
+
+    is($caps->{textDocumentSync}, 2, "textDocumentSync is 2 (incremental)");
+
+    my @optional = qw(
+        hoverProvider definitionProvider referencesProvider
+        completionProvider renameProvider documentSymbolProvider
+        foldingRangeProvider signatureHelpProvider
+        documentFormattingProvider semanticTokensProvider
+    );
+    for my $cap (@optional) {
+        ok(!exists $caps->{$cap}, "minimal bridge should not advertise $cap");
+    }
+};
+
+# ── Full bridge capabilities ────────────────────────────────────────────────
+
+subtest "full bridge: all capabilities present" => sub {
+    my $caps = build_capabilities(FullBridge->new());
+
+    is($caps->{textDocumentSync}, 2, "textDocumentSync is 2");
+    ok($caps->{hoverProvider}, "hoverProvider present");
+    ok($caps->{definitionProvider}, "definitionProvider present");
+    ok($caps->{referencesProvider}, "referencesProvider present");
+    is(ref $caps->{completionProvider}, 'HASH', "completionProvider is hashref");
+    ok($caps->{renameProvider}, "renameProvider present");
+    ok($caps->{documentSymbolProvider}, "documentSymbolProvider present");
+    ok($caps->{foldingRangeProvider}, "foldingRangeProvider present");
+    is(ref $caps->{signatureHelpProvider}, 'HASH', "signatureHelpProvider is hashref");
+    ok($caps->{documentFormattingProvider}, "documentFormattingProvider present");
+    is(ref $caps->{semanticTokensProvider}, 'HASH', "semanticTokensProvider is hashref");
+};
+
+# ── Selective capabilities ──────────────────────────────────────────────────
+
+subtest "hover-only bridge" => sub {
+    my $caps = build_capabilities(HoverOnlyBridge->new());
+
+    ok($caps->{hoverProvider}, "hoverProvider present");
+    ok($caps->{documentSymbolProvider}, "documentSymbolProvider present");
+    ok(!exists $caps->{definitionProvider}, "no definitionProvider");
+    ok(!exists $caps->{completionProvider}, "no completionProvider");
+};
+
+# ── Completion trigger characters ────────────────────────────────────────────
+
+subtest "completion trigger characters" => sub {
+    my $caps = build_capabilities(FullBridge->new());
+    my $cp = $caps->{completionProvider};
+    is(ref $cp->{triggerCharacters}, 'ARRAY', "triggerCharacters is arrayref");
+    ok(scalar @{$cp->{triggerCharacters}} > 0, "has trigger characters");
+};
+
+# ── Signature help trigger characters ────────────────────────────────────────
+
+subtest "signature help trigger characters" => sub {
+    my $caps = build_capabilities(FullBridge->new());
+    my $shp = $caps->{signatureHelpProvider};
+    is(ref $shp->{triggerCharacters}, 'ARRAY', "triggerCharacters is arrayref");
+};
+
+# ── Semantic tokens has legend ───────────────────────────────────────────────
+
+subtest "semantic tokens provider has legend" => sub {
+    my $caps = build_capabilities(FullBridge->new());
+    my $stp = $caps->{semanticTokensProvider};
+    is(ref $stp->{legend}, 'HASH', "legend present");
+    is(ref $stp->{legend}{tokenTypes}, 'ARRAY', "tokenTypes is arrayref");
+    is(ref $stp->{legend}{tokenModifiers}, 'ARRAY', "tokenModifiers is arrayref");
+};
+
+done_testing();

--- a/code/packages/perl/ls00/t/05_semantic_tokens.t
+++ b/code/packages/perl/ls00/t/05_semantic_tokens.t
@@ -1,0 +1,158 @@
+#!/usr/bin/env perl
+
+# 05_semantic_tokens.t -- Semantic token encoding tests
+
+use strict;
+use warnings;
+use Test::More;
+
+use CodingAdventures::Ls00::Capabilities qw(:all);
+
+# ── Empty input ──────────────────────────────────────────────────────────────
+
+subtest "empty tokens" => sub {
+    my $data = encode_semantic_tokens([]);
+    is(scalar @$data, 0, "empty data for empty tokens");
+};
+
+subtest "undef tokens" => sub {
+    my $data = encode_semantic_tokens(undef);
+    is(scalar @$data, 0, "empty data for undef");
+};
+
+# ── Single token ────────────────────────────────────────────────────────────
+
+subtest "single keyword token" => sub {
+    my $tokens = [
+        { line => 0, character => 0, length => 5, token_type => 'keyword', modifiers => [] },
+    ];
+    my $data = encode_semantic_tokens($tokens);
+
+    is(scalar @$data, 5, "5 ints for one token");
+    is($data->[0], 0,  "deltaLine = 0");
+    is($data->[1], 0,  "deltaChar = 0");
+    is($data->[2], 5,  "length = 5");
+    is($data->[3], 15, "tokenTypeIndex = 15 (keyword)");
+    is($data->[4], 0,  "modifiers = 0");
+};
+
+# ── Multiple tokens on same line ────────────────────────────────────────────
+
+subtest "two tokens same line" => sub {
+    my $tokens = [
+        { line => 0, character => 0, length => 3, token_type => 'keyword', modifiers => [] },
+        { line => 0, character => 4, length => 4, token_type => 'function', modifiers => ['declaration'] },
+    ];
+    my $data = encode_semantic_tokens($tokens);
+
+    is(scalar @$data, 10, "10 ints for 2 tokens");
+
+    is($data->[0], 0,  "A: deltaLine = 0");
+    is($data->[1], 0,  "A: deltaChar = 0");
+    is($data->[2], 3,  "A: length = 3");
+    is($data->[3], 15, "A: keyword = 15");
+    is($data->[4], 0,  "A: mods = 0");
+
+    is($data->[5], 0,  "B: deltaLine = 0 (same line)");
+    is($data->[6], 4,  "B: deltaChar = 4 (relative to A)");
+    is($data->[7], 4,  "B: length = 4");
+    is($data->[8], 12, "B: function = 12");
+    is($data->[9], 1,  "B: declaration = bit 0 = 1");
+};
+
+# ── Tokens on different lines ───────────────────────────────────────────────
+
+subtest "tokens on different lines" => sub {
+    my $tokens = [
+        { line => 0, character => 0, length => 3, token_type => 'keyword', modifiers => [] },
+        { line => 2, character => 4, length => 5, token_type => 'number', modifiers => [] },
+    ];
+    my $data = encode_semantic_tokens($tokens);
+
+    is(scalar @$data, 10, "10 ints for 2 tokens");
+    is($data->[5], 2,  "B: deltaLine = 2");
+    is($data->[6], 4,  "B: deltaChar = 4 (absolute on new line)");
+    is($data->[8], 19, "B: number = 19");
+};
+
+# ── Unsorted input ──────────────────────────────────────────────────────────
+
+subtest "unsorted input gets sorted" => sub {
+    my $tokens = [
+        { line => 1, character => 0, length => 2, token_type => 'number', modifiers => [] },
+        { line => 0, character => 0, length => 3, token_type => 'keyword', modifiers => [] },
+    ];
+    my $data = encode_semantic_tokens($tokens);
+
+    is(scalar @$data, 10, "10 ints for 2 tokens");
+    is($data->[3], 15, "first token is keyword (15)");
+    is($data->[8], 19, "second token is number (19)");
+};
+
+# ── Unknown token type skipped ──────────────────────────────────────────────
+
+subtest "unknown token type skipped" => sub {
+    my $tokens = [
+        { line => 0, character => 0, length => 3, token_type => 'unknownType', modifiers => [] },
+        { line => 0, character => 4, length => 2, token_type => 'keyword', modifiers => [] },
+    ];
+    my $data = encode_semantic_tokens($tokens);
+
+    is(scalar @$data, 5, "unknown type skipped, only 5 ints");
+};
+
+# ── Modifier bitmask ────────────────────────────────────────────────────────
+
+subtest "modifier bitmask: readonly" => sub {
+    my $tokens = [
+        { line => 0, character => 0, length => 3, token_type => 'variable', modifiers => ['readonly'] },
+    ];
+    my $data = encode_semantic_tokens($tokens);
+
+    is($data->[4], 4, "readonly = bit 2 = value 4");
+};
+
+subtest "modifier bitmask: multiple modifiers" => sub {
+    my $tokens = [
+        { line => 0, character => 0, length => 3, token_type => 'variable', modifiers => ['declaration', 'readonly'] },
+    ];
+    my $data = encode_semantic_tokens($tokens);
+
+    is($data->[4], 5, "declaration + readonly = 1 | 4 = 5");
+};
+
+# ── SemanticTokenLegend consistency ──────────────────────────────────────────
+
+subtest "legend has required types" => sub {
+    my $legend = semantic_token_legend();
+
+    ok(scalar @{$legend->{tokenTypes}} > 0, "non-empty tokenTypes");
+    ok(scalar @{$legend->{tokenModifiers}} > 0, "non-empty tokenModifiers");
+
+    my @required = qw(keyword string number variable function);
+    for my $rt (@required) {
+        my $found = grep { $_ eq $rt } @{$legend->{tokenTypes}};
+        ok($found, "legend contains '$rt'");
+    }
+};
+
+subtest "token_type_index for known types" => sub {
+    is(token_type_index('keyword'),  15, "keyword is at index 15");
+    is(token_type_index('function'), 12, "function is at index 12");
+    is(token_type_index('number'),   19, "number is at index 19");
+    is(token_type_index('variable'),  8, "variable is at index 8");
+};
+
+subtest "token_type_index for unknown type" => sub {
+    is(token_type_index('nonexistent'), -1, "unknown type returns -1");
+};
+
+subtest "token_modifier_mask" => sub {
+    is(token_modifier_mask([]),              0, "empty modifiers = 0");
+    is(token_modifier_mask(['declaration']), 1, "declaration = bit 0 = 1");
+    is(token_modifier_mask(['definition']),  2, "definition = bit 1 = 2");
+    is(token_modifier_mask(['readonly']),    4, "readonly = bit 2 = 4");
+    is(token_modifier_mask(['declaration', 'readonly']), 5, "declaration + readonly = 5");
+};
+
+done_testing();

--- a/code/packages/perl/ls00/t/06_server.t
+++ b/code/packages/perl/ls00/t/06_server.t
@@ -1,0 +1,315 @@
+#!/usr/bin/env perl
+
+# 06_server.t -- Server integration tests
+
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+
+use JSON::PP qw(encode_json decode_json);
+
+use CodingAdventures::Ls00::Server;
+use CodingAdventures::Ls00::Capabilities qw(build_capabilities);
+
+# ── TestBridge ───────────────────────────────────────────────────────────────
+
+{
+    package TestBridge;
+
+    sub new {
+        my ($class, %args) = @_;
+        return bless {
+            hover_result => $args{hover_result},
+        }, $class;
+    }
+
+    sub tokenize {
+        my ($self, $source) = @_;
+        my @tokens;
+        my $col = 1;
+        for my $word (split /\s+/, $source) {
+            push @tokens, {
+                type   => 'WORD',
+                value  => $word,
+                line   => 1,
+                column => $col,
+            };
+            $col += length($word) + 1;
+        }
+        return (\@tokens, undef);
+    }
+
+    sub parse {
+        my ($self, $source) = @_;
+        my @diags;
+        if ($source =~ /ERROR/) {
+            push @diags, {
+                range => {
+                    start => { line => 0, character => 0 },
+                    end   => { line => 0, character => 5 },
+                },
+                severity => 1,
+                message  => 'syntax error: unexpected ERROR token',
+            };
+        }
+        return ($source, \@diags, undef);
+    }
+
+    sub hover {
+        my ($self, $ast, $pos) = @_;
+        return ($self->{hover_result}, undef);
+    }
+
+    sub document_symbols {
+        my ($self, $ast) = @_;
+        return ([
+            {
+                name => 'main',
+                kind => 12,
+                range => {
+                    start => { line => 0, character => 0 },
+                    end   => { line => 10, character => 1 },
+                },
+                selection_range => {
+                    start => { line => 0, character => 9 },
+                    end   => { line => 0, character => 13 },
+                },
+                children => [
+                    {
+                        name => 'x',
+                        kind => 13,
+                        range => {
+                            start => { line => 1, character => 4 },
+                            end   => { line => 1, character => 12 },
+                        },
+                        selection_range => {
+                            start => { line => 1, character => 8 },
+                            end   => { line => 1, character => 9 },
+                        },
+                        children => [],
+                    },
+                ],
+            },
+        ], undef);
+    }
+}
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+sub make_message {
+    my ($obj) = @_;
+    my $json = encode_json($obj);
+    my $len  = length($json);
+    return "Content-Length: $len\r\n\r\n$json";
+}
+
+sub read_message_from_string {
+    my ($str_ref) = @_;
+    if ($$str_ref =~ s/^Content-Length:\s*(\d+)\r\n\r\n//s) {
+        my $len = $1;
+        my $payload = substr($$str_ref, 0, $len, '');
+        return decode_json($payload);
+    }
+    return undef;
+}
+
+# ── Capabilities Tests ──────────────────────────────────────────────────────
+
+subtest "build capabilities for test bridge" => sub {
+    my $bridge = TestBridge->new(
+        hover_result => { contents => '**main** function' },
+    );
+    my $caps = build_capabilities($bridge);
+
+    is($caps->{textDocumentSync}, 2, "textDocumentSync = 2");
+    ok($caps->{hoverProvider}, "hoverProvider advertised");
+    ok($caps->{documentSymbolProvider}, "documentSymbolProvider advertised");
+    ok(!exists $caps->{definitionProvider}, "no definitionProvider");
+    ok(!exists $caps->{referencesProvider}, "no referencesProvider");
+    ok(!exists $caps->{completionProvider}, "no completionProvider");
+    ok(!exists $caps->{renameProvider}, "no renameProvider");
+};
+
+# ── Initialize returns capabilities ─────────────────────────────────────────
+
+subtest "initialize returns capabilities" => sub {
+    my $bridge = TestBridge->new(
+        hover_result => { contents => '**main** function' },
+    );
+
+    my $input_str = make_message({
+        jsonrpc => '2.0',
+        id      => 1,
+        method  => 'initialize',
+        params  => {
+            processId    => 12345,
+            capabilities => {},
+        },
+    });
+
+    open my $in_fh,  '<', \$input_str  or die "Cannot open input: $!";
+    my $output_str = '';
+    open my $out_fh, '>', \$output_str or die "Cannot open output: $!";
+    binmode($in_fh, ':raw');
+    binmode($out_fh, ':raw');
+
+    my $server = CodingAdventures::Ls00::Server->new($bridge, $in_fh, $out_fh);
+    $server->serve();
+
+    my $resp = read_message_from_string(\$output_str);
+    ok($resp, "got a response");
+    is($resp->{id}, 1, "response id matches");
+
+    my $result = $resp->{result};
+    ok($result, "result present");
+    ok($result->{capabilities}, "capabilities present");
+    is($result->{capabilities}{textDocumentSync}, 2, "textDocumentSync = 2");
+    ok($result->{capabilities}{hoverProvider}, "hoverProvider in capabilities");
+    ok($result->{capabilities}{documentSymbolProvider}, "documentSymbolProvider in capabilities");
+
+    ok($result->{serverInfo}, "serverInfo present");
+    is($result->{serverInfo}{name}, 'ls00-generic-lsp-server', "server name correct");
+};
+
+# ── didOpen publishes diagnostics ────────────────────────────────────────────
+
+subtest "didOpen publishes diagnostics" => sub {
+    my $bridge = TestBridge->new();
+
+    my $input_str = '';
+    $input_str .= make_message({
+        jsonrpc => '2.0',
+        id      => 1,
+        method  => 'initialize',
+        params  => { processId => 1, capabilities => {} },
+    });
+    $input_str .= make_message({
+        jsonrpc => '2.0',
+        method  => 'initialized',
+        params  => {},
+    });
+    $input_str .= make_message({
+        jsonrpc => '2.0',
+        method  => 'textDocument/didOpen',
+        params  => {
+            textDocument => {
+                uri        => 'file:///test.txt',
+                languageId => 'test',
+                version    => 1,
+                text       => 'some ERROR here',
+            },
+        },
+    });
+
+    open my $in_fh,  '<', \$input_str  or die "Cannot open input: $!";
+    my $output_str = '';
+    open my $out_fh, '>', \$output_str or die "Cannot open output: $!";
+    binmode($in_fh, ':raw');
+    binmode($out_fh, ':raw');
+
+    my $server = CodingAdventures::Ls00::Server->new($bridge, $in_fh, $out_fh);
+    $server->serve();
+
+    my $resp1 = read_message_from_string(\$output_str);
+    ok($resp1, "got initialize response");
+    is($resp1->{id}, 1, "initialize response id = 1");
+
+    my $resp2 = read_message_from_string(\$output_str);
+    ok($resp2, "got diagnostics notification");
+    is($resp2->{method}, 'textDocument/publishDiagnostics', "method is publishDiagnostics");
+    my $diag_params = $resp2->{params};
+    is($diag_params->{uri}, 'file:///test.txt', "diagnostics for correct URI");
+    ok(scalar @{$diag_params->{diagnostics}} > 0, "diagnostics array non-empty");
+};
+
+# ── Clean source has empty diagnostics ───────────────────────────────────────
+
+subtest "didOpen with clean source has empty diagnostics" => sub {
+    my $bridge = TestBridge->new();
+
+    my $input_str = '';
+    $input_str .= make_message({
+        jsonrpc => '2.0',
+        id      => 1,
+        method  => 'initialize',
+        params  => { processId => 1, capabilities => {} },
+    });
+    $input_str .= make_message({
+        jsonrpc => '2.0',
+        method  => 'textDocument/didOpen',
+        params  => {
+            textDocument => {
+                uri     => 'file:///clean.txt',
+                version => 1,
+                text    => 'clean source code',
+            },
+        },
+    });
+
+    open my $in_fh,  '<', \$input_str  or die "Cannot open input: $!";
+    my $output_str = '';
+    open my $out_fh, '>', \$output_str or die "Cannot open output: $!";
+    binmode($in_fh, ':raw');
+    binmode($out_fh, ':raw');
+
+    my $server = CodingAdventures::Ls00::Server->new($bridge, $in_fh, $out_fh);
+    $server->serve();
+
+    my $resp1 = read_message_from_string(\$output_str);
+    my $resp2 = read_message_from_string(\$output_str);
+    ok($resp2, "got diagnostics notification");
+    is(scalar @{$resp2->{params}{diagnostics}}, 0, "no diagnostics for clean source");
+};
+
+# ── Shutdown request ─────────────────────────────────────────────────────────
+
+subtest "shutdown returns null" => sub {
+    my $bridge = TestBridge->new();
+
+    my $input_str = '';
+    $input_str .= make_message({
+        jsonrpc => '2.0',
+        id      => 1,
+        method  => 'initialize',
+        params  => { processId => 1, capabilities => {} },
+    });
+    $input_str .= make_message({
+        jsonrpc => '2.0',
+        id      => 2,
+        method  => 'shutdown',
+    });
+
+    open my $in_fh,  '<', \$input_str  or die "Cannot open input: $!";
+    my $output_str = '';
+    open my $out_fh, '>', \$output_str or die "Cannot open output: $!";
+    binmode($in_fh, ':raw');
+    binmode($out_fh, ':raw');
+
+    my $server = CodingAdventures::Ls00::Server->new($bridge, $in_fh, $out_fh);
+    $server->serve();
+
+    my $resp1 = read_message_from_string(\$output_str);
+    my $resp2 = read_message_from_string(\$output_str);
+    ok($resp2, "got shutdown response");
+    is($resp2->{id}, 2, "shutdown response id = 2");
+};
+
+# ── Minimal bridge capabilities ──────────────────────────────────────────────
+
+{
+    package MinBridge;
+    sub new { bless {}, shift }
+    sub tokenize { return ([], undef) }
+    sub parse    { return ($_[1], [], undef) }
+}
+
+subtest "minimal bridge capabilities" => sub {
+    my $caps = build_capabilities(MinBridge->new());
+
+    is($caps->{textDocumentSync}, 2, "textDocumentSync present");
+    ok(!exists $caps->{hoverProvider}, "no hoverProvider");
+    ok(!exists $caps->{definitionProvider}, "no definitionProvider");
+};
+
+done_testing();

--- a/code/packages/python/ls00/BUILD
+++ b/code/packages/python/ls00/BUILD
@@ -1,3 +1,3 @@
 uv venv -q .venv
-uv pip install -q -e ../json-rpc -e ".[dev]"
+uv pip install -q -e ../json-rpc -e .[dev]
 .venv/bin/python -m pytest tests/ -v --tb=short --cov=ls00 --cov-report=term-missing

--- a/code/packages/python/ls00/BUILD
+++ b/code/packages/python/ls00/BUILD
@@ -1,0 +1,1 @@
+cd ../json-rpc && uv venv -q .venv && uv pip install -q -e ".[dev]" && cd ../ls00 && uv venv -q .venv && uv pip install -q -e ".[dev]" && uv pip install -q -e ../json-rpc && .venv/Scripts/python -m pytest tests/ -v --tb=short --cov=ls00 --cov-report=term-missing

--- a/code/packages/python/ls00/BUILD
+++ b/code/packages/python/ls00/BUILD
@@ -1,1 +1,3 @@
-cd ../json-rpc && uv venv -q .venv && uv pip install -q -e ".[dev]" && cd ../ls00 && uv venv -q .venv && uv pip install -q -e ".[dev]" && uv pip install -q -e ../json-rpc && .venv/Scripts/python -m pytest tests/ -v --tb=short --cov=ls00 --cov-report=term-missing
+uv venv -q .venv
+uv pip install -q -e ../json-rpc -e ".[dev]"
+.venv/Scripts/python -m pytest tests/ -v --tb=short --cov=ls00 --cov-report=term-missing

--- a/code/packages/python/ls00/BUILD
+++ b/code/packages/python/ls00/BUILD
@@ -1,3 +1,3 @@
 uv venv -q .venv
 uv pip install -q -e ../json-rpc -e ".[dev]"
-.venv/Scripts/python -m pytest tests/ -v --tb=short --cov=ls00 --cov-report=term-missing
+.venv/bin/python -m pytest tests/ -v --tb=short --cov=ls00 --cov-report=term-missing

--- a/code/packages/python/ls00/BUILD_windows
+++ b/code/packages/python/ls00/BUILD_windows
@@ -1,0 +1,4 @@
+uv venv -q .venv
+uv pip install -q --no-deps -e ../json-rpc -e .
+uv pip install -q pytest pytest-cov ruff mypy
+uv run --no-project python -m pytest tests/ -v --tb=short --cov=ls00 --cov-report=term-missing

--- a/code/packages/python/ls00/CHANGELOG.md
+++ b/code/packages/python/ls00/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2026-04-12
+
+### Added
+
+- Initial release of the Python ls00 LSP framework
+- Port of Go implementation at `code/packages/go/ls00/`
+- `LanguageBridge` protocol with `tokenize()` and `parse()` as required methods
+- 10 optional provider protocols using `@runtime_checkable`:
+  - `HoverProvider` -- hover tooltips
+  - `DefinitionProvider` -- Go to Definition (F12)
+  - `ReferencesProvider` -- Find All References
+  - `CompletionProvider` -- autocomplete suggestions
+  - `RenameProvider` -- symbol rename (F2)
+  - `SemanticTokensProvider` -- semantic syntax highlighting
+  - `DocumentSymbolsProvider` -- document outline panel
+  - `FoldingRangesProvider` -- code folding
+  - `SignatureHelpProvider` -- function signature hints
+  - `FormatProvider` -- document formatting
+- `DocumentManager` with UTF-16 offset conversion for LSP compatibility
+- `ParseCache` with `(uri, version)` keyed caching
+- Dynamic capability advertisement via `isinstance()` checks
+- Semantic token encoding in LSP's compact delta format
+- Full LSP lifecycle: initialize -> didOpen -> features -> shutdown -> exit
+- All LSP types as Python dataclasses with full type annotations
+- LSP-specific error codes (ServerNotInitialized, RequestFailed, etc.)
+- Comprehensive test suite with 40+ tests covering:
+  - UTF-16 offset conversion (10 test cases including emoji, CJK, BMP)
+  - DocumentManager lifecycle (7 tests)
+  - ParseCache hit/miss behavior (5 tests)
+  - Capability advertisement (7 tests)
+  - Semantic token encoding (7 tests)
+  - Full JSON-RPC round-trip handler tests (15+ tests)

--- a/code/packages/python/ls00/README.md
+++ b/code/packages/python/ls00/README.md
@@ -1,0 +1,106 @@
+# ls00 — Generic LSP Framework (Python)
+
+A generic Language Server Protocol (LSP) framework that language-specific "bridges" plug into. This is the Python port of the Go implementation at `code/packages/go/ls00/`.
+
+## What is LSP?
+
+When you open a source file in VS Code and see red squiggles under syntax errors, autocomplete suggestions, or "Go to Definition" -- none of that is built into the editor. It comes from a *language server*: a separate process that communicates with the editor over the Language Server Protocol.
+
+LSP solves the M x N problem: M editors x N languages = M x N integrations. With LSP, each language writes one server, and every LSP-aware editor gets all features automatically.
+
+## Architecture
+
+```
+Lexer -> Parser -> [LanguageBridge] -> [LspServer] -> VS Code / Neovim / Emacs
+```
+
+This package is the *generic* half -- it handles all the protocol boilerplate. A language author only writes the `LanguageBridge` that connects their lexer/parser to this framework.
+
+## How It Works
+
+The framework uses Python's `typing.Protocol` with `@runtime_checkable` to implement capability detection. A bridge class simply defines the methods it supports -- no explicit registration needed.
+
+### Required Interface
+
+Every bridge must implement `tokenize()` and `parse()`:
+
+```python
+class MyBridge:
+    def tokenize(self, source: str) -> list[Token]:
+        # Your lexer here
+        return []
+
+    def parse(self, source: str) -> tuple[Any, list[Diagnostic]]:
+        # Your parser here
+        return (ast, diagnostics)
+```
+
+### Optional Features
+
+Add more methods to enable more LSP features:
+
+```python
+class MyBridge:
+    # ... required methods ...
+
+    def hover(self, ast, pos):
+        """Enables hover tooltips."""
+        return HoverResult(contents="**int** variable")
+
+    def definition(self, ast, pos, uri):
+        """Enables Go to Definition (F12)."""
+        return Location(uri=uri, range=decl_range)
+
+    def completion(self, ast, pos):
+        """Enables autocomplete."""
+        return [CompletionItem(label="myVar")]
+```
+
+The server automatically detects which protocols the bridge implements and advertises only those capabilities to the editor.
+
+## Quick Start
+
+```python
+import sys
+from ls00 import LspServer, Token, Diagnostic
+
+class MyBridge:
+    def tokenize(self, source):
+        return []
+
+    def parse(self, source):
+        return (None, [])
+
+server = LspServer(MyBridge(), sys.stdin.buffer, sys.stdout.buffer)
+server.serve()  # blocks until editor disconnects
+```
+
+## Dependencies
+
+- Python >= 3.11
+- `json-rpc` (internal package at `../json-rpc`)
+- No external dependencies (stdlib only)
+
+## Package Structure
+
+```
+src/ls00/
+  __init__.py          # Public API exports
+  types.py             # All LSP types as dataclasses
+  language_bridge.py   # Protocol classes for bridge + optional providers
+  document_manager.py  # Document tracking + UTF-16 conversion
+  parse_cache.py       # (uri, version)-keyed parse result cache
+  capabilities.py      # Dynamic capability building + semantic token encoding
+  lsp_errors.py        # LSP-specific error code constants
+  server.py            # LspServer coordinator class
+  handlers.py          # All LSP request/notification handlers
+```
+
+## Testing
+
+```bash
+cd code/packages/python/ls00
+uv venv .venv
+uv pip install -e ".[dev]"
+python -m pytest tests/ -v --cov=ls00
+```

--- a/code/packages/python/ls00/pyproject.toml
+++ b/code/packages/python/ls00/pyproject.toml
@@ -1,0 +1,60 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-ls00"
+version = "0.1.0"
+description = "Generic Language Server Protocol (LSP) framework"
+requires-python = ">=3.11"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["lsp", "language-server", "protocol", "editor", "computer-science", "education"]
+dependencies = []
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Education",
+    "Topic :: Education",
+    "Topic :: Scientific/Engineering",
+    "Programming Language :: Python :: 3.11",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://github.com/adhithyan15/coding-adventures"
+Repository = "https://github.com/adhithyan15/coding-adventures"
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0", "pytest-cov>=4.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/ls00"]
+
+[tool.ruff]
+target-version = "py311"
+line-length = 88
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort (import sorting)
+    "UP",   # pyupgrade (modern Python syntax)
+    "B",    # bugbear (common bugs)
+    "SIM",  # simplify
+    "ANN",  # type annotation enforcement
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=ls00 --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.run]
+source = ["src/ls00"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/packages/python/ls00/pyproject.toml
+++ b/code/packages/python/ls00/pyproject.toml
@@ -11,7 +11,7 @@ license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]
 readme = "README.md"
 keywords = ["lsp", "language-server", "protocol", "editor", "computer-science", "education"]
-dependencies = []
+dependencies = ["coding-adventures-json-rpc"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Education",

--- a/code/packages/python/ls00/src/ls00/__init__.py
+++ b/code/packages/python/ls00/src/ls00/__init__.py
@@ -1,0 +1,151 @@
+"""ls00 — Generic Language Server Protocol (LSP) framework.
+
+This package implements a generic LSP server framework that language-specific
+"bridges" plug into. The framework handles all protocol boilerplate:
+JSON-RPC transport, document synchronization, parse caching, and capability
+advertisement. A language author only writes the LanguageBridge that connects
+their lexer/parser to this framework.
+
+Architecture
+------------
+
+::
+
+    Lexer -> Parser -> [LanguageBridge] -> [LspServer] -> VS Code / Neovim / Emacs
+
+How to use this package
+------------------------
+
+1. Implement the ``LanguageBridge`` protocol (and any optional provider
+   protocols) for your language.
+2. Call ``LspServer(bridge, sys.stdin.buffer, sys.stdout.buffer)``.
+3. Call ``server.serve()`` -- it blocks until the editor closes the connection.
+
+Quick start
+-----------
+
+::
+
+    import sys
+    from ls00 import LspServer
+
+    class MyBridge:
+        def tokenize(self, source):
+            return []  # your lexer here
+
+        def parse(self, source):
+            return (None, [])  # your parser here
+
+    server = LspServer(MyBridge(), sys.stdin.buffer, sys.stdout.buffer)
+    server.serve()
+"""
+
+from ls00.capabilities import (
+    build_capabilities,
+    encode_semantic_tokens,
+    semantic_token_legend,
+)
+from ls00.document_manager import (
+    Document,
+    DocumentManager,
+    TextChange,
+    convert_utf16_offset_to_byte_offset,
+)
+from ls00.language_bridge import (
+    CompletionProvider,
+    DefinitionProvider,
+    DocumentSymbolsProvider,
+    FoldingRangesProvider,
+    FormatProvider,
+    HoverProvider,
+    LanguageBridge,
+    ReferencesProvider,
+    RenameProvider,
+    SemanticTokensProvider,
+    SignatureHelpProvider,
+)
+from ls00.lsp_errors import (
+    CONTENT_MODIFIED,
+    REQUEST_CANCELLED,
+    REQUEST_FAILED,
+    SERVER_CANCELLED,
+    SERVER_NOT_INITIALIZED,
+    UNKNOWN_ERROR_CODE,
+)
+from ls00.parse_cache import ParseCache, ParseResult
+from ls00.server import LspServer
+from ls00.types import (
+    CompletionItem,
+    CompletionItemKind,
+    Diagnostic,
+    DiagnosticSeverity,
+    DocumentSymbol,
+    FoldingRange,
+    HoverResult,
+    Location,
+    ParameterInformation,
+    Position,
+    Range,
+    SemanticToken,
+    SignatureHelpResult,
+    SignatureInformation,
+    SymbolKind,
+    TextEdit,
+    Token,
+    WorkspaceEdit,
+)
+
+__all__ = [
+    # Server
+    "LspServer",
+    # Bridge protocols
+    "LanguageBridge",
+    "HoverProvider",
+    "DefinitionProvider",
+    "ReferencesProvider",
+    "CompletionProvider",
+    "RenameProvider",
+    "SemanticTokensProvider",
+    "DocumentSymbolsProvider",
+    "FoldingRangesProvider",
+    "SignatureHelpProvider",
+    "FormatProvider",
+    # Types
+    "Position",
+    "Range",
+    "Location",
+    "DiagnosticSeverity",
+    "Diagnostic",
+    "Token",
+    "TextEdit",
+    "WorkspaceEdit",
+    "HoverResult",
+    "CompletionItemKind",
+    "CompletionItem",
+    "SemanticToken",
+    "SymbolKind",
+    "DocumentSymbol",
+    "FoldingRange",
+    "ParameterInformation",
+    "SignatureInformation",
+    "SignatureHelpResult",
+    # Document management
+    "Document",
+    "DocumentManager",
+    "TextChange",
+    "convert_utf16_offset_to_byte_offset",
+    # Parse cache
+    "ParseCache",
+    "ParseResult",
+    # Capabilities
+    "build_capabilities",
+    "encode_semantic_tokens",
+    "semantic_token_legend",
+    # Error codes
+    "SERVER_NOT_INITIALIZED",
+    "UNKNOWN_ERROR_CODE",
+    "REQUEST_FAILED",
+    "SERVER_CANCELLED",
+    "CONTENT_MODIFIED",
+    "REQUEST_CANCELLED",
+]

--- a/code/packages/python/ls00/src/ls00/capabilities.py
+++ b/code/packages/python/ls00/src/ls00/capabilities.py
@@ -1,0 +1,275 @@
+"""Capabilities, SemanticTokenLegend, and encode_semantic_tokens.
+
+What Are Capabilities?
+-----------------------
+
+During the LSP initialize handshake, the server sends back a "capabilities"
+object telling the editor which LSP features it supports. The editor uses
+this to decide which requests to send. If a capability is absent, the editor
+won't send the corresponding requests -- so no "Go to Definition" button
+appears unless ``definitionProvider`` is true.
+
+Building capabilities dynamically (based on the bridge's protocol
+implementations) means the server is always honest about what it can do.
+
+Semantic Token Legend
+-----------------------
+
+Semantic tokens use a compact binary encoding. Instead of sending
+``{"type":"keyword"}`` per token, LSP sends an integer index into a legend.
+The legend must be declared in the capabilities so the editor knows what
+each index means.
+
+Example legend::
+
+    tokenTypes:     ["namespace","type","class","enum",...,"keyword","string","number",...]
+    tokenModifiers: ["declaration","definition","readonly","static",...]
+
+A token with type index 14 and modifiers bitmask 0b0001 means:
+    type = tokenTypes[14] = "keyword", modifiers = [tokenModifiers[0]] = ["declaration"]
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ls00.language_bridge import (
+    CompletionProvider,
+    DefinitionProvider,
+    DocumentSymbolsProvider,
+    FoldingRangesProvider,
+    FormatProvider,
+    HoverProvider,
+    LanguageBridge,
+    ReferencesProvider,
+    RenameProvider,
+    SemanticTokensProvider,
+    SignatureHelpProvider,
+)
+from ls00.types import SemanticToken
+
+
+def build_capabilities(bridge: LanguageBridge) -> dict[str, Any]:
+    """Inspect the bridge at runtime and return the LSP capabilities object.
+
+    Uses ``isinstance()`` with ``@runtime_checkable`` Protocol classes to
+    check which optional provider protocols the bridge implements. Only
+    advertises capabilities for features the bridge actually supports.
+
+    This mirrors Go's type assertion pattern: ``if _, ok := bridge.(HoverProvider); ok``
+    """
+    # textDocumentSync=2 means "incremental": the editor sends only changed
+    # ranges, not the full file, on every keystroke. We always advertise this.
+    caps: dict[str, Any] = {
+        "textDocumentSync": 2,
+    }
+
+    # Check each optional provider via isinstance().
+    # Python's @runtime_checkable Protocol + isinstance() is equivalent to
+    # Go's type assertion: bridge.(HoverProvider)
+
+    if isinstance(bridge, HoverProvider):
+        caps["hoverProvider"] = True
+
+    if isinstance(bridge, DefinitionProvider):
+        caps["definitionProvider"] = True
+
+    if isinstance(bridge, ReferencesProvider):
+        caps["referencesProvider"] = True
+
+    if isinstance(bridge, CompletionProvider):
+        # completionProvider is an object, not a boolean, because it can
+        # include triggerCharacters.
+        caps["completionProvider"] = {
+            "triggerCharacters": [" ", "."],
+        }
+
+    if isinstance(bridge, RenameProvider):
+        caps["renameProvider"] = True
+
+    if isinstance(bridge, DocumentSymbolsProvider):
+        caps["documentSymbolProvider"] = True
+
+    if isinstance(bridge, FoldingRangesProvider):
+        caps["foldingRangeProvider"] = True
+
+    if isinstance(bridge, SignatureHelpProvider):
+        caps["signatureHelpProvider"] = {
+            "triggerCharacters": ["(", ","],
+        }
+
+    if isinstance(bridge, FormatProvider):
+        caps["documentFormattingProvider"] = True
+
+    if isinstance(bridge, SemanticTokensProvider):
+        caps["semanticTokensProvider"] = {
+            "legend": semantic_token_legend(),
+            "full": True,
+        }
+
+    return caps
+
+
+# ---------------------------------------------------------------------------
+# Semantic Token Legend
+# ---------------------------------------------------------------------------
+
+
+def semantic_token_legend() -> dict[str, list[str]]:
+    """Return the full legend for all supported semantic token types and modifiers.
+
+    Why a Fixed Legend?
+    ~~~~~~~~~~~~~~~~~~~~
+
+    The legend is sent once in the capabilities response. Afterwards, each
+    semantic token is encoded as an integer index into this legend rather
+    than a string. This makes the per-token encoding much smaller.
+
+    The ordering matters: index 0 in ``tokenTypes`` corresponds to
+    ``"namespace"``, index 1 to ``"type"``, etc. These match the standard
+    LSP token types.
+    """
+    return {
+        # Standard LSP token types (in the order VS Code expects them).
+        "tokenTypes": [
+            "namespace",      # 0
+            "type",           # 1
+            "class",          # 2
+            "enum",           # 3
+            "interface",      # 4
+            "struct",         # 5
+            "typeParameter",  # 6
+            "parameter",      # 7
+            "variable",       # 8
+            "property",       # 9
+            "enumMember",     # 10
+            "event",          # 11
+            "function",       # 12
+            "method",         # 13
+            "macro",          # 14
+            "keyword",        # 15
+            "modifier",       # 16
+            "comment",        # 17
+            "string",         # 18
+            "number",         # 19
+            "regexp",         # 20
+            "operator",       # 21
+            "decorator",      # 22
+        ],
+        # Standard LSP token modifiers (bitmask flags).
+        "tokenModifiers": [
+            "declaration",    # bit 0
+            "definition",     # bit 1
+            "readonly",       # bit 2
+            "static",         # bit 3
+            "deprecated",     # bit 4
+            "abstract",       # bit 5
+            "async",          # bit 6
+            "modification",   # bit 7
+            "documentation",  # bit 8
+            "defaultLibrary", # bit 9
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Semantic Token Encoding
+# ---------------------------------------------------------------------------
+
+
+def _token_type_index(token_type: str) -> int:
+    """Return the integer index for a semantic token type string.
+
+    Returns -1 if the type is not in the legend (the caller should skip
+    such tokens).
+    """
+    legend = semantic_token_legend()
+    try:
+        return legend["tokenTypes"].index(token_type)
+    except ValueError:
+        return -1
+
+
+def _token_modifier_mask(modifiers: list[str]) -> int:
+    """Return the bitmask for a list of modifier strings.
+
+    The LSP semantic tokens encoding represents modifiers as a bitmask:
+    - ``"declaration"`` -> bit 0 -> value 1
+    - ``"definition"`` -> bit 1 -> value 2
+    - both -> value 3 (bitwise OR)
+
+    Unknown modifiers are silently ignored.
+    """
+    legend = semantic_token_legend()
+    modifier_list = legend["tokenModifiers"]
+    mask = 0
+    for mod in modifiers:
+        if mod in modifier_list:
+            mask |= (1 << modifier_list.index(mod))
+    return mask
+
+
+def encode_semantic_tokens(tokens: list[SemanticToken]) -> list[int]:
+    """Convert a list of SemanticToken values to the LSP compact integer encoding.
+
+    The LSP Semantic Token Encoding
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    LSP encodes semantic tokens as a flat array of integers, grouped in
+    5-tuples::
+
+        [deltaLine, deltaStartChar, length, tokenTypeIndex, tokenModifierBitmask, ...]
+
+    Where "delta" means: the difference from the PREVIOUS token's position.
+    This delta encoding makes most values small (often 0 or 1), which
+    compresses well and is efficient to parse.
+
+    Example: three tokens on different lines::
+
+        Token A: line=0, char=0, len=3, type="keyword",  modifiers=[]
+        Token B: line=0, char=4, len=5, type="function", modifiers=["declaration"]
+        Token C: line=1, char=0, len=8, type="variable", modifiers=[]
+
+    Encoded as::
+
+        [0, 0, 3, 15, 0,   # A: deltaLine=0, deltaChar=0 (first token)
+         0, 4, 5, 12, 1,   # B: deltaLine=0, deltaChar=4 (same line)
+         1, 0, 8,  8, 0]   # C: deltaLine=1, deltaChar=0 (next line)
+
+    Note: when deltaLine > 0, deltaStartChar is relative to column 0 of the
+    new line (i.e., absolute for that line). When deltaLine == 0, deltaStartChar
+    is relative to the previous token's start character.
+    """
+    if not tokens:
+        return []
+
+    # Sort by (line, character) ascending. The delta encoding requires
+    # tokens to be in document order.
+    sorted_tokens = sorted(tokens, key=lambda t: (t.line, t.character))
+
+    data: list[int] = []
+    prev_line = 0
+    prev_char = 0
+
+    for tok in sorted_tokens:
+        type_idx = _token_type_index(tok.token_type)
+        if type_idx == -1:
+            # Unknown token type -- skip it.
+            continue
+
+        delta_line = tok.line - prev_line
+        if delta_line == 0:
+            # Same line: character offset is relative to previous token.
+            delta_char = tok.character - prev_char
+        else:
+            # Different line: character offset is absolute.
+            delta_char = tok.character
+
+        mod_mask = _token_modifier_mask(tok.modifiers)
+
+        data.extend([delta_line, delta_char, tok.length, type_idx, mod_mask])
+
+        prev_line = tok.line
+        prev_char = tok.character
+
+    return data

--- a/code/packages/python/ls00/src/ls00/document_manager.py
+++ b/code/packages/python/ls00/src/ls00/document_manager.py
@@ -1,0 +1,262 @@
+"""DocumentManager and UTF-16 offset handling.
+
+The Document Manager's Job
+----------------------------
+
+When the user opens a file in VS Code, the editor sends a
+``textDocument/didOpen`` notification with the full file content. From that
+point on, the editor does NOT re-send the entire file on every keystroke.
+Instead, it sends incremental changes: what changed, and where. The
+DocumentManager applies these changes to maintain the current text of each
+open file.
+
+::
+
+    Editor opens file:   didOpen   -> DocumentManager stores text at version 1
+    User types "X":      didChange -> DocumentManager applies delta -> version 2
+    User saves:          didSave   -> (optional: trigger format)
+    User closes:         didClose  -> DocumentManager removes entry
+
+Why Version Numbers?
+---------------------
+
+The editor increments the version number with every change. The ParseCache
+uses ``(uri, version)`` as its cache key -- if the version matches, the
+cached parse result is still valid.
+
+UTF-16: The Tricky Part
+--------------------------
+
+LSP specifies that character offsets are measured in UTF-16 CODE UNITS.
+This is a historical accident: VS Code is built on TypeScript, which uses
+UTF-16 strings internally (like Java and C#).
+
+Python strings are sequences of Unicode codepoints (internally UCS-2 or
+UCS-4 depending on build). A single Unicode codepoint can occupy:
+
+- 1 byte in UTF-8 (ASCII, e.g. 'A')
+- 2 bytes in UTF-8 (e.g. 'e-accent', U+00E9)
+- 3 bytes in UTF-8 (e.g. 'zhong', U+4E2D)
+- 4 bytes in UTF-8 (e.g. guitar emoji, U+1F3B8)
+
+In UTF-16:
+- Codepoints in the Basic Multilingual Plane (U+0000-U+FFFF) -> 1 code unit
+- Codepoints above U+FFFF (emojis, rare CJK) -> 2 code units (a "surrogate pair")
+
+The guitar emoji (U+1F3B8) is above U+FFFF:
+  UTF-8:  4 bytes  (0xF0 0x9F 0x8E 0xB8)
+  UTF-16: 2 code units (surrogate pair: 0xD83C 0xDFB8)
+
+So if the LSP client says character=8 (UTF-16), we cannot simply index 8
+characters into the Python string. We must walk codepoints, converting each
+to its UTF-16 length, accumulating until we reach code unit 8.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ls00.types import Position, Range
+
+
+# ---------------------------------------------------------------------------
+# Document — a single open file
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Document:
+    """Represents an open file tracked by the DocumentManager.
+
+    Attributes:
+        uri: The file URI (e.g. ``"file:///home/user/main.py"``).
+        text: Current content, as a Python string.
+        version: Monotonically increasing; matches LSP's document version.
+    """
+
+    uri: str
+    text: str
+    version: int
+
+
+# ---------------------------------------------------------------------------
+# TextChange — one incremental change to a document
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TextChange:
+    """Describes one incremental change to a document.
+
+    If ``range`` is ``None``, ``new_text`` replaces the ENTIRE document
+    content (full sync). If ``range`` is set, ``new_text`` replaces just
+    the specified range (incremental sync).
+
+    The LSP ``textDocumentSync`` capability controls which mode the editor uses:
+    - ``textDocumentSync=1`` -> full sync (range is always None)
+    - ``textDocumentSync=2`` -> incremental sync (range specifies what changed)
+
+    We advertise ``textDocumentSync=2`` (incremental) but handle both modes.
+    """
+
+    range: Range | None
+    new_text: str
+
+
+# ---------------------------------------------------------------------------
+# DocumentManager — tracks all open files
+# ---------------------------------------------------------------------------
+
+
+class DocumentManager:
+    """Tracks all files currently open in the editor.
+
+    The editor sends open/change/close notifications; this manager keeps the
+    authoritative current text of each file. The ParseCache and all feature
+    handlers read from this manager to get the source text.
+    """
+
+    def __init__(self) -> None:
+        self._docs: dict[str, Document] = {}
+
+    def open(self, uri: str, text: str, version: int) -> None:
+        """Record a newly opened file.
+
+        Called when the editor sends ``textDocument/didOpen``. Stores the
+        initial text and version number (typically 1 for a freshly opened file).
+        """
+        self._docs[uri] = Document(uri=uri, text=text, version=version)
+
+    def apply_changes(
+        self, uri: str, changes: list[TextChange], version: int
+    ) -> None:
+        """Apply a list of incremental changes to an open document.
+
+        Changes are applied in order. If a range is ``None``, the change
+        replaces the entire document. After all changes, the document's
+        version is updated.
+
+        Raises:
+            KeyError: If the document is not open.
+        """
+        doc = self._docs.get(uri)
+        if doc is None:
+            raise KeyError(f"document not open: {uri}")
+
+        for change in changes:
+            if change.range is None:
+                # Full document replacement -- simplest case.
+                doc.text = change.new_text
+            else:
+                # Incremental update: splice new text at the specified range.
+                doc.text = _apply_range_change(
+                    doc.text, change.range, change.new_text
+                )
+
+        doc.version = version
+
+    def get(self, uri: str) -> Document | None:
+        """Return the document for a URI, or None if not open."""
+        return self._docs.get(uri)
+
+    def close(self, uri: str) -> None:
+        """Remove a document from the manager.
+
+        Called when the editor sends ``textDocument/didClose``. After this,
+        the document's text is no longer tracked.
+        """
+        self._docs.pop(uri, None)
+
+
+# ---------------------------------------------------------------------------
+# Range application — splicing text at an LSP range
+# ---------------------------------------------------------------------------
+
+
+def _apply_range_change(text: str, r: Range, new_text: str) -> str:
+    """Splice ``new_text`` into ``text`` at the given LSP range.
+
+    Converts LSP's (line, UTF-16-character) coordinates to Python string
+    indices, then performs the splice.
+    """
+    start_idx = _convert_position_to_index(text, r.start)
+    end_idx = _convert_position_to_index(text, r.end)
+
+    if start_idx > end_idx:
+        start_idx, end_idx = end_idx, start_idx
+    if end_idx > len(text):
+        end_idx = len(text)
+
+    return text[:start_idx] + new_text + text[end_idx:]
+
+
+def _convert_position_to_index(text: str, pos: Position) -> int:
+    """Convert an LSP Position (0-based line, UTF-16 char) to a Python string index.
+
+    Algorithm:
+    1. Walk line-by-line to find the start of the target line.
+    2. From that offset, walk codepoints, converting each to its UTF-16
+       length, until we reach the target UTF-16 character offset.
+    """
+    # Phase 1: find the string index of the start of pos.line.
+    line_start = 0
+    current_line = 0
+
+    while current_line < pos.line:
+        idx = text.find("\n", line_start)
+        if idx == -1:
+            # Line number exceeds the number of lines. Clamp to end.
+            return len(text)
+        line_start = idx + 1
+        current_line += 1
+
+    # Phase 2: from line_start, advance pos.character UTF-16 code units.
+    char_idx = line_start
+    utf16_units = 0
+
+    while utf16_units < pos.character and char_idx < len(text):
+        ch = text[char_idx]
+        if ch == "\n":
+            # Don't advance past the newline.
+            break
+
+        # How many UTF-16 code units does this codepoint occupy?
+        cp = ord(ch)
+        utf16_len = 2 if cp > 0xFFFF else 1
+
+        if utf16_units + utf16_len > pos.character:
+            # This codepoint would overshoot the target character.
+            break
+
+        char_idx += 1
+        utf16_units += utf16_len
+
+    return char_idx
+
+
+def convert_utf16_offset_to_byte_offset(text: str, line: int, char: int) -> int:
+    """Convert a 0-based (line, UTF-16 char) position to a byte offset in UTF-8.
+
+    This is the exported version for use in tests and external packages.
+
+    Why UTF-16?
+    ~~~~~~~~~~~~
+
+    LSP character offsets are UTF-16 code units because VS Code's internal
+    string representation is UTF-16 (as is JavaScript's String type). This
+    function bridges the gap to Python's strings and UTF-8 encoded bytes.
+
+    Example::
+
+        text = "hello guitar_emoji world"
+        # guitar_emoji (U+1F3B8) is 4 UTF-8 bytes but 2 UTF-16 code units.
+        # After the guitar emoji, LSP says character=8 (6 for "hello ", 2 for emoji).
+        # But in UTF-8, "world" starts at byte 11 (6 + 4 + 1 for the space).
+        byte_off = convert_utf16_offset_to_byte_offset(text, 0, 8)
+        # byte_off = 11
+    """
+    # First convert to a Python string index, then compute the byte offset
+    # of that index in the UTF-8 encoding of the text.
+    idx = _convert_position_to_index(text, Position(line=line, character=char))
+    # The byte offset is the length of text[:idx] encoded as UTF-8.
+    return len(text[:idx].encode("utf-8"))

--- a/code/packages/python/ls00/src/ls00/handlers.py
+++ b/code/packages/python/ls00/src/ls00/handlers.py
@@ -1,0 +1,667 @@
+"""LSP handler methods — initialize, shutdown, text sync, and all feature handlers.
+
+These handlers implement the LSP server lifecycle and feature requests.
+Every LSP session begins with initialize and ends with shutdown+exit.
+
+Server Lifecycle
+-----------------
+
+::
+
+    Client (editor)              Server (us)
+      |                               |
+      |--initialize------------------->  store clientInfo, return capabilities
+      | <--------------result----------  |
+      |                               |
+      |--initialized (notif)---------->  no-op (handshake complete)
+      |                               |
+      |--textDocument/didOpen-------->  open doc, parse, push diagnostics
+      |--textDocument/didChange------>  apply change, re-parse, push diagnostics
+      |--textDocument/hover---------->  get parse result, call bridge.hover
+      | <--------------result----------  |
+      |                               |
+      |--shutdown--------------------->  set shutdown flag, return null
+      |--exit (notif)----------------->  (server stops)
+
+Handler Contract
+-----------------
+
+Request handlers return ``(result, error)`` where:
+- ``result`` is any JSON-serializable value (success)
+- ``error`` is a ``ResponseError`` (failure)
+- Only one should be non-None.
+
+Notification handlers have no return value.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+from json_rpc import ResponseError
+from json_rpc import INVALID_PARAMS as JSON_RPC_INVALID_PARAMS
+
+from ls00.capabilities import build_capabilities, encode_semantic_tokens
+from ls00.language_bridge import (
+    CompletionProvider,
+    DefinitionProvider,
+    DocumentSymbolsProvider,
+    FoldingRangesProvider,
+    FormatProvider,
+    HoverProvider,
+    ReferencesProvider,
+    RenameProvider,
+    SemanticTokensProvider,
+    SignatureHelpProvider,
+)
+from ls00.lsp_errors import REQUEST_FAILED
+from ls00.types import (
+    DocumentSymbol,
+    Position,
+    Range,
+    TextEdit,
+)
+
+if sys.version_info >= (3, 11):
+    from typing import TYPE_CHECKING
+else:
+    from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ls00.server import LspServer
+
+
+# ---------------------------------------------------------------------------
+# LSP type conversion helpers
+# ---------------------------------------------------------------------------
+
+
+def _position_to_lsp(p: Position) -> dict[str, Any]:
+    """Convert our Position to a JSON-serializable dict."""
+    return {"line": p.line, "character": p.character}
+
+
+def _range_to_lsp(r: Range) -> dict[str, Any]:
+    """Convert our Range to a JSON-serializable dict."""
+    return {"start": _position_to_lsp(r.start), "end": _position_to_lsp(r.end)}
+
+
+def _location_to_lsp(uri: str, r: Range) -> dict[str, Any]:
+    """Convert a Location to a JSON-serializable dict."""
+    return {"uri": uri, "range": _range_to_lsp(r)}
+
+
+def _parse_position(params: dict[str, Any]) -> Position:
+    """Extract a Position from a JSON params object.
+
+    The LSP sends positions as ``{"line": N, "character": N}``.
+    """
+    pos = params.get("position", {})
+    line = int(pos.get("line", 0))
+    char = int(pos.get("character", 0))
+    return Position(line=line, character=char)
+
+
+def _parse_uri(params: dict[str, Any]) -> str:
+    """Extract the document URI from params that have a textDocument field."""
+    td = params.get("textDocument", {})
+    return str(td.get("uri", ""))
+
+
+def _parse_lsp_range(raw: Any) -> Range:
+    """Parse a raw JSON range object from the LSP protocol.
+
+    The LSP sends ranges as::
+
+        {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 5}}
+    """
+    if not isinstance(raw, dict):
+        return Range(start=Position(0, 0), end=Position(0, 0))
+
+    start_map = raw.get("start", {})
+    end_map = raw.get("end", {})
+
+    return Range(
+        start=Position(
+            line=int(start_map.get("line", 0)),
+            character=int(start_map.get("character", 0)),
+        ),
+        end=Position(
+            line=int(end_map.get("line", 0)),
+            character=int(end_map.get("character", 0)),
+        ),
+    )
+
+
+def _convert_document_symbols(
+    symbols: list[DocumentSymbol],
+) -> list[dict[str, Any]]:
+    """Recursively convert DocumentSymbol objects to JSON-serializable dicts."""
+    result: list[dict[str, Any]] = []
+    for sym in symbols:
+        m: dict[str, Any] = {
+            "name": sym.name,
+            "kind": int(sym.kind),
+            "range": _range_to_lsp(sym.range),
+            "selectionRange": _range_to_lsp(sym.selection_range),
+        }
+        if sym.children:
+            m["children"] = _convert_document_symbols(sym.children)
+        result.append(m)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle handlers
+# ---------------------------------------------------------------------------
+
+
+def handle_initialize(
+    server: LspServer, id: Any, params: Any  # noqa: A002
+) -> Any:
+    """Process the LSP initialize request.
+
+    This is the server's first message. We store the client info (for logging)
+    and return our capabilities built from the bridge.
+    """
+    server.initialized = True
+
+    caps = build_capabilities(server.bridge)
+
+    return {
+        "capabilities": caps,
+        "serverInfo": {
+            "name": "ls00-generic-lsp-server",
+            "version": "0.1.0",
+        },
+    }
+
+
+def handle_initialized(server: LspServer, params: Any) -> None:
+    """Process the "initialized" notification.
+
+    No-op: the handshake is complete. Normal operation begins now.
+    """
+
+
+def handle_shutdown(
+    server: LspServer, id: Any, params: Any  # noqa: A002
+) -> Any:
+    """Process the LSP shutdown request.
+
+    After receiving shutdown, the server should stop processing new
+    requests and return null as the result.
+    """
+    server.shutdown = True
+    return None
+
+
+def handle_exit(server: LspServer, params: Any) -> None:
+    """Process the "exit" notification.
+
+    Exit code semantics (from the LSP spec):
+    - 0: shutdown was received before exit -> clean shutdown
+    - 1: shutdown was NOT received -> abnormal termination
+    """
+    if server.shutdown:
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Text document synchronization handlers
+# ---------------------------------------------------------------------------
+
+
+def handle_did_open(server: LspServer, params: Any) -> None:
+    """Handle textDocument/didOpen — editor opened a file.
+
+    Params: ``{"textDocument": {"uri": "...", "languageId": "...", "version": 1, "text": "..."}}``
+    """
+    if not isinstance(params, dict):
+        return
+
+    td = params.get("textDocument", {})
+    uri = td.get("uri", "")
+    text = td.get("text", "")
+    version = int(td.get("version", 1))
+
+    if not uri:
+        return
+
+    server.doc_manager.open(uri, text, version)
+
+    # Parse immediately and push diagnostics so the editor shows squiggles
+    # as soon as the file is opened.
+    result = server.parse_cache.get_or_parse(uri, version, text, server.bridge)
+    server.publish_diagnostics(uri, version, result.diagnostics)
+
+
+def handle_did_change(server: LspServer, params: Any) -> None:
+    """Handle textDocument/didChange — user edited a file.
+
+    Params: ``{"textDocument": {"uri": "...", "version": 2}, "contentChanges": [...]}``
+    """
+    if not isinstance(params, dict):
+        return
+
+    uri = _parse_uri(params)
+    if not uri:
+        return
+
+    version = 0
+    td = params.get("textDocument", {})
+    if isinstance(td, dict):
+        version = int(td.get("version", 0))
+
+    from ls00.document_manager import TextChange
+
+    changes_raw = params.get("contentChanges", [])
+    changes: list[TextChange] = []
+
+    for change_raw in changes_raw:
+        if not isinstance(change_raw, dict):
+            continue
+
+        new_text = change_raw.get("text", "")
+        range_raw = change_raw.get("range")
+
+        if range_raw is not None:
+            r = _parse_lsp_range(range_raw)
+            changes.append(TextChange(range=r, new_text=new_text))
+        else:
+            changes.append(TextChange(range=None, new_text=new_text))
+
+    try:
+        server.doc_manager.apply_changes(uri, changes, version)
+    except KeyError:
+        return
+
+    doc = server.doc_manager.get(uri)
+    if doc is None:
+        return
+
+    result = server.parse_cache.get_or_parse(
+        uri, doc.version, doc.text, server.bridge
+    )
+    server.publish_diagnostics(uri, version, result.diagnostics)
+
+
+def handle_did_close(server: LspServer, params: Any) -> None:
+    """Handle textDocument/didClose — editor closed a file.
+
+    Removes the document and clears diagnostics.
+    """
+    if not isinstance(params, dict):
+        return
+
+    uri = _parse_uri(params)
+    if not uri:
+        return
+
+    server.doc_manager.close(uri)
+    server.parse_cache.evict(uri)
+
+    # Clear diagnostics for the closed file by publishing an empty list.
+    server.publish_diagnostics(uri, 0, [])
+
+
+def handle_did_save(server: LspServer, params: Any) -> None:
+    """Handle textDocument/didSave — editor saved a file.
+
+    If the client sends full text in didSave, apply it.
+    """
+    if not isinstance(params, dict):
+        return
+
+    uri = _parse_uri(params)
+    if not uri:
+        return
+
+    text = params.get("text")
+    if isinstance(text, str) and text:
+        doc = server.doc_manager.get(uri)
+        if doc is not None:
+            server.doc_manager.close(uri)
+            server.doc_manager.open(uri, text, doc.version)
+            result = server.parse_cache.get_or_parse(
+                uri, doc.version, text, server.bridge
+            )
+            server.publish_diagnostics(uri, doc.version, result.diagnostics)
+
+
+# ---------------------------------------------------------------------------
+# Feature request handlers
+# ---------------------------------------------------------------------------
+
+
+def handle_hover(
+    server: LspServer, id: Any, params: Any  # noqa: A002
+) -> Any:
+    """Process textDocument/hover."""
+    if not isinstance(params, dict):
+        return ResponseError(code=JSON_RPC_INVALID_PARAMS, message="invalid params")
+
+    uri = _parse_uri(params)
+    pos = _parse_position(params)
+
+    if not isinstance(server.bridge, HoverProvider):
+        return None
+
+    doc, parse_result = server.get_parse_result(uri)
+    if parse_result is None:
+        return ResponseError(code=REQUEST_FAILED, message=f"document not open: {uri}")
+
+    if parse_result.ast is None:
+        return None
+
+    hover_result = server.bridge.hover(parse_result.ast, pos)
+    if hover_result is None:
+        return None
+
+    result: dict[str, Any] = {
+        "contents": {
+            "kind": "markdown",
+            "value": hover_result.contents,
+        },
+    }
+
+    if hover_result.range is not None:
+        result["range"] = _range_to_lsp(hover_result.range)
+
+    return result
+
+
+def handle_definition(
+    server: LspServer, id: Any, params: Any  # noqa: A002
+) -> Any:
+    """Process textDocument/definition."""
+    if not isinstance(params, dict):
+        return ResponseError(code=JSON_RPC_INVALID_PARAMS, message="invalid params")
+
+    uri = _parse_uri(params)
+    pos = _parse_position(params)
+
+    if not isinstance(server.bridge, DefinitionProvider):
+        return None
+
+    doc, parse_result = server.get_parse_result(uri)
+    if parse_result is None:
+        return ResponseError(code=REQUEST_FAILED, message=f"document not open: {uri}")
+
+    if parse_result.ast is None:
+        return None
+
+    location = server.bridge.definition(parse_result.ast, pos, uri)
+    if location is None:
+        return None
+
+    return _location_to_lsp(location.uri, location.range)
+
+
+def handle_references(
+    server: LspServer, id: Any, params: Any  # noqa: A002
+) -> Any:
+    """Process textDocument/references."""
+    if not isinstance(params, dict):
+        return ResponseError(code=JSON_RPC_INVALID_PARAMS, message="invalid params")
+
+    uri = _parse_uri(params)
+    pos = _parse_position(params)
+
+    include_decl = False
+    ctx = params.get("context", {})
+    if isinstance(ctx, dict):
+        include_decl = bool(ctx.get("includeDeclaration", False))
+
+    if not isinstance(server.bridge, ReferencesProvider):
+        return []
+
+    doc, parse_result = server.get_parse_result(uri)
+    if parse_result is None:
+        return ResponseError(code=REQUEST_FAILED, message=f"document not open: {uri}")
+
+    if parse_result.ast is None:
+        return []
+
+    locations = server.bridge.references(parse_result.ast, pos, uri, include_decl)
+    return [_location_to_lsp(loc.uri, loc.range) for loc in locations]
+
+
+def handle_completion(
+    server: LspServer, id: Any, params: Any  # noqa: A002
+) -> Any:
+    """Process textDocument/completion."""
+    if not isinstance(params, dict):
+        return ResponseError(code=JSON_RPC_INVALID_PARAMS, message="invalid params")
+
+    uri = _parse_uri(params)
+    pos = _parse_position(params)
+    empty_list: dict[str, Any] = {"isIncomplete": False, "items": []}
+
+    if not isinstance(server.bridge, CompletionProvider):
+        return empty_list
+
+    doc, parse_result = server.get_parse_result(uri)
+    if parse_result is None:
+        return ResponseError(code=REQUEST_FAILED, message=f"document not open: {uri}")
+
+    if parse_result.ast is None:
+        return empty_list
+
+    items = server.bridge.completion(parse_result.ast, pos)
+
+    lsp_items: list[dict[str, Any]] = []
+    for item in items:
+        ci: dict[str, Any] = {"label": item.label}
+        if item.kind is not None and item.kind != 0:
+            ci["kind"] = int(item.kind)
+        if item.detail:
+            ci["detail"] = item.detail
+        if item.documentation:
+            ci["documentation"] = item.documentation
+        if item.insert_text:
+            ci["insertText"] = item.insert_text
+        if item.insert_text_format:
+            ci["insertTextFormat"] = item.insert_text_format
+        lsp_items.append(ci)
+
+    return {"isIncomplete": False, "items": lsp_items}
+
+
+def handle_rename(
+    server: LspServer, id: Any, params: Any  # noqa: A002
+) -> Any:
+    """Process textDocument/rename."""
+    if not isinstance(params, dict):
+        return ResponseError(code=JSON_RPC_INVALID_PARAMS, message="invalid params")
+
+    uri = _parse_uri(params)
+    pos = _parse_position(params)
+    new_name = params.get("newName", "")
+
+    if not new_name:
+        return ResponseError(code=JSON_RPC_INVALID_PARAMS, message="newName is required")
+
+    if not isinstance(server.bridge, RenameProvider):
+        return ResponseError(code=REQUEST_FAILED, message="rename not supported")
+
+    doc, parse_result = server.get_parse_result(uri)
+    if parse_result is None:
+        return ResponseError(code=REQUEST_FAILED, message=f"document not open: {uri}")
+
+    if parse_result.ast is None:
+        return ResponseError(code=REQUEST_FAILED, message="no AST available")
+
+    edit = server.bridge.rename(parse_result.ast, pos, new_name)
+    if edit is None:
+        return ResponseError(
+            code=REQUEST_FAILED, message="symbol not found at position"
+        )
+
+    # Convert WorkspaceEdit to LSP format.
+    lsp_changes: dict[str, Any] = {}
+    for edit_uri, edits in edit.changes.items():
+        lsp_edits: list[dict[str, Any]] = []
+        for te in edits:
+            lsp_edits.append({
+                "range": _range_to_lsp(te.range),
+                "newText": te.new_text,
+            })
+        lsp_changes[edit_uri] = lsp_edits
+
+    return {"changes": lsp_changes}
+
+
+def handle_document_symbol(
+    server: LspServer, id: Any, params: Any  # noqa: A002
+) -> Any:
+    """Process textDocument/documentSymbol."""
+    if not isinstance(params, dict):
+        return ResponseError(code=JSON_RPC_INVALID_PARAMS, message="invalid params")
+
+    uri = _parse_uri(params)
+
+    if not isinstance(server.bridge, DocumentSymbolsProvider):
+        return []
+
+    doc, parse_result = server.get_parse_result(uri)
+    if parse_result is None:
+        return ResponseError(code=REQUEST_FAILED, message=f"document not open: {uri}")
+
+    if parse_result.ast is None:
+        return []
+
+    symbols = server.bridge.document_symbols(parse_result.ast)
+    return _convert_document_symbols(symbols)
+
+
+def handle_semantic_tokens_full(
+    server: LspServer, id: Any, params: Any  # noqa: A002
+) -> Any:
+    """Process textDocument/semanticTokens/full."""
+    if not isinstance(params, dict):
+        return ResponseError(code=JSON_RPC_INVALID_PARAMS, message="invalid params")
+
+    uri = _parse_uri(params)
+    empty_data: dict[str, Any] = {"data": []}
+
+    if not isinstance(server.bridge, SemanticTokensProvider):
+        return empty_data
+
+    doc = server.doc_manager.get(uri)
+    if doc is None:
+        return empty_data
+
+    tokens = server.bridge.tokenize(doc.text)
+    sem_tokens = server.bridge.semantic_tokens(doc.text, tokens)
+    data = encode_semantic_tokens(sem_tokens)
+
+    return {"data": data}
+
+
+def handle_folding_range(
+    server: LspServer, id: Any, params: Any  # noqa: A002
+) -> Any:
+    """Process textDocument/foldingRange."""
+    if not isinstance(params, dict):
+        return ResponseError(code=JSON_RPC_INVALID_PARAMS, message="invalid params")
+
+    uri = _parse_uri(params)
+
+    if not isinstance(server.bridge, FoldingRangesProvider):
+        return []
+
+    doc, parse_result = server.get_parse_result(uri)
+    if parse_result is None:
+        return ResponseError(code=REQUEST_FAILED, message=f"document not open: {uri}")
+
+    if parse_result.ast is None:
+        return []
+
+    ranges = server.bridge.folding_ranges(parse_result.ast)
+
+    result: list[dict[str, Any]] = []
+    for fr in ranges:
+        m: dict[str, Any] = {
+            "startLine": fr.start_line,
+            "endLine": fr.end_line,
+        }
+        if fr.kind:
+            m["kind"] = fr.kind
+        result.append(m)
+
+    return result
+
+
+def handle_signature_help(
+    server: LspServer, id: Any, params: Any  # noqa: A002
+) -> Any:
+    """Process textDocument/signatureHelp."""
+    if not isinstance(params, dict):
+        return ResponseError(code=JSON_RPC_INVALID_PARAMS, message="invalid params")
+
+    uri = _parse_uri(params)
+    pos = _parse_position(params)
+
+    if not isinstance(server.bridge, SignatureHelpProvider):
+        return None
+
+    doc, parse_result = server.get_parse_result(uri)
+    if parse_result is None:
+        return ResponseError(code=REQUEST_FAILED, message=f"document not open: {uri}")
+
+    if parse_result.ast is None:
+        return None
+
+    sig_help = server.bridge.signature_help(parse_result.ast, pos)
+    if sig_help is None:
+        return None
+
+    lsp_sigs: list[dict[str, Any]] = []
+    for sig in sig_help.signatures:
+        lsp_params: list[dict[str, Any]] = []
+        for param in sig.parameters:
+            pp: dict[str, Any] = {"label": param.label}
+            if param.documentation:
+                pp["documentation"] = param.documentation
+            lsp_params.append(pp)
+        s: dict[str, Any] = {
+            "label": sig.label,
+            "parameters": lsp_params,
+        }
+        if sig.documentation:
+            s["documentation"] = sig.documentation
+        lsp_sigs.append(s)
+
+    return {
+        "signatures": lsp_sigs,
+        "activeSignature": sig_help.active_signature,
+        "activeParameter": sig_help.active_parameter,
+    }
+
+
+def handle_formatting(
+    server: LspServer, id: Any, params: Any  # noqa: A002
+) -> Any:
+    """Process textDocument/formatting."""
+    if not isinstance(params, dict):
+        return ResponseError(code=JSON_RPC_INVALID_PARAMS, message="invalid params")
+
+    uri = _parse_uri(params)
+
+    if not isinstance(server.bridge, FormatProvider):
+        return []
+
+    doc = server.doc_manager.get(uri)
+    if doc is None:
+        return []
+
+    edits = server.bridge.format(doc.text)
+
+    return [
+        {"range": _range_to_lsp(edit.range), "newText": edit.new_text}
+        for edit in edits
+    ]

--- a/code/packages/python/ls00/src/ls00/language_bridge.py
+++ b/code/packages/python/ls00/src/ls00/language_bridge.py
@@ -1,0 +1,296 @@
+"""LanguageBridge and optional provider protocols.
+
+Design Philosophy: Narrow Interfaces
+--------------------------------------
+
+Python's ``typing.Protocol`` with ``@runtime_checkable`` mirrors Go's
+implicit interface satisfaction. A class implements a protocol simply by
+having the right methods -- no explicit ``implements`` declaration.
+
+We use many small protocols (one per LSP feature) instead of one large
+abstract base class. This is the "interface segregation principle" from
+SOLID:
+
+    APPROACH A -- fat interface (one big ABC, every method required)::
+
+        class LanguageBridge(ABC):
+            def tokenize(self, source: str) -> list[Token]: ...
+            def parse(self, source: str) -> tuple[Any, list[Diagnostic]]: ...
+            def hover(self, ast: Any, pos: Position) -> HoverResult | None: ...
+            def definition(self, ast: Any, pos: Position, uri: str) -> Location | None: ...
+            # ... 8 more methods, all REQUIRED
+
+        Problem: a language that only has a lexer and parser must implement
+        ALL methods, even features it doesn't support yet.
+
+    APPROACH B -- narrow protocols (what we use)::
+
+        class LanguageBridge(Protocol):
+            def tokenize(self, source: str) -> list[Token]: ...
+            def parse(self, source: str) -> tuple[Any, list[Diagnostic]]: ...
+
+        class HoverProvider(Protocol):
+            def hover(self, ast: Any, pos: Position) -> HoverResult | None: ...
+
+        At runtime, the server checks: ``isinstance(bridge, HoverProvider)``?
+        If yes: advertise ``hoverProvider: true`` and call ``bridge.hover()``.
+        If no: omit hover from capabilities. No stubs required.
+
+Runtime Capability Detection
+------------------------------
+
+Detection uses Python's ``isinstance()`` with ``@runtime_checkable``
+Protocol classes::
+
+    if isinstance(bridge, HoverProvider):
+        result = bridge.hover(ast, pos)
+
+This mirrors Go's type assertion pattern: ``if hp, ok := bridge.(HoverProvider); ok``
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from ls00.types import (
+    CompletionItem,
+    Diagnostic,
+    DocumentSymbol,
+    FoldingRange,
+    HoverResult,
+    Location,
+    Position,
+    SemanticToken,
+    SignatureHelpResult,
+    TextEdit,
+    Token,
+    WorkspaceEdit,
+)
+
+
+# ---------------------------------------------------------------------------
+# Required interface — every language bridge must implement this
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class LanguageBridge(Protocol):
+    """The required minimum interface every language must implement.
+
+    ``tokenize`` and ``parse`` are the foundation for all other features:
+    - ``tokenize`` drives semantic token highlighting (accurate syntax coloring)
+    - ``parse`` drives diagnostics, folding, and document symbols
+
+    All other features (hover, go-to-definition, etc.) are optional and
+    declared as separate Protocol classes below. The LspServer checks at
+    runtime whether the bridge also implements those protocols.
+    """
+
+    def tokenize(self, source: str) -> list[Token]:
+        """Lex the source string and return the token stream.
+
+        The tokens are used for semantic highlighting. Each Token carries a
+        ``type`` string (e.g. "KEYWORD", "IDENTIFIER"), its ``value``, and
+        its 1-based ``line`` and ``column`` position. The bridge is
+        responsible for converting 1-based positions to 0-based before
+        building SemanticToken values.
+        """
+        ...
+
+    def parse(self, source: str) -> tuple[Any, list[Diagnostic]]:
+        """Parse the source string and return (ast, diagnostics).
+
+        Returns:
+            A tuple of:
+            - ast: the parsed abstract syntax tree (may be partial on error)
+            - diagnostics: parse errors and warnings as LSP Diagnostic objects
+
+        Even when there are syntax errors, parse should return a partial AST.
+        This allows hover, folding, and symbol features to continue working on
+        the valid portions of the file.
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Optional Provider Protocols
+# ---------------------------------------------------------------------------
+#
+# Each protocol represents one optional LSP feature. A bridge implements
+# only the features its language supports. The server uses isinstance()
+# to detect support at runtime.
+#
+# None of these protocols extend LanguageBridge -- they are purely additive.
+
+
+@runtime_checkable
+class HoverProvider(Protocol):
+    """Enables hover tooltips.
+
+    When the user moves their mouse over a symbol, the editor sends
+    ``textDocument/hover`` with the cursor position. The bridge should
+    return Markdown text describing the symbol (type, documentation, etc.).
+    """
+
+    def hover(self, ast: Any, pos: Position) -> HoverResult | None:
+        """Return hover information for the AST node at the given position.
+
+        Returns:
+            - ``HoverResult`` -- hover content to display
+            - ``None`` -- no hover info at this position (not an error)
+        """
+        ...
+
+
+@runtime_checkable
+class DefinitionProvider(Protocol):
+    """Enables "Go to Definition" (F12 in VS Code).
+
+    When the user right-clicks on a symbol and chooses "Go to Definition",
+    the editor sends ``textDocument/definition``. The bridge looks up the
+    symbol in its symbol table and returns the location where it was declared.
+    """
+
+    def definition(self, ast: Any, pos: Position, uri: str) -> Location | None:
+        """Return the location where the symbol at ``pos`` was declared.
+
+        Returns:
+            - ``Location`` -- the declaration location
+            - ``None`` -- symbol not found (not an error)
+        """
+        ...
+
+
+@runtime_checkable
+class ReferencesProvider(Protocol):
+    """Enables "Find All References".
+
+    When the user right-clicks and chooses "Find All References", the editor
+    sends ``textDocument/references``. The bridge returns every location
+    where the symbol is used.
+    """
+
+    def references(
+        self, ast: Any, pos: Position, uri: str, include_decl: bool
+    ) -> list[Location]:
+        """Return all uses of the symbol at ``pos``.
+
+        Args:
+            include_decl: if True, include the declaration location in results.
+        """
+        ...
+
+
+@runtime_checkable
+class CompletionProvider(Protocol):
+    """Enables autocomplete suggestions.
+
+    When the user pauses typing or presses Ctrl+Space, the editor sends
+    ``textDocument/completion``. The bridge returns a list of valid
+    completions at the cursor position.
+    """
+
+    def completion(self, ast: Any, pos: Position) -> list[CompletionItem]:
+        """Return autocomplete suggestions valid at ``pos``."""
+        ...
+
+
+@runtime_checkable
+class RenameProvider(Protocol):
+    """Enables symbol rename (F2 in VS Code).
+
+    When the user presses F2 on a symbol, the editor sends
+    ``textDocument/rename``. The bridge must find all occurrences of
+    the symbol and return text edits that replace each one with ``new_name``.
+    """
+
+    def rename(
+        self, ast: Any, pos: Position, new_name: str
+    ) -> WorkspaceEdit | None:
+        """Return the set of text edits needed to rename the symbol at ``pos``."""
+        ...
+
+
+@runtime_checkable
+class SemanticTokensProvider(Protocol):
+    """Enables accurate syntax highlighting.
+
+    The bridge receives the full token stream from the lexer and maps each
+    token to a semantic type (keyword, string, number, variable, function, etc.).
+    The framework then encodes the result into LSP's compact binary format.
+    """
+
+    def semantic_tokens(
+        self, source: str, tokens: list[Token]
+    ) -> list[SemanticToken]:
+        """Return semantic token data for the whole document.
+
+        ``tokens`` is the output of ``tokenize()`` -- the bridge should use
+        these rather than re-lexing. The returned SemanticTokens must be
+        sorted by line, then by character (ascending), because the LSP
+        encoding is delta-based.
+        """
+        ...
+
+
+@runtime_checkable
+class DocumentSymbolsProvider(Protocol):
+    """Enables the document outline panel.
+
+    The bridge walks the AST looking for declaration nodes and returns
+    them as a tree of DocumentSymbol objects.
+    """
+
+    def document_symbols(self, ast: Any) -> list[DocumentSymbol]:
+        """Return the outline tree for the given AST."""
+        ...
+
+
+@runtime_checkable
+class FoldingRangesProvider(Protocol):
+    """Enables code folding (collapsible blocks).
+
+    The bridge typically marks any AST node that spans multiple lines
+    as foldable.
+    """
+
+    def folding_ranges(self, ast: Any) -> list[FoldingRange]:
+        """Return collapsible regions derived from the AST structure."""
+        ...
+
+
+@runtime_checkable
+class SignatureHelpProvider(Protocol):
+    """Enables function signature hints.
+
+    When the user types the opening parenthesis of a function call, the
+    editor sends ``textDocument/signatureHelp``. The bridge returns the
+    function's signature with the active parameter highlighted.
+    """
+
+    def signature_help(
+        self, ast: Any, pos: Position
+    ) -> SignatureHelpResult | None:
+        """Return signature hint information for the call at ``pos``.
+
+        Returns:
+            - ``SignatureHelpResult`` -- signature data
+            - ``None`` -- not inside a call expression
+        """
+        ...
+
+
+@runtime_checkable
+class FormatProvider(Protocol):
+    """Enables document formatting (Format on Save).
+
+    The bridge returns a list of text edits that transform the source into
+    its canonical formatted form.
+    """
+
+    def format(self, source: str) -> list[TextEdit]:
+        """Return the text edits needed to format the document.
+
+        Typically this is a single edit replacing the entire file content.
+        """
+        ...

--- a/code/packages/python/ls00/src/ls00/lsp_errors.py
+++ b/code/packages/python/ls00/src/ls00/lsp_errors.py
@@ -1,0 +1,45 @@
+"""LSP-specific error codes.
+
+The JSON-RPC 2.0 specification reserves error codes in the range
+[-32768, -32000]. The LSP specification further reserves [-32899, -32800]
+for LSP protocol-level errors.
+
+Standard JSON-RPC error codes (from the json-rpc package)::
+
+    -32700  PARSE_ERROR
+    -32600  INVALID_REQUEST
+    -32601  METHOD_NOT_FOUND
+    -32602  INVALID_PARAMS
+    -32603  INTERNAL_ERROR
+
+LSP-specific error codes are listed below.
+
+Reference:
+    https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#errorCodes
+"""
+
+from __future__ import annotations
+
+# The server has received a request before the initialize handshake was
+# completed. The server must reject any request (other than initialize)
+# before it has been initialized.
+SERVER_NOT_INITIALIZED: int = -32002
+
+# A generic error code for unknown errors.
+UNKNOWN_ERROR_CODE: int = -32001
+
+# LSP-specific codes in the range [-32899, -32800]:
+
+# A request failed but not due to a protocol problem. For example, the
+# document requested was not found.
+REQUEST_FAILED: int = -32803
+
+# The server cancelled the request.
+SERVER_CANCELLED: int = -32802
+
+# The document content was modified before the request completed.
+# The client should retry.
+CONTENT_MODIFIED: int = -32801
+
+# The client cancelled the request.
+REQUEST_CANCELLED: int = -32800

--- a/code/packages/python/ls00/src/ls00/parse_cache.py
+++ b/code/packages/python/ls00/src/ls00/parse_cache.py
@@ -1,0 +1,112 @@
+"""ParseCache — avoid re-parsing unchanged documents.
+
+Why Cache Parse Results?
+--------------------------
+
+Parsing is the most expensive operation in a language server. For a large
+file, parsing on every keystroke would lag the editor noticeably.
+
+The LSP protocol helps by sending a version number with every change. If
+the document hasn't changed (same URI, same version), the parse result
+from the previous keystroke is still valid.
+
+Cache Key Design
+-----------------
+
+The cache key is ``(uri, version)``. Version is a monotonically increasing
+integer that the editor increments with each change. Using version in the
+key means:
+
+- Same ``(uri, version)`` -> cache hit -> return cached result
+- Different version -> cache miss -> re-parse and cache new result
+
+The old entry is evicted when a new version is cached for the same URI.
+This keeps memory bounded at O(open_documents) entries.
+
+Thread Safety
+--------------
+
+The ParseCache is NOT thread-safe. This is intentional: the LspServer
+processes one message at a time (single-threaded), so no locking is needed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from ls00.language_bridge import LanguageBridge
+from ls00.types import Diagnostic
+
+
+@dataclass
+class ParseResult:
+    """Holds the outcome of parsing one version of a document.
+
+    Even on parse error, we store the partial AST and diagnostics so that
+    other features (hover, folding, symbols) can still work on the valid
+    portions.
+    """
+
+    ast: Any  # may be None if the parser couldn't produce any AST
+    diagnostics: list[Diagnostic] = field(default_factory=list)
+
+
+class ParseCache:
+    """Stores the most recent parse result for each open document.
+
+    Create one with ``ParseCache()``. Call ``get_or_parse()`` on every
+    feature request to get the current (possibly cached) parse result.
+    """
+
+    def __init__(self) -> None:
+        self._cache: dict[tuple[str, int], ParseResult] = {}
+
+    def get_or_parse(
+        self,
+        uri: str,
+        version: int,
+        source: str,
+        bridge: LanguageBridge,
+    ) -> ParseResult:
+        """Return the parse result for ``(uri, version)``.
+
+        If the result is already cached, it is returned immediately without
+        calling the bridge again. Otherwise, ``bridge.parse(source)`` is
+        called, the result is stored, and the previous cache entry for this
+        URI (if any) is evicted to prevent unbounded growth.
+
+        This function is the single point of truth for "what is the parsed
+        state of this document right now?" All feature handlers call it
+        before operating on the AST.
+        """
+        key = (uri, version)
+
+        # Cache hit: the document hasn't changed since last parse.
+        if key in self._cache:
+            return self._cache[key]
+
+        # Cache miss: parse and store. Evict any stale entry first.
+        self._evict(uri)
+
+        ast, diags = bridge.parse(source)
+        if diags is None:
+            diags = []  # normalize None to empty list for JSON
+
+        result = ParseResult(ast=ast, diagnostics=diags)
+        self._cache[key] = result
+        return result
+
+    def evict(self, uri: str) -> None:
+        """Remove all cached entries for a given URI.
+
+        Called when a document is closed (didClose) so the cache entry
+        is cleaned up.
+        """
+        self._evict(uri)
+
+    def _evict(self, uri: str) -> None:
+        """Internal eviction implementation."""
+        keys_to_remove = [k for k in self._cache if k[0] == uri]
+        for k in keys_to_remove:
+            del self._cache[k]

--- a/code/packages/python/ls00/src/ls00/server.py
+++ b/code/packages/python/ls00/src/ls00/server.py
@@ -1,0 +1,241 @@
+"""LspServer — the main coordinator.
+
+LspServer wires together:
+- The LanguageBridge (language-specific logic)
+- The DocumentManager (tracks open file contents)
+- The ParseCache (avoids redundant parses)
+- The JSON-RPC Server (protocol layer)
+
+It registers all LSP request and notification handlers with the JSON-RPC
+server, then calls ``serve()`` to start the blocking read-dispatch-write loop.
+
+Sending Notifications to the Editor
+--------------------------------------
+
+The JSON-RPC Server (from the json-rpc package) handles request/response
+pairs. But the LSP server also needs to PUSH notifications to the editor
+(e.g., ``textDocument/publishDiagnostics``). We do this by holding a
+reference to the JSON-RPC MessageWriter and calling ``write_message``
+directly.
+"""
+
+from __future__ import annotations
+
+from typing import IO, Any
+
+from json_rpc import MessageWriter, Notification, ResponseError, Server
+
+from ls00.capabilities import build_capabilities
+from ls00.document_manager import DocumentManager
+from ls00.handlers import (
+    _range_to_lsp,
+    handle_completion,
+    handle_definition,
+    handle_did_change,
+    handle_did_close,
+    handle_did_open,
+    handle_did_save,
+    handle_document_symbol,
+    handle_exit,
+    handle_folding_range,
+    handle_formatting,
+    handle_hover,
+    handle_initialize,
+    handle_initialized,
+    handle_references,
+    handle_rename,
+    handle_semantic_tokens_full,
+    handle_shutdown,
+    handle_signature_help,
+)
+from ls00.language_bridge import LanguageBridge
+from ls00.parse_cache import ParseCache, ParseResult
+from ls00.types import Diagnostic
+
+
+class LspServer:
+    """The main LSP server.
+
+    Create it with ``LspServer(bridge, in_stream, out_stream)``, then call
+    ``serve()`` to start serving. It is designed to be used once per process --
+    start it, it blocks, it exits.
+
+    Example::
+
+        server = LspServer(my_bridge, sys.stdin.buffer, sys.stdout.buffer)
+        server.serve()
+    """
+
+    def __init__(
+        self,
+        bridge: LanguageBridge,
+        in_stream: IO[bytes],
+        out_stream: IO[bytes],
+    ) -> None:
+        self.bridge = bridge
+        self.doc_manager = DocumentManager()
+        self.parse_cache = ParseCache()
+        self._rpc_server = Server(in_stream, out_stream)
+        self._writer = MessageWriter(out_stream)
+
+        # shutdown tracks whether the editor has sent "shutdown".
+        self.shutdown = False
+        # initialized tracks whether the initialize handshake is complete.
+        self.initialized = False
+
+        self._register_handlers()
+
+    def serve(self) -> None:
+        """Start the blocking JSON-RPC read-dispatch-write loop.
+
+        This call blocks until the editor closes the connection (EOF on stdin).
+        """
+        self._rpc_server.serve()
+
+    def get_parse_result(
+        self, uri: str
+    ) -> tuple[Any, ParseResult | None]:
+        """Retrieve the current parse result for a document.
+
+        This is the hot path for all feature handlers. It:
+        1. Gets the current document text from the DocumentManager
+        2. Returns the cached ParseResult (or re-parses if needed)
+
+        Returns ``(doc, None)`` if the document is not open.
+        """
+        doc = self.doc_manager.get(uri)
+        if doc is None:
+            return None, None
+
+        result = self.parse_cache.get_or_parse(
+            uri, doc.version, doc.text, self.bridge
+        )
+        return doc, result
+
+    def publish_diagnostics(
+        self, uri: str, version: int, diagnostics: list[Diagnostic]
+    ) -> None:
+        """Send textDocument/publishDiagnostics notification to the editor.
+
+        Called after every didOpen and didChange event to update the
+        squiggle underlines in the editor.
+        """
+        lsp_diags: list[dict[str, Any]] = []
+        for d in diagnostics:
+            diag: dict[str, Any] = {
+                "range": _range_to_lsp(d.range),
+                "severity": int(d.severity),
+                "message": d.message,
+            }
+            if d.code:
+                diag["code"] = d.code
+            lsp_diags.append(diag)
+
+        notif_params: dict[str, Any] = {
+            "uri": uri,
+            "diagnostics": lsp_diags,
+        }
+        if version > 0:
+            notif_params["version"] = version
+
+        # Best-effort: if the write fails, the editor shows stale diagnostics.
+        try:
+            self._writer.write_message(
+                Notification(method="textDocument/publishDiagnostics", params=notif_params)
+            )
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _register_handlers(self) -> None:
+        """Wire all LSP method names to their handler functions.
+
+        Requests (have an id, get a response):
+            initialize, shutdown, textDocument/hover, textDocument/definition,
+            textDocument/references, textDocument/completion, textDocument/rename,
+            textDocument/documentSymbol, textDocument/semanticTokens/full,
+            textDocument/foldingRange, textDocument/signatureHelp,
+            textDocument/formatting
+
+        Notifications (no id, no response):
+            initialized, textDocument/didOpen, textDocument/didChange,
+            textDocument/didClose, textDocument/didSave
+        """
+        s = self
+
+        # -- Lifecycle ---------------------------------------------------------
+        self._rpc_server.on_request(
+            "initialize",
+            lambda req_id, params: handle_initialize(s, req_id, params),
+        )
+        self._rpc_server.on_notification(
+            "initialized",
+            lambda params: handle_initialized(s, params),
+        )
+        self._rpc_server.on_request(
+            "shutdown",
+            lambda req_id, params: handle_shutdown(s, req_id, params),
+        )
+        self._rpc_server.on_notification(
+            "exit",
+            lambda params: handle_exit(s, params),
+        )
+
+        # -- Text document synchronization ------------------------------------
+        self._rpc_server.on_notification(
+            "textDocument/didOpen",
+            lambda params: handle_did_open(s, params),
+        )
+        self._rpc_server.on_notification(
+            "textDocument/didChange",
+            lambda params: handle_did_change(s, params),
+        )
+        self._rpc_server.on_notification(
+            "textDocument/didClose",
+            lambda params: handle_did_close(s, params),
+        )
+        self._rpc_server.on_notification(
+            "textDocument/didSave",
+            lambda params: handle_did_save(s, params),
+        )
+
+        # -- Feature requests (conditional on bridge capability) ---------------
+        self._rpc_server.on_request(
+            "textDocument/hover",
+            lambda req_id, params: handle_hover(s, req_id, params),
+        )
+        self._rpc_server.on_request(
+            "textDocument/definition",
+            lambda req_id, params: handle_definition(s, req_id, params),
+        )
+        self._rpc_server.on_request(
+            "textDocument/references",
+            lambda req_id, params: handle_references(s, req_id, params),
+        )
+        self._rpc_server.on_request(
+            "textDocument/completion",
+            lambda req_id, params: handle_completion(s, req_id, params),
+        )
+        self._rpc_server.on_request(
+            "textDocument/rename",
+            lambda req_id, params: handle_rename(s, req_id, params),
+        )
+        self._rpc_server.on_request(
+            "textDocument/documentSymbol",
+            lambda req_id, params: handle_document_symbol(s, req_id, params),
+        )
+        self._rpc_server.on_request(
+            "textDocument/semanticTokens/full",
+            lambda req_id, params: handle_semantic_tokens_full(s, req_id, params),
+        )
+        self._rpc_server.on_request(
+            "textDocument/foldingRange",
+            lambda req_id, params: handle_folding_range(s, req_id, params),
+        )
+        self._rpc_server.on_request(
+            "textDocument/signatureHelp",
+            lambda req_id, params: handle_signature_help(s, req_id, params),
+        )
+        self._rpc_server.on_request(
+            "textDocument/formatting",
+            lambda req_id, params: handle_formatting(s, req_id, params),
+        )

--- a/code/packages/python/ls00/src/ls00/types.py
+++ b/code/packages/python/ls00/src/ls00/types.py
@@ -1,0 +1,381 @@
+"""LSP types — all shared data types used across the server.
+
+These types mirror the LSP specification's TypeScript type definitions,
+translated to idiomatic Python with dataclasses and enums.
+
+The LSP spec lives at:
+https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/
+
+Coordinate System
+-----------------
+
+LSP uses a 0-based, line/character coordinate system. Line 0, character 0
+is the very first character of the file. This differs from most editors
+(which display 1-based line numbers) and from most lexers (which emit
+1-based tokens). The LanguageBridge is responsible for converting.
+
+UTF-16 Code Units
+-----------------
+
+LSP's "character" offset is measured in UTF-16 CODE UNITS, not bytes or
+Unicode codepoints. This is a historical artifact: VS Code is built on
+TypeScript, which uses UTF-16 strings internally. See document_manager.py
+for the conversion function and a detailed explanation of why this matters.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import IntEnum
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Position and Range — the fundamental coordinate types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Position:
+    """A cursor position in a document.
+
+    Both ``line`` and ``character`` are 0-based. ``character`` is measured
+    in UTF-16 code units (see the module doc above for why).
+
+    Example: in the string ``"hello guitar_emoji world"``, the guitar emoji
+    (U+1F3B8) occupies UTF-16 characters 6 and 7 (it requires two UTF-16
+    surrogates). ``"world"`` starts at UTF-16 character 8.
+    """
+
+    line: int
+    character: int
+
+
+@dataclass
+class Range:
+    """A span of text in a document, from start (inclusive) to end (exclusive).
+
+    Analogy: think of it like a text selection. ``start`` is where the
+    cursor lands when you click, ``end`` is where you drag to.
+    """
+
+    start: Position
+    end: Position
+
+
+@dataclass
+class Location:
+    """A position in a specific file.
+
+    ``uri`` uses the ``file://`` scheme, e.g., ``"file:///home/user/main.py"``.
+    """
+
+    uri: str
+    range: Range
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic — errors, warnings, hints displayed in the editor
+# ---------------------------------------------------------------------------
+
+
+class DiagnosticSeverity(IntEnum):
+    """How serious a diagnostic is. These match the LSP integer codes.
+
+    The editor renders diagnostics as underlined squiggles:
+    - Red squiggles = Error
+    - Yellow squiggles = Warning
+    - Blue squiggles = Information
+    - Faint underline = Hint
+    """
+
+    ERROR = 1
+    WARNING = 2
+    INFORMATION = 3
+    HINT = 4
+
+
+@dataclass
+class Diagnostic:
+    """An error, warning, or hint to display in the editor.
+
+    The editor renders diagnostics as underlined squiggles, with the
+    message shown on hover.
+    """
+
+    range: Range
+    severity: DiagnosticSeverity
+    message: str
+    code: str = ""  # optional: e.g. "E001"
+
+
+# ---------------------------------------------------------------------------
+# Token — a single lexical token from the language's lexer
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Token:
+    """A single lexical token from the language's lexer.
+
+    The bridge's ``tokenize()`` method returns a list of these. The LSP
+    server uses tokens to provide semantic syntax highlighting
+    (SemanticTokensProvider).
+
+    Note: ``line`` and ``column`` are 1-based (matching most lexers). The
+    bridge must convert to 0-based when building SemanticToken values for
+    the LSP response.
+    """
+
+    type: str  # e.g. "KEYWORD", "IDENTIFIER", "STRING_LIT"
+    value: str  # the actual source text, e.g. "let" or "myVar"
+    line: int  # 1-based line number
+    column: int  # 1-based column number
+
+
+# ---------------------------------------------------------------------------
+# TextEdit and WorkspaceEdit — text modifications
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TextEdit:
+    """A single text replacement in a document.
+
+    Used by formatting (replace the whole file) and rename (replace each
+    occurrence). ``new_text`` replaces the content at ``range``. If
+    ``new_text`` is empty, the range is deleted.
+    """
+
+    range: Range
+    new_text: str
+
+
+@dataclass
+class WorkspaceEdit:
+    """Groups TextEdits across potentially multiple files.
+
+    For rename operations that affect a single file, ``changes`` will have
+    one key. For multi-file projects, a rename may produce edits across
+    many files.
+    """
+
+    changes: dict[str, list[TextEdit]] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# HoverResult — content for the hover popup
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class HoverResult:
+    """The content to show in the hover popup.
+
+    ``contents`` is Markdown text. VS Code renders it with syntax
+    highlighting, bold/italic, code blocks, etc. ``range`` is optional --
+    if set, it highlights the symbol in the editor when the hover popup
+    is shown.
+    """
+
+    contents: str  # Markdown
+    range: Range | None = None
+
+
+# ---------------------------------------------------------------------------
+# CompletionItemKind — icon classification for autocomplete
+# ---------------------------------------------------------------------------
+
+
+class CompletionItemKind(IntEnum):
+    """Classifies completion items so the editor can show the right icon.
+
+    Each value corresponds to a different icon in the autocomplete dropdown:
+    function icon, variable icon, keyword icon, etc.
+    """
+
+    TEXT = 1
+    METHOD = 2
+    FUNCTION = 3
+    CONSTRUCTOR = 4
+    FIELD = 5
+    VARIABLE = 6
+    CLASS = 7
+    INTERFACE = 8
+    MODULE = 9
+    PROPERTY = 10
+    UNIT = 11
+    VALUE = 12
+    ENUM = 13
+    KEYWORD = 14
+    SNIPPET = 15
+    COLOR = 16
+    FILE = 17
+    REFERENCE = 18
+    FOLDER = 19
+    ENUM_MEMBER = 20
+    CONSTANT = 21
+    STRUCT = 22
+    EVENT = 23
+    OPERATOR = 24
+    TYPE_PARAMETER = 25
+
+
+@dataclass
+class CompletionItem:
+    """A single autocomplete suggestion.
+
+    When the user triggers autocomplete (e.g., by pressing Ctrl+Space or
+    typing after a dot), the editor shows a dropdown list of CompletionItems.
+    """
+
+    label: str
+    kind: CompletionItemKind | None = None
+    detail: str = ""
+    documentation: str = ""
+    insert_text: str = ""
+    insert_text_format: int = 0  # 1=plain, 2=snippet
+
+
+# ---------------------------------------------------------------------------
+# SemanticToken — semantic highlighting data
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SemanticToken:
+    """One token's contribution to the semantic highlighting pass.
+
+    Semantic tokens are the "second pass" of syntax highlighting. The
+    editor's grammar-based highlighter (TextMate/tmLanguage) does a fast
+    regex pass first. Semantic tokens layer on top with accurate,
+    context-aware type information.
+
+    ``line`` and ``character`` are 0-based. ``token_type`` and ``modifiers``
+    reference entries in the legend returned by ``semantic_token_legend()``
+    (see capabilities.py).
+    """
+
+    line: int  # 0-based
+    character: int  # 0-based, UTF-16 code units
+    length: int  # in UTF-16 code units
+    token_type: str  # must match an entry in the legend's token_types
+    modifiers: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# SymbolKind — classification for the document outline panel
+# ---------------------------------------------------------------------------
+
+
+class SymbolKind(IntEnum):
+    """Classifies document symbols for the outline panel.
+
+    These match the LSP integer codes (1-based).
+    """
+
+    FILE = 1
+    MODULE = 2
+    NAMESPACE = 3
+    PACKAGE = 4
+    CLASS = 5
+    METHOD = 6
+    PROPERTY = 7
+    FIELD = 8
+    CONSTRUCTOR = 9
+    ENUM = 10
+    INTERFACE = 11
+    FUNCTION = 12
+    VARIABLE = 13
+    CONSTANT = 14
+    STRING = 15
+    NUMBER = 16
+    BOOLEAN = 17
+    ARRAY = 18
+    OBJECT = 19
+    KEY = 20
+    NULL = 21
+    ENUM_MEMBER = 22
+    STRUCT = 23
+    EVENT = 24
+    OPERATOR = 25
+    TYPE_PARAMETER = 26
+
+
+@dataclass
+class DocumentSymbol:
+    """One entry in the document outline panel.
+
+    The outline shows a tree of named symbols (functions, classes, variables).
+    ``children`` allows nesting: a class symbol can have method symbols as
+    children.
+
+    ``range`` covers the entire symbol (including its body).
+    ``selection_range`` is the smaller range of just the symbol's name
+    (used to highlight the name when the user clicks the outline entry).
+    """
+
+    name: str
+    kind: SymbolKind
+    range: Range
+    selection_range: Range
+    children: list[DocumentSymbol] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# FoldingRange — collapsible regions
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FoldingRange:
+    """A collapsible region of the document.
+
+    The editor shows a collapse arrow in the gutter next to ``start_line``.
+    When collapsed, lines ``start_line+1`` through ``end_line`` are hidden.
+    ``kind`` is one of ``"region"``, ``"imports"``, or ``"comment"``.
+    """
+
+    start_line: int  # 0-based
+    end_line: int  # 0-based
+    kind: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Signature help — function call tooltips
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ParameterInformation:
+    """One parameter in a function signature."""
+
+    label: str
+    documentation: str = ""
+
+
+@dataclass
+class SignatureInformation:
+    """One function overload's full signature."""
+
+    label: str
+    documentation: str = ""
+    parameters: list[ParameterInformation] = field(default_factory=list)
+
+
+@dataclass
+class SignatureHelpResult:
+    """Shown as a tooltip when the user is typing a function call.
+
+    It shows the function signature with the current parameter highlighted.
+    ``active_signature`` indexes into ``signatures``. ``active_parameter``
+    indexes into that signature's ``parameters``.
+
+    Example: typing ``foo(a, |`` (cursor after the comma) would show
+    ``signatures[0]`` with ``active_parameter=1`` (highlighting the second
+    parameter).
+    """
+
+    signatures: list[SignatureInformation] = field(default_factory=list)
+    active_signature: int = 0
+    active_parameter: int = 0

--- a/code/packages/python/ls00/tests/test_capabilities.py
+++ b/code/packages/python/ls00/tests/test_capabilities.py
@@ -1,0 +1,230 @@
+"""Tests for capability building and semantic token legend.
+
+These tests verify that:
+1. Minimal bridges only advertise textDocumentSync
+2. Full bridges advertise all implemented capabilities
+3. The semantic token legend contains required token types
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ls00 import (
+    CompletionItem,
+    Diagnostic,
+    DocumentSymbol,
+    FoldingRange,
+    HoverResult,
+    Location,
+    Position,
+    Range,
+    SemanticToken,
+    SignatureHelpResult,
+    SignatureInformation,
+    ParameterInformation,
+    SymbolKind,
+    TextEdit,
+    Token,
+    WorkspaceEdit,
+    build_capabilities,
+    semantic_token_legend,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test bridges
+# ---------------------------------------------------------------------------
+
+
+class MinimalBridge:
+    """Implements ONLY the required LanguageBridge protocol."""
+
+    def tokenize(self, source: str) -> list[Token]:
+        return []
+
+    def parse(self, source: str) -> tuple[Any, list[Diagnostic]]:
+        return source, []
+
+
+class MockBridge:
+    """Implements LanguageBridge + HoverProvider + DocumentSymbolsProvider."""
+
+    def tokenize(self, source: str) -> list[Token]:
+        return []
+
+    def parse(self, source: str) -> tuple[Any, list[Diagnostic]]:
+        return source, []
+
+    def hover(self, ast: Any, pos: Position) -> HoverResult | None:
+        return HoverResult(contents="test hover")
+
+    def document_symbols(self, ast: Any) -> list[DocumentSymbol]:
+        return [DocumentSymbol(
+            name="main",
+            kind=SymbolKind.FUNCTION,
+            range=Range(Position(0, 0), Position(10, 1)),
+            selection_range=Range(Position(0, 9), Position(0, 13)),
+        )]
+
+
+class FullMockBridge:
+    """Implements all optional provider interfaces."""
+
+    def tokenize(self, source: str) -> list[Token]:
+        return []
+
+    def parse(self, source: str) -> tuple[Any, list[Diagnostic]]:
+        return source, []
+
+    def hover(self, ast: Any, pos: Position) -> HoverResult | None:
+        return HoverResult(contents="test hover")
+
+    def definition(self, ast: Any, pos: Position, uri: str) -> Location | None:
+        return Location(uri=uri, range=Range(start=pos, end=pos))
+
+    def references(
+        self, ast: Any, pos: Position, uri: str, include_decl: bool
+    ) -> list[Location]:
+        return [Location(uri=uri, range=Range(start=pos, end=pos))]
+
+    def completion(self, ast: Any, pos: Position) -> list[CompletionItem]:
+        return [CompletionItem(label="foo")]
+
+    def rename(
+        self, ast: Any, pos: Position, new_name: str
+    ) -> WorkspaceEdit | None:
+        return WorkspaceEdit(changes={
+            "file:///test.txt": [TextEdit(
+                range=Range(start=pos, end=pos),
+                new_text=new_name,
+            )],
+        })
+
+    def semantic_tokens(
+        self, source: str, tokens: list[Token]
+    ) -> list[SemanticToken]:
+        return []
+
+    def document_symbols(self, ast: Any) -> list[DocumentSymbol]:
+        return []
+
+    def folding_ranges(self, ast: Any) -> list[FoldingRange]:
+        return [FoldingRange(start_line=0, end_line=5, kind="region")]
+
+    def signature_help(
+        self, ast: Any, pos: Position
+    ) -> SignatureHelpResult | None:
+        return SignatureHelpResult(
+            signatures=[SignatureInformation(
+                label="foo(a int, b string)",
+                parameters=[
+                    ParameterInformation(label="a int"),
+                    ParameterInformation(label="b string"),
+                ],
+            )],
+        )
+
+    def format(self, source: str) -> list[TextEdit]:
+        return [TextEdit(
+            range=Range(Position(0, 0), Position(999, 0)),
+            new_text=source,
+        )]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCapabilitiesMinimal:
+    """Minimal bridge should only advertise textDocumentSync."""
+
+    def test_text_document_sync_always_present(self) -> None:
+        bridge = MinimalBridge()
+        caps = build_capabilities(bridge)
+        assert caps["textDocumentSync"] == 2
+
+    def test_optional_capabilities_absent(self) -> None:
+        """Optional capabilities should NOT be present for a minimal bridge."""
+        bridge = MinimalBridge()
+        caps = build_capabilities(bridge)
+
+        optional = [
+            "hoverProvider",
+            "definitionProvider",
+            "referencesProvider",
+            "completionProvider",
+            "renameProvider",
+            "documentSymbolProvider",
+            "foldingRangeProvider",
+            "signatureHelpProvider",
+            "documentFormattingProvider",
+            "semanticTokensProvider",
+        ]
+        for cap in optional:
+            assert cap not in caps, f"minimal bridge should not advertise {cap}"
+
+
+class TestBuildCapabilitiesFullBridge:
+    """Full bridge should advertise all implemented capabilities."""
+
+    def test_hover_provider_present(self) -> None:
+        bridge = MockBridge()
+        caps = build_capabilities(bridge)
+        assert caps.get("hoverProvider") is True
+
+    def test_document_symbol_provider_present(self) -> None:
+        bridge = MockBridge()
+        caps = build_capabilities(bridge)
+        assert caps.get("documentSymbolProvider") is True
+
+    def test_semantic_tokens_not_present_for_mock(self) -> None:
+        """MockBridge doesn't implement SemanticTokensProvider."""
+        bridge = MockBridge()
+        caps = build_capabilities(bridge)
+        assert "semanticTokensProvider" not in caps
+
+    def test_semantic_tokens_present_for_full(self) -> None:
+        """FullMockBridge implements SemanticTokensProvider."""
+        bridge = FullMockBridge()
+        caps = build_capabilities(bridge)
+        assert "semanticTokensProvider" in caps
+        st = caps["semanticTokensProvider"]
+        assert st["full"] is True
+
+    def test_all_capabilities_for_full_bridge(self) -> None:
+        """FullMockBridge should advertise all capabilities."""
+        bridge = FullMockBridge()
+        caps = build_capabilities(bridge)
+
+        expected = [
+            "textDocumentSync",
+            "hoverProvider",
+            "definitionProvider",
+            "referencesProvider",
+            "completionProvider",
+            "renameProvider",
+            "documentSymbolProvider",
+            "foldingRangeProvider",
+            "signatureHelpProvider",
+            "documentFormattingProvider",
+            "semanticTokensProvider",
+        ]
+        for cap in expected:
+            assert cap in caps, f"expected capability {cap} for full bridge"
+
+
+class TestSemanticTokenLegend:
+    """Verify the legend contains required token types."""
+
+    def test_non_empty(self) -> None:
+        legend = semantic_token_legend()
+        assert len(legend["tokenTypes"]) > 0
+        assert len(legend["tokenModifiers"]) > 0
+
+    def test_required_types_present(self) -> None:
+        legend = semantic_token_legend()
+        required = ["keyword", "string", "number", "variable", "function"]
+        for rt in required:
+            assert rt in legend["tokenTypes"], f"legend missing required type {rt}"

--- a/code/packages/python/ls00/tests/test_document_manager.py
+++ b/code/packages/python/ls00/tests/test_document_manager.py
@@ -1,0 +1,146 @@
+"""Tests for DocumentManager — open, change, close operations.
+
+The DocumentManager is the core state manager for open files. These tests
+verify that documents are tracked correctly through their lifecycle:
+open -> apply changes -> close.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ls00 import DocumentManager, TextChange, Position, Range
+
+
+class TestDocumentManagerOpen:
+    """Tests for opening and retrieving documents."""
+
+    def test_open_and_get(self) -> None:
+        """Opening a document makes it retrievable via get()."""
+        dm = DocumentManager()
+        dm.open("file:///test.txt", "hello world", 1)
+
+        doc = dm.get("file:///test.txt")
+        assert doc is not None
+        assert doc.text == "hello world"
+        assert doc.version == 1
+
+    def test_get_missing_returns_none(self) -> None:
+        """Getting a non-open document returns None."""
+        dm = DocumentManager()
+        assert dm.get("file:///nonexistent.txt") is None
+
+
+class TestDocumentManagerClose:
+    """Tests for closing documents."""
+
+    def test_close_removes_document(self) -> None:
+        """Closing a document makes it no longer retrievable."""
+        dm = DocumentManager()
+        dm.open("file:///test.txt", "hello", 1)
+        dm.close("file:///test.txt")
+
+        assert dm.get("file:///test.txt") is None
+
+    def test_close_nonexistent_is_safe(self) -> None:
+        """Closing a document that was never opened does not raise."""
+        dm = DocumentManager()
+        dm.close("file:///never-opened.txt")  # should not raise
+
+
+class TestDocumentManagerApplyChanges:
+    """Tests for applying incremental and full changes."""
+
+    def test_full_replacement(self) -> None:
+        """A change with range=None replaces the entire document."""
+        dm = DocumentManager()
+        dm.open("file:///test.txt", "hello world", 1)
+
+        dm.apply_changes(
+            "file:///test.txt",
+            [TextChange(range=None, new_text="goodbye world")],
+            2,
+        )
+
+        doc = dm.get("file:///test.txt")
+        assert doc is not None
+        assert doc.text == "goodbye world"
+        assert doc.version == 2
+
+    def test_incremental_change(self) -> None:
+        """A change with a range replaces only that range."""
+        dm = DocumentManager()
+        dm.open("file:///test.txt", "hello world", 1)
+
+        # Replace "world" (chars 6-11) with "Go"
+        dm.apply_changes(
+            "file:///test.txt",
+            [TextChange(
+                range=Range(
+                    start=Position(line=0, character=6),
+                    end=Position(line=0, character=11),
+                ),
+                new_text="Go",
+            )],
+            2,
+        )
+
+        doc = dm.get("file:///test.txt")
+        assert doc is not None
+        assert doc.text == "hello Go"
+
+    def test_apply_changes_not_open_raises(self) -> None:
+        """Applying changes to a non-open document raises KeyError."""
+        dm = DocumentManager()
+        with pytest.raises(KeyError):
+            dm.apply_changes(
+                "file:///notopen.txt",
+                [TextChange(range=None, new_text="x")],
+                1,
+            )
+
+    def test_incremental_with_emoji(self) -> None:
+        """Incremental change works correctly with emoji (UTF-16 surrogate pairs).
+
+        "A guitar B" -- emoji is 4 UTF-8 bytes, 2 UTF-16 code units.
+        Replace "B" (UTF-16 char 3) with "X".
+        """
+        dm = DocumentManager()
+        dm.open("file:///test.txt", "A\U0001F3B8B", 1)
+
+        dm.apply_changes(
+            "file:///test.txt",
+            [TextChange(
+                range=Range(
+                    start=Position(line=0, character=3),
+                    end=Position(line=0, character=4),
+                ),
+                new_text="X",
+            )],
+            2,
+        )
+
+        doc = dm.get("file:///test.txt")
+        assert doc is not None
+        assert doc.text == "A\U0001F3B8X"
+
+    def test_incremental_multi_change(self) -> None:
+        """Multiple incremental changes applied in sequence."""
+        dm = DocumentManager()
+        dm.open("uri", "hello world", 1)
+
+        dm.apply_changes(
+            "uri",
+            [TextChange(
+                range=Range(
+                    start=Position(0, 0),
+                    end=Position(0, 5),
+                ),
+                new_text="hi",
+            )],
+            2,
+        )
+
+        doc = dm.get("uri")
+        assert doc is not None
+        assert doc.text == "hi world"

--- a/code/packages/python/ls00/tests/test_parse_cache.py
+++ b/code/packages/python/ls00/tests/test_parse_cache.py
@@ -1,0 +1,85 @@
+"""Tests for ParseCache — cache hit/miss behavior.
+
+The ParseCache avoids re-parsing unchanged documents. These tests verify
+the (uri, version) keyed caching, eviction, and diagnostic propagation.
+"""
+
+from __future__ import annotations
+
+from ls00 import ParseCache, Diagnostic, DiagnosticSeverity, Position, Range
+from ls00.language_bridge import LanguageBridge
+from ls00.types import Token
+from typing import Any
+
+
+class _MockBridge:
+    """Minimal bridge for testing the parse cache."""
+
+    def tokenize(self, source: str) -> list[Token]:
+        return []
+
+    def parse(self, source: str) -> tuple[Any, list[Diagnostic]]:
+        diags: list[Diagnostic] = []
+        if "ERROR" in source:
+            diags.append(Diagnostic(
+                range=Range(
+                    start=Position(line=0, character=0),
+                    end=Position(line=0, character=5),
+                ),
+                severity=DiagnosticSeverity.ERROR,
+                message="syntax error",
+            ))
+        return source, diags
+
+
+class TestParseCacheHitAndMiss:
+    """Tests for cache hit and miss behavior."""
+
+    def test_cache_miss_then_hit(self) -> None:
+        """First call is a miss (parses), second call with same version is a hit."""
+        bridge = _MockBridge()
+        cache = ParseCache()
+
+        r1 = cache.get_or_parse("file:///a.txt", 1, "hello", bridge)
+        assert r1 is not None
+
+        r2 = cache.get_or_parse("file:///a.txt", 1, "hello", bridge)
+        assert r1 is r2  # same object = cache hit
+
+    def test_different_version_is_miss(self) -> None:
+        """Different version produces a new parse result."""
+        bridge = _MockBridge()
+        cache = ParseCache()
+
+        r1 = cache.get_or_parse("file:///a.txt", 1, "hello", bridge)
+        r3 = cache.get_or_parse("file:///a.txt", 2, "hello world", bridge)
+        assert r3 is not r1
+
+    def test_evict_forces_reparse(self) -> None:
+        """After eviction, same (uri, version) produces a new parse."""
+        bridge = _MockBridge()
+        cache = ParseCache()
+
+        r1 = cache.get_or_parse("file:///a.txt", 1, "hello", bridge)
+        cache.evict("file:///a.txt")
+
+        r2 = cache.get_or_parse("file:///a.txt", 1, "hello", bridge)
+        assert r1 is not r2
+
+    def test_diagnostics_populated_for_error_source(self) -> None:
+        """Source containing 'ERROR' produces diagnostics."""
+        bridge = _MockBridge()
+        cache = ParseCache()
+
+        result = cache.get_or_parse(
+            "file:///a.txt", 1, "source with ERROR token", bridge
+        )
+        assert len(result.diagnostics) > 0
+
+    def test_no_diagnostics_for_clean_source(self) -> None:
+        """Clean source produces no diagnostics."""
+        bridge = _MockBridge()
+        cache = ParseCache()
+
+        result = cache.get_or_parse("file:///clean.txt", 1, "hello world", bridge)
+        assert len(result.diagnostics) == 0

--- a/code/packages/python/ls00/tests/test_semantic_tokens.py
+++ b/code/packages/python/ls00/tests/test_semantic_tokens.py
@@ -1,0 +1,128 @@
+"""Tests for semantic token encoding.
+
+The semantic token encoding is the compact 5-tuple integer format used by
+LSP to transmit token data. These tests verify:
+- Empty input produces empty output
+- Single token encoding
+- Multi-token same-line delta encoding
+- Multi-line delta encoding
+- Unsorted input is sorted before encoding
+- Unknown token types are skipped
+- Modifier bitmask encoding
+"""
+
+from __future__ import annotations
+
+from ls00 import SemanticToken, encode_semantic_tokens
+
+
+class TestEncodeSemanticTokensEmpty:
+    """Empty or None input should produce empty output."""
+
+    def test_empty_list(self) -> None:
+        data = encode_semantic_tokens([])
+        assert data == []
+
+
+class TestEncodeSemanticTokensSingle:
+    """A single token should produce one 5-tuple."""
+
+    def test_keyword_at_origin(self) -> None:
+        """keyword is at index 15 in the legend."""
+        tokens = [
+            SemanticToken(
+                line=0, character=0, length=5,
+                token_type="keyword", modifiers=[],
+            ),
+        ]
+        data = encode_semantic_tokens(tokens)
+
+        assert len(data) == 5
+        assert data[0] == 0   # deltaLine
+        assert data[1] == 0   # deltaChar
+        assert data[2] == 5   # length
+        assert data[3] == 15  # tokenTypeIndex (keyword)
+        assert data[4] == 0   # modifiers
+
+
+class TestEncodeSemanticTokensMultipleSameLine:
+    """Two tokens on the same line: deltaChar is relative."""
+
+    def test_keyword_then_function(self) -> None:
+        tokens = [
+            SemanticToken(line=0, character=0, length=3, token_type="keyword"),
+            SemanticToken(
+                line=0, character=4, length=4,
+                token_type="function", modifiers=["declaration"],
+            ),
+        ]
+        data = encode_semantic_tokens(tokens)
+
+        assert len(data) == 10
+
+        # Token A: deltaLine=0, deltaChar=0, length=3, keyword(15), mods=0
+        assert data[:5] == [0, 0, 3, 15, 0]
+        # Token B: deltaLine=0, deltaChar=4, length=4, function(12), mods=1
+        assert data[5:] == [0, 4, 4, 12, 1]
+
+
+class TestEncodeSemanticTokensMultipleLines:
+    """Tokens on different lines: deltaChar is absolute on new line."""
+
+    def test_keyword_line0_number_line2(self) -> None:
+        tokens = [
+            SemanticToken(line=0, character=0, length=3, token_type="keyword"),
+            SemanticToken(line=2, character=4, length=5, token_type="number"),
+        ]
+        data = encode_semantic_tokens(tokens)
+
+        assert len(data) == 10
+        # Token B: deltaLine=2, deltaChar=4 (absolute), number=19
+        assert data[5] == 2   # deltaLine
+        assert data[6] == 4   # deltaChar
+        assert data[8] == 19  # number
+
+
+class TestEncodeSemanticTokensUnsortedInput:
+    """Tokens in reverse order should be sorted before encoding."""
+
+    def test_reverse_order_sorted(self) -> None:
+        tokens = [
+            SemanticToken(line=1, character=0, length=2, token_type="number"),
+            SemanticToken(line=0, character=0, length=3, token_type="keyword"),
+        ]
+        data = encode_semantic_tokens(tokens)
+
+        assert len(data) == 10
+        # After sorting: keyword (line 0) first, number (line 1) second
+        assert data[3] == 15  # keyword
+        assert data[8] == 19  # number
+
+
+class TestEncodeSemanticTokensUnknownType:
+    """Unknown token types should be skipped."""
+
+    def test_skip_unknown_keep_known(self) -> None:
+        tokens = [
+            SemanticToken(line=0, character=0, length=3, token_type="unknownType"),
+            SemanticToken(line=0, character=4, length=2, token_type="keyword"),
+        ]
+        data = encode_semantic_tokens(tokens)
+
+        # unknownType skipped, only keyword remains
+        assert len(data) == 5
+
+
+class TestEncodeSemanticTokensModifierBitmask:
+    """Modifier bitmask encoding."""
+
+    def test_readonly_bitmask(self) -> None:
+        """'readonly' is bit 2 (index 2 in modifier list), value = 4."""
+        tokens = [
+            SemanticToken(
+                line=0, character=0, length=3,
+                token_type="variable", modifiers=["readonly"],
+            ),
+        ]
+        data = encode_semantic_tokens(tokens)
+        assert data[4] == 4  # readonly = bit 2 = value 4

--- a/code/packages/python/ls00/tests/test_server.py
+++ b/code/packages/python/ls00/tests/test_server.py
@@ -1,0 +1,725 @@
+"""Tests for the LspServer — lifecycle, handlers, and JSON-RPC round-trips.
+
+These tests feed JSON-RPC messages through the full pipeline using io pipes.
+The server runs in a thread; the test feeds messages and reads responses.
+
+We use threading + pipes because the server blocks in serve() waiting for
+input. A pipe provides the blocking reads the server expects.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import threading
+from typing import Any
+
+import pytest
+
+from json_rpc import (
+    MessageReader,
+    MessageWriter,
+    Notification,
+    Request,
+    Response,
+)
+from ls00 import (
+    CompletionItem,
+    CompletionItemKind,
+    Diagnostic,
+    DiagnosticSeverity,
+    DocumentSymbol,
+    FoldingRange,
+    HoverResult,
+    Location,
+    LspServer,
+    ParseCache,
+    Position,
+    Range,
+    SemanticToken,
+    SignatureHelpResult,
+    SignatureInformation,
+    ParameterInformation,
+    SymbolKind,
+    TextEdit,
+    Token,
+    WorkspaceEdit,
+    build_capabilities,
+    SERVER_NOT_INITIALIZED,
+    UNKNOWN_ERROR_CODE,
+    REQUEST_FAILED,
+    SERVER_CANCELLED,
+    CONTENT_MODIFIED,
+    REQUEST_CANCELLED,
+)
+
+
+# ---------------------------------------------------------------------------
+# Mock Bridges
+# ---------------------------------------------------------------------------
+
+
+class MockBridge:
+    """Test bridge with HoverProvider + DocumentSymbolsProvider."""
+
+    def __init__(self, hover_result: HoverResult | None = None) -> None:
+        self.hover_result = hover_result
+
+    def tokenize(self, source: str) -> list[Token]:
+        tokens: list[Token] = []
+        col = 1
+        for word in source.split():
+            tokens.append(Token(type="WORD", value=word, line=1, column=col))
+            col += len(word) + 1
+        return tokens
+
+    def parse(self, source: str) -> tuple[Any, list[Diagnostic]]:
+        diags: list[Diagnostic] = []
+        if "ERROR" in source:
+            diags.append(Diagnostic(
+                range=Range(
+                    start=Position(line=0, character=0),
+                    end=Position(line=0, character=5),
+                ),
+                severity=DiagnosticSeverity.ERROR,
+                message="syntax error: unexpected ERROR token",
+            ))
+        return source, diags
+
+    def hover(self, ast: Any, pos: Position) -> HoverResult | None:
+        return self.hover_result
+
+    def document_symbols(self, ast: Any) -> list[DocumentSymbol]:
+        return [DocumentSymbol(
+            name="main",
+            kind=SymbolKind.FUNCTION,
+            range=Range(Position(0, 0), Position(10, 1)),
+            selection_range=Range(Position(0, 9), Position(0, 13)),
+            children=[DocumentSymbol(
+                name="x",
+                kind=SymbolKind.VARIABLE,
+                range=Range(Position(1, 4), Position(1, 12)),
+                selection_range=Range(Position(1, 8), Position(1, 9)),
+            )],
+        )]
+
+
+class MinimalBridge:
+    """Implements ONLY the required LanguageBridge protocol."""
+
+    def tokenize(self, source: str) -> list[Token]:
+        return []
+
+    def parse(self, source: str) -> tuple[Any, list[Diagnostic]]:
+        return source, []
+
+
+class FullMockBridge(MockBridge):
+    """Extends MockBridge with ALL optional provider interfaces."""
+
+    def semantic_tokens(
+        self, source: str, tokens: list[Token]
+    ) -> list[SemanticToken]:
+        result: list[SemanticToken] = []
+        for tok in tokens:
+            result.append(SemanticToken(
+                line=tok.line - 1,
+                character=tok.column - 1,
+                length=len(tok.value),
+                token_type="variable",
+            ))
+        return result
+
+    def definition(self, ast: Any, pos: Position, uri: str) -> Location | None:
+        return Location(uri=uri, range=Range(start=pos, end=pos))
+
+    def references(
+        self, ast: Any, pos: Position, uri: str, include_decl: bool
+    ) -> list[Location]:
+        return [Location(uri=uri, range=Range(start=pos, end=pos))]
+
+    def completion(self, ast: Any, pos: Position) -> list[CompletionItem]:
+        return [CompletionItem(
+            label="foo",
+            kind=CompletionItemKind.FUNCTION,
+            detail="() void",
+        )]
+
+    def rename(
+        self, ast: Any, pos: Position, new_name: str
+    ) -> WorkspaceEdit | None:
+        return WorkspaceEdit(changes={
+            "file:///test.txt": [TextEdit(
+                range=Range(start=pos, end=pos),
+                new_text=new_name,
+            )],
+        })
+
+    def folding_ranges(self, ast: Any) -> list[FoldingRange]:
+        return [FoldingRange(start_line=0, end_line=5, kind="region")]
+
+    def signature_help(
+        self, ast: Any, pos: Position
+    ) -> SignatureHelpResult | None:
+        return SignatureHelpResult(
+            signatures=[SignatureInformation(
+                label="foo(a int, b string)",
+                parameters=[
+                    ParameterInformation(label="a int"),
+                    ParameterInformation(label="b string"),
+                ],
+            )],
+        )
+
+    def format(self, source: str) -> list[TextEdit]:
+        return [TextEdit(
+            range=Range(Position(0, 0), Position(999, 0)),
+            new_text=source,
+        )]
+
+
+# ---------------------------------------------------------------------------
+# Pipe-based test server utilities
+# ---------------------------------------------------------------------------
+
+
+class _PipeServer:
+    """Wraps an LspServer with pipe-based IO for testing.
+
+    The server runs in a background thread. The test writes messages via
+    ``client_writer`` and reads responses via ``client_reader``.
+    """
+
+    def __init__(self, bridge: Any) -> None:
+        # Use os-level pipes for proper blocking behavior.
+        # We use BytesIO-backed wrappers via threading for simplicity.
+        import os
+
+        # Client -> Server pipe
+        self._in_r_fd, self._in_w_fd = os.pipe()
+        # Server -> Client pipe
+        self._out_r_fd, self._out_w_fd = os.pipe()
+
+        in_r = os.fdopen(self._in_r_fd, "rb")
+        in_w = os.fdopen(self._in_w_fd, "wb")
+        out_r = os.fdopen(self._out_r_fd, "rb")
+        out_w = os.fdopen(self._out_w_fd, "wb")
+
+        self._in_w = in_w
+        self._out_r = out_r
+
+        self.server = LspServer(bridge, in_r, out_w)
+        self.client_writer = MessageWriter(in_w)
+        self.client_reader = MessageReader(out_r)
+
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def _run(self) -> None:
+        try:
+            self.server.serve()
+        except Exception:
+            pass
+
+    def close(self) -> None:
+        """Close the write pipe to trigger server EOF."""
+        try:
+            self._in_w.close()
+        except Exception:
+            pass
+
+
+def _send_request(
+    ps: _PipeServer, req_id: int, method: str, params: Any
+) -> dict[str, Any] | None:
+    """Send a request and read the response."""
+    ps.client_writer.write_message(Request(id=req_id, method=method, params=params))
+
+    msg = ps.client_reader.read_message()
+    if msg is None:
+        return None
+    assert isinstance(msg, Response)
+    assert msg.id == req_id
+
+    if msg.error is not None:
+        return {"__error": {"code": msg.error.code, "message": msg.error.message}}
+
+    if msg.result is None:
+        return None
+
+    if isinstance(msg.result, dict):
+        return msg.result
+
+    return {"__result": msg.result}
+
+
+def _send_notif(ps: _PipeServer, method: str, params: Any) -> None:
+    """Send a notification (no response expected)."""
+    ps.client_writer.write_message(Notification(method=method, params=params))
+
+
+def _read_notif(ps: _PipeServer) -> Notification:
+    """Read the next message, expecting a notification."""
+    msg = ps.client_reader.read_message()
+    assert msg is not None
+    assert isinstance(msg, Notification)
+    return msg
+
+
+def _init_server(ps: _PipeServer) -> dict[str, Any] | None:
+    """Perform the initialize/initialized handshake."""
+    result = _send_request(ps, 1, "initialize", {
+        "processId": 1234,
+        "capabilities": {},
+    })
+    _send_notif(ps, "initialized", {})
+    return result
+
+
+def _open_doc(
+    ps: _PipeServer, uri: str, text: str, version: int = 1
+) -> Notification:
+    """Open a document and consume the publishDiagnostics notification."""
+    _send_notif(ps, "textDocument/didOpen", {
+        "textDocument": {
+            "uri": uri,
+            "languageId": "test",
+            "version": version,
+            "text": text,
+        },
+    })
+    return _read_notif(ps)  # consume publishDiagnostics
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestLSPErrorCodes:
+    """Verify the error code constants match the LSP specification."""
+
+    def test_server_not_initialized(self) -> None:
+        assert SERVER_NOT_INITIALIZED == -32002
+
+    def test_unknown_error_code(self) -> None:
+        assert UNKNOWN_ERROR_CODE == -32001
+
+    def test_request_failed(self) -> None:
+        assert REQUEST_FAILED == -32803
+
+    def test_server_cancelled(self) -> None:
+        assert SERVER_CANCELLED == -32802
+
+    def test_content_modified(self) -> None:
+        assert CONTENT_MODIFIED == -32801
+
+    def test_request_cancelled(self) -> None:
+        assert REQUEST_CANCELLED == -32800
+
+
+class TestNewLspServer:
+    """Verify the constructor returns a usable server."""
+
+    def test_creates_server(self) -> None:
+        bridge = MockBridge()
+        server = LspServer(bridge, io.BytesIO(), io.BytesIO())
+        assert server is not None
+
+
+class TestHandlerInitialize:
+    """Test the initialize handler via full JSON-RPC pipeline."""
+
+    def test_returns_capabilities(self) -> None:
+        bridge = MockBridge(hover_result=HoverResult(contents="test"))
+        ps = _PipeServer(bridge)
+        try:
+            result = _init_server(ps)
+            assert result is not None
+            caps = result["capabilities"]
+            assert caps["textDocumentSync"] == 2
+            assert caps["hoverProvider"] is True
+            assert caps["documentSymbolProvider"] is True
+
+            server_info = result["serverInfo"]
+            assert server_info["name"] == "ls00-generic-lsp-server"
+        finally:
+            ps.close()
+
+
+class TestHandlerDidOpenPublishesDiagnostics:
+    """Test that opening a file pushes diagnostics."""
+
+    def test_error_source_has_diagnostics(self) -> None:
+        bridge = MockBridge()
+        ps = _PipeServer(bridge)
+        try:
+            _init_server(ps)
+
+            _send_notif(ps, "textDocument/didOpen", {
+                "textDocument": {
+                    "uri": "file:///test.txt",
+                    "languageId": "test",
+                    "version": 1,
+                    "text": "hello ERROR world",
+                },
+            })
+
+            notif = _read_notif(ps)
+            assert notif.method == "textDocument/publishDiagnostics"
+            params = notif.params
+            assert params["uri"] == "file:///test.txt"
+            diags = params["diagnostics"]
+            assert len(diags) > 0
+        finally:
+            ps.close()
+
+    def test_clean_source_has_empty_diagnostics(self) -> None:
+        bridge = MockBridge()
+        ps = _PipeServer(bridge)
+        try:
+            _init_server(ps)
+
+            _send_notif(ps, "textDocument/didOpen", {
+                "textDocument": {
+                    "uri": "file:///clean.txt",
+                    "languageId": "test",
+                    "version": 1,
+                    "text": "hello world",
+                },
+            })
+
+            notif = _read_notif(ps)
+            assert notif.method == "textDocument/publishDiagnostics"
+            params = notif.params
+            diags = params["diagnostics"]
+            assert len(diags) == 0
+        finally:
+            ps.close()
+
+
+class TestHandlerHover:
+    """Test the hover handler end-to-end."""
+
+    def test_hover_with_result(self) -> None:
+        bridge = MockBridge(hover_result=HoverResult(
+            contents="**main** function",
+            range=Range(Position(0, 0), Position(0, 4)),
+        ))
+        ps = _PipeServer(bridge)
+        try:
+            _init_server(ps)
+            _open_doc(ps, "file:///test.go", "func main() {}")
+
+            result = _send_request(ps, 2, "textDocument/hover", {
+                "textDocument": {"uri": "file:///test.go"},
+                "position": {"line": 0, "character": 5},
+            })
+
+            assert result is not None
+            contents = result["contents"]
+            assert contents["kind"] == "markdown"
+            assert contents["value"] == "**main** function"
+        finally:
+            ps.close()
+
+    def test_hover_no_bridge(self) -> None:
+        """Minimal bridge returns null hover."""
+        bridge = MinimalBridge()
+        ps = _PipeServer(bridge)
+        try:
+            _init_server(ps)
+            _open_doc(ps, "file:///test.txt", "hello")
+
+            result = _send_request(ps, 2, "textDocument/hover", {
+                "textDocument": {"uri": "file:///test.txt"},
+                "position": {"line": 0, "character": 0},
+            })
+
+            assert result is None
+        finally:
+            ps.close()
+
+
+class TestHandlerDocumentSymbol:
+    """Test the documentSymbol handler."""
+
+    def test_returns_symbols(self) -> None:
+        bridge = MockBridge()
+        ps = _PipeServer(bridge)
+        try:
+            _init_server(ps)
+            _open_doc(ps, "file:///test.go", "func main() { var x = 1 }")
+
+            result = _send_request(ps, 2, "textDocument/documentSymbol", {
+                "textDocument": {"uri": "file:///test.go"},
+            })
+
+            assert result is not None
+            arr = result["__result"]
+            assert len(arr) > 0
+            assert arr[0]["name"] == "main"
+        finally:
+            ps.close()
+
+
+class TestHandlerSemanticTokensFull:
+    """Test the semanticTokens/full handler."""
+
+    def test_returns_data(self) -> None:
+        bridge = FullMockBridge()
+        ps = _PipeServer(bridge)
+        try:
+            _init_server(ps)
+            _open_doc(ps, "file:///test.txt", "hello world")
+
+            result = _send_request(ps, 2, "textDocument/semanticTokens/full", {
+                "textDocument": {"uri": "file:///test.txt"},
+            })
+
+            assert result is not None
+            assert "data" in result
+        finally:
+            ps.close()
+
+
+class TestHandlerDefinition:
+    """Test the definition handler."""
+
+    def test_returns_location(self) -> None:
+        bridge = FullMockBridge()
+        ps = _PipeServer(bridge)
+        try:
+            _init_server(ps)
+            _open_doc(ps, "file:///test.txt", "hello world")
+
+            result = _send_request(ps, 2, "textDocument/definition", {
+                "textDocument": {"uri": "file:///test.txt"},
+                "position": {"line": 0, "character": 0},
+            })
+
+            assert result is not None
+            assert result["uri"] == "file:///test.txt"
+        finally:
+            ps.close()
+
+
+class TestHandlerReferences:
+    """Test the references handler."""
+
+    def test_returns_locations(self) -> None:
+        bridge = FullMockBridge()
+        ps = _PipeServer(bridge)
+        try:
+            _init_server(ps)
+            _open_doc(ps, "file:///test.txt", "hello")
+
+            result = _send_request(ps, 2, "textDocument/references", {
+                "textDocument": {"uri": "file:///test.txt"},
+                "position": {"line": 0, "character": 0},
+                "context": {"includeDeclaration": True},
+            })
+
+            assert result is not None
+            arr = result["__result"]
+            assert len(arr) > 0
+        finally:
+            ps.close()
+
+
+class TestHandlerCompletion:
+    """Test the completion handler."""
+
+    def test_returns_items(self) -> None:
+        bridge = FullMockBridge()
+        ps = _PipeServer(bridge)
+        try:
+            _init_server(ps)
+            _open_doc(ps, "file:///test.txt", "foo")
+
+            result = _send_request(ps, 2, "textDocument/completion", {
+                "textDocument": {"uri": "file:///test.txt"},
+                "position": {"line": 0, "character": 3},
+            })
+
+            assert result is not None
+            items = result["items"]
+            assert len(items) > 0
+        finally:
+            ps.close()
+
+
+class TestHandlerRename:
+    """Test the rename handler."""
+
+    def test_returns_changes(self) -> None:
+        bridge = FullMockBridge()
+        ps = _PipeServer(bridge)
+        try:
+            _init_server(ps)
+            _open_doc(ps, "file:///test.txt", "let x = 1")
+
+            result = _send_request(ps, 2, "textDocument/rename", {
+                "textDocument": {"uri": "file:///test.txt"},
+                "position": {"line": 0, "character": 4},
+                "newName": "y",
+            })
+
+            assert result is not None
+            assert result["changes"] is not None
+        finally:
+            ps.close()
+
+
+class TestHandlerFoldingRange:
+    """Test the foldingRange handler."""
+
+    def test_returns_ranges(self) -> None:
+        bridge = FullMockBridge()
+        ps = _PipeServer(bridge)
+        try:
+            _init_server(ps)
+            _open_doc(ps, "file:///test.txt", "func main() {\n  hello\n}")
+
+            result = _send_request(ps, 2, "textDocument/foldingRange", {
+                "textDocument": {"uri": "file:///test.txt"},
+            })
+
+            assert result is not None
+            arr = result["__result"]
+            assert len(arr) > 0
+        finally:
+            ps.close()
+
+
+class TestHandlerSignatureHelp:
+    """Test the signatureHelp handler."""
+
+    def test_returns_signatures(self) -> None:
+        bridge = FullMockBridge()
+        ps = _PipeServer(bridge)
+        try:
+            _init_server(ps)
+            _open_doc(ps, "file:///test.txt", "foo(")
+
+            result = _send_request(ps, 2, "textDocument/signatureHelp", {
+                "textDocument": {"uri": "file:///test.txt"},
+                "position": {"line": 0, "character": 4},
+            })
+
+            assert result is not None
+            sigs = result["signatures"]
+            assert len(sigs) > 0
+        finally:
+            ps.close()
+
+
+class TestHandlerFormatting:
+    """Test the formatting handler."""
+
+    def test_returns_edits(self) -> None:
+        bridge = FullMockBridge()
+        ps = _PipeServer(bridge)
+        try:
+            _init_server(ps)
+            _open_doc(ps, "file:///test.txt", "hello  world")
+
+            result = _send_request(ps, 2, "textDocument/formatting", {
+                "textDocument": {"uri": "file:///test.txt"},
+                "options": {"tabSize": 2, "insertSpaces": True},
+            })
+
+            assert result is not None
+            arr = result["__result"]
+            assert len(arr) > 0
+        finally:
+            ps.close()
+
+
+class TestHandlerDidChange:
+    """Test that didChange updates the document and pushes diagnostics."""
+
+    def test_change_triggers_diagnostics(self) -> None:
+        bridge = MockBridge()
+        ps = _PipeServer(bridge)
+        try:
+            _init_server(ps)
+            _open_doc(ps, "file:///test.txt", "hello world")
+
+            # Change document to add ERROR
+            _send_notif(ps, "textDocument/didChange", {
+                "textDocument": {"uri": "file:///test.txt", "version": 2},
+                "contentChanges": [{"text": "hello ERROR world"}],
+            })
+
+            notif = _read_notif(ps)
+            assert notif.method == "textDocument/publishDiagnostics"
+            params = notif.params
+            diags = params["diagnostics"]
+            assert len(diags) > 0
+        finally:
+            ps.close()
+
+
+class TestHandlerDidClose:
+    """Test that didClose clears diagnostics."""
+
+    def test_close_clears_diagnostics(self) -> None:
+        bridge = MockBridge()
+        ps = _PipeServer(bridge)
+        try:
+            _init_server(ps)
+            _open_doc(ps, "file:///test.txt", "hello")
+
+            _send_notif(ps, "textDocument/didClose", {
+                "textDocument": {"uri": "file:///test.txt"},
+            })
+
+            notif = _read_notif(ps)
+            assert notif.method == "textDocument/publishDiagnostics"
+            params = notif.params
+            diags = params["diagnostics"]
+            assert len(diags) == 0
+        finally:
+            ps.close()
+
+
+class TestHandlerShutdown:
+    """Test the shutdown handler."""
+
+    def test_shutdown_returns_null(self) -> None:
+        bridge = MockBridge()
+        ps = _PipeServer(bridge)
+        try:
+            _send_request(ps, 1, "initialize", {
+                "processId": 1, "capabilities": {},
+            })
+
+            result = _send_request(ps, 2, "shutdown", None)
+            assert result is None
+        finally:
+            ps.close()
+
+
+class TestDocumentSymbolConversion:
+    """Test nested symbol conversion."""
+
+    def test_nested_symbols(self) -> None:
+        bridge = MockBridge()
+        cache = ParseCache()
+        from ls00 import DocumentManager
+
+        dm = DocumentManager()
+        dm.open("file:///a.go", "func main() {}", 1)
+        doc = dm.get("file:///a.go")
+        assert doc is not None
+
+        result = cache.get_or_parse("file:///a.go", doc.version, doc.text, bridge)
+        assert result is not None
+
+        syms = bridge.document_symbols(result.ast)
+        assert len(syms) == 1
+        assert syms[0].name == "main"
+        assert syms[0].kind == SymbolKind.FUNCTION
+        assert len(syms[0].children) == 1
+        assert syms[0].children[0].name == "x"

--- a/code/packages/python/ls00/tests/test_utf16.py
+++ b/code/packages/python/ls00/tests/test_utf16.py
@@ -1,0 +1,91 @@
+"""Tests for UTF-16 offset conversion.
+
+This is the most important correctness test in the entire package. If
+``convert_utf16_offset_to_byte_offset`` is wrong, every feature that depends
+on cursor position will be wrong: hover, go-to-definition, references,
+completion, rename, signature help.
+
+UTF-16 conversion is tricky because:
+- ASCII characters: 1 UTF-8 byte = 1 UTF-16 code unit
+- BMP codepoints (U+0080-U+FFFF): 2-3 UTF-8 bytes = 1 UTF-16 code unit
+- Non-BMP codepoints (> U+FFFF): 4 UTF-8 bytes = 2 UTF-16 code units
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ls00 import convert_utf16_offset_to_byte_offset
+
+
+class TestConvertUTF16OffsetToByteOffset:
+    """Verify the critical UTF-16 -> byte offset conversion."""
+
+    def test_ascii_simple(self) -> None:
+        """ASCII characters: 1 byte = 1 UTF-16 code unit."""
+        text = "hello world"
+        assert convert_utf16_offset_to_byte_offset(text, 0, 6) == 6
+
+    def test_start_of_file(self) -> None:
+        """Offset 0 always maps to byte 0."""
+        text = "abc"
+        assert convert_utf16_offset_to_byte_offset(text, 0, 0) == 0
+
+    def test_end_of_short_string(self) -> None:
+        """Offset at end of string maps to last byte + 1."""
+        text = "abc"
+        assert convert_utf16_offset_to_byte_offset(text, 0, 3) == 3
+
+    def test_second_line(self) -> None:
+        """Line 1, char 0 maps to the byte after the newline."""
+        # "hello\nworld" -- line 1 starts at byte 6
+        text = "hello\nworld"
+        assert convert_utf16_offset_to_byte_offset(text, 1, 0) == 6
+
+    def test_emoji_surrogate_pair(self) -> None:
+        """Emoji (U+1F3B8): 4 UTF-8 bytes but 2 UTF-16 code units.
+
+        "A\U0001F3B8B"
+        UTF-8 bytes:  A (1) + guitar (4) + B (1) = 6 bytes
+        UTF-16 units: A (1) + guitar (2) + B (1) = 4 units
+        "B" is at UTF-16 character 3, byte offset 5.
+        """
+        text = "A\U0001F3B8B"
+        assert convert_utf16_offset_to_byte_offset(text, 0, 3) == 5
+
+    def test_emoji_at_start(self) -> None:
+        """Emoji at position 0: "h" is at UTF-16 char 2, byte offset 4."""
+        text = "\U0001F3B8hello"
+        assert convert_utf16_offset_to_byte_offset(text, 0, 2) == 4
+
+    def test_2byte_utf8_bmp_codepoint(self) -> None:
+        """BMP codepoint (e-accent, U+00E9): 2 UTF-8 bytes, 1 UTF-16 code unit.
+
+        "cafe-accent!" -- e-accent is 2 bytes in UTF-8 but 1 unit in UTF-16.
+        So UTF-16 char 4 = byte offset 5 (c=1, a=1, f=1, e-accent=2).
+        """
+        text = "caf\u00e9!"
+        assert convert_utf16_offset_to_byte_offset(text, 0, 4) == 5
+
+    def test_multiline_with_emoji(self) -> None:
+        """Multi-line: line 0 has emoji, line 1 starts after it.
+
+        line 0: "A guitar B\\n"  (A=1, guitar=4, B=1, \\n=1 = 7 bytes)
+        line 1: "hello" starts at byte 7
+        """
+        text = "A\U0001F3B8B\nhello"
+        assert convert_utf16_offset_to_byte_offset(text, 1, 0) == 7
+
+    def test_beyond_line_end_clamps_to_newline(self) -> None:
+        """Character past end of line stops at the newline boundary."""
+        text = "ab\ncd"
+        assert convert_utf16_offset_to_byte_offset(text, 0, 100) == 2
+
+    def test_chinese_character(self) -> None:
+        """3-byte UTF-8 / 1-unit UTF-16 codepoints (CJK).
+
+        "zhong wen" -- each Chinese char is 3 UTF-8 bytes, 1 UTF-16 code unit.
+        "wen" is at UTF-16 character 1, byte offset 3.
+        """
+        text = "\u4e2d\u6587"  # zhong wen
+        assert convert_utf16_offset_to_byte_offset(text, 0, 1) == 3

--- a/code/packages/ruby/json_rpc/coding_adventures_json_rpc.gemspec
+++ b/code/packages/ruby/json_rpc/coding_adventures_json_rpc.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
                         "servers. Provides MessageReader, MessageWriter, and Server with method dispatch."
   spec.homepage      = "https://github.com/adhithyan15/coding-adventures"
   spec.license       = "MIT"
-  spec.required_ruby_version = ">= 3.4.0"
+  spec.required_ruby_version = ">= 3.2.0"
   spec.files         = Dir["lib/**/*.rb", "README.md", "CHANGELOG.md"]
   spec.require_paths = ["lib"]
   spec.metadata      = {

--- a/code/packages/ruby/ls00/BUILD
+++ b/code/packages/ruby/ls00/BUILD
@@ -1,0 +1,1 @@
+cd ../json_rpc && bundle config set --local path vendor/bundle && bundle install --quiet && cd ../ls00 && bundle config set --local path vendor/bundle && bundle install --quiet && bundle exec ruby -Ilib -Itest -e "Dir.glob('test/test_*.rb').sort.each { |f| require \"./#{f}\" }"

--- a/code/packages/ruby/ls00/BUILD
+++ b/code/packages/ruby/ls00/BUILD
@@ -1,1 +1,1 @@
-cd ../json_rpc && bundle config set --local path vendor/bundle && bundle install --quiet && cd ../ls00 && bundle config set --local path vendor/bundle && bundle install --quiet && bundle exec ruby -Ilib -Itest -e "Dir.glob('test/test_*.rb').sort.each { |f| require \"./#{f}\" }"
+cd ../json_rpc && bundle config set --local path vendor/bundle && bundle install --quiet && cd ../ls00 && bundle config set --local path vendor/bundle && bundle install --quiet && bundle exec rake test

--- a/code/packages/ruby/ls00/BUILD_windows
+++ b/code/packages/ruby/ls00/BUILD_windows
@@ -1,0 +1,1 @@
+cd ../json_rpc && bundle config set --local path vendor/bundle && bundle install --quiet && cd ../ls00 && bundle config set --local path vendor/bundle && bundle install --quiet && bundle exec rake test

--- a/code/packages/ruby/ls00/CHANGELOG.md
+++ b/code/packages/ruby/ls00/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+## 0.1.0 — 2026-04-12
+
+### Added
+
+- Initial release of the generic LSP framework for Ruby.
+- `LspServer` class wiring JSON-RPC transport, document manager, and parse cache.
+- `DocumentManager` for tracking open file contents with incremental change support.
+- `ParseCache` for avoiding redundant parses using (uri, version) cache keys.
+- Full UTF-16 to UTF-8 byte offset conversion for correct cursor positioning.
+- Dynamic capability advertisement based on bridge's `respond_to?` checks.
+- Semantic token encoding with delta-based compact integer format.
+- All LSP data types as Ruby Struct classes (Position, Range, Location, etc.).
+- LSP-specific error code constants.
+- Duck-typed LanguageBridge interface documentation.
+- Handlers for all standard LSP features:
+  - Lifecycle: initialize, initialized, shutdown, exit
+  - Text sync: didOpen, didChange, didClose, didSave
+  - Features: hover, definition, references, completion, rename, documentSymbol, semanticTokens/full, foldingRange, signatureHelp, formatting
+- Comprehensive test suite ported from Go implementation with 35+ test cases.

--- a/code/packages/ruby/ls00/Gemfile
+++ b/code/packages/ruby/ls00/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gemspec
+
+gem "coding_adventures_json_rpc", path: "../json_rpc"

--- a/code/packages/ruby/ls00/README.md
+++ b/code/packages/ruby/ls00/README.md
@@ -1,0 +1,60 @@
+# coding_adventures_ls00
+
+Generic Language Server Protocol (LSP) framework for Ruby.
+
+## What is this?
+
+This gem implements the protocol boilerplate that every LSP server needs. A language author only writes a "bridge" object that connects their lexer/parser to this framework. The framework handles:
+
+- JSON-RPC transport over stdio (via the `coding_adventures_json_rpc` gem)
+- Document synchronization (open/change/close lifecycle)
+- Parse result caching (avoids re-parsing unchanged documents)
+- Capability negotiation (only advertises features the bridge supports)
+- Semantic token encoding (compact delta format)
+- UTF-16 offset conversion (LSP uses UTF-16, Ruby uses UTF-8)
+
+## Architecture
+
+```
+Lexer -> Parser -> [LanguageBridge] -> [LspServer] -> VS Code / Neovim / Emacs
+```
+
+## How to use
+
+1. Create a bridge object implementing `tokenize(source)` and `parse(source)` (plus any optional methods like `hover`, `definition`, etc.)
+2. Create a server:
+   ```ruby
+   server = CodingAdventures::Ls00::LspServer.new(bridge, STDIN, STDOUT)
+   ```
+3. Call `server.serve` -- it blocks until the editor closes the connection.
+
+## Bridge Interface (Duck Typing)
+
+### Required methods
+
+- `tokenize(source)` -- returns an array of `Token` structs
+- `parse(source)` -- returns `[ast, [Diagnostic, ...]]`
+
+### Optional methods (checked via `respond_to?`)
+
+- `hover(ast, pos)` -- returns `HoverResult` or `nil`
+- `definition(ast, pos, uri)` -- returns `Location` or `nil`
+- `references(ast, pos, uri, include_declaration)` -- returns `[Location, ...]`
+- `completion(ast, pos)` -- returns `[CompletionItem, ...]`
+- `rename(ast, pos, new_name)` -- returns `WorkspaceEdit` or `nil`
+- `semantic_tokens(source, tokens)` -- returns `[SemanticToken, ...]`
+- `document_symbols(ast)` -- returns `[DocumentSymbol, ...]`
+- `folding_ranges(ast)` -- returns `[FoldingRange, ...]`
+- `signature_help(ast, pos)` -- returns `SignatureHelpResult` or `nil`
+- `format(source)` -- returns `[TextEdit, ...]`
+
+## Dependencies
+
+- `coding_adventures_json_rpc` -- JSON-RPC 2.0 transport layer
+
+## Running tests
+
+```bash
+bundle install
+bundle exec rake test
+```

--- a/code/packages/ruby/ls00/Rakefile
+++ b/code/packages/ruby/ls00/Rakefile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rake/testtask"
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << "lib"
+  t.libs << "test"
+  t.test_files = FileList["test/test_*.rb"]
+end
+
+task default: :test

--- a/code/packages/ruby/ls00/coding_adventures_ls00.gemspec
+++ b/code/packages/ruby/ls00/coding_adventures_ls00.gemspec
@@ -2,24 +2,24 @@
 
 require_relative "lib/coding_adventures/ls00/version"
 
-Gem::Specification.new do |s|
-  s.name        = "coding_adventures_ls00"
-  s.version     = CodingAdventures::Ls00::VERSION
-  s.summary     = "Generic Language Server Protocol (LSP) framework"
-  s.description = "A generic LSP server framework that language-specific 'bridges' plug into " \
-                   "using Ruby's duck typing. Handles all protocol boilerplate: JSON-RPC transport, " \
-                   "document synchronization, capability negotiation, and semantic token encoding."
-  s.authors     = ["Coding Adventures"]
-  s.homepage    = "https://github.com/adhithyan15/coding-adventures"
-  s.license     = "MIT"
-  s.required_ruby_version = ">= 3.2.0"
-  s.files       = Dir["lib/**/*.rb"]
-  s.require_paths = ["lib"]
-  s.metadata    = {
+Gem::Specification.new do |spec|
+  spec.name        = "coding_adventures_ls00"
+  spec.version     = CodingAdventures::Ls00::VERSION
+  spec.summary     = "Generic Language Server Protocol (LSP) framework"
+  spec.description = "A generic LSP server framework that language-specific 'bridges' plug into " \
+                      "using Ruby's duck typing. Handles all protocol boilerplate: JSON-RPC transport, " \
+                      "document synchronization, capability negotiation, and semantic token encoding."
+  spec.authors     = ["Coding Adventures"]
+  spec.homepage    = "https://github.com/adhithyan15/coding-adventures"
+  spec.license     = "MIT"
+  spec.required_ruby_version = ">= 3.2.0"
+  spec.files       = Dir["lib/**/*.rb"]
+  spec.require_paths = ["lib"]
+  spec.metadata    = {
     "source_code_uri" => "https://github.com/adhithyan15/coding-adventures",
     "rubygems_mfa_required" => "true"
   }
-  s.add_dependency "coding_adventures_json_rpc"
-  s.add_development_dependency "minitest", "~> 5.0"
-  s.add_development_dependency "rake", "~> 13.0"
+  spec.add_dependency "coding_adventures_json_rpc"
+  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "rake", "~> 13.0"
 end

--- a/code/packages/ruby/ls00/coding_adventures_ls00.gemspec
+++ b/code/packages/ruby/ls00/coding_adventures_ls00.gemspec
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative "lib/coding_adventures/ls00/version"
+
+Gem::Specification.new do |s|
+  s.name        = "coding_adventures_ls00"
+  s.version     = CodingAdventures::Ls00::VERSION
+  s.summary     = "Generic Language Server Protocol (LSP) framework"
+  s.description = "A generic LSP server framework that language-specific 'bridges' plug into " \
+                   "using Ruby's duck typing. Handles all protocol boilerplate: JSON-RPC transport, " \
+                   "document synchronization, capability negotiation, and semantic token encoding."
+  s.authors     = ["Coding Adventures"]
+  s.homepage    = "https://github.com/adhithyan15/coding-adventures"
+  s.license     = "MIT"
+  s.required_ruby_version = ">= 3.2.0"
+  s.files       = Dir["lib/**/*.rb"]
+  s.require_paths = ["lib"]
+  s.metadata    = {
+    "source_code_uri" => "https://github.com/adhithyan15/coding-adventures",
+    "rubygems_mfa_required" => "true"
+  }
+  s.add_dependency "coding_adventures_json_rpc"
+  s.add_development_dependency "minitest", "~> 5.0"
+  s.add_development_dependency "rake", "~> 13.0"
+end

--- a/code/packages/ruby/ls00/lib/coding_adventures/ls00/capabilities.rb
+++ b/code/packages/ruby/ls00/lib/coding_adventures/ls00/capabilities.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+# ================================================================
+# CodingAdventures::Ls00 — Capabilities, SemanticTokenLegend, Encoding
+# ================================================================
+#
+# # What Are Capabilities?
+#
+# During the LSP initialize handshake, the server sends back a
+# "capabilities" object telling the editor which LSP features it
+# supports. The editor uses this to decide which requests to send.
+# If a capability is absent, the editor won't send the corresponding
+# requests -- so no "Go to Definition" button appears unless
+# definitionProvider is true.
+#
+# Building capabilities dynamically (based on the bridge's respond_to?
+# checks) means the server is always honest about what it can do.
+#
+# # Semantic Token Legend
+#
+# Semantic tokens use a compact binary encoding. Instead of sending
+# {"type":"keyword"} per token, LSP sends an integer index into a legend.
+# The legend must be declared in the capabilities so the editor knows
+# what each index means.
+#
+# ================================================================
+
+module CodingAdventures
+  module Ls00
+    # build_capabilities inspects the bridge at runtime and returns the LSP
+    # capabilities hash to include in the initialize response.
+    #
+    # Uses Ruby's +respond_to?+ to check which optional methods the bridge
+    # implements. Only advertises capabilities for features the bridge
+    # actually supports.
+    def self.build_capabilities(bridge)
+      # textDocumentSync=2 means "incremental": the editor sends only changed
+      # ranges, not the full file, on every keystroke.
+      caps = { "textDocumentSync" => 2 }
+
+      caps["hoverProvider"] = true if bridge.respond_to?(:hover)
+      caps["definitionProvider"] = true if bridge.respond_to?(:definition)
+      caps["referencesProvider"] = true if bridge.respond_to?(:references)
+
+      if bridge.respond_to?(:completion)
+        caps["completionProvider"] = { "triggerCharacters" => [" ", "."] }
+      end
+
+      caps["renameProvider"] = true if bridge.respond_to?(:rename)
+      caps["documentSymbolProvider"] = true if bridge.respond_to?(:document_symbols)
+      caps["foldingRangeProvider"] = true if bridge.respond_to?(:folding_ranges)
+
+      if bridge.respond_to?(:signature_help)
+        caps["signatureHelpProvider"] = { "triggerCharacters" => ["(", ","] }
+      end
+
+      caps["documentFormattingProvider"] = true if bridge.respond_to?(:format)
+
+      if bridge.respond_to?(:semantic_tokens)
+        caps["semanticTokensProvider"] = {
+          "legend" => semantic_token_legend,
+          "full" => true
+        }
+      end
+
+      caps
+    end
+
+    # SemanticTokenLegendData holds the legend arrays for semantic tokens.
+    SemanticTokenLegendData = Struct.new(:token_types, :token_modifiers, keyword_init: true)
+
+    # semantic_token_legend returns the full legend for all supported semantic
+    # token types and modifiers.
+    #
+    # The ordering matters: index 0 in token_types corresponds to "namespace",
+    # index 1 to "type", etc. These match the standard LSP token types.
+    def self.semantic_token_legend
+      {
+        "tokenTypes" => TOKEN_TYPES,
+        "tokenModifiers" => TOKEN_MODIFIERS
+      }
+    end
+
+    # Standard LSP token types (in the order VS Code expects them).
+    # Source: https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide
+    TOKEN_TYPES = [
+      "namespace",      # 0
+      "type",           # 1
+      "class",          # 2
+      "enum",           # 3
+      "interface",      # 4
+      "struct",         # 5
+      "typeParameter",  # 6
+      "parameter",      # 7
+      "variable",       # 8
+      "property",       # 9
+      "enumMember",     # 10
+      "event",          # 11
+      "function",       # 12
+      "method",         # 13
+      "macro",          # 14
+      "keyword",        # 15
+      "modifier",       # 16
+      "comment",        # 17
+      "string",         # 18
+      "number",         # 19
+      "regexp",         # 20
+      "operator",       # 21
+      "decorator"       # 22
+    ].freeze
+
+    # Standard LSP token modifiers (bitmask flags).
+    # tokenModifier[0] = "declaration" -> bit 0 (value 1)
+    # tokenModifier[1] = "definition"  -> bit 1 (value 2)
+    TOKEN_MODIFIERS = [
+      "declaration",    # bit 0
+      "definition",     # bit 1
+      "readonly",       # bit 2
+      "static",         # bit 3
+      "deprecated",     # bit 4
+      "abstract",       # bit 5
+      "async",          # bit 6
+      "modification",   # bit 7
+      "documentation",  # bit 8
+      "defaultLibrary"  # bit 9
+    ].freeze
+
+    # token_type_index returns the integer index for a semantic token type
+    # string. Returns -1 if the type is not in the legend.
+    def self.token_type_index(token_type)
+      idx = TOKEN_TYPES.index(token_type)
+      idx.nil? ? -1 : idx
+    end
+
+    # token_modifier_mask returns the bitmask for a list of modifier strings.
+    #
+    # The LSP semantic tokens encoding represents modifiers as a bitmask:
+    #   "declaration" -> bit 0 -> value 1
+    #   "definition"  -> bit 1 -> value 2
+    #   both          -> value 3 (bitwise OR)
+    #
+    # Unknown modifiers are silently ignored.
+    def self.token_modifier_mask(modifiers)
+      return 0 if modifiers.nil? || modifiers.empty?
+
+      mask = 0
+      modifiers.each do |mod|
+        idx = TOKEN_MODIFIERS.index(mod)
+        mask |= (1 << idx) if idx
+      end
+      mask
+    end
+
+    # encode_semantic_tokens converts an array of SemanticToken values to the
+    # LSP compact integer encoding.
+    #
+    # # The LSP Semantic Token Encoding
+    #
+    # LSP encodes semantic tokens as a flat array of integers, grouped in
+    # 5-tuples:
+    #
+    #   [deltaLine, deltaStartChar, length, tokenTypeIndex, tokenModifierBitmask, ...]
+    #
+    # Where "delta" means: the difference from the PREVIOUS token's position.
+    # This delta encoding makes most values small (often 0 or 1).
+    #
+    # Note: when deltaLine > 0, deltaStartChar is relative to column 0 of the
+    # new line. When deltaLine == 0, deltaStartChar is relative to the previous
+    # token's start character.
+    def self.encode_semantic_tokens(tokens)
+      return [] if tokens.nil? || tokens.empty?
+
+      # Sort by (line, character) ascending. The delta encoding requires tokens
+      # to be in document order.
+      sorted = tokens.sort_by { |t| [t.line, t.character] }
+
+      data = []
+      prev_line = 0
+      prev_char = 0
+
+      sorted.each do |tok|
+        type_idx = token_type_index(tok.token_type)
+        next if type_idx == -1 # unknown token type -- skip
+
+        delta_line = tok.line - prev_line
+        delta_char = if delta_line == 0
+                       # Same line: character offset is relative to previous token.
+                       tok.character - prev_char
+                     else
+                       # Different line: character offset is absolute.
+                       tok.character
+                     end
+
+        mod_mask = token_modifier_mask(tok.modifiers)
+
+        data.push(delta_line, delta_char, tok.length, type_idx, mod_mask)
+
+        prev_line = tok.line
+        prev_char = tok.character
+      end
+
+      data
+    end
+  end
+end

--- a/code/packages/ruby/ls00/lib/coding_adventures/ls00/document_manager.rb
+++ b/code/packages/ruby/ls00/lib/coding_adventures/ls00/document_manager.rb
@@ -1,0 +1,216 @@
+# frozen_string_literal: true
+
+# ================================================================
+# CodingAdventures::Ls00::DocumentManager
+# ================================================================
+#
+# # The Document Manager's Job
+#
+# When the user opens a file in VS Code, the editor sends a
+# textDocument/didOpen notification with the full file content. From
+# that point on, the editor does NOT re-send the entire file on every
+# keystroke. Instead, it sends incremental changes: what changed, and
+# where. The DocumentManager applies these changes to maintain the
+# current text of each open file.
+#
+#   Editor opens file:   didOpen   -> DocumentManager stores text at version 1
+#   User types "X":      didChange -> DocumentManager applies delta -> version 2
+#   User saves:          didSave   -> (optional: trigger format)
+#   User closes:         didClose  -> DocumentManager removes entry
+#
+# # Why Version Numbers?
+#
+# The editor increments the version number with every change. The
+# ParseCache uses (uri, version) as its cache key -- if the version
+# matches, the cached parse result is still valid.
+#
+# # UTF-16: The Tricky Part
+#
+# LSP specifies that character offsets are measured in UTF-16 CODE UNITS.
+# This is a historical accident: VS Code is built on TypeScript, which
+# uses UTF-16 strings internally.
+#
+# Ruby strings are UTF-8. A single Unicode codepoint can occupy:
+#   - 1 byte in UTF-8 (ASCII, e.g. 'A')
+#   - 2 bytes in UTF-8 (e.g. 'e-acute', U+00E9)
+#   - 3 bytes in UTF-8 (e.g. CJK character, U+4E2D)
+#   - 4 bytes in UTF-8 (e.g. guitar emoji, U+1F3B8)
+#
+# In UTF-16:
+#   - Codepoints in the Basic Multilingual Plane (U+0000-U+FFFF) -> 1 code unit
+#   - Codepoints above U+FFFF (emojis, rare CJK) -> 2 code units (surrogate pair)
+#
+# The guitar emoji (U+1F3B8) is above U+FFFF:
+#   UTF-8:  4 bytes
+#   UTF-16: 2 code units (surrogate pair)
+#
+# So if the LSP client says character=8 (UTF-16), we cannot simply slice
+# 8 bytes into the UTF-8 Ruby string. We must walk the UTF-8 bytes,
+# converting each codepoint to its UTF-16 length, accumulating until we
+# reach code unit 8.
+#
+# ================================================================
+
+module CodingAdventures
+  module Ls00
+    # Document represents an open file tracked by the DocumentManager.
+    Document = Struct.new(:uri, :text, :version, keyword_init: true)
+
+    # TextChange describes one incremental change to a document.
+    #
+    # If +range+ is nil, +new_text+ replaces the ENTIRE document content
+    # (full sync). If +range+ is non-nil, +new_text+ replaces just the
+    # specified range (incremental sync).
+    TextChange = Struct.new(:range, :new_text, keyword_init: true)
+
+    class DocumentManager
+      def initialize
+        @docs = {} # uri -> Document
+      end
+
+      # Open records a newly opened file.
+      #
+      # Called when the editor sends textDocument/didOpen. Stores the initial
+      # text and version number (typically 1 for a freshly opened file).
+      def open(uri, text, version)
+        @docs[uri] = Document.new(uri: uri, text: text, version: version)
+      end
+
+      # apply_changes applies a list of incremental changes to an open document.
+      #
+      # Changes are applied in order. If a range is nil, the change replaces
+      # the entire document. After all changes, the document's version is updated.
+      #
+      # Raises RuntimeError if the document is not open.
+      def apply_changes(uri, changes, version)
+        doc = @docs[uri]
+        raise "document not open: #{uri}" unless doc
+
+        changes.each do |change|
+          if change.range.nil?
+            # Full document replacement -- simplest case.
+            doc.text = change.new_text
+          else
+            # Incremental update: splice new text at the specified range.
+            doc.text = apply_range_change(doc.text, change.range, change.new_text)
+          end
+        end
+
+        doc.version = version
+      end
+
+      # get returns the document for a URI, or nil if not open.
+      def get(uri)
+        @docs[uri]
+      end
+
+      # close removes a document from the manager.
+      #
+      # Called when the editor sends textDocument/didClose. After this, the
+      # document's text is no longer tracked.
+      def close(uri)
+        @docs.delete(uri)
+      end
+
+      private
+
+      # apply_range_change splices new_text into text at the given LSP range.
+      #
+      # It converts LSP's (line, UTF-16-character) coordinates to byte offsets
+      # in the UTF-8 Ruby string, then performs the splice.
+      def apply_range_change(text, range, new_text)
+        start_byte = Ls00.convert_position_to_byte_offset(text, range.start)
+        end_byte = Ls00.convert_position_to_byte_offset(text, range.end_pos)
+
+        raise "start offset #{start_byte} > end offset #{end_byte}" if start_byte > end_byte
+
+        end_byte = text.bytesize if end_byte > text.bytesize
+
+        # Build new string by byte-slicing the original
+        before = text.byteslice(0, start_byte) || ""
+        after = text.byteslice(end_byte..) || ""
+        before + new_text + after
+      end
+    end
+
+    # convert_position_to_byte_offset converts an LSP Position (0-based line,
+    # UTF-16 char) to a byte offset in the UTF-8 Ruby string.
+    #
+    # Algorithm:
+    #  1. Walk line-by-line to find the byte offset of the start of the target line.
+    #  2. From that offset, walk UTF-8 codepoints, converting each to its UTF-16
+    #     length, until we reach the target UTF-16 character offset.
+    #
+    # This is a module-level function because it is used by both DocumentManager
+    # and the test suite.
+    def self.convert_position_to_byte_offset(text, pos)
+      line_start = 0
+      current_line = 0
+
+      # Phase 1: find the byte offset of the start of pos.line.
+      # We walk the raw bytes looking for newline (0x0A) characters.
+      raw_bytes = text.b # binary string for byte-level scanning
+      while current_line < pos.line
+        idx = raw_bytes.index("\n".b, line_start)
+        if idx.nil?
+          # Line number exceeds the number of lines in the file.
+          return text.bytesize
+        end
+        line_start = idx + 1
+        current_line += 1
+      end
+
+      # Phase 2: from line_start, advance pos.character UTF-16 code units.
+      byte_offset = line_start
+      utf16_units = 0
+
+      while utf16_units < pos.character && byte_offset < text.bytesize
+        # Decode one Unicode codepoint from the UTF-8 stream.
+        # Ruby's String#byteslice + force_encoding lets us decode one char.
+        remaining = text.byteslice(byte_offset..)
+        break if remaining.nil? || remaining.empty?
+
+        remaining.force_encoding("UTF-8")
+        char = remaining[0] # first character
+        break if char.nil?
+
+        # Don't advance past a newline -- the position is beyond the line end.
+        break if char == "\n"
+
+        # How many UTF-16 code units does this codepoint occupy?
+        codepoint = char.ord
+        utf16_len = codepoint > 0xFFFF ? 2 : 1
+
+        # Would this codepoint overshoot the target character?
+        break if utf16_units + utf16_len > pos.character
+
+        byte_offset += char.bytesize
+        utf16_units += utf16_len
+      end
+
+      byte_offset
+    end
+
+    # convert_utf16_offset_to_byte_offset is the public API for converting
+    # a 0-based (line, UTF-16 char) position to a byte offset.
+    #
+    # # Why UTF-16?
+    #
+    # LSP character offsets are UTF-16 code units because VS Code's internal
+    # string representation is UTF-16 (as is JavaScript's String type).
+    # This function bridges the gap to Ruby's UTF-8 strings.
+    #
+    # # Example
+    #
+    #   text = "hello guitar-emoji world"
+    #   # guitar-emoji (U+1F3B8) is 4 UTF-8 bytes but 2 UTF-16 code units.
+    #   # After the emoji, LSP says character=8 (6 for "hello ", 2 for emoji).
+    #   # But in UTF-8, "world" starts at byte 11 (6 + 4 + 1 for the space).
+    #   byte_off = Ls00.convert_utf16_offset_to_byte_offset(text, 0, 8)
+    #   # byte_off = 11
+    #
+    def self.convert_utf16_offset_to_byte_offset(text, line, char)
+      convert_position_to_byte_offset(text, Position.new(line: line, character: char))
+    end
+  end
+end

--- a/code/packages/ruby/ls00/lib/coding_adventures/ls00/handlers.rb
+++ b/code/packages/ruby/ls00/lib/coding_adventures/ls00/handlers.rb
@@ -1,0 +1,502 @@
+# frozen_string_literal: true
+
+# ================================================================
+# CodingAdventures::Ls00::Handlers — all LSP request/notification handlers
+# ================================================================
+#
+# This module is mixed into LspServer to provide all handler methods.
+# Each handler follows the same pattern:
+#
+#   1. Parse the params hash.
+#   2. Check if the bridge supports the feature (respond_to?).
+#   3. Get the parse result from the cache.
+#   4. Delegate to the bridge.
+#   5. Convert the result to LSP wire format.
+#
+# Handlers are split into categories:
+#   - Lifecycle: initialize, initialized, shutdown, exit
+#   - Text document sync: didOpen, didChange, didClose, didSave
+#   - Feature requests: hover, definition, references, completion,
+#     rename, documentSymbol, semanticTokens, foldingRange,
+#     signatureHelp, formatting
+#
+# ================================================================
+
+module CodingAdventures
+  module Ls00
+    module Handlers
+      # ── Lifecycle ──────────────────────────────────────────────────
+
+      # handle_initialize processes the LSP initialize request.
+      #
+      # This is the server's first message. We return capabilities built
+      # from the bridge's optional methods.
+      def handle_initialize(_id, _params)
+        @initialized = true
+
+        caps = Ls00.build_capabilities(@bridge)
+
+        {
+          "capabilities" => caps,
+          "serverInfo" => {
+            "name" => "ls00-generic-lsp-server",
+            "version" => "0.1.0"
+          }
+        }
+      end
+
+      # handle_initialized processes the "initialized" notification.
+      #
+      # This is the editor's acknowledgment that it received our capabilities.
+      # No-op: the handshake is complete.
+      def handle_initialized(_params)
+        # No-op
+      end
+
+      # handle_shutdown processes the LSP shutdown request.
+      #
+      # After receiving shutdown, the server should stop processing new
+      # requests. Returns nil (null in JSON).
+      def handle_shutdown(_id, _params)
+        @shutdown = true
+        nil
+      end
+
+      # handle_exit processes the "exit" notification.
+      #
+      # Exit code semantics (from the LSP spec):
+      #   0: shutdown was received before exit -> clean shutdown
+      #   1: shutdown was NOT received -> abnormal termination
+      def handle_exit(_params)
+        exit(@shutdown ? 0 : 1)
+      end
+
+      # ── Text document synchronization ──────────────────────────────
+
+      # handle_did_open is called when the editor opens a file.
+      #
+      # Params: {"textDocument" => {"uri" => "...", "languageId" => "...",
+      #          "version" => 1, "text" => "..."}}
+      def handle_did_open(params)
+        return unless params.is_a?(Hash)
+
+        td = params["textDocument"]
+        return unless td.is_a?(Hash)
+
+        uri = td["uri"]
+        text = td["text"] || ""
+        version = td["version"] || 1
+
+        return if uri.nil? || uri.empty?
+
+        @doc_manager.open(uri, text, version)
+
+        result = @parse_cache.get_or_parse(uri, version, text, @bridge)
+        publish_diagnostics(uri, version, result.diagnostics)
+      end
+
+      # handle_did_change is called when the user edits a file.
+      #
+      # Params: {"textDocument" => {"uri" => "...", "version" => 2},
+      #          "contentChanges" => [...]}
+      def handle_did_change(params)
+        return unless params.is_a?(Hash)
+
+        uri = parse_uri(params)
+        return if uri.nil? || uri.empty?
+
+        version = 0
+        if (td = params["textDocument"]) && td.is_a?(Hash)
+          version = td["version"].to_i if td["version"]
+        end
+
+        changes_raw = params["contentChanges"]
+        return unless changes_raw.is_a?(Array)
+
+        changes = changes_raw.filter_map do |change_map|
+          next unless change_map.is_a?(Hash)
+
+          new_text = change_map["text"] || ""
+          range = nil
+          if change_map.key?("range") && change_map["range"]
+            range = parse_lsp_range(change_map["range"])
+          end
+
+          TextChange.new(range: range, new_text: new_text)
+        end
+
+        begin
+          @doc_manager.apply_changes(uri, changes, version)
+        rescue RuntimeError
+          return # document wasn't open
+        end
+
+        doc = @doc_manager.get(uri)
+        return unless doc
+
+        result = @parse_cache.get_or_parse(uri, doc.version, doc.text, @bridge)
+        publish_diagnostics(uri, version, result.diagnostics)
+      end
+
+      # handle_did_close is called when the editor closes a file.
+      def handle_did_close(params)
+        return unless params.is_a?(Hash)
+
+        uri = parse_uri(params)
+        return if uri.nil? || uri.empty?
+
+        @doc_manager.close(uri)
+        @parse_cache.evict(uri)
+
+        # Clear diagnostics for the closed file by publishing an empty list.
+        publish_diagnostics(uri, 0, [])
+      end
+
+      # handle_did_save is called when the editor saves a file.
+      def handle_did_save(params)
+        return unless params.is_a?(Hash)
+
+        uri = parse_uri(params)
+        return if uri.nil? || uri.empty?
+
+        text = params["text"]
+        return unless text.is_a?(String) && !text.empty?
+
+        doc = @doc_manager.get(uri)
+        return unless doc
+
+        @doc_manager.close(uri)
+        @doc_manager.open(uri, text, doc.version)
+        result = @parse_cache.get_or_parse(uri, doc.version, text, @bridge)
+        publish_diagnostics(uri, doc.version, result.diagnostics)
+      end
+
+      # ── Feature requests ───────────────────────────────────────────
+
+      # handle_hover processes the textDocument/hover request.
+      def handle_hover(_id, params)
+        return nil unless params.is_a?(Hash)
+
+        uri = parse_uri(params)
+        pos = parse_position(params)
+
+        return nil unless @bridge.respond_to?(:hover)
+
+        _, parse_result = get_parse_result(uri)
+        return nil unless parse_result&.ast
+
+        hover_result = @bridge.hover(parse_result.ast, pos)
+        return nil unless hover_result
+
+        result = {
+          "contents" => {
+            "kind" => "markdown",
+            "value" => hover_result.contents
+          }
+        }
+
+        if hover_result.range
+          result["range"] = range_to_lsp(hover_result.range)
+        end
+
+        result
+      end
+
+      # handle_definition processes the textDocument/definition request.
+      def handle_definition(_id, params)
+        return nil unless params.is_a?(Hash)
+
+        uri = parse_uri(params)
+        pos = parse_position(params)
+
+        return nil unless @bridge.respond_to?(:definition)
+
+        _, parse_result = get_parse_result(uri)
+        return nil unless parse_result&.ast
+
+        location = @bridge.definition(parse_result.ast, pos, uri)
+        return nil unless location
+
+        location_to_lsp(location)
+      end
+
+      # handle_references processes the textDocument/references request.
+      def handle_references(_id, params)
+        return [] unless params.is_a?(Hash)
+
+        uri = parse_uri(params)
+        pos = parse_position(params)
+
+        include_decl = false
+        if (ctx = params["context"]) && ctx.is_a?(Hash)
+          include_decl = ctx["includeDeclaration"] == true
+        end
+
+        return [] unless @bridge.respond_to?(:references)
+
+        _, parse_result = get_parse_result(uri)
+        return [] unless parse_result&.ast
+
+        locations = @bridge.references(parse_result.ast, pos, uri, include_decl)
+        return [] unless locations
+
+        locations.map { |loc| location_to_lsp(loc) }
+      end
+
+      # handle_completion processes the textDocument/completion request.
+      def handle_completion(_id, params)
+        empty_result = { "isIncomplete" => false, "items" => [] }
+        return empty_result unless params.is_a?(Hash)
+
+        uri = parse_uri(params)
+        pos = parse_position(params)
+
+        return empty_result unless @bridge.respond_to?(:completion)
+
+        _, parse_result = get_parse_result(uri)
+        return empty_result unless parse_result&.ast
+
+        items = @bridge.completion(parse_result.ast, pos)
+        return empty_result unless items
+
+        lsp_items = items.map do |item|
+          ci = { "label" => item.label }
+          ci["kind"] = item.kind if item.kind && item.kind != 0
+          ci["detail"] = item.detail if item.detail && !item.detail.empty?
+          ci["documentation"] = item.documentation if item.documentation && !item.documentation.empty?
+          ci["insertText"] = item.insert_text if item.insert_text && !item.insert_text.empty?
+          ci["insertTextFormat"] = item.insert_text_format if item.insert_text_format && item.insert_text_format != 0
+          ci
+        end
+
+        { "isIncomplete" => false, "items" => lsp_items }
+      end
+
+      # handle_rename processes the textDocument/rename request.
+      def handle_rename(_id, params)
+        return error_response(JsonRpc::ErrorCodes::INVALID_PARAMS, "invalid params") unless params.is_a?(Hash)
+
+        uri = parse_uri(params)
+        pos = parse_position(params)
+        new_name = params["newName"]
+
+        if new_name.nil? || new_name.empty?
+          return error_response(JsonRpc::ErrorCodes::INVALID_PARAMS, "newName is required")
+        end
+
+        unless @bridge.respond_to?(:rename)
+          return error_response(LspErrors::REQUEST_FAILED, "rename not supported")
+        end
+
+        _, parse_result = get_parse_result(uri)
+        unless parse_result&.ast
+          return error_response(LspErrors::REQUEST_FAILED, "no AST available")
+        end
+
+        edit = @bridge.rename(parse_result.ast, pos, new_name)
+        unless edit
+          return error_response(LspErrors::REQUEST_FAILED, "symbol not found at position")
+        end
+
+        lsp_changes = {}
+        edit.changes.each do |edit_uri, edits|
+          lsp_changes[edit_uri] = edits.map do |te|
+            { "range" => range_to_lsp(te.range), "newText" => te.new_text }
+          end
+        end
+
+        { "changes" => lsp_changes }
+      end
+
+      # handle_document_symbol processes the textDocument/documentSymbol request.
+      def handle_document_symbol(_id, params)
+        return [] unless params.is_a?(Hash)
+
+        uri = parse_uri(params)
+
+        return [] unless @bridge.respond_to?(:document_symbols)
+
+        _, parse_result = get_parse_result(uri)
+        return [] unless parse_result&.ast
+
+        symbols = @bridge.document_symbols(parse_result.ast)
+        return [] unless symbols
+
+        convert_document_symbols(symbols)
+      end
+
+      # handle_semantic_tokens_full processes the textDocument/semanticTokens/full request.
+      def handle_semantic_tokens_full(_id, params)
+        empty_result = { "data" => [] }
+        return empty_result unless params.is_a?(Hash)
+
+        uri = parse_uri(params)
+
+        return empty_result unless @bridge.respond_to?(:semantic_tokens)
+
+        doc = @doc_manager.get(uri)
+        return empty_result unless doc
+
+        tokens = @bridge.tokenize(doc.text)
+        return empty_result unless tokens
+
+        sem_tokens = @bridge.semantic_tokens(doc.text, tokens)
+        return empty_result unless sem_tokens
+
+        data = Ls00.encode_semantic_tokens(sem_tokens)
+        { "data" => data }
+      end
+
+      # handle_folding_range processes the textDocument/foldingRange request.
+      def handle_folding_range(_id, params)
+        return [] unless params.is_a?(Hash)
+
+        uri = parse_uri(params)
+
+        return [] unless @bridge.respond_to?(:folding_ranges)
+
+        _, parse_result = get_parse_result(uri)
+        return [] unless parse_result&.ast
+
+        ranges = @bridge.folding_ranges(parse_result.ast)
+        return [] unless ranges
+
+        ranges.map do |fr|
+          m = { "startLine" => fr.start_line, "endLine" => fr.end_line }
+          m["kind"] = fr.kind if fr.kind && !fr.kind.empty?
+          m
+        end
+      end
+
+      # handle_signature_help processes the textDocument/signatureHelp request.
+      def handle_signature_help(_id, params)
+        return nil unless params.is_a?(Hash)
+
+        uri = parse_uri(params)
+        pos = parse_position(params)
+
+        return nil unless @bridge.respond_to?(:signature_help)
+
+        _, parse_result = get_parse_result(uri)
+        return nil unless parse_result&.ast
+
+        sig_help = @bridge.signature_help(parse_result.ast, pos)
+        return nil unless sig_help
+
+        lsp_sigs = sig_help.signatures.map do |sig|
+          lsp_params = (sig.parameters || []).map do |param|
+            pp = { "label" => param.label }
+            pp["documentation"] = param.documentation if param.documentation && !param.documentation.empty?
+            pp
+          end
+          s = { "label" => sig.label, "parameters" => lsp_params }
+          s["documentation"] = sig.documentation if sig.documentation && !sig.documentation.empty?
+          s
+        end
+
+        {
+          "signatures" => lsp_sigs,
+          "activeSignature" => sig_help.active_signature,
+          "activeParameter" => sig_help.active_parameter
+        }
+      end
+
+      # handle_formatting processes the textDocument/formatting request.
+      def handle_formatting(_id, params)
+        return [] unless params.is_a?(Hash)
+
+        uri = parse_uri(params)
+
+        return [] unless @bridge.respond_to?(:format)
+
+        doc = @doc_manager.get(uri)
+        return [] unless doc
+
+        edits = @bridge.format(doc.text)
+        return [] unless edits
+
+        edits.map do |edit|
+          { "range" => range_to_lsp(edit.range), "newText" => edit.new_text }
+        end
+      end
+
+      private
+
+      # ── LSP type conversion helpers ────────────────────────────────
+
+      # position_to_lsp converts a Position to a JSON-serializable hash.
+      def position_to_lsp(pos)
+        { "line" => pos.line, "character" => pos.character }
+      end
+
+      # range_to_lsp converts an LspRange to a JSON-serializable hash.
+      def range_to_lsp(r)
+        { "start" => position_to_lsp(r.start), "end" => position_to_lsp(r.end_pos) }
+      end
+
+      # location_to_lsp converts a Location to a JSON-serializable hash.
+      def location_to_lsp(loc)
+        { "uri" => loc.uri, "range" => range_to_lsp(loc.range) }
+      end
+
+      # parse_position extracts a Position from JSON params.
+      def parse_position(params)
+        pos = params["position"] || {}
+        Position.new(
+          line: (pos["line"] || 0).to_i,
+          character: (pos["character"] || 0).to_i
+        )
+      end
+
+      # parse_uri extracts the document URI from params.
+      def parse_uri(params)
+        td = params["textDocument"]
+        return nil unless td.is_a?(Hash)
+
+        td["uri"]
+      end
+
+      # parse_lsp_range parses a raw JSON range hash from the LSP protocol.
+      def parse_lsp_range(raw)
+        return LspRange.new(start: Position.new(line: 0, character: 0),
+                            end_pos: Position.new(line: 0, character: 0)) unless raw.is_a?(Hash)
+
+        start_map = raw["start"] || {}
+        end_map = raw["end"] || {}
+
+        LspRange.new(
+          start: Position.new(
+            line: (start_map["line"] || 0).to_i,
+            character: (start_map["character"] || 0).to_i
+          ),
+          end_pos: Position.new(
+            line: (end_map["line"] || 0).to_i,
+            character: (end_map["character"] || 0).to_i
+          )
+        )
+      end
+
+      # error_response creates a ResponseError for returning from request handlers.
+      def error_response(code, message)
+        JsonRpc::ResponseError.new(code: code, message: message)
+      end
+
+      # convert_document_symbols recursively converts DocumentSymbol arrays
+      # to JSON-serializable hashes for the LSP response.
+      def convert_document_symbols(symbols)
+        symbols.map do |sym|
+          m = {
+            "name" => sym.name,
+            "kind" => sym.kind,
+            "range" => range_to_lsp(sym.range),
+            "selectionRange" => range_to_lsp(sym.selection_range)
+          }
+          if sym.children && !sym.children.empty?
+            m["children"] = convert_document_symbols(sym.children)
+          end
+          m
+        end
+      end
+    end
+  end
+end

--- a/code/packages/ruby/ls00/lib/coding_adventures/ls00/language_bridge.rb
+++ b/code/packages/ruby/ls00/lib/coding_adventures/ls00/language_bridge.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+# ================================================================
+# CodingAdventures::Ls00 — LanguageBridge (Duck-Type Documentation)
+# ================================================================
+#
+# # Design Philosophy: Duck Typing
+#
+# Ruby uses duck typing instead of Go's interface mechanism. Rather than
+# declaring explicit interfaces, we document the expected methods and use
+# +respond_to?+ at runtime for capability detection.
+#
+# A bridge object must implement two required methods:
+#
+#   bridge.tokenize(source)  -> [Token, ...]
+#   bridge.parse(source)     -> [ast, [Diagnostic, ...]]
+#
+# All other features are optional. The server checks at runtime:
+#
+#   if bridge.respond_to?(:hover)
+#     result = bridge.hover(ast, pos)
+#   end
+#
+# This matches the LSP spec's philosophy: capabilities are advertised,
+# not assumed. An editor won't even try to ask for hover if the server
+# didn't advertise it.
+#
+# # Required Methods
+#
+#   tokenize(source)
+#     Lexes the source string and returns an array of Token structs.
+#     Used for semantic highlighting.
+#
+#   parse(source)
+#     Parses the source string and returns [ast, diagnostics].
+#     ast: any object representing the parsed syntax tree.
+#     diagnostics: array of Diagnostic structs (errors, warnings, hints).
+#     Even on parse error, return a partial AST when possible.
+#
+# # Optional Methods (checked via respond_to?)
+#
+#   hover(ast, pos)
+#     Returns a HoverResult or nil.
+#
+#   definition(ast, pos, uri)
+#     Returns a Location or nil.
+#
+#   references(ast, pos, uri, include_declaration)
+#     Returns an array of Location.
+#
+#   completion(ast, pos)
+#     Returns an array of CompletionItem.
+#
+#   rename(ast, pos, new_name)
+#     Returns a WorkspaceEdit or nil.
+#
+#   semantic_tokens(source, tokens)
+#     Returns an array of SemanticToken.
+#
+#   document_symbols(ast)
+#     Returns an array of DocumentSymbol.
+#
+#   folding_ranges(ast)
+#     Returns an array of FoldingRange.
+#
+#   signature_help(ast, pos)
+#     Returns a SignatureHelpResult or nil.
+#
+#   format(source)
+#     Returns an array of TextEdit.
+#
+# ================================================================
+
+module CodingAdventures
+  module Ls00
+    # This module exists purely as documentation. Ruby's duck typing means
+    # there is no interface to enforce. The server uses respond_to? checks
+    # at runtime to detect which optional methods the bridge supports.
+    #
+    # See the comment block above for the full contract.
+    module LanguageBridge
+    end
+  end
+end

--- a/code/packages/ruby/ls00/lib/coding_adventures/ls00/lsp_errors.rb
+++ b/code/packages/ruby/ls00/lib/coding_adventures/ls00/lsp_errors.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# ================================================================
+# CodingAdventures::Ls00::LspErrors — LSP-specific error codes
+# ================================================================
+#
+# The JSON-RPC 2.0 specification reserves error codes in the range
+# [-32768, -32000]. The LSP specification further reserves
+# [-32899, -32800] for LSP protocol-level errors.
+#
+# Standard JSON-RPC error codes (from the json_rpc package):
+#   -32700  ParseError
+#   -32600  InvalidRequest
+#   -32601  MethodNotFound
+#   -32602  InvalidParams
+#   -32603  InternalError
+#
+# LSP-specific error codes are listed below.
+#
+# Reference:
+# https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#errorCodes
+#
+# ================================================================
+
+module CodingAdventures
+  module Ls00
+    module LspErrors
+      # The server has received a request before the initialize handshake
+      # was completed.
+      SERVER_NOT_INITIALIZED = -32_002
+
+      # A generic error code for unknown errors.
+      UNKNOWN_ERROR_CODE = -32_001
+
+      # A request failed but not due to a protocol problem. For example,
+      # the document requested was not found.
+      REQUEST_FAILED = -32_803
+
+      # The server cancelled the request.
+      SERVER_CANCELLED = -32_802
+
+      # The document content was modified before the request completed.
+      # The client should retry.
+      CONTENT_MODIFIED = -32_801
+
+      # The client cancelled the request.
+      REQUEST_CANCELLED = -32_800
+    end
+  end
+end

--- a/code/packages/ruby/ls00/lib/coding_adventures/ls00/parse_cache.rb
+++ b/code/packages/ruby/ls00/lib/coding_adventures/ls00/parse_cache.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+# ================================================================
+# CodingAdventures::Ls00::ParseCache
+# ================================================================
+#
+# # Why Cache Parse Results?
+#
+# Parsing is the most expensive operation in a language server. For a large
+# file, parsing on every keystroke would lag the editor noticeably.
+#
+# The LSP protocol helps by sending a version number with every change. If
+# the document hasn't changed (same URI, same version), the parse result
+# from the previous keystroke is still valid.
+#
+# # Cache Key Design
+#
+# The cache key is [uri, version]. Version is a monotonically increasing
+# integer that the editor increments with each change. Using version in
+# the key means:
+#
+#   Same [uri, version] -> cache hit -> return cached result
+#   Different version   -> cache miss -> re-parse and cache new result
+#
+# The old entry is evicted when a new version is cached for the same URI.
+# This keeps memory bounded at O(open_documents) entries.
+#
+# # Thread Safety
+#
+# The ParseCache is NOT thread-safe. This is intentional: the LspServer
+# processes one message at a time (single-threaded), so no locking is needed.
+#
+# ================================================================
+
+module CodingAdventures
+  module Ls00
+    # ParseResult holds the outcome of parsing one version of a document.
+    #
+    # Even on parse error, we store the partial AST and diagnostics so that
+    # other features (hover, folding, symbols) can still work on valid portions.
+    ParseResult = Struct.new(:ast, :diagnostics, :error, keyword_init: true)
+
+    class ParseCache
+      def initialize
+        @cache = {} # [uri, version] -> ParseResult
+      end
+
+      # get_or_parse returns the parse result for (uri, version).
+      #
+      # If the result is already cached, it is returned immediately without
+      # calling the bridge again. Otherwise, bridge.parse(source) is called,
+      # the result is stored, and previous cache entries for this URI are
+      # evicted to prevent unbounded growth.
+      def get_or_parse(uri, version, source, bridge)
+        key = [uri, version]
+
+        # Cache hit: the document hasn't changed since last parse.
+        return @cache[key] if @cache.key?(key)
+
+        # Cache miss: parse and store. Evict any stale entry for this URI first.
+        evict(uri)
+
+        ast, diags = bridge.parse(source)
+        diags ||= [] # normalize nil to empty array for JSON
+
+        result = ParseResult.new(ast: ast, diagnostics: diags, error: nil)
+        @cache[key] = result
+        result
+      end
+
+      # evict removes all cached entries for a given URI.
+      #
+      # Called when a document is closed (didClose) so the cache entry is
+      # cleaned up. Also called internally before adding a new entry.
+      def evict(uri)
+        @cache.delete_if { |k, _| k[0] == uri }
+      end
+    end
+  end
+end

--- a/code/packages/ruby/ls00/lib/coding_adventures/ls00/server.rb
+++ b/code/packages/ruby/ls00/lib/coding_adventures/ls00/server.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+# ================================================================
+# CodingAdventures::Ls00::LspServer — the main coordinator
+# ================================================================
+#
+# LspServer wires together:
+#   - The LanguageBridge (language-specific logic via duck typing)
+#   - The DocumentManager (tracks open file contents)
+#   - The ParseCache (avoids redundant parses)
+#   - The JSON-RPC Server (protocol layer)
+#
+# It registers all LSP request and notification handlers with the
+# JSON-RPC server, then calls serve to start the blocking
+# read-dispatch-write loop.
+#
+# # Server Lifecycle
+#
+#   Client (editor)              Server (us)
+#     |                               |
+#     |--initialize-------------->    |  store clientInfo, return capabilities
+#     | <-----------------result-     |
+#     |                               |
+#     |--initialized (notif)------>   |  no-op (handshake complete)
+#     |                               |
+#     |--textDocument/didOpen------>  |  open doc, parse, push diagnostics
+#     |--textDocument/didChange---->  |  apply change, re-parse, push diagnostics
+#     |--textDocument/hover-------->  |  get parse result, call bridge.hover
+#     | <-----------------result-     |
+#     |                               |
+#     |--shutdown------------------> |  set shutdown flag, return null
+#     |--exit (notif)---------------> |  exit(0) or exit(1)
+#
+# # Sending Notifications to the Editor
+#
+# The JSON-RPC Server handles request/response pairs. But the LSP server
+# also needs to PUSH notifications to the editor (e.g.,
+# textDocument/publishDiagnostics). We do this by holding a reference to
+# the JSON-RPC MessageWriter and calling write_message directly.
+#
+# ================================================================
+
+require "coding_adventures_json_rpc"
+require_relative "handlers"
+
+module CodingAdventures
+  module Ls00
+    class LspServer
+      include Handlers
+
+      # Create an LspServer wired to read from +in_stream+ and write to
+      # +out_stream+.
+      #
+      # Typically:
+      #   server = CodingAdventures::Ls00::LspServer.new(my_bridge, STDIN, STDOUT)
+      #   server.serve
+      #
+      # For testing, pass StringIO or pipe pairs as in_stream and out_stream.
+      def initialize(bridge, in_stream, out_stream)
+        @bridge = bridge
+        @doc_manager = DocumentManager.new
+        @parse_cache = ParseCache.new
+        @rpc_server = JsonRpc::Server.new(in_stream, out_stream)
+        @writer = JsonRpc::MessageWriter.new(out_stream)
+        @shutdown = false
+        @initialized = false
+
+        register_handlers
+      end
+
+      # serve starts the blocking JSON-RPC read-dispatch-write loop.
+      #
+      # This call blocks until the editor closes the connection (EOF on stdin).
+      # All LSP messages are handled synchronously in this loop.
+      def serve
+        @rpc_server.serve
+      end
+
+      private
+
+      # send_notification sends a server-initiated notification to the editor.
+      #
+      # LSP servers push certain events proactively without the editor asking.
+      # The most important is textDocument/publishDiagnostics, which is sent
+      # after every parse to update the editor's squiggle underlines.
+      def send_notification(method, params)
+        notif = JsonRpc::Notification.new(method: method, params: params)
+        @writer.write_message(notif)
+      end
+
+      # register_handlers wires all LSP method names to their Ruby handler methods.
+      def register_handlers
+        # -- Lifecycle --
+        @rpc_server.on_request("initialize") { |id, params| handle_initialize(id, params) }
+        @rpc_server.on_notification("initialized") { |params| handle_initialized(params) }
+        @rpc_server.on_request("shutdown") { |id, params| handle_shutdown(id, params) }
+        @rpc_server.on_notification("exit") { |params| handle_exit(params) }
+
+        # -- Text document synchronization --
+        @rpc_server.on_notification("textDocument/didOpen") { |params| handle_did_open(params) }
+        @rpc_server.on_notification("textDocument/didChange") { |params| handle_did_change(params) }
+        @rpc_server.on_notification("textDocument/didClose") { |params| handle_did_close(params) }
+        @rpc_server.on_notification("textDocument/didSave") { |params| handle_did_save(params) }
+
+        # -- Feature requests (all conditional on bridge capability) --
+        @rpc_server.on_request("textDocument/hover") { |id, params| handle_hover(id, params) }
+        @rpc_server.on_request("textDocument/definition") { |id, params| handle_definition(id, params) }
+        @rpc_server.on_request("textDocument/references") { |id, params| handle_references(id, params) }
+        @rpc_server.on_request("textDocument/completion") { |id, params| handle_completion(id, params) }
+        @rpc_server.on_request("textDocument/rename") { |id, params| handle_rename(id, params) }
+        @rpc_server.on_request("textDocument/documentSymbol") { |id, params| handle_document_symbol(id, params) }
+        @rpc_server.on_request("textDocument/semanticTokens/full") { |id, params| handle_semantic_tokens_full(id, params) }
+        @rpc_server.on_request("textDocument/foldingRange") { |id, params| handle_folding_range(id, params) }
+        @rpc_server.on_request("textDocument/signatureHelp") { |id, params| handle_signature_help(id, params) }
+        @rpc_server.on_request("textDocument/formatting") { |id, params| handle_formatting(id, params) }
+      end
+
+      # get_parse_result retrieves the current parse result for a document.
+      #
+      # This is the hot path for all feature handlers. It:
+      #  1. Gets the current document text from the DocumentManager
+      #  2. Returns the cached ParseResult (or re-parses if needed)
+      #
+      # Returns [doc, parse_result] or [nil, nil] if the document is not open.
+      def get_parse_result(uri)
+        doc = @doc_manager.get(uri)
+        return [nil, nil] unless doc
+
+        result = @parse_cache.get_or_parse(uri, doc.version, doc.text, @bridge)
+        [doc, result]
+      end
+
+      # publish_diagnostics sends the textDocument/publishDiagnostics
+      # notification to the editor.
+      #
+      # Called after every didOpen and didChange event to update the
+      # squiggle underlines in the editor.
+      def publish_diagnostics(uri, version, diagnostics)
+        lsp_diags = diagnostics.map do |d|
+          diag = {
+            "range" => range_to_lsp(d.range),
+            "severity" => d.severity,
+            "message" => d.message
+          }
+          diag["code"] = d.code if d.code && !d.code.empty?
+          diag
+        end
+
+        params = { "uri" => uri, "diagnostics" => lsp_diags }
+        params["version"] = version if version > 0
+
+        # Best-effort: if the write fails, there's nothing we can do.
+        begin
+          send_notification("textDocument/publishDiagnostics", params)
+        rescue StandardError
+          # swallow
+        end
+      end
+    end
+  end
+end

--- a/code/packages/ruby/ls00/lib/coding_adventures/ls00/types.rb
+++ b/code/packages/ruby/ls00/lib/coding_adventures/ls00/types.rb
@@ -1,0 +1,218 @@
+# frozen_string_literal: true
+
+# ================================================================
+# CodingAdventures::Ls00 — LSP Data Types
+# ================================================================
+#
+# These types mirror the LSP specification's TypeScript type definitions,
+# translated to idiomatic Ruby using Struct classes.
+#
+# The LSP spec lives at:
+# https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/
+#
+# # Coordinate System
+#
+# LSP uses a 0-based, line/character coordinate system. Line 0, character 0 is
+# the very first character of the file. This differs from most editors (which
+# display 1-based line numbers) and from our lexer (which emits 1-based tokens).
+# The LanguageBridge is responsible for converting.
+#
+# # UTF-16 Code Units
+#
+# LSP's "character" offset is measured in UTF-16 CODE UNITS, not bytes or
+# Unicode codepoints. This is a historical artifact: VS Code is built on
+# TypeScript, which uses UTF-16 strings internally. See document_manager.rb
+# for the conversion function and a detailed explanation of why this matters.
+#
+# ================================================================
+
+module CodingAdventures
+  module Ls00
+    # Position is a cursor position in a document.
+    #
+    # Both +line+ and +character+ are 0-based. Character is measured in UTF-16
+    # code units (see the module doc above for why).
+    #
+    # Example: in the string "hello guitar-emoji world", the guitar emoji
+    # occupies UTF-16 characters 6 and 7 (it requires two UTF-16 surrogates).
+    # "world" starts at UTF-16 character 8.
+    Position = Struct.new(:line, :character, keyword_init: true)
+
+    # Range is a span of text in a document, from +start+ (inclusive) to
+    # +end_pos+ (exclusive).
+    #
+    # Analogy: think of it like a text selection. Start is where the cursor
+    # lands when you click, end_pos is where you drag to.
+    #
+    # Note: we use +end_pos+ instead of +end+ because +end+ is a Ruby
+    # reserved word.
+    LspRange = Struct.new(:start, :end_pos, keyword_init: true)
+
+    # Location is a position in a specific file.
+    #
+    # URI uses the "file://" scheme, e.g., "file:///home/user/main.rb".
+    Location = Struct.new(:uri, :range, keyword_init: true)
+
+    # DiagnosticSeverity represents how serious a diagnostic is.
+    # These match the LSP integer codes.
+    module DiagnosticSeverity
+      # A hard error; the code cannot run or compile.
+      ERROR = 1
+      # Potentially problematic, but not blocking.
+      WARNING = 2
+      # Informational message.
+      INFORMATION = 3
+      # A suggestion (e.g., "consider using const").
+      HINT = 4
+    end
+
+    # Diagnostic is an error, warning, or hint to display in the editor.
+    #
+    # The editor renders diagnostics as underlined squiggles, with the message
+    # shown on hover. Red squiggles = Error, yellow = Warning, blue = Info.
+    Diagnostic = Struct.new(:range, :severity, :message, :code, keyword_init: true)
+
+    # Token is a single lexical token from the language's lexer.
+    #
+    # The bridge's +tokenize+ method returns an array of these. The LSP server
+    # uses tokens to provide semantic syntax highlighting (SemanticTokensProvider).
+    #
+    # Note: +line+ and +column+ are 1-based (matching most lexers). The bridge
+    # must convert to 0-based when building SemanticToken values for the LSP
+    # response.
+    Token = Struct.new(:type, :value, :line, :column, keyword_init: true)
+
+    # TextEdit is a single text replacement in a document.
+    #
+    # Used by formatting (replace the whole file) and rename (replace each
+    # occurrence). +new_text+ replaces the content at +range+. If +new_text+
+    # is empty, the range is deleted.
+    TextEdit = Struct.new(:range, :new_text, keyword_init: true)
+
+    # WorkspaceEdit groups TextEdits across potentially multiple files.
+    #
+    # For rename operations that affect a single file, +changes+ will have one
+    # key. For multi-file projects, a rename may produce edits across many files.
+    WorkspaceEdit = Struct.new(:changes, keyword_init: true) # changes: { uri => [TextEdit] }
+
+    # HoverResult is the content to show in the hover popup.
+    #
+    # +contents+ is Markdown text. VS Code renders it with syntax highlighting,
+    # bold/italic, code blocks, etc. +range+ is optional -- if set, it highlights
+    # the symbol in the editor when the hover popup is shown.
+    HoverResult = Struct.new(:contents, :range, keyword_init: true)
+
+    # CompletionItemKind classifies completion items so the editor can show
+    # the right icon (function icon, variable icon, keyword icon, etc.).
+    module CompletionItemKind
+      TEXT          = 1
+      METHOD        = 2
+      FUNCTION      = 3
+      CONSTRUCTOR   = 4
+      FIELD         = 5
+      VARIABLE      = 6
+      CLASS         = 7
+      INTERFACE     = 8
+      MODULE        = 9
+      PROPERTY      = 10
+      UNIT          = 11
+      VALUE         = 12
+      ENUM          = 13
+      KEYWORD       = 14
+      SNIPPET       = 15
+      COLOR         = 16
+      FILE          = 17
+      REFERENCE     = 18
+      FOLDER        = 19
+      ENUM_MEMBER   = 20
+      CONSTANT      = 21
+      STRUCT        = 22
+      EVENT         = 23
+      OPERATOR      = 24
+      TYPE_PARAMETER = 25
+    end
+
+    # CompletionItem is a single autocomplete suggestion.
+    #
+    # When the user triggers autocomplete (e.g., by pressing Ctrl+Space or
+    # typing after a dot), the editor shows a dropdown list of CompletionItems.
+    CompletionItem = Struct.new(:label, :kind, :detail, :documentation,
+                               :insert_text, :insert_text_format,
+                               keyword_init: true)
+
+    # SemanticToken is one token's contribution to the semantic highlighting pass.
+    #
+    # Semantic tokens are the "second pass" of syntax highlighting. The editor's
+    # grammar-based highlighter (TextMate/tmLanguage) does a fast regex pass
+    # first. Semantic tokens layer on top with accurate, context-aware type info.
+    #
+    # +line+ and +character+ are 0-based. +token_type+ and +modifiers+ reference
+    # entries in the legend returned by SemanticTokenLegend (see capabilities.rb).
+    SemanticToken = Struct.new(:line, :character, :length, :token_type,
+                              :modifiers, keyword_init: true)
+
+    # SymbolKind classifies document symbols for the outline panel.
+    # These match the LSP integer codes (1-based).
+    module SymbolKind
+      FILE           = 1
+      MODULE         = 2
+      NAMESPACE      = 3
+      PACKAGE        = 4
+      CLASS          = 5
+      METHOD         = 6
+      PROPERTY       = 7
+      FIELD          = 8
+      CONSTRUCTOR    = 9
+      ENUM           = 10
+      INTERFACE      = 11
+      FUNCTION       = 12
+      VARIABLE       = 13
+      CONSTANT       = 14
+      STRING         = 15
+      NUMBER         = 16
+      BOOLEAN        = 17
+      ARRAY          = 18
+      OBJECT         = 19
+      KEY            = 20
+      NULL           = 21
+      ENUM_MEMBER    = 22
+      STRUCT         = 23
+      EVENT          = 24
+      OPERATOR       = 25
+      TYPE_PARAMETER = 26
+    end
+
+    # DocumentSymbol is one entry in the document outline panel.
+    #
+    # The outline shows a tree of named symbols (functions, classes, variables).
+    # +children+ allows nesting: a class symbol can have method symbols as children.
+    #
+    # +range+ covers the entire symbol (including its body). +selection_range+
+    # is the smaller range of just the symbol's name.
+    DocumentSymbol = Struct.new(:name, :kind, :range, :selection_range,
+                               :children, keyword_init: true)
+
+    # FoldingRange is a collapsible region of the document.
+    #
+    # The editor shows a collapse arrow in the gutter next to +start_line+. When
+    # collapsed, lines start_line+1 through end_line are hidden. +kind+ is one of
+    # "region", "imports", or "comment".
+    FoldingRange = Struct.new(:start_line, :end_line, :kind, keyword_init: true)
+
+    # ParameterInformation is one parameter in a function signature.
+    ParameterInformation = Struct.new(:label, :documentation, keyword_init: true)
+
+    # SignatureInformation is one function overload's full signature.
+    SignatureInformation = Struct.new(:label, :documentation, :parameters,
+                                     keyword_init: true)
+
+    # SignatureHelpResult is shown as a tooltip when the user is typing a
+    # function call.
+    #
+    # It shows the function signature with the current parameter highlighted.
+    # +active_signature+ indexes into +signatures+. +active_parameter+ indexes
+    # into that signature's +parameters+.
+    SignatureHelpResult = Struct.new(:signatures, :active_signature,
+                                    :active_parameter, keyword_init: true)
+  end
+end

--- a/code/packages/ruby/ls00/lib/coding_adventures/ls00/version.rb
+++ b/code/packages/ruby/ls00/lib/coding_adventures/ls00/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module Ls00
+    VERSION = "0.1.0"
+  end
+end

--- a/code/packages/ruby/ls00/lib/coding_adventures_ls00.rb
+++ b/code/packages/ruby/ls00/lib/coding_adventures_ls00.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# ================================================================
+# coding_adventures_ls00 -- top-level entry point
+# ================================================================
+#
+# Generic Language Server Protocol (LSP) framework.
+#
+# This gem implements the protocol boilerplate that every LSP server
+# needs. A language author only writes a "bridge" object (see
+# language_bridge.rb for the duck-type contract) that connects their
+# lexer/parser to this framework.
+#
+# Architecture:
+#
+#   Lexer -> Parser -> [LanguageBridge] -> [LspServer] -> VS Code / Neovim / Emacs
+#
+# JSON-RPC over stdio:
+#
+#   Like the Debug Adapter Protocol (DAP), LSP speaks JSON-RPC over
+#   stdio. Each message is Content-Length-framed (same format as HTTP
+#   headers). The underlying transport is handled by the json_rpc gem.
+#
+# How to use this gem:
+#
+#   1. Create a bridge object implementing +tokenize+ and +parse+
+#      (plus any optional methods like +hover+, +definition+, etc.)
+#   2. Create a server:
+#        server = CodingAdventures::Ls00::LspServer.new(bridge, STDIN, STDOUT)
+#   3. Call server.serve -- it blocks until the editor closes the connection.
+#
+# ================================================================
+
+require_relative "coding_adventures/ls00/version"
+require_relative "coding_adventures/ls00/types"
+require_relative "coding_adventures/ls00/language_bridge"
+require_relative "coding_adventures/ls00/lsp_errors"
+require_relative "coding_adventures/ls00/document_manager"
+require_relative "coding_adventures/ls00/parse_cache"
+require_relative "coding_adventures/ls00/capabilities"
+require_relative "coding_adventures/ls00/handlers"
+require_relative "coding_adventures/ls00/server"

--- a/code/packages/ruby/ls00/test/test_capabilities.rb
+++ b/code/packages/ruby/ls00/test/test_capabilities.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# ================================================================
+# Capabilities Tests
+# ================================================================
+#
+# Tests for the capability advertisement system. The server must
+# advertise exactly the features the bridge supports -- no more,
+# no less.
+#
+# ================================================================
+
+class TestCapabilities < Minitest::Test
+  # A minimal bridge (tokenize + parse only) should advertise only
+  # textDocumentSync. No optional capabilities should appear.
+  def test_minimal_bridge
+    bridge = MinimalBridge.new
+    caps = CodingAdventures::Ls00.build_capabilities(bridge)
+
+    assert_equal 2, caps["textDocumentSync"]
+
+    optional_caps = %w[
+      hoverProvider definitionProvider referencesProvider
+      completionProvider renameProvider documentSymbolProvider
+      foldingRangeProvider signatureHelpProvider
+      documentFormattingProvider semanticTokensProvider
+    ]
+
+    optional_caps.each do |cap|
+      refute caps.key?(cap), "minimal bridge should not advertise #{cap}"
+    end
+  end
+
+  # MockBridge implements hover and document_symbols.
+  def test_mock_bridge
+    bridge = MockBridge.new
+    caps = CodingAdventures::Ls00.build_capabilities(bridge)
+
+    assert caps.key?("hoverProvider"), "expected hoverProvider for MockBridge"
+    assert caps.key?("documentSymbolProvider"), "expected documentSymbolProvider for MockBridge"
+  end
+
+  # MockBridge does NOT implement semanticTokensProvider.
+  def test_semantic_tokens_not_in_mock
+    bridge = MockBridge.new
+    caps = CodingAdventures::Ls00.build_capabilities(bridge)
+    refute caps.key?("semanticTokensProvider"),
+           "MockBridge doesn't implement semantic_tokens, should not be in caps"
+  end
+
+  # FullMockBridge implements everything, including semanticTokensProvider.
+  def test_semantic_tokens_in_full_bridge
+    bridge = FullMockBridge.new
+    caps = CodingAdventures::Ls00.build_capabilities(bridge)
+
+    assert caps.key?("semanticTokensProvider"),
+           "FullMockBridge implements semantic_tokens, should be in caps"
+
+    st_provider = caps["semanticTokensProvider"]
+    assert_equal true, st_provider["full"]
+    assert st_provider.key?("legend")
+  end
+
+  # FullMockBridge should advertise ALL capabilities.
+  def test_full_bridge_all_capabilities
+    bridge = FullMockBridge.new
+    caps = CodingAdventures::Ls00.build_capabilities(bridge)
+
+    expected = %w[
+      textDocumentSync
+      hoverProvider definitionProvider referencesProvider
+      completionProvider renameProvider documentSymbolProvider
+      foldingRangeProvider signatureHelpProvider
+      documentFormattingProvider semanticTokensProvider
+    ]
+
+    expected.each do |cap|
+      assert caps.key?(cap), "expected capability #{cap} for full bridge"
+    end
+  end
+
+  def test_semantic_token_legend_consistency
+    legend = CodingAdventures::Ls00.semantic_token_legend
+
+    refute_empty legend["tokenTypes"]
+    refute_empty legend["tokenModifiers"]
+
+    # Check that critical types are present.
+    required_types = %w[keyword string number variable function]
+    required_types.each do |rt|
+      assert_includes legend["tokenTypes"], rt, "legend missing required type #{rt}"
+    end
+  end
+end

--- a/code/packages/ruby/ls00/test/test_document_manager.rb
+++ b/code/packages/ruby/ls00/test/test_document_manager.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# ================================================================
+# DocumentManager Tests
+# ================================================================
+#
+# Tests for the DocumentManager which tracks open files, applies
+# incremental changes, and handles open/close lifecycle.
+#
+# ================================================================
+
+class TestDocumentManager < Minitest::Test
+  def test_open
+    dm = CodingAdventures::Ls00::DocumentManager.new
+    dm.open("file:///test.txt", "hello world", 1)
+
+    doc = dm.get("file:///test.txt")
+    refute_nil doc
+    assert_equal "hello world", doc.text
+    assert_equal 1, doc.version
+  end
+
+  def test_get_missing
+    dm = CodingAdventures::Ls00::DocumentManager.new
+    doc = dm.get("file:///nonexistent.txt")
+    assert_nil doc
+  end
+
+  def test_close
+    dm = CodingAdventures::Ls00::DocumentManager.new
+    dm.open("file:///test.txt", "hello", 1)
+    dm.close("file:///test.txt")
+
+    doc = dm.get("file:///test.txt")
+    assert_nil doc
+  end
+
+  def test_apply_changes_full_replacement
+    dm = CodingAdventures::Ls00::DocumentManager.new
+    dm.open("file:///test.txt", "hello world", 1)
+
+    dm.apply_changes("file:///test.txt", [
+      CodingAdventures::Ls00::TextChange.new(range: nil, new_text: "goodbye world")
+    ], 2)
+
+    doc = dm.get("file:///test.txt")
+    assert_equal "goodbye world", doc.text
+    assert_equal 2, doc.version
+  end
+
+  def test_apply_changes_incremental
+    dm = CodingAdventures::Ls00::DocumentManager.new
+    dm.open("file:///test.txt", "hello world", 1)
+
+    # Replace "world" with "Go" -- range covers chars 6-11 on line 0
+    dm.apply_changes("file:///test.txt", [
+      CodingAdventures::Ls00::TextChange.new(
+        range: CodingAdventures::Ls00::LspRange.new(
+          start: CodingAdventures::Ls00::Position.new(line: 0, character: 6),
+          end_pos: CodingAdventures::Ls00::Position.new(line: 0, character: 11)
+        ),
+        new_text: "Go"
+      )
+    ], 2)
+
+    doc = dm.get("file:///test.txt")
+    assert_equal "hello Go", doc.text
+  end
+
+  def test_apply_changes_not_open
+    dm = CodingAdventures::Ls00::DocumentManager.new
+    assert_raises(RuntimeError) do
+      dm.apply_changes("file:///notopen.txt", [
+        CodingAdventures::Ls00::TextChange.new(range: nil, new_text: "x")
+      ], 1)
+    end
+  end
+
+  # Incremental change with emoji.
+  # "A\u{1F3B8}B" -- emoji is 4 UTF-8 bytes, 2 UTF-16 code units
+  # Replace "B" (UTF-16 char 3, byte offset 5) with "X"
+  def test_incremental_with_emoji
+    dm = CodingAdventures::Ls00::DocumentManager.new
+    dm.open("file:///test.txt", "A\u{1F3B8}B", 1)
+
+    dm.apply_changes("file:///test.txt", [
+      CodingAdventures::Ls00::TextChange.new(
+        range: CodingAdventures::Ls00::LspRange.new(
+          start: CodingAdventures::Ls00::Position.new(line: 0, character: 3),
+          end_pos: CodingAdventures::Ls00::Position.new(line: 0, character: 4)
+        ),
+        new_text: "X"
+      )
+    ], 2)
+
+    doc = dm.get("file:///test.txt")
+    assert_equal "A\u{1F3B8}X", doc.text
+  end
+
+  # Two incremental changes applied in sequence.
+  def test_incremental_multi_change
+    dm = CodingAdventures::Ls00::DocumentManager.new
+    dm.open("uri", "hello world", 1)
+
+    # Change "hello" to "hi"
+    dm.apply_changes("uri", [
+      CodingAdventures::Ls00::TextChange.new(
+        range: CodingAdventures::Ls00::LspRange.new(
+          start: CodingAdventures::Ls00::Position.new(line: 0, character: 0),
+          end_pos: CodingAdventures::Ls00::Position.new(line: 0, character: 5)
+        ),
+        new_text: "hi"
+      )
+    ], 2)
+
+    doc = dm.get("uri")
+    assert_equal "hi world", doc.text
+  end
+end

--- a/code/packages/ruby/ls00/test/test_helper.rb
+++ b/code/packages/ruby/ls00/test/test_helper.rb
@@ -1,0 +1,259 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "stringio"
+require "json"
+require "coding_adventures_json_rpc"
+require "coding_adventures_ls00"
+
+# ================================================================
+# Test Bridges — MockBridge and MinimalBridge
+# ================================================================
+#
+# MockBridge implements the required LanguageBridge methods PLUS hover
+# and document_symbols. It provides deterministic, simple behaviors
+# for testing the framework without a real language implementation.
+#
+# MinimalBridge implements ONLY the required methods (tokenize, parse).
+# Used to test that optional capabilities are NOT advertised.
+#
+# FullMockBridge extends MockBridge with ALL optional provider methods.
+# Used to test full capability advertisement and all handler paths.
+#
+# ================================================================
+
+# MockBridge implements required methods plus hover and document_symbols.
+class MockBridge
+  attr_accessor :hover_result
+
+  def initialize
+    @hover_result = nil
+  end
+
+  # tokenize splits source by whitespace and returns one token per word.
+  def tokenize(source)
+    col = 1
+    source.split.map do |word|
+      tok = CodingAdventures::Ls00::Token.new(
+        type: "WORD", value: word, line: 1, column: col
+      )
+      col += word.length + 1
+      tok
+    end
+  end
+
+  # parse returns a minimal AST. If source contains "ERROR", it returns
+  # a diagnostic.
+  def parse(source)
+    diags = []
+    if source.include?("ERROR")
+      diags << CodingAdventures::Ls00::Diagnostic.new(
+        range: CodingAdventures::Ls00::LspRange.new(
+          start: CodingAdventures::Ls00::Position.new(line: 0, character: 0),
+          end_pos: CodingAdventures::Ls00::Position.new(line: 0, character: 5)
+        ),
+        severity: CodingAdventures::Ls00::DiagnosticSeverity::ERROR,
+        message: "syntax error: unexpected ERROR token",
+        code: nil
+      )
+    end
+    [source, diags]
+  end
+
+  # hover returns the configured hover_result.
+  def hover(_ast, _pos)
+    @hover_result
+  end
+
+  # document_symbols returns a fixed two-symbol tree.
+  def document_symbols(_ast)
+    [
+      CodingAdventures::Ls00::DocumentSymbol.new(
+        name: "main",
+        kind: CodingAdventures::Ls00::SymbolKind::FUNCTION,
+        range: CodingAdventures::Ls00::LspRange.new(
+          start: CodingAdventures::Ls00::Position.new(line: 0, character: 0),
+          end_pos: CodingAdventures::Ls00::Position.new(line: 10, character: 1)
+        ),
+        selection_range: CodingAdventures::Ls00::LspRange.new(
+          start: CodingAdventures::Ls00::Position.new(line: 0, character: 9),
+          end_pos: CodingAdventures::Ls00::Position.new(line: 0, character: 13)
+        ),
+        children: [
+          CodingAdventures::Ls00::DocumentSymbol.new(
+            name: "x",
+            kind: CodingAdventures::Ls00::SymbolKind::VARIABLE,
+            range: CodingAdventures::Ls00::LspRange.new(
+              start: CodingAdventures::Ls00::Position.new(line: 1, character: 4),
+              end_pos: CodingAdventures::Ls00::Position.new(line: 1, character: 12)
+            ),
+            selection_range: CodingAdventures::Ls00::LspRange.new(
+              start: CodingAdventures::Ls00::Position.new(line: 1, character: 8),
+              end_pos: CodingAdventures::Ls00::Position.new(line: 1, character: 9)
+            ),
+            children: []
+          )
+        ]
+      )
+    ]
+  end
+end
+
+# MinimalBridge implements ONLY the required LanguageBridge interface.
+class MinimalBridge
+  def tokenize(_source)
+    []
+  end
+
+  def parse(source)
+    [source, []]
+  end
+end
+
+# FullMockBridge extends MockBridge with all optional interfaces.
+class FullMockBridge < MockBridge
+  def semantic_tokens(_source, tokens)
+    tokens.map do |tok|
+      CodingAdventures::Ls00::SemanticToken.new(
+        line: tok.line - 1,
+        character: tok.column - 1,
+        length: tok.value.length,
+        token_type: "variable",
+        modifiers: nil
+      )
+    end
+  end
+
+  def definition(_ast, pos, uri)
+    CodingAdventures::Ls00::Location.new(
+      uri: uri,
+      range: CodingAdventures::Ls00::LspRange.new(start: pos, end_pos: pos)
+    )
+  end
+
+  def references(_ast, pos, uri, _include_decl)
+    [CodingAdventures::Ls00::Location.new(
+      uri: uri,
+      range: CodingAdventures::Ls00::LspRange.new(start: pos, end_pos: pos)
+    )]
+  end
+
+  def completion(_ast, _pos)
+    [CodingAdventures::Ls00::CompletionItem.new(
+      label: "foo",
+      kind: CodingAdventures::Ls00::CompletionItemKind::FUNCTION,
+      detail: "() void"
+    )]
+  end
+
+  def rename(_ast, pos, new_name)
+    CodingAdventures::Ls00::WorkspaceEdit.new(
+      changes: {
+        "file:///test.txt" => [
+          CodingAdventures::Ls00::TextEdit.new(
+            range: CodingAdventures::Ls00::LspRange.new(start: pos, end_pos: pos),
+            new_text: new_name
+          )
+        ]
+      }
+    )
+  end
+
+  def folding_ranges(_ast)
+    [CodingAdventures::Ls00::FoldingRange.new(start_line: 0, end_line: 5, kind: "region")]
+  end
+
+  def signature_help(_ast, _pos)
+    CodingAdventures::Ls00::SignatureHelpResult.new(
+      signatures: [
+        CodingAdventures::Ls00::SignatureInformation.new(
+          label: "foo(a int, b string)",
+          documentation: nil,
+          parameters: [
+            CodingAdventures::Ls00::ParameterInformation.new(label: "a int", documentation: nil),
+            CodingAdventures::Ls00::ParameterInformation.new(label: "b string", documentation: nil)
+          ]
+        )
+      ],
+      active_signature: 0,
+      active_parameter: 0
+    )
+  end
+
+  def format(source)
+    [CodingAdventures::Ls00::TextEdit.new(
+      range: CodingAdventures::Ls00::LspRange.new(
+        start: CodingAdventures::Ls00::Position.new(line: 0, character: 0),
+        end_pos: CodingAdventures::Ls00::Position.new(line: 999, character: 0)
+      ),
+      new_text: source # no-op formatter: returns source unchanged
+    )]
+  end
+end
+
+# ================================================================
+# JSON-RPC test helpers
+# ================================================================
+
+# make_message creates a Content-Length-framed JSON-RPC message string.
+def make_message(obj)
+  json = JSON.generate(obj)
+  "Content-Length: #{json.bytesize}\r\n\r\n#{json}"
+end
+
+# read_message reads one Content-Length-framed message from a StringIO.
+def read_message(io)
+  reader = CodingAdventures::JsonRpc::MessageReader.new(io)
+  reader.read_message
+end
+
+# pipe_server creates an LspServer with pipe-based IO for testing.
+# Returns [writer_to_server, reader_from_server, server_thread].
+def pipe_server(bridge)
+  in_r, in_w = IO.pipe
+  out_r, out_w = IO.pipe
+  in_r.binmode
+  in_w.binmode
+  out_r.binmode
+  out_w.binmode
+
+  server = CodingAdventures::Ls00::LspServer.new(bridge, in_r, out_w)
+  thread = Thread.new do
+    server.serve
+  rescue StandardError
+    # swallow errors on shutdown
+  ensure
+    out_w.close rescue nil # rubocop:disable Style/RescueModifier
+  end
+
+  client_writer = CodingAdventures::JsonRpc::MessageWriter.new(in_w)
+  client_reader = CodingAdventures::JsonRpc::MessageReader.new(out_r)
+
+  [client_writer, client_reader, thread, in_w]
+end
+
+# send_request sends a JSON-RPC request and returns the response result.
+def send_rpc_request(writer, reader, id, method, params)
+  req = CodingAdventures::JsonRpc::Request.new(id: id, method: method, params: params)
+  writer.write_message(req)
+
+  msg = reader.read_message
+  raise "expected Response, got #{msg.class}" unless msg.is_a?(CodingAdventures::JsonRpc::Response)
+  raise "expected id #{id}, got #{msg.id}" unless msg.id == id
+
+  msg
+end
+
+# send_notification sends a JSON-RPC notification (no response expected).
+def send_rpc_notification(writer, method, params)
+  notif = CodingAdventures::JsonRpc::Notification.new(method: method, params: params)
+  writer.write_message(notif)
+end
+
+# read_notification reads the next message, expecting a notification.
+def read_rpc_notification(reader)
+  msg = reader.read_message
+  raise "expected Notification, got #{msg.class}" unless msg.is_a?(CodingAdventures::JsonRpc::Notification)
+
+  msg
+end

--- a/code/packages/ruby/ls00/test/test_parse_cache.rb
+++ b/code/packages/ruby/ls00/test/test_parse_cache.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# ================================================================
+# ParseCache Tests
+# ================================================================
+#
+# Tests for the ParseCache which avoids re-parsing unchanged documents.
+#
+# ================================================================
+
+class TestParseCache < Minitest::Test
+  def test_hit_and_miss
+    bridge = MockBridge.new
+    cache = CodingAdventures::Ls00::ParseCache.new
+
+    # First call -- cache miss -> parse
+    r1 = cache.get_or_parse("file:///a.txt", 1, "hello", bridge)
+    refute_nil r1
+
+    # Second call same version -- cache hit -> same object
+    r2 = cache.get_or_parse("file:///a.txt", 1, "hello", bridge)
+    assert_same r1, r2
+
+    # Different version -- cache miss -> new result
+    r3 = cache.get_or_parse("file:///a.txt", 2, "hello world", bridge)
+    refute_same r1, r3
+  end
+
+  def test_evict
+    bridge = MockBridge.new
+    cache = CodingAdventures::Ls00::ParseCache.new
+
+    r1 = cache.get_or_parse("file:///a.txt", 1, "hello", bridge)
+    cache.evict("file:///a.txt")
+
+    # After eviction, same (uri, version) produces a new parse
+    r2 = cache.get_or_parse("file:///a.txt", 1, "hello", bridge)
+    refute_same r1, r2
+  end
+
+  def test_diagnostics_populated
+    bridge = MockBridge.new
+    cache = CodingAdventures::Ls00::ParseCache.new
+
+    result = cache.get_or_parse("file:///a.txt", 1, "source with ERROR token", bridge)
+    refute_empty result.diagnostics
+  end
+
+  def test_no_diagnostics_for_clean_source
+    bridge = MockBridge.new
+    cache = CodingAdventures::Ls00::ParseCache.new
+
+    result = cache.get_or_parse("file:///clean.txt", 1, "hello world", bridge)
+    assert_empty result.diagnostics
+  end
+end

--- a/code/packages/ruby/ls00/test/test_semantic_tokens.rb
+++ b/code/packages/ruby/ls00/test/test_semantic_tokens.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# ================================================================
+# Semantic Token Encoding Tests
+# ================================================================
+#
+# Tests for the compact delta-encoded format that LSP uses for
+# semantic tokens. See capabilities.rb for the encoding details.
+#
+# ================================================================
+
+class TestSemanticTokens < Minitest::Test
+  def test_empty
+    data = CodingAdventures::Ls00.encode_semantic_tokens(nil)
+    assert_empty data
+
+    data2 = CodingAdventures::Ls00.encode_semantic_tokens([])
+    assert_empty data2
+  end
+
+  # A single keyword token at the start of the file.
+  # Expected: [deltaLine=0, deltaChar=0, length=5, typeIndex=15 (keyword), modifiers=0]
+  def test_single_token
+    tokens = [
+      CodingAdventures::Ls00::SemanticToken.new(
+        line: 0, character: 0, length: 5, token_type: "keyword", modifiers: []
+      )
+    ]
+    data = CodingAdventures::Ls00.encode_semantic_tokens(tokens)
+
+    assert_equal 5, data.length
+    assert_equal 0, data[0]  # deltaLine
+    assert_equal 0, data[1]  # deltaChar
+    assert_equal 5, data[2]  # length
+    assert_equal 15, data[3] # keyword index
+    assert_equal 0, data[4]  # modifiers
+  end
+
+  # Two tokens on the same line.
+  # Token A: keyword at char 0, length 3
+  # Token B: function at char 4, length 4, with "declaration" modifier
+  def test_multiple_tokens_same_line
+    tokens = [
+      CodingAdventures::Ls00::SemanticToken.new(
+        line: 0, character: 0, length: 3, token_type: "keyword", modifiers: nil
+      ),
+      CodingAdventures::Ls00::SemanticToken.new(
+        line: 0, character: 4, length: 4, token_type: "function", modifiers: ["declaration"]
+      )
+    ]
+    data = CodingAdventures::Ls00.encode_semantic_tokens(tokens)
+
+    assert_equal 10, data.length
+
+    # Token A: deltaLine=0, deltaChar=0, length=3, keyword(15), mods=0
+    assert_equal [0, 0, 3, 15, 0], data[0..4]
+
+    # Token B: deltaLine=0, deltaChar=4, length=4, function(12), mods=1 (declaration=bit0)
+    assert_equal [0, 4, 4, 12, 1], data[5..9]
+  end
+
+  # Two tokens on different lines.
+  # Token A: keyword on line 0
+  # Token B: number on line 2, char 4
+  def test_multiple_lines
+    tokens = [
+      CodingAdventures::Ls00::SemanticToken.new(
+        line: 0, character: 0, length: 3, token_type: "keyword", modifiers: nil
+      ),
+      CodingAdventures::Ls00::SemanticToken.new(
+        line: 2, character: 4, length: 5, token_type: "number", modifiers: nil
+      )
+    ]
+    data = CodingAdventures::Ls00.encode_semantic_tokens(tokens)
+
+    assert_equal 10, data.length
+    # Token B: deltaLine=2, deltaChar=4 (absolute on new line), number=19
+    assert_equal 2, data[5]   # deltaLine
+    assert_equal 4, data[6]   # deltaChar (absolute on new line)
+    assert_equal 19, data[8]  # number index
+  end
+
+  # Tokens given in reverse order -- the encoder should sort them.
+  def test_unsorted_input
+    tokens = [
+      CodingAdventures::Ls00::SemanticToken.new(
+        line: 1, character: 0, length: 2, token_type: "number", modifiers: nil
+      ),
+      CodingAdventures::Ls00::SemanticToken.new(
+        line: 0, character: 0, length: 3, token_type: "keyword", modifiers: nil
+      )
+    ]
+    data = CodingAdventures::Ls00.encode_semantic_tokens(tokens)
+
+    assert_equal 10, data.length
+    # After sorting: keyword on line 0 first, number on line 1 second
+    assert_equal 15, data[3] # first token should be keyword (15)
+    assert_equal 19, data[8] # second token should be number (19)
+  end
+
+  # Unknown token type should be skipped.
+  def test_unknown_token_type
+    tokens = [
+      CodingAdventures::Ls00::SemanticToken.new(
+        line: 0, character: 0, length: 3, token_type: "unknownType", modifiers: nil
+      ),
+      CodingAdventures::Ls00::SemanticToken.new(
+        line: 0, character: 4, length: 2, token_type: "keyword", modifiers: nil
+      )
+    ]
+    data = CodingAdventures::Ls00.encode_semantic_tokens(tokens)
+
+    # unknownType should be skipped, leaving only one 5-tuple
+    assert_equal 5, data.length
+  end
+
+  # "readonly" modifier is bit 2 (index 2), value = 4.
+  def test_modifier_bitmask
+    tokens = [
+      CodingAdventures::Ls00::SemanticToken.new(
+        line: 0, character: 0, length: 3, token_type: "variable", modifiers: ["readonly"]
+      )
+    ]
+    data = CodingAdventures::Ls00.encode_semantic_tokens(tokens)
+
+    assert_equal 4, data[4] # readonly = bit 2 = value 4
+  end
+end

--- a/code/packages/ruby/ls00/test/test_server.rb
+++ b/code/packages/ruby/ls00/test/test_server.rb
@@ -1,0 +1,551 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# ================================================================
+# LSP Server Integration Tests
+# ================================================================
+#
+# These tests feed JSON-RPC messages through the full pipeline using
+# IO.pipe. The server runs in a thread; the test feeds messages and
+# reads responses.
+#
+# ================================================================
+
+class TestServer < Minitest::Test
+  # Verify the constructor returns a usable server.
+  def test_new_server_creates_server
+    bridge = MockBridge.new
+    in_io = StringIO.new("")
+    out_io = StringIO.new
+    server = CodingAdventures::Ls00::LspServer.new(bridge, in_io, out_io)
+    refute_nil server
+  end
+
+  # Test initialize handler returns capabilities.
+  def test_handler_initialize
+    bridge = MockBridge.new
+    bridge.hover_result = CodingAdventures::Ls00::HoverResult.new(contents: "test")
+    writer, reader, thread, in_w = pipe_server(bridge)
+
+    resp = send_rpc_request(writer, reader, 1, "initialize", {
+      "processId" => 1234,
+      "capabilities" => {}
+    })
+
+    refute_nil resp.result
+    caps = resp.result["capabilities"]
+    refute_nil caps
+    refute_nil caps["textDocumentSync"]
+    refute_nil caps["hoverProvider"]
+
+    server_info = resp.result["serverInfo"]
+    refute_nil server_info
+    assert_equal "ls00-generic-lsp-server", server_info["name"]
+
+    in_w.close rescue nil # rubocop:disable Style/RescueModifier
+    thread.join(2)
+  end
+
+  # Test that opening a file with errors causes publishDiagnostics.
+  def test_handler_did_open_publishes_diagnostics
+    bridge = MockBridge.new
+    writer, reader, thread, in_w = pipe_server(bridge)
+
+    # Initialize first
+    send_rpc_request(writer, reader, 1, "initialize", {
+      "processId" => 1, "capabilities" => {}
+    })
+    send_rpc_notification(writer, "initialized", {})
+
+    # Open a file with an error
+    send_rpc_notification(writer, "textDocument/didOpen", {
+      "textDocument" => {
+        "uri" => "file:///test.txt",
+        "languageId" => "test",
+        "version" => 1,
+        "text" => "hello ERROR world"
+      }
+    })
+
+    # Expect publishDiagnostics notification
+    notif = read_rpc_notification(reader)
+    assert_equal "textDocument/publishDiagnostics", notif.method
+
+    params = notif.params
+    assert_equal "file:///test.txt", params["uri"]
+    diags = params["diagnostics"]
+    refute_empty diags
+
+    in_w.close rescue nil # rubocop:disable Style/RescueModifier
+    thread.join(2)
+  end
+
+  # Test that a clean file produces empty diagnostics.
+  def test_handler_did_open_clean_file
+    bridge = MockBridge.new
+    writer, reader, thread, in_w = pipe_server(bridge)
+
+    send_rpc_request(writer, reader, 1, "initialize", {
+      "processId" => 1, "capabilities" => {}
+    })
+    send_rpc_notification(writer, "initialized", {})
+
+    send_rpc_notification(writer, "textDocument/didOpen", {
+      "textDocument" => {
+        "uri" => "file:///clean.txt",
+        "languageId" => "test",
+        "version" => 1,
+        "text" => "hello world"
+      }
+    })
+
+    notif = read_rpc_notification(reader)
+    assert_equal "textDocument/publishDiagnostics", notif.method
+    diags = notif.params["diagnostics"]
+    assert_empty diags
+
+    in_w.close rescue nil # rubocop:disable Style/RescueModifier
+    thread.join(2)
+  end
+
+  # Test hover handler end-to-end.
+  def test_handler_hover
+    bridge = MockBridge.new
+    bridge.hover_result = CodingAdventures::Ls00::HoverResult.new(
+      contents: "**main** function",
+      range: CodingAdventures::Ls00::LspRange.new(
+        start: CodingAdventures::Ls00::Position.new(line: 0, character: 0),
+        end_pos: CodingAdventures::Ls00::Position.new(line: 0, character: 4)
+      )
+    )
+    writer, reader, thread, in_w = pipe_server(bridge)
+
+    send_rpc_request(writer, reader, 1, "initialize", {
+      "processId" => 1, "capabilities" => {}
+    })
+    send_rpc_notification(writer, "initialized", {})
+    send_rpc_notification(writer, "textDocument/didOpen", {
+      "textDocument" => {
+        "uri" => "file:///test.go", "languageId" => "go",
+        "version" => 1, "text" => "func main() {}"
+      }
+    })
+    read_rpc_notification(reader) # consume publishDiagnostics
+
+    resp = send_rpc_request(writer, reader, 2, "textDocument/hover", {
+      "textDocument" => { "uri" => "file:///test.go" },
+      "position" => { "line" => 0, "character" => 5 }
+    })
+
+    refute_nil resp.result
+    contents = resp.result["contents"]
+    assert_equal "markdown", contents["kind"]
+    assert_equal "**main** function", contents["value"]
+
+    in_w.close rescue nil # rubocop:disable Style/RescueModifier
+    thread.join(2)
+  end
+
+  # Test that a minimal bridge returns null hover.
+  def test_handler_hover_no_bridge
+    bridge = MinimalBridge.new
+    writer, reader, thread, in_w = pipe_server(bridge)
+
+    send_rpc_request(writer, reader, 1, "initialize", {
+      "processId" => 1, "capabilities" => {}
+    })
+    send_rpc_notification(writer, "initialized", {})
+    send_rpc_notification(writer, "textDocument/didOpen", {
+      "textDocument" => {
+        "uri" => "file:///test.txt", "languageId" => "test",
+        "version" => 1, "text" => "hello"
+      }
+    })
+    read_rpc_notification(reader)
+
+    resp = send_rpc_request(writer, reader, 2, "textDocument/hover", {
+      "textDocument" => { "uri" => "file:///test.txt" },
+      "position" => { "line" => 0, "character" => 0 }
+    })
+
+    assert_nil resp.result
+
+    in_w.close rescue nil # rubocop:disable Style/RescueModifier
+    thread.join(2)
+  end
+
+  # Test documentSymbol handler.
+  def test_handler_document_symbol
+    bridge = MockBridge.new
+    writer, reader, thread, in_w = pipe_server(bridge)
+
+    send_rpc_request(writer, reader, 1, "initialize", {
+      "processId" => 1, "capabilities" => {}
+    })
+    send_rpc_notification(writer, "initialized", {})
+    send_rpc_notification(writer, "textDocument/didOpen", {
+      "textDocument" => {
+        "uri" => "file:///test.go", "languageId" => "go",
+        "version" => 1, "text" => "func main() { var x = 1 }"
+      }
+    })
+    read_rpc_notification(reader)
+
+    resp = send_rpc_request(writer, reader, 2, "textDocument/documentSymbol", {
+      "textDocument" => { "uri" => "file:///test.go" }
+    })
+
+    result = resp.result
+    refute_nil result
+    assert_kind_of Array, result
+    refute_empty result
+    assert_equal "main", result[0]["name"]
+
+    in_w.close rescue nil # rubocop:disable Style/RescueModifier
+    thread.join(2)
+  end
+
+  # Test semanticTokens/full handler.
+  def test_handler_semantic_tokens_full
+    bridge = FullMockBridge.new
+    writer, reader, thread, in_w = pipe_server(bridge)
+
+    send_rpc_request(writer, reader, 1, "initialize", {
+      "processId" => 1, "capabilities" => {}
+    })
+    send_rpc_notification(writer, "initialized", {})
+    send_rpc_notification(writer, "textDocument/didOpen", {
+      "textDocument" => {
+        "uri" => "file:///test.txt", "languageId" => "test",
+        "version" => 1, "text" => "hello world"
+      }
+    })
+    read_rpc_notification(reader)
+
+    resp = send_rpc_request(writer, reader, 2, "textDocument/semanticTokens/full", {
+      "textDocument" => { "uri" => "file:///test.txt" }
+    })
+
+    refute_nil resp.result
+    assert resp.result.key?("data")
+
+    in_w.close rescue nil # rubocop:disable Style/RescueModifier
+    thread.join(2)
+  end
+
+  # Test definition handler.
+  def test_handler_definition
+    bridge = FullMockBridge.new
+    writer, reader, thread, in_w = pipe_server(bridge)
+
+    send_rpc_request(writer, reader, 1, "initialize", {
+      "processId" => 1, "capabilities" => {}
+    })
+    send_rpc_notification(writer, "initialized", {})
+    send_rpc_notification(writer, "textDocument/didOpen", {
+      "textDocument" => {
+        "uri" => "file:///test.txt", "languageId" => "test",
+        "version" => 1, "text" => "hello world"
+      }
+    })
+    read_rpc_notification(reader)
+
+    resp = send_rpc_request(writer, reader, 2, "textDocument/definition", {
+      "textDocument" => { "uri" => "file:///test.txt" },
+      "position" => { "line" => 0, "character" => 0 }
+    })
+
+    refute_nil resp.result
+    assert_equal "file:///test.txt", resp.result["uri"]
+
+    in_w.close rescue nil # rubocop:disable Style/RescueModifier
+    thread.join(2)
+  end
+
+  # Test references handler.
+  def test_handler_references
+    bridge = FullMockBridge.new
+    writer, reader, thread, in_w = pipe_server(bridge)
+
+    send_rpc_request(writer, reader, 1, "initialize", {
+      "processId" => 1, "capabilities" => {}
+    })
+    send_rpc_notification(writer, "initialized", {})
+    send_rpc_notification(writer, "textDocument/didOpen", {
+      "textDocument" => {
+        "uri" => "file:///test.txt", "languageId" => "test",
+        "version" => 1, "text" => "hello"
+      }
+    })
+    read_rpc_notification(reader)
+
+    resp = send_rpc_request(writer, reader, 2, "textDocument/references", {
+      "textDocument" => { "uri" => "file:///test.txt" },
+      "position" => { "line" => 0, "character" => 0 },
+      "context" => { "includeDeclaration" => true }
+    })
+
+    result = resp.result
+    assert_kind_of Array, result
+    refute_empty result
+
+    in_w.close rescue nil # rubocop:disable Style/RescueModifier
+    thread.join(2)
+  end
+
+  # Test completion handler.
+  def test_handler_completion
+    bridge = FullMockBridge.new
+    writer, reader, thread, in_w = pipe_server(bridge)
+
+    send_rpc_request(writer, reader, 1, "initialize", {
+      "processId" => 1, "capabilities" => {}
+    })
+    send_rpc_notification(writer, "initialized", {})
+    send_rpc_notification(writer, "textDocument/didOpen", {
+      "textDocument" => {
+        "uri" => "file:///test.txt", "languageId" => "test",
+        "version" => 1, "text" => "foo"
+      }
+    })
+    read_rpc_notification(reader)
+
+    resp = send_rpc_request(writer, reader, 2, "textDocument/completion", {
+      "textDocument" => { "uri" => "file:///test.txt" },
+      "position" => { "line" => 0, "character" => 3 }
+    })
+
+    refute_nil resp.result
+    items = resp.result["items"]
+    assert_kind_of Array, items
+    refute_empty items
+
+    in_w.close rescue nil # rubocop:disable Style/RescueModifier
+    thread.join(2)
+  end
+
+  # Test rename handler.
+  def test_handler_rename
+    bridge = FullMockBridge.new
+    writer, reader, thread, in_w = pipe_server(bridge)
+
+    send_rpc_request(writer, reader, 1, "initialize", {
+      "processId" => 1, "capabilities" => {}
+    })
+    send_rpc_notification(writer, "initialized", {})
+    send_rpc_notification(writer, "textDocument/didOpen", {
+      "textDocument" => {
+        "uri" => "file:///test.txt", "languageId" => "test",
+        "version" => 1, "text" => "let x = 1"
+      }
+    })
+    read_rpc_notification(reader)
+
+    resp = send_rpc_request(writer, reader, 2, "textDocument/rename", {
+      "textDocument" => { "uri" => "file:///test.txt" },
+      "position" => { "line" => 0, "character" => 4 },
+      "newName" => "y"
+    })
+
+    refute_nil resp.result
+    refute_nil resp.result["changes"]
+
+    in_w.close rescue nil # rubocop:disable Style/RescueModifier
+    thread.join(2)
+  end
+
+  # Test foldingRange handler.
+  def test_handler_folding_range
+    bridge = FullMockBridge.new
+    writer, reader, thread, in_w = pipe_server(bridge)
+
+    send_rpc_request(writer, reader, 1, "initialize", {
+      "processId" => 1, "capabilities" => {}
+    })
+    send_rpc_notification(writer, "initialized", {})
+    send_rpc_notification(writer, "textDocument/didOpen", {
+      "textDocument" => {
+        "uri" => "file:///test.txt", "languageId" => "test",
+        "version" => 1, "text" => "func main() {\n  hello\n}"
+      }
+    })
+    read_rpc_notification(reader)
+
+    resp = send_rpc_request(writer, reader, 2, "textDocument/foldingRange", {
+      "textDocument" => { "uri" => "file:///test.txt" }
+    })
+
+    result = resp.result
+    assert_kind_of Array, result
+    refute_empty result
+
+    in_w.close rescue nil # rubocop:disable Style/RescueModifier
+    thread.join(2)
+  end
+
+  # Test signatureHelp handler.
+  def test_handler_signature_help
+    bridge = FullMockBridge.new
+    writer, reader, thread, in_w = pipe_server(bridge)
+
+    send_rpc_request(writer, reader, 1, "initialize", {
+      "processId" => 1, "capabilities" => {}
+    })
+    send_rpc_notification(writer, "initialized", {})
+    send_rpc_notification(writer, "textDocument/didOpen", {
+      "textDocument" => {
+        "uri" => "file:///test.txt", "languageId" => "test",
+        "version" => 1, "text" => "foo("
+      }
+    })
+    read_rpc_notification(reader)
+
+    resp = send_rpc_request(writer, reader, 2, "textDocument/signatureHelp", {
+      "textDocument" => { "uri" => "file:///test.txt" },
+      "position" => { "line" => 0, "character" => 4 }
+    })
+
+    refute_nil resp.result
+    sigs = resp.result["signatures"]
+    assert_kind_of Array, sigs
+    refute_empty sigs
+
+    in_w.close rescue nil # rubocop:disable Style/RescueModifier
+    thread.join(2)
+  end
+
+  # Test formatting handler.
+  def test_handler_formatting
+    bridge = FullMockBridge.new
+    writer, reader, thread, in_w = pipe_server(bridge)
+
+    send_rpc_request(writer, reader, 1, "initialize", {
+      "processId" => 1, "capabilities" => {}
+    })
+    send_rpc_notification(writer, "initialized", {})
+    send_rpc_notification(writer, "textDocument/didOpen", {
+      "textDocument" => {
+        "uri" => "file:///test.txt", "languageId" => "test",
+        "version" => 1, "text" => "hello  world"
+      }
+    })
+    read_rpc_notification(reader)
+
+    resp = send_rpc_request(writer, reader, 2, "textDocument/formatting", {
+      "textDocument" => { "uri" => "file:///test.txt" },
+      "options" => { "tabSize" => 2, "insertSpaces" => true }
+    })
+
+    result = resp.result
+    assert_kind_of Array, result
+    refute_empty result
+
+    in_w.close rescue nil # rubocop:disable Style/RescueModifier
+    thread.join(2)
+  end
+
+  # Test didChange updates the document and republishes diagnostics.
+  def test_handler_did_change
+    bridge = MockBridge.new
+    writer, reader, thread, in_w = pipe_server(bridge)
+
+    send_rpc_request(writer, reader, 1, "initialize", {
+      "processId" => 1, "capabilities" => {}
+    })
+    send_rpc_notification(writer, "initialized", {})
+    send_rpc_notification(writer, "textDocument/didOpen", {
+      "textDocument" => {
+        "uri" => "file:///test.txt", "languageId" => "test",
+        "version" => 1, "text" => "hello world"
+      }
+    })
+    read_rpc_notification(reader) # publishDiagnostics for open
+
+    # Change the document to add "ERROR"
+    send_rpc_notification(writer, "textDocument/didChange", {
+      "textDocument" => { "uri" => "file:///test.txt", "version" => 2 },
+      "contentChanges" => [
+        { "text" => "hello ERROR world" }
+      ]
+    })
+    notif = read_rpc_notification(reader)
+    assert_equal "textDocument/publishDiagnostics", notif.method
+    diags = notif.params["diagnostics"]
+    refute_empty diags
+
+    in_w.close rescue nil # rubocop:disable Style/RescueModifier
+    thread.join(2)
+  end
+
+  # Test didClose clears diagnostics.
+  def test_handler_did_close
+    bridge = MockBridge.new
+    writer, reader, thread, in_w = pipe_server(bridge)
+
+    send_rpc_request(writer, reader, 1, "initialize", {
+      "processId" => 1, "capabilities" => {}
+    })
+    send_rpc_notification(writer, "initialized", {})
+    send_rpc_notification(writer, "textDocument/didOpen", {
+      "textDocument" => {
+        "uri" => "file:///test.txt", "languageId" => "test",
+        "version" => 1, "text" => "hello"
+      }
+    })
+    read_rpc_notification(reader)
+
+    send_rpc_notification(writer, "textDocument/didClose", {
+      "textDocument" => { "uri" => "file:///test.txt" }
+    })
+    notif = read_rpc_notification(reader)
+    assert_equal "textDocument/publishDiagnostics", notif.method
+    diags = notif.params["diagnostics"]
+    assert_empty diags
+
+    in_w.close rescue nil # rubocop:disable Style/RescueModifier
+    thread.join(2)
+  end
+
+  # Test shutdown handler returns null.
+  def test_handler_shutdown
+    bridge = MockBridge.new
+    writer, reader, thread, in_w = pipe_server(bridge)
+
+    send_rpc_request(writer, reader, 1, "initialize", {
+      "processId" => 1, "capabilities" => {}
+    })
+
+    resp = send_rpc_request(writer, reader, 2, "shutdown", nil)
+    assert_nil resp.result
+
+    in_w.close rescue nil # rubocop:disable Style/RescueModifier
+    thread.join(2)
+  end
+
+  # Test LSP error codes are correct.
+  def test_lsp_error_codes
+    assert_equal(-32_002, CodingAdventures::Ls00::LspErrors::SERVER_NOT_INITIALIZED)
+    assert_equal(-32_001, CodingAdventures::Ls00::LspErrors::UNKNOWN_ERROR_CODE)
+    assert_equal(-32_803, CodingAdventures::Ls00::LspErrors::REQUEST_FAILED)
+    assert_equal(-32_802, CodingAdventures::Ls00::LspErrors::SERVER_CANCELLED)
+    assert_equal(-32_801, CodingAdventures::Ls00::LspErrors::CONTENT_MODIFIED)
+    assert_equal(-32_800, CodingAdventures::Ls00::LspErrors::REQUEST_CANCELLED)
+  end
+
+  # Test document symbol conversion with nested children.
+  def test_document_symbol_conversion
+    bridge = MockBridge.new
+    cache = CodingAdventures::Ls00::ParseCache.new
+
+    result = cache.get_or_parse("file:///a.go", 1, "func main() {}", bridge)
+    refute_nil result
+
+    syms = bridge.document_symbols(result.ast)
+    assert_equal 1, syms.length
+    assert_equal "main", syms[0].name
+    assert_equal CodingAdventures::Ls00::SymbolKind::FUNCTION, syms[0].kind
+    assert_equal 1, syms[0].children.length
+    assert_equal "x", syms[0].children[0].name
+  end
+end

--- a/code/packages/ruby/ls00/test/test_utf16.rb
+++ b/code/packages/ruby/ls00/test/test_utf16.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# ================================================================
+# UTF-16 Offset Conversion Tests
+# ================================================================
+#
+# This is the most important correctness test in the entire package.
+# If this function is wrong, every feature that depends on cursor
+# position will be wrong: hover, go-to-definition, references,
+# completion, rename, signature help.
+#
+# LSP uses UTF-16 code units for character offsets. Ruby strings are
+# UTF-8. This test verifies the conversion between the two.
+#
+# ================================================================
+
+class TestUTF16Conversion < Minitest::Test
+  # ASCII simple: "hello world" -- "world" starts at byte 6.
+  def test_ascii_simple
+    text = "hello world"
+    assert_equal 6, CodingAdventures::Ls00.convert_utf16_offset_to_byte_offset(text, 0, 6)
+  end
+
+  # Start of file: byte 0.
+  def test_start_of_file
+    text = "abc"
+    assert_equal 0, CodingAdventures::Ls00.convert_utf16_offset_to_byte_offset(text, 0, 0)
+  end
+
+  # End of short string.
+  def test_end_of_short_string
+    text = "abc"
+    assert_equal 3, CodingAdventures::Ls00.convert_utf16_offset_to_byte_offset(text, 0, 3)
+  end
+
+  # Second line: "hello\nworld" -- line 1 starts at byte 6.
+  def test_second_line
+    text = "hello\nworld"
+    assert_equal 6, CodingAdventures::Ls00.convert_utf16_offset_to_byte_offset(text, 1, 0)
+  end
+
+  # Emoji: guitar emoji (U+1F3B8) takes 2 UTF-16 units but 4 UTF-8 bytes.
+  # "A\u{1F3B8}B"
+  # UTF-8 bytes:  A (1) + emoji (4) + B (1) = 6 bytes
+  # UTF-16 units: A (1) + emoji (2) + B (1) = 4 units
+  # "B" is at UTF-16 character 3, byte offset 5.
+  def test_emoji_guitar
+    text = "A\u{1F3B8}B"
+    assert_equal 5, CodingAdventures::Ls00.convert_utf16_offset_to_byte_offset(text, 0, 3)
+  end
+
+  # Emoji at start: "\u{1F3B8}hello"
+  # emoji = 2 UTF-16 units = 4 UTF-8 bytes
+  # "h" is at UTF-16 char 2, byte offset 4
+  def test_emoji_at_start
+    text = "\u{1F3B8}hello"
+    assert_equal 4, CodingAdventures::Ls00.convert_utf16_offset_to_byte_offset(text, 0, 2)
+  end
+
+  # 2-byte UTF-8 (BMP codepoint: e-acute U+00E9).
+  # "cafe-acute!" -- e-acute is 2 UTF-8 bytes but 1 UTF-16 code unit.
+  # UTF-16 char 4 = byte offset 5 (c=1, a=1, f=1, e-acute=2 bytes)
+  def test_two_byte_utf8_bmp
+    text = "caf\u00e9!"
+    assert_equal 5, CodingAdventures::Ls00.convert_utf16_offset_to_byte_offset(text, 0, 4)
+  end
+
+  # Multiline with emoji.
+  # line 0: "A\u{1F3B8}B\n" (A=1, emoji=4, B=1, \n=1 = 7 bytes)
+  # line 1: "hello" starts at byte 7
+  def test_multiline_with_emoji
+    text = "A\u{1F3B8}B\nhello"
+    assert_equal 7, CodingAdventures::Ls00.convert_utf16_offset_to_byte_offset(text, 1, 0)
+  end
+
+  # Beyond line end clamps to newline.
+  # If character is past the end of the line, we stop at the newline.
+  def test_beyond_line_end_clamps
+    text = "ab\ncd"
+    assert_equal 2, CodingAdventures::Ls00.convert_utf16_offset_to_byte_offset(text, 0, 100)
+  end
+
+  # Chinese character: 3-byte UTF-8 / 1-unit UTF-16.
+  # "zhong-wen" -- each Chinese character is 3 UTF-8 bytes but 1 UTF-16 code unit.
+  # Second character is at UTF-16 character 1, byte offset 3.
+  def test_chinese_character
+    text = "\u4e2d\u6587" # two CJK characters
+    assert_equal 3, CodingAdventures::Ls00.convert_utf16_offset_to_byte_offset(text, 0, 1)
+  end
+end

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -230,6 +230,7 @@ members = [
     "lzss",
     "lzw",
     "json-rpc",
+    "ls00",
     "rpc",
     "lsm-tree",
     "write-ahead-log",

--- a/code/packages/rust/ls00/BUILD
+++ b/code/packages/rust/ls00/BUILD
@@ -1,0 +1,1 @@
+cargo test -- --nocapture

--- a/code/packages/rust/ls00/CHANGELOG.md
+++ b/code/packages/rust/ls00/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+## v0.1.0 -- Initial Release
+
+### Added
+
+- `LanguageBridge` trait with required `tokenize` and `parse` methods, plus
+  10 optional provider methods (`hover`, `definition`, `references`,
+  `completion`, `rename`, `semantic_tokens`, `document_symbols`,
+  `folding_ranges`, `signature_help`, `format`).
+- `LspServer` struct that reads JSON-RPC messages, dispatches to handlers,
+  and writes responses. Handles the full LSP lifecycle (initialize, shutdown,
+  exit) and all document synchronization notifications.
+- `DocumentManager` for tracking open file contents with incremental edit
+  support and correct UTF-16 to UTF-8 offset conversion.
+- `ParseCache` for caching parse results keyed by (URI, version) to avoid
+  redundant parses on cursor movement.
+- `build_capabilities()` for dynamic capability advertisement based on which
+  `supports_*` methods the bridge overrides.
+- Semantic token encoding/decoding with the full LSP delta format and standard
+  token type/modifier legends.
+- LSP error code constants matching the specification.
+- 53 integration tests covering UTF-16 conversion, document management, parse
+  caching, capability building, semantic token encoding, and full JSON-RPC
+  round-trip handler tests for all supported LSP methods.

--- a/code/packages/rust/ls00/Cargo.toml
+++ b/code/packages/rust/ls00/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "coding-adventures-ls00"
+version = "0.1.0"
+edition = "2021"
+description = "Generic Language Server Protocol (LSP) framework"
+
+[dependencies]
+coding-adventures-json-rpc = { path = "../json-rpc" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dev-dependencies]

--- a/code/packages/rust/ls00/README.md
+++ b/code/packages/rust/ls00/README.md
@@ -1,0 +1,79 @@
+# ls00 -- Generic LSP Framework (Rust)
+
+A generic Language Server Protocol (LSP) server framework that language-specific
+"bridges" plug into. This is the Rust port of the Go implementation at
+`code/packages/go/ls00/`.
+
+## What it does
+
+When you open a source file in VS Code and see red squiggles under syntax errors,
+autocomplete suggestions, or "Go to Definition" -- none of that is built into the
+editor. It comes from a **language server**: a separate process that communicates
+with the editor over the Language Server Protocol.
+
+This crate is the *generic* half -- it handles all the protocol boilerplate. A
+language author only implements the `LanguageBridge` trait that connects their
+lexer/parser to this framework.
+
+## Architecture
+
+```
+Lexer -> Parser -> [LanguageBridge] -> [LspServer] -> VS Code / Neovim / Emacs
+```
+
+## How to use
+
+1. Implement the `LanguageBridge` trait for your language.
+2. Create an `LspServer` with `LspServer::new(bridge, reader, writer)`.
+3. Call `server.serve()` -- it blocks until the editor closes the connection.
+
+```rust
+use coding_adventures_ls00::language_bridge::LanguageBridge;
+use coding_adventures_ls00::server::LspServer;
+use coding_adventures_ls00::types::*;
+use std::any::Any;
+use std::io::{BufReader, BufWriter};
+
+struct MyBridge;
+
+impl LanguageBridge for MyBridge {
+    fn tokenize(&self, source: &str) -> Result<Vec<Token>, String> {
+        Ok(vec![]) // your lexer here
+    }
+
+    fn parse(&self, source: &str) -> Result<(Box<dyn Any + Send + Sync>, Vec<Diagnostic>), String> {
+        Ok((Box::new(()), vec![])) // your parser here
+    }
+
+    // Override supports_hover(), hover(), etc. for optional features
+}
+
+fn main() {
+    let bridge = Box::new(MyBridge);
+    let reader = BufReader::new(std::io::stdin());
+    let writer = BufWriter::new(std::io::stdout());
+    let mut server = LspServer::new(bridge, reader, writer);
+    server.serve();
+}
+```
+
+## Supported LSP Features
+
+| Feature | Method | Bridge Method |
+|---------|--------|---------------|
+| Diagnostics | `textDocument/publishDiagnostics` | `parse()` (always) |
+| Hover | `textDocument/hover` | `hover()` |
+| Go to Definition | `textDocument/definition` | `definition()` |
+| Find References | `textDocument/references` | `references()` |
+| Autocomplete | `textDocument/completion` | `completion()` |
+| Rename | `textDocument/rename` | `rename()` |
+| Semantic Tokens | `textDocument/semanticTokens/full` | `semantic_tokens()` |
+| Document Symbols | `textDocument/documentSymbol` | `document_symbols()` |
+| Code Folding | `textDocument/foldingRange` | `folding_ranges()` |
+| Signature Help | `textDocument/signatureHelp` | `signature_help()` |
+| Formatting | `textDocument/formatting` | `format()` |
+
+## Dependencies
+
+- `coding-adventures-json-rpc` -- JSON-RPC 2.0 transport layer
+- `serde` / `serde_json` -- JSON serialization

--- a/code/packages/rust/ls00/src/capabilities.rs
+++ b/code/packages/rust/ls00/src/capabilities.rs
@@ -1,0 +1,244 @@
+//! Capability advertisement and semantic token encoding.
+//!
+//! # What Are Capabilities?
+//!
+//! During the LSP initialize handshake, the server sends back a "capabilities"
+//! object telling the editor which LSP features it supports. The editor uses
+//! this to decide which requests to send. If a capability is absent, the editor
+//! won't send the corresponding requests -- so no "Go to Definition" button
+//! appears unless `definitionProvider` is `true`.
+//!
+//! # Semantic Token Legend
+//!
+//! Semantic tokens use a compact binary encoding. Instead of sending
+//! `{"type":"keyword"}` per token, LSP sends an integer index into a legend.
+//! The legend must be declared in the capabilities so the editor knows what
+//! each index means.
+
+use crate::language_bridge::LanguageBridge;
+use crate::types::SemanticToken;
+use serde::Serialize;
+use serde_json::{json, Value};
+
+/// Inspect the bridge's capability flags and return the LSP capabilities
+/// object to include in the `initialize` response.
+///
+/// Uses the `supports_*` methods on the bridge trait to determine which
+/// optional capabilities to advertise.
+pub fn build_capabilities(bridge: &dyn LanguageBridge) -> Value {
+    // textDocumentSync=2 means "incremental": the editor sends only changed
+    // ranges, not the full file, on every keystroke.
+    let mut caps = serde_json::Map::new();
+    caps.insert("textDocumentSync".to_string(), json!(2));
+
+    if bridge.supports_hover() {
+        caps.insert("hoverProvider".to_string(), json!(true));
+    }
+
+    if bridge.supports_definition() {
+        caps.insert("definitionProvider".to_string(), json!(true));
+    }
+
+    if bridge.supports_references() {
+        caps.insert("referencesProvider".to_string(), json!(true));
+    }
+
+    if bridge.supports_completion() {
+        caps.insert(
+            "completionProvider".to_string(),
+            json!({"triggerCharacters": [" ", "."]}),
+        );
+    }
+
+    if bridge.supports_rename() {
+        caps.insert("renameProvider".to_string(), json!(true));
+    }
+
+    if bridge.supports_document_symbols() {
+        caps.insert("documentSymbolProvider".to_string(), json!(true));
+    }
+
+    if bridge.supports_folding_ranges() {
+        caps.insert("foldingRangeProvider".to_string(), json!(true));
+    }
+
+    if bridge.supports_signature_help() {
+        caps.insert(
+            "signatureHelpProvider".to_string(),
+            json!({"triggerCharacters": ["(", ","]}),
+        );
+    }
+
+    if bridge.supports_format() {
+        caps.insert("documentFormattingProvider".to_string(), json!(true));
+    }
+
+    if bridge.supports_semantic_tokens() {
+        caps.insert(
+            "semanticTokensProvider".to_string(),
+            json!({
+                "legend": semantic_token_legend(),
+                "full": true
+            }),
+        );
+    }
+
+    Value::Object(caps)
+}
+
+// ---------------------------------------------------------------------------
+// SemanticTokenLegendData
+// ---------------------------------------------------------------------------
+
+/// Holds the legend arrays for semantic tokens.
+/// The editor uses these to decode the compact integer encoding.
+#[derive(Debug, Clone, Serialize)]
+pub struct SemanticTokenLegendData {
+    #[serde(rename = "tokenTypes")]
+    pub token_types: Vec<String>,
+    #[serde(rename = "tokenModifiers")]
+    pub token_modifiers: Vec<String>,
+}
+
+/// Return the full legend for all supported semantic token types and modifiers.
+///
+/// # Why a Fixed Legend?
+///
+/// The legend is sent once in the capabilities response. Afterwards, each
+/// semantic token is encoded as an integer index into this legend rather than
+/// a string. This makes the per-token encoding much smaller.
+///
+/// The ordering matters: index 0 corresponds to `"namespace"`, index 1 to
+/// `"type"`, etc. These match the standard LSP token types.
+pub fn semantic_token_legend() -> SemanticTokenLegendData {
+    SemanticTokenLegendData {
+        // Standard LSP token types (in the order VS Code expects them).
+        token_types: vec![
+            "namespace".into(),     // 0
+            "type".into(),          // 1
+            "class".into(),         // 2
+            "enum".into(),          // 3
+            "interface".into(),     // 4
+            "struct".into(),        // 5
+            "typeParameter".into(), // 6
+            "parameter".into(),     // 7
+            "variable".into(),      // 8
+            "property".into(),      // 9
+            "enumMember".into(),    // 10
+            "event".into(),         // 11
+            "function".into(),      // 12
+            "method".into(),        // 13
+            "macro".into(),         // 14
+            "keyword".into(),       // 15
+            "modifier".into(),      // 16
+            "comment".into(),       // 17
+            "string".into(),        // 18
+            "number".into(),        // 19
+            "regexp".into(),        // 20
+            "operator".into(),      // 21
+            "decorator".into(),     // 22
+        ],
+        // Standard LSP token modifiers (bitmask flags).
+        token_modifiers: vec![
+            "declaration".into(),    // bit 0
+            "definition".into(),     // bit 1
+            "readonly".into(),       // bit 2
+            "static".into(),         // bit 3
+            "deprecated".into(),     // bit 4
+            "abstract".into(),       // bit 5
+            "async".into(),          // bit 6
+            "modification".into(),   // bit 7
+            "documentation".into(),  // bit 8
+            "defaultLibrary".into(), // bit 9
+        ],
+    }
+}
+
+/// Return the integer index for a semantic token type string.
+/// Returns `None` if the type is not in the legend (the caller should skip
+/// such tokens).
+pub fn token_type_index(token_type: &str) -> Option<usize> {
+    let legend = semantic_token_legend();
+    legend.token_types.iter().position(|t| t == token_type)
+}
+
+/// Return the bitmask for a list of modifier strings.
+///
+/// The LSP semantic tokens encoding represents modifiers as a bitmask:
+/// - `"declaration"` -> bit 0 -> value 1
+/// - `"definition"` -> bit 1 -> value 2
+/// - both -> value 3 (bitwise OR)
+///
+/// Unknown modifiers are silently ignored.
+pub fn token_modifier_mask(modifiers: &[String]) -> i32 {
+    let legend = semantic_token_legend();
+    let mut mask: i32 = 0;
+    for modifier in modifiers {
+        if let Some(idx) = legend.token_modifiers.iter().position(|m| m == modifier) {
+            mask |= 1 << idx;
+        }
+    }
+    mask
+}
+
+/// Convert a slice of `SemanticToken` values to the LSP compact integer
+/// encoding.
+///
+/// # The LSP Semantic Token Encoding
+///
+/// LSP encodes semantic tokens as a flat array of integers, grouped in
+/// 5-tuples:
+///
+/// ```text
+/// [deltaLine, deltaStartChar, length, tokenTypeIndex, tokenModifierBitmask, ...]
+/// ```
+///
+/// Where "delta" means: the difference from the PREVIOUS token's position.
+/// This delta encoding makes most values small (often 0 or 1).
+///
+/// When `deltaLine > 0`, `deltaStartChar` is relative to column 0 of the new
+/// line (i.e., absolute for that line). When `deltaLine == 0`, `deltaStartChar`
+/// is relative to the previous token's start character.
+pub fn encode_semantic_tokens(tokens: &[SemanticToken]) -> Vec<i32> {
+    if tokens.is_empty() {
+        return Vec::new();
+    }
+
+    // Sort by (line, character) ascending. The delta encoding requires tokens
+    // to be in document order.
+    let mut sorted = tokens.to_vec();
+    sorted.sort_by(|a, b| {
+        a.line.cmp(&b.line).then(a.character.cmp(&b.character))
+    });
+
+    let mut data = Vec::with_capacity(sorted.len() * 5);
+    let mut prev_line: i32 = 0;
+    let mut prev_char: i32 = 0;
+
+    for tok in &sorted {
+        let type_idx = match token_type_index(&tok.token_type) {
+            Some(idx) => idx as i32,
+            None => continue, // unknown token type -- skip
+        };
+
+        let delta_line = tok.line - prev_line;
+        let delta_char = if delta_line == 0 {
+            tok.character - prev_char
+        } else {
+            tok.character // absolute on new line
+        };
+
+        let mod_mask = token_modifier_mask(&tok.modifiers);
+
+        data.push(delta_line);
+        data.push(delta_char);
+        data.push(tok.length);
+        data.push(type_idx);
+        data.push(mod_mask);
+
+        prev_line = tok.line;
+        prev_char = tok.character;
+    }
+
+    data
+}

--- a/code/packages/rust/ls00/src/document_manager.rs
+++ b/code/packages/rust/ls00/src/document_manager.rs
@@ -1,0 +1,274 @@
+//! `DocumentManager` -- tracks open file contents and applies incremental edits.
+//!
+//! # The Document Manager's Job
+//!
+//! When the user opens a file in VS Code, the editor sends a `textDocument/didOpen`
+//! notification with the full file content. From that point on, the editor does
+//! NOT re-send the entire file on every keystroke. Instead, it sends incremental
+//! changes: what changed, and where. The `DocumentManager` applies these changes
+//! to maintain the current text of each open file.
+//!
+//! ```text
+//! Editor opens file:   didOpen   -> DocumentManager stores text at version 1
+//! User types "X":      didChange -> DocumentManager applies delta -> version 2
+//! User saves:          didSave   -> (optional: trigger format)
+//! User closes:         didClose  -> DocumentManager removes entry
+//! ```
+//!
+//! # UTF-16: The Tricky Part
+//!
+//! LSP specifies that character offsets are measured in UTF-16 CODE UNITS.
+//! This is a historical accident: VS Code is built on TypeScript, which uses
+//! UTF-16 strings internally (like Java and C#).
+//!
+//! Rust strings are UTF-8. A single Unicode codepoint can occupy:
+//! - 1 byte in UTF-8 (ASCII, e.g. 'A')
+//! - 2 bytes in UTF-8 (e.g. 'e', U+00E9)
+//! - 3 bytes in UTF-8 (e.g. Chinese chars, U+4E2D)
+//! - 4 bytes in UTF-8 (e.g. guitar emoji, U+1F3B8)
+//!
+//! In UTF-16:
+//! - Codepoints in the Basic Multilingual Plane (U+0000-U+FFFF) -> 1 code unit
+//! - Codepoints above U+FFFF (emojis, rare CJK) -> 2 code units (a "surrogate pair")
+//!
+//! The function `convert_utf16_offset_to_byte_offset` bridges this gap.
+
+use crate::types::{Position, Range};
+use std::collections::HashMap;
+
+// ---------------------------------------------------------------------------
+// Document
+// ---------------------------------------------------------------------------
+
+/// An open file tracked by the `DocumentManager`.
+#[derive(Debug, Clone)]
+pub struct Document {
+    pub uri: String,
+    /// Current content, UTF-8 encoded.
+    pub text: String,
+    /// Monotonically increasing; matches LSP's document version.
+    pub version: i32,
+}
+
+// ---------------------------------------------------------------------------
+// TextChange
+// ---------------------------------------------------------------------------
+
+/// One incremental change to a document.
+///
+/// If `range` is `None`, `new_text` replaces the ENTIRE document content (full sync).
+/// If `range` is `Some`, `new_text` replaces just the specified range (incremental sync).
+#[derive(Debug, Clone)]
+pub struct TextChange {
+    /// `None` = full replacement.
+    pub range: Option<Range>,
+    pub new_text: String,
+}
+
+// ---------------------------------------------------------------------------
+// DocumentManager
+// ---------------------------------------------------------------------------
+
+/// Tracks all files currently open in the editor.
+///
+/// The editor sends open/change/close notifications; this manager keeps the
+/// authoritative current text of each file.
+pub struct DocumentManager {
+    docs: HashMap<String, Document>,
+}
+
+impl DocumentManager {
+    /// Create an empty `DocumentManager`.
+    pub fn new() -> Self {
+        Self {
+            docs: HashMap::new(),
+        }
+    }
+
+    /// Record a newly opened file.
+    ///
+    /// Called when the editor sends `textDocument/didOpen`.
+    pub fn open(&mut self, uri: &str, text: &str, version: i32) {
+        self.docs.insert(
+            uri.to_string(),
+            Document {
+                uri: uri.to_string(),
+                text: text.to_string(),
+                version,
+            },
+        );
+    }
+
+    /// Get the document for a URI, or `None` if the document is not open.
+    pub fn get(&self, uri: &str) -> Option<&Document> {
+        self.docs.get(uri)
+    }
+
+    /// Remove a document from the manager.
+    ///
+    /// Called when the editor sends `textDocument/didClose`.
+    pub fn close(&mut self, uri: &str) {
+        self.docs.remove(uri);
+    }
+
+    /// Apply a list of incremental changes to an open document.
+    ///
+    /// Changes are applied in order. If a range is `None`, the change replaces
+    /// the entire document. After all changes, the document's version is updated.
+    pub fn apply_changes(
+        &mut self,
+        uri: &str,
+        changes: &[TextChange],
+        version: i32,
+    ) -> Result<(), String> {
+        let doc = self
+            .docs
+            .get_mut(uri)
+            .ok_or_else(|| format!("document not open: {}", uri))?;
+
+        for change in changes {
+            match &change.range {
+                None => {
+                    // Full document replacement -- simplest case.
+                    doc.text = change.new_text.clone();
+                }
+                Some(range) => {
+                    // Incremental update: splice new text at the specified range.
+                    let new_text =
+                        apply_range_change(&doc.text, range, &change.new_text)?;
+                    doc.text = new_text;
+                }
+            }
+        }
+
+        doc.version = version;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Range application
+// ---------------------------------------------------------------------------
+
+/// Splice `new_text` into `text` at the given LSP range.
+///
+/// Converts LSP's (line, UTF-16-character) coordinates to byte offsets in the
+/// UTF-8 Rust string, then performs the splice.
+fn apply_range_change(text: &str, r: &Range, new_text: &str) -> Result<String, String> {
+    let start_byte = convert_position_to_byte_offset(text, &r.start);
+    let end_byte = convert_position_to_byte_offset(text, &r.end);
+
+    if start_byte > end_byte {
+        return Err(format!(
+            "start offset {} > end offset {}",
+            start_byte, end_byte
+        ));
+    }
+
+    let end_byte = end_byte.min(text.len());
+
+    // Guard against slicing mid-codepoint. The UTF-16-to-byte conversion
+    // normally lands on codepoint boundaries, but defensive checks prevent
+    // panics if a client sends overlapping or malformed edits.
+    if !text.is_char_boundary(start_byte) || !text.is_char_boundary(end_byte) {
+        return Err(format!(
+            "byte offsets not on char boundaries: {}, {}",
+            start_byte, end_byte
+        ));
+    }
+
+    let mut result = String::with_capacity(start_byte + new_text.len() + (text.len() - end_byte));
+    result.push_str(&text[..start_byte]);
+    result.push_str(new_text);
+    result.push_str(&text[end_byte..]);
+    Ok(result)
+}
+
+/// Convert an LSP `Position` (0-based line, UTF-16 char) to a byte offset
+/// in the UTF-8 Rust string.
+///
+/// # Algorithm
+///
+/// 1. Walk line-by-line to find the byte offset of the start of the target line.
+/// 2. From that offset, walk UTF-8 codepoints, converting each to its UTF-16
+///    length, until we reach the target UTF-16 character offset.
+fn convert_position_to_byte_offset(text: &str, pos: &Position) -> usize {
+    let bytes = text.as_bytes();
+    let mut line_start: usize = 0;
+    let mut current_line: i32 = 0;
+
+    // Phase 1: find the byte offset of the start of pos.line.
+    while current_line < pos.line {
+        match bytes[line_start..].iter().position(|&b| b == b'\n') {
+            None => return text.len(), // line number exceeds file lines
+            Some(idx) => {
+                line_start += idx + 1;
+                current_line += 1;
+            }
+        }
+    }
+
+    // Phase 2: from line_start, advance pos.character UTF-16 code units.
+    let mut byte_offset = line_start;
+    let mut utf16_units: i32 = 0;
+
+    while utf16_units < pos.character && byte_offset < text.len() {
+        // Check for newline -- don't advance past the end of the line.
+        if bytes[byte_offset] == b'\n' {
+            break;
+        }
+
+        // Decode one Unicode codepoint from the UTF-8 stream.
+        // Use match instead of unwrap to avoid panicking on malformed input.
+        let ch = match text[byte_offset..].chars().next() {
+            Some(c) => c,
+            None => break,
+        };
+        let char_len_utf8 = ch.len_utf8();
+
+        // How many UTF-16 code units does this codepoint occupy?
+        // Codepoints > U+FFFF require a surrogate pair (2 UTF-16 code units).
+        let utf16_len = if ch > '\u{FFFF}' { 2 } else { 1 };
+
+        if utf16_units + utf16_len > pos.character {
+            // This codepoint would overshoot the target character. Stop here.
+            break;
+        }
+
+        byte_offset += char_len_utf8;
+        utf16_units += utf16_len;
+    }
+
+    byte_offset
+}
+
+/// Convert a 0-based (line, UTF-16 char) position to a byte offset in a
+/// UTF-8 Rust string.
+///
+/// This is the public version for use in tests and external packages.
+///
+/// # Why UTF-16?
+///
+/// LSP character offsets are UTF-16 code units because VS Code's internal
+/// string representation is UTF-16 (as is JavaScript's `String` type).
+/// This function bridges the gap to Rust's UTF-8 strings.
+///
+/// # Example
+///
+/// ```rust
+/// use coding_adventures_ls00::document_manager::convert_utf16_offset_to_byte_offset;
+///
+/// // "A🎸B" -- A(1 byte, 1 UTF-16), 🎸(4 bytes, 2 UTF-16), B(1 byte, 1 UTF-16)
+/// // "B" is at UTF-16 character 3, byte offset 5.
+/// let byte_off = convert_utf16_offset_to_byte_offset("A\u{1F3B8}B", 0, 3);
+/// assert_eq!(byte_off, 5);
+/// ```
+pub fn convert_utf16_offset_to_byte_offset(text: &str, line: i32, char: i32) -> usize {
+    convert_position_to_byte_offset(
+        text,
+        &Position {
+            line,
+            character: char,
+        },
+    )
+}

--- a/code/packages/rust/ls00/src/handlers.rs
+++ b/code/packages/rust/ls00/src/handlers.rs
@@ -1,0 +1,767 @@
+//! All LSP handler implementations.
+//!
+//! Each function here processes one LSP request or notification method. The
+//! server's `register_handlers` method wires each method name to its handler.
+//!
+//! # Handler Patterns
+//!
+//! - **Request handlers** receive `(id, params)` and return `Result<Value, ResponseError>`.
+//! - **Notification handlers** receive `params` and return nothing.
+//!
+//! # Lifecycle Handlers
+//!
+//! - `initialize` -- first message, returns capabilities
+//! - `initialized` -- handshake complete, no-op
+//! - `shutdown` -- set shutdown flag, return null
+//! - `exit` -- terminate the process
+//!
+//! # Document Sync Handlers
+//!
+//! - `didOpen` -- open doc, parse, push diagnostics
+//! - `didChange` -- apply changes, re-parse, push diagnostics
+//! - `didClose` -- remove doc, evict cache
+//! - `didSave` -- optionally re-parse with saved content
+//!
+//! # Feature Handlers
+//!
+//! Each feature handler follows the same pattern:
+//! 1. Extract URI and position from params.
+//! 2. Check if the bridge supports the feature.
+//! 3. Get the parse result from cache.
+//! 4. Delegate to the bridge.
+//! 5. Convert the result to LSP JSON format.
+
+use crate::capabilities::build_capabilities;
+use crate::lsp_errors::REQUEST_FAILED;
+use crate::server::LspServer;
+use crate::types::*;
+use coding_adventures_json_rpc::ResponseError;
+use serde_json::{json, Value};
+use std::io::{BufRead, Write};
+
+// Note: The handler methods live on LspServer<R, W> so they can access
+// the bridge, document manager, parse cache, and writer. They are called
+// from the `serve()` dispatch loop in server.rs.
+
+// ---------------------------------------------------------------------------
+// JSON param extraction helpers
+// ---------------------------------------------------------------------------
+
+/// Extract a `Position` from a JSON params object.
+/// The LSP sends positions as `{"position": {"line": N, "character": N}}`.
+fn parse_position(params: &Value) -> Position {
+    let pos = &params["position"];
+    Position {
+        line: pos["line"].as_i64().unwrap_or(0) as i32,
+        character: pos["character"].as_i64().unwrap_or(0) as i32,
+    }
+}
+
+/// Extract the document URI from params that have a `textDocument` field.
+fn parse_uri(params: &Value) -> String {
+    params["textDocument"]["uri"]
+        .as_str()
+        .unwrap_or("")
+        .to_string()
+}
+
+/// Convert a `Position` to a JSON value.
+fn position_to_json(p: &Position) -> Value {
+    json!({"line": p.line, "character": p.character})
+}
+
+/// Convert a `Range` to a JSON value.
+fn range_to_json(r: &Range) -> Value {
+    json!({
+        "start": position_to_json(&r.start),
+        "end": position_to_json(&r.end)
+    })
+}
+
+/// Convert a `Location` to a JSON value.
+fn location_to_json(l: &Location) -> Value {
+    json!({
+        "uri": l.uri,
+        "range": range_to_json(&l.range)
+    })
+}
+
+/// Parse an LSP range from a JSON value.
+fn parse_lsp_range(raw: &Value) -> Range {
+    Range {
+        start: Position {
+            line: raw["start"]["line"].as_i64().unwrap_or(0) as i32,
+            character: raw["start"]["character"].as_i64().unwrap_or(0) as i32,
+        },
+        end: Position {
+            line: raw["end"]["line"].as_i64().unwrap_or(0) as i32,
+            character: raw["end"]["character"].as_i64().unwrap_or(0) as i32,
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle handlers
+// ---------------------------------------------------------------------------
+
+impl<R: BufRead, W: Write> LspServer<R, W> {
+    /// Process the LSP `initialize` request.
+    ///
+    /// This is the server's first message. We store the client info (for
+    /// logging) and return our capabilities built from the bridge.
+    pub(crate) fn handle_initialize(
+        &mut self,
+        _id: Value,
+        _params: Option<Value>,
+    ) -> Result<Value, ResponseError> {
+        self.initialized = true;
+
+        let caps = build_capabilities(self.bridge.as_ref());
+
+        Ok(json!({
+            "capabilities": caps,
+            "serverInfo": {
+                "name": "ls00-generic-lsp-server",
+                "version": "0.1.0"
+            }
+        }))
+    }
+
+    /// Process the `initialized` notification.
+    ///
+    /// The editor's acknowledgment that it received our capabilities.
+    /// No-op -- normal operation begins now.
+    pub(crate) fn handle_initialized(&mut self, _params: Option<Value>) {
+        // No-op: the handshake is complete.
+    }
+
+    /// Process the LSP `shutdown` request.
+    ///
+    /// After receiving shutdown, the server should stop processing new requests
+    /// and return null.
+    pub(crate) fn handle_shutdown(
+        &mut self,
+        _id: Value,
+        _params: Option<Value>,
+    ) -> Result<Value, ResponseError> {
+        self.shutdown = true;
+        Ok(Value::Null)
+    }
+
+    /// Process the `exit` notification.
+    ///
+    /// Exit code semantics (from the LSP spec):
+    /// - 0: shutdown was received before exit -> clean shutdown
+    /// - 1: shutdown was NOT received -> abnormal termination
+    pub(crate) fn handle_exit(&mut self, _params: Option<Value>) {
+        if self.shutdown {
+            std::process::exit(0);
+        } else {
+            std::process::exit(1);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Text document synchronization
+    // -----------------------------------------------------------------------
+
+    /// Process `textDocument/didOpen`.
+    ///
+    /// Records the opened file and immediately parses + pushes diagnostics.
+    pub(crate) fn handle_did_open(&mut self, params: Option<Value>) {
+        let params = match params {
+            Some(p) => p,
+            None => return,
+        };
+
+        let td = &params["textDocument"];
+        let uri = td["uri"].as_str().unwrap_or("").to_string();
+        let text = td["text"].as_str().unwrap_or("").to_string();
+        let version = td["version"].as_i64().unwrap_or(1) as i32;
+
+        if uri.is_empty() {
+            return;
+        }
+
+        self.doc_manager.open(&uri, &text, version);
+
+        let result = self
+            .parse_cache
+            .get_or_parse(&uri, version, &text, self.bridge.as_ref());
+        let diags = result.diagnostics.clone();
+        self.publish_diagnostics(&uri, version, &diags);
+    }
+
+    /// Process `textDocument/didChange`.
+    ///
+    /// Applies incremental changes, re-parses, and pushes diagnostics.
+    pub(crate) fn handle_did_change(&mut self, params: Option<Value>) {
+        let params = match params {
+            Some(p) => p,
+            None => return,
+        };
+
+        let uri = parse_uri(&params);
+        if uri.is_empty() {
+            return;
+        }
+
+        let version = params["textDocument"]["version"]
+            .as_i64()
+            .unwrap_or(0) as i32;
+
+        // Parse the content changes array.
+        let changes_raw = match params["contentChanges"].as_array() {
+            Some(arr) => arr,
+            None => return,
+        };
+
+        let changes: Vec<crate::document_manager::TextChange> = changes_raw
+            .iter()
+            .map(|change| {
+                let new_text = change["text"].as_str().unwrap_or("").to_string();
+                let range = if change.get("range").is_some() && !change["range"].is_null() {
+                    Some(parse_lsp_range(&change["range"]))
+                } else {
+                    None
+                };
+                crate::document_manager::TextChange { range, new_text }
+            })
+            .collect();
+
+        if self
+            .doc_manager
+            .apply_changes(&uri, &changes, version)
+            .is_err()
+        {
+            return;
+        }
+
+        let doc = match self.doc_manager.get(&uri) {
+            Some(d) => d,
+            None => return,
+        };
+
+        let doc_text = doc.text.clone();
+        let doc_version = doc.version;
+
+        let result = self
+            .parse_cache
+            .get_or_parse(&uri, doc_version, &doc_text, self.bridge.as_ref());
+        let diags = result.diagnostics.clone();
+        self.publish_diagnostics(&uri, version, &diags);
+    }
+
+    /// Process `textDocument/didClose`.
+    ///
+    /// Removes the document and clears its diagnostics.
+    pub(crate) fn handle_did_close(&mut self, params: Option<Value>) {
+        let params = match params {
+            Some(p) => p,
+            None => return,
+        };
+
+        let uri = parse_uri(&params);
+        if uri.is_empty() {
+            return;
+        }
+
+        self.doc_manager.close(&uri);
+        self.parse_cache.evict(&uri);
+
+        // Clear diagnostics for the closed file.
+        self.publish_diagnostics(&uri, 0, &[]);
+    }
+
+    /// Process `textDocument/didSave`.
+    ///
+    /// If the client sends full text in didSave, apply it and re-parse.
+    pub(crate) fn handle_did_save(&mut self, params: Option<Value>) {
+        let params = match params {
+            Some(p) => p,
+            None => return,
+        };
+
+        let uri = parse_uri(&params);
+        if uri.is_empty() {
+            return;
+        }
+
+        if let Some(text) = params["text"].as_str() {
+            if !text.is_empty() {
+                if let Some(doc) = self.doc_manager.get(&uri) {
+                    let version = doc.version;
+                    self.doc_manager.close(&uri);
+                    self.doc_manager.open(&uri, text, version);
+                    let result = self
+                        .parse_cache
+                        .get_or_parse(&uri, version, text, self.bridge.as_ref());
+                    let diags = result.diagnostics.clone();
+                    self.publish_diagnostics(&uri, version, &diags);
+                }
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Feature handlers
+    // -----------------------------------------------------------------------
+
+    /// Process `textDocument/hover`.
+    pub(crate) fn handle_hover(
+        &mut self,
+        _id: Value,
+        params: Option<Value>,
+    ) -> Result<Value, ResponseError> {
+        let params = params.ok_or_else(|| ResponseError::invalid_params(None))?;
+        let uri = parse_uri(&params);
+        let pos = parse_position(&params);
+
+        if !self.bridge.supports_hover() {
+            return Ok(Value::Null);
+        }
+
+        let (parse_result_ast, _) = self.get_parse_result_cloned(&uri)?;
+
+        let ast = match &parse_result_ast {
+            Some(a) => a,
+            None => return Ok(Value::Null),
+        };
+
+        let hover_result = match self.bridge.hover(ast.as_ref(), pos) {
+            None | Some(Err(_)) => return Ok(Value::Null),
+            Some(Ok(None)) => return Ok(Value::Null),
+            Some(Ok(Some(r))) => r,
+        };
+
+        let mut result = json!({
+            "contents": {
+                "kind": "markdown",
+                "value": hover_result.contents
+            }
+        });
+
+        if let Some(range) = &hover_result.range {
+            result["range"] = range_to_json(range);
+        }
+
+        Ok(result)
+    }
+
+    /// Process `textDocument/definition`.
+    pub(crate) fn handle_definition(
+        &mut self,
+        _id: Value,
+        params: Option<Value>,
+    ) -> Result<Value, ResponseError> {
+        let params = params.ok_or_else(|| ResponseError::invalid_params(None))?;
+        let uri = parse_uri(&params);
+        let pos = parse_position(&params);
+
+        if !self.bridge.supports_definition() {
+            return Ok(Value::Null);
+        }
+
+        let (parse_result_ast, _) = self.get_parse_result_cloned(&uri)?;
+        let ast = match &parse_result_ast {
+            Some(a) => a,
+            None => return Ok(Value::Null),
+        };
+
+        match self.bridge.definition(ast.as_ref(), pos, &uri) {
+            None | Some(Err(_)) | Some(Ok(None)) => Ok(Value::Null),
+            Some(Ok(Some(loc))) => Ok(location_to_json(&loc)),
+        }
+    }
+
+    /// Process `textDocument/references`.
+    pub(crate) fn handle_references(
+        &mut self,
+        _id: Value,
+        params: Option<Value>,
+    ) -> Result<Value, ResponseError> {
+        let params = params.ok_or_else(|| ResponseError::invalid_params(None))?;
+        let uri = parse_uri(&params);
+        let pos = parse_position(&params);
+
+        let include_decl = params["context"]["includeDeclaration"]
+            .as_bool()
+            .unwrap_or(false);
+
+        if !self.bridge.supports_references() {
+            return Ok(json!([]));
+        }
+
+        let (parse_result_ast, _) = self.get_parse_result_cloned(&uri)?;
+        let ast = match &parse_result_ast {
+            Some(a) => a,
+            None => return Ok(json!([])),
+        };
+
+        match self
+            .bridge
+            .references(ast.as_ref(), pos, &uri, include_decl)
+        {
+            None | Some(Err(_)) => Ok(json!([])),
+            Some(Ok(locations)) => {
+                let result: Vec<Value> = locations.iter().map(location_to_json).collect();
+                Ok(Value::Array(result))
+            }
+        }
+    }
+
+    /// Process `textDocument/completion`.
+    pub(crate) fn handle_completion(
+        &mut self,
+        _id: Value,
+        params: Option<Value>,
+    ) -> Result<Value, ResponseError> {
+        let params = params.ok_or_else(|| ResponseError::invalid_params(None))?;
+        let uri = parse_uri(&params);
+        let pos = parse_position(&params);
+
+        let empty_result = json!({"isIncomplete": false, "items": []});
+
+        if !self.bridge.supports_completion() {
+            return Ok(empty_result);
+        }
+
+        let (parse_result_ast, _) = self.get_parse_result_cloned(&uri)?;
+        let ast = match &parse_result_ast {
+            Some(a) => a,
+            None => return Ok(empty_result),
+        };
+
+        match self.bridge.completion(ast.as_ref(), pos) {
+            None | Some(Err(_)) => Ok(empty_result),
+            Some(Ok(items)) => {
+                let lsp_items: Vec<Value> = items
+                    .iter()
+                    .map(|item| {
+                        let mut ci = json!({"label": item.label});
+                        if let Some(kind) = &item.kind {
+                            ci["kind"] = json!(*kind as i32);
+                        }
+                        if let Some(detail) = &item.detail {
+                            if !detail.is_empty() {
+                                ci["detail"] = json!(detail);
+                            }
+                        }
+                        if let Some(doc) = &item.documentation {
+                            if !doc.is_empty() {
+                                ci["documentation"] = json!(doc);
+                            }
+                        }
+                        if let Some(text) = &item.insert_text {
+                            if !text.is_empty() {
+                                ci["insertText"] = json!(text);
+                            }
+                        }
+                        if let Some(fmt) = &item.insert_text_format {
+                            if *fmt != 0 {
+                                ci["insertTextFormat"] = json!(fmt);
+                            }
+                        }
+                        ci
+                    })
+                    .collect();
+
+                Ok(json!({"isIncomplete": false, "items": lsp_items}))
+            }
+        }
+    }
+
+    /// Process `textDocument/rename`.
+    pub(crate) fn handle_rename(
+        &mut self,
+        _id: Value,
+        params: Option<Value>,
+    ) -> Result<Value, ResponseError> {
+        let params = params.ok_or_else(|| ResponseError::invalid_params(None))?;
+        let uri = parse_uri(&params);
+        let pos = parse_position(&params);
+        let new_name = params["newName"].as_str().unwrap_or("");
+
+        if new_name.is_empty() {
+            return Err(ResponseError::invalid_params(Some(json!(
+                "newName is required"
+            ))));
+        }
+
+        if !self.bridge.supports_rename() {
+            return Err(ResponseError {
+                code: REQUEST_FAILED,
+                message: "rename not supported".to_string(),
+                data: None,
+            });
+        }
+
+        let (parse_result_ast, _) = self.get_parse_result_cloned(&uri)?;
+        let ast = match &parse_result_ast {
+            Some(a) => a,
+            None => {
+                return Err(ResponseError {
+                    code: REQUEST_FAILED,
+                    message: "no AST available".to_string(),
+                    data: None,
+                })
+            }
+        };
+
+        match self.bridge.rename(ast.as_ref(), pos, new_name) {
+            None | Some(Ok(None)) => Err(ResponseError {
+                code: REQUEST_FAILED,
+                message: "symbol not found at position".to_string(),
+                data: None,
+            }),
+            Some(Err(e)) => Err(ResponseError {
+                code: REQUEST_FAILED,
+                message: e,
+                data: None,
+            }),
+            Some(Ok(Some(edit))) => {
+                let mut lsp_changes = serde_json::Map::new();
+                for (edit_uri, edits) in &edit.changes {
+                    let lsp_edits: Vec<Value> = edits
+                        .iter()
+                        .map(|te| {
+                            json!({
+                                "range": range_to_json(&te.range),
+                                "newText": te.new_text
+                            })
+                        })
+                        .collect();
+                    lsp_changes.insert(edit_uri.clone(), Value::Array(lsp_edits));
+                }
+                Ok(json!({"changes": lsp_changes}))
+            }
+        }
+    }
+
+    /// Process `textDocument/documentSymbol`.
+    pub(crate) fn handle_document_symbol(
+        &mut self,
+        _id: Value,
+        params: Option<Value>,
+    ) -> Result<Value, ResponseError> {
+        let params = params.ok_or_else(|| ResponseError::invalid_params(None))?;
+        let uri = parse_uri(&params);
+
+        if !self.bridge.supports_document_symbols() {
+            return Ok(json!([]));
+        }
+
+        let (parse_result_ast, _) = self.get_parse_result_cloned(&uri)?;
+        let ast = match &parse_result_ast {
+            Some(a) => a,
+            None => return Ok(json!([])),
+        };
+
+        match self.bridge.document_symbols(ast.as_ref()) {
+            None | Some(Err(_)) => Ok(json!([])),
+            Some(Ok(symbols)) => Ok(Value::Array(convert_document_symbols(&symbols))),
+        }
+    }
+
+    /// Process `textDocument/semanticTokens/full`.
+    pub(crate) fn handle_semantic_tokens_full(
+        &mut self,
+        _id: Value,
+        params: Option<Value>,
+    ) -> Result<Value, ResponseError> {
+        let params = params.ok_or_else(|| ResponseError::invalid_params(None))?;
+        let uri = parse_uri(&params);
+
+        let empty = json!({"data": []});
+
+        if !self.bridge.supports_semantic_tokens() {
+            return Ok(empty);
+        }
+
+        let doc = match self.doc_manager.get(&uri) {
+            Some(d) => d,
+            None => return Ok(empty),
+        };
+        let doc_text = doc.text.clone();
+
+        let tokens = match self.bridge.tokenize(&doc_text) {
+            Ok(t) => t,
+            Err(_) => return Ok(empty),
+        };
+
+        match self.bridge.semantic_tokens(&doc_text, &tokens) {
+            None | Some(Err(_)) => Ok(empty),
+            Some(Ok(sem_tokens)) => {
+                let data = crate::capabilities::encode_semantic_tokens(&sem_tokens);
+                Ok(json!({"data": data}))
+            }
+        }
+    }
+
+    /// Process `textDocument/foldingRange`.
+    pub(crate) fn handle_folding_range(
+        &mut self,
+        _id: Value,
+        params: Option<Value>,
+    ) -> Result<Value, ResponseError> {
+        let params = params.ok_or_else(|| ResponseError::invalid_params(None))?;
+        let uri = parse_uri(&params);
+
+        if !self.bridge.supports_folding_ranges() {
+            return Ok(json!([]));
+        }
+
+        let (parse_result_ast, _) = self.get_parse_result_cloned(&uri)?;
+        let ast = match &parse_result_ast {
+            Some(a) => a,
+            None => return Ok(json!([])),
+        };
+
+        match self.bridge.folding_ranges(ast.as_ref()) {
+            None | Some(Err(_)) => Ok(json!([])),
+            Some(Ok(ranges)) => {
+                let result: Vec<Value> = ranges
+                    .iter()
+                    .map(|fr| {
+                        let mut m = json!({
+                            "startLine": fr.start_line,
+                            "endLine": fr.end_line
+                        });
+                        if let Some(kind) = &fr.kind {
+                            m["kind"] = json!(kind);
+                        }
+                        m
+                    })
+                    .collect();
+                Ok(Value::Array(result))
+            }
+        }
+    }
+
+    /// Process `textDocument/signatureHelp`.
+    pub(crate) fn handle_signature_help(
+        &mut self,
+        _id: Value,
+        params: Option<Value>,
+    ) -> Result<Value, ResponseError> {
+        let params = params.ok_or_else(|| ResponseError::invalid_params(None))?;
+        let uri = parse_uri(&params);
+        let pos = parse_position(&params);
+
+        if !self.bridge.supports_signature_help() {
+            return Ok(Value::Null);
+        }
+
+        let (parse_result_ast, _) = self.get_parse_result_cloned(&uri)?;
+        let ast = match &parse_result_ast {
+            Some(a) => a,
+            None => return Ok(Value::Null),
+        };
+
+        match self.bridge.signature_help(ast.as_ref(), pos) {
+            None | Some(Err(_)) | Some(Ok(None)) => Ok(Value::Null),
+            Some(Ok(Some(sig_help))) => {
+                let lsp_sigs: Vec<Value> = sig_help
+                    .signatures
+                    .iter()
+                    .map(|sig| {
+                        let lsp_params: Vec<Value> = sig
+                            .parameters
+                            .iter()
+                            .map(|p| {
+                                let mut pp = json!({"label": p.label});
+                                if let Some(doc) = &p.documentation {
+                                    if !doc.is_empty() {
+                                        pp["documentation"] = json!(doc);
+                                    }
+                                }
+                                pp
+                            })
+                            .collect();
+                        let mut s = json!({
+                            "label": sig.label,
+                            "parameters": lsp_params
+                        });
+                        if let Some(doc) = &sig.documentation {
+                            if !doc.is_empty() {
+                                s["documentation"] = json!(doc);
+                            }
+                        }
+                        s
+                    })
+                    .collect();
+
+                Ok(json!({
+                    "signatures": lsp_sigs,
+                    "activeSignature": sig_help.active_signature,
+                    "activeParameter": sig_help.active_parameter
+                }))
+            }
+        }
+    }
+
+    /// Process `textDocument/formatting`.
+    pub(crate) fn handle_formatting(
+        &mut self,
+        _id: Value,
+        params: Option<Value>,
+    ) -> Result<Value, ResponseError> {
+        let params = params.ok_or_else(|| ResponseError::invalid_params(None))?;
+        let uri = parse_uri(&params);
+
+        if !self.bridge.supports_format() {
+            return Ok(json!([]));
+        }
+
+        let doc = match self.doc_manager.get(&uri) {
+            Some(d) => d,
+            None => return Ok(json!([])),
+        };
+        let doc_text = doc.text.clone();
+
+        match self.bridge.format(&doc_text) {
+            None => Ok(json!([])),
+            Some(Err(e)) => Err(ResponseError {
+                code: REQUEST_FAILED,
+                message: format!("formatting failed: {}", e),
+                data: None,
+            }),
+            Some(Ok(edits)) => {
+                let lsp_edits: Vec<Value> = edits
+                    .iter()
+                    .map(|edit| {
+                        json!({
+                            "range": range_to_json(&edit.range),
+                            "newText": edit.new_text
+                        })
+                    })
+                    .collect();
+                Ok(Value::Array(lsp_edits))
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: convert DocumentSymbol tree to JSON
+// ---------------------------------------------------------------------------
+
+/// Recursively convert `DocumentSymbol` slices to JSON values for the LSP
+/// response.
+fn convert_document_symbols(symbols: &[DocumentSymbol]) -> Vec<Value> {
+    symbols
+        .iter()
+        .map(|sym| {
+            let mut m = json!({
+                "name": sym.name,
+                "kind": sym.kind as i32,
+                "range": range_to_json(&sym.range),
+                "selectionRange": range_to_json(&sym.selection_range)
+            });
+            if !sym.children.is_empty() {
+                m["children"] = Value::Array(convert_document_symbols(&sym.children));
+            }
+            m
+        })
+        .collect()
+}

--- a/code/packages/rust/ls00/src/language_bridge.rs
+++ b/code/packages/rust/ls00/src/language_bridge.rs
@@ -1,0 +1,222 @@
+//! `LanguageBridge` trait -- the single point of integration for language servers.
+//!
+//! # Design Philosophy: One Trait with Optional Methods
+//!
+//! Rust's trait system does not support Go-style runtime interface detection
+//! (type assertions like `bridge.(HoverProvider)`). Instead, we use a single
+//! trait with required + optional methods:
+//!
+//! - **Required methods** (`tokenize`, `parse`): every language MUST implement these.
+//! - **Optional provider methods** (`hover`, `definition`, etc.): default to `None`,
+//!   meaning "not supported." A bridge overrides only the methods it supports.
+//! - **Capability flags** (`supports_hover`, etc.): default to `false`. The bridge
+//!   overrides to `true` for methods it implements. The server uses these flags
+//!   to build the capabilities response during `initialize`.
+//!
+//! # The `Option<Result<...>>` Pattern
+//!
+//! Optional methods return `Option<Result<T, String>>`:
+//! - `None` -> "this feature is not supported" (don't advertise capability)
+//! - `Some(Ok(value))` -> supported and succeeded
+//! - `Some(Err(msg))` -> supported but failed
+//!
+//! This three-state return lets the server distinguish "not implemented" from
+//! "implemented but errored" without needing separate `supports_*` calls at
+//! runtime. However, we still provide `supports_*` methods for capability
+//! advertisement because calling methods with dummy values is fragile.
+//!
+//! # ASTNode Type
+//!
+//! We use `Box<dyn Any + Send + Sync>` as the AST type. Each language's parser
+//! returns its own concrete AST type boxed as `dyn Any`. The bridge downcasts
+//! it back to the concrete type inside its handler methods using
+//! `ast.downcast_ref::<MyAst>()`.
+
+use crate::types::*;
+use std::any::Any;
+
+/// The required and optional interface every language bridge must implement.
+///
+/// ## Required Methods
+///
+/// - `tokenize`: lex the source into tokens (for semantic highlighting).
+/// - `parse`: parse the source into an AST + diagnostics (for error display).
+///
+/// ## Optional Methods
+///
+/// All optional methods have default implementations returning `None` (not
+/// supported). Override only the ones your language supports.
+///
+/// ## Capability Flags
+///
+/// The `supports_*` methods default to `false`. Override them to `true` for
+/// each optional method your bridge implements. The server reads these during
+/// `initialize` to build the capabilities response.
+pub trait LanguageBridge: Send + Sync {
+    // -----------------------------------------------------------------------
+    // Required methods
+    // -----------------------------------------------------------------------
+
+    /// Lex the source string and return the token stream.
+    ///
+    /// The tokens are used for semantic highlighting. Each `Token` carries a
+    /// `token_type` string (e.g. `"KEYWORD"`, `"IDENTIFIER"`), its `value`,
+    /// and its 1-based `line` and `column` position.
+    fn tokenize(&self, source: &str) -> Result<Vec<Token>, String>;
+
+    /// Parse the source string and return:
+    /// - `ast`: the parsed abstract syntax tree (may be partial on error)
+    /// - `diagnostics`: parse errors and warnings as LSP `Diagnostic` objects
+    ///
+    /// Even when there are syntax errors, `parse` should return a partial AST.
+    /// This allows hover, folding, and symbol features to continue working on
+    /// the valid portions of the file.
+    fn parse(
+        &self,
+        source: &str,
+    ) -> Result<(Box<dyn Any + Send + Sync>, Vec<Diagnostic>), String>;
+
+    // -----------------------------------------------------------------------
+    // Optional provider methods
+    // -----------------------------------------------------------------------
+
+    /// Return hover information for the AST node at the given position.
+    ///
+    /// Returns `None` if not supported, `Some(Ok(None))` if supported but
+    /// nothing to show at this position, `Some(Ok(Some(result)))` for content.
+    fn hover(
+        &self,
+        _ast: &dyn Any,
+        _pos: Position,
+    ) -> Option<Result<Option<HoverResult>, String>> {
+        None
+    }
+
+    /// Return the location where the symbol at `pos` was declared.
+    fn definition(
+        &self,
+        _ast: &dyn Any,
+        _pos: Position,
+        _uri: &str,
+    ) -> Option<Result<Option<Location>, String>> {
+        None
+    }
+
+    /// Return all uses of the symbol at `pos`.
+    fn references(
+        &self,
+        _ast: &dyn Any,
+        _pos: Position,
+        _uri: &str,
+        _include_decl: bool,
+    ) -> Option<Result<Vec<Location>, String>> {
+        None
+    }
+
+    /// Return autocomplete suggestions valid at `pos`.
+    fn completion(
+        &self,
+        _ast: &dyn Any,
+        _pos: Position,
+    ) -> Option<Result<Vec<CompletionItem>, String>> {
+        None
+    }
+
+    /// Return the set of text edits needed to rename the symbol at `pos`.
+    fn rename(
+        &self,
+        _ast: &dyn Any,
+        _pos: Position,
+        _new_name: &str,
+    ) -> Option<Result<Option<WorkspaceEdit>, String>> {
+        None
+    }
+
+    /// Return semantic token data for the whole document.
+    fn semantic_tokens(
+        &self,
+        _source: &str,
+        _tokens: &[Token],
+    ) -> Option<Result<Vec<SemanticToken>, String>> {
+        None
+    }
+
+    /// Return the outline tree for the given AST.
+    fn document_symbols(
+        &self,
+        _ast: &dyn Any,
+    ) -> Option<Result<Vec<DocumentSymbol>, String>> {
+        None
+    }
+
+    /// Return collapsible regions derived from the AST structure.
+    fn folding_ranges(
+        &self,
+        _ast: &dyn Any,
+    ) -> Option<Result<Vec<FoldingRange>, String>> {
+        None
+    }
+
+    /// Return signature hint information for the call at `pos`.
+    fn signature_help(
+        &self,
+        _ast: &dyn Any,
+        _pos: Position,
+    ) -> Option<Result<Option<SignatureHelpResult>, String>> {
+        None
+    }
+
+    /// Return the text edits needed to format the document.
+    fn format(&self, _source: &str) -> Option<Result<Vec<TextEdit>, String>> {
+        None
+    }
+
+    // -----------------------------------------------------------------------
+    // Capability flags
+    // -----------------------------------------------------------------------
+    //
+    // These are used by `build_capabilities()` to determine which LSP
+    // capabilities to advertise. Override to `true` for each optional method
+    // your bridge implements.
+
+    /// Does this bridge support hover tooltips?
+    fn supports_hover(&self) -> bool {
+        false
+    }
+    /// Does this bridge support "Go to Definition"?
+    fn supports_definition(&self) -> bool {
+        false
+    }
+    /// Does this bridge support "Find All References"?
+    fn supports_references(&self) -> bool {
+        false
+    }
+    /// Does this bridge support autocomplete?
+    fn supports_completion(&self) -> bool {
+        false
+    }
+    /// Does this bridge support symbol rename?
+    fn supports_rename(&self) -> bool {
+        false
+    }
+    /// Does this bridge support semantic token highlighting?
+    fn supports_semantic_tokens(&self) -> bool {
+        false
+    }
+    /// Does this bridge support the document outline?
+    fn supports_document_symbols(&self) -> bool {
+        false
+    }
+    /// Does this bridge support code folding?
+    fn supports_folding_ranges(&self) -> bool {
+        false
+    }
+    /// Does this bridge support signature help?
+    fn supports_signature_help(&self) -> bool {
+        false
+    }
+    /// Does this bridge support document formatting?
+    fn supports_format(&self) -> bool {
+        false
+    }
+}

--- a/code/packages/rust/ls00/src/lib.rs
+++ b/code/packages/rust/ls00/src/lib.rs
@@ -1,0 +1,41 @@
+//! # ls00 -- Generic Language Server Protocol (LSP) Framework
+//!
+//! This crate implements a generic LSP server framework that language-specific
+//! "bridges" plug into. It handles all the protocol boilerplate -- JSON-RPC
+//! message dispatch, document synchronization, capability advertisement,
+//! semantic token encoding -- so that a language author only needs to implement
+//! the `LanguageBridge` trait.
+//!
+//! ## Architecture
+//!
+//! ```text
+//! Lexer -> Parser -> [LanguageBridge] -> [LspServer] -> VS Code / Neovim / Emacs
+//! ```
+//!
+//! ## How to use this crate
+//!
+//! 1. Implement the `LanguageBridge` trait for your language.
+//! 2. Call `LspServer::new(bridge, reader, writer)`.
+//! 3. Call `server.serve()` -- it blocks until the editor closes the connection.
+//!
+//! ## Module Map
+//!
+//! | Module             | Role                                          |
+//! |--------------------|-----------------------------------------------|
+//! | `types`            | All shared LSP data types                     |
+//! | `language_bridge`  | The `LanguageBridge` trait                     |
+//! | `document_manager` | Tracks open files, applies incremental edits  |
+//! | `parse_cache`      | Caches parse results keyed by (uri, version)  |
+//! | `capabilities`     | Builds capabilities + semantic token encoding |
+//! | `lsp_errors`       | LSP-specific error code constants             |
+//! | `server`           | `LspServer` -- the main coordinator           |
+//! | `handlers`         | All LSP handler implementations               |
+
+pub mod capabilities;
+pub mod document_manager;
+pub mod handlers;
+pub mod language_bridge;
+pub mod lsp_errors;
+pub mod parse_cache;
+pub mod server;
+pub mod types;

--- a/code/packages/rust/ls00/src/lsp_errors.rs
+++ b/code/packages/rust/ls00/src/lsp_errors.rs
@@ -1,0 +1,38 @@
+//! LSP-specific error codes.
+//!
+//! The JSON-RPC 2.0 specification reserves error codes in the range
+//! `[-32768, -32000]`. The LSP specification further reserves `[-32899, -32800]`
+//! for LSP protocol-level errors.
+//!
+//! Standard JSON-RPC error codes (from the `json-rpc` crate):
+//! - `-32700` ParseError
+//! - `-32600` InvalidRequest
+//! - `-32601` MethodNotFound
+//! - `-32602` InvalidParams
+//! - `-32603` InternalError
+//!
+//! LSP-specific codes are listed below.
+//!
+//! Reference: <https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#errorCodes>
+
+/// The server has received a request before the initialize handshake was
+/// completed. The server must reject any request (other than initialize)
+/// before it has been initialized.
+pub const SERVER_NOT_INITIALIZED: i64 = -32002;
+
+/// A generic error code for unknown errors.
+pub const UNKNOWN_ERROR_CODE: i64 = -32001;
+
+/// A request failed but not due to a protocol problem. For example, the
+/// document requested was not found.
+pub const REQUEST_FAILED: i64 = -32803;
+
+/// The server cancelled the request.
+pub const SERVER_CANCELLED: i64 = -32802;
+
+/// The document content was modified before the request completed.
+/// The client should retry.
+pub const CONTENT_MODIFIED: i64 = -32801;
+
+/// The client cancelled the request.
+pub const REQUEST_CANCELLED: i64 = -32800;

--- a/code/packages/rust/ls00/src/parse_cache.rs
+++ b/code/packages/rust/ls00/src/parse_cache.rs
@@ -1,0 +1,135 @@
+//! `ParseCache` -- avoid re-parsing unchanged documents.
+//!
+//! # Why Cache Parse Results?
+//!
+//! Parsing is the most expensive operation in a language server. For a large
+//! file, parsing on every keystroke would lag the editor noticeably.
+//!
+//! The LSP protocol helps by sending a version number with every change. If the
+//! document hasn't changed (same URI, same version), the parse result from the
+//! previous keystroke is still valid.
+//!
+//! # Cache Key Design
+//!
+//! The cache key is `(uri, version)`. Version is a monotonically increasing
+//! integer that the editor increments with each change:
+//!
+//! - Same `(uri, version)` -> cache hit -> return cached result
+//! - Different version -> cache miss -> re-parse and cache new result
+//!
+//! The old entry is evicted when a new version is cached for the same URI.
+//! This keeps memory bounded at O(open_documents) entries.
+
+use crate::language_bridge::LanguageBridge;
+use crate::types::Diagnostic;
+use std::any::Any;
+use std::collections::HashMap;
+
+// ---------------------------------------------------------------------------
+// ParseResult
+// ---------------------------------------------------------------------------
+
+/// The outcome of parsing one version of a document.
+///
+/// Even on parse error, we store the partial AST and diagnostics so that other
+/// features (hover, folding, symbols) can still work on the valid portions.
+pub struct ParseResult {
+    /// The parsed AST. May be `None` if the parser couldn't produce any AST.
+    pub ast: Option<Box<dyn Any + Send + Sync>>,
+    /// Parse errors and warnings.
+    pub diagnostics: Vec<Diagnostic>,
+    /// Non-`None` only for fatal parsing failures.
+    pub err: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// CacheKey
+// ---------------------------------------------------------------------------
+
+/// Cache key combining document URI and version number.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct CacheKey {
+    uri: String,
+    version: i32,
+}
+
+// ---------------------------------------------------------------------------
+// ParseCache
+// ---------------------------------------------------------------------------
+
+/// Stores the most recent parse result for each open document.
+///
+/// Create one with `ParseCache::new()`. Call `get_or_parse()` on every feature
+/// request to get the current (possibly cached) parse result.
+pub struct ParseCache {
+    cache: HashMap<CacheKey, ParseResult>,
+}
+
+impl ParseCache {
+    /// Create an empty `ParseCache`.
+    pub fn new() -> Self {
+        Self {
+            cache: HashMap::new(),
+        }
+    }
+
+    /// Return the parse result for `(uri, version)`.
+    ///
+    /// If the result is already cached, it is returned immediately without
+    /// calling the bridge again. Otherwise, `bridge.parse(source)` is called,
+    /// the result is stored, and the previous cache entry for this URI (if any)
+    /// is evicted to prevent unbounded growth.
+    pub fn get_or_parse(
+        &mut self,
+        uri: &str,
+        version: i32,
+        source: &str,
+        bridge: &dyn LanguageBridge,
+    ) -> &ParseResult {
+        let key = CacheKey {
+            uri: uri.to_string(),
+            version,
+        };
+
+        // Cache hit check -- must use contains_key to satisfy the borrow checker.
+        if self.cache.contains_key(&key) {
+            return self.cache.get(&key).unwrap();
+        }
+
+        // Cache miss: parse and store. Evict any stale entry for this URI first.
+        self.evict_internal(uri);
+
+        let result = match bridge.parse(source) {
+            Ok((ast, mut diags)) => {
+                if diags.is_empty() {
+                    diags = Vec::new(); // normalize for JSON
+                }
+                ParseResult {
+                    ast: Some(ast),
+                    diagnostics: diags,
+                    err: None,
+                }
+            }
+            Err(e) => ParseResult {
+                ast: None,
+                diagnostics: Vec::new(),
+                err: Some(e),
+            },
+        };
+
+        self.cache.insert(key.clone(), result);
+        self.cache.get(&key).unwrap()
+    }
+
+    /// Remove all cached entries for a given URI.
+    ///
+    /// Called when a document is closed (`didClose`) so the cache entry is
+    /// cleaned up.
+    pub fn evict(&mut self, uri: &str) {
+        self.evict_internal(uri);
+    }
+
+    fn evict_internal(&mut self, uri: &str) {
+        self.cache.retain(|k, _| k.uri != uri);
+    }
+}

--- a/code/packages/rust/ls00/src/server.rs
+++ b/code/packages/rust/ls00/src/server.rs
@@ -1,0 +1,240 @@
+//! `LspServer` -- the main coordinator.
+//!
+//! `LspServer` wires together:
+//! - The `LanguageBridge` (language-specific logic)
+//! - The `DocumentManager` (tracks open file contents)
+//! - The `ParseCache` (avoids redundant parses)
+//! - The JSON-RPC `MessageReader` and `MessageWriter` (protocol layer)
+//!
+//! Instead of using the JSON-RPC `Server`'s dispatch loop (which requires
+//! closures that are `Send + 'static`), we read and dispatch messages directly.
+//! This is simpler and avoids lifetime gymnastics with self-referential closures.
+//!
+//! # Server Lifecycle
+//!
+//! ```text
+//! Client (editor)              Server (us)
+//!   |                               |
+//!   |--initialize-------------->    |  store clientInfo, return capabilities
+//!   | <-----------------result-     |
+//!   |                               |
+//!   |--initialized (notif)----->    |  no-op (handshake complete)
+//!   |                               |
+//!   |--textDocument/didOpen---->    |  open doc, parse, push diagnostics
+//!   |--textDocument/hover------>    |  get parse result, call bridge.Hover
+//!   | <-----------------result-     |
+//!   |                               |
+//!   |--shutdown---------------->    |  set shutdown flag, return null
+//!   |--exit (notif)------------>    |  exit process
+//! ```
+
+use crate::document_manager::DocumentManager;
+use crate::language_bridge::LanguageBridge;
+use crate::lsp_errors::REQUEST_FAILED;
+use crate::parse_cache::ParseCache;
+use crate::types::Diagnostic;
+use coding_adventures_json_rpc::message::{Message, Response};
+use coding_adventures_json_rpc::{MessageReader, MessageWriter, ResponseError};
+use serde_json::{json, Value};
+use std::any::Any;
+use std::io::{BufRead, Write};
+
+/// The main LSP server.
+///
+/// Create it with `LspServer::new()`, then call `serve()` to start serving.
+/// It is designed to be used once per process -- start it, it blocks, it exits.
+pub struct LspServer<R: BufRead, W: Write> {
+    pub(crate) bridge: Box<dyn LanguageBridge>,
+    pub(crate) doc_manager: DocumentManager,
+    pub(crate) parse_cache: ParseCache,
+    reader: MessageReader<R>,
+    /// The writer for sending messages back to the client.
+    pub writer: MessageWriter<W>,
+
+    /// Whether the editor has sent "shutdown".
+    pub(crate) shutdown: bool,
+
+    /// Whether the initialize handshake is complete.
+    pub(crate) initialized: bool,
+}
+
+impl<R: BufRead, W: Write> LspServer<R, W> {
+    /// Create an `LspServer` wired to read from `reader` and write to `writer`.
+    pub fn new(bridge: Box<dyn LanguageBridge>, reader: R, writer: W) -> Self {
+        Self {
+            bridge,
+            doc_manager: DocumentManager::new(),
+            parse_cache: ParseCache::new(),
+            reader: MessageReader::new(reader),
+            writer: MessageWriter::new(writer),
+            shutdown: false,
+            initialized: false,
+        }
+    }
+
+    /// Start the blocking read-dispatch-write loop.
+    ///
+    /// This call blocks until the editor closes the connection (EOF on stdin).
+    /// All LSP messages are handled synchronously in this loop.
+    pub fn serve(&mut self) {
+        loop {
+            match self.reader.read_message() {
+                None => {
+                    // EOF -- clean shutdown.
+                    break;
+                }
+
+                Some(Ok(Message::Request(req))) => {
+                    let id = req.id.clone();
+                    let method = req.method.as_str();
+                    let params = req.params.clone();
+
+                    let result = match method {
+                        "initialize" => self.handle_initialize(id.clone(), params),
+                        "shutdown" => self.handle_shutdown(id.clone(), params),
+                        "textDocument/hover" => self.handle_hover(id.clone(), params),
+                        "textDocument/definition" => self.handle_definition(id.clone(), params),
+                        "textDocument/references" => self.handle_references(id.clone(), params),
+                        "textDocument/completion" => self.handle_completion(id.clone(), params),
+                        "textDocument/rename" => self.handle_rename(id.clone(), params),
+                        "textDocument/documentSymbol" => {
+                            self.handle_document_symbol(id.clone(), params)
+                        }
+                        "textDocument/semanticTokens/full" => {
+                            self.handle_semantic_tokens_full(id.clone(), params)
+                        }
+                        "textDocument/foldingRange" => {
+                            self.handle_folding_range(id.clone(), params)
+                        }
+                        "textDocument/signatureHelp" => {
+                            self.handle_signature_help(id.clone(), params)
+                        }
+                        "textDocument/formatting" => {
+                            self.handle_formatting(id.clone(), params)
+                        }
+                        _ => Err(ResponseError::method_not_found(method)),
+                    };
+
+                    let response = match result {
+                        Ok(value) => Response {
+                            id,
+                            result: Some(value),
+                            error: None,
+                        },
+                        Err(e) => Response {
+                            id,
+                            result: None,
+                            error: Some(e),
+                        },
+                    };
+
+                    let _ = self.writer.write_message(&Message::Response(response));
+                }
+
+                Some(Ok(Message::Notification(notif))) => {
+                    let method = notif.method.as_str();
+                    let params = notif.params.clone();
+
+                    match method {
+                        "initialized" => self.handle_initialized(params),
+                        "exit" => self.handle_exit(params),
+                        "textDocument/didOpen" => self.handle_did_open(params),
+                        "textDocument/didChange" => self.handle_did_change(params),
+                        "textDocument/didClose" => self.handle_did_close(params),
+                        "textDocument/didSave" => self.handle_did_save(params),
+                        _ => {} // unknown notifications are silently dropped
+                    }
+                }
+
+                Some(Ok(Message::Response(_))) => {
+                    // Responses are for client-side use. Ignored.
+                }
+
+                Some(Err(e)) => {
+                    let response = Response {
+                        id: Value::Null,
+                        result: None,
+                        error: Some(e),
+                    };
+                    let _ = self.writer.write_message(&Message::Response(response));
+                }
+            }
+        }
+    }
+
+    /// Send a server-initiated notification to the editor.
+    fn send_notification(&mut self, method: &str, params: Value) {
+        let notif = Message::Notification(coding_adventures_json_rpc::Notification {
+            method: method.to_string(),
+            params: Some(params),
+        });
+        let _ = self.writer.write_message(&notif);
+    }
+
+    /// Publish diagnostics to the editor.
+    pub(crate) fn publish_diagnostics(
+        &mut self,
+        uri: &str,
+        version: i32,
+        diagnostics: &[Diagnostic],
+    ) {
+        let lsp_diags: Vec<Value> = diagnostics
+            .iter()
+            .map(|d| {
+                let mut diag = json!({
+                    "range": {
+                        "start": {"line": d.range.start.line, "character": d.range.start.character},
+                        "end": {"line": d.range.end.line, "character": d.range.end.character}
+                    },
+                    "severity": d.severity as i32,
+                    "message": d.message
+                });
+                if let Some(code) = &d.code {
+                    diag["code"] = json!(code);
+                }
+                diag
+            })
+            .collect();
+
+        let mut params = json!({
+            "uri": uri,
+            "diagnostics": lsp_diags
+        });
+
+        if version > 0 {
+            params["version"] = json!(version);
+        }
+
+        self.send_notification("textDocument/publishDiagnostics", params);
+    }
+
+    /// Get the current parse result for a document, returning an owned AST.
+    ///
+    /// We call `bridge.parse()` directly to get an owned AST box, but the
+    /// parse cache ensures we don't do redundant work for diagnostics.
+    pub(crate) fn get_parse_result_cloned(
+        &mut self,
+        uri: &str,
+    ) -> Result<(Option<Box<dyn Any + Send + Sync>>, Vec<Diagnostic>), ResponseError> {
+        let doc = self.doc_manager.get(uri).ok_or_else(|| ResponseError {
+            code: REQUEST_FAILED,
+            message: format!("document not open: {}", uri),
+            data: None,
+        })?;
+
+        let text = doc.text.clone();
+        let version = doc.version;
+
+        // Ensure diagnostics are cached.
+        let cached = self
+            .parse_cache
+            .get_or_parse(uri, version, &text, self.bridge.as_ref());
+        let cached_diags = cached.diagnostics.clone();
+
+        // Re-parse for an owned AST (the cache stores its own copy).
+        match self.bridge.parse(&text) {
+            Ok((ast, _)) => Ok((Some(ast), cached_diags)),
+            Err(_) => Ok((None, cached_diags)),
+        }
+    }
+}

--- a/code/packages/rust/ls00/src/types.rs
+++ b/code/packages/rust/ls00/src/types.rs
@@ -1,0 +1,379 @@
+//! All shared LSP data types used across the server.
+//!
+//! These types mirror the LSP specification's TypeScript type definitions,
+//! translated to idiomatic Rust. The LSP spec lives at:
+//! <https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/>
+//!
+//! # Coordinate System
+//!
+//! LSP uses a 0-based, line/character coordinate system. Line 0, character 0 is
+//! the very first character of the file. This differs from most editors (which
+//! display 1-based line numbers) and from our lexer (which emits 1-based tokens).
+//! The `LanguageBridge` is responsible for converting.
+//!
+//! # UTF-16 Code Units
+//!
+//! LSP's "character" offset is measured in UTF-16 CODE UNITS, not bytes or
+//! Unicode codepoints. This is a historical artifact: VS Code is built on
+//! TypeScript, which uses UTF-16 strings internally. See `document_manager.rs`
+//! for the conversion function and a detailed explanation of why this matters.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+// ---------------------------------------------------------------------------
+// Position
+// ---------------------------------------------------------------------------
+
+/// A cursor position in a document.
+///
+/// Both `line` and `character` are 0-based. `character` is measured in UTF-16
+/// code units (see the module doc above for why).
+///
+/// # Example
+///
+/// In the string `"hello 🎸 world"`, the guitar emoji (🎸) occupies
+/// UTF-16 characters 6 and 7 (it requires two UTF-16 surrogates). `"world"`
+/// starts at UTF-16 character 9.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Position {
+    pub line: i32,
+    pub character: i32,
+}
+
+// ---------------------------------------------------------------------------
+// Range
+// ---------------------------------------------------------------------------
+
+/// A span of text in a document, from `start` (inclusive) to `end` (exclusive).
+///
+/// Analogy: think of it like a text selection. `start` is where the cursor
+/// lands when you click, `end` is where you drag to.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Range {
+    pub start: Position,
+    pub end: Position,
+}
+
+// ---------------------------------------------------------------------------
+// Location
+// ---------------------------------------------------------------------------
+
+/// A position in a specific file.
+///
+/// `uri` uses the `"file://"` scheme, e.g., `"file:///home/user/main.rs"`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Location {
+    pub uri: String,
+    pub range: Range,
+}
+
+// ---------------------------------------------------------------------------
+// DiagnosticSeverity
+// ---------------------------------------------------------------------------
+
+/// How serious a diagnostic is. These match the LSP integer codes.
+///
+/// | Value | Meaning      | Editor rendering      |
+/// |-------|--------------|-----------------------|
+/// | 1     | Error        | Red squiggle          |
+/// | 2     | Warning      | Yellow squiggle       |
+/// | 3     | Information  | Blue squiggle         |
+/// | 4     | Hint         | Faint dots            |
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[repr(i32)]
+pub enum DiagnosticSeverity {
+    /// A hard error; the code cannot run or compile.
+    Error = 1,
+    /// Potentially problematic, but not blocking.
+    Warning = 2,
+    /// Informational message.
+    Information = 3,
+    /// A suggestion (e.g., "consider using const").
+    Hint = 4,
+}
+
+// ---------------------------------------------------------------------------
+// Diagnostic
+// ---------------------------------------------------------------------------
+
+/// An error, warning, or hint to display in the editor.
+///
+/// The editor renders diagnostics as underlined squiggles, with the message
+/// shown on hover. Red squiggles = Error, yellow = Warning, blue = Info.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Diagnostic {
+    pub range: Range,
+    pub severity: DiagnosticSeverity,
+    pub message: String,
+    /// Optional error code, e.g. `"E001"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Token
+// ---------------------------------------------------------------------------
+
+/// A single lexical token from the language's lexer.
+///
+/// The bridge's `tokenize()` method returns a `Vec` of these. The LSP server
+/// uses tokens to provide semantic syntax highlighting (`SemanticTokensProvider`).
+///
+/// Note: `line` and `column` are 1-based (matching most lexers). The bridge
+/// must convert to 0-based when building `SemanticToken` values for the LSP
+/// response.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Token {
+    /// e.g. `"KEYWORD"`, `"IDENTIFIER"`, `"STRING_LIT"`
+    pub token_type: String,
+    /// The actual source text, e.g. `"let"` or `"myVar"`
+    pub value: String,
+    /// 1-based line number.
+    pub line: i32,
+    /// 1-based column number.
+    pub column: i32,
+}
+
+// ---------------------------------------------------------------------------
+// TextEdit
+// ---------------------------------------------------------------------------
+
+/// A single text replacement in a document.
+///
+/// Used by formatting (replace the whole file) and rename (replace each
+/// occurrence). `new_text` replaces the content at `range`. If `new_text`
+/// is empty, the range is deleted.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TextEdit {
+    pub range: Range,
+    pub new_text: String,
+}
+
+// ---------------------------------------------------------------------------
+// WorkspaceEdit
+// ---------------------------------------------------------------------------
+
+/// Groups `TextEdit`s across potentially multiple files.
+///
+/// For rename operations that affect a single file, `changes` will have one
+/// key. For multi-file projects, a rename may produce edits across many files.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspaceEdit {
+    /// `uri` -> list of edits for that file.
+    pub changes: HashMap<String, Vec<TextEdit>>,
+}
+
+// ---------------------------------------------------------------------------
+// HoverResult
+// ---------------------------------------------------------------------------
+
+/// The content to show in the hover popup.
+///
+/// `contents` is Markdown text. VS Code renders it with syntax highlighting,
+/// bold/italic, code blocks, etc. `range` is optional -- if set, it highlights
+/// the symbol in the editor when the hover popup is shown.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HoverResult {
+    /// Markdown text to display.
+    pub contents: String,
+    /// Optional: the range of the symbol being hovered.
+    pub range: Option<Range>,
+}
+
+// ---------------------------------------------------------------------------
+// CompletionItemKind
+// ---------------------------------------------------------------------------
+
+/// Classifies completion items so the editor can show the right icon
+/// (function icon, variable icon, keyword icon, etc.).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[repr(i32)]
+pub enum CompletionItemKind {
+    Text = 1,
+    Method = 2,
+    Function = 3,
+    Constructor = 4,
+    Field = 5,
+    Variable = 6,
+    Class = 7,
+    Interface = 8,
+    Module = 9,
+    Property = 10,
+    Unit = 11,
+    Value = 12,
+    Enum = 13,
+    Keyword = 14,
+    Snippet = 15,
+    Color = 16,
+    File = 17,
+    Reference = 18,
+    Folder = 19,
+    EnumMember = 20,
+    Constant = 21,
+    Struct = 22,
+    Event = 23,
+    Operator = 24,
+    TypeParameter = 25,
+}
+
+// ---------------------------------------------------------------------------
+// CompletionItem
+// ---------------------------------------------------------------------------
+
+/// A single autocomplete suggestion.
+///
+/// When the user triggers autocomplete (e.g., by pressing Ctrl+Space or typing
+/// after a dot), the editor shows a dropdown list of `CompletionItem`s.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompletionItem {
+    pub label: String,
+    pub kind: Option<CompletionItemKind>,
+    pub detail: Option<String>,
+    pub documentation: Option<String>,
+    pub insert_text: Option<String>,
+    /// 1 = plain text, 2 = snippet
+    pub insert_text_format: Option<i32>,
+}
+
+// ---------------------------------------------------------------------------
+// SemanticToken
+// ---------------------------------------------------------------------------
+
+/// One token's contribution to the semantic highlighting pass.
+///
+/// Semantic tokens are the "second pass" of syntax highlighting. The editor's
+/// grammar-based highlighter (TextMate/tmLanguage) does a fast regex pass first.
+/// Semantic tokens layer on top with accurate, context-aware type information.
+///
+/// `line` and `character` are 0-based. `token_type` and `modifiers` reference
+/// entries in the legend returned by `semantic_token_legend()`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SemanticToken {
+    /// 0-based line number.
+    pub line: i32,
+    /// 0-based character offset in UTF-16 code units.
+    pub character: i32,
+    /// Length in UTF-16 code units.
+    pub length: i32,
+    /// Must match an entry in `SemanticTokenLegendData::token_types`.
+    pub token_type: String,
+    /// Subset of `SemanticTokenLegendData::token_modifiers`.
+    pub modifiers: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// SymbolKind
+// ---------------------------------------------------------------------------
+
+/// Classifies document symbols for the outline panel.
+/// These match the LSP integer codes (1-based).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[repr(i32)]
+pub enum SymbolKind {
+    File = 1,
+    Module = 2,
+    Namespace = 3,
+    Package = 4,
+    Class = 5,
+    Method = 6,
+    Property = 7,
+    Field = 8,
+    Constructor = 9,
+    Enum = 10,
+    Interface = 11,
+    Function = 12,
+    Variable = 13,
+    Constant = 14,
+    String = 15,
+    Number = 16,
+    Boolean = 17,
+    Array = 18,
+    Object = 19,
+    Key = 20,
+    Null = 21,
+    EnumMember = 22,
+    Struct = 23,
+    Event = 24,
+    Operator = 25,
+    TypeParameter = 26,
+}
+
+// ---------------------------------------------------------------------------
+// DocumentSymbol
+// ---------------------------------------------------------------------------
+
+/// One entry in the document outline panel.
+///
+/// The outline shows a tree of named symbols (functions, classes, variables).
+/// `children` allows nesting: a class symbol can have method symbols as children.
+///
+/// `range` covers the entire symbol (including its body). `selection_range` is
+/// the smaller range of just the symbol's name (used to highlight the name when
+/// the user clicks the outline entry).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocumentSymbol {
+    pub name: String,
+    pub kind: SymbolKind,
+    pub range: Range,
+    pub selection_range: Range,
+    pub children: Vec<DocumentSymbol>,
+}
+
+// ---------------------------------------------------------------------------
+// FoldingRange
+// ---------------------------------------------------------------------------
+
+/// A collapsible region of the document.
+///
+/// The editor shows a collapse arrow in the gutter next to `start_line`. When
+/// collapsed, lines `start_line+1` through `end_line` are hidden. `kind` is
+/// one of `"region"`, `"imports"`, or `"comment"`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FoldingRange {
+    /// 0-based start line.
+    pub start_line: i32,
+    /// 0-based end line.
+    pub end_line: i32,
+    /// Optional kind: `"region"`, `"imports"`, or `"comment"`.
+    pub kind: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// ParameterInformation
+// ---------------------------------------------------------------------------
+
+/// One parameter in a function signature.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParameterInformation {
+    pub label: String,
+    pub documentation: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// SignatureInformation
+// ---------------------------------------------------------------------------
+
+/// One function overload's full signature.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignatureInformation {
+    pub label: String,
+    pub documentation: Option<String>,
+    pub parameters: Vec<ParameterInformation>,
+}
+
+// ---------------------------------------------------------------------------
+// SignatureHelpResult
+// ---------------------------------------------------------------------------
+
+/// Shown as a tooltip when the user is typing a function call.
+///
+/// It shows the function signature with the current parameter highlighted.
+/// `active_signature` indexes into `signatures`. `active_parameter` indexes
+/// into that signature's `parameters`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignatureHelpResult {
+    pub signatures: Vec<SignatureInformation>,
+    pub active_signature: i32,
+    pub active_parameter: i32,
+}

--- a/code/packages/rust/ls00/tests/integration_test.rs
+++ b/code/packages/rust/ls00/tests/integration_test.rs
@@ -1,0 +1,1569 @@
+//! Comprehensive tests for the ls00 LSP framework.
+//!
+//! # Test Strategy
+//!
+//! We test the framework with mock bridges that implement various subsets
+//! of the `LanguageBridge` trait. This lets us exercise every code path
+//! without needing a real language implementation.
+//!
+//! # Test Coverage Areas
+//!
+//!  1. UTF-16 offset conversion (critical for correctness)
+//!  2. DocumentManager open/change/close operations
+//!  3. ParseCache hit/miss behavior
+//!  4. Semantic token encoding (the delta format)
+//!  5. Capabilities advertisement (only what the bridge supports)
+//!  6. Full LSP lifecycle via JSON-RPC round-trips
+
+use coding_adventures_json_rpc::message::{parse_message, Message};
+use coding_adventures_ls00::capabilities::*;
+use coding_adventures_ls00::document_manager::*;
+use coding_adventures_ls00::language_bridge::LanguageBridge;
+use coding_adventures_ls00::lsp_errors::*;
+use coding_adventures_ls00::parse_cache::*;
+use coding_adventures_ls00::server::LspServer;
+use coding_adventures_ls00::types::*;
+use serde_json::{json, Value};
+use std::any::Any;
+use std::io::{BufReader, Cursor};
+
+// ============================================================================
+// Mock Bridges
+// ============================================================================
+
+/// MockBridge implements the required `LanguageBridge` methods plus hover
+/// and document symbols. Used to test basic capability advertisement.
+struct MockBridge {
+    hover_result: Option<HoverResult>,
+}
+
+impl LanguageBridge for MockBridge {
+    fn tokenize(&self, source: &str) -> Result<Vec<Token>, String> {
+        let mut tokens = Vec::new();
+        let mut col = 1;
+        for word in source.split_whitespace() {
+            tokens.push(Token {
+                token_type: "WORD".to_string(),
+                value: word.to_string(),
+                line: 1,
+                column: col,
+            });
+            col += word.len() as i32 + 1;
+        }
+        Ok(tokens)
+    }
+
+    fn parse(
+        &self,
+        source: &str,
+    ) -> Result<(Box<dyn Any + Send + Sync>, Vec<Diagnostic>), String> {
+        let mut diags = Vec::new();
+        if source.contains("ERROR") {
+            diags.push(Diagnostic {
+                range: Range {
+                    start: Position {
+                        line: 0,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 0,
+                        character: 5,
+                    },
+                },
+                severity: DiagnosticSeverity::Error,
+                message: "syntax error: unexpected ERROR token".to_string(),
+                code: None,
+            });
+        }
+        Ok((Box::new(source.to_string()), diags))
+    }
+
+    fn hover(
+        &self,
+        _ast: &dyn Any,
+        _pos: Position,
+    ) -> Option<Result<Option<HoverResult>, String>> {
+        Some(Ok(self.hover_result.clone()))
+    }
+
+    fn supports_hover(&self) -> bool {
+        true
+    }
+
+    fn document_symbols(
+        &self,
+        _ast: &dyn Any,
+    ) -> Option<Result<Vec<DocumentSymbol>, String>> {
+        Some(Ok(vec![DocumentSymbol {
+            name: "main".to_string(),
+            kind: SymbolKind::Function,
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 10,
+                    character: 1,
+                },
+            },
+            selection_range: Range {
+                start: Position {
+                    line: 0,
+                    character: 9,
+                },
+                end: Position {
+                    line: 0,
+                    character: 13,
+                },
+            },
+            children: vec![DocumentSymbol {
+                name: "x".to_string(),
+                kind: SymbolKind::Variable,
+                range: Range {
+                    start: Position {
+                        line: 1,
+                        character: 4,
+                    },
+                    end: Position {
+                        line: 1,
+                        character: 12,
+                    },
+                },
+                selection_range: Range {
+                    start: Position {
+                        line: 1,
+                        character: 8,
+                    },
+                    end: Position {
+                        line: 1,
+                        character: 9,
+                    },
+                },
+                children: vec![],
+            }],
+        }]))
+    }
+
+    fn supports_document_symbols(&self) -> bool {
+        true
+    }
+}
+
+/// MinimalBridge implements ONLY the required LanguageBridge methods.
+/// Used to test that optional capabilities are NOT advertised.
+struct MinimalBridge;
+
+impl LanguageBridge for MinimalBridge {
+    fn tokenize(&self, _source: &str) -> Result<Vec<Token>, String> {
+        Ok(Vec::new())
+    }
+
+    fn parse(
+        &self,
+        source: &str,
+    ) -> Result<(Box<dyn Any + Send + Sync>, Vec<Diagnostic>), String> {
+        Ok((Box::new(source.to_string()), Vec::new()))
+    }
+}
+
+/// FullMockBridge implements all optional interfaces.
+struct FullMockBridge;
+
+impl LanguageBridge for FullMockBridge {
+    fn tokenize(&self, source: &str) -> Result<Vec<Token>, String> {
+        let mut tokens = Vec::new();
+        let mut col = 1;
+        for word in source.split_whitespace() {
+            tokens.push(Token {
+                token_type: "WORD".to_string(),
+                value: word.to_string(),
+                line: 1,
+                column: col,
+            });
+            col += word.len() as i32 + 1;
+        }
+        Ok(tokens)
+    }
+
+    fn parse(
+        &self,
+        source: &str,
+    ) -> Result<(Box<dyn Any + Send + Sync>, Vec<Diagnostic>), String> {
+        let mut diags = Vec::new();
+        if source.contains("ERROR") {
+            diags.push(Diagnostic {
+                range: Range {
+                    start: Position {
+                        line: 0,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 0,
+                        character: 5,
+                    },
+                },
+                severity: DiagnosticSeverity::Error,
+                message: "syntax error".to_string(),
+                code: None,
+            });
+        }
+        Ok((Box::new(source.to_string()), diags))
+    }
+
+    fn hover(
+        &self,
+        _ast: &dyn Any,
+        _pos: Position,
+    ) -> Option<Result<Option<HoverResult>, String>> {
+        Some(Ok(Some(HoverResult {
+            contents: "**hover** info".to_string(),
+            range: None,
+        })))
+    }
+    fn supports_hover(&self) -> bool {
+        true
+    }
+
+    fn definition(
+        &self,
+        _ast: &dyn Any,
+        pos: Position,
+        uri: &str,
+    ) -> Option<Result<Option<Location>, String>> {
+        Some(Ok(Some(Location {
+            uri: uri.to_string(),
+            range: Range {
+                start: pos.clone(),
+                end: pos,
+            },
+        })))
+    }
+    fn supports_definition(&self) -> bool {
+        true
+    }
+
+    fn references(
+        &self,
+        _ast: &dyn Any,
+        pos: Position,
+        uri: &str,
+        _include_decl: bool,
+    ) -> Option<Result<Vec<Location>, String>> {
+        Some(Ok(vec![Location {
+            uri: uri.to_string(),
+            range: Range {
+                start: pos.clone(),
+                end: pos,
+            },
+        }]))
+    }
+    fn supports_references(&self) -> bool {
+        true
+    }
+
+    fn completion(
+        &self,
+        _ast: &dyn Any,
+        _pos: Position,
+    ) -> Option<Result<Vec<CompletionItem>, String>> {
+        Some(Ok(vec![CompletionItem {
+            label: "foo".to_string(),
+            kind: Some(CompletionItemKind::Function),
+            detail: Some("() void".to_string()),
+            documentation: None,
+            insert_text: None,
+            insert_text_format: None,
+        }]))
+    }
+    fn supports_completion(&self) -> bool {
+        true
+    }
+
+    fn rename(
+        &self,
+        _ast: &dyn Any,
+        pos: Position,
+        new_name: &str,
+    ) -> Option<Result<Option<WorkspaceEdit>, String>> {
+        let mut changes = std::collections::HashMap::new();
+        changes.insert(
+            "file:///test.txt".to_string(),
+            vec![TextEdit {
+                range: Range {
+                    start: pos.clone(),
+                    end: pos,
+                },
+                new_text: new_name.to_string(),
+            }],
+        );
+        Some(Ok(Some(WorkspaceEdit { changes })))
+    }
+    fn supports_rename(&self) -> bool {
+        true
+    }
+
+    fn semantic_tokens(
+        &self,
+        _source: &str,
+        tokens: &[Token],
+    ) -> Option<Result<Vec<SemanticToken>, String>> {
+        let result: Vec<SemanticToken> = tokens
+            .iter()
+            .map(|tok| SemanticToken {
+                line: tok.line - 1,
+                character: tok.column - 1,
+                length: tok.value.len() as i32,
+                token_type: "variable".to_string(),
+                modifiers: vec![],
+            })
+            .collect();
+        Some(Ok(result))
+    }
+    fn supports_semantic_tokens(&self) -> bool {
+        true
+    }
+
+    fn document_symbols(
+        &self,
+        _ast: &dyn Any,
+    ) -> Option<Result<Vec<DocumentSymbol>, String>> {
+        Some(Ok(vec![DocumentSymbol {
+            name: "main".to_string(),
+            kind: SymbolKind::Function,
+            range: Range {
+                start: Position { line: 0, character: 0 },
+                end: Position { line: 10, character: 1 },
+            },
+            selection_range: Range {
+                start: Position { line: 0, character: 9 },
+                end: Position { line: 0, character: 13 },
+            },
+            children: vec![],
+        }]))
+    }
+    fn supports_document_symbols(&self) -> bool {
+        true
+    }
+
+    fn folding_ranges(
+        &self,
+        _ast: &dyn Any,
+    ) -> Option<Result<Vec<FoldingRange>, String>> {
+        Some(Ok(vec![FoldingRange {
+            start_line: 0,
+            end_line: 5,
+            kind: Some("region".to_string()),
+        }]))
+    }
+    fn supports_folding_ranges(&self) -> bool {
+        true
+    }
+
+    fn signature_help(
+        &self,
+        _ast: &dyn Any,
+        _pos: Position,
+    ) -> Option<Result<Option<SignatureHelpResult>, String>> {
+        Some(Ok(Some(SignatureHelpResult {
+            signatures: vec![SignatureInformation {
+                label: "foo(a int, b string)".to_string(),
+                documentation: None,
+                parameters: vec![
+                    ParameterInformation {
+                        label: "a int".to_string(),
+                        documentation: None,
+                    },
+                    ParameterInformation {
+                        label: "b string".to_string(),
+                        documentation: None,
+                    },
+                ],
+            }],
+            active_signature: 0,
+            active_parameter: 0,
+        })))
+    }
+    fn supports_signature_help(&self) -> bool {
+        true
+    }
+
+    fn format(&self, source: &str) -> Option<Result<Vec<TextEdit>, String>> {
+        Some(Ok(vec![TextEdit {
+            range: Range {
+                start: Position { line: 0, character: 0 },
+                end: Position { line: 999, character: 0 },
+            },
+            new_text: source.to_string(),
+        }]))
+    }
+    fn supports_format(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// UTF-16 Offset Conversion Tests
+// ============================================================================
+
+/// Verifies the critical UTF-16 -> byte conversion.
+///
+/// This is the most important correctness test in the entire package. If this
+/// function is wrong, every feature that depends on cursor position will be
+/// wrong: hover, go-to-definition, references, completion, rename.
+#[test]
+fn test_convert_utf16_offset_ascii_simple() {
+    let text = "hello world";
+    let byte_off = convert_utf16_offset_to_byte_offset(text, 0, 6);
+    assert_eq!(byte_off, 6);
+}
+
+#[test]
+fn test_convert_utf16_offset_start_of_file() {
+    let byte_off = convert_utf16_offset_to_byte_offset("abc", 0, 0);
+    assert_eq!(byte_off, 0);
+}
+
+#[test]
+fn test_convert_utf16_offset_end_of_short_string() {
+    let byte_off = convert_utf16_offset_to_byte_offset("abc", 0, 3);
+    assert_eq!(byte_off, 3);
+}
+
+#[test]
+fn test_convert_utf16_offset_second_line() {
+    // "hello\nworld" -- line 1 starts at byte 6
+    let byte_off = convert_utf16_offset_to_byte_offset("hello\nworld", 1, 0);
+    assert_eq!(byte_off, 6);
+}
+
+#[test]
+fn test_convert_utf16_offset_emoji() {
+    // "A🎸B"
+    // UTF-8 bytes:  A (1) + 🎸 (4) + B (1) = 6 bytes
+    // UTF-16 units: A (1) + 🎸 (2) + B (1) = 4 units
+    // "B" is at UTF-16 character 3, byte offset 5.
+    let text = "A\u{1F3B8}B";
+    let byte_off = convert_utf16_offset_to_byte_offset(text, 0, 3);
+    assert_eq!(byte_off, 5);
+}
+
+#[test]
+fn test_convert_utf16_offset_emoji_at_start() {
+    // "🎸hello" -- 🎸 = 2 UTF-16 units, 4 UTF-8 bytes
+    // "h" is at UTF-16 char 2, byte offset 4
+    let text = "\u{1F3B8}hello";
+    let byte_off = convert_utf16_offset_to_byte_offset(text, 0, 2);
+    assert_eq!(byte_off, 4);
+}
+
+#[test]
+fn test_convert_utf16_offset_2byte_utf8_bmp() {
+    // "cafe!" -- e with accent is U+00E9
+    // UTF-8: 2 bytes. UTF-16: 1 code unit.
+    // UTF-16 char 4 = byte offset 5 (c=1, a=1, f=1, e_accent=2 bytes)
+    let text = "caf\u{00e9}!";
+    let byte_off = convert_utf16_offset_to_byte_offset(text, 0, 4);
+    assert_eq!(byte_off, 5);
+}
+
+#[test]
+fn test_convert_utf16_offset_multiline_with_emoji() {
+    // line 0: "A🎸B\n" (1+4+1+1 = 7 bytes)
+    // line 1: "hello"
+    // "hello" starts at byte 7, char 0 on line 1
+    let text = "A\u{1F3B8}B\nhello";
+    let byte_off = convert_utf16_offset_to_byte_offset(text, 1, 0);
+    assert_eq!(byte_off, 7);
+}
+
+#[test]
+fn test_convert_utf16_offset_beyond_line_end() {
+    // Character past end of line should clamp to the newline.
+    let text = "ab\ncd";
+    let byte_off = convert_utf16_offset_to_byte_offset(text, 0, 100);
+    assert_eq!(byte_off, 2);
+}
+
+#[test]
+fn test_convert_utf16_chinese_character() {
+    // "中文" -- each Chinese char is 3 UTF-8 bytes, 1 UTF-16 code unit.
+    // "文" is at UTF-16 char 1, byte offset 3.
+    let text = "\u{4e2d}\u{6587}";
+    let byte_off = convert_utf16_offset_to_byte_offset(text, 0, 1);
+    assert_eq!(byte_off, 3);
+}
+
+// ============================================================================
+// DocumentManager Tests
+// ============================================================================
+
+#[test]
+fn test_document_manager_open() {
+    let mut dm = DocumentManager::new();
+    dm.open("file:///test.txt", "hello world", 1);
+
+    let doc = dm.get("file:///test.txt").unwrap();
+    assert_eq!(doc.text, "hello world");
+    assert_eq!(doc.version, 1);
+}
+
+#[test]
+fn test_document_manager_get_missing() {
+    let dm = DocumentManager::new();
+    assert!(dm.get("file:///nonexistent.txt").is_none());
+}
+
+#[test]
+fn test_document_manager_close() {
+    let mut dm = DocumentManager::new();
+    dm.open("file:///test.txt", "hello", 1);
+    dm.close("file:///test.txt");
+    assert!(dm.get("file:///test.txt").is_none());
+}
+
+#[test]
+fn test_document_manager_apply_changes_full_replacement() {
+    let mut dm = DocumentManager::new();
+    dm.open("file:///test.txt", "hello world", 1);
+
+    dm.apply_changes(
+        "file:///test.txt",
+        &[TextChange {
+            range: None,
+            new_text: "goodbye world".to_string(),
+        }],
+        2,
+    )
+    .unwrap();
+
+    let doc = dm.get("file:///test.txt").unwrap();
+    assert_eq!(doc.text, "goodbye world");
+    assert_eq!(doc.version, 2);
+}
+
+#[test]
+fn test_document_manager_apply_changes_incremental() {
+    let mut dm = DocumentManager::new();
+    dm.open("file:///test.txt", "hello world", 1);
+
+    // Replace "world" with "Go"
+    dm.apply_changes(
+        "file:///test.txt",
+        &[TextChange {
+            range: Some(Range {
+                start: Position { line: 0, character: 6 },
+                end: Position { line: 0, character: 11 },
+            }),
+            new_text: "Go".to_string(),
+        }],
+        2,
+    )
+    .unwrap();
+
+    let doc = dm.get("file:///test.txt").unwrap();
+    assert_eq!(doc.text, "hello Go");
+}
+
+#[test]
+fn test_document_manager_apply_changes_not_open() {
+    let mut dm = DocumentManager::new();
+    let result = dm.apply_changes(
+        "file:///notopen.txt",
+        &[TextChange {
+            range: None,
+            new_text: "x".to_string(),
+        }],
+        1,
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_document_manager_incremental_with_emoji() {
+    // "A🎸B" -- emoji is 4 UTF-8 bytes, 2 UTF-16 code units
+    // Replace "B" (UTF-16 char 3) with "X"
+    let mut dm = DocumentManager::new();
+    dm.open("file:///test.txt", "A\u{1F3B8}B", 1);
+
+    dm.apply_changes(
+        "file:///test.txt",
+        &[TextChange {
+            range: Some(Range {
+                start: Position { line: 0, character: 3 },
+                end: Position { line: 0, character: 4 },
+            }),
+            new_text: "X".to_string(),
+        }],
+        2,
+    )
+    .unwrap();
+
+    let doc = dm.get("file:///test.txt").unwrap();
+    assert_eq!(doc.text, "A\u{1F3B8}X");
+}
+
+#[test]
+fn test_document_manager_incremental_multi_change() {
+    let mut dm = DocumentManager::new();
+    dm.open("uri", "hello world", 1);
+
+    dm.apply_changes(
+        "uri",
+        &[TextChange {
+            range: Some(Range {
+                start: Position { line: 0, character: 0 },
+                end: Position { line: 0, character: 5 },
+            }),
+            new_text: "hi".to_string(),
+        }],
+        2,
+    )
+    .unwrap();
+
+    let doc = dm.get("uri").unwrap();
+    assert_eq!(doc.text, "hi world");
+}
+
+// ============================================================================
+// ParseCache Tests
+// ============================================================================
+
+#[test]
+fn test_parse_cache_hit_and_miss() {
+    let bridge = MockBridge { hover_result: None };
+    let mut cache = ParseCache::new();
+
+    // First call -- cache miss -> parses
+    let r1 = cache.get_or_parse("file:///a.txt", 1, "hello", &bridge);
+    assert!(r1.ast.is_some());
+    assert!(r1.diagnostics.is_empty());
+
+    // Second call same version -- cache hit (returns same result)
+    let r2 = cache.get_or_parse("file:///a.txt", 1, "hello", &bridge);
+    assert!(r2.ast.is_some());
+    assert!(r2.diagnostics.is_empty());
+
+    // Different version with ERROR source -- cache miss -> new result with diagnostics
+    let r3 = cache.get_or_parse("file:///a.txt", 2, "hello ERROR world", &bridge);
+    assert!(!r3.diagnostics.is_empty());
+}
+
+#[test]
+fn test_parse_cache_evict() {
+    let bridge = MockBridge { hover_result: None };
+    let mut cache = ParseCache::new();
+
+    // Parse a source with ERROR to get diagnostics
+    let r1 = cache.get_or_parse("file:///a.txt", 1, "hello ERROR", &bridge);
+    assert!(!r1.diagnostics.is_empty());
+
+    cache.evict("file:///a.txt");
+
+    // After eviction, same (uri, version) but different source should re-parse
+    // (the eviction cleared the cache, so it will parse the new source)
+    let r2 = cache.get_or_parse("file:///a.txt", 1, "hello", &bridge);
+    assert!(r2.diagnostics.is_empty()); // no ERROR in new source -> no diagnostics
+}
+
+#[test]
+fn test_parse_cache_diagnostics_populated() {
+    let bridge = MockBridge { hover_result: None };
+    let mut cache = ParseCache::new();
+
+    let result = cache.get_or_parse("file:///a.txt", 1, "source with ERROR token", &bridge);
+    assert!(!result.diagnostics.is_empty());
+}
+
+#[test]
+fn test_parse_cache_no_diagnostics_for_clean_source() {
+    let bridge = MockBridge { hover_result: None };
+    let mut cache = ParseCache::new();
+
+    let result = cache.get_or_parse("file:///clean.txt", 1, "hello world", &bridge);
+    assert!(result.diagnostics.is_empty());
+}
+
+// ============================================================================
+// Capabilities Tests
+// ============================================================================
+
+#[test]
+fn test_build_capabilities_minimal_bridge() {
+    let bridge = MinimalBridge;
+    let caps = build_capabilities(&bridge);
+
+    assert_eq!(caps["textDocumentSync"], 2);
+
+    let optional = [
+        "hoverProvider",
+        "definitionProvider",
+        "referencesProvider",
+        "completionProvider",
+        "renameProvider",
+        "documentSymbolProvider",
+        "foldingRangeProvider",
+        "signatureHelpProvider",
+        "documentFormattingProvider",
+        "semanticTokensProvider",
+    ];
+    for cap in &optional {
+        assert!(caps.get(cap).is_none(), "minimal bridge should not advertise {}", cap);
+    }
+}
+
+#[test]
+fn test_build_capabilities_mock_bridge() {
+    let bridge = MockBridge { hover_result: None };
+    let caps = build_capabilities(&bridge);
+
+    assert!(caps.get("hoverProvider").is_some());
+    assert!(caps.get("documentSymbolProvider").is_some());
+    // MockBridge doesn't support these
+    assert!(caps.get("definitionProvider").is_none());
+    assert!(caps.get("completionProvider").is_none());
+}
+
+#[test]
+fn test_build_capabilities_full_bridge() {
+    let bridge = FullMockBridge;
+    let caps = build_capabilities(&bridge);
+
+    let expected = [
+        "textDocumentSync",
+        "hoverProvider",
+        "definitionProvider",
+        "referencesProvider",
+        "completionProvider",
+        "renameProvider",
+        "documentSymbolProvider",
+        "foldingRangeProvider",
+        "signatureHelpProvider",
+        "documentFormattingProvider",
+        "semanticTokensProvider",
+    ];
+    for cap in &expected {
+        assert!(
+            caps.get(cap).is_some(),
+            "full bridge should advertise {}",
+            cap
+        );
+    }
+}
+
+#[test]
+fn test_build_capabilities_semantic_tokens_provider() {
+    let bridge = FullMockBridge;
+    let caps = build_capabilities(&bridge);
+
+    let stp = &caps["semanticTokensProvider"];
+    assert_eq!(stp["full"], true);
+    assert!(stp["legend"]["tokenTypes"].is_array());
+}
+
+#[test]
+fn test_semantic_token_legend_consistency() {
+    let legend = semantic_token_legend();
+
+    assert!(!legend.token_types.is_empty());
+    assert!(!legend.token_modifiers.is_empty());
+
+    let required = ["keyword", "string", "number", "variable", "function"];
+    for rt in &required {
+        assert!(
+            legend.token_types.contains(&rt.to_string()),
+            "legend missing required type {}",
+            rt
+        );
+    }
+}
+
+// ============================================================================
+// Semantic Token Encoding Tests
+// ============================================================================
+
+#[test]
+fn test_encode_semantic_tokens_empty() {
+    let data = encode_semantic_tokens(&[]);
+    assert!(data.is_empty());
+}
+
+#[test]
+fn test_encode_semantic_tokens_single_token() {
+    let tokens = vec![SemanticToken {
+        line: 0,
+        character: 0,
+        length: 5,
+        token_type: "keyword".to_string(),
+        modifiers: vec![],
+    }];
+    let data = encode_semantic_tokens(&tokens);
+
+    assert_eq!(data.len(), 5);
+    assert_eq!(data[0], 0); // deltaLine
+    assert_eq!(data[1], 0); // deltaChar
+    assert_eq!(data[2], 5); // length
+    assert_eq!(data[3], 15); // keyword index
+    assert_eq!(data[4], 0); // modifiers
+}
+
+#[test]
+fn test_encode_semantic_tokens_multiple_same_line() {
+    let tokens = vec![
+        SemanticToken {
+            line: 0,
+            character: 0,
+            length: 3,
+            token_type: "keyword".to_string(),
+            modifiers: vec![],
+        },
+        SemanticToken {
+            line: 0,
+            character: 4,
+            length: 4,
+            token_type: "function".to_string(),
+            modifiers: vec!["declaration".to_string()],
+        },
+    ];
+    let data = encode_semantic_tokens(&tokens);
+
+    assert_eq!(data.len(), 10);
+    // Token A
+    assert_eq!(&data[0..5], &[0, 0, 3, 15, 0]);
+    // Token B: deltaLine=0, deltaChar=4, length=4, function(12), declaration(bit0=1)
+    assert_eq!(&data[5..10], &[0, 4, 4, 12, 1]);
+}
+
+#[test]
+fn test_encode_semantic_tokens_multiple_lines() {
+    let tokens = vec![
+        SemanticToken {
+            line: 0,
+            character: 0,
+            length: 3,
+            token_type: "keyword".to_string(),
+            modifiers: vec![],
+        },
+        SemanticToken {
+            line: 2,
+            character: 4,
+            length: 5,
+            token_type: "number".to_string(),
+            modifiers: vec![],
+        },
+    ];
+    let data = encode_semantic_tokens(&tokens);
+
+    assert_eq!(data.len(), 10);
+    // Token B: deltaLine=2, deltaChar=4 (absolute on new line), number=19
+    assert_eq!(data[5], 2);
+    assert_eq!(data[6], 4);
+    assert_eq!(data[8], 19);
+}
+
+#[test]
+fn test_encode_semantic_tokens_unsorted_input() {
+    let tokens = vec![
+        SemanticToken {
+            line: 1,
+            character: 0,
+            length: 2,
+            token_type: "number".to_string(),
+            modifiers: vec![],
+        },
+        SemanticToken {
+            line: 0,
+            character: 0,
+            length: 3,
+            token_type: "keyword".to_string(),
+            modifiers: vec![],
+        },
+    ];
+    let data = encode_semantic_tokens(&tokens);
+
+    assert_eq!(data.len(), 10);
+    assert_eq!(data[3], 15); // first token should be keyword
+    assert_eq!(data[8], 19); // second should be number
+}
+
+#[test]
+fn test_encode_semantic_tokens_unknown_type() {
+    let tokens = vec![
+        SemanticToken {
+            line: 0,
+            character: 0,
+            length: 3,
+            token_type: "unknownType".to_string(),
+            modifiers: vec![],
+        },
+        SemanticToken {
+            line: 0,
+            character: 4,
+            length: 2,
+            token_type: "keyword".to_string(),
+            modifiers: vec![],
+        },
+    ];
+    let data = encode_semantic_tokens(&tokens);
+
+    // unknownType should be skipped, leaving only one 5-tuple
+    assert_eq!(data.len(), 5);
+}
+
+#[test]
+fn test_encode_semantic_tokens_modifier_bitmask() {
+    // "readonly" is bit 2 (index 2), value = 4
+    let tokens = vec![SemanticToken {
+        line: 0,
+        character: 0,
+        length: 3,
+        token_type: "variable".to_string(),
+        modifiers: vec!["readonly".to_string()],
+    }];
+    let data = encode_semantic_tokens(&tokens);
+
+    assert_eq!(data[4], 4); // readonly = bit 2 = value 4
+}
+
+// ============================================================================
+// LSP Error Codes Tests
+// ============================================================================
+
+#[test]
+fn test_lsp_error_codes() {
+    assert_eq!(SERVER_NOT_INITIALIZED, -32002);
+    assert_eq!(UNKNOWN_ERROR_CODE, -32001);
+    assert_eq!(REQUEST_FAILED, -32803);
+    assert_eq!(SERVER_CANCELLED, -32802);
+    assert_eq!(CONTENT_MODIFIED, -32801);
+    assert_eq!(REQUEST_CANCELLED, -32800);
+}
+
+// ============================================================================
+// JSON-RPC Round-Trip Handler Tests
+// ============================================================================
+//
+// These tests feed JSON-RPC messages through the full LspServer pipeline
+// using in-memory buffers.
+
+/// Helper: build a Content-Length-framed message from a JSON value.
+fn frame(value: &Value) -> Vec<u8> {
+    let payload = serde_json::to_vec(value).unwrap();
+    let header = format!("Content-Length: {}\r\n\r\n", payload.len());
+    let mut result = header.into_bytes();
+    result.extend_from_slice(&payload);
+    result
+}
+
+/// Helper: parse all framed messages from a byte slice.
+fn parse_all_messages(bytes: &[u8]) -> Vec<Message> {
+    let mut result = Vec::new();
+    let mut rest = bytes;
+
+    loop {
+        if rest.is_empty() {
+            break;
+        }
+        // Find \r\n\r\n
+        let sep_pos = rest
+            .windows(4)
+            .position(|w| w == b"\r\n\r\n");
+        match sep_pos {
+            None => break,
+            Some(pos) => {
+                let header = std::str::from_utf8(&rest[..pos]).unwrap();
+                let cl_line = header
+                    .lines()
+                    .find(|l| l.starts_with("Content-Length:"))
+                    .unwrap();
+                let n: usize = cl_line
+                    .trim_start_matches("Content-Length:")
+                    .trim()
+                    .parse()
+                    .unwrap();
+
+                let payload = &rest[pos + 4..pos + 4 + n];
+                result.push(parse_message(payload).unwrap());
+                rest = &rest[pos + 4 + n..];
+            }
+        }
+    }
+
+    result
+}
+
+/// Helper: run the server with given input bytes and return output bytes.
+fn run_server(bridge: Box<dyn LanguageBridge>, input: Vec<u8>) -> Vec<u8> {
+    let reader = BufReader::new(Cursor::new(input));
+    let writer = Cursor::new(Vec::new());
+    let mut server = LspServer::new(bridge, reader, writer);
+    server.serve();
+    // Extract the written bytes from the writer.
+    server.writer.into_inner().into_inner()
+}
+
+/// Extracts the response with a given id from a list of messages.
+fn find_response(messages: &[Message], id: i64) -> Option<&coding_adventures_json_rpc::message::Response> {
+    messages.iter().find_map(|m| match m {
+        Message::Response(r) if r.id == json!(id) => Some(r),
+        _ => None,
+    })
+}
+
+/// Extracts a notification with a given method from a list of messages.
+fn find_notification<'a>(messages: &'a [Message], method: &str) -> Option<&'a coding_adventures_json_rpc::Notification> {
+    messages.iter().find_map(|m| match m {
+        Message::Notification(n) if n.method == method => Some(n),
+        _ => None,
+    })
+}
+
+// -- Initialize --
+
+#[test]
+fn test_handler_initialize() {
+    let mut input = Vec::new();
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {"processId": 1234, "capabilities": {}}
+    })));
+
+    let output = run_server(Box::new(MockBridge { hover_result: None }), input);
+    let messages = parse_all_messages(&output);
+
+    let resp = find_response(&messages, 1).unwrap();
+    let result = resp.result.as_ref().unwrap();
+    let caps = &result["capabilities"];
+
+    assert_eq!(caps["textDocumentSync"], 2);
+    assert_eq!(caps["hoverProvider"], true);
+    assert_eq!(caps["documentSymbolProvider"], true);
+
+    let server_info = &result["serverInfo"];
+    assert_eq!(server_info["name"], "ls00-generic-lsp-server");
+}
+
+// -- Shutdown --
+
+#[test]
+fn test_handler_shutdown() {
+    let mut input = Vec::new();
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {"processId": 1, "capabilities": {}}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "id": 2, "method": "shutdown"
+    })));
+
+    let output = run_server(Box::new(MinimalBridge), input);
+    let messages = parse_all_messages(&output);
+
+    let resp = find_response(&messages, 2).unwrap();
+    assert!(resp.result.as_ref().unwrap().is_null());
+}
+
+// -- DidOpen publishes diagnostics --
+
+#[test]
+fn test_handler_did_open_publishes_diagnostics() {
+    let mut input = Vec::new();
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {"processId": 1, "capabilities": {}}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "method": "initialized", "params": {}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "method": "textDocument/didOpen",
+        "params": {"textDocument": {
+            "uri": "file:///test.txt", "languageId": "test",
+            "version": 1, "text": "hello ERROR world"
+        }}
+    })));
+
+    let output = run_server(Box::new(MockBridge { hover_result: None }), input);
+    let messages = parse_all_messages(&output);
+
+    let notif = find_notification(&messages, "textDocument/publishDiagnostics").unwrap();
+    let params = notif.params.as_ref().unwrap();
+    assert_eq!(params["uri"], "file:///test.txt");
+    let diags = params["diagnostics"].as_array().unwrap();
+    assert!(!diags.is_empty());
+}
+
+#[test]
+fn test_handler_did_open_clean_file() {
+    let mut input = Vec::new();
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {"processId": 1, "capabilities": {}}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "method": "initialized", "params": {}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "method": "textDocument/didOpen",
+        "params": {"textDocument": {
+            "uri": "file:///clean.txt", "languageId": "test",
+            "version": 1, "text": "hello world"
+        }}
+    })));
+
+    let output = run_server(Box::new(MockBridge { hover_result: None }), input);
+    let messages = parse_all_messages(&output);
+
+    let notif = find_notification(&messages, "textDocument/publishDiagnostics").unwrap();
+    let params = notif.params.as_ref().unwrap();
+    let diags = params["diagnostics"].as_array().unwrap();
+    assert!(diags.is_empty());
+}
+
+// -- Hover --
+
+#[test]
+fn test_handler_hover() {
+    let mut input = Vec::new();
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {"processId": 1, "capabilities": {}}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "method": "initialized", "params": {}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "method": "textDocument/didOpen",
+        "params": {"textDocument": {
+            "uri": "file:///test.go", "languageId": "go",
+            "version": 1, "text": "func main() {}"
+        }}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "id": 2, "method": "textDocument/hover",
+        "params": {
+            "textDocument": {"uri": "file:///test.go"},
+            "position": {"line": 0, "character": 5}
+        }
+    })));
+
+    let bridge = MockBridge {
+        hover_result: Some(HoverResult {
+            contents: "**main** function".to_string(),
+            range: Some(Range {
+                start: Position { line: 0, character: 0 },
+                end: Position { line: 0, character: 4 },
+            }),
+        }),
+    };
+    let output = run_server(Box::new(bridge), input);
+    let messages = parse_all_messages(&output);
+
+    let resp = find_response(&messages, 2).unwrap();
+    let result = resp.result.as_ref().unwrap();
+    assert_eq!(result["contents"]["kind"], "markdown");
+    assert_eq!(result["contents"]["value"], "**main** function");
+}
+
+#[test]
+fn test_handler_hover_no_bridge() {
+    let mut input = Vec::new();
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {"processId": 1, "capabilities": {}}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "method": "initialized", "params": {}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "method": "textDocument/didOpen",
+        "params": {"textDocument": {
+            "uri": "file:///test.txt", "languageId": "test",
+            "version": 1, "text": "hello"
+        }}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "id": 2, "method": "textDocument/hover",
+        "params": {
+            "textDocument": {"uri": "file:///test.txt"},
+            "position": {"line": 0, "character": 0}
+        }
+    })));
+
+    let output = run_server(Box::new(MinimalBridge), input);
+    let messages = parse_all_messages(&output);
+
+    let resp = find_response(&messages, 2).unwrap();
+    let result = resp.result.as_ref().unwrap();
+    assert!(result.is_null());
+}
+
+// -- Document Symbol --
+
+#[test]
+fn test_handler_document_symbol() {
+    let mut input = Vec::new();
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {"processId": 1, "capabilities": {}}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "method": "initialized", "params": {}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "method": "textDocument/didOpen",
+        "params": {"textDocument": {
+            "uri": "file:///test.go", "languageId": "go",
+            "version": 1, "text": "func main() { var x = 1 }"
+        }}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "id": 2, "method": "textDocument/documentSymbol",
+        "params": {"textDocument": {"uri": "file:///test.go"}}
+    })));
+
+    let output = run_server(Box::new(MockBridge { hover_result: None }), input);
+    let messages = parse_all_messages(&output);
+
+    let resp = find_response(&messages, 2).unwrap();
+    let result = resp.result.as_ref().unwrap();
+    let arr = result.as_array().unwrap();
+    assert!(!arr.is_empty());
+    assert_eq!(arr[0]["name"], "main");
+}
+
+// -- Semantic Tokens Full --
+
+#[test]
+fn test_handler_semantic_tokens_full() {
+    let mut input = Vec::new();
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {"processId": 1, "capabilities": {}}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "method": "initialized", "params": {}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "method": "textDocument/didOpen",
+        "params": {"textDocument": {
+            "uri": "file:///test.txt", "languageId": "test",
+            "version": 1, "text": "hello world"
+        }}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "id": 2, "method": "textDocument/semanticTokens/full",
+        "params": {"textDocument": {"uri": "file:///test.txt"}}
+    })));
+
+    let output = run_server(Box::new(FullMockBridge), input);
+    let messages = parse_all_messages(&output);
+
+    let resp = find_response(&messages, 2).unwrap();
+    let result = resp.result.as_ref().unwrap();
+    assert!(result["data"].is_array());
+}
+
+// -- Definition --
+
+#[test]
+fn test_handler_definition() {
+    let mut input = Vec::new();
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {"processId": 1, "capabilities": {}}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "method": "initialized", "params": {}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "method": "textDocument/didOpen",
+        "params": {"textDocument": {
+            "uri": "file:///test.txt", "languageId": "test",
+            "version": 1, "text": "hello world"
+        }}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "id": 2, "method": "textDocument/definition",
+        "params": {
+            "textDocument": {"uri": "file:///test.txt"},
+            "position": {"line": 0, "character": 0}
+        }
+    })));
+
+    let output = run_server(Box::new(FullMockBridge), input);
+    let messages = parse_all_messages(&output);
+
+    let resp = find_response(&messages, 2).unwrap();
+    let result = resp.result.as_ref().unwrap();
+    assert_eq!(result["uri"], "file:///test.txt");
+}
+
+// -- References --
+
+#[test]
+fn test_handler_references() {
+    let mut input = Vec::new();
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {"processId": 1, "capabilities": {}}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "method": "initialized", "params": {}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "method": "textDocument/didOpen",
+        "params": {"textDocument": {
+            "uri": "file:///test.txt", "languageId": "test",
+            "version": 1, "text": "hello"
+        }}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "id": 2, "method": "textDocument/references",
+        "params": {
+            "textDocument": {"uri": "file:///test.txt"},
+            "position": {"line": 0, "character": 0},
+            "context": {"includeDeclaration": true}
+        }
+    })));
+
+    let output = run_server(Box::new(FullMockBridge), input);
+    let messages = parse_all_messages(&output);
+
+    let resp = find_response(&messages, 2).unwrap();
+    let result = resp.result.as_ref().unwrap();
+    let arr = result.as_array().unwrap();
+    assert!(!arr.is_empty());
+}
+
+// -- Completion --
+
+#[test]
+fn test_handler_completion() {
+    let mut input = Vec::new();
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {"processId": 1, "capabilities": {}}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "method": "initialized", "params": {}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "method": "textDocument/didOpen",
+        "params": {"textDocument": {
+            "uri": "file:///test.txt", "languageId": "test",
+            "version": 1, "text": "foo"
+        }}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "id": 2, "method": "textDocument/completion",
+        "params": {
+            "textDocument": {"uri": "file:///test.txt"},
+            "position": {"line": 0, "character": 3}
+        }
+    })));
+
+    let output = run_server(Box::new(FullMockBridge), input);
+    let messages = parse_all_messages(&output);
+
+    let resp = find_response(&messages, 2).unwrap();
+    let result = resp.result.as_ref().unwrap();
+    let items = result["items"].as_array().unwrap();
+    assert!(!items.is_empty());
+    assert_eq!(items[0]["label"], "foo");
+}
+
+// -- Rename --
+
+#[test]
+fn test_handler_rename() {
+    let mut input = Vec::new();
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {"processId": 1, "capabilities": {}}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "method": "initialized", "params": {}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "method": "textDocument/didOpen",
+        "params": {"textDocument": {
+            "uri": "file:///test.txt", "languageId": "test",
+            "version": 1, "text": "hello"
+        }}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "id": 2, "method": "textDocument/rename",
+        "params": {
+            "textDocument": {"uri": "file:///test.txt"},
+            "position": {"line": 0, "character": 0},
+            "newName": "world"
+        }
+    })));
+
+    let output = run_server(Box::new(FullMockBridge), input);
+    let messages = parse_all_messages(&output);
+
+    let resp = find_response(&messages, 2).unwrap();
+    let result = resp.result.as_ref().unwrap();
+    assert!(result["changes"].is_object());
+}
+
+// -- Folding Range --
+
+#[test]
+fn test_handler_folding_range() {
+    let mut input = Vec::new();
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {"processId": 1, "capabilities": {}}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "method": "initialized", "params": {}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "method": "textDocument/didOpen",
+        "params": {"textDocument": {
+            "uri": "file:///test.txt", "languageId": "test",
+            "version": 1, "text": "hello"
+        }}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "id": 2, "method": "textDocument/foldingRange",
+        "params": {"textDocument": {"uri": "file:///test.txt"}}
+    })));
+
+    let output = run_server(Box::new(FullMockBridge), input);
+    let messages = parse_all_messages(&output);
+
+    let resp = find_response(&messages, 2).unwrap();
+    let result = resp.result.as_ref().unwrap();
+    let arr = result.as_array().unwrap();
+    assert!(!arr.is_empty());
+    assert_eq!(arr[0]["startLine"], 0);
+    assert_eq!(arr[0]["endLine"], 5);
+}
+
+// -- Signature Help --
+
+#[test]
+fn test_handler_signature_help() {
+    let mut input = Vec::new();
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {"processId": 1, "capabilities": {}}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "method": "initialized", "params": {}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "method": "textDocument/didOpen",
+        "params": {"textDocument": {
+            "uri": "file:///test.txt", "languageId": "test",
+            "version": 1, "text": "foo(a, b)"
+        }}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "id": 2, "method": "textDocument/signatureHelp",
+        "params": {
+            "textDocument": {"uri": "file:///test.txt"},
+            "position": {"line": 0, "character": 4}
+        }
+    })));
+
+    let output = run_server(Box::new(FullMockBridge), input);
+    let messages = parse_all_messages(&output);
+
+    let resp = find_response(&messages, 2).unwrap();
+    let result = resp.result.as_ref().unwrap();
+    let sigs = result["signatures"].as_array().unwrap();
+    assert!(!sigs.is_empty());
+    assert_eq!(sigs[0]["label"], "foo(a int, b string)");
+}
+
+// -- Formatting --
+
+#[test]
+fn test_handler_formatting() {
+    let mut input = Vec::new();
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {"processId": 1, "capabilities": {}}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "method": "initialized", "params": {}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "method": "textDocument/didOpen",
+        "params": {"textDocument": {
+            "uri": "file:///test.txt", "languageId": "test",
+            "version": 1, "text": "hello world"
+        }}
+    })));
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "id": 2, "method": "textDocument/formatting",
+        "params": {"textDocument": {"uri": "file:///test.txt"}, "options": {}}
+    })));
+
+    let output = run_server(Box::new(FullMockBridge), input);
+    let messages = parse_all_messages(&output);
+
+    let resp = find_response(&messages, 2).unwrap();
+    let result = resp.result.as_ref().unwrap();
+    let edits = result.as_array().unwrap();
+    assert!(!edits.is_empty());
+}
+
+// -- Unknown method --
+
+#[test]
+fn test_handler_unknown_method() {
+    let mut input = Vec::new();
+    input.extend_from_slice(&frame(&json!({
+        "jsonrpc": "2.0", "id": 1, "method": "unknownMethod",
+        "params": {}
+    })));
+
+    let output = run_server(Box::new(MinimalBridge), input);
+    let messages = parse_all_messages(&output);
+
+    let resp = find_response(&messages, 1).unwrap();
+    assert!(resp.error.is_some());
+    assert_eq!(
+        resp.error.as_ref().unwrap().code,
+        coding_adventures_json_rpc::errors::METHOD_NOT_FOUND
+    );
+}
+
+// -- Server constructor --
+
+#[test]
+fn test_new_lsp_server_creates_server() {
+    let reader = BufReader::new(Cursor::new(Vec::<u8>::new()));
+    let writer = Cursor::new(Vec::<u8>::new());
+    // Just verify it constructs without panicking.
+    let _server = LspServer::new(Box::new(MinimalBridge), reader, writer);
+}
+
+// -- Document Symbol with children --
+
+#[test]
+fn test_document_symbol_with_children() {
+    let bridge = MockBridge { hover_result: None };
+    let mut cache = ParseCache::new();
+    let mut dm = DocumentManager::new();
+
+    dm.open("file:///a.go", "func main() {}", 1);
+    let doc = dm.get("file:///a.go").unwrap();
+    let result = cache.get_or_parse("file:///a.go", doc.version, &doc.text, &bridge);
+    assert!(result.ast.is_some());
+
+    let ast = result.ast.as_ref().unwrap();
+    let syms = bridge.document_symbols(ast.as_ref()).unwrap().unwrap();
+
+    assert_eq!(syms.len(), 1);
+    assert_eq!(syms[0].name, "main");
+    assert_eq!(syms[0].kind, SymbolKind::Function);
+    assert_eq!(syms[0].children.len(), 1);
+    assert_eq!(syms[0].children[0].name, "x");
+}

--- a/code/packages/swift/json-rpc/.gitignore
+++ b/code/packages/swift/json-rpc/.gitignore
@@ -1,0 +1,3 @@
+.build/
+.swiftpm/
+Package.resolved

--- a/code/packages/swift/json-rpc/BUILD
+++ b/code/packages/swift/json-rpc/BUILD
@@ -1,0 +1,1 @@
+if command -v xcrun >/dev/null 2>&1; then xcrun swift test --enable-code-coverage --verbose; else swift test --enable-code-coverage --verbose; fi

--- a/code/packages/swift/json-rpc/BUILD_windows
+++ b/code/packages/swift/json-rpc/BUILD_windows
@@ -1,0 +1,1 @@
+where swift >/dev/null 2>/dev/null && swift test --enable-code-coverage --verbose || echo Swift not available on this runner - skipping

--- a/code/packages/swift/json-rpc/CHANGELOG.md
+++ b/code/packages/swift/json-rpc/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-12
+
+### Added
+
+- Initial release of the JSON-RPC 2.0 package for Swift.
+- `Request`, `Response`, `Notification`, `ResponseError` message types.
+- `MessageReader` for reading Content-Length-framed JSON-RPC messages.
+- `MessageWriter` for writing Content-Length-framed JSON-RPC messages.
+- `Server` combining reader + writer with method dispatch.
+- Standard JSON-RPC 2.0 error codes (ParseError, InvalidRequest, MethodNotFound, InvalidParams, InternalError).
+- `parseMessage()` and `messageToMap()` conversion functions.
+- Comprehensive test suite covering all message types, framing, and server dispatch.

--- a/code/packages/swift/json-rpc/Package.swift
+++ b/code/packages/swift/json-rpc/Package.swift
@@ -1,0 +1,33 @@
+// swift-tools-version: 6.0
+// ============================================================================
+// Package.swift -- JsonRpc
+// ============================================================================
+//
+// JSON-RPC 2.0 implementation for Swift, providing Content-Length-framed
+// message reading/writing and a server with method dispatch. Built on top
+// of the generic Rpc package.
+//
+// ============================================================================
+import PackageDescription
+
+let package = Package(
+    name: "JsonRpc",
+    products: [
+        .library(name: "JsonRpc", targets: ["JsonRpc"]),
+    ],
+    dependencies: [
+        .package(path: "../rpc"),
+    ],
+    targets: [
+        .target(
+            name: "JsonRpc",
+            dependencies: [
+                .product(name: "Rpc", package: "rpc"),
+            ]
+        ),
+        .testTarget(
+            name: "JsonRpcTests",
+            dependencies: ["JsonRpc"]
+        ),
+    ]
+)

--- a/code/packages/swift/json-rpc/README.md
+++ b/code/packages/swift/json-rpc/README.md
@@ -1,0 +1,63 @@
+# json-rpc (Swift)
+
+A JSON-RPC 2.0 implementation for Swift, built on top of the generic `Rpc` package.
+
+## What is JSON-RPC?
+
+JSON-RPC 2.0 is a stateless, lightweight remote procedure call protocol using JSON as the data format. It is the wire protocol beneath the Language Server Protocol (LSP).
+
+Every message carries `"jsonrpc": "2.0"` and is framed with a `Content-Length` HTTP-style header:
+
+```
+Content-Length: 42\r\n
+\r\n
+{"jsonrpc":"2.0","id":1,"method":"ping"}
+```
+
+## Architecture
+
+```
+stdin --> MessageReader --> Server.serve() dispatch loop
+                                |
+                          +-----+----------+
+                          |                |
+                       Request?        Notification?
+                          |                |
+                     find handler     find handler
+                     call(id, params) call(params)
+                     write Response   (no response!)
+                          |
+                          v
+                     MessageWriter --> stdout
+```
+
+## Usage
+
+```swift
+import JsonRpc
+
+let server = Server(input: FileHandle.standardInput, output: FileHandle.standardOutput)
+
+server.onRequest("initialize") { id, params in
+    return ["capabilities": [:]]
+}
+
+server.onNotification("textDocument/didOpen") { params in
+    // handle document open
+}
+
+server.serve()
+```
+
+## Message Types
+
+| Shape        | id  | method | result | error |
+|-------------|-----|--------|--------|-------|
+| Request     | yes | yes    | --     | --    |
+| Notification| --  | yes    | --     | --    |
+| Response OK | yes | --     | yes    | --    |
+| Response Err| yes | --     | --     | yes   |
+
+## Dependencies
+
+- `Rpc` package (via relative path `../rpc`)

--- a/code/packages/swift/json-rpc/Sources/JsonRpc/Errors.swift
+++ b/code/packages/swift/json-rpc/Sources/JsonRpc/Errors.swift
@@ -1,0 +1,92 @@
+// ============================================================================
+// Errors.swift — JSON-RPC 2.0 Error Codes
+// ============================================================================
+//
+// JSON-RPC 2.0 defines a set of reserved integer error codes, analogous to
+// HTTP status codes. Each code has a standard meaning that the client can
+// switch on without parsing the human-readable message string.
+//
+// Standard error code table:
+//
+//   Code     Name              When to use
+//   ----     ----              -----------
+//   -32700   Parse error       Payload is not valid JSON
+//   -32600   Invalid Request   Valid JSON but not a JSON-RPC message
+//   -32601   Method not found  Method has no registered handler
+//   -32602   Invalid params    Wrong parameter shape for a method
+//   -32603   Internal error    Unhandled exception inside a handler
+//
+// Server-defined errors live in the range [-32099, -32000].
+// LSP reserves [-32899, -32800] for protocol-level errors; this package
+// intentionally leaves that range alone.
+//
+// Usage:
+//   let code = JsonRpcErrorCodes.methodNotFound
+//   // => -32601
+//
+// ============================================================================
+
+import Foundation
+
+/// Standard JSON-RPC 2.0 error codes.
+///
+/// These codes are reserved by the JSON-RPC specification and must not be
+/// used for application-specific errors. Application errors should use
+/// codes outside the reserved range.
+public enum JsonRpcErrorCodes {
+    /// The bytes are not valid JSON at all.
+    /// Example: "{broken json" arrives on stdin.
+    public static let parseError = -32_700
+
+    /// Valid JSON, but not a recognisable JSON-RPC message shape.
+    /// Example: the payload is a JSON array instead of an object.
+    public static let invalidRequest = -32_600
+
+    /// The method name in the Request is not registered on the server.
+    /// The server MUST send this error — it must not silently drop the request.
+    /// (Silently dropping is only allowed for unknown Notifications.)
+    public static let methodNotFound = -32_601
+
+    /// The method was found but the supplied params are wrong.
+    /// Handlers should return this when required fields are missing or types
+    /// do not match what the method expects.
+    public static let invalidParams = -32_602
+
+    /// An unexpected error occurred inside the handler.
+    /// Catch-all for server-side bugs. Ask: "was the request well-formed?"
+    /// If yes → InternalError. If no → InvalidParams.
+    public static let internalError = -32_603
+}
+
+// ============================================================================
+// JsonRpcError — exception raised by the JSON-RPC transport layer
+// ============================================================================
+//
+// Thrown by MessageReader when framing or parsing fails.
+// Carries a numeric `code` in addition to the standard message.
+//
+// Example:
+//   do {
+//       let msg = try reader.readMessage()
+//   } catch let error as JsonRpcError {
+//       print("code=\(error.code) message=\(error.message)")
+//   }
+//
+
+/// A transport-level error thrown by the JSON-RPC reader or parser.
+///
+/// This is distinct from `ResponseError` (which is a data structure embedded
+/// inside a Response). `JsonRpcError` is thrown when framing or JSON parsing
+/// fails — before a proper Response can be constructed.
+public struct JsonRpcError: Error, Sendable {
+    /// One of the `JsonRpcErrorCodes` constants.
+    public let code: Int
+
+    /// Human-readable description of what went wrong.
+    public let message: String
+
+    public init(code: Int, message: String) {
+        self.code = code
+        self.message = message
+    }
+}

--- a/code/packages/swift/json-rpc/Sources/JsonRpc/Message.swift
+++ b/code/packages/swift/json-rpc/Sources/JsonRpc/Message.swift
@@ -1,0 +1,370 @@
+// ============================================================================
+// Message.swift — JSON-RPC 2.0 Message Types
+// ============================================================================
+//
+// JSON-RPC 2.0 defines four message shapes. All carry "jsonrpc": "2.0".
+// The shape is determined by which fields are present:
+//
+//   ┌──────────────┬──────┬──────────┬────────┬───────┐
+//   │ Shape        │  id  │  method  │ result │ error │
+//   ├──────────────┼──────┼──────────┼────────┼───────┤
+//   │ Request      │  yes │   yes    │   —    │   —   │
+//   │ Notification │   —  │   yes    │   —    │   —   │
+//   │ Response OK  │  yes │    —     │  yes   │   —   │
+//   │ Response Err │  yes │    —     │   —    │  yes  │
+//   └──────────────┴──────┴──────────┴────────┴───────┘
+//
+// Public API:
+//   Request(id:, method:, params:)
+//   Notification(method:, params:)
+//   Response(id:, result:, error:)
+//   ResponseError(code:, message:, data:)
+//
+//   parseMessage(_:) → Message  (throws JsonRpcError on invalid input)
+//   messageToMap(_:) → [String: Any]  (wire-format dictionary for JSONSerialization)
+//
+// ============================================================================
+
+import Foundation
+
+// ============================================================================
+// ResponseError — the structured error inside an error Response
+// ============================================================================
+//
+// Example wire object:
+//   { "code": -32601, "message": "Method not found", "data": "..." }
+//
+// `code`    — integer; see JsonRpcErrorCodes for standard values
+// `message` — short human-readable description
+// `data`    — optional additional context (any JSON value)
+//
+
+/// The structured error object embedded inside a failed JSON-RPC Response.
+///
+/// This is a data structure, not a thrown exception. It rides inside a
+/// `Response` when the server needs to report an error to the client.
+/// For transport-level errors (framing, JSON parsing), see `JsonRpcError`.
+public struct ResponseError: Sendable, Equatable, Error {
+    /// Integer error code; see `JsonRpcErrorCodes` for standard values.
+    public let code: Int
+
+    /// Short human-readable description of the error.
+    public let message: String
+
+    /// Optional additional context. Any JSON-serializable value.
+    public let data: AnySendable?
+
+    public init(code: Int, message: String, data: AnySendable? = nil) {
+        self.code = code
+        self.message = message
+        self.data = data
+    }
+
+    public static func == (lhs: ResponseError, rhs: ResponseError) -> Bool {
+        return lhs.code == rhs.code && lhs.message == rhs.message
+    }
+}
+
+// ============================================================================
+// AnySendable — type-erased Sendable wrapper for "any JSON value"
+// ============================================================================
+//
+// Swift 6 concurrency requires all values crossing concurrency boundaries to
+// conform to Sendable. Since JSON values can be Any, we wrap them in a
+// Sendable struct that holds the underlying value.
+//
+
+/// A type-erased wrapper that satisfies Sendable for arbitrary JSON values.
+///
+/// JSON-RPC messages can carry arbitrary data (params, result, error data).
+/// Swift 6 requires Sendable conformance for concurrent code. This wrapper
+/// allows us to store `Any` values while satisfying the type system.
+public struct AnySendable: @unchecked Sendable, Equatable {
+    /// The wrapped value. Can be any JSON-representable type:
+    /// String, Int, Double, Bool, [Any], [String: Any], or nil.
+    public let value: Any
+
+    public init(_ value: Any) {
+        self.value = value
+    }
+
+    public static func == (lhs: AnySendable, rhs: AnySendable) -> Bool {
+        // Best-effort equality for common JSON types.
+        switch (lhs.value, rhs.value) {
+        case (let a as String, let b as String): return a == b
+        case (let a as Int, let b as Int): return a == b
+        case (let a as Double, let b as Double): return a == b
+        case (let a as Bool, let b as Bool): return a == b
+        case (is NSNull, is NSNull): return true
+        default: return false
+        }
+    }
+}
+
+// ============================================================================
+// Request — a call that expects a Response
+// ============================================================================
+//
+// Example wire object:
+//   { "jsonrpc":"2.0", "id":1, "method":"textDocument/hover",
+//     "params":{ "position":{"line":0,"character":3} } }
+//
+// `id`     — String or Int; ties the Response back to this call
+// `method` — String; the procedure name
+// `params` — optional dictionary or array
+//
+
+/// A JSON-RPC 2.0 request message that expects a response.
+public struct Request: Sendable, Equatable {
+    /// Ties the response back to this request. String or Int.
+    public let id: AnySendable
+
+    /// The procedure name (e.g. "textDocument/hover").
+    public let method: String
+
+    /// Optional parameters. Typically a dictionary.
+    public let params: AnySendable?
+
+    public init(id: AnySendable, method: String, params: AnySendable? = nil) {
+        self.id = id
+        self.method = method
+        self.params = params
+    }
+}
+
+// ============================================================================
+// Notification — a one-way message with no Response
+// ============================================================================
+//
+// Example wire object:
+//   { "jsonrpc":"2.0", "method":"textDocument/didOpen",
+//     "params":{ "textDocument":{"uri":"file:///main.bf"} } }
+//
+// The server MUST NOT send a response, even on error.
+//
+
+/// A JSON-RPC 2.0 notification — fire-and-forget, no response expected.
+public struct Notification: Sendable, Equatable {
+    /// The procedure name.
+    public let method: String
+
+    /// Optional parameters.
+    public let params: AnySendable?
+
+    public init(method: String, params: AnySendable? = nil) {
+        self.method = method
+        self.params = params
+    }
+}
+
+// ============================================================================
+// Response — the server's reply to a Request
+// ============================================================================
+//
+// Exactly one of `result` or `error` is present.
+//
+// `id`     — matches the originating Request; nil only when the
+//            server cannot determine the request id
+// `result` — any value on success
+// `error`  — ResponseError on failure
+//
+
+/// A JSON-RPC 2.0 response to a prior request.
+public struct Response: Sendable {
+    /// Matches the originating Request's id. Nil only when the server
+    /// cannot determine the request id (e.g. parse error).
+    public let id: AnySendable?
+
+    /// The success result (any JSON-serializable value).
+    public let result: AnySendable?
+
+    /// The error object, if the request failed.
+    public let error: ResponseError?
+
+    public init(id: AnySendable?, result: AnySendable? = nil, error: ResponseError? = nil) {
+        self.id = id
+        self.result = result
+        self.error = error
+    }
+}
+
+// ============================================================================
+// parseMessage — raw Dictionary → typed message
+// ============================================================================
+//
+// Converts a dictionary (typically from JSONSerialization) into one of the
+// typed message structs. Throws JsonRpcError(-32600) for unrecognised shapes.
+//
+// Recognition rules (mirrors the table at the top of the file):
+//   has "id" AND "method"               → Request
+//   has "method" but no "id"            → Notification
+//   has "id" AND ("result" OR "error")  → Response
+//   anything else                        → throw Invalid Request
+//
+
+/// Discriminated union of all JSON-RPC 2.0 message types.
+///
+/// Handlers receive this enum and switch on the case to determine
+/// the message type. The associated values carry the typed payload.
+public enum JsonRpcMessage: Sendable {
+    case request(Request)
+    case notification(Notification)
+    case response(Response)
+}
+
+/// Parse a raw JSON dictionary into a typed JSON-RPC message.
+///
+/// - Parameter data: A dictionary from `JSONSerialization.jsonObject`.
+/// - Returns: A `JsonRpcMessage` wrapping the typed message.
+/// - Throws: `JsonRpcError` with code -32600 for invalid message shapes.
+///
+/// Example:
+///   let dict = try JSONSerialization.jsonObject(with: bytes) as! [String: Any]
+///   let msg = try parseMessage(dict)
+public func parseMessage(_ data: [String: Any]) throws -> JsonRpcMessage {
+    let hasId = data["id"] != nil && !(data["id"] is NSNull)
+    let hasMethod: Bool = {
+        if let m = data["method"] as? String, !m.isEmpty { return true }
+        return false
+    }()
+    let hasResult = data.keys.contains("result")
+    let hasError = data.keys.contains("error")
+
+    if hasId && hasMethod {
+        // ---- Request ----
+        let id = normalizeId(data["id"]!)
+        let method = data["method"] as! String
+        let params: AnySendable? = data["params"].map { AnySendable($0) }
+        return .request(Request(id: AnySendable(id), method: method, params: params))
+    }
+
+    if hasMethod && !hasId {
+        // ---- Notification ----
+        let method = data["method"] as! String
+        let params: AnySendable? = data["params"].map { AnySendable($0) }
+        return .notification(Notification(method: method, params: params))
+    }
+
+    if hasId && (hasResult || hasError) {
+        // ---- Response ----
+        let rawId = data["id"]
+        let id: AnySendable? = (rawId is NSNull) ? nil : rawId.map { AnySendable(normalizeId($0)) }
+
+        var errorObj: ResponseError? = nil
+        if hasError, let errDict = data["error"] as? [String: Any] {
+            guard let code = errDict["code"] as? Int ?? (errDict["code"] as? Double).map({ Int($0) }),
+                  let message = errDict["message"] as? String else {
+                throw JsonRpcError(
+                    code: JsonRpcErrorCodes.invalidRequest,
+                    message: "Invalid Request: error must have integer code and string message"
+                )
+            }
+            let errData: AnySendable? = errDict["data"].map { AnySendable($0) }
+            errorObj = ResponseError(code: code, message: message, data: errData)
+        }
+
+        let result: AnySendable? = hasResult ? AnySendable(data["result"] as Any) : nil
+        return .response(Response(id: id, result: errorObj == nil ? result : nil, error: errorObj))
+    }
+
+    // Also handle response with null id (error responses from parse failures)
+    if (hasResult || hasError) {
+        let id: AnySendable? = nil
+        var errorObj: ResponseError? = nil
+        if hasError, let errDict = data["error"] as? [String: Any] {
+            let code = errDict["code"] as? Int ?? (errDict["code"] as? Double).map({ Int($0) }) ?? 0
+            let message = errDict["message"] as? String ?? ""
+            let errData: AnySendable? = errDict["data"].map { AnySendable($0) }
+            errorObj = ResponseError(code: code, message: message, data: errData)
+        }
+        let result: AnySendable? = hasResult ? AnySendable(data["result"] as Any) : nil
+        return .response(Response(id: id, result: errorObj == nil ? result : nil, error: errorObj))
+    }
+
+    throw JsonRpcError(
+        code: JsonRpcErrorCodes.invalidRequest,
+        message: "Invalid Request: unrecognised message shape"
+    )
+}
+
+/// Convert a typed JSON-RPC message back to a wire-format dictionary.
+///
+/// Adds "jsonrpc": "2.0" to every message. The resulting dictionary is
+/// suitable for `JSONSerialization.data(withJSONObject:)`.
+///
+/// Example:
+///   let req = Request(id: AnySendable(1), method: "ping")
+///   let dict = messageToMap(.request(req))
+///   // => ["jsonrpc": "2.0", "id": 1, "method": "ping"]
+public func messageToMap(_ msg: JsonRpcMessage) -> [String: Any] {
+    switch msg {
+    case .request(let req):
+        var dict: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": req.id.value,
+            "method": req.method,
+        ]
+        if let params = req.params {
+            dict["params"] = params.value
+        }
+        return dict
+
+    case .notification(let notif):
+        var dict: [String: Any] = [
+            "jsonrpc": "2.0",
+            "method": notif.method,
+        ]
+        if let params = notif.params {
+            dict["params"] = params.value
+        }
+        return dict
+
+    case .response(let resp):
+        var dict: [String: Any] = ["jsonrpc": "2.0"]
+        if let id = resp.id {
+            dict["id"] = id.value
+        } else {
+            dict["id"] = NSNull()
+        }
+        if let error = resp.error {
+            var errDict: [String: Any] = [
+                "code": error.code,
+                "message": error.message,
+            ]
+            if let data = error.data {
+                errDict["data"] = data.value
+            }
+            dict["error"] = errDict
+        } else {
+            dict["result"] = resp.result?.value ?? NSNull()
+        }
+        return dict
+    }
+}
+
+// ============================================================================
+// Helper: normalizeId
+// ============================================================================
+//
+// JSON numbers decoded by JSONSerialization arrive as NSNumber. If the number
+// is a whole number, normalize it to Int for cleaner comparisons.
+//
+
+/// Normalizes a JSON id value to Int if it is a whole-number Double.
+///
+/// JSONSerialization decodes all JSON numbers as NSNumber. For ids that
+/// are integers (e.g. "id": 1), we convert the underlying Double to Int
+/// so that comparisons work naturally.
+func normalizeId(_ id: Any) -> Any {
+    if let d = id as? Double {
+        if d == d.rounded(.towardZero) && !d.isNaN && !d.isInfinite {
+            return Int(d)
+        }
+        return d
+    }
+    // NSNumber check for integers that come through as Int already
+    if let n = id as? Int {
+        return n
+    }
+    return id
+}

--- a/code/packages/swift/json-rpc/Sources/JsonRpc/Reader.swift
+++ b/code/packages/swift/json-rpc/Sources/JsonRpc/Reader.swift
@@ -1,0 +1,210 @@
+// ============================================================================
+// Reader.swift — MessageReader: Content-Length-framed JSON-RPC reader
+// ============================================================================
+//
+// Reads one Content-Length-framed JSON-RPC message at a time from an
+// InputStream (typically connected to stdin, but any InputStream works
+// — including for testing).
+//
+// Wire format:
+//
+//   Content-Length: 97\r\n
+//   \r\n
+//   {"jsonrpc":"2.0","id":1,"method":"textDocument/hover",...}
+//
+// Why Content-Length framing?
+// ---------------------------
+// JSON has no self-delimiting structure at the byte stream level.
+// You cannot tell where one JSON object ends without parsing the
+// whole thing. Content-Length solves this: read headers, find the
+// length, then read exactly that many bytes.
+//
+// Implementation notes
+// --------------------
+// We read the stream byte-by-byte for the header until we see the
+// \r\n\r\n sentinel. Then we read exactly contentLength bytes for
+// the payload. This is simple and correct for the LSP use case.
+//
+// ============================================================================
+
+import Foundation
+
+/// Reads Content-Length-framed JSON-RPC messages from an input stream.
+///
+/// Each call to `readMessage()` reads exactly one framed message, parses
+/// the JSON, and returns a typed `JsonRpcMessage`.
+///
+/// Example:
+///   let reader = MessageReader(Data("Content-Length: 38\r\n\r\n{...}".utf8))
+///   let msg = try reader.readMessage()
+public final class MessageReader: Sendable {
+    /// The raw bytes to read from. We use Data + an index rather than
+    /// InputStream because Data is simpler for testing and InputStream
+    /// has platform-specific quirks.
+    private let data: Data
+
+    /// Current read position in the data buffer.
+    /// Using a class wrapper for interior mutability with Sendable.
+    private let state: ReadState
+
+    /// Internal mutable state wrapper.
+    private final class ReadState: @unchecked Sendable {
+        var position: Int = 0
+
+        init() {}
+    }
+
+    /// Create a reader from raw bytes.
+    ///
+    /// - Parameter data: The bytes containing one or more framed messages.
+    public init(_ data: Data) {
+        self.data = data
+        self.state = ReadState()
+    }
+
+    /// Convenience initializer from a String.
+    public convenience init(_ string: String) {
+        self.init(Data(string.utf8))
+    }
+
+    // ----------------------------------------------------------------
+    // readMessage — read, frame, parse, return typed Message
+    // ----------------------------------------------------------------
+    //
+    // Reads the next Content-Length-framed message from the data and
+    // returns a typed Request, Notification, or Response.
+    //
+    // Returns nil on clean EOF (no more data to read).
+    // Throws JsonRpcError(-32700) on malformed JSON.
+    // Throws JsonRpcError(-32600) on valid JSON that is not a message.
+    //
+
+    /// Read one framed message and return a typed message.
+    ///
+    /// - Returns: A `JsonRpcMessage`, or `nil` if no more messages remain.
+    /// - Throws: `JsonRpcError` on malformed framing or invalid JSON.
+    public func readMessage() throws -> JsonRpcMessage? {
+        let raw = try readRaw()
+        guard let raw else { return nil }
+
+        // Parse the JSON string into a dictionary.
+        guard let jsonData = raw.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any] else {
+            throw JsonRpcError(
+                code: JsonRpcErrorCodes.parseError,
+                message: "Parse error: invalid JSON"
+            )
+        }
+
+        return try parseMessage(obj)
+    }
+
+    // ----------------------------------------------------------------
+    // readRaw — read one framed message as a raw JSON string
+    // ----------------------------------------------------------------
+    //
+    // Returns the JSON string without parsing it. Useful for testing
+    // or for proxy scenarios where the caller controls parsing.
+    //
+    // Returns nil on EOF.
+    //
+
+    /// Read one framed message and return the raw JSON payload string.
+    ///
+    /// - Returns: The JSON payload, or `nil` if no more data.
+    /// - Throws: `JsonRpcError` on malformed framing.
+    public func readRaw() throws -> String? {
+        // Step 1: Read headers up to the \r\n\r\n blank line.
+        let headerBytes = readUntilBlankLine()
+        guard let headerBytes else { return nil }
+
+        // Step 2: Extract Content-Length from the headers.
+        let contentLength = try parseContentLength(headerBytes)
+
+        // Step 3: Read exactly contentLength bytes as the JSON payload.
+        guard state.position + contentLength <= data.count else {
+            throw JsonRpcError(
+                code: JsonRpcErrorCodes.parseError,
+                message: "Parse error: stream ended before payload was complete"
+            )
+        }
+
+        let payloadRange = state.position ..< (state.position + contentLength)
+        let payload = data[payloadRange]
+        state.position += contentLength
+
+        guard let result = String(data: payload, encoding: .utf8) else {
+            throw JsonRpcError(
+                code: JsonRpcErrorCodes.parseError,
+                message: "Parse error: payload is not valid UTF-8"
+            )
+        }
+
+        return result
+    }
+
+    // ----------------------------------------------------------------
+    // Private helpers
+    // ----------------------------------------------------------------
+
+    /// Read bytes one at a time until we see the sequence \r\n\r\n.
+    ///
+    /// Returns the header block as a string, or nil if the data is
+    /// exhausted before any bytes are read (clean EOF).
+    private func readUntilBlankLine() -> String? {
+        let sentinel: [UInt8] = [0x0D, 0x0A, 0x0D, 0x0A] // \r\n\r\n
+        var buffer: [UInt8] = []
+
+        while state.position < data.count {
+            let byte = data[state.position]
+            state.position += 1
+            buffer.append(byte)
+
+            // Check if we have seen the blank-line sentinel at the end.
+            if buffer.count >= 4 {
+                let tail = Array(buffer[(buffer.count - 4)...])
+                if tail == sentinel {
+                    // Return everything before the sentinel.
+                    let headerData = Data(buffer[0 ..< (buffer.count - 4)])
+                    return String(data: headerData, encoding: .utf8)
+                }
+            }
+        }
+
+        // EOF before seeing sentinel.
+        if buffer.isEmpty { return nil }
+        return nil // partial header — treat as EOF
+    }
+
+    /// Parse the Content-Length value from the header block string.
+    ///
+    /// The header block looks like:
+    ///   Content-Length: 97\r\nContent-Type: application/vscode-jsonrpc; charset=utf-8
+    ///
+    /// We split on \r\n and search for the Content-Length line
+    /// (case-insensitive, following the HTTP convention).
+    private func parseContentLength(_ headerStr: String) throws -> Int {
+        let lines = headerStr.split(separator: "\r\n", omittingEmptySubsequences: false)
+            .map { String($0) }
+
+        for line in lines {
+            if line.lowercased().hasPrefix("content-length:") {
+                let parts = line.split(separator: ":", maxSplits: 1)
+                guard parts.count == 2 else { continue }
+                let valueStr = parts[1].trimmingCharacters(in: .whitespaces)
+                guard let n = Int(valueStr), n >= 0 else {
+                    throw JsonRpcError(
+                        code: JsonRpcErrorCodes.parseError,
+                        message: "Parse error: invalid Content-Length value"
+                    )
+                }
+                return n
+            }
+        }
+
+        throw JsonRpcError(
+            code: JsonRpcErrorCodes.parseError,
+            message: "Parse error: missing Content-Length header"
+        )
+    }
+}

--- a/code/packages/swift/json-rpc/Sources/JsonRpc/Server.swift
+++ b/code/packages/swift/json-rpc/Sources/JsonRpc/Server.swift
@@ -1,0 +1,222 @@
+// ============================================================================
+// Server.swift — JSON-RPC 2.0 Server with method dispatch
+// ============================================================================
+//
+// The Server combines a MessageReader and MessageWriter with a
+// method dispatch table. It drives the read-dispatch-write loop,
+// isolating the application from all framing, parsing, and
+// error-handling details.
+//
+// Lifecycle:
+//   1. Create a Server with input Data and an OutputTarget.
+//   2. Register handlers with `onRequest` and `onNotification`.
+//   3. Call `serve()` — it blocks until the stream is exhausted.
+//
+// Dispatch rules:
+//
+//   Request received:
+//     handler found    → call it; send result or ResponseError as Response
+//     no handler       → send -32601 (Method not found) Response
+//     handler raises   → send -32603 (Internal error) Response
+//
+//   Notification received:
+//     handler found    → call it; send NOTHING
+//     no handler       → silently ignore
+//
+//   Response received:
+//     discarded in server-only mode
+//
+// Concurrency:
+//   `serve()` is single-threaded — it processes one message at a time.
+//   This is correct for LSP, where editors send one request and wait
+//   before sending the next.
+//
+// Example:
+//   let server = Server(inputData: data, output: output)
+//   server.onRequest("initialize") { id, params in
+//       return (["capabilities": [:]], nil)
+//   }
+//   server.onNotification("textDocument/didOpen") { params in }
+//   server.serve()
+//
+// ============================================================================
+
+import Foundation
+
+/// Signature for a JSON-RPC request handler.
+///
+/// The handler receives the request id and params, and must return either:
+/// - `(result, nil)` — any JSON-serializable value as a success result.
+/// - `(nil, ResponseError)` — an error to send back to the client.
+public typealias RequestHandler = (_ id: Any, _ params: Any?) -> (Any?, ResponseError?)
+
+/// Signature for a JSON-RPC notification handler.
+///
+/// The handler receives the notification params. No return value is needed
+/// because notifications never get a response.
+public typealias NotificationHandler = (_ params: Any?) -> Void
+
+/// JSON-RPC 2.0 server combining a reader + writer with method dispatch.
+///
+/// Typical usage:
+///
+///   let server = Server(inputData: stdinBytes, output: FileHandleOutput(.standardOutput))
+///   server.onRequest("initialize") { id, params in
+///       return (["capabilities": [:]], nil)
+///   }
+///   server.serve()
+public final class Server: @unchecked Sendable {
+    private let reader: MessageReader
+    private let writer: MessageWriter
+    private var requestHandlers: [String: RequestHandler] = [:]
+    private var notificationHandlers: [String: NotificationHandler] = [:]
+
+    /// Create a server that reads from input data and writes to the given output.
+    ///
+    /// - Parameters:
+    ///   - inputData: The raw bytes containing incoming JSON-RPC messages.
+    ///   - output: The target for outgoing framed messages.
+    public init(inputData: Data, output: OutputTarget) {
+        self.reader = MessageReader(inputData)
+        self.writer = MessageWriter(output)
+    }
+
+    // ----------------------------------------------------------------
+    // onRequest — register a handler for a Request method
+    // ----------------------------------------------------------------
+    //
+    // The closure receives (id, params) and must return either:
+    //   - (result, nil) for a successful response
+    //   - (nil, ResponseError) for an error response
+    //
+    // Returns `self` for chaining.
+    //
+
+    /// Register a handler for a JSON-RPC request method.
+    ///
+    /// - Parameters:
+    ///   - method: The method name to handle.
+    ///   - handler: The closure called when a request with this method arrives.
+    /// - Returns: Self, for chaining.
+    @discardableResult
+    public func onRequest(_ method: String, handler: @escaping RequestHandler) -> Self {
+        requestHandlers[method] = handler
+        return self
+    }
+
+    // ----------------------------------------------------------------
+    // onNotification — register a handler for a Notification method
+    // ----------------------------------------------------------------
+    //
+    // The closure receives (params) and returns nothing. Even if it
+    // raises, no response is sent.
+    //
+    // Returns `self` for chaining.
+    //
+
+    /// Register a handler for a JSON-RPC notification method.
+    ///
+    /// - Parameters:
+    ///   - method: The method name to handle.
+    ///   - handler: The closure called when a notification arrives.
+    /// - Returns: Self, for chaining.
+    @discardableResult
+    public func onNotification(_ method: String, handler: @escaping NotificationHandler) -> Self {
+        notificationHandlers[method] = handler
+        return self
+    }
+
+    // ----------------------------------------------------------------
+    // serve — run the read-dispatch-write loop
+    // ----------------------------------------------------------------
+    //
+    // Reads messages until the input is exhausted. Processes one
+    // message per iteration.
+    //
+
+    /// Start the blocking read-dispatch-write loop.
+    ///
+    /// Reads messages until EOF (input exhausted). Each message is
+    /// dispatched to the appropriate handler. Errors during framing
+    /// or parsing produce error responses.
+    public func serve() {
+        while true {
+            let msg: JsonRpcMessage?
+            do {
+                msg = try reader.readMessage()
+            } catch let error as JsonRpcError {
+                sendError(id: nil, code: error.code, message: error.message)
+                continue
+            } catch {
+                sendError(id: nil, code: JsonRpcErrorCodes.internalError, message: "Internal error: \(error)")
+                continue
+            }
+
+            guard let msg else { break } // clean EOF
+
+            dispatch(msg)
+        }
+    }
+
+    // ----------------------------------------------------------------
+    // Private dispatch and handler methods
+    // ----------------------------------------------------------------
+
+    private func dispatch(_ msg: JsonRpcMessage) {
+        switch msg {
+        case .request(let request):
+            handleRequest(request)
+        case .notification(let notification):
+            handleNotification(notification)
+        case .response:
+            // Server mode: discard incoming Responses.
+            break
+        }
+    }
+
+    private func handleRequest(_ request: Request) {
+        guard let handler = requestHandlers[request.method] else {
+            sendError(
+                id: request.id.value,
+                code: JsonRpcErrorCodes.methodNotFound,
+                message: "Method not found: \(request.method)"
+            )
+            return
+        }
+
+        let (result, error) = handler(request.id.value, request.params?.value)
+
+        if let error {
+            let resp = Response(
+                id: AnySendable(request.id.value),
+                error: error
+            )
+            try? writer.writeMessage(.response(resp))
+        } else {
+            let resp = Response(
+                id: AnySendable(request.id.value),
+                result: result.map { AnySendable($0) }
+            )
+            try? writer.writeMessage(.response(resp))
+        }
+    }
+
+    private func handleNotification(_ notification: Notification) {
+        guard let handler = notificationHandlers[notification.method] else {
+            // Per spec: silently ignore unknown notifications.
+            return
+        }
+
+        // Notifications are fire-and-forget. Errors are swallowed.
+        handler(notification.params?.value)
+    }
+
+    private func sendError(id: Any?, code: Int, message: String) {
+        let error = ResponseError(code: code, message: message)
+        let resp = Response(
+            id: id.map { AnySendable($0) },
+            error: error
+        )
+        try? writer.writeMessage(.response(resp))
+    }
+}

--- a/code/packages/swift/json-rpc/Sources/JsonRpc/Writer.swift
+++ b/code/packages/swift/json-rpc/Sources/JsonRpc/Writer.swift
@@ -1,0 +1,141 @@
+// ============================================================================
+// Writer.swift — MessageWriter: typed Message → framed byte stream
+// ============================================================================
+//
+// Writes one Content-Length-framed JSON-RPC message at a time to a
+// mutable Data buffer (or any output mechanism).
+//
+// Framing format:
+//
+//   Content-Length: <n>\r\n
+//   \r\n
+//   <UTF-8 JSON payload, exactly n bytes>
+//
+// The Content-Length value is the BYTE length of the UTF-8-encoded
+// JSON payload, NOT the character count. For ASCII-only JSON these
+// are identical, but multi-byte Unicode characters (e.g. "€" is 3
+// bytes in UTF-8) make them differ.
+//
+// Example:
+//   let output = DataOutput()
+//   let writer = MessageWriter(output)
+//   try writer.writeMessage(.response(Response(id: AnySendable(1), result: AnySendable(["ok": true]))))
+//
+// ============================================================================
+
+import Foundation
+
+// ============================================================================
+// OutputTarget protocol
+// ============================================================================
+//
+// An abstraction over "something you can write bytes to". In production this
+// wraps FileHandle.standardOutput. In tests it wraps a Data buffer.
+//
+
+/// Protocol for any target that can receive bytes.
+///
+/// This abstraction allows the writer to work with both FileHandle
+/// (production) and Data buffers (testing).
+public protocol OutputTarget: AnyObject, Sendable {
+    /// Write raw bytes to the output.
+    func write(_ data: Data)
+}
+
+/// A simple in-memory output target for testing.
+///
+/// Collects all written bytes in a Data buffer that can be inspected
+/// after the test completes.
+public final class DataOutput: OutputTarget, @unchecked Sendable {
+    /// All bytes written so far.
+    public private(set) var data = Data()
+
+    public init() {}
+
+    public func write(_ newData: Data) {
+        data.append(newData)
+    }
+
+    /// The accumulated output as a UTF-8 string.
+    public var string: String {
+        String(data: data, encoding: .utf8) ?? ""
+    }
+}
+
+/// An output target that wraps a FileHandle (e.g. stdout).
+public final class FileHandleOutput: OutputTarget, @unchecked Sendable {
+    private let handle: FileHandle
+
+    public init(_ handle: FileHandle) {
+        self.handle = handle
+    }
+
+    public func write(_ data: Data) {
+        handle.write(data)
+    }
+}
+
+// ============================================================================
+// MessageWriter
+// ============================================================================
+
+/// Writes Content-Length-framed JSON-RPC messages to an output target.
+///
+/// Each call to `writeMessage` produces exactly one framed message
+/// on the underlying output.
+///
+/// Example:
+///   let output = DataOutput()
+///   let writer = MessageWriter(output)
+///   try writer.writeMessage(.response(Response(id: AnySendable(1), result: AnySendable(true))))
+public final class MessageWriter: Sendable {
+    private let output: OutputTarget
+
+    /// Create a writer that sends framed messages to the given output.
+    public init(_ output: OutputTarget) {
+        self.output = output
+    }
+
+    // ----------------------------------------------------------------
+    // writeMessage — serialize and frame a typed message
+    // ----------------------------------------------------------------
+    //
+    // Converts the message to its wire-format dictionary, serializes it
+    // with JSONSerialization (compact, no extra whitespace), then writes
+    // the Content-Length header followed by the payload.
+    //
+
+    /// Serialize a typed message and write it as a Content-Length-framed message.
+    ///
+    /// - Parameter msg: The message to write.
+    /// - Throws: If JSON serialization fails.
+    public func writeMessage(_ msg: JsonRpcMessage) throws {
+        let dict = messageToMap(msg)
+        let jsonData = try JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys])
+        guard let jsonStr = String(data: jsonData, encoding: .utf8) else {
+            throw JsonRpcError(code: JsonRpcErrorCodes.internalError, message: "Failed to encode JSON as UTF-8")
+        }
+        writeRaw(jsonStr)
+    }
+
+    // ----------------------------------------------------------------
+    // writeRaw — frame and write a pre-serialized JSON string
+    // ----------------------------------------------------------------
+    //
+    // Use when you already have the JSON string and do not need message
+    // parsing — for example, in tests or proxy scenarios.
+    //
+
+    /// Write a raw JSON string as a Content-Length-framed message.
+    ///
+    /// - Parameter json: The JSON payload string.
+    public func writeRaw(_ json: String) {
+        // Force UTF-8 encoding for byte-accurate length calculation.
+        let payload = Data(json.utf8)
+        let header = "Content-Length: \(payload.count)\r\n\r\n"
+        let headerData = Data(header.utf8)
+
+        // Write header + payload together.
+        output.write(headerData + payload)
+    }
+}

--- a/code/packages/swift/json-rpc/Tests/JsonRpcTests/JsonRpcTests.swift
+++ b/code/packages/swift/json-rpc/Tests/JsonRpcTests/JsonRpcTests.swift
@@ -1,0 +1,545 @@
+// ============================================================================
+// JsonRpcTests.swift — comprehensive tests for the JSON-RPC 2.0 package
+// ============================================================================
+//
+// Test coverage areas:
+//
+//  1. Message parsing — Request, Notification, Response (success + error)
+//  2. Message serialization — messageToMap round-trips
+//  3. Error codes — all five standard codes
+//  4. Content-Length framing — reader and writer
+//  5. Server dispatch — request handling, notification handling, method not found
+//  6. Edge cases — missing Content-Length, invalid JSON, empty input
+//
+// ============================================================================
+
+import XCTest
+@testable import JsonRpc
+import Foundation
+
+final class JsonRpcTests: XCTestCase {
+
+    // ─── Error Codes ────────────────────────────────────────────────────────
+
+    func testErrorCodeValues() {
+        // Verify the standard JSON-RPC 2.0 error code constants match the spec.
+        XCTAssertEqual(JsonRpcErrorCodes.parseError, -32700)
+        XCTAssertEqual(JsonRpcErrorCodes.invalidRequest, -32600)
+        XCTAssertEqual(JsonRpcErrorCodes.methodNotFound, -32601)
+        XCTAssertEqual(JsonRpcErrorCodes.invalidParams, -32602)
+        XCTAssertEqual(JsonRpcErrorCodes.internalError, -32603)
+    }
+
+    // ─── Message Parsing: Request ────────────────────────────────────────────
+
+    func testParseRequestWithIntId() throws {
+        let dict: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "textDocument/hover",
+            "params": ["line": 5],
+        ]
+        let msg = try parseMessage(dict)
+        guard case .request(let req) = msg else {
+            XCTFail("Expected Request, got \(msg)")
+            return
+        }
+        XCTAssertEqual(req.id.value as? Int, 1)
+        XCTAssertEqual(req.method, "textDocument/hover")
+        XCTAssertNotNil(req.params)
+    }
+
+    func testParseRequestWithStringId() throws {
+        let dict: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": "abc-123",
+            "method": "ping",
+        ]
+        let msg = try parseMessage(dict)
+        guard case .request(let req) = msg else {
+            XCTFail("Expected Request")
+            return
+        }
+        XCTAssertEqual(req.id.value as? String, "abc-123")
+        XCTAssertEqual(req.method, "ping")
+        XCTAssertNil(req.params)
+    }
+
+    func testParseRequestWithoutParams() throws {
+        let dict: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": 42,
+            "method": "shutdown",
+        ]
+        let msg = try parseMessage(dict)
+        guard case .request(let req) = msg else {
+            XCTFail("Expected Request")
+            return
+        }
+        XCTAssertEqual(req.method, "shutdown")
+        XCTAssertNil(req.params)
+    }
+
+    // ─── Message Parsing: Notification ───────────────────────────────────────
+
+    func testParseNotification() throws {
+        let dict: [String: Any] = [
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": ["uri": "file:///main.bf"],
+        ]
+        let msg = try parseMessage(dict)
+        guard case .notification(let notif) = msg else {
+            XCTFail("Expected Notification, got \(msg)")
+            return
+        }
+        XCTAssertEqual(notif.method, "textDocument/didOpen")
+        XCTAssertNotNil(notif.params)
+    }
+
+    func testParseNotificationWithoutParams() throws {
+        let dict: [String: Any] = [
+            "jsonrpc": "2.0",
+            "method": "initialized",
+        ]
+        let msg = try parseMessage(dict)
+        guard case .notification(let notif) = msg else {
+            XCTFail("Expected Notification")
+            return
+        }
+        XCTAssertEqual(notif.method, "initialized")
+        XCTAssertNil(notif.params)
+    }
+
+    // ─── Message Parsing: Response ──────────────────────────────────────────
+
+    func testParseSuccessResponse() throws {
+        let dict: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": ["capabilities": [:]],
+        ]
+        let msg = try parseMessage(dict)
+        guard case .response(let resp) = msg else {
+            XCTFail("Expected Response")
+            return
+        }
+        XCTAssertEqual(resp.id?.value as? Int, 1)
+        XCTAssertNil(resp.error)
+        XCTAssertNotNil(resp.result)
+    }
+
+    func testParseErrorResponse() throws {
+        let dict: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": [
+                "code": -32601,
+                "message": "Method not found",
+            ],
+        ]
+        let msg = try parseMessage(dict)
+        guard case .response(let resp) = msg else {
+            XCTFail("Expected Response")
+            return
+        }
+        XCTAssertEqual(resp.id?.value as? Int, 1)
+        XCTAssertNotNil(resp.error)
+        XCTAssertEqual(resp.error?.code, -32601)
+        XCTAssertEqual(resp.error?.message, "Method not found")
+    }
+
+    func testParseNullResultResponse() throws {
+        let dict: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": 5,
+            "result": NSNull(),
+        ]
+        let msg = try parseMessage(dict)
+        guard case .response(let resp) = msg else {
+            XCTFail("Expected Response")
+            return
+        }
+        XCTAssertEqual(resp.id?.value as? Int, 5)
+        XCTAssertNil(resp.error)
+    }
+
+    // ─── Message Parsing: Invalid ────────────────────────────────────────────
+
+    func testParseInvalidMessageShape() {
+        // No id, no method, no result, no error → invalid
+        let dict: [String: Any] = ["jsonrpc": "2.0"]
+        XCTAssertThrowsError(try parseMessage(dict)) { error in
+            guard let e = error as? JsonRpcError else {
+                XCTFail("Expected JsonRpcError")
+                return
+            }
+            XCTAssertEqual(e.code, JsonRpcErrorCodes.invalidRequest)
+        }
+    }
+
+    // ─── Message Serialization ──────────────────────────────────────────────
+
+    func testMessageToMapRequest() {
+        let req = Request(id: AnySendable(1), method: "foo", params: AnySendable(["x": 42]))
+        let dict = messageToMap(.request(req))
+        XCTAssertEqual(dict["jsonrpc"] as? String, "2.0")
+        XCTAssertEqual(dict["id"] as? Int, 1)
+        XCTAssertEqual(dict["method"] as? String, "foo")
+        XCTAssertNotNil(dict["params"])
+    }
+
+    func testMessageToMapNotification() {
+        let notif = Notification(method: "bar")
+        let dict = messageToMap(.notification(notif))
+        XCTAssertEqual(dict["jsonrpc"] as? String, "2.0")
+        XCTAssertEqual(dict["method"] as? String, "bar")
+        XCTAssertNil(dict["id"])
+        XCTAssertNil(dict["params"])
+    }
+
+    func testMessageToMapSuccessResponse() {
+        let resp = Response(id: AnySendable(1), result: AnySendable(42))
+        let dict = messageToMap(.response(resp))
+        XCTAssertEqual(dict["jsonrpc"] as? String, "2.0")
+        XCTAssertEqual(dict["id"] as? Int, 1)
+        XCTAssertEqual(dict["result"] as? Int, 42)
+        XCTAssertNil(dict["error"])
+    }
+
+    func testMessageToMapErrorResponse() {
+        let err = ResponseError(code: -32601, message: "Method not found")
+        let resp = Response(id: AnySendable(1), error: err)
+        let dict = messageToMap(.response(resp))
+        XCTAssertEqual(dict["jsonrpc"] as? String, "2.0")
+        XCTAssertNotNil(dict["error"])
+        let errorDict = dict["error"] as? [String: Any]
+        XCTAssertEqual(errorDict?["code"] as? Int, -32601)
+        XCTAssertEqual(errorDict?["message"] as? String, "Method not found")
+    }
+
+    // ─── Reader Tests ───────────────────────────────────────────────────────
+
+    func testReaderReadsSingleMessage() throws {
+        let json = """
+        {"jsonrpc":"2.0","id":1,"method":"ping"}
+        """
+        let payload = Data(json.utf8)
+        let frame = "Content-Length: \(payload.count)\r\n\r\n" + json
+        let reader = MessageReader(frame)
+
+        let msg = try reader.readMessage()
+        XCTAssertNotNil(msg)
+        guard case .request(let req) = msg else {
+            XCTFail("Expected Request")
+            return
+        }
+        XCTAssertEqual(req.method, "ping")
+    }
+
+    func testReaderReadsMultipleMessages() throws {
+        let json1 = """
+        {"jsonrpc":"2.0","id":1,"method":"ping"}
+        """
+        let json2 = """
+        {"jsonrpc":"2.0","method":"initialized"}
+        """
+        let frame = "Content-Length: \(Data(json1.utf8).count)\r\n\r\n" + json1
+                   + "Content-Length: \(Data(json2.utf8).count)\r\n\r\n" + json2
+        let reader = MessageReader(frame)
+
+        let msg1 = try reader.readMessage()
+        XCTAssertNotNil(msg1)
+
+        let msg2 = try reader.readMessage()
+        XCTAssertNotNil(msg2)
+        guard case .notification(let notif) = msg2 else {
+            XCTFail("Expected Notification")
+            return
+        }
+        XCTAssertEqual(notif.method, "initialized")
+
+        // Third read should return nil (EOF)
+        let msg3 = try reader.readMessage()
+        XCTAssertNil(msg3)
+    }
+
+    func testReaderReturnsNilOnEmptyInput() throws {
+        let reader = MessageReader("")
+        let msg = try reader.readMessage()
+        XCTAssertNil(msg)
+    }
+
+    func testReaderThrowsOnInvalidJSON() {
+        let badJson = "not valid json at all"
+        let frame = "Content-Length: \(Data(badJson.utf8).count)\r\n\r\n" + badJson
+        let reader = MessageReader(frame)
+
+        XCTAssertThrowsError(try reader.readMessage()) { error in
+            guard let e = error as? JsonRpcError else {
+                XCTFail("Expected JsonRpcError")
+                return
+            }
+            XCTAssertEqual(e.code, JsonRpcErrorCodes.parseError)
+        }
+    }
+
+    func testReaderThrowsOnMissingContentLength() {
+        let frame = "X-Custom: foo\r\n\r\n{}"
+        let reader = MessageReader(frame)
+
+        XCTAssertThrowsError(try reader.readMessage()) { error in
+            guard let e = error as? JsonRpcError else {
+                XCTFail("Expected JsonRpcError")
+                return
+            }
+            XCTAssertEqual(e.code, JsonRpcErrorCodes.parseError)
+        }
+    }
+
+    func testReaderThrowsOnTruncatedPayload() {
+        // Content-Length says 100 bytes but only 5 bytes follow
+        let frame = "Content-Length: 100\r\n\r\nhello"
+        let reader = MessageReader(frame)
+
+        XCTAssertThrowsError(try reader.readMessage()) { error in
+            guard let e = error as? JsonRpcError else {
+                XCTFail("Expected JsonRpcError")
+                return
+            }
+            XCTAssertEqual(e.code, JsonRpcErrorCodes.parseError)
+        }
+    }
+
+    // ─── Writer Tests ───────────────────────────────────────────────────────
+
+    func testWriterFramesMessage() throws {
+        let output = DataOutput()
+        let writer = MessageWriter(output)
+        let req = Request(id: AnySendable(1), method: "ping")
+        try writer.writeMessage(.request(req))
+
+        let str = output.string
+        XCTAssertTrue(str.contains("Content-Length:"))
+        XCTAssertTrue(str.contains("\"jsonrpc\":\"2.0\""))
+        XCTAssertTrue(str.contains("\"method\":\"ping\""))
+    }
+
+    func testWriterWriteRaw() {
+        let output = DataOutput()
+        let writer = MessageWriter(output)
+        let json = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":null}"
+        writer.writeRaw(json)
+
+        let str = output.string
+        XCTAssertTrue(str.hasPrefix("Content-Length: \(Data(json.utf8).count)\r\n\r\n"))
+        XCTAssertTrue(str.hasSuffix(json))
+    }
+
+    func testWriterThenReaderRoundTrip() throws {
+        // Write a message, then read it back
+        let output = DataOutput()
+        let writer = MessageWriter(output)
+        let req = Request(id: AnySendable(42), method: "test/roundTrip", params: AnySendable(["key": "value"]))
+        try writer.writeMessage(.request(req))
+
+        let reader = MessageReader(output.data)
+        let msg = try reader.readMessage()
+        guard case .request(let readReq) = msg else {
+            XCTFail("Expected Request")
+            return
+        }
+        XCTAssertEqual(readReq.id.value as? Int, 42)
+        XCTAssertEqual(readReq.method, "test/roundTrip")
+    }
+
+    // ─── Server Dispatch Tests ──────────────────────────────────────────────
+
+    func testServerDispatchesRequest() throws {
+        let json = """
+        {"jsonrpc":"2.0","id":1,"method":"ping","params":null}
+        """
+        let inputData = Data(("Content-Length: \(Data(json.utf8).count)\r\n\r\n" + json).utf8)
+        let output = DataOutput()
+
+        let server = Server(inputData: inputData, output: output)
+        server.onRequest("ping") { id, params in
+            return ("pong", nil)
+        }
+        server.serve()
+
+        let responseStr = output.string
+        XCTAssertTrue(responseStr.contains("\"result\":\"pong\""),
+                       "Expected 'pong' result in response: \(responseStr)")
+    }
+
+    func testServerDispatchesNotification() throws {
+        let json = """
+        {"jsonrpc":"2.0","method":"test/notify","params":{"x":1}}
+        """
+        let inputData = Data(("Content-Length: \(Data(json.utf8).count)\r\n\r\n" + json).utf8)
+        let output = DataOutput()
+
+        var receivedParams: Any? = nil
+        let server = Server(inputData: inputData, output: output)
+        server.onNotification("test/notify") { params in
+            receivedParams = params
+        }
+        server.serve()
+
+        // Notifications produce no response
+        XCTAssertEqual(output.data.count, 0, "No output expected for notification")
+        XCTAssertNotNil(receivedParams)
+    }
+
+    func testServerSendsMethodNotFound() throws {
+        let json = """
+        {"jsonrpc":"2.0","id":1,"method":"nonexistent"}
+        """
+        let inputData = Data(("Content-Length: \(Data(json.utf8).count)\r\n\r\n" + json).utf8)
+        let output = DataOutput()
+
+        let server = Server(inputData: inputData, output: output)
+        server.serve()
+
+        let responseStr = output.string
+        XCTAssertTrue(responseStr.contains("-32601"),
+                       "Expected MethodNotFound error code in: \(responseStr)")
+    }
+
+    func testServerHandlerReturnsError() throws {
+        let json = """
+        {"jsonrpc":"2.0","id":1,"method":"fail"}
+        """
+        let inputData = Data(("Content-Length: \(Data(json.utf8).count)\r\n\r\n" + json).utf8)
+        let output = DataOutput()
+
+        let server = Server(inputData: inputData, output: output)
+        server.onRequest("fail") { id, params in
+            return (nil, ResponseError(code: -32602, message: "bad params"))
+        }
+        server.serve()
+
+        let responseStr = output.string
+        XCTAssertTrue(responseStr.contains("-32602"),
+                       "Expected InvalidParams code in: \(responseStr)")
+        XCTAssertTrue(responseStr.contains("bad params"))
+    }
+
+    func testServerIgnoresUnknownNotification() throws {
+        let json = """
+        {"jsonrpc":"2.0","method":"unknown/notification"}
+        """
+        let inputData = Data(("Content-Length: \(Data(json.utf8).count)\r\n\r\n" + json).utf8)
+        let output = DataOutput()
+
+        let server = Server(inputData: inputData, output: output)
+        server.serve()
+
+        // No output expected — unknown notifications are silently ignored
+        XCTAssertEqual(output.data.count, 0)
+    }
+
+    func testServerProcessesMultipleMessages() throws {
+        let json1 = """
+        {"jsonrpc":"2.0","id":1,"method":"add","params":{"a":2,"b":3}}
+        """
+        let json2 = """
+        {"jsonrpc":"2.0","id":2,"method":"add","params":{"a":10,"b":20}}
+        """
+        let frame = "Content-Length: \(Data(json1.utf8).count)\r\n\r\n" + json1
+                   + "Content-Length: \(Data(json2.utf8).count)\r\n\r\n" + json2
+        let inputData = Data(frame.utf8)
+        let output = DataOutput()
+
+        var callCount = 0
+        let server = Server(inputData: inputData, output: output)
+        server.onRequest("add") { id, params in
+            callCount += 1
+            guard let p = params as? [String: Any],
+                  let a = p["a"] as? Int,
+                  let b = p["b"] as? Int else {
+                return (nil, ResponseError(code: -32602, message: "bad params"))
+            }
+            return (a + b, nil)
+        }
+        server.serve()
+
+        XCTAssertEqual(callCount, 2, "Expected handler called twice")
+        let responseStr = output.string
+        // Both responses should be present
+        XCTAssertTrue(responseStr.contains("\"result\":5") || responseStr.contains("\"result\" : 5"),
+                       "Expected result 5 in: \(responseStr)")
+    }
+
+    // ─── ResponseError Tests ────────────────────────────────────────────────
+
+    func testResponseErrorEquality() {
+        let a = ResponseError(code: -32601, message: "Method not found")
+        let b = ResponseError(code: -32601, message: "Method not found")
+        let c = ResponseError(code: -32602, message: "Invalid params")
+        XCTAssertEqual(a, b)
+        XCTAssertNotEqual(a, c)
+    }
+
+    func testResponseErrorConformsToError() {
+        let err: Error = ResponseError(code: -32603, message: "Internal error")
+        XCTAssertNotNil(err)
+    }
+
+    // ─── AnySendable Tests ──────────────────────────────────────────────────
+
+    func testAnySendableEquality() {
+        XCTAssertEqual(AnySendable("hello"), AnySendable("hello"))
+        XCTAssertEqual(AnySendable(42), AnySendable(42))
+        XCTAssertEqual(AnySendable(true), AnySendable(true))
+        XCTAssertNotEqual(AnySendable("a"), AnySendable("b"))
+        XCTAssertNotEqual(AnySendable(1), AnySendable(2))
+    }
+
+    // ─── normalizeId Tests ──────────────────────────────────────────────────
+
+    func testNormalizeIdDouble() {
+        let result = normalizeId(1.0 as Double)
+        XCTAssertEqual(result as? Int, 1)
+    }
+
+    func testNormalizeIdString() {
+        let result = normalizeId("abc")
+        XCTAssertEqual(result as? String, "abc")
+    }
+
+    func testNormalizeIdInt() {
+        let result = normalizeId(42)
+        XCTAssertEqual(result as? Int, 42)
+    }
+
+    // ─── Unicode in Content-Length ───────────────────────────────────────────
+
+    func testWriterHandlesUnicodePayload() throws {
+        let output = DataOutput()
+        let writer = MessageWriter(output)
+        // The euro sign € is 3 UTF-8 bytes but 1 character
+        let resp = Response(id: AnySendable(1), result: AnySendable("€"))
+        try writer.writeMessage(.response(resp))
+
+        // Read it back — the reader should handle multi-byte characters correctly
+        let reader = MessageReader(output.data)
+        let msg = try reader.readMessage()
+        XCTAssertNotNil(msg)
+    }
+
+    // ─── Server chaining ────────────────────────────────────────────────────
+
+    func testServerMethodChaining() {
+        let output = DataOutput()
+        let server = Server(inputData: Data(), output: output)
+        let returned = server
+            .onRequest("a") { _, _ in (nil, nil) }
+            .onNotification("b") { _ in }
+            .onRequest("c") { _, _ in (nil, nil) }
+
+        // Chaining should return the same server instance
+        XCTAssertTrue(returned === server)
+    }
+}

--- a/code/packages/swift/ls00/.gitignore
+++ b/code/packages/swift/ls00/.gitignore
@@ -1,0 +1,3 @@
+.build/
+.swiftpm/
+Package.resolved

--- a/code/packages/swift/ls00/BUILD
+++ b/code/packages/swift/ls00/BUILD
@@ -1,0 +1,1 @@
+if command -v xcrun >/dev/null 2>&1; then xcrun swift test --enable-code-coverage --verbose; else swift test --enable-code-coverage --verbose; fi

--- a/code/packages/swift/ls00/BUILD_windows
+++ b/code/packages/swift/ls00/BUILD_windows
@@ -1,0 +1,1 @@
+where swift >/dev/null 2>/dev/null && swift test --enable-code-coverage --verbose || echo Swift not available on this runner - skipping

--- a/code/packages/swift/ls00/CHANGELOG.md
+++ b/code/packages/swift/ls00/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-12
+
+### Added
+
+- Initial release of the ls00 LSP framework for Swift.
+- `LanguageBridge` protocol with required `tokenize()` and `parse()` methods.
+- 10 optional provider protocols: HoverProvider, DefinitionProvider, ReferencesProvider, CompletionProvider, RenameProvider, SemanticTokensProvider, DocumentSymbolsProvider, FoldingRangesProvider, SignatureHelpProvider, FormatProvider.
+- All LSP types: Position, Range, Location, Diagnostic, Token, TextEdit, WorkspaceEdit, HoverResult, CompletionItem, SemanticToken, DocumentSymbol, FoldingRange, SignatureHelpResult.
+- `DocumentManager` for tracking open files with incremental change support and UTF-16 offset conversion.
+- `ParseCache` for avoiding redundant parses (keyed by URI + version).
+- Dynamic capability builder that inspects bridge protocol conformance at runtime.
+- Semantic token encoder producing LSP's compact delta-format integer array.
+- LSP-specific error codes (ServerNotInitialized, RequestFailed, etc.).
+- Full server with all LSP handler methods wired to JSON-RPC dispatch.
+- Comprehensive test suite covering UTF-16 conversion, document management, parse caching, semantic token encoding, capabilities, and server lifecycle.

--- a/code/packages/swift/ls00/Package.swift
+++ b/code/packages/swift/ls00/Package.swift
@@ -1,0 +1,36 @@
+// swift-tools-version: 6.0
+// ============================================================================
+// Package.swift -- Ls00
+// ============================================================================
+//
+// Generic LSP framework for Swift. Handles all protocol boilerplate so
+// language authors only need to implement the LanguageBridge protocol
+// and optional provider protocols.
+//
+// Depends on the JsonRpc package for Content-Length-framed JSON-RPC 2.0
+// communication, which itself depends on the generic Rpc package.
+//
+// ============================================================================
+import PackageDescription
+
+let package = Package(
+    name: "Ls00",
+    products: [
+        .library(name: "Ls00", targets: ["Ls00"]),
+    ],
+    dependencies: [
+        .package(path: "../json-rpc"),
+    ],
+    targets: [
+        .target(
+            name: "Ls00",
+            dependencies: [
+                .product(name: "JsonRpc", package: "json-rpc"),
+            ]
+        ),
+        .testTarget(
+            name: "Ls00Tests",
+            dependencies: ["Ls00"]
+        ),
+    ]
+)

--- a/code/packages/swift/ls00/README.md
+++ b/code/packages/swift/ls00/README.md
@@ -1,0 +1,76 @@
+# ls00 (Swift)
+
+A generic Language Server Protocol (LSP) framework for Swift. Handles all protocol boilerplate so language authors only write a `LanguageBridge`.
+
+## What is the Language Server Protocol?
+
+When you open a source file in VS Code and see red squiggles under syntax errors, autocomplete suggestions, or "Go to Definition" -- none of that is built into the editor. It comes from a *language server*: a separate process communicating with the editor over LSP.
+
+LSP solves the M x N problem: M editors x N languages = M x N integrations. With LSP, each language writes one server, and every LSP-aware editor gets all features automatically.
+
+## Architecture
+
+```
+Lexer -> Parser -> [LanguageBridge] -> [LspServer] -> VS Code / Neovim / Emacs
+```
+
+## Usage
+
+1. Implement the `LanguageBridge` protocol for your language:
+
+```swift
+import Ls00
+
+struct MyBridge: LanguageBridge {
+    func tokenize(source: String) -> ([Token], Error?) {
+        // your lexer here
+    }
+    func parse(source: String) -> (ASTNode?, [Diagnostic], Error?) {
+        // your parser here
+    }
+}
+```
+
+2. Optionally implement provider protocols for additional features:
+
+```swift
+extension MyBridge: HoverProvider {
+    func hover(ast: ASTNode, pos: Position) -> (HoverResult?, Error?) {
+        // return hover content
+    }
+}
+```
+
+3. Create and serve:
+
+```swift
+let server = LspServer(bridge: MyBridge(), input: stdinData, output: stdoutTarget)
+server.serve()
+```
+
+## Supported LSP Methods
+
+| Method | Type | Provider |
+|--------|------|----------|
+| initialize | request | (built-in) |
+| shutdown | request | (built-in) |
+| exit | notification | (built-in) |
+| textDocument/didOpen | notification | (built-in) |
+| textDocument/didChange | notification | (built-in) |
+| textDocument/didClose | notification | (built-in) |
+| textDocument/didSave | notification | (built-in) |
+| textDocument/hover | request | HoverProvider |
+| textDocument/definition | request | DefinitionProvider |
+| textDocument/references | request | ReferencesProvider |
+| textDocument/completion | request | CompletionProvider |
+| textDocument/rename | request | RenameProvider |
+| textDocument/documentSymbol | request | DocumentSymbolsProvider |
+| textDocument/semanticTokens/full | request | SemanticTokensProvider |
+| textDocument/foldingRange | request | FoldingRangesProvider |
+| textDocument/signatureHelp | request | SignatureHelpProvider |
+| textDocument/formatting | request | FormatProvider |
+
+## Dependencies
+
+- `JsonRpc` package (via relative path `../json-rpc`)
+- `Rpc` package (transitive, via json-rpc)

--- a/code/packages/swift/ls00/Sources/Ls00/Capabilities.swift
+++ b/code/packages/swift/ls00/Sources/Ls00/Capabilities.swift
@@ -1,0 +1,248 @@
+// ============================================================================
+// Capabilities.swift — BuildCapabilities, SemanticTokenLegend, and encoding
+// ============================================================================
+//
+// # What Are Capabilities?
+//
+// During the LSP initialize handshake, the server sends back a "capabilities"
+// object telling the editor which LSP features it supports. The editor uses this
+// to decide which requests to send.
+//
+// Building capabilities dynamically (based on the bridge's protocol conformance)
+// means the server is always honest about what it can do. A bridge that only has
+// a lexer and parser gets minimal capabilities. A full-featured bridge with a
+// symbol table gets the full set.
+//
+// # Semantic Token Legend
+//
+// Semantic tokens use a compact binary encoding. Instead of sending
+// {"type":"keyword"} per token, LSP sends an integer index into a legend.
+// The legend is declared in the capabilities so the editor knows what each
+// index means.
+//
+// ============================================================================
+
+import Foundation
+
+/// Inspect the bridge at runtime and return the LSP capabilities object.
+///
+/// Uses Swift's `as?` protocol conformance checks to determine which optional
+/// provider protocols the bridge implements. Only advertises capabilities for
+/// features the bridge actually supports.
+///
+/// - Parameter bridge: The language bridge to inspect.
+/// - Returns: A dictionary suitable for the "capabilities" field of the initialize response.
+public func buildCapabilities(_ bridge: LanguageBridge) -> [String: Any] {
+    // textDocumentSync=2 means "incremental": the editor sends only changed
+    // ranges, not the full file. We always advertise this.
+    var caps: [String: Any] = [
+        "textDocumentSync": 2,
+    ]
+
+    // Check each optional provider protocol via `as?`.
+
+    if bridge is HoverProvider {
+        caps["hoverProvider"] = true
+    }
+
+    if bridge is DefinitionProvider {
+        caps["definitionProvider"] = true
+    }
+
+    if bridge is ReferencesProvider {
+        caps["referencesProvider"] = true
+    }
+
+    if bridge is CompletionProvider {
+        caps["completionProvider"] = [
+            "triggerCharacters": [" ", "."],
+        ] as [String: Any]
+    }
+
+    if bridge is RenameProvider {
+        caps["renameProvider"] = true
+    }
+
+    if bridge is DocumentSymbolsProvider {
+        caps["documentSymbolProvider"] = true
+    }
+
+    if bridge is FoldingRangesProvider {
+        caps["foldingRangeProvider"] = true
+    }
+
+    if bridge is SignatureHelpProvider {
+        caps["signatureHelpProvider"] = [
+            "triggerCharacters": ["(", ","],
+        ] as [String: Any]
+    }
+
+    if bridge is FormatProvider {
+        caps["documentFormattingProvider"] = true
+    }
+
+    if bridge is SemanticTokensProvider {
+        caps["semanticTokensProvider"] = [
+            "legend": [
+                "tokenTypes": semanticTokenLegend().tokenTypes,
+                "tokenModifiers": semanticTokenLegend().tokenModifiers,
+            ] as [String: Any],
+            "full": true,
+        ] as [String: Any]
+    }
+
+    return caps
+}
+
+// ============================================================================
+// SemanticTokenLegendData
+// ============================================================================
+
+/// Holds the legend arrays for semantic tokens.
+/// The editor uses these to decode the compact integer encoding.
+public struct SemanticTokenLegendData: Sendable {
+    /// The token type names, indexed by their integer code.
+    public let tokenTypes: [String]
+
+    /// The token modifier names, indexed by bit position.
+    public let tokenModifiers: [String]
+}
+
+/// Return the full legend for all supported semantic token types and modifiers.
+///
+/// The ordering matters: index 0 in tokenTypes corresponds to "namespace",
+/// index 1 to "type", etc. These match the standard LSP token types.
+public func semanticTokenLegend() -> SemanticTokenLegendData {
+    return SemanticTokenLegendData(
+        tokenTypes: [
+            "namespace",     // 0
+            "type",          // 1
+            "class",         // 2
+            "enum",          // 3
+            "interface",     // 4
+            "struct",        // 5
+            "typeParameter", // 6
+            "parameter",     // 7
+            "variable",      // 8
+            "property",      // 9
+            "enumMember",    // 10
+            "event",         // 11
+            "function",      // 12
+            "method",        // 13
+            "macro",         // 14
+            "keyword",       // 15
+            "modifier",      // 16
+            "comment",       // 17
+            "string",        // 18
+            "number",        // 19
+            "regexp",        // 20
+            "operator",      // 21
+            "decorator",     // 22
+        ],
+        tokenModifiers: [
+            "declaration",    // bit 0
+            "definition",     // bit 1
+            "readonly",       // bit 2
+            "static",         // bit 3
+            "deprecated",     // bit 4
+            "abstract",       // bit 5
+            "async",          // bit 6
+            "modification",   // bit 7
+            "documentation",  // bit 8
+            "defaultLibrary", // bit 9
+        ]
+    )
+}
+
+// ============================================================================
+// Token type and modifier index lookups
+// ============================================================================
+
+/// Return the integer index for a semantic token type string.
+/// Returns -1 if the type is not in the legend.
+func tokenTypeIndex(_ tokenType: String) -> Int {
+    let legend = semanticTokenLegend()
+    for (i, t) in legend.tokenTypes.enumerated() {
+        if t == tokenType { return i }
+    }
+    return -1
+}
+
+/// Return the bitmask for a list of modifier strings.
+///
+/// Each modifier corresponds to a bit position:
+///   "declaration" -> bit 0 -> value 1
+///   "definition"  -> bit 1 -> value 2
+///   both          -> value 3 (bitwise OR)
+func tokenModifierMask(_ modifiers: [String]) -> Int {
+    let legend = semanticTokenLegend()
+    var mask = 0
+    for mod in modifiers {
+        for (i, m) in legend.tokenModifiers.enumerated() {
+            if m == mod {
+                mask |= (1 << i)
+                break
+            }
+        }
+    }
+    return mask
+}
+
+// ============================================================================
+// EncodeSemanticTokens
+// ============================================================================
+//
+// LSP encodes semantic tokens as a flat array of integers, grouped in 5-tuples:
+//
+//   [deltaLine, deltaStartChar, length, tokenTypeIndex, tokenModifierBitmask, ...]
+//
+// Where "delta" means the difference from the PREVIOUS token's position.
+// When deltaLine > 0, deltaStartChar is absolute for that line.
+// When deltaLine == 0, deltaStartChar is relative to previous token.
+//
+
+/// Convert a list of SemanticTokens to LSP's compact delta-format integer array.
+///
+/// Tokens are sorted by (line, character) before encoding. Unknown token types
+/// are silently skipped.
+///
+/// - Parameter tokens: The semantic tokens to encode.
+/// - Returns: A flat array of integers in groups of 5.
+public func encodeSemanticTokens(_ tokens: [SemanticToken]) -> [Int] {
+    if tokens.isEmpty { return [] }
+
+    // Sort by (line, character) ascending.
+    let sorted = tokens.sorted { a, b in
+        if a.line != b.line { return a.line < b.line }
+        return a.character < b.character
+    }
+
+    var data: [Int] = []
+    data.reserveCapacity(sorted.count * 5)
+    var prevLine = 0
+    var prevChar = 0
+
+    for tok in sorted {
+        let typeIdx = tokenTypeIndex(tok.tokenType)
+        if typeIdx == -1 { continue } // unknown type -- skip
+
+        let deltaLine = tok.line - prevLine
+        let deltaChar: Int
+        if deltaLine == 0 {
+            // Same line: character offset relative to previous token.
+            deltaChar = tok.character - prevChar
+        } else {
+            // Different line: character offset absolute (from line start).
+            deltaChar = tok.character
+        }
+
+        let modMask = tokenModifierMask(tok.modifiers)
+
+        data.append(contentsOf: [deltaLine, deltaChar, tok.length, typeIdx, modMask])
+
+        prevLine = tok.line
+        prevChar = tok.character
+    }
+
+    return data
+}

--- a/code/packages/swift/ls00/Sources/Ls00/DocumentManager.swift
+++ b/code/packages/swift/ls00/Sources/Ls00/DocumentManager.swift
@@ -1,0 +1,283 @@
+// ============================================================================
+// DocumentManager.swift — DocumentManager and UTF-16 offset handling
+// ============================================================================
+//
+// # The Document Manager's Job
+//
+// When the user opens a file in VS Code, the editor sends a textDocument/didOpen
+// notification with the full file content. From that point on, the editor sends
+// incremental changes: what changed, and where. The DocumentManager applies these
+// changes to maintain the current text of each open file.
+//
+//   Editor opens file:   didOpen   -> DocumentManager stores text at version 1
+//   User types "X":      didChange -> DocumentManager applies delta -> version 2
+//   User saves:          didSave   -> (optional: trigger format)
+//   User closes:         didClose  -> DocumentManager removes entry
+//
+// # Why Version Numbers?
+//
+// The editor increments the version number with every change. The ParseCache
+// uses (uri, version) as its cache key -- if the version matches, the cached
+// parse result is still valid.
+//
+// # UTF-16: The Tricky Part
+//
+// LSP specifies that character offsets are measured in UTF-16 CODE UNITS.
+// Swift strings are UTF-8 internally (via String). A single Unicode codepoint
+// can occupy different numbers of units in each encoding:
+//
+//   Codepoint   UTF-8 bytes   UTF-16 code units
+//   ---------   -----------   -----------------
+//   'A'         1             1
+//   'e'         2             1
+//   'zhong'     3             1
+//   'guitar'    4             2 (surrogate pair)
+//
+// So when the LSP client says character=8 (UTF-16), we cannot simply slice
+// 8 bytes into the UTF-8 string. We must walk the string converting each
+// codepoint to its UTF-16 length until we reach code unit 8.
+//
+// ============================================================================
+
+import Foundation
+
+// ============================================================================
+// Document — an open file tracked by the DocumentManager
+// ============================================================================
+
+/// Represents an open file tracked by the DocumentManager.
+public class Document {
+    /// The file URI (e.g. "file:///home/user/main.swift").
+    public let uri: String
+
+    /// Current content, UTF-8 encoded.
+    public var text: String
+
+    /// Monotonically increasing; matches LSP's document version.
+    public var version: Int
+
+    public init(uri: String, text: String, version: Int) {
+        self.uri = uri
+        self.text = text
+        self.version = version
+    }
+}
+
+// ============================================================================
+// TextChange — one incremental change to a document
+// ============================================================================
+//
+// If range is nil, newText replaces the ENTIRE document content (full sync).
+// If range is non-nil, newText replaces just the specified range (incremental sync).
+//
+
+/// One incremental change to a document's text.
+///
+/// With `range` nil, `newText` replaces the entire document (full sync).
+/// With `range` set, `newText` replaces just that range (incremental sync).
+public struct TextChange: Sendable {
+    /// The range to replace. Nil means full document replacement.
+    public let range: Range?
+
+    /// The new text to insert at the range (or the full document).
+    public let newText: String
+
+    public init(range: Range? = nil, newText: String) {
+        self.range = range
+        self.newText = newText
+    }
+}
+
+// ============================================================================
+// DocumentManager
+// ============================================================================
+
+/// Tracks all files currently open in the editor.
+///
+/// The editor sends open/change/close notifications; this manager keeps the
+/// authoritative current text of each file. The ParseCache and all feature
+/// handlers read from this manager to get the source text.
+public class DocumentManager {
+    private var docs: [String: Document] = [:]
+
+    public init() {}
+
+    /// Record a newly opened file.
+    ///
+    /// Called when the editor sends textDocument/didOpen.
+    public func open(uri: String, text: String, version: Int) {
+        docs[uri] = Document(uri: uri, text: text, version: version)
+    }
+
+    /// Apply incremental changes to an open document.
+    ///
+    /// Changes are applied in order. If a change's range is nil, it replaces
+    /// the entire document. After all changes, the document's version is updated.
+    ///
+    /// - Returns: An error string if the document is not open, nil on success.
+    public func applyChanges(uri: String, changes: [TextChange], version: Int) -> String? {
+        guard let doc = docs[uri] else {
+            return "document not open: \(uri)"
+        }
+
+        for change in changes {
+            if let range = change.range {
+                // Incremental update: splice new text at the specified range.
+                if let newText = applyRangeChange(doc.text, range, change.newText) {
+                    doc.text = newText
+                }
+            } else {
+                // Full document replacement.
+                doc.text = change.newText
+            }
+        }
+
+        doc.version = version
+        return nil
+    }
+
+    /// Get the document for a URI.
+    ///
+    /// - Returns: The document, or nil if not open.
+    public func get(uri: String) -> Document? {
+        return docs[uri]
+    }
+
+    /// Remove a document from tracking.
+    ///
+    /// Called when the editor sends textDocument/didClose.
+    public func close(uri: String) {
+        docs.removeValue(forKey: uri)
+    }
+}
+
+// ============================================================================
+// Range application
+// ============================================================================
+
+/// Splice newText into text at the given LSP range.
+///
+/// Converts LSP's (line, UTF-16-character) coordinates to byte offsets
+/// in the UTF-8 Swift string, then performs the splice.
+func applyRangeChange(_ text: String, _ r: Range, _ newText: String) -> String? {
+    guard let startByte = convertPositionToByteOffset(text, r.start),
+          let endByte = convertPositionToByteOffset(text, r.end) else {
+        return nil
+    }
+
+    let startIdx = text.utf8.index(text.utf8.startIndex, offsetBy: min(startByte, text.utf8.count))
+    let endIdx = text.utf8.index(text.utf8.startIndex, offsetBy: min(endByte, text.utf8.count))
+
+    return String(text[text.startIndex ..< String.Index(startIdx, within: text)!])
+         + newText
+         + String(text[String.Index(endIdx, within: text)! ..< text.endIndex])
+}
+
+// ============================================================================
+// UTF-16 offset conversion
+// ============================================================================
+
+/// Convert an LSP Position (0-based line, UTF-16 char) to a byte offset
+/// in the UTF-8 string.
+///
+/// Algorithm:
+/// 1. Walk line-by-line to find the byte offset of the start of the target line.
+/// 2. From that offset, walk UTF-8 codepoints, converting each to its UTF-16
+///    length, until we reach the target UTF-16 character offset.
+func convertPositionToByteOffset(_ text: String, _ pos: Position) -> Int? {
+    let utf8 = Array(text.utf8)
+    var lineStart = 0
+    var currentLine = 0
+
+    // Phase 1: find the byte offset of the start of pos.line.
+    while currentLine < pos.line {
+        guard let idx = utf8[lineStart...].firstIndex(of: UInt8(ascii: "\n")) else {
+            // Line number exceeds the number of lines. Clamp to end.
+            return utf8.count
+        }
+        lineStart = idx + 1
+        currentLine += 1
+    }
+
+    // Phase 2: from lineStart, advance pos.character UTF-16 code units.
+    var byteOffset = lineStart
+    var utf16Units = 0
+
+    while utf16Units < pos.character && byteOffset < utf8.count {
+        // Don't advance past newline
+        if utf8[byteOffset] == UInt8(ascii: "\n") {
+            break
+        }
+
+        // Decode one codepoint from UTF-8
+        let (codepoint, size) = decodeUTF8(utf8, byteOffset)
+
+        // How many UTF-16 code units does this codepoint need?
+        let utf16Len = codepoint > 0xFFFF ? 2 : 1
+
+        if utf16Units + utf16Len > pos.character {
+            // Would overshoot. Stop here (e.g. middle of surrogate pair).
+            break
+        }
+
+        byteOffset += size
+        utf16Units += utf16Len
+    }
+
+    return byteOffset
+}
+
+/// Convert a 0-based (line, UTF-16 char) position to a byte offset.
+///
+/// This is the public version for use in tests and external packages.
+///
+/// # Why UTF-16?
+///
+/// LSP character offsets are UTF-16 code units because VS Code's internal
+/// string representation is UTF-16. This function bridges the gap to
+/// Swift's UTF-8 strings.
+///
+/// # Example
+///
+///   let text = "hello guitar-emoji world"
+///   // guitar-emoji (U+1F3B8) is 4 UTF-8 bytes but 2 UTF-16 code units.
+///   let byteOff = convertUTF16OffsetToByteOffset(text, line: 0, char: 8)
+///   // byteOff = 11
+public func convertUTF16OffsetToByteOffset(_ text: String, line: Int, char: Int) -> Int {
+    return convertPositionToByteOffset(text, Position(line: line, character: char)) ?? text.utf8.count
+}
+
+/// Decode one UTF-8 codepoint starting at the given byte offset.
+///
+/// Returns (codepoint, byteCount). The byteCount is how many bytes
+/// this codepoint consumed (1-4).
+private func decodeUTF8(_ bytes: [UInt8], _ offset: Int) -> (UInt32, Int) {
+    let b0 = bytes[offset]
+
+    if b0 & 0x80 == 0 {
+        // 1-byte: 0xxxxxxx (ASCII)
+        return (UInt32(b0), 1)
+    } else if b0 & 0xE0 == 0xC0 {
+        // 2-byte: 110xxxxx 10xxxxxx
+        guard offset + 1 < bytes.count else { return (0xFFFD, 1) }
+        let cp = (UInt32(b0 & 0x1F) << 6) | UInt32(bytes[offset + 1] & 0x3F)
+        return (cp, 2)
+    } else if b0 & 0xF0 == 0xE0 {
+        // 3-byte: 1110xxxx 10xxxxxx 10xxxxxx
+        guard offset + 2 < bytes.count else { return (0xFFFD, 1) }
+        let cp = (UInt32(b0 & 0x0F) << 12)
+               | (UInt32(bytes[offset + 1] & 0x3F) << 6)
+               | UInt32(bytes[offset + 2] & 0x3F)
+        return (cp, 3)
+    } else if b0 & 0xF8 == 0xF0 {
+        // 4-byte: 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
+        guard offset + 3 < bytes.count else { return (0xFFFD, 1) }
+        let cp = (UInt32(b0 & 0x07) << 18)
+               | (UInt32(bytes[offset + 1] & 0x3F) << 12)
+               | (UInt32(bytes[offset + 2] & 0x3F) << 6)
+               | UInt32(bytes[offset + 3] & 0x3F)
+        return (cp, 4)
+    }
+
+    return (0xFFFD, 1) // invalid UTF-8 start byte
+}

--- a/code/packages/swift/ls00/Sources/Ls00/Handlers.swift
+++ b/code/packages/swift/ls00/Sources/Ls00/Handlers.swift
@@ -201,7 +201,7 @@ extension LspServer {
         ]
 
         if let range = hoverResult.range {
-            result["range"] = rangeToLSP(range)
+            result["range"] = Self.rangeToLSP(range)
         }
 
         return (result, nil)
@@ -223,7 +223,7 @@ extension LspServer {
         let (location, _) = dp.definition(ast: parseResult.ast!, pos: pos, uri: uri)
         guard let location else { return (nil, nil) }
 
-        return (locationToLSP(location), nil)
+        return (Self.locationToLSP(location), nil)
     }
 
     /// Handle textDocument/references.
@@ -246,7 +246,7 @@ extension LspServer {
         guard parseResult.ast != nil else { return ([] as [Any], nil) }
 
         let (locations, _) = rp.references(ast: parseResult.ast!, pos: pos, uri: uri, includeDecl: includeDecl)
-        let result = locations.map { locationToLSP($0) }
+        let result = locations.map { Self.locationToLSP($0) }
         return (result, nil)
     }
 
@@ -311,7 +311,7 @@ extension LspServer {
         var lspChanges: [String: Any] = [:]
         for (editURI, edits) in edit.changes {
             let lspEdits: [[String: Any]] = edits.map { te in
-                ["range": rangeToLSP(te.range), "newText": te.newText]
+                ["range": Self.rangeToLSP(te.range), "newText": te.newText]
             }
             lspChanges[editURI] = lspEdits
         }
@@ -427,7 +427,7 @@ extension LspServer {
         }
 
         let lspEdits: [[String: Any]] = edits.map { edit in
-            ["range": rangeToLSP(edit.range), "newText": edit.newText]
+            ["range": Self.rangeToLSP(edit.range), "newText": edit.newText]
         }
 
         return (lspEdits, nil)
@@ -443,8 +443,8 @@ extension LspServer {
             var m: [String: Any] = [
                 "name": sym.name,
                 "kind": sym.kind.rawValue,
-                "range": rangeToLSP(sym.range),
-                "selectionRange": rangeToLSP(sym.selectionRange),
+                "range": Self.rangeToLSP(sym.range),
+                "selectionRange": Self.rangeToLSP(sym.selectionRange),
             ]
             if !sym.children.isEmpty {
                 m["children"] = convertDocumentSymbols(sym.children)

--- a/code/packages/swift/ls00/Sources/Ls00/Handlers.swift
+++ b/code/packages/swift/ls00/Sources/Ls00/Handlers.swift
@@ -1,0 +1,455 @@
+// ============================================================================
+// Handlers.swift — all LSP handler implementations
+// ============================================================================
+//
+// This file contains all handler methods for the LspServer. Each handler
+// corresponds to one LSP method (initialize, shutdown, didOpen, hover, etc.).
+//
+// Handlers are split into three categories:
+//   1. Lifecycle: initialize, initialized, shutdown, exit
+//   2. Text document sync: didOpen, didChange, didClose, didSave
+//   3. Feature requests: hover, definition, references, completion, rename,
+//      documentSymbol, semanticTokens, foldingRange, signatureHelp, formatting
+//
+// ============================================================================
+
+import Foundation
+import JsonRpc
+
+extension LspServer {
+
+    // ====================================================================
+    // LIFECYCLE HANDLERS
+    // ====================================================================
+
+    /// Handle the LSP initialize request.
+    ///
+    /// The first message from the editor. We return our capabilities
+    /// built dynamically from the bridge's protocol conformance.
+    func handleInitialize(id: Any, params: Any?) -> (Any?, ResponseError?) {
+        isInitialized = true
+
+        let caps = buildCapabilities(bridge)
+
+        let result: [String: Any] = [
+            "capabilities": caps,
+            "serverInfo": [
+                "name": "ls00-generic-lsp-server",
+                "version": "0.1.0",
+            ] as [String: Any],
+        ]
+
+        return (result, nil)
+    }
+
+    /// Handle the "initialized" notification.
+    ///
+    /// The editor's acknowledgment that the handshake is complete.
+    /// No action needed -- the initialize handler already set our flag.
+    func handleInitialized(params: Any?) {
+        // No-op: handshake complete. Normal operation begins.
+    }
+
+    /// Handle the LSP shutdown request.
+    ///
+    /// Sets the shutdown flag and returns null. The server must NOT exit
+    /// here -- it waits for the "exit" notification.
+    func handleShutdown(id: Any, params: Any?) -> (Any?, ResponseError?) {
+        isShutdown = true
+        return (nil, nil)
+    }
+
+    /// Handle the "exit" notification.
+    ///
+    /// Terminates the process. Exit code 0 if shutdown was received first,
+    /// 1 if exit arrives without a prior shutdown.
+    func handleExit(params: Any?) {
+        // In a real server we would call exit(). For testability, we
+        // just set the flag. The serve() loop will end at EOF anyway.
+        // Production servers should call: exit(isShutdown ? 0 : 1)
+    }
+
+    // ====================================================================
+    // TEXT DOCUMENT SYNCHRONIZATION HANDLERS
+    // ====================================================================
+
+    /// Handle textDocument/didOpen.
+    ///
+    /// The editor sends the full file content when a file is opened.
+    /// We store it and immediately parse + push diagnostics.
+    func handleDidOpen(params: Any?) {
+        guard let p = params as? [String: Any],
+              let td = p["textDocument"] as? [String: Any],
+              let uri = td["uri"] as? String, !uri.isEmpty else { return }
+
+        let text = td["text"] as? String ?? ""
+        let version = td["version"] as? Int
+            ?? (td["version"] as? Double).map { Int($0) }
+            ?? 1
+
+        docManager.open(uri: uri, text: text, version: version)
+
+        let result = parseCache.getOrParse(uri: uri, version: version, source: text, bridge: bridge)
+        publishDiagnostics(uri: uri, version: version, diagnostics: result.diagnostics)
+    }
+
+    /// Handle textDocument/didChange.
+    ///
+    /// The editor sends incremental changes. We apply them, re-parse,
+    /// and push updated diagnostics.
+    func handleDidChange(params: Any?) {
+        guard let p = params as? [String: Any] else { return }
+
+        let uri = LspServer.parseURI(p)
+        guard !uri.isEmpty else { return }
+
+        var version = 0
+        if let td = p["textDocument"] as? [String: Any] {
+            version = td["version"] as? Int
+                ?? (td["version"] as? Double).map { Int($0) }
+                ?? 0
+        }
+
+        // Parse content changes. JSONSerialization may produce [Any] rather than
+        // [[String: Any]], so we cast the outer array first and each element individually.
+        let changesArray = p["contentChanges"] as? [Any] ?? []
+        var changes: [TextChange] = []
+
+        for changeRaw in changesArray {
+            guard let changeMap = changeRaw as? [String: Any] else { continue }
+            let newText = changeMap["text"] as? String ?? ""
+            var range: Range? = nil
+
+            if let rangeRaw = changeMap["range"] {
+                range = LspServer.parseLSPRange(rangeRaw)
+            }
+
+            changes.append(TextChange(range: range, newText: newText))
+        }
+
+        if docManager.applyChanges(uri: uri, changes: changes, version: version) != nil {
+            return // document wasn't open
+        }
+
+        guard let doc = docManager.get(uri: uri) else { return }
+
+        let result = parseCache.getOrParse(uri: uri, version: doc.version, source: doc.text, bridge: bridge)
+        publishDiagnostics(uri: uri, version: version, diagnostics: result.diagnostics)
+    }
+
+    /// Handle textDocument/didClose.
+    ///
+    /// Remove the document from tracking and clear its diagnostics.
+    func handleDidClose(params: Any?) {
+        guard let p = params as? [String: Any] else { return }
+        let uri = LspServer.parseURI(p)
+        guard !uri.isEmpty else { return }
+
+        docManager.close(uri: uri)
+        parseCache.evict(uri: uri)
+
+        // Clear diagnostics by publishing an empty list.
+        publishDiagnostics(uri: uri, version: 0, diagnostics: [])
+    }
+
+    /// Handle textDocument/didSave.
+    ///
+    /// If the editor sends full text in didSave, apply it.
+    /// Otherwise just republish from current state.
+    func handleDidSave(params: Any?) {
+        guard let p = params as? [String: Any] else { return }
+        let uri = LspServer.parseURI(p)
+        guard !uri.isEmpty else { return }
+
+        if let text = p["text"] as? String, !text.isEmpty {
+            if let doc = docManager.get(uri: uri) {
+                docManager.close(uri: uri)
+                docManager.open(uri: uri, text: text, version: doc.version)
+                let result = parseCache.getOrParse(uri: uri, version: doc.version, source: text, bridge: bridge)
+                publishDiagnostics(uri: uri, version: doc.version, diagnostics: result.diagnostics)
+            }
+        }
+    }
+
+    // ====================================================================
+    // FEATURE HANDLERS
+    // ====================================================================
+
+    /// Handle textDocument/hover.
+    ///
+    /// Returns hover tooltip content for the symbol at the cursor position.
+    func handleHover(id: Any, params: Any?) -> (Any?, ResponseError?) {
+        guard let p = params as? [String: Any] else {
+            return (nil, ResponseError(code: JsonRpcErrorCodes.invalidParams, message: "invalid params"))
+        }
+
+        let uri = LspServer.parseURI(p)
+        let pos = LspServer.parsePosition(p)
+
+        guard let hp = bridge as? HoverProvider else { return (nil, nil) }
+        guard let (_, parseResult) = getParseResult(uri: uri) else { return (nil, nil) }
+        guard parseResult.ast != nil else { return (nil, nil) }
+
+        let (hoverResult, _) = hp.hover(ast: parseResult.ast!, pos: pos)
+        guard let hoverResult else { return (nil, nil) }
+
+        var result: [String: Any] = [
+            "contents": [
+                "kind": "markdown",
+                "value": hoverResult.contents,
+            ] as [String: Any],
+        ]
+
+        if let range = hoverResult.range {
+            result["range"] = rangeToLSP(range)
+        }
+
+        return (result, nil)
+    }
+
+    /// Handle textDocument/definition.
+    func handleDefinition(id: Any, params: Any?) -> (Any?, ResponseError?) {
+        guard let p = params as? [String: Any] else {
+            return (nil, ResponseError(code: JsonRpcErrorCodes.invalidParams, message: "invalid params"))
+        }
+
+        let uri = LspServer.parseURI(p)
+        let pos = LspServer.parsePosition(p)
+
+        guard let dp = bridge as? DefinitionProvider else { return (nil, nil) }
+        guard let (_, parseResult) = getParseResult(uri: uri) else { return (nil, nil) }
+        guard parseResult.ast != nil else { return (nil, nil) }
+
+        let (location, _) = dp.definition(ast: parseResult.ast!, pos: pos, uri: uri)
+        guard let location else { return (nil, nil) }
+
+        return (locationToLSP(location), nil)
+    }
+
+    /// Handle textDocument/references.
+    func handleReferences(id: Any, params: Any?) -> (Any?, ResponseError?) {
+        guard let p = params as? [String: Any] else {
+            return (nil, ResponseError(code: JsonRpcErrorCodes.invalidParams, message: "invalid params"))
+        }
+
+        let uri = LspServer.parseURI(p)
+        let pos = LspServer.parsePosition(p)
+
+        var includeDecl = false
+        if let ctx = p["context"] as? [String: Any],
+           let incl = ctx["includeDeclaration"] as? Bool {
+            includeDecl = incl
+        }
+
+        guard let rp = bridge as? ReferencesProvider else { return ([] as [Any], nil) }
+        guard let (_, parseResult) = getParseResult(uri: uri) else { return ([] as [Any], nil) }
+        guard parseResult.ast != nil else { return ([] as [Any], nil) }
+
+        let (locations, _) = rp.references(ast: parseResult.ast!, pos: pos, uri: uri, includeDecl: includeDecl)
+        let result = locations.map { locationToLSP($0) }
+        return (result, nil)
+    }
+
+    /// Handle textDocument/completion.
+    func handleCompletion(id: Any, params: Any?) -> (Any?, ResponseError?) {
+        guard let p = params as? [String: Any] else {
+            return (nil, ResponseError(code: JsonRpcErrorCodes.invalidParams, message: "invalid params"))
+        }
+
+        let uri = LspServer.parseURI(p)
+        let pos = LspServer.parsePosition(p)
+        let emptyResult: [String: Any] = ["isIncomplete": false, "items": [] as [Any]]
+
+        guard let cp = bridge as? CompletionProvider else { return (emptyResult, nil) }
+        guard let (_, parseResult) = getParseResult(uri: uri) else { return (emptyResult, nil) }
+        guard parseResult.ast != nil else { return (emptyResult, nil) }
+
+        let (items, _) = cp.completion(ast: parseResult.ast!, pos: pos)
+        let lspItems: [[String: Any]] = items.map { item in
+            var ci: [String: Any] = ["label": item.label]
+            if let kind = item.kind { ci["kind"] = kind.rawValue }
+            if let detail = item.detail { ci["detail"] = detail }
+            if let doc = item.documentation { ci["documentation"] = doc }
+            if let insertText = item.insertText { ci["insertText"] = insertText }
+            if let fmt = item.insertTextFormat { ci["insertTextFormat"] = fmt }
+            return ci
+        }
+
+        return (["isIncomplete": false, "items": lspItems] as [String: Any], nil)
+    }
+
+    /// Handle textDocument/rename.
+    func handleRename(id: Any, params: Any?) -> (Any?, ResponseError?) {
+        guard let p = params as? [String: Any] else {
+            return (nil, ResponseError(code: JsonRpcErrorCodes.invalidParams, message: "invalid params"))
+        }
+
+        let uri = LspServer.parseURI(p)
+        let pos = LspServer.parsePosition(p)
+        let newName = p["newName"] as? String ?? ""
+
+        if newName.isEmpty {
+            return (nil, ResponseError(code: JsonRpcErrorCodes.invalidParams, message: "newName is required"))
+        }
+
+        guard let rp = bridge as? RenameProvider else {
+            return (nil, ResponseError(code: LspErrorCodes.requestFailed, message: "rename not supported"))
+        }
+        guard let (_, parseResult) = getParseResult(uri: uri) else {
+            return (nil, ResponseError(code: LspErrorCodes.requestFailed, message: "document not open"))
+        }
+        guard parseResult.ast != nil else {
+            return (nil, ResponseError(code: LspErrorCodes.requestFailed, message: "no AST available"))
+        }
+
+        let (edit, err) = rp.rename(ast: parseResult.ast!, pos: pos, newName: newName)
+        if let err { return (nil, ResponseError(code: LspErrorCodes.requestFailed, message: err.localizedDescription)) }
+        guard let edit else {
+            return (nil, ResponseError(code: LspErrorCodes.requestFailed, message: "symbol not found at position"))
+        }
+
+        var lspChanges: [String: Any] = [:]
+        for (editURI, edits) in edit.changes {
+            let lspEdits: [[String: Any]] = edits.map { te in
+                ["range": rangeToLSP(te.range), "newText": te.newText]
+            }
+            lspChanges[editURI] = lspEdits
+        }
+
+        return (["changes": lspChanges] as [String: Any], nil)
+    }
+
+    /// Handle textDocument/documentSymbol.
+    func handleDocumentSymbol(id: Any, params: Any?) -> (Any?, ResponseError?) {
+        guard let p = params as? [String: Any] else {
+            return (nil, ResponseError(code: JsonRpcErrorCodes.invalidParams, message: "invalid params"))
+        }
+
+        let uri = LspServer.parseURI(p)
+
+        guard let dsp = bridge as? DocumentSymbolsProvider else { return ([] as [Any], nil) }
+        guard let (_, parseResult) = getParseResult(uri: uri) else { return ([] as [Any], nil) }
+        guard parseResult.ast != nil else { return ([] as [Any], nil) }
+
+        let (symbols, _) = dsp.documentSymbols(ast: parseResult.ast!)
+        return (convertDocumentSymbols(symbols), nil)
+    }
+
+    /// Handle textDocument/semanticTokens/full.
+    func handleSemanticTokensFull(id: Any, params: Any?) -> (Any?, ResponseError?) {
+        guard let p = params as? [String: Any] else {
+            return (nil, ResponseError(code: JsonRpcErrorCodes.invalidParams, message: "invalid params"))
+        }
+
+        let uri = LspServer.parseURI(p)
+        let emptyResult: [String: Any] = ["data": [] as [Int]]
+
+        guard let stp = bridge as? SemanticTokensProvider else { return (emptyResult, nil) }
+        guard let doc = docManager.get(uri: uri) else { return (emptyResult, nil) }
+
+        let (tokens, _) = bridge.tokenize(source: doc.text)
+        let (semTokens, _) = stp.semanticTokens(source: doc.text, tokens: tokens)
+        let data = encodeSemanticTokens(semTokens)
+
+        return (["data": data] as [String: Any], nil)
+    }
+
+    /// Handle textDocument/foldingRange.
+    func handleFoldingRange(id: Any, params: Any?) -> (Any?, ResponseError?) {
+        guard let p = params as? [String: Any] else {
+            return (nil, ResponseError(code: JsonRpcErrorCodes.invalidParams, message: "invalid params"))
+        }
+
+        let uri = LspServer.parseURI(p)
+
+        guard let frp = bridge as? FoldingRangesProvider else { return ([] as [Any], nil) }
+        guard let (_, parseResult) = getParseResult(uri: uri) else { return ([] as [Any], nil) }
+        guard parseResult.ast != nil else { return ([] as [Any], nil) }
+
+        let (ranges, _) = frp.foldingRanges(ast: parseResult.ast!)
+        let result: [[String: Any]] = ranges.map { fr in
+            var m: [String: Any] = ["startLine": fr.startLine, "endLine": fr.endLine]
+            if let kind = fr.kind { m["kind"] = kind }
+            return m
+        }
+
+        return (result, nil)
+    }
+
+    /// Handle textDocument/signatureHelp.
+    func handleSignatureHelp(id: Any, params: Any?) -> (Any?, ResponseError?) {
+        guard let p = params as? [String: Any] else {
+            return (nil, ResponseError(code: JsonRpcErrorCodes.invalidParams, message: "invalid params"))
+        }
+
+        let uri = LspServer.parseURI(p)
+        let pos = LspServer.parsePosition(p)
+
+        guard let shp = bridge as? SignatureHelpProvider else { return (nil, nil) }
+        guard let (_, parseResult) = getParseResult(uri: uri) else { return (nil, nil) }
+        guard parseResult.ast != nil else { return (nil, nil) }
+
+        let (sigHelp, _) = shp.signatureHelp(ast: parseResult.ast!, pos: pos)
+        guard let sigHelp else { return (nil, nil) }
+
+        let lspSigs: [[String: Any]] = sigHelp.signatures.map { sig in
+            let lspParams: [[String: Any]] = sig.parameters.map { param in
+                var pp: [String: Any] = ["label": param.label]
+                if let doc = param.documentation { pp["documentation"] = doc }
+                return pp
+            }
+            var s: [String: Any] = ["label": sig.label, "parameters": lspParams]
+            if let doc = sig.documentation { s["documentation"] = doc }
+            return s
+        }
+
+        return ([
+            "signatures": lspSigs,
+            "activeSignature": sigHelp.activeSignature,
+            "activeParameter": sigHelp.activeParameter,
+        ] as [String: Any], nil)
+    }
+
+    /// Handle textDocument/formatting.
+    func handleFormatting(id: Any, params: Any?) -> (Any?, ResponseError?) {
+        guard let p = params as? [String: Any] else {
+            return (nil, ResponseError(code: JsonRpcErrorCodes.invalidParams, message: "invalid params"))
+        }
+
+        let uri = LspServer.parseURI(p)
+
+        guard let fp = bridge as? FormatProvider else { return ([] as [Any], nil) }
+        guard let doc = docManager.get(uri: uri) else { return ([] as [Any], nil) }
+
+        let (edits, err) = fp.format(source: doc.text)
+        if let err {
+            return (nil, ResponseError(code: LspErrorCodes.requestFailed, message: "formatting failed: \(err.localizedDescription)"))
+        }
+
+        let lspEdits: [[String: Any]] = edits.map { edit in
+            ["range": rangeToLSP(edit.range), "newText": edit.newText]
+        }
+
+        return (lspEdits, nil)
+    }
+
+    // ====================================================================
+    // PRIVATE HELPERS
+    // ====================================================================
+
+    /// Recursively convert DocumentSymbol slices to JSON-serializable maps.
+    private func convertDocumentSymbols(_ symbols: [DocumentSymbol]) -> [[String: Any]] {
+        return symbols.map { sym in
+            var m: [String: Any] = [
+                "name": sym.name,
+                "kind": sym.kind.rawValue,
+                "range": rangeToLSP(sym.range),
+                "selectionRange": rangeToLSP(sym.selectionRange),
+            ]
+            if !sym.children.isEmpty {
+                m["children"] = convertDocumentSymbols(sym.children)
+            }
+            return m
+        }
+    }
+}

--- a/code/packages/swift/ls00/Sources/Ls00/LanguageBridge.swift
+++ b/code/packages/swift/ls00/Sources/Ls00/LanguageBridge.swift
@@ -1,0 +1,175 @@
+// ============================================================================
+// LanguageBridge.swift — LanguageBridge and optional provider protocols
+// ============================================================================
+//
+// # Design Philosophy: Narrow Interfaces
+//
+// Swift's protocol-oriented design favors many small protocols over one large one.
+// This mirrors Go's "interface segregation principle" (from SOLID).
+//
+// Compare two approaches:
+//
+//   APPROACH A — fat protocol (one big protocol, every method required):
+//
+//     protocol LanguageBridge {
+//         func tokenize(source: String) -> ([Token], Error?)
+//         func parse(source: String) -> (ASTNode?, [Diagnostic], Error?)
+//         func hover(ast: ASTNode, pos: Position) -> (HoverResult?, Error?)
+//         func definition(ast: ASTNode, pos: Position, uri: String) -> (Location?, Error?)
+//         // ... 8 more methods, all REQUIRED
+//     }
+//
+//     Problem: a language that only has a lexer and parser must implement ALL
+//     methods, even the symbol-table features it doesn't have yet.
+//
+//   APPROACH B — narrow protocols (what we use):
+//
+//     protocol LanguageBridge {
+//         func tokenize(source: String) -> ([Token], Error?)
+//         func parse(source: String) -> (ASTNode?, [Diagnostic], Error?)
+//     }
+//     protocol HoverProvider { func hover(...) }
+//     protocol DefinitionProvider { func definition(...) }
+//
+//     At runtime, the server checks: does bridge conform to HoverProvider?
+//     If yes -> advertise hoverProvider:true and call bridge.hover().
+//     If no  -> omit hover from capabilities. No stubs required.
+//
+// This matches the LSP spec's philosophy: capabilities are advertised, not
+// assumed. An editor won't even try to ask for hover if the server didn't
+// advertise it.
+//
+// # Runtime Capability Detection
+//
+// Detection uses Swift's `as?` protocol conformance check:
+//
+//   if let hp = bridge as? HoverProvider {
+//       result = hp.hover(ast: ast, pos: pos)
+//   }
+//
+// This is O(1) and checked at compile-time metadata tables.
+//
+// ============================================================================
+
+import Foundation
+
+// ============================================================================
+// LanguageBridge — the required minimum every language must implement
+// ============================================================================
+//
+// Tokenize and Parse are the foundation for all other features:
+//   - Tokenize drives semantic token highlighting (accurate syntax coloring)
+//   - Parse drives diagnostics, folding, and document symbols
+//
+
+/// The required minimum interface every language must implement.
+///
+/// `tokenize` and `parse` are the foundation. All other features (hover,
+/// go-to-definition, etc.) are optional and declared as separate protocols.
+/// The LspServer checks at runtime whether the bridge also conforms to those.
+public protocol LanguageBridge: AnyObject {
+    /// Lex the source string and return the token stream.
+    ///
+    /// Tokens are used for semantic highlighting. Each Token carries a type
+    /// string, its value, and its 1-based line/column position.
+    ///
+    /// - Parameter source: The full source text to tokenize.
+    /// - Returns: A tuple of (tokens, error). Error is nil on success.
+    func tokenize(source: String) -> ([Token], Error?)
+
+    /// Parse the source string and return the AST, diagnostics, and any fatal error.
+    ///
+    /// Even when there are syntax errors, parse should return a partial AST
+    /// so that hover, folding, and symbol features can work on valid portions.
+    ///
+    /// - Parameter source: The full source text to parse.
+    /// - Returns: (ast, diagnostics, fatalError). ast may be nil on total failure.
+    func parse(source: String) -> (ASTNode?, [Diagnostic], Error?)
+}
+
+// ============================================================================
+// Optional Provider Protocols
+// ============================================================================
+//
+// Each protocol represents one optional LSP feature. A bridge implements only
+// the features its language supports. The server uses `bridge as? HoverProvider`
+// to detect support at runtime.
+//
+
+/// Enables hover tooltips (textDocument/hover).
+///
+/// When the user moves their mouse over a symbol, the editor sends a hover
+/// request. The bridge returns Markdown text describing the symbol.
+public protocol HoverProvider {
+    /// Return hover information for the AST node at the given position.
+    ///
+    /// - Returns: (result, error). Result is nil if no hover info at position.
+    func hover(ast: ASTNode, pos: Position) -> (HoverResult?, Error?)
+}
+
+/// Enables "Go to Definition" (textDocument/definition).
+///
+/// When the user presses F12 on a symbol, the bridge looks up where it was declared.
+public protocol DefinitionProvider {
+    /// Return the location where the symbol at pos was declared.
+    ///
+    /// - Returns: (location, error). Location is nil if symbol not found.
+    func definition(ast: ASTNode, pos: Position, uri: String) -> (Location?, Error?)
+}
+
+/// Enables "Find All References" (textDocument/references).
+public protocol ReferencesProvider {
+    /// Return all uses of the symbol at pos.
+    ///
+    /// - Parameter includeDecl: If true, include the declaration location.
+    func references(ast: ASTNode, pos: Position, uri: String, includeDecl: Bool) -> ([Location], Error?)
+}
+
+/// Enables autocomplete suggestions (textDocument/completion).
+public protocol CompletionProvider {
+    /// Return autocomplete suggestions valid at pos.
+    func completion(ast: ASTNode, pos: Position) -> ([CompletionItem], Error?)
+}
+
+/// Enables symbol rename (textDocument/rename).
+public protocol RenameProvider {
+    /// Return the text edits needed to rename the symbol at pos.
+    func rename(ast: ASTNode, pos: Position, newName: String) -> (WorkspaceEdit?, Error?)
+}
+
+/// Enables accurate syntax highlighting (textDocument/semanticTokens/full).
+///
+/// The bridge maps each token to a semantic type (keyword, string, variable, etc.).
+/// The framework encodes the result into LSP's compact binary format.
+public protocol SemanticTokensProvider {
+    /// Return semantic token data for the whole document.
+    ///
+    /// - Parameter tokens: The output of tokenize() -- reuse rather than re-lexing.
+    func semanticTokens(source: String, tokens: [Token]) -> ([SemanticToken], Error?)
+}
+
+/// Enables the document outline panel (textDocument/documentSymbol).
+public protocol DocumentSymbolsProvider {
+    /// Return the outline tree for the given AST.
+    func documentSymbols(ast: ASTNode) -> ([DocumentSymbol], Error?)
+}
+
+/// Enables code folding (textDocument/foldingRange).
+public protocol FoldingRangesProvider {
+    /// Return collapsible regions derived from the AST structure.
+    func foldingRanges(ast: ASTNode) -> ([FoldingRange], Error?)
+}
+
+/// Enables function signature hints (textDocument/signatureHelp).
+public protocol SignatureHelpProvider {
+    /// Return signature hint information for the call at pos.
+    ///
+    /// - Returns: (result, error). Result is nil if not inside a call.
+    func signatureHelp(ast: ASTNode, pos: Position) -> (SignatureHelpResult?, Error?)
+}
+
+/// Enables document formatting (textDocument/formatting).
+public protocol FormatProvider {
+    /// Return the text edits needed to format the document.
+    func format(source: String) -> ([TextEdit], Error?)
+}

--- a/code/packages/swift/ls00/Sources/Ls00/LspErrors.swift
+++ b/code/packages/swift/ls00/Sources/Ls00/LspErrors.swift
@@ -1,0 +1,47 @@
+// ============================================================================
+// LspErrors.swift — LSP-specific error codes
+// ============================================================================
+//
+// The JSON-RPC 2.0 specification reserves error codes in the range [-32768, -32000].
+// The LSP specification further reserves [-32899, -32800] for LSP protocol-level errors.
+//
+// Standard JSON-RPC error codes (from the JsonRpc package):
+//   -32700  ParseError
+//   -32600  InvalidRequest
+//   -32601  MethodNotFound
+//   -32602  InvalidParams
+//   -32603  InternalError
+//
+// LSP-specific error codes are listed below.
+//
+// Reference: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#errorCodes
+//
+// ============================================================================
+
+import Foundation
+
+/// LSP-specific error codes, distinct from the standard JSON-RPC codes.
+public enum LspErrorCodes {
+    /// The server has received a request before the initialize handshake completed.
+    /// The server must reject any request (other than initialize) before initialization.
+    public static let serverNotInitialized = -32002
+
+    /// A generic error code for unknown errors.
+    public static let unknownErrorCode = -32001
+
+    // LSP-specific codes in the range [-32899, -32800]:
+
+    /// A request failed but not due to a protocol problem.
+    /// For example, the document requested was not found.
+    public static let requestFailed = -32803
+
+    /// The server cancelled the request.
+    public static let serverCancelled = -32802
+
+    /// The document content was modified before the request completed.
+    /// The client should retry.
+    public static let contentModified = -32801
+
+    /// The client cancelled the request.
+    public static let requestCancelled = -32800
+}

--- a/code/packages/swift/ls00/Sources/Ls00/ParseCache.swift
+++ b/code/packages/swift/ls00/Sources/Ls00/ParseCache.swift
@@ -1,0 +1,121 @@
+// ============================================================================
+// ParseCache.swift — avoid re-parsing unchanged documents
+// ============================================================================
+//
+// # Why Cache Parse Results?
+//
+// Parsing is the most expensive operation in a language server. For a large
+// file, parsing on every keystroke would lag the editor noticeably.
+//
+// The LSP protocol helps by sending a version number with every change. If the
+// document hasn't changed (same URI, same version), the parse result from the
+// previous keystroke is still valid.
+//
+// # Cache Key Design
+//
+// The cache key is (uri, version). Version is a monotonically increasing integer
+// that the editor increments with each change. Using version in the key means:
+//
+//   - Same (uri, version) -> cache hit -> return cached result
+//   - Different version  -> cache miss -> re-parse and cache new result
+//
+// The old entry is evicted when a new version is cached for the same URI.
+// This keeps memory bounded at O(open_documents) entries.
+//
+// # Thread Safety
+//
+// The ParseCache is NOT thread-safe. This is intentional: the LspServer
+// processes one message at a time (single-threaded), so no locking is needed.
+//
+// ============================================================================
+
+import Foundation
+
+// ============================================================================
+// ParseResult — the outcome of parsing one version of a document
+// ============================================================================
+
+/// Holds the outcome of parsing one version of a document.
+///
+/// Even on parse error, we store the partial AST and diagnostics so that other
+/// features (hover, folding, symbols) can still work on the valid portions.
+public class ParseResult {
+    /// The parsed AST. May be nil if the parser couldn't produce any AST.
+    public let ast: ASTNode?
+
+    /// Diagnostics (errors, warnings) from the parse.
+    public let diagnostics: [Diagnostic]
+
+    /// Non-nil only for fatal parsing failures.
+    public let error: Error?
+
+    public init(ast: ASTNode?, diagnostics: [Diagnostic], error: Error? = nil) {
+        self.ast = ast
+        self.diagnostics = diagnostics
+        self.error = error
+    }
+}
+
+// ============================================================================
+// CacheKey — internal key for the cache
+// ============================================================================
+
+/// Internal cache key combining URI and version.
+private struct CacheKey: Hashable {
+    let uri: String
+    let version: Int
+}
+
+// ============================================================================
+// ParseCache
+// ============================================================================
+
+/// Stores the most recent parse result for each open document.
+///
+/// Create one with `ParseCache()`. Call `getOrParse()` on every feature
+/// request to get the current (possibly cached) parse result.
+public class ParseCache {
+    private var cache: [CacheKey: ParseResult] = [:]
+
+    public init() {}
+
+    /// Return the parse result for (uri, version), re-parsing if needed.
+    ///
+    /// If the result is already cached, it returns immediately without
+    /// calling the bridge. Otherwise, `bridge.parse(source)` is called,
+    /// the result is stored, and any previous entry for this URI is evicted.
+    ///
+    /// This is the single point of truth for "what is the parsed state of
+    /// this document right now?"
+    public func getOrParse(uri: String, version: Int, source: String, bridge: LanguageBridge) -> ParseResult {
+        let key = CacheKey(uri: uri, version: version)
+
+        // Cache hit: document hasn't changed since last parse.
+        if let result = cache[key] {
+            return result
+        }
+
+        // Cache miss: parse and store. Evict stale entries first.
+        evictInternal(uri)
+
+        let (ast, diags, err) = bridge.parse(source: source)
+        let diagnostics = diags.isEmpty ? [] : diags
+
+        let result = ParseResult(ast: ast, diagnostics: diagnostics, error: err)
+        cache[key] = result
+        return result
+    }
+
+    /// Remove all cached entries for a given URI.
+    ///
+    /// Called when a document is closed (didClose).
+    public func evict(uri: String) {
+        evictInternal(uri)
+    }
+
+    private func evictInternal(_ uri: String) {
+        for key in cache.keys where key.uri == uri {
+            cache.removeValue(forKey: key)
+        }
+    }
+}

--- a/code/packages/swift/ls00/Sources/Ls00/Server.swift
+++ b/code/packages/swift/ls00/Sources/Ls00/Server.swift
@@ -195,7 +195,7 @@ public class LspServer {
     func publishDiagnostics(uri: String, version: Int, diagnostics: [Diagnostic]) {
         let lspDiags: [[String: Any]] = diagnostics.map { d in
             var diag: [String: Any] = [
-                "range": rangeToLSP(d.range),
+                "range": Self.rangeToLSP(d.range),
                 "severity": d.severity.rawValue,
                 "message": d.message,
             ]
@@ -227,12 +227,12 @@ public class LspServer {
 
     /// Convert a Range to an LSP-format dictionary.
     static func rangeToLSP(_ r: Range) -> [String: Any] {
-        return ["start": positionToLSP(r.start), "end": positionToLSP(r.end)]
+        return ["start": Self.positionToLSP(r.start), "end": Self.positionToLSP(r.end)]
     }
 
     /// Convert a Location to an LSP-format dictionary.
     static func locationToLSP(_ l: Location) -> [String: Any] {
-        return ["uri": l.uri, "range": rangeToLSP(l.range)]
+        return ["uri": l.uri, "range": Self.rangeToLSP(l.range)]
     }
 
     /// Extract a Position from JSON params.

--- a/code/packages/swift/ls00/Sources/Ls00/Server.swift
+++ b/code/packages/swift/ls00/Sources/Ls00/Server.swift
@@ -1,0 +1,268 @@
+// ============================================================================
+// Server.swift — LspServer: the main coordinator
+// ============================================================================
+//
+// LspServer wires together:
+//   - The LanguageBridge (language-specific logic)
+//   - The DocumentManager (tracks open file contents)
+//   - The ParseCache (avoids redundant parses)
+//   - The JSON-RPC Server (protocol layer)
+//
+// It registers all LSP request and notification handlers with the JSON-RPC
+// server, then calls serve() to start the blocking read-dispatch-write loop.
+//
+// # Server Lifecycle
+//
+//   Client (editor)              Server (us)
+//     |                               |
+//     |--initialize--------------->   |  store clientInfo, return capabilities
+//     | <-----------------result-     |
+//     |                               |
+//     |--initialized (notif)------>   |  no-op (handshake complete)
+//     |                               |
+//     |--textDocument/didOpen------>  |  open doc, parse, push diagnostics
+//     |--textDocument/didChange---->  |  apply change, re-parse, push diagnostics
+//     |--textDocument/hover-------->  |  get parse result, call bridge.hover
+//     | <-----------------result-     |
+//     |                               |
+//     |--shutdown------------------>  |  set shutdown flag, return null
+//     |--exit (notif)-------------->  |  exit process
+//
+// # Sending Notifications to the Editor
+//
+// The JSON-RPC Server handles request/response pairs. But the LSP server also
+// needs to PUSH notifications to the editor (e.g., publishDiagnostics). We do
+// this by holding a reference to the MessageWriter and calling writeMessage.
+//
+// ============================================================================
+
+import Foundation
+import JsonRpc
+
+/// The main LSP server coordinating the bridge, document manager, parse cache,
+/// and JSON-RPC communication.
+///
+/// Create with `LspServer(bridge:inputData:output:)`, then call `serve()`.
+/// Designed for one-shot use: start, block, exit.
+public class LspServer {
+    let bridge: LanguageBridge
+    let docManager: DocumentManager
+    let parseCache: ParseCache
+    private let rpcServer: JsonRpc.Server
+    private let writer: JsonRpc.MessageWriter
+
+    /// Whether the editor has sent "shutdown".
+    var isShutdown = false
+
+    /// Whether the initialize handshake is complete.
+    var isInitialized = false
+
+    /// Create an LspServer wired to read from inputData and write to output.
+    ///
+    /// Typically:
+    ///   let server = LspServer(bridge: myBridge, inputData: stdinBytes, output: stdoutTarget)
+    ///   server.serve()
+    ///
+    /// For testing, pass Data and DataOutput.
+    public init(bridge: LanguageBridge, inputData: Data, output: OutputTarget) {
+        self.bridge = bridge
+        self.docManager = DocumentManager()
+        self.parseCache = ParseCache()
+        self.rpcServer = JsonRpc.Server(inputData: inputData, output: output)
+        self.writer = JsonRpc.MessageWriter(output)
+
+        registerHandlers()
+    }
+
+    /// Start the blocking JSON-RPC read-dispatch-write loop.
+    ///
+    /// Blocks until the editor closes the connection (EOF on stdin).
+    /// All LSP messages are handled synchronously in this loop.
+    public func serve() {
+        rpcServer.serve()
+    }
+
+    // ----------------------------------------------------------------
+    // sendNotification — push a server-initiated notification
+    // ----------------------------------------------------------------
+    //
+    // LSP servers push certain events proactively. The most important is
+    // textDocument/publishDiagnostics, sent after every parse.
+    //
+
+    /// Send a server-initiated notification to the editor.
+    ///
+    /// Notifications have no "id" and the editor sends no response.
+    func sendNotification(method: String, params: Any) {
+        let notif = JsonRpc.Notification(
+            method: method,
+            params: JsonRpc.AnySendable(params)
+        )
+        try? writer.writeMessage(.notification(notif))
+    }
+
+    // ----------------------------------------------------------------
+    // registerHandlers — wire all LSP methods to handlers
+    // ----------------------------------------------------------------
+
+    private func registerHandlers() {
+        // -- Lifecycle --
+        rpcServer.onRequest("initialize") { [weak self] id, params in
+            self?.handleInitialize(id: id, params: params) ?? (nil, nil)
+        }
+        rpcServer.onNotification("initialized") { [weak self] params in
+            self?.handleInitialized(params: params)
+        }
+        rpcServer.onRequest("shutdown") { [weak self] id, params in
+            self?.handleShutdown(id: id, params: params) ?? (nil, nil)
+        }
+        rpcServer.onNotification("exit") { [weak self] params in
+            self?.handleExit(params: params)
+        }
+
+        // -- Text document synchronization --
+        rpcServer.onNotification("textDocument/didOpen") { [weak self] params in
+            self?.handleDidOpen(params: params)
+        }
+        rpcServer.onNotification("textDocument/didChange") { [weak self] params in
+            self?.handleDidChange(params: params)
+        }
+        rpcServer.onNotification("textDocument/didClose") { [weak self] params in
+            self?.handleDidClose(params: params)
+        }
+        rpcServer.onNotification("textDocument/didSave") { [weak self] params in
+            self?.handleDidSave(params: params)
+        }
+
+        // -- Feature requests --
+        rpcServer.onRequest("textDocument/hover") { [weak self] id, params in
+            self?.handleHover(id: id, params: params) ?? (nil, nil)
+        }
+        rpcServer.onRequest("textDocument/definition") { [weak self] id, params in
+            self?.handleDefinition(id: id, params: params) ?? (nil, nil)
+        }
+        rpcServer.onRequest("textDocument/references") { [weak self] id, params in
+            self?.handleReferences(id: id, params: params) ?? (nil, nil)
+        }
+        rpcServer.onRequest("textDocument/completion") { [weak self] id, params in
+            self?.handleCompletion(id: id, params: params) ?? (nil, nil)
+        }
+        rpcServer.onRequest("textDocument/rename") { [weak self] id, params in
+            self?.handleRename(id: id, params: params) ?? (nil, nil)
+        }
+        rpcServer.onRequest("textDocument/documentSymbol") { [weak self] id, params in
+            self?.handleDocumentSymbol(id: id, params: params) ?? (nil, nil)
+        }
+        rpcServer.onRequest("textDocument/semanticTokens/full") { [weak self] id, params in
+            self?.handleSemanticTokensFull(id: id, params: params) ?? (nil, nil)
+        }
+        rpcServer.onRequest("textDocument/foldingRange") { [weak self] id, params in
+            self?.handleFoldingRange(id: id, params: params) ?? (nil, nil)
+        }
+        rpcServer.onRequest("textDocument/signatureHelp") { [weak self] id, params in
+            self?.handleSignatureHelp(id: id, params: params) ?? (nil, nil)
+        }
+        rpcServer.onRequest("textDocument/formatting") { [weak self] id, params in
+            self?.handleFormatting(id: id, params: params) ?? (nil, nil)
+        }
+    }
+
+    // ----------------------------------------------------------------
+    // getParseResult — hot path for all feature handlers
+    // ----------------------------------------------------------------
+
+    /// Retrieve the current parse result for a document.
+    ///
+    /// Gets the document text from the DocumentManager, then returns the
+    /// cached ParseResult (or re-parses if needed).
+    ///
+    /// - Returns: (document, parseResult) or nil if document not open.
+    func getParseResult(uri: String) -> (Document, ParseResult)? {
+        guard let doc = docManager.get(uri: uri) else {
+            return nil
+        }
+        let result = parseCache.getOrParse(uri: uri, version: doc.version, source: doc.text, bridge: bridge)
+        return (doc, result)
+    }
+
+    // ----------------------------------------------------------------
+    // publishDiagnostics — push diagnostics to the editor
+    // ----------------------------------------------------------------
+
+    /// Send textDocument/publishDiagnostics to update squiggles in the editor.
+    ///
+    /// Called after every didOpen and didChange to update diagnostic display.
+    func publishDiagnostics(uri: String, version: Int, diagnostics: [Diagnostic]) {
+        let lspDiags: [[String: Any]] = diagnostics.map { d in
+            var diag: [String: Any] = [
+                "range": rangeToLSP(d.range),
+                "severity": d.severity.rawValue,
+                "message": d.message,
+            ]
+            if let code = d.code {
+                diag["code"] = code
+            }
+            return diag
+        }
+
+        var params: [String: Any] = [
+            "uri": uri,
+            "diagnostics": lspDiags,
+        ]
+        if version > 0 {
+            params["version"] = version
+        }
+
+        sendNotification(method: "textDocument/publishDiagnostics", params: params)
+    }
+
+    // ----------------------------------------------------------------
+    // LSP type conversion helpers
+    // ----------------------------------------------------------------
+
+    /// Convert a Position to an LSP-format dictionary.
+    static func positionToLSP(_ p: Position) -> [String: Any] {
+        return ["line": p.line, "character": p.character]
+    }
+
+    /// Convert a Range to an LSP-format dictionary.
+    static func rangeToLSP(_ r: Range) -> [String: Any] {
+        return ["start": positionToLSP(r.start), "end": positionToLSP(r.end)]
+    }
+
+    /// Convert a Location to an LSP-format dictionary.
+    static func locationToLSP(_ l: Location) -> [String: Any] {
+        return ["uri": l.uri, "range": rangeToLSP(l.range)]
+    }
+
+    /// Extract a Position from JSON params.
+    static func parsePosition(_ params: [String: Any]) -> Position {
+        let pos = params["position"] as? [String: Any] ?? [:]
+        let line = pos["line"] as? Int ?? (pos["line"] as? Double).map { Int($0) } ?? 0
+        let char = pos["character"] as? Int ?? (pos["character"] as? Double).map { Int($0) } ?? 0
+        return Position(line: line, character: char)
+    }
+
+    /// Extract the document URI from params with a textDocument field.
+    static func parseURI(_ params: [String: Any]) -> String {
+        let td = params["textDocument"] as? [String: Any] ?? [:]
+        return td["uri"] as? String ?? ""
+    }
+
+    /// Parse an LSP range object from raw JSON.
+    static func parseLSPRange(_ raw: Any) -> Range {
+        guard let m = raw as? [String: Any] else { return Range(start: Position(line: 0, character: 0), end: Position(line: 0, character: 0)) }
+        let startMap = m["start"] as? [String: Any] ?? [:]
+        let endMap = m["end"] as? [String: Any] ?? [:]
+        let startLine = startMap["line"] as? Int ?? (startMap["line"] as? Double).map { Int($0) } ?? 0
+        let startChar = startMap["character"] as? Int ?? (startMap["character"] as? Double).map { Int($0) } ?? 0
+        let endLine = endMap["line"] as? Int ?? (endMap["line"] as? Double).map { Int($0) } ?? 0
+        let endChar = endMap["character"] as? Int ?? (endMap["character"] as? Double).map { Int($0) } ?? 0
+        return Range(start: Position(line: startLine, character: startChar), end: Position(line: endLine, character: endChar))
+    }
+}
+
+// Free-function wrappers for convenience in Handlers.swift
+func positionToLSP(_ p: Position) -> [String: Any] { LspServer.positionToLSP(p) }
+func rangeToLSP(_ r: Range) -> [String: Any] { LspServer.rangeToLSP(r) }
+func locationToLSP(_ l: Location) -> [String: Any] { LspServer.locationToLSP(l) }

--- a/code/packages/swift/ls00/Sources/Ls00/Types.swift
+++ b/code/packages/swift/ls00/Sources/Ls00/Types.swift
@@ -1,0 +1,486 @@
+// ============================================================================
+// Types.swift — all shared LSP data types used across the server
+// ============================================================================
+//
+// These types mirror the LSP specification's TypeScript type definitions,
+// translated to idiomatic Swift. The LSP spec lives at:
+// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/
+//
+// # Coordinate System
+//
+// LSP uses a 0-based, line/character coordinate system. Line 0, character 0 is
+// the very first character of the file. This differs from most editors (which
+// display 1-based line numbers) and from most lexers (which emit 1-based tokens).
+// The LanguageBridge is responsible for converting.
+//
+// # UTF-16 Code Units
+//
+// LSP's "character" offset is measured in UTF-16 CODE UNITS, not bytes or
+// Unicode codepoints. This is a historical artifact: VS Code is built on
+// TypeScript, which uses UTF-16 strings internally. See DocumentManager.swift
+// for the conversion function and a detailed explanation of why this matters.
+//
+// ============================================================================
+
+import Foundation
+
+// ============================================================================
+// Position — a cursor position in a document
+// ============================================================================
+//
+// Both `line` and `character` are 0-based. Character is measured in UTF-16 code
+// units (see the package doc above for why).
+//
+// Example: in the string "hello guitar-emoji world", the guitar emoji occupies
+// UTF-16 characters 6 and 7 (it requires two UTF-16 surrogates). "world" starts
+// at UTF-16 character 8.
+//
+
+/// A cursor position in a document, with 0-based line and character offsets.
+///
+/// The `character` offset is in UTF-16 code units, matching LSP's convention
+/// inherited from VS Code's JavaScript string model.
+public struct Position: Sendable, Equatable {
+    /// 0-based line number.
+    public let line: Int
+
+    /// 0-based character offset within the line, in UTF-16 code units.
+    public let character: Int
+
+    public init(line: Int, character: Int) {
+        self.line = line
+        self.character = character
+    }
+}
+
+// ============================================================================
+// Range — a span of text from Start (inclusive) to End (exclusive)
+// ============================================================================
+//
+// Analogy: think of it like a text selection. Start is where the cursor lands
+// when you click, End is where you drag to.
+//
+
+/// A span of text in a document, from start (inclusive) to end (exclusive).
+public struct Range: Sendable, Equatable {
+    /// The start position (inclusive).
+    public let start: Position
+
+    /// The end position (exclusive).
+    public let end: Position
+
+    public init(start: Position, end: Position) {
+        self.start = start
+        self.end = end
+    }
+}
+
+// ============================================================================
+// Location — a position in a specific file
+// ============================================================================
+//
+// URI uses the "file://" scheme, e.g., "file:///home/user/main.swift".
+//
+
+/// A position in a specific file, identified by URI.
+public struct Location: Sendable, Equatable {
+    /// The file URI (e.g. "file:///home/user/main.swift").
+    public let uri: String
+
+    /// The range within the file.
+    public let range: Range
+
+    public init(uri: String, range: Range) {
+        self.uri = uri
+        self.range = range
+    }
+}
+
+// ============================================================================
+// DiagnosticSeverity
+// ============================================================================
+//
+// These match the LSP integer codes:
+//   1 = Error, 2 = Warning, 3 = Information, 4 = Hint
+//
+
+/// How serious a diagnostic is. Matches LSP's integer codes.
+public enum DiagnosticSeverity: Int, Sendable {
+    /// A hard error; the code cannot run or compile. Red squiggle.
+    case error = 1
+
+    /// Potentially problematic, but not blocking. Yellow squiggle.
+    case warning = 2
+
+    /// Informational message. Blue squiggle.
+    case information = 3
+
+    /// A suggestion (e.g., "consider using let"). Subtle dots.
+    case hint = 4
+}
+
+// ============================================================================
+// Diagnostic — an error, warning, or hint to display in the editor
+// ============================================================================
+//
+// The editor renders diagnostics as underlined squiggles, with the message
+// shown on hover. Red = Error, Yellow = Warning, Blue = Info.
+//
+
+/// An error, warning, or hint displayed as a squiggle in the editor.
+public struct Diagnostic: Sendable, Equatable {
+    /// The range of text this diagnostic applies to.
+    public let range: Range
+
+    /// The severity level.
+    public let severity: DiagnosticSeverity
+
+    /// The human-readable diagnostic message.
+    public let message: String
+
+    /// Optional error code (e.g. "E001").
+    public let code: String?
+
+    public init(range: Range, severity: DiagnosticSeverity, message: String, code: String? = nil) {
+        self.range = range
+        self.severity = severity
+        self.message = message
+        self.code = code
+    }
+}
+
+// ============================================================================
+// Token — a single lexical token from the language's lexer
+// ============================================================================
+//
+// The bridge's tokenize() method returns a slice of these. The LSP server uses
+// tokens to provide semantic syntax highlighting (SemanticTokensProvider).
+//
+// Note: Line and Column are 1-based (matching most lexers). The bridge must
+// convert to 0-based when building SemanticToken values for the LSP response.
+//
+
+/// A single lexical token from the language's lexer.
+///
+/// Line and column are 1-based, matching most lexer conventions.
+/// The bridge must convert to 0-based for SemanticToken values.
+public struct Token: Sendable, Equatable {
+    /// Token type (e.g. "KEYWORD", "IDENTIFIER", "STRING_LIT").
+    public let type: String
+
+    /// The actual source text (e.g. "let", "myVar").
+    public let value: String
+
+    /// 1-based line number.
+    public let line: Int
+
+    /// 1-based column number.
+    public let column: Int
+
+    public init(type: String, value: String, line: Int, column: Int) {
+        self.type = type
+        self.value = value
+        self.line = line
+        self.column = column
+    }
+}
+
+// ============================================================================
+// ASTNode — the abstract syntax tree
+// ============================================================================
+//
+// We use Any here because each language's parser returns its own concrete
+// AST type. The LanguageBridge is responsible for accepting this and
+// downcasting to the concrete type it knows about.
+//
+
+/// Type alias for the abstract syntax tree produced by the language's parser.
+///
+/// Each language has its own AST type. The bridge downcasts internally.
+public typealias ASTNode = Any
+
+// ============================================================================
+// TextEdit — a single text replacement
+// ============================================================================
+//
+// Used by formatting (replace the whole file) and rename (replace each occurrence).
+// newText replaces the content at range. If newText is empty, the range is deleted.
+//
+
+/// A single text replacement in a document.
+public struct TextEdit: Sendable, Equatable {
+    /// The range of text to replace.
+    public let range: Range
+
+    /// The replacement text. Empty string means deletion.
+    public let newText: String
+
+    public init(range: Range, newText: String) {
+        self.range = range
+        self.newText = newText
+    }
+}
+
+// ============================================================================
+// WorkspaceEdit — TextEdits across potentially multiple files
+// ============================================================================
+
+/// Groups TextEdits across potentially multiple files.
+///
+/// For rename operations in a single file, `changes` has one key.
+/// Multi-file renames produce edits across many files.
+public struct WorkspaceEdit: Sendable {
+    /// Map from file URI to the edits for that file.
+    public let changes: [String: [TextEdit]]
+
+    public init(changes: [String: [TextEdit]]) {
+        self.changes = changes
+    }
+}
+
+// ============================================================================
+// HoverResult — content for the hover popup
+// ============================================================================
+
+/// The content to show in the hover popup.
+///
+/// `contents` is Markdown text. VS Code renders it with syntax highlighting,
+/// bold/italic, code blocks, etc. `range` is optional -- if set, it highlights
+/// the symbol in the editor while the hover popup is shown.
+public struct HoverResult: Sendable {
+    /// Markdown text to display.
+    public let contents: String
+
+    /// Optional range to highlight while the hover is shown.
+    public let range: Range?
+
+    public init(contents: String, range: Range? = nil) {
+        self.contents = contents
+        self.range = range
+    }
+}
+
+// ============================================================================
+// CompletionItemKind — icon classification for autocomplete items
+// ============================================================================
+
+/// Classifies completion items so the editor shows the right icon.
+public enum CompletionItemKind: Int, Sendable {
+    case text = 1, method, function, constructor, field,
+         variable, `class`, interface, module, property,
+         unit, value, `enum`, keyword, snippet,
+         color, file, reference, folder, enumMember,
+         constant, `struct`, event, `operator`, typeParameter
+}
+
+// ============================================================================
+// CompletionItem — a single autocomplete suggestion
+// ============================================================================
+
+/// A single autocomplete suggestion shown in the editor's dropdown.
+public struct CompletionItem: Sendable {
+    /// The text shown in the dropdown list.
+    public let label: String
+
+    /// The icon to show (function, variable, keyword, etc.).
+    public let kind: CompletionItemKind?
+
+    /// Secondary text (e.g. the return type).
+    public let detail: String?
+
+    /// Documentation shown when the item is expanded.
+    public let documentation: String?
+
+    /// What to actually insert (defaults to label if nil).
+    public let insertText: String?
+
+    /// 1 = plain text, 2 = snippet (with tab stops like ${1:name}).
+    public let insertTextFormat: Int?
+
+    public init(label: String, kind: CompletionItemKind? = nil, detail: String? = nil,
+                documentation: String? = nil, insertText: String? = nil, insertTextFormat: Int? = nil) {
+        self.label = label
+        self.kind = kind
+        self.detail = detail
+        self.documentation = documentation
+        self.insertText = insertText
+        self.insertTextFormat = insertTextFormat
+    }
+}
+
+// ============================================================================
+// SemanticToken — one token's contribution to semantic highlighting
+// ============================================================================
+//
+// Line and Character are 0-based. TokenType and Modifiers reference entries
+// in the legend returned by semanticTokenLegend().
+//
+
+/// One token's semantic highlighting data.
+///
+/// Semantic tokens are the "second pass" of syntax highlighting, layered
+/// on top of the grammar-based TextMate pass with context-aware type info.
+public struct SemanticToken: Sendable {
+    /// 0-based line number.
+    public let line: Int
+
+    /// 0-based character offset in UTF-16 code units.
+    public let character: Int
+
+    /// Length in UTF-16 code units.
+    public let length: Int
+
+    /// Must match an entry in the semantic token legend's tokenTypes.
+    public let tokenType: String
+
+    /// Subset of the legend's tokenModifiers.
+    public let modifiers: [String]
+
+    public init(line: Int, character: Int, length: Int, tokenType: String, modifiers: [String] = []) {
+        self.line = line
+        self.character = character
+        self.length = length
+        self.tokenType = tokenType
+        self.modifiers = modifiers
+    }
+}
+
+// ============================================================================
+// SymbolKind — classification for document outline symbols
+// ============================================================================
+
+/// Classifies document symbols for the outline panel. Matches LSP's 1-based codes.
+public enum SymbolKind: Int, Sendable {
+    case file = 1, module, namespace, package, `class`,
+         method, property, field, constructor, `enum`,
+         interface, function, variable, constant, string,
+         number, boolean, array, object, key,
+         null, enumMember, `struct`, event, `operator`,
+         typeParameter
+}
+
+// ============================================================================
+// DocumentSymbol — one entry in the document outline panel
+// ============================================================================
+
+/// One entry in the document outline (Explorer > OUTLINE in VS Code).
+///
+/// Children allows nesting: a class symbol can have method symbols as children.
+/// `range` covers the entire symbol (including body). `selectionRange` is just
+/// the name portion (highlighted when user clicks the outline entry).
+public struct DocumentSymbol: Sendable {
+    /// The symbol name (e.g. "main", "MyClass").
+    public let name: String
+
+    /// The symbol kind (function, variable, class, etc.).
+    public let kind: SymbolKind
+
+    /// Range covering the entire symbol including its body.
+    public let range: Range
+
+    /// Range covering just the symbol's name.
+    public let selectionRange: Range
+
+    /// Nested symbols (e.g. methods inside a class).
+    public let children: [DocumentSymbol]
+
+    public init(name: String, kind: SymbolKind, range: Range, selectionRange: Range, children: [DocumentSymbol] = []) {
+        self.name = name
+        self.kind = kind
+        self.range = range
+        self.selectionRange = selectionRange
+        self.children = children
+    }
+}
+
+// ============================================================================
+// FoldingRange — a collapsible region of the document
+// ============================================================================
+
+/// A collapsible region in the editor's code folding.
+///
+/// The editor shows a collapse arrow in the gutter next to `startLine`.
+/// When collapsed, lines startLine+1 through endLine are hidden.
+public struct FoldingRange: Sendable {
+    /// 0-based start line (the line with the collapse arrow).
+    public let startLine: Int
+
+    /// 0-based end line (inclusive).
+    public let endLine: Int
+
+    /// One of "region", "imports", or "comment" (optional).
+    public let kind: String?
+
+    public init(startLine: Int, endLine: Int, kind: String? = nil) {
+        self.startLine = startLine
+        self.endLine = endLine
+        self.kind = kind
+    }
+}
+
+// ============================================================================
+// ParameterInformation — one parameter in a function signature
+// ============================================================================
+
+/// One parameter in a function signature tooltip.
+public struct ParameterInformation: Sendable {
+    /// The parameter label (e.g. "count: Int").
+    public let label: String
+
+    /// Optional documentation for this parameter.
+    public let documentation: String?
+
+    public init(label: String, documentation: String? = nil) {
+        self.label = label
+        self.documentation = documentation
+    }
+}
+
+// ============================================================================
+// SignatureInformation — one function overload's full signature
+// ============================================================================
+
+/// One function overload's full signature.
+public struct SignatureInformation: Sendable {
+    /// The full signature label (e.g. "foo(a: Int, b: String) -> Bool").
+    public let label: String
+
+    /// Optional documentation for this signature.
+    public let documentation: String?
+
+    /// The parameters in this signature.
+    public let parameters: [ParameterInformation]
+
+    public init(label: String, documentation: String? = nil, parameters: [ParameterInformation] = []) {
+        self.label = label
+        self.documentation = documentation
+        self.parameters = parameters
+    }
+}
+
+// ============================================================================
+// SignatureHelpResult — tooltip during function call typing
+// ============================================================================
+//
+// Shows the function signature with the current parameter highlighted.
+// ActiveSignature indexes into Signatures. ActiveParameter indexes into
+// that signature's Parameters.
+//
+
+/// Signature help result shown while the user types a function call.
+public struct SignatureHelpResult: Sendable {
+    /// Available signatures (overloads).
+    public let signatures: [SignatureInformation]
+
+    /// Index into `signatures` for the active overload.
+    public let activeSignature: Int
+
+    /// Index into the active signature's parameters for the current parameter.
+    public let activeParameter: Int
+
+    public init(signatures: [SignatureInformation], activeSignature: Int, activeParameter: Int) {
+        self.signatures = signatures
+        self.activeSignature = activeSignature
+        self.activeParameter = activeParameter
+    }
+}

--- a/code/packages/swift/ls00/Tests/Ls00Tests/Ls00Tests.swift
+++ b/code/packages/swift/ls00/Tests/Ls00Tests/Ls00Tests.swift
@@ -1,0 +1,640 @@
+// ============================================================================
+// Ls00Tests.swift — comprehensive tests for the ls00 LSP framework
+// ============================================================================
+//
+// # Test Strategy
+//
+// We test the framework with a MockBridge that implements all optional
+// provider protocols. This lets us exercise every code path without
+// needing a real language implementation.
+//
+// # Test Coverage Areas
+//
+//  1. UTF-16 offset conversion (critical for correctness)
+//  2. DocumentManager open/change/close operations
+//  3. ParseCache hit/miss behavior
+//  4. Semantic token encoding (the delta format)
+//  5. Capabilities advertisement (only what the bridge supports)
+//  6. Full LSP lifecycle via JSON-RPC round-trips
+//
+// ============================================================================
+
+import XCTest
+@testable import Ls00
+import JsonRpc
+import Foundation
+
+// ============================================================================
+// MockBridge — full-featured test bridge
+// ============================================================================
+
+/// Test bridge implementing LanguageBridge + HoverProvider + DocumentSymbolsProvider.
+final class MockBridge: LanguageBridge, HoverProvider, DocumentSymbolsProvider {
+    var hoverResult: HoverResult? = HoverResult(contents: "**test** hover")
+
+    func tokenize(source: String) -> ([Token], Error?) {
+        var tokens: [Token] = []
+        var col = 1
+        for word in source.split(separator: " ") {
+            tokens.append(Token(type: "WORD", value: String(word), line: 1, column: col))
+            col += word.count + 1
+        }
+        return (tokens, nil)
+    }
+
+    func parse(source: String) -> (ASTNode?, [Diagnostic], Error?) {
+        var diags: [Diagnostic] = []
+        if source.contains("ERROR") {
+            diags.append(Diagnostic(
+                range: Range(
+                    start: Position(line: 0, character: 0),
+                    end: Position(line: 0, character: 5)
+                ),
+                severity: .error,
+                message: "syntax error: unexpected ERROR token"
+            ))
+        }
+        return (source as ASTNode, diags, nil)
+    }
+
+    func hover(ast: ASTNode, pos: Position) -> (HoverResult?, Error?) {
+        return (hoverResult, nil)
+    }
+
+    func documentSymbols(ast: ASTNode) -> ([DocumentSymbol], Error?) {
+        return ([
+            DocumentSymbol(
+                name: "main",
+                kind: .function,
+                range: Range(start: Position(line: 0, character: 0), end: Position(line: 10, character: 1)),
+                selectionRange: Range(start: Position(line: 0, character: 9), end: Position(line: 0, character: 13)),
+                children: [
+                    DocumentSymbol(
+                        name: "x",
+                        kind: .variable,
+                        range: Range(start: Position(line: 1, character: 4), end: Position(line: 1, character: 12)),
+                        selectionRange: Range(start: Position(line: 1, character: 8), end: Position(line: 1, character: 9))
+                    ),
+                ]
+            ),
+        ], nil)
+    }
+}
+
+/// Minimal bridge implementing ONLY the required LanguageBridge protocol.
+/// Used to test that optional capabilities are NOT advertised.
+final class MinimalBridge: LanguageBridge {
+    func tokenize(source: String) -> ([Token], Error?) {
+        return ([], nil)
+    }
+    func parse(source: String) -> (ASTNode?, [Diagnostic], Error?) {
+        return (source as ASTNode, [], nil)
+    }
+}
+
+// ============================================================================
+// UTF-16 Offset Conversion Tests
+// ============================================================================
+
+final class UTF16Tests: XCTestCase {
+
+    /// This is the most important correctness test. If UTF-16 conversion is wrong,
+    /// every position-dependent feature breaks: hover, definition, references, etc.
+    func testConvertUTF16OffsetToByteOffset() {
+        // ASCII simple: "hello world", char 6 -> byte 6
+        XCTAssertEqual(convertUTF16OffsetToByteOffset("hello world", line: 0, char: 6), 6)
+
+        // Start of file
+        XCTAssertEqual(convertUTF16OffsetToByteOffset("abc", line: 0, char: 0), 0)
+
+        // End of short string
+        XCTAssertEqual(convertUTF16OffsetToByteOffset("abc", line: 0, char: 3), 3)
+
+        // Second line: "hello\nworld", line 1 starts at byte 6
+        XCTAssertEqual(convertUTF16OffsetToByteOffset("hello\nworld", line: 1, char: 0), 6)
+    }
+
+    func testEmojiUTF16Conversion() {
+        // "A🎸B"
+        // UTF-8 bytes: A(1) + 🎸(4) + B(1) = 6 bytes
+        // UTF-16 units: A(1) + 🎸(2) + B(1) = 4 units
+        // "B" is at UTF-16 char 3, byte offset 5
+        let text = "A\u{1F3B8}B"
+        XCTAssertEqual(convertUTF16OffsetToByteOffset(text, line: 0, char: 3), 5)
+    }
+
+    func testEmojiAtStart() {
+        // "🎸hello" — 🎸 = 2 UTF-16 units = 4 UTF-8 bytes
+        // "h" is at UTF-16 char 2, byte offset 4
+        let text = "\u{1F3B8}hello"
+        XCTAssertEqual(convertUTF16OffsetToByteOffset(text, line: 0, char: 2), 4)
+    }
+
+    func testTwoByteUTF8() {
+        // "cafe!" — e is U+00E9 (2 UTF-8 bytes, 1 UTF-16 code unit)
+        // UTF-16 char 4 = byte offset 5 (c=1, a=1, f=1, e=2)
+        let text = "caf\u{00e9}!"
+        XCTAssertEqual(convertUTF16OffsetToByteOffset(text, line: 0, char: 4), 5)
+    }
+
+    func testMultilineWithEmoji() {
+        // line 0: "A🎸B\n" (7 bytes)
+        // line 1: "hello"
+        let text = "A\u{1F3B8}B\nhello"
+        XCTAssertEqual(convertUTF16OffsetToByteOffset(text, line: 1, char: 0), 7)
+    }
+
+    func testBeyondLineEndClamps() {
+        // Character past line end should clamp to newline position
+        let text = "ab\ncd"
+        XCTAssertEqual(convertUTF16OffsetToByteOffset(text, line: 0, char: 100), 2)
+    }
+}
+
+// ============================================================================
+// DocumentManager Tests
+// ============================================================================
+
+final class DocumentManagerTests: XCTestCase {
+
+    func testOpen() {
+        let dm = DocumentManager()
+        dm.open(uri: "file:///test.txt", text: "hello world", version: 1)
+
+        let doc = dm.get(uri: "file:///test.txt")
+        XCTAssertNotNil(doc)
+        XCTAssertEqual(doc?.text, "hello world")
+        XCTAssertEqual(doc?.version, 1)
+    }
+
+    func testGetMissing() {
+        let dm = DocumentManager()
+        XCTAssertNil(dm.get(uri: "file:///nonexistent.txt"))
+    }
+
+    func testClose() {
+        let dm = DocumentManager()
+        dm.open(uri: "file:///test.txt", text: "hello", version: 1)
+        dm.close(uri: "file:///test.txt")
+        XCTAssertNil(dm.get(uri: "file:///test.txt"))
+    }
+
+    func testApplyChangesFullReplacement() {
+        let dm = DocumentManager()
+        dm.open(uri: "file:///test.txt", text: "hello world", version: 1)
+
+        let err = dm.applyChanges(uri: "file:///test.txt", changes: [
+            TextChange(newText: "goodbye world"),
+        ], version: 2)
+        XCTAssertNil(err)
+
+        let doc = dm.get(uri: "file:///test.txt")!
+        XCTAssertEqual(doc.text, "goodbye world")
+        XCTAssertEqual(doc.version, 2)
+    }
+
+    func testApplyChangesIncremental() {
+        let dm = DocumentManager()
+        dm.open(uri: "file:///test.txt", text: "hello world", version: 1)
+
+        // Replace "world" (chars 6-11) with "Go"
+        let err = dm.applyChanges(uri: "file:///test.txt", changes: [
+            TextChange(
+                range: Range(
+                    start: Position(line: 0, character: 6),
+                    end: Position(line: 0, character: 11)
+                ),
+                newText: "Go"
+            ),
+        ], version: 2)
+        XCTAssertNil(err)
+
+        let doc = dm.get(uri: "file:///test.txt")!
+        XCTAssertEqual(doc.text, "hello Go")
+    }
+
+    func testApplyChangesNotOpen() {
+        let dm = DocumentManager()
+        let err = dm.applyChanges(uri: "file:///notopen.txt", changes: [
+            TextChange(newText: "x"),
+        ], version: 1)
+        XCTAssertNotNil(err)
+    }
+
+    func testIncrementalWithEmoji() {
+        // "A🎸B" — replace "B" (UTF-16 char 3-4) with "X"
+        let dm = DocumentManager()
+        dm.open(uri: "file:///test.txt", text: "A\u{1F3B8}B", version: 1)
+
+        let err = dm.applyChanges(uri: "file:///test.txt", changes: [
+            TextChange(
+                range: Range(
+                    start: Position(line: 0, character: 3),
+                    end: Position(line: 0, character: 4)
+                ),
+                newText: "X"
+            ),
+        ], version: 2)
+        XCTAssertNil(err)
+
+        let doc = dm.get(uri: "file:///test.txt")!
+        XCTAssertEqual(doc.text, "A\u{1F3B8}X")
+    }
+}
+
+// ============================================================================
+// ParseCache Tests
+// ============================================================================
+
+final class ParseCacheTests: XCTestCase {
+
+    func testHitAndMiss() {
+        let bridge = MockBridge()
+        let cache = ParseCache()
+
+        // First call — cache miss
+        let r1 = cache.getOrParse(uri: "file:///a.txt", version: 1, source: "hello", bridge: bridge)
+        XCTAssertNotNil(r1)
+
+        // Second call same version — cache hit (same object)
+        let r2 = cache.getOrParse(uri: "file:///a.txt", version: 1, source: "hello", bridge: bridge)
+        XCTAssertTrue(r1 === r2, "Expected same object on cache hit")
+
+        // Different version — cache miss
+        let r3 = cache.getOrParse(uri: "file:///a.txt", version: 2, source: "hello world", bridge: bridge)
+        XCTAssertFalse(r3 === r1, "Expected different object for new version")
+    }
+
+    func testEvict() {
+        let bridge = MockBridge()
+        let cache = ParseCache()
+
+        let r1 = cache.getOrParse(uri: "file:///a.txt", version: 1, source: "hello", bridge: bridge)
+        cache.evict(uri: "file:///a.txt")
+
+        let r2 = cache.getOrParse(uri: "file:///a.txt", version: 1, source: "hello", bridge: bridge)
+        XCTAssertFalse(r1 === r2, "Expected new result after eviction")
+    }
+
+    func testDiagnosticsPopulated() {
+        let bridge = MockBridge()
+        let cache = ParseCache()
+
+        let result = cache.getOrParse(uri: "file:///a.txt", version: 1, source: "source with ERROR token", bridge: bridge)
+        XCTAssertFalse(result.diagnostics.isEmpty, "Expected diagnostics for ERROR source")
+    }
+}
+
+// ============================================================================
+// Capabilities Tests
+// ============================================================================
+
+final class CapabilitiesTests: XCTestCase {
+
+    func testMinimalBridge() {
+        let bridge = MinimalBridge()
+        let caps = buildCapabilities(bridge)
+
+        // Always present
+        XCTAssertEqual(caps["textDocumentSync"] as? Int, 2)
+
+        // Optional capabilities should NOT be present
+        let optionalCaps = [
+            "hoverProvider", "definitionProvider", "referencesProvider",
+            "completionProvider", "renameProvider", "documentSymbolProvider",
+            "foldingRangeProvider", "signatureHelpProvider",
+            "documentFormattingProvider", "semanticTokensProvider",
+        ]
+        for cap in optionalCaps {
+            XCTAssertNil(caps[cap], "minimal bridge should not advertise \(cap)")
+        }
+    }
+
+    func testFullBridge() {
+        let bridge = MockBridge()
+        let caps = buildCapabilities(bridge)
+
+        // MockBridge implements HoverProvider and DocumentSymbolsProvider
+        XCTAssertNotNil(caps["hoverProvider"])
+        XCTAssertNotNil(caps["documentSymbolProvider"])
+    }
+}
+
+// ============================================================================
+// Semantic Token Encoding Tests
+// ============================================================================
+
+final class SemanticTokenTests: XCTestCase {
+
+    func testEncodeEmpty() {
+        let data = encodeSemanticTokens([])
+        XCTAssertEqual(data.count, 0)
+    }
+
+    func testEncodeSingleToken() {
+        let tokens = [
+            SemanticToken(line: 0, character: 0, length: 5, tokenType: "keyword"),
+        ]
+        let data = encodeSemanticTokens(tokens)
+
+        // Expected: [0, 0, 5, 15, 0]
+        XCTAssertEqual(data.count, 5)
+        XCTAssertEqual(data[0], 0, "deltaLine")
+        XCTAssertEqual(data[1], 0, "deltaChar")
+        XCTAssertEqual(data[2], 5, "length")
+        XCTAssertEqual(data[3], 15, "keyword = index 15")
+        XCTAssertEqual(data[4], 0, "no modifiers")
+    }
+
+    func testEncodeMultipleTokensSameLine() {
+        let tokens = [
+            SemanticToken(line: 0, character: 0, length: 3, tokenType: "keyword"),
+            SemanticToken(line: 0, character: 4, length: 4, tokenType: "function", modifiers: ["declaration"]),
+        ]
+        let data = encodeSemanticTokens(tokens)
+
+        XCTAssertEqual(data.count, 10)
+        // Token A: [0, 0, 3, 15, 0]
+        XCTAssertEqual(Array(data[0..<5]), [0, 0, 3, 15, 0])
+        // Token B: [0, 4, 4, 12, 1] (function=12, declaration=bit0=1)
+        XCTAssertEqual(Array(data[5..<10]), [0, 4, 4, 12, 1])
+    }
+
+    func testEncodeMultipleLines() {
+        let tokens = [
+            SemanticToken(line: 0, character: 0, length: 3, tokenType: "keyword"),
+            SemanticToken(line: 2, character: 4, length: 5, tokenType: "number"),
+        ]
+        let data = encodeSemanticTokens(tokens)
+
+        XCTAssertEqual(data.count, 10)
+        // Token B: deltaLine=2, deltaChar=4 (absolute on new line), number=19
+        XCTAssertEqual(data[5], 2, "deltaLine for token B")
+        XCTAssertEqual(data[6], 4, "deltaChar for token B (absolute)")
+        XCTAssertEqual(data[8], 19, "number = index 19")
+    }
+
+    func testEncodeUnsortedInput() {
+        // Tokens in reverse order — encoder should sort them
+        let tokens = [
+            SemanticToken(line: 2, character: 0, length: 3, tokenType: "keyword"),
+            SemanticToken(line: 0, character: 0, length: 5, tokenType: "string"),
+        ]
+        let data = encodeSemanticTokens(tokens)
+
+        XCTAssertEqual(data.count, 10)
+        // First token should be line 0 (string, index 18)
+        XCTAssertEqual(data[0], 0, "first deltaLine")
+        XCTAssertEqual(data[3], 18, "string = index 18")
+        // Second token should be line 2 (keyword, index 15)
+        XCTAssertEqual(data[5], 2, "second deltaLine")
+        XCTAssertEqual(data[8], 15, "keyword = index 15")
+    }
+
+    func testEncodeSkipsUnknownTypes() {
+        let tokens = [
+            SemanticToken(line: 0, character: 0, length: 5, tokenType: "NONEXISTENT"),
+        ]
+        let data = encodeSemanticTokens(tokens)
+        XCTAssertEqual(data.count, 0, "Unknown type should be skipped")
+    }
+}
+
+// ============================================================================
+// Server Integration Tests
+// ============================================================================
+
+final class ServerTests: XCTestCase {
+
+    /// Helper to build a Content-Length-framed JSON-RPC message string.
+    func frame(_ json: String) -> String {
+        let payload = Data(json.utf8)
+        return "Content-Length: \(payload.count)\r\n\r\n" + json
+    }
+
+    func testInitializeReturnsCapabilities() throws {
+        let json = """
+        {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}
+        """
+        let inputData = Data(frame(json).utf8)
+        let output = DataOutput()
+
+        let server = LspServer(bridge: MockBridge(), inputData: inputData, output: output)
+        server.serve()
+
+        let responseStr = output.string
+        XCTAssertTrue(responseStr.contains("capabilities"),
+                       "Expected capabilities in response: \(responseStr)")
+        XCTAssertTrue(responseStr.contains("hoverProvider"),
+                       "Expected hoverProvider for MockBridge: \(responseStr)")
+    }
+
+    func testDidOpenPublishesDiagnostics() throws {
+        let initJson = """
+        {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}
+        """
+        let didOpenJson = """
+        {"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file:///test.bf","languageId":"bf","version":1,"text":"hello world"}}}
+        """
+        let inputData = Data((frame(initJson) + frame(didOpenJson)).utf8)
+        let output = DataOutput()
+
+        let server = LspServer(bridge: MockBridge(), inputData: inputData, output: output)
+        server.serve()
+
+        let responseStr = output.string
+        // Should contain both the initialize response and publishDiagnostics notification
+        XCTAssertTrue(responseStr.contains("capabilities"))
+        XCTAssertTrue(responseStr.contains("publishDiagnostics") || responseStr.contains("diagnostics"),
+                       "Expected diagnostics publication: \(responseStr)")
+    }
+
+    func testDidOpenWithErrorSource() throws {
+        let initJson = """
+        {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}
+        """
+        let didOpenJson = """
+        {"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file:///test.bf","languageId":"bf","version":1,"text":"code with ERROR here"}}}
+        """
+        let inputData = Data((frame(initJson) + frame(didOpenJson)).utf8)
+        let output = DataOutput()
+
+        let server = LspServer(bridge: MockBridge(), inputData: inputData, output: output)
+        server.serve()
+
+        let responseStr = output.string
+        XCTAssertTrue(responseStr.contains("syntax error"),
+                       "Expected error diagnostic in output: \(responseStr)")
+    }
+
+    func testHoverRequest() throws {
+        let initJson = """
+        {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}
+        """
+        let didOpenJson = """
+        {"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file:///test.bf","languageId":"bf","version":1,"text":"hello world"}}}
+        """
+        let hoverJson = """
+        {"jsonrpc":"2.0","id":2,"method":"textDocument/hover","params":{"textDocument":{"uri":"file:///test.bf"},"position":{"line":0,"character":0}}}
+        """
+        let inputData = Data((frame(initJson) + frame(didOpenJson) + frame(hoverJson)).utf8)
+        let output = DataOutput()
+
+        let server = LspServer(bridge: MockBridge(), inputData: inputData, output: output)
+        server.serve()
+
+        let responseStr = output.string
+        XCTAssertTrue(responseStr.contains("test"),
+                       "Expected hover content in response: \(responseStr)")
+    }
+
+    func testDocumentSymbolRequest() throws {
+        let initJson = """
+        {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}
+        """
+        let didOpenJson = """
+        {"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file:///test.bf","languageId":"bf","version":1,"text":"hello world"}}}
+        """
+        let symbolJson = """
+        {"jsonrpc":"2.0","id":2,"method":"textDocument/documentSymbol","params":{"textDocument":{"uri":"file:///test.bf"}}}
+        """
+        let inputData = Data((frame(initJson) + frame(didOpenJson) + frame(symbolJson)).utf8)
+        let output = DataOutput()
+
+        let server = LspServer(bridge: MockBridge(), inputData: inputData, output: output)
+        server.serve()
+
+        let responseStr = output.string
+        XCTAssertTrue(responseStr.contains("main"),
+                       "Expected 'main' symbol in response: \(responseStr)")
+    }
+
+    func testShutdownSetsFlag() throws {
+        let initJson = """
+        {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}
+        """
+        let shutdownJson = """
+        {"jsonrpc":"2.0","id":2,"method":"shutdown","params":null}
+        """
+        let inputData = Data((frame(initJson) + frame(shutdownJson)).utf8)
+        let output = DataOutput()
+
+        let server = LspServer(bridge: MockBridge(), inputData: inputData, output: output)
+        server.serve()
+
+        XCTAssertTrue(server.isShutdown)
+    }
+
+    func testMinimalBridgeCapabilities() throws {
+        let json = """
+        {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}
+        """
+        let inputData = Data(frame(json).utf8)
+        let output = DataOutput()
+
+        let server = LspServer(bridge: MinimalBridge(), inputData: inputData, output: output)
+        server.serve()
+
+        let responseStr = output.string
+        XCTAssertFalse(responseStr.contains("hoverProvider"),
+                        "Minimal bridge should NOT advertise hoverProvider: \(responseStr)")
+    }
+
+    func testDidChangeThenHover() throws {
+        let initJson = """
+        {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}
+        """
+        let didOpenJson = """
+        {"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file:///test.bf","languageId":"bf","version":1,"text":"hello"}}}
+        """
+        let didChangeJson = """
+        {"jsonrpc":"2.0","method":"textDocument/didChange","params":{"textDocument":{"uri":"file:///test.bf","version":2},"contentChanges":[{"text":"hello world"}]}}
+        """
+        let hoverJson = """
+        {"jsonrpc":"2.0","id":2,"method":"textDocument/hover","params":{"textDocument":{"uri":"file:///test.bf"},"position":{"line":0,"character":0}}}
+        """
+        let inputData = Data((frame(initJson) + frame(didOpenJson) + frame(didChangeJson) + frame(hoverJson)).utf8)
+        let output = DataOutput()
+
+        let server = LspServer(bridge: MockBridge(), inputData: inputData, output: output)
+        server.serve()
+
+        let responseStr = output.string
+        XCTAssertTrue(responseStr.contains("test"),
+                       "Expected hover content after change: \(responseStr)")
+    }
+
+    func testDidCloseClearsDiagnostics() throws {
+        let initJson = """
+        {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}
+        """
+        let didOpenJson = """
+        {"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file:///test.bf","languageId":"bf","version":1,"text":"hello ERROR"}}}
+        """
+        let didCloseJson = """
+        {"jsonrpc":"2.0","method":"textDocument/didClose","params":{"textDocument":{"uri":"file:///test.bf"}}}
+        """
+        let inputData = Data((frame(initJson) + frame(didOpenJson) + frame(didCloseJson)).utf8)
+        let output = DataOutput()
+
+        let server = LspServer(bridge: MockBridge(), inputData: inputData, output: output)
+        server.serve()
+
+        // After close, the document should be gone from the manager
+        XCTAssertNil(server.docManager.get(uri: "file:///test.bf"))
+    }
+}
+
+// ============================================================================
+// Semantic Token Legend Tests
+// ============================================================================
+
+final class SemanticTokenLegendTests: XCTestCase {
+
+    func testLegendContainsStandardTypes() {
+        let legend = semanticTokenLegend()
+        XCTAssertTrue(legend.tokenTypes.contains("keyword"))
+        XCTAssertTrue(legend.tokenTypes.contains("function"))
+        XCTAssertTrue(legend.tokenTypes.contains("variable"))
+        XCTAssertTrue(legend.tokenTypes.contains("string"))
+        XCTAssertTrue(legend.tokenTypes.contains("number"))
+    }
+
+    func testLegendContainsStandardModifiers() {
+        let legend = semanticTokenLegend()
+        XCTAssertTrue(legend.tokenModifiers.contains("declaration"))
+        XCTAssertTrue(legend.tokenModifiers.contains("definition"))
+        XCTAssertTrue(legend.tokenModifiers.contains("readonly"))
+    }
+
+    func testTokenTypeIndex() {
+        XCTAssertEqual(tokenTypeIndex("keyword"), 15)
+        XCTAssertEqual(tokenTypeIndex("function"), 12)
+        XCTAssertEqual(tokenTypeIndex("variable"), 8)
+        XCTAssertEqual(tokenTypeIndex("NONEXISTENT"), -1)
+    }
+
+    func testTokenModifierMask() {
+        XCTAssertEqual(tokenModifierMask(["declaration"]), 1)    // bit 0
+        XCTAssertEqual(tokenModifierMask(["definition"]), 2)     // bit 1
+        XCTAssertEqual(tokenModifierMask(["declaration", "definition"]), 3) // bits 0+1
+        XCTAssertEqual(tokenModifierMask([]), 0)
+        XCTAssertEqual(tokenModifierMask(["NONEXISTENT"]), 0)
+    }
+}
+
+// ============================================================================
+// LSP Error Codes Tests
+// ============================================================================
+
+final class LspErrorCodesTests: XCTestCase {
+
+    func testErrorCodeValues() {
+        XCTAssertEqual(LspErrorCodes.serverNotInitialized, -32002)
+        XCTAssertEqual(LspErrorCodes.unknownErrorCode, -32001)
+        XCTAssertEqual(LspErrorCodes.requestFailed, -32803)
+        XCTAssertEqual(LspErrorCodes.serverCancelled, -32802)
+        XCTAssertEqual(LspErrorCodes.contentModified, -32801)
+        XCTAssertEqual(LspErrorCodes.requestCancelled, -32800)
+    }
+}

--- a/code/packages/typescript/ls00/BUILD
+++ b/code/packages/typescript/ls00/BUILD
@@ -1,0 +1,1 @@
+cd ../json-rpc && npm install --silent && cd ../ls00 && npm install --silent && npx vitest run

--- a/code/packages/typescript/ls00/CHANGELOG.md
+++ b/code/packages/typescript/ls00/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2026-04-12
+
+### Added
+
+- Initial implementation of the generic LSP framework for TypeScript
+- `LanguageBridge` interface with `tokenize()` and `parse()` as required methods
+- 10 optional provider interfaces: `HoverProvider`, `DefinitionProvider`,
+  `ReferencesProvider`, `CompletionProvider`, `RenameProvider`,
+  `SemanticTokensProvider`, `DocumentSymbolsProvider`, `FoldingRangesProvider`,
+  `SignatureHelpProvider`, `FormatProvider`
+- Type guard functions for runtime capability detection (e.g., `isHoverProvider()`)
+- `DocumentManager` for tracking open file contents with incremental sync
+- `ParseCache` for caching parse results by (URI, version) key
+- `buildCapabilities()` for dynamic capability advertisement based on bridge
+- `encodeSemanticTokens()` for the LSP compact delta encoding
+- `semanticTokenLegend()` with standard LSP token types and modifiers
+- `LspServer` class wiring together bridge, document manager, parse cache,
+  and JSON-RPC server
+- All LSP handlers: lifecycle, text document sync, and feature requests
+- LSP error code constants matching the specification
+- Full type definitions for all LSP data structures
+- Comprehensive test suite covering UTF-16 handling, document management,
+  parse caching, capabilities, semantic token encoding, and full JSON-RPC
+  round-trip integration tests

--- a/code/packages/typescript/ls00/README.md
+++ b/code/packages/typescript/ls00/README.md
@@ -1,0 +1,73 @@
+# @coding-adventures/ls00
+
+Generic Language Server Protocol (LSP) framework for TypeScript.
+
+## What is this?
+
+When you open a source file in VS Code and see red squiggles under syntax errors, autocomplete suggestions, or "Go to Definition" -- none of that is built into the editor. It comes from a *language server*: a separate process that communicates with the editor over the Language Server Protocol.
+
+LSP was invented by Microsoft to solve the M x N problem:
+
+```
+M editors x N languages = M x N integrations to write
+```
+
+With LSP, each language writes one server, and every LSP-aware editor gets all features automatically. This package is the *generic* half -- it handles all the protocol boilerplate. A language author only writes the `LanguageBridge` that connects their lexer/parser to this framework.
+
+## Architecture
+
+```
+Lexer -> Parser -> [LanguageBridge] -> [LspServer] -> VS Code / Neovim / Emacs
+```
+
+## How to use
+
+1. Implement the `LanguageBridge` interface (and any optional provider interfaces) for your language.
+2. Create an `LspServer` with your bridge and stdio streams.
+3. Call `server.serve()` -- it blocks until the editor closes the connection.
+
+```typescript
+import { LspServer } from "@coding-adventures/ls00";
+import type { LanguageBridge, HoverProvider } from "@coding-adventures/ls00";
+
+// A minimal bridge with just tokenize and parse
+const bridge: LanguageBridge = {
+  tokenize(source) { return []; },
+  parse(source) { return [source, []]; },
+};
+
+const server = new LspServer(bridge, process.stdin, process.stdout);
+await server.serve();
+```
+
+## Optional Providers
+
+The framework uses TypeScript's interface system for optional capability detection. Each feature is a separate interface with a type guard function:
+
+| Interface | Feature | Type Guard |
+|-----------|---------|------------|
+| `HoverProvider` | Hover tooltips | `isHoverProvider()` |
+| `DefinitionProvider` | Go to Definition | `isDefinitionProvider()` |
+| `ReferencesProvider` | Find All References | `isReferencesProvider()` |
+| `CompletionProvider` | Autocomplete | `isCompletionProvider()` |
+| `RenameProvider` | Rename Symbol | `isRenameProvider()` |
+| `SemanticTokensProvider` | Semantic Highlighting | `isSemanticTokensProvider()` |
+| `DocumentSymbolsProvider` | Document Outline | `isDocumentSymbolsProvider()` |
+| `FoldingRangesProvider` | Code Folding | `isFoldingRangesProvider()` |
+| `SignatureHelpProvider` | Signature Help | `isSignatureHelpProvider()` |
+| `FormatProvider` | Document Formatting | `isFormatProvider()` |
+
+## Dependencies
+
+- `@coding-adventures/json-rpc` -- JSON-RPC 2.0 transport layer
+
+## How it fits in the stack
+
+This package sits at the top of the compiler pipeline:
+
+```
+code/packages/typescript/json-rpc    -- transport (JSON-RPC 2.0 over stdio)
+code/packages/typescript/ls00        -- THIS PACKAGE (generic LSP framework)
+```
+
+Language-specific packages implement `LanguageBridge` and plug into this framework to create a working language server.

--- a/code/packages/typescript/ls00/package.json
+++ b/code/packages/typescript/ls00/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@coding-adventures/ls00",
+  "version": "0.1.0",
+  "description": "Generic Language Server Protocol (LSP) framework",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "keywords": [
+    "lsp",
+    "language-server-protocol",
+    "editor",
+    "ide",
+    "computer-science",
+    "education"
+  ],
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "dependencies": {
+    "@coding-adventures/json-rpc": "file:../json-rpc"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/ls00/src/capabilities.ts
+++ b/code/packages/typescript/ls00/src/capabilities.ts
@@ -1,0 +1,290 @@
+/**
+ * capabilities.ts -- BuildCapabilities, SemanticTokenLegend, and encodeSemanticTokens
+ *
+ * # What Are Capabilities?
+ *
+ * During the LSP initialize handshake, the server sends back a "capabilities"
+ * object telling the editor which LSP features it supports. The editor uses this
+ * to decide which requests to send. If a capability is absent, the editor won't
+ * send the corresponding requests -- so no "Go to Definition" button appears
+ * unless definitionProvider is true.
+ *
+ * Building capabilities dynamically (based on the bridge's interface
+ * implementations) means the server is always honest about what it can do.
+ *
+ * # Semantic Token Legend
+ *
+ * Semantic tokens use a compact binary encoding. Instead of sending
+ * {"type":"keyword"} per token, LSP sends an integer index into a legend.
+ * The legend must be declared in the capabilities so the editor knows what
+ * each index means.
+ *
+ * @module
+ */
+
+import type { LanguageBridge } from "./language-bridge.js";
+import type { SemanticToken } from "./types.js";
+import {
+  isHoverProvider,
+  isDefinitionProvider,
+  isReferencesProvider,
+  isCompletionProvider,
+  isRenameProvider,
+  isDocumentSymbolsProvider,
+  isFoldingRangesProvider,
+  isSignatureHelpProvider,
+  isFormatProvider,
+  isSemanticTokensProvider,
+} from "./language-bridge.js";
+
+// ---------------------------------------------------------------------------
+// BuildCapabilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Inspect the bridge at runtime and return the LSP capabilities object
+ * to include in the initialize response.
+ *
+ * Uses TypeScript type guard functions to check which optional provider
+ * interfaces the bridge implements. Only advertises capabilities for
+ * features the bridge actually supports.
+ */
+export function buildCapabilities(bridge: LanguageBridge): Record<string, unknown> {
+  // textDocumentSync=2 means "incremental": the editor sends only changed
+  // ranges, not the full file, on every keystroke.
+  const caps: Record<string, unknown> = {
+    textDocumentSync: 2,
+  };
+
+  if (isHoverProvider(bridge)) {
+    caps.hoverProvider = true;
+  }
+
+  if (isDefinitionProvider(bridge)) {
+    caps.definitionProvider = true;
+  }
+
+  if (isReferencesProvider(bridge)) {
+    caps.referencesProvider = true;
+  }
+
+  if (isCompletionProvider(bridge)) {
+    // completionProvider is an object, not a boolean, because it can include
+    // triggerCharacters: which chars auto-trigger completions.
+    caps.completionProvider = {
+      triggerCharacters: [" ", "."],
+    };
+  }
+
+  if (isRenameProvider(bridge)) {
+    caps.renameProvider = true;
+  }
+
+  if (isDocumentSymbolsProvider(bridge)) {
+    caps.documentSymbolProvider = true;
+  }
+
+  if (isFoldingRangesProvider(bridge)) {
+    caps.foldingRangeProvider = true;
+  }
+
+  if (isSignatureHelpProvider(bridge)) {
+    caps.signatureHelpProvider = {
+      triggerCharacters: ["(", ","],
+    };
+  }
+
+  if (isFormatProvider(bridge)) {
+    caps.documentFormattingProvider = true;
+  }
+
+  if (isSemanticTokensProvider(bridge)) {
+    caps.semanticTokensProvider = {
+      legend: semanticTokenLegend(),
+      full: true,
+    };
+  }
+
+  return caps;
+}
+
+// ---------------------------------------------------------------------------
+// Semantic Token Legend
+// ---------------------------------------------------------------------------
+
+/**
+ * SemanticTokenLegendData holds the legend arrays for semantic tokens.
+ * The editor uses these to decode the compact integer encoding.
+ */
+export interface SemanticTokenLegendData {
+  tokenTypes: string[];
+  tokenModifiers: string[];
+}
+
+/**
+ * Return the full legend for all supported semantic token types and modifiers.
+ *
+ * # Why a Fixed Legend?
+ *
+ * The legend is sent once in the capabilities response. Afterwards, each
+ * semantic token is encoded as an integer index into this legend rather than
+ * a string. This makes the per-token encoding much smaller.
+ *
+ * The ordering matters: index 0 in tokenTypes corresponds to "namespace",
+ * index 1 to "type", etc. These match the standard LSP token types.
+ */
+export function semanticTokenLegend(): SemanticTokenLegendData {
+  return {
+    // Standard LSP token types (in the order VS Code expects them).
+    // Source: https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide
+    tokenTypes: [
+      "namespace",     // 0
+      "type",          // 1
+      "class",         // 2
+      "enum",          // 3
+      "interface",     // 4
+      "struct",        // 5
+      "typeParameter", // 6
+      "parameter",     // 7
+      "variable",      // 8
+      "property",      // 9
+      "enumMember",    // 10
+      "event",         // 11
+      "function",      // 12
+      "method",        // 13
+      "macro",         // 14
+      "keyword",       // 15
+      "modifier",      // 16
+      "comment",       // 17
+      "string",        // 18
+      "number",        // 19
+      "regexp",        // 20
+      "operator",      // 21
+      "decorator",     // 22
+    ],
+    // Standard LSP token modifiers (bitmask flags).
+    // tokenModifier[0] = "declaration" -> bit 0 (value 1)
+    // tokenModifier[1] = "definition"  -> bit 1 (value 2)
+    // etc.
+    tokenModifiers: [
+      "declaration",   // bit 0
+      "definition",    // bit 1
+      "readonly",      // bit 2
+      "static",        // bit 3
+      "deprecated",    // bit 4
+      "abstract",      // bit 5
+      "async",         // bit 6
+      "modification",  // bit 7
+      "documentation", // bit 8
+      "defaultLibrary", // bit 9
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Encoding helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the integer index for a semantic token type string.
+ * Returns -1 if the type is not in the legend (the caller should skip such tokens).
+ */
+export function tokenTypeIndex(tokenType: string): number {
+  const legend = semanticTokenLegend();
+  return legend.tokenTypes.indexOf(tokenType);
+}
+
+/**
+ * Return the bitmask for a list of modifier strings.
+ *
+ * The LSP semantic tokens encoding represents modifiers as a bitmask:
+ *   - "declaration" -> bit 0 -> value 1
+ *   - "definition"  -> bit 1 -> value 2
+ *   - both          -> value 3 (bitwise OR)
+ *
+ * Unknown modifiers are silently ignored.
+ */
+export function tokenModifierMask(modifiers: string[]): number {
+  const legend = semanticTokenLegend();
+  let mask = 0;
+  for (const mod of modifiers) {
+    const idx = legend.tokenModifiers.indexOf(mod);
+    if (idx !== -1) {
+      mask |= (1 << idx);
+    }
+  }
+  return mask;
+}
+
+/**
+ * Convert an array of SemanticToken values to the LSP compact integer encoding.
+ *
+ * # The LSP Semantic Token Encoding
+ *
+ * LSP encodes semantic tokens as a flat array of integers, grouped in 5-tuples:
+ *
+ *   [deltaLine, deltaStartChar, length, tokenTypeIndex, tokenModifierBitmask, ...]
+ *
+ * Where "delta" means: the difference from the PREVIOUS token's position.
+ * This delta encoding makes most values small (often 0 or 1), which compresses
+ * well and is efficient to parse.
+ *
+ * Example: three tokens on different lines:
+ *
+ *   Token A: line=0, char=0, len=3, type="keyword",  modifiers=[]
+ *   Token B: line=0, char=4, len=5, type="function", modifiers=["declaration"]
+ *   Token C: line=1, char=0, len=8, type="variable", modifiers=[]
+ *
+ * Encoded as:
+ *   [0, 0, 3, 15, 0,   // A: deltaLine=0, deltaChar=0 (first token)
+ *    0, 4, 5, 12, 1,   // B: deltaLine=0, deltaChar=4 (same line, 4 chars later)
+ *    1, 0, 8,  8, 0]   // C: deltaLine=1, deltaChar=0 (next line, reset to abs)
+ *
+ * Note: when deltaLine > 0, deltaStartChar is relative to column 0 of the new line
+ * (i.e., absolute for that line). When deltaLine == 0, deltaStartChar is relative
+ * to the previous token's start character.
+ */
+export function encodeSemanticTokens(tokens: SemanticToken[]): number[] {
+  if (tokens.length === 0) {
+    return [];
+  }
+
+  // Sort by (line, character) ascending. The delta encoding requires tokens
+  // to be in document order -- otherwise the deltas would be negative.
+  const sorted = [...tokens].sort((a, b) => {
+    if (a.line !== b.line) return a.line - b.line;
+    return a.character - b.character;
+  });
+
+  const data: number[] = [];
+  let prevLine = 0;
+  let prevChar = 0;
+
+  for (const tok of sorted) {
+    const typeIdx = tokenTypeIndex(tok.tokenType);
+    if (typeIdx === -1) {
+      // Unknown token type -- skip it. The client wouldn't know what to do
+      // with an index outside the legend anyway.
+      continue;
+    }
+
+    const deltaLine = tok.line - prevLine;
+    let deltaChar: number;
+    if (deltaLine === 0) {
+      // Same line: character offset is relative to previous token.
+      deltaChar = tok.character - prevChar;
+    } else {
+      // Different line: character offset is absolute (relative to line start).
+      deltaChar = tok.character;
+    }
+
+    const modMask = tokenModifierMask(tok.modifiers ?? []);
+
+    data.push(deltaLine, deltaChar, tok.length, typeIdx, modMask);
+
+    prevLine = tok.line;
+    prevChar = tok.character;
+  }
+
+  return data;
+}

--- a/code/packages/typescript/ls00/src/document-manager.ts
+++ b/code/packages/typescript/ls00/src/document-manager.ts
@@ -1,0 +1,217 @@
+/**
+ * document-manager.ts -- DocumentManager and UTF-16 offset handling
+ *
+ * # The Document Manager's Job
+ *
+ * When the user opens a file in VS Code, the editor sends a textDocument/didOpen
+ * notification with the full file content. From that point on, the editor does
+ * NOT re-send the entire file on every keystroke. Instead, it sends incremental
+ * changes: what changed, and where. The DocumentManager applies these changes to
+ * maintain the current text of each open file.
+ *
+ *   Editor opens file:   didOpen   -> DocumentManager stores text at version 1
+ *   User types "X":      didChange -> DocumentManager applies delta -> version 2
+ *   User saves:          didSave   -> (optional: trigger format)
+ *   User closes:         didClose  -> DocumentManager removes entry
+ *
+ * # Why Version Numbers?
+ *
+ * The editor increments the version number with every change. The ParseCache
+ * uses (uri, version) as its cache key -- if the version matches, the cached
+ * parse result is still valid.
+ *
+ * # UTF-16 in JavaScript
+ *
+ * JavaScript strings ARE UTF-16 internally. This means:
+ *   - `string.length` gives UTF-16 code units (not Unicode codepoints)
+ *   - `string.charCodeAt(i)` gives the UTF-16 code unit at index i
+ *   - LSP character offsets map directly to JavaScript string indices
+ *
+ * For most operations, the LSP character offset IS the JavaScript string index.
+ * However, when we need to convert to byte offsets (e.g., for Buffer operations),
+ * we must account for the fact that UTF-8 byte counts differ from UTF-16 unit counts.
+ *
+ * The key insight: in JavaScript, LSP's `character` offset can be used directly
+ * as a string index -- no conversion needed! A surrogate pair (emoji) is two
+ * UTF-16 code units in both LSP and JavaScript, so string.slice(0, character)
+ * gives the correct prefix.
+ *
+ * @module
+ */
+
+import type { Position, Range, TextChange } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Document -- one open file
+// ---------------------------------------------------------------------------
+
+/**
+ * Document represents an open file tracked by the DocumentManager.
+ */
+export interface Document {
+  uri: string;
+  text: string;    // current content
+  version: number; // monotonically increasing; matches LSP's document version
+}
+
+// ---------------------------------------------------------------------------
+// DocumentManager -- tracks all open files
+// ---------------------------------------------------------------------------
+
+/**
+ * DocumentManager tracks all files currently open in the editor.
+ *
+ * The editor sends open/change/close notifications; this manager keeps the
+ * authoritative current text of each file. The ParseCache and all feature
+ * handlers read from this manager to get the source text to work on.
+ */
+export class DocumentManager {
+  /** Map from URI to Document. */
+  private docs: Map<string, Document> = new Map();
+
+  /**
+   * Open records a newly opened file.
+   *
+   * Called when the editor sends textDocument/didOpen. Stores the initial text
+   * and version number (typically 1 for a freshly opened file).
+   */
+  open(uri: string, text: string, version: number): void {
+    this.docs.set(uri, { uri, text, version });
+  }
+
+  /**
+   * ApplyChanges applies a list of incremental changes to an open document.
+   *
+   * Changes are applied in order. If a range is undefined, the change replaces
+   * the entire document. After all changes, the document's version is updated.
+   *
+   * Throws an error if the document is not open, or if a range is invalid.
+   */
+  applyChanges(uri: string, changes: TextChange[], version: number): void {
+    const doc = this.docs.get(uri);
+    if (!doc) {
+      throw new Error(`document not open: ${uri}`);
+    }
+
+    for (const change of changes) {
+      if (change.range === undefined) {
+        // Full document replacement -- simplest case.
+        doc.text = change.newText;
+      } else {
+        // Incremental update: splice new text at the specified range.
+        doc.text = applyRangeChange(doc.text, change.range, change.newText);
+      }
+    }
+
+    doc.version = version;
+  }
+
+  /**
+   * Get returns the document for a URI, or undefined if not open.
+   */
+  get(uri: string): Document | undefined {
+    return this.docs.get(uri);
+  }
+
+  /**
+   * Close removes a document from the manager.
+   *
+   * Called when the editor sends textDocument/didClose. After this, the document's
+   * text is no longer tracked.
+   */
+  close(uri: string): void {
+    this.docs.delete(uri);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Range application -- splicing text at LSP coordinates
+// ---------------------------------------------------------------------------
+
+/**
+ * applyRangeChange splices newText into text at the given LSP range.
+ *
+ * It converts LSP's (line, UTF-16-character) coordinates to string indices
+ * (which ARE UTF-16 in JavaScript), then performs the splice.
+ */
+function applyRangeChange(text: string, range: Range, newText: string): string {
+  const startIdx = convertPositionToStringIndex(text, range.start);
+  const endIdx = convertPositionToStringIndex(text, range.end);
+
+  if (startIdx > endIdx) {
+    throw new Error(`start offset ${startIdx} > end offset ${endIdx}`);
+  }
+
+  return text.slice(0, startIdx) + newText + text.slice(endIdx);
+}
+
+// ---------------------------------------------------------------------------
+// Position -> string index conversion
+// ---------------------------------------------------------------------------
+
+/**
+ * convertPositionToStringIndex converts an LSP Position (0-based line, UTF-16 char)
+ * to a JavaScript string index.
+ *
+ * Since JavaScript strings ARE UTF-16, the `character` field from LSP maps
+ * directly to the string index within a line. We just need to find the start
+ * of the target line, then add the character offset.
+ *
+ * Algorithm:
+ *  1. Walk line-by-line to find the string index of the start of the target line.
+ *  2. From that index, advance `character` positions (clamped to line end).
+ */
+export function convertPositionToStringIndex(text: string, pos: Position): number {
+  let lineStart = 0;
+  let currentLine = 0;
+
+  // Phase 1: find the string index of the start of pos.line.
+  while (currentLine < pos.line) {
+    const idx = text.indexOf("\n", lineStart);
+    if (idx === -1) {
+      // Line number exceeds the number of lines in the file. Clamp to end.
+      return text.length;
+    }
+    lineStart = idx + 1; // character AFTER the newline
+    currentLine++;
+  }
+
+  // Phase 2: from lineStart, advance pos.character UTF-16 code units.
+  // In JavaScript, each string index IS one UTF-16 code unit, so we can
+  // simply add pos.character -- but we must clamp to the line end.
+  const lineEnd = text.indexOf("\n", lineStart);
+  const lineLength = lineEnd === -1 ? text.length - lineStart : lineEnd - lineStart;
+
+  const charOffset = Math.min(pos.character, lineLength);
+  return lineStart + charOffset;
+}
+
+/**
+ * convertUTF16OffsetToByteOffset converts a 0-based (line, UTF-16 char) position
+ * to a byte offset in a UTF-8 encoding of the string.
+ *
+ * This is needed when interfacing with systems that count bytes (like Node.js
+ * Buffers) rather than UTF-16 code units.
+ *
+ * # Why this function exists
+ *
+ * Even though JavaScript strings are UTF-16 (making LSP offsets easy to use
+ * as string indices), sometimes we need byte offsets -- for example, when
+ * computing Content-Length for JSON-RPC framing or when interfacing with
+ * native code that uses UTF-8.
+ *
+ * # Example
+ *
+ *     const text = "hello \u{1F3B8} world";
+ *     // \u{1F3B8} (guitar emoji) is 2 UTF-16 code units but 4 UTF-8 bytes.
+ *     // After the emoji, LSP says character=8 (6 for "hello ", 2 for emoji).
+ *     // But in UTF-8, " world" starts at byte 11 (6 + 4 + 1 for the space).
+ *     const byteOff = convertUTF16OffsetToByteOffset(text, 0, 8);
+ *     // byteOff = 11
+ */
+export function convertUTF16OffsetToByteOffset(text: string, line: number, char: number): number {
+  const strIndex = convertPositionToStringIndex(text, { line, character: char });
+  // Get the substring up to the target position and count its UTF-8 bytes.
+  const prefix = text.slice(0, strIndex);
+  return Buffer.byteLength(prefix, "utf8");
+}

--- a/code/packages/typescript/ls00/src/handlers.ts
+++ b/code/packages/typescript/ls00/src/handlers.ts
@@ -1,0 +1,697 @@
+/**
+ * handlers.ts -- All LSP request and notification handlers
+ *
+ * This module contains every handler the LspServer registers with the JSON-RPC
+ * server. They are organized by lifecycle stage:
+ *
+ *   1. Lifecycle: initialize, initialized, shutdown, exit
+ *   2. Text document sync: didOpen, didChange, didClose, didSave
+ *   3. Feature requests: hover, definition, references, completion, rename,
+ *      documentSymbol, semanticTokens/full, foldingRange, signatureHelp, formatting
+ *
+ * Each handler extracts parameters from the raw JSON-RPC params object, delegates
+ * to the bridge (via the ParseCache), and returns a result in LSP format.
+ *
+ * # Handler Patterns
+ *
+ * Request handlers return `unknown` (the result) or throw. The Server class
+ * in json-rpc wraps thrown errors into JSON-RPC error responses.
+ *
+ * Notification handlers return void. Even if they fail, no response is sent
+ * (the LSP spec forbids it).
+ *
+ * @module
+ */
+
+import type { LanguageBridge } from "./language-bridge.js";
+import {
+  isHoverProvider,
+  isDefinitionProvider,
+  isReferencesProvider,
+  isCompletionProvider,
+  isRenameProvider,
+  isDocumentSymbolsProvider,
+  isFoldingRangesProvider,
+  isSignatureHelpProvider,
+  isFormatProvider,
+  isSemanticTokensProvider,
+} from "./language-bridge.js";
+import type { DocumentManager, Document } from "./document-manager.js";
+import type { ParseCache, ParseResult } from "./parse-cache.js";
+import type {
+  Position,
+  Range,
+  Diagnostic,
+  DocumentSymbol,
+  TextChange,
+} from "./types.js";
+import { buildCapabilities } from "./capabilities.js";
+import { encodeSemanticTokens } from "./capabilities.js";
+import { LspErrorCodes } from "./lsp-errors.js";
+
+// ---------------------------------------------------------------------------
+// Handler context -- shared state passed to all handlers
+// ---------------------------------------------------------------------------
+
+/**
+ * HandlerContext holds the shared state that all handlers need access to.
+ * This is created by the LspServer and passed to each handler function.
+ */
+export interface HandlerContext {
+  bridge: LanguageBridge;
+  docManager: DocumentManager;
+  parseCache: ParseCache;
+  sendNotification: (method: string, params: unknown) => void;
+  isInitialized: () => boolean;
+  setInitialized: (v: boolean) => void;
+  isShutdown: () => boolean;
+  setShutdown: (v: boolean) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helper functions
+// ---------------------------------------------------------------------------
+
+/** Extract a Position from params that have a "position" field. */
+function parsePosition(params: Record<string, unknown>): Position {
+  const pos = (params.position ?? {}) as Record<string, unknown>;
+  return {
+    line: Number(pos.line ?? 0),
+    character: Number(pos.character ?? 0),
+  };
+}
+
+/** Extract the document URI from params that have a textDocument field. */
+function parseURI(params: Record<string, unknown>): string {
+  const td = (params.textDocument ?? {}) as Record<string, unknown>;
+  return String(td.uri ?? "");
+}
+
+/** Convert our Position to a JSON-serializable object. */
+function positionToLSP(p: Position): Record<string, unknown> {
+  return { line: p.line, character: p.character };
+}
+
+/** Convert our Range to a JSON-serializable object. */
+function rangeToLSP(r: Range): Record<string, unknown> {
+  return { start: positionToLSP(r.start), end: positionToLSP(r.end) };
+}
+
+/** Convert a Location to a JSON-serializable object. */
+function locationToLSP(loc: { uri: string; range: Range }): Record<string, unknown> {
+  return { uri: loc.uri, range: rangeToLSP(loc.range) };
+}
+
+/** Parse a raw JSON range object from the LSP protocol. */
+function parseLSPRange(raw: unknown): Range {
+  const m = (raw ?? {}) as Record<string, unknown>;
+  const startMap = (m.start ?? {}) as Record<string, unknown>;
+  const endMap = (m.end ?? {}) as Record<string, unknown>;
+
+  return {
+    start: { line: Number(startMap.line ?? 0), character: Number(startMap.character ?? 0) },
+    end: { line: Number(endMap.line ?? 0), character: Number(endMap.character ?? 0) },
+  };
+}
+
+/**
+ * Get the current parse result for a document.
+ * This is the hot path for all feature handlers.
+ */
+function getParseResult(
+  ctx: HandlerContext,
+  uri: string,
+): { doc: Document; result: ParseResult } {
+  const doc = ctx.docManager.get(uri);
+  if (!doc) {
+    throw { code: LspErrorCodes.RequestFailed, message: `document not open: ${uri}` };
+  }
+  const result = ctx.parseCache.getOrParse(uri, doc.version, doc.text, ctx.bridge);
+  return { doc, result };
+}
+
+/**
+ * Publish diagnostics for a document to the editor.
+ *
+ * LSP servers push diagnostics proactively after every parse to update
+ * the editor's squiggle underlines.
+ */
+function publishDiagnostics(
+  ctx: HandlerContext,
+  uri: string,
+  version: number,
+  diagnostics: Diagnostic[],
+): void {
+  const lspDiags = diagnostics.map((d) => {
+    const diag: Record<string, unknown> = {
+      range: rangeToLSP(d.range),
+      severity: d.severity,
+      message: d.message,
+    };
+    if (d.code) {
+      diag.code = d.code;
+    }
+    return diag;
+  });
+
+  const params: Record<string, unknown> = {
+    uri,
+    diagnostics: lspDiags,
+  };
+  if (version > 0) {
+    params.version = version;
+  }
+
+  ctx.sendNotification("textDocument/publishDiagnostics", params);
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle handlers
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle the LSP initialize request.
+ *
+ * This is the server's first message. We store the client info (for logging)
+ * and return our capabilities built from the bridge.
+ */
+export function handleInitialize(
+  ctx: HandlerContext,
+  _id: string | number,
+  _params: unknown,
+): unknown {
+  ctx.setInitialized(true);
+
+  const caps = buildCapabilities(ctx.bridge);
+
+  return {
+    capabilities: caps,
+    serverInfo: {
+      name: "ls00-generic-lsp-server",
+      version: "0.1.0",
+    },
+  };
+}
+
+/**
+ * Handle the "initialized" notification.
+ *
+ * This is the editor's acknowledgment that it received our capabilities.
+ * No-op: the handshake is complete.
+ */
+export function handleInitialized(
+  _ctx: HandlerContext,
+  _params: unknown,
+): void {
+  // No-op
+}
+
+/**
+ * Handle the LSP shutdown request.
+ *
+ * After receiving shutdown, the server should stop processing new requests
+ * and return null.
+ */
+export function handleShutdown(
+  ctx: HandlerContext,
+  _id: string | number,
+  _params: unknown,
+): unknown {
+  ctx.setShutdown(true);
+  return null;
+}
+
+/**
+ * Handle the "exit" notification.
+ *
+ * Exit code semantics (from the LSP spec):
+ *   - 0: shutdown was received before exit -> clean shutdown
+ *   - 1: shutdown was NOT received -> abnormal termination
+ */
+export function handleExit(
+  ctx: HandlerContext,
+  _params: unknown,
+): void {
+  const exitCode = ctx.isShutdown() ? 0 : 1;
+  process.exit(exitCode);
+}
+
+// ---------------------------------------------------------------------------
+// Text document synchronization handlers
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle textDocument/didOpen -- the editor opened a file.
+ *
+ * Params: {"textDocument": {"uri": "...", "languageId": "...", "version": 1, "text": "..."}}
+ */
+export function handleDidOpen(
+  ctx: HandlerContext,
+  params: unknown,
+): void {
+  const p = params as Record<string, unknown>;
+  const td = (p.textDocument ?? {}) as Record<string, unknown>;
+
+  const uri = String(td.uri ?? "");
+  const text = String(td.text ?? "");
+  let version = 1;
+  if (typeof td.version === "number") {
+    version = td.version;
+  }
+
+  if (!uri) return;
+
+  ctx.docManager.open(uri, text, version);
+
+  // Parse immediately and push diagnostics so the editor shows squiggles
+  // as soon as the file is opened.
+  const result = ctx.parseCache.getOrParse(uri, version, text, ctx.bridge);
+  publishDiagnostics(ctx, uri, version, result.diagnostics);
+}
+
+/**
+ * Handle textDocument/didChange -- the user edited a file.
+ *
+ * Params: {"textDocument": {"uri": "...", "version": 2}, "contentChanges": [...]}
+ */
+export function handleDidChange(
+  ctx: HandlerContext,
+  params: unknown,
+): void {
+  const p = params as Record<string, unknown>;
+  const uri = parseURI(p);
+  if (!uri) return;
+
+  let version = 0;
+  const td = (p.textDocument ?? {}) as Record<string, unknown>;
+  if (typeof td.version === "number") {
+    version = td.version;
+  }
+
+  // Parse the content changes array.
+  const changesRaw = (p.contentChanges ?? []) as unknown[];
+  const changes: TextChange[] = [];
+
+  for (const changeRaw of changesRaw) {
+    const changeMap = changeRaw as Record<string, unknown>;
+    const newText = String(changeMap.text ?? "");
+    const change: TextChange = { newText };
+
+    if (changeMap.range !== undefined && changeMap.range !== null) {
+      change.range = parseLSPRange(changeMap.range);
+    }
+
+    changes.push(change);
+  }
+
+  // Apply the changes to the document manager.
+  try {
+    ctx.docManager.applyChanges(uri, changes, version);
+  } catch {
+    // Document wasn't open (e.g., a race condition). Ignore.
+    return;
+  }
+
+  // Get the updated text and re-parse.
+  const doc = ctx.docManager.get(uri);
+  if (!doc) return;
+
+  const result = ctx.parseCache.getOrParse(uri, doc.version, doc.text, ctx.bridge);
+  publishDiagnostics(ctx, uri, version, result.diagnostics);
+}
+
+/**
+ * Handle textDocument/didClose -- the editor closed a file.
+ *
+ * We remove the document from our manager and evict its parse cache entry.
+ * We also clear diagnostics by publishing an empty list.
+ */
+export function handleDidClose(
+  ctx: HandlerContext,
+  params: unknown,
+): void {
+  const p = params as Record<string, unknown>;
+  const uri = parseURI(p);
+  if (!uri) return;
+
+  ctx.docManager.close(uri);
+  ctx.parseCache.evict(uri);
+
+  // Clear diagnostics for the closed file.
+  publishDiagnostics(ctx, uri, 0, []);
+}
+
+/**
+ * Handle textDocument/didSave -- the editor saved a file.
+ *
+ * If the client sends full text in didSave, apply it. Otherwise, just
+ * republish diagnostics from the current parse state.
+ */
+export function handleDidSave(
+  ctx: HandlerContext,
+  params: unknown,
+): void {
+  const p = params as Record<string, unknown>;
+  const uri = parseURI(p);
+  if (!uri) return;
+
+  const text = p.text;
+  if (typeof text === "string" && text !== "") {
+    const doc = ctx.docManager.get(uri);
+    if (doc) {
+      ctx.docManager.close(uri);
+      ctx.docManager.open(uri, text, doc.version);
+      const result = ctx.parseCache.getOrParse(uri, doc.version, text, ctx.bridge);
+      publishDiagnostics(ctx, uri, doc.version, result.diagnostics);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Feature request handlers
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle textDocument/hover -- show tooltip on mouse-over.
+ */
+export function handleHover(
+  ctx: HandlerContext,
+  _id: string | number,
+  params: unknown,
+): unknown {
+  const p = params as Record<string, unknown>;
+  const uri = parseURI(p);
+  const pos = parsePosition(p);
+
+  if (!isHoverProvider(ctx.bridge)) {
+    return null;
+  }
+
+  const { result: parseResult } = getParseResult(ctx, uri);
+  if (parseResult.ast == null) return null;
+
+  const hoverResult = ctx.bridge.hover(parseResult.ast, pos);
+  if (!hoverResult) return null;
+
+  const result: Record<string, unknown> = {
+    contents: { kind: "markdown", value: hoverResult.contents },
+  };
+
+  if (hoverResult.range) {
+    result.range = rangeToLSP(hoverResult.range);
+  }
+
+  return result;
+}
+
+/**
+ * Handle textDocument/definition -- Go to Definition (F12).
+ */
+export function handleDefinition(
+  ctx: HandlerContext,
+  _id: string | number,
+  params: unknown,
+): unknown {
+  const p = params as Record<string, unknown>;
+  const uri = parseURI(p);
+  const pos = parsePosition(p);
+
+  if (!isDefinitionProvider(ctx.bridge)) return null;
+
+  const { result: parseResult } = getParseResult(ctx, uri);
+  if (parseResult.ast == null) return null;
+
+  const location = ctx.bridge.definition(parseResult.ast, pos, uri);
+  if (!location) return null;
+
+  return locationToLSP(location);
+}
+
+/**
+ * Handle textDocument/references -- Find All References.
+ */
+export function handleReferences(
+  ctx: HandlerContext,
+  _id: string | number,
+  params: unknown,
+): unknown {
+  const p = params as Record<string, unknown>;
+  const uri = parseURI(p);
+  const pos = parsePosition(p);
+
+  // Extract includeDeclaration from the context object.
+  let includeDecl = false;
+  const ctxObj = p.context as Record<string, unknown> | undefined;
+  if (ctxObj && typeof ctxObj.includeDeclaration === "boolean") {
+    includeDecl = ctxObj.includeDeclaration;
+  }
+
+  if (!isReferencesProvider(ctx.bridge)) return [];
+
+  const { result: parseResult } = getParseResult(ctx, uri);
+  if (parseResult.ast == null) return [];
+
+  const locations = ctx.bridge.references(parseResult.ast, pos, uri, includeDecl);
+  return locations.map(locationToLSP);
+}
+
+/**
+ * Handle textDocument/completion -- autocomplete.
+ */
+export function handleCompletion(
+  ctx: HandlerContext,
+  _id: string | number,
+  params: unknown,
+): unknown {
+  const p = params as Record<string, unknown>;
+  const uri = parseURI(p);
+  const pos = parsePosition(p);
+
+  if (!isCompletionProvider(ctx.bridge)) {
+    return { isIncomplete: false, items: [] };
+  }
+
+  const { result: parseResult } = getParseResult(ctx, uri);
+  if (parseResult.ast == null) {
+    return { isIncomplete: false, items: [] };
+  }
+
+  const items = ctx.bridge.completion(parseResult.ast, pos);
+
+  const lspItems = items.map((item) => {
+    const ci: Record<string, unknown> = { label: item.label };
+    if (item.kind) ci.kind = item.kind;
+    if (item.detail) ci.detail = item.detail;
+    if (item.documentation) ci.documentation = item.documentation;
+    if (item.insertText) ci.insertText = item.insertText;
+    if (item.insertTextFormat) ci.insertTextFormat = item.insertTextFormat;
+    return ci;
+  });
+
+  return { isIncomplete: false, items: lspItems };
+}
+
+/**
+ * Handle textDocument/rename -- symbol rename (F2).
+ */
+export function handleRename(
+  ctx: HandlerContext,
+  _id: string | number,
+  params: unknown,
+): unknown {
+  const p = params as Record<string, unknown>;
+  const uri = parseURI(p);
+  const pos = parsePosition(p);
+  const newName = String(p.newName ?? "");
+
+  if (!newName) {
+    throw { code: -32602, message: "newName is required" };
+  }
+
+  if (!isRenameProvider(ctx.bridge)) {
+    throw { code: LspErrorCodes.RequestFailed, message: "rename not supported" };
+  }
+
+  const { result: parseResult } = getParseResult(ctx, uri);
+  if (parseResult.ast == null) {
+    throw { code: LspErrorCodes.RequestFailed, message: "no AST available" };
+  }
+
+  const edit = ctx.bridge.rename(parseResult.ast, pos, newName);
+  if (!edit) {
+    throw { code: LspErrorCodes.RequestFailed, message: "symbol not found at position" };
+  }
+
+  // Convert WorkspaceEdit to LSP format.
+  const lspChanges: Record<string, unknown[]> = {};
+  for (const [editURI, edits] of Object.entries(edit.changes)) {
+    lspChanges[editURI] = edits.map((te) => ({
+      range: rangeToLSP(te.range),
+      newText: te.newText,
+    }));
+  }
+
+  return { changes: lspChanges };
+}
+
+/**
+ * Handle textDocument/documentSymbol -- outline panel.
+ */
+export function handleDocumentSymbol(
+  ctx: HandlerContext,
+  _id: string | number,
+  params: unknown,
+): unknown {
+  const p = params as Record<string, unknown>;
+  const uri = parseURI(p);
+
+  if (!isDocumentSymbolsProvider(ctx.bridge)) return [];
+
+  const { result: parseResult } = getParseResult(ctx, uri);
+  if (parseResult.ast == null) return [];
+
+  const symbols = ctx.bridge.documentSymbols(parseResult.ast);
+  return convertDocumentSymbols(symbols);
+}
+
+/**
+ * Recursively convert DocumentSymbol arrays to JSON-serializable objects.
+ */
+function convertDocumentSymbols(symbols: DocumentSymbol[]): unknown[] {
+  return symbols.map((sym) => {
+    const m: Record<string, unknown> = {
+      name: sym.name,
+      kind: sym.kind,
+      range: rangeToLSP(sym.range),
+      selectionRange: rangeToLSP(sym.selectionRange),
+    };
+    if (sym.children && sym.children.length > 0) {
+      m.children = convertDocumentSymbols(sym.children);
+    }
+    return m;
+  });
+}
+
+/**
+ * Handle textDocument/semanticTokens/full -- semantic highlighting.
+ */
+export function handleSemanticTokensFull(
+  ctx: HandlerContext,
+  _id: string | number,
+  params: unknown,
+): unknown {
+  const p = params as Record<string, unknown>;
+  const uri = parseURI(p);
+
+  if (!isSemanticTokensProvider(ctx.bridge)) {
+    return { data: [] };
+  }
+
+  const doc = ctx.docManager.get(uri);
+  if (!doc) return { data: [] };
+
+  // Tokenize the source to get raw tokens for the bridge.
+  const tokens = ctx.bridge.tokenize(doc.text);
+
+  // Ask the bridge to map tokens to semantic types.
+  const semTokens = ctx.bridge.semanticTokens(doc.text, tokens);
+
+  // Encode using the compact LSP delta format.
+  const data = encodeSemanticTokens(semTokens);
+
+  return { data };
+}
+
+/**
+ * Handle textDocument/foldingRange -- code folding.
+ */
+export function handleFoldingRange(
+  ctx: HandlerContext,
+  _id: string | number,
+  params: unknown,
+): unknown {
+  const p = params as Record<string, unknown>;
+  const uri = parseURI(p);
+
+  if (!isFoldingRangesProvider(ctx.bridge)) return [];
+
+  const { result: parseResult } = getParseResult(ctx, uri);
+  if (parseResult.ast == null) return [];
+
+  const ranges = ctx.bridge.foldingRanges(parseResult.ast);
+
+  return ranges.map((fr) => {
+    const m: Record<string, unknown> = {
+      startLine: fr.startLine,
+      endLine: fr.endLine,
+    };
+    if (fr.kind) m.kind = fr.kind;
+    return m;
+  });
+}
+
+/**
+ * Handle textDocument/signatureHelp -- function signature tooltip.
+ */
+export function handleSignatureHelp(
+  ctx: HandlerContext,
+  _id: string | number,
+  params: unknown,
+): unknown {
+  const p = params as Record<string, unknown>;
+  const uri = parseURI(p);
+  const pos = parsePosition(p);
+
+  if (!isSignatureHelpProvider(ctx.bridge)) return null;
+
+  const { result: parseResult } = getParseResult(ctx, uri);
+  if (parseResult.ast == null) return null;
+
+  const sigHelp = ctx.bridge.signatureHelp(parseResult.ast, pos);
+  if (!sigHelp) return null;
+
+  // Convert to LSP format.
+  const lspSigs = sigHelp.signatures.map((sig) => {
+    const lspParams = (sig.parameters ?? []).map((param) => {
+      const pp: Record<string, unknown> = { label: param.label };
+      if (param.documentation) pp.documentation = param.documentation;
+      return pp;
+    });
+    const s: Record<string, unknown> = {
+      label: sig.label,
+      parameters: lspParams,
+    };
+    if (sig.documentation) s.documentation = sig.documentation;
+    return s;
+  });
+
+  return {
+    signatures: lspSigs,
+    activeSignature: sigHelp.activeSignature,
+    activeParameter: sigHelp.activeParameter,
+  };
+}
+
+/**
+ * Handle textDocument/formatting -- document formatting.
+ */
+export function handleFormatting(
+  ctx: HandlerContext,
+  _id: string | number,
+  params: unknown,
+): unknown {
+  const p = params as Record<string, unknown>;
+  const uri = parseURI(p);
+
+  if (!isFormatProvider(ctx.bridge)) return [];
+
+  const doc = ctx.docManager.get(uri);
+  if (!doc) return [];
+
+  const edits = ctx.bridge.format(doc.text);
+
+  return edits.map((edit) => ({
+    range: rangeToLSP(edit.range),
+    newText: edit.newText,
+  }));
+}

--- a/code/packages/typescript/ls00/src/index.ts
+++ b/code/packages/typescript/ls00/src/index.ts
@@ -1,0 +1,121 @@
+/**
+ * @coding-adventures/ls00
+ *
+ * Generic Language Server Protocol (LSP) framework.
+ *
+ * This package implements the generic half of a language server. Language-specific
+ * "bridges" plug into this framework by implementing the LanguageBridge interface
+ * (and any optional provider interfaces). The framework handles all LSP protocol
+ * boilerplate: lifecycle, document sync, capability negotiation, and JSON-RPC transport.
+ *
+ * Architecture
+ * ------------
+ *
+ *   Lexer -> Parser -> [LanguageBridge] -> [LspServer] -> VS Code / Neovim / Emacs
+ *
+ * Quick start
+ * -----------
+ *
+ *     import { LspServer } from "@coding-adventures/ls00";
+ *     import type { LanguageBridge } from "@coding-adventures/ls00";
+ *
+ *     const bridge: LanguageBridge = {
+ *       tokenize(source) { return []; },
+ *       parse(source) { return [source, []]; },
+ *     };
+ *
+ *     const server = new LspServer(bridge, process.stdin, process.stdout);
+ *     await server.serve();
+ *
+ * Public exports
+ * --------------
+ *
+ *   LspServer           -- the main server class
+ *   LanguageBridge       -- required interface for language implementations
+ *   HoverProvider, etc.  -- optional provider interfaces
+ *   isHoverProvider, etc -- type guard functions for capability detection
+ *   buildCapabilities    -- build capabilities object from a bridge
+ *   encodeSemanticTokens -- encode semantic tokens to LSP compact format
+ *   semanticTokenLegend  -- the semantic token legend
+ *   DocumentManager      -- tracks open file contents
+ *   ParseCache           -- caches parse results by (uri, version)
+ *   LspErrorCodes        -- LSP-specific error code constants
+ *   All LSP types        -- Position, Range, Diagnostic, Token, etc.
+ *
+ * @module
+ */
+
+// Types
+export {
+  type Position,
+  type Range,
+  type Location,
+  DiagnosticSeverity,
+  type Diagnostic,
+  type Token,
+  type TextEdit,
+  type WorkspaceEdit,
+  type HoverResult,
+  CompletionItemKind,
+  type CompletionItem,
+  type SemanticToken,
+  SymbolKind,
+  type DocumentSymbol,
+  type FoldingRange,
+  type ParameterInformation,
+  type SignatureInformation,
+  type SignatureHelpResult,
+  type TextChange,
+} from "./types.js";
+
+// Language bridge interfaces and type guards
+export {
+  type LanguageBridge,
+  type HoverProvider,
+  type DefinitionProvider,
+  type ReferencesProvider,
+  type CompletionProvider,
+  type RenameProvider,
+  type SemanticTokensProvider,
+  type DocumentSymbolsProvider,
+  type FoldingRangesProvider,
+  type SignatureHelpProvider,
+  type FormatProvider,
+  isHoverProvider,
+  isDefinitionProvider,
+  isReferencesProvider,
+  isCompletionProvider,
+  isRenameProvider,
+  isSemanticTokensProvider,
+  isDocumentSymbolsProvider,
+  isFoldingRangesProvider,
+  isSignatureHelpProvider,
+  isFormatProvider,
+} from "./language-bridge.js";
+
+// Document manager
+export {
+  DocumentManager,
+  type Document,
+  convertPositionToStringIndex,
+  convertUTF16OffsetToByteOffset,
+} from "./document-manager.js";
+
+// Parse cache
+export { ParseCache, type ParseResult } from "./parse-cache.js";
+
+// Capabilities
+export {
+  buildCapabilities,
+  semanticTokenLegend,
+  type SemanticTokenLegendData,
+  encodeSemanticTokens,
+  tokenTypeIndex,
+  tokenModifierMask,
+} from "./capabilities.js";
+
+// LSP error codes
+export { LspErrorCodes } from "./lsp-errors.js";
+
+// Server
+export { LspServer } from "./server.js";

--- a/code/packages/typescript/ls00/src/language-bridge.ts
+++ b/code/packages/typescript/ls00/src/language-bridge.ts
@@ -1,0 +1,227 @@
+/**
+ * language-bridge.ts -- LanguageBridge and optional provider interfaces
+ *
+ * # Design Philosophy: Narrow Interfaces
+ *
+ * TypeScript's interface system naturally supports the narrow-interface pattern.
+ * We define one required interface (LanguageBridge) plus many small optional
+ * provider interfaces. At runtime, the server checks whether the bridge object
+ * also satisfies a provider interface using type guard functions.
+ *
+ * Compare two approaches:
+ *
+ *   APPROACH A -- fat interface (one big interface, every method required):
+ *
+ *     interface LanguageBridge {
+ *       tokenize(source: string): Token[];
+ *       parse(source: string): [unknown, Diagnostic[]];
+ *       hover(ast: unknown, pos: Position): HoverResult | null;
+ *       definition(ast: unknown, pos: Position, uri: string): Location | null;
+ *       // ... 8 more methods, all REQUIRED
+ *     }
+ *
+ *     Problem: a language that only has a lexer and parser must implement ALL
+ *     methods, even the symbol-table features it doesn't have yet.
+ *
+ *   APPROACH B -- narrow interfaces (what we use):
+ *
+ *     interface LanguageBridge {
+ *       tokenize(source: string): Token[];
+ *       parse(source: string): [unknown, Diagnostic[]];
+ *     }
+ *     interface HoverProvider { hover(...): HoverResult | null; }
+ *     interface DefinitionProvider { definition(...): Location | null; }
+ *
+ *     At runtime, the server checks: does bridge satisfy HoverProvider?
+ *     If yes -> advertise hoverProvider:true and call bridge.hover().
+ *     If no  -> omit hover from capabilities. No stubs required.
+ *
+ * # Runtime Capability Detection
+ *
+ * Detection uses TypeScript type guard functions:
+ *
+ *     function isHoverProvider(b: LanguageBridge): b is LanguageBridge & HoverProvider {
+ *       return 'hover' in b && typeof (b as any).hover === 'function';
+ *     }
+ *
+ * The `is` return type annotation is a "type predicate" -- it tells TypeScript
+ * that after calling `isHoverProvider(bridge)` and getting true, the variable
+ * `bridge` can be used as `LanguageBridge & HoverProvider` in the true branch.
+ *
+ * @module
+ */
+
+import type {
+  Token,
+  Diagnostic,
+  Position,
+  Location,
+  HoverResult,
+  CompletionItem,
+  WorkspaceEdit,
+  SemanticToken,
+  DocumentSymbol,
+  FoldingRange,
+  SignatureHelpResult,
+  TextEdit,
+} from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Required interface -- every language bridge must implement this
+// ---------------------------------------------------------------------------
+
+/**
+ * LanguageBridge is the required minimum interface every language must implement.
+ *
+ * `tokenize` and `parse` are the foundation for all other features:
+ *   - `tokenize` drives semantic token highlighting (accurate syntax coloring)
+ *   - `parse` drives diagnostics, folding, and document symbols
+ *
+ * All other features (hover, go-to-definition, etc.) are optional and declared
+ * as separate interfaces below. The LspServer checks at runtime whether the
+ * bridge also implements those interfaces.
+ */
+export interface LanguageBridge {
+  /**
+   * Lex the source string and return the token stream.
+   *
+   * The tokens are used for semantic highlighting. Each Token carries a `type`
+   * string (e.g. "KEYWORD", "IDENTIFIER"), its `value`, and its 1-based `line`
+   * and `column` position. The bridge is responsible for converting 1-based
+   * positions to 0-based before building SemanticToken values.
+   */
+  tokenize(source: string): Token[];
+
+  /**
+   * Parse the source string and return:
+   *   - ast:         the parsed abstract syntax tree (may be partial on error)
+   *   - diagnostics: parse errors and warnings as LSP Diagnostic objects
+   *
+   * Even when there are syntax errors, `parse` should return a partial AST.
+   * This allows hover, folding, and symbol features to continue working on
+   * the valid portions of the file.
+   *
+   * The AST type is `unknown` because each language's parser returns its
+   * own concrete AST type. The bridge is responsible for downcasting.
+   */
+  parse(source: string): [unknown, Diagnostic[]];
+}
+
+// ---------------------------------------------------------------------------
+// Optional Provider Interfaces
+// ---------------------------------------------------------------------------
+//
+// Each of the following interfaces represents one optional LSP feature.
+// A bridge implements only the features its language supports.
+// The server uses type guard functions to detect support at runtime.
+//
+// None of these interfaces extend LanguageBridge -- they are purely additive.
+// A bridge object simply implements whichever methods it needs.
+
+/** HoverProvider enables hover tooltips. */
+export interface HoverProvider {
+  hover(ast: unknown, pos: Position): HoverResult | null;
+}
+
+/** DefinitionProvider enables "Go to Definition" (F12 in VS Code). */
+export interface DefinitionProvider {
+  definition(ast: unknown, pos: Position, uri: string): Location | null;
+}
+
+/** ReferencesProvider enables "Find All References". */
+export interface ReferencesProvider {
+  references(ast: unknown, pos: Position, uri: string, includeDecl: boolean): Location[];
+}
+
+/** CompletionProvider enables autocomplete suggestions. */
+export interface CompletionProvider {
+  completion(ast: unknown, pos: Position): CompletionItem[];
+}
+
+/** RenameProvider enables symbol rename (F2 in VS Code). */
+export interface RenameProvider {
+  rename(ast: unknown, pos: Position, newName: string): WorkspaceEdit | null;
+}
+
+/** SemanticTokensProvider enables accurate syntax highlighting. */
+export interface SemanticTokensProvider {
+  semanticTokens(source: string, tokens: Token[]): SemanticToken[];
+}
+
+/** DocumentSymbolsProvider enables the document outline panel. */
+export interface DocumentSymbolsProvider {
+  documentSymbols(ast: unknown): DocumentSymbol[];
+}
+
+/** FoldingRangesProvider enables code folding (collapsible blocks). */
+export interface FoldingRangesProvider {
+  foldingRanges(ast: unknown): FoldingRange[];
+}
+
+/** SignatureHelpProvider enables function signature hints. */
+export interface SignatureHelpProvider {
+  signatureHelp(ast: unknown, pos: Position): SignatureHelpResult | null;
+}
+
+/** FormatProvider enables document formatting (Format on Save). */
+export interface FormatProvider {
+  format(source: string): TextEdit[];
+}
+
+// ---------------------------------------------------------------------------
+// Type guard functions -- runtime capability detection
+// ---------------------------------------------------------------------------
+//
+// Each type guard checks whether the bridge object has the relevant method.
+// The `bridge is LanguageBridge & XxxProvider` return type is a TypeScript
+// "type predicate" that narrows the type in conditional branches.
+
+/** Check if the bridge implements hover tooltips. */
+export function isHoverProvider(bridge: LanguageBridge): bridge is LanguageBridge & HoverProvider {
+  return "hover" in bridge && typeof (bridge as Record<string, unknown>).hover === "function";
+}
+
+/** Check if the bridge implements go-to-definition. */
+export function isDefinitionProvider(bridge: LanguageBridge): bridge is LanguageBridge & DefinitionProvider {
+  return "definition" in bridge && typeof (bridge as Record<string, unknown>).definition === "function";
+}
+
+/** Check if the bridge implements find-all-references. */
+export function isReferencesProvider(bridge: LanguageBridge): bridge is LanguageBridge & ReferencesProvider {
+  return "references" in bridge && typeof (bridge as Record<string, unknown>).references === "function";
+}
+
+/** Check if the bridge implements autocomplete. */
+export function isCompletionProvider(bridge: LanguageBridge): bridge is LanguageBridge & CompletionProvider {
+  return "completion" in bridge && typeof (bridge as Record<string, unknown>).completion === "function";
+}
+
+/** Check if the bridge implements rename. */
+export function isRenameProvider(bridge: LanguageBridge): bridge is LanguageBridge & RenameProvider {
+  return "rename" in bridge && typeof (bridge as Record<string, unknown>).rename === "function";
+}
+
+/** Check if the bridge implements semantic tokens. */
+export function isSemanticTokensProvider(bridge: LanguageBridge): bridge is LanguageBridge & SemanticTokensProvider {
+  return "semanticTokens" in bridge && typeof (bridge as Record<string, unknown>).semanticTokens === "function";
+}
+
+/** Check if the bridge implements document symbols (outline). */
+export function isDocumentSymbolsProvider(bridge: LanguageBridge): bridge is LanguageBridge & DocumentSymbolsProvider {
+  return "documentSymbols" in bridge && typeof (bridge as Record<string, unknown>).documentSymbols === "function";
+}
+
+/** Check if the bridge implements code folding. */
+export function isFoldingRangesProvider(bridge: LanguageBridge): bridge is LanguageBridge & FoldingRangesProvider {
+  return "foldingRanges" in bridge && typeof (bridge as Record<string, unknown>).foldingRanges === "function";
+}
+
+/** Check if the bridge implements signature help. */
+export function isSignatureHelpProvider(bridge: LanguageBridge): bridge is LanguageBridge & SignatureHelpProvider {
+  return "signatureHelp" in bridge && typeof (bridge as Record<string, unknown>).signatureHelp === "function";
+}
+
+/** Check if the bridge implements formatting. */
+export function isFormatProvider(bridge: LanguageBridge): bridge is LanguageBridge & FormatProvider {
+  return "format" in bridge && typeof (bridge as Record<string, unknown>).format === "function";
+}

--- a/code/packages/typescript/ls00/src/lsp-errors.ts
+++ b/code/packages/typescript/ls00/src/lsp-errors.ts
@@ -1,0 +1,49 @@
+/**
+ * lsp-errors.ts -- LSP-specific error codes
+ *
+ * The JSON-RPC 2.0 specification reserves error codes in the range [-32768, -32000].
+ * The LSP specification further reserves [-32899, -32800] for LSP protocol-level errors.
+ *
+ * Standard JSON-RPC error codes (from the json-rpc package):
+ *   -32700  ParseError
+ *   -32600  InvalidRequest
+ *   -32601  MethodNotFound
+ *   -32602  InvalidParams
+ *   -32603  InternalError
+ *
+ * LSP-specific error codes are listed below.
+ *
+ * Reference: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#errorCodes
+ *
+ * @module
+ */
+
+export const LspErrorCodes = {
+  /**
+   * The server has received a request before the initialize handshake was
+   * completed. The server must reject any request (other than initialize)
+   * before it has been initialized.
+   */
+  ServerNotInitialized: -32002,
+
+  /** A generic error code for unknown errors. */
+  UnknownErrorCode: -32001,
+
+  /**
+   * A request failed but not due to a protocol problem.
+   * For example, the document requested was not found.
+   */
+  RequestFailed: -32803,
+
+  /** The server cancelled the request. */
+  ServerCancelled: -32802,
+
+  /**
+   * The document content was modified before the request completed.
+   * The client should retry.
+   */
+  ContentModified: -32801,
+
+  /** The client cancelled the request. */
+  RequestCancelled: -32800,
+} as const;

--- a/code/packages/typescript/ls00/src/parse-cache.ts
+++ b/code/packages/typescript/ls00/src/parse-cache.ts
@@ -1,0 +1,129 @@
+/**
+ * parse-cache.ts -- ParseCache: avoid re-parsing unchanged documents
+ *
+ * # Why Cache Parse Results?
+ *
+ * Parsing is the most expensive operation in a language server. For a large
+ * file, parsing on every keystroke would lag the editor noticeably.
+ *
+ * The LSP protocol helps by sending a version number with every change. If the
+ * document hasn't changed (same URI, same version), the parse result from the
+ * previous keystroke is still valid.
+ *
+ * # Cache Key Design
+ *
+ * The cache key is `${uri}::${version}`. Version is a monotonically increasing
+ * integer that the editor increments with each change. Using version in the key:
+ *
+ *   - Same (uri, version) -> cache hit -> return cached result
+ *   - Different version   -> cache miss -> re-parse and cache new result
+ *
+ * The old entry is evicted when a new version is cached for the same URI.
+ * This keeps memory bounded at O(open_documents) entries.
+ *
+ * # Concurrency
+ *
+ * The ParseCache is NOT designed for concurrent access. This is intentional:
+ * the LspServer processes one message at a time (single-threaded event loop
+ * in Node.js), so no locking is needed.
+ *
+ * @module
+ */
+
+import type { Diagnostic } from "./types.js";
+import type { LanguageBridge } from "./language-bridge.js";
+
+// ---------------------------------------------------------------------------
+// ParseResult -- the outcome of one parse
+// ---------------------------------------------------------------------------
+
+/**
+ * ParseResult holds the outcome of parsing one version of a document.
+ *
+ * Even on parse error, we store the partial AST and diagnostics so that other
+ * features (hover, folding, symbols) can still work on the valid portions.
+ */
+export interface ParseResult {
+  ast: unknown;            // may be null if the parser couldn't produce any AST
+  diagnostics: Diagnostic[];
+}
+
+// ---------------------------------------------------------------------------
+// ParseCache
+// ---------------------------------------------------------------------------
+
+/**
+ * ParseCache stores the most recent parse result for each open document.
+ *
+ * Create one with `new ParseCache()`. Call `getOrParse()` on every feature
+ * request to get the current (possibly cached) parse result.
+ */
+export class ParseCache {
+  /** The cache maps "${uri}::${version}" -> ParseResult. */
+  private cache: Map<string, ParseResult> = new Map();
+
+  /**
+   * Build the cache key from URI and version.
+   *
+   * We concatenate them with "::" as a separator. Since URIs don't contain "::"
+   * and versions are integers, this is collision-free.
+   */
+  private key(uri: string, version: number): string {
+    return `${uri}::${version}`;
+  }
+
+  /**
+   * GetOrParse returns the parse result for (uri, version).
+   *
+   * If the result is already cached, it is returned immediately without calling
+   * the bridge again. Otherwise, bridge.parse(source) is called, the result is
+   * stored, and the previous cache entry for this URI (if any) is evicted to
+   * prevent unbounded growth.
+   *
+   * This function is the single point of truth for "what is the parsed state of
+   * this document right now?" All feature handlers call it before operating on
+   * the AST.
+   */
+  getOrParse(uri: string, version: number, source: string, bridge: LanguageBridge): ParseResult {
+    const k = this.key(uri, version);
+
+    // Cache hit: the document hasn't changed since last parse.
+    const cached = this.cache.get(k);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    // Cache miss: parse and store. Evict any stale entry for this URI first.
+    this.evictByUri(uri);
+
+    const [ast, diagnostics] = bridge.parse(source);
+
+    const result: ParseResult = {
+      ast,
+      diagnostics: diagnostics ?? [],
+    };
+    this.cache.set(k, result);
+    return result;
+  }
+
+  /**
+   * Evict removes all cached entries for a given URI.
+   *
+   * Called when a document is closed (didClose) so the cache entry is cleaned up.
+   */
+  evict(uri: string): void {
+    this.evictByUri(uri);
+  }
+
+  /**
+   * Internal eviction: removes all keys whose URI prefix matches.
+   */
+  private evictByUri(uri: string): void {
+    const prefix = `${uri}::`;
+    for (const k of this.cache.keys()) {
+      if (k.startsWith(prefix)) {
+        this.cache.delete(k);
+      }
+    }
+  }
+}

--- a/code/packages/typescript/ls00/src/server.ts
+++ b/code/packages/typescript/ls00/src/server.ts
@@ -1,0 +1,187 @@
+/**
+ * server.ts -- LspServer: the main coordinator
+ *
+ * LspServer wires together:
+ *   - The LanguageBridge (language-specific logic)
+ *   - The DocumentManager (tracks open file contents)
+ *   - The ParseCache (avoids redundant parses)
+ *   - The JSON-RPC Server (protocol layer)
+ *
+ * It registers all LSP request and notification handlers with the JSON-RPC
+ * server, then calls serve() to start the blocking read-dispatch-write loop.
+ *
+ * # Server Lifecycle
+ *
+ *   Client (editor)              Server (us)
+ *     |                               |
+ *     |--initialize-------------->    |  store clientInfo, return capabilities
+ *     | <-----------------result-     |
+ *     |                               |
+ *     |--initialized (notif)----->    |  no-op (handshake complete)
+ *     |                               |
+ *     |--textDocument/didOpen---->    |  open doc, parse, push diagnostics
+ *     |--textDocument/didChange-->    |  apply change, re-parse, push diagnostics
+ *     |--textDocument/hover------>    |  get parse result, call bridge.hover
+ *     | <-----------------result-     |
+ *     |                               |
+ *     |--shutdown---------------->    |  set shutdown flag, return null
+ *     |--exit (notif)------------>    |  process.exit(0) or process.exit(1)
+ *
+ * # Sending Notifications to the Editor
+ *
+ * The JSON-RPC Server handles request/response pairs. But the LSP server also
+ * needs to PUSH notifications to the editor (e.g., textDocument/publishDiagnostics).
+ * We do this by holding a reference to the JSON-RPC MessageWriter and calling
+ * writeMessage directly.
+ *
+ * @module
+ */
+
+import { Readable, Writable } from "node:stream";
+import { Server, MessageWriter } from "@coding-adventures/json-rpc";
+import type { LanguageBridge } from "./language-bridge.js";
+import { DocumentManager } from "./document-manager.js";
+import { ParseCache } from "./parse-cache.js";
+import type { HandlerContext } from "./handlers.js";
+import {
+  handleInitialize,
+  handleInitialized,
+  handleShutdown,
+  handleExit,
+  handleDidOpen,
+  handleDidChange,
+  handleDidClose,
+  handleDidSave,
+  handleHover,
+  handleDefinition,
+  handleReferences,
+  handleCompletion,
+  handleRename,
+  handleDocumentSymbol,
+  handleSemanticTokensFull,
+  handleFoldingRange,
+  handleSignatureHelp,
+  handleFormatting,
+} from "./handlers.js";
+
+// ---------------------------------------------------------------------------
+// LspServer
+// ---------------------------------------------------------------------------
+
+/**
+ * LspServer is the main LSP server.
+ *
+ * Create it with `new LspServer(bridge, inStream, outStream)`, then call
+ * `serve()` to start serving. It is designed to be used once per process --
+ * start it, it blocks, it exits.
+ *
+ * @example
+ *     const server = new LspServer(myBridge, process.stdin, process.stdout);
+ *     await server.serve();
+ */
+export class LspServer {
+  private readonly rpcServer: Server;
+  private readonly writer: MessageWriter;
+  private readonly ctx: HandlerContext;
+
+  /** Whether the editor has sent "shutdown". */
+  private shutdown = false;
+  /** Whether the initialize handshake is complete. */
+  private initialized = false;
+
+  constructor(bridge: LanguageBridge, inStream: Readable, outStream: Writable) {
+    this.rpcServer = new Server(inStream, outStream);
+    this.writer = new MessageWriter(outStream);
+
+    // Build the handler context -- a bag of shared state that every handler
+    // can access without needing a reference to the LspServer itself.
+    this.ctx = {
+      bridge,
+      docManager: new DocumentManager(),
+      parseCache: new ParseCache(),
+      sendNotification: (method: string, params: unknown) => {
+        this.writer.writeMessage({
+          type: "notification",
+          method,
+          params,
+        });
+      },
+      isInitialized: () => this.initialized,
+      setInitialized: (v: boolean) => { this.initialized = v; },
+      isShutdown: () => this.shutdown,
+      setShutdown: (v: boolean) => { this.shutdown = v; },
+    };
+
+    this.registerHandlers();
+  }
+
+  /**
+   * Start the blocking JSON-RPC read-dispatch-write loop.
+   *
+   * This call blocks (awaits) until the editor closes the connection (EOF on stdin).
+   * All LSP messages are handled synchronously in this loop.
+   */
+  async serve(): Promise<void> {
+    await this.rpcServer.serve();
+  }
+
+  /**
+   * Wire all LSP method names to their handler functions.
+   *
+   * Requests (have an id, get a response):
+   *   initialize, shutdown, textDocument/hover, textDocument/definition,
+   *   textDocument/references, textDocument/completion, textDocument/rename,
+   *   textDocument/documentSymbol, textDocument/semanticTokens/full,
+   *   textDocument/foldingRange, textDocument/signatureHelp,
+   *   textDocument/formatting
+   *
+   * Notifications (no id, no response):
+   *   initialized, textDocument/didOpen, textDocument/didChange,
+   *   textDocument/didClose, textDocument/didSave
+   */
+  private registerHandlers(): void {
+    const ctx = this.ctx;
+
+    // -- Lifecycle --
+    this.rpcServer.onRequest("initialize", (id, params) =>
+      handleInitialize(ctx, id, params));
+    this.rpcServer.onNotification("initialized", (params) =>
+      handleInitialized(ctx, params));
+    this.rpcServer.onRequest("shutdown", (id, params) =>
+      handleShutdown(ctx, id, params));
+    this.rpcServer.onNotification("exit", (params) =>
+      handleExit(ctx, params));
+
+    // -- Text document synchronization --
+    this.rpcServer.onNotification("textDocument/didOpen", (params) =>
+      handleDidOpen(ctx, params));
+    this.rpcServer.onNotification("textDocument/didChange", (params) =>
+      handleDidChange(ctx, params));
+    this.rpcServer.onNotification("textDocument/didClose", (params) =>
+      handleDidClose(ctx, params));
+    this.rpcServer.onNotification("textDocument/didSave", (params) =>
+      handleDidSave(ctx, params));
+
+    // -- Feature requests --
+    this.rpcServer.onRequest("textDocument/hover", (id, params) =>
+      handleHover(ctx, id, params));
+    this.rpcServer.onRequest("textDocument/definition", (id, params) =>
+      handleDefinition(ctx, id, params));
+    this.rpcServer.onRequest("textDocument/references", (id, params) =>
+      handleReferences(ctx, id, params));
+    this.rpcServer.onRequest("textDocument/completion", (id, params) =>
+      handleCompletion(ctx, id, params));
+    this.rpcServer.onRequest("textDocument/rename", (id, params) =>
+      handleRename(ctx, id, params));
+    this.rpcServer.onRequest("textDocument/documentSymbol", (id, params) =>
+      handleDocumentSymbol(ctx, id, params));
+    this.rpcServer.onRequest("textDocument/semanticTokens/full", (id, params) =>
+      handleSemanticTokensFull(ctx, id, params));
+    this.rpcServer.onRequest("textDocument/foldingRange", (id, params) =>
+      handleFoldingRange(ctx, id, params));
+    this.rpcServer.onRequest("textDocument/signatureHelp", (id, params) =>
+      handleSignatureHelp(ctx, id, params));
+    this.rpcServer.onRequest("textDocument/formatting", (id, params) =>
+      handleFormatting(ctx, id, params));
+  }
+}

--- a/code/packages/typescript/ls00/src/types.ts
+++ b/code/packages/typescript/ls00/src/types.ts
@@ -1,0 +1,372 @@
+/**
+ * types.ts -- all shared LSP data types used across the server
+ *
+ * These types mirror the LSP specification's TypeScript type definitions.
+ * The LSP spec lives at:
+ * https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/
+ *
+ * # Coordinate System
+ *
+ * LSP uses a 0-based, line/character coordinate system. Line 0, character 0 is
+ * the very first character of the file. This differs from most editors (which
+ * display 1-based line numbers) and from our lexer (which emits 1-based tokens).
+ * The LanguageBridge is responsible for converting.
+ *
+ * # UTF-16 Code Units
+ *
+ * LSP's "character" offset is measured in UTF-16 CODE UNITS, not bytes or
+ * Unicode codepoints. This is a historical artifact: VS Code is built on
+ * TypeScript, which uses UTF-16 strings internally. In JavaScript, strings
+ * ARE already UTF-16 internally, so `string.length` gives UTF-16 code units
+ * and `string.charCodeAt()` gives UTF-16 code unit values. This makes offset
+ * conversion simpler than in Go, Rust, or Python.
+ *
+ * @module
+ */
+
+// ---------------------------------------------------------------------------
+// Position and Range -- the two most fundamental LSP types
+// ---------------------------------------------------------------------------
+
+/**
+ * Position is a cursor position in a document.
+ *
+ * Both `line` and `character` are 0-based. `character` is measured in UTF-16
+ * code units (see the module doc above for why).
+ *
+ * Example: in the string "hello guitar-emoji world", the guitar emoji occupies
+ * UTF-16 characters 6 and 7 (it requires two UTF-16 surrogates). "world" starts
+ * at UTF-16 character 8.
+ */
+export interface Position {
+  line: number;
+  character: number;
+}
+
+/**
+ * Range is a span of text in a document, from `start` (inclusive) to `end` (exclusive).
+ *
+ * Analogy: think of it like a text selection. `start` is where the cursor lands
+ * when you click, `end` is where you drag to.
+ */
+export interface Range {
+  start: Position;
+  end: Position;
+}
+
+/**
+ * Location is a position in a specific file.
+ *
+ * URI uses the "file://" scheme, e.g., "file:///home/user/main.ts".
+ */
+export interface Location {
+  uri: string;
+  range: Range;
+}
+
+// ---------------------------------------------------------------------------
+// Diagnostics -- errors, warnings, and hints
+// ---------------------------------------------------------------------------
+
+/**
+ * DiagnosticSeverity represents how serious a diagnostic is.
+ * These match the LSP integer codes.
+ *
+ *   1 = Error (red squiggle)
+ *   2 = Warning (yellow squiggle)
+ *   3 = Information (blue squiggle)
+ *   4 = Hint (dim underline or suggestion)
+ */
+export enum DiagnosticSeverity {
+  /** A hard error; the code cannot run or compile. */
+  Error = 1,
+  /** Potentially problematic, but not blocking. */
+  Warning = 2,
+  /** Informational message. */
+  Information = 3,
+  /** A suggestion (e.g., "consider using const"). */
+  Hint = 4,
+}
+
+/**
+ * Diagnostic is an error, warning, or hint to display in the editor.
+ *
+ * The editor renders diagnostics as underlined squiggles, with the message
+ * shown on hover. Red squiggles = Error, yellow = Warning, blue = Info.
+ */
+export interface Diagnostic {
+  range: Range;
+  severity: DiagnosticSeverity;
+  message: string;
+  /** Optional error code (e.g., "E001"). */
+  code?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Tokens -- lexer output
+// ---------------------------------------------------------------------------
+
+/**
+ * Token is a single lexical token from the language's lexer.
+ *
+ * The bridge's `tokenize()` method returns an array of these. The LSP server
+ * uses tokens to provide semantic syntax highlighting (SemanticTokensProvider).
+ *
+ * Note: `line` and `column` are 1-based (matching most lexers). The bridge must
+ * convert to 0-based when building SemanticToken values for the LSP response.
+ */
+export interface Token {
+  type: string;   // e.g. "KEYWORD", "IDENTIFIER", "STRING_LIT"
+  value: string;  // the actual source text, e.g. "let" or "myVar"
+  line: number;   // 1-based line number
+  column: number; // 1-based column number
+}
+
+// ---------------------------------------------------------------------------
+// Text edits -- used by formatting and rename
+// ---------------------------------------------------------------------------
+
+/**
+ * TextEdit is a single text replacement in a document.
+ *
+ * Used by formatting (replace the whole file) and rename (replace each occurrence).
+ * `newText` replaces the content at `range`. If `newText` is empty, the range is deleted.
+ */
+export interface TextEdit {
+  range: Range;
+  newText: string;
+}
+
+/**
+ * WorkspaceEdit groups TextEdits across potentially multiple files.
+ *
+ * For rename operations that affect a single file, `changes` will have one key.
+ * For multi-file projects, a rename may produce edits across many files.
+ */
+export interface WorkspaceEdit {
+  changes: Record<string, TextEdit[]>; // uri -> edits
+}
+
+// ---------------------------------------------------------------------------
+// Hover -- tooltip on mouse-over
+// ---------------------------------------------------------------------------
+
+/**
+ * HoverResult is the content to show in the hover popup.
+ *
+ * `contents` is Markdown text. VS Code renders it with syntax highlighting,
+ * bold/italic, code blocks, etc. `range` is optional -- if set, it highlights
+ * the symbol in the editor when the hover popup is shown.
+ */
+export interface HoverResult {
+  contents: string; // Markdown
+  range?: Range;
+}
+
+// ---------------------------------------------------------------------------
+// Completion -- autocomplete
+// ---------------------------------------------------------------------------
+
+/**
+ * CompletionItemKind classifies completion items so the editor can show
+ * the right icon (function icon, variable icon, keyword icon, etc.).
+ */
+export enum CompletionItemKind {
+  Text = 1,
+  Method = 2,
+  Function = 3,
+  Constructor = 4,
+  Field = 5,
+  Variable = 6,
+  Class = 7,
+  Interface = 8,
+  Module = 9,
+  Property = 10,
+  Unit = 11,
+  Value = 12,
+  Enum = 13,
+  Keyword = 14,
+  Snippet = 15,
+  Color = 16,
+  File = 17,
+  Reference = 18,
+  Folder = 19,
+  EnumMember = 20,
+  Constant = 21,
+  Struct = 22,
+  Event = 23,
+  Operator = 24,
+  TypeParameter = 25,
+}
+
+/**
+ * CompletionItem is a single autocomplete suggestion.
+ *
+ * When the user triggers autocomplete (e.g., by pressing Ctrl+Space or typing
+ * after a dot), the editor shows a dropdown list of CompletionItems.
+ */
+export interface CompletionItem {
+  label: string;
+  kind?: CompletionItemKind;
+  detail?: string;
+  documentation?: string;
+  insertText?: string;
+  insertTextFormat?: number; // 1=plain, 2=snippet
+}
+
+// ---------------------------------------------------------------------------
+// Semantic tokens -- accurate syntax highlighting
+// ---------------------------------------------------------------------------
+
+/**
+ * SemanticToken is one token's contribution to the semantic highlighting pass.
+ *
+ * Semantic tokens are the "second pass" of syntax highlighting. The editor's
+ * grammar-based highlighter (TextMate/tmLanguage) does a fast regex pass first.
+ * Semantic tokens layer on top with accurate, context-aware type information.
+ *
+ * For example, a variable named `string` is just an IDENTIFIER in the grammar
+ * pass. But semantic tokens can label it as "variable" so the editor gives it
+ * a different color from the built-in keyword "string".
+ *
+ * `line` and `character` are 0-based. `tokenType` and `modifiers` reference
+ * entries in the legend returned by `semanticTokenLegend()`.
+ */
+export interface SemanticToken {
+  line: number;      // 0-based
+  character: number; // 0-based, UTF-16 code units
+  length: number;    // in UTF-16 code units
+  tokenType: string; // must match an entry in the legend's tokenTypes
+  modifiers: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Document symbols -- outline panel
+// ---------------------------------------------------------------------------
+
+/**
+ * SymbolKind classifies document symbols for the outline panel.
+ * These match the LSP integer codes (1-based).
+ */
+export enum SymbolKind {
+  File = 1,
+  Module = 2,
+  Namespace = 3,
+  Package = 4,
+  Class = 5,
+  Method = 6,
+  Property = 7,
+  Field = 8,
+  Constructor = 9,
+  Enum = 10,
+  Interface = 11,
+  Function = 12,
+  Variable = 13,
+  Constant = 14,
+  String = 15,
+  Number = 16,
+  Boolean = 17,
+  Array = 18,
+  Object = 19,
+  Key = 20,
+  Null = 21,
+  EnumMember = 22,
+  Struct = 23,
+  Event = 24,
+  Operator = 25,
+  TypeParameter = 26,
+}
+
+/**
+ * DocumentSymbol is one entry in the document outline panel.
+ *
+ * The outline shows a tree of named symbols (functions, classes, variables).
+ * `children` allows nesting: a class symbol can have method symbols as children.
+ *
+ * `range` covers the entire symbol (including its body). `selectionRange` is the
+ * smaller range of just the symbol's name (used to highlight the name when
+ * the user clicks the outline entry).
+ */
+export interface DocumentSymbol {
+  name: string;
+  kind: SymbolKind;
+  range: Range;
+  selectionRange: Range;
+  children?: DocumentSymbol[];
+}
+
+// ---------------------------------------------------------------------------
+// Folding ranges -- collapsible code blocks
+// ---------------------------------------------------------------------------
+
+/**
+ * FoldingRange is a collapsible region of the document.
+ *
+ * The editor shows a collapse arrow in the gutter next to `startLine`. When
+ * collapsed, lines startLine+1 through endLine are hidden. `kind` is one of
+ * "region", "imports", or "comment".
+ */
+export interface FoldingRange {
+  startLine: number; // 0-based
+  endLine: number;   // 0-based
+  kind?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Signature help -- function signature tooltip
+// ---------------------------------------------------------------------------
+
+/**
+ * ParameterInformation is one parameter in a function signature.
+ */
+export interface ParameterInformation {
+  label: string;
+  documentation?: string;
+}
+
+/**
+ * SignatureInformation is one function overload's full signature.
+ */
+export interface SignatureInformation {
+  label: string;
+  documentation?: string;
+  parameters?: ParameterInformation[];
+}
+
+/**
+ * SignatureHelpResult is shown as a tooltip when the user is typing a function call.
+ *
+ * It shows the function signature with the current parameter highlighted.
+ * `activeSignature` indexes into `signatures`. `activeParameter` indexes into
+ * that signature's `parameters`.
+ *
+ * Example: typing `foo(a, |` (cursor after the comma) would show Signatures[0]
+ * with activeParameter=1 (highlighting the second parameter).
+ */
+export interface SignatureHelpResult {
+  signatures: SignatureInformation[];
+  activeSignature: number;
+  activeParameter: number;
+}
+
+// ---------------------------------------------------------------------------
+// Text change -- incremental document updates
+// ---------------------------------------------------------------------------
+
+/**
+ * TextChange describes one incremental change to a document.
+ *
+ * If `range` is undefined, `newText` replaces the ENTIRE document content (full sync).
+ * If `range` is defined, `newText` replaces just the specified range (incremental sync).
+ *
+ * The LSP textDocumentSync capability controls which mode the editor uses:
+ *   - textDocumentSync=1: full sync (range is always undefined)
+ *   - textDocumentSync=2: incremental sync (range specifies what changed)
+ *
+ * We advertise textDocumentSync=2 (incremental) in our capabilities, but
+ * we handle both modes for robustness.
+ */
+export interface TextChange {
+  range?: Range; // undefined = full replacement
+  newText: string;
+}

--- a/code/packages/typescript/ls00/tests/capabilities.test.ts
+++ b/code/packages/typescript/ls00/tests/capabilities.test.ts
@@ -1,0 +1,271 @@
+/**
+ * capabilities.test.ts -- Capabilities and type guard tests
+ *
+ * Tests cover:
+ *   - MinimalBridge: only textDocumentSync, no optional capabilities
+ *   - MockBridge with hover + documentSymbols: those capabilities present
+ *   - FullMockBridge with all providers: all capabilities present
+ *   - SemanticTokenLegend consistency
+ *   - LSP error code constants
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  buildCapabilities,
+  semanticTokenLegend,
+} from "../src/capabilities.js";
+import { LspErrorCodes } from "../src/lsp-errors.js";
+import type { LanguageBridge, HoverProvider, DocumentSymbolsProvider } from "../src/language-bridge.js";
+import type {
+  Token,
+  Diagnostic,
+  Position,
+  HoverResult,
+  DocumentSymbol,
+  Location,
+  CompletionItem,
+  WorkspaceEdit,
+  SemanticToken,
+  FoldingRange,
+  SignatureHelpResult,
+  TextEdit,
+} from "../src/types.js";
+import { SymbolKind, CompletionItemKind } from "../src/types.js";
+
+// ---------------------------------------------------------------------------
+// Test bridges
+// ---------------------------------------------------------------------------
+
+/** MinimalBridge implements ONLY the required LanguageBridge interface. */
+class MinimalBridge implements LanguageBridge {
+  tokenize(_source: string): Token[] { return []; }
+  parse(source: string): [unknown, Diagnostic[]] { return [source, []]; }
+}
+
+/** MockBridge implements LanguageBridge + HoverProvider + DocumentSymbolsProvider. */
+class MockBridge implements LanguageBridge, HoverProvider, DocumentSymbolsProvider {
+  tokenize(source: string): Token[] {
+    const tokens: Token[] = [];
+    let col = 1;
+    for (const word of source.split(/\s+/).filter(Boolean)) {
+      tokens.push({ type: "WORD", value: word, line: 1, column: col });
+      col += word.length + 1;
+    }
+    return tokens;
+  }
+
+  parse(source: string): [unknown, Diagnostic[]] {
+    const diags: Diagnostic[] = [];
+    if (source.includes("ERROR")) {
+      diags.push({
+        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 5 } },
+        severity: 1,
+        message: "syntax error",
+      });
+    }
+    return [source, diags];
+  }
+
+  hover(_ast: unknown, _pos: Position): HoverResult | null {
+    return { contents: "**test**" };
+  }
+
+  documentSymbols(_ast: unknown): DocumentSymbol[] {
+    return [{
+      name: "main",
+      kind: SymbolKind.Function,
+      range: { start: { line: 0, character: 0 }, end: { line: 10, character: 1 } },
+      selectionRange: { start: { line: 0, character: 9 }, end: { line: 0, character: 13 } },
+      children: [{
+        name: "x",
+        kind: SymbolKind.Variable,
+        range: { start: { line: 1, character: 4 }, end: { line: 1, character: 12 } },
+        selectionRange: { start: { line: 1, character: 8 }, end: { line: 1, character: 9 } },
+      }],
+    }];
+  }
+}
+
+/**
+ * FullMockBridge implements every optional provider interface.
+ * Used to test that all capabilities are advertised.
+ */
+class FullMockBridge extends MockBridge {
+  semanticTokens(_source: string, tokens: Token[]): SemanticToken[] {
+    return tokens.map((tok) => ({
+      line: tok.line - 1,
+      character: tok.column - 1,
+      length: tok.value.length,
+      tokenType: "variable",
+      modifiers: [],
+    }));
+  }
+
+  definition(_ast: unknown, pos: Position, uri: string): Location | null {
+    return { uri, range: { start: pos, end: pos } };
+  }
+
+  references(_ast: unknown, pos: Position, uri: string, _includeDecl: boolean): Location[] {
+    return [{ uri, range: { start: pos, end: pos } }];
+  }
+
+  completion(_ast: unknown, _pos: Position): CompletionItem[] {
+    return [{ label: "foo", kind: CompletionItemKind.Function, detail: "() void" }];
+  }
+
+  rename(_ast: unknown, pos: Position, newName: string): WorkspaceEdit | null {
+    return {
+      changes: {
+        "file:///test.txt": [
+          { range: { start: pos, end: pos }, newText: newName },
+        ],
+      },
+    };
+  }
+
+  foldingRanges(_ast: unknown): FoldingRange[] {
+    return [{ startLine: 0, endLine: 5, kind: "region" }];
+  }
+
+  signatureHelp(_ast: unknown, _pos: Position): SignatureHelpResult | null {
+    return {
+      signatures: [{
+        label: "foo(a int, b string)",
+        parameters: [{ label: "a int" }, { label: "b string" }],
+      }],
+      activeSignature: 0,
+      activeParameter: 0,
+    };
+  }
+
+  format(_source: string): TextEdit[] {
+    return [{
+      range: { start: { line: 0, character: 0 }, end: { line: 999, character: 0 } },
+      newText: _source,
+    }];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("buildCapabilities", () => {
+  it("minimal bridge: only textDocumentSync", () => {
+    const caps = buildCapabilities(new MinimalBridge());
+
+    expect(caps.textDocumentSync).toBe(2);
+
+    const optionalCaps = [
+      "hoverProvider", "definitionProvider", "referencesProvider",
+      "completionProvider", "renameProvider", "documentSymbolProvider",
+      "foldingRangeProvider", "signatureHelpProvider",
+      "documentFormattingProvider", "semanticTokensProvider",
+    ];
+    for (const cap of optionalCaps) {
+      expect(caps[cap]).toBeUndefined();
+    }
+  });
+
+  it("mock bridge: hover + documentSymbols advertised", () => {
+    const caps = buildCapabilities(new MockBridge());
+
+    expect(caps.hoverProvider).toBe(true);
+    expect(caps.documentSymbolProvider).toBe(true);
+
+    // Should NOT have capabilities the MockBridge doesn't implement
+    expect(caps.definitionProvider).toBeUndefined();
+    expect(caps.semanticTokensProvider).toBeUndefined();
+  });
+
+  it("full bridge: all capabilities advertised", () => {
+    const caps = buildCapabilities(new FullMockBridge());
+
+    const expected = [
+      "textDocumentSync",
+      "hoverProvider",
+      "definitionProvider",
+      "referencesProvider",
+      "completionProvider",
+      "renameProvider",
+      "documentSymbolProvider",
+      "foldingRangeProvider",
+      "signatureHelpProvider",
+      "documentFormattingProvider",
+      "semanticTokensProvider",
+    ];
+    for (const cap of expected) {
+      expect(caps[cap]).toBeDefined();
+    }
+  });
+
+  it("semanticTokensProvider includes legend and full flag", () => {
+    const caps = buildCapabilities(new FullMockBridge());
+    const stp = caps.semanticTokensProvider as Record<string, unknown>;
+    expect(stp.full).toBe(true);
+    expect(stp.legend).toBeDefined();
+  });
+
+  it("completionProvider includes triggerCharacters", () => {
+    const caps = buildCapabilities(new FullMockBridge());
+    const cp = caps.completionProvider as Record<string, unknown>;
+    expect(cp.triggerCharacters).toEqual([" ", "."]);
+  });
+
+  it("signatureHelpProvider includes triggerCharacters", () => {
+    const caps = buildCapabilities(new FullMockBridge());
+    const shp = caps.signatureHelpProvider as Record<string, unknown>;
+    expect(shp.triggerCharacters).toEqual(["(", ","]);
+  });
+});
+
+describe("semanticTokenLegend", () => {
+  it("has non-empty tokenTypes", () => {
+    const legend = semanticTokenLegend();
+    expect(legend.tokenTypes.length).toBeGreaterThan(0);
+  });
+
+  it("has non-empty tokenModifiers", () => {
+    const legend = semanticTokenLegend();
+    expect(legend.tokenModifiers.length).toBeGreaterThan(0);
+  });
+
+  it("contains required types", () => {
+    const legend = semanticTokenLegend();
+    const required = ["keyword", "string", "number", "variable", "function"];
+    for (const rt of required) {
+      expect(legend.tokenTypes).toContain(rt);
+    }
+  });
+
+  it("contains declaration modifier", () => {
+    const legend = semanticTokenLegend();
+    expect(legend.tokenModifiers).toContain("declaration");
+  });
+});
+
+describe("LspErrorCodes", () => {
+  it("ServerNotInitialized is -32002", () => {
+    expect(LspErrorCodes.ServerNotInitialized).toBe(-32002);
+  });
+
+  it("UnknownErrorCode is -32001", () => {
+    expect(LspErrorCodes.UnknownErrorCode).toBe(-32001);
+  });
+
+  it("RequestFailed is -32803", () => {
+    expect(LspErrorCodes.RequestFailed).toBe(-32803);
+  });
+
+  it("ServerCancelled is -32802", () => {
+    expect(LspErrorCodes.ServerCancelled).toBe(-32802);
+  });
+
+  it("ContentModified is -32801", () => {
+    expect(LspErrorCodes.ContentModified).toBe(-32801);
+  });
+
+  it("RequestCancelled is -32800", () => {
+    expect(LspErrorCodes.RequestCancelled).toBe(-32800);
+  });
+});

--- a/code/packages/typescript/ls00/tests/document-manager.test.ts
+++ b/code/packages/typescript/ls00/tests/document-manager.test.ts
@@ -1,0 +1,175 @@
+/**
+ * document-manager.test.ts -- DocumentManager tests
+ *
+ * Tests cover:
+ *   - Opening and retrieving documents
+ *   - Closing documents
+ *   - Full replacement changes
+ *   - Incremental changes (range-based edits)
+ *   - Incremental changes with emoji (surrogate pairs)
+ *   - Multiple sequential changes
+ *   - Error handling for non-open documents
+ */
+
+import { describe, it, expect } from "vitest";
+import { DocumentManager } from "../src/document-manager.js";
+import type { Range } from "../src/types.js";
+
+describe("DocumentManager", () => {
+  it("open and get", () => {
+    const dm = new DocumentManager();
+    dm.open("file:///test.txt", "hello world", 1);
+
+    const doc = dm.get("file:///test.txt");
+    expect(doc).toBeDefined();
+    expect(doc!.text).toBe("hello world");
+    expect(doc!.version).toBe(1);
+  });
+
+  it("get missing returns undefined", () => {
+    const dm = new DocumentManager();
+    expect(dm.get("file:///nonexistent.txt")).toBeUndefined();
+  });
+
+  it("close removes document", () => {
+    const dm = new DocumentManager();
+    dm.open("file:///test.txt", "hello", 1);
+    dm.close("file:///test.txt");
+    expect(dm.get("file:///test.txt")).toBeUndefined();
+  });
+
+  it("applyChanges full replacement", () => {
+    const dm = new DocumentManager();
+    dm.open("file:///test.txt", "hello world", 1);
+
+    dm.applyChanges("file:///test.txt", [
+      { newText: "goodbye world" },
+    ], 2);
+
+    const doc = dm.get("file:///test.txt");
+    expect(doc!.text).toBe("goodbye world");
+    expect(doc!.version).toBe(2);
+  });
+
+  it("applyChanges incremental", () => {
+    const dm = new DocumentManager();
+    dm.open("file:///test.txt", "hello world", 1);
+
+    // Replace "world" (chars 6-11) with "Go"
+    dm.applyChanges("file:///test.txt", [
+      {
+        range: {
+          start: { line: 0, character: 6 },
+          end: { line: 0, character: 11 },
+        },
+        newText: "Go",
+      },
+    ], 2);
+
+    const doc = dm.get("file:///test.txt");
+    expect(doc!.text).toBe("hello Go");
+  });
+
+  it("applyChanges on non-open document throws", () => {
+    const dm = new DocumentManager();
+    expect(() => {
+      dm.applyChanges("file:///notopen.txt", [{ newText: "x" }], 1);
+    }).toThrow("document not open");
+  });
+
+  it("incremental change with emoji", () => {
+    // "A\u{1F3B8}B" -- emoji is 2 UTF-16 code units
+    // Replace "B" (UTF-16 char 3, string index 3) with "X"
+    const dm = new DocumentManager();
+    dm.open("file:///test.txt", "A\u{1F3B8}B", 1);
+
+    dm.applyChanges("file:///test.txt", [
+      {
+        range: {
+          start: { line: 0, character: 3 },
+          end: { line: 0, character: 4 },
+        },
+        newText: "X",
+      },
+    ], 2);
+
+    const doc = dm.get("file:///test.txt");
+    expect(doc!.text).toBe("A\u{1F3B8}X");
+  });
+
+  it("multiple sequential incremental changes", () => {
+    const dm = new DocumentManager();
+    dm.open("uri", "hello world", 1);
+
+    // Change "hello" to "hi"
+    dm.applyChanges("uri", [
+      {
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 5 },
+        },
+        newText: "hi",
+      },
+    ], 2);
+
+    const doc = dm.get("uri");
+    expect(doc!.text).toBe("hi world");
+  });
+
+  it("multiline incremental change", () => {
+    const dm = new DocumentManager();
+    dm.open("file:///test.txt", "line1\nline2\nline3", 1);
+
+    // Replace "line2" (line 1, chars 0-5) with "REPLACED"
+    dm.applyChanges("file:///test.txt", [
+      {
+        range: {
+          start: { line: 1, character: 0 },
+          end: { line: 1, character: 5 },
+        },
+        newText: "REPLACED",
+      },
+    ], 2);
+
+    const doc = dm.get("file:///test.txt");
+    expect(doc!.text).toBe("line1\nREPLACED\nline3");
+  });
+
+  it("insertion (empty range)", () => {
+    const dm = new DocumentManager();
+    dm.open("file:///test.txt", "helloworld", 1);
+
+    // Insert " " at position 5
+    dm.applyChanges("file:///test.txt", [
+      {
+        range: {
+          start: { line: 0, character: 5 },
+          end: { line: 0, character: 5 },
+        },
+        newText: " ",
+      },
+    ], 2);
+
+    const doc = dm.get("file:///test.txt");
+    expect(doc!.text).toBe("hello world");
+  });
+
+  it("deletion (empty newText)", () => {
+    const dm = new DocumentManager();
+    dm.open("file:///test.txt", "hello world", 1);
+
+    // Delete " world" (chars 5-11)
+    dm.applyChanges("file:///test.txt", [
+      {
+        range: {
+          start: { line: 0, character: 5 },
+          end: { line: 0, character: 11 },
+        },
+        newText: "",
+      },
+    ], 2);
+
+    const doc = dm.get("file:///test.txt");
+    expect(doc!.text).toBe("hello");
+  });
+});

--- a/code/packages/typescript/ls00/tests/parse-cache.test.ts
+++ b/code/packages/typescript/ls00/tests/parse-cache.test.ts
@@ -1,0 +1,113 @@
+/**
+ * parse-cache.test.ts -- ParseCache tests
+ *
+ * Tests cover:
+ *   - Cache miss (first parse)
+ *   - Cache hit (same uri + version returns same result)
+ *   - Cache invalidation (new version triggers re-parse)
+ *   - Manual eviction
+ *   - Diagnostics from parse errors
+ *   - Clean source produces no diagnostics
+ */
+
+import { describe, it, expect } from "vitest";
+import { ParseCache } from "../src/parse-cache.js";
+import type { LanguageBridge } from "../src/language-bridge.js";
+import type { Token, Diagnostic, DiagnosticSeverity } from "../src/types.js";
+
+/**
+ * MinimalBridge for testing -- splits by whitespace and detects "ERROR" in source.
+ */
+const mockBridge: LanguageBridge = {
+  tokenize(source: string): Token[] {
+    const tokens: Token[] = [];
+    let col = 1;
+    for (const word of source.split(/\s+/).filter(Boolean)) {
+      tokens.push({ type: "WORD", value: word, line: 1, column: col });
+      col += word.length + 1;
+    }
+    return tokens;
+  },
+  parse(source: string): [unknown, Diagnostic[]] {
+    const diags: Diagnostic[] = [];
+    if (source.includes("ERROR")) {
+      diags.push({
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 5 },
+        },
+        severity: 1 as DiagnosticSeverity,
+        message: "syntax error: unexpected ERROR token",
+      });
+    }
+    return [source, diags];
+  },
+};
+
+describe("ParseCache", () => {
+  it("cache miss returns fresh parse result", () => {
+    const cache = new ParseCache();
+    const r1 = cache.getOrParse("file:///a.txt", 1, "hello", mockBridge);
+    expect(r1).toBeDefined();
+    expect(r1.ast).toBe("hello");
+  });
+
+  it("cache hit returns same object", () => {
+    const cache = new ParseCache();
+    const r1 = cache.getOrParse("file:///a.txt", 1, "hello", mockBridge);
+    const r2 = cache.getOrParse("file:///a.txt", 1, "hello", mockBridge);
+    expect(r1).toBe(r2); // same reference
+  });
+
+  it("new version causes cache miss", () => {
+    const cache = new ParseCache();
+    const r1 = cache.getOrParse("file:///a.txt", 1, "hello", mockBridge);
+    const r2 = cache.getOrParse("file:///a.txt", 2, "hello world", mockBridge);
+    expect(r1).not.toBe(r2);
+  });
+
+  it("evict removes cached entries", () => {
+    const cache = new ParseCache();
+    const r1 = cache.getOrParse("file:///a.txt", 1, "hello", mockBridge);
+    cache.evict("file:///a.txt");
+    const r2 = cache.getOrParse("file:///a.txt", 1, "hello", mockBridge);
+    expect(r1).not.toBe(r2);
+  });
+
+  it("diagnostics populated for error source", () => {
+    const cache = new ParseCache();
+    const result = cache.getOrParse("file:///a.txt", 1, "source with ERROR token", mockBridge);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("no diagnostics for clean source", () => {
+    const cache = new ParseCache();
+    const result = cache.getOrParse("file:///clean.txt", 1, "hello world", mockBridge);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("different URIs are cached independently", () => {
+    const cache = new ParseCache();
+    const r1 = cache.getOrParse("file:///a.txt", 1, "hello", mockBridge);
+    const r2 = cache.getOrParse("file:///b.txt", 1, "world", mockBridge);
+    expect(r1).not.toBe(r2);
+    expect(r1.ast).toBe("hello");
+    expect(r2.ast).toBe("world");
+  });
+
+  it("evict only affects the specified URI", () => {
+    const cache = new ParseCache();
+    const r1 = cache.getOrParse("file:///a.txt", 1, "hello", mockBridge);
+    cache.getOrParse("file:///b.txt", 1, "world", mockBridge);
+    cache.evict("file:///a.txt");
+
+    // a.txt should be re-parsed
+    const r1b = cache.getOrParse("file:///a.txt", 1, "hello", mockBridge);
+    expect(r1b).not.toBe(r1);
+
+    // b.txt should still be cached
+    const r2b = cache.getOrParse("file:///b.txt", 1, "world", mockBridge);
+    // (r2b could be the same reference since b was not evicted)
+    expect(r2b.ast).toBe("world");
+  });
+});

--- a/code/packages/typescript/ls00/tests/semantic-tokens.test.ts
+++ b/code/packages/typescript/ls00/tests/semantic-tokens.test.ts
@@ -1,0 +1,172 @@
+/**
+ * semantic-tokens.test.ts -- Semantic token encoding tests
+ *
+ * Tests the delta encoding algorithm that converts SemanticToken objects
+ * into the LSP compact integer array format.
+ *
+ * The encoding is a flat array of 5-tuples:
+ *   [deltaLine, deltaStartChar, length, tokenTypeIndex, tokenModifierBitmask, ...]
+ *
+ * "Delta" means the difference from the PREVIOUS token's position.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  encodeSemanticTokens,
+  tokenTypeIndex,
+  tokenModifierMask,
+} from "../src/capabilities.js";
+import type { SemanticToken } from "../src/types.js";
+
+describe("encodeSemanticTokens", () => {
+  it("empty input returns empty array", () => {
+    expect(encodeSemanticTokens([])).toEqual([]);
+  });
+
+  it("single keyword token", () => {
+    const tokens: SemanticToken[] = [
+      { line: 0, character: 0, length: 5, tokenType: "keyword", modifiers: [] },
+    ];
+    const data = encodeSemanticTokens(tokens);
+
+    // Expected: [deltaLine=0, deltaChar=0, length=5, keyword=15, mods=0]
+    expect(data).toHaveLength(5);
+    expect(data[0]).toBe(0); // deltaLine
+    expect(data[1]).toBe(0); // deltaChar
+    expect(data[2]).toBe(5); // length
+    expect(data[3]).toBe(15); // keyword index
+    expect(data[4]).toBe(0); // no modifiers
+  });
+
+  it("two tokens on same line", () => {
+    const tokens: SemanticToken[] = [
+      { line: 0, character: 0, length: 3, tokenType: "keyword", modifiers: [] },
+      { line: 0, character: 4, length: 4, tokenType: "function", modifiers: ["declaration"] },
+    ];
+    const data = encodeSemanticTokens(tokens);
+
+    expect(data).toHaveLength(10);
+
+    // Token A: deltaLine=0, deltaChar=0, length=3, keyword(15), mods=0
+    expect(data.slice(0, 5)).toEqual([0, 0, 3, 15, 0]);
+    // Token B: deltaLine=0, deltaChar=4, length=4, function(12), mods=1 (declaration=bit0)
+    expect(data.slice(5, 10)).toEqual([0, 4, 4, 12, 1]);
+  });
+
+  it("tokens on different lines", () => {
+    const tokens: SemanticToken[] = [
+      { line: 0, character: 0, length: 3, tokenType: "keyword", modifiers: [] },
+      { line: 2, character: 4, length: 5, tokenType: "number", modifiers: [] },
+    ];
+    const data = encodeSemanticTokens(tokens);
+
+    expect(data).toHaveLength(10);
+    // Token B: deltaLine=2, deltaChar=4 (absolute on new line), number=19
+    expect(data[5]).toBe(2);  // deltaLine
+    expect(data[6]).toBe(4);  // deltaChar (absolute since different line)
+    expect(data[8]).toBe(19); // number index
+  });
+
+  it("unsorted input is auto-sorted", () => {
+    const tokens: SemanticToken[] = [
+      { line: 1, character: 0, length: 2, tokenType: "number", modifiers: [] },
+      { line: 0, character: 0, length: 3, tokenType: "keyword", modifiers: [] },
+    ];
+    const data = encodeSemanticTokens(tokens);
+
+    expect(data).toHaveLength(10);
+    // After sorting: keyword (15) first, number (19) second
+    expect(data[3]).toBe(15); // first token is keyword
+    expect(data[8]).toBe(19); // second token is number
+  });
+
+  it("unknown token type is skipped", () => {
+    const tokens: SemanticToken[] = [
+      { line: 0, character: 0, length: 3, tokenType: "unknownType", modifiers: [] },
+      { line: 0, character: 4, length: 2, tokenType: "keyword", modifiers: [] },
+    ];
+    const data = encodeSemanticTokens(tokens);
+
+    // unknownType skipped, only keyword remains
+    expect(data).toHaveLength(5);
+  });
+
+  it("readonly modifier bitmask", () => {
+    // "readonly" is at index 2 in the modifier list, value = 1 << 2 = 4
+    const tokens: SemanticToken[] = [
+      { line: 0, character: 0, length: 3, tokenType: "variable", modifiers: ["readonly"] },
+    ];
+    const data = encodeSemanticTokens(tokens);
+    expect(data[4]).toBe(4); // readonly = bit 2 = value 4
+  });
+
+  it("multiple modifiers combine as bitmask", () => {
+    // "declaration" = bit 0 = 1, "readonly" = bit 2 = 4, combined = 5
+    const tokens: SemanticToken[] = [
+      { line: 0, character: 0, length: 3, tokenType: "variable", modifiers: ["declaration", "readonly"] },
+    ];
+    const data = encodeSemanticTokens(tokens);
+    expect(data[4]).toBe(5); // 1 | 4 = 5
+  });
+
+  it("three tokens across multiple lines", () => {
+    const tokens: SemanticToken[] = [
+      { line: 0, character: 0, length: 3, tokenType: "keyword", modifiers: [] },
+      { line: 0, character: 4, length: 5, tokenType: "function", modifiers: ["declaration"] },
+      { line: 1, character: 0, length: 8, tokenType: "variable", modifiers: [] },
+    ];
+    const data = encodeSemanticTokens(tokens);
+
+    expect(data).toHaveLength(15);
+    // Token C: deltaLine=1, deltaChar=0 (reset on new line), length=8, variable(8), mods=0
+    expect(data.slice(10, 15)).toEqual([1, 0, 8, 8, 0]);
+  });
+});
+
+describe("tokenTypeIndex", () => {
+  it("keyword is 15", () => {
+    expect(tokenTypeIndex("keyword")).toBe(15);
+  });
+
+  it("function is 12", () => {
+    expect(tokenTypeIndex("function")).toBe(12);
+  });
+
+  it("variable is 8", () => {
+    expect(tokenTypeIndex("variable")).toBe(8);
+  });
+
+  it("number is 19", () => {
+    expect(tokenTypeIndex("number")).toBe(19);
+  });
+
+  it("unknown returns -1", () => {
+    expect(tokenTypeIndex("nonexistent")).toBe(-1);
+  });
+});
+
+describe("tokenModifierMask", () => {
+  it("empty list returns 0", () => {
+    expect(tokenModifierMask([])).toBe(0);
+  });
+
+  it("declaration is bit 0", () => {
+    expect(tokenModifierMask(["declaration"])).toBe(1);
+  });
+
+  it("definition is bit 1", () => {
+    expect(tokenModifierMask(["definition"])).toBe(2);
+  });
+
+  it("readonly is bit 2", () => {
+    expect(tokenModifierMask(["readonly"])).toBe(4);
+  });
+
+  it("combined modifiers", () => {
+    expect(tokenModifierMask(["declaration", "definition"])).toBe(3);
+  });
+
+  it("unknown modifier ignored", () => {
+    expect(tokenModifierMask(["unknownMod"])).toBe(0);
+  });
+});

--- a/code/packages/typescript/ls00/tests/server.test.ts
+++ b/code/packages/typescript/ls00/tests/server.test.ts
@@ -1,0 +1,728 @@
+/**
+ * server.test.ts -- Handler integration tests via JSON-RPC round-trip
+ *
+ * These tests feed JSON-RPC messages through the full LspServer pipeline.
+ * The server runs in a goroutine-equivalent (async background), and the test
+ * sends messages via pipes and reads responses.
+ *
+ * # Test Pattern
+ *
+ * 1. Create an LspServer with a MockBridge connected to io.Pipe equivalents
+ * 2. Start server.serve() in the background
+ * 3. Send JSON-RPC messages via the client writer
+ * 4. Read responses via the client reader
+ * 5. Assert on the response content
+ *
+ * We use PassThrough streams (Node.js equivalent of io.Pipe) for in-memory
+ * bidirectional communication.
+ */
+
+import { describe, it, expect } from "vitest";
+import { PassThrough } from "node:stream";
+import { MessageReader, MessageWriter } from "@coding-adventures/json-rpc";
+import type { Message, Request, Notification, Response } from "@coding-adventures/json-rpc";
+import { LspServer } from "../src/server.js";
+import type { LanguageBridge, HoverProvider, DocumentSymbolsProvider } from "../src/language-bridge.js";
+import type {
+  Token,
+  Diagnostic,
+  Position,
+  HoverResult,
+  DocumentSymbol,
+  Location,
+  CompletionItem,
+  WorkspaceEdit,
+  SemanticToken,
+  FoldingRange,
+  SignatureHelpResult,
+  TextEdit,
+} from "../src/types.js";
+import { SymbolKind, CompletionItemKind } from "../src/types.js";
+
+// ---------------------------------------------------------------------------
+// Mock bridges
+// ---------------------------------------------------------------------------
+
+/** MockBridge implements hover and documentSymbols. */
+class MockBridge implements LanguageBridge, HoverProvider, DocumentSymbolsProvider {
+  hoverResult: HoverResult | null = null;
+
+  tokenize(source: string): Token[] {
+    const tokens: Token[] = [];
+    let col = 1;
+    for (const word of source.split(/\s+/).filter(Boolean)) {
+      tokens.push({ type: "WORD", value: word, line: 1, column: col });
+      col += word.length + 1;
+    }
+    return tokens;
+  }
+
+  parse(source: string): [unknown, Diagnostic[]] {
+    const diags: Diagnostic[] = [];
+    if (source.includes("ERROR")) {
+      diags.push({
+        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 5 } },
+        severity: 1,
+        message: "syntax error: unexpected ERROR token",
+      });
+    }
+    return [source, diags];
+  }
+
+  hover(_ast: unknown, _pos: Position): HoverResult | null {
+    return this.hoverResult;
+  }
+
+  documentSymbols(_ast: unknown): DocumentSymbol[] {
+    return [{
+      name: "main",
+      kind: SymbolKind.Function,
+      range: { start: { line: 0, character: 0 }, end: { line: 10, character: 1 } },
+      selectionRange: { start: { line: 0, character: 9 }, end: { line: 0, character: 13 } },
+      children: [{
+        name: "x",
+        kind: SymbolKind.Variable,
+        range: { start: { line: 1, character: 4 }, end: { line: 1, character: 12 } },
+        selectionRange: { start: { line: 1, character: 8 }, end: { line: 1, character: 9 } },
+      }],
+    }];
+  }
+}
+
+/** FullMockBridge with all optional providers. */
+class FullMockBridge extends MockBridge {
+  semanticTokens(_source: string, tokens: Token[]): SemanticToken[] {
+    return tokens.map((tok) => ({
+      line: tok.line - 1,
+      character: tok.column - 1,
+      length: tok.value.length,
+      tokenType: "variable",
+      modifiers: [],
+    }));
+  }
+
+  definition(_ast: unknown, pos: Position, uri: string): Location | null {
+    return { uri, range: { start: pos, end: pos } };
+  }
+
+  references(_ast: unknown, pos: Position, uri: string, _includeDecl: boolean): Location[] {
+    return [{ uri, range: { start: pos, end: pos } }];
+  }
+
+  completion(_ast: unknown, _pos: Position): CompletionItem[] {
+    return [{ label: "foo", kind: CompletionItemKind.Function, detail: "() void" }];
+  }
+
+  rename(_ast: unknown, pos: Position, newName: string): WorkspaceEdit | null {
+    return {
+      changes: {
+        "file:///test.txt": [
+          { range: { start: pos, end: pos }, newText: newName },
+        ],
+      },
+    };
+  }
+
+  foldingRanges(_ast: unknown): FoldingRange[] {
+    return [{ startLine: 0, endLine: 5, kind: "region" }];
+  }
+
+  signatureHelp(_ast: unknown, _pos: Position): SignatureHelpResult | null {
+    return {
+      signatures: [{
+        label: "foo(a int, b string)",
+        parameters: [{ label: "a int" }, { label: "b string" }],
+      }],
+      activeSignature: 0,
+      activeParameter: 0,
+    };
+  }
+
+  format(source: string): TextEdit[] {
+    return [{
+      range: { start: { line: 0, character: 0 }, end: { line: 999, character: 0 } },
+      newText: source,
+    }];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Create an LspServer with pipe-based IO for testing.
+ * Returns the client's writer and reader for sending/receiving messages.
+ */
+function createTestServer(bridge: LanguageBridge): {
+  clientWriter: MessageWriter;
+  clientReader: MessageReader;
+  done: Promise<void>;
+} {
+  // Client writes to inStream, server reads from inStream
+  const inStream = new PassThrough();
+  // Server writes to outStream, client reads from outStream
+  const outStream = new PassThrough();
+
+  const server = new LspServer(bridge, inStream, outStream);
+
+  // Start the server in the background
+  const done = server.serve().then(() => {
+    outStream.end();
+  });
+
+  const clientWriter = new MessageWriter(inStream);
+  const clientReader = new MessageReader(outStream);
+
+  return { clientWriter, clientReader, done };
+}
+
+/** Send a JSON-RPC request and read the response. */
+async function sendRequest(
+  writer: MessageWriter,
+  reader: MessageReader,
+  id: number,
+  method: string,
+  params: unknown,
+): Promise<Record<string, unknown> | null> {
+  writer.writeMessage({
+    type: "request" as const,
+    id,
+    method,
+    params,
+  });
+
+  const msg = await reader.readMessage();
+  if (!msg || msg.type !== "response") {
+    throw new Error(`expected response, got ${msg?.type}`);
+  }
+  const resp = msg as Response;
+
+  if (resp.error) {
+    return { __error: resp.error };
+  }
+  if (resp.result === null || resp.result === undefined) {
+    return null;
+  }
+  if (typeof resp.result === "object" && !Array.isArray(resp.result)) {
+    return resp.result as Record<string, unknown>;
+  }
+  return { __result: resp.result };
+}
+
+/** Send a JSON-RPC notification (no response expected). */
+function sendNotif(
+  writer: MessageWriter,
+  method: string,
+  params: unknown,
+): void {
+  writer.writeMessage({
+    type: "notification" as const,
+    method,
+    params,
+  });
+}
+
+/** Read the next notification from the reader. */
+async function readNotif(reader: MessageReader): Promise<Notification> {
+  const msg = await reader.readMessage();
+  if (!msg || msg.type !== "notification") {
+    throw new Error(`expected notification, got ${msg?.type}`);
+  }
+  return msg as Notification;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("LspServer integration", () => {
+  it("initialize returns capabilities", async () => {
+    const bridge = new MockBridge();
+    bridge.hoverResult = { contents: "test" };
+    const { clientWriter, clientReader } = createTestServer(bridge);
+
+    const result = await sendRequest(clientWriter, clientReader, 1, "initialize", {
+      processId: 1234,
+      capabilities: {},
+    });
+
+    expect(result).toBeDefined();
+    const caps = result!.capabilities as Record<string, unknown>;
+    expect(caps.textDocumentSync).toBe(2);
+    expect(caps.hoverProvider).toBe(true);
+    expect(caps.documentSymbolProvider).toBe(true);
+
+    const serverInfo = result!.serverInfo as Record<string, unknown>;
+    expect(serverInfo.name).toBe("ls00-generic-lsp-server");
+  });
+
+  it("didOpen publishes diagnostics for error source", async () => {
+    const bridge = new MockBridge();
+    const { clientWriter, clientReader } = createTestServer(bridge);
+
+    // Initialize
+    await sendRequest(clientWriter, clientReader, 1, "initialize", {
+      processId: 1, capabilities: {},
+    });
+    sendNotif(clientWriter, "initialized", {});
+
+    // Open a file with ERROR
+    sendNotif(clientWriter, "textDocument/didOpen", {
+      textDocument: {
+        uri: "file:///test.txt",
+        languageId: "test",
+        version: 1,
+        text: "hello ERROR world",
+      },
+    });
+
+    const notif = await readNotif(clientReader);
+    expect(notif.method).toBe("textDocument/publishDiagnostics");
+
+    const params = notif.params as Record<string, unknown>;
+    expect(params.uri).toBe("file:///test.txt");
+    const diags = params.diagnostics as unknown[];
+    expect(diags.length).toBeGreaterThan(0);
+  });
+
+  it("didOpen publishes empty diagnostics for clean source", async () => {
+    const bridge = new MockBridge();
+    const { clientWriter, clientReader } = createTestServer(bridge);
+
+    await sendRequest(clientWriter, clientReader, 1, "initialize", {
+      processId: 1, capabilities: {},
+    });
+    sendNotif(clientWriter, "initialized", {});
+
+    sendNotif(clientWriter, "textDocument/didOpen", {
+      textDocument: {
+        uri: "file:///clean.txt",
+        languageId: "test",
+        version: 1,
+        text: "hello world",
+      },
+    });
+
+    const notif = await readNotif(clientReader);
+    expect(notif.method).toBe("textDocument/publishDiagnostics");
+
+    const params = notif.params as Record<string, unknown>;
+    const diags = params.diagnostics as unknown[];
+    expect(diags).toHaveLength(0);
+  });
+
+  it("hover returns content with range", async () => {
+    const bridge = new MockBridge();
+    bridge.hoverResult = {
+      contents: "**main** function",
+      range: {
+        start: { line: 0, character: 0 },
+        end: { line: 0, character: 4 },
+      },
+    };
+    const { clientWriter, clientReader } = createTestServer(bridge);
+
+    await sendRequest(clientWriter, clientReader, 1, "initialize", {
+      processId: 1, capabilities: {},
+    });
+    sendNotif(clientWriter, "initialized", {});
+
+    sendNotif(clientWriter, "textDocument/didOpen", {
+      textDocument: {
+        uri: "file:///test.go",
+        languageId: "go",
+        version: 1,
+        text: "func main() {}",
+      },
+    });
+    await readNotif(clientReader); // consume publishDiagnostics
+
+    const result = await sendRequest(clientWriter, clientReader, 2, "textDocument/hover", {
+      textDocument: { uri: "file:///test.go" },
+      position: { line: 0, character: 5 },
+    });
+
+    expect(result).toBeDefined();
+    const contents = result!.contents as Record<string, unknown>;
+    expect(contents.kind).toBe("markdown");
+    expect(contents.value).toBe("**main** function");
+    expect(result!.range).toBeDefined();
+  });
+
+  it("hover returns null when bridge returns null", async () => {
+    const bridge = new MockBridge();
+    bridge.hoverResult = null;
+    const { clientWriter, clientReader } = createTestServer(bridge);
+
+    await sendRequest(clientWriter, clientReader, 1, "initialize", {
+      processId: 1, capabilities: {},
+    });
+    sendNotif(clientWriter, "initialized", {});
+
+    sendNotif(clientWriter, "textDocument/didOpen", {
+      textDocument: {
+        uri: "file:///test.go",
+        languageId: "go",
+        version: 1,
+        text: "hello",
+      },
+    });
+    await readNotif(clientReader);
+
+    const result = await sendRequest(clientWriter, clientReader, 2, "textDocument/hover", {
+      textDocument: { uri: "file:///test.go" },
+      position: { line: 0, character: 0 },
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("didChange triggers re-parse and new diagnostics", async () => {
+    const bridge = new MockBridge();
+    const { clientWriter, clientReader } = createTestServer(bridge);
+
+    await sendRequest(clientWriter, clientReader, 1, "initialize", {
+      processId: 1, capabilities: {},
+    });
+    sendNotif(clientWriter, "initialized", {});
+
+    // Open clean file
+    sendNotif(clientWriter, "textDocument/didOpen", {
+      textDocument: {
+        uri: "file:///test.txt",
+        languageId: "test",
+        version: 1,
+        text: "hello",
+      },
+    });
+    const notif1 = await readNotif(clientReader);
+    const diags1 = (notif1.params as Record<string, unknown>).diagnostics as unknown[];
+    expect(diags1).toHaveLength(0);
+
+    // Change to include ERROR
+    sendNotif(clientWriter, "textDocument/didChange", {
+      textDocument: { uri: "file:///test.txt", version: 2 },
+      contentChanges: [{ text: "hello ERROR" }],
+    });
+    const notif2 = await readNotif(clientReader);
+    const diags2 = (notif2.params as Record<string, unknown>).diagnostics as unknown[];
+    expect(diags2.length).toBeGreaterThan(0);
+  });
+
+  it("didClose clears diagnostics", async () => {
+    const bridge = new MockBridge();
+    const { clientWriter, clientReader } = createTestServer(bridge);
+
+    await sendRequest(clientWriter, clientReader, 1, "initialize", {
+      processId: 1, capabilities: {},
+    });
+    sendNotif(clientWriter, "initialized", {});
+
+    sendNotif(clientWriter, "textDocument/didOpen", {
+      textDocument: {
+        uri: "file:///test.txt",
+        languageId: "test",
+        version: 1,
+        text: "hello ERROR",
+      },
+    });
+    await readNotif(clientReader); // consume open diagnostics
+
+    sendNotif(clientWriter, "textDocument/didClose", {
+      textDocument: { uri: "file:///test.txt" },
+    });
+
+    const notif = await readNotif(clientReader);
+    expect(notif.method).toBe("textDocument/publishDiagnostics");
+    const params = notif.params as Record<string, unknown>;
+    const diags = params.diagnostics as unknown[];
+    expect(diags).toHaveLength(0);
+  });
+
+  it("documentSymbol returns nested symbols", async () => {
+    const bridge = new MockBridge();
+    const { clientWriter, clientReader } = createTestServer(bridge);
+
+    await sendRequest(clientWriter, clientReader, 1, "initialize", {
+      processId: 1, capabilities: {},
+    });
+    sendNotif(clientWriter, "initialized", {});
+
+    sendNotif(clientWriter, "textDocument/didOpen", {
+      textDocument: {
+        uri: "file:///a.go",
+        languageId: "go",
+        version: 1,
+        text: "func main() {}",
+      },
+    });
+    await readNotif(clientReader);
+
+    const result = await sendRequest(clientWriter, clientReader, 2, "textDocument/documentSymbol", {
+      textDocument: { uri: "file:///a.go" },
+    });
+
+    expect(result).toBeDefined();
+    const symbols = result!.__result as unknown[];
+    expect(symbols).toHaveLength(1);
+
+    const mainSym = symbols[0] as Record<string, unknown>;
+    expect(mainSym.name).toBe("main");
+    expect(mainSym.kind).toBe(SymbolKind.Function);
+
+    const children = mainSym.children as unknown[];
+    expect(children).toHaveLength(1);
+    expect((children[0] as Record<string, unknown>).name).toBe("x");
+  });
+
+  it("definition handler returns location", async () => {
+    const bridge = new FullMockBridge();
+    const { clientWriter, clientReader } = createTestServer(bridge);
+
+    await sendRequest(clientWriter, clientReader, 1, "initialize", {
+      processId: 1, capabilities: {},
+    });
+    sendNotif(clientWriter, "initialized", {});
+
+    sendNotif(clientWriter, "textDocument/didOpen", {
+      textDocument: {
+        uri: "file:///test.txt",
+        languageId: "test",
+        version: 1,
+        text: "hello",
+      },
+    });
+    await readNotif(clientReader);
+
+    const result = await sendRequest(clientWriter, clientReader, 2, "textDocument/definition", {
+      textDocument: { uri: "file:///test.txt" },
+      position: { line: 0, character: 0 },
+    });
+
+    expect(result).toBeDefined();
+    expect(result!.uri).toBe("file:///test.txt");
+  });
+
+  it("completion handler returns items", async () => {
+    const bridge = new FullMockBridge();
+    const { clientWriter, clientReader } = createTestServer(bridge);
+
+    await sendRequest(clientWriter, clientReader, 1, "initialize", {
+      processId: 1, capabilities: {},
+    });
+    sendNotif(clientWriter, "initialized", {});
+
+    sendNotif(clientWriter, "textDocument/didOpen", {
+      textDocument: {
+        uri: "file:///test.txt",
+        languageId: "test",
+        version: 1,
+        text: "hello",
+      },
+    });
+    await readNotif(clientReader);
+
+    const result = await sendRequest(clientWriter, clientReader, 2, "textDocument/completion", {
+      textDocument: { uri: "file:///test.txt" },
+      position: { line: 0, character: 0 },
+    });
+
+    expect(result).toBeDefined();
+    expect(result!.isIncomplete).toBe(false);
+    const items = result!.items as unknown[];
+    expect(items).toHaveLength(1);
+    expect((items[0] as Record<string, unknown>).label).toBe("foo");
+  });
+
+  it("references handler returns locations", async () => {
+    const bridge = new FullMockBridge();
+    const { clientWriter, clientReader } = createTestServer(bridge);
+
+    await sendRequest(clientWriter, clientReader, 1, "initialize", {
+      processId: 1, capabilities: {},
+    });
+    sendNotif(clientWriter, "initialized", {});
+
+    sendNotif(clientWriter, "textDocument/didOpen", {
+      textDocument: {
+        uri: "file:///test.txt",
+        languageId: "test",
+        version: 1,
+        text: "hello",
+      },
+    });
+    await readNotif(clientReader);
+
+    const result = await sendRequest(clientWriter, clientReader, 2, "textDocument/references", {
+      textDocument: { uri: "file:///test.txt" },
+      position: { line: 0, character: 0 },
+      context: { includeDeclaration: true },
+    });
+
+    expect(result).toBeDefined();
+    const locs = result!.__result as unknown[];
+    expect(locs).toHaveLength(1);
+  });
+
+  it("foldingRange handler returns ranges", async () => {
+    const bridge = new FullMockBridge();
+    const { clientWriter, clientReader } = createTestServer(bridge);
+
+    await sendRequest(clientWriter, clientReader, 1, "initialize", {
+      processId: 1, capabilities: {},
+    });
+    sendNotif(clientWriter, "initialized", {});
+
+    sendNotif(clientWriter, "textDocument/didOpen", {
+      textDocument: {
+        uri: "file:///test.txt",
+        languageId: "test",
+        version: 1,
+        text: "hello",
+      },
+    });
+    await readNotif(clientReader);
+
+    const result = await sendRequest(clientWriter, clientReader, 2, "textDocument/foldingRange", {
+      textDocument: { uri: "file:///test.txt" },
+    });
+
+    expect(result).toBeDefined();
+    const ranges = result!.__result as unknown[];
+    expect(ranges).toHaveLength(1);
+    expect((ranges[0] as Record<string, unknown>).startLine).toBe(0);
+    expect((ranges[0] as Record<string, unknown>).endLine).toBe(5);
+  });
+
+  it("signatureHelp handler returns signatures", async () => {
+    const bridge = new FullMockBridge();
+    const { clientWriter, clientReader } = createTestServer(bridge);
+
+    await sendRequest(clientWriter, clientReader, 1, "initialize", {
+      processId: 1, capabilities: {},
+    });
+    sendNotif(clientWriter, "initialized", {});
+
+    sendNotif(clientWriter, "textDocument/didOpen", {
+      textDocument: {
+        uri: "file:///test.txt",
+        languageId: "test",
+        version: 1,
+        text: "foo(a, b)",
+      },
+    });
+    await readNotif(clientReader);
+
+    const result = await sendRequest(clientWriter, clientReader, 2, "textDocument/signatureHelp", {
+      textDocument: { uri: "file:///test.txt" },
+      position: { line: 0, character: 4 },
+    });
+
+    expect(result).toBeDefined();
+    const sigs = result!.signatures as unknown[];
+    expect(sigs).toHaveLength(1);
+    expect(result!.activeSignature).toBe(0);
+    expect(result!.activeParameter).toBe(0);
+  });
+
+  it("formatting handler returns edits", async () => {
+    const bridge = new FullMockBridge();
+    const { clientWriter, clientReader } = createTestServer(bridge);
+
+    await sendRequest(clientWriter, clientReader, 1, "initialize", {
+      processId: 1, capabilities: {},
+    });
+    sendNotif(clientWriter, "initialized", {});
+
+    sendNotif(clientWriter, "textDocument/didOpen", {
+      textDocument: {
+        uri: "file:///test.txt",
+        languageId: "test",
+        version: 1,
+        text: "hello world",
+      },
+    });
+    await readNotif(clientReader);
+
+    const result = await sendRequest(clientWriter, clientReader, 2, "textDocument/formatting", {
+      textDocument: { uri: "file:///test.txt" },
+      options: { tabSize: 4, insertSpaces: true },
+    });
+
+    expect(result).toBeDefined();
+    const edits = result!.__result as unknown[];
+    expect(edits).toHaveLength(1);
+  });
+
+  it("semanticTokens handler returns encoded data", async () => {
+    const bridge = new FullMockBridge();
+    const { clientWriter, clientReader } = createTestServer(bridge);
+
+    await sendRequest(clientWriter, clientReader, 1, "initialize", {
+      processId: 1, capabilities: {},
+    });
+    sendNotif(clientWriter, "initialized", {});
+
+    sendNotif(clientWriter, "textDocument/didOpen", {
+      textDocument: {
+        uri: "file:///test.txt",
+        languageId: "test",
+        version: 1,
+        text: "hello world",
+      },
+    });
+    await readNotif(clientReader);
+
+    const result = await sendRequest(clientWriter, clientReader, 2, "textDocument/semanticTokens/full", {
+      textDocument: { uri: "file:///test.txt" },
+    });
+
+    expect(result).toBeDefined();
+    const data = result!.data as number[];
+    // "hello world" -> 2 tokens -> 10 integers
+    expect(data).toHaveLength(10);
+  });
+
+  it("rename handler returns workspace edit", async () => {
+    const bridge = new FullMockBridge();
+    const { clientWriter, clientReader } = createTestServer(bridge);
+
+    await sendRequest(clientWriter, clientReader, 1, "initialize", {
+      processId: 1, capabilities: {},
+    });
+    sendNotif(clientWriter, "initialized", {});
+
+    sendNotif(clientWriter, "textDocument/didOpen", {
+      textDocument: {
+        uri: "file:///test.txt",
+        languageId: "test",
+        version: 1,
+        text: "hello world",
+      },
+    });
+    await readNotif(clientReader);
+
+    const result = await sendRequest(clientWriter, clientReader, 2, "textDocument/rename", {
+      textDocument: { uri: "file:///test.txt" },
+      position: { line: 0, character: 0 },
+      newName: "hi",
+    });
+
+    expect(result).toBeDefined();
+    const changes = result!.changes as Record<string, unknown[]>;
+    expect(changes["file:///test.txt"]).toHaveLength(1);
+  });
+
+  it("shutdown returns null", async () => {
+    const bridge = new MockBridge();
+    const { clientWriter, clientReader } = createTestServer(bridge);
+
+    await sendRequest(clientWriter, clientReader, 1, "initialize", {
+      processId: 1, capabilities: {},
+    });
+
+    const result = await sendRequest(clientWriter, clientReader, 2, "shutdown", {});
+    expect(result).toBeNull();
+  });
+});

--- a/code/packages/typescript/ls00/tests/utf16.test.ts
+++ b/code/packages/typescript/ls00/tests/utf16.test.ts
@@ -1,0 +1,130 @@
+/**
+ * utf16.test.ts -- UTF-16 offset conversion tests
+ *
+ * This is the most important correctness test in the entire package. If the
+ * position conversion functions are wrong, every feature that depends on cursor
+ * position will be wrong: hover, go-to-definition, references, completion,
+ * rename, signature help.
+ *
+ * # Why UTF-16 Matters
+ *
+ * LSP's "character" offset is measured in UTF-16 code units. In JavaScript,
+ * strings are already UTF-16 internally, so the conversion is simpler than
+ * in Go or Rust. But we still need to test edge cases with emoji (surrogate
+ * pairs) and multi-byte UTF-8 characters to ensure byte offset conversion
+ * is correct.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  convertPositionToStringIndex,
+  convertUTF16OffsetToByteOffset,
+} from "../src/document-manager.js";
+
+describe("convertPositionToStringIndex", () => {
+  it("ASCII simple", () => {
+    // "hello world" -- "world" starts at character 6
+    expect(convertPositionToStringIndex("hello world", { line: 0, character: 6 })).toBe(6);
+  });
+
+  it("start of file", () => {
+    expect(convertPositionToStringIndex("abc", { line: 0, character: 0 })).toBe(0);
+  });
+
+  it("end of short string", () => {
+    expect(convertPositionToStringIndex("abc", { line: 0, character: 3 })).toBe(3);
+  });
+
+  it("second line", () => {
+    // "hello\nworld" -- line 1 starts at string index 6
+    expect(convertPositionToStringIndex("hello\nworld", { line: 1, character: 0 })).toBe(6);
+  });
+
+  it("emoji: guitar takes 2 UTF-16 units", () => {
+    // "A\u{1F3B8}B"
+    // UTF-16 units: A (1 unit) + guitar (2 units) + B (1 unit) = 4 units
+    // "B" is at UTF-16 character 3, string index 3 (JS strings ARE UTF-16)
+    const text = "A\u{1F3B8}B";
+    expect(text.length).toBe(4); // JS .length is UTF-16 code units
+    expect(convertPositionToStringIndex(text, { line: 0, character: 3 })).toBe(3);
+  });
+
+  it("emoji at start", () => {
+    // "\u{1F3B8}hello"
+    // guitar = 2 UTF-16 units, "h" is at character 2
+    const text = "\u{1F3B8}hello";
+    expect(convertPositionToStringIndex(text, { line: 0, character: 2 })).toBe(2);
+  });
+
+  it("multiline with emoji", () => {
+    // line 0: "A\u{1F3B8}B\n"  (A=1, guitar=2, B=1, \n=1 = 5 UTF-16 units)
+    // line 1: "hello"
+    // "hello" starts at string index 5 on line 1
+    const text = "A\u{1F3B8}B\nhello";
+    expect(convertPositionToStringIndex(text, { line: 1, character: 0 })).toBe(5);
+  });
+
+  it("beyond line end clamps to newline", () => {
+    // If character is past the end of the line, we stop at the newline.
+    expect(convertPositionToStringIndex("ab\ncd", { line: 0, character: 100 })).toBe(2);
+  });
+
+  it("line beyond file end clamps to end", () => {
+    expect(convertPositionToStringIndex("abc", { line: 5, character: 0 })).toBe(3);
+  });
+
+  it("Chinese characters (BMP codepoints)", () => {
+    // Each Chinese character is 1 UTF-16 code unit (BMP)
+    const text = "\u4e2d\u6587"; // "zhong wen"
+    expect(convertPositionToStringIndex(text, { line: 0, character: 1 })).toBe(1);
+  });
+});
+
+describe("convertUTF16OffsetToByteOffset", () => {
+  it("ASCII simple", () => {
+    expect(convertUTF16OffsetToByteOffset("hello world", 0, 6)).toBe(6);
+  });
+
+  it("emoji: guitar is 4 UTF-8 bytes but 2 UTF-16 units", () => {
+    // "A\u{1F3B8}B"
+    // UTF-8: A(1) + guitar(4) + B(1) = 6 bytes
+    // UTF-16: A(1) + guitar(2) + B(1) = 4 units
+    // "B" is at UTF-16 char 3, byte offset 5
+    const text = "A\u{1F3B8}B";
+    expect(convertUTF16OffsetToByteOffset(text, 0, 3)).toBe(5);
+  });
+
+  it("emoji at start", () => {
+    // "\u{1F3B8}hello"
+    // guitar = 4 UTF-8 bytes, "h" starts at byte 4
+    const text = "\u{1F3B8}hello";
+    expect(convertUTF16OffsetToByteOffset(text, 0, 2)).toBe(4);
+  });
+
+  it("2-byte UTF-8 (BMP codepoint: e-acute)", () => {
+    // "cafe-acute!" -- e-acute (U+00E9) is 2 UTF-8 bytes, 1 UTF-16 unit
+    // c(1) + a(1) + f(1) + e-acute(2) = 5 bytes for "cafe-acute"
+    // "!" is at UTF-16 char 4, byte offset 5
+    const text = "caf\u00e9!";
+    expect(convertUTF16OffsetToByteOffset(text, 0, 4)).toBe(5);
+  });
+
+  it("multiline with emoji", () => {
+    // line 0: "A\u{1F3B8}B\n"  (1 + 4 + 1 + 1 = 7 UTF-8 bytes)
+    // line 1: "hello"
+    // "hello" starts at byte 7
+    const text = "A\u{1F3B8}B\nhello";
+    expect(convertUTF16OffsetToByteOffset(text, 1, 0)).toBe(7);
+  });
+
+  it("Chinese character (3-byte UTF-8, 1 UTF-16 unit)", () => {
+    // "zhong wen" -- each character is 3 UTF-8 bytes, 1 UTF-16 unit
+    // Second character starts at byte 3
+    const text = "\u4e2d\u6587";
+    expect(convertUTF16OffsetToByteOffset(text, 0, 1)).toBe(3);
+  });
+
+  it("beyond line end clamps", () => {
+    expect(convertUTF16OffsetToByteOffset("ab\ncd", 0, 100)).toBe(2);
+  });
+});

--- a/code/packages/typescript/ls00/tsconfig.json
+++ b/code/packages/typescript/ls00/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/ls00/vitest.config.ts
+++ b/code/packages/typescript/ls00/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: 'v8',
+    },
+  },
+});

--- a/code/packages/wasm/ls00/BUILD
+++ b/code/packages/wasm/ls00/BUILD
@@ -1,0 +1,1 @@
+cargo test -- --nocapture

--- a/code/packages/wasm/ls00/BUILD_windows
+++ b/code/packages/wasm/ls00/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -- --nocapture

--- a/code/packages/wasm/ls00/CHANGELOG.md
+++ b/code/packages/wasm/ls00/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to the ls00-wasm package will be documented in this file.
+
+## [0.1.0] - 2026-04-12
+
+### Added
+
+- Initial release of the WASM LSP server wrapper.
+- `WasmLanguageBridge` struct for providing tokenize/parse logic from JavaScript callbacks.
+- `WasmLspServer` struct with callback-based message-passing API (no stdio).
+- `handleMessage(json)` method for processing incoming JSON-RPC messages.
+- `isInitialized()` and `isShutdown()` state query methods.
+- Full LSP request dispatch: initialize, shutdown, hover, definition, references, completion, rename, documentSymbol, semanticTokens/full, foldingRange, signatureHelp, formatting.
+- Full LSP notification dispatch: initialized, didOpen, didChange, didClose, didSave.
+- Server-initiated notifications (publishDiagnostics) sent via JS callback.
+- Document manager and parse cache reused from the core ls00 crate.
+- Native Rust unit tests guarded with `#[cfg(not(target_arch = "wasm32"))]`.
+- BUILD file for build-tool integration.

--- a/code/packages/wasm/ls00/Cargo.toml
+++ b/code/packages/wasm/ls00/Cargo.toml
@@ -1,0 +1,60 @@
+# Cargo.toml -- WASM LSP Server Wrapper
+# ======================================
+#
+# This crate wraps the pure-Rust `coding-adventures-ls00` LSP framework
+# for use in browsers, Deno, and Node.js via WebAssembly. It uses
+# wasm-bindgen to generate JavaScript bindings that expose a
+# `WasmLspServer` class with a message-passing API.
+#
+# Why a separate crate?
+#
+# The core `ls00` crate reads and writes over stdio using
+# Content-Length-framed JSON-RPC. Browsers and web workers do not have
+# stdio. This wrapper replaces the stdio transport with a callback-based
+# message-passing interface:
+#
+#   - Client sends JSON string in via `handleMessage(json)`
+#   - Server sends JSON string out via a registered JS callback
+#
+# The core LSP logic (document manager, parse cache, capability
+# advertisement, semantic token encoding) is reused unchanged.
+#
+# Build with:
+#   wasm-pack build --target web     (for browsers)
+#   wasm-pack build --target nodejs  (for Node.js/Deno)
+#   cargo test                       (for native unit tests)
+
+# This crate is NOT part of the main Rust workspace at code/packages/rust/.
+# It lives in code/packages/wasm/ and declares its own workspace root.
+[workspace]
+
+[package]
+name = "ls00-wasm"
+version = "0.1.0"
+edition = "2021"
+description = "WebAssembly bindings for the ls00 LSP framework via wasm-bindgen"
+license = "MIT"
+
+[lib]
+# cdylib produces a .wasm file that wasm-pack can process.
+# rlib is needed for cargo test (native unit tests).
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+# wasm-bindgen provides the #[wasm_bindgen] macro that generates JS glue code.
+wasm-bindgen = "0.2"
+
+# js-sys provides Rust bindings to JavaScript built-in objects (Function, etc.).
+js-sys = "0.3"
+
+# serde + serde_json for JSON serialization of LSP messages.
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+# The core LSP framework, referenced by relative path.
+coding-adventures-ls00 = { path = "../../rust/ls00" }
+
+[dev-dependencies]
+# wasm-bindgen-test is used for in-browser/Node WASM tests (not used here
+# because we guard our tests with #[cfg(not(target_arch = "wasm32"))]).
+# wasm-bindgen-test = "0.3"

--- a/code/packages/wasm/ls00/README.md
+++ b/code/packages/wasm/ls00/README.md
@@ -1,0 +1,127 @@
+# ls00-wasm
+
+WebAssembly bindings for the [ls00](../../rust/ls00/) LSP framework, exposing a message-passing LSP server for use in browsers, web workers, and Deno.
+
+## What This Does
+
+This package wraps the Rust `coding-adventures-ls00` LSP framework with `wasm-bindgen` so it can run in environments without stdio (browsers, web workers, VS Code web extensions). Instead of reading/writing Content-Length-framed messages on stdin/stdout, the WASM server uses a callback-based message-passing API.
+
+## How It Fits in the Stack
+
+```
++------------------------------+
+|  Browser / Web Worker / Deno |  <-- JavaScript consumer
++------------------------------+
+|  ls00-wasm (this)            |  <-- wasm-bindgen wrapper (cdylib)
++------------------------------+
+|  ls00 (Rust)                 |  <-- core LSP framework
++------------------------------+
+|  json-rpc (Rust)             |  <-- JSON-RPC types (used for capabilities)
++------------------------------+
+```
+
+The core `ls00` crate contains all the LSP logic (document management, parse caching, capability advertisement, semantic token encoding). This crate adds only the WASM transport layer.
+
+## Building
+
+```bash
+# Native unit tests (no WASM tooling needed):
+cargo test
+
+# Build WASM for browsers:
+wasm-pack build --target web
+
+# Build WASM for Node.js/Deno:
+wasm-pack build --target nodejs
+```
+
+## Usage (JavaScript)
+
+```javascript
+import init, { WasmLspServer, WasmLanguageBridge } from './ls00_wasm.js';
+
+await init();  // initialize WASM module
+
+// 1. Create a language bridge with tokenize and parse callbacks
+const bridge = new WasmLanguageBridge(
+  (source) => {
+    // Tokenize: return JSON array of tokens
+    const tokens = myLexer.tokenize(source);
+    return JSON.stringify(tokens.map(t => ({
+      token_type: t.type,
+      value: t.value,
+      line: t.line,
+      column: t.column
+    })));
+  },
+  (source) => {
+    // Parse: return JSON with ast + diagnostics
+    const result = myParser.parse(source);
+    return JSON.stringify({
+      ast: JSON.stringify(result.ast),
+      diagnostics: result.errors.map(e => ({
+        range: { start: e.start, end: e.end },
+        severity: 1,
+        message: e.message
+      }))
+    });
+  }
+);
+
+// 2. Create the server with a callback for outgoing notifications
+const server = new WasmLspServer(bridge, (jsonStr) => {
+  // Handle server-initiated messages (e.g., diagnostics)
+  const msg = JSON.parse(jsonStr);
+  if (msg.method === 'textDocument/publishDiagnostics') {
+    showDiagnostics(msg.params);
+  }
+});
+
+// 3. Send incoming messages and handle responses
+const initResponse = server.handleMessage(JSON.stringify({
+  jsonrpc: '2.0',
+  id: 1,
+  method: 'initialize',
+  params: {}
+}));
+console.log(JSON.parse(initResponse));  // { capabilities: {...} }
+```
+
+## API Reference
+
+### WasmLanguageBridge
+
+| Method | Description |
+|--------|-------------|
+| `new WasmLanguageBridge(tokenizeFn, parseFn)` | Create a bridge with JS callbacks |
+
+### WasmLspServer
+
+| Method | Description |
+|--------|-------------|
+| `new WasmLspServer(bridge, sendCallback)` | Create a server with a language bridge and outgoing message callback |
+| `handleMessage(json)` | Process an incoming JSON-RPC message; returns response string (or empty for notifications) |
+| `isInitialized()` | Whether the server has received `initialize` |
+| `isShutdown()` | Whether the server has received `shutdown` |
+
+### Supported LSP Methods
+
+**Requests** (return a response via `handleMessage`):
+- `initialize` / `shutdown`
+- `textDocument/hover`
+- `textDocument/definition`
+- `textDocument/references`
+- `textDocument/completion`
+- `textDocument/rename`
+- `textDocument/documentSymbol`
+- `textDocument/semanticTokens/full`
+- `textDocument/foldingRange`
+- `textDocument/signatureHelp`
+- `textDocument/formatting`
+
+**Notifications** (no response, side effects via callback):
+- `initialized`
+- `textDocument/didOpen`
+- `textDocument/didChange`
+- `textDocument/didClose`
+- `textDocument/didSave`

--- a/code/packages/wasm/ls00/required_capabilities.json
+++ b/code/packages/wasm/ls00/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "wasm/ls00",
+  "capabilities": [],
+  "justification": "Pure computation. WASM bindings wrap the Rust LSP framework with callback-based message passing -- no filesystem, network, process, or environment access needed."
+}

--- a/code/packages/wasm/ls00/src/lib.rs
+++ b/code/packages/wasm/ls00/src/lib.rs
@@ -1,0 +1,1936 @@
+// lib.rs -- WASM Bindings for the ls00 LSP Framework
+// ====================================================
+//
+// This module wraps the Rust `coding-adventures-ls00` LSP framework for use
+// in browsers and web workers via WebAssembly. The core challenge is that
+// browsers do not have stdio -- there is no stdin to read from and no stdout
+// to write to. This wrapper replaces the stdio transport with a callback-based
+// message-passing API.
+//
+// # Architecture
+//
+// ```text
+// ┌───────────────────────────────────┐
+// │  Browser / Web Worker / Deno      │
+// │                                   │
+// │  const server = new WasmLspServer(│
+// │    (json) => sendToEditor(json)   │  <-- outgoing callback
+// │  );                               │
+// │                                   │
+// │  server.handleMessage(incomingJson);  <-- incoming messages
+// └───────────────────────────────────┘
+//        |                    ^
+//        v                    |
+// ┌───────────────────────────────────┐
+// │  WasmLspServer (this crate)       │
+// │                                   │
+// │  ┌──────────────────────────────┐ │
+// │  │ DocumentManager              │ │  tracks open file contents
+// │  │ ParseCache                   │ │  avoids redundant parses
+// │  │ LanguageBridge (from JS)     │ │  language-specific logic
+// │  │ Capability builder           │ │  advertises LSP features
+// │  └──────────────────────────────┘ │
+// └───────────────────────────────────┘
+// ```
+//
+// # Design Decisions
+//
+// 1. **Message-passing, not stdio**: The server accepts incoming JSON-RPC
+//    messages as strings via `handleMessage()` and sends outgoing messages
+//    through a JS callback function. This matches how web workers and
+//    browser extensions communicate.
+//
+// 2. **JS-based LanguageBridge**: The `WasmLanguageBridge` struct implements
+//    the Rust `LanguageBridge` trait by calling JS callback functions for
+//    `tokenize` and `parse`. This lets language-specific logic live in
+//    JavaScript/TypeScript while reusing the Rust LSP framework.
+//
+// 3. **JSON serialization at the boundary**: All data crosses the WASM
+//    boundary as JSON strings. This avoids complex wasm-bindgen type
+//    mappings and lets JS consumers work with plain objects.
+//
+// 4. **No WASM-target tests**: Tests run natively with `cargo test` and
+//    are guarded with `#[cfg(not(target_arch = "wasm32"))]`.
+
+use coding_adventures_ls00::capabilities::build_capabilities;
+use coding_adventures_ls00::document_manager::DocumentManager;
+use coding_adventures_ls00::language_bridge::LanguageBridge;
+use coding_adventures_ls00::parse_cache::ParseCache;
+use coding_adventures_ls00::types::*;
+use serde_json::{json, Value};
+use std::any::Any;
+use wasm_bindgen::prelude::*;
+
+// ---------------------------------------------------------------------------
+// WasmLanguageBridge -- language logic provided by JavaScript
+// ---------------------------------------------------------------------------
+//
+// In the native Rust LSP server, the LanguageBridge is a Rust struct that
+// implements tokenize() and parse(). In the WASM version, these operations
+// are implemented in JavaScript. The WasmLanguageBridge stores JS callback
+// functions and calls them when the server needs to tokenize or parse.
+//
+// The JS callbacks receive and return JSON strings:
+//
+//   tokenize(source: string) -> string  // returns JSON: Token[] or {error: string}
+//   parse(source: string) -> string     // returns JSON: {ast: any, diagnostics: Diagnostic[]}
+//                                       //   or {error: string}
+//
+// This keeps the WASM boundary simple -- everything is a string.
+
+/// A language bridge that delegates to JavaScript callback functions.
+///
+/// Create one with `WasmLanguageBridge::new(tokenize_fn, parse_fn)` where
+/// each function takes a source string and returns a JSON string with the
+/// results.
+///
+/// ## JavaScript Usage
+///
+/// ```javascript
+/// const bridge = new WasmLanguageBridge(
+///   (source) => {
+///     // tokenize the source, return JSON array of tokens
+///     const tokens = myLexer.tokenize(source);
+///     return JSON.stringify(tokens);
+///   },
+///   (source) => {
+///     // parse the source, return JSON with ast + diagnostics
+///     const result = myParser.parse(source);
+///     return JSON.stringify({
+///       ast: result.ast,
+///       diagnostics: result.diagnostics
+///     });
+///   }
+/// );
+/// ```
+#[wasm_bindgen]
+pub struct WasmLanguageBridge {
+    /// JS function: (source: string) -> JSON string of Token[]
+    tokenize_fn: js_sys::Function,
+    /// JS function: (source: string) -> JSON string of {ast, diagnostics}
+    parse_fn: js_sys::Function,
+}
+
+#[wasm_bindgen]
+impl WasmLanguageBridge {
+    /// Create a new language bridge from two JavaScript callback functions.
+    ///
+    /// - `tokenize_fn`: `(source: string) -> string` -- returns JSON array of tokens.
+    ///   Each token must have: `{ token_type: string, value: string, line: number, column: number }`
+    ///
+    /// - `parse_fn`: `(source: string) -> string` -- returns JSON object with:
+    ///   `{ ast: string, diagnostics: [...] }` where `ast` is an opaque JSON string
+    ///   that will be passed back to JS for hover/completion/etc., and `diagnostics`
+    ///   is an array of `{ range: {start: {line, character}, end: {line, character}},
+    ///   severity: number, message: string, code?: string }`.
+    #[wasm_bindgen(constructor)]
+    pub fn new(tokenize_fn: js_sys::Function, parse_fn: js_sys::Function) -> WasmLanguageBridge {
+        WasmLanguageBridge {
+            tokenize_fn,
+            parse_fn,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Implementing the Rust LanguageBridge trait for WasmLanguageBridge
+// ---------------------------------------------------------------------------
+//
+// This is the key integration point. The Rust LSP server calls these methods
+// when it needs to tokenize or parse a document. We forward the calls to
+// JavaScript by invoking the stored callback functions.
+//
+// The `Send + Sync` requirement is satisfied because WASM is single-threaded:
+// there is only one thread, so all types are trivially Send + Sync.
+
+// SAFETY: WASM is single-threaded, so js_sys::Function can be sent between
+// "threads" (there is only one). This is the standard pattern for wasm-bindgen.
+unsafe impl Send for WasmLanguageBridge {}
+unsafe impl Sync for WasmLanguageBridge {}
+
+/// An opaque AST container that wraps a JSON string.
+///
+/// When the JS `parse_fn` returns an AST, we store it as a JSON string inside
+/// this struct. When the server later needs the AST for hover/completion/etc.,
+/// it passes this value back. Since the WASM wrapper doesn't interpret the AST
+/// itself (that's the JS bridge's job), the JSON string is opaque to us.
+struct JsAst {
+    /// The opaque AST JSON string from the JS bridge. Stored for potential
+    /// future use when the bridge needs to downcast and inspect the AST.
+    #[allow(dead_code)]
+    json: String,
+}
+
+impl LanguageBridge for WasmLanguageBridge {
+    /// Tokenize the source by calling the JS tokenize callback.
+    ///
+    /// The JS function receives the source string and must return a JSON
+    /// string representing an array of tokens:
+    ///
+    /// ```json
+    /// [
+    ///   {"token_type": "KEYWORD", "value": "let", "line": 1, "column": 1},
+    ///   {"token_type": "IDENTIFIER", "value": "x", "line": 1, "column": 5}
+    /// ]
+    /// ```
+    ///
+    /// If the JS function returns an object with an `error` field, that error
+    /// is propagated as `Err(message)`.
+    fn tokenize(&self, source: &str) -> Result<Vec<Token>, String> {
+        // Call the JS function with the source string.
+        let this = JsValue::NULL;
+        let source_js = JsValue::from_str(source);
+        let result = self
+            .tokenize_fn
+            .call1(&this, &source_js)
+            .map_err(|e| format!("tokenize callback failed: {:?}", e))?;
+
+        // Convert the JsValue result to a Rust string.
+        let json_str = result
+            .as_string()
+            .ok_or_else(|| "tokenize callback did not return a string".to_string())?;
+
+        // Parse the JSON string.
+        let parsed: Value =
+            serde_json::from_str(&json_str).map_err(|e| format!("invalid JSON from tokenize: {}", e))?;
+
+        // Check for error response.
+        if let Some(err) = parsed.get("error") {
+            return Err(err.as_str().unwrap_or("unknown error").to_string());
+        }
+
+        // Parse as array of tokens.
+        let arr = parsed
+            .as_array()
+            .ok_or_else(|| "tokenize result is not an array".to_string())?;
+
+        let tokens: Vec<Token> = arr
+            .iter()
+            .map(|item| Token {
+                token_type: item["token_type"]
+                    .as_str()
+                    .unwrap_or("UNKNOWN")
+                    .to_string(),
+                value: item["value"].as_str().unwrap_or("").to_string(),
+                line: item["line"].as_i64().unwrap_or(1) as i32,
+                column: item["column"].as_i64().unwrap_or(1) as i32,
+            })
+            .collect();
+
+        Ok(tokens)
+    }
+
+    /// Parse the source by calling the JS parse callback.
+    ///
+    /// The JS function receives the source string and must return a JSON string:
+    ///
+    /// ```json
+    /// {
+    ///   "ast": "<opaque JSON string representing the AST>",
+    ///   "diagnostics": [
+    ///     {
+    ///       "range": {
+    ///         "start": {"line": 0, "character": 0},
+    ///         "end": {"line": 0, "character": 5}
+    ///       },
+    ///       "severity": 1,
+    ///       "message": "unexpected token"
+    ///     }
+    ///   ]
+    /// }
+    /// ```
+    ///
+    /// The `ast` field is stored as an opaque string and will be passed back
+    /// to the JS bridge when hover/completion/etc. are requested.
+    fn parse(
+        &self,
+        source: &str,
+    ) -> Result<(Box<dyn Any + Send + Sync>, Vec<Diagnostic>), String> {
+        let this = JsValue::NULL;
+        let source_js = JsValue::from_str(source);
+        let result = self
+            .parse_fn
+            .call1(&this, &source_js)
+            .map_err(|e| format!("parse callback failed: {:?}", e))?;
+
+        let json_str = result
+            .as_string()
+            .ok_or_else(|| "parse callback did not return a string".to_string())?;
+
+        let parsed: Value =
+            serde_json::from_str(&json_str).map_err(|e| format!("invalid JSON from parse: {}", e))?;
+
+        // Check for error response.
+        if let Some(err) = parsed.get("error") {
+            return Err(err.as_str().unwrap_or("unknown error").to_string());
+        }
+
+        // Extract the opaque AST string.
+        let ast_str = match &parsed["ast"] {
+            Value::String(s) => s.clone(),
+            other => serde_json::to_string(other).unwrap_or_default(),
+        };
+
+        // Extract diagnostics.
+        let diagnostics = parse_diagnostics_from_json(&parsed["diagnostics"]);
+
+        let ast = Box::new(JsAst { json: ast_str }) as Box<dyn Any + Send + Sync>;
+        Ok((ast, diagnostics))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Diagnostic parsing helper
+// ---------------------------------------------------------------------------
+
+/// Parse an array of diagnostics from a JSON value.
+///
+/// Each diagnostic has the shape:
+/// ```json
+/// {
+///   "range": {
+///     "start": {"line": 0, "character": 0},
+///     "end": {"line": 0, "character": 5}
+///   },
+///   "severity": 1,
+///   "message": "unexpected token",
+///   "code": "E001"  // optional
+/// }
+/// ```
+fn parse_diagnostics_from_json(value: &Value) -> Vec<Diagnostic> {
+    let arr = match value.as_array() {
+        Some(a) => a,
+        None => return Vec::new(),
+    };
+
+    arr.iter()
+        .map(|item| {
+            let range = &item["range"];
+            Diagnostic {
+                range: Range {
+                    start: Position {
+                        line: range["start"]["line"].as_i64().unwrap_or(0) as i32,
+                        character: range["start"]["character"].as_i64().unwrap_or(0) as i32,
+                    },
+                    end: Position {
+                        line: range["end"]["line"].as_i64().unwrap_or(0) as i32,
+                        character: range["end"]["character"].as_i64().unwrap_or(0) as i32,
+                    },
+                },
+                severity: match item["severity"].as_i64().unwrap_or(1) {
+                    2 => DiagnosticSeverity::Warning,
+                    3 => DiagnosticSeverity::Information,
+                    4 => DiagnosticSeverity::Hint,
+                    _ => DiagnosticSeverity::Error,
+                },
+                message: item["message"].as_str().unwrap_or("").to_string(),
+                code: item["code"].as_str().map(|s| s.to_string()),
+            }
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// WasmLspServer -- the main exported type
+// ---------------------------------------------------------------------------
+//
+// This is the WASM equivalent of `LspServer` from the core crate. Instead
+// of reading from stdin and writing to stdout, it:
+//
+// - Receives incoming JSON-RPC messages as strings via `handleMessage()`
+// - Sends outgoing JSON-RPC messages via a JS callback function
+//
+// Internally it reuses the same DocumentManager and ParseCache from the
+// core crate, and dispatches to the same handler logic.
+//
+// JavaScript usage:
+//
+//   import { WasmLspServer, WasmLanguageBridge } from './ls00_wasm.js';
+//
+//   const bridge = new WasmLanguageBridge(tokenizeFn, parseFn);
+//   const server = new WasmLspServer(bridge, (outJson) => {
+//     // send outJson to the editor
+//     postMessage(outJson);
+//   });
+//
+//   // When a message arrives from the editor:
+//   onmessage = (event) => {
+//     const response = server.handleMessage(event.data);
+//     if (response) {
+//       postMessage(response);
+//     }
+//   };
+
+/// An LSP server that runs in WebAssembly.
+///
+/// Instead of stdio, this server communicates via:
+/// - `handleMessage(json)` -- receives incoming JSON-RPC messages
+/// - A callback function -- sends outgoing notifications (diagnostics, etc.)
+///
+/// The callback is called whenever the server needs to push a message to the
+/// client (e.g., `textDocument/publishDiagnostics`). Request responses are
+/// returned directly from `handleMessage()`.
+#[wasm_bindgen]
+pub struct WasmLspServer {
+    /// The language bridge (owned, moved in from WasmLanguageBridge).
+    bridge: Box<dyn LanguageBridge>,
+    /// Tracks open documents and their current contents.
+    doc_manager: DocumentManager,
+    /// Caches parse results to avoid redundant parsing.
+    parse_cache: ParseCache,
+    /// JS callback for sending outgoing notifications.
+    /// Wrapped in Option so that native tests can create a server without a
+    /// real JS function (js_sys::Function panics outside WASM targets).
+    send_callback: Option<js_sys::Function>,
+    /// Whether the server has been initialized (received "initialize").
+    initialized: bool,
+    /// Whether the server has received "shutdown".
+    shutdown: bool,
+}
+
+#[wasm_bindgen]
+impl WasmLspServer {
+    /// Create a new WASM LSP server.
+    ///
+    /// - `bridge`: a `WasmLanguageBridge` that provides tokenize/parse logic
+    /// - `send_callback`: a JS function `(json: string) -> void` that will be
+    ///   called whenever the server needs to send a notification to the client
+    ///   (e.g., diagnostics after a file is opened or changed)
+    ///
+    /// ## Example (JavaScript)
+    ///
+    /// ```javascript
+    /// const bridge = new WasmLanguageBridge(tokenize, parse);
+    /// const server = new WasmLspServer(bridge, (json) => {
+    ///   // Send to editor via WebSocket, postMessage, etc.
+    ///   socket.send(json);
+    /// });
+    /// ```
+    #[wasm_bindgen(constructor)]
+    pub fn new(bridge: WasmLanguageBridge, send_callback: js_sys::Function) -> WasmLspServer {
+        WasmLspServer {
+            bridge: Box::new(bridge),
+            doc_manager: DocumentManager::new(),
+            parse_cache: ParseCache::new(),
+            send_callback: Some(send_callback),
+            initialized: false,
+            shutdown: false,
+        }
+    }
+
+    /// Process an incoming JSON-RPC message and return the response (if any).
+    ///
+    /// The input `json` should be a complete JSON-RPC 2.0 message object as a
+    /// string. The return value is:
+    /// - A JSON string containing the response (for requests)
+    /// - An empty string (for notifications, which don't produce responses)
+    ///
+    /// Any server-initiated notifications (like `publishDiagnostics`) are sent
+    /// via the `send_callback` provided in the constructor, NOT returned here.
+    ///
+    /// ## Message Flow
+    ///
+    /// ```text
+    /// JS calls handleMessage('{"jsonrpc":"2.0","id":1,"method":"initialize",...}')
+    ///   -> returns '{"jsonrpc":"2.0","id":1,"result":{...capabilities...}}'
+    ///
+    /// JS calls handleMessage('{"jsonrpc":"2.0","method":"textDocument/didOpen",...}')
+    ///   -> returns ""  (notification, no response)
+    ///   -> send_callback is called with publishDiagnostics notification
+    /// ```
+    #[wasm_bindgen(js_name = "handleMessage")]
+    pub fn handle_message(&mut self, json: &str) -> String {
+        // Parse the incoming JSON-RPC message.
+        let msg: Value = match serde_json::from_str(json) {
+            Ok(v) => v,
+            Err(e) => {
+                // Return a JSON-RPC parse error response.
+                return serde_json::to_string(&json!({
+                    "jsonrpc": "2.0",
+                    "id": null,
+                    "error": {
+                        "code": -32700,
+                        "message": format!("Parse error: {}", e)
+                    }
+                }))
+                .unwrap_or_default();
+            }
+        };
+
+        // Determine if this is a request (has "id") or notification (no "id").
+        let id = msg.get("id").cloned();
+        let method = msg["method"].as_str().unwrap_or("");
+
+        if let Some(id) = id {
+            // This is a request -- dispatch and return the response.
+            let params = msg.get("params").cloned();
+            let result = self.dispatch_request(method, params);
+
+            let response = match result {
+                Ok(value) => json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": value
+                }),
+                Err((code, message)) => json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "error": {
+                        "code": code,
+                        "message": message
+                    }
+                }),
+            };
+
+            serde_json::to_string(&response).unwrap_or_default()
+        } else {
+            // This is a notification -- dispatch and return empty string.
+            let params = msg.get("params").cloned();
+            self.dispatch_notification(method, params);
+            String::new()
+        }
+    }
+
+    /// Check whether the server has been initialized.
+    ///
+    /// Returns `true` after the `initialize` request has been processed.
+    #[wasm_bindgen(js_name = "isInitialized")]
+    pub fn is_initialized(&self) -> bool {
+        self.initialized
+    }
+
+    /// Check whether the server has received a shutdown request.
+    #[wasm_bindgen(js_name = "isShutdown")]
+    pub fn is_shutdown(&self) -> bool {
+        self.shutdown
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal dispatch logic
+// ---------------------------------------------------------------------------
+//
+// These methods are NOT exported to JavaScript (no #[wasm_bindgen]).
+// They contain the core message dispatch logic, reusing the same handler
+// patterns from the Rust LspServer but adapted for the message-passing API.
+
+impl WasmLspServer {
+    /// Dispatch a JSON-RPC request to the appropriate handler.
+    ///
+    /// Returns `Ok(Value)` for success or `Err((code, message))` for errors.
+    /// The error format uses standard JSON-RPC error codes:
+    /// - `-32601` for "method not found"
+    /// - `-32602` for "invalid params"
+    /// - `-32603` for "internal error"
+    fn dispatch_request(
+        &mut self,
+        method: &str,
+        params: Option<Value>,
+    ) -> Result<Value, (i32, String)> {
+        match method {
+            "initialize" => self.handle_initialize(params),
+            "shutdown" => self.handle_shutdown(),
+            "textDocument/hover" => self.handle_hover(params),
+            "textDocument/definition" => self.handle_definition(params),
+            "textDocument/references" => self.handle_references(params),
+            "textDocument/completion" => self.handle_completion(params),
+            "textDocument/rename" => self.handle_rename(params),
+            "textDocument/documentSymbol" => self.handle_document_symbol(params),
+            "textDocument/semanticTokens/full" => self.handle_semantic_tokens_full(params),
+            "textDocument/foldingRange" => self.handle_folding_range(params),
+            "textDocument/signatureHelp" => self.handle_signature_help(params),
+            "textDocument/formatting" => self.handle_formatting(params),
+            _ => Err((-32601, format!("Method not found: {}", method))),
+        }
+    }
+
+    /// Dispatch a JSON-RPC notification.
+    ///
+    /// Notifications have no response. Side effects (like sending diagnostics)
+    /// are delivered via the send_callback.
+    fn dispatch_notification(&mut self, method: &str, params: Option<Value>) {
+        match method {
+            "initialized" => { /* handshake complete, no-op */ }
+            "textDocument/didOpen" => self.handle_did_open(params),
+            "textDocument/didChange" => self.handle_did_change(params),
+            "textDocument/didClose" => self.handle_did_close(params),
+            "textDocument/didSave" => self.handle_did_save(params),
+            _ => { /* unknown notifications are silently dropped */ }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Lifecycle handlers
+    // -----------------------------------------------------------------------
+
+    /// Handle `initialize` -- return server capabilities.
+    ///
+    /// This builds the capabilities object by inspecting which features the
+    /// language bridge supports (hover, completion, etc.) and returns them
+    /// to the editor so it knows what requests to send.
+    fn handle_initialize(&mut self, _params: Option<Value>) -> Result<Value, (i32, String)> {
+        self.initialized = true;
+
+        let caps = build_capabilities(self.bridge.as_ref());
+
+        Ok(json!({
+            "capabilities": caps,
+            "serverInfo": {
+                "name": "ls00-wasm-lsp-server",
+                "version": "0.1.0"
+            }
+        }))
+    }
+
+    /// Handle `shutdown` -- mark the server as shut down.
+    fn handle_shutdown(&mut self) -> Result<Value, (i32, String)> {
+        self.shutdown = true;
+        Ok(Value::Null)
+    }
+
+    // -----------------------------------------------------------------------
+    // Document synchronization handlers
+    // -----------------------------------------------------------------------
+
+    /// Handle `textDocument/didOpen` -- open a document and publish diagnostics.
+    ///
+    /// When the editor opens a file, it sends the full text. We store it in
+    /// the document manager, parse it, and push diagnostics to the editor.
+    fn handle_did_open(&mut self, params: Option<Value>) {
+        let params = match params {
+            Some(p) => p,
+            None => return,
+        };
+
+        let td = &params["textDocument"];
+        let uri = td["uri"].as_str().unwrap_or("").to_string();
+        let text = td["text"].as_str().unwrap_or("").to_string();
+        let version = td["version"].as_i64().unwrap_or(1) as i32;
+
+        if uri.is_empty() {
+            return;
+        }
+
+        self.doc_manager.open(&uri, &text, version);
+
+        let result = self
+            .parse_cache
+            .get_or_parse(&uri, version, &text, self.bridge.as_ref());
+        let diags = result.diagnostics.clone();
+        self.publish_diagnostics(&uri, version, &diags);
+    }
+
+    /// Handle `textDocument/didChange` -- apply incremental changes.
+    ///
+    /// The editor sends only the changed portions of the document. We apply
+    /// the changes, re-parse, and push updated diagnostics.
+    fn handle_did_change(&mut self, params: Option<Value>) {
+        let params = match params {
+            Some(p) => p,
+            None => return,
+        };
+
+        let uri = params["textDocument"]["uri"]
+            .as_str()
+            .unwrap_or("")
+            .to_string();
+        if uri.is_empty() {
+            return;
+        }
+
+        let version = params["textDocument"]["version"]
+            .as_i64()
+            .unwrap_or(0) as i32;
+
+        let changes_raw = match params["contentChanges"].as_array() {
+            Some(arr) => arr.clone(),
+            None => return,
+        };
+
+        let changes: Vec<coding_adventures_ls00::document_manager::TextChange> = changes_raw
+            .iter()
+            .map(|change| {
+                let new_text = change["text"].as_str().unwrap_or("").to_string();
+                let range = if change.get("range").is_some() && !change["range"].is_null() {
+                    let r = &change["range"];
+                    Some(Range {
+                        start: Position {
+                            line: r["start"]["line"].as_i64().unwrap_or(0) as i32,
+                            character: r["start"]["character"].as_i64().unwrap_or(0) as i32,
+                        },
+                        end: Position {
+                            line: r["end"]["line"].as_i64().unwrap_or(0) as i32,
+                            character: r["end"]["character"].as_i64().unwrap_or(0) as i32,
+                        },
+                    })
+                } else {
+                    None
+                };
+                coding_adventures_ls00::document_manager::TextChange { range, new_text }
+            })
+            .collect();
+
+        if self
+            .doc_manager
+            .apply_changes(&uri, &changes, version)
+            .is_err()
+        {
+            return;
+        }
+
+        let doc = match self.doc_manager.get(&uri) {
+            Some(d) => d,
+            None => return,
+        };
+
+        let doc_text = doc.text.clone();
+        let doc_version = doc.version;
+
+        let result = self
+            .parse_cache
+            .get_or_parse(&uri, doc_version, &doc_text, self.bridge.as_ref());
+        let diags = result.diagnostics.clone();
+        self.publish_diagnostics(&uri, version, &diags);
+    }
+
+    /// Handle `textDocument/didClose` -- remove the document.
+    fn handle_did_close(&mut self, params: Option<Value>) {
+        let params = match params {
+            Some(p) => p,
+            None => return,
+        };
+
+        let uri = params["textDocument"]["uri"]
+            .as_str()
+            .unwrap_or("")
+            .to_string();
+        if uri.is_empty() {
+            return;
+        }
+
+        self.doc_manager.close(&uri);
+        self.parse_cache.evict(&uri);
+        self.publish_diagnostics(&uri, 0, &[]);
+    }
+
+    /// Handle `textDocument/didSave` -- optionally re-parse with saved content.
+    fn handle_did_save(&mut self, params: Option<Value>) {
+        let params = match params {
+            Some(p) => p,
+            None => return,
+        };
+
+        let uri = params["textDocument"]["uri"]
+            .as_str()
+            .unwrap_or("")
+            .to_string();
+        if uri.is_empty() {
+            return;
+        }
+
+        if let Some(text) = params["text"].as_str() {
+            if !text.is_empty() {
+                if let Some(doc) = self.doc_manager.get(&uri) {
+                    let version = doc.version;
+                    self.doc_manager.close(&uri);
+                    self.doc_manager.open(&uri, text, version);
+                    let result = self
+                        .parse_cache
+                        .get_or_parse(&uri, version, text, self.bridge.as_ref());
+                    let diags = result.diagnostics.clone();
+                    self.publish_diagnostics(&uri, version, &diags);
+                }
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Feature handlers
+    // -----------------------------------------------------------------------
+    //
+    // Each feature handler follows the same pattern from the core crate:
+    // 1. Extract URI and position from params.
+    // 2. Check if the bridge supports the feature.
+    // 3. Get the parse result.
+    // 4. Delegate to the bridge.
+    // 5. Convert the result to LSP JSON format.
+
+    /// Handle `textDocument/hover` -- return hover information.
+    fn handle_hover(&mut self, params: Option<Value>) -> Result<Value, (i32, String)> {
+        let params = params.ok_or((-32602, "Missing params".to_string()))?;
+        let uri = extract_uri(&params);
+        let pos = extract_position(&params);
+
+        if !self.bridge.supports_hover() {
+            return Ok(Value::Null);
+        }
+
+        let (ast, _) = self.get_parse_result(&uri)?;
+        let ast = match &ast {
+            Some(a) => a,
+            None => return Ok(Value::Null),
+        };
+
+        match self.bridge.hover(ast.as_ref(), pos) {
+            None | Some(Err(_)) | Some(Ok(None)) => Ok(Value::Null),
+            Some(Ok(Some(hover))) => {
+                let mut result = json!({
+                    "contents": {
+                        "kind": "markdown",
+                        "value": hover.contents
+                    }
+                });
+                if let Some(range) = &hover.range {
+                    result["range"] = range_to_json(range);
+                }
+                Ok(result)
+            }
+        }
+    }
+
+    /// Handle `textDocument/definition` -- return definition location.
+    fn handle_definition(&mut self, params: Option<Value>) -> Result<Value, (i32, String)> {
+        let params = params.ok_or((-32602, "Missing params".to_string()))?;
+        let uri = extract_uri(&params);
+        let pos = extract_position(&params);
+
+        if !self.bridge.supports_definition() {
+            return Ok(Value::Null);
+        }
+
+        let (ast, _) = self.get_parse_result(&uri)?;
+        let ast = match &ast {
+            Some(a) => a,
+            None => return Ok(Value::Null),
+        };
+
+        match self.bridge.definition(ast.as_ref(), pos, &uri) {
+            None | Some(Err(_)) | Some(Ok(None)) => Ok(Value::Null),
+            Some(Ok(Some(loc))) => Ok(location_to_json(&loc)),
+        }
+    }
+
+    /// Handle `textDocument/references` -- return all references.
+    fn handle_references(&mut self, params: Option<Value>) -> Result<Value, (i32, String)> {
+        let params = params.ok_or((-32602, "Missing params".to_string()))?;
+        let uri = extract_uri(&params);
+        let pos = extract_position(&params);
+        let include_decl = params["context"]["includeDeclaration"]
+            .as_bool()
+            .unwrap_or(false);
+
+        if !self.bridge.supports_references() {
+            return Ok(json!([]));
+        }
+
+        let (ast, _) = self.get_parse_result(&uri)?;
+        let ast = match &ast {
+            Some(a) => a,
+            None => return Ok(json!([])),
+        };
+
+        match self
+            .bridge
+            .references(ast.as_ref(), pos, &uri, include_decl)
+        {
+            None | Some(Err(_)) => Ok(json!([])),
+            Some(Ok(locs)) => {
+                let result: Vec<Value> = locs.iter().map(location_to_json).collect();
+                Ok(Value::Array(result))
+            }
+        }
+    }
+
+    /// Handle `textDocument/completion` -- return autocomplete suggestions.
+    fn handle_completion(&mut self, params: Option<Value>) -> Result<Value, (i32, String)> {
+        let params = params.ok_or((-32602, "Missing params".to_string()))?;
+        let uri = extract_uri(&params);
+        let pos = extract_position(&params);
+
+        let empty = json!({"isIncomplete": false, "items": []});
+
+        if !self.bridge.supports_completion() {
+            return Ok(empty);
+        }
+
+        let (ast, _) = self.get_parse_result(&uri)?;
+        let ast = match &ast {
+            Some(a) => a,
+            None => return Ok(empty),
+        };
+
+        match self.bridge.completion(ast.as_ref(), pos) {
+            None | Some(Err(_)) => Ok(empty),
+            Some(Ok(items)) => {
+                let lsp_items: Vec<Value> = items
+                    .iter()
+                    .map(|item| {
+                        let mut ci = json!({"label": item.label});
+                        if let Some(kind) = &item.kind {
+                            ci["kind"] = json!(*kind as i32);
+                        }
+                        if let Some(detail) = &item.detail {
+                            if !detail.is_empty() {
+                                ci["detail"] = json!(detail);
+                            }
+                        }
+                        if let Some(doc) = &item.documentation {
+                            if !doc.is_empty() {
+                                ci["documentation"] = json!(doc);
+                            }
+                        }
+                        if let Some(text) = &item.insert_text {
+                            if !text.is_empty() {
+                                ci["insertText"] = json!(text);
+                            }
+                        }
+                        if let Some(fmt) = &item.insert_text_format {
+                            if *fmt != 0 {
+                                ci["insertTextFormat"] = json!(fmt);
+                            }
+                        }
+                        ci
+                    })
+                    .collect();
+
+                Ok(json!({"isIncomplete": false, "items": lsp_items}))
+            }
+        }
+    }
+
+    /// Handle `textDocument/rename` -- return workspace edits for renaming.
+    fn handle_rename(&mut self, params: Option<Value>) -> Result<Value, (i32, String)> {
+        let params = params.ok_or((-32602, "Missing params".to_string()))?;
+        let uri = extract_uri(&params);
+        let pos = extract_position(&params);
+        let new_name = params["newName"].as_str().unwrap_or("");
+
+        if new_name.is_empty() {
+            return Err((-32602, "newName is required".to_string()));
+        }
+
+        if !self.bridge.supports_rename() {
+            return Err((-32803, "Rename not supported".to_string()));
+        }
+
+        let (ast, _) = self.get_parse_result(&uri)?;
+        let ast = match &ast {
+            Some(a) => a,
+            None => return Err((-32803, "No AST available".to_string())),
+        };
+
+        match self.bridge.rename(ast.as_ref(), pos, new_name) {
+            None | Some(Ok(None)) => Err((-32803, "Symbol not found at position".to_string())),
+            Some(Err(e)) => Err((-32803, e)),
+            Some(Ok(Some(edit))) => {
+                let mut lsp_changes = serde_json::Map::new();
+                for (edit_uri, edits) in &edit.changes {
+                    let lsp_edits: Vec<Value> = edits
+                        .iter()
+                        .map(|te| {
+                            json!({
+                                "range": range_to_json(&te.range),
+                                "newText": te.new_text
+                            })
+                        })
+                        .collect();
+                    lsp_changes.insert(edit_uri.clone(), Value::Array(lsp_edits));
+                }
+                Ok(json!({"changes": lsp_changes}))
+            }
+        }
+    }
+
+    /// Handle `textDocument/documentSymbol` -- return the document outline.
+    fn handle_document_symbol(&mut self, params: Option<Value>) -> Result<Value, (i32, String)> {
+        let params = params.ok_or((-32602, "Missing params".to_string()))?;
+        let uri = extract_uri(&params);
+
+        if !self.bridge.supports_document_symbols() {
+            return Ok(json!([]));
+        }
+
+        let (ast, _) = self.get_parse_result(&uri)?;
+        let ast = match &ast {
+            Some(a) => a,
+            None => return Ok(json!([])),
+        };
+
+        match self.bridge.document_symbols(ast.as_ref()) {
+            None | Some(Err(_)) => Ok(json!([])),
+            Some(Ok(symbols)) => Ok(Value::Array(convert_document_symbols(&symbols))),
+        }
+    }
+
+    /// Handle `textDocument/semanticTokens/full` -- return semantic tokens.
+    fn handle_semantic_tokens_full(
+        &mut self,
+        params: Option<Value>,
+    ) -> Result<Value, (i32, String)> {
+        let params = params.ok_or((-32602, "Missing params".to_string()))?;
+        let uri = extract_uri(&params);
+        let empty = json!({"data": []});
+
+        if !self.bridge.supports_semantic_tokens() {
+            return Ok(empty);
+        }
+
+        let doc = match self.doc_manager.get(&uri) {
+            Some(d) => d,
+            None => return Ok(empty),
+        };
+        let doc_text = doc.text.clone();
+
+        let tokens = match self.bridge.tokenize(&doc_text) {
+            Ok(t) => t,
+            Err(_) => return Ok(empty),
+        };
+
+        match self.bridge.semantic_tokens(&doc_text, &tokens) {
+            None | Some(Err(_)) => Ok(empty),
+            Some(Ok(sem_tokens)) => {
+                let data = coding_adventures_ls00::capabilities::encode_semantic_tokens(&sem_tokens);
+                Ok(json!({"data": data}))
+            }
+        }
+    }
+
+    /// Handle `textDocument/foldingRange` -- return collapsible regions.
+    fn handle_folding_range(&mut self, params: Option<Value>) -> Result<Value, (i32, String)> {
+        let params = params.ok_or((-32602, "Missing params".to_string()))?;
+        let uri = extract_uri(&params);
+
+        if !self.bridge.supports_folding_ranges() {
+            return Ok(json!([]));
+        }
+
+        let (ast, _) = self.get_parse_result(&uri)?;
+        let ast = match &ast {
+            Some(a) => a,
+            None => return Ok(json!([])),
+        };
+
+        match self.bridge.folding_ranges(ast.as_ref()) {
+            None | Some(Err(_)) => Ok(json!([])),
+            Some(Ok(ranges)) => {
+                let result: Vec<Value> = ranges
+                    .iter()
+                    .map(|fr| {
+                        let mut m = json!({
+                            "startLine": fr.start_line,
+                            "endLine": fr.end_line
+                        });
+                        if let Some(kind) = &fr.kind {
+                            m["kind"] = json!(kind);
+                        }
+                        m
+                    })
+                    .collect();
+                Ok(Value::Array(result))
+            }
+        }
+    }
+
+    /// Handle `textDocument/signatureHelp` -- return function signature hints.
+    fn handle_signature_help(&mut self, params: Option<Value>) -> Result<Value, (i32, String)> {
+        let params = params.ok_or((-32602, "Missing params".to_string()))?;
+        let uri = extract_uri(&params);
+        let pos = extract_position(&params);
+
+        if !self.bridge.supports_signature_help() {
+            return Ok(Value::Null);
+        }
+
+        let (ast, _) = self.get_parse_result(&uri)?;
+        let ast = match &ast {
+            Some(a) => a,
+            None => return Ok(Value::Null),
+        };
+
+        match self.bridge.signature_help(ast.as_ref(), pos) {
+            None | Some(Err(_)) | Some(Ok(None)) => Ok(Value::Null),
+            Some(Ok(Some(sig_help))) => {
+                let lsp_sigs: Vec<Value> = sig_help
+                    .signatures
+                    .iter()
+                    .map(|sig| {
+                        let lsp_params: Vec<Value> = sig
+                            .parameters
+                            .iter()
+                            .map(|p| {
+                                let mut pp = json!({"label": p.label});
+                                if let Some(doc) = &p.documentation {
+                                    if !doc.is_empty() {
+                                        pp["documentation"] = json!(doc);
+                                    }
+                                }
+                                pp
+                            })
+                            .collect();
+                        let mut s = json!({
+                            "label": sig.label,
+                            "parameters": lsp_params
+                        });
+                        if let Some(doc) = &sig.documentation {
+                            if !doc.is_empty() {
+                                s["documentation"] = json!(doc);
+                            }
+                        }
+                        s
+                    })
+                    .collect();
+
+                Ok(json!({
+                    "signatures": lsp_sigs,
+                    "activeSignature": sig_help.active_signature,
+                    "activeParameter": sig_help.active_parameter
+                }))
+            }
+        }
+    }
+
+    /// Handle `textDocument/formatting` -- return text edits for formatting.
+    fn handle_formatting(&mut self, params: Option<Value>) -> Result<Value, (i32, String)> {
+        let params = params.ok_or((-32602, "Missing params".to_string()))?;
+        let uri = extract_uri(&params);
+
+        if !self.bridge.supports_format() {
+            return Ok(json!([]));
+        }
+
+        let doc = match self.doc_manager.get(&uri) {
+            Some(d) => d,
+            None => return Ok(json!([])),
+        };
+        let doc_text = doc.text.clone();
+
+        match self.bridge.format(&doc_text) {
+            None => Ok(json!([])),
+            Some(Err(e)) => Err((-32803, format!("Formatting failed: {}", e))),
+            Some(Ok(edits)) => {
+                let lsp_edits: Vec<Value> = edits
+                    .iter()
+                    .map(|edit| {
+                        json!({
+                            "range": range_to_json(&edit.range),
+                            "newText": edit.new_text
+                        })
+                    })
+                    .collect();
+                Ok(Value::Array(lsp_edits))
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal helpers
+    // -----------------------------------------------------------------------
+
+    /// Get a fresh parse result for a document.
+    ///
+    /// Returns the AST and diagnostics. If the document is not open, returns
+    /// an error. Uses the parse cache to avoid redundant parsing.
+    fn get_parse_result(
+        &mut self,
+        uri: &str,
+    ) -> Result<(Option<Box<dyn Any + Send + Sync>>, Vec<Diagnostic>), (i32, String)> {
+        let doc = self.doc_manager.get(uri).ok_or_else(|| {
+            (-32803i32, format!("Document not open: {}", uri))
+        })?;
+
+        let text = doc.text.clone();
+        let version = doc.version;
+
+        // Ensure the cache is populated.
+        let cached = self
+            .parse_cache
+            .get_or_parse(uri, version, &text, self.bridge.as_ref());
+        let cached_diags = cached.diagnostics.clone();
+
+        // Re-parse for an owned AST (the cache stores its own copy).
+        match self.bridge.parse(&text) {
+            Ok((ast, _)) => Ok((Some(ast), cached_diags)),
+            Err(_) => Ok((None, cached_diags)),
+        }
+    }
+
+    /// Send a notification to the client via the JS callback.
+    ///
+    /// This is the WASM equivalent of writing to stdout. The notification is
+    /// serialized as a JSON-RPC notification string and passed to the callback.
+    ///
+    /// If no callback is registered (e.g., in native tests), the notification
+    /// is silently dropped.
+    fn send_notification(&self, method: &str, params: Value) {
+        let callback = match &self.send_callback {
+            Some(cb) => cb,
+            None => return, // no callback registered (native test mode)
+        };
+
+        let notif = json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params
+        });
+
+        let json_str = serde_json::to_string(&notif).unwrap_or_default();
+        let this = JsValue::NULL;
+        let _ = callback.call1(&this, &JsValue::from_str(&json_str));
+    }
+
+    /// Publish diagnostics to the client.
+    ///
+    /// Builds the `textDocument/publishDiagnostics` notification and sends it
+    /// via the callback. This is called after every document open/change.
+    fn publish_diagnostics(&self, uri: &str, version: i32, diagnostics: &[Diagnostic]) {
+        let lsp_diags: Vec<Value> = diagnostics
+            .iter()
+            .map(|d| {
+                let mut diag = json!({
+                    "range": {
+                        "start": {"line": d.range.start.line, "character": d.range.start.character},
+                        "end": {"line": d.range.end.line, "character": d.range.end.character}
+                    },
+                    "severity": d.severity as i32,
+                    "message": d.message
+                });
+                if let Some(code) = &d.code {
+                    diag["code"] = json!(code);
+                }
+                diag
+            })
+            .collect();
+
+        let mut params = json!({
+            "uri": uri,
+            "diagnostics": lsp_diags
+        });
+
+        if version > 0 {
+            params["version"] = json!(version);
+        }
+
+        self.send_notification("textDocument/publishDiagnostics", params);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// JSON helpers
+// ---------------------------------------------------------------------------
+//
+// These are utility functions for converting between LSP types and JSON
+// values. They mirror the helpers in the core crate's handlers module.
+
+/// Extract the document URI from params that have a `textDocument` field.
+fn extract_uri(params: &Value) -> String {
+    params["textDocument"]["uri"]
+        .as_str()
+        .unwrap_or("")
+        .to_string()
+}
+
+/// Extract a Position from params that have a `position` field.
+fn extract_position(params: &Value) -> Position {
+    let pos = &params["position"];
+    Position {
+        line: pos["line"].as_i64().unwrap_or(0) as i32,
+        character: pos["character"].as_i64().unwrap_or(0) as i32,
+    }
+}
+
+/// Convert a Position to a JSON value.
+fn position_to_json(p: &Position) -> Value {
+    json!({"line": p.line, "character": p.character})
+}
+
+/// Convert a Range to a JSON value.
+fn range_to_json(r: &Range) -> Value {
+    json!({
+        "start": position_to_json(&r.start),
+        "end": position_to_json(&r.end)
+    })
+}
+
+/// Convert a Location to a JSON value.
+fn location_to_json(l: &Location) -> Value {
+    json!({
+        "uri": l.uri,
+        "range": range_to_json(&l.range)
+    })
+}
+
+/// Recursively convert DocumentSymbol trees to JSON values.
+fn convert_document_symbols(symbols: &[DocumentSymbol]) -> Vec<Value> {
+    symbols
+        .iter()
+        .map(|sym| {
+            let mut m = json!({
+                "name": sym.name,
+                "kind": sym.kind as i32,
+                "range": range_to_json(&sym.range),
+                "selectionRange": range_to_json(&sym.selection_range)
+            });
+            if !sym.children.is_empty() {
+                m["children"] = Value::Array(convert_document_symbols(&sym.children));
+            }
+            m
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Native Rust tests
+// ---------------------------------------------------------------------------
+//
+// These tests verify the WASM wrapper's internal logic (JSON parsing,
+// diagnostic extraction, message dispatch) without needing WASM tooling.
+// They are excluded when compiling for WASM.
+//
+// Since WasmLanguageBridge requires JS functions (which don't exist in
+// native Rust), we test using a mock bridge that implements LanguageBridge
+// directly.
+
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -----------------------------------------------------------------------
+    // Mock bridge for testing
+    // -----------------------------------------------------------------------
+
+    /// A minimal bridge that tokenizes by splitting on whitespace and
+    /// produces a trivial AST.
+    struct MockBridge;
+
+    impl LanguageBridge for MockBridge {
+        fn tokenize(&self, source: &str) -> Result<Vec<Token>, String> {
+            let mut tokens = Vec::new();
+            for (line_idx, line) in source.lines().enumerate() {
+                let mut col = 1;
+                for word in line.split_whitespace() {
+                    tokens.push(Token {
+                        token_type: "IDENTIFIER".to_string(),
+                        value: word.to_string(),
+                        line: (line_idx + 1) as i32,
+                        column: col,
+                    });
+                    col += word.len() as i32 + 1;
+                }
+            }
+            Ok(tokens)
+        }
+
+        fn parse(
+            &self,
+            source: &str,
+        ) -> Result<(Box<dyn Any + Send + Sync>, Vec<Diagnostic>), String> {
+            // Store the source as the "AST" for simplicity.
+            let ast = Box::new(JsAst {
+                json: source.to_string(),
+            }) as Box<dyn Any + Send + Sync>;
+            Ok((ast, Vec::new()))
+        }
+    }
+
+    /// Create a test server with the MockBridge.
+    ///
+    /// Since we can't create JS functions in native Rust, we set
+    /// `send_callback` to `None`. The server will silently skip sending
+    /// notifications (like `publishDiagnostics`) in this mode, which
+    /// is fine for testing the dispatch logic.
+    fn make_test_server() -> WasmLspServer {
+        WasmLspServer {
+            bridge: Box::new(MockBridge),
+            doc_manager: DocumentManager::new(),
+            parse_cache: ParseCache::new(),
+            send_callback: None,
+            initialized: false,
+            shutdown: false,
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Diagnostic parsing tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_diagnostics_empty() {
+        let diags = parse_diagnostics_from_json(&Value::Null);
+        assert!(diags.is_empty(), "Null should produce empty diagnostics");
+    }
+
+    #[test]
+    fn test_parse_diagnostics_empty_array() {
+        let diags = parse_diagnostics_from_json(&json!([]));
+        assert!(diags.is_empty(), "Empty array should produce empty diagnostics");
+    }
+
+    #[test]
+    fn test_parse_diagnostics_single() {
+        let input = json!([{
+            "range": {
+                "start": {"line": 0, "character": 0},
+                "end": {"line": 0, "character": 5}
+            },
+            "severity": 1,
+            "message": "unexpected token"
+        }]);
+
+        let diags = parse_diagnostics_from_json(&input);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].message, "unexpected token");
+        assert_eq!(diags[0].severity, DiagnosticSeverity::Error);
+        assert_eq!(diags[0].range.start.line, 0);
+        assert_eq!(diags[0].range.start.character, 0);
+        assert_eq!(diags[0].range.end.line, 0);
+        assert_eq!(diags[0].range.end.character, 5);
+    }
+
+    #[test]
+    fn test_parse_diagnostics_with_code() {
+        let input = json!([{
+            "range": {
+                "start": {"line": 1, "character": 3},
+                "end": {"line": 1, "character": 10}
+            },
+            "severity": 2,
+            "message": "unused variable",
+            "code": "W001"
+        }]);
+
+        let diags = parse_diagnostics_from_json(&input);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, DiagnosticSeverity::Warning);
+        assert_eq!(diags[0].code, Some("W001".to_string()));
+    }
+
+    #[test]
+    fn test_parse_diagnostics_all_severities() {
+        let input = json!([
+            {"range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 1}}, "severity": 1, "message": "error"},
+            {"range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 1}}, "severity": 2, "message": "warning"},
+            {"range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 1}}, "severity": 3, "message": "info"},
+            {"range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 1}}, "severity": 4, "message": "hint"}
+        ]);
+
+        let diags = parse_diagnostics_from_json(&input);
+        assert_eq!(diags.len(), 4);
+        assert_eq!(diags[0].severity, DiagnosticSeverity::Error);
+        assert_eq!(diags[1].severity, DiagnosticSeverity::Warning);
+        assert_eq!(diags[2].severity, DiagnosticSeverity::Information);
+        assert_eq!(diags[3].severity, DiagnosticSeverity::Hint);
+    }
+
+    #[test]
+    fn test_parse_diagnostics_multiple() {
+        let input = json!([
+            {
+                "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 3}},
+                "severity": 1,
+                "message": "first error"
+            },
+            {
+                "range": {"start": {"line": 2, "character": 5}, "end": {"line": 2, "character": 10}},
+                "severity": 2,
+                "message": "second warning"
+            }
+        ]);
+
+        let diags = parse_diagnostics_from_json(&input);
+        assert_eq!(diags.len(), 2);
+        assert_eq!(diags[0].message, "first error");
+        assert_eq!(diags[1].message, "second warning");
+        assert_eq!(diags[1].range.start.line, 2);
+        assert_eq!(diags[1].range.start.character, 5);
+    }
+
+    // -----------------------------------------------------------------------
+    // JSON helper tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_extract_uri() {
+        let params = json!({
+            "textDocument": {"uri": "file:///test.rs"}
+        });
+        assert_eq!(extract_uri(&params), "file:///test.rs");
+    }
+
+    #[test]
+    fn test_extract_uri_missing() {
+        let params = json!({});
+        assert_eq!(extract_uri(&params), "");
+    }
+
+    #[test]
+    fn test_extract_position() {
+        let params = json!({
+            "position": {"line": 5, "character": 10}
+        });
+        let pos = extract_position(&params);
+        assert_eq!(pos.line, 5);
+        assert_eq!(pos.character, 10);
+    }
+
+    #[test]
+    fn test_extract_position_defaults() {
+        let params = json!({});
+        let pos = extract_position(&params);
+        assert_eq!(pos.line, 0);
+        assert_eq!(pos.character, 0);
+    }
+
+    #[test]
+    fn test_position_to_json() {
+        let pos = Position {
+            line: 3,
+            character: 7,
+        };
+        let j = position_to_json(&pos);
+        assert_eq!(j["line"], 3);
+        assert_eq!(j["character"], 7);
+    }
+
+    #[test]
+    fn test_range_to_json() {
+        let range = Range {
+            start: Position {
+                line: 1,
+                character: 2,
+            },
+            end: Position {
+                line: 3,
+                character: 4,
+            },
+        };
+        let j = range_to_json(&range);
+        assert_eq!(j["start"]["line"], 1);
+        assert_eq!(j["start"]["character"], 2);
+        assert_eq!(j["end"]["line"], 3);
+        assert_eq!(j["end"]["character"], 4);
+    }
+
+    #[test]
+    fn test_location_to_json() {
+        let loc = Location {
+            uri: "file:///test.rs".to_string(),
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 5,
+                },
+            },
+        };
+        let j = location_to_json(&loc);
+        assert_eq!(j["uri"], "file:///test.rs");
+        assert_eq!(j["range"]["start"]["line"], 0);
+    }
+
+    #[test]
+    fn test_convert_document_symbols_empty() {
+        let symbols: Vec<DocumentSymbol> = Vec::new();
+        let result = convert_document_symbols(&symbols);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_convert_document_symbols_nested() {
+        let symbols = vec![DocumentSymbol {
+            name: "main".to_string(),
+            kind: SymbolKind::Function,
+            range: Range {
+                start: Position { line: 0, character: 0 },
+                end: Position { line: 5, character: 1 },
+            },
+            selection_range: Range {
+                start: Position { line: 0, character: 3 },
+                end: Position { line: 0, character: 7 },
+            },
+            children: vec![DocumentSymbol {
+                name: "x".to_string(),
+                kind: SymbolKind::Variable,
+                range: Range {
+                    start: Position { line: 1, character: 4 },
+                    end: Position { line: 1, character: 10 },
+                },
+                selection_range: Range {
+                    start: Position { line: 1, character: 8 },
+                    end: Position { line: 1, character: 9 },
+                },
+                children: Vec::new(),
+            }],
+        }];
+
+        let result = convert_document_symbols(&symbols);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0]["name"], "main");
+        assert_eq!(result[0]["kind"], SymbolKind::Function as i32);
+        let children = result[0]["children"].as_array().unwrap();
+        assert_eq!(children.len(), 1);
+        assert_eq!(children[0]["name"], "x");
+    }
+
+    // -----------------------------------------------------------------------
+    // Dispatch tests (using the mock bridge directly)
+    // -----------------------------------------------------------------------
+    //
+    // We can't test handleMessage directly because it requires a real
+    // js_sys::Function. Instead, we test the internal dispatch methods.
+
+    #[test]
+    fn test_initialize() {
+        let mut server = make_test_server();
+        assert!(!server.initialized);
+
+        let result = server.handle_initialize(None);
+        assert!(result.is_ok());
+        assert!(server.initialized);
+
+        let caps = &result.unwrap();
+        assert!(caps["capabilities"].is_object());
+        assert_eq!(
+            caps["serverInfo"]["name"],
+            "ls00-wasm-lsp-server"
+        );
+    }
+
+    #[test]
+    fn test_shutdown() {
+        let mut server = make_test_server();
+        assert!(!server.shutdown);
+
+        let result = server.handle_shutdown();
+        assert!(result.is_ok());
+        assert!(server.shutdown);
+        assert_eq!(result.unwrap(), Value::Null);
+    }
+
+    #[test]
+    fn test_dispatch_request_unknown_method() {
+        let mut server = make_test_server();
+        let result = server.dispatch_request("nonexistent/method", None);
+        assert!(result.is_err());
+        let (code, msg) = result.unwrap_err();
+        assert_eq!(code, -32601);
+        assert!(msg.contains("Method not found"));
+    }
+
+    #[test]
+    fn test_dispatch_notification_unknown_method() {
+        let mut server = make_test_server();
+        // Unknown notifications should be silently dropped (no panic).
+        server.dispatch_notification("nonexistent/notification", None);
+    }
+
+    #[test]
+    fn test_hover_unsupported() {
+        let mut server = make_test_server();
+        let params = json!({
+            "textDocument": {"uri": "file:///test.rs"},
+            "position": {"line": 0, "character": 0}
+        });
+
+        let result = server.handle_hover(Some(params));
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Value::Null);
+    }
+
+    #[test]
+    fn test_hover_missing_params() {
+        let mut server = make_test_server();
+        let result = server.handle_hover(None);
+        assert!(result.is_err());
+        let (code, _) = result.unwrap_err();
+        assert_eq!(code, -32602);
+    }
+
+    #[test]
+    fn test_definition_unsupported() {
+        let mut server = make_test_server();
+        let params = json!({
+            "textDocument": {"uri": "file:///test.rs"},
+            "position": {"line": 0, "character": 0}
+        });
+        let result = server.handle_definition(Some(params));
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Value::Null);
+    }
+
+    #[test]
+    fn test_references_unsupported() {
+        let mut server = make_test_server();
+        let params = json!({
+            "textDocument": {"uri": "file:///test.rs"},
+            "position": {"line": 0, "character": 0}
+        });
+        let result = server.handle_references(Some(params));
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), json!([]));
+    }
+
+    #[test]
+    fn test_completion_unsupported() {
+        let mut server = make_test_server();
+        let params = json!({
+            "textDocument": {"uri": "file:///test.rs"},
+            "position": {"line": 0, "character": 0}
+        });
+        let result = server.handle_completion(Some(params));
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), json!({"isIncomplete": false, "items": []}));
+    }
+
+    #[test]
+    fn test_rename_unsupported() {
+        let mut server = make_test_server();
+        let params = json!({
+            "textDocument": {"uri": "file:///test.rs"},
+            "position": {"line": 0, "character": 0},
+            "newName": "foo"
+        });
+        let result = server.handle_rename(Some(params));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_rename_missing_new_name() {
+        let mut server = make_test_server();
+        let params = json!({
+            "textDocument": {"uri": "file:///test.rs"},
+            "position": {"line": 0, "character": 0}
+        });
+        let result = server.handle_rename(Some(params));
+        assert!(result.is_err());
+        let (code, msg) = result.unwrap_err();
+        assert_eq!(code, -32602);
+        assert!(msg.contains("newName"));
+    }
+
+    #[test]
+    fn test_document_symbol_unsupported() {
+        let mut server = make_test_server();
+        let params = json!({"textDocument": {"uri": "file:///test.rs"}});
+        let result = server.handle_document_symbol(Some(params));
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), json!([]));
+    }
+
+    #[test]
+    fn test_semantic_tokens_unsupported() {
+        let mut server = make_test_server();
+        let params = json!({"textDocument": {"uri": "file:///test.rs"}});
+        let result = server.handle_semantic_tokens_full(Some(params));
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), json!({"data": []}));
+    }
+
+    #[test]
+    fn test_folding_range_unsupported() {
+        let mut server = make_test_server();
+        let params = json!({"textDocument": {"uri": "file:///test.rs"}});
+        let result = server.handle_folding_range(Some(params));
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), json!([]));
+    }
+
+    #[test]
+    fn test_signature_help_unsupported() {
+        let mut server = make_test_server();
+        let params = json!({
+            "textDocument": {"uri": "file:///test.rs"},
+            "position": {"line": 0, "character": 0}
+        });
+        let result = server.handle_signature_help(Some(params));
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Value::Null);
+    }
+
+    #[test]
+    fn test_formatting_unsupported() {
+        let mut server = make_test_server();
+        let params = json!({"textDocument": {"uri": "file:///test.rs"}});
+        let result = server.handle_formatting(Some(params));
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), json!([]));
+    }
+
+    // -----------------------------------------------------------------------
+    // Document lifecycle tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_did_open_registers_document() {
+        let mut server = make_test_server();
+        server.handle_did_open(Some(json!({
+            "textDocument": {
+                "uri": "file:///test.rs",
+                "text": "let x = 1;",
+                "version": 1
+            }
+        })));
+
+        // Verify the document is tracked.
+        let doc = server.doc_manager.get("file:///test.rs");
+        assert!(doc.is_some());
+        assert_eq!(doc.unwrap().text, "let x = 1;");
+        assert_eq!(doc.unwrap().version, 1);
+    }
+
+    #[test]
+    fn test_did_open_empty_uri_ignored() {
+        let mut server = make_test_server();
+        server.handle_did_open(Some(json!({
+            "textDocument": {
+                "uri": "",
+                "text": "let x = 1;",
+                "version": 1
+            }
+        })));
+
+        // No document should be registered.
+        assert!(server.doc_manager.get("").is_none());
+    }
+
+    #[test]
+    fn test_did_open_no_params() {
+        let mut server = make_test_server();
+        // Should not panic.
+        server.handle_did_open(None);
+    }
+
+    #[test]
+    fn test_did_change_full_replacement() {
+        let mut server = make_test_server();
+
+        // Open a document first.
+        server.handle_did_open(Some(json!({
+            "textDocument": {"uri": "file:///test.rs", "text": "hello", "version": 1}
+        })));
+
+        // Full replacement (no range).
+        server.handle_did_change(Some(json!({
+            "textDocument": {"uri": "file:///test.rs", "version": 2},
+            "contentChanges": [{"text": "world"}]
+        })));
+
+        let doc = server.doc_manager.get("file:///test.rs").unwrap();
+        assert_eq!(doc.text, "world");
+        assert_eq!(doc.version, 2);
+    }
+
+    #[test]
+    fn test_did_close_removes_document() {
+        let mut server = make_test_server();
+
+        server.handle_did_open(Some(json!({
+            "textDocument": {"uri": "file:///test.rs", "text": "hello", "version": 1}
+        })));
+
+        assert!(server.doc_manager.get("file:///test.rs").is_some());
+
+        server.handle_did_close(Some(json!({
+            "textDocument": {"uri": "file:///test.rs"}
+        })));
+
+        assert!(server.doc_manager.get("file:///test.rs").is_none());
+    }
+
+    #[test]
+    fn test_did_save_no_params() {
+        let mut server = make_test_server();
+        // Should not panic.
+        server.handle_did_save(None);
+    }
+
+    #[test]
+    fn test_did_save_with_text() {
+        let mut server = make_test_server();
+
+        server.handle_did_open(Some(json!({
+            "textDocument": {"uri": "file:///test.rs", "text": "old content", "version": 1}
+        })));
+
+        server.handle_did_save(Some(json!({
+            "textDocument": {"uri": "file:///test.rs"},
+            "text": "saved content"
+        })));
+
+        let doc = server.doc_manager.get("file:///test.rs").unwrap();
+        assert_eq!(doc.text, "saved content");
+    }
+
+    // -----------------------------------------------------------------------
+    // Integration tests -- request dispatch after document open
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_hover_on_open_document() {
+        let mut server = make_test_server();
+
+        server.handle_did_open(Some(json!({
+            "textDocument": {"uri": "file:///test.rs", "text": "hello world", "version": 1}
+        })));
+
+        // MockBridge does not support hover, so this should return null.
+        let result = server.handle_hover(Some(json!({
+            "textDocument": {"uri": "file:///test.rs"},
+            "position": {"line": 0, "character": 0}
+        })));
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Value::Null);
+    }
+
+    #[test]
+    fn test_hover_on_unopened_document() {
+        let mut server = make_test_server();
+
+        // The document is not open, so this should produce an error.
+        // But since hover is not supported by MockBridge, it returns Null first.
+        let result = server.handle_hover(Some(json!({
+            "textDocument": {"uri": "file:///nonexistent.rs"},
+            "position": {"line": 0, "character": 0}
+        })));
+
+        // MockBridge doesn't support hover, so it returns Null before checking the doc.
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Value::Null);
+    }
+
+    // -----------------------------------------------------------------------
+    // Initialize and state tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_initialize_sets_state() {
+        let mut server = make_test_server();
+        assert!(!server.is_initialized());
+        assert!(!server.is_shutdown());
+
+        let _ = server.handle_initialize(None);
+        assert!(server.is_initialized());
+        assert!(!server.is_shutdown());
+
+        let _ = server.handle_shutdown();
+        assert!(server.is_initialized());
+        assert!(server.is_shutdown());
+    }
+
+    #[test]
+    fn test_initialize_returns_capabilities() {
+        let mut server = make_test_server();
+        let result = server.handle_initialize(None).unwrap();
+
+        // MockBridge supports nothing optional, so capabilities should
+        // just have textDocumentSync.
+        let caps = &result["capabilities"];
+        assert!(caps.is_object());
+        // textDocumentSync=2 (incremental) is always set.
+        assert_eq!(caps["textDocumentSync"], 2);
+    }
+}

--- a/lessons.md
+++ b/lessons.md
@@ -1615,3 +1615,16 @@ caused a "invalid redeclaration of 'bLen'" compile error.
 **Rule:** When replacing a `let x = expr` with an overflow-checked version that also binds `x`,
 always remove the original `let x` line. The compiler will catch both declarations at the same
 scope level.
+
+---
+
+## Python BUILD files: Always use Unix venv paths
+
+**Date:** 2026-04-12
+
+**What happened:** Python ls00 BUILD file used `.venv/Scripts/python` (Windows venv layout).
+CI runs on Linux where the path is `.venv/bin/python`, causing `sh: .venv/Scripts/python: not found`.
+
+**Rule:** Always use `.venv/bin/python` in BUILD files. CI runs on Linux. All other Python packages
+in the repo use `.venv/bin/python`. The Windows path `.venv/Scripts/python` only works locally on
+Windows and will fail in CI.

--- a/lessons.md
+++ b/lessons.md
@@ -4,6 +4,22 @@ This file tracks mistakes made during development so they are not repeated. Chec
 
 ---
 
+### 2026-04-12: Build tool validator requires declared deps in metadata files, not just BUILD
+
+When a BUILD file references a sibling package (e.g., `cd ../json-rpc`), the build tool's validator (`-validate-build-files`) checks that the referenced package is a declared predecessor in the dependency graph. The graph edges come from **metadata files**, not BUILD files:
+
+- **Python**: `dependencies` array in `pyproject.toml`
+- **Ruby**: `spec.add_dependency` in `.gemspec` (regex requires `spec.`, not `s.`)
+- **Perl**: `requires 'coding-adventures-xxx';` in `cpanfile`
+- **Go**: `require` in `go.mod`
+- **Swift**: `.package(path: "...")` in `Package.swift`
+- **Rust**: `[dependencies]` in `Cargo.toml`
+- **TypeScript**: `dependencies` in `package.json`
+
+**Rule:** Every package that references a sibling in its BUILD file must also declare the dependency in the language-appropriate metadata file. The Ruby gemspec must use `spec` (not `s`) as the block variable, matching the build tool's regex `spec\.add_dependency`.
+
+---
+
 ### 2026-04-06: Perl `reverse LIST, $extra` vs `(reverse LIST), $extra` — precedence trap
 
 When building a list that is the reverse of one list plus an extra item, the expression

--- a/lessons.md
+++ b/lessons.md
@@ -1628,3 +1628,19 @@ CI runs on Linux where the path is `.venv/bin/python`, causing `sh: .venv/Script
 **Rule:** Always use `.venv/bin/python` in BUILD files. CI runs on Linux. All other Python packages
 in the repo use `.venv/bin/python`. The Windows path `.venv/Scripts/python` only works locally on
 Windows and will fail in CI.
+
+---
+
+## BUILD_windows files required for Windows CI
+
+**Date:** 2026-04-12
+
+**What happened:** Python, Perl, and Ruby ls00 packages failed on Windows CI because the BUILD file
+uses `sh` syntax (`.venv/bin/python`, `for f in ...; do ... done`, etc.) but the build tool runs
+`cmd /C` on Windows. The build tool supports `BUILD_windows` as a platform-specific override.
+
+**Rule:** When creating a new package, check if sibling packages (e.g., json-rpc) have `BUILD_windows`
+files. If they do, create one for the new package too. Key differences for Windows:
+- Python: use `uv run --no-project python` instead of `.venv/bin/python`
+- Perl: skip tests on Windows (matches json-rpc pattern)
+- Ruby: `bundle exec rake test` works on both platforms, but `cd` path separators may differ


### PR DESCRIPTION
## Summary

- Implements the LS00 (Language Server Protocol) generic framework spec across all 9 supported languages + a WASM wrapper, mirroring the existing Go reference implementation
- Each language's ls00 package provides: LanguageBridge interface, DocumentManager with UTF-16 conversion, ParseCache, semantic token encoder, capabilities builder, full LSP handler set, and server coordinator
- Also adds Swift json-rpc prerequisite package (Swift was the only language missing json-rpc)
- Security review passed: fixed char-boundary panic in Rust, silent error swallowing in Elixir, cache key collision in Lua

### Test results

| Language | Tests | Coverage |
|----------|-------|----------|
| Go (existing) | 47 | - |
| Rust | 54 | - |
| Python | 65 | 87% |
| TypeScript | 89 | 92% |
| Elixir | 61 | - |
| Ruby | 55 | - |
| Lua | 54 | - |
| Perl | 49 | - |
| Swift | - | (no Swift on Windows) |
| WASM | 42 | - |
| **Total** | **516** | |

## Test plan

- [x] Rust: `cargo test` — 54 passed
- [x] Python: `pytest` — 65 passed, 87% coverage
- [x] TypeScript: `vitest` — 89 passed, 92% coverage
- [x] Elixir: `mix test` — 61 passed
- [x] Ruby: `minitest` — 55 passed, 158 assertions
- [x] Lua: `busted` — 54 passed
- [x] Perl: `Test::More` — 49 passed
- [x] WASM: `cargo test` — 42 passed
- [ ] Swift: needs macOS/Linux CI (no Swift on Windows)
- [x] Security review passed (3 rounds, 3 fixes applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)