### PR TITLE
[codex] feat(barcode): port 1d symbologies to python ruby elixir

### DIFF
--- a/code/packages/elixir/barcode_1d/lib/coding_adventures/barcode_1d.ex
+++ b/code/packages/elixir/barcode_1d/lib/coding_adventures/barcode_1d.ex
@@ -3,14 +3,23 @@ defmodule CodingAdventures.Barcode1D do
   High-level 1D barcode pipeline for Elixir.
 
   This package keeps the layers separated:
-  - barcode package (`CodingAdventures.Code39`) owns encoding
+  - barcode packages own encoding
   - `barcode_layout_1d` owns geometry
   - native Paint VM packages own pixels and image encoding
   """
 
-  alias CodingAdventures.{Code39, PaintCodecPngNative, PaintVmMetalNative}
+  alias CodingAdventures.{
+    Codabar,
+    Code128,
+    Code39,
+    Ean13,
+    Itf,
+    PaintCodecPngNative,
+    PaintVmMetalNative,
+    UpcA
+  }
 
-  @type symbology :: :code39 | String.t()
+  @type symbology :: :codabar | :code128 | :code39 | :ean13 | :itf | :upca | String.t()
   @type render_error ::
           :unsupported_symbology
           | :metal_backend_unavailable
@@ -62,7 +71,12 @@ defmodule CodingAdventures.Barcode1D do
     layout_config = Keyword.get(opts, :layout_config, Code39.default_layout_config())
 
     case normalize_symbology(symbology) do
+      :codabar -> {:ok, Codabar.layout_codabar(data, layout_config)}
+      :code128 -> {:ok, Code128.layout_code128(data, layout_config)}
       :code39 -> {:ok, Code39.layout_code39(data, layout_config)}
+      :ean13 -> {:ok, Ean13.layout_ean_13(data, layout_config)}
+      :itf -> {:ok, Itf.layout_itf(data, layout_config)}
+      :upca -> {:ok, UpcA.layout_upc_a(data, layout_config)}
       :unsupported -> {:error, :unsupported_symbology}
     end
   end
@@ -100,7 +114,19 @@ defmodule CodingAdventures.Barcode1D do
 
   defp execute_scene(scene, :metal), do: PaintVmMetalNative.render(scene)
 
+  defp normalize_symbology(:codabar), do: :codabar
+  defp normalize_symbology(:code128), do: :code128
   defp normalize_symbology(:code39), do: :code39
+  defp normalize_symbology(:ean13), do: :ean13
+  defp normalize_symbology(:itf), do: :itf
+  defp normalize_symbology(:upca), do: :upca
+  defp normalize_symbology("codabar"), do: :codabar
+  defp normalize_symbology("code128"), do: :code128
   defp normalize_symbology("code39"), do: :code39
+  defp normalize_symbology("ean13"), do: :ean13
+  defp normalize_symbology("ean-13"), do: :ean13
+  defp normalize_symbology("itf"), do: :itf
+  defp normalize_symbology("upca"), do: :upca
+  defp normalize_symbology("upc-a"), do: :upca
   defp normalize_symbology(_symbology), do: :unsupported
 end

--- a/code/packages/elixir/barcode_1d/mix.exs
+++ b/code/packages/elixir/barcode_1d/mix.exs
@@ -18,10 +18,15 @@ defmodule CodingAdventures.Barcode1D.MixProject do
 
   defp deps do
     [
+      {:coding_adventures_codabar, path: "../codabar"},
+      {:coding_adventures_code128, path: "../code128"},
       {:coding_adventures_code39, path: "../code39"},
+      {:coding_adventures_ean_13, path: "../ean_13"},
+      {:coding_adventures_itf, path: "../itf"},
       {:coding_adventures_paint_vm_metal_native, path: "../paint_vm_metal_native"},
       {:coding_adventures_paint_codec_png_native, path: "../paint_codec_png_native"},
-      {:coding_adventures_pixel_container, path: "../pixel_container"}
+      {:coding_adventures_pixel_container, path: "../pixel_container"},
+      {:coding_adventures_upc_a, path: "../upc_a"}
     ]
   end
 end

--- a/code/packages/elixir/barcode_1d/test/barcode_1d_test.exs
+++ b/code/packages/elixir/barcode_1d/test/barcode_1d_test.exs
@@ -30,6 +30,37 @@ defmodule CodingAdventures.Barcode1DTest do
     assert scene.width > 0
   end
 
+  test "accepts string names for additional symbologies" do
+    cases = [
+      {"codabar", "40156"},
+      {"code128", "Code 128"},
+      {"ean-13", "400638133393"},
+      {"itf", "123456"},
+      {"upc-a", "03600029145"}
+    ]
+
+    Enum.each(cases, fn {symbology, data} ->
+      assert {:ok, scene} = Barcode1D.build_scene(data, symbology: symbology)
+      assert scene.width > 0
+    end)
+  end
+
+  test "builds scenes for additional symbologies" do
+    cases = [
+      {:codabar, "40156"},
+      {:code128, "Code 128"},
+      {:ean13, "400638133393"},
+      {:itf, "123456"},
+      {:upca, "03600029145"}
+    ]
+
+    Enum.each(cases, fn {symbology, data} ->
+      assert {:ok, scene} = Barcode1D.build_scene(data, symbology: symbology)
+      assert scene.width > 0
+      assert scene.metadata.symbology
+    end)
+  end
+
   test "resolves backend selection for supported and future platforms" do
     assert Barcode1D.current_backend({:unix, :darwin}, "aarch64-apple-darwin") == {:ok, :metal}
 
@@ -99,7 +130,7 @@ defmodule CodingAdventures.Barcode1DTest do
   end
 
   test "returns a clean error for unsupported symbologies" do
-    assert Barcode1D.render_png("HELLO-123", symbology: :ean_13) == {:error, :unsupported_symbology}
+    assert Barcode1D.render_png("HELLO-123", symbology: :qr) == {:error, :unsupported_symbology}
   end
 
   test "rejects non-binary barcode payloads" do

--- a/code/packages/elixir/codabar/BUILD
+++ b/code/packages/elixir/codabar/BUILD
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/codabar/lib/coding_adventures/codabar.ex
+++ b/code/packages/elixir/codabar/lib/coding_adventures/codabar.ex
@@ -1,0 +1,152 @@
+defmodule CodingAdventures.Codabar do
+  @moduledoc """
+  Dependency-free Codabar encoder that emits backend-neutral paint scenes.
+  """
+
+  alias CodingAdventures.BarcodeLayout1D
+
+  @default_layout_config %{
+    module_unit: 4,
+    bar_height: 120,
+    quiet_zone_modules: 10
+  }
+
+  @guards MapSet.new(~w[A B C D])
+
+  @patterns %{
+    "0" => "101010011",
+    "1" => "101011001",
+    "2" => "101001011",
+    "3" => "110010101",
+    "4" => "101101001",
+    "5" => "110101001",
+    "6" => "100101011",
+    "7" => "100101101",
+    "8" => "100110101",
+    "9" => "110100101",
+    "-" => "101001101",
+    "$" => "101100101",
+    ":" => "1101011011",
+    "/" => "1101101011",
+    "." => "1101101101",
+    "+" => "1011011011",
+    "A" => "1011001001",
+    "B" => "1001001011",
+    "C" => "1010010011",
+    "D" => "1010011001"
+  }
+
+  def default_layout_config, do: @default_layout_config
+  def default_render_config, do: @default_layout_config
+
+  def normalize_codabar(data, opts \\ []) do
+    normalized = String.upcase(data)
+
+    cond do
+      String.length(normalized) >= 2 and guard?(String.first(normalized)) and guard?(String.last(normalized)) ->
+        assert_body_chars!(String.slice(normalized, 1, String.length(normalized) - 2))
+        normalized
+
+      true ->
+        start = Keyword.get(opts, :start, "A")
+        stop = Keyword.get(opts, :stop, "A")
+
+        unless guard?(start) and guard?(stop) do
+          raise ArgumentError, "Codabar guards must be one of A, B, C, or D"
+        end
+
+        assert_body_chars!(normalized)
+        start <> normalized <> stop
+    end
+  end
+
+  def encode_codabar(data, opts \\ []) do
+    normalized = normalize_codabar(data, opts)
+
+    normalized
+    |> String.graphemes()
+    |> Enum.with_index()
+    |> Enum.map(fn {char, index} ->
+      role =
+        cond do
+          index == 0 -> "start"
+          index == String.length(normalized) - 1 -> "stop"
+          true -> "data"
+        end
+
+      %{
+        char: char,
+        pattern: Map.fetch!(@patterns, char),
+        source_index: index,
+        role: role
+      }
+    end)
+  end
+
+  def expand_codabar_runs(data, opts \\ []) do
+    encoded = encode_codabar(data, opts)
+
+    encoded
+    |> Enum.with_index()
+    |> Enum.flat_map(fn {symbol, index} ->
+      symbol_runs =
+        BarcodeLayout1D.runs_from_binary_pattern(
+          symbol.pattern,
+          source_char: symbol.char,
+          source_index: symbol.source_index
+        )
+        |> retag_runs(symbol.role)
+
+      if index < length(encoded) - 1 do
+        symbol_runs ++
+          [
+            %{
+              color: "space",
+              modules: 1,
+              source_char: symbol.char,
+              source_index: symbol.source_index,
+              role: "inter-character-gap",
+              metadata: %{}
+            }
+          ]
+      else
+        symbol_runs
+      end
+    end)
+  end
+
+  def layout_codabar(data, config \\ @default_layout_config, opts \\ []) do
+    normalized = normalize_codabar(data, opts)
+
+    BarcodeLayout1D.layout_barcode_1d(
+      expand_codabar_runs(normalized),
+      config,
+      %{
+        fill: "#000000",
+        background: "#ffffff",
+        metadata: %{
+          symbology: "codabar",
+          start: String.first(normalized),
+          stop: String.last(normalized)
+        }
+      }
+    )
+  end
+
+  def draw_codabar(data, config \\ @default_layout_config, opts \\ []),
+    do: layout_codabar(data, config, opts)
+
+  defp guard?(char), do: MapSet.member?(@guards, char)
+
+  defp assert_body_chars!(body) do
+    Enum.each(String.graphemes(body), fn char ->
+      if not Map.has_key?(@patterns, char) or guard?(char) do
+        raise ArgumentError, ~s(Invalid Codabar body character "#{char}")
+      end
+    end)
+  end
+
+  defp retag_runs(runs, role) do
+    Enum.map(runs, fn run -> %{run | role: role, metadata: Map.new(Map.get(run, :metadata, %{}))} end)
+  end
+end

--- a/code/packages/elixir/codabar/mix.exs
+++ b/code/packages/elixir/codabar/mix.exs
@@ -1,0 +1,25 @@
+defmodule CodingAdventures.Codabar.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :coding_adventures_codabar,
+      version: "0.1.0",
+      elixir: "~> 1.14",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      test_coverage: [summary: [threshold: 80]]
+    ]
+  end
+
+  def application do
+    [extra_applications: [:logger]]
+  end
+
+  defp deps do
+    [
+      {:coding_adventures_paint_instructions, path: "../paint_instructions"},
+      {:coding_adventures_barcode_layout_1d, path: "../barcode_layout_1d"}
+    ]
+  end
+end

--- a/code/packages/elixir/codabar/required_capabilities.json
+++ b/code/packages/elixir/codabar/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "elixir/codabar",
+  "capabilities": [],
+  "justification": "Pure computation package for Codabar normalization, encoding, run expansion, and paint-scene generation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/elixir/codabar/test/codabar_test.exs
+++ b/code/packages/elixir/codabar/test/codabar_test.exs
@@ -1,0 +1,25 @@
+defmodule CodingAdventures.CodabarTest do
+  use ExUnit.Case
+
+  test "module loads" do
+    assert Code.ensure_loaded?(CodingAdventures.Codabar)
+  end
+
+  test "normalizes and draws codabar" do
+    assert CodingAdventures.Codabar.normalize_codabar("40156") == "A40156A"
+
+    scene = CodingAdventures.Codabar.draw_codabar("40156")
+    assert scene.metadata.symbology == "codabar"
+    assert scene.metadata.start == "A"
+    assert scene.metadata.stop == "A"
+    assert scene.width > 0
+    assert scene.height == 120
+  end
+
+  test "expands inter-character gaps" do
+    assert Enum.any?(
+             CodingAdventures.Codabar.expand_codabar_runs("40156"),
+             &(&1.role == "inter-character-gap")
+           )
+  end
+end

--- a/code/packages/elixir/codabar/test/test_helper.exs
+++ b/code/packages/elixir/codabar/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/code/packages/elixir/code128/BUILD
+++ b/code/packages/elixir/code128/BUILD
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/code128/lib/coding_adventures/code128.ex
+++ b/code/packages/elixir/code128/lib/coding_adventures/code128.ex
@@ -1,0 +1,121 @@
+defmodule CodingAdventures.Code128 do
+  @moduledoc """
+  Dependency-free Code 128 encoder that emits backend-neutral paint scenes.
+  """
+
+  alias CodingAdventures.BarcodeLayout1D
+
+  @default_layout_config %{
+    module_unit: 4,
+    bar_height: 120,
+    quiet_zone_modules: 10
+  }
+
+  @start_b 104
+  @stop 106
+
+  @patterns ~w[
+    11011001100 11001101100 11001100110 10010011000 10010001100 10001001100 10011001000 10011000100
+    10001100100 11001001000 11001000100 11000100100 10110011100 10011011100 10011001110 10111001100
+    10011101100 10011100110 11001110010 11001011100 11001001110 11011100100 11001110100 11101101110
+    11101001100 11100101100 11100100110 11101100100 11100110100 11100110010 11011011000 11011000110
+    11000110110 10100011000 10001011000 10001000110 10110001000 10001101000 10001100010 11010001000
+    11000101000 11000100010 10110111000 10110001110 10001101110 10111011000 10111000110 10001110110
+    11101110110 11010001110 11000101110 11011101000 11011100010 11011101110 11101011000 11101000110
+    11100010110 11101101000 11101100010 11100011010 11101111010 11001000010 11110001010 10100110000
+    10100001100 10010110000 10010000110 10000101100 10000100110 10110010000 10110000100 10011010000
+    10011000010 10000110100 10000110010 11000010010 11001010000 11110111010 11000010100 10001111010
+    10100111100 10010111100 10010011110 10111100100 10011110100 10011110010 11110100100 11110010100
+    11110010010 11011011110 11011110110 11110110110 10101111000 10100011110 10001011110 10111101000
+    10111100010 11110101000 11110100010 10111011110 10111101110 11101011110 11110101110 11010000100
+    11010010000 11010011100 1100011101011
+  ]
+
+  def default_layout_config, do: @default_layout_config
+  def default_render_config, do: @default_layout_config
+
+  def normalize_code128_b(data) do
+    Enum.each(String.to_charlist(data), fn code ->
+      if code < 32 or code > 126 do
+        raise ArgumentError, "Code 128 Code Set B supports printable ASCII characters only"
+      end
+    end)
+
+    data
+  end
+
+  def value_for_code128_b_char(char), do: hd(String.to_charlist(char)) - 32
+
+  def compute_code128_checksum(values) do
+    weighted_sum =
+      values
+      |> Enum.with_index()
+      |> Enum.map(fn {value, index} -> value * (index + 1) end)
+      |> Enum.sum()
+
+    rem(@start_b + weighted_sum, 103)
+  end
+
+  def encode_code128_b(data) do
+    normalized = normalize_code128_b(data)
+
+    data_symbols =
+      normalized
+      |> String.graphemes()
+      |> Enum.with_index()
+      |> Enum.map(fn {char, index} ->
+        value = value_for_code128_b_char(char)
+
+        %{
+          label: char,
+          value: value,
+          pattern: Enum.at(@patterns, value),
+          source_index: index,
+          role: "data"
+        }
+      end)
+
+    checksum = compute_code128_checksum(Enum.map(data_symbols, & &1.value))
+
+    [
+      %{label: "Start B", value: @start_b, pattern: Enum.at(@patterns, @start_b), source_index: -1, role: "start"}
+      | data_symbols
+    ] ++
+      [
+        %{label: "Checksum #{checksum}", value: checksum, pattern: Enum.at(@patterns, checksum), source_index: String.length(normalized), role: "check"},
+        %{label: "Stop", value: @stop, pattern: Enum.at(@patterns, @stop), source_index: String.length(normalized) + 1, role: "stop"}
+      ]
+  end
+
+  def expand_code128_runs(data) do
+    Enum.flat_map(encode_code128_b(data), fn symbol ->
+      BarcodeLayout1D.runs_from_binary_pattern(
+        symbol.pattern,
+        source_char: symbol.label,
+        source_index: symbol.source_index
+      )
+      |> retag_runs(symbol.role)
+    end)
+  end
+
+  def layout_code128(data, config \\ @default_layout_config) do
+    normalized = normalize_code128_b(data)
+    checksum = encode_code128_b(normalized) |> Enum.at(-2) |> Map.fetch!(:value)
+
+    BarcodeLayout1D.layout_barcode_1d(
+      expand_code128_runs(normalized),
+      config,
+      %{
+        fill: "#000000",
+        background: "#ffffff",
+        metadata: %{symbology: "code128", code_set: "B", checksum: checksum}
+      }
+    )
+  end
+
+  def draw_code128(data, config \\ @default_layout_config), do: layout_code128(data, config)
+
+  defp retag_runs(runs, role) do
+    Enum.map(runs, fn run -> %{run | role: role, metadata: Map.new(Map.get(run, :metadata, %{}))} end)
+  end
+end

--- a/code/packages/elixir/code128/mix.exs
+++ b/code/packages/elixir/code128/mix.exs
@@ -1,0 +1,25 @@
+defmodule CodingAdventures.Code128.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :coding_adventures_code128,
+      version: "0.1.0",
+      elixir: "~> 1.14",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      test_coverage: [summary: [threshold: 80]]
+    ]
+  end
+
+  def application do
+    [extra_applications: [:logger]]
+  end
+
+  defp deps do
+    [
+      {:coding_adventures_paint_instructions, path: "../paint_instructions"},
+      {:coding_adventures_barcode_layout_1d, path: "../barcode_layout_1d"}
+    ]
+  end
+end

--- a/code/packages/elixir/code128/required_capabilities.json
+++ b/code/packages/elixir/code128/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "elixir/code128",
+  "capabilities": [],
+  "justification": "Pure computation package for Code 128 normalization, encoding, run expansion, and paint-scene generation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/elixir/code128/test/code128_test.exs
+++ b/code/packages/elixir/code128/test/code128_test.exs
@@ -1,0 +1,29 @@
+defmodule CodingAdventures.Code128Test do
+  use ExUnit.Case
+
+  test "module loads" do
+    assert Code.ensure_loaded?(CodingAdventures.Code128)
+  end
+
+  test "computes checksum and draws" do
+    values =
+      "Code 128"
+      |> String.graphemes()
+      |> Enum.map(&CodingAdventures.Code128.value_for_code128_b_char/1)
+
+    assert CodingAdventures.Code128.compute_code128_checksum(values) == 64
+
+    scene = CodingAdventures.Code128.draw_code128("Code 128")
+    assert scene.metadata.symbology == "code128"
+    assert scene.metadata.code_set == "B"
+    assert scene.width > 0
+    assert scene.height == 120
+  end
+
+  test "encodes start checksum and stop" do
+    encoded = CodingAdventures.Code128.encode_code128_b("Code 128")
+    assert hd(encoded).role == "start"
+    assert Enum.at(encoded, -2).role == "check"
+    assert List.last(encoded).role == "stop"
+  end
+end

--- a/code/packages/elixir/code128/test/test_helper.exs
+++ b/code/packages/elixir/code128/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/code/packages/elixir/ean_13/BUILD
+++ b/code/packages/elixir/ean_13/BUILD
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/ean_13/lib/coding_adventures/ean_13.ex
+++ b/code/packages/elixir/ean_13/lib/coding_adventures/ean_13.ex
@@ -1,0 +1,161 @@
+defmodule CodingAdventures.Ean13 do
+  @moduledoc """
+  Dependency-free EAN-13 encoder that emits backend-neutral paint scenes.
+  """
+
+  alias CodingAdventures.BarcodeLayout1D
+
+  @default_layout_config %{
+    module_unit: 4,
+    bar_height: 120,
+    quiet_zone_modules: 10
+  }
+
+  @side_guard "101"
+  @center_guard "01010"
+
+  @digit_patterns %{
+    "L" => ~w[0001101 0011001 0010011 0111101 0100011 0110001 0101111 0111011 0110111 0001011],
+    "G" => ~w[0100111 0110011 0011011 0100001 0011101 0111001 0000101 0010001 0001001 0010111],
+    "R" => ~w[1110010 1100110 1101100 1000010 1011100 1001110 1010000 1000100 1001000 1110100]
+  }
+
+  @left_parity_patterns ~w[
+    LLLLLL LLGLGG LLGGLG LLGGGL LGLLGG LGGLLG LGGGLL LGLGLG LGLGGL LGGLGL
+  ]
+
+  def default_layout_config, do: @default_layout_config
+  def default_render_config, do: @default_layout_config
+
+  def compute_ean_13_check_digit(payload12) do
+    assert_digits!(payload12, [12], "EAN-13 input must contain 12 digits or 13 digits")
+
+    total =
+      payload12
+      |> String.graphemes()
+      |> Enum.reverse()
+      |> Enum.with_index()
+      |> Enum.map(fn {digit, index} ->
+        String.to_integer(digit) * if(rem(index, 2) == 0, do: 3, else: 1)
+      end)
+      |> Enum.sum()
+
+    Integer.to_string(rem(10 - rem(total, 10), 10))
+  end
+
+  def normalize_ean_13(data) do
+    assert_digits!(data, [12, 13], "EAN-13 input must contain 12 digits or 13 digits")
+
+    if String.length(data) == 12 do
+      data <> compute_ean_13_check_digit(data)
+    else
+      expected = compute_ean_13_check_digit(String.slice(data, 0, 12))
+      actual = String.at(data, 12)
+
+      if expected == actual do
+        data
+      else
+        raise ArgumentError, "Invalid EAN-13 check digit: expected #{expected} but received #{actual}"
+      end
+    end
+  end
+
+  def left_parity_pattern(data) do
+    normalized = normalize_ean_13(data)
+    Enum.at(@left_parity_patterns, String.at(normalized, 0) |> String.to_integer())
+  end
+
+  def encode_ean_13(data) do
+    normalized = normalize_ean_13(data)
+    parity = left_parity_pattern(normalized)
+    digits = String.graphemes(normalized)
+
+    left_digits =
+      digits
+      |> Enum.slice(1, 6)
+      |> Enum.with_index()
+      |> Enum.map(fn {digit, offset} ->
+        encoding = String.at(parity, offset)
+
+        %{
+          digit: digit,
+          encoding: encoding,
+          pattern: @digit_patterns |> Map.fetch!(encoding) |> Enum.at(String.to_integer(digit)),
+          source_index: offset + 1,
+          role: "data"
+        }
+      end)
+
+    right_digits =
+      digits
+      |> Enum.slice(7, 6)
+      |> Enum.with_index()
+      |> Enum.map(fn {digit, offset} ->
+        %{
+          digit: digit,
+          encoding: "R",
+          pattern: @digit_patterns |> Map.fetch!("R") |> Enum.at(String.to_integer(digit)),
+          source_index: offset + 7,
+          role: if(offset == 5, do: "check", else: "data")
+        }
+      end)
+
+    left_digits ++ right_digits
+  end
+
+  def expand_ean_13_runs(data) do
+    encoded_digits = encode_ean_13(data)
+
+    retag_runs(BarcodeLayout1D.runs_from_binary_pattern(@side_guard, source_char: "start", source_index: -1), "guard") ++
+      expand_ean_13_side(Enum.take(encoded_digits, 6)) ++
+      retag_runs(BarcodeLayout1D.runs_from_binary_pattern(@center_guard, source_char: "center", source_index: -2), "guard") ++
+      expand_ean_13_side(Enum.drop(encoded_digits, 6)) ++
+      retag_runs(BarcodeLayout1D.runs_from_binary_pattern(@side_guard, source_char: "end", source_index: -3), "guard")
+  end
+
+  def layout_ean_13(data, config \\ @default_layout_config) do
+    normalized = normalize_ean_13(data)
+
+    BarcodeLayout1D.layout_barcode_1d(
+      expand_ean_13_runs(normalized),
+      config,
+      %{
+        fill: "#000000",
+        background: "#ffffff",
+        metadata: %{
+          symbology: "ean-13",
+          leading_digit: String.at(normalized, 0),
+          left_parity: left_parity_pattern(normalized),
+          content_modules: 95
+        }
+      }
+    )
+  end
+
+  def draw_ean_13(data, config \\ @default_layout_config), do: layout_ean_13(data, config)
+
+  defp expand_ean_13_side(entries) do
+    Enum.flat_map(entries, fn entry ->
+      BarcodeLayout1D.runs_from_binary_pattern(
+        entry.pattern,
+        source_char: entry.digit,
+        source_index: entry.source_index
+      )
+      |> retag_runs(entry.role)
+    end)
+  end
+
+  defp assert_digits!(data, lengths, length_message) do
+    unless String.match?(data, ~r/^\d+$/) do
+      raise ArgumentError, "EAN-13 input must contain digits only"
+    end
+
+    unless String.length(data) in lengths do
+      raise ArgumentError, length_message
+    end
+  end
+
+  defp retag_runs(runs, role) do
+    Enum.map(runs, fn run -> %{run | role: role, metadata: Map.new(Map.get(run, :metadata, %{}))} end)
+  end
+end

--- a/code/packages/elixir/ean_13/mix.exs
+++ b/code/packages/elixir/ean_13/mix.exs
@@ -1,0 +1,25 @@
+defmodule CodingAdventures.Ean13.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :coding_adventures_ean_13,
+      version: "0.1.0",
+      elixir: "~> 1.14",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      test_coverage: [summary: [threshold: 80]]
+    ]
+  end
+
+  def application do
+    [extra_applications: [:logger]]
+  end
+
+  defp deps do
+    [
+      {:coding_adventures_paint_instructions, path: "../paint_instructions"},
+      {:coding_adventures_barcode_layout_1d, path: "../barcode_layout_1d"}
+    ]
+  end
+end

--- a/code/packages/elixir/ean_13/required_capabilities.json
+++ b/code/packages/elixir/ean_13/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "elixir/ean_13",
+  "capabilities": [],
+  "justification": "Pure computation package for EAN-13 normalization, encoding, run expansion, and paint-scene generation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/elixir/ean_13/test/ean_13_test.exs
+++ b/code/packages/elixir/ean_13/test/ean_13_test.exs
@@ -1,0 +1,20 @@
+defmodule CodingAdventures.Ean13Test do
+  use ExUnit.Case
+
+  test "module loads" do
+    assert Code.ensure_loaded?(CodingAdventures.Ean13)
+  end
+
+  test "computes check digit and parity" do
+    assert CodingAdventures.Ean13.compute_ean_13_check_digit("400638133393") == "1"
+    assert CodingAdventures.Ean13.left_parity_pattern("4006381333931") == "LGLLGG"
+  end
+
+  test "draws ean-13" do
+    scene = CodingAdventures.Ean13.draw_ean_13("400638133393")
+    assert scene.metadata.symbology == "ean-13"
+    assert scene.metadata.content_modules == 95
+    assert scene.width > 0
+    assert scene.height == 120
+  end
+end

--- a/code/packages/elixir/ean_13/test/test_helper.exs
+++ b/code/packages/elixir/ean_13/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/code/packages/elixir/itf/BUILD
+++ b/code/packages/elixir/itf/BUILD
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/itf/lib/coding_adventures/itf.ex
+++ b/code/packages/elixir/itf/lib/coding_adventures/itf.ex
@@ -1,0 +1,95 @@
+defmodule CodingAdventures.Itf do
+  @moduledoc """
+  Dependency-free ITF encoder that emits backend-neutral paint scenes.
+  """
+
+  alias CodingAdventures.BarcodeLayout1D
+
+  @default_layout_config %{
+    module_unit: 4,
+    bar_height: 120,
+    quiet_zone_modules: 10
+  }
+
+  @start_pattern "1010"
+  @stop_pattern "11101"
+  @digit_patterns ~w[00110 10001 01001 11000 00101 10100 01100 00011 10010 01010]
+
+  def default_layout_config, do: @default_layout_config
+  def default_render_config, do: @default_layout_config
+
+  def normalize_itf(data) do
+    unless String.match?(data, ~r/^\d+$/) do
+      raise ArgumentError, "ITF input must contain digits only"
+    end
+
+    if data == "" or rem(String.length(data), 2) != 0 do
+      raise ArgumentError, "ITF input must contain an even number of digits"
+    end
+
+    data
+  end
+
+  def encode_itf(data) do
+    normalize_itf(data)
+    |> String.graphemes()
+    |> Enum.chunk_every(2)
+    |> Enum.with_index()
+    |> Enum.map(fn {pair_chars, index} ->
+      pair = Enum.join(pair_chars)
+      bar_pattern = Enum.at(@digit_patterns, String.at(pair, 0) |> String.to_integer())
+      space_pattern = Enum.at(@digit_patterns, String.at(pair, 1) |> String.to_integer())
+
+      binary_pattern =
+        bar_pattern
+        |> String.graphemes()
+        |> Enum.zip(String.graphemes(space_pattern))
+        |> Enum.map_join(fn {bar_marker, space_marker} ->
+          "#{if(bar_marker == "1", do: "111", else: "1")}#{if(space_marker == "1", do: "000", else: "0")}"
+        end)
+
+      %{
+        pair: pair,
+        bar_pattern: bar_pattern,
+        space_pattern: space_pattern,
+        binary_pattern: binary_pattern,
+        source_index: index
+      }
+    end)
+  end
+
+  def expand_itf_runs(data) do
+    encoded_pairs = encode_itf(data)
+
+    retag_runs(BarcodeLayout1D.runs_from_binary_pattern(@start_pattern, source_char: "start", source_index: -1), "start") ++
+      Enum.flat_map(encoded_pairs, fn entry ->
+        BarcodeLayout1D.runs_from_binary_pattern(
+          entry.binary_pattern,
+          source_char: entry.pair,
+          source_index: entry.source_index
+        )
+        |> retag_runs("data")
+      end) ++
+      retag_runs(BarcodeLayout1D.runs_from_binary_pattern(@stop_pattern, source_char: "stop", source_index: -2), "stop")
+  end
+
+  def layout_itf(data, config \\ @default_layout_config) do
+    normalized = normalize_itf(data)
+
+    BarcodeLayout1D.layout_barcode_1d(
+      expand_itf_runs(normalized),
+      config,
+      %{
+        fill: "#000000",
+        background: "#ffffff",
+        metadata: %{symbology: "itf", pair_count: div(String.length(normalized), 2)}
+      }
+    )
+  end
+
+  def draw_itf(data, config \\ @default_layout_config), do: layout_itf(data, config)
+
+  defp retag_runs(runs, role) do
+    Enum.map(runs, fn run -> %{run | role: role, metadata: Map.new(Map.get(run, :metadata, %{}))} end)
+  end
+end

--- a/code/packages/elixir/itf/mix.exs
+++ b/code/packages/elixir/itf/mix.exs
@@ -1,0 +1,25 @@
+defmodule CodingAdventures.Itf.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :coding_adventures_itf,
+      version: "0.1.0",
+      elixir: "~> 1.14",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      test_coverage: [summary: [threshold: 80]]
+    ]
+  end
+
+  def application do
+    [extra_applications: [:logger]]
+  end
+
+  defp deps do
+    [
+      {:coding_adventures_paint_instructions, path: "../paint_instructions"},
+      {:coding_adventures_barcode_layout_1d, path: "../barcode_layout_1d"}
+    ]
+  end
+end

--- a/code/packages/elixir/itf/required_capabilities.json
+++ b/code/packages/elixir/itf/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "elixir/itf",
+  "capabilities": [],
+  "justification": "Pure computation package for ITF normalization, encoding, run expansion, and paint-scene generation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/elixir/itf/test/itf_test.exs
+++ b/code/packages/elixir/itf/test/itf_test.exs
@@ -1,0 +1,25 @@
+defmodule CodingAdventures.ItfTest do
+  use ExUnit.Case
+
+  test "module loads" do
+    assert Code.ensure_loaded?(CodingAdventures.Itf)
+  end
+
+  test "encodes and draws" do
+    encoded = CodingAdventures.Itf.encode_itf("123456")
+    assert length(encoded) == 3
+    assert hd(encoded).pair == "12"
+
+    scene = CodingAdventures.Itf.draw_itf("123456")
+    assert scene.metadata.symbology == "itf"
+    assert scene.metadata.pair_count == 3
+    assert scene.width > 0
+    assert scene.height == 120
+  end
+
+  test "expands start and stop runs" do
+    roles = Enum.map(CodingAdventures.Itf.expand_itf_runs("123456"), & &1.role)
+    assert "start" in roles
+    assert "stop" in roles
+  end
+end

--- a/code/packages/elixir/itf/test/test_helper.exs
+++ b/code/packages/elixir/itf/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/code/packages/elixir/upc_a/BUILD
+++ b/code/packages/elixir/upc_a/BUILD
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/upc_a/lib/coding_adventures/upc_a.ex
+++ b/code/packages/elixir/upc_a/lib/coding_adventures/upc_a.ex
@@ -1,0 +1,127 @@
+defmodule CodingAdventures.UpcA do
+  @moduledoc """
+  Dependency-free UPC-A encoder that emits backend-neutral paint scenes.
+  """
+
+  alias CodingAdventures.BarcodeLayout1D
+
+  @default_layout_config %{
+    module_unit: 4,
+    bar_height: 120,
+    quiet_zone_modules: 10
+  }
+
+  @side_guard "101"
+  @center_guard "01010"
+
+  @digit_patterns %{
+    "L" => ~w[0001101 0011001 0010011 0111101 0100011 0110001 0101111 0111011 0110111 0001011],
+    "R" => ~w[1110010 1100110 1101100 1000010 1011100 1001110 1010000 1000100 1001000 1110100]
+  }
+
+  def default_layout_config, do: @default_layout_config
+  def default_render_config, do: @default_layout_config
+
+  def compute_upc_a_check_digit(payload11) do
+    assert_digits!(payload11, [11], "UPC-A input must contain 11 digits or 12 digits")
+
+    {odd_sum, even_sum} =
+      payload11
+      |> String.graphemes()
+      |> Enum.with_index()
+      |> Enum.reduce({0, 0}, fn {digit, index}, {odd_sum, even_sum} ->
+        if rem(index, 2) == 0 do
+          {odd_sum + String.to_integer(digit), even_sum}
+        else
+          {odd_sum, even_sum + String.to_integer(digit)}
+        end
+      end)
+
+    Integer.to_string(rem(10 - rem(odd_sum * 3 + even_sum, 10), 10))
+  end
+
+  def normalize_upc_a(data) do
+    assert_digits!(data, [11, 12], "UPC-A input must contain 11 digits or 12 digits")
+
+    if String.length(data) == 11 do
+      data <> compute_upc_a_check_digit(data)
+    else
+      expected = compute_upc_a_check_digit(String.slice(data, 0, 11))
+      actual = String.at(data, 11)
+
+      if expected == actual do
+        data
+      else
+        raise ArgumentError, "Invalid UPC-A check digit: expected #{expected} but received #{actual}"
+      end
+    end
+  end
+
+  def encode_upc_a(data) do
+    normalize_upc_a(data)
+    |> String.graphemes()
+    |> Enum.with_index()
+    |> Enum.map(fn {digit, index} ->
+      encoding = if(index < 6, do: "L", else: "R")
+
+      %{
+        digit: digit,
+        encoding: encoding,
+        pattern: @digit_patterns |> Map.fetch!(encoding) |> Enum.at(String.to_integer(digit)),
+        source_index: index,
+        role: if(index == 11, do: "check", else: "data")
+      }
+    end)
+  end
+
+  def expand_upc_a_runs(data) do
+    encoded_digits = encode_upc_a(data)
+
+    retag_runs(BarcodeLayout1D.runs_from_binary_pattern(@side_guard, source_char: "start", source_index: -1), "guard") ++
+      expand_upc_a_side(Enum.take(encoded_digits, 6)) ++
+      retag_runs(BarcodeLayout1D.runs_from_binary_pattern(@center_guard, source_char: "center", source_index: -2), "guard") ++
+      expand_upc_a_side(Enum.drop(encoded_digits, 6)) ++
+      retag_runs(BarcodeLayout1D.runs_from_binary_pattern(@side_guard, source_char: "end", source_index: -3), "guard")
+  end
+
+  def layout_upc_a(data, config \\ @default_layout_config) do
+    normalized = normalize_upc_a(data)
+
+    BarcodeLayout1D.layout_barcode_1d(
+      expand_upc_a_runs(normalized),
+      config,
+      %{
+        fill: "#000000",
+        background: "#ffffff",
+        metadata: %{symbology: "upc-a", content_modules: 95}
+      }
+    )
+  end
+
+  def draw_upc_a(data, config \\ @default_layout_config), do: layout_upc_a(data, config)
+
+  defp expand_upc_a_side(entries) do
+    Enum.flat_map(entries, fn entry ->
+      BarcodeLayout1D.runs_from_binary_pattern(
+        entry.pattern,
+        source_char: entry.digit,
+        source_index: entry.source_index
+      )
+      |> retag_runs(entry.role)
+    end)
+  end
+
+  defp assert_digits!(data, lengths, length_message) do
+    unless String.match?(data, ~r/^\d+$/) do
+      raise ArgumentError, "UPC-A input must contain digits only"
+    end
+
+    unless String.length(data) in lengths do
+      raise ArgumentError, length_message
+    end
+  end
+
+  defp retag_runs(runs, role) do
+    Enum.map(runs, fn run -> %{run | role: role, metadata: Map.new(Map.get(run, :metadata, %{}))} end)
+  end
+end

--- a/code/packages/elixir/upc_a/mix.exs
+++ b/code/packages/elixir/upc_a/mix.exs
@@ -1,0 +1,25 @@
+defmodule CodingAdventures.UpcA.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :coding_adventures_upc_a,
+      version: "0.1.0",
+      elixir: "~> 1.14",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      test_coverage: [summary: [threshold: 80]]
+    ]
+  end
+
+  def application do
+    [extra_applications: [:logger]]
+  end
+
+  defp deps do
+    [
+      {:coding_adventures_paint_instructions, path: "../paint_instructions"},
+      {:coding_adventures_barcode_layout_1d, path: "../barcode_layout_1d"}
+    ]
+  end
+end

--- a/code/packages/elixir/upc_a/required_capabilities.json
+++ b/code/packages/elixir/upc_a/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "elixir/upc_a",
+  "capabilities": [],
+  "justification": "Pure computation package for UPC-A normalization, encoding, run expansion, and paint-scene generation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/elixir/upc_a/test/test_helper.exs
+++ b/code/packages/elixir/upc_a/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/code/packages/elixir/upc_a/test/upc_a_test.exs
+++ b/code/packages/elixir/upc_a/test/upc_a_test.exs
@@ -1,0 +1,17 @@
+defmodule CodingAdventures.UpcATest do
+  use ExUnit.Case
+
+  test "module loads" do
+    assert Code.ensure_loaded?(CodingAdventures.UpcA)
+  end
+
+  test "computes check digit and draws" do
+    assert CodingAdventures.UpcA.compute_upc_a_check_digit("03600029145") == "2"
+
+    scene = CodingAdventures.UpcA.draw_upc_a("03600029145")
+    assert scene.metadata.symbology == "upc-a"
+    assert scene.metadata.content_modules == 95
+    assert scene.width > 0
+    assert scene.height == 120
+  end
+end

--- a/code/packages/go/codabar/BUILD
+++ b/code/packages/go/codabar/BUILD
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/codabar/codabar.go
+++ b/code/packages/go/codabar/codabar.go
@@ -1,0 +1,187 @@
+// Package codabar implements the Codabar barcode symbology and emits PaintScene.
+package codabar
+
+import (
+	"fmt"
+	"strings"
+
+	barcodelayout1d "github.com/adhithyan15/coding-adventures/code/packages/go/barcode-layout-1d"
+	paintinstructions "github.com/adhithyan15/coding-adventures/code/packages/go/paint-instructions"
+)
+
+const Version = "0.1.0"
+
+type EncodedSymbol struct {
+	Char        string
+	Pattern     string
+	SourceIndex int
+	Role        string
+}
+
+type BarcodeRun = barcodelayout1d.Barcode1DRun
+type RenderConfig = barcodelayout1d.LayoutConfig
+
+var DefaultLayoutConfig = barcodelayout1d.DefaultLayoutConfig
+var DefaultRenderConfig = DefaultLayoutConfig
+
+var guards = map[string]struct{}{"A": {}, "B": {}, "C": {}, "D": {}}
+
+var patterns = map[string]string{
+	"0": "101010011",
+	"1": "101011001",
+	"2": "101001011",
+	"3": "110010101",
+	"4": "101101001",
+	"5": "110101001",
+	"6": "100101011",
+	"7": "100101101",
+	"8": "100110101",
+	"9": "110100101",
+	"-": "101001101",
+	"$": "101100101",
+	":": "1101011011",
+	"/": "1101101011",
+	".": "1101101101",
+	"+": "1011011011",
+	"A": "1011001001",
+	"B": "1001001011",
+	"C": "1010010011",
+	"D": "1010011001",
+}
+
+func copyMetadata(metadata paintinstructions.Metadata) paintinstructions.Metadata {
+	if metadata == nil {
+		return paintinstructions.Metadata{}
+	}
+	result := make(paintinstructions.Metadata, len(metadata))
+	for key, value := range metadata {
+		result[key] = value
+	}
+	return result
+}
+
+func isGuard(char string) bool {
+	_, ok := guards[char]
+	return ok
+}
+
+func assertBodyChars(body string) error {
+	for _, ch := range body {
+		value := string(ch)
+		_, ok := patterns[value]
+		if !ok || isGuard(value) {
+			return fmt.Errorf("invalid Codabar body character %q", value)
+		}
+	}
+	return nil
+}
+
+// NormalizeCodabar normalizes payloads and adds default A/A guards when needed.
+func NormalizeCodabar(data string) (string, error) {
+	normalized := strings.ToUpper(data)
+	if len(normalized) >= 2 && isGuard(string(normalized[0])) && isGuard(string(normalized[len(normalized)-1])) {
+		if err := assertBodyChars(normalized[1 : len(normalized)-1]); err != nil {
+			return "", err
+		}
+		return normalized, nil
+	}
+	if err := assertBodyChars(normalized); err != nil {
+		return "", err
+	}
+	return "A" + normalized + "A", nil
+}
+
+// EncodeCodabar encodes a payload into logical symbols.
+func EncodeCodabar(data string) ([]EncodedSymbol, error) {
+	normalized, err := NormalizeCodabar(data)
+	if err != nil {
+		return nil, err
+	}
+	encoded := make([]EncodedSymbol, 0, len(normalized))
+	for index, ch := range normalized {
+		char := string(ch)
+		role := "data"
+		if index == 0 {
+			role = "start"
+		} else if index == len(normalized)-1 {
+			role = "stop"
+		}
+		encoded = append(encoded, EncodedSymbol{
+			Char:        char,
+			Pattern:     patterns[char],
+			SourceIndex: index,
+			Role:        role,
+		})
+	}
+	return encoded, nil
+}
+
+func retagRuns(runs []BarcodeRun, role string) []BarcodeRun {
+	result := make([]BarcodeRun, len(runs))
+	for index, run := range runs {
+		result[index] = run
+		result[index].Role = role
+		result[index].Metadata = copyMetadata(run.Metadata)
+	}
+	return result
+}
+
+// ExpandCodabarRuns expands encoded symbols into barcode runs.
+func ExpandCodabarRuns(data string) ([]BarcodeRun, error) {
+	encoded, err := EncodeCodabar(data)
+	if err != nil {
+		return nil, err
+	}
+	runs := make([]BarcodeRun, 0)
+	for index, symbol := range encoded {
+		segmentRuns, err := barcodelayout1d.RunsFromBinaryPattern(
+			symbol.Pattern,
+			'1',
+			'0',
+			symbol.Char,
+			symbol.SourceIndex,
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+		runs = append(runs, retagRuns(segmentRuns, symbol.Role)...)
+		if index < len(encoded)-1 {
+			runs = append(runs, BarcodeRun{
+				Color:       "space",
+				Modules:     1,
+				SourceChar:  symbol.Char,
+				SourceIndex: symbol.SourceIndex,
+				Role:        "inter-character-gap",
+				Metadata:    paintinstructions.Metadata{},
+			})
+		}
+	}
+	return runs, nil
+}
+
+// LayoutCodabar generates a paint scene for Codabar.
+func LayoutCodabar(data string, config RenderConfig) (paintinstructions.PaintScene, error) {
+	normalized, err := NormalizeCodabar(data)
+	if err != nil {
+		return paintinstructions.PaintScene{}, err
+	}
+	runs, err := ExpandCodabarRuns(normalized)
+	if err != nil {
+		return paintinstructions.PaintScene{}, err
+	}
+	return barcodelayout1d.DrawOneDimensionalBarcode(runs, config, barcodelayout1d.PaintOptions{
+		Fill:       "#000000",
+		Background: "#ffffff",
+		Metadata: paintinstructions.Metadata{
+			"symbology": "codabar",
+			"start":     string(normalized[0]),
+			"stop":      string(normalized[len(normalized)-1]),
+		},
+	})
+}
+
+// DrawCodabar is a compatibility alias for LayoutCodabar.
+func DrawCodabar(data string, config RenderConfig) (paintinstructions.PaintScene, error) {
+	return LayoutCodabar(data, config)
+}

--- a/code/packages/go/codabar/codabar_test.go
+++ b/code/packages/go/codabar/codabar_test.go
@@ -1,0 +1,37 @@
+package codabar
+
+import "testing"
+
+func TestCodabar(t *testing.T) {
+	if Version != "0.1.0" {
+		t.Fatalf("unexpected version %s", Version)
+	}
+	normalized, err := NormalizeCodabar("40156")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if normalized != "A40156A" {
+		t.Fatalf("unexpected normalized value %s", normalized)
+	}
+	runs, err := ExpandCodabarRuns("40156")
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundGap := false
+	for _, run := range runs {
+		if run.Role == "inter-character-gap" {
+			foundGap = true
+			break
+		}
+	}
+	if !foundGap {
+		t.Fatal("expected an inter-character-gap run")
+	}
+	scene, err := DrawCodabar("40156", DefaultRenderConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scene.Metadata["symbology"] != "codabar" {
+		t.Fatalf("unexpected scene metadata %#v", scene.Metadata)
+	}
+}

--- a/code/packages/go/codabar/go.mod
+++ b/code/packages/go/codabar/go.mod
@@ -1,0 +1,11 @@
+module github.com/adhithyan15/coding-adventures/code/packages/go/codabar
+
+go 1.26
+
+require (
+	github.com/adhithyan15/coding-adventures/code/packages/go/barcode-layout-1d v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/paint-instructions v0.0.0
+)
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/barcode-layout-1d => ../barcode-layout-1d
+replace github.com/adhithyan15/coding-adventures/code/packages/go/paint-instructions => ../paint-instructions

--- a/code/packages/go/codabar/required_capabilities.json
+++ b/code/packages/go/codabar/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "go/codabar",
+  "capabilities": [],
+  "justification": "Pure computation package for Codabar normalization, encoding, run expansion, and paint-scene generation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/go/code128/BUILD
+++ b/code/packages/go/code128/BUILD
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/code128/code128.go
+++ b/code/packages/go/code128/code128.go
@@ -1,0 +1,196 @@
+// Package code128 implements the Code 128 barcode symbology and emits PaintScene.
+package code128
+
+import (
+	"fmt"
+
+	barcodelayout1d "github.com/adhithyan15/coding-adventures/code/packages/go/barcode-layout-1d"
+	paintinstructions "github.com/adhithyan15/coding-adventures/code/packages/go/paint-instructions"
+)
+
+const Version = "0.1.0"
+
+const (
+	startB = 104
+	stop   = 106
+)
+
+type EncodedSymbol struct {
+	Label       string
+	Value       int
+	Pattern     string
+	SourceIndex int
+	Role        string
+}
+
+type BarcodeRun = barcodelayout1d.Barcode1DRun
+type RenderConfig = barcodelayout1d.LayoutConfig
+
+var DefaultLayoutConfig = barcodelayout1d.DefaultLayoutConfig
+var DefaultRenderConfig = DefaultLayoutConfig
+
+var patterns = []string{
+	"11011001100", "11001101100", "11001100110", "10010011000", "10010001100",
+	"10001001100", "10011001000", "10011000100", "10001100100", "11001001000",
+	"11001000100", "11000100100", "10110011100", "10011011100", "10011001110",
+	"10111001100", "10011101100", "10011100110", "11001110010", "11001011100",
+	"11001001110", "11011100100", "11001110100", "11101101110", "11101001100",
+	"11100101100", "11100100110", "11101100100", "11100110100", "11100110010",
+	"11011011000", "11011000110", "11000110110", "10100011000", "10001011000",
+	"10001000110", "10110001000", "10001101000", "10001100010", "11010001000",
+	"11000101000", "11000100010", "10110111000", "10110001110", "10001101110",
+	"10111011000", "10111000110", "10001110110", "11101110110", "11010001110",
+	"11000101110", "11011101000", "11011100010", "11011101110", "11101011000",
+	"11101000110", "11100010110", "11101101000", "11101100010", "11100011010",
+	"11101111010", "11001000010", "11110001010", "10100110000", "10100001100",
+	"10010110000", "10010000110", "10000101100", "10000100110", "10110010000",
+	"10110000100", "10011010000", "10011000010", "10000110100", "10000110010",
+	"11000010010", "11001010000", "11110111010", "11000010100", "10001111010",
+	"10100111100", "10010111100", "10010011110", "10111100100", "10011110100",
+	"10011110010", "11110100100", "11110010100", "11110010010", "11011011110",
+	"11011110110", "11110110110", "10101111000", "10100011110", "10001011110",
+	"10111101000", "10111100010", "11110101000", "11110100010", "10111011110",
+	"10111101110", "11101011110", "11110101110", "11010000100", "11010010000",
+	"11010011100", "1100011101011",
+}
+
+func copyMetadata(metadata paintinstructions.Metadata) paintinstructions.Metadata {
+	if metadata == nil {
+		return paintinstructions.Metadata{}
+	}
+	result := make(paintinstructions.Metadata, len(metadata))
+	for key, value := range metadata {
+		result[key] = value
+	}
+	return result
+}
+
+// NormalizeCode128B validates printable ASCII input for Code Set B.
+func NormalizeCode128B(data string) (string, error) {
+	for _, ch := range data {
+		if ch < 32 || ch > 126 {
+			return "", fmt.Errorf("Code 128 Code Set B supports printable ASCII characters only")
+		}
+	}
+	return data, nil
+}
+
+// ValueForCode128BChar converts a printable ASCII character into its Code 128 value.
+func ValueForCode128BChar(char rune) int {
+	return int(char) - 32
+}
+
+// ComputeCode128Checksum computes the weighted Code 128 checksum.
+func ComputeCode128Checksum(values []int) int {
+	sum := startB
+	for index, value := range values {
+		sum += value * (index + 1)
+	}
+	return sum % 103
+}
+
+func retagRuns(runs []BarcodeRun, role string) []BarcodeRun {
+	result := make([]BarcodeRun, len(runs))
+	for index, run := range runs {
+		result[index] = run
+		result[index].Role = role
+		result[index].Metadata = copyMetadata(run.Metadata)
+	}
+	return result
+}
+
+// EncodeCode128B encodes a Code Set B payload into logical symbols.
+func EncodeCode128B(data string) ([]EncodedSymbol, error) {
+	normalized, err := NormalizeCode128B(data)
+	if err != nil {
+		return nil, err
+	}
+	dataSymbols := make([]EncodedSymbol, 0, len(normalized))
+	values := make([]int, 0, len(normalized))
+	for index, ch := range normalized {
+		value := ValueForCode128BChar(ch)
+		dataSymbols = append(dataSymbols, EncodedSymbol{
+			Label:       string(ch),
+			Value:       value,
+			Pattern:     patterns[value],
+			SourceIndex: index,
+			Role:        "data",
+		})
+		values = append(values, value)
+	}
+	checksum := ComputeCode128Checksum(values)
+	return append([]EncodedSymbol{{
+		Label:       "Start B",
+		Value:       startB,
+		Pattern:     patterns[startB],
+		SourceIndex: -1,
+		Role:        "start",
+	}}, append(dataSymbols, EncodedSymbol{
+		Label:       fmt.Sprintf("Checksum %d", checksum),
+		Value:       checksum,
+		Pattern:     patterns[checksum],
+		SourceIndex: len(normalized),
+		Role:        "check",
+	}, EncodedSymbol{
+		Label:       "Stop",
+		Value:       stop,
+		Pattern:     patterns[stop],
+		SourceIndex: len(normalized) + 1,
+		Role:        "stop",
+	})...), nil
+}
+
+// ExpandCode128Runs expands encoded symbols into barcode runs.
+func ExpandCode128Runs(data string) ([]BarcodeRun, error) {
+	encoded, err := EncodeCode128B(data)
+	if err != nil {
+		return nil, err
+	}
+	runs := make([]BarcodeRun, 0)
+	for _, symbol := range encoded {
+		segmentRuns, err := barcodelayout1d.RunsFromBinaryPattern(
+			symbol.Pattern,
+			'1',
+			'0',
+			symbol.Label,
+			symbol.SourceIndex,
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+		runs = append(runs, retagRuns(segmentRuns, symbol.Role)...)
+	}
+	return runs, nil
+}
+
+// LayoutCode128 generates a paint scene for Code 128 Code Set B.
+func LayoutCode128(data string, config RenderConfig) (paintinstructions.PaintScene, error) {
+	normalized, err := NormalizeCode128B(data)
+	if err != nil {
+		return paintinstructions.PaintScene{}, err
+	}
+	runs, err := ExpandCode128Runs(normalized)
+	if err != nil {
+		return paintinstructions.PaintScene{}, err
+	}
+	encoded, err := EncodeCode128B(normalized)
+	if err != nil {
+		return paintinstructions.PaintScene{}, err
+	}
+	checksum := encoded[len(encoded)-2].Value
+	return barcodelayout1d.DrawOneDimensionalBarcode(runs, config, barcodelayout1d.PaintOptions{
+		Fill:       "#000000",
+		Background: "#ffffff",
+		Metadata: paintinstructions.Metadata{
+			"symbology": "code128",
+			"code_set":  "B",
+			"checksum":  checksum,
+		},
+	})
+}
+
+// DrawCode128 is a compatibility alias for LayoutCode128.
+func DrawCode128(data string, config RenderConfig) (paintinstructions.PaintScene, error) {
+	return LayoutCode128(data, config)
+}

--- a/code/packages/go/code128/code128_test.go
+++ b/code/packages/go/code128/code128_test.go
@@ -1,0 +1,30 @@
+package code128
+
+import "testing"
+
+func TestCode128(t *testing.T) {
+	if Version != "0.1.0" {
+		t.Fatalf("unexpected version %s", Version)
+	}
+	values := make([]int, 0, len("Code 128"))
+	for _, ch := range "Code 128" {
+		values = append(values, ValueForCode128BChar(ch))
+	}
+	if checksum := ComputeCode128Checksum(values); checksum != 64 {
+		t.Fatalf("unexpected checksum %d", checksum)
+	}
+	encoded, err := EncodeCode128B("Code 128")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if encoded[0].Role != "start" || encoded[len(encoded)-2].Role != "check" || encoded[len(encoded)-1].Role != "stop" {
+		t.Fatalf("unexpected encoded roles %#v", encoded)
+	}
+	scene, err := DrawCode128("Code 128", DefaultRenderConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scene.Metadata["symbology"] != "code128" {
+		t.Fatalf("unexpected scene metadata %#v", scene.Metadata)
+	}
+}

--- a/code/packages/go/code128/go.mod
+++ b/code/packages/go/code128/go.mod
@@ -1,0 +1,11 @@
+module github.com/adhithyan15/coding-adventures/code/packages/go/code128
+
+go 1.26
+
+require (
+	github.com/adhithyan15/coding-adventures/code/packages/go/barcode-layout-1d v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/paint-instructions v0.0.0
+)
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/barcode-layout-1d => ../barcode-layout-1d
+replace github.com/adhithyan15/coding-adventures/code/packages/go/paint-instructions => ../paint-instructions

--- a/code/packages/go/code128/required_capabilities.json
+++ b/code/packages/go/code128/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "go/code128",
+  "capabilities": [],
+  "justification": "Pure computation package for Code 128 normalization, encoding, run expansion, and paint-scene generation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/go/ean-13/BUILD
+++ b/code/packages/go/ean-13/BUILD
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/ean-13/ean_13.go
+++ b/code/packages/go/ean-13/ean_13.go
@@ -1,0 +1,235 @@
+// Package ean13 implements the EAN-13 barcode symbology and emits PaintScene.
+package ean13
+
+import (
+	"fmt"
+	"strings"
+
+	barcodelayout1d "github.com/adhithyan15/coding-adventures/code/packages/go/barcode-layout-1d"
+	paintinstructions "github.com/adhithyan15/coding-adventures/code/packages/go/paint-instructions"
+)
+
+const Version = "0.1.0"
+
+type EncodedDigit struct {
+	Digit       string
+	Encoding    string
+	Pattern     string
+	SourceIndex int
+	Role        string
+}
+
+type BarcodeRun = barcodelayout1d.Barcode1DRun
+type RenderConfig = barcodelayout1d.LayoutConfig
+
+var DefaultLayoutConfig = barcodelayout1d.DefaultLayoutConfig
+var DefaultRenderConfig = DefaultLayoutConfig
+
+const sideGuard = "101"
+const centerGuard = "01010"
+
+var digitPatterns = map[string][]string{
+	"L": {"0001101", "0011001", "0010011", "0111101", "0100011", "0110001", "0101111", "0111011", "0110111", "0001011"},
+	"G": {"0100111", "0110011", "0011011", "0100001", "0011101", "0111001", "0000101", "0010001", "0001001", "0010111"},
+	"R": {"1110010", "1100110", "1101100", "1000010", "1011100", "1001110", "1010000", "1000100", "1001000", "1110100"},
+}
+
+var leftParityPatterns = []string{
+	"LLLLLL", "LLGLGG", "LLGGLG", "LLGGGL", "LGLLGG",
+	"LGGLLG", "LGGGLL", "LGLGLG", "LGLGGL", "LGGLGL",
+}
+
+func copyMetadata(metadata paintinstructions.Metadata) paintinstructions.Metadata {
+	if metadata == nil {
+		return paintinstructions.Metadata{}
+	}
+	result := make(paintinstructions.Metadata, len(metadata))
+	for key, value := range metadata {
+		result[key] = value
+	}
+	return result
+}
+
+func assertDigits(data string, allowedLengths ...int) error {
+	if data == "" {
+		return fmt.Errorf("EAN-13 input must contain digits only")
+	}
+	for _, ch := range data {
+		if ch < '0' || ch > '9' {
+			return fmt.Errorf("EAN-13 input must contain digits only")
+		}
+	}
+	for _, length := range allowedLengths {
+		if len(data) == length {
+			return nil
+		}
+	}
+	return fmt.Errorf("EAN-13 input must contain 12 digits or 13 digits")
+}
+
+func retagRuns(runs []BarcodeRun, role string) []BarcodeRun {
+	result := make([]BarcodeRun, len(runs))
+	for index, run := range runs {
+		result[index] = run
+		result[index].Role = role
+		result[index].Metadata = copyMetadata(run.Metadata)
+	}
+	return result
+}
+
+// ComputeEAN13CheckDigit computes the check digit for a 12-digit payload.
+func ComputeEAN13CheckDigit(payload12 string) (string, error) {
+	if err := assertDigits(payload12, 12); err != nil {
+		return "", err
+	}
+	total := 0
+	reversed := []rune(payload12)
+	for index := len(reversed) - 1; index >= 0; index-- {
+		position := len(reversed) - 1 - index
+		multiplier := 1
+		if position%2 == 0 {
+			multiplier = 3
+		}
+		total += int(reversed[index]-'0') * multiplier
+	}
+	return fmt.Sprintf("%d", (10-(total%10))%10), nil
+}
+
+// NormalizeEAN13 normalizes EAN-13 payloads and computes the check digit when needed.
+func NormalizeEAN13(data string) (string, error) {
+	if err := assertDigits(data, 12, 13); err != nil {
+		return "", err
+	}
+	if len(data) == 12 {
+		checkDigit, err := ComputeEAN13CheckDigit(data)
+		if err != nil {
+			return "", err
+		}
+		return data + checkDigit, nil
+	}
+	expected, err := ComputeEAN13CheckDigit(data[:12])
+	if err != nil {
+		return "", err
+	}
+	if expected != data[12:] {
+		return "", fmt.Errorf("invalid EAN-13 check digit: expected %s but received %s", expected, data[12:])
+	}
+	return data, nil
+}
+
+// LeftParityPattern returns the left-side parity pattern for a normalized EAN-13 value.
+func LeftParityPattern(data string) (string, error) {
+	normalized, err := NormalizeEAN13(data)
+	if err != nil {
+		return "", err
+	}
+	return leftParityPatterns[int(normalized[0]-'0')], nil
+}
+
+// EncodeEAN13 encodes an EAN-13 payload into logical digits.
+func EncodeEAN13(data string) ([]EncodedDigit, error) {
+	normalized, err := NormalizeEAN13(data)
+	if err != nil {
+		return nil, err
+	}
+	parity, err := LeftParityPattern(normalized)
+	if err != nil {
+		return nil, err
+	}
+	digits := strings.Split(normalized, "")
+	encoded := make([]EncodedDigit, 0, 12)
+	for offset, digit := range digits[1:7] {
+		encoding := string(parity[offset])
+		encoded = append(encoded, EncodedDigit{
+			Digit:       digit,
+			Encoding:    encoding,
+			Pattern:     digitPatterns[encoding][int(digit[0]-'0')],
+			SourceIndex: offset + 1,
+			Role:        "data",
+		})
+	}
+	for offset, digit := range digits[7:] {
+		role := "data"
+		if offset == 5 {
+			role = "check"
+		}
+		encoded = append(encoded, EncodedDigit{
+			Digit:       digit,
+			Encoding:    "R",
+			Pattern:     digitPatterns["R"][int(digit[0]-'0')],
+			SourceIndex: offset + 7,
+			Role:        role,
+		})
+	}
+	return encoded, nil
+}
+
+// ExpandEAN13Runs expands an encoded EAN-13 payload into barcode runs.
+func ExpandEAN13Runs(data string) ([]BarcodeRun, error) {
+	encoded, err := EncodeEAN13(data)
+	if err != nil {
+		return nil, err
+	}
+	runs := make([]BarcodeRun, 0)
+	startRuns, err := barcodelayout1d.RunsFromBinaryPattern(sideGuard, '1', '0', "start", -1, nil)
+	if err != nil {
+		return nil, err
+	}
+	runs = append(runs, retagRuns(startRuns, "guard")...)
+	for _, entry := range encoded[:6] {
+		segmentRuns, err := barcodelayout1d.RunsFromBinaryPattern(entry.Pattern, '1', '0', entry.Digit, entry.SourceIndex, nil)
+		if err != nil {
+			return nil, err
+		}
+		runs = append(runs, retagRuns(segmentRuns, entry.Role)...)
+	}
+	centerRuns, err := barcodelayout1d.RunsFromBinaryPattern(centerGuard, '1', '0', "center", -2, nil)
+	if err != nil {
+		return nil, err
+	}
+	runs = append(runs, retagRuns(centerRuns, "guard")...)
+	for _, entry := range encoded[6:] {
+		segmentRuns, err := barcodelayout1d.RunsFromBinaryPattern(entry.Pattern, '1', '0', entry.Digit, entry.SourceIndex, nil)
+		if err != nil {
+			return nil, err
+		}
+		runs = append(runs, retagRuns(segmentRuns, entry.Role)...)
+	}
+	endRuns, err := barcodelayout1d.RunsFromBinaryPattern(sideGuard, '1', '0', "end", -3, nil)
+	if err != nil {
+		return nil, err
+	}
+	runs = append(runs, retagRuns(endRuns, "guard")...)
+	return runs, nil
+}
+
+// LayoutEAN13 generates a paint scene for EAN-13.
+func LayoutEAN13(data string, config RenderConfig) (paintinstructions.PaintScene, error) {
+	normalized, err := NormalizeEAN13(data)
+	if err != nil {
+		return paintinstructions.PaintScene{}, err
+	}
+	parity, err := LeftParityPattern(normalized)
+	if err != nil {
+		return paintinstructions.PaintScene{}, err
+	}
+	runs, err := ExpandEAN13Runs(normalized)
+	if err != nil {
+		return paintinstructions.PaintScene{}, err
+	}
+	return barcodelayout1d.DrawOneDimensionalBarcode(runs, config, barcodelayout1d.PaintOptions{
+		Fill:       "#000000",
+		Background: "#ffffff",
+		Metadata: paintinstructions.Metadata{
+			"symbology":       "ean-13",
+			"leading_digit":   string(normalized[0]),
+			"left_parity":     parity,
+			"content_modules": 95,
+		},
+	})
+}
+
+// DrawEAN13 is a compatibility alias for LayoutEAN13.
+func DrawEAN13(data string, config RenderConfig) (paintinstructions.PaintScene, error) {
+	return LayoutEAN13(data, config)
+}

--- a/code/packages/go/ean-13/ean_13_test.go
+++ b/code/packages/go/ean-13/ean_13_test.go
@@ -1,0 +1,31 @@
+package ean13
+
+import "testing"
+
+func TestEAN13(t *testing.T) {
+	checkDigit, err := ComputeEAN13CheckDigit("400638133393")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if checkDigit != "1" {
+		t.Fatalf("unexpected check digit %s", checkDigit)
+	}
+	parity, err := LeftParityPattern("4006381333931")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parity != "LGLLGG" {
+		t.Fatalf("unexpected parity %s", parity)
+	}
+	runs, err := ExpandEAN13Runs("4006381333931")
+	if err != nil {
+		t.Fatal(err)
+	}
+	totalModules := 0
+	for _, run := range runs {
+		totalModules += run.Modules
+	}
+	if totalModules != 95 {
+		t.Fatalf("unexpected module count %d", totalModules)
+	}
+}

--- a/code/packages/go/ean-13/go.mod
+++ b/code/packages/go/ean-13/go.mod
@@ -1,0 +1,11 @@
+module github.com/adhithyan15/coding-adventures/code/packages/go/ean-13
+
+go 1.26
+
+require (
+	github.com/adhithyan15/coding-adventures/code/packages/go/barcode-layout-1d v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/paint-instructions v0.0.0
+)
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/barcode-layout-1d => ../barcode-layout-1d
+replace github.com/adhithyan15/coding-adventures/code/packages/go/paint-instructions => ../paint-instructions

--- a/code/packages/go/ean-13/required_capabilities.json
+++ b/code/packages/go/ean-13/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "go/ean-13",
+  "capabilities": [],
+  "justification": "Pure computation package for EAN-13 normalization, encoding, run expansion, and paint-scene generation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/go/itf/BUILD
+++ b/code/packages/go/itf/BUILD
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/itf/go.mod
+++ b/code/packages/go/itf/go.mod
@@ -1,0 +1,11 @@
+module github.com/adhithyan15/coding-adventures/code/packages/go/itf
+
+go 1.26
+
+require (
+	github.com/adhithyan15/coding-adventures/code/packages/go/barcode-layout-1d v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/paint-instructions v0.0.0
+)
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/barcode-layout-1d => ../barcode-layout-1d
+replace github.com/adhithyan15/coding-adventures/code/packages/go/paint-instructions => ../paint-instructions

--- a/code/packages/go/itf/itf.go
+++ b/code/packages/go/itf/itf.go
@@ -1,0 +1,156 @@
+// Package itf implements the ITF barcode symbology and emits PaintScene.
+package itf
+
+import (
+	"fmt"
+
+	barcodelayout1d "github.com/adhithyan15/coding-adventures/code/packages/go/barcode-layout-1d"
+	paintinstructions "github.com/adhithyan15/coding-adventures/code/packages/go/paint-instructions"
+)
+
+const Version = "0.1.0"
+
+const startPattern = "1010"
+const stopPattern = "11101"
+
+type EncodedPair struct {
+	Pair          string
+	BarPattern    string
+	SpacePattern  string
+	BinaryPattern string
+	SourceIndex   int
+}
+
+type BarcodeRun = barcodelayout1d.Barcode1DRun
+type RenderConfig = barcodelayout1d.LayoutConfig
+
+var DefaultLayoutConfig = barcodelayout1d.DefaultLayoutConfig
+var DefaultRenderConfig = DefaultLayoutConfig
+
+var digitPatterns = []string{
+	"00110", "10001", "01001", "11000", "00101",
+	"10100", "01100", "00011", "10010", "01010",
+}
+
+func copyMetadata(metadata paintinstructions.Metadata) paintinstructions.Metadata {
+	if metadata == nil {
+		return paintinstructions.Metadata{}
+	}
+	result := make(paintinstructions.Metadata, len(metadata))
+	for key, value := range metadata {
+		result[key] = value
+	}
+	return result
+}
+
+func retagRuns(runs []BarcodeRun, role string) []BarcodeRun {
+	result := make([]BarcodeRun, len(runs))
+	for index, run := range runs {
+		result[index] = run
+		result[index].Role = role
+		result[index].Metadata = copyMetadata(run.Metadata)
+	}
+	return result
+}
+
+// NormalizeITF validates even-length digit strings.
+func NormalizeITF(data string) (string, error) {
+	if data == "" {
+		return "", fmt.Errorf("ITF input must contain an even number of digits")
+	}
+	for _, ch := range data {
+		if ch < '0' || ch > '9' {
+			return "", fmt.Errorf("ITF input must contain digits only")
+		}
+	}
+	if len(data)%2 != 0 {
+		return "", fmt.Errorf("ITF input must contain an even number of digits")
+	}
+	return data, nil
+}
+
+// EncodeITF encodes an ITF payload into digit pairs.
+func EncodeITF(data string) ([]EncodedPair, error) {
+	normalized, err := NormalizeITF(data)
+	if err != nil {
+		return nil, err
+	}
+	encoded := make([]EncodedPair, 0, len(normalized)/2)
+	for index := 0; index < len(normalized); index += 2 {
+		pair := normalized[index : index+2]
+		barPattern := digitPatterns[int(pair[0]-'0')]
+		spacePattern := digitPatterns[int(pair[1]-'0')]
+		binaryPattern := ""
+		for offset := range barPattern {
+			barToken := "1"
+			if barPattern[offset] == '1' {
+				barToken = "111"
+			}
+			spaceToken := "0"
+			if spacePattern[offset] == '1' {
+				spaceToken = "000"
+			}
+			binaryPattern += barToken + spaceToken
+		}
+		encoded = append(encoded, EncodedPair{
+			Pair:          pair,
+			BarPattern:    barPattern,
+			SpacePattern:  spacePattern,
+			BinaryPattern: binaryPattern,
+			SourceIndex:   index / 2,
+		})
+	}
+	return encoded, nil
+}
+
+// ExpandITFRuns expands encoded digit pairs into barcode runs.
+func ExpandITFRuns(data string) ([]BarcodeRun, error) {
+	encoded, err := EncodeITF(data)
+	if err != nil {
+		return nil, err
+	}
+	runs := make([]BarcodeRun, 0)
+	startRuns, err := barcodelayout1d.RunsFromBinaryPattern(startPattern, '1', '0', "start", -1, nil)
+	if err != nil {
+		return nil, err
+	}
+	runs = append(runs, retagRuns(startRuns, "start")...)
+	for _, entry := range encoded {
+		segmentRuns, err := barcodelayout1d.RunsFromBinaryPattern(entry.BinaryPattern, '1', '0', entry.Pair, entry.SourceIndex, nil)
+		if err != nil {
+			return nil, err
+		}
+		runs = append(runs, retagRuns(segmentRuns, "data")...)
+	}
+	stopRuns, err := barcodelayout1d.RunsFromBinaryPattern(stopPattern, '1', '0', "stop", -2, nil)
+	if err != nil {
+		return nil, err
+	}
+	runs = append(runs, retagRuns(stopRuns, "stop")...)
+	return runs, nil
+}
+
+// LayoutITF generates a paint scene for ITF.
+func LayoutITF(data string, config RenderConfig) (paintinstructions.PaintScene, error) {
+	normalized, err := NormalizeITF(data)
+	if err != nil {
+		return paintinstructions.PaintScene{}, err
+	}
+	runs, err := ExpandITFRuns(normalized)
+	if err != nil {
+		return paintinstructions.PaintScene{}, err
+	}
+	return barcodelayout1d.DrawOneDimensionalBarcode(runs, config, barcodelayout1d.PaintOptions{
+		Fill:       "#000000",
+		Background: "#ffffff",
+		Metadata: paintinstructions.Metadata{
+			"symbology":  "itf",
+			"pair_count": len(normalized) / 2,
+		},
+	})
+}
+
+// DrawITF is a compatibility alias for LayoutITF.
+func DrawITF(data string, config RenderConfig) (paintinstructions.PaintScene, error) {
+	return LayoutITF(data, config)
+}

--- a/code/packages/go/itf/itf_test.go
+++ b/code/packages/go/itf/itf_test.go
@@ -1,0 +1,23 @@
+package itf
+
+import "testing"
+
+func TestITF(t *testing.T) {
+	if _, err := NormalizeITF("12345"); err == nil {
+		t.Fatal("expected odd-length input to fail")
+	}
+	encoded, err := EncodeITF("123456")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(encoded) != 3 || encoded[0].Pair != "12" {
+		t.Fatalf("unexpected encoding %#v", encoded)
+	}
+	runs, err := ExpandITFRuns("123456")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runs[0].Role != "start" || runs[len(runs)-1].Role != "stop" {
+		t.Fatalf("unexpected edge roles %#v %#v", runs[0], runs[len(runs)-1])
+	}
+}

--- a/code/packages/go/itf/required_capabilities.json
+++ b/code/packages/go/itf/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "go/itf",
+  "capabilities": [],
+  "justification": "Pure computation package for ITF normalization, encoding, run expansion, and paint-scene generation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/go/upc-a/BUILD
+++ b/code/packages/go/upc-a/BUILD
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/upc-a/go.mod
+++ b/code/packages/go/upc-a/go.mod
@@ -1,0 +1,11 @@
+module github.com/adhithyan15/coding-adventures/code/packages/go/upc-a
+
+go 1.26
+
+require (
+	github.com/adhithyan15/coding-adventures/code/packages/go/barcode-layout-1d v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/paint-instructions v0.0.0
+)
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/barcode-layout-1d => ../barcode-layout-1d
+replace github.com/adhithyan15/coding-adventures/code/packages/go/paint-instructions => ../paint-instructions

--- a/code/packages/go/upc-a/required_capabilities.json
+++ b/code/packages/go/upc-a/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "go/upc-a",
+  "capabilities": [],
+  "justification": "Pure computation package for UPC-A normalization, encoding, run expansion, and paint-scene generation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/go/upc-a/upc_a.go
+++ b/code/packages/go/upc-a/upc_a.go
@@ -1,0 +1,201 @@
+// Package upca implements the UPC-A barcode symbology and emits PaintScene.
+package upca
+
+import (
+	"fmt"
+
+	barcodelayout1d "github.com/adhithyan15/coding-adventures/code/packages/go/barcode-layout-1d"
+	paintinstructions "github.com/adhithyan15/coding-adventures/code/packages/go/paint-instructions"
+)
+
+const Version = "0.1.0"
+
+const sideGuard = "101"
+const centerGuard = "01010"
+
+type EncodedDigit struct {
+	Digit       string
+	Encoding    string
+	Pattern     string
+	SourceIndex int
+	Role        string
+}
+
+type BarcodeRun = barcodelayout1d.Barcode1DRun
+type RenderConfig = barcodelayout1d.LayoutConfig
+
+var DefaultLayoutConfig = barcodelayout1d.DefaultLayoutConfig
+var DefaultRenderConfig = DefaultLayoutConfig
+
+var digitPatterns = map[string][]string{
+	"L": {"0001101", "0011001", "0010011", "0111101", "0100011", "0110001", "0101111", "0111011", "0110111", "0001011"},
+	"R": {"1110010", "1100110", "1101100", "1000010", "1011100", "1001110", "1010000", "1000100", "1001000", "1110100"},
+}
+
+func copyMetadata(metadata paintinstructions.Metadata) paintinstructions.Metadata {
+	if metadata == nil {
+		return paintinstructions.Metadata{}
+	}
+	result := make(paintinstructions.Metadata, len(metadata))
+	for key, value := range metadata {
+		result[key] = value
+	}
+	return result
+}
+
+func assertDigits(data string, allowedLengths ...int) error {
+	if data == "" {
+		return fmt.Errorf("UPC-A input must contain digits only")
+	}
+	for _, ch := range data {
+		if ch < '0' || ch > '9' {
+			return fmt.Errorf("UPC-A input must contain digits only")
+		}
+	}
+	for _, length := range allowedLengths {
+		if len(data) == length {
+			return nil
+		}
+	}
+	return fmt.Errorf("UPC-A input must contain 11 digits or 12 digits")
+}
+
+func retagRuns(runs []BarcodeRun, role string) []BarcodeRun {
+	result := make([]BarcodeRun, len(runs))
+	for index, run := range runs {
+		result[index] = run
+		result[index].Role = role
+		result[index].Metadata = copyMetadata(run.Metadata)
+	}
+	return result
+}
+
+// ComputeUPCACheckDigit computes the check digit for an 11-digit payload.
+func ComputeUPCACheckDigit(payload11 string) (string, error) {
+	if err := assertDigits(payload11, 11); err != nil {
+		return "", err
+	}
+	oddSum := 0
+	evenSum := 0
+	for index, ch := range payload11 {
+		if index%2 == 0 {
+			oddSum += int(ch - '0')
+		} else {
+			evenSum += int(ch - '0')
+		}
+	}
+	return fmt.Sprintf("%d", (10-(((oddSum*3)+evenSum)%10))%10), nil
+}
+
+// NormalizeUPCA normalizes UPC-A payloads and computes the check digit when needed.
+func NormalizeUPCA(data string) (string, error) {
+	if err := assertDigits(data, 11, 12); err != nil {
+		return "", err
+	}
+	if len(data) == 11 {
+		checkDigit, err := ComputeUPCACheckDigit(data)
+		if err != nil {
+			return "", err
+		}
+		return data + checkDigit, nil
+	}
+	expected, err := ComputeUPCACheckDigit(data[:11])
+	if err != nil {
+		return "", err
+	}
+	if expected != data[11:] {
+		return "", fmt.Errorf("invalid UPC-A check digit: expected %s but received %s", expected, data[11:])
+	}
+	return data, nil
+}
+
+// EncodeUPCA encodes a UPC-A payload into logical digits.
+func EncodeUPCA(data string) ([]EncodedDigit, error) {
+	normalized, err := NormalizeUPCA(data)
+	if err != nil {
+		return nil, err
+	}
+	encoded := make([]EncodedDigit, 0, len(normalized))
+	for index, ch := range normalized {
+		encoding := "R"
+		if index < 6 {
+			encoding = "L"
+		}
+		role := "data"
+		if index == 11 {
+			role = "check"
+		}
+		encoded = append(encoded, EncodedDigit{
+			Digit:       string(ch),
+			Encoding:    encoding,
+			Pattern:     digitPatterns[encoding][int(ch-'0')],
+			SourceIndex: index,
+			Role:        role,
+		})
+	}
+	return encoded, nil
+}
+
+// ExpandUPCARuns expands an encoded UPC-A payload into barcode runs.
+func ExpandUPCARuns(data string) ([]BarcodeRun, error) {
+	encoded, err := EncodeUPCA(data)
+	if err != nil {
+		return nil, err
+	}
+	runs := make([]BarcodeRun, 0)
+	startRuns, err := barcodelayout1d.RunsFromBinaryPattern(sideGuard, '1', '0', "start", -1, nil)
+	if err != nil {
+		return nil, err
+	}
+	runs = append(runs, retagRuns(startRuns, "guard")...)
+	for _, entry := range encoded[:6] {
+		segmentRuns, err := barcodelayout1d.RunsFromBinaryPattern(entry.Pattern, '1', '0', entry.Digit, entry.SourceIndex, nil)
+		if err != nil {
+			return nil, err
+		}
+		runs = append(runs, retagRuns(segmentRuns, entry.Role)...)
+	}
+	centerRuns, err := barcodelayout1d.RunsFromBinaryPattern(centerGuard, '1', '0', "center", -2, nil)
+	if err != nil {
+		return nil, err
+	}
+	runs = append(runs, retagRuns(centerRuns, "guard")...)
+	for _, entry := range encoded[6:] {
+		segmentRuns, err := barcodelayout1d.RunsFromBinaryPattern(entry.Pattern, '1', '0', entry.Digit, entry.SourceIndex, nil)
+		if err != nil {
+			return nil, err
+		}
+		runs = append(runs, retagRuns(segmentRuns, entry.Role)...)
+	}
+	endRuns, err := barcodelayout1d.RunsFromBinaryPattern(sideGuard, '1', '0', "end", -3, nil)
+	if err != nil {
+		return nil, err
+	}
+	runs = append(runs, retagRuns(endRuns, "guard")...)
+	return runs, nil
+}
+
+// LayoutUPCA generates a paint scene for UPC-A.
+func LayoutUPCA(data string, config RenderConfig) (paintinstructions.PaintScene, error) {
+	normalized, err := NormalizeUPCA(data)
+	if err != nil {
+		return paintinstructions.PaintScene{}, err
+	}
+	runs, err := ExpandUPCARuns(normalized)
+	if err != nil {
+		return paintinstructions.PaintScene{}, err
+	}
+	return barcodelayout1d.DrawOneDimensionalBarcode(runs, config, barcodelayout1d.PaintOptions{
+		Fill:       "#000000",
+		Background: "#ffffff",
+		Metadata: paintinstructions.Metadata{
+			"symbology":       "upc-a",
+			"content_modules": 95,
+		},
+	})
+}
+
+// DrawUPCA is a compatibility alias for LayoutUPCA.
+func DrawUPCA(data string, config RenderConfig) (paintinstructions.PaintScene, error) {
+	return LayoutUPCA(data, config)
+}

--- a/code/packages/go/upc-a/upc_a_test.go
+++ b/code/packages/go/upc-a/upc_a_test.go
@@ -1,0 +1,24 @@
+package upca
+
+import "testing"
+
+func TestUPCA(t *testing.T) {
+	checkDigit, err := ComputeUPCACheckDigit("03600029145")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if checkDigit != "2" {
+		t.Fatalf("unexpected check digit %s", checkDigit)
+	}
+	runs, err := ExpandUPCARuns("036000291452")
+	if err != nil {
+		t.Fatal(err)
+	}
+	totalModules := 0
+	for _, run := range runs {
+		totalModules += run.Modules
+	}
+	if totalModules != 95 {
+		t.Fatalf("unexpected module count %d", totalModules)
+	}
+}

--- a/code/packages/python/barcode-1d/BUILD
+++ b/code/packages/python/barcode-1d/BUILD
@@ -1,8 +1,13 @@
 uv venv --quiet --clear
 uv pip install --python .venv/bin/python -e ../paint-instructions --quiet
 uv pip install --python .venv/bin/python -e ../barcode-layout-1d --quiet
-uv pip install --python .venv/bin/python -e ../code39 --quiet
 uv pip install --python .venv/bin/python -e ../pixel_container --quiet
+uv pip install --python .venv/bin/python -e ../code39 --quiet
+uv pip install --python .venv/bin/python -e ../codabar --quiet
+uv pip install --python .venv/bin/python -e ../code128 --quiet
+uv pip install --python .venv/bin/python -e ../ean-13 --quiet
+uv pip install --python .venv/bin/python -e ../itf --quiet
+uv pip install --python .venv/bin/python -e ../upc-a --quiet
 if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "arm64" ]; then (cd ../paint-vm-metal-native && bash BUILD) && (cd ../paint-codec-png-native && bash BUILD) && uv pip install --python .venv/bin/python -e ../paint-vm-metal-native --quiet && uv pip install --python .venv/bin/python -e ../paint-codec-png-native --quiet; fi
 uv pip install --python .venv/bin/python -e ".[dev]" --quiet
 .venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/barcode-1d/BUILD_windows
+++ b/code/packages/python/barcode-1d/BUILD_windows
@@ -2,7 +2,12 @@ echo Windows prerequisite refs for python/barcode-1d: ../paint-vm-metal-native .
 uv venv --quiet --clear
 uv pip install --python .venv\Scripts\python.exe -e ../paint-instructions --quiet
 uv pip install --python .venv\Scripts\python.exe -e ../barcode-layout-1d --quiet
-uv pip install --python .venv\Scripts\python.exe -e ../code39 --quiet
 uv pip install --python .venv\Scripts\python.exe -e ../pixel_container --quiet
+uv pip install --python .venv\Scripts\python.exe -e ../code39 --quiet
+uv pip install --python .venv\Scripts\python.exe -e ../codabar --quiet
+uv pip install --python .venv\Scripts\python.exe -e ../code128 --quiet
+uv pip install --python .venv\Scripts\python.exe -e ../ean-13 --quiet
+uv pip install --python .venv\Scripts\python.exe -e ../itf --quiet
+uv pip install --python .venv\Scripts\python.exe -e ../upc-a --quiet
 uv pip install --python .venv\Scripts\python.exe -e .[dev] --quiet
 .venv\Scripts\python.exe -m pytest tests -v

--- a/code/packages/python/barcode-1d/pyproject.toml
+++ b/code/packages/python/barcode-1d/pyproject.toml
@@ -11,8 +11,13 @@ license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]
 readme = "README.md"
 dependencies = [
+    "coding-adventures-codabar",
+    "coding-adventures-code128",
     "coding-adventures-code39",
+    "coding-adventures-ean-13",
+    "coding-adventures-itf",
     "coding-adventures-pixel_container",
+    "coding-adventures-upc-a",
 ]
 
 [project.optional-dependencies]

--- a/code/packages/python/barcode-1d/src/barcode_1d/__init__.py
+++ b/code/packages/python/barcode-1d/src/barcode_1d/__init__.py
@@ -6,8 +6,13 @@ import importlib
 import platform
 from typing import Any
 
+import codabar
+import code128
 import code39
+import ean_13
+import itf
 from pixel_container import PixelContainer
+import upc_a
 
 __version__ = "0.1.0"
 
@@ -47,6 +52,16 @@ def _normalize_symbology(symbology: str) -> str:
     normalized = symbology.replace("-", "").replace("_", "").lower()
     if normalized == "code39":
         return "code39"
+    if normalized == "codabar":
+        return "codabar"
+    if normalized == "code128":
+        return "code128"
+    if normalized == "ean13":
+        return "ean13"
+    if normalized == "itf":
+        return "itf"
+    if normalized == "upca":
+        return "upca"
     raise UnsupportedSymbologyError(f"unsupported symbology: {symbology}")
 
 
@@ -59,6 +74,16 @@ def build_scene(
     match _normalize_symbology(symbology):
         case "code39":
             return code39.layout_code39(data, layout_config)
+        case "codabar":
+            return codabar.layout_codabar(data, layout_config)
+        case "code128":
+            return code128.layout_code128(data, layout_config)
+        case "ean13":
+            return ean_13.layout_ean_13(data, layout_config)
+        case "itf":
+            return itf.layout_itf(data, layout_config)
+        case "upca":
+            return upc_a.layout_upc_a(data, layout_config)
 
 
 def _load_module(module_name: str):

--- a/code/packages/python/barcode-1d/tests/test_barcode_1d.py
+++ b/code/packages/python/barcode-1d/tests/test_barcode_1d.py
@@ -9,13 +9,29 @@ def test_build_scene() -> None:
     assert scene.background == "#ffffff"
 
 
+@pytest.mark.parametrize(
+    ("symbology", "data"),
+    [
+        ("codabar", "40156"),
+        ("code128", "Code 128"),
+        ("ean13", "400638133393"),
+        ("itf", "123456"),
+        ("upca", "03600029145"),
+    ],
+)
+def test_build_scene_for_additional_symbologies(symbology: str, data: str) -> None:
+    scene = barcode_1d.build_scene(data, symbology=symbology)
+    assert scene.width > 0
+    assert scene.metadata["symbology"]
+
+
 def test_current_backend_probe() -> None:
     assert barcode_1d.current_backend() in {"metal", None}
 
 
 def test_build_scene_rejects_unsupported_symbology() -> None:
     with pytest.raises(barcode_1d.UnsupportedSymbologyError):
-        barcode_1d.build_scene("HELLO-123", symbology="ean13")
+        barcode_1d.build_scene("HELLO-123", symbology="qr")
 
 
 def test_render_pixels_fails_without_native_backend(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/code/packages/python/codabar/BUILD
+++ b/code/packages/python/codabar/BUILD
@@ -1,0 +1,5 @@
+uv venv --quiet --clear
+uv pip install -e ../paint-instructions --quiet
+uv pip install -e ../barcode-layout-1d --quiet
+uv pip install -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/codabar/BUILD_windows
+++ b/code/packages/python/codabar/BUILD_windows
@@ -1,0 +1,6 @@
+uv venv --quiet --clear
+uv pip install -e ../paint-instructions --quiet
+uv pip install -e ../barcode-layout-1d --quiet
+uv pip install --no-deps -e .[dev] --quiet
+uv pip install pytest pytest-cov ruff mypy --quiet
+uv run --no-project python -m pytest tests/ -v

--- a/code/packages/python/codabar/pyproject.toml
+++ b/code/packages/python/codabar/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-codabar"
+version = "0.1.0"
+description = "Dependency-free Codabar encoder that emits backend-neutral paint scenes"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+dependencies = ["coding-adventures-barcode-layout-1d"]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/codabar"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM", "ANN"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=codabar --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.run]
+source = ["src/codabar"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/packages/python/codabar/src/codabar/__init__.py
+++ b/code/packages/python/codabar/src/codabar/__init__.py
@@ -1,0 +1,164 @@
+"""Dependency-free Codabar encoder that emits backend-neutral paint scenes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from barcode_layout_1d import (
+    DEFAULT_BARCODE_1D_LAYOUT_CONFIG,
+    Barcode1DLayoutConfig,
+    Barcode1DRun,
+    Barcode1DError,
+    PaintBarcode1DOptions,
+    draw_one_dimensional_barcode,
+    runs_from_binary_pattern,
+)
+from paint_instructions import PaintScene
+
+__version__ = "0.1.0"
+
+
+@dataclass(frozen=True)
+class EncodedCodabarSymbol:
+    char: str
+    pattern: str
+    source_index: int
+    role: str
+
+
+DEFAULT_LAYOUT_CONFIG: Final = DEFAULT_BARCODE_1D_LAYOUT_CONFIG
+DEFAULT_RENDER_CONFIG: Final = DEFAULT_LAYOUT_CONFIG
+
+
+class CodabarError(Barcode1DError):
+    """Base error for Codabar input issues."""
+
+
+class InvalidCodabarInputError(CodabarError):
+    """Raised when a Codabar payload cannot be encoded."""
+
+
+GUARDS: Final = {"A", "B", "C", "D"}
+
+PATTERNS: Final[dict[str, str]] = {
+    "0": "101010011",
+    "1": "101011001",
+    "2": "101001011",
+    "3": "110010101",
+    "4": "101101001",
+    "5": "110101001",
+    "6": "100101011",
+    "7": "100101101",
+    "8": "100110101",
+    "9": "110100101",
+    "-": "101001101",
+    "$": "101100101",
+    ":": "1101011011",
+    "/": "1101101011",
+    ".": "1101101101",
+    "+": "1011011011",
+    "A": "1011001001",
+    "B": "1001001011",
+    "C": "1010010011",
+    "D": "1010011001",
+}
+
+
+def _is_guard(char: str) -> bool:
+    return char in GUARDS
+
+
+def _assert_body_chars(body: str) -> None:
+    for char in body:
+        if char not in PATTERNS or _is_guard(char):
+            raise InvalidCodabarInputError(f'Invalid Codabar body character "{char}"')
+
+
+def _retag_runs(runs: list[Barcode1DRun], role: str) -> list[Barcode1DRun]:
+    return [
+        Barcode1DRun(run.color, run.modules, run.source_char, run.source_index, role, dict(run.metadata))
+        for run in runs
+    ]
+
+
+def normalize_codabar(data: str, *, start: str = "A", stop: str = "A") -> str:
+    normalized = data.upper()
+
+    if len(normalized) >= 2 and _is_guard(normalized[0]) and _is_guard(normalized[-1]):
+        _assert_body_chars(normalized[1:-1])
+        return normalized
+
+    if not _is_guard(start) or not _is_guard(stop):
+        raise InvalidCodabarInputError("Codabar guards must be one of A, B, C, or D")
+
+    _assert_body_chars(normalized)
+    return f"{start}{normalized}{stop}"
+
+
+def encode_codabar(data: str, *, start: str = "A", stop: str = "A") -> list[EncodedCodabarSymbol]:
+    normalized = normalize_codabar(data, start=start, stop=stop)
+    result: list[EncodedCodabarSymbol] = []
+
+    for index, char in enumerate(normalized):
+        role = "start" if index == 0 else "stop" if index == len(normalized) - 1 else "data"
+        result.append(EncodedCodabarSymbol(char, PATTERNS[char], index, role))
+
+    return result
+
+
+def expand_codabar_runs(data: str, *, start: str = "A", stop: str = "A") -> list[Barcode1DRun]:
+    encoded = encode_codabar(data, start=start, stop=stop)
+    runs: list[Barcode1DRun] = []
+
+    for index, symbol in enumerate(encoded):
+        symbol_runs = runs_from_binary_pattern(
+            symbol.pattern,
+            source_char=symbol.char,
+            source_index=symbol.source_index,
+        )
+        runs.extend(_retag_runs(symbol_runs, symbol.role))
+
+        if index < len(encoded) - 1:
+            runs.append(
+                Barcode1DRun(
+                    "space",
+                    1,
+                    symbol.char,
+                    symbol.source_index,
+                    "inter-character-gap",
+                )
+            )
+
+    return runs
+
+
+def layout_codabar(
+    data: str,
+    config: Barcode1DLayoutConfig = DEFAULT_LAYOUT_CONFIG,
+    *,
+    start: str = "A",
+    stop: str = "A",
+) -> PaintScene:
+    normalized = normalize_codabar(data, start=start, stop=stop)
+    return draw_one_dimensional_barcode(
+        expand_codabar_runs(normalized),
+        config,
+        PaintBarcode1DOptions(
+            metadata={
+                "symbology": "codabar",
+                "start": normalized[0],
+                "stop": normalized[-1],
+            }
+        ),
+    )
+
+
+def draw_codabar(
+    data: str,
+    config: Barcode1DLayoutConfig = DEFAULT_LAYOUT_CONFIG,
+    *,
+    start: str = "A",
+    stop: str = "A",
+) -> PaintScene:
+    return layout_codabar(data, config, start=start, stop=stop)

