### PR TITLE
[codex] Refactor huffman-tree to use standalone heap packages

### DIFF
--- a/code/packages/lua/heap/BUILD
+++ b/code/packages/lua/heap/BUILD
@@ -1,0 +1,2 @@
+luarocks make --local --deps-mode=none coding-adventures-heap-0.1.0-1.rockspec
+cd tests && LUA_PATH="../src/?.lua;../src/?/init.lua;;" busted . --verbose --pattern=test_

--- a/code/packages/lua/heap/BUILD_windows
+++ b/code/packages/lua/heap/BUILD_windows
@@ -1,0 +1,2 @@
+luarocks make --local --deps-mode=none coding-adventures-heap-0.1.0-1.rockspec
+cd tests && set LUA_PATH=..\src\?.lua;..\src\?\init.lua;; && busted . --verbose --pattern=test_

--- a/code/packages/lua/heap/CHANGELOG.md
+++ b/code/packages/lua/heap/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog — coding-adventures-heap (Lua)
+
+All notable changes to this package are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [0.1.0] — 2026-04-12
+
+### Added
+
+- Initial implementation of `coding_adventures.heap`.
+- Generic comparator-based `MinHeap` and `MaxHeap` binary heaps.
+- `new(compare)` and `from_iterable(items, compare)` constructors.
+- `push`, `pop`, `peek`, `len`, `size`, `is_empty`, and `to_array` operations.
+- Busted tests covering min-heap ordering, max-heap ordering, heapify, custom
+  comparators, and empty-heap behavior.

--- a/code/packages/lua/heap/README.md
+++ b/code/packages/lua/heap/README.md
@@ -1,0 +1,53 @@
+# coding-adventures-heap (Lua)
+
+Comparator-based binary heap package for Lua.
+
+## Usage
+
+```lua
+local heap = require("coding_adventures.heap")
+
+local min_heap = heap.MinHeap.new()
+min_heap:push(5)
+min_heap:push(1)
+min_heap:push(3)
+print(min_heap:pop()) -- 1
+
+local max_heap = heap.MaxHeap.new()
+max_heap:push(5)
+max_heap:push(1)
+max_heap:push(3)
+print(max_heap:pop()) -- 5
+
+local tuple_heap = heap.MinHeap.new(function(left, right)
+    if left[1] == right[1] then
+        if left[2] == right[2] then
+            return 0
+        end
+        return left[2] < right[2] and -1 or 1
+    end
+    return left[1] < right[1] and -1 or 1
+end)
+tuple_heap:push({1, "b"})
+tuple_heap:push({1, "a"})
+print(tuple_heap:pop()[2]) -- "a"
+```
+
+## API
+
+- `heap.MinHeap.new(compare)` creates an empty min-heap.
+- `heap.MaxHeap.new(compare)` creates an empty max-heap.
+- `from_iterable(items, compare)` heapifies a Lua array.
+- `push(value)` inserts a value.
+- `pop()` removes and returns the root, or `nil` when empty.
+- `peek()` returns the root, or `nil` when empty.
+- `len()` and `size()` return the number of elements.
+- `is_empty()` reports whether the heap is empty.
+- `to_array()` returns a shallow copy of the underlying array-backed heap.
+
+## Running Tests
+
+```bash
+luarocks make --local --deps-mode=none coding-adventures-heap-0.1.0-1.rockspec
+cd tests && LUA_PATH="../src/?.lua;../src/?/init.lua;;" busted . --verbose --pattern=test_
+```

--- a/code/packages/lua/heap/coding-adventures-heap-0.1.0-1.rockspec
+++ b/code/packages/lua/heap/coding-adventures-heap-0.1.0-1.rockspec
@@ -1,0 +1,18 @@
+package = "coding-adventures-heap"
+version = "0.1.0-1"
+source = {
+    url = "git://github.com/adhithyan15/coding-adventures.git",
+}
+description = {
+    summary = "Comparator-based binary min-heaps and max-heaps",
+    license = "MIT",
+}
+dependencies = {
+    "lua >= 5.4",
+}
+build = {
+    type = "builtin",
+    modules = {
+        ["coding_adventures.heap"] = "src/coding_adventures/heap/init.lua",
+    },
+}

