### PR TITLE
Add Haskell lexer and parser scaffolds

### DIFF
--- a/code/packages/haskell/algol-lexer/BUILD
+++ b/code/packages/haskell/algol-lexer/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/algol-lexer/BUILD_windows
+++ b/code/packages/haskell/algol-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/algol-lexer/CHANGELOG.md
+++ b/code/packages/haskell/algol-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/algol-lexer/README.md
+++ b/code/packages/haskell/algol-lexer/README.md
@@ -1,0 +1,11 @@
+# algol-lexer
+
+Haskell starter wrapper for algol-lexer built on the generic lexer package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer

--- a/code/packages/haskell/algol-lexer/algol-lexer.cabal
+++ b/code/packages/haskell/algol-lexer/algol-lexer.cabal
@@ -1,0 +1,28 @@
+cabal-version: 3.0
+name:          algol-lexer
+version:       0.1.0
+synopsis:      Haskell starter wrapper for algol-lexer built on the generic lexer package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  AlgolLexer
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    AlgolLexerSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , algol-lexer
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/algol-lexer/cabal.project
+++ b/code/packages/haskell/algol-lexer/cabal.project
@@ -1,0 +1,6 @@
+packages:
+  .
+  ../lexer
+  ../graph
+  ../directed-graph
+  ../state-machine

--- a/code/packages/haskell/algol-lexer/src/AlgolLexer.hs
+++ b/code/packages/haskell/algol-lexer/src/AlgolLexer.hs
@@ -1,0 +1,18 @@
+module AlgolLexer
+    ( description
+    , algolLexerKeywords
+    , tokenizeAlgol
+    ) where
+
+import Lexer (LexerConfig(..), LexerError, Token, defaultLexerConfig, tokenize)
+
+-- Thin wrapper around the shared lexer package so language-specific ports can
+-- grow their own keyword tables and token helpers incrementally.
+description :: String
+description = "Haskell starter wrapper for algol-lexer built on the generic lexer package"
+
+algolLexerKeywords :: [String]
+algolLexerKeywords = []
+
+tokenizeAlgol :: String -> Either LexerError [Token]
+tokenizeAlgol = tokenize defaultLexerConfig {lexerKeywords = algolLexerKeywords}

--- a/code/packages/haskell/algol-lexer/test/AlgolLexerSpec.hs
+++ b/code/packages/haskell/algol-lexer/test/AlgolLexerSpec.hs
@@ -1,0 +1,9 @@
+module AlgolLexerSpec (spec) where
+
+import Test.Hspec
+import AlgolLexer
+
+spec :: Spec
+spec = describe "AlgolLexer" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/algol-lexer/test/Spec.hs
+++ b/code/packages/haskell/algol-lexer/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import AlgolLexerSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/algol-parser/BUILD
+++ b/code/packages/haskell/algol-parser/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/algol-parser/BUILD_windows
+++ b/code/packages/haskell/algol-parser/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/algol-parser/CHANGELOG.md
+++ b/code/packages/haskell/algol-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/algol-parser/README.md
+++ b/code/packages/haskell/algol-parser/README.md
@@ -1,0 +1,11 @@
+# algol-parser
+
+Haskell starter wrapper for algol-parser built on the generic parser package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer, parser, algol-lexer

--- a/code/packages/haskell/algol-parser/algol-parser.cabal
+++ b/code/packages/haskell/algol-parser/algol-parser.cabal
@@ -1,0 +1,30 @@
+cabal-version: 3.0
+name:          algol-parser
+version:       0.1.0
+synopsis:      Haskell starter wrapper for algol-parser built on the generic parser package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  AlgolParser
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+                    , parser
+                    , algol-lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    AlgolParserSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , algol-parser
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/algol-parser/cabal.project
+++ b/code/packages/haskell/algol-parser/cabal.project
@@ -1,0 +1,8 @@
+packages:
+  .
+  ../parser
+  ../graph
+  ../directed-graph
+  ../state-machine
+  ../lexer
+  ../algol-lexer

--- a/code/packages/haskell/algol-parser/src/AlgolParser.hs
+++ b/code/packages/haskell/algol-parser/src/AlgolParser.hs
@@ -1,0 +1,32 @@
+module AlgolParser
+    ( description
+    , AlgolParserError(..)
+    , parseAlgolTokens
+    , tokenizeAndParseAlgol
+    ) where
+
+import Lexer (LexerError, Token)
+import Parser (ASTNode, ParseError, parseTokens)
+import qualified AlgolLexer
+
+-- Starter parser wrapper that composes the shared parser engine with the
+-- sibling lexer package for this language family.
+description :: String
+description = "Haskell starter wrapper for algol-parser built on the generic parser package"
+
+data AlgolParserError
+    = AlgolParserLexerError LexerError
+    | AlgolParserParseError ParseError
+    deriving (Eq, Show)
+
+parseAlgolTokens :: [Token] -> Either ParseError ASTNode
+parseAlgolTokens = parseTokens
+
+tokenizeAndParseAlgol :: String -> Either AlgolParserError ASTNode
+tokenizeAndParseAlgol source =
+    case AlgolLexer.tokenizeAlgol source of
+        Left err -> Left (AlgolParserLexerError err)
+        Right tokens ->
+            case parseAlgolTokens tokens of
+                Left err -> Left (AlgolParserParseError err)
+                Right ast -> Right ast

--- a/code/packages/haskell/algol-parser/test/AlgolParserSpec.hs
+++ b/code/packages/haskell/algol-parser/test/AlgolParserSpec.hs
@@ -1,0 +1,9 @@
+module AlgolParserSpec (spec) where
+
+import Test.Hspec
+import AlgolParser
+
+spec :: Spec
+spec = describe "AlgolParser" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/algol-parser/test/Spec.hs
+++ b/code/packages/haskell/algol-parser/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import AlgolParserSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/asciidoc-parser/BUILD
+++ b/code/packages/haskell/asciidoc-parser/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/asciidoc-parser/BUILD_windows
+++ b/code/packages/haskell/asciidoc-parser/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/asciidoc-parser/CHANGELOG.md
+++ b/code/packages/haskell/asciidoc-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/asciidoc-parser/README.md
+++ b/code/packages/haskell/asciidoc-parser/README.md
@@ -1,0 +1,11 @@
+# asciidoc-parser
+
+Haskell starter wrapper for asciidoc-parser built on the generic parser package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer, parser

--- a/code/packages/haskell/asciidoc-parser/asciidoc-parser.cabal
+++ b/code/packages/haskell/asciidoc-parser/asciidoc-parser.cabal
@@ -1,0 +1,29 @@
+cabal-version: 3.0
+name:          asciidoc-parser
+version:       0.1.0
+synopsis:      Haskell starter wrapper for asciidoc-parser built on the generic parser package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  AsciidocParser
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+                    , parser
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    AsciidocParserSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , asciidoc-parser
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/asciidoc-parser/cabal.project
+++ b/code/packages/haskell/asciidoc-parser/cabal.project
@@ -1,0 +1,7 @@
+packages:
+  .
+  ../parser
+  ../graph
+  ../directed-graph
+  ../state-machine
+  ../lexer

--- a/code/packages/haskell/asciidoc-parser/src/AsciidocParser.hs
+++ b/code/packages/haskell/asciidoc-parser/src/AsciidocParser.hs
@@ -1,0 +1,15 @@
+module AsciidocParser
+    ( description
+    , parseAsciidocTokens
+    ) where
+
+import Lexer (Token)
+import Parser (ASTNode, ParseError, parseTokens)
+
+-- Starter parser wrapper for grammars that do not yet have a sibling Haskell
+-- lexer package in this first porting wave.
+description :: String
+description = "Haskell starter wrapper for asciidoc-parser built on the generic parser package"
+
+parseAsciidocTokens :: [Token] -> Either ParseError ASTNode
+parseAsciidocTokens = parseTokens

--- a/code/packages/haskell/asciidoc-parser/test/AsciidocParserSpec.hs
+++ b/code/packages/haskell/asciidoc-parser/test/AsciidocParserSpec.hs
@@ -1,0 +1,9 @@
+module AsciidocParserSpec (spec) where
+
+import Test.Hspec
+import AsciidocParser
+
+spec :: Spec
+spec = describe "AsciidocParser" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/asciidoc-parser/test/Spec.hs
+++ b/code/packages/haskell/asciidoc-parser/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import AsciidocParserSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/commonmark-parser/BUILD
+++ b/code/packages/haskell/commonmark-parser/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/commonmark-parser/BUILD_windows
+++ b/code/packages/haskell/commonmark-parser/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/commonmark-parser/CHANGELOG.md
+++ b/code/packages/haskell/commonmark-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/commonmark-parser/README.md
+++ b/code/packages/haskell/commonmark-parser/README.md
@@ -1,0 +1,11 @@
+# commonmark-parser
+
+Haskell starter wrapper for commonmark-parser built on the generic parser package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer, parser

--- a/code/packages/haskell/commonmark-parser/cabal.project
+++ b/code/packages/haskell/commonmark-parser/cabal.project
@@ -1,0 +1,7 @@
+packages:
+  .
+  ../parser
+  ../graph
+  ../directed-graph
+  ../state-machine
+  ../lexer

--- a/code/packages/haskell/commonmark-parser/commonmark-parser.cabal
+++ b/code/packages/haskell/commonmark-parser/commonmark-parser.cabal
@@ -1,0 +1,29 @@
+cabal-version: 3.0
+name:          commonmark-parser
+version:       0.1.0
+synopsis:      Haskell starter wrapper for commonmark-parser built on the generic parser package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  CommonmarkParser
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+                    , parser
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    CommonmarkParserSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , commonmark-parser
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/commonmark-parser/src/CommonmarkParser.hs
+++ b/code/packages/haskell/commonmark-parser/src/CommonmarkParser.hs
@@ -1,0 +1,15 @@
+module CommonmarkParser
+    ( description
+    , parseCommonmarkTokens
+    ) where
+
+import Lexer (Token)
+import Parser (ASTNode, ParseError, parseTokens)
+
+-- Starter parser wrapper for grammars that do not yet have a sibling Haskell
+-- lexer package in this first porting wave.
+description :: String
+description = "Haskell starter wrapper for commonmark-parser built on the generic parser package"
+
+parseCommonmarkTokens :: [Token] -> Either ParseError ASTNode
+parseCommonmarkTokens = parseTokens

--- a/code/packages/haskell/commonmark-parser/test/CommonmarkParserSpec.hs
+++ b/code/packages/haskell/commonmark-parser/test/CommonmarkParserSpec.hs
@@ -1,0 +1,9 @@
+module CommonmarkParserSpec (spec) where
+
+import Test.Hspec
+import CommonmarkParser
+
+spec :: Spec
+spec = describe "CommonmarkParser" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/commonmark-parser/test/Spec.hs
+++ b/code/packages/haskell/commonmark-parser/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import CommonmarkParserSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/csharp-lexer/BUILD
+++ b/code/packages/haskell/csharp-lexer/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/csharp-lexer/BUILD_windows
+++ b/code/packages/haskell/csharp-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/csharp-lexer/CHANGELOG.md
+++ b/code/packages/haskell/csharp-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/csharp-lexer/README.md
+++ b/code/packages/haskell/csharp-lexer/README.md
@@ -1,0 +1,11 @@
+# csharp-lexer
+
+Haskell starter wrapper for csharp-lexer built on the generic lexer package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer

--- a/code/packages/haskell/csharp-lexer/cabal.project
+++ b/code/packages/haskell/csharp-lexer/cabal.project
@@ -1,0 +1,6 @@
+packages:
+  .
+  ../lexer
+  ../graph
+  ../directed-graph
+  ../state-machine

--- a/code/packages/haskell/csharp-lexer/csharp-lexer.cabal
+++ b/code/packages/haskell/csharp-lexer/csharp-lexer.cabal
@@ -1,0 +1,28 @@
+cabal-version: 3.0
+name:          csharp-lexer
+version:       0.1.0
+synopsis:      Haskell starter wrapper for csharp-lexer built on the generic lexer package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  CsharpLexer
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    CsharpLexerSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , csharp-lexer
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/csharp-lexer/src/CsharpLexer.hs
+++ b/code/packages/haskell/csharp-lexer/src/CsharpLexer.hs
@@ -1,0 +1,18 @@
+module CsharpLexer
+    ( description
+    , csharpLexerKeywords
+    , tokenizeCsharp
+    ) where
+
+import Lexer (LexerConfig(..), LexerError, Token, defaultLexerConfig, tokenize)
+
+-- Thin wrapper around the shared lexer package so language-specific ports can
+-- grow their own keyword tables and token helpers incrementally.
+description :: String
+description = "Haskell starter wrapper for csharp-lexer built on the generic lexer package"
+
+csharpLexerKeywords :: [String]
+csharpLexerKeywords = []
+
+tokenizeCsharp :: String -> Either LexerError [Token]
+tokenizeCsharp = tokenize defaultLexerConfig {lexerKeywords = csharpLexerKeywords}

--- a/code/packages/haskell/csharp-lexer/test/CsharpLexerSpec.hs
+++ b/code/packages/haskell/csharp-lexer/test/CsharpLexerSpec.hs
@@ -1,0 +1,9 @@
+module CsharpLexerSpec (spec) where
+
+import Test.Hspec
+import CsharpLexer
+
+spec :: Spec
+spec = describe "CsharpLexer" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/csharp-lexer/test/Spec.hs
+++ b/code/packages/haskell/csharp-lexer/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import CsharpLexerSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/csharp-parser/BUILD
+++ b/code/packages/haskell/csharp-parser/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/csharp-parser/BUILD_windows
+++ b/code/packages/haskell/csharp-parser/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/csharp-parser/CHANGELOG.md
+++ b/code/packages/haskell/csharp-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/csharp-parser/README.md
+++ b/code/packages/haskell/csharp-parser/README.md
@@ -1,0 +1,11 @@
+# csharp-parser
+
+Haskell starter wrapper for csharp-parser built on the generic parser package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer, parser, csharp-lexer

--- a/code/packages/haskell/csharp-parser/cabal.project
+++ b/code/packages/haskell/csharp-parser/cabal.project
@@ -1,0 +1,8 @@
+packages:
+  .
+  ../parser
+  ../graph
+  ../directed-graph
+  ../state-machine
+  ../lexer
+  ../csharp-lexer

--- a/code/packages/haskell/csharp-parser/csharp-parser.cabal
+++ b/code/packages/haskell/csharp-parser/csharp-parser.cabal
@@ -1,0 +1,30 @@
+cabal-version: 3.0
+name:          csharp-parser
+version:       0.1.0
+synopsis:      Haskell starter wrapper for csharp-parser built on the generic parser package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  CsharpParser
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+                    , parser
+                    , csharp-lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    CsharpParserSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , csharp-parser
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/csharp-parser/src/CsharpParser.hs
+++ b/code/packages/haskell/csharp-parser/src/CsharpParser.hs
@@ -1,0 +1,32 @@
+module CsharpParser
+    ( description
+    , CsharpParserError(..)
+    , parseCsharpTokens
+    , tokenizeAndParseCsharp
+    ) where
+
+import Lexer (LexerError, Token)
+import Parser (ASTNode, ParseError, parseTokens)
+import qualified CsharpLexer
+
+-- Starter parser wrapper that composes the shared parser engine with the
+-- sibling lexer package for this language family.
+description :: String
+description = "Haskell starter wrapper for csharp-parser built on the generic parser package"
+
+data CsharpParserError
+    = CsharpParserLexerError LexerError
+    | CsharpParserParseError ParseError
+    deriving (Eq, Show)
+
+parseCsharpTokens :: [Token] -> Either ParseError ASTNode
+parseCsharpTokens = parseTokens
+
+tokenizeAndParseCsharp :: String -> Either CsharpParserError ASTNode
+tokenizeAndParseCsharp source =
+    case CsharpLexer.tokenizeCsharp source of
+        Left err -> Left (CsharpParserLexerError err)
+        Right tokens ->
+            case parseCsharpTokens tokens of
+                Left err -> Left (CsharpParserParseError err)
+                Right ast -> Right ast

--- a/code/packages/haskell/csharp-parser/test/CsharpParserSpec.hs
+++ b/code/packages/haskell/csharp-parser/test/CsharpParserSpec.hs
@@ -1,0 +1,9 @@
+module CsharpParserSpec (spec) where
+
+import Test.Hspec
+import CsharpParser
+
+spec :: Spec
+spec = describe "CsharpParser" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/csharp-parser/test/Spec.hs
+++ b/code/packages/haskell/csharp-parser/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import CsharpParserSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/css-lexer/BUILD
+++ b/code/packages/haskell/css-lexer/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/css-lexer/BUILD_windows
+++ b/code/packages/haskell/css-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/css-lexer/CHANGELOG.md
+++ b/code/packages/haskell/css-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/css-lexer/README.md
+++ b/code/packages/haskell/css-lexer/README.md
@@ -1,0 +1,11 @@
+# css-lexer
+
+Haskell starter wrapper for css-lexer built on the generic lexer package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer

--- a/code/packages/haskell/css-lexer/cabal.project
+++ b/code/packages/haskell/css-lexer/cabal.project
@@ -1,0 +1,6 @@
+packages:
+  .
+  ../lexer
+  ../graph
+  ../directed-graph
+  ../state-machine

--- a/code/packages/haskell/css-lexer/css-lexer.cabal
+++ b/code/packages/haskell/css-lexer/css-lexer.cabal
@@ -1,0 +1,28 @@
+cabal-version: 3.0
+name:          css-lexer
+version:       0.1.0
+synopsis:      Haskell starter wrapper for css-lexer built on the generic lexer package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  CssLexer
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    CssLexerSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , css-lexer
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/css-lexer/src/CssLexer.hs
+++ b/code/packages/haskell/css-lexer/src/CssLexer.hs
@@ -1,0 +1,18 @@
+module CssLexer
+    ( description
+    , cssLexerKeywords
+    , tokenizeCss
+    ) where
+
+import Lexer (LexerConfig(..), LexerError, Token, defaultLexerConfig, tokenize)
+
+-- Thin wrapper around the shared lexer package so language-specific ports can
+-- grow their own keyword tables and token helpers incrementally.
+description :: String
+description = "Haskell starter wrapper for css-lexer built on the generic lexer package"
+
+cssLexerKeywords :: [String]
+cssLexerKeywords = []
+
+tokenizeCss :: String -> Either LexerError [Token]
+tokenizeCss = tokenize defaultLexerConfig {lexerKeywords = cssLexerKeywords}

