### PR TITLE
fix(build-tool): port ci workflow toolchain scoping

### DIFF
--- a/code/programs/elixir/build-tool/lib/build_tool/ci_workflow.ex
+++ b/code/programs/elixir/build-tool/lib/build_tool/ci_workflow.ex
@@ -1,0 +1,289 @@
+defmodule BuildTool.CIWorkflow do
+  @moduledoc false
+
+  @ci_workflow_path ".github/workflows/ci.yml"
+
+  @toolchain_markers %{
+    "python" => [
+      "needs_python",
+      "setup-python",
+      "python-version",
+      "setup-uv",
+      "python --version",
+      "uv --version",
+      "pytest",
+      "set up python",
+      "install uv"
+    ],
+    "ruby" => [
+      "needs_ruby",
+      "setup-ruby",
+      "ruby-version",
+      "bundler",
+      "gem install bundler",
+      "ruby --version",
+      "bundle --version",
+      "set up ruby",
+      "install bundler"
+    ],
+    "go" => [
+      "needs_go",
+      "setup-go",
+      "go-version",
+      "go version",
+      "set up go"
+    ],
+    "typescript" => [
+      "needs_typescript",
+      "setup-node",
+      "node-version",
+      "npm install -g jest",
+      "node --version",
+      "npm --version",
+      "set up node"
+    ],
+    "rust" => [
+      "needs_rust",
+      "rust-toolchain",
+      "cargo",
+      "rustc",
+      "tarpaulin",
+      "wasm32-unknown-unknown",
+      "set up rust",
+      "install cargo-tarpaulin"
+    ],
+    "elixir" => [
+      "needs_elixir",
+      "setup-beam",
+      "elixir-version",
+      "otp-version",
+      "elixir --version",
+      "mix --version",
+      "set up elixir"
+    ],
+    "lua" => [
+      "needs_lua",
+      "gh-actions-lua",
+      "gh-actions-luarocks",
+      "luarocks",
+      "lua -v",
+      "msvc",
+      "set up lua",
+      "set up luarocks"
+    ],
+    "perl" => [
+      "needs_perl",
+      "cpanm",
+      "perl --version",
+      "install cpanm"
+    ],
+    "haskell" => [
+      "needs_haskell",
+      "haskell-actions/setup",
+      "ghc-version",
+      "cabal-version",
+      "ghc --version",
+      "cabal --version",
+      "set up haskell"
+    ],
+    "dotnet" => [
+      "needs_dotnet",
+      "setup-dotnet",
+      "dotnet-version",
+      "dotnet --version",
+      "set up .net"
+    ]
+  }
+
+  @unsafe_markers [
+    "./build-tool",
+    "build-tool.exe",
+    "-detect-languages",
+    "-emit-plan",
+    "-force",
+    "-plan-file",
+    "-validate-build-files",
+    "actions/checkout",
+    "build-plan",
+    "cancel-in-progress:",
+    "concurrency:",
+    "diff-base",
+    "download-artifact",
+    "event_name",
+    "fetch-depth",
+    "git fetch origin main",
+    "git_ref",
+    "is_main",
+    "matrix:",
+    "permissions:",
+    "pr_base_ref",
+    "pull_request:",
+    "push:",
+    "runs-on:",
+    "strategy:",
+    "upload-artifact"
+  ]
+
+  def ci_workflow_path, do: @ci_workflow_path
+
+  def analyze_changes(root, diff_base) do
+    analyze_patch(file_diff(root, diff_base, @ci_workflow_path))
+  end
+
+  def analyze_patch(patch) do
+    do_analyze_patch(String.split(patch, "\n"), MapSet.new(), [])
+  end
+
+  def sorted_toolchains(toolchains) do
+    toolchains
+    |> Enum.sort()
+  end
+
+  defp do_analyze_patch([], toolchains, hunk) do
+    case classify_hunk(Enum.reverse(hunk)) do
+      {hunk_toolchains, false} ->
+        %{toolchains: MapSet.union(toolchains, hunk_toolchains), requires_full_rebuild: false}
+
+      {_hunk_toolchains, true} ->
+        %{toolchains: MapSet.new(), requires_full_rebuild: true}
+    end
+  end
+
+  defp do_analyze_patch([line | rest], toolchains, hunk) do
+    cond do
+      String.starts_with?(line, "@@") ->
+        case classify_hunk(Enum.reverse(hunk)) do
+          {hunk_toolchains, false} ->
+            do_analyze_patch(rest, MapSet.union(toolchains, hunk_toolchains), [])
+
+          {_hunk_toolchains, true} ->
+            %{toolchains: MapSet.new(), requires_full_rebuild: true}
+        end
+
+      String.starts_with?(line, "diff --git ") or
+        String.starts_with?(line, "index ") or
+        String.starts_with?(line, "--- ") or
+          String.starts_with?(line, "+++ ") ->
+        do_analyze_patch(rest, toolchains, hunk)
+
+      true ->
+        do_analyze_patch(rest, toolchains, [line | hunk])
+    end
+  end
+
+  defp classify_hunk(lines) do
+    {hunk_toolchains, changed_toolchains, changed_lines} =
+      Enum.reduce(lines, {MapSet.new(), MapSet.new(), []}, fn line,
+                                                              {hunk_toolchains,
+                                                               changed_toolchains, changed_lines} ->
+        cond do
+          line == "" or not diff_line?(line) ->
+            {hunk_toolchains, changed_toolchains, changed_lines}
+
+          true ->
+            content = line |> String.slice(1, String.length(line) - 1) |> String.trim()
+            hunk_toolchains = MapSet.union(hunk_toolchains, detect_toolchains(content))
+
+            cond do
+              not changed_line?(line) or content == "" or String.starts_with?(content, "#") ->
+                {hunk_toolchains, changed_toolchains, changed_lines}
+
+              true ->
+                changed_toolchains = MapSet.union(changed_toolchains, detect_toolchains(content))
+                {hunk_toolchains, changed_toolchains, [content | changed_lines]}
+            end
+        end
+      end)
+
+    changed_lines = Enum.reverse(changed_lines)
+
+    cond do
+      changed_lines == [] ->
+        {MapSet.new(), false}
+
+      MapSet.size(changed_toolchains) == 0 and MapSet.size(hunk_toolchains) != 1 ->
+        {MapSet.new(), true}
+
+      true ->
+        resolved_toolchains =
+          if MapSet.size(changed_toolchains) == 0 do
+            hunk_toolchains
+          else
+            changed_toolchains
+          end
+
+        unsafe_change =
+          Enum.any?(changed_lines, fn content ->
+            touches_shared_ci_behavior?(content) or
+              (MapSet.size(detect_toolchains(content)) == 0 and
+                 not toolchain_scoped_structural_line?(content))
+          end)
+
+        if unsafe_change do
+          {MapSet.new(), true}
+        else
+          {resolved_toolchains, false}
+        end
+    end
+  end
+
+  defp detect_toolchains(content) do
+    normalized = String.downcase(content)
+
+    Enum.reduce(@toolchain_markers, MapSet.new(), fn {toolchain, markers}, found ->
+      if Enum.any?(markers, &String.contains?(normalized, &1)) do
+        MapSet.put(found, toolchain)
+      else
+        found
+      end
+    end)
+  end
+
+  defp touches_shared_ci_behavior?(content) do
+    normalized = String.downcase(content)
+    Enum.any?(@unsafe_markers, &String.contains?(normalized, &1))
+  end
+
+  defp toolchain_scoped_structural_line?(content) do
+    String.starts_with?(
+      content,
+      [
+        "if:",
+        "run:",
+        "shell:",
+        "with:",
+        "env:",
+        "else",
+        "fi",
+        "then",
+        "printf ",
+        "echo ",
+        "curl ",
+        "powershell ",
+        "call ",
+        "cd "
+      ]
+    )
+  end
+
+  defp diff_line?(line) do
+    String.starts_with?(line, " ") or changed_line?(line)
+  end
+
+  defp changed_line?(line) do
+    String.starts_with?(line, "+") or String.starts_with?(line, "-")
+  end
+
+  defp file_diff(root, diff_base, relative_path) do
+    [
+      ["diff", "--unified=0", diff_base <> "...HEAD", "--", relative_path],
+      ["diff", "--unified=0", diff_base, "HEAD", "--", relative_path]
+    ]
+    |> Enum.find_value("", fn args ->
+      case System.cmd("git", args, cd: root, stderr_to_stdout: true) do
+        {output, 0} -> output
+        _ -> nil
+      end
+    end)
+  end
+end