--- a/code/packages/python/codabar/tests/test_codabar.py
+++ b/code/packages/python/codabar/tests/test_codabar.py
@@ -1,0 +1,47 @@
+from codabar import (
+    __version__,
+    InvalidCodabarInputError,
+    draw_codabar,
+    encode_codabar,
+    expand_codabar_runs,
+    normalize_codabar,
+)
+
+
+def test_version_exists() -> None:
+    assert __version__ == "0.1.0"
+
+
+def test_normalize_codabar_defaults_to_a_guards() -> None:
+    assert normalize_codabar("40156") == "A40156A"
+
+
+def test_normalize_codabar_preserves_explicit_guards() -> None:
+    assert normalize_codabar("B40156D") == "B40156D"
+
+
+def test_normalize_codabar_rejects_invalid_body_chars() -> None:
+    try:
+        normalize_codabar("40*56")
+    except InvalidCodabarInputError:
+        assert True
+    else:
+        raise AssertionError("expected InvalidCodabarInputError")
+
+
+def test_encode_codabar_marks_outer_symbols() -> None:
+    encoded = encode_codabar("40156")
+    assert encoded[0].char == "A"
+    assert encoded[0].role == "start"
+    assert encoded[-1].role == "stop"
+
+
+def test_expand_codabar_runs_adds_inter_character_gaps() -> None:
+    runs = expand_codabar_runs("40156")
+    assert any(run.role == "inter-character-gap" for run in runs)
+
+
+def test_draw_codabar_returns_barcode_scene() -> None:
+    scene = draw_codabar("40156")
+    assert scene.metadata["symbology"] == "codabar"
+    assert scene.width > 0

