### PR TITLE
fix(actions): repair stale deploy workflow dependency installs

### DIFF
--- a/.github/workflows/deploy-arithmetic.yml
+++ b/.github/workflows/deploy-arithmetic.yml
@@ -22,8 +22,11 @@ on:
     paths:
       - "code/programs/typescript/arithmetic-visualizer/**"
       - "code/packages/typescript/arithmetic/**"
+      - "code/packages/typescript/draw-instructions/**"
+      - "code/packages/typescript/draw-instructions-canvas/**"
       - "code/packages/typescript/intel4004-gatelevel/**"
       - "code/packages/typescript/logic-gates/**"
+      - "code/packages/typescript/transistors/**"
       - "code/packages/typescript/ui-components/**"
       - ".github/workflows/deploy-arithmetic.yml"
   workflow_dispatch:
@@ -45,21 +48,19 @@ jobs:
 
       - name: Install dependencies (packages)
         run: |
-          cd code/packages/typescript/transistors && npm install
-          cd ../logic-gates && npm install
-          cd ../arithmetic && npm install
-          cd ../intel4004-gatelevel && npm install
-          cd ../ui-components && npm install
+          (cd code/packages/typescript/transistors && npm install)
+          (cd code/packages/typescript/logic-gates && npm install)
+          (cd code/packages/typescript/draw-instructions && npm install)
+          (cd code/packages/typescript/draw-instructions-canvas && npm install)
+          (cd code/packages/typescript/ui-components && npm install)
+          (cd code/packages/typescript/arithmetic && npm install)
+          (cd code/packages/typescript/intel4004-gatelevel && npm install)
 
       - name: Install dependencies (app)
-        run: |
-          cd code/programs/typescript/arithmetic-visualizer
-          npm install
+        run: (cd code/programs/typescript/arithmetic-visualizer && npm install)
 
       - name: Build
-        run: |
-          cd code/programs/typescript/arithmetic-visualizer
-          npm run build
+        run: (cd code/programs/typescript/arithmetic-visualizer && npm run build)
 
       - name: Deploy to GitHub Pages (arithmetic/ subdirectory)
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/deploy-code39.yml
+++ b/.github/workflows/deploy-code39.yml
@@ -5,8 +5,22 @@ on:
     branches: [main]
     paths:
       - "code/programs/typescript/code39-visualizer/**"
+      - "code/packages/typescript/directed-graph/**"
+      - "code/packages/typescript/grammar-tools/**"
+      - "code/packages/typescript/lexer/**"
+      - "code/packages/typescript/state-machine/**"
+      - "code/packages/typescript/lattice-lexer/**"
+      - "code/packages/typescript/parser/**"
+      - "code/packages/typescript/lattice-parser/**"
+      - "code/packages/typescript/lattice-ast-to-css/**"
+      - "code/packages/typescript/pixel-container/**"
+      - "code/packages/typescript/paint-instructions/**"
+      - "code/packages/typescript/paint-vm/**"
+      - "code/packages/typescript/paint-vm-canvas/**"
+      - "code/packages/typescript/paint-vm-svg/**"
+      - "code/packages/typescript/barcode-layout-1d/**"
       - "code/packages/typescript/code39/**"
-      - "code/packages/typescript/draw-instructions-svg/**"
+      - "code/packages/typescript/lattice-transpiler/**"
       - ".github/workflows/deploy-code39.yml"
   workflow_dispatch:
 
@@ -27,8 +41,22 @@ jobs:
 
       - name: Install renderer dependencies
         run: |
+          (cd code/packages/typescript/directed-graph && npm install)
+          (cd code/packages/typescript/grammar-tools && npm install)
+          (cd code/packages/typescript/lexer && npm install)
+          (cd code/packages/typescript/state-machine && npm install)
+          (cd code/packages/typescript/lattice-lexer && npm install)
+          (cd code/packages/typescript/parser && npm install)
+          (cd code/packages/typescript/lattice-parser && npm install)
+          (cd code/packages/typescript/lattice-ast-to-css && npm install)
+          (cd code/packages/typescript/pixel-container && npm install)
+          (cd code/packages/typescript/paint-instructions && npm install)
+          (cd code/packages/typescript/paint-vm && npm install)
+          (cd code/packages/typescript/paint-vm-canvas && npm install)
+          (cd code/packages/typescript/paint-vm-svg && npm install)
+          (cd code/packages/typescript/barcode-layout-1d && npm install)
           (cd code/packages/typescript/code39 && npm install)
