### PR TITLE
spec(07f): Intel 8008 behavioral + gate-level simulator specs

### DIFF
--- a/code/specs/07f-intel8008-simulator.md
+++ b/code/specs/07f-intel8008-simulator.md
@@ -1,0 +1,861 @@
+# 07f — Intel 8008 Simulator (Full Instruction Set)
+
+## Overview
+
+The Intel 8008 simulator implements the complete instruction set of the world's first
+8-bit microprocessor, released by Intel in April 1972. It was designed by Ted Hoff,
+Stanley Mazor, and Hal Feeney at the request of Computer Terminal Corporation (CTC),
+who wanted a CPU for their Datapoint 2200 terminal. CTC ultimately rejected the chip
+for being too slow, allowing Intel to sell it commercially. The 8008 went on to
+inspire the 8080, which inspired the Z80 and the x86 architecture — making this
+humble terminal chip the ancestor of the processors running the world's computers today.
+
+This is a **behavioral simulator** — it executes 8008 machine code directly, producing
+correct results without modeling internal hardware. For a gate-level simulation that
+routes every operation through actual logic gates, see `07f2-intel8008-gatelevel.md`.
+
+The simulator uses a **custom dispatch loop** (not GenericVM) because the 8008 has
+variable-length instructions (1, 2, or 3 bytes) and its address space and stack model
+differ enough from the generic VM that building on top of it would require more adapters
+than the implementation itself.
+
+## Layer Position
+
+```
+Logic Gates → Arithmetic → CPU → [YOU ARE HERE] → Assembler → Lexer → Parser → Compiler → VM
+```
+
+This is an alternative Layer 4 alongside RISC-V (07a), ARM/ARMv7 (07b), WASM (07c),
+Intel 4004 (07d), and ARM1 (07e).
+
+## Why the Intel 8008?
+
+- **Historical** — the chip that launched 8-bit computing and the x86 lineage
+- **Bridge** — connects the 4-bit accumulator world (4004, 1971) to modern computing
+- **Rejected and vindicated** — CTC said no; the rest of computing history said yes
+- **Architectural evolution** — 7 general-purpose registers vs 4004's accumulator-only design
+- **Real constraints** — 3,500 transistors, 14-bit address space, internal push-down stack
+- **Contrast with ARM1** — shows 13 years of architecture evolution (1972→1985)
+
+## Architecture
+
+| Feature | Value |
+|---------|-------|
+| Data width | 8 bits |
+| Instruction width | 8 bits (instructions are 1, 2, or 3 bytes) |
+| Registers | 7 × 8-bit (A, B, C, D, E, H, L) + M (memory pseudo-register) |
+| Accumulator | A (register 7 — used implicitly in most ALU operations) |
+| Flags | Carry (CY), Zero (Z), Sign (S), Parity (P) — 4 flags |
+| Program counter | 14 bits (addresses 16 KiB) |
+| Stack | 8-level internal push-down stack (14-bit entries) — 7 usable for calls |
+| Memory | 16,384 bytes (14-bit address space) |
+| I/O | 8 input ports (IN 0–7), 24 output ports (OUT 0–23) |
+| Transistors | ~3,500 (PMOS, 10 μm process) |
+| Clock | 500–800 kHz two-phase clock (≈200–500 kHz effective instruction rate) |
+
+### Registers
+
+The 8008 exposes 7 working registers plus a memory pseudo-register:
+
+```
+┌───┬──────────────────────────────────────────────────────────────┐
+│ A │ Accumulator — primary target of all ALU operations           │
+│ B │ General purpose 8-bit register                               │
+│ C │ General purpose 8-bit register                               │
+│ D │ General purpose 8-bit register                               │
+│ E │ General purpose 8-bit register                               │
+│ H │ High byte of the memory address register pair                │
+│ L │ Low byte of the memory address register pair                 │
+│ M │ Pseudo-register: memory at address [H:L] (H=high, L=low)     │
+└───┴──────────────────────────────────────────────────────────────┘
+```
+
+M is not a physical register — it is a shorthand for an indirect memory reference.
+When an instruction uses M as a source or destination, it reads or writes the byte
+at the 14-bit address formed by combining H (bits 13–8) and L (bits 7–0):
+
+```
+memory_address = ((H & 0x3F) << 8) | L      ; 14-bit: H contributes top 6 bits
+```
+
+Only the low 6 bits of H are used for addressing (the top 2 bits of H are "don't care").
+
+### Register Encoding (3-bit field)
+
+Instructions encode register operands in 3-bit fields:
+
+| Binary | Register | Notes |
+|--------|----------|-------|
+| 000 | B | |
+| 001 | C | |
+| 010 | D | |
+| 011 | E | |
+| 100 | H | High byte of address pair |
+| 101 | L | Low byte of address pair |
+| 110 | M | Indirect memory [H:L] |
+| 111 | A | Accumulator |
+
+### Flag Register
+
+The 8008 maintains 4 condition flags, updated by most ALU operations:
+
+```
+Bit 7  Bit 6  Bit 5  Bit 4  Bit 3  Bit 2  Bit 1  Bit 0
+  S      -      -      -      -      P      Z     CY
+```
+
+- **CY (Carry):** Set when an addition overflows 8 bits, or when a subtraction borrows.
+  Also set/cleared by rotate instructions.
+- **Z (Zero):** Set when the result of an operation is exactly 0x00.
+- **S (Sign):** Set when bit 7 of the result is 1 (treating result as a signed byte).
+- **P (Parity):** Set when the result has an even number of 1-bits (even parity).
+
+Unlike the Intel 8080 (its successor), the 8008 does **not** have an Auxiliary Carry flag.
+This means BCD arithmetic requires software emulation rather than the DAA instruction
+that the 8080 provides.
+
+### The 8-Level Push-Down Stack
+
+The 8008's hardware stack is fundamentally different from the software stack used by
+most modern CPUs. There is no stack pointer register visible to the programmer. Instead,
+the chip contains 8 × 14-bit registers arranged as a circular push-down stack:
+
+```
+Stack (conceptual view — entries are 14-bit return addresses):
+
+    ┌──────────────────┐  ← Top of stack (current PC lives here)
+    │  Entry 0 (PC)    │  ← Program counter is always the top entry
+    ├──────────────────┤
+    │  Entry 1         │  ← First saved return address
+    ├──────────────────┤
+    │  Entry 2         │
+    ├──────────────────┤
+    │  Entry 3         │
+    ├──────────────────┤
+    │  Entry 4         │
+    ├──────────────────┤
+    │  Entry 5         │
+    ├──────────────────┤
+    │  Entry 6         │
+    ├──────────────────┤
+    │  Entry 7         │  ← Oldest saved return address
+    └──────────────────┘
+```
+
+**Critical insight:** Entry 0 is always the current program counter. When a CALL
+instruction executes:
+1. The stack rotates down (entry 0 → entry 1, entry 1 → entry 2, ...)
+2. The jump target is loaded into entry 0 (the new PC)
+
+When a RETURN executes:
+1. The stack rotates up (entry 1 → entry 0, ...)
+2. Entry 0 now contains the saved return address, which becomes the new PC
+
+Since entry 0 is always consumed by the current PC, programs can call at most 7 levels
+deep before the stack wraps (overwriting the oldest return address silently).
+
+This is a pure push-down automaton — there is no `PUSH`/`POP` for data, only for
+return addresses via CALL and RETURN.
+
+### Address Space Layout
+
+The 8008 addresses 16 KiB of unified memory:
+
+```
+0x0000 ──────────────────────────────────────
+        Program memory starts here
+        (code and data share the same space)
+
+        The 8008 has no separate I/O address space —
+        I/O is handled by IN/OUT instructions with
+        port numbers encoded in the opcode.
+
+0x3FFF ──────────────────────────────────────
+        End of 14-bit address space (16,384 bytes)
+```
+
+## Complete Instruction Set
+
+The 8008 has 48 distinct operations (not counting register variants as separate
+instructions). Instructions are 1, 2, or 3 bytes wide.
+
+### Instruction Encoding Overview
+
+```
+ 7   6   5   4   3   2   1   0
+┌───┬───┬───┬───┬───┬───┬───┬───┐
+│ b7  b6 │  DDD  │  SSS/data │
+└───┴───┴───┴───┴───┴───┴───┴───┘
+
+Bits 7–6: Major opcode group
+  00 = Register operations (INR, DCR, Rotates) and 2-byte MVI
+  01 = Register-to-register transfer (MOV) and HLT
+  10 = ALU register operand (ADD, SUB, AND, OR, XOR, CMP, ADC, SBB)
+  11 = ALU immediate and control flow (ADI, SUI, JMP, CALL, RET, IN, OUT)
+
+Bits 5–3 (DDD): Destination register (for MOV/MVI)
+                Or ALU operation select (for group 10/11)
+Bits 2–0 (SSS): Source register (for MOV/ALU)
+                Or sub-operation code (for group 00/11)
+```
+
+### Group 1: Index Register Instructions
+
+These instructions load, store, increment, and decrement the working registers.
+
+#### MOV — Register-to-Register Transfer (1 byte)
+
+```
+Encoding: 01 DDD SSS
+```
+
+Copies the value of source register SSS into destination register DDD. If either
+is M, the memory at [H:L] is read or written. The instruction `01 110 110` (MOV M, M)
+is the HALT instruction — an intentional design quirk.
+
+| Mnemonic | Encoding | Operation |
+|----------|----------|-----------|
+| MOV D, S | `01 DDD SSS` | D ← S |
+| MOV A, B | `01 111 000` (`0x78`) | A ← B |
+| MOV H, L | `01 100 101` (`0x65`) | H ← L |
+| MOV M, A | `01 110 111` (`0x77`) | mem[H:L] ← A |
+| MOV A, M | `01 111 110` (`0x7E`) | A ← mem[H:L] |
+
+Flags: Not affected.
+
+#### MVI — Move Immediate (2 bytes)
+
+```
+Encoding: 00 DDD 110, data8
+```
+
+Loads the 8-bit immediate value `data8` into register DDD. If DDD = M (110), the
+value is written to memory at [H:L].
+
+| Mnemonic | Encoding | Operation |
+|----------|----------|-----------|
+| MVI A, d | `00 111 110, d` (`0x3E, d`) | A ← d |
+| MVI B, d | `00 000 110, d` (`0x06, d`) | B ← d |
+| MVI M, d | `00 110 110, d` (`0x36, d`) | mem[H:L] ← d |
+
+Flags: Not affected.
+
+#### INR — Increment Register (1 byte)
+
+```
+Encoding: 00 DDD 000
+```
+
+Increments register DDD by 1. Wraps from 0xFF to 0x00. Updates Z, S, P flags;
+does **not** update CY (carry is preserved).
+
+| Mnemonic | Encoding | Operation |
+|----------|----------|-----------|
+| INR A | `00 111 000` (`0x38`) | A ← A + 1 |
+| INR B | `00 000 000` (`0x00`) | B ← B + 1 |
+| INR M | `00 110 000` (`0x30`) | mem[H:L] ← mem[H:L] + 1 |
+
+Flags: Z, S, P updated. CY unchanged.
+
+**Note:** `INR B` encodes to `0x00`. The 8008 has no explicit NOP instruction —
+`INR B` with B=0xFF wrapping is the closest equivalent (or just accepting the
+side effect). Some assemblers emit `INR B` as a NOP alternative.
+
+#### DCR — Decrement Register (1 byte)
+
+```
+Encoding: 00 DDD 001
+```
+
+Decrements register DDD by 1. Wraps from 0x00 to 0xFF. Updates Z, S, P flags;
+does **not** update CY.
+
+| Mnemonic | Encoding | Operation |
+|----------|----------|-----------|
+| DCR A | `00 111 001` (`0x39`) | A ← A - 1 |
+| DCR B | `00 000 001` (`0x01`) | B ← B - 1 |
+| DCR M | `00 110 001` (`0x31`) | mem[H:L] ← mem[H:L] - 1 |
+
+Flags: Z, S, P updated. CY unchanged.
+
+### Group 2: Accumulator ALU Instructions
+
+All arithmetic and logical operations target the accumulator A. The source can be
+any register (including M for memory) or an immediate byte.
+
+#### ALU Register Instructions (1 byte)
+
+```
+Encoding: 10 OOO SSS
+  OOO = operation (3 bits)
+  SSS = source register (3 bits)
+```
+
+| OOO | Mnemonic | Operation | Flags |
+|-----|----------|-----------|-------|
+| 000 | ADD S | A ← A + S | Z, S, P, CY |
+| 001 | ADC S | A ← A + S + CY | Z, S, P, CY |
+| 010 | SUB S | A ← A − S | Z, S, P, CY |
+| 011 | SBB S | A ← A − S − CY | Z, S, P, CY |
+| 100 | ANA S | A ← A & S | Z, S, P; CY=0 |
+| 101 | XRA S | A ← A ^ S | Z, S, P; CY=0 |
+| 110 | ORA S | A ← A \| S | Z, S, P; CY=0 |
+| 111 | CMP S | Set flags for A − S, A unchanged | Z, S, P, CY |
+
+Examples:
+- `ADD B` = `10 000 000` (`0x80`) — A ← A + B
+- `SUB M` = `10 010 110` (`0x96`) — A ← A − mem[H:L]
+- `ANA A` = `10 100 111` (`0xA7`) — A ← A & A (zeros CY, useful to clear carry)
+- `CMP A` = `10 111 111` (`0xBF`) — compare A with itself (sets Z, clears CY, sets P)
+
+**Subtraction note:** SUB uses two's complement. CY is set if a borrow occurred
+(i.e., when the unsigned subtraction would go negative). This is the inverse of
+the carry convention used on some other architectures — on the 8008, CY=1 after
+SUB means "the result required a borrow."
+
+**ANA clears carry:** AND, OR, XOR always clear the carry flag. This differs from
+the 8080 successor, which clears carry for AND but not consistently for OR/XOR.
+
+#### ALU Immediate Instructions (2 bytes)
+
+```
+Encoding: 11 OOO 100, data8
+  OOO = same operation codes as above
+```
+
+| OOO | Mnemonic | Operation |
+|-----|----------|-----------|
+| 000 | ADI d | A ← A + d |
+| 001 | ACI d | A ← A + d + CY |
+| 010 | SUI d | A ← A − d |
+| 011 | SBI d | A ← A − d − CY |
+| 100 | ANI d | A ← A & d |
+| 101 | XRI d | A ← A ^ d |
+| 110 | ORI d | A ← A \| d |
+| 111 | CPI d | Set flags for A − d, A unchanged |
+
+Examples:
+- `ADI 5` = `11 000 100, 0x05` (`0xC4, 0x05`) — A ← A + 5
+- `CPI 0x0A` = `11 111 100, 0x0A` (`0xFC, 0x0A`) — compare A with 10
+
+### Group 3: Rotate Instructions (1 byte)
+
+Rotate the accumulator left or right, either circular or through the carry flag.
+
+```
+Encoding: 00 0RR 010  (R=rotate type, using bits 4–3)
+```
+
+| Binary | Mnemonic | Operation | Description |
+|--------|----------|-----------|-------------|
+| `00 000 010` (`0x02`) | RLC | CY ← A[7]; A ← (A << 1) \| A[7] | Rotate left circular (bit 7 → CY and bit 0) |
+| `00 001 010` (`0x0A`) | RRC | CY ← A[0]; A ← (A >> 1) \| (A[0] << 7) | Rotate right circular (bit 0 → CY and bit 7) |
+| `00 010 010` (`0x12`) | RAL | new_CY ← A[7]; A ← (A << 1) \| old_CY | Rotate left through carry (9-bit rotation) |
+| `00 011 010` (`0x1A`) | RAR | new_CY ← A[0]; A ← (old_CY << 7) \| (A >> 1) | Rotate right through carry (9-bit rotation) |
+
+```
+RLC (Rotate Left Circular):         RAL (Rotate Left through Carry):
+  ┌───────────────────────┐           ┌──────────────────────────────┐
+  │ A[7] A[6] ... A[1] A[0] │           │ CY  A[7] A[6] ... A[1] A[0] │
+  └──┬──────────────────┬──┘           └─┬──────────────────────────┬─┘
+     │     rotate left  │                │        rotate left         │
+     └──────────────────┘                └───────────────────────────┘
+  CY ← A[7] (old)                     CY ← A[7] (old)
+  A[0] ← A[7] (old)                   A[0] ← CY (old)
+```
+
+Flags: CY updated. Z, S, P not affected by rotate instructions.
+
+### Group 4: Jump Instructions (3 bytes)
+
+Jumps use a 14-bit address spread across two bytes following the opcode. The address
+is stored **low byte first** (little-endian): `addr_lo` (bits 7–0) then `addr_hi`
+(bits 13–8, in the low 6 bits of the second address byte).
+
+```
+Address reconstruction: address = (addr_hi & 0x3F) << 8 | addr_lo
+```
+
+#### JMP — Unconditional Jump (3 bytes)
+
+```
+Encoding: 01 111 100, addr_lo, addr_hi
+          0x7C, low, high
+```
+
+PC ← (addr_hi[5:0] << 8) | addr_lo
+
+#### Conditional Jumps (3 bytes)
+
+```
+Encoding: 01 CCC T00, addr_lo, addr_hi
+  CCC = condition code (3 bits)
+  T = sense (0 = jump if false/not-set, 1 = jump if true/set)
+```
+
+Condition codes CCC:
+| CCC | Condition tested |
+|-----|-----------------|
+| 000 | CY (Carry) |
+| 001 | Z (Zero) |
+| 010 | S (Sign) |
+| 011 | P (Parity) |
+| 100–111 | (reserved) |
+
+| Mnemonic | Encoding | Jump if... |
+|----------|----------|------------|
+| JFC addr | `01 000 000, lo, hi` (`0x40`) | Carry false (CY=0) |
+| JTC addr | `01 000 100, lo, hi` (`0x44`) | Carry true (CY=1) |
+| JFZ addr | `01 001 000, lo, hi` (`0x48`) | Zero false (Z=0) |
+| JTZ addr | `01 001 100, lo, hi` (`0x4C`) | Zero true (Z=1) |
+| JFS addr | `01 010 000, lo, hi` (`0x50`) | Sign false (S=0, positive) |
+| JTS addr | `01 010 100, lo, hi` (`0x54`) | Sign true (S=1, negative) |
+| JFP addr | `01 011 000, lo, hi` (`0x58`) | Parity false (P=0, odd) |
+| JTP addr | `01 011 100, lo, hi` (`0x5C`) | Parity true (P=1, even) |
+| JMP addr | `01 111 100, lo, hi` (`0x7C`) | Always (unconditional) |
+
+### Group 5: Call Instructions (3 bytes)
+
+```
+Encoding: 01 CCC T10, addr_lo, addr_hi
+```
+
+Call instructions push the current PC onto the hardware stack and jump to the target.
+The condition encoding is identical to jumps (T=0 for "if false", T=1 for "if true").
+
+| Mnemonic | Encoding | Call if... |
+|----------|----------|------------|
+| CFC addr | `01 000 010, lo, hi` (`0x42`) | Carry false |
+| CTC addr | `01 000 110, lo, hi` (`0x46`) | Carry true |
+| CFZ addr | `01 001 010, lo, hi` (`0x4A`) | Zero false |
+| CTZ addr | `01 001 110, lo, hi` (`0x4E`) | Zero true |
+| CFS addr | `01 010 010, lo, hi` (`0x52`) | Sign false |
+| CTS addr | `01 010 110, lo, hi` (`0x56`) | Sign true |
+| CFP addr | `01 011 010, lo, hi` (`0x5A`) | Parity false |
+| CTP addr | `01 011 110, lo, hi` (`0x5E`) | Parity true |
+| CAL addr | `01 111 110, lo, hi` (`0x7E`) | Always (unconditional) |
+
+### Group 6: Return Instructions (1 byte)
+
+```
+Encoding: 00 CCC T11
+```
+
+Pop the return address from the hardware stack and jump to it. Same condition encoding.
+
+| Mnemonic | Encoding | Return if... |
+|----------|----------|-------------|
+| RFC | `00 000 011` (`0x03`) | Carry false |
+| RTC | `00 000 111` (`0x07`) | Carry true |
+| RFZ | `00 001 011` (`0x0B`) | Zero false |
+| RTZ | `00 001 111` (`0x0F`) | Zero true |
+| RFS | `00 010 011` (`0x13`) | Sign false |
+| RTS | `00 010 111` (`0x17`) | Sign true |
+| RFP | `00 011 011` (`0x1B`) | Parity false |
+| RTP | `00 011 111` (`0x1F`) | Parity true |
+| RET | `00 111 111` (`0x3F`) | Always (unconditional) |
+
+### Group 7: Restart Instructions (1 byte)
+
+```
+Encoding: 00 AAA 101
+```
+
+Restart is a 1-byte CALL to a fixed low-memory address. The 3-bit field AAA encodes
+the target address as `AAA << 3` (multiples of 8: 0, 8, 16, 24, 32, 40, 48, 56).
+This provides 8 fast interrupt-service entry points in the first 64 bytes of memory.
+
+| Mnemonic | Encoding | Target |
+|----------|----------|--------|
+| RST 0 | `00 000 101` (`0x05`) | 0x0000 |
+| RST 1 | `00 001 101` (`0x0D`) | 0x0008 |
+| RST 2 | `00 010 101` (`0x15`) | 0x0010 |
+| RST 3 | `00 011 101` (`0x1D`) | 0x0018 |
+| RST 4 | `00 100 101` (`0x25`) | 0x0020 |
+| RST 5 | `00 101 101` (`0x2D`) | 0x0028 |
+| RST 6 | `00 110 101` (`0x35`) | 0x0030 |
+| RST 7 | `00 111 101` (`0x3D`) | 0x0038 |
+
+RST is equivalent to `CAL target` but encoded in a single byte.
+
+### Group 8: Input/Output Instructions (1 byte)
+
+The 8008 has separate IN and OUT instructions. Port numbers are encoded in the opcode.
+
+#### IN — Read from Input Port
+
+```
+Encoding: 01 PPP P01  (port number split across bits 4–1)
+```
+
+Reads 8 bits from input port `P` (0–7) into the accumulator. The port number is
+encoded in bits 4–1 of the opcode byte (4-bit field, supporting 8 distinct ports
+with the MSB always 0).
+
+| Mnemonic | Encoding | Operation |
+|----------|----------|-----------|
+| IN 0 | `01 000 001` (`0x41`) | A ← port[0] |
+| IN 1 | `01 000 011`... wait, let me clarify | A ← port[1] |
+
+Actually, the IN instruction encoding in the 8008 is:
+```
+IN P: 01 PP0 001  where PP is 2-bit port number (ports 0–3 directly accessible)
+```
+
+The actual encoding puts the port number in bits [4:3]:
+- IN 0: `0x41` (`01 000 001`)
+- IN 1: `0x49` (`01 001 001`)
+- IN 2: `0x51` (`01 010 001`)
+- IN 3: `0x59` (`01 011 001`)
+- IN 4: `0x61` (`01 100 001`)
+- IN 5: `0x69` (`01 101 001`)
+- IN 6: `0x71` (`01 110 001`)
+- IN 7: `0x79` (`01 111 001`)
+
+Flags: Not affected.
+
+#### OUT — Write to Output Port
+
+```
+Encoding: 00 PPP P10  (port number in bits 4–1, 3 LSB = 010)
+```
+
+Writes the accumulator to output port `P` (0–23). The 8008 supports 24 output
+ports via a 5-bit port field in the opcode.
+
+- OUT 0: `0x02` — OUT 7: `0x3A` (first bank, port 8 via bit)
+- Ports 8–23 use the high bits of the port field
+
+Flags: Not affected.
+
+### Group 9: Machine Instructions (1 byte)
+
+#### HLT — Halt
+
+The 8008 has two halt encodings:
+
+| Encoding | Notes |
+|----------|-------|
+| `01 110 110` (`0x76`) | MOV M, M — the standard HLT opcode |
+| `11 111 111` (`0xFF`) | Also halts the processor |
+
+When HLT executes, the processor stops fetching instructions and enters a halted
+state. External hardware can resume execution via the interrupt mechanism.
+In the simulator, HLT terminates the `run()` loop.
+
+## Execution Engine
+
+The simulator uses a custom fetch-decode-execute loop rather than GenericVM, because:
+
+1. Instructions are variable-length (1, 2, or 3 bytes) in a way that doesn't fit
+   GenericVM's fixed opcode model
+2. The 14-bit PC and 8-level push-down stack need custom logic
+3. The IN/OUT port model has no equivalent in GenericVM
+
+### Fetch
+
+```python
+opcode = memory[pc]
+pc += 1
+
+# Detect instruction length from opcode
+if needs_data_byte(opcode):
+    data = memory[pc]; pc += 1
+if needs_addr_bytes(opcode):
+    addr_lo = memory[pc]; pc += 1
+    addr_hi = memory[pc]; pc += 1
+```
+
+Variable-length detection rules:
+- MVI (00DDD110): 2 bytes total (opcode + data)
+- ALU immediate (11OOO100): 2 bytes total
+- JMP/JFC/etc. (01CCC_00, 01CCC_10): 3 bytes total (opcode + addr_lo + addr_hi)
+- All other instructions: 1 byte
+
+### Decode
+
+The opcode byte is decomposed into bit fields:
+
+```python
+group   = (opcode >> 6) & 0x03    # bits 7–6
+ddd     = (opcode >> 3) & 0x07    # bits 5–3 (destination or operation)
+sss     = opcode & 0x07           # bits 2–0 (source or sub-op)
+```
+
+### Execute
+
+Handlers are dispatched based on group and sub-fields. The dispatch tree follows
+the instruction encoding structure exactly, mirroring the real chip's decoder.
+
+### State
+
+The `Intel8008Simulator` instance holds all CPU state:
+
+```python
+registers: list[int]     # [B, C, D, E, H, L, unused, A] — indexed by 3-bit reg code
+flags: int               # 4-bit: bits [S, -, -, -, -, P, Z, CY]
+memory: bytearray        # 16,384 bytes
+pc: int                  # 14-bit program counter
+stack: list[int]         # 8-entry push-down stack (stack[0] = return addrs)
+stack_depth: int         # 0–7 — how many entries are in use beyond current PC
+input_ports: list[int]   # 8 input port values (set externally)
+output_ports: list[int]  # 24 output port values (written by OUT instructions)
+```
+
+## Public API
+
+```python
+class Intel8008Simulator:
+    def __init__(self) -> None: ...
+
+    # --- CPU State ---
+    @property
+    def a(self) -> int: ...                  # Accumulator (0–255)
+    @property
+    def b(self) -> int: ...                  # Register B
+    @property
+    def c(self) -> int: ...                  # Register C
+    @property
+    def d(self) -> int: ...                  # Register D
+    @property
+    def e(self) -> int: ...                  # Register E
+    @property
+    def h(self) -> int: ...                  # Register H
+    @property
+    def l(self) -> int: ...                  # Register L
+    @property
+    def hl_address(self) -> int: ...         # 14-bit: (H & 0x3F) << 8 | L
+    @property
+    def pc(self) -> int: ...                 # 14-bit program counter (0–16383)
+    @property
+    def flags(self) -> Intel8008Flags: ...   # Named flag fields
+    @property
+    def stack(self) -> list[int]: ...        # Current stack contents (up to 7 entries)
+    @property
+    def stack_depth(self) -> int: ...        # 0–7
+
+    # --- Memory ---
+    @property
+    def memory(self) -> bytearray: ...       # 16,384 bytes
+
+    # --- I/O ---
+    def set_input_port(self, port: int, value: int) -> None: ...   # port 0–7
+    def get_output_port(self, port: int) -> int: ...               # port 0–23
+
+    # --- Execution ---
+    def load_program(self, program: bytes, start_address: int = 0) -> None: ...
+    def step(self) -> Intel8008Trace: ...
+    def run(
+        self,
+        program: bytes,
+        max_steps: int = 100_000,
+        start_address: int = 0,
+    ) -> list[Intel8008Trace]: ...
+    def reset(self) -> None: ...
+
+@dataclass
+class Intel8008Flags:
+    carry: bool     # CY
+    zero: bool      # Z
+    sign: bool      # S — True when result bit 7 is 1
+    parity: bool    # P — True when result has even parity
+
+@dataclass
+class Intel8008Trace:
+    address: int                   # PC where this instruction was fetched
+    raw: bytes                     # Raw instruction bytes (1, 2, or 3 bytes)
+    mnemonic: str                  # "MOV A, B", "ADI 0x05", "JMP 0x0100"
+    a_before: int
+    a_after: int
+    flags_before: Intel8008Flags
+    flags_after: Intel8008Flags
+    memory_address: int | None     # Set if instruction accessed memory (M register)
+    memory_value: int | None       # Value read/written (if applicable)
+```
+
+## Example Programs
+
+### x = 1 + 2 (Basic Arithmetic)
+
+```asm
+; Load 1 into B, 2 into A, then compute A = A + B
+        MVI B, 0x01     ; B ← 1               (0x06 0x01)
+        MVI A, 0x02     ; A ← 2               (0x3E 0x02)
+        ADD B           ; A ← A + B = 3       (0x80)
+        HLT             ; stop                (0x76)
+; Result: A = 0x03, Z=0, S=0, CY=0, P=1 (even parity of 0b00000011)
+```
+
+### x = 1 + 2 Using Memory
+
+```asm
+; Store 1 at [H:L]=0x0010, load it back, add 2
+        MVI H, 0x00     ; H ← 0               (0x26 0x00)
+        MVI L, 0x10     ; L ← 16 = address    (0x2E 0x10)
+        MVI M, 0x01     ; mem[0x0010] ← 1     (0x36 0x01)
+        MOV A, M        ; A ← mem[0x0010] = 1 (0x7E)
+        ADI 0x02        ; A ← A + 2 = 3       (0xC4 0x02)
+        HLT             ;                      (0x76)
+```
+
+### Multiply 4 × 5 (Loop with DCR / JFZ)
+
+```asm
+; A = 4 × 5 using repeated addition
+; B = multiplicand (5), C = counter (4), A = accumulator (running total)
+        MVI B, 0x05     ; B ← 5               (0x06 0x05)
+        MVI C, 0x04     ; C ← 4               (0x0E 0x04)
+        MVI A, 0x00     ; A ← 0               (0x3E 0x00)
+LOOP:   ADD B           ; A ← A + B           (0x80)
+        DCR C           ; C ← C - 1           (0x09)
+        JFZ LOOP        ; if Z=0 goto LOOP    (0x48 <lo> <hi>)
+        HLT             ; A = 20 = 0x14       (0x76)
+```
+
+### Subroutine: Absolute Value
+
+```asm
+; Call a subroutine that computes |A| (absolute value of signed byte)
+        MVI A, 0xF6     ; A ← -10 (signed: 0xF6 = -10)  (0x3E 0xF6)
+        CAL ABS_VAL     ; call subroutine                 (0x7E lo hi)
+        HLT             ; A = 10 = 0x0A                   (0x76)
+
+ABS_VAL:
+; If S=0 (positive), return immediately
+        JFS DONE        ; if Sign=0, skip negate          (0x50 lo hi)
+; Negate: A ← ~A + 1 (two's complement)
+        XRI 0xFF        ; A ← A ^ 0xFF (bitwise NOT)      (0xED 0xFF)
+        ADI 0x01        ; A ← A + 1                       (0xC4 0x01)
+DONE:   RET             ; return to caller                 (0x3F)
+```
+
+### Parity Check (Using P Flag)
+
+```asm
+; Check if the value in A has even or odd parity
+; The 8008 P flag makes this trivial — just load the value and check P
+        MVI A, 0b10110101   ; A ← 0xB5 (5 ones = odd parity)  (0x3E 0xB5)
+        ORI 0x00            ; A unchanged, flags updated        (0xF4 0x00)
+; After ORI 0x00: P=0 (odd parity), Z=0, S=1, CY=0
+        HLT                                                     (0x76)
+```
+
+`ORI 0x00` is the canonical 8008 idiom for "set flags from A without changing A."
+
+### H:L Pointer — Walking Memory
+
+```asm
+; Copy 4 bytes from address 0x0020 to 0x0030
+; Uses H:L as a source pointer and H:D... wait, 8008 only has one address pair.
+; Strategy: copy bytes one at a time using both H:L for source and fixed dest.
+        MVI H, 0x00     ; H ← 0               (0x26 0x00)
+        MVI L, 0x20     ; L ← 0x20 (source)   (0x2E 0x20)
+        MOV A, M        ; A ← mem[0x0020]      (0x7E)
+        MVI L, 0x30     ; L ← 0x30 (dest)      (0x2E 0x30)
+        MOV M, A        ; mem[0x0030] ← A       (0x77)
+        HLT             ;                       (0x76)
+; (For a loop, maintain the offset in B/C and use ADI to advance L)
+```
+
+## Test Strategy
+
+### Individual Instruction Tests
+
+Every instruction must be tested in isolation with:
+- Correct result value
+- Correct flag updates after the instruction
+- Flags that should not change are confirmed unchanged
+- PC advances by the correct number of bytes (1, 2, or 3)
+
+**ALU edge cases:**
+- ADD: 0xFF + 0x01 = 0x00 with CY=1, Z=1
+- SUB: 0x00 - 0x01 = 0xFF with CY=1 (borrow), S=1, Z=0, P=1
+- ANA: 0xFF & 0x00 = 0x00 with CY=0 (always cleared)
+- ADC with CY=1: 0xFE + 0x01 + 1 = 0x00 with CY=1, Z=1
+
+**Rotate edge cases:**
+- RLC with 0x80: result=0x01, CY=1 (bit 7 wraps to bit 0 and carry)
+- RAL with 0xFF and CY=0: result=0xFE, CY=1
+- RAR with 0x01 and CY=1: result=0x80, CY=1
+
+**INR/DCR:**
+- INR 0xFF → 0x00: Z=1, S=0, P=1, CY unchanged
+- DCR 0x00 → 0xFF: Z=0, S=1, P=1, CY unchanged
+
+### Flag Tests
+
+- Z: test ADD producing 0, subtract producing 0, compare equal
+- S: test results with bit 7 set (values 0x80–0xFF)
+- P: test values with even (0x00, 0x03, 0xFF) and odd (0x01, 0x80, 0x7F) parity
+- CY: test addition overflow, subtraction borrow, rotate into/out of carry
+- Flag independence: INR/DCR do not touch CY; ANA/XRA/ORA clear CY
+
+### Control Flow Tests
+
+- JMP: unconditional jump to any 14-bit address
+- JFC/JTC: all 8 conditions (4 flags × true/false)
+- Conditional jump not taken: PC advances past 3-byte instruction
+- CAL/RET: subroutine call saves return address, return restores it
+- Nested calls: 2, 3, 4, 7 levels deep
+- Stack overflow (8th call wraps): oldest return address silently overwritten
+- RST: jump to fixed low-memory address, verify stack push
+
+### Memory (M pseudo-register) Tests
+
+- MOV A, M: read from current [H:L]
+- MOV M, A: write to current [H:L]
+- MVI M, d: write immediate to current [H:L]
+- INR M / DCR M: increment/decrement memory
+- ADD M / SUB M: ALU with memory operand
+- H:L boundary: address 0x0000, 0x3FFF, and wraparound
+
+### Stack Tests
+
+- 1 level: CAL + RET restores correct PC
+- 7 levels: maximum usable depth before wrap
+- 8th call overwrites entry (verify with specific return addresses)
+- Return without call (underflow): simulator must handle gracefully
+
+### I/O Tests
+
+- IN 0–7: verify A loaded from input port value
+- OUT 0–23: verify output port updated with A value
+- Input ports can be set externally and read correctly
+
+### End-to-End Programs
+
+- x = 1 + 2 (basic)
+- Multiply 4 × 5 via loop
+- Absolute value subroutine (tests CAL/RET + conditional branch)
+- Parity check (flag-based branch)
+- Bubble sort over 8 bytes in memory (tests H:L addressing, INR L, compare)
+- Fibonacci sequence (tests nested register operations)
+
+### Cross-Language Consistency
+
+Same programs must produce identical results across all language implementations
+(Python, Go, Rust, Ruby, TypeScript). Each language's simulator is run with
+the same byte sequences and the final state (A, B, C, D, E, H, L, PC, flags)
+is compared.
+
+## Dependencies
+
+```
+intel8008-simulator
+└── (no runtime dependencies)
+    (test dependencies: pytest, hypothesis for property-based testing)
+```
+
+Unlike the Intel 4004 simulator, this package does not depend on `virtual-machine`.
+The 8008's instruction format and stack model make a custom loop cleaner.
+
+## Future Extensions
+
+- **Assembler** — Accept 8008 assembly mnemonics and produce machine code. Use the
+  `assembler` package (spec 06) as the foundation.
+- **Disassembler** — Decode raw bytes back into mnemonic form (useful for trace output).
+- **Interrupt simulation** — Model the INT line, which causes a RST instruction to be
+  injected into the instruction stream by external hardware.
+- **Timing model** — The 8008 takes 5–11 clock cycles per instruction. A cycle-accurate
+  model would let us measure execution time for real programs.
+- **Gate-level simulator** — See `07f2-intel8008-gatelevel.md`.