--- a/code/packages/python/code128/BUILD
+++ b/code/packages/python/code128/BUILD
@@ -1,0 +1,5 @@
+uv venv --quiet --clear
+uv pip install -e ../paint-instructions --quiet
+uv pip install -e ../barcode-layout-1d --quiet
+uv pip install -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/code128/BUILD_windows
+++ b/code/packages/python/code128/BUILD_windows
@@ -1,0 +1,6 @@
+uv venv --quiet --clear
+uv pip install -e ../paint-instructions --quiet
+uv pip install -e ../barcode-layout-1d --quiet
+uv pip install --no-deps -e .[dev] --quiet
+uv pip install pytest pytest-cov ruff mypy --quiet
+uv run --no-project python -m pytest tests/ -v

--- a/code/packages/python/code128/pyproject.toml
+++ b/code/packages/python/code128/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-code128"
+version = "0.1.0"
+description = "Dependency-free Code 128 encoder that emits backend-neutral paint scenes"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+dependencies = ["coding-adventures-barcode-layout-1d"]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/code128"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM", "ANN"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=code128 --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.run]
+source = ["src/code128"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/packages/python/code128/src/code128/__init__.py
+++ b/code/packages/python/code128/src/code128/__init__.py
@@ -1,0 +1,160 @@
+"""Dependency-free Code 128 encoder that emits backend-neutral paint scenes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from barcode_layout_1d import (
+    DEFAULT_BARCODE_1D_LAYOUT_CONFIG,
+    Barcode1DLayoutConfig,
+    Barcode1DRun,
+    Barcode1DError,
+    PaintBarcode1DOptions,
+    draw_one_dimensional_barcode,
+    runs_from_binary_pattern,
+)
+from paint_instructions import PaintScene
+
+__version__ = "0.1.0"
+
+
+@dataclass(frozen=True)
+class EncodedCode128Symbol:
+    label: str
+    value: int
+    pattern: str
+    source_index: int
+    role: str
+
+
+DEFAULT_LAYOUT_CONFIG: Final = DEFAULT_BARCODE_1D_LAYOUT_CONFIG
+DEFAULT_RENDER_CONFIG: Final = DEFAULT_LAYOUT_CONFIG
+
+
+class Code128Error(Barcode1DError):
+    """Base error for Code 128 input issues."""
+
+
+class InvalidCode128InputError(Code128Error):
+    """Raised when input falls outside Code Set B."""
+
+
+START_B: Final = 104
+STOP: Final = 106
+
+PATTERNS: Final[tuple[str, ...]] = (
+    "11011001100", "11001101100", "11001100110", "10010011000", "10010001100",
+    "10001001100", "10011001000", "10011000100", "10001100100", "11001001000",
+    "11001000100", "11000100100", "10110011100", "10011011100", "10011001110",
+    "10111001100", "10011101100", "10011100110", "11001110010", "11001011100",
+    "11001001110", "11011100100", "11001110100", "11101101110", "11101001100",
+    "11100101100", "11100100110", "11101100100", "11100110100", "11100110010",
+    "11011011000", "11011000110", "11000110110", "10100011000", "10001011000",
+    "10001000110", "10110001000", "10001101000", "10001100010", "11010001000",
+    "11000101000", "11000100010", "10110111000", "10110001110", "10001101110",
+    "10111011000", "10111000110", "10001110110", "11101110110", "11010001110",
+    "11000101110", "11011101000", "11011100010", "11011101110", "11101011000",
+    "11101000110", "11100010110", "11101101000", "11101100010", "11100011010",
+    "11101111010", "11001000010", "11110001010", "10100110000", "10100001100",
+    "10010110000", "10010000110", "10000101100", "10000100110", "10110010000",
+    "10110000100", "10011010000", "10011000010", "10000110100", "10000110010",
+    "11000010010", "11001010000", "11110111010", "11000010100", "10001111010",
+    "10100111100", "10010111100", "10010011110", "10111100100", "10011110100",
+    "10011110010", "11110100100", "11110010100", "11110010010", "11011011110",
+    "11011110110", "11110110110", "10101111000", "10100011110", "10001011110",
+    "10111101000", "10111100010", "11110101000", "11110100010", "10111011110",
+    "10111101110", "11101011110", "11110101110", "11010000100", "11010010000",
+    "11010011100", "1100011101011",
+)
+
+
+def _retag_runs(runs: list[Barcode1DRun], role: str) -> list[Barcode1DRun]:
+    return [
+        Barcode1DRun(run.color, run.modules, run.source_char, run.source_index, role, dict(run.metadata))
+        for run in runs
+    ]
+
+
+def normalize_code128_b(data: str) -> str:
+    for char in data:
+        code = ord(char)
+        if code < 32 or code > 126:
+            raise InvalidCode128InputError(
+                "Code 128 Code Set B supports printable ASCII characters only"
+            )
+    return data
+
+
+def value_for_code128_b_char(char: str) -> int:
+    return ord(char) - 32
+
+
+def compute_code128_checksum(values: list[int]) -> int:
+    return (START_B + sum(value * (index + 1) for index, value in enumerate(values))) % 103
+
+
+def encode_code128_b(data: str) -> list[EncodedCode128Symbol]:
+    normalized = normalize_code128_b(data)
+    data_symbols = [
+        EncodedCode128Symbol(
+            char,
+            value_for_code128_b_char(char),
+            PATTERNS[value_for_code128_b_char(char)],
+            index,
+            "data",
+        )
+        for index, char in enumerate(normalized)
+    ]
+    checksum = compute_code128_checksum([symbol.value for symbol in data_symbols])
+
+    return [
+        EncodedCode128Symbol("Start B", START_B, PATTERNS[START_B], -1, "start"),
+        *data_symbols,
+        EncodedCode128Symbol(
+            f"Checksum {checksum}",
+            checksum,
+            PATTERNS[checksum],
+            len(normalized),
+            "check",
+        ),
+        EncodedCode128Symbol("Stop", STOP, PATTERNS[STOP], len(normalized) + 1, "stop"),
+    ]
+
+
+def expand_code128_runs(data: str) -> list[Barcode1DRun]:
+    runs: list[Barcode1DRun] = []
+    for symbol in encode_code128_b(data):
+        segment_runs = runs_from_binary_pattern(
+            symbol.pattern,
+            source_char=symbol.label,
+            source_index=symbol.source_index,
+        )
+        runs.extend(_retag_runs(segment_runs, symbol.role))
+    return runs
+
+
+def layout_code128(
+    data: str,
+    config: Barcode1DLayoutConfig = DEFAULT_LAYOUT_CONFIG,
+) -> PaintScene:
+    normalized = normalize_code128_b(data)
+    checksum = encode_code128_b(normalized)[-2].value
+    return draw_one_dimensional_barcode(
+        expand_code128_runs(normalized),
+        config,
+        PaintBarcode1DOptions(
+            metadata={
+                "symbology": "code128",
+                "code_set": "B",
+                "checksum": checksum,
+            }
+        ),
+    )
+
+
+def draw_code128(
+    data: str,
+    config: Barcode1DLayoutConfig = DEFAULT_LAYOUT_CONFIG,
+) -> PaintScene:
+    return layout_code128(data, config)

--- a/code/packages/python/code128/tests/test_code128.py
+++ b/code/packages/python/code128/tests/test_code128.py
@@ -1,0 +1,51 @@
+from code128 import (
+    __version__,
+    InvalidCode128InputError,
+    compute_code128_checksum,
+    draw_code128,
+    encode_code128_b,
+    expand_code128_runs,
+    normalize_code128_b,
+)
+
+
+def test_version_exists() -> None:
+    assert __version__ == "0.1.0"
+
+
+def test_normalize_code128_b_accepts_printable_ascii() -> None:
+    assert normalize_code128_b("Code 128") == "Code 128"
+
+
+def test_normalize_code128_b_rejects_control_characters() -> None:
+    try:
+        normalize_code128_b("bad\ninput")
+    except InvalidCode128InputError:
+        assert True
+    else:
+        raise AssertionError("expected InvalidCode128InputError")
+
+
+def test_compute_code128_checksum_matches_reference() -> None:
+    assert compute_code128_checksum([35, 79, 68, 69, 0, 17, 18, 24]) == 64
+
+
+def test_encode_code128_b_adds_start_checksum_and_stop() -> None:
+    encoded = encode_code128_b("Code 128")
+    assert encoded[0].label == "Start B"
+    assert encoded[0].role == "start"
+    assert encoded[-2].label == "Checksum 64"
+    assert encoded[-1].role == "stop"
+
+
+def test_expand_code128_runs_ends_with_stop_pattern() -> None:
+    runs = expand_code128_runs("Hi")
+    assert runs[-1].source_char == "Stop"
+    assert runs[-1].role == "stop"
+
+
+def test_draw_code128_returns_barcode_scene() -> None:
+    scene = draw_code128("Code 128")
+    assert scene.metadata["symbology"] == "code128"
+    assert scene.metadata["code_set"] == "B"
+    assert scene.metadata["checksum"] == 64

--- a/code/packages/python/ean-13/BUILD
+++ b/code/packages/python/ean-13/BUILD
@@ -1,0 +1,5 @@
+uv venv --quiet --clear
+uv pip install -e ../paint-instructions --quiet
+uv pip install -e ../barcode-layout-1d --quiet
+uv pip install -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/ean-13/BUILD_windows
+++ b/code/packages/python/ean-13/BUILD_windows
@@ -1,0 +1,6 @@
+uv venv --quiet --clear
+uv pip install -e ../paint-instructions --quiet
+uv pip install -e ../barcode-layout-1d --quiet
+uv pip install --no-deps -e .[dev] --quiet
+uv pip install pytest pytest-cov ruff mypy --quiet
+uv run --no-project python -m pytest tests/ -v

--- a/code/packages/python/ean-13/pyproject.toml
+++ b/code/packages/python/ean-13/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-ean-13"
+version = "0.1.0"
+description = "Dependency-free EAN-13 encoder that emits backend-neutral paint scenes"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+dependencies = ["coding-adventures-barcode-layout-1d"]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/ean_13"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM", "ANN"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=ean_13 --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.run]
+source = ["src/ean_13"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/packages/python/ean-13/src/ean_13/__init__.py
+++ b/code/packages/python/ean-13/src/ean_13/__init__.py
@@ -1,0 +1,225 @@
+"""Dependency-free EAN-13 encoder that emits backend-neutral paint scenes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from barcode_layout_1d import (
+    DEFAULT_BARCODE_1D_LAYOUT_CONFIG,
+    Barcode1DLayoutConfig,
+    Barcode1DRun,
+    Barcode1DError,
+    PaintBarcode1DOptions,
+    draw_one_dimensional_barcode,
+    runs_from_binary_pattern,
+)
+from paint_instructions import PaintScene
+
+__version__ = "0.1.0"
+
+
+@dataclass(frozen=True)
+class EncodedDigit:
+    digit: str
+    encoding: str
+    pattern: str
+    source_index: int
+    role: str
+
+
+DEFAULT_LAYOUT_CONFIG: Final = DEFAULT_BARCODE_1D_LAYOUT_CONFIG
+DEFAULT_RENDER_CONFIG: Final = DEFAULT_LAYOUT_CONFIG
+
+
+class Ean13Error(Barcode1DError):
+    """Base error for EAN-13 input issues."""
+
+
+class InvalidEan13InputError(Ean13Error):
+    """Raised when EAN-13 input is malformed."""
+
+
+class InvalidEan13CheckDigitError(Ean13Error):
+    """Raised when an explicit check digit is wrong."""
+
+
+SIDE_GUARD: Final = "101"
+CENTER_GUARD: Final = "01010"
+
+DIGIT_PATTERNS: Final[dict[str, list[str]]] = {
+    "L": [
+        "0001101", "0011001", "0010011", "0111101", "0100011",
+        "0110001", "0101111", "0111011", "0110111", "0001011",
+    ],
+    "G": [
+        "0100111", "0110011", "0011011", "0100001", "0011101",
+        "0111001", "0000101", "0010001", "0001001", "0010111",
+    ],
+    "R": [
+        "1110010", "1100110", "1101100", "1000010", "1011100",
+        "1001110", "1010000", "1000100", "1001000", "1110100",
+    ],
+}
+
+LEFT_PARITY_PATTERNS: Final = (
+    "LLLLLL",
+    "LLGLGG",
+    "LLGGLG",
+    "LLGGGL",
+    "LGLLGG",
+    "LGGLLG",
+    "LGGGLL",
+    "LGLGLG",
+    "LGLGGL",
+    "LGGLGL",
+)
+
+
+def _assert_digits(data: str, expected_lengths: set[int]) -> None:
+    if not data.isdigit():
+        raise InvalidEan13InputError("EAN-13 input must contain digits only")
+    if len(data) not in expected_lengths:
+        raise InvalidEan13InputError("EAN-13 input must contain 12 digits or 13 digits")
+
+
+def _retag_runs(runs: list[Barcode1DRun], role: str) -> list[Barcode1DRun]:
+    return [
+        Barcode1DRun(run.color, run.modules, run.source_char, run.source_index, role, dict(run.metadata))
+        for run in runs
+    ]
+
+
+def compute_ean_13_check_digit(payload12: str) -> str:
+    _assert_digits(payload12, {12})
+    total = sum(
+        int(digit) * (3 if index % 2 == 0 else 1)
+        for index, digit in enumerate(reversed(payload12))
+    )
+    return str((10 - (total % 10)) % 10)
+
+
+def normalize_ean_13(data: str) -> str:
+    _assert_digits(data, {12, 13})
+    if len(data) == 12:
+        return f"{data}{compute_ean_13_check_digit(data)}"
+
+    expected = compute_ean_13_check_digit(data[:12])
+    actual = data[12]
+    if expected != actual:
+        raise InvalidEan13CheckDigitError(
+            f"Invalid EAN-13 check digit: expected {expected} but received {actual}"
+        )
+    return data
+
+
+def left_parity_pattern(data: str) -> str:
+    normalized = normalize_ean_13(data)
+    return LEFT_PARITY_PATTERNS[int(normalized[0])]
+
+
+def encode_ean_13(data: str) -> list[EncodedDigit]:
+    normalized = normalize_ean_13(data)
+    parity = LEFT_PARITY_PATTERNS[int(normalized[0])]
+    digits = list(normalized)
+
+    left_digits = [
+        EncodedDigit(
+            digit,
+            parity[offset],
+            DIGIT_PATTERNS[parity[offset]][int(digit)],
+            offset + 1,
+            "data",
+        )
+        for offset, digit in enumerate(digits[1:7])
+    ]
+
+    right_digits = [
+        EncodedDigit(
+            digit,
+            "R",
+            DIGIT_PATTERNS["R"][int(digit)],
+            offset + 7,
+            "check" if offset == 5 else "data",
+        )
+        for offset, digit in enumerate(digits[7:])
+    ]
+
+    return [*left_digits, *right_digits]
+
+
+def expand_ean_13_runs(data: str) -> list[Barcode1DRun]:
+    encoded_digits = encode_ean_13(data)
+    runs: list[Barcode1DRun] = []
+
+    runs.extend(
+        _retag_runs(
+            runs_from_binary_pattern(SIDE_GUARD, source_char="start", source_index=-1),
+            "guard",
+        )
+    )
+
+    for entry in encoded_digits[:6]:
+        runs.extend(
+            _retag_runs(
+                runs_from_binary_pattern(
+                    entry.pattern,
+                    source_char=entry.digit,
+                    source_index=entry.source_index,
+                ),
+                entry.role,
+            )
+        )
+
+    runs.extend(
+        _retag_runs(
+            runs_from_binary_pattern(CENTER_GUARD, source_char="center", source_index=-2),
+            "guard",
+        )
+    )
+
+    for entry in encoded_digits[6:]:
+        runs.extend(
+            _retag_runs(
+                runs_from_binary_pattern(
+                    entry.pattern,
+                    source_char=entry.digit,
+                    source_index=entry.source_index,
+                ),
+                entry.role,
+            )
+        )
+
+    runs.extend(
+        _retag_runs(
+            runs_from_binary_pattern(SIDE_GUARD, source_char="end", source_index=-3),
+            "guard",
+        )
+    )
+    return runs
+
+
+def layout_ean_13(
+    data: str,
+    config: Barcode1DLayoutConfig = DEFAULT_LAYOUT_CONFIG,
+) -> PaintScene:
+    normalized = normalize_ean_13(data)
+    return draw_one_dimensional_barcode(
+        expand_ean_13_runs(normalized),
+        config,
+        PaintBarcode1DOptions(
+            metadata={
+                "symbology": "ean-13",
+                "leading_digit": normalized[0],
+                "left_parity": LEFT_PARITY_PATTERNS[int(normalized[0])],
+                "content_modules": 95,
+            }
+        ),
+    )
+
+
+def draw_ean_13(
+    data: str,
+    config: Barcode1DLayoutConfig = DEFAULT_LAYOUT_CONFIG,
+) -> PaintScene:
+    return layout_ean_13(data, config)

--- a/code/packages/python/ean-13/tests/test_ean_13.py
+++ b/code/packages/python/ean-13/tests/test_ean_13.py
@@ -1,0 +1,64 @@
+from ean_13 import (
+    __version__,
+    InvalidEan13CheckDigitError,
+    InvalidEan13InputError,
+    compute_ean_13_check_digit,
+    draw_ean_13,
+    encode_ean_13,
+    expand_ean_13_runs,
+    left_parity_pattern,
+    normalize_ean_13,
+)
+
+
+def test_version_exists() -> None:
+    assert __version__ == "0.1.0"
+
+
+def test_compute_ean_13_check_digit_matches_reference() -> None:
+    assert compute_ean_13_check_digit("400638133393") == "1"
+
+
+def test_normalize_ean_13_computes_check_digit() -> None:
+    assert normalize_ean_13("400638133393") == "4006381333931"
+
+
+def test_normalize_ean_13_rejects_non_digit_input() -> None:
+    try:
+        normalize_ean_13("40063813339A")
+    except InvalidEan13InputError:
+        assert True
+    else:
+        raise AssertionError("expected InvalidEan13InputError")
+
+
+def test_normalize_ean_13_rejects_bad_check_digit() -> None:
+    try:
+        normalize_ean_13("4006381333932")
+    except InvalidEan13CheckDigitError:
+        assert True
+    else:
+        raise AssertionError("expected InvalidEan13CheckDigitError")
+
+
+def test_left_parity_pattern_matches_reference() -> None:
+    assert left_parity_pattern("400638133393") == "LGLLGG"
+
+
+def test_encode_ean_13_tracks_parity_and_check_digit() -> None:
+    encoded = encode_ean_13("400638133393")
+    assert encoded[0].digit == "0"
+    assert encoded[0].encoding == "L"
+    assert encoded[1].encoding == "G"
+    assert encoded[-1].role == "check"
+
+
+def test_expand_ean_13_runs_total_95_modules() -> None:
+    runs = expand_ean_13_runs("400638133393")
+    assert sum(run.modules for run in runs) == 95
+
+
+def test_draw_ean_13_returns_scene_metadata() -> None:
+    scene = draw_ean_13("400638133393")
+    assert scene.metadata["symbology"] == "ean-13"
+    assert scene.metadata["left_parity"] == "LGLLGG"

--- a/code/packages/python/itf/BUILD
+++ b/code/packages/python/itf/BUILD
@@ -1,0 +1,5 @@
+uv venv --quiet --clear
+uv pip install -e ../paint-instructions --quiet
+uv pip install -e ../barcode-layout-1d --quiet
+uv pip install -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/itf/BUILD_windows
+++ b/code/packages/python/itf/BUILD_windows
@@ -1,0 +1,6 @@
+uv venv --quiet --clear
+uv pip install -e ../paint-instructions --quiet
+uv pip install -e ../barcode-layout-1d --quiet
+uv pip install --no-deps -e .[dev] --quiet
+uv pip install pytest pytest-cov ruff mypy --quiet
+uv run --no-project python -m pytest tests/ -v

--- a/code/packages/python/itf/pyproject.toml
+++ b/code/packages/python/itf/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-itf"
+version = "0.1.0"
+description = "Dependency-free ITF encoder that emits backend-neutral paint scenes"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+dependencies = ["coding-adventures-barcode-layout-1d"]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/itf"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM", "ANN"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=itf --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.run]
+source = ["src/itf"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/packages/python/itf/src/itf/__init__.py
+++ b/code/packages/python/itf/src/itf/__init__.py
@@ -1,0 +1,146 @@
+"""Dependency-free ITF encoder that emits backend-neutral paint scenes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from barcode_layout_1d import (
+    DEFAULT_BARCODE_1D_LAYOUT_CONFIG,
+    Barcode1DLayoutConfig,
+    Barcode1DRun,
+    Barcode1DError,
+    PaintBarcode1DOptions,
+    draw_one_dimensional_barcode,
+    runs_from_binary_pattern,
+)
+from paint_instructions import PaintScene
+
+__version__ = "0.1.0"
+
+
+@dataclass(frozen=True)
+class EncodedPair:
+    pair: str
+    bar_pattern: str
+    space_pattern: str
+    binary_pattern: str
+    source_index: int
+
+
+DEFAULT_LAYOUT_CONFIG: Final = DEFAULT_BARCODE_1D_LAYOUT_CONFIG
+DEFAULT_RENDER_CONFIG: Final = DEFAULT_LAYOUT_CONFIG
+
+
+class ItfError(Barcode1DError):
+    """Base error for ITF input issues."""
+
+
+class InvalidItfInputError(ItfError):
+    """Raised when ITF input is malformed."""
+
+
+START_PATTERN: Final = "1010"
+STOP_PATTERN: Final = "11101"
+
+DIGIT_PATTERNS: Final = (
+    "00110",
+    "10001",
+    "01001",
+    "11000",
+    "00101",
+    "10100",
+    "01100",
+    "00011",
+    "10010",
+    "01010",
+)
+
+
+def _retag_runs(runs: list[Barcode1DRun], role: str) -> list[Barcode1DRun]:
+    return [
+        Barcode1DRun(run.color, run.modules, run.source_char, run.source_index, role, dict(run.metadata))
+        for run in runs
+    ]
+
+
+def normalize_itf(data: str) -> str:
+    if not data.isdigit():
+        raise InvalidItfInputError("ITF input must contain digits only")
+    if len(data) == 0 or len(data) % 2 != 0:
+        raise InvalidItfInputError("ITF input must contain an even number of digits")
+    return data
+
+
+def _encode_pair(pair: str, source_index: int) -> EncodedPair:
+    bar_pattern = DIGIT_PATTERNS[int(pair[0])]
+    space_pattern = DIGIT_PATTERNS[int(pair[1])]
+    binary_pattern = "".join(
+        f'{"111" if bar_marker == "1" else "1"}{"000" if space_marker == "1" else "0"}'
+        for bar_marker, space_marker in zip(bar_pattern, space_pattern, strict=True)
+    )
+    return EncodedPair(pair, bar_pattern, space_pattern, binary_pattern, source_index)
+
+
+def encode_itf(data: str) -> list[EncodedPair]:
+    normalized = normalize_itf(data)
+    return [
+        _encode_pair(normalized[index : index + 2], index // 2)
+        for index in range(0, len(normalized), 2)
+    ]
+
+
+def expand_itf_runs(data: str) -> list[Barcode1DRun]:
+    encoded_pairs = encode_itf(data)
+    runs: list[Barcode1DRun] = []
+
+    runs.extend(
+        _retag_runs(
+            runs_from_binary_pattern(START_PATTERN, source_char="start", source_index=-1),
+            "start",
+        )
+    )
+
+    for entry in encoded_pairs:
+        runs.extend(
+            _retag_runs(
+                runs_from_binary_pattern(
+                    entry.binary_pattern,
+                    source_char=entry.pair,
+                    source_index=entry.source_index,
+                ),
+                "data",
+            )
+        )
+
+    runs.extend(
+        _retag_runs(
+            runs_from_binary_pattern(STOP_PATTERN, source_char="stop", source_index=-2),
+            "stop",
+        )
+    )
+    return runs
+
+
+def layout_itf(
+    data: str,
+    config: Barcode1DLayoutConfig = DEFAULT_LAYOUT_CONFIG,
+) -> PaintScene:
+    normalized = normalize_itf(data)
+    return draw_one_dimensional_barcode(
+        expand_itf_runs(normalized),
+        config,
+        PaintBarcode1DOptions(
+            metadata={
+                "symbology": "itf",
+                "pair_count": len(normalized) // 2,
+            }
+        ),
+    )
+
+
+def draw_itf(
+    data: str,
+    config: Barcode1DLayoutConfig = DEFAULT_LAYOUT_CONFIG,
+) -> PaintScene:
+    return layout_itf(data, config)

--- a/code/packages/python/itf/tests/test_itf.py
+++ b/code/packages/python/itf/tests/test_itf.py
@@ -1,0 +1,45 @@
+from itf import (
+    __version__,
+    InvalidItfInputError,
+    draw_itf,
+    encode_itf,
+    expand_itf_runs,
+    normalize_itf,
+)
+
+
+def test_version_exists() -> None:
+    assert __version__ == "0.1.0"
+
+
+def test_normalize_itf_accepts_even_length_digit_string() -> None:
+    assert normalize_itf("123456") == "123456"
+
+
+def test_normalize_itf_rejects_odd_length_input() -> None:
+    try:
+        normalize_itf("12345")
+    except InvalidItfInputError:
+        assert True
+    else:
+        raise AssertionError("expected InvalidItfInputError")
+
+
+def test_encode_itf_encodes_digit_pairs() -> None:
+    encoded = encode_itf("123456")
+    assert len(encoded) == 3
+    assert encoded[0].pair == "12"
+
+
+def test_expand_itf_runs_include_start_and_stop_patterns() -> None:
+    runs = expand_itf_runs("123456")
+    assert runs[0].source_char == "start"
+    assert runs[0].role == "start"
+    assert runs[-1].source_char == "stop"
+    assert runs[-1].role == "stop"
+
+
+def test_draw_itf_returns_barcode_scene() -> None:
+    scene = draw_itf("123456")
+    assert scene.metadata["symbology"] == "itf"
+    assert scene.metadata["pair_count"] == 3

--- a/code/packages/python/upc-a/BUILD
+++ b/code/packages/python/upc-a/BUILD
@@ -1,0 +1,5 @@
+uv venv --quiet --clear
+uv pip install -e ../paint-instructions --quiet
+uv pip install -e ../barcode-layout-1d --quiet
+uv pip install -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/upc-a/BUILD_windows
+++ b/code/packages/python/upc-a/BUILD_windows
@@ -1,0 +1,6 @@
+uv venv --quiet --clear
+uv pip install -e ../paint-instructions --quiet
+uv pip install -e ../barcode-layout-1d --quiet
+uv pip install --no-deps -e .[dev] --quiet
+uv pip install pytest pytest-cov ruff mypy --quiet
+uv run --no-project python -m pytest tests/ -v

--- a/code/packages/python/upc-a/pyproject.toml
+++ b/code/packages/python/upc-a/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-upc-a"
+version = "0.1.0"
+description = "Dependency-free UPC-A encoder that emits backend-neutral paint scenes"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+dependencies = ["coding-adventures-barcode-layout-1d"]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/upc_a"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM", "ANN"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=upc_a --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.run]
+source = ["src/upc_a"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/packages/python/upc-a/src/upc_a/__init__.py
+++ b/code/packages/python/upc-a/src/upc_a/__init__.py
@@ -1,0 +1,192 @@
+"""Dependency-free UPC-A encoder that emits backend-neutral paint scenes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from barcode_layout_1d import (
+    DEFAULT_BARCODE_1D_LAYOUT_CONFIG,
+    Barcode1DLayoutConfig,
+    Barcode1DRun,
+    Barcode1DError,
+    PaintBarcode1DOptions,
+    draw_one_dimensional_barcode,
+    runs_from_binary_pattern,
+)
+from paint_instructions import PaintScene
+
+__version__ = "0.1.0"
+
+
+@dataclass(frozen=True)
+class EncodedDigit:
+    digit: str
+    encoding: str
+    pattern: str
+    source_index: int
+    role: str
+
+
+DEFAULT_LAYOUT_CONFIG: Final = DEFAULT_BARCODE_1D_LAYOUT_CONFIG
+DEFAULT_RENDER_CONFIG: Final = DEFAULT_LAYOUT_CONFIG
+
+
+class UpcAError(Barcode1DError):
+    """Base error for UPC-A input issues."""
+
+
+class InvalidUpcAInputError(UpcAError):
+    """Raised when UPC-A input is malformed."""
+
+
+class InvalidUpcACheckDigitError(UpcAError):
+    """Raised when an explicit check digit is wrong."""
+
+
+SIDE_GUARD: Final = "101"
+CENTER_GUARD: Final = "01010"
+
+DIGIT_PATTERNS: Final[dict[str, list[str]]] = {
+    "L": [
+        "0001101", "0011001", "0010011", "0111101", "0100011",
+        "0110001", "0101111", "0111011", "0110111", "0001011",
+    ],
+    "R": [
+        "1110010", "1100110", "1101100", "1000010", "1011100",
+        "1001110", "1010000", "1000100", "1001000", "1110100",
+    ],
+}
+
+
+def _assert_digits(data: str, expected_lengths: set[int]) -> None:
+    if not data.isdigit():
+        raise InvalidUpcAInputError("UPC-A input must contain digits only")
+    if len(data) not in expected_lengths:
+        raise InvalidUpcAInputError("UPC-A input must contain 11 digits or 12 digits")
+
+
+def _retag_runs(runs: list[Barcode1DRun], role: str) -> list[Barcode1DRun]:
+    return [
+        Barcode1DRun(run.color, run.modules, run.source_char, run.source_index, role, dict(run.metadata))
+        for run in runs
+    ]
+
+
+def compute_upc_a_check_digit(payload11: str) -> str:
+    _assert_digits(payload11, {11})
+
+    odd_sum = 0
+    even_sum = 0
+    for index, digit in enumerate(payload11):
+        if index % 2 == 0:
+            odd_sum += int(digit)
+        else:
+            even_sum += int(digit)
+
+    total = odd_sum * 3 + even_sum
+    return str((10 - (total % 10)) % 10)
+
+
+def normalize_upc_a(data: str) -> str:
+    _assert_digits(data, {11, 12})
+
+    if len(data) == 11:
+        return f"{data}{compute_upc_a_check_digit(data)}"
+
+    expected = compute_upc_a_check_digit(data[:11])
+    actual = data[11]
+    if expected != actual:
+        raise InvalidUpcACheckDigitError(
+            f"Invalid UPC-A check digit: expected {expected} but received {actual}"
+        )
+    return data
+
+
+def encode_upc_a(data: str) -> list[EncodedDigit]:
+    normalized = normalize_upc_a(data)
+    return [
+        EncodedDigit(
+            digit,
+            "L" if index < 6 else "R",
+            DIGIT_PATTERNS["L" if index < 6 else "R"][int(digit)],
+            index,
+            "check" if index == 11 else "data",
+        )
+        for index, digit in enumerate(normalized)
+    ]
+
+
+def expand_upc_a_runs(data: str) -> list[Barcode1DRun]:
+    encoded_digits = encode_upc_a(data)
+    runs: list[Barcode1DRun] = []
+
+    runs.extend(
+        _retag_runs(
+            runs_from_binary_pattern(SIDE_GUARD, source_char="start", source_index=-1),
+            "guard",
+        )
+    )
+
+    for entry in encoded_digits[:6]:
+        runs.extend(
+            _retag_runs(
+                runs_from_binary_pattern(
+                    entry.pattern,
+                    source_char=entry.digit,
+                    source_index=entry.source_index,
+                ),
+                entry.role,
+            )
+        )
+
+    runs.extend(
+        _retag_runs(
+            runs_from_binary_pattern(CENTER_GUARD, source_char="center", source_index=-2),
+            "guard",
+        )
+    )
+
+    for entry in encoded_digits[6:]:
+        runs.extend(
+            _retag_runs(
+                runs_from_binary_pattern(
+                    entry.pattern,
+                    source_char=entry.digit,
+                    source_index=entry.source_index,
+                ),
+                entry.role,
+            )
+        )
+
+    runs.extend(
+        _retag_runs(
+            runs_from_binary_pattern(SIDE_GUARD, source_char="end", source_index=-3),
+            "guard",
+        )
+    )
+    return runs
+
+
+def layout_upc_a(
+    data: str,
+    config: Barcode1DLayoutConfig = DEFAULT_LAYOUT_CONFIG,
+) -> PaintScene:
+    normalized = normalize_upc_a(data)
+    return draw_one_dimensional_barcode(
+        expand_upc_a_runs(normalized),
+        config,
+        PaintBarcode1DOptions(
+            metadata={
+                "symbology": "upc-a",
+                "content_modules": 95,
+            }
+        ),
+    )
+
+
+def draw_upc_a(
+    data: str,
+    config: Barcode1DLayoutConfig = DEFAULT_LAYOUT_CONFIG,
+) -> PaintScene:
+    return layout_upc_a(data, config)

--- a/code/packages/python/upc-a/tests/test_upc_a.py
+++ b/code/packages/python/upc-a/tests/test_upc_a.py
@@ -1,0 +1,60 @@
+from upc_a import (
+    __version__,
+    InvalidUpcACheckDigitError,
+    InvalidUpcAInputError,
+    compute_upc_a_check_digit,
+    draw_upc_a,
+    encode_upc_a,
+    expand_upc_a_runs,
+    normalize_upc_a,
+)
+
+
+def test_version_exists() -> None:
+    assert __version__ == "0.1.0"
+
+
+def test_compute_upc_a_check_digit_matches_reference() -> None:
+    assert compute_upc_a_check_digit("03600029145") == "2"
+
+
+def test_normalize_upc_a_computes_check_digit() -> None:
+    assert normalize_upc_a("03600029145") == "036000291452"
+
+
+def test_normalize_upc_a_rejects_non_digit_input() -> None:
+    try:
+        normalize_upc_a("03600A29145")
+    except InvalidUpcAInputError:
+        assert True
+    else:
+        raise AssertionError("expected InvalidUpcAInputError")
+
+
+def test_normalize_upc_a_rejects_bad_check_digit() -> None:
+    try:
+        normalize_upc_a("036000291453")
+    except InvalidUpcACheckDigitError:
+        assert True
+    else:
+        raise AssertionError("expected InvalidUpcACheckDigitError")
+
+
+def test_encode_upc_a_marks_final_digit_as_check() -> None:
+    encoded = encode_upc_a("03600029145")
+    assert len(encoded) == 12
+    assert encoded[0].encoding == "L"
+    assert encoded[-1].digit == "2"
+    assert encoded[-1].role == "check"
+
+
+def test_expand_upc_a_runs_total_95_modules() -> None:
+    runs = expand_upc_a_runs("03600029145")
+    assert sum(run.modules for run in runs) == 95
+    assert runs[0].role == "guard"
+
+
+def test_draw_upc_a_returns_barcode_scene() -> None:
+    scene = draw_upc_a("03600029145")
+    assert scene.metadata["symbology"] == "upc-a"
+    assert scene.metadata["content_modules"] == 95

--- a/code/packages/ruby/barcode_1d/BUILD
+++ b/code/packages/ruby/barcode_1d/BUILD
@@ -1,2 +1,2 @@
 if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "arm64" ]; then (cd ../paint_vm_metal_native && bash BUILD) && (cd ../paint_codec_png_native && bash BUILD); fi
