### PR TITLE
[codex] Add Haskell compiler tooling foundation packages

### DIFF
--- a/code/packages/haskell/compiler-source-map/BUILD
+++ b/code/packages/haskell/compiler-source-map/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/compiler-source-map/BUILD_windows
+++ b/code/packages/haskell/compiler-source-map/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/compiler-source-map/CHANGELOG.md
+++ b/code/packages/haskell/compiler-source-map/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/compiler-source-map/README.md
+++ b/code/packages/haskell/compiler-source-map/README.md
@@ -1,0 +1,14 @@
+# compiler-source-map
+
+Source mapping chain for compiler pipelines.
+
+## What it does
+
+- tracks `source -> AST -> IR -> machine code` relationships
+- supports forward lookup from source positions to machine code spans
+- supports reverse lookup from machine code offsets back to source
+- preserves optimiser-pass mappings so compiler debugging stays explainable
+
+## Status
+
+This Haskell package now provides a real source-map chain with tests covering segment lookups and end-to-end composition.

--- a/code/packages/haskell/compiler-source-map/cabal.project
+++ b/code/packages/haskell/compiler-source-map/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/code/packages/haskell/compiler-source-map/compiler-source-map.cabal
+++ b/code/packages/haskell/compiler-source-map/compiler-source-map.cabal
@@ -1,0 +1,26 @@
+cabal-version: 3.0
+name:          compiler-source-map
+version:       0.1.0
+synopsis:      Source mapping chain for compiler pipelines
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  CompilerSourceMap
+    build-depends:    base >=4.14
+                    , containers
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    CompilerSourceMapSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , containers
+                    , compiler-source-map
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/compiler-source-map/src/CompilerSourceMap.hs
+++ b/code/packages/haskell/compiler-source-map/src/CompilerSourceMap.hs
@@ -1,0 +1,257 @@
+module CompilerSourceMap
+    ( SourcePosition(..)
+    , formatSourcePosition
+    , SourceToAstEntry(..)
+    , SourceToAst(..)
+    , emptySourceToAst
+    , addSourceToAst
+    , lookupSourceByAstNodeId
+    , lookupAstNodeIdBySourcePosition
+    , AstToIrEntry(..)
+    , AstToIr(..)
+    , emptyAstToIr
+    , addAstToIr
+    , lookupIrIdsByAstNodeId
+    , lookupAstNodeIdByIrId
+    , IrToIrEntry(..)
+    , IrToIr(..)
+    , emptyIrToIr
+    , addIrMapping
+    , addIrDeletion
+    , lookupNewIrIdsByOriginalId
+    , lookupOriginalIrIdByNewId
+    , IrToMachineCodeEntry(..)
+    , IrToMachineCode(..)
+    , emptyIrToMachineCode
+    , addIrToMachineCode
+    , lookupMachineCodeByIrId
+    , lookupIrIdByMachineCodeOffset
+    , SourceMapChain(..)
+    , emptySourceMapChain
+    , addOptimizerPass
+    , setIrToMachineCode
+    , sourceToMachineCode
+    , machineCodeToSource
+    ) where
+
+import Data.List (find)
+import qualified Data.Set as Set
+import Data.Set (Set)
+
+data SourcePosition = SourcePosition
+    { sourcePositionFile :: FilePath
+    , sourcePositionLine :: Int
+    , sourcePositionColumn :: Int
+    , sourcePositionLength :: Int
+    }
+    deriving (Eq, Ord, Show)
+
+formatSourcePosition :: SourcePosition -> String
+formatSourcePosition pos =
+    sourcePositionFile pos
+        ++ ":"
+        ++ show (sourcePositionLine pos)
+        ++ ":"
+        ++ show (sourcePositionColumn pos)
+        ++ " (len="
+        ++ show (sourcePositionLength pos)
+        ++ ")"
+
+data SourceToAstEntry = SourceToAstEntry
+    { sourceToAstPosition :: SourcePosition
+    , sourceToAstNodeId :: Int
+    }
+    deriving (Eq, Show)
+
+newtype SourceToAst = SourceToAst
+    { sourceToAstEntries :: [SourceToAstEntry]
+    }
+    deriving (Eq, Show)
+
+emptySourceToAst :: SourceToAst
+emptySourceToAst = SourceToAst []
+
+addSourceToAst :: SourcePosition -> Int -> SourceToAst -> SourceToAst
+addSourceToAst pos astNodeId (SourceToAst entries) =
+    SourceToAst (entries ++ [SourceToAstEntry pos astNodeId])
+
+lookupSourceByAstNodeId :: Int -> SourceToAst -> Maybe SourcePosition
+lookupSourceByAstNodeId astNodeId (SourceToAst entries) =
+    sourceToAstPosition <$> find ((== astNodeId) . sourceToAstNodeId) entries
+
+lookupAstNodeIdBySourcePosition :: SourcePosition -> SourceToAst -> Maybe Int
+lookupAstNodeIdBySourcePosition pos (SourceToAst entries) =
+    sourceToAstNodeId <$> find (\entry -> matchesSourcePosition pos (sourceToAstPosition entry)) entries
+
+data AstToIrEntry = AstToIrEntry
+    { astToIrNodeId :: Int
+    , astToIrIrIds :: [Int]
+    }
+    deriving (Eq, Show)
+
+newtype AstToIr = AstToIr
+    { astToIrEntries :: [AstToIrEntry]
+    }
+    deriving (Eq, Show)
+
+emptyAstToIr :: AstToIr
+emptyAstToIr = AstToIr []
+
+addAstToIr :: Int -> [Int] -> AstToIr -> AstToIr
+addAstToIr astNodeId irIds (AstToIr entries) =
+    AstToIr (entries ++ [AstToIrEntry astNodeId irIds])
+
+lookupIrIdsByAstNodeId :: Int -> AstToIr -> Maybe [Int]
+lookupIrIdsByAstNodeId astNodeId (AstToIr entries) =
+    astToIrIrIds <$> find ((== astNodeId) . astToIrNodeId) entries
+
+lookupAstNodeIdByIrId :: Int -> AstToIr -> Maybe Int
+lookupAstNodeIdByIrId irId (AstToIr entries) =
+    astToIrNodeId <$> find (elem irId . astToIrIrIds) entries
+
+data IrToIrEntry = IrToIrEntry
+    { irToIrOriginalId :: Int
+    , irToIrNewIds :: [Int]
+    }
+    deriving (Eq, Show)
+
+data IrToIr = IrToIr
+    { irToIrEntries :: [IrToIrEntry]
+    , irToIrDeleted :: Set Int
+    , irToIrPassName :: String
+    }
+    deriving (Eq, Show)
+
+emptyIrToIr :: String -> IrToIr
+emptyIrToIr passName =
+    IrToIr
+        { irToIrEntries = []
+        , irToIrDeleted = Set.empty
+        , irToIrPassName = passName
+        }
+
+addIrMapping :: Int -> [Int] -> IrToIr -> IrToIr
+addIrMapping originalId newIds segment =
+    segment{irToIrEntries = irToIrEntries segment ++ [IrToIrEntry originalId newIds]}
+
+addIrDeletion :: Int -> IrToIr -> IrToIr
+addIrDeletion originalId segment =
+    segment
+        { irToIrEntries = irToIrEntries segment ++ [IrToIrEntry originalId []]
+        , irToIrDeleted = Set.insert originalId (irToIrDeleted segment)
+        }
+
+lookupNewIrIdsByOriginalId :: Int -> IrToIr -> Maybe [Int]
+lookupNewIrIdsByOriginalId originalId segment
+    | Set.member originalId (irToIrDeleted segment) = Nothing
+    | otherwise =
+        irToIrNewIds <$> find ((== originalId) . irToIrOriginalId) (irToIrEntries segment)
+
+lookupOriginalIrIdByNewId :: Int -> IrToIr -> Maybe Int
+lookupOriginalIrIdByNewId newId segment =
+    irToIrOriginalId <$> find (elem newId . irToIrNewIds) (irToIrEntries segment)
+
+data IrToMachineCodeEntry = IrToMachineCodeEntry
+    { irToMachineCodeIrId :: Int
+    , irToMachineCodeOffset :: Int
+    , irToMachineCodeLength :: Int
+    }
+    deriving (Eq, Show)
+
+newtype IrToMachineCode = IrToMachineCode
+    { irToMachineCodeEntries :: [IrToMachineCodeEntry]
+    }
+    deriving (Eq, Show)
+
+emptyIrToMachineCode :: IrToMachineCode
+emptyIrToMachineCode = IrToMachineCode []
+
+addIrToMachineCode :: Int -> Int -> Int -> IrToMachineCode -> IrToMachineCode
+addIrToMachineCode irId offset len (IrToMachineCode entries) =
+    IrToMachineCode (entries ++ [IrToMachineCodeEntry irId offset len])
+
+lookupMachineCodeByIrId :: Int -> IrToMachineCode -> Maybe (Int, Int)
+lookupMachineCodeByIrId irId (IrToMachineCode entries) =
+    fmap
+        (\entry -> (irToMachineCodeOffset entry, irToMachineCodeLength entry))
+        (find ((== irId) . irToMachineCodeIrId) entries)
+
+lookupIrIdByMachineCodeOffset :: Int -> IrToMachineCode -> Maybe Int
+lookupIrIdByMachineCodeOffset offset (IrToMachineCode entries) =
+    irToMachineCodeIrId
+        <$> find
+            (\entry ->
+                offset >= irToMachineCodeOffset entry
+                    && offset < irToMachineCodeOffset entry + irToMachineCodeLength entry
+            )
+            entries
+
+data SourceMapChain = SourceMapChain
+    { sourceMapChainSourceToAst :: SourceToAst
+    , sourceMapChainAstToIr :: AstToIr
+    , sourceMapChainIrToIr :: [IrToIr]
+    , sourceMapChainIrToMachineCode :: Maybe IrToMachineCode
+    }
+    deriving (Eq, Show)
+
+emptySourceMapChain :: SourceMapChain
+emptySourceMapChain =
+    SourceMapChain
+        { sourceMapChainSourceToAst = emptySourceToAst
+        , sourceMapChainAstToIr = emptyAstToIr
+        , sourceMapChainIrToIr = []
+        , sourceMapChainIrToMachineCode = Nothing
+        }
+
+addOptimizerPass :: IrToIr -> SourceMapChain -> SourceMapChain
+addOptimizerPass segment chain =
+    chain{sourceMapChainIrToIr = sourceMapChainIrToIr chain ++ [segment]}
+
+setIrToMachineCode :: IrToMachineCode -> SourceMapChain -> SourceMapChain
+setIrToMachineCode segment chain =
+    chain{sourceMapChainIrToMachineCode = Just segment}
+
+sourceToMachineCode :: SourceMapChain -> SourcePosition -> Maybe [IrToMachineCodeEntry]
+sourceToMachineCode chain pos = do
+    astNodeId <- lookupAstNodeIdBySourcePosition pos (sourceMapChainSourceToAst chain)
+    initialIrIds <- lookupIrIdsByAstNodeId astNodeId (sourceMapChainAstToIr chain)
+    let finalIrIds = foldl applyOptimizerPass initialIrIds (sourceMapChainIrToIr chain)
+    if null finalIrIds
+        then Nothing
+        else do
+            machineCode <- sourceMapChainIrToMachineCode chain
+            let results =
+                    [ IrToMachineCodeEntry irId offset len
+                    | irId <- finalIrIds
+                    , Just (offset, len) <- [lookupMachineCodeByIrId irId machineCode]
+                    ]
+            if null results then Nothing else Just results
+
+machineCodeToSource :: SourceMapChain -> Int -> Maybe SourcePosition
+machineCodeToSource chain offset = do
+    machineCode <- sourceMapChainIrToMachineCode chain
+    finalIrId <- lookupIrIdByMachineCodeOffset offset machineCode
+    originalIrId <- foldr walkPass (Just finalIrId) (sourceMapChainIrToIr chain)
+    astNodeId <- lookupAstNodeIdByIrId originalIrId (sourceMapChainAstToIr chain)
+    lookupSourceByAstNodeId astNodeId (sourceMapChainSourceToAst chain)
+
+applyOptimizerPass :: [Int] -> IrToIr -> [Int]
+applyOptimizerPass currentIds segment =
+    concatMap step currentIds
+  where
+    step irId
+        | Set.member irId (irToIrDeleted segment) = []
+        | otherwise =
+            case lookupNewIrIdsByOriginalId irId segment of
+                Just newIds -> newIds
+                Nothing -> []
+
+walkPass :: IrToIr -> Maybe Int -> Maybe Int
+walkPass _ Nothing = Nothing
+walkPass segment (Just irId) = lookupOriginalIrIdByNewId irId segment
+
+matchesSourcePosition :: SourcePosition -> SourcePosition -> Bool
+matchesSourcePosition left right =
+    sourcePositionFile left == sourcePositionFile right
+        && sourcePositionLine left == sourcePositionLine right
+        && sourcePositionColumn left == sourcePositionColumn right

