### PR TITLE
Implement Haskell JSON lexer and parser

### DIFF
--- a/code/packages/haskell/json-lexer/json-lexer.cabal
+++ b/code/packages/haskell/json-lexer/json-lexer.cabal
@@ -23,6 +23,7 @@ test-suite spec
     other-modules:    JsonLexerSpec
     hs-source-dirs:   test
     build-depends:    base >=4.14
+                    , lexer
                     , json-lexer
                     , hspec == 2.*
     default-language: Haskell2010

--- a/code/packages/haskell/json-lexer/src/JsonLexer.hs
+++ b/code/packages/haskell/json-lexer/src/JsonLexer.hs
@@ -4,15 +4,275 @@ module JsonLexer
     , tokenizeJson
     ) where
 
-import Lexer (LexerConfig(..), LexerError, Token, defaultLexerConfig, tokenize)
+import Data.Char (chr, isDigit)
+import Numeric (readHex)
+import Lexer (LexerError(..), Token, TokenType(..), makeToken, withTypeName)
 
--- Thin wrapper around the shared lexer package so language-specific ports can
--- grow their own keyword tables and token helpers incrementally.
+data Scanner = Scanner
+    { scannerRemaining :: String
+    , scannerLine :: Int
+    , scannerColumn :: Int
+    }
+    deriving (Eq, Show)
+
 description :: String
-description = "Haskell starter wrapper for json-lexer built on the generic lexer package"
+description = "Haskell JSON lexer with dedicated number, string, and literal handling"
 
 jsonLexerKeywords :: [String]
-jsonLexerKeywords = []
+jsonLexerKeywords = ["true", "false", "null"]
 
 tokenizeJson :: String -> Either LexerError [Token]
