### PR TITLE
Rewrite foundational F# packages in pure F#

### DIFF
--- a/code/packages/fsharp/directed-graph/BUILD
+++ b/code/packages/fsharp/directed-graph/BUILD
@@ -1,1 +1,1 @@
-dotnet test tests/CodingAdventures.DirectedGraph.Tests/CodingAdventures.DirectedGraph.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
+mkdir -p .dotnet && DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_CLI_HOME="$PWD/.dotnet" dotnet test tests/CodingAdventures.DirectedGraph.Tests/CodingAdventures.DirectedGraph.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/directed-graph/CHANGELOG.md
+++ b/code/packages/fsharp/directed-graph/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## 0.1.0
 
-- add initial F# directed-graph wrapper
+- replace the initial C# wrapper with a native F# directed graph implementation

--- a/code/packages/fsharp/directed-graph/CodingAdventures.DirectedGraph.fsproj
+++ b/code/packages/fsharp/directed-graph/CodingAdventures.DirectedGraph.fsproj
@@ -6,12 +6,11 @@
     <PackageId>CodingAdventures.DirectedGraph.FSharp</PackageId>
     <Version>0.1.0</Version>
     <Authors>Adhithya Rajasekaran</Authors>
-    <Description>F# wrappers for the directed-graph package</Description>
+    <Description>Pure F# directed graph with cycle detection, topological sorting, and dependency queries</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../csharp/directed-graph/CodingAdventures.DirectedGraph.csproj" />
     <Compile Include="DirectedGraph.fs" />
   </ItemGroup>
 </Project>

--- a/code/packages/fsharp/directed-graph/DirectedGraph.fs
+++ b/code/packages/fsharp/directed-graph/DirectedGraph.fs
@@ -1,17 +1,270 @@
 namespace CodingAdventures.DirectedGraph.FSharp
 
-open CodingAdventures.DirectedGraph
+open System
+open System.Collections.Generic
+
+type CycleError(message: string, cycle: IReadOnlyList<string>) =
+    inherit Exception(message)
+
+    member _.Cycle = cycle
+
+type NodeNotFoundError(node: string) =
+    inherit Exception(sprintf "Node not found: \"%s\"" node)
+
+    member _.Node = node
+
+type EdgeNotFoundError(fromNode: string, toNode: string) =
+    inherit Exception(sprintf "Edge not found: \"%s\" -> \"%s\"" fromNode toNode)
+
+    member _.FromNode = fromNode
+    member _.ToNode = toNode
+
+type Graph(?allowSelfLoops: bool) =
+    let allowSelfLoops = defaultArg allowSelfLoops false
+    let forward = Dictionary<string, HashSet<string>>(StringComparer.Ordinal)
+    let reverse = Dictionary<string, HashSet<string>>(StringComparer.Ordinal)
+
+    let ensureNode (node: string) =
+        if not (forward.ContainsKey(node)) then
+            raise (NodeNotFoundError(node))
+
+    let orderedStrings (values: seq<string>) =
+        values |> Seq.sortWith (fun left right -> StringComparer.Ordinal.Compare(left, right)) |> Seq.toList
+
+    member _.AllowSelfLoops = allowSelfLoops
+    member _.Size = forward.Count
+
+    member _.AddNode(node: string) =
+        if not (forward.ContainsKey(node)) then
+            forward.[node] <- HashSet<string>(StringComparer.Ordinal)
+
+        if not (reverse.ContainsKey(node)) then
+            reverse.[node] <- HashSet<string>(StringComparer.Ordinal)
+
+    member this.RemoveNode(node: string) =
+        ensureNode node
+
+        for successor in forward.[node] |> Seq.toArray do
+            reverse.[successor].Remove(node) |> ignore
+
+        for predecessor in reverse.[node] |> Seq.toArray do
+            forward.[predecessor].Remove(node) |> ignore
+
+        forward.Remove(node) |> ignore
+        reverse.Remove(node) |> ignore
+
+    member _.HasNode(node: string) = forward.ContainsKey(node)
+
+    member _.Nodes() = orderedStrings forward.Keys
+
+    member this.AddEdge(fromNode: string, toNode: string) =
+        if fromNode = toNode && not allowSelfLoops then
+            invalidArg "toNode" (sprintf "Self-loops are not allowed: \"%s\" -> \"%s\"" fromNode toNode)
+
+        this.AddNode(fromNode)
+        this.AddNode(toNode)
+        forward.[fromNode].Add(toNode) |> ignore
+        reverse.[toNode].Add(fromNode) |> ignore
+
+    member _.RemoveEdge(fromNode: string, toNode: string) =
+        ensureNode fromNode
+
+        if not (forward.ContainsKey(toNode)) || not (forward.[fromNode].Contains(toNode)) then
+            raise (EdgeNotFoundError(fromNode, toNode))
+
+        forward.[fromNode].Remove(toNode) |> ignore
+        reverse.[toNode].Remove(fromNode) |> ignore
+
+    member _.HasEdge(fromNode: string, toNode: string) =
+        forward.ContainsKey(fromNode) && forward.[fromNode].Contains(toNode)
+
+    member _.Successors(node: string) =
+        ensureNode node
+        orderedStrings forward.[node]
+
+    member _.Predecessors(node: string) =
+        ensureNode node
+        orderedStrings reverse.[node]
+
+    member _.Edges() =
+        [
+            for KeyValue(source, targets) in forward do
+                for target in targets do
+                    yield source, target
+        ]
+        |> List.sortWith (fun (leftSource, leftTarget) (rightSource, rightTarget) ->
+            let bySource = StringComparer.Ordinal.Compare(leftSource, rightSource)
+            if bySource <> 0 then bySource else StringComparer.Ordinal.Compare(leftTarget, rightTarget))
+
+    member this.TransitiveClosure(startNode: string) =
+        this.Reach(startNode, this.Successors)
+
+    member this.TransitiveDependents(startNode: string) =
+        this.Reach(startNode, this.Predecessors)
+
+    member this.TopologicalSort() =
+        let indegree = Dictionary<string, int>(StringComparer.Ordinal)
+        for node in forward.Keys do
+            indegree.[node] <- reverse.[node].Count
+
+        let available =
+            ResizeArray(
+                indegree
+                |> Seq.choose (fun (KeyValue(node, count)) -> if count = 0 then Some node else None)
+                |> Seq.sortWith (fun left right -> StringComparer.Ordinal.Compare(left, right)))
+        let order = ResizeArray<string>()
+
+        let popSmallest () =
+            let smallest =
+                available
+                |> Seq.minBy id
+
+            available.Remove(smallest) |> ignore
+            smallest
+
+        while available.Count > 0 do
+            let node = popSmallest ()
+            order.Add(node)
+
+            for successor in this.Successors(node) do
+                indegree.[successor] <- indegree.[successor] - 1
+                if indegree.[successor] = 0 then
+                    available.Add(successor)
+
+        if order.Count <> forward.Count then
+            raise (CycleError("Graph contains a cycle", this.FindCycle()))
+
+        order |> Seq.toList
+
+    member this.IndependentGroups() =
+        let indegree = Dictionary<string, int>(StringComparer.Ordinal)
+        for node in forward.Keys do
+            indegree.[node] <- reverse.[node].Count
+
+        let remaining = HashSet<string>(forward.Keys, StringComparer.Ordinal)
+        let groups = ResizeArray<IReadOnlyList<string>>()
+
+        while remaining.Count > 0 do
+            let layer =
+                remaining
+                |> Seq.filter (fun node -> indegree.[node] = 0)
+                |> Seq.sortWith (fun left right -> StringComparer.Ordinal.Compare(left, right))
+                |> Seq.toList
+
+            if List.isEmpty layer then
+                raise (CycleError("Graph contains a cycle", this.FindCycle()))
+
+            groups.Add(layer)
+            for node in layer do
+                remaining.Remove(node) |> ignore
+                for successor in this.Successors(node) do
+                    indegree.[successor] <- indegree.[successor] - 1
+
+        groups |> Seq.toList
+
+    member this.AffectedNodes(changedNodes: seq<string>) =
+        let affected = HashSet<string>(StringComparer.Ordinal)
+        for node in changedNodes do
+            if this.HasNode(node) then
+                affected.Add(node) |> ignore
+                affected.UnionWith(this.TransitiveClosure(node))
+
+        this.TopologicalSort() |> List.filter affected.Contains
+
+    member private _.Reach(startNode: string, next: string -> string list) =
+        ensureNode startNode
+
+        let visited = HashSet<string>(StringComparer.Ordinal)
+        let stack = Stack<string>()
+        stack.Push(startNode)
+
+        while stack.Count > 0 do
+            let node = stack.Pop()
+            for neighbor in next(node) do
+                if visited.Add(neighbor) then
+                    stack.Push(neighbor)
+
+        visited :> ISet<string>
+
+    member private this.FindCycle() =
+        let visited = HashSet<string>(StringComparer.Ordinal)
+        let onStack = HashSet<string>(StringComparer.Ordinal)
+        let parent = Dictionary<string, string option>(StringComparer.Ordinal)
+
+        let rec findCycleFrom node =
+            if onStack.Contains(node) then
+                let mutable cycle = [ node ]
+                let mutable current =
+                    match parent.TryGetValue(node) with
+                    | true, value -> value
+                    | _ -> None
+
+                while current.IsSome && current.Value <> node do
+                    cycle <- current.Value :: cycle
+                    current <-
+                        match parent.TryGetValue(current.Value) with
+                        | true, value -> value
+                        | _ -> None
+
+                cycle @ [ node ]
+
+            elif not (visited.Add(node)) then
+                []
+
+            else
+                onStack.Add(node) |> ignore
+                let mutable found = []
+                for successor in this.Successors(node) do
+                    if List.isEmpty found then
+                        parent.[successor] <- Some node
+                        let cycle = findCycleFrom successor
+                        if not (List.isEmpty cycle) then
+                            found <- cycle
+
+                onStack.Remove(node) |> ignore
+                found
+
+        forward.Keys
+        |> Seq.tryPick (fun node ->
+            let cycle = findCycleFrom node
+            if List.isEmpty cycle then None else Some cycle)
+        |> Option.defaultValue []
+
+type LabeledDirectedGraph(?allowSelfLoops: bool) =
+    let graph = Graph(defaultArg allowSelfLoops false)
+    let labels = Dictionary<string, Dictionary<string, HashSet<string>>>(StringComparer.Ordinal)
+
+    member _.AddNode(node: string) =
+        graph.AddNode(node)
+        if not (labels.ContainsKey(node)) then
+            labels.[node] <- Dictionary<string, HashSet<string>>(StringComparer.Ordinal)
+
+    member this.AddEdge(fromNode: string, toNode: string, label: string) =
+        this.AddNode(fromNode)
+        this.AddNode(toNode)
+        graph.AddEdge(fromNode, toNode)
+
+        if not (labels.[fromNode].ContainsKey(toNode)) then
+            labels.[fromNode].[toNode] <- HashSet<string>(StringComparer.Ordinal)
+
+        labels.[fromNode].[toNode].Add(label) |> ignore
+
+    member _.Labels(fromNode: string, toNode: string) =
+        match labels.TryGetValue(fromNode) with
+        | true, targets when targets.ContainsKey(toNode) ->
+            targets.[toNode] |> Seq.sortWith (fun left right -> StringComparer.Ordinal.Compare(left, right)) |> Seq.toList
+        | _ ->
+            []
+
+    member _.TopologicalSort() = graph.TopologicalSort()
+    member _.TransitiveClosure(startNode: string) = graph.TransitiveClosure(startNode)
 
 module DirectedGraph =
-    let create allowSelfLoops =
-        Graph(allowSelfLoops)
-
-    let createDefault () =
-        Graph()
+    let create allowSelfLoops = Graph(allowSelfLoops)
+    let createDefault () = Graph()
 
     let addEdge fromNode toNode (graph: Graph) =
         graph.AddEdge(fromNode, toNode)
         graph
 
-    let topologicalSort (graph: Graph) =
-        graph.TopologicalSort() |> Seq.toList
+    let topologicalSort (graph: Graph) = graph.TopologicalSort()