--- a/code/packages/haskell/compiler-source-map/test/CompilerSourceMapSpec.hs
+++ b/code/packages/haskell/compiler-source-map/test/CompilerSourceMapSpec.hs
@@ -1,0 +1,87 @@
+module CompilerSourceMapSpec (spec) where
+
+import Test.Hspec
+
+import CompilerSourceMap
+
+spec :: Spec
+spec = do
+    describe "formatSourcePosition" $
+        it "renders file, line, column, and length" $
+            formatSourcePosition samplePosition `shouldBe` "hello.bf:1:3 (len=1)"
+
+    describe "SourceToAst" $ do
+        it "looks up positions by AST node id" $ do
+            let mapping =
+                    addSourceToAst samplePosition 42 $
+                        addSourceToAst (SourcePosition "hello.bf" 1 4 1) 43 emptySourceToAst
+            lookupSourceByAstNodeId 42 mapping `shouldBe` Just samplePosition
+
+        it "matches positions by file, line, and column" $ do
+            let mapping = addSourceToAst samplePosition 42 emptySourceToAst
+            lookupAstNodeIdBySourcePosition (samplePosition{sourcePositionLength = 4}) mapping
+                `shouldBe` Just 42
+
+    describe "AstToIr" $
+        it "finds the originating AST node from an IR id" $ do
+            let mapping =
+                    addAstToIr 42 [7, 8, 9, 10] $
+                        addAstToIr 43 [11] emptyAstToIr
+            lookupAstNodeIdByIrId 9 mapping `shouldBe` Just 42
+
+    describe "IrToIr" $ do
+        it "tracks replacement mappings" $ do
+            let segment = addIrMapping 7 [100] $ addIrMapping 8 [101] (emptyIrToIr "contraction")
+            lookupNewIrIdsByOriginalId 8 segment `shouldBe` Just [101]
+
+        it "treats deleted instructions as absent" $ do
+            let segment = addIrDeletion 9 (emptyIrToIr "dead-store")
+            lookupNewIrIdsByOriginalId 9 segment `shouldBe` Nothing
+
+    describe "IrToMachineCode" $
+        it "maps byte offsets back to IR ids" $ do
+            let segment =
+                    addIrToMachineCode 7 0 4 $
+                        addIrToMachineCode 8 4 4 emptyIrToMachineCode
+            lookupIrIdByMachineCodeOffset 6 segment `shouldBe` Just 8
+
+    describe "SourceMapChain" $ do
+        it "walks source positions forward to machine code" $ do
+            let expected =
+                    [ IrToMachineCodeEntry 100 0 4
+                    , IrToMachineCodeEntry 101 4 4
+                    ]
+            sourceToMachineCode completeChain samplePosition `shouldBe` Just expected
+
+        it "walks machine code offsets back to source positions" $
+            machineCodeToSource completeChain 5 `shouldBe` Just samplePosition
+
+        it "returns Nothing when all IR instructions are deleted" $ do
+            let deletedPass = addIrDeletion 7 $ addIrDeletion 8 (emptyIrToIr "erase")
+                chain = addOptimizerPass deletedPass baseChain
+            sourceToMachineCode chain samplePosition `shouldBe` Nothing
+
+samplePosition :: SourcePosition
+samplePosition = SourcePosition "hello.bf" 1 3 1
+
+baseChain :: SourceMapChain
+baseChain =
+    emptySourceMapChain
+        { sourceMapChainSourceToAst = addSourceToAst samplePosition 42 emptySourceToAst
+        , sourceMapChainAstToIr = addAstToIr 42 [7, 8] emptyAstToIr
+        }
+
+completeChain :: SourceMapChain
+completeChain =
+    setIrToMachineCode machineCodeSegment $
+        addOptimizerPass optimizerPass baseChain
+
+optimizerPass :: IrToIr
+optimizerPass =
+    addIrMapping 7 [100] $
+        addIrMapping 8 [101] (emptyIrToIr "contraction")
+
+machineCodeSegment :: IrToMachineCode
+machineCodeSegment =
+    addIrToMachineCode 100 0 4 $
+        addIrToMachineCode 101 4 4 emptyIrToMachineCode

