### PR TITLE
feat(type-checker-protocol): generic TypeChecker protocol

### DIFF
--- a/code/grammars/nib.grammar
+++ b/code/grammars/nib.grammar
@@ -1,0 +1,324 @@
+# Parser grammar for Nib
+# @version 1
+#
+# Nib is a safe, statically-typed toy language that compiles to Intel 4004 machine code.
+# This grammar defines the syntax rules that the parser reads after the lexer has
+# produced a stream of tokens (see nib.tokens).
+#
+# NOTATION (repo standard):
+#   UPPERCASE    token kinds from nib.tokens (custom operators, literals)
+#   "keyword"    quoted keyword literals (match token.value for keyword tokens)
+#   lowercase    grammar rules (non-terminals, defined below)
+#   |            alternation (or)
+#   { x }        zero or more repetitions of x
+#   [ x ]        optional (zero or one occurrence of x)
+#   ( x )        grouping
+#   ;            rule terminator
+#
+# TOKEN MATCHING RULES:
+#   - UPPERCASE names match by token type (WRAP_ADD, SAT_ADD, RANGE, ARROW, …)
+#   - Quoted literals ("fn", "let", "if", …) match keyword token values
+#   - NAME matches identifier tokens
+#   - INT_LIT and HEX_LIT match their respective literal tokens
+#
+# ENTRY POINT: program
+#
+# KEY DESIGN DECISIONS (documented inline throughout the grammar):
+#   - For-loop range uses RANGE token (not .. operator) — see for_stmt note
+#   - Expression precedence: logical < equality < relational < additive < bitwise < unary
+#   - STAR and SLASH are in the token set (reserved) but not in arithmetic rules (v2)
+#   - Wrap/sat operations are at the same precedence as PLUS/MINUS — they are add variants
+#   - call_expr appears before NAME in primary to avoid NAME consuming the function name
+
+# ---------------------------------------------------------------------------
+# Top-level structure
+# ---------------------------------------------------------------------------
+
+# A Nib program is a sequence of top-level declarations.
+# There is no "main" block or module wrapper — the entry point is a function
+# named "main" that the compiler looks for by convention.
+# Having only top-level declarations (no top-level statements) keeps the
+# compilation model simple: declarations are collected first, then compiled.
+program       = { top_decl } ;
+
+# Top-level declarations: compile-time constants, static (RAM-mapped) variables,
+# and function definitions. These are the only three things that can appear at
+# the top level of a Nib source file.
+top_decl      = const_decl
+              | static_decl
+              | fn_decl
+              ;
+
+# ---------------------------------------------------------------------------
+# Constants and statics
+# ---------------------------------------------------------------------------
+
+# Compile-time constant. Value must be a constant expression (folded at compile time).
+# No RAM is allocated; the constant is inlined wherever it is used.
+# Example: const MAX_DIGITS: u4 = 9;
+# The colon-type annotation is mandatory — Nib has no type inference for declarations.
+const_decl    = "const" NAME COLON type EQ expr SEMICOLON ;
+
+# Static variable. Allocated in the 4004's RAM at a fixed address.
+# Total static RAM across all static declarations must be ≤ 160 bytes.
+# The initial value is written to RAM at program startup before main() is called.
+# Example: static digit_count: u8 = 0;
+static_decl   = "static" NAME COLON type EQ expr SEMICOLON ;
+
+# ---------------------------------------------------------------------------
+# Function declarations
+# ---------------------------------------------------------------------------
+
+# Function declaration. Return type is optional — omitting it declares a void function.
+# Examples:
+#   fn main() { ... }                    void function, no parameters
+#   fn add(a: u4, b: u4) -> u4 { ... }  returns u4, two parameters
+# The ARROW token (->) precedes the return type annotation.
+fn_decl       = "fn" NAME LPAREN [ param_list ] RPAREN [ ARROW type ] block ;
+
+# A non-empty parameter list: one or more params separated by commas.
+param_list    = param { COMMA param } ;
+
+# A single parameter: name followed by colon and type.
+# Example: a: u4
+# Nib has no default arguments, no variadic parameters, no &mut references.
+# All parameters are passed by value — this simplifies the calling convention
+# for the 4004's tiny 3-level call stack.
+param         = NAME COLON type ;
+
+# ---------------------------------------------------------------------------
+# Block and statements
+# ---------------------------------------------------------------------------
+
+# A block is a brace-enclosed sequence of statements.
+# Blocks create lexical scope for let declarations.
+# All function bodies, if-branches, else-branches, and for-loop bodies are blocks.
+# Requiring braces (rather than single-statement bodies) eliminates the
+# dangling-else ambiguity at the grammar level.
+block         = LBRACE { stmt } RBRACE ;
+
+# A statement is one of six forms.
+# Nib has no expression statements for bare function calls (like C's `f();`) —
+# all statements must have visible side effects in their syntax:
+#   - let introduces a new variable
+#   - assignment writes to an existing variable
+#   - return exits the function
+#   - for iterates over a range
+#   - if conditionally executes a block
+#   - expr_stmt allows a call expression to be used as a statement (for side effects)
+stmt          = let_stmt
+              | assign_stmt
+              | return_stmt
+              | for_stmt
+              | if_stmt
+              | expr_stmt
+              ;
+
+# Local variable declaration. The type annotation is mandatory.
+# Nib v1: let is immutable after initialization — there is no way to rebind
+# a let-declared variable. If you need a mutable counter, use for-loop variables.
+# Example: let carry: bool = false;
+let_stmt      = "let" NAME COLON type EQ expr SEMICOLON ;
+
+# Assignment to an existing variable (let, static, or for-loop variable).
+# Simple assignment only — no compound assignment (+=, -=, etc.) in v1.
+# Example: digit_count = digit_count +% 1;
+assign_stmt   = NAME EQ expr SEMICOLON ;
+
+# Return statement. Void functions use a bare return with a dummy expression
+# or no expression — in v1 we require an expression for non-void functions.
+# Example: return result;
+return_stmt   = "return" expr SEMICOLON ;
+
+# For loop. The only loop construct in Nib v1.
+# Syntax: for NAME: type in lower_expr RANGE upper_expr { ... }
+#
+# WHY RANGE IS A TOKEN NOT A SYNTAX RULE:
+# The RANGE token ".." is produced by the lexer as a single token, not parsed
+# as two dot operators. This matters because Nib has no floating-point and no
+# struct field access — the only use of "." in source is the range separator.
+# Making RANGE a lexer token means the parser rule for_stmt simply consumes
+# the RANGE token between the two bound expressions, rather than needing to
+# distinguish "." "." (two separate tokens) from ".5" (malformed float).
+#
+# WHY LOOP BOUNDS MUST BE CONST/LITERAL:
+# The Intel 4004 has no indirect addressing for jump targets. A loop must be
+# implemented with a DJNZ (decrement and jump if not zero) pattern where the
+# trip count is loaded into a register. If the bounds are not compile-time
+# constants, the compiler cannot generate static 4004 code without runtime
+# bounds-check overhead — and 160 bytes of RAM leaves no room for that.
+# The compiler enforces: both bound expressions must reduce to constant values
+# during semantic analysis.
+#
+# Example: for i: u4 in 0..8 { ... }
+for_stmt      = "for" NAME COLON type "in" expr RANGE expr block ;
+
+# Conditional statement. The else branch is optional.
+# Both branches must be full blocks (not single statements).
+# Requiring braces eliminates the dangling-else ambiguity.
+# Example: if carry { digit = 0; } else { digit = digit +% 1; }
+if_stmt       = "if" expr block [ "else" block ] ;
+
+# Expression statement: a call expression followed by a semicolon.
+# This allows functions with side effects to be called in statement position.
+# Example: update_display(row, col);
+# Only call expressions are meaningful here — other expression forms have
+# no side effects in Nib v1.
+expr_stmt     = expr SEMICOLON ;
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+# Nib's type system is intentionally minimal, matching what the 4004 can hold.
+#
+#   u4   — unsigned 4-bit integer, values 0–15.
+#          This is the native data size of the Intel 4004. All register operations
+#          work on 4-bit "nibbles". A u4 fits in a single 4004 register (R0–R15).
+#
+#   u8   — unsigned 8-bit integer, values 0–255.
+#          Two nibbles stored in a register pair (e.g. P0 = R0:R1).
+#          The 4004 handles 8-bit values via FIM (fetch immediate to pair) and
+#          multi-step add/subtract sequences.
+#
+#   bcd  — Binary-Coded Decimal nibble, values 0–9.
+#          The Intel 4004 was designed for decimal calculators, and has special
+#          DAA (decimal adjust accumulator) support for BCD arithmetic.
+#          A bcd value is stored as a u4 (nibble) but constrained to 0–9.
+#          The compiler inserts range checks; values 10–15 are invalid.
+#
+#   bool — Boolean: true (1) or false (0).
+#          Stored as a nibble (u4) under the hood — the 4004 has no bit-packed
+#          type. Arithmetic on bool is undefined; only logical operators apply.
+#
+# WHY NO SIGNED TYPES?
+# The 4004 has no signed arithmetic instructions. Two's complement negation
+# would require a DAA workaround and waste precious RAM. Nib v1 keeps everything
+# unsigned. Signed arithmetic can be layered on top in a library using +% and CY.
+#
+# WHY NO FLOAT?
+# The 4004 has no floating-point hardware. A software float library would consume
+# hundreds of bytes of ROM and RAM — untenable given the constraints.
+type          = "u4" | "u8" | "bcd" | "bool" ;
+
+# ---------------------------------------------------------------------------
+# Expressions — operator precedence hierarchy
+# ---------------------------------------------------------------------------
+#
+# Precedence levels (lowest to highest):
+#
+#   Level 1 — Logical OR   (||)        or_expr
+#   Level 2 — Logical AND  (&&)        and_expr
+#   Level 3 — Equality     (==, !=)    eq_expr
+#   Level 4 — Comparison   (<,>,<=,>=) cmp_expr
+#   Level 5 — Additive     (+,-,+%,+?) add_expr
+#   Level 6 — Bitwise      (&, |, ^)   bitwise_expr
+#   Level 7 — Unary        (!, ~)      unary_expr
+#   Level 8 — Primary                  primary
+#
+# WHY THIS ORDERING?
+# Following C-family conventions for levels 1–4 and 7–8 matches programmer
+# expectations. The interesting decision is levels 5–6:
+#
+#   Bitwise ABOVE additive — this is the same as Java/Rust.
+#   In C, bitwise is BELOW equality, which causes the famous bug:
+#     if (x & MASK == 0) { ... }   // intended: (x & MASK) == 0
+#     // but actually: x & (MASK == 0) because == binds tighter than &
+#   By putting bitwise above additive (but below relational), we avoid this.
+#   The tradeoff is that `a + b & c` is parsed as `a + (b & c)`,
+#   which requires explicit parentheses for the rare case where you want
+#   `(a + b) & c`. Given the 4004's use cases (masks and nibble manipulation),
+#   the bitwise-above-additive convention is more natural.
+#
+# Operators at the same level are LEFT-ASSOCIATIVE:
+#   a +% b +% c = (a +% b) +% c
+#   a == b == c is a parse error (you must parenthesise one comparison)
+#   — actually the grammar allows chaining at level 3 but the type checker
+#   rejects it because bool == bool requires bool == bool == bool to return bool
+#   from the first ==, then bool == bool for the second, which is fine.
+#   So chained == compiles but has C-like semantics: left-to-right.
+
+# Entry point for all expression contexts.
+expr          = or_expr ;
+
+# Logical OR: a || b. Short-circuits: if a is true, b is not evaluated.
+# On the 4004, short-circuit evaluation is implemented with a conditional branch:
+#   if a is true, skip the evaluation of b and set result to true.
+# { LOR and_expr } makes this left-associative: a || b || c = (a || b) || c.
+or_expr       = and_expr { LOR and_expr } ;
+
+# Logical AND: a && b. Short-circuits: if a is false, b is not evaluated.
+# 4004 implementation: conditional branch on a, evaluate b only if a is true.
+and_expr      = eq_expr { LAND eq_expr } ;
+
+# Equality operators: == and !=.
+# Both operands must have the same type. Result type is always bool.
+# Example: carry == true, digit != 9
+eq_expr       = cmp_expr { ( EQ_EQ | NEQ ) cmp_expr } ;
+
+# Relational comparison: <, >, <=, >=.
+# Operands must be numeric (u4, u8, or bcd). Result type is always bool.
+# The 4004 has no compare-and-set instruction; comparisons are implemented
+# using subtraction and checking the carry/borrow flag.
+cmp_expr      = add_expr { ( LT | GT | LEQ | GEQ ) add_expr } ;
+
+# Additive operators: +, -, +% (wrapping add), +? (saturating add).
+# All four are at the same precedence level because they are all "addition variants".
+# The programmer chooses the overflow semantics explicitly:
+#   PLUS    — may overflow (compiler warns if it can prove this)
+#   MINUS   — subtraction (borrows from next nibble in multi-byte types)
+#   WRAP_ADD (+%) — wraps at type max: u4 15 +% 1 = 0
+#   SAT_ADD (+?) — clamps at type max: u4 15 +? 1 = 15
+# On the 4004, all four map to ADD (add to accumulator) with post-processing:
+#   PLUS/MINUS: use raw ADD/SUB, carry = overflow bit
+#   WRAP_ADD: mask result to type width (AND 0xF for u4)
+#   SAT_ADD: add, then conditional clamp if carry is set
+add_expr      = bitwise_expr { ( PLUS | MINUS | WRAP_ADD | SAT_ADD ) bitwise_expr } ;
+
+# Bitwise operators: &, |, ^.
+# Maps directly to 4004 ANL, ORL, XRL instructions.
+# Useful for nibble manipulation: extract high nibble with `x & 0xF0`, etc.
+# Note: ~ (bitwise NOT) is a unary operator at the next level up, not binary.
+bitwise_expr  = unary_expr { ( AMP | PIPE | CARET ) unary_expr } ;
+
+# Unary operators: ! (logical NOT) and ~ (bitwise NOT).
+# Both are right-recursive: !!x = !(!x), ~~x = ~(~x).
+# The base case delegates to primary.
+# WHY RIGHT-RECURSIVE: `!~x` should parse as `!(~x)`, not `(!~)x`.
+# Right recursion naturally gives right-to-left application of unary operators,
+# which matches the intuitive reading of prefix chains.
+unary_expr    = ( BANG | TILDE ) unary_expr
+              | primary
+              ;
+
+# Primary expressions: the leaves of the expression tree.
+# Listed in order of specificity — call_expr before NAME because a function call
+# starts with a NAME token; if NAME were listed first, the parser would consume
+# the function name as a variable reference and never try call_expr.
+primary       = INT_LIT
+              | HEX_LIT
+              | "true"
+              | "false"
+              | call_expr
+              | NAME
+              | LPAREN expr RPAREN
+              ;
+
+# ---------------------------------------------------------------------------
+# Function calls
+# ---------------------------------------------------------------------------
+
+# Function call: NAME followed by a parenthesised argument list.
+# The argument list is optional — zero-argument calls look like: reset().
+# call_expr must appear before NAME in primary (see note above).
+#
+# CALL DEPTH CONSTRAINT:
+# The Intel 4004 has a 3-level hardware call stack (PC0, PC1, PC2).
+# One level is always occupied by the current function's return address.
+# That leaves 2 levels for nested calls. Nib enforces: no call chain may
+# exceed depth 2. The compiler builds a static call graph and verifies this.
+# Recursion is not allowed (same constraint, caught separately as a cycle check).
+call_expr     = NAME LPAREN [ arg_list ] RPAREN ;
+
+# Argument list: one or more expressions separated by commas.
+arg_list      = expr { COMMA expr } ;

