### PR TITLE
Rewrite JVM and CLR simulator specs

### DIFF
--- a/code/specs/04e-jvm-simulator.md
+++ b/code/specs/04e-jvm-simulator.md
@@ -1,97 +1,334 @@
-# 04e — JVM Simulator
+# 04e - JVM Simulator
 
 ## Overview
 
-A simulator for the Java Virtual Machine (JVM) bytecode instruction set.
-The JVM (1995) is the most widely deployed virtual machine in history —
-it runs Java, Kotlin, Scala, Clojure, and Groovy. It is a **stack-based**
-machine, like our VM and WASM, but with a much richer type system.
+The Java Virtual Machine is a stack-based virtual machine defined by the Java
+Virtual Machine Specification (JVMS). As of April 16, 2026, the latest Java SE
+specification is Java SE 26, released in March 2026, and the corresponding
+class file major version is 70.
+
+For this repo, the right long-term goal is not a single monolithic
+`jvm-simulator` package. The reusable seam is the class file pipeline:
+
+```text
+class bytes -> class file decoder -> constant pool / attribute decoders
+            -> method bytecode decoder -> disassembler -> runtime model
+            -> simulator
+```
+
+That mirrors the BEAM direction and makes the lower layers reusable for future
+tools such as:
+
+- class file inspectors
+- bytecode validators
+- compiler backends
+- future JIT or ahead-of-time experiments
+- cross-language ports
+
+The existing `jvm-simulator` package should become a thin facade over smaller
+packages rather than the place where all logic lives.
 
 ## Where it fits
 
