### PR TITLE
[codex] add Haskell layout lexer prototype

### DIFF
--- a/code/packages/ruby/grammar_tools/lib/coding_adventures/grammar_tools/compiler.rb
+++ b/code/packages/ruby/grammar_tools/lib/coding_adventures/grammar_tools/compiler.rb
@@ -100,6 +100,7 @@ module CodingAdventures
             reserved_keywords: #{grammar.reserved_keywords.inspect},
             error_definitions: #{err_src},
             groups: #{groups_src},
+            layout_keywords: #{grammar.layout_keywords.inspect},
             context_keywords: #{grammar.context_keywords.inspect},
             soft_keywords: #{grammar.soft_keywords.inspect},
           )

--- a/code/packages/ruby/grammar_tools/lib/coding_adventures/grammar_tools/token_grammar.rb
+++ b/code/packages/ruby/grammar_tools/lib/coding_adventures/grammar_tools/token_grammar.rb
@@ -118,6 +118,11 @@ module CodingAdventures
     #                      true" magic comment; defaults to false
     # The complete contents of a parsed .tokens file.
     #
+    # layout_keywords  -- list of keywords that introduce a layout context
+    #                     when mode is "layout". The generic lexer uses
+    #                     these to inject virtual "{", ";", and "}"
+    #                     tokens following Haskell-style offside rules.
+    #                     Examples: let, where, do, of.
     # context_keywords -- list of context-sensitive keywords from the
     #                     context_keywords: section. These are words that
     #                     are keywords in some syntactic positions but
@@ -149,12 +154,14 @@ module CodingAdventures
     #                       Python 3.12+: type
     class TokenGrammar
       attr_reader :definitions, :keywords, :skip_definitions, :error_definitions,
-                  :reserved_keywords, :groups, :context_keywords, :soft_keywords
+                  :reserved_keywords, :groups, :layout_keywords,
+                  :context_keywords, :soft_keywords
       attr_accessor :mode, :escape_mode, :case_sensitive, :version, :case_insensitive
 
       def initialize(definitions: [], keywords: [], mode: nil,
                      skip_definitions: [], error_definitions: [],
                      reserved_keywords: [], escape_mode: nil, groups: {},
+                     layout_keywords: [],
                      case_sensitive: true, version: 0, case_insensitive: false,
                      context_keywords: [], soft_keywords: [])
         @definitions = definitions
@@ -165,6 +172,7 @@ module CodingAdventures
         @reserved_keywords = reserved_keywords
         @escape_mode = escape_mode
         @groups = groups
+        @layout_keywords = layout_keywords
         @case_sensitive = case_sensitive
         @version = version
         @case_insensitive = case_insensitive
@@ -446,7 +454,10 @@ module CodingAdventures
               line_number
             )
           end
