### PR TITLE
[codex] Allow explicit Go FFI capability opt-ins

### DIFF
--- a/code/packages/go/ca-capability-analyzer/CHANGELOG.md
+++ b/code/packages/go/ca-capability-analyzer/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [1.0.2] - 2026-04-13
+
+### Security
+
+- **Explicit FFI opt-in for Go**: `import "C"` and `plugin.Open` are no longer
+  treated the same as the irreducibly dangerous constructs. They remain blocked
+  by default, but packages may now opt in explicitly by declaring both a matching
+  `banned_construct_exceptions` entry and the corresponding `ffi` capability
+  (`ffi:call:*` for `import "C"`, `ffi:load:*` for `plugin.Open`).
+
+- **`LoadManifestData`**: Added a richer manifest loader that returns both declared
+  capabilities and `banned_construct_exceptions`, while keeping `LoadManifest`
+  as a compatibility helper for callers that only need declared capabilities.
+
+- **CAP002 guidance**: Violations for partially-declared FFI constructs now explain
+  the missing opt-in step, so packages know whether they still need the manifest
+  exception, the `ffi` capability, or both.
+
 ## [1.0.1] - 2026-03-26
 
 ### Security

--- a/code/packages/go/ca-capability-analyzer/README.md
+++ b/code/packages/go/ca-capability-analyzer/README.md
@@ -97,7 +97,11 @@ main.go:7: [CAP002] banned construct: import "C" (CGo)
 
 ## Banned Constructs
 
-These are flagged unconditionally — no manifest entry can authorize them. They represent patterns that defeat static capability analysis entirely.
+These are blocked by default because they defeat static capability analysis entirely.
+Two FFI-style constructs can be explicitly opted into: `import "C"` requires both
+`banned_construct_exceptions` for `import "C"` and an `ffi:call:*` capability, and
+`plugin.Open` requires both a `banned_construct_exceptions` entry for `plugin.Open`
+and an `ffi:load:*` capability. The remaining constructs stay hard-blocked.
 
 | Construct | Why It's Banned |
 |---|---|
@@ -108,6 +112,35 @@ These are flagged unconditionally — no manifest entry can authorize them. They
 | `reflect.Value.CallSlice(...)` | Same as above |
 | `reflect.Value.MethodByName(...)` | Same as above |
 | `//go:linkname` | Reaches into unexported symbols; defeats encapsulation |
+
+### Explicit FFI opt-in
+
+If a package genuinely needs a reviewed native bridge, it must declare both:
+
+1. A matching `ffi` capability in `capabilities`
+2. A matching `banned_construct_exceptions` entry
+
+Example for `cgo`:
+
+```json
+{
+  "capabilities": [
+    {
+      "category": "ffi",
+      "action": "call",
+      "target": "libbarcode_renderer",
+      "justification": "Calls a reviewed native bridge."
+    }
+  ],
+  "banned_construct_exceptions": [
+    {
+      "construct": "import \"C\"",
+      "language": "go",
+      "justification": "Uses cgo to call the reviewed native bridge."
+    }
+  ]
+}
+```
 
 ## Exemptions
 
@@ -150,6 +183,9 @@ func DetectBanned(fset *token.FileSet, f *ast.File, filename string) []BannedCon
 
 // Manifest loading: reads required_capabilities.json and returns declared set.
 func LoadManifest(dir string) (map[CapabilityString]bool, error)