--- a/code/packages/haskell/compiler-source-map/test/Spec.hs
+++ b/code/packages/haskell/compiler-source-map/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import CompilerSourceMapSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/content-addressable-storage/BUILD
+++ b/code/packages/haskell/content-addressable-storage/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/content-addressable-storage/BUILD_windows
+++ b/code/packages/haskell/content-addressable-storage/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/content-addressable-storage/CHANGELOG.md
+++ b/code/packages/haskell/content-addressable-storage/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/content-addressable-storage/README.md
+++ b/code/packages/haskell/content-addressable-storage/README.md
@@ -1,0 +1,14 @@
+# content-addressable-storage
+
+Content-addressable blob storage for Haskell.
+
+## What it does
+
+- computes SHA-1 keys from blob content
+- stores and retrieves blobs through pluggable backends
+- supports in-memory and local-disk stores
+- resolves abbreviated hex prefixes and verifies content integrity on read
+
+## Status
+
+This Haskell package now includes a self-contained SHA-1 implementation plus tests for hex conversion, corruption detection, prefix lookup, and disk-backed storage.

--- a/code/packages/haskell/content-addressable-storage/cabal.project
+++ b/code/packages/haskell/content-addressable-storage/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/code/packages/haskell/content-addressable-storage/content-addressable-storage.cabal
+++ b/code/packages/haskell/content-addressable-storage/content-addressable-storage.cabal
@@ -1,0 +1,30 @@
+cabal-version: 3.0
+name:          coding-adventures-content-addressable-storage
+version:       0.1.0
+synopsis:      Content-addressable blob storage for Haskell
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  ContentAddressableStorage
+    build-depends:    base >=4.14
+                    , bytestring
+                    , containers
+                    , directory
+                    , filepath
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    ContentAddressableStorageSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , bytestring
+                    , coding-adventures-content-addressable-storage
+                    , directory
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/content-addressable-storage/src/ContentAddressableStorage.hs
+++ b/code/packages/haskell/content-addressable-storage/src/ContentAddressableStorage.hs
@@ -1,0 +1,349 @@
+module ContentAddressableStorage
+    ( Key
+    , keyToHex
+    , hexToKey
+    , sha1Key
+    , BlobStore(..)
+    , CasError(..)
+    , ContentAddressableStore
+    , newContentAddressableStore
+    , MemoryStore
+    , newMemoryStore
+    , LocalDiskStore
+    , newLocalDiskStore
+    , putContent
+    , getContent
+    , existsContent
+    , findByPrefix
+    ) where
+
+import Control.Exception (IOException, try)
+import Data.Bits
+    ( rotateL
+    , shiftL
+    , shiftR
+    , xor
+    , (.&.)
+    , (.|.)
+    )
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BSC
+import qualified Data.IORef as IORef
+import qualified Data.List as List
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
+import Data.Maybe (mapMaybe)
+import Data.Word (Word32, Word64, Word8)
+import Numeric (showHex)
+import System.Directory
+    ( createDirectoryIfMissing
+    , doesDirectoryExist
+    , doesFileExist
+    , listDirectory
+    )
+import System.FilePath ((</>))
+
+newtype Key = Key BS.ByteString
+    deriving (Eq, Ord)
+
+instance Show Key where
+    show = keyToHex
+
+keyToHex :: Key -> String
+keyToHex (Key bytes) =
+    concatMap toHexPair (BS.unpack bytes)
+  where
+    toHexPair byte =
+        let hexDigits = showHex byte ""
+         in replicate (2 - length hexDigits) '0' ++ hexDigits
+
+hexToKey :: String -> Either String Key
+hexToKey hexValue
+    | length hexValue /= 40 = Left ("expected 40 hex chars, got " ++ show (length hexValue))
+    | otherwise = Key . BS.pack <$> go hexValue
+  where
+    go [] = Right []
+    go (left : right : rest) = do
+        hi <- fromHexDigit left
+        lo <- fromHexDigit right
+        let byte = fromIntegral (hi * 16 + lo)
+        (byte :) <$> go rest
+    go _ = Left "expected an even number of hex digits"
+
+fromHexDigit :: Char -> Either String Int
+fromHexDigit charValue
+    | charValue >= '0' && charValue <= '9' = Right (fromEnum charValue - fromEnum '0')
+    | charValue >= 'a' && charValue <= 'f' = Right (10 + fromEnum charValue - fromEnum 'a')
+    | charValue >= 'A' && charValue <= 'F' = Right (10 + fromEnum charValue - fromEnum 'A')
+    | otherwise = Left ("invalid hex character: " ++ [charValue])
+
+sha1Key :: BS.ByteString -> Key
+sha1Key input =
+    Key . BS.pack . concatMap word32ToBytes $ finalState
+  where
+    finalState = foldl processChunk initialState (chunkify 64 (padSha1 input))
+    initialState =
+        [ 0x67452301
+        , 0xEFCDAB89
+        , 0x98BADCFE
+        , 0x10325476
+        , 0xC3D2E1F0
+        ]
+
+data CasError
+    = CasStoreError String
+    | CasNotFound Key
+    | CasCorrupted Key
+    | CasAmbiguousPrefix String
+    | CasPrefixNotFound String
+    | CasInvalidPrefix String
+    deriving (Eq, Show)
+
+class BlobStore store where
+    putBlob :: store -> Key -> BS.ByteString -> IO (Either String ())
+    getBlob :: store -> Key -> IO (Either String (Maybe BS.ByteString))
+    existsBlob :: store -> Key -> IO (Either String Bool)
+    keysWithPrefix :: store -> String -> IO (Either String [Key])
+
+newtype ContentAddressableStore store = ContentAddressableStore store
+
+newContentAddressableStore :: store -> ContentAddressableStore store
+newContentAddressableStore = ContentAddressableStore
+
+data MemoryStore = MemoryStore (IORef.IORef (Map Key BS.ByteString))
+
+newMemoryStore :: IO MemoryStore
+newMemoryStore =
+    MemoryStore <$> IORef.newIORef Map.empty
+
+instance BlobStore MemoryStore where
+    putBlob (MemoryStore ref) key bytes = do
+        IORef.modifyIORef' ref (Map.insert key bytes)
+        pure (Right ())
+
+    getBlob (MemoryStore ref) key = do
+        store <- IORef.readIORef ref
+        pure (Right (Map.lookup key store))
+
+    existsBlob (MemoryStore ref) key = do
+        store <- IORef.readIORef ref
+        pure (Right (Map.member key store))
+
+    keysWithPrefix (MemoryStore ref) prefix = do
+        store <- IORef.readIORef ref
+        pure (Right [key | key <- Map.keys store, prefix `List.isPrefixOf` keyToHex key])
+
+newtype LocalDiskStore = LocalDiskStore FilePath
+
+newLocalDiskStore :: FilePath -> IO LocalDiskStore
+newLocalDiskStore root = do
+    createDirectoryIfMissing True root
+    pure (LocalDiskStore root)
+
+instance BlobStore LocalDiskStore where
+    putBlob (LocalDiskStore root) key bytes =
+        wrapIoError $ do
+            let path = pathForKey root key
+            createDirectoryIfMissing True (keyDirectory root key)
+            BS.writeFile path bytes
+
+    getBlob (LocalDiskStore root) key =
+        wrapIoError $ do
+            let path = pathForKey root key
+            present <- doesFileExist path
+            if present
+                then Just <$> BS.readFile path
+                else pure Nothing
+
+    existsBlob (LocalDiskStore root) key =
+        wrapIoError (doesFileExist (pathForKey root key))
+
+    keysWithPrefix (LocalDiskStore root) prefix =
+        wrapIoError (discoverMatchingKeys root prefix)
+
+putContent :: BlobStore store => ContentAddressableStore store -> BS.ByteString -> IO (Either CasError Key)
+putContent (ContentAddressableStore store) bytes = do
+    let key = sha1Key bytes
+    result <- putBlob store key bytes
+    pure $
+        case result of
+            Left err -> Left (CasStoreError err)
+            Right () -> Right key
+
+getContent :: BlobStore store => ContentAddressableStore store -> Key -> IO (Either CasError BS.ByteString)
+getContent (ContentAddressableStore store) key = do
+    result <- getBlob store key
+    pure $
+        case result of
+            Left err -> Left (CasStoreError err)
+            Right Nothing -> Left (CasNotFound key)
+            Right (Just bytes) ->
+                if sha1Key bytes == key
+                    then Right bytes
+                    else Left (CasCorrupted key)
+
+existsContent :: BlobStore store => ContentAddressableStore store -> Key -> IO (Either CasError Bool)
+existsContent (ContentAddressableStore store) key = do
+    result <- existsBlob store key
+    pure $
+        case result of
+            Left err -> Left (CasStoreError err)
+            Right present -> Right present
+
+findByPrefix :: BlobStore store => ContentAddressableStore store -> String -> IO (Either CasError Key)
+findByPrefix (ContentAddressableStore store) prefix =
+    case validatePrefix prefix of
+        Left err -> pure (Left err)
+        Right normalizedPrefix -> do
+            result <- keysWithPrefix store normalizedPrefix
+            pure $
+                case result of
+                    Left err -> Left (CasStoreError err)
+                    Right [] -> Left (CasPrefixNotFound normalizedPrefix)
+                    Right [key] -> Right key
+                    Right _ -> Left (CasAmbiguousPrefix normalizedPrefix)
+
+validatePrefix :: String -> Either CasError String
+validatePrefix prefix
+    | null prefix = Left (CasInvalidPrefix prefix)
+    | any (not . isHexChar) prefix = Left (CasInvalidPrefix prefix)
+    | otherwise = Right prefix
+
+isHexChar :: Char -> Bool
+isHexChar charValue =
+    (charValue >= '0' && charValue <= '9')
+        || (charValue >= 'a' && charValue <= 'f')
+        || (charValue >= 'A' && charValue <= 'F')
+
+pathForKey :: FilePath -> Key -> FilePath
+pathForKey root key =
+    keyDirectory root key </> drop 2 (keyToHex key)
+
+keyDirectory :: FilePath -> Key -> FilePath
+keyDirectory root key =
+    root </> take 2 (keyToHex key)
+
+discoverMatchingKeys :: FilePath -> String -> IO [Key]
+discoverMatchingKeys root prefix = do
+    rootExists <- doesDirectoryExist root
+    if not rootExists
+        then pure []
+        else do
+            directoryNames <- candidateDirectories root prefix
+            fmap concat $
+                mapM (discoverKeysInDirectory root prefix) directoryNames
+
+candidateDirectories :: FilePath -> String -> IO [FilePath]
+candidateDirectories root prefix
+    | length prefix < 2 = do
+        entries <- listDirectory root
+        pure [entry | entry <- entries, prefix `List.isPrefixOf` entry]
+    | otherwise = do
+        let dirName = take 2 prefix
+        exists <- doesDirectoryExist (root </> dirName)
+        pure [dirName | exists]
+
+discoverKeysInDirectory :: FilePath -> String -> FilePath -> IO [Key]
+discoverKeysInDirectory root prefix dirName = do
+    fileNames <- listDirectory (root </> dirName)
+    pure $
+        mapMaybe
+            (\fileName ->
+                let candidate = dirName ++ fileName
+                 in if length candidate == 40
+                        && prefix `List.isPrefixOf` candidate
+                        then either (const Nothing) Just (hexToKey candidate)
+                        else Nothing
+            )
+            fileNames
+
+wrapIoError :: IO a -> IO (Either String a)
+wrapIoError action = do
+    result <- try action
+    pure $
+        case result of
+            Left err -> Left (show (err :: IOException))
+            Right value -> Right value
+
+padSha1 :: BS.ByteString -> BS.ByteString
+padSha1 input =
+    input <> BS.pack [0x80] <> BS.replicate paddingLength 0 <> BS.pack (word64ToBytes messageLengthBits)
+  where
+    messageLengthBits =
+        fromIntegral (BS.length input) * 8 :: Word64
+    remainder =
+        (BS.length input + 1 + 8) `mod` 64
+    paddingLength =
+        if remainder == 0 then 0 else 64 - remainder
+
+chunkify :: Int -> BS.ByteString -> [BS.ByteString]
+chunkify chunkSize bytes
+    | BS.null bytes = []
+    | otherwise =
+        let (current, rest) = BS.splitAt chunkSize bytes
+         in current : chunkify chunkSize rest
+
+processChunk :: [Word32] -> BS.ByteString -> [Word32]
+processChunk [h0, h1, h2, h3, h4] chunk =
+    [ h0 + aFinal
+    , h1 + bFinal
+    , h2 + cFinal
+    , h3 + dFinal
+    , h4 + eFinal
+    ]
+  where
+    schedule = expandSchedule (map bytesToWord32 (chunkify 4 chunk))
+    (aFinal, bFinal, cFinal, dFinal, eFinal) =
+        foldl step (h0, h1, h2, h3, h4) (zip [0 :: Int .. 79] schedule)
+
+    step (a, b, c, d, e) (index, wordValue) =
+        let (f, k)
+                | index <= 19 = ((b .&. c) .|. (complement32 b .&. d), 0x5A827999)
+                | index <= 39 = (b `xor` c `xor` d, 0x6ED9EBA1)
+                | index <= 59 = ((b .&. c) .|. (b .&. d) .|. (c .&. d), 0x8F1BBCDC)
+                | otherwise = (b `xor` c `xor` d, 0xCA62C1D6)
+            temp = rotateL a 5 + f + e + k + wordValue
+         in (temp, a, rotateL b 30, c, d)
+processChunk state _ = state
+
+expandSchedule :: [Word32] -> [Word32]
+expandSchedule initialWords =
+    initialWords ++ map buildWord [16 .. 79]
+  where
+    buildWord index =
+        rotateL
+            ( schedule !! (index - 3)
+                `xor` schedule !! (index - 8)
+                `xor` schedule !! (index - 14)
+                `xor` schedule !! (index - 16)
+            )
+            1
+    schedule = expandSchedule initialWords
+
+complement32 :: Word32 -> Word32
+complement32 value =
+    value `xor` 0xFFFFFFFF
+
+bytesToWord32 :: BS.ByteString -> Word32
+bytesToWord32 bytes =
+    foldl (\acc byte -> shiftL acc 8 .|. fromIntegral byte) 0 (BS.unpack bytes)
+
+word32ToBytes :: Word32 -> [Word8]
+word32ToBytes value =
+    [ fromIntegral (shiftR value 24 .&. 0xFF)
+    , fromIntegral (shiftR value 16 .&. 0xFF)
+    , fromIntegral (shiftR value 8 .&. 0xFF)
+    , fromIntegral (value .&. 0xFF)
+    ]
+
+word64ToBytes :: Word64 -> [Word8]
+word64ToBytes value =
+    [ fromIntegral (shiftR value 56 .&. 0xFF)
+    , fromIntegral (shiftR value 48 .&. 0xFF)
+    , fromIntegral (shiftR value 40 .&. 0xFF)
+    , fromIntegral (shiftR value 32 .&. 0xFF)
+    , fromIntegral (shiftR value 24 .&. 0xFF)
+    , fromIntegral (shiftR value 16 .&. 0xFF)
+    , fromIntegral (shiftR value 8 .&. 0xFF)
+    , fromIntegral (value .&. 0xFF)
+    ]

