### PR TITLE
fix(build-tool): port JVM ci workflow scoping

### DIFF
--- a/code/programs/elixir/build-tool/lib/build_tool/ci_workflow.ex
+++ b/code/programs/elixir/build-tool/lib/build_tool/ci_workflow.ex
@@ -86,6 +86,33 @@ defmodule BuildTool.CIWorkflow do
       "cabal --version",
       "set up haskell"
     ],
+    "java" => [
+      "needs_java",
+      "setup-java",
+      "java-version",
+      "java --version",
+      "temurin",
+      "set up jdk",
+      "set up gradle",
+      "setup-gradle",
+      "disable long-lived gradle services",
+      "gradle_opts",
+      "org.gradle.daemon",
+      "org.gradle.vfs.watch"
+    ],
+    "kotlin" => [
+      "needs_kotlin",
+      "setup-java",
+      "java-version",
+      "temurin",
+      "set up jdk",
+      "set up gradle",
+      "setup-gradle",
+      "disable long-lived gradle services",
+      "gradle_opts",
+      "org.gradle.daemon",
+      "org.gradle.vfs.watch"
+    ],
     "dotnet" => [
       "needs_dotnet",
       "setup-dotnet",
@@ -253,6 +280,8 @@ defmodule BuildTool.CIWorkflow do
         "shell:",
         "with:",
         "env:",
+        "{",
+        "}",
         "else",
         "fi",
         "then",

--- a/code/programs/elixir/build-tool/lib/build_tool/validator.ex
+++ b/code/programs/elixir/build-tool/lib/build_tool/validator.ex
@@ -9,6 +9,8 @@ defmodule BuildTool.Validator do
                                     "elixir",
                                     "lua",
                                     "perl",
+                                    "java",
+                                    "kotlin",
                                     "haskell"
                                   ])
 

--- a/code/programs/elixir/build-tool/test/ci_workflow_test.exs
+++ b/code/programs/elixir/build-tool/test/ci_workflow_test.exs
@@ -18,6 +18,32 @@ defmodule BuildTool.CIWorkflowTest do
     assert CIWorkflow.sorted_toolchains(change.toolchains) == ["dotnet"]
   end
 