--- a/code/packages/haskell/css-lexer/test/CssLexerSpec.hs
+++ b/code/packages/haskell/css-lexer/test/CssLexerSpec.hs
@@ -1,0 +1,9 @@
+module CssLexerSpec (spec) where
+
+import Test.Hspec
+import CssLexer
+
+spec :: Spec
+spec = describe "CssLexer" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/css-lexer/test/Spec.hs
+++ b/code/packages/haskell/css-lexer/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import CssLexerSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/css-parser/BUILD
+++ b/code/packages/haskell/css-parser/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/css-parser/BUILD_windows
+++ b/code/packages/haskell/css-parser/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/css-parser/CHANGELOG.md
+++ b/code/packages/haskell/css-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/css-parser/README.md
+++ b/code/packages/haskell/css-parser/README.md
@@ -1,0 +1,11 @@
+# css-parser
+
+Haskell starter wrapper for css-parser built on the generic parser package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer, parser, css-lexer

--- a/code/packages/haskell/css-parser/cabal.project
+++ b/code/packages/haskell/css-parser/cabal.project
@@ -1,0 +1,8 @@
+packages:
+  .
+  ../parser
+  ../graph
+  ../directed-graph
+  ../state-machine
+  ../lexer
+  ../css-lexer

--- a/code/packages/haskell/css-parser/css-parser.cabal
+++ b/code/packages/haskell/css-parser/css-parser.cabal
@@ -1,0 +1,30 @@
+cabal-version: 3.0
+name:          css-parser
+version:       0.1.0
+synopsis:      Haskell starter wrapper for css-parser built on the generic parser package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  CssParser
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+                    , parser
+                    , css-lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    CssParserSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , css-parser
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/css-parser/src/CssParser.hs
+++ b/code/packages/haskell/css-parser/src/CssParser.hs
@@ -1,0 +1,32 @@
+module CssParser
+    ( description
+    , CssParserError(..)
+    , parseCssTokens
+    , tokenizeAndParseCss
+    ) where
+
+import Lexer (LexerError, Token)
+import Parser (ASTNode, ParseError, parseTokens)
+import qualified CssLexer
+
+-- Starter parser wrapper that composes the shared parser engine with the
+-- sibling lexer package for this language family.
+description :: String
+description = "Haskell starter wrapper for css-parser built on the generic parser package"
+
+data CssParserError
+    = CssParserLexerError LexerError
+    | CssParserParseError ParseError
+    deriving (Eq, Show)
+
+parseCssTokens :: [Token] -> Either ParseError ASTNode
+parseCssTokens = parseTokens
+
+tokenizeAndParseCss :: String -> Either CssParserError ASTNode
+tokenizeAndParseCss source =
+    case CssLexer.tokenizeCss source of
+        Left err -> Left (CssParserLexerError err)
+        Right tokens ->
+            case parseCssTokens tokens of
+                Left err -> Left (CssParserParseError err)
+                Right ast -> Right ast

--- a/code/packages/haskell/css-parser/test/CssParserSpec.hs
+++ b/code/packages/haskell/css-parser/test/CssParserSpec.hs
@@ -1,0 +1,9 @@
+module CssParserSpec (spec) where
+
+import Test.Hspec
+import CssParser
+
+spec :: Spec
+spec = describe "CssParser" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/css-parser/test/Spec.hs
+++ b/code/packages/haskell/css-parser/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import CssParserSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/csv-parser/BUILD
+++ b/code/packages/haskell/csv-parser/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/csv-parser/BUILD_windows
+++ b/code/packages/haskell/csv-parser/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/csv-parser/CHANGELOG.md
+++ b/code/packages/haskell/csv-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/csv-parser/README.md
+++ b/code/packages/haskell/csv-parser/README.md
@@ -1,0 +1,11 @@
+# csv-parser
+
+Haskell starter wrapper for csv-parser built on the generic parser package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer, parser

--- a/code/packages/haskell/csv-parser/cabal.project
+++ b/code/packages/haskell/csv-parser/cabal.project
@@ -1,0 +1,7 @@
+packages:
+  .
+  ../parser
+  ../graph
+  ../directed-graph
+  ../state-machine
+  ../lexer

--- a/code/packages/haskell/csv-parser/csv-parser.cabal
+++ b/code/packages/haskell/csv-parser/csv-parser.cabal
@@ -1,0 +1,29 @@
+cabal-version: 3.0
+name:          csv-parser
+version:       0.1.0
+synopsis:      Haskell starter wrapper for csv-parser built on the generic parser package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  CsvParser
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+                    , parser
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    CsvParserSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , csv-parser
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/csv-parser/src/CsvParser.hs
+++ b/code/packages/haskell/csv-parser/src/CsvParser.hs
@@ -1,0 +1,15 @@
+module CsvParser
+    ( description
+    , parseCsvTokens
+    ) where
+
+import Lexer (Token)
+import Parser (ASTNode, ParseError, parseTokens)
+
+-- Starter parser wrapper for grammars that do not yet have a sibling Haskell
+-- lexer package in this first porting wave.
+description :: String
+description = "Haskell starter wrapper for csv-parser built on the generic parser package"
+
+parseCsvTokens :: [Token] -> Either ParseError ASTNode
+parseCsvTokens = parseTokens

--- a/code/packages/haskell/csv-parser/test/CsvParserSpec.hs
+++ b/code/packages/haskell/csv-parser/test/CsvParserSpec.hs
@@ -1,0 +1,9 @@
+module CsvParserSpec (spec) where
+
+import Test.Hspec
+import CsvParser
+
+spec :: Spec
+spec = describe "CsvParser" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/csv-parser/test/Spec.hs
+++ b/code/packages/haskell/csv-parser/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import CsvParserSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/dartmouth-basic-lexer/BUILD
+++ b/code/packages/haskell/dartmouth-basic-lexer/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/dartmouth-basic-lexer/BUILD_windows
+++ b/code/packages/haskell/dartmouth-basic-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/dartmouth-basic-lexer/CHANGELOG.md
+++ b/code/packages/haskell/dartmouth-basic-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/dartmouth-basic-lexer/README.md
+++ b/code/packages/haskell/dartmouth-basic-lexer/README.md
@@ -1,0 +1,11 @@
+# dartmouth-basic-lexer
+
+Haskell starter wrapper for dartmouth-basic-lexer built on the generic lexer package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer

--- a/code/packages/haskell/dartmouth-basic-lexer/cabal.project
+++ b/code/packages/haskell/dartmouth-basic-lexer/cabal.project
@@ -1,0 +1,6 @@
+packages:
+  .
+  ../lexer
+  ../graph
+  ../directed-graph
+  ../state-machine

--- a/code/packages/haskell/dartmouth-basic-lexer/dartmouth-basic-lexer.cabal
+++ b/code/packages/haskell/dartmouth-basic-lexer/dartmouth-basic-lexer.cabal
@@ -1,0 +1,28 @@
+cabal-version: 3.0
+name:          dartmouth-basic-lexer
+version:       0.1.0
+synopsis:      Haskell starter wrapper for dartmouth-basic-lexer built on the generic lexer package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  DartmouthBasicLexer
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    DartmouthBasicLexerSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , dartmouth-basic-lexer
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/dartmouth-basic-lexer/src/DartmouthBasicLexer.hs
+++ b/code/packages/haskell/dartmouth-basic-lexer/src/DartmouthBasicLexer.hs
@@ -1,0 +1,18 @@
+module DartmouthBasicLexer
+    ( description
+    , dartmouthBasicLexerKeywords
+    , tokenizeDartmouthBasic
+    ) where
+
+import Lexer (LexerConfig(..), LexerError, Token, defaultLexerConfig, tokenize)
+
+-- Thin wrapper around the shared lexer package so language-specific ports can
+-- grow their own keyword tables and token helpers incrementally.
+description :: String
+description = "Haskell starter wrapper for dartmouth-basic-lexer built on the generic lexer package"
+
+dartmouthBasicLexerKeywords :: [String]
+dartmouthBasicLexerKeywords = []
+
+tokenizeDartmouthBasic :: String -> Either LexerError [Token]
+tokenizeDartmouthBasic = tokenize defaultLexerConfig {lexerKeywords = dartmouthBasicLexerKeywords}

--- a/code/packages/haskell/dartmouth-basic-lexer/test/DartmouthBasicLexerSpec.hs
+++ b/code/packages/haskell/dartmouth-basic-lexer/test/DartmouthBasicLexerSpec.hs
@@ -1,0 +1,9 @@
+module DartmouthBasicLexerSpec (spec) where
+
+import Test.Hspec
+import DartmouthBasicLexer
+
+spec :: Spec
+spec = describe "DartmouthBasicLexer" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/dartmouth-basic-lexer/test/Spec.hs
+++ b/code/packages/haskell/dartmouth-basic-lexer/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import DartmouthBasicLexerSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/dartmouth-basic-parser/BUILD
+++ b/code/packages/haskell/dartmouth-basic-parser/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/dartmouth-basic-parser/BUILD_windows
+++ b/code/packages/haskell/dartmouth-basic-parser/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/dartmouth-basic-parser/CHANGELOG.md
+++ b/code/packages/haskell/dartmouth-basic-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/dartmouth-basic-parser/README.md
+++ b/code/packages/haskell/dartmouth-basic-parser/README.md
@@ -1,0 +1,11 @@
+# dartmouth-basic-parser
+
+Haskell starter wrapper for dartmouth-basic-parser built on the generic parser package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer, parser, dartmouth-basic-lexer

--- a/code/packages/haskell/dartmouth-basic-parser/cabal.project
+++ b/code/packages/haskell/dartmouth-basic-parser/cabal.project
@@ -1,0 +1,8 @@
+packages:
+  .
+  ../parser
+  ../graph
+  ../directed-graph
+  ../state-machine
+  ../lexer
+  ../dartmouth-basic-lexer

--- a/code/packages/haskell/dartmouth-basic-parser/dartmouth-basic-parser.cabal
+++ b/code/packages/haskell/dartmouth-basic-parser/dartmouth-basic-parser.cabal
@@ -1,0 +1,30 @@
+cabal-version: 3.0
+name:          dartmouth-basic-parser
+version:       0.1.0
+synopsis:      Haskell starter wrapper for dartmouth-basic-parser built on the generic parser package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  DartmouthBasicParser
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+                    , parser
+                    , dartmouth-basic-lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    DartmouthBasicParserSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , dartmouth-basic-parser
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/dartmouth-basic-parser/src/DartmouthBasicParser.hs
+++ b/code/packages/haskell/dartmouth-basic-parser/src/DartmouthBasicParser.hs
@@ -1,0 +1,32 @@
+module DartmouthBasicParser
+    ( description
+    , DartmouthBasicParserError(..)
+    , parseDartmouthBasicTokens
+    , tokenizeAndParseDartmouthBasic
+    ) where
+
+import Lexer (LexerError, Token)
+import Parser (ASTNode, ParseError, parseTokens)
+import qualified DartmouthBasicLexer
+
+-- Starter parser wrapper that composes the shared parser engine with the
+-- sibling lexer package for this language family.
+description :: String
+description = "Haskell starter wrapper for dartmouth-basic-parser built on the generic parser package"
+
+data DartmouthBasicParserError
+    = DartmouthBasicParserLexerError LexerError
+    | DartmouthBasicParserParseError ParseError
+    deriving (Eq, Show)
+
+parseDartmouthBasicTokens :: [Token] -> Either ParseError ASTNode
+parseDartmouthBasicTokens = parseTokens
+
+tokenizeAndParseDartmouthBasic :: String -> Either DartmouthBasicParserError ASTNode
+tokenizeAndParseDartmouthBasic source =
+    case DartmouthBasicLexer.tokenizeDartmouthBasic source of
+        Left err -> Left (DartmouthBasicParserLexerError err)
+        Right tokens ->
+            case parseDartmouthBasicTokens tokens of
+                Left err -> Left (DartmouthBasicParserParseError err)
+                Right ast -> Right ast

--- a/code/packages/haskell/dartmouth-basic-parser/test/DartmouthBasicParserSpec.hs
+++ b/code/packages/haskell/dartmouth-basic-parser/test/DartmouthBasicParserSpec.hs
@@ -1,0 +1,9 @@
+module DartmouthBasicParserSpec (spec) where
+
+import Test.Hspec
+import DartmouthBasicParser
+
+spec :: Spec
+spec = describe "DartmouthBasicParser" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/dartmouth-basic-parser/test/Spec.hs
+++ b/code/packages/haskell/dartmouth-basic-parser/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import DartmouthBasicParserSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/ecmascript-es1-lexer/BUILD
+++ b/code/packages/haskell/ecmascript-es1-lexer/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/ecmascript-es1-lexer/BUILD_windows
+++ b/code/packages/haskell/ecmascript-es1-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/ecmascript-es1-lexer/CHANGELOG.md
+++ b/code/packages/haskell/ecmascript-es1-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/ecmascript-es1-lexer/README.md
+++ b/code/packages/haskell/ecmascript-es1-lexer/README.md
@@ -1,0 +1,11 @@
+# ecmascript-es1-lexer
+
+Haskell starter wrapper for ecmascript-es1-lexer built on the generic lexer package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer

--- a/code/packages/haskell/ecmascript-es1-lexer/cabal.project
+++ b/code/packages/haskell/ecmascript-es1-lexer/cabal.project
@@ -1,0 +1,6 @@
+packages:
+  .
+  ../lexer
+  ../graph
+  ../directed-graph
+  ../state-machine

--- a/code/packages/haskell/ecmascript-es1-lexer/ecmascript-es1-lexer.cabal
+++ b/code/packages/haskell/ecmascript-es1-lexer/ecmascript-es1-lexer.cabal
@@ -1,0 +1,28 @@
+cabal-version: 3.0
+name:          ecmascript-es1-lexer
+version:       0.1.0
+synopsis:      Haskell starter wrapper for ecmascript-es1-lexer built on the generic lexer package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  EcmascriptEs1Lexer
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    EcmascriptEs1LexerSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , ecmascript-es1-lexer
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/ecmascript-es1-lexer/src/EcmascriptEs1Lexer.hs
+++ b/code/packages/haskell/ecmascript-es1-lexer/src/EcmascriptEs1Lexer.hs
@@ -1,0 +1,18 @@
+module EcmascriptEs1Lexer
+    ( description
+    , ecmascriptEs1LexerKeywords
+    , tokenizeEcmascriptEs1
+    ) where
+
+import Lexer (LexerConfig(..), LexerError, Token, defaultLexerConfig, tokenize)
+
+-- Thin wrapper around the shared lexer package so language-specific ports can
+-- grow their own keyword tables and token helpers incrementally.
+description :: String
+description = "Haskell starter wrapper for ecmascript-es1-lexer built on the generic lexer package"
+
+ecmascriptEs1LexerKeywords :: [String]
+ecmascriptEs1LexerKeywords = []
+
+tokenizeEcmascriptEs1 :: String -> Either LexerError [Token]
+tokenizeEcmascriptEs1 = tokenize defaultLexerConfig {lexerKeywords = ecmascriptEs1LexerKeywords}

--- a/code/packages/haskell/ecmascript-es1-lexer/test/EcmascriptEs1LexerSpec.hs
+++ b/code/packages/haskell/ecmascript-es1-lexer/test/EcmascriptEs1LexerSpec.hs
@@ -1,0 +1,9 @@
+module EcmascriptEs1LexerSpec (spec) where
+
+import Test.Hspec
+import EcmascriptEs1Lexer
+
+spec :: Spec
+spec = describe "EcmascriptEs1Lexer" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/ecmascript-es1-lexer/test/Spec.hs
+++ b/code/packages/haskell/ecmascript-es1-lexer/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import EcmascriptEs1LexerSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/ecmascript-es3-lexer/BUILD
+++ b/code/packages/haskell/ecmascript-es3-lexer/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/ecmascript-es3-lexer/BUILD_windows
+++ b/code/packages/haskell/ecmascript-es3-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/ecmascript-es3-lexer/CHANGELOG.md
+++ b/code/packages/haskell/ecmascript-es3-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/ecmascript-es3-lexer/README.md
+++ b/code/packages/haskell/ecmascript-es3-lexer/README.md
@@ -1,0 +1,11 @@
+# ecmascript-es3-lexer
+
+Haskell starter wrapper for ecmascript-es3-lexer built on the generic lexer package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer

--- a/code/packages/haskell/ecmascript-es3-lexer/cabal.project
+++ b/code/packages/haskell/ecmascript-es3-lexer/cabal.project
@@ -1,0 +1,6 @@
+packages:
+  .
+  ../lexer
+  ../graph
+  ../directed-graph
+  ../state-machine

--- a/code/packages/haskell/ecmascript-es3-lexer/ecmascript-es3-lexer.cabal
+++ b/code/packages/haskell/ecmascript-es3-lexer/ecmascript-es3-lexer.cabal
@@ -1,0 +1,28 @@
+cabal-version: 3.0
+name:          ecmascript-es3-lexer
+version:       0.1.0
+synopsis:      Haskell starter wrapper for ecmascript-es3-lexer built on the generic lexer package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  EcmascriptEs3Lexer
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    EcmascriptEs3LexerSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , ecmascript-es3-lexer
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/ecmascript-es3-lexer/src/EcmascriptEs3Lexer.hs
+++ b/code/packages/haskell/ecmascript-es3-lexer/src/EcmascriptEs3Lexer.hs
@@ -1,0 +1,18 @@
+module EcmascriptEs3Lexer
+    ( description
+    , ecmascriptEs3LexerKeywords
+    , tokenizeEcmascriptEs3
+    ) where
+
+import Lexer (LexerConfig(..), LexerError, Token, defaultLexerConfig, tokenize)
+
+-- Thin wrapper around the shared lexer package so language-specific ports can
+-- grow their own keyword tables and token helpers incrementally.
+description :: String
+description = "Haskell starter wrapper for ecmascript-es3-lexer built on the generic lexer package"
+
+ecmascriptEs3LexerKeywords :: [String]
+ecmascriptEs3LexerKeywords = []
+
+tokenizeEcmascriptEs3 :: String -> Either LexerError [Token]
+tokenizeEcmascriptEs3 = tokenize defaultLexerConfig {lexerKeywords = ecmascriptEs3LexerKeywords}