--- a/code/packages/haskell/content-addressable-storage/test/ContentAddressableStorageSpec.hs
+++ b/code/packages/haskell/content-addressable-storage/test/ContentAddressableStorageSpec.hs
@@ -1,0 +1,81 @@
+module ContentAddressableStorageSpec (spec) where
+
+import qualified Data.ByteString.Char8 as BSC
+import System.Directory
+    ( createDirectory
+    , getTemporaryDirectory
+    , removeFile
+    , removePathForcibly
+    )
+import System.IO (hClose, openTempFile)
+import Test.Hspec
+
+import ContentAddressableStorage
+
+spec :: Spec
+spec = do
+    describe "hex utilities" $ do
+        it "round-trips a SHA-1 key through hex" $ do
+            let key = sha1Key (BSC.pack "hello")
+            keyToHex key `shouldBe` "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d"
+            hexToKey (keyToHex key) `shouldBe` Right key
+
+    describe "MemoryStore" $ do
+        it "stores and retrieves blobs by content hash" $ do
+            store <- newMemoryStore
+            let cas = newContentAddressableStore store
+            putResult <- putContent cas (BSC.pack "hello, world")
+            case putResult of
+                Left err -> expectationFailure (show err)
+                Right key -> do
+                    getContent cas key `shouldReturn` Right (BSC.pack "hello, world")
+                    existsContent cas key `shouldReturn` Right True
+
+        it "detects corrupted blobs on read" $ do
+            store <- newMemoryStore
+            let cas = newContentAddressableStore store
+            putResult <- putContent cas (BSC.pack "hello")
+            case putResult of
+                Left err -> expectationFailure (show err)
+                Right key -> do
+                    putBlob store key (BSC.pack "tampered") `shouldReturn` Right ()
+                    getContent cas key `shouldReturn` Left (CasCorrupted key)
+
+        it "finds keys by unique prefix and rejects ambiguous prefixes" $ do
+            store <- newMemoryStore
+            let cas = newContentAddressableStore store
+            Right keyA <- putContent cas (BSC.pack "alpha")
+            Right keyB <- putContent cas (BSC.pack "beta")
+            let prefixA = take 8 (keyToHex keyA)
+                ambiguousPrefix = sharedPrefix (keyToHex keyA) (keyToHex keyB)
+            findByPrefix cas prefixA `shouldReturn` Right keyA
+            if null ambiguousPrefix
+                then pure ()
+                else findByPrefix cas ambiguousPrefix `shouldReturn` Left (CasAmbiguousPrefix ambiguousPrefix)
+
+    describe "LocalDiskStore" $
+        it "round-trips blobs on disk" $ do
+            tempDir <- withTempDirectory "cas"
+            store <- newLocalDiskStore tempDir
+            let cas = newContentAddressableStore store
+            Right key <- putContent cas (BSC.pack "disk blob")
+            getContent cas key `shouldReturn` Right (BSC.pack "disk blob")
+            removePathForcibly tempDir
+
+withTempDirectory :: String -> IO FilePath
+withTempDirectory label = do
+    tempRoot <- getTemporaryDirectory
+    (path, handle) <- openTempFile tempRoot (label ++ "-XXXXXX")
+    hClose handle
+    removeFile path
+    createDirectory path
+    pure path
+
+sharedPrefix :: String -> String -> String
+sharedPrefix left right =
+    takeWhileSame left right
+  where
+    takeWhileSame (l : ls) (r : rs)
+        | l == r = l : takeWhileSame ls rs
+        | otherwise = []
+    takeWhileSame _ _ = []