--- a/code/packages/fsharp/directed-graph/README.md
+++ b/code/packages/fsharp/directed-graph/README.md
@@ -1,3 +1,3 @@
 # Directed Graph
 
-F# wrapper helpers for the C# directed-graph implementation.
+Pure F# directed graph operations with topological sorting, dependency grouping, transitive queries, and labeled edges.

--- a/code/packages/fsharp/directed-graph/tests/CodingAdventures.DirectedGraph.Tests/DirectedGraphTests.fs
+++ b/code/packages/fsharp/directed-graph/tests/CodingAdventures.DirectedGraph.Tests/DirectedGraphTests.fs
@@ -12,3 +12,24 @@ module DirectedGraphTests =
             |> DirectedGraph.addEdge "B" "C"
 
         Assert.Equal<string list>(["A"; "B"; "C"], DirectedGraph.topologicalSort graph)
+
+    [<Fact>]
+    let ``graph exposes successors predecessors and affected nodes`` () =
+        let graph = Graph()
+        graph.AddEdge("logic-gates", "arithmetic")
+        graph.AddEdge("arithmetic", "cpu")
+        graph.AddEdge("logic-gates", "alu")
+
+        Assert.Equal<string list>(["alu"; "arithmetic"], graph.Successors("logic-gates"))
+        Assert.Equal<string list>(["logic-gates"], graph.Predecessors("arithmetic"))
+        Assert.Equal<string list>(["logic-gates"; "alu"; "arithmetic"; "cpu"], graph.AffectedNodes([ "logic-gates" ]))
+
+    [<Fact>]
+    let ``cycles surface a helpful error`` () =
+        let graph = Graph()
+        graph.AddEdge("A", "B")
+        graph.AddEdge("B", "C")
+        graph.AddEdge("C", "A")
+
+        let error = Assert.Throws<CycleError>(fun () -> graph.TopologicalSort() |> ignore)
+        Assert.Contains("A", error.Cycle)

--- a/code/packages/fsharp/grammar-tools/BUILD
+++ b/code/packages/fsharp/grammar-tools/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.GrammarTools.Tests/CodingAdventures.GrammarTools.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/grammar-tools/BUILD
+++ b/code/packages/fsharp/grammar-tools/BUILD
@@ -1,1 +1,1 @@
-dotnet test tests/CodingAdventures.GrammarTools.Tests/CodingAdventures.GrammarTools.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
+mkdir -p .dotnet && DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_CLI_HOME="$PWD/.dotnet" dotnet test tests/CodingAdventures.GrammarTools.Tests/CodingAdventures.GrammarTools.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/grammar-tools/BUILD_windows
+++ b/code/packages/fsharp/grammar-tools/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.GrammarTools.Tests/CodingAdventures.GrammarTools.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/grammar-tools/CHANGELOG.md
+++ b/code/packages/fsharp/grammar-tools/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+- 0.1.0 Initial pure F# release.

--- a/code/packages/fsharp/grammar-tools/CodingAdventures.GrammarTools.fsproj
+++ b/code/packages/fsharp/grammar-tools/CodingAdventures.GrammarTools.fsproj
@@ -1,17 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
-    <AssemblyName>CodingAdventures.Lexer.FSharp</AssemblyName>
+    <AssemblyName>CodingAdventures.GrammarTools.FSharp</AssemblyName>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageId>CodingAdventures.Lexer.FSharp</PackageId>
+    <PackageId>CodingAdventures.GrammarTools.FSharp</PackageId>
     <Version>0.1.0</Version>
     <Authors>Adhithya Rajasekaran</Authors>
-    <Description>Pure F# grammar-driven lexer built on the F# grammar tools package</Description>
+    <Description>Pure F# parsers and data models for .tokens and .grammar files</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../fsharp/grammar-tools/CodingAdventures.GrammarTools.fsproj" />
-    <Compile Include="Lexer.fs" />
+    <Compile Include="GrammarTools.fs" />
   </ItemGroup>
 </Project>

