### PR TITLE
Add Dart graph package

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ This repo is part computing-stack curriculum, part polyglot package lab, part to
 
 As of this refresh, the repo contains:
 
-- 2014 package directories across 11 package language roots
-- 132 program directories across 14 program language roots
-- 303 Markdown specs in `code/specs/`
+- 2198 package directories across 17 package language roots
+- 135 program directories across 14 program language roots
+- 309 Markdown specs in `code/specs/`
 - 12 learning files in `code/learning/`
 - 41 shared grammar source files in `code/grammars/`
 
@@ -30,17 +30,23 @@ As of this refresh, the repo contains:
 
 | Language | Package dirs |
 | --- | ---: |
-| elixir | 216 |
-| go | 215 |
-| lua | 186 |
-| perl | 190 |
-| python | 256 |
-| ruby | 244 |
-| rust | 269 |
+| csharp | 8 |
+| dart | 1 |
+| elixir | 221 |
+| fsharp | 8 |
+| go | 227 |
+| haskell | 17 |
+| java | 41 |
+| kotlin | 41 |
+| lua | 189 |
+| perl | 193 |
+| python | 266 |
+| ruby | 247 |
+| rust | 284 |
 | starlark | 3 |
-| swift | 121 |
-| typescript | 247 |
-| wasm | 67 |
+| swift | 123 |
+| typescript | 260 |
+| wasm | 69 |
 
 ### Program Languages
 
@@ -50,7 +56,7 @@ As of this refresh, the repo contains:
 | dotnet | 2 |
 | elixir | 13 |
 | go | 14 |
-| haskell | 1 |
+| haskell | 2 |
 | kotlin | 5 |
 | lua | 6 |
 | perl | 4 |
@@ -59,7 +65,7 @@ As of this refresh, the repo contains:
 | rust | 14 |
 | static | 1 |
 | swift | 9 |
-| typescript | 34 |
+| typescript | 36 |
 
 ## Main Themes
 

--- a/code/packages/dart/graph/.gitignore
+++ b/code/packages/dart/graph/.gitignore
@@ -1,0 +1,2 @@
+.dart_tool/
+pubspec.lock

--- a/code/packages/dart/graph/BUILD
+++ b/code/packages/dart/graph/BUILD
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/graph/BUILD_windows
+++ b/code/packages/dart/graph/BUILD_windows
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/graph/CHANGELOG.md
+++ b/code/packages/dart/graph/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Added the initial Dart graph package with adjacency-list and adjacency-matrix representations.
+- Added BFS, DFS, connectivity, cycle detection, shortest path, and minimum spanning tree algorithms.

--- a/code/packages/dart/graph/README.md
+++ b/code/packages/dart/graph/README.md
@@ -1,0 +1,34 @@
+# coding_adventures_graph
+
+Undirected weighted graph package for Dart with interchangeable adjacency-list
+and adjacency-matrix storage.
+
+## What It Provides
+
+- `Graph` with `GraphRepr.adjacencyList` and `GraphRepr.adjacencyMatrix`
+- Weighted undirected edges, including self-loops
+- `bfs`, `dfs`, `isConnected`, `connectedComponents`, and `hasCycle`
+- `shortestPath` and `minimumSpanningTree`
+
+## Usage
+
+```dart
+import 'package:coding_adventures_graph/graph.dart';
+
+void main() {
+  final graph = Graph<String>(GraphRepr.adjacencyList);
+  graph.addEdge('London', 'Paris', 300);
+  graph.addEdge('London', 'Amsterdam', 520);
+  graph.addEdge('Amsterdam', 'Berlin', 655);
+
+  print(shortestPath(graph, 'London', 'Berlin'));
+  // [London, Amsterdam, Berlin]
+}
+```
+
+## Building and Testing
+
+```bash
+dart pub get
+dart test
+```

--- a/code/packages/dart/graph/lib/graph.dart
+++ b/code/packages/dart/graph/lib/graph.dart
@@ -1,0 +1,3 @@
+export 'src/algorithms.dart';
+export 'src/errors.dart';
+export 'src/graph.dart';

