### PR TITLE
[codex] feat(dotnet): add literate activation and loss packages

### DIFF
--- a/code/packages/csharp/.gitignore
+++ b/code/packages/csharp/.gitignore
@@ -1,0 +1,3 @@
+**/bin/
+**/obj/
+**/coverage.json

--- a/code/packages/csharp/activation-functions/ActivationFunctions.cs
+++ b/code/packages/csharp/activation-functions/ActivationFunctions.cs
@@ -1,0 +1,105 @@
+using System;
+
+namespace CodingAdventures.ActivationFunctions;
+
+// ActivationFunctions.cs -- The three non-linear gates that make neural networks useful
+// ======================================================================================
+//
+// A stack of linear layers is still just one big linear layer. That is the central
+// reason activation functions exist. They bend the output of a neuron so that the next
+// layer receives something richer than "just another weighted sum".
+//
+// This package starts with the three most common scalar activations:
+//
+//   sigmoid(x)  -- squeezes any real number into the probability-like range (0, 1)
+//   relu(x)     -- keeps positive values, clips negative values to zero
+//   tanh(x)     -- squeezes to (-1, 1) and is centered at zero
+//
+// Each function also exposes its derivative, because gradient descent needs both the
+// forward pass ("what value do we emit?") and the backward pass ("how sensitive is the
+// loss to a small change in this input?").
+
+/// <summary>
+/// Pure scalar activation functions plus their derivatives.
+/// </summary>
+public static class ActivationFunctions
+{
+    // exp(710) overflows a double, so we clamp before calling Math.Exp.
+    private const double SigmoidOverflowClamp = 709.0;
+
+    /// <summary>
+    /// Compute the logistic sigmoid.
+    ///
+    /// sigma(x) = 1 / (1 + e^-x)
+    ///
+    /// The output is useful as a probability because it always stays between
+    /// zero and one. Large negative inputs saturate near 0, large positive
+    /// inputs saturate near 1, and x = 0 maps to 0.5.
+    /// </summary>
+    public static double Sigmoid(double x)
+    {
+        if (x < -SigmoidOverflowClamp)
+        {
+            return 0.0;
+        }
+
+        if (x > SigmoidOverflowClamp)
+        {
+            return 1.0;
+        }
+
+        return 1.0 / (1.0 + Math.Exp(-x));
+    }
+
+    /// <summary>
+    /// Compute sigma(x) * (1 - sigma(x)).
+    ///
+    /// This derivative is largest at x = 0 and shrinks near the saturated tails,
+    /// which is the classic "vanishing gradient" behavior of sigmoid networks.
+    /// </summary>
+    public static double SigmoidDerivative(double x)
+    {
+        var sigmoid = Sigmoid(x);
+        return sigmoid * (1.0 - sigmoid);
+    }
+
+    /// <summary>
+    /// Compute the rectified linear unit: max(0, x).
+    ///
+    /// ReLU is popular because it is simple, cheap, and does not compress the
+    /// positive half-line. Positive signals keep their scale; negative ones are
+    /// treated as "the neuron did not fire".
+    /// </summary>
+    public static double Relu(double x) => Math.Max(0.0, x);
+
+    /// <summary>
+    /// Return the slope of ReLU.
+    ///
+    /// ReLU is piecewise linear: slope 1 on the positive side, slope 0 on the
+    /// negative side. At exactly zero the mathematical derivative is undefined,
+    /// and the common machine-learning convention is to return 0.
+    /// </summary>
+    public static double ReluDerivative(double x) => x > 0.0 ? 1.0 : 0.0;
+
+    /// <summary>
+    /// Compute tanh(x), the zero-centered sibling of sigmoid.
+    ///
+    /// tanh maps any real number to (-1, 1). Because its midpoint is 0 rather
+    /// than 0.5, it often behaves better in hidden layers whose activations
+    /// should stay balanced around zero.
+    /// </summary>
+    public static double Tanh(double x) => Math.Tanh(x);
+
+    /// <summary>
+    /// Compute 1 - tanh(x)^2.
+    ///
+    /// tanh has a convenient derivative because the answer can be written in
+    /// terms of the activation itself rather than re-deriving the exponential
+    /// quotient from scratch.
+    /// </summary>
+    public static double TanhDerivative(double x)
+    {
+        var tanh = Math.Tanh(x);
+        return 1.0 - (tanh * tanh);
+    }
+}

--- a/code/packages/csharp/activation-functions/BUILD
+++ b/code/packages/csharp/activation-functions/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.ActivationFunctions.Tests/CodingAdventures.ActivationFunctions.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/activation-functions/BUILD_windows
+++ b/code/packages/csharp/activation-functions/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.ActivationFunctions.Tests/CodingAdventures.ActivationFunctions.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/activation-functions/CHANGELOG.md
+++ b/code/packages/csharp/activation-functions/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-15
+
+### Added
+
+- Knuth-style literate implementation of sigmoid, ReLU, and tanh
+- Derivative helpers for all three activation functions
+- Spec-vector and symmetry/range tests covering the numerical edge cases

--- a/code/packages/csharp/activation-functions/CodingAdventures.ActivationFunctions.csproj
+++ b/code/packages/csharp/activation-functions/CodingAdventures.ActivationFunctions.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.ActivationFunctions.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Scalar neural-network activation functions with derivatives</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\\**\\*.cs" />
+    <EmbeddedResource Remove="tests\\**" />
+    <None Remove="tests\\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/activation-functions/README.md
+++ b/code/packages/csharp/activation-functions/README.md
@@ -1,0 +1,32 @@
+# activation-functions
+
+Scalar neural-network activation functions with derivatives, ported into C#
+from the repo's dependency-free Rust math layer.
+
+## What it provides
+
+- `ActivationFunctions.Sigmoid(x)` and `ActivationFunctions.SigmoidDerivative(x)`
+- `ActivationFunctions.Relu(x)` and `ActivationFunctions.ReluDerivative(x)`
+- `ActivationFunctions.Tanh(x)` and `ActivationFunctions.TanhDerivative(x)`
+
+## Why this is a good starter port
+
+This package is a leaf: it depends only on `System.Math`, so it lets the new
+.NET package roots grow without pulling in any sibling packages first. It also
+sets the style baseline for future ports: small public API, parity tests, and
+Knuth-style inline commentary in the source.
+
+## Example
+
+```csharp
+using CodingAdventures.ActivationFunctions;
+
+var probability = ActivationFunctions.Sigmoid(1.0);
+var slope = ActivationFunctions.SigmoidDerivative(1.0);
+```
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/csharp/activation-functions/required_capabilities.json
+++ b/code/packages/csharp/activation-functions/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/activation-functions",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/activation-functions/tests/CodingAdventures.ActivationFunctions.Tests/ActivationFunctionsTests.cs
+++ b/code/packages/csharp/activation-functions/tests/CodingAdventures.ActivationFunctions.Tests/ActivationFunctionsTests.cs
@@ -1,0 +1,74 @@
+using Activation = CodingAdventures.ActivationFunctions.ActivationFunctions;
+
+namespace CodingAdventures.ActivationFunctions.Tests;
+
+public sealed class ActivationFunctionsTests
+{
+    private static void AssertClose(double expected, double actual, double tolerance = 1e-12)
+    {
+        Assert.True(
+            Math.Abs(expected - actual) <= tolerance,
+            $"Expected {expected:R} but got {actual:R}.");
+    }
+
+    [Fact]
+    public void SigmoidMatchesTheSpecVectors()
+    {
+        AssertClose(0.5, Activation.Sigmoid(0.0));
+        AssertClose(0.7310585786300049, Activation.Sigmoid(1.0));
+        AssertClose(0.2689414213699951, Activation.Sigmoid(-1.0));
+        AssertClose(0.9999546021312976, Activation.Sigmoid(10.0));
+        AssertClose(0.0, Activation.Sigmoid(-710.0));
+        AssertClose(1.0, Activation.Sigmoid(710.0));
+    }
+
+    [Fact]
+    public void SigmoidDerivativeMatchesTheSpecVectors()
+    {
+        AssertClose(0.25, Activation.SigmoidDerivative(0.0));
+        AssertClose(0.19661193324148185, Activation.SigmoidDerivative(1.0));
+        AssertClose(0.00004539580773595167, Activation.SigmoidDerivative(10.0));
+    }
+
+    [Fact]
+    public void ReluAndItsDerivativeMatchThePiecewiseDefinition()
+    {
+        AssertClose(5.0, Activation.Relu(5.0));
+        AssertClose(0.0, Activation.Relu(-3.0));
+        AssertClose(0.0, Activation.Relu(0.0));
+
+        AssertClose(1.0, Activation.ReluDerivative(5.0));
+        AssertClose(0.0, Activation.ReluDerivative(-3.0));
+        AssertClose(0.0, Activation.ReluDerivative(0.0));
+    }
+
+    [Fact]
+    public void TanhAndItsDerivativeMatchTheReferenceValues()
+    {
+        AssertClose(0.0, Activation.Tanh(0.0));
+        AssertClose(0.7615941559557649, Activation.Tanh(1.0));
+        AssertClose(-0.7615941559557649, Activation.Tanh(-1.0));
+
+        AssertClose(1.0, Activation.TanhDerivative(0.0));
+        AssertClose(0.41997434161402614, Activation.TanhDerivative(1.0));
+    }
+
+    [Fact]
+    public void SymmetryAndRangePropertiesHoldForRepresentativeSamples()
+    {
+        foreach (var sample in new[] { -6.0, -1.5, -0.5, 0.5, 1.5, 6.0 })
+        {
+            var sigmoid = Activation.Sigmoid(sample);
+            Assert.InRange(sigmoid, 0.0, 1.0);
+            AssertClose(sigmoid, 1.0 - Activation.Sigmoid(-sample), 1e-10);
+
+            var tanh = Activation.Tanh(sample);
+            Assert.InRange(tanh, -1.0, 1.0);
+            AssertClose(tanh, -Activation.Tanh(-sample), 1e-10);
+
+            Assert.True(Activation.SigmoidDerivative(sample) >= 0.0);
+            Assert.True(Activation.ReluDerivative(sample) >= 0.0);
+            Assert.True(Activation.TanhDerivative(sample) >= 0.0);
+        }
+    }
+}