-ruby -Ilib -I../code39/lib -I../barcode_layout_1d/lib -I../paint_instructions/lib -I../pixel_container/lib -I../paint_vm_metal_native/lib -I../paint_codec_png_native/lib test/test_barcode_1d.rb
+ruby -Ilib -I../barcode_layout_1d/lib -I../codabar/lib -I../code128/lib -I../code39/lib -I../ean_13/lib -I../itf/lib -I../paint_instructions/lib -I../pixel_container/lib -I../paint_vm_metal_native/lib -I../paint_codec_png_native/lib -I../upc_a/lib test/test_barcode_1d.rb

--- a/code/packages/ruby/barcode_1d/BUILD_windows
+++ b/code/packages/ruby/barcode_1d/BUILD_windows
@@ -1,1 +1,1 @@
-ruby -Ilib -I../code39/lib -I../barcode_layout_1d/lib -I../paint_instructions/lib -I../pixel_container/lib -I../paint_vm_metal_native/lib -I../paint_codec_png_native/lib test/test_barcode_1d.rb
+ruby -Ilib -I../barcode_layout_1d/lib -I../codabar/lib -I../code128/lib -I../code39/lib -I../ean_13/lib -I../itf/lib -I../paint_instructions/lib -I../pixel_container/lib -I../paint_vm_metal_native/lib -I../paint_codec_png_native/lib -I../upc_a/lib test/test_barcode_1d.rb