--- a/code/packages/dart/graph/lib/src/algorithms.dart
+++ b/code/packages/dart/graph/lib/src/algorithms.dart
@@ -1,0 +1,407 @@
+import 'dart:collection';
+
+import 'errors.dart';
+import 'graph.dart';
+
+List<T> bfs<T>(Graph<T> graph, T start) {
+  if (!graph.hasNode(start)) {
+    throw NodeNotFoundError<T>(start);
+  }
+
+  final visited = <T>{start};
+  final queue = ListQueue<T>()..add(start);
+  final result = <T>[];
+
+  while (queue.isNotEmpty) {
+    final node = queue.removeFirst();
+    result.add(node);
+
+    for (final neighbor in _sortedNodes(graph.neighbors(node))) {
+      if (visited.add(neighbor)) {
+        queue.addLast(neighbor);
+      }
+    }
+  }
+
+  return List<T>.unmodifiable(result);
+}
+
+List<T> dfs<T>(Graph<T> graph, T start) {
+  if (!graph.hasNode(start)) {
+    throw NodeNotFoundError<T>(start);
+  }
+
+  final visited = <T>{};
+  final stack = <T>[start];
+  final result = <T>[];
+
+  while (stack.isNotEmpty) {
+    final node = stack.removeLast();
+    if (!visited.add(node)) {
+      continue;
+    }
+
+    result.add(node);
+
+    for (final neighbor in _sortedNodes(graph.neighbors(node)).reversed) {
+      if (!visited.contains(neighbor)) {
+        stack.add(neighbor);
+      }
+    }
+  }
+
+  return List<T>.unmodifiable(result);
+}
+
+bool isConnected<T>(Graph<T> graph) {
+  if (graph.size == 0) {
+    return true;
+  }
+
+  final start = _sortedNodes(graph.nodes()).first;
+  return bfs(graph, start).length == graph.size;
+}
+
+List<Set<T>> connectedComponents<T>(Graph<T> graph) {
+  final unvisited = graph.nodes().toSet();
+  final result = <Set<T>>[];
+
+  while (unvisited.isNotEmpty) {
+    final start = _sortedNodes(unvisited).first;
+    final component = bfs(graph, start).toSet();
+    result.add(Set<T>.unmodifiable(component));
+    for (final node in component) {
+      unvisited.remove(node);
+    }
+  }
+
+  return List<Set<T>>.unmodifiable(result);
+}
+
+bool hasCycle<T>(Graph<T> graph) {
+  final visited = <T>{};
+
+  for (final start in _sortedNodes(graph.nodes())) {
+    if (visited.contains(start)) {
+      continue;
+    }
+
+    final stack = <_CycleFrame<T>>[_CycleFrame<T>(node: start)];
+    while (stack.isNotEmpty) {
+      final frame = stack.removeLast();
+      if (visited.contains(frame.node)) {
+        continue;
+      }
+
+      visited.add(frame.node);
+      for (final neighbor in _sortedNodes(graph.neighbors(frame.node))) {
+        if (!visited.contains(neighbor)) {
+          stack.add(
+            _CycleFrame<T>(
+              node: neighbor,
+              parent: frame.node,
+              hasParent: true,
+            ),
+          );
+        } else if (!frame.hasParent || neighbor != frame.parent) {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
+List<T> shortestPath<T>(Graph<T> graph, T start, T end) {
+  if (!graph.hasNode(start) || !graph.hasNode(end)) {
+    return <T>[];
+  }
+  if (start == end) {
+    return List<T>.unmodifiable(<T>[start]);
+  }
+
+  final allUnit = graph.edges().every((edge) => edge.weight == 1.0);
+  return allUnit
+      ? _bfsShortestPath(graph, start, end)
+      : _dijkstraShortestPath(graph, start, end);
+}
+
+Set<WeightedEdge<T>> minimumSpanningTree<T>(Graph<T> graph) {
+  final nodes = _sortedNodes(graph.nodes());
+  final edges = graph.edges();
+  if (nodes.length <= 1 || edges.isEmpty) {
+    return <WeightedEdge<T>>{};
+  }
+  if (!isConnected(graph)) {
+    throw const GraphNotConnectedError();
+  }
+
+  final unionFind = _UnionFind<T>(nodes);
+  final mst = LinkedHashSet<WeightedEdge<T>>();
+  for (final edge in edges) {
+    if (unionFind.find(edge.left) != unionFind.find(edge.right)) {
+      unionFind.union(edge.left, edge.right);
+      mst.add(edge);
+      if (mst.length == nodes.length - 1) {
+        break;
+      }
+    }
+  }
+
+  return Set<WeightedEdge<T>>.unmodifiable(mst);
+}
+
+List<T> _bfsShortestPath<T>(Graph<T> graph, T start, T end) {
+  final parent = <T, T>{};
+  final visited = <T>{start};
+  final queue = ListQueue<T>()..add(start);
+
+  while (queue.isNotEmpty) {
+    final node = queue.removeFirst();
+    if (node == end) {
+      break;
+    }
+
+    for (final neighbor in _sortedNodes(graph.neighbors(node))) {
+      if (visited.add(neighbor)) {
+        parent[neighbor] = node;
+        queue.addLast(neighbor);
+      }
+    }
+  }
+
+  if (!visited.contains(end)) {
+    return <T>[];
+  }
+
+  return _reconstructPath(parent, start, end);
+}
+
+List<T> _dijkstraShortestPath<T>(Graph<T> graph, T start, T end) {
+  final distances = <T, double>{};
+  final parent = <T, T>{};
+  final queue = _MinPriorityQueue<T>();
+  var sequence = 0;
+
+  for (final node in graph.nodes()) {
+    distances[node] = double.infinity;
+  }
+
+  distances[start] = 0;
+  queue.push(priority: 0, sequence: sequence, value: start);
+
+  while (queue.isNotEmpty) {
+    final current = queue.pop()!;
+    final currentDistance = distances[current.value] ?? double.infinity;
+    if (current.priority > currentDistance) {
+      continue;
+    }
+    if (current.value == end) {
+      break;
+    }
+
+    final neighbors = graph.neighborsWeighted(current.value).entries.toList()
+      ..sort((left, right) => compareNodes(left.key, right.key));
+
+    for (final entry in neighbors) {
+      final nextDistance = currentDistance + entry.value;
+      if (nextDistance < (distances[entry.key] ?? double.infinity)) {
+        distances[entry.key] = nextDistance;
+        parent[entry.key] = current.value;
+        sequence += 1;
+        queue.push(
+          priority: nextDistance,
+          sequence: sequence,
+          value: entry.key,
+        );
+      }
+    }
+  }
+
+  if ((distances[end] ?? double.infinity) == double.infinity) {
+    return <T>[];
+  }
+
+  return _reconstructPath(parent, start, end);
+}
+
+List<T> _reconstructPath<T>(Map<T, T> parent, T start, T end) {
+  final path = <T>[];
+  var current = end;
+  while (true) {
+    path.add(current);
+    if (current == start) {
+      break;
+    }
+
+    final previous = parent[current];
+    if (previous == null) {
+      return <T>[];
+    }
+    current = previous;
+  }
+
+  return List<T>.unmodifiable(path.reversed.toList());
+}
+
+List<T> _sortedNodes<T>(Iterable<T> nodes) {
+  final sorted = nodes.toList();
+  sorted.sort(compareNodes);
+  return sorted;
+}
+
+class _CycleFrame<T> {
+  _CycleFrame({
+    required this.node,
+    this.parent,
+    this.hasParent = false,
+  });
+
+  final T node;
+  final T? parent;
+  final bool hasParent;
+}
+
+class _PriorityQueueEntry<T> {
+  const _PriorityQueueEntry({
+    required this.priority,
+    required this.sequence,
+    required this.value,
+  });
+
+  final double priority;
+  final int sequence;
+  final T value;
+}
+
+class _MinPriorityQueue<T> {
+  final List<_PriorityQueueEntry<T>> _items = <_PriorityQueueEntry<T>>[];
+
+  bool get isNotEmpty => _items.isNotEmpty;
+
+  void push({
+    required double priority,
+    required int sequence,
+    required T value,
+  }) {
+    _items.add(
+      _PriorityQueueEntry<T>(
+        priority: priority,
+        sequence: sequence,
+        value: value,
+      ),
+    );
+    _bubbleUp(_items.length - 1);
+  }
+
+  _PriorityQueueEntry<T>? pop() {
+    if (_items.isEmpty) {
+      return null;
+    }
+
+    final top = _items.first;
+    final last = _items.removeLast();
+    if (_items.isNotEmpty) {
+      _items[0] = last;
+      _bubbleDown(0);
+    }
+    return top;
+  }
+
+  void _bubbleUp(int index) {
+    var currentIndex = index;
+    while (currentIndex > 0) {
+      final parentIndex = (currentIndex - 1) ~/ 2;
+      if (_compare(_items[parentIndex], _items[currentIndex]) <= 0) {
+        break;
+      }
+
+      final tmp = _items[parentIndex];
+      _items[parentIndex] = _items[currentIndex];
+      _items[currentIndex] = tmp;
+      currentIndex = parentIndex;
+    }
+  }
+
+  void _bubbleDown(int index) {
+    var currentIndex = index;
+    while (true) {
+      var smallest = currentIndex;
+      final left = currentIndex * 2 + 1;
+      final right = currentIndex * 2 + 2;
+
+      if (left < _items.length &&
+          _compare(_items[left], _items[smallest]) < 0) {
+        smallest = left;
+      }
+      if (right < _items.length &&
+          _compare(_items[right], _items[smallest]) < 0) {
+        smallest = right;
+      }
+      if (smallest == currentIndex) {
+        return;
+      }
+
+      final tmp = _items[currentIndex];
+      _items[currentIndex] = _items[smallest];
+      _items[smallest] = tmp;
+      currentIndex = smallest;
+    }
+  }
+
+  int _compare(
+    _PriorityQueueEntry<T> left,
+    _PriorityQueueEntry<T> right,
+  ) {
+    final byPriority = left.priority.compareTo(right.priority);
+    if (byPriority != 0) {
+      return byPriority;
+    }
+    return left.sequence.compareTo(right.sequence);
+  }
+}
+
+class _UnionFind<T> {
+  _UnionFind(Iterable<T> nodes) {
+    for (final node in nodes) {
+      _parent[node] = node;
+      _rank[node] = 0;
+    }
+  }
+
+  final Map<T, T> _parent = <T, T>{};
+  final Map<T, int> _rank = <T, int>{};
+
+  T find(T node) {
+    final parent = _parent[node];
+    if (parent == null) {
+      throw NodeNotFoundError<T>(node);
+    }
+    if (parent != node) {
+      _parent[node] = find(parent);
+    }
+    return _parent[node] as T;
+  }
+
+  void union(T left, T right) {
+    var leftRoot = find(left);
+    var rightRoot = find(right);
+    if (leftRoot == rightRoot) {
+      return;
+    }
+
+    final leftRank = _rank[leftRoot] ?? 0;
+    final rightRank = _rank[rightRoot] ?? 0;
+    if (leftRank < rightRank) {
+      final tmp = leftRoot;
+      leftRoot = rightRoot;
+      rightRoot = tmp;
+    }
+
+    _parent[rightRoot] = leftRoot;
+    if (leftRank == rightRank) {
+      _rank[leftRoot] = leftRank + 1;
+    }
+  }
+}

--- a/code/packages/dart/graph/lib/src/errors.dart
+++ b/code/packages/dart/graph/lib/src/errors.dart
@@ -1,0 +1,33 @@
+class GraphException implements Exception {
+  const GraphException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+class NodeNotFoundError<T> extends GraphException {
+  NodeNotFoundError(this.node) : super('Node not found: ${_describeNode(node)}');
+
+  final T node;
+}
+
+class EdgeNotFoundError<T> extends GraphException {
+  EdgeNotFoundError(this.left, this.right)
+      : super(
+          'Edge not found: ${_describeNode(left)} -- ${_describeNode(right)}',
+        );
+
+  final T left;
+  final T right;
+}
+
+class GraphNotConnectedError extends GraphException {
+  const GraphNotConnectedError()
+      : super(
+          'minimumSpanningTree: graph is not connected and has no spanning tree',
+        );
+}
+
+String _describeNode(Object? node) => '$node';

--- a/code/packages/dart/graph/lib/src/graph.dart
+++ b/code/packages/dart/graph/lib/src/graph.dart
@@ -1,0 +1,333 @@
+import 'dart:collection';
+import 'dart:convert';
+
+import 'errors.dart';
+
+enum GraphRepr {
+  adjacencyList,
+  adjacencyMatrix,
+}
+
+typedef WeightedEdge<T> = ({T left, T right, double weight});
+
+int compareNodes<T>(T left, T right) {
+  if (left is String && right is String) {
+    return left.compareTo(right);
+  }
+  if (left is num && right is num) {
+    return left.compareTo(right);
+  }
+  if (left is bool && right is bool) {
+    if (left == right) {
+      return 0;
+    }
+    return left ? 1 : -1;
+  }
+
+  return _nodeSortKey(left).compareTo(_nodeSortKey(right));
+}
+
+class Graph<T> {
+  Graph([GraphRepr repr = GraphRepr.adjacencyList]) : _repr = repr;
+
+  final GraphRepr _repr;
+  final Map<T, Map<T, double>> _adj = <T, Map<T, double>>{};
+  final List<T> _nodeList = <T>[];
+  final Map<T, int> _nodeIndex = <T, int>{};
+  final List<List<double?>> _matrix = <List<double?>>[];
+
+  GraphRepr get repr => _repr;
+
+  int get size =>
+      _repr == GraphRepr.adjacencyList ? _adj.length : _nodeList.length;
+
+  void addNode(T node) {
+    if (_repr == GraphRepr.adjacencyList) {
+      _adj.putIfAbsent(node, () => <T, double>{});
+      return;
+    }
+
+    if (_nodeIndex.containsKey(node)) {
+      return;
+    }
+
+    final index = _nodeList.length;
+    _nodeList.add(node);
+    _nodeIndex[node] = index;
+
+    for (final row in _matrix) {
+      row.add(null);
+    }
+    _matrix.add(List<double?>.filled(index + 1, null, growable: true));
+  }
+
+  void removeNode(T node) {
+    if (_repr == GraphRepr.adjacencyList) {
+      final neighbors = _adj[node];
+      if (neighbors == null) {
+        throw NodeNotFoundError<T>(node);
+      }
+
+      for (final neighbor in List<T>.from(neighbors.keys)) {
+        _adj[neighbor]?.remove(node);
+      }
+      _adj.remove(node);
+      return;
+    }
+
+    final index = _nodeIndex.remove(node);
+    if (index == null) {
+      throw NodeNotFoundError<T>(node);
+    }
+
+    _nodeList.removeAt(index);
+    _matrix.removeAt(index);
+    for (final row in _matrix) {
+      row.removeAt(index);
+    }
+
+    for (var i = index; i < _nodeList.length; i++) {
+      _nodeIndex[_nodeList[i]] = i;
+    }
+  }
+
+  bool hasNode(T node) => _repr == GraphRepr.adjacencyList
+      ? _adj.containsKey(node)
+      : _nodeIndex.containsKey(node);
+
+  Set<T> nodes() {
+    final nodes = _repr == GraphRepr.adjacencyList
+        ? _adj.keys.toList()
+        : List<T>.from(_nodeList);
+    nodes.sort(compareNodes);
+    return Set<T>.unmodifiable(nodes);
+  }
+
+  void addEdge(T left, T right, [num weight = 1]) {
+    final normalizedWeight = weight.toDouble();
+    addNode(left);
+    addNode(right);
+
+    if (_repr == GraphRepr.adjacencyList) {
+      _adj[left]![right] = normalizedWeight;
+      _adj[right]![left] = normalizedWeight;
+      return;
+    }
+
+    final leftIndex = _nodeIndex[left]!;
+    final rightIndex = _nodeIndex[right]!;
+    _matrix[leftIndex][rightIndex] = normalizedWeight;
+    _matrix[rightIndex][leftIndex] = normalizedWeight;
+  }
+
+  void removeEdge(T left, T right) {
+    if (_repr == GraphRepr.adjacencyList) {
+      final leftNeighbors = _adj[left];
+      final rightNeighbors = _adj[right];
+      if (leftNeighbors == null ||
+          rightNeighbors == null ||
+          !leftNeighbors.containsKey(right)) {
+        throw EdgeNotFoundError<T>(left, right);
+      }
+
+      leftNeighbors.remove(right);
+      if (left != right) {
+        rightNeighbors.remove(left);
+      }
+      return;
+    }
+
+    final leftIndex = _nodeIndex[left];
+    final rightIndex = _nodeIndex[right];
+    if (leftIndex == null ||
+        rightIndex == null ||
+        _matrix[leftIndex][rightIndex] == null) {
+      throw EdgeNotFoundError<T>(left, right);
+    }
+
+    _matrix[leftIndex][rightIndex] = null;
+    _matrix[rightIndex][leftIndex] = null;
+  }
+
+  bool hasEdge(T left, T right) {
+    if (_repr == GraphRepr.adjacencyList) {
+      return _adj[left]?.containsKey(right) ?? false;
+    }
+
+    final leftIndex = _nodeIndex[left];
+    final rightIndex = _nodeIndex[right];
+    if (leftIndex == null || rightIndex == null) {
+      return false;
+    }
+
+    return _matrix[leftIndex][rightIndex] != null;
+  }
+
+  double edgeWeight(T left, T right) {
+    if (_repr == GraphRepr.adjacencyList) {
+      final weight = _adj[left]?[right];
+      if (weight == null) {
+        throw EdgeNotFoundError<T>(left, right);
+      }
+      return weight;
+    }
+
+    final leftIndex = _nodeIndex[left];
+    final rightIndex = _nodeIndex[right];
+    if (leftIndex == null || rightIndex == null) {
+      throw EdgeNotFoundError<T>(left, right);
+    }
+
+    final weight = _matrix[leftIndex][rightIndex];
+    if (weight == null) {
+      throw EdgeNotFoundError<T>(left, right);
+    }
+    return weight;
+  }
+
+  List<WeightedEdge<T>> edges() {
+    final result = <WeightedEdge<T>>[];
+
+    if (_repr == GraphRepr.adjacencyList) {
+      final seen = <String>{};
+      for (final entry in _adj.entries) {
+        final left = entry.key;
+        for (final neighborEntry in entry.value.entries) {
+          final right = neighborEntry.key;
+          final key = _edgeKey(left, right);
+          if (!seen.add(key)) {
+            continue;
+          }
+          result.add(_canonicalEdge(left, right, neighborEntry.value));
+        }
+      }
+    } else {
+      for (var row = 0; row < _nodeList.length; row++) {
+        for (var col = row; col < _nodeList.length; col++) {
+          final weight = _matrix[row][col];
+          if (weight != null) {
+            result.add(
+              _canonicalEdge(_nodeList[row], _nodeList[col], weight),
+            );
+          }
+        }
+      }
+    }
+
+    result.sort(_compareEdges);
+    return List<WeightedEdge<T>>.unmodifiable(result);
+  }
+
+  Set<T> neighbors(T node) {
+    if (_repr == GraphRepr.adjacencyList) {
+      final neighbors = _adj[node];
+      if (neighbors == null) {
+        throw NodeNotFoundError<T>(node);
+      }
+
+      final sorted = neighbors.keys.toList()..sort(compareNodes);
+      return Set<T>.unmodifiable(sorted);
+    }
+
+    final index = _nodeIndex[node];
+    if (index == null) {
+      throw NodeNotFoundError<T>(node);
+    }
+
+    final neighbors = <T>[];
+    for (var col = 0; col < _nodeList.length; col++) {
+      if (_matrix[index][col] != null) {
+        neighbors.add(_nodeList[col]);
+      }
+    }
+    neighbors.sort(compareNodes);
+    return Set<T>.unmodifiable(neighbors);
+  }
+
+  Map<T, double> neighborsWeighted(T node) {
+    if (_repr == GraphRepr.adjacencyList) {
+      final neighbors = _adj[node];
+      if (neighbors == null) {
+        throw NodeNotFoundError<T>(node);
+      }
+
+      final entries = neighbors.entries.toList()
+        ..sort((left, right) => compareNodes(left.key, right.key));
+      return Map<T, double>.unmodifiable(
+        LinkedHashMap<T, double>.fromEntries(entries),
+      );
+    }
+
+    final index = _nodeIndex[node];
+    if (index == null) {
+      throw NodeNotFoundError<T>(node);
+    }
+
+    final entries = <MapEntry<T, double>>[];
+    for (var col = 0; col < _nodeList.length; col++) {
+      final weight = _matrix[index][col];
+      if (weight != null) {
+        entries.add(MapEntry<T, double>(_nodeList[col], weight));
+      }
+    }
+    entries.sort((left, right) => compareNodes(left.key, right.key));
+    return Map<T, double>.unmodifiable(
+      LinkedHashMap<T, double>.fromEntries(entries),
+    );
+  }
+
+  int degree(T node) => neighbors(node).length;
+
+  @override
+  String toString() => 'Graph(nodes=$size, edges=${edges().length}, repr=$_repr)';
+}
+
+String _nodeSortKey(Object? node) {
+  if (node is String) {
+    return 'string:$node';
+  }
+  if (node is num) {
+    return 'number:$node';
+  }
+  if (node is bool) {
+    return 'bool:$node';
+  }
+  if (node == null) {
+    return 'null:null';
+  }
+
+  try {
+    return 'json:${jsonEncode(node)}';
+  } catch (_) {
+    return 'string:$node';
+  }
+}
+
+String _edgeKey<T>(T left, T right) {
+  final leftKey = _nodeSortKey(left);
+  final rightKey = _nodeSortKey(right);
+  return leftKey.compareTo(rightKey) <= 0
+      ? '$leftKey\0$rightKey'
+      : '$rightKey\0$leftKey';
+}
+
+WeightedEdge<T> _canonicalEdge<T>(T left, T right, double weight) {
+  if (compareNodes(left, right) <= 0) {
+    return (left: left, right: right, weight: weight);
+  }
+  return (left: right, right: left, weight: weight);
+}
+
+int _compareEdges<T>(WeightedEdge<T> left, WeightedEdge<T> right) {
+  final byWeight = left.weight.compareTo(right.weight);
+  if (byWeight != 0) {
+    return byWeight;
+  }
+
+  final byLeft = compareNodes(left.left, right.left);
+  if (byLeft != 0) {
+    return byLeft;
+  }
+
+  return compareNodes(left.right, right.right);
+}

--- a/code/packages/dart/graph/pubspec.yaml
+++ b/code/packages/dart/graph/pubspec.yaml
@@ -1,0 +1,14 @@
+name: coding_adventures_graph
+description: >
+  Undirected graph with adjacency-list and adjacency-matrix representations;
+  BFS, DFS, shortest path, MST, cycle detection, and connected components.
+version: 0.1.0
+repository: https://github.com/adhithyan15/coding-adventures
+
+environment:
+  sdk: ^3.0.0
+
+dependencies: {}
+
+dev_dependencies:
+  test: ^1.25.0

--- a/code/packages/dart/graph/required_capabilities.json
+++ b/code/packages/dart/graph/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "dart/graph",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/dart/graph/test/graph_test.dart
+++ b/code/packages/dart/graph/test/graph_test.dart
@@ -1,0 +1,316 @@
+import 'package:coding_adventures_graph/graph.dart';
+import 'package:test/test.dart';
+
+final representations = <GraphRepr>[
+  GraphRepr.adjacencyList,
+  GraphRepr.adjacencyMatrix,
+];
+
+Graph<String> makeGraph(GraphRepr repr) {
+  final graph = Graph<String>(repr);
+  graph.addEdge('London', 'Paris', 300);
+  graph.addEdge('London', 'Amsterdam', 520);
+  graph.addEdge('Paris', 'Berlin', 878);
+  graph.addEdge('Amsterdam', 'Berlin', 655);
+  graph.addEdge('Amsterdam', 'Brussels', 180);
+  return graph;
+}
+
+Graph<String> makeTriangle(GraphRepr repr) {
+  final graph = Graph<String>(repr);
+  graph.addEdge('A', 'B');
+  graph.addEdge('B', 'C');
+  graph.addEdge('C', 'A');
+  return graph;
+}
+
+Graph<String> makePath(GraphRepr repr) {
+  final graph = Graph<String>(repr);
+  graph.addEdge('A', 'B');
+  graph.addEdge('B', 'C');
+  return graph;
+}
+
+void main() {
+  group('construction', () {
+    test('defaults to adjacency list', () {
+      expect(Graph<String>().repr, GraphRepr.adjacencyList);
+    });
+
+    for (final repr in representations) {
+      test('tracks empty state for $repr', () {
+        final graph = Graph<String>(repr);
+        expect(graph.size, 0);
+        expect(graph.nodes(), isEmpty);
+      });
+    }
+  });
+
+  group('node operations', () {
+    for (final repr in representations) {
+      test('adds and removes nodes for $repr', () {
+        final graph = Graph<String>(repr);
+        graph.addNode('A');
+        graph.addNode('B');
+        expect(graph.hasNode('A'), isTrue);
+        expect(graph.size, 2);
+
+        graph.removeNode('A');
+        expect(graph.hasNode('A'), isFalse);
+        expect(graph.hasNode('B'), isTrue);
+        expect(graph.size, 1);
+      });
+
+      test('removing a missing node throws for $repr', () {
+        final graph = Graph<String>(repr);
+        expect(
+          () => graph.removeNode('missing'),
+          throwsA(isA<NodeNotFoundError<String>>()),
+        );
+      });
+    }
+  });
+
+  group('edge operations', () {
+    for (final repr in representations) {
+      test('creates undirected edges for $repr', () {
+        final graph = Graph<String>(repr);
+        graph.addEdge('A', 'B', 2.5);
+        expect(graph.hasEdge('A', 'B'), isTrue);
+        expect(graph.hasEdge('B', 'A'), isTrue);
+        expect(graph.edgeWeight('A', 'B'), 2.5);
+        expect(graph.edgeWeight('B', 'A'), 2.5);
+      });
+
+      test('keeps a self-loop visible as a neighbor for $repr', () {
+        final graph = Graph<String>(repr);
+        graph.addEdge('A', 'A');
+        expect(graph.hasEdge('A', 'A'), isTrue);
+        expect(graph.neighbors('A'), {'A'});
+      });
+
+      test('preserves explicit zero-weight edges for $repr', () {
+        final graph = Graph<String>(repr);
+        graph.addEdge('A', 'B', 0);
+        expect(graph.edgeWeight('A', 'B'), 0);
+        expect(graph.edges().single.weight, 0);
+      });
+
+      test('removes edges without deleting nodes for $repr', () {
+        final graph = Graph<String>(repr);
+        graph.addEdge('A', 'B');
+        graph.removeEdge('A', 'B');
+        expect(graph.hasNode('A'), isTrue);
+        expect(graph.hasNode('B'), isTrue);
+        expect(graph.hasEdge('A', 'B'), isFalse);
+      });
+
+      test('deduplicates edges() for $repr', () {
+        final graph = Graph<String>(repr);
+        graph.addEdge('A', 'B', 1);
+        graph.addEdge('B', 'C', 2);
+        expect(graph.edges(), hasLength(2));
+      });
+    }
+  });
+
+  group('neighborhood queries', () {
+    for (final repr in representations) {
+      test('returns neighbors, weights, and degree for $repr', () {
+        final graph = makeGraph(repr);
+        expect(graph.neighbors('Amsterdam'), {'Berlin', 'Brussels', 'London'});
+        expect(graph.degree('Amsterdam'), 3);
+        expect(graph.neighborsWeighted('Amsterdam')['London'], 520);
+        expect(graph.neighborsWeighted('Amsterdam')['Brussels'], 180);
+      });
+    }
+  });
+
+  group('traversals', () {
+    for (final repr in representations) {
+      test('runs BFS over reachable nodes for $repr', () {
+        expect(bfs(makePath(repr), 'A'), ['A', 'B', 'C']);
+      });
+
+      test('runs DFS over reachable nodes for $repr', () {
+        expect(dfs(makePath(repr), 'A'), ['A', 'B', 'C']);
+      });
+
+      test('limits traversal to reachable nodes for $repr', () {
+        final graph = Graph<String>(repr);
+        graph.addEdge('A', 'B');
+        graph.addNode('C');
+        expect(bfs(graph, 'A').toSet(), {'A', 'B'});
+        expect(dfs(graph, 'A').toSet(), {'A', 'B'});
+      });
+    }
+  });
+
+  group('connectivity', () {
+    for (final repr in representations) {
+      test('detects connected graphs for $repr', () {
+        expect(isConnected(makeGraph(repr)), isTrue);
+      });
+
+      test('detects disconnected graphs for $repr', () {
+        final graph = Graph<String>(repr);
+        graph.addEdge('A', 'B');
+        graph.addNode('C');
+        expect(isConnected(graph), isFalse);
+      });
+
+      test('finds connected components for $repr', () {
+        final graph = Graph<String>(repr);
+        graph.addEdge('A', 'B');
+        graph.addEdge('B', 'C');
+        graph.addEdge('D', 'E');
+        graph.addNode('F');
+
+        final components = connectedComponents(graph);
+        expect(components, hasLength(3));
+        expect(
+          components.any(
+            (component) => component.length == 3 &&
+                component.containsAll({'A', 'B', 'C'}),
+          ),
+          isTrue,
+        );
+        expect(
+          components.any(
+            (component) =>
+                component.length == 2 && component.containsAll({'D', 'E'}),
+          ),
+          isTrue,
+        );
+        expect(
+          components.any(
+            (component) =>
+                component.length == 1 && component.containsAll({'F'}),
+          ),
+          isTrue,
+        );
+      });
+    }
+  });
+
+  group('cycle detection', () {
+    for (final repr in representations) {
+      test('finds a cycle in a triangle for $repr', () {
+        expect(hasCycle(makeTriangle(repr)), isTrue);
+      });
+
+      test('reports no cycle in a path for $repr', () {
+        expect(hasCycle(makePath(repr)), isFalse);
+      });
+    }
+  });
+
+  group('shortest path', () {
+    for (final repr in representations) {
+      test('finds unweighted shortest path for $repr', () {
+        expect(shortestPath(makePath(repr), 'A', 'C'), ['A', 'B', 'C']);
+      });
+
+      test('prefers lower total weight for $repr', () {
+        final graph = Graph<String>(repr);
+        graph.addEdge('A', 'B', 1);
+        graph.addEdge('B', 'D', 10);
+        graph.addEdge('A', 'C', 3);
+        graph.addEdge('C', 'D', 3);
+        expect(shortestPath(graph, 'A', 'D'), ['A', 'C', 'D']);
+      });
+
+      test('returns empty when no path exists for $repr', () {
+        final graph = Graph<String>(repr);
+        graph.addNode('A');
+        graph.addNode('B');
+        expect(shortestPath(graph, 'A', 'B'), isEmpty);
+      });
+
+      test('handles the city example for $repr', () {
+        expect(
+          shortestPath(makeGraph(repr), 'London', 'Berlin'),
+          ['London', 'Amsterdam', 'Berlin'],
+        );
+      });
+    }
+  });
+
+  group('minimum spanning tree', () {
+    for (final repr in representations) {
+      test('returns V-1 edges for $repr', () {
+        final graph = makeGraph(repr);
+        expect(minimumSpanningTree(graph), hasLength(graph.size - 1));
+      });
+
+      test('picks the cheapest edges in a triangle for $repr', () {
+        final graph = Graph<String>(repr);
+        graph.addEdge('A', 'B', 1);
+        graph.addEdge('B', 'C', 2);
+        graph.addEdge('C', 'A', 4);
+        final total = minimumSpanningTree(graph)
+            .fold<double>(0, (sum, edge) => sum + edge.weight);
+        expect(total, 3);
+      });
+
+      test('throws on disconnected graphs for $repr', () {
+        final graph = Graph<String>(repr);
+        graph.addEdge('A', 'B');
+        graph.addNode('C');
+        expect(
+          () => minimumSpanningTree(graph),
+          throwsA(isA<GraphNotConnectedError>()),
+        );
+      });
+    }
+  });
+
+  group('edge cases', () {
+    for (final repr in representations) {
+      test('supports numeric nodes for $repr', () {
+        final graph = Graph<int>(repr);
+        graph.addEdge(1, 2);
+        graph.addEdge(2, 3);
+        expect(shortestPath(graph, 1, 3), [1, 2, 3]);
+      });
+
+      test('supports record nodes for $repr', () {
+        final origin = (0, 0);
+        final north = (0, 1);
+        final east = (1, 1);
+        final graph = Graph<(int, int)>(repr);
+        graph.addEdge(origin, north);
+        graph.addEdge(north, east);
+        expect(isConnected(graph), isTrue);
+      });
+    }
+
+    test('handles a 1000-node sparse path graph quickly enough', () {
+      final graph = Graph<int>(GraphRepr.adjacencyList);
+      for (var i = 0; i < 999; i++) {
+        graph.addEdge(i, i + 1);
+      }
+
+      expect(graph.size, 1000);
+      expect(isConnected(graph), isTrue);
+      expect(hasCycle(graph), isFalse);
+    });
+
+    for (final repr in representations) {
+      test('handles a complete K4 graph for $repr', () {
+        final graph = Graph<String>(repr);
+        final nodes = ['A', 'B', 'C', 'D'];
+        for (var i = 0; i < nodes.length; i++) {
+          for (var j = i + 1; j < nodes.length; j++) {
+            graph.addEdge(nodes[i], nodes[j]);
+          }
+        }
+
+        expect(graph.edges(), hasLength(6));
+        expect(isConnected(graph), isTrue);
+        expect(hasCycle(graph), isTrue);
+        expect(minimumSpanningTree(graph), hasLength(3));
+      });
+    }
+  });
+}

--- a/code/specs/schemas/required_capabilities.schema.json
+++ b/code/specs/schemas/required_capabilities.schema.json
@@ -18,7 +18,7 @@
     },
     "package": {
       "type": "string",
-      "pattern": "^(python|ruby|go|typescript|rust|elixir|lua|swift)/[a-z0-9][a-z0-9_-]*$",
+      "pattern": "^(csharp|dart|elixir|fsharp|go|haskell|java|kotlin|lua|perl|python|ruby|rust|starlark|swift|typescript|wasm)/[a-z0-9][a-z0-9_-]*$",
       "description": "Qualified package name matching the build tool's naming: {language}/{dirname}. Examples: python/logic-gates, ruby/lexer, go/cache, rust/json-value, elixir/json_value, lua/grammar_tools."
     },
     "capabilities": {


### PR DESCRIPTION
## Summary
- add the first Dart package in the repo as `code/packages/dart/graph`
- implement the shared graph API with adjacency-list and adjacency-matrix storage plus traversal/pathfinding algorithms
- update repo metadata so Dart packages are recognized by the capabilities schema and reflected in the root inventory

## Verification
- `dart analyze`
- `dart test`
- `go run . -root C:\Users\adhit\Downloads\Codex\coding-adventures-dart-graph-package -language dart -force -dry-run`