--- a/code/packages/csharp/activation-functions/tests/CodingAdventures.ActivationFunctions.Tests/CodingAdventures.ActivationFunctions.Tests.csproj
+++ b/code/packages/csharp/activation-functions/tests/CodingAdventures.ActivationFunctions.Tests/CodingAdventures.ActivationFunctions.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.ActivationFunctions.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/graph/CHANGELOG.md
+++ b/code/packages/csharp/graph/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this package will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- Expanded `Graph.cs` into the repo's literate-programming style with design
+  commentary about representations, traversal order, shortest path selection,
+  and Kruskal's MST algorithm
+- Expanded the README so the package explains the API surface and its teaching
+  intent instead of only listing the test command
+
 ## [0.1.0] - 2026-04-12
 
 ### Added

--- a/code/packages/csharp/graph/Graph.cs
+++ b/code/packages/csharp/graph/Graph.cs
@@ -1,15 +1,50 @@
 using System.Text.Json;
 
+// Graph.cs -- Two ways to store the same undirected weighted graph
+// ================================================================
+//
+// This package teaches a useful systems lesson: the *interface* to a data
+// structure can stay stable while the *representation* changes underneath.
+//
+// We expose one Graph<T> API, but let callers choose between:
+//
+//   1. Adjacency list   -- best when the graph is sparse
+//   2. Adjacency matrix -- best when edge lookups matter more than space
+//
+// The algorithms later in the file (BFS, DFS, shortest path, MST) are written
+// in terms of the public graph operations rather than the private fields, so
+// they work for both representations without duplicating the algorithmic logic.
+
 namespace CodingAdventures.Graph;
 
+/// <summary>
+/// Select which internal storage model backs the graph.
+/// </summary>
 public enum GraphRepr
 {
+    /// <summary>
+    /// Store only the edges that actually exist.
+    /// </summary>
     AdjacencyList,
+
+    /// <summary>
+    /// Reserve a table entry for every possible node-to-node connection.
+    /// </summary>
     AdjacencyMatrix,
 }
 
+/// <summary>
+/// A single undirected weighted edge.
+///
+/// The endpoints are stored in canonical order so equality checks and sorted
+/// test assertions stay deterministic.
+/// </summary>
 public readonly record struct WeightedEdge<T>(T Left, T Right, double Weight) where T : notnull;
 
+// Node ordering exists purely to make iteration deterministic. Hash-based
+// collections do not promise a stable traversal order, but educational tests
+// and examples are much easier to reason about when neighbors always appear in
+// the same sequence.
 internal static class NodeOrdering
 {
     public static string CanonicalKey<T>(T node)
@@ -47,25 +82,49 @@ internal static class NodeOrdering
     }
 }
 
