### PR TITLE
[codex] Add Dart grammar-tools package

### DIFF
--- a/code/packages/dart/grammar-tools/.gitignore
+++ b/code/packages/dart/grammar-tools/.gitignore
@@ -1,0 +1,2 @@
+.dart_tool/
+pubspec.lock

--- a/code/packages/dart/grammar-tools/BUILD
+++ b/code/packages/dart/grammar-tools/BUILD
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/grammar-tools/BUILD_windows
+++ b/code/packages/dart/grammar-tools/BUILD_windows
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/grammar-tools/CHANGELOG.md
+++ b/code/packages/dart/grammar-tools/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Initial Dart port of `grammar-tools`.
+- Added `.tokens` parsing and validation.
+- Added `.grammar` parsing and validation.
+- Added cross-validation and source compilation helpers.

--- a/code/packages/dart/grammar-tools/README.md
+++ b/code/packages/dart/grammar-tools/README.md
@@ -1,0 +1,12 @@
+# coding_adventures_grammar_tools
+
+Parsers, validators, and source compilers for the shared `.tokens` and
+`.grammar` formats used across the repository.
+
+This is the first Dart bring-up of the grammar-driven toolchain. It is meant
+to unblock the Dart lexer/parser ports by handling:
+
+- `.tokens` parsing into `TokenGrammar`
+- `.grammar` parsing into `ParserGrammar`
+- token/parser cross-validation
+- source-code compilation into embedded Dart objects

--- a/code/packages/dart/grammar-tools/lib/grammar_tools.dart
+++ b/code/packages/dart/grammar-tools/lib/grammar_tools.dart
@@ -1,0 +1,6 @@
+library;
+
+export 'src/compiler.dart';
+export 'src/cross_validator.dart';
+export 'src/parser_grammar.dart';
+export 'src/token_grammar.dart';

--- a/code/packages/dart/grammar-tools/lib/src/compiler.dart
+++ b/code/packages/dart/grammar-tools/lib/src/compiler.dart
@@ -1,0 +1,149 @@
+import 'dart:convert';
+
+import 'parser_grammar.dart';
+import 'token_grammar.dart';
+
+String compileTokenGrammar(TokenGrammar grammar, {String sourceFile = ''}) {
+  final sanitizedSource = sourceFile
+      .replaceAll('\n', '_')
+      .replaceAll('\r', '_');
+  final sourceLine = sanitizedSource.isEmpty
+      ? ''
+      : '// Source: $sanitizedSource\n';
+
+  return [
+    '// AUTO-GENERATED FILE - DO NOT EDIT',
+    if (sourceLine.isNotEmpty) sourceLine.trimRight(),
+    '// Regenerate with: grammar-tools compile-tokens <source.tokens>',
+    "import 'package:coding_adventures_grammar_tools/grammar_tools.dart';",
+    '',
+    'final tokenGrammar = ${_compileTokenGrammarValue(grammar)};',
+    '',
+  ].join('\n');
+}
+
+String compileParserGrammar(ParserGrammar grammar, {String sourceFile = ''}) {
+  final sanitizedSource = sourceFile
+      .replaceAll('\n', '_')
+      .replaceAll('\r', '_');
+  final sourceLine = sanitizedSource.isEmpty
+      ? ''
+      : '// Source: $sanitizedSource\n';
+
+  return [
+    '// AUTO-GENERATED FILE - DO NOT EDIT',
+    if (sourceLine.isNotEmpty) sourceLine.trimRight(),
+    '// Regenerate with: grammar-tools compile-grammar <source.grammar>',
+    "import 'package:coding_adventures_grammar_tools/grammar_tools.dart';",
+    '',
+    'final parserGrammar = ${_compileParserGrammarValue(grammar)};',
+    '',
+  ].join('\n');
+}
+
+String _compileTokenGrammarValue(TokenGrammar grammar) {
+  return '''
+TokenGrammar(
+  version: ${grammar.version},
+  caseInsensitive: ${grammar.caseInsensitive},
+  definitions: ${_compileTokenDefinitionList(grammar.definitions)},
+  keywords: ${_compileStringList(grammar.keywords)},
+  mode: ${_compileNullableString(grammar.mode)},
+  skipDefinitions: ${_compileTokenDefinitionList(grammar.skipDefinitions)},
+  reservedKeywords: ${_compileStringList(grammar.reservedKeywords)},
+  escapeMode: ${_compileNullableString(grammar.escapeMode)},
+  errorDefinitions: ${_compileTokenDefinitionList(grammar.errorDefinitions)},
+  groups: ${_compileGroups(grammar.groups)},
+  caseSensitive: ${grammar.caseSensitive},
+  contextKeywords: ${_compileStringList(grammar.contextKeywords)},
+  softKeywords: ${_compileStringList(grammar.softKeywords)},
+)''';
+}
+
+String _compileParserGrammarValue(ParserGrammar grammar) {
+  return '''
+ParserGrammar(
+  version: ${grammar.version},
+  rules: [
+${grammar.rules.map((rule) => '    ${_compileRule(rule)},').join('\n')}
+  ],
+)''';
+}
+
+String _compileRule(GrammarRule rule) {
+  return 'GrammarRule(name: ${jsonEncode(rule.name)}, body: ${_compileElement(rule.body)}, lineNumber: ${rule.lineNumber})';
+}
+
+String _compileTokenDefinitionList(List<TokenDefinition> definitions) {
+  if (definitions.isEmpty) {
+    return 'const []';
+  }
+  final items = definitions
+      .map((definition) => '    ${_compileTokenDefinition(definition)},')
+      .join('\n');
+  return '[\n$items\n  ]';
+}
+
+String _compileTokenDefinition(TokenDefinition definition) {
+  return 'TokenDefinition(name: ${jsonEncode(definition.name)}, pattern: ${jsonEncode(definition.pattern)}, isRegex: ${definition.isRegex}, lineNumber: ${definition.lineNumber}, alias: ${_compileNullableString(definition.alias)})';
+}
+
+String _compileStringList(List<String> values) {
+  if (values.isEmpty) {
+    return 'const []';
+  }
+  return '[${values.map(jsonEncode).join(', ')}]';
+}
+
+String _compileNullableString(String? value) =>
+    value == null ? 'null' : jsonEncode(value);
+
+String _compileGroups(Map<String, PatternGroup> groups) {
+  if (groups.isEmpty) {
+    return 'const {}';
+  }
+  final entries = groups.entries
+      .map(
+        (entry) =>
+            '    ${jsonEncode(entry.key)}: PatternGroup(name: ${jsonEncode(entry.value.name)}, definitions: ${_compileTokenDefinitionList(entry.value.definitions)}),',
+      )
+      .join('\n');
+  return '{\n$entries\n  }';
+}
+
+String _compileElement(GrammarElement element) {
+  if (element is RuleReference) {
+    return 'RuleReference(${jsonEncode(element.name)}, isToken: ${element.isToken})';
+  }
+  if (element is Literal) {
+    return 'Literal(${jsonEncode(element.value)})';
+  }
+  if (element is Sequence) {
+    return 'Sequence(elements: [${element.elements.map(_compileElement).join(', ')}])';
+  }
+  if (element is Alternation) {
+    return 'Alternation(choices: [${element.choices.map(_compileElement).join(', ')}])';
+  }
+  if (element is Repetition) {
+    return 'Repetition(element: ${_compileElement(element.element)})';
+  }
+  if (element is Optional) {
+    return 'Optional(element: ${_compileElement(element.element)})';
+  }
+  if (element is Group) {
+    return 'Group(element: ${_compileElement(element.element)})';
+  }
+  if (element is PositiveLookahead) {
+    return 'PositiveLookahead(element: ${_compileElement(element.element)})';
+  }
+  if (element is NegativeLookahead) {
+    return 'NegativeLookahead(element: ${_compileElement(element.element)})';
+  }
+  if (element is OneOrMoreRepetition) {
+    return 'OneOrMoreRepetition(element: ${_compileElement(element.element)})';
+  }
+  if (element is SeparatedRepetition) {
+    return 'SeparatedRepetition(element: ${_compileElement(element.element)}, separator: ${_compileElement(element.separator)}, atLeastOne: ${element.atLeastOne})';
+  }
+  throw ArgumentError('Unsupported grammar element: $element');
+}

