### PR TITLE
[codex] Add .NET bitset packages and native wrappers

### DIFF
--- a/code/packages/csharp/bitset-native/BUILD
+++ b/code/packages/csharp/bitset-native/BUILD
@@ -1,0 +1,2 @@
+cargo build --release --manifest-path ../../rust/bitset-c/Cargo.toml
+dotnet test tests/CodingAdventures.BitsetNative.Tests/CodingAdventures.BitsetNative.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/bitset-native/BUILD_windows
+++ b/code/packages/csharp/bitset-native/BUILD_windows
@@ -1,0 +1,2 @@
+cargo build --release --manifest-path ../../rust/bitset-c/Cargo.toml
+dotnet test tests/CodingAdventures.BitsetNative.Tests/CodingAdventures.BitsetNative.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/bitset-native/BitsetNative.cs
+++ b/code/packages/csharp/bitset-native/BitsetNative.cs
@@ -1,0 +1,480 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace CodingAdventures.BitsetNative;
+
+// BitsetNative.cs -- Managed .NET wrapper over the Rust bitset C ABI
+// ==================================================================
+//
+// .NET does have a native interop story: P/Invoke. The runtime can call a
+// stable C ABI exported from a shared library, so this package simply wraps the
+// Rust `bitset-c` shim in an API that mirrors the pure C# bitset package.
+//
+// The handle lifetime is the one thing the managed wrapper must own carefully.
+// Each Bitset instance is backed by an opaque native pointer allocated in Rust.
+// We release it via IDisposable/finalization and keep the public API otherwise
+// familiar: constructors, single-bit operations, bulk operations, queries, and
+// conversion helpers.
+
+/// <summary>
+/// Raised when the Rust native layer rejects an operation, such as parsing an
+/// invalid binary string.
+/// </summary>
+public sealed class BitsetError : Exception
+{
+    public BitsetError(string message)
+        : base(message)
+    {
+    }
+}
+
+/// <summary>
+/// A native-backed compact boolean array packed into 64-bit words.
+/// </summary>
+public sealed class Bitset : IEquatable<Bitset>, IEnumerable<int>, IDisposable
+{
+    private nint _handle;
+
+    /// <summary>
+    /// Create a zero-filled bitset with the requested logical length.
+    /// </summary>
+    public Bitset(int size)
+    {
+        if (size < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(size), "Bitset size cannot be negative.");
+        }
+
+        _handle = NativeMethods.bitset_c_new((ulong)size);
+        ThrowIfCreateFailed(_handle, "bitset_c_new");
+    }
+
+    private Bitset(nint handle)
+    {
+        _handle = handle;
+        ThrowIfCreateFailed(_handle, "native bitset operation");
+    }
+
+    /// <summary>
+    /// Logical size: the number of addressable bits.
+    /// </summary>
+    public int Length => CheckedInt(NativeMethods.bitset_c_len(Handle), nameof(Length));
+
+    /// <summary>
+    /// Allocated size rounded to a multiple of 64.
+    /// </summary>
+    public int Capacity => CheckedInt(NativeMethods.bitset_c_capacity(Handle), nameof(Capacity));
+
+    /// <summary>
+    /// Whether the bitset has zero logical length.
+    /// </summary>
+    public bool IsEmpty => NativeMethods.bitset_c_is_empty(Handle) != 0;
+
+    /// <summary>
+    /// Create a bitset from a non-negative integer using LSB-first ordering.
+    /// </summary>
+    public static Bitset FromInteger(UInt128 value)
+    {
+        var low = (ulong)value;
+        var high = (ulong)(value >> 64);
+        return CreateChecked(NativeMethods.bitset_c_from_u128(low, high), "bitset_c_from_u128");
+    }
+
+    /// <summary>
+    /// Create a bitset from a string whose leftmost character is the highest bit.
+    /// </summary>
+    public static Bitset FromBinaryString(string value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        return CreateChecked(NativeMethods.bitset_c_from_binary_str(value), "bitset_c_from_binary_str");
+    }
+
+    /// <summary>
+    /// Set a bit to 1, growing the bitset if needed.
+    /// </summary>
+    public void Set(int index)
+    {
+        ValidateIndex(index);
+        NativeMethods.bitset_c_set(Handle, (ulong)index);
+    }
+
+    /// <summary>
+    /// Set a bit to 0. Clearing beyond <see cref="Length"/> is a no-op.
+    /// </summary>
+    public void Clear(int index)
+    {
+        ValidateIndex(index);
+        NativeMethods.bitset_c_clear(Handle, (ulong)index);
+    }
+
+    /// <summary>
+    /// Return whether a bit is set. Testing beyond <see cref="Length"/> is false.
+    /// </summary>
+    public bool Test(int index)
+    {
+        ValidateIndex(index);
+        return NativeMethods.bitset_c_test(Handle, (ulong)index) != 0;
+    }
+
+    /// <summary>
+    /// Flip a bit, growing the bitset if needed.
+    /// </summary>
+    public void Toggle(int index)
+    {
+        ValidateIndex(index);
+        NativeMethods.bitset_c_toggle(Handle, (ulong)index);
+    }
+
+    /// <summary>
+    /// Bitwise AND. The result length is the longer input length.
+    /// </summary>
+    public Bitset And(Bitset other) => CreateChecked(NativeMethods.bitset_c_and(Handle, RequiredHandle(other)), "bitset_c_and");
+
+    /// <summary>
+    /// Bitwise OR. The result length is the longer input length.
+    /// </summary>
+    public Bitset Or(Bitset other) => CreateChecked(NativeMethods.bitset_c_or(Handle, RequiredHandle(other)), "bitset_c_or");
+
+    /// <summary>
+    /// Bitwise XOR. The result length is the longer input length.
+    /// </summary>
+    public Bitset Xor(Bitset other) => CreateChecked(NativeMethods.bitset_c_xor(Handle, RequiredHandle(other)), "bitset_c_xor");
+
+    /// <summary>
+    /// Bitwise complement within the logical length of the bitset.
+    /// </summary>
+    public Bitset Not() => CreateChecked(NativeMethods.bitset_c_not(Handle), "bitset_c_not");
+
+    /// <summary>
+    /// Set difference: keep bits set in this bitset that are not set in <paramref name="other"/>.
+    /// </summary>
+    public Bitset AndNot(Bitset other) => CreateChecked(NativeMethods.bitset_c_and_not(Handle, RequiredHandle(other)), "bitset_c_and_not");
+
+    /// <summary>
+    /// Count how many bits are set to 1.
+    /// </summary>
+    public int PopCount() => CheckedInt(NativeMethods.bitset_c_popcount(Handle), nameof(PopCount));
+
+    /// <summary>
+    /// Return whether at least one bit is set.
+    /// </summary>
+    public bool Any() => NativeMethods.bitset_c_any(Handle) != 0;
+
+    /// <summary>
+    /// Return whether all bits within <see cref="Length"/> are set.
+    /// </summary>
+    public bool All() => NativeMethods.bitset_c_all(Handle) != 0;
+
+    /// <summary>
+    /// Return whether no bits are set.
+    /// </summary>
+    public bool None() => NativeMethods.bitset_c_none(Handle) != 0;
+
+    /// <summary>
+    /// Convert to a 64-bit integer when the value fits in a single word.
+    /// </summary>
+    public ulong? ToInteger()
+    {
+        return NativeMethods.bitset_c_to_u64(Handle, out var value) != 0
+            ? value
+            : null;
+    }
+
+    /// <summary>
+    /// Convert to a conventional binary string with the highest bit on the left.
+    /// </summary>
+    public string ToBinaryString()
+    {
+        var length = Length;
+        if (length == 0)
+        {
+            return string.Empty;
+        }
+
+        var chars = new char[length];
+        for (var i = 0; i < length; i++)
+        {
+            chars[length - 1 - i] = Test(i) ? '1' : '0';
+        }
+
+        return new string(chars);
+    }
+
+    /// <summary>
+    /// Iterate over the indices of set bits in ascending order.
+    /// </summary>
+    public IEnumerable<int> IterSetBits()
+    {
+        var length = Length;
+        for (var i = 0; i < length; i++)
+        {
+            if (Test(i))
+            {
+                yield return i;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Convenience alias for <see cref="Test"/>.
+    /// </summary>
+    public bool Contains(int index) => Test(index);
+
+    /// <summary>
+    /// Release the native Rust handle.
+    /// </summary>
+    public void Dispose()
+    {
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Return a debug-friendly representation such as <c>Bitset(101)</c>.
+    /// </summary>
+    public override string ToString() => $"Bitset({ToBinaryString()})";
+
+    /// <summary>
+    /// Compare two bitsets by logical length and logical bits.
+    /// </summary>
+    public bool Equals(Bitset? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        return NativeMethods.bitset_c_equals(Handle, other.Handle) != 0;
+    }
+
+    /// <summary>
+    /// Compare this bitset to another object.
+    /// </summary>
+    public override bool Equals(object? obj) => obj is Bitset other && Equals(other);
+
+    /// <summary>
+    /// Compute a hash from the logical length and set-bit positions.
+    /// </summary>
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(Length);
+        foreach (var bit in this)
+        {
+            hash.Add(bit);
+        }
+
+        return hash.ToHashCode();
+    }
+
+    /// <summary>
+    /// Enumerate the indices of all set bits.
+    /// </summary>
+    public IEnumerator<int> GetEnumerator() => IterSetBits().GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    /// <summary>
+    /// Operator shorthand for <see cref="And"/>.
+    /// </summary>
+    public static Bitset operator &(Bitset left, Bitset right)
+    {
+        ArgumentNullException.ThrowIfNull(left);
+        return left.And(right);
+    }
+
+    /// <summary>
+    /// Operator shorthand for <see cref="Or"/>.
+    /// </summary>
+    public static Bitset operator |(Bitset left, Bitset right)
+    {
+        ArgumentNullException.ThrowIfNull(left);
+        return left.Or(right);
+    }
+
+    /// <summary>
+    /// Operator shorthand for <see cref="Xor"/>.
+    /// </summary>
+    public static Bitset operator ^(Bitset left, Bitset right)
+    {
+        ArgumentNullException.ThrowIfNull(left);
+        return left.Xor(right);
+    }
+
+    /// <summary>
+    /// Operator shorthand for <see cref="Not"/>.
+    /// </summary>
+    public static Bitset operator ~(Bitset value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        return value.Not();
+    }
+
+    /// <summary>
+    /// Equality operator based on logical length and logical bits.
+    /// </summary>
+    public static bool operator ==(Bitset? left, Bitset? right)
+    {
+        if (ReferenceEquals(left, right))
+        {
+            return true;
+        }
+
+        if (left is null || right is null)
+        {
+            return false;
+        }
+
+        return left.Equals(right);
+    }
+
+    /// <summary>
+    /// Inequality operator based on logical length and logical bits.
+    /// </summary>
+    public static bool operator !=(Bitset? left, Bitset? right) => !(left == right);
+
+    ~Bitset()
+    {
+        Dispose(disposing: false);
+    }
+
+    private nint Handle => _handle != 0
+        ? _handle
+        : throw new ObjectDisposedException(nameof(Bitset));
+
+    private static Bitset CreateChecked(nint handle, string operation)
+    {
+        ThrowIfCreateFailed(handle, operation);
+        return new Bitset(handle);
+    }
+
+    private static nint RequiredHandle(Bitset? bitset)
+    {
+        ArgumentNullException.ThrowIfNull(bitset);
+        return bitset.Handle;
+    }
+
+    private static void ThrowIfCreateFailed(nint handle, string operation)
+    {
+        if (handle == 0)
+        {
+            throw new BitsetError($"{operation} failed: {ReadLastErrorMessage()}");
+        }
+    }
+
+    private static string ReadLastErrorMessage()
+    {
+        var pointer = NativeMethods.bitset_c_last_error_message();
+        return pointer == 0
+            ? "bitset-c reported an unknown error."
+            : Marshal.PtrToStringUTF8(pointer) ?? "bitset-c reported an unreadable UTF-8 error message.";
+    }
+
+    private static void ValidateIndex(int index)
+    {
+        if (index < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(index), "Bit indices cannot be negative.");
+        }
+    }
+
+    private static int CheckedInt(ulong value, string operation)
+    {
+        if (value > int.MaxValue)
+        {
+            throw new OverflowException($"{operation} exceeded Int32.MaxValue.");
+        }
+
+        return (int)value;
+    }
+
+    private void Dispose(bool disposing)
+    {
+        if (_handle != 0)
+        {
+            NativeMethods.bitset_c_free(_handle);
+            _handle = 0;
+        }
+    }
+
+    private static class NativeMethods
+    {
+        private const string LibraryName = "bitset_c";
+
+        [DllImport(LibraryName, EntryPoint = "bitset_c_new", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern nint bitset_c_new(ulong size);
+
+        [DllImport(LibraryName, EntryPoint = "bitset_c_from_u128", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern nint bitset_c_from_u128(ulong low, ulong high);
+
+        [DllImport(LibraryName, EntryPoint = "bitset_c_from_binary_str", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern nint bitset_c_from_binary_str([MarshalAs(UnmanagedType.LPUTF8Str)] string binary);
+
+        [DllImport(LibraryName, EntryPoint = "bitset_c_free", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void bitset_c_free(nint handle);
+
+        [DllImport(LibraryName, EntryPoint = "bitset_c_set", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void bitset_c_set(nint handle, ulong index);
+
+        [DllImport(LibraryName, EntryPoint = "bitset_c_clear", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void bitset_c_clear(nint handle, ulong index);
+
+        [DllImport(LibraryName, EntryPoint = "bitset_c_test", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern byte bitset_c_test(nint handle, ulong index);
+
+        [DllImport(LibraryName, EntryPoint = "bitset_c_toggle", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void bitset_c_toggle(nint handle, ulong index);
+
+        [DllImport(LibraryName, EntryPoint = "bitset_c_and", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern nint bitset_c_and(nint left, nint right);
+
+        [DllImport(LibraryName, EntryPoint = "bitset_c_or", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern nint bitset_c_or(nint left, nint right);
+
+        [DllImport(LibraryName, EntryPoint = "bitset_c_xor", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern nint bitset_c_xor(nint left, nint right);
+
+        [DllImport(LibraryName, EntryPoint = "bitset_c_not", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern nint bitset_c_not(nint handle);
+
+        [DllImport(LibraryName, EntryPoint = "bitset_c_and_not", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern nint bitset_c_and_not(nint left, nint right);
+
+        [DllImport(LibraryName, EntryPoint = "bitset_c_popcount", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern ulong bitset_c_popcount(nint handle);
+
+        [DllImport(LibraryName, EntryPoint = "bitset_c_len", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern ulong bitset_c_len(nint handle);
+
+        [DllImport(LibraryName, EntryPoint = "bitset_c_capacity", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern ulong bitset_c_capacity(nint handle);
+
+        [DllImport(LibraryName, EntryPoint = "bitset_c_any", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern byte bitset_c_any(nint handle);
+
+        [DllImport(LibraryName, EntryPoint = "bitset_c_all", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern byte bitset_c_all(nint handle);
+
+        [DllImport(LibraryName, EntryPoint = "bitset_c_none", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern byte bitset_c_none(nint handle);
+
+        [DllImport(LibraryName, EntryPoint = "bitset_c_is_empty", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern byte bitset_c_is_empty(nint handle);
+
+        [DllImport(LibraryName, EntryPoint = "bitset_c_to_u64", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern byte bitset_c_to_u64(nint handle, out ulong value);
+
+        [DllImport(LibraryName, EntryPoint = "bitset_c_equals", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern byte bitset_c_equals(nint left, nint right);
+
+        [DllImport(LibraryName, EntryPoint = "bitset_c_last_error_message", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern nint bitset_c_last_error_message();
+    }
+}

--- a/code/packages/csharp/bitset-native/CHANGELOG.md
+++ b/code/packages/csharp/bitset-native/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-15
+
+### Added
+
+- Native C# wrapper over the Rust `bitset-c` library using .NET P/Invoke
+- Disposable `Bitset` API that mirrors the pure C# bitset package while delegating core operations to Rust
+- xUnit coverage for constructors, mutation, bulk operations, queries, equality, disposal, and conversion helpers

--- a/code/packages/csharp/bitset-native/CodingAdventures.BitsetNative.csproj
+++ b/code/packages/csharp/bitset-native/CodingAdventures.BitsetNative.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <PackageId>CodingAdventures.BitsetNative</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Native .NET wrapper over the Rust bitset crate</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Remove="tests\\**\\*.cs" />
+    <EmbeddedResource Remove="tests\\**" />
+    <None Remove="tests\\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/bitset-native/README.md
+++ b/code/packages/csharp/bitset-native/README.md
@@ -1,0 +1,35 @@
+# bitset-native
+
+Native C# wrapper over the Rust `bitset-c` library.
+
+## What It Includes
+
+- A managed `Bitset` class backed by the Rust `bitset` implementation
+- P/Invoke bindings to the `bitset-c` shared library
+- The same core API shape as the pure C# package: constructors, single-bit operations, bulk ops, queries, and conversions
+- Deterministic cleanup through `IDisposable`
+
+## Example
+
+```csharp
+using CodingAdventures.BitsetNative;
+
+using var left = Bitset.FromBinaryString("1100");
+using var right = Bitset.FromBinaryString("1010");
+using var intersection = left & right;
+
+Console.WriteLine(intersection.ToBinaryString()); // 1000
+```
+
+## Build Notes
+
+The package `BUILD` script first compiles `rust/bitset-c`, then runs
+`dotnet test`. The test project copies the resulting shared library into its
+output directory so the runtime loader can resolve `bitset_c`.
+
+## Development
+
+```bash
+# Run tests
+bash BUILD
+```

--- a/code/packages/csharp/bitset-native/required_capabilities.json
+++ b/code/packages/csharp/bitset-native/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/bitset-native",
+  "capabilities": [],
+  "justification": "Pure in-memory bitset operations through a Rust native library. No filesystem, network, process, or environment access at runtime."
+}

--- a/code/packages/csharp/bitset-native/tests/CodingAdventures.BitsetNative.Tests/BitsetNativeTests.cs
+++ b/code/packages/csharp/bitset-native/tests/CodingAdventures.BitsetNative.Tests/BitsetNativeTests.cs
@@ -1,0 +1,260 @@
+using BitsetType = CodingAdventures.BitsetNative.Bitset;
+
+namespace CodingAdventures.BitsetNative.Tests;
+
+public sealed class BitsetNativeTests
+{
+    [Fact]
+    public void NewTracksLengthCapacityAndEmptyQueries()
+    {
+        using var empty = new BitsetType(0);
+        Assert.Equal(0, empty.Length);
+        Assert.Equal(0, empty.Capacity);
+        Assert.Equal(0, empty.PopCount());
+        Assert.True(empty.None());
+        Assert.True(empty.All());
+        Assert.True(empty.IsEmpty);
+        Assert.Equal(string.Empty, empty.ToBinaryString());
+        Assert.Equal<ulong?>(0, empty.ToInteger());
+
+        using var sized = new BitsetType(65);
+        Assert.Equal(65, sized.Length);
+        Assert.Equal(128, sized.Capacity);
+        Assert.False(sized.Any());
+        Assert.False(sized.Test(64));
+    }
+
+    [Fact]
+    public void FromIntegerSupportsSmallAndCrossWordValues()
+    {
+        using var five = BitsetType.FromInteger((UInt128)5);
+        Assert.Equal(3, five.Length);
+        Assert.True(five.Test(0));
+        Assert.False(five.Test(1));
+        Assert.True(five.Test(2));
+        Assert.Equal("101", five.ToBinaryString());
+        Assert.Equal<ulong?>(5, five.ToInteger());
+
+        using var crossWord = BitsetType.FromInteger((UInt128.One << 64) | UInt128.One);
+        Assert.Equal(65, crossWord.Length);
+        Assert.True(crossWord.Test(0));
+        Assert.True(crossWord.Test(64));
+        Assert.Null(crossWord.ToInteger());
+    }
+
+    [Fact]
+    public void FromBinaryStringUnderstandsConventionalBitOrder()
+    {
+        using var bitset = BitsetType.FromBinaryString("00101");
+        Assert.Equal(5, bitset.Length);
+        Assert.True(bitset.Test(0));
+        Assert.False(bitset.Test(1));
+        Assert.True(bitset.Test(2));
+        Assert.False(bitset.Test(3));
+        Assert.False(bitset.Test(4));
+        Assert.Equal("00101", bitset.ToBinaryString());
+    }
+
+    [Fact]
+    public void FromBinaryStringRejectsInvalidCharacters()
+    {
+        Assert.Throws<BitsetError>(() => BitsetType.FromBinaryString("10x1"));
+    }
+
+    [Fact]
+    public void SetClearTestAndToggleHandleSingleBits()
+    {
+        using var bitset = new BitsetType(10);
+
+        bitset.Set(5);
+        Assert.True(bitset.Test(5));
+        Assert.Equal(1, bitset.PopCount());
+
+        bitset.Set(5);
+        Assert.Equal(1, bitset.PopCount());
+
+        bitset.Clear(5);
+        Assert.False(bitset.Test(5));
+        Assert.Equal(0, bitset.PopCount());
+
+        bitset.Toggle(2);
+        Assert.True(bitset.Test(2));
+        bitset.Toggle(2);
+        Assert.False(bitset.Test(2));
+    }
+
+    [Fact]
+    public void ClearAndTestBeyondLengthAreSafeNoOps()
+    {
+        using var bitset = new BitsetType(8);
+        bitset.Set(1);
+
+        bitset.Clear(100);
+
+        Assert.True(bitset.Test(1));
+        Assert.False(bitset.Test(100));
+        Assert.Equal(8, bitset.Length);
+    }
+
+    [Fact]
+    public void SetAndToggleAutoGrowWithDoublingCapacity()
+    {
+        using var bitset = new BitsetType(100);
+
+        bitset.Set(200);
+
+        Assert.Equal(201, bitset.Length);
+        Assert.Equal(256, bitset.Capacity);
+        Assert.True(bitset.Test(200));
+        Assert.False(bitset.Test(199));
+
+        bitset.Toggle(500);
+        Assert.Equal(501, bitset.Length);
+        Assert.Equal(512, bitset.Capacity);
+        Assert.True(bitset.Test(500));
+    }
+
+    [Fact]
+    public void BulkOperationsMatchReferenceTruthTables()
+    {
+        using var left = BitsetType.FromInteger((UInt128)0b1100);
+        using var right = BitsetType.FromInteger((UInt128)0b1010);
+        using var andResult = left.And(right);
+        using var orResult = left.Or(right);
+        using var xorResult = left.Xor(right);
+        using var andNotResult = left.AndNot(right);
+        using var opAnd = left & right;
+        using var opOr = left | right;
+        using var opXor = left ^ right;
+
+        Assert.Equal("1000", andResult.ToBinaryString());
+        Assert.Equal("1110", orResult.ToBinaryString());
+        Assert.Equal("0110", xorResult.ToBinaryString());
+        Assert.Equal("0100", andNotResult.ToBinaryString());
+
+        Assert.Equal("1000", opAnd.ToBinaryString());
+        Assert.Equal("1110", opOr.ToBinaryString());
+        Assert.Equal("0110", opXor.ToBinaryString());
+    }
+
+    [Fact]
+    public void BulkOperationsZeroExtendShorterInputs()
+    {
+        using var shortBitset = BitsetType.FromBinaryString("101");
+        using var longBitset = BitsetType.FromBinaryString("100001");
+        using var orResult = shortBitset.Or(longBitset);
+        using var andResult = shortBitset.And(longBitset);
+        using var xorResult = shortBitset.Xor(longBitset);
+
+        Assert.Equal("100101", orResult.ToBinaryString());
+        Assert.Equal("000001", andResult.ToBinaryString());
+        Assert.Equal("100100", xorResult.ToBinaryString());
+        Assert.Equal(6, orResult.Length);
+    }
+
+    [Fact]
+    public void NotOnlyFlipsBitsInsideLogicalLength()
+    {
+        using var bitset = new BitsetType(5);
+        bitset.Set(0);
+        bitset.Set(2);
+
+        using var inverted = bitset.Not();
+        using var roundTrip = ~inverted;
+
+        Assert.Equal("11010", inverted.ToBinaryString());
+        Assert.Equal(3, inverted.PopCount());
+        Assert.False(inverted.Test(5));
+        Assert.Equal(bitset, roundTrip);
+    }
+
+    [Fact]
+    public void AnyAllNoneAndIsEmptyReflectCurrentState()
+    {
+        using var empty = new BitsetType(0);
+        Assert.False(empty.Any());
+        Assert.True(empty.All());
+        Assert.True(empty.None());
+        Assert.True(empty.IsEmpty);
+
+        using var partial = new BitsetType(5);
+        partial.Set(0);
+        partial.Set(4);
+        Assert.True(partial.Any());
+        Assert.False(partial.All());
+        Assert.False(partial.None());
+
+        using var full = BitsetType.FromBinaryString("11111");
+        Assert.True(full.All());
+        Assert.False(full.None());
+    }
+
+    [Fact]
+    public void IterSetBitsYieldsAscendingIndicesAcrossWords()
+    {
+        using var bitset = new BitsetType(130);
+        bitset.Set(0);
+        bitset.Set(2);
+        bitset.Set(64);
+        bitset.Set(129);
+
+        Assert.Equal(new[] { 0, 2, 64, 129 }, bitset.IterSetBits().ToArray());
+        Assert.Equal(new[] { 0, 2, 64, 129 }, bitset.ToArray());
+        Assert.True(bitset.Contains(64));
+    }
+
+    [Fact]
+    public void BinaryStringRoundTripPreservesLeadingZeros()
+    {
+        using var bitset = new BitsetType(8);
+        bitset.Set(0);
+        bitset.Set(7);
+
+        Assert.Equal("10000001", bitset.ToBinaryString());
+
+        using var roundTrip = BitsetType.FromBinaryString(bitset.ToBinaryString());
+        Assert.Equal(bitset, roundTrip);
+    }
+
+    [Fact]
+    public void EqualityUsesLogicalBits()
+    {
+        using var left = BitsetType.FromBinaryString("101001");
+        using var right = new BitsetType(2);
+        right.Set(5);
+        right.Set(3);
+        right.Set(0);
+
+        Assert.Equal(left, right);
+        Assert.True(left == right);
+        Assert.False(left != right);
+        Assert.Equal(left.GetHashCode(), right.GetHashCode());
+    }
+
+    [Fact]
+    public void NegativeIndicesThrow()
+    {
+        using var bitset = new BitsetType(4);
+        Assert.Throws<ArgumentOutOfRangeException>(() => bitset.Set(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => bitset.Clear(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => bitset.Test(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => bitset.Toggle(-1));
+    }
+
+    [Fact]
+    public void DisposePreventsFurtherUse()
+    {
+        var bitset = new BitsetType(4);
+        bitset.Dispose();
+        bitset.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => bitset.Set(0));
+    }
+
+    [Fact]
+    public void ToStringUsesBinaryForm()
+    {
+        using var bitset = BitsetType.FromBinaryString("101");
+        Assert.Equal("Bitset(101)", bitset.ToString());
+    }
+}

--- a/code/packages/csharp/bitset-native/tests/CodingAdventures.BitsetNative.Tests/CodingAdventures.BitsetNative.Tests.csproj
+++ b/code/packages/csharp/bitset-native/tests/CodingAdventures.BitsetNative.Tests/CodingAdventures.BitsetNative.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.BitsetNative.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <NativeBitsetLibrary Include="../../../../rust/target/release/libbitset_c.dylib" Condition="Exists('../../../../rust/target/release/libbitset_c.dylib')" />
+    <NativeBitsetLibrary Include="../../../../rust/target/release/libbitset_c.so" Condition="Exists('../../../../rust/target/release/libbitset_c.so')" />
+    <NativeBitsetLibrary Include="../../../../rust/target/release/bitset_c.dll" Condition="Exists('../../../../rust/target/release/bitset_c.dll')" />
+  </ItemGroup>
+
+  <Target Name="CopyBitsetNativeLibrary" AfterTargets="Build">
+    <Copy SourceFiles="@(NativeBitsetLibrary)" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
+  </Target>
+</Project>

--- a/code/packages/csharp/bitset/BUILD
+++ b/code/packages/csharp/bitset/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Bitset.Tests/CodingAdventures.Bitset.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/bitset/BUILD_windows
+++ b/code/packages/csharp/bitset/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Bitset.Tests/CodingAdventures.Bitset.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/bitset/Bitset.cs
+++ b/code/packages/csharp/bitset/Bitset.cs
@@ -1,0 +1,556 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Text;
+
+namespace CodingAdventures.Bitset;
+
+// Bitset.cs -- Bitsets as densely packed boolean arrays
+// =====================================================
+//
+// A normal bool array spends one byte per flag. A bitset spends one bit.
+// That 8x reduction matters because the real payoff is not only memory but
+// also bulk operations: a single 64-bit AND instruction combines 64 flags at
+// once.
+//
+// This implementation follows the same LSB-first layout used by the Rust,
+// Python, and TypeScript packages:
+//
+//   bit 0  -> least significant bit of word 0
+//   bit 63 -> most significant bit of word 0
+//   bit 64 -> least significant bit of word 1
+//
+// The bitset grows automatically when Set or Toggle reach beyond the current
+// length. That makes it behave more like a dynamic array than a fixed bitmap.
+
+/// <summary>
+/// Raised when a binary-string constructor receives characters other than
+/// <c>0</c> and <c>1</c>.
+/// </summary>
+public sealed class BitsetError : Exception
+{
+    /// <summary>
+    /// Create an error that records the invalid binary input.
+    /// </summary>
+    public BitsetError(string input)
+        : base($"Invalid binary string: \"{input}\".")
+    {
+        Input = input;
+    }
+
+    /// <summary>
+    /// The offending input string.
+    /// </summary>
+    public string Input { get; }
+}
+
+/// <summary>
+/// A compact boolean array packed into 64-bit words.
+/// </summary>
+public sealed class Bitset : IEquatable<Bitset>, IEnumerable<int>
+{
+    private const int BitsPerWord = 64;
+
+    private readonly List<ulong> _words;
+    private int _length;
+
+    /// <summary>
+    /// Create a zero-filled bitset with the requested logical length.
+    /// </summary>
+    public Bitset(int size)
+    {
+        if (size < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(size), "Bitset size cannot be negative.");
+        }
+
+        _length = size;
+        _words = new List<ulong>(WordsNeeded(size));
+        for (var i = 0; i < WordsNeeded(size); i++)
+        {
+            _words.Add(0);
+        }
+    }
+
+    private Bitset(List<ulong> words, int length)
+    {
+        _words = words;
+        _length = length;
+        CleanTrailingBits();
+    }
+
+    /// <summary>
+    /// Logical size: the number of addressable bits.
+    /// </summary>
+    public int Length => _length;
+
+    /// <summary>
+    /// Allocated size rounded to a multiple of 64.
+    /// </summary>
+    public int Capacity => _words.Count * BitsPerWord;
+
+    /// <summary>
+    /// Whether the bitset has zero logical length.
+    /// </summary>
+    public bool IsEmpty => _length == 0;
+
+    /// <summary>
+    /// Create a bitset from a non-negative integer using LSB-first ordering.
+    /// </summary>
+    public static Bitset FromInteger(UInt128 value)
+    {
+        if (value == UInt128.Zero)
+        {
+            return new Bitset(0);
+        }
+
+        var low = (ulong)value;
+        var high = (ulong)(value >> 64);
+        var length = high != 0
+            ? 64 + (64 - BitOperations.LeadingZeroCount(high))
+            : 64 - BitOperations.LeadingZeroCount(low);
+
+        var words = new List<ulong> { low };
+        if (high != 0)
+        {
+            words.Add(high);
+        }
+
+        return new Bitset(words, length);
+    }
+
+    /// <summary>
+    /// Create a bitset from a string whose leftmost character is the highest bit.
+    /// </summary>
+    public static Bitset FromBinaryString(string value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+        foreach (var ch in value)
+        {
+            if (ch != '0' && ch != '1')
+            {
+                throw new BitsetError(value);
+            }
+        }
+
+        var bitset = new Bitset(value.Length);
+        for (var bitIndex = 0; bitIndex < value.Length; bitIndex++)
+        {
+            var ch = value[value.Length - 1 - bitIndex];
+            if (ch == '1')
+            {
+                bitset._words[WordIndex(bitIndex)] |= Bitmask(bitIndex);
+            }
+        }
+
+        bitset.CleanTrailingBits();
+        return bitset;
+    }
+
+    /// <summary>
+    /// Set a bit to 1, growing the bitset if needed.
+    /// </summary>
+    public void Set(int index)
+    {
+        EnsureCapacity(index);
+        _words[WordIndex(index)] |= Bitmask(index);
+    }
+
+    /// <summary>
+    /// Set a bit to 0. Clearing beyond <see cref="Length"/> is a no-op.
+    /// </summary>
+    public void Clear(int index)
+    {
+        ValidateIndex(index);
+        if (index >= _length)
+        {
+            return;
+        }
+
+        _words[WordIndex(index)] &= ~Bitmask(index);
+    }
+
+    /// <summary>
+    /// Return whether a bit is set. Testing beyond <see cref="Length"/> is false.
+    /// </summary>
+    public bool Test(int index)
+    {
+        ValidateIndex(index);
+        if (index >= _length)
+        {
+            return false;
+        }
+
+        return (_words[WordIndex(index)] & Bitmask(index)) != 0;
+    }
+
+    /// <summary>
+    /// Flip a bit, growing the bitset if needed.
+    /// </summary>
+    public void Toggle(int index)
+    {
+        EnsureCapacity(index);
+        _words[WordIndex(index)] ^= Bitmask(index);
+        CleanTrailingBits();
+    }
+
+    /// <summary>
+    /// Bitwise AND. The result length is the longer input length.
+    /// </summary>
+    public Bitset And(Bitset other) => BinaryOp(other, static (left, right) => left & right);
+
+    /// <summary>
+    /// Bitwise OR. The result length is the longer input length.
+    /// </summary>
+    public Bitset Or(Bitset other) => BinaryOp(other, static (left, right) => left | right);
+
+    /// <summary>
+    /// Bitwise XOR. The result length is the longer input length.
+    /// </summary>
+    public Bitset Xor(Bitset other) => BinaryOp(other, static (left, right) => left ^ right);
+
+    /// <summary>
+    /// Bitwise complement within the logical length of the bitset.
+    /// </summary>
+    public Bitset Not()
+    {
+        var relevantWords = WordsNeeded(_length);
+        var words = new List<ulong>(relevantWords);
+        for (var i = 0; i < relevantWords; i++)
+        {
+            words.Add(~GetWord(i));
+        }
+
+        return new Bitset(words, _length);
+    }
+
+    /// <summary>
+    /// Set difference: keep bits set in this bitset that are not set in <paramref name="other"/>.
+    /// </summary>
+    public Bitset AndNot(Bitset other) => BinaryOp(other, static (left, right) => left & ~right);
+
+    /// <summary>
+    /// Count how many bits are set to 1.
+    /// </summary>
+    public int PopCount()
+    {
+        var count = 0;
+        for (var i = 0; i < WordsNeeded(_length); i++)
+        {
+            count += BitOperations.PopCount(GetWord(i));
+        }
+
+        return count;
+    }
+
+    /// <summary>
+    /// Return whether at least one bit is set.
+    /// </summary>
+    public bool Any()
+    {
+        for (var i = 0; i < WordsNeeded(_length); i++)
+        {
+            if (GetWord(i) != 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Return whether all bits within <see cref="Length"/> are set.
+    /// Empty bitsets satisfy this vacuously.
+    /// </summary>
+    public bool All()
+    {
+        if (_length == 0)
+        {
+            return true;
+        }
+
+        var fullWords = _length / BitsPerWord;
+        for (var i = 0; i < fullWords; i++)
+        {
+            if (GetWord(i) != ulong.MaxValue)
+            {
+                return false;
+            }
+        }
+
+        var remainingBits = _length % BitsPerWord;
+        if (remainingBits == 0)
+        {
+            return true;
+        }
+
+        return GetWord(fullWords) == TrailingMask(remainingBits);
+    }
+
+    /// <summary>
+    /// Return whether no bits are set.
+    /// </summary>
+    public bool None() => !Any();
+
+    /// <summary>
+    /// Iterate over the indices of set bits in ascending order.
+    /// </summary>
+    public IEnumerable<int> IterSetBits()
+    {
+        var relevantWords = WordsNeeded(_length);
+        for (var wordIndex = 0; wordIndex < relevantWords; wordIndex++)
+        {
+            var word = GetWord(wordIndex);
+            while (word != 0)
+            {
+                var offset = BitOperations.TrailingZeroCount(word);
+                yield return (wordIndex * BitsPerWord) + offset;
+                word &= word - 1;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Convert to a 64-bit integer when the value fits in a single word.
+    /// Returns <see langword="null"/> otherwise.
+    /// </summary>
+    public ulong? ToInteger()
+    {
+        var relevantWords = WordsNeeded(_length);
+        if (relevantWords == 0)
+        {
+            return 0;
+        }
+
+        for (var i = 1; i < relevantWords; i++)
+        {
+            if (GetWord(i) != 0)
+            {
+                return null;
+            }
+        }
+
+        return GetWord(0);
+    }
+
+    /// <summary>
+    /// Convert to a conventional binary string with the highest bit on the left.
+    /// </summary>
+    public string ToBinaryString()
+    {
+        if (_length == 0)
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder(_length);
+        for (var i = _length - 1; i >= 0; i--)
+        {
+            builder.Append(Test(i) ? '1' : '0');
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Convenience alias for <see cref="Test"/>.
+    /// </summary>
+    public bool Contains(int index) => Test(index);
+
+    /// <summary>
+    /// Return a debug-friendly representation such as <c>Bitset(101)</c>.
+    /// </summary>
+    public override string ToString() => $"Bitset({ToBinaryString()})";
+
+    /// <summary>
+    /// Compare two bitsets by logical length and logical bits, ignoring spare capacity.
+    /// </summary>
+    public bool Equals(Bitset? other)
+    {
+        if (other is null || _length != other._length)
+        {
+            return false;
+        }
+
+        var relevantWords = WordsNeeded(_length);
+        for (var i = 0; i < relevantWords; i++)
+        {
+            if (GetWord(i) != other.GetWord(i))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Compare this bitset to another object.
+    /// </summary>
+    public override bool Equals(object? obj) => obj is Bitset other && Equals(other);
+
+    /// <summary>
+    /// Compute a hash from the logical length and words inside that logical range.
+    /// </summary>
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(_length);
+        for (var i = 0; i < WordsNeeded(_length); i++)
+        {
+            hash.Add(GetWord(i));
+        }
+
+        return hash.ToHashCode();
+    }
+
+    /// <summary>
+    /// Enumerate the indices of all set bits.
+    /// </summary>
+    public IEnumerator<int> GetEnumerator() => IterSetBits().GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    /// <summary>
+    /// Operator shorthand for <see cref="And"/>.
+    /// </summary>
+    public static Bitset operator &(Bitset left, Bitset right)
+    {
+        ArgumentNullException.ThrowIfNull(left);
+        return left.And(right);
+    }
+
+    /// <summary>
+    /// Operator shorthand for <see cref="Or"/>.
+    /// </summary>
+    public static Bitset operator |(Bitset left, Bitset right)
+    {
+        ArgumentNullException.ThrowIfNull(left);
+        return left.Or(right);
+    }
+
+    /// <summary>
+    /// Operator shorthand for <see cref="Xor"/>.
+    /// </summary>
+    public static Bitset operator ^(Bitset left, Bitset right)
+    {
+        ArgumentNullException.ThrowIfNull(left);
+        return left.Xor(right);
+    }
+
+    /// <summary>
+    /// Operator shorthand for <see cref="Not"/>.
+    /// </summary>
+    public static Bitset operator ~(Bitset value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        return value.Not();
+    }
+
+    /// <summary>
+    /// Equality operator based on logical length and logical bits.
+    /// </summary>
+    public static bool operator ==(Bitset? left, Bitset? right)
+    {
+        if (ReferenceEquals(left, right))
+        {
+            return true;
+        }
+
+        if (left is null || right is null)
+        {
+            return false;
+        }
+
+        return left.Equals(right);
+    }
+
+    /// <summary>
+    /// Inequality operator based on logical length and logical bits.
+    /// </summary>
+    public static bool operator !=(Bitset? left, Bitset? right) => !(left == right);
+
+    private Bitset BinaryOp(Bitset other, Func<ulong, ulong, ulong> operation)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+
+        var resultLength = Math.Max(_length, other._length);
+        var relevantWords = WordsNeeded(resultLength);
+        var words = new List<ulong>(relevantWords);
+        for (var i = 0; i < relevantWords; i++)
+        {
+            words.Add(operation(GetWord(i), other.GetWord(i)));
+        }
+
+        return new Bitset(words, resultLength);
+    }
+
+    private ulong GetWord(int index) => index < _words.Count ? _words[index] : 0;
+
+    private void EnsureCapacity(int index)
+    {
+        ValidateIndex(index);
+
+        if (index >= Capacity)
+        {
+            var newCapacity = Capacity == 0 ? BitsPerWord : Capacity;
+            while (index >= newCapacity)
+            {
+                newCapacity *= 2;
+            }
+
+            var targetWordCount = WordsNeeded(newCapacity);
+            while (_words.Count < targetWordCount)
+            {
+                _words.Add(0);
+            }
+        }
+
+        if (index + 1 > _length)
+        {
+            _length = index + 1;
+        }
+    }
+
+    private void CleanTrailingBits()
+    {
+        var relevantWords = WordsNeeded(_length);
+
+        for (var i = relevantWords; i < _words.Count; i++)
+        {
+            _words[i] = 0;
+        }
+
+        if (relevantWords == 0)
+        {
+            return;
+        }
+
+        var remainingBits = _length % BitsPerWord;
+        if (remainingBits == 0)
+        {
+            return;
+        }
+
+        _words[relevantWords - 1] &= TrailingMask(remainingBits);
+    }
+
+    private static void ValidateIndex(int index)
+    {
+        if (index < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(index), "Bit indices cannot be negative.");
+        }
+    }
+
+    private static int WordsNeeded(int bitCount) => bitCount == 0 ? 0 : ((bitCount - 1) / BitsPerWord) + 1;
+
+    private static int WordIndex(int index) => index / BitsPerWord;
+
+    private static ulong Bitmask(int index) => 1UL << (index % BitsPerWord);
+
+    private static ulong TrailingMask(int bitCount) => bitCount == BitsPerWord ? ulong.MaxValue : (1UL << bitCount) - 1;
+}

--- a/code/packages/csharp/bitset/CHANGELOG.md
+++ b/code/packages/csharp/bitset/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-15
+
+### Added
+
+- Literate C# bitset implementation with dynamic growth, bulk bitwise operations, conversions, and set-bit iteration
+- Spec-style xUnit coverage for constructors, single-bit operations, growth, bulk ops, queries, conversions, equality, and edge cases

--- a/code/packages/csharp/bitset/CodingAdventures.Bitset.csproj
+++ b/code/packages/csharp/bitset/CodingAdventures.Bitset.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Bitset</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Compact boolean array packed into 64-bit words</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Remove="tests\\**\\*.cs" />
+    <EmbeddedResource Remove="tests\\**" />
+    <None Remove="tests\\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/bitset/README.md
+++ b/code/packages/csharp/bitset/README.md
@@ -1,0 +1,34 @@
+# bitset
+
+Compact boolean arrays packed into 64-bit words for space-efficient storage and fast bulk bitwise operations.
+
+## Layer 1
+
+This package is part of Layer 1 of the coding-adventures computing stack.
+
+## What It Includes
+
+- Dynamic growth when `Set` or `Toggle` reach beyond the current logical length
+- Bulk bitwise operations: AND, OR, XOR, NOT, and AND-NOT
+- Counting and queries: `PopCount`, `Any`, `All`, `None`, `Length`, and `Capacity`
+- Conversions to and from binary strings plus 64-bit integer conversion when the value fits
+- Efficient iteration over set-bit indices using trailing-zero counting
+
+## Example
+
+```csharp
+using CodingAdventures.Bitset;
+
+var left = Bitset.FromBinaryString("1100");
+var right = Bitset.FromBinaryString("1010");
+
+var intersection = left & right;
+Console.WriteLine(intersection.ToBinaryString()); // 1000
+```
+
+## Development
+
+```bash
+# Run tests
+bash BUILD
+```

--- a/code/packages/csharp/bitset/required_capabilities.json
+++ b/code/packages/csharp/bitset/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/bitset",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/bitset/tests/CodingAdventures.Bitset.Tests/BitsetTests.cs
+++ b/code/packages/csharp/bitset/tests/CodingAdventures.Bitset.Tests/BitsetTests.cs
@@ -1,0 +1,237 @@
+using BitsetType = CodingAdventures.Bitset.Bitset;
+
+namespace CodingAdventures.Bitset.Tests;
+
+public sealed class BitsetTests
+{
+    [Fact]
+    public void NewTracksLengthCapacityAndEmptyQueries()
+    {
+        var empty = new BitsetType(0);
+        Assert.Equal(0, empty.Length);
+        Assert.Equal(0, empty.Capacity);
+        Assert.Equal(0, empty.PopCount());
+        Assert.True(empty.None());
+        Assert.True(empty.All());
+        Assert.True(empty.IsEmpty);
+        Assert.Equal(string.Empty, empty.ToBinaryString());
+        Assert.Equal<ulong?>(0, empty.ToInteger());
+
+        var sized = new BitsetType(65);
+        Assert.Equal(65, sized.Length);
+        Assert.Equal(128, sized.Capacity);
+        Assert.False(sized.Any());
+        Assert.False(sized.Test(64));
+    }
+
+    [Fact]
+    public void FromIntegerSupportsSmallAndCrossWordValues()
+    {
+        var five = BitsetType.FromInteger((UInt128)5);
+        Assert.Equal(3, five.Length);
+        Assert.True(five.Test(0));
+        Assert.False(five.Test(1));
+        Assert.True(five.Test(2));
+        Assert.Equal("101", five.ToBinaryString());
+        Assert.Equal<ulong?>(5, five.ToInteger());
+
+        var crossWord = BitsetType.FromInteger((UInt128.One << 64) | UInt128.One);
+        Assert.Equal(65, crossWord.Length);
+        Assert.True(crossWord.Test(0));
+        Assert.True(crossWord.Test(64));
+        Assert.Null(crossWord.ToInteger());
+    }
+
+    [Fact]
+    public void FromBinaryStringUnderstandsConventionalBitOrder()
+    {
+        var bitset = BitsetType.FromBinaryString("00101");
+        Assert.Equal(5, bitset.Length);
+        Assert.True(bitset.Test(0));
+        Assert.False(bitset.Test(1));
+        Assert.True(bitset.Test(2));
+        Assert.False(bitset.Test(3));
+        Assert.False(bitset.Test(4));
+        Assert.Equal("00101", bitset.ToBinaryString());
+    }
+
+    [Fact]
+    public void FromBinaryStringRejectsInvalidCharacters()
+    {
+        Assert.Throws<BitsetError>(() => BitsetType.FromBinaryString("10x1"));
+    }
+
+    [Fact]
+    public void SetClearTestAndToggleHandleSingleBits()
+    {
+        var bitset = new BitsetType(10);
+
+        bitset.Set(5);
+        Assert.True(bitset.Test(5));
+        Assert.Equal(1, bitset.PopCount());
+
+        bitset.Set(5);
+        Assert.Equal(1, bitset.PopCount());
+
+        bitset.Clear(5);
+        Assert.False(bitset.Test(5));
+        Assert.Equal(0, bitset.PopCount());
+
+        bitset.Toggle(2);
+        Assert.True(bitset.Test(2));
+        bitset.Toggle(2);
+        Assert.False(bitset.Test(2));
+    }
+
+    [Fact]
+    public void ClearAndTestBeyondLengthAreSafeNoOps()
+    {
+        var bitset = new BitsetType(8);
+        bitset.Set(1);
+
+        bitset.Clear(100);
+
+        Assert.True(bitset.Test(1));
+        Assert.False(bitset.Test(100));
+        Assert.Equal(8, bitset.Length);
+    }
+
+    [Fact]
+    public void SetAndToggleAutoGrowWithDoublingCapacity()
+    {
+        var bitset = new BitsetType(100);
+
+        bitset.Set(200);
+
+        Assert.Equal(201, bitset.Length);
+        Assert.Equal(256, bitset.Capacity);
+        Assert.True(bitset.Test(200));
+        Assert.False(bitset.Test(199));
+
+        bitset.Toggle(500);
+        Assert.Equal(501, bitset.Length);
+        Assert.Equal(512, bitset.Capacity);
+        Assert.True(bitset.Test(500));
+    }
+
+    [Fact]
+    public void BulkOperationsMatchReferenceTruthTables()
+    {
+        var left = BitsetType.FromInteger((UInt128)0b1100);
+        var right = BitsetType.FromInteger((UInt128)0b1010);
+
+        Assert.Equal("1000", left.And(right).ToBinaryString());
+        Assert.Equal("1110", left.Or(right).ToBinaryString());
+        Assert.Equal("0110", left.Xor(right).ToBinaryString());
+        Assert.Equal("0100", left.AndNot(right).ToBinaryString());
+
+        Assert.Equal("1000", (left & right).ToBinaryString());
+        Assert.Equal("1110", (left | right).ToBinaryString());
+        Assert.Equal("0110", (left ^ right).ToBinaryString());
+    }
+
+    [Fact]
+    public void BulkOperationsZeroExtendShorterInputs()
+    {
+        var shortBitset = BitsetType.FromBinaryString("101");
+        var longBitset = BitsetType.FromBinaryString("100001");
+
+        Assert.Equal("100101", shortBitset.Or(longBitset).ToBinaryString());
+        Assert.Equal("000001", shortBitset.And(longBitset).ToBinaryString());
+        Assert.Equal("100100", shortBitset.Xor(longBitset).ToBinaryString());
+        Assert.Equal(6, shortBitset.Or(longBitset).Length);
+    }
+
+    [Fact]
+    public void NotOnlyFlipsBitsInsideLogicalLength()
+    {
+        var bitset = new BitsetType(5);
+        bitset.Set(0);
+        bitset.Set(2);
+
+        var inverted = bitset.Not();
+
+        Assert.Equal("11010", inverted.ToBinaryString());
+        Assert.Equal(3, inverted.PopCount());
+        Assert.False(inverted.Test(5));
+        Assert.Equal(bitset, ~inverted);
+    }
+
+    [Fact]
+    public void AnyAllNoneAndIsEmptyReflectCurrentState()
+    {
+        var empty = new BitsetType(0);
+        Assert.False(empty.Any());
+        Assert.True(empty.All());
+        Assert.True(empty.None());
+        Assert.True(empty.IsEmpty);
+
+        var partial = new BitsetType(5);
+        partial.Set(0);
+        partial.Set(4);
+        Assert.True(partial.Any());
+        Assert.False(partial.All());
+        Assert.False(partial.None());
+
+        var full = BitsetType.FromBinaryString("11111");
+        Assert.True(full.All());
+        Assert.False(full.None());
+    }
+
+    [Fact]
+    public void IterSetBitsYieldsAscendingIndicesAcrossWords()
+    {
+        var bitset = new BitsetType(130);
+        bitset.Set(0);
+        bitset.Set(2);
+        bitset.Set(64);
+        bitset.Set(129);
+
+        Assert.Equal(new[] { 0, 2, 64, 129 }, bitset.IterSetBits().ToArray());
+        Assert.Equal(new[] { 0, 2, 64, 129 }, bitset.ToArray());
+        Assert.True(bitset.Contains(64));
+    }
+
+    [Fact]
+    public void BinaryStringRoundTripPreservesLeadingZeros()
+    {
+        var bitset = new BitsetType(8);
+        bitset.Set(0);
+        bitset.Set(7);
+
+        Assert.Equal("10000001", bitset.ToBinaryString());
+        Assert.Equal(bitset, BitsetType.FromBinaryString(bitset.ToBinaryString()));
+    }
+
+    [Fact]
+    public void EqualityIgnoresInternalStorageChoicesAndUsesLogicalBits()
+    {
+        var left = BitsetType.FromBinaryString("101001");
+        var right = new BitsetType(2);
+        right.Set(5);
+        right.Set(3);
+        right.Set(0);
+
+        Assert.Equal(left, right);
+        Assert.True(left == right);
+        Assert.False(left != right);
+        Assert.Equal(left.GetHashCode(), right.GetHashCode());
+    }
+
+    [Fact]
+    public void NegativeIndicesThrow()
+    {
+        var bitset = new BitsetType(4);
+        Assert.Throws<ArgumentOutOfRangeException>(() => bitset.Set(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => bitset.Clear(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => bitset.Test(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => bitset.Toggle(-1));
+    }
+
+    [Fact]
+    public void ToStringUsesBinaryForm()
+    {
+        var bitset = BitsetType.FromBinaryString("101");
+        Assert.Equal("Bitset(101)", bitset.ToString());
+    }
+}

--- a/code/packages/csharp/bitset/tests/CodingAdventures.Bitset.Tests/CodingAdventures.Bitset.Tests.csproj
+++ b/code/packages/csharp/bitset/tests/CodingAdventures.Bitset.Tests/CodingAdventures.Bitset.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Bitset.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/bitset-native/BUILD
+++ b/code/packages/fsharp/bitset-native/BUILD
@@ -1,0 +1,2 @@
+cargo build --release --manifest-path ../../rust/bitset-c/Cargo.toml
+dotnet test tests/CodingAdventures.BitsetNative.Tests/CodingAdventures.BitsetNative.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/bitset-native/BUILD_windows
+++ b/code/packages/fsharp/bitset-native/BUILD_windows
@@ -1,0 +1,2 @@
+cargo build --release --manifest-path ../../rust/bitset-c/Cargo.toml
+dotnet test tests/CodingAdventures.BitsetNative.Tests/CodingAdventures.BitsetNative.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/bitset-native/BitsetNative.fs
+++ b/code/packages/fsharp/bitset-native/BitsetNative.fs
@@ -1,0 +1,328 @@
+namespace CodingAdventures.BitsetNative
+
+open System
+open System.Collections
+open System.Collections.Generic
+open System.Runtime.InteropServices
+
+// BitsetNative.fs -- F# wrapper over the Rust bitset C ABI
+// =========================================================
+//
+// The .NET runtime already knows how to call native code through P/Invoke.
+// That means F# can reuse the same Rust `bitset-c` shared library as C#:
+//
+//   F# API -> DllImport -> bitset-c -> bitset
+//
+// The wrapper keeps the public API close to the pure F# bitset package while
+// taking responsibility for one native concern: releasing the opaque handle.
+
+/// Raised when the Rust native layer rejects an operation such as parsing an invalid binary string.
+type BitsetError(message: string) =
+    inherit Exception(message)
+
+module private NativeMethods =
+    [<Literal>]
+    let LibraryName = "bitset_c"
+
+    [<DllImport(LibraryName, EntryPoint = "bitset_c_new", CallingConvention = CallingConvention.Cdecl)>]
+    extern nativeint bitset_c_new(uint64 size)
+
+    [<DllImport(LibraryName, EntryPoint = "bitset_c_from_u128", CallingConvention = CallingConvention.Cdecl)>]
+    extern nativeint bitset_c_from_u128(uint64 low, uint64 high)
+
+    [<DllImport(LibraryName, EntryPoint = "bitset_c_from_binary_str", CallingConvention = CallingConvention.Cdecl)>]
+    extern nativeint bitset_c_from_binary_str([<MarshalAs(UnmanagedType.LPUTF8Str)>] string binary)
+
+    [<DllImport(LibraryName, EntryPoint = "bitset_c_free", CallingConvention = CallingConvention.Cdecl)>]
+    extern void bitset_c_free(nativeint handle)
+
+    [<DllImport(LibraryName, EntryPoint = "bitset_c_set", CallingConvention = CallingConvention.Cdecl)>]
+    extern void bitset_c_set(nativeint handle, uint64 index)
+
+    [<DllImport(LibraryName, EntryPoint = "bitset_c_clear", CallingConvention = CallingConvention.Cdecl)>]
+    extern void bitset_c_clear(nativeint handle, uint64 index)
+
+    [<DllImport(LibraryName, EntryPoint = "bitset_c_test", CallingConvention = CallingConvention.Cdecl)>]
+    extern byte bitset_c_test(nativeint handle, uint64 index)
+
+    [<DllImport(LibraryName, EntryPoint = "bitset_c_toggle", CallingConvention = CallingConvention.Cdecl)>]
+    extern void bitset_c_toggle(nativeint handle, uint64 index)
+
+    [<DllImport(LibraryName, EntryPoint = "bitset_c_and", CallingConvention = CallingConvention.Cdecl)>]
+    extern nativeint bitset_c_and(nativeint left, nativeint right)
+
+    [<DllImport(LibraryName, EntryPoint = "bitset_c_or", CallingConvention = CallingConvention.Cdecl)>]
+    extern nativeint bitset_c_or(nativeint left, nativeint right)
+
+    [<DllImport(LibraryName, EntryPoint = "bitset_c_xor", CallingConvention = CallingConvention.Cdecl)>]
+    extern nativeint bitset_c_xor(nativeint left, nativeint right)
+
+    [<DllImport(LibraryName, EntryPoint = "bitset_c_not", CallingConvention = CallingConvention.Cdecl)>]
+    extern nativeint bitset_c_not(nativeint handle)
+
+    [<DllImport(LibraryName, EntryPoint = "bitset_c_and_not", CallingConvention = CallingConvention.Cdecl)>]
+    extern nativeint bitset_c_and_not(nativeint left, nativeint right)
+
+    [<DllImport(LibraryName, EntryPoint = "bitset_c_popcount", CallingConvention = CallingConvention.Cdecl)>]
+    extern uint64 bitset_c_popcount(nativeint handle)
+
+    [<DllImport(LibraryName, EntryPoint = "bitset_c_len", CallingConvention = CallingConvention.Cdecl)>]
+    extern uint64 bitset_c_len(nativeint handle)
+
+    [<DllImport(LibraryName, EntryPoint = "bitset_c_capacity", CallingConvention = CallingConvention.Cdecl)>]
+    extern uint64 bitset_c_capacity(nativeint handle)
+
+    [<DllImport(LibraryName, EntryPoint = "bitset_c_any", CallingConvention = CallingConvention.Cdecl)>]
+    extern byte bitset_c_any(nativeint handle)
+
+    [<DllImport(LibraryName, EntryPoint = "bitset_c_all", CallingConvention = CallingConvention.Cdecl)>]
+    extern byte bitset_c_all(nativeint handle)
+
+    [<DllImport(LibraryName, EntryPoint = "bitset_c_none", CallingConvention = CallingConvention.Cdecl)>]
+    extern byte bitset_c_none(nativeint handle)
+
+    [<DllImport(LibraryName, EntryPoint = "bitset_c_is_empty", CallingConvention = CallingConvention.Cdecl)>]
+    extern byte bitset_c_is_empty(nativeint handle)
+
+    [<DllImport(LibraryName, EntryPoint = "bitset_c_to_u64", CallingConvention = CallingConvention.Cdecl)>]
+    extern byte bitset_c_to_u64(nativeint handle, uint64& value)
+
+    [<DllImport(LibraryName, EntryPoint = "bitset_c_equals", CallingConvention = CallingConvention.Cdecl)>]
+    extern byte bitset_c_equals(nativeint left, nativeint right)
+
+    [<DllImport(LibraryName, EntryPoint = "bitset_c_last_error_message", CallingConvention = CallingConvention.Cdecl)>]
+    extern nativeint bitset_c_last_error_message()
+
+module private Interop =
+    let readLastErrorMessage operation =
+        let ptr = NativeMethods.bitset_c_last_error_message()
+        let message =
+            if ptr = 0n then
+                "bitset-c reported an unknown error."
+            else
+                match Marshal.PtrToStringUTF8(ptr) with
+                | null -> "bitset-c reported an unreadable UTF-8 error message."
+                | text -> text
+
+        $"{operation} failed: {message}"
+
+    let raiseBitsetError operation =
+        raise (BitsetError(readLastErrorMessage operation))
+
+    let validateIndex index =
+        if index < 0 then
+            raise (ArgumentOutOfRangeException("index", "Bit indices cannot be negative."))
+
+    let checkedInt operation value =
+        if value > uint64 Int32.MaxValue then
+            raise (OverflowException($"{operation} exceeded Int32.MaxValue."))
+
+        int value
+
+/// A native-backed compact boolean array packed into 64-bit words.
+[<AllowNullLiteral>]
+type Bitset private (nativeHandle: nativeint) =
+    let mutable handle = nativeHandle
+
+    new(size: int) =
+        if size < 0 then
+            raise (ArgumentOutOfRangeException("size", "Bitset size cannot be negative."))
+
+        let handle = NativeMethods.bitset_c_new(uint64 size)
+        if handle = 0n then
+            Interop.raiseBitsetError "bitset_c_new"
+
+        new Bitset(handle)
+
+    static member FromInteger(value: UInt128) =
+        let low = uint64 value
+        let high = uint64 (value >>> 64)
+        let handle = NativeMethods.bitset_c_from_u128(low, high)
+        if handle = 0n then
+            Interop.raiseBitsetError "bitset_c_from_u128"
+
+        new Bitset(handle)
+
+    static member FromBinaryString(value: string) =
+        if isNull value then
+            nullArg "value"
+
+        let handle = NativeMethods.bitset_c_from_binary_str(value)
+        if handle = 0n then
+            Interop.raiseBitsetError "bitset_c_from_binary_str"
+
+        new Bitset(handle)
+
+    member private _.Handle =
+        if handle = 0n then
+            raise (ObjectDisposedException("Bitset"))
+        else
+            handle
+
+    member private _.ReleaseHandle() =
+        if handle <> 0n then
+            NativeMethods.bitset_c_free(handle)
+            handle <- 0n
+
+    /// Logical size: the number of addressable bits.
+    member this.Length = NativeMethods.bitset_c_len(this.Handle) |> Interop.checkedInt "Length"
+
+    /// Allocated size rounded to a multiple of 64.
+    member this.Capacity = NativeMethods.bitset_c_capacity(this.Handle) |> Interop.checkedInt "Capacity"
+
+    /// Whether the bitset has zero logical length.
+    member this.IsEmpty = NativeMethods.bitset_c_is_empty(this.Handle) <> 0uy
+
+    /// Set a bit to 1, growing the bitset if needed.
+    member this.Set(index: int) =
+        Interop.validateIndex index
+        NativeMethods.bitset_c_set(this.Handle, uint64 index)
+
+    /// Set a bit to 0. Clearing beyond the logical length is a no-op.
+    member this.Clear(index: int) =
+        Interop.validateIndex index
+        NativeMethods.bitset_c_clear(this.Handle, uint64 index)
+
+    /// Return whether a bit is set. Testing beyond the logical length is false.
+    member this.Test(index: int) =
+        Interop.validateIndex index
+        NativeMethods.bitset_c_test(this.Handle, uint64 index) <> 0uy
+
+    /// Flip a bit, growing the bitset if needed.
+    member this.Toggle(index: int) =
+        Interop.validateIndex index
+        NativeMethods.bitset_c_toggle(this.Handle, uint64 index)
+
+    /// Bitwise AND. The result length is the longer input length.
+    member this.And(other: Bitset) =
+        if isNull (box other) then
+            nullArg "other"
+
+        let handle = NativeMethods.bitset_c_and(this.Handle, other.Handle)
+        if handle = 0n then
+            Interop.raiseBitsetError "bitset_c_and"
+
+        new Bitset(handle)
+
+    /// Bitwise OR. The result length is the longer input length.
+    member this.Or(other: Bitset) =
+        if isNull (box other) then
+            nullArg "other"
+
+        let handle = NativeMethods.bitset_c_or(this.Handle, other.Handle)
+        if handle = 0n then
+            Interop.raiseBitsetError "bitset_c_or"
+
+        new Bitset(handle)
+
+    /// Bitwise XOR. The result length is the longer input length.
+    member this.Xor(other: Bitset) =
+        if isNull (box other) then
+            nullArg "other"
+
+        let handle = NativeMethods.bitset_c_xor(this.Handle, other.Handle)
+        if handle = 0n then
+            Interop.raiseBitsetError "bitset_c_xor"
+
+        new Bitset(handle)
+
+    /// Bitwise complement within the logical length of the bitset.
+    member this.Not() =
+        let handle = NativeMethods.bitset_c_not(this.Handle)
+        if handle = 0n then
+            Interop.raiseBitsetError "bitset_c_not"
+
+        new Bitset(handle)
+
+    /// Set difference: keep bits set in this bitset that are not set in the other one.
+    member this.AndNot(other: Bitset) =
+        if isNull (box other) then
+            nullArg "other"
+
+        let handle = NativeMethods.bitset_c_and_not(this.Handle, other.Handle)
+        if handle = 0n then
+            Interop.raiseBitsetError "bitset_c_and_not"
+
+        new Bitset(handle)
+
+    /// Count how many bits are set to 1.
+    member this.PopCount() = NativeMethods.bitset_c_popcount(this.Handle) |> Interop.checkedInt "PopCount"
+
+    /// Return whether at least one bit is set.
+    member this.Any() = NativeMethods.bitset_c_any(this.Handle) <> 0uy
+
+    /// Return whether all logical bits are set.
+    member this.All() = NativeMethods.bitset_c_all(this.Handle) <> 0uy
+
+    /// Return whether no bits are set.
+    member this.None() = NativeMethods.bitset_c_none(this.Handle) <> 0uy
+
+    /// Convert to a 64-bit integer when the value fits in a single word.
+    member this.ToInteger() =
+        let mutable value = 0UL
+        if NativeMethods.bitset_c_to_u64(this.Handle, &value) <> 0uy then
+            Some value
+        else
+            None
+
+    /// Convert to a conventional binary string with the highest bit on the left.
+    member this.ToBinaryString() =
+        let length = this.Length
+
+        if length = 0 then
+            String.Empty
+        else
+            Array.init length (fun i -> if this.Test(length - 1 - i) then '1' else '0')
+            |> fun chars -> String(chars)
+
+    /// Iterate over the set-bit indices in ascending order.
+    member this.IterSetBits() : seq<int> =
+        seq {
+            let length = this.Length
+            for i in 0 .. length - 1 do
+                if this.Test(i) then
+                    yield i
+        }
+
+    /// Convenience alias for Test.
+    member this.Contains(index: int) = this.Test(index)
+
+    override this.ToString() = $"Bitset({this.ToBinaryString()})"
+
+    member this.Equals(other: Bitset) =
+        if isNull (box other) then
+            false
+        elif Object.ReferenceEquals(this, other) then
+            true
+        else
+            NativeMethods.bitset_c_equals(this.Handle, other.Handle) <> 0uy
+
+    override this.Equals(obj: obj) =
+        match obj with
+        | :? Bitset as other -> this.Equals(other)
+        | _ -> false
+
+    override this.GetHashCode() =
+        let mutable hash = HashCode.Combine(this.Length)
+
+        for bit in this.IterSetBits() do
+            hash <- HashCode.Combine(hash, bit)
+
+        hash
+
+    interface IEquatable<Bitset> with
+        member this.Equals(other) = this.Equals(other)
+
+    interface IEnumerable<int> with
+        member this.GetEnumerator() = (this.IterSetBits()).GetEnumerator()
+
+    interface IEnumerable with
+        member this.GetEnumerator() = (this.IterSetBits() :> IEnumerable).GetEnumerator()
+
+    interface IDisposable with
+        member this.Dispose() =
+            this.ReleaseHandle()
+            GC.SuppressFinalize(this)
+
+    override this.Finalize() =
+        this.ReleaseHandle()

--- a/code/packages/fsharp/bitset-native/CHANGELOG.md
+++ b/code/packages/fsharp/bitset-native/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-15
+
+### Added
+
+- Native F# wrapper over the Rust `bitset-c` library using .NET P/Invoke
+- Disposable `Bitset` API that mirrors the pure F# bitset package while delegating core operations to Rust
+- xUnit coverage for constructors, mutation, bulk operations, queries, equality, disposal, and conversion helpers

--- a/code/packages/fsharp/bitset-native/CodingAdventures.BitsetNative.fsproj
+++ b/code/packages/fsharp/bitset-native/CodingAdventures.BitsetNative.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.BitsetNative</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Native .NET wrapper over the Rust bitset crate</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="BitsetNative.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/bitset-native/README.md
+++ b/code/packages/fsharp/bitset-native/README.md
@@ -1,0 +1,35 @@
+# bitset-native
+
+Native F# wrapper over the Rust `bitset-c` library.
+
+## What It Includes
+
+- A managed `Bitset` type backed by the Rust `bitset` implementation
+- P/Invoke bindings to the `bitset-c` shared library
+- The same core API shape as the pure F# package: constructors, single-bit operations, bulk ops, queries, and conversions
+- Deterministic cleanup through `IDisposable`
+
+## Example
+
+```fsharp
+open CodingAdventures.BitsetNative
+
+use left = Bitset.FromBinaryString("1100")
+use right = Bitset.FromBinaryString("1010")
+use intersection = left.And(right)
+
+printfn "%s" (intersection.ToBinaryString()) // 1000
+```
+
+## Build Notes
+
+The package `BUILD` script first compiles `rust/bitset-c`, then runs
+`dotnet test`. The test project copies the resulting shared library into its
+output directory so the runtime loader can resolve `bitset_c`.
+
+## Development
+
+```bash
+# Run tests
+bash BUILD
+```

--- a/code/packages/fsharp/bitset-native/required_capabilities.json
+++ b/code/packages/fsharp/bitset-native/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/bitset-native",
+  "capabilities": [],
+  "justification": "Pure in-memory bitset operations through a Rust native library. No filesystem, network, process, or environment access at runtime."
+}

--- a/code/packages/fsharp/bitset-native/tests/CodingAdventures.BitsetNative.Tests/BitsetNativeTests.fs
+++ b/code/packages/fsharp/bitset-native/tests/CodingAdventures.BitsetNative.Tests/BitsetNativeTests.fs
@@ -1,0 +1,256 @@
+namespace CodingAdventures.BitsetNative.Tests
+
+open System
+open System.Collections
+open System.Collections.Generic
+open Xunit
+open CodingAdventures.BitsetNative
+
+module private Helpers =
+    let uint128 (value: string) = UInt128.Parse(value)
+
+type BitsetNativeTests() =
+    [<Fact>]
+    member _.``new tracks length capacity and empty queries``() =
+        use empty = new Bitset(0)
+        Assert.Equal(0, empty.Length)
+        Assert.Equal(0, empty.Capacity)
+        Assert.Equal(0, empty.PopCount())
+        Assert.True(empty.None())
+        Assert.True(empty.All())
+        Assert.True(empty.IsEmpty)
+        Assert.Equal(String.Empty, empty.ToBinaryString())
+        Assert.Equal(Some 0UL, empty.ToInteger())
+
+        use sized = new Bitset(65)
+        Assert.Equal(65, sized.Length)
+        Assert.Equal(128, sized.Capacity)
+        Assert.False(sized.Any())
+        Assert.False(sized.Test(64))
+
+    [<Fact>]
+    member _.``from integer supports small and cross-word values``() =
+        use five = Bitset.FromInteger(Helpers.uint128 "5")
+        Assert.Equal(3, five.Length)
+        Assert.True(five.Test(0))
+        Assert.False(five.Test(1))
+        Assert.True(five.Test(2))
+        Assert.Equal("101", five.ToBinaryString())
+        Assert.Equal(Some 5UL, five.ToInteger())
+
+        use crossWord = Bitset.FromInteger(Helpers.uint128 "18446744073709551617")
+        Assert.Equal(65, crossWord.Length)
+        Assert.True(crossWord.Test(0))
+        Assert.True(crossWord.Test(64))
+        Assert.Equal(None, crossWord.ToInteger())
+
+    [<Fact>]
+    member _.``from binary string understands conventional bit order``() =
+        use bitset = Bitset.FromBinaryString("00101")
+        Assert.Equal(5, bitset.Length)
+        Assert.True(bitset.Test(0))
+        Assert.False(bitset.Test(1))
+        Assert.True(bitset.Test(2))
+        Assert.False(bitset.Test(3))
+        Assert.False(bitset.Test(4))
+        Assert.Equal("00101", bitset.ToBinaryString())
+
+    [<Fact>]
+    member _.``from binary string rejects invalid characters``() =
+        Assert.Throws<BitsetError>(fun () -> Bitset.FromBinaryString("10x1") |> ignore)
+        |> ignore
+
+    [<Fact>]
+    member _.``set clear test and toggle handle single bits``() =
+        use bitset = new Bitset(10)
+
+        bitset.Set(5)
+        Assert.True(bitset.Test(5))
+        Assert.Equal(1, bitset.PopCount())
+
+        bitset.Set(5)
+        Assert.Equal(1, bitset.PopCount())
+
+        bitset.Clear(5)
+        Assert.False(bitset.Test(5))
+        Assert.Equal(0, bitset.PopCount())
+
+        bitset.Toggle(2)
+        Assert.True(bitset.Test(2))
+        bitset.Toggle(2)
+        Assert.False(bitset.Test(2))
+
+    [<Fact>]
+    member _.``clear and test beyond length are safe no-ops``() =
+        use bitset = new Bitset(8)
+        bitset.Set(1)
+
+        bitset.Clear(100)
+
+        Assert.True(bitset.Test(1))
+        Assert.False(bitset.Test(100))
+        Assert.Equal(8, bitset.Length)
+
+    [<Fact>]
+    member _.``set and toggle auto-grow with doubling capacity``() =
+        use bitset = new Bitset(100)
+
+        bitset.Set(200)
+
+        Assert.Equal(201, bitset.Length)
+        Assert.Equal(256, bitset.Capacity)
+        Assert.True(bitset.Test(200))
+        Assert.False(bitset.Test(199))
+
+        bitset.Toggle(500)
+        Assert.Equal(501, bitset.Length)
+        Assert.Equal(512, bitset.Capacity)
+        Assert.True(bitset.Test(500))
+
+    [<Fact>]
+    member _.``bulk operations match reference truth tables``() =
+        use left = Bitset.FromInteger(Helpers.uint128 "12")
+        use right = Bitset.FromInteger(Helpers.uint128 "10")
+        use andResult = left.And(right)
+        use orResult = left.Or(right)
+        use xorResult = left.Xor(right)
+        use andNotResult = left.AndNot(right)
+
+        Assert.Equal("1000", andResult.ToBinaryString())
+        Assert.Equal("1110", orResult.ToBinaryString())
+        Assert.Equal("0110", xorResult.ToBinaryString())
+        Assert.Equal("0100", andNotResult.ToBinaryString())
+
+    [<Fact>]
+    member _.``bulk operations zero-extend shorter inputs``() =
+        use shortBitset = Bitset.FromBinaryString("101")
+        use longBitset = Bitset.FromBinaryString("100001")
+        use orResult = shortBitset.Or(longBitset)
+        use andResult = shortBitset.And(longBitset)
+        use xorResult = shortBitset.Xor(longBitset)
+
+        Assert.Equal("100101", orResult.ToBinaryString())
+        Assert.Equal("000001", andResult.ToBinaryString())
+        Assert.Equal("100100", xorResult.ToBinaryString())
+        Assert.Equal(6, orResult.Length)
+
+    [<Fact>]
+    member _.``not only flips bits inside logical length``() =
+        use bitset = new Bitset(5)
+        bitset.Set(0)
+        bitset.Set(2)
+
+        use inverted = bitset.Not()
+        use roundTrip = inverted.Not()
+
+        Assert.Equal("11010", inverted.ToBinaryString())
+        Assert.Equal(3, inverted.PopCount())
+        Assert.False(inverted.Test(5))
+        Assert.True(bitset.Equals(roundTrip))
+
+    [<Fact>]
+    member _.``any all none and is-empty reflect current state``() =
+        use empty = new Bitset(0)
+        Assert.False(empty.Any())
+        Assert.True(empty.All())
+        Assert.True(empty.None())
+        Assert.True(empty.IsEmpty)
+
+        use partial = new Bitset(5)
+        partial.Set(0)
+        partial.Set(4)
+        Assert.True(partial.Any())
+        Assert.False(partial.All())
+        Assert.False(partial.None())
+
+        use full = Bitset.FromBinaryString("11111")
+        Assert.True(full.All())
+        Assert.False(full.None())
+
+    [<Fact>]
+    member _.``iter set bits yields ascending indices across words``() =
+        use bitset = new Bitset(130)
+        bitset.Set(0)
+        bitset.Set(2)
+        bitset.Set(64)
+        bitset.Set(129)
+
+        Assert.Equal<int array>([| 0; 2; 64; 129 |], bitset.IterSetBits() |> Seq.toArray)
+        Assert.True(bitset.Contains(64))
+
+    [<Fact>]
+    member _.``binary string round trip preserves leading zeros``() =
+        use bitset = new Bitset(8)
+        bitset.Set(0)
+        bitset.Set(7)
+
+        Assert.Equal("10000001", bitset.ToBinaryString())
+
+        use roundTrip = Bitset.FromBinaryString(bitset.ToBinaryString())
+        Assert.True(bitset.Equals(roundTrip))
+
+    [<Fact>]
+    member _.``equality uses logical bits``() =
+        use left = Bitset.FromBinaryString("101001")
+        use right = new Bitset(2)
+        right.Set(5)
+        right.Set(3)
+        right.Set(0)
+
+        Assert.True(left.Equals(right))
+        Assert.Equal(left.GetHashCode(), right.GetHashCode())
+
+    [<Fact>]
+    member _.``negative indices throw``() =
+        use bitset = new Bitset(4)
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> bitset.Set(-1)) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> bitset.Clear(-1)) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> bitset.Test(-1) |> ignore) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> bitset.Toggle(-1)) |> ignore
+
+    [<Fact>]
+    member _.``constructors and bulk operations reject invalid managed inputs``() =
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> new Bitset(-1) |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> Bitset.FromBinaryString(null) |> ignore) |> ignore
+
+        use bitset = new Bitset(4)
+        let nullBitset = null : Bitset
+
+        Assert.Throws<ArgumentNullException>(fun () -> bitset.And(nullBitset) |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> bitset.Or(nullBitset) |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> bitset.Xor(nullBitset) |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> bitset.AndNot(nullBitset) |> ignore) |> ignore
+
+    [<Fact>]
+    member _.``equality and collection interfaces use managed conventions``() =
+        use left = Bitset.FromBinaryString("101001")
+        use right = Bitset.FromBinaryString("101001")
+
+        Assert.True(left.Equals(left))
+        Assert.False(left.Equals(null : Bitset))
+        Assert.True(left.Equals(right :> obj))
+        Assert.False(left.Equals("101001" :> obj))
+        Assert.True((left :> IEquatable<Bitset>).Equals(right))
+
+        let genericEnumerator = (left :> IEnumerable<int>).GetEnumerator()
+        Assert.True(genericEnumerator.MoveNext())
+        Assert.Equal(0, genericEnumerator.Current)
+        Assert.True(genericEnumerator.MoveNext())
+        Assert.Equal(3, genericEnumerator.Current)
+
+        let nongenericEnumerator = (left :> IEnumerable).GetEnumerator()
+        Assert.True(nongenericEnumerator.MoveNext())
+        Assert.Equal(box 0, nongenericEnumerator.Current)
+
+    [<Fact>]
+    member _.``dispose prevents further use``() =
+        let bitset = new Bitset(4)
+        (bitset :> IDisposable).Dispose()
+        (bitset :> IDisposable).Dispose()
+
+        Assert.Throws<ObjectDisposedException>(fun () -> bitset.Set(0)) |> ignore
+
+    [<Fact>]
+    member _.``to string uses binary form``() =
+        use bitset = Bitset.FromBinaryString("101")
+        Assert.Equal("Bitset(101)", bitset.ToString())

--- a/code/packages/fsharp/bitset-native/tests/CodingAdventures.BitsetNative.Tests/CodingAdventures.BitsetNative.Tests.fsproj
+++ b/code/packages/fsharp/bitset-native/tests/CodingAdventures.BitsetNative.Tests/CodingAdventures.BitsetNative.Tests.fsproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.BitsetNative.fsproj" />
+    <Compile Include="BitsetNativeTests.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <NativeBitsetLibrary Include="../../../../rust/target/release/libbitset_c.dylib" Condition="Exists('../../../../rust/target/release/libbitset_c.dylib')" />
+    <NativeBitsetLibrary Include="../../../../rust/target/release/libbitset_c.so" Condition="Exists('../../../../rust/target/release/libbitset_c.so')" />
+    <NativeBitsetLibrary Include="../../../../rust/target/release/bitset_c.dll" Condition="Exists('../../../../rust/target/release/bitset_c.dll')" />
+  </ItemGroup>
+
+  <Target Name="CopyBitsetNativeLibrary" AfterTargets="Build">
+    <Copy SourceFiles="@(NativeBitsetLibrary)" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
+  </Target>
+</Project>

--- a/code/packages/fsharp/bitset/BUILD
+++ b/code/packages/fsharp/bitset/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Bitset.Tests/CodingAdventures.Bitset.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/bitset/BUILD_windows
+++ b/code/packages/fsharp/bitset/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Bitset.Tests/CodingAdventures.Bitset.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/bitset/Bitset.fs
+++ b/code/packages/fsharp/bitset/Bitset.fs
@@ -1,0 +1,360 @@
+namespace CodingAdventures.Bitset
+
+open System
+open System.Collections
+open System.Collections.Generic
+open System.Numerics
+
+module private BitsetHelpers =
+    [<Literal>]
+    let BitsPerWord = 64
+
+    let wordsNeeded bitCount =
+        if bitCount = 0 then
+            0
+        else
+            ((bitCount - 1) / BitsPerWord) + 1
+
+    let wordIndex index = index / BitsPerWord
+
+    let bitmask index = 1UL <<< (index % BitsPerWord)
+
+    let trailingMask bitCount =
+        if bitCount = BitsPerWord then
+            UInt64.MaxValue
+        else
+            (1UL <<< bitCount) - 1UL
+
+    let validateIndex index =
+        if index < 0 then
+            raise (ArgumentOutOfRangeException("index", "Bit indices cannot be negative."))
+
+// Bitset.fs -- Dense boolean arrays for the .NET side of the repo
+// ================================================================
+//
+// The bitset packages are foundation pieces, so the implementation is careful
+// about two invariants:
+//
+//   1. bits are stored LSB-first inside 64-bit words
+//   2. any bits beyond Length are always kept at zero
+//
+// That second rule matters more than it first appears. It keeps popcount,
+// equality, binary-string conversion, and logical queries trustworthy even when
+// the underlying storage has grown beyond the current logical tail.
+
+/// Raised when a binary-string constructor receives characters other than 0 and 1.
+type BitsetError(input: string) =
+    inherit Exception($"Invalid binary string: \"{input}\".")
+
+    member _.Input = input
+
+/// A compact boolean array packed into 64-bit words.
+type Bitset(size: int) =
+    let words = ResizeArray<uint64>(BitsetHelpers.wordsNeeded size)
+    let mutable length = 0
+
+    do
+        if size < 0 then
+            raise (ArgumentOutOfRangeException("size", "Bitset size cannot be negative."))
+
+        length <- size
+
+        for _ in 1 .. BitsetHelpers.wordsNeeded size do
+            words.Add 0UL
+
+    new() = Bitset(0)
+
+    static member FromInteger(value: UInt128) =
+        if value = UInt128.Zero then
+            Bitset(0)
+        else
+            let low = uint64 value
+            let high = uint64 (value >>> 64)
+
+            let logicalLength =
+                if high <> 0UL then
+                    64 + (64 - BitOperations.LeadingZeroCount(high))
+                else
+                    64 - BitOperations.LeadingZeroCount(low)
+
+            let bitset = Bitset(logicalLength)
+            bitset.SetWord(0, low)
+
+            if high <> 0UL then
+                bitset.SetWord(1, high)
+
+            bitset.CleanTrailingBits()
+            bitset
+
+    static member FromBinaryString(value: string) =
+        if isNull value then
+            nullArg "value"
+
+        if value |> Seq.exists (fun ch -> ch <> '0' && ch <> '1') then
+            raise (BitsetError(value))
+
+        let bitset = Bitset(value.Length)
+
+        for bitIndex in 0 .. value.Length - 1 do
+            let ch = value[value.Length - 1 - bitIndex]
+            if ch = '1' then
+                let wi = BitsetHelpers.wordIndex bitIndex
+                bitset.SetWord(wi, bitset.GetWord(wi) ||| BitsetHelpers.bitmask bitIndex)
+
+        bitset.CleanTrailingBits()
+        bitset
+
+    /// Logical size: the number of addressable bits.
+    member _.Length = length
+
+    /// Allocated size rounded to a multiple of 64.
+    member _.Capacity = words.Count * BitsetHelpers.BitsPerWord
+
+    /// Whether the bitset has zero logical length.
+    member _.IsEmpty = (length = 0)
+
+    /// Set a bit to 1, growing the bitset if needed.
+    member this.Set(index: int) =
+        this.EnsureCapacity(index)
+        let wi = BitsetHelpers.wordIndex index
+        this.SetWord(wi, this.GetWord(wi) ||| BitsetHelpers.bitmask index)
+
+    /// Set a bit to 0. Clearing beyond the current length is a no-op.
+    member this.Clear(index: int) =
+        BitsetHelpers.validateIndex index
+
+        if index < length then
+            let wi = BitsetHelpers.wordIndex index
+            this.SetWord(wi, this.GetWord(wi) &&& (~~~(BitsetHelpers.bitmask index)))
+
+    /// Test whether a bit is set. Testing beyond the current length returns false.
+    member this.Test(index: int) =
+        BitsetHelpers.validateIndex index
+
+        if index >= length then
+            false
+        else
+            let wi = BitsetHelpers.wordIndex index
+            (this.GetWord(wi) &&& BitsetHelpers.bitmask index) <> 0UL
+
+    /// Flip a bit, growing the bitset if needed.
+    member this.Toggle(index: int) =
+        this.EnsureCapacity(index)
+        let wi = BitsetHelpers.wordIndex index
+        this.SetWord(wi, this.GetWord(wi) ^^^ BitsetHelpers.bitmask index)
+        this.CleanTrailingBits()
+
+    /// Bitwise AND. The result length is the longer input length.
+    member this.And(other: Bitset) =
+        this.BinaryOp(other, fun left right -> left &&& right)
+
+    /// Bitwise OR. The result length is the longer input length.
+    member this.Or(other: Bitset) =
+        this.BinaryOp(other, fun left right -> left ||| right)
+
+    /// Bitwise XOR. The result length is the longer input length.
+    member this.Xor(other: Bitset) =
+        this.BinaryOp(other, fun left right -> left ^^^ right)
+
+    /// Bitwise complement within the logical length of the bitset.
+    member this.Not() =
+        let result = Bitset(length)
+
+        for wi in 0 .. BitsetHelpers.wordsNeeded length - 1 do
+            result.SetWord(wi, ~~~(this.GetWord(wi)))
+
+        result.CleanTrailingBits()
+        result
+
+    /// Set difference: keep bits set in this bitset that are not set in the other one.
+    member this.AndNot(other: Bitset) =
+        this.BinaryOp(other, fun left right -> left &&& (~~~right))
+
+    /// Count how many bits are set to 1.
+    member this.PopCount() =
+        let mutable count = 0
+
+        for wi in 0 .. BitsetHelpers.wordsNeeded length - 1 do
+            count <- count + BitOperations.PopCount(this.GetWord(wi))
+
+        count
+
+    /// Return whether at least one bit is set.
+    member this.Any() =
+        let mutable found = false
+        let mutable wi = 0
+        let relevantWords = BitsetHelpers.wordsNeeded length
+
+        while not found && wi < relevantWords do
+            if this.GetWord(wi) <> 0UL then
+                found <- true
+
+            wi <- wi + 1
+
+        found
+
+    /// Return whether every logical bit is set. Empty bitsets satisfy this vacuously.
+    member this.All() =
+        if length = 0 then
+            true
+        else
+            let fullWords = length / BitsetHelpers.BitsPerWord
+            let mutable allSet = true
+            let mutable wi = 0
+
+            while allSet && wi < fullWords do
+                if this.GetWord(wi) <> UInt64.MaxValue then
+                    allSet <- false
+
+                wi <- wi + 1
+
+            if not allSet then
+                false
+            else
+                let remainingBits = length % BitsetHelpers.BitsPerWord
+                if remainingBits = 0 then
+                    true
+                else
+                    this.GetWord(fullWords) = BitsetHelpers.trailingMask remainingBits
+
+    /// Return whether no bits are set.
+    member this.None() = not (this.Any())
+
+    /// Iterate over the set-bit indices in ascending order.
+    member this.IterSetBits() : seq<int> =
+        seq {
+            for wi in 0 .. BitsetHelpers.wordsNeeded length - 1 do
+                let mutable word = this.GetWord(wi)
+
+                while word <> 0UL do
+                    let offset = BitOperations.TrailingZeroCount(word)
+                    yield (wi * BitsetHelpers.BitsPerWord) + offset
+                    word <- word &&& (word - 1UL)
+        }
+
+    /// Convert to a 64-bit integer when the value fits in a single word.
+    member this.ToInteger() : uint64 option =
+        let relevantWords = BitsetHelpers.wordsNeeded length
+
+        if relevantWords = 0 then
+            Some 0UL
+        else
+            let mutable fits = true
+            let mutable wi = 1
+
+            while fits && wi < relevantWords do
+                if this.GetWord(wi) <> 0UL then
+                    fits <- false
+
+                wi <- wi + 1
+
+            if fits then
+                Some(this.GetWord(0))
+            else
+                None
+
+    /// Convert to a conventional binary string with the highest bit on the left.
+    member this.ToBinaryString() =
+        if length = 0 then
+            String.Empty
+        else
+            Array.init length (fun i -> if this.Test(length - 1 - i) then '1' else '0')
+            |> fun chars -> String(chars)
+
+    /// Convenience alias for Test.
+    member this.Contains(index: int) = this.Test(index)
+
+    override this.ToString() = $"Bitset({this.ToBinaryString()})"
+
+    member this.Equals(other: Bitset) =
+        if isNull (box other) || length <> other.Length then
+            false
+        else
+            let relevantWords = BitsetHelpers.wordsNeeded length
+            let mutable equal = true
+            let mutable wi = 0
+
+            while equal && wi < relevantWords do
+                if this.GetWord(wi) <> other.GetWord(wi) then
+                    equal <- false
+
+                wi <- wi + 1
+
+            equal
+
+    override this.Equals(obj: obj) =
+        match obj with
+        | :? Bitset as other -> this.Equals(other)
+        | _ -> false
+
+    override _.GetHashCode() =
+        let mutable hash = HashCode.Combine(length)
+
+        for wi in 0 .. BitsetHelpers.wordsNeeded length - 1 do
+            hash <- HashCode.Combine(hash, words[wi])
+
+        hash
+
+    interface IEquatable<Bitset> with
+        member this.Equals(other) = this.Equals(other)
+
+    interface IEnumerable<int> with
+        member this.GetEnumerator() = (this.IterSetBits()).GetEnumerator()
+
+    interface IEnumerable with
+        member this.GetEnumerator() = (this.IterSetBits() :> IEnumerable).GetEnumerator()
+
+    member private _.GetWord(index: int) =
+        if index < words.Count then
+            words[index]
+        else
+            0UL
+
+    member private _.SetWord(index: int, value: uint64) =
+        words[index] <- value
+
+    member private this.BinaryOp(other: Bitset, operation: uint64 -> uint64 -> uint64) =
+        if isNull (box other) then
+            nullArg "other"
+
+        let resultLength = max length other.Length
+        let result = Bitset(resultLength)
+
+        for wi in 0 .. BitsetHelpers.wordsNeeded resultLength - 1 do
+            result.SetWord(wi, operation (this.GetWord(wi)) (other.GetWord(wi)))
+
+        result.CleanTrailingBits()
+        result
+
+    member private this.EnsureCapacity(index: int) =
+        BitsetHelpers.validateIndex index
+
+        if index >= this.Capacity then
+            let mutable newCapacity =
+                if this.Capacity = 0 then
+                    BitsetHelpers.BitsPerWord
+                else
+                    this.Capacity
+
+            while index >= newCapacity do
+                newCapacity <- newCapacity * 2
+
+            let targetWords = BitsetHelpers.wordsNeeded newCapacity
+
+            while words.Count < targetWords do
+                words.Add 0UL
+
+        if index + 1 > length then
+            length <- index + 1
+
+    member private _.CleanTrailingBits() =
+        let relevantWords = BitsetHelpers.wordsNeeded length
+
+        for wi in relevantWords .. words.Count - 1 do
+            words[wi] <- 0UL
+
+        if relevantWords > 0 then
+            let remainingBits = length % BitsetHelpers.BitsPerWord
+
+            if remainingBits <> 0 then
+                words[relevantWords - 1] <- words[relevantWords - 1] &&& BitsetHelpers.trailingMask remainingBits

--- a/code/packages/fsharp/bitset/CHANGELOG.md
+++ b/code/packages/fsharp/bitset/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-15
+
+### Added
+
+- Literate F# bitset implementation with dynamic growth, bulk bitwise operations, conversions, and set-bit iteration
+- Spec-style xUnit coverage for constructors, single-bit operations, growth, bulk ops, queries, conversions, equality, and edge cases

--- a/code/packages/fsharp/bitset/CodingAdventures.Bitset.fsproj
+++ b/code/packages/fsharp/bitset/CodingAdventures.Bitset.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Bitset</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Compact boolean array packed into 64-bit words</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Bitset.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/bitset/README.md
+++ b/code/packages/fsharp/bitset/README.md
@@ -1,0 +1,34 @@
+# bitset
+
+Compact boolean arrays packed into 64-bit words for space-efficient storage and fast bulk bitwise operations.
+
+## Layer 1
+
+This package is part of Layer 1 of the coding-adventures computing stack.
+
+## What It Includes
+
+- Dynamic growth when `Set` or `Toggle` reach beyond the current logical length
+- Bulk bitwise operations: `And`, `Or`, `Xor`, `Not`, and `AndNot`
+- Counting and queries: `PopCount`, `Any`, `All`, `None`, `Length`, and `Capacity`
+- Conversions to and from binary strings plus 64-bit integer conversion when the value fits
+- Efficient iteration over set-bit indices using trailing-zero counting
+
+## Example
+
+```fsharp
+open CodingAdventures.Bitset
+
+let left = Bitset.FromBinaryString("1100")
+let right = Bitset.FromBinaryString("1010")
+
+let intersection = left.And(right)
+printfn "%s" (intersection.ToBinaryString()) // 1000
+```
+
+## Development
+
+```bash
+# Run tests
+bash BUILD
+```

--- a/code/packages/fsharp/bitset/required_capabilities.json
+++ b/code/packages/fsharp/bitset/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/bitset",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/bitset/tests/CodingAdventures.Bitset.Tests/BitsetTests.fs
+++ b/code/packages/fsharp/bitset/tests/CodingAdventures.Bitset.Tests/BitsetTests.fs
@@ -1,0 +1,201 @@
+namespace CodingAdventures.Bitset.Tests
+
+open System
+open Xunit
+open CodingAdventures.Bitset
+
+type BitsetTests() =
+    let uint128 value = UInt128.Parse(value)
+
+    [<Fact>]
+    member _.``new tracks length capacity and empty queries``() =
+        let empty = Bitset(0)
+        Assert.Equal(0, empty.Length)
+        Assert.Equal(0, empty.Capacity)
+        Assert.Equal(0, empty.PopCount())
+        Assert.True(empty.None())
+        Assert.True(empty.All())
+        Assert.True(empty.IsEmpty)
+        Assert.Equal(String.Empty, empty.ToBinaryString())
+        Assert.Equal(Some 0UL, empty.ToInteger())
+
+        let sized = Bitset(65)
+        Assert.Equal(65, sized.Length)
+        Assert.Equal(128, sized.Capacity)
+        Assert.False(sized.Any())
+        Assert.False(sized.Test(64))
+
+    [<Fact>]
+    member _.``from integer supports small and cross-word values``() =
+        let five = Bitset.FromInteger(uint128 "5")
+        Assert.Equal(3, five.Length)
+        Assert.True(five.Test(0))
+        Assert.False(five.Test(1))
+        Assert.True(five.Test(2))
+        Assert.Equal("101", five.ToBinaryString())
+        Assert.Equal(Some 5UL, five.ToInteger())
+
+        let crossWord = Bitset.FromInteger(uint128 "18446744073709551617")
+        Assert.Equal(65, crossWord.Length)
+        Assert.True(crossWord.Test(0))
+        Assert.True(crossWord.Test(64))
+        Assert.Equal(None, crossWord.ToInteger())
+
+    [<Fact>]
+    member _.``from binary string understands conventional bit order``() =
+        let bitset = Bitset.FromBinaryString("00101")
+        Assert.Equal(5, bitset.Length)
+        Assert.True(bitset.Test(0))
+        Assert.False(bitset.Test(1))
+        Assert.True(bitset.Test(2))
+        Assert.False(bitset.Test(3))
+        Assert.False(bitset.Test(4))
+        Assert.Equal("00101", bitset.ToBinaryString())
+
+    [<Fact>]
+    member _.``from binary string rejects invalid characters``() =
+        Assert.Throws<BitsetError>(fun () -> Bitset.FromBinaryString("10x1") |> ignore)
+        |> ignore
+
+    [<Fact>]
+    member _.``set clear test and toggle handle single bits``() =
+        let bitset = Bitset(10)
+
+        bitset.Set(5)
+        Assert.True(bitset.Test(5))
+        Assert.Equal(1, bitset.PopCount())
+
+        bitset.Set(5)
+        Assert.Equal(1, bitset.PopCount())
+
+        bitset.Clear(5)
+        Assert.False(bitset.Test(5))
+        Assert.Equal(0, bitset.PopCount())
+
+        bitset.Toggle(2)
+        Assert.True(bitset.Test(2))
+        bitset.Toggle(2)
+        Assert.False(bitset.Test(2))
+
+    [<Fact>]
+    member _.``clear and test beyond length are safe no-ops``() =
+        let bitset = Bitset(8)
+        bitset.Set(1)
+
+        bitset.Clear(100)
+
+        Assert.True(bitset.Test(1))
+        Assert.False(bitset.Test(100))
+        Assert.Equal(8, bitset.Length)
+
+    [<Fact>]
+    member _.``set and toggle auto-grow with doubling capacity``() =
+        let bitset = Bitset(100)
+
+        bitset.Set(200)
+
+        Assert.Equal(201, bitset.Length)
+        Assert.Equal(256, bitset.Capacity)
+        Assert.True(bitset.Test(200))
+        Assert.False(bitset.Test(199))
+
+        bitset.Toggle(500)
+        Assert.Equal(501, bitset.Length)
+        Assert.Equal(512, bitset.Capacity)
+        Assert.True(bitset.Test(500))
+
+    [<Fact>]
+    member _.``bulk operations match reference truth tables``() =
+        let left = Bitset.FromInteger(uint128 "12")
+        let right = Bitset.FromInteger(uint128 "10")
+
+        Assert.Equal("1000", left.And(right).ToBinaryString())
+        Assert.Equal("1110", left.Or(right).ToBinaryString())
+        Assert.Equal("0110", left.Xor(right).ToBinaryString())
+        Assert.Equal("0100", left.AndNot(right).ToBinaryString())
+
+    [<Fact>]
+    member _.``bulk operations zero-extend shorter inputs``() =
+        let shortBitset = Bitset.FromBinaryString("101")
+        let longBitset = Bitset.FromBinaryString("100001")
+
+        Assert.Equal("100101", shortBitset.Or(longBitset).ToBinaryString())
+        Assert.Equal("000001", shortBitset.And(longBitset).ToBinaryString())
+        Assert.Equal("100100", shortBitset.Xor(longBitset).ToBinaryString())
+        Assert.Equal(6, shortBitset.Or(longBitset).Length)
+
+    [<Fact>]
+    member _.``not only flips bits inside logical length``() =
+        let bitset = Bitset(5)
+        bitset.Set(0)
+        bitset.Set(2)
+
+        let inverted = bitset.Not()
+
+        Assert.Equal("11010", inverted.ToBinaryString())
+        Assert.Equal(3, inverted.PopCount())
+        Assert.False(inverted.Test(5))
+        Assert.True(bitset.Equals(inverted.Not()))
+
+    [<Fact>]
+    member _.``any all none and is-empty reflect current state``() =
+        let empty = Bitset(0)
+        Assert.False(empty.Any())
+        Assert.True(empty.All())
+        Assert.True(empty.None())
+        Assert.True(empty.IsEmpty)
+
+        let partial = Bitset(5)
+        partial.Set(0)
+        partial.Set(4)
+        Assert.True(partial.Any())
+        Assert.False(partial.All())
+        Assert.False(partial.None())
+
+        let full = Bitset.FromBinaryString("11111")
+        Assert.True(full.All())
+        Assert.False(full.None())
+
+    [<Fact>]
+    member _.``iter set bits yields ascending indices across words``() =
+        let bitset = Bitset(130)
+        bitset.Set(0)
+        bitset.Set(2)
+        bitset.Set(64)
+        bitset.Set(129)
+
+        Assert.Equal<int array>([| 0; 2; 64; 129 |], bitset.IterSetBits() |> Seq.toArray)
+        Assert.True(bitset.Contains(64))
+
+    [<Fact>]
+    member _.``binary string round trip preserves leading zeros``() =
+        let bitset = Bitset(8)
+        bitset.Set(0)
+        bitset.Set(7)
+
+        Assert.Equal("10000001", bitset.ToBinaryString())
+        Assert.True(bitset.Equals(Bitset.FromBinaryString(bitset.ToBinaryString())))
+
+    [<Fact>]
+    member _.``equality uses logical bits``() =
+        let left = Bitset.FromBinaryString("101001")
+        let right = Bitset(2)
+        right.Set(5)
+        right.Set(3)
+        right.Set(0)
+
+        Assert.True(left.Equals(right))
+        Assert.Equal(left.GetHashCode(), right.GetHashCode())
+
+    [<Fact>]
+    member _.``negative indices throw``() =
+        let bitset = Bitset(4)
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> bitset.Set(-1)) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> bitset.Clear(-1)) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> bitset.Test(-1) |> ignore) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> bitset.Toggle(-1)) |> ignore
+
+    [<Fact>]
+    member _.``to string uses binary form``() =
+        let bitset = Bitset.FromBinaryString("101")
+        Assert.Equal("Bitset(101)", bitset.ToString())

--- a/code/packages/fsharp/bitset/tests/CodingAdventures.Bitset.Tests/CodingAdventures.Bitset.Tests.fsproj
+++ b/code/packages/fsharp/bitset/tests/CodingAdventures.Bitset.Tests/CodingAdventures.Bitset.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Bitset.fsproj" />
+    <Compile Include="BitsetTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -282,4 +282,5 @@ members = [
     "intel-4004-assembler",
     "intel-4004-packager",
     "nib-compiler",
+  "bitset-c",
 ]

--- a/code/packages/rust/bitset-c/BUILD
+++ b/code/packages/rust/bitset-c/BUILD
@@ -1,0 +1,1 @@
+cargo test -p bitset-c -- --nocapture

--- a/code/packages/rust/bitset-c/BUILD_windows
+++ b/code/packages/rust/bitset-c/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p bitset-c -- --nocapture

--- a/code/packages/rust/bitset-c/CHANGELOG.md
+++ b/code/packages/rust/bitset-c/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-15
+
+### Added
+
+- Stable C ABI wrapper around the Rust `bitset` crate using opaque handles
+- Error reporting helpers for invalid binary strings, null handles, invalid UTF-8, size overflow, and panic containment
+- Unit tests that exercise handle lifecycle, mutation, bulk operations, integer conversion, and error propagation

--- a/code/packages/rust/bitset-c/Cargo.toml
+++ b/code/packages/rust/bitset-c/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "bitset-c"
+version = "0.1.0"
+edition = "2021"
+description = "C ABI wrapper for the Rust bitset crate — for .NET/C interop"
+license = "MIT"
+
+[lib]
+crate-type = ["staticlib", "cdylib"]
+
+[dependencies]
+bitset = { path = "../bitset" }

--- a/code/packages/rust/bitset-c/README.md
+++ b/code/packages/rust/bitset-c/README.md
@@ -1,0 +1,49 @@
+# bitset-c
+
+A Rust crate that wraps the `bitset` crate in a stable C ABI so C, C++, Swift,
+and .NET callers can reuse the Rust implementation through a thin FFI layer.
+
+## What This Crate Exports
+
+- Opaque `bitset_c` handles for native callers
+- Constructors from size, `u128` split into two `u64`s, and binary strings
+- In-place single-bit operations: `set`, `clear`, `test`, `toggle`
+- Bulk operations that return fresh handles: AND, OR, XOR, NOT, AND-NOT
+- Query helpers: `len`, `capacity`, `popcount`, `any`, `all`, `none`, `is_empty`
+- Conversion helpers: `to_u64`, equality, and thread-local error inspection
+
+## Error Model
+
+The ABI catches Rust panics before they can unwind through a C frame, because
+that would be undefined behaviour. Functions that fail return a sentinel
+(`NULL`, `0`, or `false`) and store per-thread error information retrievable via:
+
+- `bitset_c_had_error()`
+- `bitset_c_last_error_code()`
+- `bitset_c_last_error_message()`
+
+## Build
+
+```bash
+cargo build --release
+```
+
+This produces:
+
+- `target/release/libbitset_c.dylib` on macOS
+- `target/release/libbitset_c.so` on Linux
+- `target/release/bitset_c.dll` on Windows
+
+The package also emits a static library (`staticlib`) for compile-time linkage
+scenarios.
+
+## Header
+
+The public C declarations live in `include/bitset_c.h`.
+
+## Development
+
+```bash
+# Run tests
+bash BUILD
+```

--- a/code/packages/rust/bitset-c/include/bitset_c.h
+++ b/code/packages/rust/bitset-c/include/bitset_c.h
@@ -1,0 +1,77 @@
+/*
+ * bitset_c.h -- C declarations for the Rust bitset-c library.
+ *
+ * This header describes the stable C ABI exposed by the Rust `bitset-c`
+ * wrapper crate. The underlying implementation lives in the pure Rust
+ * `bitset` crate; this layer simply translates between native callers and the
+ * Rust data structure.
+ *
+ * HANDLE MODEL
+ * ------------
+ * Bitsets are opaque heap-allocated handles. Create them with one of the
+ * constructor functions and release them with `bitset_c_free`.
+ *
+ * ERROR MODEL
+ * -----------
+ * Functions that fail return a sentinel value (`NULL`, `0`, or false) and set
+ * thread-local error information. Read it immediately via:
+ *
+ *   bitset_c_had_error()
+ *   bitset_c_last_error_code()
+ *   bitset_c_last_error_message()
+ *
+ * Error codes:
+ *   0 = no error
+ *   1 = invalid binary string
+ *   2 = null pointer
+ *   3 = invalid UTF-8
+ *   4 = value too large for this platform
+ *   5 = caught Rust panic
+ */
+
+#ifndef BITSET_C_H
+#define BITSET_C_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct bitset_c_handle bitset_c_handle;
+
+bitset_c_handle *bitset_c_new(uint64_t size);
+bitset_c_handle *bitset_c_from_u128(uint64_t low, uint64_t high);
+bitset_c_handle *bitset_c_from_binary_str(const char *binary);
+void bitset_c_free(bitset_c_handle *handle);
+
+void bitset_c_set(bitset_c_handle *handle, uint64_t index);
+void bitset_c_clear(bitset_c_handle *handle, uint64_t index);
+uint8_t bitset_c_test(const bitset_c_handle *handle, uint64_t index);
+void bitset_c_toggle(bitset_c_handle *handle, uint64_t index);
+
+bitset_c_handle *bitset_c_and(const bitset_c_handle *left, const bitset_c_handle *right);
+bitset_c_handle *bitset_c_or(const bitset_c_handle *left, const bitset_c_handle *right);
+bitset_c_handle *bitset_c_xor(const bitset_c_handle *left, const bitset_c_handle *right);
+bitset_c_handle *bitset_c_not(const bitset_c_handle *handle);
+bitset_c_handle *bitset_c_and_not(const bitset_c_handle *left, const bitset_c_handle *right);
+
+uint64_t bitset_c_popcount(const bitset_c_handle *handle);
+uint64_t bitset_c_len(const bitset_c_handle *handle);
+uint64_t bitset_c_capacity(const bitset_c_handle *handle);
+uint8_t bitset_c_any(const bitset_c_handle *handle);
+uint8_t bitset_c_all(const bitset_c_handle *handle);
+uint8_t bitset_c_none(const bitset_c_handle *handle);
+uint8_t bitset_c_is_empty(const bitset_c_handle *handle);
+uint8_t bitset_c_to_u64(const bitset_c_handle *handle, uint64_t *out);
+uint8_t bitset_c_equals(const bitset_c_handle *left, const bitset_c_handle *right);
+
+uint8_t bitset_c_had_error(void);
+uint32_t bitset_c_last_error_code(void);
+const char *bitset_c_last_error_message(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BITSET_C_H */

--- a/code/packages/rust/bitset-c/src/lib.rs
+++ b/code/packages/rust/bitset-c/src/lib.rs
@@ -1,0 +1,501 @@
+//! # bitset-c — Stable C ABI wrapper for the `bitset` crate.
+//!
+//! The pure Rust `bitset` crate is already the canonical implementation for
+//! compact boolean arrays in this repo. This wrapper turns that implementation
+//! into a small C ABI so higher-level runtimes can reuse it without embedding
+//! Rust-specific concepts like iterators or unwinding panics.
+//!
+//! ## Why use opaque handles?
+//!
+//! C callers cannot own a Rust `Bitset` value directly because its layout is
+//! not part of Rust's stability guarantees. Instead, each bitset lives on the
+//! heap behind an opaque pointer. Callers create a handle, call exported
+//! functions, and finally release it with `bitset_c_free`.
+//!
+//! ## Why thread-local error state?
+//!
+//! Several constructors can fail (`from_binary_str`, null pointers, invalid
+//! UTF-8, values larger than the local platform can index). Those failures are
+//! reported through a familiar FFI pattern:
+//!
+//! 1. the function returns a sentinel (`NULL`, `0`, or `false`)
+//! 2. it stores an error code and message in thread-local state
+//! 3. the caller immediately reads that error state
+//!
+//! This avoids cross-FFI heap ownership while still giving managed callers a
+//! useful error message to surface as an exception.
+
+use bitset::{Bitset, BitsetError};
+use std::cell::{Cell, RefCell};
+use std::ffi::{c_char, CStr, CString};
+use std::panic::{self, AssertUnwindSafe};
+use std::ptr;
+
+thread_local! {
+    static LAST_ERROR_CODE: Cell<u32> = const { Cell::new(0) };
+    static LAST_ERROR_MESSAGE: RefCell<Option<CString>> = RefCell::new(None);
+}
+
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ErrorCode {
+    None = 0,
+    InvalidBinaryString = 1,
+    NullPointer = 2,
+    InvalidUtf8 = 3,
+    ValueTooLarge = 4,
+    Panic = 5,
+}
+
+pub struct BitsetHandle {
+    inner: Bitset,
+}
+
+fn clear_error() {
+    LAST_ERROR_CODE.with(|slot| slot.set(ErrorCode::None as u32));
+    LAST_ERROR_MESSAGE.with(|slot| *slot.borrow_mut() = None);
+}
+
+fn sanitize_message(message: &str) -> CString {
+    match CString::new(message) {
+        Ok(message) => message,
+        Err(_) => CString::new(message.replace('\0', " ")).expect("nul-stripped message must be a valid CString"),
+    }
+}
+
+fn set_error(code: ErrorCode, message: impl AsRef<str>) {
+    LAST_ERROR_CODE.with(|slot| slot.set(code as u32));
+    LAST_ERROR_MESSAGE.with(|slot| *slot.borrow_mut() = Some(sanitize_message(message.as_ref())));
+}
+
+fn catch_ptr(operation: impl FnOnce() -> *mut BitsetHandle) -> *mut BitsetHandle {
+    clear_error();
+    match panic::catch_unwind(AssertUnwindSafe(operation)) {
+        Ok(result) => result,
+        Err(_) => {
+            set_error(ErrorCode::Panic, "bitset-c caught a Rust panic before it crossed the C ABI boundary.");
+            ptr::null_mut()
+        }
+    }
+}
+
+fn catch_u64(operation: impl FnOnce() -> u64) -> u64 {
+    clear_error();
+    match panic::catch_unwind(AssertUnwindSafe(operation)) {
+        Ok(result) => result,
+        Err(_) => {
+            set_error(ErrorCode::Panic, "bitset-c caught a Rust panic before it crossed the C ABI boundary.");
+            0
+        }
+    }
+}
+
+fn catch_u8(operation: impl FnOnce() -> u8) -> u8 {
+    clear_error();
+    match panic::catch_unwind(AssertUnwindSafe(operation)) {
+        Ok(result) => result,
+        Err(_) => {
+            set_error(ErrorCode::Panic, "bitset-c caught a Rust panic before it crossed the C ABI boundary.");
+            0
+        }
+    }
+}
+
+fn catch_void(operation: impl FnOnce()) {
+    clear_error();
+    if panic::catch_unwind(AssertUnwindSafe(operation)).is_err() {
+        set_error(ErrorCode::Panic, "bitset-c caught a Rust panic before it crossed the C ABI boundary.");
+    }
+}
+
+fn usize_from_u64(value: u64) -> Result<usize, ()> {
+    usize::try_from(value).map_err(|_| {
+        set_error(
+            ErrorCode::ValueTooLarge,
+            format!("value {value} does not fit into this platform's usize."),
+        );
+    })
+}
+
+unsafe fn bitset_ref<'a>(handle: *const BitsetHandle, operation: &str) -> Result<&'a Bitset, ()> {
+    unsafe { handle.as_ref() }
+        .map(|handle| &handle.inner)
+        .ok_or_else(|| {
+            set_error(ErrorCode::NullPointer, format!("{operation} received a null bitset handle."));
+        })
+}
+
+unsafe fn bitset_mut<'a>(handle: *mut BitsetHandle, operation: &str) -> Result<&'a mut Bitset, ()> {
+    unsafe { handle.as_mut() }
+        .map(|handle| &mut handle.inner)
+        .ok_or_else(|| {
+            set_error(ErrorCode::NullPointer, format!("{operation} received a null bitset handle."));
+        })
+}
+
+fn wrap_bitset(bitset: Bitset) -> *mut BitsetHandle {
+    Box::into_raw(Box::new(BitsetHandle { inner: bitset }))
+}
+
+fn build_u128(low: u64, high: u64) -> u128 {
+    ((high as u128) << 64) | (low as u128)
+}
+
+fn message_for_bitset_error(error: &BitsetError) -> String {
+    match error {
+        BitsetError::InvalidBinaryString(value) => format!("invalid binary string: {:?}", value),
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn bitset_c_new(size: u64) -> *mut BitsetHandle {
+    catch_ptr(|| {
+        usize_from_u64(size)
+            .map(|size| wrap_bitset(Bitset::new(size)))
+            .unwrap_or(ptr::null_mut())
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn bitset_c_from_u128(low: u64, high: u64) -> *mut BitsetHandle {
+    catch_ptr(|| wrap_bitset(Bitset::from_integer(build_u128(low, high))))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn bitset_c_from_binary_str(binary: *const c_char) -> *mut BitsetHandle {
+    catch_ptr(|| {
+        if binary.is_null() {
+            set_error(ErrorCode::NullPointer, "bitset_c_from_binary_str requires a non-null string pointer.");
+            ptr::null_mut()
+        } else {
+            let binary = match unsafe { CStr::from_ptr(binary) }.to_str() {
+                Ok(binary) => binary,
+                Err(_) => {
+                    set_error(ErrorCode::InvalidUtf8, "bitset_c_from_binary_str requires valid UTF-8 input.");
+                    return ptr::null_mut();
+                }
+            };
+
+            match Bitset::from_binary_str(binary) {
+                Ok(bitset) => wrap_bitset(bitset),
+                Err(error) => {
+                    set_error(ErrorCode::InvalidBinaryString, message_for_bitset_error(&error));
+                    ptr::null_mut()
+                }
+            }
+        }
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn bitset_c_free(handle: *mut BitsetHandle) {
+    if !handle.is_null() {
+        drop(unsafe { Box::from_raw(handle) });
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn bitset_c_set(handle: *mut BitsetHandle, index: u64) {
+    catch_void(|| {
+        if let (Ok(bitset), Ok(index)) = (unsafe { bitset_mut(handle, "bitset_c_set") }, usize_from_u64(index)) {
+            bitset.set(index);
+        }
+    });
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn bitset_c_clear(handle: *mut BitsetHandle, index: u64) {
+    catch_void(|| {
+        if let (Ok(bitset), Ok(index)) = (unsafe { bitset_mut(handle, "bitset_c_clear") }, usize_from_u64(index)) {
+            bitset.clear(index);
+        }
+    });
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn bitset_c_test(handle: *const BitsetHandle, index: u64) -> u8 {
+    catch_u8(|| match (unsafe { bitset_ref(handle, "bitset_c_test") }, usize_from_u64(index)) {
+        (Ok(bitset), Ok(index)) => u8::from(bitset.test(index)),
+        _ => 0,
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn bitset_c_toggle(handle: *mut BitsetHandle, index: u64) {
+    catch_void(|| {
+        if let (Ok(bitset), Ok(index)) = (unsafe { bitset_mut(handle, "bitset_c_toggle") }, usize_from_u64(index)) {
+            bitset.toggle(index);
+        }
+    });
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn bitset_c_and(
+    left: *const BitsetHandle,
+    right: *const BitsetHandle,
+) -> *mut BitsetHandle {
+    catch_ptr(|| match (unsafe { bitset_ref(left, "bitset_c_and") }, unsafe { bitset_ref(right, "bitset_c_and") }) {
+        (Ok(left), Ok(right)) => wrap_bitset(left.and(right)),
+        _ => ptr::null_mut(),
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn bitset_c_or(
+    left: *const BitsetHandle,
+    right: *const BitsetHandle,
+) -> *mut BitsetHandle {
+    catch_ptr(|| match (unsafe { bitset_ref(left, "bitset_c_or") }, unsafe { bitset_ref(right, "bitset_c_or") }) {
+        (Ok(left), Ok(right)) => wrap_bitset(left.or(right)),
+        _ => ptr::null_mut(),
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn bitset_c_xor(
+    left: *const BitsetHandle,
+    right: *const BitsetHandle,
+) -> *mut BitsetHandle {
+    catch_ptr(|| match (unsafe { bitset_ref(left, "bitset_c_xor") }, unsafe { bitset_ref(right, "bitset_c_xor") }) {
+        (Ok(left), Ok(right)) => wrap_bitset(left.xor(right)),
+        _ => ptr::null_mut(),
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn bitset_c_not(handle: *const BitsetHandle) -> *mut BitsetHandle {
+    catch_ptr(|| match unsafe { bitset_ref(handle, "bitset_c_not") } {
+        Ok(bitset) => wrap_bitset(bitset.not()),
+        Err(_) => ptr::null_mut(),
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn bitset_c_and_not(
+    left: *const BitsetHandle,
+    right: *const BitsetHandle,
+) -> *mut BitsetHandle {
+    catch_ptr(|| match (unsafe { bitset_ref(left, "bitset_c_and_not") }, unsafe { bitset_ref(right, "bitset_c_and_not") }) {
+        (Ok(left), Ok(right)) => wrap_bitset(left.and_not(right)),
+        _ => ptr::null_mut(),
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn bitset_c_popcount(handle: *const BitsetHandle) -> u64 {
+    catch_u64(|| match unsafe { bitset_ref(handle, "bitset_c_popcount") } {
+        Ok(bitset) => bitset.popcount() as u64,
+        Err(_) => 0,
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn bitset_c_len(handle: *const BitsetHandle) -> u64 {
+    catch_u64(|| match unsafe { bitset_ref(handle, "bitset_c_len") } {
+        Ok(bitset) => bitset.len() as u64,
+        Err(_) => 0,
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn bitset_c_capacity(handle: *const BitsetHandle) -> u64 {
+    catch_u64(|| match unsafe { bitset_ref(handle, "bitset_c_capacity") } {
+        Ok(bitset) => bitset.capacity() as u64,
+        Err(_) => 0,
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn bitset_c_any(handle: *const BitsetHandle) -> u8 {
+    catch_u8(|| match unsafe { bitset_ref(handle, "bitset_c_any") } {
+        Ok(bitset) => u8::from(bitset.any()),
+        Err(_) => 0,
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn bitset_c_all(handle: *const BitsetHandle) -> u8 {
+    catch_u8(|| match unsafe { bitset_ref(handle, "bitset_c_all") } {
+        Ok(bitset) => u8::from(bitset.all()),
+        Err(_) => 0,
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn bitset_c_none(handle: *const BitsetHandle) -> u8 {
+    catch_u8(|| match unsafe { bitset_ref(handle, "bitset_c_none") } {
+        Ok(bitset) => u8::from(bitset.none()),
+        Err(_) => 0,
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn bitset_c_is_empty(handle: *const BitsetHandle) -> u8 {
+    catch_u8(|| match unsafe { bitset_ref(handle, "bitset_c_is_empty") } {
+        Ok(bitset) => u8::from(bitset.is_empty()),
+        Err(_) => 0,
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn bitset_c_to_u64(handle: *const BitsetHandle, out: *mut u64) -> u8 {
+    catch_u8(|| {
+        if out.is_null() {
+            set_error(ErrorCode::NullPointer, "bitset_c_to_u64 requires a non-null output pointer.");
+            0
+        } else {
+            match unsafe { bitset_ref(handle, "bitset_c_to_u64") } {
+                Ok(bitset) => match bitset.to_integer() {
+                    Some(value) => {
+                        unsafe { *out = value };
+                        1
+                    }
+                    None => 0,
+                },
+                Err(_) => 0,
+            }
+        }
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn bitset_c_equals(
+    left: *const BitsetHandle,
+    right: *const BitsetHandle,
+) -> u8 {
+    catch_u8(|| match (unsafe { bitset_ref(left, "bitset_c_equals") }, unsafe { bitset_ref(right, "bitset_c_equals") }) {
+        (Ok(left), Ok(right)) => u8::from(left == right),
+        _ => 0,
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn bitset_c_had_error() -> u8 {
+    LAST_ERROR_CODE.with(|slot| u8::from(slot.get() != ErrorCode::None as u32))
+}
+
+#[no_mangle]
+pub extern "C" fn bitset_c_last_error_code() -> u32 {
+    LAST_ERROR_CODE.with(|slot| slot.get())
+}
+
+#[no_mangle]
+pub extern "C" fn bitset_c_last_error_message() -> *const c_char {
+    LAST_ERROR_MESSAGE.with(|slot| {
+        slot.borrow()
+            .as_ref()
+            .map(|message| message.as_ptr())
+            .unwrap_or(ptr::null())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn error_message() -> String {
+        let ptr = bitset_c_last_error_message();
+        if ptr.is_null() {
+            String::new()
+        } else {
+            unsafe { CStr::from_ptr(ptr) }.to_str().unwrap().to_string()
+        }
+    }
+
+    #[test]
+    fn creates_mutates_and_queries_handles() {
+        unsafe {
+            let bitset = bitset_c_new(10);
+            assert!(!bitset.is_null());
+            assert_eq!(bitset_c_len(bitset), 10);
+            assert_eq!(bitset_c_capacity(bitset), 64);
+            assert_eq!(bitset_c_popcount(bitset), 0);
+            assert_eq!(bitset_c_none(bitset), 1);
+
+            bitset_c_set(bitset, 5);
+            assert_eq!(bitset_c_test(bitset, 5), 1);
+            assert_eq!(bitset_c_popcount(bitset), 1);
+
+            bitset_c_toggle(bitset, 5);
+            assert_eq!(bitset_c_test(bitset, 5), 0);
+
+            bitset_c_toggle(bitset, 80);
+            assert_eq!(bitset_c_len(bitset), 81);
+            assert_eq!(bitset_c_capacity(bitset), 128);
+            assert_eq!(bitset_c_test(bitset, 80), 1);
+
+            bitset_c_free(bitset);
+        }
+    }
+
+    #[test]
+    fn bulk_operations_match_reference_values() {
+        unsafe {
+            let left = bitset_c_from_u128(0b1100, 0);
+            let right = bitset_c_from_u128(0b1010, 0);
+
+            let and_result = bitset_c_and(left, right);
+            let or_result = bitset_c_or(left, right);
+            let xor_result = bitset_c_xor(left, right);
+            let and_not_result = bitset_c_and_not(left, right);
+
+            let mut value = 0;
+            assert_eq!(bitset_c_to_u64(and_result, &mut value), 1);
+            assert_eq!(value, 0b1000);
+
+            assert_eq!(bitset_c_to_u64(or_result, &mut value), 1);
+            assert_eq!(value, 0b1110);
+
+            assert_eq!(bitset_c_to_u64(xor_result, &mut value), 1);
+            assert_eq!(value, 0b0110);
+
+            assert_eq!(bitset_c_to_u64(and_not_result, &mut value), 1);
+            assert_eq!(value, 0b0100);
+
+            bitset_c_free(and_result);
+            bitset_c_free(or_result);
+            bitset_c_free(xor_result);
+            bitset_c_free(and_not_result);
+            bitset_c_free(left);
+            bitset_c_free(right);
+        }
+    }
+
+    #[test]
+    fn from_binary_string_reports_invalid_input() {
+        unsafe {
+            let invalid = CString::new("10x1").unwrap();
+            let bitset = bitset_c_from_binary_str(invalid.as_ptr());
+            assert!(bitset.is_null());
+            assert_eq!(bitset_c_had_error(), 1);
+            assert_eq!(bitset_c_last_error_code(), ErrorCode::InvalidBinaryString as u32);
+            assert!(error_message().contains("invalid binary string"));
+        }
+    }
+
+    #[test]
+    fn round_trips_split_u128_and_reports_u64_overflow() {
+        unsafe {
+            let bitset = bitset_c_from_u128(1, 1);
+            assert!(!bitset.is_null());
+            assert_eq!(bitset_c_len(bitset), 65);
+            assert_eq!(bitset_c_test(bitset, 0), 1);
+            assert_eq!(bitset_c_test(bitset, 64), 1);
+
+            let mut value = 0;
+            assert_eq!(bitset_c_to_u64(bitset, &mut value), 0);
+
+            bitset_c_free(bitset);
+        }
+    }
+
+    #[test]
+    fn null_handles_set_error_state() {
+        unsafe {
+            assert_eq!(bitset_c_test(ptr::null(), 0), 0);
+            assert_eq!(bitset_c_had_error(), 1);
+            assert_eq!(bitset_c_last_error_code(), ErrorCode::NullPointer as u32);
+            assert!(error_message().contains("null bitset handle"));
+        }
+    }
+}


### PR DESCRIPTION
## What changed
- add literate C# and F# `bitset` packages with dynamic growth, bulk bitwise operations, binary and integer conversions, equality, and set-bit iteration
- add a Rust `bitset-c` package that exposes the canonical Rust `bitset` crate through a stable C ABI with an opaque handle model and thread-local error reporting
- add `csharp/bitset-native` and `fsharp/bitset-native` packages that wrap `bitset-c` via .NET P/Invoke so managed code can reuse the Rust implementation directly
- add xUnit coverage for the pure managed packages and the new native wrappers, plus README and changelog updates for the new packages

## Why
C# and F# were still missing the `bitset` foundation package that already exists in Rust and other language ecosystems. This PR fills that leaf-package gap in literate style, and it also establishes the repo's .NET native-extension pattern: Rust crate -> C ABI shim -> C#/F# wrapper.

## Validation
- `cd code/packages/csharp/bitset && mise exec dotnet@9.0.313 -- bash BUILD`
- `cd code/packages/fsharp/bitset && mise exec dotnet@9.0.313 -- bash BUILD`
- `cd code/packages/rust && cargo test -p bitset-c -- --nocapture`
- `cd code/packages/csharp/bitset-native && mise exec dotnet@9.0.313 -- bash BUILD`
- `cd code/packages/fsharp/bitset-native && mise exec dotnet@9.0.313 -- bash BUILD`

## Notes
- `bitset-native` uses the workspace Cargo target directory, so the test projects copy `libbitset_c` from `code/packages/rust/target/release`
- C# native-wrapper coverage: 90.34% line
- F# native-wrapper coverage: 90.59% line