--- a/code/specs/07f2-intel8008-gatelevel.md
+++ b/code/specs/07f2-intel8008-gatelevel.md
@@ -1,0 +1,844 @@
+# 07f2 — Intel 8008 Gate-Level Simulator
+
+## Overview
+
+The gate-level 8008 simulator models the world's first 8-bit microprocessor at the
+hardware level. Every arithmetic operation routes through actual logic gate functions —
+AND, OR, XOR, NOT — chained into half-adders, full-adders, a ripple-carry adder, and
+then an 8-bit ALU. Registers are built from D flip-flops. The 14-bit program counter
+uses an incrementer built from a chain of half-adders. The 8-level push-down stack
+is built from 8 × 14-bit registers. The instruction decoder is a combinational gate
+tree that pattern-matches opcode bits into control signals.
+
+This is NOT the same as the behavioral simulator (`07f-intel8008-simulator.md`).
+The behavioral simulator executes instructions directly with host-language integers.
+This simulator routes everything through the gate abstractions built from scratch in
+`logic-gates` and `arithmetic`, showing exactly how the real 8008 computed at the
+circuit level.
+
+Both simulators implement the same instruction set and produce identical results for
+any program. The difference is the execution path:
+
+```
+Behavioral:  opcode → match statement → host arithmetic → result
+Gate-level:  opcode → decoder gates → ALU gates → adder gates → logic gates → result
+```
+
+## Layer Position
+
+```
+[Logic Gates] → [Arithmetic] → [CPU] → [YOU ARE HERE] → Assembler → ...
+     ↑              ↑            ↑            ↑
+  AND/OR/NOT    Adders/ALU    Registers   8008 wiring
+```
+
+This package composes packages from layers below:
+- `logic-gates`: AND, OR, XOR, NOT, MUX, D flip-flop, register
+- `arithmetic`: half_adder, full_adder, ripple_carry_adder, ALU
+- `clock`: Clock, ClockEdge
+
+## Why Gate-Level for the 8008?
+
+The real Intel 8008 had approximately 3,500 transistors — 52% more than the 4004's
+2,300. Those extra transistors paid for:
+1. **8-bit datapath** instead of 4-bit (doubles the ALU and register widths)
+2. **7 registers** instead of accumulator-only (register file doubled)
+3. **14-bit PC** instead of 12-bit (longer address counter)
+4. **8-level stack** instead of 3-level (stack doubled)
+5. **Richer decoder** — 48 operations vs 46, with 3-byte instruction formats
+
+By simulating at gate level, we can count exactly how each of those transistors
+contributes to the expanded capability, and trace a bit through the full 8-bit
+ripple-carry adder to see 8 gate delays (vs 4 for the 4004).
+
+## Architecture — Block Diagram
+
+```
+                    ┌─────────────────────────────────────────────┐
+                    │         Intel 8008 (Gate-Level)              │
+                    │                                             │
+    Memory ───────→ │  ┌──────────┐    ┌──────────────────────┐   │
+    (program        │  │ Program  │    │   Instruction         │   │
+     + data)        │  │ Counter  │───→│   Decoder             │   │
+                    │  │ (14-bit) │    │   (gate trees)        │   │
+                    │  └──────────┘    └────────┬─────────────┘   │
+                    │       ↑                   │                 │
+                    │       │            control signals          │
+                    │       │                   │                 │
+                    │  ┌────┴────┐       ┌──────┴──────┐          │
+                    │  │ Stack   │       │  Control    │          │
+                    │  │ 8×14-bit│       │  Unit (FSM) │          │
+                    │  └─────────┘       └──────┬──────┘          │
+                    │                           │                 │
+                    │       ┌───────────────────┼──────┐          │
+                    │       │                   │      │          │
+                    │  ┌────┴──────┐  ┌─────────┴┐  ┌──┴──┐      │
+                    │  │ Register  │  │  8-bit   │  │Flag │      │
+                    │  │  File     │─→│  ALU     │──│Reg  │      │
+                    │  │ 7×8-bit   │  │(gates!)  │  └─────┘      │
+                    │  └───────────┘  └──────────┘               │
+                    │       ↑              ↑                      │
+                    │  ┌────┴────┐    ┌────┴────┐                 │
+                    │  │ Accum   │    │ 16 KiB  │                 │
+                    │  │ (8-bit) │    │ Memory  │                 │
+                    │  └─────────┘    └─────────┘                 │
+                    │                                             │
+                    │  ┌──────────┐   ┌───────────────────┐       │
+                    │  │ Input    │   │ Output Ports       │       │
+                    │  │ Ports 0–7│   │ 0–23               │       │
+                    │  └──────────┘   └───────────────────┘       │
+                    └─────────────────────────────────────────────┘
+```
+
+## Components
+
+### 1. bits.py — Bit Conversion Helpers
+
+Converts between integer values and bit lists (LSB-first, matching the arithmetic
+package's convention). This is the same module as in the 4004 gate-level simulator,
+extended to support 14-bit values for the PC and stack.
+
+```python
+def int_to_bits(value: int, width: int) -> list[int]:
+    """Convert integer to bit list (LSB first).
+    
+    E.g., int_to_bits(5, 8) → [1, 0, 1, 0, 0, 0, 0, 0]
+    The arithmetic package's adders use LSB-first ordering.
+    """
+
+def bits_to_int(bits: list[int]) -> int:
+    """Convert bit list (LSB first) to integer.
+    
+    E.g., bits_to_int([1, 0, 1, 0, 0, 0, 0, 0]) → 5
+    """
+
+def bits_parity(bits: list[int]) -> int:
+    """Compute parity of a bit list via XOR reduction using logic gates.
+    
+    Returns 1 if even parity (even number of 1s), 0 if odd parity.
+    Implemented as a chain of XOR gates:
+    parity = XOR(bit0, XOR(bit1, XOR(bit2, ...)))
+    then invert: P = NOT(xor_chain)
+    (P=1 means even parity in 8008 convention)
+    """
+```
+
+### 2. alu.py — 8-Bit ALU
+
+Thin wrapper around `ALU(bit_width=8)` from the arithmetic package. The existing
+ALU routes internally through gates. The 8008 ALU is double-wide compared to the
+4004's 4-bit ALU — requiring 8 full-adders in the ripple-carry chain instead of 4.
+
+```
+ALU.execute(ADD, a_bits, b_bits):
+  → ripple_carry_adder(a_bits, b_bits, cin=0)  [8 full-adders]
+    → full_adder(a[0], b[0], 0)
+      → half_adder(a[0], b[0])  → XOR(a, b), AND(a, b)
+      → half_adder(sum, 0)      → XOR(sum, 0), AND(sum, 0)
+      → OR(carry1, carry2)
+    → full_adder(a[1], b[1], carry)
+    → ...
+    → full_adder(a[7], b[7], carry)   ← 4 more gates than 4004
+
+8-bit ripple-carry: 8 × full_adder = 8 × 5 gates = 40 gates
+vs 4-bit:           4 × full_adder = 4 × 5 gates = 20 gates
+```
+
+The 8008 also needs parity computation on the ALU output, which the 4004 lacked.
+Parity is implemented as a 7-gate XOR reduction tree:
+
+```
+parity_bit = XOR(XOR(XOR(b0, b1), XOR(b2, b3)), XOR(XOR(b4, b5), XOR(b6, b7)))
+```
+
+```python
+class Intel8008ALU:
+    def __init__(self) -> None:
+        self._alu = ALU(bit_width=8)
+
+    def add(self, a: int, b: int, carry_in: bool) -> tuple[int, bool]:
+        """Add two 8-bit values with carry. Returns (result, carry_out)."""
+
+    def subtract(self, a: int, b: int, borrow_in: bool) -> tuple[int, bool]:
+        """Subtract b from a with borrow. Returns (result, borrow_out).
+        
+        Implemented as a + ~b + 1 (two's complement via gates):
+        1. NOT each bit of b (8 NOT gates)
+        2. ripple_carry_adder(a, ~b, cin=1)
+        CY=1 after SUB means no borrow was needed (unsigned a >= b).
+        CY=0 means a borrow occurred.
+        """
+
+    def bitwise_and(self, a: int, b: int) -> int:
+        """8-bit AND via 8 AND gates. Also clears carry."""
+
+    def bitwise_or(self, a: int, b: int) -> int:
+        """8-bit OR via 8 OR gates. Also clears carry."""
+
+    def bitwise_xor(self, a: int, b: int) -> int:
+        """8-bit XOR via 8 XOR gates. Also clears carry."""
+
+    def compare(self, a: int, b: int) -> tuple[bool, bool, bool, bool]:
+        """Compare a and b (a - b), return (carry, zero, sign, parity).
+        
+        Identical to subtract() but discards the numeric result.
+        Uses the same full-adder chain internally.
+        """
+
+    def increment(self, a: int) -> tuple[int, bool]:
+        """a + 1 via half-adder chain. Returns (result, carry_out)."""
+
+    def decrement(self, a: int) -> tuple[int, bool]:
+        """a - 1 via ~a + 0 trick: complement, add 0, complement back.
+        More precisely: a - 1 = a + 0xFF via ripple_carry_adder.
+        Returns (result, borrow_occurred).
+        """
+
+    def rotate_left_circular(self, a: int) -> tuple[int, bool]:
+        """Rotate A left circular. CY ← A[7]; A[0] ← A[7].
+        
+        Implemented via bit shift in the gate representation:
+        new_bits = [old_bits[7]] + old_bits[0:7]
+        (no arithmetic gates needed — just rewiring)
+        """
+
+    def rotate_right_circular(self, a: int) -> tuple[int, bool]:
+        """Rotate A right circular. CY ← A[0]; A[7] ← A[0]."""
+
+    def rotate_left_carry(self, a: int, carry_in: bool) -> tuple[int, bool]:
+        """9-bit rotate left through carry.
+        
+        [CY | A7 | A6 | ... | A0] rotate left by 1:
+        new_A[0] ← old_CY
+        new_CY  ← old_A[7]
+        """
+
+    def rotate_right_carry(self, a: int, carry_in: bool) -> tuple[int, bool]:
+        """9-bit rotate right through carry."""
+
+    def compute_flags(self, result: int, carry: bool) -> Intel8008FlagBits:
+        """Compute all 4 flags from an 8-bit result.
+        
+        zero   = NOR(b7, b6, b5, b4, b3, b2, b1, b0)  [8-input NOR]
+        sign   = b7  [direct wire]
+        carry  = carry_out  [from adder]
+        parity = NOT(XOR(XOR(XOR(b0,b1), XOR(b2,b3)), XOR(XOR(b4,b5), XOR(b6,b7))))
+        """
+```
+
+### 3. registers.py — Register File (Sequential Logic)
+
+7 × 8-bit registers (A, B, C, D, E, H, L) plus the 4-bit flag register, all built
+from D flip-flops via the `register()` function from `logic_gates.sequential`.
+
+The 8008 has twice as many data bits per register as the 4004 (8 vs 4), so the
+register file requires twice the flip-flop count.
+
+```python
+class Intel8008RegisterFile:
+    # Register indices (matching 3-bit hardware encoding):
+    # 0=B, 1=C, 2=D, 3=E, 4=H, 5=L, 6=unused, 7=A
+
+    def __init__(self) -> None:
+        # 7 × 8-bit registers, each sequential.register(width=8)
+        # = 7 × 8 = 56 D flip-flops
+        # Plus 4-bit flag register: sequential.register(width=4)
+        # = 4 D flip-flops
+        # Total: 60 D flip-flops = 60 × 4 NOR gates = 240 NOR gates
+
+    def read(self, reg_index: int) -> int:
+        """Read 8-bit value from register 0–7 (6 is undefined, returns 0).
+        
+        If reg_index == 6 (M), raises ValueError — caller must resolve
+        M to a memory address before calling read().
+        """
+
+    def write(self, reg_index: int, value: int) -> None:
+        """Write 8-bit value to register. reg_index 6 (M) raises ValueError."""
+
+    @property
+    def a(self) -> int: ...       # Accumulator = register index 7
+    @a.setter
+    def a(self, value: int) -> None: ...
+
+    @property
+    def h(self) -> int: ...
+    @property
+    def l(self) -> int: ...
+
+    @property
+    def hl_address(self) -> int:
+        """14-bit address formed from H and L.
+        
+        Implemented via bit extraction and OR/AND gates:
+        address = (H[5:0] << 8) | L[7:0]
+        = (H & 0x3F) << 8 | L
+        """
+
+    @property
+    def flags(self) -> Intel8008FlagBits: ...
+    @flags.setter
+    def flags(self, value: Intel8008FlagBits) -> None: ...
+```
+
+Each register write traverses:
+```
+value → int_to_bits(value, 8) → register(bits, clock_edge, state, width=8)
+  → 8 × D_flip_flop(bit, clock_edge)
+    → 8 × SR_latch(D, NOT(D))
+      → 8 × 2 NOR gates = 16 NOR gates per register
+```
+
+### 4. decoder.py — Instruction Decoder (Combinational Gates)
+
+The instruction decoder takes the opcode byte (8 bits) and produces a set of control
+signals that drive the rest of the CPU for one instruction cycle.
+
+The decoder is pure combinational logic — no state, no clock. It is the "what do
+I do with this instruction?" question answered entirely by AND/OR/NOT gate trees.
+
+The 8008's decoder is more complex than the 4004's because:
+- Instructions vary by 1, 2, or 3 bytes (the decoder must signal instruction length)
+- The T/F sense bit for conditional branches adds a NOT gate
+- The 3-bit operation field in ALU instructions creates an 8-way demultiplexer
+- The parity computation is new (4004 had no parity flag)
+
+```python
+@dataclass
+class DecoderOutput:
+    """Control signals produced by the 8008 instruction decoder."""
+    # --- Datapath signals ---
+    alu_op: str             # "add", "adc", "sub", "sbb", "and", "or", "xor",
+                            #  "cmp", "inr", "dcr", "rlc", "rrc", "ral", "rar"
+    reg_src: int            # Source register (0–7, where 6=M, 7=A)
+    reg_dst: int            # Destination register (0–7)
+    use_immediate: bool     # True for MVI, ADI, SUI, etc.
+    write_memory: bool      # True when M is destination (MOV M,r or MVI M,d)
+    read_memory: bool       # True when M is source (MOV r,M or ALU M ops)
+    
+    # --- Register file signals ---
+    write_acc: bool         # True when A is the destination
+    write_reg: bool         # True when any register (not A) is written
+    
+    # --- Flag signals ---
+    update_carry: bool      # True for ADD/SUB/ADC/SBB/rotates
+    update_zero: bool       # True for most ALU ops
+    update_sign: bool       # True for most ALU ops
+    update_parity: bool     # True for most ALU ops
+    clear_carry: bool       # True for AND/OR/XOR
+    
+    # --- Control flow ---
+    is_jump: bool
+    is_call: bool
+    is_return: bool
+    is_rst: bool            # Restart instruction (1-byte call to fixed address)
+    condition_code: int     # 0=CY, 1=Z, 2=S, 3=P (for conditional branches)
+    condition_sense: bool   # True = jump-if-true, False = jump-if-false
+    jump_target_rst: int    # 0, 8, 16, ... 56 (for RST instructions)
+    
+    # --- I/O ---
+    is_input: bool
+    is_output: bool
+    port_number: int        # IN port 0–7 or OUT port 0–23
+    
+    # --- Instruction properties ---
+    is_halt: bool
+    instruction_bytes: int  # 1, 2, or 3
+
+def decode(opcode_bits: list[int]) -> DecoderOutput:
+    """Decode 8 opcode bits into control signals using gate logic.
+
+    Input: 8 bits (MSB first: bit7, bit6, ..., bit0)
+    Output: control signals for this instruction cycle.
+
+    The decoder is organized as a hierarchy of AND/OR/NOT gates
+    that match the 8008's instruction encoding structure:
+
+    Level 1 — Decode major group (bits 7–6):
+      group_00 = AND(NOT(b7), NOT(b6))    → INR/DCR/MVI/Rotates
+      group_01 = AND(NOT(b7), b6)         → MOV, HLT, JMP, CAL, JFc/JTc, IN
+      group_10 = AND(b7, NOT(b6))         → ALU register ops
+      group_11 = AND(b7, b6)              → ALU immediate, RET, RST, OUT
+
+    Level 2 — Decode within each group (bits 5–0):
+      For group_01: check if bits 2–0 are 110 (for MOV family)
+        is_mov   = AND(group_01, b2, NOT(b1), b0) ... etc.
+        is_halt  = AND(group_01, b5, b4, b3, b2, NOT(b1), b0)  ; 0x76
+        is_jump  = AND(group_01, b2, NOT(b1), NOT(b0)) ; bits[2:0] = 100
+        is_call  = AND(group_01, b2, b1, NOT(b0))      ; bits[2:0] = 110
+      For group_10: decode 3-bit ALU op from bits 5–3
+        is_add = AND(group_10, NOT(b5), NOT(b4), NOT(b3))
+        is_adc = AND(group_10, NOT(b5), NOT(b4), b3)
+        ...etc for all 8 ALU ops
+    """
+```
+
+Example: detecting `ADD B` (opcode = `0x80` = `10 000 000`):
+
+```
+b7=1, b6=0 → group_10 = AND(1, NOT(0)) = AND(1,1) = 1    ✓ ALU reg group
+b5=0, b4=0, b3=0 → is_add = AND(NOT(0),NOT(0),NOT(0)) = AND(1,1,1) = 1  ✓ ADD
+b2=0, b1=0, b0=0 → reg_src = 0 (register B)              ✓ source = B
+```
+
+Example: detecting conditional jump `JFZ` (opcode = `0x48` = `01 001 000`):
+
+```
+b7=0, b6=1 → group_01 = 1                   ✓ control group
+b2=0, b1=0, b0=0 → bits[2:0] = 000          ✓ jump (not call=110, not mov=xxx)
+b4=0 → T=0 → condition_sense = False        ✓ jump-if-false
+b5=0, b3=1 → CCC = 001 → condition = Zero  ✓ zero flag
+→ "Jump if Zero is False" = JFZ             ✓
+```
+
+### 5. pc.py — Program Counter (14-Bit Register + Incrementer)
+
+```python
+class Intel8008PC:
+    def __init__(self) -> None:
+        # 14-bit register using sequential.register(width=14)
+        # Incrementer: chain of 14 half-adders
+        # (2 more than 4004's 12-bit PC)
+
+    @property
+    def value(self) -> int: ...            # Current PC (0–16383)
+
+    def increment(self) -> None:
+        """PC += 1 using 14 chained half-adders.
+
+        half_adder(pc_bit0, 1) → sum0, carry0
+        half_adder(pc_bit1, carry0) → sum1, carry1
+        ...
+        half_adder(pc_bit13, carry12) → sum13, carry13
+        (carry13 is discarded — 14-bit wrap at 0x3FFF → 0x0000)
+        """
+
+    def increment_by(self, n: int) -> None:
+        """PC += n (for 2-byte and 3-byte instructions).
+
+        Implemented as n sequential increment() calls. This matches how
+        the real chip incremented the PC one byte at a time during fetch.
+        """
+
+    def load(self, address: int) -> None:
+        """PC = address (for jumps, calls, returns).
+
+        Implemented via parallel load into the 14-bit register.
+        address must be 0–16383 (14-bit range).
+        """
+```
+
+### 6. stack.py — 8-Level Push-Down Stack
+
+The 8008's stack differs architecturally from the 4004's: it holds 8 entries
+(vs 3), and the current PC is always entry 0 (it is part of the stack hardware,
+not a separate register). Push and pop are implemented by rotating the stack
+register array.
+
+```python
+class Intel8008Stack:
+    def __init__(self) -> None:
+        # 8 × 14-bit registers, each sequential.register(width=14)
+        # = 8 × 14 = 112 D flip-flops
+        # = 112 × 4 NOR gates = 448 NOR gates
+        # Plus a 3-bit stack pointer (0–7): sequential.register(width=3)
+
+    def current_pc(self) -> int:
+        """Return the current program counter (top of stack)."""
+
+    def push(self, return_address: int) -> None:
+        """Rotate stack down: old PC saved at entry 1, target at entry 0.
+
+        Stack rotation via sequential register writes:
+        entry[7] ← entry[6]
+        entry[6] ← entry[5]
+        ...
+        entry[1] ← entry[0]  (saves return address = current PC + instr_len)
+        entry[0] ← return_address (the call target)
+
+        On overflow (8th push), entry[7] is silently overwritten.
+        """
+
+    def pop(self) -> int:
+        """Rotate stack up: return address is now at entry 0.
+
+        entry[0] ← entry[1]
+        entry[1] ← entry[2]
+        ...
+        entry[6] ← entry[7]
+        entry[7] ← 0 (or unchanged — behavior on underflow is undefined)
+
+        Returns the new top of stack (the return address).
+        """
+
+    def load_pc(self, address: int) -> None:
+        """Write directly to entry[0] (for JMP and RST, which don't push)."""
+
+    @property
+    def depth(self) -> int: ...    # 0–7: number of saved return addresses
+```
+
+### 7. memory.py — 16 KiB Byte-Addressable Memory
+
+The 8008 has a unified memory space (no separate I/O address space — I/O uses
+dedicated IN/OUT instructions). The memory model is simple: 16,384 bytes.
+
+In the gate-level simulator, each byte in memory is modeled as an 8-bit register
+built from D flip-flops. However, simulating 16,384 × 8-bit registers (131,072
+flip-flops) would be impractically slow. We use the same practical compromise as
+the ARM1 gate-level simulator: memory cells are modeled as Python bytearrays for
+storage, but the address decoding logic (the multiplexer tree that selects a memory
+cell from a 14-bit address) is implemented using gate functions.
+
+```python
+class Intel8008Memory:
+    def __init__(self) -> None:
+        # Physical storage: bytearray(16384)
+        # Address decoder: combinational 14-to-16384 demultiplexer
+        #   (implemented as a tree of AND/NOT gates on address bits)
+
+    def read(self, address_bits: list[int]) -> list[int]:
+        """Read 8 bits from the address specified by a 14-bit bit list.
+
+        The address decoder uses AND gate trees to select the memory cell:
+        For address 0x0010 = [0,0,0,0,1,0,0,0, 0,0,0,0,0,0] (LSB first):
+          - Gate tree matches addr_bit4=1, all others 0
+          - Returns the 8 bits at that cell
+        """
+
+    def write(self, address_bits: list[int], data_bits: list[int]) -> None:
+        """Write 8 bits to the address specified by a 14-bit bit list."""
+
+    def load_bytes(self, data: bytes, start: int = 0) -> None:
+        """Load a byte sequence directly (bypasses gate model for initialization)."""
+```
+
+### 8. io.py — Input/Output Ports
+
+The 8008 has 8 input ports (read by IN) and 24 output ports (written by OUT).
+Port selection is encoded in the opcode's bit fields and decoded by gate logic.
+
+```python
+class Intel8008IO:
+    def __init__(self) -> None:
+        # 8 input port registers: each sequential.register(width=8)
+        # 24 output port registers: each sequential.register(width=8)
+        # Port select decoder: AND/NOT gate tree on port bits from opcode
+
+    def read_input(self, port_bits: list[int]) -> list[int]:
+        """Read 8 bits from input port selected by port_bits (3-bit).
+
+        Port decoder:
+          port_0 = AND(NOT(p2), NOT(p1), NOT(p0))
+          port_1 = AND(NOT(p2), NOT(p1), p0)
+          ...
+          port_7 = AND(p2, p1, p0)
+        MUX8: select one of 8 input registers based on decoded port.
+        """
+
+    def write_output(self, port_bits: list[int], data_bits: list[int]) -> None:
+        """Write 8 bits to output port selected by port_bits (5-bit, ports 0–23)."""
+
+    def set_input(self, port: int, value: int) -> None:
+        """Set input port value (called by test harness / external simulation)."""
+
+    def get_output(self, port: int) -> int:
+        """Read current output port value."""
+```
+
+### 9. control.py — Control Unit (FSM)
+
+The control unit sequences the fetch-decode-execute cycle. For the 8008, this
+is more complex than the 4004 because the instruction length (1, 2, or 3 bytes)
+must be determined during fetch to know how many additional bytes to read.
+
+```
+FSM states:
+  FETCH1   → Read opcode byte from PC, increment PC
+  DECODE   → Decode opcode, determine instruction length
+  FETCH2   → (if 2 or 3 bytes) Read second byte, increment PC
+  FETCH3   → (if 3 bytes) Read third byte, increment PC
+  EXECUTE  → Apply decoded operation to registers/memory/PC/flags
+```
+
+```python
+class Intel8008ControlUnit:
+    def __init__(self, clock: Clock) -> None:
+        # FSM using sequential logic (D flip-flop for state register)
+
+    def step(self) -> ControlSignals:
+        """Advance one full instruction (multiple clock cycles internally).
+
+        The real 8008 uses a multi-phase clock cycle (T-states):
+          - Short instruction: 5 T-states (T1–T5)
+          - Long instruction: up to 11 T-states for 3-byte instructions
+        We model this as a 5-state FSM that abstracts the T-state detail.
+        """
+```
+
+The real 8008 used an 8-phase machine cycle with states T1–T5 plus WAIT, STOPPED,
+and HALTED. Each machine cycle took either 1 or 2 cycles of the two-phase external
+clock. We simplify to the logical FETCH/DECODE/FETCH2/FETCH3/EXECUTE model that
+captures the essential sequencing without the electrical timing.
+
+### 10. cpu.py — Top-Level Wiring
+
+```python
+class Intel8008GateLevel:
+    def __init__(self) -> None:
+        self._alu       = Intel8008ALU()
+        self._registers = Intel8008RegisterFile()
+        self._decoder   = decode           # Combinational decoder function
+        self._pc        = Intel8008PC()    # Bundled into stack for 8008
+        self._stack     = Intel8008Stack() # Stack owns the PC
+        self._memory    = Intel8008Memory()
+        self._io        = Intel8008IO()
+        self._control   = Intel8008ControlUnit(Clock(frequency_hz=500_000))
+
+    # --- Same public API as behavioral simulator ---
+    def load_program(self, program: bytes, start_address: int = 0) -> None: ...
+    def step(self) -> Intel8008Trace: ...
+    def run(
+        self,
+        program: bytes,
+        max_steps: int = 100_000,
+        start_address: int = 0,
+    ) -> list[Intel8008Trace]: ...
+    def reset(self) -> None: ...
+
+    @property
+    def a(self) -> int: ...
+    @property
+    def b(self) -> int: ...
+    @property
+    def c(self) -> int: ...
+    @property
+    def d(self) -> int: ...
+    @property
+    def e(self) -> int: ...
+    @property
+    def h(self) -> int: ...
+    @property
+    def l(self) -> int: ...
+    @property
+    def pc(self) -> int: ...
+    @property
+    def flags(self) -> Intel8008Flags: ...
+
+    # --- I/O (same as behavioral) ---
+    def set_input_port(self, port: int, value: int) -> None: ...
+    def get_output_port(self, port: int) -> int: ...
+
+    # --- Gate-level specific ---
+    def gate_count(self) -> dict[str, int]:
+        """Count gate invocations by component.
+
+        Returns a dict with keys: 'alu', 'registers', 'decoder', 'stack',
+        'memory_decoder', 'io_decoder', 'pc', 'flags'. Values are gate
+        call counts for the most recent instruction execution.
+        """
+
+    def gate_count_total(self) -> dict[str, int]:
+        """Estimated static gate count (hardware gates, not invocations).
+
+        This models how many AND/OR/NOT/XOR/NOT gates the chip would need
+        if built in hardware. Compare with the real 8008's ~3,500 transistors.
+        """
+
+    def inspect_internals(self) -> dict:
+        """Return raw bit-level internal state for debugging.
+
+        Returns: {
+            'a_bits': list[int],       # Accumulator bits (LSB first)
+            'b_bits': list[int],       # Register B bits
+            ...
+            'flags_bits': list[int],   # [CY, Z, S, P]
+            'pc_bits': list[int],      # 14-bit PC bits (LSB first)
+            'stack_bits': list[list[int]],  # 8 × 14-bit stack entries
+        }
+        """
+```
+
+## Execution Flow (One ADD Instruction)
+
+Here's what happens when the gate-level simulator executes `ADD B` (`0x80`):
+
+```
+1. FETCH1
+   PC value (14 bits) → memory address decoder → read byte 0x80
+   PC.increment() → 14 half-adders chain to compute PC+1
+
+2. DECODE
+   0x80 → 8 bits [0,0,0,0,0,0,0,1] (LSB first) = [1,0,0,0,0,0,0,0] (MSB first)
+   → decoder gate tree:
+     b7=1, b6=0 → group_10 = AND(b7, NOT(b6)) = 1   ✓ ALU register group
+     b5=0,b4=0,b3=0 → is_add = AND(NOT(b5),NOT(b4),NOT(b3)) = 1  ✓ ADD
+     b2=0,b1=0,b0=0 → reg_src = 0 (register B)      ✓
+   → DecoderOutput(alu_op="add", reg_src=0, write_acc=True,
+                   update_carry=True, update_zero=True,
+                   update_sign=True, update_parity=True,
+                   instruction_bytes=1)
+
+3. EXECUTE
+   Read B  → register_file.read(0) → e.g., 0x03 = [1, 1, 0, 0, 0, 0, 0, 0]
+   Read A  → register_file.a       → e.g., 0x05 = [1, 0, 1, 0, 0, 0, 0, 0]
+   Read CY → register_file.flags.carry → False
+
+   ALU.add(0x05, 0x03, False):
+     a_bits = [1,0,1,0, 0,0,0,0]   (A=5, LSB first)
+     b_bits = [1,1,0,0, 0,0,0,0]   (B=3, LSB first)
+     → ripple_carry_adder(a_bits, b_bits, cin=0):
+       → full_adder(1, 1, 0) → sum=0, carry=1
+       → full_adder(0, 1, 1) → sum=0, carry=1
+       → full_adder(1, 0, 1) → sum=0, carry=1
+       → full_adder(0, 0, 1) → sum=1, carry=0
+       → full_adder(0, 0, 0) → sum=0, carry=0
+       → full_adder(0, 0, 0) → sum=0, carry=0
+       → full_adder(0, 0, 0) → sum=0, carry=0
+       → full_adder(0, 0, 0) → sum=0, carry=0   [8 adders vs 4 for 4004]
+     result_bits = [0,0,0,1, 0,0,0,0] → bits_to_int → 8
+     carry_out = 0
+
+   Compute flags from result 8 (0x08):
+     zero   = NOR8([0,0,0,1,0,0,0,0]) = 0           (not all zero)
+     sign   = result_bits[7] = 0                     (bit 7 = 0)
+     carry  = carry_out = 0
+     parity = XOR tree over 8 bits:
+              XOR(XOR(XOR(0,0), XOR(0,1)), XOR(XOR(0,0), XOR(0,0)))
+              = XOR(XOR(0,1), XOR(0,0)) = XOR(1,0) = 1
+              parity = NOT(1) = 0                    (odd number of 1 bits)
+
+   Write A = 8 → register_file.a = 8
+     → 8 D flip-flops updated
+   Write flags (CY=0, Z=0, S=0, P=0)
+     → 4 D flip-flops updated
+```
+
+Total gate operations for one ADD: ~100+ individual gate function calls
+(vs ~60 for the 4004's 4-bit ADD, as expected for double-width).
+
+## Gate Count Estimates
+
+| Component | Gates (approx) | Transistors (approx) | Notes |
+|-----------|----------------|---------------------|-------|
+| ALU (8-bit) | ~200 | ~500 | 8 full-adders + parity tree + NOT/AND/OR arrays |
+| Register file (7×8-bit) | ~448 (flip-flops) | ~1,792 | 56 DFFs × 8 NOR gates each |
+| Accumulator (8-bit) | ~32 | ~128 | 8 DFFs |
+| Flag register (4-bit) | ~16 | ~64 | 4 DFFs |
+| Instruction decoder | ~200 | ~500 | 8008 has more complex decoding than 4004 |
+| Program counter (14-bit) | ~112 | ~280 | 14 DFFs + 14 half-adders |
+| Stack (8×14-bit) | ~448 | ~1,120 | 112 DFFs |
+| Control unit | ~50 | ~120 | FSM with more states than 4004 |
+| Multiplexers/glue | ~60 | ~150 | Address decoding, bus selection |
+| I/O decoders | ~40 | ~100 | Port select logic |
+| **Total** | **~1,606** | **~4,754** | |
+
+The real 8008 had approximately 3,500 transistors. Our model runs slightly high
+because:
+1. We model the full stack as individual flip-flops (the real chip likely used
+   a more compact shift-register style implementation for the push-down stack)
+2. Our CMOS-equivalent transistor count uses 4 per NOR gate, but the real 8008
+   used PMOS with different gate structures
+
+## Dependencies
+
+```
+intel8008-gatelevel
+├── logic-gates (AND, OR, XOR, NOT, MUX, D flip-flop, register, SR latch)
+├── arithmetic (half_adder, full_adder, ripple_carry_adder, ALU)
+└── clock (Clock, ClockEdge)
+```
+
+## Test Strategy
+
+### Unit Tests (per component)
+
+- **ALU**:
+  - add: (0,0), (0xFF, 0x01) → overflow, (0x7F, 0x01) → sign change
+  - subtract: borrow semantics (CY=0 when borrow occurs)
+  - AND/OR/XOR: verify CY cleared even when operands have CY preloaded
+  - rotate: RLC, RRC, RAL, RAR with edge cases (0x80, 0x01, 0xFF)
+  - compute_flags: zero detection, sign detection, parity for all 256 values,
+    carry from adder
+
+- **Registers**:
+  - Read/write all 7 registers (B, C, D, E, H, L, A)
+  - hl_address: verify 14-bit address formation for various H:L combinations
+  - Flag register: write and read all flag combinations
+
+- **Decoder**:
+  - Verify control signals for every 8008 opcode (exhaustive — 256 inputs,
+    many are undefined but decoder must not crash)
+  - Spot-check: MOV A,B (0x78), ADD M (0x86), JMP (0x7C), CAL (0x7E),
+    RET (0x3F), RST 4 (0x25), IN 3 (0x49+?), HLT (0x76)
+
+- **Stack**:
+  - Push/pop at depths 1, 2, 7
+  - Verify depth counter is accurate
+  - Wrap on 8th push: entry[7] overwritten, caller can detect via address mismatch
+
+- **Memory**:
+  - Read/write at address 0x0000, 0x0001, 0x1234, 0x3FFE, 0x3FFF
+  - Address decoder: correct cell selected from gate logic
+  - Verify gate path for address 0x0010 (spot check the AND gate tree)
+
+- **PC**:
+  - Increment from 0, from 0x3FFE, from 0x3FFF (wrap to 0x0000)
+  - increment_by(1), increment_by(2), increment_by(3)
+  - load() to arbitrary address
+
+- **I/O**:
+  - Read each input port 0–7
+  - Write each output port 0–23
+  - Port decoder gate tree spot-checks
+
+### Integration Tests
+
+Same programs as the behavioral simulator:
+- x = 1 + 2
+- 4 × 5 multiply via loop
+- Absolute value subroutine
+- Parity check
+
+### Cross-Validation Tests
+
+The ultimate correctness guarantee: run N programs on both behavioral and gate-level
+simulators and assert identical final CPU state after every instruction.
+
+```python
+def test_cross_validate(program: bytes) -> None:
+    behavioral = Intel8008Simulator()
+    gatelevel  = Intel8008GateLevel()
+    b_traces = behavioral.run(program, max_steps=1000)
+    g_traces = gatelevel.run(program, max_steps=1000)
+    assert len(b_traces) == len(g_traces)
+    for b, g in zip(b_traces, g_traces):
+        assert b.address == g.address
+        assert b.a_after == g.a_after
+        assert b.flags_after == g.flags_after
+```
+
+Programs used for cross-validation:
+- All single-instruction tests (one per opcode)
+- All example programs from 07f
+- Hypothesis-generated random programs (property-based testing)
+
+### Gate Count Tests
+
+```python
+def test_gate_count_reasonable() -> None:
+    counts = Intel8008GateLevel().gate_count_total()
+    # ALU should need more gates than 4004's ~80
+    assert counts['alu'] > 80
+    # Register file scales with 7×8 = 56 DFFs
+    assert counts['registers'] >= 448
+    # Total should be in the ballpark of real transistor count
+    assert 1000 < sum(counts.values()) < 10000
+```
+
+### Performance Tests (Informational)
+
+Measure the wall-clock slowdown factor of gate-level vs behavioral for the same
+program. The 8008 gate-level simulator will be slower than the 4004 gate-level
+simulator (more gates per instruction), but the ratio should be similar (~100–1000×).
+Document this in the README as an educational data point.


### PR DESCRIPTION
## Summary

- Adds `code/specs/07f-intel8008-simulator.md` — complete behavioral simulator spec for the Intel 8008 (April 1972, world's first 8-bit microprocessor, ~3,500 transistors)
- Adds `code/specs/07f2-intel8008-gatelevel.md` — gate-level simulator spec routing every operation through AND/OR/XOR/NOT gate functions

## Architecture highlights

The 8008 is architecturally unique in this repo:
- **7 registers** (A, B, C, D, E, H, L) + M pseudo-register (indirect [H:L]) — first chip with a real register file
- **14-bit address space** (16 KiB) vs 4004's 12-bit (4 KiB)
- **8-level push-down stack** where entry 0 **is** the PC — no separate program counter register
- **4 flags**: Carry, Zero, Sign, **Parity** (new vs 4004 — needs XOR reduction in gate-level)
- **Variable-length instructions**: 1, 2, or 3 bytes — uses custom dispatch loop, not GenericVM

## Gate-level highlights

- 8-bit ALU: 8 full-adders in ripple chain (double the 4004's 4)
- New parity computation: 7-gate XOR reduction tree + NOT
- Gate count: ~1,606 gates / ~4,754 transistor-equivalents (real chip: ~3,500)

## Test plan
- [ ] Implementation PRs follow (behavioral + gate-level, all 5 main languages)
- [ ] Gate-level cross-validates against behavioral for all example programs
- [ ] 95%+ test coverage target for both packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)