--- a/code/packages/fsharp/grammar-tools/GrammarTools.fs
+++ b/code/packages/fsharp/grammar-tools/GrammarTools.fs
@@ -1,0 +1,562 @@
+namespace CodingAdventures.GrammarTools.FSharp
+
+open System
+open System.Collections.Generic
+open System.Text
+
+type TokenGrammarError(message: string, lineNumber: int) =
+    inherit Exception(sprintf "Line %d: %s" lineNumber message)
+
+    member _.LineNumber = lineNumber
+
+type TokenDefinition(name: string, pattern: string, isRegex: bool, lineNumber: int, ?alias: string) =
+    member _.Name = name
+    member _.Pattern = pattern
+    member _.IsRegex = isRegex
+    member _.LineNumber = lineNumber
+    member _.Alias = defaultArg alias null
+
+type PatternGroup(name: string, definitions: IReadOnlyList<TokenDefinition>) =
+    member _.Name = name
+    member _.Definitions = definitions
+
+type TokenGrammar
+    (
+        definitions: IReadOnlyList<TokenDefinition>,
+        keywords: IReadOnlyList<string>,
+        ?mode: string,
+        ?escapeMode: string,
+        ?skipDefinitions: IReadOnlyList<TokenDefinition>,
+        ?reservedKeywords: IReadOnlyList<string>,
+        ?groups: IReadOnlyDictionary<string, PatternGroup>,
+        ?caseSensitive: bool,
+        ?version: int,
+        ?caseInsensitive: bool,
+        ?contextKeywords: IReadOnlyList<string>,
+        ?softKeywords: IReadOnlyList<string>,
+        ?errorDefinitions: IReadOnlyList<TokenDefinition>
+    ) =
+    let emptyDefinitions = Array.Empty<TokenDefinition>() :> IReadOnlyList<TokenDefinition>
+    let emptyStrings = Array.Empty<string>() :> IReadOnlyList<string>
+    let emptyGroups =
+        Dictionary<string, PatternGroup>(StringComparer.Ordinal) :> IReadOnlyDictionary<string, PatternGroup>
+
+    member _.Definitions = definitions
+    member _.Keywords = keywords
+    member _.Mode = defaultArg mode null
+    member _.EscapeMode = defaultArg escapeMode null
+    member _.SkipDefinitions = defaultArg skipDefinitions emptyDefinitions
+    member _.ReservedKeywords = defaultArg reservedKeywords emptyStrings
+    member _.Groups = defaultArg groups emptyGroups
+    member _.CaseSensitive = defaultArg caseSensitive true
+    member _.Version = defaultArg version 0
+    member _.CaseInsensitive = defaultArg caseInsensitive false
+    member _.ContextKeywords = defaultArg contextKeywords emptyStrings
+    member _.SoftKeywords = defaultArg softKeywords emptyStrings
+    member _.ErrorDefinitions = defaultArg errorDefinitions emptyDefinitions
+
+[<AbstractClass>]
+type GrammarElement() = class end
+
+type RuleReference(name: string, isToken: bool) =
+    inherit GrammarElement()
+
+    member _.Name = name
+    member _.IsToken = isToken
+
+type Literal(value: string) =
+    inherit GrammarElement()
+
+    member _.Value = value
+
+type Group(element: GrammarElement) =
+    inherit GrammarElement()
+
+    member _.Element = element
+
+type Optional(element: GrammarElement) =
+    inherit GrammarElement()
+
+    member _.Element = element
+
+type Repetition(element: GrammarElement) =
+    inherit GrammarElement()
+
+    member _.Element = element
+
+type Alternation(choices: IReadOnlyList<GrammarElement>) =
+    inherit GrammarElement()
+
+    member _.Choices = choices
+
+type Sequence(elements: IReadOnlyList<GrammarElement>) =
+    inherit GrammarElement()
+
+    member _.Elements = elements
+
+type PositiveLookahead(element: GrammarElement) =
+    inherit GrammarElement()
+
+    member _.Element = element
+
+type NegativeLookahead(element: GrammarElement) =
+    inherit GrammarElement()
+
+    member _.Element = element
+
+type OneOrMoreRepetition(element: GrammarElement) =
+    inherit GrammarElement()
+
+    member _.Element = element
+
+type SeparatedRepetition(element: GrammarElement, separator: GrammarElement, atLeastOne: bool) =
+    inherit GrammarElement()
+
+    member _.Element = element
+    member _.Separator = separator
+    member _.AtLeastOne = atLeastOne
+
+type GrammarRule(name: string, body: GrammarElement) =
+    member _.Name = name
+    member _.Body = body
+
+type ParserGrammar(?rules: IReadOnlyList<GrammarRule>) =
+    let emptyRules = Array.Empty<GrammarRule>() :> IReadOnlyList<GrammarRule>
+
+    member _.Rules = defaultArg rules emptyRules
+
+type ParserGrammarError(message: string, lineNumber: int) =
+    inherit Exception(sprintf "Line %d: %s" lineNumber message)
+
+    member _.LineNumber = lineNumber
+
+module private TokenGrammarParsing =
+    let tryParseMagicComment (line: string) =
+        let trimmed = line.Trim()
+        if not (trimmed.StartsWith("# @", StringComparison.Ordinal)) then
+            false, String.Empty, String.Empty
+        else
+            let rest = trimmed.Substring(3).Trim()
+            let split = rest.Split([| ' ' |], 2, StringSplitOptions.RemoveEmptyEntries)
+            if split.Length = 0 then
+                false, String.Empty, String.Empty
+            else
+                let value = if split.Length = 2 then split[1].Trim() else String.Empty
+                true, split[0], value
+
+    let unescapeQuoted (text: string) =
+        let result = StringBuilder(text.Length)
+        let mutable i = 0
+
+        while i < text.Length do
+            if text[i] = '\\' && i + 1 < text.Length then
+                i <- i + 1
+
+                result.Append(
+                    match text[i] with
+                    | 'n' -> '\n'
+                    | 't' -> '\t'
+                    | 'r' -> '\r'
+                    | '"' -> '"'
+                    | '\\' -> '\\'
+                    | ch -> ch)
+                |> ignore
+            else
+                result.Append(text[i]) |> ignore
+
+            i <- i + 1
+
+        result.ToString()
+
+    let parseDefinition (line: string) lineNumber =
+        let equalsIndex = line.IndexOf('=')
+        if equalsIndex < 1 then
+            raise (TokenGrammarError("Expected TOKEN_NAME = PATTERN", lineNumber))
+
+        let name = line.Substring(0, equalsIndex).Trim()
+        let mutable rhs = line.Substring(equalsIndex + 1).Trim()
+        let mutable alias = None
+        let aliasIndex = rhs.IndexOf("->", StringComparison.Ordinal)
+
+        if aliasIndex >= 0 then
+            alias <- Some(rhs.Substring(aliasIndex + 2).Trim())
+            rhs <- rhs.Substring(0, aliasIndex).Trim()
+
+        if rhs.StartsWith("/", StringComparison.Ordinal) && rhs.EndsWith("/", StringComparison.Ordinal) then
+            TokenDefinition(name, rhs.Substring(1, rhs.Length - 2), true, lineNumber, ?alias = alias)
+        elif rhs.StartsWith("\"", StringComparison.Ordinal) && rhs.EndsWith("\"", StringComparison.Ordinal) then
+            TokenDefinition(name, unescapeQuoted (rhs.Substring(1, rhs.Length - 2)), false, lineNumber, ?alias = alias)
+        else
+            raise (TokenGrammarError("Pattern must be /regex/ or \"literal\"", lineNumber))
+
+[<AbstractClass; Sealed>]
+type TokenGrammarParser =
+    static member Parse(source: string) =
+        let definitions = ResizeArray<TokenDefinition>()
+        let skipDefinitions = ResizeArray<TokenDefinition>()
+        let errorDefinitions = ResizeArray<TokenDefinition>()
+        let keywords = ResizeArray<string>()
+        let reserved = ResizeArray<string>()
+        let contextKeywords = ResizeArray<string>()
+        let softKeywords = ResizeArray<string>()
+        let groups = Dictionary<string, PatternGroup>(StringComparer.Ordinal)
+        let groupDefinitions = Dictionary<string, ResizeArray<TokenDefinition>>(StringComparer.Ordinal)
+        let mutable mode = None
+        let mutable escapeMode = None
+        let mutable version = 0
+        let mutable caseInsensitive = false
+        let mutable section = "definitions"
+        let mutable currentGroup = None
+
+        let lines = source.Replace("\r\n", "\n").Split('\n')
+
+        for index = 0 to lines.Length - 1 do
+            let lineNumber = index + 1
+            let trimmed = lines[index].Trim()
+
+            if trimmed.Length <> 0 then
+                if trimmed.StartsWith("#", StringComparison.Ordinal) then
+                    let ok, key, value = TokenGrammarParsing.tryParseMagicComment trimmed
+
+                    if ok then
+                        if key = "version" then
+                            match Int32.TryParse(value) with
+                            | true, parsedVersion -> version <- parsedVersion
+                            | _ -> ()
+                        elif key = "case_insensitive" then
+                            match Boolean.TryParse(value) with
+                            | true, parsedBool -> caseInsensitive <- parsedBool
+                            | _ -> ()
+                elif trimmed.StartsWith("mode:", StringComparison.Ordinal) then
+                    mode <- Some(trimmed.Substring("mode:".Length).Trim())
+                elif trimmed.StartsWith("escape_mode:", StringComparison.Ordinal) then
+                    escapeMode <- Some(trimmed.Substring("escape_mode:".Length).Trim())
+                elif
+                    trimmed = "keywords:"
+                    || trimmed = "reserved:"
+                    || trimmed = "context_keywords:"
+                    || trimmed = "soft_keywords:"
+                    || trimmed = "skip:"
+                    || trimmed = "errors:"
+                then
+                    section <- trimmed.Substring(0, trimmed.Length - 1)
+                    currentGroup <- None
+                elif trimmed.StartsWith("group ", StringComparison.Ordinal) && trimmed.EndsWith(":", StringComparison.Ordinal) then
+                    let groupName = trimmed.Substring(6, trimmed.Length - 7).Trim()
+
+                    if groupName.Length = 0 then
+                        raise (TokenGrammarError("Group name cannot be empty", lineNumber))
+
+                    section <- "group"
+                    currentGroup <- Some groupName
+                    groupDefinitions[groupName] <- ResizeArray<TokenDefinition>()
+                else
+                    match section with
+                    | "keywords" -> keywords.Add(trimmed)
+                    | "reserved" -> reserved.Add(trimmed)
+                    | "context_keywords" -> contextKeywords.Add(trimmed)
+                    | "soft_keywords" -> softKeywords.Add(trimmed)
+                    | "definitions"
+                    | "skip"
+                    | "errors"
+                    | "group" ->
+                        let definition = TokenGrammarParsing.parseDefinition trimmed lineNumber
+
+                        match section with
+                        | "skip" -> skipDefinitions.Add(definition)
+                        | "errors" -> errorDefinitions.Add(definition)
+                        | "group" -> groupDefinitions[currentGroup.Value].Add(definition)
+                        | _ -> definitions.Add(definition)
+                    | _ -> raise (TokenGrammarError(sprintf "Unsupported section '%s'" section, lineNumber))
+
+        for KeyValue(name, defs) in groupDefinitions do
+            groups[name] <- PatternGroup(name, defs :> IReadOnlyList<TokenDefinition>)
+
+        TokenGrammar(
+            definitions :> IReadOnlyList<TokenDefinition>,
+            keywords :> IReadOnlyList<string>,
+            ?mode = mode,
+            ?escapeMode = escapeMode,
+            ?skipDefinitions = Some(skipDefinitions :> IReadOnlyList<TokenDefinition>),
+            ?reservedKeywords = Some(reserved :> IReadOnlyList<string>),
+            ?groups = Some(groups :> IReadOnlyDictionary<string, PatternGroup>),
+            ?caseSensitive = Some(not caseInsensitive),
+            ?version = Some(version),
+            ?caseInsensitive = Some(caseInsensitive),
+            ?contextKeywords = Some(contextKeywords :> IReadOnlyList<string>),
+            ?softKeywords = Some(softKeywords :> IReadOnlyList<string>),
+            ?errorDefinitions = Some(errorDefinitions :> IReadOnlyList<TokenDefinition>))
+
+[<AbstractClass; Sealed>]
+type TokenGrammarValidator =
+    static member Validate(grammar: TokenGrammar) =
+        let seen = HashSet<string>(StringComparer.Ordinal)
+
+        for definition in grammar.Definitions do
+            if not (seen.Add(definition.Name)) then
+                raise (InvalidOperationException(sprintf "Duplicate token definition: %s" definition.Name))
+
+module private ParserGrammarParsing =
+    type Kind =
+        | Identifier
+        | String
+        | Equals
+        | Pipe
+        | LBrace
+        | RBrace
+        | LBracket
+        | RBracket
+        | LParen
+        | RParen
+        | Semicolon
+        | Ampersand
+        | Bang
+        | DoubleSlash
+        | Plus
+        | End
+
+    type MetaToken =
+        {
+            Kind: Kind
+            Text: string
+            Line: int
+        }
+
+    let setOf (values: seq<Kind>) = HashSet<Kind>(values)
+
+    type Parser(tokens: ResizeArray<MetaToken>) =
+        let mutable pos = 0
+
+        member private _.Peek() = tokens[pos]
+
+        member private this.Match(kind: Kind) =
+            if this.Peek().Kind = kind then
+                let token = tokens[pos]
+                pos <- pos + 1
+                Some token
+            else
+                None
+
+        member private this.Expect(kind: Kind) =
+            match this.Match(kind) with
+            | Some token -> token
+            | None ->
+                raise (ParserGrammarError(sprintf "Expected %A but found '%s'" kind (this.Peek().Text), this.Peek().Line))
+
+        member this.Parse() =
+            let rules = ResizeArray<GrammarRule>()
+
+            while this.Peek().Kind <> Kind.End do
+                let name = this.Expect(Kind.Identifier).Text
+                this.Expect(Kind.Equals) |> ignore
+                let body = this.ParseAlternation(setOf [ Kind.Semicolon ])
+                this.Expect(Kind.Semicolon) |> ignore
+                rules.Add(GrammarRule(name, body))
+
+            ParserGrammar(rules :> IReadOnlyList<GrammarRule>)
+
+        member private this.ParseAlternation(terminators: HashSet<Kind>) =
+            let choices = ResizeArray<GrammarElement>()
+            choices.Add(this.ParseSequence(setOf (seq { yield! terminators; yield Kind.Pipe })))
+
+            while this.Match(Kind.Pipe).IsSome do
+                choices.Add(this.ParseSequence(setOf (seq { yield! terminators; yield Kind.Pipe })))
+
+            if choices.Count = 1 then
+                choices[0]
+            else
+                Alternation(choices :> IReadOnlyList<GrammarElement>) :> GrammarElement
+
+        member private this.ParseSequence(terminators: HashSet<Kind>) =
+            let elements = ResizeArray<GrammarElement>()
+
+            while not (terminators.Contains(this.Peek().Kind)) && this.Peek().Kind <> Kind.End do
+                elements.Add(this.ParseElement())
+
+            match elements.Count with
+            | 0 -> Sequence(Array.Empty<GrammarElement>() :> IReadOnlyList<GrammarElement>) :> GrammarElement
+            | 1 -> elements[0]
+            | _ -> Sequence(elements :> IReadOnlyList<GrammarElement>) :> GrammarElement
+
+        member private this.ParseElement() =
+            match this.Match(Kind.Ampersand) with
+            | Some _ -> PositiveLookahead(this.ParseElement()) :> GrammarElement
+            | None ->
+                match this.Match(Kind.Bang) with
+                | Some _ -> NegativeLookahead(this.ParseElement()) :> GrammarElement
+                | None ->
+                    match this.Match(Kind.Identifier) with
+                    | Some identifier ->
+                        let isToken = identifier.Text |> Seq.forall (fun ch -> Char.IsUpper(ch) || ch = '_')
+                        RuleReference(identifier.Text, isToken) :> GrammarElement
+                    | None ->
+                        match this.Match(Kind.String) with
+                        | Some literal -> Literal(literal.Text) :> GrammarElement
+                        | None ->
+                            match this.Match(Kind.LParen) with
+                            | Some _ ->
+                                let inner = this.ParseAlternation(setOf [ Kind.RParen ])
+                                this.Expect(Kind.RParen) |> ignore
+                                Group(inner) :> GrammarElement
+                            | None ->
+                                match this.Match(Kind.LBracket) with
+                                | Some _ ->
+                                    let inner = this.ParseAlternation(setOf [ Kind.RBracket ])
+                                    this.Expect(Kind.RBracket) |> ignore
+                                    Optional(inner) :> GrammarElement
+                                | None ->
+                                    match this.Match(Kind.LBrace) with
+                                    | Some _ ->
+                                        let inner = this.ParseAlternation(setOf [ Kind.RBrace; Kind.DoubleSlash ])
+
+                                        let repetition =
+                                            match this.Match(Kind.DoubleSlash) with
+                                            | Some _ ->
+                                                let separator = this.ParseAlternation(setOf [ Kind.RBrace ])
+                                                this.Expect(Kind.RBrace) |> ignore
+                                                SeparatedRepetition(inner, separator, false) :> GrammarElement
+                                            | None ->
+                                                this.Expect(Kind.RBrace) |> ignore
+                                                Repetition(inner) :> GrammarElement
+
+                                        match this.Match(Kind.Plus) with
+                                        | Some _ ->
+                                            match repetition with
+                                            | :? SeparatedRepetition as separated ->
+                                                SeparatedRepetition(separated.Element, separated.Separator, true) :> GrammarElement
+                                            | :? Repetition as repeated -> OneOrMoreRepetition(repeated.Element) :> GrammarElement
+                                            | _ -> repetition
+                                        | None -> repetition
+                                    | None ->
+                                        raise (ParserGrammarError(sprintf "Unexpected token '%s'" (this.Peek().Text), this.Peek().Line))
+
+    let tokenize (source: string) =
+        let tokens = ResizeArray<MetaToken>()
+        let mutable line = 1
+        let mutable i = 0
+
+        while i < source.Length do
+            let ch = source[i]
+
+            if ch = '\r' then
+                i <- i + 1
+            elif ch = '\n' then
+                line <- line + 1
+                i <- i + 1
+            elif Char.IsWhiteSpace(ch) then
+                i <- i + 1
+            elif ch = '#' then
+                while i < source.Length && source[i] <> '\n' do
+                    i <- i + 1
+            elif Char.IsLetter(ch) || ch = '_' then
+                let start = i
+
+                while i < source.Length && (Char.IsLetterOrDigit(source[i]) || source[i] = '_' || source[i] = '-') do
+                    i <- i + 1
+
+                tokens.Add({ Kind = Kind.Identifier; Text = source.Substring(start, i - start); Line = line })
+            elif ch = '"' then
+                let builder = StringBuilder()
+                let mutable closed = false
+                i <- i + 1
+
+                while i < source.Length && not closed do
+                    if source[i] = '"' && source[i - 1] <> '\\' then
+                        i <- i + 1
+                        closed <- true
+                    elif source[i] = '\\' && i + 1 < source.Length then
+                        i <- i + 1
+
+                        builder.Append(
+                            match source[i] with
+                            | 'n' -> '\n'
+                            | 't' -> '\t'
+                            | 'r' -> '\r'
+                            | '"' -> '"'
+                            | '\\' -> '\\'
+                            | escaped -> escaped)
+                        |> ignore
+
+                        i <- i + 1
+                    else
+                        builder.Append(source[i]) |> ignore
+                        i <- i + 1
+
+                tokens.Add({ Kind = Kind.String; Text = builder.ToString(); Line = line })
+            elif ch = '/' && i + 1 < source.Length && source[i + 1] = '/' then
+                tokens.Add({ Kind = Kind.DoubleSlash; Text = "//"; Line = line })
+                i <- i + 2
+            else
+                let token =
+                    match ch with
+                    | '=' -> { Kind = Kind.Equals; Text = "="; Line = line }
+                    | '|' -> { Kind = Kind.Pipe; Text = "|"; Line = line }
+                    | '{' -> { Kind = Kind.LBrace; Text = "{"; Line = line }
+                    | '}' -> { Kind = Kind.RBrace; Text = "}"; Line = line }
+                    | '[' -> { Kind = Kind.LBracket; Text = "["; Line = line }
+                    | ']' -> { Kind = Kind.RBracket; Text = "]"; Line = line }
+                    | '(' -> { Kind = Kind.LParen; Text = "("; Line = line }
+                    | ')' -> { Kind = Kind.RParen; Text = ")"; Line = line }
+                    | ';' -> { Kind = Kind.Semicolon; Text = ";"; Line = line }
+                    | '&' -> { Kind = Kind.Ampersand; Text = "&"; Line = line }
+                    | '!' -> { Kind = Kind.Bang; Text = "!"; Line = line }
+                    | '+' -> { Kind = Kind.Plus; Text = "+"; Line = line }
+                    | _ -> raise (ParserGrammarError(sprintf "Unexpected character '%c'" ch, line))
+
+                tokens.Add(token)
+                i <- i + 1
+
+        tokens.Add({ Kind = Kind.End; Text = String.Empty; Line = line })
+        tokens
+
+[<AbstractClass; Sealed>]
+type ParserGrammarParser =
+    static member Parse(source: string) =
+        ParserGrammarParsing.Parser(ParserGrammarParsing.tokenize source).Parse()
+
+[<AbstractClass; Sealed>]
+type ParserGrammarValidator =
+    static member Validate(grammar: ParserGrammar) =
+        let names = HashSet<string>(StringComparer.Ordinal)
+
+        for rule in grammar.Rules do
+            if not (names.Add(rule.Name)) then
+                raise (InvalidOperationException(sprintf "Duplicate grammar rule: %s" rule.Name))
+
+[<AbstractClass; Sealed>]
+type CrossValidator =
+    static member Validate(tokenGrammar: TokenGrammar, parserGrammar: ParserGrammar) =
+        let tokenNames = HashSet<string>(StringComparer.Ordinal)
+
+        for definition in tokenGrammar.Definitions do
+            let exportedName =
+                if String.IsNullOrEmpty(definition.Alias) then definition.Name else definition.Alias
+
+            tokenNames.Add(exportedName) |> ignore
+
+        if tokenGrammar.Keywords.Count > 0 then
+            tokenNames.Add("KEYWORD") |> ignore
+
+        let rec visit (element: GrammarElement) =
+            match element with
+            | :? RuleReference as reference when reference.IsToken && not (tokenNames.Contains(reference.Name)) ->
+                raise (InvalidOperationException(sprintf "Unknown token reference: %s" reference.Name))
+            | :? Group as group -> visit group.Element
+            | :? Optional as optional -> visit optional.Element
+            | :? Repetition as repetition -> visit repetition.Element
+            | :? OneOrMoreRepetition as repetition -> visit repetition.Element
+            | :? PositiveLookahead as lookahead -> visit lookahead.Element
+            | :? NegativeLookahead as lookahead -> visit lookahead.Element
+            | :? SeparatedRepetition as separated ->
+                visit separated.Element
+                visit separated.Separator
+            | :? Alternation as alternation ->
+                for choice in alternation.Choices do
+                    visit choice
+            | :? Sequence as sequence ->
+                for child in sequence.Elements do
+                    visit child
+            | _ -> ()
+
+        for rule in parserGrammar.Rules do
+            visit rule.Body