--- a/code/packages/haskell/ecmascript-es3-lexer/test/EcmascriptEs3LexerSpec.hs
+++ b/code/packages/haskell/ecmascript-es3-lexer/test/EcmascriptEs3LexerSpec.hs
@@ -1,0 +1,9 @@
+module EcmascriptEs3LexerSpec (spec) where
+
+import Test.Hspec
+import EcmascriptEs3Lexer
+
+spec :: Spec
+spec = describe "EcmascriptEs3Lexer" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/ecmascript-es3-lexer/test/Spec.hs
+++ b/code/packages/haskell/ecmascript-es3-lexer/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import EcmascriptEs3LexerSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/ecmascript-es5-lexer/BUILD
+++ b/code/packages/haskell/ecmascript-es5-lexer/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/ecmascript-es5-lexer/BUILD_windows
+++ b/code/packages/haskell/ecmascript-es5-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/ecmascript-es5-lexer/CHANGELOG.md
+++ b/code/packages/haskell/ecmascript-es5-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/ecmascript-es5-lexer/README.md
+++ b/code/packages/haskell/ecmascript-es5-lexer/README.md
@@ -1,0 +1,11 @@
+# ecmascript-es5-lexer
+
+Haskell starter wrapper for ecmascript-es5-lexer built on the generic lexer package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer

--- a/code/packages/haskell/ecmascript-es5-lexer/cabal.project
+++ b/code/packages/haskell/ecmascript-es5-lexer/cabal.project
@@ -1,0 +1,6 @@
+packages:
+  .
+  ../lexer
+  ../graph
+  ../directed-graph
+  ../state-machine

--- a/code/packages/haskell/ecmascript-es5-lexer/ecmascript-es5-lexer.cabal
+++ b/code/packages/haskell/ecmascript-es5-lexer/ecmascript-es5-lexer.cabal
@@ -1,0 +1,28 @@
+cabal-version: 3.0
+name:          ecmascript-es5-lexer
+version:       0.1.0
+synopsis:      Haskell starter wrapper for ecmascript-es5-lexer built on the generic lexer package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  EcmascriptEs5Lexer
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    EcmascriptEs5LexerSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , ecmascript-es5-lexer
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/ecmascript-es5-lexer/src/EcmascriptEs5Lexer.hs
+++ b/code/packages/haskell/ecmascript-es5-lexer/src/EcmascriptEs5Lexer.hs
@@ -1,0 +1,18 @@
+module EcmascriptEs5Lexer
+    ( description
+    , ecmascriptEs5LexerKeywords
+    , tokenizeEcmascriptEs5
+    ) where
+
+import Lexer (LexerConfig(..), LexerError, Token, defaultLexerConfig, tokenize)
+
+-- Thin wrapper around the shared lexer package so language-specific ports can
+-- grow their own keyword tables and token helpers incrementally.
+description :: String
+description = "Haskell starter wrapper for ecmascript-es5-lexer built on the generic lexer package"
+
+ecmascriptEs5LexerKeywords :: [String]
+ecmascriptEs5LexerKeywords = []
+
+tokenizeEcmascriptEs5 :: String -> Either LexerError [Token]
+tokenizeEcmascriptEs5 = tokenize defaultLexerConfig {lexerKeywords = ecmascriptEs5LexerKeywords}

--- a/code/packages/haskell/ecmascript-es5-lexer/test/EcmascriptEs5LexerSpec.hs
+++ b/code/packages/haskell/ecmascript-es5-lexer/test/EcmascriptEs5LexerSpec.hs
@@ -1,0 +1,9 @@
+module EcmascriptEs5LexerSpec (spec) where
+
+import Test.Hspec
+import EcmascriptEs5Lexer
+
+spec :: Spec
+spec = describe "EcmascriptEs5Lexer" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/ecmascript-es5-lexer/test/Spec.hs
+++ b/code/packages/haskell/ecmascript-es5-lexer/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import EcmascriptEs5LexerSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/excel-lexer/BUILD
+++ b/code/packages/haskell/excel-lexer/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/excel-lexer/BUILD_windows
+++ b/code/packages/haskell/excel-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/excel-lexer/CHANGELOG.md
+++ b/code/packages/haskell/excel-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/excel-lexer/README.md
+++ b/code/packages/haskell/excel-lexer/README.md
@@ -1,0 +1,11 @@
+# excel-lexer
+
+Haskell starter wrapper for excel-lexer built on the generic lexer package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer

--- a/code/packages/haskell/excel-lexer/cabal.project
+++ b/code/packages/haskell/excel-lexer/cabal.project
@@ -1,0 +1,6 @@
+packages:
+  .
+  ../lexer
+  ../graph
+  ../directed-graph
+  ../state-machine

--- a/code/packages/haskell/excel-lexer/excel-lexer.cabal
+++ b/code/packages/haskell/excel-lexer/excel-lexer.cabal
@@ -1,0 +1,28 @@
+cabal-version: 3.0
+name:          excel-lexer
+version:       0.1.0
+synopsis:      Haskell starter wrapper for excel-lexer built on the generic lexer package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  ExcelLexer
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    ExcelLexerSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , excel-lexer
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/excel-lexer/src/ExcelLexer.hs
+++ b/code/packages/haskell/excel-lexer/src/ExcelLexer.hs
@@ -1,0 +1,18 @@
+module ExcelLexer
+    ( description
+    , excelLexerKeywords
+    , tokenizeExcel
+    ) where
+
+import Lexer (LexerConfig(..), LexerError, Token, defaultLexerConfig, tokenize)
+
+-- Thin wrapper around the shared lexer package so language-specific ports can
+-- grow their own keyword tables and token helpers incrementally.
+description :: String
+description = "Haskell starter wrapper for excel-lexer built on the generic lexer package"
+
+excelLexerKeywords :: [String]
+excelLexerKeywords = []
+
+tokenizeExcel :: String -> Either LexerError [Token]
+tokenizeExcel = tokenize defaultLexerConfig {lexerKeywords = excelLexerKeywords}

--- a/code/packages/haskell/excel-lexer/test/ExcelLexerSpec.hs
+++ b/code/packages/haskell/excel-lexer/test/ExcelLexerSpec.hs
@@ -1,0 +1,9 @@
+module ExcelLexerSpec (spec) where
+
+import Test.Hspec
+import ExcelLexer
+
+spec :: Spec
+spec = describe "ExcelLexer" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/excel-lexer/test/Spec.hs
+++ b/code/packages/haskell/excel-lexer/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import ExcelLexerSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/excel-parser/BUILD
+++ b/code/packages/haskell/excel-parser/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/excel-parser/BUILD_windows
+++ b/code/packages/haskell/excel-parser/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/excel-parser/CHANGELOG.md
+++ b/code/packages/haskell/excel-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/excel-parser/README.md
+++ b/code/packages/haskell/excel-parser/README.md
@@ -1,0 +1,11 @@
+# excel-parser
+
+Haskell starter wrapper for excel-parser built on the generic parser package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer, parser, excel-lexer

--- a/code/packages/haskell/excel-parser/cabal.project
+++ b/code/packages/haskell/excel-parser/cabal.project
@@ -1,0 +1,8 @@
+packages:
+  .
+  ../parser
+  ../graph
+  ../directed-graph
+  ../state-machine
+  ../lexer
+  ../excel-lexer

--- a/code/packages/haskell/excel-parser/excel-parser.cabal
+++ b/code/packages/haskell/excel-parser/excel-parser.cabal
@@ -1,0 +1,30 @@
+cabal-version: 3.0
+name:          excel-parser
+version:       0.1.0
+synopsis:      Haskell starter wrapper for excel-parser built on the generic parser package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  ExcelParser
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+                    , parser
+                    , excel-lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    ExcelParserSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , excel-parser
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/excel-parser/src/ExcelParser.hs
+++ b/code/packages/haskell/excel-parser/src/ExcelParser.hs
@@ -1,0 +1,32 @@
+module ExcelParser
+    ( description
+    , ExcelParserError(..)
+    , parseExcelTokens
+    , tokenizeAndParseExcel
+    ) where
+
+import Lexer (LexerError, Token)
+import Parser (ASTNode, ParseError, parseTokens)
+import qualified ExcelLexer
+
+-- Starter parser wrapper that composes the shared parser engine with the
+-- sibling lexer package for this language family.
+description :: String
+description = "Haskell starter wrapper for excel-parser built on the generic parser package"
+
+data ExcelParserError
+    = ExcelParserLexerError LexerError
+    | ExcelParserParseError ParseError
+    deriving (Eq, Show)
+
+parseExcelTokens :: [Token] -> Either ParseError ASTNode
+parseExcelTokens = parseTokens
+
+tokenizeAndParseExcel :: String -> Either ExcelParserError ASTNode
+tokenizeAndParseExcel source =
+    case ExcelLexer.tokenizeExcel source of
+        Left err -> Left (ExcelParserLexerError err)
+        Right tokens ->
+            case parseExcelTokens tokens of
+                Left err -> Left (ExcelParserParseError err)
+                Right ast -> Right ast

--- a/code/packages/haskell/excel-parser/test/ExcelParserSpec.hs
+++ b/code/packages/haskell/excel-parser/test/ExcelParserSpec.hs
@@ -1,0 +1,9 @@
+module ExcelParserSpec (spec) where
+
+import Test.Hspec
+import ExcelParser
+
+spec :: Spec
+spec = describe "ExcelParser" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/excel-parser/test/Spec.hs
+++ b/code/packages/haskell/excel-parser/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import ExcelParserSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/font-parser/BUILD
+++ b/code/packages/haskell/font-parser/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/font-parser/BUILD_windows
+++ b/code/packages/haskell/font-parser/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/font-parser/CHANGELOG.md
+++ b/code/packages/haskell/font-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/font-parser/README.md
+++ b/code/packages/haskell/font-parser/README.md
@@ -1,0 +1,11 @@
+# font-parser
+
+Haskell starter wrapper for font-parser built on the generic parser package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer, parser

--- a/code/packages/haskell/font-parser/cabal.project
+++ b/code/packages/haskell/font-parser/cabal.project
@@ -1,0 +1,7 @@
+packages:
+  .
+  ../parser
+  ../graph
+  ../directed-graph
+  ../state-machine
+  ../lexer

--- a/code/packages/haskell/font-parser/font-parser.cabal
+++ b/code/packages/haskell/font-parser/font-parser.cabal
@@ -1,0 +1,29 @@
+cabal-version: 3.0
+name:          font-parser
+version:       0.1.0
+synopsis:      Haskell starter wrapper for font-parser built on the generic parser package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  FontParser
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+                    , parser
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    FontParserSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , font-parser
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/font-parser/src/FontParser.hs
+++ b/code/packages/haskell/font-parser/src/FontParser.hs
@@ -1,0 +1,15 @@
+module FontParser
+    ( description
+    , parseFontTokens
+    ) where
+
+import Lexer (Token)
+import Parser (ASTNode, ParseError, parseTokens)
+
+-- Starter parser wrapper for grammars that do not yet have a sibling Haskell
+-- lexer package in this first porting wave.
+description :: String
+description = "Haskell starter wrapper for font-parser built on the generic parser package"
+
+parseFontTokens :: [Token] -> Either ParseError ASTNode
+parseFontTokens = parseTokens

--- a/code/packages/haskell/font-parser/test/FontParserSpec.hs
+++ b/code/packages/haskell/font-parser/test/FontParserSpec.hs
@@ -1,0 +1,9 @@
+module FontParserSpec (spec) where
+
+import Test.Hspec
+import FontParser
+
+spec :: Spec
+spec = describe "FontParser" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/font-parser/test/Spec.hs
+++ b/code/packages/haskell/font-parser/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import FontParserSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/fsharp-lexer/BUILD
+++ b/code/packages/haskell/fsharp-lexer/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/fsharp-lexer/BUILD_windows
+++ b/code/packages/haskell/fsharp-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/fsharp-lexer/CHANGELOG.md
+++ b/code/packages/haskell/fsharp-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/fsharp-lexer/README.md
+++ b/code/packages/haskell/fsharp-lexer/README.md
@@ -1,0 +1,11 @@
+# fsharp-lexer
+
+Haskell starter wrapper for fsharp-lexer built on the generic lexer package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer

--- a/code/packages/haskell/fsharp-lexer/cabal.project
+++ b/code/packages/haskell/fsharp-lexer/cabal.project
@@ -1,0 +1,6 @@
+packages:
+  .
+  ../lexer
+  ../graph
+  ../directed-graph
+  ../state-machine

--- a/code/packages/haskell/fsharp-lexer/fsharp-lexer.cabal
+++ b/code/packages/haskell/fsharp-lexer/fsharp-lexer.cabal
@@ -1,0 +1,28 @@
+cabal-version: 3.0
+name:          fsharp-lexer
+version:       0.1.0
+synopsis:      Haskell starter wrapper for fsharp-lexer built on the generic lexer package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  FsharpLexer
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    FsharpLexerSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , fsharp-lexer
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/fsharp-lexer/src/FsharpLexer.hs
+++ b/code/packages/haskell/fsharp-lexer/src/FsharpLexer.hs
@@ -1,0 +1,18 @@
+module FsharpLexer
+    ( description
+    , fsharpLexerKeywords
+    , tokenizeFsharp
+    ) where
+
+import Lexer (LexerConfig(..), LexerError, Token, defaultLexerConfig, tokenize)
+
+-- Thin wrapper around the shared lexer package so language-specific ports can
+-- grow their own keyword tables and token helpers incrementally.
+description :: String
+description = "Haskell starter wrapper for fsharp-lexer built on the generic lexer package"
+
+fsharpLexerKeywords :: [String]
+fsharpLexerKeywords = []
+
+tokenizeFsharp :: String -> Either LexerError [Token]
+tokenizeFsharp = tokenize defaultLexerConfig {lexerKeywords = fsharpLexerKeywords}

--- a/code/packages/haskell/fsharp-lexer/test/FsharpLexerSpec.hs
+++ b/code/packages/haskell/fsharp-lexer/test/FsharpLexerSpec.hs
@@ -1,0 +1,9 @@
+module FsharpLexerSpec (spec) where
+
+import Test.Hspec
+import FsharpLexer
+
+spec :: Spec
+spec = describe "FsharpLexer" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/fsharp-lexer/test/Spec.hs
+++ b/code/packages/haskell/fsharp-lexer/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import FsharpLexerSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/fsharp-parser/BUILD
+++ b/code/packages/haskell/fsharp-parser/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/fsharp-parser/BUILD_windows
+++ b/code/packages/haskell/fsharp-parser/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/fsharp-parser/CHANGELOG.md
+++ b/code/packages/haskell/fsharp-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/fsharp-parser/README.md
+++ b/code/packages/haskell/fsharp-parser/README.md
@@ -1,0 +1,11 @@
+# fsharp-parser
+
+Haskell starter wrapper for fsharp-parser built on the generic parser package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer, parser, fsharp-lexer

--- a/code/packages/haskell/fsharp-parser/cabal.project
+++ b/code/packages/haskell/fsharp-parser/cabal.project
@@ -1,0 +1,8 @@
+packages:
+  .
+  ../parser
+  ../graph
+  ../directed-graph
+  ../state-machine
+  ../lexer
+  ../fsharp-lexer

--- a/code/packages/haskell/fsharp-parser/fsharp-parser.cabal
+++ b/code/packages/haskell/fsharp-parser/fsharp-parser.cabal
@@ -1,0 +1,30 @@
+cabal-version: 3.0
+name:          fsharp-parser
+version:       0.1.0
+synopsis:      Haskell starter wrapper for fsharp-parser built on the generic parser package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  FsharpParser
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+                    , parser
+                    , fsharp-lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    FsharpParserSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , fsharp-parser
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/fsharp-parser/src/FsharpParser.hs
+++ b/code/packages/haskell/fsharp-parser/src/FsharpParser.hs
@@ -1,0 +1,32 @@
+module FsharpParser
+    ( description
+    , FsharpParserError(..)
+    , parseFsharpTokens
+    , tokenizeAndParseFsharp
+    ) where
+
+import Lexer (LexerError, Token)
+import Parser (ASTNode, ParseError, parseTokens)
+import qualified FsharpLexer
+
+-- Starter parser wrapper that composes the shared parser engine with the
+-- sibling lexer package for this language family.
+description :: String
+description = "Haskell starter wrapper for fsharp-parser built on the generic parser package"
+
+data FsharpParserError
+    = FsharpParserLexerError LexerError
+    | FsharpParserParseError ParseError
+    deriving (Eq, Show)
+
+parseFsharpTokens :: [Token] -> Either ParseError ASTNode
+parseFsharpTokens = parseTokens
+
+tokenizeAndParseFsharp :: String -> Either FsharpParserError ASTNode
+tokenizeAndParseFsharp source =
+    case FsharpLexer.tokenizeFsharp source of
+        Left err -> Left (FsharpParserLexerError err)
+        Right tokens ->
+            case parseFsharpTokens tokens of
+                Left err -> Left (FsharpParserParseError err)
+                Right ast -> Right ast

--- a/code/packages/haskell/fsharp-parser/test/FsharpParserSpec.hs
+++ b/code/packages/haskell/fsharp-parser/test/FsharpParserSpec.hs
@@ -1,0 +1,9 @@
+module FsharpParserSpec (spec) where
+
+import Test.Hspec
+import FsharpParser
+
+spec :: Spec
+spec = describe "FsharpParser" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/fsharp-parser/test/Spec.hs
+++ b/code/packages/haskell/fsharp-parser/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import FsharpParserSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/gfm-parser/BUILD
+++ b/code/packages/haskell/gfm-parser/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/gfm-parser/BUILD_windows
+++ b/code/packages/haskell/gfm-parser/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/gfm-parser/CHANGELOG.md
+++ b/code/packages/haskell/gfm-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/gfm-parser/README.md
+++ b/code/packages/haskell/gfm-parser/README.md
@@ -1,0 +1,11 @@
+# gfm-parser
+
+Haskell starter wrapper for gfm-parser built on the generic parser package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer, parser

--- a/code/packages/haskell/gfm-parser/cabal.project
+++ b/code/packages/haskell/gfm-parser/cabal.project
@@ -1,0 +1,7 @@
+packages:
+  .
+  ../parser
+  ../graph
+  ../directed-graph
+  ../state-machine
+  ../lexer

--- a/code/packages/haskell/gfm-parser/gfm-parser.cabal
+++ b/code/packages/haskell/gfm-parser/gfm-parser.cabal
@@ -1,0 +1,29 @@
+cabal-version: 3.0
+name:          gfm-parser
+version:       0.1.0
+synopsis:      Haskell starter wrapper for gfm-parser built on the generic parser package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  GfmParser
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+                    , parser
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    GfmParserSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , gfm-parser
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/gfm-parser/src/GfmParser.hs
+++ b/code/packages/haskell/gfm-parser/src/GfmParser.hs
@@ -1,0 +1,15 @@
+module GfmParser
+    ( description
+    , parseGfmTokens
+    ) where
+
+import Lexer (Token)
+import Parser (ASTNode, ParseError, parseTokens)
+
+-- Starter parser wrapper for grammars that do not yet have a sibling Haskell
+-- lexer package in this first porting wave.
+description :: String
+description = "Haskell starter wrapper for gfm-parser built on the generic parser package"
+
+parseGfmTokens :: [Token] -> Either ParseError ASTNode
+parseGfmTokens = parseTokens