--- a/code/packages/haskell/content-addressable-storage/test/Spec.hs
+++ b/code/packages/haskell/content-addressable-storage/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import ContentAddressableStorageSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/json-rpc/BUILD
+++ b/code/packages/haskell/json-rpc/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/json-rpc/BUILD_windows
+++ b/code/packages/haskell/json-rpc/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/json-rpc/CHANGELOG.md
+++ b/code/packages/haskell/json-rpc/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/json-rpc/README.md
+++ b/code/packages/haskell/json-rpc/README.md
@@ -1,0 +1,14 @@
+# json-rpc
+
+JSON-RPC 2.0 transport and dispatch for Haskell.
+
+## What it does
+
+- parses and serialises JSON-RPC requests, responses, and notifications
+- frames messages with `Content-Length` headers
+- dispatches request and notification handlers through a small server abstraction
+- stays self-contained with an internal JSON value/parser layer so it builds in this repo environment
+
+## Status
+
+This Haskell package now has end-to-end framing and dispatch tests, including parse-error responses.

--- a/code/packages/haskell/json-rpc/cabal.project
+++ b/code/packages/haskell/json-rpc/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/code/packages/haskell/json-rpc/json-rpc.cabal
+++ b/code/packages/haskell/json-rpc/json-rpc.cabal
@@ -1,0 +1,27 @@
+cabal-version: 3.0
+name:          coding-adventures-json-rpc
+version:       0.1.0
+synopsis:      JSON-RPC 2.0 transport and dispatch for Haskell
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  JsonRpc
+    build-depends:    base >=4.14
+                    , bytestring
+                    , containers
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    JsonRpcSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , bytestring
+                    , hspec == 2.*
+                    , coding-adventures-json-rpc
+    default-language: Haskell2010