--- a/code/packages/fsharp/grammar-tools/README.md
+++ b/code/packages/fsharp/grammar-tools/README.md
@@ -1,0 +1,3 @@
+# Grammar Tools
+
+Pure F# support for parsing `.tokens` and `.grammar` files into structured in-memory models.

--- a/code/packages/fsharp/grammar-tools/required_capabilities.json
+++ b/code/packages/fsharp/grammar-tools/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/grammar-tools",
+  "capabilities": [],
+  "justification": "Pure F# in-memory grammar parsing and validation."
+}

--- a/code/packages/fsharp/grammar-tools/tests/CodingAdventures.GrammarTools.Tests/CodingAdventures.GrammarTools.Tests.fsproj
+++ b/code/packages/fsharp/grammar-tools/tests/CodingAdventures.GrammarTools.Tests/CodingAdventures.GrammarTools.Tests.fsproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.GrammarTools.fsproj" />
+    <Compile Include="GrammarToolsTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/grammar-tools/tests/CodingAdventures.GrammarTools.Tests/GrammarToolsTests.fs
+++ b/code/packages/fsharp/grammar-tools/tests/CodingAdventures.GrammarTools.Tests/GrammarToolsTests.fs
@@ -1,0 +1,160 @@
+namespace CodingAdventures.GrammarTools.FSharp.Tests
+
+open System
+open System.Collections.Generic
+open CodingAdventures.GrammarTools.FSharp
+open Xunit
+
+module GrammarToolsTests =
+    [<Fact>]
+    let ``token grammar parser handles sections metadata and groups`` () =
+        let grammar =
+            TokenGrammarParser.Parse """
+                # @version 3
+                # @case_insensitive true
+                mode: default
+                escape_mode: string
+                NUMBER = /[0-9]+/
+                NAME = /[a-z]+/ -> IDENT
+                group punctuation:
+                  PLUS = "+"
+                skip:
+                  WS = /[ \t]+/
+                keywords:
+                  if
+                reserved:
+                  class
+                context_keywords:
+                  await
+                soft_keywords:
+                  from
+                errors:
+                  BAD = /.+/
+                """
+
+        Assert.Equal(2, grammar.Definitions.Count)
+        Assert.Equal("default", grammar.Mode)
+        Assert.Equal("string", grammar.EscapeMode)
+        Assert.False(grammar.CaseSensitive)
+        Assert.True(grammar.CaseInsensitive)
+        Assert.Equal(3, grammar.Version)
+        Assert.Equal("IDENT", grammar.Definitions[1].Alias)
+        Assert.Single(grammar.SkipDefinitions) |> ignore
+        Assert.Single(grammar.Keywords) |> ignore
+        Assert.Single(grammar.ReservedKeywords) |> ignore
+        Assert.Single(grammar.ContextKeywords) |> ignore
+        Assert.Single(grammar.SoftKeywords) |> ignore
+        Assert.Single(grammar.ErrorDefinitions) |> ignore
+        Assert.True(grammar.Groups.ContainsKey("punctuation"))
+
+    [<Fact>]
+    let ``token grammar parser rejects malformed definitions`` () =
+        let error =
+            Assert.Throws<TokenGrammarError>(fun () ->
+                TokenGrammarParser.Parse "NAME = nope" |> ignore)
+
+        Assert.Contains("Pattern must be", error.Message)
+
+    [<Fact>]
+    let ``token grammar validator rejects duplicate definitions`` () =
+        let grammar =
+            TokenGrammar(
+                [|
+                    TokenDefinition("NAME", "[a-z]+", true, 1)
+                    TokenDefinition("NAME", "[0-9]+", true, 2)
+                |]
+                :> IReadOnlyList<TokenDefinition>,
+                Array.Empty<string>() :> IReadOnlyList<string>)
+
+        let error =
+            Assert.Throws<InvalidOperationException>(fun () ->
+                TokenGrammarValidator.Validate(grammar))
+
+        Assert.Contains("Duplicate token definition", error.Message)
+
+    [<Fact>]
+    let ``parser grammar parser handles core grammar forms`` () =
+        let grammar =
+            ParserGrammarParser.Parse """
+                program = { statement } ;
+                statement = NAME | NUMBER | [ STRING ] | &NAME NAME | !PLUS NUMBER | { NUMBER // COMMA }+ | ( NAME ) ;
+                """
+
+        Assert.Equal(2, grammar.Rules.Count)
+        Assert.Equal("program", grammar.Rules[0].Name)
+
+        match grammar.Rules[1].Body with
+        | :? Alternation as alternation ->
+            Assert.True(alternation.Choices.Count >= 6)
+
+            Assert.Contains(
+                alternation.Choices,
+                fun choice ->
+                    match choice with
+                    | :? SeparatedRepetition as repetition -> repetition.AtLeastOne
+                    | _ -> false)
+        | _ -> Assert.Fail("Expected alternation body")
+
+    [<Fact>]
+    let ``parser grammar parser reports unexpected characters`` () =
+        let error =
+            Assert.Throws<ParserGrammarError>(fun () ->
+                ParserGrammarParser.Parse "rule = NAME @ NUMBER ;" |> ignore)
+
+        Assert.Contains("Unexpected character '@'", error.Message)
+
+    [<Fact>]
+    let ``parser grammar validator rejects duplicate rules`` () =
+        let rules =
+            [|
+                GrammarRule("program", RuleReference("NAME", true) :> GrammarElement)
+                GrammarRule("program", RuleReference("NUMBER", true) :> GrammarElement)
+            |]
+
+        let error =
+            Assert.Throws<InvalidOperationException>(fun () ->
+                ParserGrammarValidator.Validate(ParserGrammar(rules :> IReadOnlyList<GrammarRule>)))
+
+        Assert.Contains("Duplicate grammar rule", error.Message)
+
+    [<Fact>]
+    let ``cross validator accepts keyword references`` () =
+        let tokenGrammar =
+            TokenGrammar(
+                [| TokenDefinition("NAME", "[a-z]+", true, 1) |] :> IReadOnlyList<TokenDefinition>,
+                [| "if" |] :> IReadOnlyList<string>)
+
+        let parserGrammar =
+            ParserGrammar(
+                [|
+                    GrammarRule(
+                        "program",
+                        Sequence(
+                            [|
+                                RuleReference("KEYWORD", true) :> GrammarElement
+                                RuleReference("NAME", true) :> GrammarElement
+                            |]
+                            :> IReadOnlyList<GrammarElement>)
+                        :> GrammarElement)
+                |]
+                :> IReadOnlyList<GrammarRule>)
+
+        CrossValidator.Validate(tokenGrammar, parserGrammar)
+
+    [<Fact>]
+    let ``cross validator rejects unknown token references`` () =
+        let tokenGrammar =
+            TokenGrammar(
+                [| TokenDefinition("NAME", "[a-z]+", true, 1) |] :> IReadOnlyList<TokenDefinition>,
+                Array.Empty<string>() :> IReadOnlyList<string>)
+
+        let parserGrammar =
+            ParserGrammar(
+                [| GrammarRule("program", RuleReference("NUMBER", true) :> GrammarElement) |]
+                :> IReadOnlyList<GrammarRule>)
+
+        let error =
+            Assert.Throws<InvalidOperationException>(fun () ->
+                CrossValidator.Validate(tokenGrammar, parserGrammar))
+
+        Assert.Contains("Unknown token reference", error.Message)

--- a/code/packages/fsharp/lexer/BUILD
+++ b/code/packages/fsharp/lexer/BUILD
@@ -1,1 +1,1 @@
-dotnet test tests/CodingAdventures.Lexer.Tests/CodingAdventures.Lexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
+mkdir -p .dotnet && DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_CLI_HOME="$PWD/.dotnet" dotnet test tests/CodingAdventures.Lexer.Tests/CodingAdventures.Lexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/lexer/CHANGELOG.md
+++ b/code/packages/fsharp/lexer/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## 0.1.0
 
-- add initial F# lexer wrapper
+- replace the initial C# wrapper with a native F# lexer implementation

--- a/code/packages/fsharp/lexer/CodingAdventures.Lexer.fsproj
+++ b/code/packages/fsharp/lexer/CodingAdventures.Lexer.fsproj
@@ -6,12 +6,11 @@
     <PackageId>CodingAdventures.Lexer.FSharp</PackageId>
     <Version>0.1.0</Version>
     <Authors>Adhithya Rajasekaran</Authors>
-    <Description>F# wrappers for the lexer package</Description>
+    <Description>Pure F# grammar-driven lexer built on the shared grammar model</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../csharp/lexer/CodingAdventures.Lexer.csproj" />
     <ProjectReference Include="../../csharp/grammar-tools/CodingAdventures.GrammarTools.csproj" />
     <Compile Include="Lexer.fs" />
   </ItemGroup>

