### PR TITLE
Add Dart support to build tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
       needs_elixir: ${{ steps.toolchains.outputs.needs_elixir }}
       needs_lua: ${{ steps.toolchains.outputs.needs_lua }}
       needs_perl: ${{ steps.toolchains.outputs.needs_perl }}
+      needs_dart: ${{ steps.toolchains.outputs.needs_dart }}
       needs_haskell: ${{ steps.toolchains.outputs.needs_haskell }}
       needs_dotnet: ${{ steps.toolchains.outputs.needs_dotnet }}
       needs_java: ${{ steps.toolchains.outputs.needs_java }}
@@ -141,6 +142,7 @@ jobs:
               'needs_elixir=true' \
               'needs_lua=true' \
               'needs_perl=true' \
+              'needs_dart=true' \
               'needs_haskell=true' \
               'needs_dotnet=true' >> "$GITHUB_OUTPUT"
             printf '%s\n' \
@@ -156,6 +158,7 @@ jobs:
               'needs_elixir=${{ steps.detect.outputs.needs_elixir }}' \
               'needs_lua=${{ steps.detect.outputs.needs_lua }}' \
               'needs_perl=${{ steps.detect.outputs.needs_perl }}' \
+              'needs_dart=${{ steps.detect.outputs.needs_dart }}' \
               'needs_haskell=${{ steps.detect.outputs.needs_haskell }}' \
               'needs_dotnet=${{ steps.detect.outputs.needs_dotnet }}' >> "$GITHUB_OUTPUT"
             printf '%s\n' \
@@ -297,6 +300,10 @@ jobs:
           elixir-version: '1.16'
           otp-version: '26.0'
 
+      - name: Set up Dart
+        if: needs.detect.outputs.needs_dart == 'true'
+        uses: dart-lang/setup-dart@v1
+
       # ── Java / Kotlin ──────────────────────────────────────────
       #
       # Both Java and Kotlin packages use Gradle and JDK 21.
@@ -385,6 +392,9 @@ jobs:
           if [ "${{ needs.detect.outputs.needs_elixir }}" = "true" ]; then
             echo "Elixir: $(elixir --version)"
             echo "Mix: $(mix --version)"
+          fi
+          if [ "${{ needs.detect.outputs.needs_dart }}" = "true" ]; then
+            echo "Dart: $(dart --version 2>&1)"
           fi
           if [ "${{ needs.detect.outputs.needs_lua }}" = "true" ]; then
             echo "Lua: $(lua -v)"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This repo is part computing-stack curriculum, part polyglot package lab, part to
 As of this refresh, the repo contains:
 
 - 2014 package directories across 11 package language roots
-- 131 program directories across 13 program language roots
+- 132 program directories across 14 program language roots
 - 303 Markdown specs in `code/specs/`
 - 12 learning files in `code/learning/`
 - 41 shared grammar source files in `code/grammars/`
@@ -46,6 +46,7 @@ As of this refresh, the repo contains:
 
 | Language | Program dirs |
 | --- | ---: |
+| dart | 1 |
 | dotnet | 2 |
 | elixir | 13 |
 | go | 14 |
@@ -153,6 +154,7 @@ tests prove the behavior
 
 The root `mise.toml` currently pins:
 
+- Dart `latest`
 - Go `latest`
 - Python `3.12`
 - Ruby `3.4`

--- a/code/programs/dart/hello-world/BUILD
+++ b/code/programs/dart/hello-world/BUILD
@@ -1,0 +1,1 @@
+dart run bin/hello_world.dart

--- a/code/programs/dart/hello-world/CHANGELOG.md
+++ b/code/programs/dart/hello-world/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [0.1.0] - 2026-04-15
+
+### Added
+
+- Initial Dart hello-world program.

--- a/code/programs/dart/hello-world/README.md
+++ b/code/programs/dart/hello-world/README.md
@@ -1,0 +1,19 @@
+# Hello World
+
+The first Dart program in the repo.
+
+## What it does
+
+Prints `Hello, World!` to the console.
+
+## Usage
+
+```bash
+dart run bin/hello_world.dart
+```
+
+## How it fits in the stack
+
+This is the Dart entry point for the same "start with the simplest possible
+program" story used in the other language roots. It gives us a concrete target
+for build-tool support, CI wiring, and future Dart package work.

--- a/code/programs/dart/hello-world/bin/hello_world.dart
+++ b/code/programs/dart/hello-world/bin/hello_world.dart
@@ -1,0 +1,3 @@
+void main() {
+  print('Hello, World!');
+}