--- a/code/packages/haskell/gfm-parser/test/GfmParserSpec.hs
+++ b/code/packages/haskell/gfm-parser/test/GfmParserSpec.hs
@@ -1,0 +1,9 @@
+module GfmParserSpec (spec) where
+
+import Test.Hspec
+import GfmParser
+
+spec :: Spec
+spec = describe "GfmParser" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/gfm-parser/test/Spec.hs
+++ b/code/packages/haskell/gfm-parser/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import GfmParserSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/java-lexer/BUILD
+++ b/code/packages/haskell/java-lexer/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/java-lexer/BUILD_windows
+++ b/code/packages/haskell/java-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/java-lexer/CHANGELOG.md
+++ b/code/packages/haskell/java-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/java-lexer/README.md
+++ b/code/packages/haskell/java-lexer/README.md
@@ -1,0 +1,11 @@
+# java-lexer
+
+Haskell starter wrapper for java-lexer built on the generic lexer package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer

--- a/code/packages/haskell/java-lexer/cabal.project
+++ b/code/packages/haskell/java-lexer/cabal.project
@@ -1,0 +1,6 @@
+packages:
+  .
+  ../lexer
+  ../graph
+  ../directed-graph
+  ../state-machine

--- a/code/packages/haskell/java-lexer/java-lexer.cabal
+++ b/code/packages/haskell/java-lexer/java-lexer.cabal
@@ -1,0 +1,28 @@
+cabal-version: 3.0
+name:          java-lexer
+version:       0.1.0
+synopsis:      Haskell starter wrapper for java-lexer built on the generic lexer package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  JavaLexer
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    JavaLexerSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , java-lexer
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/java-lexer/src/JavaLexer.hs
+++ b/code/packages/haskell/java-lexer/src/JavaLexer.hs
@@ -1,0 +1,18 @@
+module JavaLexer
+    ( description
+    , javaLexerKeywords
+    , tokenizeJava
+    ) where
+
+import Lexer (LexerConfig(..), LexerError, Token, defaultLexerConfig, tokenize)
+
+-- Thin wrapper around the shared lexer package so language-specific ports can
+-- grow their own keyword tables and token helpers incrementally.
+description :: String
+description = "Haskell starter wrapper for java-lexer built on the generic lexer package"
+
+javaLexerKeywords :: [String]
+javaLexerKeywords = []
+
+tokenizeJava :: String -> Either LexerError [Token]
+tokenizeJava = tokenize defaultLexerConfig {lexerKeywords = javaLexerKeywords}

--- a/code/packages/haskell/java-lexer/test/JavaLexerSpec.hs
+++ b/code/packages/haskell/java-lexer/test/JavaLexerSpec.hs
@@ -1,0 +1,9 @@
+module JavaLexerSpec (spec) where
+
+import Test.Hspec
+import JavaLexer
+
+spec :: Spec
+spec = describe "JavaLexer" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/java-lexer/test/Spec.hs
+++ b/code/packages/haskell/java-lexer/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import JavaLexerSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/java-parser/BUILD
+++ b/code/packages/haskell/java-parser/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/java-parser/BUILD_windows
+++ b/code/packages/haskell/java-parser/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/java-parser/CHANGELOG.md
+++ b/code/packages/haskell/java-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/java-parser/README.md
+++ b/code/packages/haskell/java-parser/README.md
@@ -1,0 +1,11 @@
+# java-parser
+
+Haskell starter wrapper for java-parser built on the generic parser package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer, parser, java-lexer

--- a/code/packages/haskell/java-parser/cabal.project
+++ b/code/packages/haskell/java-parser/cabal.project
@@ -1,0 +1,8 @@
+packages:
+  .
+  ../parser
+  ../graph
+  ../directed-graph
+  ../state-machine
+  ../lexer
+  ../java-lexer

--- a/code/packages/haskell/java-parser/java-parser.cabal
+++ b/code/packages/haskell/java-parser/java-parser.cabal
@@ -1,0 +1,30 @@
+cabal-version: 3.0
+name:          java-parser
+version:       0.1.0
+synopsis:      Haskell starter wrapper for java-parser built on the generic parser package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  JavaParser
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+                    , parser
+                    , java-lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    JavaParserSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , java-parser
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/java-parser/src/JavaParser.hs
+++ b/code/packages/haskell/java-parser/src/JavaParser.hs
@@ -1,0 +1,32 @@
+module JavaParser
+    ( description
+    , JavaParserError(..)
+    , parseJavaTokens
+    , tokenizeAndParseJava
+    ) where
+
+import Lexer (LexerError, Token)
+import Parser (ASTNode, ParseError, parseTokens)
+import qualified JavaLexer
+
+-- Starter parser wrapper that composes the shared parser engine with the
+-- sibling lexer package for this language family.
+description :: String
+description = "Haskell starter wrapper for java-parser built on the generic parser package"
+
+data JavaParserError
+    = JavaParserLexerError LexerError
+    | JavaParserParseError ParseError
+    deriving (Eq, Show)
+
+parseJavaTokens :: [Token] -> Either ParseError ASTNode
+parseJavaTokens = parseTokens
+
+tokenizeAndParseJava :: String -> Either JavaParserError ASTNode
+tokenizeAndParseJava source =
+    case JavaLexer.tokenizeJava source of
+        Left err -> Left (JavaParserLexerError err)
+        Right tokens ->
+            case parseJavaTokens tokens of
+                Left err -> Left (JavaParserParseError err)
+                Right ast -> Right ast

--- a/code/packages/haskell/java-parser/test/JavaParserSpec.hs
+++ b/code/packages/haskell/java-parser/test/JavaParserSpec.hs
@@ -1,0 +1,9 @@
+module JavaParserSpec (spec) where
+
+import Test.Hspec
+import JavaParser
+
+spec :: Spec
+spec = describe "JavaParser" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/java-parser/test/Spec.hs
+++ b/code/packages/haskell/java-parser/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import JavaParserSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/javascript-lexer/BUILD
+++ b/code/packages/haskell/javascript-lexer/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/javascript-lexer/BUILD_windows
+++ b/code/packages/haskell/javascript-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/javascript-lexer/CHANGELOG.md
+++ b/code/packages/haskell/javascript-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/javascript-lexer/README.md
+++ b/code/packages/haskell/javascript-lexer/README.md
@@ -1,0 +1,11 @@
+# javascript-lexer
+
+Haskell starter wrapper for javascript-lexer built on the generic lexer package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer

--- a/code/packages/haskell/javascript-lexer/cabal.project
+++ b/code/packages/haskell/javascript-lexer/cabal.project
@@ -1,0 +1,6 @@
+packages:
+  .
+  ../lexer
+  ../graph
+  ../directed-graph
+  ../state-machine

--- a/code/packages/haskell/javascript-lexer/javascript-lexer.cabal
+++ b/code/packages/haskell/javascript-lexer/javascript-lexer.cabal
@@ -1,0 +1,28 @@
+cabal-version: 3.0
+name:          javascript-lexer
+version:       0.1.0
+synopsis:      Haskell starter wrapper for javascript-lexer built on the generic lexer package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  JavascriptLexer
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    JavascriptLexerSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , javascript-lexer
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/javascript-lexer/src/JavascriptLexer.hs
+++ b/code/packages/haskell/javascript-lexer/src/JavascriptLexer.hs
@@ -1,0 +1,18 @@
+module JavascriptLexer
+    ( description
+    , javascriptLexerKeywords
+    , tokenizeJavascript
+    ) where
+
+import Lexer (LexerConfig(..), LexerError, Token, defaultLexerConfig, tokenize)
+
+-- Thin wrapper around the shared lexer package so language-specific ports can
+-- grow their own keyword tables and token helpers incrementally.
+description :: String
+description = "Haskell starter wrapper for javascript-lexer built on the generic lexer package"
+
+javascriptLexerKeywords :: [String]
+javascriptLexerKeywords = []
+
+tokenizeJavascript :: String -> Either LexerError [Token]
+tokenizeJavascript = tokenize defaultLexerConfig {lexerKeywords = javascriptLexerKeywords}

--- a/code/packages/haskell/javascript-lexer/test/JavascriptLexerSpec.hs
+++ b/code/packages/haskell/javascript-lexer/test/JavascriptLexerSpec.hs
@@ -1,0 +1,9 @@
+module JavascriptLexerSpec (spec) where
+
+import Test.Hspec
+import JavascriptLexer
+
+spec :: Spec
+spec = describe "JavascriptLexer" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/javascript-lexer/test/Spec.hs
+++ b/code/packages/haskell/javascript-lexer/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import JavascriptLexerSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/javascript-parser/BUILD
+++ b/code/packages/haskell/javascript-parser/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/javascript-parser/BUILD_windows
+++ b/code/packages/haskell/javascript-parser/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/javascript-parser/CHANGELOG.md
+++ b/code/packages/haskell/javascript-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/javascript-parser/README.md
+++ b/code/packages/haskell/javascript-parser/README.md
@@ -1,0 +1,11 @@
+# javascript-parser
+
+Haskell starter wrapper for javascript-parser built on the generic parser package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer, parser, javascript-lexer

--- a/code/packages/haskell/javascript-parser/cabal.project
+++ b/code/packages/haskell/javascript-parser/cabal.project
@@ -1,0 +1,8 @@
+packages:
+  .
+  ../parser
+  ../graph
+  ../directed-graph
+  ../state-machine
+  ../lexer
+  ../javascript-lexer

--- a/code/packages/haskell/javascript-parser/javascript-parser.cabal
+++ b/code/packages/haskell/javascript-parser/javascript-parser.cabal
@@ -1,0 +1,30 @@
+cabal-version: 3.0
+name:          javascript-parser
+version:       0.1.0
+synopsis:      Haskell starter wrapper for javascript-parser built on the generic parser package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  JavascriptParser
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+                    , parser
+                    , javascript-lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    JavascriptParserSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , javascript-parser
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/javascript-parser/src/JavascriptParser.hs
+++ b/code/packages/haskell/javascript-parser/src/JavascriptParser.hs
@@ -1,0 +1,32 @@
+module JavascriptParser
+    ( description
+    , JavascriptParserError(..)
+    , parseJavascriptTokens
+    , tokenizeAndParseJavascript
+    ) where
+
+import Lexer (LexerError, Token)
+import Parser (ASTNode, ParseError, parseTokens)
+import qualified JavascriptLexer
+
+-- Starter parser wrapper that composes the shared parser engine with the
+-- sibling lexer package for this language family.
+description :: String
+description = "Haskell starter wrapper for javascript-parser built on the generic parser package"
+
+data JavascriptParserError
+    = JavascriptParserLexerError LexerError
+    | JavascriptParserParseError ParseError
+    deriving (Eq, Show)
+
+parseJavascriptTokens :: [Token] -> Either ParseError ASTNode
+parseJavascriptTokens = parseTokens
+
+tokenizeAndParseJavascript :: String -> Either JavascriptParserError ASTNode
+tokenizeAndParseJavascript source =
+    case JavascriptLexer.tokenizeJavascript source of
+        Left err -> Left (JavascriptParserLexerError err)
+        Right tokens ->
+            case parseJavascriptTokens tokens of
+                Left err -> Left (JavascriptParserParseError err)
+                Right ast -> Right ast

--- a/code/packages/haskell/javascript-parser/test/JavascriptParserSpec.hs
+++ b/code/packages/haskell/javascript-parser/test/JavascriptParserSpec.hs
@@ -1,0 +1,9 @@
+module JavascriptParserSpec (spec) where
+
+import Test.Hspec
+import JavascriptParser
+
+spec :: Spec
+spec = describe "JavascriptParser" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/javascript-parser/test/Spec.hs
+++ b/code/packages/haskell/javascript-parser/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import JavascriptParserSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/json-lexer/BUILD
+++ b/code/packages/haskell/json-lexer/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/json-lexer/BUILD_windows
+++ b/code/packages/haskell/json-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/json-lexer/CHANGELOG.md
+++ b/code/packages/haskell/json-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/json-lexer/README.md
+++ b/code/packages/haskell/json-lexer/README.md
@@ -1,0 +1,11 @@
+# json-lexer
+
+Haskell starter wrapper for json-lexer built on the generic lexer package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer

--- a/code/packages/haskell/json-lexer/cabal.project
+++ b/code/packages/haskell/json-lexer/cabal.project
@@ -1,0 +1,6 @@
+packages:
+  .
+  ../lexer
+  ../graph
+  ../directed-graph
+  ../state-machine

--- a/code/packages/haskell/json-lexer/json-lexer.cabal
+++ b/code/packages/haskell/json-lexer/json-lexer.cabal
@@ -1,0 +1,28 @@
+cabal-version: 3.0
+name:          json-lexer
+version:       0.1.0
+synopsis:      Haskell starter wrapper for json-lexer built on the generic lexer package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  JsonLexer
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    JsonLexerSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , json-lexer
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/json-lexer/src/JsonLexer.hs
+++ b/code/packages/haskell/json-lexer/src/JsonLexer.hs
@@ -1,0 +1,18 @@
+module JsonLexer
+    ( description
+    , jsonLexerKeywords
+    , tokenizeJson
+    ) where
+
+import Lexer (LexerConfig(..), LexerError, Token, defaultLexerConfig, tokenize)
+
+-- Thin wrapper around the shared lexer package so language-specific ports can
+-- grow their own keyword tables and token helpers incrementally.
+description :: String
+description = "Haskell starter wrapper for json-lexer built on the generic lexer package"
+
+jsonLexerKeywords :: [String]
+jsonLexerKeywords = []
+
+tokenizeJson :: String -> Either LexerError [Token]
+tokenizeJson = tokenize defaultLexerConfig {lexerKeywords = jsonLexerKeywords}

--- a/code/packages/haskell/json-lexer/test/JsonLexerSpec.hs
+++ b/code/packages/haskell/json-lexer/test/JsonLexerSpec.hs
@@ -1,0 +1,9 @@
+module JsonLexerSpec (spec) where
+
+import Test.Hspec
+import JsonLexer
+
+spec :: Spec
+spec = describe "JsonLexer" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/json-lexer/test/Spec.hs
+++ b/code/packages/haskell/json-lexer/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import JsonLexerSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/json-parser/BUILD
+++ b/code/packages/haskell/json-parser/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/json-parser/BUILD_windows
+++ b/code/packages/haskell/json-parser/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/json-parser/CHANGELOG.md
+++ b/code/packages/haskell/json-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/json-parser/README.md
+++ b/code/packages/haskell/json-parser/README.md
@@ -1,0 +1,11 @@
+# json-parser
+
+Haskell starter wrapper for json-parser built on the generic parser package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer, parser, json-lexer

--- a/code/packages/haskell/json-parser/cabal.project
+++ b/code/packages/haskell/json-parser/cabal.project
@@ -1,0 +1,8 @@
+packages:
+  .
+  ../parser
+  ../graph
+  ../directed-graph
+  ../state-machine
+  ../lexer
+  ../json-lexer

--- a/code/packages/haskell/json-parser/json-parser.cabal
+++ b/code/packages/haskell/json-parser/json-parser.cabal
@@ -1,0 +1,30 @@
+cabal-version: 3.0
+name:          json-parser
+version:       0.1.0
+synopsis:      Haskell starter wrapper for json-parser built on the generic parser package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  JsonParser
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+                    , parser
+                    , json-lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    JsonParserSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , json-parser
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/json-parser/src/JsonParser.hs
+++ b/code/packages/haskell/json-parser/src/JsonParser.hs
@@ -1,0 +1,32 @@
+module JsonParser
+    ( description
+    , JsonParserError(..)
+    , parseJsonTokens
+    , tokenizeAndParseJson
+    ) where
+
+import Lexer (LexerError, Token)
+import Parser (ASTNode, ParseError, parseTokens)
+import qualified JsonLexer
+
+-- Starter parser wrapper that composes the shared parser engine with the
+-- sibling lexer package for this language family.
+description :: String
+description = "Haskell starter wrapper for json-parser built on the generic parser package"
+
+data JsonParserError
+    = JsonParserLexerError LexerError
+    | JsonParserParseError ParseError
+    deriving (Eq, Show)
+
+parseJsonTokens :: [Token] -> Either ParseError ASTNode
+parseJsonTokens = parseTokens
+
+tokenizeAndParseJson :: String -> Either JsonParserError ASTNode
+tokenizeAndParseJson source =
+    case JsonLexer.tokenizeJson source of
+        Left err -> Left (JsonParserLexerError err)
+        Right tokens ->
+            case parseJsonTokens tokens of
+                Left err -> Left (JsonParserParseError err)
+                Right ast -> Right ast

--- a/code/packages/haskell/json-parser/test/JsonParserSpec.hs
+++ b/code/packages/haskell/json-parser/test/JsonParserSpec.hs
@@ -1,0 +1,9 @@
+module JsonParserSpec (spec) where
+
+import Test.Hspec
+import JsonParser
+
+spec :: Spec
+spec = describe "JsonParser" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/json-parser/test/Spec.hs
+++ b/code/packages/haskell/json-parser/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import JsonParserSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/lattice-lexer/BUILD
+++ b/code/packages/haskell/lattice-lexer/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/lattice-lexer/BUILD_windows
+++ b/code/packages/haskell/lattice-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/lattice-lexer/CHANGELOG.md
+++ b/code/packages/haskell/lattice-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/lattice-lexer/README.md
+++ b/code/packages/haskell/lattice-lexer/README.md
@@ -1,0 +1,11 @@
+# lattice-lexer
+
+Haskell starter wrapper for lattice-lexer built on the generic lexer package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer

--- a/code/packages/haskell/lattice-lexer/cabal.project
+++ b/code/packages/haskell/lattice-lexer/cabal.project
@@ -1,0 +1,6 @@
+packages:
+  .
+  ../lexer
+  ../graph
+  ../directed-graph
+  ../state-machine