--- a/code/packages/ruby/barcode_1d/Gemfile
+++ b/code/packages/ruby/barcode_1d/Gemfile
@@ -7,3 +7,12 @@ gemspec
 # Bundler needs to know where to find each gem locally.
 gem "coding_adventures_paint_instructions", path: "../paint_instructions"
 gem "coding_adventures_barcode_layout_1d", path: "../barcode_layout_1d"
+gem "coding_adventures_codabar", path: "../codabar"
+gem "coding_adventures_code128", path: "../code128"
+gem "coding_adventures_code39", path: "../code39"
+gem "coding_adventures_ean_13", path: "../ean_13"
+gem "coding_adventures_itf", path: "../itf"
+gem "coding_adventures_upc_a", path: "../upc_a"
+gem "coding_adventures_pixel_container", path: "../pixel_container"
+gem "coding_adventures_paint_vm_metal_native", path: "../paint_vm_metal_native"
+gem "coding_adventures_paint_codec_png_native", path: "../paint_codec_png_native"

--- a/code/packages/ruby/barcode_1d/coding_adventures_barcode_1d.gemspec
+++ b/code/packages/ruby/barcode_1d/coding_adventures_barcode_1d.gemspec
@@ -19,9 +19,14 @@ Gem::Specification.new do |spec|
     "rubygems_mfa_required" => "true",
   }
 