-          (cd code/packages/typescript/draw-instructions-svg && npm install)
+          (cd code/packages/typescript/lattice-transpiler && npm install)
 
       - name: Install app dependencies
         run: (cd code/programs/typescript/code39-visualizer && npm install)

--- a/.github/workflows/deploy-electronics-visualizers.yml
+++ b/.github/workflows/deploy-electronics-visualizers.yml
@@ -22,6 +22,8 @@ on:
     paths:
       - "code/programs/typescript/electronics-visualizers/**"
       - "code/packages/typescript/analog-waveform/**"
+      - "code/packages/typescript/draw-instructions/**"
+      - "code/packages/typescript/draw-instructions-canvas/**"
       - "code/packages/typescript/electronics/**"
       - "code/packages/typescript/power-supply/**"
       - "code/packages/typescript/ui-components/**"
@@ -45,20 +47,18 @@ jobs:
 
       - name: Install dependencies (packages)
         run: |
-          cd code/packages/typescript/analog-waveform && npm install
-          cd ../power-supply && npm install
-          cd ../electronics && npm install
-          cd ../ui-components && npm install
+          (cd code/packages/typescript/analog-waveform && npm install)
+          (cd code/packages/typescript/draw-instructions && npm install)
+          (cd code/packages/typescript/draw-instructions-canvas && npm install)
+          (cd code/packages/typescript/ui-components && npm install)
+          (cd code/packages/typescript/power-supply && npm install)
+          (cd code/packages/typescript/electronics && npm install)
 
       - name: Install dependencies (app)
-        run: |
-          cd code/programs/typescript/electronics-visualizers
-          npm install
+        run: (cd code/programs/typescript/electronics-visualizers && npm install)
 
       - name: Build
-        run: |
-          cd code/programs/typescript/electronics-visualizers
-          npm run build
+        run: (cd code/programs/typescript/electronics-visualizers && npm run build)
 
       - name: Deploy to GitHub Pages (electronics-visualizers/ subdirectory)
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/deploy-eniac.yml
+++ b/.github/workflows/deploy-eniac.yml
@@ -5,8 +5,10 @@ on:
     branches: [main]
     paths:
       - "code/programs/typescript/eniac-visualizer/**"
-      - "code/packages/typescript/eniac/**"
       - "code/packages/typescript/arithmetic/**"
+      - "code/packages/typescript/draw-instructions/**"
+      - "code/packages/typescript/draw-instructions-canvas/**"
+      - "code/packages/typescript/eniac/**"
       - "code/packages/typescript/logic-gates/**"
       - "code/packages/typescript/transistors/**"
       - "code/packages/typescript/ui-components/**"
@@ -30,21 +32,19 @@ jobs:
 
       - name: Install dependencies (packages)
         run: |
-          cd code/packages/typescript/transistors && npm install
-          cd ../logic-gates && npm install
-          cd ../arithmetic && npm install
-          cd ../eniac && npm install
-          cd ../ui-components && npm install
+          (cd code/packages/typescript/logic-gates && npm install)
+          (cd code/packages/typescript/transistors && npm install)
+          (cd code/packages/typescript/draw-instructions && npm install)
+          (cd code/packages/typescript/draw-instructions-canvas && npm install)
+          (cd code/packages/typescript/ui-components && npm install)
+          (cd code/packages/typescript/arithmetic && npm install)
+          (cd code/packages/typescript/eniac && npm install)
 
       - name: Install dependencies (app)
-        run: |
-          cd code/programs/typescript/eniac-visualizer
-          npm install
+        run: (cd code/programs/typescript/eniac-visualizer && npm install)
 
       - name: Build
-        run: |
-          cd code/programs/typescript/eniac-visualizer
-          npm run build
+        run: (cd code/programs/typescript/eniac-visualizer && npm run build)
 
       - name: Deploy to GitHub Pages (eniac/ subdirectory)
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/deploy-logic-gates.yml
+++ b/.github/workflows/deploy-logic-gates.yml
@@ -21,6 +21,8 @@ on:
     branches: [main]
     paths:
       - "code/programs/typescript/logic-gates-visualizer/**"