-tokenizeJson = tokenize defaultLexerConfig {lexerKeywords = jsonLexerKeywords}
+tokenizeJson source = scanTokens initialScanner []
+  where
+    initialScanner =
+        Scanner
+            { scannerRemaining = source
+            , scannerLine = 1
+            , scannerColumn = 1
+            }
+
+scanTokens :: Scanner -> [Token] -> Either LexerError [Token]
+scanTokens scanner tokens =
+    case skipWhitespace scanner of
+        current
+            | isAtEnd current ->
+                Right (tokens ++ [makeToken TokenEof "" (scannerLine current) (scannerColumn current)])
+            | otherwise ->
+                case currentChar current of
+                    Just '"' -> do
+                        (token, nextScanner) <- readString current
+                        scanTokens nextScanner (tokens ++ [token])
+                    Just '-' -> do
+                        (token, nextScanner) <- readNumber current
+                        scanTokens nextScanner (tokens ++ [token])
+                    Just ch
+                        | isDigit ch -> do
+                            (token, nextScanner) <- readNumber current
+                            scanTokens nextScanner (tokens ++ [token])
+                    Just '{' ->
+                        continueWith (makeToken TokenLBrace "{" (scannerLine current) (scannerColumn current)) (advanceChar current) tokens
+                    Just '}' ->
+                        continueWith (makeToken TokenRBrace "}" (scannerLine current) (scannerColumn current)) (advanceChar current) tokens
+                    Just '[' ->
+                        continueWith (makeToken TokenLBracket "[" (scannerLine current) (scannerColumn current)) (advanceChar current) tokens
+                    Just ']' ->
+                        continueWith (makeToken TokenRBracket "]" (scannerLine current) (scannerColumn current)) (advanceChar current) tokens
+                    Just ':' ->
+                        continueWith (makeToken TokenColon ":" (scannerLine current) (scannerColumn current)) (advanceChar current) tokens
+                    Just ',' ->
+                        continueWith (makeToken TokenComma "," (scannerLine current) (scannerColumn current)) (advanceChar current) tokens
+                    Just 't' -> readLiteral "true" "TRUE" current >>= advanceWith tokens
+                    Just 'f' -> readLiteral "false" "FALSE" current >>= advanceWith tokens
+                    Just 'n' -> readLiteral "null" "NULL" current >>= advanceWith tokens
+                    _ ->
+                        Left
+                            LexerError
+                                { lexerErrorMessage = "unexpected character in JSON input"
+                                , lexerErrorLine = scannerLine current
+                                , lexerErrorColumn = scannerColumn current
+                                }
+
+continueWith :: Token -> Scanner -> [Token] -> Either LexerError [Token]
+continueWith token nextScanner tokens =
+    scanTokens nextScanner (tokens ++ [token])
+
+advanceWith :: [Token] -> (Token, Scanner) -> Either LexerError [Token]
+advanceWith tokens (token, nextScanner) =
+    scanTokens nextScanner (tokens ++ [token])
+
+skipWhitespace :: Scanner -> Scanner
+skipWhitespace scanner =
+    case currentChar scanner of
+        Just ch
+            | ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n' ->
+                skipWhitespace (advanceChar scanner)
+        _ -> scanner
+
+readLiteral :: String -> String -> Scanner -> Either LexerError (Token, Scanner)
+readLiteral expected customTypeName scanner =
+    if take (length expected) (scannerRemaining scanner) == expected
+        then
+            Right
+                ( withTypeName customTypeName (makeToken TokenKeyword expected (scannerLine scanner) (scannerColumn scanner))
+                , advanceChars (length expected) scanner
+                )
+        else
+            Left
+                LexerError
+                    { lexerErrorMessage = "invalid JSON literal"
+                    , lexerErrorLine = scannerLine scanner
+                    , lexerErrorColumn = scannerColumn scanner
+                    }
+
+readString :: Scanner -> Either LexerError (Token, Scanner)
+readString scanner =
+    go [] (advanceChar scanner)
+  where
+    startLine = scannerLine scanner
+    startColumn = scannerColumn scanner
+
+    go acc current =
+        case currentChar current of
+            Nothing ->
+                Left
+                    LexerError
+                        { lexerErrorMessage = "unterminated JSON string"
+                        , lexerErrorLine = startLine
+                        , lexerErrorColumn = startColumn
+                        }
+            Just '"' ->
+                Right (makeToken TokenString (reverse acc) startLine startColumn, advanceChar current)
+            Just '\\' ->
+                case parseEscape current of
+                    Left err -> Left err
+                    Right (escaped, nextScanner) -> go (reverse escaped ++ acc) nextScanner
+            Just ch ->
+                if ch < ' '
+                    then
+                        Left
+                            LexerError
+                                { lexerErrorMessage = "control character in JSON string"
+                                , lexerErrorLine = scannerLine current
+                                , lexerErrorColumn = scannerColumn current
+                                }
+                    else go ([ch] ++ acc) (advanceChar current)
+
+parseEscape :: Scanner -> Either LexerError (String, Scanner)
+parseEscape scanner =
+    case currentChar (advanceChar scanner) of
+        Nothing ->
+            Left
+                LexerError
+                    { lexerErrorMessage = "unterminated JSON escape"
+                    , lexerErrorLine = scannerLine scanner
+                    , lexerErrorColumn = scannerColumn scanner
+                    }
+        Just escaped ->
+            case escaped of
+                '"' -> Right ("\"", advanceChar (advanceChar scanner))
+                '\\' -> Right ("\\", advanceChar (advanceChar scanner))
+                '/' -> Right ("/", advanceChar (advanceChar scanner))
+                'b' -> Right ("\b", advanceChar (advanceChar scanner))
+                'f' -> Right ("\f", advanceChar (advanceChar scanner))
+                'n' -> Right ("\n", advanceChar (advanceChar scanner))
+                'r' -> Right ("\r", advanceChar (advanceChar scanner))
+                't' -> Right ("\t", advanceChar (advanceChar scanner))
+                'u' ->
+                    let unicodeStart = advanceChar (advanceChar scanner)
+                        digits = take 4 (scannerRemaining unicodeStart)
+                     in if length digits == 4 && all isHexDigit digits
+                            then
+                                case readHex digits of
+                                    [(value, "")] ->
+                                        Right ([chr value], advanceChars 4 unicodeStart)
+                                    _ ->
+                                        invalidEscape unicodeStart
+                            else invalidEscape unicodeStart
+                _ -> invalidEscape (advanceChar scanner)
+  where
+    invalidEscape current =
+        Left
+            LexerError
+                { lexerErrorMessage = "invalid JSON escape"
+                , lexerErrorLine = scannerLine current
+                , lexerErrorColumn = scannerColumn current
+                }
+
+readNumber :: Scanner -> Either LexerError (Token, Scanner)
+readNumber scanner = do
+    let startLine = scannerLine scanner
+        startColumn = scannerColumn scanner
+        (signScanner, seenMinus) =
+            case currentChar scanner of
+                Just '-' -> (advanceChar scanner, True)
+                _ -> (scanner, False)
+    integerScanner <-
+        case currentChar signScanner of
+            Just '0' -> Right (advanceChar signScanner)
+            Just ch
+                | ch >= '1' && ch <= '9' ->
+                    Right (advanceWhile isDigitChar signScanner)
+            _ ->
+                Left
+                    LexerError
+                        { lexerErrorMessage = if seenMinus then "expected digits after '-'" else "invalid JSON number"
+                        , lexerErrorLine = startLine
+                        , lexerErrorColumn = startColumn
+                        }
+    fractionScanner <-
+        case currentChar integerScanner of
+            Just '.' ->
+                let afterDot = advanceChar integerScanner
+                 in case currentChar afterDot of
+                        Just digit
+                            | isDigitChar digit -> Right (advanceWhile isDigitChar afterDot)
+                        _ ->
+                            Left
+                                LexerError
+                                    { lexerErrorMessage = "invalid JSON fraction"
+                                    , lexerErrorLine = scannerLine integerScanner
+                                    , lexerErrorColumn = scannerColumn integerScanner
+                                    }
+            _ -> Right integerScanner
+    exponentScanner <-
+        case currentChar fractionScanner of
+            Just marker
+                | marker == 'e' || marker == 'E' ->
+                    let afterMarker = advanceChar fractionScanner
+                        afterSign =
+                            case currentChar afterMarker of
+                                Just '+' -> advanceChar afterMarker
+                                Just '-' -> advanceChar afterMarker
+                                _ -> afterMarker
+                     in case currentChar afterSign of
+                            Just digit
+                                | isDigitChar digit -> Right (advanceWhile isDigitChar afterSign)
+                            _ ->
+                                Left
+                                    LexerError
+                                        { lexerErrorMessage = "invalid JSON exponent"
+                                        , lexerErrorLine = scannerLine afterMarker
+                                        , lexerErrorColumn = scannerColumn afterMarker
+                                        }
+            _ -> Right fractionScanner
+    let consumedLength = length (scannerRemaining scanner) - length (scannerRemaining exponentScanner)
+        numberText = take consumedLength (scannerRemaining scanner)
+    Right (makeToken TokenNumber numberText startLine startColumn, exponentScanner)
+
+advanceWhile :: (Char -> Bool) -> Scanner -> Scanner
+advanceWhile predicate scanner =
+    case currentChar scanner of
+        Just ch
+            | predicate ch -> advanceWhile predicate (advanceChar scanner)
+        _ -> scanner
+
+advanceChars :: Int -> Scanner -> Scanner
+advanceChars count scanner
+    | count <= 0 = scanner
+    | otherwise = advanceChars (count - 1) (advanceChar scanner)
+
+advanceChar :: Scanner -> Scanner
+advanceChar scanner =
+    case scannerRemaining scanner of
+        [] -> scanner
+        ch : rest ->
+            scanner
+                { scannerRemaining = rest
+                , scannerLine = if ch == '\n' then scannerLine scanner + 1 else scannerLine scanner
+                , scannerColumn = if ch == '\n' then 1 else scannerColumn scanner + 1
+                }
+
+currentChar :: Scanner -> Maybe Char
+currentChar scanner =
+    case scannerRemaining scanner of
+        [] -> Nothing
+        ch : _ -> Just ch
+
+isAtEnd :: Scanner -> Bool
+isAtEnd scanner = null (scannerRemaining scanner)
+
+isDigitChar :: Char -> Bool
+isDigitChar ch = ch >= '0' && ch <= '9'
+
+isHexDigit :: Char -> Bool
+isHexDigit ch = isDigit ch || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F')

