### PR TITLE
Add Haskell mini-redis core packages

### DIFF
--- a/code/packages/haskell/hash-functions/BUILD
+++ b/code/packages/haskell/hash-functions/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/hash-functions/BUILD_windows
+++ b/code/packages/haskell/hash-functions/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/hash-functions/CHANGELOG.md
+++ b/code/packages/haskell/hash-functions/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/hash-functions/README.md
+++ b/code/packages/haskell/hash-functions/README.md
@@ -1,0 +1,11 @@
+# hash-functions
+
+Haskell hashing helpers for DT data structures
+
+## Type
+
+library
+
+## Dependencies
+
+(none)

--- a/code/packages/haskell/hash-functions/cabal.project
+++ b/code/packages/haskell/hash-functions/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/code/packages/haskell/hash-functions/hash-functions.cabal
+++ b/code/packages/haskell/hash-functions/hash-functions.cabal
@@ -1,0 +1,26 @@
+cabal-version: 3.0
+name:          hash-functions
+version:       0.1.0
+synopsis:      Haskell hashing helpers for DT data structures
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  HashFunctions
+    build-depends:    base >=4.14
+                    , bytestring
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    HashFunctionsSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , bytestring
+                    , hash-functions
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/hash-functions/src/HashFunctions.hs
+++ b/code/packages/haskell/hash-functions/src/HashFunctions.hs
@@ -1,0 +1,28 @@
+module HashFunctions
+    ( description
+    , hashBytes64
+    , hashString64
+    ) where
+
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BC
+import Data.Bits (xor)
+import Data.Word (Word64)
+
+description :: String
+description = "Haskell hashing helpers for DT data structures"
+
+fnvOffset64 :: Word64
+fnvOffset64 = 14695981039346656037
+
+fnvPrime64 :: Word64
+fnvPrime64 = 1099511628211
+
+hashBytes64 :: BS.ByteString -> Word64
+hashBytes64 =
+    BS.foldl'
+        (\acc byte -> (acc `xor` fromIntegral byte) * fnvPrime64)
+        fnvOffset64
+
+hashString64 :: String -> Word64
+hashString64 = hashBytes64 . BC.pack

--- a/code/packages/haskell/hash-functions/test/HashFunctionsSpec.hs
+++ b/code/packages/haskell/hash-functions/test/HashFunctionsSpec.hs
@@ -1,0 +1,18 @@
+module HashFunctionsSpec (spec) where
+
+import qualified Data.ByteString.Char8 as BC
+import HashFunctions
+import Test.Hspec
+
+spec :: Spec
+spec = describe "HashFunctions" $ do
+    it "exposes a non-empty description" $ do
+        description `shouldSatisfy` (not . null)
+
+    it "hashes bytes deterministically" $ do
+        hashBytes64 (BC.pack "mini-redis")
+            `shouldBe` hashBytes64 (BC.pack "mini-redis")
+
+    it "changes when the input changes" $ do
+        hashBytes64 (BC.pack "alpha")
+            `shouldNotBe` hashBytes64 (BC.pack "beta")

--- a/code/packages/haskell/hash-functions/test/Spec.hs
+++ b/code/packages/haskell/hash-functions/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import HashFunctionsSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/hash-map/BUILD
+++ b/code/packages/haskell/hash-map/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/hash-map/BUILD_windows
+++ b/code/packages/haskell/hash-map/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/hash-map/CHANGELOG.md
+++ b/code/packages/haskell/hash-map/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/hash-map/README.md
+++ b/code/packages/haskell/hash-map/README.md
@@ -1,0 +1,11 @@
+# hash-map
+
+Haskell hash map for DT18 and Mini Redis
+
+## Type
+
+library
+
+## Dependencies
+
+hash-functions

--- a/code/packages/haskell/hash-map/cabal.project
+++ b/code/packages/haskell/hash-map/cabal.project
@@ -1,0 +1,3 @@
+packages:
+  .
+  ../hash-functions

--- a/code/packages/haskell/hash-map/hash-map.cabal
+++ b/code/packages/haskell/hash-map/hash-map.cabal
@@ -1,0 +1,26 @@
+cabal-version: 3.0
+name:          hash-map
+version:       0.1.0
+synopsis:      Haskell hash map for DT18 and Mini Redis
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  HashMap
+    build-depends:    base >=4.14
+                    , containers
+                    , hash-functions
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    HashMapSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , hash-map
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/hash-map/src/HashMap.hs
+++ b/code/packages/haskell/hash-map/src/HashMap.hs
@@ -1,0 +1,66 @@
+module HashMap
+    ( description
+    , HashMap
+    , empty
+    , singleton
+    , isEmpty
+    , size
+    , has
+    , get
+    , set
+    , delete
+    , keys
+    , values
+    , entries
+    , fromList
+    , toList
+    ) where
+
+import qualified Data.Map.Strict as Map
+
+description :: String
+description = "Haskell hash map for DT18 and Mini Redis"
+
+newtype HashMap key value = HashMap
+    { unHashMap :: Map.Map key value
+    }
+    deriving (Eq, Show)
+
+empty :: HashMap key value
+empty = HashMap Map.empty
+
+singleton :: Ord key => key -> value -> HashMap key value
+singleton key value = HashMap (Map.singleton key value)
+
+isEmpty :: HashMap key value -> Bool
+isEmpty (HashMap valuesMap) = Map.null valuesMap
+
+size :: HashMap key value -> Int
+size (HashMap valuesMap) = Map.size valuesMap
+
+has :: Ord key => key -> HashMap key value -> Bool
+has key (HashMap valuesMap) = Map.member key valuesMap
+
+get :: Ord key => key -> HashMap key value -> Maybe value
+get key (HashMap valuesMap) = Map.lookup key valuesMap
+
+set :: Ord key => key -> value -> HashMap key value -> HashMap key value
+set key value (HashMap valuesMap) = HashMap (Map.insert key value valuesMap)
+
+delete :: Ord key => key -> HashMap key value -> HashMap key value
+delete key (HashMap valuesMap) = HashMap (Map.delete key valuesMap)
+
+keys :: HashMap key value -> [key]
+keys (HashMap valuesMap) = Map.keys valuesMap
+
+values :: HashMap key value -> [value]
+values (HashMap valuesMap) = Map.elems valuesMap
+
+entries :: HashMap key value -> [(key, value)]
+entries (HashMap valuesMap) = Map.toAscList valuesMap
+
+fromList :: Ord key => [(key, value)] -> HashMap key value
+fromList = HashMap . Map.fromList
+
+toList :: HashMap key value -> [(key, value)]
+toList = entries

--- a/code/packages/haskell/hash-map/test/HashMapSpec.hs
+++ b/code/packages/haskell/hash-map/test/HashMapSpec.hs
@@ -1,0 +1,20 @@
+module HashMapSpec (spec) where
+
+import HashMap
+import Test.Hspec
+
+spec :: Spec
+spec = describe "HashMap" $ do
+    it "stores, updates, and deletes entries" $ do
+        let valuesMap = set "beta" (2 :: Int) (set "alpha" 1 empty)
+        get "alpha" valuesMap `shouldBe` Just 1
+        has "beta" valuesMap `shouldBe` True
+        size valuesMap `shouldBe` 2
+        keys valuesMap `shouldBe` ["alpha", "beta"]
+        entries (delete "alpha" valuesMap) `shouldBe` [("beta", 2)]
+
+    it "builds from ascending entries" $ do
+        toList (fromList [("b", 2 :: Int), ("a", 1)]) `shouldBe` [("a", 1), ("b", 2)]
+
+    it "exposes a non-empty description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/hash-map/test/Spec.hs
+++ b/code/packages/haskell/hash-map/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import HashMapSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/hash-set/BUILD
+++ b/code/packages/haskell/hash-set/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/hash-set/BUILD_windows
+++ b/code/packages/haskell/hash-set/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/hash-set/CHANGELOG.md
+++ b/code/packages/haskell/hash-set/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/hash-set/README.md
+++ b/code/packages/haskell/hash-set/README.md
@@ -1,0 +1,11 @@
+# hash-set
+
+Haskell hash set for DT19 and Mini Redis
+
+## Type
+
+library
+
+## Dependencies
+
+hash-functions, hash-map

--- a/code/packages/haskell/hash-set/cabal.project
+++ b/code/packages/haskell/hash-set/cabal.project
@@ -1,0 +1,4 @@
+packages:
+  .
+  ../hash-functions
+  ../hash-map

--- a/code/packages/haskell/hash-set/hash-set.cabal
+++ b/code/packages/haskell/hash-set/hash-set.cabal
@@ -1,0 +1,27 @@
+cabal-version: 3.0
+name:          hash-set
+version:       0.1.0
+synopsis:      Haskell hash set for DT19 and Mini Redis
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  HashSet
+    build-depends:    base >=4.14
+                    , containers
+                    , hash-functions
+                    , hash-map
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    HashSetSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , hash-set
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/hash-set/src/HashSet.hs
+++ b/code/packages/haskell/hash-set/src/HashSet.hs
@@ -1,0 +1,64 @@
+module HashSet
+    ( description
+    , HashSet
+    , empty
+    , singleton
+    , isEmpty
+    , size
+    , contains
+    , add
+    , remove
+    , fromList
+    , toList
+    , union
+    , intersection
+    , difference
+    ) where
+
+import qualified Data.Set as Set
+
+description :: String
+description = "Haskell hash set for DT19 and Mini Redis"
+
+newtype HashSet value = HashSet
+    { unHashSet :: Set.Set value
+    }
+    deriving (Eq, Show)
+
+empty :: HashSet value
+empty = HashSet Set.empty
+
+singleton :: Ord value => value -> HashSet value
+singleton value = HashSet (Set.singleton value)
+
+isEmpty :: HashSet value -> Bool
+isEmpty (HashSet valuesSet) = Set.null valuesSet
+
+size :: HashSet value -> Int
+size (HashSet valuesSet) = Set.size valuesSet
+
+contains :: Ord value => value -> HashSet value -> Bool
+contains value (HashSet valuesSet) = Set.member value valuesSet
+
+add :: Ord value => value -> HashSet value -> HashSet value
+add value (HashSet valuesSet) = HashSet (Set.insert value valuesSet)
+
+remove :: Ord value => value -> HashSet value -> HashSet value
+remove value (HashSet valuesSet) = HashSet (Set.delete value valuesSet)
+
+fromList :: Ord value => [value] -> HashSet value
+fromList = HashSet . Set.fromList
+
+toList :: HashSet value -> [value]
+toList (HashSet valuesSet) = Set.toAscList valuesSet
+
+union :: Ord value => HashSet value -> HashSet value -> HashSet value
+union (HashSet leftSet) (HashSet rightSet) = HashSet (Set.union leftSet rightSet)
+
+intersection :: Ord value => HashSet value -> HashSet value -> HashSet value
+intersection (HashSet leftSet) (HashSet rightSet) =
+    HashSet (Set.intersection leftSet rightSet)
+
+difference :: Ord value => HashSet value -> HashSet value -> HashSet value
+difference (HashSet leftSet) (HashSet rightSet) =
+    HashSet (Set.difference leftSet rightSet)

--- a/code/packages/haskell/hash-set/test/HashSetSpec.hs
+++ b/code/packages/haskell/hash-set/test/HashSetSpec.hs
@@ -1,0 +1,19 @@
+module HashSetSpec (spec) where
+
+import HashSet
+import Test.Hspec
+
+spec :: Spec
+spec = describe "HashSet" $ do
+    it "adds, removes, and combines members" $ do
+        let leftSet = add "beta" (add "alpha" empty)
+            rightSet = add "gamma" (add "beta" empty)
+        toList leftSet `shouldBe` ["alpha", "beta"]
+        contains "alpha" leftSet `shouldBe` True
+        toList (difference leftSet rightSet) `shouldBe` ["alpha"]
+        toList (intersection leftSet rightSet) `shouldBe` ["beta"]
+        toList (union leftSet rightSet) `shouldBe` ["alpha", "beta", "gamma"]
+        size (remove "alpha" leftSet) `shouldBe` 1
+
+    it "exposes a non-empty description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/hash-set/test/Spec.hs
+++ b/code/packages/haskell/hash-set/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import HashSetSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/heap/BUILD
+++ b/code/packages/haskell/heap/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/heap/BUILD_windows
+++ b/code/packages/haskell/heap/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/heap/CHANGELOG.md
+++ b/code/packages/haskell/heap/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/heap/README.md
+++ b/code/packages/haskell/heap/README.md
@@ -1,0 +1,11 @@
+# heap
+
+Haskell heap package for TTL scheduling
+
+## Type
+
+library
+
+## Dependencies
+
+(none)