--- a/code/packages/haskell/json-rpc/src/JsonRpc.hs
+++ b/code/packages/haskell/json-rpc/src/JsonRpc.hs
@@ -1,0 +1,550 @@
+module JsonRpc
+    ( JsonValue(..)
+    , parseErrorCode
+    , invalidRequestCode
+    , methodNotFoundCode
+    , invalidParamsCode
+    , internalErrorCode
+    , ResponseError(..)
+    , parseErrorResponse
+    , invalidRequestResponse
+    , methodNotFoundResponse
+    , invalidParamsResponse
+    , internalErrorResponse
+    , Id
+    , Request(..)
+    , Response(..)
+    , Notification(..)
+    , Message(..)
+    , parseJson
+    , renderJson
+    , parseMessage
+    , messageToValue
+    , encodeMessagePayload
+    , framePayload
+    , renderMessageFrame
+    , extractFrame
+    , parseFramedMessages
+    , RequestHandler
+    , NotificationHandler
+    , Server
+    , emptyServer
+    , onRequest
+    , onNotification
+    , dispatchMessage
+    , serveByteString
+    , serveHandles
+    ) where
+
+import Control.Applicative ((<|>))
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BSC
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
+import Data.Char (chr, digitToInt, isDigit, ord)
+import Data.List (intercalate)
+import Data.Maybe (mapMaybe)
+import Numeric (showHex)
+import System.IO (Handle, hFlush)
+import Text.ParserCombinators.ReadP
+    ( ReadP
+    , between
+    , char
+    , choice
+    , eof
+    , many
+    , munch1
+    , option
+    , pfail
+    , readP_to_S
+    , satisfy
+    , sepBy
+    , skipSpaces
+    , string
+    )
+
+data JsonValue
+    = JsonNull
+    | JsonBool Bool
+    | JsonNumber Double
+    | JsonString String
+    | JsonArray [JsonValue]
+    | JsonObject [(String, JsonValue)]
+    deriving (Eq, Show)
+
+parseErrorCode, invalidRequestCode, methodNotFoundCode, invalidParamsCode, internalErrorCode :: Int
+parseErrorCode = -32700
+invalidRequestCode = -32600
+methodNotFoundCode = -32601
+invalidParamsCode = -32602
+internalErrorCode = -32603
+
+data ResponseError = ResponseError
+    { responseErrorCode :: Int
+    , responseErrorMessage :: String
+    , responseErrorData :: Maybe JsonValue
+    }
+    deriving (Eq, Show)
+
+type Id = JsonValue
+
+data Request = Request
+    { requestId :: Id
+    , requestMethod :: String
+    , requestParams :: Maybe JsonValue
+    }
+    deriving (Eq, Show)
+
+data Response = Response
+    { responseId :: Id
+    , responseResult :: Maybe JsonValue
+    , responseError :: Maybe ResponseError
+    }
+    deriving (Eq, Show)
+
+data Notification = Notification
+    { notificationMethod :: String
+    , notificationParams :: Maybe JsonValue
+    }
+    deriving (Eq, Show)
+
+data Message
+    = RequestMessage Request
+    | ResponseMessage Response
+    | NotificationMessage Notification
+    deriving (Eq, Show)
+
+parseErrorResponse :: Maybe JsonValue -> ResponseError
+parseErrorResponse =
+    ResponseError parseErrorCode "Parse error"
+
+invalidRequestResponse :: Maybe JsonValue -> ResponseError
+invalidRequestResponse =
+    ResponseError invalidRequestCode "Invalid Request"
+
+methodNotFoundResponse :: String -> ResponseError
+methodNotFoundResponse methodName =
+    ResponseError methodNotFoundCode "Method not found" (Just (JsonString methodName))
+
+invalidParamsResponse :: Maybe JsonValue -> ResponseError
+invalidParamsResponse =
+    ResponseError invalidParamsCode "Invalid params"
+
+internalErrorResponse :: Maybe JsonValue -> ResponseError
+internalErrorResponse =
+    ResponseError internalErrorCode "Internal error"
+
+parseJson :: String -> Either String JsonValue
+parseJson input =
+    case [value | (value, rest) <- readP_to_S (skipSpaces *> jsonValueParser <* skipSpaces <* eof) input, null rest] of
+        [] -> Left "invalid json"
+        values -> Right (last values)
+
+renderJson :: JsonValue -> String
+renderJson value =
+    case value of
+        JsonNull -> "null"
+        JsonBool True -> "true"
+        JsonBool False -> "false"
+        JsonNumber numberValue
+            | isWholeNumber numberValue -> show (round numberValue :: Integer)
+            | otherwise -> show numberValue
+        JsonString textValue -> "\"" ++ concatMap escapeJsonChar textValue ++ "\""
+        JsonArray values -> "[" ++ intercalate "," (map renderJson values) ++ "]"
+        JsonObject fields ->
+            "{"
+                ++ intercalate
+                    ","
+                    [ renderJson (JsonString fieldName) ++ ":" ++ renderJson fieldValue
+                    | (fieldName, fieldValue) <- fields
+                    ]
+                ++ "}"
+
+parseMessage :: BS.ByteString -> Either ResponseError Message
+parseMessage payload =
+    case parseJson (BSC.unpack payload) of
+        Left _ -> Left (parseErrorResponse Nothing)
+        Right value -> parseMessageValue value
+
+messageToValue :: Message -> JsonValue
+messageToValue message =
+    case message of
+        RequestMessage req ->
+            JsonObject $
+                [ ("jsonrpc", JsonString "2.0")
+                , ("id", requestId req)
+                , ("method", JsonString (requestMethod req))
+                ]
+                    ++ maybe [] (\params -> [("params", params)]) (requestParams req)
+        NotificationMessage notif ->
+            JsonObject $
+                [ ("jsonrpc", JsonString "2.0")
+                , ("method", JsonString (notificationMethod notif))
+                ]
+                    ++ maybe [] (\params -> [("params", params)]) (notificationParams notif)
+        ResponseMessage resp ->
+            JsonObject $
+                [ ("jsonrpc", JsonString "2.0")
+                , ("id", responseId resp)
+                ]
+                    ++ maybe [] (\resultValue -> [("result", resultValue)]) (responseResult resp)
+                    ++ maybe [] (\err -> [("error", responseErrorToValue err)]) (responseError resp)
+
+encodeMessagePayload :: Message -> BS.ByteString
+encodeMessagePayload =
+    BSC.pack . renderJson . messageToValue
+
+framePayload :: BS.ByteString -> BS.ByteString
+framePayload payload =
+    BSC.pack ("Content-Length: " ++ show (BS.length payload) ++ "\r\n\r\n") <> payload
+
+renderMessageFrame :: Message -> BS.ByteString
+renderMessageFrame =
+    framePayload . encodeMessagePayload
+
+extractFrame :: BS.ByteString -> Either String (Maybe (BS.ByteString, BS.ByteString))
+extractFrame input
+    | BS.null input = Right Nothing
+    | otherwise =
+        case findHeaderSeparator input of
+            Nothing -> Left "missing header separator"
+            Just headerLength -> do
+                let headerBytes = BS.take headerLength input
+                    remaining = BS.drop (headerLength + 4) input
+                contentLength <- parseContentLength headerBytes
+                if BS.length remaining < contentLength
+                    then Left "incomplete frame"
+                    else Right (Just (BS.take contentLength remaining, BS.drop contentLength remaining))
+
+parseFramedMessages :: BS.ByteString -> Either String [Message]
+parseFramedMessages =
+    go []
+  where
+    go acc buffer =
+        case extractFrame buffer of
+            Left err -> Left err
+            Right Nothing -> Right (reverse acc)
+            Right (Just (payload, rest)) ->
+                case parseMessage payload of
+                    Left err -> Left ("invalid payload: " ++ responseErrorMessage err)
+                    Right message -> go (message : acc) rest
+
+type RequestHandler = Id -> Maybe JsonValue -> IO (Either ResponseError JsonValue)
+type NotificationHandler = Maybe JsonValue -> IO ()
+
+data Server = Server
+    { serverRequestHandlers :: Map String RequestHandler
+    , serverNotificationHandlers :: Map String NotificationHandler
+    }
+
+emptyServer :: Server
+emptyServer =
+    Server
+        { serverRequestHandlers = Map.empty
+        , serverNotificationHandlers = Map.empty
+        }
+
+onRequest :: String -> RequestHandler -> Server -> Server
+onRequest methodName handler server =
+    server{serverRequestHandlers = Map.insert methodName handler (serverRequestHandlers server)}
+
+onNotification :: String -> NotificationHandler -> Server -> Server
+onNotification methodName handler server =
+    server{serverNotificationHandlers = Map.insert methodName handler (serverNotificationHandlers server)}
+
+dispatchMessage :: Server -> Message -> IO (Maybe Message)
+dispatchMessage server message =
+    case message of
+        ResponseMessage _ ->
+            pure Nothing
+        NotificationMessage notif ->
+            case Map.lookup (notificationMethod notif) (serverNotificationHandlers server) of
+                Nothing -> pure Nothing
+                Just handler -> handler (notificationParams notif) >> pure Nothing
+        RequestMessage req ->
+            case Map.lookup (requestMethod req) (serverRequestHandlers server) of
+                Nothing ->
+                    pure
+                        (Just
+                            (ResponseMessage
+                                (Response
+                                    (requestId req)
+                                    Nothing
+                                    (Just (methodNotFoundResponse (requestMethod req)))
+                                )
+                            )
+                        )
+                Just handler -> do
+                    result <- handler (requestId req) (requestParams req)
+                    pure . Just $
+                        ResponseMessage $
+                            case result of
+                                Left err -> Response (requestId req) Nothing (Just err)
+                                Right value -> Response (requestId req) (Just value) Nothing
+
+serveByteString :: Server -> BS.ByteString -> IO (Either String BS.ByteString)
+serveByteString server input = do
+    responses <- collectResponses [] input
+    pure (fmap (BS.concat . map renderMessageFrame) responses)
+  where
+    collectResponses acc buffer =
+        case extractFrame buffer of
+            Left err -> pure (Left err)
+            Right Nothing -> pure (Right (reverse acc))
+            Right (Just (payload, rest)) ->
+                case parseMessage payload of
+                    Left err ->
+                        collectResponses
+                            (ResponseMessage (Response JsonNull Nothing (Just err)) : acc)
+                            rest
+                    Right message -> do
+                        maybeResponse <- dispatchMessage server message
+                        collectResponses (maybe acc (: acc) maybeResponse) rest
+
+serveHandles :: Server -> Handle -> Handle -> IO (Either String ())
+serveHandles server inputHandle outputHandle = do
+    payload <- BS.hGetContents inputHandle
+    result <- serveByteString server payload
+    case result of
+        Left err -> pure (Left err)
+        Right output -> do
+            BS.hPut outputHandle output
+            hFlush outputHandle
+            pure (Right ())
+
+parseMessageValue :: JsonValue -> Either ResponseError Message
+parseMessageValue (JsonObject fields) = do
+    ensureJsonRpcVersion fields
+    let hasId = hasField "id" fields
+        hasMethod = hasField "method" fields
+        hasResult = hasField "result" fields
+        hasError = hasField "error" fields
+    case (hasId, hasMethod, hasResult, hasError) of
+        (True, True, False, False) -> parseRequest fields
+        (False, True, False, False) -> parseNotification fields
+        (_, False, _, _) | hasResult || hasError -> parseResponse fields
+        _ -> Left (invalidRequestResponse Nothing)
+parseMessageValue _ =
+    Left (invalidRequestResponse Nothing)
+
+parseRequest :: [(String, JsonValue)] -> Either ResponseError Message
+parseRequest fields = do
+    ident <- requiredField "id" fields
+    if ident == JsonNull
+        then Left (invalidRequestResponse (Just (JsonString "request id must not be null")))
+        else do
+            methodName <- requiredString "method" fields
+            pure (RequestMessage (Request ident methodName (lookupField "params" fields)))
+
+parseNotification :: [(String, JsonValue)] -> Either ResponseError Message
+parseNotification fields = do
+    methodName <- requiredString "method" fields
+    pure (NotificationMessage (Notification methodName (lookupField "params" fields)))
+
+parseResponse :: [(String, JsonValue)] -> Either ResponseError Message
+parseResponse fields = do
+    ident <- requiredField "id" fields
+    let resultValue = lookupField "result" fields
+        errorValue = lookupField "error" fields
+    case (resultValue, errorValue) of
+        (Just _, Just _) -> Left (invalidRequestResponse (Just (JsonString "response cannot contain both result and error")))
+        (Nothing, Nothing) -> Left (invalidRequestResponse (Just (JsonString "response must contain result or error")))
+        (Just value, Nothing) ->
+            pure (ResponseMessage (Response ident (Just value) Nothing))
+        (Nothing, Just value) ->
+            case responseErrorFromValue value of
+                Left err -> Left err
+                Right responseErr -> pure (ResponseMessage (Response ident Nothing (Just responseErr)))
+
+ensureJsonRpcVersion :: [(String, JsonValue)] -> Either ResponseError ()
+ensureJsonRpcVersion fields =
+    case lookupField "jsonrpc" fields of
+        Just (JsonString "2.0") -> Right ()
+        _ -> Left (invalidRequestResponse (Just (JsonString "jsonrpc must be \"2.0\"")))
+
+responseErrorToValue :: ResponseError -> JsonValue
+responseErrorToValue err =
+    JsonObject $
+        [ ("code", JsonNumber (fromIntegral (responseErrorCode err)))
+        , ("message", JsonString (responseErrorMessage err))
+        ]
+            ++ maybe [] (\value -> [("data", value)]) (responseErrorData err)
+
+responseErrorFromValue :: JsonValue -> Either ResponseError ResponseError
+responseErrorFromValue (JsonObject fields) = do
+    codeValue <- requiredField "code" fields
+    codeNumber <-
+        case codeValue of
+            JsonNumber value -> Right (round value)
+            _ -> Left (invalidRequestResponse (Just (JsonString "error code must be numeric")))
+    messageValue <- requiredString "message" fields
+    pure
+        (ResponseError
+            { responseErrorCode = codeNumber
+            , responseErrorMessage = messageValue
+            , responseErrorData = lookupField "data" fields
+            }
+        )
+responseErrorFromValue _ =
+    Left (invalidRequestResponse (Just (JsonString "error must be an object")))
+
+requiredField :: String -> [(String, JsonValue)] -> Either ResponseError JsonValue
+requiredField name fields =
+    maybe (Left (invalidRequestResponse (Just (JsonString ("missing field " ++ name))))) Right (lookupField name fields)
+
+requiredString :: String -> [(String, JsonValue)] -> Either ResponseError String
+requiredString name fields =
+    case lookupField name fields of
+        Just (JsonString value) -> Right value
+        _ -> Left (invalidRequestResponse (Just (JsonString ("invalid string field " ++ name))))
+
+lookupField :: String -> [(String, JsonValue)] -> Maybe JsonValue
+lookupField name fields =
+    lookup name fields
+
+hasField :: String -> [(String, JsonValue)] -> Bool
+hasField name fields =
+    case lookupField name fields of
+        Nothing -> False
+        Just _ -> True
+
+parseContentLength :: BS.ByteString -> Either String Int
+parseContentLength headerBytes =
+    case lookup "Content-Length" headerPairs of
+        Nothing -> Left "missing Content-Length header"
+        Just rawValue ->
+            case reads rawValue of
+                [(count, "")] | count >= 0 -> Right count
+                _ -> Left "invalid Content-Length header"
+  where
+    headerPairs =
+        mapMaybe parseHeaderLine (BSC.lines headerBytes)
+
+parseHeaderLine :: BS.ByteString -> Maybe (String, String)
+parseHeaderLine line =
+    case break (== ':') (BSC.unpack (stripTrailingCarriageReturn line)) of
+        (_, []) -> Nothing
+        (name, _ : value) -> Just (name, dropWhile (== ' ') value)
+
+findHeaderSeparator :: BS.ByteString -> Maybe Int
+findHeaderSeparator =
+    go 0
+  where
+    marker = BSC.pack "\r\n\r\n"
+    markerLength = BS.length marker
+
+    go index bytes
+        | BS.length bytes < markerLength = Nothing
+        | marker `BS.isPrefixOf` bytes = Just index
+        | otherwise = go (index + 1) (BS.tail bytes)
+
+stripTrailingCarriageReturn :: BS.ByteString -> BS.ByteString
+stripTrailingCarriageReturn =
+    BS.dropWhileEnd (== 13)
+
+jsonValueParser :: ReadP JsonValue
+jsonValueParser =
+    skipSpaces *> choice
+        [ JsonNull <$ string "null"
+        , JsonBool True <$ string "true"
+        , JsonBool False <$ string "false"
+        , JsonString <$> jsonStringLiteral
+        , JsonArray <$> between (char '[' *> skipSpaces) (skipSpaces *> char ']') (jsonValueParser `sepBy` (skipSpaces *> char ',' *> skipSpaces))
+        , JsonObject <$> between (char '{' *> skipSpaces) (skipSpaces *> char '}') (jsonPairParser `sepBy` (skipSpaces *> char ',' *> skipSpaces))
+        , JsonNumber <$> jsonNumberParser
+        ]
+
+jsonPairParser :: ReadP (String, JsonValue)
+jsonPairParser = do
+    key <- jsonStringLiteral
+    skipSpaces
+    _ <- char ':'
+    skipSpaces
+    value <- jsonValueParser
+    pure (key, value)
+
+jsonStringLiteral :: ReadP String
+jsonStringLiteral =
+    between (char '"') (char '"') (many jsonCharacterParser)
+
+jsonCharacterParser :: ReadP Char
+jsonCharacterParser =
+    escaped <|> plain
+  where
+    plain = satisfyNot ['"', '\\']
+    escaped = do
+        _ <- char '\\'
+        choice
+            [ '"' <$ char '"'
+            , '\\' <$ char '\\'
+            , '/' <$ char '/'
+            , '\b' <$ char 'b'
+            , '\f' <$ char 'f'
+            , '\n' <$ char 'n'
+            , '\r' <$ char 'r'
+            , '\t' <$ char 't'
+            , unicodeEscape
+            ]
+    unicodeEscape = do
+        _ <- char 'u'
+        hexDigits <- countExactly 4 hexDigitParser
+        pure (chr (foldl (\acc digitValue -> acc * 16 + digitToInt digitValue) 0 hexDigits))
+
+jsonNumberParser :: ReadP Double
+jsonNumberParser = do
+    sign <- option "" (string "-")
+    whole <- ifZeroPrefixedNumber
+    fractional <- option "" ((:) <$> char '.' <*> munch1 isDigit)
+    exponentPart <- option "" exponentParser
+    pure (read (sign ++ whole ++ fractional ++ exponentPart))
+  where
+    ifZeroPrefixedNumber =
+        (string "0")
+            <|> ((:) <$> satisfyDigitOneToNine <*> manyDigitParser)
+    exponentParser = do
+        exponentMarker <- choice [char 'e', char 'E']
+        exponentSign <- option "" (string "+" <|> string "-")
+        exponentDigits <- munch1 isDigit
+        pure (exponentMarker : exponentSign ++ exponentDigits)
+
+manyDigitParser :: ReadP String
+manyDigitParser =
+    many (satisfy isDigit)
+
+satisfyDigitOneToNine :: ReadP Char
+satisfyDigitOneToNine =
+    satisfy (`elem` ['1' .. '9'])
+
+hexDigitParser :: ReadP Char
+hexDigitParser =
+    satisfy (`elem` (['0' .. '9'] ++ ['a' .. 'f'] ++ ['A' .. 'F']))
+
+satisfyNot :: [Char] -> ReadP Char
+satisfyNot disallowed =
+    satisfy (`notElem` disallowed)
+
+countExactly :: Int -> ReadP a -> ReadP [a]
+countExactly n parser
+    | n <= 0 = pure []
+    | otherwise = (:) <$> parser <*> countExactly (n - 1) parser
+
+escapeJsonChar :: Char -> String
+escapeJsonChar charValue =
+    case charValue of
+        '"' -> "\\\""
+        '\\' -> "\\\\"
+        '\b' -> "\\b"
+        '\f' -> "\\f"
+        '\n' -> "\\n"
+        '\r' -> "\\r"
+        '\t' -> "\\t"
+        _ | ord charValue < 0x20 -> "\\u" ++ padHex (showHex (ord charValue) "")
+        _ -> [charValue]
+
+padHex :: String -> String
+padHex hexDigits =
+    replicate (4 - length hexDigits) '0' ++ hexDigits
+
+isWholeNumber :: Double -> Bool
+isWholeNumber numberValue =
+    numberValue == fromIntegral (round numberValue :: Integer)

