### PR TITLE
feat(java): rescue foundational grammar, lexer, parser, and document AST packages

### DIFF
--- a/code/packages/java/document-ast/.gitignore
+++ b/code/packages/java/document-ast/.gitignore
@@ -1,0 +1,2 @@
+gradle-build/
+.gradle/

--- a/code/packages/java/document-ast/BUILD
+++ b/code/packages/java/document-ast/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/document-ast/BUILD_windows
+++ b/code/packages/java/document-ast/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/document-ast/CHANGELOG.md
+++ b/code/packages/java/document-ast/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.1.0 — 2026-04-04
+
+### Added
+- Sealed interface hierarchy: Node, BlockNode, InlineNode
+- 13 block node types: Document, Heading, Paragraph, CodeBlock, Blockquote, List, ListItem, TaskItem, ThematicBreak, RawBlock, Table, TableRow, TableCell
+- 11 inline node types: Text, Emphasis, Strong, Strikethrough, CodeSpan, Link, Image, Autolink, RawInline, HardBreak, SoftBreak
+- TableAlignment enum
+- Full test suite with type tests and structural tests

--- a/code/packages/java/document-ast/README.md
+++ b/code/packages/java/document-ast/README.md
@@ -1,0 +1,30 @@
+# document-ast (Java)
+
+Universal document IR (intermediate representation) types for the coding-adventures project.
+
+## What it does
+
+Defines the Document AST type hierarchy — the format-agnostic IR for structured documents. Block nodes form the structural skeleton; inline nodes carry prose content.
+
+### Block nodes
+DocumentNode, HeadingNode, ParagraphNode, CodeBlockNode, BlockquoteNode, ListNode, ListItemNode, TaskItemNode, ThematicBreakNode, RawBlockNode, TableNode, TableRowNode, TableCellNode
+
+### Inline nodes
+TextNode, EmphasisNode, StrongNode, StrikethroughNode, CodeSpanNode, LinkNode, ImageNode, AutolinkNode, RawInlineNode, HardBreakNode, SoftBreakNode
+
+## Usage
+
+```java
+import com.codingadventures.documentast.*;
+
+var doc = new BlockNode.DocumentNode(List.of(
+    new BlockNode.HeadingNode(1, List.of(new InlineNode.TextNode("Hello"))),
+    new BlockNode.ParagraphNode(List.of(new InlineNode.TextNode("World")))
+));
+```
+
+Uses Java sealed interfaces for exhaustive pattern matching.
+
+## Layer
+
+TE00 (text/language layer — document IR). Leaf package, zero dependencies.

--- a/code/packages/java/document-ast/build.gradle.kts
+++ b/code/packages/java/document-ast/build.gradle.kts
@@ -1,0 +1,28 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/document-ast/settings.gradle.kts
+++ b/code/packages/java/document-ast/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "document-ast"

--- a/code/packages/java/document-ast/src/main/java/com/codingadventures/documentast/BlockNode.java
+++ b/code/packages/java/document-ast/src/main/java/com/codingadventures/documentast/BlockNode.java
@@ -1,0 +1,96 @@
+// ============================================================================
+// BlockNode.java — Block-level document AST nodes
+// ============================================================================
+
+package com.codingadventures.documentast;
+
+import java.util.List;
+
+/**
+ * Block-level nodes form the structural skeleton of a document.
+ * They live inside DocumentNode, BlockquoteNode, and ListItemNode.
+ */
+public sealed interface BlockNode extends Node
+        permits BlockNode.DocumentNode, BlockNode.HeadingNode, BlockNode.ParagraphNode,
+                BlockNode.CodeBlockNode, BlockNode.BlockquoteNode, BlockNode.ListNode,
+                BlockNode.ListItemNode, BlockNode.TaskItemNode, BlockNode.ThematicBreakNode,
+                BlockNode.RawBlockNode, BlockNode.TableNode, BlockNode.TableRowNode,
+                BlockNode.TableCellNode {
+
+    /** Root of every document. An empty document has an empty children list. */
+    record DocumentNode(List<BlockNode> children) implements BlockNode {
+        @Override public String nodeType() { return "document"; }
+    }
+
+    /** Section heading with nesting depth 1-6. */
+    record HeadingNode(int level, List<InlineNode> children) implements BlockNode {
+        @Override public String nodeType() { return "heading"; }
+    }
+
+    /** A block of prose containing inline nodes. */
+    record ParagraphNode(List<InlineNode> children) implements BlockNode {
+        @Override public String nodeType() { return "paragraph"; }
+    }
+
+    /** A block of literal code or pre-formatted text. */
+    record CodeBlockNode(String language, String value) implements BlockNode {
+        @Override public String nodeType() { return "code_block"; }
+    }
+
+    /** A block of content set apart as a quotation. Can contain nested blocks. */
+    record BlockquoteNode(List<BlockNode> children) implements BlockNode {
+        @Override public String nodeType() { return "blockquote"; }
+    }
+
+    /**
+     * An ordered or unordered list.
+     *
+     * @param ordered true for numbered lists
+     * @param start   opening number for ordered lists (default 1; 0 for unordered)
+     * @param tight   true if no blank lines between items (rendering hint)
+     */
+    record ListNode(boolean ordered, int start, boolean tight,
+                    List<BlockNode> children) implements BlockNode {
+        @Override public String nodeType() { return "list"; }
+    }
+
+    /** One item in a ListNode. Contains block-level content. */
+    record ListItemNode(List<BlockNode> children) implements BlockNode {
+        @Override public String nodeType() { return "list_item"; }
+    }
+
+    /** A task-list item with a checkbox state. */
+    record TaskItemNode(boolean checked, List<BlockNode> children) implements BlockNode {
+        @Override public String nodeType() { return "task_item"; }
+    }
+
+    /** A horizontal rule / thematic break. Leaf node, no children. */
+    record ThematicBreakNode() implements BlockNode {
+        @Override public String nodeType() { return "thematic_break"; }
+    }
+
+    /**
+     * Raw content for a specific back-end (e.g. "html", "latex").
+     * Back-ends that don't recognise the format skip this node silently.
+     */
+    record RawBlockNode(String format, String value) implements BlockNode {
+        @Override public String nodeType() { return "raw_block"; }
+    }
+
+    /** A table with column alignments and rows. */
+    record TableNode(List<TableAlignment> align,
+                     List<TableRowNode> rows) implements BlockNode {
+        @Override public String nodeType() { return "table"; }
+    }
+
+    /** One row in a table. */
+    record TableRowNode(boolean isHeader,
+                        List<TableCellNode> cells) implements BlockNode {
+        @Override public String nodeType() { return "table_row"; }
+    }
+
+    /** A single table cell containing inline content. */
+    record TableCellNode(List<InlineNode> children) implements BlockNode {
+        @Override public String nodeType() { return "table_cell"; }
+    }
+}

--- a/code/packages/java/document-ast/src/main/java/com/codingadventures/documentast/InlineNode.java
+++ b/code/packages/java/document-ast/src/main/java/com/codingadventures/documentast/InlineNode.java
@@ -1,0 +1,90 @@
+// ============================================================================
+// InlineNode.java — Inline document AST nodes
+// ============================================================================
+
+package com.codingadventures.documentast;
+
+import java.util.List;
+
+/**
+ * Inline nodes appear inside block nodes that contain prose:
+ * headings, paragraphs, list items, and table cells.
+ */
+public sealed interface InlineNode extends Node
+        permits InlineNode.TextNode, InlineNode.EmphasisNode, InlineNode.StrongNode,
+                InlineNode.StrikethroughNode, InlineNode.CodeSpanNode, InlineNode.LinkNode,
+                InlineNode.ImageNode, InlineNode.AutolinkNode, InlineNode.RawInlineNode,
+                InlineNode.HardBreakNode, InlineNode.SoftBreakNode {
+
+    /** Plain text with no markup. Value contains decoded Unicode. */
+    record TextNode(String value) implements InlineNode {
+        @Override public String nodeType() { return "text"; }
+    }
+
+    /** Stressed emphasis — renders as <em> / italic. */
+    record EmphasisNode(List<InlineNode> children) implements InlineNode {
+        @Override public String nodeType() { return "emphasis"; }
+    }
+
+    /** Strong importance — renders as <strong> / bold. */
+    record StrongNode(List<InlineNode> children) implements InlineNode {
+        @Override public String nodeType() { return "strong"; }
+    }
+
+    /** Struck-through text. */
+    record StrikethroughNode(List<InlineNode> children) implements InlineNode {
+        @Override public String nodeType() { return "strikethrough"; }
+    }
+
+    /** Inline code span. Value is raw, not decoded for HTML entities. */
+    record CodeSpanNode(String value) implements InlineNode {
+        @Override public String nodeType() { return "code_span"; }
+    }
+
+    /**
+     * A hyperlink with resolved destination.
+     *
+     * @param destination fully resolved URL
+     * @param title       optional tooltip text (null if absent)
+     */
+    record LinkNode(String destination, String title,
+                    List<InlineNode> children) implements InlineNode {
+        @Override public String nodeType() { return "link"; }
+    }
+
+    /**
+     * An embedded image.
+     *
+     * @param destination fully resolved URL
+     * @param title       optional tooltip text (null if absent)
+     * @param alt          plain-text alt description (markup stripped)
+     */
+    record ImageNode(String destination, String title, String alt) implements InlineNode {
+        @Override public String nodeType() { return "image"; }
+    }
+
+    /**
+     * A URL or email address presented as a direct link.
+     *
+     * @param destination the URL or email address
+     * @param isEmail     true for email autolinks
+     */
+    record AutolinkNode(String destination, boolean isEmail) implements InlineNode {
+        @Override public String nodeType() { return "autolink"; }
+    }
+
+    /** Raw inline content for a specific back-end format. */
+    record RawInlineNode(String format, String value) implements InlineNode {
+        @Override public String nodeType() { return "raw_inline"; }
+    }
+
+    /** Forced line break within a paragraph. */
+    record HardBreakNode() implements InlineNode {
+        @Override public String nodeType() { return "hard_break"; }
+    }
+
+    /** Soft line break — a newline that is not a hard break. */
+    record SoftBreakNode() implements InlineNode {
+        @Override public String nodeType() { return "soft_break"; }
+    }
+}

--- a/code/packages/java/document-ast/src/main/java/com/codingadventures/documentast/Node.java
+++ b/code/packages/java/document-ast/src/main/java/com/codingadventures/documentast/Node.java
@@ -1,0 +1,59 @@
+// ============================================================================
+// Node.java — Document AST node type hierarchy
+// ============================================================================
+//
+// The Document AST is the "LLVM IR of documents" — a format-agnostic
+// intermediate representation for structured documents. Just as LLVM IR sits
+// between many source languages and many targets, the Document AST sits
+// between document source formats (Markdown, RST, HTML) and output renderers
+// (HTML, PDF, plain text):
+//
+//   Markdown ──────────────────────────────► HTML
+//   reStructuredText ──► Document AST ──────► PDF
+//   HTML ───────────────────────────────────► Plain text
+//
+// With this shared IR, N front-ends x M back-ends requires only N+M
+// implementations instead of N*M.
+//
+// Design principles:
+//
+//   1. Semantic, not notational — nodes carry meaning (heading, emphasis),
+//      not syntax (### or ***).
+//
+//   2. Resolved, not deferred — all link references are resolved before
+//      the IR is produced.
+//
+//   3. Format-agnostic — RawBlock and RawInline carry a format tag so
+//      back-ends can selectively pass through or ignore content.
+//
+//   4. Minimal and stable — only universal document concepts appear here.
+//
+// The type hierarchy uses sealed interfaces for exhaustive pattern matching
+// in Java 21+:
+//
+//   Node (sealed)
+//     BlockNode (sealed) — structural nodes
+//       DocumentNode, HeadingNode, ParagraphNode, CodeBlockNode,
+//       BlockquoteNode, ListNode, ListItemNode, TaskItemNode,
+//       ThematicBreakNode, RawBlockNode, TableNode, TableRowNode, TableCellNode
+//     InlineNode (sealed) — inline content nodes
+//       TextNode, EmphasisNode, StrongNode, StrikethroughNode,
+//       CodeSpanNode, LinkNode, ImageNode, AutolinkNode,
+//       RawInlineNode, HardBreakNode, SoftBreakNode
+//
+// Layer: TE00 (text/language layer — document IR)
+// ============================================================================
+
+package com.codingadventures.documentast;
+
+/**
+ * Root interface for all Document AST nodes.
+ *
+ * <p>Use pattern matching (instanceof or switch) to access concrete types.
+ */
+public sealed interface Node
+        permits BlockNode, InlineNode {
+
+    /** Returns a string tag for the node type (e.g. "heading", "paragraph"). */
+    String nodeType();
+}

--- a/code/packages/java/document-ast/src/main/java/com/codingadventures/documentast/TableAlignment.java
+++ b/code/packages/java/document-ast/src/main/java/com/codingadventures/documentast/TableAlignment.java
@@ -1,0 +1,15 @@
+// ============================================================================
+// TableAlignment.java — Column alignment for GFM tables
+// ============================================================================
+
+package com.codingadventures.documentast;
+
+/**
+ * Column alignment hint for table cells.
+ */
+public enum TableAlignment {
+    NONE,
+    LEFT,
+    RIGHT,
+    CENTER
+}

--- a/code/packages/java/document-ast/src/test/java/com/codingadventures/documentast/DocumentAstTest.java
+++ b/code/packages/java/document-ast/src/test/java/com/codingadventures/documentast/DocumentAstTest.java
@@ -1,0 +1,249 @@
+package com.codingadventures.documentast;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Nested;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DocumentAstTest {
+
+    @Nested
+    class NodeTypeTests {
+
+        @Test void documentNodeType() {
+            var node = new BlockNode.DocumentNode(List.of());
+            assertEquals("document", node.nodeType());
+        }
+
+        @Test void headingNodeType() {
+            var node = new BlockNode.HeadingNode(1, List.of(new InlineNode.TextNode("Title")));
+            assertEquals("heading", node.nodeType());
+            assertEquals(1, node.level());
+        }
+
+        @Test void paragraphNodeType() {
+            var node = new BlockNode.ParagraphNode(List.of(new InlineNode.TextNode("Hello")));
+            assertEquals("paragraph", node.nodeType());
+        }
+
+        @Test void codeBlockNodeType() {
+            var node = new BlockNode.CodeBlockNode("java", "int x = 1;\n");
+            assertEquals("code_block", node.nodeType());
+            assertEquals("java", node.language());
+        }
+
+        @Test void blockquoteNodeType() {
+            var node = new BlockNode.BlockquoteNode(List.of());
+            assertEquals("blockquote", node.nodeType());
+        }
+
+        @Test void listNodeType() {
+            var node = new BlockNode.ListNode(true, 1, false, List.of());
+            assertEquals("list", node.nodeType());
+            assertTrue(node.ordered());
+        }
+
+        @Test void listItemNodeType() {
+            var node = new BlockNode.ListItemNode(List.of());
+            assertEquals("list_item", node.nodeType());
+        }
+
+        @Test void taskItemNodeType() {
+            var node = new BlockNode.TaskItemNode(true, List.of());
+            assertEquals("task_item", node.nodeType());
+            assertTrue(node.checked());
+        }
+
+        @Test void thematicBreakNodeType() {
+            var node = new BlockNode.ThematicBreakNode();
+            assertEquals("thematic_break", node.nodeType());
+        }
+
+        @Test void rawBlockNodeType() {
+            var node = new BlockNode.RawBlockNode("html", "<div>raw</div>");
+            assertEquals("raw_block", node.nodeType());
+            assertEquals("html", node.format());
+        }
+
+        @Test void tableNodeType() {
+            var node = new BlockNode.TableNode(List.of(), List.of());
+            assertEquals("table", node.nodeType());
+        }
+
+        @Test void tableRowNodeType() {
+            var node = new BlockNode.TableRowNode(true, List.of());
+            assertEquals("table_row", node.nodeType());
+            assertTrue(node.isHeader());
+        }
+
+        @Test void tableCellNodeType() {
+            var node = new BlockNode.TableCellNode(List.of());
+            assertEquals("table_cell", node.nodeType());
+        }
+
+        @Test void textNodeType() {
+            var node = new InlineNode.TextNode("hello");
+            assertEquals("text", node.nodeType());
+            assertEquals("hello", node.value());
+        }
+
+        @Test void emphasisNodeType() {
+            var node = new InlineNode.EmphasisNode(List.of(new InlineNode.TextNode("em")));
+            assertEquals("emphasis", node.nodeType());
+        }
+
+        @Test void strongNodeType() {
+            var node = new InlineNode.StrongNode(List.of(new InlineNode.TextNode("bold")));
+            assertEquals("strong", node.nodeType());
+        }
+
+        @Test void strikethroughNodeType() {
+            var node = new InlineNode.StrikethroughNode(List.of(new InlineNode.TextNode("del")));
+            assertEquals("strikethrough", node.nodeType());
+        }
+
+        @Test void codeSpanNodeType() {
+            var node = new InlineNode.CodeSpanNode("x = 1");
+            assertEquals("code_span", node.nodeType());
+        }
+
+        @Test void linkNodeType() {
+            var node = new InlineNode.LinkNode("https://example.com", "Example",
+                    List.of(new InlineNode.TextNode("click")));
+            assertEquals("link", node.nodeType());
+            assertEquals("https://example.com", node.destination());
+        }
+
+        @Test void imageNodeType() {
+            var node = new InlineNode.ImageNode("cat.png", null, "a cat");
+            assertEquals("image", node.nodeType());
+            assertEquals("a cat", node.alt());
+        }
+
+        @Test void autolinkNodeType() {
+            var node = new InlineNode.AutolinkNode("https://example.com", false);
+            assertEquals("autolink", node.nodeType());
+            assertFalse(node.isEmail());
+        }
+
+        @Test void autolinkEmail() {
+            var node = new InlineNode.AutolinkNode("user@example.com", true);
+            assertTrue(node.isEmail());
+        }
+
+        @Test void rawInlineNodeType() {
+            var node = new InlineNode.RawInlineNode("html", "<em>raw</em>");
+            assertEquals("raw_inline", node.nodeType());
+        }
+
+        @Test void hardBreakNodeType() {
+            var node = new InlineNode.HardBreakNode();
+            assertEquals("hard_break", node.nodeType());
+        }
+
+        @Test void softBreakNodeType() {
+            var node = new InlineNode.SoftBreakNode();
+            assertEquals("soft_break", node.nodeType());
+        }
+    }
+
+    @Nested
+    class DocumentStructureTests {
+
+        @Test void simpleDocument() {
+            var doc = new BlockNode.DocumentNode(List.of(
+                    new BlockNode.HeadingNode(1, List.of(new InlineNode.TextNode("Hello"))),
+                    new BlockNode.ParagraphNode(List.of(new InlineNode.TextNode("World")))
+            ));
+            assertEquals(2, doc.children().size());
+            assertInstanceOf(BlockNode.HeadingNode.class, doc.children().get(0));
+            assertInstanceOf(BlockNode.ParagraphNode.class, doc.children().get(1));
+        }
+
+        @Test void nestedBlockquote() {
+            var quote = new BlockNode.BlockquoteNode(List.of(
+                    new BlockNode.ParagraphNode(List.of(new InlineNode.TextNode("quoted"))),
+                    new BlockNode.BlockquoteNode(List.of(
+                            new BlockNode.ParagraphNode(List.of(new InlineNode.TextNode("nested")))
+                    ))
+            ));
+            assertEquals(2, quote.children().size());
+        }
+
+        @Test void orderedList() {
+            var list = new BlockNode.ListNode(true, 3, false, List.of(
+                    new BlockNode.ListItemNode(List.of(
+                            new BlockNode.ParagraphNode(List.of(new InlineNode.TextNode("item 3")))
+                    )),
+                    new BlockNode.ListItemNode(List.of(
+                            new BlockNode.ParagraphNode(List.of(new InlineNode.TextNode("item 4")))
+                    ))
+            ));
+            assertTrue(list.ordered());
+            assertEquals(3, list.start());
+        }
+
+        @Test void tightUnorderedList() {
+            var list = new BlockNode.ListNode(false, 0, true, List.of(
+                    new BlockNode.ListItemNode(List.of(
+                            new BlockNode.ParagraphNode(List.of(new InlineNode.TextNode("a")))
+                    ))
+            ));
+            assertFalse(list.ordered());
+            assertTrue(list.tight());
+        }
+
+        @Test void richInlineContent() {
+            var para = new BlockNode.ParagraphNode(List.of(
+                    new InlineNode.TextNode("Hello "),
+                    new InlineNode.StrongNode(List.of(
+                            new InlineNode.TextNode("bold "),
+                            new InlineNode.EmphasisNode(List.of(new InlineNode.TextNode("and italic")))
+                    )),
+                    new InlineNode.TextNode(".")
+            ));
+            assertEquals(3, para.children().size());
+        }
+
+        @Test void tableStructure() {
+            var table = new BlockNode.TableNode(
+                    List.of(TableAlignment.LEFT, TableAlignment.RIGHT),
+                    List.of(
+                            new BlockNode.TableRowNode(true, List.of(
+                                    new BlockNode.TableCellNode(List.of(new InlineNode.TextNode("Name"))),
+                                    new BlockNode.TableCellNode(List.of(new InlineNode.TextNode("Score")))
+                            )),
+                            new BlockNode.TableRowNode(false, List.of(
+                                    new BlockNode.TableCellNode(List.of(new InlineNode.TextNode("Alice"))),
+                                    new BlockNode.TableCellNode(List.of(new InlineNode.TextNode("100")))
+                            ))
+                    )
+            );
+            assertEquals(2, table.align().size());
+            assertEquals(2, table.rows().size());
+            assertTrue(table.rows().get(0).isHeader());
+            assertFalse(table.rows().get(1).isHeader());
+        }
+
+        @Test void patternMatchingOnNodes() {
+            Node node = new InlineNode.TextNode("hello");
+            String result = switch (node) {
+                case BlockNode b -> "block: " + b.nodeType();
+                case InlineNode.TextNode t -> "text: " + t.value();
+                case InlineNode i -> "inline: " + i.nodeType();
+            };
+            assertEquals("text: hello", result);
+        }
+
+        @Test void patternMatchingOnBlockNode() {
+            BlockNode node = new BlockNode.HeadingNode(2, List.of(new InlineNode.TextNode("Title")));
+            String result = switch (node) {
+                case BlockNode.HeadingNode h -> "h" + h.level();
+                default -> "other";
+            };
+            assertEquals("h2", result);
+        }
+    }
+}

