### PR TITLE
[codex] Extract scaffold-generator C#/F# support from #654

### DIFF
--- a/code/programs/scaffold-generator.json
+++ b/code/programs/scaffold-generator.json
@@ -20,7 +20,7 @@
       "id": "language",
       "short": "l",
       "long": "language",
-      "description": "Target language(s). Comma-separated or 'all' for all 10 languages: python, go, ruby, typescript, rust, elixir, perl, lua, swift, haskell",
+      "description": "Target language(s). Comma-separated or 'all' for all 12 scaffold languages: python, go, ruby, typescript, rust, elixir, perl, lua, swift, haskell, csharp, fsharp",
       "type": "string",
       "default": "all"
     },

--- a/code/programs/typescript/scaffold-generator/BUILD
+++ b/code/programs/typescript/scaffold-generator/BUILD
@@ -1,5 +1,5 @@
-cd ../../../packages/typescript/directed-graph && npm install --silent
-cd ../../../packages/typescript/state-machine && npm install --silent
-cd ../../../packages/typescript/cli-builder && npm install --silent
+(cd ../../../packages/typescript/directed-graph && npm install --silent)
+(cd ../../../packages/typescript/state-machine && npm install --silent)
+(cd ../../../packages/typescript/cli-builder && npm install --silent)
 npm ci --quiet
 npx vitest run --coverage

--- a/code/programs/typescript/scaffold-generator/README.md
+++ b/code/programs/typescript/scaffold-generator/README.md
@@ -5,7 +5,8 @@ Generate CI-ready package scaffolding for the coding-adventures monorepo.
 ## What It Does
 
 This CLI tool generates correctly-structured, CI-ready package directories
-for all six languages: Python, Go, Ruby, TypeScript, Rust, and Elixir.
+for the package ecosystems currently scaffolded in the repo: Python, Go,
+Ruby, TypeScript, Rust, Elixir, Perl, Lua, Swift, Haskell, C#, and F#.
 
 It is powered by [cli-builder](../../../packages/typescript/cli-builder/) --
 the entire command-line interface is defined in a JSON spec file, and this
@@ -28,7 +29,7 @@ lints, and passes tests. Then fill in the business logic.
 ## Usage
 
 ```bash
-# Generate a library package for all 6 languages
+# Generate a library package for all supported scaffold languages
 npx tsx src/index.ts my-package --description "My awesome package" --layer 5
 
 # Generate for a specific language
@@ -36,6 +37,10 @@ npx tsx src/index.ts my-package -l typescript --description "TS only"
 
 # Generate a program (goes in code/programs/ instead of code/packages/)
 npx tsx src/index.ts my-tool -t program -l go
+
+# Generate a .NET package
+npx tsx src/index.ts graph -l csharp --description "Undirected graph"
+npx tsx src/index.ts graph -l fsharp --description "Undirected graph"
 
 # Specify dependencies
 npx tsx src/index.ts my-package -d logic-gates,arithmetic
@@ -54,3 +59,7 @@ npx tsx src/index.ts my-package --dry-run
 # Run tests
 bash BUILD
 ```
+
+The generated TypeScript packages enforce an 80% line coverage threshold in
+`vitest.config.ts`, and the C#/F# templates run `dotnet test` with Coverlet
+and an 80% line threshold by default.

--- a/code/programs/typescript/scaffold-generator/src/index.ts
+++ b/code/programs/typescript/scaffold-generator/src/index.ts
@@ -4,8 +4,9 @@
  * === What This Program Does ===
  *
  * This tool generates correctly-structured, CI-ready package directories
- * for the coding-adventures monorepo. It supports all six languages:
- * Python, Go, Ruby, TypeScript, Rust, and Elixir.
+ * for the coding-adventures monorepo. It supports the repo's current
+ * scaffoldable language set: Python, Go, Ruby, TypeScript, Rust, Elixir,
+ * Perl, Lua, Swift, Haskell, C#, and F#.
  *
  * === Why This Tool Exists ===
  *
