### PR TITLE
[codex] feat(dotnet): add trig and classical cipher packages

### DIFF
--- a/code/packages/csharp/atbash-cipher/AtbashCipher.cs
+++ b/code/packages/csharp/atbash-cipher/AtbashCipher.cs
@@ -1,0 +1,56 @@
+namespace CodingAdventures.AtbashCipher;
+
+/// <summary>
+/// The fixed reverse-alphabet substitution cipher.
+///
+/// Atbash has no key at all: A maps to Z, B maps to Y, and so on. That makes
+/// it easy to understand and even easier to break, but it is a perfect example
+/// of a self-inverse transformation.
+/// </summary>
+public static class AtbashCipher
+{
+    private static char Transform(char ch)
+    {
+        if (ch is >= 'A' and <= 'Z')
+        {
+            var position = ch - 'A';
+            return (char)('A' + (25 - position));
+        }
+
+        if (ch is >= 'a' and <= 'z')
+        {
+            var position = ch - 'a';
+            return (char)('a' + (25 - position));
+        }
+
+        return ch;
+    }
+
+    /// <summary>
+    /// Apply the Atbash substitution to every ASCII letter in the input.
+    /// </summary>
+    public static string Encrypt(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+
+        var chars = text.ToCharArray();
+        for (var i = 0; i < chars.Length; i++)
+        {
+            chars[i] = Transform(chars[i]);
+        }
+
+        return new string(chars);
+    }
+
+    /// <summary>
+    /// Decrypt Atbash text.
+    ///
+    /// Since Atbash is self-inverse, decryption is the same operation as
+    /// encryption.
+    /// </summary>
+    public static string Decrypt(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        return Encrypt(text);
+    }
+}

--- a/code/packages/csharp/atbash-cipher/BUILD
+++ b/code/packages/csharp/atbash-cipher/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.AtbashCipher.Tests/CodingAdventures.AtbashCipher.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/atbash-cipher/BUILD_windows
+++ b/code/packages/csharp/atbash-cipher/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.AtbashCipher.Tests/CodingAdventures.AtbashCipher.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/atbash-cipher/CHANGELOG.md
+++ b/code/packages/csharp/atbash-cipher/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-15
+
+### Added
+
+- Self-inverse Atbash cipher implementation with ASCII case preservation and
+  passthrough handling for non-alphabetic characters
+- Tests covering classic examples, full alphabets, and the involution property

--- a/code/packages/csharp/atbash-cipher/CodingAdventures.AtbashCipher.csproj
+++ b/code/packages/csharp/atbash-cipher/CodingAdventures.AtbashCipher.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.AtbashCipher.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Fixed reverse-alphabet substitution cipher</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\\**\\*.cs" />
+    <EmbeddedResource Remove="tests\\**" />
+    <None Remove="tests\\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/atbash-cipher/README.md
+++ b/code/packages/csharp/atbash-cipher/README.md
@@ -1,0 +1,27 @@
+# atbash-cipher
+
+C# implementation of the `atbash-cipher` foundation package.
+
+Atbash is the fixed reverse-alphabet substitution cipher: A maps to Z, B maps
+to Y, and so on. Because the mapping is self-inverse, encryption and
+decryption are the same transformation.
+
+## API
+
+- `AtbashCipher.Encrypt(text)`
+- `AtbashCipher.Decrypt(text)`
+
+## Usage
+
+```csharp
+using CodingAdventures.AtbashCipher;
+
+var ciphertext = AtbashCipher.Encrypt("HELLO");
+var plaintext = AtbashCipher.Decrypt(ciphertext);
+```
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/csharp/atbash-cipher/required_capabilities.json
+++ b/code/packages/csharp/atbash-cipher/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/atbash-cipher",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/atbash-cipher/tests/CodingAdventures.AtbashCipher.Tests/AtbashCipherTests.cs
+++ b/code/packages/csharp/atbash-cipher/tests/CodingAdventures.AtbashCipher.Tests/AtbashCipherTests.cs
@@ -1,0 +1,62 @@
+namespace CodingAdventures.AtbashCipher.Tests;
+
+public sealed class AtbashCipherTests
+{
+    [Fact]
+    public void EncryptMatchesClassicExamples()
+    {
+        Assert.Equal("SVOOL", AtbashCipher.Encrypt("HELLO"));
+        Assert.Equal("svool", AtbashCipher.Encrypt("hello"));
+        Assert.Equal("Svool, Dliow! 123", AtbashCipher.Encrypt("Hello, World! 123"));
+    }
+
+    [Fact]
+    public void EncryptPreservesCaseAndPassthroughCharacters()
+    {
+        Assert.Equal("ZYX", AtbashCipher.Encrypt("ABC"));
+        Assert.Equal("zyx", AtbashCipher.Encrypt("abc"));
+        Assert.Equal("ZyXwVu", AtbashCipher.Encrypt("AbCdEf"));
+        Assert.Equal("12345", AtbashCipher.Encrypt("12345"));
+        Assert.Equal("!@#$%", AtbashCipher.Encrypt("!@#$%"));
+        Assert.Equal("Z\nY\tX", AtbashCipher.Encrypt("A\nB\tC"));
+    }
+
+    [Fact]
+    public void EncryptTransformsEntireAlphabet()
+    {
+        Assert.Equal("ZYXWVUTSRQPONMLKJIHGFEDCBA", AtbashCipher.Encrypt("ABCDEFGHIJKLMNOPQRSTUVWXYZ"));
+        Assert.Equal("zyxwvutsrqponmlkjihgfedcba", AtbashCipher.Encrypt("abcdefghijklmnopqrstuvwxyz"));
+    }
+
+    [Fact]
+    public void CipherIsSelfInverse()
+    {
+        var text = "The quick brown fox jumps over the lazy dog! 42";
+        Assert.Equal(text, AtbashCipher.Encrypt(AtbashCipher.Encrypt(text)));
+        Assert.Equal(text, AtbashCipher.Decrypt(AtbashCipher.Encrypt(text)));
+        Assert.Equal(AtbashCipher.Encrypt(text), AtbashCipher.Decrypt(text));
+    }
+
+    [Fact]
+    public void HandlesEdgeCases()
+    {
+        Assert.Equal("", AtbashCipher.Encrypt(""));
+        Assert.Equal("5", AtbashCipher.Encrypt("5"));
+        Assert.Equal("Z", AtbashCipher.Encrypt("A"));
+        Assert.Equal("A", AtbashCipher.Encrypt("Z"));
+        Assert.Equal("N", AtbashCipher.Encrypt("M"));
+        Assert.Equal("M", AtbashCipher.Encrypt("N"));
+    }
+
+    [Fact]
+    public void NoLetterMapsToItself()
+    {
+        for (var offset = 0; offset < 26; offset++)
+        {
+            var upper = ((char)('A' + offset)).ToString();
+            var lower = ((char)('a' + offset)).ToString();
+            Assert.NotEqual(upper, AtbashCipher.Encrypt(upper));
+            Assert.NotEqual(lower, AtbashCipher.Encrypt(lower));
+        }
+    }
+}

--- a/code/packages/csharp/atbash-cipher/tests/CodingAdventures.AtbashCipher.Tests/CodingAdventures.AtbashCipher.Tests.csproj
+++ b/code/packages/csharp/atbash-cipher/tests/CodingAdventures.AtbashCipher.Tests/CodingAdventures.AtbashCipher.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.AtbashCipher.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/caesar-cipher/BUILD
+++ b/code/packages/csharp/caesar-cipher/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.CaesarCipher.Tests/CodingAdventures.CaesarCipher.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/caesar-cipher/BUILD_windows
+++ b/code/packages/csharp/caesar-cipher/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.CaesarCipher.Tests/CodingAdventures.CaesarCipher.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/caesar-cipher/CHANGELOG.md
+++ b/code/packages/csharp/caesar-cipher/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-15
+
+### Added
+
+- Caesar cipher implementation with case preservation, wraparound behavior,
+  negative shift support, and ROT13
+- Brute-force helpers plus chi-squared English-frequency analysis
+- High-coverage unit tests for encryption, decryption, attacks, and statistical
+  tables