--- a/code/packages/haskell/json-lexer/test/JsonLexerSpec.hs
+++ b/code/packages/haskell/json-lexer/test/JsonLexerSpec.hs
@@ -1,9 +1,27 @@
 module JsonLexerSpec (spec) where
 
 import Test.Hspec
+import Lexer (Token, canonicalTokenName, tokenValue)
 import JsonLexer
 
 spec :: Spec
 spec = describe "JsonLexer" $ do
-    it "exposes a non-empty starter description" $ do
-        description `shouldSatisfy` (not . null)
+    it "tokenizes JSON punctuation, literals, and EOF" $ do
+        let result = tokenizeJson "{\"enabled\":true,\"count\":2}"
+        fmap (map canonicalTokenName) result
+            `shouldBe` Right ["LBRACE", "STRING", "COLON", "TRUE", "COMMA", "STRING", "COLON", "NUMBER", "RBRACE", "EOF"]
+
+    it "decodes escaped JSON string content" $ do
+        let result = tokenizeJson "\"line\\nfeed\""
+        fmap firstTokenValue result `shouldBe` Right "line\nfeed"
+
+    it "rejects malformed numbers" $ do
+        case tokenizeJson "-" of
+            Left err -> show err `shouldContain` "expected digits after '-'"
+            Right _ -> expectationFailure "expected lexer error"
+
+firstTokenValue :: [Token] -> String
+firstTokenValue tokens =
+    case tokens of
+        token : _ -> tokenValue token
+        [] -> ""