--- a/code/grammars/nib.tokens
+++ b/code/grammars/nib.tokens
@@ -1,0 +1,297 @@
+# Token definitions for Nib
+# @version 1
+#
+# Nib is a safe, statically-typed toy language designed to compile down to Intel 4004
+# machine code. The name comes from "nibble" (4 bits), the native word size of the 4004.
+#
+# WHY A NEW LANGUAGE?
+# The Intel 4004 (1971) is the world's first commercial microprocessor. It is a 4-bit
+# CPU with extreme constraints: 160 bytes of usable RAM, 4 KB of ROM, a 3-level hardware
+# call stack, and no multiplication or division in hardware. Writing 4004 assembly by
+# hand is error-prone. Nib gives us a safer, higher-level notation that can be verified
+# and compiled rather than hand-assembled.
+#
+# SAFETY MODEL
+# Nib enforces a strict subset of operations suited to the 4004:
+#   - All types fit in 4-bit (u4), 8-bit (u8), BCD (binary-coded decimal), or boolean
+#   - Call depth is statically bounded to 2 (the 4004 stack has 3 levels;
+#     one is always reserved for the current function frame)
+#   - No recursion allowed — the static call graph must be acyclic
+#   - No heap allocation — the 4004 has no heap; all data is stack or static
+#   - Loop bounds must be compile-time constants so ROM size is predictable
+#
+# DESIGN PHILOSOPHY
+# Token ordering follows first-match-wins semantics. The lexer scans the input
+# character by character, trying each pattern in the order they appear in this file.
+# When two patterns could both match at the current position, the one listed first wins.
+# This is why multi-character operators appear before single-character operators,
+# and why HEX_LIT appears before INT_LIT.
+#
+# Key ordering rules:
+#   +%  must come before  +   (WRAP_ADD before PLUS)
+#   +?  must come before  +   (SAT_ADD before PLUS)
+#   ..  must come before nothing that starts with .  (RANGE is the only dot token)
+#   ->  must come before  -   (ARROW before MINUS)
+#   ==  must come before  =   (EQ_EQ before EQ)
+#   !=  must come before nothing (only multi-char use of !)
+#   <=  must come before  <   (LEQ before LT)
+#   >=  must come before  >   (GEQ before GT)
+#   &&  must come before  &   (LAND before AMP)
+#   ||  must come before  |   (LOR before PIPE)
+#   HEX_LIT must come before INT_LIT (0xA must match as hex, not "0" then "xA")
+
+# ---------------------------------------------------------------------------
+# Multi-character operators — must appear before single-character versions
+# ---------------------------------------------------------------------------
+
+# Wrapping addition: +%
+# On the Intel 4004, a u4 value ranges from 0 to 15. Normal addition can overflow
+# silently, producing a wrong answer and (sometimes) setting the carry flag.
+# Wrapping addition is EXPLICIT overflow: 15 +% 1 = 0, with the carry discarded.
+# The % sigil signals "wrap around like a modular counter". This mirrors Rust's
+# wrapping_add() and Zig's +% operator. Making wrapping explicit prevents accidental
+# silent overflow in safety-critical embedded code.
+WRAP_ADD    = "+%"
+
+# Saturating addition: +?
+# Saturating addition clamps at the maximum value instead of overflowing.
+# 15 +? 1 = 15 on u4. The ? sigil asks "did we overflow?" — it saturates at the limit.
+# Useful for things like BCD digit carry: you want to stay at 9 rather than wrap.
+# Inspired by ARM's UQADD instruction and Rust's saturating_add().
+SAT_ADD     = "+?"
+
+# Range separator for for-loops: ..
+# Nib for loops look like: for i: u4 in 0..8 { ... }
+# The two-dot range notation is borrowed from Rust. The range is EXCLUSIVE on the
+# right: 0..8 means i takes values 0, 1, 2, 3, 4, 5, 6, 7 (not 8).
+# Why exclusive? It makes the length of the range equal to the upper bound minus
+# the lower bound (8 - 0 = 8 iterations), which matches 4004 DJNZ loop patterns.
+# The lexer must see ".." as a single token so "0..8" doesn't lex as "0" "." "." "8".
+# (Nib has no floating-point, so single "." never appears outside string/comment context.)
+RANGE       = ".."
+
+# Function return type arrow: ->
+# Function signatures look like: fn add(a: u4, b: u4) -> u4 { ... }
+# The arrow notation (borrowed from Haskell/Rust) visually reads as "produces".
+# Must come before MINUS so "->" is not lexed as MINUS GT.
+ARROW       = "->"
+
+# Equality comparison: ==
+# Nib uses = for assignment (like ALGOL and ML) and == for equality (like C).
+# Wait — actually Nib uses = for assignment in let/static/const declarations
+# and == for comparison in expressions. The single = is never used in expression
+# context, which avoids the classic C bug of writing = when you mean ==.
+# Must come before EQ so "==" is not lexed as EQ EQ.
+EQ_EQ       = "=="
+
+# Not-equal comparison: !=
+# Standard C-family syntax. Bang (!) is the logical NOT unary operator, so "!="
+# is a two-character sequence, not bang followed by equals.
+# Must come before BANG so "!=" is lexed atomically.
+NEQ         = "!="
+
+# Less-or-equal: <=
+# Must come before LT so "<=" is not lexed as LT EQ.
+LEQ         = "<="
+
+# Greater-or-equal: >=
+# Must come before GT so ">=" is not lexed as GT EQ.
+GEQ         = ">="
+
+# Logical AND: &&
+# Short-circuit AND — if the left operand is false, the right is not evaluated.
+# Uses C/Java/Rust syntax. The double-ampersand distinguishes logical AND (&&)
+# from bitwise AND (&), which is important on the 4004 where bitwise AND is a
+# real hardware operation (ANL instruction). Must come before AMP.
+LAND        = "&&"
+
+# Logical OR: ||
+# Short-circuit OR — if the left operand is true, the right is not evaluated.
+# Double-pipe distinguishes logical OR (||) from bitwise OR (|).
+# On the 4004 there is no logical OR instruction — it must be compiled as a
+# branch on the first operand. Must come before PIPE.
+LOR         = "||"
+
+# ---------------------------------------------------------------------------
+# Single-character arithmetic operators
+# ---------------------------------------------------------------------------
+
+# Ordinary addition. On u4 operands, this may raise a compile-time error if
+# the compiler cannot prove the result fits — prefer +% or +? in hot paths.
+PLUS        = "+"
+
+# Subtraction. The 4004 uses SUB (subtract with borrow) for multi-nibble values.
+MINUS       = "-"
+
+# Multiplication. Note: the Intel 4004 has NO multiply instruction in hardware.
+# Nib v1 does NOT include multiplication — see NIB00-nib-language.md section
+# "What is NOT in v1". The STAR token is reserved for future v2.
+STAR        = "*"
+
+# Division. Likewise, the 4004 has no divide instruction. Reserved for v2.
+SLASH       = "/"
+
+# ---------------------------------------------------------------------------
+# Single-character bitwise operators
+# ---------------------------------------------------------------------------
+
+# Bitwise AND. On the 4004 this maps directly to the ANL (AND logical) instruction.
+# AMP is the single-& version; LAND (&&) is logical and.
+AMP         = "&"
+
+# Bitwise OR. Maps to ORL (OR logical) on the 4004.
+# PIPE is single-|; LOR (||) is logical or.
+PIPE        = "|"
+
+# Bitwise XOR. Maps to XRL (XOR logical) on the 4004.
+CARET       = "^"
+
+# Bitwise NOT (complement). Maps to CMA (complement accumulator) on the 4004.
+# Flips all bits: ~0b1010 = 0b0101 on u4.
+TILDE       = "~"
+
+# ---------------------------------------------------------------------------
+# Single-character comparison and logical operators
+# ---------------------------------------------------------------------------
+
+# Logical NOT (boolean negation). Only valid on bool expressions.
+# !true = false, !false = true.
+# Distinct from TILDE (~) which is bitwise NOT.
+BANG        = "!"
+
+# Less-than comparison.
+LT          = "<"
+
+# Greater-than comparison.
+GT          = ">"
+
+# ---------------------------------------------------------------------------
+# Assignment
+# ---------------------------------------------------------------------------
+
+# Assignment in let/static/const declarations: let x: u4 = 5;
+# Also used as the separator between the declared type and initial value.
+# NOT used in expression context — assignment is statement-only in Nib.
+# This eliminates the bug class where = is written when == is intended.
+EQ          = "="
+
+# ---------------------------------------------------------------------------
+# Delimiters
+# ---------------------------------------------------------------------------
+
+# Block delimiters for function bodies, if-bodies, for-bodies.
+LBRACE      = "{"
+RBRACE      = "}"
+
+# Grouping for expressions and parameter lists.
+LPAREN      = "("
+RPAREN      = ")"
+
+# Type annotation separator: let x: u4 = ...
+# Also used in param lists: fn add(a: u4, b: u4) -> u4
+COLON       = ":"
+
+# Statement terminator. Every statement ends with a semicolon.
+# Explicit semicolons keep the grammar unambiguous and simple — no need for
+# the tricky automatic semicolon insertion rules of JavaScript or Go.
+SEMICOLON   = ";"
+
+# Argument/parameter separator.
+COMMA       = ","
+
+# ---------------------------------------------------------------------------
+# Literals
+# ---------------------------------------------------------------------------
+
+# Hexadecimal integer literal: 0x followed by one or more hex digits (case-insensitive).
+# Examples: 0x0, 0xA, 0xFF, 0x1F, 0xfe
+# WHY HEX FIRST: 0xFF must be lexed as a single HEX_LIT token, not as INT_LIT("0")
+# followed by NAME("xFF"). Placing HEX_LIT before INT_LIT ensures the full hex
+# token is consumed before the decimal rule fires on the leading "0".
+# Hex literals are crucial for 4004 programming: nibble masks (0xF), port values,
+# and ROM addresses are all naturally expressed in hex.
+HEX_LIT     = /0x[0-9A-Fa-f]+/
+
+# Decimal integer literal: one or more decimal digits.
+# Must come after HEX_LIT (see above). Examples: 0, 1, 15, 255.
+INT_LIT     = /[0-9]+/
+
+# Identifier: letter or underscore, followed by letters, digits, or underscores.
+# Underscores are allowed (unlike ALGOL 60) because embedded code often uses
+# names like carry_out, nibble_high, or bcd_digit_2.
+# Keywords are reclassified from NAME after a full-token match (see keywords section).
+# The identifier token is named NAME so that the GrammarLexer's keyword promotion
+# logic fires: the check is token_name == "NAME" && value in keyword_set.
+NAME        = /[a-zA-Z_][a-zA-Z0-9_]*/
+
+# ---------------------------------------------------------------------------
+# Keywords — reclassified from NAME after a full-token match
+# ---------------------------------------------------------------------------
+#
+# Case-sensitive: Nib is lowercase-only for keywords (unlike ALGOL 60).
+# Partial matches do NOT qualify: "format" is NAME (identifier), not "for" keyword
+# followed by NAME("mat"). The keyword match fires only on the complete token.
+#
+# Keywords are intentionally minimal. The 4004 target forces a tiny language;
+# a small keyword set keeps the compiler simple and the grammar unambiguous.
+
+keywords:
+  # Function declaration keyword. Short for "function" — matches Rust/Go style.
+  fn
+
+  # Local variable declaration. Introduces a variable into the current block scope.
+  # let is immutable after initialization (Nib v1); a mutable variant may come in v2.
+  let
+
+  # Static variable declaration. Lives in ROM-mapped data section.
+  # On the 4004, static variables map to chip RAM registers.
+  # Limit: total static RAM must be ≤ 160 bytes (compiler enforced).
+  static
+
+  # Compile-time constant. Value is folded into ROM at compile time; no RAM used.
+  # Prefer const over static whenever the value never changes.
+  const
+
+  # Return statement keyword. Returns a value from a function.
+  # Void functions use bare return; (no expression).
+  return
+
+  # For loop keyword. Only loop construct in Nib v1.
+  # Form: for NAME: type in expr..expr { ... }
+  # No while loop — the for loop with const bounds is sufficient for 4004 programs,
+  # and const bounds make loop trip count statically verifiable.
+  for
+
+  # Range keyword in for loop: for i: u4 in 0..8 { ... }
+  # The "in" keyword separates the loop variable from the range.
+  in
+
+  # Conditional: if expr { ... } or if expr { ... } else { ... }
+  if
+
+  # Else branch of conditional.
+  else
+
+  # Boolean literal true. Type: bool.
+  true
+
+  # Boolean literal false. Type: bool.
+  false
+
+# ---------------------------------------------------------------------------
+# Skip patterns — consumed silently, no tokens emitted
+# ---------------------------------------------------------------------------
+
+skip:
+  # Whitespace is completely insignificant in Nib.
+  # Spaces, tabs, carriage returns, and newlines between tokens are all ignored.
+  # Free-format source gives the programmer control over indentation style.
+  WHITESPACE    = /[ \t\r\n]+/
+
+  # Line comments start with // and extend to end of line.
+  # C++/Java/Rust style was chosen over # (Python/Ruby) because // is already
+  # used in the language's division operator context (even though division is
+  # reserved for v2), and because 4004 assembly conventionally uses semicolons
+  # for comments — keeping // as the Nib comment marker avoids confusion.
+  # The [^\n]* matches zero or more non-newline characters greedily.
+  LINE_COMMENT  = /\/\/[^\n]*/