--- a/code/programs/dart/hello-world/pubspec.yaml
+++ b/code/programs/dart/hello-world/pubspec.yaml
@@ -1,0 +1,7 @@
+name: hello_world
+description: The first Dart program for the coding-adventures monorepo.
+version: 0.1.0
+publish_to: none
+
+environment:
+  sdk: ^3.0.0

--- a/code/programs/go/build-tool/README.md
+++ b/code/programs/go/build-tool/README.md
@@ -51,7 +51,7 @@ This produces a single static binary with no runtime dependencies.
 | `-force` | false | Rebuild everything regardless of cache |
 | `-dry-run` | false | Show what would build without executing |
 | `-jobs` | NumCPU | Maximum parallel build jobs |
-| `-language` | all | Filter to: python, ruby, go, rust, typescript, elixir, or all |
+| `-language` | all | Filter to: python, ruby, go, rust, typescript, elixir, lua, perl, swift, dart, java, kotlin, haskell, dotnet, or all |
 | `-diff-base` | origin/main | Git ref to diff against for change detection |
 | `-cache-file` | .build-cache.json | Path to the build cache file |
 
@@ -60,7 +60,7 @@ This produces a single static binary with no runtime dependencies.
 The tool is organized into seven internal packages, each responsible for one phase of the build pipeline:
 
 1. **discovery** -- Recursively walks for `BUILD` files to find packages
-2. **resolver** -- Parses `pyproject.toml`, `.gemspec`, `go.mod`, `Cargo.toml`, `package.json`, and `mix.exs`
+2. **resolver** -- Parses `pyproject.toml`, `.gemspec`, `go.mod`, `Cargo.toml`, `package.json`, `mix.exs`, and `pubspec.yaml`
 3. **hasher** -- SHA256 hashing for change detection
 4. **cache** -- JSON-based build cache (read/write with atomic saves)
 5. **executor** -- Parallel execution with goroutines + semaphore