--- a/code/packages/haskell/json-parser/cabal.project
+++ b/code/packages/haskell/json-parser/cabal.project
@@ -5,4 +5,5 @@ packages:
   ../directed-graph
   ../state-machine
   ../lexer
+  ../grammar-tools
   ../json-lexer

--- a/code/packages/haskell/json-parser/json-parser.cabal
+++ b/code/packages/haskell/json-parser/json-parser.cabal
@@ -13,6 +13,7 @@ library
                     , graph
                     , directed-graph
                     , state-machine
+                    , grammar-tools
                     , lexer
                     , parser
                     , json-lexer
@@ -25,6 +26,8 @@ test-suite spec
     other-modules:    JsonParserSpec
     hs-source-dirs:   test
     build-depends:    base >=4.14
+                    , lexer
+                    , parser
                     , json-parser
                     , hspec == 2.*
     default-language: Haskell2010

--- a/code/packages/haskell/json-parser/src/JsonParser.hs
+++ b/code/packages/haskell/json-parser/src/JsonParser.hs
@@ -6,13 +6,12 @@ module JsonParser
     ) where
 
 import Lexer (LexerError, Token)
-import Parser (ASTNode, ParseError, parseTokens)
+import Parser (ASTNode, ParseError, parseWithGrammar)
+import GrammarTools (parseParserGrammar)
 import qualified JsonLexer
 
--- Starter parser wrapper that composes the shared parser engine with the
--- sibling lexer package for this language family.
 description :: String
-description = "Haskell starter wrapper for json-parser built on the generic parser package"
+description = "Haskell JSON parser backed by the shared grammar-driven parser runtime"
 
 data JsonParserError
     = JsonParserLexerError LexerError
@@ -20,7 +19,7 @@ data JsonParserError
     deriving (Eq, Show)
 
 parseJsonTokens :: [Token] -> Either ParseError ASTNode
-parseJsonTokens = parseTokens
+parseJsonTokens = parseWithGrammar jsonParserGrammar
 
 tokenizeAndParseJson :: String -> Either JsonParserError ASTNode
 tokenizeAndParseJson source =
@@ -30,3 +29,17 @@ tokenizeAndParseJson source =
             case parseJsonTokens tokens of
                 Left err -> Left (JsonParserParseError err)
                 Right ast -> Right ast
+
+jsonParserGrammarSource :: String
+jsonParserGrammarSource =
+    unlines
+        [ "value = object | array | STRING | NUMBER | TRUE | FALSE | NULL ;"
+        , "object = LBRACE [ pair { COMMA pair } ] RBRACE ;"
+        , "pair = STRING COLON value ;"
+        , "array = LBRACKET [ value { COMMA value } ] RBRACKET ;"
+        ]
+
+jsonParserGrammar = 
+    case parseParserGrammar jsonParserGrammarSource of
+        Left err -> error (show err)
+        Right grammar -> grammar

--- a/code/packages/haskell/json-parser/test/JsonParserSpec.hs
+++ b/code/packages/haskell/json-parser/test/JsonParserSpec.hs
@@ -1,9 +1,43 @@
 module JsonParserSpec (spec) where
 
 import Test.Hspec
