### PR TITLE
Add JVM Algol lexer and parser packages

### DIFF
--- a/code/packages/java/algol-lexer/.gitignore
+++ b/code/packages/java/algol-lexer/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/java/algol-lexer/BUILD
+++ b/code/packages/java/algol-lexer/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/algol-lexer/BUILD_windows
+++ b/code/packages/java/algol-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/algol-lexer/CHANGELOG.md
+++ b/code/packages/java/algol-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# algol-lexer
+
+## 0.1.0
+
+- add runtime grammar-backed ALGOL 60 tokenization with version selection

--- a/code/packages/java/algol-lexer/README.md
+++ b/code/packages/java/algol-lexer/README.md
@@ -1,0 +1,14 @@
+# algol-lexer
+
+Grammar-backed ALGOL 60 lexer for Java with support for the bundled `algol60` token grammar.
+
+## Dependencies
+
+- grammar-tools
+- lexer
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/java/algol-lexer/build.gradle.kts
+++ b/code/packages/java/algol-lexer/build.gradle.kts
@@ -1,0 +1,37 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+sourceSets {
+    named("main") {
+        resources.srcDir("../../../grammars/algol")
+        resources.include("algol*.tokens")
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    api("com.codingadventures:grammar-tools")
+    api("com.codingadventures:lexer")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/algol-lexer/required_capabilities.json
+++ b/code/packages/java/algol-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "java/algol-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/java/algol-lexer/settings.gradle.kts
+++ b/code/packages/java/algol-lexer/settings.gradle.kts
@@ -1,0 +1,4 @@
+rootProject.name = "algol-lexer"
+
+includeBuild("../grammar-tools")
+includeBuild("../lexer")

--- a/code/packages/java/algol-lexer/src/main/java/com/codingadventures/algollexer/AlgolLexer.java
+++ b/code/packages/java/algol-lexer/src/main/java/com/codingadventures/algollexer/AlgolLexer.java
@@ -1,0 +1,80 @@
+package com.codingadventures.algollexer;
+
+import com.codingadventures.grammartools.TokenGrammar;
+import com.codingadventures.grammartools.TokenGrammarError;
+import com.codingadventures.grammartools.TokenGrammarParser;
+import com.codingadventures.lexer.GrammarLexer;
+import com.codingadventures.lexer.LexerError;
+import com.codingadventures.lexer.Token;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class AlgolLexer {
+    public static final String DEFAULT_VERSION = "algol60";
+    public static final List<String> SUPPORTED_VERSIONS = List.of("algol60");
+
+    private static final Map<String, TokenGrammar> TOKEN_GRAMMARS = new ConcurrentHashMap<>();
+
+    private AlgolLexer() {}
+
+    public static GrammarLexer createAlgolLexer() {
+        return createAlgolLexer(DEFAULT_VERSION);
+    }
+
+    public static GrammarLexer createAlgolLexer(String version) {
+        return new GrammarLexer(loadTokenGrammar(version));
+    }
+
+    public static List<Token> tokenizeAlgol(String source) {
+        return tokenizeAlgol(source, DEFAULT_VERSION);
+    }
+
+    public static List<Token> tokenizeAlgol(String source, String version) {
+        try {
+            return createAlgolLexer(version).tokenize(source);
+        } catch (LexerError error) {
+            throw new IllegalArgumentException("ALGOL tokenization failed: " + error.getMessage(), error);
+        }
+    }
+
+    private static TokenGrammar loadTokenGrammar(String version) {
+        String validated = validateVersion(version);
+        return TOKEN_GRAMMARS.computeIfAbsent(validated, AlgolLexer::parseTokenGrammarResource);
+    }
+
+    private static String validateVersion(String version) {
+        if (version == null || version.isBlank()) {
+            return DEFAULT_VERSION;
+        }
+        if (!SUPPORTED_VERSIONS.contains(version)) {
+            throw new IllegalArgumentException(
+                    "Unknown ALGOL version '" + version + "'. Valid values: " + String.join(", ", SUPPORTED_VERSIONS)
+            );
+        }
+        return version;
+    }
+
+    private static TokenGrammar parseTokenGrammarResource(String version) {
+        try {
+            return TokenGrammarParser.parse(readResource(version + ".tokens"));
+        } catch (TokenGrammarError error) {
+            throw new IllegalStateException("Failed to parse bundled ALGOL token grammar for version " + version, error);
+        }
+    }
+
+    private static String readResource(String resourceName) {
+        try (InputStream stream = AlgolLexer.class.getClassLoader().getResourceAsStream(resourceName)) {
+            if (stream == null) {
+                throw new IllegalStateException("Missing bundled resource: " + resourceName);
+            }
+            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException error) {
+            throw new IllegalStateException("Failed to read bundled resource: " + resourceName, error);
+        }
+    }
+}

--- a/code/packages/java/algol-lexer/src/test/java/com/codingadventures/algollexer/AlgolLexerTest.java
+++ b/code/packages/java/algol-lexer/src/test/java/com/codingadventures/algollexer/AlgolLexerTest.java
@@ -1,0 +1,49 @@
+package com.codingadventures.algollexer;
+
+import com.codingadventures.lexer.Token;
+import com.codingadventures.lexer.TokenType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AlgolLexerTest {
+    @Test
+    void tokenizesAssignmentStatement() {
+        List<Token> tokens = AlgolLexer.tokenizeAlgol("begin integer x; x := 42 end");
+
+        assertEquals(TokenType.KEYWORD, tokens.get(0).getType());
+        assertEquals("begin", tokens.get(0).getValue());
+        assertEquals(TokenType.KEYWORD, tokens.get(1).getType());
+        assertEquals("integer", tokens.get(1).getValue());
+        assertEquals("NAME", tokens.get(2).effectiveTypeName());
+        assertEquals("x", tokens.get(2).getValue());
+        assertEquals("NAME", tokens.get(4).effectiveTypeName());
+        assertEquals("x", tokens.get(4).getValue());
+        assertEquals("ASSIGN", tokens.get(5).effectiveTypeName());
+        assertEquals(":=", tokens.get(5).getValue());
+        assertEquals("INTEGER_LIT", tokens.get(6).effectiveTypeName());
+        assertEquals("42", tokens.get(6).getValue());
+    }
+
+    @Test
+    void defaultVersionMatchesExplicitAlgol60() {
+        List<Token> defaultTokens = AlgolLexer.tokenizeAlgol("begin integer x; x := 42 end");
+        List<Token> explicitTokens = AlgolLexer.tokenizeAlgol("begin integer x; x := 42 end", "algol60");
+
+        assertEquals(defaultTokens, explicitTokens);
+    }
+
+    @Test
+    void rejectsUnknownVersion() {
+        IllegalArgumentException error = assertThrows(
+                IllegalArgumentException.class,
+                () -> AlgolLexer.tokenizeAlgol("begin integer x; x := 42 end", "algol68")
+        );
+
+        assertTrue(error.getMessage().contains("Unknown ALGOL version"));
+    }
+}

--- a/code/packages/java/algol-parser/.gitignore
+++ b/code/packages/java/algol-parser/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/java/algol-parser/BUILD
+++ b/code/packages/java/algol-parser/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/algol-parser/BUILD_windows
+++ b/code/packages/java/algol-parser/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/algol-parser/CHANGELOG.md
+++ b/code/packages/java/algol-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# algol-parser
+
+## 0.1.0
+
+- add runtime grammar-backed ALGOL 60 parsing with version selection

--- a/code/packages/java/algol-parser/README.md
+++ b/code/packages/java/algol-parser/README.md
@@ -1,0 +1,16 @@
+# algol-parser
+
+Grammar-backed ALGOL 60 parser for Java with support for the bundled `algol60` parser grammar.
+
+## Dependencies
+
+- grammar-tools
+- lexer
+- parser
+- algol-lexer
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/java/algol-parser/build.gradle.kts
+++ b/code/packages/java/algol-parser/build.gradle.kts
@@ -1,0 +1,39 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+sourceSets {
+    named("main") {
+        resources.srcDir("../../../grammars/algol")
+        resources.include("algol*.grammar")
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    api("com.codingadventures:grammar-tools")
+    api("com.codingadventures:lexer")
+    api("com.codingadventures:parser")
+    api("com.codingadventures:algol-lexer")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/algol-parser/required_capabilities.json
+++ b/code/packages/java/algol-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "java/algol-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/java/algol-parser/settings.gradle.kts
+++ b/code/packages/java/algol-parser/settings.gradle.kts
@@ -1,0 +1,6 @@
+rootProject.name = "algol-parser"
+
+includeBuild("../grammar-tools")
+includeBuild("../lexer")
+includeBuild("../parser")
+includeBuild("../algol-lexer")

--- a/code/packages/java/algol-parser/src/main/java/com/codingadventures/algolparser/AlgolParser.java
+++ b/code/packages/java/algol-parser/src/main/java/com/codingadventures/algolparser/AlgolParser.java
@@ -1,0 +1,81 @@
+package com.codingadventures.algolparser;
+
+import com.codingadventures.grammartools.ParserGrammar;
+import com.codingadventures.grammartools.ParserGrammarError;
+import com.codingadventures.grammartools.ParserGrammarParser;
+import com.codingadventures.parser.ASTNode;
+import com.codingadventures.parser.GrammarParseError;
+import com.codingadventures.parser.GrammarParser;
+import com.codingadventures.algollexer.AlgolLexer;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class AlgolParser {
+    public static final String DEFAULT_VERSION = AlgolLexer.DEFAULT_VERSION;
+    public static final List<String> SUPPORTED_VERSIONS = AlgolLexer.SUPPORTED_VERSIONS;
+
+    private static final Map<String, ParserGrammar> PARSER_GRAMMARS = new ConcurrentHashMap<>();
+
+    private AlgolParser() {}
+
+    public static GrammarParser createAlgolParser() {
+        return createAlgolParser(DEFAULT_VERSION);
+    }
+
+    public static GrammarParser createAlgolParser(String version) {
+        return new GrammarParser(loadParserGrammar(version));
+    }
+
+    public static ASTNode parseAlgol(String source) {
+        return parseAlgol(source, DEFAULT_VERSION);
+    }
+
+    public static ASTNode parseAlgol(String source, String version) {
+        try {
+            return createAlgolParser(version).parse(AlgolLexer.tokenizeAlgol(source, version));
+        } catch (GrammarParseError error) {
+            throw new IllegalArgumentException("ALGOL parse failed: " + error.getMessage(), error);
+        }
+    }
+
+    private static ParserGrammar loadParserGrammar(String version) {
+        String validated = validateVersion(version);
+        return PARSER_GRAMMARS.computeIfAbsent(validated, AlgolParser::parseParserGrammarResource);
+    }
+
+    private static String validateVersion(String version) {
+        if (version == null || version.isBlank()) {
+            return DEFAULT_VERSION;
+        }
+        if (!SUPPORTED_VERSIONS.contains(version)) {
+            throw new IllegalArgumentException(
+                    "Unknown ALGOL version '" + version + "'. Valid values: " + String.join(", ", SUPPORTED_VERSIONS)
+            );
+        }
+        return version;
+    }
+
+    private static ParserGrammar parseParserGrammarResource(String version) {
+        try {
+            return ParserGrammarParser.parse(readResource(version + ".grammar"));
+        } catch (ParserGrammarError error) {
+            throw new IllegalStateException("Failed to parse bundled ALGOL parser grammar for version " + version, error);
+        }
+    }
+
+    private static String readResource(String resourceName) {
+        try (InputStream stream = AlgolParser.class.getClassLoader().getResourceAsStream(resourceName)) {
+            if (stream == null) {
+                throw new IllegalStateException("Missing bundled resource: " + resourceName);
+            }
+            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException error) {
+            throw new IllegalStateException("Failed to read bundled resource: " + resourceName, error);
+        }
+    }
+}

--- a/code/packages/java/algol-parser/src/test/java/com/codingadventures/algolparser/AlgolParserTest.java
+++ b/code/packages/java/algol-parser/src/test/java/com/codingadventures/algolparser/AlgolParserTest.java
@@ -1,0 +1,36 @@
+package com.codingadventures.algolparser;
+
+import com.codingadventures.parser.ASTNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AlgolParserTest {
+    @Test
+    void parsesMinimalProgram() {
+        ASTNode ast = AlgolParser.parseAlgol("begin integer x; x := 42 end");
+
+        assertEquals("program", ast.getRuleName());
+        assertTrue(ast.descendantCount() > 0);
+    }
+
+    @Test
+    void defaultVersionMatchesExplicitAlgol60() {
+        ASTNode defaultAst = AlgolParser.parseAlgol("begin integer x; x := 42 end");
+        ASTNode explicitAst = AlgolParser.parseAlgol("begin integer x; x := 42 end", "algol60");
+
+        assertEquals(defaultAst.getRuleName(), explicitAst.getRuleName());
+    }
+
+    @Test
+    void rejectsUnknownVersion() {
+        IllegalArgumentException error = assertThrows(
+                IllegalArgumentException.class,
+                () -> AlgolParser.parseAlgol("begin integer x; x := 42 end", "algol68")
+        );
+
+        assertTrue(error.getMessage().contains("Unknown ALGOL version"));
+    }
+}

--- a/code/packages/kotlin/algol-lexer/.gitignore
+++ b/code/packages/kotlin/algol-lexer/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/kotlin/algol-lexer/BUILD
+++ b/code/packages/kotlin/algol-lexer/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/algol-lexer/BUILD_windows
+++ b/code/packages/kotlin/algol-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/algol-lexer/CHANGELOG.md
+++ b/code/packages/kotlin/algol-lexer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# algol-lexer
+
+## 0.1.0
+
+- add runtime grammar-backed ALGOL 60 tokenization with version selection

--- a/code/packages/kotlin/algol-lexer/README.md
+++ b/code/packages/kotlin/algol-lexer/README.md
@@ -1,0 +1,14 @@
+# algol-lexer
+
+Grammar-backed ALGOL 60 lexer for Kotlin with support for the bundled `algol60` token grammar.
+
+## Dependencies
+
+- grammar-tools
+- lexer
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/kotlin/algol-lexer/build.gradle.kts
+++ b/code/packages/kotlin/algol-lexer/build.gradle.kts
@@ -1,0 +1,44 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+sourceSets {
+    named("main") {
+        resources.srcDir("../../../grammars/algol")
+        resources.include("algol*.tokens")
+    }
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    api("com.codingadventures:grammar-tools")
+    api("com.codingadventures:lexer")
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/algol-lexer/required_capabilities.json
+++ b/code/packages/kotlin/algol-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "kotlin/algol-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/kotlin/algol-lexer/settings.gradle.kts
+++ b/code/packages/kotlin/algol-lexer/settings.gradle.kts
@@ -1,0 +1,4 @@
+rootProject.name = "algol-lexer"
+
+includeBuild("../grammar-tools")
+includeBuild("../lexer")

--- a/code/packages/kotlin/algol-lexer/src/main/kotlin/com/codingadventures/algollexer/AlgolLexer.kt
+++ b/code/packages/kotlin/algol-lexer/src/main/kotlin/com/codingadventures/algollexer/AlgolLexer.kt
@@ -1,0 +1,42 @@
+package com.codingadventures.algollexer
+
+import com.codingadventures.grammartools.TokenGrammar
+import com.codingadventures.grammartools.parseTokenGrammar
+import com.codingadventures.lexer.GrammarLexer
+import com.codingadventures.lexer.Token
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.ConcurrentHashMap
+
+object AlgolLexer {
+    const val DEFAULT_VERSION = "algol60"
+    val SUPPORTED_VERSIONS: List<String> = listOf("algol60")
+
+    private val tokenGrammars = ConcurrentHashMap<String, TokenGrammar>()
+
+    fun createAlgolLexer(version: String = DEFAULT_VERSION): GrammarLexer =
+        GrammarLexer(loadTokenGrammar(version))
+
+    fun tokenizeAlgol(source: String, version: String = DEFAULT_VERSION): List<Token> =
+        createAlgolLexer(version).tokenize(source)
+
+    private fun loadTokenGrammar(version: String): TokenGrammar {
+        val validated = validateVersion(version)
+        return tokenGrammars.computeIfAbsent(validated) { parseTokenGrammar(readResource("$it.tokens")) }
+    }
+
+    private fun validateVersion(version: String?): String {
+        if (version.isNullOrBlank()) {
+            return DEFAULT_VERSION
+        }
+        require(version in SUPPORTED_VERSIONS) {
+            "Unknown ALGOL version '$version'. Valid values: ${SUPPORTED_VERSIONS.joinToString(", ")}"
+        }
+        return version
+    }
+
+    private fun readResource(resourceName: String): String {
+        val stream = javaClass.classLoader.getResourceAsStream(resourceName)
+            ?: error("Missing bundled resource: $resourceName")
+        return stream.use { String(it.readAllBytes(), StandardCharsets.UTF_8) }
+    }
+}

--- a/code/packages/kotlin/algol-lexer/src/test/kotlin/com/codingadventures/algollexer/AlgolLexerTest.kt
+++ b/code/packages/kotlin/algol-lexer/src/test/kotlin/com/codingadventures/algollexer/AlgolLexerTest.kt
@@ -1,0 +1,44 @@
+package com.codingadventures.algollexer
+
+import com.codingadventures.lexer.TokenType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class AlgolLexerTest {
+    @Test
+    fun tokenizesAssignmentStatement() {
+        val tokens = AlgolLexer.tokenizeAlgol("begin integer x; x := 42 end")
+
+        assertEquals(TokenType.KEYWORD, tokens[0].type)
+        assertEquals("begin", tokens[0].value)
+        assertEquals(TokenType.KEYWORD, tokens[1].type)
+        assertEquals("integer", tokens[1].value)
+        assertEquals("NAME", tokens[2].effectiveTypeName())
+        assertEquals("x", tokens[2].value)
+        assertEquals("NAME", tokens[4].effectiveTypeName())
+        assertEquals("x", tokens[4].value)
+        assertEquals("ASSIGN", tokens[5].effectiveTypeName())
+        assertEquals(":=", tokens[5].value)
+        assertEquals("INTEGER_LIT", tokens[6].effectiveTypeName())
+        assertEquals("42", tokens[6].value)
+    }
+
+    @Test
+    fun defaultVersionMatchesExplicitAlgol60() {
+        val defaultTokens = AlgolLexer.tokenizeAlgol("begin integer x; x := 42 end")
+        val explicitTokens = AlgolLexer.tokenizeAlgol("begin integer x; x := 42 end", "algol60")
+
+        assertEquals(defaultTokens, explicitTokens)
+    }
+
+    @Test
+    fun rejectsUnknownVersion() {
+        val error = assertFailsWith<IllegalArgumentException> {
+            AlgolLexer.tokenizeAlgol("begin integer x; x := 42 end", "algol68")
+        }
+
+        assertTrue(error.message!!.contains("Unknown ALGOL version"))
+    }
+}

--- a/code/packages/kotlin/algol-parser/.gitignore
+++ b/code/packages/kotlin/algol-parser/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/kotlin/algol-parser/BUILD
+++ b/code/packages/kotlin/algol-parser/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/algol-parser/BUILD_windows
+++ b/code/packages/kotlin/algol-parser/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/algol-parser/CHANGELOG.md
+++ b/code/packages/kotlin/algol-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# algol-parser
+
+## 0.1.0
+
+- add runtime grammar-backed ALGOL 60 parsing with version selection

--- a/code/packages/kotlin/algol-parser/README.md
+++ b/code/packages/kotlin/algol-parser/README.md
@@ -1,0 +1,16 @@
+# algol-parser
+
+Grammar-backed ALGOL 60 parser for Kotlin with support for the bundled `algol60` parser grammar.
+
+## Dependencies
+
+- grammar-tools
+- lexer
+- parser
+- algol-lexer
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/kotlin/algol-parser/build.gradle.kts
+++ b/code/packages/kotlin/algol-parser/build.gradle.kts
@@ -1,0 +1,46 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+sourceSets {
+    named("main") {
+        resources.srcDir("../../../grammars/algol")
+        resources.include("algol*.grammar")
+    }
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    api("com.codingadventures:grammar-tools")
+    api("com.codingadventures:lexer")
+    api("com.codingadventures:parser")
+    api("com.codingadventures:algol-lexer")
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/algol-parser/required_capabilities.json
+++ b/code/packages/kotlin/algol-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "kotlin/algol-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/kotlin/algol-parser/settings.gradle.kts
+++ b/code/packages/kotlin/algol-parser/settings.gradle.kts
@@ -1,0 +1,6 @@
+rootProject.name = "algol-parser"
+
+includeBuild("../grammar-tools")
+includeBuild("../lexer")
+includeBuild("../parser")
+includeBuild("../algol-lexer")

--- a/code/packages/kotlin/algol-parser/src/main/kotlin/com/codingadventures/algolparser/AlgolParser.kt
+++ b/code/packages/kotlin/algol-parser/src/main/kotlin/com/codingadventures/algolparser/AlgolParser.kt
@@ -1,0 +1,43 @@
+package com.codingadventures.algolparser
+
+import com.codingadventures.grammartools.ParserGrammar
+import com.codingadventures.grammartools.parseParserGrammar
+import com.codingadventures.parser.ASTNode
+import com.codingadventures.parser.GrammarParser
+import com.codingadventures.algollexer.AlgolLexer
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.ConcurrentHashMap
+
+object AlgolParser {
+    const val DEFAULT_VERSION = AlgolLexer.DEFAULT_VERSION
+    val SUPPORTED_VERSIONS: List<String> = AlgolLexer.SUPPORTED_VERSIONS
+
+    private val parserGrammars = ConcurrentHashMap<String, ParserGrammar>()
+
+    fun createAlgolParser(version: String = DEFAULT_VERSION): GrammarParser =
+        GrammarParser(loadParserGrammar(version))
+
+    fun parseAlgol(source: String, version: String = DEFAULT_VERSION): ASTNode =
+        createAlgolParser(version).parse(AlgolLexer.tokenizeAlgol(source, version))
+
+    private fun loadParserGrammar(version: String): ParserGrammar {
+        val validated = validateVersion(version)
+        return parserGrammars.computeIfAbsent(validated) { parseParserGrammar(readResource("$it.grammar")) }
+    }
+
+    private fun validateVersion(version: String?): String {
+        if (version.isNullOrBlank()) {
+            return DEFAULT_VERSION
+        }
+        require(version in SUPPORTED_VERSIONS) {
+            "Unknown ALGOL version '$version'. Valid values: ${SUPPORTED_VERSIONS.joinToString(", ")}"
+        }
+        return version
+    }
+
+    private fun readResource(resourceName: String): String {
+        val stream = javaClass.classLoader.getResourceAsStream(resourceName)
+            ?: error("Missing bundled resource: $resourceName")
+        return stream.use { String(it.readAllBytes(), StandardCharsets.UTF_8) }
+    }
+}

--- a/code/packages/kotlin/algol-parser/src/test/kotlin/com/codingadventures/algolparser/AlgolParserTest.kt
+++ b/code/packages/kotlin/algol-parser/src/test/kotlin/com/codingadventures/algolparser/AlgolParserTest.kt
@@ -1,0 +1,33 @@
+package com.codingadventures.algolparser
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class AlgolParserTest {
+    @Test
+    fun parsesMinimalProgram() {
+        val ast = AlgolParser.parseAlgol("begin integer x; x := 42 end")
+
+        assertEquals("program", ast.ruleName)
+        assertTrue(ast.descendantCount() > 0)
+    }
+
+    @Test
+    fun defaultVersionMatchesExplicitAlgol60() {
+        val defaultAst = AlgolParser.parseAlgol("begin integer x; x := 42 end")
+        val explicitAst = AlgolParser.parseAlgol("begin integer x; x := 42 end", "algol60")
+
+        assertEquals(defaultAst.ruleName, explicitAst.ruleName)
+    }
+
+    @Test
+    fun rejectsUnknownVersion() {
+        val error = assertFailsWith<IllegalArgumentException> {
+            AlgolParser.parseAlgol("begin integer x; x := 42 end", "algol68")
+        }
+
+        assertTrue(error.message!!.contains("Unknown ALGOL version"))
+    }
+}


### PR DESCRIPTION
## Summary
- add Java `algol-lexer` and `algol-parser` packages that load the bundled `algol60` grammars at runtime
- add matching Kotlin `algol-lexer` and `algol-parser` packages with the same API shape and version handling
- cover tokenization/parsing plus default-version behavior with targeted package tests

## Testing
- `gradlew.bat --no-daemon -p code/packages/java/algol-lexer test`
- `gradlew.bat --no-daemon -p code/packages/java/algol-parser test`
- `gradlew.bat --no-daemon -p code/packages/kotlin/algol-lexer test`
- `gradlew.bat --no-daemon -p code/packages/kotlin/algol-parser test`