--- a/code/packages/csharp/caesar-cipher/CaesarCipher.cs
+++ b/code/packages/csharp/caesar-cipher/CaesarCipher.cs
@@ -1,0 +1,158 @@
+namespace CodingAdventures.CaesarCipher;
+
+/// <summary>
+/// One brute-force-friendly classical cipher plus the simplest statistical
+/// attack against it.
+/// </summary>
+public readonly record struct BruteForceResult(int Shift, string Plaintext);
+
+/// <summary>
+/// Encrypt, decrypt, and attack Caesar ciphers.
+/// </summary>
+public static class CaesarCipher
+{
+    private static readonly double[] EnglishFrequenciesStorage =
+    [
+        0.08167, 0.01492, 0.02782, 0.04253, 0.12702, 0.02228, 0.02015,
+        0.06094, 0.06966, 0.00153, 0.00772, 0.04025, 0.02406, 0.06749,
+        0.07507, 0.01929, 0.00095, 0.05987, 0.06327, 0.09056, 0.02758,
+        0.00978, 0.02360, 0.00150, 0.01974, 0.00074,
+    ];
+
+    /// <summary>
+    /// Expected English letter frequencies for A through Z.
+    /// </summary>
+    public static IReadOnlyList<double> EnglishFrequencies => EnglishFrequenciesStorage;
+
+    private static int NormalizeShift(int shift) => ((shift % 26) + 26) % 26;
+
+    private static char ShiftChar(char ch, int normalizedShift)
+    {
+        if (ch is >= 'A' and <= 'Z')
+        {
+            var position = ch - 'A';
+            return (char)('A' + (position + normalizedShift) % 26);
+        }
+
+        if (ch is >= 'a' and <= 'z')
+        {
+            var position = ch - 'a';
+            return (char)('a' + (position + normalizedShift) % 26);
+        }
+
+        return ch;
+    }
+
+    /// <summary>
+    /// Shift alphabetic characters forward by the requested amount.
+    /// </summary>
+    public static string Encrypt(string text, int shift)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+
+        var normalizedShift = NormalizeShift(shift);
+        var chars = text.ToCharArray();
+        for (var i = 0; i < chars.Length; i++)
+        {
+            chars[i] = ShiftChar(chars[i], normalizedShift);
+        }
+
+        return new string(chars);
+    }
+
+    /// <summary>
+    /// Shift alphabetic characters backward by the requested amount.
+    /// </summary>
+    public static string Decrypt(string text, int shift)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        return Encrypt(text, -shift);
+    }
+
+    /// <summary>
+    /// Apply the special self-inverse shift-13 variant.
+    /// </summary>
+    public static string Rot13(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        return Encrypt(text, 13);
+    }
+
+    /// <summary>
+    /// Try every non-trivial shift and return the resulting plaintexts.
+    /// </summary>
+    public static IReadOnlyList<BruteForceResult> BruteForce(string ciphertext)
+    {
+        ArgumentNullException.ThrowIfNull(ciphertext);
+
+        var results = new List<BruteForceResult>(25);
+        for (var shift = 1; shift <= 25; shift++)
+        {
+            results.Add(new BruteForceResult(shift, Decrypt(ciphertext, shift)));
+        }
+
+        return results;
+    }
+
+    private static int[] LetterCounts(string text)
+    {
+        var counts = new int[26];
+        foreach (var ch in text)
+        {
+            if (char.IsAsciiLetter(ch))
+            {
+                counts[char.ToUpperInvariant(ch) - 'A'] += 1;
+            }
+        }
+
+        return counts;
+    }
+
+    private static double ChiSquared(string text)
+    {
+        var counts = LetterCounts(text);
+        var total = counts.Sum();
+        if (total == 0)
+        {
+            return double.MaxValue;
+        }
+
+        var totalAsDouble = (double)total;
+        var sum = 0.0;
+        for (var i = 0; i < 26; i++)
+        {
+            var expected = totalAsDouble * EnglishFrequenciesStorage[i];
+            var difference = counts[i] - expected;
+            sum += difference * difference / expected;
+        }
+
+        return sum;
+    }
+
+    /// <summary>
+    /// Guess the most likely shift by comparing each candidate plaintext
+    /// against English letter frequencies.
+    /// </summary>
+    public static (int Shift, string Plaintext) FrequencyAnalysis(string ciphertext)
+    {
+        ArgumentNullException.ThrowIfNull(ciphertext);
+
+        var bestShift = 1;
+        var bestPlaintext = Decrypt(ciphertext, 1);
+        var bestScore = ChiSquared(bestPlaintext);
+
+        for (var shift = 2; shift <= 25; shift++)
+        {
+            var candidate = Decrypt(ciphertext, shift);
+            var score = ChiSquared(candidate);
+            if (score < bestScore)
+            {
+                bestShift = shift;
+                bestPlaintext = candidate;
+                bestScore = score;
+            }
+        }
+
+        return (bestShift, bestPlaintext);
+    }
+}