+
+// Rich manifest loading: declared capabilities + banned-construct exceptions.
+func LoadManifestData(dir string) (*ManifestData, error)
 ```
 
 ## Test Coverage

--- a/code/packages/go/ca-capability-analyzer/analyzer.go
+++ b/code/packages/go/ca-capability-analyzer/analyzer.go
@@ -8,7 +8,8 @@ package main
 //  3. Run capability detection and banned-construct detection.
 //  4. Load required_capabilities.json.
 //  5. Cross-reference detected vs declared → produce violations.
-//  6. Return AnalysisResult.
+//  6. Apply explicit banned-construct exceptions for supported FFI cases.
+//  7. Return AnalysisResult.
 //
 // The two exported functions are:
 //
@@ -267,9 +268,9 @@ func detectSpecialCalls(
 //  1. Walk dir for .go files (skipping gen_capabilities.go and test helpers).
 //  2. Parse each file with go/parser in ParseComments mode.
 //  3. Run DetectCapabilities and DetectBanned over all parsed files.
-//  4. Load required_capabilities.json via LoadManifest.
+//  4. Load required_capabilities.json via LoadManifestData.
 //  5. Cross-reference: detected ⊄ declared → CAP001 violations.
-//  6. Every banned construct → CAP002 violation.
+//  6. Every remaining disallowed restricted construct → CAP002 violation.
 //  7. Return AnalysisResult.
 func AnalyzeDir(dir string) (*AnalysisResult, error) {
 	absDir, err := filepath.Abs(dir)
@@ -324,10 +325,11 @@ func AnalyzeDir(dir string) (*AnalysisResult, error) {
 	}
 
 	// ── Step 4: Load manifest ─────────────────────────────────────────────
-	declared, err := LoadManifest(absDir)
+	manifest, err := LoadManifestData(absDir)
 	if err != nil {
 		return nil, err
 	}
+	declared := manifest.Declared
 	for k := range declared {
 		result.Declared = append(result.Declared, k)
 	}
@@ -350,12 +352,66 @@ func AnalyzeDir(dir string) (*AnalysisResult, error) {
 		}
 	}
 
-	// ── Step 6: Banned constructs → violations ────────────────────────────
+	// ── Step 6: Restricted constructs → violations ────────────────────────
+	filteredBanned := make([]BannedConstruct, 0, len(result.Banned))
 	for _, b := range result.Banned {
-		result.Violations = append(result.Violations, newViolationCAP002(b))
+		allowed, hint := allowBannedConstruct(manifest, b)
+		if allowed {
+			continue
+		}
+		filteredBanned = append(filteredBanned, b)
+		result.Violations = append(result.Violations, newViolationCAP002Hint(b, hint))
 	}
+	result.Banned = filteredBanned
 
 	return result, nil
+}
+
+// allowBannedConstruct returns whether the restricted construct is explicitly
+// authorized for this package. Today this is intentionally narrow: only the
+// two FFI-style bridge constructs may opt in, and they must declare both a
+// banned_construct_exceptions entry and the matching ffi capability.
+func allowBannedConstruct(manifest *ManifestData, banned BannedConstruct) (bool, string) {
+	switch banned.Construct {
+	case bannedConstructImportC:
+		return allowExplicitFFIConstruct(manifest, banned, "ffi:call:*")
+	case bannedConstructPluginOpen:
+		return allowExplicitFFIConstruct(manifest, banned, "ffi:load:*")
+	default:
+		return false, ""
+	}
+}
+
+func allowExplicitFFIConstruct(
+	manifest *ManifestData,
+	banned BannedConstruct,
+	required CapabilityString,
+) (bool, string) {
+	exceptionKey := canonicalBannedConstructExceptionKey("go", banned.Construct)
+	hasException := manifest.BannedConstructExceptions[exceptionKey]
+	hasCapability := manifest.Declared[required]
+
+	if hasException && hasCapability {
+		return true, ""
+	}
+
+	switch {
+	case !hasException && !hasCapability:
+		return false, fmt.Sprintf(
+			"add banned_construct_exceptions for %q and declare %s",
+			banned.Construct, required,
+		)
+	case !hasException:
+		return false, fmt.Sprintf(
+			"add banned_construct_exceptions for %q",
+			banned.Construct,
+		)
+	default:
+		return false, fmt.Sprintf(
+			"declare %s to accompany the %q exception",
+			required, banned.Construct,
+		)
+	}
 }
 
 // ── Internal helpers ──────────────────────────────────────────────────────────

--- a/code/packages/go/ca-capability-analyzer/analyzer_test.go
+++ b/code/packages/go/ca-capability-analyzer/analyzer_test.go
@@ -583,14 +583,14 @@ func f() { os.ReadFile("x") }
 	}
 }
 
-// TestAnalyzeDir_BannedConstructFails verifies that a banned construct produces
-// a CAP002 violation regardless of what the manifest declares.
+// TestAnalyzeDir_BannedConstructFails verifies that a restricted construct still
+// produces CAP002 unless the package explicitly opts in through both manifest
+// exception metadata and matching ffi capabilities.
 func TestAnalyzeDir_BannedConstructFails(t *testing.T) {
 	dir := t.TempDir()
 	writeGoFile(t, dir, "foo.go", `package foo
 import "C"
 `)
-	// Even with an empty manifest (or no manifest), CGo is always banned.
 
 	result, err := AnalyzeDir(dir)
 	if err != nil {
@@ -608,6 +608,165 @@ import "C"
 	}
 	if !hasCAP002 {
 		t.Errorf("expected CAP002 violation, got %v", result.Violations)
+	}
+}
+
+func TestAnalyzeDir_CGoAllowedWithExplicitOptIn(t *testing.T) {
+	dir := t.TempDir()
+	writeGoFile(t, dir, "foo.go", `package foo
+import "C"
+`)
+	writeManifest(t, dir, `{
+		"version": 1,
+		"package": "go/test-pkg",
+		"capabilities": [
+			{
+				"category": "ffi",
+				"action": "call",
+				"target": "libexample",
+				"justification": "Calls reviewed native code."
+			}
+		],
+		"banned_construct_exceptions": [
+			{
+				"construct": "import \"C\"",
+				"language": "go",
+				"justification": "Bridge to reviewed native implementation."
+			}
+		],
+		"justification": "Reviewed FFI package."
+	}`)
+
+	result, err := AnalyzeDir(dir)
+	if err != nil {
+		t.Fatalf("AnalyzeDir: %v", err)
+	}
+	if !result.Passed() {
+		t.Fatalf("expected explicit CGo opt-in to pass, got violations: %v", result.Violations)
+	}
+	if len(result.Banned) != 0 {
+		t.Fatalf("expected no remaining banned constructs, got %v", result.Banned)
+	}
+}
+
+func TestAnalyzeDir_CGoExceptionWithoutFFICapabilityFails(t *testing.T) {
+	dir := t.TempDir()
+	writeGoFile(t, dir, "foo.go", `package foo
+import "C"
+`)
+	writeManifest(t, dir, `{
+		"version": 1,
+		"package": "go/test-pkg",
+		"capabilities": [],
+		"banned_construct_exceptions": [
+			{
+				"construct": "import \"C\"",
+				"language": "go",
+				"justification": "Bridge to reviewed native implementation."
+			}
+		],
+		"justification": "Missing ffi capability."
+	}`)
+
+	result, err := AnalyzeDir(dir)
+	if err != nil {
+		t.Fatalf("AnalyzeDir: %v", err)
+	}
+
+	if result.Passed() {
+		t.Fatal("expected missing ffi capability to fail")
+	}
+	if len(result.Violations) == 0 || result.Violations[0].Code != "CAP002" {
+		t.Fatalf("expected CAP002 violation, got %v", result.Violations)
+	}
+	if got := result.Violations[0].Message; !strings.Contains(got, "ffi:call:*") {
+		t.Fatalf("expected ffi:call hint in %q", got)
+	}
+}
+
+func TestAnalyzeDir_PluginOpenAllowedWithExplicitOptIn(t *testing.T) {
+	dir := t.TempDir()
+	writeGoFile(t, dir, "foo.go", `package foo
+import "plugin"
+func load(path string) {
+	_, _ = plugin.Open(path)
+}
+`)
+	writeManifest(t, dir, `{
+		"version": 1,
+		"package": "go/test-pkg",
+		"capabilities": [
+			{
+				"category": "ffi",
+				"action": "load",
+				"target": "barcode-renderer",
+				"justification": "Loads a reviewed native bridge."
+			}
+		],
+		"banned_construct_exceptions": [
+			{
+				"construct": "plugin.Open()",
+				"language": "go",
+				"justification": "Loads a reviewed native bridge."
+			}
+		],
+		"justification": "Reviewed plugin-based FFI package."
+	}`)
+
+	result, err := AnalyzeDir(dir)
+	if err != nil {
+		t.Fatalf("AnalyzeDir: %v", err)
+	}
+	if !result.Passed() {
+		t.Fatalf("expected explicit plugin.Open opt-in to pass, got violations: %v", result.Violations)
+	}
+}
+
+func TestAnalyzeDir_UnsafePointerStillFailsEvenWithException(t *testing.T) {
+	dir := t.TempDir()
+	writeGoFile(t, dir, "foo.go", `package foo
+import "unsafe"
+func f(x int) uintptr {
+	return uintptr(unsafe.Pointer(&x))
+}
+`)
+	writeManifest(t, dir, `{
+		"version": 1,
+		"package": "go/test-pkg",
+		"capabilities": [
+			{
+				"category": "ffi",
+				"action": "call",
+				"target": "libexample",
+				"justification": "Calls reviewed native code."
+			}
+		],
+		"banned_construct_exceptions": [
+			{
+				"construct": "unsafe.Pointer",
+				"language": "go",
+				"justification": "Attempted exception should not be honored."
+			}
+		],
+		"justification": "Unsafe should stay blocked."
+	}`)
+
+	result, err := AnalyzeDir(dir)
+	if err != nil {
+		t.Fatalf("AnalyzeDir: %v", err)
+	}
+	if result.Passed() {
+		t.Fatal("expected unsafe.Pointer to remain banned")
+	}
+	hasCAP002 := false
+	for _, v := range result.Violations {
+		if v.Code == "CAP002" {
+			hasCAP002 = true
+			break
+		}
+	}
+	if !hasCAP002 {
+		t.Fatalf("expected CAP002 violation, got %v", result.Violations)
 	}
 }
 

--- a/code/packages/go/ca-capability-analyzer/banned.go
+++ b/code/packages/go/ca-capability-analyzer/banned.go
@@ -1,11 +1,11 @@
 package main
 
-// banned.go detects banned code constructs in a Go AST file.
+// banned.go detects restricted code constructs in a Go AST file.
 //
-// Banned constructs are flagged unconditionally — no manifest entry can
-// authorize them. They represent code patterns that defeat static capability
-// analysis entirely by providing dynamic or native code execution paths that
-// the AST walker cannot see through.
+// Most of these constructs remain hard CAP002 violations. The only exceptions
+// the Go analyzer currently allows are the FFI-style bridges (`import "C"` and
+// `plugin.Open`) when a package explicitly opts in through both
+// banned_construct_exceptions and matching ffi capabilities.
 //
 // # The Five Banned Categories
 //
@@ -42,7 +42,17 @@ import (
 	"strings"
 )
 
-// DetectBanned returns all banned constructs found in f.
+const (
+	bannedConstructUnsafePointer       = "unsafe.Pointer"
+	bannedConstructImportC             = `import "C"`
+	bannedConstructPluginOpen          = "plugin.Open"
+	bannedConstructReflectCall         = "reflect.Value.Call"
+	bannedConstructReflectCallSlice    = "reflect.Value.CallSlice"
+	bannedConstructReflectMethodByName = "reflect.Value.MethodByName"
+	bannedConstructLinkname            = "//go:linkname"
+)
+
+// DetectBanned returns all restricted constructs found in f.
 //
 // The caller is responsible for not passing gen_capabilities.go to this
 // function — generated files are exempt from all checks.
@@ -75,9 +85,10 @@ func detectCgo(fset *token.FileSet, f *ast.File, filename string) []BannedConstr
 		if spec.Path.Value == `"C"` {
 			pos := fset.Position(spec.Pos())
 			found = append(found, BannedConstruct{
-				File: filename,
-				Line: pos.Line,
-				Kind: `import "C" (CGo)`,
+				File:      filename,
+				Line:      pos.Line,
+				Construct: bannedConstructImportC,
+				Kind:      `import "C" (CGo)`,
 			})
 		}
 	}
@@ -118,9 +129,10 @@ func detectUnsafe(fset *token.FileSet, f *ast.File, filename string) []BannedCon
 		if ident.Name == localName && sel.Sel.Name == "Pointer" {
 			pos := fset.Position(call.Pos())
 			found = append(found, BannedConstruct{
-				File: filename,
-				Line: pos.Line,
-				Kind: "unsafe.Pointer conversion",
+				File:      filename,
+				Line:      pos.Line,
+				Construct: bannedConstructUnsafePointer,
+				Kind:      "unsafe.Pointer conversion",
 			})
 		}
 		return true
@@ -159,9 +171,10 @@ func detectPlugin(fset *token.FileSet, f *ast.File, filename string) []BannedCon
 		if ident.Name == localName && sel.Sel.Name == "Open" {
 			pos := fset.Position(call.Pos())
 			found = append(found, BannedConstruct{
-				File: filename,
-				Line: pos.Line,
-				Kind: "plugin.Open (dynamic library loading)",
+				File:      filename,
+				Line:      pos.Line,
+				Construct: bannedConstructPluginOpen,
+				Kind:      "plugin.Open (dynamic library loading)",
 			})
 		}
 		return true
@@ -204,8 +217,8 @@ func detectReflect(fset *token.FileSet, f *ast.File, filename string) []BannedCo
 	}
 
 	bannedMethods := map[string]bool{
-		"Call":        true,
-		"CallSlice":   true,
+		"Call":         true,
+		"CallSlice":    true,
 		"MethodByName": true,
 	}
 
@@ -221,10 +234,18 @@ func detectReflect(fset *token.FileSet, f *ast.File, filename string) []BannedCo
 		}
 		if bannedMethods[sel.Sel.Name] {
 			pos := fset.Position(call.Pos())
+			construct := bannedConstructReflectCall
+			switch sel.Sel.Name {
+			case "CallSlice":
+				construct = bannedConstructReflectCallSlice
+			case "MethodByName":
+				construct = bannedConstructReflectMethodByName
+			}
 			found = append(found, BannedConstruct{
-				File: filename,
-				Line: pos.Line,
-				Kind: "reflect." + sel.Sel.Name + " (dynamic dispatch)",
+				File:      filename,
+				Line:      pos.Line,
+				Construct: construct,
+				Kind:      "reflect." + sel.Sel.Name + " (dynamic dispatch)",
 			})
 		}
 		return true
@@ -249,14 +270,40 @@ func detectLinkname(fset *token.FileSet, f *ast.File, filename string) []BannedC
 			if strings.Contains(c.Text, "go:linkname") {
 				pos := fset.Position(c.Pos())
 				found = append(found, BannedConstruct{
-					File: filename,
-					Line: pos.Line,
-					Kind: "//go:linkname directive",
+					File:      filename,
+					Line:      pos.Line,
+					Construct: bannedConstructLinkname,
+					Kind:      "//go:linkname directive",
 				})
 			}
 		}
 	}
 	return found
+}
+
+// normalizeBannedConstructName canonicalizes manifest and detection identifiers
+// so a package can write either "plugin.Open" or "plugin.Open()" and still
+// match the same restricted construct.
+func normalizeBannedConstructName(construct string) string {
+	construct = strings.TrimSpace(construct)
+	switch {
+	case strings.HasPrefix(construct, bannedConstructImportC):
+		return bannedConstructImportC
+	case strings.HasPrefix(construct, bannedConstructPluginOpen):
+		return bannedConstructPluginOpen
+	case strings.HasPrefix(construct, bannedConstructUnsafePointer):
+		return bannedConstructUnsafePointer
+	case strings.HasPrefix(construct, bannedConstructReflectCallSlice):
+		return bannedConstructReflectCallSlice
+	case strings.HasPrefix(construct, bannedConstructReflectCall):
+		return bannedConstructReflectCall
+	case strings.HasPrefix(construct, bannedConstructReflectMethodByName):
+		return bannedConstructReflectMethodByName
+	case strings.Contains(construct, "go:linkname"):
+		return bannedConstructLinkname
+	default:
+		return strings.TrimSuffix(construct, "()")
+	}
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -293,4 +340,3 @@ func importLocalName(f *ast.File, importPath string) string {
 	parts := strings.Split(importPath, "/")
 	return parts[len(parts)-1]
 }
-

--- a/code/packages/go/ca-capability-analyzer/manifest.go
+++ b/code/packages/go/ca-capability-analyzer/manifest.go
@@ -47,17 +47,19 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // manifestJSON mirrors the on-disk JSON structure of required_capabilities.json.
 // The "JSON" suffix signals "raw parse target, not an abstraction." Callers
 // receive the higher-level map[CapabilityString]bool.
 type manifestJSON struct {
-	Schema        string           `json:"$schema"`
-	Version       int              `json:"version"`
-	Package       string           `json:"package"`
-	Capabilities  []capabilityJSON `json:"capabilities"`
-	Justification string           `json:"justification"`
+	Schema                    string                         `json:"$schema"`
+	Version                   int                            `json:"version"`
+	Package                   string                         `json:"package"`
+	Capabilities              []capabilityJSON               `json:"capabilities"`
+	Justification             string                         `json:"justification"`
+	BannedConstructExceptions []bannedConstructExceptionJSON `json:"banned_construct_exceptions"`
 }
 
 // capabilityJSON is one capability entry in the raw JSON.
@@ -66,6 +68,27 @@ type capabilityJSON struct {
 	Action        string `json:"action"`
 	Target        string `json:"target"`
 	Justification string `json:"justification"`
+}
+
+// bannedConstructExceptionJSON is one banned_construct_exceptions entry in the
+// raw JSON.
+type bannedConstructExceptionJSON struct {
+	Construct     string `json:"construct"`
+	Language      string `json:"language"`
+	Justification string `json:"justification"`
+}
+
+// ManifestData is the parsed manifest information the analyzer needs.
+//
+// Declared contains the capability declaration set, including the category:action:*
+// wildcard entries added by LoadManifest.
+//
+// BannedConstructExceptions contains explicit per-language exception keys in the
+// form "<language>:<construct>". Only a small subset of constructs are currently
+// honorably exemptible in the Go analyzer.
+type ManifestData struct {
+	Declared                  map[CapabilityString]bool
+	BannedConstructExceptions map[string]bool
 }
 
 // canonicalCapabilityString converts a (category, action, target) triple to
@@ -77,12 +100,17 @@ func canonicalCapabilityString(category, action, target string) CapabilityString
 	return CapabilityString(category + ":" + action + ":" + target)
 }
 
-// LoadManifest reads required_capabilities.json from dir and returns the set
-// of declared capabilities as a set (map with bool values) for O(1) lookup.
+// canonicalBannedConstructExceptionKey converts a (language, construct) pair
+// into the standard "<language>:<construct>" form used for O(1) exemption checks.
+func canonicalBannedConstructExceptionKey(language, construct string) string {
+	return strings.ToLower(strings.TrimSpace(language)) + ":" + normalizeBannedConstructName(construct)
+}
+
+// LoadManifestData reads required_capabilities.json from dir and returns the
+// declared capability set plus any explicit banned-construct exceptions.
 //
-// The map contains one entry per declared capability in canonical form.
-// If no manifest file exists, the map is empty but non-nil — this represents
-// a package with zero declared capabilities.
+// If no manifest file exists, both maps are empty but non-nil — this represents
+// a package with zero declared capabilities and zero construct exemptions.
 //
 // The function also adds "wildcard" entries for each (category:action) pair
 // present in the manifest. This lets the analyzer treat a manifest that
@@ -90,7 +118,7 @@ func canonicalCapabilityString(category, action, target string) CapabilityString
 // because if the package has declared any fs:read target, it has gone through
 // the manifest process, and the specific path enforcement is handled at
 // runtime by the Operations system, not by this static analyzer.
-func LoadManifest(dir string) (map[CapabilityString]bool, error) {
+func LoadManifestData(dir string) (*ManifestData, error) {
 	manifestPath := filepath.Join(dir, "required_capabilities.json")
 
 	// Use op.File.ReadFile via the Operations system (this package declares
@@ -117,7 +145,10 @@ func LoadManifest(dir string) (map[CapabilityString]bool, error) {
 		// so errors.Is(err, os.ErrNotExist) resolves correctly through the
 		// error chain regardless of locale or OS.
 		if errors.Is(err, os.ErrNotExist) {
-			return make(map[CapabilityString]bool), nil
+			return &ManifestData{
+				Declared:                  make(map[CapabilityString]bool),
+				BannedConstructExceptions: make(map[string]bool),
+			}, nil
 		}
 		return nil, fmt.Errorf("LoadManifest: reading %s: %w", manifestPath, err)
 	}
@@ -127,10 +158,13 @@ func LoadManifest(dir string) (map[CapabilityString]bool, error) {
 		return nil, fmt.Errorf("LoadManifest: parsing %s: %w", manifestPath, err)
 	}
 
-	declared := make(map[CapabilityString]bool)
+	manifest := &ManifestData{
+		Declared:                  make(map[CapabilityString]bool),
+		BannedConstructExceptions: make(map[string]bool),
+	}
 	for _, cap := range mf.Capabilities {
 		// Add the exact capability as declared.
-		declared[canonicalCapabilityString(cap.Category, cap.Action, cap.Target)] = true
+		manifest.Declared[canonicalCapabilityString(cap.Category, cap.Action, cap.Target)] = true
 
 		// Also add a wildcard-target entry for this (category, action) pair.
 		// This allows the analyzer to treat any declared target as covering the
@@ -138,10 +172,26 @@ func LoadManifest(dir string) (map[CapabilityString]bool, error) {
 		// "fs:read:*" (it cannot know which specific path will be accessed);
 		// if the manifest declares any fs:read entry, the package has accepted
 		// the manifest discipline and path enforcement is handled at runtime.
-		declared[canonicalCapabilityString(cap.Category, cap.Action, "*")] = true
+		manifest.Declared[canonicalCapabilityString(cap.Category, cap.Action, "*")] = true
 	}
 
-	return declared, nil
+	for _, exception := range mf.BannedConstructExceptions {
+		key := canonicalBannedConstructExceptionKey(exception.Language, exception.Construct)
+		manifest.BannedConstructExceptions[key] = true
+	}
+
+	return manifest, nil
+}
+
+// LoadManifest reads required_capabilities.json from dir and returns just the
+// declared capability set. This compatibility helper keeps the old API surface
+// while the analyzer uses LoadManifestData for the richer manifest shape.
+func LoadManifest(dir string) (map[CapabilityString]bool, error) {
+	manifest, err := LoadManifestData(dir)
+	if err != nil {
+		return nil, err
+	}
+	return manifest.Declared, nil
 }
 
 // DeclaredCapabilityList returns the canonical capability strings from a manifest
@@ -157,4 +207,3 @@ func DeclaredCapabilityList(dir string) ([]CapabilityString, error) {
 	}
 	return result, nil
 }
-

--- a/code/packages/go/ca-capability-analyzer/manifest_test.go
+++ b/code/packages/go/ca-capability-analyzer/manifest_test.go
@@ -36,6 +36,22 @@ func TestLoadManifest_NoFile(t *testing.T) {
 	}
 }
 
+// TestLoadManifestData_NoFile verifies that the richer manifest loader returns
+// empty maps for both declared capabilities and banned-construct exceptions.
+func TestLoadManifestData_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	m, err := LoadManifestData(dir)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if len(m.Declared) != 0 {
+		t.Errorf("expected empty declared map, got %v", m.Declared)
+	}
+	if len(m.BannedConstructExceptions) != 0 {
+		t.Errorf("expected empty exception map, got %v", m.BannedConstructExceptions)
+	}
+}
+
 // TestLoadManifest_EmptyCapabilities verifies that a manifest with an empty
 // capabilities array returns an empty map.
 func TestLoadManifest_EmptyCapabilities(t *testing.T) {
@@ -164,6 +180,42 @@ func TestLoadManifest_MultipleCapabilities(t *testing.T) {
 	}
 }
 
+// TestLoadManifestData_BannedConstructExceptions verifies that manifest
+// exceptions are parsed and canonicalized for language-specific lookup.
+func TestLoadManifestData_BannedConstructExceptions(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, `{
+		"version": 1,
+		"package": "go/test-pkg",
+		"capabilities": [],
+		"banned_construct_exceptions": [
+			{
+				"construct": "import \"C\" (CGo)",
+				"language": "go",
+				"justification": "Reviewed C bridge."
+			},
+			{
+				"construct": "plugin.Open()",
+				"language": "go",
+				"justification": "Reviewed plugin loader."
+			}
+		],
+		"justification": "Explicit FFI package."
+	}`)
+
+	m, err := LoadManifestData(dir)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if !m.BannedConstructExceptions[`go:import "C"`] {
+		t.Errorf("expected import C exception, got %v", m.BannedConstructExceptions)
+	}
+	if !m.BannedConstructExceptions["go:plugin.Open"] {
+		t.Errorf("expected plugin.Open exception, got %v", m.BannedConstructExceptions)
+	}
+}
+
 // TestLoadManifest_InvalidJSON verifies that malformed JSON returns an error.
 func TestLoadManifest_InvalidJSON(t *testing.T) {
 	dir := t.TempDir()
@@ -222,6 +274,26 @@ func TestCanonicalCapabilityString(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("canonicalCapabilityString(%q, %q, %q) = %q, want %q",
 				tc.category, tc.action, tc.target, got, tc.want)
+		}
+	}
+}
+
+func TestCanonicalBannedConstructExceptionKey(t *testing.T) {
+	cases := []struct {
+		language  string
+		construct string
+		want      string
+	}{
+		{"go", `import "C" (CGo)`, `go:import "C"`},
+		{"Go", "plugin.Open()", "go:plugin.Open"},
+		{"go", "reflect.Value.Call()", "go:reflect.Value.Call"},
+	}
+
+	for _, tc := range cases {
+		got := canonicalBannedConstructExceptionKey(tc.language, tc.construct)
+		if got != tc.want {
+			t.Errorf("canonicalBannedConstructExceptionKey(%q, %q) = %q, want %q",
+				tc.language, tc.construct, got, tc.want)
 		}
 	}
 }

--- a/code/packages/go/ca-capability-analyzer/report.go
+++ b/code/packages/go/ca-capability-analyzer/report.go
@@ -19,7 +19,7 @@
 // 2. Detect raw stdlib calls that map to capability categories.
 // 3. Read required_capabilities.json to get what is declared.
 // 4. Report CAP001 violations for any detected capability not in the manifest.
-// 5. Report CAP002 violations for any banned construct (unconditional).
+// 5. Report CAP002 violations for any disallowed restricted construct.
 //
 // # Exemptions
 //
@@ -66,16 +66,20 @@ type DetectedCapability struct {
 	Evidence string
 }
 
-// BannedConstruct records a detected banned code pattern. These are reported
-// unconditionally — no manifest entry can authorize them. They represent
-// constructs that defeat static capability analysis entirely (dynamic dispatch,
-// native code interop, linker tricks).
+// BannedConstruct records a detected restricted code pattern. The Go analyzer
+// only allows a tiny subset of these through an explicit manifest opt-in;
+// everything else remains a CAP002 violation because it defeats static
+// capability analysis (dynamic dispatch, native code interop, linker tricks).
 type BannedConstruct struct {
 	// File is the path to the source file, relative to the analyzed directory.
 	File string
 
 	// Line is the 1-based line number.
 	Line int
+
+	// Construct is the canonical manifest-facing identifier, e.g. `import "C"`,
+	// "plugin.Open", "reflect.Value.Call", or "//go:linkname".
+	Construct string
 
 	// Kind identifies the banned construct, e.g., "unsafe.Pointer",
 	// `import "C"`, "reflect.Value.Call", "go:linkname".
@@ -87,8 +91,9 @@ type BannedConstruct struct {
 //
 //   - CAP001: an undeclared capability was detected. Fix: add the capability
 //     to required_capabilities.json and regenerate gen_capabilities.go.
-//   - CAP002: a banned construct was detected. Fix: remove the construct.
-//     No manifest entry can authorize banned constructs.
+//   - CAP002: a restricted construct was detected and not explicitly authorized.
+//     Fix: remove it, or for supported FFI-style constructs add the matching
+//     banned_construct_exceptions entry plus the required ffi capability.
 type Violation struct {
 	// Code is the short error code, "CAP001" or "CAP002".
 	Code string
@@ -117,14 +122,16 @@ type AnalysisResult struct {
 	// With --verbose, the CLI prints this list even on a passing run.
 	Detected []DetectedCapability
 
-	// Banned is every banned construct found.
+	// Banned is every restricted construct that remains disallowed after
+	// manifest exceptions are applied.
 	Banned []BannedConstruct
 
 	// Declared is the capability set loaded from required_capabilities.json.
 	// Empty if no manifest exists (treated as zero declared capabilities).
 	Declared []CapabilityString
 
-	// Violations is the final verdict: undeclared capabilities + banned constructs.
+	// Violations is the final verdict: undeclared capabilities + disallowed
+	// restricted constructs.
 	// If len(Violations) == 0, the analysis passes.
 	Violations []Violation
 
@@ -165,8 +172,17 @@ func newViolationCAP001(d DetectedCapability) Violation {
 //
 // No fix instruction because the only valid fix is removing the construct.
 func newViolationCAP002(b BannedConstruct) Violation {
+	return newViolationCAP002Hint(b, "")
+}
+
+// newViolationCAP002Hint constructs a CAP002 violation with extra guidance.
+func newViolationCAP002Hint(b BannedConstruct, hint string) Violation {
+	message := fmt.Sprintf("%s:%d: [CAP002] banned construct: %s", b.File, b.Line, b.Kind)
+	if hint != "" {
+		message += " — " + hint
+	}
 	return Violation{
 		Code:    "CAP002",
-		Message: fmt.Sprintf("%s:%d: [CAP002] banned construct: %s", b.File, b.Line, b.Kind),
+		Message: message,
 	}
 }

--- a/code/specs/13-capability-security.md
+++ b/code/specs/13-capability-security.md
@@ -649,6 +649,17 @@ itself uses `ast` which involves `compile()`), it must:
 
 2. Obtain hardware-key-signed approval, just like any capability escalation.
 
+For Go, the FFI-style constructs require a second declaration in addition to the
+exception itself:
+
+- `import "C"` also requires an `ffi:call:*` capability (or a specific
+  `ffi:call:<library>` target)
+- `plugin.Open()` also requires an `ffi:load:*` capability (or a specific
+  `ffi:load:<library>` target)
+
+This keeps native interop explicitly opt-in instead of silently turning
+`banned_construct_exceptions` into a blanket escape hatch.
+
 ---
 
 ## Layer 4: CI Gate (Static Analysis)

--- a/code/specs/schemas/required_capabilities.schema.json
+++ b/code/specs/schemas/required_capabilities.schema.json
@@ -35,7 +35,7 @@
     },
     "banned_construct_exceptions": {
       "type": "array",
-      "description": "Exceptions to the banned dynamic execution constructs (eval, exec, __import__, etc.). Each exception requires hardware-key-signed approval. Most packages should not have any exceptions.",
+      "description": "Exceptions to the banned dynamic execution constructs (eval, exec, __import__, import \"C\", plugin.Open, etc.). Each exception requires hardware-key-signed approval. Some languages also require a matching capability declaration, such as Go ffi:call/load for native interop. Most packages should not have any exceptions.",
       "items": {
         "$ref": "#/$defs/banned_construct_exception"
       }
@@ -82,7 +82,7 @@
       "properties": {
         "construct": {
           "type": "string",
-          "description": "The banned construct being exempted (e.g., 'eval', 'compile', '__import__', 'reflect.Value.Call')."
+          "description": "The banned construct being exempted (e.g., 'eval', 'compile', '__import__', 'reflect.Value.Call', 'import \"C\"', or 'plugin.Open')."
         },
         "language": {
           "type": "string",


### PR DESCRIPTION
## What changed
- taught the Go capability analyzer to honor explicit `banned_construct_exceptions` for FFI-style constructs
- require a matching `ffi` capability alongside the exception: `ffi:call:*` for `import "C"` and `ffi:load:*` for `plugin.Open`
- kept the other restricted constructs hard-blocked (`unsafe.Pointer`, `reflect.Value.Call/CallSlice/MethodByName`, and `//go:linkname`)
- added manifest parsing support for `banned_construct_exceptions`
- updated tests, README, spec 13, and the capability schema to document the policy

## Why
The schema/spec already described explicit banned-construct exceptions, but the Go analyzer still treated every restricted construct as unconditional CAP002. This change makes native interop explicitly opt-in instead of forcing a blanket ban, while still keeping the dangerous dynamic/unsafe escape hatches closed.

## Impact
Go packages can now opt into reviewed native interop without weakening the overall capability cage. A package must declare both the restricted-construct exception and the matching `ffi` capability, so the policy stays auditable.

## Validation
- `go test ./...` in `code/packages/go/ca-capability-analyzer`
- `go run . -root /Users/adhithya/Downloads/Codex/coding-adventures-go-capability-cage-pr -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/go-capability-cage-pr-plan.json` in `code/programs/go/build-tool`