+  spec.add_dependency "coding_adventures_codabar", "~> 0.1"
+  spec.add_dependency "coding_adventures_code128", "~> 0.1"
   spec.add_dependency "coding_adventures_code39", "~> 0.1"
+  spec.add_dependency "coding_adventures_ean_13", "~> 0.1"
+  spec.add_dependency "coding_adventures_itf", "~> 0.1"
   spec.add_dependency "coding_adventures_paint_vm_metal_native", "~> 0.1"
   spec.add_dependency "coding_adventures_paint_codec_png_native", "~> 0.1"
+  spec.add_dependency "coding_adventures_upc_a", "~> 0.1"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "rake", "~> 13.0"
 end

--- a/code/packages/ruby/barcode_1d/lib/coding_adventures_barcode_1d.rb
+++ b/code/packages/ruby/barcode_1d/lib/coding_adventures_barcode_1d.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
+require "coding_adventures_codabar"
+require "coding_adventures_code128"
 require "coding_adventures_code39"
+require "coding_adventures_ean_13"
+require "coding_adventures_itf"
+require "coding_adventures_upc_a"
 require_relative "coding_adventures/barcode_1d/version"
 
 module CodingAdventures
@@ -22,8 +27,18 @@ module CodingAdventures
 
     def build_scene(data, symbology: :code39, layout_config: DEFAULT_LAYOUT_CONFIG)
       case normalize_symbology(symbology)
+      when :codabar
+        CodingAdventures::Codabar.layout_codabar(data, layout_config)
+      when :code128
+        CodingAdventures::Code128.layout_code128(data, layout_config)
       when :code39
         CodingAdventures::Code39.layout_code39(data, layout_config)
+      when :ean13
+        CodingAdventures::Ean13.layout_ean_13(data, layout_config)
+      when :itf
+        CodingAdventures::Itf.layout_itf(data, layout_config)
+      when :upca
+        CodingAdventures::UpcA.layout_upc_a(data, layout_config)
       end
     end
 