--- a/code/packages/fsharp/lexer/Lexer.fs
+++ b/code/packages/fsharp/lexer/Lexer.fs
@@ -3,7 +3,7 @@ namespace CodingAdventures.Lexer.FSharp
 open System
 open System.Collections.Generic
 open System.Text.RegularExpressions
-open CodingAdventures.GrammarTools
+open CodingAdventures.GrammarTools.FSharp
 
 type TokenType =
     | Name = 0

--- a/code/packages/fsharp/lexer/Lexer.fs
+++ b/code/packages/fsharp/lexer/Lexer.fs
@@ -1,11 +1,224 @@
 namespace CodingAdventures.Lexer.FSharp
 
+open System
+open System.Collections.Generic
+open System.Text.RegularExpressions
 open CodingAdventures.GrammarTools
-open CodingAdventures.Lexer
+
+type TokenType =
+    | Name = 0
+    | Number = 1
+    | String = 2
+    | Keyword = 3
+    | Plus = 4
+    | Minus = 5
+    | Star = 6
+    | Slash = 7
+    | Equals = 8
+    | EqualsEquals = 9
+    | LParen = 10
+    | RParen = 11
+    | Comma = 12
+    | Colon = 13
+    | Semicolon = 14
+    | LBrace = 15
+    | RBrace = 16
+    | LBracket = 17
+    | RBracket = 18
+    | Dot = 19
+    | Bang = 20
+    | Newline = 21
+    | EOF = 22
+    | Grammar = 23
+
+type Token(tokenType: TokenType, value: string, line: int, column: int, ?typeName: string, ?flags: int) =
+    let typeName = defaultArg typeName null
+    let flags = defaultArg flags 0
+
+    static member FlagPrecededByNewline = 1
+    static member FlagContextKeyword = 2
+
+    member _.Type = tokenType
+    member _.Value = value
+    member _.Line = line
+    member _.Column = column
+    member _.TypeName = typeName
+    member _.Flags = flags
+    member this.EffectiveTypeName = if String.IsNullOrEmpty(typeName) then tokenType.ToString().ToUpperInvariant() else typeName
+    member _.HasFlag(flag: int) = (flags &&& flag) <> 0
+
+    override this.ToString() = sprintf "Token(%s, \"%s\", %d:%d)" this.EffectiveTypeName value line column
+
+    override this.Equals(other: obj) =
+        match other with
+        | :? Token as token ->
+            token.Type = tokenType
+            && token.Value = value
+            && token.Line = line
+            && token.Column = column
+            && token.TypeName = typeName
+            && token.Flags = flags
+        | _ ->
+            false
+
+    override _.GetHashCode() =
+        HashCode.Combine(tokenType, value, line, column, typeName, flags)
+
+type LexerError(message: string, line: int, column: int) =
+    inherit Exception(sprintf "Lexer error at %d:%d: %s" line column message)
+
+    member _.Line = line
+    member _.Column = column
+
+type private CompiledPattern =
+    {
+        Name: string
+        Regex: Regex
+        Alias: string
+    }
+
+type private MatcherNode =
+    {
+        Stage: string
+        Pattern: CompiledPattern
+    }
+
+type GrammarLexer(grammar: TokenGrammar) =
+    let definitionsOrEmpty (definitions: IReadOnlyList<TokenDefinition>) =
+        if isNull definitions then Seq.empty else definitions :> seq<TokenDefinition>
+
+    let compileDefinitions definitions =
+        let mutable options = RegexOptions.Compiled ||| RegexOptions.CultureInvariant
+        if not grammar.CaseSensitive then
+            options <- options ||| RegexOptions.IgnoreCase
+
+        definitions
+        |> Seq.map (fun (definition: TokenDefinition) ->
+            let pattern =
+                if definition.IsRegex then
+                    sprintf @"\G(?:%s)" definition.Pattern
+                else
+                    sprintf @"\G%s" (Regex.Escape(definition.Pattern))
+
+            {
+                Name = definition.Name
+                Regex = Regex(pattern, options)
+                Alias =
+                    if String.IsNullOrEmpty(definition.Alias) then
+                        null
+                    else
+                        definition.Alias
+            })
+        |> Seq.toList
+
+    let matcherPipeline =
+        [
+            yield!
+                compileDefinitions (definitionsOrEmpty grammar.SkipDefinitions)
+                |> List.map (fun pattern -> { Stage = "skip"; Pattern = pattern })
+            yield!
+                compileDefinitions grammar.Definitions
+                |> List.map (fun pattern -> { Stage = "token"; Pattern = pattern })
+            yield!
+                compileDefinitions (definitionsOrEmpty grammar.ErrorDefinitions)
+                |> List.map (fun pattern -> { Stage = "error"; Pattern = pattern })
+        ]
+
+    let keywords = HashSet<string>(grammar.Keywords, StringComparer.Ordinal)
+    let reserved =
+        let values =
+            if isNull grammar.ReservedKeywords then
+                Seq.empty
+            else
+                grammar.ReservedKeywords :> seq<string>
+
+        HashSet<string>(
+            values,
+            StringComparer.Ordinal)
+
+    let contextKeywords =
+        let values =
+            if isNull grammar.ContextKeywords then
+                Seq.empty
+            else
+                grammar.ContextKeywords :> seq<string>
+
+        HashSet<string>(
+            values,
+            StringComparer.Ordinal)
+
+    let normalizeCase (value: string) =
+        if grammar.CaseSensitive then value else value.ToLowerInvariant()
+
+    let advance (text: string) (line: byref<int>) (column: byref<int>) (precededByNewline: byref<bool>) =
+        for ch in text do
+            if ch = '\n' then
+                line <- line + 1
+                column <- 1
+                precededByNewline <- true
+            else
+                column <- column + 1
+
+    let promoteKeywords (tokens: ResizeArray<Token>) =
+        if keywords.Count > 0 then
+            for index in 0 .. tokens.Count - 1 do
+                let token = tokens.[index]
+                if token.TypeName = "NAME" && keywords.Contains(normalizeCase token.Value) then
+                    tokens.[index] <- Token(TokenType.Keyword, token.Value, token.Line, token.Column, "KEYWORD", token.Flags)
+
+    member _.Tokenize(source: string) =
+        let workingSource = if grammar.CaseSensitive then source else source.ToLowerInvariant()
+        let tokens = ResizeArray<Token>()
+        let mutable pos = 0
+        let mutable line = 1
+        let mutable column = 1
+        let mutable precededByNewline = false
+
+        while pos < workingSource.Length do
+            let mutable matched = false
+
+            for node in matcherPipeline do
+                if not matched then
+                    let ``match`` = node.Pattern.Regex.Match(workingSource, pos)
+                    if ``match``.Success && ``match``.Index = pos then
+                        let value = source.Substring(pos, ``match``.Length)
+                        match node.Stage with
+                        | "skip" ->
+                            advance value &line &column &precededByNewline
+                            pos <- pos + value.Length
+                        | _ ->
+                            let typeName =
+                                if String.IsNullOrEmpty(node.Pattern.Alias) then
+                                    node.Pattern.Name
+                                else
+                                    node.Pattern.Alias
+
+                            if typeName = "NAME" && reserved.Contains(value) then
+                                raise (LexerError(sprintf "Reserved keyword '%s'" value, line, column))
+
+                            let mutable tokenFlags = 0
+                            if precededByNewline then
+                                tokenFlags <- tokenFlags ||| Token.FlagPrecededByNewline
+
+                            if typeName = "NAME" && contextKeywords.Contains(normalizeCase value) then
+                                tokenFlags <- tokenFlags ||| Token.FlagContextKeyword
+
+                            tokens.Add(Token(TokenType.Grammar, value, line, column, typeName, tokenFlags))
+
+                            let mutable ignoredPrecededByNewline = false
+                            advance value &line &column &ignoredPrecededByNewline
+                            precededByNewline <- false
+                            pos <- pos + value.Length
+
+                        matched <- true
+
+            if not matched then
+                raise (LexerError(sprintf "Unexpected character '%c'" source.[pos], line, column))
+
+        promoteKeywords tokens
+        tokens.Add(Token(TokenType.EOF, String.Empty, line, column, "EOF"))
+        tokens |> Seq.toList
 
 module Lexer =
-    let parseGrammar source =
-        TokenGrammarParser.Parse(source)
-
-    let tokenize source grammar =
-        GrammarLexer(grammar).Tokenize(source) |> Seq.toList
+    let parseGrammar source = TokenGrammarParser.Parse(source)
+    let tokenize source grammar = GrammarLexer(grammar).Tokenize(source)

--- a/code/packages/fsharp/lexer/README.md
+++ b/code/packages/fsharp/lexer/README.md
@@ -1,3 +1,3 @@
 # Lexer
 
-F# wrapper helpers for the C# lexer implementation.
+Pure F# grammar-driven lexer using the shared grammar-tools grammar model.

--- a/code/packages/fsharp/lexer/tests/CodingAdventures.Lexer.Tests/LexerTests.fs
+++ b/code/packages/fsharp/lexer/tests/CodingAdventures.Lexer.Tests/LexerTests.fs
@@ -5,7 +5,7 @@ open Xunit
 
 module LexerTests =
     [<Fact>]