-```
-Source → Lexer → Parser → JVM Compiler → JVM Simulator
-                              (new)          (new)
-```
-
-The JVM simulator sits at the same layer as WASM, ARM, and RISC-V — it's
-another execution target. The JVM compiler translates our AST into JVM
-bytecode, and the simulator executes it.
-
-## Architecture: Stack-based with typed opcodes
-
-Unlike our VM (which has a single ADD instruction), the JVM has separate
-opcodes for each type:
-
-```
-Our VM:    ADD           ← works on whatever's on the stack
-JVM:       iadd          ← integer add
-           ladd          ← long add
-           fadd          ← float add
-           dadd          ← double add
+```text
+Source -> Lexer -> Parser -> JVM compiler -> class file / bytecode pipeline -> JVM simulator
 ```
 
-The JVM also has a **local variable array** (like our STORE_LOCAL/LOAD_LOCAL)
-alongside the operand stack.
+The simulator is only the last stage. Most JVM complexity lives before
+execution: parsing class files, decoding the constant pool, understanding
+attributes, decoding method bodies, and resolving symbolic references.
 
-## Minimal instruction set for x = 1 + 2
+## Core research findings
 
+### 1. Versioning is mostly a class file problem, not an opcode-table problem
+
+The JVM instruction set is much more stable than BEAM's. The moving parts
+across Java releases are mostly:
+
+- class file major/minor versions
+- constant pool tags
+- attributes
+- verification rules
+- linkage rules
+- newer language features lowered onto old or mostly-stable opcodes
+
+Inference from JVMS editions: the biggest post-1.0 execution-level addition is
+`invokedynamic`; most newer Java features show up as new constant-pool entries
+and attributes rather than large opcode-table churn.
+
+### 2. A JVM simulator should target `.class` files and `Code` attributes
+
+For educational traces we may expose a raw-bytecode entry point, but the real
+input unit is a class file:
+
+- magic: `0xCAFEBABE`
+- minor / major version
+- constant pool
+- fields
+- methods
+- attributes
+
+Each executable method body comes from a `Code` attribute containing:
+
+- `max_stack`
+- `max_locals`
+- `code_length`
+- instruction bytes
+- exception table
+- nested attributes
+
+### 3. Public APIs should accept exact Java targets, but implementation should use profiles
+
+We should support exact targets such as:
+
+- `java_1_0_2`
+- `java_8`
+- `java_17`
+- `java_21`
+- `java_26`
+
+Internally these resolve to immutable `JvmProfile` values that describe the
+actual decoding and runtime rules.
+
+## Exact version strategy
+
+### Public target names
+
+The public interface should accept exact release identifiers, not just raw major
+numbers:
+
+```python
+simulate_class_file(data, target="java_17")
+decode_class_file(data, target="java_1_4")
 ```
-iconst_1          Push integer constant 1
-iconst_2          Push integer constant 2
-iadd              Pop two integers, push their sum
-istore_0          Pop and store in local variable 0
-return            Return from method
+
+### Internal profile model
+
+```python
+@dataclass(frozen=True)
+class JvmProfile:
+    target: str
+    classfile_major: int
+    classfile_minor_mode: Literal["legacy", "preview_capable"]
+    constant_pool_tags: frozenset[str]
+    attribute_kinds: frozenset[str]
+    verifier_mode: Literal["legacy", "stack_map_transition", "modern"]
+    invocation_mode: Literal["pre_indy", "indy_capable"]
 ```
 
-## MVP instruction set
+The target string is for user intent. The profile is what the decoder and
+simulator actually use.
 
-| Opcode | Hex | Description |
-|--------|-----|-------------|
-| `iconst_0` | 0x03 | Push int 0 |
-| `iconst_1` | 0x04 | Push int 1 |
-| `iconst_2` | 0x05 | Push int 2 |
-| `iconst_3` | 0x06 | Push int 3 |
-| `iconst_4` | 0x07 | Push int 4 |
-| `iconst_5` | 0x08 | Push int 5 |
-| `bipush` | 0x10 | Push byte as int (1 operand) |
-| `sipush` | 0x11 | Push short as int (2 operands) |
-| `ldc` | 0x12 | Push from constant pool (1 operand) |
-| `iload` | 0x15 | Load int from local variable |
-| `iload_0` | 0x1A | Load int from local 0 |
-| `iload_1` | 0x1B | Load int from local 1 |
-| `iload_2` | 0x1C | Load int from local 2 |
-| `iload_3` | 0x1D | Load int from local 3 |
-| `istore` | 0x36 | Store int to local variable |
-| `istore_0` | 0x3B | Store int to local 0 |
-| `istore_1` | 0x3C | Store int to local 1 |
-| `istore_2` | 0x3D | Store int to local 2 |
-| `istore_3` | 0x3E | Store int to local 3 |
-| `iadd` | 0x60 | Add two ints |
-| `isub` | 0x64 | Subtract two ints |
-| `imul` | 0x68 | Multiply two ints |
-| `idiv` | 0x6C | Divide two ints |
-| `if_icmpeq` | 0x9F | Branch if ints equal |
-| `if_icmpgt` | 0xA3 | Branch if int > int |
-| `goto` | 0xA7 | Unconditional branch |
-| `ireturn` | 0xAC | Return int from method |
-| `return` | 0xB1 | Return void |
-| `getstatic` | 0xB2 | Get static field (for System.out) |
-| `invokevirtual` | 0xB6 | Invoke method (for println) |
+### Class file version map
 
-## Key differences from our VM
+From Oracle's JVMS version table, the exact Java release should map as follows:
 
-| Feature | Our VM | JVM |
-|---------|--------|-----|
-| Types | Untyped stack | Typed opcodes (i/l/f/d prefix) |
-| Variables | Named (hash map) | Numbered slots (array) |
-| Constants | Index into pool | `iconst_N` shortcuts + pool |
-| Encoding | Each instruction is an object | Variable-width bytes |
-| Methods | Simple CALL/RETURN | Full method descriptors |
+| Java release | Class file major |
+|--------------|------------------|
+| 1.0.2 / 1.1 | 45 |
+| 1.2 | 46 |
+| 1.3 | 47 |
+| 1.4 | 48 |
+| 5.0 | 49 |
+| 6 | 50 |
+| 7 | 51 |
+| 8 | 52 |
+| 9 | 53 |
+| 10 | 54 |
+| 11 | 55 |
+| 12 | 56 |
+| 13 | 57 |
+| 14 | 58 |
+| 15 | 59 |
+| 16 | 60 |
+| 17 | 61 |
+| 18 | 62 |
+| 19 | 63 |
+| 20 | 64 |
+| 21 | 65 |
+| 22 | 66 |
+| 23 | 67 |
+| 24 | 68 |
+| 25 | 69 |
+| 26 | 70 |
 
-## Implementation notes
+### Compatibility buckets
 
-- Standalone simulator (does not wrap the generic CPU)
-- Bytecode is a `bytes` object (variable-width encoding)
-- Step trace captures: PC, opcode, stack before/after, locals snapshot
-- Use real JVM opcode values for educational accuracy
+Exact targets should still collapse onto a smaller number of implementation
+buckets:
+
+- `legacy_45_48`: Java 1.0.2 through 1.4
+- `classic_49_50`: Java 5 and 6
+- `indy_transition_51_52`: Java 7 and 8
+- `module_transition_53_55`: Java 9 through 11
+- `modern_56_61`: Java 12 through 17
+- `current_62_70`: Java 18 through 26
+
+This keeps the public API exact while avoiding an explosion of duplicated logic.
+
+## Proposed package structure
+
+### Python-first package split
+
+| Package | Responsibility | Primary output |
+|---------|----------------|----------------|
+| `jvm-version-profiles` | Exact-version lookup and compatibility buckets | `JvmProfile` |
+| `jvm-classfile-decoder` | Parse `CAFEBABE` container and top-level structure | `DecodedClassFile` |
+| `jvm-constant-pool-decoder` | Decode `cp_info` entries by tag and profile | `DecodedConstantPool` |
+| `jvm-attribute-decoder` | Decode class, field, method, and code attributes | `DecodedAttribute` values |
+| `jvm-bytecode-decoder` | Decode method `Code` bytes into instruction records | `JvmInstruction` list |
+| `jvm-bytecode-disassembler` | Pretty-print and label decoded bytecode | `JvmDisassembly` |
+| `jvm-verifier-model` | Stack/locals frame modeling, verifier-oriented type flow | `JvmFrameState` |
+| `jvm-runtime-model` | Heap refs, frames, operand stack, locals, class/method refs | `JvmRuntimeState` |
+| `jvm-vm-simulator` | Execute decoded method bodies | `ExecutionResult[JvmState]` |
+| `jvm-simulator` | Backward-compatible facade package | thin composition layer |
+
+### Why this split matters
+
+- `jvm-classfile-decoder` is reusable by inspectors and compilers.
+- `jvm-bytecode-decoder` is reusable by disassemblers and validators.
+- `jvm-verifier-model` is reusable even before we implement full execution.
+- `jvm-simulator` stays user-friendly while the internals stay modular.
+
+## File format and decoder boundaries
+
+### `jvm-classfile-decoder`
+
+This package should stop at structural parsing:
+
+- magic / version
+- counts
+- raw constant pool entry envelopes
+- raw field / method headers
+- raw attribute blobs
+
+It should not interpret every attribute inline. That belongs to
+`jvm-attribute-decoder`.
+
+### `jvm-constant-pool-decoder`
+
+Must handle the historical and modern tag set, including at least:
+
+- `Utf8`
+- `Integer`, `Float`, `Long`, `Double`
+- `Class`, `String`
+- `Fieldref`, `Methodref`, `InterfaceMethodref`
+- `NameAndType`
+- `MethodHandle`, `MethodType`
+- `Dynamic`, `InvokeDynamic`
+- `Module`, `Package`
+
+### `jvm-attribute-decoder`
+
+Needs a version-aware registry for attributes such as:
+
+- `Code`
+- `ConstantValue`
+- `Exceptions`
+- `InnerClasses`
+- `Signature`
+- `StackMapTable`
+- `BootstrapMethods`
+- `Module`
+- `NestHost`, `NestMembers`
+- `Record`
+- `PermittedSubclasses`
+
+Unknown attributes should be preserved as raw blobs, not discarded.
+
+### `jvm-bytecode-decoder`
+
+This package should decode instruction width and operands only. It should not
+perform execution. Important details:
+
+- branch offsets are relative to the current instruction
+- `tableswitch` and `lookupswitch` require 4-byte alignment handling
+- `wide` rewrites operand widths for a subset of instructions
+- many instructions reference constant-pool indices rather than inline values
+
+## Runtime model
+
+The simulator should model real JVM execution concepts rather than flattening
+everything into a generic stack VM:
+
+- operand stack per frame
+- local variable array per frame
+- current method and current class
+- constant pool attached to defining class
+- invocation frames and return flow
+- exception handler table lookup
+- typed computational categories (`category 1` vs `category 2`)
+
+Suggested state split:
+
+- `JvmValue`
+- `JvmFrame`
+- `JvmThreadState`
+- `JvmHeapRef`
+- `JvmClassRef`
+- `JvmMethodRef`
+
+## JVM MVP execution slice
+
+The first useful simulator slice should start with a single target profile:
+
+- `java_8`
+
+Reason:
+
+- modern enough to be useful
+- old enough to avoid modules, records, nestmates, and `ConstantDynamic`
+- common real-world bytecode corpus
+
+### MVP opcode families
+
+- constants: `iconst_*`, `bipush`, `sipush`, `ldc`, `ldc_w`, `ldc2_w`
+- loads/stores: `iload*`, `istore*`, `aload*`, `astore*`, `lload*`, `lstore*`
+- stack ops: `pop`, `dup`, `dup_x1`, `swap`
+- integer arithmetic: `iadd`, `isub`, `imul`, `idiv`, `irem`, `ineg`
+- comparisons and branches: `ifeq`, `ifne`, `if_icmp*`, `goto`
+- returns: `ireturn`, `areturn`, `return`
+- fields and calls: `getstatic`, `putstatic`, `getfield`, `putfield`,
+  `invokestatic`, `invokevirtual`, `invokespecial`
+- object basics: `new`, `checkcast`, `instanceof`
+
+### Defer for later
+
+- full verifier enforcement
+- monitors / synchronization
+- `invokedynamic`
+- interface default-method corner cases
+- module system
+- records / sealed / preview-only surface area
+
+## Cross-language portability plan
+
+We should not hardcode JVM metadata tables separately in every language port.
+Instead, check in normalized repo-owned manifests such as:
+
+- `jvm-classfile-versions.json`
+- `jvm-opcodes.json`
+- `jvm-attributes.json`
+- `jvm-constant-pool-tags.json`
+
+Each language implementation can consume those manifests while keeping runtime
+logic native.
+
+## Implementation phases
+
+1. `jvm-version-profiles`
+2. `jvm-classfile-decoder`
+3. `jvm-constant-pool-decoder`
+4. `jvm-attribute-decoder`
+5. `jvm-bytecode-decoder`
+6. `jvm-bytecode-disassembler`
+7. `jvm-runtime-model`
+8. `jvm-vm-simulator`
+9. Backward-compatible facade updates in `jvm-simulator`
+
+## References
+
+- Oracle Java SE 26 specifications: https://docs.oracle.com/javase/specs/
+- JVMS class file format: https://docs.oracle.com/javase/specs/jvms/se26/html/jvms-4.html
+- JVMS instruction set: https://docs.oracle.com/javase/specs/jvms/se26/html/jvms-6.html
+- OpenJDK JDK 26 project page: https://openjdk.org/projects/jdk/26/

--- a/code/specs/04f-clr-simulator.md
+++ b/code/specs/04f-clr-simulator.md
@@ -1,93 +1,335 @@
-# 04f — CLR Simulator
+# 04f - CLR Simulator
 
 ## Overview
 
-A simulator for the Common Language Runtime (CLR) Intermediate Language (IL),
-also known as CIL or MSIL. The CLR (2002) is Microsoft's answer to the JVM —
-it runs C#, F#, VB.NET, and PowerShell. Like the JVM, it is a **stack-based**
-virtual machine, but with notable design differences.
+The Common Language Runtime executes Common Intermediate Language (CIL) stored
+inside CLI assemblies. As of April 16, 2026:
+
+- the latest modern product release is .NET 10, originally released on
+  November 11, 2025
+- .NET Framework still spans the classic CLR line from 1.0 through 4.8.1
+- Microsoft's standards page still points to ECMA-335 / ISO/IEC 23271:2012 as
+  the CLI standard baseline
+
+For this repo, the important design decision is:
+
+- use `CLR` for the top-level simulator package
+- use `CLI` and `CIL` for the lower reusable packages
+
+That keeps the implementation aligned with the standard and makes the decoder
+pipeline reusable beyond one simulator.
 
 ## Where it fits
 
-```
-Source → Lexer → Parser → CLR Compiler → CLR Simulator
-                              (new)          (new)
-```
-
-## Architecture: Stack-based with unified type system
-
-The CLR uses a simpler opcode scheme than the JVM. Where the JVM has
-`iadd`, `ladd`, `fadd`, `dadd` (one per type), the CLR has just `add` —
-it infers the type from what's on the stack. This makes CLR bytecode
-more compact.
-
-```
-JVM:    iconst_1 / iconst_2 / iadd     ← type in the opcode
-CLR:    ldc.i4.1 / ldc.i4.2 / add      ← type inferred from stack
+```text
+Source -> Lexer -> Parser -> CLR compiler -> PE/CLI/CIL pipeline -> CLR simulator
 ```
 
