### PR TITLE
[codex] add JVM Verilog and VHDL lexer/parser packages

### DIFF
--- a/code/packages/java/verilog-lexer/.gitignore
+++ b/code/packages/java/verilog-lexer/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/java/verilog-lexer/BUILD
+++ b/code/packages/java/verilog-lexer/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/verilog-lexer/BUILD_windows
+++ b/code/packages/java/verilog-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/verilog-lexer/CHANGELOG.md
+++ b/code/packages/java/verilog-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# verilog-lexer
+
+## 0.1.0
+
+- add runtime grammar-backed Verilog tokenization with edition selection

--- a/code/packages/java/verilog-lexer/README.md
+++ b/code/packages/java/verilog-lexer/README.md
@@ -1,0 +1,14 @@
+# verilog-lexer
+
+Grammar-backed Verilog lexer for Java with support for the 1995, 2001, and 2005 language editions.
+
+## Dependencies
+
+- grammar-tools
+- lexer
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/java/verilog-lexer/build.gradle.kts
+++ b/code/packages/java/verilog-lexer/build.gradle.kts
@@ -1,0 +1,37 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+sourceSets {
+    named("main") {
+        resources.srcDir("../../../grammars/verilog")
+        resources.include("verilog*.tokens")
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    api("com.codingadventures:grammar-tools")
+    api("com.codingadventures:lexer")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/verilog-lexer/required_capabilities.json
+++ b/code/packages/java/verilog-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "java/verilog-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/java/verilog-lexer/settings.gradle.kts
+++ b/code/packages/java/verilog-lexer/settings.gradle.kts
@@ -1,0 +1,4 @@
+rootProject.name = "verilog-lexer"
+
+includeBuild("../grammar-tools")
+includeBuild("../lexer")

--- a/code/packages/java/verilog-lexer/src/main/java/com/codingadventures/veriloglexer/VerilogLexer.java
+++ b/code/packages/java/verilog-lexer/src/main/java/com/codingadventures/veriloglexer/VerilogLexer.java
@@ -1,0 +1,80 @@
+package com.codingadventures.veriloglexer;
+
+import com.codingadventures.grammartools.TokenGrammar;
+import com.codingadventures.grammartools.TokenGrammarError;
+import com.codingadventures.grammartools.TokenGrammarParser;
+import com.codingadventures.lexer.GrammarLexer;
+import com.codingadventures.lexer.LexerError;
+import com.codingadventures.lexer.Token;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class VerilogLexer {
+    public static final String DEFAULT_VERSION = "2005";
+    public static final List<String> SUPPORTED_VERSIONS = List.of("1995", "2001", "2005");
+
+    private static final Map<String, TokenGrammar> TOKEN_GRAMMARS = new ConcurrentHashMap<>();
+
+    private VerilogLexer() {}
+
+    public static GrammarLexer createVerilogLexer() {
+        return createVerilogLexer(DEFAULT_VERSION);
+    }
+
+    public static GrammarLexer createVerilogLexer(String version) {
+        return new GrammarLexer(loadTokenGrammar(version));
+    }
+
+    public static List<Token> tokenizeVerilog(String source) {
+        return tokenizeVerilog(source, DEFAULT_VERSION);
+    }
+
+    public static List<Token> tokenizeVerilog(String source, String version) {
+        try {
+            return createVerilogLexer(version).tokenize(source);
+        } catch (LexerError error) {
+            throw new IllegalArgumentException("Verilog tokenization failed: " + error.getMessage(), error);
+        }
+    }
+
+    private static TokenGrammar loadTokenGrammar(String version) {
+        String validated = validateVersion(version);
+        return TOKEN_GRAMMARS.computeIfAbsent(validated, VerilogLexer::parseTokenGrammarResource);
+    }
+
+    private static String validateVersion(String version) {
+        if (version == null || version.isBlank()) {
+            return DEFAULT_VERSION;
+        }
+        if (!SUPPORTED_VERSIONS.contains(version)) {
+            throw new IllegalArgumentException(
+                    "Unknown Verilog version '" + version + "'. Valid values: " + String.join(", ", SUPPORTED_VERSIONS)
+            );
+        }
+        return version;
+    }
+
+    private static TokenGrammar parseTokenGrammarResource(String version) {
+        try {
+            return TokenGrammarParser.parse(readResource("verilog" + version + ".tokens"));
+        } catch (TokenGrammarError error) {
+            throw new IllegalStateException("Failed to parse bundled Verilog token grammar for version " + version, error);
+        }
+    }
+
+    private static String readResource(String resourceName) {
+        try (InputStream stream = VerilogLexer.class.getClassLoader().getResourceAsStream(resourceName)) {
+            if (stream == null) {
+                throw new IllegalStateException("Missing bundled resource: " + resourceName);
+            }
+            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException error) {
+            throw new IllegalStateException("Failed to read bundled resource: " + resourceName, error);
+        }
+    }
+}

--- a/code/packages/java/verilog-lexer/src/test/java/com/codingadventures/veriloglexer/VerilogLexerTest.java
+++ b/code/packages/java/verilog-lexer/src/test/java/com/codingadventures/veriloglexer/VerilogLexerTest.java
@@ -1,0 +1,41 @@
+package com.codingadventures.veriloglexer;
+
+import com.codingadventures.lexer.Token;
+import com.codingadventures.lexer.TokenType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class VerilogLexerTest {
+    @Test
+    void tokenizesModuleDeclaration() {
+        List<Token> tokens = VerilogLexer.tokenizeVerilog("module top; endmodule");
+
+        assertEquals(TokenType.KEYWORD, tokens.get(0).getType());
+        assertEquals("module", tokens.get(0).getValue());
+        assertEquals("NAME", tokens.get(1).effectiveTypeName());
+        assertEquals("top", tokens.get(1).getValue());
+    }
+
+    @Test
+    void defaultVersionMatchesExplicit2005() {
+        List<Token> defaultTokens = VerilogLexer.tokenizeVerilog("module top; endmodule");
+        List<Token> explicitTokens = VerilogLexer.tokenizeVerilog("module top; endmodule", "2005");
+
+        assertEquals(defaultTokens, explicitTokens);
+    }
+
+    @Test
+    void rejectsUnknownVersion() {
+        IllegalArgumentException error = assertThrows(
+                IllegalArgumentException.class,
+                () -> VerilogLexer.tokenizeVerilog("module top; endmodule", "2099")
+        );
+
+        assertTrue(error.getMessage().contains("Unknown Verilog version"));
+    }
+}

--- a/code/packages/java/verilog-parser/.gitignore
+++ b/code/packages/java/verilog-parser/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/java/verilog-parser/BUILD
+++ b/code/packages/java/verilog-parser/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/verilog-parser/BUILD_windows
+++ b/code/packages/java/verilog-parser/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/verilog-parser/CHANGELOG.md
+++ b/code/packages/java/verilog-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# verilog-parser
+
+## 0.1.0
+
+- add runtime grammar-backed Verilog parsing with edition selection

--- a/code/packages/java/verilog-parser/README.md
+++ b/code/packages/java/verilog-parser/README.md
@@ -1,0 +1,16 @@
+# verilog-parser
+
+Grammar-backed Verilog parser for Java with support for the 1995, 2001, and 2005 language editions.
+
+## Dependencies
+
+- grammar-tools
+- lexer
+- parser
+- verilog-lexer
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/java/verilog-parser/build.gradle.kts
+++ b/code/packages/java/verilog-parser/build.gradle.kts
@@ -1,0 +1,39 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+sourceSets {
+    named("main") {
+        resources.srcDir("../../../grammars/verilog")
+        resources.include("verilog*.grammar")
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    api("com.codingadventures:grammar-tools")
+    api("com.codingadventures:lexer")
+    api("com.codingadventures:parser")
+    api("com.codingadventures:verilog-lexer")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/verilog-parser/required_capabilities.json
+++ b/code/packages/java/verilog-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "java/verilog-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/java/verilog-parser/settings.gradle.kts
+++ b/code/packages/java/verilog-parser/settings.gradle.kts
@@ -1,0 +1,6 @@
+rootProject.name = "verilog-parser"
+
+includeBuild("../grammar-tools")
+includeBuild("../lexer")
+includeBuild("../parser")
+includeBuild("../verilog-lexer")

--- a/code/packages/java/verilog-parser/src/main/java/com/codingadventures/verilogparser/VerilogParser.java
+++ b/code/packages/java/verilog-parser/src/main/java/com/codingadventures/verilogparser/VerilogParser.java
@@ -1,0 +1,81 @@
+package com.codingadventures.verilogparser;
+
+import com.codingadventures.grammartools.ParserGrammar;
+import com.codingadventures.grammartools.ParserGrammarError;
+import com.codingadventures.grammartools.ParserGrammarParser;
+import com.codingadventures.parser.ASTNode;
+import com.codingadventures.parser.GrammarParseError;
+import com.codingadventures.parser.GrammarParser;
+import com.codingadventures.veriloglexer.VerilogLexer;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class VerilogParser {
+    public static final String DEFAULT_VERSION = VerilogLexer.DEFAULT_VERSION;
+    public static final List<String> SUPPORTED_VERSIONS = VerilogLexer.SUPPORTED_VERSIONS;
+
+    private static final Map<String, ParserGrammar> PARSER_GRAMMARS = new ConcurrentHashMap<>();
+
+    private VerilogParser() {}
+
+    public static GrammarParser createVerilogParser() {
+        return createVerilogParser(DEFAULT_VERSION);
+    }
+
+    public static GrammarParser createVerilogParser(String version) {
+        return new GrammarParser(loadParserGrammar(version));
+    }
+
+    public static ASTNode parseVerilog(String source) {
+        return parseVerilog(source, DEFAULT_VERSION);
+    }
+
+    public static ASTNode parseVerilog(String source, String version) {
+        try {
+            return createVerilogParser(version).parse(VerilogLexer.tokenizeVerilog(source, version));
+        } catch (GrammarParseError error) {
+            throw new IllegalArgumentException("Verilog parse failed: " + error.getMessage(), error);
+        }
+    }
+
+    private static ParserGrammar loadParserGrammar(String version) {
+        String validated = validateVersion(version);
+        return PARSER_GRAMMARS.computeIfAbsent(validated, VerilogParser::parseParserGrammarResource);
+    }
+
+    private static String validateVersion(String version) {
+        if (version == null || version.isBlank()) {
+            return DEFAULT_VERSION;
+        }
+        if (!SUPPORTED_VERSIONS.contains(version)) {
+            throw new IllegalArgumentException(
+                    "Unknown Verilog version '" + version + "'. Valid values: " + String.join(", ", SUPPORTED_VERSIONS)
+            );
+        }
+        return version;
+    }
+
+    private static ParserGrammar parseParserGrammarResource(String version) {
+        try {
+            return ParserGrammarParser.parse(readResource("verilog" + version + ".grammar"));
+        } catch (ParserGrammarError error) {
+            throw new IllegalStateException("Failed to parse bundled Verilog parser grammar for version " + version, error);
+        }
+    }
+
+    private static String readResource(String resourceName) {
+        try (InputStream stream = VerilogParser.class.getClassLoader().getResourceAsStream(resourceName)) {
+            if (stream == null) {
+                throw new IllegalStateException("Missing bundled resource: " + resourceName);
+            }
+            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException error) {
+            throw new IllegalStateException("Failed to read bundled resource: " + resourceName, error);
+        }
+    }
+}

--- a/code/packages/java/verilog-parser/src/test/java/com/codingadventures/verilogparser/VerilogParserTest.java
+++ b/code/packages/java/verilog-parser/src/test/java/com/codingadventures/verilogparser/VerilogParserTest.java
@@ -1,0 +1,36 @@
+package com.codingadventures.verilogparser;
+
+import com.codingadventures.parser.ASTNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class VerilogParserTest {
+    @Test
+    void parsesSimpleModule() {
+        ASTNode ast = VerilogParser.parseVerilog("module top; endmodule");
+
+        assertEquals("source_text", ast.getRuleName());
+        assertTrue(ast.descendantCount() > 0);
+    }
+
+    @Test
+    void defaultVersionMatchesExplicit2005() {
+        ASTNode defaultAst = VerilogParser.parseVerilog("module top; endmodule");
+        ASTNode explicitAst = VerilogParser.parseVerilog("module top; endmodule", "2005");
+
+        assertEquals(defaultAst.getRuleName(), explicitAst.getRuleName());
+    }
+
+    @Test
+    void rejectsUnknownVersion() {
+        IllegalArgumentException error = assertThrows(
+                IllegalArgumentException.class,
+                () -> VerilogParser.parseVerilog("module top; endmodule", "2099")
+        );
+
+        assertTrue(error.getMessage().contains("Unknown Verilog version"));
+    }
+}

--- a/code/packages/java/vhdl-lexer/.gitignore
+++ b/code/packages/java/vhdl-lexer/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/java/vhdl-lexer/BUILD
+++ b/code/packages/java/vhdl-lexer/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/vhdl-lexer/BUILD_windows
+++ b/code/packages/java/vhdl-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/vhdl-lexer/CHANGELOG.md
+++ b/code/packages/java/vhdl-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# vhdl-lexer
+
+## 0.1.0
+
+- add runtime grammar-backed VHDL tokenization with edition selection

--- a/code/packages/java/vhdl-lexer/README.md
+++ b/code/packages/java/vhdl-lexer/README.md
@@ -1,0 +1,14 @@
+# vhdl-lexer
+
+Grammar-backed VHDL lexer for Java with support for the 1987, 1993, 2002, 2008, and 2019 language editions.
+
+## Dependencies
+
+- grammar-tools
+- lexer
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/java/vhdl-lexer/build.gradle.kts
+++ b/code/packages/java/vhdl-lexer/build.gradle.kts
@@ -1,0 +1,37 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+sourceSets {
+    named("main") {
+        resources.srcDir("../../../grammars/vhdl")
+        resources.include("vhdl*.tokens")
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    api("com.codingadventures:grammar-tools")
+    api("com.codingadventures:lexer")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/vhdl-lexer/required_capabilities.json
+++ b/code/packages/java/vhdl-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "java/vhdl-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/java/vhdl-lexer/settings.gradle.kts
+++ b/code/packages/java/vhdl-lexer/settings.gradle.kts
@@ -1,0 +1,4 @@
+rootProject.name = "vhdl-lexer"
+
+includeBuild("../grammar-tools")
+includeBuild("../lexer")

--- a/code/packages/java/vhdl-lexer/src/main/java/com/codingadventures/vhdllexer/VhdlLexer.java
+++ b/code/packages/java/vhdl-lexer/src/main/java/com/codingadventures/vhdllexer/VhdlLexer.java
@@ -1,0 +1,118 @@
+package com.codingadventures.vhdllexer;
+
+import com.codingadventures.grammartools.TokenGrammar;
+import com.codingadventures.grammartools.TokenGrammarError;
+import com.codingadventures.grammartools.TokenGrammarParser;
+import com.codingadventures.lexer.GrammarLexer;
+import com.codingadventures.lexer.LexerError;
+import com.codingadventures.lexer.Token;
+import com.codingadventures.lexer.TokenType;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class VhdlLexer {
+    public static final String DEFAULT_VERSION = "2008";
+    public static final List<String> SUPPORTED_VERSIONS = List.of("1987", "1993", "2002", "2008", "2019");
+
+    private static final Map<String, TokenGrammar> TOKEN_GRAMMARS = new ConcurrentHashMap<>();
+
+    private VhdlLexer() {}
+
+    public static GrammarLexer createVhdlLexer() {
+        return createVhdlLexer(DEFAULT_VERSION);
+    }
+
+    public static GrammarLexer createVhdlLexer(String version) {
+        return new GrammarLexer(loadTokenGrammar(version));
+    }
+
+    public static List<Token> tokenizeVhdl(String source) {
+        return tokenizeVhdl(source, DEFAULT_VERSION);
+    }
+
+    public static List<Token> tokenizeVhdl(String source, String version) {
+        TokenGrammar grammar = loadTokenGrammar(version);
+        try {
+            List<Token> tokens = new GrammarLexer(grammar).tokenize(source);
+            return normalizeCase(tokens, new HashSet<>(grammar.getKeywords()));
+        } catch (LexerError error) {
+            throw new IllegalArgumentException("VHDL tokenization failed: " + error.getMessage(), error);
+        }
+    }
+
+    private static List<Token> normalizeCase(List<Token> tokens, Set<String> keywords) {
+        List<Token> normalized = new ArrayList<>(tokens.size());
+        for (Token token : tokens) {
+            boolean normalizeKeyword = token.getType() == TokenType.KEYWORD;
+            boolean normalizeName = token.getType() == TokenType.GRAMMAR && "NAME".equals(token.getTypeName());
+
+            if (!normalizeKeyword && !normalizeName) {
+                normalized.add(token);
+                continue;
+            }
+
+            String lowered = token.getValue().toLowerCase();
+            TokenType normalizedType = normalizeKeyword ? TokenType.KEYWORD : token.getType();
+            String normalizedTypeName = normalizeKeyword ? "KEYWORD" : token.getTypeName();
+
+            if (normalizeName && keywords.contains(lowered)) {
+                normalizedType = TokenType.KEYWORD;
+                normalizedTypeName = "KEYWORD";
+            }
+
+            normalized.add(new Token(
+                    normalizedType,
+                    lowered,
+                    token.getLine(),
+                    token.getColumn(),
+                    normalizedTypeName,
+                    token.getFlags()
+            ));
+        }
+        return normalized;
+    }
+
+    private static TokenGrammar loadTokenGrammar(String version) {
+        String validated = validateVersion(version);
+        return TOKEN_GRAMMARS.computeIfAbsent(validated, VhdlLexer::parseTokenGrammarResource);
+    }
+
+    private static String validateVersion(String version) {
+        if (version == null || version.isBlank()) {
+            return DEFAULT_VERSION;
+        }
+        if (!SUPPORTED_VERSIONS.contains(version)) {
+            throw new IllegalArgumentException(
+                    "Unknown VHDL version '" + version + "'. Valid values: " + String.join(", ", SUPPORTED_VERSIONS)
+            );
+        }
+        return version;
+    }
+
+    private static TokenGrammar parseTokenGrammarResource(String version) {
+        try {
+            return TokenGrammarParser.parse(readResource("vhdl" + version + ".tokens"));
+        } catch (TokenGrammarError error) {
+            throw new IllegalStateException("Failed to parse bundled VHDL token grammar for version " + version, error);
+        }
+    }
+
+    private static String readResource(String resourceName) {
+        try (InputStream stream = VhdlLexer.class.getClassLoader().getResourceAsStream(resourceName)) {
+            if (stream == null) {
+                throw new IllegalStateException("Missing bundled resource: " + resourceName);
+            }
+            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException error) {
+            throw new IllegalStateException("Failed to read bundled resource: " + resourceName, error);
+        }
+    }
+}

--- a/code/packages/java/vhdl-lexer/src/test/java/com/codingadventures/vhdllexer/VhdlLexerTest.java
+++ b/code/packages/java/vhdl-lexer/src/test/java/com/codingadventures/vhdllexer/VhdlLexerTest.java
@@ -1,0 +1,41 @@
+package com.codingadventures.vhdllexer;
+
+import com.codingadventures.lexer.Token;
+import com.codingadventures.lexer.TokenType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class VhdlLexerTest {
+    @Test
+    void normalizesCaseInsensitiveTokens() {
+        List<Token> tokens = VhdlLexer.tokenizeVhdl("ENTITY TOP IS END ENTITY TOP;");
+
+        assertEquals(TokenType.KEYWORD, tokens.get(0).getType());
+        assertEquals("entity", tokens.get(0).getValue());
+        assertEquals("NAME", tokens.get(1).effectiveTypeName());
+        assertEquals("top", tokens.get(1).getValue());
+    }
+
+    @Test
+    void defaultVersionMatchesExplicit2008() {
+        List<Token> defaultTokens = VhdlLexer.tokenizeVhdl("entity top is end entity top;");
+        List<Token> explicitTokens = VhdlLexer.tokenizeVhdl("entity top is end entity top;", "2008");
+
+        assertEquals(defaultTokens, explicitTokens);
+    }
+
+    @Test
+    void rejectsUnknownVersion() {
+        IllegalArgumentException error = assertThrows(
+                IllegalArgumentException.class,
+                () -> VhdlLexer.tokenizeVhdl("entity top is end entity top;", "2099")
+        );
+
+        assertTrue(error.getMessage().contains("Unknown VHDL version"));
+    }
+}

--- a/code/packages/java/vhdl-parser/.gitignore
+++ b/code/packages/java/vhdl-parser/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/java/vhdl-parser/BUILD
+++ b/code/packages/java/vhdl-parser/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/vhdl-parser/BUILD_windows
+++ b/code/packages/java/vhdl-parser/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/vhdl-parser/CHANGELOG.md
+++ b/code/packages/java/vhdl-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# vhdl-parser
+
+## 0.1.0
+
+- add runtime grammar-backed VHDL parsing with edition selection

--- a/code/packages/java/vhdl-parser/README.md
+++ b/code/packages/java/vhdl-parser/README.md
@@ -1,0 +1,16 @@
+# vhdl-parser
+
+Grammar-backed VHDL parser for Java with support for the 1987, 1993, 2002, 2008, and 2019 language editions.
+
+## Dependencies
+
+- grammar-tools
+- lexer
+- parser
+- vhdl-lexer
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/java/vhdl-parser/build.gradle.kts
+++ b/code/packages/java/vhdl-parser/build.gradle.kts
@@ -1,0 +1,39 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+sourceSets {
+    named("main") {
+        resources.srcDir("../../../grammars/vhdl")
+        resources.include("vhdl*.grammar")
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    api("com.codingadventures:grammar-tools")
+    api("com.codingadventures:lexer")
+    api("com.codingadventures:parser")
+    api("com.codingadventures:vhdl-lexer")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/vhdl-parser/required_capabilities.json
+++ b/code/packages/java/vhdl-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "java/vhdl-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/java/vhdl-parser/settings.gradle.kts
+++ b/code/packages/java/vhdl-parser/settings.gradle.kts
@@ -1,0 +1,6 @@
+rootProject.name = "vhdl-parser"
+
+includeBuild("../grammar-tools")
+includeBuild("../lexer")
+includeBuild("../parser")
+includeBuild("../vhdl-lexer")

--- a/code/packages/java/vhdl-parser/src/main/java/com/codingadventures/vhdlparser/VhdlParser.java
+++ b/code/packages/java/vhdl-parser/src/main/java/com/codingadventures/vhdlparser/VhdlParser.java
@@ -1,0 +1,81 @@
+package com.codingadventures.vhdlparser;
+
+import com.codingadventures.grammartools.ParserGrammar;
+import com.codingadventures.grammartools.ParserGrammarError;
+import com.codingadventures.grammartools.ParserGrammarParser;
+import com.codingadventures.parser.ASTNode;
+import com.codingadventures.parser.GrammarParseError;
+import com.codingadventures.parser.GrammarParser;
+import com.codingadventures.vhdllexer.VhdlLexer;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class VhdlParser {
+    public static final String DEFAULT_VERSION = VhdlLexer.DEFAULT_VERSION;
+    public static final List<String> SUPPORTED_VERSIONS = VhdlLexer.SUPPORTED_VERSIONS;
+
+    private static final Map<String, ParserGrammar> PARSER_GRAMMARS = new ConcurrentHashMap<>();
+
+    private VhdlParser() {}
+
+    public static GrammarParser createVhdlParser() {
+        return createVhdlParser(DEFAULT_VERSION);
+    }
+
+    public static GrammarParser createVhdlParser(String version) {
+        return new GrammarParser(loadParserGrammar(version));
+    }
+
+    public static ASTNode parseVhdl(String source) {
+        return parseVhdl(source, DEFAULT_VERSION);
+    }
+
+    public static ASTNode parseVhdl(String source, String version) {
+        try {
+            return createVhdlParser(version).parse(VhdlLexer.tokenizeVhdl(source, version));
+        } catch (GrammarParseError error) {
+            throw new IllegalArgumentException("VHDL parse failed: " + error.getMessage(), error);
+        }
+    }
+
+    private static ParserGrammar loadParserGrammar(String version) {
+        String validated = validateVersion(version);
+        return PARSER_GRAMMARS.computeIfAbsent(validated, VhdlParser::parseParserGrammarResource);
+    }
+
+    private static String validateVersion(String version) {
+        if (version == null || version.isBlank()) {
+            return DEFAULT_VERSION;
+        }
+        if (!SUPPORTED_VERSIONS.contains(version)) {
+            throw new IllegalArgumentException(
+                    "Unknown VHDL version '" + version + "'. Valid values: " + String.join(", ", SUPPORTED_VERSIONS)
+            );
+        }
+        return version;
+    }
+
+    private static ParserGrammar parseParserGrammarResource(String version) {
+        try {
+            return ParserGrammarParser.parse(readResource("vhdl" + version + ".grammar"));
+        } catch (ParserGrammarError error) {
+            throw new IllegalStateException("Failed to parse bundled VHDL parser grammar for version " + version, error);
+        }
+    }
+
+    private static String readResource(String resourceName) {
+        try (InputStream stream = VhdlParser.class.getClassLoader().getResourceAsStream(resourceName)) {
+            if (stream == null) {
+                throw new IllegalStateException("Missing bundled resource: " + resourceName);
+            }
+            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException error) {
+            throw new IllegalStateException("Failed to read bundled resource: " + resourceName, error);
+        }
+    }
+}

--- a/code/packages/java/vhdl-parser/src/test/java/com/codingadventures/vhdlparser/VhdlParserTest.java
+++ b/code/packages/java/vhdl-parser/src/test/java/com/codingadventures/vhdlparser/VhdlParserTest.java
@@ -1,0 +1,36 @@
+package com.codingadventures.vhdlparser;
+
+import com.codingadventures.parser.ASTNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class VhdlParserTest {
+    @Test
+    void parsesSimpleEntity() {
+        ASTNode ast = VhdlParser.parseVhdl("entity top is end entity top;");
+
+        assertEquals("design_file", ast.getRuleName());
+        assertTrue(ast.descendantCount() > 0);
+    }
+
+    @Test
+    void defaultVersionMatchesExplicit2008() {
+        ASTNode defaultAst = VhdlParser.parseVhdl("entity top is end entity top;");
+        ASTNode explicitAst = VhdlParser.parseVhdl("entity top is end entity top;", "2008");
+
+        assertEquals(defaultAst.getRuleName(), explicitAst.getRuleName());
+    }
+
+    @Test
+    void rejectsUnknownVersion() {
+        IllegalArgumentException error = assertThrows(
+                IllegalArgumentException.class,
+                () -> VhdlParser.parseVhdl("entity top is end entity top;", "2099")
+        );
+
+        assertTrue(error.getMessage().contains("Unknown VHDL version"));
+    }
+}

--- a/code/packages/kotlin/verilog-lexer/.gitignore
+++ b/code/packages/kotlin/verilog-lexer/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/kotlin/verilog-lexer/BUILD
+++ b/code/packages/kotlin/verilog-lexer/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/verilog-lexer/BUILD_windows
+++ b/code/packages/kotlin/verilog-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/verilog-lexer/CHANGELOG.md
+++ b/code/packages/kotlin/verilog-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# verilog-lexer
+
+## 0.1.0
+
+- add runtime grammar-backed Verilog tokenization with edition selection

--- a/code/packages/kotlin/verilog-lexer/README.md
+++ b/code/packages/kotlin/verilog-lexer/README.md
@@ -1,0 +1,14 @@
+# verilog-lexer
+
+Grammar-backed Verilog lexer for Kotlin with support for the 1995, 2001, and 2005 language editions.
+
+## Dependencies
+
+- grammar-tools
+- lexer
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/kotlin/verilog-lexer/build.gradle.kts
+++ b/code/packages/kotlin/verilog-lexer/build.gradle.kts
@@ -1,0 +1,44 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+sourceSets {
+    named("main") {
+        resources.srcDir("../../../grammars/verilog")
+        resources.include("verilog*.tokens")
+    }
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    api("com.codingadventures:grammar-tools")
+    api("com.codingadventures:lexer")
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/verilog-lexer/required_capabilities.json
+++ b/code/packages/kotlin/verilog-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "kotlin/verilog-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/kotlin/verilog-lexer/settings.gradle.kts
+++ b/code/packages/kotlin/verilog-lexer/settings.gradle.kts
@@ -1,0 +1,4 @@
+rootProject.name = "verilog-lexer"
+
+includeBuild("../grammar-tools")
+includeBuild("../lexer")

--- a/code/packages/kotlin/verilog-lexer/src/main/kotlin/com/codingadventures/veriloglexer/VerilogLexer.kt
+++ b/code/packages/kotlin/verilog-lexer/src/main/kotlin/com/codingadventures/veriloglexer/VerilogLexer.kt
@@ -1,0 +1,42 @@
+package com.codingadventures.veriloglexer
+
+import com.codingadventures.grammartools.TokenGrammar
+import com.codingadventures.grammartools.parseTokenGrammar
+import com.codingadventures.lexer.GrammarLexer
+import com.codingadventures.lexer.Token
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.ConcurrentHashMap
+
+object VerilogLexer {
+    const val DEFAULT_VERSION = "2005"
+    val SUPPORTED_VERSIONS: List<String> = listOf("1995", "2001", "2005")
+
+    private val tokenGrammars = ConcurrentHashMap<String, TokenGrammar>()
+
+    fun createVerilogLexer(version: String = DEFAULT_VERSION): GrammarLexer =
+        GrammarLexer(loadTokenGrammar(version))
+
+    fun tokenizeVerilog(source: String, version: String = DEFAULT_VERSION): List<Token> =
+        createVerilogLexer(version).tokenize(source)
+
+    private fun loadTokenGrammar(version: String): TokenGrammar {
+        val validated = validateVersion(version)
+        return tokenGrammars.computeIfAbsent(validated) { parseTokenGrammar(readResource("verilog$it.tokens")) }
+    }
+
+    private fun validateVersion(version: String?): String {
+        if (version.isNullOrBlank()) {
+            return DEFAULT_VERSION
+        }
+        require(version in SUPPORTED_VERSIONS) {
+            "Unknown Verilog version '$version'. Valid values: ${SUPPORTED_VERSIONS.joinToString(", ")}"
+        }
+        return version
+    }
+
+    private fun readResource(resourceName: String): String {
+        val stream = javaClass.classLoader.getResourceAsStream(resourceName)
+            ?: error("Missing bundled resource: $resourceName")
+        return stream.use { String(it.readAllBytes(), StandardCharsets.UTF_8) }
+    }
+}

--- a/code/packages/kotlin/verilog-lexer/src/test/kotlin/com/codingadventures/veriloglexer/VerilogLexerTest.kt
+++ b/code/packages/kotlin/verilog-lexer/src/test/kotlin/com/codingadventures/veriloglexer/VerilogLexerTest.kt
@@ -1,0 +1,36 @@
+package com.codingadventures.veriloglexer
+
+import com.codingadventures.lexer.TokenType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class VerilogLexerTest {
+    @Test
+    fun tokenizesModuleDeclaration() {
+        val tokens = VerilogLexer.tokenizeVerilog("module top; endmodule")
+
+        assertEquals(TokenType.KEYWORD, tokens[0].type)
+        assertEquals("module", tokens[0].value)
+        assertEquals("NAME", tokens[1].effectiveTypeName())
+        assertEquals("top", tokens[1].value)
+    }
+
+    @Test
+    fun defaultVersionMatchesExplicit2005() {
+        val defaultTokens = VerilogLexer.tokenizeVerilog("module top; endmodule")
+        val explicitTokens = VerilogLexer.tokenizeVerilog("module top; endmodule", "2005")
+
+        assertEquals(defaultTokens, explicitTokens)
+    }
+
+    @Test
+    fun rejectsUnknownVersion() {
+        val error = assertFailsWith<IllegalArgumentException> {
+            VerilogLexer.tokenizeVerilog("module top; endmodule", "2099")
+        }
+
+        assertTrue(error.message!!.contains("Unknown Verilog version"))
+    }
+}

--- a/code/packages/kotlin/verilog-parser/.gitignore
+++ b/code/packages/kotlin/verilog-parser/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/kotlin/verilog-parser/BUILD
+++ b/code/packages/kotlin/verilog-parser/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/verilog-parser/BUILD_windows
+++ b/code/packages/kotlin/verilog-parser/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/verilog-parser/CHANGELOG.md
+++ b/code/packages/kotlin/verilog-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# verilog-parser
+
+## 0.1.0
+
+- add runtime grammar-backed Verilog parsing with edition selection

--- a/code/packages/kotlin/verilog-parser/README.md
+++ b/code/packages/kotlin/verilog-parser/README.md
@@ -1,0 +1,16 @@
+# verilog-parser
+
+Grammar-backed Verilog parser for Kotlin with support for the 1995, 2001, and 2005 language editions.
+
+## Dependencies
+
+- grammar-tools
+- lexer
+- parser
+- verilog-lexer
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/kotlin/verilog-parser/build.gradle.kts
+++ b/code/packages/kotlin/verilog-parser/build.gradle.kts
@@ -1,0 +1,46 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+sourceSets {
+    named("main") {
+        resources.srcDir("../../../grammars/verilog")
+        resources.include("verilog*.grammar")
+    }
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    api("com.codingadventures:grammar-tools")
+    api("com.codingadventures:lexer")
+    api("com.codingadventures:parser")
+    api("com.codingadventures:verilog-lexer")
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/verilog-parser/required_capabilities.json
+++ b/code/packages/kotlin/verilog-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "kotlin/verilog-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/kotlin/verilog-parser/settings.gradle.kts
+++ b/code/packages/kotlin/verilog-parser/settings.gradle.kts
@@ -1,0 +1,6 @@
+rootProject.name = "verilog-parser"
+
+includeBuild("../grammar-tools")
+includeBuild("../lexer")
+includeBuild("../parser")
+includeBuild("../verilog-lexer")

--- a/code/packages/kotlin/verilog-parser/src/main/kotlin/com/codingadventures/verilogparser/VerilogParser.kt
+++ b/code/packages/kotlin/verilog-parser/src/main/kotlin/com/codingadventures/verilogparser/VerilogParser.kt
@@ -1,0 +1,43 @@
+package com.codingadventures.verilogparser
+
+import com.codingadventures.grammartools.ParserGrammar
+import com.codingadventures.grammartools.parseParserGrammar
+import com.codingadventures.parser.ASTNode
+import com.codingadventures.parser.GrammarParser
+import com.codingadventures.veriloglexer.VerilogLexer
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.ConcurrentHashMap
+
+object VerilogParser {
+    const val DEFAULT_VERSION = VerilogLexer.DEFAULT_VERSION
+    val SUPPORTED_VERSIONS: List<String> = VerilogLexer.SUPPORTED_VERSIONS
+
+    private val parserGrammars = ConcurrentHashMap<String, ParserGrammar>()
+
+    fun createVerilogParser(version: String = DEFAULT_VERSION): GrammarParser =
+        GrammarParser(loadParserGrammar(version))
+
+    fun parseVerilog(source: String, version: String = DEFAULT_VERSION): ASTNode =
+        createVerilogParser(version).parse(VerilogLexer.tokenizeVerilog(source, version))
+
+    private fun loadParserGrammar(version: String): ParserGrammar {
+        val validated = validateVersion(version)
+        return parserGrammars.computeIfAbsent(validated) { parseParserGrammar(readResource("verilog$it.grammar")) }
+    }
+
+    private fun validateVersion(version: String?): String {
+        if (version.isNullOrBlank()) {
+            return DEFAULT_VERSION
+        }
+        require(version in SUPPORTED_VERSIONS) {
+            "Unknown Verilog version '$version'. Valid values: ${SUPPORTED_VERSIONS.joinToString(", ")}"
+        }
+        return version
+    }
+
+    private fun readResource(resourceName: String): String {
+        val stream = javaClass.classLoader.getResourceAsStream(resourceName)
+            ?: error("Missing bundled resource: $resourceName")
+        return stream.use { String(it.readAllBytes(), StandardCharsets.UTF_8) }
+    }
+}

--- a/code/packages/kotlin/verilog-parser/src/test/kotlin/com/codingadventures/verilogparser/VerilogParserTest.kt
+++ b/code/packages/kotlin/verilog-parser/src/test/kotlin/com/codingadventures/verilogparser/VerilogParserTest.kt
@@ -1,0 +1,33 @@
+package com.codingadventures.verilogparser
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class VerilogParserTest {
+    @Test
+    fun parsesSimpleModule() {
+        val ast = VerilogParser.parseVerilog("module top; endmodule")
+
+        assertEquals("source_text", ast.ruleName)
+        assertTrue(ast.descendantCount() > 0)
+    }
+
+    @Test
+    fun defaultVersionMatchesExplicit2005() {
+        val defaultAst = VerilogParser.parseVerilog("module top; endmodule")
+        val explicitAst = VerilogParser.parseVerilog("module top; endmodule", "2005")
+
+        assertEquals(defaultAst.ruleName, explicitAst.ruleName)
+    }
+
+    @Test
+    fun rejectsUnknownVersion() {
+        val error = assertFailsWith<IllegalArgumentException> {
+            VerilogParser.parseVerilog("module top; endmodule", "2099")
+        }
+
+        assertTrue(error.message!!.contains("Unknown Verilog version"))
+    }
+}

--- a/code/packages/kotlin/vhdl-lexer/.gitignore
+++ b/code/packages/kotlin/vhdl-lexer/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/kotlin/vhdl-lexer/BUILD
+++ b/code/packages/kotlin/vhdl-lexer/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/vhdl-lexer/BUILD_windows
+++ b/code/packages/kotlin/vhdl-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/vhdl-lexer/CHANGELOG.md
+++ b/code/packages/kotlin/vhdl-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# vhdl-lexer
+
+## 0.1.0
+
+- add runtime grammar-backed VHDL tokenization with edition selection

--- a/code/packages/kotlin/vhdl-lexer/README.md
+++ b/code/packages/kotlin/vhdl-lexer/README.md
@@ -1,0 +1,14 @@
+# vhdl-lexer
+
+Grammar-backed VHDL lexer for Kotlin with support for the 1987, 1993, 2002, 2008, and 2019 language editions.
+
+## Dependencies
+
+- grammar-tools
+- lexer
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/kotlin/vhdl-lexer/build.gradle.kts
+++ b/code/packages/kotlin/vhdl-lexer/build.gradle.kts
@@ -1,0 +1,44 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+sourceSets {
+    named("main") {
+        resources.srcDir("../../../grammars/vhdl")
+        resources.include("vhdl*.tokens")
+    }
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    api("com.codingadventures:grammar-tools")
+    api("com.codingadventures:lexer")
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/vhdl-lexer/required_capabilities.json
+++ b/code/packages/kotlin/vhdl-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "kotlin/vhdl-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/kotlin/vhdl-lexer/settings.gradle.kts
+++ b/code/packages/kotlin/vhdl-lexer/settings.gradle.kts
@@ -1,0 +1,4 @@
+rootProject.name = "vhdl-lexer"
+
+includeBuild("../grammar-tools")
+includeBuild("../lexer")

--- a/code/packages/kotlin/vhdl-lexer/src/main/kotlin/com/codingadventures/vhdllexer/VhdlLexer.kt
+++ b/code/packages/kotlin/vhdl-lexer/src/main/kotlin/com/codingadventures/vhdllexer/VhdlLexer.kt
@@ -1,0 +1,63 @@
+package com.codingadventures.vhdllexer
+
+import com.codingadventures.grammartools.TokenGrammar
+import com.codingadventures.grammartools.parseTokenGrammar
+import com.codingadventures.lexer.GrammarLexer
+import com.codingadventures.lexer.Token
+import com.codingadventures.lexer.TokenType
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.ConcurrentHashMap
+
+object VhdlLexer {
+    const val DEFAULT_VERSION = "2008"
+    val SUPPORTED_VERSIONS: List<String> = listOf("1987", "1993", "2002", "2008", "2019")
+
+    private val tokenGrammars = ConcurrentHashMap<String, TokenGrammar>()
+
+    fun createVhdlLexer(version: String = DEFAULT_VERSION): GrammarLexer =
+        GrammarLexer(loadTokenGrammar(version))
+
+    fun tokenizeVhdl(source: String, version: String = DEFAULT_VERSION): List<Token> {
+        val grammar = loadTokenGrammar(version)
+        val keywordSet = grammar.keywords.toSet()
+        return GrammarLexer(grammar)
+            .tokenize(source)
+            .map { token -> normalizeToken(token, keywordSet) }
+    }
+
+    private fun normalizeToken(token: Token, keywords: Set<String>): Token {
+        val normalizeKeyword = token.type == TokenType.KEYWORD
+        val normalizeName = token.type == TokenType.GRAMMAR && token.typeName == "NAME"
+        if (!normalizeKeyword && !normalizeName) {
+            return token
+        }
+
+        val lowered = token.value.lowercase()
+        return when {
+            normalizeKeyword -> token.copy(value = lowered, typeName = "KEYWORD")
+            normalizeName && lowered in keywords -> token.copy(type = TokenType.KEYWORD, value = lowered, typeName = "KEYWORD")
+            else -> token.copy(value = lowered)
+        }
+    }
+
+    private fun loadTokenGrammar(version: String): TokenGrammar {
+        val validated = validateVersion(version)
+        return tokenGrammars.computeIfAbsent(validated) { parseTokenGrammar(readResource("vhdl$it.tokens")) }
+    }
+
+    private fun validateVersion(version: String?): String {
+        if (version.isNullOrBlank()) {
+            return DEFAULT_VERSION
+        }
+        require(version in SUPPORTED_VERSIONS) {
+            "Unknown VHDL version '$version'. Valid values: ${SUPPORTED_VERSIONS.joinToString(", ")}"
+        }
+        return version
+    }
+
+    private fun readResource(resourceName: String): String {
+        val stream = javaClass.classLoader.getResourceAsStream(resourceName)
+            ?: error("Missing bundled resource: $resourceName")
+        return stream.use { String(it.readAllBytes(), StandardCharsets.UTF_8) }
+    }
+}

--- a/code/packages/kotlin/vhdl-lexer/src/test/kotlin/com/codingadventures/vhdllexer/VhdlLexerTest.kt
+++ b/code/packages/kotlin/vhdl-lexer/src/test/kotlin/com/codingadventures/vhdllexer/VhdlLexerTest.kt
@@ -1,0 +1,36 @@
+package com.codingadventures.vhdllexer
+
+import com.codingadventures.lexer.TokenType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class VhdlLexerTest {
+    @Test
+    fun normalizesCaseInsensitiveTokens() {
+        val tokens = VhdlLexer.tokenizeVhdl("ENTITY TOP IS END ENTITY TOP;")
+
+        assertEquals(TokenType.KEYWORD, tokens[0].type)
+        assertEquals("entity", tokens[0].value)
+        assertEquals("NAME", tokens[1].effectiveTypeName())
+        assertEquals("top", tokens[1].value)
+    }
+
+    @Test
+    fun defaultVersionMatchesExplicit2008() {
+        val defaultTokens = VhdlLexer.tokenizeVhdl("entity top is end entity top;")
+        val explicitTokens = VhdlLexer.tokenizeVhdl("entity top is end entity top;", "2008")
+
+        assertEquals(defaultTokens, explicitTokens)
+    }
+
+    @Test
+    fun rejectsUnknownVersion() {
+        val error = assertFailsWith<IllegalArgumentException> {
+            VhdlLexer.tokenizeVhdl("entity top is end entity top;", "2099")
+        }
+
+        assertTrue(error.message!!.contains("Unknown VHDL version"))
+    }
+}

--- a/code/packages/kotlin/vhdl-parser/.gitignore
+++ b/code/packages/kotlin/vhdl-parser/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/kotlin/vhdl-parser/BUILD
+++ b/code/packages/kotlin/vhdl-parser/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/vhdl-parser/BUILD_windows
+++ b/code/packages/kotlin/vhdl-parser/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/vhdl-parser/CHANGELOG.md
+++ b/code/packages/kotlin/vhdl-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# vhdl-parser
+
+## 0.1.0
+
+- add runtime grammar-backed VHDL parsing with edition selection

--- a/code/packages/kotlin/vhdl-parser/README.md
+++ b/code/packages/kotlin/vhdl-parser/README.md
@@ -1,0 +1,16 @@
+# vhdl-parser
+
+Grammar-backed VHDL parser for Kotlin with support for the 1987, 1993, 2002, 2008, and 2019 language editions.
+
+## Dependencies
+
+- grammar-tools
+- lexer
+- parser
+- vhdl-lexer
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/kotlin/vhdl-parser/build.gradle.kts
+++ b/code/packages/kotlin/vhdl-parser/build.gradle.kts
@@ -1,0 +1,46 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+sourceSets {
+    named("main") {
+        resources.srcDir("../../../grammars/vhdl")
+        resources.include("vhdl*.grammar")
+    }
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    api("com.codingadventures:grammar-tools")
+    api("com.codingadventures:lexer")
+    api("com.codingadventures:parser")
+    api("com.codingadventures:vhdl-lexer")
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/vhdl-parser/required_capabilities.json
+++ b/code/packages/kotlin/vhdl-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "kotlin/vhdl-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/kotlin/vhdl-parser/settings.gradle.kts
+++ b/code/packages/kotlin/vhdl-parser/settings.gradle.kts
@@ -1,0 +1,6 @@
+rootProject.name = "vhdl-parser"
+
+includeBuild("../grammar-tools")
+includeBuild("../lexer")
+includeBuild("../parser")
+includeBuild("../vhdl-lexer")

--- a/code/packages/kotlin/vhdl-parser/src/main/kotlin/com/codingadventures/vhdlparser/VhdlParser.kt
+++ b/code/packages/kotlin/vhdl-parser/src/main/kotlin/com/codingadventures/vhdlparser/VhdlParser.kt
@@ -1,0 +1,43 @@
+package com.codingadventures.vhdlparser
+
+import com.codingadventures.grammartools.ParserGrammar
+import com.codingadventures.grammartools.parseParserGrammar
+import com.codingadventures.parser.ASTNode
+import com.codingadventures.parser.GrammarParser
+import com.codingadventures.vhdllexer.VhdlLexer
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.ConcurrentHashMap
+
+object VhdlParser {
+    const val DEFAULT_VERSION = VhdlLexer.DEFAULT_VERSION
+    val SUPPORTED_VERSIONS: List<String> = VhdlLexer.SUPPORTED_VERSIONS
+
+    private val parserGrammars = ConcurrentHashMap<String, ParserGrammar>()
+
+    fun createVhdlParser(version: String = DEFAULT_VERSION): GrammarParser =
+        GrammarParser(loadParserGrammar(version))
+
+    fun parseVhdl(source: String, version: String = DEFAULT_VERSION): ASTNode =
+        createVhdlParser(version).parse(VhdlLexer.tokenizeVhdl(source, version))
+
+    private fun loadParserGrammar(version: String): ParserGrammar {
+        val validated = validateVersion(version)
+        return parserGrammars.computeIfAbsent(validated) { parseParserGrammar(readResource("vhdl$it.grammar")) }
+    }
+
+    private fun validateVersion(version: String?): String {
+        if (version.isNullOrBlank()) {
+            return DEFAULT_VERSION
+        }
+        require(version in SUPPORTED_VERSIONS) {
+            "Unknown VHDL version '$version'. Valid values: ${SUPPORTED_VERSIONS.joinToString(", ")}"
+        }
+        return version
+    }
+
+    private fun readResource(resourceName: String): String {
+        val stream = javaClass.classLoader.getResourceAsStream(resourceName)
+            ?: error("Missing bundled resource: $resourceName")
+        return stream.use { String(it.readAllBytes(), StandardCharsets.UTF_8) }
+    }
+}

--- a/code/packages/kotlin/vhdl-parser/src/test/kotlin/com/codingadventures/vhdlparser/VhdlParserTest.kt
+++ b/code/packages/kotlin/vhdl-parser/src/test/kotlin/com/codingadventures/vhdlparser/VhdlParserTest.kt
@@ -1,0 +1,33 @@
+package com.codingadventures.vhdlparser
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class VhdlParserTest {
+    @Test
+    fun parsesSimpleEntity() {
+        val ast = VhdlParser.parseVhdl("entity top is end entity top;")
+
+        assertEquals("design_file", ast.ruleName)
+        assertTrue(ast.descendantCount() > 0)
+    }
+
+    @Test
+    fun defaultVersionMatchesExplicit2008() {
+        val defaultAst = VhdlParser.parseVhdl("entity top is end entity top;")
+        val explicitAst = VhdlParser.parseVhdl("entity top is end entity top;", "2008")
+
+        assertEquals(defaultAst.ruleName, explicitAst.ruleName)
+    }
+
+    @Test
+    fun rejectsUnknownVersion() {
+        val error = assertFailsWith<IllegalArgumentException> {
+            VhdlParser.parseVhdl("entity top is end entity top;", "2099")
+        }
+
+        assertTrue(error.message!!.contains("Unknown VHDL version"))
+    }
+}


### PR DESCRIPTION
## Summary
- add Java `verilog-lexer`, `verilog-parser`, `vhdl-lexer`, and `vhdl-parser` packages
- add matching Kotlin `verilog-lexer`, `verilog-parser`, `vhdl-lexer`, and `vhdl-parser` packages
- load the shared versioned HDL grammars at runtime and cover version/default behavior with package tests

## Testing
- `gradlew.bat -p code/packages/java/verilog-lexer clean test`
- `gradlew.bat -p code/packages/java/verilog-parser clean test`
- `gradlew.bat -p code/packages/java/vhdl-lexer test`
- `gradlew.bat -p code/packages/java/vhdl-parser test`
- `gradlew.bat -p code/packages/kotlin/verilog-lexer test`
- `gradlew.bat -p code/packages/kotlin/verilog-parser test`
- `gradlew.bat -p code/packages/kotlin/vhdl-lexer test`
- `gradlew.bat -p code/packages/kotlin/vhdl-parser test`