### PR TITLE
[codex] add GE-225 simulator ports

### DIFF
--- a/code/packages/go/ge225-simulator/BUILD
+++ b/code/packages/go/ge225-simulator/BUILD
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/ge225-simulator/CHANGELOG.md
+++ b/code/packages/go/ge225-simulator/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to the ge225-simulator Go package will be documented in this file.
+
+## [0.1.0] - 2026-04-15
+
+### Added
+- Initial Go GE-225 behavioral simulator package
+- Documented opcode maps, helpers, and focused execution tests

--- a/code/packages/go/ge225-simulator/README.md
+++ b/code/packages/go/ge225-simulator/README.md
@@ -1,0 +1,13 @@
+# GE-225 Simulator (Go)
+
+Behavioral Go simulator for the **GE-225 instruction repertoire**.
+
+This package is the first non-Python GE-225 port in the repo and is intended to
+track the Python simulator closely enough for backend cross-checking.
+
+## Scope
+
+- 20-bit word-addressed machine state
+- documented memory-reference and fixed-word instruction families
+- host-side control-switch, typewriter, and queued record helpers
+- focused tests covering arithmetic, branching, block move, and console flow

--- a/code/packages/go/ge225-simulator/go.mod
+++ b/code/packages/go/ge225-simulator/go.mod
@@ -1,0 +1,3 @@
+module github.com/adhithyan15/coding-adventures/code/packages/go/ge225-simulator
+
+go 1.22