@@ -49,7 +64,12 @@ module CodingAdventures
 
     def normalize_symbology(symbology)
       normalized = symbology.to_s.delete("_-").downcase
+      return :codabar if normalized == "codabar"
+      return :code128 if normalized == "code128"
       return :code39 if normalized == "code39"
+      return :ean13 if normalized == "ean13"
+      return :itf if normalized == "itf"
+      return :upca if normalized == "upca"
 
       raise UnsupportedSymbologyError, "unsupported symbology: #{symbology}"
     end

--- a/code/packages/ruby/barcode_1d/test/test_barcode_1d.rb
+++ b/code/packages/ruby/barcode_1d/test/test_barcode_1d.rb
@@ -11,8 +11,30 @@ class Barcode1DTest < Minitest::Test
     assert_equal 120, scene.height
   end
 
+  def test_build_scene_for_additional_symbologies
+    cases = {
+      codabar: "40156",
+      code128: "Code 128",
+      ean13: "400638133393",
+      itf: "123456",
+      upca: "03600029145",
+    }
+
+    cases.each do |symbology, data|
+      scene = CodingAdventures::Barcode1D.build_scene(data, symbology: symbology)
+      assert scene.metadata[:symbology]
+      assert_operator scene.width, :>, 0
+    end
+  end
+
   def test_backend_probe
     assert_includes [nil, :metal], CodingAdventures::Barcode1D.current_backend
+  end
+
+  def test_unsupported_symbology
+    assert_raises(CodingAdventures::Barcode1D::UnsupportedSymbologyError) do
+      CodingAdventures::Barcode1D.build_scene("HELLO-123", symbology: :qr)
+    end
   end
 
   def test_render_png_when_backend_is_available

--- a/code/packages/ruby/codabar/BUILD
+++ b/code/packages/ruby/codabar/BUILD
@@ -1,0 +1,1 @@
+ruby -Ilib -I../paint_instructions/lib -I../barcode_layout_1d/lib test/test_codabar.rb

--- a/code/packages/ruby/codabar/BUILD_windows
+++ b/code/packages/ruby/codabar/BUILD_windows
@@ -1,0 +1,1 @@
+ruby -Ilib -I../paint_instructions/lib -I../barcode_layout_1d/lib test/test_codabar.rb

--- a/code/packages/ruby/codabar/Gemfile
+++ b/code/packages/ruby/codabar/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+gemspec
+
+gem "coding_adventures_paint_instructions", path: "../paint_instructions"
+gem "coding_adventures_barcode_layout_1d", path: "../barcode_layout_1d"

--- a/code/packages/ruby/codabar/Rakefile
+++ b/code/packages/ruby/codabar/Rakefile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rake/testtask"
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList["test/**/test_*.rb"]
+end
+
+task default: :test

--- a/code/packages/ruby/codabar/coding_adventures_codabar.gemspec
+++ b/code/packages/ruby/codabar/coding_adventures_codabar.gemspec
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative "lib/coding_adventures/codabar/version"
+
+Gem::Specification.new do |spec|
+  spec.name          = "coding_adventures_codabar"
+  spec.version       = CodingAdventures::Codabar::VERSION
+  spec.authors       = ["Adhithya Rajasekaran"]
+  spec.summary       = "Dependency-free Codabar encoder that emits backend-neutral paint scenes"
+  spec.homepage      = "https://github.com/adhithyan15/coding-adventures"
+  spec.license       = "MIT"
+  spec.required_ruby_version = ">= 3.3.0"
+
+  spec.files         = Dir["lib/**/*.rb", "README.md", "CHANGELOG.md"]
+  spec.require_paths = ["lib"]
+
+  spec.metadata = {
+    "source_code_uri" => "https://github.com/adhithyan15/coding-adventures",
+    "rubygems_mfa_required" => "true",
+  }
+
+  spec.add_dependency "coding_adventures_barcode_layout_1d", "~> 0.1"
+  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "rake", "~> 13.0"
+end

--- a/code/packages/ruby/codabar/lib/coding_adventures/codabar/version.rb
+++ b/code/packages/ruby/codabar/lib/coding_adventures/codabar/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module Codabar
+    VERSION = "0.1.0"
+  end
+end

--- a/code/packages/ruby/codabar/lib/coding_adventures_codabar.rb
+++ b/code/packages/ruby/codabar/lib/coding_adventures_codabar.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require "coding_adventures_barcode_layout_1d"
+require_relative "coding_adventures/codabar/version"
+
+module CodingAdventures
+  module Codabar
+    module_function
+
+    DEFAULT_LAYOUT_CONFIG = CodingAdventures::BarcodeLayout1D::DEFAULT_BARCODE_1D_LAYOUT_CONFIG
+    DEFAULT_RENDER_CONFIG = DEFAULT_LAYOUT_CONFIG
+
+    GUARDS = %w[A B C D].freeze
+
+    PATTERNS = {
+      "0" => "101010011", "1" => "101011001", "2" => "101001011", "3" => "110010101",
+      "4" => "101101001", "5" => "110101001", "6" => "100101011", "7" => "100101101",
+      "8" => "100110101", "9" => "110100101", "-" => "101001101", "$" => "101100101",
+      ":" => "1101011011", "/" => "1101101011", "." => "1101101101", "+" => "1011011011",
+      "A" => "1011001001", "B" => "1001001011", "C" => "1010010011", "D" => "1010011001",
+    }.freeze
+
+    def normalize_codabar(data, start: "A", stop: "A")
+      normalized = data.upcase
+
+      if normalized.length >= 2 && guard?(normalized[0]) && guard?(normalized[-1])
+        assert_body_chars!(normalized[1...-1])
+        return normalized
+      end
+
+      raise ArgumentError, "Codabar guards must be one of A, B, C, or D" unless guard?(start) && guard?(stop)
+
+      assert_body_chars!(normalized)
+      "#{start}#{normalized}#{stop}"
+    end
+
+    def encode_codabar(data, start: "A", stop: "A")
+      normalized = normalize_codabar(data, start: start, stop: stop)
+      normalized.chars.each_with_index.map do |char, index|
+        role = if index.zero?
+          "start"
+        elsif index == normalized.length - 1
+          "stop"
+        else
+          "data"
+        end
+
+        {
+          char: char,
+          pattern: PATTERNS.fetch(char),
+          source_index: index,
+          role: role,
+        }
+      end
+    end
+
+    def expand_codabar_runs(data, options = {})
+      start = options.fetch(:start, "A")
+      stop = options.fetch(:stop, "A")
+      encoded = encode_codabar(data, start: start, stop: stop)
+      encoded.each_with_index.flat_map do |symbol, index|
+        symbol_runs = retag_runs(
+          CodingAdventures::BarcodeLayout1D.runs_from_binary_pattern(
+            symbol[:pattern],
+            source_char: symbol[:char],
+            source_index: symbol[:source_index],
+          ),
+          symbol[:role],
+        )
+
+        if index < encoded.length - 1
+          symbol_runs + [
+            {
+              color: "space",
+              modules: 1,
+              source_char: symbol[:char],
+              source_index: symbol[:source_index],
+              role: "inter-character-gap",
+              metadata: {},
+            },
+          ]
+        else
+          symbol_runs
+        end
+      end
+    end
+
+    def layout_codabar(data, config = DEFAULT_LAYOUT_CONFIG, options = {})
+      start = options.fetch(:start, "A")
+      stop = options.fetch(:stop, "A")
+      normalized = normalize_codabar(data, start: start, stop: stop)
+      CodingAdventures::BarcodeLayout1D.draw_one_dimensional_barcode(
+        expand_codabar_runs(normalized),
+        config,
+        {
+          metadata: {
+            symbology: "codabar",
+            start: normalized[0],
+            stop: normalized[-1],
+          },
+        },
+      )
+    end
+
+    def draw_codabar(data, config = DEFAULT_LAYOUT_CONFIG, options = {})
+      layout_codabar(data, config, options)
+    end
+
+    def guard?(char)
+      GUARDS.include?(char)
+    end
+    private_class_method :guard?
+
+    def assert_body_chars!(body)
+      body.each_char do |char|
+        raise ArgumentError, %(Invalid Codabar body character "#{char}") unless PATTERNS.key?(char) && !guard?(char)
+      end
+    end
+    private_class_method :assert_body_chars!
+
+    def retag_runs(runs, role)
+      runs.map do |run|
+        run.merge(role: role, metadata: run.fetch(:metadata, {}).dup)
+      end
+    end
+    private_class_method :retag_runs
+  end
+end

--- a/code/packages/ruby/codabar/required_capabilities.json
+++ b/code/packages/ruby/codabar/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "ruby/codabar",
+  "capabilities": [],
+  "justification": "Pure computation package for Codabar normalization, encoding, run expansion, and paint-scene generation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/ruby/codabar/test/test_codabar.rb
+++ b/code/packages/ruby/codabar/test/test_codabar.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "coding_adventures_codabar"
+
+class TestCodabar < Minitest::Test
+  def test_version_exists
+    refute_nil CodingAdventures::Codabar::VERSION
+  end
+
+  def test_normalize_codabar_adds_default_guards
+    assert_equal "A40156A", CodingAdventures::Codabar.normalize_codabar("40156")
+  end
+
+  def test_normalize_codabar_preserves_explicit_guards
+    assert_equal "B1234D", CodingAdventures::Codabar.normalize_codabar("B1234D")
+  end
+
+  def test_expand_runs_marks_inter_character_gap
+    runs = CodingAdventures::Codabar.expand_codabar_runs("40156")
+    assert_includes runs.map { |run| run[:role] }, "inter-character-gap"
+  end
+
+  def test_paint_scene
+    scene = CodingAdventures::Codabar.draw_codabar("40156")
+    assert_equal "codabar", scene.metadata[:symbology]
+    assert_equal "A", scene.metadata[:start]
+    assert_equal "A", scene.metadata[:stop]
+    assert_operator scene.width, :>, 0
+    assert_equal 120, scene.height
+  end
+end

--- a/code/packages/ruby/code128/BUILD
+++ b/code/packages/ruby/code128/BUILD
@@ -1,0 +1,1 @@
+ruby -Ilib -I../paint_instructions/lib -I../barcode_layout_1d/lib test/test_code128.rb

--- a/code/packages/ruby/code128/BUILD_windows
+++ b/code/packages/ruby/code128/BUILD_windows
@@ -1,0 +1,1 @@
+ruby -Ilib -I../paint_instructions/lib -I../barcode_layout_1d/lib test/test_code128.rb

--- a/code/packages/ruby/code128/Gemfile
+++ b/code/packages/ruby/code128/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+gemspec
+
+gem "coding_adventures_paint_instructions", path: "../paint_instructions"
+gem "coding_adventures_barcode_layout_1d", path: "../barcode_layout_1d"

--- a/code/packages/ruby/code128/Rakefile
+++ b/code/packages/ruby/code128/Rakefile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rake/testtask"
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList["test/**/test_*.rb"]
+end
+
+task default: :test

--- a/code/packages/ruby/code128/coding_adventures_code128.gemspec
+++ b/code/packages/ruby/code128/coding_adventures_code128.gemspec
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative "lib/coding_adventures/code128/version"
+
+Gem::Specification.new do |spec|
+  spec.name          = "coding_adventures_code128"
+  spec.version       = CodingAdventures::Code128::VERSION
+  spec.authors       = ["Adhithya Rajasekaran"]
+  spec.summary       = "Dependency-free Code 128 encoder that emits backend-neutral paint scenes"
+  spec.homepage      = "https://github.com/adhithyan15/coding-adventures"
+  spec.license       = "MIT"
+  spec.required_ruby_version = ">= 3.3.0"
+
+  spec.files         = Dir["lib/**/*.rb", "README.md", "CHANGELOG.md"]
+  spec.require_paths = ["lib"]
+
+  spec.metadata = {
+    "source_code_uri" => "https://github.com/adhithyan15/coding-adventures",
+    "rubygems_mfa_required" => "true",
+  }
+
+  spec.add_dependency "coding_adventures_barcode_layout_1d", "~> 0.1"
+  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "rake", "~> 13.0"
+end

--- a/code/packages/ruby/code128/lib/coding_adventures/code128/version.rb
+++ b/code/packages/ruby/code128/lib/coding_adventures/code128/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module Code128
+    VERSION = "0.1.0"
+  end
+end

--- a/code/packages/ruby/code128/lib/coding_adventures_code128.rb
+++ b/code/packages/ruby/code128/lib/coding_adventures_code128.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require "coding_adventures_barcode_layout_1d"
+require_relative "coding_adventures/code128/version"
+
+module CodingAdventures
+  module Code128
+    module_function
+
+    DEFAULT_LAYOUT_CONFIG = CodingAdventures::BarcodeLayout1D::DEFAULT_BARCODE_1D_LAYOUT_CONFIG
+    DEFAULT_RENDER_CONFIG = DEFAULT_LAYOUT_CONFIG
+
+    START_B = 104
+    STOP = 106
+
+    PATTERNS = %w[
+      11011001100 11001101100 11001100110 10010011000 10010001100 10001001100 10011001000 10011000100
+      10001100100 11001001000 11001000100 11000100100 10110011100 10011011100 10011001110 10111001100
+      10011101100 10011100110 11001110010 11001011100 11001001110 11011100100 11001110100 11101101110
+      11101001100 11100101100 11100100110 11101100100 11100110100 11100110010 11011011000 11011000110
+      11000110110 10100011000 10001011000 10001000110 10110001000 10001101000 10001100010 11010001000
+      11000101000 11000100010 10110111000 10110001110 10001101110 10111011000 10111000110 10001110110
+      11101110110 11010001110 11000101110 11011101000 11011100010 11011101110 11101011000 11101000110
+      11100010110 11101101000 11101100010 11100011010 11101111010 11001000010 11110001010 10100110000
+      10100001100 10010110000 10010000110 10000101100 10000100110 10110010000 10110000100 10011010000
+      10011000010 10000110100 10000110010 11000010010 11001010000 11110111010 11000010100 10001111010
+      10100111100 10010111100 10010011110 10111100100 10011110100 10011110010 11110100100 11110010100
+      11110010010 11011011110 11011110110 11110110110 10101111000 10100011110 10001011110 10111101000
+      10111100010 11110101000 11110100010 10111011110 10111101110 11101011110 11110101110 11010000100
+      11010010000 11010011100 1100011101011
+    ].freeze
+
+    def normalize_code128_b(data)
+      data.each_char do |char|
+        code = char.ord
+        next if code >= 32 && code <= 126
+
+        raise ArgumentError, "Code 128 Code Set B supports printable ASCII characters only"
+      end
+      data
+    end
+
+    def value_for_code128_b_char(char)
+      char.ord - 32
+    end
+
+    def compute_code128_checksum(values)
+      (START_B + values.each_with_index.sum { |value, index| value * (index + 1) }) % 103
+    end
+
+    def encode_code128_b(data)
+      normalized = normalize_code128_b(data)
+      data_symbols = normalized.chars.each_with_index.map do |char, index|
+        value = value_for_code128_b_char(char)
+        {
+          label: char,
+          value: value,
+          pattern: PATTERNS.fetch(value),
+          source_index: index,
+          role: "data",
+        }
+      end
+      checksum = compute_code128_checksum(data_symbols.map { |symbol| symbol[:value] })
+
+      [
+        { label: "Start B", value: START_B, pattern: PATTERNS.fetch(START_B), source_index: -1, role: "start" },
+        *data_symbols,
+        {
+          label: "Checksum #{checksum}",
+          value: checksum,
+          pattern: PATTERNS.fetch(checksum),
+          source_index: normalized.length,
+          role: "check",
+        },
+        { label: "Stop", value: STOP, pattern: PATTERNS.fetch(STOP), source_index: normalized.length + 1, role: "stop" },
+      ]
+    end
+
+    def expand_code128_runs(data)
+      encode_code128_b(data).flat_map do |symbol|
+        retag_runs(
+          CodingAdventures::BarcodeLayout1D.runs_from_binary_pattern(
+            symbol[:pattern],
+            source_char: symbol[:label],
+            source_index: symbol[:source_index],
+          ),
+          symbol[:role],
+        )
+      end
+    end
+
+    def layout_code128(data, config = DEFAULT_LAYOUT_CONFIG)
+      normalized = normalize_code128_b(data)
+      checksum = encode_code128_b(normalized)[-2][:value]
+      CodingAdventures::BarcodeLayout1D.draw_one_dimensional_barcode(
+        expand_code128_runs(normalized),
+        config,
+        {
+          metadata: {
+            symbology: "code128",
+            code_set: "B",
+            checksum: checksum,
+          },
+        },
+      )
+    end
+
+    def draw_code128(data, config = DEFAULT_LAYOUT_CONFIG)
+      layout_code128(data, config)
+    end
+
+    def retag_runs(runs, role)
+      runs.map do |run|
+        run.merge(role: role, metadata: run.fetch(:metadata, {}).dup)
+      end
+    end
+    private_class_method :retag_runs
+  end
+end

--- a/code/packages/ruby/code128/required_capabilities.json
+++ b/code/packages/ruby/code128/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "ruby/code128",
+  "capabilities": [],
+  "justification": "Pure computation package for Code 128 normalization, encoding, run expansion, and paint-scene generation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/ruby/code128/test/test_code128.rb
+++ b/code/packages/ruby/code128/test/test_code128.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "coding_adventures_code128"
+
+class TestCode128 < Minitest::Test
+  def test_version_exists
+    refute_nil CodingAdventures::Code128::VERSION
+  end
+
+  def test_compute_checksum_matches_reference
+    values = "Code 128".chars.map { |char| CodingAdventures::Code128.value_for_code128_b_char(char) }
+    assert_equal 64, CodingAdventures::Code128.compute_code128_checksum(values)
+  end
+
+  def test_normalize_rejects_non_printable_characters
+    assert_raises(ArgumentError) { CodingAdventures::Code128.normalize_code128_b("HELLO\n") }
+  end
+
+  def test_encode_code128_includes_start_checksum_and_stop
+    encoded = CodingAdventures::Code128.encode_code128_b("Code 128")
+    assert_equal "start", encoded.first[:role]
+    assert_equal "check", encoded[-2][:role]
+    assert_equal "stop", encoded.last[:role]
+  end
+
+  def test_paint_scene
+    scene = CodingAdventures::Code128.draw_code128("Code 128")
+    assert_equal "code128", scene.metadata[:symbology]
+    assert_equal "B", scene.metadata[:code_set]
+    assert_operator scene.width, :>, 0
+    assert_equal 120, scene.height
+  end
+end

--- a/code/packages/ruby/ean_13/BUILD
+++ b/code/packages/ruby/ean_13/BUILD
@@ -1,0 +1,1 @@
+ruby -Ilib -I../paint_instructions/lib -I../barcode_layout_1d/lib test/test_ean_13.rb

--- a/code/packages/ruby/ean_13/BUILD_windows
+++ b/code/packages/ruby/ean_13/BUILD_windows
@@ -1,0 +1,1 @@
+ruby -Ilib -I../paint_instructions/lib -I../barcode_layout_1d/lib test/test_ean_13.rb

--- a/code/packages/ruby/ean_13/Gemfile
+++ b/code/packages/ruby/ean_13/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+gemspec
+
+gem "coding_adventures_paint_instructions", path: "../paint_instructions"
+gem "coding_adventures_barcode_layout_1d", path: "../barcode_layout_1d"

--- a/code/packages/ruby/ean_13/Rakefile
+++ b/code/packages/ruby/ean_13/Rakefile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rake/testtask"
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList["test/**/test_*.rb"]
+end
+
+task default: :test

--- a/code/packages/ruby/ean_13/coding_adventures_ean_13.gemspec
+++ b/code/packages/ruby/ean_13/coding_adventures_ean_13.gemspec
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative "lib/coding_adventures/ean_13/version"
+
+Gem::Specification.new do |spec|
+  spec.name          = "coding_adventures_ean_13"
+  spec.version       = CodingAdventures::Ean13::VERSION
+  spec.authors       = ["Adhithya Rajasekaran"]
+  spec.summary       = "Dependency-free EAN-13 encoder that emits backend-neutral paint scenes"
+  spec.homepage      = "https://github.com/adhithyan15/coding-adventures"
+  spec.license       = "MIT"
+  spec.required_ruby_version = ">= 3.3.0"
+
+  spec.files         = Dir["lib/**/*.rb", "README.md", "CHANGELOG.md"]
+  spec.require_paths = ["lib"]
+
+  spec.metadata = {
+    "source_code_uri" => "https://github.com/adhithyan15/coding-adventures",
+    "rubygems_mfa_required" => "true",
+  }
+
+  spec.add_dependency "coding_adventures_barcode_layout_1d", "~> 0.1"
+  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "rake", "~> 13.0"
+end

--- a/code/packages/ruby/ean_13/lib/coding_adventures/ean_13/version.rb
+++ b/code/packages/ruby/ean_13/lib/coding_adventures/ean_13/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module Ean13
+    VERSION = "0.1.0"
+  end
+end