--- a/code/packages/java/grammar-tools/.gitignore
+++ b/code/packages/java/grammar-tools/.gitignore
@@ -1,0 +1,2 @@
+gradle-build/
+.gradle/

--- a/code/packages/java/grammar-tools/BUILD
+++ b/code/packages/java/grammar-tools/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/grammar-tools/BUILD_windows
+++ b/code/packages/java/grammar-tools/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/grammar-tools/CHANGELOG.md
+++ b/code/packages/java/grammar-tools/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## 0.1.0 — 2026-04-04
+
+### Added
+- `TokenGrammarParser` — parses `.tokens` files into `TokenGrammar`
+- `ParserGrammarParser` — parses `.grammar` files into `ParserGrammar`
+- `TokenGrammarValidator` — semantic validation for token grammars
+- `ParserGrammarValidator` — semantic validation for parser grammars
+- `CrossValidator` �� cross-validation between token and parser grammars
+- Support for magic comments (`# @version`, `# @case_insensitive`)
+- Support for all sections: keywords, reserved, skip, errors, context_keywords, groups
+- Support for all EBNF constructs: sequence, alternation, repetition, optional, group, lookaheads, separated repetition
+- Full test suite with 40+ tests

--- a/code/packages/java/grammar-tools/README.md
+++ b/code/packages/java/grammar-tools/README.md
@@ -1,0 +1,32 @@
+# grammar-tools (Java)
+
+Parser and validator for `.tokens` and `.grammar` file formats — the declarative language specifications used throughout the coding-adventures project.
+
+## What it does
+
+- **TokenGrammarParser** — Parses `.tokens` files into a `TokenGrammar` data structure
+- **ParserGrammarParser** — Parses `.grammar` files into a `ParserGrammar` data structure
+- **TokenGrammarValidator** — Lint pass for token grammars (duplicates, invalid regex, naming conventions)
+- **ParserGrammarValidator** — Lint pass for parser grammars (undefined refs, unreachable rules)
+- **CrossValidator** — Checks consistency between a `.tokens` and `.grammar` file pair
+
+## Usage
+
+```java
+import com.codingadventures.grammartools.*;
+
+// Parse a .tokens file
+TokenGrammar tokens = TokenGrammarParser.parse(tokensFileContent);
+List<String> tokenIssues = TokenGrammarValidator.validate(tokens);
+
+// Parse a .grammar file
+ParserGrammar grammar = ParserGrammarParser.parse(grammarFileContent);
+List<String> grammarIssues = ParserGrammarValidator.validate(grammar, tokens.tokenNames());
+
+// Cross-validate
+List<String> crossIssues = CrossValidator.crossValidate(tokens, grammar);
+```
+
+## Layer
+
+TE (text/language layer) — foundational infrastructure for lexer/parser generation.

--- a/code/packages/java/grammar-tools/build.gradle.kts
+++ b/code/packages/java/grammar-tools/build.gradle.kts
@@ -1,0 +1,28 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/grammar-tools/settings.gradle.kts
+++ b/code/packages/java/grammar-tools/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "grammar-tools"

--- a/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/CrossValidator.java
+++ b/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/CrossValidator.java
@@ -1,0 +1,78 @@
+// ============================================================================
+// CrossValidator.java — Cross-validates .tokens and .grammar files
+// ============================================================================
+//
+// The .grammar file references tokens by UPPERCASE name. The .tokens file
+// defines which tokens exist. This module checks that the two are consistent:
+//
+//   1. Every UPPERCASE name in the grammar must be defined in the tokens file.
+//      If not, the parser will try to match a token type the lexer never emits.
+//
+//   2. Every token in the .tokens file should ideally be used somewhere in
+//      the grammar. Unused tokens suggest typos or leftover cruft.
+//
+// Synthetic tokens (NEWLINE, INDENT, DEDENT, EOF) are always valid — the
+// lexer produces these implicitly.
+// ============================================================================
+
+package com.codingadventures.grammartools;
+
+import java.util.*;
+
+/**
+ * Cross-validates a {@link TokenGrammar} and {@link ParserGrammar} for consistency.
+ */
+public final class CrossValidator {
+
+    private CrossValidator() {}
+
+    /**
+     * Check that a TokenGrammar and ParserGrammar are consistent.
+     *
+     * @return list of error/warning strings; empty means fully consistent
+     */
+    public static List<String> crossValidate(TokenGrammar tokenGrammar, ParserGrammar parserGrammar) {
+        List<String> issues = new ArrayList<>();
+
+        // Build the set of all defined token names (including aliases)
+        Set<String> definedTokens = new HashSet<>(tokenGrammar.tokenNames());
+
+        // Add synthetic tokens
+        definedTokens.add("NEWLINE");
+        definedTokens.add("EOF");
+        if ("indentation".equals(tokenGrammar.getMode())) {
+            definedTokens.add("INDENT");
+            definedTokens.add("DEDENT");
+        }
+
+        Set<String> referencedTokens = parserGrammar.tokenReferences();
+
+        // Missing token references (errors)
+        for (String ref : sorted(referencedTokens)) {
+            if (!definedTokens.contains(ref)) {
+                issues.add("Error: Grammar references token '" + ref
+                        + "' which is not defined in the tokens file");
+            }
+        }
+
+        // Unused tokens (warnings)
+        for (TokenDefinition defn : tokenGrammar.getDefinitions()) {
+            boolean isUsed = referencedTokens.contains(defn.getName());
+            if (defn.getAlias() != null && referencedTokens.contains(defn.getAlias())) {
+                isUsed = true;
+            }
+            if (!isUsed) {
+                issues.add("Warning: Token '" + defn.getName() + "' (line " + defn.getLineNumber()
+                        + ") is defined but never used in the grammar");
+            }
+        }
+
+        return issues;
+    }
+
+    private static List<String> sorted(Set<String> set) {
+        List<String> list = new ArrayList<>(set);
+        Collections.sort(list);
+        return list;
+    }
+}

--- a/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/GrammarElement.java
+++ b/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/GrammarElement.java
@@ -1,0 +1,81 @@
+// ============================================================================
+// GrammarElement.java — AST node types for .grammar file EBNF rules
+// ============================================================================
+//
+// A .grammar file uses Extended Backus-Naur Form (EBNF) to describe how tokens
+// combine into valid programs. Each grammar rule has a body composed of these
+// element types:
+//
+//   RuleReference — a named reference to another rule or token
+//   Literal       — a quoted string literal like "+" or "class"
+//   Sequence      — elements that must appear in order (A B C)
+//   Alternation   — choices separated by | (A | B | C)
+//   Repetition    — zero or more: { element }
+//   Optional      — zero or one: [ element ]
+//   Group         — parenthesized grouping: ( element )
+//   OneOrMoreRepetition  — one or more: { element }+
+//   SeparatedRepetition  — zero/one+ with separator: { element // sep }
+//   PositiveLookahead    — match without consuming: &element
+//   NegativeLookahead    — fail if matches: !element
+//
+// These types form a sealed hierarchy (via sealed interface) that exhaustive
+// pattern matching can check at compile time.
+//
+// Layer: TE (text/language layer)
+// ============================================================================
+
+package com.codingadventures.grammartools;
+
+import java.util.List;
+
+/**
+ * Base interface for all grammar rule body elements.
+ *
+ * <p>Implementations are records for value semantics and pattern matching.
+ */
+public sealed interface GrammarElement
+        permits GrammarElement.RuleReference,
+                GrammarElement.Literal,
+                GrammarElement.Sequence,
+                GrammarElement.Alternation,
+                GrammarElement.Repetition,
+                GrammarElement.Optional,
+                GrammarElement.Group,
+                GrammarElement.PositiveLookahead,
+                GrammarElement.NegativeLookahead,
+                GrammarElement.OneOrMoreRepetition,
+                GrammarElement.SeparatedRepetition {
+
+    /** A reference to a rule (lowercase) or token (UPPERCASE). */
+    record RuleReference(String name, boolean isToken) implements GrammarElement {}
+
+    /** A quoted string literal in a grammar rule. */
+    record Literal(String value) implements GrammarElement {}
+
+    /** Multiple elements that must appear in sequence. */
+    record Sequence(List<GrammarElement> elements) implements GrammarElement {}
+
+    /** Alternative choices separated by |. */
+    record Alternation(List<GrammarElement> choices) implements GrammarElement {}
+
+    /** Zero or more repetitions: { element }. */
+    record Repetition(GrammarElement element) implements GrammarElement {}
+
+    /** Zero or one occurrences: [ element ]. */
+    record Optional(GrammarElement element) implements GrammarElement {}
+
+    /** Parenthesized grouping: ( element ). */
+    record Group(GrammarElement element) implements GrammarElement {}
+
+    /** Positive lookahead: &element — succeeds without consuming input. */
+    record PositiveLookahead(GrammarElement element) implements GrammarElement {}
+
+    /** Negative lookahead: !element — succeeds if element does NOT match. */
+    record NegativeLookahead(GrammarElement element) implements GrammarElement {}
+
+    /** One or more repetitions: { element }+. */
+    record OneOrMoreRepetition(GrammarElement element) implements GrammarElement {}
+
+    /** Separated repetition: { element // separator } or { element // separator }+. */
+    record SeparatedRepetition(GrammarElement element, GrammarElement separator, boolean atLeastOne) implements GrammarElement {}
+}

--- a/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/GrammarRule.java
+++ b/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/GrammarRule.java
@@ -1,0 +1,14 @@
+// ============================================================================
+// GrammarRule.java — A single rule from a .grammar file
+// ============================================================================
+
+package com.codingadventures.grammartools;
+
+/**
+ * A named rule from a .grammar file: {@code name = body ;}.
+ *
+ * @param name       the rule name (lowercase for rules, UPPERCASE for tokens)
+ * @param body       the parsed EBNF body
+ * @param lineNumber 1-based line number where the rule was defined
+ */
+public record GrammarRule(String name, GrammarElement body, int lineNumber) {}

--- a/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/ParserGrammar.java
+++ b/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/ParserGrammar.java
@@ -1,0 +1,107 @@
+// ============================================================================
+// ParserGrammar.java — Complete contents of a parsed .grammar file
+// ============================================================================
+//
+// A .grammar file uses EBNF to describe how tokens (from a .tokens file)
+// combine into valid programs. This class holds the parsed result.
+//
+// Helper methods extract useful information for cross-validation:
+//   - ruleNames()       — all defined rule names
+//   - ruleReferences()  — all lowercase names referenced in rule bodies
+//   - tokenReferences() — all UPPERCASE names referenced in rule bodies
+//
+// Layer: TE (text/language layer)
+// ============================================================================
+
+package com.codingadventures.grammartools;
+
+import java.util.*;
+
+/**
+ * The complete contents of a parsed .grammar file.
+ */
+public final class ParserGrammar {
+
+    private int version = 0;
+    private final List<GrammarRule> rules;
+
+    public ParserGrammar(List<GrammarRule> rules) {
+        this.rules = rules;
+    }
+
+    public ParserGrammar() {
+        this(new ArrayList<>());
+    }
+
+    public int getVersion() { return version; }
+    public void setVersion(int version) { this.version = version; }
+
+    public List<GrammarRule> getRules() { return rules; }
+
+    /** Return the set of all defined rule names. */
+    public Set<String> ruleNames() {
+        Set<String> names = new HashSet<>();
+        for (GrammarRule rule : rules) {
+            names.add(rule.name());
+        }
+        return names;
+    }
+
+    /** Return all lowercase rule names referenced in rule bodies. */
+    public Set<String> ruleReferences() {
+        Set<String> refs = new HashSet<>();
+        for (GrammarRule rule : rules) {
+            collectRuleRefs(rule.body(), refs);
+        }
+        return refs;
+    }
+
+    /** Return all UPPERCASE token names referenced in rule bodies. */
+    public Set<String> tokenReferences() {
+        Set<String> refs = new HashSet<>();
+        for (GrammarRule rule : rules) {
+            collectTokenRefs(rule.body(), refs);
+        }
+        return refs;
+    }
+
+    // --- Tree walkers for collecting references ---
+
+    private static void collectRuleRefs(GrammarElement element, Set<String> refs) {
+        switch (element) {
+            case GrammarElement.RuleReference r -> { if (!r.isToken()) refs.add(r.name()); }
+            case GrammarElement.Sequence s -> s.elements().forEach(e -> collectRuleRefs(e, refs));
+            case GrammarElement.Alternation a -> a.choices().forEach(c -> collectRuleRefs(c, refs));
+            case GrammarElement.Repetition r -> collectRuleRefs(r.element(), refs);
+            case GrammarElement.Optional o -> collectRuleRefs(o.element(), refs);
+            case GrammarElement.Group g -> collectRuleRefs(g.element(), refs);
+            case GrammarElement.PositiveLookahead p -> collectRuleRefs(p.element(), refs);
+            case GrammarElement.NegativeLookahead n -> collectRuleRefs(n.element(), refs);
+            case GrammarElement.OneOrMoreRepetition r -> collectRuleRefs(r.element(), refs);
+            case GrammarElement.SeparatedRepetition s -> {
+                collectRuleRefs(s.element(), refs);
+                collectRuleRefs(s.separator(), refs);
+            }
+            case GrammarElement.Literal ignored -> {}
+        }
+    }
+
+    private static void collectTokenRefs(GrammarElement element, Set<String> refs) {
+        switch (element) {
+            case GrammarElement.RuleReference r -> { if (r.isToken()) refs.add(r.name()); }
+            case GrammarElement.Sequence s -> s.elements().forEach(e -> collectTokenRefs(e, refs));
+            case GrammarElement.Alternation a -> a.choices().forEach(c -> collectTokenRefs(c, refs));
+            case GrammarElement.Repetition r -> collectTokenRefs(r.element(), refs);
+            case GrammarElement.Optional o -> collectTokenRefs(o.element(), refs);
+            case GrammarElement.Group g -> collectTokenRefs(g.element(), refs);
+            case GrammarElement.PositiveLookahead p -> collectTokenRefs(p.element(), refs);
+            case GrammarElement.NegativeLookahead n -> collectTokenRefs(n.element(), refs);
+            case GrammarElement.OneOrMoreRepetition r -> collectTokenRefs(r.element(), refs);
+            case GrammarElement.SeparatedRepetition s -> {
+                collectTokenRefs(s.element(), refs);
+                collectTokenRefs(s.separator(), refs);
+            }
+            case GrammarElement.Literal ignored -> {}
+        }
+    }
+}

--- a/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/ParserGrammarError.java
+++ b/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/ParserGrammarError.java
@@ -1,0 +1,20 @@
+// ============================================================================
+// ParserGrammarError.java — Exception for .grammar file parse errors
+// ============================================================================
+
+package com.codingadventures.grammartools;
+
+/**
+ * Thrown when a .grammar file cannot be parsed.
+ */
+public class ParserGrammarError extends Exception {
+
+    private final int lineNumber;
+
+    public ParserGrammarError(String message, int lineNumber) {
+        super("Line " + lineNumber + ": " + message);
+        this.lineNumber = lineNumber;
+    }
+
+    public int getLineNumber() { return lineNumber; }
+}