--- a/code/packages/haskell/lattice-lexer/lattice-lexer.cabal
+++ b/code/packages/haskell/lattice-lexer/lattice-lexer.cabal
@@ -1,0 +1,28 @@
+cabal-version: 3.0
+name:          lattice-lexer
+version:       0.1.0
+synopsis:      Haskell starter wrapper for lattice-lexer built on the generic lexer package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  LatticeLexer
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    LatticeLexerSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , lattice-lexer
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/lattice-lexer/src/LatticeLexer.hs
+++ b/code/packages/haskell/lattice-lexer/src/LatticeLexer.hs
@@ -1,0 +1,18 @@
+module LatticeLexer
+    ( description
+    , latticeLexerKeywords
+    , tokenizeLattice
+    ) where
+
+import Lexer (LexerConfig(..), LexerError, Token, defaultLexerConfig, tokenize)
+
+-- Thin wrapper around the shared lexer package so language-specific ports can
+-- grow their own keyword tables and token helpers incrementally.
+description :: String
+description = "Haskell starter wrapper for lattice-lexer built on the generic lexer package"
+
+latticeLexerKeywords :: [String]
+latticeLexerKeywords = []
+
+tokenizeLattice :: String -> Either LexerError [Token]
+tokenizeLattice = tokenize defaultLexerConfig {lexerKeywords = latticeLexerKeywords}

--- a/code/packages/haskell/lattice-lexer/test/LatticeLexerSpec.hs
+++ b/code/packages/haskell/lattice-lexer/test/LatticeLexerSpec.hs
@@ -1,0 +1,9 @@
+module LatticeLexerSpec (spec) where
+
+import Test.Hspec
+import LatticeLexer
+
+spec :: Spec
+spec = describe "LatticeLexer" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/lattice-lexer/test/Spec.hs
+++ b/code/packages/haskell/lattice-lexer/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import LatticeLexerSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/lattice-parser/BUILD
+++ b/code/packages/haskell/lattice-parser/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/lattice-parser/BUILD_windows
+++ b/code/packages/haskell/lattice-parser/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/lattice-parser/CHANGELOG.md
+++ b/code/packages/haskell/lattice-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/lattice-parser/README.md
+++ b/code/packages/haskell/lattice-parser/README.md
@@ -1,0 +1,11 @@
+# lattice-parser
+
+Haskell starter wrapper for lattice-parser built on the generic parser package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer, parser, lattice-lexer

--- a/code/packages/haskell/lattice-parser/cabal.project
+++ b/code/packages/haskell/lattice-parser/cabal.project
@@ -1,0 +1,8 @@
+packages:
+  .
+  ../parser
+  ../graph
+  ../directed-graph
+  ../state-machine
+  ../lexer
+  ../lattice-lexer

--- a/code/packages/haskell/lattice-parser/lattice-parser.cabal
+++ b/code/packages/haskell/lattice-parser/lattice-parser.cabal
@@ -1,0 +1,30 @@
+cabal-version: 3.0
+name:          lattice-parser
+version:       0.1.0
+synopsis:      Haskell starter wrapper for lattice-parser built on the generic parser package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  LatticeParser
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+                    , parser
+                    , lattice-lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    LatticeParserSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , lattice-parser
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/lattice-parser/src/LatticeParser.hs
+++ b/code/packages/haskell/lattice-parser/src/LatticeParser.hs
@@ -1,0 +1,32 @@
+module LatticeParser
+    ( description
+    , LatticeParserError(..)
+    , parseLatticeTokens
+    , tokenizeAndParseLattice
+    ) where
+
+import Lexer (LexerError, Token)
+import Parser (ASTNode, ParseError, parseTokens)
+import qualified LatticeLexer
+
+-- Starter parser wrapper that composes the shared parser engine with the
+-- sibling lexer package for this language family.
+description :: String
+description = "Haskell starter wrapper for lattice-parser built on the generic parser package"
+
+data LatticeParserError
+    = LatticeParserLexerError LexerError
+    | LatticeParserParseError ParseError
+    deriving (Eq, Show)
+
+parseLatticeTokens :: [Token] -> Either ParseError ASTNode
+parseLatticeTokens = parseTokens
+
+tokenizeAndParseLattice :: String -> Either LatticeParserError ASTNode
+tokenizeAndParseLattice source =
+    case LatticeLexer.tokenizeLattice source of
+        Left err -> Left (LatticeParserLexerError err)
+        Right tokens ->
+            case parseLatticeTokens tokens of
+                Left err -> Left (LatticeParserParseError err)
+                Right ast -> Right ast

--- a/code/packages/haskell/lattice-parser/test/LatticeParserSpec.hs
+++ b/code/packages/haskell/lattice-parser/test/LatticeParserSpec.hs
@@ -1,0 +1,9 @@
+module LatticeParserSpec (spec) where
+
+import Test.Hspec
+import LatticeParser
+
+spec :: Spec
+spec = describe "LatticeParser" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/lattice-parser/test/Spec.hs
+++ b/code/packages/haskell/lattice-parser/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import LatticeParserSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/lisp-lexer/BUILD
+++ b/code/packages/haskell/lisp-lexer/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/lisp-lexer/BUILD_windows
+++ b/code/packages/haskell/lisp-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/lisp-lexer/CHANGELOG.md
+++ b/code/packages/haskell/lisp-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/lisp-lexer/README.md
+++ b/code/packages/haskell/lisp-lexer/README.md
@@ -1,0 +1,11 @@
+# lisp-lexer
+
+Haskell starter wrapper for lisp-lexer built on the generic lexer package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer

--- a/code/packages/haskell/lisp-lexer/cabal.project
+++ b/code/packages/haskell/lisp-lexer/cabal.project
@@ -1,0 +1,6 @@
+packages:
+  .
+  ../lexer
+  ../graph
+  ../directed-graph
+  ../state-machine

--- a/code/packages/haskell/lisp-lexer/lisp-lexer.cabal
+++ b/code/packages/haskell/lisp-lexer/lisp-lexer.cabal
@@ -1,0 +1,28 @@
+cabal-version: 3.0
+name:          lisp-lexer
+version:       0.1.0
+synopsis:      Haskell starter wrapper for lisp-lexer built on the generic lexer package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  LispLexer
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    LispLexerSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , lisp-lexer
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/lisp-lexer/src/LispLexer.hs
+++ b/code/packages/haskell/lisp-lexer/src/LispLexer.hs
@@ -1,0 +1,18 @@
+module LispLexer
+    ( description
+    , lispLexerKeywords
+    , tokenizeLisp
+    ) where
+
+import Lexer (LexerConfig(..), LexerError, Token, defaultLexerConfig, tokenize)
+
+-- Thin wrapper around the shared lexer package so language-specific ports can
+-- grow their own keyword tables and token helpers incrementally.
+description :: String
+description = "Haskell starter wrapper for lisp-lexer built on the generic lexer package"
+
+lispLexerKeywords :: [String]
+lispLexerKeywords = []
+
+tokenizeLisp :: String -> Either LexerError [Token]
+tokenizeLisp = tokenize defaultLexerConfig {lexerKeywords = lispLexerKeywords}

--- a/code/packages/haskell/lisp-lexer/test/LispLexerSpec.hs
+++ b/code/packages/haskell/lisp-lexer/test/LispLexerSpec.hs
@@ -1,0 +1,9 @@
+module LispLexerSpec (spec) where
+
+import Test.Hspec
+import LispLexer
+
+spec :: Spec
+spec = describe "LispLexer" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/lisp-lexer/test/Spec.hs
+++ b/code/packages/haskell/lisp-lexer/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import LispLexerSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/lisp-parser/BUILD
+++ b/code/packages/haskell/lisp-parser/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/lisp-parser/BUILD_windows
+++ b/code/packages/haskell/lisp-parser/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/lisp-parser/CHANGELOG.md
+++ b/code/packages/haskell/lisp-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/lisp-parser/README.md
+++ b/code/packages/haskell/lisp-parser/README.md
@@ -1,0 +1,11 @@
+# lisp-parser
+
+Haskell starter wrapper for lisp-parser built on the generic parser package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer, parser, lisp-lexer

--- a/code/packages/haskell/lisp-parser/cabal.project
+++ b/code/packages/haskell/lisp-parser/cabal.project
@@ -1,0 +1,8 @@
+packages:
+  .
+  ../parser
+  ../graph
+  ../directed-graph
+  ../state-machine
+  ../lexer
+  ../lisp-lexer

--- a/code/packages/haskell/lisp-parser/lisp-parser.cabal
+++ b/code/packages/haskell/lisp-parser/lisp-parser.cabal
@@ -1,0 +1,30 @@
+cabal-version: 3.0
+name:          lisp-parser
+version:       0.1.0
+synopsis:      Haskell starter wrapper for lisp-parser built on the generic parser package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  LispParser
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+                    , parser
+                    , lisp-lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    LispParserSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , lisp-parser
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/lisp-parser/src/LispParser.hs
+++ b/code/packages/haskell/lisp-parser/src/LispParser.hs
@@ -1,0 +1,32 @@
+module LispParser
+    ( description
+    , LispParserError(..)
+    , parseLispTokens
+    , tokenizeAndParseLisp
+    ) where
+
+import Lexer (LexerError, Token)
+import Parser (ASTNode, ParseError, parseTokens)
+import qualified LispLexer
+
+-- Starter parser wrapper that composes the shared parser engine with the
+-- sibling lexer package for this language family.
+description :: String
+description = "Haskell starter wrapper for lisp-parser built on the generic parser package"
+
+data LispParserError
+    = LispParserLexerError LexerError
+    | LispParserParseError ParseError
+    deriving (Eq, Show)
+
+parseLispTokens :: [Token] -> Either ParseError ASTNode
+parseLispTokens = parseTokens
+
+tokenizeAndParseLisp :: String -> Either LispParserError ASTNode
+tokenizeAndParseLisp source =
+    case LispLexer.tokenizeLisp source of
+        Left err -> Left (LispParserLexerError err)
+        Right tokens ->
+            case parseLispTokens tokens of
+                Left err -> Left (LispParserParseError err)
+                Right ast -> Right ast

--- a/code/packages/haskell/lisp-parser/test/LispParserSpec.hs
+++ b/code/packages/haskell/lisp-parser/test/LispParserSpec.hs
@@ -1,0 +1,9 @@
+module LispParserSpec (spec) where
+
+import Test.Hspec
+import LispParser
+
+spec :: Spec
+spec = describe "LispParser" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/lisp-parser/test/Spec.hs
+++ b/code/packages/haskell/lisp-parser/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import LispParserSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/mosaic-lexer/BUILD
+++ b/code/packages/haskell/mosaic-lexer/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/mosaic-lexer/BUILD_windows
+++ b/code/packages/haskell/mosaic-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/mosaic-lexer/CHANGELOG.md
+++ b/code/packages/haskell/mosaic-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/mosaic-lexer/README.md
+++ b/code/packages/haskell/mosaic-lexer/README.md
@@ -1,0 +1,11 @@
+# mosaic-lexer
+
+Haskell starter wrapper for mosaic-lexer built on the generic lexer package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer

--- a/code/packages/haskell/mosaic-lexer/cabal.project
+++ b/code/packages/haskell/mosaic-lexer/cabal.project
@@ -1,0 +1,6 @@
+packages:
+  .
+  ../lexer
+  ../graph
+  ../directed-graph
+  ../state-machine

--- a/code/packages/haskell/mosaic-lexer/mosaic-lexer.cabal
+++ b/code/packages/haskell/mosaic-lexer/mosaic-lexer.cabal
@@ -1,0 +1,28 @@
+cabal-version: 3.0
+name:          mosaic-lexer
+version:       0.1.0
+synopsis:      Haskell starter wrapper for mosaic-lexer built on the generic lexer package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  MosaicLexer
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    MosaicLexerSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , mosaic-lexer
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/mosaic-lexer/src/MosaicLexer.hs
+++ b/code/packages/haskell/mosaic-lexer/src/MosaicLexer.hs
@@ -1,0 +1,18 @@
+module MosaicLexer
+    ( description
+    , mosaicLexerKeywords
+    , tokenizeMosaic
+    ) where
+
+import Lexer (LexerConfig(..), LexerError, Token, defaultLexerConfig, tokenize)
+
+-- Thin wrapper around the shared lexer package so language-specific ports can
+-- grow their own keyword tables and token helpers incrementally.
+description :: String
+description = "Haskell starter wrapper for mosaic-lexer built on the generic lexer package"
+
+mosaicLexerKeywords :: [String]
+mosaicLexerKeywords = []
+
+tokenizeMosaic :: String -> Either LexerError [Token]
+tokenizeMosaic = tokenize defaultLexerConfig {lexerKeywords = mosaicLexerKeywords}

--- a/code/packages/haskell/mosaic-lexer/test/MosaicLexerSpec.hs
+++ b/code/packages/haskell/mosaic-lexer/test/MosaicLexerSpec.hs
@@ -1,0 +1,9 @@
+module MosaicLexerSpec (spec) where
+
+import Test.Hspec
+import MosaicLexer
+
+spec :: Spec
+spec = describe "MosaicLexer" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/mosaic-lexer/test/Spec.hs
+++ b/code/packages/haskell/mosaic-lexer/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import MosaicLexerSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/mosaic-parser/BUILD
+++ b/code/packages/haskell/mosaic-parser/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/mosaic-parser/BUILD_windows
+++ b/code/packages/haskell/mosaic-parser/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/mosaic-parser/CHANGELOG.md
+++ b/code/packages/haskell/mosaic-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/mosaic-parser/README.md
+++ b/code/packages/haskell/mosaic-parser/README.md
@@ -1,0 +1,11 @@
+# mosaic-parser
+
+Haskell starter wrapper for mosaic-parser built on the generic parser package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer, parser, mosaic-lexer

--- a/code/packages/haskell/mosaic-parser/cabal.project
+++ b/code/packages/haskell/mosaic-parser/cabal.project
@@ -1,0 +1,8 @@
+packages:
+  .
+  ../parser
+  ../graph
+  ../directed-graph
+  ../state-machine
+  ../lexer
+  ../mosaic-lexer

--- a/code/packages/haskell/mosaic-parser/mosaic-parser.cabal
+++ b/code/packages/haskell/mosaic-parser/mosaic-parser.cabal
@@ -1,0 +1,30 @@
+cabal-version: 3.0
+name:          mosaic-parser
+version:       0.1.0
+synopsis:      Haskell starter wrapper for mosaic-parser built on the generic parser package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  MosaicParser
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+                    , parser
+                    , mosaic-lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    MosaicParserSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , mosaic-parser
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/mosaic-parser/src/MosaicParser.hs
+++ b/code/packages/haskell/mosaic-parser/src/MosaicParser.hs
@@ -1,0 +1,32 @@
+module MosaicParser
+    ( description
+    , MosaicParserError(..)
+    , parseMosaicTokens
+    , tokenizeAndParseMosaic
+    ) where
+
+import Lexer (LexerError, Token)
+import Parser (ASTNode, ParseError, parseTokens)
+import qualified MosaicLexer
+
+-- Starter parser wrapper that composes the shared parser engine with the
+-- sibling lexer package for this language family.
+description :: String
+description = "Haskell starter wrapper for mosaic-parser built on the generic parser package"
+
+data MosaicParserError
+    = MosaicParserLexerError LexerError
+    | MosaicParserParseError ParseError
+    deriving (Eq, Show)
+
+parseMosaicTokens :: [Token] -> Either ParseError ASTNode
+parseMosaicTokens = parseTokens
+
+tokenizeAndParseMosaic :: String -> Either MosaicParserError ASTNode
+tokenizeAndParseMosaic source =
+    case MosaicLexer.tokenizeMosaic source of
+        Left err -> Left (MosaicParserLexerError err)
+        Right tokens ->
+            case parseMosaicTokens tokens of
+                Left err -> Left (MosaicParserParseError err)
+                Right ast -> Right ast

--- a/code/packages/haskell/mosaic-parser/test/MosaicParserSpec.hs
+++ b/code/packages/haskell/mosaic-parser/test/MosaicParserSpec.hs
@@ -1,0 +1,9 @@
+module MosaicParserSpec (spec) where
+
+import Test.Hspec
+import MosaicParser
+
+spec :: Spec
+spec = describe "MosaicParser" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/mosaic-parser/test/Spec.hs
+++ b/code/packages/haskell/mosaic-parser/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import MosaicParserSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/nib-lexer/BUILD
+++ b/code/packages/haskell/nib-lexer/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/nib-lexer/BUILD_windows
+++ b/code/packages/haskell/nib-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/nib-lexer/CHANGELOG.md
+++ b/code/packages/haskell/nib-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/nib-lexer/README.md
+++ b/code/packages/haskell/nib-lexer/README.md
@@ -1,0 +1,11 @@
+# nib-lexer
+
+Haskell starter wrapper for nib-lexer built on the generic lexer package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer

--- a/code/packages/haskell/nib-lexer/cabal.project
+++ b/code/packages/haskell/nib-lexer/cabal.project
@@ -1,0 +1,6 @@
+packages:
+  .
+  ../lexer
+  ../graph
+  ../directed-graph
+  ../state-machine

--- a/code/packages/haskell/nib-lexer/nib-lexer.cabal
+++ b/code/packages/haskell/nib-lexer/nib-lexer.cabal
@@ -1,0 +1,28 @@
+cabal-version: 3.0
+name:          nib-lexer
+version:       0.1.0
+synopsis:      Haskell starter wrapper for nib-lexer built on the generic lexer package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  NibLexer
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    NibLexerSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , nib-lexer
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/nib-lexer/src/NibLexer.hs
+++ b/code/packages/haskell/nib-lexer/src/NibLexer.hs
@@ -1,0 +1,18 @@
+module NibLexer
+    ( description
+    , nibLexerKeywords
+    , tokenizeNib
+    ) where
+
+import Lexer (LexerConfig(..), LexerError, Token, defaultLexerConfig, tokenize)
+
+-- Thin wrapper around the shared lexer package so language-specific ports can
+-- grow their own keyword tables and token helpers incrementally.
+description :: String
+description = "Haskell starter wrapper for nib-lexer built on the generic lexer package"
+
+nibLexerKeywords :: [String]
+nibLexerKeywords = []
+
+tokenizeNib :: String -> Either LexerError [Token]
+tokenizeNib = tokenize defaultLexerConfig {lexerKeywords = nibLexerKeywords}

--- a/code/packages/haskell/nib-lexer/test/NibLexerSpec.hs
+++ b/code/packages/haskell/nib-lexer/test/NibLexerSpec.hs
@@ -1,0 +1,9 @@
+module NibLexerSpec (spec) where
+
+import Test.Hspec
+import NibLexer
+
+spec :: Spec
+spec = describe "NibLexer" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/nib-lexer/test/Spec.hs
+++ b/code/packages/haskell/nib-lexer/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import NibLexerSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/nib-parser/BUILD
+++ b/code/packages/haskell/nib-parser/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/nib-parser/BUILD_windows
+++ b/code/packages/haskell/nib-parser/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/nib-parser/CHANGELOG.md
+++ b/code/packages/haskell/nib-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/nib-parser/README.md
+++ b/code/packages/haskell/nib-parser/README.md
@@ -1,0 +1,11 @@
+# nib-parser
+
+Haskell starter wrapper for nib-parser built on the generic parser package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer, parser, nib-lexer