--- a/code/packages/haskell/heap/cabal.project
+++ b/code/packages/haskell/heap/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/code/packages/haskell/heap/heap.cabal
+++ b/code/packages/haskell/heap/heap.cabal
@@ -1,0 +1,24 @@
+cabal-version: 3.0
+name:          heap
+version:       0.1.0
+synopsis:      Haskell heap package for TTL scheduling
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  Heap
+    build-depends:    base >=4.14
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    HeapSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , heap
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/heap/src/Heap.hs
+++ b/code/packages/haskell/heap/src/Heap.hs
@@ -1,0 +1,67 @@
+module Heap
+    ( description
+    , MinHeap
+    , new
+    , empty
+    , singleton
+    , isEmpty
+    , size
+    , push
+    , peek
+    , pop
+    , minView
+    , fromList
+    , toAscList
+    ) where
+
+import Data.List (foldl', insert)
+
+description :: String
+description = "Haskell heap package for TTL scheduling"
+
+newtype MinHeap value = MinHeap
+    { unMinHeap :: [value]
+    }
+    deriving (Eq, Show)
+
+new :: MinHeap value
+new = MinHeap []
+
+empty :: MinHeap value
+empty = new
+
+singleton :: value -> MinHeap value
+singleton value = MinHeap [value]
+
+isEmpty :: MinHeap value -> Bool
+isEmpty (MinHeap valuesList) = null valuesList
+
+size :: MinHeap value -> Int
+size (MinHeap valuesList) = length valuesList
+
+push :: Ord value => value -> MinHeap value -> MinHeap value
+push value (MinHeap valuesList) = MinHeap (insert value valuesList)
+
+peek :: MinHeap value -> Maybe value
+peek (MinHeap valuesList) =
+    case valuesList of
+        [] -> Nothing
+        value : _ -> Just value
+
+pop :: MinHeap value -> MinHeap value
+pop (MinHeap valuesList) =
+    case valuesList of
+        [] -> MinHeap []
+        _ : rest -> MinHeap rest
+
+minView :: MinHeap value -> Maybe (value, MinHeap value)
+minView valuesHeap =
+    case peek valuesHeap of
+        Nothing -> Nothing
+        Just value -> Just (value, pop valuesHeap)
+
+fromList :: Ord value => [value] -> MinHeap value
+fromList = foldl' (flip push) new
+
+toAscList :: MinHeap value -> [value]
+toAscList (MinHeap valuesList) = valuesList

--- a/code/packages/haskell/heap/test/HeapSpec.hs
+++ b/code/packages/haskell/heap/test/HeapSpec.hs
@@ -1,0 +1,15 @@
+module HeapSpec (spec) where
+
+import Heap
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Heap" $ do
+    it "keeps values in ascending order" $ do
+        let valuesHeap = fromList [3 :: Int, 1, 2]
+        peek valuesHeap `shouldBe` Just 1
+        fmap fst (minView valuesHeap) `shouldBe` Just 1
+        toAscList (pop valuesHeap) `shouldBe` [2, 3]
+
+    it "exposes a non-empty description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/heap/test/Spec.hs
+++ b/code/packages/haskell/heap/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import HeapSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/hyperloglog/BUILD
+++ b/code/packages/haskell/hyperloglog/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/hyperloglog/BUILD_windows
+++ b/code/packages/haskell/hyperloglog/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/hyperloglog/CHANGELOG.md
+++ b/code/packages/haskell/hyperloglog/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/hyperloglog/README.md
+++ b/code/packages/haskell/hyperloglog/README.md
@@ -1,0 +1,11 @@
+# hyperloglog
+
+Haskell HyperLogLog approximate cardinality package
+
+## Type
+
+library
+
+## Dependencies
+
+hash-functions

--- a/code/packages/haskell/hyperloglog/cabal.project
+++ b/code/packages/haskell/hyperloglog/cabal.project
@@ -1,0 +1,3 @@
+packages:
+  .
+  ../hash-functions

--- a/code/packages/haskell/hyperloglog/hyperloglog.cabal
+++ b/code/packages/haskell/hyperloglog/hyperloglog.cabal
@@ -1,0 +1,27 @@
+cabal-version: 3.0
+name:          hyperloglog
+version:       0.1.0
+synopsis:      Haskell HyperLogLog approximate cardinality package
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  Hyperloglog
+    build-depends:    base >=4.14
+                    , bytestring
+                    , hash-functions
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    HyperloglogSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , bytestring
+                    , hspec == 2.*
+                    , hyperloglog
+    default-language: Haskell2010

--- a/code/packages/haskell/hyperloglog/src/Hyperloglog.hs
+++ b/code/packages/haskell/hyperloglog/src/Hyperloglog.hs
@@ -1,0 +1,101 @@
+module Hyperloglog
+    ( description
+    , HyperLogLog(..)
+    , defaultPrecision
+    , new
+    , add
+    , addMany
+    , count
+    , merge
+    , mergeMany
+    ) where
+
+import qualified Data.ByteString as BS
+import Data.Bits (FiniteBits(countLeadingZeros), (.&.), shiftR)
+import Data.List (foldl')
+import HashFunctions (hashBytes64)
+
+description :: String
+description = "Haskell HyperLogLog approximate cardinality package"
+
+defaultPrecision :: Int
+defaultPrecision = 10
+
+data HyperLogLog = HyperLogLog
+    { hllPrecision :: Int
+    , hllRegisters :: [Int]
+    }
+    deriving (Eq, Show)
+
+new :: HyperLogLog
+new = HyperLogLog defaultPrecision (replicate (2 ^ defaultPrecision) 0)
+
+add :: BS.ByteString -> HyperLogLog -> (HyperLogLog, Bool)
+add bytesValue hll =
+    let precisionValue = hllPrecision hll
+        registersValue = hllRegisters hll
+        hashedValue = hashBytes64 bytesValue
+        bucketIndex = fromIntegral (hashedValue .&. fromIntegral ((2 ^ precisionValue) - 1))
+        shiftedValue = hashedValue `shiftR` precisionValue
+        rankValue =
+            min
+                (64 - precisionValue + 1)
+                (countLeadingZeros shiftedValue + 1)
+        oldRegister = registersValue !! bucketIndex
+        newRegister = max oldRegister rankValue
+        updatedRegisters = replaceAt bucketIndex newRegister registersValue
+     in (HyperLogLog precisionValue updatedRegisters, newRegister /= oldRegister)
+
+addMany :: [BS.ByteString] -> HyperLogLog -> (HyperLogLog, Bool)
+addMany bytesValues initialHll =
+    foldl'
+        step
+        (initialHll, False)
+        bytesValues
+  where
+    step (currentHll, changed) value =
+        let (nextHll, valueChanged) = add value currentHll
+         in (nextHll, changed || valueChanged)
+
+count :: HyperLogLog -> Integer
+count hll =
+    max 0 (round correctedEstimate)
+  where
+    precisionValue = hllPrecision hll
+    registersValue = hllRegisters hll
+    registerCountValue = fromIntegral (2 ^ precisionValue) :: Double
+    alphaValue =
+        case round registerCountValue :: Int of
+            16 -> 0.673
+            32 -> 0.697
+            64 -> 0.709
+            _ -> 0.7213 / (1 + 1.079 / registerCountValue)
+    harmonicDenominator =
+        sum [2 ** negate (fromIntegral registerValue :: Double) | registerValue <- registersValue]
+    rawEstimate = alphaValue * registerCountValue * registerCountValue / harmonicDenominator
+    zeroRegisters = length (filter (== 0) registersValue)
+    correctedEstimate
+        | rawEstimate <= 2.5 * registerCountValue && zeroRegisters > 0 =
+            registerCountValue
+                * log (registerCountValue / fromIntegral zeroRegisters)
+        | otherwise = rawEstimate
+
+merge :: HyperLogLog -> HyperLogLog -> HyperLogLog
+merge leftHll rightHll
+    | hllPrecision leftHll /= hllPrecision rightHll =
+        error "HyperLogLog precision mismatch"
+    | otherwise =
+        HyperLogLog
+            { hllPrecision = hllPrecision leftHll
+            , hllRegisters =
+                zipWith max (hllRegisters leftHll) (hllRegisters rightHll)
+            }
+
+mergeMany :: [HyperLogLog] -> HyperLogLog
+mergeMany = foldl' merge new
+
+replaceAt :: Int -> value -> [value] -> [value]
+replaceAt indexValue replacement valuesList =
+    take indexValue valuesList
+        ++ [replacement]
+        ++ drop (indexValue + 1) valuesList

--- a/code/packages/haskell/hyperloglog/test/HyperloglogSpec.hs
+++ b/code/packages/haskell/hyperloglog/test/HyperloglogSpec.hs
@@ -1,0 +1,22 @@
+module HyperloglogSpec (spec) where
+
+import qualified Data.ByteString.Char8 as BC
+import Hyperloglog
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Hyperloglog" $ do
+    it "tracks approximate small-cardinality counts" $ do
+        let (valuesHll, changed) =
+                addMany (map BC.pack ["a", "b", "c"]) new
+        changed `shouldBe` True
+        count valuesHll `shouldSatisfy` (\value -> value >= 3 && value <= 4)
+
+    it "merges sketches" $ do
+        let leftHll = fst (addMany (map BC.pack ["a", "b", "c"]) new)
+            rightHll = fst (addMany (map BC.pack ["b", "c", "d"]) new)
+        count (merge leftHll rightHll)
+            `shouldSatisfy` (\value -> value >= 4 && value <= 5)
+
+    it "exposes a non-empty description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/hyperloglog/test/Spec.hs
+++ b/code/packages/haskell/hyperloglog/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import HyperloglogSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/in-memory-data-store-engine/BUILD
+++ b/code/packages/haskell/in-memory-data-store-engine/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/in-memory-data-store-engine/BUILD_windows
+++ b/code/packages/haskell/in-memory-data-store-engine/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/in-memory-data-store-engine/CHANGELOG.md
+++ b/code/packages/haskell/in-memory-data-store-engine/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/in-memory-data-store-engine/README.md
+++ b/code/packages/haskell/in-memory-data-store-engine/README.md
@@ -1,0 +1,11 @@
+# in-memory-data-store-engine
+
+Haskell in-memory data store engine without TCP transport
+
+## Type
+
+library
+
+## Dependencies
+
+hash-functions, hash-map, hash-set, heap, hyperloglog, in-memory-data-store-protocol, radix-tree, resp-protocol, skip-list

--- a/code/packages/haskell/in-memory-data-store-engine/cabal.project
+++ b/code/packages/haskell/in-memory-data-store-engine/cabal.project
@@ -1,0 +1,11 @@
+packages:
+  .
+  ../hash-functions
+  ../hash-map
+  ../hash-set
+  ../heap
+  ../hyperloglog
+  ../in-memory-data-store-protocol
+  ../radix-tree
+  ../resp-protocol
+  ../skip-list

--- a/code/packages/haskell/in-memory-data-store-engine/in-memory-data-store-engine.cabal
+++ b/code/packages/haskell/in-memory-data-store-engine/in-memory-data-store-engine.cabal
@@ -1,0 +1,38 @@
+cabal-version: 3.0
+name:          in-memory-data-store-engine
+version:       0.1.0
+synopsis:      Haskell in-memory data store engine without TCP transport
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  InMemoryDataStoreEngine
+    build-depends:    base >=4.14
+                    , bytestring
+                    , containers
+                    , hash-functions
+                    , hash-map
+                    , hash-set
+                    , heap
+                    , hyperloglog
+                    , in-memory-data-store-protocol
+                    , radix-tree
+                    , resp-protocol
+                    , skip-list
+                    , time
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    InMemoryDataStoreEngineSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , bytestring
+                    , hspec == 2.*
+                    , in-memory-data-store-protocol
+                    , in-memory-data-store-engine
+    default-language: Haskell2010

--- a/code/packages/haskell/in-memory-data-store-engine/src/InMemoryDataStoreEngine.hs
+++ b/code/packages/haskell/in-memory-data-store-engine/src/InMemoryDataStoreEngine.hs
@@ -1,0 +1,1541 @@
+module InMemoryDataStoreEngine
+    ( description
+    , OrderedDouble(..)
+    , mkOrderedDouble
+    , SortedSet
+    , emptySortedSet
+    , sortedSetInsert
+    , sortedSetRemove
+    , sortedSetRank
+    , sortedSetOrderedEntries
+    , sortedSetRangeByIndex
+    , sortedSetRangeByScore
+    , EntryType(..)
+    , entryTypeName
+    , EntryValue(..)
+    , Entry(..)
+    , Database(..)
+    , Store(..)
+    , emptyStore
+    , currentTimeMs
+    , DataStoreBackend(..)
+    , DataStoreEngine
+    , newDataStoreEngine
+    , executeFrame
+    , executeOwned
+    , executeWithDb
+    , storeSnapshot
+    , activeExpireAll
+    ) where
+
+import qualified Control.Concurrent.MVar as MVar
+import Data.Char (toUpper)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BC
+import qualified Data.Foldable as Foldable
+import qualified Data.List as List
+import Data.Maybe (isJust)
+import qualified Data.Sequence as Seq
+import Data.Sequence (Seq, ViewL(..), ViewR(..))
+import qualified Data.Time.Clock.POSIX as POSIX
+import Data.Word (Word8)
+import qualified HashMap as HM
+import qualified HashSet as HS
+import qualified Heap
+import qualified Hyperloglog as HLL
+import InMemoryDataStoreProtocol
+    ( CommandFrame(..)
+    , EngineResponse(..)
+    , commandFrameFromParts
+    )
+import Numeric (showFFloat)
+import qualified RadixTree as RT
+import qualified SkipList as Skip
+import Text.Read (readMaybe)
+
+description :: String
+description = "Haskell in-memory data store engine without TCP transport"
+
+newtype OrderedDouble = OrderedDouble
+    { unwrapOrderedDouble :: Double
+    }
+    deriving (Show)
+
+instance Eq OrderedDouble where
+    OrderedDouble leftValue == OrderedDouble rightValue = leftValue == rightValue
+
+instance Ord OrderedDouble where
+    compare (OrderedDouble leftValue) (OrderedDouble rightValue) =
+        compare leftValue rightValue
+
+mkOrderedDouble :: Double -> Maybe OrderedDouble
+mkOrderedDouble value
+    | isNaN value = Nothing
+    | otherwise = Just (OrderedDouble value)
+
+data SortedEntry = SortedEntry
+    { sortedEntryScore :: OrderedDouble
+    , sortedEntryMember :: BS.ByteString
+    }
+    deriving (Eq, Ord, Show)
+
+data SortedSet = SortedSet
+    { sortedSetMembersMap :: HM.HashMap BS.ByteString OrderedDouble
+    , sortedSetOrderingMap :: Skip.SkipList SortedEntry ()
+    }
+    deriving (Eq, Show)
+
+emptySortedSet :: SortedSet
+emptySortedSet =
+    SortedSet
+        { sortedSetMembersMap = HM.empty
+        , sortedSetOrderingMap = Skip.empty
+        }
+
+sortedSetInsert :: Double -> BS.ByteString -> SortedSet -> Either String (SortedSet, Bool)
+sortedSetInsert scoreValue memberValue valuesSet =
+    case mkOrderedDouble scoreValue of
+        Nothing -> Left "ERR value is not a valid float"
+        Just orderedScore ->
+            let existingScore = HM.get memberValue (sortedSetMembersMap valuesSet)
+                strippedOrdering =
+                    case existingScore of
+                        Nothing -> sortedSetOrderingMap valuesSet
+                        Just oldScore ->
+                            Skip.delete (SortedEntry oldScore memberValue) (sortedSetOrderingMap valuesSet)
+                updatedMembers =
+                    HM.set memberValue orderedScore (sortedSetMembersMap valuesSet)
+                updatedOrdering =
+                    Skip.insert (SortedEntry orderedScore memberValue) () strippedOrdering
+             in Right
+                    ( SortedSet
+                        { sortedSetMembersMap = updatedMembers
+                        , sortedSetOrderingMap = updatedOrdering
+                        }
+                    , not (isJust existingScore)
+                    )
+
+sortedSetRemove :: BS.ByteString -> SortedSet -> (SortedSet, Bool)
+sortedSetRemove memberValue valuesSet =
+    case HM.get memberValue (sortedSetMembersMap valuesSet) of
+        Nothing -> (valuesSet, False)
+        Just oldScore ->
+            ( SortedSet
+                { sortedSetMembersMap =
+                    HM.delete memberValue (sortedSetMembersMap valuesSet)
+                , sortedSetOrderingMap =
+                    Skip.delete
+                        (SortedEntry oldScore memberValue)
+                        (sortedSetOrderingMap valuesSet)
+                }
+            , True
+            )
+
+sortedSetRank :: BS.ByteString -> SortedSet -> Maybe Int
+sortedSetRank memberValue valuesSet =
+    List.findIndex
+        ((== memberValue) . fst)
+        (sortedSetOrderedEntries valuesSet)
+
+sortedSetOrderedEntries :: SortedSet -> [(BS.ByteString, Double)]
+sortedSetOrderedEntries valuesSet =
+    [ (sortedEntryMember entry, unwrapOrderedDouble (sortedEntryScore entry))
+    | (entry, ()) <- Skip.entries (sortedSetOrderingMap valuesSet)
+    ]
+
+sortedSetRangeByIndex :: Int -> Int -> SortedSet -> [(BS.ByteString, Double)]
+sortedSetRangeByIndex startIndex endIndex valuesSet
+    | null orderedEntries = []
+    | normalizedStart < 0 = []
+    | normalizedStart >= entryCount = []
+    | normalizedEnd < 0 = []
+    | clampedStart > clampedEnd = []
+    | otherwise = take (clampedEnd - clampedStart + 1) (drop clampedStart orderedEntries)
+  where
+    orderedEntries = sortedSetOrderedEntries valuesSet
+    entryCount = length orderedEntries
+    normalizedStart = normalizeIndex entryCount startIndex
+    normalizedEnd = normalizeIndex entryCount endIndex
+    clampedStart = max 0 normalizedStart
+    clampedEnd = min (entryCount - 1) normalizedEnd
+
+sortedSetRangeByScore :: Double -> Double -> SortedSet -> [(BS.ByteString, Double)]
+sortedSetRangeByScore minScore maxScore valuesSet =
+    filter
+        (\(_, scoreValue) -> scoreValue >= minScore && scoreValue <= maxScore)
+        (sortedSetOrderedEntries valuesSet)
+
+data EntryType
+    = EntryString
+    | EntryHash
+    | EntryList
+    | EntrySet
+    | EntryZSet
+    | EntryHll
+    deriving (Eq, Ord, Show)
+
+entryTypeName :: EntryType -> String
+entryTypeName entryTypeValue =
+    case entryTypeValue of
+        EntryString -> "string"
+        EntryHash -> "hash"
+        EntryList -> "list"
+        EntrySet -> "set"
+        EntryZSet -> "zset"
+        EntryHll -> "hll"
+
+data EntryValue
+    = EntryStringValue BS.ByteString
+    | EntryHashValue (HM.HashMap BS.ByteString BS.ByteString)
+    | EntryListValue (Seq BS.ByteString)
+    | EntrySetValue (HS.HashSet BS.ByteString)
+    | EntryZSetValue SortedSet
+    | EntryHllValue HLL.HyperLogLog
+    deriving (Eq, Show)
+
+data Entry = Entry
+    { entryTypeValue :: EntryType
+    , entryValue :: EntryValue
+    , entryExpiresAt :: Maybe Integer
+    }
+    deriving (Eq, Show)
+
+data Database = Database
+    { databaseEntries :: HM.HashMap BS.ByteString Entry
+    , databaseTtlHeap :: Heap.MinHeap (Integer, BS.ByteString)
+    , databaseKeyIndex :: RT.RadixTree ()
+    }
+    deriving (Eq, Show)
+
+data Store = Store
+    { storeDatabases :: [Database]
+    , storeActiveDb :: Int
+    }
+    deriving (Eq, Show)
+
+emptyDatabase :: Database
+emptyDatabase =
+    Database
+        { databaseEntries = HM.empty
+        , databaseTtlHeap = Heap.empty
+        , databaseKeyIndex = RT.empty
+        }
+
+emptyStore :: Store
+emptyStore =
+    Store
+        { storeDatabases = replicate 16 emptyDatabase
+        , storeActiveDb = 0
+        }
+
+currentTimeMs :: IO Integer
+currentTimeMs = floor . (* 1000) <$> POSIX.getPOSIXTime
+
+data DataStoreEngine = DataStoreEngine
+    { engineStoreVar :: MVar.MVar Store
+    , engineAofPath :: Maybe FilePath
+    }
+
+class DataStoreBackend backend where
+    executeBackendFrame :: backend -> CommandFrame -> IO EngineResponse
+    executeBackendOwned :: backend -> [BS.ByteString] -> IO EngineResponse
+    backendStoreSnapshot :: backend -> IO Store
+    backendActiveExpireAll :: backend -> IO ()
+
+instance DataStoreBackend DataStoreEngine where
+    executeBackendFrame = executeFrame
+    executeBackendOwned = executeOwned
+    backendStoreSnapshot = storeSnapshot
+    backendActiveExpireAll = activeExpireAll
+
+newDataStoreEngine :: Maybe FilePath -> IO DataStoreEngine
+newDataStoreEngine maybeAofPath = do
+    storeVar <- MVar.newMVar emptyStore
+    pure
+        DataStoreEngine
+            { engineStoreVar = storeVar
+            , engineAofPath = maybeAofPath
+            }
+
+executeFrame :: DataStoreEngine -> CommandFrame -> IO EngineResponse
+executeFrame engine commandFrameValue = snd <$> executeWithDb engine 0 commandFrameValue
+
+executeOwned :: DataStoreEngine -> [BS.ByteString] -> IO EngineResponse
+executeOwned engine parts =
+    case commandFrameFromParts parts of
+        Nothing ->
+            pure (EngineError "ERR protocol error: expected array of bulk strings")
+        Just commandFrameValue ->
+            executeFrame engine commandFrameValue
+
+executeWithDb :: DataStoreEngine -> Int -> CommandFrame -> IO (Int, EngineResponse)
+executeWithDb engine requestedDb commandFrameValue = do
+    now <- currentTimeMs
+    MVar.modifyMVar
+        (engineStoreVar engine)
+        (\storeValue ->
+            let commandName = map toUpper (commandFrameCommand commandFrameValue)
+                storeWithDb = storeSelect requestedDb storeValue
+                preparedStore =
+                    if skipLazyExpire commandName
+                        then storeWithDb
+                        else storeExpireLazy now (listToMaybeByteString (commandFrameArgs commandFrameValue)) storeWithDb
+                (updatedStore, response) =
+                    dispatchCommand now preparedStore commandName (commandFrameArgs commandFrameValue)
+             in pure (updatedStore, (storeActiveDb updatedStore, response)))
+
+storeSnapshot :: DataStoreEngine -> IO Store
+storeSnapshot engine = MVar.readMVar (engineStoreVar engine)
+
+activeExpireAll :: DataStoreEngine -> IO ()
+activeExpireAll engine = do
+    now <- currentTimeMs
+    MVar.modifyMVar_ (engineStoreVar engine) (pure . storeActiveExpireAll now)
+
+entryFromValue :: EntryValue -> Maybe Integer -> Entry
+entryFromValue value expiresAtValue =
+    Entry
+        { entryTypeValue = entryValueType value
+        , entryValue = value
+        , entryExpiresAt = expiresAtValue
+        }
+
+entryValueType :: EntryValue -> EntryType
+entryValueType value =
+    case value of
+        EntryStringValue _ -> EntryString
+        EntryHashValue _ -> EntryHash
+        EntryListValue _ -> EntryList
+        EntrySetValue _ -> EntrySet
+        EntryZSetValue _ -> EntryZSet
+        EntryHllValue _ -> EntryHll
+
+databaseGet :: Integer -> BS.ByteString -> Database -> Maybe Entry
+databaseGet now keyValue database =
+    case HM.get keyValue (databaseEntries database) of
+        Just entryValueFound
+            | isExpired now entryValueFound -> Nothing
+            | otherwise -> Just entryValueFound
+        Nothing -> Nothing
+
+databaseSet :: BS.ByteString -> Entry -> Database -> Database
+databaseSet keyValue entryValueToStore database =
+    database
+        { databaseEntries = HM.set keyValue entryValueToStore (databaseEntries database)
+        , databaseTtlHeap =
+            case entryExpiresAt entryValueToStore of
+                Nothing -> databaseTtlHeap database
+                Just expiresAtValue ->
+                    Heap.push (expiresAtValue, keyValue) (databaseTtlHeap database)
+        , databaseKeyIndex = RT.insert keyValue () (databaseKeyIndex database)
+        }
+
+databaseDelete :: BS.ByteString -> Database -> Database
+databaseDelete keyValue database =
+    database
+        { databaseEntries = HM.delete keyValue (databaseEntries database)
+        , databaseKeyIndex = RT.delete keyValue (databaseKeyIndex database)
+        }
+
+databaseKeys :: Integer -> BS.ByteString -> Database -> [BS.ByteString]
+databaseKeys now patternBytes database =
+    List.sort
+        [ keyValue
+        | keyValue <- candidateKeys
+        , isJust (databaseGet now keyValue database)
+        , globMatch patternBytes keyValue
+        ]
+  where
+    candidateKeys =
+        case extractSimplePrefix patternBytes of
+            Just prefixBytes -> RT.keysWithPrefix prefixBytes (databaseKeyIndex database)
+            Nothing -> HM.keys (databaseEntries database)
+
+databaseDbSize :: Integer -> Database -> Int
+databaseDbSize now database =
+    length [() | keyValue <- HM.keys (databaseEntries database), isJust (databaseGet now keyValue database)]
+
+databaseExpireLazy :: Integer -> Maybe BS.ByteString -> Database -> Database
+databaseExpireLazy now maybeKey database =
+    case maybeKey of
+        Nothing -> database
+        Just keyValue ->
+            case HM.get keyValue (databaseEntries database) of
+                Just entryValueFound
+                    | isExpired now entryValueFound -> databaseDelete keyValue database
+                _ -> database
+
+databaseActiveExpire :: Integer -> Database -> Database
+databaseActiveExpire now database = loop database
+  where
+    loop currentDatabase =
+        case Heap.minView (databaseTtlHeap currentDatabase) of
+            Nothing -> currentDatabase
+            Just ((expiresAtValue, keyValue), remainingHeap)
+                | expiresAtValue > now -> currentDatabase
+                | otherwise ->
+                    let databaseWithoutTop = currentDatabase {databaseTtlHeap = remainingHeap}
+                        shouldDelete =
+                            case HM.get keyValue (databaseEntries databaseWithoutTop) of
+                                Just entryValueFound ->
+                                    entryExpiresAt entryValueFound == Just expiresAtValue
+                                        && expiresAtValue <= now
+                                Nothing -> False
+                        nextDatabase =
+                            if shouldDelete
+                                then databaseDelete keyValue databaseWithoutTop
+                                else databaseWithoutTop
+                     in loop nextDatabase
+
+databaseClear :: Database -> Database
+databaseClear _ = emptyDatabase
+
+storeSelect :: Int -> Store -> Store
+storeSelect requestedDb storeValue =
+    storeValue {storeActiveDb = clampDbIndex requestedDb}
+
+storeGet :: Integer -> BS.ByteString -> Store -> Maybe Entry
+storeGet now keyValue storeValue = databaseGet now keyValue (currentDatabase storeValue)
+
+storeSet :: BS.ByteString -> Entry -> Store -> Store
+storeSet keyValue entryValueToStore storeValue =
+    updateCurrentDatabase (databaseSet keyValue entryValueToStore) storeValue
+
+storeDelete :: BS.ByteString -> Store -> Store
+storeDelete keyValue storeValue =
+    updateCurrentDatabase (databaseDelete keyValue) storeValue
+
+storeTypeOf :: Integer -> BS.ByteString -> Store -> Maybe EntryType
+storeTypeOf now keyValue storeValue =
+    entryTypeValue <$> storeGet now keyValue storeValue
+
+storeKeys :: Integer -> BS.ByteString -> Store -> [BS.ByteString]
+storeKeys now patternBytes storeValue =
+    databaseKeys now patternBytes (currentDatabase storeValue)
+
+storeDbSize :: Integer -> Store -> Int
+storeDbSize now storeValue = databaseDbSize now (currentDatabase storeValue)
+
+storeExpireLazy :: Integer -> Maybe BS.ByteString -> Store -> Store
+storeExpireLazy now maybeKey storeValue =
+    updateCurrentDatabase (databaseExpireLazy now maybeKey) storeValue
+
+storeActiveExpireAll :: Integer -> Store -> Store
+storeActiveExpireAll now storeValue =
+    storeValue
+        { storeDatabases =
+            map (databaseActiveExpire now) (storeDatabases storeValue)
+        }
+
+storeFlushDb :: Store -> Store
+storeFlushDb storeValue =
+    updateCurrentDatabase databaseClear storeValue
+
+storeFlushAll :: Store -> Store
+storeFlushAll storeValue =
+    storeValue {storeDatabases = replicate 16 emptyDatabase}
+
+currentDatabase :: Store -> Database
+currentDatabase storeValue = storeDatabases storeValue !! storeActiveDb storeValue
+
+updateCurrentDatabase :: (Database -> Database) -> Store -> Store
+updateCurrentDatabase updateFn storeValue =
+    storeValue
+        { storeDatabases =
+            take activeIndex databasesValue
+                ++ [updateFn (databasesValue !! activeIndex)]
+                ++ drop (activeIndex + 1) databasesValue
+        }
+  where
+    activeIndex = storeActiveDb storeValue
+    databasesValue = storeDatabases storeValue
+
+skipLazyExpire :: String -> Bool
+skipLazyExpire commandName =
+    commandName `elem` ["PING", "ECHO", "SELECT", "FLUSHDB", "FLUSHALL", "DBSIZE", "INFO"]
+
+dispatchCommand :: Integer -> Store -> String -> [BS.ByteString] -> (Store, EngineResponse)
+dispatchCommand now storeValue commandName args =
+    case commandName of
+        "PING" -> cmdPing storeValue args
+        "ECHO" -> cmdEcho storeValue args
+        "SET" -> cmdSet now storeValue args
+        "GET" -> cmdGet now storeValue args
+        "DEL" -> cmdDel now storeValue args
+        "EXISTS" -> cmdExists now storeValue args
+        "TYPE" -> cmdType now storeValue args
+        "RENAME" -> cmdRename now storeValue args
+        "INCR" -> cmdIncr now storeValue args
+        "DECR" -> cmdDecr now storeValue args
+        "INCRBY" -> cmdIncrBy now storeValue args
+        "DECRBY" -> cmdDecrBy now storeValue args
+        "APPEND" -> cmdAppend now storeValue args
+        "HSET" -> cmdHSet now storeValue args
+        "HGET" -> cmdHGet now storeValue args
+        "HDEL" -> cmdHDel now storeValue args
+        "HGETALL" -> cmdHGetAll now storeValue args
+        "HLEN" -> cmdHLen now storeValue args
+        "HEXISTS" -> cmdHExists now storeValue args
+        "HKEYS" -> cmdHKeys now storeValue args
+        "HVALS" -> cmdHVals now storeValue args
+        "LPUSH" -> cmdLPush now storeValue args
+        "RPUSH" -> cmdRPush now storeValue args
+        "LPOP" -> cmdLPop now storeValue args
+        "RPOP" -> cmdRPop now storeValue args
+        "LLEN" -> cmdLLen now storeValue args
+        "LRANGE" -> cmdLRange now storeValue args
+        "LINDEX" -> cmdLIndex now storeValue args
+        "SADD" -> cmdSAdd now storeValue args
+        "SREM" -> cmdSRem now storeValue args
+        "SISMEMBER" -> cmdSIsMember now storeValue args
+        "SMEMBERS" -> cmdSMembers now storeValue args
+        "SCARD" -> cmdSCard now storeValue args
+        "SUNION" -> cmdSUnion now storeValue args
+        "SINTER" -> cmdSInter now storeValue args
+        "SDIFF" -> cmdSDiff now storeValue args
+        "ZADD" -> cmdZAdd now storeValue args
+        "ZRANGE" -> cmdZRange now storeValue args
+        "ZRANGEBYSCORE" -> cmdZRangeByScore now storeValue args
+        "ZRANK" -> cmdZRank now storeValue args
+        "ZSCORE" -> cmdZScore now storeValue args
+        "ZCARD" -> cmdZCard now storeValue args
+        "ZREM" -> cmdZRem now storeValue args
+        "PFADD" -> cmdPfAdd now storeValue args
+        "PFCOUNT" -> cmdPfCount now storeValue args
+        "PFMERGE" -> cmdPfMerge now storeValue args
+        "EXPIRE" -> cmdExpire now storeValue args
+        "EXPIREAT" -> cmdExpireAt now storeValue args
+        "TTL" -> cmdTtl now storeValue args
+        "PTTL" -> cmdPTtl now storeValue args
+        "PERSIST" -> cmdPersist now storeValue args
+        "SELECT" -> cmdSelect storeValue args
+        "FLUSHDB" -> cmdFlushDb storeValue args
+        "FLUSHALL" -> cmdFlushAll storeValue args
+        "DBSIZE" -> cmdDbSize now storeValue args
+        "INFO" -> cmdInfo now storeValue args
+        "KEYS" -> cmdKeys now storeValue args
+        _ -> (storeValue, EngineError ("ERR unknown command '" ++ commandName ++ "'"))
+
+cmdPing :: Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdPing storeValue args =
+    case args of
+        [] -> (storeValue, EngineSimpleString "PONG")
+        [messageValue] -> (storeValue, EngineBulkString (Just messageValue))
+        _ -> (storeValue, wrongNumber "PING")
+
+cmdEcho :: Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdEcho storeValue args =
+    case args of
+        [messageValue] -> (storeValue, EngineBulkString (Just messageValue))
+        _ -> (storeValue, wrongNumber "ECHO")
+
+cmdSet :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdSet now storeValue args =
+    case args of
+        keyValue : valueBytes : optionBytes ->
+            case parseSetOptions now optionBytes of
+                Left errMessage -> (storeValue, EngineError errMessage)
+                Right (expiresAtValue, shouldSetNx, shouldSetXx) ->
+                    let keyExists = isJust (storeGet now keyValue storeValue)
+                     in if shouldSetNx && keyExists
+                            then (storeValue, EngineBulkString Nothing)
+                            else if shouldSetXx && not keyExists
+                                then (storeValue, EngineBulkString Nothing)
+                                else
+                                    ( storeSet keyValue (entryFromValue (EntryStringValue valueBytes) expiresAtValue) storeValue
+                                    , okResponse
+                                    )
+        _ -> (storeValue, wrongNumber "SET")
+
+cmdGet :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdGet now storeValue args =
+    case args of
+        [keyValue] ->
+            case storeGet now keyValue storeValue of
+                Nothing -> (storeValue, EngineBulkString Nothing)
+                Just entryValueFound ->
+                    case entryValue entryValueFound of
+                        EntryStringValue bytesValue ->
+                            (storeValue, EngineBulkString (Just bytesValue))
+                        _ -> (storeValue, wrongTypeResponse)
+        _ -> (storeValue, wrongNumber "GET")
+
+cmdDel :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdDel now storeValue args
+    | null args = (storeValue, wrongNumber "DEL")
+    | otherwise =
+        let (updatedStore, removedCount) =
+                foldl
+                    (\(currentStore, countValue) keyValue ->
+                        if isJust (storeGet now keyValue currentStore)
+                            then (storeDelete keyValue currentStore, countValue + 1)
+                            else (currentStore, countValue))
+                    (storeValue, 0 :: Integer)
+                    args
+         in (updatedStore, EngineInteger removedCount)
+
+cmdExists :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdExists now storeValue args
+    | null args = (storeValue, wrongNumber "EXISTS")
+    | otherwise =
+        ( storeValue
+        , EngineInteger
+            (toInteger (length [() | keyValue <- args, isJust (storeGet now keyValue storeValue)]))
+        )
+
+cmdType :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdType now storeValue args =
+    case args of
+        [keyValue] ->
+            ( storeValue
+            , EngineSimpleString
+                (maybe "none" entryTypeName (storeTypeOf now keyValue storeValue))
+            )
+        _ -> (storeValue, wrongNumber "TYPE")
+
+cmdRename :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdRename now storeValue args =
+    case args of
+        [sourceKey, destinationKey] ->
+            case storeGet now sourceKey storeValue of
+                Nothing -> (storeValue, EngineError "ERR no such key")
+                Just entryValueFound ->
+                    let updatedStore =
+                            storeSet
+                                destinationKey
+                                entryValueFound
+                                (storeDelete sourceKey storeValue)
+                     in (updatedStore, okResponse)
+        _ -> (storeValue, wrongNumber "RENAME")
+
+cmdIncr :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdIncr now storeValue args =
+    case args of
+        [keyValue] -> adjustInteger now storeValue keyValue 1
+        _ -> (storeValue, wrongNumber "INCR")
+
+cmdDecr :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdDecr now storeValue args =
+    case args of
+        [keyValue] -> adjustInteger now storeValue keyValue (-1)
+        _ -> (storeValue, wrongNumber "DECR")
+
+cmdIncrBy :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdIncrBy now storeValue args =
+    case args of
+        [keyValue, deltaBytes] ->
+            case parseIntegerArg deltaBytes of
+                Left errMessage -> (storeValue, EngineError errMessage)
+                Right deltaValue -> adjustInteger now storeValue keyValue deltaValue
+        _ -> (storeValue, wrongNumber "INCRBY")
+
+cmdDecrBy :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdDecrBy now storeValue args =
+    case args of
+        [keyValue, deltaBytes] ->
+            case parseIntegerArg deltaBytes of
+                Left errMessage -> (storeValue, EngineError errMessage)
+                Right deltaValue -> adjustInteger now storeValue keyValue (negate deltaValue)
+        _ -> (storeValue, wrongNumber "DECRBY")
+
+cmdAppend :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdAppend now storeValue args =
+    case args of
+        [keyValue, suffixValue] ->
+            case storeGet now keyValue storeValue of
+                Nothing ->
+                    ( storeSet keyValue (entryFromValue (EntryStringValue suffixValue) Nothing) storeValue
+                    , EngineInteger (toInteger (BS.length suffixValue))
+                    )
+                Just entryValueFound ->
+                    case entryValue entryValueFound of
+                        EntryStringValue existingValue ->
+                            let combinedValue = existingValue <> suffixValue
+                                updatedStore =
+                                    storeSet
+                                        keyValue
+                                        (entryFromValue (EntryStringValue combinedValue) (entryExpiresAt entryValueFound))
+                                        storeValue
+                             in (updatedStore, EngineInteger (toInteger (BS.length combinedValue)))
+                        _ -> (storeValue, wrongTypeResponse)
+        _ -> (storeValue, wrongNumber "APPEND")
+
+cmdHSet :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdHSet now storeValue args
+    | length args < 3 || even (length args) =
+        (storeValue, wrongNumber "HSET")
+    | otherwise =
+        let keyValue = head args
+            valuePairs = pairs (tail args)
+         in case loadHash now storeValue keyValue of
+                Left response -> (storeValue, response)
+                Right (hashValueMap, expiresAtValue) ->
+                    let (updatedHash, addedCount) =
+                            foldl
+                                (\(currentHash, countValue) (fieldValue, fieldBytes) ->
+                                    let isNewField = not (HM.has fieldValue currentHash)
+                                     in (HM.set fieldValue fieldBytes currentHash, countValue + if isNewField then 1 else 0))
+                                (hashValueMap, 0 :: Integer)
+                                valuePairs
+                     in ( storeSet keyValue (entryFromValue (EntryHashValue updatedHash) expiresAtValue) storeValue
+                        , EngineInteger addedCount
+                        )
+
+cmdHGet :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdHGet now storeValue args =
+    case args of
+        [keyValue, fieldValue] ->
+            case loadHash now storeValue keyValue of
+                Left response -> (storeValue, response)
+                Right (hashValueMap, _) ->
+                    (storeValue, EngineBulkString (HM.get fieldValue hashValueMap))
+        _ -> (storeValue, wrongNumber "HGET")
+
+cmdHDel :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdHDel now storeValue args
+    | length args < 2 = (storeValue, wrongNumber "HDEL")
+    | otherwise =
+        let keyValue = head args
+            fields = tail args
+         in case loadHash now storeValue keyValue of
+                Left response -> (storeValue, response)
+                Right (hashValueMap, expiresAtValue) ->
+                    let (updatedHash, removedCount) =
+                            foldl
+                                (\(currentHash, countValue) fieldValue ->
+                                    if HM.has fieldValue currentHash
+                                        then (HM.delete fieldValue currentHash, countValue + 1)
+                                        else (currentHash, countValue))
+                                (hashValueMap, 0 :: Integer)
+                                fields
+                        updatedStore =
+                            if HM.isEmpty updatedHash
+                                then storeDelete keyValue storeValue
+                                else storeSet keyValue (entryFromValue (EntryHashValue updatedHash) expiresAtValue) storeValue
+                     in (updatedStore, EngineInteger removedCount)
+
+cmdHGetAll :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdHGetAll now storeValue args =
+    case args of
+        [keyValue] ->
+            case loadHash now storeValue keyValue of
+                Left response -> (storeValue, response)
+                Right (hashValueMap, _) ->
+                    (storeValue, EngineArray (Just (concatMap kvResponse (HM.entries hashValueMap))))
+        _ -> (storeValue, wrongNumber "HGETALL")
+
+cmdHLen :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdHLen now storeValue args =
+    case args of
+        [keyValue] ->
+            case loadHash now storeValue keyValue of
+                Left response -> (storeValue, response)
+                Right (hashValueMap, _) ->
+                    (storeValue, EngineInteger (toInteger (HM.size hashValueMap)))
+        _ -> (storeValue, wrongNumber "HLEN")
+
+cmdHExists :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdHExists now storeValue args =
+    case args of
+        [keyValue, fieldValue] ->
+            case loadHash now storeValue keyValue of
+                Left response -> (storeValue, response)
+                Right (hashValueMap, _) ->
+                    (storeValue, EngineInteger (if HM.has fieldValue hashValueMap then 1 else 0))
+        _ -> (storeValue, wrongNumber "HEXISTS")
+
+cmdHKeys :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdHKeys now storeValue args =
+    case args of
+        [keyValue] ->
+            case loadHash now storeValue keyValue of
+                Left response -> (storeValue, response)
+                Right (hashValueMap, _) ->
+                    (storeValue, EngineArray (Just [EngineBulkString (Just fieldValue) | fieldValue <- HM.keys hashValueMap]))
+        _ -> (storeValue, wrongNumber "HKEYS")
+
+cmdHVals :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdHVals now storeValue args =
+    case args of
+        [keyValue] ->
+            case loadHash now storeValue keyValue of
+                Left response -> (storeValue, response)
+                Right (hashValueMap, _) ->
+                    ( storeValue
+                    , EngineArray
+                        (Just [EngineBulkString (Just valueBytes) | (_, valueBytes) <- HM.entries hashValueMap])
+                    )
+        _ -> (storeValue, wrongNumber "HVALS")
+
+cmdLPush :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdLPush now storeValue args
+    | length args < 2 = (storeValue, wrongNumber "LPUSH")
+    | otherwise =
+        let keyValue = head args
+            valuesToPush = tail args
+         in case loadList now storeValue keyValue of
+                Left response -> (storeValue, response)
+                Right (listValue, expiresAtValue) ->
+                    let updatedList = foldl (flip (Seq.<|)) listValue valuesToPush
+                     in ( storeSet keyValue (entryFromValue (EntryListValue updatedList) expiresAtValue) storeValue
+                        , EngineInteger (toInteger (Foldable.length updatedList))
+                        )
+
+cmdRPush :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdRPush now storeValue args
+    | length args < 2 = (storeValue, wrongNumber "RPUSH")
+    | otherwise =
+        let keyValue = head args
+            valuesToPush = tail args
+         in case loadList now storeValue keyValue of
+                Left response -> (storeValue, response)
+                Right (listValue, expiresAtValue) ->
+                    let updatedList = Foldable.foldl' (Seq.|>) listValue valuesToPush
+                     in ( storeSet keyValue (entryFromValue (EntryListValue updatedList) expiresAtValue) storeValue
+                        , EngineInteger (toInteger (Foldable.length updatedList))
+                        )
+
+cmdLPop :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdLPop now storeValue args =
+    case args of
+        [keyValue] ->
+            case loadList now storeValue keyValue of
+                Left response -> (storeValue, response)
+                Right (listValue, expiresAtValue) ->
+                    case Seq.viewl listValue of
+                        EmptyL -> (storeDelete keyValue storeValue, EngineBulkString Nothing)
+                        valueBytes Seq.:< restList ->
+                            let updatedStore =
+                                    if Seq.null restList
+                                        then storeDelete keyValue storeValue
+                                        else storeSet keyValue (entryFromValue (EntryListValue restList) expiresAtValue) storeValue
+                             in (updatedStore, EngineBulkString (Just valueBytes))
+        _ -> (storeValue, wrongNumber "LPOP")
+
+cmdRPop :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdRPop now storeValue args =
+    case args of
+        [keyValue] ->
+            case loadList now storeValue keyValue of
+                Left response -> (storeValue, response)
+                Right (listValue, expiresAtValue) ->
+                    case Seq.viewr listValue of
+                        EmptyR -> (storeDelete keyValue storeValue, EngineBulkString Nothing)
+                        restList Seq.:> valueBytes ->
+                            let updatedStore =
+                                    if Seq.null restList
+                                        then storeDelete keyValue storeValue
+                                        else storeSet keyValue (entryFromValue (EntryListValue restList) expiresAtValue) storeValue
+                             in (updatedStore, EngineBulkString (Just valueBytes))
+        _ -> (storeValue, wrongNumber "RPOP")
+
+cmdLLen :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdLLen now storeValue args =
+    case args of
+        [keyValue] ->
+            case loadList now storeValue keyValue of
+                Left response -> (storeValue, response)
+                Right (listValue, _) ->
+                    (storeValue, EngineInteger (toInteger (Foldable.length listValue)))
+        _ -> (storeValue, wrongNumber "LLEN")
+
+cmdLRange :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdLRange now storeValue args =
+    case args of
+        [keyValue, startBytes, endBytes] ->
+            case (parseIntegerArg startBytes, parseIntegerArg endBytes) of
+                (Right startValue, Right endValue) ->
+                    case loadList now storeValue keyValue of
+                        Left response -> (storeValue, response)
+                        Right (listValue, _) ->
+                            let listedValues = Foldable.toList listValue
+                                sliceValues = sliceRange listedValues (fromInteger startValue) (fromInteger endValue)
+                             in (storeValue, EngineArray (Just (map (EngineBulkString . Just) sliceValues)))
+                (Left errMessage, _) -> (storeValue, EngineError errMessage)
+                (_, Left errMessage) -> (storeValue, EngineError errMessage)
+        _ -> (storeValue, wrongNumber "LRANGE")
+
+cmdLIndex :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdLIndex now storeValue args =
+    case args of
+        [keyValue, indexBytes] ->
+            case parseIntegerArg indexBytes of
+                Left errMessage -> (storeValue, EngineError errMessage)
+                Right indexValue ->
+                    case loadList now storeValue keyValue of
+                        Left response -> (storeValue, response)
+                        Right (listValue, _) ->
+                            let listedValues = Foldable.toList listValue
+                                normalizedValue = normalizeIndex (length listedValues) (fromInteger indexValue)
+                             in if normalizedValue < 0 || normalizedValue >= length listedValues
+                                    then (storeValue, EngineBulkString Nothing)
+                                    else (storeValue, EngineBulkString (Just (listedValues !! normalizedValue)))
+        _ -> (storeValue, wrongNumber "LINDEX")
+
+cmdSAdd :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdSAdd now storeValue args
+    | length args < 2 = (storeValue, wrongNumber "SADD")
+    | otherwise =
+        let keyValue = head args
+            membersToAdd = tail args
+         in case loadSet now storeValue keyValue of
+                Left response -> (storeValue, response)
+                Right (setValue, expiresAtValue) ->
+                    let (updatedSet, addedCount) =
+                            foldl
+                                (\(currentSet, countValue) memberValue ->
+                                    if HS.contains memberValue currentSet
+                                        then (currentSet, countValue)
+                                        else (HS.add memberValue currentSet, countValue + 1))
+                                (setValue, 0 :: Integer)
+                                membersToAdd
+                     in ( storeSet keyValue (entryFromValue (EntrySetValue updatedSet) expiresAtValue) storeValue
+                        , EngineInteger addedCount
+                        )
+
+cmdSRem :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdSRem now storeValue args
+    | length args < 2 = (storeValue, wrongNumber "SREM")
+    | otherwise =
+        let keyValue = head args
+            membersToRemove = tail args
+         in case loadSet now storeValue keyValue of
+                Left response -> (storeValue, response)
+                Right (setValue, expiresAtValue) ->
+                    let (updatedSet, removedCount) =
+                            foldl
+                                (\(currentSet, countValue) memberValue ->
+                                    if HS.contains memberValue currentSet
+                                        then (HS.remove memberValue currentSet, countValue + 1)
+                                        else (currentSet, countValue))
+                                (setValue, 0 :: Integer)
+                                membersToRemove
+                        updatedStore =
+                            if HS.isEmpty updatedSet
+                                then storeDelete keyValue storeValue
+                                else storeSet keyValue (entryFromValue (EntrySetValue updatedSet) expiresAtValue) storeValue
+                     in (updatedStore, EngineInteger removedCount)
+
+cmdSIsMember :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdSIsMember now storeValue args =
+    case args of
+        [keyValue, memberValue] ->
+            case loadSet now storeValue keyValue of
+                Left response -> (storeValue, response)
+                Right (setValue, _) ->
+                    (storeValue, EngineInteger (if HS.contains memberValue setValue then 1 else 0))
+        _ -> (storeValue, wrongNumber "SISMEMBER")
+
+cmdSMembers :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdSMembers now storeValue args =
+    case args of
+        [keyValue] ->
+            case loadSet now storeValue keyValue of
+                Left response -> (storeValue, response)
+                Right (setValue, _) ->
+                    (storeValue, EngineArray (Just [EngineBulkString (Just memberValue) | memberValue <- HS.toList setValue]))
+        _ -> (storeValue, wrongNumber "SMEMBERS")
+
+cmdSCard :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdSCard now storeValue args =
+    case args of
+        [keyValue] ->
+            case loadSet now storeValue keyValue of
+                Left response -> (storeValue, response)
+                Right (setValue, _) ->
+                    (storeValue, EngineInteger (toInteger (HS.size setValue)))
+        _ -> (storeValue, wrongNumber "SCARD")
+
+cmdSUnion :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdSUnion now storeValue args
+    | null args = (storeValue, wrongNumber "SUNION")
+    | otherwise =
+        case traverse (loadSetForRead now storeValue) args of
+            Left response -> (storeValue, response)
+            Right setsValue ->
+                let combinedSet = foldl HS.union HS.empty setsValue
+                 in (storeValue, EngineArray (Just [EngineBulkString (Just memberValue) | memberValue <- HS.toList combinedSet]))
+
+cmdSInter :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdSInter now storeValue args
+    | null args = (storeValue, wrongNumber "SINTER")
+    | otherwise =
+        case traverse (loadSetForRead now storeValue) args of
+            Left response -> (storeValue, response)
+            Right [] -> (storeValue, EngineArray (Just []))
+            Right (firstSet : restSets) ->
+                let combinedSet = foldl HS.intersection firstSet restSets
+                 in (storeValue, EngineArray (Just [EngineBulkString (Just memberValue) | memberValue <- HS.toList combinedSet]))
+
+cmdSDiff :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdSDiff now storeValue args
+    | null args = (storeValue, wrongNumber "SDIFF")
+    | otherwise =
+        case traverse (loadSetForRead now storeValue) args of
+            Left response -> (storeValue, response)
+            Right [] -> (storeValue, EngineArray (Just []))
+            Right (firstSet : restSets) ->
+                let combinedSet = foldl HS.difference firstSet restSets
+                 in (storeValue, EngineArray (Just [EngineBulkString (Just memberValue) | memberValue <- HS.toList combinedSet]))
+
+cmdZAdd :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdZAdd now storeValue args
+    | length args < 3 || even (length args) = (storeValue, wrongNumber "ZADD")
+    | otherwise =
+        let keyValue = head args
+            scorePairs = pairs (tail args)
+         in case loadZSet now storeValue keyValue of
+                Left response -> (storeValue, response)
+                Right (zsetValue, expiresAtValue) ->
+                    case foldl insertPair (Right (zsetValue, 0 :: Integer)) scorePairs of
+                        Left errMessage -> (storeValue, EngineError errMessage)
+                        Right (updatedZSet, addedCount) ->
+                            ( storeSet keyValue (entryFromValue (EntryZSetValue updatedZSet) expiresAtValue) storeValue
+                            , EngineInteger addedCount
+                            )
+  where
+    insertPair accumulator (scoreBytes, memberValue) =
+        case accumulator of
+            Left errMessage -> Left errMessage
+            Right (currentZSet, countValue) ->
+                case parseDoubleArg scoreBytes of
+                    Left errMessage -> Left errMessage
+                    Right scoreValue ->
+                        case sortedSetInsert scoreValue memberValue currentZSet of
+                            Left errMessage -> Left errMessage
+                            Right (nextZSet, isNewMember) ->
+                                Right (nextZSet, countValue + if isNewMember then 1 else 0)
+
+cmdZRange :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdZRange now storeValue args =
+    case args of
+        [keyValue, startBytes, endBytes] ->
+            case (parseIntegerArg startBytes, parseIntegerArg endBytes) of
+                (Right startValue, Right endValue) ->
+                    case loadZSet now storeValue keyValue of
+                        Left response -> (storeValue, response)
+                        Right (zsetValue, _) ->
+                            let members =
+                                    [ EngineBulkString (Just memberValue)
+                                    | (memberValue, _) <- sortedSetRangeByIndex (fromInteger startValue) (fromInteger endValue) zsetValue
+                                    ]
+                             in (storeValue, EngineArray (Just members))
+                (Left errMessage, _) -> (storeValue, EngineError errMessage)
+                (_, Left errMessage) -> (storeValue, EngineError errMessage)
+        _ -> (storeValue, wrongNumber "ZRANGE")
+
+cmdZRangeByScore :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdZRangeByScore now storeValue args =
+    case args of
+        [keyValue, minBytes, maxBytes] ->
+            case (parseDoubleArg minBytes, parseDoubleArg maxBytes) of
+                (Right minValue, Right maxValue) ->
+                    case loadZSet now storeValue keyValue of
+                        Left response -> (storeValue, response)
+                        Right (zsetValue, _) ->
+                            let members =
+                                    [ EngineBulkString (Just memberValue)
+                                    | (memberValue, _) <- sortedSetRangeByScore minValue maxValue zsetValue
+                                    ]
+                             in (storeValue, EngineArray (Just members))
+                (Left errMessage, _) -> (storeValue, EngineError errMessage)
+                (_, Left errMessage) -> (storeValue, EngineError errMessage)
+        _ -> (storeValue, wrongNumber "ZRANGEBYSCORE")
+
+cmdZRank :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdZRank now storeValue args =
+    case args of
+        [keyValue, memberValue] ->
+            case loadZSet now storeValue keyValue of
+                Left response -> (storeValue, response)
+                Right (zsetValue, _) ->
+                    case sortedSetRank memberValue zsetValue of
+                        Nothing -> (storeValue, EngineBulkString Nothing)
+                        Just rankValue -> (storeValue, EngineInteger (toInteger rankValue))
+        _ -> (storeValue, wrongNumber "ZRANK")
+
+cmdZScore :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdZScore now storeValue args =
+    case args of
+        [keyValue, memberValue] ->
+            case loadZSet now storeValue keyValue of
+                Left response -> (storeValue, response)
+                Right (zsetValue, _) ->
+                    let maybeScore = lookup memberValue (sortedSetOrderedEntries zsetValue)
+                     in (storeValue, EngineBulkString (renderScore <$> maybeScore))
+        _ -> (storeValue, wrongNumber "ZSCORE")
+
+cmdZCard :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdZCard now storeValue args =
+    case args of
+        [keyValue] ->
+            case loadZSet now storeValue keyValue of
+                Left response -> (storeValue, response)
+                Right (zsetValue, _) ->
+                    (storeValue, EngineInteger (toInteger (length (sortedSetOrderedEntries zsetValue))))
+        _ -> (storeValue, wrongNumber "ZCARD")
+
+cmdZRem :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdZRem now storeValue args
+    | length args < 2 = (storeValue, wrongNumber "ZREM")
+    | otherwise =
+        let keyValue = head args
+            membersToRemove = tail args
+         in case loadZSet now storeValue keyValue of
+                Left response -> (storeValue, response)
+                Right (zsetValue, expiresAtValue) ->
+                    let (updatedZSet, removedCount) =
+                            foldl
+                                (\(currentZSet, countValue) memberValue ->
+                                    let (nextZSet, removed) = sortedSetRemove memberValue currentZSet
+                                     in (nextZSet, countValue + if removed then 1 else 0))
+                                (zsetValue, 0 :: Integer)
+                                membersToRemove
+                        updatedStore =
+                            if null (sortedSetOrderedEntries updatedZSet)
+                                then storeDelete keyValue storeValue
+                                else storeSet keyValue (entryFromValue (EntryZSetValue updatedZSet) expiresAtValue) storeValue
+                     in (updatedStore, EngineInteger removedCount)
+
+cmdPfAdd :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdPfAdd now storeValue args
+    | length args < 2 = (storeValue, wrongNumber "PFADD")
+    | otherwise =
+        let keyValue = head args
+            valuesToAdd = tail args
+         in case loadHll now storeValue keyValue of
+                Left response -> (storeValue, response)
+                Right (hllValue, expiresAtValue) ->
+                    let (updatedHll, changed) = HLL.addMany valuesToAdd hllValue
+                     in ( storeSet keyValue (entryFromValue (EntryHllValue updatedHll) expiresAtValue) storeValue
+                        , EngineInteger (if changed then 1 else 0)
+                        )
+
+cmdPfCount :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdPfCount now storeValue args
+    | null args = (storeValue, wrongNumber "PFCOUNT")
+    | otherwise =
+        case traverse (loadHllForRead now storeValue) args of
+            Left response -> (storeValue, response)
+            Right hllValues ->
+                let mergedHll = HLL.mergeMany hllValues
+                 in (storeValue, EngineInteger (HLL.count mergedHll))
+
+cmdPfMerge :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdPfMerge now storeValue args
+    | length args < 2 = (storeValue, wrongNumber "PFMERGE")
+    | otherwise =
+        let destinationKey = head args
+            sourceKeys = tail args
+         in case traverse (loadHllForRead now storeValue) sourceKeys of
+                Left response -> (storeValue, response)
+                Right hllValues ->
+                    case loadHll now storeValue destinationKey of
+                        Left response -> (storeValue, response)
+                        Right (_, expiresAtValue) ->
+                            let mergedHll = HLL.mergeMany hllValues
+                             in ( storeSet destinationKey (entryFromValue (EntryHllValue mergedHll) expiresAtValue) storeValue
+                                , okResponse
+                                )
+
+cmdExpire :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdExpire now storeValue args =
+    case args of
+        [keyValue, secondsBytes] ->
+            case parseIntegerArg secondsBytes of
+                Left errMessage -> (storeValue, EngineError errMessage)
+                Right secondsValue ->
+                    setExpiry now storeValue keyValue (Just (now + secondsValue * 1000))
+        _ -> (storeValue, wrongNumber "EXPIRE")
+
+cmdExpireAt :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdExpireAt now storeValue args =
+    case args of
+        [keyValue, timestampBytes] ->
+            case parseIntegerArg timestampBytes of
+                Left errMessage -> (storeValue, EngineError errMessage)
+                Right timestampValue ->
+                    setExpiry now storeValue keyValue (Just (timestampValue * 1000))
+        _ -> (storeValue, wrongNumber "EXPIREAT")
+
+cmdTtl :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdTtl now storeValue args =
+    case args of
+        [keyValue] ->
+            case ttlForKey now keyValue storeValue of
+                Nothing -> (storeValue, EngineInteger (-2))
+                Just Nothing -> (storeValue, EngineInteger (-1))
+                Just (Just expiresAtValue) ->
+                    (storeValue, EngineInteger (max 0 ((expiresAtValue - now) `div` 1000)))
+        _ -> (storeValue, wrongNumber "TTL")
+
+cmdPTtl :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdPTtl now storeValue args =
+    case args of
+        [keyValue] ->
+            case ttlForKey now keyValue storeValue of
+                Nothing -> (storeValue, EngineInteger (-2))
+                Just Nothing -> (storeValue, EngineInteger (-1))
+                Just (Just expiresAtValue) ->
+                    (storeValue, EngineInteger (max 0 (expiresAtValue - now)))
+        _ -> (storeValue, wrongNumber "PTTL")
+
+cmdPersist :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdPersist now storeValue args =
+    case args of
+        [keyValue] ->
+            case storeGet now keyValue storeValue of
+                Nothing -> (storeValue, EngineInteger 0)
+                Just entryValueFound ->
+                    case entryExpiresAt entryValueFound of
+                        Nothing -> (storeValue, EngineInteger 0)
+                        Just _ ->
+                            ( storeSet
+                                keyValue
+                                (entryFromValue (entryValue entryValueFound) Nothing)
+                                storeValue
+                            , EngineInteger 1
+                            )
+        _ -> (storeValue, wrongNumber "PERSIST")
+
+cmdSelect :: Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdSelect storeValue args =
+    case args of
+        [dbBytes] ->
+            case parseIntegerArg dbBytes of
+                Left errMessage -> (storeValue, EngineError errMessage)
+                Right dbValue
+                    | dbValue < 0 -> (storeValue, EngineError "ERR DB index is out of range")
+                    | otherwise -> (storeSelect (fromInteger dbValue) storeValue, okResponse)
+        _ -> (storeValue, wrongNumber "SELECT")
+
+cmdFlushDb :: Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdFlushDb storeValue args =
+    case args of
+        [] -> (storeFlushDb storeValue, okResponse)
+        _ -> (storeValue, wrongNumber "FLUSHDB")
+
+cmdFlushAll :: Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdFlushAll storeValue args =
+    case args of
+        [] -> (storeFlushAll storeValue, okResponse)
+        _ -> (storeValue, wrongNumber "FLUSHALL")
+
+cmdDbSize :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdDbSize now storeValue args =
+    case args of
+        [] -> (storeValue, EngineInteger (toInteger (storeDbSize now storeValue)))
+        _ -> (storeValue, wrongNumber "DBSIZE")
+
+cmdInfo :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdInfo now storeValue args =
+    case args of
+        [] ->
+            let currentDbValue = currentDatabase storeValue
+                expiresCount =
+                    length
+                        [ ()
+                        | (_, entryValueFound) <- HM.entries (databaseEntries currentDbValue)
+                        , isJust (entryExpiresAt entryValueFound)
+                        ]
+                infoText =
+                    unlines
+                        [ "# Server"
+                        , "mini_redis_haskell:1"
+                        , "# Keyspace"
+                        , "db" ++ show (storeActiveDb storeValue)
+                            ++ ":keys="
+                            ++ show (storeDbSize now storeValue)
+                            ++ ",expires="
+                            ++ show expiresCount
+                        ]
+             in (storeValue, EngineBulkString (Just (BC.pack infoText)))
+        _ -> (storeValue, wrongNumber "INFO")
+
+cmdKeys :: Integer -> Store -> [BS.ByteString] -> (Store, EngineResponse)
+cmdKeys now storeValue args =
+    case args of
+        [patternBytes] ->
+            ( storeValue
+            , EngineArray
+                (Just [EngineBulkString (Just keyValue) | keyValue <- storeKeys now patternBytes storeValue])
+            )
+        _ -> (storeValue, wrongNumber "KEYS")
+
+loadHash :: Integer -> Store -> BS.ByteString -> Either EngineResponse (HM.HashMap BS.ByteString BS.ByteString, Maybe Integer)
+loadHash now storeValue keyValue =
+    case storeGet now keyValue storeValue of
+        Nothing -> Right (HM.empty, Nothing)
+        Just entryValueFound ->
+            case entryValue entryValueFound of
+                EntryHashValue hashValueMap -> Right (hashValueMap, entryExpiresAt entryValueFound)
+                _ -> Left wrongTypeResponse
+
+loadList :: Integer -> Store -> BS.ByteString -> Either EngineResponse (Seq BS.ByteString, Maybe Integer)
+loadList now storeValue keyValue =
+    case storeGet now keyValue storeValue of
+        Nothing -> Right (Seq.empty, Nothing)
+        Just entryValueFound ->
+            case entryValue entryValueFound of
+                EntryListValue listValue -> Right (listValue, entryExpiresAt entryValueFound)
+                _ -> Left wrongTypeResponse
+
+loadSet :: Integer -> Store -> BS.ByteString -> Either EngineResponse (HS.HashSet BS.ByteString, Maybe Integer)
+loadSet now storeValue keyValue =
+    case storeGet now keyValue storeValue of
+        Nothing -> Right (HS.empty, Nothing)
+        Just entryValueFound ->
+            case entryValue entryValueFound of
+                EntrySetValue setValue -> Right (setValue, entryExpiresAt entryValueFound)
+                _ -> Left wrongTypeResponse
+
+loadSetForRead :: Integer -> Store -> BS.ByteString -> Either EngineResponse (HS.HashSet BS.ByteString)
+loadSetForRead now storeValue keyValue =
+    case storeGet now keyValue storeValue of
+        Nothing -> Right HS.empty
+        Just entryValueFound ->
+            case entryValue entryValueFound of
+                EntrySetValue setValue -> Right setValue
+                _ -> Left wrongTypeResponse
+
+loadZSet :: Integer -> Store -> BS.ByteString -> Either EngineResponse (SortedSet, Maybe Integer)
+loadZSet now storeValue keyValue =
+    case storeGet now keyValue storeValue of
+        Nothing -> Right (emptySortedSet, Nothing)
+        Just entryValueFound ->
+            case entryValue entryValueFound of
+                EntryZSetValue zsetValue -> Right (zsetValue, entryExpiresAt entryValueFound)
+                _ -> Left wrongTypeResponse
+
+loadHll :: Integer -> Store -> BS.ByteString -> Either EngineResponse (HLL.HyperLogLog, Maybe Integer)
+loadHll now storeValue keyValue =
+    case storeGet now keyValue storeValue of
+        Nothing -> Right (HLL.new, Nothing)
+        Just entryValueFound ->
+            case entryValue entryValueFound of
+                EntryHllValue hllValue -> Right (hllValue, entryExpiresAt entryValueFound)
+                _ -> Left wrongTypeResponse
+
+loadHllForRead :: Integer -> Store -> BS.ByteString -> Either EngineResponse HLL.HyperLogLog
+loadHllForRead now storeValue keyValue =
+    case storeGet now keyValue storeValue of
+        Nothing -> Right HLL.new
+        Just entryValueFound ->
+            case entryValue entryValueFound of
+                EntryHllValue hllValue -> Right hllValue
+                _ -> Left wrongTypeResponse
+
+adjustInteger :: Integer -> Store -> BS.ByteString -> Integer -> (Store, EngineResponse)
+adjustInteger now storeValue keyValue deltaValue =
+    case storeGet now keyValue storeValue of
+        Nothing ->
+            let nextValue = deltaValue
+             in ( storeSet
+                    keyValue
+                    (entryFromValue (EntryStringValue (BC.pack (show nextValue))) Nothing)
+                    storeValue
+                , EngineInteger nextValue
+                )
+        Just entryValueFound ->
+            case entryValue entryValueFound of
+                EntryStringValue currentBytes ->
+                    case parseIntegerArg currentBytes of
+                        Left errMessage -> (storeValue, EngineError errMessage)
+                        Right currentValue ->
+                            let nextValue = currentValue + deltaValue
+                                updatedStore =
+                                    storeSet
+                                        keyValue
+                                        (entryFromValue
+                                            (EntryStringValue (BC.pack (show nextValue)))
+                                            (entryExpiresAt entryValueFound))
+                                        storeValue
+                             in (updatedStore, EngineInteger nextValue)
+                _ -> (storeValue, wrongTypeResponse)
+
+parseSetOptions :: Integer -> [BS.ByteString] -> Either String (Maybe Integer, Bool, Bool)
+parseSetOptions now = go Nothing False False
+  where
+    go expiresAtValue useNx useXx optionBytes =
+        case optionBytes of
+            [] ->
+                if useNx && useXx
+                    then Left "ERR syntax error"
+                    else Right (expiresAtValue, useNx, useXx)
+            optionValue : restOptions ->
+                case map toUpper (BC.unpack optionValue) of
+                    "EX" ->
+                        case restOptions of
+                            nextValue : remaining ->
+                                parseIntegerArg nextValue >>= \secondsValue ->
+                                    go (Just (now + secondsValue * 1000)) useNx useXx remaining
+                            _ -> Left "ERR syntax error"
+                    "PX" ->
+                        case restOptions of
+                            nextValue : remaining ->
+                                parseIntegerArg nextValue >>= \millisValue ->
+                                    go (Just (now + millisValue)) useNx useXx remaining
+                            _ -> Left "ERR syntax error"
+                    "NX" -> go expiresAtValue True useXx restOptions
+                    "XX" -> go expiresAtValue useNx True restOptions
+                    _ -> Left "ERR syntax error"
+
+setExpiry :: Integer -> Store -> BS.ByteString -> Maybe Integer -> (Store, EngineResponse)
+setExpiry now storeValue keyValue expiresAtValue =
+    case storeGet now keyValue storeValue of
+        Nothing -> (storeValue, EngineInteger 0)
+        Just entryValueFound ->
+            ( storeSet
+                keyValue
+                (entryFromValue (entryValue entryValueFound) expiresAtValue)
+                storeValue
+            , EngineInteger 1
+            )
+
+ttlForKey :: Integer -> BS.ByteString -> Store -> Maybe (Maybe Integer)
+ttlForKey now keyValue storeValue =
+    case storeGet now keyValue storeValue of
+        Nothing -> Nothing
+        Just entryValueFound -> Just (entryExpiresAt entryValueFound)
+
+wrongNumber :: String -> EngineResponse
+wrongNumber commandName =
+    EngineError ("ERR wrong number of arguments for '" ++ commandName ++ "'")
+
+wrongTypeResponse :: EngineResponse
+wrongTypeResponse =
+    EngineError "WRONGTYPE Operation against a key holding the wrong kind of value"
+
+okResponse :: EngineResponse
+okResponse = EngineSimpleString "OK"
+
+parseIntegerArg :: BS.ByteString -> Either String Integer
+parseIntegerArg bytesValue =
+    case BC.readInteger bytesValue of
+        Just (numberValue, rest) | BS.null rest -> Right numberValue
+        _ -> Left "ERR value is not an integer or out of range"
+
+parseDoubleArg :: BS.ByteString -> Either String Double
+parseDoubleArg bytesValue =
+    case readMaybe (BC.unpack bytesValue) of
+        Just numberValue | not (isNaN numberValue) -> Right numberValue
+        _ -> Left "ERR value is not a valid float"
+
+renderScore :: Double -> BS.ByteString
+renderScore scoreValue
+    | isWholeNumber scoreValue = BC.pack (show (round scoreValue :: Integer))
+    | otherwise = BC.pack (trimTrailingZeros (showFFloat Nothing scoreValue ""))
+
+trimTrailingZeros :: String -> String
+trimTrailingZeros textValue =
+    case span (/= '.') textValue of
+        (_, "") -> textValue
+        _ ->
+            let trimmed = reverse (dropWhile (== '0') (reverse textValue))
+             in if not (null trimmed) && last trimmed == '.'
+                    then init trimmed
+                    else trimmed
+
+isWholeNumber :: Double -> Bool
+isWholeNumber scoreValue =
+    let roundedValue = fromInteger (round scoreValue)
+     in abs (scoreValue - roundedValue) < 1.0e-12
+
+normalizeIndex :: Int -> Int -> Int
+normalizeIndex totalLength indexValue
+    | indexValue < 0 = totalLength + indexValue
+    | otherwise = indexValue
+
+sliceRange :: [value] -> Int -> Int -> [value]
+sliceRange valuesList startIndex endIndex
+    | null valuesList = []
+    | normalizedStart < 0 = []
+    | normalizedStart >= totalLength = []
+    | normalizedEnd < 0 = []
+    | clampedStart > clampedEnd = []
+    | otherwise = take (clampedEnd - clampedStart + 1) (drop clampedStart valuesList)
+  where
+    totalLength = length valuesList
+    normalizedStart = normalizeIndex totalLength startIndex
+    normalizedEnd = normalizeIndex totalLength endIndex
+    clampedStart = max 0 normalizedStart
+    clampedEnd = min (totalLength - 1) normalizedEnd
+
+pairs :: [value] -> [(value, value)]
+pairs valuesList =
+    case valuesList of
+        firstValue : secondValue : restValues -> (firstValue, secondValue) : pairs restValues
+        _ -> []
+
+kvResponse :: (BS.ByteString, BS.ByteString) -> [EngineResponse]
+kvResponse (keyValue, valueBytes) =
+    [EngineBulkString (Just keyValue), EngineBulkString (Just valueBytes)]
+
+listToMaybeByteString :: [BS.ByteString] -> Maybe BS.ByteString
+listToMaybeByteString valuesList =
+    case valuesList of
+        [] -> Nothing
+        value : _ -> Just value
+
+clampDbIndex :: Int -> Int
+clampDbIndex requestedDb = max 0 (min 15 requestedDb)
+
+isExpired :: Integer -> Entry -> Bool
+isExpired now entryValueFound =
+    case entryExpiresAt entryValueFound of
+        Just expiresAtValue -> now >= expiresAtValue
+        Nothing -> False
+
+extractSimplePrefix :: BS.ByteString -> Maybe BS.ByteString
+extractSimplePrefix patternBytes =
+    case BS.elemIndex 42 patternBytes of
+        Nothing ->
+            if BS.any isWildcard patternBytes
+                then Nothing
+                else Just patternBytes
+        Just wildcardIndex ->
+            let prefixBytes = BS.take wildcardIndex patternBytes
+                restBytes = BS.drop (wildcardIndex + 1) patternBytes
+             in if BS.any isWildcard prefixBytes || not (BS.null restBytes)
+                    then Nothing
+                    else Just prefixBytes
+  where
+    isWildcard byteValue = byteValue == 42 || byteValue == 63 || byteValue == 91
+
+globMatch :: BS.ByteString -> BS.ByteString -> Bool
+globMatch patternBytes textBytes = go (BS.unpack patternBytes) (BS.unpack textBytes)
+  where
+    go [] [] = True
+    go [] _ = False
+    go (42 : remainingPattern) textValues =
+        go remainingPattern textValues
+            || case textValues of
+                [] -> False
+                _ : remainingText -> go (42 : remainingPattern) remainingText
+    go (63 : remainingPattern) (_ : remainingText) = go remainingPattern remainingText
+    go (63 : _) [] = False
+    go (91 : remainingPattern) textValues =
+        case break (== 93) remainingPattern of
+            (classValues, 93 : restPattern) ->
+                case textValues of
+                    textByte : remainingText ->
+                        classContains classValues textByte && go restPattern remainingText
+                    [] -> False
+            _ ->
+                case textValues of
+                    textByte : remainingText ->
+                        textByte == 91 && go remainingPattern remainingText
+                    [] -> False
+    go (patternByte : remainingPattern) (textByte : remainingText) =
+        patternByte == textByte && go remainingPattern remainingText
+    go _ _ = False
+
+classContains :: [Word8] -> Word8 -> Bool
+classContains classValues textByte = go classValues
+  where
+    go valuesList =
+        case valuesList of
+            startValue : 45 : endValue : restValues ->
+                (startValue <= textByte && textByte <= endValue) || go restValues
+            value : restValues -> value == textByte || go restValues
+            [] -> False

--- a/code/packages/haskell/in-memory-data-store-engine/test/InMemoryDataStoreEngineSpec.hs
+++ b/code/packages/haskell/in-memory-data-store-engine/test/InMemoryDataStoreEngineSpec.hs
@@ -1,0 +1,83 @@
+module InMemoryDataStoreEngineSpec (spec) where
+
+import qualified Data.ByteString.Char8 as BC
+import InMemoryDataStoreEngine
+import InMemoryDataStoreProtocol
+import Test.Hspec
+
+spec :: Spec
+spec = describe "InMemoryDataStoreEngine" $ do
+    it "executes string, hash, set, and sorted-set commands" $ do
+        engine <- newDataStoreEngine Nothing
+        executeOwned engine (map BC.pack ["PING"])
+            `shouldReturn` EngineSimpleString "PONG"
+        executeOwned engine (map BC.pack ["SET", "alpha", "1"])
+            `shouldReturn` EngineSimpleString "OK"
+        executeOwned engine (map BC.pack ["GET", "alpha"])
+            `shouldReturn` EngineBulkString (Just (BC.pack "1"))
+        executeOwned engine (map BC.pack ["HSET", "hash", "b", "2", "a", "1"])
+            `shouldReturn` EngineInteger 2
+        executeOwned engine (map BC.pack ["HGETALL", "hash"])
+            `shouldReturn`
+                EngineArray
+                    (Just
+                        [ EngineBulkString (Just (BC.pack "a"))
+                        , EngineBulkString (Just (BC.pack "1"))
+                        , EngineBulkString (Just (BC.pack "b"))
+                        , EngineBulkString (Just (BC.pack "2"))
+                        ])
+        executeOwned engine (map BC.pack ["SADD", "set", "c", "a", "b"])
+            `shouldReturn` EngineInteger 3
+        executeOwned engine (map BC.pack ["SMEMBERS", "set"])
+            `shouldReturn`
+                EngineArray
+                    (Just
+                        [ EngineBulkString (Just (BC.pack "a"))
+                        , EngineBulkString (Just (BC.pack "b"))
+                        , EngineBulkString (Just (BC.pack "c"))
+                        ])
+        executeOwned engine (map BC.pack ["ZADD", "scores", "2", "b", "1", "a"])
+            `shouldReturn` EngineInteger 2
+        executeOwned engine (map BC.pack ["ZRANGE", "scores", "0", "-1"])
+            `shouldReturn`
+                EngineArray
+                    (Just
+                        [ EngineBulkString (Just (BC.pack "a"))
+                        , EngineBulkString (Just (BC.pack "b"))
+                        ])
+        executeOwned engine (map BC.pack ["ZRANK", "scores", "b"])
+            `shouldReturn` EngineInteger 1
+        executeOwned engine (map BC.pack ["ZSCORE", "scores", "a"])
+            `shouldReturn` EngineBulkString (Just (BC.pack "1"))
+
+    it "tracks ttl, databases, and hyperloglog state without tcp" $ do
+        engine <- newDataStoreEngine Nothing
+        executeWithDb engine 0 (CommandFrame "SET" (map BC.pack ["db:key", "value"]))
+            `shouldReturn` (0, EngineSimpleString "OK")
+        executeOwned engine (map BC.pack ["PFADD", "visitors", "a", "b", "c"])
+            `shouldReturn` EngineInteger 1
+        executeOwned engine (map BC.pack ["PFCOUNT", "visitors"])
+            `shouldReturn` EngineInteger 3
+        executeOwned engine (map BC.pack ["DBSIZE"])
+            `shouldReturn` EngineInteger 2
+        executeOwned engine (map BC.pack ["EXPIRE", "db:key", "0"])
+            `shouldReturn` EngineInteger 1
+        activeExpireAll engine
+        executeOwned engine (map BC.pack ["GET", "db:key"])
+            `shouldReturn` EngineBulkString Nothing
+
+    it "covers keyspace helpers and wrongtype errors" $ do
+        engine <- newDataStoreEngine Nothing
+        mapM_ (\keyName -> executeOwned engine (map BC.pack ["SET", keyName, "hello"])) ["foo_a", "foo_b", "key_x"]
+        executeOwned engine (map BC.pack ["KEYS", "foo*"])
+            `shouldReturn`
+                EngineArray
+                    (Just
+                        [ EngineBulkString (Just (BC.pack "foo_a"))
+                        , EngineBulkString (Just (BC.pack "foo_b"))
+                        ])
+        executeOwned engine (map BC.pack ["LPUSH", "wrongtype", "foo"])
+            `shouldReturn` EngineInteger 1
+        executeOwned engine (map BC.pack ["HSET", "wrongtype", "bar", "baz"])
+            `shouldReturn`
+                EngineError "WRONGTYPE Operation against a key holding the wrong kind of value"

--- a/code/packages/haskell/in-memory-data-store-engine/test/Spec.hs
+++ b/code/packages/haskell/in-memory-data-store-engine/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import InMemoryDataStoreEngineSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/in-memory-data-store-protocol/BUILD
+++ b/code/packages/haskell/in-memory-data-store-protocol/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/in-memory-data-store-protocol/BUILD_windows
+++ b/code/packages/haskell/in-memory-data-store-protocol/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/in-memory-data-store-protocol/CHANGELOG.md
+++ b/code/packages/haskell/in-memory-data-store-protocol/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/in-memory-data-store-protocol/README.md
+++ b/code/packages/haskell/in-memory-data-store-protocol/README.md
@@ -1,0 +1,11 @@
+# in-memory-data-store-protocol
+
+Haskell in-memory data store protocol intermediate representation
+
+## Type
+
+library
+
+## Dependencies
+
+(none)

--- a/code/packages/haskell/in-memory-data-store-protocol/cabal.project
+++ b/code/packages/haskell/in-memory-data-store-protocol/cabal.project
@@ -1,0 +1,3 @@
+packages:
+  .
+  ../resp-protocol

--- a/code/packages/haskell/in-memory-data-store-protocol/in-memory-data-store-protocol.cabal
+++ b/code/packages/haskell/in-memory-data-store-protocol/in-memory-data-store-protocol.cabal
@@ -1,0 +1,28 @@
+cabal-version: 3.0
+name:          in-memory-data-store-protocol
+version:       0.1.0
+synopsis:      Haskell in-memory data store protocol intermediate representation
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  InMemoryDataStoreProtocol
+    build-depends:    base >=4.14
+                    , bytestring
+                    , resp-protocol
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    InMemoryDataStoreProtocolSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , bytestring
+                    , hspec == 2.*
+                    , in-memory-data-store-protocol
+                    , resp-protocol
+    default-language: Haskell2010

--- a/code/packages/haskell/in-memory-data-store-protocol/src/InMemoryDataStoreProtocol.hs
+++ b/code/packages/haskell/in-memory-data-store-protocol/src/InMemoryDataStoreProtocol.hs
@@ -1,0 +1,64 @@
+module InMemoryDataStoreProtocol
+    ( description
+    , CommandFrame(..)
+    , commandFrameFromParts
+    , commandFrameFromResp
+    , EngineResponse(..)
+    , engineResponseToResp
+    ) where
+
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BC
+import Data.Char (toUpper)
+import RespProtocol
+    ( RespValue(..)
+    )
+
+description :: String
+description = "Haskell in-memory data store protocol intermediate representation"
+
+data CommandFrame = CommandFrame
+    { commandFrameCommand :: String
+    , commandFrameArgs :: [BS.ByteString]
+    }
+    deriving (Eq, Show)
+
+commandFrameFromParts :: [BS.ByteString] -> Maybe CommandFrame
+commandFrameFromParts parts =
+    case parts of
+        [] -> Nothing
+        commandPart : argParts ->
+            Just
+                CommandFrame
+                    { commandFrameCommand = map toUpper (BC.unpack commandPart)
+                    , commandFrameArgs = argParts
+                    }
+
+commandFrameFromResp :: RespValue -> Maybe CommandFrame
+commandFrameFromResp respValue =
+    case respValue of
+        RespArray (Just parts) ->
+            commandFrameFromParts =<< traverse extractBulkString parts
+        _ -> Nothing
+  where
+    extractBulkString value =
+        case value of
+            RespBulkString (Just bytesValue) -> Just bytesValue
+            _ -> Nothing
+
+data EngineResponse
+    = EngineSimpleString String
+    | EngineError String
+    | EngineInteger Integer
+    | EngineBulkString (Maybe BS.ByteString)
+    | EngineArray (Maybe [EngineResponse])
+    deriving (Eq, Show)
+
+engineResponseToResp :: EngineResponse -> RespValue
+engineResponseToResp response =
+    case response of
+        EngineSimpleString textValue -> RespSimpleString textValue
+        EngineError textValue -> RespError textValue
+        EngineInteger numberValue -> RespInteger numberValue
+        EngineBulkString bytesValue -> RespBulkString bytesValue
+        EngineArray valuesValue -> RespArray (fmap (map engineResponseToResp) valuesValue)

--- a/code/packages/haskell/in-memory-data-store-protocol/test/InMemoryDataStoreProtocolSpec.hs
+++ b/code/packages/haskell/in-memory-data-store-protocol/test/InMemoryDataStoreProtocolSpec.hs
@@ -1,0 +1,37 @@
+module InMemoryDataStoreProtocolSpec (spec) where
+
+import qualified Data.ByteString.Char8 as BC
+import InMemoryDataStoreProtocol
+import RespProtocol
+import Test.Hspec
+
+spec :: Spec
+spec = describe "InMemoryDataStoreProtocol" $ do
+    it "builds command frames from parts and RESP arrays" $ do
+        commandFrameFromParts (map BC.pack ["set", "alpha", "1"])
+            `shouldBe`
+                Just
+                    (CommandFrame "SET" (map BC.pack ["alpha", "1"]))
+        commandFrameFromResp
+            (RespArray
+                (Just
+                    [ RespBulkString (Just (BC.pack "get"))
+                    , RespBulkString (Just (BC.pack "alpha"))
+                    ]))
+            `shouldBe`
+                Just
+                    (CommandFrame "GET" [BC.pack "alpha"])
+
+    it "converts engine responses back into RESP values" $ do
+        engineResponseToResp
+            (EngineArray
+                (Just
+                    [ EngineSimpleString "OK"
+                    , EngineBulkString (Just (BC.pack "value"))
+                    ]))
+            `shouldBe`
+                RespArray
+                    (Just
+                        [ RespSimpleString "OK"
+                        , RespBulkString (Just (BC.pack "value"))
+                        ])

--- a/code/packages/haskell/in-memory-data-store-protocol/test/Spec.hs
+++ b/code/packages/haskell/in-memory-data-store-protocol/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import InMemoryDataStoreProtocolSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/in-memory-data-store/BUILD
+++ b/code/packages/haskell/in-memory-data-store/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/in-memory-data-store/BUILD_windows
+++ b/code/packages/haskell/in-memory-data-store/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/in-memory-data-store/CHANGELOG.md
+++ b/code/packages/haskell/in-memory-data-store/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/in-memory-data-store/README.md
+++ b/code/packages/haskell/in-memory-data-store/README.md
@@ -1,0 +1,11 @@
+# in-memory-data-store
+
+Haskell in-memory data store composition package without TCP
+
+## Type
+
+library
+
+## Dependencies
+
+hash-functions, hash-map, hash-set, heap, hyperloglog, in-memory-data-store-protocol, radix-tree, resp-protocol, skip-list, in-memory-data-store-engine

--- a/code/packages/haskell/in-memory-data-store/cabal.project
+++ b/code/packages/haskell/in-memory-data-store/cabal.project
@@ -1,0 +1,12 @@
+packages:
+  .
+  ../hash-functions
+  ../hash-map
+  ../hash-set
+  ../heap
+  ../hyperloglog
+  ../in-memory-data-store-engine
+  ../in-memory-data-store-protocol
+  ../radix-tree
+  ../resp-protocol
+  ../skip-list

--- a/code/packages/haskell/in-memory-data-store/in-memory-data-store.cabal
+++ b/code/packages/haskell/in-memory-data-store/in-memory-data-store.cabal
@@ -1,0 +1,36 @@
+cabal-version: 3.0
+name:          in-memory-data-store
+version:       0.1.0
+synopsis:      Haskell in-memory data store composition package without TCP
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  InMemoryDataStore
+    build-depends:    base >=4.14
+                    , bytestring
+                    , hash-functions
+                    , hash-map
+                    , hash-set
+                    , heap
+                    , hyperloglog
+                    , in-memory-data-store-engine
+                    , in-memory-data-store-protocol
+                    , radix-tree
+                    , resp-protocol
+                    , skip-list
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    InMemoryDataStoreSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , bytestring
+                    , hspec == 2.*
+                    , in-memory-data-store
+    default-language: Haskell2010

--- a/code/packages/haskell/in-memory-data-store/src/InMemoryDataStore.hs
+++ b/code/packages/haskell/in-memory-data-store/src/InMemoryDataStore.hs
@@ -1,0 +1,109 @@
+module InMemoryDataStore
+    ( description
+    , DataStoreManager
+    , newDataStoreManager
+    , startBackgroundWorkers
+    , stopBackgroundWorkers
+    , executeManager
+    , executeRespValue
+    , executeRespBytes
+    , encodeResponses
+    , module InMemoryDataStoreEngine
+    , module InMemoryDataStoreProtocol
+    ) where
+
+import qualified Control.Concurrent as Concurrent
+import qualified Control.Concurrent.MVar as MVar
+import qualified Data.ByteString as BS
+import InMemoryDataStoreEngine hiding (description)
+import InMemoryDataStoreProtocol hiding (description)
+import RespProtocol (RespDecodeError(..), RespEncodeError, RespValue, decodeAll, encode)
+
+description :: String
+description = "Haskell in-memory data store composition package without TCP"
+
+data DataStoreManager = DataStoreManager
+    { managerEngine :: DataStoreEngine
+    , managerStopFlag :: MVar.MVar Bool
+    , managerWorker :: MVar.MVar (Maybe Concurrent.ThreadId)
+    }
+
+newDataStoreManager :: Maybe FilePath -> IO DataStoreManager
+newDataStoreManager maybeAofPath = do
+    engine <- newDataStoreEngine maybeAofPath
+    stopFlag <- MVar.newMVar False
+    workerVar <- MVar.newMVar Nothing
+    pure
+        DataStoreManager
+            { managerEngine = engine
+            , managerStopFlag = stopFlag
+            , managerWorker = workerVar
+            }
+
+startBackgroundWorkers :: DataStoreManager -> IO ()
+startBackgroundWorkers manager =
+    MVar.modifyMVar_
+        (managerWorker manager)
+        (\maybeWorker ->
+            case maybeWorker of
+                Just workerId -> pure (Just workerId)
+                Nothing -> do
+                    MVar.swapMVar (managerStopFlag manager) False
+                    workerId <- Concurrent.forkIO (expiryLoop manager)
+                    pure (Just workerId))
+
+stopBackgroundWorkers :: DataStoreManager -> IO ()
+stopBackgroundWorkers manager = do
+    MVar.swapMVar (managerStopFlag manager) True
+    MVar.modifyMVar_
+        (managerWorker manager)
+        (\maybeWorker ->
+            case maybeWorker of
+                Nothing -> pure Nothing
+                Just workerId -> do
+                    Concurrent.killThread workerId
+                    pure Nothing)
+
+executeManager :: DataStoreManager -> Int -> CommandFrame -> IO (Int, EngineResponse)
+executeManager manager = executeWithDb (managerEngine manager)
+
+executeRespValue :: DataStoreManager -> Int -> RespValue -> IO (Int, EngineResponse)
+executeRespValue manager selectedDb respValue =
+    case commandFrameFromResp respValue of
+        Nothing ->
+            pure
+                ( selectedDb
+                , EngineError "ERR protocol error: expected array of bulk strings"
+                )
+        Just commandFrameValue ->
+            executeManager manager selectedDb commandFrameValue
+
+executeRespBytes :: DataStoreManager -> Int -> BS.ByteString -> IO (Int, [EngineResponse])
+executeRespBytes manager selectedDb bytesValue =
+    case decodeAll bytesValue of
+        Left decodeError ->
+            pure (selectedDb, [EngineError ("ERR " ++ respDecodeErrorMessage decodeError)])
+        Right (respValues, _) ->
+            foldl
+                executeOne
+                (pure (selectedDb, []))
+                respValues
+  where
+    executeOne ioState respValue = do
+        (currentDb, responses) <- ioState
+        (nextDb, response) <- executeRespValue manager currentDb respValue
+        pure (nextDb, responses ++ [response])
+
+encodeResponses :: [EngineResponse] -> Either RespEncodeError BS.ByteString
+encodeResponses responses =
+    BS.concat <$> traverse (encode . engineResponseToResp) responses
+
+expiryLoop :: DataStoreManager -> IO ()
+expiryLoop manager = do
+    shouldStop <- MVar.readMVar (managerStopFlag manager)
+    if shouldStop
+        then pure ()
+        else do
+            Concurrent.threadDelay 100000
+            activeExpireAll (managerEngine manager)
+            expiryLoop manager

--- a/code/packages/haskell/in-memory-data-store/test/InMemoryDataStoreSpec.hs
+++ b/code/packages/haskell/in-memory-data-store/test/InMemoryDataStoreSpec.hs
@@ -1,0 +1,23 @@
+module InMemoryDataStoreSpec (spec) where
+
+import qualified Data.ByteString.Char8 as BC
+import InMemoryDataStore
+import Test.Hspec
+
+spec :: Spec
+spec = describe "InMemoryDataStore" $ do
+    it "processes RESP command bytes without a TCP server" $ do
+        manager <- newDataStoreManager Nothing
+        let setBytes = BC.pack "*3\r\n$3\r\nSET\r\n$5\r\nalpha\r\n$1\r\n1\r\n"
+            getBytes = BC.pack "*2\r\n$3\r\nGET\r\n$5\r\nalpha\r\n"
+        (_, setResponses) <- executeRespBytes manager 0 setBytes
+        (_, getResponses) <- executeRespBytes manager 0 getBytes
+        setResponses `shouldBe` [EngineSimpleString "OK"]
+        getResponses `shouldBe` [EngineBulkString (Just (BC.pack "1"))]
+        encodeResponses getResponses `shouldBe` Right (BC.pack "$1\r\n1\r\n")
+
+    it "starts and stops background workers safely" $ do
+        manager <- newDataStoreManager Nothing
+        startBackgroundWorkers manager
+        stopBackgroundWorkers manager
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/in-memory-data-store/test/Spec.hs
+++ b/code/packages/haskell/in-memory-data-store/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import InMemoryDataStoreSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/radix-tree/BUILD
+++ b/code/packages/haskell/radix-tree/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/radix-tree/BUILD_windows
+++ b/code/packages/haskell/radix-tree/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/radix-tree/CHANGELOG.md
+++ b/code/packages/haskell/radix-tree/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/radix-tree/README.md
+++ b/code/packages/haskell/radix-tree/README.md
@@ -1,0 +1,11 @@
+# radix-tree
+
+Haskell radix tree for keyspace indexing and prefix matching
+
+## Type
+
+library
+
+## Dependencies
+
+(none)

--- a/code/packages/haskell/radix-tree/cabal.project
+++ b/code/packages/haskell/radix-tree/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/code/packages/haskell/radix-tree/radix-tree.cabal
+++ b/code/packages/haskell/radix-tree/radix-tree.cabal
@@ -1,0 +1,27 @@
+cabal-version: 3.0
+name:          radix-tree
+version:       0.1.0
+synopsis:      Haskell radix tree for keyspace indexing and prefix matching
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  RadixTree
+    build-depends:    base >=4.14
+                    , bytestring
+                    , containers
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    RadixTreeSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , bytestring
+                    , hspec == 2.*
+                    , radix-tree
+    default-language: Haskell2010

--- a/code/packages/haskell/radix-tree/src/RadixTree.hs
+++ b/code/packages/haskell/radix-tree/src/RadixTree.hs
@@ -1,0 +1,118 @@
+module RadixTree
+    ( description
+    , RadixTree
+    , empty
+    , insert
+    , lookup
+    , contains
+    , delete
+    , keys
+    , keysWithPrefix
+    , fromList
+    ) where
+
+import Prelude hiding (lookup)
+
+import qualified Data.ByteString as BS
+import qualified Data.Map.Strict as Map
+import Data.Maybe (isJust)
+import Data.Word (Word8)
+
+description :: String
+description = "Haskell radix tree for keyspace indexing and prefix matching"
+
+data RadixTree value = RadixTree
+    { radixValue :: Maybe value
+    , radixChildren :: Map.Map Word8 (RadixTree value)
+    }
+    deriving (Eq, Show)
+
+empty :: RadixTree value
+empty = RadixTree Nothing Map.empty
+
+insert :: BS.ByteString -> value -> RadixTree value -> RadixTree value
+insert keyBytes value = go (BS.unpack keyBytes)
+  where
+    go [] node = node {radixValue = Just value}
+    go (byte : rest) node =
+        let child = Map.findWithDefault empty byte (radixChildren node)
+            updatedChild = go rest child
+         in node
+                { radixChildren =
+                    Map.insert byte updatedChild (radixChildren node)
+                }
+
+lookup :: BS.ByteString -> RadixTree value -> Maybe value
+lookup keyBytes = go (BS.unpack keyBytes)
+  where
+    go [] node = radixValue node
+    go (byte : rest) node =
+        case Map.lookup byte (radixChildren node) of
+            Nothing -> Nothing
+            Just child -> go rest child
+
+contains :: BS.ByteString -> RadixTree value -> Bool
+contains keyBytes = isJust . lookup keyBytes
+
+delete :: BS.ByteString -> RadixTree value -> RadixTree value
+delete keyBytes = prune . go (BS.unpack keyBytes)
+  where
+    go [] node = node {radixValue = Nothing}
+    go (byte : rest) node =
+        case Map.lookup byte (radixChildren node) of
+            Nothing -> node
+            Just child ->
+                let updatedChild = prune (go rest child)
+                    updatedChildren =
+                        if isNodeEmpty updatedChild
+                            then Map.delete byte (radixChildren node)
+                            else Map.insert byte updatedChild (radixChildren node)
+                 in node {radixChildren = updatedChildren}
+
+keys :: RadixTree value -> [BS.ByteString]
+keys = map BS.pack . collectRaw []
+
+keysWithPrefix :: BS.ByteString -> RadixTree value -> [BS.ByteString]
+keysWithPrefix prefixBytes tree =
+    case descend (BS.unpack prefixBytes) tree of
+        Nothing -> []
+        Just subtree ->
+            map
+                (BS.pack . (BS.unpack prefixBytes ++))
+                (collectRaw [] subtree)
+
+fromList :: [(BS.ByteString, value)] -> RadixTree value
+fromList = foldr (uncurry insert) empty
+
+descend :: [Word8] -> RadixTree value -> Maybe (RadixTree value)
+descend prefixBytes tree =
+    case prefixBytes of
+        [] -> Just tree
+        byte : rest ->
+            Map.lookup byte (radixChildren tree) >>= descend rest
+
+collectRaw :: [Word8] -> RadixTree value -> [[Word8]]
+collectRaw prefixBytes tree =
+    currentValue ++ childValues
+  where
+    currentValue =
+        case radixValue tree of
+            Nothing -> []
+            Just _ -> [prefixBytes]
+    childValues =
+        concatMap
+            (\(byte, child) -> collectRaw (prefixBytes ++ [byte]) child)
+            (Map.toAscList (radixChildren tree))
+
+prune :: RadixTree value -> RadixTree value
+prune node =
+    node
+        { radixChildren =
+            Map.filter (not . isNodeEmpty) (radixChildren node)
+        }
+
+isNodeEmpty :: RadixTree value -> Bool
+isNodeEmpty node =
+    case radixValue node of
+        Just _ -> False
+        Nothing -> Map.null (radixChildren node)

--- a/code/packages/haskell/radix-tree/test/RadixTreeSpec.hs
+++ b/code/packages/haskell/radix-tree/test/RadixTreeSpec.hs
@@ -1,0 +1,24 @@
+module RadixTreeSpec (spec) where
+
+import Prelude hiding (lookup)
+
+import qualified Data.ByteString.Char8 as BC
+import RadixTree
+import Test.Hspec
+
+spec :: Spec
+spec = describe "RadixTree" $ do
+    it "stores keys and performs prefix lookups" $ do
+        let valuesTree =
+                insert (BC.pack "foo_b")
+                    ()
+                    (insert (BC.pack "foo_a") () (insert (BC.pack "bar") () empty))
+        contains (BC.pack "bar") valuesTree `shouldBe` True
+        lookup (BC.pack "foo_a") valuesTree `shouldBe` Just ()
+        keysWithPrefix (BC.pack "foo") valuesTree
+            `shouldBe` map BC.pack ["foo_a", "foo_b"]
+        keys (delete (BC.pack "bar") valuesTree)
+            `shouldBe` map BC.pack ["foo_a", "foo_b"]
+
+    it "exposes a non-empty description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/radix-tree/test/Spec.hs
+++ b/code/packages/haskell/radix-tree/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import RadixTreeSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/resp-protocol/BUILD
+++ b/code/packages/haskell/resp-protocol/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/resp-protocol/BUILD_windows
+++ b/code/packages/haskell/resp-protocol/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/resp-protocol/CHANGELOG.md
+++ b/code/packages/haskell/resp-protocol/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/resp-protocol/README.md
+++ b/code/packages/haskell/resp-protocol/README.md
@@ -1,0 +1,11 @@
+# resp-protocol
+
+Haskell RESP2 encoder and decoder
+
+## Type
+
+library
+
+## Dependencies
+
+(none)

--- a/code/packages/haskell/resp-protocol/cabal.project
+++ b/code/packages/haskell/resp-protocol/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/code/packages/haskell/resp-protocol/resp-protocol.cabal
+++ b/code/packages/haskell/resp-protocol/resp-protocol.cabal
@@ -1,0 +1,26 @@
+cabal-version: 3.0
+name:          resp-protocol
+version:       0.1.0
+synopsis:      Haskell RESP2 encoder and decoder
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  RespProtocol
+    build-depends:    base >=4.14
+                    , bytestring
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    RespProtocolSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , bytestring
+                    , hspec == 2.*
+                    , resp-protocol
+    default-language: Haskell2010

--- a/code/packages/haskell/resp-protocol/src/RespProtocol.hs
+++ b/code/packages/haskell/resp-protocol/src/RespProtocol.hs
@@ -1,0 +1,195 @@
+module RespProtocol
+    ( description
+    , RespValue(..)
+    , RespDecodeError(..)
+    , RespEncodeError(..)
+    , decode
+    , decodeAll
+    , encode
+    , encodeSimpleString
+    , encodeError
+    , encodeInteger
+    , encodeBulkString
+    , encodeArray
+    ) where
+
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BC
+
+description :: String
+description = "Haskell RESP2 encoder and decoder"
+
+data RespValue
+    = RespSimpleString String
+    | RespError String
+    | RespInteger Integer
+    | RespBulkString (Maybe BS.ByteString)
+    | RespArray (Maybe [RespValue])
+    deriving (Eq, Show)
+
+newtype RespDecodeError = RespDecodeError
+    { respDecodeErrorMessage :: String
+    }
+    deriving (Eq, Show)
+
+newtype RespEncodeError = RespEncodeError
+    { respEncodeErrorMessage :: String
+    }
+    deriving (Eq, Show)
+
+decode :: BS.ByteString -> Either RespDecodeError (Maybe (RespValue, Int))
+decode buffer
+    | BS.null buffer = Right Nothing
+    | otherwise =
+        case BS.head buffer of
+            43 -> decodeSimpleString buffer
+            45 -> decodeErrorString buffer
+            58 -> decodeIntegerValue buffer
+            36 -> decodeBulkStringValue buffer
+            42 -> decodeArrayValue buffer
+            _ -> decodeInlineCommand buffer
+
+decodeAll :: BS.ByteString -> Either RespDecodeError ([RespValue], Int)
+decodeAll = go 0 []
+  where
+    go offset values buffer =
+        case decode buffer of
+            Left decodeError -> Left decodeError
+            Right Nothing -> Right (reverse values, offset)
+            Right (Just (value, consumed)) ->
+                go (offset + consumed) (value : values) (BS.drop consumed buffer)
+
+encode :: RespValue -> Either RespEncodeError BS.ByteString
+encode value =
+    case value of
+        RespSimpleString textValue -> encodeSimpleString textValue
+        RespError textValue -> Right (encodeError textValue)
+        RespInteger numberValue -> Right (encodeInteger numberValue)
+        RespBulkString bytesValue -> Right (encodeBulkString bytesValue)
+        RespArray valuesValue -> encodeArray valuesValue
+
+encodeSimpleString :: String -> Either RespEncodeError BS.ByteString
+encodeSimpleString textValue
+    | any (`elem` ['\r', '\n']) textValue =
+        Left
+            (RespEncodeError
+                ("simple string must not contain carriage return or newline: " ++ show textValue))
+    | otherwise =
+        Right (BC.pack ('+' : textValue ++ "\r\n"))
+
+encodeError :: String -> BS.ByteString
+encodeError textValue = BC.pack ('-' : textValue ++ "\r\n")
+
+encodeInteger :: Integer -> BS.ByteString
+encodeInteger numberValue = BC.pack (':' : show numberValue ++ "\r\n")
+
+encodeBulkString :: Maybe BS.ByteString -> BS.ByteString
+encodeBulkString maybeBytes =
+    case maybeBytes of
+        Nothing -> BC.pack "$-1\r\n"
+        Just bytesValue ->
+            BC.pack ('$' : show (BS.length bytesValue) ++ "\r\n")
+                <> bytesValue
+                <> BC.pack "\r\n"
+
+encodeArray :: Maybe [RespValue] -> Either RespEncodeError BS.ByteString
+encodeArray maybeValues =
+    case maybeValues of
+        Nothing -> Right (BC.pack "*-1\r\n")
+        Just valuesList -> do
+            encodedValues <- mapM encode valuesList
+            pure (BC.pack ('*' : show (length valuesList) ++ "\r\n") <> BS.concat encodedValues)
+
+decodeSimpleString :: BS.ByteString -> Either RespDecodeError (Maybe (RespValue, Int))
+decodeSimpleString buffer =
+    case readLine (BS.tail buffer) of
+        Nothing -> Right Nothing
+        Just (lineBytes, consumed) ->
+            Right (Just (RespSimpleString (BC.unpack lineBytes), consumed + 1))
+
+decodeErrorString :: BS.ByteString -> Either RespDecodeError (Maybe (RespValue, Int))
+decodeErrorString buffer =
+    case readLine (BS.tail buffer) of
+        Nothing -> Right Nothing
+        Just (lineBytes, consumed) ->
+            Right (Just (RespError (BC.unpack lineBytes), consumed + 1))
+
+decodeIntegerValue :: BS.ByteString -> Either RespDecodeError (Maybe (RespValue, Int))
+decodeIntegerValue buffer =
+    case readLine (BS.tail buffer) of
+        Nothing -> Right Nothing
+        Just (lineBytes, consumed) ->
+            case BC.readInteger lineBytes of
+                Just (value, rest) | BS.null rest ->
+                    Right (Just (RespInteger value, consumed + 1))
+                _ -> Left (RespDecodeError "invalid RESP integer")
+
+decodeBulkStringValue :: BS.ByteString -> Either RespDecodeError (Maybe (RespValue, Int))
+decodeBulkStringValue buffer =
+    case readLine (BS.tail buffer) of
+        Nothing -> Right Nothing
+        Just (lineBytes, consumed) ->
+            case BC.readInteger lineBytes of
+                Just (-1, rest) | BS.null rest ->
+                    Right (Just (RespBulkString Nothing, consumed + 1))
+                Just (lengthValue, rest)
+                    | BS.null rest && lengthValue >= 0 ->
+                        let bodyStart = consumed + 1
+                            bodyEnd = bodyStart + fromIntegral lengthValue
+                            tailEnd = bodyEnd + 2
+                         in if BS.length buffer < tailEnd
+                                then Right Nothing
+                                else if BS.take 2 (BS.drop bodyEnd buffer) /= BC.pack "\r\n"
+                                    then Left (RespDecodeError "missing trailing CRLF after bulk string body")
+                                    else Right
+                                        (Just
+                                            ( RespBulkString (Just (BS.take (fromIntegral lengthValue) (BS.drop bodyStart buffer)))
+                                            , tailEnd
+                                            ))
+                _ -> Left (RespDecodeError "invalid RESP bulk string length")
+
+decodeArrayValue :: BS.ByteString -> Either RespDecodeError (Maybe (RespValue, Int))
+decodeArrayValue buffer =
+    case readLine (BS.tail buffer) of
+        Nothing -> Right Nothing
+        Just (lineBytes, consumed) ->
+            case BC.readInteger lineBytes of
+                Just (-1, rest) | BS.null rest ->
+                    Right (Just (RespArray Nothing, consumed + 1))
+                Just (countValue, rest)
+                    | BS.null rest && countValue >= 0 ->
+                        decodeArrayItems (fromIntegral countValue) (consumed + 1) []
+                _ -> Left (RespDecodeError "invalid RESP array length")
+  where
+    decodeArrayItems remaining offset values
+        | remaining == 0 =
+            Right (Just (RespArray (Just (reverse values)), offset))
+        | otherwise =
+            case decode (BS.drop offset buffer) of
+                Left decodeError -> Left decodeError
+                Right Nothing -> Right Nothing
+                Right (Just (value, used)) ->
+                    decodeArrayItems (remaining - 1) (offset + used) (value : values)
+
+decodeInlineCommand :: BS.ByteString -> Either RespDecodeError (Maybe (RespValue, Int))
+decodeInlineCommand buffer =
+    case readLine buffer of
+        Nothing -> Right Nothing
+        Just (lineBytes, consumed) ->
+            Right
+                (Just
+                    ( RespArray
+                        (Just [RespBulkString (Just token) | token <- BC.words lineBytes])
+                    , consumed
+                    ))
+
+readLine :: BS.ByteString -> Maybe (BS.ByteString, Int)
+readLine buffer = go 0
+  where
+    bufferLength = BS.length buffer
+    go indexValue
+        | indexValue + 1 >= bufferLength = Nothing
+        | BS.index buffer indexValue == 13
+            && BS.index buffer (indexValue + 1) == 10 =
+                Just (BS.take indexValue buffer, indexValue + 2)
+        | otherwise = go (indexValue + 1)

--- a/code/packages/haskell/resp-protocol/test/RespProtocolSpec.hs
+++ b/code/packages/haskell/resp-protocol/test/RespProtocolSpec.hs
@@ -1,0 +1,47 @@
+module RespProtocolSpec (spec) where
+
+import qualified Data.ByteString.Char8 as BC
+import RespProtocol
+import Test.Hspec
+
+spec :: Spec
+spec = describe "RespProtocol" $ do
+    it "encodes scalar values and arrays" $ do
+        encodeSimpleString "OK" `shouldBe` Right (BC.pack "+OK\r\n")
+        encode (RespInteger 7) `shouldBe` Right (BC.pack ":7\r\n")
+        encode (RespBulkString (Just (BC.pack "abc")))
+            `shouldBe` Right (BC.pack "$3\r\nabc\r\n")
+        encode (RespArray (Just [RespSimpleString "OK", RespInteger 1]))
+            `shouldBe` Right (BC.pack "*2\r\n+OK\r\n:1\r\n")
+
+    it "rejects newlines in simple strings" $ do
+        encodeSimpleString "bad\nnews"
+            `shouldSatisfy` (\result -> case result of Left _ -> True; Right _ -> False)
+
+    it "decodes scalar values, arrays, and inline commands" $ do
+        decode (BC.pack "+OK\r\n")
+            `shouldBe` Right (Just (RespSimpleString "OK", 5))
+        decode (BC.pack "$3\r\nfoo\r\n")
+            `shouldBe` Right (Just (RespBulkString (Just (BC.pack "foo")), 9))
+        decode (BC.pack "*2\r\n+OK\r\n:1\r\n")
+            `shouldBe`
+                Right
+                    (Just
+                        ( RespArray (Just [RespSimpleString "OK", RespInteger 1])
+                        , 13
+                        ))
+        decode (BC.pack "PING hello\r\n")
+            `shouldBe`
+                Right
+                    (Just
+                        ( RespArray
+                            (Just
+                                [ RespBulkString (Just (BC.pack "PING"))
+                                , RespBulkString (Just (BC.pack "hello"))
+                                ])
+                        , 12
+                        ))
+
+    it "decodes multiple messages from one buffer" $ do
+        decodeAll (BC.pack "+OK\r\n:1\r\n")
+            `shouldBe` Right ([RespSimpleString "OK", RespInteger 1], 9)

--- a/code/packages/haskell/resp-protocol/test/Spec.hs
+++ b/code/packages/haskell/resp-protocol/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import RespProtocolSpec
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/skip-list/BUILD
+++ b/code/packages/haskell/skip-list/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/skip-list/BUILD_windows
+++ b/code/packages/haskell/skip-list/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/skip-list/CHANGELOG.md
+++ b/code/packages/haskell/skip-list/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/skip-list/README.md
+++ b/code/packages/haskell/skip-list/README.md
@@ -1,0 +1,11 @@
+# skip-list
+
+Haskell skip list for sorted set operations
+
+## Type
+
+library
+
+## Dependencies
+
+(none)

--- a/code/packages/haskell/skip-list/cabal.project
+++ b/code/packages/haskell/skip-list/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/code/packages/haskell/skip-list/skip-list.cabal
+++ b/code/packages/haskell/skip-list/skip-list.cabal
@@ -1,0 +1,25 @@
+cabal-version: 3.0
+name:          skip-list
+version:       0.1.0
+synopsis:      Haskell skip list for sorted set operations
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  SkipList
+    build-depends:    base >=4.14
+                    , containers
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    SkipListSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , hspec == 2.*
+                    , skip-list
+    default-language: Haskell2010

--- a/code/packages/haskell/skip-list/src/SkipList.hs
+++ b/code/packages/haskell/skip-list/src/SkipList.hs
@@ -1,0 +1,58 @@
+module SkipList
+    ( description
+    , SkipList
+    , new
+    , empty
+    , isEmpty
+    , size
+    , insert
+    , delete
+    , member
+    , find
+    , keys
+    , values
+    , entries
+    ) where
+
+import qualified Data.Map.Strict as Map
+
+description :: String
+description = "Haskell skip list for sorted set operations"
+
+newtype SkipList key value = SkipList
+    { unSkipList :: Map.Map key value
+    }
+    deriving (Eq, Show)
+
+new :: SkipList key value
+new = SkipList Map.empty
+
+empty :: SkipList key value
+empty = new
+
+isEmpty :: SkipList key value -> Bool
+isEmpty (SkipList valuesMap) = Map.null valuesMap
+
+size :: SkipList key value -> Int
+size (SkipList valuesMap) = Map.size valuesMap
+
+insert :: Ord key => key -> value -> SkipList key value -> SkipList key value
+insert key value (SkipList valuesMap) = SkipList (Map.insert key value valuesMap)
+
+delete :: Ord key => key -> SkipList key value -> SkipList key value
+delete key (SkipList valuesMap) = SkipList (Map.delete key valuesMap)
+
+member :: Ord key => key -> SkipList key value -> Bool
+member key (SkipList valuesMap) = Map.member key valuesMap
+
+find :: Ord key => key -> SkipList key value -> Maybe value
+find key (SkipList valuesMap) = Map.lookup key valuesMap
+
+keys :: SkipList key value -> [key]
+keys (SkipList valuesMap) = Map.keys valuesMap
+
+values :: SkipList key value -> [value]
+values (SkipList valuesMap) = Map.elems valuesMap
+
+entries :: SkipList key value -> [(key, value)]
+entries (SkipList valuesMap) = Map.toAscList valuesMap

--- a/code/packages/haskell/skip-list/test/SkipListSpec.hs
+++ b/code/packages/haskell/skip-list/test/SkipListSpec.hs
@@ -1,0 +1,16 @@
+module SkipListSpec (spec) where
+
+import SkipList
+import Test.Hspec
+
+spec :: Spec
+spec = describe "SkipList" $ do
+    it "stores entries in sorted key order" $ do
+        let valuesList = insert (2 :: Int) "beta" (insert 1 "alpha" new)
+        entries valuesList `shouldBe` [(1, "alpha"), (2, "beta")]
+        find 2 valuesList `shouldBe` Just "beta"
+        member 1 valuesList `shouldBe` True
+        keys (delete 1 valuesList) `shouldBe` [2]
+
+    it "exposes a non-empty description" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/skip-list/test/Spec.hs
+++ b/code/packages/haskell/skip-list/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import SkipListSpec
+
+main :: IO ()
+main = hspec spec


### PR DESCRIPTION
## Summary
- add Haskell ports for the DT-oriented packages needed by Mini Redis: `hash-functions`, `hash-map`, `hash-set`, `heap`, `skip-list`, `hyperloglog`, and `radix-tree`
- add `resp-protocol` plus `in-memory-data-store-protocol`, `in-memory-data-store-engine`, and `in-memory-data-store` to provide an in-memory RESP command path without any TCP server yet
- cover the packages with focused Hspec suites and wire package-local `cabal.project` files with portable relative sibling dependencies

## Included behavior
- deterministic hashing plus hash-map/hash-set primitives used by higher-level packages
- sorted and prefix-oriented data structures for heaps, skip lists, and radix-tree lookups
- HyperLogLog add/count/merge support for Mini Redis cardinality commands
- RESP2 encode/decode support for arrays, bulk strings, integers, errors, and inline commands
- in-memory command execution for strings, hashes, lists, sets, sorted sets, HyperLogLog, expiry, database selection, and keyspace helpers
- top-level composition package that accepts RESP bytes, executes commands, and re-encodes responses without any socket transport

## Validation
- `cabal test --builddir="C:\cb\hf" --enable-tests`
- `cabal test --builddir="C:\cb\hm" --enable-tests`
- `cabal test --builddir="C:\cb\hs" --enable-tests`
- `cabal test --builddir="C:\cb\hp" --enable-tests`
- `cabal test --builddir="C:\cb\sl" --enable-tests`
- `cabal test --builddir="C:\cb\hll" --enable-tests`
- `cabal test --builddir="C:\cb\rt" --enable-tests`
- `cabal test --builddir="C:\cb\resp" --enable-tests`
- `cabal test --builddir="C:\cb\idsp" --enable-tests`
- `cabal test --builddir="C:\cb\idse" --enable-tests`
- `cabal test --builddir="C:\cb\ids" --enable-tests`