--- a/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/ParserGrammarParser.java
+++ b/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/ParserGrammarParser.java
@@ -1,0 +1,299 @@
+// ============================================================================
+// ParserGrammarParser.java — Parser for .grammar files (EBNF syntax)
+// ============================================================================
+//
+// A .grammar file describes a language's syntactic structure using EBNF:
+//
+//   program = { statement } ;
+//   statement = assignment | expression_stmt ;
+//   assignment = NAME EQUALS expression SEMI ;
+//   expression = term { (PLUS | MINUS) term } ;
+//   term = factor { (STAR | SLASH) factor } ;
+//   factor = NUMBER | NAME | LPAREN expression RPAREN ;
+//
+// The parser works in two phases:
+//
+//   1. Tokenization — the grammar text is tokenized into a flat list of
+//      internal tokens (IDENT, EQUALS, SEMI, PIPE, LBRACE, RBRACE, etc.)
+//
+//   2. Recursive descent parsing — the token list is parsed into a list of
+//      GrammarRule objects, each with a name and an EBNF body.
+//
+// EBNF constructs supported:
+//   - name = body ;           — rule definition
+//   - A B C                   — sequence
+//   - A | B                   — alternation
+//   - { A }                   — zero or more repetition
+//   - { A }+                  — one or more repetition
+//   - { A // B }              — separated repetition
+//   - [ A ]                   — optional
+//   - ( A )                   — grouping
+//   - &A                      — positive lookahead
+//   - !A                      — negative lookahead
+//   - "literal"               — string literal
+//   - UPPERCASE               — token reference
+//   - lowercase               — rule reference
+//
+// Layer: TE (text/language layer)
+// ============================================================================
+
+package com.codingadventures.grammartools;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Parses .grammar file text into a {@link ParserGrammar}.
+ */
+public final class ParserGrammarParser {
+
+    private static final Pattern MAGIC_COMMENT = Pattern.compile("^#\\s*@(\\w+)\\s*(.*)$");
+
+    private ParserGrammarParser() {}
+
+    /**
+     * Parse a .grammar file into a ParserGrammar.
+     *
+     * @param source the complete text of a .grammar file
+     * @return the parsed ParserGrammar
+     * @throws ParserGrammarError if the grammar text is malformed
+     */
+    public static ParserGrammar parse(String source) throws ParserGrammarError {
+        ParserGrammar grammar = new ParserGrammar();
+
+        // Scan for magic comments before tokenizing
+        for (String rawLine : source.split("\n", -1)) {
+            String stripped = rawLine.strip();
+            if (!stripped.startsWith("#")) continue;
+            Matcher m = MAGIC_COMMENT.matcher(stripped);
+            if (m.matches()) {
+                String key = m.group(1);
+                String value = m.group(2).strip();
+                if ("version".equals(key)) {
+                    try { grammar.setVersion(Integer.parseInt(value)); }
+                    catch (NumberFormatException ignored) {}
+                }
+            }
+        }
+
+        List<InternalToken> tokens = tokenize(source);
+        Parser parser = new Parser(tokens);
+        List<GrammarRule> rules = parser.parseRules();
+        grammar.getRules().addAll(rules);
+        return grammar;
+    }
+
+    // =========================================================================
+    // Internal Token — A simple token for grammar file tokenization
+    // =========================================================================
+
+    private record InternalToken(String kind, String value, int line) {}
+
+    // =========================================================================
+    // Tokenizer — Converts grammar text into a flat token list
+    // =========================================================================
+
+    private static List<InternalToken> tokenize(String source) throws ParserGrammarError {
+        List<InternalToken> tokens = new ArrayList<>();
+        String[] lines = source.split("\n", -1);
+
+        for (int i = 0; i < lines.length; i++) {
+            int lineNum = i + 1;
+            String line = lines[i].stripTrailing();
+            String stripped = line.strip();
+            if (stripped.isEmpty() || stripped.startsWith("#")) continue;
+
+            int j = 0;
+            while (j < line.length()) {
+                char ch = line.charAt(j);
+                if (ch == ' ' || ch == '\t') { j++; continue; }
+                if (ch == '#') break; // inline comment
+
+                switch (ch) {
+                    case '=' -> { tokens.add(new InternalToken("EQUALS", "=", lineNum)); j++; }
+                    case ';' -> { tokens.add(new InternalToken("SEMI", ";", lineNum)); j++; }
+                    case '|' -> { tokens.add(new InternalToken("PIPE", "|", lineNum)); j++; }
+                    case '{' -> { tokens.add(new InternalToken("LBRACE", "{", lineNum)); j++; }
+                    case '}' -> { tokens.add(new InternalToken("RBRACE", "}", lineNum)); j++; }
+                    case '[' -> { tokens.add(new InternalToken("LBRACKET", "[", lineNum)); j++; }
+                    case ']' -> { tokens.add(new InternalToken("RBRACKET", "]", lineNum)); j++; }
+                    case '(' -> { tokens.add(new InternalToken("LPAREN", "(", lineNum)); j++; }
+                    case ')' -> { tokens.add(new InternalToken("RPAREN", ")", lineNum)); j++; }
+                    case '&' -> { tokens.add(new InternalToken("AMPERSAND", "&", lineNum)); j++; }
+                    case '!' -> { tokens.add(new InternalToken("BANG", "!", lineNum)); j++; }
+                    case '+' -> { tokens.add(new InternalToken("PLUS", "+", lineNum)); j++; }
+                    case '/' -> {
+                        if (j + 1 < line.length() && line.charAt(j + 1) == '/') {
+                            tokens.add(new InternalToken("DOUBLE_SLASH", "//", lineNum));
+                            j += 2;
+                        } else {
+                            throw new ParserGrammarError("Unexpected character '/'", lineNum);
+                        }
+                    }
+                    case '"' -> {
+                        int k = j + 1;
+                        while (k < line.length() && line.charAt(k) != '"') {
+                            if (line.charAt(k) == '\\') k++;
+                            k++;
+                        }
+                        if (k >= line.length()) {
+                            throw new ParserGrammarError("Unterminated string literal", lineNum);
+                        }
+                        tokens.add(new InternalToken("STRING", line.substring(j + 1, k), lineNum));
+                        j = k + 1;
+                    }
+                    default -> {
+                        if (Character.isLetter(ch) || ch == '_') {
+                            int k = j;
+                            while (k < line.length() && (Character.isLetterOrDigit(line.charAt(k)) || line.charAt(k) == '_')) {
+                                k++;
+                            }
+                            tokens.add(new InternalToken("IDENT", line.substring(j, k), lineNum));
+                            j = k;
+                        } else {
+                            throw new ParserGrammarError("Unexpected character '" + ch + "'", lineNum);
+                        }
+                    }
+                }
+            }
+        }
+        tokens.add(new InternalToken("EOF", "", lines.length));
+        return tokens;
+    }
+
+    // =========================================================================
+    // Recursive Descent Parser
+    // =========================================================================
+
+    private static class Parser {
+        private final List<InternalToken> tokens;
+        private int pos = 0;
+
+        Parser(List<InternalToken> tokens) {
+            this.tokens = tokens;
+        }
+
+        private InternalToken peek() { return tokens.get(pos); }
+
+        private InternalToken advance() { return tokens.get(pos++); }
+
+        private InternalToken expect(String kind) throws ParserGrammarError {
+            InternalToken tok = advance();
+            if (!tok.kind().equals(kind)) {
+                throw new ParserGrammarError("Expected " + kind + ", got " + tok.kind(), tok.line());
+            }
+            return tok;
+        }
+
+        List<GrammarRule> parseRules() throws ParserGrammarError {
+            List<GrammarRule> rules = new ArrayList<>();
+            while (!"EOF".equals(peek().kind())) {
+                rules.add(parseRule());
+            }
+            return rules;
+        }
+
+        private GrammarRule parseRule() throws ParserGrammarError {
+            InternalToken nameTok = expect("IDENT");
+            expect("EQUALS");
+            GrammarElement body = parseBody();
+            expect("SEMI");
+            return new GrammarRule(nameTok.value(), body, nameTok.line());
+        }
+
+        private GrammarElement parseBody() throws ParserGrammarError {
+            GrammarElement first = parseSequence();
+            List<GrammarElement> alternatives = new ArrayList<>();
+            alternatives.add(first);
+
+            while ("PIPE".equals(peek().kind())) {
+                advance();
+                alternatives.add(parseSequence());
+            }
+
+            return alternatives.size() == 1
+                    ? alternatives.get(0)
+                    : new GrammarElement.Alternation(List.copyOf(alternatives));
+        }
+
+        private GrammarElement parseSequence() throws ParserGrammarError {
+            List<GrammarElement> elements = new ArrayList<>();
+            while (true) {
+                String kind = peek().kind();
+                if ("PIPE".equals(kind) || "SEMI".equals(kind) || "RBRACE".equals(kind)
+                        || "RBRACKET".equals(kind) || "RPAREN".equals(kind)
+                        || "EOF".equals(kind) || "DOUBLE_SLASH".equals(kind)) {
+                    break;
+                }
+                elements.add(parseElement());
+            }
+            if (elements.isEmpty()) {
+                throw new ParserGrammarError("Expected at least one element in sequence", peek().line());
+            }
+            return elements.size() == 1 ? elements.get(0) : new GrammarElement.Sequence(List.copyOf(elements));
+        }
+
+        private GrammarElement parseElement() throws ParserGrammarError {
+            InternalToken tok = peek();
+
+            // Lookahead predicates
+            if ("AMPERSAND".equals(tok.kind())) {
+                advance();
+                return new GrammarElement.PositiveLookahead(parseElement());
+            }
+            if ("BANG".equals(tok.kind())) {
+                advance();
+                return new GrammarElement.NegativeLookahead(parseElement());
+            }
+
+            switch (tok.kind()) {
+                case "IDENT" -> {
+                    advance();
+                    boolean isToken = Character.isUpperCase(tok.value().charAt(0));
+                    return new GrammarElement.RuleReference(tok.value(), isToken);
+                }
+                case "STRING" -> {
+                    advance();
+                    return new GrammarElement.Literal(tok.value());
+                }
+                case "LBRACE" -> {
+                    advance();
+                    GrammarElement body = parseBody();
+
+                    // Separated repetition: { element // separator }
+                    if ("DOUBLE_SLASH".equals(peek().kind())) {
+                        advance();
+                        GrammarElement separator = parseBody();
+                        expect("RBRACE");
+                        boolean atLeastOne = "PLUS".equals(peek().kind());
+                        if (atLeastOne) advance();
+                        return new GrammarElement.SeparatedRepetition(body, separator, atLeastOne);
+                    }
+
+                    expect("RBRACE");
+                    // One-or-more: { element }+
+                    if ("PLUS".equals(peek().kind())) {
+                        advance();
+                        return new GrammarElement.OneOrMoreRepetition(body);
+                    }
+                    return new GrammarElement.Repetition(body);
+                }
+                case "LBRACKET" -> {
+                    advance();
+                    GrammarElement body = parseBody();
+                    expect("RBRACKET");
+                    return new GrammarElement.Optional(body);
+                }
+                case "LPAREN" -> {
+                    advance();
+                    GrammarElement body = parseBody();
+                    expect("RPAREN");
+                    return new GrammarElement.Group(body);
+                }
+                default -> throw new ParserGrammarError("Unexpected token " + tok.kind(), tok.line());
+            }
+        }
+    }
+}

--- a/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/ParserGrammarValidator.java
+++ b/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/ParserGrammarValidator.java
@@ -1,0 +1,86 @@
+// ============================================================================
+// ParserGrammarValidator.java — Lint pass for parsed ParserGrammar
+// ============================================================================
+
+package com.codingadventures.grammartools;
+
+import java.util.*;
+
+/**
+ * Validates a parsed {@link ParserGrammar} for semantic issues.
+ */
+public final class ParserGrammarValidator {
+
+    /** Synthetic tokens always valid — the lexer produces these implicitly. */
+    private static final Set<String> SYNTHETIC_TOKENS = Set.of("NEWLINE", "INDENT", "DEDENT", "EOF");
+
+    private ParserGrammarValidator() {}
+
+    /**
+     * Check a parsed ParserGrammar for issues.
+     *
+     * @param grammar    the grammar to validate
+     * @param tokenNames optional set of valid token names from a .tokens file; null to skip token checks
+     * @return list of issue strings; empty means no issues
+     */
+    public static List<String> validate(ParserGrammar grammar, Set<String> tokenNames) {
+        List<String> issues = new ArrayList<>();
+
+        Set<String> defined = grammar.ruleNames();
+        Set<String> referencedRules = grammar.ruleReferences();
+        Set<String> referencedTokens = grammar.tokenReferences();
+
+        // Duplicate rule names
+        Map<String, Integer> seen = new HashMap<>();
+        for (GrammarRule rule : grammar.getRules()) {
+            if (seen.containsKey(rule.name())) {
+                issues.add("Line " + rule.lineNumber() + ": Duplicate rule name '" + rule.name()
+                        + "' (first defined on line " + seen.get(rule.name()) + ")");
+            } else {
+                seen.put(rule.name(), rule.lineNumber());
+            }
+        }
+
+        // Non-lowercase rule names
+        for (GrammarRule rule : grammar.getRules()) {
+            if (!rule.name().equals(rule.name().toLowerCase())) {
+                issues.add("Line " + rule.lineNumber() + ": Rule name '" + rule.name() + "' should be lowercase");
+            }
+        }
+
+        // Undefined rule references
+        for (String ref : sorted(referencedRules)) {
+            if (!defined.contains(ref)) {
+                issues.add("Undefined rule reference: '" + ref + "'");
+            }
+        }
+
+        // Undefined token references
+        if (tokenNames != null) {
+            for (String ref : sorted(referencedTokens)) {
+                if (!tokenNames.contains(ref) && !SYNTHETIC_TOKENS.contains(ref)) {
+                    issues.add("Undefined token reference: '" + ref + "'");
+                }
+            }
+        }
+
+        // Unreachable rules
+        if (!grammar.getRules().isEmpty()) {
+            String startRule = grammar.getRules().get(0).name();
+            for (GrammarRule rule : grammar.getRules()) {
+                if (!rule.name().equals(startRule) && !referencedRules.contains(rule.name())) {
+                    issues.add("Line " + rule.lineNumber() + ": Rule '" + rule.name()
+                            + "' is defined but never referenced (unreachable)");
+                }
+            }
+        }
+
+        return issues;
+    }
+
+    private static List<String> sorted(Set<String> set) {
+        List<String> list = new ArrayList<>(set);
+        Collections.sort(list);
+        return list;
+    }
+}

--- a/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/PatternGroup.java
+++ b/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/PatternGroup.java
@@ -1,0 +1,46 @@
+// ============================================================================
+// PatternGroup.java — A named set of token definitions for context-sensitive lexing
+// ============================================================================
+//
+// Pattern groups enable context-sensitive lexing. For example, an XML lexer
+// defines a "tag" group with patterns for attribute names, equals signs, and
+// attribute values. These patterns are only active inside tags — a callback
+// pushes the "tag" group when "<" is matched and pops it when ">" is matched.
+//
+// When a group is at the top of the lexer's group stack, only that group's
+// patterns are tried during token matching. Skip patterns remain global.
+// ============================================================================
+
+package com.codingadventures.grammartools;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A named set of token definitions that are active together during
+ * context-sensitive lexing.
+ *
+ * @see TokenGrammar
+ */
+public final class PatternGroup {
+
+    private final String name;
+    private final List<TokenDefinition> definitions;
+
+    public PatternGroup(String name, List<TokenDefinition> definitions) {
+        this.name = Objects.requireNonNull(name);
+        this.definitions = Collections.unmodifiableList(definitions);
+    }
+
+    /** The group name, e.g. "tag" or "cdata". */
+    public String getName() { return name; }
+
+    /** Ordered list of token definitions. Order matters (first-match-wins). */
+    public List<TokenDefinition> getDefinitions() { return definitions; }
+
+    @Override
+    public String toString() {
+        return "PatternGroup(" + name + ", " + definitions.size() + " definitions)";
+    }
+}

--- a/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/TokenDefinition.java
+++ b/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/TokenDefinition.java
@@ -1,0 +1,86 @@
+// ============================================================================
+// TokenDefinition.java — A single token rule from a .tokens file
+// ============================================================================
+//
+// Each line in a .tokens file defines one token: a name paired with a pattern.
+// Patterns can be regular expressions (delimited by /slashes/) or literal
+// strings (delimited by "quotes"). An optional -> ALIAS suffix lets multiple
+// patterns emit the same token type.
+//
+// Examples from a .tokens file:
+//
+//   NUMBER  = /[0-9]+/              — regex pattern, no alias
+//   PLUS    = "+"                   — literal pattern, no alias
+//   STRING_DQ = /"[^"]*"/  -> STRING  — regex pattern with alias
+//
+// The lexer tries patterns in definition order (first match wins), so a
+// TokenDefinition's position in the list determines its priority.
+//
+// Layer: TE (text/language layer — foundational infrastructure)
+// ============================================================================
+
+package com.codingadventures.grammartools;
+
+import java.util.Objects;
+
+/**
+ * An immutable record of a single token rule parsed from a .tokens file.
+ *
+ * <p>Fields:
+ * <ul>
+ *   <li>{@code name} — the token name, e.g. "NUMBER" or "PLUS"</li>
+ *   <li>{@code pattern} — the pattern string (without delimiters)</li>
+ *   <li>{@code isRegex} — true if /regex/, false if "literal"</li>
+ *   <li>{@code lineNumber} — 1-based line where this definition appeared</li>
+ *   <li>{@code alias} — optional type alias (null if none)</li>
+ * </ul>
+ */
+public final class TokenDefinition {
+
+    private final String name;
+    private final String pattern;
+    private final boolean isRegex;
+    private final int lineNumber;
+    private final String alias;
+
+    public TokenDefinition(String name, String pattern, boolean isRegex, int lineNumber, String alias) {
+        this.name = Objects.requireNonNull(name);
+        this.pattern = Objects.requireNonNull(pattern);
+        this.isRegex = isRegex;
+        this.lineNumber = lineNumber;
+        this.alias = alias; // null means no alias
+    }
+
+    public TokenDefinition(String name, String pattern, boolean isRegex, int lineNumber) {
+        this(name, pattern, isRegex, lineNumber, null);
+    }
+
+    public String getName() { return name; }
+    public String getPattern() { return pattern; }
+    public boolean isRegex() { return isRegex; }
+    public int getLineNumber() { return lineNumber; }
+    public String getAlias() { return alias; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof TokenDefinition that)) return false;
+        return isRegex == that.isRegex
+                && lineNumber == that.lineNumber
+                && name.equals(that.name)
+                && pattern.equals(that.pattern)
+                && Objects.equals(alias, that.alias);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, pattern, isRegex, lineNumber, alias);
+    }
+
+    @Override
+    public String toString() {
+        String aliasStr = alias != null ? " -> " + alias : "";
+        String patternStr = isRegex ? "/" + pattern + "/" : "\"" + pattern + "\"";
+        return "TokenDefinition(" + name + " = " + patternStr + aliasStr + ", line " + lineNumber + ")";
+    }
+}