+import Lexer (canonicalTokenName)
+import Parser (ASTNode(..), ParseError(..))
 import JsonParser
 
 spec :: Spec
 spec = describe "JsonParser" $ do
-    it "exposes a non-empty starter description" $ do
-        description `shouldSatisfy` (not . null)
+    it "parses nested JSON structures into grammar nodes" $ do
+        case tokenizeAndParseJson "{\"user\":{\"name\":\"Ada\"},\"scores\":[1,2]}" of
+            Left err -> expectationFailure ("expected successful parse, got " ++ show err)
+            Right ast -> do
+                rootRuleName ast `shouldBe` Just "value"
+                collectRuleNames ast `shouldSatisfy` all (`elem` ["value", "object", "pair", "array"])
+                collectRuleNames ast `shouldSatisfy` \names -> all (`elem` names) ["object", "pair", "array", "value"]
+                collectTokenNames ast `shouldSatisfy` \names -> all (`elem` names) ["LBRACE", "STRING", "COLON", "LBRACKET", "NUMBER", "RBRACKET", "RBRACE"]
+
+    it "reports parser errors for malformed JSON" $ do
+        case tokenizeAndParseJson "{\"name\":}" of
+            Left (JsonParserParseError err) -> parseErrorMessage err `shouldContain` "expected token"
+            Left other -> expectationFailure ("expected parser error, got " ++ show other)
+            Right _ -> expectationFailure "expected parse failure"
+
+rootRuleName :: ASTNode -> Maybe String
+rootRuleName ast =
+    case ast of
+        RuleNode name _ -> Just name
+        _ -> Nothing
+
+collectRuleNames :: ASTNode -> [String]
+collectRuleNames ast =
+    case ast of
+        RuleNode name children -> name : concatMap collectRuleNames children
+        TokenNode _ -> []
+        _ -> []
+
+collectTokenNames :: ASTNode -> [String]
+collectTokenNames ast =
+    case ast of
+        RuleNode _ children -> concatMap collectTokenNames children
+        TokenNode token -> [canonicalTokenName token]
+        _ -> []

--- a/code/packages/haskell/lexer/src/Lexer/Token.hs
+++ b/code/packages/haskell/lexer/src/Lexer/Token.hs
@@ -6,7 +6,9 @@ module Lexer.Token
     , tokenContextKeyword
     , renderTokenType
     , effectiveTypeName
+    , canonicalTokenName
     , makeToken
+    , withTypeName
     , withFlags
     , simpleTokenType
     ) where
@@ -110,6 +112,38 @@ effectiveTypeName token =
         Just customName -> customName
         Nothing -> renderTokenType (tokenType token)
 
+canonicalTokenName :: Token -> String
+canonicalTokenName token =
+    case tokenTypeName token of
+        Just customName -> customName
+        Nothing ->
+            case tokenType token of
+                TokenName -> "NAME"
+                TokenNumber -> "NUMBER"
+                TokenString -> "STRING"
+                TokenKeyword -> "KEYWORD"
+                TokenPlus -> "PLUS"
+                TokenMinus -> "MINUS"
+                TokenStar -> "STAR"
+                TokenSlash -> "SLASH"
+                TokenEquals -> "EQUALS"
+                TokenEqualsEquals -> "EQUALS_EQUALS"
+                TokenLParen -> "LPAREN"
+                TokenRParen -> "RPAREN"
+                TokenComma -> "COMMA"
+                TokenColon -> "COLON"
+                TokenSemicolon -> "SEMICOLON"
+                TokenLBrace -> "LBRACE"
+                TokenRBrace -> "RBRACE"
+                TokenLBracket -> "LBRACKET"
+                TokenRBracket -> "RBRACKET"
+                TokenDot -> "DOT"
+                TokenBang -> "BANG"
+                TokenNewline -> "NEWLINE"
+                TokenIndent -> "INDENT"
+                TokenDedent -> "DEDENT"
+                TokenEof -> "EOF"
+
 makeToken :: TokenType -> String -> Int -> Int -> Token
 makeToken tokenTypeValue value line column =
     Token
@@ -120,6 +154,9 @@ makeToken tokenTypeValue value line column =
         , tokenTypeName = Nothing
         , tokenFlags = 0
         }
+
+withTypeName :: String -> Token -> Token
+withTypeName customName token = token {tokenTypeName = Just customName}
 
 withFlags :: Int -> Token -> Token
 withFlags flags token = token {tokenFlags = tokenFlags token .|. flags}

