### PR TITLE
feat(kotlin): rescue foundational grammar, lexer, parser, and document AST packages

### DIFF
--- a/code/packages/kotlin/document-ast/.gitignore
+++ b/code/packages/kotlin/document-ast/.gitignore
@@ -1,0 +1,2 @@
+gradle-build/
+.gradle/

--- a/code/packages/kotlin/document-ast/BUILD
+++ b/code/packages/kotlin/document-ast/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/document-ast/BUILD_windows
+++ b/code/packages/kotlin/document-ast/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/document-ast/CHANGELOG.md
+++ b/code/packages/kotlin/document-ast/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0 — 2026-04-04
+
+### Added
+- Sealed interface hierarchy: Node, BlockNode, InlineNode
+- 13 block node types, 11 inline node types
+- TableAlignment enum
+- Full test suite with exhaustive when-expression tests

--- a/code/packages/kotlin/document-ast/README.md
+++ b/code/packages/kotlin/document-ast/README.md
@@ -1,0 +1,7 @@
+# document-ast (Kotlin)
+
+Universal document IR types using Kotlin sealed interfaces and data classes.
+
+## Layer
+
+TE00 (text/language layer — document IR). Leaf package, zero dependencies.

--- a/code/packages/kotlin/document-ast/build.gradle.kts
+++ b/code/packages/kotlin/document-ast/build.gradle.kts
@@ -1,0 +1,34 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    targetCompatibility = "21"
+    sourceCompatibility = "21"
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/document-ast/settings.gradle.kts
+++ b/code/packages/kotlin/document-ast/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "document-ast"

--- a/code/packages/kotlin/document-ast/src/main/kotlin/com/codingadventures/documentast/DocumentAst.kt
+++ b/code/packages/kotlin/document-ast/src/main/kotlin/com/codingadventures/documentast/DocumentAst.kt
@@ -1,0 +1,180 @@
+// ============================================================================
+// DocumentAst.kt — Universal document IR types
+// ============================================================================
+//
+// The Document AST is a format-agnostic intermediate representation for
+// structured documents. It sits between source formats (Markdown, RST, HTML)
+// and output renderers (HTML, PDF, plain text).
+//
+// Kotlin's sealed interfaces provide exhaustive when-expressions, ensuring
+// every node type is handled at compile time.
+//
+// Design principles:
+//   1. Semantic, not notational — nodes carry meaning, not syntax
+//   2. Resolved, not deferred — all references resolved before IR
+//   3. Format-agnostic — RawBlock/RawInline carry format tags
+//   4. Minimal and stable — only universal document concepts
+//
+// Layer: TE00 (text/language layer — document IR)
+// ============================================================================
+
+package com.codingadventures.documentast
+
+// ---------------------------------------------------------------------------
+// Root interface
+// ---------------------------------------------------------------------------
+
+/** Root interface for all Document AST nodes. */
+sealed interface Node {
+    val nodeType: String
+}
+
+// ---------------------------------------------------------------------------
+// Block nodes
+// ---------------------------------------------------------------------------
+
+/** Block-level nodes form the structural skeleton of a document. */
+sealed interface BlockNode : Node
+
+/** Root of every document. */
+data class DocumentNode(val children: List<BlockNode>) : BlockNode {
+    override val nodeType get() = "document"
+}
+
+/** Section heading with depth 1-6. */
+data class HeadingNode(val level: Int, val children: List<InlineNode>) : BlockNode {
+    override val nodeType get() = "heading"
+}
+
+/** A block of prose containing inline nodes. */
+data class ParagraphNode(val children: List<InlineNode>) : BlockNode {
+    override val nodeType get() = "paragraph"
+}
+
+/** A block of literal code. */
+data class CodeBlockNode(val language: String, val value: String) : BlockNode {
+    override val nodeType get() = "code_block"
+}
+
+/** Quotation or aside. Can contain nested blocks. */
+data class BlockquoteNode(val children: List<BlockNode>) : BlockNode {
+    override val nodeType get() = "blockquote"
+}
+
+/** Ordered or unordered list. */
+data class ListNode(
+    val ordered: Boolean,
+    val start: Int,
+    val tight: Boolean,
+    val children: List<BlockNode>
+) : BlockNode {
+    override val nodeType get() = "list"
+}
+
+/** One item in a list. */
+data class ListItemNode(val children: List<BlockNode>) : BlockNode {
+    override val nodeType get() = "list_item"
+}
+
+/** Task-list item with checkbox. */
+data class TaskItemNode(val checked: Boolean, val children: List<BlockNode>) : BlockNode {
+    override val nodeType get() = "task_item"
+}
+
+/** Horizontal rule. Leaf node. */
+data object ThematicBreakNode : BlockNode {
+    override val nodeType get() = "thematic_break"
+}
+
+/** Raw content for a specific back-end format. */
+data class RawBlockNode(val format: String, val value: String) : BlockNode {
+    override val nodeType get() = "raw_block"
+}
+
+/** Table with column alignments and rows. */
+data class TableNode(val align: List<TableAlignment>, val rows: List<TableRowNode>) : BlockNode {
+    override val nodeType get() = "table"
+}
+
+/** One row in a table. */
+data class TableRowNode(val isHeader: Boolean, val cells: List<TableCellNode>) : BlockNode {
+    override val nodeType get() = "table_row"
+}
+
+/** Single table cell. */
+data class TableCellNode(val children: List<InlineNode>) : BlockNode {
+    override val nodeType get() = "table_cell"
+}
+
+/** Column alignment for tables. */
+enum class TableAlignment { NONE, LEFT, RIGHT, CENTER }
+
+// ---------------------------------------------------------------------------
+// Inline nodes
+// ---------------------------------------------------------------------------
+
+/** Inline nodes appear inside block nodes that contain prose. */
+sealed interface InlineNode : Node
+
+/** Plain text with no markup. */
+data class TextNode(val value: String) : InlineNode {
+    override val nodeType get() = "text"
+}
+
+/** Stressed emphasis (italic). */
+data class EmphasisNode(val children: List<InlineNode>) : InlineNode {
+    override val nodeType get() = "emphasis"
+}
+
+/** Strong importance (bold). */
+data class StrongNode(val children: List<InlineNode>) : InlineNode {
+    override val nodeType get() = "strong"
+}
+
+/** Struck-through text. */
+data class StrikethroughNode(val children: List<InlineNode>) : InlineNode {
+    override val nodeType get() = "strikethrough"
+}
+
+/** Inline code span. */
+data class CodeSpanNode(val value: String) : InlineNode {
+    override val nodeType get() = "code_span"
+}
+
+/** Hyperlink with resolved destination. */
+data class LinkNode(
+    val destination: String,
+    val title: String?,
+    val children: List<InlineNode>
+) : InlineNode {
+    override val nodeType get() = "link"
+}
+
+/** Embedded image. */
+data class ImageNode(
+    val destination: String,
+    val title: String?,
+    val alt: String
+) : InlineNode {
+    override val nodeType get() = "image"
+}
+
+/** URL or email autolink. */
+data class AutolinkNode(val destination: String, val isEmail: Boolean) : InlineNode {
+    override val nodeType get() = "autolink"
+}
+
+/** Raw inline content for a specific back-end. */
+data class RawInlineNode(val format: String, val value: String) : InlineNode {
+    override val nodeType get() = "raw_inline"
+}
+
+/** Forced line break. */
+data object HardBreakNode : InlineNode {
+    override val nodeType get() = "hard_break"
+}
+
+/** Soft line break. */
+data object SoftBreakNode : InlineNode {
+    override val nodeType get() = "soft_break"
+}