@@ -33,6 +34,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { fileURLToPath } from "node:url";
 import { Parser, ParseErrors } from "@coding-adventures/cli-builder";
 import type { ParseResult, HelpResult, VersionResult } from "@coding-adventures/cli-builder";
 
@@ -41,7 +43,7 @@ import type { ParseResult, HelpResult, VersionResult } from "@coding-adventures/
 // =========================================================================
 
 /**
- * All six languages supported by the scaffold generator.
+ * All languages supported by the scaffold generator.
  *
  * These match the directory names under `code/packages/<lang>/` and
  * `code/programs/<lang>/` in the monorepo.
@@ -57,6 +59,8 @@ export const VALID_LANGUAGES = [
   "lua",
   "swift",
   "haskell",
+  "csharp",
+  "fsharp",
 ] as const;
 
 /**
@@ -70,6 +74,18 @@ export const VALID_LANGUAGES = [
  *   - "trailing-"    -- INVALID (trailing hyphen)
  */
 export const KEBAB_RE = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;
+
+/**
+ * Escape text before embedding it in XML element content or attributes.
+ */
+export function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
 
 // =========================================================================
 // Name normalization
@@ -173,6 +189,7 @@ export function resolveDepDir(repoRoot: string, lang: string, dep: string): stri
  *   - TypeScript: package.json with `"file:../dep"` values
  *   - Rust: Cargo.toml with `path = "../dep"` entries
  *   - Elixir: mix.exs with `path: "../dep"` entries
+ *   - C# / F#: .csproj / .fsproj with `<ProjectReference Include="../dep/...">`
  */
 export function readDeps(pkgDir: string, lang: string): string[] {
   const readers: Record<string, (dir: string) => string[]> = {
@@ -186,6 +203,8 @@ export function readDeps(pkgDir: string, lang: string): string[] {
     lua: () => [],
     swift: () => [],
     haskell: readHaskellDeps,
+    csharp: readDotnetDeps,
+    fsharp: readDotnetDeps,
   };
   const reader = readers[lang];
   if (!reader) {
@@ -442,6 +461,39 @@ export function readHaskellDeps(pkgDir: string): string[] {
     const m = line.match(re);
     if (m && m[1] && m[1] !== selfName) {
       deps.push(m[1]);
+    }
+  }
+  return deps;
+}
+
+export function readDotnetDeps(pkgDir: string): string[] {
+  let files: string[];
+  try {
+    files = fs.readdirSync(pkgDir);
+  } catch {
+    return [];
+  }
+  const projectFile = files.find(
+    (file) => file.endsWith(".csproj") || file.endsWith(".fsproj"),
+  );
+  if (!projectFile) {
+    return [];
+  }
+  const content = fs.readFileSync(path.join(pkgDir, projectFile), "utf-8");
+  const deps: string[] = [];
+  const re =
+    /<ProjectReference\s+Include\s*=\s*"\.\.[\\/]([^/\\"]+)[\\/][^"]+"/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(content)) !== null) {
+    const depDir = match[1]?.trim();
+    if (
+      depDir &&
+      depDir !== "." &&
+      depDir !== ".." &&
+      !depDir.includes("/") &&
+      !depDir.includes("\\")
+    ) {
+      deps.push(depDir.replace(/_/g, "-"));
     }
   }
   return deps;
@@ -1768,6 +1820,220 @@ main = do
 }
 
 // -------------------------------------------------------------------------