--- a/code/packages/dart/grammar-tools/lib/src/cross_validator.dart
+++ b/code/packages/dart/grammar-tools/lib/src/cross_validator.dart
@@ -1,0 +1,40 @@
+import 'parser_grammar.dart';
+import 'token_grammar.dart';
+
+List<String> crossValidate(
+  TokenGrammar tokenGrammar,
+  ParserGrammar parserGrammar,
+) {
+  final issues = <String>[];
+  final definedTokens = tokenGrammar.tokenNames();
+
+  if (tokenGrammar.mode == 'indentation') {
+    definedTokens.addAll(const {'INDENT', 'DEDENT', 'NEWLINE'});
+  }
+  definedTokens.addAll(const {'NEWLINE', 'EOF'});
+
+  final referencedTokens = parserGrammar.tokenReferences();
+  for (final reference in referencedTokens.toList()..sort()) {
+    if (!definedTokens.contains(reference)) {
+      issues.add(
+        "Error: Grammar references token '$reference' which is not defined in the tokens file",
+      );
+    }
+  }
+
+  for (final definition in tokenGrammar.definitions) {
+    var isUsed = referencedTokens.contains(definition.name);
+    final alias = definition.alias;
+    if (alias != null && referencedTokens.contains(alias)) {
+      isUsed = true;
+    }
+
+    if (!isUsed) {
+      issues.add(
+        "Warning: Token '${definition.name}' (line ${definition.lineNumber}) is defined but never used in the grammar",
+      );
+    }
+  }
+
+  return issues;
+}