--- a/code/packages/haskell/parser/cabal.project
+++ b/code/packages/haskell/parser/cabal.project
@@ -4,3 +4,4 @@ packages:
   ../directed-graph
   ../state-machine
   ../lexer
+  ../grammar-tools

--- a/code/packages/haskell/parser/parser.cabal
+++ b/code/packages/haskell/parser/parser.cabal
@@ -10,9 +10,11 @@ build-type:    Simple
 library
     exposed-modules:  Parser
                     , Parser.AST
+                    , Parser.GrammarRuntime
                     , Parser.RecursiveDescent
     build-depends:    base >=4.14
                     , lexer
+                    , grammar-tools
     hs-source-dirs:   src
     default-language: Haskell2010
 
@@ -22,6 +24,7 @@ test-suite spec
     other-modules:    ParserSpec
     build-depends:    base >=4.14
                     , hspec == 2.*
+                    , grammar-tools
                     , lexer
                     , parser
     hs-source-dirs:   test

--- a/code/packages/haskell/parser/src/Parser.hs
+++ b/code/packages/haskell/parser/src/Parser.hs
@@ -1,7 +1,9 @@
 module Parser
     ( module Parser.AST
+    , module Parser.GrammarRuntime
     , module Parser.RecursiveDescent
     ) where
 
 import Parser.AST
+import Parser.GrammarRuntime
 import Parser.RecursiveDescent

--- a/code/packages/haskell/parser/src/Parser/AST.hs
+++ b/code/packages/haskell/parser/src/Parser/AST.hs
@@ -2,6 +2,8 @@ module Parser.AST
     ( ASTNode(..)
     ) where
 
+import Lexer.Token
+
 data ASTNode
     = NumberNode Double
     | StringNode String
@@ -10,4 +12,6 @@ data ASTNode
     | AssignmentNode String ASTNode
     | ExpressionStmtNode ASTNode
     | ProgramNode [ASTNode]
+    | RuleNode String [ASTNode]
+    | TokenNode Token
     deriving (Eq, Show)