-## Minimal instruction set for x = 1 + 2
+Like the JVM, the simulator is only the last stage. Most of the real work is in
+parsing the container and metadata:
 
+```text
+PE bytes -> PE decoder -> CLI header decoder -> metadata stream decoders
+         -> metadata table decoders -> signature decoder -> IL method decoder
+         -> disassembler -> runtime model -> simulator
 ```
-ldc.i4.1          Push int32 constant 1
-ldc.i4.2          Push int32 constant 2
-add               Pop two, push sum (type inferred)
-stloc.0           Store in local variable 0
-ret               Return
+
+## Core research findings
+
+### 1. Versioning is mostly a metadata/runtime-family problem, not an opcode problem
+
+The CIL opcode space is comparatively stable. Versioning pressure shows up more
+in:
+
+- runtime family (`clr` vs `coreclr`)
+- metadata version strings
+- metadata tables and coded indices
+- generic signatures and token resolution
+- verification and runtime semantics
+- PE/CLI packaging details
+
+### 2. The real input unit is a managed PE/CLI assembly, not raw IL bytes
+
+A CLR simulator should eventually accept real assemblies, not just naked IL.
+The decoder stack must understand:
+
+- DOS stub and PE signature
+- COFF header and optional header
+- CLI data directory / COR header
+- metadata root
+- metadata streams such as `#~`, `#Strings`, `#US`, `#GUID`, `#Blob`
+- method bodies in tiny or fat format
+- extra sections such as exception handling data
+
+### 3. Exact product versions should map to reusable profiles
+
+The public interface should accept exact targets such as:
+
+- `netfx_1_0`
+- `netfx_2_0`
+- `netfx_4_8_1`
+- `netcore_3_1`
+- `net_8_0`
+- `net_10_0`
+
+Internally those resolve to a smaller set of `CliProfile` compatibility buckets.
+
+## Exact version strategy
+
+### Public target names
+
+```python
+simulate_assembly(data, target="netfx_4_8_1")
+decode_cli_module(data, target="net_10_0")
 ```
 