+/// <summary>
+/// An undirected weighted graph with interchangeable adjacency-list and
+/// adjacency-matrix storage.
+/// </summary>
 public sealed class Graph<T> where T : notnull
 {
+    // Adjacency-list storage:
+    //   node -> (neighbor -> weight)
     private readonly GraphRepr _repr;
     private readonly Dictionary<T, Dictionary<T, double>> _adj = new();
+
+    // Adjacency-matrix storage:
+    //   _nodeList/_nodeIndex translate T <-> integer position
+    //   _matrix[row][col] stores Some(weight) / None
     private readonly List<T> _nodeList = new();
     private readonly Dictionary<T, int> _nodeIndex = new();
     private readonly List<List<double?>> _matrix = new();
 
+    /// <summary>
+    /// Create an empty graph backed by the selected representation.
+    /// </summary>
     public Graph(GraphRepr repr = GraphRepr.AdjacencyList)
     {
         _repr = repr;
     }
 
+    /// <summary>
+    /// Report which internal storage model this graph currently uses.
+    /// </summary>
     public GraphRepr Representation => _repr;
 
+    /// <summary>
+    /// Count how many nodes are currently present in the graph.
+    /// </summary>
     public int Size => _repr == GraphRepr.AdjacencyList ? _adj.Count : _nodeList.Count;
 
+    /// <summary>
+    /// Add a node if it is not already present.
+    /// </summary>
     public void AddNode(T node)
     {
+        // In adjacency-list mode, "adding a node" just means ensuring it has an
+        // empty neighbor map.
         if (_repr == GraphRepr.AdjacencyList)
         {
             if (!_adj.ContainsKey(node))
@@ -76,6 +135,8 @@ public sealed class Graph<T> where T : notnull
             return;
         }
 
+        // In adjacency-matrix mode we must grow the matrix in both dimensions:
+        // every existing row gets a new column, and we append one new row.
         if (_nodeIndex.ContainsKey(node))
         {
             return;
@@ -99,6 +160,9 @@ public sealed class Graph<T> where T : notnull
         _matrix.Add(newRow);
     }
 
+    /// <summary>
+    /// Remove a node and every incident edge attached to it.
+    /// </summary>
     public void RemoveNode(T node)
     {
         if (_repr == GraphRepr.AdjacencyList)
@@ -136,14 +200,24 @@ public sealed class Graph<T> where T : notnull
         }
     }
 
+    /// <summary>
+    /// Test whether the graph already contains the given node.
+    /// </summary>
     public bool HasNode(T node) =>
         _repr == GraphRepr.AdjacencyList ? _adj.ContainsKey(node) : _nodeIndex.ContainsKey(node);
 
+    /// <summary>
+    /// Return the set of nodes currently stored in the graph.
+    /// </summary>
     public IReadOnlyCollection<T> Nodes() =>
         _repr == GraphRepr.AdjacencyList
             ? new HashSet<T>(_adj.Keys)
             : new HashSet<T>(_nodeList);
 
+    /// <summary>
+    /// Add or overwrite an undirected weighted edge between two nodes.
+    /// Missing endpoints are created automatically.
+    /// </summary>
     public void AddEdge(T left, T right, double weight = 1.0)
     {
         AddNode(left);
@@ -162,6 +236,9 @@ public sealed class Graph<T> where T : notnull
         _matrix[rightIndex][leftIndex] = weight;
     }
 
+    /// <summary>
+    /// Remove an existing undirected edge.
+    /// </summary>
     public void RemoveEdge(T left, T right)
     {
         if (_repr == GraphRepr.AdjacencyList)
@@ -189,6 +266,9 @@ public sealed class Graph<T> where T : notnull
         _matrix[rightIndex][leftIndex] = null;
     }
 
+    /// <summary>
+    /// Test whether an undirected edge currently exists between two nodes.
+    /// </summary>
     public bool HasEdge(T left, T right)
     {
         if (_repr == GraphRepr.AdjacencyList)
@@ -201,6 +281,9 @@ public sealed class Graph<T> where T : notnull
                _matrix[leftIndex][rightIndex] is not null;
     }
 
+    /// <summary>
+    /// Look up the stored weight for an existing undirected edge.
+    /// </summary>
     public double EdgeWeight(T left, T right)
     {
         if (_repr == GraphRepr.AdjacencyList)
@@ -223,12 +306,17 @@ public sealed class Graph<T> where T : notnull
         return weightValue;
     }
 
+    /// <summary>
+    /// Return all graph edges in deterministic order.
+    /// </summary>
     public IReadOnlyList<WeightedEdge<T>> Edges()
     {
         var result = new List<WeightedEdge<T>>();
 
         if (_repr == GraphRepr.AdjacencyList)
         {
+            // Each undirected edge is stored twice internally (A -> B and B -> A),
+            // so we track a canonical edge key to emit it only once.
             var seen = new HashSet<string>(StringComparer.Ordinal);
             foreach (var (left, neighbors) in _adj)
             {
@@ -278,6 +366,9 @@ public sealed class Graph<T> where T : notnull
         return result;
     }
 
+    /// <summary>
+    /// Return the neighboring nodes of one node in deterministic order.
+    /// </summary>
     public IReadOnlyList<T> Neighbors(T node)
     {
         if (_repr == GraphRepr.AdjacencyList)
@@ -307,6 +398,9 @@ public sealed class Graph<T> where T : notnull
         return NodeOrdering.Sort(result);
     }
 
+    /// <summary>
+    /// Return the neighbor-to-weight mapping for one node.
+    /// </summary>
     public IReadOnlyDictionary<T, double> NeighborsWeighted(T node)
     {
         if (_repr == GraphRepr.AdjacencyList)
@@ -336,14 +430,28 @@ public sealed class Graph<T> where T : notnull
         return result;
     }
 
+    /// <summary>
+    /// Count how many neighbors a node has.
+    /// </summary>
     public int Degree(T node) => Neighbors(node).Count;
 
+    /// <summary>
+    /// Produce a short human-readable graph summary.
+    /// </summary>
     public override string ToString() =>
         $"Graph(nodes={Size}, edges={Edges().Count}, repr={Representation})";
 }
 
+/// <summary>
+/// Algorithms that operate on <see cref="Graph{T}"/> without caring which
+/// internal representation stores the edges.
+/// </summary>
 public static class GraphAlgorithms
 {
+    /// <summary>
+    /// Breadth-first search explores the graph in "layers" radiating from the
+    /// start node: all nodes one hop away, then two hops away, and so on.
+    /// </summary>
     public static IReadOnlyList<T> Bfs<T>(Graph<T> graph, T start) where T : notnull
     {
         EnsureNode(graph, start);
@@ -370,8 +478,14 @@ public static class GraphAlgorithms
         return result;
     }
 
+    /// <summary>
+    /// Depth-first search follows one branch as far as possible before
+    /// backtracking to try the next branch.
+    /// </summary>
     public static IReadOnlyList<T> Dfs<T>(Graph<T> graph, T start) where T : notnull
     {
+        // DFS uses an explicit stack so we can control the visit order without
+        // recursion depth concerns.
         EnsureNode(graph, start);
 
         var visited = new HashSet<T>();
@@ -401,6 +515,9 @@ public static class GraphAlgorithms
         return result;
     }
 
+    /// <summary>
+    /// Report whether every node is reachable from every other node.
+    /// </summary>
     public static bool IsConnected<T>(Graph<T> graph) where T : notnull
     {
         if (graph.Size == 0)
@@ -412,6 +529,9 @@ public static class GraphAlgorithms
         return Bfs(graph, start).Count == graph.Size;
     }
 
+    /// <summary>
+    /// Partition the graph into its connected components.
+    /// </summary>
     public static IReadOnlyList<HashSet<T>> ConnectedComponents<T>(Graph<T> graph) where T : notnull
     {
         var remaining = new HashSet<T>(graph.Nodes());
@@ -428,6 +548,9 @@ public static class GraphAlgorithms
         return result;
     }
 
+    /// <summary>
+    /// Detect whether an undirected cycle exists anywhere in the graph.
+    /// </summary>
     public static bool HasCycle<T>(Graph<T> graph) where T : notnull
     {
         var visited = new HashSet<T>();
@@ -469,8 +592,15 @@ public static class GraphAlgorithms
         return false;
     }
 
+    /// <summary>
+    /// Compute the lowest-cost path between two nodes.
+    /// For unit-weight graphs this uses BFS; otherwise it uses Dijkstra.
+    /// </summary>
     public static IReadOnlyList<T> ShortestPath<T>(Graph<T> graph, T start, T end) where T : notnull
     {
+        // Unweighted graphs can use BFS because every hop costs the same.
+        // Weighted graphs need Dijkstra so a "longer in hops, cheaper in total"
+        // route is still discovered.
         if (!graph.HasNode(start) || !graph.HasNode(end))
         {
             return Array.Empty<T>();
@@ -486,8 +616,15 @@ public static class GraphAlgorithms
             : DijkstraShortestPath(graph, start, end);
     }
 
+    /// <summary>
+    /// Build a minimum spanning tree using Kruskal's algorithm.
+    /// </summary>
     public static IReadOnlyList<WeightedEdge<T>> MinimumSpanningTree<T>(Graph<T> graph) where T : notnull
     {
+        // We use Kruskal's algorithm:
+        //   sort edges by weight
+        //   keep adding the next-lightest edge that does not create a cycle
+        // A union-find structure makes the cycle test efficient.
         if (graph.Size <= 1)
         {
             return Array.Empty<WeightedEdge<T>>();
@@ -633,6 +770,8 @@ public static class GraphAlgorithms
 
 internal sealed class UnionFind<T> where T : notnull
 {
+    // Union-find keeps track of which nodes already belong to the same partial
+    // tree while Kruskal's algorithm is building the spanning forest.
     private readonly Dictionary<T, T> _parent = new();
     private readonly Dictionary<T, int> _rank = new();
 

--- a/code/packages/csharp/graph/README.md
+++ b/code/packages/csharp/graph/README.md
@@ -1,10 +1,23 @@
 # graph
 
-An undirected weighted graph with adjacency-list and adjacency-matrix representations plus traversal and pathfinding algorithms
+An undirected weighted graph for C# with two interchangeable storage models:
+adjacency lists for sparse graphs and adjacency matrices for dense ones.
+
+## What it provides
+
+- `Graph<T>` with `GraphRepr.AdjacencyList` and `GraphRepr.AdjacencyMatrix`
+- weighted undirected edges, including self-loops
+- traversal algorithms: BFS, DFS, connectivity, components, cycle detection
+- path and tree helpers: shortest path and minimum spanning tree
+
+## Literate source
+
+The implementation is written in the repo's Knuth-style literate format. The
+goal is that someone learning graph theory or data-structure tradeoffs can read
+[Graph.cs](./Graph.cs) and understand both the code and the design decisions.
 
 ## Development
 
 ```bash
-# Run tests
 bash BUILD
 ```

--- a/code/packages/csharp/loss-functions/BUILD
+++ b/code/packages/csharp/loss-functions/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.LossFunctions.Tests/CodingAdventures.LossFunctions.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/loss-functions/BUILD_windows
+++ b/code/packages/csharp/loss-functions/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.LossFunctions.Tests/CodingAdventures.LossFunctions.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/loss-functions/CHANGELOG.md
+++ b/code/packages/csharp/loss-functions/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-15
+
+### Added
+
+- Knuth-style literate implementation of MSE, MAE, BCE, and CCE
+- Gradient helpers for all four losses, matching the shared math spec
+- Validation and epsilon-clamping tests for the regression and cross-entropy paths

--- a/code/packages/csharp/loss-functions/CodingAdventures.LossFunctions.csproj
+++ b/code/packages/csharp/loss-functions/CodingAdventures.LossFunctions.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.LossFunctions.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure scalar-array loss functions and gradients for machine learning</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\\**\\*.cs" />
+    <EmbeddedResource Remove="tests\\**" />
+    <None Remove="tests\\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/loss-functions/LossFunctions.cs
+++ b/code/packages/csharp/loss-functions/LossFunctions.cs
@@ -1,0 +1,229 @@
+using System;
+using System.Collections.Generic;
+
+namespace CodingAdventures.LossFunctions;
+
+// LossFunctions.cs -- Measuring how wrong a model is, one vector at a time
+// =========================================================================
+//
+// Training a model is impossible without a scoring rule. The optimizer asks:
+//
+//   "Given the prediction we just made and the truth we wanted, how bad was it?"
+//
+// That scoring rule is the loss function. This package implements four of the
+// most common ones:
+//
+//   MSE -- mean squared error, the classic regression loss
+//   MAE -- mean absolute error, more robust to outliers
+//   BCE -- binary cross-entropy, for yes/no classification
+//   CCE -- categorical cross-entropy, for one-hot multi-class classification
+//
+// Each loss also has a derivative with respect to y_pred, because backpropagation
+// needs to know not only the scalar error but the direction in which each
+// prediction should move.
+
+/// <summary>
+/// Pure vector-to-scalar loss functions plus vector derivatives.
+/// </summary>
+public static class LossFunctions
+{
+    // log(0) is undefined, so probabilities are clamped away from the boundary.
+    private const double Epsilon = 1e-7;
+
+    /// <summary>
+    /// Compute mean squared error.
+    ///
+    /// MSE = (1 / n) * sum((y_true - y_pred)^2)
+    ///
+    /// Squaring makes large mistakes disproportionately expensive, which is why
+    /// MSE is the standard regression loss.
+    /// </summary>
+    public static double Mse(IReadOnlyList<double> yTrue, IReadOnlyList<double> yPred)
+    {
+        ValidateVectors(yTrue, yPred);
+
+        var sum = 0.0;
+        for (var i = 0; i < yTrue.Count; i++)
+        {
+            var diff = yTrue[i] - yPred[i];
+            sum += diff * diff;
+        }
+
+        return sum / yTrue.Count;
+    }
+
+    /// <summary>
+    /// Compute mean absolute error.
+    ///
+    /// MAE = (1 / n) * sum(abs(y_true - y_pred))
+    ///
+    /// Because the error is not squared, MAE reacts more gently to outliers.
+    /// </summary>
+    public static double Mae(IReadOnlyList<double> yTrue, IReadOnlyList<double> yPred)
+    {
+        ValidateVectors(yTrue, yPred);
+
+        var sum = 0.0;
+        for (var i = 0; i < yTrue.Count; i++)
+        {
+            sum += Math.Abs(yTrue[i] - yPred[i]);
+        }
+
+        return sum / yTrue.Count;
+    }
+
+    /// <summary>
+    /// Compute binary cross-entropy for binary labels and probabilities.
+    ///
+    /// BCE = -(1 / n) * sum(y * log(p) + (1 - y) * log(1 - p))
+    ///
+    /// The prediction p is clamped to [epsilon, 1 - epsilon] so that log never
+    /// sees an exact zero.
+    /// </summary>
+    public static double Bce(IReadOnlyList<double> yTrue, IReadOnlyList<double> yPred)
+    {
+        ValidateVectors(yTrue, yPred);
+
+        var sum = 0.0;
+        for (var i = 0; i < yTrue.Count; i++)
+        {
+            var probability = ClampProbability(yPred[i]);
+            sum += yTrue[i] * Math.Log(probability) +
+                   (1.0 - yTrue[i]) * Math.Log(1.0 - probability);
+        }
+
+        return -sum / yTrue.Count;
+    }
+
+    /// <summary>
+    /// Compute categorical cross-entropy for a one-hot target vector.
+    ///
+    /// CCE = -(1 / n) * sum(y * log(p))
+    ///
+    /// Only the entries whose ground-truth value is non-zero contribute to the
+    /// sum, which mirrors the "probability assigned to the correct class"
+    /// intuition.
+    /// </summary>
+    public static double Cce(IReadOnlyList<double> yTrue, IReadOnlyList<double> yPred)
+    {
+        ValidateVectors(yTrue, yPred);
+
+        var sum = 0.0;
+        for (var i = 0; i < yTrue.Count; i++)
+        {
+            var probability = ClampProbability(yPred[i]);
+            sum += yTrue[i] * Math.Log(probability);
+        }
+
+        return -sum / yTrue.Count;
+    }
+
+    /// <summary>
+    /// Compute the gradient of mean squared error with respect to the prediction.
+    ///
+    /// d/dy_pred MSE = (2 / n) * (y_pred - y_true)
+    /// </summary>
+    public static double[] MseDerivative(IReadOnlyList<double> yTrue, IReadOnlyList<double> yPred)
+    {
+        ValidateVectors(yTrue, yPred);
+
+        var gradient = new double[yTrue.Count];
+        var scale = 2.0 / yTrue.Count;
+        for (var i = 0; i < yTrue.Count; i++)
+        {
+            gradient[i] = scale * (yPred[i] - yTrue[i]);
+        }
+
+        return gradient;
+    }
+
+    /// <summary>
+    /// Compute the gradient of mean absolute error.
+    ///
+    /// The derivative is the sign of (y_pred - y_true) divided by n. Exactly
+    /// at zero the derivative is undefined, and the conventional subgradient is 0.
+    /// </summary>
+    public static double[] MaeDerivative(IReadOnlyList<double> yTrue, IReadOnlyList<double> yPred)
+    {
+        ValidateVectors(yTrue, yPred);
+
+        var gradient = new double[yTrue.Count];
+        var scale = 1.0 / yTrue.Count;
+        for (var i = 0; i < yTrue.Count; i++)
+        {
+            if (yPred[i] > yTrue[i])
+            {
+                gradient[i] = scale;
+            }
+            else if (yPred[i] < yTrue[i])
+            {
+                gradient[i] = -scale;
+            }
+            else
+            {
+                gradient[i] = 0.0;
+            }
+        }
+
+        return gradient;
+    }
+
+    /// <summary>
+    /// Compute the gradient of binary cross-entropy.
+    ///
+    /// d/dy_pred BCE = (1 / n) * (p - y) / (p * (1 - p))
+    ///
+    /// We use the clamped probability in both the numerator and denominator so
+    /// that the derivative stays finite at the probability boundaries.
+    /// </summary>
+    public static double[] BceDerivative(IReadOnlyList<double> yTrue, IReadOnlyList<double> yPred)
+    {
+        ValidateVectors(yTrue, yPred);
+
+        var gradient = new double[yTrue.Count];
+        var scale = 1.0 / yTrue.Count;
+        for (var i = 0; i < yTrue.Count; i++)
+        {
+            var probability = ClampProbability(yPred[i]);
+            gradient[i] = scale * ((probability - yTrue[i]) / (probability * (1.0 - probability)));
+        }
+
+        return gradient;
+    }
+
+    /// <summary>
+    /// Compute the gradient of categorical cross-entropy.
+    ///
+    /// d/dy_pred CCE = -(1 / n) * y / p
+    ///
+    /// Again, p is clamped so that division by zero cannot occur.
+    /// </summary>
+    public static double[] CceDerivative(IReadOnlyList<double> yTrue, IReadOnlyList<double> yPred)
+    {
+        ValidateVectors(yTrue, yPred);
+
+        var gradient = new double[yTrue.Count];
+        var scale = -1.0 / yTrue.Count;
+        for (var i = 0; i < yTrue.Count; i++)
+        {
+            var probability = ClampProbability(yPred[i]);
+            gradient[i] = scale * (yTrue[i] / probability);
+        }
+
+        return gradient;
+    }
+
+    private static void ValidateVectors(IReadOnlyList<double> yTrue, IReadOnlyList<double> yPred)
+    {
+        ArgumentNullException.ThrowIfNull(yTrue);
+        ArgumentNullException.ThrowIfNull(yPred);
+
+        if (yTrue.Count == 0 || yTrue.Count != yPred.Count)
+        {
+            throw new ArgumentException("Vectors must have the same non-zero length.");
+        }
+    }
+
+    private static double ClampProbability(double probability) =>
+        Math.Max(Epsilon, Math.Min(1.0 - Epsilon, probability));
+}

--- a/code/packages/csharp/loss-functions/README.md
+++ b/code/packages/csharp/loss-functions/README.md
@@ -1,0 +1,33 @@
+# loss-functions
+
+Pure vector loss functions and gradients for machine learning, ported into C#
+from the repo's standalone Rust math layer.
+
+## What it provides
+
+- `LossFunctions.Mse` and `LossFunctions.MseDerivative`
+- `LossFunctions.Mae` and `LossFunctions.MaeDerivative`
+- `LossFunctions.Bce` and `LossFunctions.BceDerivative`
+- `LossFunctions.Cce` and `LossFunctions.CceDerivative`
+
+## Why this is a good starter port
+
+`loss-functions` is another true leaf package. It has no sibling dependencies,
+but it still exercises real numerical concerns such as epsilon clamping,
+argument validation, and vector-shaped parity tests. That makes it a good
+baseline for future .NET ML/math ports.
+
+## Example
+
+```csharp
+using CodingAdventures.LossFunctions;
+
+var mse = LossFunctions.Mse([1.0, 0.0], [0.9, 0.1]);
+var grad = LossFunctions.MseDerivative([1.0, 0.0], [0.9, 0.1]);
+```
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/csharp/loss-functions/required_capabilities.json
+++ b/code/packages/csharp/loss-functions/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/loss-functions",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/loss-functions/tests/CodingAdventures.LossFunctions.Tests/CodingAdventures.LossFunctions.Tests.csproj
+++ b/code/packages/csharp/loss-functions/tests/CodingAdventures.LossFunctions.Tests/CodingAdventures.LossFunctions.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.LossFunctions.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/loss-functions/tests/CodingAdventures.LossFunctions.Tests/LossFunctionsTests.cs
+++ b/code/packages/csharp/loss-functions/tests/CodingAdventures.LossFunctions.Tests/LossFunctionsTests.cs
@@ -1,0 +1,76 @@
+using Loss = CodingAdventures.LossFunctions.LossFunctions;
+
+namespace CodingAdventures.LossFunctions.Tests;
+
+public sealed class LossFunctionsTests
+{
+    private static void AssertClose(double expected, double actual, double tolerance = 1e-9)
+    {
+        Assert.True(
+            Math.Abs(expected - actual) <= tolerance,
+            $"Expected {expected:R} but got {actual:R}.");
+    }
+
+    private static void AssertClose(double[] expected, double[] actual, double tolerance = 1e-9)
+    {
+        Assert.Equal(expected.Length, actual.Length);
+        for (var i = 0; i < expected.Length; i++)
+        {
+            AssertClose(expected[i], actual[i], tolerance);
+        }
+    }
+
+    [Fact]
+    public void CoreLossFunctionsMatchTheSpecVectors()
+    {
+        AssertClose(0.02, Loss.Mse([1.0, 0.0, 0.0], [0.9, 0.1, 0.2]));
+        AssertClose(0.13333333333333333, Loss.Mae([1.0, 0.0, 0.0], [0.9, 0.1, 0.2]));
+        AssertClose(0.14462152754328741, Loss.Bce([1.0, 0.0, 1.0], [0.9, 0.1, 0.8]));
+        AssertClose(0.07438118377140324, Loss.Cce([1.0, 0.0, 0.0], [0.8, 0.1, 0.1]));
+    }
+
+    [Fact]
+    public void IdenticalVectorsHaveZeroRegressionLoss()
+    {
+        var values = new[] { 1.0, 0.0, 0.5 };
+        AssertClose(0.0, Loss.Mse(values, values));
+        AssertClose(0.0, Loss.Mae(values, values));
+    }
+
+    [Fact]
+    public void DerivativesMatchTheReferenceCalculations()
+    {
+        AssertClose([-0.2, 0.2], Loss.MseDerivative([1.0, 0.0], [0.8, 0.2]));
+        AssertClose([-1.0 / 3.0, 1.0 / 3.0, 0.0], Loss.MaeDerivative([1.0, 0.0, 0.5], [0.8, 0.2, 0.5]));
+        AssertClose([-0.625, 0.625], Loss.BceDerivative([1.0, 0.0], [0.8, 0.2]));
+        AssertClose([-0.625, 0.0], Loss.CceDerivative([1.0, 0.0], [0.8, 0.2]));
+    }
+
+    [Fact]
+    public void InvalidShapesThrowForEveryLoss()
+    {
+        Assert.Throws<ArgumentException>(() => Loss.Mse([1.0], [0.9, 0.1]));
+        Assert.Throws<ArgumentException>(() => Loss.Mae([1.0], [0.9, 0.1]));
+        Assert.Throws<ArgumentException>(() => Loss.Bce([1.0], [0.9, 0.1]));
+        Assert.Throws<ArgumentException>(() => Loss.Cce([1.0], [0.9, 0.1]));
+    }
+
+    [Fact]
+    public void EmptyVectorsThrowForEveryLoss()
+    {
+        Assert.Throws<ArgumentException>(() => Loss.Mse([], []));
+        Assert.Throws<ArgumentException>(() => Loss.Mae([], []));
+        Assert.Throws<ArgumentException>(() => Loss.Bce([], []));
+        Assert.Throws<ArgumentException>(() => Loss.Cce([], []));
+    }
+
+    [Fact]
+    public void CrossEntropyClampsBoundaryProbabilitiesToStayFinite()
+    {
+        var bce = Loss.Bce([1.0, 0.0], [1.0, 0.0]);
+        var cce = Loss.Cce([1.0, 0.0, 0.0], [1.0, 0.0, 0.0]);
+
+        Assert.True(double.IsFinite(bce));
+        Assert.True(double.IsFinite(cce));
+    }
+}

--- a/code/packages/fsharp/.gitignore
+++ b/code/packages/fsharp/.gitignore
@@ -1,0 +1,3 @@
+**/bin/
+**/obj/
+**/coverage.json

--- a/code/packages/fsharp/activation-functions/ActivationFunctions.fs
+++ b/code/packages/fsharp/activation-functions/ActivationFunctions.fs
@@ -1,0 +1,76 @@
+namespace CodingAdventures.ActivationFunctions
+
+open System
+
+// ActivationFunctions.fs -- The non-linear turns in an otherwise linear road
+// ===========================================================================
+//
+// A neural network alternates between:
+//
+//   1. linear mixing   -- weighted sums
+//   2. non-linear bend -- activation functions
+//
+// Without step 2, the entire network collapses into a single linear transform.
+// This file implements the three scalar activations that show up over and over
+// in introductory machine learning:
+//
+//   sigmoid -- probability-like squashing to (0, 1)
+//   relu    -- keep positives, discard negatives
+//   tanh    -- zero-centered squashing to (-1, 1)
+//
+// Each function also exposes its derivative so the same package is useful in
+// both the forward pass and the backward pass of training.
+
+[<RequireQualifiedAccess>]
+module ActivationFunctions =
+    // exp(710) is already too large for float, so we clamp before calling Exp.
+    let private sigmoidOverflowClamp = 709.0
+
+    /// Compute the logistic sigmoid.
+    ///
+    /// sigma(x) = 1 / (1 + e^-x)
+    ///
+    /// The result is always between zero and one, which is why sigmoid often
+    /// appears in binary-classification output layers.
+    let sigmoid (x: float) =
+        if x < -sigmoidOverflowClamp then
+            0.0
+        elif x > sigmoidOverflowClamp then
+            1.0
+        else
+            1.0 / (1.0 + Math.Exp(-x))
+
+    /// Compute sigma(x) * (1 - sigma(x)).
+    ///
+    /// The derivative is largest in the middle and smallest in the saturated
+    /// tails, which is the textbook source of vanishing gradients.
+    let sigmoidDerivative (x: float) =
+        let s = sigmoid x
+        s * (1.0 - s)
+
+    /// Compute the rectified linear unit: max(0, x).
+    ///
+    /// ReLU became the default hidden-layer choice because it is cheap and
+    /// preserves positive magnitudes instead of compressing them.
+    let relu (x: float) = max 0.0 x
+
+    /// Return the slope of ReLU.
+    ///
+    /// The function is piecewise linear: slope 1 to the right of zero, slope 0
+    /// to the left. At exactly zero we follow the common convention of 0.
+    let reluDerivative (x: float) =
+        if x > 0.0 then
+            1.0
+        else
+            0.0
+
+    /// Compute tanh(x), the zero-centered sibling of sigmoid.
+    let tanh (x: float) = Math.Tanh(x)
+
+    /// Compute 1 - tanh(x)^2.
+    ///
+    /// This derivative is convenient because it can be expressed directly in
+    /// terms of the activation value.
+    let tanhDerivative (x: float) =
+        let t = Math.Tanh(x)
+        1.0 - (t * t)

--- a/code/packages/fsharp/activation-functions/BUILD
+++ b/code/packages/fsharp/activation-functions/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.ActivationFunctions.Tests/CodingAdventures.ActivationFunctions.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/activation-functions/BUILD_windows
+++ b/code/packages/fsharp/activation-functions/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.ActivationFunctions.Tests/CodingAdventures.ActivationFunctions.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/activation-functions/CHANGELOG.md
+++ b/code/packages/fsharp/activation-functions/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-15
+
+### Added
+
+- Knuth-style literate implementation of sigmoid, ReLU, and tanh
+- Derivative helpers for all three activation functions
+- Spec-vector and symmetry/range tests covering the numerical edge cases

--- a/code/packages/fsharp/activation-functions/CodingAdventures.ActivationFunctions.fsproj
+++ b/code/packages/fsharp/activation-functions/CodingAdventures.ActivationFunctions.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.ActivationFunctions.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Scalar neural-network activation functions with derivatives</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ActivationFunctions.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/activation-functions/README.md
+++ b/code/packages/fsharp/activation-functions/README.md
@@ -1,0 +1,32 @@
+# activation-functions
+
+Scalar neural-network activation functions with derivatives, ported into F#
+from the repo's dependency-free Rust math layer.
+
+## What it provides
+
+- `ActivationFunctions.sigmoid` and `ActivationFunctions.sigmoidDerivative`
+- `ActivationFunctions.relu` and `ActivationFunctions.reluDerivative`
+- `ActivationFunctions.tanh` and `ActivationFunctions.tanhDerivative`
+
+## Why this is a good starter port
+
+This package is a leaf: it depends only on `System.Math`, so it lets the new
+.NET package roots grow without a sibling dependency chain. It also establishes
+the literate F# style we want for later ports: public functions that are small,
+parity-tested, and explained inline.
+
+## Example
+
+```fsharp
+open CodingAdventures.ActivationFunctions
+
+let probability = ActivationFunctions.sigmoid 1.0
+let slope = ActivationFunctions.sigmoidDerivative 1.0
+```
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/fsharp/activation-functions/required_capabilities.json
+++ b/code/packages/fsharp/activation-functions/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/activation-functions",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/activation-functions/tests/CodingAdventures.ActivationFunctions.Tests/ActivationFunctionsTests.fs
+++ b/code/packages/fsharp/activation-functions/tests/CodingAdventures.ActivationFunctions.Tests/ActivationFunctionsTests.fs
@@ -1,0 +1,58 @@
+namespace CodingAdventures.ActivationFunctions.Tests
+
+open System
+open Xunit
+open CodingAdventures.ActivationFunctions
+
+type ActivationFunctionsTests() =
+    let assertClose expected actual tolerance =
+        Assert.True(abs (expected - actual) <= tolerance, $"Expected {expected} but got {actual}.")
+
+    [<Fact>]
+    member _.``Sigmoid matches the spec vectors``() =
+        assertClose 0.5 (ActivationFunctions.sigmoid 0.0) 1e-12
+        assertClose 0.7310585786300049 (ActivationFunctions.sigmoid 1.0) 1e-12
+        assertClose 0.2689414213699951 (ActivationFunctions.sigmoid -1.0) 1e-12
+        assertClose 0.9999546021312976 (ActivationFunctions.sigmoid 10.0) 1e-12
+        assertClose 0.0 (ActivationFunctions.sigmoid -710.0) 1e-12
+        assertClose 1.0 (ActivationFunctions.sigmoid 710.0) 1e-12
+
+    [<Fact>]
+    member _.``Sigmoid derivative matches the spec vectors``() =
+        assertClose 0.25 (ActivationFunctions.sigmoidDerivative 0.0) 1e-12
+        assertClose 0.19661193324148185 (ActivationFunctions.sigmoidDerivative 1.0) 1e-12
+        assertClose 0.00004539580773595167 (ActivationFunctions.sigmoidDerivative 10.0) 1e-12
+
+    [<Fact>]
+    member _.``ReLU and its derivative match the piecewise definition``() =
+        assertClose 5.0 (ActivationFunctions.relu 5.0) 1e-12
+        assertClose 0.0 (ActivationFunctions.relu -3.0) 1e-12
+        assertClose 0.0 (ActivationFunctions.relu 0.0) 1e-12
+
+        assertClose 1.0 (ActivationFunctions.reluDerivative 5.0) 1e-12
+        assertClose 0.0 (ActivationFunctions.reluDerivative -3.0) 1e-12
+        assertClose 0.0 (ActivationFunctions.reluDerivative 0.0) 1e-12
+
+    [<Fact>]
+    member _.``Tanh and its derivative match the reference values``() =
+        assertClose 0.0 (ActivationFunctions.tanh 0.0) 1e-12
+        assertClose 0.7615941559557649 (ActivationFunctions.tanh 1.0) 1e-12
+        assertClose -0.7615941559557649 (ActivationFunctions.tanh -1.0) 1e-12
+
+        assertClose 1.0 (ActivationFunctions.tanhDerivative 0.0) 1e-12
+        assertClose 0.41997434161402614 (ActivationFunctions.tanhDerivative 1.0) 1e-12
+
+    [<Fact>]
+    member _.``Symmetry and range properties hold for representative samples``() =
+        for sample in [| -6.0; -1.5; -0.5; 0.5; 1.5; 6.0 |] do
+            let sigmoid = ActivationFunctions.sigmoid sample
+            Assert.InRange(sigmoid, 0.0, 1.0)
+            assertClose sigmoid (1.0 - ActivationFunctions.sigmoid (-sample)) 1e-10
+
+            let tanh = ActivationFunctions.tanh sample
+            Assert.InRange(tanh, -1.0, 1.0)
+            assertClose tanh (-ActivationFunctions.tanh (-sample)) 1e-10
+
+            Assert.True(ActivationFunctions.sigmoidDerivative sample >= 0.0)
+            Assert.True(ActivationFunctions.reluDerivative sample >= 0.0)
+            Assert.True(ActivationFunctions.tanhDerivative sample >= 0.0)

--- a/code/packages/fsharp/activation-functions/tests/CodingAdventures.ActivationFunctions.Tests/CodingAdventures.ActivationFunctions.Tests.fsproj
+++ b/code/packages/fsharp/activation-functions/tests/CodingAdventures.ActivationFunctions.Tests/CodingAdventures.ActivationFunctions.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.ActivationFunctions.fsproj" />
+    <Compile Include="ActivationFunctionsTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/graph/CHANGELOG.md
+++ b/code/packages/fsharp/graph/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this package will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- Expanded `Graph.fs` into the repo's literate-programming style with design
+  commentary about representations, traversal order, shortest path selection,
+  and Kruskal's MST algorithm
+- Expanded the README so the package explains the API surface and its teaching
+  intent instead of only listing the test command
+
 ## [0.1.0] - 2026-04-12
 
 ### Added

--- a/code/packages/fsharp/graph/Graph.fs
+++ b/code/packages/fsharp/graph/Graph.fs
@@ -4,11 +4,26 @@ open System
 open System.Collections.Generic
 open System.Text.Json
 
+// Graph.fs -- One graph interface, two internal storage stories
+// =============================================================
+//
+// This package is intentionally educational. We keep the public graph API
+// stable while allowing the internal representation to vary:
+//
+//   AdjacencyList   -- compact for sparse graphs
+//   AdjacencyMatrix -- direct edge lookup for dense graphs
+//
+// The higher-level algorithms later in the file are written against the public
+// members of Graph<'T>, so BFS, DFS, shortest path, and minimum spanning tree
+// all work regardless of which representation the caller chooses.
+
+/// Select which internal storage model backs the graph.
 type GraphRepr =
     | AdjacencyList = 0
     | AdjacencyMatrix = 1
 
 [<Struct>]
+/// A single undirected weighted edge in canonical endpoint order.
 type WeightedEdge<'T when 'T : equality> =
     {
         Left: 'T
@@ -17,6 +32,8 @@ type WeightedEdge<'T when 'T : equality> =
     }
 
 module internal NodeOrdering =
+    // Hash-based containers do not preserve insertion order. We sort by a
+    // canonical textual key so examples and tests stay deterministic.
     let canonicalKey<'T> (node: 'T) =
         try
             sprintf "%s:%s" typeof<'T>.FullName (JsonSerializer.Serialize(node))
@@ -45,7 +62,14 @@ module internal NodeOrdering =
 
 type Graph<'T when 'T : equality>(?repr: GraphRepr) =
     let representation = defaultArg repr GraphRepr.AdjacencyList
+
+    // Adjacency-list storage:
+    //   node -> (neighbor -> weight)
     let adjacency = Dictionary<'T, Dictionary<'T, float>>()
+
+    // Adjacency-matrix storage:
+    //   nodeList/nodeIndex translate values to integer positions
+    //   matrix[row][col] stores Some(weight) / None
     let nodeList = ResizeArray<'T>()
     let nodeIndex = Dictionary<'T, int>()
     let matrix = ResizeArray<ResizeArray<float option>>()
@@ -60,9 +84,11 @@ type Graph<'T when 'T : equality>(?repr: GraphRepr) =
 
     member _.AddNode(node: 'T) =
         if representation = GraphRepr.AdjacencyList then
+            // In list mode, a node exists once it has an empty neighbor map.
             if not (adjacency.ContainsKey(node)) then
                 adjacency.[node] <- Dictionary<'T, float>()
         else if not (nodeIndex.ContainsKey(node)) then
+            // In matrix mode we must grow the matrix in both dimensions.
             let index = nodeList.Count
             nodeList.Add(node)
             nodeIndex.[node] <- index
@@ -167,6 +193,8 @@ type Graph<'T when 'T : equality>(?repr: GraphRepr) =
         let result = ResizeArray<WeightedEdge<'T>>()
 
         if representation = GraphRepr.AdjacencyList then
+            // Each undirected edge is stored twice internally, so we deduplicate
+            // using a canonical key before exposing the public edge list.
             let seen = HashSet<string>(StringComparer.Ordinal)
             for KeyValue(left, neighbors) in adjacency do
                 for KeyValue(right, weight) in neighbors do
@@ -284,6 +312,7 @@ module GraphAlgorithms =
         if not (graph.HasNode(start)) then
             raise (KeyNotFoundException(sprintf "Node not found: %A" start))
 
+    /// Breadth-first search visits nodes in increasing hop distance.
     let bfs (graph: Graph<'T>) (start: 'T) =
         ensureNode graph start
 
@@ -304,6 +333,7 @@ module GraphAlgorithms =
 
         result |> Seq.toList
 
+    /// Depth-first search explores one branch as far as it can before backtracking.
     let dfs (graph: Graph<'T>) (start: 'T) =
         ensureNode graph start
 
@@ -456,6 +486,8 @@ module GraphAlgorithms =
         | _ -> []
 
     let shortestPath (graph: Graph<'T>) (start: 'T) (finish: 'T) =
+        // If every edge has weight 1.0, BFS already gives the optimal route.
+        // Once weights vary, we switch to Dijkstra.
         if not (graph.HasNode(start)) || not (graph.HasNode(finish)) then
             []
         elif EqualityComparer<'T>.Default.Equals(start, finish) then
@@ -466,6 +498,9 @@ module GraphAlgorithms =
             dijkstraShortestPath graph start finish
 
     let minimumSpanningTree (graph: Graph<'T>) =
+        // Kruskal's algorithm:
+        //   1. sort edges from cheapest to most expensive
+        //   2. keep an edge only if it connects two previously separate trees
         if graph.Size <= 1 then
             []
         elif not (isConnected graph) then

--- a/code/packages/fsharp/graph/README.md
+++ b/code/packages/fsharp/graph/README.md
@@ -1,10 +1,23 @@
 # graph
 
-An undirected weighted graph with adjacency-list and adjacency-matrix representations plus traversal and pathfinding algorithms
+An undirected weighted graph for F# with two interchangeable storage models:
+adjacency lists for sparse graphs and adjacency matrices for dense ones.
+
+## What it provides
+
+- `Graph<'T>` with `GraphRepr.AdjacencyList` and `GraphRepr.AdjacencyMatrix`
+- weighted undirected edges, including self-loops
+- traversal algorithms: BFS, DFS, connectivity, components, cycle detection
+- path and tree helpers: shortest path and minimum spanning tree
+
+## Literate source
+
+The implementation is written in the repo's Knuth-style literate format. The
+goal is that someone learning graph theory or data-structure tradeoffs can read
+[Graph.fs](./Graph.fs) and understand both the code and the design decisions.
 
 ## Development
 
 ```bash
-# Run tests
 bash BUILD
 ```

--- a/code/packages/fsharp/loss-functions/BUILD
+++ b/code/packages/fsharp/loss-functions/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.LossFunctions.Tests/CodingAdventures.LossFunctions.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/loss-functions/BUILD_windows
+++ b/code/packages/fsharp/loss-functions/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.LossFunctions.Tests/CodingAdventures.LossFunctions.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/loss-functions/CHANGELOG.md
+++ b/code/packages/fsharp/loss-functions/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-15
+
+### Added
+
+- Knuth-style literate implementation of MSE, MAE, BCE, and CCE
+- Gradient helpers for all four losses, matching the shared math spec
+- Validation and epsilon-clamping tests for the regression and cross-entropy paths

--- a/code/packages/fsharp/loss-functions/CodingAdventures.LossFunctions.fsproj
+++ b/code/packages/fsharp/loss-functions/CodingAdventures.LossFunctions.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.LossFunctions.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure scalar-array loss functions and gradients for machine learning</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="LossFunctions.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/loss-functions/LossFunctions.fs
+++ b/code/packages/fsharp/loss-functions/LossFunctions.fs
@@ -1,0 +1,147 @@
+namespace CodingAdventures.LossFunctions
+
+open System
+
+// LossFunctions.fs -- Converting "that prediction was bad" into math
+// ==================================================================
+//
+// A model can only improve if we can score its mistakes. Loss functions turn a
+// pair of vectors:
+//
+//   yTrue -- what should have happened
+//   yPred -- what the model predicted
+//
+// into either:
+//
+//   1. a single scalar error value, or
+//   2. a gradient telling each prediction which direction to move next
+//
+// This module implements four standard losses:
+//
+//   mse -- mean squared error
+//   mae -- mean absolute error
+//   bce -- binary cross-entropy
+//   cce -- categorical cross-entropy
+
+[<RequireQualifiedAccess>]
+module LossFunctions =
+    // Cross-entropy uses logarithms, so we clamp away from the undefined point log(0).
+    let private epsilon = 1e-7
+
+    let private validateInputs (yTrue: float array) (yPred: float array) =
+        if yTrue.Length = 0 || yTrue.Length <> yPred.Length then
+            invalidArg "yPred" "Vectors must have the same non-zero length."
+
+    let private clampProbability probability =
+        max epsilon (min (1.0 - epsilon) probability)
+
+    /// Compute mean squared error.
+    ///
+    /// MSE = (1 / n) * sum((y_true - y_pred)^2)
+    ///
+    /// Squaring makes large errors dominate the total, which is why MSE is so
+    /// common in regression tasks.
+    let mse (yTrue: float array) (yPred: float array) =
+        validateInputs yTrue yPred
+
+        let mutable sum = 0.0
+        for i in 0 .. yTrue.Length - 1 do
+            let diff = yTrue[i] - yPred[i]
+            sum <- sum + (diff * diff)
+
+        sum / float yTrue.Length
+
+    /// Compute mean absolute error.
+    ///
+    /// MAE = (1 / n) * sum(abs(y_true - y_pred))
+    ///
+    /// Without the square, outliers matter less than they do under MSE.
+    let mae (yTrue: float array) (yPred: float array) =
+        validateInputs yTrue yPred
+
+        let mutable sum = 0.0
+        for i in 0 .. yTrue.Length - 1 do
+            sum <- sum + abs (yTrue[i] - yPred[i])
+
+        sum / float yTrue.Length
+
+    /// Compute binary cross-entropy.
+    ///
+    /// BCE = -(1 / n) * sum(y * log(p) + (1 - y) * log(1 - p))
+    ///
+    /// Probabilities are clamped so that logarithms stay finite at the edges.
+    let bce (yTrue: float array) (yPred: float array) =
+        validateInputs yTrue yPred
+
+        let mutable sum = 0.0
+        for i in 0 .. yTrue.Length - 1 do
+            let probability = clampProbability yPred[i]
+            sum <-
+                sum
+                + (yTrue[i] * Math.Log(probability))
+                + ((1.0 - yTrue[i]) * Math.Log(1.0 - probability))
+
+        -sum / float yTrue.Length
+
+    /// Compute categorical cross-entropy for a one-hot target vector.
+    ///
+    /// CCE = -(1 / n) * sum(y * log(p))
+    let cce (yTrue: float array) (yPred: float array) =
+        validateInputs yTrue yPred
+
+        let mutable sum = 0.0
+        for i in 0 .. yTrue.Length - 1 do
+            let probability = clampProbability yPred[i]
+            sum <- sum + (yTrue[i] * Math.Log(probability))
+
+        -sum / float yTrue.Length
+
+    /// Compute the gradient of mean squared error.
+    ///
+    /// d/dy_pred MSE = (2 / n) * (y_pred - y_true)
+    let mseDerivative (yTrue: float array) (yPred: float array) =
+        validateInputs yTrue yPred
+
+        let scale = 2.0 / float yTrue.Length
+        Array.init yTrue.Length (fun i -> scale * (yPred[i] - yTrue[i]))
+
+    /// Compute the gradient of mean absolute error.
+    ///
+    /// The derivative is the sign of the error divided by n. At zero we use the
+    /// conventional subgradient 0.
+    let maeDerivative (yTrue: float array) (yPred: float array) =
+        validateInputs yTrue yPred
+
+        let scale = 1.0 / float yTrue.Length
+
+        Array.init yTrue.Length (fun i ->
+            if yPred[i] > yTrue[i] then
+                scale
+            elif yPred[i] < yTrue[i] then
+                -scale
+            else
+                0.0)
+
+    /// Compute the gradient of binary cross-entropy.
+    ///
+    /// d/dy_pred BCE = (1 / n) * (p - y) / (p * (1 - p))
+    let bceDerivative (yTrue: float array) (yPred: float array) =
+        validateInputs yTrue yPred
+
+        let scale = 1.0 / float yTrue.Length
+
+        Array.init yTrue.Length (fun i ->
+            let probability = clampProbability yPred[i]
+            scale * ((probability - yTrue[i]) / (probability * (1.0 - probability))))
+
+    /// Compute the gradient of categorical cross-entropy.
+    ///
+    /// d/dy_pred CCE = -(1 / n) * y / p
+    let cceDerivative (yTrue: float array) (yPred: float array) =
+        validateInputs yTrue yPred
+
+        let scale = -1.0 / float yTrue.Length
+
+        Array.init yTrue.Length (fun i ->
+            let probability = clampProbability yPred[i]
+            scale * (yTrue[i] / probability))

--- a/code/packages/fsharp/loss-functions/README.md
+++ b/code/packages/fsharp/loss-functions/README.md
@@ -1,0 +1,32 @@
+# loss-functions
+
+Pure vector loss functions and gradients for machine learning, ported into F#
+from the repo's standalone Rust math layer.
+
+## What it provides
+
+- `LossFunctions.mse` and `LossFunctions.mseDerivative`
+- `LossFunctions.mae` and `LossFunctions.maeDerivative`
+- `LossFunctions.bce` and `LossFunctions.bceDerivative`
+- `LossFunctions.cce` and `LossFunctions.cceDerivative`
+
+## Why this is a good starter port
+
+`loss-functions` stays leaf-level while still covering the things later ports
+will need to get right: validation, floating-point edge cases, and parity with
+other language implementations.
+
+## Example
+
+```fsharp
+open CodingAdventures.LossFunctions
+
+let mse = LossFunctions.mse [| 1.0; 0.0 |] [| 0.9; 0.1 |]
+let grad = LossFunctions.mseDerivative [| 1.0; 0.0 |] [| 0.9; 0.1 |]
+```
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/fsharp/loss-functions/required_capabilities.json
+++ b/code/packages/fsharp/loss-functions/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/loss-functions",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/loss-functions/tests/CodingAdventures.LossFunctions.Tests/CodingAdventures.LossFunctions.Tests.fsproj
+++ b/code/packages/fsharp/loss-functions/tests/CodingAdventures.LossFunctions.Tests/CodingAdventures.LossFunctions.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.LossFunctions.fsproj" />
+    <Compile Include="LossFunctionsTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/loss-functions/tests/CodingAdventures.LossFunctions.Tests/LossFunctionsTests.fs
+++ b/code/packages/fsharp/loss-functions/tests/CodingAdventures.LossFunctions.Tests/LossFunctionsTests.fs
@@ -1,0 +1,55 @@
+namespace CodingAdventures.LossFunctions.Tests
+
+open System
+open Xunit
+open CodingAdventures.LossFunctions
+
+type LossFunctionsTests() =
+    let assertClose expected actual tolerance =
+        Assert.True(abs (expected - actual) <= tolerance, $"Expected {expected} but got {actual}.")
+
+    let assertArrayClose (expected: float array) (actual: float array) tolerance =
+        Assert.Equal(expected.Length, actual.Length)
+        Array.iter2 (fun left right -> assertClose left right tolerance) expected actual
+
+    [<Fact>]
+    member _.``Core loss functions match the spec vectors``() =
+        assertClose 0.02 (LossFunctions.mse [| 1.0; 0.0; 0.0 |] [| 0.9; 0.1; 0.2 |]) 1e-9
+        assertClose 0.13333333333333333 (LossFunctions.mae [| 1.0; 0.0; 0.0 |] [| 0.9; 0.1; 0.2 |]) 1e-9
+        assertClose 0.14462152754328741 (LossFunctions.bce [| 1.0; 0.0; 1.0 |] [| 0.9; 0.1; 0.8 |]) 1e-9
+        assertClose 0.07438118377140324 (LossFunctions.cce [| 1.0; 0.0; 0.0 |] [| 0.8; 0.1; 0.1 |]) 1e-9
+
+    [<Fact>]
+    member _.``Identical vectors have zero regression loss``() =
+        let values = [| 1.0; 0.0; 0.5 |]
+        assertClose 0.0 (LossFunctions.mse values values) 1e-12
+        assertClose 0.0 (LossFunctions.mae values values) 1e-12
+
+    [<Fact>]
+    member _.``Derivatives match the reference calculations``() =
+        assertArrayClose [| -0.2; 0.2 |] (LossFunctions.mseDerivative [| 1.0; 0.0 |] [| 0.8; 0.2 |]) 1e-9
+        assertArrayClose [| -1.0 / 3.0; 1.0 / 3.0; 0.0 |] (LossFunctions.maeDerivative [| 1.0; 0.0; 0.5 |] [| 0.8; 0.2; 0.5 |]) 1e-9
+        assertArrayClose [| -0.625; 0.625 |] (LossFunctions.bceDerivative [| 1.0; 0.0 |] [| 0.8; 0.2 |]) 1e-9
+        assertArrayClose [| -0.625; 0.0 |] (LossFunctions.cceDerivative [| 1.0; 0.0 |] [| 0.8; 0.2 |]) 1e-9
+
+    [<Fact>]
+    member _.``Invalid shapes throw for every loss``() =
+        Assert.Throws<ArgumentException>(fun () -> LossFunctions.mse [| 1.0 |] [| 0.9; 0.1 |] |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> LossFunctions.mae [| 1.0 |] [| 0.9; 0.1 |] |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> LossFunctions.bce [| 1.0 |] [| 0.9; 0.1 |] |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> LossFunctions.cce [| 1.0 |] [| 0.9; 0.1 |] |> ignore) |> ignore
+
+    [<Fact>]
+    member _.``Empty vectors throw for every loss``() =
+        Assert.Throws<ArgumentException>(fun () -> LossFunctions.mse [||] [||] |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> LossFunctions.mae [||] [||] |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> LossFunctions.bce [||] [||] |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> LossFunctions.cce [||] [||] |> ignore) |> ignore
+
+    [<Fact>]
+    member _.``Cross entropy clamps boundary probabilities to stay finite``() =
+        let bce = LossFunctions.bce [| 1.0; 0.0 |] [| 1.0; 0.0 |]
+        let cce = LossFunctions.cce [| 1.0; 0.0; 0.0 |] [| 1.0; 0.0; 0.0 |]
+
+        Assert.True(Double.IsFinite(bce))
+        Assert.True(Double.IsFinite(cce))

--- a/lessons.md
+++ b/lessons.md
@@ -4,6 +4,26 @@ This file tracks mistakes made during development so they are not repeated. Chec
 
 ---
 
+### 2026-04-15: SDK-style C# package projects must exclude nested test sources
+
+SDK-style `.csproj` files include `**/*.cs` by default. In this monorepo, package tests live under each package's `tests/` directory, so a new library project will accidentally compile its own xUnit test files unless the package project excludes them explicitly.
+
+**Symptom:** `dotnet test` fails while building the library project itself with errors like `CS0400: The type or namespace name 'Xunit' could not be found` and `CS0246: The type or namespace name 'FactAttribute' could not be found`, even though the test project has the correct xUnit package references.
+
+**Rule:** Every new C# package with in-package `tests/` folders must add this exclusion block to the library `.csproj`:
+
+```xml
+<ItemGroup>
+  <Compile Remove="tests\\**\\*.cs" />
+  <EmbeddedResource Remove="tests\\**" />
+  <None Remove="tests\\**" />
+</ItemGroup>
+```
+
+This keeps the library assembly focused on production code while the test project references it normally.
+
+---
+
 ### 2026-04-12: Never commit build artifacts — agents running tests will generate them
 
 When agents run tests locally (e.g., `swift test`, `mix test`, `bundle exec rake test`), they generate build artifacts in directories like `.build/`, `cover/`, `vendor/`, `node_modules/`, `_build/`, `deps/`, `blib/`, `MYMETA.*`, `pm_to_blib`. If the agent then runs `git add .` or `git add <package-dir>/`, these artifacts get committed.


### PR DESCRIPTION
## Summary

This PR starts the C# and F# catch-up from Rust at the leaf-package layer and brings the existing graph packages closer to the repo's literate-programming standard.

## What changed

- added `activation-functions` for C# and F# with literate implementations and tests
- added `loss-functions` for C# and F# with literate implementations and tests
- expanded the existing C# and F# `graph` packages with fuller inline teaching commentary, API documentation, README updates, and changelog notes
- added `.gitignore` coverage under the C# and F# package roots for `bin/`, `obj/`, and `coverage.json`
- documented the C# SDK-style `tests/` exclusion requirement in `lessons.md`

## Why

C# and F# were recently introduced in the repo and only had `graph` packages. Starting with dependency-free leaf packages makes it easier to grow those ecosystems outward while keeping the first ports easy to test and reason about. The graph documentation pass also fixes a repo-standard gap: the existing .NET packages were functional but not yet written in the same literate style used elsewhere in the project.

## Validation

Ran these package BUILD checks locally in an isolated worktree using .NET SDK `9.0.313`:

- `code/packages/csharp/graph`
- `code/packages/fsharp/graph`
- `code/packages/csharp/activation-functions`
- `code/packages/fsharp/activation-functions`
- `code/packages/csharp/loss-functions`
- `code/packages/fsharp/loss-functions`

All passed, including coverage thresholds.
