### PR TITLE
[codex] Add JVM Mini-Redis core foundations

### DIFF
--- a/code/packages/java/hash-map/.gitignore
+++ b/code/packages/java/hash-map/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/java/hash-map/BUILD
+++ b/code/packages/java/hash-map/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/hash-map/BUILD_windows
+++ b/code/packages/java/hash-map/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/hash-map/CHANGELOG.md
+++ b/code/packages/java/hash-map/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-16
+
+### Added
+
+- Initial JVM mini-redis core package

--- a/code/packages/java/hash-map/README.md
+++ b/code/packages/java/hash-map/README.md
@@ -1,0 +1,9 @@
+# hash-map
+
+Native Java hash map for JVM mini-redis and other DT ports
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/java/hash-map/build.gradle.kts
+++ b/code/packages/java/hash-map/build.gradle.kts
@@ -1,0 +1,28 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/hash-map/required_capabilities.json
+++ b/code/packages/java/hash-map/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "java/hash-map",
+  "capabilities": [],
+  "justification": "Pure in-memory data structure and protocol logic. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/java/hash-map/settings.gradle.kts
+++ b/code/packages/java/hash-map/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "hash-map"

--- a/code/packages/java/hash-map/src/main/java/com/codingadventures/hashmap/HashMap.java
+++ b/code/packages/java/hash-map/src/main/java/com/codingadventures/hashmap/HashMap.java
@@ -1,0 +1,90 @@
+package com.codingadventures.hashmap;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public final class HashMap<K, V> {
+    private final LinkedHashMap<K, V> delegate;
+
+    public HashMap() {
+        this.delegate = new LinkedHashMap<>();
+    }
+
+    public HashMap(Map<K, V> values) {
+        this.delegate = new LinkedHashMap<>(values);
+    }
+
+    public int size() {
+        return delegate.size();
+    }
+
+    public boolean isEmpty() {
+        return delegate.isEmpty();
+    }
+
+    public boolean has(K key) {
+        return delegate.containsKey(key);
+    }
+
+    public V get(K key) {
+        return delegate.get(key);
+    }
+
+    public V getOrDefault(K key, V defaultValue) {
+        return delegate.getOrDefault(key, defaultValue);
+    }
+
+    public HashMap<K, V> set(K key, V value) {
+        delegate.put(key, value);
+        return this;
+    }
+
+    public boolean delete(K key) {
+        return delegate.remove(key) != null;
+    }
+
+    public void clear() {
+        delegate.clear();
+    }
+
+    public List<K> keys() {
+        return new ArrayList<>(delegate.keySet());
+    }
+
+    public List<V> values() {
+        return new ArrayList<>(delegate.values());
+    }
+
+    public List<Map.Entry<K, V>> entries() {
+        List<Map.Entry<K, V>> entries = new ArrayList<>();
+        for (Map.Entry<K, V> entry : delegate.entrySet()) {
+            entries.add(Map.entry(entry.getKey(), entry.getValue()));
+        }
+        return entries;
+    }
+
+    public HashMap<K, V> copy() {
+        return new HashMap<>(delegate);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof HashMap<?, ?> that)) {
+            return false;
+        }
+        return Objects.equals(delegate, that.delegate);
+    }
+
+    @Override
+    public int hashCode() {
+        return delegate.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
+}

--- a/code/packages/java/hash-map/src/test/java/com/codingadventures/hashmap/HashMapTest.java
+++ b/code/packages/java/hash-map/src/test/java/com/codingadventures/hashmap/HashMapTest.java
@@ -1,0 +1,29 @@
+package com.codingadventures.hashmap;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HashMapTest {
+    @Test
+    void storesAndDeletesValues() {
+        HashMap<String, Integer> map = new HashMap<>();
+        map.set("alpha", 1).set("beta", 2);
+
+        assertEquals(2, map.size());
+        assertTrue(map.has("alpha"));
+        assertEquals(2, map.get("beta"));
+        assertTrue(map.delete("alpha"));
+        assertFalse(map.has("alpha"));
+    }
+
+    @Test
+    void preservesInsertionOrder() {
+        HashMap<String, Integer> map = new HashMap<>();
+        map.set("alpha", 1).set("beta", 2).set("gamma", 3);
+
+        assertEquals(List.of("alpha", "beta", "gamma"), map.keys());
+    }
+}

--- a/code/packages/java/hash-set/.gitignore
+++ b/code/packages/java/hash-set/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/java/hash-set/BUILD
+++ b/code/packages/java/hash-set/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/hash-set/BUILD_windows
+++ b/code/packages/java/hash-set/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/hash-set/CHANGELOG.md
+++ b/code/packages/java/hash-set/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-16
+
+### Added
+
+- Initial JVM mini-redis core package

--- a/code/packages/java/hash-set/README.md
+++ b/code/packages/java/hash-set/README.md
@@ -1,0 +1,9 @@
+# hash-set
+
+Native Java hash set built on top of the JVM hash-map package
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/java/hash-set/build.gradle.kts
+++ b/code/packages/java/hash-set/build.gradle.kts
@@ -1,0 +1,29 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    api("com.codingadventures:hash-map")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/hash-set/required_capabilities.json
+++ b/code/packages/java/hash-set/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "java/hash-set",
+  "capabilities": [],
+  "justification": "Pure in-memory data structure and protocol logic. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/java/hash-set/settings.gradle.kts
+++ b/code/packages/java/hash-set/settings.gradle.kts
@@ -1,0 +1,2 @@
+rootProject.name = "hash-set"
+includeBuild("../hash-map")

--- a/code/packages/java/hash-set/src/main/java/com/codingadventures/hashset/HashSet.java
+++ b/code/packages/java/hash-set/src/main/java/com/codingadventures/hashset/HashSet.java
@@ -1,0 +1,93 @@
+package com.codingadventures.hashset;
+
+import com.codingadventures.hashmap.HashMap;
+
+import java.util.List;
+import java.util.Objects;
+
+public final class HashSet<T> {
+    private final HashMap<T, Boolean> map;
+
+    public HashSet() {
+        this.map = new HashMap<>();
+    }
+
+    private HashSet(HashMap<T, Boolean> map) {
+        this.map = map;
+    }
+
+    public int size() {
+        return map.size();
+    }
+
+    public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
+    public boolean contains(T value) {
+        return map.has(value);
+    }
+
+    public HashSet<T> add(T value) {
+        map.set(value, Boolean.TRUE);
+        return this;
+    }
+
+    public boolean remove(T value) {
+        return map.delete(value);
+    }
+
+    public List<T> items() {
+        return map.keys();
+    }
+
+    public HashSet<T> union(HashSet<T> other) {
+        HashSet<T> result = copy();
+        for (T value : other.items()) {
+            result.add(value);
+        }
+        return result;
+    }
+
+    public HashSet<T> intersection(HashSet<T> other) {
+        HashSet<T> result = new HashSet<>();
+        for (T value : items()) {
+            if (other.contains(value)) {
+                result.add(value);
+            }
+        }
+        return result;
+    }
+
+    public HashSet<T> difference(HashSet<T> other) {
+        HashSet<T> result = new HashSet<>();
+        for (T value : items()) {
+            if (!other.contains(value)) {
+                result.add(value);
+            }
+        }
+        return result;
+    }
+
+    public HashSet<T> copy() {
+        return new HashSet<>(map.copy());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof HashSet<?> that)) {
+            return false;
+        }
+        return Objects.equals(map, that.map);
+    }
+
+    @Override
+    public int hashCode() {
+        return map.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return items().toString();
+    }
+}

--- a/code/packages/java/hash-set/src/test/java/com/codingadventures/hashset/HashSetTest.java
+++ b/code/packages/java/hash-set/src/test/java/com/codingadventures/hashset/HashSetTest.java
@@ -1,0 +1,30 @@
+package com.codingadventures.hashset;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HashSetTest {
+    @Test
+    void supportsMembershipAndRemoval() {
+        HashSet<String> set = new HashSet<>();
+        set.add("alpha").add("beta");
+
+        assertTrue(set.contains("alpha"));
+        assertEquals(2, set.size());
+        assertTrue(set.remove("alpha"));
+        assertFalse(set.contains("alpha"));
+    }
+
+    @Test
+    void supportsSetAlgebra() {
+        HashSet<String> left = new HashSet<>();
+        left.add("alpha").add("beta");
+        HashSet<String> right = new HashSet<>();
+        right.add("beta").add("gamma");
+
+        assertEquals(3, left.union(right).size());
+        assertEquals(1, left.intersection(right).size());
+        assertTrue(left.difference(right).contains("alpha"));
+    }
+}

--- a/code/packages/java/heap/.gitignore
+++ b/code/packages/java/heap/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/java/heap/BUILD
+++ b/code/packages/java/heap/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/heap/BUILD_windows
+++ b/code/packages/java/heap/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/heap/CHANGELOG.md
+++ b/code/packages/java/heap/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-16
+
+### Added
+
+- Initial JVM mini-redis core package

--- a/code/packages/java/heap/README.md
+++ b/code/packages/java/heap/README.md
@@ -1,0 +1,9 @@
+# heap
+
+Native Java min-heap for TTL scheduling and priority-queue workloads
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/java/heap/build.gradle.kts
+++ b/code/packages/java/heap/build.gradle.kts
@@ -1,0 +1,28 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/heap/required_capabilities.json
+++ b/code/packages/java/heap/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "java/heap",
+  "capabilities": [],
+  "justification": "Pure in-memory data structure and protocol logic. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/java/heap/settings.gradle.kts
+++ b/code/packages/java/heap/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "heap"

--- a/code/packages/java/heap/src/main/java/com/codingadventures/heap/MinHeap.java
+++ b/code/packages/java/heap/src/main/java/com/codingadventures/heap/MinHeap.java
@@ -1,0 +1,75 @@
+package com.codingadventures.heap;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class MinHeap<T extends Comparable<? super T>> {
+    private final List<T> values = new ArrayList<>();
+
+    public int size() {
+        return values.size();
+    }
+
+    public boolean isEmpty() {
+        return values.isEmpty();
+    }
+
+    public void push(T value) {
+        values.add(value);
+        siftUp(values.size() - 1);
+    }
+
+    public T peek() {
+        return values.isEmpty() ? null : values.getFirst();
+    }
+
+    public T pop() {
+        if (values.isEmpty()) {
+            return null;
+        }
+        T result = values.getFirst();
+        T last = values.remove(values.size() - 1);
+        if (!values.isEmpty()) {
+            values.set(0, last);
+            siftDown(0);
+        }
+        return result;
+    }
+
+    private void siftUp(int index) {
+        while (index > 0) {
+            int parent = (index - 1) / 2;
+            if (values.get(parent).compareTo(values.get(index)) <= 0) {
+                return;
+            }
+            swap(parent, index);
+            index = parent;
+        }
+    }
+
+    private void siftDown(int index) {
+        int size = values.size();
+        while (true) {
+            int left = index * 2 + 1;
+            int right = left + 1;
+            int smallest = index;
+            if (left < size && values.get(left).compareTo(values.get(smallest)) < 0) {
+                smallest = left;
+            }
+            if (right < size && values.get(right).compareTo(values.get(smallest)) < 0) {
+                smallest = right;
+            }
+            if (smallest == index) {
+                return;
+            }
+            swap(index, smallest);
+            index = smallest;
+        }
+    }
+
+    private void swap(int left, int right) {
+        T temp = values.get(left);
+        values.set(left, values.get(right));
+        values.set(right, temp);
+    }
+}

--- a/code/packages/java/heap/src/test/java/com/codingadventures/heap/MinHeapTest.java
+++ b/code/packages/java/heap/src/test/java/com/codingadventures/heap/MinHeapTest.java
@@ -1,0 +1,20 @@
+package com.codingadventures.heap;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MinHeapTest {
+    @Test
+    void popsValuesInSortedOrder() {
+        MinHeap<Integer> heap = new MinHeap<>();
+        heap.push(5);
+        heap.push(1);
+        heap.push(3);
+
+        assertEquals(1, heap.pop());
+        assertEquals(3, heap.pop());
+        assertEquals(5, heap.pop());
+        assertNull(heap.pop());
+    }
+}

--- a/code/packages/java/in-memory-data-store-engine/.gitignore
+++ b/code/packages/java/in-memory-data-store-engine/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/java/in-memory-data-store-engine/BUILD
+++ b/code/packages/java/in-memory-data-store-engine/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/in-memory-data-store-engine/BUILD_windows
+++ b/code/packages/java/in-memory-data-store-engine/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/in-memory-data-store-engine/CHANGELOG.md
+++ b/code/packages/java/in-memory-data-store-engine/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-16
+
+### Added
+
+- Initial JVM mini-redis core package

--- a/code/packages/java/in-memory-data-store-engine/README.md
+++ b/code/packages/java/in-memory-data-store-engine/README.md
@@ -1,0 +1,9 @@
+# in-memory-data-store-engine
+
+Internal JVM execution engine for the in-memory data store
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/java/in-memory-data-store-engine/build.gradle.kts
+++ b/code/packages/java/in-memory-data-store-engine/build.gradle.kts
@@ -1,0 +1,32 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    api("com.codingadventures:hash-map")
+    api("com.codingadventures:hash-set")
+    api("com.codingadventures:heap")
+    api("com.codingadventures:in-memory-data-store-protocol")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/in-memory-data-store-engine/required_capabilities.json
+++ b/code/packages/java/in-memory-data-store-engine/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "java/in-memory-data-store-engine",
+  "capabilities": [],
+  "justification": "Pure in-memory data structure and protocol logic. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/java/in-memory-data-store-engine/settings.gradle.kts
+++ b/code/packages/java/in-memory-data-store-engine/settings.gradle.kts
@@ -1,0 +1,5 @@
+rootProject.name = "in-memory-data-store-engine"
+includeBuild("../hash-map")
+includeBuild("../hash-set")
+includeBuild("../heap")
+includeBuild("../in-memory-data-store-protocol")