--- a/code/packages/haskell/parser/src/Parser/GrammarRuntime.hs
+++ b/code/packages/haskell/parser/src/Parser/GrammarRuntime.hs
@@ -1,0 +1,196 @@
+module Parser.GrammarRuntime
+    ( parseWithGrammar
+    ) where
+
+import Data.List (find)
+import GrammarTools.ParserGrammar
+import Lexer.Token
+import Parser.AST
+import Parser.RecursiveDescent (ParseError(..))
+
+data ParserState = ParserState
+    { parserTokens :: [Token]
+    , parserPosition :: Int
+    }
+    deriving (Eq, Show)
+
+parseWithGrammar :: ParserGrammar -> [Token] -> Either ParseError ASTNode
+parseWithGrammar grammar rawTokens =
+    case parserGrammarRules grammar of
+        [] -> Left (makeParseError "parser grammar has no rules" fallbackToken)
+        startRule : _ -> do
+            (ast, finalState) <- parseRule grammar (grammarRuleName startRule) initialState
+            case peekToken finalState of
+                token
+                    | canonicalTokenName token == "EOF" ->
+                        Right ast
+                    | otherwise ->
+                        Left (makeParseError "expected EOF" token)
+  where
+    initialState = ParserState (normalizeTokens rawTokens) 0
+    fallbackToken =
+        case reverse rawTokens of
+            token : _ -> token
+            [] -> makeToken TokenEof "" 1 1
+
+parseRule :: ParserGrammar -> String -> ParserState -> Either ParseError (ASTNode, ParserState)
+parseRule grammar ruleName state =
+    case find ((== ruleName) . grammarRuleName) (parserGrammarRules grammar) of
+        Nothing ->
+            Left (makeParseError ("unknown grammar rule " ++ show ruleName) (peekToken state))
+        Just rule -> do
+            (children, nextState) <- parseElement grammar (grammarRuleBody rule) state
+            Right (RuleNode ruleName children, nextState)
+
+parseElement :: ParserGrammar -> GrammarElement -> ParserState -> Either ParseError ([ASTNode], ParserState)
+parseElement grammar element state =
+    case element of
+        RuleReference name True ->
+            case peekToken state of
+                token
+                    | canonicalTokenName token == name ->
+                        let (_, nextState) = advanceToken state
+                         in Right ([TokenNode token], nextState)
+                    | otherwise ->
+                        Left (makeParseError ("expected token " ++ name) token)
+        RuleReference name False -> do
+            (node, nextState) <- parseRule grammar name state
+            Right ([node], nextState)
+        Literal value ->
+            case peekToken state of
+                token
+                    | tokenValue token == value ->
+                        let (_, nextState) = advanceToken state
+                         in Right ([TokenNode token], nextState)
+                    | otherwise ->
+                        Left (makeParseError ("expected literal " ++ show value) token)
+        Sequence elements ->
+            parseSequence grammar elements state
+        Alternation choices ->
+            parseAlternation grammar choices state
+        Repetition child ->
+            parseRepetition grammar child False state
+        Optional child ->
+            case parseElement grammar child state of
+                Right result -> Right result
+                Left _ -> Right ([], state)
+        Group child ->
+            parseElement grammar child state
+        PositiveLookahead child ->
+            case parseElement grammar child state of
+                Right _ -> Right ([], state)
+                Left err -> Left err
+        NegativeLookahead child ->
+            case parseElement grammar child state of
+                Right _ -> Left (makeParseError "negative lookahead failed" (peekToken state))
+                Left _ -> Right ([], state)
+        OneOrMoreRepetition child ->
+            parseRepetition grammar child True state
+        SeparatedRepetition child separator atLeastOne ->
+            parseSeparatedRepetition grammar child separator atLeastOne state
+
+parseSequence :: ParserGrammar -> [GrammarElement] -> ParserState -> Either ParseError ([ASTNode], ParserState)
+parseSequence grammar elements state =
+    go [] state elements
+  where
+    go acc currentState [] = Right (acc, currentState)
+    go acc currentState (next : rest) = do
+        (nodes, nextState) <- parseElement grammar next currentState
+        go (acc ++ nodes) nextState rest
+
+parseAlternation :: ParserGrammar -> [GrammarElement] -> ParserState -> Either ParseError ([ASTNode], ParserState)
+parseAlternation grammar choices state =
+    tryChoices Nothing choices
+  where
+    tryChoices maybeErr [] =
+        case maybeErr of
+            Just err -> Left err
+            Nothing -> Left (makeParseError "expected one of the grammar alternatives" (peekToken state))
+    tryChoices maybeErr (choice : rest) =
+        case parseElement grammar choice state of
+            Right result -> Right result
+            Left err -> tryChoices (pickBetterError maybeErr err) rest
+
+parseRepetition :: ParserGrammar -> GrammarElement -> Bool -> ParserState -> Either ParseError ([ASTNode], ParserState)
+parseRepetition grammar child requireOne state = do
+    (firstNodes, firstState) <-
+        if requireOne
+            then parseElement grammar child state
+            else Right ([], state)
+    continue firstNodes firstState
+  where
+    continue acc currentState =
+        case parseElement grammar child currentState of
+            Right (nodes, nextState)
+                | parserPosition nextState == parserPosition currentState ->
+                    Left (makeParseError "grammar repetition did not consume input" (peekToken currentState))
+                | otherwise ->
+                    continue (acc ++ nodes) nextState
+            Left _ -> Right (acc, currentState)
+
+parseSeparatedRepetition ::
+       ParserGrammar
+    -> GrammarElement
+    -> GrammarElement
+    -> Bool
+    -> ParserState
+    -> Either ParseError ([ASTNode], ParserState)
+parseSeparatedRepetition grammar child separator atLeastOne state =
+    case parseElement grammar child state of
+        Left err
+            | atLeastOne -> Left err
+            | otherwise -> Right ([], state)
+        Right (firstNodes, firstState) ->
+            continue firstNodes firstState
+  where
+    continue acc currentState =
+        case parseElement grammar separator currentState of
+            Left _ -> Right (acc, currentState)
+            Right (separatorNodes, afterSeparator) -> do
+                (childNodes, nextState) <- parseElement grammar child afterSeparator
+                if parserPosition nextState == parserPosition currentState
+                    then Left (makeParseError "separated repetition did not consume input" (peekToken currentState))
+                    else continue (acc ++ separatorNodes ++ childNodes) nextState
+
+peekToken :: ParserState -> Token
+peekToken state =
+    case drop (parserPosition state) (parserTokens state) of
+        token : _ -> token
+        [] -> makeToken TokenEof "" 1 1
+
+advanceToken :: ParserState -> (Token, ParserState)
+advanceToken state =
+    let token = peekToken state
+     in (token, state {parserPosition = parserPosition state + 1})
+
+normalizeTokens :: [Token] -> [Token]
+normalizeTokens [] = [makeToken TokenEof "" 1 1]
+normalizeTokens tokens =
+    case reverse tokens of
+        lastToken : _
+            | canonicalTokenName lastToken == "EOF" -> tokens
+            | otherwise ->
+                tokens
+                    ++ [ makeToken
+                            TokenEof
+                            ""
+                            (tokenLine lastToken)
+                            (tokenColumn lastToken + max 1 (length (tokenValue lastToken)))
+                       ]
+        [] -> [makeToken TokenEof "" 1 1]
+
+pickBetterError :: Maybe ParseError -> ParseError -> Maybe ParseError
+pickBetterError Nothing err = Just err
+pickBetterError (Just existing) candidate
+    | tokenLine (parseErrorToken candidate) > tokenLine (parseErrorToken existing) = Just candidate
+    | tokenLine (parseErrorToken candidate) == tokenLine (parseErrorToken existing)
+        && tokenColumn (parseErrorToken candidate) >= tokenColumn (parseErrorToken existing) =
+            Just candidate
+    | otherwise = Just existing
+
+makeParseError :: String -> Token -> ParseError
+makeParseError message token =
+    ParseError
+        { parseErrorMessage = message
+        , parseErrorToken = token
+        }