--- a/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/TokenGrammar.java
+++ b/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/TokenGrammar.java
@@ -1,0 +1,112 @@
+// ============================================================================
+// TokenGrammar.java — Complete contents of a parsed .tokens file
+// ============================================================================
+//
+// A .tokens file is the lexical specification for a programming language. It
+// describes every token the lexer should recognize, organized into:
+//
+//   1. Token definitions — NAME = /regex/ or NAME = "literal"
+//   2. Keywords section — reserved words promoted from NAME tokens
+//   3. Skip section — patterns consumed silently (whitespace, comments)
+//   4. Mode directive — special lexer modes like "indentation"
+//   5. Pattern groups — context-sensitive token sets
+//
+// This class holds the parsed result of all those sections.
+//
+// Layer: TE (text/language layer)
+// ============================================================================
+
+package com.codingadventures.grammartools;
+
+import java.util.*;
+
+/**
+ * The complete contents of a parsed .tokens file.
+ *
+ * <p>All fields have sensible defaults so a freshly constructed TokenGrammar
+ * represents an empty but valid grammar.
+ */
+public final class TokenGrammar {
+
+    private int version = 0;
+    private boolean caseInsensitive = false;
+    private boolean caseSensitive = true;
+    private final List<TokenDefinition> definitions = new ArrayList<>();
+    private final List<String> keywords = new ArrayList<>();
+    private String mode = null;
+    private String escapeMode = null;
+    private final List<TokenDefinition> skipDefinitions = new ArrayList<>();
+    private final List<TokenDefinition> errorDefinitions = new ArrayList<>();
+    private final List<String> reservedKeywords = new ArrayList<>();
+    private final List<String> contextKeywords = new ArrayList<>();
+    private final Map<String, PatternGroup> groups = new LinkedHashMap<>();
+
+    // --- Getters and setters ---
+
+    public int getVersion() { return version; }
+    public void setVersion(int version) { this.version = version; }
+
+    public boolean isCaseInsensitive() { return caseInsensitive; }
+    public void setCaseInsensitive(boolean v) { this.caseInsensitive = v; }
+
+    public boolean isCaseSensitive() { return caseSensitive; }
+    public void setCaseSensitive(boolean v) { this.caseSensitive = v; }
+
+    public List<TokenDefinition> getDefinitions() { return definitions; }
+    public List<String> getKeywords() { return keywords; }
+
+    public String getMode() { return mode; }
+    public void setMode(String mode) { this.mode = mode; }
+
+    public String getEscapeMode() { return escapeMode; }
+    public void setEscapeMode(String escapeMode) { this.escapeMode = escapeMode; }
+
+    public List<TokenDefinition> getSkipDefinitions() { return skipDefinitions; }
+    public List<TokenDefinition> getErrorDefinitions() { return errorDefinitions; }
+    public List<String> getReservedKeywords() { return reservedKeywords; }
+    public List<String> getContextKeywords() { return contextKeywords; }
+    public Map<String, PatternGroup> getGroups() { return groups; }
+
+    /**
+     * Return the set of all defined token names (including aliases).
+     *
+     * <p>When a definition has an alias, both the original name and the alias
+     * are included. Includes names from all pattern groups.
+     *
+     * <p>Useful for cross-validation: the parser grammar references tokens by
+     * name, and we need to check that every referenced token exists.
+     */
+    public Set<String> tokenNames() {
+        Set<String> names = new HashSet<>();
+        List<TokenDefinition> allDefs = new ArrayList<>(definitions);
+        for (PatternGroup group : groups.values()) {
+            allDefs.addAll(group.getDefinitions());
+        }
+        for (TokenDefinition d : allDefs) {
+            names.add(d.getName());
+            if (d.getAlias() != null) {
+                names.add(d.getAlias());
+            }
+        }
+        return names;
+    }
+
+    /**
+     * Return the set of token names as the parser will see them.
+     *
+     * <p>For definitions with aliases, returns the alias (not the definition
+     * name). For definitions without aliases, returns the definition name.
+     * Includes names from all pattern groups.
+     */
+    public Set<String> effectiveTokenNames() {
+        Set<String> names = new HashSet<>();
+        List<TokenDefinition> allDefs = new ArrayList<>(definitions);
+        for (PatternGroup group : groups.values()) {
+            allDefs.addAll(group.getDefinitions());
+        }
+        for (TokenDefinition d : allDefs) {
+            names.add(d.getAlias() != null ? d.getAlias() : d.getName());
+        }
+        return names;
+    }
+}

--- a/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/TokenGrammarError.java
+++ b/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/TokenGrammarError.java
@@ -1,0 +1,26 @@
+// ============================================================================
+// TokenGrammarError.java — Exception for .tokens file parse errors
+// ============================================================================
+
+package com.codingadventures.grammartools;
+
+/**
+ * Thrown when a .tokens file cannot be parsed.
+ */
+public class TokenGrammarError extends Exception {
+
+    private final String msg;
+    private final int lineNumber;
+
+    public TokenGrammarError(String message, int lineNumber) {
+        super("Line " + lineNumber + ": " + message);
+        this.msg = message;
+        this.lineNumber = lineNumber;
+    }
+
+    /** Human-readable description of the problem. */
+    public String getMsg() { return msg; }
+
+    /** 1-based line number where the error occurred. */
+    public int getLineNumber() { return lineNumber; }
+}

--- a/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/TokenGrammarParser.java
+++ b/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/TokenGrammarParser.java
@@ -1,0 +1,397 @@
+// ============================================================================
+// TokenGrammarParser.java — Parser for .tokens files
+// ============================================================================
+//
+// A .tokens file describes the lexical grammar of a programming language:
+// which patterns the lexer should recognize, in what order, and how to
+// classify the matched text.
+//
+// The parser operates line-by-line with several modes:
+//
+//   1. Definition mode (default) — each line is a comment, blank, section
+//      header, or token definition (NAME = /pattern/ or NAME = "literal").
+//
+//   2. Keywords mode — entered on "keywords:". Indented lines are keywords.
+//
+//   3. Reserved mode — entered on "reserved:". Same format as keywords but
+//      populates reserved_keywords (which cause lex errors).
+//
+//   4. Skip mode — entered on "skip:". Indented lines define patterns that
+//      the lexer matches and consumes silently (no token produced).
+//
+//   5. Errors mode — entered on "errors:". Error recovery patterns tried
+//      when no normal token matches.
+//
+//   6. Group mode — entered on "group NAME:". Indented lines define token
+//      patterns for context-sensitive lexing groups.
+//
+// Magic comments (# @key value) configure metadata like version and
+// case-insensitivity. Unknown keys are silently ignored for forward compat.
+//
+// Layer: TE (text/language layer)
+// ============================================================================
+
+package com.codingadventures.grammartools;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Parses .tokens file text into a {@link TokenGrammar}.
+ */
+public final class TokenGrammarParser {
+
+    // Magic comment pattern: # @key value
+    private static final Pattern MAGIC_COMMENT = Pattern.compile("^#\\s*@(\\w+)\\s*(.*)$");
+
+    // Valid group name: lowercase identifier
+    private static final Pattern GROUP_NAME_PATTERN = Pattern.compile("^[a-z_][a-z0-9_]*$");
+
+    // Valid token name: identifier (letters, digits, underscore)
+    private static final Pattern TOKEN_NAME_PATTERN = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_]*$");
+
+    // Reserved group names that cannot be used as pattern groups
+    private static final java.util.Set<String> RESERVED_GROUP_NAMES = java.util.Set.of(
+            "default", "skip", "keywords", "reserved", "errors"
+    );
+
+    private TokenGrammarParser() {} // utility class
+
+    /**
+     * Parse the full text of a .tokens file into a TokenGrammar.
+     *
+     * @param source the complete text content of a .tokens file
+     * @return a populated TokenGrammar
+     * @throws TokenGrammarError if any line cannot be parsed
+     */
+    public static TokenGrammar parse(String source) throws TokenGrammarError {
+        TokenGrammar grammar = new TokenGrammar();
+        String[] lines = source.split("\n", -1);
+        String currentSection = null;
+
+        for (int i = 0; i < lines.length; i++) {
+            int lineNumber = i + 1;
+            String line = stripTrailing(lines[i]);
+            String stripped = line.strip();
+
+            // --- Blank lines ---
+            if (stripped.isEmpty()) continue;
+
+            // --- Comments and magic comments ---
+            if (stripped.startsWith("#")) {
+                Matcher m = MAGIC_COMMENT.matcher(stripped);
+                if (m.matches()) {
+                    String key = m.group(1);
+                    String value = m.group(2).strip();
+                    switch (key) {
+                        case "version":
+                            try { grammar.setVersion(Integer.parseInt(value)); }
+                            catch (NumberFormatException ignored) {}
+                            break;
+                        case "case_insensitive":
+                            grammar.setCaseInsensitive("true".equals(value));
+                            break;
+                        // Unknown keys silently ignored for forward compatibility
+                    }
+                }
+                continue;
+            }
+
+            // --- mode: directive ---
+            if (stripped.startsWith("mode:")) {
+                String modeValue = stripped.substring(5).strip();
+                if (modeValue.isEmpty()) {
+                    throw new TokenGrammarError("Missing value after 'mode:'", lineNumber);
+                }
+                grammar.setMode(modeValue);
+                currentSection = null;
+                continue;
+            }
+
+            // --- escapes: directive ---
+            if (stripped.startsWith("escapes:")) {
+                String escapeValue = stripped.substring(8).strip();
+                if (escapeValue.isEmpty()) {
+                    throw new TokenGrammarError("Missing value after 'escapes:'", lineNumber);
+                }
+                grammar.setEscapeMode(escapeValue);
+                currentSection = null;
+                continue;
+            }
+
+            // --- case_sensitive: directive ---
+            if (stripped.startsWith("case_sensitive:")) {
+                String csValue = stripped.substring(15).strip().toLowerCase();
+                if (!"true".equals(csValue) && !"false".equals(csValue)) {
+                    throw new TokenGrammarError(
+                            "Invalid value for 'case_sensitive:': '" + csValue + "' (expected 'true' or 'false')",
+                            lineNumber);
+                }
+                grammar.setCaseSensitive("true".equals(csValue));
+                currentSection = null;
+                continue;
+            }
+
+            // --- Group headers: "group NAME:" ---
+            if (stripped.startsWith("group ") && stripped.endsWith(":")) {
+                String groupName = stripped.substring(6, stripped.length() - 1).strip();
+                if (groupName.isEmpty()) {
+                    throw new TokenGrammarError("Missing group name after 'group'", lineNumber);
+                }
+                if (!GROUP_NAME_PATTERN.matcher(groupName).matches()) {
+                    throw new TokenGrammarError(
+                            "Invalid group name: '" + groupName + "' (must be a lowercase identifier)",
+                            lineNumber);
+                }
+                if (RESERVED_GROUP_NAMES.contains(groupName)) {
+                    throw new TokenGrammarError(
+                            "Reserved group name: '" + groupName + "'",
+                            lineNumber);
+                }
+                if (grammar.getGroups().containsKey(groupName)) {
+                    throw new TokenGrammarError("Duplicate group name: '" + groupName + "'", lineNumber);
+                }
+                grammar.getGroups().put(groupName, new PatternGroup(groupName, new ArrayList<>()));
+                currentSection = "group:" + groupName;
+                continue;
+            }
+
+            // --- Section headers ---
+            if ("keywords:".equals(stripped) || "keywords :".equals(stripped)) {
+                currentSection = "keywords"; continue;
+            }
+            if ("reserved:".equals(stripped) || "reserved :".equals(stripped)) {
+                currentSection = "reserved"; continue;
+            }
+            if ("skip:".equals(stripped) || "skip :".equals(stripped)) {
+                currentSection = "skip"; continue;
+            }
+            if ("errors:".equals(stripped) || "errors :".equals(stripped)) {
+                currentSection = "errors"; continue;
+            }
+            if ("context_keywords:".equals(stripped) || "context_keywords :".equals(stripped)) {
+                currentSection = "context_keywords"; continue;
+            }
+
+            // --- Inside a section (indented lines) ---
+            if (currentSection != null) {
+                if (!line.isEmpty() && (line.charAt(0) == ' ' || line.charAt(0) == '\t')) {
+                    handleSectionLine(grammar, currentSection, stripped, lineNumber);
+                    continue;
+                }
+                // Non-indented line exits the section
+                currentSection = null;
+            }
+
+            // --- Token definition: NAME = pattern ---
+            int eqIndex = line.indexOf('=');
+            if (eqIndex == -1) {
+                throw new TokenGrammarError(
+                        "Expected token definition (NAME = pattern), got: '" + stripped + "'",
+                        lineNumber);
+            }
+
+            String namePart = line.substring(0, eqIndex).strip();
+            String patternPart = line.substring(eqIndex + 1).strip();
+
+            if (namePart.isEmpty()) {
+                throw new TokenGrammarError("Missing token name before '='", lineNumber);
+            }
+            if (!TOKEN_NAME_PATTERN.matcher(namePart).matches()) {
+                throw new TokenGrammarError(
+                        "Invalid token name: '" + namePart + "' (must be an identifier)",
+                        lineNumber);
+            }
+            if (patternPart.isEmpty()) {
+                throw new TokenGrammarError("Missing pattern after '=' for token '" + namePart + "'", lineNumber);
+            }
+
+            grammar.getDefinitions().add(parseDefinition(patternPart, namePart, lineNumber));
+        }
+
+        return grammar;
+    }
+
+    // --- Section line handler ---
+
+    private static void handleSectionLine(
+            TokenGrammar grammar, String section, String stripped, int lineNumber
+    ) throws TokenGrammarError {
+        if (stripped.isEmpty()) return;
+
+        switch (section) {
+            case "keywords":
+                grammar.getKeywords().add(stripped);
+                break;
+            case "reserved":
+                grammar.getReservedKeywords().add(stripped);
+                break;
+            case "context_keywords":
+                grammar.getContextKeywords().add(stripped);
+                break;
+            case "skip":
+                parseAndAddDefinition(grammar.getSkipDefinitions(), stripped, lineNumber, "skip pattern");
+                break;
+            case "errors":
+                parseAndAddDefinition(grammar.getErrorDefinitions(), stripped, lineNumber, "error pattern");
+                break;
+            default:
+                if (section.startsWith("group:")) {
+                    String groupName = section.substring(6);
+                    parseAndAddGroupDefinition(grammar, groupName, stripped, lineNumber);
+                }
+                break;
+        }
+    }
+
+    private static void parseAndAddDefinition(
+            List<TokenDefinition> target, String stripped, int lineNumber, String label
+    ) throws TokenGrammarError {
+        int eqIdx = stripped.indexOf('=');
+        if (eqIdx == -1) {
+            throw new TokenGrammarError(
+                    "Expected " + label + " definition (NAME = pattern), got: '" + stripped + "'",
+                    lineNumber);
+        }
+        String name = stripped.substring(0, eqIdx).strip();
+        String pattern = stripped.substring(eqIdx + 1).strip();
+        if (name.isEmpty() || pattern.isEmpty()) {
+            throw new TokenGrammarError("Incomplete " + label + " definition: '" + stripped + "'", lineNumber);
+        }
+        target.add(parseDefinition(pattern, name, lineNumber));
+    }
+
+    private static void parseAndAddGroupDefinition(
+            TokenGrammar grammar, String groupName, String stripped, int lineNumber
+    ) throws TokenGrammarError {
+        int eqIdx = stripped.indexOf('=');
+        if (eqIdx == -1) {
+            throw new TokenGrammarError(
+                    "Expected token definition in group '" + groupName + "' (NAME = pattern), got: '" + stripped + "'",
+                    lineNumber);
+        }
+        String name = stripped.substring(0, eqIdx).strip();
+        String pattern = stripped.substring(eqIdx + 1).strip();
+        if (name.isEmpty() || pattern.isEmpty()) {
+            throw new TokenGrammarError(
+                    "Incomplete definition in group '" + groupName + "': '" + stripped + "'",
+                    lineNumber);
+        }
+        TokenDefinition defn = parseDefinition(pattern, name, lineNumber);
+
+        // Replace the group with one that has the new definition appended
+        PatternGroup oldGroup = grammar.getGroups().get(groupName);
+        List<TokenDefinition> newDefs = new ArrayList<>(oldGroup.getDefinitions());
+        newDefs.add(defn);
+        grammar.getGroups().put(groupName, new PatternGroup(groupName, newDefs));
+    }
+
+    // --- Definition parser ---
+
+    /**
+     * Parse a single token definition pattern with optional -> ALIAS suffix.
+     *
+     * <p>Supports two forms:
+     * <ul>
+     *   <li>/regex/ — regex pattern</li>
+     *   <li>"literal" — literal string pattern</li>
+     * </ul>
+     *
+     * Either form may have a {@code -> ALIAS} suffix after the closing delimiter.
+     */
+    static TokenDefinition parseDefinition(String patternPart, String namePart, int lineNumber)
+            throws TokenGrammarError {
+
+        if (patternPart.startsWith("/")) {
+            // --- Regex pattern ---
+            int lastSlash = findClosingSlash(patternPart);
+            if (lastSlash == -1) {
+                throw new TokenGrammarError("Unclosed regex pattern for token '" + namePart + "'", lineNumber);
+            }
+            String regexBody = patternPart.substring(1, lastSlash);
+            String remainder = patternPart.substring(lastSlash + 1).strip();
+
+            if (regexBody.isEmpty()) {
+                throw new TokenGrammarError("Empty regex pattern for token '" + namePart + "'", lineNumber);
+            }
+
+            String alias = parseAlias(remainder, namePart, lineNumber);
+            return new TokenDefinition(namePart, regexBody, true, lineNumber, alias);
+
+        } else if (patternPart.startsWith("\"")) {
+            // --- Literal pattern ---
+            int closeQuote = patternPart.indexOf('"', 1);
+            if (closeQuote == -1) {
+                throw new TokenGrammarError("Unclosed literal pattern for token '" + namePart + "'", lineNumber);
+            }
+            String literalBody = patternPart.substring(1, closeQuote);
+            String remainder = patternPart.substring(closeQuote + 1).strip();
+
+            if (literalBody.isEmpty()) {
+                throw new TokenGrammarError("Empty literal pattern for token '" + namePart + "'", lineNumber);
+            }
+
+            String alias = parseAlias(remainder, namePart, lineNumber);
+            return new TokenDefinition(namePart, literalBody, false, lineNumber, alias);
+
+        } else {
+            throw new TokenGrammarError(
+                    "Pattern for token '" + namePart + "' must be /regex/ or \"literal\", got: '" + patternPart + "'",
+                    lineNumber);
+        }
+    }
+
+    /** Parse optional -> ALIAS suffix from remainder text after the pattern delimiter. */
+    private static String parseAlias(String remainder, String namePart, int lineNumber) throws TokenGrammarError {
+        if (remainder.isEmpty()) return null;
+        if (remainder.startsWith("->")) {
+            String alias = remainder.substring(2).strip();
+            if (alias.isEmpty()) {
+                throw new TokenGrammarError("Missing alias after '->' for token '" + namePart + "'", lineNumber);
+            }
+            return alias;
+        }
+        throw new TokenGrammarError(
+                "Unexpected text after pattern for token '" + namePart + "': '" + remainder + "'",
+                lineNumber);
+    }
+
+    /**
+     * Find the closing / in a regex pattern, skipping escaped characters
+     * and characters inside [...] character classes.
+     *
+     * @param s the pattern string starting with /
+     * @return index of closing /, or -1 if not found
+     */
+    static int findClosingSlash(String s) {
+        boolean inBracket = false;
+        for (int i = 1; i < s.length(); i++) {
+            char ch = s.charAt(i);
+            if (ch == '\\') {
+                i++; // skip escaped character
+                continue;
+            }
+            if (ch == '[' && !inBracket) {
+                inBracket = true;
+            } else if (ch == ']' && inBracket) {
+                inBracket = false;
+            } else if (ch == '/' && !inBracket) {
+                return i;
+            }
+        }
+        // Fallback: last / as best-effort
+        int last = s.lastIndexOf('/');
+        return last > 0 ? last : -1;
+    }
+
+    /** Strip trailing whitespace (Java 8-compatible helper). */
+    private static String stripTrailing(String s) {
+        int end = s.length();
+        while (end > 0 && Character.isWhitespace(s.charAt(end - 1))) {
+            end--;
+        }
+        return s.substring(0, end);
+    }
+}