--- a/code/packages/java/in-memory-data-store-engine/src/main/java/com/codingadventures/inmemorydatastoreengine/DataStoreEngine.java
+++ b/code/packages/java/in-memory-data-store-engine/src/main/java/com/codingadventures/inmemorydatastoreengine/DataStoreEngine.java
@@ -1,0 +1,732 @@
+package com.codingadventures.inmemorydatastoreengine;
+
+import com.codingadventures.hashmap.HashMap;
+import com.codingadventures.hashset.HashSet;
+import com.codingadventures.heap.MinHeap;
+import com.codingadventures.inmemorydatastoreprotocol.CommandFrame;
+import com.codingadventures.inmemorydatastoreprotocol.EngineResponse;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+public final class DataStoreEngine {
+    private final Store store = new Store(16);
+
+    public synchronized EngineResponse executeFrame(CommandFrame frame) {
+        if (frame == null) {
+            return EngineResponse.error("ERR protocol error: expected array of bulk strings");
+        }
+        store.activeDatabase().activeExpire();
+        return switch (frame.command()) {
+            case "PING" -> ping(frame.args());
+            case "ECHO" -> echo(frame.args());
+            case "SET" -> set(frame.args());
+            case "GET" -> get(frame.args());
+            case "DEL" -> del(frame.args());
+            case "EXISTS" -> exists(frame.args());
+            case "KEYS" -> keys(frame.args());
+            case "TYPE" -> type(frame.args());
+            case "APPEND" -> append(frame.args());
+            case "INCR" -> incrBy(frame.args(), 1);
+            case "DECR" -> incrBy(frame.args(), -1);
+            case "INCRBY" -> incrBy(frame.args(), null);
+            case "DECRBY" -> decrBy(frame.args());
+            case "HSET" -> hset(frame.args());
+            case "HGET" -> hget(frame.args());
+            case "HDEL" -> hdel(frame.args());
+            case "HGETALL" -> hgetall(frame.args());
+            case "HLEN" -> hlen(frame.args());
+            case "HEXISTS" -> hexists(frame.args());
+            case "HKEYS" -> hkeys(frame.args());
+            case "HVALS" -> hvals(frame.args());
+            case "LPUSH" -> lpush(frame.args(), true);
+            case "RPUSH" -> lpush(frame.args(), false);
+            case "LPOP" -> lpop(frame.args(), true);
+            case "RPOP" -> lpop(frame.args(), false);
+            case "LLEN" -> llen(frame.args());
+            case "LINDEX" -> lindex(frame.args());
+            case "LRANGE" -> lrange(frame.args());
+            case "SADD" -> sadd(frame.args());
+            case "SREM" -> srem(frame.args());
+            case "SISMEMBER" -> sismember(frame.args());
+            case "SMEMBERS" -> smembers(frame.args());
+            case "SCARD" -> scard(frame.args());
+            case "EXPIRE" -> expire(frame.args(), false);
+            case "EXPIREAT" -> expire(frame.args(), true);
+            case "PTTL" -> pttl(frame.args());
+            case "PERSIST" -> persist(frame.args());
+            case "SELECT" -> select(frame.args());
+            case "FLUSHDB" -> flushdb(frame.args());
+            case "FLUSHALL" -> flushall(frame.args());
+            case "DBSIZE" -> dbsize(frame.args());
+            case "INFO" -> info(frame.args());
+            default -> EngineResponse.error("ERR unknown command '" + frame.command().toLowerCase(Locale.ROOT) + "'");
+        };
+    }
+
+    public static long currentTimeMs() {
+        return Instant.now().toEpochMilli();
+    }
+
+    private EngineResponse ping(List<byte[]> args) {
+        if (args.isEmpty()) {
+            return EngineResponse.simpleString("PONG");
+        }
+        if (args.size() == 1) {
+            return EngineResponse.bulkString(args.getFirst());
+        }
+        return wrongArity("ping");
+    }
+
+    private EngineResponse echo(List<byte[]> args) {
+        if (args.size() != 1) return wrongArity("echo");
+        return EngineResponse.bulkString(args.getFirst());
+    }
+
+    private EngineResponse set(List<byte[]> args) {
+        if (args.size() != 2) return wrongArity("set");
+        ByteSequence key = wrap(args.get(0));
+        store.activeDatabase().set(key, Entry.string(args.get(1), null));
+        return EngineResponse.ok();
+    }
+
+    private EngineResponse get(List<byte[]> args) {
+        if (args.size() != 1) return wrongArity("get");
+        ByteSequence key = wrap(args.getFirst());
+        store.activeDatabase().expireLazy(key);
+        Entry entry = store.activeDatabase().get(key);
+        if (entry == null) return EngineResponse.nullBulkString();
+        if (entry.type != EntryType.STRING) return wrongType();
+        return EngineResponse.bulkString((byte[]) entry.value);
+    }
+
+    private EngineResponse del(List<byte[]> args) {
+        if (args.isEmpty()) return wrongArity("del");
+        long removed = 0;
+        for (byte[] arg : args) {
+            if (store.activeDatabase().delete(wrap(arg))) removed++;
+        }
+        return EngineResponse.integer(removed);
+    }
+
+    private EngineResponse exists(List<byte[]> args) {
+        if (args.isEmpty()) return wrongArity("exists");
+        long count = 0;
+        for (byte[] arg : args) {
+            ByteSequence key = wrap(arg);
+            store.activeDatabase().expireLazy(key);
+            if (store.activeDatabase().get(key) != null) count++;
+        }
+        return EngineResponse.integer(count);
+    }
+
+    private EngineResponse keys(List<byte[]> args) {
+        if (args.size() != 1) return wrongArity("keys");
+        List<EngineResponse> values = new ArrayList<>();
+        for (ByteSequence key : store.activeDatabase().keys(args.getFirst())) {
+            values.add(EngineResponse.bulkString(key.bytes()));
+        }
+        return EngineResponse.array(values);
+    }
+
+    private EngineResponse type(List<byte[]> args) {
+        if (args.size() != 1) return wrongArity("type");
+        ByteSequence key = wrap(args.getFirst());
+        store.activeDatabase().expireLazy(key);
+        Entry entry = store.activeDatabase().get(key);
+        return EngineResponse.simpleString(entry == null ? "none" : entry.type.wireName);
+    }
+
+    private EngineResponse append(List<byte[]> args) {
+        if (args.size() != 2) return wrongArity("append");
+        ByteSequence key = wrap(args.get(0));
+        byte[] suffix = args.get(1);
+        store.activeDatabase().expireLazy(key);
+        Entry entry = store.activeDatabase().get(key);
+        if (entry == null) {
+            store.activeDatabase().set(key, Entry.string(suffix, null));
+            return EngineResponse.integer(suffix.length);
+        }
+        if (entry.type != EntryType.STRING) return wrongType();
+        byte[] prefix = (byte[]) entry.value;
+        byte[] combined = Arrays.copyOf(prefix, prefix.length + suffix.length);
+        System.arraycopy(suffix, 0, combined, prefix.length, suffix.length);
+        entry.value = combined;
+        return EngineResponse.integer(combined.length);
+    }
+
+    private EngineResponse incrBy(List<byte[]> args, Integer fixedDelta) {
+        if ((fixedDelta == null && args.size() != 2) || (fixedDelta != null && args.size() != 1)) {
+            return wrongArity(fixedDelta == null ? "incrby" : (fixedDelta > 0 ? "incr" : "decr"));
+        }
+        long delta = fixedDelta == null ? parseLong(args.get(1)) : fixedDelta;
+        if (fixedDelta == null && args.size() == 2 && delta == Long.MIN_VALUE) return integerParseError();
+        ByteSequence key = wrap(args.getFirst());
+        store.activeDatabase().expireLazy(key);
+        Entry entry = store.activeDatabase().get(key);
+        long value = 0;
+        if (entry != null) {
+            if (entry.type != EntryType.STRING) return wrongType();
+            value = parseLong((byte[]) entry.value);
+            if (value == Long.MIN_VALUE) return integerParseError();
+        }
+        long next = value + delta;
+        store.activeDatabase().set(key, Entry.string(Long.toString(next).getBytes(StandardCharsets.UTF_8), entry == null ? null : entry.expiresAtMs));
+        return EngineResponse.integer(next);
+    }
+
+    private EngineResponse decrBy(List<byte[]> args) {
+        if (args.size() != 2) return wrongArity("decrby");
+        long delta = parseLong(args.get(1));
+        if (delta == Long.MIN_VALUE) return integerParseError();
+        return incrBy(List.of(args.get(0), Long.toString(-delta).getBytes(StandardCharsets.UTF_8)), null);
+    }
+
+    private EngineResponse hset(List<byte[]> args) {
+        if (args.size() < 3 || args.size() % 2 == 0) return wrongArity("hset");
+        ByteSequence key = wrap(args.getFirst());
+        store.activeDatabase().expireLazy(key);
+        Entry entry = store.activeDatabase().get(key);
+        HashMap<ByteSequence, byte[]> hash;
+        Long expiresAt = null;
+        if (entry == null) {
+            hash = new HashMap<>();
+            entry = Entry.hash(hash, null);
+            store.activeDatabase().set(key, entry);
+        } else {
+            if (entry.type != EntryType.HASH) return wrongType();
+            hash = castHash(entry.value);
+            expiresAt = entry.expiresAtMs;
+        }
+        long added = 0;
+        for (int i = 1; i < args.size(); i += 2) {
+            ByteSequence field = wrap(args.get(i));
+            if (!hash.has(field)) added++;
+            hash.set(field, args.get(i + 1));
+        }
+        entry.expiresAtMs = expiresAt;
+        return EngineResponse.integer(added);
+    }
+
+    private EngineResponse hget(List<byte[]> args) {
+        if (args.size() != 2) return wrongArity("hget");
+        Entry entry = keyEntry(args.getFirst());
+        if (entry == null) return EngineResponse.nullBulkString();
+        if (entry.type != EntryType.HASH) return wrongType();
+        return EngineResponse.bulkString(castHash(entry.value).get(wrap(args.get(1))));
+    }
+
+    private EngineResponse hdel(List<byte[]> args) {
+        if (args.size() < 2) return wrongArity("hdel");
+        ByteSequence key = wrap(args.getFirst());
+        Entry entry = keyEntry(args.getFirst());
+        if (entry == null) return EngineResponse.integer(0);
+        if (entry.type != EntryType.HASH) return wrongType();
+        HashMap<ByteSequence, byte[]> hash = castHash(entry.value);
+        long removed = 0;
+        for (int i = 1; i < args.size(); i++) {
+            if (hash.delete(wrap(args.get(i)))) removed++;
+        }
+        if (hash.isEmpty()) store.activeDatabase().delete(key);
+        return EngineResponse.integer(removed);
+    }
+
+    private EngineResponse hgetall(List<byte[]> args) {
+        if (args.size() != 1) return wrongArity("hgetall");
+        Entry entry = keyEntry(args.getFirst());
+        if (entry == null) return EngineResponse.array(List.of());
+        if (entry.type != EntryType.HASH) return wrongType();
+        List<EngineResponse> values = new ArrayList<>();
+        for (var pair : castHash(entry.value).entries()) {
+            values.add(EngineResponse.bulkString(pair.getKey().bytes()));
+            values.add(EngineResponse.bulkString(pair.getValue()));
+        }
+        return EngineResponse.array(values);
+    }
+
+    private EngineResponse hlen(List<byte[]> args) {
+        if (args.size() != 1) return wrongArity("hlen");
+        Entry entry = keyEntry(args.getFirst());
+        if (entry == null) return EngineResponse.integer(0);
+        if (entry.type != EntryType.HASH) return wrongType();
+        return EngineResponse.integer(castHash(entry.value).size());
+    }
+
+    private EngineResponse hexists(List<byte[]> args) {
+        if (args.size() != 2) return wrongArity("hexists");
+        Entry entry = keyEntry(args.getFirst());
+        if (entry == null) return EngineResponse.integer(0);
+        if (entry.type != EntryType.HASH) return wrongType();
+        return EngineResponse.integer(castHash(entry.value).has(wrap(args.get(1))) ? 1 : 0);
+    }
+
+    private EngineResponse hkeys(List<byte[]> args) {
+        if (args.size() != 1) return wrongArity("hkeys");
+        Entry entry = keyEntry(args.getFirst());
+        if (entry == null) return EngineResponse.array(List.of());
+        if (entry.type != EntryType.HASH) return wrongType();
+        List<EngineResponse> values = new ArrayList<>();
+        for (ByteSequence field : castHash(entry.value).keys()) {
+            values.add(EngineResponse.bulkString(field.bytes()));
+        }
+        return EngineResponse.array(values);
+    }
+
+    private EngineResponse hvals(List<byte[]> args) {
+        if (args.size() != 1) return wrongArity("hvals");
+        Entry entry = keyEntry(args.getFirst());
+        if (entry == null) return EngineResponse.array(List.of());
+        if (entry.type != EntryType.HASH) return wrongType();
+        List<EngineResponse> values = new ArrayList<>();
+        for (byte[] value : castHash(entry.value).values()) {
+            values.add(EngineResponse.bulkString(value));
+        }
+        return EngineResponse.array(values);
+    }
+
+    private EngineResponse lpush(List<byte[]> args, boolean left) {
+        if (args.size() < 2) return wrongArity(left ? "lpush" : "rpush");
+        Entry entry = ensureList(args.getFirst());
+        if (entry == null) return wrongType();
+        @SuppressWarnings("unchecked")
+        ArrayList<byte[]> list = (ArrayList<byte[]>) entry.value;
+        for (int i = 1; i < args.size(); i++) {
+            if (left) list.add(0, args.get(i)); else list.add(args.get(i));
+        }
+        return EngineResponse.integer(list.size());
+    }
+
+    private EngineResponse lpop(List<byte[]> args, boolean left) {
+        if (args.size() != 1) return wrongArity(left ? "lpop" : "rpop");
+        ByteSequence key = wrap(args.getFirst());
+        Entry entry = keyEntry(args.getFirst());
+        if (entry == null) return EngineResponse.nullBulkString();
+        if (entry.type != EntryType.LIST) return wrongType();
+        @SuppressWarnings("unchecked")
+        ArrayList<byte[]> list = (ArrayList<byte[]>) entry.value;
+        byte[] value = list.remove(left ? 0 : list.size() - 1);
+        if (list.isEmpty()) store.activeDatabase().delete(key);
+        return EngineResponse.bulkString(value);
+    }
+
+    private EngineResponse llen(List<byte[]> args) {
+        if (args.size() != 1) return wrongArity("llen");
+        Entry entry = keyEntry(args.getFirst());
+        if (entry == null) return EngineResponse.integer(0);
+        if (entry.type != EntryType.LIST) return wrongType();
+        @SuppressWarnings("unchecked")
+        ArrayList<byte[]> list = (ArrayList<byte[]>) entry.value;
+        return EngineResponse.integer(list.size());
+    }
+
+    private EngineResponse lindex(List<byte[]> args) {
+        if (args.size() != 2) return wrongArity("lindex");
+        Entry entry = keyEntry(args.getFirst());
+        if (entry == null) return EngineResponse.nullBulkString();
+        if (entry.type != EntryType.LIST) return wrongType();
+        @SuppressWarnings("unchecked")
+        ArrayList<byte[]> list = (ArrayList<byte[]>) entry.value;
+        Integer index = parseInt(args.get(1));
+        if (index == null) return EngineResponse.error("ERR value is not an integer or out of range");
+        int resolved = index < 0 ? list.size() + index : index;
+        if (resolved < 0 || resolved >= list.size()) return EngineResponse.nullBulkString();
+        return EngineResponse.bulkString(list.get(resolved));
+    }
+
+    private EngineResponse lrange(List<byte[]> args) {
+        if (args.size() != 3) return wrongArity("lrange");
+        Entry entry = keyEntry(args.getFirst());
+        if (entry == null) return EngineResponse.array(List.of());
+        if (entry.type != EntryType.LIST) return wrongType();
+        Integer startValue = parseInt(args.get(1));
+        Integer stopValue = parseInt(args.get(2));
+        if (startValue == null || stopValue == null) return EngineResponse.error("ERR value is not an integer or out of range");
+        @SuppressWarnings("unchecked")
+        ArrayList<byte[]> list = (ArrayList<byte[]>) entry.value;
+        int start = startValue < 0 ? list.size() + startValue : startValue;
+        int stop = stopValue < 0 ? list.size() + stopValue : stopValue;
+        start = Math.max(0, start);
+        stop = Math.min(list.size() - 1, stop);
+        if (list.isEmpty() || start > stop || start >= list.size()) return EngineResponse.array(List.of());
+        List<EngineResponse> values = new ArrayList<>();
+        for (int i = start; i <= stop; i++) values.add(EngineResponse.bulkString(list.get(i)));
+        return EngineResponse.array(values);
+    }
+
+    private EngineResponse sadd(List<byte[]> args) {
+        if (args.size() < 2) return wrongArity("sadd");
+        Entry entry = ensureSet(args.getFirst());
+        if (entry == null) return wrongType();
+        @SuppressWarnings("unchecked")
+        HashSet<ByteSequence> set = (HashSet<ByteSequence>) entry.value;
+        long added = 0;
+        for (int i = 1; i < args.size(); i++) {
+            ByteSequence value = wrap(args.get(i));
+            if (!set.contains(value)) {
+                set.add(value);
+                added++;
+            }
+        }
+        return EngineResponse.integer(added);
+    }
+
+    private EngineResponse srem(List<byte[]> args) {
+        if (args.size() < 2) return wrongArity("srem");
+        ByteSequence key = wrap(args.getFirst());
+        Entry entry = keyEntry(args.getFirst());
+        if (entry == null) return EngineResponse.integer(0);
+        if (entry.type != EntryType.SET) return wrongType();
+        @SuppressWarnings("unchecked")
+        HashSet<ByteSequence> set = (HashSet<ByteSequence>) entry.value;
+        long removed = 0;
+        for (int i = 1; i < args.size(); i++) {
+            if (set.remove(wrap(args.get(i)))) removed++;
+        }
+        if (set.isEmpty()) store.activeDatabase().delete(key);
+        return EngineResponse.integer(removed);
+    }
+
+    private EngineResponse sismember(List<byte[]> args) {
+        if (args.size() != 2) return wrongArity("sismember");
+        Entry entry = keyEntry(args.getFirst());
+        if (entry == null) return EngineResponse.integer(0);
+        if (entry.type != EntryType.SET) return wrongType();
+        @SuppressWarnings("unchecked")
+        HashSet<ByteSequence> set = (HashSet<ByteSequence>) entry.value;
+        return EngineResponse.integer(set.contains(wrap(args.get(1))) ? 1 : 0);
+    }
+
+    private EngineResponse smembers(List<byte[]> args) {
+        if (args.size() != 1) return wrongArity("smembers");
+        Entry entry = keyEntry(args.getFirst());
+        if (entry == null) return EngineResponse.array(List.of());
+        if (entry.type != EntryType.SET) return wrongType();
+        @SuppressWarnings("unchecked")
+        HashSet<ByteSequence> set = (HashSet<ByteSequence>) entry.value;
+        List<ByteSequence> items = new ArrayList<>(set.items());
+        items.sort(ByteSequence::compareTo);
+        List<EngineResponse> values = new ArrayList<>();
+        for (ByteSequence item : items) values.add(EngineResponse.bulkString(item.bytes()));
+        return EngineResponse.array(values);
+    }
+
+    private EngineResponse scard(List<byte[]> args) {
+        if (args.size() != 1) return wrongArity("scard");
+        Entry entry = keyEntry(args.getFirst());
+        if (entry == null) return EngineResponse.integer(0);
+        if (entry.type != EntryType.SET) return wrongType();
+        @SuppressWarnings("unchecked")
+        HashSet<ByteSequence> set = (HashSet<ByteSequence>) entry.value;
+        return EngineResponse.integer(set.size());
+    }
+
+    private EngineResponse expire(List<byte[]> args, boolean absoluteSeconds) {
+        if (args.size() != 2) return wrongArity(absoluteSeconds ? "expireat" : "expire");
+        ByteSequence key = wrap(args.getFirst());
+        Entry entry = keyEntry(args.getFirst());
+        if (entry == null) return EngineResponse.integer(0);
+        long parsed = parseLong(args.get(1));
+        if (parsed == Long.MIN_VALUE) return integerParseError();
+        long expiresAt = absoluteSeconds ? parsed * 1000L : currentTimeMs() + (parsed * 1000L);
+        entry.expiresAtMs = expiresAt;
+        store.activeDatabase().ttlHeap.push(new ExpiryRecord(expiresAt, key));
+        return EngineResponse.integer(1);
+    }
+
+    private EngineResponse pttl(List<byte[]> args) {
+        if (args.size() != 1) return wrongArity("pttl");
+        ByteSequence key = wrap(args.getFirst());
+        store.activeDatabase().expireLazy(key);
+        Entry entry = store.activeDatabase().get(key);
+        if (entry == null) return EngineResponse.integer(-2);
+        if (entry.expiresAtMs == null) return EngineResponse.integer(-1);
+        return EngineResponse.integer(Math.max(-1, entry.expiresAtMs - currentTimeMs()));
+    }
+
+    private EngineResponse persist(List<byte[]> args) {
+        if (args.size() != 1) return wrongArity("persist");
+        Entry entry = keyEntry(args.getFirst());
+        if (entry == null || entry.expiresAtMs == null) return EngineResponse.integer(0);
+        entry.expiresAtMs = null;
+        return EngineResponse.integer(1);
+    }
+
+    private EngineResponse select(List<byte[]> args) {
+        if (args.size() != 1) return wrongArity("select");
+        Integer index = parseInt(args.getFirst());
+        if (index == null || index < 0 || index >= store.databaseCount()) {
+            return EngineResponse.error("ERR DB index is out of range");
+        }
+        store.select(index);
+        return EngineResponse.ok();
+    }
+
+    private EngineResponse flushdb(List<byte[]> args) {
+        if (!args.isEmpty()) return wrongArity("flushdb");
+        store.flushdb();
+        return EngineResponse.ok();
+    }
+
+    private EngineResponse flushall(List<byte[]> args) {
+        if (!args.isEmpty()) return wrongArity("flushall");
+        store.flushall();
+        return EngineResponse.ok();
+    }
+
+    private EngineResponse dbsize(List<byte[]> args) {
+        if (!args.isEmpty()) return wrongArity("dbsize");
+        return EngineResponse.integer(store.activeDatabase().dbsize());
+    }
+
+    private EngineResponse info(List<byte[]> args) {
+        if (!args.isEmpty()) return wrongArity("info");
+        String text = "# Server\r\nmini_redis_jvm:0.1.0\r\nactive_db:" + store.activeDb + "\r\ndbsize:" + store.activeDatabase().dbsize() + "\r\n";
+        return EngineResponse.bulkString(text.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private Entry keyEntry(byte[] rawKey) {
+        ByteSequence key = wrap(rawKey);
+        store.activeDatabase().expireLazy(key);
+        return store.activeDatabase().get(key);
+    }
+
+    private Entry ensureList(byte[] rawKey) {
+        ByteSequence key = wrap(rawKey);
+        store.activeDatabase().expireLazy(key);
+        Entry entry = store.activeDatabase().get(key);
+        if (entry == null) {
+            entry = Entry.list(new ArrayList<>(), null);
+            store.activeDatabase().set(key, entry);
+            return entry;
+        }
+        return entry.type == EntryType.LIST ? entry : null;
+    }
+
+    private Entry ensureSet(byte[] rawKey) {
+        ByteSequence key = wrap(rawKey);
+        store.activeDatabase().expireLazy(key);
+        Entry entry = store.activeDatabase().get(key);
+        if (entry == null) {
+            entry = Entry.set(new HashSet<>(), null);
+            store.activeDatabase().set(key, entry);
+            return entry;
+        }
+        return entry.type == EntryType.SET ? entry : null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private HashMap<ByteSequence, byte[]> castHash(Object value) {
+        return (HashMap<ByteSequence, byte[]>) value;
+    }
+
+    private static ByteSequence wrap(byte[] bytes) {
+        return new ByteSequence(bytes);
+    }
+
+    private static EngineResponse wrongArity(String command) {
+        return EngineResponse.error("ERR wrong number of arguments for '" + command + "' command");
+    }
+
+    private static EngineResponse wrongType() {
+        return EngineResponse.error("WRONGTYPE Operation against a key holding the wrong kind of value");
+    }
+
+    private static EngineResponse integerParseError() {
+        return EngineResponse.error("ERR value is not an integer or out of range");
+    }
+
+    private static long parseLong(byte[] bytes) {
+        try {
+            return Long.parseLong(new String(bytes, StandardCharsets.UTF_8));
+        } catch (NumberFormatException error) {
+            return Long.MIN_VALUE;
+        }
+    }
+
+    private static Integer parseInt(byte[] bytes) {
+        try {
+            return Integer.parseInt(new String(bytes, StandardCharsets.UTF_8));
+        } catch (NumberFormatException error) {
+            return null;
+        }
+    }
+
+    private enum EntryType {
+        STRING("string"), HASH("hash"), LIST("list"), SET("set");
+
+        private final String wireName;
+
+        EntryType(String wireName) {
+            this.wireName = wireName;
+        }
+    }
+
+    private static final class Entry {
+        private final EntryType type;
+        private Object value;
+        private Long expiresAtMs;
+
+        private Entry(EntryType type, Object value, Long expiresAtMs) {
+            this.type = type;
+            this.value = value;
+            this.expiresAtMs = expiresAtMs;
+        }
+
+        private static Entry string(byte[] value, Long expiresAtMs) {
+            return new Entry(EntryType.STRING, value, expiresAtMs);
+        }
+
+        private static Entry hash(HashMap<ByteSequence, byte[]> value, Long expiresAtMs) {
+            return new Entry(EntryType.HASH, value, expiresAtMs);
+        }
+
+        private static Entry list(ArrayList<byte[]> value, Long expiresAtMs) {
+            return new Entry(EntryType.LIST, value, expiresAtMs);
+        }
+
+        private static Entry set(HashSet<ByteSequence> value, Long expiresAtMs) {
+            return new Entry(EntryType.SET, value, expiresAtMs);
+        }
+    }
+
+    private static final class Database {
+        private final HashMap<ByteSequence, Entry> entries = new HashMap<>();
+        private final MinHeap<ExpiryRecord> ttlHeap = new MinHeap<>();
+
+        private Entry get(ByteSequence key) {
+            Entry entry = entries.get(key);
+            if (entry == null) return null;
+            if (entry.expiresAtMs != null && entry.expiresAtMs <= currentTimeMs()) return null;
+            return entry;
+        }
+
+        private void set(ByteSequence key, Entry entry) {
+            entries.set(key, entry);
+            if (entry.expiresAtMs != null) ttlHeap.push(new ExpiryRecord(entry.expiresAtMs, key));
+        }
+
+        private boolean delete(ByteSequence key) {
+            return entries.delete(key);
+        }
+
+        private void expireLazy(ByteSequence key) {
+            Entry entry = entries.get(key);
+            if (entry != null && entry.expiresAtMs != null && entry.expiresAtMs <= currentTimeMs()) {
+                entries.delete(key);
+            }
+        }
+
+        private void activeExpire() {
+            long now = currentTimeMs();
+            while (!ttlHeap.isEmpty()) {
+                ExpiryRecord record = ttlHeap.peek();
+                if (record == null || record.expiresAtMs > now) break;
+                ttlHeap.pop();
+                Entry entry = entries.get(record.key);
+                if (entry != null && entry.expiresAtMs != null && entry.expiresAtMs.equals(record.expiresAtMs)) {
+                    entries.delete(record.key);
+                }
+            }
+        }
+
+        private List<ByteSequence> keys(byte[] pattern) {
+            List<ByteSequence> keys = new ArrayList<>();
+            for (ByteSequence key : entries.keys()) {
+                expireLazy(key);
+                if (entries.get(key) != null && globMatch(pattern, key.bytes())) keys.add(key);
+            }
+            keys.sort(ByteSequence::compareTo);
+            return keys;
+        }
+
+        private int dbsize() {
+            activeExpire();
+            return entries.size();
+        }
+
+        private void clear() {
+            entries.clear();
+        }
+    }
+
+    private static final class Store {
+        private final List<Database> databases;
+        private int activeDb;
+
+        private Store(int count) {
+            databases = new ArrayList<>();
+            for (int i = 0; i < count; i++) databases.add(new Database());
+        }
+
+        private Database activeDatabase() {
+            return databases.get(activeDb);
+        }
+
+        private void select(int nextDb) {
+            activeDb = nextDb;
+        }
+
+        private int databaseCount() {
+            return databases.size();
+        }
+
+        private void flushdb() {
+            activeDatabase().clear();
+        }
+
+        private void flushall() {
+            for (Database database : databases) database.clear();
+        }
+    }
+
+    private record ExpiryRecord(long expiresAtMs, ByteSequence key) implements Comparable<ExpiryRecord> {
+        @Override
+        public int compareTo(ExpiryRecord other) {
+            int byTime = Long.compare(expiresAtMs, other.expiresAtMs);
+            return byTime != 0 ? byTime : key.compareTo(other.key);
+        }
+    }
+
+    private record ByteSequence(byte[] bytes) implements Comparable<ByteSequence> {
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof ByteSequence that && Arrays.equals(bytes, that.bytes);
+        }
+
+        @Override
+        public int hashCode() {
+            return Arrays.hashCode(bytes);
+        }
+
+        @Override
+        public int compareTo(ByteSequence other) {
+            int limit = Math.min(bytes.length, other.bytes.length);
+            for (int i = 0; i < limit; i++) {
+                int diff = Byte.compareUnsigned(bytes[i], other.bytes[i]);
+                if (diff != 0) return diff;
+            }
+            return Integer.compare(bytes.length, other.bytes.length);
+        }
+    }
+
+    private static boolean globMatch(byte[] pattern, byte[] text) {
+        return globMatch(pattern, 0, text, 0);
+    }
+
+    private static boolean globMatch(byte[] pattern, int p, byte[] text, int t) {
+        if (p == pattern.length) return t == text.length;
+        if (pattern[p] == '*') {
+            for (int next = t; next <= text.length; next++) {
+                if (globMatch(pattern, p + 1, text, next)) return true;
+            }
+            return false;
+        }
+        if (t == text.length) return false;
+        if (pattern[p] == '?' || pattern[p] == text[t]) return globMatch(pattern, p + 1, text, t + 1);
+        return false;
+    }
+}

--- a/code/packages/java/in-memory-data-store-engine/src/test/java/com/codingadventures/inmemorydatastoreengine/DataStoreEngineTest.java
+++ b/code/packages/java/in-memory-data-store-engine/src/test/java/com/codingadventures/inmemorydatastoreengine/DataStoreEngineTest.java
@@ -1,0 +1,58 @@
+package com.codingadventures.inmemorydatastoreengine;
+
+import com.codingadventures.inmemorydatastoreprotocol.CommandFrame;
+import com.codingadventures.inmemorydatastoreprotocol.EngineResponse;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DataStoreEngineTest {
+    private static byte[] bytes(String value) {
+        return value.getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void handlesStringRoundTripsAndIntegers() {
+        DataStoreEngine engine = new DataStoreEngine();
+        assertInstanceOf(EngineResponse.SimpleString.class, engine.executeFrame(CommandFrame.fromParts(List.of(bytes("SET"), bytes("alpha"), bytes("1")))));
+        EngineResponse.BulkString get = (EngineResponse.BulkString) engine.executeFrame(CommandFrame.fromParts(List.of(bytes("GET"), bytes("alpha"))));
+        assertEquals("1", new String(get.value(), StandardCharsets.UTF_8));
+        EngineResponse.IntegerValue incr = (EngineResponse.IntegerValue) engine.executeFrame(CommandFrame.fromParts(List.of(bytes("INCR"), bytes("alpha"))));
+        assertEquals(2, incr.value());
+    }
+
+    @Test
+    void handlesHashListAndSetCommands() {
+        DataStoreEngine engine = new DataStoreEngine();
+        EngineResponse.IntegerValue hset = (EngineResponse.IntegerValue) engine.executeFrame(CommandFrame.fromParts(List.of(bytes("HSET"), bytes("user:1"), bytes("name"), bytes("Ada"))));
+        assertEquals(1, hset.value());
+        EngineResponse.BulkString hget = (EngineResponse.BulkString) engine.executeFrame(CommandFrame.fromParts(List.of(bytes("HGET"), bytes("user:1"), bytes("name"))));
+        assertEquals("Ada", new String(hget.value(), StandardCharsets.UTF_8));
+
+        engine.executeFrame(CommandFrame.fromParts(List.of(bytes("LPUSH"), bytes("queue"), bytes("b"), bytes("a"))));
+        EngineResponse.ArrayValue range = (EngineResponse.ArrayValue) engine.executeFrame(CommandFrame.fromParts(List.of(bytes("LRANGE"), bytes("queue"), bytes("0"), bytes("-1"))));
+        assertEquals(2, range.value().size());
+
+        engine.executeFrame(CommandFrame.fromParts(List.of(bytes("SADD"), bytes("tags"), bytes("red"), bytes("blue"))));
+        EngineResponse.IntegerValue scard = (EngineResponse.IntegerValue) engine.executeFrame(CommandFrame.fromParts(List.of(bytes("SCARD"), bytes("tags"))));
+        assertEquals(2, scard.value());
+    }
+
+    @Test
+    void handlesExpiryAndDatabaseSelection() {
+        DataStoreEngine engine = new DataStoreEngine();
+        engine.executeFrame(CommandFrame.fromParts(List.of(bytes("SET"), bytes("ttl"), bytes("value"))));
+        long expired = (DataStoreEngine.currentTimeMs() / 1000L) - 1L;
+        engine.executeFrame(CommandFrame.fromParts(List.of(bytes("EXPIREAT"), bytes("ttl"), bytes(Long.toString(expired)))));
+        EngineResponse.BulkString value = (EngineResponse.BulkString) engine.executeFrame(CommandFrame.fromParts(List.of(bytes("GET"), bytes("ttl"))));
+        assertNull(value.value());
+
+        engine.executeFrame(CommandFrame.fromParts(List.of(bytes("SELECT"), bytes("1"))));
+        engine.executeFrame(CommandFrame.fromParts(List.of(bytes("SET"), bytes("alpha"), bytes("db1"))));
+        EngineResponse.IntegerValue dbsize = (EngineResponse.IntegerValue) engine.executeFrame(CommandFrame.fromParts(List.of(bytes("DBSIZE"))));
+        assertEquals(1, dbsize.value());
+    }
+}

--- a/code/packages/java/in-memory-data-store-protocol/.gitignore
+++ b/code/packages/java/in-memory-data-store-protocol/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/java/in-memory-data-store-protocol/BUILD
+++ b/code/packages/java/in-memory-data-store-protocol/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/in-memory-data-store-protocol/BUILD_windows
+++ b/code/packages/java/in-memory-data-store-protocol/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/in-memory-data-store-protocol/CHANGELOG.md
+++ b/code/packages/java/in-memory-data-store-protocol/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-16
+
+### Added
+
+- Initial JVM mini-redis core package

--- a/code/packages/java/in-memory-data-store-protocol/README.md
+++ b/code/packages/java/in-memory-data-store-protocol/README.md
@@ -1,0 +1,9 @@
+# in-memory-data-store-protocol
+
+RESP-to-engine command frame bridge for the JVM in-memory data store
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/java/in-memory-data-store-protocol/build.gradle.kts
+++ b/code/packages/java/in-memory-data-store-protocol/build.gradle.kts
@@ -1,0 +1,29 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    api("com.codingadventures:resp-protocol")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/in-memory-data-store-protocol/required_capabilities.json
+++ b/code/packages/java/in-memory-data-store-protocol/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "java/in-memory-data-store-protocol",
+  "capabilities": [],
+  "justification": "Pure in-memory data structure and protocol logic. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/java/in-memory-data-store-protocol/settings.gradle.kts
+++ b/code/packages/java/in-memory-data-store-protocol/settings.gradle.kts
@@ -1,0 +1,2 @@
+rootProject.name = "in-memory-data-store-protocol"
+includeBuild("../resp-protocol")

--- a/code/packages/java/in-memory-data-store-protocol/src/main/java/com/codingadventures/inmemorydatastoreprotocol/CommandFrame.java
+++ b/code/packages/java/in-memory-data-store-protocol/src/main/java/com/codingadventures/inmemorydatastoreprotocol/CommandFrame.java
@@ -1,0 +1,32 @@
+package com.codingadventures.inmemorydatastoreprotocol;
+
+import com.codingadventures.respprotocol.RespValue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+public record CommandFrame(String command, List<byte[]> args) {
+    public static CommandFrame fromParts(List<byte[]> parts) {
+        if (parts.isEmpty()) {
+            return null;
+        }
+        String command = new String(parts.getFirst(), StandardCharsets.UTF_8).toUpperCase(Locale.ROOT);
+        return new CommandFrame(command, new ArrayList<>(parts.subList(1, parts.size())));
+    }
+
+    public static CommandFrame fromRespValue(RespValue value) {
+        if (!(value instanceof RespValue.ArrayValue array) || array.isNull()) {
+            return null;
+        }
+        List<byte[]> parts = new ArrayList<>();
+        for (RespValue item : array.value()) {
+            if (!(item instanceof RespValue.BulkString bulk) || bulk.isNull()) {
+                return null;
+            }
+            parts.add(bulk.value());
+        }
+        return fromParts(parts);
+    }
+}

--- a/code/packages/java/in-memory-data-store-protocol/src/main/java/com/codingadventures/inmemorydatastoreprotocol/EngineResponse.java
+++ b/code/packages/java/in-memory-data-store-protocol/src/main/java/com/codingadventures/inmemorydatastoreprotocol/EngineResponse.java
@@ -1,0 +1,75 @@
+package com.codingadventures.inmemorydatastoreprotocol;
+
+import com.codingadventures.respprotocol.RespValue;
+
+import java.util.List;
+
+public sealed interface EngineResponse permits EngineResponse.SimpleString, EngineResponse.ErrorString, EngineResponse.IntegerValue, EngineResponse.BulkString, EngineResponse.ArrayValue {
+    RespValue toRespValue();
+
+    record SimpleString(String value) implements EngineResponse {
+        @Override
+        public RespValue toRespValue() {
+            return new RespValue.SimpleString(value);
+        }
+    }
+
+    record ErrorString(String value) implements EngineResponse {
+        @Override
+        public RespValue toRespValue() {
+            return new RespValue.ErrorString(value);
+        }
+    }
+
+    record IntegerValue(long value) implements EngineResponse {
+        @Override
+        public RespValue toRespValue() {
+            return new RespValue.IntegerValue(value);
+        }
+    }
+
+    record BulkString(byte[] value) implements EngineResponse {
+        @Override
+        public RespValue toRespValue() {
+            return new RespValue.BulkString(value);
+        }
+    }
+
+    record ArrayValue(List<EngineResponse> value) implements EngineResponse {
+        @Override
+        public RespValue toRespValue() {
+            if (value == null) {
+                return new RespValue.ArrayValue(null);
+            }
+            return new RespValue.ArrayValue(value.stream().map(EngineResponse::toRespValue).toList());
+        }
+    }
+
+    static SimpleString simpleString(String value) {
+        return new SimpleString(value);
+    }
+
+    static ErrorString error(String value) {
+        return new ErrorString(value);
+    }
+
+    static IntegerValue integer(long value) {
+        return new IntegerValue(value);
+    }
+
+    static BulkString bulkString(byte[] value) {
+        return new BulkString(value);
+    }
+
+    static BulkString nullBulkString() {
+        return new BulkString(null);
+    }
+
+    static ArrayValue array(List<EngineResponse> value) {
+        return new ArrayValue(value);
+    }
+
+    static SimpleString ok() {
+        return new SimpleString("OK");
+    }
+}

--- a/code/packages/java/in-memory-data-store-protocol/src/test/java/com/codingadventures/inmemorydatastoreprotocol/InMemoryDataStoreProtocolTest.java
+++ b/code/packages/java/in-memory-data-store-protocol/src/test/java/com/codingadventures/inmemorydatastoreprotocol/InMemoryDataStoreProtocolTest.java
@@ -1,0 +1,31 @@
+package com.codingadventures.inmemorydatastoreprotocol;
+
+import com.codingadventures.respprotocol.RespValue;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class InMemoryDataStoreProtocolTest {
+    @Test
+    void buildsCommandFramesFromRespArrays() {
+        CommandFrame frame = CommandFrame.fromRespValue(new RespValue.ArrayValue(List.of(
+                new RespValue.BulkString("SET".getBytes(StandardCharsets.UTF_8)),
+                new RespValue.BulkString("alpha".getBytes(StandardCharsets.UTF_8)),
+                new RespValue.BulkString("1".getBytes(StandardCharsets.UTF_8))
+        )));
+
+        assertNotNull(frame);
+        assertEquals("SET", frame.command());
+        assertEquals(2, frame.args().size());
+    }
+
+    @Test
+    void convertsResponsesBackToRespValues() {
+        RespValue value = EngineResponse.integer(42).toRespValue();
+        assertInstanceOf(RespValue.IntegerValue.class, value);
+        assertEquals(42, ((RespValue.IntegerValue) value).value());
+    }
+}

--- a/code/packages/java/in-memory-data-store/.gitignore
+++ b/code/packages/java/in-memory-data-store/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/java/in-memory-data-store/BUILD
+++ b/code/packages/java/in-memory-data-store/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/in-memory-data-store/BUILD_windows
+++ b/code/packages/java/in-memory-data-store/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/in-memory-data-store/CHANGELOG.md
+++ b/code/packages/java/in-memory-data-store/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-16
+
+### Added
+
+- Initial JVM mini-redis core package

--- a/code/packages/java/in-memory-data-store/README.md
+++ b/code/packages/java/in-memory-data-store/README.md
@@ -1,0 +1,9 @@
+# in-memory-data-store
+
+Composable JVM in-memory data store facade
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/java/in-memory-data-store/build.gradle.kts
+++ b/code/packages/java/in-memory-data-store/build.gradle.kts
@@ -1,0 +1,31 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    api("com.codingadventures:in-memory-data-store-engine")
+    api("com.codingadventures:in-memory-data-store-protocol")
+    api("com.codingadventures:resp-protocol")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/in-memory-data-store/required_capabilities.json
+++ b/code/packages/java/in-memory-data-store/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "java/in-memory-data-store",
+  "capabilities": [],
+  "justification": "Pure in-memory data structure and protocol logic. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/java/in-memory-data-store/settings.gradle.kts
+++ b/code/packages/java/in-memory-data-store/settings.gradle.kts
@@ -1,0 +1,4 @@
+rootProject.name = "in-memory-data-store"
+includeBuild("../in-memory-data-store-engine")
+includeBuild("../in-memory-data-store-protocol")
+includeBuild("../resp-protocol")

--- a/code/packages/java/in-memory-data-store/src/main/java/com/codingadventures/inmemorydatastore/DataStoreManager.java
+++ b/code/packages/java/in-memory-data-store/src/main/java/com/codingadventures/inmemorydatastore/DataStoreManager.java
@@ -1,0 +1,34 @@
+package com.codingadventures.inmemorydatastore;
+
+import com.codingadventures.inmemorydatastoreengine.DataStoreEngine;
+import com.codingadventures.inmemorydatastoreprotocol.CommandFrame;
+import com.codingadventures.inmemorydatastoreprotocol.EngineResponse;
+import com.codingadventures.respprotocol.RespCodec;
+import com.codingadventures.respprotocol.RespValue;
+
+import java.util.List;
+
+public final class DataStoreManager {
+    private final DataStoreEngine engine = new DataStoreEngine();
+
+    public EngineResponse executeFrame(CommandFrame frame) {
+        return engine.executeFrame(frame);
+    }
+
+    public EngineResponse executeParts(List<byte[]> parts) {
+        return executeFrame(CommandFrame.fromParts(parts));
+    }
+
+    public byte[] executeRespBytes(byte[] request) {
+        RespCodec.DecodeResult decoded = RespCodec.decode(request);
+        if (decoded == null) {
+            return RespCodec.encode(EngineResponse.error("ERR incomplete RESP frame").toRespValue());
+        }
+        CommandFrame frame = CommandFrame.fromRespValue(decoded.value());
+        return RespCodec.encode(executeFrame(frame).toRespValue());
+    }
+
+    public RespValue executeRespValue(RespValue value) {
+        return executeFrame(CommandFrame.fromRespValue(value)).toRespValue();
+    }
+}

--- a/code/packages/java/in-memory-data-store/src/test/java/com/codingadventures/inmemorydatastore/DataStoreManagerTest.java
+++ b/code/packages/java/in-memory-data-store/src/test/java/com/codingadventures/inmemorydatastore/DataStoreManagerTest.java
@@ -1,0 +1,30 @@
+package com.codingadventures.inmemorydatastore;
+
+import com.codingadventures.respprotocol.RespCodec;
+import com.codingadventures.respprotocol.RespValue;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DataStoreManagerTest {
+    @Test
+    void executesRespCommandsEndToEnd() {
+        DataStoreManager manager = new DataStoreManager();
+        byte[] setResponse = manager.executeRespBytes(RespCodec.encode(new RespValue.ArrayValue(List.of(
+                new RespValue.BulkString("SET".getBytes(StandardCharsets.UTF_8)),
+                new RespValue.BulkString("alpha".getBytes(StandardCharsets.UTF_8)),
+                new RespValue.BulkString("1".getBytes(StandardCharsets.UTF_8))
+        ))));
+        assertInstanceOf(RespValue.SimpleString.class, RespCodec.decode(setResponse).value());
+
+        byte[] getResponse = manager.executeRespBytes(RespCodec.encode(new RespValue.ArrayValue(List.of(
+                new RespValue.BulkString("GET".getBytes(StandardCharsets.UTF_8)),
+                new RespValue.BulkString("alpha".getBytes(StandardCharsets.UTF_8))
+        ))));
+        RespValue.BulkString bulk = (RespValue.BulkString) RespCodec.decode(getResponse).value();
+        assertEquals("1", new String(bulk.value(), StandardCharsets.UTF_8));
+    }
+}

--- a/code/packages/java/resp-protocol/.gitignore
+++ b/code/packages/java/resp-protocol/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/java/resp-protocol/BUILD
+++ b/code/packages/java/resp-protocol/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/resp-protocol/BUILD_windows
+++ b/code/packages/java/resp-protocol/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/resp-protocol/CHANGELOG.md
+++ b/code/packages/java/resp-protocol/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-16
+
+### Added
+
+- Initial JVM mini-redis core package

--- a/code/packages/java/resp-protocol/README.md
+++ b/code/packages/java/resp-protocol/README.md
@@ -1,0 +1,9 @@
+# resp-protocol
+
+RESP2 encoder/decoder for JVM Redis-compatible transports
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/java/resp-protocol/build.gradle.kts
+++ b/code/packages/java/resp-protocol/build.gradle.kts
@@ -1,0 +1,28 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/resp-protocol/required_capabilities.json
+++ b/code/packages/java/resp-protocol/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "java/resp-protocol",
+  "capabilities": [],
+  "justification": "Pure in-memory data structure and protocol logic. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/java/resp-protocol/settings.gradle.kts
+++ b/code/packages/java/resp-protocol/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "resp-protocol"

--- a/code/packages/java/resp-protocol/src/main/java/com/codingadventures/respprotocol/RespCodec.java
+++ b/code/packages/java/resp-protocol/src/main/java/com/codingadventures/respprotocol/RespCodec.java
@@ -1,0 +1,136 @@
+package com.codingadventures.respprotocol;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public final class RespCodec {
+    private RespCodec() {}
+
+    public static byte[] encode(RespValue value) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        writeValue(out, value);
+        return out.toByteArray();
+    }
+
+    public static DecodeResult decode(byte[] bytes) {
+        return decode(bytes, 0);
+    }
+
+    public static DecodeResult decode(byte[] bytes, int offset) {
+        if (offset >= bytes.length) {
+            return null;
+        }
+        int cursor = offset;
+        return switch (bytes[cursor]) {
+            case '+' -> {
+                LineResult line = readLine(bytes, cursor + 1);
+                if (line == null) yield null;
+                yield new DecodeResult(new RespValue.SimpleString(line.text), line.nextOffset);
+            }
+            case '-' -> {
+                LineResult line = readLine(bytes, cursor + 1);
+                if (line == null) yield null;
+                yield new DecodeResult(new RespValue.ErrorString(line.text), line.nextOffset);
+            }
+            case ':' -> {
+                LineResult line = readLine(bytes, cursor + 1);
+                if (line == null) yield null;
+                yield new DecodeResult(new RespValue.IntegerValue(Long.parseLong(line.text)), line.nextOffset);
+            }
+            case '$' -> decodeBulkString(bytes, cursor + 1);
+            case '*' -> decodeArray(bytes, cursor + 1);
+            default -> throw new IllegalArgumentException("Unknown RESP prefix: " + (char) bytes[cursor]);
+        };
+    }
+
+    private static DecodeResult decodeBulkString(byte[] bytes, int offset) {
+        LineResult line = readLine(bytes, offset);
+        if (line == null) {
+            return null;
+        }
+        int length = Integer.parseInt(line.text);
+        if (length == -1) {
+            return new DecodeResult(new RespValue.BulkString(null), line.nextOffset);
+        }
+        if (line.nextOffset + length + 2 > bytes.length) {
+            return null;
+        }
+        byte[] payload = Arrays.copyOfRange(bytes, line.nextOffset, line.nextOffset + length);
+        if (bytes[line.nextOffset + length] != '\r' || bytes[line.nextOffset + length + 1] != '\n') {
+            throw new IllegalArgumentException("Invalid RESP bulk string terminator");
+        }
+        return new DecodeResult(new RespValue.BulkString(payload), line.nextOffset + length + 2);
+    }
+
+    private static DecodeResult decodeArray(byte[] bytes, int offset) {
+        LineResult line = readLine(bytes, offset);
+        if (line == null) {
+            return null;
+        }
+        int count = Integer.parseInt(line.text);
+        if (count == -1) {
+            return new DecodeResult(new RespValue.ArrayValue(null), line.nextOffset);
+        }
+        List<RespValue> values = new ArrayList<>();
+        int cursor = line.nextOffset;
+        for (int i = 0; i < count; i++) {
+            DecodeResult child = decode(bytes, cursor);
+            if (child == null) {
+                return null;
+            }
+            values.add(child.value());
+            cursor = child.nextOffset();
+        }
+        return new DecodeResult(new RespValue.ArrayValue(values), cursor);
+    }
+
+    private static void writeValue(ByteArrayOutputStream out, RespValue value) {
+        switch (value) {
+            case RespValue.SimpleString simple -> writeLine(out, '+', simple.value());
+            case RespValue.ErrorString error -> writeLine(out, '-', error.value());
+            case RespValue.IntegerValue integer -> writeLine(out, ':', Long.toString(integer.value()));
+            case RespValue.BulkString bulk -> {
+                if (bulk.isNull()) {
+                    writeRaw(out, "$-1\r\n");
+                } else {
+                    writeRaw(out, "$" + bulk.value().length + "\r\n");
+                    out.writeBytes(bulk.value());
+                    writeRaw(out, "\r\n");
+                }
+            }
+            case RespValue.ArrayValue array -> {
+                if (array.isNull()) {
+                    writeRaw(out, "*-1\r\n");
+                } else {
+                    writeRaw(out, "*" + array.value().size() + "\r\n");
+                    for (RespValue item : array.value()) {
+                        writeValue(out, item);
+                    }
+                }
+            }
+        }
+    }
+
+    private static void writeLine(ByteArrayOutputStream out, char prefix, String value) {
+        writeRaw(out, prefix + value + "\r\n");
+    }
+
+    private static void writeRaw(ByteArrayOutputStream out, String text) {
+        out.writeBytes(text.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static LineResult readLine(byte[] bytes, int offset) {
+        for (int i = offset; i + 1 < bytes.length; i++) {
+            if (bytes[i] == '\r' && bytes[i + 1] == '\n') {
+                return new LineResult(new String(bytes, offset, i - offset, StandardCharsets.UTF_8), i + 2);
+            }
+        }
+        return null;
+    }
+
+    private record LineResult(String text, int nextOffset) {}
+    public record DecodeResult(RespValue value, int nextOffset) {}
+}

--- a/code/packages/java/resp-protocol/src/main/java/com/codingadventures/respprotocol/RespValue.java
+++ b/code/packages/java/resp-protocol/src/main/java/com/codingadventures/respprotocol/RespValue.java
@@ -1,0 +1,19 @@
+package com.codingadventures.respprotocol;
+
+import java.util.List;
+
+public sealed interface RespValue permits RespValue.SimpleString, RespValue.ErrorString, RespValue.IntegerValue, RespValue.BulkString, RespValue.ArrayValue {
+    record SimpleString(String value) implements RespValue {}
+    record ErrorString(String value) implements RespValue {}
+    record IntegerValue(long value) implements RespValue {}
+    record BulkString(byte[] value) implements RespValue {
+        public boolean isNull() {
+            return value == null;
+        }
+    }
+    record ArrayValue(List<RespValue> value) implements RespValue {
+        public boolean isNull() {
+            return value == null;
+        }
+    }
+}

--- a/code/packages/java/resp-protocol/src/test/java/com/codingadventures/respprotocol/RespCodecTest.java
+++ b/code/packages/java/resp-protocol/src/test/java/com/codingadventures/respprotocol/RespCodecTest.java
@@ -1,0 +1,31 @@
+package com.codingadventures.respprotocol;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RespCodecTest {
+    @Test
+    void encodesAndDecodesCommandArrays() {
+        RespValue.ArrayValue command = new RespValue.ArrayValue(List.of(
+                new RespValue.BulkString("PING".getBytes(StandardCharsets.UTF_8)),
+                new RespValue.BulkString("hello".getBytes(StandardCharsets.UTF_8))
+        ));
+
+        byte[] encoded = RespCodec.encode(command);
+        RespCodec.DecodeResult decoded = RespCodec.decode(encoded);
+
+        assertNotNull(decoded);
+        assertEquals(encoded.length, decoded.nextOffset());
+        RespValue.ArrayValue array = (RespValue.ArrayValue) decoded.value();
+        assertEquals(2, array.value().size());
+    }
+
+    @Test
+    void returnsNullForIncompleteFrames() {
+        assertNull(RespCodec.decode("$5\r\nhel".getBytes(StandardCharsets.UTF_8)));
+    }
+}

--- a/code/packages/kotlin/hash-map/.gitignore
+++ b/code/packages/kotlin/hash-map/.gitignore
@@ -1,0 +1,5 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/
+/.kotlin/

--- a/code/packages/kotlin/hash-map/BUILD
+++ b/code/packages/kotlin/hash-map/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/hash-map/BUILD_windows
+++ b/code/packages/kotlin/hash-map/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/hash-map/CHANGELOG.md
+++ b/code/packages/kotlin/hash-map/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-16
+
+### Added
+
+- Initial JVM mini-redis core package

--- a/code/packages/kotlin/hash-map/README.md
+++ b/code/packages/kotlin/hash-map/README.md
@@ -1,0 +1,9 @@
+# hash-map
+
+Native Kotlin hash map for JVM mini-redis and other DT ports
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/kotlin/hash-map/build.gradle.kts
+++ b/code/packages/kotlin/hash-map/build.gradle.kts
@@ -1,0 +1,35 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/hash-map/required_capabilities.json
+++ b/code/packages/kotlin/hash-map/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "kotlin/hash-map",
+  "capabilities": [],
+  "justification": "Pure in-memory data structure and protocol logic. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/kotlin/hash-map/settings.gradle.kts
+++ b/code/packages/kotlin/hash-map/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "hash-map"

--- a/code/packages/kotlin/hash-map/src/main/kotlin/com/codingadventures/hashmap/HashMap.kt
+++ b/code/packages/kotlin/hash-map/src/main/kotlin/com/codingadventures/hashmap/HashMap.kt
@@ -1,0 +1,25 @@
+package com.codingadventures.hashmap
+
+class HashMap<K, V>(values: Map<K, V> = emptyMap()) {
+    private val delegate = linkedMapOf<K, V>().apply { putAll(values) }
+
+    val size: Int get() = delegate.size
+    fun isEmpty(): Boolean = delegate.isEmpty()
+    fun has(key: K): Boolean = delegate.containsKey(key)
+    operator fun get(key: K): V? = delegate[key]
+    fun getOrDefault(key: K, defaultValue: V): V = delegate.getOrDefault(key, defaultValue)
+    fun set(key: K, value: V): HashMap<K, V> {
+        delegate[key] = value
+        return this
+    }
+    fun delete(key: K): Boolean = delegate.remove(key) != null
+    fun clear() = delegate.clear()
+    fun keys(): List<K> = delegate.keys.toList()
+    fun values(): List<V> = delegate.values.toList()
+    fun entries(): List<Pair<K, V>> = delegate.entries.map { it.key to it.value }
+    fun copy(): HashMap<K, V> = HashMap(delegate)
+
+    override fun equals(other: Any?): Boolean = other is HashMap<*, *> && delegate == other.delegate
+    override fun hashCode(): Int = delegate.hashCode()
+    override fun toString(): String = delegate.toString()
+}

--- a/code/packages/kotlin/hash-map/src/test/kotlin/com/codingadventures/hashmap/HashMapTest.kt
+++ b/code/packages/kotlin/hash-map/src/test/kotlin/com/codingadventures/hashmap/HashMapTest.kt
@@ -1,0 +1,20 @@
+package com.codingadventures.hashmap
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class HashMapTest {
+    @Test
+    fun storesAndDeletesValues() {
+        val map = HashMap<String, Int>()
+        map.set("alpha", 1).set("beta", 2)
+
+        assertEquals(2, map.size)
+        assertTrue(map.has("alpha"))
+        assertEquals(2, map["beta"])
+        assertTrue(map.delete("alpha"))
+        assertFalse(map.has("alpha"))
+    }
+}

--- a/code/packages/kotlin/hash-set/.gitignore
+++ b/code/packages/kotlin/hash-set/.gitignore
@@ -1,0 +1,5 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/
+/.kotlin/

--- a/code/packages/kotlin/hash-set/BUILD
+++ b/code/packages/kotlin/hash-set/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/hash-set/BUILD_windows
+++ b/code/packages/kotlin/hash-set/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/hash-set/CHANGELOG.md
+++ b/code/packages/kotlin/hash-set/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-16
+
+### Added
+
+- Initial JVM mini-redis core package

--- a/code/packages/kotlin/hash-set/README.md
+++ b/code/packages/kotlin/hash-set/README.md
@@ -1,0 +1,9 @@
+# hash-set
+
+Native Kotlin hash set built on top of the JVM hash-map package
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/kotlin/hash-set/build.gradle.kts
+++ b/code/packages/kotlin/hash-set/build.gradle.kts
@@ -1,0 +1,36 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    api("com.codingadventures:hash-map")
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/hash-set/required_capabilities.json
+++ b/code/packages/kotlin/hash-set/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "kotlin/hash-set",
+  "capabilities": [],
+  "justification": "Pure in-memory data structure and protocol logic. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/kotlin/hash-set/settings.gradle.kts
+++ b/code/packages/kotlin/hash-set/settings.gradle.kts
@@ -1,0 +1,2 @@
+rootProject.name = "hash-set"
+includeBuild("../hash-map")

--- a/code/packages/kotlin/hash-set/src/main/kotlin/com/codingadventures/hashset/HashSet.kt
+++ b/code/packages/kotlin/hash-set/src/main/kotlin/com/codingadventures/hashset/HashSet.kt
@@ -1,0 +1,22 @@
+package com.codingadventures.hashset
+
+import com.codingadventures.hashmap.HashMap
+
+class HashSet<T>(private val map: HashMap<T, Boolean> = HashMap()) {
+    val size: Int get() = map.size
+    fun isEmpty(): Boolean = map.isEmpty()
+    fun contains(value: T): Boolean = map.has(value)
+    fun add(value: T): HashSet<T> {
+        map.set(value, true)
+        return this
+    }
+    fun remove(value: T): Boolean = map.delete(value)
+    fun items(): List<T> = map.keys()
+    fun union(other: HashSet<T>): HashSet<T> = copy().also { result -> other.items().forEach(result::add) }
+    fun intersection(other: HashSet<T>): HashSet<T> = HashSet<T>().also { result -> items().filter(other::contains).forEach(result::add) }
+    fun difference(other: HashSet<T>): HashSet<T> = HashSet<T>().also { result -> items().filterNot(other::contains).forEach(result::add) }
+    fun copy(): HashSet<T> = HashSet(map.copy())
+    override fun equals(other: Any?): Boolean = other is HashSet<*> && map == other.map
+    override fun hashCode(): Int = map.hashCode()
+    override fun toString(): String = items().toString()
+}

--- a/code/packages/kotlin/hash-set/src/test/kotlin/com/codingadventures/hashset/HashSetTest.kt
+++ b/code/packages/kotlin/hash-set/src/test/kotlin/com/codingadventures/hashset/HashSetTest.kt
@@ -1,0 +1,20 @@
+package com.codingadventures.hashset
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class HashSetTest {
+    @Test
+    fun supportsMembershipAndSetAlgebra() {
+        val left = HashSet<String>().add("alpha").add("beta")
+        val right = HashSet<String>().add("beta").add("gamma")
+
+        assertTrue(left.contains("alpha"))
+        assertTrue(left.remove("alpha"))
+        assertFalse(left.contains("alpha"))
+        assertEquals(2, left.union(right).size)
+        assertTrue(left.intersection(right).contains("beta"))
+    }
+}

--- a/code/packages/kotlin/heap/.gitignore
+++ b/code/packages/kotlin/heap/.gitignore
@@ -1,0 +1,5 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/
+/.kotlin/

--- a/code/packages/kotlin/heap/BUILD
+++ b/code/packages/kotlin/heap/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/heap/BUILD_windows
+++ b/code/packages/kotlin/heap/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/heap/CHANGELOG.md
+++ b/code/packages/kotlin/heap/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-16
+
+### Added
+
+- Initial JVM mini-redis core package

--- a/code/packages/kotlin/heap/README.md
+++ b/code/packages/kotlin/heap/README.md
@@ -1,0 +1,9 @@
+# heap
+
+Native Kotlin min-heap for TTL scheduling and priority-queue workloads
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/kotlin/heap/build.gradle.kts
+++ b/code/packages/kotlin/heap/build.gradle.kts
@@ -1,0 +1,35 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/heap/required_capabilities.json
+++ b/code/packages/kotlin/heap/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "kotlin/heap",
+  "capabilities": [],
+  "justification": "Pure in-memory data structure and protocol logic. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/kotlin/heap/settings.gradle.kts
+++ b/code/packages/kotlin/heap/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "heap"

--- a/code/packages/kotlin/heap/src/main/kotlin/com/codingadventures/heap/MinHeap.kt
+++ b/code/packages/kotlin/heap/src/main/kotlin/com/codingadventures/heap/MinHeap.kt
@@ -1,0 +1,50 @@
+package com.codingadventures.heap
+
+class MinHeap<T : Comparable<T>> {
+    private val values = mutableListOf<T>()
+
+    val size: Int get() = values.size
+    fun isEmpty(): Boolean = values.isEmpty()
+
+    fun push(value: T) {
+        values += value
+        siftUp(values.lastIndex)
+    }
+
+    fun peek(): T? = values.firstOrNull()
+
+    fun pop(): T? {
+        if (values.isEmpty()) return null
+        val result = values.first()
+        val last = values.removeAt(values.lastIndex)
+        if (values.isNotEmpty()) {
+            values[0] = last
+            siftDown(0)
+        }
+        return result
+    }
+
+    private fun siftUp(start: Int) {
+        var index = start
+        while (index > 0) {
+            val parent = (index - 1) / 2
+            if (values[parent] <= values[index]) return
+            values[parent] = values[index].also { values[index] = values[parent] }
+            index = parent
+        }
+    }
+
+    private fun siftDown(start: Int) {
+        var index = start
+        while (true) {
+            val left = index * 2 + 1
+            val right = left + 1
+            var smallest = index
+            if (left < values.size && values[left] < values[smallest]) smallest = left
+            if (right < values.size && values[right] < values[smallest]) smallest = right
+            if (smallest == index) return
+            values[index] = values[smallest].also { values[smallest] = values[index] }
+            index = smallest
+        }
+    }
+}

--- a/code/packages/kotlin/heap/src/test/kotlin/com/codingadventures/heap/MinHeapTest.kt
+++ b/code/packages/kotlin/heap/src/test/kotlin/com/codingadventures/heap/MinHeapTest.kt
@@ -1,0 +1,20 @@
+package com.codingadventures.heap
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class MinHeapTest {
+    @Test
+    fun popsValuesInSortedOrder() {
+        val heap = MinHeap<Int>()
+        heap.push(5)
+        heap.push(1)
+        heap.push(3)
+
+        assertEquals(1, heap.pop())
+        assertEquals(3, heap.pop())
+        assertEquals(5, heap.pop())
+        assertNull(heap.pop())
+    }
+}

--- a/code/packages/kotlin/in-memory-data-store-engine/.gitignore
+++ b/code/packages/kotlin/in-memory-data-store-engine/.gitignore
@@ -1,0 +1,5 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/
+/.kotlin/

--- a/code/packages/kotlin/in-memory-data-store-engine/BUILD
+++ b/code/packages/kotlin/in-memory-data-store-engine/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/in-memory-data-store-engine/BUILD_windows
+++ b/code/packages/kotlin/in-memory-data-store-engine/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/in-memory-data-store-engine/CHANGELOG.md
+++ b/code/packages/kotlin/in-memory-data-store-engine/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-16
+
+### Added
+
+- Initial JVM mini-redis core package

--- a/code/packages/kotlin/in-memory-data-store-engine/README.md
+++ b/code/packages/kotlin/in-memory-data-store-engine/README.md
@@ -1,0 +1,9 @@
+# in-memory-data-store-engine
+
+Internal JVM execution engine for the in-memory data store
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/kotlin/in-memory-data-store-engine/build.gradle.kts
+++ b/code/packages/kotlin/in-memory-data-store-engine/build.gradle.kts
@@ -1,0 +1,39 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    api("com.codingadventures:hash-map")
+    api("com.codingadventures:hash-set")
+    api("com.codingadventures:heap")
+    api("com.codingadventures:in-memory-data-store-protocol")
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/in-memory-data-store-engine/required_capabilities.json
+++ b/code/packages/kotlin/in-memory-data-store-engine/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "kotlin/in-memory-data-store-engine",
+  "capabilities": [],
+  "justification": "Pure in-memory data structure and protocol logic. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/kotlin/in-memory-data-store-engine/settings.gradle.kts
+++ b/code/packages/kotlin/in-memory-data-store-engine/settings.gradle.kts
@@ -1,0 +1,5 @@
+rootProject.name = "in-memory-data-store-engine"
+includeBuild("../hash-map")
+includeBuild("../hash-set")
+includeBuild("../heap")
+includeBuild("../in-memory-data-store-protocol")

--- a/code/packages/kotlin/in-memory-data-store-engine/src/main/kotlin/com/codingadventures/inmemorydatastoreengine/DataStoreEngine.kt
+++ b/code/packages/kotlin/in-memory-data-store-engine/src/main/kotlin/com/codingadventures/inmemorydatastoreengine/DataStoreEngine.kt
@@ -1,0 +1,493 @@
+package com.codingadventures.inmemorydatastoreengine
+
+import com.codingadventures.hashmap.HashMap
+import com.codingadventures.hashset.HashSet
+import com.codingadventures.heap.MinHeap
+import com.codingadventures.inmemorydatastoreprotocol.CommandFrame
+import com.codingadventures.inmemorydatastoreprotocol.EngineResponse
+import com.codingadventures.inmemorydatastoreprotocol.bulkString
+import com.codingadventures.inmemorydatastoreprotocol.error
+import com.codingadventures.inmemorydatastoreprotocol.integer
+import com.codingadventures.inmemorydatastoreprotocol.ok
+import java.time.Instant
+import java.util.Locale
+
+class DataStoreEngine {
+    private val store = Store(16)
+
+    fun executeFrame(frame: CommandFrame?): EngineResponse {
+        if (frame == null) return error("ERR protocol error: expected array of bulk strings")
+        store.activeDatabase().activeExpire()
+        return when (frame.command) {
+            "PING" -> ping(frame.args)
+            "ECHO" -> echo(frame.args)
+            "SET" -> set(frame.args)
+            "GET" -> get(frame.args)
+            "DEL" -> del(frame.args)
+            "EXISTS" -> exists(frame.args)
+            "KEYS" -> keys(frame.args)
+            "TYPE" -> type(frame.args)
+            "APPEND" -> append(frame.args)
+            "INCR" -> incrBy(frame.args, 1)
+            "DECR" -> incrBy(frame.args, -1)
+            "INCRBY" -> incrBy(frame.args, null)
+            "DECRBY" -> decrBy(frame.args)
+            "HSET" -> hset(frame.args)
+            "HGET" -> hget(frame.args)
+            "HDEL" -> hdel(frame.args)
+            "HGETALL" -> hgetall(frame.args)
+            "HLEN" -> hlen(frame.args)
+            "HEXISTS" -> hexists(frame.args)
+            "HKEYS" -> hkeys(frame.args)
+            "HVALS" -> hvals(frame.args)
+            "LPUSH" -> pushList(frame.args, true)
+            "RPUSH" -> pushList(frame.args, false)
+            "LPOP" -> popList(frame.args, true)
+            "RPOP" -> popList(frame.args, false)
+            "LLEN" -> llen(frame.args)
+            "LINDEX" -> lindex(frame.args)
+            "LRANGE" -> lrange(frame.args)
+            "SADD" -> sadd(frame.args)
+            "SREM" -> srem(frame.args)
+            "SISMEMBER" -> sismember(frame.args)
+            "SMEMBERS" -> smembers(frame.args)
+            "SCARD" -> scard(frame.args)
+            "EXPIRE" -> expire(frame.args, false)
+            "EXPIREAT" -> expire(frame.args, true)
+            "PTTL" -> pttl(frame.args)
+            "PERSIST" -> persist(frame.args)
+            "SELECT" -> select(frame.args)
+            "FLUSHDB" -> flushdb(frame.args)
+            "FLUSHALL" -> flushall(frame.args)
+            "DBSIZE" -> dbsize(frame.args)
+            "INFO" -> info(frame.args)
+            else -> error("ERR unknown command '${frame.command.lowercase(Locale.ROOT)}'")
+        }
+    }
+
+    companion object {
+        fun currentTimeMs(): Long = Instant.now().toEpochMilli()
+    }
+
+    private fun ping(args: List<ByteArray>): EngineResponse = when (args.size) {
+        0 -> EngineResponse.SimpleString("PONG")
+        1 -> bulkString(args.first())
+        else -> wrongArity("ping")
+    }
+
+    private fun echo(args: List<ByteArray>): EngineResponse = if (args.size == 1) bulkString(args.first()) else wrongArity("echo")
+
+    private fun set(args: List<ByteArray>): EngineResponse {
+        if (args.size != 2) return wrongArity("set")
+        store.activeDatabase().set(ByteSequence(args[0]), Entry.string(args[1], null))
+        return ok()
+    }
+
+    private fun get(args: List<ByteArray>): EngineResponse {
+        if (args.size != 1) return wrongArity("get")
+        val entry = keyEntry(args.first()) ?: return bulkString(null)
+        if (entry.type != EntryType.STRING) return wrongType()
+        return bulkString(entry.value as ByteArray)
+    }
+
+    private fun del(args: List<ByteArray>): EngineResponse {
+        if (args.isEmpty()) return wrongArity("del")
+        return integer(args.count { store.activeDatabase().delete(ByteSequence(it)) }.toLong())
+    }
+
+    private fun exists(args: List<ByteArray>): EngineResponse {
+        if (args.isEmpty()) return wrongArity("exists")
+        return integer(args.count { keyEntry(it) != null }.toLong())
+    }
+
+    private fun keys(args: List<ByteArray>): EngineResponse {
+        if (args.size != 1) return wrongArity("keys")
+        return EngineResponse.ArrayValue(store.activeDatabase().keys(args.first()).map { bulkString(it.bytes) })
+    }
+
+    private fun type(args: List<ByteArray>): EngineResponse {
+        if (args.size != 1) return wrongArity("type")
+        return EngineResponse.SimpleString(keyEntry(args.first())?.type?.wireName ?: "none")
+    }
+
+    private fun append(args: List<ByteArray>): EngineResponse {
+        if (args.size != 2) return wrongArity("append")
+        val key = ByteSequence(args[0])
+        val suffix = args[1]
+        val entry = keyEntry(args[0])
+        if (entry == null) {
+            store.activeDatabase().set(key, Entry.string(suffix, null))
+            return integer(suffix.size.toLong())
+        }
+        if (entry.type != EntryType.STRING) return wrongType()
+        val combined = (entry.value as ByteArray) + suffix
+        entry.value = combined
+        return integer(combined.size.toLong())
+    }
+
+    private fun incrBy(args: List<ByteArray>, fixedDelta: Long?): EngineResponse {
+        if ((fixedDelta == null && args.size != 2) || (fixedDelta != null && args.size != 1)) {
+            return wrongArity(if (fixedDelta == null) "incrby" else if (fixedDelta > 0) "incr" else "decr")
+        }
+        val delta = fixedDelta ?: parseLong(args[1]) ?: return integerParseError()
+        val key = ByteSequence(args.first())
+        val entry = keyEntry(args.first())
+        val current = when {
+            entry == null -> 0L
+            entry.type != EntryType.STRING -> return wrongType()
+            else -> parseLong(entry.value as ByteArray) ?: return integerParseError()
+        }
+        val next = current + delta
+        store.activeDatabase().set(key, Entry.string(next.toString().encodeToByteArray(), entry?.expiresAtMs))
+        return integer(next)
+    }
+
+    private fun decrBy(args: List<ByteArray>): EngineResponse {
+        if (args.size != 2) return wrongArity("decrby")
+        val delta = parseLong(args[1]) ?: return integerParseError()
+        return incrBy(listOf(args[0], (-delta).toString().encodeToByteArray()), null)
+    }
+
+    private fun hset(args: List<ByteArray>): EngineResponse {
+        if (args.size < 3 || args.size % 2 == 0) return wrongArity("hset")
+        val key = ByteSequence(args.first())
+        val entry = keyEntry(args.first()) ?: Entry.hash(HashMap(), null).also { store.activeDatabase().set(key, it) }
+        if (entry.type != EntryType.HASH) return wrongType()
+        val hash = entry.value as HashMap<ByteSequence, ByteArray>
+        var added = 0L
+        for (index in 1 until args.size step 2) {
+            val field = ByteSequence(args[index])
+            if (!hash.has(field)) added += 1
+            hash.set(field, args[index + 1])
+        }
+        return integer(added)
+    }
+
+    private fun hget(args: List<ByteArray>): EngineResponse {
+        if (args.size != 2) return wrongArity("hget")
+        val entry = keyEntry(args.first()) ?: return bulkString(null)
+        if (entry.type != EntryType.HASH) return wrongType()
+        return bulkString((entry.value as HashMap<ByteSequence, ByteArray>)[ByteSequence(args[1])])
+    }
+
+    private fun hdel(args: List<ByteArray>): EngineResponse {
+        if (args.size < 2) return wrongArity("hdel")
+        val key = ByteSequence(args.first())
+        val entry = keyEntry(args.first()) ?: return integer(0)
+        if (entry.type != EntryType.HASH) return wrongType()
+        val hash = entry.value as HashMap<ByteSequence, ByteArray>
+        var removed = 0L
+        for (field in args.drop(1)) if (hash.delete(ByteSequence(field))) removed += 1
+        if (hash.isEmpty()) store.activeDatabase().delete(key)
+        return integer(removed)
+    }
+
+    private fun hgetall(args: List<ByteArray>): EngineResponse {
+        if (args.size != 1) return wrongArity("hgetall")
+        val entry = keyEntry(args.first()) ?: return EngineResponse.ArrayValue(emptyList())
+        if (entry.type != EntryType.HASH) return wrongType()
+        val responses = mutableListOf<EngineResponse>()
+        for ((field, value) in (entry.value as HashMap<ByteSequence, ByteArray>).entries()) {
+            responses += bulkString(field.bytes)
+            responses += bulkString(value)
+        }
+        return EngineResponse.ArrayValue(responses)
+    }
+
+    private fun hlen(args: List<ByteArray>): EngineResponse {
+        if (args.size != 1) return wrongArity("hlen")
+        val entry = keyEntry(args.first()) ?: return integer(0)
+        if (entry.type != EntryType.HASH) return wrongType()
+        return integer((entry.value as HashMap<ByteSequence, ByteArray>).size.toLong())
+    }
+
+    private fun hexists(args: List<ByteArray>): EngineResponse {
+        if (args.size != 2) return wrongArity("hexists")
+        val entry = keyEntry(args.first()) ?: return integer(0)
+        if (entry.type != EntryType.HASH) return wrongType()
+        return integer(if ((entry.value as HashMap<ByteSequence, ByteArray>).has(ByteSequence(args[1]))) 1 else 0)
+    }
+
+    private fun hkeys(args: List<ByteArray>): EngineResponse {
+        if (args.size != 1) return wrongArity("hkeys")
+        val entry = keyEntry(args.first()) ?: return EngineResponse.ArrayValue(emptyList())
+        if (entry.type != EntryType.HASH) return wrongType()
+        return EngineResponse.ArrayValue((entry.value as HashMap<ByteSequence, ByteArray>).keys().map { bulkString(it.bytes) })
+    }
+
+    private fun hvals(args: List<ByteArray>): EngineResponse {
+        if (args.size != 1) return wrongArity("hvals")
+        val entry = keyEntry(args.first()) ?: return EngineResponse.ArrayValue(emptyList())
+        if (entry.type != EntryType.HASH) return wrongType()
+        return EngineResponse.ArrayValue((entry.value as HashMap<ByteSequence, ByteArray>).values().map(::bulkString))
+    }
+
+    private fun pushList(args: List<ByteArray>, left: Boolean): EngineResponse {
+        if (args.size < 2) return wrongArity(if (left) "lpush" else "rpush")
+        val entry = ensureList(args.first()) ?: return wrongType()
+        val list = entry.value as MutableList<ByteArray>
+        for (value in args.drop(1)) if (left) list.add(0, value) else list.add(value)
+        return integer(list.size.toLong())
+    }
+
+    private fun popList(args: List<ByteArray>, left: Boolean): EngineResponse {
+        if (args.size != 1) return wrongArity(if (left) "lpop" else "rpop")
+        val key = ByteSequence(args.first())
+        val entry = keyEntry(args.first()) ?: return bulkString(null)
+        if (entry.type != EntryType.LIST) return wrongType()
+        val list = entry.value as MutableList<ByteArray>
+        val value = list.removeAt(if (left) 0 else list.lastIndex)
+        if (list.isEmpty()) store.activeDatabase().delete(key)
+        return bulkString(value)
+    }
+
+    private fun llen(args: List<ByteArray>): EngineResponse {
+        if (args.size != 1) return wrongArity("llen")
+        val entry = keyEntry(args.first()) ?: return integer(0)
+        if (entry.type != EntryType.LIST) return wrongType()
+        return integer((entry.value as MutableList<ByteArray>).size.toLong())
+    }
+
+    private fun lindex(args: List<ByteArray>): EngineResponse {
+        if (args.size != 2) return wrongArity("lindex")
+        val entry = keyEntry(args.first()) ?: return bulkString(null)
+        if (entry.type != EntryType.LIST) return wrongType()
+        val list = entry.value as MutableList<ByteArray>
+        val index = parseInt(args[1]) ?: return error("ERR value is not an integer or out of range")
+        val resolved = if (index < 0) list.size + index else index
+        return if (resolved in list.indices) bulkString(list[resolved]) else bulkString(null)
+    }
+
+    private fun lrange(args: List<ByteArray>): EngineResponse {
+        if (args.size != 3) return wrongArity("lrange")
+        val entry = keyEntry(args.first()) ?: return EngineResponse.ArrayValue(emptyList())
+        if (entry.type != EntryType.LIST) return wrongType()
+        val list = entry.value as MutableList<ByteArray>
+        val startValue = parseInt(args[1]) ?: return error("ERR value is not an integer or out of range")
+        val stopValue = parseInt(args[2]) ?: return error("ERR value is not an integer or out of range")
+        val start = (if (startValue < 0) list.size + startValue else startValue).coerceAtLeast(0)
+        val stop = (if (stopValue < 0) list.size + stopValue else stopValue).coerceAtMost(list.lastIndex)
+        if (list.isEmpty() || start > stop || start >= list.size) return EngineResponse.ArrayValue(emptyList())
+        return EngineResponse.ArrayValue((start..stop).map { bulkString(list[it]) })
+    }
+
+    private fun sadd(args: List<ByteArray>): EngineResponse {
+        if (args.size < 2) return wrongArity("sadd")
+        val entry = ensureSet(args.first()) ?: return wrongType()
+        val set = entry.value as HashSet<ByteSequence>
+        var added = 0L
+        for (value in args.drop(1).map(::ByteSequence)) {
+            if (!set.contains(value)) {
+                set.add(value)
+                added += 1
+            }
+        }
+        return integer(added)
+    }
+
+    private fun srem(args: List<ByteArray>): EngineResponse {
+        if (args.size < 2) return wrongArity("srem")
+        val key = ByteSequence(args.first())
+        val entry = keyEntry(args.first()) ?: return integer(0)
+        if (entry.type != EntryType.SET) return wrongType()
+        val set = entry.value as HashSet<ByteSequence>
+        val removed = args.drop(1).count { set.remove(ByteSequence(it)) }
+        if (set.isEmpty()) store.activeDatabase().delete(key)
+        return integer(removed.toLong())
+    }
+
+    private fun sismember(args: List<ByteArray>): EngineResponse {
+        if (args.size != 2) return wrongArity("sismember")
+        val entry = keyEntry(args.first()) ?: return integer(0)
+        if (entry.type != EntryType.SET) return wrongType()
+        return integer(if ((entry.value as HashSet<ByteSequence>).contains(ByteSequence(args[1]))) 1 else 0)
+    }
+
+    private fun smembers(args: List<ByteArray>): EngineResponse {
+        if (args.size != 1) return wrongArity("smembers")
+        val entry = keyEntry(args.first()) ?: return EngineResponse.ArrayValue(emptyList())
+        if (entry.type != EntryType.SET) return wrongType()
+        return EngineResponse.ArrayValue((entry.value as HashSet<ByteSequence>).items().sorted().map { bulkString(it.bytes) })
+    }
+
+    private fun scard(args: List<ByteArray>): EngineResponse {
+        if (args.size != 1) return wrongArity("scard")
+        val entry = keyEntry(args.first()) ?: return integer(0)
+        if (entry.type != EntryType.SET) return wrongType()
+        return integer((entry.value as HashSet<ByteSequence>).size.toLong())
+    }
+
+    private fun expire(args: List<ByteArray>, absoluteSeconds: Boolean): EngineResponse {
+        if (args.size != 2) return wrongArity(if (absoluteSeconds) "expireat" else "expire")
+        val key = ByteSequence(args.first())
+        val entry = keyEntry(args.first()) ?: return integer(0)
+        val parsed = parseLong(args[1]) ?: return integerParseError()
+        val expiresAt = if (absoluteSeconds) parsed * 1000L else currentTimeMs() + parsed * 1000L
+        entry.expiresAtMs = expiresAt
+        store.activeDatabase().ttlHeap.push(ExpiryRecord(expiresAt, key))
+        return integer(1)
+    }
+
+    private fun pttl(args: List<ByteArray>): EngineResponse {
+        if (args.size != 1) return wrongArity("pttl")
+        val entry = keyEntry(args.first()) ?: return integer(-2)
+        if (entry.expiresAtMs == null) return integer(-1)
+        return integer(maxOf(-1, entry.expiresAtMs!! - currentTimeMs()))
+    }
+
+    private fun persist(args: List<ByteArray>): EngineResponse {
+        if (args.size != 1) return wrongArity("persist")
+        val entry = keyEntry(args.first()) ?: return integer(0)
+        if (entry.expiresAtMs == null) return integer(0)
+        entry.expiresAtMs = null
+        return integer(1)
+    }
+
+    private fun select(args: List<ByteArray>): EngineResponse {
+        if (args.size != 1) return wrongArity("select")
+        val index = parseInt(args.first()) ?: return error("ERR DB index is out of range")
+        if (index !in 0 until store.databaseCount()) return error("ERR DB index is out of range")
+        store.select(index)
+        return ok()
+    }
+
+    private fun flushdb(args: List<ByteArray>): EngineResponse = if (args.isEmpty()) {
+        store.flushdb(); ok()
+    } else wrongArity("flushdb")
+
+    private fun flushall(args: List<ByteArray>): EngineResponse = if (args.isEmpty()) {
+        store.flushall(); ok()
+    } else wrongArity("flushall")
+
+    private fun dbsize(args: List<ByteArray>): EngineResponse = if (args.isEmpty()) integer(store.activeDatabase().dbsize().toLong()) else wrongArity("dbsize")
+
+    private fun info(args: List<ByteArray>): EngineResponse {
+        if (args.isNotEmpty()) return wrongArity("info")
+        val text = "# Server\r\nmini_redis_kotlin:0.1.0\r\nactive_db:${store.activeDb}\r\ndbsize:${store.activeDatabase().dbsize()}\r\n"
+        return bulkString(text.encodeToByteArray())
+    }
+
+    private fun keyEntry(rawKey: ByteArray): Entry? {
+        val key = ByteSequence(rawKey)
+        store.activeDatabase().expireLazy(key)
+        return store.activeDatabase().get(key)
+    }
+
+    private fun ensureList(rawKey: ByteArray): Entry? {
+        val key = ByteSequence(rawKey)
+        store.activeDatabase().expireLazy(key)
+        val current = store.activeDatabase().get(key)
+        if (current == null) {
+            return Entry.list(mutableListOf(), null).also { store.activeDatabase().set(key, it) }
+        }
+        return current.takeIf { it.type == EntryType.LIST }
+    }
+
+    private fun ensureSet(rawKey: ByteArray): Entry? {
+        val key = ByteSequence(rawKey)
+        store.activeDatabase().expireLazy(key)
+        val current = store.activeDatabase().get(key)
+        if (current == null) {
+            return Entry.set(HashSet(), null).also { store.activeDatabase().set(key, it) }
+        }
+        return current.takeIf { it.type == EntryType.SET }
+    }
+
+    private fun wrongArity(command: String): EngineResponse = error("ERR wrong number of arguments for '$command' command")
+    private fun wrongType(): EngineResponse = error("WRONGTYPE Operation against a key holding the wrong kind of value")
+    private fun integerParseError(): EngineResponse = error("ERR value is not an integer or out of range")
+    private fun parseLong(bytes: ByteArray): Long? = bytes.decodeToString().toLongOrNull()
+    private fun parseInt(bytes: ByteArray): Int? = bytes.decodeToString().toIntOrNull()
+}
+
+enum class EntryType(val wireName: String) { STRING("string"), HASH("hash"), LIST("list"), SET("set") }
+
+data class Entry(val type: EntryType, var value: Any, var expiresAtMs: Long?) {
+    companion object {
+        fun string(value: ByteArray, expiresAtMs: Long?) = Entry(EntryType.STRING, value, expiresAtMs)
+        fun hash(value: HashMap<ByteSequence, ByteArray>, expiresAtMs: Long?) = Entry(EntryType.HASH, value, expiresAtMs)
+        fun list(value: MutableList<ByteArray>, expiresAtMs: Long?) = Entry(EntryType.LIST, value, expiresAtMs)
+        fun set(value: HashSet<ByteSequence>, expiresAtMs: Long?) = Entry(EntryType.SET, value, expiresAtMs)
+    }
+}
+
+class Store(count: Int) {
+    private val databases = List(count) { Database() }
+    var activeDb: Int = 0
+        private set
+
+    fun activeDatabase(): Database = databases[activeDb]
+    fun select(index: Int) { activeDb = index }
+    fun databaseCount(): Int = databases.size
+    fun flushdb() = activeDatabase().clear()
+    fun flushall() = databases.forEach { it.clear() }
+}
+
+class Database {
+    private val entries = HashMap<ByteSequence, Entry>()
+    val ttlHeap = MinHeap<ExpiryRecord>()
+
+    fun get(key: ByteSequence): Entry? {
+        val entry = entries[key] ?: return null
+        return if (entry.expiresAtMs != null && entry.expiresAtMs!! <= DataStoreEngine.currentTimeMs()) null else entry
+    }
+
+    fun set(key: ByteSequence, entry: Entry) {
+        entries.set(key, entry)
+        entry.expiresAtMs?.let { ttlHeap.push(ExpiryRecord(it, key)) }
+    }
+
+    fun delete(key: ByteSequence): Boolean = entries.delete(key)
+
+    fun expireLazy(key: ByteSequence) {
+        val entry = entries[key] ?: return
+        if (entry.expiresAtMs != null && entry.expiresAtMs!! <= DataStoreEngine.currentTimeMs()) entries.delete(key)
+    }
+
+    fun activeExpire() {
+        val now = DataStoreEngine.currentTimeMs()
+        while (!ttlHeap.isEmpty()) {
+            val record = ttlHeap.peek() ?: break
+            if (record.expiresAtMs > now) break
+            ttlHeap.pop()
+            val entry = entries[record.key]
+            if (entry != null && entry.expiresAtMs == record.expiresAtMs) entries.delete(record.key)
+        }
+    }
+
+    fun keys(pattern: ByteArray): List<ByteSequence> = entries.keys().filter {
+        expireLazy(it)
+        entries[it] != null && globMatch(pattern, it.bytes)
+    }.sorted()
+
+    fun dbsize(): Int {
+        activeExpire()
+        return entries.size
+    }
+
+    fun clear() = entries.clear()
+}
+
+data class ExpiryRecord(val expiresAtMs: Long, val key: ByteSequence) : Comparable<ExpiryRecord> {
+    override fun compareTo(other: ExpiryRecord): Int = compareValuesBy(this, other, ExpiryRecord::expiresAtMs, ExpiryRecord::key)
+}
+
+class ByteSequence(val bytes: ByteArray) : Comparable<ByteSequence> {
+    override fun equals(other: Any?): Boolean = other is ByteSequence && bytes.contentEquals(other.bytes)
+    override fun hashCode(): Int = bytes.contentHashCode()
+    override fun compareTo(other: ByteSequence): Int {
+        val limit = minOf(bytes.size, other.bytes.size)
+        for (index in 0 until limit) {
+            val diff = bytes[index].toUByte().compareTo(other.bytes[index].toUByte())
+            if (diff != 0) return diff
+        }
+        return bytes.size.compareTo(other.bytes.size)
+    }
+}
+
+private fun globMatch(pattern: ByteArray, text: ByteArray, p: Int = 0, t: Int = 0): Boolean {
+    if (p == pattern.size) return t == text.size
+    if (pattern[p] == '*'.code.toByte()) return (t..text.size).any { globMatch(pattern, text, p + 1, it) }
+    if (t == text.size) return false
+    return if (pattern[p] == '?'.code.toByte() || pattern[p] == text[t]) globMatch(pattern, text, p + 1, t + 1) else false
+}

--- a/code/packages/kotlin/in-memory-data-store-engine/src/test/kotlin/com/codingadventures/inmemorydatastoreengine/DataStoreEngineTest.kt
+++ b/code/packages/kotlin/in-memory-data-store-engine/src/test/kotlin/com/codingadventures/inmemorydatastoreengine/DataStoreEngineTest.kt
@@ -1,0 +1,54 @@
+package com.codingadventures.inmemorydatastoreengine
+
+import com.codingadventures.inmemorydatastoreprotocol.CommandFrame
+import com.codingadventures.inmemorydatastoreprotocol.EngineResponse
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class DataStoreEngineTest {
+    private fun bytes(value: String) = value.encodeToByteArray()
+
+    @Test
+    fun handlesStringRoundTripsAndIntegers() {
+        val engine = DataStoreEngine()
+        engine.executeFrame(CommandFrame.fromParts(listOf(bytes("SET"), bytes("alpha"), bytes("1"))))
+        val get = engine.executeFrame(CommandFrame.fromParts(listOf(bytes("GET"), bytes("alpha")))) as EngineResponse.BulkString
+        assertEquals("1", get.value?.decodeToString())
+        val incr = engine.executeFrame(CommandFrame.fromParts(listOf(bytes("INCR"), bytes("alpha")))) as EngineResponse.IntegerValue
+        assertEquals(2, incr.value)
+    }
+
+    @Test
+    fun handlesHashListAndSetCommands() {
+        val engine = DataStoreEngine()
+        val hset = engine.executeFrame(CommandFrame.fromParts(listOf(bytes("HSET"), bytes("user:1"), bytes("name"), bytes("Ada")))) as EngineResponse.IntegerValue
+        assertEquals(1, hset.value)
+        val hget = engine.executeFrame(CommandFrame.fromParts(listOf(bytes("HGET"), bytes("user:1"), bytes("name")))) as EngineResponse.BulkString
+        assertEquals("Ada", hget.value?.decodeToString())
+
+        engine.executeFrame(CommandFrame.fromParts(listOf(bytes("LPUSH"), bytes("queue"), bytes("b"), bytes("a"))))
+        val range = engine.executeFrame(CommandFrame.fromParts(listOf(bytes("LRANGE"), bytes("queue"), bytes("0"), bytes("-1")))) as EngineResponse.ArrayValue
+        assertEquals(2, range.value?.size)
+
+        engine.executeFrame(CommandFrame.fromParts(listOf(bytes("SADD"), bytes("tags"), bytes("red"), bytes("blue"))))
+        val scard = engine.executeFrame(CommandFrame.fromParts(listOf(bytes("SCARD"), bytes("tags")))) as EngineResponse.IntegerValue
+        assertEquals(2, scard.value)
+    }
+
+    @Test
+    fun handlesExpiryAndDatabaseSelection() {
+        val engine = DataStoreEngine()
+        engine.executeFrame(CommandFrame.fromParts(listOf(bytes("SET"), bytes("ttl"), bytes("value"))))
+        val expired = (DataStoreEngine.currentTimeMs() / 1000L) - 1L
+        engine.executeFrame(CommandFrame.fromParts(listOf(bytes("EXPIREAT"), bytes("ttl"), bytes(expired.toString()))))
+        val value = engine.executeFrame(CommandFrame.fromParts(listOf(bytes("GET"), bytes("ttl")))) as EngineResponse.BulkString
+        assertNull(value.value)
+
+        engine.executeFrame(CommandFrame.fromParts(listOf(bytes("SELECT"), bytes("1"))))
+        engine.executeFrame(CommandFrame.fromParts(listOf(bytes("SET"), bytes("alpha"), bytes("db1"))))
+        val dbsize = engine.executeFrame(CommandFrame.fromParts(listOf(bytes("DBSIZE")))) as EngineResponse.IntegerValue
+        assertEquals(1, dbsize.value)
+    }
+}

--- a/code/packages/kotlin/in-memory-data-store-protocol/.gitignore
+++ b/code/packages/kotlin/in-memory-data-store-protocol/.gitignore
@@ -1,0 +1,5 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/
+/.kotlin/

--- a/code/packages/kotlin/in-memory-data-store-protocol/BUILD
+++ b/code/packages/kotlin/in-memory-data-store-protocol/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/in-memory-data-store-protocol/BUILD_windows
+++ b/code/packages/kotlin/in-memory-data-store-protocol/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/in-memory-data-store-protocol/CHANGELOG.md
+++ b/code/packages/kotlin/in-memory-data-store-protocol/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-16
+
+### Added
+
+- Initial JVM mini-redis core package

--- a/code/packages/kotlin/in-memory-data-store-protocol/README.md
+++ b/code/packages/kotlin/in-memory-data-store-protocol/README.md
@@ -1,0 +1,9 @@
+# in-memory-data-store-protocol
+
+RESP-to-engine command frame bridge for the JVM in-memory data store
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/kotlin/in-memory-data-store-protocol/build.gradle.kts
+++ b/code/packages/kotlin/in-memory-data-store-protocol/build.gradle.kts
@@ -1,0 +1,36 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    api("com.codingadventures:resp-protocol")
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/in-memory-data-store-protocol/required_capabilities.json
+++ b/code/packages/kotlin/in-memory-data-store-protocol/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "kotlin/in-memory-data-store-protocol",
+  "capabilities": [],
+  "justification": "Pure in-memory data structure and protocol logic. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/kotlin/in-memory-data-store-protocol/settings.gradle.kts
+++ b/code/packages/kotlin/in-memory-data-store-protocol/settings.gradle.kts
@@ -1,0 +1,2 @@
+rootProject.name = "in-memory-data-store-protocol"
+includeBuild("../resp-protocol")

--- a/code/packages/kotlin/in-memory-data-store-protocol/src/main/kotlin/com/codingadventures/inmemorydatastoreprotocol/InMemoryDataStoreProtocol.kt
+++ b/code/packages/kotlin/in-memory-data-store-protocol/src/main/kotlin/com/codingadventures/inmemorydatastoreprotocol/InMemoryDataStoreProtocol.kt
@@ -1,0 +1,45 @@
+package com.codingadventures.inmemorydatastoreprotocol
+
+import com.codingadventures.respprotocol.RespValue
+
+import java.util.Locale
+
+data class CommandFrame(val command: String, val args: List<ByteArray>) {
+    companion object {
+        fun fromParts(parts: List<ByteArray>): CommandFrame? {
+            if (parts.isEmpty()) return null
+            return CommandFrame(parts.first().decodeToString().uppercase(Locale.ROOT), parts.drop(1))
+        }
+
+        fun fromRespValue(value: RespValue): CommandFrame? {
+            val array = value as? RespValue.ArrayValue ?: return null
+            val parts = array.value?.map { (it as? RespValue.BulkString)?.value ?: return null } ?: return null
+            return fromParts(parts)
+        }
+    }
+}
+
+sealed interface EngineResponse {
+    fun toRespValue(): RespValue
+
+    data class SimpleString(val value: String) : EngineResponse {
+        override fun toRespValue(): RespValue = RespValue.SimpleString(value)
+    }
+    data class ErrorString(val value: String) : EngineResponse {
+        override fun toRespValue(): RespValue = RespValue.ErrorString(value)
+    }
+    data class IntegerValue(val value: Long) : EngineResponse {
+        override fun toRespValue(): RespValue = RespValue.IntegerValue(value)
+    }
+    data class BulkString(val value: ByteArray?) : EngineResponse {
+        override fun toRespValue(): RespValue = RespValue.BulkString(value)
+    }
+    data class ArrayValue(val value: List<EngineResponse>?) : EngineResponse {
+        override fun toRespValue(): RespValue = RespValue.ArrayValue(value?.map { it.toRespValue() })
+    }
+}
+
+fun ok(): EngineResponse = EngineResponse.SimpleString("OK")
+fun error(message: String): EngineResponse = EngineResponse.ErrorString(message)
+fun integer(value: Long): EngineResponse = EngineResponse.IntegerValue(value)
+fun bulkString(value: ByteArray?): EngineResponse = EngineResponse.BulkString(value)

--- a/code/packages/kotlin/in-memory-data-store-protocol/src/test/kotlin/com/codingadventures/inmemorydatastoreprotocol/InMemoryDataStoreProtocolTest.kt
+++ b/code/packages/kotlin/in-memory-data-store-protocol/src/test/kotlin/com/codingadventures/inmemorydatastoreprotocol/InMemoryDataStoreProtocolTest.kt
@@ -1,0 +1,31 @@
+package com.codingadventures.inmemorydatastoreprotocol
+
+import com.codingadventures.respprotocol.RespValue
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class InMemoryDataStoreProtocolTest {
+    @Test
+    fun buildsCommandFramesFromRespArrays() {
+        val frame = CommandFrame.fromRespValue(
+            RespValue.ArrayValue(
+                listOf(
+                    RespValue.BulkString("SET".encodeToByteArray()),
+                    RespValue.BulkString("alpha".encodeToByteArray()),
+                    RespValue.BulkString("1".encodeToByteArray()),
+                ),
+            ),
+        )
+
+        assertNotNull(frame)
+        assertEquals("SET", frame.command)
+        assertEquals(2, frame.args.size)
+    }
+
+    @Test
+    fun convertsResponsesBackToRespValues() {
+        assertTrue(integer(42).toRespValue() is RespValue.IntegerValue)
+    }
+}

--- a/code/packages/kotlin/in-memory-data-store/.gitignore
+++ b/code/packages/kotlin/in-memory-data-store/.gitignore
@@ -1,0 +1,5 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/
+/.kotlin/

--- a/code/packages/kotlin/in-memory-data-store/BUILD
+++ b/code/packages/kotlin/in-memory-data-store/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/in-memory-data-store/BUILD_windows
+++ b/code/packages/kotlin/in-memory-data-store/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/in-memory-data-store/CHANGELOG.md
+++ b/code/packages/kotlin/in-memory-data-store/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-16
+
+### Added
+
+- Initial JVM mini-redis core package

--- a/code/packages/kotlin/in-memory-data-store/README.md
+++ b/code/packages/kotlin/in-memory-data-store/README.md
@@ -1,0 +1,9 @@
+# in-memory-data-store
+
+Composable JVM in-memory data store facade
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/kotlin/in-memory-data-store/build.gradle.kts
+++ b/code/packages/kotlin/in-memory-data-store/build.gradle.kts
@@ -1,0 +1,38 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    api("com.codingadventures:in-memory-data-store-engine")
+    api("com.codingadventures:in-memory-data-store-protocol")
+    api("com.codingadventures:resp-protocol")
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/in-memory-data-store/required_capabilities.json
+++ b/code/packages/kotlin/in-memory-data-store/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "kotlin/in-memory-data-store",
+  "capabilities": [],
+  "justification": "Pure in-memory data structure and protocol logic. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/kotlin/in-memory-data-store/settings.gradle.kts
+++ b/code/packages/kotlin/in-memory-data-store/settings.gradle.kts
@@ -1,0 +1,4 @@
+rootProject.name = "in-memory-data-store"
+includeBuild("../in-memory-data-store-engine")
+includeBuild("../in-memory-data-store-protocol")
+includeBuild("../resp-protocol")

--- a/code/packages/kotlin/in-memory-data-store/src/main/kotlin/com/codingadventures/inmemorydatastore/DataStoreManager.kt
+++ b/code/packages/kotlin/in-memory-data-store/src/main/kotlin/com/codingadventures/inmemorydatastore/DataStoreManager.kt
@@ -1,0 +1,23 @@
+package com.codingadventures.inmemorydatastore
+
+import com.codingadventures.inmemorydatastoreengine.DataStoreEngine
+import com.codingadventures.inmemorydatastoreprotocol.CommandFrame
+import com.codingadventures.inmemorydatastoreprotocol.EngineResponse
+import com.codingadventures.inmemorydatastoreprotocol.error
+import com.codingadventures.respprotocol.RespCodec
+import com.codingadventures.respprotocol.RespValue
+
+class DataStoreManager {
+    private val engine = DataStoreEngine()
+
+    fun executeFrame(frame: CommandFrame?): EngineResponse = engine.executeFrame(frame)
+    fun executeParts(parts: List<ByteArray>): EngineResponse = executeFrame(CommandFrame.fromParts(parts))
+
+    fun executeRespBytes(request: ByteArray): ByteArray {
+        val decoded = RespCodec.decode(request)
+        val response = if (decoded == null) error("ERR incomplete RESP frame") else executeFrame(CommandFrame.fromRespValue(decoded.value))
+        return RespCodec.encode(response.toRespValue())
+    }
+
+    fun executeRespValue(value: RespValue): RespValue = executeFrame(CommandFrame.fromRespValue(value)).toRespValue()
+}

--- a/code/packages/kotlin/in-memory-data-store/src/test/kotlin/com/codingadventures/inmemorydatastore/DataStoreManagerTest.kt
+++ b/code/packages/kotlin/in-memory-data-store/src/test/kotlin/com/codingadventures/inmemorydatastore/DataStoreManagerTest.kt
@@ -1,0 +1,39 @@
+package com.codingadventures.inmemorydatastore
+
+import com.codingadventures.respprotocol.RespCodec
+import com.codingadventures.respprotocol.RespValue
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DataStoreManagerTest {
+    @Test
+    fun executesRespCommandsEndToEnd() {
+        val manager = DataStoreManager()
+        manager.executeRespBytes(
+            RespCodec.encode(
+                RespValue.ArrayValue(
+                    listOf(
+                        RespValue.BulkString("SET".encodeToByteArray()),
+                        RespValue.BulkString("alpha".encodeToByteArray()),
+                        RespValue.BulkString("1".encodeToByteArray()),
+                    ),
+                ),
+            ),
+        )
+        val decoded = RespCodec.decode(
+            manager.executeRespBytes(
+                RespCodec.encode(
+                    RespValue.ArrayValue(
+                        listOf(
+                            RespValue.BulkString("GET".encodeToByteArray()),
+                            RespValue.BulkString("alpha".encodeToByteArray()),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        val bulk = decoded?.value as RespValue.BulkString
+        assertEquals("1", bulk.value?.decodeToString())
+    }
+}

--- a/code/packages/kotlin/resp-protocol/.gitignore
+++ b/code/packages/kotlin/resp-protocol/.gitignore
@@ -1,0 +1,5 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/
+/.kotlin/

--- a/code/packages/kotlin/resp-protocol/BUILD
+++ b/code/packages/kotlin/resp-protocol/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/resp-protocol/BUILD_windows
+++ b/code/packages/kotlin/resp-protocol/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/resp-protocol/CHANGELOG.md
+++ b/code/packages/kotlin/resp-protocol/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-16
+
+### Added
+
+- Initial JVM mini-redis core package

--- a/code/packages/kotlin/resp-protocol/README.md
+++ b/code/packages/kotlin/resp-protocol/README.md
@@ -1,0 +1,9 @@
+# resp-protocol
+
+RESP2 encoder/decoder for JVM Redis-compatible transports
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/kotlin/resp-protocol/build.gradle.kts
+++ b/code/packages/kotlin/resp-protocol/build.gradle.kts
@@ -1,0 +1,35 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/resp-protocol/required_capabilities.json
+++ b/code/packages/kotlin/resp-protocol/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "kotlin/resp-protocol",
+  "capabilities": [],
+  "justification": "Pure in-memory data structure and protocol logic. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/kotlin/resp-protocol/settings.gradle.kts
+++ b/code/packages/kotlin/resp-protocol/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "resp-protocol"

--- a/code/packages/kotlin/resp-protocol/src/main/kotlin/com/codingadventures/respprotocol/RespProtocol.kt
+++ b/code/packages/kotlin/resp-protocol/src/main/kotlin/com/codingadventures/respprotocol/RespProtocol.kt
@@ -1,0 +1,88 @@
+package com.codingadventures.respprotocol
+
+import java.io.ByteArrayOutputStream
+
+sealed interface RespValue {
+    data class SimpleString(val value: String) : RespValue
+    data class ErrorString(val value: String) : RespValue
+    data class IntegerValue(val value: Long) : RespValue
+    data class BulkString(val value: ByteArray?) : RespValue
+    data class ArrayValue(val value: List<RespValue>?) : RespValue
+}
+
+data class DecodeResult(val value: RespValue, val nextOffset: Int)
+
+object RespCodec {
+    fun encode(value: RespValue): ByteArray = ByteArrayOutputStream().also { writeValue(it, value) }.toByteArray()
+
+    fun decode(bytes: ByteArray, offset: Int = 0): DecodeResult? {
+        if (offset >= bytes.size) return null
+        return when (bytes[offset].toInt().toChar()) {
+            '+' -> readLine(bytes, offset + 1)?.let { DecodeResult(RespValue.SimpleString(it.first), it.second) }
+            '-' -> readLine(bytes, offset + 1)?.let { DecodeResult(RespValue.ErrorString(it.first), it.second) }
+            ':' -> readLine(bytes, offset + 1)?.let { DecodeResult(RespValue.IntegerValue(it.first.toLong()), it.second) }
+            '$' -> decodeBulkString(bytes, offset + 1)
+            '*' -> decodeArray(bytes, offset + 1)
+            else -> error("Unknown RESP prefix: ${bytes[offset].toInt().toChar()}")
+        }
+    }
+
+    private fun decodeBulkString(bytes: ByteArray, offset: Int): DecodeResult? {
+        val (lengthText, nextOffset) = readLine(bytes, offset) ?: return null
+        val length = lengthText.toInt()
+        if (length == -1) return DecodeResult(RespValue.BulkString(null), nextOffset)
+        if (nextOffset + length + 2 > bytes.size) return null
+        val payload = bytes.copyOfRange(nextOffset, nextOffset + length)
+        return DecodeResult(RespValue.BulkString(payload), nextOffset + length + 2)
+    }
+
+    private fun decodeArray(bytes: ByteArray, offset: Int): DecodeResult? {
+        val (countText, startOffset) = readLine(bytes, offset) ?: return null
+        val count = countText.toInt()
+        if (count == -1) return DecodeResult(RespValue.ArrayValue(null), startOffset)
+        val values = mutableListOf<RespValue>()
+        var cursor = startOffset
+        repeat(count) {
+            val decoded = decode(bytes, cursor) ?: return null
+            values += decoded.value
+            cursor = decoded.nextOffset
+        }
+        return DecodeResult(RespValue.ArrayValue(values), cursor)
+    }
+
+    private fun writeValue(out: ByteArrayOutputStream, value: RespValue) {
+        when (value) {
+            is RespValue.SimpleString -> writeRaw(out, "+${value.value}\r\n")
+            is RespValue.ErrorString -> writeRaw(out, "-${value.value}\r\n")
+            is RespValue.IntegerValue -> writeRaw(out, ":${value.value}\r\n")
+            is RespValue.BulkString -> {
+                if (value.value == null) {
+                    writeRaw(out, "$-1\r\n")
+                } else {
+                    writeRaw(out, "$${value.value.size}\r\n")
+                    out.write(value.value)
+                    writeRaw(out, "\r\n")
+                }
+            }
+            is RespValue.ArrayValue -> {
+                if (value.value == null) {
+                    writeRaw(out, "*-1\r\n")
+                } else {
+                    writeRaw(out, "*${value.value.size}\r\n")
+                    value.value.forEach { writeValue(out, it) }
+                }
+            }
+        }
+    }
+
+    private fun writeRaw(out: ByteArrayOutputStream, value: String) = out.write(value.toByteArray())
+
+    private fun readLine(bytes: ByteArray, offset: Int): Pair<String, Int>? {
+        for (index in offset until bytes.size - 1) {
+            if (bytes[index] == '\r'.code.toByte() && bytes[index + 1] == '\n'.code.toByte()) {
+                return String(bytes, offset, index - offset) to (index + 2)
+            }
+        }
+        return null
+    }
+}

--- a/code/packages/kotlin/resp-protocol/src/test/kotlin/com/codingadventures/respprotocol/RespProtocolTest.kt
+++ b/code/packages/kotlin/resp-protocol/src/test/kotlin/com/codingadventures/respprotocol/RespProtocolTest.kt
@@ -1,0 +1,28 @@
+package com.codingadventures.respprotocol
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class RespProtocolTest {
+    @Test
+    fun encodesAndDecodesArrayCommands() {
+        val encoded = RespCodec.encode(
+            RespValue.ArrayValue(
+                listOf(
+                    RespValue.BulkString("PING".encodeToByteArray()),
+                    RespValue.BulkString("hello".encodeToByteArray()),
+                ),
+            ),
+        )
+        val decoded = RespCodec.decode(encoded)
+        assertNotNull(decoded)
+        assertEquals(encoded.size, decoded.nextOffset)
+    }
+
+    @Test
+    fun returnsNullForIncompleteFrames() {
+        assertNull(RespCodec.decode("$5\r\nhel".encodeToByteArray()))
+    }
+}


### PR DESCRIPTION
## Summary
- add Java and Kotlin `hash-map`, `hash-set`, and `heap` packages as Mini-Redis core building blocks
- add Java and Kotlin RESP and in-memory data store protocol packages for command/request-response framing
- add Java and Kotlin in-memory data store engine and manager packages so a future TCP server can hand off raw RESP bytes directly

## Testing
- `gradle test --rerun-tasks` in `code/packages/java/hash-map`
- `gradle test --rerun-tasks` in `code/packages/kotlin/hash-map`
- `gradle test --rerun-tasks` in `code/packages/java/in-memory-data-store-engine`
- `gradle clean test --rerun-tasks --no-daemon` in `code/packages/kotlin/in-memory-data-store-engine`
- `gradle test --rerun-tasks` in `code/packages/java/in-memory-data-store`
- `gradle test --rerun-tasks` in `code/packages/kotlin/in-memory-data-store`
- previously validated in this worktree: `gradle test` in `code/packages/java/hash-set`, `code/packages/java/heap`, `code/packages/java/resp-protocol`, `code/packages/java/in-memory-data-store-protocol`, `code/packages/kotlin/hash-set`, `code/packages/kotlin/heap`, `code/packages/kotlin/resp-protocol`, and `code/packages/kotlin/in-memory-data-store-protocol`

## Follow-ups
- port `skip-list` and `hyperloglog` so sorted-set and HLL commands can land on JVM as well
- fill in the remaining Mini-Redis command families from `DT25-mini-redis.md` after the lower-level structures are in place
- add the TCP server package on top once the internal core is complete