--- a/code/packages/csharp/caesar-cipher/CodingAdventures.CaesarCipher.csproj
+++ b/code/packages/csharp/caesar-cipher/CodingAdventures.CaesarCipher.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.CaesarCipher.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Caesar cipher with brute-force and frequency-analysis helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\\**\\*.cs" />
+    <EmbeddedResource Remove="tests\\**" />
+    <None Remove="tests\\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/caesar-cipher/README.md
+++ b/code/packages/csharp/caesar-cipher/README.md
@@ -1,0 +1,33 @@
+# caesar-cipher
+
+C# implementation of the `caesar-cipher` foundation package.
+
+This package includes both sides of the classic Caesar cipher story: the
+encryption helpers themselves and the brute-force / frequency-analysis tools
+that show why the cipher is insecure.
+
+## API
+
+- `CaesarCipher.Encrypt(text, shift)`
+- `CaesarCipher.Decrypt(text, shift)`
+- `CaesarCipher.Rot13(text)`
+- `CaesarCipher.BruteForce(ciphertext)`
+- `CaesarCipher.FrequencyAnalysis(ciphertext)`
+- `CaesarCipher.EnglishFrequencies`
+
+## Usage
+
+```csharp
+using CodingAdventures.CaesarCipher;
+
+var ciphertext = CaesarCipher.Encrypt("Hello, World!", 3);
+var plaintext = CaesarCipher.Decrypt(ciphertext, 3);
+var guesses = CaesarCipher.BruteForce(ciphertext);
+var (shift, decoded) = CaesarCipher.FrequencyAnalysis(ciphertext);
+```
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/csharp/caesar-cipher/required_capabilities.json
+++ b/code/packages/csharp/caesar-cipher/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/caesar-cipher",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/caesar-cipher/tests/CodingAdventures.CaesarCipher.Tests/CaesarCipherTests.cs
+++ b/code/packages/csharp/caesar-cipher/tests/CodingAdventures.CaesarCipher.Tests/CaesarCipherTests.cs
@@ -1,0 +1,123 @@
+namespace CodingAdventures.CaesarCipher.Tests;
+
+public sealed class CaesarCipherTests
+{
+    [Fact]
+    public void EncryptAndDecryptHandleKnownExamples()
+    {
+        Assert.Equal("KHOOR", CaesarCipher.Encrypt("HELLO", 3));
+        Assert.Equal("khoor", CaesarCipher.Encrypt("hello", 3));
+        Assert.Equal("Khoor, Zruog!", CaesarCipher.Encrypt("Hello, World!", 3));
+        Assert.Equal("HELLO", CaesarCipher.Decrypt("KHOOR", 3));
+        Assert.Equal("Hello, World!", CaesarCipher.Decrypt("Khoor, Zruog!", 3));
+    }
+
+    [Fact]
+    public void EncryptRespectsWrappingAndNegativeShifts()
+    {
+        Assert.Equal("abc XYZ 123!", CaesarCipher.Encrypt("abc XYZ 123!", 0));
+        Assert.Equal("Wrap around test", CaesarCipher.Encrypt("Wrap around test", 26));
+        Assert.Equal("Double wrap", CaesarCipher.Encrypt("Double wrap", 52));
+        Assert.Equal("ZAB", CaesarCipher.Encrypt("ABC", -1));
+        Assert.Equal("ZAB", CaesarCipher.Encrypt("ABC", -27));
+        Assert.Equal("ABC", CaesarCipher.Encrypt("XYZ", 3));
+    }
+
+    [Fact]
+    public void RoundTripsAcrossManyShifts()
+    {
+        var original = "The Quick Brown Fox Jumps Over The Lazy Dog! 123";
+        for (var shift = -30; shift <= 30; shift++)
+        {
+            var encrypted = CaesarCipher.Encrypt(original, shift);
+            var decrypted = CaesarCipher.Decrypt(encrypted, shift);
+            Assert.Equal(original, decrypted);
+        }
+    }
+
+    [Fact]
+    public void Rot13IsSelfInverse()
+    {
+        var text = "The Quick Brown Fox! 123";
+        Assert.Equal(text, CaesarCipher.Rot13(CaesarCipher.Rot13(text)));
+        Assert.Equal(CaesarCipher.Encrypt(text, 13), CaesarCipher.Rot13(text));
+    }
+
+    [Fact]
+    public void NonAsciiCharactersPassThrough()
+    {
+        const string original = "Cafe\u0301 costs $3.50 \u2764";
+        var encrypted = CaesarCipher.Encrypt(original, 7);
+        var decrypted = CaesarCipher.Decrypt(encrypted, 7);
+        Assert.Equal(original, decrypted);
+    }
+
+    [Fact]
+    public void BruteForceReturnsAllCandidates()
+    {
+        var results = CaesarCipher.BruteForce("KHOOR");
+        Assert.Equal(25, results.Count);
+        Assert.Equal(3, results[2].Shift);
+        Assert.Equal("HELLO", results[2].Plaintext);
+        Assert.All(results, result => Assert.InRange(result.Shift, 1, 25));
+    }
+
+    [Fact]
+    public void BruteForceHandlesEmptyAndNonAlphabeticInput()
+    {
+        var emptyResults = CaesarCipher.BruteForce("");
+        Assert.Equal(25, emptyResults.Count);
+        Assert.All(emptyResults, result => Assert.Equal("", result.Plaintext));
+
+        var punctuationResults = CaesarCipher.BruteForce("123!!!");
+        Assert.All(punctuationResults, result => Assert.Equal("123!!!", result.Plaintext));
+    }
+
+    [Fact]
+    public void FrequencyAnalysisFindsKnownShifts()
+    {
+        var plaintext = "THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG";
+        var ciphertext = CaesarCipher.Encrypt(plaintext, 3);
+        var (shift, decoded) = CaesarCipher.FrequencyAnalysis(ciphertext);
+        Assert.Equal(3, shift);
+        Assert.Equal(plaintext, decoded);
+
+        plaintext = "IN CRYPTOGRAPHY A CAESAR CIPHER ALSO KNOWN AS SHIFT CIPHER IS ONE OF THE SIMPLEST AND MOST WIDELY KNOWN ENCRYPTION TECHNIQUES";
+        ciphertext = CaesarCipher.Encrypt(plaintext, 17);
+        (shift, decoded) = CaesarCipher.FrequencyAnalysis(ciphertext);
+        Assert.Equal(17, shift);
+        Assert.Equal(plaintext, decoded);
+    }
+
+    [Fact]
+    public void FrequencyAnalysisHandlesLowSignalInputs()
+    {
+        var (shift, decoded) = CaesarCipher.FrequencyAnalysis("");
+        Assert.InRange(shift, 1, 25);
+        Assert.Equal("", decoded);
+
+        (shift, decoded) = CaesarCipher.FrequencyAnalysis("12345!@#$%");
+        Assert.Equal(1, shift);
+        Assert.Equal("12345!@#$%", decoded);
+
+        (shift, _) = CaesarCipher.FrequencyAnalysis("EEEEEEEEEEE");
+        Assert.InRange(shift, 1, 25);
+    }
+
+    [Fact]
+    public void EnglishFrequencyTableMatchesExpectations()
+    {
+        Assert.Equal(26, CaesarCipher.EnglishFrequencies.Count);
+        Assert.InRange(CaesarCipher.EnglishFrequencies.Sum(), 0.99, 1.01);
+
+        var eFrequency = CaesarCipher.EnglishFrequencies[4];
+        for (var i = 0; i < CaesarCipher.EnglishFrequencies.Count; i++)
+        {
+            Assert.True(CaesarCipher.EnglishFrequencies[i] > 0.0);
+            if (i != 4)
+            {
+                Assert.True(eFrequency > CaesarCipher.EnglishFrequencies[i]);
+            }
+        }
+    }
+}

--- a/code/packages/csharp/caesar-cipher/tests/CodingAdventures.CaesarCipher.Tests/CodingAdventures.CaesarCipher.Tests.csproj
+++ b/code/packages/csharp/caesar-cipher/tests/CodingAdventures.CaesarCipher.Tests/CodingAdventures.CaesarCipher.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.CaesarCipher.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/trig/BUILD
+++ b/code/packages/csharp/trig/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Trig.Tests/CodingAdventures.Trig.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/trig/BUILD_windows
+++ b/code/packages/csharp/trig/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Trig.Tests/CodingAdventures.Trig.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/trig/CHANGELOG.md
+++ b/code/packages/csharp/trig/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-15
+
+### Added
+
+- First-principles `Trig` implementation covering `sin`, `cos`, `tan`,
+  `sqrt`, `atan`, `atan2`, `Radians`, and `Degrees`
+- Literate inline documentation explaining Maclaurin series, range reduction,
+  and Newton iteration
+- Unit tests covering canonical identities, quadrant handling, and conversion
+  round-trips

--- a/code/packages/csharp/trig/CodingAdventures.Trig.csproj
+++ b/code/packages/csharp/trig/CodingAdventures.Trig.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Trig.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Trigonometric functions from first principles using Taylor series</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\\**\\*.cs" />
+    <EmbeddedResource Remove="tests\\**" />
+    <None Remove="tests\\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/trig/README.md
+++ b/code/packages/csharp/trig/README.md
@@ -1,0 +1,37 @@
+# trig
+
+C# implementation of the `trig` foundation package.
+
+This package computes `sin`, `cos`, `tan`, `sqrt`, `atan`, and `atan2`
+without delegating to the host runtime's trigonometry helpers. It is intended
+as a leaf-level teaching package that other geometry and physics packages can
+build on.
+
+## API
+
+- `Trig.PI`
+- `Trig.Sin(x)`
+- `Trig.Cos(x)`
+- `Trig.Tan(x)`
+- `Trig.Sqrt(x)`
+- `Trig.Atan(x)`
+- `Trig.Atan2(y, x)`
+- `Trig.Radians(deg)`
+- `Trig.Degrees(rad)`
+
+## Usage
+
+```csharp
+using CodingAdventures.Trig;
+
+var theta = Trig.Radians(45.0);
+var sine = Trig.Sin(theta);
+var cosine = Trig.Cos(theta);
+var tangent = Trig.Tan(theta);
+```
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/csharp/trig/Trig.cs
+++ b/code/packages/csharp/trig/Trig.cs
@@ -1,0 +1,211 @@
+namespace CodingAdventures.Trig;
+
+/// <summary>
+/// Trigonometric functions from first principles.
+///
+/// The key teaching idea in this package is that "advanced" math functions do
+/// not need magic CPU instructions. Sine and cosine come from Maclaurin
+/// series, square root comes from Newton's method, and tangent/arctangent are
+/// built on top of those primitives.
+/// </summary>
+public static class Trig
+{
+    /// <summary>
+    /// Pi to double-precision accuracy.
+    /// </summary>
+    public const double PI = 3.141592653589793;
+
+    private const double TwoPi = 2.0 * PI;
+    private const double HalfPi = PI / 2.0;
+
+    private static double RangeReduce(double x)
+    {
+        var reduced = x % TwoPi;
+        if (reduced > PI)
+        {
+            reduced -= TwoPi;
+        }
+
+        if (reduced < -PI)
+        {
+            reduced += TwoPi;
+        }
+
+        return reduced;
+    }
+
+    /// <summary>
+    /// Compute sine by summing the Maclaurin series after reducing the input
+    /// into the range [-pi, pi].
+    /// </summary>
+    public static double Sin(double x)
+    {
+        var reduced = RangeReduce(x);
+        var squared = reduced * reduced;
+        var term = reduced;
+        var sum = term;
+
+        for (var k = 1; k < 20; k++)
+        {
+            var denominator = (2.0 * k) * (2.0 * k + 1.0);
+            term *= -squared / denominator;
+            sum += term;
+        }
+
+        return sum;
+    }
+
+    /// <summary>
+    /// Compute cosine by summing the even-powered Maclaurin series.
+    /// </summary>
+    public static double Cos(double x)
+    {
+        var reduced = RangeReduce(x);
+        var squared = reduced * reduced;
+        var term = 1.0;
+        var sum = term;
+
+        for (var k = 1; k < 20; k++)
+        {
+            var denominator = (2.0 * k - 1.0) * (2.0 * k);
+            term *= -squared / denominator;
+            sum += term;
+        }
+
+        return sum;
+    }
+
+    /// <summary>
+    /// Convert degrees to radians.
+    /// </summary>
+    public static double Radians(double degrees) => degrees * (PI / 180.0);
+
+    /// <summary>
+    /// Convert radians to degrees.
+    /// </summary>
+    public static double Degrees(double radians) => radians * (180.0 / PI);
+
+    /// <summary>
+    /// Compute a square root using Newton's method.
+    /// </summary>
+    public static double Sqrt(double x)
+    {
+        if (x < 0.0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(x), x, "sqrt: domain error -- input is negative");
+        }
+
+        if (x == 0.0)
+        {
+            return 0.0;
+        }
+
+        var guess = x >= 1.0 ? x : 1.0;
+        for (var i = 0; i < 60; i++)
+        {
+            var next = (guess + x / guess) / 2.0;
+            if (Math.Abs(next - guess) < 1e-15 * guess + 1e-300)
+            {
+                return next;
+            }
+
+            guess = next;
+        }
+
+        return guess;
+    }
+
+    /// <summary>
+    /// Compute tangent as the ratio of sine to cosine.
+    /// </summary>
+    public static double Tan(double x)
+    {
+        var sine = Sin(x);
+        var cosine = Cos(x);
+        if (Math.Abs(cosine) < 1e-15)
+        {
+            return sine > 0.0 ? 1.0e308 : -1.0e308;
+        }
+
+        return sine / cosine;
+    }
+
+    private static double AtanCore(double x)
+    {
+        // Half-angle reduction shrinks the series input so the alternating
+        // arctangent series converges quickly.
+        var reduced = x / (1.0 + Sqrt(1.0 + x * x));
+        var squared = reduced * reduced;
+        var term = reduced;
+        var result = reduced;
+
+        for (var n = 1; n <= 30; n++)
+        {
+            term = term * (-squared) * (2.0 * n - 1.0) / (2.0 * n + 1.0);
+            result += term;
+
+            if (Math.Abs(term) < 1e-17)
+            {
+                break;
+            }
+        }
+
+        return 2.0 * result;
+    }
+
+    /// <summary>
+    /// Compute arctangent with range reduction for large magnitudes.
+    /// </summary>
+    public static double Atan(double x)
+    {
+        if (x == 0.0)
+        {
+            return 0.0;
+        }
+
+        if (x > 1.0)
+        {
+            return HalfPi - AtanCore(1.0 / x);
+        }
+
+        if (x < -1.0)
+        {
+            return -HalfPi - AtanCore(1.0 / x);
+        }
+
+        return AtanCore(x);
+    }
+
+    /// <summary>
+    /// Compute the four-quadrant arctangent in the range (-pi, pi].
+    /// </summary>
+    public static double Atan2(double y, double x)
+    {
+        if (x > 0.0)
+        {
+            return Atan(y / x);
+        }
+
+        if (x < 0.0 && y >= 0.0)
+        {
+            return Atan(y / x) + PI;
+        }
+
+        if (x < 0.0 && y < 0.0)
+        {
+            return Atan(y / x) - PI;
+        }
+
+        if (x == 0.0 && y > 0.0)
+        {
+            return HalfPi;
+        }
+
+        if (x == 0.0 && y < 0.0)
+        {
+            return -HalfPi;
+        }
+
+        return 0.0;
+    }
+}