--- a/code/packages/dart/grammar-tools/lib/src/parser_grammar.dart
+++ b/code/packages/dart/grammar-tools/lib/src/parser_grammar.dart
@@ -1,0 +1,697 @@
+final RegExp _parserMagicCommentPattern = RegExp(r'^#\s*@(\w+)\s*(.*)$');
+
+class ParserGrammarError implements Exception {
+  ParserGrammarError(this.message, this.lineNumber);
+
+  final String message;
+  final int lineNumber;
+
+  @override
+  String toString() => 'Line $lineNumber: $message';
+}
+
+abstract class GrammarElement {
+  const GrammarElement();
+}
+
+class RuleReference extends GrammarElement {
+  const RuleReference(this.name, {required this.isToken});
+
+  final String name;
+  final bool isToken;
+
+  @override
+  bool operator ==(Object other) {
+    return other is RuleReference &&
+        other.name == name &&
+        other.isToken == isToken;
+  }
+
+  @override
+  int get hashCode => Object.hash(name, isToken);
+}
+
+class Literal extends GrammarElement {
+  const Literal(this.value);
+
+  final String value;
+
+  @override
+  bool operator ==(Object other) => other is Literal && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
+}
+
+class Sequence extends GrammarElement {
+  const Sequence({required this.elements});
+
+  final List<GrammarElement> elements;
+
+  @override
+  bool operator ==(Object other) {
+    return other is Sequence && _grammarListEquals(other.elements, elements);
+  }
+
+  @override
+  int get hashCode => Object.hashAll(elements);
+}
+
+class Alternation extends GrammarElement {
+  const Alternation({required this.choices});
+
+  final List<GrammarElement> choices;
+
+  @override
+  bool operator ==(Object other) {
+    return other is Alternation && _grammarListEquals(other.choices, choices);
+  }
+
+  @override
+  int get hashCode => Object.hashAll(choices);
+}
+
+class Repetition extends GrammarElement {
+  const Repetition({required this.element});
+
+  final GrammarElement element;
+
+  @override
+  bool operator ==(Object other) =>
+      other is Repetition && other.element == element;
+
+  @override
+  int get hashCode => element.hashCode;
+}
+
+class Optional extends GrammarElement {
+  const Optional({required this.element});
+
+  final GrammarElement element;
+
+  @override
+  bool operator ==(Object other) =>
+      other is Optional && other.element == element;
+
+  @override
+  int get hashCode => element.hashCode;
+}
+
+class Group extends GrammarElement {
+  const Group({required this.element});
+
+  final GrammarElement element;
+
+  @override
+  bool operator ==(Object other) => other is Group && other.element == element;
+
+  @override
+  int get hashCode => element.hashCode;
+}
+
+class PositiveLookahead extends GrammarElement {
+  const PositiveLookahead({required this.element});
+
+  final GrammarElement element;
+
+  @override
+  bool operator ==(Object other) {
+    return other is PositiveLookahead && other.element == element;
+  }
+
+  @override
+  int get hashCode => element.hashCode;
+}
+
+class NegativeLookahead extends GrammarElement {
+  const NegativeLookahead({required this.element});
+
+  final GrammarElement element;
+
+  @override
+  bool operator ==(Object other) {
+    return other is NegativeLookahead && other.element == element;
+  }
+
+  @override
+  int get hashCode => element.hashCode;
+}
+
+class OneOrMoreRepetition extends GrammarElement {
+  const OneOrMoreRepetition({required this.element});
+
+  final GrammarElement element;
+
+  @override
+  bool operator ==(Object other) {
+    return other is OneOrMoreRepetition && other.element == element;
+  }
+
+  @override
+  int get hashCode => element.hashCode;
+}
+
+class SeparatedRepetition extends GrammarElement {
+  const SeparatedRepetition({
+    required this.element,
+    required this.separator,
+    required this.atLeastOne,
+  });
+
+  final GrammarElement element;
+  final GrammarElement separator;
+  final bool atLeastOne;
+
+  @override
+  bool operator ==(Object other) {
+    return other is SeparatedRepetition &&
+        other.element == element &&
+        other.separator == separator &&
+        other.atLeastOne == atLeastOne;
+  }
+
+  @override
+  int get hashCode => Object.hash(element, separator, atLeastOne);
+}
+
+class GrammarRule {
+  const GrammarRule({
+    required this.name,
+    required this.body,
+    required this.lineNumber,
+  });
+
+  final String name;
+  final GrammarElement body;
+  final int lineNumber;
+
+  @override
+  bool operator ==(Object other) {
+    return other is GrammarRule &&
+        other.name == name &&
+        other.body == body &&
+        other.lineNumber == lineNumber;
+  }
+
+  @override
+  int get hashCode => Object.hash(name, body, lineNumber);
+}
+
+class ParserGrammar {
+  const ParserGrammar({this.version = 0, this.rules = const []});
+
+  final int version;
+  final List<GrammarRule> rules;
+
+  Set<String> ruleNames() => rules.map((rule) => rule.name).toSet();
+
+  Set<String> tokenReferences() {
+    final refs = <String>{};
+    for (final rule in rules) {
+      _collectTokenRefs(rule.body, refs);
+    }
+    return refs;
+  }
+
+  Set<String> ruleReferences() {
+    final refs = <String>{};
+    for (final rule in rules) {
+      _collectRuleRefs(rule.body, refs);
+    }
+    return refs;
+  }
+}
+
+class _GrammarToken {
+  const _GrammarToken(this.kind, this.value, this.line);
+
+  final String kind;
+  final String value;
+  final int line;
+}
+
+ParserGrammar parseParserGrammar(String source) {
+  var version = 0;
+  for (final rawLine in source.split('\n')) {
+    final stripped = rawLine.trim();
+    if (!stripped.startsWith('#')) {
+      continue;
+    }
+    final match = _parserMagicCommentPattern.firstMatch(stripped);
+    if (match != null && match.group(1) == 'version') {
+      final parsed = int.tryParse((match.group(2) ?? '').trim());
+      if (parsed != null) {
+        version = parsed;
+      }
+    }
+  }
+
+  final parser = _Parser(_tokenizeGrammar(source));
+  return ParserGrammar(version: version, rules: parser.parse());
+}
+
+List<String> validateParserGrammar(
+  ParserGrammar grammar, {
+  Set<String>? tokenNames,
+}) {
+  final issues = <String>[];
+  final defined = grammar.ruleNames();
+  final referencedRules = grammar.ruleReferences();
+  final referencedTokens = grammar.tokenReferences();
+
+  final seen = <String, int>{};
+  for (final rule in grammar.rules) {
+    final firstLine = seen[rule.name];
+    if (firstLine != null) {
+      issues.add(
+        "Line ${rule.lineNumber}: Duplicate rule name '${rule.name}' (first defined on line $firstLine)",
+      );
+    } else {
+      seen[rule.name] = rule.lineNumber;
+    }
+  }
+
+  for (final rule in grammar.rules) {
+    if (rule.name != rule.name.toLowerCase()) {
+      issues.add(
+        "Line ${rule.lineNumber}: Rule name '${rule.name}' should be lowercase",
+      );
+    }
+  }
+
+  for (final reference in referencedRules.toList()..sort()) {
+    if (!defined.contains(reference)) {
+      issues.add("Undefined rule reference: '$reference'");
+    }
+  }
+
+  if (tokenNames != null) {
+    const syntheticTokens = {'NEWLINE', 'INDENT', 'DEDENT', 'EOF'};
+    for (final reference in referencedTokens.toList()..sort()) {
+      if (!tokenNames.contains(reference) &&
+          !syntheticTokens.contains(reference)) {
+        issues.add("Undefined token reference: '$reference'");
+      }
+    }
+  }
+
+  if (grammar.rules.isNotEmpty) {
+    final startRule = grammar.rules.first.name;
+    for (final rule in grammar.rules) {
+      if (rule.name != startRule && !referencedRules.contains(rule.name)) {
+        issues.add(
+          "Line ${rule.lineNumber}: Rule '${rule.name}' is defined but never referenced (unreachable)",
+        );
+      }
+    }
+  }
+
+  return issues;
+}
+
+List<_GrammarToken> _tokenizeGrammar(String source) {
+  final tokens = <_GrammarToken>[];
+  final lines = source.split('\n');
+
+  for (var index = 0; index < lines.length; index++) {
+    final lineNumber = index + 1;
+    final line = lines[index].replaceFirst(RegExp(r'\r$'), '');
+    final stripped = line.trim();
+
+    if (stripped.isEmpty || stripped.startsWith('#')) {
+      continue;
+    }
+
+    var cursor = 0;
+    while (cursor < line.length) {
+      final char = line[cursor];
+      if (char == ' ' || char == '\t') {
+        cursor += 1;
+        continue;
+      }
+      if (char == '#') {
+        break;
+      }
+      switch (char) {
+        case '=':
+          tokens.add(_GrammarToken('EQUALS', '=', lineNumber));
+          cursor += 1;
+          continue;
+        case ';':
+          tokens.add(_GrammarToken('SEMI', ';', lineNumber));
+          cursor += 1;
+          continue;
+        case '|':
+          tokens.add(_GrammarToken('PIPE', '|', lineNumber));
+          cursor += 1;
+          continue;
+        case '{':
+          tokens.add(_GrammarToken('LBRACE', '{', lineNumber));
+          cursor += 1;
+          continue;
+        case '}':
+          tokens.add(_GrammarToken('RBRACE', '}', lineNumber));
+          cursor += 1;
+          continue;
+        case '[':
+          tokens.add(_GrammarToken('LBRACKET', '[', lineNumber));
+          cursor += 1;
+          continue;
+        case ']':
+          tokens.add(_GrammarToken('RBRACKET', ']', lineNumber));
+          cursor += 1;
+          continue;
+        case '(':
+          tokens.add(_GrammarToken('LPAREN', '(', lineNumber));
+          cursor += 1;
+          continue;
+        case ')':
+          tokens.add(_GrammarToken('RPAREN', ')', lineNumber));
+          cursor += 1;
+          continue;
+        case '&':
+          tokens.add(_GrammarToken('AMPERSAND', '&', lineNumber));
+          cursor += 1;
+          continue;
+        case '!':
+          tokens.add(_GrammarToken('BANG', '!', lineNumber));
+          cursor += 1;
+          continue;
+        case '+':
+          tokens.add(_GrammarToken('PLUS', '+', lineNumber));
+          cursor += 1;
+          continue;
+        case '/':
+          if (cursor + 1 < line.length && line[cursor + 1] == '/') {
+            tokens.add(_GrammarToken('DOUBLE_SLASH', '//', lineNumber));
+            cursor += 2;
+            continue;
+          }
+          throw ParserGrammarError("Unexpected character: '$char'", lineNumber);
+        case '"':
+          final end = _findGrammarStringEnd(line, cursor);
+          if (end == -1) {
+            throw ParserGrammarError('Unterminated string literal', lineNumber);
+          }
+          tokens.add(
+            _GrammarToken(
+              'STRING',
+              line.substring(cursor + 1, end),
+              lineNumber,
+            ),
+          );
+          cursor = end + 1;
+          continue;
+        default:
+          if (_isIdentifierStart(char)) {
+            var end = cursor + 1;
+            while (end < line.length && _isIdentifierPart(line[end])) {
+              end += 1;
+            }
+            tokens.add(
+              _GrammarToken('IDENT', line.substring(cursor, end), lineNumber),
+            );
+            cursor = end;
+            continue;
+          }
+          throw ParserGrammarError("Unexpected character: '$char'", lineNumber);
+      }
+    }
+  }
+
+  tokens.add(_GrammarToken('EOF', '', lines.length));
+  return tokens;
+}
+
+int _findGrammarStringEnd(String line, int start) {
+  var index = start + 1;
+  while (index < line.length) {
+    final char = line[index];
+    if (char == r'\') {
+      index += 2;
+      continue;
+    }
+    if (char == '"') {
+      return index;
+    }
+    index += 1;
+  }
+  return -1;
+}
+
+bool _isIdentifierStart(String char) => RegExp(r'[A-Za-z_]').hasMatch(char);
+bool _isIdentifierPart(String char) => RegExp(r'[A-Za-z0-9_]').hasMatch(char);
+
+class _Parser {
+  _Parser(this._tokens);
+
+  final List<_GrammarToken> _tokens;
+  int _position = 0;
+
+  List<GrammarRule> parse() {
+    final rules = <GrammarRule>[];
+    while (_peek().kind != 'EOF') {
+      rules.add(_parseRule());
+    }
+    return rules;
+  }
+
+  GrammarRule _parseRule() {
+    final name = _expect('IDENT');
+    _expect('EQUALS');
+    final body = _parseBody();
+    _expect('SEMI');
+    return GrammarRule(name: name.value, body: body, lineNumber: name.line);
+  }
+
+  GrammarElement _parseBody() {
+    final first = _parseSequence();
+    final choices = <GrammarElement>[first];
+    while (_peek().kind == 'PIPE') {
+      _advance();
+      choices.add(_parseSequence());
+    }
+    if (choices.length == 1) {
+      return choices.first;
+    }
+    return Alternation(choices: choices);
+  }
+
+  GrammarElement _parseSequence() {
+    final elements = <GrammarElement>[];
+    while (!const {
+      'PIPE',
+      'SEMI',
+      'RBRACE',
+      'RBRACKET',
+      'RPAREN',
+      'DOUBLE_SLASH',
+      'EOF',
+    }.contains(_peek().kind)) {
+      elements.add(_parseElement());
+    }
+    if (elements.isEmpty) {
+      throw ParserGrammarError(
+        'Expected at least one element in sequence',
+        _peek().line,
+      );
+    }
+    if (elements.length == 1) {
+      return elements.first;
+    }
+    return Sequence(elements: elements);
+  }
+
+  GrammarElement _parseElement() {
+    final token = _peek();
+    switch (token.kind) {
+      case 'AMPERSAND':
+        _advance();
+        return PositiveLookahead(element: _parseElement());
+      case 'BANG':
+        _advance();
+        return NegativeLookahead(element: _parseElement());
+      case 'IDENT':
+        _advance();
+        final value = token.value;
+        final isToken =
+            value == value.toUpperCase() && _isIdentifierStart(value[0]);
+        return RuleReference(value, isToken: isToken);
+      case 'STRING':
+        _advance();
+        return Literal(token.value);
+      case 'LBRACE':
+        _advance();
+        final body = _parseBody();
+        if (_peek().kind == 'DOUBLE_SLASH') {
+          _advance();
+          final separator = _parseBody();
+          _expect('RBRACE');
+          final atLeastOne = _peek().kind == 'PLUS';
+          if (atLeastOne) {
+            _advance();
+          }
+          return SeparatedRepetition(
+            element: body,
+            separator: separator,
+            atLeastOne: atLeastOne,
+          );
+        }
+        _expect('RBRACE');
+        if (_peek().kind == 'PLUS') {
+          _advance();
+          return OneOrMoreRepetition(element: body);
+        }
+        return Repetition(element: body);
+      case 'LBRACKET':
+        _advance();
+        final body = _parseBody();
+        _expect('RBRACKET');
+        return Optional(element: body);
+      case 'LPAREN':
+        _advance();
+        final body = _parseBody();
+        _expect('RPAREN');
+        return Group(element: body);
+      default:
+        throw ParserGrammarError(
+          "Unexpected token: ${token.kind} ('${token.value}')",
+          token.line,
+        );
+    }
+  }
+
+  _GrammarToken _peek() => _tokens[_position];
+
+  _GrammarToken _advance() => _tokens[_position++];
+
+  _GrammarToken _expect(String kind) {
+    final token = _advance();
+    if (token.kind != kind) {
+      throw ParserGrammarError(
+        'Expected $kind, got ${token.kind} (\'${token.value}\')',
+        token.line,
+      );
+    }
+    return token;
+  }
+}
+
+void _collectTokenRefs(GrammarElement node, Set<String> refs) {
+  if (node is RuleReference) {
+    if (node.isToken) {
+      refs.add(node.name);
+    }
+    return;
+  }
+  if (node is Literal) {
+    return;
+  }
+  if (node is Sequence) {
+    for (final element in node.elements) {
+      _collectTokenRefs(element, refs);
+    }
+    return;
+  }
+  if (node is Alternation) {
+    for (final choice in node.choices) {
+      _collectTokenRefs(choice, refs);
+    }
+    return;
+  }
+  if (node is Repetition) {
+    _collectTokenRefs(node.element, refs);
+    return;
+  }
+  if (node is Optional) {
+    _collectTokenRefs(node.element, refs);
+    return;
+  }
+  if (node is Group) {
+    _collectTokenRefs(node.element, refs);
+    return;
+  }
+  if (node is PositiveLookahead) {
+    _collectTokenRefs(node.element, refs);
+    return;
+  }
+  if (node is NegativeLookahead) {
+    _collectTokenRefs(node.element, refs);
+    return;
+  }
+  if (node is OneOrMoreRepetition) {
+    _collectTokenRefs(node.element, refs);
+    return;
+  }
+  if (node is SeparatedRepetition) {
+    _collectTokenRefs(node.element, refs);
+    _collectTokenRefs(node.separator, refs);
+  }
+}
+
+void _collectRuleRefs(GrammarElement node, Set<String> refs) {
+  if (node is RuleReference) {
+    if (!node.isToken) {
+      refs.add(node.name);
+    }
+    return;
+  }
+  if (node is Literal) {
+    return;
+  }
+  if (node is Sequence) {
+    for (final element in node.elements) {
+      _collectRuleRefs(element, refs);
+    }
+    return;
+  }
+  if (node is Alternation) {
+    for (final choice in node.choices) {
+      _collectRuleRefs(choice, refs);
+    }
+    return;
+  }
+  if (node is Repetition) {
+    _collectRuleRefs(node.element, refs);
+    return;
+  }
+  if (node is Optional) {
+    _collectRuleRefs(node.element, refs);
+    return;
+  }
+  if (node is Group) {
+    _collectRuleRefs(node.element, refs);
+    return;
+  }
+  if (node is PositiveLookahead) {
+    _collectRuleRefs(node.element, refs);
+    return;
+  }
+  if (node is NegativeLookahead) {
+    _collectRuleRefs(node.element, refs);
+    return;
+  }
+  if (node is OneOrMoreRepetition) {
+    _collectRuleRefs(node.element, refs);
+    return;
+  }
+  if (node is SeparatedRepetition) {
+    _collectRuleRefs(node.element, refs);
+    _collectRuleRefs(node.separator, refs);
+  }
+}
+
+bool _grammarListEquals(List<GrammarElement> left, List<GrammarElement> right) {
+  if (identical(left, right)) {
+    return true;
+  }
+  if (left.length != right.length) {
+    return false;
+  }
+  for (var index = 0; index < left.length; index++) {
+    if (left[index] != right[index]) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/code/packages/dart/grammar-tools/lib/src/token_grammar.dart
+++ b/code/packages/dart/grammar-tools/lib/src/token_grammar.dart
@@ -1,0 +1,583 @@
+import 'dart:collection';
+
+final RegExp _magicCommentPattern = RegExp(r'^#\s*@(\w+)\s*(.*)$');
+
+class TokenGrammarError implements Exception {
+  TokenGrammarError(this.message, this.lineNumber);
+
+  final String message;
+  final int lineNumber;
+
+  @override
+  String toString() => 'Line $lineNumber: $message';
+}
+
+class TokenDefinition {
+  const TokenDefinition({
+    required this.name,
+    required this.pattern,
+    required this.isRegex,
+    required this.lineNumber,
+    this.alias,
+  });
+
+  final String name;
+  final String pattern;
+  final bool isRegex;
+  final int lineNumber;
+  final String? alias;
+
+  @override
+  bool operator ==(Object other) {
+    return other is TokenDefinition &&
+        other.name == name &&
+        other.pattern == pattern &&
+        other.isRegex == isRegex &&
+        other.lineNumber == lineNumber &&
+        other.alias == alias;
+  }
+
+  @override
+  int get hashCode => Object.hash(name, pattern, isRegex, lineNumber, alias);
+}
+
+class PatternGroup {
+  const PatternGroup({required this.name, required this.definitions});
+
+  final String name;
+  final List<TokenDefinition> definitions;
+
+  @override
+  bool operator ==(Object other) {
+    return other is PatternGroup &&
+        other.name == name &&
+        _listEquals(other.definitions, definitions);
+  }
+
+  @override
+  int get hashCode => Object.hash(name, Object.hashAll(definitions));
+}
+
+class TokenGrammar {
+  TokenGrammar({
+    this.version = 0,
+    this.caseInsensitive = false,
+    this.definitions = const [],
+    this.keywords = const [],
+    this.mode,
+    this.skipDefinitions = const [],
+    this.reservedKeywords = const [],
+    this.escapeMode,
+    this.errorDefinitions = const [],
+    Map<String, PatternGroup> groups = const {},
+    this.caseSensitive = true,
+    this.contextKeywords = const [],
+    this.softKeywords = const [],
+  }) : groups = UnmodifiableMapView(Map<String, PatternGroup>.from(groups));
+
+  final int version;
+  final bool caseInsensitive;
+  final List<TokenDefinition> definitions;
+  final List<String> keywords;
+  final String? mode;
+  final List<TokenDefinition> skipDefinitions;
+  final List<String> reservedKeywords;
+  final String? escapeMode;
+  final List<TokenDefinition> errorDefinitions;
+  final Map<String, PatternGroup> groups;
+  final bool caseSensitive;
+  final List<String> contextKeywords;
+  final List<String> softKeywords;
+
+  Set<String> tokenNames() {
+    final names = <String>{};
+    for (final definition in _allDefinitions()) {
+      names.add(definition.name);
+      final alias = definition.alias;
+      if (alias != null) {
+        names.add(alias);
+      }
+    }
+    return names;
+  }
+
+  Set<String> effectiveTokenNames() {
+    return _allDefinitions()
+        .map((definition) => definition.alias ?? definition.name)
+        .toSet();
+  }
+
+  Iterable<TokenDefinition> _allDefinitions() sync* {
+    yield* definitions;
+    for (final group in groups.values) {
+      yield* group.definitions;
+    }
+  }
+}
+
+TokenGrammar parseTokenGrammar(String source) {
+  var version = 0;
+  var caseInsensitive = false;
+  String? mode;
+  String? escapeMode;
+  var caseSensitive = true;
+
+  final definitions = <TokenDefinition>[];
+  final keywords = <String>[];
+  final skipDefinitions = <TokenDefinition>[];
+  final reservedKeywords = <String>[];
+  final errorDefinitions = <TokenDefinition>[];
+  final groups = <String, PatternGroup>{};
+  final contextKeywords = <String>[];
+  final softKeywords = <String>[];
+
+  String? currentSection;
+  final lines = source.split('\n');
+
+  for (var index = 0; index < lines.length; index++) {
+    final lineNumber = index + 1;
+    final line = lines[index].replaceFirst(RegExp(r'\r$'), '');
+    final stripped = line.trim();
+
+    if (stripped.isEmpty) {
+      continue;
+    }
+
+    if (stripped.startsWith('#')) {
+      final match = _magicCommentPattern.firstMatch(stripped);
+      if (match != null) {
+        final key = match.group(1)!;
+        final value = (match.group(2) ?? '').trim();
+        if (key == 'version') {
+          final parsed = int.tryParse(value);
+          if (parsed != null) {
+            version = parsed;
+          }
+        } else if (key == 'case_insensitive') {
+          caseInsensitive = value == 'true';
+        }
+      }
+      continue;
+    }
+
+    if (stripped.startsWith('mode:')) {
+      final value = stripped.substring(5).trim();
+      if (value.isEmpty) {
+        throw TokenGrammarError("Missing value after 'mode:'", lineNumber);
+      }
+      mode = value;
+      currentSection = null;
+      continue;
+    }
+
+    if (stripped.startsWith('escapes:')) {
+      final value = stripped.substring(8).trim();
+      if (value.isEmpty) {
+        throw TokenGrammarError("Missing value after 'escapes:'", lineNumber);
+      }
+      escapeMode = value;
+      currentSection = null;
+      continue;
+    }
+
+    if (stripped.startsWith('case_sensitive:')) {
+      final value = stripped.substring(15).trim().toLowerCase();
+      if (value != 'true' && value != 'false') {
+        throw TokenGrammarError(
+          "Invalid value for 'case_sensitive:': '$value' (expected 'true' or 'false')",
+          lineNumber,
+        );
+      }
+      caseSensitive = value == 'true';
+      currentSection = null;
+      continue;
+    }
+
+    if (stripped.startsWith('group ') && stripped.endsWith(':')) {
+      final groupName = stripped.substring(6, stripped.length - 1).trim();
+      if (groupName.isEmpty) {
+        throw TokenGrammarError("Missing group name after 'group'", lineNumber);
+      }
+      if (!RegExp(r'^[a-z_][a-z0-9_]*$').hasMatch(groupName)) {
+        throw TokenGrammarError(
+          "Invalid group name: '$groupName' (must be a lowercase identifier like 'tag' or 'cdata')",
+          lineNumber,
+        );
+      }
+      const reservedNames = {
+        'default',
+        'skip',
+        'keywords',
+        'reserved',
+        'errors',
+      };
+      if (reservedNames.contains(groupName)) {
+        throw TokenGrammarError(
+          "Reserved group name: '$groupName'",
+          lineNumber,
+        );
+      }
+      if (groups.containsKey(groupName)) {
+        throw TokenGrammarError(
+          "Duplicate group name: '$groupName'",
+          lineNumber,
+        );
+      }
+      groups[groupName] = PatternGroup(name: groupName, definitions: const []);
+      currentSection = 'group:$groupName';
+      continue;
+    }
+
+    if (stripped == 'keywords:' || stripped == 'keywords :') {
+      currentSection = 'keywords';
+      continue;
+    }
+    if (stripped == 'reserved:' || stripped == 'reserved :') {
+      currentSection = 'reserved';
+      continue;
+    }
+    if (stripped == 'skip:' || stripped == 'skip :') {
+      currentSection = 'skip';
+      continue;
+    }
+    if (stripped == 'errors:' || stripped == 'errors :') {
+      currentSection = 'errors';
+      continue;
+    }
+    if (stripped == 'context_keywords:' || stripped == 'context_keywords :') {
+      currentSection = 'context_keywords';
+      continue;
+    }
+    if (stripped == 'soft_keywords:' || stripped == 'soft_keywords :') {
+      currentSection = 'soft_keywords';
+      continue;
+    }
+
+    if (currentSection != null) {
+      final firstChar = line.isEmpty ? '' : line[0];
+      if (firstChar == ' ' || firstChar == '\t') {
+        if (currentSection == 'keywords') {
+          keywords.add(stripped);
+        } else if (currentSection == 'reserved') {
+          reservedKeywords.add(stripped);
+        } else if (currentSection == 'context_keywords') {
+          contextKeywords.add(stripped);
+        } else if (currentSection == 'soft_keywords') {
+          softKeywords.add(stripped);
+        } else if (currentSection == 'skip') {
+          skipDefinitions.add(
+            _parseSectionDefinition(stripped, lineNumber, 'skip pattern'),
+          );
+        } else if (currentSection == 'errors') {
+          errorDefinitions.add(
+            _parseSectionDefinition(stripped, lineNumber, 'error pattern'),
+          );
+        } else if (currentSection.startsWith('group:')) {
+          final groupName = currentSection.substring(6);
+          final definition = _parseSectionDefinition(
+            stripped,
+            lineNumber,
+            'group token',
+          );
+          final group = groups[groupName]!;
+          groups[groupName] = PatternGroup(
+            name: group.name,
+            definitions: [...group.definitions, definition],
+          );
+        }
+        continue;
+      }
+      currentSection = null;
+    }
+
+    final equalsIndex = line.indexOf('=');
+    if (equalsIndex == -1) {
+      throw TokenGrammarError(
+        "Expected token definition (NAME = pattern), got: '$stripped'",
+        lineNumber,
+      );
+    }
+
+    final name = line.substring(0, equalsIndex).trim();
+    final pattern = line.substring(equalsIndex + 1).trim();
+    if (name.isEmpty) {
+      throw TokenGrammarError("Missing token name before '='", lineNumber);
+    }
+    if (!RegExp(r'^[a-zA-Z_][a-zA-Z0-9_]*$').hasMatch(name)) {
+      throw TokenGrammarError(
+        "Invalid token name: '$name' (must be an identifier like NAME or PLUS_EQUALS)",
+        lineNumber,
+      );
+    }
+    if (pattern.isEmpty) {
+      throw TokenGrammarError(
+        "Missing pattern after '=' for token '$name'",
+        lineNumber,
+      );
+    }
+    definitions.add(_parseDefinition(pattern, name, lineNumber));
+  }
+
+  return TokenGrammar(
+    version: version,
+    caseInsensitive: caseInsensitive,
+    definitions: definitions,
+    keywords: keywords,
+    mode: mode,
+    skipDefinitions: skipDefinitions,
+    reservedKeywords: reservedKeywords,
+    escapeMode: escapeMode,
+    errorDefinitions: errorDefinitions,
+    groups: groups,
+    caseSensitive: caseSensitive,
+    contextKeywords: contextKeywords,
+    softKeywords: softKeywords,
+  );
+}
+
+List<String> validateTokenGrammar(TokenGrammar grammar) {
+  final issues = <String>[];
+  issues.addAll(_validateDefinitions(grammar.definitions, 'token'));
+  issues.addAll(_validateDefinitions(grammar.skipDefinitions, 'skip pattern'));
+  issues.addAll(
+    _validateDefinitions(grammar.errorDefinitions, 'error pattern'),
+  );
+
+  if (grammar.mode != null && grammar.mode != 'indentation') {
+    issues.add(
+      "Unknown lexer mode '${grammar.mode}' (only 'indentation' is supported)",
+    );
+  }
+  if (grammar.escapeMode != null && grammar.escapeMode != 'none') {
+    issues.add(
+      "Unknown escape mode '${grammar.escapeMode}' (only 'none' is supported)",
+    );
+  }
+
+  for (final entry in grammar.groups.entries) {
+    final groupName = entry.key;
+    final group = entry.value;
+    if (!RegExp(r'^[a-z_][a-z0-9_]*$').hasMatch(groupName)) {
+      issues.add(
+        "Invalid group name '$groupName' (must be a lowercase identifier)",
+      );
+    }
+    if (group.definitions.isEmpty) {
+      issues.add("Empty pattern group '$groupName' (has no token definitions)");
+    }
+    issues.addAll(
+      _validateDefinitions(group.definitions, "group '$groupName' token"),
+    );
+  }
+
+  return issues;
+}
+
+TokenDefinition _parseSectionDefinition(
+  String stripped,
+  int lineNumber,
+  String label,
+) {
+  final equalsIndex = stripped.indexOf('=');
+  if (equalsIndex == -1) {
+    throw TokenGrammarError(
+      "Expected $label definition (NAME = pattern), got: '$stripped'",
+      lineNumber,
+    );
+  }
+  final name = stripped.substring(0, equalsIndex).trim();
+  final pattern = stripped.substring(equalsIndex + 1).trim();
+  if (name.isEmpty || pattern.isEmpty) {
+    throw TokenGrammarError(
+      "Incomplete $label definition: '$stripped'",
+      lineNumber,
+    );
+  }
+  return _parseDefinition(pattern, name, lineNumber);
+}
+
+TokenDefinition _parseDefinition(
+  String patternPart,
+  String name,
+  int lineNumber,
+) {
+  if (patternPart.startsWith('/')) {
+    final slashIndex = _findClosingSlash(patternPart);
+    if (slashIndex == -1) {
+      throw TokenGrammarError(
+        "Unclosed regex pattern for token '$name'",
+        lineNumber,
+      );
+    }
+    final body = patternPart.substring(1, slashIndex);
+    if (body.isEmpty) {
+      throw TokenGrammarError(
+        "Empty regex pattern for token '$name'",
+        lineNumber,
+      );
+    }
+    final remainder = patternPart.substring(slashIndex + 1).trim();
+    final alias = _parseAliasRemainder(remainder, name, lineNumber);
+    return TokenDefinition(
+      name: name,
+      pattern: body,
+      isRegex: true,
+      lineNumber: lineNumber,
+      alias: alias,
+    );
+  }
+
+  if (patternPart.startsWith('"')) {
+    final quoteIndex = _findClosingQuote(patternPart);
+    if (quoteIndex == -1) {
+      throw TokenGrammarError(
+        "Unclosed literal pattern for token '$name'",
+        lineNumber,
+      );
+    }
+    final body = patternPart.substring(1, quoteIndex);
+    if (body.isEmpty) {
+      throw TokenGrammarError(
+        "Empty literal pattern for token '$name'",
+        lineNumber,
+      );
+    }
+    final remainder = patternPart.substring(quoteIndex + 1).trim();
+    final alias = _parseAliasRemainder(remainder, name, lineNumber);
+    return TokenDefinition(
+      name: name,
+      pattern: body,
+      isRegex: false,
+      lineNumber: lineNumber,
+      alias: alias,
+    );
+  }
+
+  throw TokenGrammarError(
+    "Pattern for token '$name' must be /regex/ or \"literal\", got: '$patternPart'",
+    lineNumber,
+  );
+}
+
+String? _parseAliasRemainder(String remainder, String name, int lineNumber) {
+  if (remainder.isEmpty) {
+    return null;
+  }
+  if (!remainder.startsWith('->')) {
+    throw TokenGrammarError(
+      "Unexpected text after pattern for token '$name': '$remainder'",
+      lineNumber,
+    );
+  }
+  final alias = remainder.substring(2).trim();
+  if (alias.isEmpty) {
+    throw TokenGrammarError(
+      "Missing alias after '->' for token '$name'",
+      lineNumber,
+    );
+  }
+  return alias;
+}
+
+int _findClosingSlash(String patternPart) {
+  var index = 1;
+  var inBracket = false;
+  while (index < patternPart.length) {
+    final char = patternPart[index];
+    if (char == r'\') {
+      index += 2;
+      continue;
+    }
+    if (char == '[' && !inBracket) {
+      inBracket = true;
+    } else if (char == ']' && inBracket) {
+      inBracket = false;
+    } else if (char == '/' && !inBracket) {
+      return index;
+    }
+    index += 1;
+  }
+  final fallback = patternPart.lastIndexOf('/');
+  return fallback > 0 ? fallback : -1;
+}
+
+int _findClosingQuote(String patternPart) {
+  var index = 1;
+  while (index < patternPart.length) {
+    final char = patternPart[index];
+    if (char == r'\') {
+      index += 2;
+      continue;
+    }
+    if (char == '"') {
+      return index;
+    }
+    index += 1;
+  }
+  return -1;
+}
+
+List<String> _validateDefinitions(
+  List<TokenDefinition> definitions,
+  String label,
+) {
+  final issues = <String>[];
+  final seen = <String, int>{};
+
+  for (final definition in definitions) {
+    final firstLine = seen[definition.name];
+    if (firstLine != null) {
+      issues.add(
+        "Line ${definition.lineNumber}: Duplicate $label name '${definition.name}' (first defined on line $firstLine)",
+      );
+    } else {
+      seen[definition.name] = definition.lineNumber;
+    }
+
+    if (definition.pattern.isEmpty) {
+      issues.add(
+        "Line ${definition.lineNumber}: Empty pattern for $label '${definition.name}'",
+      );
+    }
+
+    if (definition.isRegex) {
+      try {
+        RegExp(definition.pattern);
+      } catch (error) {
+        issues.add(
+          "Line ${definition.lineNumber}: Invalid regex for $label '${definition.name}': $error",
+        );
+      }
+    }
+
+    if (definition.name != definition.name.toUpperCase()) {
+      issues.add(
+        "Line ${definition.lineNumber}: Token name '${definition.name}' should be UPPER_CASE",
+      );
+    }
+
+    final alias = definition.alias;
+    if (alias != null && alias != alias.toUpperCase()) {
+      issues.add(
+        "Line ${definition.lineNumber}: Alias '$alias' for token '${definition.name}' should be UPPER_CASE",
+      );
+    }
+  }
+
+  return issues;
+}
+
+bool _listEquals<T>(List<T> left, List<T> right) {
+  if (identical(left, right)) {
+    return true;
+  }
+  if (left.length != right.length) {
+    return false;
+  }
+  for (var index = 0; index < left.length; index++) {
+    if (left[index] != right[index]) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/code/packages/dart/grammar-tools/pubspec.yaml
+++ b/code/packages/dart/grammar-tools/pubspec.yaml
@@ -1,0 +1,15 @@
+name: coding_adventures_grammar_tools
+description: >
+  Parsers, validators, and source compilers for the shared .tokens and
+  .grammar formats used by grammar-driven lexers and parsers.
+version: 0.1.0
+repository: https://github.com/adhithyan15/coding-adventures
+publish_to: none
+
+environment:
+  sdk: ^3.0.0
+
+dependencies: {}
+
+dev_dependencies:
+  test: ^1.25.0

--- a/code/packages/dart/grammar-tools/required_capabilities.json
+++ b/code/packages/dart/grammar-tools/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "dart/grammar-tools",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/dart/grammar-tools/test/compiler_cross_validator_test.dart
+++ b/code/packages/dart/grammar-tools/test/compiler_cross_validator_test.dart
@@ -1,0 +1,50 @@
+import 'package:coding_adventures_grammar_tools/grammar_tools.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('crossValidate', () {
+    test('flags missing and unused tokens while respecting aliases', () {
+      final tokenGrammar = parseTokenGrammar('''
+STRING_DQ = /"[^"]*"/ -> STRING
+UNUSED = "~"
+''');
+      final parserGrammar = parseParserGrammar(
+        'program = STRING EOF MISSING ;',
+      );
+
+      final issues = crossValidate(tokenGrammar, parserGrammar);
+      expect(
+        issues,
+        contains(
+          "Error: Grammar references token 'MISSING' which is not defined in the tokens file",
+        ),
+      );
+      expect(
+        issues,
+        contains(
+          "Warning: Token 'UNUSED' (line 2) is defined but never used in the grammar",
+        ),
+      );
+    });
+  });
+
+  group('compiler', () {
+    test('compiles token grammar to Dart source', () {
+      final grammar = parseTokenGrammar('NUMBER = /[0-9]+/');
+      final source = compileTokenGrammar(grammar, sourceFile: 'json.tokens');
+
+      expect(source, contains('AUTO-GENERATED FILE'));
+      expect(source, contains('TokenGrammar('));
+      expect(source, contains('json.tokens'));
+    });
+
+    test('compiles parser grammar to Dart source', () {
+      final grammar = parseParserGrammar('program = NUMBER ;');
+      final source = compileParserGrammar(grammar, sourceFile: 'json.grammar');
+
+      expect(source, contains('ParserGrammar('));
+      expect(source, contains('RuleReference("NUMBER"'));
+      expect(source, contains('json.grammar'));
+    });
+  });
+}

--- a/code/packages/dart/grammar-tools/test/parser_grammar_test.dart
+++ b/code/packages/dart/grammar-tools/test/parser_grammar_test.dart
@@ -1,0 +1,76 @@
+import 'package:coding_adventures_grammar_tools/grammar_tools.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('parseParserGrammar', () {
+    test('parses sequences and alternations', () {
+      final grammar = parseParserGrammar(
+        'assignment = NAME EQUALS NUMBER | STRING ;',
+      );
+      final rule = grammar.rules.single;
+      expect(rule.name, 'assignment');
+      expect(rule.body, isA<Alternation>());
+    });
+
+    test('parses repetition, optional, grouping, and lookahead', () {
+      final grammar = parseParserGrammar(
+        'expression = term { ( PLUS | MINUS ) term } [ SEMI ] &EOF ;',
+      );
+      final rule = grammar.rules.single;
+      final body = rule.body as Sequence;
+
+      expect(body.elements[1], isA<Repetition>());
+      expect(body.elements[2], isA<Optional>());
+      expect(body.elements[3], isA<PositiveLookahead>());
+    });
+
+    test('parses separated repetition and one-or-more suffix', () {
+      final grammar = parseParserGrammar('args = { expression // COMMA }+ ;');
+      final rule = grammar.rules.single;
+      expect(
+        rule.body,
+        const SeparatedRepetition(
+          element: RuleReference('expression', isToken: false),
+          separator: RuleReference('COMMA', isToken: true),
+          atLeastOne: true,
+        ),
+      );
+    });
+
+    test('parses version magic comments', () {
+      final grammar = parseParserGrammar('''
+# @version 2
+program = NUMBER ;
+''');
+      expect(grammar.version, 2);
+    });
+
+    test('throws on malformed grammar', () {
+      expect(
+        () => parseParserGrammar('program = NUMBER'),
+        throwsA(isA<ParserGrammarError>()),
+      );
+    });
+  });
+
+  group('validateParserGrammar', () {
+    test('detects undefined and unreachable rules', () {
+      final grammar = parseParserGrammar('''
+program = expression ;
+expression = NUMBER ;
+unused = STRING ;
+''');
+
+      final issues = validateParserGrammar(grammar, tokenNames: {'NUMBER'});
+
+      expect(issues, contains("Undefined token reference: 'STRING'"));
+      expect(
+        issues.any(
+          (issue) =>
+              issue.contains("Rule 'unused' is defined but never referenced"),
+        ),
+        isTrue,
+      );
+    });
+  });
+}