--- a/code/packages/haskell/parser/test/ParserSpec.hs
+++ b/code/packages/haskell/parser/test/ParserSpec.hs
@@ -2,6 +2,7 @@ module ParserSpec (spec) where
 
 import Test.Hspec
 
+import GrammarTools (parseParserGrammar)
 import Lexer
 import Parser
 
@@ -51,8 +52,35 @@ spec = do
                 Left err -> parseErrorMessage err `shouldBe` "unexpected token"
                 Right _ -> expectationFailure "expected parse error"
 
+    describe "parseWithGrammar" $ do
+        it "builds a grammar-shaped AST from token references" $ do
+            let grammar =
+                    either (error . show) id $
+                        parseParserGrammar
+                            (unlines
+                                [ "value = LBRACE pair RBRACE ;"
+                                , "pair = STRING COLON NUMBER ;"
+                                ]
+                            )
+                tokens =
+                    [ makeToken TokenLBrace "{" 1 1
+                    , makeToken TokenString "answer" 1 2
+                    , makeToken TokenColon ":" 1 10
+                    , makeToken TokenNumber "42" 1 11
+                    , makeToken TokenRBrace "}" 1 13
+                    ]
+            fmap collectRuleNames (parseWithGrammar grammar tokens)
+                `shouldBe` Right ["value", "pair"]
+
 parseSource :: String -> Either ParseError ASTNode
 parseSource source =
     case tokenize defaultLexerConfig source of
         Left lexerErrorValue -> error (show lexerErrorValue)
         Right tokens -> parseTokens tokens
+
+collectRuleNames :: ASTNode -> [String]
+collectRuleNames ast =
+    case ast of
+        RuleNode name children -> name : concatMap collectRuleNames children
+        TokenNode _ -> []
+        _ -> []


### PR DESCRIPTION
﻿## Summary
- add a grammar-driven runtime to the shared Haskell `parser` package
- promote `json-lexer` from scaffold to a real JSON lexer with string, number, and literal handling
- promote `json-parser` from scaffold to a real JSON parser backed by the shared grammar runtime
- add focused tests for the shared parser runtime and the JSON lexer/parser pair

## Notes
- this is the first implementation batch after the scaffold PR
- the new parser runtime gives us a reusable foundation for additional Haskell parser ports
- the lexer side is still language-specific here; broader grammar-file-driven lexing can follow in later PRs

## Validation
- `cabal test --enable-tests` in `code/packages/haskell/parser`
- `cabal test --enable-tests` in `code/packages/haskell/json-lexer`
- `cabal test --enable-tests` in `code/packages/haskell/json-parser`