--- a/code/packages/haskell/nib-parser/cabal.project
+++ b/code/packages/haskell/nib-parser/cabal.project
@@ -1,0 +1,8 @@
+packages:
+  .
+  ../parser
+  ../graph
+  ../directed-graph
+  ../state-machine
+  ../lexer
+  ../nib-lexer

--- a/code/packages/haskell/nib-parser/nib-parser.cabal
+++ b/code/packages/haskell/nib-parser/nib-parser.cabal
@@ -1,0 +1,30 @@
+cabal-version: 3.0
+name:          nib-parser
+version:       0.1.0
+synopsis:      Haskell starter wrapper for nib-parser built on the generic parser package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  NibParser
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+                    , parser
+                    , nib-lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    NibParserSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , nib-parser
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/nib-parser/src/NibParser.hs
+++ b/code/packages/haskell/nib-parser/src/NibParser.hs
@@ -1,0 +1,32 @@
+module NibParser
+    ( description
+    , NibParserError(..)
+    , parseNibTokens
+    , tokenizeAndParseNib
+    ) where
+
+import Lexer (LexerError, Token)
+import Parser (ASTNode, ParseError, parseTokens)
+import qualified NibLexer
+
+-- Starter parser wrapper that composes the shared parser engine with the
+-- sibling lexer package for this language family.
+description :: String
+description = "Haskell starter wrapper for nib-parser built on the generic parser package"
+
+data NibParserError
+    = NibParserLexerError LexerError
+    | NibParserParseError ParseError
+    deriving (Eq, Show)
+
+parseNibTokens :: [Token] -> Either ParseError ASTNode
+parseNibTokens = parseTokens
+
+tokenizeAndParseNib :: String -> Either NibParserError ASTNode
+tokenizeAndParseNib source =
+    case NibLexer.tokenizeNib source of
+        Left err -> Left (NibParserLexerError err)
+        Right tokens ->
+            case parseNibTokens tokens of
+                Left err -> Left (NibParserParseError err)
+                Right ast -> Right ast

--- a/code/packages/haskell/nib-parser/test/NibParserSpec.hs
+++ b/code/packages/haskell/nib-parser/test/NibParserSpec.hs
@@ -1,0 +1,9 @@
+module NibParserSpec (spec) where
+
+import Test.Hspec
+import NibParser
+
+spec :: Spec
+spec = describe "NibParser" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/nib-parser/test/Spec.hs
+++ b/code/packages/haskell/nib-parser/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import NibParserSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/python-lexer/BUILD
+++ b/code/packages/haskell/python-lexer/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/python-lexer/BUILD_windows
+++ b/code/packages/haskell/python-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/python-lexer/CHANGELOG.md
+++ b/code/packages/haskell/python-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/python-lexer/README.md
+++ b/code/packages/haskell/python-lexer/README.md
@@ -1,0 +1,11 @@
+# python-lexer
+
+Haskell starter wrapper for python-lexer built on the generic lexer package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer

--- a/code/packages/haskell/python-lexer/cabal.project
+++ b/code/packages/haskell/python-lexer/cabal.project
@@ -1,0 +1,6 @@
+packages:
+  .
+  ../lexer
+  ../graph
+  ../directed-graph
+  ../state-machine

--- a/code/packages/haskell/python-lexer/python-lexer.cabal
+++ b/code/packages/haskell/python-lexer/python-lexer.cabal
@@ -1,0 +1,28 @@
+cabal-version: 3.0
+name:          python-lexer
+version:       0.1.0
+synopsis:      Haskell starter wrapper for python-lexer built on the generic lexer package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  PythonLexer
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    PythonLexerSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , python-lexer
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/python-lexer/src/PythonLexer.hs
+++ b/code/packages/haskell/python-lexer/src/PythonLexer.hs
@@ -1,0 +1,18 @@
+module PythonLexer
+    ( description
+    , pythonLexerKeywords
+    , tokenizePython
+    ) where
+
+import Lexer (LexerConfig(..), LexerError, Token, defaultLexerConfig, tokenize)
+
+-- Thin wrapper around the shared lexer package so language-specific ports can
+-- grow their own keyword tables and token helpers incrementally.
+description :: String
+description = "Haskell starter wrapper for python-lexer built on the generic lexer package"
+
+pythonLexerKeywords :: [String]
+pythonLexerKeywords = []
+
+tokenizePython :: String -> Either LexerError [Token]
+tokenizePython = tokenize defaultLexerConfig {lexerKeywords = pythonLexerKeywords}

--- a/code/packages/haskell/python-lexer/test/PythonLexerSpec.hs
+++ b/code/packages/haskell/python-lexer/test/PythonLexerSpec.hs
@@ -1,0 +1,9 @@
+module PythonLexerSpec (spec) where
+
+import Test.Hspec
+import PythonLexer
+
+spec :: Spec
+spec = describe "PythonLexer" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/python-lexer/test/Spec.hs
+++ b/code/packages/haskell/python-lexer/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import PythonLexerSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/python-parser/BUILD
+++ b/code/packages/haskell/python-parser/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/python-parser/BUILD_windows
+++ b/code/packages/haskell/python-parser/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/python-parser/CHANGELOG.md
+++ b/code/packages/haskell/python-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/python-parser/README.md
+++ b/code/packages/haskell/python-parser/README.md
@@ -1,0 +1,11 @@
+# python-parser
+
+Haskell starter wrapper for python-parser built on the generic parser package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer, parser, python-lexer

--- a/code/packages/haskell/python-parser/cabal.project
+++ b/code/packages/haskell/python-parser/cabal.project
@@ -1,0 +1,8 @@
+packages:
+  .
+  ../parser
+  ../graph
+  ../directed-graph
+  ../state-machine
+  ../lexer
+  ../python-lexer

--- a/code/packages/haskell/python-parser/python-parser.cabal
+++ b/code/packages/haskell/python-parser/python-parser.cabal
@@ -1,0 +1,30 @@
+cabal-version: 3.0
+name:          python-parser
+version:       0.1.0
+synopsis:      Haskell starter wrapper for python-parser built on the generic parser package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  PythonParser
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+                    , parser
+                    , python-lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    PythonParserSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , python-parser
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/python-parser/src/PythonParser.hs
+++ b/code/packages/haskell/python-parser/src/PythonParser.hs
@@ -1,0 +1,32 @@
+module PythonParser
+    ( description
+    , PythonParserError(..)
+    , parsePythonTokens
+    , tokenizeAndParsePython
+    ) where
+
+import Lexer (LexerError, Token)
+import Parser (ASTNode, ParseError, parseTokens)
+import qualified PythonLexer
+
+-- Starter parser wrapper that composes the shared parser engine with the
+-- sibling lexer package for this language family.
+description :: String
+description = "Haskell starter wrapper for python-parser built on the generic parser package"
+
+data PythonParserError
+    = PythonParserLexerError LexerError
+    | PythonParserParseError ParseError
+    deriving (Eq, Show)
+
+parsePythonTokens :: [Token] -> Either ParseError ASTNode
+parsePythonTokens = parseTokens
+
+tokenizeAndParsePython :: String -> Either PythonParserError ASTNode
+tokenizeAndParsePython source =
+    case PythonLexer.tokenizePython source of
+        Left err -> Left (PythonParserLexerError err)
+        Right tokens ->
+            case parsePythonTokens tokens of
+                Left err -> Left (PythonParserParseError err)
+                Right ast -> Right ast

--- a/code/packages/haskell/python-parser/test/PythonParserSpec.hs
+++ b/code/packages/haskell/python-parser/test/PythonParserSpec.hs
@@ -1,0 +1,9 @@
+module PythonParserSpec (spec) where
+
+import Test.Hspec
+import PythonParser
+
+spec :: Spec
+spec = describe "PythonParser" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/python-parser/test/Spec.hs
+++ b/code/packages/haskell/python-parser/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import PythonParserSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/ruby-lexer/BUILD
+++ b/code/packages/haskell/ruby-lexer/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/ruby-lexer/BUILD_windows
+++ b/code/packages/haskell/ruby-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/ruby-lexer/CHANGELOG.md
+++ b/code/packages/haskell/ruby-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/ruby-lexer/README.md
+++ b/code/packages/haskell/ruby-lexer/README.md
@@ -1,0 +1,11 @@
+# ruby-lexer
+
+Haskell starter wrapper for ruby-lexer built on the generic lexer package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer

--- a/code/packages/haskell/ruby-lexer/cabal.project
+++ b/code/packages/haskell/ruby-lexer/cabal.project
@@ -1,0 +1,6 @@
+packages:
+  .
+  ../lexer
+  ../graph
+  ../directed-graph
+  ../state-machine

--- a/code/packages/haskell/ruby-lexer/ruby-lexer.cabal
+++ b/code/packages/haskell/ruby-lexer/ruby-lexer.cabal
@@ -1,0 +1,28 @@
+cabal-version: 3.0
+name:          ruby-lexer
+version:       0.1.0
+synopsis:      Haskell starter wrapper for ruby-lexer built on the generic lexer package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  RubyLexer
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    RubyLexerSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , ruby-lexer
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/ruby-lexer/src/RubyLexer.hs
+++ b/code/packages/haskell/ruby-lexer/src/RubyLexer.hs
@@ -1,0 +1,18 @@
+module RubyLexer
+    ( description
+    , rubyLexerKeywords
+    , tokenizeRuby
+    ) where
+
+import Lexer (LexerConfig(..), LexerError, Token, defaultLexerConfig, tokenize)
+
+-- Thin wrapper around the shared lexer package so language-specific ports can
+-- grow their own keyword tables and token helpers incrementally.
+description :: String
+description = "Haskell starter wrapper for ruby-lexer built on the generic lexer package"
+
+rubyLexerKeywords :: [String]
+rubyLexerKeywords = []
+
+tokenizeRuby :: String -> Either LexerError [Token]
+tokenizeRuby = tokenize defaultLexerConfig {lexerKeywords = rubyLexerKeywords}

--- a/code/packages/haskell/ruby-lexer/test/RubyLexerSpec.hs
+++ b/code/packages/haskell/ruby-lexer/test/RubyLexerSpec.hs
@@ -1,0 +1,9 @@
+module RubyLexerSpec (spec) where
+
+import Test.Hspec
+import RubyLexer
+
+spec :: Spec
+spec = describe "RubyLexer" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/ruby-lexer/test/Spec.hs
+++ b/code/packages/haskell/ruby-lexer/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import RubyLexerSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/ruby-parser/BUILD
+++ b/code/packages/haskell/ruby-parser/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/ruby-parser/BUILD_windows
+++ b/code/packages/haskell/ruby-parser/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/ruby-parser/CHANGELOG.md
+++ b/code/packages/haskell/ruby-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/ruby-parser/README.md
+++ b/code/packages/haskell/ruby-parser/README.md
@@ -1,0 +1,11 @@
+# ruby-parser
+
+Haskell starter wrapper for ruby-parser built on the generic parser package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer, parser, ruby-lexer

--- a/code/packages/haskell/ruby-parser/cabal.project
+++ b/code/packages/haskell/ruby-parser/cabal.project
@@ -1,0 +1,8 @@
+packages:
+  .
+  ../parser
+  ../graph
+  ../directed-graph
+  ../state-machine
+  ../lexer
+  ../ruby-lexer

--- a/code/packages/haskell/ruby-parser/ruby-parser.cabal
+++ b/code/packages/haskell/ruby-parser/ruby-parser.cabal
@@ -1,0 +1,30 @@
+cabal-version: 3.0
+name:          ruby-parser
+version:       0.1.0
+synopsis:      Haskell starter wrapper for ruby-parser built on the generic parser package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  RubyParser
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+                    , parser
+                    , ruby-lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    RubyParserSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , ruby-parser
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/ruby-parser/src/RubyParser.hs
+++ b/code/packages/haskell/ruby-parser/src/RubyParser.hs
@@ -1,0 +1,32 @@
+module RubyParser
+    ( description
+    , RubyParserError(..)
+    , parseRubyTokens
+    , tokenizeAndParseRuby
+    ) where
+
+import Lexer (LexerError, Token)
+import Parser (ASTNode, ParseError, parseTokens)
+import qualified RubyLexer
+
+-- Starter parser wrapper that composes the shared parser engine with the
+-- sibling lexer package for this language family.
+description :: String
+description = "Haskell starter wrapper for ruby-parser built on the generic parser package"
+
+data RubyParserError
+    = RubyParserLexerError LexerError
+    | RubyParserParseError ParseError
+    deriving (Eq, Show)
+
+parseRubyTokens :: [Token] -> Either ParseError ASTNode
+parseRubyTokens = parseTokens
+
+tokenizeAndParseRuby :: String -> Either RubyParserError ASTNode
+tokenizeAndParseRuby source =
+    case RubyLexer.tokenizeRuby source of
+        Left err -> Left (RubyParserLexerError err)
+        Right tokens ->
+            case parseRubyTokens tokens of
+                Left err -> Left (RubyParserParseError err)
+                Right ast -> Right ast

--- a/code/packages/haskell/ruby-parser/test/RubyParserSpec.hs
+++ b/code/packages/haskell/ruby-parser/test/RubyParserSpec.hs
@@ -1,0 +1,9 @@
+module RubyParserSpec (spec) where
+
+import Test.Hspec
+import RubyParser
+
+spec :: Spec
+spec = describe "RubyParser" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/ruby-parser/test/Spec.hs
+++ b/code/packages/haskell/ruby-parser/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import RubyParserSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/sql-lexer/BUILD
+++ b/code/packages/haskell/sql-lexer/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/sql-lexer/BUILD_windows
+++ b/code/packages/haskell/sql-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/sql-lexer/CHANGELOG.md
+++ b/code/packages/haskell/sql-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/sql-lexer/README.md
+++ b/code/packages/haskell/sql-lexer/README.md
@@ -1,0 +1,11 @@
+# sql-lexer
+
+Haskell starter wrapper for sql-lexer built on the generic lexer package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer

--- a/code/packages/haskell/sql-lexer/cabal.project
+++ b/code/packages/haskell/sql-lexer/cabal.project
@@ -1,0 +1,6 @@
+packages:
+  .
+  ../lexer
+  ../graph
+  ../directed-graph
+  ../state-machine

--- a/code/packages/haskell/sql-lexer/sql-lexer.cabal
+++ b/code/packages/haskell/sql-lexer/sql-lexer.cabal
@@ -1,0 +1,28 @@
+cabal-version: 3.0
+name:          sql-lexer
+version:       0.1.0
+synopsis:      Haskell starter wrapper for sql-lexer built on the generic lexer package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  SqlLexer
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    SqlLexerSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , sql-lexer
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/sql-lexer/src/SqlLexer.hs
+++ b/code/packages/haskell/sql-lexer/src/SqlLexer.hs
@@ -1,0 +1,18 @@
+module SqlLexer
+    ( description
+    , sqlLexerKeywords
+    , tokenizeSql
+    ) where
+
+import Lexer (LexerConfig(..), LexerError, Token, defaultLexerConfig, tokenize)
+
+-- Thin wrapper around the shared lexer package so language-specific ports can
+-- grow their own keyword tables and token helpers incrementally.
+description :: String
+description = "Haskell starter wrapper for sql-lexer built on the generic lexer package"
+
+sqlLexerKeywords :: [String]
+sqlLexerKeywords = []
+
+tokenizeSql :: String -> Either LexerError [Token]
+tokenizeSql = tokenize defaultLexerConfig {lexerKeywords = sqlLexerKeywords}

--- a/code/packages/haskell/sql-lexer/test/Spec.hs
+++ b/code/packages/haskell/sql-lexer/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import SqlLexerSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/sql-lexer/test/SqlLexerSpec.hs
+++ b/code/packages/haskell/sql-lexer/test/SqlLexerSpec.hs
@@ -1,0 +1,9 @@
+module SqlLexerSpec (spec) where
+
+import Test.Hspec
+import SqlLexer
+
+spec :: Spec
+spec = describe "SqlLexer" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/sql-parser/BUILD
+++ b/code/packages/haskell/sql-parser/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/sql-parser/BUILD_windows
+++ b/code/packages/haskell/sql-parser/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/sql-parser/CHANGELOG.md
+++ b/code/packages/haskell/sql-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/sql-parser/README.md
+++ b/code/packages/haskell/sql-parser/README.md
@@ -1,0 +1,11 @@
+# sql-parser
+
+Haskell starter wrapper for sql-parser built on the generic parser package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer, parser, sql-lexer

--- a/code/packages/haskell/sql-parser/cabal.project
+++ b/code/packages/haskell/sql-parser/cabal.project
@@ -1,0 +1,8 @@
+packages:
+  .
+  ../parser
+  ../graph
+  ../directed-graph
+  ../state-machine
+  ../lexer
+  ../sql-lexer

--- a/code/packages/haskell/sql-parser/sql-parser.cabal
+++ b/code/packages/haskell/sql-parser/sql-parser.cabal
@@ -1,0 +1,30 @@
+cabal-version: 3.0
+name:          sql-parser
+version:       0.1.0
+synopsis:      Haskell starter wrapper for sql-parser built on the generic parser package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  SqlParser
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+                    , parser
+                    , sql-lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    SqlParserSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , sql-parser
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/sql-parser/src/SqlParser.hs
+++ b/code/packages/haskell/sql-parser/src/SqlParser.hs
@@ -1,0 +1,32 @@
+module SqlParser
+    ( description
+    , SqlParserError(..)
+    , parseSqlTokens
+    , tokenizeAndParseSql
+    ) where
+
+import Lexer (LexerError, Token)
+import Parser (ASTNode, ParseError, parseTokens)
+import qualified SqlLexer
+
+-- Starter parser wrapper that composes the shared parser engine with the
+-- sibling lexer package for this language family.
+description :: String
+description = "Haskell starter wrapper for sql-parser built on the generic parser package"
+
+data SqlParserError
+    = SqlParserLexerError LexerError
+    | SqlParserParseError ParseError
+    deriving (Eq, Show)
+
+parseSqlTokens :: [Token] -> Either ParseError ASTNode
+parseSqlTokens = parseTokens
+
+tokenizeAndParseSql :: String -> Either SqlParserError ASTNode
+tokenizeAndParseSql source =
+    case SqlLexer.tokenizeSql source of
+        Left err -> Left (SqlParserLexerError err)
+        Right tokens ->
+            case parseSqlTokens tokens of
+                Left err -> Left (SqlParserParseError err)
+                Right ast -> Right ast