-          reserved_names = %w[default skip keywords reserved errors context_keywords soft_keywords].to_set
+          reserved_names = %w[
+            default skip keywords reserved errors layout_keywords
+            context_keywords soft_keywords
+          ].to_set
           if reserved_names.include?(group_name)
             raise TokenGrammarError.new(
               "Reserved group name: #{group_name.inspect} " \
@@ -493,6 +504,11 @@ module CodingAdventures
           next
         end
 
+        if stripped == "layout_keywords:" || stripped == "layout_keywords :"
+          current_section = "layout_keywords"
+          next
+        end
+
         # context_keywords: section -- words that are keywords in some
         # syntactic positions but identifiers in others. The lexer emits
         # these as NAME tokens with the TOKEN_CONTEXT_KEYWORD flag set.
@@ -516,6 +532,8 @@ module CodingAdventures
             case current_section
             when "keywords"
               grammar.keywords << stripped unless stripped.empty?
+            when "layout_keywords"
+              grammar.layout_keywords << stripped unless stripped.empty?
             when "context_keywords"
               grammar.context_keywords << stripped unless stripped.empty?
             when "soft_keywords"
@@ -700,8 +718,14 @@ module CodingAdventures
       issues.concat(validate_definitions(grammar.definitions, "token"))
       issues.concat(validate_definitions(grammar.skip_definitions, "skip pattern"))
 
-      if grammar.mode && grammar.mode != "indentation"
-        issues << "Unknown lexer mode '#{grammar.mode}' (only 'indentation' is supported)"
+      supported_modes = [nil, "indentation", "layout"]
+      unless supported_modes.include?(grammar.mode)
+        issues << "Unknown lexer mode '#{grammar.mode}' " \
+                  "(supported: indentation, layout)"
+      end
+
+      if grammar.mode == "layout" && grammar.layout_keywords.empty?
+        issues << "Layout mode requires a non-empty layout_keywords: section"
       end
 
       # Validate pattern groups.

--- a/code/packages/ruby/grammar_tools/test/test_compiler.rb
+++ b/code/packages/ruby/grammar_tools/test/test_compiler.rb
@@ -153,6 +153,21 @@ class TestCompileTokenGrammarRoundTrip < Minitest::Test
     assert_equal "indentation", loaded.mode
   end
 
+  def test_mode_layout_with_layout_keywords
+    source = <<~TOKENS
+      mode: layout
+      NAME = /[a-z]+/
+      layout_keywords:
+        let
+        where
+    TOKENS
+    original = GT.parse_token_grammar(source)
+    code     = GT.compile_token_grammar(original)
+    loaded   = eval_token_grammar(code)
+    assert_equal "layout", loaded.mode
+    assert_equal %w[let where], loaded.layout_keywords
+  end
+
   def test_escape_mode_none
     source = "escapes: none\nSTRING = /\"[^\"]*\"/"
     original = GT.parse_token_grammar(source)

--- a/code/packages/ruby/grammar_tools/test/test_token_grammar.rb
+++ b/code/packages/ruby/grammar_tools/test/test_token_grammar.rb
@@ -224,6 +224,19 @@ class TestTokenGrammar < Minitest::Test
     assert_includes error.message, "Missing value"
   end
 
+  def test_parse_layout_mode_directive
+    source = <<~TOKENS
+      mode: layout
+      NAME = /[a-z]+/
+      layout_keywords:
+        let
+        where
+    TOKENS
+    grammar = GT.parse_token_grammar(source)
+    assert_equal "layout", grammar.mode
+    assert_equal %w[let where], grammar.layout_keywords
+  end
+
   # -----------------------------------------------------------------------
   # Extended format: skip section
   # -----------------------------------------------------------------------
@@ -371,6 +384,19 @@ class TestTokenGrammar < Minitest::Test
     grammar = GT::TokenGrammar.new(mode: "indentation")
     issues = GT.validate_token_grammar(grammar)
     refute issues.any? { |i| i.include?("Unknown lexer mode") }
+  end
+
+  def test_validate_layout_mode_requires_layout_keywords
+    grammar = GT::TokenGrammar.new(mode: "layout")
+    issues = GT.validate_token_grammar(grammar)
+    assert issues.any? { |i| i.include?("layout_keywords") }
+  end
+
+  def test_validate_layout_mode_ok
+    grammar = GT::TokenGrammar.new(mode: "layout", layout_keywords: ["let"])
+    issues = GT.validate_token_grammar(grammar)
+    refute issues.any? { |i| i.include?("Unknown lexer mode") }
+    refute issues.any? { |i| i.include?("layout_keywords") }
   end
 
   def test_validate_skip_definitions
@@ -834,6 +860,13 @@ class TestTokenGrammar < Minitest::Test
     # "context_keywords" should also be a reserved group name.
     error = assert_raises(GT::TokenGrammarError) do
       GT.parse_token_grammar("TEXT = /abc/\ngroup context_keywords:\n  FOO = /x/\n")
+    end
+    assert_includes error.message, "Reserved group name"
+  end
+
+  def test_layout_keywords_reserved_group_name
+    error = assert_raises(GT::TokenGrammarError) do
+      GT.parse_token_grammar("TEXT = /abc/\ngroup layout_keywords:\n  FOO = /x/\n")
     end
     assert_includes error.message, "Reserved group name"
   end

--- a/code/packages/ruby/lexer/lib/coding_adventures/lexer/grammar_lexer.rb
+++ b/code/packages/ruby/lexer/lib/coding_adventures/lexer/grammar_lexer.rb
@@ -351,10 +351,12 @@ module CodingAdventures
         # that match keywords. Used by case-insensitive languages like VHDL.
         @case_sensitive = grammar.case_sensitive
 
-        # Indentation mode state.
+        # Lexer modes.
         @indentation_mode = grammar.mode == "indentation"
+        @layout_mode = grammar.mode == "layout"
         @indent_stack = [0]
         @bracket_depth_indent = 0
+        @layout_keyword_set = (grammar.respond_to?(:layout_keywords) ? grammar.layout_keywords : []).to_set.freeze
 
         # --- Pattern groups ---
         # Compile per-group patterns. The "default" group uses the
@@ -474,6 +476,8 @@ module CodingAdventures
         # Stage 2: Core tokenization.
         tokens = if @indentation_mode
           tokenize_indentation
+        elsif @layout_mode
+          tokenize_layout
         else
           tokenize_standard
         end
@@ -722,6 +726,24 @@ module CodingAdventures
         tokens
       end
 
+      # Layout-aware tokenization (prototype for Haskell-style offside rules).
+      #
+      # We intentionally reuse the standard tokenization pass first so
+      # callbacks, pattern groups, and skip handling all continue to work.
+      # A second pass injects virtual "{", ";", and "}" tokens after
+      # layout introducers declared in the grammar's layout_keywords: section.
+      #
+      # The current prototype is intentionally narrow:
+      # - basic let/where/do/of-style blocks
+      # - explicit "{" cancels implicit layout for that introducer
+      # - dedent and EOF close open layout contexts
+      #
+      # This is enough to validate the engine shape before we tackle the
+      # full Haskell report.
+      def tokenize_layout
+        apply_layout(tokenize_standard)
+      end
+
       # Process the start of a logical line in indentation mode.
       # Returns an array of INDENT/DEDENT tokens, :skip_line for blank/comment
       # lines, or nil if no indent change.
@@ -807,6 +829,102 @@ module CodingAdventures
           end
         end
         false
+      end
+
+      def apply_layout(tokens)
+        result = []
+        layout_stack = []
+        pending_layouts = 0
+        suppress_depth = 0
+
+        tokens.each_with_index do |token, index|
+          type_name = token.type_name
+
+          if type_name == "NEWLINE"
+            result << token
+            next_token = next_layout_token(tokens, index + 1)
+            if suppress_depth == 0 && next_token
+              while !layout_stack.empty? && next_token.column < layout_stack.last
+                result << virtual_layout_token("VIRTUAL_RBRACE", "}", next_token)
+                layout_stack.pop
+              end
+
+              if !layout_stack.empty? &&
+                  next_token.type_name != "EOF" &&
+                  next_token.value != "}" &&
+                  next_token.column == layout_stack.last
+                result << virtual_layout_token("VIRTUAL_SEMICOLON", ";", next_token)
+              end
+            end
+            next
+          end
+
+          if type_name == "EOF"
+            while !layout_stack.empty?
+              result << virtual_layout_token("VIRTUAL_RBRACE", "}", token)
+              layout_stack.pop
+            end
+            result << token
+            next
+          end
+
+          if pending_layouts.positive?
+            if token.value == "{"
+              pending_layouts -= 1
+            else
+              pending_layouts.times do
+                layout_stack << token.column
+                result << virtual_layout_token("VIRTUAL_LBRACE", "{", token)
+              end
+              pending_layouts = 0
+            end
+          end
+
+          result << token
+
+          unless virtual_layout_token?(token)
+            case token.value
+            when "(", "[", "{"
+              suppress_depth += 1
+            when ")", "]", "}"
+              suppress_depth -= 1 if suppress_depth > 0
+            end
+          end
+
+          pending_layouts += 1 if layout_keyword?(token)
+        end
+
+        result
+      end
+
+      def next_layout_token(tokens, start_index)
+        idx = start_index
+        while idx < tokens.length
+          token = tokens[idx]
+          return token unless token.type_name == "NEWLINE"
+          idx += 1
+        end
+        nil
+      end
+
+      def virtual_layout_token(type_name, value, anchor)
+        Token.new(
+          type: type_name,
+          value: value,
+          line: anchor.line,
+          column: anchor.column
+        )
+      end
+
+      def virtual_layout_token?(token)
+        token.type_name.start_with?("VIRTUAL_")
+      end
+
+      def layout_keyword?(token)
+        return false if @layout_keyword_set.empty?
+
+        value = token.value.to_s
+        @layout_keyword_set.include?(value) || @layout_keyword_set.include?(value.downcase)
       end
 
       # Try to match a token using the default group's patterns.

--- a/code/packages/ruby/lexer/test/test_grammar_lexer.rb
+++ b/code/packages/ruby/lexer/test/test_grammar_lexer.rb
@@ -339,6 +339,79 @@ class TestGrammarLexer < Minitest::Test
   end
 
   # -----------------------------------------------------------------------
+  # Layout mode (Haskell-style prototype)
+  # -----------------------------------------------------------------------
+
+  def haskell_layout_grammar
+    GT.parse_token_grammar(<<~TOKENS)
+      mode: layout
+      NAME = /[a-zA-Z_][a-zA-Z0-9_]*/
+      NUMBER = /[0-9]+/
+      EQUALS = "="
+      SEMICOLON = ";"
+      LBRACE = "{"
+      RBRACE = "}"
+      LPAREN = "("
+      RPAREN = ")"
+
+      keywords:
+        let
+        in
+        where
+        do
+        of
+
+      layout_keywords:
+        let
+        where
+        do
+        of
+
+      skip:
+        WHITESPACE = /[ \\t\\r]+/
+    TOKENS
+  end
+
+  def filtered_layout_tokens(source)
+    GL.new(source, haskell_layout_grammar).tokenize.reject do |token|
+      %w[NEWLINE EOF].include?(token.type_name)
+    end
+  end
+
+  def test_layout_mode_inserts_virtual_tokens_for_let_block
+    tokens = filtered_layout_tokens(<<~HS)
+      let
+        x = 1
+        y = 2
+      in x
+    HS
+
+    assert_equal [
+      "KEYWORD:let",
+      "VIRTUAL_LBRACE:{",
+      "NAME:x",
+      "EQUALS:=",
+      "NUMBER:1",
+      "VIRTUAL_SEMICOLON:;",
+      "NAME:y",
+      "EQUALS:=",
+      "NUMBER:2",
+      "VIRTUAL_RBRACE:}",
+      "KEYWORD:in",
+      "NAME:x"
+    ], tokens.map { |token| "#{token.type_name}:#{token.value}" }
+  end
+
+  def test_layout_mode_skips_virtual_open_when_explicit_brace_present
+    tokens = filtered_layout_tokens("let { x = 1; y = 2 } in x\n")
+    types = tokens.map(&:type_name)
+
+    refute_includes types, "VIRTUAL_LBRACE"
+    refute_includes types, "VIRTUAL_SEMICOLON"
+    refute_includes types, "VIRTUAL_RBRACE"
+  end
+
+  # -----------------------------------------------------------------------
   # Starlark integration
   # -----------------------------------------------------------------------
 

--- a/code/specs/F06-haskell-layout-mode.md
+++ b/code/specs/F06-haskell-layout-mode.md
@@ -1,0 +1,193 @@
+# Haskell Layout Mode And Versioned Grammar Roadmap
+
+## Overview
+
+This spec adds the first generic lexer feature we need before full Haskell
+support is realistic in the repo: a **layout-aware lexer mode** for
+Haskell-style offside rules.
+
+The existing `mode: indentation` support is deliberately Python-shaped. It emits
+`INDENT` and `DEDENT` tokens at physical line starts and works well for Python
+and Starlark. Haskell is different:
+
+- layout is introduced only after specific keywords (`let`, `where`, `do`, `of`)
+- the virtual structure is `{`, `;`, and `}`, not `INDENT`/`DEDENT`
+- layout can begin after a keyword even when that keyword is not at line start
+- an explicit `{ ... }` suppresses implicit layout for that construct
+
+This spec is intentionally **lexer-focused**. Full Haskell parsing also needs a
+later fixity-resolution phase, but that is a parser or semantic pass and not
+part of this document.
+
+## Why This Exists
+
+We want to support versioned Haskell grammars across the language line, starting
+from the first standardized report:
+
+- Haskell 1.0
+- Haskell 1.1
+- Haskell 1.2
+- Haskell 1.3
+- Haskell 1.4
+- Haskell 98
+- Haskell 2010
+
+The exact grammar files for those versions will live under a future
+`code/grammars/haskell/` directory. All of them need the same core lexical
+capability: convert offside layout into an explicit token stream the parser can
+consume consistently.
+
+## Relationship To Existing Specs
+
+- `tokens-format.md`: adds one new lexer mode and one new section
+- `lexer-parser-hooks.md`: remains valid; hooks still compose around layout mode
+- `lexer-parser-extensions.md`: this spec complements those generic extensions
+- `14-starlark.md`: similar motivation, but Haskell layout is not Python-style
+
+## Design Principles
+
+1. Generic capability first, language policy second.
+2. Keep the physical token pass and the layout transform separate.
+3. Preserve compatibility with the existing grammar-driven lexer API.
+4. Make versioned Haskell grammars data-driven, not hardcoded in the engine.
+
+## `.tokens` Format Changes
+
+### New Mode: `mode: layout`
+
+```text
+mode: layout
+```
+
+This activates a second lexer pass after physical tokenization. The first pass
+still produces normal tokens and `NEWLINE`s. The second pass injects virtual
+layout tokens according to the rules below.
+
+### New Section: `layout_keywords:`
+
+```text
+layout_keywords:
+  let
+  where
+  do
+  of
+```
+
+These are the token values that introduce a layout context when `mode: layout`
+is active. The list is intentionally declarative so other layout-sensitive
+languages can reuse the same engine shape without hardcoding Haskell words into
+the generic lexer.
+
+## Generic Layout Algorithm
+
+The lexer runs in two stages:
+
+1. **Physical tokenization**
+   - tokenize with the normal grammar-driven machinery
+   - emit regular tokens plus physical `NEWLINE`
+   - preserve source positions
+
+2. **Layout transform**
+   - scan the physical token stream
+   - after a layout introducer:
+     - if the next significant token is an explicit `{`, do nothing
+     - otherwise inject a virtual `{` before the next significant token and
+       record that token's column as the layout column
+   - after each physical newline:
+     - if the next significant token is at the same column as the active layout
+       context, inject a virtual `;`
+     - if it is to the left, inject one or more virtual `}` until the stack
+       matches
+   - at EOF, close any remaining implicit layout contexts with virtual `}`
+
+### Synthetic Tokens
+
+The layout transform emits:
+
+- `VIRTUAL_LBRACE` with value `{`
+- `VIRTUAL_SEMICOLON` with value `;`
+- `VIRTUAL_RBRACE` with value `}`
+
+The parser can match these by literal value, which keeps grammars compatible
+with both explicit and implicit block structure.
+
+## Prototype Scope
+
+The first prototype does **not** attempt the entire Haskell report. It focuses
+on the smallest generic engine slice that proves the model:
+
+- parse `mode: layout`
+- parse `layout_keywords:`
+- inject virtual `{ ; }` for simple `let`/`where`/`do`/`of` blocks
+- cancel implicit layout when an explicit `{` follows the introducer
+- close outstanding layout contexts at dedent and EOF
+
+Known prototype limitations:
+
+- nested layout inside parentheses or brackets is not complete yet
+- the full Haskell lexical grammar is not implemented yet
+- pragmas, nested comments, string gaps, and fixity are out of scope here
+
+That is acceptable for phase 1. The goal is to make the engine shape real, not
+to finish Haskell in one change.
+
+## Ruby Prototype
+
+The first implementation language is Ruby because the shared generic lexer and
+parser infrastructure already lives there:
+
+- `code/packages/ruby/grammar_tools/`
+- `code/packages/ruby/lexer/`
+- `code/packages/ruby/parser/`
+
+Phase 1 Ruby changes:
+
+1. Accept `mode: layout` in `TokenGrammar`.
+2. Accept `layout_keywords:` in `TokenGrammar`.
+3. Extend the Ruby `GrammarLexer` with a `tokenize_layout` path.
+4. Add focused tests for virtual token insertion.
+
+## Future Haskell Grammar Layout
+
+Once the lexer mode is stable, versioned Haskell grammars should follow the
+same pattern as the Python, Java, C#, and TypeScript grammar families:
+
+```text
+code/grammars/haskell/
+  haskell1.0.tokens
+  haskell1.0.grammar
+  haskell1.1.tokens
+  haskell1.1.grammar
+  ...
+  haskell2010.tokens
+  haskell2010.grammar
+```
+
+Expected wrapper packages later:
+
+- `code/packages/ruby/haskell_lexer/`
+- `code/packages/ruby/haskell_parser/`
+
+Other languages can follow once the Ruby prototype is stable.
+
+## Non-Goals
+
+This spec does not define:
+
+- full Haskell parser grammar
+- user-declared fixity resolution
+- GHC extension support
+- semantic analysis or desugaring
+
+Those are separate phases. This document is only about making the lexer capable
+of expressing Haskell's layout-sensitive surface syntax.
+
+## Success Criteria
+
+Phase 1 is successful when:
+
+1. the `.tokens` format accepts `mode: layout`
+2. the Ruby lexer can inject virtual layout tokens for simple blocks
+3. explicit `{ ... }` suppresses implicit layout in the prototype
+4. the design is documented well enough to build versioned Haskell grammars on
+   top of it next


### PR DESCRIPTION
## What changed
- added a new spec for a generic `layout` lexer mode aimed at future versioned Haskell support from Haskell 1.0 through Haskell 2010
- extended the Ruby grammar-tools token grammar to support `mode: layout` and a new `layout_keywords:` section
- added a first Ruby lexer prototype that injects `VIRTUAL_LBRACE`, `VIRTUAL_SEMICOLON`, and `VIRTUAL_RBRACE` tokens for simple Haskell-style layout blocks
- added focused Ruby tests covering grammar parsing, compiler round-tripping, and simple layout-token insertion behavior

## Why this changed
Haskell layout cannot be modeled cleanly with the existing Python-style `mode: indentation` support. We need a separate generic lexer mode that can evolve into full Haskell offside-rule handling before versioned Haskell grammars and parsers are practical in the repo.

## Impact
- creates a documented path for future `code/grammars/haskell/` version families
- proves the engine shape in one shared implementation language without locking the design to Haskell-specific hardcoding
- keeps the current prototype deliberately narrow so we can iterate on layout semantics before adding full grammar coverage

## Validation
- `ruby -c code/packages/ruby/grammar_tools/lib/coding_adventures/grammar_tools/token_grammar.rb`
- `ruby -c code/packages/ruby/grammar_tools/lib/coding_adventures/grammar_tools/compiler.rb`
- `ruby -c code/packages/ruby/lexer/lib/coding_adventures/lexer/grammar_lexer.rb`
- direct Ruby smoke check: parse and validate `mode: layout` + `layout_keywords:`
- direct Ruby smoke check: confirm the layout prototype emits the expected virtual tokens for a simple `let` block and respects explicit braces

## Notes
The package test entrypoints were not runnable in this environment because the local Ruby bundle is missing the `simplecov` development gem required by the test helpers. The prototype behavior was validated with direct Ruby smoke checks instead.