--- a/code/packages/kotlin/document-ast/src/test/kotlin/com/codingadventures/documentast/DocumentAstTest.kt
+++ b/code/packages/kotlin/document-ast/src/test/kotlin/com/codingadventures/documentast/DocumentAstTest.kt
@@ -1,0 +1,125 @@
+package com.codingadventures.documentast
+
+import kotlin.test.*
+
+class DocumentAstTest {
+
+    // === Node types ===
+
+    @Test fun documentNodeType() = assertEquals("document", DocumentNode(emptyList()).nodeType)
+    @Test fun headingNodeType() = assertEquals("heading", HeadingNode(1, listOf(TextNode("T"))).nodeType)
+    @Test fun paragraphNodeType() = assertEquals("paragraph", ParagraphNode(listOf(TextNode("T"))).nodeType)
+    @Test fun codeBlockNodeType() = assertEquals("code_block", CodeBlockNode("java", "x").nodeType)
+    @Test fun blockquoteNodeType() = assertEquals("blockquote", BlockquoteNode(emptyList()).nodeType)
+    @Test fun listNodeType() = assertEquals("list", ListNode(true, 1, false, emptyList()).nodeType)
+    @Test fun listItemNodeType() = assertEquals("list_item", ListItemNode(emptyList()).nodeType)
+    @Test fun taskItemNodeType() = assertEquals("task_item", TaskItemNode(true, emptyList()).nodeType)
+    @Test fun thematicBreakNodeType() = assertEquals("thematic_break", ThematicBreakNode.nodeType)
+    @Test fun rawBlockNodeType() = assertEquals("raw_block", RawBlockNode("html", "<div>").nodeType)
+    @Test fun tableNodeType() = assertEquals("table", TableNode(emptyList(), emptyList()).nodeType)
+    @Test fun tableRowNodeType() = assertEquals("table_row", TableRowNode(true, emptyList()).nodeType)
+    @Test fun tableCellNodeType() = assertEquals("table_cell", TableCellNode(emptyList()).nodeType)
+    @Test fun textNodeType() = assertEquals("text", TextNode("hello").nodeType)
+    @Test fun emphasisNodeType() = assertEquals("emphasis", EmphasisNode(listOf(TextNode("em"))).nodeType)
+    @Test fun strongNodeType() = assertEquals("strong", StrongNode(listOf(TextNode("b"))).nodeType)
+    @Test fun strikethroughNodeType() = assertEquals("strikethrough", StrikethroughNode(listOf(TextNode("d"))).nodeType)
+    @Test fun codeSpanNodeType() = assertEquals("code_span", CodeSpanNode("x").nodeType)
+    @Test fun linkNodeType() = assertEquals("link", LinkNode("url", null, listOf(TextNode("t"))).nodeType)
+    @Test fun imageNodeType() = assertEquals("image", ImageNode("cat.png", null, "cat").nodeType)
+    @Test fun autolinkNodeType() = assertEquals("autolink", AutolinkNode("url", false).nodeType)
+    @Test fun rawInlineNodeType() = assertEquals("raw_inline", RawInlineNode("html", "<em>").nodeType)
+    @Test fun hardBreakNodeType() = assertEquals("hard_break", HardBreakNode.nodeType)
+    @Test fun softBreakNodeType() = assertEquals("soft_break", SoftBreakNode.nodeType)
+
+    // === Structure ===
+
+    @Test fun simpleDocument() {
+        val doc = DocumentNode(listOf(
+            HeadingNode(1, listOf(TextNode("Hello"))),
+            ParagraphNode(listOf(TextNode("World")))
+        ))
+        assertEquals(2, doc.children.size)
+        assertIs<HeadingNode>(doc.children[0])
+        assertIs<ParagraphNode>(doc.children[1])
+    }
+
+    @Test fun nestedBlockquote() {
+        val q = BlockquoteNode(listOf(
+            ParagraphNode(listOf(TextNode("outer"))),
+            BlockquoteNode(listOf(ParagraphNode(listOf(TextNode("inner")))))
+        ))
+        assertEquals(2, q.children.size)
+    }
+
+    @Test fun orderedList() {
+        val list = ListNode(true, 3, false, listOf(
+            ListItemNode(listOf(ParagraphNode(listOf(TextNode("item 3")))))
+        ))
+        assertTrue(list.ordered)
+        assertEquals(3, list.start)
+    }
+
+    @Test fun richInline() {
+        val p = ParagraphNode(listOf(
+            TextNode("Hello "),
+            StrongNode(listOf(TextNode("bold"), EmphasisNode(listOf(TextNode(" and italic"))))),
+            TextNode(".")
+        ))
+        assertEquals(3, p.children.size)
+    }
+
+    @Test fun tableStructure() {
+        val table = TableNode(
+            listOf(TableAlignment.LEFT, TableAlignment.RIGHT),
+            listOf(
+                TableRowNode(true, listOf(
+                    TableCellNode(listOf(TextNode("Name"))),
+                    TableCellNode(listOf(TextNode("Score")))
+                )),
+                TableRowNode(false, listOf(
+                    TableCellNode(listOf(TextNode("Alice"))),
+                    TableCellNode(listOf(TextNode("100")))
+                ))
+            )
+        )
+        assertEquals(2, table.align.size)
+        assertEquals(2, table.rows.size)
+        assertTrue(table.rows[0].isHeader)
+    }
+
+    @Test fun whenExhaustive() {
+        val node: InlineNode = TextNode("hello")
+        val result = when (node) {
+            is TextNode -> "text: ${node.value}"
+            is EmphasisNode -> "em"
+            is StrongNode -> "strong"
+            is StrikethroughNode -> "strike"
+            is CodeSpanNode -> "code"
+            is LinkNode -> "link"
+            is ImageNode -> "img"
+            is AutolinkNode -> "autolink"
+            is RawInlineNode -> "raw"
+            HardBreakNode -> "hard"
+            SoftBreakNode -> "soft"
+        }
+        assertEquals("text: hello", result)
+    }
+
+    @Test fun taskItemChecked() {
+        assertTrue(TaskItemNode(true, emptyList()).checked)
+        assertFalse(TaskItemNode(false, emptyList()).checked)
+    }
+
+    @Test fun autolinkEmail() {
+        assertTrue(AutolinkNode("user@example.com", true).isEmail)
+        assertFalse(AutolinkNode("https://example.com", false).isEmail)
+    }
+
+    @Test fun headingLevel() {
+        assertEquals(2, HeadingNode(2, listOf(TextNode("H2"))).level)
+    }
+
+    @Test fun codeBlockLanguage() {
+        assertEquals("kotlin", CodeBlockNode("kotlin", "val x = 1\n").language)
+    }
+}

--- a/code/packages/kotlin/grammar-tools/.gitignore
+++ b/code/packages/kotlin/grammar-tools/.gitignore
@@ -1,0 +1,2 @@
+gradle-build/
+.gradle/

--- a/code/packages/kotlin/grammar-tools/BUILD
+++ b/code/packages/kotlin/grammar-tools/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/grammar-tools/BUILD_windows
+++ b/code/packages/kotlin/grammar-tools/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/grammar-tools/CHANGELOG.md
+++ b/code/packages/kotlin/grammar-tools/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0 — 2026-04-04
+
+### Added
+- Token grammar types, parser, and validator
+- Parser grammar types, recursive descent parser, and validator
+- Cross-validator for token/parser grammar consistency
+- Full test suite

--- a/code/packages/kotlin/grammar-tools/README.md
+++ b/code/packages/kotlin/grammar-tools/README.md
@@ -1,0 +1,15 @@
+# grammar-tools (Kotlin)
+
+Parser and validator for `.tokens` and `.grammar` file formats.
+
+## What it does
+
+- `parseTokenGrammar()` — Parses `.tokens` files into `TokenGrammar`
+- `parseParserGrammar()` — Parses `.grammar` files into `ParserGrammar`
+- `validateTokenGrammar()` — Lint pass for token grammars
+- `validateParserGrammar()` — Lint pass for parser grammars
+- `crossValidate()` — Checks consistency between token and parser grammars
+
+## Layer
+
+TE (text/language layer) — foundational infrastructure for lexer/parser generation.

--- a/code/packages/kotlin/grammar-tools/build.gradle.kts
+++ b/code/packages/kotlin/grammar-tools/build.gradle.kts
@@ -1,0 +1,34 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    targetCompatibility = "21"
+    sourceCompatibility = "21"
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/grammar-tools/settings.gradle.kts
+++ b/code/packages/kotlin/grammar-tools/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "grammar-tools"