--- a/code/programs/elixir/build-tool/lib/build_tool/cli.ex
+++ b/code/programs/elixir/build-tool/lib/build_tool/cli.ex
@@ -40,7 +40,21 @@ defmodule BuildTool.CLI do
       ./build_tool --root /path/to/repo --force
   """
 
-  alias BuildTool.{Cache, Discovery, DirectedGraph, Executor, GitDiff, Hasher, Plan, Reporter, Resolver, StarlarkEvaluator, Validator}
+  alias BuildTool.{
+    CIWorkflow,
+    Cache,
+    Discovery,
+    DirectedGraph,
+    Executor,
+    GitDiff,
+    Hasher,
+    Plan,
+    Reporter,
+    Resolver,
+    StarlarkEvaluator,
+    Validator
+  }
+
   alias CodingAdventures.ProgressBar
 
   # ---------------------------------------------------------------------------
@@ -114,14 +128,33 @@ defmodule BuildTool.CLI do
       IO.puts(:stderr, "Use --root to specify the repo root.")
       1
     else
-      do_build(repo_root, force, dry_run, jobs, language, diff_base, cache_file,
+      do_build(
+        repo_root,
+        force,
+        dry_run,
+        jobs,
+        language,
+        diff_base,
+        cache_file,
         validate_build_files,
-        emit_plan_path, plan_file_path)
+        emit_plan_path,
+        plan_file_path
+      )
     end
   end
 
-  defp do_build(repo_root, force, dry_run, jobs, language, diff_base, cache_file,
-               validate_build_files, emit_plan_path, plan_file_path) do
+  defp do_build(
+         repo_root,
+         force,
+         dry_run,
+         jobs,
+         language,
+         diff_base,
+         cache_file,
+         validate_build_files,
+         emit_plan_path,
+         plan_file_path
+       ) do
     # The build starts from the code/ directory inside the repo root.
     code_root = Path.join(repo_root, "code")
 
@@ -159,28 +192,57 @@ defmodule BuildTool.CLI do
           if validate_build_files do
             case Validator.validate_build_contracts(repo_root, packages) do
               nil ->
-                do_build_packages(packages, repo_root, force, dry_run, jobs, diff_base,
-                  cache_file, emit_plan_path, plan_file_path)
+                do_build_packages(
+                  packages,
+                  repo_root,
+                  force,
+                  dry_run,
+                  jobs,
+                  diff_base,
+                  cache_file,
+                  emit_plan_path,
+                  plan_file_path
+                )
 
               validation_error ->
                 IO.puts(:stderr, "BUILD/CI validation failed:")
                 IO.puts(:stderr, "  - #{validation_error}")
+
                 IO.puts(
                   :stderr,
                   "Fix the BUILD file or CI workflow so isolated and full-build runs stay correct."
                 )
+
                 1
             end
           else
-            do_build_packages(packages, repo_root, force, dry_run, jobs, diff_base,
-              cache_file, emit_plan_path, plan_file_path)
+            do_build_packages(
+              packages,
+              repo_root,
+              force,
+              dry_run,
+              jobs,
+              diff_base,
+              cache_file,
+              emit_plan_path,
+              plan_file_path
+            )
           end
       end
     end
   end
 
-  defp do_build_packages(packages, repo_root, force, dry_run, jobs, diff_base,
-                         cache_file, emit_plan_path, _plan_file_path) do
+  defp do_build_packages(
+         packages,
+         repo_root,
+         force,
+         dry_run,
+         jobs,
+         diff_base,
+         cache_file,
+         emit_plan_path,
+         _plan_file_path
+       ) do
     IO.puts("Discovered #{length(packages)} packages")
 
     # Step 4: Resolve dependencies.
@@ -194,12 +256,28 @@ defmodule BuildTool.CLI do
         changed_files = GitDiff.get_changed_files(repo_root, diff_base)
 
         if length(changed_files) > 0 do
-          shared_changed = Enum.any?(changed_files, fn f ->
-            String.starts_with?(f, ".github/")
-          end)
+          ci_change =
+            if Enum.member?(changed_files, CIWorkflow.ci_workflow_path()) do
+              change = CIWorkflow.analyze_changes(repo_root, diff_base)
 
-          if shared_changed do
-            IO.puts("Git diff: shared files changed — rebuilding everything")
+              if change.requires_full_rebuild do
+                IO.puts("Git diff: ci.yml changed in shared ways — rebuilding everything")
+              else
+                toolchains = CIWorkflow.sorted_toolchains(change.toolchains)
+
+                if toolchains != [] do
+                  IO.puts(
+                    "Git diff: ci.yml changed only toolchain-scoped setup for #{Enum.join(toolchains, ", ")}"
+                  )
+                end
+              end
+
+              change
+            else
+              %{toolchains: MapSet.new(), requires_full_rebuild: false}
+            end
+
+          if ci_change.requires_full_rebuild do
             {nil, true}
           else
             changed_pkgs = GitDiff.map_files_to_packages(changed_files, packages, repo_root)
@@ -227,11 +305,27 @@ defmodule BuildTool.CLI do
     # This is used by CI to compute the plan in a fast "detect" job and
     # share it across build jobs on multiple platforms.
     if emit_plan_path != nil do
-      return_emit_plan(packages, graph, repo_root, diff_base, force_override, affected_set,
-        emit_plan_path)
+      return_emit_plan(
+        packages,
+        graph,
+        repo_root,
+        diff_base,
+        force_override,
+        affected_set,
+        emit_plan_path
+      )
     else
-      do_execute_builds(packages, graph, repo_root, force_override, dry_run, jobs, diff_base,
-        cache_file, affected_set)
+      do_execute_builds(
+        packages,
+        graph,
+        repo_root,
+        force_override,
+        dry_run,
+        jobs,
+        diff_base,
+        cache_file,
+        affected_set
+      )
     end
   end
 
@@ -242,8 +336,15 @@ defmodule BuildTool.CLI do
   # When --emit-plan is specified, we serialize the discovery + change
   # detection results to a JSON file and exit. No builds are executed.
 
-  defp return_emit_plan(packages, graph, repo_root, diff_base, force, affected_set,
-                        emit_plan_path) do
+  defp return_emit_plan(
+         packages,
+         graph,
+         repo_root,
+         diff_base,
+         force,
+         affected_set,
+         emit_plan_path
+       ) do
     # Convert affected_set to a list (or nil for "rebuild all").
     affected_list =
       case affected_set do
@@ -309,9 +410,17 @@ defmodule BuildTool.CLI do
   # Build execution (normal flow)
   # ---------------------------------------------------------------------------
 
-  defp do_execute_builds(packages, graph, repo_root, force, dry_run, jobs, _diff_base,
-                         cache_file, affected_set) do
-
+  defp do_execute_builds(
+         packages,
+         graph,
+         repo_root,
+         force,
+         dry_run,
+         jobs,
+         _diff_base,
+         cache_file,
+         affected_set
+       ) do
     # Step 6: Hash all packages.
     package_hashes = Map.new(packages, fn pkg -> {pkg.name, Hasher.hash_package(pkg)} end)
 
@@ -447,5 +556,4 @@ defmodule BuildTool.CLI do
       end
     end
   end
-
 end

--- a/code/programs/elixir/build-tool/test/ci_workflow_test.exs
+++ b/code/programs/elixir/build-tool/test/ci_workflow_test.exs
@@ -1,0 +1,53 @@
+defmodule BuildTool.CIWorkflowTest do
+  use ExUnit.Case, async: true
+
+  alias BuildTool.CIWorkflow
+
+  test "allows toolchain-scoped dotnet changes" do
+    change =
+      CIWorkflow.analyze_patch("""
+      @@ -312,0 +313,6 @@
+      +      - name: Set up .NET
+      +        if: needs.detect.outputs.needs_dotnet == 'true'
+      +        uses: actions/setup-dotnet@v4
+      +        with:
+      +          dotnet-version: '9.0.x'
+      """)
+
+    refute change.requires_full_rebuild
+    assert CIWorkflow.sorted_toolchains(change.toolchains) == ["dotnet"]
+  end
+
+  test "ignores comment-only changes" do
+    change =
+      CIWorkflow.analyze_patch("""
+      @@ -316,2 +316,2 @@
+      -          # .NET 8 is the current LTS release.
+      +          # .NET 9 is the current LTS release.
+      """)
+
+    refute change.requires_full_rebuild
+    assert MapSet.size(change.toolchains) == 0
+  end
+
+  test "requires a full rebuild for build command changes" do
+    change =
+      CIWorkflow.analyze_patch("""
+      @@ -404,1 +404,1 @@
+      -          $BT -root . -validate-build-files -language all
+      +          $BT -root . -force -validate-build-files -language all
+      """)
+
+    assert change.requires_full_rebuild
+  end
+
+  test "requires a full rebuild for unknown workflow changes" do
+    change =
+      CIWorkflow.analyze_patch("""
+      @@ -170,0 +171,1 @@
+      +      timeout-minutes: 45
+      """)
+
+    assert change.requires_full_rebuild
+  end
+end

--- a/code/programs/perl/build-tool/lib/CodingAdventures/BuildTool/CIWorkflow.pm
+++ b/code/programs/perl/build-tool/lib/CodingAdventures/BuildTool/CIWorkflow.pm
@@ -1,0 +1,240 @@
+package CodingAdventures::BuildTool::CIWorkflow;
+
+use strict;
+use warnings;
+
+our $CI_WORKFLOW_PATH = '.github/workflows/ci.yml';
+
+my %TOOLCHAIN_MARKERS = (
+    python => [
+        'needs_python', 'setup-python', 'python-version', 'setup-uv',
+        'python --version', 'uv --version', 'pytest',
+        'set up python', 'install uv',
+    ],
+    ruby => [
+        'needs_ruby', 'setup-ruby', 'ruby-version', 'bundler',
+        'gem install bundler', 'ruby --version', 'bundle --version',
+        'set up ruby', 'install bundler',
+    ],
+    go => [
+        'needs_go', 'setup-go', 'go-version', 'go version', 'set up go',
+    ],
+    typescript => [
+        'needs_typescript', 'setup-node', 'node-version', 'npm install -g jest',
+        'node --version', 'npm --version', 'set up node',
+    ],
+    rust => [
+        'needs_rust', 'rust-toolchain', 'cargo', 'rustc', 'tarpaulin',
+        'wasm32-unknown-unknown', 'set up rust', 'install cargo-tarpaulin',
+    ],
+    elixir => [
+        'needs_elixir', 'setup-beam', 'elixir-version', 'otp-version',
+        'elixir --version', 'mix --version', 'set up elixir',
+    ],
+    lua => [
+        'needs_lua', 'gh-actions-lua', 'gh-actions-luarocks', 'luarocks',
+        'lua -v', 'msvc', 'set up lua', 'set up luarocks',
+    ],
+    perl => [
+        'needs_perl', 'cpanm', 'perl --version', 'install cpanm',
+    ],
+    haskell => [
+        'needs_haskell', 'haskell-actions/setup', 'ghc-version', 'cabal-version',
+        'ghc --version', 'cabal --version', 'set up haskell',
+    ],
+    dotnet => [
+        'needs_dotnet', 'setup-dotnet', 'dotnet-version', 'dotnet --version',
+        'set up .net',
+    ],
+);
+
+my @UNSAFE_MARKERS = (
+    './build-tool',
+    'build-tool.exe',
+    '-detect-languages',
+    '-emit-plan',
+    '-force',
+    '-plan-file',
+    '-validate-build-files',
+    'actions/checkout',
+    'build-plan',
+    'cancel-in-progress:',
+    'concurrency:',
+    'diff-base',
+    'download-artifact',
+    'event_name',
+    'fetch-depth',
+    'git fetch origin main',
+    'git_ref',
+    'is_main',
+    'matrix:',
+    'permissions:',
+    'pr_base_ref',
+    'pull_request:',
+    'push:',
+    'runs-on:',
+    'strategy:',
+    'upload-artifact',
+);
+
+sub ci_workflow_path {
+    return $CI_WORKFLOW_PATH;
+}
+
+sub analyze_changes {
+    my ($root, $diff_base) = @_;
+    return analyze_patch(_file_diff($root, $diff_base, $CI_WORKFLOW_PATH));
+}
+
+sub analyze_patch {
+    my ($patch) = @_;
+    my %toolchains;
+    my @hunk;
+
+    for my $line (split /\n/, $patch // q{}) {
+        if ($line =~ /^@@/) {
+            my ($hunk_toolchains, $unsafe) = _classify_hunk(\@hunk);
+            return { toolchains => {}, requires_full_rebuild => 1 } if $unsafe;
+            %toolchains = (%toolchains, %{$hunk_toolchains});
+            @hunk = ();
+            next;
+        }
+
+        next if $line =~ /^(?:diff --git |index |--- |\+\+\+ )/;
+        push @hunk, $line;
+    }
+
+    my ($hunk_toolchains, $unsafe) = _classify_hunk(\@hunk);
+    return { toolchains => {}, requires_full_rebuild => 1 } if $unsafe;
+    %toolchains = (%toolchains, %{$hunk_toolchains});
+
+    return {
+        toolchains => \%toolchains,
+        requires_full_rebuild => 0,
+    };
+}
+
+sub sorted_toolchains {
+    my ($toolchains) = @_;
+    return sort keys %{ $toolchains || {} };
+}
+
+sub _classify_hunk {
+    my ($lines) = @_;
+    my %hunk_toolchains;
+    my %changed_toolchains;
+    my @changed_lines;
+
+    for my $line (@{$lines || []}) {
+        next if $line eq q{} || !_is_diff_line($line);
+
+        my $content = substr($line, 1);
+        $content =~ s/^\s+|\s+$//g;
+
+        %hunk_toolchains = (%hunk_toolchains, %{ _detect_toolchains($content) });
+
+        next if !_is_changed_line($line);
+        next if $content eq q{} || $content =~ /^#/;
+
+        push @changed_lines, $content;
+        %changed_toolchains = (%changed_toolchains, %{ _detect_toolchains($content) });
+    }
+
+    return ({}, 0) if !@changed_lines;
+
+    my $resolved_toolchains;
+    if (!%changed_toolchains) {
+        return ({}, 1) if scalar(keys %hunk_toolchains) != 1;
+        $resolved_toolchains = { %hunk_toolchains };
+    } else {
+        $resolved_toolchains = { %changed_toolchains };
+    }
+
+    for my $content (@changed_lines) {
+        return ({}, 1) if _touches_shared_ci_behavior($content);
+        next if scalar(keys %{ _detect_toolchains($content) }) > 0;
+        next if _is_toolchain_scoped_structural_line($content);
+        return ({}, 1);
+    }
+
+    return ($resolved_toolchains, 0);
+}
+
+sub _detect_toolchains {
+    my ($content) = @_;
+    my $normalized = lc($content // q{});
+    my %found;
+
+    for my $toolchain (keys %TOOLCHAIN_MARKERS) {
+        for my $marker (@{ $TOOLCHAIN_MARKERS{$toolchain} }) {
+            if (index($normalized, $marker) >= 0) {
+                $found{$toolchain} = 1;
+                last;
+            }
+        }
+    }
+
+    return \%found;
+}
+
+sub _touches_shared_ci_behavior {
+    my ($content) = @_;
+    my $normalized = lc($content // q{});
+
+    for my $marker (@UNSAFE_MARKERS) {
+        return 1 if index($normalized, $marker) >= 0;
+    }
+
+    return 0;
+}
+
+sub _is_toolchain_scoped_structural_line {
+    my ($content) = @_;
+
+    for my $prefix (
+        'if:',
+        'run:',
+        'shell:',
+        'with:',
+        'env:',
+        'else',
+        'fi',
+        'then',
+        'printf ',
+        'echo ',
+        'curl ',
+        'powershell ',
+        'call ',
+        'cd ',
+    ) {
+        return 1 if index($content, $prefix) == 0;
+    }
+
+    return 0;
+}
+
+sub _is_diff_line {
+    my ($line) = @_;
+    return index($line, ' ') == 0 || _is_changed_line($line);
+}
+
+sub _is_changed_line {
+    my ($line) = @_;
+    return index($line, '+') == 0 || index($line, '-') == 0;
+}
+
+sub _file_diff {
+    my ($root, $diff_base, $relative_path) = @_;
+
+    for my $cmd (
+        "git -C \\Q$root\\E diff --unified=0 ${diff_base}...HEAD -- $relative_path 2>/dev/null",
+        "git -C \\Q$root\\E diff --unified=0 $diff_base HEAD -- $relative_path 2>/dev/null",
+    ) {
+        my $output = `$cmd`;
+        return $output if $? == 0 && defined $output;
+    }
+
+    return q{};
+}
+
+1;

--- a/code/programs/perl/build-tool/lib/CodingAdventures/BuildTool/GitDiff.pm
+++ b/code/programs/perl/build-tool/lib/CodingAdventures/BuildTool/GitDiff.pm
@@ -32,6 +32,7 @@ package CodingAdventures::BuildTool::GitDiff;
 use strict;
 use warnings;
 use File::Spec ();
+use CodingAdventures::BuildTool::CIWorkflow ();
 
 our $VERSION = '0.01';
 
@@ -91,10 +92,22 @@ sub affected_packages {
     my @changed_files = $self->changed_files();
     return () unless @changed_files;
 
-    for my $file (@changed_files) {
-        if ($file =~ /^\.github\//) {
-            print "Git diff: shared files changed -- rebuilding everything\n";
+    if (grep { $_ eq CodingAdventures::BuildTool::CIWorkflow::ci_workflow_path() } @changed_files) {
+        my $ci_change = CodingAdventures::BuildTool::CIWorkflow::analyze_changes(
+            $self->{root},
+            $self->{diff_base},
+        );
+
+        if ($ci_change->{requires_full_rebuild}) {
+            print "Git diff: ci.yml changed in shared ways -- rebuilding everything\n";
             return map { $_->{name} } @{$packages_ref};
+        }
+
+        my @toolchains =
+            CodingAdventures::BuildTool::CIWorkflow::sorted_toolchains($ci_change->{toolchains});
+        if (@toolchains) {
+            print "Git diff: ci.yml changed only toolchain-scoped setup for "
+                . join(', ', @toolchains) . "\n";
         }
     }
 

--- a/code/programs/perl/build-tool/t/05-gitdiff.t
+++ b/code/programs/perl/build-tool/t/05-gitdiff.t
@@ -18,6 +18,7 @@ use File::Spec ();
 
 use CodingAdventures::BuildTool::GitDiff;
 use CodingAdventures::BuildTool::Resolver;
+use CodingAdventures::BuildTool::CIWorkflow ();
 
 # Mock subclass that returns a predetermined list of changed files.
 package MockGitDiff;
@@ -262,6 +263,59 @@ subtest 'path matching handles subdirectory correctly' => sub {
 
     my @affected = $gd->affected_packages([$pkg], $graph);
     ok(grep { $_ eq 'perl/tree' } @affected, 'deeply nested file maps to package');
+};
+
+# ---------------------------------------------------------------------------
+# Test 11: Safe ci.yml changes no longer force a full rebuild
+# ---------------------------------------------------------------------------
+subtest 'toolchain-scoped ci workflow change does not force a full rebuild' => sub {
+    my $root = tempdir(CLEANUP => 1);
+    my $pkg_path = "$root/code/packages/perl/bitset";
+    make_path($pkg_path);
+
+    my $pkg   = make_pkg(name => 'perl/bitset', path => $pkg_path);
+    my $graph = empty_graph($pkg);
+
+    my $gd = MockGitDiff->new(
+        root       => $root,
+        mock_files => [CodingAdventures::BuildTool::CIWorkflow::ci_workflow_path()],
+    );
+
+    no warnings 'redefine';
+    local *CodingAdventures::BuildTool::CIWorkflow::analyze_changes = sub {
+        return { toolchains => { dotnet => 1 }, requires_full_rebuild => 0 };
+    };
+
+    my @affected = $gd->affected_packages([$pkg], $graph);
+    is(scalar @affected, 0, 'safe ci.yml change does not affect packages directly');
+};
+
+# ---------------------------------------------------------------------------
+# Test 12: Unsafe ci.yml changes still force a full rebuild
+# ---------------------------------------------------------------------------
+subtest 'unsafe ci workflow change still forces a full rebuild' => sub {
+    my $root  = tempdir(CLEANUP => 1);
+    my $path1 = "$root/code/packages/perl/pkg-x";
+    my $path2 = "$root/code/packages/perl/pkg-y";
+    make_path($path1);
+    make_path($path2);
+
+    my $pkg1  = make_pkg(name => 'perl/pkg-x', path => $path1);
+    my $pkg2  = make_pkg(name => 'perl/pkg-y', path => $path2);
+    my $graph = empty_graph($pkg1, $pkg2);
+
+    my $gd = MockGitDiff->new(
+        root       => $root,
+        mock_files => [CodingAdventures::BuildTool::CIWorkflow::ci_workflow_path()],
+    );
+
+    no warnings 'redefine';
+    local *CodingAdventures::BuildTool::CIWorkflow::analyze_changes = sub {
+        return { toolchains => {}, requires_full_rebuild => 1 };
+    };
+
+    my @affected = sort $gd->affected_packages([$pkg1, $pkg2], $graph);
+    is(\@affected, ['perl/pkg-x', 'perl/pkg-y'], 'unsafe ci.yml change still rebuilds everything');
 };
 
 done_testing();

--- a/code/programs/perl/build-tool/t/12-ci-workflow.t
+++ b/code/programs/perl/build-tool/t/12-ci-workflow.t
@@ -1,0 +1,64 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use FindBin qw($Bin);
+use lib "$Bin/../lib";
+
+use Test2::V0;
+
+use CodingAdventures::BuildTool::CIWorkflow;
+
+subtest 'allows toolchain-scoped dotnet changes' => sub {
+    my $change = CodingAdventures::BuildTool::CIWorkflow::analyze_patch(<<'PATCH');
+@@ -312,0 +313,6 @@
++      - name: Set up .NET
++        if: needs.detect.outputs.needs_dotnet == 'true'
++        uses: actions/setup-dotnet@v4
++        with:
++          dotnet-version: '9.0.x'
+PATCH
+
+    ok(!$change->{requires_full_rebuild}, 'dotnet-only workflow change stays scoped');
+    is(
+        [ CodingAdventures::BuildTool::CIWorkflow::sorted_toolchains($change->{toolchains}) ],
+        ['dotnet'],
+        'detects the dotnet toolchain',
+    );
+};
+
+subtest 'ignores comment-only changes' => sub {
+    my $change = CodingAdventures::BuildTool::CIWorkflow::analyze_patch(<<'PATCH');
+@@ -316,2 +316,2 @@
+-          # .NET 8 is the current LTS release.
++          # .NET 9 is the current LTS release.
+PATCH
+
+    ok(!$change->{requires_full_rebuild}, 'comment-only change stays scoped');
+    is(
+        [ CodingAdventures::BuildTool::CIWorkflow::sorted_toolchains($change->{toolchains}) ],
+        [],
+        'comment-only change does not claim toolchains',
+    );
+};
+
+subtest 'requires a full rebuild for build command changes' => sub {
+    my $change = CodingAdventures::BuildTool::CIWorkflow::analyze_patch(<<'PATCH');
+@@ -404,1 +404,1 @@
+-          $BT -root . -validate-build-files -language all
++          $BT -root . -force -validate-build-files -language all
+PATCH
+
+    ok($change->{requires_full_rebuild}, 'shared build command changes remain unsafe');
+};
+
+subtest 'requires a full rebuild for unknown workflow changes' => sub {
+    my $change = CodingAdventures::BuildTool::CIWorkflow::analyze_patch(<<'PATCH');
+@@ -170,0 +171,1 @@
++      timeout-minutes: 45
+PATCH
+
+    ok($change->{requires_full_rebuild}, 'unknown workflow edits stay conservative');
+};
+
+done_testing();

--- a/code/programs/python/build-tool/src/build_tool/ci_workflow.py
+++ b/code/programs/python/build-tool/src/build_tool/ci_workflow.py
@@ -1,0 +1,221 @@
+"""Helpers for classifying CI workflow edits.
+
+The main monorepo CI workflow can change in two very different ways:
+
+1. Toolchain-scoped edits, such as bumping `actions/setup-dotnet` or
+   updating the `.NET` verification step. These should only opt the touched
+   toolchains into CI verification.
+2. Shared CI behavior edits, such as changing the build commands or matrix.
+   Those still need a full rebuild because they can affect every package.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import subprocess
+
+CI_WORKFLOW_PATH = ".github/workflows/ci.yml"
+
+_TOOLCHAIN_MARKERS: dict[str, tuple[str, ...]] = {
+    "python": (
+        "needs_python", "setup-python", "python-version", "setup-uv",
+        "python --version", "uv --version", "pytest",
+        "set up python", "install uv",
+    ),
+    "ruby": (
+        "needs_ruby", "setup-ruby", "ruby-version", "bundler",
+        "gem install bundler", "ruby --version", "bundle --version",
+        "set up ruby", "install bundler",
+    ),
+    "go": (
+        "needs_go", "setup-go", "go-version", "go version", "set up go",
+    ),
+    "typescript": (
+        "needs_typescript", "setup-node", "node-version", "npm install -g jest",
+        "node --version", "npm --version", "set up node",
+    ),
+    "rust": (
+        "needs_rust", "rust-toolchain", "cargo", "rustc", "tarpaulin",
+        "wasm32-unknown-unknown", "set up rust", "install cargo-tarpaulin",
+    ),
+    "elixir": (
+        "needs_elixir", "setup-beam", "elixir-version", "otp-version",
+        "elixir --version", "mix --version", "set up elixir",
+    ),
+    "lua": (
+        "needs_lua", "gh-actions-lua", "gh-actions-luarocks", "luarocks",
+        "lua -v", "msvc", "set up lua", "set up luarocks",
+    ),
+    "perl": (
+        "needs_perl", "cpanm", "perl --version", "install cpanm",
+    ),
+    "haskell": (
+        "needs_haskell", "haskell-actions/setup", "ghc-version", "cabal-version",
+        "ghc --version", "cabal --version", "set up haskell",
+    ),
+    "dotnet": (
+        "needs_dotnet", "setup-dotnet", "dotnet-version", "dotnet --version",
+        "set up .net",
+    ),
+}
+
+_UNSAFE_MARKERS = (
+    "./build-tool",
+    "build-tool.exe",
+    "-detect-languages",
+    "-emit-plan",
+    "-force",
+    "-plan-file",
+    "-validate-build-files",
+    "actions/checkout",
+    "build-plan",
+    "cancel-in-progress:",
+    "concurrency:",
+    "diff-base",
+    "download-artifact",
+    "event_name",
+    "fetch-depth",
+    "git fetch origin main",
+    "git_ref",
+    "is_main",
+    "matrix:",
+    "permissions:",
+    "pr_base_ref",
+    "pull_request:",
+    "push:",
+    "runs-on:",
+    "strategy:",
+    "upload-artifact",
+)
+
+
+@dataclass(frozen=True)
+class CIWorkflowChange:
+    toolchains: frozenset[str]
+    requires_full_rebuild: bool = False
+
+
+def analyze_ci_workflow_changes(root: Path, diff_base: str) -> CIWorkflowChange:
+    """Read the current ci.yml patch and classify it."""
+    return analyze_ci_workflow_patch(_get_file_diff(root, diff_base, CI_WORKFLOW_PATH))
+
+
+def analyze_ci_workflow_patch(patch: str) -> CIWorkflowChange:
+    toolchains: set[str] = set()
+    hunk: list[str] = []
+
+    def flush() -> CIWorkflowChange | None:
+        nonlocal hunk
+        hunk_toolchains, unsafe = _classify_hunk(hunk)
+        hunk = []
+        if unsafe:
+            return CIWorkflowChange(frozenset(), requires_full_rebuild=True)
+        toolchains.update(hunk_toolchains)
+        return None
+
+    for line in patch.splitlines():
+        if line.startswith("@@"):
+            result = flush()
+            if result is not None:
+                return result
+            continue
+        if line.startswith(("diff --git ", "index ", "--- ", "+++ ")):
+            continue
+        hunk.append(line)
+
+    result = flush()
+    if result is not None:
+        return result
+    return CIWorkflowChange(frozenset(toolchains))
+
+
+def sorted_toolchains(toolchains: frozenset[str] | set[str]) -> list[str]:
+    return sorted(toolchains)
+
+
+def _classify_hunk(lines: list[str]) -> tuple[set[str], bool]:
+    hunk_toolchains: set[str] = set()
+    changed_toolchains: set[str] = set()
+    changed_lines: list[str] = []
+
+    for line in lines:
+        if not line or not _is_diff_line(line):
+            continue
+
+        content = line[1:].strip()
+        hunk_toolchains.update(_detect_toolchains(content))
+
+        if not _is_changed_line(line):
+            continue
+        if not content or content.startswith("#"):
+            continue
+
+        changed_lines.append(content)
+        changed_toolchains.update(_detect_toolchains(content))
+
+    if not changed_lines:
+        return set(), False
+
+    resolved_toolchains = changed_toolchains
+    if not resolved_toolchains:
+        if len(hunk_toolchains) != 1:
+            return set(), True
+        resolved_toolchains = set(hunk_toolchains)
+
+    for content in changed_lines:
+        if _touches_shared_ci_behavior(content):
+            return set(), True
+        if _detect_toolchains(content):
+            continue
+        if _is_toolchain_scoped_structural_line(content):
+            continue
+        return set(), True
+
+    return resolved_toolchains, False
+
+
+def _detect_toolchains(content: str) -> set[str]:
+    found: set[str] = set()
+    normalized = content.lower()
+    for toolchain, markers in _TOOLCHAIN_MARKERS.items():
+        if any(marker in normalized for marker in markers):
+            found.add(toolchain)
+    return found
+
+
+def _touches_shared_ci_behavior(content: str) -> bool:
+    normalized = content.lower()
+    return any(marker in normalized for marker in _UNSAFE_MARKERS)
+
+
+def _is_toolchain_scoped_structural_line(content: str) -> bool:
+    return content.startswith((
+        "if:", "run:", "shell:", "with:", "env:", "else", "fi", "then",
+        "printf ", "echo ", "curl ", "powershell ", "call ", "cd ",
+    ))
+
+
+def _is_diff_line(line: str) -> bool:
+    return line.startswith(" ") or _is_changed_line(line)
+
+
+def _is_changed_line(line: str) -> bool:
+    return line.startswith(("+", "-"))
+
+
+def _get_file_diff(root: Path, diff_base: str, relative_path: str) -> str:
+    for args in (
+        ["git", "diff", "--unified=0", f"{diff_base}...HEAD", "--", relative_path],
+        ["git", "diff", "--unified=0", diff_base, "HEAD", "--", relative_path],
+    ):
+        result = subprocess.run(
+            args,
+            cwd=root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            return result.stdout
+    return ""

--- a/code/programs/python/build-tool/src/build_tool/cli.py
+++ b/code/programs/python/build-tool/src/build_tool/cli.py
@@ -40,6 +40,11 @@ import sys
 from pathlib import Path
 
 from build_tool.cache import BuildCache
+from build_tool.ci_workflow import (
+    CI_WORKFLOW_PATH,
+    analyze_ci_workflow_changes,
+    sorted_toolchains,
+)
 from build_tool.discovery import Package, discover_packages
 from build_tool.executor import execute_builds
 from build_tool.gitdiff import get_changed_files, map_files_to_packages
@@ -69,13 +74,25 @@ except ImportError:
     Tracker = None  # type: ignore[assignment, misc]
 
 
-# ALL_LANGUAGES is the canonical list of supported languages in the monorepo.
-# The order is stable and matches the order used in CI toolchain setup.
+# ALL_LANGUAGES is the canonical list of package languages the Python build
+# tool knows how to build directly.
 ALL_LANGUAGES = ["python", "ruby", "go", "typescript", "rust", "elixir", "lua", "perl", "swift", "haskell"]
 
-# SHARED_PREFIXES are repo paths that, when changed, mean ALL languages need
-# rebuilding. Only the CI workflow itself fans out to a full rebuild.
-SHARED_PREFIXES = [".github/workflows/ci.yml"]
+# ALL_TOOLCHAINS is the canonical list of CI toolchains we can request.
+ALL_TOOLCHAINS = [*ALL_LANGUAGES, "dotnet"]
+
+# SHARED_PREFIXES are repo paths that, when changed, still mean every
+# toolchain needs rebuilding. ci.yml is handled separately via patch analysis
+# so toolchain-scoped edits do not fan out across the whole repo.
+SHARED_PREFIXES: list[str] = []
+
+
+def _toolchain_for_package_language(language: str) -> str:
+    if language == "wasm":
+        return "rust"
+    if language in {"csharp", "fsharp", "dotnet"}:
+        return "dotnet"
+    return language
 
 
 def _expand_affected_set_with_prereqs(
@@ -314,14 +331,30 @@ def main(argv: list[str] | None = None) -> int:
     # Git is the source of truth -- no cache file needed.
     # Fallback: hash-based cache (for local dev when not on a branch).
     affected_set: set[str] | None = None
+    ci_toolchains: frozenset[str] = frozenset()
 
     if not args.force:
         # Try git-diff mode first (the default)
         changed_files = get_changed_files(root, args.diff_base)
         if changed_files:
+            if CI_WORKFLOW_PATH in changed_files:
+                ci_change = analyze_ci_workflow_changes(root, args.diff_base)
+                if ci_change.requires_full_rebuild:
+                    print("Git diff: ci.yml changed in shared ways -- rebuilding everything")
+                    args.force = True
+                    affected_set = None
+                else:
+                    ci_toolchains = ci_change.toolchains
+                    if ci_toolchains:
+                        print(
+                            "Git diff: ci.yml changed only toolchain-scoped setup for "
+                            + ", ".join(sorted_toolchains(ci_toolchains))
+                        )
+
             shared_changed = any(
                 f == prefix or f.startswith(prefix + "/")
                 for f in changed_files
+                if f != CI_WORKFLOW_PATH
                 for prefix in SHARED_PREFIXES
             )
             if shared_changed:
@@ -347,19 +380,11 @@ def main(argv: list[str] | None = None) -> int:
     # --emit-plan mode: serialize the plan and exit without building.
     # This is the fast path for CI detect jobs.
     if args.emit_plan is not None:
-        return _emit_plan(args, root, packages, graph, affected_set)
+        return _emit_plan(args, root, packages, graph, affected_set, ci_toolchains)
 
     # --detect-languages standalone mode: output language flags and exit.
     if args.detect_languages:
-        languages_needed: dict[str, bool] = {"go": True}
-        if args.force or affected_set is None:
-            for lang in ALL_LANGUAGES:
-                languages_needed[lang] = True
-        else:
-            for pkg in packages:
-                if pkg.name in affected_set:
-                    languages_needed[pkg.language] = True
-        _output_language_flags(languages_needed)
+        _output_language_flags(_compute_languages_needed(packages, affected_set, args.force, ci_toolchains))
         return 0
 
     # Step 6: Hash all packages (needed for cache fallback)
@@ -422,6 +447,7 @@ def _emit_plan(
     packages: list[Package],
     graph: DirectedGraph,
     affected_set: set[str] | None,
+    ci_toolchains: frozenset[str],
 ) -> int:
     """Serialize the build plan to JSON and exit.
 
@@ -467,15 +493,7 @@ def _emit_plan(
             )
         )
 
-    # Determine which languages are needed. A language is "needed" if
-    # at least one affected package uses that language.
-    languages_needed: dict[str, bool] = {}
-    for pkg in packages:
-        lang = pkg.language
-        if lang not in languages_needed:
-            languages_needed[lang] = False
-        if affected_set is None or pkg.name in affected_set:
-            languages_needed[lang] = True
+    languages_needed = _compute_languages_needed(packages, affected_set, args.force, ci_toolchains)
 
     # Build the plan.
     bp = BuildPlan(
@@ -676,11 +694,11 @@ def _output_language_flags(languages_needed: dict[str, bool]) -> None:
         except OSError as exc:
             print(f"Warning: could not open $GITHUB_OUTPUT: {exc}", file=sys.stderr)
 
-    # Always output all known languages in stable order.
+    # Always output all known toolchains in stable order.
     all_needed = {"go": True}  # Go is always needed
     all_needed.update(languages_needed)
 
-    for lang in ALL_LANGUAGES:
+    for lang in ALL_TOOLCHAINS:
         value = all_needed.get(lang, False)
         line = f"needs_{lang}={'true' if value else 'false'}"
         print(line)
@@ -689,6 +707,30 @@ def _output_language_flags(languages_needed: dict[str, bool]) -> None:
 
     if gh_file is not None:
         gh_file.close()
+
+
+def _compute_languages_needed(
+    packages: list[Package],
+    affected_set: set[str] | None,
+    force: bool,
+    ci_toolchains: frozenset[str],
+) -> dict[str, bool]:
+    languages_needed = {toolchain: False for toolchain in ALL_TOOLCHAINS}
+    languages_needed["go"] = True
+
+    if force or affected_set is None:
+        for toolchain in ALL_TOOLCHAINS:
+            languages_needed[toolchain] = True
+        return languages_needed
+
+    for pkg in packages:
+        if pkg.name in affected_set:
+            languages_needed[_toolchain_for_package_language(pkg.language)] = True
+
+    for toolchain in ci_toolchains:
+        languages_needed[toolchain] = True
+
+    return languages_needed
 
 
 if __name__ == "__main__":

--- a/code/programs/python/build-tool/tests/test_ci_workflow.py
+++ b/code/programs/python/build-tool/tests/test_ci_workflow.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from build_tool.ci_workflow import analyze_ci_workflow_patch
+from build_tool.cli import _compute_languages_needed
+from build_tool.discovery import Package
+
+
+def test_analyze_ci_workflow_patch_allows_toolchain_scoped_dotnet_changes():
+    change = analyze_ci_workflow_patch(
+        """
+@@ -312,0 +313,6 @@
++      - name: Set up .NET
++        if: needs.detect.outputs.needs_dotnet == 'true'
++        uses: actions/setup-dotnet@v4
++        with:
++          dotnet-version: '9.0.x'
+"""
+    )
+
+    assert not change.requires_full_rebuild
+    assert change.toolchains == frozenset({"dotnet"})
+
+
+def test_analyze_ci_workflow_patch_ignores_comment_only_changes():
+    change = analyze_ci_workflow_patch(
+        """
+@@ -316,2 +316,2 @@
+-          # .NET 8 is the current LTS release.
++          # .NET 9 is the current LTS release.
+"""
+    )
+
+    assert not change.requires_full_rebuild
+    assert change.toolchains == frozenset()
+
+
+def test_analyze_ci_workflow_patch_requires_full_rebuild_for_build_command_changes():
+    change = analyze_ci_workflow_patch(
+        """
+@@ -404,1 +404,1 @@
+-          $BT -root . -validate-build-files -language all
++          $BT -root . -force -validate-build-files -language all
+"""
+    )
+
+    assert change.requires_full_rebuild
+
+
+def test_compute_languages_needed_includes_safe_ci_workflow_toolchains():
+    packages = [
+        Package(
+            name="python/logic-gates",
+            path=Path("/repo/code/packages/python/logic-gates"),
+            build_commands=[],
+            language="python",
+        )
+    ]
+
+    needed = _compute_languages_needed(
+        packages,
+        {"python/logic-gates"},
+        False,
+        frozenset({"dotnet"}),
+    )
+
+    assert needed["go"] is True
+    assert needed["python"] is True
+    assert needed["dotnet"] is True
+    assert needed["rust"] is False

--- a/code/programs/ruby/build-tool/build.rb
+++ b/code/programs/ruby/build-tool/build.rb
@@ -57,6 +57,7 @@ require_relative "lib/build_tool/executor"
 require_relative "lib/build_tool/reporter"
 require_relative "lib/build_tool/starlark_evaluator"
 require_relative "lib/build_tool/git_diff"
+require_relative "lib/build_tool/ci_workflow"
 require_relative "lib/build_tool/plan"
 require_relative "lib/build_tool/validator"
 
@@ -64,14 +65,24 @@ module BuildTool
   module CLI
     module_function
 
-    # ALL_LANGUAGES is the canonical list of supported languages in the monorepo.
-    # The order is stable and matches the order used in CI toolchain setup.
+    # ALL_LANGUAGES is the canonical list of package languages this CLI builds.
     ALL_LANGUAGES = %w[python ruby go typescript rust elixir lua perl swift haskell].freeze
 
-    # SHARED_PREFIXES are repo paths that, when changed, mean ALL languages
-    # need rebuilding. Only changes to the CI workflow itself fan out to
-    # a full rebuild — deployment-only workflows do NOT.
-    SHARED_PREFIXES = [".github/workflows/ci.yml"].freeze
+    # ALL_TOOLCHAINS is the canonical list of CI toolchains we can request.
+    ALL_TOOLCHAINS = (ALL_LANGUAGES + ["dotnet"]).freeze
+
+    # SHARED_PREFIXES are repo paths that, when changed, still mean every
+    # toolchain needs rebuilding. ci.yml is handled separately via patch
+    # analysis so toolchain-scoped edits do not fan out across the repo.
+    SHARED_PREFIXES = [].freeze
+
+    def toolchain_for_package_language(language)
+      case language
+      when "wasm" then "rust"
+      when "csharp", "fsharp", "dotnet" then "dotnet"
+      else language
+      end
+    end
 
     # find_repo_root -- Walk up from `start` (or cwd) looking for a `.git` dir.
     #
@@ -309,11 +320,28 @@ module BuildTool
       # Git is the source of truth — no cache file needed for primary workflow.
       # Fallback: hash-based cache (when git diff is unavailable).
       affected_set = nil
+      ci_toolchains = Set.new
 
       unless options[:force]
         changed_files = GitDiff.get_changed_files(root.to_s, options[:diff_base])
         if changed_files && !changed_files.empty?
+          if changed_files.include?(CIWorkflow::CI_WORKFLOW_PATH)
+            ci_change = CIWorkflow.analyze_changes(root, options[:diff_base])
+            if ci_change.requires_full_rebuild
+              puts "Git diff: ci.yml changed in shared ways — rebuilding everything"
+              options[:force] = true
+              affected_set = nil
+            else
+              ci_toolchains = ci_change.toolchains
+              unless ci_toolchains.empty?
+                puts "Git diff: ci.yml changed only toolchain-scoped setup for " \
+                     "#{CIWorkflow.sorted_toolchains(ci_toolchains).join(', ')}"
+              end
+            end
+          end
+
           shared_changed = changed_files.any? do |f|
+            next false if f == CIWorkflow::CI_WORKFLOW_PATH
             SHARED_PREFIXES.any? { |prefix| f == prefix || f.start_with?("#{prefix}/") }
           end
 
@@ -348,12 +376,12 @@ module BuildTool
 
       # -- Step 6a: Emit plan (early exit) --------------------------------------
       if options[:emit_plan]
-        return emit_build_plan(options, root, packages, graph, affected_set)
+        return emit_build_plan(options, root, packages, graph, affected_set, ci_toolchains)
       end
 
       # -- Step 6b: Detect languages (early exit) -------------------------------
       if options[:detect_languages]
-        return detect_needed_languages(packages, affected_set, options[:force])
+        return detect_needed_languages(packages, affected_set, options[:force], ci_toolchains)
       end
 
       # -- Step 7: Hash all packages --------------------------------------------
@@ -427,7 +455,7 @@ module BuildTool
     # @param graph [DirectedGraph] Dependency graph.
     # @param affected_set [Hash<String, Boolean>, nil] Affected packages.
     # @return [Integer] Exit code.
-    def emit_build_plan(options, root, packages, graph, affected_set)
+    def emit_build_plan(options, root, packages, graph, affected_set, ci_toolchains)
       # Convert affected_set to a sorted array (or nil for "all").
       affected_list = if affected_set
                         affected_set.keys.sort
@@ -461,7 +489,7 @@ module BuildTool
       end
 
       # Compute languages needed.
-      languages_needed = compute_languages_needed(packages, affected_set, options[:force])
+      languages_needed = compute_languages_needed(packages, affected_set, options[:force], ci_toolchains)
 
       bp = Plan::BuildPlan.new(
         diff_base: options[:diff_base],
@@ -631,8 +659,8 @@ module BuildTool
     # @param affected_set [Hash<String, Boolean>, nil] Affected packages.
     # @param force [Boolean] Whether --force was set.
     # @return [Integer] Exit code (always 0).
-    def detect_needed_languages(packages, affected_set, force)
-      languages_needed = compute_languages_needed(packages, affected_set, force)
+    def detect_needed_languages(packages, affected_set, force, ci_toolchains)
+      languages_needed = compute_languages_needed(packages, affected_set, force, ci_toolchains)
       output_language_flags(languages_needed)
       0
     end
@@ -646,17 +674,20 @@ module BuildTool
     # @param affected_set [Hash<String, Boolean>, nil]
     # @param force [Boolean]
     # @return [Hash<String, Boolean>]
-    def compute_languages_needed(packages, affected_set, force)
-      needed = { "go" => true }
+    def compute_languages_needed(packages, affected_set, force, ci_toolchains = Set.new)
+      needed = ALL_TOOLCHAINS.each_with_object({}) { |lang, acc| acc[lang] = false }
+      needed["go"] = true
 
       if force || affected_set.nil?
-        ALL_LANGUAGES.each { |lang| needed[lang] = true }
+        ALL_TOOLCHAINS.each { |lang| needed[lang] = true }
         return needed
       end
 
       packages.each do |pkg|
-        needed[pkg.language] = true if affected_set.key?(pkg.name)
+        needed[toolchain_for_package_language(pkg.language)] = true if affected_set.key?(pkg.name)
       end
+
+      ci_toolchains.each { |toolchain| needed[toolchain] = true }
 
       needed
     end
@@ -677,7 +708,7 @@ module BuildTool
                   end
                 end
 
-      ALL_LANGUAGES.each do |lang|
+      ALL_TOOLCHAINS.each do |lang|
         value = languages_needed.fetch(lang, false)
         line = "needs_#{lang}=#{value}"
         puts line

--- a/code/programs/ruby/build-tool/build.rb
+++ b/code/programs/ruby/build-tool/build.rb
@@ -660,7 +660,7 @@ module BuildTool
     # @param force [Boolean] Whether --force was set.
     # @return [Integer] Exit code (always 0).
     def detect_needed_languages(packages, affected_set, force, ci_toolchains)
-      languages_needed = compute_languages_needed(packages, affected_set, force, ci_toolchains)
+      languages_needed = CIWorkflow.compute_languages_needed(packages, affected_set, force, ci_toolchains)
       output_language_flags(languages_needed)
       0
     end
@@ -675,21 +675,7 @@ module BuildTool
     # @param force [Boolean]
     # @return [Hash<String, Boolean>]
     def compute_languages_needed(packages, affected_set, force, ci_toolchains = Set.new)
-      needed = ALL_TOOLCHAINS.each_with_object({}) { |lang, acc| acc[lang] = false }
-      needed["go"] = true
-
-      if force || affected_set.nil?
-        ALL_TOOLCHAINS.each { |lang| needed[lang] = true }
-        return needed
-      end
-
-      packages.each do |pkg|
-        needed[toolchain_for_package_language(pkg.language)] = true if affected_set.key?(pkg.name)
-      end
-
-      ci_toolchains.each { |toolchain| needed[toolchain] = true }
-
-      needed
+      CIWorkflow.compute_languages_needed(packages, affected_set, force, ci_toolchains)
     end
 
     # output_language_flags -- Print language flags to stdout and $GITHUB_OUTPUT.

--- a/code/programs/ruby/build-tool/lib/build_tool/ci_workflow.rb
+++ b/code/programs/ruby/build-tool/lib/build_tool/ci_workflow.rb
@@ -8,6 +8,7 @@ module BuildTool
     module_function
 
     CI_WORKFLOW_PATH = ".github/workflows/ci.yml"
+    ALL_TOOLCHAINS = (%w[python ruby go typescript rust elixir lua perl swift haskell] + ["dotnet"]).freeze
 
     Change = Data.define(:toolchains, :requires_full_rebuild)
 
@@ -98,6 +99,32 @@ module BuildTool
 
     def sorted_toolchains(toolchains)
       toolchains.to_a.sort
+    end
+
+    def toolchain_for_package_language(language)
+      case language
+      when "wasm" then "rust"
+      when "csharp", "fsharp", "dotnet" then "dotnet"
+      else language
+      end
+    end
+
+    def compute_languages_needed(packages, affected_set, force, ci_toolchains = Set.new)
+      needed = ALL_TOOLCHAINS.each_with_object({}) { |lang, acc| acc[lang] = false }
+      needed["go"] = true
+
+      if force || affected_set.nil?
+        ALL_TOOLCHAINS.each { |lang| needed[lang] = true }
+        return needed
+      end
+
+      packages.each do |pkg|
+        needed[toolchain_for_package_language(pkg.language)] = true if affected_set.key?(pkg.name)
+      end
+
+      ci_toolchains.each { |toolchain| needed[toolchain] = true }
+
+      needed
     end
 
     def classify_hunk(lines)

--- a/code/programs/ruby/build-tool/lib/build_tool/ci_workflow.rb
+++ b/code/programs/ruby/build-tool/lib/build_tool/ci_workflow.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+require "open3"
+require "set"
+
+module BuildTool
+  module CIWorkflow
+    module_function
+
+    CI_WORKFLOW_PATH = ".github/workflows/ci.yml"
+
+    Change = Data.define(:toolchains, :requires_full_rebuild)
+
+    TOOLCHAIN_MARKERS = {
+      "python" => [
+        "needs_python", "setup-python", "python-version", "setup-uv",
+        "python --version", "uv --version", "pytest",
+        "set up python", "install uv"
+      ],
+      "ruby" => [
+        "needs_ruby", "setup-ruby", "ruby-version", "bundler",
+        "gem install bundler", "ruby --version", "bundle --version",
+        "set up ruby", "install bundler"
+      ],
+      "go" => [
+        "needs_go", "setup-go", "go-version", "go version", "set up go"
+      ],
+      "typescript" => [
+        "needs_typescript", "setup-node", "node-version", "npm install -g jest",
+        "node --version", "npm --version", "set up node"
+      ],
+      "rust" => [
+        "needs_rust", "rust-toolchain", "cargo", "rustc", "tarpaulin",
+        "wasm32-unknown-unknown", "set up rust", "install cargo-tarpaulin"
+      ],
+      "elixir" => [
+        "needs_elixir", "setup-beam", "elixir-version", "otp-version",
+        "elixir --version", "mix --version", "set up elixir"
+      ],
+      "lua" => [
+        "needs_lua", "gh-actions-lua", "gh-actions-luarocks", "luarocks",
+        "lua -v", "msvc", "set up lua", "set up luarocks"
+      ],
+      "perl" => [
+        "needs_perl", "cpanm", "perl --version", "install cpanm"
+      ],
+      "haskell" => [
+        "needs_haskell", "haskell-actions/setup", "ghc-version", "cabal-version",
+        "ghc --version", "cabal --version", "set up haskell"
+      ],
+      "dotnet" => [
+        "needs_dotnet", "setup-dotnet", "dotnet-version", "dotnet --version",
+        "set up .net"
+      ]
+    }.freeze
+
+    UNSAFE_MARKERS = %w[
+      ./build-tool build-tool.exe -detect-languages -emit-plan -force -plan-file
+      -validate-build-files actions/checkout build-plan cancel-in-progress:
+      concurrency: diff-base download-artifact event_name fetch-depth
+      git_ref is_main matrix: permissions: pr_base_ref pull_request:
+      push: runs-on: strategy: upload-artifact
+    ].freeze + ["git fetch origin main"]
+
+    def analyze_changes(root, diff_base)
+      analyze_patch(file_diff(root, diff_base, CI_WORKFLOW_PATH))
+    end
+
+    def analyze_patch(patch)
+      toolchains = Set.new
+      hunk = []
+
+      flush = lambda do
+        hunk_toolchains, unsafe = classify_hunk(hunk)
+        hunk = []
+        return Change.new(Set.new.freeze, true) if unsafe
+
+        toolchains.merge(hunk_toolchains)
+        nil
+      end
+
+      patch.each_line do |line|
+        if line.start_with?("@@")
+          result = flush.call
+          return result if result
+          next
+        end
+        next if line.start_with?("diff --git ", "index ", "--- ", "+++ ")
+
+        hunk << line.chomp
+      end
+
+      result = flush.call
+      return result if result
+
+      Change.new(toolchains.freeze, false)
+    end
+
+    def sorted_toolchains(toolchains)
+      toolchains.to_a.sort
+    end
+
+    def classify_hunk(lines)
+      hunk_toolchains = Set.new
+      changed_toolchains = Set.new
+      changed_lines = []
+
+      lines.each do |line|
+        next if line.empty? || !diff_line?(line)
+
+        content = line[1..]&.strip.to_s
+        hunk_toolchains.merge(detect_toolchains(content))
+
+        next unless changed_line?(line)
+        next if content.empty? || content.start_with?("#")
+
+        changed_lines << content
+        changed_toolchains.merge(detect_toolchains(content))
+      end
+
+      return [Set.new, false] if changed_lines.empty?
+
+      resolved_toolchains = changed_toolchains
+      if resolved_toolchains.empty?
+        return [Set.new, true] unless hunk_toolchains.size == 1
+
+        resolved_toolchains = hunk_toolchains
+      end
+
+      changed_lines.each do |content|
+        return [Set.new, true] if touches_shared_ci_behavior?(content)
+        next unless detect_toolchains(content).empty?
+        next if toolchain_scoped_structural_line?(content)
+
+        return [Set.new, true]
+      end
+
+      [resolved_toolchains, false]
+    end
+
+    def detect_toolchains(content)
+      normalized = content.downcase
+      TOOLCHAIN_MARKERS.each_with_object(Set.new) do |(toolchain, markers), found|
+        found << toolchain if markers.any? { |marker| normalized.include?(marker) }
+      end
+    end
+
+    def touches_shared_ci_behavior?(content)
+      normalized = content.downcase
+      UNSAFE_MARKERS.any? { |marker| normalized.include?(marker) }
+    end
+
+    def toolchain_scoped_structural_line?(content)
+      content.start_with?(
+        "if:", "run:", "shell:", "with:", "env:", "else", "fi", "then",
+        "printf ", "echo ", "curl ", "powershell ", "call ", "cd "
+      )
+    end
+
+    def diff_line?(line)
+      line.start_with?(" ") || changed_line?(line)
+    end
+
+    def changed_line?(line)
+      line.start_with?("+", "-")
+    end
+
+    def file_diff(root, diff_base, relative_path)
+      [
+        ["git", "diff", "--unified=0", "#{diff_base}...HEAD", "--", relative_path],
+        ["git", "diff", "--unified=0", diff_base, "HEAD", "--", relative_path]
+      ].each do |cmd|
+        stdout, status = Open3.capture2(*cmd, chdir: root.to_s)
+        return stdout if status.success?
+      end
+      ""
+    end
+  end
+end

--- a/code/programs/ruby/build-tool/test/test_ci_workflow.rb
+++ b/code/programs/ruby/build-tool/test/test_ci_workflow.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require_relative "../build"
+
+class TestCIWorkflow < Minitest::Test
+  def test_analyze_patch_allows_toolchain_scoped_dotnet_changes
+    change = BuildTool::CIWorkflow.analyze_patch(<<~PATCH)
+      @@ -312,0 +313,6 @@
+      +      - name: Set up .NET
+      +        if: needs.detect.outputs.needs_dotnet == 'true'
+      +        uses: actions/setup-dotnet@v4
+      +        with:
+      +          dotnet-version: '9.0.x'
+    PATCH
+
+    refute change.requires_full_rebuild
+    assert_equal ["dotnet"], BuildTool::CIWorkflow.sorted_toolchains(change.toolchains)
+  end
+
+  def test_analyze_patch_ignores_comment_only_changes
+    change = BuildTool::CIWorkflow.analyze_patch(<<~PATCH)
+      @@ -316,2 +316,2 @@
+      -          # .NET 8 is the current LTS release.
+      +          # .NET 9 is the current LTS release.
+    PATCH
+
+    refute change.requires_full_rebuild
+    assert_empty change.toolchains.to_a
+  end
+
+  def test_analyze_patch_requires_full_rebuild_for_build_command_changes
+    change = BuildTool::CIWorkflow.analyze_patch(<<~PATCH)
+      @@ -404,1 +404,1 @@
+      -          $BT -root . -validate-build-files -language all
+      +          $BT -root . -force -validate-build-files -language all
+    PATCH
+
+    assert change.requires_full_rebuild
+  end
+
+  def test_compute_languages_needed_includes_safe_ci_toolchains
+    packages = [
+      BuildTool::Package.new(
+        name: "python/logic-gates",
+        path: Pathname("/repo/code/packages/python/logic-gates"),
+        build_commands: [],
+        language: "python"
+      )
+    ]
+
+    needed = BuildTool::CLI.compute_languages_needed(
+      packages,
+      { "python/logic-gates" => true },
+      false,
+      Set.new(["dotnet"])
+    )
+
+    assert needed["go"]
+    assert needed["python"]
+    assert needed["dotnet"]
+    refute needed["rust"]
+  end
+end

--- a/code/programs/ruby/build-tool/test/test_ci_workflow.rb
+++ b/code/programs/ruby/build-tool/test/test_ci_workflow.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative "test_helper"
-require_relative "../build"
 
 class TestCIWorkflow < Minitest::Test
   def test_analyze_patch_allows_toolchain_scoped_dotnet_changes
@@ -49,7 +48,7 @@ class TestCIWorkflow < Minitest::Test
       )
     ]
 
-    needed = BuildTool::CLI.compute_languages_needed(
+    needed = BuildTool::CIWorkflow.compute_languages_needed(
       packages,
       { "python/logic-gates" => true },
       false,
@@ -60,5 +59,19 @@ class TestCIWorkflow < Minitest::Test
     assert needed["python"]
     assert needed["dotnet"]
     refute needed["rust"]
+  end
+
+  def test_compute_languages_needed_enables_everything_for_force
+    needed = BuildTool::CIWorkflow.compute_languages_needed([], nil, true)
+
+    BuildTool::CIWorkflow::ALL_TOOLCHAINS.each do |toolchain|
+      assert needed[toolchain], "expected #{toolchain} to be enabled"
+    end
+  end
+
+  def test_toolchain_for_package_language_maps_non_native_languages
+    assert_equal "rust", BuildTool::CIWorkflow.toolchain_for_package_language("wasm")
+    assert_equal "dotnet", BuildTool::CIWorkflow.toolchain_for_package_language("csharp")
+    assert_equal "python", BuildTool::CIWorkflow.toolchain_for_package_language("python")
   end
 end

--- a/code/programs/ruby/build-tool/test/test_helper.rb
+++ b/code/programs/ruby/build-tool/test/test_helper.rb
@@ -34,6 +34,7 @@ require_relative "../lib/build_tool/executor"
 require_relative "../lib/build_tool/reporter"
 require_relative "../lib/build_tool/starlark_evaluator"
 require_relative "../lib/build_tool/git_diff"
+require_relative "../lib/build_tool/ci_workflow"
 require_relative "../lib/build_tool/plan"
 require_relative "../lib/build_tool/validator"
 

--- a/code/programs/rust/build-tool/src/ci_workflow.rs
+++ b/code/programs/rust/build-tool/src/ci_workflow.rs
@@ -1,0 +1,407 @@
+use std::collections::HashSet;
+use std::path::Path;
+use std::process::Command;
+
+pub const CI_WORKFLOW_PATH: &str = ".github/workflows/ci.yml";
+
+#[derive(Debug, Default)]
+pub struct CIWorkflowChange {
+    pub toolchains: HashSet<String>,
+    pub requires_full_rebuild: bool,
+}
+
+const TOOLCHAIN_MARKERS: &[(&str, &[&str])] = &[
+    (
+        "python",
+        &[
+            "needs_python",
+            "setup-python",
+            "python-version",
+            "setup-uv",
+            "python --version",
+            "uv --version",
+            "pytest",
+            "set up python",
+            "install uv",
+        ],
+    ),
+    (
+        "ruby",
+        &[
+            "needs_ruby",
+            "setup-ruby",
+            "ruby-version",
+            "bundler",
+            "gem install bundler",
+            "ruby --version",
+            "bundle --version",
+            "set up ruby",
+            "install bundler",
+        ],
+    ),
+    (
+        "go",
+        &[
+            "needs_go",
+            "setup-go",
+            "go-version",
+            "go version",
+            "set up go",
+        ],
+    ),
+    (
+        "typescript",
+        &[
+            "needs_typescript",
+            "setup-node",
+            "node-version",
+            "npm install -g jest",
+            "node --version",
+            "npm --version",
+            "set up node",
+        ],
+    ),
+    (
+        "rust",
+        &[
+            "needs_rust",
+            "rust-toolchain",
+            "cargo",
+            "rustc",
+            "tarpaulin",
+            "wasm32-unknown-unknown",
+            "set up rust",
+            "install cargo-tarpaulin",
+        ],
+    ),
+    (
+        "elixir",
+        &[
+            "needs_elixir",
+            "setup-beam",
+            "elixir-version",
+            "otp-version",
+            "elixir --version",
+            "mix --version",
+            "set up elixir",
+        ],
+    ),
+    (
+        "lua",
+        &[
+            "needs_lua",
+            "gh-actions-lua",
+            "gh-actions-luarocks",
+            "luarocks",
+            "lua -v",
+            "msvc",
+            "set up lua",
+            "set up luarocks",
+        ],
+    ),
+    (
+        "perl",
+        &["needs_perl", "cpanm", "perl --version", "install cpanm"],
+    ),
+    (
+        "haskell",
+        &[
+            "needs_haskell",
+            "haskell-actions/setup",
+            "ghc-version",
+            "cabal-version",
+            "ghc --version",
+            "cabal --version",
+            "set up haskell",
+        ],
+    ),
+    (
+        "dotnet",
+        &[
+            "needs_dotnet",
+            "setup-dotnet",
+            "dotnet-version",
+            "dotnet --version",
+            "set up .net",
+        ],
+    ),
+];
+
+const UNSAFE_MARKERS: &[&str] = &[
+    "./build-tool",
+    "build-tool.exe",
+    "-detect-languages",
+    "-emit-plan",
+    "-force",
+    "-plan-file",
+    "-validate-build-files",
+    "actions/checkout",
+    "build-plan",
+    "cancel-in-progress:",
+    "concurrency:",
+    "diff-base",
+    "download-artifact",
+    "event_name",
+    "fetch-depth",
+    "git fetch origin main",
+    "git_ref",
+    "is_main",
+    "matrix:",
+    "permissions:",
+    "pr_base_ref",
+    "pull_request:",
+    "push:",
+    "runs-on:",
+    "strategy:",
+    "upload-artifact",
+];
+
+pub fn analyze_ci_workflow_changes(repo_root: &Path, diff_base: &str) -> CIWorkflowChange {
+    analyze_ci_workflow_patch(&get_file_diff(repo_root, diff_base, CI_WORKFLOW_PATH))
+}
+
+pub fn analyze_ci_workflow_patch(patch: &str) -> CIWorkflowChange {
+    let mut toolchains = HashSet::new();
+    let mut hunk = Vec::new();
+
+    for line in patch.lines() {
+        if line.starts_with("@@") {
+            let (hunk_toolchains, unsafe_change) = classify_hunk(&hunk);
+            if unsafe_change {
+                return CIWorkflowChange {
+                    toolchains: HashSet::new(),
+                    requires_full_rebuild: true,
+                };
+            }
+            toolchains.extend(hunk_toolchains);
+            hunk.clear();
+            continue;
+        }
+
+        if line.starts_with("diff --git ")
+            || line.starts_with("index ")
+            || line.starts_with("--- ")
+            || line.starts_with("+++ ")
+        {
+            continue;
+        }
+
+        hunk.push(line.to_string());
+    }
+
+    let (hunk_toolchains, unsafe_change) = classify_hunk(&hunk);
+    if unsafe_change {
+        return CIWorkflowChange {
+            toolchains: HashSet::new(),
+            requires_full_rebuild: true,
+        };
+    }
+    toolchains.extend(hunk_toolchains);
+
+    CIWorkflowChange {
+        toolchains,
+        requires_full_rebuild: false,
+    }
+}
+
+pub fn sorted_toolchains(toolchains: &HashSet<String>) -> Vec<String> {
+    let mut sorted: Vec<String> = toolchains.iter().cloned().collect();
+    sorted.sort();
+    sorted
+}
+
+fn classify_hunk(lines: &[String]) -> (HashSet<String>, bool) {
+    let mut hunk_toolchains = HashSet::new();
+    let mut changed_toolchains = HashSet::new();
+    let mut changed_lines = Vec::new();
+
+    for line in lines {
+        if line.is_empty() || !is_diff_line(line) {
+            continue;
+        }
+
+        let content = line[1..].trim();
+        hunk_toolchains.extend(detect_toolchains(content));
+
+        if !is_changed_line(line) {
+            continue;
+        }
+        if content.is_empty() || content.starts_with('#') {
+            continue;
+        }
+
+        changed_lines.push(content.to_string());
+        changed_toolchains.extend(detect_toolchains(content));
+    }
+
+    if changed_lines.is_empty() {
+        return (HashSet::new(), false);
+    }
+
+    let resolved_toolchains = if changed_toolchains.is_empty() {
+        if hunk_toolchains.len() != 1 {
+            return (HashSet::new(), true);
+        }
+        hunk_toolchains
+    } else {
+        changed_toolchains
+    };
+
+    for content in &changed_lines {
+        if touches_shared_ci_behavior(content) {
+            return (HashSet::new(), true);
+        }
+        if !detect_toolchains(content).is_empty() {
+            continue;
+        }
+        if is_toolchain_scoped_structural_line(content) {
+            continue;
+        }
+        return (HashSet::new(), true);
+    }
+
+    (resolved_toolchains, false)
+}
+
+fn detect_toolchains(content: &str) -> HashSet<String> {
+    let normalized = content.to_lowercase();
+    let mut found = HashSet::new();
+
+    for (toolchain, markers) in TOOLCHAIN_MARKERS {
+        if markers.iter().any(|marker| normalized.contains(marker)) {
+            found.insert((*toolchain).to_string());
+        }
+    }
+
+    found
+}
+
+fn touches_shared_ci_behavior(content: &str) -> bool {
+    let normalized = content.to_lowercase();
+    UNSAFE_MARKERS
+        .iter()
+        .any(|marker| normalized.contains(marker))
+}
+
+fn is_toolchain_scoped_structural_line(content: &str) -> bool {
+    [
+        "if:",
+        "run:",
+        "shell:",
+        "with:",
+        "env:",
+        "else",
+        "fi",
+        "then",
+        "printf ",
+        "echo ",
+        "curl ",
+        "powershell ",
+        "call ",
+        "cd ",
+    ]
+    .iter()
+    .any(|prefix| content.starts_with(prefix))
+}
+
+fn is_diff_line(line: &str) -> bool {
+    line.starts_with(' ') || is_changed_line(line)
+}
+
+fn is_changed_line(line: &str) -> bool {
+    line.starts_with('+') || line.starts_with('-')
+}
+
+fn get_file_diff(repo_root: &Path, diff_base: &str, relative_path: &str) -> String {
+    for args in [
+        vec![
+            "diff".to_string(),
+            "--unified=0".to_string(),
+            format!("{diff_base}...HEAD"),
+            "--".to_string(),
+            relative_path.to_string(),
+        ],
+        vec![
+            "diff".to_string(),
+            "--unified=0".to_string(),
+            diff_base.to_string(),
+            "HEAD".to_string(),
+            "--".to_string(),
+            relative_path.to_string(),
+        ],
+    ] {
+        match Command::new("git")
+            .args(&args)
+            .current_dir(repo_root)
+            .output()
+        {
+            Ok(output) if output.status.success() => {
+                return String::from_utf8_lossy(&output.stdout).into_owned();
+            }
+            _ => {}
+        }
+    }
+
+    String::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{analyze_ci_workflow_patch, sorted_toolchains};
+
+    #[test]
+    fn test_analyze_ci_workflow_patch_allows_toolchain_scoped_dotnet_changes() {
+        let change = analyze_ci_workflow_patch(
+            r#"
+@@ -312,0 +313,6 @@
++      - name: Set up .NET
++        if: needs.detect.outputs.needs_dotnet == 'true'
++        uses: actions/setup-dotnet@v4
++        with:
++          dotnet-version: '9.0.x'
+"#,
+        );
+
+        assert!(!change.requires_full_rebuild);
+        assert_eq!(sorted_toolchains(&change.toolchains), vec!["dotnet"]);
+    }
+
+    #[test]
+    fn test_analyze_ci_workflow_patch_ignores_comment_only_changes() {
+        let change = analyze_ci_workflow_patch(
+            r#"
+@@ -316,2 +316,2 @@
+-          # .NET 8 is the current LTS release.
++          # .NET 9 is the current LTS release.
+"#,
+        );
+
+        assert!(!change.requires_full_rebuild);
+        assert!(change.toolchains.is_empty());
+    }
+
+    #[test]
+    fn test_analyze_ci_workflow_patch_requires_full_rebuild_for_build_command_changes() {
+        let change = analyze_ci_workflow_patch(
+            r#"
+@@ -404,1 +404,1 @@
+-          $BT -root . -validate-build-files -language all
++          $BT -root . -force -validate-build-files -language all
+"#,
+        );
+
+        assert!(change.requires_full_rebuild);
+    }
+
+    #[test]
+    fn test_analyze_ci_workflow_patch_requires_full_rebuild_for_unknown_changes() {
+        let change = analyze_ci_workflow_patch(
+            r#"
+@@ -170,0 +171,1 @@
++      timeout-minutes: 45
+"#,
+        );
+
+        assert!(change.requires_full_rebuild);
+    }
+}

--- a/code/programs/rust/build-tool/src/main.rs
+++ b/code/programs/rust/build-tool/src/main.rs
@@ -30,6 +30,7 @@
 //   - Demonstrates the same algorithms in a different systems language.
 
 mod cache;
+mod ci_workflow;
 mod discovery;
 mod executor;
 mod gitdiff;
@@ -276,7 +277,9 @@ fn run() -> i32 {
         if let Some(validation_error) = validator::validate_build_contracts(&repo_root, &packages) {
             eprintln!("BUILD/CI validation failed:");
             eprintln!("  - {}", validation_error);
-            eprintln!("Fix the BUILD file or CI workflow so isolated and full-build runs stay correct.");
+            eprintln!(
+                "Fix the BUILD file or CI workflow so isolated and full-build runs stay correct."
+            );
             return 1;
         }
     }
@@ -292,24 +295,40 @@ fn run() -> i32 {
     let affected_set = if !force {
         let changed_files = gitdiff::get_changed_files(&repo_root, &args.diff_base);
         if !changed_files.is_empty() {
-            let shared_prefixes = [".github/"];
-            let mut shared_changed = false;
-            for f in &changed_files {
-                for prefix in &shared_prefixes {
-                    if f.starts_with(prefix) {
-                        shared_changed = true;
-                        break;
+            if changed_files
+                .iter()
+                .any(|path| path == ci_workflow::CI_WORKFLOW_PATH)
+            {
+                let ci_change =
+                    ci_workflow::analyze_ci_workflow_changes(&repo_root, &args.diff_base);
+                if ci_change.requires_full_rebuild {
+                    println!("Git diff: ci.yml changed in shared ways — rebuilding everything");
+                    force = true;
+                    None
+                } else {
+                    let ci_toolchains = ci_workflow::sorted_toolchains(&ci_change.toolchains);
+                    if !ci_toolchains.is_empty() {
+                        println!(
+                            "Git diff: ci.yml changed only toolchain-scoped setup for {}",
+                            ci_toolchains.join(", ")
+                        );
+                    }
+
+                    let changed_pkgs =
+                        gitdiff::map_files_to_packages(&changed_files, &packages, &repo_root);
+                    if !changed_pkgs.is_empty() {
+                        let affected = graph.affected_nodes(&changed_pkgs);
+                        println!(
+                            "Git diff: {} packages changed, {} affected (including dependents)",
+                            changed_pkgs.len(),
+                            affected.len()
+                        );
+                        Some(affected)
+                    } else {
+                        println!("Git diff: no package files changed — nothing to build");
+                        Some(std::collections::HashSet::new()) // empty = build nothing
                     }
                 }
-                if shared_changed {
-                    break;
-                }
-            }
-
-            if shared_changed {
-                println!("Git diff: shared files changed — rebuilding everything");
-                force = true;
-                None
             } else {
                 let changed_pkgs =
                     gitdiff::map_files_to_packages(&changed_files, &packages, &repo_root);

--- a/code/programs/swift/build-tool/Sources/BuildToolCore/BuildTool.swift
+++ b/code/programs/swift/build-tool/Sources/BuildToolCore/BuildTool.swift
@@ -56,7 +56,7 @@ public enum BuildTool {
             handle?.closeFile()
         }
 
-        for language in allLanguages {
+        for language in allToolchains {
             let value = languagesNeeded[language] ?? false
             let line = "needs_\(language)=\(value ? "true" : "false")"
             print(line)
@@ -95,12 +95,31 @@ public enum BuildTool {
 
         var force = options.force
         var affectedSet: Set<String>? = nil
+        var ciToolchains = Set<String>()
 
         if !force {
             let changedFiles = GitDiff.getChangedFiles(repoRoot: repoRoot, diffBase: options.diffBase)
             if !changedFiles.isEmpty {
+                if changedFiles.contains(CIWorkflow.workflowPath) {
+                    let ciChange = CIWorkflow.analyzeChanges(repoRoot: repoRoot, diffBase: options.diffBase)
+                    if ciChange.requiresFullRebuild {
+                        print("Git diff: ci.yml changed in shared ways -- rebuilding everything")
+                        force = true
+                    } else {
+                        ciToolchains = ciChange.toolchains
+                        if !ciToolchains.isEmpty {
+                            print(
+                                "Git diff: ci.yml changed only toolchain-scoped setup for \(CIWorkflow.sortedToolchains(ciToolchains).joined(separator: ", "))"
+                            )
+                        }
+                    }
+                }
+
                 let sharedChanged = changedFiles.contains { file in
-                    sharedPrefixes.contains { prefix in
+                    guard file != CIWorkflow.workflowPath else {
+                        return false
+                    }
+                    return sharedPrefixes.contains { prefix in
                         file == prefix || file.hasPrefix(prefix + "/")
                     }
                 }
@@ -137,12 +156,20 @@ public enum BuildTool {
                 graph: graph,
                 affectedSet: affectedSet,
                 force: force,
+                ciToolchains: ciToolchains,
                 repoRoot: repoRoot
             )
         }
 
         if options.detectLanguages {
-            outputLanguageFlags(computeLanguagesNeeded(packages: packages, affectedSet: affectedSet, force: force))
+            outputLanguageFlags(
+                computeLanguagesNeeded(
+                    packages: packages,
+                    affectedSet: affectedSet,
+                    force: force,
+                    ciToolchains: ciToolchains
+                )
+            )
             return 0
         }
 
@@ -260,6 +287,7 @@ public enum BuildTool {
         graph: DirectedGraph,
         affectedSet: Set<String>?,
         force: Bool,
+        ciToolchains: Set<String>,
         repoRoot: String
     ) throws -> Int32 {
         let affectedPackages = affectedSet.map { Array($0).sorted() }
@@ -275,7 +303,12 @@ public enum BuildTool {
             )
         }
         let dependencyEdges = graph.edges().map { [$0.0, $0.1] }
-        let languagesNeeded = computeLanguagesNeeded(packages: packages, affectedSet: affectedSet, force: force)
+        let languagesNeeded = computeLanguagesNeeded(
+            packages: packages,
+            affectedSet: affectedSet,
+            force: force,
+            ciToolchains: ciToolchains
+        )
         let plan = BuildPlan(
             schemaVersion: PlanIO.currentSchemaVersion,
             diffBase: options.diffBase,
@@ -295,17 +328,26 @@ public enum BuildTool {
         return 0
     }
 
-    private static func computeLanguagesNeeded(packages: [BuildPackage], affectedSet: Set<String>?, force: Bool) -> [String: Bool] {
-        var languagesNeeded: [String: Bool] = Dictionary(uniqueKeysWithValues: allLanguages.map { ($0, false) })
+    private static func computeLanguagesNeeded(
+        packages: [BuildPackage],
+        affectedSet: Set<String>?,
+        force: Bool,
+        ciToolchains: Set<String>
+    ) -> [String: Bool] {
+        var languagesNeeded: [String: Bool] = Dictionary(uniqueKeysWithValues: allToolchains.map { ($0, false) })
+        languagesNeeded["go"] = true
         if force || affectedSet == nil {
-            for package in packages {
-                languagesNeeded[package.language] = true
+            for toolchain in allToolchains {
+                languagesNeeded[toolchain] = true
             }
             return languagesNeeded
         }
 
         for package in packages where affectedSet?.contains(package.name) == true {
-            languagesNeeded[package.language] = true
+            languagesNeeded[toolchainForPackageLanguage(package.language)] = true
+        }
+        for toolchain in ciToolchains {
+            languagesNeeded[toolchain] = true
         }
         return languagesNeeded
     }

--- a/code/programs/swift/build-tool/Sources/BuildToolCore/CIWorkflow.swift
+++ b/code/programs/swift/build-tool/Sources/BuildToolCore/CIWorkflow.swift
@@ -1,0 +1,259 @@
+import Foundation
+
+public struct CIWorkflowChange {
+    public var toolchains: Set<String>
+    public var requiresFullRebuild: Bool
+
+    public init(toolchains: Set<String> = [], requiresFullRebuild: Bool = false) {
+        self.toolchains = toolchains
+        self.requiresFullRebuild = requiresFullRebuild
+    }
+}
+
+public enum CIWorkflow {
+    public static let workflowPath = ".github/workflows/ci.yml"
+
+    private static let toolchainMarkers: [String: [String]] = [
+        "python": [
+            "needs_python", "setup-python", "python-version", "setup-uv",
+            "python --version", "uv --version", "pytest",
+            "set up python", "install uv",
+        ],
+        "ruby": [
+            "needs_ruby", "setup-ruby", "ruby-version", "bundler",
+            "gem install bundler", "ruby --version", "bundle --version",
+            "set up ruby", "install bundler",
+        ],
+        "go": ["needs_go", "setup-go", "go-version", "go version", "set up go"],
+        "typescript": [
+            "needs_typescript", "setup-node", "node-version", "npm install -g jest",
+            "node --version", "npm --version", "set up node",
+        ],
+        "rust": [
+            "needs_rust", "rust-toolchain", "cargo", "rustc", "tarpaulin",
+            "wasm32-unknown-unknown", "set up rust", "install cargo-tarpaulin",
+        ],
+        "elixir": [
+            "needs_elixir", "setup-beam", "elixir-version", "otp-version",
+            "elixir --version", "mix --version", "set up elixir",
+        ],
+        "lua": [
+            "needs_lua", "gh-actions-lua", "gh-actions-luarocks", "luarocks",
+            "lua -v", "msvc", "set up lua", "set up luarocks",
+        ],
+        "perl": ["needs_perl", "cpanm", "perl --version", "install cpanm"],
+        "haskell": [
+            "needs_haskell", "haskell-actions/setup", "ghc-version", "cabal-version",
+            "ghc --version", "cabal --version", "set up haskell",
+        ],
+        "dotnet": [
+            "needs_dotnet", "setup-dotnet", "dotnet-version", "dotnet --version",
+            "set up .net",
+        ],
+    ]
+
+    private static let unsafeMarkers = [
+        "./build-tool",
+        "build-tool.exe",
+        "-detect-languages",
+        "-emit-plan",
+        "-force",
+        "-plan-file",
+        "-validate-build-files",
+        "actions/checkout",
+        "build-plan",
+        "cancel-in-progress:",
+        "concurrency:",
+        "diff-base",
+        "download-artifact",
+        "event_name",
+        "fetch-depth",
+        "git fetch origin main",
+        "git_ref",
+        "is_main",
+        "matrix:",
+        "permissions:",
+        "pr_base_ref",
+        "pull_request:",
+        "push:",
+        "runs-on:",
+        "strategy:",
+        "upload-artifact",
+    ]
+
+    public static func analyzeChanges(repoRoot: String, diffBase: String) -> CIWorkflowChange {
+        analyzePatch(fileDiff(repoRoot: repoRoot, diffBase: diffBase, relativePath: workflowPath))
+    }
+
+    public static func analyzePatch(_ patch: String) -> CIWorkflowChange {
+        var toolchains = Set<String>()
+        var hunk: [String] = []
+
+        func flush() -> CIWorkflowChange? {
+            let (hunkToolchains, unsafe) = classifyHunk(hunk)
+            hunk.removeAll(keepingCapacity: true)
+            if unsafe {
+                return CIWorkflowChange(requiresFullRebuild: true)
+            }
+            toolchains.formUnion(hunkToolchains)
+            return nil
+        }
+
+        for line in patch.split(separator: "\n", omittingEmptySubsequences: false).map(String.init) {
+            if line.hasPrefix("@@") {
+                if let result = flush() {
+                    return result
+                }
+                continue
+            }
+
+            if line.hasPrefix("diff --git ")
+                || line.hasPrefix("index ")
+                || line.hasPrefix("--- ")
+                || line.hasPrefix("+++ ")
+            {
+                continue
+            }
+
+            hunk.append(line)
+        }
+
+        if let result = flush() {
+            return result
+        }
+        return CIWorkflowChange(toolchains: toolchains)
+    }
+
+    public static func sortedToolchains(_ toolchains: Set<String>) -> [String] {
+        toolchains.sorted()
+    }
+
+    private static func classifyHunk(_ lines: [String]) -> (Set<String>, Bool) {
+        var hunkToolchains = Set<String>()
+        var changedToolchains = Set<String>()
+        var changedLines: [String] = []
+
+        for line in lines {
+            guard !line.isEmpty, isDiffLine(line) else {
+                continue
+            }
+
+            let content = String(line.dropFirst()).trimmingCharacters(in: .whitespacesAndNewlines)
+            hunkToolchains.formUnion(detectToolchains(content))
+
+            guard isChangedLine(line) else {
+                continue
+            }
+            guard !content.isEmpty, !content.hasPrefix("#") else {
+                continue
+            }
+
+            changedLines.append(content)
+            changedToolchains.formUnion(detectToolchains(content))
+        }
+
+        guard !changedLines.isEmpty else {
+            return ([], false)
+        }
+
+        var resolvedToolchains = changedToolchains
+        if resolvedToolchains.isEmpty {
+            guard hunkToolchains.count == 1 else {
+                return ([], true)
+            }
+            resolvedToolchains = hunkToolchains
+        }
+
+        for content in changedLines {
+            if touchesSharedCIBehavior(content) {
+                return ([], true)
+            }
+            if !detectToolchains(content).isEmpty {
+                continue
+            }
+            if isToolchainScopedStructuralLine(content) {
+                continue
+            }
+            return ([], true)
+        }
+
+        return (resolvedToolchains, false)
+    }
+
+    private static func detectToolchains(_ content: String) -> Set<String> {
+        let normalized = content.lowercased()
+        return Set(
+            toolchainMarkers.compactMap { toolchain, markers in
+                markers.contains(where: { normalized.contains($0) }) ? toolchain : nil
+            }
+        )
+    }
+
+    private static func touchesSharedCIBehavior(_ content: String) -> Bool {
+        let normalized = content.lowercased()
+        return unsafeMarkers.contains(where: { normalized.contains($0) })
+    }
+
+    private static func isToolchainScopedStructuralLine(_ content: String) -> Bool {
+        [
+            "if:",
+            "run:",
+            "shell:",
+            "with:",
+            "env:",
+            "else",
+            "fi",
+            "then",
+            "printf ",
+            "echo ",
+            "curl ",
+            "powershell ",
+            "call ",
+            "cd ",
+        ].contains(where: { content.hasPrefix($0) })
+    }
+
+    private static func isDiffLine(_ line: String) -> Bool {
+        line.hasPrefix(" ") || isChangedLine(line)
+    }
+
+    private static func isChangedLine(_ line: String) -> Bool {
+        line.hasPrefix("+") || line.hasPrefix("-")
+    }
+
+    private static func fileDiff(repoRoot: String, diffBase: String, relativePath: String) -> String {
+        let argLists = [
+            ["diff", "--unified=0", "\(diffBase)...HEAD", "--", relativePath],
+            ["diff", "--unified=0", diffBase, "HEAD", "--", relativePath],
+        ]
+
+        for args in argLists {
+            if let output = try? runGit(args: args, repoRoot: repoRoot) {
+                return output
+            }
+        }
+
+        return ""
+    }
+
+    private static func runGit(args: [String], repoRoot: String) throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["git"] + args
+        process.currentDirectoryURL = URL(fileURLWithPath: repoRoot)
+
+        let stdout = Pipe()
+        process.standardOutput = stdout
+        process.standardError = Pipe()
+
+        try process.run()
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0 else {
+            throw BuildToolError.io("git diff failed")
+        }
+
+        let data = stdout.fileHandleForReading.readDataToEndOfFile()
+        return String(decoding: data, as: UTF8.self)
+    }
+}

--- a/code/programs/swift/build-tool/Sources/BuildToolCore/Models.swift
+++ b/code/programs/swift/build-tool/Sources/BuildToolCore/Models.swift
@@ -253,6 +253,17 @@ public let allLanguages = [
     "haskell",
 ]
 
-public let sharedPrefixes = [
-    ".github/workflows/ci.yml",
-]
+public let allToolchains = allLanguages + ["dotnet"]
+
+public let sharedPrefixes: [String] = []
+
+public func toolchainForPackageLanguage(_ language: String) -> String {
+    switch language {
+    case "wasm":
+        return "rust"
+    case "csharp", "fsharp", "dotnet":
+        return "dotnet"
+    default:
+        return language
+    }
+}

--- a/code/programs/swift/build-tool/Tests/BuildToolCoreTests/CIWorkflowTests.swift
+++ b/code/programs/swift/build-tool/Tests/BuildToolCoreTests/CIWorkflowTests.swift
@@ -1,0 +1,56 @@
+import BuildToolCore
+import Testing
+
+struct CIWorkflowTests {
+    @Test
+    func analyzePatchAllowsToolchainScopedDotnetChanges() {
+        let change = CIWorkflow.analyzePatch(
+            """
+            @@ -312,0 +313,6 @@
+            +      - name: Set up .NET
+            +        if: needs.detect.outputs.needs_dotnet == 'true'
+            +        uses: actions/setup-dotnet@v4
+            +        with:
+            +          dotnet-version: '9.0.x'
+            """
+        )
+
+        #expect(change.requiresFullRebuild == false)
+        #expect(CIWorkflow.sortedToolchains(change.toolchains) == ["dotnet"])
+    }
+
+    @Test
+    func analyzePatchIgnoresCommentOnlyChanges() {
+        let change = CIWorkflow.analyzePatch(
+            """
+            @@ -316,2 +316,2 @@
+            -          # .NET 8 is the current LTS release.
+            +          # .NET 9 is the current LTS release.
+            """
+        )
+
+        #expect(change.requiresFullRebuild == false)
+        #expect(CIWorkflow.sortedToolchains(change.toolchains).isEmpty)
+    }
+
+    @Test
+    func analyzePatchRequiresFullRebuildForBuildCommandChanges() {
+        let change = CIWorkflow.analyzePatch(
+            """
+            @@ -404,1 +404,1 @@
+            -          $BT -root . -validate-build-files -language all
+            +          $BT -root . -force -validate-build-files -language all
+            """
+        )
+
+        #expect(change.requiresFullRebuild == true)
+    }
+
+    @Test
+    func toolchainMappingSupportsSharedFamilies() {
+        #expect(toolchainForPackageLanguage("wasm") == "rust")
+        #expect(toolchainForPackageLanguage("csharp") == "dotnet")
+        #expect(toolchainForPackageLanguage("fsharp") == "dotnet")
+        #expect(toolchainForPackageLanguage("python") == "python")
+    }
+}

--- a/code/programs/typescript/build-tool/src/ci-workflow.ts
+++ b/code/programs/typescript/build-tool/src/ci-workflow.ts
@@ -1,0 +1,243 @@
+import { execFileSync } from "node:child_process";
+
+export const CI_WORKFLOW_PATH = ".github/workflows/ci.yml";
+
+export type CIWorkflowChange = {
+  toolchains: Set<string>;
+  requiresFullRebuild: boolean;
+};
+
+const TOOLCHAIN_MARKERS: Record<string, string[]> = {
+  python: [
+    "needs_python", "setup-python", "python-version", "setup-uv",
+    "python --version", "uv --version", "pytest",
+    "set up python", "install uv",
+  ],
+  ruby: [
+    "needs_ruby", "setup-ruby", "ruby-version", "bundler",
+    "gem install bundler", "ruby --version", "bundle --version",
+    "set up ruby", "install bundler",
+  ],
+  go: ["needs_go", "setup-go", "go-version", "go version", "set up go"],
+  typescript: [
+    "needs_typescript", "setup-node", "node-version", "npm install -g jest",
+    "node --version", "npm --version", "set up node",
+  ],
+  rust: [
+    "needs_rust", "rust-toolchain", "cargo", "rustc", "tarpaulin",
+    "wasm32-unknown-unknown", "set up rust", "install cargo-tarpaulin",
+  ],
+  elixir: [
+    "needs_elixir", "setup-beam", "elixir-version", "otp-version",
+    "elixir --version", "mix --version", "set up elixir",
+  ],
+  lua: [
+    "needs_lua", "gh-actions-lua", "gh-actions-luarocks", "luarocks",
+    "lua -v", "msvc", "set up lua", "set up luarocks",
+  ],
+  perl: ["needs_perl", "cpanm", "perl --version", "install cpanm"],
+  haskell: [
+    "needs_haskell", "haskell-actions/setup", "ghc-version", "cabal-version",
+    "ghc --version", "cabal --version", "set up haskell",
+  ],
+  dotnet: [
+    "needs_dotnet", "setup-dotnet", "dotnet-version", "dotnet --version",
+    "set up .net",
+  ],
+};
+
+const UNSAFE_MARKERS = [
+  "./build-tool",
+  "build-tool.exe",
+  "-detect-languages",
+  "-emit-plan",
+  "-force",
+  "-plan-file",
+  "-validate-build-files",
+  "actions/checkout",
+  "build-plan",
+  "cancel-in-progress:",
+  "concurrency:",
+  "diff-base",
+  "download-artifact",
+  "event_name",
+  "fetch-depth",
+  "git fetch origin main",
+  "git_ref",
+  "is_main",
+  "matrix:",
+  "permissions:",
+  "pr_base_ref",
+  "pull_request:",
+  "push:",
+  "runs-on:",
+  "strategy:",
+  "upload-artifact",
+];
+
+export function analyzeCIWorkflowChanges(root: string, diffBase: string): CIWorkflowChange {
+  return analyzeCIWorkflowPatch(getFileDiff(root, diffBase, CI_WORKFLOW_PATH));
+}
+
+export function analyzeCIWorkflowPatch(patch: string): CIWorkflowChange {
+  const toolchains = new Set<string>();
+  let hunk: string[] = [];
+
+  const flush = (): CIWorkflowChange | null => {
+    const { toolchains: hunkToolchains, unsafe } = classifyHunk(hunk);
+    hunk = [];
+    if (unsafe) {
+      return { toolchains: new Set<string>(), requiresFullRebuild: true };
+    }
+    for (const toolchain of hunkToolchains) {
+      toolchains.add(toolchain);
+    }
+    return null;
+  };
+
+  for (const line of patch.split("\n")) {
+    if (line.startsWith("@@")) {
+      const result = flush();
+      if (result) {
+        return result;
+      }
+      continue;
+    }
+
+    if (
+      line.startsWith("diff --git ") ||
+      line.startsWith("index ") ||
+      line.startsWith("--- ") ||
+      line.startsWith("+++ ")
+    ) {
+      continue;
+    }
+
+    hunk.push(line);
+  }
+
+  const result = flush();
+  if (result) {
+    return result;
+  }
+  return { toolchains, requiresFullRebuild: false };
+}
+
+export function sortedToolchains(toolchains: Set<string>): string[] {
+  return Array.from(toolchains).sort();
+}
+
+function classifyHunk(lines: string[]): { toolchains: Set<string>; unsafe: boolean } {
+  const hunkToolchains = new Set<string>();
+  const changedToolchains = new Set<string>();
+  const changedLines: string[] = [];
+
+  for (const line of lines) {
+    if (line.length === 0 || !isDiffLine(line)) {
+      continue;
+    }
+
+    const content = line.slice(1).trim();
+    for (const toolchain of detectToolchains(content)) {
+      hunkToolchains.add(toolchain);
+    }
+
+    if (!isChangedLine(line)) {
+      continue;
+    }
+    if (content.length === 0 || content.startsWith("#")) {
+      continue;
+    }
+
+    changedLines.push(content);
+    for (const toolchain of detectToolchains(content)) {
+      changedToolchains.add(toolchain);
+    }
+  }
+
+  if (changedLines.length === 0) {
+    return { toolchains: new Set<string>(), unsafe: false };
+  }
+
+  let resolvedToolchains = changedToolchains;
+  if (resolvedToolchains.size === 0) {
+    if (hunkToolchains.size !== 1) {
+      return { toolchains: new Set<string>(), unsafe: true };
+    }
+    resolvedToolchains = hunkToolchains;
+  }
+
+  for (const content of changedLines) {
+    if (touchesSharedCIBehavior(content)) {
+      return { toolchains: new Set<string>(), unsafe: true };
+    }
+    if (detectToolchains(content).size > 0) {
+      continue;
+    }
+    if (isToolchainScopedStructuralLine(content)) {
+      continue;
+    }
+    return { toolchains: new Set<string>(), unsafe: true };
+  }
+
+  return { toolchains: resolvedToolchains, unsafe: false };
+}
+
+function detectToolchains(content: string): Set<string> {
+  const found = new Set<string>();
+  const normalized = content.toLowerCase();
+
+  for (const [toolchain, markers] of Object.entries(TOOLCHAIN_MARKERS)) {
+    if (markers.some((marker) => normalized.includes(marker))) {
+      found.add(toolchain);
+    }
+  }
+
+  return found;
+}
+
+function touchesSharedCIBehavior(content: string): boolean {
+  const normalized = content.toLowerCase();
+  return UNSAFE_MARKERS.some((marker) => normalized.includes(marker));
+}
+
+function isToolchainScopedStructuralLine(content: string): boolean {
+  return [
+    "if:",
+    "run:",
+    "shell:",
+    "with:",
+    "env:",
+    "else",
+    "fi",
+    "then",
+    "printf ",
+    "echo ",
+    "curl ",
+    "powershell ",
+    "call ",
+    "cd ",
+  ].some((prefix) => content.startsWith(prefix));
+}
+
+function isDiffLine(line: string): boolean {
+  return line.startsWith(" ") || isChangedLine(line);
+}
+
+function isChangedLine(line: string): boolean {
+  return line.startsWith("+") || line.startsWith("-");
+}
+
+function getFileDiff(root: string, diffBase: string, relativePath: string): string {
+  for (const args of [
+    ["diff", "--unified=0", `${diffBase}...HEAD`, "--", relativePath],
+    ["diff", "--unified=0", diffBase, "HEAD", "--", relativePath],
+  ]) {
+    try {
+      return execFileSync("git", args, { cwd: root, encoding: "utf-8" });
+    } catch {
+      // Try the next diff form.
+    }
+  }
+  return "";
+}

--- a/code/programs/typescript/build-tool/src/index.ts
+++ b/code/programs/typescript/build-tool/src/index.ts
@@ -35,6 +35,11 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { parseArgs } from "node:util";
 import { discoverPackages } from "./discovery.js";
+import {
+  CI_WORKFLOW_PATH,
+  analyzeCIWorkflowChanges,
+  sortedToolchains,
+} from "./ci-workflow.js";
 import { resolveDependencies } from "./resolver.js";
 import { getChangedFiles, mapFilesToPackages } from "./gitdiff.js";
 import { hashPackage, hashDeps } from "./hasher.js";
@@ -212,6 +217,7 @@ Options:
   // Git is the source of truth -- no cache file needed.
   // Fallback: hash-based cache (for local dev when not on a branch).
   let affectedSet: Set<string> | null = null;
+  let ciToolchains = new Set<string>();
   let force = values.force ?? false;
   const dryRun = values["dry-run"] ?? false;
   const diffBase = values["diff-base"] ?? "origin/main";
@@ -220,8 +226,26 @@ Options:
     // Try git-diff mode first (the default).
     const changedFiles = getChangedFiles(root, diffBase);
     if (changedFiles.length > 0) {
-      const sharedPrefixes = [".github/"];
-      const sharedChanged = changedFiles.some(f => sharedPrefixes.some(p => f.startsWith(p)));
+      if (changedFiles.includes(CI_WORKFLOW_PATH)) {
+        const ciChange = analyzeCIWorkflowChanges(root, diffBase);
+        if (ciChange.requiresFullRebuild) {
+          console.log("Git diff: ci.yml changed in shared ways -- rebuilding everything");
+          force = true;
+          affectedSet = null;
+        } else {
+          ciToolchains = ciChange.toolchains;
+          if (ciToolchains.size > 0) {
+            console.log(
+              `Git diff: ci.yml changed only toolchain-scoped setup for ${sortedToolchains(ciToolchains).join(", ")}`,
+            );
+          }
+        }
+      }
+
+      const sharedPrefixes: string[] = [];
+      const sharedChanged = changedFiles.some((f) =>
+        f !== CI_WORKFLOW_PATH && sharedPrefixes.some((p) => f.startsWith(p)),
+      );
 
       if (sharedChanged) {
         console.log("Git diff: shared files changed -- rebuilding everything");
@@ -272,6 +296,10 @@ Options:
       if (affectedSet.has(pkg.name)) {
         langsNeeded[toolchainForLanguage(pkg.language)] = true;
       }
+    }
+
+    for (const toolchain of ciToolchains) {
+      langsNeeded[toolchain] = true;
     }
   }
 

--- a/code/programs/typescript/build-tool/tests/ci-workflow.test.ts
+++ b/code/programs/typescript/build-tool/tests/ci-workflow.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import {
+  analyzeCIWorkflowPatch,
+  sortedToolchains,
+} from "../src/ci-workflow.js";
+
+describe("analyzeCIWorkflowPatch", () => {
+  it("allows toolchain-scoped dotnet changes", () => {
+    const change = analyzeCIWorkflowPatch(`
+@@ -312,0 +313,6 @@
++      - name: Set up .NET
++        if: needs.detect.outputs.needs_dotnet == 'true'
++        uses: actions/setup-dotnet@v4
++        with:
++          dotnet-version: '9.0.x'
+`);
+
+    expect(change.requiresFullRebuild).toBe(false);
+    expect(sortedToolchains(change.toolchains)).toEqual(["dotnet"]);
+  });
+
+  it("ignores comment-only changes", () => {
+    const change = analyzeCIWorkflowPatch(`
+@@ -316,2 +316,2 @@
+-          # .NET 8 is the current LTS release.
++          # .NET 9 is the current LTS release.
+`);
+
+    expect(change.requiresFullRebuild).toBe(false);
+    expect(sortedToolchains(change.toolchains)).toEqual([]);
+  });
+
+  it("requires a full rebuild for build command changes", () => {
+    const change = analyzeCIWorkflowPatch(`
+@@ -404,1 +404,1 @@
+-          $BT -root . -validate-build-files -language all
++          $BT -root . -force -validate-build-files -language all
+`);
+
+    expect(change.requiresFullRebuild).toBe(true);
+  });
+
+  it("requires a full rebuild for unknown workflow changes", () => {
+    const change = analyzeCIWorkflowPatch(`
+@@ -170,0 +171,1 @@
++      timeout-minutes: 45
+`);
+
+    expect(change.requiresFullRebuild).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- port the narrower `ci.yml` toolchain-scoping logic from the Go build tool to the Python, Ruby, TypeScript, Swift, Rust, Elixir, and Perl implementations
- stop treating every `.github/workflows/ci.yml` change as an automatic full rebuild in those implementations
- keep full rebuild behavior for shared or unsafe workflow edits while allowing toolchain-specific workflow changes to enable only the touched toolchain

## Why
The original Go fix narrowed an overly broad CI rule where any `ci.yml` change forced the full package chain to rebuild. This parity PR applies the same behavior across the other build-tool implementations so adding or adjusting a toolchain such as C# does not unnecessarily pull unrelated ecosystems like Rust into CI.

## Validation
- `npm test` in `code/programs/typescript/build-tool`
- `swift test` in `code/programs/swift/build-tool`
- `PYTHONPATH=code/programs/python/build-tool/src python3 -m pytest -o addopts='' code/programs/python/build-tool/tests/test_ci_workflow.py`
- `mix deps.get && mix test test/ci_workflow_test.exs test/validator_test.exs` in `code/programs/elixir/build-tool`
- `cargo test` in `code/programs/rust/build-tool`
- `perl -Ilib -c lib/CodingAdventures/BuildTool/CIWorkflow.pm && perl -Ilib -c lib/CodingAdventures/BuildTool/GitDiff.pm && prove -Ilib t/05-gitdiff.t t/12-ci-workflow.t` in `code/programs/perl/build-tool`
- `/Users/adhithya/.local/share/mise/installs/ruby/3.4.9/bin/ruby -S rake test` in `code/programs/ruby/build-tool`

## Notes
- The branch has been rebased onto `main` now that the original `#669` CI fix is merged.
- Lua and Haskell were intentionally left unchanged because they do not currently implement the same git-diff-based `ci.yml` change-detection path.