--- a/code/packages/csharp/trig/required_capabilities.json
+++ b/code/packages/csharp/trig/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/trig",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/trig/tests/CodingAdventures.Trig.Tests/CodingAdventures.Trig.Tests.csproj
+++ b/code/packages/csharp/trig/tests/CodingAdventures.Trig.Tests/CodingAdventures.Trig.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Trig.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/trig/tests/CodingAdventures.Trig.Tests/TrigTests.cs
+++ b/code/packages/csharp/trig/tests/CodingAdventures.Trig.Tests/TrigTests.cs
@@ -1,0 +1,120 @@
+namespace CodingAdventures.Trig.Tests;
+
+public sealed class TrigTests
+{
+    private static bool ApproxEqual(double left, double right, double tolerance = 1e-10) =>
+        Math.Abs(left - right) < tolerance;
+
+    [Fact]
+    public void SinMatchesKnownPoints()
+    {
+        Assert.True(ApproxEqual(Trig.Sin(0.0), 0.0));
+        Assert.True(ApproxEqual(Trig.Sin(Trig.PI / 2.0), 1.0));
+        Assert.True(ApproxEqual(Trig.Sin(Trig.PI), 0.0));
+        Assert.True(ApproxEqual(Trig.Sin(3.0 * Trig.PI / 2.0), -1.0));
+    }
+
+    [Fact]
+    public void CosMatchesKnownPoints()
+    {
+        Assert.True(ApproxEqual(Trig.Cos(0.0), 1.0));
+        Assert.True(ApproxEqual(Trig.Cos(Trig.PI / 2.0), 0.0));
+        Assert.True(ApproxEqual(Trig.Cos(Trig.PI), -1.0));
+    }
+
+    [Fact]
+    public void SinAndCosRespectOddEvenSymmetry()
+    {
+        var values = new[] { 0.5, 1.0, 2.0, Trig.PI / 4.0, Trig.PI / 3.0 };
+        foreach (var value in values)
+        {
+            Assert.True(ApproxEqual(Trig.Sin(-value), -Trig.Sin(value)));
+            Assert.True(ApproxEqual(Trig.Cos(-value), Trig.Cos(value)));
+        }
+    }
+
+    [Fact]
+    public void PythagoreanIdentityHolds()
+    {
+        var values = new[] { 0.0, 0.5, 1.0, Trig.PI / 6.0, Trig.PI / 4.0, Trig.PI / 3.0, Trig.PI / 2.0, Trig.PI, 2.5, 5.0 };
+        foreach (var value in values)
+        {
+            var sine = Trig.Sin(value);
+            var cosine = Trig.Cos(value);
+            Assert.True(ApproxEqual(sine * sine + cosine * cosine, 1.0));
+        }
+    }
+
+    [Fact]
+    public void RangeReductionKeepsLargeInputsAccurate()
+    {
+        Assert.True(ApproxEqual(Trig.Sin(1000.0 * Trig.PI), 0.0));
+        Assert.True(ApproxEqual(Trig.Cos(500.0 * 2.0 * Trig.PI), 1.0));
+    }
+
+    [Fact]
+    public void AngleConversionsRoundTrip()
+    {
+        Assert.True(ApproxEqual(Trig.Radians(180.0), Trig.PI));
+        Assert.True(ApproxEqual(Trig.Radians(90.0), Trig.PI / 2.0));
+        Assert.True(ApproxEqual(Trig.Degrees(Trig.PI), 180.0));
+        Assert.True(ApproxEqual(Trig.Degrees(Trig.PI / 2.0), 90.0));
+
+        foreach (var degrees in new[] { 0.0, 45.0, 90.0, 180.0, 270.0, 360.0 })
+        {
+            Assert.True(ApproxEqual(Trig.Degrees(Trig.Radians(degrees)), degrees));
+        }
+    }
+
+    [Fact]
+    public void SqrtMatchesKnownValues()
+    {
+        Assert.Equal(0.0, Trig.Sqrt(0.0));
+        Assert.True(ApproxEqual(Trig.Sqrt(1.0), 1.0));
+        Assert.True(ApproxEqual(Trig.Sqrt(4.0), 2.0));
+        Assert.True(ApproxEqual(Trig.Sqrt(9.0), 3.0));
+        Assert.True(ApproxEqual(Trig.Sqrt(2.0), 1.41421356237));
+        Assert.True(ApproxEqual(Trig.Sqrt(0.25), 0.5));
+        Assert.True(Math.Abs(Trig.Sqrt(1e10) - 1e5) < 1e-4);
+    }
+
+    [Fact]
+    public void SqrtRejectsNegativeInputs()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => Trig.Sqrt(-1.0));
+    }
+
+    [Fact]
+    public void TanMatchesKnownValues()
+    {
+        Assert.True(ApproxEqual(Trig.Tan(0.0), 0.0));
+        Assert.True(ApproxEqual(Trig.Tan(Trig.PI / 4.0), 1.0));
+        Assert.True(ApproxEqual(Trig.Tan(Trig.PI / 6.0), 1.0 / Trig.Sqrt(3.0)));
+        Assert.True(ApproxEqual(Trig.Tan(-Trig.PI / 4.0), -1.0));
+    }
+
+    [Fact]
+    public void AtanMatchesKnownValues()
+    {
+        Assert.Equal(0.0, Trig.Atan(0.0));
+        Assert.True(ApproxEqual(Trig.Atan(1.0), Trig.PI / 4.0));
+        Assert.True(ApproxEqual(Trig.Atan(-1.0), -Trig.PI / 4.0));
+        Assert.True(ApproxEqual(Trig.Atan(Trig.Sqrt(3.0)), Trig.PI / 3.0));
+        Assert.True(ApproxEqual(Trig.Atan(1.0 / Trig.Sqrt(3.0)), Trig.PI / 6.0));
+        Assert.True(Math.Abs(Trig.Atan(1e10) - Trig.PI / 2.0) < 1e-5);
+        Assert.True(Math.Abs(Trig.Atan(-1e10) + Trig.PI / 2.0) < 1e-5);
+    }
+
+    [Fact]
+    public void Atan2HandlesAxesAndQuadrants()
+    {
+        Assert.True(ApproxEqual(Trig.Atan2(0.0, 1.0), 0.0));
+        Assert.True(ApproxEqual(Trig.Atan2(1.0, 0.0), Trig.PI / 2.0));
+        Assert.True(ApproxEqual(Trig.Atan2(0.0, -1.0), Trig.PI));
+        Assert.True(ApproxEqual(Trig.Atan2(-1.0, 0.0), -Trig.PI / 2.0));
+        Assert.True(ApproxEqual(Trig.Atan2(1.0, 1.0), Trig.PI / 4.0));
+        Assert.True(ApproxEqual(Trig.Atan2(1.0, -1.0), 3.0 * Trig.PI / 4.0));
+        Assert.True(ApproxEqual(Trig.Atan2(-1.0, -1.0), -3.0 * Trig.PI / 4.0));
+        Assert.True(ApproxEqual(Trig.Atan2(-1.0, 1.0), -Trig.PI / 4.0));
+    }
+}