+// C# generator
+// -------------------------------------------------------------------------
+
+export function generateCSharp(
+  targetDir: string,
+  pkgName: string,
+  description: string,
+  layerCtx: string,
+  directDeps: string[],
+): void {
+  const camel = toCamelCase(pkgName);
+  const projectName = `CodingAdventures.${camel}`;
+  const testProjectName = `${projectName}.Tests`;
+
+  const projectRefs = directDeps
+    .map(
+      (dep) =>
+        `    <ProjectReference Include="../${dep}/CodingAdventures.${toCamelCase(dep)}.csproj" />`,
+    )
+    .join("\n");
+
+  const csproj = `<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>${projectName}</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>${escapeXml(description)}</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+${projectRefs ? `  <ItemGroup>\n${projectRefs}\n  </ItemGroup>\n` : ""}</Project>
+`;
+
+  const graphCs = `namespace ${projectName};
+
+/// <summary>
+/// ${description}
+/// ${layerCtx}
+/// </summary>
+public static class ${camel}
+{
+    public static string Ping() => "${pkgName}";
+}
+`;
+
+  const testCsproj = `<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../${projectName}.csproj" />
+  </ItemGroup>
+</Project>
+`;
+
+  const testCs = `namespace ${testProjectName};
+
+public sealed class ${camel}Tests
+{
+    [Fact]
+    public void PingReturnsPackageName()
+    {
+        Assert.Equal("${pkgName}", ${projectName}.${camel}.Ping());
+    }
+}
+`;
+
+  const build = `dotnet test tests/${testProjectName}/${testProjectName}.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line\n`;
+
+  writeFile(path.join(targetDir, `${projectName}.csproj`), csproj);
+  writeFile(path.join(targetDir, `${camel}.cs`), graphCs);
+  writeFile(path.join(targetDir, "tests", testProjectName, `${testProjectName}.csproj`), testCsproj);
+  writeFile(path.join(targetDir, "tests", testProjectName, `${camel}Tests.cs`), testCs);
+  writeFile(path.join(targetDir, "BUILD"), build);
+  writeFile(path.join(targetDir, "BUILD_windows"), build);
+  writeFile(
+    path.join(targetDir, "required_capabilities.json"),
+    JSON.stringify(
+      {
+        $schema:
+          "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+        version: 1,
+        package: `csharp/${pkgName}`,
+        capabilities: [],
+        justification:
+          "Pure in-memory library and tests. No filesystem, process, environment, or network access needed.",
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+}
+
+// -------------------------------------------------------------------------
+// F# generator
+// -------------------------------------------------------------------------
+
+export function generateFSharp(
+  targetDir: string,
+  pkgName: string,
+  description: string,
+  layerCtx: string,
+  directDeps: string[],
+): void {
+  const camel = toCamelCase(pkgName);
+  const projectName = `CodingAdventures.${camel}`;
+  const testProjectName = `${projectName}.Tests`;
+
+  const projectRefs = directDeps
+    .map(
+      (dep) =>
+        `    <ProjectReference Include="../${dep}/CodingAdventures.${toCamelCase(dep)}.fsproj" />`,
+    )
+    .join("\n");
+
+  const fsproj = `<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>${projectName}</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>${escapeXml(description)}</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+${projectRefs ? `  <ItemGroup>\n${projectRefs}\n  </ItemGroup>\n` : ""}  <ItemGroup>
+    <Compile Include="${camel}.fs" />
+  </ItemGroup>
+</Project>
+`;
+
+  const moduleFs = `namespace ${projectName}
+
+/// ${description}
+/// ${layerCtx}
+module ${camel} =
+    let ping () = "${pkgName}"
+`;
+
+  const testFsproj = `<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../${projectName}.fsproj" />
+    <Compile Include="${camel}Tests.fs" />
+  </ItemGroup>
+</Project>
+`;
+
+  const testFs = `namespace ${testProjectName}
+
+open Xunit
+open ${projectName}
+
+type ${camel}Tests() =
+    [<Fact>]
+    member _.\`\`Ping returns package name\`\`() =
+        Assert.Equal("${pkgName}", ${camel}.ping())
+`;
+
+  const build = `dotnet test tests/${testProjectName}/${testProjectName}.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line\n`;
+
+  writeFile(path.join(targetDir, `${projectName}.fsproj`), fsproj);
+  writeFile(path.join(targetDir, `${camel}.fs`), moduleFs);
+  writeFile(path.join(targetDir, "tests", testProjectName, `${testProjectName}.fsproj`), testFsproj);
+  writeFile(path.join(targetDir, "tests", testProjectName, `${camel}Tests.fs`), testFs);
+  writeFile(path.join(targetDir, "BUILD"), build);
+  writeFile(path.join(targetDir, "BUILD_windows"), build);
+  writeFile(
+    path.join(targetDir, "required_capabilities.json"),
+    JSON.stringify(
+      {
+        $schema:
+          "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+        version: 1,
+        package: `fsharp/${pkgName}`,
+        capabilities: [],
+        justification:
+          "Pure in-memory library and tests. No filesystem, process, environment, or network access needed.",
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+}
+
+// -------------------------------------------------------------------------
 // Common files (README.md + CHANGELOG.md)
 // -------------------------------------------------------------------------
 
@@ -2010,6 +2276,10 @@ export function scaffoldOne(
         directDeps,
         orderedDeps,
       ),
+    csharp: () =>
+      generateCSharp(targetDir, pkgName, description, layerCtx, directDeps),
+    fsharp: () =>
+      generateFSharp(targetDir, pkgName, description, layerCtx, directDeps),
   };
 
   generators[lang]();
@@ -2032,6 +2302,8 @@ export function scaffoldOne(
     );
   } else if (lang === "go") {
     output(`  Run: cd ${targetDir} && go mod tidy`);
+  } else if (lang === "csharp" || lang === "fsharp") {
+    output(`  Run: cd ${targetDir} && dotnet test`);
   }
 }
 
@@ -2051,7 +2323,7 @@ export function scaffoldOne(
  */
 export function main(argv: string[] = process.argv): void {
   const specFile = path.resolve(
-    path.dirname(new URL(import.meta.url).pathname),
+    path.dirname(fileURLToPath(import.meta.url)),
     "..",
     "..",
     "..",
@@ -2164,8 +2436,15 @@ export function main(argv: string[] = process.argv): void {
 const isMainModule =
   typeof process !== "undefined" &&
   process.argv[1] &&
-  (process.argv[1].endsWith("scaffold-generator/src/index.ts") ||
-    process.argv[1].endsWith("scaffold-generator/dist/index.js"));
+  (() => {
+    const entry = process.argv[1].replace(/\\/g, "/");
+    return (
+      entry.endsWith("scaffold-generator/src/index.ts") ||
+      entry.endsWith("scaffold-generator/dist/index.js") ||
+      entry.endsWith("/src/index.ts") ||
+      entry.endsWith("/dist/index.js")
+    );
+  })();
 
 if (isMainModule) {
   main();

--- a/code/programs/typescript/scaffold-generator/tests/scaffold-generator.test.ts
+++ b/code/programs/typescript/scaffold-generator/tests/scaffold-generator.test.ts
@@ -3,7 +3,7 @@
  *
  * These tests verify the core logic of the scaffold generator:
  *   1. Name normalization (kebab -> snake, camel, joined-lower)
- *   2. Dependency reading for all 6 languages
+ *   2. Dependency reading for all supported languages
  *   3. Transitive closure (BFS)
  *   4. Topological sort (Kahn's algorithm)
  *   5. File generation (verify critical fields per language)
@@ -33,10 +33,13 @@ import {
   generateElixir,
   generatePerl,
   generateHaskell,
+  generateCSharp,
+  generateFSharp,
   generateCommonFiles,
   updateRustWorkspace,
   findRepoRoot,
   scaffoldOne,
+  escapeXml,
   VALID_LANGUAGES,
   KEBAB_RE,
 } from "../src/index.js";
@@ -187,8 +190,14 @@ describe("KEBAB_RE", () => {
   });
 });
 
+describe("escapeXml", () => {
+  it("escapes XML metacharacters", () => {
+    expect(escapeXml(`a&b<c>"d"'e'`)).toBe("a&amp;b&lt;c&gt;&quot;d&quot;&apos;e&apos;");
+  });
+});
+
 // =========================================================================
-// 3. Dependency reading tests (all 6 languages)
+// 3. Dependency reading tests
 // =========================================================================
 
 describe("readDeps", () => {
@@ -365,6 +374,59 @@ describe("readDeps", () => {
     const pkgDir = path.join(tmpDir, "no-cpanfile");
     fs.mkdirSync(pkgDir, { recursive: true });
     expect(readDeps(pkgDir, "perl")).toEqual([]);
+  });
+
+  // --- C# / F# ---
+
+  it("reads C# deps from ProjectReference entries", () => {
+    const pkgDir = path.join(tmpDir, "my-pkg");
+    writeTestFile(pkgDir, "CodingAdventures.MyPkg.csproj", [
+      '<Project Sdk="Microsoft.NET.Sdk">',
+      "  <ItemGroup>",
+      '    <ProjectReference Include="../logic-gates/CodingAdventures.LogicGates.csproj" />',
+      '    <ProjectReference Include="../state_machine/CodingAdventures.StateMachine.csproj" />',
+      "  </ItemGroup>",
+      "</Project>",
+    ].join("\n"));
+
+    const deps = readDeps(pkgDir, "csharp");
+    expect(deps).toEqual(["logic-gates", "state-machine"]);
+  });
+
+  it("reads F# deps from ProjectReference entries", () => {
+    const pkgDir = path.join(tmpDir, "my-pkg");
+    writeTestFile(pkgDir, "CodingAdventures.MyPkg.fsproj", [
+      '<Project Sdk="Microsoft.NET.Sdk">',
+      "  <ItemGroup>",
+      '    <ProjectReference Include="../graph/CodingAdventures.Graph.fsproj" />',
+      "  </ItemGroup>",
+      "</Project>",
+    ].join("\n"));
+
+    const deps = readDeps(pkgDir, "fsharp");
+    expect(deps).toEqual(["graph"]);
+  });
+
+  it("rejects traversal-style .NET project references", () => {
+    const pkgDir = path.join(tmpDir, "my-pkg");
+    writeTestFile(pkgDir, "CodingAdventures.MyPkg.csproj", [
+      '<Project Sdk="Microsoft.NET.Sdk">',
+      "  <ItemGroup>",
+      '    <ProjectReference Include="../../evil/CodingAdventures.Evil.csproj" />',
+      '    <ProjectReference Include="../safe-dep/CodingAdventures.SafeDep.csproj" />',
+      "  </ItemGroup>",
+      "</Project>",
+    ].join("\n"));
+
+    const deps = readDeps(pkgDir, "csharp");
+    expect(deps).toEqual(["safe-dep"]);
+  });
+
+  it("returns empty for .NET package with no project file", () => {
+    const pkgDir = path.join(tmpDir, "no-project");
+    fs.mkdirSync(pkgDir, { recursive: true });
+    expect(readDeps(pkgDir, "csharp")).toEqual([]);
+    expect(readDeps(pkgDir, "fsharp")).toEqual([]);
   });
 
   // --- Unknown language ---
@@ -973,6 +1035,164 @@ describe("generatePerl", () => {
   });
 });
 
+describe("generateCSharp", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    removeDir(tmpDir);
+  });
+
+  it("creates a library project and test project", () => {
+    generateCSharp(tmpDir, "my-pkg", "A test package", "", []);
+
+    const csproj = fs.readFileSync(
+      path.join(tmpDir, "CodingAdventures.MyPkg.csproj"),
+      "utf-8",
+    );
+    const testProject = fs.readFileSync(
+      path.join(
+        tmpDir,
+        "tests",
+        "CodingAdventures.MyPkg.Tests",
+        "CodingAdventures.MyPkg.Tests.csproj",
+      ),
+      "utf-8",
+    );
+
+    expect(csproj).toContain("<TargetFramework>net9.0</TargetFramework>");
+    expect(csproj).toContain("<PackageId>CodingAdventures.MyPkg</PackageId>");
+    expect(testProject).toContain('PackageReference Include="xunit"');
+    expect(testProject).toContain('PackageReference Include="coverlet.msbuild"');
+    expect(testProject).toContain(
+      'ProjectReference Include="../../CodingAdventures.MyPkg.csproj"',
+    );
+  });
+
+  it("creates BUILD files and required capabilities metadata", () => {
+    generateCSharp(tmpDir, "my-pkg", "A test package", "", []);
+
+    const build = fs.readFileSync(path.join(tmpDir, "BUILD"), "utf-8");
+    const buildWindows = fs.readFileSync(
+      path.join(tmpDir, "BUILD_windows"),
+      "utf-8",
+    );
+    const capabilities = fs.readFileSync(
+      path.join(tmpDir, "required_capabilities.json"),
+      "utf-8",
+    );
+
+    expect(build).toContain(
+      "dotnet test tests/CodingAdventures.MyPkg.Tests/CodingAdventures.MyPkg.Tests.csproj",
+    );
+    expect(build).toContain("/p:Threshold=80");
+    expect(buildWindows).toBe(build);
+    expect(capabilities).toContain('"package": "csharp/my-pkg"');
+  });
+
+  it("escapes XML in generated project metadata", () => {
+    generateCSharp(
+      tmpDir,
+      "my-pkg",
+      'A & B </Description><Target Name="Injected" />',
+      "",
+      [],
+    );
+
+    const csproj = fs.readFileSync(
+      path.join(tmpDir, "CodingAdventures.MyPkg.csproj"),
+      "utf-8",
+    );
+
+    expect(csproj).toContain(
+      "<Description>A &amp; B &lt;/Description&gt;&lt;Target Name=&quot;Injected&quot; /&gt;</Description>",
+    );
+    expect(csproj).not.toContain('<Target Name="Injected"');
+  });
+});
+
+describe("generateFSharp", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    removeDir(tmpDir);
+  });
+
+  it("creates a library project and test project", () => {
+    generateFSharp(tmpDir, "my-pkg", "A test package", "", []);
+
+    const fsproj = fs.readFileSync(
+      path.join(tmpDir, "CodingAdventures.MyPkg.fsproj"),
+      "utf-8",
+    );
+    const testProject = fs.readFileSync(
+      path.join(
+        tmpDir,
+        "tests",
+        "CodingAdventures.MyPkg.Tests",
+        "CodingAdventures.MyPkg.Tests.fsproj",
+      ),
+      "utf-8",
+    );
+
+    expect(fsproj).toContain("<TargetFramework>net9.0</TargetFramework>");
+    expect(fsproj).toContain('<Compile Include="MyPkg.fs" />');
+    expect(testProject).toContain('PackageReference Include="xunit"');
+    expect(testProject).toContain('PackageReference Include="coverlet.msbuild"');
+    expect(testProject).toContain(
+      'ProjectReference Include="../../CodingAdventures.MyPkg.fsproj"',
+    );
+  });
+
+  it("creates BUILD files and required capabilities metadata", () => {
+    generateFSharp(tmpDir, "my-pkg", "A test package", "", []);
+
+    const build = fs.readFileSync(path.join(tmpDir, "BUILD"), "utf-8");
+    const buildWindows = fs.readFileSync(
+      path.join(tmpDir, "BUILD_windows"),
+      "utf-8",
+    );
+    const capabilities = fs.readFileSync(
+      path.join(tmpDir, "required_capabilities.json"),
+      "utf-8",
+    );
+
+    expect(build).toContain(
+      "dotnet test tests/CodingAdventures.MyPkg.Tests/CodingAdventures.MyPkg.Tests.fsproj",
+    );
+    expect(build).toContain("/p:Threshold=80");
+    expect(buildWindows).toBe(build);
+    expect(capabilities).toContain('"package": "fsharp/my-pkg"');
+  });
+
+  it("escapes XML in generated project metadata", () => {
+    generateFSharp(
+      tmpDir,
+      "my-pkg",
+      'A & B </Description><Target Name="Injected" />',
+      "",
+      [],
+    );
+
+    const fsproj = fs.readFileSync(
+      path.join(tmpDir, "CodingAdventures.MyPkg.fsproj"),
+      "utf-8",
+    );
+
+    expect(fsproj).toContain(
+      "<Description>A &amp; B &lt;/Description&gt;&lt;Target Name=&quot;Injected&quot; /&gt;</Description>",
+    );
+    expect(fsproj).not.toContain('<Target Name="Injected"');
+  });
+});
+
 // =========================================================================
 // 7. Common files tests
 // =========================================================================
@@ -1112,8 +1332,8 @@ describe("findRepoRoot", () => {
 // =========================================================================
 
 describe("VALID_LANGUAGES", () => {
-  it("contains all 10 supported languages", () => {
-    expect(VALID_LANGUAGES).toHaveLength(10);
+  it("contains all supported languages, including C# and F#", () => {
+    expect(VALID_LANGUAGES).toHaveLength(12);
     expect(VALID_LANGUAGES).toContain("python");
     expect(VALID_LANGUAGES).toContain("go");
     expect(VALID_LANGUAGES).toContain("ruby");
@@ -1124,6 +1344,8 @@ describe("VALID_LANGUAGES", () => {
     expect(VALID_LANGUAGES).toContain("lua");
     expect(VALID_LANGUAGES).toContain("swift");
     expect(VALID_LANGUAGES).toContain("haskell");
+    expect(VALID_LANGUAGES).toContain("csharp");
+    expect(VALID_LANGUAGES).toContain("fsharp");
   });
 });
 
@@ -1329,5 +1551,75 @@ describe("scaffoldOne", () => {
     );
     expect(fs.existsSync(pkgDir)).toBe(true);
     expect(fs.existsSync(path.join(pkgDir, "mix.exs"))).toBe(true);
+  });
+
+  it("creates a complete C# package", () => {
+    scaffoldOne(
+      "test-pkg",
+      "library",
+      "csharp",
+      [],
+      0,
+      "A test package",
+      false,
+      repoRoot,
+      () => {},
+    );
+
+    const pkgDir = path.join(
+      repoRoot,
+      "code",
+      "packages",
+      "csharp",
+      "test-pkg",
+    );
+    expect(fs.existsSync(path.join(pkgDir, "CodingAdventures.TestPkg.csproj"))).toBe(true);
+    expect(fs.existsSync(path.join(pkgDir, "BUILD"))).toBe(true);
+    expect(fs.existsSync(path.join(pkgDir, "BUILD_windows"))).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(
+          pkgDir,
+          "tests",
+          "CodingAdventures.TestPkg.Tests",
+          "CodingAdventures.TestPkg.Tests.csproj",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("creates a complete F# package", () => {
+    scaffoldOne(
+      "test-pkg",
+      "library",
+      "fsharp",
+      [],
+      0,
+      "A test package",
+      false,
+      repoRoot,
+      () => {},
+    );
+
+    const pkgDir = path.join(
+      repoRoot,
+      "code",
+      "packages",
+      "fsharp",
+      "test-pkg",
+    );
+    expect(fs.existsSync(path.join(pkgDir, "CodingAdventures.TestPkg.fsproj"))).toBe(true);
+    expect(fs.existsSync(path.join(pkgDir, "BUILD"))).toBe(true);
+    expect(fs.existsSync(path.join(pkgDir, "BUILD_windows"))).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(
+          pkgDir,
+          "tests",
+          "CodingAdventures.TestPkg.Tests",
+          "CodingAdventures.TestPkg.Tests.fsproj",
+        ),
+      ),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

This PR extracts the scaffold-generator portion of #654 into a focused, reviewable change.

## What changed

- added C# and F# to the scaffold generator's supported language set
- taught dependency discovery to read `.csproj` and `.fsproj` `ProjectReference` entries
- added C# and F# package templates, test projects, `BUILD` / `BUILD_windows`, and `required_capabilities.json` generation
- escaped XML metadata in generated .NET project files to avoid malformed project output from descriptions
- updated scaffold-generator docs and CLI spec text to reflect the current scaffolded language set
- fixed `code/programs/typescript/scaffold-generator/BUILD` so it installs sibling TypeScript dependencies without changing the working directory away from scaffold-generator before running tests
- added focused tests covering .NET dependency parsing, XML escaping, template generation, and end-to-end scaffolding for C# and F#

## Why

PR #654 bundled these scaffold-generator updates together with broader .NET packages and cross-language build-tool work. Pulling the generator changes into their own PR should make review and landing much easier.

## Validation

- `npm test` in `code/programs/typescript/scaffold-generator`
- `npm run test:coverage` in `code/programs/typescript/scaffold-generator`
- `bash BUILD` in `code/programs/typescript/scaffold-generator`

## Notes

This branch intentionally focuses on the scaffold-generator slice from #654 rather than the DT00 graph packages or build-tool parity work.