--- a/code/programs/go/build-tool/detect_languages_test.go
+++ b/code/programs/go/build-tool/detect_languages_test.go
@@ -18,7 +18,7 @@ func TestAllToolchainsConstant(t *testing.T) {
 	expected := map[string]bool{
 		"python": true, "ruby": true, "go": true,
 		"typescript": true, "rust": true, "elixir": true, "lua": true, "perl": true,
-		"swift": true, "java": true, "kotlin": true, "haskell": true, "dotnet": true,
+		"swift": true, "dart": true, "java": true, "kotlin": true, "haskell": true, "dotnet": true,
 	}
 	if len(allToolchains) != len(expected) {
 		t.Errorf("allToolchains has %d entries, want %d", len(allToolchains), len(expected))
@@ -100,6 +100,7 @@ func TestCollectAffectedLanguages(t *testing.T) {
 		{Name: "typescript/starlark-vm", Language: "typescript"},
 		{Name: "rust/starlark-vm", Language: "rust"},
 		{Name: "elixir/starlark_vm", Language: "elixir"},
+		{Name: "dart/hello-world", Language: "dart"},
 		{Name: "wasm/graph", Language: "wasm"},
 		{Name: "csharp/graph", Language: "csharp"},
 		{Name: "fsharp/graph", Language: "fsharp"},
@@ -117,8 +118,8 @@ func TestCollectAffectedLanguages(t *testing.T) {
 		},
 		{
 			name:        "multiple languages affected",
-			affectedSet: map[string]bool{"python/logic-gates": true, "rust/starlark-vm": true},
-			wantLangs:   map[string]bool{"python": true, "rust": true, "go": true},
+			affectedSet: map[string]bool{"python/logic-gates": true, "rust/starlark-vm": true, "dart/hello-world": true},
+			wantLangs:   map[string]bool{"python": true, "rust": true, "dart": true, "go": true},
 		},
 		{
 			name:        "empty affected set",
@@ -220,6 +221,7 @@ func TestToolchainForPackageLanguage(t *testing.T) {
 		"csharp":  "dotnet",
 		"fsharp":  "dotnet",
 		"dotnet":  "dotnet",
+		"dart":    "dart",
 		"java":    "java",
 		"kotlin":  "kotlin",
 		"python":  "python",

--- a/code/programs/go/build-tool/internal/discovery/discovery.go
+++ b/code/programs/go/build-tool/internal/discovery/discovery.go
@@ -60,7 +60,7 @@ type Package struct {
 	Name          string   // Qualified name, e.g. "python/logic-gates"
 	Path          string   // Absolute path to the package directory
 	BuildCommands []string // Lines from the BUILD file (commands to execute)
-	Language      string   // Inferred language: "python", "ruby", "go", "rust", "typescript", "elixir", "lua", "perl", "swift", "wasm", "csharp", "fsharp", "dotnet", "starlark", or "unknown"
+	Language      string   // Inferred language: "python", "ruby", "go", "rust", "typescript", "elixir", "lua", "perl", "swift", "dart", "wasm", "csharp", "fsharp", "dotnet", "starlark", or "unknown"
 	BuildContent  string   // Raw BUILD file content (used for Starlark detection)
 	IsStarlark    bool     // Whether this BUILD file is Starlark (vs shell)
 	DeclaredSrcs  []string // Explicit source files from Starlark srcs field
@@ -88,6 +88,7 @@ var skipDirs = map[string]bool{
 	"target":        true,
 	".claude":       true,
 	"Pods":          true,
+	".dart_tool":    true,
 	".build":        true, // Swift Package Manager build artefacts and dependency checkouts
 	".gradle":       true, // Gradle build cache and wrapper metadata
 	"gradle-build":  true, // Gradle output dir (renamed from "build" to avoid BUILD file conflict)
@@ -117,14 +118,14 @@ func readLines(filepath string) []string {
 
 // inferLanguage inspects the directory path to determine the programming
 // language. We look for known language names ("python", "ruby", "go", "rust",
-// "typescript", "elixir", "lua", "perl", "swift", "wasm", "haskell",
+// "typescript", "elixir", "lua", "perl", "swift", "dart", "wasm", "haskell",
 // "starlark", "csharp", "fsharp", "dotnet") as path components.
 // For example, "/repo/code/packages/python/logic-gates" yields "python" and
 // "/repo/code/programs/dotnet/hello-world-csharp" yields "dotnet".
 func inferLanguage(path string) string {
 	// Split the path into its components and search for a known language.
 	parts := strings.Split(filepath.ToSlash(path), "/")
-	for _, lang := range []string{"python", "ruby", "go", "rust", "typescript", "elixir", "lua", "perl", "swift", "wasm", "haskell", "starlark", "java", "kotlin", "csharp", "fsharp", "dotnet"} {
+	for _, lang := range []string{"python", "ruby", "go", "rust", "typescript", "elixir", "lua", "perl", "swift", "dart", "wasm", "haskell", "starlark", "java", "kotlin", "csharp", "fsharp", "dotnet"} {
 		for _, part := range parts {
 			if part == lang {
 				return lang

--- a/code/programs/go/build-tool/internal/discovery/discovery_test.go
+++ b/code/programs/go/build-tool/internal/discovery/discovery_test.go
@@ -91,6 +91,13 @@ func TestInferLanguageTypescript(t *testing.T) {
 	}
 }
 
+func TestInferLanguageDart(t *testing.T) {
+	lang := inferLanguage("/repo/code/programs/dart/hello-world")
+	if lang != "dart" {
+		t.Fatalf("expected dart, got %s", lang)
+	}
+}
+
 func TestInferLanguageHaskell(t *testing.T) {
 	lang := inferLanguage("/repo/code/programs/haskell/build-tool")
 	if lang != "haskell" {
@@ -295,9 +302,9 @@ func TestGetBuildFileMacOverridesMacAndLinux(t *testing.T) {
 func TestDiscoverSimplePackage(t *testing.T) {
 	// A minimal fixture: nested directories with a BUILD file at the leaf.
 	root := makeFixture(t, map[string]string{
-		"packages/python/pkg-a/BUILD":           "echo build\n",
-		"packages/python/pkg-a/pyproject.toml":  "[project]\nname = \"coding-adventures-pkg-a\"\n",
-		"packages/python/pkg-a/src/main.py":     "print('hello')\n",
+		"packages/python/pkg-a/BUILD":          "echo build\n",
+		"packages/python/pkg-a/pyproject.toml": "[project]\nname = \"coding-adventures-pkg-a\"\n",
+		"packages/python/pkg-a/src/main.py":    "print('hello')\n",
 	})
 
 	packages := DiscoverPackages(root)
@@ -386,19 +393,20 @@ func TestDiscoverMultiLanguage(t *testing.T) {
 		"packages/ruby/lib-rb/BUILD":   "echo rb",
 		"packages/go/lib-go/BUILD":     "echo go",
 		"packages/rust/lib-rs/BUILD":   "echo rs",
+		"packages/dart/lib-dart/BUILD": "echo dart",
 		"programs/python/app/BUILD":    "echo app",
 	})
 
 	packages := DiscoverPackages(root)
-	if len(packages) != 5 {
-		t.Fatalf("expected 5 packages, got %d", len(packages))
+	if len(packages) != 6 {
+		t.Fatalf("expected 6 packages, got %d", len(packages))
 	}
 
 	langs := make(map[string]int)
 	for _, pkg := range packages {
 		langs[pkg.Language]++
 	}
-	if langs["python"] != 2 || langs["ruby"] != 1 || langs["go"] != 1 || langs["rust"] != 1 {
+	if langs["python"] != 2 || langs["ruby"] != 1 || langs["go"] != 1 || langs["rust"] != 1 || langs["dart"] != 1 {
 		t.Errorf("unexpected language distribution: %v", langs)
 	}
 }
@@ -423,12 +431,12 @@ func TestDiscoverSkipsSkipListDirs(t *testing.T) {
 	// Directories in the skip list should be completely ignored, even if
 	// they contain BUILD files.
 	root := makeFixture(t, map[string]string{
-		"packages/python/pkg-a/BUILD":           "echo a",
-		"packages/python/pkg-a/.venv/BUILD":     "echo venv",
+		"packages/python/pkg-a/BUILD":              "echo a",
+		"packages/python/pkg-a/.venv/BUILD":        "echo venv",
 		"packages/python/pkg-a/node_modules/BUILD": "echo node",
-		".git/hooks/BUILD":                      "echo git",
-		"packages/python/pkg-b/BUILD":           "echo b",
-		"packages/python/pkg-b/__pycache__/BUILD": "echo pycache",
+		".git/hooks/BUILD":                         "echo git",
+		"packages/python/pkg-b/BUILD":              "echo b",
+		"packages/python/pkg-b/__pycache__/BUILD":  "echo pycache",
 	})
 
 	packages := DiscoverPackages(root)
@@ -443,8 +451,8 @@ func TestDiscoverSkipsSkipListDirs(t *testing.T) {
 func TestDiscoverSkipsTargetDir(t *testing.T) {
 	// The "target" directory (Rust build output) should be skipped.
 	root := makeFixture(t, map[string]string{
-		"packages/rust/lib-rs/BUILD":                   "echo rs",
-		"packages/rust/lib-rs/target/debug/BUILD":      "echo target",
+		"packages/rust/lib-rs/BUILD":              "echo rs",
+		"packages/rust/lib-rs/target/debug/BUILD": "echo target",
 	})
 
 	packages := DiscoverPackages(root)
@@ -461,7 +469,7 @@ func TestDiscoverSkipsTargetDir(t *testing.T) {
 func TestDiscoverSkipsRootLevelSkipDirs(t *testing.T) {
 	// Skip-list directories at the root level should be ignored.
 	root := makeFixture(t, map[string]string{
-		"packages/python/pkg-a/BUILD": "echo a",
+		"packages/python/pkg-a/BUILD":  "echo a",
 		".claude/worktrees/test/BUILD": "echo claude",
 		"vendor/some-dep/BUILD":        "echo vendor",
 	})

--- a/code/programs/go/build-tool/internal/gitdiff/ci_workflow.go
+++ b/code/programs/go/build-tool/internal/gitdiff/ci_workflow.go
@@ -51,6 +51,9 @@ var ciWorkflowToolchainMarkers = map[string][]string{
 	"perl": {
 		"needs_perl", "cpanm", "perl --version", "install cpanm",
 	},
+	"dart": {
+		"needs_dart", "setup-dart", "dart --version", "set up dart",
+	},
 	"haskell": {
 		"needs_haskell", "haskell-actions/setup", "ghc-version", "cabal-version",
 		"ghc --version", "cabal --version", "set up haskell",

--- a/code/programs/go/build-tool/internal/gitdiff/ci_workflow_test.go
+++ b/code/programs/go/build-tool/internal/gitdiff/ci_workflow_test.go
@@ -23,6 +23,28 @@ func TestAnalyzeCIWorkflowPatchAllowsToolchainScopedDotnetChanges(t *testing.T) 
 	}
 }
 
+func TestAnalyzeCIWorkflowPatchAllowsToolchainScopedDartChanges(t *testing.T) {
+	patch := `
+@@ -300,0 +301,6 @@
++      - name: Set up Dart
++        if: needs.detect.outputs.needs_dart == 'true'
++        uses: dart-lang/setup-dart@v1
+@@ -393,0 +397,3 @@
++          if [ "${{ needs.detect.outputs.needs_dart }}" = "true" ]; then
++            echo "Dart: $(dart --version 2>&1)"
+`
+
+	change := AnalyzeCIWorkflowPatch(patch)
+	if change.RequiresFullRebuild {
+		t.Fatalf("expected toolchain-scoped dart change to stay incremental")
+	}
+
+	got := SortedToolchains(change.Toolchains)
+	if len(got) != 1 || got[0] != "dart" {
+		t.Fatalf("expected dart toolchain only, got %v", got)
+	}
+}
+
 func TestAnalyzeCIWorkflowPatchAllowsSharedJVMToolchainChanges(t *testing.T) {
 	patch := `
 @@ -314,0 +315,17 @@

--- a/code/programs/go/build-tool/internal/hasher/hasher.go
+++ b/code/programs/go/build-tool/internal/hasher/hasher.go
@@ -56,6 +56,7 @@ var sourceExtensions = map[string]map[string]bool{
 	"typescript": {".ts": true, ".tsx": true, ".json": true},
 	"rust":       {".rs": true, ".toml": true},
 	"elixir":     {".ex": true, ".exs": true},
+	"dart":       {".dart": true, ".yaml": true},
 	"starlark":   {".star": true},
 	"perl":       {".pl": true, ".pm": true, ".t": true, ".xs": true},
 	"haskell":    {".hs": true, ".cabal": true},
@@ -74,6 +75,7 @@ var specialFilenames = map[string]map[string]bool{
 	"typescript": {"package.json": true, "tsconfig.json": true, "vitest.config.ts": true},
 	"rust":       {"Cargo.toml": true, "Cargo.lock": true},
 	"elixir":     {"mix.exs": true, "mix.lock": true},
+	"dart":       {"pubspec.yaml": true, "pubspec.lock": true, "analysis_options.yaml": true},
 	"starlark":   {},
 	"perl":       {"Makefile.PL": true, "Build.PL": true, "cpanfile": true, "MANIFEST": true, "META.json": true, "META.yml": true},
 	"haskell":    {},
@@ -89,7 +91,7 @@ var specialFilenames = map[string]map[string]bool{
 // relative path for deterministic hashing.
 //
 // The collection rules:
-//   - BUILD, BUILD_mac, BUILD_linux are always included.
+//   - BUILD, BUILD_mac, BUILD_linux, and BUILD_windows are always included.
 //   - Files matching the language's extensions are included.
 //   - Special filenames (go.mod, Gemfile, etc.) are included.
 //   - Everything else is ignored.
@@ -114,7 +116,7 @@ func collectSourceFiles(pkg discovery.Package) []string {
 		name := info.Name()
 
 		// Always include BUILD files — they define how the package is built.
-		if name == "BUILD" || name == "BUILD_mac" || name == "BUILD_linux" {
+		if name == "BUILD" || name == "BUILD_mac" || name == "BUILD_linux" || name == "BUILD_windows" {
 			files = append(files, path)
 			return nil
 		}

--- a/code/programs/go/build-tool/internal/hasher/hasher_test.go
+++ b/code/programs/go/build-tool/internal/hasher/hasher_test.go
@@ -40,12 +40,12 @@ func emptyHash() string {
 
 func TestCollectSourceFilesPython(t *testing.T) {
 	root := makeFixture(t, map[string]string{
-		"pkg/BUILD":             "echo build",
-		"pkg/pyproject.toml":    "[project]\nname = \"test\"\n",
-		"pkg/src/main.py":       "print('hello')\n",
-		"pkg/src/helper.py":     "pass\n",
-		"pkg/README.md":         "docs",                  // should be excluded
-		"pkg/data/config.json":  `{"key": "value"}`,      // should be excluded
+		"pkg/BUILD":            "echo build",
+		"pkg/pyproject.toml":   "[project]\nname = \"test\"\n",
+		"pkg/src/main.py":      "print('hello')\n",
+		"pkg/src/helper.py":    "pass\n",
+		"pkg/README.md":        "docs",             // should be excluded
+		"pkg/data/config.json": `{"key": "value"}`, // should be excluded
 	})
 
 	pkg := discovery.Package{
@@ -67,12 +67,12 @@ func TestCollectSourceFilesPython(t *testing.T) {
 
 func TestCollectSourceFilesGo(t *testing.T) {
 	root := makeFixture(t, map[string]string{
-		"pkg/BUILD":       "go build .",
-		"pkg/go.mod":      "module test\n",
-		"pkg/go.sum":      "hash\n",
-		"pkg/main.go":     "package main\n",
+		"pkg/BUILD":        "go build .",
+		"pkg/go.mod":       "module test\n",
+		"pkg/go.sum":       "hash\n",
+		"pkg/main.go":      "package main\n",
 		"pkg/main_test.go": "package main\n",
-		"pkg/README.md":   "docs",
+		"pkg/README.md":    "docs",
 	})
 
 	pkg := discovery.Package{
@@ -94,12 +94,12 @@ func TestCollectSourceFilesGo(t *testing.T) {
 
 func TestCollectSourceFilesRuby(t *testing.T) {
 	root := makeFixture(t, map[string]string{
-		"pkg/BUILD":        "bundle exec rake",
-		"pkg/Gemfile":      "source 'https://rubygems.org'\n",
-		"pkg/Rakefile":     "task :default\n",
-		"pkg/lib.gemspec":  "spec\n",
-		"pkg/lib/main.rb":  "puts 'hi'\n",
-		"pkg/README.md":    "docs",
+		"pkg/BUILD":       "bundle exec rake",
+		"pkg/Gemfile":     "source 'https://rubygems.org'\n",
+		"pkg/Rakefile":    "task :default\n",
+		"pkg/lib.gemspec": "spec\n",
+		"pkg/lib/main.rb": "puts 'hi'\n",
+		"pkg/README.md":   "docs",
 	})
 
 	pkg := discovery.Package{
@@ -110,6 +110,32 @@ func TestCollectSourceFilesRuby(t *testing.T) {
 
 	files := collectSourceFiles(pkg)
 	// Expected: BUILD, Gemfile, Rakefile, lib.gemspec, main.rb
+	if len(files) != 5 {
+		names := make([]string, len(files))
+		for i, f := range files {
+			names[i] = filepath.Base(f)
+		}
+		t.Fatalf("expected 5 files, got %d: %v", len(files), names)
+	}
+}
+
+func TestCollectSourceFilesDart(t *testing.T) {
+	root := makeFixture(t, map[string]string{
+		"pkg/BUILD":                 "dart run bin/hello_world.dart",
+		"pkg/pubspec.yaml":          "name: hello_world\n",
+		"pkg/pubspec.lock":          "packages:\n",
+		"pkg/analysis_options.yaml": "include: package:lints/recommended.yaml\n",
+		"pkg/bin/hello_world.dart":  "void main() => print('hi');\n",
+		"pkg/README.md":             "docs",
+	})
+
+	pkg := discovery.Package{
+		Name:     "dart/pkg",
+		Path:     filepath.Join(root, "pkg"),
+		Language: "dart",
+	}
+
+	files := collectSourceFiles(pkg)
 	if len(files) != 5 {
 		names := make([]string, len(files))
 		for i, f := range files {

--- a/code/programs/go/build-tool/internal/resolver/resolver.go
+++ b/code/programs/go/build-tool/internal/resolver/resolver.go
@@ -1,5 +1,5 @@
 // Package resolver reads package metadata files (pyproject.toml, .gemspec,
-// go.mod, package.json, .rockspec) and extracts internal dependencies,
+// go.mod, package.json, .rockspec, pubspec.yaml) and extracts internal dependencies,
 // building a directed graph.
 //
 // # Why dependency resolution matters
@@ -24,6 +24,9 @@
 //
 //   - TypeScript: package.json uses "@coding-adventures/" scoped npm names.
 //     "@coding-adventures/logic-gates" maps to "typescript/logic-gates".
+//
+//   - Dart: pubspec.yaml uses snake_case package names.
+//     "coding_adventures_logic_gates" maps to "dart/logic-gates".
 //
 // External dependencies (those not matching the monorepo prefix) are
 // silently skipped — we only care about internal build ordering.
@@ -285,6 +288,70 @@ func parseTypescriptDeps(pkg discovery.Package, knownNames map[string]string) []
 			if pkgName, ok := knownNames[depName]; ok {
 				internalDeps = append(internalDeps, pkgName)
 			}
+		}
+	}
+
+	return internalDeps
+}
+
+// parseDartDeps extracts internal dependencies from a Dart pubspec.yaml file.
+//
+// Dart packages declare dependencies in `dependencies:` and
+// `dev_dependencies:` blocks. Local monorepo dependencies still use the
+// package name key even when the value is a path map:
+//
+//	dependencies:
+//	  coding_adventures_logic_gates:
+//	    path: ../logic-gates
+//
+// We only need the dependency keys, so a small line-oriented parser is
+// sufficient here.
+func parseDartDeps(pkg discovery.Package, knownNames map[string]string) []string {
+	pubspec := filepath.Join(pkg.Path, "pubspec.yaml")
+	data, err := os.ReadFile(pubspec)
+	if err != nil {
+		return nil
+	}
+
+	var internalDeps []string
+	currentBlock := ""
+
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		if !strings.HasPrefix(line, " ") && strings.HasSuffix(trimmed, ":") {
+			switch strings.TrimSuffix(trimmed, ":") {
+			case "dependencies", "dev_dependencies":
+				currentBlock = strings.TrimSuffix(trimmed, ":")
+			default:
+				currentBlock = ""
+			}
+			continue
+		}
+
+		if currentBlock == "" {
+			continue
+		}
+
+		if len(line)-len(strings.TrimLeft(line, " ")) < 2 {
+			continue
+		}
+
+		if strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "sdk:") || strings.HasPrefix(trimmed, "path:") {
+			continue
+		}
+
+		if !strings.Contains(trimmed, ":") {
+			continue
+		}
+
+		depName := strings.TrimSpace(strings.SplitN(trimmed, ":", 2)[0])
+		depName = strings.ToLower(depName)
+		if pkgName, ok := knownNames[depName]; ok && pkgName != pkg.Name {
+			internalDeps = append(internalDeps, pkgName)
 		}
 	}
 
@@ -928,6 +995,21 @@ func buildKnownNamesForLanguage(packages []discovery.Package, language string) m
 				}
 			}
 
+		case "dart":
+			baseName := strings.ReplaceAll(strings.ToLower(filepath.Base(pkg.Path)), "-", "_")
+			pubName := "coding_adventures_" + baseName
+			setKnown(pubName, pkg.Name, pkg.Path, pkg.Language)
+			setKnown(baseName, pkg.Name, pkg.Path, pkg.Language)
+
+			pubspec := filepath.Join(pkg.Path, "pubspec.yaml")
+			data, err := os.ReadFile(pubspec)
+			if err == nil {
+				re := regexp.MustCompile(`(?m)^name\s*:\s*([a-z0-9_]+)\s*$`)
+				if match := re.FindStringSubmatch(string(data)); len(match) == 2 {
+					setKnown(strings.ToLower(strings.TrimSpace(match[1])), pkg.Name, pkg.Path, pkg.Language)
+				}
+			}
+
 		case "lua":
 			// Lua rockspec names use hyphens: "logic_gates" → "coding-adventures-logic-gates"
 			// Note: Lua directory names use underscores, rockspec names use hyphens.
@@ -1027,6 +1109,8 @@ func ResolveDependencies(packages []discovery.Package) *directedgraph.Graph {
 			deps = parseGoDeps(pkg, knownNames)
 		case "typescript":
 			deps = parseTypescriptDeps(pkg, knownNames)
+		case "dart":
+			deps = parseDartDeps(pkg, knownNames)
 		case "rust":
 			deps = parseRustDeps(pkg, knownNames)
 		case "wasm":

--- a/code/programs/go/build-tool/internal/resolver/resolver_test.go
+++ b/code/programs/go/build-tool/internal/resolver/resolver_test.go
@@ -698,6 +698,64 @@ func TestParseTypescriptDepsExternalSkipped(t *testing.T) {
 	}
 }
 
+func TestBuildKnownNamesDart(t *testing.T) {
+	packages := []discovery.Package{
+		{Name: "dart/logic-gates", Path: "/repo/packages/dart/logic-gates", Language: "dart"},
+	}
+	known := BuildKnownNames(packages)
+	if known["coding_adventures_logic_gates"] != "dart/logic-gates" {
+		t.Fatalf("expected dart/logic-gates, got %s", known["coding_adventures_logic_gates"])
+	}
+	if known["logic_gates"] != "dart/logic-gates" {
+		t.Fatalf("expected unprefixed mapping for dart/logic-gates, got %s", known["logic_gates"])
+	}
+}
+
+func TestParseDartDeps(t *testing.T) {
+	root := makeFixture(t, map[string]string{
+		"pkg-a/pubspec.yaml": `name: pkg_a
+dependencies:
+  coding_adventures_pkg_b: ^0.1.0
+dev_dependencies:
+  pkg_c:
+    path: ../pkg-c
+`,
+		"pkg-b/pubspec.yaml": `name: coding_adventures_pkg_b
+`,
+		"pkg-c/pubspec.yaml": `name: pkg_c
+`,
+	})
+
+	packages := []discovery.Package{
+		{Name: "dart/pkg-a", Path: filepath.Join(root, "pkg-a"), Language: "dart"},
+		{Name: "dart/pkg-b", Path: filepath.Join(root, "pkg-b"), Language: "dart"},
+		{Name: "dart/pkg-c", Path: filepath.Join(root, "pkg-c"), Language: "dart"},
+	}
+
+	known := BuildKnownNames(packages)
+	deps := parseDartDeps(packages[0], known)
+
+	if len(deps) != 2 {
+		t.Fatalf("expected 2 deps, got %d: %v", len(deps), deps)
+	}
+}
+
+func TestParseDartDepsExternalSkipped(t *testing.T) {
+	root := makeFixture(t, map[string]string{
+		"pkg-a/pubspec.yaml": `name: pkg_a
+dependencies:
+  collection: ^1.18.0
+  args: ^2.6.0
+`,
+	})
+
+	pkg := discovery.Package{Name: "dart/pkg-a", Path: filepath.Join(root, "pkg-a"), Language: "dart"}
+	deps := parseDartDeps(pkg, map[string]string{})
+	if len(deps) != 0 {
+		t.Fatalf("expected external deps to be skipped, got %d", len(deps))
+	}
+}
+
 func TestBuildKnownNamesRust(t *testing.T) {
 	packages := []discovery.Package{
 		{Name: "rust/logic-gates", Path: "/repo/packages/rust/logic-gates", Language: "rust"},

--- a/code/programs/go/build-tool/internal/validator/validator.go
+++ b/code/programs/go/build-tool/internal/validator/validator.go
@@ -47,6 +47,7 @@ var ciManagedToolchainLanguages = map[string]bool{
 	"elixir":     true,
 	"lua":        true,
 	"perl":       true,
+	"dart":       true,
 	"haskell":    true,
 }
 
@@ -542,7 +543,7 @@ func validateRustWorkspaceMembers(packages []discovery.Package) []string {
 		memberRe := regexp.MustCompile(`"([^"]+)"`)
 		inMembers := false
 		inExclude := false
-		members := make(map[string]int)  // name → count (to detect duplicates)
+		members := make(map[string]int)   // name → count (to detect duplicates)
 		excluded := make(map[string]bool) // packages intentionally excluded from workspace
 		for _, line := range strings.Split(string(g.data), "\n") {
 			trimmed := strings.TrimSpace(line)

--- a/code/programs/go/build-tool/main.go
+++ b/code/programs/go/build-tool/main.go
@@ -11,7 +11,7 @@
 //  1. Find the repo root (walk up looking for .git)
 //  2. Discover packages (walk BUILD files under code/)
 //  3. Filter by language if requested
-//  4. Resolve dependencies (parse pyproject.toml, .gemspec, go.mod, Cargo.toml, package.json, mix.exs)
+//  4. Resolve dependencies (parse pyproject.toml, .gemspec, go.mod, Cargo.toml, package.json, mix.exs, pubspec.yaml)
 //  5. Hash all packages and their dependencies
 //  6. Load cache, determine what needs building
 //  7. If --dry-run, report what would build and exit
@@ -140,7 +140,7 @@ func run() int {
 	force := flag.Bool("force", false, "Rebuild everything regardless of cache")
 	dryRun := flag.Bool("dry-run", false, "Show what would build without executing")
 	jobs := flag.Int("jobs", runtime.NumCPU(), "Max parallel jobs")
-	language := flag.String("language", "all", "Filter to package language: python, ruby, go, rust, typescript, elixir, lua, perl, swift, wasm, csharp, fsharp, dotnet, all")
+	language := flag.String("language", "all", "Filter to package language: python, ruby, go, rust, typescript, elixir, lua, perl, swift, dart, wasm, csharp, fsharp, dotnet, all")
 	diffBase := flag.String("diff-base", "origin/main", "Git ref to diff against for change detection (default: origin/main)")
 	cacheFile := flag.String("cache-file", ".build-cache.json", "Path to cache file (fallback when git diff unavailable)")
 	detectLanguages := flag.Bool("detect-languages", false, "Output which language toolchains are needed based on git diff, then exit")
@@ -481,7 +481,7 @@ func run() int {
 
 // allToolchains is the canonical list of build toolchains we may need in CI.
 // The order is stable and matches the order used in CI setup.
-var allToolchains = []string{"python", "ruby", "go", "typescript", "rust", "elixir", "lua", "perl", "swift", "java", "kotlin", "haskell", "dotnet"}
+var allToolchains = []string{"python", "ruby", "go", "typescript", "rust", "elixir", "lua", "perl", "swift", "dart", "java", "kotlin", "haskell", "dotnet"}
 
 func toolchainForPackageLanguage(language string) string {
 	switch language {

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,6 @@
 [tools]
 cabal = "3.16.1.0"
+dart = "latest"
 ghc = "9.14.1"
 go = "latest"
 python = "3.12"


### PR DESCRIPTION
## Summary
- add Dart as a first-class language in the Go build tool for discovery, hashing, dependency resolution, filtering, and CI toolchain detection
- wire Dart into repo tooling and CI setup
- add a Dart hello-world program under `code/programs/dart/hello-world`

## Testing
- `go test ./...` in `code/programs/go/build-tool`
- `go run . -root C:\Users\adhit\Downloads\Codex\coding-adventures -language dart -force -dry-run` in `code/programs/go/build-tool`

## Notes
- The local machine does not currently have the Dart SDK installed, so the Dart hello-world program itself was not executed locally.