--- a/code/packages/fsharp/atbash-cipher/AtbashCipher.fs
+++ b/code/packages/fsharp/atbash-cipher/AtbashCipher.fs
@@ -1,0 +1,30 @@
+namespace CodingAdventures.AtbashCipher
+
+open System
+
+/// Fixed reverse-alphabet substitution cipher.
+[<RequireQualifiedAccess>]
+module AtbashCipher =
+    let private transform (ch: char) =
+        if ch >= 'A' && ch <= 'Z' then
+            let position = int ch - int 'A'
+            char (int 'A' + (25 - position))
+        elif ch >= 'a' && ch <= 'z' then
+            let position = int ch - int 'a'
+            char (int 'a' + (25 - position))
+        else
+            ch
+
+    let encrypt (text: string) =
+        if isNull text then
+            nullArg (nameof text)
+
+        text.ToCharArray()
+        |> Array.map transform
+        |> fun chars -> new string(chars)
+
+    let decrypt (text: string) =
+        if isNull text then
+            nullArg (nameof text)
+
+        encrypt text

--- a/code/packages/fsharp/atbash-cipher/BUILD
+++ b/code/packages/fsharp/atbash-cipher/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.AtbashCipher.Tests/CodingAdventures.AtbashCipher.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/atbash-cipher/BUILD_windows
+++ b/code/packages/fsharp/atbash-cipher/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.AtbashCipher.Tests/CodingAdventures.AtbashCipher.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/atbash-cipher/CHANGELOG.md
+++ b/code/packages/fsharp/atbash-cipher/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-15
+
+### Added
+
+- Self-inverse Atbash cipher implementation with case preservation and
+  non-alphabetic passthrough
+- Tests for classic examples, alphabet reversal, and involution behavior