-## MVP instruction set
+### Internal profile model
 
-| Opcode | Hex | Description |
-|--------|-----|-------------|
-| `nop` | 0x00 | No operation |
-| `ldnull` | 0x01 | Push null |
-| `ldc.i4.0` | 0x16 | Push int32 0 |
-| `ldc.i4.1` | 0x17 | Push int32 1 |
-| `ldc.i4.2` | 0x18 | Push int32 2 |
-| `ldc.i4.3` | 0x19 | Push int32 3 |
-| `ldc.i4.4` | 0x1A | Push int32 4 |
-| `ldc.i4.5` | 0x1B | Push int32 5 |
-| `ldc.i4.s` | 0x1F | Push int8 as int32 (1 operand) |
-| `ldc.i4` | 0x20 | Push int32 (4 byte operand) |
-| `ldloc.0` | 0x06 | Load local variable 0 |
-| `ldloc.1` | 0x07 | Load local variable 1 |
-| `ldloc.2` | 0x08 | Load local variable 2 |
-| `ldloc.3` | 0x09 | Load local variable 3 |
-| `stloc.0` | 0x0A | Store to local variable 0 |
-| `stloc.1` | 0x0B | Store to local variable 1 |
-| `stloc.2` | 0x0C | Store to local variable 2 |
-| `stloc.3` | 0x0D | Store to local variable 3 |
-| `ldloc.s` | 0x11 | Load local variable N (1 operand) |
-| `stloc.s` | 0x13 | Store to local variable N (1 operand) |
-| `add` | 0x58 | Add (type inferred) |
-| `sub` | 0x59 | Subtract |
-| `mul` | 0x5A | Multiply |
-| `div` | 0x5B | Divide |
-| `ceq` | 0xFE01 | Compare equal (push 1 or 0) |
-| `cgt` | 0xFE02 | Compare greater than |
-| `clt` | 0xFE04 | Compare less than |
-| `br` | 0x38 | Unconditional branch (4-byte offset) |
-| `br.s` | 0x2B | Short branch (1-byte offset) |
-| `brfalse.s` | 0x2C | Branch if false/zero (short) |
-| `brtrue.s` | 0x2D | Branch if true/nonzero (short) |
-| `ret` | 0x2A | Return |
-| `call` | 0x28 | Call method |
+```python
+@dataclass(frozen=True)
+class CliProfile:
+    target: str
+    runtime_family: Literal["clr", "coreclr"]
+    ecma_baseline: str
+    metadata_version_string: str
+    table_schema_mode: str
+    signature_feature_set: frozenset[str]
+    il_semantics_mode: str
+```
 