--- a/code/packages/haskell/sql-parser/test/Spec.hs
+++ b/code/packages/haskell/sql-parser/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import SqlParserSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/sql-parser/test/SqlParserSpec.hs
+++ b/code/packages/haskell/sql-parser/test/SqlParserSpec.hs
@@ -1,0 +1,9 @@
+module SqlParserSpec (spec) where
+
+import Test.Hspec
+import SqlParser
+
+spec :: Spec
+spec = describe "SqlParser" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/starlark-lexer/BUILD
+++ b/code/packages/haskell/starlark-lexer/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/starlark-lexer/BUILD_windows
+++ b/code/packages/haskell/starlark-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/starlark-lexer/CHANGELOG.md
+++ b/code/packages/haskell/starlark-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/starlark-lexer/README.md
+++ b/code/packages/haskell/starlark-lexer/README.md
@@ -1,0 +1,11 @@
+# starlark-lexer
+
+Haskell starter wrapper for starlark-lexer built on the generic lexer package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer

--- a/code/packages/haskell/starlark-lexer/cabal.project
+++ b/code/packages/haskell/starlark-lexer/cabal.project
@@ -1,0 +1,6 @@
+packages:
+  .
+  ../lexer
+  ../graph
+  ../directed-graph
+  ../state-machine

--- a/code/packages/haskell/starlark-lexer/src/StarlarkLexer.hs
+++ b/code/packages/haskell/starlark-lexer/src/StarlarkLexer.hs
@@ -1,0 +1,18 @@
+module StarlarkLexer
+    ( description
+    , starlarkLexerKeywords
+    , tokenizeStarlark
+    ) where
+
+import Lexer (LexerConfig(..), LexerError, Token, defaultLexerConfig, tokenize)
+
+-- Thin wrapper around the shared lexer package so language-specific ports can
+-- grow their own keyword tables and token helpers incrementally.
+description :: String
+description = "Haskell starter wrapper for starlark-lexer built on the generic lexer package"
+
+starlarkLexerKeywords :: [String]
+starlarkLexerKeywords = []
+
+tokenizeStarlark :: String -> Either LexerError [Token]
+tokenizeStarlark = tokenize defaultLexerConfig {lexerKeywords = starlarkLexerKeywords}

--- a/code/packages/haskell/starlark-lexer/starlark-lexer.cabal
+++ b/code/packages/haskell/starlark-lexer/starlark-lexer.cabal
@@ -1,0 +1,28 @@
+cabal-version: 3.0
+name:          starlark-lexer
+version:       0.1.0
+synopsis:      Haskell starter wrapper for starlark-lexer built on the generic lexer package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  StarlarkLexer
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    StarlarkLexerSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , starlark-lexer
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/starlark-lexer/test/Spec.hs
+++ b/code/packages/haskell/starlark-lexer/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import StarlarkLexerSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/starlark-lexer/test/StarlarkLexerSpec.hs
+++ b/code/packages/haskell/starlark-lexer/test/StarlarkLexerSpec.hs
@@ -1,0 +1,9 @@
+module StarlarkLexerSpec (spec) where
+
+import Test.Hspec
+import StarlarkLexer
+
+spec :: Spec
+spec = describe "StarlarkLexer" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/starlark-parser/BUILD
+++ b/code/packages/haskell/starlark-parser/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/starlark-parser/BUILD_windows
+++ b/code/packages/haskell/starlark-parser/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/starlark-parser/CHANGELOG.md
+++ b/code/packages/haskell/starlark-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/starlark-parser/README.md
+++ b/code/packages/haskell/starlark-parser/README.md
@@ -1,0 +1,11 @@
+# starlark-parser
+
+Haskell starter wrapper for starlark-parser built on the generic parser package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer, parser, starlark-lexer

--- a/code/packages/haskell/starlark-parser/cabal.project
+++ b/code/packages/haskell/starlark-parser/cabal.project
@@ -1,0 +1,8 @@
+packages:
+  .
+  ../parser
+  ../graph
+  ../directed-graph
+  ../state-machine
+  ../lexer
+  ../starlark-lexer

--- a/code/packages/haskell/starlark-parser/src/StarlarkParser.hs
+++ b/code/packages/haskell/starlark-parser/src/StarlarkParser.hs
@@ -1,0 +1,32 @@
+module StarlarkParser
+    ( description
+    , StarlarkParserError(..)
+    , parseStarlarkTokens
+    , tokenizeAndParseStarlark
+    ) where
+
+import Lexer (LexerError, Token)
+import Parser (ASTNode, ParseError, parseTokens)
+import qualified StarlarkLexer
+
+-- Starter parser wrapper that composes the shared parser engine with the
+-- sibling lexer package for this language family.
+description :: String
+description = "Haskell starter wrapper for starlark-parser built on the generic parser package"
+
+data StarlarkParserError
+    = StarlarkParserLexerError LexerError
+    | StarlarkParserParseError ParseError
+    deriving (Eq, Show)
+
+parseStarlarkTokens :: [Token] -> Either ParseError ASTNode
+parseStarlarkTokens = parseTokens
+
+tokenizeAndParseStarlark :: String -> Either StarlarkParserError ASTNode
+tokenizeAndParseStarlark source =
+    case StarlarkLexer.tokenizeStarlark source of
+        Left err -> Left (StarlarkParserLexerError err)
+        Right tokens ->
+            case parseStarlarkTokens tokens of
+                Left err -> Left (StarlarkParserParseError err)
+                Right ast -> Right ast

--- a/code/packages/haskell/starlark-parser/starlark-parser.cabal
+++ b/code/packages/haskell/starlark-parser/starlark-parser.cabal
@@ -1,0 +1,30 @@
+cabal-version: 3.0
+name:          starlark-parser
+version:       0.1.0
+synopsis:      Haskell starter wrapper for starlark-parser built on the generic parser package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  StarlarkParser
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+                    , parser
+                    , starlark-lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    StarlarkParserSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , starlark-parser
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/starlark-parser/test/Spec.hs
+++ b/code/packages/haskell/starlark-parser/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import StarlarkParserSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/starlark-parser/test/StarlarkParserSpec.hs
+++ b/code/packages/haskell/starlark-parser/test/StarlarkParserSpec.hs
@@ -1,0 +1,9 @@
+module StarlarkParserSpec (spec) where
+
+import Test.Hspec
+import StarlarkParser
+
+spec :: Spec
+spec = describe "StarlarkParser" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/toml-lexer/BUILD
+++ b/code/packages/haskell/toml-lexer/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/toml-lexer/BUILD_windows
+++ b/code/packages/haskell/toml-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/toml-lexer/CHANGELOG.md
+++ b/code/packages/haskell/toml-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/toml-lexer/README.md
+++ b/code/packages/haskell/toml-lexer/README.md
@@ -1,0 +1,11 @@
+# toml-lexer
+
+Haskell starter wrapper for toml-lexer built on the generic lexer package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer

--- a/code/packages/haskell/toml-lexer/cabal.project
+++ b/code/packages/haskell/toml-lexer/cabal.project
@@ -1,0 +1,6 @@
+packages:
+  .
+  ../lexer
+  ../graph
+  ../directed-graph
+  ../state-machine

--- a/code/packages/haskell/toml-lexer/src/TomlLexer.hs
+++ b/code/packages/haskell/toml-lexer/src/TomlLexer.hs
@@ -1,0 +1,18 @@
+module TomlLexer
+    ( description
+    , tomlLexerKeywords
+    , tokenizeToml
+    ) where
+
+import Lexer (LexerConfig(..), LexerError, Token, defaultLexerConfig, tokenize)
+
+-- Thin wrapper around the shared lexer package so language-specific ports can
+-- grow their own keyword tables and token helpers incrementally.
+description :: String
+description = "Haskell starter wrapper for toml-lexer built on the generic lexer package"
+
+tomlLexerKeywords :: [String]
+tomlLexerKeywords = []
+
+tokenizeToml :: String -> Either LexerError [Token]
+tokenizeToml = tokenize defaultLexerConfig {lexerKeywords = tomlLexerKeywords}

--- a/code/packages/haskell/toml-lexer/test/Spec.hs
+++ b/code/packages/haskell/toml-lexer/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import TomlLexerSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/toml-lexer/test/TomlLexerSpec.hs
+++ b/code/packages/haskell/toml-lexer/test/TomlLexerSpec.hs
@@ -1,0 +1,9 @@
+module TomlLexerSpec (spec) where
+
+import Test.Hspec
+import TomlLexer
+
+spec :: Spec
+spec = describe "TomlLexer" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/toml-lexer/toml-lexer.cabal
+++ b/code/packages/haskell/toml-lexer/toml-lexer.cabal
@@ -1,0 +1,28 @@
+cabal-version: 3.0
+name:          toml-lexer
+version:       0.1.0
+synopsis:      Haskell starter wrapper for toml-lexer built on the generic lexer package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  TomlLexer
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    TomlLexerSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , toml-lexer
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/toml-parser/BUILD
+++ b/code/packages/haskell/toml-parser/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/toml-parser/BUILD_windows
+++ b/code/packages/haskell/toml-parser/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/toml-parser/CHANGELOG.md
+++ b/code/packages/haskell/toml-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/toml-parser/README.md
+++ b/code/packages/haskell/toml-parser/README.md
@@ -1,0 +1,11 @@
+# toml-parser
+
+Haskell starter wrapper for toml-parser built on the generic parser package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer, parser, toml-lexer

--- a/code/packages/haskell/toml-parser/cabal.project
+++ b/code/packages/haskell/toml-parser/cabal.project
@@ -1,0 +1,8 @@
+packages:
+  .
+  ../parser
+  ../graph
+  ../directed-graph
+  ../state-machine
+  ../lexer
+  ../toml-lexer

--- a/code/packages/haskell/toml-parser/src/TomlParser.hs
+++ b/code/packages/haskell/toml-parser/src/TomlParser.hs
@@ -1,0 +1,32 @@
+module TomlParser
+    ( description
+    , TomlParserError(..)
+    , parseTomlTokens
+    , tokenizeAndParseToml
+    ) where
+
+import Lexer (LexerError, Token)
+import Parser (ASTNode, ParseError, parseTokens)
+import qualified TomlLexer
+
+-- Starter parser wrapper that composes the shared parser engine with the
+-- sibling lexer package for this language family.
+description :: String
+description = "Haskell starter wrapper for toml-parser built on the generic parser package"
+
+data TomlParserError
+    = TomlParserLexerError LexerError
+    | TomlParserParseError ParseError
+    deriving (Eq, Show)
+
+parseTomlTokens :: [Token] -> Either ParseError ASTNode
+parseTomlTokens = parseTokens
+
+tokenizeAndParseToml :: String -> Either TomlParserError ASTNode
+tokenizeAndParseToml source =
+    case TomlLexer.tokenizeToml source of
+        Left err -> Left (TomlParserLexerError err)
+        Right tokens ->
+            case parseTomlTokens tokens of
+                Left err -> Left (TomlParserParseError err)
+                Right ast -> Right ast

--- a/code/packages/haskell/toml-parser/test/Spec.hs
+++ b/code/packages/haskell/toml-parser/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import TomlParserSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/toml-parser/test/TomlParserSpec.hs
+++ b/code/packages/haskell/toml-parser/test/TomlParserSpec.hs
@@ -1,0 +1,9 @@
+module TomlParserSpec (spec) where
+
+import Test.Hspec
+import TomlParser
+
+spec :: Spec
+spec = describe "TomlParser" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/toml-parser/toml-parser.cabal
+++ b/code/packages/haskell/toml-parser/toml-parser.cabal
@@ -1,0 +1,30 @@
+cabal-version: 3.0
+name:          toml-parser
+version:       0.1.0
+synopsis:      Haskell starter wrapper for toml-parser built on the generic parser package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  TomlParser
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+                    , parser
+                    , toml-lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    TomlParserSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , toml-parser
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/typescript-lexer/BUILD
+++ b/code/packages/haskell/typescript-lexer/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/typescript-lexer/BUILD_windows
+++ b/code/packages/haskell/typescript-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/typescript-lexer/CHANGELOG.md
+++ b/code/packages/haskell/typescript-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/typescript-lexer/README.md
+++ b/code/packages/haskell/typescript-lexer/README.md
@@ -1,0 +1,11 @@
+# typescript-lexer
+
+Haskell starter wrapper for typescript-lexer built on the generic lexer package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer

--- a/code/packages/haskell/typescript-lexer/cabal.project
+++ b/code/packages/haskell/typescript-lexer/cabal.project
@@ -1,0 +1,6 @@
+packages:
+  .
+  ../lexer
+  ../graph
+  ../directed-graph
+  ../state-machine

--- a/code/packages/haskell/typescript-lexer/src/TypescriptLexer.hs
+++ b/code/packages/haskell/typescript-lexer/src/TypescriptLexer.hs
@@ -1,0 +1,18 @@
+module TypescriptLexer
+    ( description
+    , typescriptLexerKeywords
+    , tokenizeTypescript
+    ) where
+
+import Lexer (LexerConfig(..), LexerError, Token, defaultLexerConfig, tokenize)
+
+-- Thin wrapper around the shared lexer package so language-specific ports can
+-- grow their own keyword tables and token helpers incrementally.
+description :: String
+description = "Haskell starter wrapper for typescript-lexer built on the generic lexer package"
+
+typescriptLexerKeywords :: [String]
+typescriptLexerKeywords = []
+
+tokenizeTypescript :: String -> Either LexerError [Token]
+tokenizeTypescript = tokenize defaultLexerConfig {lexerKeywords = typescriptLexerKeywords}

--- a/code/packages/haskell/typescript-lexer/test/Spec.hs
+++ b/code/packages/haskell/typescript-lexer/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import TypescriptLexerSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/typescript-lexer/test/TypescriptLexerSpec.hs
+++ b/code/packages/haskell/typescript-lexer/test/TypescriptLexerSpec.hs
@@ -1,0 +1,9 @@
+module TypescriptLexerSpec (spec) where
+
+import Test.Hspec
+import TypescriptLexer
+
+spec :: Spec
+spec = describe "TypescriptLexer" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/typescript-lexer/typescript-lexer.cabal
+++ b/code/packages/haskell/typescript-lexer/typescript-lexer.cabal
@@ -1,0 +1,28 @@
+cabal-version: 3.0
+name:          typescript-lexer
+version:       0.1.0
+synopsis:      Haskell starter wrapper for typescript-lexer built on the generic lexer package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  TypescriptLexer
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    TypescriptLexerSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , typescript-lexer
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/typescript-parser/BUILD
+++ b/code/packages/haskell/typescript-parser/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/typescript-parser/BUILD_windows
+++ b/code/packages/haskell/typescript-parser/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/typescript-parser/CHANGELOG.md
+++ b/code/packages/haskell/typescript-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/typescript-parser/README.md
+++ b/code/packages/haskell/typescript-parser/README.md
@@ -1,0 +1,11 @@
+# typescript-parser
+
+Haskell starter wrapper for typescript-parser built on the generic parser package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer, parser, typescript-lexer

--- a/code/packages/haskell/typescript-parser/cabal.project
+++ b/code/packages/haskell/typescript-parser/cabal.project
@@ -1,0 +1,8 @@
+packages:
+  .
+  ../parser
+  ../graph
+  ../directed-graph
+  ../state-machine
+  ../lexer
+  ../typescript-lexer

--- a/code/packages/haskell/typescript-parser/src/TypescriptParser.hs
+++ b/code/packages/haskell/typescript-parser/src/TypescriptParser.hs
@@ -1,0 +1,32 @@
+module TypescriptParser
+    ( description
+    , TypescriptParserError(..)
+    , parseTypescriptTokens
+    , tokenizeAndParseTypescript
+    ) where
+
+import Lexer (LexerError, Token)
+import Parser (ASTNode, ParseError, parseTokens)
+import qualified TypescriptLexer
+
+-- Starter parser wrapper that composes the shared parser engine with the
+-- sibling lexer package for this language family.
+description :: String
+description = "Haskell starter wrapper for typescript-parser built on the generic parser package"
+
+data TypescriptParserError
+    = TypescriptParserLexerError LexerError
+    | TypescriptParserParseError ParseError
+    deriving (Eq, Show)
+
+parseTypescriptTokens :: [Token] -> Either ParseError ASTNode
+parseTypescriptTokens = parseTokens
+
+tokenizeAndParseTypescript :: String -> Either TypescriptParserError ASTNode
+tokenizeAndParseTypescript source =
+    case TypescriptLexer.tokenizeTypescript source of
+        Left err -> Left (TypescriptParserLexerError err)
+        Right tokens ->
+            case parseTypescriptTokens tokens of
+                Left err -> Left (TypescriptParserParseError err)
+                Right ast -> Right ast

--- a/code/packages/haskell/typescript-parser/test/Spec.hs
+++ b/code/packages/haskell/typescript-parser/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import TypescriptParserSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/typescript-parser/test/TypescriptParserSpec.hs
+++ b/code/packages/haskell/typescript-parser/test/TypescriptParserSpec.hs
@@ -1,0 +1,9 @@
+module TypescriptParserSpec (spec) where
+
+import Test.Hspec
+import TypescriptParser
+
+spec :: Spec
+spec = describe "TypescriptParser" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/typescript-parser/typescript-parser.cabal
+++ b/code/packages/haskell/typescript-parser/typescript-parser.cabal
@@ -1,0 +1,30 @@
+cabal-version: 3.0
+name:          typescript-parser
+version:       0.1.0
+synopsis:      Haskell starter wrapper for typescript-parser built on the generic parser package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  TypescriptParser
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+                    , parser
+                    , typescript-lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    TypescriptParserSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , typescript-parser
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/url-parser/BUILD
+++ b/code/packages/haskell/url-parser/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/url-parser/BUILD_windows
+++ b/code/packages/haskell/url-parser/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/url-parser/CHANGELOG.md
+++ b/code/packages/haskell/url-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/url-parser/README.md
+++ b/code/packages/haskell/url-parser/README.md
@@ -1,0 +1,11 @@
+# url-parser
+
+Haskell starter wrapper for url-parser built on the generic parser package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer, parser

--- a/code/packages/haskell/url-parser/cabal.project
+++ b/code/packages/haskell/url-parser/cabal.project
@@ -1,0 +1,7 @@
+packages:
+  .
+  ../parser
+  ../graph
+  ../directed-graph
+  ../state-machine
+  ../lexer

--- a/code/packages/haskell/url-parser/src/UrlParser.hs
+++ b/code/packages/haskell/url-parser/src/UrlParser.hs
@@ -1,0 +1,15 @@
+module UrlParser
+    ( description
+    , parseUrlTokens
+    ) where
+
+import Lexer (Token)
+import Parser (ASTNode, ParseError, parseTokens)
+
+-- Starter parser wrapper for grammars that do not yet have a sibling Haskell
+-- lexer package in this first porting wave.
+description :: String
+description = "Haskell starter wrapper for url-parser built on the generic parser package"
+
+parseUrlTokens :: [Token] -> Either ParseError ASTNode
+parseUrlTokens = parseTokens