--- a/code/packages/lua/heap/src/coding_adventures/heap/init.lua
+++ b/code/packages/lua/heap/src/coding_adventures/heap/init.lua
@@ -1,0 +1,161 @@
+local M = {}
+
+M.VERSION = "0.1.0"
+
+local function default_compare(left, right)
+    if left == right then
+        return 0
+    end
+    return left < right and -1 or 1
+end
+
+M.default_compare = default_compare
+
+local Heap = {}
+Heap.__index = Heap
+
+function Heap:len()
+    return #self._data
+end
+
+function Heap:size()
+    return #self._data
+end
+
+function Heap:is_empty()
+    return #self._data == 0
+end
+
+function Heap:peek()
+    return self._data[1]
+end
+
+function Heap:to_array()
+    local result = {}
+    for index, value in ipairs(self._data) do
+        result[index] = value
+    end
+    return result
+end
+
+function Heap:_higher_priority(_left, _right)
+    error("Heap:_higher_priority must be implemented by subclasses")
+end
+
+function Heap:_sift_up(index)
+    while index > 1 do
+        local parent = math.floor(index / 2)
+        if self:_higher_priority(self._data[index], self._data[parent]) then
+            self._data[index], self._data[parent] = self._data[parent], self._data[index]
+            index = parent
+        else
+            break
+        end
+    end
+end
+
+function Heap:_sift_down(index)
+    local size = #self._data
+    while true do
+        local left = index * 2
+        local right = left + 1
+        local best = index
+
+        if left <= size and self:_higher_priority(self._data[left], self._data[best]) then
+            best = left
+        end
+        if right <= size and self:_higher_priority(self._data[right], self._data[best]) then
+            best = right
+        end
+
+        if best == index then
+            break
+        end
+
+        self._data[index], self._data[best] = self._data[best], self._data[index]
+        index = best
+    end
+end
+
+function Heap:_build_from_iterable(items)
+    self._data = {}
+    if items == nil then
+        return
+    end
+
+    for _, value in ipairs(items) do
+        self._data[#self._data + 1] = value
+    end
+
+    for index = math.floor(#self._data / 2), 1, -1 do
+        self:_sift_down(index)
+    end
+end
+
+function Heap:push(value)
+    self._data[#self._data + 1] = value
+    self:_sift_up(#self._data)
+    return self
+end
+
+function Heap:pop()
+    if #self._data == 0 then
+        return nil
+    end
+
+    local root = self._data[1]
+    if #self._data == 1 then
+        self._data[1] = nil
+        return root
+    end
+
+    self._data[1] = self._data[#self._data]
+    self._data[#self._data] = nil
+    self:_sift_down(1)
+    return root
+end
+
+local MinHeap = setmetatable({}, {__index = Heap})
+MinHeap.__index = MinHeap
+
+function MinHeap.new(compare)
+    return setmetatable({
+        _compare = compare or default_compare,
+        _data = {},
+    }, MinHeap)
+end
+
+function MinHeap.from_iterable(items, compare)
+    local heap = MinHeap.new(compare)
+    heap:_build_from_iterable(items)
+    return heap
+end
+
+function MinHeap:_higher_priority(left, right)
+    return self._compare(left, right) < 0
+end
+
+local MaxHeap = setmetatable({}, {__index = Heap})
+MaxHeap.__index = MaxHeap
+
+function MaxHeap.new(compare)
+    return setmetatable({
+        _compare = compare or default_compare,
+        _data = {},
+    }, MaxHeap)
+end
+
+function MaxHeap.from_iterable(items, compare)
+    local heap = MaxHeap.new(compare)
+    heap:_build_from_iterable(items)
+    return heap
+end
+
+function MaxHeap:_higher_priority(left, right)
+    return self._compare(left, right) > 0
+end
+
+M.MinHeap = MinHeap
+M.MaxHeap = MaxHeap
+
+return M

--- a/code/packages/lua/heap/tests/test_heap.lua
+++ b/code/packages/lua/heap/tests/test_heap.lua
@@ -1,0 +1,91 @@
+package.path = "../src/?.lua;../src/?/init.lua;" .. package.path
+
+local heap_module = require("coding_adventures.heap")
+local MinHeap = heap_module.MinHeap
+local MaxHeap = heap_module.MaxHeap
+
+describe("heap module", function()
+    it("exposes VERSION and heap classes", function()
+        assert.equals("0.1.0", heap_module.VERSION)
+        assert.is_table(MinHeap)
+        assert.is_table(MaxHeap)
+    end)
+end)
+
+describe("MinHeap", function()
+    it("pops values in ascending order", function()
+        local heap = MinHeap.new()
+        for _, value in ipairs({5, 3, 8, 1, 4}) do
+            heap:push(value)
+        end
+
+        assert.equals(1, heap:peek())
+        assert.equals(1, heap:pop())
+        assert.equals(3, heap:pop())
+        assert.equals(4, heap:pop())
+        assert.equals(5, heap:pop())
+        assert.equals(8, heap:pop())
+        assert.is_nil(heap:pop())
+    end)
+
+    it("supports heapifying from an iterable", function()
+        local heap = MinHeap.from_iterable({9, 2, 7, 1, 5})
+        local popped = {}
+        while not heap:is_empty() do
+            popped[#popped + 1] = heap:pop()
+        end
+
+        assert.are.same({1, 2, 5, 7, 9}, popped)
+    end)
+
+    it("supports custom comparators", function()
+        local heap = MinHeap.new(function(left, right)
+            if left[1] ~= right[1] then
+                return left[1] < right[1] and -1 or 1
+            end
+            if left[2] ~= right[2] then
+                return left[2] < right[2] and -1 or 1
+            end
+            return 0
+        end)
+
+        heap:push({1, "b"})
+        heap:push({1, "a"})
+        heap:push({0, "z"})
+
+        assert.are.same({0, "z"}, heap:pop())
+        assert.are.same({1, "a"}, heap:pop())
+        assert.are.same({1, "b"}, heap:pop())
+    end)
+end)
+
+describe("MaxHeap", function()
+    it("pops values in descending order", function()
+        local heap = MaxHeap.new()
+        for _, value in ipairs({5, 3, 8, 1, 4}) do
+            heap:push(value)
+        end
+
+        assert.equals(8, heap:peek())
+        assert.equals(8, heap:pop())
+        assert.equals(5, heap:pop())
+        assert.equals(4, heap:pop())
+        assert.equals(3, heap:pop())
+        assert.equals(1, heap:pop())
+        assert.is_nil(heap:pop())
+    end)
+end)
+
+describe("empty heap helpers", function()
+    it("reports empty state correctly", function()
+        local heap = MinHeap.new()
+        assert.is_true(heap:is_empty())
+        assert.equals(0, heap:len())
+        assert.equals(0, heap:size())
+        assert.is_nil(heap:peek())
+        heap:push(42)
+        assert.is_false(heap:is_empty())
+        assert.equals(1, heap:len())
+        assert.are.same({42}, heap:to_array())
+    end)
+end)

--- a/code/packages/lua/huffman-tree/BUILD
+++ b/code/packages/lua/huffman-tree/BUILD
@@ -1,1 +1,3 @@
-cd tests && LUA_PATH="../src/?.lua;../src/?/init.lua;;" busted . --verbose --pattern=test_
+luarocks show coding-adventures-heap 1>/dev/null 2>/dev/null || (cd ../heap && luarocks make --local --deps-mode=none coding-adventures-heap-0.1.0-1.rockspec)
+luarocks make --local --deps-mode=none coding-adventures-huffman-tree-0.1.0-1.rockspec
+cd tests && LUA_PATH="../src/?.lua;../src/?/init.lua;../../heap/src/?.lua;../../heap/src/?/init.lua;;" busted . --verbose --pattern=test_

--- a/code/packages/lua/huffman-tree/BUILD_windows
+++ b/code/packages/lua/huffman-tree/BUILD_windows
@@ -1,1 +1,3 @@
-cd tests && set LUA_PATH=..\src\?.lua;..\src\?\init.lua;; && busted . --verbose --pattern=test_
+luarocks show coding-adventures-heap 1>nul 2>nul || (cd ../heap && luarocks make --local --deps-mode=none coding-adventures-heap-0.1.0-1.rockspec)
+luarocks make --local --deps-mode=none coding-adventures-huffman-tree-0.1.0-1.rockspec
+cd tests && set LUA_PATH=..\src\?.lua;..\src\?\init.lua;..\..\heap\src\?.lua;..\..\heap\src\?\init.lua;; && busted . --verbose --pattern=test_

--- a/code/packages/lua/huffman-tree/CHANGELOG.md
+++ b/code/packages/lua/huffman-tree/CHANGELOG.md
@@ -8,8 +8,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Initial implementation of `CodingAdventures.HuffmanTree` (DT27).
-- Embedded min-heap (array-based binary heap) with 4-tuple priority comparator
-  for deterministic tie-breaking: `{weight, leaf_flag, symbol_or_huge, order_or_huge}`.
+- Depends on `coding-adventures-heap` for the comparator-based min-heap used
+  during deterministic greedy construction.
 - `HuffmanTree.build(weights)` — greedy construction from `{{symbol, freq}, ...}` pairs
   with four-level tie-breaking rules identical to the Python reference implementation.
 - `tree:code_table()` — returns `{[symbol] = bitstring}` for all symbols.

--- a/code/packages/lua/huffman-tree/README.md
+++ b/code/packages/lua/huffman-tree/README.md
@@ -88,6 +88,11 @@ Tie-breaking (for identical output across all implementations):
 3. Lower symbol value among equal-weight leaves.
 4. Earlier-created (FIFO) among equal-weight internal nodes.
 
+## Dependency
+
+This package depends on `coding-adventures-heap` for the standalone `MinHeap`
+used during tree construction.
+
 ## API
 
 | Function | Description |
@@ -117,7 +122,9 @@ Tie-breaking (for identical output across all implementations):
 ## Running Tests
 
 ```bash
-cd tests && LUA_PATH="../src/?.lua;../src/?/init.lua;;" busted . --verbose --pattern=test_
+luarocks show coding-adventures-heap 1>/dev/null 2>/dev/null || (cd ../heap && luarocks make --local --deps-mode=none coding-adventures-heap-0.1.0-1.rockspec)
+luarocks make --local --deps-mode=none coding-adventures-huffman-tree-0.1.0-1.rockspec
+cd tests && LUA_PATH="../src/?.lua;../src/?/init.lua;../../heap/src/?.lua;../../heap/src/?/init.lua;;" busted . --verbose --pattern=test_
 ```
 
 ## License

--- a/code/packages/lua/huffman-tree/coding-adventures-huffman-tree-0.1.0-1.rockspec
+++ b/code/packages/lua/huffman-tree/coding-adventures-huffman-tree-0.1.0-1.rockspec
@@ -9,6 +9,7 @@ description = {
 }
 dependencies = {
     "lua >= 5.4",
+    "coding-adventures-heap >= 0.1.0",
 }
 build = {
     type = "builtin",

--- a/code/packages/lua/huffman-tree/src/coding_adventures/huffman_tree/init.lua
+++ b/code/packages/lua/huffman-tree/src/coding_adventures/huffman_tree/init.lua
@@ -86,12 +86,13 @@
 --     B → 10       (length 2,  code = 0+1=1, shifted 1 bit → 10)
 --     C → 11       (length 2,  code = 10+1 = 11)
 --
--- Embedded Min-Heap
--- -----------------
+-- Heap Package
+-- ------------
 --
--- Lua does not have a built-in priority queue. We embed a simple binary heap
--- (array-based) with a custom comparator. The heap stores items with a priority
--- tuple: {weight, leaf_flag, symbol_or_huge, order_or_huge}.
+-- This package depends on coding_adventures.heap for the array-backed binary
+-- min-heap used during greedy construction. Heap items are stored as
+-- {priority, node} pairs, where priority is the 4-tuple used for
+-- deterministic tie-breaking.
 --
 -- A binary heap uses a parent/child indexing trick:
 --   - Root is at index 1.
@@ -110,107 +111,18 @@ local M = {}
 
 M.VERSION = "0.1.0"
 
--- ── Embedded Min-Heap ─────────────────────────────────────────────────────────
+local heap_module = require("coding_adventures.heap")
+local MinHeap = heap_module.MinHeap
 
--- new_heap creates an empty binary min-heap.
---
--- Each element is stored as {priority, data} where priority is a 4-element
--- table {weight, leaf_flag, symbol_or_huge, order_or_huge}.
---
--- The comparison function compares two priority tuples lexicographically,
--- implementing the four-level tie-breaking rule described above.
---
--- @return table  A heap object with :push(priority, data) and :pop() methods.
-local function new_heap()
-    local h = {items = {}, size = 0}
+local function compare_entries(left, right)
+    local a = left[1]
+    local b = right[1]
 
-    -- cmp_priority compares two 4-element priority tuples lexicographically.
-    -- Returns true if a has higher priority than b (a < b in min-heap terms).
-    --
-    -- A priority tuple is: {weight, leaf_flag, symbol_or_huge, order_or_huge}
-    --
-    -- Comparison:
-    --   First compare weight (lower wins).
-    --   On tie: compare leaf_flag (0=leaf wins over 1=internal).
-    --   On tie: compare symbol/huge (lower symbol wins; internal nodes use math.huge).
-    --   On tie: compare order/huge (lower order wins; leaves use math.huge).
-    local function cmp_priority(a, b)
-        if a[1] ~= b[1] then return a[1] < b[1] end
-        if a[2] ~= b[2] then return a[2] < b[2] end
-        if a[3] ~= b[3] then return a[3] < b[3] end
-        return a[4] < b[4]
-    end
-
-    -- sift_up restores the heap property after inserting at index i.
-    -- It repeatedly swaps the new element with its parent as long as it has
-    -- higher priority (smaller key) than its parent.
-    local function sift_up(items, i)
-        while i > 1 do
-            local parent = math.floor(i / 2)
-            if cmp_priority(items[i][1], items[parent][1]) then
-                items[i], items[parent] = items[parent], items[i]
-                i = parent
-            else
-                break
-            end
-        end
-    end
-
-    -- sift_down restores the heap property after removing the root.
-    -- It repeatedly swaps the displaced element with the smaller of its two
-    -- children as long as it has lower priority (larger key) than a child.
-    local function sift_down(items, size, i)
-        while true do
-            local left  = 2 * i
-            local right = 2 * i + 1
-            local smallest = i
-
-            if left <= size and cmp_priority(items[left][1], items[smallest][1]) then
-                smallest = left
-            end
-            if right <= size and cmp_priority(items[right][1], items[smallest][1]) then
-                smallest = right
-            end
-
-            if smallest == i then break end
-
-            items[i], items[smallest] = items[smallest], items[i]
-            i = smallest
-        end
-    end
-
-    -- push adds a new item to the heap.
-    --
-    -- @param priority  table  4-element priority tuple {weight, leaf_flag, sym, ord}.
-    -- @param data       any    The payload associated with this priority.
-    function h:push(priority, data)
-        self.size = self.size + 1
-        self.items[self.size] = {priority, data}
-        sift_up(self.items, self.size)
-    end
-
-    -- pop removes and returns the item with the highest priority (smallest key).
-    --
-    -- @return priority, data  The priority tuple and associated data.
-    -- @return nil             If the heap is empty.
-    function h:pop()
-        if self.size == 0 then return nil end
-        local top = self.items[1]
-        self.items[1] = self.items[self.size]
-        self.items[self.size] = nil
-        self.size = self.size - 1
-        if self.size > 0 then
-            sift_down(self.items, self.size, 1)
-        end
-        return top[1], top[2]
-    end
-
-    -- len returns the number of items currently in the heap.
-    function h:len()
-        return self.size
-    end
-
-    return h
+    if a[1] ~= b[1] then return a[1] < b[1] and -1 or 1 end
+    if a[2] ~= b[2] then return a[2] < b[2] and -1 or 1 end
+    if a[3] ~= b[3] then return a[3] < b[3] and -1 or 1 end
+    if a[4] ~= b[4] then return a[4] < b[4] and -1 or 1 end
+    return 0
 end
 
 -- ── Node Constructors ──────────────────────────────────────────────────────────
@@ -309,26 +221,28 @@ function HuffmanTree.build(weights)
         end
     end
 
-    local heap = new_heap()
+    local heap = MinHeap.new(compare_entries)
 
     -- Seed the heap with one leaf per symbol.
     for _, pair in ipairs(weights) do
         local leaf = new_leaf(pair[1], pair[2])
-        heap:push(node_priority(leaf), leaf)
+        heap:push({node_priority(leaf), leaf})
     end
 
     local order_counter = 0
 
     -- Merge phase: repeatedly combine the two smallest nodes.
     while heap:len() > 1 do
-        local _, left  = heap:pop()
-        local _, right = heap:pop()
+        local left_entry = heap:pop()
+        local right_entry = heap:pop()
+        local left = left_entry[2]
+        local right = right_entry[2]
         local internal = new_internal(left, right, order_counter)
         order_counter = order_counter + 1
-        heap:push(node_priority(internal), internal)
+        heap:push({node_priority(internal), internal})
     end
 
-    local _, root = heap:pop()
+    local root = heap:pop()[2]
 
     local tree = {
         _root         = root,

--- a/code/packages/lua/huffman-tree/tests/test_huffman_tree.lua
+++ b/code/packages/lua/huffman-tree/tests/test_huffman_tree.lua
@@ -8,7 +8,7 @@
 --
 -- Uses Busted test framework: https://olivinelabs.com/busted/
 
-package.path = "../src/?.lua;../src/?/init.lua;" .. package.path
+package.path = "../src/?.lua;../src/?/init.lua;../../heap/src/?.lua;../../heap/src/?/init.lua;" .. package.path
 
 local HuffmanTree = require("coding_adventures.huffman_tree")
 

--- a/code/packages/perl/heap/BUILD
+++ b/code/packages/perl/heap/BUILD
@@ -1,2 +1,1 @@
-cpanm --installdeps --quiet .
 prove -l -v t/

--- a/code/packages/perl/heap/BUILD
+++ b/code/packages/perl/heap/BUILD
@@ -1,0 +1,2 @@
+cpanm --installdeps --quiet .
+prove -l -v t/

--- a/code/packages/perl/heap/BUILD_windows
+++ b/code/packages/perl/heap/BUILD_windows
@@ -1,2 +1,1 @@
-cpanm --installdeps --quiet .
 prove -l -v t/

--- a/code/packages/perl/heap/BUILD_windows
+++ b/code/packages/perl/heap/BUILD_windows
@@ -1,0 +1,2 @@
+cpanm --installdeps --quiet .
+prove -l -v t/

--- a/code/packages/perl/heap/BUILD_windows
+++ b/code/packages/perl/heap/BUILD_windows
@@ -1,1 +1,1 @@
-prove -l -v t/
+perl -Ilib t/00-load.t && perl -Ilib t/01-heap.t

--- a/code/packages/perl/heap/CHANGELOG.md
+++ b/code/packages/perl/heap/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog — CodingAdventures::Heap (Perl)
+
+All notable changes to this package are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [0.1.0] — 2026-04-12
+
+### Added
+
+- Initial implementation of `CodingAdventures::Heap`.
+- Generic comparator-based `CodingAdventures::Heap::MinHeap` and
+  `CodingAdventures::Heap::MaxHeap` classes.
+- `new`, `from_iterable`, `push`, `pop`, `peek`, `size`, `is_empty`, and
+  `to_array` operations.
+- Test2::V0 coverage for min-heap ordering, max-heap ordering, custom
+  comparators, heapify, and empty-heap behavior.

--- a/code/packages/perl/heap/Makefile.PL
+++ b/code/packages/perl/heap/Makefile.PL
@@ -3,14 +3,13 @@ use warnings;
 use ExtUtils::MakeMaker;
 
 WriteMakefile(
-    NAME             => 'CodingAdventures::HuffmanTree',
-    VERSION_FROM     => 'lib/CodingAdventures/HuffmanTree.pm',
-    ABSTRACT         => 'Huffman Tree optimal prefix-free entropy coding — DT27',
+    NAME             => 'CodingAdventures::Heap',
+    VERSION_FROM     => 'lib/CodingAdventures/Heap.pm',
+    ABSTRACT         => 'Comparator-based binary min-heaps and max-heaps',
     AUTHOR           => 'coding-adventures',
     LICENSE          => 'mit',
     MIN_PERL_VERSION => '5.026000',
     PREREQ_PM        => {
-        'CodingAdventures::Heap' => 0,
     },
     TEST_REQUIRES    => {
         'Test2::V0' => 0,

--- a/code/packages/perl/heap/Makefile.PL
+++ b/code/packages/perl/heap/Makefile.PL
@@ -11,9 +11,6 @@ WriteMakefile(
     MIN_PERL_VERSION => '5.026000',
     PREREQ_PM        => {
     },
-    TEST_REQUIRES    => {
-        'Test2::V0' => 0,
-    },
     META_MERGE       => {
         'meta-spec' => { version => 2 },
         resources   => {

--- a/code/packages/perl/heap/README.md
+++ b/code/packages/perl/heap/README.md
@@ -1,0 +1,46 @@
+# CodingAdventures::Heap (Perl)
+
+Comparator-based binary heap package for Perl.
+
+## Usage
+
+```perl
+use CodingAdventures::Heap;
+
+my $min_heap = CodingAdventures::Heap::MinHeap->new();
+$min_heap->push(5);
+$min_heap->push(1);
+$min_heap->push(3);
+print $min_heap->pop();  # 1
+
+my $max_heap = CodingAdventures::Heap::MaxHeap->new();
+$max_heap->push(5);
+$max_heap->push(1);
+$max_heap->push(3);
+print $max_heap->pop();  # 5
+
+my $tuple_heap = CodingAdventures::Heap::MinHeap->new(sub {
+    my ($left, $right) = @_;
+    return $left->[0] <=> $right->[0] || $left->[1] cmp $right->[1];
+});
+$tuple_heap->push([1, 'b']);
+$tuple_heap->push([1, 'a']);
+print $tuple_heap->pop()->[1];  # a
+```
+
+## API
+
+- `CodingAdventures::Heap::MinHeap->new($compare)`
+- `CodingAdventures::Heap::MaxHeap->new($compare)`
+- `from_iterable(\@items, $compare)`
+- `push($value)`
+- `pop()` returns the root or `undef` when empty
+- `peek()` returns the root or `undef` when empty
+- `size()`, `is_empty()`, and `to_array()`
+
+## Running Tests
+
+```bash
+cpanm --installdeps --quiet .
+prove -l -v t/
+```

--- a/code/packages/perl/heap/cpanfile
+++ b/code/packages/perl/heap/cpanfile
@@ -1,0 +1,3 @@
+on 'test' => sub {
+    requires 'Test2::V0';
+};

--- a/code/packages/perl/heap/cpanfile
+++ b/code/packages/perl/heap/cpanfile
@@ -1,3 +1,1 @@
-on 'test' => sub {
-    requires 'Test2::V0';
-};
+# No non-core dependencies.

--- a/code/packages/perl/heap/lib/CodingAdventures/Heap.pm
+++ b/code/packages/perl/heap/lib/CodingAdventures/Heap.pm
@@ -1,0 +1,152 @@
+package CodingAdventures::Heap;
+
+use strict;
+use warnings;
+
+our $VERSION = '0.1.0';
+
+sub default_compare {
+    my ($left, $right) = @_;
+    return 0 if $left == $right;
+    return $left < $right ? -1 : 1;
+}
+
+1;
+
+package CodingAdventures::Heap::Heap;
+
+use strict;
+use warnings;
+
+sub new {
+    my ($class, $compare) = @_;
+    $compare ||= \&CodingAdventures::Heap::default_compare;
+    return bless {
+        compare => $compare,
+        items   => [],
+    }, $class;
+}
+
+sub from_iterable {
+    my ($class, $items, $compare) = @_;
+    my $heap = $class->new($compare);
+    $heap->push($_) for @{ $items || [] };
+    return $heap;
+}
+
+sub size {
+    my ($self) = @_;
+    return scalar @{ $self->{items} };
+}
+
+sub is_empty {
+    my ($self) = @_;
+    return $self->size() == 0;
+}
+
+sub peek {
+    my ($self) = @_;
+    return $self->{items}[0];
+}
+
+sub to_array {
+    my ($self) = @_;
+    return [@{ $self->{items} }];
+}
+
+sub push {
+    my ($self, $value) = @_;
+    push @{ $self->{items} }, $value;
+    $self->_sift_up($#{ $self->{items} });
+    return $self;
+}
+
+sub pop {
+    my ($self) = @_;
+    return undef if $self->is_empty();
+
+    my $items = $self->{items};
+    my $top = $items->[0];
+
+    if (@$items == 1) {
+        pop @$items;
+        return $top;
+    }
+
+    $items->[0] = pop @$items;
+    $self->_sift_down(0);
+    return $top;
+}
+
+sub _higher_priority {
+    die "_higher_priority must be implemented by subclasses\n";
+}
+
+sub _sift_up {
+    my ($self, $index) = @_;
+    my $items = $self->{items};
+
+    while ($index > 0) {
+        my $parent = int(($index - 1) / 2);
+        if ($self->_higher_priority($items->[$index], $items->[$parent])) {
+            @{$items}[$index, $parent] = @{$items}[$parent, $index];
+            $index = $parent;
+        } else {
+            last;
+        }
+    }
+}
+
+sub _sift_down {
+    my ($self, $index) = @_;
+    my $items = $self->{items};
+    my $size = scalar @$items;
+
+    while (1) {
+        my $left = 2 * $index + 1;
+        my $right = $left + 1;
+        my $best = $index;
+
+        if ($left < $size && $self->_higher_priority($items->[$left], $items->[$best])) {
+            $best = $left;
+        }
+        if ($right < $size && $self->_higher_priority($items->[$right], $items->[$best])) {
+            $best = $right;
+        }
+
+        last if $best == $index;
+
+        @{$items}[$index, $best] = @{$items}[$best, $index];
+        $index = $best;
+    }
+}
+
+1;
+
+package CodingAdventures::Heap::MinHeap;
+
+use strict;
+use warnings;
+
+our @ISA = ('CodingAdventures::Heap::Heap');
+
+sub _higher_priority {
+    my ($self, $left, $right) = @_;
+    return $self->{compare}->($left, $right) < 0;
+}
+
+1;
+
+package CodingAdventures::Heap::MaxHeap;
+
+use strict;
+use warnings;
+
+our @ISA = ('CodingAdventures::Heap::Heap');
+
+sub _higher_priority {
+    my ($self, $left, $right) = @_;
+    return $self->{compare}->($left, $right) > 0;
+}
+
+1;

--- a/code/packages/perl/heap/t/00-load.t
+++ b/code/packages/perl/heap/t/00-load.t
@@ -1,0 +1,10 @@
+use strict;
+use warnings;
+use Test2::V0;
+
+ok lives {
+    require CodingAdventures::Heap;
+    1;
+}, 'CodingAdventures::Heap loads';
+
+done_testing;

--- a/code/packages/perl/heap/t/00-load.t
+++ b/code/packages/perl/heap/t/00-load.t
@@ -1,6 +1,11 @@
 use strict;
 use warnings;
-use Test2::V0;
+use Test::More;
+
+sub lives (&) {
+    my ($code) = @_;
+    return eval { $code->(); 1 } ? 1 : 0;
+}
 
 ok lives {
     require CodingAdventures::Heap;

--- a/code/packages/perl/heap/t/01-heap.t
+++ b/code/packages/perl/heap/t/01-heap.t
@@ -1,0 +1,54 @@
+use strict;
+use warnings;
+use Test2::V0;
+use CodingAdventures::Heap;
+
+subtest 'min heap orders ascending' => sub {
+    my $heap = CodingAdventures::Heap::MinHeap->new();
+    $heap->push($_) for (5, 3, 8, 1, 4);
+
+    is $heap->peek(), 1, 'peek returns smallest value';
+    is [map { $heap->pop() } 1..5], [1, 3, 4, 5, 8], 'pop returns ascending order';
+    is $heap->pop(), undef, 'empty heap returns undef';
+};
+
+subtest 'max heap orders descending' => sub {
+    my $heap = CodingAdventures::Heap::MaxHeap->new();
+    $heap->push($_) for (5, 3, 8, 1, 4);
+
+    is $heap->peek(), 8, 'peek returns largest value';
+    is [map { $heap->pop() } 1..5], [8, 5, 4, 3, 1], 'pop returns descending order';
+};
+
+subtest 'from_iterable heapifies input' => sub {
+    my $heap = CodingAdventures::Heap::MinHeap->from_iterable([9, 2, 7, 1, 5]);
+    is $heap->size(), 5, 'heap contains all items';
+    is [map { $heap->pop() } 1..5], [1, 2, 5, 7, 9], 'heapified items pop in sorted order';
+};
+
+subtest 'custom comparator supports tuples' => sub {
+    my $heap = CodingAdventures::Heap::MinHeap->new(sub {
+        my ($left, $right) = @_;
+        return $left->[0] <=> $right->[0] || $left->[1] cmp $right->[1];
+    });
+
+    $heap->push([1, 'b']);
+    $heap->push([1, 'a']);
+    $heap->push([0, 'z']);
+
+    is $heap->pop(), [0, 'z'], 'lowest priority tuple pops first';
+    is $heap->pop(), [1, 'a'], 'tie breaks by secondary comparator';
+    is $heap->pop(), [1, 'b'], 'remaining tuple pops last';
+};
+
+subtest 'empty helpers report state' => sub {
+    my $heap = CodingAdventures::Heap::MinHeap->new();
+    is $heap->size(), 0, 'empty heap size is zero';
+    ok $heap->is_empty(), 'empty heap reports true';
+    is $heap->peek(), undef, 'peek on empty heap returns undef';
+    $heap->push(42);
+    ok !$heap->is_empty(), 'heap is no longer empty after push';
+    is $heap->to_array(), [42], 'to_array returns shallow copy';
+};
+
+done_testing;

--- a/code/packages/perl/heap/t/01-heap.t
+++ b/code/packages/perl/heap/t/01-heap.t
@@ -1,7 +1,16 @@
 use strict;
 use warnings;
-use Test2::V0;
+use Test::More;
 use CodingAdventures::Heap;
+no warnings 'redefine';
+
+sub is ($$;$) {
+    my ($got, $expected, $name) = @_;
+    if (ref($got) || ref($expected)) {
+        return Test::More::is_deeply($got, $expected, $name);
+    }
+    return Test::More::is($got, $expected, $name);
+}
 
 subtest 'min heap orders ascending' => sub {
     my $heap = CodingAdventures::Heap::MinHeap->new();

--- a/code/packages/perl/huffman-tree/BUILD
+++ b/code/packages/perl/huffman-tree/BUILD
@@ -1,2 +1,2 @@
-cpanm --installdeps --quiet .
-prove -l -v t/
+cpanm --notest --quiet Test2::V0
+PERL5LIB=$(cd ../heap && pwd)/lib:${PERL5LIB:-} prove -l -v t/

--- a/code/packages/perl/huffman-tree/BUILD
+++ b/code/packages/perl/huffman-tree/BUILD
@@ -1,2 +1,1 @@
-cpanm --notest --quiet Test2::V0
 PERL5LIB=$(cd ../heap && pwd)/lib:${PERL5LIB:-} prove -l -v t/

--- a/code/packages/perl/huffman-tree/BUILD_windows
+++ b/code/packages/perl/huffman-tree/BUILD_windows
@@ -1,2 +1,2 @@
 cpanm --notest --quiet Test2::V0
-set PERL5LIB=..\heap\lib;%PERL5LIB% && prove -l -v t/
+cd ..\heap && cd ..\huffman-tree && set PERL5LIB=..\heap\lib;%PERL5LIB% && prove -l -v t/

--- a/code/packages/perl/huffman-tree/BUILD_windows
+++ b/code/packages/perl/huffman-tree/BUILD_windows
@@ -1,1 +1,1 @@
-cd ..\heap && cd ..\huffman-tree && set PERL5LIB=..\heap\lib;%PERL5LIB% && prove -l -v t/
+cd ..\heap && cd ..\huffman-tree && set PERL5LIB=..\heap\lib;%PERL5LIB% && perl -Ilib -I..\heap\lib t/00-load.t && perl -Ilib -I..\heap\lib t/01-huffman-tree.t

--- a/code/packages/perl/huffman-tree/BUILD_windows
+++ b/code/packages/perl/huffman-tree/BUILD_windows
@@ -1,2 +1,2 @@
-cpanm --installdeps --quiet .
-prove -l -v t/
+cpanm --notest --quiet Test2::V0
+set PERL5LIB=..\heap\lib;%PERL5LIB% && prove -l -v t/

--- a/code/packages/perl/huffman-tree/BUILD_windows
+++ b/code/packages/perl/huffman-tree/BUILD_windows
@@ -1,2 +1,1 @@
-cpanm --notest --quiet Test2::V0
 cd ..\heap && cd ..\huffman-tree && set PERL5LIB=..\heap\lib;%PERL5LIB% && prove -l -v t/

--- a/code/packages/perl/huffman-tree/CHANGELOG.md
+++ b/code/packages/perl/huffman-tree/CHANGELOG.md
@@ -8,9 +8,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Initial implementation of `CodingAdventures::HuffmanTree` (DT27).
-- Embedded min-heap (array-based binary min-heap, indices 0-based) with
-  4-tuple priority comparator using Perl's floating-point infinity (`9**9**9`)
-  as the sentinel for unused tie-breaking fields.
+- Depends on `CodingAdventures::Heap` for the comparator-based min-heap used
+  during deterministic greedy construction.
 - `build(\@weights)` — greedy construction from `[[$symbol, $freq], ...]` pairs
   with four-level tie-breaking rules matching the Python reference implementation.
 - `code_table()` — returns `{symbol => bitstring}` hashref for all symbols.

--- a/code/packages/perl/huffman-tree/Makefile.PL
+++ b/code/packages/perl/huffman-tree/Makefile.PL
@@ -12,9 +12,6 @@ WriteMakefile(
     PREREQ_PM        => {
         'CodingAdventures::Heap' => 0,
     },
-    TEST_REQUIRES    => {
-        'Test2::V0' => 0,
-    },
     META_MERGE       => {
         'meta-spec' => { version => 2 },
         resources   => {

--- a/code/packages/perl/huffman-tree/README.md
+++ b/code/packages/perl/huffman-tree/README.md
@@ -20,6 +20,9 @@ frequency distribution.
 cpanm CodingAdventures::HuffmanTree
 ```
 
+Tree construction uses the separate `CodingAdventures::Heap` package for the
+shared min-heap implementation.
+
 ## Usage
 
 ```perl

--- a/code/packages/perl/huffman-tree/cpanfile
+++ b/code/packages/perl/huffman-tree/cpanfile
@@ -1,3 +1,5 @@
+requires 'coding-adventures-heap', '0.01';
+
 # Test dependencies
 on 'test' => sub {
     requires 'Test2::V0';

--- a/code/packages/perl/huffman-tree/cpanfile
+++ b/code/packages/perl/huffman-tree/cpanfile
@@ -1,6 +1,1 @@
 requires 'coding-adventures-heap', '0.01';
-
-# Test dependencies
-on 'test' => sub {
-    requires 'Test2::V0';
-};

--- a/code/packages/perl/huffman-tree/lib/CodingAdventures/HuffmanTree.pm
+++ b/code/packages/perl/huffman-tree/lib/CodingAdventures/HuffmanTree.pm
@@ -2,6 +2,7 @@ package CodingAdventures::HuffmanTree;
 
 use strict;
 use warnings;
+use CodingAdventures::Heap;
 
 our $VERSION = '0.1.0';
 
@@ -106,125 +107,31 @@ when moving to a longer length.
 
 =back
 
-=head2 Embedded Min-Heap
+=head2 Heap Dependency
 
-Perl does not have a built-in priority queue. This module embeds a simple
-array-based binary min-heap with a custom 4-tuple comparator. Each heap item
-stores a priority tuple C<[$weight, $leaf_flag, $sym_or_inf, $order_or_inf]>
-alongside the node data.
-
-A binary heap uses index arithmetic:
-  Root at index 0.
-  Parent of index i is at int((i-1)/2).
-  Left child of i at 2*i+1, right child at 2*i+2.
-
-Push: append, sift up.  Pop: swap root with last, shrink, sift down.
-Both O(log n).
+This module depends on L<CodingAdventures::Heap> for the shared min-heap used
+during greedy construction. Heap items are stored as C<[$priority, $node]>
+pairs, and the comparator compares the four-element priority tuples
+lexicographically.
 
 =cut
-
-# ---------------------------------------------------------------------------
-# Embedded Min-Heap
-# ---------------------------------------------------------------------------
-
-# _heap_new returns a new empty heap (arrayref of [$priority, $node] pairs).
-sub _heap_new {
-    return { items => [], size => 0 };
-}
-
-# _heap_cmp compares two 4-element priority tuples lexicographically.
-#
-# A priority tuple is: [$weight, $leaf_flag, $sym_or_inf, $order_or_inf]
-#
-# Returns true (1) if tuple $a has higher priority than $b (a < b in min terms).
-# Uses Inf (9**9**9) as the "infinity" sentinel for unused fields, which Perl
-# compares as a very large floating-point number.
-sub _heap_cmp {
-    my ($a, $b) = @_;
-    for my $i (0..3) {
-        return 1 if $a->[$i] < $b->[$i];
-        return 0 if $a->[$i] > $b->[$i];
-    }
-    return 0;  # equal
-}
-
-# _heap_sift_up restores the heap property after inserting at the given index.
-sub _heap_sift_up {
-    my ($h, $i) = @_;
-    my $items = $h->{items};
-    while ($i > 0) {
-        my $parent = int(($i - 1) / 2);
-        if (_heap_cmp($items->[$i][0], $items->[$parent][0])) {
-            @{$items}[$i, $parent] = @{$items}[$parent, $i];
-            $i = $parent;
-        } else {
-            last;
-        }
-    }
-}
-
-# _heap_sift_down restores the heap property after removing the root.
-sub _heap_sift_down {
-    my ($h, $i) = @_;
-    my $items = $h->{items};
-    my $size  = $h->{size};
-    while (1) {
-        my $left     = 2 * $i + 1;
-        my $right    = 2 * $i + 2;
-        my $smallest = $i;
-
-        if ($left < $size && _heap_cmp($items->[$left][0], $items->[$smallest][0])) {
-            $smallest = $left;
-        }
-        if ($right < $size && _heap_cmp($items->[$right][0], $items->[$smallest][0])) {
-            $smallest = $right;
-        }
-
-        last if $smallest == $i;
-
-        @{$items}[$i, $smallest] = @{$items}[$smallest, $i];
-        $i = $smallest;
-    }
-}
-
-# _heap_push adds an item to the heap.
-#
-# @param $h         (hashref) heap state.
-# @param $priority  (arrayref) 4-element priority tuple.
-# @param $node      (hashref)  node data.
-sub _heap_push {
-    my ($h, $priority, $node) = @_;
-    $h->{items}[$h->{size}] = [$priority, $node];
-    $h->{size}++;
-    _heap_sift_up($h, $h->{size} - 1);
-}
-
-# _heap_pop removes and returns the highest-priority item.
-#
-# @param $h  (hashref) heap state.
-# @return ($priority, $node) or undef if empty.
-sub _heap_pop {
-    my ($h) = @_;
-    return undef if $h->{size} == 0;
-    my $top = $h->{items}[0];
-    $h->{size}--;
-    if ($h->{size} > 0) {
-        $h->{items}[0] = $h->{items}[$h->{size}];
-        $h->{items}[$h->{size}] = undef;
-        _heap_sift_down($h, 0);
-    } else {
-        $h->{items}[0] = undef;
-    }
-    return ($top->[0], $top->[1]);
-}
-
-# ---------------------------------------------------------------------------
-# Node Constructors
-# ---------------------------------------------------------------------------
 
 # _INF is the infinity sentinel used for unused priority tuple fields.
 # In Perl, 9**9**9 evaluates to the floating-point infinity.
 use constant _INF => 9**9**9;
+
+sub _entry_compare {
+    my ($left, $right) = @_;
+    my $a = $left->[0];
+    my $b = $right->[0];
+
+    for my $i (0..3) {
+        return -1 if $a->[$i] < $b->[$i];
+        return 1 if $a->[$i] > $b->[$i];
+    }
+
+    return 0;
+}
 
 # _new_leaf creates a leaf node.
 #
@@ -312,26 +219,28 @@ sub build {
             if $pair->[1] <= 0;
     }
 
-    my $heap = _heap_new();
+    my $heap = CodingAdventures::Heap::MinHeap->new(\&_entry_compare);
 
     # Seed the heap with one leaf per symbol.
     for my $pair (@$weights) {
         my $leaf = _new_leaf($pair->[0], $pair->[1]);
-        _heap_push($heap, _node_priority($leaf), $leaf);
+        $heap->push([_node_priority($leaf), $leaf]);
     }
 
     my $order_counter = 0;
 
     # Merge phase: pop two smallest, create internal, push back.
-    while ($heap->{size} > 1) {
-        my (undef, $left)  = _heap_pop($heap);
-        my (undef, $right) = _heap_pop($heap);
+    while ($heap->size() > 1) {
+        my $left_entry  = $heap->pop();
+        my $right_entry = $heap->pop();
+        my $left = $left_entry->[1];
+        my $right = $right_entry->[1];
         my $internal = _new_internal($left, $right, $order_counter);
         $order_counter++;
-        _heap_push($heap, _node_priority($internal), $internal);
+        $heap->push([_node_priority($internal), $internal]);
     }
 
-    my (undef, $root) = _heap_pop($heap);
+    my $root = $heap->pop()->[1];
 
     return bless {
         _root         => $root,

--- a/code/packages/perl/huffman-tree/t/00-load.t
+++ b/code/packages/perl/huffman-tree/t/00-load.t
@@ -1,6 +1,15 @@
 use strict;
 use warnings;
-use Test2::V0;
+use Test::More;
+no warnings 'redefine';
+
+sub is ($$;$) {
+    my ($got, $expected, $name) = @_;
+    if (ref($got) || ref($expected)) {
+        return Test::More::is_deeply($got, $expected, $name);
+    }
+    return Test::More::is($got, $expected, $name);
+}
 
 ok( eval { require CodingAdventures::HuffmanTree; 1 }, 'CodingAdventures::HuffmanTree loads' );
 

--- a/code/packages/perl/huffman-tree/t/01-huffman-tree.t
+++ b/code/packages/perl/huffman-tree/t/01-huffman-tree.t
@@ -1,7 +1,26 @@
 use strict;
 use warnings;
-use Test2::V0;
+use Test::More;
 use CodingAdventures::HuffmanTree;
+no warnings 'redefine';
+
+sub is ($$;$) {
+    my ($got, $expected, $name) = @_;
+    if (ref($got) || ref($expected)) {
+        return Test::More::is_deeply($got, $expected, $name);
+    }
+    return Test::More::is($got, $expected, $name);
+}
+
+sub dies (&) {
+    my ($code) = @_;
+    return !eval { $code->(); 1 };
+}
+
+sub lives (&) {
+    my ($code) = @_;
+    return eval { $code->(); 1 } ? 1 : 0;
+}
 
 # ── Build validation ──────────────────────────────────────────────────────────
 

--- a/code/packages/swift/heap/BUILD
+++ b/code/packages/swift/heap/BUILD
@@ -1,0 +1,1 @@
+if command -v xcrun >/dev/null 2>&1; then xcrun swift test; else swift test; fi

--- a/code/packages/swift/heap/BUILD_windows
+++ b/code/packages/swift/heap/BUILD_windows
@@ -1,0 +1,1 @@
+where swift >/dev/null 2>/dev/null && swift test || echo Swift not available on this runner — skipping

--- a/code/packages/swift/heap/CHANGELOG.md
+++ b/code/packages/swift/heap/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog — Heap (Swift)
+
+All notable changes to this package are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [0.1.0] — 2026-04-12
+
+### Added
+
+- Initial implementation of `Heap`.
+- Generic `MinHeap<Element>` and `MaxHeap<Element>` binary heaps.
+- Default `Comparable` initializers plus custom comparator initializers.
+- Sequence-based heapify initializers.
+- XCTest coverage for min-heap ordering, max-heap ordering, heapify, and
+  custom comparator support.

--- a/code/packages/swift/heap/Package.swift
+++ b/code/packages/swift/heap/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "Heap",
+    products: [
+        .library(name: "Heap", targets: ["Heap"]),
+    ],
+    targets: [
+        .target(
+            name: "Heap",
+            path: "Sources/Heap"
+        ),
+        .testTarget(
+            name: "HeapTests",
+            dependencies: ["Heap"],
+            path: "Tests/HeapTests"
+        ),
+    ]
+)

--- a/code/packages/swift/heap/README.md
+++ b/code/packages/swift/heap/README.md
@@ -1,0 +1,44 @@
+# Heap (Swift)
+
+Comparator-based binary min-heap and max-heap package for Swift.
+
+## Usage
+
+```swift
+import Heap
+
+var minHeap = MinHeap<Int>()
+minHeap.push(5)
+minHeap.push(1)
+minHeap.push(3)
+print(minHeap.pop()!) // 1
+
+var maxHeap = MaxHeap<Int>()
+maxHeap.push(5)
+maxHeap.push(1)
+maxHeap.push(3)
+print(maxHeap.pop()!) // 5
+
+var tupleHeap = MinHeap<(priority: Int, label: String)> {
+    if $0.priority != $1.priority {
+        return $0.priority < $1.priority
+    }
+    return $0.label < $1.label
+}
+tupleHeap.push((priority: 1, label: "b"))
+tupleHeap.push((priority: 1, label: "a"))
+print(tupleHeap.pop()!.label) // a
+```
+
+## API
+
+- `MinHeap<Element>()` and `MaxHeap<Element>()` for `Element: Comparable`
+- `MinHeap<Element> { ... }` and `MaxHeap<Element> { ... }` for custom ordering
+- `init(_ elements: Sequence)` and `init(_ elements: Sequence, _ comparator)`
+- `push`, `pop`, `peek`, `count`, `isEmpty`, and `toArray`
+
+## Running Tests
+
+```bash
+swift test
+```

--- a/code/packages/swift/heap/Sources/Heap/Heap.swift
+++ b/code/packages/swift/heap/Sources/Heap/Heap.swift
@@ -1,0 +1,192 @@
+private struct BinaryHeap<Element> {
+    private var storage: [Element] = []
+    private let higherPriority: (Element, Element) -> Bool
+
+    init(_ higherPriority: @escaping (Element, Element) -> Bool) {
+        self.higherPriority = higherPriority
+    }
+
+    init<S: Sequence>(_ elements: S, _ higherPriority: @escaping (Element, Element) -> Bool)
+    where S.Element == Element {
+        self.init(higherPriority)
+        self.storage = Array(elements)
+        self.buildHeap()
+    }
+
+    var count: Int {
+        storage.count
+    }
+
+    var isEmpty: Bool {
+        storage.isEmpty
+    }
+
+    func peek() -> Element? {
+        storage.first
+    }
+
+    func toArray() -> [Element] {
+        storage
+    }
+
+    mutating func push(_ element: Element) {
+        storage.append(element)
+        siftUp(from: storage.count - 1)
+    }
+
+    mutating func pop() -> Element? {
+        guard !storage.isEmpty else {
+            return nil
+        }
+
+        if storage.count == 1 {
+            return storage.removeLast()
+        }
+
+        let top = storage[0]
+        storage[0] = storage.removeLast()
+        siftDown(from: 0)
+        return top
+    }
+
+    private mutating func buildHeap() {
+        guard storage.count > 1 else {
+            return
+        }
+
+        for index in stride(from: (storage.count - 2) / 2, through: 0, by: -1) {
+            siftDown(from: index)
+        }
+    }
+
+    private mutating func siftUp(from index: Int) {
+        var current = index
+        while current > 0 {
+            let parent = (current - 1) / 2
+            if higherPriority(storage[current], storage[parent]) {
+                storage.swapAt(current, parent)
+                current = parent
+            } else {
+                break
+            }
+        }
+    }
+
+    private mutating func siftDown(from index: Int) {
+        var current = index
+
+        while true {
+            let left = current * 2 + 1
+            let right = left + 1
+            var best = current
+
+            if left < storage.count && higherPriority(storage[left], storage[best]) {
+                best = left
+            }
+            if right < storage.count && higherPriority(storage[right], storage[best]) {
+                best = right
+            }
+
+            if best == current {
+                break
+            }
+
+            storage.swapAt(current, best)
+            current = best
+        }
+    }
+}
+
+public struct MinHeap<Element> {
+    private var heap: BinaryHeap<Element>
+
+    public init(_ areInIncreasingOrder: @escaping (Element, Element) -> Bool) {
+        self.heap = BinaryHeap(areInIncreasingOrder)
+    }
+
+    public init<S: Sequence>(_ elements: S, _ areInIncreasingOrder: @escaping (Element, Element) -> Bool)
+    where S.Element == Element {
+        self.heap = BinaryHeap(elements, areInIncreasingOrder)
+    }
+
+    public init() where Element: Comparable {
+        self.init(<)
+    }
+
+    public init<S: Sequence>(_ elements: S) where S.Element == Element, Element: Comparable {
+        self.init(elements, <)
+    }
+
+    public var count: Int {
+        heap.count
+    }
+
+    public var isEmpty: Bool {
+        heap.isEmpty
+    }
+
+    public func peek() -> Element? {
+        heap.peek()
+    }
+
+    public func toArray() -> [Element] {
+        heap.toArray()
+    }
+
+    public mutating func push(_ element: Element) {
+        heap.push(element)
+    }
+
+    public mutating func pop() -> Element? {
+        heap.pop()
+    }
+}
+
+public struct MaxHeap<Element> {
+    private var heap: BinaryHeap<Element>
+
+    public init(_ areInIncreasingOrder: @escaping (Element, Element) -> Bool) {
+        self.heap = BinaryHeap { left, right in
+            areInIncreasingOrder(right, left)
+        }
+    }
+
+    public init<S: Sequence>(_ elements: S, _ areInIncreasingOrder: @escaping (Element, Element) -> Bool)
+    where S.Element == Element {
+        self.heap = BinaryHeap(elements) { left, right in
+            areInIncreasingOrder(right, left)
+        }
+    }
+
+    public init() where Element: Comparable {
+        self.init(<)
+    }
+
+    public init<S: Sequence>(_ elements: S) where S.Element == Element, Element: Comparable {
+        self.init(elements, <)
+    }
+
+    public var count: Int {
+        heap.count
+    }
+
+    public var isEmpty: Bool {
+        heap.isEmpty
+    }
+
+    public func peek() -> Element? {
+        heap.peek()
+    }
+
+    public func toArray() -> [Element] {
+        heap.toArray()
+    }
+
+    public mutating func push(_ element: Element) {
+        heap.push(element)
+    }
+
+    public mutating func pop() -> Element? {
+        heap.pop()
+    }
+}

--- a/code/packages/swift/heap/Tests/HeapTests/HeapTests.swift
+++ b/code/packages/swift/heap/Tests/HeapTests/HeapTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import Heap
+
+final class HeapTests: XCTestCase {
+    func testMinHeapOrdersAscending() {
+        var heap = MinHeap<Int>()
+        [5, 3, 8, 1, 4].forEach { heap.push($0) }
+
+        XCTAssertEqual(heap.peek(), 1)
+        XCTAssertEqual(heap.pop(), 1)
+        XCTAssertEqual(heap.pop(), 3)
+        XCTAssertEqual(heap.pop(), 4)
+        XCTAssertEqual(heap.pop(), 5)
+        XCTAssertEqual(heap.pop(), 8)
+        XCTAssertNil(heap.pop())
+    }
+
+    func testMaxHeapOrdersDescending() {
+        var heap = MaxHeap<Int>()
+        [5, 3, 8, 1, 4].forEach { heap.push($0) }
+
+        XCTAssertEqual(heap.peek(), 8)
+        XCTAssertEqual(heap.pop(), 8)
+        XCTAssertEqual(heap.pop(), 5)
+        XCTAssertEqual(heap.pop(), 4)
+        XCTAssertEqual(heap.pop(), 3)
+        XCTAssertEqual(heap.pop(), 1)
+        XCTAssertNil(heap.pop())
+    }
+
+    func testSequenceInitializerHeapifies() {
+        var heap = MinHeap([9, 2, 7, 1, 5])
+        XCTAssertEqual(heap.count, 5)
+        XCTAssertEqual(heap.peek(), 1)
+        XCTAssertEqual(heap.toArray().count, 5)
+        XCTAssertEqual(heap.pop(), 1)
+        XCTAssertEqual(heap.pop(), 2)
+        XCTAssertEqual(heap.pop(), 5)
+        XCTAssertEqual(heap.pop(), 7)
+        XCTAssertEqual(heap.pop(), 9)
+    }
+
+    func testCustomComparatorSupportsTuples() {
+        typealias Pair = (priority: Int, label: String)
+        var heap = MinHeap<Pair> {
+            if $0.priority != $1.priority {
+                return $0.priority < $1.priority
+            }
+            return $0.label < $1.label
+        }
+
+        heap.push((priority: 1, label: "b"))
+        heap.push((priority: 1, label: "a"))
+        heap.push((priority: 0, label: "z"))
+
+        XCTAssertEqual(heap.pop()?.priority, 0)
+        XCTAssertEqual(heap.pop()?.label, "a")
+        XCTAssertEqual(heap.pop()?.label, "b")
+    }
+}

--- a/code/packages/swift/huffman-tree/CHANGELOG.md
+++ b/code/packages/swift/huffman-tree/CHANGELOG.md
@@ -8,8 +8,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Initial implementation of `HuffmanTree` (DT27).
-- Private `MinHeap<T>` struct (generic, array-based binary min-heap) with
-  custom comparator closure — embedded within the module, no external dependency.
+- Depends on the standalone `Heap` package for the generic min-heap used during
+  deterministic greedy construction.
 - Private `PriorityKey: Comparable` struct encoding the four-level tie-breaking
   rule: `{weight, leafFlag, symbolOrMax, orderOrMax}`.
 - Private `Node` indirect enum with `.leaf(symbol:weight:)` and

--- a/code/packages/swift/huffman-tree/Package.swift
+++ b/code/packages/swift/huffman-tree/Package.swift
@@ -14,9 +14,15 @@ let package = Package(
     products: [
         .library(name: "HuffmanTree", targets: ["HuffmanTree"]),
     ],
+    dependencies: [
+        .package(path: "../heap"),
+    ],
     targets: [
         .target(
             name: "HuffmanTree",
+            dependencies: [
+                .product(name: "Heap", package: "heap"),
+            ],
             path: "Sources/HuffmanTree"
         ),
         .testTarget(

--- a/code/packages/swift/huffman-tree/README.md
+++ b/code/packages/swift/huffman-tree/README.md
@@ -22,6 +22,9 @@ Add to your `Package.swift`:
 .package(url: "https://github.com/adhithyan15/coding-adventures.git", from: "0.1.0")
 ```
 
+This package depends on the standalone `Heap` package for the shared min-heap
+implementation used during tree construction.
+
 ## Usage
 
 ```swift

--- a/code/packages/swift/huffman-tree/Sources/HuffmanTree/HuffmanTree.swift
+++ b/code/packages/swift/huffman-tree/Sources/HuffmanTree/HuffmanTree.swift
@@ -12,6 +12,7 @@
 // "--.." (four symbols). The designers knew "E" is the most common letter in
 // English so they gave it the shortest code. Huffman's algorithm does this
 // automatically and optimally for any alphabet with any frequency distribution.
+import Heap
 //
 // ============================================================
 // Algorithm: Greedy construction via min-heap
@@ -64,131 +65,13 @@
 // length table, not the tree, saving space.
 //
 // ============================================================
-// Embedded Min-Heap
+// Heap Package
 // ============================================================
 //
-// Swift does not have a built-in min-priority queue. This module embeds a
-// private `MinHeap<T>` struct with a custom comparator closure.
-//
-// A binary heap uses index arithmetic on an array:
-//   Root at index 0.
-//   Parent of index i: (i - 1) / 2
-//   Left child of i:   2*i + 1
-//   Right child of i:  2*i + 2
-//
-// Push: append to the end, then sift up (swap with parent while smaller).
-// Pop:  replace root with last element, shrink, sift down (swap with smaller
-//       child while larger than either child).
-//
-// Both operations are O(log n).
+// This package depends on the standalone Heap package for the generic min-heap
+// used during greedy construction. Heap items are stored as `(PriorityKey, Node)`
+// pairs so the Huffman-specific tie-breaking remains local to this module.
 // ============================================================================
-
-// MARK: - Embedded Min-Heap
-
-/// A generic min-heap with a custom comparator.
-///
-/// Elements are stored in an array using the standard binary heap layout.
-/// The comparator defines the ordering: `isHigherPriority(a, b)` should
-/// return `true` when `a` should be popped before `b`.
-///
-/// Example usage:
-/// ```swift
-/// var heap = MinHeap<Int> { $0 < $1 }
-/// heap.push(5)
-/// heap.push(2)
-/// heap.pop()  // returns 2
-/// ```
-private struct MinHeap<T> {
-    /// The raw storage array. Index 0 is the heap root.
-    private var storage: [T] = []
-
-    /// The comparator: returns `true` if `a` has higher priority than `b`.
-    private let isHigherPriority: (T, T) -> Bool
-
-    /// Creates an empty heap with the given priority comparator.
-    init(isHigherPriority: @escaping (T, T) -> Bool) {
-        self.isHigherPriority = isHigherPriority
-    }
-
-    /// The number of elements currently in the heap.
-    var count: Int { storage.count }
-
-    /// Returns true when the heap contains no elements.
-    var isEmpty: Bool { storage.isEmpty }
-
-    // MARK: - Private index helpers
-
-    /// Returns the index of the parent of `i`. Undefined for `i == 0`.
-    private func parentIndex(_ i: Int) -> Int { (i - 1) / 2 }
-
-    /// Returns the index of the left child of `i`.
-    private func leftIndex(_ i: Int) -> Int { 2 * i + 1 }
-
-    /// Returns the index of the right child of `i`.
-    private func rightIndex(_ i: Int) -> Int { 2 * i + 2 }
-
-    // MARK: - Push
-
-    /// Inserts a new element into the heap.
-    ///
-    /// Appends to the end and sifts up to restore the heap property.
-    /// Time: O(log n).
-    mutating func push(_ element: T) {
-        storage.append(element)
-        siftUp(from: storage.count - 1)
-    }
-
-    /// Restores the heap property by moving the element at `index` up
-    /// toward the root as long as it has higher priority than its parent.
-    private mutating func siftUp(from index: Int) {
-        var i = index
-        while i > 0 {
-            let parent = parentIndex(i)
-            if isHigherPriority(storage[i], storage[parent]) {
-                storage.swapAt(i, parent)
-                i = parent
-            } else {
-                break
-            }
-        }
-    }
-
-    // MARK: - Pop
-
-    /// Removes and returns the element with the highest priority.
-    ///
-    /// Moves the last element to the root and sifts down to restore the heap.
-    /// Time: O(log n).
-    ///
-    /// - Returns: The highest-priority element, or `nil` if empty.
-    mutating func pop() -> T? {
-        guard !storage.isEmpty else { return nil }
-        if storage.count == 1 { return storage.removeFirst() }
-        let top = storage[0]
-        storage[0] = storage.removeLast()
-        siftDown(from: 0)
-        return top
-    }
-
-    /// Restores the heap property by moving the element at `index` down
-    /// toward the leaves as long as a child has higher priority.
-    private mutating func siftDown(from index: Int) {
-        var i = index
-        let n = storage.count
-        while true {
-            let left  = leftIndex(i)
-            let right = rightIndex(i)
-            var best  = i
-
-            if left  < n && isHigherPriority(storage[left],  storage[best]) { best = left  }
-            if right < n && isHigherPriority(storage[right], storage[best]) { best = right }
-
-            if best == i { break }
-            storage.swapAt(i, best)
-            i = best
-        }
-    }
-}
 
 // MARK: - Priority Key
 


### PR DESCRIPTION
## Summary
This follow-up extracts the Lua, Perl, and Swift heap implementations out of the `huffman-tree` packages into standalone `heap` packages.

## What changed
- added new `heap` packages for Lua, Perl, and Swift
- moved each language's heap implementation and coverage into those new packages
- updated the Lua, Perl, and Swift `huffman-tree` packages to depend on and use the shared heap packages
- updated package metadata, build files, and READMEs to document the new dependency layout

## Why
PR #675 merged the Huffman tree rollout across all languages, but Lua, Perl, and Swift still had heap implementations embedded inside `huffman-tree`. That left those languages without standalone heap packages even though the data structure is a reusable primitive.

## Impact
Every language now has a heap data structure package available, and the Huffman tree implementations use those packages instead of carrying private embedded heap logic.

## Validation
- `code/packages/lua/heap`: `bash BUILD`
- `code/packages/lua/huffman-tree`: `bash BUILD`
- `code/packages/perl/heap`: `PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin /usr/bin/prove -l -v t/`
- `code/packages/perl/huffman-tree`: `bash BUILD`
- `code/packages/swift/heap`: `swift test`
- `code/packages/swift/huffman-tree`: `swift test`