-## Key differences from JVM
+### Official runtime/version map
 
-| Feature | JVM | CLR |
-|---------|-----|-----|
-| Type in opcodes | Yes (`iadd`, `ladd`) | No (`add` — inferred) |
-| Generics | Type erasure (fake at runtime) | Reified (real at runtime) |
-| Value types | No (everything is object) | Yes (`struct` on stack) |
-| Multi-byte opcodes | No | Yes (`0xFE` prefix for `ceq`, `cgt`, `clt`) |
-| Short encodings | `iconst_0`..`iconst_5` | `ldc.i4.0`..`ldc.i4.8` (more!) |
+From Microsoft's runtime/version docs:
 
-## Implementation notes
+| Product line | Runtime family |
+|--------------|----------------|
+| .NET Framework 1.0 | CLR 1.0 |
+| .NET Framework 1.1 | CLR 1.1 |
+| .NET Framework 2.0 | CLR 2.0 |
+| .NET Framework 3.0 | CLR 2.0 |
+| .NET Framework 3.5 | CLR 2.0 |
+| .NET Framework 4.0 through 4.8.1 | CLR 4 |
+| .NET Core 1.0 through 3.1 | CoreCLR |
+| .NET 5 through .NET 10 | CoreCLR |
 
-- Standalone simulator (does not wrap generic CPU)
-- Bytecode is a `bytes` object (variable-width)
-- Multi-byte opcodes: `ceq` = `0xFE 0x01` (2 bytes for opcode)
-- Step trace captures: PC, opcode, stack before/after, locals snapshot
-- Use real CLR opcode values for educational accuracy
+Microsoft also states that .NET Core and .NET 5+ do not expose a separate CLR
+version number the way .NET Framework did, so a simulator cannot key only on a
+CLR number for modern releases.
+
+### Compatibility buckets
+
+Implementation can group exact targets like this:
+
+- `clr_1x`: .NET Framework 1.0 and 1.1
+- `clr_2x`: .NET Framework 2.0, 3.0, 3.5
+- `clr_4x`: .NET Framework 4.0 through 4.8.1
+- `coreclr_1_to_3`: .NET Core 1.0 through 3.1
+- `net_5_plus`: .NET 5 through current
+
+The public API stays exact even when the implementation shares logic.
+
+## Proposed package structure
+
+### Python-first package split
+
+| Package | Responsibility | Primary output |
+|---------|----------------|----------------|
+| `cli-version-profiles` | Exact target lookup and compatibility buckets | `CliProfile` |
+| `pe-container-decoder` | Parse DOS/PE/COFF container structure | `DecodedPEImage` |
+| `cli-header-decoder` | Decode the CLI header and managed-data directories | `DecodedCliHeader` |
+| `cli-metadata-streams-decoder` | Parse metadata root and stream headers | `DecodedMetadataRoot` |
+| `cli-metadata-tables-decoder` | Decode `#~` / `#-` table rows and coded indices | typed metadata rows |
+| `cli-signature-decoder` | Decode blob signatures for methods, fields, locals, generics | `DecodedSignature` |
+| `cil-method-body-decoder` | Decode tiny/fat method bodies and EH sections | `DecodedMethodBody` |
+| `cil-bytecode-disassembler` | Pretty-print IL instructions and resolved operands | `CilDisassembly` |
+| `cli-runtime-model` | Tokens, stack types, frames, heap refs, value types | `CliRuntimeState` |
+| `clr-vm-simulator` | Execute decoded IL method bodies | `ExecutionResult[ClrState]` |
+| `clr-simulator` | Backward-compatible facade package | thin composition layer |
+
+### Naming note
+
+Lower layers should prefer `cli` and `cil` because those are the standardized
+units. `clr-vm-simulator` is the execution package because users think in terms
+of the CLR.
+
+## Container and metadata boundaries
+
+### `pe-container-decoder`
+
+This package should only parse the PE shell:
+
+- DOS stub
+- PE signature
+- COFF header
+- optional header
+- section table
+- data-directory entries
+
+It should not know how to decode CLI metadata streams.
+
+### `cli-header-decoder`
+
+Must decode the managed runtime header that points to:
+
+- metadata
+- resources
+- strong name signature
+- VTable fixups
+- entry point token or RVA
+
+### `cli-metadata-streams-decoder`
+
+Should decode the metadata root and stream directory for streams such as:
+
+- `#~` or `#-`
+- `#Strings`
+- `#US`
+- `#GUID`
+- `#Blob`
+
+### `cli-metadata-tables-decoder`
+
+Must handle table schema and coded-index interpretation for rows such as:
+
+- `Module`
+- `TypeRef`, `TypeDef`, `TypeSpec`
+- `Field`
+- `MethodDef`
+- `Param`
+- `MemberRef`
+- `StandAloneSig`
+- `CustomAttribute`
+- `Assembly`, `AssemblyRef`
+- `GenericParam`, `GenericParamConstraint`
+- `MethodSpec`
+
+### `cli-signature-decoder`
+
+This should be its own package because signature blobs are reused everywhere:
+
+- method signatures
+- field signatures
+- local variable signatures
+- property signatures
+- generic instantiations
+
+## IL method bodies and disassembly
+
+### `cil-method-body-decoder`
+
+Must support:
+
+- tiny method headers
+- fat method headers
+- max stack
+- local signature token
+- raw IL bytes
+- extra sections
+- small and fat exception-handling sections
+
+### `cil-bytecode-disassembler`
+
+Must support:
+
+- single-byte opcodes
+- `0xFE`-prefixed two-byte opcodes
+- branch target reconstruction
+- metadata-token operand labeling
+- method/field/type token pretty-printing
+
+## Runtime model
+
+The simulator should model CLR concepts directly rather than flattening
+everything into a generic stack machine:
+
+- evaluation stack
+- local variable slots
+- arguments
+- current method and method signature
+- metadata token resolution
+- reference types vs value types
+- boxing and unboxing
+- `call` vs `callvirt` behavior
+- exception handler lookup
+
+Suggested state split:
+
+- `CliValue`
+- `CliEvaluationStack`
+- `ClrFrame`
+- `ClrThreadState`
+- `CliTokenResolver`
+- `ClrHeapRef`
+
+## CLR MVP execution slice
+
+The first useful executable slice should start at:
+
+- `netfx_2_0`
+
+Reason:
+
+- it includes generics, which are central to real-world CLI code
+- it avoids some of the later CLR/CoreCLR product split
+- it is a strong bridge profile: backporting to 1.x is manageable and most
+  later 4.x code shares the same broad file and IL model
+
+### MVP opcode families
+
+- constants: `ldnull`, `ldc.i4.*`, `ldc.i8`, `ldc.r4`, `ldc.r8`, `ldstr`
+- locals/args: `ldarg*`, `starg*`, `ldloc*`, `stloc*`, `ldloca*`
+- stack ops: `pop`, `dup`
+- arithmetic: `add`, `sub`, `mul`, `div`, `rem`, `neg`
+- comparisons and branches: `ceq`, `cgt`, `clt`, `br*`, `beq`, `bne.un`,
+  `switch`
+- calls: `call`, `callvirt`, `ret`
+- object model: `newobj`, `ldfld`, `stfld`, `ldsfld`, `stsfld`
+- type ops: `box`, `unbox.any`, `castclass`, `isinst`
+- exceptions: `throw`, `leave`, `endfinally`
+
+### Defer for later
+
+- full verifier emulation
+- remoting-era behavior
+- advanced generics corner cases
+- constrained calls and tailcalls
+- byref-heavy intrinsics
+- async/iterator lowering patterns
+
+## Cross-language portability plan
+
+Like the JVM plan, lower-level metadata should live in normalized repo-owned
+manifests rather than being rewritten by hand in every language port:
+
+- `cli-opcodes.json`
+- `cli-metadata-tables.json`
+- `cli-coded-indices.json`
+- `cli-signature-codes.json`
+- `cli-profile-map.json`
+
+Each language can then implement decoding and runtime semantics natively while
+sharing one metadata source of truth.
+
+## Implementation phases
+
+1. `cli-version-profiles`
+2. `pe-container-decoder`
+3. `cli-header-decoder`
+4. `cli-metadata-streams-decoder`
+5. `cli-metadata-tables-decoder`
+6. `cli-signature-decoder`
+7. `cil-method-body-decoder`
+8. `cil-bytecode-disassembler`
+9. `cli-runtime-model`
+10. `clr-vm-simulator`
+11. Backward-compatible facade updates in `clr-simulator`
+
+## References
+
+- Microsoft CLR overview: https://learn.microsoft.com/en-us/dotnet/standard/clr
+- .NET Framework versions and dependencies: https://learn.microsoft.com/en-us/dotnet/framework/install/versions-and-dependencies
+- .NET release lifecycle: https://learn.microsoft.com/en-us/lifecycle/products/microsoft-net-and-net-core
+- .NET 10 download page: https://dotnet.microsoft.com/en-us/download/dotnet/10.0
+- Microsoft PE format reference: https://learn.microsoft.com/en-us/windows/win32/debug/pe-format
+- Microsoft standards page for CLI / ECMA-335: https://learn.microsoft.com/en-us/dotnet/fundamentals/standards
+- ECMA-335: https://www.ecma-international.org/publications-and-standards/standards/ecma-335/


### PR DESCRIPTION
## Summary
- rewrite the JVM simulator spec around a reusable class-file pipeline instead of a monolithic package
- rewrite the CLR simulator spec around PE/CLI/CIL package boundaries and exact-version profile mapping
- document exact-from-1.0 version support strategy for both runtimes while keeping implementation bucketed internally

## Notes
- JVM spec now treats versioning primarily as a class-file, constant-pool, attribute, and verifier problem
- CLR spec now treats versioning primarily as a PE/CLI metadata and runtime-family problem, with lower reusable packages named around CLI/CIL rather than CLR
- both specs keep the top-level jvm-simulator / clr-simulator packages as facade packages for backwards compatibility

## Validation
- reviewed the rewritten spec files locally
- ran git diff --check to verify there are no whitespace issues