### PR TITLE
[codex] extend X25519 iterated test timeout

### DIFF
--- a/code/packages/typescript/x25519/tests/x25519.test.ts
+++ b/code/packages/typescript/x25519/tests/x25519.test.ts
@@ -184,7 +184,7 @@ describe("X25519", () => {
   // After 1000 iterations of the same process, we must reach a specific value.
   // This is a thorough stress test of the field arithmetic.
 
-  it("should pass iterated test after 1000 iterations", () => {
+  it("should pass iterated test after 1000 iterations", { timeout: 15_000 }, () => {
     let k = new Uint8Array(32);
     k[0] = 9;
     let u = new Uint8Array(32);


### PR DESCRIPTION
## What changed
- Increased the Vitest timeout for the 1000-iteration X25519 stress test to 15 seconds.

## Why
- The test itself is correct, but the default 5 second timeout was too short on `origin/main`, causing a false failure even though the implementation passes.

## Validation
- Ran `npm test` in `code/packages/typescript/x25519`
- Confirmed all 12 tests pass, including the 1000-iteration iterated test

## Notes
- This keeps the stress test in place while avoiding a global timeout change for the whole suite.