--- a/code/packages/haskell/json-rpc/test/JsonRpcSpec.hs
+++ b/code/packages/haskell/json-rpc/test/JsonRpcSpec.hs
@@ -1,0 +1,93 @@
+module JsonRpcSpec (spec) where
+
+import qualified Data.ByteString.Char8 as BSC
+import Data.IORef
+import Test.Hspec
+
+import JsonRpc
+
+spec :: Spec
+spec = do
+    describe "parseMessage" $ do
+        it "parses a request with params" $ do
+            let payload = BSC.pack "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ping\",\"params\":{\"value\":3}}"
+            parseMessage payload
+                `shouldBe` Right
+                    (RequestMessage
+                        (Request
+                            (JsonNumber 1)
+                            "ping"
+                            (Just (JsonObject [("value", JsonNumber 3)]))
+                        )
+                    )
+
+        it "parses a notification" $ do
+            let payload = BSC.pack "{\"jsonrpc\":\"2.0\",\"method\":\"initialized\"}"
+            parseMessage payload
+                `shouldBe` Right (NotificationMessage (Notification "initialized" Nothing))
+
+        it "returns a parse error for invalid JSON" $
+            parseMessage (BSC.pack "not json")
+                `shouldBe` Left (parseErrorResponse Nothing)
+
+    describe "messageToValue" $
+        it "serialises error responses without a result field" $ do
+            let value =
+                    messageToValue
+                        (ResponseMessage (Response (JsonNumber 1) Nothing (Just (methodNotFoundResponse "hover"))))
+            value
+                `shouldBe` JsonObject
+                    [ ("jsonrpc", JsonString "2.0")
+                    , ("id", JsonNumber 1)
+                    , ("error", JsonObject [("code", JsonNumber (fromIntegral methodNotFoundCode)), ("message", JsonString "Method not found"), ("data", JsonString "hover")])
+                    ]
+
+    describe "framing" $ do
+        it "writes a Content-Length frame" $ do
+            let framed = renderMessageFrame (NotificationMessage (Notification "initialized" Nothing))
+            BSC.isPrefixOf (BSC.pack "Content-Length: ") framed `shouldBe` True
+
+        it "round-trips multiple framed messages" $ do
+            let first = NotificationMessage (Notification "one" Nothing)
+                second = RequestMessage (Request (JsonNumber 2) "two" Nothing)
+                payload = renderMessageFrame first <> renderMessageFrame second
+            parseFramedMessages payload `shouldBe` Right [first, second]
+
+    describe "dispatchMessage" $ do
+        it "dispatches registered request handlers" $ do
+            let server =
+                    onRequest "ping" (\_ _ -> pure (Right (JsonObject [("ok", JsonBool True)]))) emptyServer
+            dispatchMessage server (RequestMessage (Request (JsonNumber 1) "ping" Nothing))
+                `shouldReturn` Just (ResponseMessage (Response (JsonNumber 1) (Just (JsonObject [("ok", JsonBool True)])) Nothing))
+
+        it "returns method-not-found for unknown requests" $ do
+            let server = emptyServer
+            dispatchMessage server (RequestMessage (Request (JsonNumber 1) "missing" Nothing))
+                `shouldReturn` Just (ResponseMessage (Response (JsonNumber 1) Nothing (Just (methodNotFoundResponse "missing"))))
+
+        it "runs notification handlers without returning a response" $ do
+            seen <- newIORef ([] :: [JsonValue])
+            let server =
+                    onNotification
+                        "opened"
+                        (\params -> writeIORef seen [maybe JsonNull id params])
+                        emptyServer
+            dispatchMessage server (NotificationMessage (Notification "opened" (Just (JsonString "file.txt"))))
+                `shouldReturn` Nothing
+            readIORef seen `shouldReturn` [JsonString "file.txt"]
+
+    describe "serveByteString" $
+        it "produces framed responses for requests and parse errors" $ do
+            let validRequest = renderMessageFrame (RequestMessage (Request (JsonNumber 9) "ping" Nothing))
+                invalidRequest = framePayload (BSC.pack "{bad json")
+                server =
+                    onRequest "ping" (\_ _ -> pure (Right (JsonString "pong"))) emptyServer
+            result <- serveByteString server (validRequest <> invalidRequest)
+            case result of
+                Left err -> expectationFailure err
+                Right output ->
+                    parseFramedMessages output
+                        `shouldBe` Right
+                            [ ResponseMessage (Response (JsonNumber 9) (Just (JsonString "pong")) Nothing)
+                            , ResponseMessage (Response JsonNull Nothing (Just (parseErrorResponse Nothing)))
+                            ]