--- a/code/packages/dart/grammar-tools/test/token_grammar_test.dart
+++ b/code/packages/dart/grammar-tools/test/token_grammar_test.dart
@@ -1,0 +1,115 @@
+import 'package:coding_adventures_grammar_tools/grammar_tools.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('parseTokenGrammar', () {
+    test('parses regex and literal token definitions', () {
+      final grammar = parseTokenGrammar('''NUMBER = /[0-9]+/
+PLUS = "+"
+''');
+
+      expect(grammar.definitions.length, 2);
+      expect(
+        grammar.definitions.first,
+        const TokenDefinition(
+          name: 'NUMBER',
+          pattern: '[0-9]+',
+          isRegex: true,
+          lineNumber: 1,
+        ),
+      );
+      expect(grammar.definitions[1].isRegex, isFalse);
+      expect(grammar.definitions[1].pattern, '+');
+    });
+
+    test('parses keywords, reserved, skip, errors, and aliases', () {
+      final grammar = parseTokenGrammar('''
+NAME = /[a-z]+/
+STRING_DQ = /"[^"]*"/ -> STRING
+mode: indentation
+escapes: none
+case_sensitive: false
+keywords:
+  if
+reserved:
+  class
+skip:
+  SPACE = /[ \t]+/
+errors:
+  BAD = /@+/
+context_keywords:
+  async
+soft_keywords:
+  match
+''');
+
+      expect(grammar.mode, 'indentation');
+      expect(grammar.escapeMode, 'none');
+      expect(grammar.caseSensitive, isFalse);
+      expect(grammar.keywords, ['if']);
+      expect(grammar.reservedKeywords, ['class']);
+      expect(grammar.skipDefinitions.single.name, 'SPACE');
+      expect(grammar.errorDefinitions.single.name, 'BAD');
+      expect(grammar.contextKeywords, ['async']);
+      expect(grammar.softKeywords, ['match']);
+      expect(grammar.definitions[1].alias, 'STRING');
+    });
+
+    test('parses pattern groups', () {
+      final grammar = parseTokenGrammar('''
+TEXT = /[^<]+/
+group tag:
+  TAG_NAME = /[a-z]+/
+  EQUALS = "="
+''');
+
+      expect(grammar.groups.keys, ['tag']);
+      expect(grammar.groups['tag']!.definitions.length, 2);
+    });
+
+    test('reports malformed definitions with line numbers', () {
+      expect(
+        () => parseTokenGrammar('NUMBER /[0-9]+/'),
+        throwsA(
+          isA<TokenGrammarError>().having(
+            (error) => error.lineNumber,
+            'lineNumber',
+            1,
+          ),
+        ),
+      );
+    });
+  });
+
+  group('validateTokenGrammar', () {
+    test('detects duplicate names and invalid mode', () {
+      final grammar = parseTokenGrammar('''
+name = /[a-z]+/
+name = /[a-z0-9]+/
+mode: weird
+''');
+
+      final issues = validateTokenGrammar(grammar);
+      expect(
+        issues.any((issue) => issue.contains('Duplicate token name')),
+        isTrue,
+      );
+      expect(
+        issues.any((issue) => issue.contains("Unknown lexer mode 'weird'")),
+        isTrue,
+      );
+      expect(
+        issues.any(
+          (issue) => issue.contains("Token name 'name' should be UPPER_CASE"),
+        ),
+        isTrue,
+      );
+    });
+
+    test('includes aliases in token names', () {
+      final grammar = parseTokenGrammar('STRING_DQ = /"[^"]*"/ -> STRING');
+      expect(grammar.tokenNames(), containsAll(['STRING_DQ', 'STRING']));
+      expect(grammar.effectiveTokenNames(), {'STRING'});
+    });
+  });
+}


### PR DESCRIPTION
## What changed

This adds a new Dart package at `code/packages/dart/grammar-tools` as the first real port of the shared grammar toolchain into Dart.

The package includes:

- `.tokens` parsing and validation
- `.grammar` parsing and validation
- token/parser cross-validation
- Dart source compilation helpers for embedded grammar objects
- package metadata, BUILD files, and package-level documentation
- a focused Dart test suite covering parsing, validation, cross-validation, and compiler output

## Why

Dart already has foundational runtime packages in the monorepo, but it was still missing `grammar-tools`, which is the main blocker for porting the grammar-driven lexer/parser packages mechanically.

Landing this package gives Dart the same core grammar description layer that the other mature language lanes already rely on.

## Impact

- unblocks Dart ports of grammar-driven packages like `json-lexer`, `json-parser`, `toml-lexer`, and `toml-parser`
- establishes the package shape and test strategy for future Dart grammar packages
- reduces the amount of one-off handwritten parsing logic needed in later Dart ports

## Validation

Ran in `code/packages/dart/grammar-tools`:

- `dart pub get`
- `dart test`
- `dart analyze`