--- a/code/packages/go/ge225-simulator/simulator.go
+++ b/code/packages/go/ge225-simulator/simulator.go
@@ -1,0 +1,585 @@
+package ge225simulator
+
+import "fmt"
+
+const (
+	mask20    = (1 << 20) - 1
+	dataMask  = (1 << 19) - 1
+	signBit   = 1 << 19
+	addrMask  = 0x1fff
+	xMask     = 0x7fff
+	nMask     = 0x3f
+	wordBytes = 3
+	maxXGroups = 32
+)
+
+const (
+	opLDA = 0o00
+	opADD = 0o01
+	opSUB = 0o02
+	opSTA = 0o03
+	opBXL = 0o04
+	opBXH = 0o05
+	opLDX = 0o06
+	opSPB = 0o07
+	opDLD = 0o10
+	opDAD = 0o11
+	opDSU = 0o12
+	opDST = 0o13
+	opINX = 0o14
+	opMPY = 0o15
+	opDVD = 0o16
+	opSTX = 0o17
+	opEXT = 0o20
+	opCAB = 0o21
+	opDCB = 0o22
+	opORY = 0o23
+	opMOY = 0o24
+	opRCD = 0o25
+	opBRU = 0o26
+	opSTO = 0o27
+)
+
+var baseOpcodeNames = map[int]string{
+	opLDA: "LDA", opADD: "ADD", opSUB: "SUB", opSTA: "STA", opBXL: "BXL",
+	opBXH: "BXH", opLDX: "LDX", opSPB: "SPB", opDLD: "DLD", opDAD: "DAD",
+	opDSU: "DSU", opDST: "DST", opINX: "INX", opMPY: "MPY", opDVD: "DVD",
+	opSTX: "STX", opEXT: "EXT", opCAB: "CAB", opDCB: "DCB", opORY: "ORY",
+	opMOY: "MOY", opRCD: "RCD", opBRU: "BRU", opSTO: "STO",
+}
+
+var fixedWords = map[string]int{
+	"OFF": 0o2500005, "TYP": 0o2500006, "TON": 0o2500007, "RCS": 0o2500011,
+	"HPT": 0o2500016, "LDZ": 0o2504002, "LDO": 0o2504022, "LMO": 0o2504102,
+	"CPL": 0o2504502, "NEG": 0o2504522, "CHS": 0o2504040, "NOP": 0o2504012,
+	"LAQ": 0o2504001, "LQA": 0o2504004, "XAQ": 0o2504005, "MAQ": 0o2504006,
+	"ADO": 0o2504032, "SBO": 0o2504112, "SET_DECMODE": 0o2506011, "SET_BINMODE": 0o2506012,
+	"SXG": 0o2506013, "SET_PST": 0o2506015, "SET_PBK": 0o2506016,
+	"BOD": 0o2514000, "BEV": 0o2516000, "BMI": 0o2514001, "BPL": 0o2516001,
+	"BZE": 0o2514002, "BNZ": 0o2516002, "BOV": 0o2514003, "BNO": 0o2516003,
+	"BPE": 0o2514004, "BPC": 0o2516004, "BNR": 0o2514005, "BNN": 0o2516005,
+}
+
+var fixedNames = func() map[int]string {
+	out := map[int]string{}
+	for name, word := range fixedWords {
+		out[word] = name
+	}
+	return out
+}()
+
+var shiftBases = map[string]int{
+	"SRA": 0o2510000, "SNA": 0o2510100, "SCA": 0o2510040, "SAN": 0o2510400,
+	"SRD": 0o2511000, "NAQ": 0o2511100, "SCD": 0o2511200, "ANQ": 0o2511400,
+	"SLA": 0o2512000, "SLD": 0o2512200, "NOR": 0o2513000, "DNO": 0o2513200,
+}
+
+var typewriterCodes = map[int]string{
+	0o00: "0", 0o01: "1", 0o02: "2", 0o03: "3", 0o04: "4", 0o05: "5", 0o06: "6", 0o07: "7",
+	0o10: "8", 0o11: "9", 0o13: "/", 0o21: "A", 0o22: "B", 0o23: "C", 0o24: "D", 0o25: "E",
+	0o26: "F", 0o27: "G", 0o30: "H", 0o31: "I", 0o33: "-", 0o40: ".", 0o41: "J", 0o42: "K",
+	0o43: "L", 0o44: "M", 0o45: "N", 0o46: "O", 0o47: "P", 0o50: "Q", 0o51: "R", 0o53: "$",
+	0o60: " ", 0o62: "S", 0o63: "T", 0o64: "U", 0o65: "V", 0o66: "W", 0o67: "X", 0o70: "Y",
+	0o71: "Z",
+}
+
+type Indicators struct {
+	Carry       bool
+	Zero        bool
+	Negative    bool
+	Overflow    bool
+	ParityError bool
+}
+
+type State struct {
+	A                      int
+	Q                      int
+	M                      int
+	N                      int
+	PC                     int
+	IR                     int
+	Indicators             Indicators
+	Overflow               bool
+	ParityError            bool
+	DecimalMode            bool
+	AutomaticInterruptMode bool
+	SelectedXGroup         int
+	NReady                 bool
+	TypewriterPower        bool
+	ControlSwitches        int
+	XWords                 []int
+	Halted                 bool
+	Memory                 []int
+}
+
+type Trace struct {
+	Address          int
+	InstructionWord  int
+	Mnemonic         string
+	ABefore          int
+	AAfter           int
+	QBefore          int
+	QAfter           int
+	EffectiveAddress *int
+}
+
+type decodedInstruction struct {
+	Mnemonic  string
+	Opcode    *int
+	Modifier  *int
+	Address   *int
+	Count     *int
+	FixedWord bool
+}
+
+type Simulator struct {
+	memorySize              int
+	memory                  []int
+	cardReaderQueue         [][]int
+	a, q, m, n             int
+	pc, ir                  int
+	overflow, parityError   bool
+	decimalMode             bool
+	automaticInterruptMode  bool
+	selectedXGroup          int
+	nReady, typewriterPower bool
+	typewriterOutput        []string
+	controlSwitches         int
+	halted                  bool
+	xGroups                 [maxXGroups][4]int
+}
+
+func New(memoryWords int) *Simulator {
+	if memoryWords <= 0 {
+		panic("memoryWords must be positive")
+	}
+	return &Simulator{memorySize: memoryWords, memory: make([]int, memoryWords)}
+}
+
+func (s *Simulator) Reset() {
+	s.a, s.q, s.m, s.n = 0, 0, 0, 0
+	s.pc, s.ir = 0, 0
+	s.overflow, s.parityError = false, false
+	s.decimalMode, s.automaticInterruptMode = false, false
+	s.selectedXGroup = 0
+	s.nReady = true
+	s.typewriterPower = false
+	s.typewriterOutput = nil
+	s.controlSwitches = 0
+	s.halted = false
+	for i := range s.xGroups {
+		s.xGroups[i] = [4]int{}
+	}
+}
+
+func (s *Simulator) GetState() State {
+	mem := append([]int(nil), s.memory...)
+	xWords := append([]int(nil), s.xGroups[s.selectedXGroup][:]...)
+	return State{
+		A: s.a, Q: s.q, M: s.m, N: s.n, PC: s.pc, IR: s.ir,
+		Indicators: Indicators{
+			Carry: s.overflow, Zero: s.a == 0, Negative: s.a&signBit != 0,
+			Overflow: s.overflow, ParityError: s.parityError,
+		},
+		Overflow: s.overflow, ParityError: s.parityError, DecimalMode: s.decimalMode,
+		AutomaticInterruptMode: s.automaticInterruptMode, SelectedXGroup: s.selectedXGroup,
+		NReady: s.nReady, TypewriterPower: s.typewriterPower, ControlSwitches: s.controlSwitches,
+		XWords: xWords, Halted: s.halted, Memory: mem,
+	}
+}
+
+func (s *Simulator) SetControlSwitches(value int) { s.controlSwitches = value & mask20 }
+func (s *Simulator) QueueCardReaderRecord(words []int) {
+	record := make([]int, len(words))
+	for i, word := range words { record[i] = word & mask20 }
+	s.cardReaderQueue = append(s.cardReaderQueue, record)
+}
+func (s *Simulator) GetTypewriterOutput() string {
+	out := ""
+	for _, chunk := range s.typewriterOutput { out += chunk }
+	return out
+}
+
+func (s *Simulator) LoadWords(words []int, startAddress int) error {
+	for i, word := range words {
+		if err := s.WriteWord(startAddress+i, word); err != nil { return err }
+	}
+	return nil
+}
+
+func (s *Simulator) ReadWord(address int) (int, error) {
+	if err := s.checkAddress(address); err != nil { return 0, err }
+	return s.memory[address], nil
+}
+
+func (s *Simulator) WriteWord(address int, value int) error {
+	if err := s.checkAddress(address); err != nil { return err }
+	s.memory[address] = value & mask20
+	return nil
+}
+
+func EncodeInstruction(opcode, modifier, address int) (int, error) {
+	if opcode < 0 || opcode > 0o37 { return 0, fmt.Errorf("opcode out of range: %d", opcode) }
+	if modifier < 0 || modifier > 0o3 { return 0, fmt.Errorf("modifier out of range: %d", modifier) }
+	if address < 0 || address > addrMask { return 0, fmt.Errorf("address out of range: %d", address) }
+	return ((opcode & 0x1f) << 15) | ((modifier & 0x03) << 13) | (address & addrMask), nil
+}
+
+func DecodeInstruction(word int) (int, int, int) {
+	normalized := word & mask20
+	return (normalized >> 15) & 0x1f, (normalized >> 13) & 0x03, normalized & addrMask
+}
+
+func AssembleFixed(mnemonic string) (int, error) {
+	word, ok := fixedWords[mnemonic]
+	if !ok { return 0, fmt.Errorf("unknown fixed GE-225 instruction: %s", mnemonic) }
+	return word, nil
+}
+
+func AssembleShift(mnemonic string, count int) (int, error) {
+	if count < 0 || count > 0o37 { return 0, fmt.Errorf("shift count out of range: %d", count) }
+	base, ok := shiftBases[mnemonic]
+	if !ok { return 0, fmt.Errorf("unknown GE-225 shift instruction: %s", mnemonic) }
+	return base | count, nil
+}
+
+func PackWords(words []int) []byte {
+	blob := make([]byte, len(words)*wordBytes)
+	for i, word := range words {
+		normalized := word & mask20
+		blob[i*wordBytes] = byte((normalized >> 16) & 0xff)
+		blob[i*wordBytes+1] = byte((normalized >> 8) & 0xff)
+		blob[i*wordBytes+2] = byte(normalized & 0xff)
+	}
+	return blob
+}
+
+func UnpackWords(program []byte) ([]int, error) {
+	if len(program)%wordBytes != 0 { return nil, fmt.Errorf("GE-225 byte stream must be a multiple of %d bytes, got %d", wordBytes, len(program)) }
+	words := make([]int, 0, len(program)/wordBytes)
+	for i := 0; i < len(program); i += wordBytes {
+		words = append(words, (int(program[i])<<16|int(program[i+1])<<8|int(program[i+2]))&mask20)
+	}
+	return words, nil
+}
+
+func (s *Simulator) DisassembleWord(word int) (string, error) {
+	decoded, err := s.decodeWord(word)
+	if err != nil { return "", err }
+	if decoded.FixedWord {
+		if decoded.Count == nil { return decoded.Mnemonic, nil }
+		return fmt.Sprintf("%s %d", decoded.Mnemonic, *decoded.Count), nil
+	}
+	return fmt.Sprintf("%s 0x%03X,X%d", decoded.Mnemonic, *decoded.Address, *decoded.Modifier), nil
+}
+
+func (s *Simulator) Step() (Trace, error) {
+	if s.halted { return Trace{}, fmt.Errorf("cannot step a halted GE-225 simulator") }
+	pcBefore := s.pc
+	word, _ := s.ReadWord(s.pc)
+	s.ir = word
+	s.pc = (s.pc + 1) % s.memorySize
+	decoded, err := s.decodeWord(s.ir)
+	if err != nil { return Trace{}, err }
+	aBefore, qBefore := s.a, s.q
+	var effectiveAddress *int
+	if !decoded.FixedWord {
+		address := *decoded.Address
+		if decoded.Mnemonic != "BXL" && decoded.Mnemonic != "BXH" && decoded.Mnemonic != "LDX" &&
+			decoded.Mnemonic != "SPB" && decoded.Mnemonic != "INX" && decoded.Mnemonic != "STX" && decoded.Mnemonic != "MOY" {
+			ea := s.resolveEffectiveAddress(address, *decoded.Modifier)
+			effectiveAddress = &ea
+		}
+		runAddr := address
+		if effectiveAddress != nil { runAddr = *effectiveAddress }
+		if err := s.executeMemoryReference(decoded.Mnemonic, *decoded.Modifier, runAddr, address, pcBefore); err != nil { return Trace{}, err }
+	} else {
+		if err := s.executeFixed(decoded); err != nil { return Trace{}, err }
+	}
+	mnemonic, _ := s.DisassembleWord(s.ir)
+	return Trace{Address: pcBefore, InstructionWord: s.ir, Mnemonic: mnemonic, ABefore: aBefore, AAfter: s.a, QBefore: qBefore, QAfter: s.q, EffectiveAddress: effectiveAddress}, nil
+}
+
+func (s *Simulator) Run(maxSteps int) ([]Trace, error) {
+	traces := []Trace{}
+	for steps := 0; !s.halted && steps < maxSteps; steps++ {
+		trace, err := s.Step()
+		if err != nil { return traces, err }
+		traces = append(traces, trace)
+	}
+	return traces, nil
+}
+
+func toSigned20(value int) int {
+	word := value & mask20
+	if word&signBit != 0 { return word - (1 << 20) }
+	return word
+}
+
+func fromSigned20(value int) int { return value & mask20 }
+func signOf(word int) int { if word&signBit != 0 { return 1 }; return 0 }
+func withSign(word, sign int) int { return ((sign & 1) << 19) | (word & dataMask) }
+
+func combineWords(high, low int) int64 { return (int64(high&mask20) << 20) | int64(low&mask20) }
+func splitSigned40(value int64) (int, int) {
+	const mask40 int64 = (1 << 40) - 1
+	raw := value & mask40
+	return int((raw >> 20) & mask20), int(raw & mask20)
+}
+func toSigned40(value int64) int64 { return (value << 24) >> 24 }
+
+func arithCompare(left, right int) int {
+	l, r := toSigned20(left), toSigned20(right)
+	if l < r { return -1 }
+	if l > r { return 1 }
+	return 0
+}
+func arithCompareDouble(lh, ll, rh, rl int) int {
+	left, right := toSigned40(combineWords(lh, ll)), toSigned40(combineWords(rh, rl))
+	if left < right { return -1 }
+	if left > right { return 1 }
+	return 0
+}
+
+func (s *Simulator) getXWord(slot int) int { return s.xGroups[s.selectedXGroup][slot] & xMask }
+func (s *Simulator) setXWord(slot, value int) { s.xGroups[s.selectedXGroup][slot] = value & xMask }
+
+func (s *Simulator) executeMemoryReference(mnemonic string, modifier, effectiveOrRawAddress, rawAddress, pcBefore int) error {
+	effectiveAddress := effectiveOrRawAddress % s.memorySize
+	switch mnemonic {
+	case "LDA":
+		word, _ := s.ReadWord(effectiveAddress); s.m = word; s.a = word
+	case "ADD":
+		word, _ := s.ReadWord(effectiveAddress); s.m = word
+		total := toSigned20(s.a) + toSigned20(s.m); s.a = fromSigned20(total); s.overflow = total < -(1<<19) || total > ((1<<19)-1)
+	case "SUB":
+		word, _ := s.ReadWord(effectiveAddress); s.m = word
+		total := toSigned20(s.a) - toSigned20(s.m); s.a = fromSigned20(total); s.overflow = total < -(1<<19) || total > ((1<<19)-1)
+	case "STA":
+		return s.WriteWord(effectiveAddress, s.a)
+	case "BXL":
+		if s.getXWord(modifier)&addrMask >= rawAddress { s.pc = (s.pc + 1) % s.memorySize }
+	case "BXH":
+		if s.getXWord(modifier)&addrMask < rawAddress { s.pc = (s.pc + 1) % s.memorySize }
+	case "LDX":
+		word, _ := s.ReadWord(rawAddress % s.memorySize); s.setXWord(modifier, word)
+	case "SPB":
+		s.setXWord(modifier, pcBefore); s.pc = rawAddress % s.memorySize
+	case "DLD":
+		first, _ := s.ReadWord(effectiveAddress)
+		if effectiveAddress&1 != 0 { s.a, s.q = first, first } else { second, _ := s.ReadWord((effectiveAddress + 1) % s.memorySize); s.a, s.q = first, second }
+	case "DAD":
+		left := toSigned40(combineWords(s.a, s.q))
+		first, _ := s.ReadWord(effectiveAddress); second := first
+		if effectiveAddress&1 == 0 { second, _ = s.ReadWord((effectiveAddress + 1) % s.memorySize) }
+		total := left + toSigned40(combineWords(first, second)); s.a, s.q = splitSigned40(total); s.overflow = total < -(1<<39) || total > ((1<<39)-1)
+	case "DSU":
+		left := toSigned40(combineWords(s.a, s.q))
+		first, _ := s.ReadWord(effectiveAddress); second := first
+		if effectiveAddress&1 == 0 { second, _ = s.ReadWord((effectiveAddress + 1) % s.memorySize) }
+		total := left - toSigned40(combineWords(first, second)); s.a, s.q = splitSigned40(total); s.overflow = total < -(1<<39) || total > ((1<<39)-1)
+	case "DST":
+		if effectiveAddress&1 != 0 { return s.WriteWord(effectiveAddress, s.q) }
+		if err := s.WriteWord(effectiveAddress, s.a); err != nil { return err }
+		return s.WriteWord((effectiveAddress+1)%s.memorySize, s.q)
+	case "INX":
+		s.setXWord(modifier, (s.getXWord(modifier)+rawAddress)&xMask)
+	case "MPY":
+		word, _ := s.ReadWord(effectiveAddress); s.m = word
+		product := int64(toSigned20(s.q))*int64(toSigned20(s.m)) + int64(toSigned20(s.a)); s.a, s.q = splitSigned40(product); s.overflow = product < -(1<<39) || product > ((1<<39)-1)
+	case "DVD":
+		word, _ := s.ReadWord(effectiveAddress); s.m = word; divisor := int64(toSigned20(s.m))
+		if divisor == 0 { return fmt.Errorf("GE-225 divide by zero") }
+		aAbs := toSigned20(s.a); if aAbs < 0 { aAbs = -aAbs }
+		dAbs := divisor; if dAbs < 0 { dAbs = -dAbs }
+		if int64(aAbs) >= dAbs { s.overflow = true; return nil }
+		dividend := toSigned40(combineWords(s.a, s.q)); absDividend := dividend; if absDividend < 0 { absDividend = -absDividend }
+		quotientMag, remainderMag := absDividend/dAbs, absDividend%dAbs
+		quotient := quotientMag; if (dividend < 0) != (divisor < 0) { quotient = -quotient }
+		remainder := remainderMag; if quotient < 0 { remainder = -remainder }
+		s.a, s.q = fromSigned20(int(quotient)), fromSigned20(int(remainder)); s.overflow = quotient < -(1<<19) || quotient > ((1<<19)-1)
+	case "STX":
+		return s.WriteWord(rawAddress%s.memorySize, s.getXWord(modifier))
+	case "EXT":
+		word, _ := s.ReadWord(effectiveAddress); s.m = word; s.a &= (^s.m) & mask20
+	case "CAB":
+		word, _ := s.ReadWord(effectiveAddress); s.m = word; relation := arithCompare(s.m, s.a)
+		if relation == 0 { s.pc = (s.pc + 1) % s.memorySize } else if relation < 0 { s.pc = (s.pc + 2) % s.memorySize }
+	case "DCB":
+		first, _ := s.ReadWord(effectiveAddress); second := first; if effectiveAddress&1 == 0 { second, _ = s.ReadWord((effectiveAddress + 1) % s.memorySize) }
+		relation := arithCompareDouble(first, second, s.a, s.q)
+		if relation == 0 { s.pc = (s.pc + 1) % s.memorySize } else if relation < 0 { s.pc = (s.pc + 2) % s.memorySize }
+	case "ORY":
+		word, _ := s.ReadWord(effectiveAddress); return s.WriteWord(effectiveAddress, word|s.a)
+	case "MOY":
+		wordCount := -toSigned20(s.q); if wordCount < 0 { wordCount = 0 }
+		destination := s.a & xMask
+		for offset := 0; offset < wordCount; offset++ { word, _ := s.ReadWord((rawAddress + offset) % s.memorySize); _ = s.WriteWord((destination+offset)%s.memorySize, word) }
+		s.setXWord(0, s.pc); s.a = 0
+	case "RCD":
+		if len(s.cardReaderQueue) == 0 { return fmt.Errorf("RCD executed with no queued card-reader record") }
+		record := s.cardReaderQueue[0]; s.cardReaderQueue = s.cardReaderQueue[1:]
+		for offset, word := range record { _ = s.WriteWord((effectiveAddress+offset)%s.memorySize, word) }
+	case "BRU":
+		s.pc = effectiveAddress
+	case "STO":
+		existing, _ := s.ReadWord(effectiveAddress); return s.WriteWord(effectiveAddress, (existing &^ addrMask) | (s.a & addrMask))
+	default:
+		return fmt.Errorf("unimplemented GE-225 memory-reference instruction: %s", mnemonic)
+	}
+	return nil
+}
+
+func (s *Simulator) executeFixed(decoded decodedInstruction) error {
+	mnemonic, count := decoded.Mnemonic, 0
+	if decoded.Count != nil { count = *decoded.Count }
+	switch mnemonic {
+	case "OFF":
+		s.typewriterPower, s.nReady = false, true
+	case "TYP":
+		if !s.typewriterPower { s.nReady = false; return nil }
+		code := s.n & nMask
+		if code == 0o37 { s.typewriterOutput = append(s.typewriterOutput, "\r") } else if code == 0o76 { s.typewriterOutput = append(s.typewriterOutput, "\t") } else if code != 0o72 && code != 0o75 {
+			char, ok := typewriterCodes[code]; if !ok { s.nReady = false; return nil }; s.typewriterOutput = append(s.typewriterOutput, char)
+		}
+		s.nReady = true
+	case "TON":
+		s.typewriterPower = true
+	case "RCS":
+		s.a |= s.controlSwitches
+	case "HPT":
+		s.nReady = false
+	case "LDZ":
+		s.a = 0
+	case "LDO":
+		s.a = 1
+	case "LMO":
+		s.a = mask20
+	case "CPL":
+		s.a = (^s.a) & mask20
+	case "NEG":
+		before := toSigned20(s.a); s.a = fromSigned20(-before); s.overflow = before == -(1<<19)
+	case "CHS":
+		s.a ^= signBit
+	case "NOP":
+	case "LAQ":
+		s.a = s.q
+	case "LQA":
+		s.q = s.a
+	case "XAQ":
+		s.a, s.q = s.q, s.a
+	case "MAQ":
+		s.q = s.a; s.a = 0
+	case "ADO":
+		total := toSigned20(s.a) + 1; s.a = fromSigned20(total); s.overflow = total < -(1<<19) || total > ((1<<19)-1)
+	case "SBO":
+		total := toSigned20(s.a) - 1; s.a = fromSigned20(total); s.overflow = total < -(1<<19) || total > ((1<<19)-1)
+	case "SET_DECMODE":
+		s.decimalMode = true
+	case "SET_BINMODE":
+		s.decimalMode = false
+	case "SXG":
+		s.selectedXGroup = s.a & 0x1f
+	case "SET_PST":
+		s.automaticInterruptMode = true
+	case "SET_PBK":
+		s.automaticInterruptMode = false
+	case "BOD", "BEV", "BMI", "BPL", "BZE", "BNZ", "BOV", "BNO", "BPE", "BPC", "BNR", "BNN":
+		s.executeBranchTest(mnemonic)
+	default:
+		if _, ok := shiftBases[mnemonic]; ok { s.executeShift(mnemonic, count); return nil }
+		return fmt.Errorf("unimplemented GE-225 fixed instruction: %s", mnemonic)
+	}
+	return nil
+}
+
+func (s *Simulator) executeBranchTest(mnemonic string) {
+	cond := false
+	switch mnemonic {
+	case "BOD": cond = s.a&1 != 0
+	case "BEV": cond = s.a&1 == 0
+	case "BMI": cond = s.a&signBit != 0
+	case "BPL": cond = s.a&signBit == 0
+	case "BZE": cond = s.a == 0
+	case "BNZ": cond = s.a != 0
+	case "BOV": cond = s.overflow
+	case "BNO": cond = !s.overflow
+	case "BPE": cond = s.parityError
+	case "BPC": cond = !s.parityError
+	case "BNR": cond = s.nReady
+	case "BNN": cond = !s.nReady
+	}
+	if mnemonic == "BOV" || mnemonic == "BNO" { s.overflow = false }
+	if mnemonic == "BPE" || mnemonic == "BPC" { s.parityError = false }
+	if !cond { s.pc = (s.pc + 1) % s.memorySize }
+}
+
+func (s *Simulator) executeShift(mnemonic string, count int) {
+	if count == 0 {
+		if mnemonic == "SRD" { s.q = withSign(s.q, signOf(s.a)) } else if mnemonic == "SLD" { s.a = withSign(s.a, signOf(s.q)) }
+		return
+	}
+	aSign, aData := signOf(s.a), s.a&dataMask
+	qSign, qData := signOf(s.q), s.q&dataMask
+	switch mnemonic {
+	case "SRA":
+		s.a = fromSigned20(toSigned20(s.a) >> min(count, 19))
+	case "SLA":
+		s.overflow = (aData >> max(0, 19-count)) != 0; s.a = withSign((aData<<count)&dataMask, aSign)
+	case "SCA":
+		rotation := count % 19; if rotation != 0 { aData = ((aData >> rotation) | (aData << (19 - rotation))) & dataMask }; s.a = withSign(aData, aSign)
+	case "SAN":
+		fill := 0; if aSign == 1 { fill = (1 << count) - 1 }
+		combined := ((aData & dataMask) << 6) | (s.n & nMask); combined = ((fill << 25) | combined) >> count
+		s.a = withSign((combined>>6)&dataMask, aSign); s.n = combined & nMask
+	case "SNA":
+		combined := (((s.n & nMask) << 19) | aData) >> count; s.n = (combined >> 19) & nMask; s.a = withSign(combined&dataMask, aSign)
+	case "SRD":
+		value := combineWords(s.a, s.q) >> count; s.a = withSign(int((value>>20)&dataMask), aSign); s.q = withSign(int(value&dataMask), aSign)
+	case "NAQ":
+		combined := (((s.n & nMask) << 38) | ((aData & dataMask) << 19) | qData) >> count
+		s.n = (combined >> 38) & nMask; s.a = withSign((combined>>19)&dataMask, aSign); s.q = withSign(combined&dataMask, aSign)
+	case "SCD":
+		rotation := count % 38; combined := ((aData & dataMask) << 19) | qData
+		if rotation != 0 { combined = ((combined >> rotation) | (combined << (38 - rotation))) & ((1 << 38) - 1) }
+		s.a = withSign((combined>>19)&dataMask, aSign); s.q = withSign(combined&dataMask, aSign)
+	case "ANQ":
+		for i := 0; i < count; i++ { bit := s.a & 1; s.a = fromSigned20(toSigned20(s.a) >> 1); qData = ((bit << 18) | ((s.q & dataMask) >> 1)) & dataMask; s.q = withSign(qData, aSign); s.n = ((bit << 5) | (s.n >> 1)) & nMask }
+	case "SLD":
+		combined := ((aData & dataMask) << 19) | qData; s.overflow = (combined >> max(0, 38-count)) != 0; combined = (combined << count) & ((1 << 38) - 1); s.a = withSign((combined>>19)&dataMask, qSign); s.q = withSign(combined&dataMask, qSign)
+	case "NOR":
+		shifts, targetBit := 0, 0; if aSign == 1 { targetBit = 1 }
+		for shifts < count { lead := (aData >> 18) & 1; if lead != targetBit { break }; s.overflow = s.overflow || lead == 1; aData = (aData << 1) & dataMask; shifts++ }
+		s.a = withSign(aData, aSign); s.setXWord(0, count-shifts)
+	case "DNO":
+		shifts, targetBit := 0, 0; if aSign == 1 { targetBit = 1 }
+		combined := ((aData & dataMask) << 19) | qData
+		for shifts < count { lead := (combined >> 37) & 1; if lead != targetBit { break }; s.overflow = s.overflow || lead == 1; combined = (combined << 1) & ((1 << 38) - 1); shifts++ }
+		s.a = withSign((combined>>19)&dataMask, qSign); s.q = withSign(combined&dataMask, qSign); s.setXWord(0, count-shifts)
+	}
+}
+
+func (s *Simulator) decodeWord(word int) (decodedInstruction, error) {
+	normalized := word & mask20
+	if name, ok := fixedNames[normalized]; ok { return decodedInstruction{Mnemonic: name, FixedWord: true}, nil }
+	for name, base := range shiftBases {
+		if (normalized & ^0o37) == base { count := normalized & 0o37; return decodedInstruction{Mnemonic: name, Count: &count, FixedWord: true}, nil }
+	}
+	opcode, modifier, address := DecodeInstruction(normalized); mnemonic, ok := baseOpcodeNames[opcode]
+	if !ok { return decodedInstruction{}, fmt.Errorf("unknown GE-225 opcode field %o", opcode) }
+	return decodedInstruction{Mnemonic: mnemonic, Opcode: &opcode, Modifier: &modifier, Address: &address, FixedWord: false}, nil
+}
+
+func (s *Simulator) resolveEffectiveAddress(address, modifier int) int {
+	base := address % s.memorySize
+	if modifier == 0 { return base }
+	return (base + (s.getXWord(modifier) % s.memorySize)) % s.memorySize
+}
+
+func (s *Simulator) checkAddress(address int) error {
+	if address < 0 || address >= s.memorySize { return fmt.Errorf("address out of range: %d", address) }
+	return nil
+}
+
+func min(a, b int) int { if a < b { return a }; return b }
+func max(a, b int) int { if a > b { return a }; return b }