--- a/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/TokenGrammarValidator.java
+++ b/code/packages/java/grammar-tools/src/main/java/com/codingadventures/grammartools/TokenGrammarValidator.java
@@ -1,0 +1,106 @@
+// ============================================================================
+// TokenGrammarValidator.java — Lint pass for parsed TokenGrammar
+// ============================================================================
+//
+// This validates a TokenGrammar that was already parsed successfully. We look
+// for semantic issues: duplicate names, invalid regex patterns, naming
+// convention violations, invalid modes, empty groups.
+// ============================================================================
+
+package com.codingadventures.grammartools;
+
+import java.util.*;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * Validates a parsed {@link TokenGrammar} for common semantic problems.
+ */
+public final class TokenGrammarValidator {
+
+    private static final Pattern GROUP_NAME_PATTERN = Pattern.compile("^[a-z_][a-z0-9_]*$");
+
+    private TokenGrammarValidator() {}
+
+    /**
+     * Check a parsed TokenGrammar for issues.
+     *
+     * @return a list of warning/error strings; empty means no issues
+     */
+    public static List<String> validate(TokenGrammar grammar) {
+        List<String> issues = new ArrayList<>();
+
+        issues.addAll(validateDefinitions(grammar.getDefinitions(), "token"));
+        issues.addAll(validateDefinitions(grammar.getSkipDefinitions(), "skip pattern"));
+        issues.addAll(validateDefinitions(grammar.getErrorDefinitions(), "error pattern"));
+
+        // Validate mode
+        if (grammar.getMode() != null && !"indentation".equals(grammar.getMode())) {
+            issues.add("Unknown lexer mode '" + grammar.getMode() + "' (only 'indentation' is supported)");
+        }
+
+        // Validate escape mode
+        if (grammar.getEscapeMode() != null && !"none".equals(grammar.getEscapeMode())) {
+            issues.add("Unknown escape mode '" + grammar.getEscapeMode() + "' (only 'none' is supported)");
+        }
+
+        // Validate pattern groups
+        for (var entry : grammar.getGroups().entrySet()) {
+            String groupName = entry.getKey();
+            PatternGroup group = entry.getValue();
+
+            if (!GROUP_NAME_PATTERN.matcher(groupName).matches()) {
+                issues.add("Invalid group name '" + groupName + "' (must be a lowercase identifier)");
+            }
+            if (group.getDefinitions().isEmpty()) {
+                issues.add("Empty pattern group '" + groupName + "' (has no token definitions)");
+            }
+            issues.addAll(validateDefinitions(group.getDefinitions(), "group '" + groupName + "' token"));
+        }
+
+        return issues;
+    }
+
+    private static List<String> validateDefinitions(List<TokenDefinition> definitions, String label) {
+        List<String> issues = new ArrayList<>();
+        Map<String, Integer> seenNames = new HashMap<>();
+
+        for (TokenDefinition defn : definitions) {
+            // Duplicate check
+            if (seenNames.containsKey(defn.getName())) {
+                issues.add("Line " + defn.getLineNumber() + ": Duplicate " + label + " name '"
+                        + defn.getName() + "' (first defined on line " + seenNames.get(defn.getName()) + ")");
+            } else {
+                seenNames.put(defn.getName(), defn.getLineNumber());
+            }
+
+            // Empty pattern check
+            if (defn.getPattern().isEmpty()) {
+                issues.add("Line " + defn.getLineNumber() + ": Empty pattern for " + label + " '" + defn.getName() + "'");
+            }
+
+            // Invalid regex check
+            if (defn.isRegex()) {
+                try {
+                    Pattern.compile(defn.getPattern());
+                } catch (PatternSyntaxException e) {
+                    issues.add("Line " + defn.getLineNumber() + ": Invalid regex for " + label + " '"
+                            + defn.getName() + "': " + e.getDescription());
+                }
+            }
+
+            // Naming convention: UPPER_CASE
+            if (!defn.getName().equals(defn.getName().toUpperCase())) {
+                issues.add("Line " + defn.getLineNumber() + ": Token name '" + defn.getName() + "' should be UPPER_CASE");
+            }
+
+            // Alias naming convention
+            if (defn.getAlias() != null && !defn.getAlias().equals(defn.getAlias().toUpperCase())) {
+                issues.add("Line " + defn.getLineNumber() + ": Alias '" + defn.getAlias()
+                        + "' for token '" + defn.getName() + "' should be UPPER_CASE");
+            }
+        }
+
+        return issues;
+    }
+}

--- a/code/packages/java/grammar-tools/src/test/java/com/codingadventures/grammartools/GrammarToolsTest.java
+++ b/code/packages/java/grammar-tools/src/test/java/com/codingadventures/grammartools/GrammarToolsTest.java
@@ -1,0 +1,445 @@
+package com.codingadventures.grammartools;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Nested;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GrammarToolsTest {
+
+    // =========================================================================
+    // Token Grammar Parsing
+    // =========================================================================
+
+    @Nested
+    class TokenGrammarParserTests {
+
+        @Test void emptyInput() throws TokenGrammarError {
+            TokenGrammar g = TokenGrammarParser.parse("");
+            assertTrue(g.getDefinitions().isEmpty());
+            assertTrue(g.getKeywords().isEmpty());
+        }
+
+        @Test void commentsAndBlanks() throws TokenGrammarError {
+            TokenGrammar g = TokenGrammarParser.parse("# comment\n\n# another comment\n");
+            assertTrue(g.getDefinitions().isEmpty());
+        }
+
+        @Test void simpleRegexDefinition() throws TokenGrammarError {
+            TokenGrammar g = TokenGrammarParser.parse("NUMBER = /[0-9]+/\n");
+            assertEquals(1, g.getDefinitions().size());
+            TokenDefinition d = g.getDefinitions().get(0);
+            assertEquals("NUMBER", d.getName());
+            assertEquals("[0-9]+", d.getPattern());
+            assertTrue(d.isRegex());
+            assertEquals(1, d.getLineNumber());
+            assertNull(d.getAlias());
+        }
+
+        @Test void simpleLiteralDefinition() throws TokenGrammarError {
+            TokenGrammar g = TokenGrammarParser.parse("PLUS = \"+\"\n");
+            assertEquals(1, g.getDefinitions().size());
+            TokenDefinition d = g.getDefinitions().get(0);
+            assertEquals("PLUS", d.getName());
+            assertEquals("+", d.getPattern());
+            assertFalse(d.isRegex());
+        }
+
+        @Test void aliasDefinition() throws TokenGrammarError {
+            TokenGrammar g = TokenGrammarParser.parse("STRING_DQ = /\"[^\"]*\"/ -> STRING\n");
+            TokenDefinition d = g.getDefinitions().get(0);
+            assertEquals("STRING_DQ", d.getName());
+            assertEquals("STRING", d.getAlias());
+        }
+
+        @Test void keywordsSection() throws TokenGrammarError {
+            String src = "NUMBER = /[0-9]+/\nkeywords:\n  if\n  else\n  while\n";
+            TokenGrammar g = TokenGrammarParser.parse(src);
+            assertEquals(List.of("if", "else", "while"), g.getKeywords());
+        }
+
+        @Test void reservedKeywords() throws TokenGrammarError {
+            String src = "NUMBER = /[0-9]+/\nreserved:\n  class\n  import\n";
+            TokenGrammar g = TokenGrammarParser.parse(src);
+            assertEquals(List.of("class", "import"), g.getReservedKeywords());
+        }
+
+        @Test void skipSection() throws TokenGrammarError {
+            String src = "NUMBER = /[0-9]+/\nskip:\n  WS = /[ \\t]+/\n  COMMENT = /\\/\\/.*/\n";
+            TokenGrammar g = TokenGrammarParser.parse(src);
+            assertEquals(2, g.getSkipDefinitions().size());
+            assertEquals("WS", g.getSkipDefinitions().get(0).getName());
+        }
+
+        @Test void errorsSection() throws TokenGrammarError {
+            String src = "NUMBER = /[0-9]+/\nerrors:\n  BAD_STRING = /\"[^\"\\n]*/\n";
+            TokenGrammar g = TokenGrammarParser.parse(src);
+            assertEquals(1, g.getErrorDefinitions().size());
+            assertEquals("BAD_STRING", g.getErrorDefinitions().get(0).getName());
+        }
+
+        @Test void modeDirective() throws TokenGrammarError {
+            TokenGrammar g = TokenGrammarParser.parse("mode: indentation\nNUMBER = /[0-9]+/\n");
+            assertEquals("indentation", g.getMode());
+        }
+
+        @Test void escapesDirective() throws TokenGrammarError {
+            TokenGrammar g = TokenGrammarParser.parse("escapes: none\nSTRING = /\"[^\"]*\"/\n");
+            assertEquals("none", g.getEscapeMode());
+        }
+
+        @Test void caseSensitiveDirective() throws TokenGrammarError {
+            TokenGrammar g = TokenGrammarParser.parse("case_sensitive: false\nNUMBER = /[0-9]+/\n");
+            assertFalse(g.isCaseSensitive());
+        }
+
+        @Test void magicCommentVersion() throws TokenGrammarError {
+            TokenGrammar g = TokenGrammarParser.parse("# @version 2\nNUMBER = /[0-9]+/\n");
+            assertEquals(2, g.getVersion());
+        }
+
+        @Test void magicCommentCaseInsensitive() throws TokenGrammarError {
+            TokenGrammar g = TokenGrammarParser.parse("# @case_insensitive true\nNUMBER = /[0-9]+/\n");
+            assertTrue(g.isCaseInsensitive());
+        }
+
+        @Test void patternGroup() throws TokenGrammarError {
+            String src = "OPEN = \"<\"\ngroup tag:\n  ATTR_NAME = /[a-zA-Z]+/\n  EQUALS = \"=\"\n";
+            TokenGrammar g = TokenGrammarParser.parse(src);
+            assertTrue(g.getGroups().containsKey("tag"));
+            assertEquals(2, g.getGroups().get("tag").getDefinitions().size());
+        }
+
+        @Test void contextKeywords() throws TokenGrammarError {
+            String src = "NAME = /[a-z]+/\ncontext_keywords:\n  async\n  await\n";
+            TokenGrammar g = TokenGrammarParser.parse(src);
+            assertEquals(List.of("async", "await"), g.getContextKeywords());
+        }
+
+        @Test void tokenNames() throws TokenGrammarError {
+            TokenGrammar g = TokenGrammarParser.parse("NUMBER = /[0-9]+/\nSTRING_DQ = /\".*\"/ -> STRING\n");
+            Set<String> names = g.tokenNames();
+            assertTrue(names.contains("NUMBER"));
+            assertTrue(names.contains("STRING_DQ"));
+            assertTrue(names.contains("STRING"));
+        }
+
+        @Test void effectiveTokenNames() throws TokenGrammarError {
+            TokenGrammar g = TokenGrammarParser.parse("NUMBER = /[0-9]+/\nSTRING_DQ = /\".*\"/ -> STRING\n");
+            Set<String> names = g.effectiveTokenNames();
+            assertTrue(names.contains("NUMBER"));
+            assertFalse(names.contains("STRING_DQ")); // replaced by alias
+            assertTrue(names.contains("STRING"));
+        }
+
+        @Test void missingModeValue() {
+            assertThrows(TokenGrammarError.class, () -> TokenGrammarParser.parse("mode:\n"));
+        }
+
+        @Test void unclosedRegex() {
+            assertThrows(TokenGrammarError.class, () -> TokenGrammarParser.parse("BAD = /unclosed\n"));
+        }
+
+        @Test void emptyPattern() {
+            assertThrows(TokenGrammarError.class, () -> TokenGrammarParser.parse("BAD = //\n"));
+        }
+
+        @Test void duplicateGroupName() {
+            String src = "group tag:\n  A = \"a\"\ngroup tag:\n  B = \"b\"\n";
+            assertThrows(TokenGrammarError.class, () -> TokenGrammarParser.parse(src));
+        }
+
+        @Test void reservedGroupName() {
+            assertThrows(TokenGrammarError.class, () -> TokenGrammarParser.parse("group default:\n  A = \"a\"\n"));
+        }
+
+        @Test void multipleDefinitions() throws TokenGrammarError {
+            String src = "NUMBER = /[0-9]+/\nPLUS = \"+\"\nMINUS = \"-\"\n";
+            TokenGrammar g = TokenGrammarParser.parse(src);
+            assertEquals(3, g.getDefinitions().size());
+        }
+
+        @Test void regexWithBrackets() throws TokenGrammarError {
+            // Regex with character class containing /
+            TokenGrammar g = TokenGrammarParser.parse("REGEX = /[a/b]+/\n");
+            assertEquals("[a/b]+", g.getDefinitions().get(0).getPattern());
+        }
+
+        @Test void findClosingSlashSkipsEscaped() {
+            assertEquals(7, TokenGrammarParser.findClosingSlash("/ab\\/cd/"));
+        }
+
+        @Test void findClosingSlashSkipsBrackets() {
+            assertEquals(6, TokenGrammarParser.findClosingSlash("/[a/b]/"));
+        }
+    }
+
+    // =========================================================================
+    // Token Grammar Validation
+    // =========================================================================
+
+    @Nested
+    class TokenGrammarValidatorTests {
+
+        @Test void validGrammar() throws TokenGrammarError {
+            TokenGrammar g = TokenGrammarParser.parse("NUMBER = /[0-9]+/\nPLUS = \"+\"\n");
+            List<String> issues = TokenGrammarValidator.validate(g);
+            assertTrue(issues.isEmpty());
+        }
+
+        @Test void duplicateNames() throws TokenGrammarError {
+            TokenGrammar g = new TokenGrammar();
+            g.getDefinitions().add(new TokenDefinition("NUM", "[0-9]+", true, 1));
+            g.getDefinitions().add(new TokenDefinition("NUM", "[0-9]+", true, 2));
+            List<String> issues = TokenGrammarValidator.validate(g);
+            assertTrue(issues.stream().anyMatch(s -> s.contains("Duplicate")));
+        }
+
+        @Test void invalidRegex() throws TokenGrammarError {
+            TokenGrammar g = new TokenGrammar();
+            g.getDefinitions().add(new TokenDefinition("BAD", "[unclosed", true, 1));
+            List<String> issues = TokenGrammarValidator.validate(g);
+            assertTrue(issues.stream().anyMatch(s -> s.contains("Invalid regex")));
+        }
+
+        @Test void nonUpperCaseName() throws TokenGrammarError {
+            TokenGrammar g = new TokenGrammar();
+            g.getDefinitions().add(new TokenDefinition("number", "[0-9]+", true, 1));
+            List<String> issues = TokenGrammarValidator.validate(g);
+            assertTrue(issues.stream().anyMatch(s -> s.contains("UPPER_CASE")));
+        }
+
+        @Test void unknownMode() {
+            TokenGrammar g = new TokenGrammar();
+            g.setMode("unknown_mode");
+            List<String> issues = TokenGrammarValidator.validate(g);
+            assertTrue(issues.stream().anyMatch(s -> s.contains("Unknown lexer mode")));
+        }
+
+        @Test void unknownEscapeMode() {
+            TokenGrammar g = new TokenGrammar();
+            g.setEscapeMode("bad");
+            List<String> issues = TokenGrammarValidator.validate(g);
+            assertTrue(issues.stream().anyMatch(s -> s.contains("Unknown escape mode")));
+        }
+
+        @Test void emptyGroup() throws TokenGrammarError {
+            TokenGrammar g = new TokenGrammar();
+            g.getGroups().put("empty", new PatternGroup("empty", List.of()));
+            List<String> issues = TokenGrammarValidator.validate(g);
+            assertTrue(issues.stream().anyMatch(s -> s.contains("Empty pattern group")));
+        }
+    }
+
+    // =========================================================================
+    // Parser Grammar Parsing
+    // =========================================================================
+
+    @Nested
+    class ParserGrammarParserTests {
+
+        @Test void simpleRule() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("program = statement ;");
+            assertEquals(1, g.getRules().size());
+            assertEquals("program", g.getRules().get(0).name());
+        }
+
+        @Test void alternation() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("expr = NUMBER | NAME ;");
+            GrammarElement body = g.getRules().get(0).body();
+            assertInstanceOf(GrammarElement.Alternation.class, body);
+            assertEquals(2, ((GrammarElement.Alternation) body).choices().size());
+        }
+
+        @Test void sequence() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("assign = NAME EQUALS NUMBER SEMI ;");
+            GrammarElement body = g.getRules().get(0).body();
+            assertInstanceOf(GrammarElement.Sequence.class, body);
+        }
+
+        @Test void repetition() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("list = { item } ;");
+            GrammarElement body = g.getRules().get(0).body();
+            assertInstanceOf(GrammarElement.Repetition.class, body);
+        }
+
+        @Test void oneOrMore() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("list = { item }+ ;");
+            GrammarElement body = g.getRules().get(0).body();
+            assertInstanceOf(GrammarElement.OneOrMoreRepetition.class, body);
+        }
+
+        @Test void optional() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("call = NAME LPAREN [ args ] RPAREN ;");
+            // body is a sequence with optional inside
+            GrammarElement body = g.getRules().get(0).body();
+            assertInstanceOf(GrammarElement.Sequence.class, body);
+        }
+
+        @Test void group() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("expr = term (PLUS | MINUS) term ;");
+            GrammarElement body = g.getRules().get(0).body();
+            assertInstanceOf(GrammarElement.Sequence.class, body);
+        }
+
+        @Test void literal() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("op = \"+\" ;");
+            GrammarElement body = g.getRules().get(0).body();
+            assertInstanceOf(GrammarElement.Literal.class, body);
+            assertEquals("+", ((GrammarElement.Literal) body).value());
+        }
+
+        @Test void positiveLookahead() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("check = &NUMBER item ;");
+            GrammarElement body = g.getRules().get(0).body();
+            assertInstanceOf(GrammarElement.Sequence.class, body);
+        }
+
+        @Test void negativeLookahead() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("check = !NUMBER item ;");
+            GrammarElement body = g.getRules().get(0).body();
+            assertInstanceOf(GrammarElement.Sequence.class, body);
+        }
+
+        @Test void separatedRepetition() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("args = { expr // COMMA } ;");
+            GrammarElement body = g.getRules().get(0).body();
+            assertInstanceOf(GrammarElement.SeparatedRepetition.class, body);
+            GrammarElement.SeparatedRepetition sep = (GrammarElement.SeparatedRepetition) body;
+            assertFalse(sep.atLeastOne());
+        }
+
+        @Test void separatedRepetitionAtLeastOne() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("args = { expr // COMMA }+ ;");
+            GrammarElement body = g.getRules().get(0).body();
+            assertInstanceOf(GrammarElement.SeparatedRepetition.class, body);
+            assertTrue(((GrammarElement.SeparatedRepetition) body).atLeastOne());
+        }
+
+        @Test void multipleRules() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("a = NUMBER ;\nb = NAME ;");
+            assertEquals(2, g.getRules().size());
+        }
+
+        @Test void ruleReferences() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("program = { statement } ;\nstatement = expr SEMI ;");
+            assertTrue(g.ruleReferences().contains("statement"));
+            assertTrue(g.ruleReferences().contains("expr"));
+        }
+
+        @Test void tokenReferences() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("assign = NAME EQUALS NUMBER ;");
+            Set<String> refs = g.tokenReferences();
+            assertTrue(refs.contains("NAME"));
+            assertTrue(refs.contains("EQUALS"));
+            assertTrue(refs.contains("NUMBER"));
+        }
+
+        @Test void magicVersion() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("# @version 3\nexpr = NUMBER ;");
+            assertEquals(3, g.getVersion());
+        }
+
+        @Test void unexpectedToken() {
+            assertThrows(ParserGrammarError.class, () -> ParserGrammarParser.parse("123"));
+        }
+    }
+
+    // =========================================================================
+    // Parser Grammar Validation
+    // =========================================================================
+
+    @Nested
+    class ParserGrammarValidatorTests {
+
+        @Test void validGrammar() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("program = { statement } ;\nstatement = NUMBER ;");
+            List<String> issues = ParserGrammarValidator.validate(g, null);
+            assertTrue(issues.isEmpty());
+        }
+
+        @Test void duplicateRuleName() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("a = NUMBER ;\na = NAME ;");
+            List<String> issues = ParserGrammarValidator.validate(g, null);
+            assertTrue(issues.stream().anyMatch(s -> s.contains("Duplicate rule name")));
+        }
+
+        @Test void undefinedRuleRef() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("program = undefined_rule ;");
+            List<String> issues = ParserGrammarValidator.validate(g, null);
+            assertTrue(issues.stream().anyMatch(s -> s.contains("Undefined rule reference")));
+        }
+
+        @Test void undefinedTokenRef() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("program = NONEXISTENT ;");
+            Set<String> tokenNames = Set.of("NUMBER", "NAME");
+            List<String> issues = ParserGrammarValidator.validate(g, tokenNames);
+            assertTrue(issues.stream().anyMatch(s -> s.contains("Undefined token reference")));
+        }
+
+        @Test void syntheticTokensAlwaysValid() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("program = NEWLINE EOF ;");
+            List<String> issues = ParserGrammarValidator.validate(g, Set.of());
+            assertFalse(issues.stream().anyMatch(s -> s.contains("Undefined token")));
+        }
+
+        @Test void unreachableRule() throws ParserGrammarError {
+            ParserGrammar g = ParserGrammarParser.parse("start = NUMBER ;\nunused = NAME ;");
+            List<String> issues = ParserGrammarValidator.validate(g, null);
+            assertTrue(issues.stream().anyMatch(s -> s.contains("unreachable")));
+        }
+    }
+
+    // =========================================================================
+    // Cross Validation
+    // =========================================================================
+
+    @Nested
+    class CrossValidatorTests {
+
+        @Test void consistentGrammars() throws Exception {
+            TokenGrammar tg = TokenGrammarParser.parse("NUMBER = /[0-9]+/\nNAME = /[a-z]+/\n");
+            ParserGrammar pg = ParserGrammarParser.parse("expr = NUMBER | NAME ;");
+            List<String> issues = CrossValidator.crossValidate(tg, pg);
+            assertTrue(issues.isEmpty());
+        }
+
+        @Test void missingToken() throws Exception {
+            TokenGrammar tg = TokenGrammarParser.parse("NUMBER = /[0-9]+/\n");
+            ParserGrammar pg = ParserGrammarParser.parse("expr = NUMBER | NONEXISTENT ;");
+            List<String> issues = CrossValidator.crossValidate(tg, pg);
+            assertTrue(issues.stream().anyMatch(s -> s.startsWith("Error:") && s.contains("NONEXISTENT")));
+        }
+
+        @Test void unusedToken() throws Exception {
+            TokenGrammar tg = TokenGrammarParser.parse("NUMBER = /[0-9]+/\nUNUSED = \"~\"\n");
+            ParserGrammar pg = ParserGrammarParser.parse("expr = NUMBER ;");
+            List<String> issues = CrossValidator.crossValidate(tg, pg);
+            assertTrue(issues.stream().anyMatch(s -> s.startsWith("Warning:") && s.contains("UNUSED")));
+        }
+
+        @Test void syntheticTokensValid() throws Exception {
+            TokenGrammar tg = TokenGrammarParser.parse("NUMBER = /[0-9]+/\n");
+            ParserGrammar pg = ParserGrammarParser.parse("program = NUMBER NEWLINE EOF ;");
+            List<String> issues = CrossValidator.crossValidate(tg, pg);
+            assertFalse(issues.stream().anyMatch(s -> s.contains("NEWLINE") || s.contains("EOF")));
+        }
+
+        @Test void aliasedTokenUsed() throws Exception {
+            TokenGrammar tg = TokenGrammarParser.parse("STRING_DQ = /\"[^\"]*\"/ -> STRING\n");
+            ParserGrammar pg = ParserGrammarParser.parse("value = STRING ;");
+            List<String> issues = CrossValidator.crossValidate(tg, pg);
+            assertFalse(issues.stream().anyMatch(s -> s.startsWith("Warning:")));
+        }
+
+        @Test void indentDedenValidInIndentMode() throws Exception {
+            TokenGrammar tg = TokenGrammarParser.parse("mode: indentation\nNUMBER = /[0-9]+/\n");
+            ParserGrammar pg = ParserGrammarParser.parse("block = INDENT { NUMBER } DEDENT ;");
+            List<String> issues = CrossValidator.crossValidate(tg, pg);
+            assertFalse(issues.stream().anyMatch(s -> s.contains("INDENT") || s.contains("DEDENT")));
+        }
+    }
+}