--- a/code/packages/fsharp/atbash-cipher/CodingAdventures.AtbashCipher.fsproj
+++ b/code/packages/fsharp/atbash-cipher/CodingAdventures.AtbashCipher.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.AtbashCipher.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Fixed reverse-alphabet substitution cipher</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="AtbashCipher.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/atbash-cipher/README.md
+++ b/code/packages/fsharp/atbash-cipher/README.md
@@ -1,0 +1,27 @@
+# atbash-cipher
+
+F# implementation of the `atbash-cipher` foundation package.
+
+Atbash is the simplest possible fixed substitution cipher: it mirrors the
+alphabet so A becomes Z, B becomes Y, and so on. Because that mapping is an
+involution, the same code path handles both encryption and decryption.
+
+## API
+
+- `AtbashCipher.encrypt text`
+- `AtbashCipher.decrypt text`
+
+## Usage
+
+```fsharp
+open CodingAdventures.AtbashCipher
+
+let ciphertext = AtbashCipher.encrypt "HELLO"
+let plaintext = AtbashCipher.decrypt ciphertext
+```
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/fsharp/atbash-cipher/required_capabilities.json
+++ b/code/packages/fsharp/atbash-cipher/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/atbash-cipher",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/atbash-cipher/tests/CodingAdventures.AtbashCipher.Tests/AtbashCipherTests.fs
+++ b/code/packages/fsharp/atbash-cipher/tests/CodingAdventures.AtbashCipher.Tests/AtbashCipherTests.fs
@@ -1,0 +1,49 @@
+namespace CodingAdventures.AtbashCipher.Tests
+
+open Xunit
+open CodingAdventures.AtbashCipher
+
+type AtbashCipherTests() =
+    [<Fact>]
+    member _.``Encrypt matches classic examples``() =
+        Assert.Equal("SVOOL", AtbashCipher.encrypt "HELLO")
+        Assert.Equal("svool", AtbashCipher.encrypt "hello")
+        Assert.Equal("Svool, Dliow! 123", AtbashCipher.encrypt "Hello, World! 123")
+
+    [<Fact>]
+    member _.``Encrypt preserves case and passthrough characters``() =
+        Assert.Equal("ZYX", AtbashCipher.encrypt "ABC")
+        Assert.Equal("zyx", AtbashCipher.encrypt "abc")
+        Assert.Equal("ZyXwVu", AtbashCipher.encrypt "AbCdEf")
+        Assert.Equal("12345", AtbashCipher.encrypt "12345")
+        Assert.Equal("!@#$%", AtbashCipher.encrypt "!@#$%")
+        Assert.Equal("Z\nY\tX", AtbashCipher.encrypt "A\nB\tC")
+
+    [<Fact>]
+    member _.``Encrypt transforms the full alphabet``() =
+        Assert.Equal("ZYXWVUTSRQPONMLKJIHGFEDCBA", AtbashCipher.encrypt "ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+        Assert.Equal("zyxwvutsrqponmlkjihgfedcba", AtbashCipher.encrypt "abcdefghijklmnopqrstuvwxyz")
+
+    [<Fact>]
+    member _.``Cipher is self inverse``() =
+        let text = "The quick brown fox jumps over the lazy dog! 42"
+        Assert.Equal(text, AtbashCipher.encrypt (AtbashCipher.encrypt text))
+        Assert.Equal(text, AtbashCipher.decrypt (AtbashCipher.encrypt text))
+        Assert.Equal(AtbashCipher.encrypt text, AtbashCipher.decrypt text)
+
+    [<Fact>]
+    member _.``Edge cases remain stable``() =
+        Assert.Equal("", AtbashCipher.encrypt "")
+        Assert.Equal("5", AtbashCipher.encrypt "5")
+        Assert.Equal("Z", AtbashCipher.encrypt "A")
+        Assert.Equal("A", AtbashCipher.encrypt "Z")
+        Assert.Equal("N", AtbashCipher.encrypt "M")
+        Assert.Equal("M", AtbashCipher.encrypt "N")
+
+    [<Fact>]
+    member _.``No letter maps to itself``() =
+        for offset in 0 .. 25 do
+            let upper = string (char (int 'A' + offset))
+            let lower = string (char (int 'a' + offset))
+            Assert.NotEqual<string>(upper, AtbashCipher.encrypt upper)
+            Assert.NotEqual<string>(lower, AtbashCipher.encrypt lower)

--- a/code/packages/fsharp/atbash-cipher/tests/CodingAdventures.AtbashCipher.Tests/CodingAdventures.AtbashCipher.Tests.fsproj
+++ b/code/packages/fsharp/atbash-cipher/tests/CodingAdventures.AtbashCipher.Tests/CodingAdventures.AtbashCipher.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.AtbashCipher.fsproj" />
+    <Compile Include="AtbashCipherTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/caesar-cipher/BUILD
+++ b/code/packages/fsharp/caesar-cipher/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.CaesarCipher.Tests/CodingAdventures.CaesarCipher.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/caesar-cipher/BUILD_windows
+++ b/code/packages/fsharp/caesar-cipher/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.CaesarCipher.Tests/CodingAdventures.CaesarCipher.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/caesar-cipher/CHANGELOG.md
+++ b/code/packages/fsharp/caesar-cipher/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-15
+
+### Added
+
+- Caesar cipher implementation with wraparound shifts, ROT13, and case
+  preservation
+- Brute-force helpers and chi-squared English-frequency analysis
+- Unit tests covering round-trips, statistical attack behavior, and frequency
+  table invariants

--- a/code/packages/fsharp/caesar-cipher/CaesarCipher.fs
+++ b/code/packages/fsharp/caesar-cipher/CaesarCipher.fs
@@ -1,0 +1,106 @@
+namespace CodingAdventures.CaesarCipher
+
+open System
+
+type BruteForceResult = {
+    Shift: int
+    Plaintext: string
+}
+
+/// Caesar cipher helpers and the simplest statistical attack against them.
+[<RequireQualifiedAccess>]
+module CaesarCipher =
+    let englishFrequencies =
+        [|
+            0.08167; 0.01492; 0.02782; 0.04253; 0.12702; 0.02228; 0.02015
+            0.06094; 0.06966; 0.00153; 0.00772; 0.04025; 0.02406; 0.06749
+            0.07507; 0.01929; 0.00095; 0.05987; 0.06327; 0.09056; 0.02758
+            0.00978; 0.02360; 0.00150; 0.01974; 0.00074
+        |]
+
+    let private normalizeShift shift = ((shift % 26) + 26) % 26
+
+    let private shiftChar normalizedShift (ch: char) =
+        if ch >= 'A' && ch <= 'Z' then
+            let position = int ch - int 'A'
+            char (int 'A' + (position + normalizedShift) % 26)
+        elif ch >= 'a' && ch <= 'z' then
+            let position = int ch - int 'a'
+            char (int 'a' + (position + normalizedShift) % 26)
+        else
+            ch
+
+    let encrypt (text: string) (shift: int) =
+        if isNull text then
+            nullArg (nameof text)
+
+        let normalizedShift = normalizeShift shift
+
+        text.ToCharArray()
+        |> Array.map (shiftChar normalizedShift)
+        |> fun chars -> new string(chars)
+
+    let decrypt (text: string) (shift: int) =
+        if isNull text then
+            nullArg (nameof text)
+
+        encrypt text (-shift)
+
+    let rot13 (text: string) =
+        if isNull text then
+            nullArg (nameof text)
+
+        encrypt text 13
+
+    let bruteForce (ciphertext: string) =
+        if isNull ciphertext then
+            nullArg (nameof ciphertext)
+
+        [ for shift in 1 .. 25 ->
+            { Shift = shift; Plaintext = decrypt ciphertext shift } ]
+
+    let private letterCounts (text: string) =
+        let counts = Array.zeroCreate<int> 26
+
+        for ch in text do
+            if Char.IsAsciiLetter(ch) then
+                let index = int (Char.ToUpperInvariant(ch)) - int 'A'
+                counts[index] <- counts[index] + 1
+
+        counts
+
+    let private chiSquared (text: string) =
+        let counts = letterCounts text
+        let total = Array.sum counts
+
+        if total = 0 then
+            Double.MaxValue
+        else
+            let totalAsFloat = float total
+            let mutable sum = 0.0
+
+            for i in 0 .. 25 do
+                let expected = totalAsFloat * englishFrequencies[i]
+                let difference = float counts[i] - expected
+                sum <- sum + difference * difference / expected
+
+            sum
+
+    let frequencyAnalysis (ciphertext: string) =
+        if isNull ciphertext then
+            nullArg (nameof ciphertext)
+
+        let mutable bestShift = 1
+        let mutable bestPlaintext = decrypt ciphertext 1
+        let mutable bestScore = chiSquared bestPlaintext
+
+        for shift in 2 .. 25 do
+            let candidate = decrypt ciphertext shift
+            let score = chiSquared candidate
+
+            if score < bestScore then
+                bestShift <- shift
+                bestPlaintext <- candidate
+                bestScore <- score
+
+        bestShift, bestPlaintext

--- a/code/packages/fsharp/caesar-cipher/CodingAdventures.CaesarCipher.fsproj
+++ b/code/packages/fsharp/caesar-cipher/CodingAdventures.CaesarCipher.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.CaesarCipher.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Caesar cipher with brute-force and frequency-analysis helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="CaesarCipher.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/caesar-cipher/README.md
+++ b/code/packages/fsharp/caesar-cipher/README.md
@@ -1,0 +1,33 @@
+# caesar-cipher
+
+F# implementation of the `caesar-cipher` foundation package.
+
+This package pairs the classical Caesar cipher with the two attacks that make
+it a good teaching cipher: exhaustive brute force and English-frequency
+analysis.
+
+## API
+
+- `CaesarCipher.encrypt text shift`
+- `CaesarCipher.decrypt text shift`
+- `CaesarCipher.rot13 text`
+- `CaesarCipher.bruteForce ciphertext`
+- `CaesarCipher.frequencyAnalysis ciphertext`
+- `CaesarCipher.englishFrequencies`
+
+## Usage
+
+```fsharp
+open CodingAdventures.CaesarCipher
+
+let ciphertext = CaesarCipher.encrypt "Hello, World!" 3
+let plaintext = CaesarCipher.decrypt ciphertext 3
+let guesses = CaesarCipher.bruteForce ciphertext
+let shift, decoded = CaesarCipher.frequencyAnalysis ciphertext
+```
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/fsharp/caesar-cipher/required_capabilities.json
+++ b/code/packages/fsharp/caesar-cipher/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/caesar-cipher",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/caesar-cipher/tests/CodingAdventures.CaesarCipher.Tests/CaesarCipherTests.fs
+++ b/code/packages/fsharp/caesar-cipher/tests/CodingAdventures.CaesarCipher.Tests/CaesarCipherTests.fs
@@ -1,0 +1,107 @@
+namespace CodingAdventures.CaesarCipher.Tests
+
+open Xunit
+open CodingAdventures.CaesarCipher
+
+type CaesarCipherTests() =
+    [<Fact>]
+    member _.``Encrypt and decrypt handle known examples``() =
+        Assert.Equal("KHOOR", CaesarCipher.encrypt "HELLO" 3)
+        Assert.Equal("khoor", CaesarCipher.encrypt "hello" 3)
+        Assert.Equal("Khoor, Zruog!", CaesarCipher.encrypt "Hello, World!" 3)
+        Assert.Equal("HELLO", CaesarCipher.decrypt "KHOOR" 3)
+        Assert.Equal("Hello, World!", CaesarCipher.decrypt "Khoor, Zruog!" 3)
+
+    [<Fact>]
+    member _.``Encrypt respects wrapping and negative shifts``() =
+        Assert.Equal("abc XYZ 123!", CaesarCipher.encrypt "abc XYZ 123!" 0)
+        Assert.Equal("Wrap around test", CaesarCipher.encrypt "Wrap around test" 26)
+        Assert.Equal("Double wrap", CaesarCipher.encrypt "Double wrap" 52)
+        Assert.Equal("ZAB", CaesarCipher.encrypt "ABC" -1)
+        Assert.Equal("ZAB", CaesarCipher.encrypt "ABC" -27)
+        Assert.Equal("ABC", CaesarCipher.encrypt "XYZ" 3)
+
+    [<Fact>]
+    member _.``Round trips across many shifts``() =
+        let original = "The Quick Brown Fox Jumps Over The Lazy Dog! 123"
+
+        for shift in -30 .. 30 do
+            let encrypted = CaesarCipher.encrypt original shift
+            let decrypted = CaesarCipher.decrypt encrypted shift
+            Assert.Equal(original, decrypted)
+
+    [<Fact>]
+    member _.``Rot13 is self inverse``() =
+        let text = "The Quick Brown Fox! 123"
+        Assert.Equal(text, CaesarCipher.rot13 (CaesarCipher.rot13 text))
+        Assert.Equal(CaesarCipher.encrypt text 13, CaesarCipher.rot13 text)
+
+    [<Fact>]
+    member _.``Non ASCII characters pass through``() =
+        let original = "Cafe\u0301 costs $3.50 \u2764"
+        let encrypted = CaesarCipher.encrypt original 7
+        let decrypted = CaesarCipher.decrypt encrypted 7
+        Assert.Equal(original, decrypted)
+
+    [<Fact>]
+    member _.``Brute force returns every candidate``() =
+        let results = CaesarCipher.bruteForce "KHOOR"
+        Assert.Equal(25, List.length results)
+        Assert.Equal(3, results[2].Shift)
+        Assert.Equal("HELLO", results[2].Plaintext)
+
+        for result in results do
+            Assert.InRange(result.Shift, 1, 25)
+
+    [<Fact>]
+    member _.``Brute force handles empty and punctuation only input``() =
+        let emptyResults = CaesarCipher.bruteForce ""
+        Assert.Equal(25, List.length emptyResults)
+
+        for result in emptyResults do
+            Assert.Equal("", result.Plaintext)
+
+        let punctuationResults = CaesarCipher.bruteForce "123!!!"
+        for result in punctuationResults do
+            Assert.Equal("123!!!", result.Plaintext)
+
+    [<Fact>]
+    member _.``Frequency analysis finds known shifts``() =
+        let plaintext1 = "THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG"
+        let ciphertext1 = CaesarCipher.encrypt plaintext1 3
+        let shift1, decoded1 = CaesarCipher.frequencyAnalysis ciphertext1
+        Assert.Equal(3, shift1)
+        Assert.Equal(plaintext1, decoded1)
+
+        let plaintext2 =
+            "IN CRYPTOGRAPHY A CAESAR CIPHER ALSO KNOWN AS SHIFT CIPHER IS ONE OF THE SIMPLEST AND MOST WIDELY KNOWN ENCRYPTION TECHNIQUES"
+
+        let ciphertext2 = CaesarCipher.encrypt plaintext2 17
+        let shift2, decoded2 = CaesarCipher.frequencyAnalysis ciphertext2
+        Assert.Equal(17, shift2)
+        Assert.Equal(plaintext2, decoded2)
+
+    [<Fact>]
+    member _.``Frequency analysis handles low signal inputs``() =
+        let shift1, decoded1 = CaesarCipher.frequencyAnalysis ""
+        Assert.InRange(shift1, 1, 25)
+        Assert.Equal("", decoded1)
+
+        let shift2, decoded2 = CaesarCipher.frequencyAnalysis "12345!@#$%"
+        Assert.Equal(1, shift2)
+        Assert.Equal("12345!@#$%", decoded2)
+
+        let shift3, _ = CaesarCipher.frequencyAnalysis "EEEEEEEEEEE"
+        Assert.InRange(shift3, 1, 25)
+
+    [<Fact>]
+    member _.``English frequencies match expectations``() =
+        Assert.Equal(26, CaesarCipher.englishFrequencies.Length)
+        Assert.InRange(Array.sum CaesarCipher.englishFrequencies, 0.99, 1.01)
+
+        let eFrequency = CaesarCipher.englishFrequencies[4]
+
+        for i in 0 .. CaesarCipher.englishFrequencies.Length - 1 do
+            Assert.True(CaesarCipher.englishFrequencies[i] > 0.0)
+            if i <> 4 then
+                Assert.True(eFrequency > CaesarCipher.englishFrequencies[i])

--- a/code/packages/fsharp/caesar-cipher/tests/CodingAdventures.CaesarCipher.Tests/CodingAdventures.CaesarCipher.Tests.fsproj
+++ b/code/packages/fsharp/caesar-cipher/tests/CodingAdventures.CaesarCipher.Tests/CodingAdventures.CaesarCipher.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.CaesarCipher.fsproj" />
+    <Compile Include="CaesarCipherTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/trig/BUILD
+++ b/code/packages/fsharp/trig/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Trig.Tests/CodingAdventures.Trig.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/trig/BUILD_windows
+++ b/code/packages/fsharp/trig/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Trig.Tests/CodingAdventures.Trig.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/trig/CHANGELOG.md
+++ b/code/packages/fsharp/trig/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-15
+
+### Added
+
+- First-principles `Trig` module implementing `sin`, `cos`, `tan`, `sqrt`,
+  `atan`, `atan2`, `radians`, and `degrees`
+- Literate comments covering Maclaurin series, range reduction, and Newton's
+  method
+- Test coverage for standard identities, large inputs, and quadrant handling

--- a/code/packages/fsharp/trig/CodingAdventures.Trig.fsproj
+++ b/code/packages/fsharp/trig/CodingAdventures.Trig.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Trig.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Trigonometric functions from first principles using Taylor series</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Trig.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/trig/README.md
+++ b/code/packages/fsharp/trig/README.md
@@ -1,0 +1,36 @@
+# trig
+
+F# implementation of the `trig` foundation package.
+
+This package computes trigonometric functions from arithmetic building blocks
+instead of delegating to opaque runtime helpers. It is meant to be a leaf
+package for future geometry and physics work in the F# package tree.
+
+## API
+
+- `Trig.PI`
+- `Trig.sin x`
+- `Trig.cos x`
+- `Trig.tan x`
+- `Trig.sqrt x`
+- `Trig.atan x`
+- `Trig.atan2 y x`
+- `Trig.radians deg`
+- `Trig.degrees rad`
+
+## Usage
+
+```fsharp
+open CodingAdventures.Trig
+
+let theta = Trig.radians 45.0
+let sine = Trig.sin theta
+let cosine = Trig.cos theta
+let tangent = Trig.tan theta
+```
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/fsharp/trig/Trig.fs
+++ b/code/packages/fsharp/trig/Trig.fs
@@ -1,0 +1,123 @@
+namespace CodingAdventures.Trig
+
+open System
+
+/// Trigonometric functions from first principles.
+///
+/// We deliberately build these operations from arithmetic and iterative
+/// algorithms so the source teaches how a runtime approximates transcendental
+/// functions under the hood.
+[<RequireQualifiedAccess>]
+module Trig =
+    [<Literal>]
+    let PI = 3.141592653589793
+
+    let private twoPi = 2.0 * PI
+    let private halfPi = PI / 2.0
+
+    let private rangeReduce (x: float) =
+        let mutable reduced = x % twoPi
+        if reduced > PI then
+            reduced <- reduced - twoPi
+
+        if reduced < -PI then
+            reduced <- reduced + twoPi
+
+        reduced
+
+    let sin (x: float) =
+        let reduced = rangeReduce x
+        let squared = reduced * reduced
+        let mutable term = reduced
+        let mutable sum = term
+
+        for k in 1 .. 19 do
+            let denominator = float (2 * k) * float (2 * k + 1)
+            term <- term * (-squared) / denominator
+            sum <- sum + term
+
+        sum
+
+    let cos (x: float) =
+        let reduced = rangeReduce x
+        let squared = reduced * reduced
+        let mutable term = 1.0
+        let mutable sum = term
+
+        for k in 1 .. 19 do
+            let denominator = float (2 * k - 1) * float (2 * k)
+            term <- term * (-squared) / denominator
+            sum <- sum + term
+
+        sum
+
+    let radians (degrees: float) = degrees * (PI / 180.0)
+
+    let degrees (radians: float) = radians * (180.0 / PI)
+
+    let sqrt (x: float) =
+        if x < 0.0 then
+            raise (ArgumentOutOfRangeException("x", x, "sqrt: domain error -- input is negative"))
+
+        elif x = 0.0 then
+            0.0
+
+        else
+            let mutable guess = if x >= 1.0 then x else 1.0
+
+            for _ in 0 .. 59 do
+                let next = (guess + x / guess) / 2.0
+                if abs (next - guess) < 1e-15 * guess + 1e-300 then
+                    guess <- next
+                else
+                    guess <- next
+
+            guess
+
+    let tan (x: float) =
+        let sine = sin x
+        let cosine = cos x
+
+        if abs cosine < 1e-15 then
+            if sine > 0.0 then 1.0e308 else -1.0e308
+        else
+            sine / cosine
+
+    let private atanCore (x: float) =
+        let reduced = x / (1.0 + sqrt (1.0 + x * x))
+        let squared = reduced * reduced
+        let mutable term = reduced
+        let mutable result = reduced
+
+        for n in 1 .. 30 do
+            term <- term * (-squared) * float (2 * n - 1) / float (2 * n + 1)
+            result <- result + term
+
+            if abs term < 1e-17 then
+                ()
+
+        2.0 * result
+
+    let atan (x: float) =
+        if x = 0.0 then
+            0.0
+        elif x > 1.0 then
+            halfPi - atanCore (1.0 / x)
+        elif x < -1.0 then
+            -halfPi - atanCore (1.0 / x)
+        else
+            atanCore x
+
+    let atan2 (y: float) (x: float) =
+        if x > 0.0 then
+            atan (y / x)
+        elif x < 0.0 && y >= 0.0 then
+            atan (y / x) + PI
+        elif x < 0.0 && y < 0.0 then
+            atan (y / x) - PI
+        elif x = 0.0 && y > 0.0 then
+            halfPi
+        elif x = 0.0 && y < 0.0 then
+            -halfPi
+        else
+            0.0

--- a/code/packages/fsharp/trig/required_capabilities.json
+++ b/code/packages/fsharp/trig/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/trig",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/trig/tests/CodingAdventures.Trig.Tests/CodingAdventures.Trig.Tests.fsproj
+++ b/code/packages/fsharp/trig/tests/CodingAdventures.Trig.Tests/CodingAdventures.Trig.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Trig.fsproj" />
+    <Compile Include="TrigTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/trig/tests/CodingAdventures.Trig.Tests/TrigTests.fs
+++ b/code/packages/fsharp/trig/tests/CodingAdventures.Trig.Tests/TrigTests.fs
@@ -1,0 +1,82 @@
+namespace CodingAdventures.Trig.Tests
+
+open Xunit
+open CodingAdventures.Trig
+
+type TrigTests() =
+    [<Fact>]
+    member _.``Sin and cos match canonical values``() =
+        let approxEqual left right = abs (left - right) < 1e-10
+
+        Assert.True(approxEqual (Trig.sin 0.0) 0.0)
+        Assert.True(approxEqual (Trig.sin (Trig.PI / 2.0)) 1.0)
+        Assert.True(approxEqual (Trig.sin Trig.PI) 0.0)
+        Assert.True(approxEqual (Trig.cos 0.0) 1.0)
+        Assert.True(approxEqual (Trig.cos (Trig.PI / 2.0)) 0.0)
+        Assert.True(approxEqual (Trig.cos Trig.PI) -1.0)
+
+    [<Fact>]
+    member _.``Symmetry and Pythagorean identities hold``() =
+        let approxEqual left right = abs (left - right) < 1e-10
+
+        for value in [| 0.5; 1.0; 2.0; Trig.PI / 4.0; Trig.PI / 3.0 |] do
+            Assert.True(approxEqual (Trig.sin (-value)) (-Trig.sin value))
+            Assert.True(approxEqual (Trig.cos (-value)) (Trig.cos value))
+
+        for value in [| 0.0; 0.5; 1.0; Trig.PI / 6.0; Trig.PI / 4.0; Trig.PI / 3.0; Trig.PI / 2.0; Trig.PI; 2.5; 5.0 |] do
+            let sine = Trig.sin value
+            let cosine = Trig.cos value
+            Assert.True(approxEqual (sine * sine + cosine * cosine) 1.0)
+
+    [<Fact>]
+    member _.``Range reduction and angle conversions behave``() =
+        let approxEqual left right = abs (left - right) < 1e-10
+
+        Assert.True(approxEqual (Trig.sin (1000.0 * Trig.PI)) 0.0)
+        Assert.True(approxEqual (Trig.cos (500.0 * 2.0 * Trig.PI)) 1.0)
+        Assert.True(approxEqual (Trig.radians 180.0) Trig.PI)
+        Assert.True(approxEqual (Trig.radians 90.0) (Trig.PI / 2.0))
+        Assert.True(approxEqual (Trig.degrees Trig.PI) 180.0)
+        Assert.True(approxEqual (Trig.degrees (Trig.PI / 2.0)) 90.0)
+
+        for degrees in [| 0.0; 45.0; 90.0; 180.0; 270.0; 360.0 |] do
+            Assert.True(approxEqual (Trig.degrees (Trig.radians degrees)) degrees)
+
+    [<Fact>]
+    member _.``Square root matches reference values``() =
+        let approxEqual left right = abs (left - right) < 1e-10
+
+        Assert.Equal(0.0, Trig.sqrt 0.0)
+        Assert.True(approxEqual (Trig.sqrt 1.0) 1.0)
+        Assert.True(approxEqual (Trig.sqrt 4.0) 2.0)
+        Assert.True(approxEqual (Trig.sqrt 9.0) 3.0)
+        Assert.True(approxEqual (Trig.sqrt 2.0) 1.41421356237)
+        Assert.True(approxEqual (Trig.sqrt 0.25) 0.5)
+        Assert.True(abs (Trig.sqrt 1e10 - 1e5) < 1e-4)
+        Assert.Throws<System.ArgumentOutOfRangeException>(fun () -> Trig.sqrt -1.0 |> ignore) |> ignore
+
+    [<Fact>]
+    member _.``Tan atan and atan2 cover standard identities``() =
+        let approxEqual left right = abs (left - right) < 1e-10
+
+        Assert.True(approxEqual (Trig.tan 0.0) 0.0)
+        Assert.True(approxEqual (Trig.tan (Trig.PI / 4.0)) 1.0)
+        Assert.True(approxEqual (Trig.tan (Trig.PI / 6.0)) (1.0 / Trig.sqrt 3.0))
+        Assert.True(approxEqual (Trig.tan (-Trig.PI / 4.0)) -1.0)
+
+        Assert.Equal(0.0, Trig.atan 0.0)
+        Assert.True(approxEqual (Trig.atan 1.0) (Trig.PI / 4.0))
+        Assert.True(approxEqual (Trig.atan -1.0) (-Trig.PI / 4.0))
+        Assert.True(approxEqual (Trig.atan (Trig.sqrt 3.0)) (Trig.PI / 3.0))
+        Assert.True(approxEqual (Trig.atan (1.0 / Trig.sqrt 3.0)) (Trig.PI / 6.0))
+        Assert.True(abs (Trig.atan 1e10 - Trig.PI / 2.0) < 1e-5)
+        Assert.True(abs (Trig.atan -1e10 + Trig.PI / 2.0) < 1e-5)
+
+        Assert.True(approxEqual (Trig.atan2 0.0 1.0) 0.0)
+        Assert.True(approxEqual (Trig.atan2 1.0 0.0) (Trig.PI / 2.0))
+        Assert.True(approxEqual (Trig.atan2 0.0 -1.0) Trig.PI)
+        Assert.True(approxEqual (Trig.atan2 -1.0 0.0) (-Trig.PI / 2.0))
+        Assert.True(approxEqual (Trig.atan2 1.0 1.0) (Trig.PI / 4.0))
+        Assert.True(approxEqual (Trig.atan2 1.0 -1.0) (3.0 * Trig.PI / 4.0))
+        Assert.True(approxEqual (Trig.atan2 -1.0 -1.0) (-3.0 * Trig.PI / 4.0))
+        Assert.True(approxEqual (Trig.atan2 -1.0 1.0) (-Trig.PI / 4.0))


### PR DESCRIPTION
## Summary

This PR continues the C# and F# catch-up after #732 by adding the next low-dependency leaf packages from the Rust package tree.

## What changed

- added `trig` for C# and F# with first-principles implementations of `sin`, `cos`, `tan`, `sqrt`, `atan`, `atan2`, and angle conversion helpers
- added `caesar-cipher` for C# and F# with encryption, decryption, ROT13, brute-force helpers, and English-frequency analysis
- added `atbash-cipher` for C# and F# with self-inverse encryption/decryption helpers
- filled in package READMEs and changelogs for all six new packages
- aligned C# project files with the repo's nested-test exclusion pattern

## Why

After the graph / activation / loss-function work landed in #732, the next useful catch-up step is to keep building outward from dependency-light leaf packages. `trig` is a foundational math package that later geometry and physics work can depend on, while `caesar-cipher` and `atbash-cipher` expand the new .NET package trees with small, fully testable CR-series packages.

## Validation

Ran these package BUILD checks locally on the isolated follow-up branch using .NET SDK `9.0.313`:

- `code/packages/csharp/trig`
- `code/packages/fsharp/trig`
- `code/packages/csharp/caesar-cipher`
- `code/packages/fsharp/caesar-cipher`
- `code/packages/csharp/atbash-cipher`
- `code/packages/fsharp/atbash-cipher`

All six passed, including coverage thresholds.