+      - "code/packages/typescript/draw-instructions/**"
+      - "code/packages/typescript/draw-instructions-canvas/**"
       - "code/packages/typescript/logic-gates/**"
       - "code/packages/typescript/transistors/**"
       - "code/packages/typescript/ui-components/**"
@@ -44,19 +46,17 @@ jobs:
 
       - name: Install dependencies (packages)
         run: |
-          cd code/packages/typescript/transistors && npm install
-          cd ../logic-gates && npm install
-          cd ../ui-components && npm install
+          (cd code/packages/typescript/logic-gates && npm install)
+          (cd code/packages/typescript/transistors && npm install)
+          (cd code/packages/typescript/draw-instructions && npm install)
+          (cd code/packages/typescript/draw-instructions-canvas && npm install)
+          (cd code/packages/typescript/ui-components && npm install)
 
       - name: Install dependencies (app)
-        run: |
-          cd code/programs/typescript/logic-gates-visualizer
-          npm install
+        run: (cd code/programs/typescript/logic-gates-visualizer && npm install)
 
       - name: Build
-        run: |
-          cd code/programs/typescript/logic-gates-visualizer
-          npm run build
+        run: (cd code/programs/typescript/logic-gates-visualizer && npm run build)
 
       - name: Deploy to GitHub Pages (logic-gates/ subdirectory)
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/deploy-transistors.yml
+++ b/.github/workflows/deploy-transistors.yml
@@ -21,6 +21,8 @@ on:
     branches: [main]
     paths:
       - "code/programs/typescript/transistor-visualizer/**"
+      - "code/packages/typescript/draw-instructions/**"
+      - "code/packages/typescript/draw-instructions-canvas/**"
       - "code/packages/typescript/transistors/**"
       - "code/packages/typescript/ui-components/**"
       - ".github/workflows/deploy-transistors.yml"
@@ -43,18 +45,16 @@ jobs:
 
       - name: Install dependencies (packages)
         run: |
-          cd code/packages/typescript/transistors && npm install
-          cd ../ui-components && npm install
+          (cd code/packages/typescript/transistors && npm install)
+          (cd code/packages/typescript/draw-instructions && npm install)
+          (cd code/packages/typescript/draw-instructions-canvas && npm install)
+          (cd code/packages/typescript/ui-components && npm install)
 
       - name: Install dependencies (app)
-        run: |
-          cd code/programs/typescript/transistor-visualizer
-          npm install
+        run: (cd code/programs/typescript/transistor-visualizer && npm install)
 
       - name: Build
-        run: |
-          cd code/programs/typescript/transistor-visualizer
-          npm run build
+        run: (cd code/programs/typescript/transistor-visualizer && npm run build)
 
       - name: Deploy to GitHub Pages (transistors/ subdirectory)
         uses: peaceiris/actions-gh-pages@v4


### PR DESCRIPTION
## Summary
This rescues the broken deploy workflows that have been failing because they no longer install the full package graph each app needs before building.

## What changed
- align `deploy-code39.yml` with the `code39-visualizer/BUILD` dependency graph
- add missing `draw-instructions` and `draw-instructions-canvas` installs to the arithmetic, electronics, logic-gates, ENIAC, and transistor deploy workflows
- update `push.paths` for those workflows so dependency changes trigger the matching deploy job
- switch the multi-package install steps to subshell form so path drift cannot break later installs

## Root cause
Several deploy workflows had drifted away from the app BUILD files. On GitHub Actions that showed up as missing-module failures such as:
- `@coding-adventures/lattice-ast-to-css` during the Code39 deploy
- `@coding-adventures/draw-instructions` during arithmetic, electronics, and related visualizer deploys

## Validation
- parsed the updated workflow YAML successfully
- reproduced successful local builds with the updated dependency chains for:
  - `code/programs/typescript/code39-visualizer`
  - `code/programs/typescript/electronics-visualizers`
  - `code/programs/typescript/transistor-visualizer`

## Notes
I investigated older historical deploy failures for CommonMark and Lattice Docs as well, but those were not reproducible on current `main`, so this PR stays focused on the workflows that are still clearly stale and failing for dependency-install reasons.