--- a/code/packages/java/lexer/.gitignore
+++ b/code/packages/java/lexer/.gitignore
@@ -1,0 +1,2 @@
+gradle-build/
+.gradle/

--- a/code/packages/java/lexer/BUILD
+++ b/code/packages/java/lexer/BUILD
@@ -1,0 +1,1 @@
+cd ../grammar-tools && gradle jar && cd ../lexer && gradle test

--- a/code/packages/java/lexer/BUILD_windows
+++ b/code/packages/java/lexer/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/lexer/CHANGELOG.md
+++ b/code/packages/java/lexer/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## 0.1.0 — 2026-04-04
+
+### Added
+- `Token` class with type, value, line, column, typeName, and flags
+- `TokenType` enum for standard token types
+- `GrammarLexer` — grammar-driven tokenizer using TokenGrammar
+- Keyword promotion, type aliases, reserved keyword detection
+- Context-sensitive keyword flags
+- Preceded-by-newline tracking
+- Error recovery pattern support
+- Full test suite

--- a/code/packages/java/lexer/README.md
+++ b/code/packages/java/lexer/README.md
@@ -1,0 +1,27 @@
+# lexer (Java)
+
+Generic lexer/tokenizer infrastructure for the coding-adventures project.
+
+## What it does
+
+- **Token** — Immutable token with type, value, line, column, and flags
+- **GrammarLexer** — Tokenizes source code using a TokenGrammar from a `.tokens` file
+- First-match-wins pattern matching with priority ordering
+- Keyword promotion, type aliases, reserved keyword detection
+- Context-sensitive keyword flags, newline-preceded flags
+- Error recovery patterns for graceful degradation
+
+## Usage
+
+```java
+import com.codingadventures.lexer.*;
+import com.codingadventures.grammartools.*;
+
+TokenGrammar grammar = TokenGrammarParser.parse(tokensFileContent);
+GrammarLexer lexer = new GrammarLexer(grammar);
+List<Token> tokens = lexer.tokenize("1 + 2");
+```
+
+## Layer
+
+TE (text/language layer) — depends on grammar-tools.

--- a/code/packages/java/lexer/build.gradle.kts
+++ b/code/packages/java/lexer/build.gradle.kts
@@ -1,0 +1,29 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}
+
+dependencies {
+    implementation("com.codingadventures:grammar-tools")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/lexer/settings.gradle.kts
+++ b/code/packages/java/lexer/settings.gradle.kts
@@ -1,0 +1,3 @@
+rootProject.name = "lexer"
+
+includeBuild("../grammar-tools")

--- a/code/packages/java/lexer/src/main/java/com/codingadventures/lexer/GrammarLexer.java
+++ b/code/packages/java/lexer/src/main/java/com/codingadventures/lexer/GrammarLexer.java
@@ -1,0 +1,234 @@
+// ============================================================================
+// GrammarLexer.java — Grammar-driven tokenizer
+// ============================================================================
+//
+// Instead of hardcoding which characters map to which tokens, this lexer
+// reads token definitions from a TokenGrammar (parsed from a .tokens file)
+// and uses those definitions to drive tokenization at runtime.
+//
+// How it works:
+//
+//   1. Compile each TokenDefinition into a Java regex Pattern.
+//      Literal patterns are escaped with Pattern.quote().
+//      Regex patterns are anchored at the start with \A.
+//
+//   2. At each position in the source, try patterns in priority order
+//      (first match wins). Skip patterns are tried first; if one matches,
+//      the lexer consumes the matched text silently (no token produced).
+//
+//   3. When a definition has an alias (e.g. STRING_DQ -> STRING), the
+//      emitted token uses the alias as its type name.
+//
+//   4. After tokenization, keywords in the grammar's keyword list are
+//      promoted: a NAME token whose value matches a keyword gets its
+//      type changed to KEYWORD.
+//
+//   5. If no pattern matches at a position, the lexer raises a LexerError.
+//
+// Layer: TE (text/language layer)
+// ============================================================================
+
+package com.codingadventures.lexer;
+
+import com.codingadventures.grammartools.TokenDefinition;
+import com.codingadventures.grammartools.TokenGrammar;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A lexer that tokenizes source code using a {@link TokenGrammar}.
+ *
+ * <p>This is the runtime equivalent of tools like Lex/Flex: it takes a
+ * declarative description of tokens and produces a token stream.
+ */
+public final class GrammarLexer {
+
+    // A compiled pattern ready for matching
+    private record CompiledPattern(String name, Pattern regex, String alias) {}
+
+    private final TokenGrammar grammar;
+    private final List<CompiledPattern> patterns;
+    private final List<CompiledPattern> skipPatterns;
+    private final List<CompiledPattern> errorPatterns;
+    private final Set<String> keywordSet;
+    private final Set<String> reservedSet;
+    private final Set<String> contextKeywordSet;
+
+    /**
+     * Create a new GrammarLexer from a TokenGrammar.
+     *
+     * @param grammar the parsed .tokens file
+     */
+    public GrammarLexer(TokenGrammar grammar) {
+        this.grammar = grammar;
+        this.patterns = compileDefinitions(grammar.getDefinitions());
+        this.skipPatterns = compileDefinitions(grammar.getSkipDefinitions());
+        this.errorPatterns = compileDefinitions(grammar.getErrorDefinitions());
+        this.keywordSet = new HashSet<>(grammar.getKeywords());
+        this.reservedSet = new HashSet<>(grammar.getReservedKeywords());
+        this.contextKeywordSet = new HashSet<>(grammar.getContextKeywords());
+    }
+
+    /**
+     * Tokenize source code into a list of tokens.
+     *
+     * <p>The returned list always ends with an EOF token.
+     *
+     * @param source the source code text
+     * @return list of tokens
+     * @throws LexerError if source cannot be tokenized
+     */
+    public List<Token> tokenize(String source) throws LexerError {
+        // Optionally lowercase source for case-insensitive languages
+        String workingSource = grammar.isCaseSensitive() ? source : source.toLowerCase();
+
+        List<Token> tokens = new ArrayList<>();
+        int pos = 0;
+        int line = 1;
+        int column = 1;
+        boolean precededByNewline = false;
+
+        while (pos < workingSource.length()) {
+            // --- Try skip patterns first ---
+            boolean skipped = false;
+            for (CompiledPattern sp : skipPatterns) {
+                Matcher m = sp.regex.matcher(workingSource);
+                m.region(pos, workingSource.length());
+                if (m.lookingAt()) {
+                    String matched = m.group();
+                    // Track newlines in skipped content
+                    for (char ch : matched.toCharArray()) {
+                        if (ch == '\n') {
+                            line++;
+                            column = 1;
+                            precededByNewline = true;
+                        } else {
+                            column++;
+                        }
+                    }
+                    pos += matched.length();
+                    skipped = true;
+                    break;
+                }
+            }
+            if (skipped) continue;
+
+            // --- Try token patterns ---
+            boolean matched = false;
+            for (CompiledPattern cp : patterns) {
+                Matcher m = cp.regex.matcher(workingSource);
+                m.region(pos, workingSource.length());
+                if (m.lookingAt()) {
+                    // Use original source for the token value (preserve case)
+                    String value = source.substring(pos, pos + m.group().length());
+                    String typeName = cp.alias != null ? cp.alias : cp.name;
+
+                    // Check for reserved keywords
+                    if ("NAME".equals(typeName) && reservedSet.contains(value)) {
+                        throw new LexerError("Reserved keyword '" + value + "'", line, column);
+                    }
+
+                    // Build flags
+                    int flags = 0;
+                    if (precededByNewline) flags |= Token.FLAG_PRECEDED_BY_NEWLINE;
+                    if ("NAME".equals(typeName) && contextKeywordSet.contains(
+                            grammar.isCaseSensitive() ? value : value.toLowerCase())) {
+                        flags |= Token.FLAG_CONTEXT_KEYWORD;
+                    }
+
+                    Token token = new Token(TokenType.GRAMMAR, value, line, column, typeName, flags);
+                    tokens.add(token);
+
+                    // Advance position and track line/column
+                    for (char ch : value.toCharArray()) {
+                        if (ch == '\n') {
+                            line++;
+                            column = 1;
+                        } else {
+                            column++;
+                        }
+                    }
+                    pos += value.length();
+                    matched = true;
+                    precededByNewline = false;
+                    break;
+                }
+            }
+            if (matched) continue;
+
+            // --- Try error recovery patterns ---
+            boolean errorMatched = false;
+            for (CompiledPattern ep : errorPatterns) {
+                Matcher m = ep.regex.matcher(workingSource);
+                m.region(pos, workingSource.length());
+                if (m.lookingAt()) {
+                    String value = source.substring(pos, pos + m.group().length());
+                    String typeName = ep.alias != null ? ep.alias : ep.name;
+                    Token token = new Token(TokenType.GRAMMAR, value, line, column, typeName, 0);
+                    tokens.add(token);
+
+                    for (char ch : value.toCharArray()) {
+                        if (ch == '\n') { line++; column = 1; }
+                        else column++;
+                    }
+                    pos += value.length();
+                    errorMatched = true;
+                    break;
+                }
+            }
+            if (errorMatched) continue;
+
+            // No pattern matched
+            throw new LexerError("Unexpected character '" + source.charAt(pos) + "'", line, column);
+        }
+
+        // Keyword promotion: NAME tokens whose values match keywords become KEYWORD
+        promoteKeywords(tokens);
+
+        // Add EOF token
+        tokens.add(new Token(TokenType.EOF, "", line, column, "EOF", 0));
+        return tokens;
+    }
+
+    /**
+     * Promote NAME tokens whose values match keywords to KEYWORD type.
+     */
+    private void promoteKeywords(List<Token> tokens) {
+        if (keywordSet.isEmpty()) return;
+        for (int i = 0; i < tokens.size(); i++) {
+            Token t = tokens.get(i);
+            if ("NAME".equals(t.getTypeName())) {
+                String checkValue = grammar.isCaseSensitive() ? t.getValue() : t.getValue().toLowerCase();
+                if (keywordSet.contains(checkValue)) {
+                    tokens.set(i, new Token(TokenType.KEYWORD, t.getValue(), t.getLine(), t.getColumn(),
+                            "KEYWORD", t.getFlags()));
+                }
+            }
+        }
+    }
+
+    /**
+     * Compile a list of TokenDefinitions into regex patterns.
+     */
+    private static List<CompiledPattern> compileDefinitions(List<TokenDefinition> definitions) {
+        List<CompiledPattern> result = new ArrayList<>();
+        for (TokenDefinition defn : definitions) {
+            String regexStr;
+            if (defn.isRegex()) {
+                // Anchor regex at current position with \G
+                regexStr = "\\G(?:" + defn.getPattern() + ")";
+            } else {
+                // Escape literal and anchor
+                regexStr = "\\G" + Pattern.quote(defn.getPattern());
+            }
+            Pattern regex = Pattern.compile(regexStr);
+            result.add(new CompiledPattern(defn.getName(), regex, defn.getAlias()));
+        }
+        return result;
+    }
+}

--- a/code/packages/java/lexer/src/main/java/com/codingadventures/lexer/LexerError.java
+++ b/code/packages/java/lexer/src/main/java/com/codingadventures/lexer/LexerError.java
@@ -1,0 +1,23 @@
+// ============================================================================
+// LexerError.java — Exception for tokenization errors
+// ============================================================================
+
+package com.codingadventures.lexer;
+
+/**
+ * Thrown when the lexer encounters text it cannot tokenize.
+ */
+public class LexerError extends Exception {
+
+    private final int line;
+    private final int column;
+
+    public LexerError(String message, int line, int column) {
+        super("Lexer error at " + line + ":" + column + ": " + message);
+        this.line = line;
+        this.column = column;
+    }
+
+    public int getLine() { return line; }
+    public int getColumn() { return column; }
+}

--- a/code/packages/java/lexer/src/main/java/com/codingadventures/lexer/Token.java
+++ b/code/packages/java/lexer/src/main/java/com/codingadventures/lexer/Token.java
@@ -1,0 +1,101 @@
+// ============================================================================
+// Token.java — A single token produced by a lexer
+// ============================================================================
+//
+// A token is the atomic unit of source code. Just as written English can be
+// decomposed into words, punctuation, and spaces, source code can be
+// decomposed into tokens: identifiers, numbers, operators, keywords, etc.
+//
+// Every token carries four pieces of information:
+//
+//   1. Type — what kind of token (NUMBER, PLUS, NAME, etc.)
+//   2. Value — the actual text from the source code
+//   3. Line — which line the token appeared on (1-based)
+//   4. Column — which column the token starts at (1-based)
+//
+// The type/value distinction is important: the token "42" has type NUMBER
+// and value "42". The token "+" has type PLUS and value "+". The parser
+// cares about types (it matches on NUMBER, not "42"); the code generator
+// cares about values (it needs the actual number 42).
+//
+// Layer: TE (text/language layer)
+// ============================================================================
+
+package com.codingadventures.lexer;
+
+import java.util.Objects;
+
+/**
+ * An immutable token from source code.
+ *
+ * <p>Grammar-driven tokens use {@code typeName} to carry the grammar-defined
+ * token name (e.g. "INT", "FLOAT_LITERAL"). Hand-written lexer tokens use
+ * the {@code type} enum and leave {@code typeName} null.
+ */
+public final class Token {
+
+    /** Bitmask flag: a line break appeared before this token. */
+    public static final int FLAG_PRECEDED_BY_NEWLINE = 1;
+
+    /** Bitmask flag: this is a context-sensitive keyword. */
+    public static final int FLAG_CONTEXT_KEYWORD = 2;
+
+    private final TokenType type;
+    private final String value;
+    private final int line;
+    private final int column;
+    private final String typeName;
+    private final int flags;
+
+    public Token(TokenType type, String value, int line, int column, String typeName, int flags) {
+        this.type = type;
+        this.value = Objects.requireNonNull(value);
+        this.line = line;
+        this.column = column;
+        this.typeName = typeName;
+        this.flags = flags;
+    }
+
+    public Token(TokenType type, String value, int line, int column) {
+        this(type, value, line, column, null, 0);
+    }
+
+    public Token(TokenType type, String value, int line, int column, String typeName) {
+        this(type, value, line, column, typeName, 0);
+    }
+
+    public TokenType getType() { return type; }
+    public String getValue() { return value; }
+    public int getLine() { return line; }
+    public int getColumn() { return column; }
+    public String getTypeName() { return typeName; }
+    public int getFlags() { return flags; }
+
+    /** Returns the effective type name: typeName if set, else the TokenType name. */
+    public String effectiveTypeName() {
+        return typeName != null ? typeName : type.name();
+    }
+
+    /** Check if a specific flag is set. */
+    public boolean hasFlag(int flag) {
+        return (flags & flag) != 0;
+    }
+
+    @Override
+    public String toString() {
+        return "Token(" + effectiveTypeName() + ", \"" + value + "\", " + line + ":" + column + ")";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Token that)) return false;
+        return type == that.type && line == that.line && column == that.column
+                && flags == that.flags && value.equals(that.value) && Objects.equals(typeName, that.typeName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, value, line, column, typeName, flags);
+    }
+}