--- a/code/packages/kotlin/grammar-tools/src/main/kotlin/com/codingadventures/grammartools/ParserGrammar.kt
+++ b/code/packages/kotlin/grammar-tools/src/main/kotlin/com/codingadventures/grammartools/ParserGrammar.kt
@@ -1,0 +1,304 @@
+// ============================================================================
+// ParserGrammar.kt — Parser grammar types and parser for .grammar files
+// ============================================================================
+//
+// A .grammar file uses EBNF to describe how tokens combine into valid programs.
+// This file contains the grammar element sealed hierarchy, the ParserGrammar
+// data class, the tokenizer, the recursive descent parser, and the validators.
+//
+// Layer: TE (text/language layer)
+// ============================================================================
+
+package com.codingadventures.grammartools
+
+// ---------------------------------------------------------------------------
+// Grammar element types (sealed hierarchy)
+// ---------------------------------------------------------------------------
+
+/** Base type for all grammar rule body elements. */
+sealed interface GrammarElement
+
+data class RuleReference(val name: String, val isToken: Boolean) : GrammarElement
+data class Literal(val value: String) : GrammarElement
+data class Sequence(val elements: List<GrammarElement>) : GrammarElement
+data class Alternation(val choices: List<GrammarElement>) : GrammarElement
+data class Repetition(val element: GrammarElement) : GrammarElement
+data class Optional(val element: GrammarElement) : GrammarElement
+data class Group(val element: GrammarElement) : GrammarElement
+data class PositiveLookahead(val element: GrammarElement) : GrammarElement
+data class NegativeLookahead(val element: GrammarElement) : GrammarElement
+data class OneOrMoreRepetition(val element: GrammarElement) : GrammarElement
+data class SeparatedRepetition(
+    val element: GrammarElement,
+    val separator: GrammarElement,
+    val atLeastOne: Boolean
+) : GrammarElement
+
+data class GrammarRule(val name: String, val body: GrammarElement, val lineNumber: Int)
+
+data class ParserGrammar(
+    var version: Int = 0,
+    val rules: MutableList<GrammarRule> = mutableListOf()
+) {
+    fun ruleNames(): Set<String> = rules.map { it.name }.toSet()
+
+    fun ruleReferences(): Set<String> {
+        val refs = mutableSetOf<String>()
+        rules.forEach { collectRuleRefs(it.body, refs) }
+        return refs
+    }
+
+    fun tokenReferences(): Set<String> {
+        val refs = mutableSetOf<String>()
+        rules.forEach { collectTokenRefs(it.body, refs) }
+        return refs
+    }
+}
+
+class ParserGrammarError(message: String, val line: Int) :
+    Exception("Line $line: $message")
+
+// ---------------------------------------------------------------------------
+// Reference collectors
+// ---------------------------------------------------------------------------
+
+private fun collectRuleRefs(element: GrammarElement, refs: MutableSet<String>) {
+    when (element) {
+        is RuleReference -> if (!element.isToken) refs.add(element.name)
+        is Sequence -> element.elements.forEach { collectRuleRefs(it, refs) }
+        is Alternation -> element.choices.forEach { collectRuleRefs(it, refs) }
+        is Repetition -> collectRuleRefs(element.element, refs)
+        is Optional -> collectRuleRefs(element.element, refs)
+        is Group -> collectRuleRefs(element.element, refs)
+        is PositiveLookahead -> collectRuleRefs(element.element, refs)
+        is NegativeLookahead -> collectRuleRefs(element.element, refs)
+        is OneOrMoreRepetition -> collectRuleRefs(element.element, refs)
+        is SeparatedRepetition -> { collectRuleRefs(element.element, refs); collectRuleRefs(element.separator, refs) }
+        is Literal -> {}
+    }
+}
+
+private fun collectTokenRefs(element: GrammarElement, refs: MutableSet<String>) {
+    when (element) {
+        is RuleReference -> if (element.isToken) refs.add(element.name)
+        is Sequence -> element.elements.forEach { collectTokenRefs(it, refs) }
+        is Alternation -> element.choices.forEach { collectTokenRefs(it, refs) }
+        is Repetition -> collectTokenRefs(element.element, refs)
+        is Optional -> collectTokenRefs(element.element, refs)
+        is Group -> collectTokenRefs(element.element, refs)
+        is PositiveLookahead -> collectTokenRefs(element.element, refs)
+        is NegativeLookahead -> collectTokenRefs(element.element, refs)
+        is OneOrMoreRepetition -> collectTokenRefs(element.element, refs)
+        is SeparatedRepetition -> { collectTokenRefs(element.element, refs); collectTokenRefs(element.separator, refs) }
+        is Literal -> {}
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tokenizer
+// ---------------------------------------------------------------------------
+
+private data class InternalToken(val kind: String, val value: String, val line: Int)
+
+private fun tokenizeGrammar(source: String): List<InternalToken> {
+    val tokens = mutableListOf<InternalToken>()
+    val lines = source.split("\n")
+    for ((i, rawLine) in lines.withIndex()) {
+        val lineNum = i + 1
+        val line = rawLine.trimEnd()
+        val stripped = line.trim()
+        if (stripped.isEmpty() || stripped.startsWith("#")) continue
+
+        var j = 0
+        while (j < line.length) {
+            val ch = line[j]
+            if (ch == ' ' || ch == '\t') { j++; continue }
+            if (ch == '#') break
+            when (ch) {
+                '=' -> { tokens.add(InternalToken("EQUALS", "=", lineNum)); j++ }
+                ';' -> { tokens.add(InternalToken("SEMI", ";", lineNum)); j++ }
+                '|' -> { tokens.add(InternalToken("PIPE", "|", lineNum)); j++ }
+                '{' -> { tokens.add(InternalToken("LBRACE", "{", lineNum)); j++ }
+                '}' -> { tokens.add(InternalToken("RBRACE", "}", lineNum)); j++ }
+                '[' -> { tokens.add(InternalToken("LBRACKET", "[", lineNum)); j++ }
+                ']' -> { tokens.add(InternalToken("RBRACKET", "]", lineNum)); j++ }
+                '(' -> { tokens.add(InternalToken("LPAREN", "(", lineNum)); j++ }
+                ')' -> { tokens.add(InternalToken("RPAREN", ")", lineNum)); j++ }
+                '&' -> { tokens.add(InternalToken("AMPERSAND", "&", lineNum)); j++ }
+                '!' -> { tokens.add(InternalToken("BANG", "!", lineNum)); j++ }
+                '+' -> { tokens.add(InternalToken("PLUS", "+", lineNum)); j++ }
+                '/' -> {
+                    if (j + 1 < line.length && line[j + 1] == '/') {
+                        tokens.add(InternalToken("DOUBLE_SLASH", "//", lineNum)); j += 2
+                    } else throw ParserGrammarError("Unexpected character '/'", lineNum)
+                }
+                '"' -> {
+                    var k = j + 1
+                    while (k < line.length && line[k] != '"') {
+                        if (line[k] == '\\') k++
+                        k++
+                    }
+                    if (k >= line.length) throw ParserGrammarError("Unterminated string literal", lineNum)
+                    tokens.add(InternalToken("STRING", line.substring(j + 1, k), lineNum))
+                    j = k + 1
+                }
+                else -> {
+                    if (ch.isLetter() || ch == '_') {
+                        var k = j
+                        while (k < line.length && (line[k].isLetterOrDigit() || line[k] == '_')) k++
+                        tokens.add(InternalToken("IDENT", line.substring(j, k), lineNum))
+                        j = k
+                    } else throw ParserGrammarError("Unexpected character '$ch'", lineNum)
+                }
+            }
+        }
+    }
+    tokens.add(InternalToken("EOF", "", lines.size))
+    return tokens
+}
+
+// ---------------------------------------------------------------------------
+// Recursive descent parser
+// ---------------------------------------------------------------------------
+
+private class GrammarParserImpl(private val tokens: List<InternalToken>) {
+    private var pos = 0
+    fun peek() = tokens[pos]
+    fun advance() = tokens[pos++]
+    fun expect(kind: String): InternalToken {
+        val tok = advance()
+        if (tok.kind != kind) throw ParserGrammarError("Expected $kind, got ${tok.kind}", tok.line)
+        return tok
+    }
+
+    fun parseRules(): List<GrammarRule> {
+        val rules = mutableListOf<GrammarRule>()
+        while (peek().kind != "EOF") rules.add(parseRule())
+        return rules
+    }
+
+    private fun parseRule(): GrammarRule {
+        val nameTok = expect("IDENT")
+        expect("EQUALS")
+        val body = parseBody()
+        expect("SEMI")
+        return GrammarRule(nameTok.value, body, nameTok.line)
+    }
+
+    fun parseBody(): GrammarElement {
+        val first = parseSequence()
+        val alts = mutableListOf(first)
+        while (peek().kind == "PIPE") { advance(); alts.add(parseSequence()) }
+        return if (alts.size == 1) alts[0] else Alternation(alts.toList())
+    }
+
+    private fun parseSequence(): GrammarElement {
+        val elems = mutableListOf<GrammarElement>()
+        while (peek().kind !in listOf("PIPE", "SEMI", "RBRACE", "RBRACKET", "RPAREN", "EOF", "DOUBLE_SLASH")) {
+            elems.add(parseElement())
+        }
+        if (elems.isEmpty()) throw ParserGrammarError("Expected at least one element", peek().line)
+        return if (elems.size == 1) elems[0] else Sequence(elems.toList())
+    }
+
+    private fun parseElement(): GrammarElement {
+        val tok = peek()
+        if (tok.kind == "AMPERSAND") { advance(); return PositiveLookahead(parseElement()) }
+        if (tok.kind == "BANG") { advance(); return NegativeLookahead(parseElement()) }
+        return when (tok.kind) {
+            "IDENT" -> { advance(); RuleReference(tok.value, tok.value[0].isUpperCase()) }
+            "STRING" -> { advance(); Literal(tok.value) }
+            "LBRACE" -> {
+                advance()
+                val body = parseBody()
+                if (peek().kind == "DOUBLE_SLASH") {
+                    advance()
+                    val sep = parseBody()
+                    expect("RBRACE")
+                    val atLeast = if (peek().kind == "PLUS") { advance(); true } else false
+                    SeparatedRepetition(body, sep, atLeast)
+                } else {
+                    expect("RBRACE")
+                    if (peek().kind == "PLUS") { advance(); OneOrMoreRepetition(body) }
+                    else Repetition(body)
+                }
+            }
+            "LBRACKET" -> { advance(); val body = parseBody(); expect("RBRACKET"); Optional(body) }
+            "LPAREN" -> { advance(); val body = parseBody(); expect("RPAREN"); Group(body) }
+            else -> throw ParserGrammarError("Unexpected token ${tok.kind}", tok.line)
+        }
+    }
+}
+
+fun parseParserGrammar(source: String): ParserGrammar {
+    val grammar = ParserGrammar()
+    val magicRe = Regex("""^#\s*@(\w+)\s*(.*)$""")
+    for (line in source.split("\n")) {
+        val stripped = line.trim()
+        if (!stripped.startsWith("#")) continue
+        magicRe.matchEntire(stripped)?.let { m ->
+            if (m.groupValues[1] == "version") m.groupValues[2].trim().toIntOrNull()?.let { grammar.version = it }
+        }
+    }
+    val tokens = tokenizeGrammar(source)
+    grammar.rules.addAll(GrammarParserImpl(tokens).parseRules())
+    return grammar
+}
+
+// ---------------------------------------------------------------------------
+// Validators
+// ---------------------------------------------------------------------------
+
+private val SYNTHETIC_TOKENS = setOf("NEWLINE", "INDENT", "DEDENT", "EOF")
+
+fun validateParserGrammar(grammar: ParserGrammar, tokenNames: Set<String>? = null): List<String> {
+    val issues = mutableListOf<String>()
+    val defined = grammar.ruleNames()
+    val refRules = grammar.ruleReferences()
+    val refTokens = grammar.tokenReferences()
+
+    val seen = mutableMapOf<String, Int>()
+    for (rule in grammar.rules) {
+        seen[rule.name]?.let {
+            issues.add("Line ${rule.lineNumber}: Duplicate rule name '${rule.name}' (first on line $it)")
+        } ?: run { seen[rule.name] = rule.lineNumber }
+        if (rule.name != rule.name.lowercase()) issues.add("Line ${rule.lineNumber}: Rule name '${rule.name}' should be lowercase")
+    }
+    for (ref in refRules.sorted()) {
+        if (ref !in defined) issues.add("Undefined rule reference: '$ref'")
+    }
+    tokenNames?.let {
+        for (ref in refTokens.sorted()) {
+            if (ref !in it && ref !in SYNTHETIC_TOKENS) issues.add("Undefined token reference: '$ref'")
+        }
+    }
+    if (grammar.rules.isNotEmpty()) {
+        val start = grammar.rules[0].name
+        for (rule in grammar.rules) {
+            if (rule.name != start && rule.name !in refRules)
+                issues.add("Line ${rule.lineNumber}: Rule '${rule.name}' is defined but never referenced (unreachable)")
+        }
+    }
+    return issues
+}
+
+// ---------------------------------------------------------------------------
+// Cross-validator
+// ---------------------------------------------------------------------------
+
+fun crossValidate(tokenGrammar: TokenGrammar, parserGrammar: ParserGrammar): List<String> {
+    val issues = mutableListOf<String>()
+    val definedTokens = tokenGrammar.tokenNames().toMutableSet()
+    definedTokens.addAll(listOf("NEWLINE", "EOF"))
+    if (tokenGrammar.mode == "indentation") definedTokens.addAll(listOf("INDENT", "DEDENT"))
+    val refTokens = parserGrammar.tokenReferences()
+
+    for (ref in refTokens.sorted()) {
+        if (ref !in definedTokens) issues.add("Error: Grammar references token '$ref' which is not defined in the tokens file")
+    }
+    for (defn in tokenGrammar.definitions) {
+        val isUsed = defn.name in refTokens || (defn.alias != null && defn.alias in refTokens)
+        if (!isUsed) issues.add("Warning: Token '${defn.name}' (line ${defn.lineNumber}) is defined but never used in the grammar")
+    }
+    return issues
+}

--- a/code/packages/kotlin/grammar-tools/src/main/kotlin/com/codingadventures/grammartools/TokenGrammar.kt
+++ b/code/packages/kotlin/grammar-tools/src/main/kotlin/com/codingadventures/grammartools/TokenGrammar.kt
@@ -1,0 +1,317 @@
+// ============================================================================
+// TokenGrammar.kt — Token grammar types and parser for .tokens files
+// ============================================================================
+//
+// A .tokens file is a declarative description of a language's lexical grammar.
+// Each line defines a token pattern (regex or literal) that the lexer should
+// recognize. Sections organize keywords, skip patterns, error recovery, and
+// pattern groups for context-sensitive lexing.
+//
+// This file contains all the data types and the parser for .tokens files,
+// following the Kotlin convention of keeping related types together.
+//
+// Layer: TE (text/language layer)
+// ============================================================================
+
+package com.codingadventures.grammartools
+
+// ---------------------------------------------------------------------------
+// Data types
+// ---------------------------------------------------------------------------
+
+/**
+ * A single token rule from a .tokens file.
+ *
+ * @property name       Token name, e.g. "NUMBER" or "PLUS"
+ * @property pattern    The pattern string (without delimiters)
+ * @property isRegex    true if /regex/, false if "literal"
+ * @property lineNumber 1-based line where this definition appeared
+ * @property alias      Optional type alias (e.g. STRING_DQ -> STRING)
+ */
+data class TokenDefinition(
+    val name: String,
+    val pattern: String,
+    val isRegex: Boolean,
+    val lineNumber: Int,
+    val alias: String? = null
+)
+
+/**
+ * A named set of token definitions for context-sensitive lexing.
+ */
+data class PatternGroup(
+    val name: String,
+    val definitions: List<TokenDefinition>
+)
+
+/**
+ * The complete contents of a parsed .tokens file.
+ */
+data class TokenGrammar(
+    var version: Int = 0,
+    var caseInsensitive: Boolean = false,
+    var caseSensitive: Boolean = true,
+    val definitions: MutableList<TokenDefinition> = mutableListOf(),
+    val keywords: MutableList<String> = mutableListOf(),
+    var mode: String? = null,
+    var escapeMode: String? = null,
+    val skipDefinitions: MutableList<TokenDefinition> = mutableListOf(),
+    val errorDefinitions: MutableList<TokenDefinition> = mutableListOf(),
+    val reservedKeywords: MutableList<String> = mutableListOf(),
+    val contextKeywords: MutableList<String> = mutableListOf(),
+    val groups: MutableMap<String, PatternGroup> = mutableMapOf()
+) {
+    /** All defined token names including aliases and group tokens. */
+    fun tokenNames(): Set<String> {
+        val allDefs = definitions + groups.values.flatMap { it.definitions }
+        val names = mutableSetOf<String>()
+        for (d in allDefs) {
+            names.add(d.name)
+            d.alias?.let { names.add(it) }
+        }
+        return names
+    }
+
+    /** Token names as the parser will see them (aliases replace original names). */
+    fun effectiveTokenNames(): Set<String> =
+        (definitions + groups.values.flatMap { it.definitions })
+            .map { it.alias ?: it.name }
+            .toSet()
+}
+
+// ---------------------------------------------------------------------------
+// Exceptions
+// ---------------------------------------------------------------------------
+
+class TokenGrammarError(val msg: String, val line: Int) :
+    Exception("Line $line: $msg")
+
+// ---------------------------------------------------------------------------
+// Parser
+// ---------------------------------------------------------------------------
+
+private val MAGIC_COMMENT = Regex("""^#\s*@(\w+)\s*(.*)$""")
+private val GROUP_NAME_RE = Regex("""^[a-z_][a-z0-9_]*$""")
+private val TOKEN_NAME_RE = Regex("""^[a-zA-Z_][a-zA-Z0-9_]*$""")
+private val RESERVED_GROUP_NAMES = setOf("default", "skip", "keywords", "reserved", "errors")
+
+/**
+ * Parse the full text of a .tokens file into a [TokenGrammar].
+ */
+fun parseTokenGrammar(source: String): TokenGrammar {
+    val grammar = TokenGrammar()
+    val lines = source.split("\n")
+    var currentSection: String? = null
+
+    for ((i, rawLine) in lines.withIndex()) {
+        val lineNumber = i + 1
+        val line = rawLine.trimEnd()
+        val stripped = line.trim()
+
+        if (stripped.isEmpty()) continue
+
+        // Comments and magic comments
+        if (stripped.startsWith("#")) {
+            MAGIC_COMMENT.matchEntire(stripped)?.let { m ->
+                val key = m.groupValues[1]
+                val value = m.groupValues[2].trim()
+                when (key) {
+                    "version" -> value.toIntOrNull()?.let { grammar.version = it }
+                    "case_insensitive" -> grammar.caseInsensitive = (value == "true")
+                }
+            }
+            continue
+        }
+
+        // mode: directive
+        if (stripped.startsWith("mode:")) {
+            val v = stripped.removePrefix("mode:").trim()
+            if (v.isEmpty()) throw TokenGrammarError("Missing value after 'mode:'", lineNumber)
+            grammar.mode = v
+            currentSection = null
+            continue
+        }
+
+        // escapes: directive
+        if (stripped.startsWith("escapes:")) {
+            val v = stripped.removePrefix("escapes:").trim()
+            if (v.isEmpty()) throw TokenGrammarError("Missing value after 'escapes:'", lineNumber)
+            grammar.escapeMode = v
+            currentSection = null
+            continue
+        }
+
+        // case_sensitive: directive
+        if (stripped.startsWith("case_sensitive:")) {
+            val v = stripped.removePrefix("case_sensitive:").trim().lowercase()
+            if (v != "true" && v != "false")
+                throw TokenGrammarError("Invalid value for 'case_sensitive:': '$v'", lineNumber)
+            grammar.caseSensitive = (v == "true")
+            currentSection = null
+            continue
+        }
+
+        // Group headers
+        if (stripped.startsWith("group ") && stripped.endsWith(":")) {
+            val groupName = stripped.removePrefix("group ").removeSuffix(":").trim()
+            if (groupName.isEmpty()) throw TokenGrammarError("Missing group name after 'group'", lineNumber)
+            if (!GROUP_NAME_RE.matches(groupName))
+                throw TokenGrammarError("Invalid group name: '$groupName'", lineNumber)
+            if (groupName in RESERVED_GROUP_NAMES)
+                throw TokenGrammarError("Reserved group name: '$groupName'", lineNumber)
+            if (groupName in grammar.groups)
+                throw TokenGrammarError("Duplicate group name: '$groupName'", lineNumber)
+            grammar.groups[groupName] = PatternGroup(groupName, mutableListOf())
+            currentSection = "group:$groupName"
+            continue
+        }
+
+        // Section headers
+        when (stripped) {
+            "keywords:", "keywords :" -> { currentSection = "keywords"; continue }
+            "reserved:", "reserved :" -> { currentSection = "reserved"; continue }
+            "skip:", "skip :" -> { currentSection = "skip"; continue }
+            "errors:", "errors :" -> { currentSection = "errors"; continue }
+            "context_keywords:", "context_keywords :" -> { currentSection = "context_keywords"; continue }
+        }
+
+        // Inside a section
+        if (currentSection != null) {
+            if (line.isNotEmpty() && (line[0] == ' ' || line[0] == '\t')) {
+                if (stripped.isEmpty()) continue
+                when {
+                    currentSection == "keywords" -> grammar.keywords.add(stripped)
+                    currentSection == "reserved" -> grammar.reservedKeywords.add(stripped)
+                    currentSection == "context_keywords" -> grammar.contextKeywords.add(stripped)
+                    currentSection == "skip" -> parseSectionDef(stripped, lineNumber, grammar.skipDefinitions, "skip pattern")
+                    currentSection == "errors" -> parseSectionDef(stripped, lineNumber, grammar.errorDefinitions, "error pattern")
+                    currentSection!!.startsWith("group:") -> {
+                        val gName = currentSection!!.removePrefix("group:")
+                        val eqIdx = stripped.indexOf('=')
+                        if (eqIdx == -1) throw TokenGrammarError("Expected definition in group '$gName'", lineNumber)
+                        val n = stripped.substring(0, eqIdx).trim()
+                        val p = stripped.substring(eqIdx + 1).trim()
+                        if (n.isEmpty() || p.isEmpty()) throw TokenGrammarError("Incomplete definition in group '$gName'", lineNumber)
+                        val defn = parseDefinition(p, n, lineNumber)
+                        val old = grammar.groups[gName]!!
+                        grammar.groups[gName] = PatternGroup(gName, old.definitions + defn)
+                    }
+                }
+                continue
+            }
+            currentSection = null
+        }
+
+        // Token definition
+        val eqIndex = line.indexOf('=')
+        if (eqIndex == -1) throw TokenGrammarError("Expected token definition, got: '$stripped'", lineNumber)
+        val namePart = line.substring(0, eqIndex).trim()
+        val patternPart = line.substring(eqIndex + 1).trim()
+        if (namePart.isEmpty()) throw TokenGrammarError("Missing token name before '='", lineNumber)
+        if (!TOKEN_NAME_RE.matches(namePart))
+            throw TokenGrammarError("Invalid token name: '$namePart'", lineNumber)
+        if (patternPart.isEmpty()) throw TokenGrammarError("Missing pattern after '='", lineNumber)
+        grammar.definitions.add(parseDefinition(patternPart, namePart, lineNumber))
+    }
+    return grammar
+}
+
+private fun parseSectionDef(stripped: String, lineNumber: Int, target: MutableList<TokenDefinition>, label: String) {
+    val eqIdx = stripped.indexOf('=')
+    if (eqIdx == -1) throw TokenGrammarError("Expected $label definition", lineNumber)
+    val n = stripped.substring(0, eqIdx).trim()
+    val p = stripped.substring(eqIdx + 1).trim()
+    if (n.isEmpty() || p.isEmpty()) throw TokenGrammarError("Incomplete $label definition", lineNumber)
+    target.add(parseDefinition(p, n, lineNumber))
+}
+
+internal fun parseDefinition(patternPart: String, namePart: String, lineNumber: Int): TokenDefinition {
+    return when {
+        patternPart.startsWith("/") -> {
+            val lastSlash = findClosingSlash(patternPart)
+            if (lastSlash == -1) throw TokenGrammarError("Unclosed regex pattern for token '$namePart'", lineNumber)
+            val body = patternPart.substring(1, lastSlash)
+            if (body.isEmpty()) throw TokenGrammarError("Empty regex pattern for token '$namePart'", lineNumber)
+            val remainder = patternPart.substring(lastSlash + 1).trim()
+            val alias = parseAlias(remainder, namePart, lineNumber)
+            TokenDefinition(namePart, body, true, lineNumber, alias)
+        }
+        patternPart.startsWith("\"") -> {
+            val closeQuote = patternPart.indexOf('"', 1)
+            if (closeQuote == -1) throw TokenGrammarError("Unclosed literal pattern for token '$namePart'", lineNumber)
+            val body = patternPart.substring(1, closeQuote)
+            if (body.isEmpty()) throw TokenGrammarError("Empty literal pattern for token '$namePart'", lineNumber)
+            val remainder = patternPart.substring(closeQuote + 1).trim()
+            val alias = parseAlias(remainder, namePart, lineNumber)
+            TokenDefinition(namePart, body, false, lineNumber, alias)
+        }
+        else -> throw TokenGrammarError("Pattern must be /regex/ or \"literal\"", lineNumber)
+    }
+}
+
+private fun parseAlias(remainder: String, namePart: String, lineNumber: Int): String? {
+    if (remainder.isEmpty()) return null
+    if (remainder.startsWith("->")) {
+        val alias = remainder.removePrefix("->").trim()
+        if (alias.isEmpty()) throw TokenGrammarError("Missing alias after '->' for '$namePart'", lineNumber)
+        return alias
+    }
+    throw TokenGrammarError("Unexpected text after pattern for '$namePart'", lineNumber)
+}
+
+internal fun findClosingSlash(s: String): Int {
+    var inBracket = false
+    var i = 1
+    while (i < s.length) {
+        val ch = s[i]
+        if (ch == '\\') { i += 2; continue }
+        if (ch == '[' && !inBracket) inBracket = true
+        else if (ch == ']' && inBracket) inBracket = false
+        else if (ch == '/' && !inBracket) return i
+        i++
+    }
+    val last = s.lastIndexOf('/')
+    return if (last > 0) last else -1
+}
+
+// ---------------------------------------------------------------------------
+// Validator
+// ---------------------------------------------------------------------------
+
+fun validateTokenGrammar(grammar: TokenGrammar): List<String> {
+    val issues = mutableListOf<String>()
+    issues.addAll(validateDefs(grammar.definitions, "token"))
+    issues.addAll(validateDefs(grammar.skipDefinitions, "skip pattern"))
+    issues.addAll(validateDefs(grammar.errorDefinitions, "error pattern"))
+
+    grammar.mode?.let { if (it != "indentation") issues.add("Unknown lexer mode '$it'") }
+    grammar.escapeMode?.let { if (it != "none") issues.add("Unknown escape mode '$it'") }
+
+    for ((name, group) in grammar.groups) {
+        if (!GROUP_NAME_RE.matches(name)) issues.add("Invalid group name '$name'")
+        if (group.definitions.isEmpty()) issues.add("Empty pattern group '$name'")
+        issues.addAll(validateDefs(group.definitions, "group '$name' token"))
+    }
+    return issues
+}
+
+private fun validateDefs(definitions: List<TokenDefinition>, label: String): List<String> {
+    val issues = mutableListOf<String>()
+    val seen = mutableMapOf<String, Int>()
+    for (d in definitions) {
+        seen[d.name]?.let {
+            issues.add("Line ${d.lineNumber}: Duplicate $label name '${d.name}' (first on line $it)")
+        } ?: run { seen[d.name] = d.lineNumber }
+
+        if (d.pattern.isEmpty()) issues.add("Line ${d.lineNumber}: Empty pattern for $label '${d.name}'")
+
+        if (d.isRegex) {
+            try { Regex(d.pattern) }
+            catch (e: Exception) { issues.add("Line ${d.lineNumber}: Invalid regex for $label '${d.name}'") }
+        }
+
+        if (d.name != d.name.uppercase()) issues.add("Line ${d.lineNumber}: Token name '${d.name}' should be UPPER_CASE")
+        d.alias?.let { if (it != it.uppercase()) issues.add("Line ${d.lineNumber}: Alias '$it' should be UPPER_CASE") }
+    }
+    return issues
+}

--- a/code/packages/kotlin/grammar-tools/src/test/kotlin/com/codingadventures/grammartools/GrammarToolsTest.kt
+++ b/code/packages/kotlin/grammar-tools/src/test/kotlin/com/codingadventures/grammartools/GrammarToolsTest.kt
@@ -1,0 +1,263 @@
+package com.codingadventures.grammartools
+
+import kotlin.test.*
+
+class GrammarToolsTest {
+
+    // === Token Grammar Parsing ===
+
+    @Test fun emptyInput() {
+        val g = parseTokenGrammar("")
+        assertTrue(g.definitions.isEmpty())
+    }
+
+    @Test fun simpleRegex() {
+        val g = parseTokenGrammar("NUMBER = /[0-9]+/\n")
+        assertEquals(1, g.definitions.size)
+        assertEquals("NUMBER", g.definitions[0].name)
+        assertEquals("[0-9]+", g.definitions[0].pattern)
+        assertTrue(g.definitions[0].isRegex)
+    }
+
+    @Test fun simpleLiteral() {
+        val g = parseTokenGrammar("PLUS = \"+\"\n")
+        assertEquals("+", g.definitions[0].pattern)
+        assertFalse(g.definitions[0].isRegex)
+    }
+
+    @Test fun aliasDefinition() {
+        val g = parseTokenGrammar("STRING_DQ = /\"[^\"]*\"/ -> STRING\n")
+        assertEquals("STRING", g.definitions[0].alias)
+    }
+
+    @Test fun keywordsSection() {
+        val g = parseTokenGrammar("NAME = /[a-z]+/\nkeywords:\n  if\n  else\n")
+        assertEquals(listOf("if", "else"), g.keywords)
+    }
+
+    @Test fun reservedKeywords() {
+        val g = parseTokenGrammar("NAME = /[a-z]+/\nreserved:\n  class\n")
+        assertEquals(listOf("class"), g.reservedKeywords)
+    }
+
+    @Test fun skipSection() {
+        val g = parseTokenGrammar("NAME = /[a-z]+/\nskip:\n  WS = /[ \\t]+/\n")
+        assertEquals(1, g.skipDefinitions.size)
+    }
+
+    @Test fun errorsSection() {
+        val g = parseTokenGrammar("NAME = /[a-z]+/\nerrors:\n  BAD = /[^\\n]*/\n")
+        assertEquals(1, g.errorDefinitions.size)
+    }
+
+    @Test fun modeDirective() {
+        val g = parseTokenGrammar("mode: indentation\nNAME = /[a-z]+/\n")
+        assertEquals("indentation", g.mode)
+    }
+
+    @Test fun escapesDirective() {
+        val g = parseTokenGrammar("escapes: none\nSTRING = /\"[^\"]*\"/\n")
+        assertEquals("none", g.escapeMode)
+    }
+
+    @Test fun caseSensitiveDirective() {
+        val g = parseTokenGrammar("case_sensitive: false\nNAME = /[a-z]+/\n")
+        assertFalse(g.caseSensitive)
+    }
+
+    @Test fun magicCommentVersion() {
+        val g = parseTokenGrammar("# @version 2\nNUMBER = /[0-9]+/\n")
+        assertEquals(2, g.version)
+    }
+
+    @Test fun patternGroup() {
+        val g = parseTokenGrammar("OPEN = \"<\"\ngroup tag:\n  ATTR = /[a-z]+/\n")
+        assertTrue("tag" in g.groups)
+        assertEquals(1, g.groups["tag"]!!.definitions.size)
+    }
+
+    @Test fun contextKeywords() {
+        val g = parseTokenGrammar("NAME = /[a-z]+/\ncontext_keywords:\n  async\n")
+        assertEquals(listOf("async"), g.contextKeywords)
+    }
+
+    @Test fun tokenNames() {
+        val g = parseTokenGrammar("NUM = /[0-9]+/\nSTR_DQ = /\".*\"/ -> STR\n")
+        val names = g.tokenNames()
+        assertTrue("NUM" in names)
+        assertTrue("STR_DQ" in names)
+        assertTrue("STR" in names)
+    }
+
+    @Test fun effectiveTokenNames() {
+        val g = parseTokenGrammar("NUM = /[0-9]+/\nSTR_DQ = /\".*\"/ -> STR\n")
+        val names = g.effectiveTokenNames()
+        assertTrue("NUM" in names)
+        assertFalse("STR_DQ" in names)
+        assertTrue("STR" in names)
+    }
+
+    @Test fun unclosedRegex() {
+        assertFailsWith<TokenGrammarError> { parseTokenGrammar("BAD = /unclosed\n") }
+    }
+
+    @Test fun duplicateGroup() {
+        assertFailsWith<TokenGrammarError> { parseTokenGrammar("group a:\n  X = \"x\"\ngroup a:\n  Y = \"y\"\n") }
+    }
+
+    @Test fun reservedGroupName() {
+        assertFailsWith<TokenGrammarError> { parseTokenGrammar("group default:\n  X = \"x\"\n") }
+    }
+
+    // === Token Grammar Validation ===
+
+    @Test fun validGrammar() {
+        val g = parseTokenGrammar("NUMBER = /[0-9]+/\n")
+        assertTrue(validateTokenGrammar(g).isEmpty())
+    }
+
+    @Test fun duplicateNameWarning() {
+        val g = TokenGrammar(definitions = mutableListOf(
+            TokenDefinition("NUM", "[0-9]+", true, 1),
+            TokenDefinition("NUM", "[0-9]+", true, 2)
+        ))
+        assertTrue(validateTokenGrammar(g).any { "Duplicate" in it })
+    }
+
+    @Test fun invalidRegexWarning() {
+        val g = TokenGrammar(definitions = mutableListOf(
+            TokenDefinition("BAD", "[unclosed", true, 1)
+        ))
+        assertTrue(validateTokenGrammar(g).any { "Invalid regex" in it })
+    }
+
+    @Test fun nonUpperCaseWarning() {
+        val g = TokenGrammar(definitions = mutableListOf(
+            TokenDefinition("number", "[0-9]+", true, 1)
+        ))
+        assertTrue(validateTokenGrammar(g).any { "UPPER_CASE" in it })
+    }
+
+    @Test fun unknownMode() {
+        val g = TokenGrammar(mode = "bad")
+        assertTrue(validateTokenGrammar(g).any { "Unknown lexer mode" in it })
+    }
+
+    // === Parser Grammar Parsing ===
+
+    @Test fun simpleRule() {
+        val g = parseParserGrammar("program = NUMBER ;")
+        assertEquals(1, g.rules.size)
+        assertEquals("program", g.rules[0].name)
+    }
+
+    @Test fun alternation() {
+        val g = parseParserGrammar("expr = NUMBER | NAME ;")
+        assertIs<Alternation>(g.rules[0].body)
+    }
+
+    @Test fun sequence() {
+        val g = parseParserGrammar("a = NAME EQUALS NUMBER ;")
+        assertIs<Sequence>(g.rules[0].body)
+    }
+
+    @Test fun repetition() {
+        val g = parseParserGrammar("list = { item } ;")
+        assertIs<Repetition>(g.rules[0].body)
+    }
+
+    @Test fun oneOrMore() {
+        val g = parseParserGrammar("list = { item }+ ;")
+        assertIs<OneOrMoreRepetition>(g.rules[0].body)
+    }
+
+    @Test fun optional() {
+        val g = parseParserGrammar("call = NAME [ args ] ;")
+        assertIs<Sequence>(g.rules[0].body)
+    }
+
+    @Test fun literal() {
+        val g = parseParserGrammar("op = \"+\" ;")
+        assertIs<Literal>(g.rules[0].body)
+        assertEquals("+", (g.rules[0].body as Literal).value)
+    }
+
+    @Test fun positiveLookahead() {
+        val g = parseParserGrammar("c = &NUMBER item ;")
+        assertIs<Sequence>(g.rules[0].body)
+    }
+
+    @Test fun negativeLookahead() {
+        val g = parseParserGrammar("c = !NUMBER item ;")
+        assertIs<Sequence>(g.rules[0].body)
+    }
+
+    @Test fun separatedRepetition() {
+        val g = parseParserGrammar("args = { expr // COMMA } ;")
+        assertIs<SeparatedRepetition>(g.rules[0].body)
+    }
+
+    @Test fun ruleReferences() {
+        val g = parseParserGrammar("p = { stmt } ;\nstmt = expr ;")
+        assertTrue("stmt" in g.ruleReferences())
+        assertTrue("expr" in g.ruleReferences())
+    }
+
+    @Test fun tokenReferences() {
+        val g = parseParserGrammar("a = NAME EQUALS NUMBER ;")
+        assertTrue("NAME" in g.tokenReferences())
+        assertTrue("EQUALS" in g.tokenReferences())
+    }
+
+    @Test fun magicVersion() {
+        val g = parseParserGrammar("# @version 3\nexpr = NUMBER ;")
+        assertEquals(3, g.version)
+    }
+
+    // === Parser Grammar Validation ===
+
+    @Test fun validParserGrammar() {
+        val g = parseParserGrammar("p = { s } ;\ns = NUMBER ;")
+        assertTrue(validateParserGrammar(g).isEmpty())
+    }
+
+    @Test fun undefinedRuleRef() {
+        val g = parseParserGrammar("p = undef ;")
+        assertTrue(validateParserGrammar(g).any { "Undefined rule" in it })
+    }
+
+    @Test fun undefinedTokenRef() {
+        val g = parseParserGrammar("p = MISSING ;")
+        assertTrue(validateParserGrammar(g, setOf("NUMBER")).any { "Undefined token" in it })
+    }
+
+    @Test fun syntheticTokensValid() {
+        val g = parseParserGrammar("p = NEWLINE EOF ;")
+        assertFalse(validateParserGrammar(g, emptySet()).any { "Undefined token" in it })
+    }
+
+    @Test fun unreachableRule() {
+        val g = parseParserGrammar("start = NUMBER ;\nunused = NAME ;")
+        assertTrue(validateParserGrammar(g).any { "unreachable" in it })
+    }
+
+    // === Cross Validation ===
+
+    @Test fun consistentGrammars() {
+        val tg = parseTokenGrammar("NUMBER = /[0-9]+/\nNAME = /[a-z]+/\n")
+        val pg = parseParserGrammar("expr = NUMBER | NAME ;")
+        assertTrue(crossValidate(tg, pg).isEmpty())
+    }
+
+    @Test fun missingToken() {
+        val tg = parseTokenGrammar("NUMBER = /[0-9]+/\n")
+        val pg = parseParserGrammar("expr = NUMBER | MISSING ;")
+        assertTrue(crossValidate(tg, pg).any { "Error:" in it && "MISSING" in it })
+    }
+
+    @Test fun unusedToken() {
+        val tg = parseTokenGrammar("NUMBER = /[0-9]+/\nUNUSED = \"~\"\n")
+        val pg = parseParserGrammar("expr = NUMBER ;")
+        assertTrue(crossValidate(tg, pg).any { "Warning:" in it && "UNUSED" in it })
+    }
+}

--- a/code/packages/kotlin/lexer/.gitignore
+++ b/code/packages/kotlin/lexer/.gitignore
@@ -1,0 +1,2 @@
+gradle-build/
+.gradle/

--- a/code/packages/kotlin/lexer/BUILD
+++ b/code/packages/kotlin/lexer/BUILD
@@ -1,0 +1,1 @@
+cd ../grammar-tools && gradle jar && cd ../lexer && gradle test

--- a/code/packages/kotlin/lexer/BUILD_windows
+++ b/code/packages/kotlin/lexer/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/lexer/CHANGELOG.md
+++ b/code/packages/kotlin/lexer/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0 — 2026-04-04
+
+### Added
+- Token data class with type, value, line, column, typeName, flags
+- GrammarLexer — grammar-driven tokenizer using TokenGrammar
+- Full test suite

--- a/code/packages/kotlin/lexer/README.md
+++ b/code/packages/kotlin/lexer/README.md
@@ -1,0 +1,7 @@
+# lexer (Kotlin)
+
+Generic lexer/tokenizer infrastructure for the coding-adventures project.
+
+## Layer
+
+TE (text/language layer) — depends on grammar-tools.

--- a/code/packages/kotlin/lexer/build.gradle.kts
+++ b/code/packages/kotlin/lexer/build.gradle.kts
@@ -1,0 +1,35 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    targetCompatibility = "21"
+    sourceCompatibility = "21"
+}
+
+dependencies {
+    implementation("com.codingadventures:grammar-tools")
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/lexer/settings.gradle.kts
+++ b/code/packages/kotlin/lexer/settings.gradle.kts
@@ -1,0 +1,3 @@
+rootProject.name = "lexer"
+
+includeBuild("../grammar-tools")

--- a/code/packages/kotlin/lexer/src/main/kotlin/com/codingadventures/lexer/Lexer.kt
+++ b/code/packages/kotlin/lexer/src/main/kotlin/com/codingadventures/lexer/Lexer.kt
@@ -1,0 +1,181 @@
+// ============================================================================
+// Lexer.kt — Token types and grammar-driven lexer
+// ============================================================================
+//
+// A lexer (also called a tokenizer or scanner) breaks source code into a
+// stream of tokens. This file contains all the types and the GrammarLexer.
+//
+// Layer: TE (text/language layer)
+// ============================================================================
+
+package com.codingadventures.lexer
+
+import com.codingadventures.grammartools.TokenDefinition
+import com.codingadventures.grammartools.TokenGrammar
+
+// ---------------------------------------------------------------------------
+// Token types
+// ---------------------------------------------------------------------------
+
+enum class TokenType {
+    NAME, NUMBER, STRING, KEYWORD,
+    PLUS, MINUS, STAR, SLASH,
+    EQUALS, EQUALS_EQUALS,
+    LPAREN, RPAREN, COMMA, COLON, SEMICOLON,
+    LBRACE, RBRACE, LBRACKET, RBRACKET,
+    DOT, BANG, NEWLINE, EOF,
+    GRAMMAR  // Grammar-driven token — actual type is in typeName
+}
+
+/** Bitmask flag: a line break appeared before this token. */
+const val FLAG_PRECEDED_BY_NEWLINE = 1
+/** Bitmask flag: this is a context-sensitive keyword. */
+const val FLAG_CONTEXT_KEYWORD = 2
+
+/**
+ * An immutable token from source code.
+ */
+data class Token(
+    val type: TokenType,
+    val value: String,
+    val line: Int,
+    val column: Int,
+    val typeName: String? = null,
+    val flags: Int = 0
+) {
+    fun effectiveTypeName(): String = typeName ?: type.name
+    fun hasFlag(flag: Int): Boolean = (flags and flag) != 0
+    override fun toString() = "Token(${effectiveTypeName()}, \"$value\", $line:$column)"
+}
+
+// ---------------------------------------------------------------------------
+// Exceptions
+// ---------------------------------------------------------------------------
+
+class LexerError(message: String, val line: Int, val column: Int) :
+    Exception("Lexer error at $line:$column: $message")
+
+// ---------------------------------------------------------------------------
+// Compiled pattern
+// ---------------------------------------------------------------------------
+
+private data class CompiledPattern(val name: String, val regex: Regex, val alias: String?)
+
+// ---------------------------------------------------------------------------
+// Grammar-driven lexer
+// ---------------------------------------------------------------------------
+
+/**
+ * A lexer driven by a [TokenGrammar]. Compiles token definitions into
+ * regexes and tries them in priority order at each source position.
+ */
+class GrammarLexer(private val grammar: TokenGrammar) {
+
+    private val patterns = compileDefinitions(grammar.definitions)
+    private val skipPatterns = compileDefinitions(grammar.skipDefinitions)
+    private val errorPatterns = compileDefinitions(grammar.errorDefinitions)
+    private val keywordSet = grammar.keywords.toSet()
+    private val reservedSet = grammar.reservedKeywords.toSet()
+    private val contextKeywordSet = grammar.contextKeywords.toSet()
+
+    /**
+     * Tokenize source code into a list of tokens.
+     * The returned list always ends with an EOF token.
+     */
+    fun tokenize(source: String): List<Token> {
+        val working = if (grammar.caseSensitive) source else source.lowercase()
+        val tokens = mutableListOf<Token>()
+        var pos = 0
+        var line = 1
+        var column = 1
+        var precededByNewline = false
+
+        while (pos < working.length) {
+            // Try skip patterns first
+            var skipped = false
+            for (sp in skipPatterns) {
+                val m = sp.regex.find(working, pos)
+                if (m != null && m.range.first == pos) {
+                    for (ch in m.value) {
+                        if (ch == '\n') { line++; column = 1; precededByNewline = true }
+                        else column++
+                    }
+                    pos += m.value.length
+                    skipped = true
+                    break
+                }
+            }
+            if (skipped) continue
+
+            // Try token patterns
+            var matched = false
+            for (cp in patterns) {
+                val m = cp.regex.find(working, pos)
+                if (m != null && m.range.first == pos) {
+                    val value = source.substring(pos, pos + m.value.length)
+                    val typeName = cp.alias ?: cp.name
+
+                    if (typeName == "NAME" && value in reservedSet)
+                        throw LexerError("Reserved keyword '$value'", line, column)
+
+                    var flags = 0
+                    if (precededByNewline) flags = flags or FLAG_PRECEDED_BY_NEWLINE
+                    val checkVal = if (grammar.caseSensitive) value else value.lowercase()
+                    if (typeName == "NAME" && checkVal in contextKeywordSet)
+                        flags = flags or FLAG_CONTEXT_KEYWORD
+
+                    tokens.add(Token(TokenType.GRAMMAR, value, line, column, typeName, flags))
+                    for (ch in value) {
+                        if (ch == '\n') { line++; column = 1 } else column++
+                    }
+                    pos += value.length
+                    matched = true
+                    precededByNewline = false
+                    break
+                }
+            }
+            if (matched) continue
+
+            // Try error recovery patterns
+            var errorMatched = false
+            for (ep in errorPatterns) {
+                val m = ep.regex.find(working, pos)
+                if (m != null && m.range.first == pos) {
+                    val value = source.substring(pos, pos + m.value.length)
+                    tokens.add(Token(TokenType.GRAMMAR, value, line, column, ep.alias ?: ep.name))
+                    for (ch in value) {
+                        if (ch == '\n') { line++; column = 1 } else column++
+                    }
+                    pos += value.length
+                    errorMatched = true
+                    break
+                }
+            }
+            if (errorMatched) continue
+
+            throw LexerError("Unexpected character '${source[pos]}'", line, column)
+        }
+
+        // Keyword promotion
+        if (keywordSet.isNotEmpty()) {
+            for (i in tokens.indices) {
+                val t = tokens[i]
+                if (t.typeName == "NAME") {
+                    val checkVal = if (grammar.caseSensitive) t.value else t.value.lowercase()
+                    if (checkVal in keywordSet) {
+                        tokens[i] = Token(TokenType.KEYWORD, t.value, t.line, t.column, "KEYWORD", t.flags)
+                    }
+                }
+            }
+        }
+
+        tokens.add(Token(TokenType.EOF, "", line, column, "EOF"))
+        return tokens
+    }
+
+    private fun compileDefinitions(defs: List<TokenDefinition>): List<CompiledPattern> =
+        defs.map { defn ->
+            val pattern = if (defn.isRegex) "\\G(?:${defn.pattern})" else "\\G${Regex.escape(defn.pattern)}"
+            CompiledPattern(defn.name, Regex(pattern), defn.alias)
+        }
+}

--- a/code/packages/kotlin/lexer/src/test/kotlin/com/codingadventures/lexer/LexerTest.kt
+++ b/code/packages/kotlin/lexer/src/test/kotlin/com/codingadventures/lexer/LexerTest.kt
@@ -1,0 +1,95 @@
+package com.codingadventures.lexer
+
+import com.codingadventures.grammartools.parseTokenGrammar
+import kotlin.test.*
+
+class LexerTest {
+
+    @Test fun tokenConstruction() {
+        val t = Token(TokenType.NUMBER, "42", 1, 1)
+        assertEquals(TokenType.NUMBER, t.type)
+        assertEquals("42", t.value)
+    }
+
+    @Test fun effectiveTypeName() {
+        assertEquals("NUMBER", Token(TokenType.NUMBER, "42", 1, 1).effectiveTypeName())
+        assertEquals("INT", Token(TokenType.GRAMMAR, "42", 1, 1, "INT").effectiveTypeName())
+    }
+
+    @Test fun flags() {
+        val t = Token(TokenType.GRAMMAR, "x", 1, 1, "NAME", FLAG_PRECEDED_BY_NEWLINE)
+        assertTrue(t.hasFlag(FLAG_PRECEDED_BY_NEWLINE))
+        assertFalse(t.hasFlag(FLAG_CONTEXT_KEYWORD))
+    }
+
+    @Test fun simpleTokenization() {
+        val g = parseTokenGrammar("NUMBER = /[0-9]+/\nPLUS = \"+\"\nskip:\n  WS = /[ \\t]+/\n")
+        val tokens = GrammarLexer(g).tokenize("42 + 7")
+        assertEquals(4, tokens.size)
+        assertEquals("NUMBER", tokens[0].typeName)
+        assertEquals("42", tokens[0].value)
+        assertEquals("PLUS", tokens[1].typeName)
+        assertEquals("NUMBER", tokens[2].typeName)
+        assertEquals("EOF", tokens[3].typeName)
+    }
+
+    @Test fun lineColumnTracking() {
+        val g = parseTokenGrammar("NAME = /[a-z]+/\nNL = /\\n/\nskip:\n  WS = /[ \\t]+/\n")
+        val tokens = GrammarLexer(g).tokenize("abc\ndef")
+        assertEquals(1, tokens[0].line)
+        assertEquals(1, tokens[0].column)
+        assertEquals(2, tokens[2].line)
+        assertEquals(1, tokens[2].column)
+    }
+
+    @Test fun keywordPromotion() {
+        val g = parseTokenGrammar("NAME = /[a-z]+/\nskip:\n  WS = /[ \\t]+/\nkeywords:\n  if\n  else\n")
+        val tokens = GrammarLexer(g).tokenize("if x else y")
+        assertEquals("KEYWORD", tokens[0].typeName)
+        assertEquals("NAME", tokens[1].typeName)
+        assertEquals("KEYWORD", tokens[2].typeName)
+    }
+
+    @Test fun aliasedToken() {
+        val g = parseTokenGrammar("STRING_DQ = /\"[^\"]*\"/ -> STRING\n")
+        val tokens = GrammarLexer(g).tokenize("\"hello\"")
+        assertEquals("STRING", tokens[0].typeName)
+    }
+
+    @Test fun unexpectedCharacter() {
+        val g = parseTokenGrammar("NUMBER = /[0-9]+/\n")
+        assertFailsWith<LexerError> { GrammarLexer(g).tokenize("abc") }
+    }
+
+    @Test fun reservedKeyword() {
+        val g = parseTokenGrammar("NAME = /[a-z]+/\nreserved:\n  class\n")
+        assertFailsWith<LexerError> { GrammarLexer(g).tokenize("class") }
+    }
+
+    @Test fun emptyInput() {
+        val g = parseTokenGrammar("NUMBER = /[0-9]+/\n")
+        val tokens = GrammarLexer(g).tokenize("")
+        assertEquals(1, tokens.size)
+        assertEquals("EOF", tokens[0].typeName)
+    }
+
+    @Test fun contextKeywordFlag() {
+        val g = parseTokenGrammar("NAME = /[a-z]+/\nskip:\n  WS = /[ \\t]+/\ncontext_keywords:\n  async\n")
+        val tokens = GrammarLexer(g).tokenize("async foo")
+        assertTrue(tokens[0].hasFlag(FLAG_CONTEXT_KEYWORD))
+        assertFalse(tokens[1].hasFlag(FLAG_CONTEXT_KEYWORD))
+    }
+
+    @Test fun errorRecovery() {
+        val g = parseTokenGrammar("STRING = /\"[^\"]*\"/\nskip:\n  WS = /[ \\t]+/\nerrors:\n  BAD_STRING = /\"[^\"\\n]*/\n")
+        val tokens = GrammarLexer(g).tokenize("\"unclosed")
+        assertEquals("BAD_STRING", tokens[0].typeName)
+    }
+
+    @Test fun precededByNewlineFlag() {
+        val g = parseTokenGrammar("NAME = /[a-z]+/\nskip:\n  WS = /[ \\t\\n]+/\n")
+        val tokens = GrammarLexer(g).tokenize("a\nb")
+        assertFalse(tokens[0].hasFlag(FLAG_PRECEDED_BY_NEWLINE))
+        assertTrue(tokens[1].hasFlag(FLAG_PRECEDED_BY_NEWLINE))
+    }
+}

--- a/code/packages/kotlin/parser/.gitignore
+++ b/code/packages/kotlin/parser/.gitignore
@@ -1,0 +1,2 @@
+gradle-build/
+.gradle/

--- a/code/packages/kotlin/parser/BUILD
+++ b/code/packages/kotlin/parser/BUILD
@@ -1,0 +1,1 @@
+cd ../grammar-tools && gradle jar && cd ../lexer && gradle jar && cd ../parser && gradle test

--- a/code/packages/kotlin/parser/BUILD_windows
+++ b/code/packages/kotlin/parser/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/parser/CHANGELOG.md
+++ b/code/packages/kotlin/parser/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0 — 2026-04-04
+
+### Added
+- ASTNode data class with position tracking
+- GrammarParser — recursive descent parser with packrat memoization
+- Full test suite

--- a/code/packages/kotlin/parser/README.md
+++ b/code/packages/kotlin/parser/README.md
@@ -1,0 +1,7 @@
+# parser (Kotlin)
+
+Generic grammar-driven parser infrastructure for the coding-adventures project.
+
+## Layer
+
+TE (text/language layer) — depends on grammar-tools and lexer.

--- a/code/packages/kotlin/parser/build.gradle.kts
+++ b/code/packages/kotlin/parser/build.gradle.kts
@@ -1,0 +1,36 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    targetCompatibility = "21"
+    sourceCompatibility = "21"
+}
+
+dependencies {
+    implementation("com.codingadventures:grammar-tools")
+    implementation("com.codingadventures:lexer")
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/parser/settings.gradle.kts
+++ b/code/packages/kotlin/parser/settings.gradle.kts
@@ -1,0 +1,4 @@
+rootProject.name = "parser"
+
+includeBuild("../grammar-tools")
+includeBuild("../lexer")

--- a/code/packages/kotlin/parser/src/main/kotlin/com/codingadventures/parser/Parser.kt
+++ b/code/packages/kotlin/parser/src/main/kotlin/com/codingadventures/parser/Parser.kt
@@ -1,0 +1,213 @@
+// ============================================================================
+// Parser.kt — Grammar-driven recursive descent parser with packrat memoization
+// ============================================================================
+//
+// Takes a token stream and a ParserGrammar and produces an AST.
+//
+// Layer: TE (text/language layer)
+// ============================================================================
+
+package com.codingadventures.parser
+
+import com.codingadventures.grammartools.*
+import com.codingadventures.lexer.Token
+
+// ---------------------------------------------------------------------------
+// AST node
+// ---------------------------------------------------------------------------
+
+/**
+ * A generic AST node produced by grammar-driven parsing.
+ * Children can be either ASTNode or Token instances.
+ */
+data class ASTNode(
+    val ruleName: String,
+    val children: List<Any>,  // ASTNode or Token
+    val startLine: Int = 0,
+    val startColumn: Int = 0,
+    val endLine: Int = 0,
+    val endColumn: Int = 0
+) {
+    val isLeaf: Boolean get() = children.size == 1 && children[0] is Token
+    val token: Token? get() = if (isLeaf) children[0] as Token else null
+
+    fun descendantCount(): Int = children.sumOf { child ->
+        1 + if (child is ASTNode) child.descendantCount() else 0
+    }
+}
+
+class GrammarParseError(message: String, val token: Token) :
+    Exception("Parse error at ${token.line}:${token.column}: $message")
+
+// ---------------------------------------------------------------------------
+// Memo entry
+// ---------------------------------------------------------------------------
+
+private data class MemoEntry(val children: List<Any>?, val endPos: Int, val ok: Boolean)
+private data class MatchResult(val children: List<Any>, val endPos: Int)
+
+// ---------------------------------------------------------------------------
+// Grammar parser
+// ---------------------------------------------------------------------------
+
+class GrammarParser(private val grammar: ParserGrammar) {
+
+    private val ruleMap: Map<String, GrammarRule> = grammar.rules.associateBy { it.name }
+
+    fun parse(tokens: List<Token>): ASTNode {
+        if (grammar.rules.isEmpty())
+            throw GrammarParseError("No rules in grammar", tokens.last())
+
+        val startRule = grammar.rules[0].name
+        val memo = mutableMapOf<String, MutableMap<Int, MemoEntry>>()
+
+        val result = matchRule(startRule, tokens, 0, memo)
+            ?: throw GrammarParseError("Failed to parse starting rule '$startRule'", tokens[0])
+
+        return buildNode(startRule, result.children, tokens)
+    }
+
+    private fun matchRule(
+        ruleName: String, tokens: List<Token>, pos: Int,
+        memo: MutableMap<String, MutableMap<Int, MemoEntry>>
+    ): MatchResult? {
+        val ruleMemo = memo.getOrPut(ruleName) { mutableMapOf() }
+        ruleMemo[pos]?.let { cached ->
+            return if (cached.ok) MatchResult(cached.children!!, cached.endPos) else null
+        }
+
+        val rule = ruleMap[ruleName]
+        if (rule == null) {
+            ruleMemo[pos] = MemoEntry(null, pos, false)
+            return null
+        }
+
+        val result = matchElement(rule.body, tokens, pos, memo)
+        return if (result != null) {
+            val wrapped = listOf(buildNode(ruleName, result.children, tokens))
+            ruleMemo[pos] = MemoEntry(wrapped, result.endPos, true)
+            MatchResult(wrapped, result.endPos)
+        } else {
+            ruleMemo[pos] = MemoEntry(null, pos, false)
+            null
+        }
+    }
+
+    private fun matchElement(
+        element: GrammarElement, tokens: List<Token>, pos: Int,
+        memo: MutableMap<String, MutableMap<Int, MemoEntry>>
+    ): MatchResult? = when (element) {
+        is RuleReference -> if (element.isToken) {
+            if (pos < tokens.size && element.name == tokens[pos].effectiveTypeName())
+                MatchResult(listOf(tokens[pos]), pos + 1)
+            else null
+        } else matchRule(element.name, tokens, pos, memo)
+
+        is Literal -> if (pos < tokens.size && element.value == tokens[pos].value)
+            MatchResult(listOf(tokens[pos]), pos + 1) else null
+
+        is Sequence -> {
+            val children = mutableListOf<Any>()
+            var curPos = pos
+            var failed = false
+            for (sub in element.elements) {
+                val r = matchElement(sub, tokens, curPos, memo)
+                if (r == null) { failed = true; break }
+                children.addAll(r.children)
+                curPos = r.endPos
+            }
+            if (failed) null else MatchResult(children, curPos)
+        }
+
+        is Alternation -> {
+            var result: MatchResult? = null
+            for (choice in element.choices) {
+                result = matchElement(choice, tokens, pos, memo)
+                if (result != null) break
+            }
+            result
+        }
+
+        is Repetition -> {
+            val children = mutableListOf<Any>()
+            var curPos = pos
+            while (true) {
+                val r = matchElement(element.element, tokens, curPos, memo) ?: break
+                if (r.endPos == curPos) break
+                children.addAll(r.children)
+                curPos = r.endPos
+            }
+            MatchResult(children, curPos)
+        }
+
+        is OneOrMoreRepetition -> {
+            val first = matchElement(element.element, tokens, pos, memo) ?: return null
+            val children = first.children.toMutableList()
+            var curPos = first.endPos
+            while (true) {
+                val r = matchElement(element.element, tokens, curPos, memo) ?: break
+                if (r.endPos == curPos) break
+                children.addAll(r.children)
+                curPos = r.endPos
+            }
+            MatchResult(children, curPos)
+        }
+
+        is Optional -> matchElement(element.element, tokens, pos, memo)
+            ?: MatchResult(emptyList(), pos)
+
+        is Group -> matchElement(element.element, tokens, pos, memo)
+
+        is PositiveLookahead -> if (matchElement(element.element, tokens, pos, memo) != null)
+            MatchResult(emptyList(), pos) else null
+
+        is NegativeLookahead -> if (matchElement(element.element, tokens, pos, memo) == null)
+            MatchResult(emptyList(), pos) else null
+
+        is SeparatedRepetition -> {
+            val children = mutableListOf<Any>()
+            val first = matchElement(element.element, tokens, pos, memo)
+            if (first == null) {
+                if (element.atLeastOne) null else MatchResult(emptyList(), pos)
+            } else {
+                children.addAll(first.children)
+                var curPos = first.endPos
+                while (true) {
+                    val sepMatch = matchElement(element.separator, tokens, curPos, memo) ?: break
+                    val elemMatch = matchElement(element.element, tokens, sepMatch.endPos, memo) ?: break
+                    children.addAll(sepMatch.children)
+                    children.addAll(elemMatch.children)
+                    curPos = elemMatch.endPos
+                }
+                MatchResult(children, curPos)
+            }
+        }
+    }
+
+    private fun buildNode(ruleName: String, children: List<Any>, tokens: List<Token>): ASTNode {
+        val first = findFirstToken(children)
+        val last = findLastToken(children)
+        return ASTNode(
+            ruleName, children,
+            first?.line ?: 0, first?.column ?: 0,
+            last?.line ?: 0, last?.column ?: 0
+        )
+    }
+
+    private fun findFirstToken(children: List<Any>): Token? {
+        for (child in children) {
+            if (child is Token) return child
+            if (child is ASTNode) findFirstToken(child.children)?.let { return it }
+        }
+        return null
+    }
+
+    private fun findLastToken(children: List<Any>): Token? {
+        for (i in children.indices.reversed()) {
+            val child = children[i]
+            if (child is Token) return child
+            if (child is ASTNode) findLastToken(child.children)?.let { return it }
+        }
+        return null
+    }
+}

--- a/code/packages/kotlin/parser/src/test/kotlin/com/codingadventures/parser/ParserTest.kt
+++ b/code/packages/kotlin/parser/src/test/kotlin/com/codingadventures/parser/ParserTest.kt
@@ -1,0 +1,110 @@
+package com.codingadventures.parser
+
+import com.codingadventures.grammartools.*
+import com.codingadventures.lexer.Token
+import com.codingadventures.lexer.TokenType
+import kotlin.test.*
+
+class ParserTest {
+
+    private fun makeTokens(vararg typesAndValues: String): List<Token> {
+        val tokens = mutableListOf<Token>()
+        var i = 0
+        while (i < typesAndValues.size) {
+            tokens.add(Token(TokenType.GRAMMAR, typesAndValues[i + 1], 1, tokens.size + 1, typesAndValues[i]))
+            i += 2
+        }
+        tokens.add(Token(TokenType.EOF, "", 1, tokens.size + 1, "EOF"))
+        return tokens
+    }
+
+    @Test fun emptyNode() {
+        val node = ASTNode("test", emptyList())
+        assertFalse(node.isLeaf)
+        assertNull(node.token)
+    }
+
+    @Test fun leafNode() {
+        val t = Token(TokenType.NUMBER, "42", 1, 1)
+        val node = ASTNode("num", listOf(t))
+        assertTrue(node.isLeaf)
+        assertEquals(t, node.token)
+    }
+
+    @Test fun singleTokenRule() {
+        val g = parseParserGrammar("program = NUMBER ;")
+        val ast = GrammarParser(g).parse(makeTokens("NUMBER", "42"))
+        assertEquals("program", ast.ruleName)
+    }
+
+    @Test fun sequenceRule() {
+        val g = parseParserGrammar("assign = NAME EQUALS NUMBER ;")
+        val ast = GrammarParser(g).parse(makeTokens("NAME", "x", "EQUALS", "=", "NUMBER", "42"))
+        assertEquals("assign", ast.ruleName)
+    }
+
+    @Test fun alternationRule() {
+        val g = parseParserGrammar("value = NUMBER | NAME ;")
+        assertEquals("value", GrammarParser(g).parse(makeTokens("NUMBER", "42")).ruleName)
+        assertEquals("value", GrammarParser(g).parse(makeTokens("NAME", "x")).ruleName)
+    }
+
+    @Test fun repetitionRule() {
+        val g = parseParserGrammar("list = { NUMBER } ;")
+        assertEquals("list", GrammarParser(g).parse(makeTokens()).ruleName)
+        assertEquals("list", GrammarParser(g).parse(makeTokens("NUMBER", "1", "NUMBER", "2")).ruleName)
+    }
+
+    @Test fun optionalRule() {
+        val g = parseParserGrammar("maybe = [ NUMBER ] ;")
+        assertEquals("maybe", GrammarParser(g).parse(makeTokens("NUMBER", "42")).ruleName)
+        assertEquals("maybe", GrammarParser(g).parse(makeTokens()).ruleName)
+    }
+
+    @Test fun nestedRules() {
+        val g = parseParserGrammar("program = { statement } ;\nstatement = NUMBER ;")
+        assertEquals("program", GrammarParser(g).parse(makeTokens("NUMBER", "1", "NUMBER", "2")).ruleName)
+    }
+
+    @Test fun parseFailure() {
+        val g = parseParserGrammar("program = NUMBER ;")
+        assertFailsWith<GrammarParseError> { GrammarParser(g).parse(makeTokens("NAME", "x")) }
+    }
+
+    @Test fun emptyGrammar() {
+        val g = ParserGrammar()
+        assertFailsWith<GrammarParseError> { GrammarParser(g).parse(makeTokens()) }
+    }
+
+    @Test fun positiveLookahead() {
+        val g = parseParserGrammar("check = &NUMBER NUMBER ;")
+        assertEquals("check", GrammarParser(g).parse(makeTokens("NUMBER", "42")).ruleName)
+    }
+
+    @Test fun negativeLookahead() {
+        val g = parseParserGrammar("check = !NAME NUMBER ;")
+        assertEquals("check", GrammarParser(g).parse(makeTokens("NUMBER", "42")).ruleName)
+    }
+
+    @Test fun negativeLookaheadFails() {
+        val g = parseParserGrammar("check = !NUMBER NUMBER ;")
+        assertFailsWith<GrammarParseError> { GrammarParser(g).parse(makeTokens("NUMBER", "42")) }
+    }
+
+    @Test fun separatedRepetition() {
+        val g = parseParserGrammar("args = { NUMBER // COMMA } ;")
+        assertEquals("args", GrammarParser(g).parse(makeTokens("NUMBER", "1", "COMMA", ",", "NUMBER", "2")).ruleName)
+    }
+
+    @Test fun literalMatch() {
+        val g = parseParserGrammar("op = \"+\" ;")
+        assertEquals("op", GrammarParser(g).parse(makeTokens("PLUS", "+")).ruleName)
+    }
+
+    @Test fun descendantCount() {
+        val t = Token(TokenType.NUMBER, "1", 1, 1)
+        val leaf = ASTNode("num", listOf(t))
+        val parent = ASTNode("expr", listOf(leaf))
+        assertEquals(2, parent.descendantCount())
+    }
+}


### PR DESCRIPTION
## Summary
- rescue the foundational Kotlin package work from #527 onto current `main`
- add `kotlin/document-ast`, `kotlin/grammar-tools`, `kotlin/lexer`, and `kotlin/parser`
- intentionally drop the stale CI and Go build-tool hunks from #527 because current `main` already contains newer JVM toolchain support and the newer Kotlin package set

## Validation
- `mise exec java@21.0.2 -- gradle test` in `code/packages/kotlin/grammar-tools`
- `mise exec java@21.0.2 -- gradle test` in `code/packages/kotlin/document-ast`
- `mise exec java@21.0.2 -- gradle test` in `code/packages/kotlin/lexer`
- `mise exec java@21.0.2 -- gradle test` in `code/packages/kotlin/parser`
- `go run . -root /Users/adhithya/Downloads/Codex/coding-adventures-pr527-rescue -validate-build-files -dry-run -language kotlin` in `code/programs/go/build-tool`

## Notes
- This supersedes the package portion of #527 on top of latest `main` as of April 14, 2026 (`2ceb6ccc4`).
- Existing JVM CI setup and toolchain detection on `main` are preserved as-is.