--- a/code/packages/python/type-checker-protocol/CHANGELOG.md
+++ b/code/packages/python/type-checker-protocol/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## [0.1.0] - 2026-04-12
+
+### Added
+
+- `TypeChecker[ASTIn, ASTOut]` Protocol — generic interface for all language
+  type checkers in this repo.  Uses structural subtyping (`typing.Protocol`):
+  no inheritance required.
+- `TypeCheckResult[ASTOut]` frozen dataclass — carries the typed AST and a
+  list of `TypeErrorDiagnostic` objects; exposes an `.ok` property as a
+  shorthand for `len(errors) == 0`.
+- `TypeErrorDiagnostic` frozen dataclass — represents one type error with
+  `message`, `line`, and `column` source-location fields.
+- Full test suite with ≥ 20 test cases covering construction, immutability,
+  structural protocol satisfaction, duck typing, and the public API surface.

--- a/code/packages/python/type-checker-protocol/README.md
+++ b/code/packages/python/type-checker-protocol/README.md
@@ -1,0 +1,270 @@
+# coding-adventures-type-checker-protocol
+
+Generic type-checker protocol for the coding-adventures compiler stack.
+
+This package defines the **shared interface** that all language type checkers
+in this repository must implement.  Future languages — Nib, and others — each
+ship their own type checker, but they all speak the same protocol so the
+compiler pipeline can compose them uniformly.
+
+---
+
+## What Is a Type Checker?
+
+A compiler typically transforms source text through a series of stages:
+
+```
+Source text
+  → Lexer        (characters → tokens)
+  → Parser       (tokens → untyped AST)
+  → Type Checker (untyped AST → typed AST)   ← this layer
+  → IR Compiler  (typed AST → intermediate representation)
+  → Code Generator (IR → bytecode / machine code)
+```
+
+The **type checker** sits between the parser and the IR compiler.  Its two
+jobs are:
+
+1. **Verify** that the program is type-safe — catch mistakes like adding a
+   number to a string before they become mysterious runtime crashes.
+2. **Annotate** the AST with type information — stamp each node with its
+   resolved type so that later stages (IR generation, optimization) don't
+   need to re-derive it.
+
+For example, given the Nib expression `1 + "hello"`, the type checker would:
+
+- Walk the `+` node.
+- Infer the left operand `1` has type `Int`.
+- Infer the right operand `"hello"` has type `String`.
+- Detect the mismatch and produce a `TypeErrorDiagnostic` at the right line
+  and column.
+- Return the (partially annotated) AST together with the error list so the
+  user can see *all* the errors in one go, not just the first one.
+
+---
+
+## Why a Protocol / Interface?
+
+This repo will have **many** type checkers:
+
+| Package                     | What it checks         |
+|-----------------------------|------------------------|
+| `nib-type-checker`          | The Nib language       |
+| `lattice-type-checker`      | Lattice stylesheets    |
+| `mosaic-type-checker`       | Mosaic components      |
+| … more to come …            |                        |
+
+All of them must implement the **same interface** so that:
+
+- The compiler pipeline can compose them uniformly.
+- Each checker can be unit-tested in isolation against the same contract.
+- Tools (dashboards, linters, IDEs) can treat all type checkers the same way.
+
+Python's `typing.Protocol` gives us **structural subtyping** — a class
+satisfies the protocol if it has the right methods with the right signatures,
+without needing to inherit from anything.  This is sometimes called
+*duck typing with types*: if it walks like a type checker and quacks like a
+type checker, it *is* a type checker — mypy will verify this statically.
+
+---
+
+## Core Types
+
+### `TypeErrorDiagnostic`
+
+A frozen (immutable) dataclass representing a single type error:
+
+```python
+@dataclass(frozen=True)
+class TypeErrorDiagnostic:
+    message: str   # human-readable description
+    line: int      # 1-based line number in the source
+    column: int    # 1-based column number within the line
+```
+
+**Frozen** means you cannot accidentally mutate a diagnostic after creating
+it.  It also makes diagnostics hashable, so you can put them in sets.
+
+```python
+from type_checker_protocol import TypeErrorDiagnostic
+
+err = TypeErrorDiagnostic(
+    message="Cannot add Int and String",
+    line=5,
+    column=12,
+)
+print(err)
+# TypeErrorDiagnostic(message='Cannot add Int and String', line=5, column=12)
+```
+
+---
+
+### `TypeCheckResult[ASTOut]`
+
+A frozen dataclass wrapping the result of a complete type-checking pass:
+
+```python
+@dataclass(frozen=True)
+class TypeCheckResult(Generic[ASTOut]):
+    typed_ast: ASTOut
+    errors: list[TypeErrorDiagnostic]
+
+    @property
+    def ok(self) -> bool:
+        return len(self.errors) == 0
+```
+
+Key design decisions:
+
+- **Always returns a result, never raises.**  Exceptions are for unexpected
+  internal errors, not for type errors the programmer made.
+- **Collects all errors in one pass.**  The user sees every problem at once,
+  not just the first one.
+- **Carries the AST even on failure.**  IDEs can use the partially-annotated
+  AST for completions and hover types while the user is still fixing mistakes.
+- **`.ok` shorthand.**  The most common check (`if result.ok`) reads naturally.
+
+```python
+from type_checker_protocol import TypeCheckResult, TypeErrorDiagnostic
+
+# Success
+result: TypeCheckResult[MyTypedAST] = TypeCheckResult(
+    typed_ast=my_typed_ast,
+    errors=[],
+)
+assert result.ok  # True
+
+# Failure
+err = TypeErrorDiagnostic("Bad type", line=3, column=7)
+result = TypeCheckResult(typed_ast=partial_ast, errors=[err])
+assert not result.ok  # False
+assert result.errors[0].line == 3
+```
+
+---
+
+### `TypeChecker[ASTIn, ASTOut]`
+
+The protocol every type checker must satisfy:
+
+```python
+class TypeChecker(Protocol[ASTIn, ASTOut]):
+    def check(self, ast: ASTIn) -> TypeCheckResult[ASTOut]:
+        ...
+```
+
+**Why generics?**  Different languages have different AST types.  A Nib type
+checker works on `NibNode` objects; a Lattice type checker works on
+`LatticeNode` objects.  The two type parameters let mypy enforce that you
+don't accidentally pass the wrong AST to the wrong checker:
+
+```python
+# mypy catches this at compile time — wrong checker for the wrong AST:
+nib_checker: TypeChecker[NibNode, TypedNibNode] = LatticeTypeChecker()  # type error!
+```
+
+**Structural typing — no inheritance needed.**  A class automatically
+satisfies the protocol as long as it has the right `check` method.  You never
+need to write `class MyChecker(TypeChecker[...])`.
+
+---
+
+## Usage Example
+
+```python
+from dataclasses import dataclass
+from type_checker_protocol import TypeChecker, TypeCheckResult, TypeErrorDiagnostic
+
+
+# --- AST node types (defined in your language package) ---
+
+@dataclass
+class NibNode:
+    kind: str
+    children: list["NibNode"]
+
+@dataclass
+class TypedNibNode:
+    kind: str
+    children: list["TypedNibNode"]
+    resolved_type: str
+
+
+# --- Concrete type checker (no inheritance needed) ---
+
+class NibTypeChecker:
+    """Type-checks Nib ASTs."""
+
+    def check(self, ast: NibNode) -> TypeCheckResult[TypedNibNode]:
+        errors: list[TypeErrorDiagnostic] = []
+        typed = self._check_node(ast, errors)
+        return TypeCheckResult(typed_ast=typed, errors=errors)
+
+    def _check_node(
+        self,
+        node: NibNode,
+        errors: list[TypeErrorDiagnostic],
+    ) -> TypedNibNode:
+        if node.kind == "add":
+            # … infer types of children, check compatibility …
+            pass
+        return TypedNibNode(kind=node.kind, children=[], resolved_type="int")
+
+
+# --- Using the protocol annotation ---
+
+def compile_nib(
+    checker: TypeChecker[NibNode, TypedNibNode],
+    ast: NibNode,
+) -> TypedNibNode:
+    result = checker.check(ast)
+    if not result.ok:
+        for err in result.errors:
+            print(f"  {err.line}:{err.column}: {err.message}")
+        raise SystemExit("Type errors found.")
+    return result.typed_ast
+
+
+checker = NibTypeChecker()
+typed_ast = compile_nib(checker, my_ast)
+```
+
+---
+
+## How This Fits in the Compiler Pipeline
+
+```
+coding-adventures-type-checker-protocol   ← you are here
+        ↑ implemented by
+coding-adventures-nib-type-checker
+coding-adventures-lattice-type-checker
+… etc.
+        ↓ consumes TypeCheckResult
+coding-adventures-compiler-ir
+coding-adventures-bytecode-compiler
+```
+
+The protocol lives at the **bottom** of the type-checking layer.  It has zero
+dependencies (only Python stdlib).  Every concrete type checker in the repo
+depends on it; nothing below it does.
+
+---
+
+## Installation
+
+```bash
+pip install coding-adventures-type-checker-protocol
+```
+
+For development:
+
+```bash
+pip install "coding-adventures-type-checker-protocol[dev]"
+pytest
+```
+
+---
+
+## License
+
+MIT