-    let ``lexer wrapper tokenizes`` () =
+    let ``lexer tokenizes grammar driven input`` () =
         let grammar =
             Lexer.parseGrammar """
                 NUMBER = /[0-9]+/
@@ -16,3 +16,21 @@ module LexerTests =
 
         let tokens = Lexer.tokenize "42 + 7" grammar
         Assert.Equal("NUMBER", tokens[0].TypeName)
+        Assert.Equal("PLUS", tokens[1].TypeName)
+        Assert.Equal("NUMBER", tokens[2].TypeName)
+
+    [<Fact>]
+    let ``lexer promotes keywords and preserves newline flags`` () =
+        let grammar =
+            Lexer.parseGrammar """
+                NAME = /[a-z]+/
+                skip:
+                  WS = /[ \t]+/
+                  NL = /\n/
+                keywords:
+                  if
+                """
+
+        let tokens = Lexer.tokenize "if\nname" grammar
+        Assert.Equal(TokenType.Keyword, tokens[0].Type)
+        Assert.True(tokens[1].HasFlag(Token.FlagPrecededByNewline))

--- a/code/packages/fsharp/parser/BUILD
+++ b/code/packages/fsharp/parser/BUILD
@@ -1,1 +1,1 @@
-dotnet test tests/CodingAdventures.Parser.Tests/CodingAdventures.Parser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
+mkdir -p .dotnet && DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_CLI_HOME="$PWD/.dotnet" dotnet test tests/CodingAdventures.Parser.Tests/CodingAdventures.Parser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/parser/CHANGELOG.md
+++ b/code/packages/fsharp/parser/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## 0.1.0
 
-- add initial F# parser wrapper
+- replace the initial C# wrapper with a native F# parser implementation

--- a/code/packages/fsharp/parser/CodingAdventures.Parser.fsproj
+++ b/code/packages/fsharp/parser/CodingAdventures.Parser.fsproj
@@ -6,12 +6,12 @@
     <PackageId>CodingAdventures.Parser.FSharp</PackageId>
     <Version>0.1.0</Version>
     <Authors>Adhithya Rajasekaran</Authors>
-    <Description>Pure F# grammar-driven parser built on the shared grammar model</Description>
+    <Description>Pure F# grammar-driven parser built on the F# grammar tools package</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../csharp/grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../../fsharp/grammar-tools/CodingAdventures.GrammarTools.fsproj" />
     <ProjectReference Include="../../fsharp/lexer/CodingAdventures.Lexer.fsproj" />
     <Compile Include="Parser.fs" />
   </ItemGroup>

--- a/code/packages/fsharp/parser/CodingAdventures.Parser.fsproj
+++ b/code/packages/fsharp/parser/CodingAdventures.Parser.fsproj
@@ -6,14 +6,13 @@
     <PackageId>CodingAdventures.Parser.FSharp</PackageId>
     <Version>0.1.0</Version>
     <Authors>Adhithya Rajasekaran</Authors>
-    <Description>F# wrappers for the parser package</Description>
+    <Description>Pure F# grammar-driven parser built on the shared grammar model</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../csharp/parser/CodingAdventures.Parser.csproj" />
     <ProjectReference Include="../../csharp/grammar-tools/CodingAdventures.GrammarTools.csproj" />
-    <ProjectReference Include="../../csharp/lexer/CodingAdventures.Lexer.csproj" />
+    <ProjectReference Include="../../fsharp/lexer/CodingAdventures.Lexer.fsproj" />
     <Compile Include="Parser.fs" />
   </ItemGroup>
 </Project>

--- a/code/packages/fsharp/parser/Parser.fs
+++ b/code/packages/fsharp/parser/Parser.fs
@@ -2,7 +2,7 @@ namespace CodingAdventures.Parser.FSharp
 
 open System
 open System.Collections.Generic
-open CodingAdventures.GrammarTools
+open CodingAdventures.GrammarTools.FSharp
 open CodingAdventures.Lexer.FSharp
 
 type GrammarParseError(message: string, ?token: Token) =

--- a/code/packages/fsharp/parser/Parser.fs
+++ b/code/packages/fsharp/parser/Parser.fs
@@ -1,12 +1,238 @@
 namespace CodingAdventures.Parser.FSharp
 
+open System
+open System.Collections.Generic
 open CodingAdventures.GrammarTools
-open CodingAdventures.Lexer
-open CodingAdventures.Parser
+open CodingAdventures.Lexer.FSharp
+
+type GrammarParseError(message: string, ?token: Token) =
+    inherit
+        Exception(
+            match token with
+            | Some value -> sprintf "Parse error at %d:%d: %s" value.Line value.Column message
+            | None -> sprintf "Parse error: %s" message)
+
+    member _.Token = defaultArg token Unchecked.defaultof<Token>
+
+type ASTNode(ruleName: string, children: IReadOnlyList<obj>, ?startLine: int, ?startColumn: int, ?endLine: int, ?endColumn: int) =
+    let startLine = defaultArg startLine 0
+    let startColumn = defaultArg startColumn 0
+    let endLine = defaultArg endLine 0
+    let endColumn = defaultArg endColumn 0
+
+    new (ruleName: string) = ASTNode(ruleName, ResizeArray<obj>() :> IReadOnlyList<obj>)
+
+    member _.RuleName = ruleName
+    member _.Children = children
+    member _.StartLine = startLine
+    member _.StartColumn = startColumn
+    member _.EndLine = endLine
+    member _.EndColumn = endColumn
+    member _.IsLeaf = children.Count = 1 && children.[0] :? Token
+    member this.Token = if this.IsLeaf then children.[0] :?> Token else Unchecked.defaultof<Token>
+
+    member this.DescendantCount() =
+        children
+        |> Seq.sumBy (fun child ->
+            match child with
+            | :? ASTNode as node -> 1 + node.DescendantCount()
+            | _ -> 1)
+
+type private MemoEntry =
+    {
+        Children: IReadOnlyList<obj> option
+        EndPos: int
+        Ok: bool
+    }
+
+type private MatchResult =
+    {
+        Children: IReadOnlyList<obj>
+        EndPos: int
+    }
+
+type GrammarParser(grammar: ParserGrammar) =
+    let ruleMap =
+        let result = Dictionary<string, GrammarRule>(StringComparer.Ordinal)
+        for rule in grammar.Rules do
+            result.[rule.Name] <- rule
+        result
+
+    static member private AsReadOnly(items: seq<obj>) =
+        ResizeArray<obj>(items) :> IReadOnlyList<obj>
+
+    static member private FindFirstToken(children: IReadOnlyList<obj>) =
+        children
+        |> Seq.tryPick (fun child ->
+            match child with
+            | :? Token as token -> Some token
+            | :? ASTNode as node -> GrammarParser.FindFirstToken(node.Children)
+            | _ -> None)
+
+    static member private FindLastToken(children: IReadOnlyList<obj>) =
+        children
+        |> Seq.toArray
+        |> Array.rev
+        |> Array.tryPick (fun child ->
+            match child with
+            | :? Token as token -> Some token
+            | :? ASTNode as node -> GrammarParser.FindLastToken(node.Children)
+            | _ -> None)
+
+    static member private BuildNode(ruleName: string, children: IReadOnlyList<obj>) =
+        let first = GrammarParser.FindFirstToken(children)
+        let last = GrammarParser.FindLastToken(children)
+        ASTNode(
+            ruleName,
+            children,
+            first |> Option.map (fun token -> token.Line) |> Option.defaultValue 0,
+            first |> Option.map (fun token -> token.Column) |> Option.defaultValue 0,
+            last |> Option.map (fun token -> token.Line) |> Option.defaultValue 0,
+            last |> Option.map (fun token -> token.Column) |> Option.defaultValue 0)
+
+    member this.Parse(tokens: IReadOnlyList<Token>) =
+        if grammar.Rules.Count = 0 then
+            raise (GrammarParseError("No rules in grammar", if tokens.Count > 0 then tokens.[tokens.Count - 1] else Unchecked.defaultof<Token>))
+
+        let startRule = grammar.Rules.[0].Name
+        let memo = Dictionary<struct (string * int), MemoEntry>()
+        let recursion = HashSet<struct (string * int)>()
+
+        match this.MatchRule(startRule, tokens, 0, memo, recursion) with
+        | None ->
+            raise (GrammarParseError(sprintf "Failed to parse starting rule '%s'" startRule, if tokens.Count > 0 then tokens.[0] else Unchecked.defaultof<Token>))
+        | Some result ->
+            if result.Children.Count = 1 && result.Children.[0] :? ASTNode then
+                let node = result.Children.[0] :?> ASTNode
+                if node.RuleName = startRule then node else GrammarParser.BuildNode(startRule, result.Children)
+            else
+                GrammarParser.BuildNode(startRule, result.Children)
+
+    member private this.MatchRule(ruleName: string, tokens: IReadOnlyList<Token>, pos: int, memo: IDictionary<struct (string * int), MemoEntry>, recursion: HashSet<struct (string * int)>) =
+        match memo.TryGetValue(struct (ruleName, pos)) with
+        | true, cached ->
+            if cached.Ok then
+                Some { Children = cached.Children.Value; EndPos = cached.EndPos }
+            else
+                None
+        | _ when not (recursion.Add(struct (ruleName, pos))) ->
+            memo.[struct (ruleName, pos)] <- { Children = None; EndPos = pos; Ok = false }
+            None
+        | _ ->
+            try
+                match ruleMap.TryGetValue(ruleName) with
+                | false, _ ->
+                    memo.[struct (ruleName, pos)] <- { Children = None; EndPos = pos; Ok = false }
+                    None
+                | true, rule ->
+                    match this.MatchElement(rule.Body, tokens, pos, memo, recursion) with
+                    | None ->
+                        memo.[struct (ruleName, pos)] <- { Children = None; EndPos = pos; Ok = false }
+                        None
+                    | Some result ->
+                        let wrapped = GrammarParser.AsReadOnly [ box (GrammarParser.BuildNode(ruleName, result.Children)) ]
+                        memo.[struct (ruleName, pos)] <- { Children = Some wrapped; EndPos = result.EndPos; Ok = true }
+                        Some { Children = wrapped; EndPos = result.EndPos }
+            finally
+                recursion.Remove(struct (ruleName, pos)) |> ignore
+
+    member private this.MatchRepeated(element: GrammarElement, tokens: IReadOnlyList<Token>, pos: int, memo: IDictionary<struct (string * int), MemoEntry>, recursion: HashSet<struct (string * int)>, requireOne: bool) =
+        let children = ResizeArray<obj>()
+        let mutable currentPos = pos
+        let mutable matchedOne = false
+        let mutable keepGoing = true
+
+        while keepGoing do
+            match this.MatchElement(element, tokens, currentPos, memo, recursion) with
+            | Some result when result.EndPos <> currentPos ->
+                matchedOne <- true
+                children.AddRange(result.Children)
+                currentPos <- result.EndPos
+            | _ ->
+                keepGoing <- false
+
+        if requireOne && not matchedOne then
+            None
+        else
+            Some { Children = children :> IReadOnlyList<obj>; EndPos = currentPos }
+
+    member private this.MatchElement(element: GrammarElement, tokens: IReadOnlyList<Token>, pos: int, memo: IDictionary<struct (string * int), MemoEntry>, recursion: HashSet<struct (string * int)>) =
+        match element with
+        | :? RuleReference as reference ->
+            if reference.IsToken then
+                if pos < tokens.Count && tokens.[pos].EffectiveTypeName = reference.Name then
+                    Some { Children = GrammarParser.AsReadOnly [ box tokens.[pos] ]; EndPos = pos + 1 }
+                else
+                    None
+            else
+                this.MatchRule(reference.Name, tokens, pos, memo, recursion)
+        | :? Literal as literal ->
+            if pos < tokens.Count && tokens.[pos].Value = literal.Value then
+                Some { Children = GrammarParser.AsReadOnly [ box tokens.[pos] ]; EndPos = pos + 1 }
+            else
+                None
+        | :? Sequence as sequence ->
+            let children = ResizeArray<obj>()
+            let mutable currentPos = pos
+            let mutable failed = false
+            for child in sequence.Elements do
+                if not failed then
+                    match this.MatchElement(child, tokens, currentPos, memo, recursion) with
+                    | Some result ->
+                        children.AddRange(result.Children)
+                        currentPos <- result.EndPos
+                    | None ->
+                        failed <- true
+
+            if failed then None else Some { Children = children :> IReadOnlyList<obj>; EndPos = currentPos }
+        | :? Alternation as alternation ->
+            alternation.Choices |> Seq.tryPick (fun choice -> this.MatchElement(choice, tokens, pos, memo, recursion))
+        | :? Repetition as repetition ->
+            this.MatchRepeated(repetition.Element, tokens, pos, memo, recursion, false)
+        | :? OneOrMoreRepetition as repetition ->
+            this.MatchRepeated(repetition.Element, tokens, pos, memo, recursion, true)
+        | :? Optional as optional ->
+            match this.MatchElement(optional.Element, tokens, pos, memo, recursion) with
+            | Some result -> Some result
+            | None -> Some { Children = GrammarParser.AsReadOnly []; EndPos = pos }
+        | :? Group as group ->
+            this.MatchElement(group.Element, tokens, pos, memo, recursion)
+        | :? PositiveLookahead as lookahead ->
+            if this.MatchElement(lookahead.Element, tokens, pos, memo, recursion) |> Option.isSome then
+                Some { Children = GrammarParser.AsReadOnly []; EndPos = pos }
+            else
+                None
+        | :? NegativeLookahead as lookahead ->
+            if this.MatchElement(lookahead.Element, tokens, pos, memo, recursion) |> Option.isNone then
+                Some { Children = GrammarParser.AsReadOnly []; EndPos = pos }
+            else
+                None
+        | :? SeparatedRepetition as separated ->
+            match this.MatchElement(separated.Element, tokens, pos, memo, recursion) with
+            | None when separated.AtLeastOne -> None
+            | None -> Some { Children = GrammarParser.AsReadOnly []; EndPos = pos }
+            | Some first ->
+                let children = ResizeArray<obj>(first.Children)
+                let mutable currentPos = first.EndPos
+                let mutable keepGoing = true
+
+                while keepGoing do
+                    match this.MatchElement(separated.Separator, tokens, currentPos, memo, recursion) with
+                    | None ->
+                        keepGoing <- false
+                    | Some separatorResult ->
+                        match this.MatchElement(separated.Element, tokens, separatorResult.EndPos, memo, recursion) with
+                        | None ->
+                            keepGoing <- false
+                        | Some elementResult ->
+                            children.AddRange(separatorResult.Children)
+                            children.AddRange(elementResult.Children)
+                            currentPos <- elementResult.EndPos
+
+                Some { Children = children :> IReadOnlyList<obj>; EndPos = currentPos }
+        | _ ->
+            invalidOp (sprintf "Unsupported grammar element: %s" (element.GetType().Name))
 
 module Parser =
-    let parseGrammar source =
-        ParserGrammarParser.Parse(source)
-
-    let parse tokens grammar =
-        GrammarParser(grammar).Parse(tokens)
+    let parseGrammar source = ParserGrammarParser.Parse(source)
+    let parse (tokens: IReadOnlyList<Token>) grammar = GrammarParser(grammar).Parse(tokens)

--- a/code/packages/fsharp/parser/README.md
+++ b/code/packages/fsharp/parser/README.md
@@ -1,3 +1,3 @@
 # Parser
 
-F# wrapper helpers for the C# parser implementation.
+Pure F# grammar-driven parser using the shared grammar-tools grammar model.

--- a/code/packages/fsharp/parser/tests/CodingAdventures.Parser.Tests/ParserTests.fs
+++ b/code/packages/fsharp/parser/tests/CodingAdventures.Parser.Tests/ParserTests.fs
@@ -1,13 +1,13 @@
 namespace CodingAdventures.Parser.FSharp.Tests
 
 open System.Collections.Generic
-open CodingAdventures.Lexer
+open CodingAdventures.Lexer.FSharp
 open CodingAdventures.Parser.FSharp
 open Xunit
 
 module ParserTests =
     [<Fact>]
-    let ``parser wrapper parses`` () =
+    let ``parser builds an AST from tokens`` () =
         let grammar = Parser.parseGrammar "assign = NAME EQUALS NUMBER ;"
         let tokens =
             [|
@@ -19,3 +19,20 @@ module ParserTests =
 
         let ast = Parser.parse tokens grammar
         Assert.Equal("assign", ast.RuleName)
+        Assert.Equal(1, ast.StartLine)
+        Assert.True(ast.DescendantCount() >= 3)
+
+    [<Fact>]
+    let ``parser handles repetition and optionals`` () =
+        let grammar = Parser.parseGrammar "program = { NAME } [ NUMBER ] ;"
+        let tokens =
+            [|
+                Token(TokenType.Grammar, "alpha", 1, 1, "NAME")
+                Token(TokenType.Grammar, "beta", 1, 7, "NAME")
+                Token(TokenType.Grammar, "7", 1, 12, "NUMBER")
+                Token(TokenType.EOF, "", 1, 13, "EOF")
+            |]
+
+        let ast = Parser.parse tokens grammar
+        Assert.Equal("program", ast.RuleName)
+        Assert.True(ast.DescendantCount() >= 3)

--- a/code/packages/fsharp/state-machine/BUILD
+++ b/code/packages/fsharp/state-machine/BUILD
@@ -1,1 +1,1 @@
-dotnet test tests/CodingAdventures.StateMachine.Tests/CodingAdventures.StateMachine.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
+mkdir -p .dotnet && DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_CLI_HOME="$PWD/.dotnet" dotnet test tests/CodingAdventures.StateMachine.Tests/CodingAdventures.StateMachine.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/state-machine/CHANGELOG.md
+++ b/code/packages/fsharp/state-machine/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## 0.1.0
 
-- add initial F# state-machine wrapper
+- replace the initial C# wrapper with native F# automata implementations

--- a/code/packages/fsharp/state-machine/CodingAdventures.StateMachine.fsproj
+++ b/code/packages/fsharp/state-machine/CodingAdventures.StateMachine.fsproj
@@ -6,12 +6,11 @@
     <PackageId>CodingAdventures.StateMachine.FSharp</PackageId>
     <Version>0.1.0</Version>
     <Authors>Adhithya Rajasekaran</Authors>
-    <Description>F# wrappers for the state-machine package</Description>
+    <Description>Pure F# deterministic, nondeterministic, modal, and pushdown state machines</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../csharp/state-machine/CodingAdventures.StateMachine.csproj" />
     <Compile Include="StateMachine.fs" />
   </ItemGroup>
 </Project>

--- a/code/packages/fsharp/state-machine/README.md
+++ b/code/packages/fsharp/state-machine/README.md
@@ -1,3 +1,3 @@
 # State Machine
 
-F# wrapper helpers for the C# state-machine implementation.
+Pure F# deterministic, nondeterministic, modal, and pushdown state machines.

--- a/code/packages/fsharp/state-machine/StateMachine.fs
+++ b/code/packages/fsharp/state-machine/StateMachine.fs
@@ -1,7 +1,440 @@
 namespace CodingAdventures.StateMachine.FSharp
 
+open System
 open System.Collections.Generic
-open CodingAdventures.StateMachine
+
+type TransitionAction = delegate of source: string * eventName: string * target: string -> unit
+
+[<CLIMutable>]
+type TransitionRecord =
+    {
+        Source: string
+        Event: string
+        Target: string
+        ActionName: string
+    }
+
+[<CLIMutable>]
+type ModeTransitionRecord =
+    {
+        FromMode: string
+        Trigger: string
+        ToMode: string
+    }
+
+[<CLIMutable>]
+type PDATransition =
+    {
+        Source: string
+        Event: string option
+        StackRead: string
+        Target: string
+        StackPush: IReadOnlyList<string>
+    }
+
+[<CLIMutable>]
+type PDATraceEntry =
+    {
+        Source: string
+        Event: string option
+        StackRead: string
+        Target: string
+        StackPush: IReadOnlyList<string>
+        StackAfter: IReadOnlyList<string>
+    }
+
+type DFA
+    (
+        states: seq<string>,
+        alphabet: seq<string>,
+        transitions: IDictionary<struct (string * string), string>,
+        initial: string,
+        accepting: seq<string>,
+        ?actions: IDictionary<struct (string * string), TransitionAction>
+    ) =
+    let states = HashSet<string>(states, StringComparer.Ordinal)
+    let alphabet = HashSet<string>(alphabet, StringComparer.Ordinal)
+    let accepting = HashSet<string>(accepting, StringComparer.Ordinal)
+    let transitions = Dictionary<struct (string * string), string>(transitions)
+    let actions =
+        match actions with
+        | Some value -> Dictionary<struct (string * string), TransitionAction>(value)
+        | None -> Dictionary<struct (string * string), TransitionAction>()
+
+    let trace = ResizeArray<TransitionRecord>()
+    let mutable currentState = initial
+
+    do
+        if states.Count = 0 then
+            invalidArg "states" "states set must be non-empty"
+
+        if not (states.Contains(initial)) then
+            invalidArg "initial" (sprintf "Initial state '%s' is not in the states set" initial)
+
+        if not (accepting |> Seq.forall states.Contains) then
+            invalidArg "accepting" "Accepting states must be a subset of states"
+
+        for KeyValue(struct (state, eventName), target) in transitions do
+            if not (states.Contains(state)) || not (states.Contains(target)) then
+                invalidArg "transitions" "Transition source and target must be in states"
+
+            if not (alphabet.Contains(eventName)) then
+                invalidArg "transitions" "Transition events must be in alphabet"
+
+    member _.States = states :> IReadOnlyCollection<string>
+    member _.Alphabet = alphabet :> IReadOnlyCollection<string>
+    member _.Accepting = accepting :> IReadOnlyCollection<string>
+    member _.Initial = initial
+    member _.CurrentState = currentState
+    member _.Transitions = Dictionary<struct (string * string), string>(transitions) :> IReadOnlyDictionary<struct (string * string), string>
+    member _.Trace = trace |> Seq.toList
+
+    member _.Process(eventName: string) =
+        let key = struct (currentState, eventName)
+        match transitions.TryGetValue(key) with
+        | true, target ->
+            let action =
+                match actions.TryGetValue(key) with
+                | true, value -> Some value
+                | _ -> None
+
+            action |> Option.iter (fun callback -> callback.Invoke(currentState, eventName, target))
+            trace.Add(
+                {
+                    Source = currentState
+                    Event = eventName
+                    Target = target
+                    ActionName = action |> Option.map (fun callback -> callback.Method.Name) |> Option.defaultValue String.Empty
+                })
+            currentState <- target
+            target
+        | _ ->
+            invalidOp (sprintf "No transition defined for (%s, %s)" currentState eventName)
+
+    member this.Process(events: seq<string>) =
+        let mutable state = currentState
+        for eventName in events do
+            state <- this.Process(eventName)
+
+        state
+
+    member _.Reset() =
+        currentState <- initial
+        trace.Clear()
+
+    member _.IsAccepting() = accepting.Contains(currentState)
+
+    member this.Accepts(events: seq<string>) =
+        this.Reset()
+        this.Process(events) |> ignore
+        this.IsAccepting()
+
+    member _.MissingTransitions() =
+        let missing = Dictionary<struct (string * string), string>()
+        for state in states do
+            for eventName in alphabet do
+                let key = struct (state, eventName)
+                if not (transitions.ContainsKey(key)) then
+                    missing.[key] <- String.Empty
+
+        missing
+
+    member this.IsComplete() = this.MissingTransitions().Count = 0
+
+    member _.ReachableStates() =
+        let reachable = HashSet<string>(StringComparer.Ordinal)
+        reachable.Add(initial) |> ignore
+        let queue = Queue<string>()
+        queue.Enqueue(initial)
+
+        while queue.Count > 0 do
+            let state = queue.Dequeue()
+            for eventName in alphabet do
+                match transitions.TryGetValue(struct (state, eventName)) with
+                | true, target when reachable.Add(target) ->
+                    queue.Enqueue(target)
+                | _ -> ()
+
+        reachable :> ISet<string>
+
+type NFA
+    (
+        states: seq<string>,
+        alphabet: seq<string>,
+        transitions: IDictionary<struct (string * string), seq<string>>,
+        initial: string,
+        accepting: seq<string>
+    ) =
+    let states = HashSet<string>(states, StringComparer.Ordinal)
+    let alphabet = HashSet<string>(alphabet, StringComparer.Ordinal)
+    let accepting = HashSet<string>(accepting, StringComparer.Ordinal)
+    let transitions =
+        Dictionary<struct (string * string), HashSet<string>>(
+            transitions
+            |> Seq.map (fun (KeyValue(key, value)) -> KeyValuePair<_, _>(key, HashSet<string>(value, StringComparer.Ordinal))))
+
+    let mutable currentStates = HashSet<string>(StringComparer.Ordinal)
+
+    do
+        if not (states.Contains(initial)) then
+            invalidArg "initial" (sprintf "Initial state '%s' is not in the states set" initial)
+
+        currentStates <-
+            let closure = HashSet<string>(StringComparer.Ordinal)
+            closure.Add(initial) |> ignore
+            closure
+
+    static member EPSILON = ""
+
+    member _.States = states :> IReadOnlyCollection<string>
+    member _.Alphabet = alphabet :> IReadOnlyCollection<string>
+    member _.Accepting = accepting :> IReadOnlyCollection<string>
+    member _.Initial = initial
+    member _.CurrentStates = currentStates :> IReadOnlySet<string>
+
+    member this.Reset() =
+        currentStates <- this.EpsilonClosure([ initial ])
+
+    member _.EpsilonClosure(seedStates: seq<string>) =
+        let closure = HashSet<string>(seedStates, StringComparer.Ordinal)
+        let stack = Stack<string>(closure)
+        while stack.Count > 0 do
+            let state = stack.Pop()
+            match transitions.TryGetValue(struct (state, NFA.EPSILON)) with
+            | true, targets ->
+                for target in targets do
+                    if closure.Add(target) then
+                        stack.Push(target)
+            | _ -> ()
+
+        closure
+
+    member this.Process(eventName: string) =
+        let next = HashSet<string>(StringComparer.Ordinal)
+        for state in currentStates do
+            match transitions.TryGetValue(struct (state, eventName)) with
+            | true, targets -> next.UnionWith(targets)
+            | _ -> ()
+
+        currentStates <- this.EpsilonClosure(next)
+        currentStates :> IReadOnlySet<string>
+
+    member this.Accepts(events: seq<string>) =
+        this.Reset()
+        for eventName in events do
+            this.Process(eventName) |> ignore
+
+        currentStates.Overlaps(accepting)
+
+[<AbstractClass; Sealed>]
+type Minimize private () =
+    static member Run(dfa: DFA) =
+        let reachable = dfa.ReachableStates()
+        let accepting = HashSet<string>(reachable |> Seq.filter (fun state -> (dfa.Accepting :> seq<string>) |> Seq.contains state), StringComparer.Ordinal)
+        let nonAccepting = HashSet<string>(reachable |> Seq.filter (fun state -> not (accepting.Contains(state))), StringComparer.Ordinal)
+        let mutable partitions =
+            [
+                if accepting.Count > 0 then accepting
+                if nonAccepting.Count > 0 then nonAccepting
+            ]
+
+        let splitGroup (group: HashSet<string>) (allPartitions: HashSet<string> list) =
+            if group.Count <= 1 then
+                [ group ]
+            else
+                let stateToPartition =
+                    allPartitions
+                    |> List.mapi (fun index partition -> partition |> Seq.map (fun state -> state, index))
+                    |> Seq.concat
+                    |> dict
+
+                group
+                |> Seq.groupBy (fun state ->
+                    dfa.Alphabet
+                    |> Seq.cast<string>
+                    |> Seq.sortWith (fun left right -> StringComparer.Ordinal.Compare(left, right))
+                    |> Seq.map (fun eventName ->
+                        match dfa.Transitions.TryGetValue(struct (state, eventName)) with
+                        | true, target -> string stateToPartition.[target]
+                        | _ -> "-1")
+                    |> String.concat "|")
+                |> Seq.map (fun (_, states) -> HashSet<string>(states, StringComparer.Ordinal))
+                |> Seq.toList
+
+        let mutable changed = true
+        while changed do
+            changed <- false
+            let nextPartitions = ResizeArray<HashSet<string>>()
+            for group in partitions do
+                let splits = splitGroup group partitions
+                nextPartitions.AddRange(splits)
+                if splits.Length > 1 then
+                    changed <- true
+
+            partitions <- nextPartitions |> Seq.toList
+
+        let partitionNames =
+            partitions
+            |> List.map (fun group ->
+                if group.Count = 1 then
+                    Seq.head group
+                else
+                    "{" + (group |> Seq.sortWith (fun left right -> StringComparer.Ordinal.Compare(left, right)) |> String.concat ",") + "}")
+
+        let stateToPartition =
+            partitions
+            |> List.mapi (fun index partition -> partition |> Seq.map (fun state -> state, index))
+            |> Seq.concat
+            |> dict
+
+        let minimizedTransitions = Dictionary<struct (string * string), string>()
+        for index, group in partitions |> List.indexed do
+            let representative = Seq.head group
+            let fromName = partitionNames.[index]
+            for eventName in dfa.Alphabet |> Seq.cast<string> do
+                match dfa.Transitions.TryGetValue(struct (representative, eventName)) with
+                | true, target ->
+                    minimizedTransitions.[struct (fromName, eventName)] <- partitionNames.[stateToPartition.[target]]
+                | _ -> ()
+
+        let acceptingStates =
+            partitions
+            |> List.indexed
+            |> List.choose (fun (index, group) ->
+                if group |> Seq.exists (fun state -> (dfa.Accepting :> seq<string>) |> Seq.contains state) then
+                    Some partitionNames.[index]
+                else
+                    None)
+
+        DFA(partitionNames, dfa.Alphabet, minimizedTransitions, partitionNames.[stateToPartition.[dfa.Initial]], acceptingStates)
+
+type ModalStateMachine(modes: IDictionary<string, DFA>, modeTransitions: IDictionary<struct (string * string), string>, initialMode: string) =
+    let modes = Dictionary<string, DFA>(modes, StringComparer.Ordinal)
+    let modeTransitions = Dictionary<struct (string * string), string>(modeTransitions)
+    let modeTrace = ResizeArray<ModeTransitionRecord>()
+    let mutable currentMode = initialMode
+
+    do
+        if not (modes.ContainsKey(initialMode)) then
+            invalidArg "initialMode" (sprintf "Unknown mode '%s'" initialMode)
+
+    member _.InitialMode = initialMode
+    member _.CurrentMode = currentMode
+    member _.ActiveMachine = modes.[currentMode]
+    member _.ModeTrace = modeTrace |> Seq.toList
+
+    member this.Process(eventName: string) =
+        this.ActiveMachine.Process(eventName)
+
+    member this.TriggerMode(trigger: string) =
+        match modeTransitions.TryGetValue(struct (currentMode, trigger)) with
+        | true, target ->
+            let fromMode = currentMode
+            currentMode <- target
+            this.ActiveMachine.Reset()
+            modeTrace.Add({ FromMode = fromMode; Trigger = trigger; ToMode = target })
+            target
+        | _ ->
+            invalidOp (sprintf "No mode transition defined for (%s, %s)" currentMode trigger)
+
+    member _.Reset() =
+        currentMode <- initialMode
+        modeTrace.Clear()
+        for machine in modes.Values do
+            machine.Reset()
+
+type PushdownAutomaton
+    (
+        states: seq<string>,
+        inputAlphabet: seq<string>,
+        stackAlphabet: seq<string>,
+        transitions: seq<PDATransition>,
+        initial: string,
+        initialStackSymbol: string,
+        accepting: seq<string>
+    ) =
+    let index =
+        Dictionary<struct (string * string option * string), PDATransition>(
+            transitions
+            |> Seq.map (fun transition -> KeyValuePair<_, _>(struct (transition.Source, transition.Event, transition.StackRead), transition)))
+
+    let accepting = HashSet<string>(accepting, StringComparer.Ordinal)
+    let stack = ResizeArray<string>()
+    let trace = ResizeArray<PDATraceEntry>()
+    let mutable currentState = initial
+
+    do
+        if not (states |> Seq.exists ((=) initial)) then
+            invalidArg "initial" (sprintf "Initial state '%s' is not in the states set" initial)
+
+        if not (accepting |> Seq.forall (fun state -> states |> Seq.exists ((=) state))) then
+            invalidArg "accepting" "Accepting states must be a subset of states"
+
+        ignore inputAlphabet
+        ignore stackAlphabet
+        stack.Add(initialStackSymbol)
+
+    let applyTransition (transition: PDATransition) =
+        if stack.Count = 0 || stack.[stack.Count - 1] <> transition.StackRead then
+            invalidOp "PDA stack top does not match transition"
+
+        stack.RemoveAt(stack.Count - 1)
+        for symbol in transition.StackPush do
+            stack.Add(symbol)
+
+        currentState <- transition.Target
+        trace.Add(
+            {
+                Source = transition.Source
+                Event = transition.Event
+                StackRead = transition.StackRead
+                Target = transition.Target
+                StackPush = transition.StackPush
+                StackAfter = stack |> Seq.toList
+            })
+
+    let step eventName =
+        let top = if stack.Count > 0 then stack.[stack.Count - 1] else String.Empty
+        match index.TryGetValue(struct (currentState, eventName, top)) with
+        | true, transition -> applyTransition transition
+        | _ -> invalidOp (sprintf "No PDA transition defined for (%s, %A, %s)" currentState eventName top)
+
+    let tryStepEpsilon () =
+        let top = if stack.Count > 0 then stack.[stack.Count - 1] else String.Empty
+        match index.TryGetValue(struct (currentState, None, top)) with
+        | true, transition ->
+            applyTransition transition
+            true
+        | _ -> false
+
+    member _.Initial = initial
+    member _.InitialStackSymbol = initialStackSymbol
+    member _.CurrentState = currentState
+    member _.Stack = stack |> Seq.toList
+    member _.Trace = trace |> Seq.toList
+
+    member _.Reset() =
+        currentState <- initial
+        stack.Clear()
+        stack.Add(initialStackSymbol)
+        trace.Clear()
+
+    member _.Process(eventName: string) =
+        step (Some eventName)
+        while tryStepEpsilon () do
+            ()
+
+    member this.Process(events: seq<string>) =
+        for eventName in events do
+            this.Process(eventName)
+
+        while tryStepEpsilon () do
+            ()
+
+    member this.Accepts(events: seq<string>) =
+        this.Reset()
+        this.Process(events)
+        accepting.Contains(currentState)
 
 module StateMachine =
     let createDfa
@@ -10,4 +443,4 @@ module StateMachine =
         (transitions: IDictionary<struct (string * string), string>)
         (initial: string)
         (accepting: seq<string>) =
-        DFA(states, alphabet, Dictionary<struct (string * string), string>(transitions), initial, accepting)
+        DFA(states, alphabet, transitions, initial, accepting)

--- a/code/packages/fsharp/state-machine/tests/CodingAdventures.StateMachine.Tests/StateMachineTests.fs
+++ b/code/packages/fsharp/state-machine/tests/CodingAdventures.StateMachine.Tests/StateMachineTests.fs
@@ -6,7 +6,7 @@ open Xunit
 
 module StateMachineTests =
     [<Fact>]
-    let ``dfa wrapper works`` () =
+    let ``dfa processes events`` () =
         let transitions = Dictionary<struct (string * string), string>()
         transitions.Add(struct ("locked", "coin"), "unlocked")
         transitions.Add(struct ("locked", "push"), "locked")
@@ -15,3 +15,59 @@ module StateMachineTests =
 
         let dfa = StateMachine.createDfa [ "locked"; "unlocked" ] [ "coin"; "push" ] transitions "locked" [ "unlocked" ]
         Assert.Equal("unlocked", dfa.Process("coin"))
+
+    [<Fact>]
+    let ``minimize collapses equivalent states`` () =
+        let transitions = Dictionary<struct (string * string), string>()
+        transitions.Add(struct ("A", "0"), "B")
+        transitions.Add(struct ("A", "1"), "C")
+        transitions.Add(struct ("B", "0"), "B")
+        transitions.Add(struct ("B", "1"), "C")
+        transitions.Add(struct ("C", "0"), "B")
+        transitions.Add(struct ("C", "1"), "C")
+
+        let dfa = DFA([ "A"; "B"; "C" ], [ "0"; "1" ], transitions, "A", [ "C" ])
+        let minimized = Minimize.Run(dfa)
+        Assert.True((minimized.States :> seq<string>) |> Seq.length <= 3)
+        Assert.True(minimized.Accepts([ "1" ]))
+
+    [<Fact>]
+    let ``pushdown automaton traces stack updates`` () =
+        let transitions =
+            [
+                {
+                    Source = "start"
+                    Event = Some "("
+                    StackRead = "$"
+                    Target = "start"
+                    StackPush = [ "$"; "(" ]
+                }
+                {
+                    Source = "start"
+                    Event = Some "("
+                    StackRead = "("
+                    Target = "start"
+                    StackPush = [ "("; "(" ]
+                }
+                {
+                    Source = "start"
+                    Event = Some ")"
+                    StackRead = "("
+                    Target = "start"
+                    StackPush = []
+                }
+            ]
+
+        let pda =
+            PushdownAutomaton(
+                [ "start" ],
+                [ "("; ")" ],
+                [ "$"; "(" ],
+                transitions,
+                "start",
+                "$",
+                [ "start" ])
+
+        pda.Process([ "("; "("; ")" ])
+        Assert.Equal("start", pda.CurrentState)
+        Assert.True(pda.Stack |> Seq.contains "(")


### PR DESCRIPTION
## Summary
- rewrite the F# directed-graph and state-machine packages as native F# implementations
- replace the F# lexer and parser wrappers with F# implementations that keep only the shared grammar-tools dependency
- update tests and package metadata to reflect the native F# ports

## Testing
- dotnet test code/packages/fsharp/directed-graph/tests/CodingAdventures.DirectedGraph.Tests/CodingAdventures.DirectedGraph.Tests.fsproj --no-restore
- dotnet test code/packages/fsharp/state-machine/tests/CodingAdventures.StateMachine.Tests/CodingAdventures.StateMachine.Tests.fsproj --no-restore
- dotnet test code/packages/fsharp/lexer/tests/CodingAdventures.Lexer.Tests/CodingAdventures.Lexer.Tests.fsproj --no-restore
- dotnet test code/packages/fsharp/parser/tests/CodingAdventures.Parser.Tests/CodingAdventures.Parser.Tests.fsproj --no-restore

## Follow-up
- port grammar-tools to F# so lexer and parser can drop their remaining shared C# dependency