--- a/code/packages/java/lexer/src/main/java/com/codingadventures/lexer/TokenType.java
+++ b/code/packages/java/lexer/src/main/java/com/codingadventures/lexer/TokenType.java
@@ -1,0 +1,44 @@
+// ============================================================================
+// TokenType.java — Standard token type enumeration
+// ============================================================================
+//
+// These are the built-in token types used by the hand-written lexer.
+// Grammar-driven lexers use the typeName field on Token instead, since
+// token types are defined by the .tokens file, not a fixed enum.
+// ============================================================================
+
+package com.codingadventures.lexer;
+
+/**
+ * Standard token types for hand-written lexers.
+ *
+ * <p>Grammar-driven lexers use string type names from the .tokens file instead
+ * of this enum, but this enum is still needed for the generic Token class.
+ */
+public enum TokenType {
+    NAME,
+    NUMBER,
+    STRING,
+    KEYWORD,
+    PLUS,
+    MINUS,
+    STAR,
+    SLASH,
+    EQUALS,
+    EQUALS_EQUALS,
+    LPAREN,
+    RPAREN,
+    COMMA,
+    COLON,
+    SEMICOLON,
+    LBRACE,
+    RBRACE,
+    LBRACKET,
+    RBRACKET,
+    DOT,
+    BANG,
+    NEWLINE,
+    EOF,
+    /** Grammar-driven token — the actual type is in Token.typeName. */
+    GRAMMAR
+}