--- a/code/packages/python/type-checker-protocol/pyproject.toml
+++ b/code/packages/python/type-checker-protocol/pyproject.toml
@@ -1,0 +1,60 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-type-checker-protocol"
+version = "0.1.0"
+description = "Generic type-checker protocol — the shared interface all language type checkers in this repo implement"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["type-checker", "protocol", "compiler", "type-system", "education", "computer-science"]
+dependencies = []
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Education",
+    "Topic :: Education",
+    "Topic :: Scientific/Engineering",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://github.com/adhithyan15/coding-adventures"
+Repository = "https://github.com/adhithyan15/coding-adventures"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/type_checker_protocol"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort (import sorting)
+    "UP",   # pyupgrade (modern Python syntax)
+    "B",    # bugbear (common bugs)
+    "SIM",  # simplify
+    "ANN",  # type annotation enforcement
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=type_checker_protocol --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.run]
+source = ["src/type_checker_protocol"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/packages/python/type-checker-protocol/src/type_checker_protocol/__init__.py
+++ b/code/packages/python/type-checker-protocol/src/type_checker_protocol/__init__.py
@@ -1,0 +1,45 @@
+"""
+coding-adventures-type-checker-protocol
+========================================
+
+Generic type-checker protocol for the coding-adventures compiler stack.
+
+This package defines the shared interface that all language type checkers in
+this repository must implement.  Import from here rather than from the
+internal ``protocol`` module so that the public API is stable even if we
+reorganise the internals.
+
+Public API
+----------
+TypeChecker
+    ``typing.Protocol[ASTIn, ASTOut]`` — the interface all type checkers must
+    implement.  Structural: no inheritance required.
+
+TypeCheckResult
+    Frozen dataclass carrying the typed AST and any errors from a single pass.
+    Check ``.ok`` to see whether the pass succeeded.
+
+TypeErrorDiagnostic
+    Frozen dataclass representing one type error with ``message``, ``line``,
+    and ``column``.
+
+Example
+-------
+    from type_checker_protocol import TypeChecker, TypeCheckResult, TypeErrorDiagnostic
+
+    class MyTypeChecker:
+        def check(self, ast: MyNode) -> TypeCheckResult[TypedMyNode]:
+            ...
+"""
+
+from type_checker_protocol.protocol import (
+    TypeCheckResult,
+    TypeChecker,
+    TypeErrorDiagnostic,
+)
+
+__all__ = [
+    "TypeChecker",
+    "TypeCheckResult",
+    "TypeErrorDiagnostic",
+]

--- a/code/packages/python/type-checker-protocol/src/type_checker_protocol/protocol.py
+++ b/code/packages/python/type-checker-protocol/src/type_checker_protocol/protocol.py
@@ -1,0 +1,304 @@
+"""
+Generic type-checker protocol — the shared contract all language type checkers
+must implement.
+
+──────────────────────────────────────────────────────────────────────────────
+WHAT IS A TYPE CHECKER?
+──────────────────────────────────────────────────────────────────────────────
+
+A compiler typically passes source code through several stages:
+
+    Source text
+        → Lexer        (characters → tokens)
+        → Parser       (tokens → AST)
+        → Type Checker (untyped AST → typed AST)   ← this layer
+        → IR Compiler  (typed AST → IR)
+        → Code Generator (IR → machine code / bytecode)
+
+The type checker's job is to *verify* that a program is type-safe and to
+*annotate* the AST with type information that later stages need.
+
+For example, in a statically typed language the expression `1 + "hello"` is
+illegal.  The type checker detects this, produces a ``TypeErrorDiagnostic``
+(with the line/column where the mistake is), and reports it back to the user.
+
+If the program *is* type-safe, the type checker produces a *typed AST* —
+the same tree, but with every node annotated with its resolved type.  Later
+stages (IR generation, optimization) can then trust those annotations without
+doing type inference again.
+
+──────────────────────────────────────────────────────────────────────────────
+WHY A PROTOCOL?
+──────────────────────────────────────────────────────────────────────────────
+
+This repo will have *many* type checkers:
+
+    NibTypeChecker         — for the Nib language
+    LatticeTypeChecker     — for the Lattice stylesheet language
+    MosaicTypeChecker      — for the Mosaic component language
+    … and so on
+
+All of them must implement the *same* interface so that:
+
+  1. The compiler pipeline can compose them uniformly.
+  2. We can test each checker in isolation against the same contract.
+  3. Tools like static analysis dashboards can treat all checkers the same way.
+
+Python's ``typing.Protocol`` gives us *structural subtyping* — a class
+satisfies the protocol if it has the right methods with the right signatures,
+without needing to inherit from anything.  This is sometimes called "duck
+typing with types".
+
+──────────────────────────────────────────────────────────────────────────────
+GENERICS: WHY TypeChecker[ASTIn, ASTOut]?
+──────────────────────────────────────────────────────────────────────────────
+
+Different languages have different AST node types.  A Nib type checker works
+on ``NibASTNode`` objects; a Lattice type checker works on ``LatticeNode``
+objects.  We want mypy to catch mismatches:
+
+    # This should be a type error — wrong checker for the wrong AST:
+    nib_checker: TypeChecker[NibNode, TypedNibNode] = LatticeTypeChecker()
+
+The two type parameters let mypy enforce this at compile time:
+
+    ``ASTIn``  — the untyped AST that goes *in*  (contravariant: a checker
+                 that accepts a supertype of NibNode is also valid here)
+    ``ASTOut`` — the typed AST that comes *out* (covariant: returning a
+                 subtype of TypedNibNode is also valid)
+
+In practice, most users just write:
+
+    checker: TypeChecker[MyNode, TypedMyNode] = MyTypeChecker()
+
+and never think about variance — the generics are there to help mypy, not
+to make your life harder.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Generic, Protocol, TypeVar
+
+# ---------------------------------------------------------------------------
+# Type variables
+# ---------------------------------------------------------------------------
+
+ASTIn = TypeVar("ASTIn", contravariant=True)  # type: ignore[misc]
+ASTOut = TypeVar("ASTOut", covariant=True)  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# TypeErrorDiagnostic
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TypeErrorDiagnostic:
+    """A single type error with its source location.
+
+    Frozen (immutable) so that callers cannot accidentally mutate a diagnostic
+    after it has been added to a result.  This also makes diagnostics safe to
+    use as dict keys or in sets.
+
+    Attributes
+    ----------
+    message:
+        Human-readable description of what went wrong.  Should be clear enough
+        for a student learning the language to understand.  Example:
+        ``"Cannot add Int and String — both sides of '+' must have the same type"``
+    line:
+        1-based line number where the error was detected.  Line 1 is the first
+        line of the source file.
+    column:
+        1-based column number within that line.  Column 1 is the first
+        character.
+
+    Examples
+    --------
+    >>> err = TypeErrorDiagnostic(message="Type mismatch", line=3, column=7)
+    >>> err.message
+    'Type mismatch'
+    >>> err.line
+    3
+    >>> err.column
+    7
+    >>> # Frozen — mutations raise FrozenInstanceError:
+    >>> err.line = 99  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    dataclasses.FrozenInstanceError: ...
+    """
+
+    message: str
+    line: int
+    column: int
+
+
+# ---------------------------------------------------------------------------
+# TypeCheckResult
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TypeCheckResult(Generic[ASTOut]):
+    """The result of running a type-checking pass.
+
+    A type checker always returns a ``TypeCheckResult``, never raises an
+    exception (except for truly unexpected internal errors).  This allows
+    the pipeline to collect *all* type errors in one pass rather than stopping
+    at the first.
+
+    The result carries *both* the (possibly partially annotated) typed AST
+    *and* the list of errors.  This is intentional: even when there are errors,
+    the AST may be partially annotated, which lets IDE tooling provide
+    completions and hover information while the user is still fixing mistakes.
+
+    Attributes
+    ----------
+    typed_ast:
+        The output AST.  If ``ok`` is True this is fully annotated and safe to
+        pass to the IR compiler.  If ``ok`` is False this may be partially
+        annotated — use it for IDE features but do not compile it further.
+    errors:
+        The list of type errors found.  An empty list means success.
+
+    Properties
+    ----------
+    ok:
+        ``True`` when there are no errors; ``False`` otherwise.  Shorthand
+        for ``len(result.errors) == 0``.
+
+    Examples
+    --------
+    >>> from dataclasses import dataclass
+    >>> @dataclass
+    ... class FakeAST:
+    ...     label: str
+    ...
+    >>> # Success path
+    >>> result = TypeCheckResult(typed_ast=FakeAST("typed"), errors=[])
+    >>> result.ok
+    True
+    >>> result.typed_ast.label
+    'typed'
+    >>>
+    >>> # Error path
+    >>> err = TypeErrorDiagnostic(message="Bad type", line=1, column=1)
+    >>> result = TypeCheckResult(typed_ast=FakeAST("partial"), errors=[err])
+    >>> result.ok
+    False
+    >>> len(result.errors)
+    1
+    """
+
+    typed_ast: ASTOut
+    errors: list[TypeErrorDiagnostic] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        """Return True if there are no type errors.
+
+        This is the primary way to check whether type-checking succeeded:
+
+            result = checker.check(ast)
+            if result.ok:
+                ir = ir_compiler.compile(result.typed_ast)
+            else:
+                for error in result.errors:
+                    print(f"{error.line}:{error.column}: {error.message}")
+        """
+        return len(self.errors) == 0
+
+
+# ---------------------------------------------------------------------------
+# TypeChecker Protocol
+# ---------------------------------------------------------------------------
+
+
+class TypeChecker(Protocol[ASTIn, ASTOut]):
+    """Generic protocol for all type-checking passes in this repo.
+
+    Any class that implements a ``check`` method with the right signature
+    automatically satisfies this protocol — no inheritance needed.
+
+    Type Parameters
+    ---------------
+    ASTIn:
+        The *untyped* AST that this checker accepts as input.  Contravariant:
+        a checker that works on a *supertype* of ASTIn also satisfies this
+        protocol.
+    ASTOut:
+        The *typed* AST that this checker produces as output.  Covariant: a
+        checker that produces a *subtype* of ASTOut also satisfies this
+        protocol.
+
+    Usage
+    -----
+    Implementing a concrete type checker::
+
+        from dataclasses import dataclass
+        from type_checker_protocol import TypeChecker, TypeCheckResult, TypeErrorDiagnostic
+
+        @dataclass
+        class NibNode:
+            kind: str
+
+        @dataclass
+        class TypedNibNode:
+            kind: str
+            resolved_type: str
+
+        class NibTypeChecker:
+            def check(self, ast: NibNode) -> TypeCheckResult[TypedNibNode]:
+                if ast.kind == "bad":
+                    err = TypeErrorDiagnostic("Unknown node kind", line=1, column=1)
+                    typed = TypedNibNode(kind=ast.kind, resolved_type="unknown")
+                    return TypeCheckResult(typed_ast=typed, errors=[err])
+                typed = TypedNibNode(kind=ast.kind, resolved_type="int")
+                return TypeCheckResult(typed_ast=typed, errors=[])
+
+    Using the protocol as a type annotation::
+
+        def run_pipeline(
+            checker: TypeChecker[NibNode, TypedNibNode],
+            ast: NibNode,
+        ) -> TypedNibNode:
+            result = checker.check(ast)
+            if not result.ok:
+                raise RuntimeError(f"{len(result.errors)} type error(s)")
+            return result.typed_ast
+
+    Notes
+    -----
+    - The ``check`` method must never raise an exception for type errors; it
+      should always return a ``TypeCheckResult``.
+    - Multiple errors should be collected in a single pass rather than stopping
+      at the first.
+    - The ``typed_ast`` field in the result may be partially annotated when
+      errors are present.
+    """
+
+    def check(self, ast: ASTIn) -> TypeCheckResult[ASTOut]:
+        """Type-check the given AST and return the result.
+
+        Parameters
+        ----------
+        ast:
+            The untyped AST produced by the parser.  This checker will walk
+            the tree, verify type safety, and annotate each node.
+
+        Returns
+        -------
+        TypeCheckResult[ASTOut]:
+            A result object containing:
+            - ``typed_ast``: the annotated AST (may be partial if errors exist)
+            - ``errors``: list of ``TypeErrorDiagnostic``; empty means success
+
+        Notes
+        -----
+        - Do not raise exceptions for type errors — put them in ``errors``.
+        - Do raise exceptions for truly unexpected internal errors (e.g.,
+          receiving ``None`` when an AST is required).
+        """
+        ...

--- a/code/packages/python/type-checker-protocol/tests/test_type_checker_protocol.py
+++ b/code/packages/python/type-checker-protocol/tests/test_type_checker_protocol.py
@@ -1,0 +1,340 @@
+"""
+Tests for type_checker_protocol.
+
+We test:
+  1. TypeErrorDiagnostic construction and immutability
+  2. TypeCheckResult construction, .ok property, and immutability
+  3. That a concrete mock class structurally satisfies the Protocol
+  4. Duck typing (no explicit inheritance required)
+  5. Edge cases: empty errors list, multiple errors, partial AST on failure
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import FrozenInstanceError
+from typing import runtime_checkable
+
+import pytest
+
+from type_checker_protocol import TypeCheckResult, TypeChecker, TypeErrorDiagnostic
+from type_checker_protocol.protocol import ASTIn, ASTOut  # noqa: F401 — imported for annotation use
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class SimpleNode:
+    """A minimal untyped AST node used in tests."""
+
+    kind: str
+    value: str = ""
+
+
+@dataclasses.dataclass
+class TypedNode:
+    """A minimal typed AST node used in tests."""
+
+    kind: str
+    value: str = ""
+    resolved_type: str = "unknown"
+
+
+class GoodTypeChecker:
+    """Concrete implementation that always succeeds.
+
+    This class does NOT inherit from TypeChecker — it relies entirely on
+    structural subtyping (duck typing).
+    """
+
+    def check(self, ast: SimpleNode) -> TypeCheckResult[TypedNode]:
+        """Annotate the node with a trivial type."""
+        typed = TypedNode(kind=ast.kind, value=ast.value, resolved_type="int")
+        return TypeCheckResult(typed_ast=typed, errors=[])
+
+
+class BadTypeChecker:
+    """Concrete implementation that always reports one type error."""
+
+    def check(self, ast: SimpleNode) -> TypeCheckResult[TypedNode]:
+        """Return an error for every node."""
+        err = TypeErrorDiagnostic(
+            message=f"Unknown kind: {ast.kind}",
+            line=1,
+            column=1,
+        )
+        typed = TypedNode(kind=ast.kind, value=ast.value, resolved_type="error")
+        return TypeCheckResult(typed_ast=typed, errors=[err])
+
+
+class MultiErrorTypeChecker:
+    """Concrete implementation that reports multiple errors."""
+
+    def check(self, ast: SimpleNode) -> TypeCheckResult[TypedNode]:
+        """Return two errors."""
+        errors = [
+            TypeErrorDiagnostic(message="First error", line=1, column=1),
+            TypeErrorDiagnostic(message="Second error", line=2, column=5),
+        ]
+        typed = TypedNode(kind=ast.kind, value=ast.value, resolved_type="error")
+        return TypeCheckResult(typed_ast=typed, errors=errors)
+
+
+# ---------------------------------------------------------------------------
+# TypeErrorDiagnostic tests
+# ---------------------------------------------------------------------------
+
+
+class TestTypeErrorDiagnostic:
+    """Tests for the TypeErrorDiagnostic frozen dataclass."""
+
+    def test_construction_with_all_fields(self) -> None:
+        """Can construct a diagnostic with message, line, and column."""
+        diag = TypeErrorDiagnostic(message="Type mismatch", line=3, column=7)
+        assert diag.message == "Type mismatch"
+        assert diag.line == 3
+        assert diag.column == 7
+
+    def test_construction_with_line_one(self) -> None:
+        """Line 1 column 1 is a valid location (first token in source)."""
+        diag = TypeErrorDiagnostic(message="Error at start", line=1, column=1)
+        assert diag.line == 1
+        assert diag.column == 1
+
+    def test_frozen_message(self) -> None:
+        """Mutating message raises FrozenInstanceError."""
+        diag = TypeErrorDiagnostic(message="Immutable", line=1, column=1)
+        with pytest.raises(FrozenInstanceError):
+            diag.message = "Changed"  # type: ignore[misc]
+
+    def test_frozen_line(self) -> None:
+        """Mutating line raises FrozenInstanceError."""
+        diag = TypeErrorDiagnostic(message="Immutable", line=5, column=2)
+        with pytest.raises(FrozenInstanceError):
+            diag.line = 99  # type: ignore[misc]
+
+    def test_frozen_column(self) -> None:
+        """Mutating column raises FrozenInstanceError."""
+        diag = TypeErrorDiagnostic(message="Immutable", line=5, column=2)
+        with pytest.raises(FrozenInstanceError):
+            diag.column = 99  # type: ignore[misc]
+
+    def test_equality(self) -> None:
+        """Two diagnostics with the same fields are equal (dataclass __eq__)."""
+        a = TypeErrorDiagnostic(message="msg", line=1, column=1)
+        b = TypeErrorDiagnostic(message="msg", line=1, column=1)
+        assert a == b
+
+    def test_inequality_different_line(self) -> None:
+        """Diagnostics with different line numbers are not equal."""
+        a = TypeErrorDiagnostic(message="msg", line=1, column=1)
+        b = TypeErrorDiagnostic(message="msg", line=2, column=1)
+        assert a != b
+
+    def test_inequality_different_message(self) -> None:
+        """Diagnostics with different messages are not equal."""
+        a = TypeErrorDiagnostic(message="error A", line=1, column=1)
+        b = TypeErrorDiagnostic(message="error B", line=1, column=1)
+        assert a != b
+
+    def test_hashable(self) -> None:
+        """Frozen dataclasses are hashable — can be used in sets and as dict keys."""
+        diag = TypeErrorDiagnostic(message="msg", line=1, column=1)
+        s = {diag}
+        assert diag in s
+
+    def test_repr_contains_message(self) -> None:
+        """repr() should mention the message so it shows up in test failure output."""
+        diag = TypeErrorDiagnostic(message="Something broke", line=3, column=4)
+        assert "Something broke" in repr(diag)
+
+
+# ---------------------------------------------------------------------------
+# TypeCheckResult tests
+# ---------------------------------------------------------------------------
+
+
+class TestTypeCheckResult:
+    """Tests for the TypeCheckResult frozen dataclass."""
+
+    def test_ok_when_no_errors(self) -> None:
+        """ok is True when errors list is empty."""
+        node = TypedNode(kind="int")
+        result = TypeCheckResult(typed_ast=node, errors=[])
+        assert result.ok is True
+
+    def test_not_ok_when_errors_present(self) -> None:
+        """ok is False when there is at least one error."""
+        node = TypedNode(kind="bad")
+        err = TypeErrorDiagnostic(message="error", line=1, column=1)
+        result = TypeCheckResult(typed_ast=node, errors=[err])
+        assert result.ok is False
+
+    def test_ok_with_default_empty_errors(self) -> None:
+        """errors defaults to empty list; ok is True."""
+        node = TypedNode(kind="int")
+        result = TypeCheckResult(typed_ast=node)
+        assert result.ok is True
+
+    def test_typed_ast_accessible(self) -> None:
+        """typed_ast is accessible after construction."""
+        node = TypedNode(kind="string", resolved_type="str")
+        result = TypeCheckResult(typed_ast=node, errors=[])
+        assert result.typed_ast.resolved_type == "str"
+
+    def test_partial_ast_with_errors(self) -> None:
+        """typed_ast is accessible even when errors are present (partial annotation)."""
+        node = TypedNode(kind="broken", resolved_type="error")
+        err = TypeErrorDiagnostic(message="bad type", line=2, column=3)
+        result = TypeCheckResult(typed_ast=node, errors=[err])
+        assert result.ok is False
+        assert result.typed_ast.resolved_type == "error"
+        assert result.errors[0].line == 2
+
+    def test_multiple_errors(self) -> None:
+        """errors list can hold multiple diagnostics."""
+        node = TypedNode(kind="broken")
+        errors = [
+            TypeErrorDiagnostic(message="error 1", line=1, column=1),
+            TypeErrorDiagnostic(message="error 2", line=5, column=10),
+            TypeErrorDiagnostic(message="error 3", line=10, column=3),
+        ]
+        result = TypeCheckResult(typed_ast=node, errors=errors)
+        assert result.ok is False
+        assert len(result.errors) == 3
+
+    def test_frozen_typed_ast(self) -> None:
+        """Mutating typed_ast raises FrozenInstanceError."""
+        node = TypedNode(kind="int")
+        result = TypeCheckResult(typed_ast=node, errors=[])
+        with pytest.raises(FrozenInstanceError):
+            result.typed_ast = TypedNode(kind="str")  # type: ignore[misc]
+
+    def test_frozen_errors(self) -> None:
+        """Mutating errors raises FrozenInstanceError."""
+        node = TypedNode(kind="int")
+        result = TypeCheckResult(typed_ast=node, errors=[])
+        with pytest.raises(FrozenInstanceError):
+            result.errors = []  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Protocol structural subtyping tests
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolStructuralSubtyping:
+    """Verify that concrete implementations satisfy the TypeChecker Protocol."""
+
+    def test_good_checker_satisfies_protocol(self) -> None:
+        """GoodTypeChecker satisfies TypeChecker without inheriting from it."""
+        # If GoodTypeChecker didn't satisfy the protocol, this type-annotation
+        # would be wrong (mypy would catch it).  At runtime we verify the
+        # duck-typed call works correctly.
+        checker: TypeChecker[SimpleNode, TypedNode] = GoodTypeChecker()
+        node = SimpleNode(kind="literal", value="42")
+        result = checker.check(node)
+        assert result.ok is True
+        assert result.typed_ast.resolved_type == "int"
+
+    def test_bad_checker_satisfies_protocol(self) -> None:
+        """BadTypeChecker satisfies TypeChecker and returns errors correctly."""
+        checker: TypeChecker[SimpleNode, TypedNode] = BadTypeChecker()
+        node = SimpleNode(kind="??")
+        result = checker.check(node)
+        assert result.ok is False
+        assert len(result.errors) == 1
+        assert "??" in result.errors[0].message
+
+    def test_multi_error_checker_satisfies_protocol(self) -> None:
+        """MultiErrorTypeChecker satisfies TypeChecker with multiple errors."""
+        checker: TypeChecker[SimpleNode, TypedNode] = MultiErrorTypeChecker()
+        node = SimpleNode(kind="bad")
+        result = checker.check(node)
+        assert result.ok is False
+        assert len(result.errors) == 2
+
+    def test_no_inheritance_required(self) -> None:
+        """The concrete checker does not inherit from TypeChecker at all."""
+        assert TypeChecker not in GoodTypeChecker.__mro__
+        assert TypeChecker not in BadTypeChecker.__mro__
+
+    def test_duck_typing_with_inline_class(self) -> None:
+        """An anonymous inline class satisfies the protocol (duck typing)."""
+
+        class InlineChecker:
+            def check(self, ast: SimpleNode) -> TypeCheckResult[TypedNode]:
+                return TypeCheckResult(
+                    typed_ast=TypedNode(kind=ast.kind, resolved_type="bool"),
+                    errors=[],
+                )
+
+        checker: TypeChecker[SimpleNode, TypedNode] = InlineChecker()
+        result = checker.check(SimpleNode(kind="bool_expr"))
+        assert result.ok is True
+        assert result.typed_ast.resolved_type == "bool"
+
+    def test_pipeline_function_accepts_any_conforming_checker(self) -> None:
+        """A function typed with TypeChecker[In, Out] accepts any conforming impl."""
+
+        def run_check(
+            checker: TypeChecker[SimpleNode, TypedNode],
+            ast: SimpleNode,
+        ) -> TypeCheckResult[TypedNode]:
+            return checker.check(ast)
+
+        good_result = run_check(GoodTypeChecker(), SimpleNode(kind="x"))
+        bad_result = run_check(BadTypeChecker(), SimpleNode(kind="x"))
+        assert good_result.ok is True
+        assert bad_result.ok is False
+
+    def test_result_errors_are_type_error_diagnostics(self) -> None:
+        """Every item in result.errors is a TypeErrorDiagnostic instance."""
+        checker = MultiErrorTypeChecker()
+        result = checker.check(SimpleNode(kind="x"))
+        for err in result.errors:
+            assert isinstance(err, TypeErrorDiagnostic)
+
+    def test_result_errors_order_preserved(self) -> None:
+        """Errors are returned in the order the checker added them."""
+        checker = MultiErrorTypeChecker()
+        result = checker.check(SimpleNode(kind="x"))
+        assert result.errors[0].message == "First error"
+        assert result.errors[1].message == "Second error"
+        assert result.errors[0].line < result.errors[1].line
+
+
+# ---------------------------------------------------------------------------
+# Import / public API tests
+# ---------------------------------------------------------------------------
+
+
+class TestPublicAPI:
+    """Verify the public API exported from __init__.py."""
+
+    def test_type_checker_importable_from_package(self) -> None:
+        """TypeChecker is importable from the top-level package."""
+        from type_checker_protocol import TypeChecker as TC  # noqa: F401
+
+        assert TC is TypeChecker
+
+    def test_type_check_result_importable_from_package(self) -> None:
+        """TypeCheckResult is importable from the top-level package."""
+        from type_checker_protocol import TypeCheckResult as TCR  # noqa: F401
+
+        assert TCR is TypeCheckResult
+
+    def test_type_error_diagnostic_importable_from_package(self) -> None:
+        """TypeErrorDiagnostic is importable from the top-level package."""
+        from type_checker_protocol import TypeErrorDiagnostic as TED  # noqa: F401
+
+        assert TED is TypeErrorDiagnostic
+
+    def test_all_exports_present(self) -> None:
+        """__all__ contains the three public names."""
+        import type_checker_protocol as pkg
+
+        assert set(pkg.__all__) == {"TypeChecker", "TypeCheckResult", "TypeErrorDiagnostic"}

--- a/code/specs/NIB00-nib-language.md
+++ b/code/specs/NIB00-nib-language.md
@@ -1,0 +1,513 @@
+# NIB00 — Nib Language Specification
+
+## Overview
+
+Nib is a safe, statically-typed toy programming language designed to compile down to
+Intel 4004 machine code. The name is a pun on "nibble" — the 4-bit quantity that is
+the native data size of the 4004. You write Nib source code; the compiler produces a
+binary image that can be burned to 4004 ROM.
+
+### Why Nib Exists
+
+The Intel 4004 (released November 1971) was the world's first commercial
+microprocessor. Federico Faggin, Ted Hoff, and Stanley Mazor designed it at Intel for
+the Busicom 141-PF desktop calculator. It was a 4-bit CPU with:
+
+- 2,300 transistors
+- 740 kHz clock speed
+- 4-bit data registers
+- 12-bit program counter (addresses 4 KB of ROM)
+- A **3-level hardware call stack** (no software stack in RAM)
+- 640 **nibbles** (320 bytes) of RAM — with only 160 bytes addressable as general RAM
+- 46 instructions
+
+Writing software for the 4004 in raw assembly is error-prone:
+
+- The programmer must manually track which registers are live
+- Overflow behavior is implicit and easy to miss
+- The 3-level stack constraint is not enforced by the assembler
+- BCD arithmetic requires manual DAA (decimal adjust) instructions
+
+Nib solves this by providing a higher-level language that:
+
+1. **Expresses overflow semantics explicitly** — `+%` wraps, `+?` saturates
+2. **Enforces hardware constraints statically** — call depth, RAM usage, no recursion
+3. **Gives the compiler enough information** to generate correct 4004 code
+4. **Reads like modern code** while producing code that would run on 1971 silicon
+
+### Relationship to the Coding-Adventures Stack
+
+Nib sits on top of the existing Intel 4004 simulator layer:
+
+```
+Logic Gates → Arithmetic → 4004 Gate-Level → 4004 Behavioral Simulator
+                                                          ↑
+Nib Source → [Lexer] → [Parser] → [Semantic Checker] → [4004 Code Generator] → ROM Binary
+```
+
+The Nib compiler does NOT go through the generic VM layer. It targets 4004 assembly
+directly, then assembles to Intel HEX format for burning to ROM.
+
+---
+
+## Intel 4004 Hardware Constraints
+
+Understanding these constraints is essential to understanding why Nib looks the way
+it does.
+
+### Register File
+
+The 4004 has **16 registers**, each holding 4 bits (one nibble). They are numbered R0
+through R15. Registers are also organized as 8 **register pairs** for 8-bit operations:
+
+| Pair | High Register | Low Register |
+|------|--------------|-------------|
+| P0   | R0           | R1          |
+| P1   | R2           | R3          |
+| P2   | R4           | R5          |
+| P3   | R6           | R7          |
+| P4   | R8           | R9          |
+| P5   | R10          | R11         |
+| P6   | R12          | R13         |
+| P7   | R14          | R15         |
+
+A pair holds an 8-bit value: `pair_value = (R_high << 4) | R_low`.
+
+### The Accumulator
+
+Most arithmetic goes through a special register called the **accumulator** (A). It is
+also 4 bits wide. The 4004 is an **accumulator architecture**: you load a value into
+A, perform an operation, and the result is stored back in A.
+
+This is very different from modern CPUs (x86, ARM, RISC-V) where any register can be
+the destination of any instruction.
+
+### Call Stack
+
+The 4004 has a **hardware call stack** with exactly **3 levels**. When you call a
+subroutine (JMS instruction), the 12-bit return address is pushed onto this stack.
+When the subroutine returns (BBL instruction), the address is popped. There is no
+software stack, no stack pointer, and no way to save more than 3 return addresses.
+
+Consequence: **maximum call depth is 3**. If you have function A calling function B
+calling function C calling function D, function D has no way to return — it would
+need a 4th stack level that does not exist.
+
+Nib enforces: the static call graph must have depth ≤ 2 (so with the main function
+occupying level 1, the chain A→B→C is the deepest allowed).
+
+### RAM
+
+The 4004's RAM is organized in a hierarchy of banks → registers → characters:
+
+```
+4 banks × 4 registers/bank × 16 main characters/register = 256 nibbles (128 bytes)
+4 banks × 4 registers/bank × 4 status characters/register = 64 nibbles (32 bytes)
+Total: 320 nibbles = 160 bytes
+```
+
+But only the main characters are general-purpose storage. Status characters are
+reserved for I/O. So the usable general RAM is:
+
+```
+256 nibbles = 128 bytes of main RAM
+```
+
+The 4004 documentation often cites "640 nibbles" but most of that is status RAM
+and output port latches. Nib conservatively limits static RAM to 160 bytes (the
+total of main + status, as a safe upper bound the compiler can check statically).
+
+### ROM
+
+4 KB of ROM (4096 × 8-bit bytes). This holds the program code. Nib programs compile
+to 4004 assembly and then to binary ROM images. The compiler must ensure the compiled
+program fits within 4096 bytes.
+
+### No Multiply, No Divide
+
+The 4004 instruction set has **no multiplication or division instructions**. It has:
+- ADD (add to accumulator with carry)
+- SUB (subtract from accumulator with borrow)
+- Logical operations (AND, OR, XOR, complement)
+- Rotate (RAL/RAR — rotate accumulator left/right through carry)
+- Increment/decrement for registers and pairs
+
+Multiplication requires a software loop; division requires long division in software.
+Both are expensive in ROM and RAM. Nib v1 omits these operations entirely.
+
+---
+
+## Type System
+
+Nib has exactly four types. This minimal type system reflects the 4004's native data
+sizes.
+
+### `u4` — Unsigned 4-bit Integer
+
+- Storage: 1 nibble (one 4004 register, R0–R15)
+- Range: 0 to 15 (inclusive)
+- Operations: `+`, `-`, `+%`, `+?`, `&`, `|`, `^`, `~`, comparisons
+
+The 4004's natural word size. Most BCD digits, nibble masks, and small counters fit
+in u4. Overflow wraps unless you use `+%` (explicit wrap) or `+?` (saturate).
+
+### `u8` — Unsigned 8-bit Integer
+
+- Storage: 1 register pair (two nibbles in adjacent registers, e.g. R0:R1 = P0)
+- Range: 0 to 255 (inclusive)
+- Operations: same as u4, but multi-step on the 4004
+
+An 8-bit quantity. Useful for byte addresses, loop trip counts up to 255, and
+accumulating two BCD digits. The 4004 handles 8-bit values by operating on each
+nibble separately, then combining them.
+
+### `bcd` — Binary-Coded Decimal
+
+- Storage: 1 nibble (same as u4)
+- Range: 0 to 9 (values 10–15 are invalid — compiler error if proven out-of-range)
+- Operations: `+` (with automatic DAA), comparisons
+
+BCD is the 4004's raison d'être. The original Busicom calculator stored each decimal
+digit in one BCD nibble. The 4004's `DAA` instruction adjusts the result of an ADD
+to keep the value in the 0–9 range.
+
+In Nib, `bcd +` automatically emits an ADD followed by DAA. You do not need to write
+DAA yourself. Out-of-range BCD literals (e.g. `bcd = 10`) are rejected at compile
+time.
+
+### `bool` — Boolean
+
+- Storage: 1 nibble (stored as 0 for false, 1 for true)
+- Range: `true` (1) or `false` (0)
+- Operations: `!`, `&&`, `||`, `==`, `!=`
+
+The 4004 has no dedicated boolean type. Booleans are stored as nibbles with the
+convention that 0 = false and non-zero = true. The compiler generates appropriate
+test-and-branch sequences for logical operators.
+
+---
+
+## Operators
+
+### Arithmetic Operators
+
+| Operator | Name              | Types        | Description                                      |
+|----------|-------------------|--------------|--------------------------------------------------|
+| `+`      | Add               | u4, u8, bcd  | Add. Compiler warns if overflow is provable.     |
+| `-`      | Subtract          | u4, u8       | Subtract. Borrows propagate for multi-nibble.    |
+| `+%`     | Wrapping Add      | u4, u8       | Add, then mask to type width. Never overflows.   |
+| `+?`     | Saturating Add    | u4, u8, bcd  | Add, then clamp to type maximum. Never wraps.    |
+
+Note: `*` and `/` are reserved tokens but **not available in v1**. See "What's NOT in v1".
+
+### Bitwise Operators
+
+| Operator | Name              | Types        | Description                                      |
+|----------|-------------------|--------------|--------------------------------------------------|
+| `&`      | Bitwise AND       | u4, u8       | ANL instruction on the 4004.                     |
+| `\|`     | Bitwise OR        | u4, u8       | ORL instruction on the 4004.                     |
+| `^`      | Bitwise XOR       | u4, u8       | XRL instruction on the 4004.                     |
+| `~`      | Bitwise NOT       | u4, u8       | CMA (complement accumulator) on the 4004.        |
+
+### Comparison Operators
+
+| Operator | Name              | Result | Description                                      |
+|----------|-------------------|--------|--------------------------------------------------|
+| `==`     | Equal             | bool   | Implemented via SUB + zero check.               |
+| `!=`     | Not Equal         | bool   | Implemented via SUB + non-zero check.           |
+| `<`      | Less Than         | bool   | Implemented via SUB + carry check.              |
+| `>`      | Greater Than      | bool   | Implemented via SUB with operands swapped.       |
+| `<=`     | Less or Equal     | bool   | Combination of == and <.                        |
+| `>=`     | Greater or Equal  | bool   | Combination of == and >.                        |
+
+### Logical Operators
+
+| Operator | Name              | Result | Description                                      |
+|----------|-------------------|--------|--------------------------------------------------|
+| `&&`     | Logical AND       | bool   | Short-circuit: right not evaluated if left false.|
+| `\|\|`   | Logical OR        | bool   | Short-circuit: right not evaluated if left true. |
+| `!`      | Logical NOT       | bool   | Negates a boolean value.                         |
+
+### Operator Precedence Table
+
+Listed from lowest precedence (evaluated last) to highest (evaluated first):
+
+| Level | Operators           | Associativity |
+|-------|---------------------|---------------|
+| 1     | `\|\|`              | Left          |
+| 2     | `&&`                | Left          |
+| 3     | `==`, `!=`          | Left          |
+| 4     | `<`, `>`, `<=`, `>=`| Left          |
+| 5     | `+`, `-`, `+%`, `+?`| Left          |
+| 6     | `&`, `\|`, `^`      | Left          |
+| 7     | `!`, `~` (unary)    | Right (prefix)|
+| 8     | Primary             | —             |
+
+---
+
+## Grammar Reference
+
+The complete grammar in EBNF notation (matches `code/grammars/nib.grammar`):
+
+```
+program       = { top_decl } ;
+
+top_decl      = const_decl | static_decl | fn_decl ;
+
+const_decl    = "const" NAME ":" type "=" expr ";" ;
+static_decl   = "static" NAME ":" type "=" expr ";" ;
+
+fn_decl       = "fn" NAME "(" [ param_list ] ")" [ "->" type ] block ;
+param_list    = param { "," param } ;
+param         = NAME ":" type ;
+
+block         = "{" { stmt } "}" ;
+
+stmt          = let_stmt
+              | assign_stmt
+              | return_stmt
+              | for_stmt
+              | if_stmt
+              | expr_stmt
+              ;
+
+let_stmt      = "let" NAME ":" type "=" expr ";" ;
+assign_stmt   = NAME "=" expr ";" ;
+return_stmt   = "return" expr ";" ;
+for_stmt      = "for" NAME ":" type "in" expr ".." expr block ;
+if_stmt       = "if" expr block [ "else" block ] ;
+expr_stmt     = expr ";" ;
+
+type          = "u4" | "u8" | "bcd" | "bool" ;
+
+expr          = or_expr ;
+or_expr       = and_expr { "||" and_expr } ;
+and_expr      = eq_expr { "&&" eq_expr } ;
+eq_expr       = cmp_expr { ( "==" | "!=" ) cmp_expr } ;
+cmp_expr      = add_expr { ( "<" | ">" | "<=" | ">=" ) add_expr } ;
+add_expr      = bitwise_expr { ( "+" | "-" | "+%" | "+?" ) bitwise_expr } ;
+bitwise_expr  = unary_expr { ( "&" | "|" | "^" ) unary_expr } ;
+unary_expr    = ( "!" | "~" ) unary_expr | primary ;
+primary       = INT_LIT
+              | HEX_LIT
+              | "true"
+              | "false"
+              | call_expr
+              | NAME
+              | "(" expr ")"
+              ;
+call_expr     = NAME "(" [ arg_list ] ")" ;
+arg_list      = expr { "," expr } ;
+```
+
+---
+
+## Safety Invariants
+
+The Nib compiler statically enforces the following invariants. A program that violates
+any of these is rejected at compile time with a descriptive error message.
+
+### 1. Call Depth ≤ 2
+
+The Intel 4004 has a 3-level hardware call stack. Level 1 is always occupied by the
+return address of the currently-executing function. This leaves 2 levels for nested
+calls.
+
+The compiler builds a **static call graph** — a directed graph where an edge from
+function A to function B means "A calls B". It then computes the longest path from
+any entry point (`main`). If this path has more than 2 edges, compilation fails.
+
+Example (rejected):
+```nib
+fn main() { step1(); }
+fn step1() { step2(); }
+fn step2() { step3(); }   // depth = 3 — ERROR
+fn step3() { }
+```
+
+### 2. Static RAM ≤ 160 Bytes
+
+The total size of all `static` variable declarations must not exceed 160 bytes (320
+nibbles). The compiler sums the sizes of all static variables:
+
+- `u4` = 1 nibble
+- `u8` = 2 nibbles
+- `bcd` = 1 nibble
+- `bool` = 1 nibble
+
+If the total exceeds 320 nibbles, compilation fails.
+
+### 3. No Recursion
+
+A function may not call itself, directly or indirectly. The compiler checks the static
+call graph for cycles. Any cycle (even indirect: A→B→A) is a compile error.
+
+Recursion would require a software stack (to save local state across recursive calls),
+which requires RAM that the 4004 does not have in useful quantity. And even if it did,
+the 3-level hardware stack would overflow after 3 recursive calls.
+
+### 4. No Heap
+
+Nib has no dynamic memory allocation — no `malloc`, no `new`, no garbage collector.
+All memory is either:
+- **Stack-allocated**: `let` variables in function bodies (allocated in registers)
+- **Static**: `static` variables in ROM-mapped data (allocated at link time)
+- **Literals**: constant values embedded in ROM
+
+This matches the 4004's memory model exactly.
+
+### 5. Loop Bounds Must Be Const or Literal
+
+For loops must have bounds that are known at compile time:
+
+```nib
+// Allowed — literal bounds:
+for i: u4 in 0..8 { ... }
+
+// Allowed — const bounds:
+const COUNT: u4 = 8;
+for i: u4 in 0..COUNT { ... }
+
+// Rejected — variable bounds:
+let n: u4 = get_input();
+for i: u4 in 0..n { ... }  // ERROR: n is not const
+```
+
+This restriction exists because the 4004's DJNZ (decrement and jump) loop pattern
+requires the trip count to be loaded into a register at loop entry. If the bound is
+a variable, computing the trip count requires subtraction and potentially overflow
+checks, which eat precious instructions and registers.
+
+---
+
+## Example Programs
+
+### Example 1: BCD Digit Addition
+
+```nib
+// Add two BCD digits, producing a sum and a carry.
+// Returns the sum digit in the low nibble, carry in the high nibble.
+fn bcd_add(a: bcd, b: bcd) -> u8 {
+    let sum: u4 = a + b;
+    if sum >= 10 {
+        // Carry out: sum wraps around 10 (like decimal addition)
+        let adjusted: bcd = sum - 10;
+        return adjusted | 0x10;  // high nibble = 1 (carry), low nibble = adjusted digit
+    } else {
+        return sum;  // no carry, high nibble = 0
+    }
+}
+```
+
+### Example 2: Nibble Extraction
+
+```nib
+// Extract the high nibble of an 8-bit value.
+// Example: high_nibble(0xAB) = 0xA
+fn high_nibble(x: u8) -> u4 {
+    // Shift right by 4 positions using bitwise tricks.
+    // Nib v1 has no shift operator, so we rotate via carry.
+    // (In practice the compiler emits RAR x4 + mask sequence.)
+    let hi: u4 = (x & 0xF0) >> 4;  // Note: >> reserved for v2; shown for clarity
+    return hi;
+}
+
+// Extract the low nibble of an 8-bit value.
+// Example: low_nibble(0xAB) = 0xB
+fn low_nibble(x: u8) -> u4 {
+    return x & 0x0F;
+}
+```
+
+### Example 3: Counting Loop
+
+```nib
+// Sum the BCD digits 0..9 (should equal 45).
+static total: u8 = 0;
+
+fn sum_digits() {
+    for i: bcd in 0..9 {
+        total = total + i;
+    }
+}
+
+fn main() {
+    sum_digits();
+}
+```
+
+### Example 4: Wrapping Counter
+
+```nib
+// A 4-bit wrapping counter that rolls over from 15 to 0.
+// Models a 4004 counter register that cycles endlessly.
+static counter: u4 = 0;
+
+fn tick() {
+    counter = counter +% 1;  // +% means: wrap at 16 (0..15, then 0 again)
+}
+
+fn main() {
+    for cycle: u8 in 0..255 {
+        tick();
+    }
+}
+```
+
+### Example 5: Saturating Accumulator
+
+```nib
+// Accumulate values but never exceed 9 (max BCD digit).
+// Models a BCD accumulator with saturation rather than overflow.
+static accumulator: u4 = 0;
+
+fn add_clamped(delta: u4) {
+    accumulator = accumulator +? delta;  // +? means: clamp at 15 (u4 max)
+}
+```
+
+---
+
+## What Is NOT in Nib v1
+
+These features are intentionally absent in v1. They may appear in future versions or
+companion libraries.
+
+| Feature          | Reason for exclusion                                         |
+|------------------|--------------------------------------------------------------|
+| Multiplication   | 4004 has no MUL instruction; software mul is expensive       |
+| Division         | 4004 has no DIV instruction; software div is expensive       |
+| While loops      | For loops with const bounds are sufficient for v1            |
+| Pointers/refs    | 4004's addressing model doesn't map well to pointers          |
+| Arrays           | Would require dynamic addressing; reserved for v2            |
+| Strings          | 4004 has no string support whatsoever                        |
+| Floating-point   | 4004 has no FPU; software float is impractical               |
+| Signed integers  | 4004 has no signed arithmetic instructions                   |
+| Shift operators  | Available via DAA/rotate workaround; explicit in v2          |
+| Struct/record    | No compound types; 4 primitive types are sufficient          |
+| Imports/modules  | Single-file programs only in v1                              |
+| Generics         | Not needed given the minimal type system                     |
+| Error handling   | No exceptions; error codes via return values                 |
+
+---
+
+## Implementation Status
+
+| Phase | Description                               | PR   | Status     |
+|-------|-------------------------------------------|------|------------|
+| 1     | Grammar files + spec documents            | PR 1 | This PR    |
+| 2     | Lexer (Python)                            | PR 2 | Planned    |
+| 3     | Parser (Python)                           | PR 3 | Planned    |
+| 4     | Semantic checker + type checker (Python)  | PR 4 | Planned    |
+| 5     | 4004 code generator (Python)              | PR 5 | Planned    |
+| 6     | Assembler + Intel HEX packager (Python)   | PR 6 | Planned    |
+| 7     | End-to-end tests + example programs       | PR 7 | Planned    |
+| 8     | Multi-language ports (Go, Rust, TypeScript)| PR 8| Planned    |
+
+---
+
+## Version History
+
+| Version | Date       | Description                  |
+|---------|------------|------------------------------|
+| 0.1.0   | 2026-04-12 | Initial specification draft  |

--- a/code/specs/NIB01-intel-4004-backend.md
+++ b/code/specs/NIB01-intel-4004-backend.md
@@ -1,0 +1,569 @@
+# NIB01 — Intel 4004 Backend Specification
+
+## Overview
+
+This document specifies the Nib compiler's backend: the code generator that translates
+the Nib compiler's intermediate representation (IR) into Intel 4004 assembly text, and
+the two-pass assembler that converts that assembly text into a binary ROM image encoded
+in Intel HEX format.
+
+The backend has three stages:
+
+```
+Nib IR (from semantic checker)
+    ↓  [Code Generator]
+4004 Assembly Text (.asm)
+    ↓  [Two-Pass Assembler]
+Relocatable Object (label → address map)
+    ↓  [Intel HEX Packager]
+Intel HEX File (.hex)
+    ↓  [ROM Programmer]
+4004 ROM Chip
+```
+
+### Relationship to the Simulator
+
+The 4004 behavioral simulator (`code/packages/*/intel4004-sim`) and gate-level
+simulator (`code/packages/*/intel4004-gatelevel`) can both execute the binary output
+of this backend. This means the full pipeline is:
+
+```
+Write Nib source
+  → compile with nibcc
+  → run on intel4004-sim (behavioral, fast)
+  → run on intel4004-gatelevel (gates, slow but accurate to silicon)
+```
+
+---
+
+## Intel 4004 ISA Overview
+
+The Intel 4004 (1971) has 46 instructions. They fall into seven categories:
+
+### Machine Word Format
+
+Instructions are either **1 byte** (8 bits) or **2 bytes** (16 bits). The first byte
+always contains the opcode. Some instructions pack small operands (register numbers,
+condition codes) into the opcode byte itself.
+
+```
+1-byte instruction:  [opcode:4][operand:4]
+2-byte instruction:  [opcode:4][operand:4]  [data:8]
+```
+
+The 4004 fetches 2 bytes at a time from ROM, so even 1-byte instructions have a
+partner byte. Instruction alignment therefore matters.
+
+### Register Operations
+
+| Mnemonic | Bytes | Description                                          |
+|----------|-------|------------------------------------------------------|
+| LDM d4   | 1     | Load 4-bit immediate d4 into accumulator A           |
+| LD Rr    | 1     | Load register Rr into A                              |
+| XCH Rr   | 1     | Exchange A with register Rr                          |
+| ADD Rr   | 1     | Add Rr to A; carry flag = overflow                   |
+| SUB Rr   | 1     | Subtract Rr from A; carry = borrow                   |
+| INC Rr   | 1     | Increment register Rr (does not affect carry)        |
+| FIM Rp d8| 2     | Load 8-bit immediate d8 into pair Rp                 |
+| SRC Rp   | 1     | Send pair Rp as address to RAM or ROM port           |
+| FIN Rp   | 1     | Fetch indirect: load ROM byte at PC+R0R1 into pair Rp|
+
+### Accumulator Operations
+
+| Mnemonic | Bytes | Description                                          |
+|----------|-------|------------------------------------------------------|
+| CLB      | 1     | Clear A and carry (A=0, CY=0)                        |
+| CLC      | 1     | Clear carry (CY=0)                                   |
+| CMC      | 1     | Complement carry (CY=~CY)                            |
+| CMA      | 1     | Complement A (A=~A, bitwise NOT of nibble)           |
+| RAL      | 1     | Rotate A left through carry                          |
+| RAR      | 1     | Rotate A right through carry                         |
+| TCC      | 1     | Transfer carry to A, then clear carry                |
+| DAC      | 1     | Decrement A                                          |
+| IAC      | 1     | Increment A                                          |
+| DAA      | 1     | Decimal adjust A (adds 6 if A>9 or carry is set)     |
+| KBP      | 1     | Keyboard process: decode 1-hot nibble to 0–4         |
+| DCL      | 1     | Designate command line: select RAM bank from A       |
+
+### Branching
+
+| Mnemonic   | Bytes | Description                                         |
+|------------|-------|-----------------------------------------------------|
+| JUN a12    | 2     | Jump unconditional to 12-bit address a12            |
+| JCN c a8   | 2     | Jump conditional: condition c, 8-bit page-relative  |
+| JMS a12    | 2     | Jump to subroutine at a12; push return addr to stack|
+| BBL d4     | 1     | Return from subroutine; pop stack; A = d4           |
+| ISZ Rr a8  | 2     | Increment Rr; jump to page-relative a8 if not zero  |
+
+JCN condition bits (4-bit condition code):
+- Bit 3: invert (1 = jump if condition NOT met)
+- Bit 2: test carry flag
+- Bit 1: test accumulator zero
+- Bit 0: test test pin (external hardware signal)
+
+### RAM Operations
+
+| Mnemonic | Bytes | Description                                          |
+|----------|-------|------------------------------------------------------|
+| RDM      | 1     | Read RAM main character into A                       |
+| RD0–RD3  | 1     | Read RAM status characters 0–3 into A                |
+| WRM      | 1     | Write A to RAM main character                        |
+| WR0–WR3  | 1     | Write A to RAM status characters 0–3                 |
+| ADM      | 1     | Add RAM main character to A with carry               |
+| SBM      | 1     | Subtract RAM main character from A with borrow       |
+| WMP      | 1     | Write A to RAM output port                           |
+
+### ROM Operations
+
+| Mnemonic | Bytes | Description                                          |
+|----------|-------|------------------------------------------------------|
+| WRR      | 1     | Write A to ROM I/O port (SRC must set port address)  |
+| RDR      | 1     | Read ROM I/O port into A                             |
+
+### Input Operations
+
+| Mnemonic | Bytes | Description                                          |
+|----------|-------|------------------------------------------------------|
+| WPM      | 1     | Write A to program RAM (used with extended chips)    |
+| NOP      | 1     | No operation                                         |
+
+---
+
+## Registers and Virtual Register Mapping
+
+The Nib compiler assigns virtual registers to physical 4004 registers according to
+the following convention.
+
+### Calling Convention
+
+```
+Caller-saved (scratch) registers:
+  R0–R3   — arguments / scratch (pair P0 and P1)
+  A       — accumulator (always caller-saved; every operation touches it)
+  CY      — carry flag (always caller-saved)
+
+Callee-saved registers:
+  R4–R11  — local variables (pairs P2, P3, P4, P5)
+  R12–R15 — reserved for the code generator (pairs P6, P7)
+```
+
+### Argument Passing
+
+Functions take up to 4 u4 arguments, or 2 u8 arguments, or combinations:
+
+| Argument | Physical register(s) |
+|----------|---------------------|
+| arg[0]: u4 | R0 |
+| arg[1]: u4 | R1 |
+| arg[2]: u4 | R2 |
+| arg[3]: u4 | R3 |
+| arg[0]: u8 | P0 (R0:R1) |
+| arg[1]: u8 | P1 (R2:R3) |
+
+Return values follow the same layout: u4 in R0, u8 in P0.
+
+### Local Variable Allocation
+
+The compiler performs **register allocation** for local variables (`let` declarations
+and for-loop variables). Because there is no software stack, all locals must fit in
+the physical registers R4–R11. If a function declares more locals than there are
+available registers, the compiler emits an error.
+
+Register allocation uses a simple linear scan approach:
+
+1. Assign each local a virtual register number (v0, v1, v2, …)
+2. Determine the live range of each virtual register (first use to last use)
+3. Greedily assign virtual registers to physical registers in order
+4. If no physical register is free when a virtual register becomes live, fail
+
+### Special Registers
+
+| Register | Purpose |
+|----------|---------|
+| R12:R13 (P6) | Loop counter (for for-loops) |
+| R14:R15 (P7) | Temporary scratch for multi-step operations |
+
+---
+
+## IR Opcode to 4004 Assembly Mapping
+
+The Nib IR is a simple 3-address code. Each IR instruction maps to one or more 4004
+assembly instructions.
+
+### Load Operations
+
+| IR Opcode          | 4004 Assembly                    | Notes                         |
+|--------------------|----------------------------------|-------------------------------|
+| `LOAD_IMM dst, imm`| `LDM imm; XCH dst`               | u4: imm fits in nibble        |
+| `LOAD_IMM dst, imm`| `FIM pair, imm`                  | u8: imm fits in byte          |
+| `LOAD_VAR dst, src`| `LD src; XCH dst`                | Copy between registers        |
+| `LOAD_STATIC dst, addr`| `SRC pair_for_addr; RDM; XCH dst` | Read from RAM                |
+
+### Arithmetic Operations
+
+| IR Opcode           | 4004 Assembly                    | Notes                         |
+|---------------------|----------------------------------|-------------------------------|
+| `ADD dst, a, b`     | `LD a; ADD b; XCH dst`           | u4 plain add                  |
+| `SUB dst, a, b`     | `LD a; SUB b; XCH dst`           | u4 subtract                   |
+| `WRAP_ADD dst, a, b`| `LD a; CLC; ADD b; ANL 0xF; XCH dst` | u4 wrap: mask carry away |
+| `SAT_ADD dst, a, b` | `LD a; CLC; ADD b; JCN NC skip; LDM 0xF; skip: XCH dst` | u4 saturate |
+| `BCD_ADD dst, a, b` | `LD a; CLC; ADD b; DAA; XCH dst` | bcd add with decimal adjust  |
+
+Note: `ANL` is the AND logical with accumulator. `JCN NC skip` = jump if carry not set.
+
+### Bitwise Operations
+
+| IR Opcode         | 4004 Assembly              | Notes                      |
+|-------------------|---------------------------|----------------------------|
+| `AND dst, a, b`   | `LD a; ANL b; XCH dst`    | Bitwise AND                |
+| `OR dst, a, b`    | `LD a; ORL b; XCH dst`    | Bitwise OR                 |
+| `XOR dst, a, b`   | `LD a; XRL b; XCH dst`    | Bitwise XOR                |
+| `NOT dst, a`      | `LD a; CMA; XCH dst`      | Bitwise complement nibble  |
+
+Note: The 4004 ANL/ORL/XRL instructions are immediate (operate A with a nibble
+constant). Register-to-register variants require one operand in A, the other in a
+register: load into A, then combine with XCH-then-ANL sequence. The code generator
+handles this.
+
+### Comparison Operations
+
+Comparisons use subtract-and-check-carry:
+
+| IR Opcode        | 4004 Assembly                                         |
+|------------------|-------------------------------------------------------|
+| `EQ dst, a, b`   | `LD a; SUB b; JCN ZN skip; LDM 1; JUN done; skip: LDM 0; done: XCH dst` |
+| `LT dst, a, b`   | `LD a; SUB b; TCC; XCH dst`  (TCC: transfer carry to A) |
+| `GT dst, a, b`   | `LD b; SUB a; TCC; XCH dst`  (swap operands for a>b) |
+
+### Branch Operations
+
+| IR Opcode          | 4004 Assembly                    | Notes                        |
+|--------------------|----------------------------------|------------------------------|
+| `JMP label`        | `JUN label`                      | Unconditional 12-bit jump    |
+| `JIF cond, label`  | `LD cond; JCN NZ label`          | Jump if cond != 0 (truthy)   |
+| `JNIF cond, label` | `LD cond; JCN Z label`           | Jump if cond == 0 (falsy)    |
+
+### For Loop Compilation
+
+A for loop `for i: u4 in low..high { body }` compiles to:
+
+```asm
+    ; Load loop counter = high - low
+    LDM  high
+    SUB  low         ; A = count = high - low
+    XCH  R12         ; R12 = loop counter
+
+    ; Load loop variable = low
+    LDM  low
+    XCH  Ri          ; Ri = i (loop variable, caller's register for i)
+
+loop_top:
+    ; ... body instructions ...
+
+    ; Increment i
+    LD   Ri
+    IAC
+    XCH  Ri
+
+    ; Decrement counter and loop
+    ISZ  R12, loop_top   ; R12 -= 1; if R12 != 0, jump to loop_top
+
+loop_end:
+```
+
+The `ISZ` (increment Rr, jump if not zero) instruction is used backwards here:
+we pre-decrement by using the loop counter and ISZ's semantics. Actually, since ISZ
+increments (not decrements), we use a DJNZ-like sequence:
+
+```asm
+    ; Decrement counter:
+    LD   R12
+    DAC              ; Decrement A
+    XCH  R12
+    JCN  NZ loop_top ; Jump if R12 != 0
+```
+
+### Function Call and Return
+
+| IR Opcode          | 4004 Assembly                    | Notes                         |
+|--------------------|----------------------------------|-------------------------------|
+| `CALL label`       | `JMS label`                      | Push return address, jump     |
+| `RETURN val`       | `LD val; BBL 0` OR `BBL imm`     | Return, popping stack         |
+
+`BBL d4` returns from subroutine AND loads d4 into A. For functions returning u4,
+the return value is placed in R0 (A after BBL). For void functions, `BBL 0` is used.
+
+---
+
+## Assembly Text Format
+
+The Nib code generator emits 4004 assembly text in the following format.
+
+### Structure
+
+```asm
+; Nib-generated 4004 assembly
+; Source: program.nib
+; Generated: 2026-04-12
+
+    ORG 0x000         ; Program starts at ROM address 0
+
+; --------------- static initializers ---------------
+; Initialize static variable 'counter' (at RAM address 0x00)
+    FIM  P0, 0x00     ; P0 = RAM address for 'counter'
+    SRC  P0           ; Send address
+    LDM  0            ; Initial value = 0
+    WRM               ; Write to RAM
+
+; --------------- entry point ---------------
+    JMS  main         ; Call main
+
+halt:
+    JUN  halt         ; Infinite loop (halt)
+
+; --------------- function: main ---------------
+main:
+    ; ... function body ...
+    BBL  0            ; return void
+```
+
+### ORG Directive
+
+`ORG address` sets the current assembly location counter to `address`. The 4004 ROM
+starts at address 0x000. Programs should begin with `ORG 0x000`.
+
+The 4004 has 4 pages of ROM (each 256 bytes = 0x000–0x0FF, 0x100–0x1FF, 0x200–0x2FF,
+0x300–0x3FF). Page-relative branches (`JCN`) can only jump within the current page.
+The code generator must place jump targets on the same page as their branches.
+
+### Label Syntax
+
+Labels are identifiers followed by a colon on their own line (or any line):
+
+```asm
+loop_top:
+    LD R0
+```
+
+Labels are referenced by name in branch instructions. The assembler resolves labels
+to 12-bit addresses in the second pass.
+
+### Comment Syntax
+
+Line comments start with `;`:
+
+```asm
+    LDM 5    ; load immediate 5 into A
+```
+
+Block comments are not supported. Use multiple `;` lines.
+
+### Instruction Format
+
+```asm
+    MNEMONIC  [operands]   ; optional comment
+```
+
+- Indentation: 4 spaces for instructions, 0 for labels
+- Operands are comma-separated with a single space after the mnemonic
+- Register names: `R0`–`R15`, `P0`–`P7`, `A` (accumulator), `CY` (carry)
+- Immediate values: decimal (`5`) or hex (`0xF`)
+- Addresses: hex preferred for clarity (`0x3F2`)
+
+---
+
+## Two-Pass Assembler Design
+
+The assembler processes the assembly text in two passes.
+
+### Pass 1: Symbol Collection
+
+Scan the text from top to bottom. For each line:
+
+1. Strip leading/trailing whitespace, remove comments
+2. If the line is blank after stripping, skip
+3. If the line ends with `:` (after identifier), record the label → current address
+4. Otherwise, parse the mnemonic and count the instruction size (1 or 2 bytes)
+5. Advance the location counter by the instruction size
+
+At the end of Pass 1, the **symbol table** maps every label to its ROM address.
+
+Example after Pass 1:
+```
+symbol_table = {
+    "main":     0x010,
+    "loop_top": 0x018,
+    "loop_end": 0x020,
+    "halt":     0x008,
+}
+```
+
+### Pass 2: Code Emission
+
+Scan the text again from top to bottom. For each instruction:
+
+1. Parse the mnemonic and operands
+2. If an operand is a label, look it up in the symbol table from Pass 1
+3. Verify that page-relative branches have targets on the same page
+4. Encode the instruction to bytes (see encoding tables below)
+5. Append bytes to the output buffer
+
+At the end of Pass 2, the output buffer contains the complete binary ROM image.
+
+### Instruction Encoding
+
+Each 4004 instruction maps to one or two bytes:
+
+```
+LDM d4:       0xD_ where _ = d4          (1 byte)
+LD  Rr:       0xA_ where _ = r           (1 byte)
+XCH Rr:       0xB_ where _ = r           (1 byte)
+ADD Rr:       0x8_ where _ = r           (1 byte)
+SUB Rr:       0x9_ where _ = r           (1 byte)
+INC Rr:       0x6_ where _ = r           (1 byte)
+FIM Rp d8:    0x2_ 0xdd where _ = p*2, dd = d8 (2 bytes)
+CLB:          0xF0                        (1 byte)
+CLC:          0xF1                        (1 byte)
+CMC:          0xF3                        (1 byte)
+CMA:          0xF4                        (1 byte)
+RAL:          0xF5                        (1 byte)
+RAR:          0xF6                        (1 byte)
+TCC:          0xF7                        (1 byte)
+DAC:          0xF8                        (1 byte)
+IAC:          0xFA                        (1 byte)
+DAA:          0xFB                        (1 byte)
+NOP:          0x00                        (1 byte)
+JUN a12:      0x4_ 0xaa where _= a[11:8], aa = a[7:0] (2 bytes)
+JMS a12:      0x5_ 0xaa  (same encoding as JUN)       (2 bytes)
+JCN c a8:     0x1_ 0xaa where _ = c, aa = page-relative addr (2 bytes)
+ISZ Rr a8:    0x7_ 0xaa where _ = r, aa = page-relative addr (2 bytes)
+BBL d4:       0xC_ where _ = d4          (1 byte)
+SRC Rp:       0x2_ where _ = p*2+1       (1 byte)
+RDM:          0xE9                        (1 byte)
+WRM:          0xE0                        (1 byte)
+ANL:          (accumulator AND with I/O — see 4004 manual for full ANL variants)
+ORL:          (accumulator OR — see manual)
+XRL:          (accumulator XOR — see manual)
+```
+
+Note: `ANL`, `ORL`, `XRL` are ROM-port immediate operations in the official 4004 ISA,
+not register-to-register. For bitwise AND/OR/XOR between registers, the code generator
+uses the XCH/ADD/SUB trick: move one operand to a scratchpad register, XCH into A,
+then use the accumulator form.
+
+The Nib assembler supports a slightly extended pseudo-ISA that the code generator
+targets, with the assembler expanding pseudo-instructions to true 4004 bytes.
+
+### Error Handling
+
+The assembler halts with a descriptive error on:
+- Undefined label reference
+- Page-relative branch out of range (target not on same 256-byte page)
+- Value overflow (e.g., LDM with value > 15)
+- ROM overflow (program exceeds 4096 bytes)
+- Unknown mnemonic
+
+---
+
+## Intel HEX Format
+
+The final output of the assembler is an **Intel HEX** file. Intel HEX is a text format
+for representing binary data as ASCII hex digits. ROM programmers understand it
+natively.
+
+### Record Format
+
+Each line of an Intel HEX file is one **record**. Records have the format:
+
+```
+:LLAAAATT[DD...]CC
+```
+
+Where:
+- `:` — start code (colon)
+- `LL` — byte count: number of data bytes in this record (2 hex digits)
+- `AAAA` — address: 16-bit load address of the first data byte (4 hex digits)
+- `TT` — record type (2 hex digits):
+  - `00` — Data record
+  - `01` — End of File record
+- `DD...` — data bytes (2 hex digits each)
+- `CC` — checksum: two's complement of the sum of all bytes from LL to last DD
+
+### Checksum Calculation
+
+```python
+def checksum(bytes_without_colon):
+    total = sum(bytes_without_colon) & 0xFF
+    return (~total + 1) & 0xFF
+```
+
+### Example Output
+
+```
+:10000000D0A0F0F8F1F3F4FAFC4002580040005200AF
+:10001000BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBCC
+:00000001FF
+```
+
+Line 1: 16 bytes starting at address 0x0000
+Line 2: 16 bytes starting at address 0x0010
+Line 3: End of File record
+
+### ROM Packaging Constraints
+
+The 4004 ROM is divided into **pages** of 256 bytes. The Intel HEX packager must:
+
+1. Emit records of at most 16 bytes each (standard HEX line length)
+2. Group records by page (new record address when page boundary is crossed)
+3. Pad unused ROM bytes to `0xFF` (erased ROM state)
+4. Emit the End of File record (`0x01`) as the last line
+5. Ensure total ROM image size is exactly 4096 bytes
+
+The packager takes the binary output buffer from the assembler and produces the HEX
+file. It does not know about labels or the source program — it only handles bytes and
+addresses.
+
+---
+
+## Summary of Backend Passes
+
+```
+Nib IR
+  │
+  ▼  Pass: Register Allocation
+  │  - Assign virtual registers to physical R0–R15
+  │  - Fail if too many locals for available registers
+  │  - Record the allocation map
+  │
+  ▼  Pass: Code Generation
+  │  - Walk IR instructions, emit 4004 pseudo-assembly lines
+  │  - Use allocation map for register operands
+  │  - Generate labels for: function entry points, branch targets, loop tops/ends
+  │  - Emit static initializer block at ROM address 0
+  │
+  ▼  Pass: Assembly Pass 1 (Symbol Collection)
+  │  - Scan assembly text
+  │  - Count instruction sizes (1 or 2 bytes each)
+  │  - Build symbol table: label → 12-bit ROM address
+  │
+  ▼  Pass: Assembly Pass 2 (Code Emission)
+  │  - Encode each instruction to bytes
+  │  - Substitute labels with addresses from symbol table
+  │  - Verify page-relative branches are in-page
+  │  - Produce flat binary buffer
+  │
+  ▼  Pass: Intel HEX Packaging
+     - Pad binary buffer to 4096 bytes (0xFF fill)
+     - Emit records of 16 bytes each
+     - Calculate checksum per record
+     - Emit End of File record
+     → .hex file ready for ROM programmer
+```
+
+---
+
+## Version History
+
+| Version | Date       | Description                        |
+|---------|------------|------------------------------------|
+| 0.1.0   | 2026-04-12 | Initial backend specification      |


### PR DESCRIPTION
## Summary

- Adds `coding-adventures-type-checker-protocol` — a zero-dependency Python package defining the shared interface all language type checkers in this repo must implement
- `TypeChecker[ASTIn, ASTOut]` Protocol using `typing.Protocol` with structural subtyping (no inheritance required)
- `TypeCheckResult[ASTOut]` frozen dataclass carrying the typed AST and error list, with `.ok` shorthand
- `TypeErrorDiagnostic` frozen dataclass representing a single type error with `message`, `line`, and `column` source location

## Motivation

This is PR 2 of the Nib compiler pipeline. The pipeline will have many type checkers (Nib, Lattice, Mosaic, …). By defining a shared protocol now, each checker can be developed, tested, and composed independently.

## Test plan

- [ ] `pytest` passes (26 test cases across `TestTypeErrorDiagnostic`, `TestTypeCheckResult`, `TestProtocolStructuralSubtyping`, `TestPublicAPI`)
- [ ] `--cov-fail-under=80` passes
- [ ] No external dependencies — stdlib only (`typing`, `dataclasses`)
- [ ] Security review passed — zero-dependency type definitions, no user input, no network, no eval/exec/pickle

🤖 Generated with [Claude Code](https://claude.com/claude-code)