--- a/code/packages/ruby/ean_13/lib/coding_adventures_ean_13.rb
+++ b/code/packages/ruby/ean_13/lib/coding_adventures_ean_13.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require "coding_adventures_barcode_layout_1d"
+require_relative "coding_adventures/ean_13/version"
+
+module CodingAdventures
+  module Ean13
+    module_function
+
+    DEFAULT_LAYOUT_CONFIG = CodingAdventures::BarcodeLayout1D::DEFAULT_BARCODE_1D_LAYOUT_CONFIG
+    DEFAULT_RENDER_CONFIG = DEFAULT_LAYOUT_CONFIG
+
+    SIDE_GUARD = "101"
+    CENTER_GUARD = "01010"
+
+    DIGIT_PATTERNS = {
+      "L" => %w[0001101 0011001 0010011 0111101 0100011 0110001 0101111 0111011 0110111 0001011],
+      "G" => %w[0100111 0110011 0011011 0100001 0011101 0111001 0000101 0010001 0001001 0010111],
+      "R" => %w[1110010 1100110 1101100 1000010 1011100 1001110 1010000 1000100 1001000 1110100],
+    }.freeze
+
+    LEFT_PARITY_PATTERNS = %w[
+      LLLLLL LLGLGG LLGGLG LLGGGL LGLLGG LGGLLG LGGGLL LGLGLG LGLGGL LGGLGL
+    ].freeze
+
+    def compute_ean_13_check_digit(payload12)
+      assert_digits!(payload12, [12])
+      total = payload12.chars.reverse.each_with_index.sum do |digit, index|
+        digit.to_i * (index.even? ? 3 : 1)
+      end
+      ((10 - (total % 10)) % 10).to_s
+    end
+
+    def normalize_ean_13(data)
+      assert_digits!(data, [12, 13])
+      return "#{data}#{compute_ean_13_check_digit(data)}" if data.length == 12
+
+      expected = compute_ean_13_check_digit(data[0, 12])
+      actual = data[12]
+      raise ArgumentError, "Invalid EAN-13 check digit: expected #{expected} but received #{actual}" unless expected == actual
+
+      data
+    end
+
+    def left_parity_pattern(data)
+      normalized = normalize_ean_13(data)
+      LEFT_PARITY_PATTERNS.fetch(normalized[0].to_i)
+    end
+
+    def encode_ean_13(data)
+      normalized = normalize_ean_13(data)
+      parity = left_parity_pattern(normalized)
+      digits = normalized.chars
+
+      left_digits = digits[1, 6].each_with_index.map do |digit, offset|
+        encoding = parity[offset]
+        {
+          digit: digit,
+          encoding: encoding,
+          pattern: DIGIT_PATTERNS.fetch(encoding).fetch(digit.to_i),
+          source_index: offset + 1,
+          role: "data",
+        }
+      end
+
+      right_digits = digits[7, 6].each_with_index.map do |digit, offset|
+        {
+          digit: digit,
+          encoding: "R",
+          pattern: DIGIT_PATTERNS.fetch("R").fetch(digit.to_i),
+          source_index: offset + 7,
+          role: offset == 5 ? "check" : "data",
+        }
+      end
+
+      left_digits + right_digits
+    end
+
+    def expand_ean_13_runs(data)
+      encoded_digits = encode_ean_13(data)
+      runs = []
+      runs.concat retag_runs(CodingAdventures::BarcodeLayout1D.runs_from_binary_pattern(SIDE_GUARD, source_char: "start", source_index: -1), "guard")
+
+      encoded_digits.first(6).each do |entry|
+        runs.concat retag_runs(
+          CodingAdventures::BarcodeLayout1D.runs_from_binary_pattern(
+            entry[:pattern],
+            source_char: entry[:digit],
+            source_index: entry[:source_index],
+          ),
+          entry[:role],
+        )
+      end
+
+      runs.concat retag_runs(CodingAdventures::BarcodeLayout1D.runs_from_binary_pattern(CENTER_GUARD, source_char: "center", source_index: -2), "guard")
+
+      encoded_digits.drop(6).each do |entry|
+        runs.concat retag_runs(
+          CodingAdventures::BarcodeLayout1D.runs_from_binary_pattern(
+            entry[:pattern],
+            source_char: entry[:digit],
+            source_index: entry[:source_index],
+          ),
+          entry[:role],
+        )
+      end
+
+      runs.concat retag_runs(CodingAdventures::BarcodeLayout1D.runs_from_binary_pattern(SIDE_GUARD, source_char: "end", source_index: -3), "guard")
+      runs
+    end
+
+    def layout_ean_13(data, config = DEFAULT_LAYOUT_CONFIG)
+      normalized = normalize_ean_13(data)
+      CodingAdventures::BarcodeLayout1D.draw_one_dimensional_barcode(
+        expand_ean_13_runs(normalized),
+        config,
+        {
+          metadata: {
+            symbology: "ean-13",
+            leading_digit: normalized[0],
+            left_parity: left_parity_pattern(normalized),
+            content_modules: 95,
+          },
+        },
+      )
+    end
+
+    def draw_ean_13(data, config = DEFAULT_LAYOUT_CONFIG)
+      layout_ean_13(data, config)
+    end
+
+    def assert_digits!(data, lengths)
+      raise ArgumentError, "EAN-13 input must contain digits only" unless /\A\d+\z/.match?(data)
+      raise ArgumentError, "EAN-13 input must contain 12 digits or 13 digits" unless lengths.include?(data.length)
+    end
+    private_class_method :assert_digits!
+
+    def retag_runs(runs, role)
+      runs.map do |run|
+        run.merge(role: role, metadata: run.fetch(:metadata, {}).dup)
+      end
+    end
+    private_class_method :retag_runs
+  end
+end

--- a/code/packages/ruby/ean_13/required_capabilities.json
+++ b/code/packages/ruby/ean_13/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "ruby/ean_13",
+  "capabilities": [],
+  "justification": "Pure computation package for EAN-13 normalization, encoding, run expansion, and paint-scene generation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/ruby/ean_13/test/test_ean_13.rb
+++ b/code/packages/ruby/ean_13/test/test_ean_13.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "coding_adventures_ean_13"
+
+class TestEan13 < Minitest::Test
+  def test_version_exists
+    refute_nil CodingAdventures::Ean13::VERSION
+  end
+
+  def test_compute_check_digit_matches_reference
+    assert_equal "1", CodingAdventures::Ean13.compute_ean_13_check_digit("400638133393")
+  end
+
+  def test_normalize_appends_check_digit
+    assert_equal "4006381333931", CodingAdventures::Ean13.normalize_ean_13("400638133393")
+  end
+
+  def test_left_parity_pattern_matches_reference
+    assert_equal "LGLLGG", CodingAdventures::Ean13.left_parity_pattern("4006381333931")
+  end
+
+  def test_expand_runs_total_95_modules
+    assert_equal 95, CodingAdventures::Ean13.expand_ean_13_runs("4006381333931").sum { |run| run[:modules] }
+  end
+
+  def test_paint_scene
+    scene = CodingAdventures::Ean13.draw_ean_13("400638133393")
+    assert_equal "ean-13", scene.metadata[:symbology]
+    assert_equal 95, scene.metadata[:content_modules]
+    assert_operator scene.width, :>, 0
+    assert_equal 120, scene.height
+  end
+end

--- a/code/packages/ruby/itf/BUILD
+++ b/code/packages/ruby/itf/BUILD
@@ -1,0 +1,1 @@
+ruby -Ilib -I../paint_instructions/lib -I../barcode_layout_1d/lib test/test_itf.rb

--- a/code/packages/ruby/itf/BUILD_windows
+++ b/code/packages/ruby/itf/BUILD_windows
@@ -1,0 +1,1 @@
+ruby -Ilib -I../paint_instructions/lib -I../barcode_layout_1d/lib test/test_itf.rb

--- a/code/packages/ruby/itf/Gemfile
+++ b/code/packages/ruby/itf/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+gemspec
+
+gem "coding_adventures_paint_instructions", path: "../paint_instructions"
+gem "coding_adventures_barcode_layout_1d", path: "../barcode_layout_1d"

--- a/code/packages/ruby/itf/Rakefile
+++ b/code/packages/ruby/itf/Rakefile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rake/testtask"
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList["test/**/test_*.rb"]
+end
+
+task default: :test

--- a/code/packages/ruby/itf/coding_adventures_itf.gemspec
+++ b/code/packages/ruby/itf/coding_adventures_itf.gemspec
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative "lib/coding_adventures/itf/version"
+
+Gem::Specification.new do |spec|
+  spec.name          = "coding_adventures_itf"
+  spec.version       = CodingAdventures::Itf::VERSION
+  spec.authors       = ["Adhithya Rajasekaran"]
+  spec.summary       = "Dependency-free ITF encoder that emits backend-neutral paint scenes"
+  spec.homepage      = "https://github.com/adhithyan15/coding-adventures"
+  spec.license       = "MIT"
+  spec.required_ruby_version = ">= 3.3.0"
+
+  spec.files         = Dir["lib/**/*.rb", "README.md", "CHANGELOG.md"]
+  spec.require_paths = ["lib"]
+
+  spec.metadata = {
+    "source_code_uri" => "https://github.com/adhithyan15/coding-adventures",
+    "rubygems_mfa_required" => "true",
+  }
+
+  spec.add_dependency "coding_adventures_barcode_layout_1d", "~> 0.1"
+  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "rake", "~> 13.0"
+end

--- a/code/packages/ruby/itf/lib/coding_adventures/itf/version.rb
+++ b/code/packages/ruby/itf/lib/coding_adventures/itf/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module Itf
+    VERSION = "0.1.0"
+  end
+end

--- a/code/packages/ruby/itf/lib/coding_adventures_itf.rb
+++ b/code/packages/ruby/itf/lib/coding_adventures_itf.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "coding_adventures_barcode_layout_1d"
+require_relative "coding_adventures/itf/version"
+
+module CodingAdventures
+  module Itf
+    module_function
+
+    DEFAULT_LAYOUT_CONFIG = CodingAdventures::BarcodeLayout1D::DEFAULT_BARCODE_1D_LAYOUT_CONFIG
+    DEFAULT_RENDER_CONFIG = DEFAULT_LAYOUT_CONFIG
+
+    START_PATTERN = "1010"
+    STOP_PATTERN = "11101"
+
+    DIGIT_PATTERNS = %w[
+      00110 10001 01001 11000 00101 10100 01100 00011 10010 01010
+    ].freeze
+
+    def normalize_itf(data)
+      raise ArgumentError, "ITF input must contain digits only" unless /\A\d+\z/.match?(data)
+      raise ArgumentError, "ITF input must contain an even number of digits" if data.empty? || data.length.odd?
+
+      data
+    end
+
+    def encode_itf(data)
+      normalized = normalize_itf(data)
+      normalized.chars.each_slice(2).with_index.map do |pair_chars, index|
+        pair = pair_chars.join
+        bar_pattern = DIGIT_PATTERNS.fetch(pair[0].to_i)
+        space_pattern = DIGIT_PATTERNS.fetch(pair[1].to_i)
+        binary_pattern = bar_pattern.chars.zip(space_pattern.chars).map do |bar_marker, space_marker|
+          "#{bar_marker == "1" ? "111" : "1"}#{space_marker == "1" ? "000" : "0"}"
+        end.join
+
+        {
+          pair: pair,
+          bar_pattern: bar_pattern,
+          space_pattern: space_pattern,
+          binary_pattern: binary_pattern,
+          source_index: index,
+        }
+      end
+    end
+
+    def expand_itf_runs(data)
+      encoded_pairs = encode_itf(data)
+      runs = []
+      runs.concat retag_runs(CodingAdventures::BarcodeLayout1D.runs_from_binary_pattern(START_PATTERN, source_char: "start", source_index: -1), "start")
+      encoded_pairs.each do |entry|
+        runs.concat retag_runs(
+          CodingAdventures::BarcodeLayout1D.runs_from_binary_pattern(
+            entry[:binary_pattern],
+            source_char: entry[:pair],
+            source_index: entry[:source_index],
+          ),
+          "data",
+        )
+      end
+      runs.concat retag_runs(CodingAdventures::BarcodeLayout1D.runs_from_binary_pattern(STOP_PATTERN, source_char: "stop", source_index: -2), "stop")
+      runs
+    end
+
+    def layout_itf(data, config = DEFAULT_LAYOUT_CONFIG)
+      normalized = normalize_itf(data)
+      CodingAdventures::BarcodeLayout1D.draw_one_dimensional_barcode(
+        expand_itf_runs(normalized),
+        config,
+        {
+          metadata: {
+            symbology: "itf",
+            pair_count: normalized.length / 2,
+          },
+        },
+      )
+    end
+
+    def draw_itf(data, config = DEFAULT_LAYOUT_CONFIG)
+      layout_itf(data, config)
+    end
+
+    def retag_runs(runs, role)
+      runs.map do |run|
+        run.merge(role: role, metadata: run.fetch(:metadata, {}).dup)
+      end
+    end
+    private_class_method :retag_runs
+  end
+end

--- a/code/packages/ruby/itf/required_capabilities.json
+++ b/code/packages/ruby/itf/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "ruby/itf",
+  "capabilities": [],
+  "justification": "Pure computation package for ITF normalization, encoding, run expansion, and paint-scene generation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/ruby/itf/test/test_itf.rb
+++ b/code/packages/ruby/itf/test/test_itf.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "coding_adventures_itf"
+
+class TestItf < Minitest::Test
+  def test_version_exists
+    refute_nil CodingAdventures::Itf::VERSION
+  end
+
+  def test_normalize_rejects_odd_input
+    assert_raises(ArgumentError) { CodingAdventures::Itf.normalize_itf("12345") }
+  end
+
+  def test_encode_interleaves_digit_pairs
+    encoded = CodingAdventures::Itf.encode_itf("123456")
+    assert_equal 3, encoded.length
+    assert_equal "12", encoded.first[:pair]
+  end
+
+  def test_expand_runs_include_start_and_stop
+    roles = CodingAdventures::Itf.expand_itf_runs("123456").map { |run| run[:role] }
+    assert_includes roles, "start"
+    assert_includes roles, "stop"
+  end
+
+  def test_paint_scene
+    scene = CodingAdventures::Itf.draw_itf("123456")
+    assert_equal "itf", scene.metadata[:symbology]
+    assert_equal 3, scene.metadata[:pair_count]
+    assert_operator scene.width, :>, 0
+    assert_equal 120, scene.height
+  end
+end

--- a/code/packages/ruby/upc_a/BUILD
+++ b/code/packages/ruby/upc_a/BUILD
@@ -1,0 +1,1 @@
+ruby -Ilib -I../paint_instructions/lib -I../barcode_layout_1d/lib test/test_upc_a.rb

--- a/code/packages/ruby/upc_a/BUILD_windows
+++ b/code/packages/ruby/upc_a/BUILD_windows
@@ -1,0 +1,1 @@
+ruby -Ilib -I../paint_instructions/lib -I../barcode_layout_1d/lib test/test_upc_a.rb

--- a/code/packages/ruby/upc_a/Gemfile
+++ b/code/packages/ruby/upc_a/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+gemspec
+
+gem "coding_adventures_paint_instructions", path: "../paint_instructions"
+gem "coding_adventures_barcode_layout_1d", path: "../barcode_layout_1d"

--- a/code/packages/ruby/upc_a/Rakefile
+++ b/code/packages/ruby/upc_a/Rakefile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rake/testtask"
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList["test/**/test_*.rb"]
+end
+
+task default: :test

--- a/code/packages/ruby/upc_a/coding_adventures_upc_a.gemspec
+++ b/code/packages/ruby/upc_a/coding_adventures_upc_a.gemspec
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative "lib/coding_adventures/upc_a/version"
+
+Gem::Specification.new do |spec|
+  spec.name          = "coding_adventures_upc_a"
+  spec.version       = CodingAdventures::UpcA::VERSION
+  spec.authors       = ["Adhithya Rajasekaran"]
+  spec.summary       = "Dependency-free UPC-A encoder that emits backend-neutral paint scenes"
+  spec.homepage      = "https://github.com/adhithyan15/coding-adventures"
+  spec.license       = "MIT"
+  spec.required_ruby_version = ">= 3.3.0"
+
+  spec.files         = Dir["lib/**/*.rb", "README.md", "CHANGELOG.md"]
+  spec.require_paths = ["lib"]
+
+  spec.metadata = {
+    "source_code_uri" => "https://github.com/adhithyan15/coding-adventures",
+    "rubygems_mfa_required" => "true",
+  }
+
+  spec.add_dependency "coding_adventures_barcode_layout_1d", "~> 0.1"
+  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "rake", "~> 13.0"
+end

--- a/code/packages/ruby/upc_a/lib/coding_adventures/upc_a/version.rb
+++ b/code/packages/ruby/upc_a/lib/coding_adventures/upc_a/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module UpcA
+    VERSION = "0.1.0"
+  end
+end

--- a/code/packages/ruby/upc_a/lib/coding_adventures_upc_a.rb
+++ b/code/packages/ruby/upc_a/lib/coding_adventures_upc_a.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "coding_adventures_barcode_layout_1d"
+require_relative "coding_adventures/upc_a/version"
+
+module CodingAdventures
+  module UpcA
+    module_function
+
+    DEFAULT_LAYOUT_CONFIG = CodingAdventures::BarcodeLayout1D::DEFAULT_BARCODE_1D_LAYOUT_CONFIG
+    DEFAULT_RENDER_CONFIG = DEFAULT_LAYOUT_CONFIG
+
+    SIDE_GUARD = "101"
+    CENTER_GUARD = "01010"
+
+    DIGIT_PATTERNS = {
+      "L" => %w[0001101 0011001 0010011 0111101 0100011 0110001 0101111 0111011 0110111 0001011],
+      "R" => %w[1110010 1100110 1101100 1000010 1011100 1001110 1010000 1000100 1001000 1110100],
+    }.freeze
+
+    def compute_upc_a_check_digit(payload11)
+      assert_digits!(payload11, [11])
+      odd_sum = 0
+      even_sum = 0
+
+      payload11.chars.each_with_index do |digit, index|
+        if index.even?
+          odd_sum += digit.to_i
+        else
+          even_sum += digit.to_i
+        end
+      end
+
+      ((10 - (((odd_sum * 3) + even_sum) % 10)) % 10).to_s
+    end
+
+    def normalize_upc_a(data)
+      assert_digits!(data, [11, 12])
+      return "#{data}#{compute_upc_a_check_digit(data)}" if data.length == 11
+
+      expected = compute_upc_a_check_digit(data[0, 11])
+      actual = data[11]
+      raise ArgumentError, "Invalid UPC-A check digit: expected #{expected} but received #{actual}" unless expected == actual
+
+      data
+    end
+
+    def encode_upc_a(data)
+      normalized = normalize_upc_a(data)
+      normalized.chars.each_with_index.map do |digit, index|
+        encoding = index < 6 ? "L" : "R"
+        {
+          digit: digit,
+          encoding: encoding,
+          pattern: DIGIT_PATTERNS.fetch(encoding).fetch(digit.to_i),
+          source_index: index,
+          role: index == 11 ? "check" : "data",
+        }
+      end
+    end
+
+    def expand_upc_a_runs(data)
+      encoded_digits = encode_upc_a(data)
+      runs = []
+      runs.concat retag_runs(CodingAdventures::BarcodeLayout1D.runs_from_binary_pattern(SIDE_GUARD, source_char: "start", source_index: -1), "guard")
+
+      encoded_digits.first(6).each do |entry|
+        runs.concat retag_runs(
+          CodingAdventures::BarcodeLayout1D.runs_from_binary_pattern(
+            entry[:pattern],
+            source_char: entry[:digit],
+            source_index: entry[:source_index],
+          ),
+          entry[:role],
+        )
+      end
+
+      runs.concat retag_runs(CodingAdventures::BarcodeLayout1D.runs_from_binary_pattern(CENTER_GUARD, source_char: "center", source_index: -2), "guard")
+
+      encoded_digits.drop(6).each do |entry|
+        runs.concat retag_runs(
+          CodingAdventures::BarcodeLayout1D.runs_from_binary_pattern(
+            entry[:pattern],
+            source_char: entry[:digit],
+            source_index: entry[:source_index],
+          ),
+          entry[:role],
+        )
+      end
+
+      runs.concat retag_runs(CodingAdventures::BarcodeLayout1D.runs_from_binary_pattern(SIDE_GUARD, source_char: "end", source_index: -3), "guard")
+      runs
+    end
+
+    def layout_upc_a(data, config = DEFAULT_LAYOUT_CONFIG)
+      normalized = normalize_upc_a(data)
+      CodingAdventures::BarcodeLayout1D.draw_one_dimensional_barcode(
+        expand_upc_a_runs(normalized),
+        config,
+        {
+          metadata: {
+            symbology: "upc-a",
+            content_modules: 95,
+          },
+        },
+      )
+    end
+
+    def draw_upc_a(data, config = DEFAULT_LAYOUT_CONFIG)
+      layout_upc_a(data, config)
+    end
+
+    def assert_digits!(data, lengths)
+      raise ArgumentError, "UPC-A input must contain digits only" unless /\A\d+\z/.match?(data)
+      raise ArgumentError, "UPC-A input must contain 11 digits or 12 digits" unless lengths.include?(data.length)
+    end
+    private_class_method :assert_digits!
+
+    def retag_runs(runs, role)
+      runs.map do |run|
+        run.merge(role: role, metadata: run.fetch(:metadata, {}).dup)
+      end
+    end
+    private_class_method :retag_runs
+  end
+end

--- a/code/packages/ruby/upc_a/required_capabilities.json
+++ b/code/packages/ruby/upc_a/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "ruby/upc_a",
+  "capabilities": [],
+  "justification": "Pure computation package for UPC-A normalization, encoding, run expansion, and paint-scene generation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/ruby/upc_a/test/test_upc_a.rb
+++ b/code/packages/ruby/upc_a/test/test_upc_a.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "coding_adventures_upc_a"
+
+class TestUpcA < Minitest::Test
+  def test_version_exists
+    refute_nil CodingAdventures::UpcA::VERSION
+  end
+
+  def test_compute_check_digit_matches_reference
+    assert_equal "2", CodingAdventures::UpcA.compute_upc_a_check_digit("03600029145")
+  end
+
+  def test_normalize_appends_check_digit
+    assert_equal "036000291452", CodingAdventures::UpcA.normalize_upc_a("03600029145")
+  end
+
+  def test_expand_runs_total_95_modules
+    assert_equal 95, CodingAdventures::UpcA.expand_upc_a_runs("036000291452").sum { |run| run[:modules] }
+  end
+
+  def test_paint_scene
+    scene = CodingAdventures::UpcA.draw_upc_a("03600029145")
+    assert_equal "upc-a", scene.metadata[:symbology]
+    assert_equal 95, scene.metadata[:content_modules]
+    assert_operator scene.width, :>, 0
+    assert_equal 120, scene.height
+  end
+end


### PR DESCRIPTION
## What changed

This ports the missing 1D barcode symbologies from the TypeScript/Rust pipeline into Python, Ruby, and Elixir.

Added pure barcode packages for:
- Codabar
- Code 128
- EAN-13
- ITF
- UPC-A

Updated the high-level `barcode-1d` / `barcode_1d` packages in each language to dispatch those symbologies through the existing `barcode-layout-1d` paint-scene pipeline.

## Why

Only a subset of languages had moved beyond Code 39. This starts aligning the multi-language surface so each language has:
- pure symbology packages
- shared 1D layout
- paint-scene output
- a language-level orchestration package where one exists

## Impact

Python, Ruby, and Elixir can now build paint scenes for the additional 1D barcode formats without routing through draw instructions.

## Validation

### Python
- `bash BUILD` in `code/packages/python/codabar`
- `bash BUILD` in `code/packages/python/code128`
- `bash BUILD` in `code/packages/python/ean-13`
- `bash BUILD` in `code/packages/python/itf`
- `bash BUILD` in `code/packages/python/upc-a`
- `bash BUILD` in `code/packages/python/barcode-1d`

### Ruby
- `bash BUILD` in `code/packages/ruby/codabar`
- `bash BUILD` in `code/packages/ruby/code128`
- `bash BUILD` in `code/packages/ruby/ean_13`
- `bash BUILD` in `code/packages/ruby/itf`
- `bash BUILD` in `code/packages/ruby/upc_a`
- `bash BUILD` in `code/packages/ruby/barcode_1d`

### Elixir
- `bash BUILD` in `code/packages/elixir/codabar`
- `bash BUILD` in `code/packages/elixir/code128`
- `bash BUILD` in `code/packages/elixir/ean_13`
- `bash BUILD` in `code/packages/elixir/itf`
- `bash BUILD` in `code/packages/elixir/upc_a`
- `bash BUILD` in `code/packages/elixir/barcode_1d`