--- a/code/packages/haskell/json-rpc/test/Spec.hs
+++ b/code/packages/haskell/json-rpc/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import JsonRpcSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/specs/haskell-catch-up-survey.md
+++ b/code/specs/haskell-catch-up-survey.md
@@ -2,9 +2,9 @@
 
 ## Snapshot
 
-- Haskell package count: `14`
+- Haskell package count: `17`
 - Rust package count: `283`
-- Shared package names today: `arithmetic`, `block-ram`, `clock`, `directed-graph`, `fpga`, `grammar-tools`, `graph`, `lexer`, `logic-gates`, `parser`, `state-machine`
+- Shared package names today: `arithmetic`, `block-ram`, `clock`, `compiler-source-map`, `content-addressable-storage`, `directed-graph`, `fpga`, `grammar-tools`, `graph`, `json-rpc`, `lexer`, `logic-gates`, `parser`, `state-machine`
 - Haskell-only package names today: `discrete-waveform`, `electronics`, `power-supply`
 
 The largest gap is not in one vertical. Rust already has broad coverage across:
@@ -32,14 +32,11 @@ These unblock more Haskell package growth immediately:
 
 - `file-system`
 - `cli-builder`
-- `content_addressable_storage`
-- `json-rpc`
 
 ### Tier 2
 
 These make Haskell more competitive for language tooling and compiler work:
 
-- `compiler-source-map`
 - richer grammar-driven lexer and parser layers
 - source formatting and diagnostics helpers
 
@@ -59,8 +56,8 @@ These extend Haskell beyond the current hardware-focused cluster:
 ## Proposed Strategy
 
 1. Stabilize the Haskell `build-tool` and `scaffold-generator` so new packages are cheap to add.
-2. Port Tier 1 packages first to support package creation, dependency modeling, file IO, and simple CLIs.
-3. Build out Tier 2 now that `state-machine`, `lexer`, `parser`, and `grammar-tools` exist, so generated Haskell packages can share the same parsing/tooling substrate Rust already has.
+2. Port the remaining Tier 1 packages next so Haskell can cover file IO and richer CLI ergonomics inside the repo tooling lane.
+3. Build out Tier 2 on top of `state-machine`, `lexer`, `parser`, `grammar-tools`, `compiler-source-map`, `json-rpc`, and `content-addressable-storage`, so generated Haskell packages can share the same parsing, transport, and compiler substrate Rust already has.
 4. Use the scaffold generator to create the missing packages with consistent `cabal`, `BUILD`, docs, and tests before filling in implementation details.
 
 ## Near-Term Goal


### PR DESCRIPTION
## Summary
- add Haskell `compiler-source-map` with forward and reverse source-map chain composition
- add Haskell `json-rpc` with framed transport, message parsing/serialization, and handler dispatch
- add Haskell `content-addressable-storage` with in-memory and disk backends, SHA-1 hashing, prefix lookup, and corruption detection
- update the Haskell catch-up survey and package READMEs to reflect the new baseline

## Validation
- `cabal test` in `code/packages/haskell/compiler-source-map`
- `cabal test` in `code/packages/haskell/json-rpc`
- `cabal test` in `code/packages/haskell/content-addressable-storage`
- `cabal test all` in `code/packages/haskell`

## Notes
- `json-rpc` uses a small internal JSON value/parser layer so it can build cleanly in this local toolchain without depending on `aeson`.
- `content-addressable-storage` includes a self-contained SHA-1 implementation for the same reason.