--- a/code/packages/go/ge225-simulator/simulator_test.go
+++ b/code/packages/go/ge225-simulator/simulator_test.go
@@ -1,0 +1,109 @@
+package ge225simulator
+
+import "testing"
+
+func ins(t *testing.T, opcode, address, modifier int) int {
+	t.Helper()
+	word, err := EncodeInstruction(opcode, modifier, address)
+	if err != nil { t.Fatalf("encode failed: %v", err) }
+	return word
+}
+
+func fixed(t *testing.T, mnemonic string) int {
+	t.Helper()
+	word, err := AssembleFixed(mnemonic)
+	if err != nil { t.Fatalf("assemble fixed failed: %v", err) }
+	return word
+}
+
+func shift(t *testing.T, mnemonic string, count int) int {
+	t.Helper()
+	word, err := AssembleShift(mnemonic, count)
+	if err != nil { t.Fatalf("assemble shift failed: %v", err) }
+	return word
+}
+
+func TestEncodeDecodeRoundTrip(t *testing.T) {
+	word := ins(t, 0o01, 0x1234&0x1fff, 0o2)
+	opcode, modifier, address := DecodeInstruction(word)
+	if opcode != 0o01 || modifier != 0o2 || address != (0x1234&0x1fff) {
+		t.Fatalf("unexpected decode: %o %o %o", opcode, modifier, address)
+	}
+	packed := PackWords([]int{word, fixed(t, "NOP")})
+	unpacked, err := UnpackWords(packed)
+	if err != nil { t.Fatalf("unpack failed: %v", err) }
+	if len(unpacked) != 2 || unpacked[0] != word || unpacked[1] != fixed(t, "NOP") {
+		t.Fatalf("unexpected unpacked words: %#v", unpacked)
+	}
+}
+
+func TestLDAAddSTAProgram(t *testing.T) {
+	sim := New(4096)
+	if err := sim.LoadWords([]int{ins(t, 0o00, 10, 0), ins(t, 0o01, 11, 0), ins(t, 0o03, 12, 0), fixed(t, "NOP"), 0, 0, 0, 0, 0, 0, 1, 2, 0}, 0); err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+	if _, err := sim.Run(4); err != nil { t.Fatalf("run failed: %v", err) }
+	state := sim.GetState()
+	if state.A != 3 || state.Memory[12] != 3 { t.Fatalf("unexpected state: %+v", state) }
+}
+
+func TestSPBStoresP(t *testing.T) {
+	sim := New(4096)
+	if err := sim.LoadWords([]int{ins(t, 0o07, 4, 2), fixed(t, "NOP"), fixed(t, "NOP"), fixed(t, "NOP"), ins(t, 0o00, 10, 0), fixed(t, "NOP"), 0, 0, 0, 0, 0x12345}, 0); err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+	if _, err := sim.Run(3); err != nil { t.Fatalf("run failed: %v", err) }
+	state := sim.GetState()
+	if state.XWords[2] != 0 || state.A != 0x12345 { t.Fatalf("unexpected state: %+v", state) }
+}
+
+func TestOddAddressDoubleOps(t *testing.T) {
+	sim := New(4096)
+	_ = sim.WriteWord(11, 0x13579)
+	if err := sim.LoadWords([]int{ins(t, 0o10, 11, 0), ins(t, 0o13, 13, 0), fixed(t, "NOP")}, 0); err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+	if _, err := sim.Run(3); err != nil { t.Fatalf("run failed: %v", err) }
+	state := sim.GetState()
+	if state.A != 0x13579 || state.Q != 0x13579 || state.Memory[13] != 0x13579 {
+		t.Fatalf("unexpected state: %+v", state)
+	}
+}
+
+func TestMOYMovesBlocks(t *testing.T) {
+	sim := New(4096)
+	_ = sim.WriteWord(20, 0x11111)
+	_ = sim.WriteWord(21, 0x22222)
+	_ = sim.WriteWord(30, 40)
+	_ = sim.WriteWord(31, (1<<20)-2)
+	if err := sim.LoadWords([]int{ins(t, 0o00, 30, 0), fixed(t, "LQA"), ins(t, 0o00, 31, 0), fixed(t, "XAQ"), ins(t, 0o24, 20, 0), fixed(t, "NOP")}, 0); err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+	if _, err := sim.Run(6); err != nil { t.Fatalf("run failed: %v", err) }
+	state := sim.GetState()
+	if state.A != 0 || state.Memory[40] != 0x11111 || state.Memory[41] != 0x22222 {
+		t.Fatalf("unexpected state: %+v", state)
+	}
+}
+
+func TestConsoleTypewriterPath(t *testing.T) {
+	sim := New(4096)
+	sim.SetControlSwitches(0o1633)
+	if err := sim.LoadWords([]int{fixed(t, "RCS"), fixed(t, "TON"), shift(t, "SAN", 6), fixed(t, "TYP"), fixed(t, "NOP")}, 0); err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+	if _, err := sim.Run(5); err != nil { t.Fatalf("run failed: %v", err) }
+	if sim.GetTypewriterOutput() != "-" { t.Fatalf("unexpected output: %q", sim.GetTypewriterOutput()) }
+	if !sim.GetState().TypewriterPower { t.Fatalf("typewriter should be on") }
+}
+
+func TestRCDLoadsQueuedRecord(t *testing.T) {
+	sim := New(4096)
+	sim.QueueCardReaderRecord([]int{0x11111, 0x22222})
+	if err := sim.LoadWords([]int{ins(t, 0o25, 10, 0), fixed(t, "NOP")}, 0); err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+	if _, err := sim.Run(2); err != nil { t.Fatalf("run failed: %v", err) }
+	state := sim.GetState()
+	if state.Memory[10] != 0x11111 || state.Memory[11] != 0x22222 { t.Fatalf("unexpected memory: %#v %#v", state.Memory[10], state.Memory[11]) }
+}

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -56,6 +56,7 @@ members = [
     "fsharp-lexer",
     "fsharp-parser",
     "garbage-collector",
+    "ge225-simulator",
     "hkdf",
     "hmac",
     "pbkdf2",

--- a/code/packages/rust/ge225-simulator/BUILD
+++ b/code/packages/rust/ge225-simulator/BUILD
@@ -1,0 +1,1 @@
+cargo test

--- a/code/packages/rust/ge225-simulator/CHANGELOG.md
+++ b/code/packages/rust/ge225-simulator/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to the ge225-simulator Rust package will be documented in this file.
+
+## [0.1.0] - 2026-04-15
+
+### Added
+- Initial Rust GE-225 behavioral simulator package
+- Documented opcode maps, helpers, and focused execution tests

--- a/code/packages/rust/ge225-simulator/Cargo.toml
+++ b/code/packages/rust/ge225-simulator/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "coding-adventures-ge225-simulator"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+description = "GE-225 behavioral simulator and compiler backend target"
+
+[lib]
+name = "coding_adventures_ge225_simulator"
+path = "src/lib.rs"

--- a/code/packages/rust/ge225-simulator/README.md
+++ b/code/packages/rust/ge225-simulator/README.md
@@ -1,0 +1,6 @@
+# GE-225 Simulator (Rust)
+
+Behavioral Rust simulator for the **GE-225 instruction repertoire**.
+
+This package mirrors the same GE-225 machine model now available in Python, Go,
+and TypeScript so we can cross-check backend behavior across implementations.

--- a/code/packages/rust/ge225-simulator/src/lib.rs
+++ b/code/packages/rust/ge225-simulator/src/lib.rs
@@ -1,0 +1,808 @@
+const MASK_20: i32 = (1 << 20) - 1;
+const DATA_MASK: i32 = (1 << 19) - 1;
+const SIGN_BIT: i32 = 1 << 19;
+const ADDR_MASK: i32 = 0x1fff;
+const X_MASK: i32 = 0x7fff;
+const N_MASK: i32 = 0x3f;
+const WORD_BYTES: usize = 3;
+const MAX_X_GROUPS: usize = 32;
+
+const OP_LDA: i32 = 0o00;
+const OP_ADD: i32 = 0o01;
+const OP_SUB: i32 = 0o02;
+const OP_STA: i32 = 0o03;
+const OP_BXL: i32 = 0o04;
+const OP_BXH: i32 = 0o05;
+const OP_LDX: i32 = 0o06;
+const OP_SPB: i32 = 0o07;
+const OP_DLD: i32 = 0o10;
+const OP_DAD: i32 = 0o11;
+const OP_DSU: i32 = 0o12;
+const OP_DST: i32 = 0o13;
+const OP_INX: i32 = 0o14;
+const OP_MPY: i32 = 0o15;
+const OP_DVD: i32 = 0o16;
+const OP_STX: i32 = 0o17;
+const OP_EXT: i32 = 0o20;
+const OP_CAB: i32 = 0o21;
+const OP_DCB: i32 = 0o22;
+const OP_ORY: i32 = 0o23;
+const OP_MOY: i32 = 0o24;
+const OP_RCD: i32 = 0o25;
+const OP_BRU: i32 = 0o26;
+const OP_STO: i32 = 0o27;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Indicators {
+    pub carry: bool,
+    pub zero: bool,
+    pub negative: bool,
+    pub overflow: bool,
+    pub parity_error: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct State {
+    pub a: i32,
+    pub q: i32,
+    pub m: i32,
+    pub n: i32,
+    pub pc: i32,
+    pub ir: i32,
+    pub indicators: Indicators,
+    pub overflow: bool,
+    pub parity_error: bool,
+    pub decimal_mode: bool,
+    pub automatic_interrupt_mode: bool,
+    pub selected_x_group: usize,
+    pub n_ready: bool,
+    pub typewriter_power: bool,
+    pub control_switches: i32,
+    pub x_words: Vec<i32>,
+    pub halted: bool,
+    pub memory: Vec<i32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Trace {
+    pub address: i32,
+    pub instruction_word: i32,
+    pub mnemonic: String,
+    pub a_before: i32,
+    pub a_after: i32,
+    pub q_before: i32,
+    pub q_after: i32,
+    pub effective_address: Option<i32>,
+}
+
+#[derive(Debug, Clone)]
+struct DecodedInstruction {
+    mnemonic: &'static str,
+    modifier: Option<i32>,
+    address: Option<i32>,
+    count: Option<i32>,
+    fixed_word: bool,
+}
+
+fn base_opcode_name(opcode: i32) -> Option<&'static str> {
+    Some(match opcode {
+        OP_LDA => "LDA",
+        OP_ADD => "ADD",
+        OP_SUB => "SUB",
+        OP_STA => "STA",
+        OP_BXL => "BXL",
+        OP_BXH => "BXH",
+        OP_LDX => "LDX",
+        OP_SPB => "SPB",
+        OP_DLD => "DLD",
+        OP_DAD => "DAD",
+        OP_DSU => "DSU",
+        OP_DST => "DST",
+        OP_INX => "INX",
+        OP_MPY => "MPY",
+        OP_DVD => "DVD",
+        OP_STX => "STX",
+        OP_EXT => "EXT",
+        OP_CAB => "CAB",
+        OP_DCB => "DCB",
+        OP_ORY => "ORY",
+        OP_MOY => "MOY",
+        OP_RCD => "RCD",
+        OP_BRU => "BRU",
+        OP_STO => "STO",
+        _ => return None,
+    })
+}
+
+fn fixed_word(mnemonic: &str) -> Option<i32> {
+    Some(match mnemonic {
+        "OFF" => 0o2500005,
+        "TYP" => 0o2500006,
+        "TON" => 0o2500007,
+        "RCS" => 0o2500011,
+        "HPT" => 0o2500016,
+        "LDZ" => 0o2504002,
+        "LDO" => 0o2504022,
+        "LMO" => 0o2504102,
+        "CPL" => 0o2504502,
+        "NEG" => 0o2504522,
+        "CHS" => 0o2504040,
+        "NOP" => 0o2504012,
+        "LAQ" => 0o2504001,
+        "LQA" => 0o2504004,
+        "XAQ" => 0o2504005,
+        "MAQ" => 0o2504006,
+        "ADO" => 0o2504032,
+        "SBO" => 0o2504112,
+        "SET_DECMODE" => 0o2506011,
+        "SET_BINMODE" => 0o2506012,
+        "SXG" => 0o2506013,
+        "SET_PST" => 0o2506015,
+        "SET_PBK" => 0o2506016,
+        "BOD" => 0o2514000,
+        "BEV" => 0o2516000,
+        "BMI" => 0o2514001,
+        "BPL" => 0o2516001,
+        "BZE" => 0o2514002,
+        "BNZ" => 0o2516002,
+        "BOV" => 0o2514003,
+        "BNO" => 0o2516003,
+        "BPE" => 0o2514004,
+        "BPC" => 0o2516004,
+        "BNR" => 0o2514005,
+        "BNN" => 0o2516005,
+        _ => return None,
+    })
+}
+
+fn fixed_name(word: i32) -> Option<&'static str> {
+    Some(match word {
+        0o2500005 => "OFF",
+        0o2500006 => "TYP",
+        0o2500007 => "TON",
+        0o2500011 => "RCS",
+        0o2500016 => "HPT",
+        0o2504002 => "LDZ",
+        0o2504022 => "LDO",
+        0o2504102 => "LMO",
+        0o2504502 => "CPL",
+        0o2504522 => "NEG",
+        0o2504040 => "CHS",
+        0o2504012 => "NOP",
+        0o2504001 => "LAQ",
+        0o2504004 => "LQA",
+        0o2504005 => "XAQ",
+        0o2504006 => "MAQ",
+        0o2504032 => "ADO",
+        0o2504112 => "SBO",
+        0o2506011 => "SET_DECMODE",
+        0o2506012 => "SET_BINMODE",
+        0o2506013 => "SXG",
+        0o2506015 => "SET_PST",
+        0o2506016 => "SET_PBK",
+        0o2514000 => "BOD",
+        0o2516000 => "BEV",
+        0o2514001 => "BMI",
+        0o2516001 => "BPL",
+        0o2514002 => "BZE",
+        0o2516002 => "BNZ",
+        0o2514003 => "BOV",
+        0o2516003 => "BNO",
+        0o2514004 => "BPE",
+        0o2516004 => "BPC",
+        0o2514005 => "BNR",
+        0o2516005 => "BNN",
+        _ => return None,
+    })
+}
+
+fn shift_base(mnemonic: &str) -> Option<i32> {
+    Some(match mnemonic {
+        "SRA" => 0o2510000,
+        "SNA" => 0o2510100,
+        "SCA" => 0o2510040,
+        "SAN" => 0o2510400,
+        "SRD" => 0o2511000,
+        "NAQ" => 0o2511100,
+        "SCD" => 0o2511200,
+        "ANQ" => 0o2511400,
+        "SLA" => 0o2512000,
+        "SLD" => 0o2512200,
+        "NOR" => 0o2513000,
+        "DNO" => 0o2513200,
+        _ => return None,
+    })
+}
+
+fn typewriter_char(code: i32) -> Option<&'static str> {
+    Some(match code {
+        0o00 => "0", 0o01 => "1", 0o02 => "2", 0o03 => "3", 0o04 => "4", 0o05 => "5",
+        0o06 => "6", 0o07 => "7", 0o10 => "8", 0o11 => "9", 0o13 => "/", 0o21 => "A",
+        0o22 => "B", 0o23 => "C", 0o24 => "D", 0o25 => "E", 0o26 => "F", 0o27 => "G",
+        0o30 => "H", 0o31 => "I", 0o33 => "-", 0o40 => ".", 0o41 => "J", 0o42 => "K",
+        0o43 => "L", 0o44 => "M", 0o45 => "N", 0o46 => "O", 0o47 => "P", 0o50 => "Q",
+        0o51 => "R", 0o53 => "$", 0o60 => " ", 0o62 => "S", 0o63 => "T", 0o64 => "U",
+        0o65 => "V", 0o66 => "W", 0o67 => "X", 0o70 => "Y", 0o71 => "Z",
+        _ => return None,
+    })
+}
+
+fn to_signed20(value: i32) -> i32 {
+    let word = value & MASK_20;
+    if (word & SIGN_BIT) != 0 { word - (1 << 20) } else { word }
+}
+
+fn from_signed20(value: i32) -> i32 { value & MASK_20 }
+fn sign_of(word: i32) -> i32 { if (word & SIGN_BIT) != 0 { 1 } else { 0 } }
+fn with_sign(word: i32, sign: i32) -> i32 { ((sign & 1) << 19) | (word & DATA_MASK) }
+
+fn combine_words(high: i32, low: i32) -> i64 {
+    ((high & MASK_20) as i64) << 20 | ((low & MASK_20) as i64)
+}
+
+fn to_signed40(value: i64) -> i64 {
+    (value << 24) >> 24
+}
+
+fn split_signed40(value: i64) -> (i32, i32) {
+    let raw = value & ((1_i64 << 40) - 1);
+    (((raw >> 20) & MASK_20 as i64) as i32, (raw & MASK_20 as i64) as i32)
+}
+
+fn arith_compare(left: i32, right: i32) -> i32 {
+    match to_signed20(left).cmp(&to_signed20(right)) {
+        std::cmp::Ordering::Less => -1,
+        std::cmp::Ordering::Greater => 1,
+        std::cmp::Ordering::Equal => 0,
+    }
+}
+
+fn arith_compare_double(left_high: i32, left_low: i32, right_high: i32, right_low: i32) -> i32 {
+    match to_signed40(combine_words(left_high, left_low)).cmp(&to_signed40(combine_words(right_high, right_low))) {
+        std::cmp::Ordering::Less => -1,
+        std::cmp::Ordering::Greater => 1,
+        std::cmp::Ordering::Equal => 0,
+    }
+}
+
+pub fn encode_instruction(opcode: i32, modifier: i32, address: i32) -> Result<i32, String> {
+    if !(0..=0o37).contains(&opcode) { return Err(format!("opcode out of range: {opcode}")); }
+    if !(0..=0o3).contains(&modifier) { return Err(format!("modifier out of range: {modifier}")); }
+    if !(0..=ADDR_MASK).contains(&address) { return Err(format!("address out of range: {address}")); }
+    Ok(((opcode & 0x1f) << 15) | ((modifier & 0x03) << 13) | (address & ADDR_MASK))
+}
+
+pub fn decode_instruction(word: i32) -> (i32, i32, i32) {
+    let normalized = word & MASK_20;
+    ((normalized >> 15) & 0x1f, (normalized >> 13) & 0x03, normalized & ADDR_MASK)
+}
+
+pub fn assemble_fixed(mnemonic: &str) -> Result<i32, String> {
+    fixed_word(mnemonic).ok_or_else(|| format!("unknown fixed GE-225 instruction: {mnemonic}"))
+}
+
+pub fn assemble_shift(mnemonic: &str, count: i32) -> Result<i32, String> {
+    if !(0..=0o37).contains(&count) { return Err(format!("shift count out of range: {count}")); }
+    shift_base(mnemonic)
+        .map(|base| base | count)
+        .ok_or_else(|| format!("unknown GE-225 shift instruction: {mnemonic}"))
+}
+
+pub fn pack_words(words: &[i32]) -> Vec<u8> {
+    let mut blob = vec![0; words.len() * WORD_BYTES];
+    for (index, word) in words.iter().enumerate() {
+        let normalized = word & MASK_20;
+        blob[index * WORD_BYTES] = ((normalized >> 16) & 0xff) as u8;
+        blob[index * WORD_BYTES + 1] = ((normalized >> 8) & 0xff) as u8;
+        blob[index * WORD_BYTES + 2] = (normalized & 0xff) as u8;
+    }
+    blob
+}
+
+pub fn unpack_words(program: &[u8]) -> Result<Vec<i32>, String> {
+    if program.len() % WORD_BYTES != 0 {
+        return Err(format!("GE-225 byte stream must be a multiple of {WORD_BYTES} bytes, got {}", program.len()));
+    }
+    Ok(program
+        .chunks_exact(WORD_BYTES)
+        .map(|chunk| (((chunk[0] as i32) << 16) | ((chunk[1] as i32) << 8) | chunk[2] as i32) & MASK_20)
+        .collect())
+}
+
+pub struct Simulator {
+    memory_size: i32,
+    memory: Vec<i32>,
+    card_reader_queue: Vec<Vec<i32>>,
+    a: i32,
+    q: i32,
+    m: i32,
+    n: i32,
+    pc: i32,
+    ir: i32,
+    overflow: bool,
+    parity_error: bool,
+    decimal_mode: bool,
+    automatic_interrupt_mode: bool,
+    selected_x_group: usize,
+    n_ready: bool,
+    typewriter_power: bool,
+    typewriter_output: Vec<String>,
+    control_switches: i32,
+    halted: bool,
+    x_groups: [[i32; 4]; MAX_X_GROUPS],
+}
+
+impl Simulator {
+    pub fn new(memory_words: i32) -> Self {
+        assert!(memory_words > 0, "memory_words must be positive");
+        Self {
+            memory_size: memory_words,
+            memory: vec![0; memory_words as usize],
+            card_reader_queue: vec![],
+            a: 0, q: 0, m: 0, n: 0, pc: 0, ir: 0,
+            overflow: false, parity_error: false, decimal_mode: false, automatic_interrupt_mode: false,
+            selected_x_group: 0, n_ready: true, typewriter_power: false, typewriter_output: vec![],
+            control_switches: 0, halted: false, x_groups: [[0; 4]; MAX_X_GROUPS],
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.a = 0; self.q = 0; self.m = 0; self.n = 0; self.pc = 0; self.ir = 0;
+        self.overflow = false; self.parity_error = false; self.decimal_mode = false; self.automatic_interrupt_mode = false;
+        self.selected_x_group = 0; self.n_ready = true; self.typewriter_power = false; self.typewriter_output.clear();
+        self.control_switches = 0; self.halted = false; self.x_groups = [[0; 4]; MAX_X_GROUPS];
+    }
+
+    pub fn get_state(&self) -> State {
+        State {
+            a: self.a, q: self.q, m: self.m, n: self.n, pc: self.pc, ir: self.ir,
+            indicators: Indicators {
+                carry: self.overflow, zero: self.a == 0, negative: (self.a & SIGN_BIT) != 0,
+                overflow: self.overflow, parity_error: self.parity_error,
+            },
+            overflow: self.overflow, parity_error: self.parity_error, decimal_mode: self.decimal_mode,
+            automatic_interrupt_mode: self.automatic_interrupt_mode, selected_x_group: self.selected_x_group,
+            n_ready: self.n_ready, typewriter_power: self.typewriter_power, control_switches: self.control_switches,
+            x_words: self.x_groups[self.selected_x_group].to_vec(), halted: self.halted, memory: self.memory.clone(),
+        }
+    }
+
+    pub fn set_control_switches(&mut self, value: i32) { self.control_switches = value & MASK_20; }
+    pub fn queue_card_reader_record(&mut self, words: &[i32]) { self.card_reader_queue.push(words.iter().map(|w| w & MASK_20).collect()); }
+    pub fn get_typewriter_output(&self) -> String { self.typewriter_output.join("") }
+    pub fn load_words(&mut self, words: &[i32], start_address: i32) -> Result<(), String> {
+        for (offset, word) in words.iter().enumerate() { self.write_word(start_address + offset as i32, *word)?; }
+        Ok(())
+    }
+    pub fn read_word(&self, address: i32) -> Result<i32, String> {
+        self.check_address(address)?;
+        Ok(self.memory[address as usize])
+    }
+    pub fn write_word(&mut self, address: i32, value: i32) -> Result<(), String> {
+        self.check_address(address)?;
+        self.memory[address as usize] = value & MASK_20;
+        Ok(())
+    }
+
+    pub fn disassemble_word(&self, word: i32) -> Result<String, String> {
+        let decoded = self.decode_word(word)?;
+        if decoded.fixed_word {
+            return Ok(match decoded.count { Some(count) => format!("{} {count}", decoded.mnemonic), None => decoded.mnemonic.to_string() });
+        }
+        Ok(format!("{} 0x{:03X},X{}", decoded.mnemonic, decoded.address.unwrap(), decoded.modifier.unwrap()))
+    }
+
+    pub fn step(&mut self) -> Result<Trace, String> {
+        if self.halted { return Err("cannot step a halted GE-225 simulator".into()); }
+        let pc_before = self.pc;
+        self.ir = self.read_word(self.pc)?;
+        self.pc = (self.pc + 1) % self.memory_size;
+        let decoded = self.decode_word(self.ir)?;
+        let a_before = self.a;
+        let q_before = self.q;
+        let mut effective_address = None;
+        if !decoded.fixed_word {
+            let address = decoded.address.unwrap();
+            if !matches!(decoded.mnemonic, "BXL" | "BXH" | "LDX" | "SPB" | "INX" | "STX" | "MOY") {
+                effective_address = Some(self.resolve_effective_address(address, decoded.modifier.unwrap()));
+            }
+            self.execute_memory_reference(decoded.mnemonic, decoded.modifier.unwrap(), effective_address.unwrap_or(address), address, pc_before)?;
+        } else {
+            self.execute_fixed(&decoded)?;
+        }
+        Ok(Trace {
+            address: pc_before,
+            instruction_word: self.ir,
+            mnemonic: self.disassemble_word(self.ir)?,
+            a_before,
+            a_after: self.a,
+            q_before,
+            q_after: self.q,
+            effective_address,
+        })
+    }
+
+    pub fn run(&mut self, max_steps: usize) -> Result<Vec<Trace>, String> {
+        let mut traces = vec![];
+        for _ in 0..max_steps {
+            if self.halted { break; }
+            traces.push(self.step()?);
+        }
+        Ok(traces)
+    }
+
+    fn get_x_word(&self, slot: usize) -> i32 { self.x_groups[self.selected_x_group][slot] & X_MASK }
+    fn set_x_word(&mut self, slot: usize, value: i32) { self.x_groups[self.selected_x_group][slot] = value & X_MASK; }
+
+    fn execute_memory_reference(&mut self, mnemonic: &str, modifier: i32, effective_or_raw_address: i32, raw_address: i32, pc_before: i32) -> Result<(), String> {
+        let effective_address = effective_or_raw_address % self.memory_size;
+        match mnemonic {
+            "LDA" => { self.m = self.read_word(effective_address)?; self.a = self.m; }
+            "ADD" => { self.m = self.read_word(effective_address)?; let total = to_signed20(self.a) + to_signed20(self.m); self.a = from_signed20(total); self.overflow = !(-(1 << 19)..=(1 << 19) - 1).contains(&total); }
+            "SUB" => { self.m = self.read_word(effective_address)?; let total = to_signed20(self.a) - to_signed20(self.m); self.a = from_signed20(total); self.overflow = !(-(1 << 19)..=(1 << 19) - 1).contains(&total); }
+            "STA" => self.write_word(effective_address, self.a)?,
+            "BXL" => if (self.get_x_word(modifier as usize) & ADDR_MASK) >= raw_address { self.pc = (self.pc + 1) % self.memory_size; },
+            "BXH" => if (self.get_x_word(modifier as usize) & ADDR_MASK) < raw_address { self.pc = (self.pc + 1) % self.memory_size; },
+            "LDX" => { let word = self.read_word(raw_address % self.memory_size)?; self.set_x_word(modifier as usize, word); }
+            "SPB" => { self.set_x_word(modifier as usize, pc_before); self.pc = raw_address % self.memory_size; }
+            "DLD" => {
+                let first = self.read_word(effective_address)?;
+                if (effective_address & 1) != 0 { self.a = first; self.q = first; }
+                else { self.a = first; self.q = self.read_word((effective_address + 1) % self.memory_size)?; }
+            }
+            "DAD" => {
+                let left = to_signed40(combine_words(self.a, self.q));
+                let first = self.read_word(effective_address)?;
+                let second = if (effective_address & 1) != 0 { first } else { self.read_word((effective_address + 1) % self.memory_size)? };
+                let total = left + to_signed40(combine_words(first, second));
+                (self.a, self.q) = split_signed40(total);
+                self.overflow = !(-(1_i64 << 39)..=((1_i64 << 39) - 1)).contains(&total);
+            }
+            "DSU" => {
+                let left = to_signed40(combine_words(self.a, self.q));
+                let first = self.read_word(effective_address)?;
+                let second = if (effective_address & 1) != 0 { first } else { self.read_word((effective_address + 1) % self.memory_size)? };
+                let total = left - to_signed40(combine_words(first, second));
+                (self.a, self.q) = split_signed40(total);
+                self.overflow = !(-(1_i64 << 39)..=((1_i64 << 39) - 1)).contains(&total);
+            }
+            "DST" => {
+                if (effective_address & 1) != 0 { self.write_word(effective_address, self.q)?; }
+                else { self.write_word(effective_address, self.a)?; self.write_word((effective_address + 1) % self.memory_size, self.q)?; }
+            }
+            "INX" => self.set_x_word(modifier as usize, (self.get_x_word(modifier as usize) + raw_address) & X_MASK),
+            "MPY" => {
+                self.m = self.read_word(effective_address)?;
+                let product = i64::from(to_signed20(self.q)) * i64::from(to_signed20(self.m)) + i64::from(to_signed20(self.a));
+                (self.a, self.q) = split_signed40(product);
+                self.overflow = !(-(1_i64 << 39)..=((1_i64 << 39) - 1)).contains(&product);
+            }
+            "DVD" => {
+                self.m = self.read_word(effective_address)?;
+                let divisor = i64::from(to_signed20(self.m));
+                if divisor == 0 { return Err("GE-225 divide by zero".into()); }
+                if i64::from(to_signed20(self.a).abs()) >= divisor.abs() { self.overflow = true; return Ok(()); }
+                let dividend = to_signed40(combine_words(self.a, self.q));
+                let quotient_mag = dividend.abs() / divisor.abs();
+                let remainder_mag = dividend.abs() % divisor.abs();
+                let quotient = if (dividend < 0) ^ (divisor < 0) { -quotient_mag } else { quotient_mag };
+                let remainder = if quotient < 0 { -remainder_mag } else { remainder_mag };
+                self.a = from_signed20(quotient as i32);
+                self.q = from_signed20(remainder as i32);
+                self.overflow = !(-(1_i64 << 19)..=((1_i64 << 19) - 1)).contains(&quotient);
+            }
+            "STX" => self.write_word(raw_address % self.memory_size, self.get_x_word(modifier as usize))?,
+            "EXT" => { self.m = self.read_word(effective_address)?; self.a &= (!self.m) & MASK_20; }
+            "CAB" => {
+                self.m = self.read_word(effective_address)?;
+                match arith_compare(self.m, self.a) {
+                    0 => self.pc = (self.pc + 1) % self.memory_size,
+                    x if x < 0 => self.pc = (self.pc + 2) % self.memory_size,
+                    _ => {}
+                }
+            }
+            "DCB" => {
+                let first = self.read_word(effective_address)?;
+                let second = if (effective_address & 1) != 0 { first } else { self.read_word((effective_address + 1) % self.memory_size)? };
+                match arith_compare_double(first, second, self.a, self.q) {
+                    0 => self.pc = (self.pc + 1) % self.memory_size,
+                    x if x < 0 => self.pc = (self.pc + 2) % self.memory_size,
+                    _ => {}
+                }
+            }
+            "ORY" => {
+                let word = self.read_word(effective_address)?;
+                self.write_word(effective_address, word | self.a)?;
+            }
+            "MOY" => {
+                let word_count = (-to_signed20(self.q)).max(0);
+                let destination = self.a & X_MASK;
+                for offset in 0..word_count { let word = self.read_word((raw_address + offset) % self.memory_size)?; self.write_word((destination + offset) % self.memory_size, word)?; }
+                self.set_x_word(0, self.pc);
+                self.a = 0;
+            }
+            "RCD" => {
+                if self.card_reader_queue.is_empty() { return Err("RCD executed with no queued card-reader record".into()); }
+                let record = self.card_reader_queue.remove(0);
+                for (offset, word) in record.iter().enumerate() { self.write_word((effective_address + offset as i32) % self.memory_size, *word)?; }
+            }
+            "BRU" => self.pc = effective_address,
+            "STO" => {
+                let existing = self.read_word(effective_address)?;
+                self.write_word(effective_address, (existing & !ADDR_MASK) | (self.a & ADDR_MASK))?;
+            }
+            _ => return Err(format!("unimplemented GE-225 memory-reference instruction: {mnemonic}")),
+        }
+        Ok(())
+    }
+
+    fn execute_fixed(&mut self, decoded: &DecodedInstruction) -> Result<(), String> {
+        let mnemonic = decoded.mnemonic;
+        let count = decoded.count.unwrap_or(0);
+        match mnemonic {
+            "OFF" => { self.typewriter_power = false; self.n_ready = true; }
+            "TYP" => {
+                if !self.typewriter_power { self.n_ready = false; return Ok(()); }
+                let code = self.n & N_MASK;
+                if code == 0o37 { self.typewriter_output.push("\r".into()); }
+                else if code == 0o76 { self.typewriter_output.push("\t".into()); }
+                else if code != 0o72 && code != 0o75 {
+                    let ch = typewriter_char(code).ok_or_else(|| "invalid typewriter code".to_string())?;
+                    self.typewriter_output.push(ch.into());
+                }
+                self.n_ready = true;
+            }
+            "TON" => self.typewriter_power = true,
+            "RCS" => self.a |= self.control_switches,
+            "HPT" => self.n_ready = false,
+            "LDZ" => self.a = 0,
+            "LDO" => self.a = 1,
+            "LMO" => self.a = MASK_20,
+            "CPL" => self.a = (!self.a) & MASK_20,
+            "NEG" => { let before = to_signed20(self.a); self.a = from_signed20(-before); self.overflow = before == -(1 << 19); }
+            "CHS" => self.a ^= SIGN_BIT,
+            "NOP" => {}
+            "LAQ" => self.a = self.q,
+            "LQA" => self.q = self.a,
+            "XAQ" => std::mem::swap(&mut self.a, &mut self.q),
+            "MAQ" => { self.q = self.a; self.a = 0; }
+            "ADO" => { let total = to_signed20(self.a) + 1; self.a = from_signed20(total); self.overflow = !(-(1 << 19)..=(1 << 19) - 1).contains(&total); }
+            "SBO" => { let total = to_signed20(self.a) - 1; self.a = from_signed20(total); self.overflow = !(-(1 << 19)..=(1 << 19) - 1).contains(&total); }
+            "SET_DECMODE" => self.decimal_mode = true,
+            "SET_BINMODE" => self.decimal_mode = false,
+            "SXG" => self.selected_x_group = (self.a & 0x1f) as usize,
+            "SET_PST" => self.automatic_interrupt_mode = true,
+            "SET_PBK" => self.automatic_interrupt_mode = false,
+            "BOD" | "BEV" | "BMI" | "BPL" | "BZE" | "BNZ" | "BOV" | "BNO" | "BPE" | "BPC" | "BNR" | "BNN" => self.execute_branch_test(mnemonic),
+            _ => {
+                if shift_base(mnemonic).is_some() { self.execute_shift(mnemonic, count); }
+                else { return Err(format!("unimplemented GE-225 fixed instruction: {mnemonic}")); }
+            }
+        }
+        Ok(())
+    }
+
+    fn execute_branch_test(&mut self, mnemonic: &str) {
+        let cond = match mnemonic {
+            "BOD" => (self.a & 1) != 0,
+            "BEV" => (self.a & 1) == 0,
+            "BMI" => (self.a & SIGN_BIT) != 0,
+            "BPL" => (self.a & SIGN_BIT) == 0,
+            "BZE" => self.a == 0,
+            "BNZ" => self.a != 0,
+            "BOV" => self.overflow,
+            "BNO" => !self.overflow,
+            "BPE" => self.parity_error,
+            "BPC" => !self.parity_error,
+            "BNR" => self.n_ready,
+            "BNN" => !self.n_ready,
+            _ => false,
+        };
+        if matches!(mnemonic, "BOV" | "BNO") { self.overflow = false; }
+        if matches!(mnemonic, "BPE" | "BPC") { self.parity_error = false; }
+        if !cond { self.pc = (self.pc + 1) % self.memory_size; }
+    }
+
+    fn execute_shift(&mut self, mnemonic: &str, count: i32) {
+        if count == 0 {
+            if mnemonic == "SRD" { self.q = with_sign(self.q, sign_of(self.a)); }
+            else if mnemonic == "SLD" { self.a = with_sign(self.a, sign_of(self.q)); }
+            return;
+        }
+        let a_sign = sign_of(self.a);
+        let mut a_data = self.a & DATA_MASK;
+        let q_sign = sign_of(self.q);
+        let mut q_data = self.q & DATA_MASK;
+        match mnemonic {
+            "SRA" => self.a = from_signed20(to_signed20(self.a) >> count.min(19)),
+            "SLA" => { self.overflow = (a_data >> (19 - count).max(0)) != 0; self.a = with_sign((a_data << count) & DATA_MASK, a_sign); }
+            "SCA" => { let rotation = count % 19; if rotation != 0 { a_data = ((a_data >> rotation) | (a_data << (19 - rotation))) & DATA_MASK; } self.a = with_sign(a_data, a_sign); }
+            "SAN" => {
+                let fill = if a_sign == 1 { (1 << count) - 1 } else { 0 };
+                let mut combined = ((a_data & DATA_MASK) << 6) | (self.n & N_MASK);
+                combined = ((fill << 25) | combined) >> count;
+                self.a = with_sign((combined >> 6) & DATA_MASK, a_sign);
+                self.n = combined & N_MASK;
+            }
+            "SNA" => {
+                let combined = (((self.n & N_MASK) << 19) | a_data) >> count;
+                self.n = (combined >> 19) & N_MASK;
+                self.a = with_sign(combined & DATA_MASK, a_sign);
+            }
+            "SRD" => {
+                let value = combine_words(self.a, self.q) >> count;
+                self.a = with_sign(((value >> 20) as i32) & DATA_MASK, a_sign);
+                self.q = with_sign((value as i32) & DATA_MASK, a_sign);
+            }
+            "NAQ" => {
+                let combined = ((((self.n & N_MASK) as i64) << 38) | (((a_data & DATA_MASK) as i64) << 19) | (q_data as i64)) >> count;
+                self.n = ((combined >> 38) as i32) & N_MASK;
+                self.a = with_sign(((combined >> 19) as i32) & DATA_MASK, a_sign);
+                self.q = with_sign((combined as i32) & DATA_MASK, a_sign);
+            }
+            "SCD" => {
+                let rotation = count % 38;
+                let mut combined = (((a_data & DATA_MASK) as i64) << 19) | (q_data as i64);
+                if rotation != 0 { combined = ((combined >> rotation) | (combined << (38 - rotation))) & ((1_i64 << 38) - 1); }
+                self.a = with_sign(((combined >> 19) as i32) & DATA_MASK, a_sign);
+                self.q = with_sign((combined as i32) & DATA_MASK, a_sign);
+            }
+            "ANQ" => {
+                for _ in 0..count {
+                    let bit = self.a & 1;
+                    self.a = from_signed20(to_signed20(self.a) >> 1);
+                    q_data = ((bit << 18) | ((self.q & DATA_MASK) >> 1)) & DATA_MASK;
+                    self.q = with_sign(q_data, a_sign);
+                    self.n = ((bit << 5) | (self.n >> 1)) & N_MASK;
+                }
+            }
+            "SLD" => {
+                let mut combined = (((a_data & DATA_MASK) as i64) << 19) | (q_data as i64);
+                self.overflow = (combined >> (38 - count).max(0)) != 0;
+                combined = (combined << count) & ((1_i64 << 38) - 1);
+                self.a = with_sign(((combined >> 19) as i32) & DATA_MASK, q_sign);
+                self.q = with_sign((combined as i32) & DATA_MASK, q_sign);
+            }
+            "NOR" => {
+                let mut shifts = 0;
+                let target_bit = if a_sign == 0 { 0 } else { 1 };
+                while shifts < count {
+                    let lead = (a_data >> 18) & 1;
+                    if lead != target_bit { break; }
+                    self.overflow |= lead == 1;
+                    a_data = (a_data << 1) & DATA_MASK;
+                    shifts += 1;
+                }
+                self.a = with_sign(a_data, a_sign);
+                self.set_x_word(0, count - shifts);
+            }
+            "DNO" => {
+                let mut shifts = 0;
+                let target_bit = if a_sign == 0 { 0 } else { 1 };
+                let mut combined = (((a_data & DATA_MASK) as i64) << 19) | (q_data as i64);
+                while shifts < count {
+                    let lead = (combined >> 37) & 1_i64;
+                    if lead != target_bit { break; }
+                    self.overflow |= lead == 1;
+                    combined = (combined << 1) & ((1_i64 << 38) - 1);
+                    shifts += 1;
+                }
+                self.a = with_sign(((combined >> 19) as i32) & DATA_MASK, q_sign);
+                self.q = with_sign((combined as i32) & DATA_MASK, q_sign);
+                self.set_x_word(0, count - shifts);
+            }
+            _ => {}
+        }
+    }
+
+    fn decode_word(&self, word: i32) -> Result<DecodedInstruction, String> {
+        let normalized = word & MASK_20;
+        if let Some(name) = fixed_name(normalized) {
+            return Ok(DecodedInstruction { mnemonic: name, modifier: None, address: None, count: None, fixed_word: true });
+        }
+        for name in ["SRA", "SNA", "SCA", "SAN", "SRD", "NAQ", "SCD", "ANQ", "SLA", "SLD", "NOR", "DNO"] {
+            if let Some(base) = shift_base(name) {
+                if (normalized & !0o37) == base {
+                    return Ok(DecodedInstruction { mnemonic: name, modifier: None, address: None, count: Some(normalized & 0o37), fixed_word: true });
+                }
+            }
+        }
+        let (opcode, modifier, address) = decode_instruction(normalized);
+        let mnemonic = base_opcode_name(opcode).ok_or_else(|| format!("unknown GE-225 opcode field {opcode:o}"))?;
+        Ok(DecodedInstruction { mnemonic, modifier: Some(modifier), address: Some(address), count: None, fixed_word: false })
+    }
+
+    fn resolve_effective_address(&self, address: i32, modifier: i32) -> i32 {
+        let base = address % self.memory_size;
+        if modifier == 0 { return base; }
+        (base + (self.get_x_word(modifier as usize) % self.memory_size)) % self.memory_size
+    }
+
+    fn check_address(&self, address: i32) -> Result<(), String> {
+        if address < 0 || address >= self.memory_size { Err(format!("address out of range: {address}")) } else { Ok(()) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ins(opcode: i32, address: i32, modifier: i32) -> i32 {
+        encode_instruction(opcode, modifier, address).unwrap()
+    }
+
+    #[test]
+    fn encode_decode_round_trip() {
+        let word = ins(0o01, 0x1234 & 0x1fff, 0o2);
+        assert_eq!(decode_instruction(word), (0o01, 0o2, 0x1234 & 0x1fff));
+        assert_eq!(unpack_words(&pack_words(&[word, assemble_fixed("NOP").unwrap()])).unwrap(), vec![word, assemble_fixed("NOP").unwrap()]);
+    }
+
+    #[test]
+    fn lda_add_sta_program() {
+        let mut sim = Simulator::new(4096);
+        sim.load_words(&[ins(0o00, 10, 0), ins(0o01, 11, 0), ins(0o03, 12, 0), assemble_fixed("NOP").unwrap(), 0, 0, 0, 0, 0, 0, 1, 2, 0], 0).unwrap();
+        sim.run(4).unwrap();
+        let state = sim.get_state();
+        assert_eq!(state.a, 3);
+        assert_eq!(state.memory[12], 3);
+    }
+
+    #[test]
+    fn spb_stores_p() {
+        let mut sim = Simulator::new(4096);
+        sim.load_words(&[ins(0o07, 4, 2), assemble_fixed("NOP").unwrap(), assemble_fixed("NOP").unwrap(), assemble_fixed("NOP").unwrap(), ins(0o00, 10, 0), assemble_fixed("NOP").unwrap(), 0, 0, 0, 0, 0x12345], 0).unwrap();
+        sim.run(3).unwrap();
+        let state = sim.get_state();
+        assert_eq!(state.x_words[2], 0);
+        assert_eq!(state.a, 0x12345);
+    }
+
+    #[test]
+    fn odd_address_double_ops() {
+        let mut sim = Simulator::new(4096);
+        sim.write_word(11, 0x13579).unwrap();
+        sim.load_words(&[ins(0o10, 11, 0), ins(0o13, 13, 0), assemble_fixed("NOP").unwrap()], 0).unwrap();
+        sim.run(3).unwrap();
+        let state = sim.get_state();
+        assert_eq!(state.a, 0x13579);
+        assert_eq!(state.q, 0x13579);
+        assert_eq!(state.memory[13], 0x13579);
+    }
+
+    #[test]
+    fn moy_moves_blocks() {
+        let mut sim = Simulator::new(4096);
+        sim.write_word(20, 0x11111).unwrap();
+        sim.write_word(21, 0x22222).unwrap();
+        sim.write_word(30, 40).unwrap();
+        sim.write_word(31, (1 << 20) - 2).unwrap();
+        sim.load_words(&[ins(0o00, 30, 0), assemble_fixed("LQA").unwrap(), ins(0o00, 31, 0), assemble_fixed("XAQ").unwrap(), ins(0o24, 20, 0), assemble_fixed("NOP").unwrap()], 0).unwrap();
+        sim.run(6).unwrap();
+        let state = sim.get_state();
+        assert_eq!(state.a, 0);
+        assert_eq!(state.memory[40], 0x11111);
+        assert_eq!(state.memory[41], 0x22222);
+    }
+
+    #[test]
+    fn console_typewriter_path() {
+        let mut sim = Simulator::new(4096);
+        sim.set_control_switches(0o1633);
+        sim.load_words(&[assemble_fixed("RCS").unwrap(), assemble_fixed("TON").unwrap(), assemble_shift("SAN", 6).unwrap(), assemble_fixed("TYP").unwrap(), assemble_fixed("NOP").unwrap()], 0).unwrap();
+        sim.run(5).unwrap();
+        assert_eq!(sim.get_typewriter_output(), "-");
+        assert!(sim.get_state().typewriter_power);
+    }
+
+    #[test]
+    fn rcd_loads_queued_record() {
+        let mut sim = Simulator::new(4096);
+        sim.queue_card_reader_record(&[0x11111, 0x22222]);
+        sim.load_words(&[ins(0o25, 10, 0), assemble_fixed("NOP").unwrap()], 0).unwrap();
+        sim.run(2).unwrap();
+        let state = sim.get_state();
+        assert_eq!(state.memory[10], 0x11111);
+        assert_eq!(state.memory[11], 0x22222);
+    }
+}

--- a/code/packages/typescript/ge225-simulator/BUILD
+++ b/code/packages/typescript/ge225-simulator/BUILD
@@ -1,0 +1,2 @@
+npm ci --quiet
+npx vitest run --coverage

--- a/code/packages/typescript/ge225-simulator/CHANGELOG.md
+++ b/code/packages/typescript/ge225-simulator/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to the ge225-simulator TypeScript package will be documented in this file.
+
+## [0.1.0] - 2026-04-15
+
+### Added
+- Initial TypeScript GE-225 behavioral simulator package
+- 20-bit word-addressed machine model with documented opcode families
+- Encoding helpers, frozen state snapshots, and focused execution tests

--- a/code/packages/typescript/ge225-simulator/README.md
+++ b/code/packages/typescript/ge225-simulator/README.md
@@ -1,0 +1,20 @@
+# GE-225 Simulator (TypeScript)
+
+Behavioral TypeScript simulator for the **GE-225 instruction repertoire**.
+
+This package mirrors the Python GE-225 simulator closely enough to serve as a
+second implementation for backend validation work.
+
+## Scope
+
+- 20-bit word-addressed memory
+- documented GE-225 memory-reference and fixed-word instruction families
+- index-group state, compare/skip behavior, and host-side console helpers
+- focused tests for arithmetic, branching, block move, and typewriter flow
+
+## Running Tests
+
+```bash
+npm install
+npx vitest run --coverage
+```

--- a/code/packages/typescript/ge225-simulator/package-lock.json
+++ b/code/packages/typescript/ge225-simulator/package-lock.json
@@ -1,0 +1,2503 @@
+{
+  "name": "@coding-adventures/ge225-simulator",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/ge225-simulator",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/ge225-simulator/package.json
+++ b/code/packages/typescript/ge225-simulator/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@coding-adventures/ge225-simulator",
+  "version": "0.1.0",
+  "description": "GE-225 behavioral simulator and compiler backend target",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "keywords": [
+    "ge-225",
+    "mainframe",
+    "historical",
+    "simulator",
+    "dartmouth-basic",
+    "education"
+  ],
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "devDependencies": {
+    "@vitest/coverage-v8": "^3.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/ge225-simulator/src/index.ts
+++ b/code/packages/typescript/ge225-simulator/src/index.ts
@@ -1,0 +1,15 @@
+export {
+  GE225Simulator,
+  assembleFixed,
+  assembleShift,
+  decodeInstruction,
+  encodeInstruction,
+  packWords,
+  unpackWords,
+} from "./simulator.js";
+
+export type {
+  GE225Indicators,
+  GE225State,
+  GE225Trace,
+} from "./simulator.js";

--- a/code/packages/typescript/ge225-simulator/src/simulator.ts
+++ b/code/packages/typescript/ge225-simulator/src/simulator.ts
@@ -1,0 +1,781 @@
+const MASK_20 = (1 << 20) - 1;
+const DATA_MASK = (1 << 19) - 1;
+const SIGN_BIT = 1 << 19;
+const ADDR_MASK = 0x1fff;
+const X_MASK = 0x7fff;
+const N_MASK = 0x3f;
+const WORD_BYTES = 3;
+const MAX_X_GROUPS = 32;
+
+const OP_LDA = 0o00;
+const OP_ADD = 0o01;
+const OP_SUB = 0o02;
+const OP_STA = 0o03;
+const OP_BXL = 0o04;
+const OP_BXH = 0o05;
+const OP_LDX = 0o06;
+const OP_SPB = 0o07;
+const OP_DLD = 0o10;
+const OP_DAD = 0o11;
+const OP_DSU = 0o12;
+const OP_DST = 0o13;
+const OP_INX = 0o14;
+const OP_MPY = 0o15;
+const OP_DVD = 0o16;
+const OP_STX = 0o17;
+const OP_EXT = 0o20;
+const OP_CAB = 0o21;
+const OP_DCB = 0o22;
+const OP_ORY = 0o23;
+const OP_MOY = 0o24;
+const OP_RCD = 0o25;
+const OP_BRU = 0o26;
+const OP_STO = 0o27;
+
+const BASE_OPCODE_NAMES = new Map<number, string>([
+  [OP_LDA, "LDA"],
+  [OP_ADD, "ADD"],
+  [OP_SUB, "SUB"],
+  [OP_STA, "STA"],
+  [OP_BXL, "BXL"],
+  [OP_BXH, "BXH"],
+  [OP_LDX, "LDX"],
+  [OP_SPB, "SPB"],
+  [OP_DLD, "DLD"],
+  [OP_DAD, "DAD"],
+  [OP_DSU, "DSU"],
+  [OP_DST, "DST"],
+  [OP_INX, "INX"],
+  [OP_MPY, "MPY"],
+  [OP_DVD, "DVD"],
+  [OP_STX, "STX"],
+  [OP_EXT, "EXT"],
+  [OP_CAB, "CAB"],
+  [OP_DCB, "DCB"],
+  [OP_ORY, "ORY"],
+  [OP_MOY, "MOY"],
+  [OP_RCD, "RCD"],
+  [OP_BRU, "BRU"],
+  [OP_STO, "STO"],
+]);
+
+const NON_MODIFYING_MEMORY_REFERENCE = new Set(["BXL", "BXH", "LDX", "SPB", "INX", "STX", "MOY"]);
+
+const FIXED_WORDS = new Map<string, number>([
+  ["OFF", parseInt("2500005", 8)],
+  ["TYP", parseInt("2500006", 8)],
+  ["TON", parseInt("2500007", 8)],
+  ["RCS", parseInt("2500011", 8)],
+  ["HPT", parseInt("2500016", 8)],
+  ["LDZ", parseInt("2504002", 8)],
+  ["LDO", parseInt("2504022", 8)],
+  ["LMO", parseInt("2504102", 8)],
+  ["CPL", parseInt("2504502", 8)],
+  ["NEG", parseInt("2504522", 8)],
+  ["CHS", parseInt("2504040", 8)],
+  ["NOP", parseInt("2504012", 8)],
+  ["LAQ", parseInt("2504001", 8)],
+  ["LQA", parseInt("2504004", 8)],
+  ["XAQ", parseInt("2504005", 8)],
+  ["MAQ", parseInt("2504006", 8)],
+  ["ADO", parseInt("2504032", 8)],
+  ["SBO", parseInt("2504112", 8)],
+  ["SET_DECMODE", parseInt("2506011", 8)],
+  ["SET_BINMODE", parseInt("2506012", 8)],
+  ["SXG", parseInt("2506013", 8)],
+  ["SET_PST", parseInt("2506015", 8)],
+  ["SET_PBK", parseInt("2506016", 8)],
+  ["BOD", parseInt("2514000", 8)],
+  ["BEV", parseInt("2516000", 8)],
+  ["BMI", parseInt("2514001", 8)],
+  ["BPL", parseInt("2516001", 8)],
+  ["BZE", parseInt("2514002", 8)],
+  ["BNZ", parseInt("2516002", 8)],
+  ["BOV", parseInt("2514003", 8)],
+  ["BNO", parseInt("2516003", 8)],
+  ["BPE", parseInt("2514004", 8)],
+  ["BPC", parseInt("2516004", 8)],
+  ["BNR", parseInt("2514005", 8)],
+  ["BNN", parseInt("2516005", 8)],
+]);
+
+const FIXED_NAMES = new Map<number, string>(Array.from(FIXED_WORDS.entries()).map(([k, v]) => [v, k]));
+
+const SHIFT_BASES = new Map<string, number>([
+  ["SRA", parseInt("2510000", 8)],
+  ["SNA", parseInt("2510100", 8)],
+  ["SCA", parseInt("2510040", 8)],
+  ["SAN", parseInt("2510400", 8)],
+  ["SRD", parseInt("2511000", 8)],
+  ["NAQ", parseInt("2511100", 8)],
+  ["SCD", parseInt("2511200", 8)],
+  ["ANQ", parseInt("2511400", 8)],
+  ["SLA", parseInt("2512000", 8)],
+  ["SLD", parseInt("2512200", 8)],
+  ["NOR", parseInt("2513000", 8)],
+  ["DNO", parseInt("2513200", 8)],
+]);
+
+const TYPEWRITER_CODES = new Map<number, string>([
+  [0o00, "0"], [0o01, "1"], [0o02, "2"], [0o03, "3"], [0o04, "4"], [0o05, "5"], [0o06, "6"], [0o07, "7"],
+  [0o10, "8"], [0o11, "9"], [0o13, "/"], [0o21, "A"], [0o22, "B"], [0o23, "C"], [0o24, "D"], [0o25, "E"],
+  [0o26, "F"], [0o27, "G"], [0o30, "H"], [0o31, "I"], [0o33, "-"], [0o40, "."], [0o41, "J"], [0o42, "K"],
+  [0o43, "L"], [0o44, "M"], [0o45, "N"], [0o46, "O"], [0o47, "P"], [0o50, "Q"], [0o51, "R"], [0o53, "$"],
+  [0o60, " "], [0o62, "S"], [0o63, "T"], [0o64, "U"], [0o65, "V"], [0o66, "W"], [0o67, "X"], [0o70, "Y"],
+  [0o71, "Z"],
+]);
+
+export interface GE225Indicators {
+  carry: boolean;
+  zero: boolean;
+  negative: boolean;
+  overflow: boolean;
+  parityError: boolean;
+}
+
+export interface GE225State {
+  a: number;
+  q: number;
+  m: number;
+  n: number;
+  pc: number;
+  ir: number;
+  indicators: GE225Indicators;
+  overflow: boolean;
+  parityError: boolean;
+  decimalMode: boolean;
+  automaticInterruptMode: boolean;
+  selectedXGroup: number;
+  nReady: boolean;
+  typewriterPower: boolean;
+  controlSwitches: number;
+  xWords: readonly number[];
+  halted: boolean;
+  memory: readonly number[];
+}
+
+export interface GE225Trace {
+  address: number;
+  instructionWord: number;
+  mnemonic: string;
+  aBefore: number;
+  aAfter: number;
+  qBefore: number;
+  qAfter: number;
+  effectiveAddress: number | null;
+}
+
+interface DecodedInstruction {
+  mnemonic: string;
+  opcode: number | null;
+  modifier: number | null;
+  address: number | null;
+  count: number | null;
+  fixedWord: boolean;
+}
+
+function toSigned20(value: number): number {
+  const word = value & MASK_20;
+  return (word & SIGN_BIT) !== 0 ? word - (1 << 20) : word;
+}
+
+function fromSigned20(value: number): number {
+  return value & MASK_20;
+}
+
+function signOf(word: number): number {
+  return (word & SIGN_BIT) !== 0 ? 1 : 0;
+}
+
+function withSign(word: number, sign: number): number {
+  return ((sign & 1) << 19) | (word & DATA_MASK);
+}
+
+function combineWords(high: number, low: number): bigint {
+  return (BigInt(high & MASK_20) << 20n) | BigInt(low & MASK_20);
+}
+
+function splitSigned40(value: bigint): [number, number] {
+  const masked = BigInt.asUintN(40, value);
+  return [Number((masked >> 20n) & BigInt(MASK_20)), Number(masked & BigInt(MASK_20))];
+}
+
+function toSigned40(value: bigint): bigint {
+  return BigInt.asIntN(40, value);
+}
+
+function arithCompare(left: number, right: number): number {
+  const l = toSigned20(left);
+  const r = toSigned20(right);
+  if (l < r) return -1;
+  if (l > r) return 1;
+  return 0;
+}
+
+function arithCompareDouble(leftHigh: number, leftLow: number, rightHigh: number, rightLow: number): number {
+  const left = toSigned40(combineWords(leftHigh, leftLow));
+  const right = toSigned40(combineWords(rightHigh, rightLow));
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+export function encodeInstruction(opcode: number, modifier: number, address: number): number {
+  if (opcode < 0 || opcode > 0o37) throw new Error(`opcode out of range: ${opcode}`);
+  if (modifier < 0 || modifier > 0o3) throw new Error(`modifier out of range: ${modifier}`);
+  if (address < 0 || address > ADDR_MASK) throw new Error(`address out of range: ${address}`);
+  return ((opcode & 0x1f) << 15) | ((modifier & 0x03) << 13) | (address & ADDR_MASK);
+}
+
+export function decodeInstruction(word: number): [number, number, number] {
+  const normalized = word & MASK_20;
+  return [(normalized >> 15) & 0x1f, (normalized >> 13) & 0x03, normalized & ADDR_MASK];
+}
+
+export function assembleFixed(mnemonic: string): number {
+  const word = FIXED_WORDS.get(mnemonic);
+  if (word === undefined) throw new Error(`unknown fixed GE-225 instruction: ${mnemonic}`);
+  return word;
+}
+
+export function assembleShift(mnemonic: string, count: number): number {
+  if (count < 0 || count > 0o37) throw new Error(`shift count out of range: ${count}`);
+  const base = SHIFT_BASES.get(mnemonic);
+  if (base === undefined) throw new Error(`unknown GE-225 shift instruction: ${mnemonic}`);
+  return base | count;
+}
+
+export function packWords(words: number[]): Uint8Array {
+  const blob = new Uint8Array(words.length * WORD_BYTES);
+  words.forEach((word, index) => {
+    const normalized = word & MASK_20;
+    blob[index * WORD_BYTES] = (normalized >> 16) & 0xff;
+    blob[index * WORD_BYTES + 1] = (normalized >> 8) & 0xff;
+    blob[index * WORD_BYTES + 2] = normalized & 0xff;
+  });
+  return blob;
+}
+
+export function unpackWords(program: Uint8Array): number[] {
+  if (program.length % WORD_BYTES !== 0) {
+    throw new Error(`GE-225 byte stream must be a multiple of ${WORD_BYTES} bytes, got ${program.length}`);
+  }
+  const words: number[] = [];
+  for (let i = 0; i < program.length; i += WORD_BYTES) {
+    words.push(((program[i] << 16) | (program[i + 1] << 8) | program[i + 2]) & MASK_20);
+  }
+  return words;
+}
+
+export class GE225Simulator {
+  private readonly memorySize: number;
+  private readonly memory: number[];
+  private readonly cardReaderQueue: number[][] = [];
+  private a = 0;
+  private q = 0;
+  private m = 0;
+  private n = 0;
+  private pc = 0;
+  private ir = 0;
+  private overflow = false;
+  private parityError = false;
+  private decimalMode = false;
+  private automaticInterruptMode = false;
+  private selectedXGroup = 0;
+  private nReady = true;
+  private typewriterPower = false;
+  private readonly typewriterOutput: string[] = [];
+  private controlSwitches = 0;
+  private halted = false;
+  private readonly xGroups: number[][] = Array.from({ length: MAX_X_GROUPS }, () => [0, 0, 0, 0]);
+
+  constructor(memoryWords = 4096) {
+    if (memoryWords <= 0) throw new Error("memoryWords must be positive");
+    this.memorySize = memoryWords;
+    this.memory = new Array(memoryWords).fill(0);
+  }
+
+  reset(): void {
+    this.a = 0;
+    this.q = 0;
+    this.m = 0;
+    this.n = 0;
+    this.pc = 0;
+    this.ir = 0;
+    this.overflow = false;
+    this.parityError = false;
+    this.decimalMode = false;
+    this.automaticInterruptMode = false;
+    this.selectedXGroup = 0;
+    this.nReady = true;
+    this.typewriterPower = false;
+    this.typewriterOutput.length = 0;
+    this.controlSwitches = 0;
+    this.halted = false;
+    this.xGroups.forEach((group) => group.fill(0));
+  }
+
+  getState(): GE225State {
+    return {
+      a: this.a,
+      q: this.q,
+      m: this.m,
+      n: this.n,
+      pc: this.pc,
+      ir: this.ir,
+      indicators: {
+        carry: this.overflow,
+        zero: this.a === 0,
+        negative: (this.a & SIGN_BIT) !== 0,
+        overflow: this.overflow,
+        parityError: this.parityError,
+      },
+      overflow: this.overflow,
+      parityError: this.parityError,
+      decimalMode: this.decimalMode,
+      automaticInterruptMode: this.automaticInterruptMode,
+      selectedXGroup: this.selectedXGroup,
+      nReady: this.nReady,
+      typewriterPower: this.typewriterPower,
+      controlSwitches: this.controlSwitches,
+      xWords: [...this.xGroups[this.selectedXGroup]],
+      halted: this.halted,
+      memory: [...this.memory],
+    };
+  }
+
+  setControlSwitches(value: number): void {
+    this.controlSwitches = value & MASK_20;
+  }
+
+  queueCardReaderRecord(words: number[]): void {
+    this.cardReaderQueue.push(words.map((word) => word & MASK_20));
+  }
+
+  getTypewriterOutput(): string {
+    return this.typewriterOutput.join("");
+  }
+
+  loadWords(words: number[], startAddress = 0): void {
+    words.forEach((word, index) => this.writeWord(startAddress + index, word));
+  }
+
+  readWord(address: number): number {
+    this.checkAddress(address);
+    return this.memory[address];
+  }
+
+  writeWord(address: number, value: number): void {
+    this.checkAddress(address);
+    this.memory[address] = value & MASK_20;
+  }
+
+  disassembleWord(word: number): string {
+    const decoded = this.decodeWord(word);
+    if (decoded.fixedWord) {
+      return decoded.count === null ? decoded.mnemonic : `${decoded.mnemonic} ${decoded.count}`;
+    }
+    return `${decoded.mnemonic} 0x${decoded.address!.toString(16).toUpperCase().padStart(3, "0")},X${decoded.modifier}`;
+  }
+
+  step(): GE225Trace {
+    if (this.halted) throw new Error("cannot step a halted GE-225 simulator");
+
+    const pcBefore = this.pc;
+    this.ir = this.readWord(this.pc);
+    this.pc = (this.pc + 1) % this.memorySize;
+
+    const decoded = this.decodeWord(this.ir);
+    const aBefore = this.a;
+    const qBefore = this.q;
+    let effectiveAddress: number | null = null;
+
+    if (!decoded.fixedWord) {
+      const address = decoded.address!;
+      if (!NON_MODIFYING_MEMORY_REFERENCE.has(decoded.mnemonic)) {
+        effectiveAddress = this.resolveEffectiveAddress(address, decoded.modifier!);
+      }
+      this.executeMemoryReference(
+        decoded.mnemonic,
+        decoded.modifier!,
+        effectiveAddress === null ? address : effectiveAddress,
+        address,
+        pcBefore,
+      );
+    } else {
+      this.executeFixed(decoded);
+    }
+
+    return {
+      address: pcBefore,
+      instructionWord: this.ir,
+      mnemonic: this.disassembleWord(this.ir),
+      aBefore,
+      aAfter: this.a,
+      qBefore,
+      qAfter: this.q,
+      effectiveAddress,
+    };
+  }
+
+  run(maxSteps = 100000): GE225Trace[] {
+    const traces: GE225Trace[] = [];
+    let steps = 0;
+    while (!this.halted && steps < maxSteps) {
+      traces.push(this.step());
+      steps += 1;
+    }
+    return traces;
+  }
+
+  private getXWord(slot: number): number {
+    return this.xGroups[this.selectedXGroup][slot] & X_MASK;
+  }
+
+  private setXWord(slot: number, value: number): void {
+    this.xGroups[this.selectedXGroup][slot] = value & X_MASK;
+  }
+
+  private executeMemoryReference(
+    mnemonic: string,
+    modifier: number,
+    effectiveOrRawAddress: number,
+    rawAddress: number,
+    pcBefore: number,
+  ): void {
+    const effectiveAddress = effectiveOrRawAddress % this.memorySize;
+
+    if (mnemonic === "LDA") {
+      this.m = this.readWord(effectiveAddress);
+      this.a = this.m;
+    } else if (mnemonic === "ADD") {
+      this.m = this.readWord(effectiveAddress);
+      const total = toSigned20(this.a) + toSigned20(this.m);
+      this.a = fromSigned20(total);
+      this.overflow = total < -(1 << 19) || total > ((1 << 19) - 1);
+    } else if (mnemonic === "SUB") {
+      this.m = this.readWord(effectiveAddress);
+      const total = toSigned20(this.a) - toSigned20(this.m);
+      this.a = fromSigned20(total);
+      this.overflow = total < -(1 << 19) || total > ((1 << 19) - 1);
+    } else if (mnemonic === "STA") {
+      this.writeWord(effectiveAddress, this.a);
+    } else if (mnemonic === "BXL") {
+      if ((this.getXWord(modifier) & ADDR_MASK) >= rawAddress) this.pc = (this.pc + 1) % this.memorySize;
+    } else if (mnemonic === "BXH") {
+      if ((this.getXWord(modifier) & ADDR_MASK) < rawAddress) this.pc = (this.pc + 1) % this.memorySize;
+    } else if (mnemonic === "LDX") {
+      this.setXWord(modifier, this.readWord(rawAddress % this.memorySize));
+    } else if (mnemonic === "SPB") {
+      this.setXWord(modifier, pcBefore);
+      this.pc = rawAddress % this.memorySize;
+    } else if (mnemonic === "DLD") {
+      const first = this.readWord(effectiveAddress);
+      if ((effectiveAddress & 1) !== 0) {
+        this.a = first;
+        this.q = first;
+      } else {
+        this.a = first;
+        this.q = this.readWord((effectiveAddress + 1) % this.memorySize);
+      }
+    } else if (mnemonic === "DAD") {
+      const left = toSigned40(combineWords(this.a, this.q));
+      const first = this.readWord(effectiveAddress);
+      const second = (effectiveAddress & 1) !== 0 ? first : this.readWord((effectiveAddress + 1) % this.memorySize);
+      const total = left + toSigned40(combineWords(first, second));
+      [this.a, this.q] = splitSigned40(total);
+      this.overflow = total < -(1n << 39n) || total > ((1n << 39n) - 1n);
+    } else if (mnemonic === "DSU") {
+      const left = toSigned40(combineWords(this.a, this.q));
+      const first = this.readWord(effectiveAddress);
+      const second = (effectiveAddress & 1) !== 0 ? first : this.readWord((effectiveAddress + 1) % this.memorySize);
+      const total = left - toSigned40(combineWords(first, second));
+      [this.a, this.q] = splitSigned40(total);
+      this.overflow = total < -(1n << 39n) || total > ((1n << 39n) - 1n);
+    } else if (mnemonic === "DST") {
+      if ((effectiveAddress & 1) !== 0) {
+        this.writeWord(effectiveAddress, this.q);
+      } else {
+        this.writeWord(effectiveAddress, this.a);
+        this.writeWord((effectiveAddress + 1) % this.memorySize, this.q);
+      }
+    } else if (mnemonic === "INX") {
+      this.setXWord(modifier, (this.getXWord(modifier) + rawAddress) & X_MASK);
+    } else if (mnemonic === "MPY") {
+      this.m = this.readWord(effectiveAddress);
+      const product = BigInt(toSigned20(this.q)) * BigInt(toSigned20(this.m)) + BigInt(toSigned20(this.a));
+      [this.a, this.q] = splitSigned40(product);
+      this.overflow = product < -(1n << 39n) || product > ((1n << 39n) - 1n);
+    } else if (mnemonic === "DVD") {
+      this.m = this.readWord(effectiveAddress);
+      const divisor = BigInt(toSigned20(this.m));
+      if (divisor === 0n) throw new Error("GE-225 divide by zero");
+      if (BigInt(Math.abs(toSigned20(this.a))) >= (divisor < 0n ? -divisor : divisor)) {
+        this.overflow = true;
+        return;
+      }
+      const dividend = toSigned40(combineWords(this.a, this.q));
+      const absDividend = dividend < 0n ? -dividend : dividend;
+      const absDivisor = divisor < 0n ? -divisor : divisor;
+      const quotientMag = absDividend / absDivisor;
+      const remainderMag = absDividend % absDivisor;
+      const quotient = (dividend < 0n) !== (divisor < 0n) ? -quotientMag : quotientMag;
+      const remainder = quotient < 0n ? -remainderMag : remainderMag;
+      this.a = fromSigned20(Number(quotient));
+      this.q = fromSigned20(Number(remainder));
+      this.overflow = quotient < -(1n << 19n) || quotient > ((1n << 19n) - 1n);
+    } else if (mnemonic === "STX") {
+      this.writeWord(rawAddress % this.memorySize, this.getXWord(modifier));
+    } else if (mnemonic === "EXT") {
+      this.m = this.readWord(effectiveAddress);
+      this.a &= (~this.m) & MASK_20;
+    } else if (mnemonic === "CAB") {
+      this.m = this.readWord(effectiveAddress);
+      const relation = arithCompare(this.m, this.a);
+      if (relation === 0) this.pc = (this.pc + 1) % this.memorySize;
+      else if (relation < 0) this.pc = (this.pc + 2) % this.memorySize;
+    } else if (mnemonic === "DCB") {
+      const first = this.readWord(effectiveAddress);
+      const second = (effectiveAddress & 1) !== 0 ? first : this.readWord((effectiveAddress + 1) % this.memorySize);
+      const relation = arithCompareDouble(first, second, this.a, this.q);
+      if (relation === 0) this.pc = (this.pc + 1) % this.memorySize;
+      else if (relation < 0) this.pc = (this.pc + 2) % this.memorySize;
+    } else if (mnemonic === "ORY") {
+      this.writeWord(effectiveAddress, this.readWord(effectiveAddress) | this.a);
+    } else if (mnemonic === "MOY") {
+      const wordCount = Math.max(0, -toSigned20(this.q));
+      const destination = this.a & X_MASK;
+      for (let offset = 0; offset < wordCount; offset += 1) {
+        this.writeWord((destination + offset) % this.memorySize, this.readWord((rawAddress + offset) % this.memorySize));
+      }
+      this.setXWord(0, this.pc);
+      this.a = 0;
+    } else if (mnemonic === "RCD") {
+      const record = this.cardReaderQueue.shift();
+      if (record === undefined) throw new Error("RCD executed with no queued card-reader record");
+      record.forEach((word, offset) => this.writeWord((effectiveAddress + offset) % this.memorySize, word));
+    } else if (mnemonic === "BRU") {
+      this.pc = effectiveAddress;
+    } else if (mnemonic === "STO") {
+      const existing = this.readWord(effectiveAddress);
+      this.writeWord(effectiveAddress, (existing & ~ADDR_MASK) | (this.a & ADDR_MASK));
+    } else {
+      throw new Error(`unimplemented GE-225 memory-reference instruction: ${mnemonic}`);
+    }
+  }
+
+  private executeFixed(decoded: DecodedInstruction): void {
+    const { mnemonic, count } = decoded;
+    if (mnemonic === "OFF") {
+      this.typewriterPower = false;
+      this.nReady = true;
+    } else if (mnemonic === "TYP") {
+      if (!this.typewriterPower) {
+        this.nReady = false;
+        return;
+      }
+      const code = this.n & N_MASK;
+      if (code === 0o37) this.typewriterOutput.push("\r");
+      else if (code === 0o76) this.typewriterOutput.push("\t");
+      else if (code !== 0o72 && code !== 0o75) {
+        const char = TYPEWRITER_CODES.get(code);
+        if (char === undefined) {
+          this.nReady = false;
+          return;
+        }
+        this.typewriterOutput.push(char);
+      }
+      this.nReady = true;
+    } else if (mnemonic === "TON") {
+      this.typewriterPower = true;
+    } else if (mnemonic === "RCS") {
+      this.a |= this.controlSwitches;
+    } else if (mnemonic === "HPT") {
+      this.nReady = false;
+    } else if (mnemonic === "LDZ") {
+      this.a = 0;
+    } else if (mnemonic === "LDO") {
+      this.a = 1;
+    } else if (mnemonic === "LMO") {
+      this.a = MASK_20;
+    } else if (mnemonic === "CPL") {
+      this.a = (~this.a) & MASK_20;
+    } else if (mnemonic === "NEG") {
+      const before = toSigned20(this.a);
+      this.a = fromSigned20(-before);
+      this.overflow = before === -(1 << 19);
+    } else if (mnemonic === "CHS") {
+      this.a ^= SIGN_BIT;
+    } else if (mnemonic === "NOP") {
+      return;
+    } else if (mnemonic === "LAQ") {
+      this.a = this.q;
+    } else if (mnemonic === "LQA") {
+      this.q = this.a;
+    } else if (mnemonic === "XAQ") {
+      [this.a, this.q] = [this.q, this.a];
+    } else if (mnemonic === "MAQ") {
+      this.q = this.a;
+      this.a = 0;
+    } else if (mnemonic === "ADO") {
+      const total = toSigned20(this.a) + 1;
+      this.a = fromSigned20(total);
+      this.overflow = total < -(1 << 19) || total > ((1 << 19) - 1);
+    } else if (mnemonic === "SBO") {
+      const total = toSigned20(this.a) - 1;
+      this.a = fromSigned20(total);
+      this.overflow = total < -(1 << 19) || total > ((1 << 19) - 1);
+    } else if (mnemonic === "SET_DECMODE") {
+      this.decimalMode = true;
+    } else if (mnemonic === "SET_BINMODE") {
+      this.decimalMode = false;
+    } else if (mnemonic === "SXG") {
+      this.selectedXGroup = this.a & 0x1f;
+    } else if (mnemonic === "SET_PST") {
+      this.automaticInterruptMode = true;
+    } else if (mnemonic === "SET_PBK") {
+      this.automaticInterruptMode = false;
+    } else if (["BOD", "BEV", "BMI", "BPL", "BZE", "BNZ", "BOV", "BNO", "BPE", "BPC", "BNR", "BNN"].includes(mnemonic)) {
+      this.executeBranchTest(mnemonic);
+    } else if (SHIFT_BASES.has(mnemonic)) {
+      this.executeShift(mnemonic, count ?? 0);
+    } else {
+      throw new Error(`unimplemented GE-225 fixed instruction: ${mnemonic}`);
+    }
+  }
+
+  private executeBranchTest(mnemonic: string): void {
+    const cond =
+      mnemonic === "BOD" ? (this.a & 1) !== 0 :
+      mnemonic === "BEV" ? (this.a & 1) === 0 :
+      mnemonic === "BMI" ? (this.a & SIGN_BIT) !== 0 :
+      mnemonic === "BPL" ? (this.a & SIGN_BIT) === 0 :
+      mnemonic === "BZE" ? this.a === 0 :
+      mnemonic === "BNZ" ? this.a !== 0 :
+      mnemonic === "BOV" ? this.overflow :
+      mnemonic === "BNO" ? !this.overflow :
+      mnemonic === "BPE" ? this.parityError :
+      mnemonic === "BPC" ? !this.parityError :
+      mnemonic === "BNR" ? this.nReady :
+      !this.nReady;
+    if (mnemonic === "BOV" || mnemonic === "BNO") this.overflow = false;
+    if (mnemonic === "BPE" || mnemonic === "BPC") this.parityError = false;
+    if (!cond) this.pc = (this.pc + 1) % this.memorySize;
+  }
+
+  private executeShift(mnemonic: string, count: number): void {
+    if (count === 0) {
+      if (mnemonic === "SRD") this.q = withSign(this.q, signOf(this.a));
+      else if (mnemonic === "SLD") this.a = withSign(this.a, signOf(this.q));
+      return;
+    }
+
+    const aSign = signOf(this.a);
+    let aData = this.a & DATA_MASK;
+    const qSign = signOf(this.q);
+    let qData = this.q & DATA_MASK;
+
+    if (mnemonic === "SRA") {
+      this.a = fromSigned20(toSigned20(this.a) >> Math.min(count, 19));
+    } else if (mnemonic === "SLA") {
+      this.overflow = (aData >> Math.max(0, 19 - count)) !== 0;
+      this.a = withSign((aData << count) & DATA_MASK, aSign);
+    } else if (mnemonic === "SCA") {
+      const rotation = count % 19;
+      if (rotation !== 0) aData = ((aData >> rotation) | (aData << (19 - rotation))) & DATA_MASK;
+      this.a = withSign(aData, aSign);
+    } else if (mnemonic === "SAN") {
+      const fill = aSign === 1 ? ((1 << count) - 1) : 0;
+      let combined = ((aData & DATA_MASK) << 6) | (this.n & N_MASK);
+      combined = ((fill << 25) | combined) >> count;
+      this.a = withSign((combined >> 6) & DATA_MASK, aSign);
+      this.n = combined & N_MASK;
+    } else if (mnemonic === "SNA") {
+      const combined = (((this.n & N_MASK) << 19) | aData) >>> count;
+      this.n = (combined >> 19) & N_MASK;
+      this.a = withSign(combined & DATA_MASK, aSign);
+    } else if (mnemonic === "SRD") {
+      const value = combineWords(this.a, this.q) >> BigInt(count);
+      this.a = withSign(Number((value >> 20n) & BigInt(DATA_MASK)), aSign);
+      this.q = withSign(Number(value & BigInt(DATA_MASK)), aSign);
+    } else if (mnemonic === "NAQ") {
+      const combined = (((this.n & N_MASK) << 38) | ((aData & DATA_MASK) << 19) | qData) >>> count;
+      this.n = (combined >> 38) & N_MASK;
+      this.a = withSign((combined >> 19) & DATA_MASK, aSign);
+      this.q = withSign(combined & DATA_MASK, aSign);
+    } else if (mnemonic === "SCD") {
+      const rotation = count % 38;
+      let combined = ((aData & DATA_MASK) << 19) | qData;
+      if (rotation !== 0) combined = ((combined >> rotation) | (combined << (38 - rotation))) & ((1 << 38) - 1);
+      this.a = withSign((combined >> 19) & DATA_MASK, aSign);
+      this.q = withSign(combined & DATA_MASK, aSign);
+    } else if (mnemonic === "ANQ") {
+      for (let i = 0; i < count; i += 1) {
+        const bit = this.a & 1;
+        this.a = fromSigned20(toSigned20(this.a) >> 1);
+        qData = ((bit << 18) | ((this.q & DATA_MASK) >> 1)) & DATA_MASK;
+        this.q = withSign(qData, aSign);
+        this.n = ((bit << 5) | (this.n >> 1)) & N_MASK;
+      }
+    } else if (mnemonic === "SLD") {
+      let combined = ((aData & DATA_MASK) << 19) | qData;
+      this.overflow = (combined >> Math.max(0, 38 - count)) !== 0;
+      combined = (combined << count) & ((1 << 38) - 1);
+      this.a = withSign((combined >> 19) & DATA_MASK, qSign);
+      this.q = withSign(combined & DATA_MASK, qSign);
+    } else if (mnemonic === "NOR") {
+      let shifts = 0;
+      const targetBit = aSign === 0 ? 0 : 1;
+      while (shifts < count) {
+        const lead = (aData >> 18) & 1;
+        if (lead !== targetBit) break;
+        this.overflow = this.overflow || lead === 1;
+        aData = (aData << 1) & DATA_MASK;
+        shifts += 1;
+      }
+      this.a = withSign(aData, aSign);
+      this.setXWord(0, count - shifts);
+    } else if (mnemonic === "DNO") {
+      let shifts = 0;
+      const targetBit = aSign === 0 ? 0 : 1;
+      let combined = ((aData & DATA_MASK) << 19) | qData;
+      while (shifts < count) {
+        const lead = (combined >> 37) & 1;
+        if (lead !== targetBit) break;
+        this.overflow = this.overflow || lead === 1;
+        combined = (combined << 1) & ((1 << 38) - 1);
+        shifts += 1;
+      }
+      this.a = withSign((combined >> 19) & DATA_MASK, qSign);
+      this.q = withSign(combined & DATA_MASK, qSign);
+      this.setXWord(0, count - shifts);
+    }
+  }
+
+  private decodeWord(word: number): DecodedInstruction {
+    const normalized = word & MASK_20;
+    const fixedName = FIXED_NAMES.get(normalized);
+    if (fixedName !== undefined) return { mnemonic: fixedName, opcode: null, modifier: null, address: null, count: null, fixedWord: true };
+
+    for (const [mnemonic, base] of SHIFT_BASES.entries()) {
+      if ((normalized & ~0o37) === base) {
+        return { mnemonic, opcode: null, modifier: null, address: null, count: normalized & 0o37, fixedWord: true };
+      }
+    }
+
+    const [opcode, modifier, address] = decodeInstruction(normalized);
+    const mnemonic = BASE_OPCODE_NAMES.get(opcode);
+    if (mnemonic === undefined) throw new Error(`unknown GE-225 opcode field ${opcode.toString(8)}`);
+    return { mnemonic, opcode, modifier, address, count: null, fixedWord: false };
+  }
+
+  private resolveEffectiveAddress(address: number, modifier: number): number {
+    const base = address % this.memorySize;
+    if (modifier === 0) return base;
+    return (base + (this.getXWord(modifier) % this.memorySize)) % this.memorySize;
+  }
+
+  private checkAddress(address: number): void {
+    if (address < 0 || address >= this.memorySize) throw new Error(`address out of range: ${address}`);
+  }
+}

--- a/code/packages/typescript/ge225-simulator/tests/simulator.test.ts
+++ b/code/packages/typescript/ge225-simulator/tests/simulator.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  GE225Simulator,
+  assembleFixed,
+  assembleShift,
+  decodeInstruction,
+  encodeInstruction,
+  packWords,
+  unpackWords,
+} from "../src/index.js";
+
+function ins(opcode: number, address = 0, modifier = 0): number {
+  return encodeInstruction(opcode, modifier, address);
+}
+
+describe("GE225Simulator", () => {
+  it("encodes and decodes instructions", () => {
+    const word = encodeInstruction(0o01, 0o2, 0x1234 & 0x1fff);
+    expect(decodeInstruction(word)).toEqual([0o01, 0o2, 0x1234 & 0x1fff]);
+    expect(unpackWords(packWords([word, assembleFixed("NOP")]))).toEqual([word, assembleFixed("NOP")]);
+  });
+
+  it("runs LDA/ADD/STA program", () => {
+    const sim = new GE225Simulator();
+    sim.loadWords([ins(0o00, 10), ins(0o01, 11), ins(0o03, 12), assembleFixed("NOP"), 0, 0, 0, 0, 0, 0, 1, 2, 0]);
+    sim.run(4);
+    const state = sim.getState();
+    expect(state.a).toBe(3);
+    expect(state.memory[12]).toBe(3);
+  });
+
+  it("stores P on SPB and loads through target", () => {
+    const sim = new GE225Simulator();
+    sim.loadWords([ins(0o07, 4, 2), assembleFixed("NOP"), assembleFixed("NOP"), assembleFixed("NOP"), ins(0o00, 10), assembleFixed("NOP"), 0, 0, 0, 0, 0x12345]);
+    sim.run(3);
+    const state = sim.getState();
+    expect(state.xWords[2]).toBe(0);
+    expect(state.a).toBe(0x12345);
+  });
+
+  it("honors odd-address double load/store", () => {
+    const sim = new GE225Simulator();
+    sim.writeWord(11, 0x13579);
+    sim.loadWords([ins(0o10, 11), ins(0o13, 13), assembleFixed("NOP")]);
+    sim.run(3);
+    const state = sim.getState();
+    expect(state.a).toBe(0x13579);
+    expect(state.q).toBe(0x13579);
+    expect(state.memory[13]).toBe(0x13579);
+  });
+
+  it("moves blocks with MOY", () => {
+    const sim = new GE225Simulator();
+    sim.writeWord(20, 0x11111);
+    sim.writeWord(21, 0x22222);
+    sim.writeWord(30, 40);
+    sim.writeWord(31, ((1 << 20) - 2));
+    sim.loadWords([ins(0o00, 30), assembleFixed("LQA"), ins(0o00, 31), assembleFixed("XAQ"), ins(0o24, 20), assembleFixed("NOP")]);
+    sim.run(6);
+    const state = sim.getState();
+    expect(state.a).toBe(0);
+    expect(state.memory[40]).toBe(0x11111);
+    expect(state.memory[41]).toBe(0x22222);
+  });
+
+  it("supports console typewriter path", () => {
+    const sim = new GE225Simulator();
+    sim.setControlSwitches(0o1633);
+    sim.loadWords([assembleFixed("RCS"), assembleFixed("TON"), assembleShift("SAN", 6), assembleFixed("TYP"), assembleFixed("NOP")]);
+    sim.run(5);
+    expect(sim.getTypewriterOutput()).toBe("-");
+    expect(sim.getState().typewriterPower).toBe(true);
+  });
+
+  it("loads queued records with RCD", () => {
+    const sim = new GE225Simulator();
+    sim.queueCardReaderRecord([0x11111, 0x22222]);
+    sim.loadWords([ins(0o25, 10), assembleFixed("NOP")]);
+    sim.run(2);
+    expect(sim.getState().memory[10]).toBe(0x11111);
+    expect(sim.getState().memory[11]).toBe(0x22222);
+  });
+});

--- a/code/packages/typescript/ge225-simulator/tsconfig.json
+++ b/code/packages/typescript/ge225-simulator/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add first-wave GE-225 simulator ports in Go, TypeScript, and Rust
- mirror the Python GE-225 machine model with opcode helpers, machine state, and focused execution coverage
- register the new Rust crate in the Rust workspace

## Why
This gets the GE-225 backend work started across the language ecosystems already used for simulator packages in this repo, so we can validate backend behavior across multiple implementations while the Dartmouth BASIC and IR work takes shape.

## Validation
- `go test ./...`
- `npx vitest run`
- `cargo test`