--- a/code/packages/haskell/url-parser/test/Spec.hs
+++ b/code/packages/haskell/url-parser/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import UrlParserSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/url-parser/test/UrlParserSpec.hs
+++ b/code/packages/haskell/url-parser/test/UrlParserSpec.hs
@@ -1,0 +1,9 @@
+module UrlParserSpec (spec) where
+
+import Test.Hspec
+import UrlParser
+
+spec :: Spec
+spec = describe "UrlParser" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/url-parser/url-parser.cabal
+++ b/code/packages/haskell/url-parser/url-parser.cabal
@@ -1,0 +1,29 @@
+cabal-version: 3.0
+name:          url-parser
+version:       0.1.0
+synopsis:      Haskell starter wrapper for url-parser built on the generic parser package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  UrlParser
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+                    , parser
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    UrlParserSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , url-parser
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/verilog-lexer/BUILD
+++ b/code/packages/haskell/verilog-lexer/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/verilog-lexer/BUILD_windows
+++ b/code/packages/haskell/verilog-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/verilog-lexer/CHANGELOG.md
+++ b/code/packages/haskell/verilog-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/verilog-lexer/README.md
+++ b/code/packages/haskell/verilog-lexer/README.md
@@ -1,0 +1,11 @@
+# verilog-lexer
+
+Haskell starter wrapper for verilog-lexer built on the generic lexer package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer

--- a/code/packages/haskell/verilog-lexer/cabal.project
+++ b/code/packages/haskell/verilog-lexer/cabal.project
@@ -1,0 +1,6 @@
+packages:
+  .
+  ../lexer
+  ../graph
+  ../directed-graph
+  ../state-machine

--- a/code/packages/haskell/verilog-lexer/src/VerilogLexer.hs
+++ b/code/packages/haskell/verilog-lexer/src/VerilogLexer.hs
@@ -1,0 +1,18 @@
+module VerilogLexer
+    ( description
+    , verilogLexerKeywords
+    , tokenizeVerilog
+    ) where
+
+import Lexer (LexerConfig(..), LexerError, Token, defaultLexerConfig, tokenize)
+
+-- Thin wrapper around the shared lexer package so language-specific ports can
+-- grow their own keyword tables and token helpers incrementally.
+description :: String
+description = "Haskell starter wrapper for verilog-lexer built on the generic lexer package"
+
+verilogLexerKeywords :: [String]
+verilogLexerKeywords = []
+
+tokenizeVerilog :: String -> Either LexerError [Token]
+tokenizeVerilog = tokenize defaultLexerConfig {lexerKeywords = verilogLexerKeywords}

--- a/code/packages/haskell/verilog-lexer/test/Spec.hs
+++ b/code/packages/haskell/verilog-lexer/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import VerilogLexerSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/verilog-lexer/test/VerilogLexerSpec.hs
+++ b/code/packages/haskell/verilog-lexer/test/VerilogLexerSpec.hs
@@ -1,0 +1,9 @@
+module VerilogLexerSpec (spec) where
+
+import Test.Hspec
+import VerilogLexer
+
+spec :: Spec
+spec = describe "VerilogLexer" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/verilog-lexer/verilog-lexer.cabal
+++ b/code/packages/haskell/verilog-lexer/verilog-lexer.cabal
@@ -1,0 +1,28 @@
+cabal-version: 3.0
+name:          verilog-lexer
+version:       0.1.0
+synopsis:      Haskell starter wrapper for verilog-lexer built on the generic lexer package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  VerilogLexer
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    VerilogLexerSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , verilog-lexer
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/verilog-parser/BUILD
+++ b/code/packages/haskell/verilog-parser/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/verilog-parser/BUILD_windows
+++ b/code/packages/haskell/verilog-parser/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/verilog-parser/CHANGELOG.md
+++ b/code/packages/haskell/verilog-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/verilog-parser/README.md
+++ b/code/packages/haskell/verilog-parser/README.md
@@ -1,0 +1,11 @@
+# verilog-parser
+
+Haskell starter wrapper for verilog-parser built on the generic parser package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer, parser, verilog-lexer

--- a/code/packages/haskell/verilog-parser/cabal.project
+++ b/code/packages/haskell/verilog-parser/cabal.project
@@ -1,0 +1,8 @@
+packages:
+  .
+  ../parser
+  ../graph
+  ../directed-graph
+  ../state-machine
+  ../lexer
+  ../verilog-lexer

--- a/code/packages/haskell/verilog-parser/src/VerilogParser.hs
+++ b/code/packages/haskell/verilog-parser/src/VerilogParser.hs
@@ -1,0 +1,32 @@
+module VerilogParser
+    ( description
+    , VerilogParserError(..)
+    , parseVerilogTokens
+    , tokenizeAndParseVerilog
+    ) where
+
+import Lexer (LexerError, Token)
+import Parser (ASTNode, ParseError, parseTokens)
+import qualified VerilogLexer
+
+-- Starter parser wrapper that composes the shared parser engine with the
+-- sibling lexer package for this language family.
+description :: String
+description = "Haskell starter wrapper for verilog-parser built on the generic parser package"
+
+data VerilogParserError
+    = VerilogParserLexerError LexerError
+    | VerilogParserParseError ParseError
+    deriving (Eq, Show)
+
+parseVerilogTokens :: [Token] -> Either ParseError ASTNode
+parseVerilogTokens = parseTokens
+
+tokenizeAndParseVerilog :: String -> Either VerilogParserError ASTNode
+tokenizeAndParseVerilog source =
+    case VerilogLexer.tokenizeVerilog source of
+        Left err -> Left (VerilogParserLexerError err)
+        Right tokens ->
+            case parseVerilogTokens tokens of
+                Left err -> Left (VerilogParserParseError err)
+                Right ast -> Right ast

--- a/code/packages/haskell/verilog-parser/test/Spec.hs
+++ b/code/packages/haskell/verilog-parser/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import VerilogParserSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/verilog-parser/test/VerilogParserSpec.hs
+++ b/code/packages/haskell/verilog-parser/test/VerilogParserSpec.hs
@@ -1,0 +1,9 @@
+module VerilogParserSpec (spec) where
+
+import Test.Hspec
+import VerilogParser
+
+spec :: Spec
+spec = describe "VerilogParser" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/verilog-parser/verilog-parser.cabal
+++ b/code/packages/haskell/verilog-parser/verilog-parser.cabal
@@ -1,0 +1,30 @@
+cabal-version: 3.0
+name:          verilog-parser
+version:       0.1.0
+synopsis:      Haskell starter wrapper for verilog-parser built on the generic parser package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  VerilogParser
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+                    , parser
+                    , verilog-lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    VerilogParserSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , verilog-parser
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/vhdl-lexer/BUILD
+++ b/code/packages/haskell/vhdl-lexer/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/vhdl-lexer/BUILD_windows
+++ b/code/packages/haskell/vhdl-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/vhdl-lexer/CHANGELOG.md
+++ b/code/packages/haskell/vhdl-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/vhdl-lexer/README.md
+++ b/code/packages/haskell/vhdl-lexer/README.md
@@ -1,0 +1,11 @@
+# vhdl-lexer
+
+Haskell starter wrapper for vhdl-lexer built on the generic lexer package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer

--- a/code/packages/haskell/vhdl-lexer/cabal.project
+++ b/code/packages/haskell/vhdl-lexer/cabal.project
@@ -1,0 +1,6 @@
+packages:
+  .
+  ../lexer
+  ../graph
+  ../directed-graph
+  ../state-machine

--- a/code/packages/haskell/vhdl-lexer/src/VhdlLexer.hs
+++ b/code/packages/haskell/vhdl-lexer/src/VhdlLexer.hs
@@ -1,0 +1,18 @@
+module VhdlLexer
+    ( description
+    , vhdlLexerKeywords
+    , tokenizeVhdl
+    ) where
+
+import Lexer (LexerConfig(..), LexerError, Token, defaultLexerConfig, tokenize)
+
+-- Thin wrapper around the shared lexer package so language-specific ports can
+-- grow their own keyword tables and token helpers incrementally.
+description :: String
+description = "Haskell starter wrapper for vhdl-lexer built on the generic lexer package"
+
+vhdlLexerKeywords :: [String]
+vhdlLexerKeywords = []
+
+tokenizeVhdl :: String -> Either LexerError [Token]
+tokenizeVhdl = tokenize defaultLexerConfig {lexerKeywords = vhdlLexerKeywords}

--- a/code/packages/haskell/vhdl-lexer/test/Spec.hs
+++ b/code/packages/haskell/vhdl-lexer/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import VhdlLexerSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/vhdl-lexer/test/VhdlLexerSpec.hs
+++ b/code/packages/haskell/vhdl-lexer/test/VhdlLexerSpec.hs
@@ -1,0 +1,9 @@
+module VhdlLexerSpec (spec) where
+
+import Test.Hspec
+import VhdlLexer
+
+spec :: Spec
+spec = describe "VhdlLexer" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/vhdl-lexer/vhdl-lexer.cabal
+++ b/code/packages/haskell/vhdl-lexer/vhdl-lexer.cabal
@@ -1,0 +1,28 @@
+cabal-version: 3.0
+name:          vhdl-lexer
+version:       0.1.0
+synopsis:      Haskell starter wrapper for vhdl-lexer built on the generic lexer package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  VhdlLexer
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    VhdlLexerSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , vhdl-lexer
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/vhdl-parser/BUILD
+++ b/code/packages/haskell/vhdl-parser/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/vhdl-parser/BUILD_windows
+++ b/code/packages/haskell/vhdl-parser/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/vhdl-parser/CHANGELOG.md
+++ b/code/packages/haskell/vhdl-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/vhdl-parser/README.md
+++ b/code/packages/haskell/vhdl-parser/README.md
@@ -1,0 +1,11 @@
+# vhdl-parser
+
+Haskell starter wrapper for vhdl-parser built on the generic parser package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer, parser, vhdl-lexer

--- a/code/packages/haskell/vhdl-parser/cabal.project
+++ b/code/packages/haskell/vhdl-parser/cabal.project
@@ -1,0 +1,8 @@
+packages:
+  .
+  ../parser
+  ../graph
+  ../directed-graph
+  ../state-machine
+  ../lexer
+  ../vhdl-lexer

--- a/code/packages/haskell/vhdl-parser/src/VhdlParser.hs
+++ b/code/packages/haskell/vhdl-parser/src/VhdlParser.hs
@@ -1,0 +1,32 @@
+module VhdlParser
+    ( description
+    , VhdlParserError(..)
+    , parseVhdlTokens
+    , tokenizeAndParseVhdl
+    ) where
+
+import Lexer (LexerError, Token)
+import Parser (ASTNode, ParseError, parseTokens)
+import qualified VhdlLexer
+
+-- Starter parser wrapper that composes the shared parser engine with the
+-- sibling lexer package for this language family.
+description :: String
+description = "Haskell starter wrapper for vhdl-parser built on the generic parser package"
+
+data VhdlParserError
+    = VhdlParserLexerError LexerError
+    | VhdlParserParseError ParseError
+    deriving (Eq, Show)
+
+parseVhdlTokens :: [Token] -> Either ParseError ASTNode
+parseVhdlTokens = parseTokens
+
+tokenizeAndParseVhdl :: String -> Either VhdlParserError ASTNode
+tokenizeAndParseVhdl source =
+    case VhdlLexer.tokenizeVhdl source of
+        Left err -> Left (VhdlParserLexerError err)
+        Right tokens ->
+            case parseVhdlTokens tokens of
+                Left err -> Left (VhdlParserParseError err)
+                Right ast -> Right ast

--- a/code/packages/haskell/vhdl-parser/test/Spec.hs
+++ b/code/packages/haskell/vhdl-parser/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import VhdlParserSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/vhdl-parser/test/VhdlParserSpec.hs
+++ b/code/packages/haskell/vhdl-parser/test/VhdlParserSpec.hs
@@ -1,0 +1,9 @@
+module VhdlParserSpec (spec) where
+
+import Test.Hspec
+import VhdlParser
+
+spec :: Spec
+spec = describe "VhdlParser" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/vhdl-parser/vhdl-parser.cabal
+++ b/code/packages/haskell/vhdl-parser/vhdl-parser.cabal
@@ -1,0 +1,30 @@
+cabal-version: 3.0
+name:          vhdl-parser
+version:       0.1.0
+synopsis:      Haskell starter wrapper for vhdl-parser built on the generic parser package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  VhdlParser
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+                    , parser
+                    , vhdl-lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    VhdlParserSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , vhdl-parser
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/wasm-module-parser/BUILD
+++ b/code/packages/haskell/wasm-module-parser/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/wasm-module-parser/BUILD_windows
+++ b/code/packages/haskell/wasm-module-parser/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/wasm-module-parser/CHANGELOG.md
+++ b/code/packages/haskell/wasm-module-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/wasm-module-parser/README.md
+++ b/code/packages/haskell/wasm-module-parser/README.md
@@ -1,0 +1,11 @@
+# wasm-module-parser
+
+Haskell starter wrapper for wasm-module-parser built on the generic parser package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer, parser

--- a/code/packages/haskell/wasm-module-parser/cabal.project
+++ b/code/packages/haskell/wasm-module-parser/cabal.project
@@ -1,0 +1,7 @@
+packages:
+  .
+  ../parser
+  ../graph
+  ../directed-graph
+  ../state-machine
+  ../lexer

--- a/code/packages/haskell/wasm-module-parser/src/WasmModuleParser.hs
+++ b/code/packages/haskell/wasm-module-parser/src/WasmModuleParser.hs
@@ -1,0 +1,15 @@
+module WasmModuleParser
+    ( description
+    , parseWasmModuleTokens
+    ) where
+
+import Lexer (Token)
+import Parser (ASTNode, ParseError, parseTokens)
+
+-- Starter parser wrapper for grammars that do not yet have a sibling Haskell
+-- lexer package in this first porting wave.
+description :: String
+description = "Haskell starter wrapper for wasm-module-parser built on the generic parser package"
+
+parseWasmModuleTokens :: [Token] -> Either ParseError ASTNode
+parseWasmModuleTokens = parseTokens

--- a/code/packages/haskell/wasm-module-parser/test/Spec.hs
+++ b/code/packages/haskell/wasm-module-parser/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import WasmModuleParserSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/wasm-module-parser/test/WasmModuleParserSpec.hs
+++ b/code/packages/haskell/wasm-module-parser/test/WasmModuleParserSpec.hs
@@ -1,0 +1,9 @@
+module WasmModuleParserSpec (spec) where
+
+import Test.Hspec
+import WasmModuleParser
+
+spec :: Spec
+spec = describe "WasmModuleParser" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/wasm-module-parser/wasm-module-parser.cabal
+++ b/code/packages/haskell/wasm-module-parser/wasm-module-parser.cabal
@@ -1,0 +1,29 @@
+cabal-version: 3.0
+name:          wasm-module-parser
+version:       0.1.0
+synopsis:      Haskell starter wrapper for wasm-module-parser built on the generic parser package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  WasmModuleParser
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+                    , parser
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    WasmModuleParserSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , wasm-module-parser
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/xml-lexer/BUILD
+++ b/code/packages/haskell/xml-lexer/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/xml-lexer/BUILD_windows
+++ b/code/packages/haskell/xml-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/xml-lexer/CHANGELOG.md
+++ b/code/packages/haskell/xml-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/xml-lexer/README.md
+++ b/code/packages/haskell/xml-lexer/README.md
@@ -1,0 +1,11 @@
+# xml-lexer
+
+Haskell starter wrapper for xml-lexer built on the generic lexer package
+
+## Type
+
+library
+
+## Dependencies
+
+graph, directed-graph, state-machine, lexer

--- a/code/packages/haskell/xml-lexer/cabal.project
+++ b/code/packages/haskell/xml-lexer/cabal.project
@@ -1,0 +1,6 @@
+packages:
+  .
+  ../lexer
+  ../graph
+  ../directed-graph
+  ../state-machine

--- a/code/packages/haskell/xml-lexer/src/XmlLexer.hs
+++ b/code/packages/haskell/xml-lexer/src/XmlLexer.hs
@@ -1,0 +1,18 @@
+module XmlLexer
+    ( description
+    , xmlLexerKeywords
+    , tokenizeXml
+    ) where
+
+import Lexer (LexerConfig(..), LexerError, Token, defaultLexerConfig, tokenize)
+
+-- Thin wrapper around the shared lexer package so language-specific ports can
+-- grow their own keyword tables and token helpers incrementally.
+description :: String
+description = "Haskell starter wrapper for xml-lexer built on the generic lexer package"
+
+xmlLexerKeywords :: [String]
+xmlLexerKeywords = []
+
+tokenizeXml :: String -> Either LexerError [Token]
+tokenizeXml = tokenize defaultLexerConfig {lexerKeywords = xmlLexerKeywords}

--- a/code/packages/haskell/xml-lexer/test/Spec.hs
+++ b/code/packages/haskell/xml-lexer/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import XmlLexerSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/xml-lexer/test/XmlLexerSpec.hs
+++ b/code/packages/haskell/xml-lexer/test/XmlLexerSpec.hs
@@ -1,0 +1,9 @@
+module XmlLexerSpec (spec) where
+
+import Test.Hspec
+import XmlLexer
+
+spec :: Spec
+spec = describe "XmlLexer" $ do
+    it "exposes a non-empty starter description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/xml-lexer/xml-lexer.cabal
+++ b/code/packages/haskell/xml-lexer/xml-lexer.cabal
@@ -1,0 +1,28 @@
+cabal-version: 3.0
+name:          xml-lexer
+version:       0.1.0
+synopsis:      Haskell starter wrapper for xml-lexer built on the generic lexer package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  XmlLexer
+    build-depends:    base >=4.14
+                    , graph
+                    , directed-graph
+                    , state-machine
+                    , lexer
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    XmlLexerSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , xml-lexer
+                    , hspec == 2.*
+    default-language: Haskell2010


### PR DESCRIPTION
## Summary
- add scaffolded Haskell `*-lexer` and `*-parser` packages
- wire the generated packages to the shared Haskell `lexer` and `parser` base packages
- include local Cabal project wiring and starter tests for the scaffold batch

## Notes
- this PR is intentionally limited to scaffolding and shared-wrapper setup
- grammar-specific implementations will follow in a separate PR

## Validation
- `cabal build`
- `cabal test --enable-tests`