--- a/code/packages/java/lexer/src/test/java/com/codingadventures/lexer/LexerTest.java
+++ b/code/packages/java/lexer/src/test/java/com/codingadventures/lexer/LexerTest.java
@@ -1,0 +1,211 @@
+package com.codingadventures.lexer;
+
+import com.codingadventures.grammartools.TokenGrammar;
+import com.codingadventures.grammartools.TokenGrammarParser;
+import com.codingadventures.grammartools.TokenGrammarError;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Nested;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LexerTest {
+
+    // =========================================================================
+    // Token Tests
+    // =========================================================================
+
+    @Nested
+    class TokenTests {
+
+        @Test void construction() {
+            Token t = new Token(TokenType.NUMBER, "42", 1, 1);
+            assertEquals(TokenType.NUMBER, t.getType());
+            assertEquals("42", t.getValue());
+            assertEquals(1, t.getLine());
+            assertEquals(1, t.getColumn());
+        }
+
+        @Test void effectiveTypeNameWithoutTypeName() {
+            Token t = new Token(TokenType.NUMBER, "42", 1, 1);
+            assertEquals("NUMBER", t.effectiveTypeName());
+        }
+
+        @Test void effectiveTypeNameWithTypeName() {
+            Token t = new Token(TokenType.GRAMMAR, "42", 1, 1, "INT");
+            assertEquals("INT", t.effectiveTypeName());
+        }
+
+        @Test void flagPrecededByNewline() {
+            Token t = new Token(TokenType.GRAMMAR, "x", 2, 1, "NAME", Token.FLAG_PRECEDED_BY_NEWLINE);
+            assertTrue(t.hasFlag(Token.FLAG_PRECEDED_BY_NEWLINE));
+            assertFalse(t.hasFlag(Token.FLAG_CONTEXT_KEYWORD));
+        }
+
+        @Test void flagContextKeyword() {
+            Token t = new Token(TokenType.GRAMMAR, "async", 1, 1, "NAME", Token.FLAG_CONTEXT_KEYWORD);
+            assertTrue(t.hasFlag(Token.FLAG_CONTEXT_KEYWORD));
+        }
+
+        @Test void toStringFormat() {
+            Token t = new Token(TokenType.NUMBER, "42", 1, 5);
+            assertEquals("Token(NUMBER, \"42\", 1:5)", t.toString());
+        }
+
+        @Test void equality() {
+            Token a = new Token(TokenType.NUMBER, "42", 1, 1);
+            Token b = new Token(TokenType.NUMBER, "42", 1, 1);
+            assertEquals(a, b);
+        }
+
+        @Test void inequality() {
+            Token a = new Token(TokenType.NUMBER, "42", 1, 1);
+            Token b = new Token(TokenType.NUMBER, "43", 1, 1);
+            assertNotEquals(a, b);
+        }
+    }
+
+    // =========================================================================
+    // Grammar Lexer Tests
+    // =========================================================================
+
+    @Nested
+    class GrammarLexerTests {
+
+        private TokenGrammar parseGrammar(String source) {
+            try {
+                return TokenGrammarParser.parse(source);
+            } catch (TokenGrammarError e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Test void simpleTokenization() throws Exception {
+            TokenGrammar g = parseGrammar(
+                    "NUMBER = /[0-9]+/\nPLUS = \"+\"\nskip:\n  WS = /[ \\t]+/\n");
+            GrammarLexer lexer = new GrammarLexer(g);
+            List<Token> tokens = lexer.tokenize("42 + 7");
+
+            assertEquals(4, tokens.size()); // NUMBER, PLUS, NUMBER, EOF
+            assertEquals("NUMBER", tokens.get(0).getTypeName());
+            assertEquals("42", tokens.get(0).getValue());
+            assertEquals("PLUS", tokens.get(1).getTypeName());
+            assertEquals("NUMBER", tokens.get(2).getTypeName());
+            assertEquals("7", tokens.get(2).getValue());
+            assertEquals("EOF", tokens.get(3).getTypeName());
+        }
+
+        @Test void lineAndColumnTracking() throws Exception {
+            TokenGrammar g = parseGrammar(
+                    "NAME = /[a-z]+/\nNL = /\\n/\nskip:\n  WS = /[ \\t]+/\n");
+            GrammarLexer lexer = new GrammarLexer(g);
+            List<Token> tokens = lexer.tokenize("abc\ndef");
+
+            assertEquals("abc", tokens.get(0).getValue());
+            assertEquals(1, tokens.get(0).getLine());
+            assertEquals(1, tokens.get(0).getColumn());
+
+            // NL token
+            assertEquals(1, tokens.get(1).getLine());
+            assertEquals(4, tokens.get(1).getColumn());
+
+            assertEquals("def", tokens.get(2).getValue());
+            assertEquals(2, tokens.get(2).getLine());
+            assertEquals(1, tokens.get(2).getColumn());
+        }
+
+        @Test void keywordPromotion() throws Exception {
+            TokenGrammar g = parseGrammar(
+                    "NAME = /[a-z]+/\nskip:\n  WS = /[ \\t]+/\nkeywords:\n  if\n  else\n");
+            GrammarLexer lexer = new GrammarLexer(g);
+            List<Token> tokens = lexer.tokenize("if x else y");
+
+            assertEquals("KEYWORD", tokens.get(0).getTypeName());
+            assertEquals("if", tokens.get(0).getValue());
+            assertEquals("NAME", tokens.get(1).getTypeName());
+            assertEquals("KEYWORD", tokens.get(2).getTypeName());
+            assertEquals("NAME", tokens.get(3).getTypeName());
+        }
+
+        @Test void aliasedToken() throws Exception {
+            TokenGrammar g = parseGrammar(
+                    "STRING_DQ = /\"[^\"]*\"/ -> STRING\nskip:\n  WS = /[ \\t]+/\n");
+            GrammarLexer lexer = new GrammarLexer(g);
+            List<Token> tokens = lexer.tokenize("\"hello\"");
+
+            assertEquals("STRING", tokens.get(0).getTypeName());
+            assertEquals("\"hello\"", tokens.get(0).getValue());
+        }
+
+        @Test void unexpectedCharacterError() {
+            TokenGrammar g = parseGrammar("NUMBER = /[0-9]+/\n");
+            GrammarLexer lexer = new GrammarLexer(g);
+            assertThrows(LexerError.class, () -> lexer.tokenize("abc"));
+        }
+
+        @Test void reservedKeywordError() {
+            TokenGrammar g = parseGrammar(
+                    "NAME = /[a-z]+/\nreserved:\n  class\n");
+            GrammarLexer lexer = new GrammarLexer(g);
+            assertThrows(LexerError.class, () -> lexer.tokenize("class"));
+        }
+
+        @Test void emptyInput() throws Exception {
+            TokenGrammar g = parseGrammar("NUMBER = /[0-9]+/\n");
+            GrammarLexer lexer = new GrammarLexer(g);
+            List<Token> tokens = lexer.tokenize("");
+            assertEquals(1, tokens.size());
+            assertEquals("EOF", tokens.get(0).getTypeName());
+        }
+
+        @Test void multiplePatterns() throws Exception {
+            TokenGrammar g = parseGrammar(
+                    "NUMBER = /[0-9]+/\nNAME = /[a-zA-Z_][a-zA-Z0-9_]*/\nPLUS = \"+\"\nMINUS = \"-\"\n"
+                    + "skip:\n  WS = /[ \\t]+/\n");
+            GrammarLexer lexer = new GrammarLexer(g);
+            List<Token> tokens = lexer.tokenize("x + 42 - y");
+            assertEquals(6, tokens.size()); // NAME PLUS NUMBER MINUS NAME EOF
+        }
+
+        @Test void firstMatchWins() throws Exception {
+            // When two patterns could match at the same position, the first
+            // definition in the file wins. Here FLOAT is listed before INT,
+            // so "3.14" matches FLOAT rather than INT + error.
+            TokenGrammar g = parseGrammar(
+                    "FLOAT = /[0-9]+\\.[0-9]+/\nINT = /[0-9]+/\nskip:\n  WS = /[ \\t]+/\n");
+            GrammarLexer lexer = new GrammarLexer(g);
+            List<Token> tokens = lexer.tokenize("3.14 42");
+            assertEquals("FLOAT", tokens.get(0).getTypeName());
+            assertEquals("3.14", tokens.get(0).getValue());
+            assertEquals("INT", tokens.get(1).getTypeName());
+            assertEquals("42", tokens.get(1).getValue());
+        }
+
+        @Test void contextKeywordFlag() throws Exception {
+            TokenGrammar g = parseGrammar(
+                    "NAME = /[a-z]+/\nskip:\n  WS = /[ \\t]+/\ncontext_keywords:\n  async\n");
+            GrammarLexer lexer = new GrammarLexer(g);
+            List<Token> tokens = lexer.tokenize("async foo");
+            assertTrue(tokens.get(0).hasFlag(Token.FLAG_CONTEXT_KEYWORD));
+            assertFalse(tokens.get(1).hasFlag(Token.FLAG_CONTEXT_KEYWORD));
+        }
+
+        @Test void errorRecoveryPatterns() throws Exception {
+            TokenGrammar g = parseGrammar(
+                    "STRING = /\"[^\"]*\"/\nskip:\n  WS = /[ \\t]+/\nerrors:\n  BAD_STRING = /\"[^\"\\n]*/\n");
+            GrammarLexer lexer = new GrammarLexer(g);
+            List<Token> tokens = lexer.tokenize("\"unclosed");
+            assertEquals("BAD_STRING", tokens.get(0).getTypeName());
+        }
+
+        @Test void precededByNewlineFlag() throws Exception {
+            TokenGrammar g = parseGrammar(
+                    "NAME = /[a-z]+/\nskip:\n  WS = /[ \\t\\n]+/\n");
+            GrammarLexer lexer = new GrammarLexer(g);
+            List<Token> tokens = lexer.tokenize("a\nb");
+            assertFalse(tokens.get(0).hasFlag(Token.FLAG_PRECEDED_BY_NEWLINE));
+            assertTrue(tokens.get(1).hasFlag(Token.FLAG_PRECEDED_BY_NEWLINE));
+        }
+    }
+}

--- a/code/packages/java/parser/.gitignore
+++ b/code/packages/java/parser/.gitignore
@@ -1,0 +1,2 @@
+gradle-build/
+.gradle/

--- a/code/packages/java/parser/BUILD
+++ b/code/packages/java/parser/BUILD
@@ -1,0 +1,1 @@
+cd ../grammar-tools && gradle jar && cd ../lexer && gradle jar && cd ../parser && gradle test

--- a/code/packages/java/parser/BUILD_windows
+++ b/code/packages/java/parser/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/parser/CHANGELOG.md
+++ b/code/packages/java/parser/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.1.0 — 2026-04-04
+
+### Added
+- `ASTNode` — generic AST node with position tracking
+- `GrammarParser` — recursive descent parser driven by ParserGrammar
+- Packrat memoization for all (rule, position) pairs
+- Support for all EBNF constructs
+- Full test suite

--- a/code/packages/java/parser/README.md
+++ b/code/packages/java/parser/README.md
@@ -1,0 +1,26 @@
+# parser (Java)
+
+Generic grammar-driven parser infrastructure for the coding-adventures project.
+
+## What it does
+
+- **ASTNode** — Generic AST node with rule name, children (nodes or tokens), and position tracking
+- **GrammarParser** — Recursive descent parser driven by a ParserGrammar from a `.grammar` file
+- Packrat memoization for efficient parsing
+- Supports all EBNF constructs: sequence, alternation, repetition, optional, lookaheads, separated repetition
+
+## Usage
+
+```java
+import com.codingadventures.parser.*;
+import com.codingadventures.grammartools.*;
+import com.codingadventures.lexer.*;
+
+ParserGrammar grammar = ParserGrammarParser.parse(grammarFileContent);
+GrammarParser parser = new GrammarParser(grammar);
+ASTNode ast = parser.parse(tokens);
+```
+
+## Layer
+
+TE (text/language layer) — depends on grammar-tools and lexer.

--- a/code/packages/java/parser/build.gradle.kts
+++ b/code/packages/java/parser/build.gradle.kts
@@ -1,0 +1,30 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}
+
+dependencies {
+    implementation("com.codingadventures:grammar-tools")
+    implementation("com.codingadventures:lexer")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/parser/settings.gradle.kts
+++ b/code/packages/java/parser/settings.gradle.kts
@@ -1,0 +1,4 @@
+rootProject.name = "parser"
+
+includeBuild("../grammar-tools")
+includeBuild("../lexer")

--- a/code/packages/java/parser/src/main/java/com/codingadventures/parser/ASTNode.java
+++ b/code/packages/java/parser/src/main/java/com/codingadventures/parser/ASTNode.java
@@ -1,0 +1,104 @@
+// ============================================================================
+// ASTNode.java — Generic AST node for grammar-driven parsing
+// ============================================================================
+//
+// When a grammar-driven parser processes a token stream, it produces a tree
+// of ASTNode objects. Each ASTNode represents either:
+//
+//   1. A rule match — a node with a rule name and child nodes/tokens
+//   2. A leaf — a node wrapping a single Token from the lexer
+//
+// The tree structure mirrors the grammar rules. For example, parsing
+// "1 + 2" with the grammar:
+//
+//   expression = term { PLUS term } ;
+//   term = NUMBER ;
+//
+// Produces:
+//
+//   ASTNode("expression")
+//     ASTNode("term")
+//       Token(NUMBER, "1")
+//     Token(PLUS, "+")
+//     ASTNode("term")
+//       Token(NUMBER, "2")
+//
+// Layer: TE (text/language layer)
+// ============================================================================
+
+package com.codingadventures.parser;
+
+import com.codingadventures.lexer.Token;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A generic AST node produced by grammar-driven parsing.
+ *
+ * <p>Children can be either other ASTNode instances or Token instances
+ * from the lexer. Use {@link #isLeaf()} and {@link #getToken()} to check
+ * for leaf nodes.
+ */
+public final class ASTNode {
+
+    private final String ruleName;
+    private final List<Object> children; // ASTNode or Token
+    private final int startLine;
+    private final int startColumn;
+    private final int endLine;
+    private final int endColumn;
+
+    public ASTNode(String ruleName, List<Object> children,
+                   int startLine, int startColumn, int endLine, int endColumn) {
+        this.ruleName = ruleName;
+        this.children = Collections.unmodifiableList(new ArrayList<>(children));
+        this.startLine = startLine;
+        this.startColumn = startColumn;
+        this.endLine = endLine;
+        this.endColumn = endColumn;
+    }
+
+    public ASTNode(String ruleName, List<Object> children) {
+        this(ruleName, children, 0, 0, 0, 0);
+    }
+
+    public ASTNode(String ruleName) {
+        this(ruleName, List.of());
+    }
+
+    public String getRuleName() { return ruleName; }
+    public List<Object> getChildren() { return children; }
+    public int getStartLine() { return startLine; }
+    public int getStartColumn() { return startColumn; }
+    public int getEndLine() { return endLine; }
+    public int getEndColumn() { return endColumn; }
+
+    /** True if this node wraps exactly one Token. */
+    public boolean isLeaf() {
+        return children.size() == 1 && children.get(0) instanceof Token;
+    }
+
+    /** Returns the leaf Token if isLeaf(), null otherwise. */
+    public Token getToken() {
+        return isLeaf() ? (Token) children.get(0) : null;
+    }
+
+    /** Count the total number of descendant nodes (for testing/debugging). */
+    public int descendantCount() {
+        int count = 0;
+        for (Object child : children) {
+            count++;
+            if (child instanceof ASTNode node) {
+                count += node.descendantCount();
+            }
+        }
+        return count;
+    }
+
+    @Override
+    public String toString() {
+        return "ASTNode(" + ruleName + ", " + children.size() + " children)";
+    }
+}

--- a/code/packages/java/parser/src/main/java/com/codingadventures/parser/GrammarParseError.java
+++ b/code/packages/java/parser/src/main/java/com/codingadventures/parser/GrammarParseError.java
@@ -1,0 +1,22 @@
+// ============================================================================
+// GrammarParseError.java — Exception for grammar-driven parse failures
+// ============================================================================
+
+package com.codingadventures.parser;
+
+import com.codingadventures.lexer.Token;
+
+/**
+ * Thrown when grammar-driven parsing fails.
+ */
+public class GrammarParseError extends Exception {
+
+    private final Token token;
+
+    public GrammarParseError(String message, Token token) {
+        super("Parse error at " + token.getLine() + ":" + token.getColumn() + ": " + message);
+        this.token = token;
+    }
+
+    public Token getToken() { return token; }
+}

--- a/code/packages/java/parser/src/main/java/com/codingadventures/parser/GrammarParser.java
+++ b/code/packages/java/parser/src/main/java/com/codingadventures/parser/GrammarParser.java
@@ -1,0 +1,282 @@
+// ============================================================================
+// GrammarParser.java — Grammar-driven recursive descent parser
+// ============================================================================
+//
+// This parser takes a token stream (from a GrammarLexer) and a ParserGrammar
+// (from a .grammar file) and produces an AST. It implements a recursive
+// descent parser with packrat memoization for each (rule, position) pair.
+//
+// How it works:
+//
+//   1. Build a rule lookup table from the ParserGrammar's rule list.
+//
+//   2. Start parsing from the first rule (the start symbol).
+//
+//   3. For each rule, recursively match the rule body against the token
+//      stream. The body is a tree of GrammarElement nodes (Sequence,
+//      Alternation, Repetition, etc.) that we match recursively.
+//
+//   4. Each successful match returns a list of children (ASTNode and Token
+//      objects) and the new position in the token stream.
+//
+//   5. Each (rule, position) result is memoized so we never re-parse the
+//      same rule at the same position twice (packrat optimization).
+//
+// EBNF construct matching:
+//
+//   RuleReference (lowercase) — recursively parse the named rule
+//   RuleReference (UPPERCASE) — match a token with that type name
+//   Literal                   — match a token with that exact value
+//   Sequence                  — match all elements in order
+//   Alternation               — try each choice, take first that succeeds
+//   Repetition                — match zero or more times
+//   OneOrMoreRepetition       — match one or more times
+//   Optional                  — match zero or one time
+//   Group                     — match inner element (parenthesized grouping)
+//   PositiveLookahead         — succeed if element matches (no consumption)
+//   NegativeLookahead         — succeed if element does NOT match
+//   SeparatedRepetition       — match with separator between elements
+//
+// Layer: TE (text/language layer)
+// ============================================================================
+
+package com.codingadventures.parser;
+
+import com.codingadventures.grammartools.*;
+import com.codingadventures.lexer.Token;
+
+import java.util.*;
+
+/**
+ * A grammar-driven recursive descent parser with packrat memoization.
+ */
+public final class GrammarParser {
+
+    private final ParserGrammar grammar;
+    private final Map<String, GrammarRule> ruleMap;
+
+    public GrammarParser(ParserGrammar grammar) {
+        this.grammar = grammar;
+        this.ruleMap = new HashMap<>();
+        for (GrammarRule rule : grammar.getRules()) {
+            ruleMap.put(rule.name(), rule);
+        }
+    }
+
+    /**
+     * Parse a token list starting from the grammar's first rule.
+     *
+     * @param tokens the token list (must end with an EOF token)
+     * @return the root ASTNode
+     * @throws GrammarParseError if parsing fails
+     */
+    public ASTNode parse(List<Token> tokens) throws GrammarParseError {
+        if (grammar.getRules().isEmpty()) {
+            throw new GrammarParseError("No rules in grammar", tokens.get(tokens.size() - 1));
+        }
+
+        String startRule = grammar.getRules().get(0).name();
+        Map<String, Map<Integer, MemoEntry>> memo = new HashMap<>();
+
+        MatchResult result = matchRule(startRule, tokens, 0, memo);
+        if (result == null) {
+            throw new GrammarParseError("Failed to parse starting rule '" + startRule + "'",
+                    tokens.get(0));
+        }
+
+        return buildNode(startRule, result.children, tokens);
+    }
+
+    // =========================================================================
+    // Internal matching
+    // =========================================================================
+
+    private record MemoEntry(List<Object> children, int endPos, boolean ok) {}
+    private record MatchResult(List<Object> children, int endPos) {}
+
+    private MatchResult matchRule(String ruleName, List<Token> tokens, int pos,
+                                  Map<String, Map<Integer, MemoEntry>> memo) {
+        // Check memo
+        Map<Integer, MemoEntry> ruleMemo = memo.computeIfAbsent(ruleName, k -> new HashMap<>());
+        MemoEntry cached = ruleMemo.get(pos);
+        if (cached != null) {
+            return cached.ok ? new MatchResult(cached.children, cached.endPos) : null;
+        }
+
+        GrammarRule rule = ruleMap.get(ruleName);
+        if (rule == null) {
+            ruleMemo.put(pos, new MemoEntry(null, pos, false));
+            return null;
+        }
+
+        MatchResult result = matchElement(rule.body(), tokens, pos, memo);
+        if (result != null) {
+            // Wrap in a rule node
+            List<Object> wrapped = List.of(buildNode(ruleName, result.children, tokens));
+            ruleMemo.put(pos, new MemoEntry(wrapped, result.endPos, true));
+            return new MatchResult(wrapped, result.endPos);
+        }
+
+        ruleMemo.put(pos, new MemoEntry(null, pos, false));
+        return null;
+    }
+
+    private MatchResult matchElement(GrammarElement element, List<Token> tokens, int pos,
+                                     Map<String, Map<Integer, MemoEntry>> memo) {
+        return switch (element) {
+            case GrammarElement.RuleReference ref -> {
+                if (ref.isToken()) {
+                    // Match a token by type name
+                    if (pos < tokens.size()) {
+                        Token tok = tokens.get(pos);
+                        if (ref.name().equals(tok.effectiveTypeName())) {
+                            yield new MatchResult(List.of(tok), pos + 1);
+                        }
+                    }
+                    yield null;
+                } else {
+                    // Match a grammar rule
+                    yield matchRule(ref.name(), tokens, pos, memo);
+                }
+            }
+
+            case GrammarElement.Literal lit -> {
+                if (pos < tokens.size() && lit.value().equals(tokens.get(pos).getValue())) {
+                    yield new MatchResult(List.of(tokens.get(pos)), pos + 1);
+                }
+                yield null;
+            }
+
+            case GrammarElement.Sequence seq -> {
+                List<Object> children = new ArrayList<>();
+                int curPos = pos;
+                for (GrammarElement sub : seq.elements()) {
+                    MatchResult r = matchElement(sub, tokens, curPos, memo);
+                    if (r == null) yield null;
+                    children.addAll(r.children);
+                    curPos = r.endPos;
+                }
+                yield new MatchResult(children, curPos);
+            }
+
+            case GrammarElement.Alternation alt -> {
+                for (GrammarElement choice : alt.choices()) {
+                    MatchResult r = matchElement(choice, tokens, pos, memo);
+                    if (r != null) yield r;
+                }
+                yield null;
+            }
+
+            case GrammarElement.Repetition rep -> {
+                List<Object> children = new ArrayList<>();
+                int curPos = pos;
+                while (true) {
+                    MatchResult r = matchElement(rep.element(), tokens, curPos, memo);
+                    if (r == null || r.endPos == curPos) break;
+                    children.addAll(r.children);
+                    curPos = r.endPos;
+                }
+                yield new MatchResult(children, curPos);
+            }
+
+            case GrammarElement.OneOrMoreRepetition rep -> {
+                MatchResult first = matchElement(rep.element(), tokens, pos, memo);
+                if (first == null) yield null;
+                List<Object> children = new ArrayList<>(first.children);
+                int curPos = first.endPos;
+                while (true) {
+                    MatchResult r = matchElement(rep.element(), tokens, curPos, memo);
+                    if (r == null || r.endPos == curPos) break;
+                    children.addAll(r.children);
+                    curPos = r.endPos;
+                }
+                yield new MatchResult(children, curPos);
+            }
+
+            case GrammarElement.Optional opt -> {
+                MatchResult r = matchElement(opt.element(), tokens, pos, memo);
+                yield r != null ? r : new MatchResult(List.of(), pos);
+            }
+
+            case GrammarElement.Group grp ->
+                matchElement(grp.element(), tokens, pos, memo);
+
+            case GrammarElement.PositiveLookahead la -> {
+                MatchResult r = matchElement(la.element(), tokens, pos, memo);
+                yield r != null ? new MatchResult(List.of(), pos) : null;
+            }
+
+            case GrammarElement.NegativeLookahead la -> {
+                MatchResult r = matchElement(la.element(), tokens, pos, memo);
+                yield r == null ? new MatchResult(List.of(), pos) : null;
+            }
+
+            case GrammarElement.SeparatedRepetition sep -> {
+                List<Object> children = new ArrayList<>();
+                int curPos = pos;
+
+                // First element
+                MatchResult first = matchElement(sep.element(), tokens, curPos, memo);
+                if (first == null) {
+                    yield sep.atLeastOne() ? null : new MatchResult(List.of(), pos);
+                }
+                children.addAll(first.children);
+                curPos = first.endPos;
+
+                // Subsequent: separator then element
+                while (true) {
+                    MatchResult sepMatch = matchElement(sep.separator(), tokens, curPos, memo);
+                    if (sepMatch == null) break;
+                    MatchResult elemMatch = matchElement(sep.element(), tokens, sepMatch.endPos, memo);
+                    if (elemMatch == null) break;
+                    children.addAll(sepMatch.children);
+                    children.addAll(elemMatch.children);
+                    curPos = elemMatch.endPos;
+                }
+                yield new MatchResult(children, curPos);
+            }
+        };
+    }
+
+    private ASTNode buildNode(String ruleName, List<Object> children, List<Token> tokens) {
+        int startLine = 0, startColumn = 0, endLine = 0, endColumn = 0;
+
+        // Find position from first and last tokens in children
+        Token firstToken = findFirstToken(children);
+        Token lastToken = findLastToken(children);
+
+        if (firstToken != null) {
+            startLine = firstToken.getLine();
+            startColumn = firstToken.getColumn();
+        }
+        if (lastToken != null) {
+            endLine = lastToken.getLine();
+            endColumn = lastToken.getColumn();
+        }
+
+        return new ASTNode(ruleName, children, startLine, startColumn, endLine, endColumn);
+    }
+
+    private Token findFirstToken(List<Object> children) {
+        for (Object child : children) {
+            if (child instanceof Token t) return t;
+            if (child instanceof ASTNode node) {
+                Token t = findFirstToken(node.getChildren());
+                if (t != null) return t;
+            }
+        }
+        return null;
+    }
+
+    private Token findLastToken(List<Object> children) {
+        for (int i = children.size() - 1; i >= 0; i--) {
+            Object child = children.get(i);
+            if (child instanceof Token t) return t;
+            if (child instanceof ASTNode node) {
+                Token t = findLastToken(node.getChildren());
+                if (t != null) return t;
+            }
+        }
+        return null;
+    }
+}

--- a/code/packages/java/parser/src/test/java/com/codingadventures/parser/ParserTest.java
+++ b/code/packages/java/parser/src/test/java/com/codingadventures/parser/ParserTest.java
@@ -1,0 +1,189 @@
+package com.codingadventures.parser;
+
+import com.codingadventures.grammartools.*;
+import com.codingadventures.lexer.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Nested;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ParserTest {
+
+    // =========================================================================
+    // ASTNode Tests
+    // =========================================================================
+
+    @Nested
+    class ASTNodeTests {
+
+        @Test void emptyNode() {
+            ASTNode node = new ASTNode("test");
+            assertEquals("test", node.getRuleName());
+            assertTrue(node.getChildren().isEmpty());
+            assertFalse(node.isLeaf());
+            assertNull(node.getToken());
+        }
+
+        @Test void leafNode() {
+            Token t = new Token(TokenType.NUMBER, "42", 1, 1);
+            ASTNode node = new ASTNode("number", List.of(t));
+            assertTrue(node.isLeaf());
+            assertEquals(t, node.getToken());
+        }
+
+        @Test void branchNode() {
+            Token t1 = new Token(TokenType.NUMBER, "1", 1, 1);
+            Token t2 = new Token(TokenType.NUMBER, "2", 1, 5);
+            ASTNode child1 = new ASTNode("num", List.of(t1));
+            ASTNode child2 = new ASTNode("num", List.of(t2));
+            ASTNode parent = new ASTNode("add", List.of(child1, child2));
+            assertFalse(parent.isLeaf());
+            assertEquals(2, parent.getChildren().size());
+        }
+
+        @Test void descendantCount() {
+            Token t = new Token(TokenType.NUMBER, "1", 1, 1);
+            ASTNode leaf = new ASTNode("num", List.of(t));
+            ASTNode parent = new ASTNode("expr", List.of(leaf));
+            assertEquals(2, parent.descendantCount()); // leaf + token
+        }
+
+        @Test void positionTracking() {
+            ASTNode node = new ASTNode("test", List.of(), 1, 5, 3, 10);
+            assertEquals(1, node.getStartLine());
+            assertEquals(5, node.getStartColumn());
+            assertEquals(3, node.getEndLine());
+            assertEquals(10, node.getEndColumn());
+        }
+    }
+
+    // =========================================================================
+    // Grammar Parser Tests
+    // =========================================================================
+
+    @Nested
+    class GrammarParserTests {
+
+        private List<Token> makeTokens(String... typesAndValues) {
+            List<Token> tokens = new java.util.ArrayList<>();
+            for (int i = 0; i < typesAndValues.length; i += 2) {
+                tokens.add(new Token(TokenType.GRAMMAR, typesAndValues[i + 1],
+                        1, tokens.size() + 1, typesAndValues[i]));
+            }
+            tokens.add(new Token(TokenType.EOF, "", 1, tokens.size() + 1, "EOF"));
+            return tokens;
+        }
+
+        @Test void singleTokenRule() throws Exception {
+            ParserGrammar g = ParserGrammarParser.parse("program = NUMBER ;");
+            GrammarParser parser = new GrammarParser(g);
+            List<Token> tokens = makeTokens("NUMBER", "42");
+            ASTNode ast = parser.parse(tokens);
+            assertEquals("program", ast.getRuleName());
+        }
+
+        @Test void sequenceRule() throws Exception {
+            ParserGrammar g = ParserGrammarParser.parse("assign = NAME EQUALS NUMBER ;");
+            GrammarParser parser = new GrammarParser(g);
+            List<Token> tokens = makeTokens("NAME", "x", "EQUALS", "=", "NUMBER", "42");
+            ASTNode ast = parser.parse(tokens);
+            assertEquals("assign", ast.getRuleName());
+        }
+
+        @Test void alternationRule() throws Exception {
+            ParserGrammar g = ParserGrammarParser.parse("value = NUMBER | NAME ;");
+            GrammarParser parser = new GrammarParser(g);
+
+            // First alternative
+            ASTNode ast1 = parser.parse(makeTokens("NUMBER", "42"));
+            assertEquals("value", ast1.getRuleName());
+
+            // Second alternative
+            ASTNode ast2 = parser.parse(makeTokens("NAME", "x"));
+            assertEquals("value", ast2.getRuleName());
+        }
+
+        @Test void repetitionRule() throws Exception {
+            ParserGrammar g = ParserGrammarParser.parse("list = { NUMBER } ;");
+            GrammarParser parser = new GrammarParser(g);
+
+            // Zero items
+            ASTNode empty = parser.parse(makeTokens());
+            assertEquals("list", empty.getRuleName());
+
+            // Multiple items
+            ASTNode multi = parser.parse(makeTokens("NUMBER", "1", "NUMBER", "2", "NUMBER", "3"));
+            assertEquals("list", multi.getRuleName());
+        }
+
+        @Test void optionalRule() throws Exception {
+            ParserGrammar g = ParserGrammarParser.parse("maybe = [ NUMBER ] ;");
+            GrammarParser parser = new GrammarParser(g);
+
+            // Present
+            ASTNode present = parser.parse(makeTokens("NUMBER", "42"));
+            assertEquals("maybe", present.getRuleName());
+
+            // Absent
+            ASTNode absent = parser.parse(makeTokens());
+            assertEquals("maybe", absent.getRuleName());
+        }
+
+        @Test void nestedRules() throws Exception {
+            ParserGrammar g = ParserGrammarParser.parse(
+                    "program = { statement } ;\nstatement = NUMBER ;");
+            GrammarParser parser = new GrammarParser(g);
+            ASTNode ast = parser.parse(makeTokens("NUMBER", "1", "NUMBER", "2"));
+            assertEquals("program", ast.getRuleName());
+        }
+
+        @Test void parseFailure() throws Exception {
+            ParserGrammar g = ParserGrammarParser.parse("program = NUMBER ;");
+            GrammarParser parser = new GrammarParser(g);
+            assertThrows(GrammarParseError.class, () -> parser.parse(makeTokens("NAME", "x")));
+        }
+
+        @Test void emptyGrammarThrows() {
+            ParserGrammar g = new ParserGrammar();
+            GrammarParser parser = new GrammarParser(g);
+            assertThrows(GrammarParseError.class, () -> parser.parse(makeTokens()));
+        }
+
+        @Test void positiveLookahead() throws Exception {
+            ParserGrammar g = ParserGrammarParser.parse("check = &NUMBER NUMBER ;");
+            GrammarParser parser = new GrammarParser(g);
+            ASTNode ast = parser.parse(makeTokens("NUMBER", "42"));
+            assertEquals("check", ast.getRuleName());
+        }
+
+        @Test void negativeLookahead() throws Exception {
+            ParserGrammar g = ParserGrammarParser.parse("check = !NAME NUMBER ;");
+            GrammarParser parser = new GrammarParser(g);
+            ASTNode ast = parser.parse(makeTokens("NUMBER", "42"));
+            assertEquals("check", ast.getRuleName());
+        }
+
+        @Test void negativeLookaheadFails() throws Exception {
+            ParserGrammar g = ParserGrammarParser.parse("check = !NUMBER NUMBER ;");
+            GrammarParser parser = new GrammarParser(g);
+            // Negative lookahead sees NUMBER, so it fails, and the whole parse fails
+            assertThrows(GrammarParseError.class, () -> parser.parse(makeTokens("NUMBER", "42")));
+        }
+
+        @Test void separatedRepetition() throws Exception {
+            ParserGrammar g = ParserGrammarParser.parse("args = { NUMBER // COMMA } ;");
+            GrammarParser parser = new GrammarParser(g);
+            ASTNode ast = parser.parse(makeTokens("NUMBER", "1", "COMMA", ",", "NUMBER", "2"));
+            assertEquals("args", ast.getRuleName());
+        }
+
+        @Test void literalMatch() throws Exception {
+            ParserGrammar g = ParserGrammarParser.parse("op = \"+\" ;");
+            GrammarParser parser = new GrammarParser(g);
+            ASTNode ast = parser.parse(makeTokens("PLUS", "+"));
+            assertEquals("op", ast.getRuleName());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- rescue the foundational Java package work from #528 onto current `main`
- add `java/document-ast`, `java/grammar-tools`, `java/lexer`, and `java/parser`
- intentionally drop the stale CI and Go build-tool hunks from #528 because current `main` already contains newer JVM toolchain support

## Validation
- `mise exec java@21.0.2 -- gradle test` in `code/packages/java/grammar-tools`
- `mise exec java@21.0.2 -- gradle test` in `code/packages/java/document-ast`
- `mise exec java@21.0.2 -- gradle test` in `code/packages/java/lexer`
- `mise exec java@21.0.2 -- gradle test` in `code/packages/java/parser`
- `go run . -root /Users/adhithya/Downloads/Codex/coding-adventures-pr528-rescue -validate-build-files -dry-run -language java` in `code/programs/go/build-tool`

## Notes
- This supersedes the package portion of #528 on top of latest `main` as of April 14, 2026 (`7b83f72e7`).
- Existing JVM CI setup and toolchain detection on `main` are preserved as-is.