+  test "allows shared jvm toolchain changes" do
+    change =
+      CIWorkflow.analyze_patch("""
+      @@ -314,0 +315,17 @@
+      +      - name: Set up JDK 21
+      +        if: needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true'
+      +        uses: actions/setup-java@v4
+      +        with:
+      +          distribution: 'temurin'
+      +          java-version: '21'
+      +      - name: Set up Gradle
+      +        if: needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true'
+      +        uses: gradle/actions/setup-gradle@v4
+      +      - name: Disable long-lived Gradle services on Windows CI
+      +        if: (needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true') && runner.os == 'Windows'
+      +        shell: bash
+      +        run: |
+      +          {
+      +            echo 'GRADLE_OPTS=-Dorg.gradle.daemon=false -Dorg.gradle.vfs.watch=false'
+      +          } >> "$GITHUB_ENV"
+      """)
+
+    refute change.requires_full_rebuild
+    assert CIWorkflow.sorted_toolchains(change.toolchains) == ["java", "kotlin"]
+  end
+
   test "ignores comment-only changes" do
     change =
       CIWorkflow.analyze_patch("""

--- a/code/programs/lua/build-tool/lib/build_tool/validator.lua
+++ b/code/programs/lua/build-tool/lib/build_tool/validator.lua
@@ -8,6 +8,8 @@ local CI_MANAGED_TOOLCHAIN_LANGUAGES = {
     elixir = true,
     lua = true,
     perl = true,
+    java = true,
+    kotlin = true,
     haskell = true,
 }
 

--- a/code/programs/lua/build-tool/tests/test_validator.lua
+++ b/code/programs/lua/build-tool/tests/test_validator.lua
@@ -88,6 +88,32 @@ jobs:
         }))
     end)
 
+    it("allows normalized outputs for jvm toolchains", function()
+        write_file(tmpdir .. "/.github/workflows/ci.yml", [[
+jobs:
+  detect:
+    outputs:
+      needs_java: ${{ steps.toolchains.outputs.needs_java }}
+      needs_kotlin: ${{ steps.toolchains.outputs.needs_kotlin }}
+    steps:
+      - name: Normalize toolchain requirements
+        id: toolchains
+        run: |
+          printf '%s\n' \
+            'needs_java=true' \
+            'needs_kotlin=true' >> "$GITHUB_OUTPUT"
+  build:
+    steps:
+      - name: Full build on main merge
+        run: ./build-tool -root . -force -validate-build-files -language all
+]])
+
+        assert.is_nil(Validator.validate_ci_full_build_toolchains(tmpdir, {
+            { language = "java" },
+            { language = "kotlin" },
+        }))
+    end)
+
     it("flags Lua isolated-build violations", function()
         make_dir(tmpdir .. "/code/packages/lua/problem_pkg")
         write_file(tmpdir .. "/code/packages/lua/problem_pkg/BUILD", [[

--- a/code/programs/perl/build-tool/lib/CodingAdventures/BuildTool/CIWorkflow.pm
+++ b/code/programs/perl/build-tool/lib/CodingAdventures/BuildTool/CIWorkflow.pm
@@ -42,6 +42,18 @@ my %TOOLCHAIN_MARKERS = (
         'needs_haskell', 'haskell-actions/setup', 'ghc-version', 'cabal-version',
         'ghc --version', 'cabal --version', 'set up haskell',
     ],
+    java => [
+        'needs_java', 'setup-java', 'java-version', 'java --version',
+        'temurin', 'set up jdk', 'set up gradle', 'setup-gradle',
+        'disable long-lived gradle services',
+        'gradle_opts', 'org.gradle.daemon', 'org.gradle.vfs.watch',
+    ],
+    kotlin => [
+        'needs_kotlin', 'setup-java', 'java-version',
+        'temurin', 'set up jdk', 'set up gradle', 'setup-gradle',
+        'disable long-lived gradle services',
+        'gradle_opts', 'org.gradle.daemon', 'org.gradle.vfs.watch',
+    ],
     dotnet => [
         'needs_dotnet', 'setup-dotnet', 'dotnet-version', 'dotnet --version',
         'set up .net',
@@ -197,6 +209,8 @@ sub _is_toolchain_scoped_structural_line {
         'shell:',
         'with:',
         'env:',
+        '{',
+        '}',
         'else',
         'fi',
         'then',

--- a/code/programs/perl/build-tool/lib/CodingAdventures/BuildTool/Validator.pm
+++ b/code/programs/perl/build-tool/lib/CodingAdventures/BuildTool/Validator.pm
@@ -6,7 +6,7 @@ use File::Basename qw(basename);
 use File::Spec ();
 
 my %CI_MANAGED_TOOLCHAIN_LANGUAGES = map { $_ => 1 } qw(
-    python ruby typescript rust elixir lua perl haskell
+    python ruby typescript rust elixir lua perl java kotlin haskell
 );
 
 sub validate_ci_full_build_toolchains {

--- a/code/programs/perl/build-tool/t/12-ci-workflow.t
+++ b/code/programs/perl/build-tool/t/12-ci-workflow.t
@@ -27,6 +27,35 @@ PATCH
     );
 };
 
+subtest 'allows shared jvm toolchain changes' => sub {
+    my $change = CodingAdventures::BuildTool::CIWorkflow::analyze_patch(<<'PATCH');
+@@ -314,0 +315,17 @@
++      - name: Set up JDK 21
++        if: needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true'
++        uses: actions/setup-java@v4
++        with:
++          distribution: 'temurin'
++          java-version: '21'
++      - name: Set up Gradle
++        if: needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true'
++        uses: gradle/actions/setup-gradle@v4
++      - name: Disable long-lived Gradle services on Windows CI
++        if: (needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true') && runner.os == 'Windows'
++        shell: bash
++        run: |
++          {
++            echo 'GRADLE_OPTS=-Dorg.gradle.daemon=false -Dorg.gradle.vfs.watch=false'
++          } >> "$GITHUB_ENV"
+PATCH
+
+    ok(!$change->{requires_full_rebuild}, 'jvm workflow change stays scoped');
+    is(
+        [ CodingAdventures::BuildTool::CIWorkflow::sorted_toolchains($change->{toolchains}) ],
+        ['java', 'kotlin'],
+        'detects the java and kotlin toolchains',
+    );
+};
+
 subtest 'ignores comment-only changes' => sub {
     my $change = CodingAdventures::BuildTool::CIWorkflow::analyze_patch(<<'PATCH');
 @@ -316,2 +316,2 @@

--- a/code/programs/python/build-tool/src/build_tool/ci_workflow.py
+++ b/code/programs/python/build-tool/src/build_tool/ci_workflow.py
@@ -54,6 +54,18 @@ _TOOLCHAIN_MARKERS: dict[str, tuple[str, ...]] = {
         "needs_haskell", "haskell-actions/setup", "ghc-version", "cabal-version",
         "ghc --version", "cabal --version", "set up haskell",
     ),
+    "java": (
+        "needs_java", "setup-java", "java-version", "java --version",
+        "temurin", "set up jdk", "set up gradle", "setup-gradle",
+        "disable long-lived gradle services",
+        "gradle_opts", "org.gradle.daemon", "org.gradle.vfs.watch",
+    ),
+    "kotlin": (
+        "needs_kotlin", "setup-java", "java-version",
+        "temurin", "set up jdk", "set up gradle", "setup-gradle",
+        "disable long-lived gradle services",
+        "gradle_opts", "org.gradle.daemon", "org.gradle.vfs.watch",
+    ),
     "dotnet": (
         "needs_dotnet", "setup-dotnet", "dotnet-version", "dotnet --version",
         "set up .net",
@@ -191,7 +203,7 @@ def _touches_shared_ci_behavior(content: str) -> bool:
 
 def _is_toolchain_scoped_structural_line(content: str) -> bool:
     return content.startswith((
-        "if:", "run:", "shell:", "with:", "env:", "else", "fi", "then",
+        "if:", "run:", "shell:", "with:", "env:", "{", "}", "else", "fi", "then",
         "printf ", "echo ", "curl ", "powershell ", "call ", "cd ",
     ))
 

--- a/code/programs/python/build-tool/src/build_tool/cli.py
+++ b/code/programs/python/build-tool/src/build_tool/cli.py
@@ -79,7 +79,21 @@ except ImportError:
 ALL_LANGUAGES = ["python", "ruby", "go", "typescript", "rust", "elixir", "lua", "perl", "swift", "haskell"]
 
 # ALL_TOOLCHAINS is the canonical list of CI toolchains we can request.
-ALL_TOOLCHAINS = [*ALL_LANGUAGES, "dotnet"]
+ALL_TOOLCHAINS = [
+    "python",
+    "ruby",
+    "go",
+    "typescript",
+    "rust",
+    "elixir",
+    "lua",
+    "perl",
+    "swift",
+    "java",
+    "kotlin",
+    "haskell",
+    "dotnet",
+]
 
 # SHARED_PREFIXES are repo paths that, when changed, still mean every
 # toolchain needs rebuilding. ci.yml is handled separately via patch analysis

--- a/code/programs/python/build-tool/src/build_tool/validator.py
+++ b/code/programs/python/build-tool/src/build_tool/validator.py
@@ -10,7 +10,18 @@ from build_tool.discovery import Package
 
 
 CI_MANAGED_TOOLCHAIN_LANGUAGES = frozenset(
-    {"python", "ruby", "typescript", "rust", "elixir", "lua", "perl", "haskell"}
+    {
+        "python",
+        "ruby",
+        "typescript",
+        "rust",
+        "elixir",
+        "lua",
+        "perl",
+        "java",
+        "kotlin",
+        "haskell",
+    }
 )
 
 

--- a/code/programs/python/build-tool/tests/test_ci_workflow.py
+++ b/code/programs/python/build-tool/tests/test_ci_workflow.py
@@ -23,6 +23,33 @@ def test_analyze_ci_workflow_patch_allows_toolchain_scoped_dotnet_changes():
     assert change.toolchains == frozenset({"dotnet"})
 
 
+def test_analyze_ci_workflow_patch_allows_shared_jvm_toolchain_changes():
+    change = analyze_ci_workflow_patch(
+        """
+@@ -314,0 +315,17 @@
++      - name: Set up JDK 21
++        if: needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true'
++        uses: actions/setup-java@v4
++        with:
++          distribution: 'temurin'
++          java-version: '21'
++      - name: Set up Gradle
++        if: needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true'
++        uses: gradle/actions/setup-gradle@v4
++      - name: Disable long-lived Gradle services on Windows CI
++        if: (needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true') && runner.os == 'Windows'
++        shell: bash
++        run: |
++          {
++            echo 'GRADLE_OPTS=-Dorg.gradle.daemon=false -Dorg.gradle.vfs.watch=false'
++          } >> "$GITHUB_ENV"
+"""
+    )
+
+    assert not change.requires_full_rebuild
+    assert change.toolchains == frozenset({"java", "kotlin"})
+
+
 def test_analyze_ci_workflow_patch_ignores_comment_only_changes():
     change = analyze_ci_workflow_patch(
         """
@@ -69,3 +96,27 @@ def test_compute_languages_needed_includes_safe_ci_workflow_toolchains():
     assert needed["python"] is True
     assert needed["dotnet"] is True
     assert needed["rust"] is False
+
+
+def test_compute_languages_needed_includes_safe_jvm_ci_workflow_toolchains():
+    packages = [
+        Package(
+            name="python/logic-gates",
+            path=Path("/repo/code/packages/python/logic-gates"),
+            build_commands=[],
+            language="python",
+        )
+    ]
+
+    needed = _compute_languages_needed(
+        packages,
+        {"python/logic-gates"},
+        False,
+        frozenset({"java", "kotlin"}),
+    )
+
+    assert needed["go"] is True
+    assert needed["python"] is True
+    assert needed["java"] is True
+    assert needed["kotlin"] is True
+    assert needed["dotnet"] is False

--- a/code/programs/ruby/build-tool/build.rb
+++ b/code/programs/ruby/build-tool/build.rb
@@ -69,7 +69,9 @@ module BuildTool
     ALL_LANGUAGES = %w[python ruby go typescript rust elixir lua perl swift haskell].freeze
 
     # ALL_TOOLCHAINS is the canonical list of CI toolchains we can request.
-    ALL_TOOLCHAINS = (ALL_LANGUAGES + ["dotnet"]).freeze
+    ALL_TOOLCHAINS = %w[
+      python ruby go typescript rust elixir lua perl swift java kotlin haskell dotnet
+    ].freeze
 
     # SHARED_PREFIXES are repo paths that, when changed, still mean every
     # toolchain needs rebuilding. ci.yml is handled separately via patch

--- a/code/programs/ruby/build-tool/lib/build_tool/ci_workflow.rb
+++ b/code/programs/ruby/build-tool/lib/build_tool/ci_workflow.rb
@@ -8,7 +8,9 @@ module BuildTool
     module_function
 
     CI_WORKFLOW_PATH = ".github/workflows/ci.yml"
-    ALL_TOOLCHAINS = (%w[python ruby go typescript rust elixir lua perl swift haskell] + ["dotnet"]).freeze
+    ALL_TOOLCHAINS = %w[
+      python ruby go typescript rust elixir lua perl swift java kotlin haskell dotnet
+    ].freeze
 
     Change = Data.define(:toolchains, :requires_full_rebuild)
 
@@ -48,6 +50,18 @@ module BuildTool
       "haskell" => [
         "needs_haskell", "haskell-actions/setup", "ghc-version", "cabal-version",
         "ghc --version", "cabal --version", "set up haskell"
+      ],
+      "java" => [
+        "needs_java", "setup-java", "java-version", "java --version",
+        "temurin", "set up jdk", "set up gradle", "setup-gradle",
+        "disable long-lived gradle services",
+        "gradle_opts", "org.gradle.daemon", "org.gradle.vfs.watch"
+      ],
+      "kotlin" => [
+        "needs_kotlin", "setup-java", "java-version",
+        "temurin", "set up jdk", "set up gradle", "setup-gradle",
+        "disable long-lived gradle services",
+        "gradle_opts", "org.gradle.daemon", "org.gradle.vfs.watch"
       ],
       "dotnet" => [
         "needs_dotnet", "setup-dotnet", "dotnet-version", "dotnet --version",
@@ -179,7 +193,7 @@ module BuildTool
 
     def toolchain_scoped_structural_line?(content)
       content.start_with?(
-        "if:", "run:", "shell:", "with:", "env:", "else", "fi", "then",
+        "if:", "run:", "shell:", "with:", "env:", "{", "}", "else", "fi", "then",
         "printf ", "echo ", "curl ", "powershell ", "call ", "cd "
       )
     end

--- a/code/programs/ruby/build-tool/lib/build_tool/validator.rb
+++ b/code/programs/ruby/build-tool/lib/build_tool/validator.rb
@@ -15,6 +15,8 @@ module BuildTool
       "elixir",
       "lua",
       "perl",
+      "java",
+      "kotlin",
       "haskell"
     ].freeze
 

--- a/code/programs/ruby/build-tool/test/test_ci_workflow.rb
+++ b/code/programs/ruby/build-tool/test/test_ci_workflow.rb
@@ -17,6 +17,31 @@ class TestCIWorkflow < Minitest::Test
     assert_equal ["dotnet"], BuildTool::CIWorkflow.sorted_toolchains(change.toolchains)
   end
 
+  def test_analyze_patch_allows_shared_jvm_toolchain_changes
+    change = BuildTool::CIWorkflow.analyze_patch(<<~PATCH)
+      @@ -314,0 +315,17 @@
+      +      - name: Set up JDK 21
+      +        if: needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true'
+      +        uses: actions/setup-java@v4
+      +        with:
+      +          distribution: 'temurin'
+      +          java-version: '21'
+      +      - name: Set up Gradle
+      +        if: needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true'
+      +        uses: gradle/actions/setup-gradle@v4
+      +      - name: Disable long-lived Gradle services on Windows CI
+      +        if: (needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true') && runner.os == 'Windows'
+      +        shell: bash
+      +        run: |
+      +          {
+      +            echo 'GRADLE_OPTS=-Dorg.gradle.daemon=false -Dorg.gradle.vfs.watch=false'
+      +          } >> "$GITHUB_ENV"
+    PATCH
+
+    refute change.requires_full_rebuild
+    assert_equal ["java", "kotlin"], BuildTool::CIWorkflow.sorted_toolchains(change.toolchains)
+  end
+
   def test_analyze_patch_ignores_comment_only_changes
     change = BuildTool::CIWorkflow.analyze_patch(<<~PATCH)
       @@ -316,2 +316,2 @@

--- a/code/programs/rust/build-tool/src/ci_workflow.rs
+++ b/code/programs/rust/build-tool/src/ci_workflow.rs
@@ -116,6 +116,39 @@ const TOOLCHAIN_MARKERS: &[(&str, &[&str])] = &[
         ],
     ),
     (
+        "java",
+        &[
+            "needs_java",
+            "setup-java",
+            "java-version",
+            "java --version",
+            "temurin",
+            "set up jdk",
+            "set up gradle",
+            "setup-gradle",
+            "disable long-lived gradle services",
+            "gradle_opts",
+            "org.gradle.daemon",
+            "org.gradle.vfs.watch",
+        ],
+    ),
+    (
+        "kotlin",
+        &[
+            "needs_kotlin",
+            "setup-java",
+            "java-version",
+            "temurin",
+            "set up jdk",
+            "set up gradle",
+            "setup-gradle",
+            "disable long-lived gradle services",
+            "gradle_opts",
+            "org.gradle.daemon",
+            "org.gradle.vfs.watch",
+        ],
+    ),
+    (
         "dotnet",
         &[
             "needs_dotnet",
@@ -290,6 +323,8 @@ fn is_toolchain_scoped_structural_line(content: &str) -> bool {
         "shell:",
         "with:",
         "env:",
+        "{",
+        "}",
         "else",
         "fi",
         "then",
@@ -364,6 +399,34 @@ mod tests {
 
         assert!(!change.requires_full_rebuild);
         assert_eq!(sorted_toolchains(&change.toolchains), vec!["dotnet"]);
+    }
+
+    #[test]
+    fn test_analyze_ci_workflow_patch_allows_shared_jvm_toolchain_changes() {
+        let change = analyze_ci_workflow_patch(
+            r#"
+@@ -314,0 +315,17 @@
++      - name: Set up JDK 21
++        if: needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true'
++        uses: actions/setup-java@v4
++        with:
++          distribution: 'temurin'
++          java-version: '21'
++      - name: Set up Gradle
++        if: needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true'
++        uses: gradle/actions/setup-gradle@v4
++      - name: Disable long-lived Gradle services on Windows CI
++        if: (needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true') && runner.os == 'Windows'
++        shell: bash
++        run: |
++          {
++            echo 'GRADLE_OPTS=-Dorg.gradle.daemon=false -Dorg.gradle.vfs.watch=false'
++          } >> "$GITHUB_ENV"
+"#,
+        );
+
+        assert!(!change.requires_full_rebuild);
+        assert_eq!(sorted_toolchains(&change.toolchains), vec!["java", "kotlin"]);
     }
 
     #[test]

--- a/code/programs/rust/build-tool/src/validator.rs
+++ b/code/programs/rust/build-tool/src/validator.rs
@@ -12,6 +12,8 @@ const CI_MANAGED_TOOLCHAIN_LANGUAGES: &[&str] = &[
     "elixir",
     "lua",
     "perl",
+    "java",
+    "kotlin",
     "haskell",
 ];
 

--- a/code/programs/swift/build-tool/Sources/BuildToolCore/CIWorkflow.swift
+++ b/code/programs/swift/build-tool/Sources/BuildToolCore/CIWorkflow.swift
@@ -46,6 +46,18 @@ public enum CIWorkflow {
             "needs_haskell", "haskell-actions/setup", "ghc-version", "cabal-version",
             "ghc --version", "cabal --version", "set up haskell",
         ],
+        "java": [
+            "needs_java", "setup-java", "java-version", "java --version",
+            "temurin", "set up jdk", "set up gradle", "setup-gradle",
+            "disable long-lived gradle services",
+            "gradle_opts", "org.gradle.daemon", "org.gradle.vfs.watch",
+        ],
+        "kotlin": [
+            "needs_kotlin", "setup-java", "java-version",
+            "temurin", "set up jdk", "set up gradle", "setup-gradle",
+            "disable long-lived gradle services",
+            "gradle_opts", "org.gradle.daemon", "org.gradle.vfs.watch",
+        ],
         "dotnet": [
             "needs_dotnet", "setup-dotnet", "dotnet-version", "dotnet --version",
             "set up .net",
@@ -201,6 +213,8 @@ public enum CIWorkflow {
             "shell:",
             "with:",
             "env:",
+            "{",
+            "}",
             "else",
             "fi",
             "then",

--- a/code/programs/swift/build-tool/Sources/BuildToolCore/Models.swift
+++ b/code/programs/swift/build-tool/Sources/BuildToolCore/Models.swift
@@ -253,7 +253,21 @@ public let allLanguages = [
     "haskell",
 ]
 
-public let allToolchains = allLanguages + ["dotnet"]
+public let allToolchains = [
+    "python",
+    "ruby",
+    "go",
+    "typescript",
+    "rust",
+    "elixir",
+    "lua",
+    "perl",
+    "swift",
+    "java",
+    "kotlin",
+    "haskell",
+    "dotnet",
+]
 
 public let sharedPrefixes: [String] = []
 

--- a/code/programs/swift/build-tool/Sources/BuildToolCore/Validator.swift
+++ b/code/programs/swift/build-tool/Sources/BuildToolCore/Validator.swift
@@ -9,6 +9,8 @@ public enum Validator {
         "elixir",
         "lua",
         "perl",
+        "java",
+        "kotlin",
         "haskell",
     ]
 

--- a/code/programs/swift/build-tool/Tests/BuildToolCoreTests/CIWorkflowTests.swift
+++ b/code/programs/swift/build-tool/Tests/BuildToolCoreTests/CIWorkflowTests.swift
@@ -20,6 +20,34 @@ struct CIWorkflowTests {
     }
 
     @Test
+    func analyzePatchAllowsSharedJVMToolchainChanges() {
+        let change = CIWorkflow.analyzePatch(
+            """
+            @@ -314,0 +315,17 @@
+            +      - name: Set up JDK 21
+            +        if: needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true'
+            +        uses: actions/setup-java@v4
+            +        with:
+            +          distribution: 'temurin'
+            +          java-version: '21'
+            +      - name: Set up Gradle
+            +        if: needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true'
+            +        uses: gradle/actions/setup-gradle@v4
+            +      - name: Disable long-lived Gradle services on Windows CI
+            +        if: (needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true') && runner.os == 'Windows'
+            +        shell: bash
+            +        run: |
+            +          {
+            +            echo 'GRADLE_OPTS=-Dorg.gradle.daemon=false -Dorg.gradle.vfs.watch=false'
+            +          } >> "$GITHUB_ENV"
+            """
+        )
+
+        #expect(change.requiresFullRebuild == false)
+        #expect(CIWorkflow.sortedToolchains(change.toolchains) == ["java", "kotlin"])
+    }
+
+    @Test
     func analyzePatchIgnoresCommentOnlyChanges() {
         let change = CIWorkflow.analyzePatch(
             """

--- a/code/programs/typescript/build-tool/src/ci-workflow.ts
+++ b/code/programs/typescript/build-tool/src/ci-workflow.ts
@@ -40,6 +40,18 @@ const TOOLCHAIN_MARKERS: Record<string, string[]> = {
     "needs_haskell", "haskell-actions/setup", "ghc-version", "cabal-version",
     "ghc --version", "cabal --version", "set up haskell",
   ],
+  java: [
+    "needs_java", "setup-java", "java-version", "java --version",
+    "temurin", "set up jdk", "set up gradle", "setup-gradle",
+    "disable long-lived gradle services",
+    "gradle_opts", "org.gradle.daemon", "org.gradle.vfs.watch",
+  ],
+  kotlin: [
+    "needs_kotlin", "setup-java", "java-version",
+    "temurin", "set up jdk", "set up gradle", "setup-gradle",
+    "disable long-lived gradle services",
+    "gradle_opts", "org.gradle.daemon", "org.gradle.vfs.watch",
+  ],
   dotnet: [
     "needs_dotnet", "setup-dotnet", "dotnet-version", "dotnet --version",
     "set up .net",
@@ -208,6 +220,8 @@ function isToolchainScopedStructuralLine(content: string): boolean {
     "shell:",
     "with:",
     "env:",
+    "{",
+    "}",
     "else",
     "fi",
     "then",

--- a/code/programs/typescript/build-tool/src/index.ts
+++ b/code/programs/typescript/build-tool/src/index.ts
@@ -60,6 +60,8 @@ const ALL_TOOLCHAINS = [
   "lua",
   "perl",
   "swift",
+  "java",
+  "kotlin",
   "haskell",
   "dotnet",
 ];

--- a/code/programs/typescript/build-tool/src/validator.ts
+++ b/code/programs/typescript/build-tool/src/validator.ts
@@ -10,6 +10,8 @@ const CI_MANAGED_TOOLCHAIN_LANGUAGES = new Set([
   "elixir",
   "lua",
   "perl",
+  "java",
+  "kotlin",
   "haskell",
 ]);
 

--- a/code/programs/typescript/build-tool/tests/ci-workflow.test.ts
+++ b/code/programs/typescript/build-tool/tests/ci-workflow.test.ts
@@ -19,6 +19,31 @@ describe("analyzeCIWorkflowPatch", () => {
     expect(sortedToolchains(change.toolchains)).toEqual(["dotnet"]);
   });
 
+  it("allows shared jvm toolchain changes", () => {
+    const change = analyzeCIWorkflowPatch(`
+@@ -314,0 +315,17 @@
++      - name: Set up JDK 21
++        if: needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true'
++        uses: actions/setup-java@v4
++        with:
++          distribution: 'temurin'
++          java-version: '21'
++      - name: Set up Gradle
++        if: needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true'
++        uses: gradle/actions/setup-gradle@v4
++      - name: Disable long-lived Gradle services on Windows CI
++        if: (needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true') && runner.os == 'Windows'
++        shell: bash
++        run: |
++          {
++            echo 'GRADLE_OPTS=-Dorg.gradle.daemon=false -Dorg.gradle.vfs.watch=false'
++          } >> "$GITHUB_ENV"
+`);
+
+    expect(change.requiresFullRebuild).toBe(false);
+    expect(sortedToolchains(change.toolchains)).toEqual(["java", "kotlin"]);
+  });
+
   it("ignores comment-only changes", () => {
     const change = analyzeCIWorkflowPatch(`
 @@ -316,2 +316,2 @@


### PR DESCRIPTION
## Summary
- port the JVM-safe `ci.yml` workflow classification to the Python, Ruby, TypeScript, Swift, Rust, Elixir, and Perl build-tool implementations
- widen the CI toolchain lists so `needs_java` and `needs_kotlin` are emitted in the implementations that expose `--detect-languages`
- add regression tests for JDK/Gradle workflow hunks, including the Windows Gradle env block with scoped structural lines

## Validation
- `PYTHONPATH=src python3 -m pytest -o addopts='' tests/test_ci_workflow.py`
- `/Users/adhithya/.local/share/mise/installs/ruby/3.4.9/bin/ruby -S rake test`
- `npm test -- --run tests/ci-workflow.test.ts`
- `swift test --filter CIWorkflowTests`
- `cargo test ci_workflow`
- `mix test test/ci_workflow_test.exs`
- `prove -Ilib t/12-ci-workflow.t`