### PR TITLE
[codex] add pure leaf packages for C# and F#

### DIFF
--- a/code/packages/csharp/csv-parser/BUILD
+++ b/code/packages/csharp/csv-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.CsvParser.Tests/CodingAdventures.CsvParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/csv-parser/BUILD_windows
+++ b/code/packages/csharp/csv-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.CsvParser.Tests/CodingAdventures.CsvParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/csv-parser/CHANGELOG.md
+++ b/code/packages/csharp/csv-parser/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-16
+
+### Added
+
+- Hand-rolled RFC 4180 style CSV parser with quoted-field support
+- Delimiter-aware state machine handling escaped quotes and mixed newline styles
+- Tests covering ragged rows, blank lines, custom delimiters, and error cases

--- a/code/packages/csharp/csv-parser/CodingAdventures.CsvParser.csproj
+++ b/code/packages/csharp/csv-parser/CodingAdventures.CsvParser.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.CsvParser.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>State-machine CSV parser with quoted-field and ragged-row support</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\\**\\*.cs" />
+    <EmbeddedResource Remove="tests\\**" />
+    <None Remove="tests\\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/csv-parser/CsvParser.cs
+++ b/code/packages/csharp/csv-parser/CsvParser.cs
@@ -1,0 +1,275 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CodingAdventures.CsvParser;
+
+// CsvParser.cs -- CSV is simple until quotes turn commas back into ordinary text
+// =============================================================================
+//
+// CSV looks regular until one column contains:
+//
+//   "New York, NY"
+//
+// The comma inside quotes is data, not a separator. That means parsing CSV is
+// not just "split on commas" -- the parser must remember whether it is inside
+// a quoted field. A small state machine is the cleanest way to do that.
+
+/// <summary>
+/// Raised when the input ends while the parser is still inside a quoted field.
+/// </summary>
+public sealed class UnclosedQuoteError : Exception
+{
+    /// <summary>
+    /// Create the standard unclosed-quote error.
+    /// </summary>
+    public UnclosedQuoteError()
+        : base("unclosed quoted field: EOF reached inside a quoted field")
+    {
+    }
+}
+
+/// <summary>
+/// State-machine CSV parser following RFC 4180 style quoting rules.
+/// </summary>
+public static class CsvParser
+{
+    private enum ParseState
+    {
+        FieldStart,
+        InUnquotedField,
+        InQuotedField,
+        InQuotedMaybeEnd,
+    }
+
+    /// <summary>
+    /// Parse CSV text using a comma as the delimiter.
+    /// </summary>
+    public static List<Dictionary<string, string>> ParseCsv(string source) =>
+        ParseCsvWithDelimiter(source, ',');
+
+    /// <summary>
+    /// Parse CSV text using a single-character delimiter string.
+    /// </summary>
+    public static List<Dictionary<string, string>> ParseCsvWithDelimiter(
+        string source,
+        string delimiter)
+    {
+        ArgumentNullException.ThrowIfNull(delimiter);
+
+        if (delimiter.Length != 1)
+        {
+            throw new ArgumentException("Delimiter must be a single character.", nameof(delimiter));
+        }
+
+        return ParseCsvWithDelimiter(source, delimiter[0]);
+    }
+
+    /// <summary>
+    /// Parse CSV text using a custom delimiter.
+    /// </summary>
+    public static List<Dictionary<string, string>> ParseCsvWithDelimiter(
+        string source,
+        char delimiter)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        if (delimiter == '"')
+        {
+            throw new ArgumentException("Delimiter cannot be a double quote.", nameof(delimiter));
+        }
+
+        var rawRows = TokenizeRows(source, delimiter);
+        if (rawRows.Count == 0)
+        {
+            return [];
+        }
+
+        var header = rawRows[0];
+        if (rawRows.Count == 1)
+        {
+            return [];
+        }
+
+        var rows = new List<Dictionary<string, string>>(rawRows.Count - 1);
+        for (var rowIndex = 1; rowIndex < rawRows.Count; rowIndex++)
+        {
+            rows.Add(BuildRowMap(header, rawRows[rowIndex]));
+        }
+
+        return rows;
+    }
+
+    private static List<List<string>> TokenizeRows(string source, char delimiter)
+    {
+        var rows = new List<List<string>>();
+        var currentRow = new List<string>();
+        var fieldBuffer = new StringBuilder();
+        var state = ParseState.FieldStart;
+        var index = 0;
+
+        while (index < source.Length)
+        {
+            var ch = source[index];
+
+            switch (state)
+            {
+                case ParseState.FieldStart:
+                    if (ch == '"')
+                    {
+                        state = ParseState.InQuotedField;
+                        index++;
+                    }
+                    else if (ch == delimiter)
+                    {
+                        currentRow.Add(string.Empty);
+                        index++;
+                    }
+                    else if (IsNewlineStart(ch))
+                    {
+                        if (currentRow.Count > 0)
+                        {
+                            currentRow.Add(string.Empty);
+                        }
+
+                        rows.Add(currentRow);
+                        currentRow = [];
+                        index = ConsumeNewline(source, index);
+                    }
+                    else
+                    {
+                        fieldBuffer.Append(ch);
+                        state = ParseState.InUnquotedField;
+                        index++;
+                    }
+
+                    break;
+
+                case ParseState.InUnquotedField:
+                    if (ch == delimiter)
+                    {
+                        currentRow.Add(fieldBuffer.ToString());
+                        fieldBuffer.Clear();
+                        state = ParseState.FieldStart;
+                        index++;
+                    }
+                    else if (IsNewlineStart(ch))
+                    {
+                        currentRow.Add(fieldBuffer.ToString());
+                        fieldBuffer.Clear();
+                        rows.Add(currentRow);
+                        currentRow = [];
+                        state = ParseState.FieldStart;
+                        index = ConsumeNewline(source, index);
+                    }
+                    else
+                    {
+                        fieldBuffer.Append(ch);
+                        index++;
+                    }
+
+                    break;
+
+                case ParseState.InQuotedField:
+                    if (ch == '"')
+                    {
+                        state = ParseState.InQuotedMaybeEnd;
+                    }
+                    else
+                    {
+                        fieldBuffer.Append(ch);
+                    }
+
+                    index++;
+                    break;
+
+                case ParseState.InQuotedMaybeEnd:
+                    if (ch == '"')
+                    {
+                        fieldBuffer.Append('"');
+                        state = ParseState.InQuotedField;
+                        index++;
+                    }
+                    else if (ch == delimiter)
+                    {
+                        currentRow.Add(fieldBuffer.ToString());
+                        fieldBuffer.Clear();
+                        state = ParseState.FieldStart;
+                        index++;
+                    }
+                    else if (IsNewlineStart(ch))
+                    {
+                        currentRow.Add(fieldBuffer.ToString());
+                        fieldBuffer.Clear();
+                        rows.Add(currentRow);
+                        currentRow = [];
+                        state = ParseState.FieldStart;
+                        index = ConsumeNewline(source, index);
+                    }
+                    else
+                    {
+                        // Lenient mode: treat unexpected text after a closing
+                        // quote as plain characters in the same field.
+                        fieldBuffer.Append(ch);
+                        state = ParseState.InUnquotedField;
+                        index++;
+                    }
+
+                    break;
+            }
+        }
+
+        switch (state)
+        {
+            case ParseState.FieldStart:
+                if (currentRow.Count > 0)
+                {
+                    currentRow.Add(string.Empty);
+                    rows.Add(currentRow);
+                }
+
+                break;
+
+            case ParseState.InUnquotedField:
+                currentRow.Add(fieldBuffer.ToString());
+                rows.Add(currentRow);
+                break;
+
+            case ParseState.InQuotedField:
+                throw new UnclosedQuoteError();
+
+            case ParseState.InQuotedMaybeEnd:
+                currentRow.Add(fieldBuffer.ToString());
+                rows.Add(currentRow);
+                break;
+        }
+
+        return rows;
+    }
+
+    private static Dictionary<string, string> BuildRowMap(
+        IReadOnlyList<string> header,
+        IReadOnlyList<string> row)
+    {
+        var map = new Dictionary<string, string>(header.Count, StringComparer.Ordinal);
+
+        for (var index = 0; index < header.Count; index++)
+        {
+            map[header[index]] = index < row.Count ? row[index] : string.Empty;
+        }
+
+        return map;
+    }
+
+    private static bool IsNewlineStart(char ch) => ch is '\n' or '\r';
+
+    private static int ConsumeNewline(string source, int index)
+    {
+        if (source[index] == '\r' && index + 1 < source.Length && source[index + 1] == '\n')
+        {
+            return index + 2;
+        }
+
+        return index + 1;
+    }
+}

--- a/code/packages/csharp/csv-parser/README.md
+++ b/code/packages/csharp/csv-parser/README.md
@@ -1,0 +1,33 @@
+# csv-parser
+
+Hand-rolled CSV parser that follows RFC 4180 style quoting rules with support
+for quoted commas, embedded newlines, blank fields, and ragged rows.
+
+## Layer 1
+
+This package is part of Layer 1 of the coding-adventures computing stack.
+
+## What It Includes
+
+- `ParseCsv` for comma-separated input
+- `ParseCsvWithDelimiter` for TSV or other delimiter-separated variants
+- `UnclosedQuoteError` when the input ends inside a quoted field
+- Ragged-row handling that pads missing columns with `""` and truncates extras
+
+## Example
+
+```csharp
+using CodingAdventures.CsvParser;
+
+var csv = "name,city\nAlice,\"New York, NY\"\n";
+var rows = CsvParser.ParseCsv(csv);
+
+Console.WriteLine(rows[0]["city"]); // New York, NY
+```
+
+## Development
+
+```bash
+# Run tests
+bash BUILD
+```

--- a/code/packages/csharp/csv-parser/required_capabilities.json
+++ b/code/packages/csharp/csv-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/csv-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory parser and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/csv-parser/tests/CodingAdventures.CsvParser.Tests/CodingAdventures.CsvParser.Tests.csproj
+++ b/code/packages/csharp/csv-parser/tests/CodingAdventures.CsvParser.Tests/CodingAdventures.CsvParser.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.CsvParser.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/csv-parser/tests/CodingAdventures.CsvParser.Tests/CsvParserTests.cs
+++ b/code/packages/csharp/csv-parser/tests/CodingAdventures.CsvParser.Tests/CsvParserTests.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using Parser = CodingAdventures.CsvParser.CsvParser;
+
+namespace CodingAdventures.CsvParser.Tests;
+
+public sealed class CsvParserTests
+{
+    [Fact]
+    public void ParsesSimpleTablesAndKeepsValuesAsStrings()
+    {
+        var rows = Parser.ParseCsv("name,age,city\nAlice,30,New York\nBob,25,London\n");
+
+        Assert.Equal(2, rows.Count);
+        AssertRow(rows[0], ("name", "Alice"), ("age", "30"), ("city", "New York"));
+        AssertRow(rows[1], ("name", "Bob"), ("age", "25"), ("city", "London"));
+    }
+
+    [Fact]
+    public void HandlesEmptyInputHeaderOnlyFilesAndMissingTrailingNewlines()
+    {
+        Assert.Empty(Parser.ParseCsv(string.Empty));
+        Assert.Empty(Parser.ParseCsv("name,age\n"));
+
+        var rows = Parser.ParseCsv("name,value\nhello,world");
+        Assert.Single(rows);
+        AssertRow(rows[0], ("name", "hello"), ("value", "world"));
+    }
+
+    [Fact]
+    public void QuotedFieldsHandleCommasEmbeddedNewlinesAndEscapedQuotes()
+    {
+        var commaRows = Parser.ParseCsv("product,description\nWidget,\"A small, round widget\"\n");
+        Assert.Single(commaRows);
+        AssertRow(commaRows[0], ("product", "Widget"), ("description", "A small, round widget"));
+
+        var newlineRows = Parser.ParseCsv("note,text\n1,\"Line one\nLine two\"\n");
+        Assert.Single(newlineRows);
+        AssertRow(newlineRows[0], ("note", "1"), ("text", "Line one\nLine two"));
+
+        var escapedQuoteRows = Parser.ParseCsv("quote,value\n2,\"She said \"\"hello\"\"\"\n");
+        Assert.Single(escapedQuoteRows);
+        AssertRow(escapedQuoteRows[0], ("quote", "2"), ("value", "She said \"hello\""));
+    }
+
+    [Fact]
+    public void EmptyFieldsAndBlankLinesBecomeEmptyStrings()
+    {
+        var rows = Parser.ParseCsv("a,b,c\n,2,\n,,\n");
+        Assert.Equal(2, rows.Count);
+        AssertRow(rows[0], ("a", string.Empty), ("b", "2"), ("c", string.Empty));
+        AssertRow(rows[1], ("a", string.Empty), ("b", string.Empty), ("c", string.Empty));
+
+        var blankLineRows = Parser.ParseCsv("a\n\n");
+        Assert.Single(blankLineRows);
+        AssertRow(blankLineRows[0], ("a", string.Empty));
+    }
+
+    [Fact]
+    public void RaggedRowsArePaddedAndTruncatedToHeaderLength()
+    {
+        var rows = Parser.ParseCsv(
+            "a,b,c\n1\n2,two\n3,three,THREE\n4,four,FOUR,extra\n");
+
+        Assert.Equal(4, rows.Count);
+        AssertRow(rows[0], ("a", "1"), ("b", string.Empty), ("c", string.Empty));
+        AssertRow(rows[1], ("a", "2"), ("b", "two"), ("c", string.Empty));
+        AssertRow(rows[2], ("a", "3"), ("b", "three"), ("c", "THREE"));
+        AssertRow(rows[3], ("a", "4"), ("b", "four"), ("c", "FOUR"));
+    }
+
+    [Fact]
+    public void SupportsLfCrLfAndCrLineEndings()
+    {
+        var lf = Parser.ParseCsv("a,b\n1,2\n");
+        var crlf = Parser.ParseCsv("a,b\r\n1,2\r\n");
+        var cr = Parser.ParseCsv("a,b\r1,2\r");
+
+        AssertRow(lf[0], ("a", "1"), ("b", "2"));
+        AssertRow(crlf[0], ("a", "1"), ("b", "2"));
+        AssertRow(cr[0], ("a", "1"), ("b", "2"));
+    }
+
+    [Fact]
+    public void SupportsCustomDelimiters()
+    {
+        var rows = Parser.ParseCsvWithDelimiter("name\tage\nAlice\t30\n", '\t');
+        Assert.Single(rows);
+        AssertRow(rows[0], ("name", "Alice"), ("age", "30"));
+
+        var pipeRows = Parser.ParseCsvWithDelimiter("name|age\nBob|25\n", "|");
+        Assert.Single(pipeRows);
+        AssertRow(pipeRows[0], ("name", "Bob"), ("age", "25"));
+    }
+
+    [Fact]
+    public void PreservesWhitespaceOutsideQuotes()
+    {
+        var rows = Parser.ParseCsv("a,b\n  spaced  ,\"trim? no\"\n");
+        Assert.Single(rows);
+        AssertRow(rows[0], ("a", "  spaced  "), ("b", "trim? no"));
+    }
+
+    [Fact]
+    public void ThrowsWhenQuotedFieldIsNotClosed()
+    {
+        Assert.Throws<UnclosedQuoteError>(() => Parser.ParseCsv("a,b\n1,\"oops"));
+    }
+
+    [Fact]
+    public void ValidatesDelimiterInputs()
+    {
+        Assert.Throws<ArgumentException>(() => Parser.ParseCsvWithDelimiter("a,b\n", "\""));
+        Assert.Throws<ArgumentException>(() => Parser.ParseCsvWithDelimiter("a,b\n", "||"));
+    }
+
+    private static void AssertRow(
+        IReadOnlyDictionary<string, string> row,
+        params (string Key, string Value)[] expected)
+    {
+        Assert.Equal(expected.Length, row.Count);
+
+        foreach (var (key, value) in expected)
+        {
+            Assert.Equal(value, row[key]);
+        }
+    }
+}

--- a/code/packages/csharp/fenwick-tree/BUILD
+++ b/code/packages/csharp/fenwick-tree/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.FenwickTree.Tests/CodingAdventures.FenwickTree.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/fenwick-tree/BUILD_windows
+++ b/code/packages/csharp/fenwick-tree/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.FenwickTree.Tests/CodingAdventures.FenwickTree.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/fenwick-tree/CHANGELOG.md
+++ b/code/packages/csharp/fenwick-tree/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-16
+
+### Added
+
+- Literate `FenwickTree` implementation for prefix sums, range sums, and point
+  updates
+- Error-aware search helpers covering empty trees, invalid indices, and
+  out-of-range order statistics
+- Deterministic tests covering construction, updates, order statistics, and
+  brute-force correctness checks

--- a/code/packages/csharp/fenwick-tree/CodingAdventures.FenwickTree.csproj
+++ b/code/packages/csharp/fenwick-tree/CodingAdventures.FenwickTree.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.FenwickTree.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Fenwick tree for prefix sums, range sums, and point updates</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\\**\\*.cs" />
+    <EmbeddedResource Remove="tests\\**" />
+    <None Remove="tests\\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/fenwick-tree/FenwickTree.cs
+++ b/code/packages/csharp/fenwick-tree/FenwickTree.cs
@@ -1,0 +1,262 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace CodingAdventures.FenwickTree;
+
+// FenwickTree.cs -- Prefix sums stored in a tree hidden inside an array
+// =====================================================================
+//
+// A Fenwick tree, also called a Binary Indexed Tree, answers prefix-sum
+// queries while still supporting point updates:
+//
+//   update(i, delta)     -- add delta to one element
+//   prefixSum(i)         -- sum elements 1..i
+//
+// Both operations run in O(log n) time. The trick is that each array slot
+// stores the total for a power-of-two-sized range, and the least-significant
+// set bit of the index tells us the width of that range.
+//
+// Example:
+//
+//   index 12 = 1100b
+//   lowbit(12) = 0100b = 4
+//
+// So tree[12] stores the sum of the last 4 values that end at 12.
+// Following parent links by adding lowbit(index) walks upward to larger ranges.
+
+/// <summary>
+/// Base class for Fenwick-tree specific errors.
+/// </summary>
+public class FenwickError : Exception
+{
+    /// <summary>
+    /// Create a new Fenwick-specific error.
+    /// </summary>
+    public FenwickError(string message)
+        : base(message)
+    {
+    }
+}
+
+/// <summary>
+/// Raised when an operation uses an index outside the legal range.
+/// </summary>
+public sealed class FenwickIndexOutOfRangeError : FenwickError
+{
+    /// <summary>
+    /// Create an index-range error.
+    /// </summary>
+    public FenwickIndexOutOfRangeError(string message)
+        : base(message)
+    {
+    }
+}
+
+/// <summary>
+/// Raised when <see cref="FenwickTree.FindKth"/> is called on an empty tree.
+/// </summary>
+public sealed class FenwickEmptyTreeError : FenwickError
+{
+    /// <summary>
+    /// Create an empty-tree error.
+    /// </summary>
+    public FenwickEmptyTreeError(string message)
+        : base(message)
+    {
+    }
+}
+
+/// <summary>
+/// Binary Indexed Tree for prefix sums with point updates.
+/// </summary>
+public sealed class FenwickTree
+{
+    private readonly int _length;
+    private readonly double[] _bit;
+
+    /// <summary>
+    /// Create a zero-filled tree of the requested size.
+    /// </summary>
+    public FenwickTree(int length)
+    {
+        if (length < 0)
+        {
+            throw new FenwickError($"Size must be a non-negative integer, got {length}");
+        }
+
+        _length = length;
+        _bit = new double[length + 1];
+    }
+
+    /// <summary>
+    /// Build a tree from a list of values in O(n).
+    /// </summary>
+    public static FenwickTree FromList(IEnumerable<double> values)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+
+        var data = values.ToArray();
+        var tree = new FenwickTree(data.Length);
+
+        for (var index = 1; index <= tree._length; index++)
+        {
+            tree._bit[index] += data[index - 1];
+            var parent = index + LowBit(index);
+            if (parent <= tree._length)
+            {
+                tree._bit[parent] += tree._bit[index];
+            }
+        }
+
+        return tree;
+    }
+
+    /// <summary>
+    /// Number of values stored in the logical array.
+    /// </summary>
+    public int Length => _length;
+
+    /// <summary>
+    /// Whether the tree has zero elements.
+    /// </summary>
+    public bool IsEmpty => _length == 0;
+
+    /// <summary>
+    /// Add <paramref name="delta"/> to the value at <paramref name="index"/>.
+    /// </summary>
+    public void Update(int index, double delta)
+    {
+        CheckIndex(index);
+
+        var current = index;
+        while (current <= _length)
+        {
+            _bit[current] += delta;
+            current += LowBit(current);
+        }
+    }
+
+    /// <summary>
+    /// Return the sum of elements in the inclusive range 1..index.
+    /// </summary>
+    public double PrefixSum(int index)
+    {
+        if (index < 0 || index > _length)
+        {
+            throw new FenwickIndexOutOfRangeError(
+                $"prefixSum index {index} out of range [0, {_length}]");
+        }
+
+        var total = 0.0;
+        var current = index;
+        while (current > 0)
+        {
+            total += _bit[current];
+            current -= LowBit(current);
+        }
+
+        return total;
+    }
+
+    /// <summary>
+    /// Return the sum of the inclusive range left..right.
+    /// </summary>
+    public double RangeSum(int left, int right)
+    {
+        if (left > right)
+        {
+            throw new FenwickError($"left ({left}) must be <= right ({right})");
+        }
+
+        CheckIndex(left);
+        CheckIndex(right);
+
+        return left == 1
+            ? PrefixSum(right)
+            : PrefixSum(right) - PrefixSum(left - 1);
+    }
+
+    /// <summary>
+    /// Return the exact value stored at one index.
+    /// </summary>
+    public double PointQuery(int index)
+    {
+        CheckIndex(index);
+        return RangeSum(index, index);
+    }
+
+    /// <summary>
+    /// Find the smallest index whose prefix sum is at least <paramref name="target"/>.
+    /// </summary>
+    public int FindKth(double target)
+    {
+        if (_length == 0)
+        {
+            throw new FenwickEmptyTreeError("findKth called on empty tree");
+        }
+
+        if (target <= 0.0)
+        {
+            throw new FenwickError($"k must be positive, got {FormatDouble(target)}");
+        }
+
+        var total = PrefixSum(_length);
+        if (target > total)
+        {
+            throw new FenwickError(
+                $"k ({FormatDouble(target)}) exceeds total sum of the tree ({FormatDouble(total)})");
+        }
+
+        var index = 0;
+        var remaining = target;
+        var step = HighestPowerOfTwoAtMost(_length);
+
+        while (step > 0)
+        {
+            var nextIndex = index + step;
+            if (nextIndex <= _length && _bit[nextIndex] < remaining)
+            {
+                index = nextIndex;
+                remaining -= _bit[nextIndex];
+            }
+
+            step >>= 1;
+        }
+
+        return index + 1;
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        var rendered = string.Join(", ", _bit.Skip(1).Select(FormatDouble));
+        return $"FenwickTree(n={_length}, bit=[{rendered}])";
+    }
+
+    private static int LowBit(int index) => index & -index;
+
+    private static int HighestPowerOfTwoAtMost(int value)
+    {
+        var result = 1;
+        while (result <= value / 2)
+        {
+            result <<= 1;
+        }
+
+        return result;
+    }
+
+    private static string FormatDouble(double value) =>
+        value.ToString("G17", CultureInfo.InvariantCulture);
+
+    private void CheckIndex(int index)
+    {
+        if (index < 1 || index > _length)
+        {
+            throw new FenwickIndexOutOfRangeError(
+                $"Index {index} out of range [1, {_length}]");
+        }
+    }
+}

--- a/code/packages/csharp/fenwick-tree/README.md
+++ b/code/packages/csharp/fenwick-tree/README.md
@@ -1,0 +1,35 @@
+# fenwick-tree
+
+Fenwick tree, also called a Binary Indexed Tree, for prefix sums, range sums,
+and point updates in `O(log n)` time.
+
+## Layer 1
+
+This package is part of Layer 1 of the coding-adventures computing stack.
+
+## What It Includes
+
+- `FenwickTree(length)` for zero-filled construction
+- `FromList` for linear-time tree building from existing values
+- `Update`, `PrefixSum`, `RangeSum`, and `PointQuery`
+- `FindKth` for prefix-sum order statistics
+- Literate comments explaining why `lowbit(index)` reveals each node's range
+
+## Example
+
+```csharp
+using CodingAdventures.FenwickTree;
+
+var tree = FenwickTree.FromList([3.0, 2.0, 1.0, 7.0, 4.0]);
+
+Console.WriteLine(tree.PrefixSum(4)); // 13
+tree.Update(3, 5.0);
+Console.WriteLine(tree.PointQuery(3)); // 6
+```
+
+## Development
+
+```bash
+# Run tests
+bash BUILD
+```

--- a/code/packages/csharp/fenwick-tree/required_capabilities.json
+++ b/code/packages/csharp/fenwick-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/fenwick-tree",
+  "capabilities": [],
+  "justification": "Pure in-memory data structure and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/fenwick-tree/tests/CodingAdventures.FenwickTree.Tests/CodingAdventures.FenwickTree.Tests.csproj
+++ b/code/packages/csharp/fenwick-tree/tests/CodingAdventures.FenwickTree.Tests/CodingAdventures.FenwickTree.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.FenwickTree.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/fenwick-tree/tests/CodingAdventures.FenwickTree.Tests/FenwickTreeTests.cs
+++ b/code/packages/csharp/fenwick-tree/tests/CodingAdventures.FenwickTree.Tests/FenwickTreeTests.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FenwickTreeType = CodingAdventures.FenwickTree.FenwickTree;
+
+namespace CodingAdventures.FenwickTree.Tests;
+
+public sealed class FenwickTreeTests
+{
+    private const double Epsilon = 1e-9;
+
+    [Fact]
+    public void ConstructionValidatesSizeAndTracksLength()
+    {
+        var empty = new FenwickTreeType(0);
+        Assert.Equal(0, empty.Length);
+        Assert.True(empty.IsEmpty);
+        Assert.Equal(0.0, empty.PrefixSum(0));
+
+        var sized = new FenwickTreeType(5);
+        Assert.Equal(5, sized.Length);
+        Assert.False(sized.IsEmpty);
+
+        Assert.Throws<FenwickError>(() => new FenwickTreeType(-1));
+    }
+
+    [Fact]
+    public void FromListBuildsExpectedPrefixTotals()
+    {
+        var tree = FenwickTreeType.FromList([3.0, 2.0, 1.0, 7.0, 4.0]);
+
+        AssertClose(tree.PrefixSum(1), 3.0);
+        AssertClose(tree.PrefixSum(2), 5.0);
+        AssertClose(tree.PrefixSum(3), 6.0);
+        AssertClose(tree.PrefixSum(4), 13.0);
+        AssertClose(tree.PrefixSum(5), 17.0);
+    }
+
+    [Fact]
+    public void PrefixRangeAndPointQueriesMatchExpectedValues()
+    {
+        var tree = FenwickTreeType.FromList([3.0, 2.0, 1.0, 7.0, 4.0]);
+
+        AssertClose(tree.PrefixSum(0), 0.0);
+        AssertClose(tree.RangeSum(1, 5), 17.0);
+        AssertClose(tree.RangeSum(2, 4), 10.0);
+        AssertClose(tree.PointQuery(4), 7.0);
+    }
+
+    [Fact]
+    public void UpdateAppliesPositiveAndNegativeDeltas()
+    {
+        var tree = FenwickTreeType.FromList([3.0, 2.0, 1.0, 7.0, 4.0]);
+
+        tree.Update(3, 5.0);
+        AssertClose(tree.PointQuery(3), 6.0);
+        AssertClose(tree.PrefixSum(3), 11.0);
+
+        tree.Update(2, -1.0);
+        AssertClose(tree.PointQuery(2), 1.0);
+        AssertClose(tree.PrefixSum(3), 10.0);
+    }
+
+    [Fact]
+    public void UpdateFromIndexOnePropagatesAcrossPowerOfTwoParents()
+    {
+        var tree = FenwickTreeType.FromList(new double[8]);
+
+        tree.Update(1, 10.0);
+
+        for (var index = 1; index <= 8; index++)
+        {
+            AssertClose(tree.PrefixSum(index), 10.0);
+        }
+    }
+
+    [Fact]
+    public void QueryOperationsValidateBounds()
+    {
+        var tree = FenwickTreeType.FromList([1.0, 2.0, 3.0]);
+
+        Assert.Throws<FenwickIndexOutOfRangeError>(() => tree.PrefixSum(-1));
+        Assert.Throws<FenwickIndexOutOfRangeError>(() => tree.PrefixSum(4));
+        Assert.Throws<FenwickIndexOutOfRangeError>(() => tree.Update(0, 1.0));
+        Assert.Throws<FenwickIndexOutOfRangeError>(() => tree.RangeSum(0, 2));
+        Assert.Throws<FenwickIndexOutOfRangeError>(() => tree.PointQuery(4));
+        Assert.Throws<FenwickError>(() => tree.RangeSum(3, 1));
+    }
+
+    [Fact]
+    public void FindKthMatchesDocumentedExamplesAndValidationRules()
+    {
+        var tree = FenwickTreeType.FromList([1.0, 2.0, 3.0, 4.0, 5.0]);
+
+        Assert.Equal(1, tree.FindKth(1.0));
+        Assert.Equal(2, tree.FindKth(2.0));
+        Assert.Equal(2, tree.FindKth(3.0));
+        Assert.Equal(3, tree.FindKth(4.0));
+        Assert.Equal(4, tree.FindKth(10.0));
+        Assert.Equal(5, tree.FindKth(11.0));
+
+        Assert.Throws<FenwickError>(() => tree.FindKth(0.0));
+        Assert.Throws<FenwickError>(() => tree.FindKth(100.0));
+        Assert.Throws<FenwickEmptyTreeError>(() => new FenwickTreeType(0).FindKth(1.0));
+    }
+
+    [Fact]
+    public void PrefixAndRangeQueriesMatchBruteForceAcrossRandomArrays()
+    {
+        var seed = 1337;
+
+        static int Next(ref int state)
+        {
+            state = (int)(((long)state * 1103515245 + 12345) & 0x7fffffff);
+            return state;
+        }
+
+        for (var run = 0; run < 120; run++)
+        {
+            var n = (Next(ref seed) % 30) + 1;
+            var values = Enumerable.Range(0, n)
+                .Select(_ => (double)((Next(ref seed) % 101) - 50))
+                .ToArray();
+            var tree = FenwickTreeType.FromList(values);
+
+            for (var index = 1; index <= n; index++)
+            {
+                AssertClose(tree.PrefixSum(index), BrutePrefix(values, index));
+            }
+
+            for (var left = 1; left <= n; left++)
+            {
+                for (var right = left; right <= n; right++)
+                {
+                    AssertClose(tree.RangeSum(left, right), BruteRange(values, left, right));
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void TreeStaysConsistentUnderInterleavedUpdatesAndQueries()
+    {
+        var seed = 99u;
+
+        static uint Next(ref uint state)
+        {
+            state = state * 1664525u + 1013904223u;
+            return state;
+        }
+
+        const int Size = 60;
+        var values = Enumerable.Range(0, Size)
+            .Select(_ => (double)((Next(ref seed) % 20) + 1))
+            .ToArray();
+        var tree = FenwickTreeType.FromList(values);
+
+        for (var iteration = 0; iteration < 1200; iteration++)
+        {
+            if (Next(ref seed) % 10 < 4)
+            {
+                var left = (int)(Next(ref seed) % Size) + 1;
+                var right = left + (int)(Next(ref seed) % (Size - left + 1));
+                AssertClose(tree.RangeSum(left, right), BruteRange(values, left, right));
+            }
+            else
+            {
+                var index = (int)(Next(ref seed) % Size) + 1;
+                var delta = (double)((int)(Next(ref seed) % 41) - 20);
+                values[index - 1] += delta;
+                tree.Update(index, delta);
+            }
+        }
+    }
+
+    [Fact]
+    public void ToStringRendersLogicalShape()
+    {
+        var tree = FenwickTreeType.FromList([1.0, 2.0, 3.0]);
+        Assert.Equal("FenwickTree(n=3, bit=[1, 3, 3])", tree.ToString());
+    }
+
+    private static void AssertClose(double actual, double expected)
+    {
+        Assert.True(
+            Math.Abs(actual - expected) < Epsilon,
+            $"Expected {expected}, got {actual}");
+    }
+
+    private static double BrutePrefix(IReadOnlyList<double> values, int index) =>
+        values.Take(index).Sum();
+
+    private static double BruteRange(IReadOnlyList<double> values, int left, int right) =>
+        values.Skip(left - 1).Take(right - left + 1).Sum();
+}

--- a/code/packages/csharp/gf256/BUILD
+++ b/code/packages/csharp/gf256/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Gf256.Tests/CodingAdventures.Gf256.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/gf256/BUILD_windows
+++ b/code/packages/csharp/gf256/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Gf256.Tests/CodingAdventures.Gf256.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/gf256/CHANGELOG.md
+++ b/code/packages/csharp/gf256/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-16
+
+### Added
+
+- GF(2^8) arithmetic over the Reed-Solomon polynomial `0x11D`
+- Public log and antilog tables plus add, subtract, multiply, divide, power,
+  and inverse operations
+- Parameterizable `Gf256Field` for alternate polynomials such as AES `0x11B`

--- a/code/packages/csharp/gf256/CodingAdventures.Gf256.csproj
+++ b/code/packages/csharp/gf256/CodingAdventures.Gf256.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Gf256.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>GF(2^8) arithmetic for Reed-Solomon and related byte-oriented codes</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\\**\\*.cs" />
+    <EmbeddedResource Remove="tests\\**" />
+    <None Remove="tests\\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/gf256/Gf256.cs
+++ b/code/packages/csharp/gf256/Gf256.cs
@@ -1,0 +1,301 @@
+using System;
+using System.Collections.Generic;
+
+namespace CodingAdventures.Gf256;
+
+// Gf256.cs -- Byte arithmetic where addition is XOR and multiplication wraps in a field
+// ======================================================================================
+//
+// GF(2^8) has exactly 256 elements: the byte values 0 through 255.
+// The surprise is that arithmetic is not ordinary integer arithmetic:
+//
+//   add(a, b) = a XOR b
+//
+// because each bit is a coefficient in GF(2), where 1 + 1 = 0.
+//
+// For multiplication we work modulo the primitive polynomial 0x11D, which is
+// the common Reed-Solomon choice used in QR and storage-style error correction.
+
+/// <summary>
+/// GF(2^8) arithmetic over the primitive polynomial 0x11D.
+/// </summary>
+public static class Gf256
+{
+    /// <summary>
+    /// Package version.
+    /// </summary>
+    public const string VERSION = "0.1.0";
+
+    /// <summary>
+    /// Additive identity.
+    /// </summary>
+    public const byte ZERO = 0;
+
+    /// <summary>
+    /// Multiplicative identity.
+    /// </summary>
+    public const byte ONE = 1;
+
+    /// <summary>
+    /// Primitive polynomial x^8 + x^4 + x^3 + x^2 + 1.
+    /// </summary>
+    public const int PRIMITIVE_POLYNOMIAL = 0x11d;
+
+    private static readonly int[] LogTable = new int[256];
+    private static readonly int[] AlogTable = new int[256];
+
+    static Gf256()
+    {
+        var value = 1;
+        for (var index = 0; index < 255; index++)
+        {
+            AlogTable[index] = value;
+            LogTable[value] = index;
+
+            value <<= 1;
+            if (value >= 256)
+            {
+                value ^= PRIMITIVE_POLYNOMIAL;
+            }
+        }
+
+        AlogTable[255] = 1;
+    }
+
+    /// <summary>
+    /// Antilog table where ALOG[i] = 2^i in GF(256).
+    /// </summary>
+    public static IReadOnlyList<int> ALOG => Array.AsReadOnly(AlogTable);
+
+    /// <summary>
+    /// Log table where LOG[x] = i such that 2^i = x in GF(256).
+    /// </summary>
+    public static IReadOnlyList<int> LOG => Array.AsReadOnly(LogTable);
+
+    /// <summary>
+    /// Add two field elements. In characteristic 2 this is XOR.
+    /// </summary>
+    public static byte Add(byte a, byte b) => (byte)(a ^ b);
+
+    /// <summary>
+    /// Subtract two field elements. In characteristic 2 this is also XOR.
+    /// </summary>
+    public static byte Subtract(byte a, byte b) => (byte)(a ^ b);
+
+    /// <summary>
+    /// Multiply two field elements using log and antilog tables.
+    /// </summary>
+    public static byte Multiply(byte a, byte b)
+    {
+        if (a == 0 || b == 0)
+        {
+            return 0;
+        }
+
+        var exponent = (LogTable[a] + LogTable[b]) % 255;
+        return (byte)AlogTable[exponent];
+    }
+
+    /// <summary>
+    /// Divide a by b in GF(256).
+    /// </summary>
+    public static byte Divide(byte a, byte b)
+    {
+        if (b == 0)
+        {
+            throw new InvalidOperationException("GF256: division by zero");
+        }
+
+        if (a == 0)
+        {
+            return 0;
+        }
+
+        var exponent = ((LogTable[a] - LogTable[b] + 255) % 255 + 255) % 255;
+        return (byte)AlogTable[exponent];
+    }
+
+    /// <summary>
+    /// Raise a field element to a non-negative integer power.
+    /// </summary>
+    public static byte Power(byte @base, int exponent)
+    {
+        if (exponent < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(exponent), "Exponent must be non-negative.");
+        }
+
+        if (@base == 0)
+        {
+            return exponent == 0 ? ONE : ZERO;
+        }
+
+        if (exponent == 0)
+        {
+            return ONE;
+        }
+
+        var tableIndex = ((LogTable[@base] * exponent) % 255 + 255) % 255;
+        return (byte)AlogTable[tableIndex];
+    }
+
+    /// <summary>
+    /// Compute the multiplicative inverse of a non-zero field element.
+    /// </summary>
+    public static byte Inverse(byte a)
+    {
+        if (a == 0)
+        {
+            throw new InvalidOperationException("GF256: zero has no multiplicative inverse");
+        }
+
+        return (byte)AlogTable[255 - LogTable[a]];
+    }
+
+    /// <summary>
+    /// Return the additive identity.
+    /// </summary>
+    public static byte Zero() => ZERO;
+
+    /// <summary>
+    /// Return the multiplicative identity.
+    /// </summary>
+    public static byte One() => ONE;
+
+    /// <summary>
+    /// Create a GF(2^8) field for a different primitive polynomial.
+    /// </summary>
+    public static Gf256Field CreateField(int polynomial) => new(polynomial);
+}
+
+/// <summary>
+/// GF(2^8) field parameterized by an arbitrary primitive polynomial.
+/// </summary>
+public sealed class Gf256Field
+{
+    private readonly byte _reduce;
+
+    /// <summary>
+    /// Create a field using the provided primitive polynomial.
+    /// </summary>
+    public Gf256Field(int polynomial)
+    {
+        if (polynomial <= 0 || polynomial > 0x1FF)
+        {
+            throw new ArgumentOutOfRangeException(nameof(polynomial), "Polynomial must fit in 9 bits.");
+        }
+
+        Polynomial = polynomial;
+        _reduce = (byte)(polynomial & 0xFF);
+    }
+
+    /// <summary>
+    /// Primitive polynomial backing this field instance.
+    /// </summary>
+    public int Polynomial { get; }
+
+    /// <summary>
+    /// Add two field elements.
+    /// </summary>
+    public byte Add(byte a, byte b) => (byte)(a ^ b);
+
+    /// <summary>
+    /// Subtract two field elements.
+    /// </summary>
+    public byte Subtract(byte a, byte b) => (byte)(a ^ b);
+
+    /// <summary>
+    /// Multiply two field elements via Russian peasant multiplication.
+    /// </summary>
+    public byte Multiply(byte a, byte b) => MultiplyCore(a, b);
+
+    /// <summary>
+    /// Divide a by b in this field.
+    /// </summary>
+    public byte Divide(byte a, byte b)
+    {
+        if (b == 0)
+        {
+            throw new InvalidOperationException("GF256Field: division by zero");
+        }
+
+        return MultiplyCore(a, Power(b, 254));
+    }
+
+    /// <summary>
+    /// Raise a field element to a non-negative integer power.
+    /// </summary>
+    public byte Power(byte @base, int exponent)
+    {
+        if (exponent < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(exponent), "Exponent must be non-negative.");
+        }
+
+        if (@base == 0)
+        {
+            return exponent == 0 ? Gf256.ONE : Gf256.ZERO;
+        }
+
+        if (exponent == 0)
+        {
+            return Gf256.ONE;
+        }
+
+        var result = Gf256.ONE;
+        var factor = @base;
+        var remaining = exponent;
+
+        while (remaining > 0)
+        {
+            if ((remaining & 1) != 0)
+            {
+                result = MultiplyCore(result, factor);
+            }
+
+            factor = MultiplyCore(factor, factor);
+            remaining >>= 1;
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Compute the multiplicative inverse of a non-zero field element.
+    /// </summary>
+    public byte Inverse(byte a)
+    {
+        if (a == 0)
+        {
+            throw new InvalidOperationException("GF256Field: zero has no multiplicative inverse");
+        }
+
+        return Power(a, 254);
+    }
+
+    private byte MultiplyCore(byte a, byte b)
+    {
+        var result = 0;
+        var left = a;
+        var right = b;
+
+        for (var bit = 0; bit < 8; bit++)
+        {
+            if ((right & 1) != 0)
+            {
+                result ^= left;
+            }
+
+            var highBit = left & 0x80;
+            left = (byte)(left << 1);
+            if (highBit != 0)
+            {
+                left ^= _reduce;
+            }
+
+            right >>= 1;
+        }
+
+        return (byte)result;
+    }
+}

--- a/code/packages/csharp/gf256/README.md
+++ b/code/packages/csharp/gf256/README.md
@@ -1,0 +1,34 @@
+# gf256
+
+Finite-field arithmetic over `GF(2^8)` for byte-oriented coding theory and
+crypto building blocks such as Reed-Solomon, QR, and AES-style field math.
+
+## Layer 1
+
+This package is part of Layer 1 of the coding-adventures computing stack.
+
+## What It Includes
+
+- Reed-Solomon style field operations over primitive polynomial `0x11D`
+- Public `LOG` and `ALOG` tables for learning and debugging
+- `Add`, `Subtract`, `Multiply`, `Divide`, `Power`, `Inverse`
+- `CreateField` for alternate primitive polynomials such as AES `0x11B`
+
+## Example
+
+```csharp
+using CodingAdventures.Gf256;
+
+var product = Gf256.Multiply(0x53, 0x8c);
+Console.WriteLine(product); // 1
+
+var aes = Gf256.CreateField(0x11b);
+Console.WriteLine(aes.Multiply(0x57, 0x83)); // 193 (0xC1)
+```
+
+## Development
+
+```bash
+# Run tests
+bash BUILD
+```

--- a/code/packages/csharp/gf256/required_capabilities.json
+++ b/code/packages/csharp/gf256/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/gf256",
+  "capabilities": [],
+  "justification": "Pure in-memory arithmetic and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/gf256/tests/CodingAdventures.Gf256.Tests/CodingAdventures.Gf256.Tests.csproj
+++ b/code/packages/csharp/gf256/tests/CodingAdventures.Gf256.Tests/CodingAdventures.Gf256.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Gf256.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/gf256/tests/CodingAdventures.Gf256.Tests/Gf256Tests.cs
+++ b/code/packages/csharp/gf256/tests/CodingAdventures.Gf256.Tests/Gf256Tests.cs
@@ -1,0 +1,103 @@
+namespace CodingAdventures.Gf256.Tests;
+
+public sealed class Gf256Tests
+{
+    [Fact]
+    public void ExposesExpectedConstants()
+    {
+        Assert.Equal("0.1.0", Gf256.VERSION);
+        Assert.Equal((byte)0, Gf256.ZERO);
+        Assert.Equal((byte)1, Gf256.ONE);
+        Assert.Equal(0x11d, Gf256.PRIMITIVE_POLYNOMIAL);
+    }
+
+    [Fact]
+    public void LogAndAlogTablesMatchKnownValues()
+    {
+        Assert.Equal(256, Gf256.ALOG.Count);
+        Assert.Equal(256, Gf256.LOG.Count);
+        Assert.Equal(1, Gf256.ALOG[0]);
+        Assert.Equal(2, Gf256.ALOG[1]);
+        Assert.Equal(29, Gf256.ALOG[8]);
+        Assert.Equal(0, Gf256.LOG[1]);
+        Assert.Equal(1, Gf256.LOG[2]);
+
+        for (var value = 1; value <= 255; value++)
+        {
+            Assert.Equal(value, Gf256.ALOG[Gf256.LOG[value]]);
+        }
+    }
+
+    [Fact]
+    public void AddAndSubtractAreXor()
+    {
+        for (var value = 0; value <= 255; value++)
+        {
+            Assert.Equal((byte)value, Gf256.Add(0, (byte)value));
+            Assert.Equal((byte)0, Gf256.Add((byte)value, (byte)value));
+            Assert.Equal(Gf256.Add((byte)value, 0x42), Gf256.Subtract((byte)value, 0x42));
+        }
+
+        Assert.Equal((byte)0x99, Gf256.Add(0x53, 0xca));
+    }
+
+    [Fact]
+    public void MultiplyObeysIdentityZeroAndKnownSpotChecks()
+    {
+        for (var value = 0; value <= 255; value++)
+        {
+            Assert.Equal((byte)0, Gf256.Multiply((byte)value, 0));
+            Assert.Equal((byte)value, Gf256.Multiply((byte)value, 1));
+        }
+
+        Assert.Equal((byte)1, Gf256.Multiply(0x53, 0x8c));
+        Assert.Equal(Gf256.Multiply(0x34, 0x56), Gf256.Multiply(0x56, 0x34));
+    }
+
+    [Fact]
+    public void DivideAndInverseWorkForNonZeroInputs()
+    {
+        for (var value = 1; value <= 255; value++)
+        {
+            Assert.Equal((byte)1, Gf256.Divide((byte)value, (byte)value));
+            Assert.Equal((byte)value, Gf256.Divide((byte)value, 1));
+            Assert.Equal((byte)1, Gf256.Multiply((byte)value, Gf256.Inverse((byte)value)));
+        }
+
+        Assert.Equal((byte)0, Gf256.Divide(0, 1));
+        Assert.Throws<InvalidOperationException>(() => Gf256.Divide(1, 0));
+        Assert.Throws<InvalidOperationException>(() => Gf256.Inverse(0));
+    }
+
+    [Fact]
+    public void PowerHandlesZeroAndPositiveExponents()
+    {
+        Assert.Equal((byte)1, Gf256.Power(0, 0));
+        Assert.Equal((byte)0, Gf256.Power(0, 5));
+        Assert.Equal((byte)1, Gf256.Power(0x53, 0));
+        Assert.Equal((byte)0x53, Gf256.Power(0x53, 1));
+        Assert.Equal(Gf256.Multiply(0x53, 0x53), Gf256.Power(0x53, 2));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Gf256.Power(1, -1));
+    }
+
+    [Fact]
+    public void ZeroAndOneHelpersReturnFieldIdentities()
+    {
+        Assert.Equal(Gf256.ZERO, Gf256.Zero());
+        Assert.Equal(Gf256.ONE, Gf256.One());
+    }
+
+    [Fact]
+    public void AlternateFieldSupportsAesPolynomial()
+    {
+        var aes = Gf256.CreateField(0x11b);
+
+        Assert.Equal(0x11b, aes.Polynomial);
+        Assert.Equal((byte)0x01, aes.Multiply(0x53, 0xca));
+        Assert.Equal((byte)0xc1, aes.Multiply(0x57, 0x83));
+        Assert.Equal((byte)0x53, aes.Divide(0x53, 1));
+        Assert.Equal((byte)1, aes.Multiply(0x57, aes.Inverse(0x57)));
+        Assert.Throws<InvalidOperationException>(() => aes.Divide(1, 0));
+        Assert.Throws<InvalidOperationException>(() => aes.Inverse(0));
+    }
+}

--- a/code/packages/csharp/md5/BUILD
+++ b/code/packages/csharp/md5/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Md5.Tests/CodingAdventures.Md5.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/md5/BUILD_windows
+++ b/code/packages/csharp/md5/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Md5.Tests/CodingAdventures.Md5.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/md5/CHANGELOG.md
+++ b/code/packages/csharp/md5/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-16
+
+### Added
+
+- From-scratch MD5 implementation following RFC 1321
+- One-shot `SumMd5` and `HexString` helpers plus `ToHex`
+- Streaming `Md5Hasher` with copy, non-destructive digesting, and chunked update

--- a/code/packages/csharp/md5/CodingAdventures.Md5.csproj
+++ b/code/packages/csharp/md5/CodingAdventures.Md5.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Md5.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>From-scratch MD5 digest implementation with one-shot and streaming APIs</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\\**\\*.cs" />
+    <EmbeddedResource Remove="tests\\**" />
+    <None Remove="tests\\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/md5/Md5.cs
+++ b/code/packages/csharp/md5/Md5.cs
@@ -1,0 +1,309 @@
+using System;
+using System.Buffers.Binary;
+using System.Numerics;
+using System.Text;
+
+namespace CodingAdventures.Md5;
+
+// Md5.cs -- RFC 1321 message digests with explicit little-endian byte handling
+// ============================================================================
+//
+// MD5 consumes bytes in 64-byte blocks and maintains four 32-bit state words.
+// Two details matter most when implementing it correctly:
+//
+//   1. arithmetic is modulo 2^32
+//   2. words are read and written in little-endian order
+//
+// That little-endian rule is the main difference from the SHA-family hashes.
+
+/// <summary>
+/// MD5 message digest algorithm (RFC 1321) implemented from scratch.
+/// </summary>
+public static class Md5
+{
+    /// <summary>
+    /// Package version.
+    /// </summary>
+    public const string VERSION = "0.1.0";
+
+    private static readonly uint[] T = BuildTTable();
+
+    private static readonly byte[] S =
+    [
+        7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22,
+        5, 9, 14, 20, 5, 9, 14, 20, 5, 9, 14, 20, 5, 9, 14, 20,
+        4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23,
+        6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21,
+    ];
+
+    private const uint InitA = 0x67452301;
+    private const uint InitB = 0xefcdab89;
+    private const uint InitC = 0x98badcfe;
+    private const uint InitD = 0x10325476;
+
+    /// <summary>
+    /// Convert bytes to lowercase hexadecimal.
+    /// </summary>
+    public static string ToHex(ReadOnlySpan<byte> bytes)
+    {
+        var builder = new StringBuilder(bytes.Length * 2);
+        foreach (var value in bytes)
+        {
+            builder.Append(value.ToString("x2"));
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Compute the 16-byte MD5 digest of the provided data.
+    /// </summary>
+    public static byte[] SumMd5(ReadOnlySpan<byte> data)
+    {
+        var padded = Pad(data);
+        var a = InitA;
+        var b = InitB;
+        var c = InitC;
+        var d = InitD;
+
+        for (var offset = 0; offset < padded.Length; offset += 64)
+        {
+            (a, b, c, d) = CompressState(a, b, c, d, padded.AsSpan(offset, 64));
+        }
+
+        return StateToBytes(a, b, c, d);
+    }
+
+    /// <summary>
+    /// Compute MD5 and render it as a 32-character lowercase hexadecimal string.
+    /// </summary>
+    public static string HexString(ReadOnlySpan<byte> data) => ToHex(SumMd5(data));
+
+    internal static byte[] FinalizeDigest(
+        uint a,
+        uint b,
+        uint c,
+        uint d,
+        byte[] buffer,
+        int bufferLength,
+        ulong byteCount)
+    {
+        var afterBit = (bufferLength + 1) % 64;
+        var zeroCount = afterBit <= 56 ? 56 - afterBit : 64 + 56 - afterBit;
+        var finalBlock = new byte[bufferLength + 1 + zeroCount + 8];
+
+        Array.Copy(buffer, 0, finalBlock, 0, bufferLength);
+        finalBlock[bufferLength] = 0x80;
+        BinaryPrimitives.WriteUInt64LittleEndian(
+            finalBlock.AsSpan(finalBlock.Length - 8),
+            byteCount * 8);
+
+        for (var offset = 0; offset < finalBlock.Length; offset += 64)
+        {
+            (a, b, c, d) = CompressState(a, b, c, d, finalBlock.AsSpan(offset, 64));
+        }
+
+        return StateToBytes(a, b, c, d);
+    }
+
+    private static uint[] BuildTTable()
+    {
+        var table = new uint[64];
+        for (var index = 0; index < table.Length; index++)
+        {
+            table[index] = (uint)Math.Floor(Math.Abs(Math.Sin(index + 1.0)) * 4294967296.0);
+        }
+
+        return table;
+    }
+
+    private static byte[] Pad(ReadOnlySpan<byte> data)
+    {
+        var bitLength = (ulong)data.Length * 8;
+        var afterBit = (data.Length + 1) % 64;
+        var zeroCount = afterBit <= 56 ? 56 - afterBit : 64 + 56 - afterBit;
+        var result = new byte[data.Length + 1 + zeroCount + 8];
+
+        data.CopyTo(result);
+        result[data.Length] = 0x80;
+        BinaryPrimitives.WriteUInt64LittleEndian(result.AsSpan(result.Length - 8), bitLength);
+        return result;
+    }
+
+    internal static (uint A, uint B, uint C, uint D) CompressState(
+        uint stateA,
+        uint stateB,
+        uint stateC,
+        uint stateD,
+        ReadOnlySpan<byte> block)
+    {
+        Span<uint> words = stackalloc uint[16];
+        for (var index = 0; index < 16; index++)
+        {
+            words[index] = BinaryPrimitives.ReadUInt32LittleEndian(block.Slice(index * 4, 4));
+        }
+
+        var a = stateA;
+        var b = stateB;
+        var c = stateC;
+        var d = stateD;
+
+        for (var index = 0; index < 64; index++)
+        {
+            uint f;
+            int g;
+
+            if (index < 16)
+            {
+                f = (b & c) | (~b & d);
+                g = index;
+            }
+            else if (index < 32)
+            {
+                f = (d & b) | (~d & c);
+                g = (5 * index + 1) % 16;
+            }
+            else if (index < 48)
+            {
+                f = b ^ c ^ d;
+                g = (3 * index + 5) % 16;
+            }
+            else
+            {
+                f = c ^ (b | ~d);
+                g = (7 * index) % 16;
+            }
+
+            var inner = unchecked(a + f + words[g] + T[index]);
+            var temp = unchecked(b + BitOperations.RotateLeft(inner, S[index]));
+            a = d;
+            d = c;
+            c = b;
+            b = temp;
+        }
+
+        return (
+            unchecked(stateA + a),
+            unchecked(stateB + b),
+            unchecked(stateC + c),
+            unchecked(stateD + d));
+    }
+
+    private static byte[] StateToBytes(uint a, uint b, uint c, uint d)
+    {
+        var digest = new byte[16];
+        BinaryPrimitives.WriteUInt32LittleEndian(digest.AsSpan(0, 4), a);
+        BinaryPrimitives.WriteUInt32LittleEndian(digest.AsSpan(4, 4), b);
+        BinaryPrimitives.WriteUInt32LittleEndian(digest.AsSpan(8, 4), c);
+        BinaryPrimitives.WriteUInt32LittleEndian(digest.AsSpan(12, 4), d);
+        return digest;
+    }
+}
+
+/// <summary>
+/// Streaming MD5 hasher that accepts data in multiple chunks.
+/// </summary>
+public sealed class Md5Hasher
+{
+    private uint _a = 0x67452301;
+    private uint _b = 0xefcdab89;
+    private uint _c = 0x98badcfe;
+    private uint _d = 0x10325476;
+    private readonly byte[] _buffer = new byte[64];
+    private int _bufferLength;
+    private ulong _byteCount;
+
+    /// <summary>
+    /// Create a new streaming hasher with MD5's initial state.
+    /// </summary>
+    public Md5Hasher()
+    {
+    }
+
+    private Md5Hasher(
+        uint a,
+        uint b,
+        uint c,
+        uint d,
+        byte[] buffer,
+        int bufferLength,
+        ulong byteCount)
+    {
+        _a = a;
+        _b = b;
+        _c = c;
+        _d = d;
+        Array.Copy(buffer, _buffer, buffer.Length);
+        _bufferLength = bufferLength;
+        _byteCount = byteCount;
+    }
+
+    /// <summary>
+    /// Feed more bytes into the hash state.
+    /// </summary>
+    public Md5Hasher Update(ReadOnlySpan<byte> data)
+    {
+        _byteCount += (ulong)data.Length;
+        var offset = 0;
+
+        if (_bufferLength > 0)
+        {
+            var needed = 64 - _bufferLength;
+            var take = Math.Min(needed, data.Length);
+            data[..take].CopyTo(_buffer.AsSpan(_bufferLength));
+            _bufferLength += take;
+            offset += take;
+
+            if (_bufferLength == 64)
+            {
+                (_a, _b, _c, _d) = CompressBufferedBlock();
+                _bufferLength = 0;
+            }
+        }
+
+        while (offset + 64 <= data.Length)
+        {
+            (_a, _b, _c, _d) = CompressSpan(data.Slice(offset, 64));
+            offset += 64;
+        }
+
+        if (offset < data.Length)
+        {
+            data[offset..].CopyTo(_buffer.AsSpan(_bufferLength));
+            _bufferLength += data.Length - offset;
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// Return the current digest without mutating the hasher state.
+    /// </summary>
+    public byte[] Digest()
+    {
+        var bufferCopy = new byte[_bufferLength];
+        Array.Copy(_buffer, bufferCopy, _bufferLength);
+        return Md5.FinalizeDigest(_a, _b, _c, _d, bufferCopy, _bufferLength, _byteCount);
+    }
+
+    /// <summary>
+    /// Alias for <see cref="Digest"/>.
+    /// </summary>
+    public byte[] SumMd5() => Digest();
+
+    /// <summary>
+    /// Return the current digest as lowercase hexadecimal.
+    /// </summary>
+    public string HexDigest() => Md5.ToHex(Digest());
+
+    /// <summary>
+    /// Clone the current streaming state.
+    /// </summary>
+    public Md5Hasher Copy() => new(_a, _b, _c, _d, _buffer, _bufferLength, _byteCount);
+
+    private (uint A, uint B, uint C, uint D) CompressBufferedBlock() =>
+        CompressSpan(_buffer);
+
+    private (uint A, uint B, uint C, uint D) CompressSpan(ReadOnlySpan<byte> block) =>
+        Md5.CompressState(_a, _b, _c, _d, block);
+}

--- a/code/packages/csharp/md5/README.md
+++ b/code/packages/csharp/md5/README.md
@@ -1,0 +1,32 @@
+# md5
+
+From-scratch MD5 implementation following RFC 1321, including both one-shot
+and streaming APIs.
+
+## Layer 1
+
+This package is part of Layer 1 of the coding-adventures computing stack.
+
+## What It Includes
+
+- `SumMd5` for the 16-byte digest
+- `HexString` and `ToHex` for lowercase hexadecimal rendering
+- `Md5Hasher` for incremental hashing across multiple chunks
+- Literate comments on little-endian block parsing and Davies-Meyer feed-forward
+
+## Example
+
+```csharp
+using System.Text;
+using CodingAdventures.Md5;
+
+var digest = Md5.HexString(Encoding.UTF8.GetBytes("abc"));
+Console.WriteLine(digest); // 900150983cd24fb0d6963f7d28e17f72
+```
+
+## Development
+
+```bash
+# Run tests
+bash BUILD
+```

--- a/code/packages/csharp/md5/required_capabilities.json
+++ b/code/packages/csharp/md5/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/md5",
+  "capabilities": [],
+  "justification": "Pure in-memory digest implementation and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/md5/tests/CodingAdventures.Md5.Tests/CodingAdventures.Md5.Tests.csproj
+++ b/code/packages/csharp/md5/tests/CodingAdventures.Md5.Tests/CodingAdventures.Md5.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Md5.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/md5/tests/CodingAdventures.Md5.Tests/Md5Tests.cs
+++ b/code/packages/csharp/md5/tests/CodingAdventures.Md5.Tests/Md5Tests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Linq;
+using System.Text;
+using Md5HasherType = CodingAdventures.Md5.Md5Hasher;
+using Md5Type = CodingAdventures.Md5.Md5;
+
+namespace CodingAdventures.Md5.Tests;
+
+public sealed class Md5Tests
+{
+    [Fact]
+    public void VersionAndHexUtilitiesMatchExpectedOutput()
+    {
+        Assert.Equal("0.1.0", Md5Type.VERSION);
+        Assert.Equal(string.Empty, Md5Type.ToHex(Array.Empty<byte>()));
+        Assert.Equal("00", Md5Type.ToHex([0x00]));
+        Assert.Equal("ff", Md5Type.ToHex([0xff]));
+        Assert.Equal("d41d8cd9", Md5Type.ToHex([0xd4, 0x1d, 0x8c, 0xd9]));
+    }
+
+    [Fact]
+    public void Rfc1321VectorsAllMatch()
+    {
+        Assert.Equal("d41d8cd98f00b204e9800998ecf8427e", Hex(""));
+        Assert.Equal("0cc175b9c0f1b6a831c399e269772661", Hex("a"));
+        Assert.Equal("900150983cd24fb0d6963f7d28e17f72", Hex("abc"));
+        Assert.Equal("f96b697d7cb7938d525a2f31aaf161d0", Hex("message digest"));
+        Assert.Equal("c3fcd3d76192e4007dfb496cca67e13b", Hex("abcdefghijklmnopqrstuvwxyz"));
+        Assert.Equal(
+            "d174ab98d277d9f5a5611c2c9f419d9f",
+            Hex("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"));
+        Assert.Equal(
+            "57edf4a22be3c955ac49da2e2107b67a",
+            Hex("12345678901234567890123456789012345678901234567890123456789012345678901234567890"));
+    }
+
+    [Fact]
+    public void KnownDigestsAndLittleEndianChecksMatch()
+    {
+        Assert.Equal("9e107d9d372bb6826bd81d3542a419d6", Hex("The quick brown fox jumps over the lazy dog"));
+        Assert.Equal("e4d909c290d0fb1ca068ffaddf22cbd0", Hex("The quick brown fox jumps over the lazy dog."));
+        Assert.Equal("93b885adfe0da089cdf634904fd59f71", Md5Type.HexString([0x00]));
+        Assert.Equal("00594fd4f42ba43fc1ca0427a0576295", Md5Type.HexString([0xff]));
+
+        var emptyDigest = Md5Type.SumMd5(Array.Empty<byte>());
+        Assert.Equal(16, emptyDigest.Length);
+        Assert.Equal(0xd4, emptyDigest[0]);
+        Assert.Equal(0x1d, emptyDigest[1]);
+    }
+
+    [Fact]
+    public void OneShotDigestAlwaysReturnsSixteenBytesAndLowercaseHex()
+    {
+        Assert.Equal(16, Md5Type.SumMd5(Encode("")).Length);
+        Assert.Equal(16, Md5Type.SumMd5(Encode("abc")).Length);
+        Assert.Equal(16, Md5Type.SumMd5(new byte[1000]).Length);
+
+        var hex = Md5Type.HexString(Encode("hello world"));
+        Assert.Equal(32, hex.Length);
+        Assert.Matches("^[0-9a-f]{32}$", hex);
+        Assert.Equal(hex, Md5Type.ToHex(Md5Type.SumMd5(Encode("hello world"))));
+    }
+
+    [Fact]
+    public void BlockBoundaryLengthsRemainStable()
+    {
+        foreach (var length in new[] { 55, 56, 63, 64, 65, 128 })
+        {
+            var data = Enumerable.Repeat((byte)'a', length).ToArray();
+            var oneShot = Md5Type.HexString(data);
+
+            var hasher = new Md5HasherType();
+            hasher.Update(data[..Math.Min(13, data.Length)]);
+            hasher.Update(data[Math.Min(13, data.Length)..]);
+
+            Assert.Equal(oneShot, hasher.HexDigest());
+        }
+    }
+
+    [Fact]
+    public void StreamingHasherMatchesOneShotAcrossArbitraryChunks()
+    {
+        var data = Enumerable.Range(0, 256).Select(value => (byte)value).ToArray();
+        var expected = Md5Type.HexString(data);
+
+        var hasher = new Md5HasherType();
+        hasher.Update(data[..7]);
+        hasher.Update(data[7..111]);
+        hasher.Update(data[111..192]);
+        hasher.Update(data[192..]);
+
+        Assert.Equal(expected, hasher.HexDigest());
+        Assert.Equal(expected, Md5Type.ToHex(hasher.Digest()));
+    }
+
+    [Fact]
+    public void DigestIsNonDestructiveAndHasherCanContinueAfterDigesting()
+    {
+        var hasher = new Md5HasherType();
+        hasher.Update(Encode("hello"));
+
+        var first = hasher.HexDigest();
+        Assert.Equal(first, hasher.HexDigest());
+        Assert.Equal(Md5Type.HexString(Encode("hello")), first);
+
+        hasher.Update(Encode(" world"));
+        Assert.Equal(Md5Type.HexString(Encode("hello world")), hasher.HexDigest());
+    }
+
+    [Fact]
+    public void CopyCreatesIndependentStreamingStates()
+    {
+        var original = new Md5HasherType();
+        original.Update(Encode("ab"));
+
+        var copy = original.Copy();
+        copy.Update(Encode("c"));
+        original.Update(Encode("x"));
+
+        Assert.Equal(Md5Type.HexString(Encode("abc")), copy.HexDigest());
+        Assert.Equal(Md5Type.HexString(Encode("abx")), original.HexDigest());
+    }
+
+    private static byte[] Encode(string value) => Encoding.UTF8.GetBytes(value);
+
+    private static string Hex(string value) => Md5Type.HexString(Encode(value));
+}

--- a/code/packages/fsharp/csv-parser/BUILD
+++ b/code/packages/fsharp/csv-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.CsvParser.Tests/CodingAdventures.CsvParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/csv-parser/BUILD_windows
+++ b/code/packages/fsharp/csv-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.CsvParser.Tests/CodingAdventures.CsvParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/csv-parser/CHANGELOG.md
+++ b/code/packages/fsharp/csv-parser/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-16
+
+### Added
+
+- RFC 4180 style CSV parser built as a small explicit state machine
+- Support for quoted commas, embedded newlines, and ragged rows
+- Tests covering blank lines, custom delimiters, and unclosed-quote failures

--- a/code/packages/fsharp/csv-parser/CodingAdventures.CsvParser.fsproj
+++ b/code/packages/fsharp/csv-parser/CodingAdventures.CsvParser.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.CsvParser.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>State-machine CSV parser with quoted-field and ragged-row support</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="CsvParser.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/csv-parser/CsvParser.fs
+++ b/code/packages/fsharp/csv-parser/CsvParser.fs
@@ -1,0 +1,172 @@
+namespace CodingAdventures.CsvParser
+
+open System
+open System.Collections.Generic
+open System.Text
+
+// CsvParser.fs -- CSV needs state because commas do not always mean "next field"
+// =============================================================================
+//
+// A comma outside quotes separates columns.
+// A comma inside quotes is ordinary text.
+//
+// That single rule is why CSV parsing becomes a state machine instead of a
+// string split. The parser must remember which mode it is in at every step.
+
+/// Raised when the input ends while the parser is still inside a quoted field.
+type UnclosedQuoteError() =
+    inherit Exception("unclosed quoted field: EOF reached inside a quoted field")
+
+[<RequireQualifiedAccess>]
+module CsvParser =
+    type private ParseState =
+        | FieldStart
+        | InUnquotedField
+        | InQuotedField
+        | InQuotedMaybeEnd
+
+    let private isNewlineStart ch =
+        ch = '\n' || ch = '\r'
+
+    let private consumeNewline (source: string) index =
+        if source[index] = '\r' && index + 1 < source.Length && source[index + 1] = '\n' then
+            index + 2
+        else
+            index + 1
+
+    let private buildRowMap (header: string array) (row: string array) =
+        let map = Dictionary<string, string>(header.Length, StringComparer.Ordinal)
+
+        for index in 0 .. header.Length - 1 do
+            map[header[index]] <-
+                if index < row.Length then
+                    row[index]
+                else
+                    String.Empty
+
+        map
+
+    let private tokeniseRows (source: string) delimiter =
+        let rows = ResizeArray<string array>()
+        let mutable currentRow = ResizeArray<string>()
+        let fieldBuffer = StringBuilder()
+        let mutable state = ParseState.FieldStart
+        let mutable index = 0
+
+        while index < source.Length do
+            let ch = source[index]
+            let mutable advance = true
+
+            match state with
+            | ParseState.FieldStart ->
+                if ch = '"' then
+                    state <- ParseState.InQuotedField
+                elif ch = delimiter then
+                    currentRow.Add(String.Empty)
+                elif isNewlineStart ch then
+                    if currentRow.Count > 0 then
+                        currentRow.Add(String.Empty)
+
+                    rows.Add(currentRow |> Seq.toArray)
+                    currentRow <- ResizeArray<string>()
+                    index <- consumeNewline source index
+                    advance <- false
+                else
+                    fieldBuffer.Append(ch) |> ignore
+                    state <- ParseState.InUnquotedField
+
+            | ParseState.InUnquotedField ->
+                if ch = delimiter then
+                    currentRow.Add(fieldBuffer.ToString())
+                    fieldBuffer.Clear() |> ignore
+                    state <- ParseState.FieldStart
+                elif isNewlineStart ch then
+                    currentRow.Add(fieldBuffer.ToString())
+                    fieldBuffer.Clear() |> ignore
+                    rows.Add(currentRow |> Seq.toArray)
+                    currentRow <- ResizeArray<string>()
+                    state <- ParseState.FieldStart
+                    index <- consumeNewline source index
+                    advance <- false
+                else
+                    fieldBuffer.Append(ch) |> ignore
+
+            | ParseState.InQuotedField ->
+                if ch = '"' then
+                    state <- ParseState.InQuotedMaybeEnd
+                else
+                    fieldBuffer.Append(ch) |> ignore
+
+            | ParseState.InQuotedMaybeEnd ->
+                if ch = '"' then
+                    fieldBuffer.Append('"') |> ignore
+                    state <- ParseState.InQuotedField
+                elif ch = delimiter then
+                    currentRow.Add(fieldBuffer.ToString())
+                    fieldBuffer.Clear() |> ignore
+                    state <- ParseState.FieldStart
+                elif isNewlineStart ch then
+                    currentRow.Add(fieldBuffer.ToString())
+                    fieldBuffer.Clear() |> ignore
+                    rows.Add(currentRow |> Seq.toArray)
+                    currentRow <- ResizeArray<string>()
+                    state <- ParseState.FieldStart
+                    index <- consumeNewline source index
+                    advance <- false
+                else
+                    fieldBuffer.Append(ch) |> ignore
+                    state <- ParseState.InUnquotedField
+
+            if advance then
+                index <- index + 1
+
+        match state with
+        | ParseState.FieldStart ->
+            if currentRow.Count > 0 then
+                currentRow.Add(String.Empty)
+                rows.Add(currentRow |> Seq.toArray)
+
+        | ParseState.InUnquotedField ->
+            currentRow.Add(fieldBuffer.ToString())
+            rows.Add(currentRow |> Seq.toArray)
+
+        | ParseState.InQuotedField ->
+            raise (UnclosedQuoteError())
+
+        | ParseState.InQuotedMaybeEnd ->
+            currentRow.Add(fieldBuffer.ToString())
+            rows.Add(currentRow |> Seq.toArray)
+
+        rows |> Seq.toArray
+
+    /// Parse CSV text using a comma as the delimiter.
+    let rec parseCsv (source: string) =
+        parseCsvWithDelimiter source ','
+
+    /// Parse CSV text using a custom delimiter.
+    and parseCsvWithDelimiter (source: string) (delimiter: char) =
+        if isNull source then
+            nullArg "source"
+
+        if delimiter = '"' then
+            invalidArg "delimiter" "Delimiter cannot be a double quote."
+
+        let rawRows = tokeniseRows source delimiter
+
+        if rawRows.Length = 0 then
+            [||]
+        elif rawRows.Length = 1 then
+            [||]
+        else
+            let header = rawRows[0]
+            rawRows[1..] |> Array.map (buildRowMap header)
+
+    /// Parse CSV text using a single-character delimiter string.
+    let parseCsvWithDelimiterString (source: string) (delimiter: string) =
+        if isNull delimiter then
+            nullArg "delimiter"
+
+        if delimiter.Length <> 1 then
+            invalidArg "delimiter" "Delimiter must be a single character."
+
+        parseCsvWithDelimiter source delimiter[0]

--- a/code/packages/fsharp/csv-parser/README.md
+++ b/code/packages/fsharp/csv-parser/README.md
@@ -1,0 +1,33 @@
+# csv-parser
+
+Hand-rolled CSV parser that follows RFC 4180 style quoting rules with support
+for quoted commas, embedded newlines, blank fields, and ragged rows.
+
+## Layer 1
+
+This package is part of Layer 1 of the coding-adventures computing stack.
+
+## What It Includes
+
+- `CsvParser.parseCsv` for comma-separated input
+- `CsvParser.parseCsvWithDelimiter` for TSV or other custom delimiters
+- `UnclosedQuoteError` when the input ends inside a quoted field
+- Ragged-row handling that pads missing columns with `""` and truncates extras
+
+## Example
+
+```fsharp
+open CodingAdventures.CsvParser
+
+let csv = "name,city\nAlice,\"New York, NY\"\n"
+let rows = CsvParser.parseCsv csv
+
+printfn "%s" rows[0]["city"] // New York, NY
+```
+
+## Development
+
+```bash
+# Run tests
+bash BUILD
+```

--- a/code/packages/fsharp/csv-parser/required_capabilities.json
+++ b/code/packages/fsharp/csv-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/csv-parser",
+  "capabilities": [],
+  "justification": "Pure in-memory parser and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/csv-parser/tests/CodingAdventures.CsvParser.Tests/CodingAdventures.CsvParser.Tests.fsproj
+++ b/code/packages/fsharp/csv-parser/tests/CodingAdventures.CsvParser.Tests/CodingAdventures.CsvParser.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.CsvParser.fsproj" />
+    <Compile Include="CsvParserTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/csv-parser/tests/CodingAdventures.CsvParser.Tests/CsvParserTests.fs
+++ b/code/packages/fsharp/csv-parser/tests/CodingAdventures.CsvParser.Tests/CsvParserTests.fs
@@ -1,0 +1,104 @@
+namespace CodingAdventures.CsvParser.Tests
+
+open System
+open System.Collections.Generic
+open Xunit
+open CodingAdventures.CsvParser
+
+type CsvParserTests() =
+    let assertRow (row: IReadOnlyDictionary<string, string>) (expected: (string * string) array) =
+        Assert.Equal(expected.Length, row.Count)
+
+        for key, value in expected do
+            Assert.Equal(value, row[key])
+
+    [<Fact>]
+    member _.``parses simple tables and keeps values as strings``() =
+        let rows = CsvParser.parseCsv "name,age,city\nAlice,30,New York\nBob,25,London\n"
+
+        Assert.Equal(2, rows.Length)
+        assertRow rows[0] [| ("name", "Alice"); ("age", "30"); ("city", "New York") |]
+        assertRow rows[1] [| ("name", "Bob"); ("age", "25"); ("city", "London") |]
+
+    [<Fact>]
+    member _.``handles empty input header-only files and missing trailing newlines``() =
+        Assert.Empty(CsvParser.parseCsv String.Empty)
+        Assert.Empty(CsvParser.parseCsv "name,age\n")
+
+        let rows = CsvParser.parseCsv "name,value\nhello,world"
+        Assert.Single rows |> ignore
+        assertRow rows[0] [| ("name", "hello"); ("value", "world") |]
+
+    [<Fact>]
+    member _.``quoted fields handle commas embedded newlines and escaped quotes``() =
+        let commaRows = CsvParser.parseCsv "product,description\nWidget,\"A small, round widget\"\n"
+        Assert.Single commaRows |> ignore
+        assertRow commaRows[0] [| ("product", "Widget"); ("description", "A small, round widget") |]
+
+        let newlineRows = CsvParser.parseCsv "note,text\n1,\"Line one\nLine two\"\n"
+        Assert.Single newlineRows |> ignore
+        assertRow newlineRows[0] [| ("note", "1"); ("text", "Line one\nLine two") |]
+
+        let escapedQuoteRows = CsvParser.parseCsv "quote,value\n2,\"She said \"\"hello\"\"\"\n"
+        Assert.Single escapedQuoteRows |> ignore
+        assertRow escapedQuoteRows[0] [| ("quote", "2"); ("value", "She said \"hello\"") |]
+
+    [<Fact>]
+    member _.``empty fields and blank lines become empty strings``() =
+        let rows = CsvParser.parseCsv "a,b,c\n,2,\n,,\n"
+        Assert.Equal(2, rows.Length)
+        assertRow rows[0] [| ("a", String.Empty); ("b", "2"); ("c", String.Empty) |]
+        assertRow rows[1] [| ("a", String.Empty); ("b", String.Empty); ("c", String.Empty) |]
+
+        let blankLineRows = CsvParser.parseCsv "a\n\n"
+        Assert.Single blankLineRows |> ignore
+        assertRow blankLineRows[0] [| ("a", String.Empty) |]
+
+    [<Fact>]
+    member _.``ragged rows are padded and truncated to header length``() =
+        let rows =
+            CsvParser.parseCsv "a,b,c\n1\n2,two\n3,three,THREE\n4,four,FOUR,extra\n"
+
+        Assert.Equal(4, rows.Length)
+        assertRow rows[0] [| ("a", "1"); ("b", String.Empty); ("c", String.Empty) |]
+        assertRow rows[1] [| ("a", "2"); ("b", "two"); ("c", String.Empty) |]
+        assertRow rows[2] [| ("a", "3"); ("b", "three"); ("c", "THREE") |]
+        assertRow rows[3] [| ("a", "4"); ("b", "four"); ("c", "FOUR") |]
+
+    [<Fact>]
+    member _.``supports lf crlf and cr line endings``() =
+        let lf = CsvParser.parseCsv "a,b\n1,2\n"
+        let crlf = CsvParser.parseCsv "a,b\r\n1,2\r\n"
+        let cr = CsvParser.parseCsv "a,b\r1,2\r"
+
+        assertRow lf[0] [| ("a", "1"); ("b", "2") |]
+        assertRow crlf[0] [| ("a", "1"); ("b", "2") |]
+        assertRow cr[0] [| ("a", "1"); ("b", "2") |]
+
+    [<Fact>]
+    member _.``supports custom delimiters``() =
+        let rows = CsvParser.parseCsvWithDelimiter "name\tage\nAlice\t30\n" '\t'
+        Assert.Single rows |> ignore
+        assertRow rows[0] [| ("name", "Alice"); ("age", "30") |]
+
+        let pipeRows = CsvParser.parseCsvWithDelimiterString "name|age\nBob|25\n" "|"
+        Assert.Single pipeRows |> ignore
+        assertRow pipeRows[0] [| ("name", "Bob"); ("age", "25") |]
+
+    [<Fact>]
+    member _.``preserves whitespace outside quotes``() =
+        let rows = CsvParser.parseCsv "a,b\n  spaced  ,\"trim? no\"\n"
+        Assert.Single rows |> ignore
+        assertRow rows[0] [| ("a", "  spaced  "); ("b", "trim? no") |]
+
+    [<Fact>]
+    member _.``throws when quoted field is not closed``() =
+        Assert.Throws<UnclosedQuoteError>(fun () -> CsvParser.parseCsv "a,b\n1,\"oops" |> ignore)
+        |> ignore
+
+    [<Fact>]
+    member _.``validates delimiter inputs``() =
+        Assert.Throws<ArgumentException>(fun () -> CsvParser.parseCsvWithDelimiter "a,b\n" '"' |> ignore)
+        |> ignore
+        Assert.Throws<ArgumentException>(fun () -> CsvParser.parseCsvWithDelimiterString "a,b\n" "||" |> ignore)
+        |> ignore

--- a/code/packages/fsharp/fenwick-tree/BUILD
+++ b/code/packages/fsharp/fenwick-tree/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.FenwickTree.Tests/CodingAdventures.FenwickTree.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/fenwick-tree/BUILD_windows
+++ b/code/packages/fsharp/fenwick-tree/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.FenwickTree.Tests/CodingAdventures.FenwickTree.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/fenwick-tree/CHANGELOG.md
+++ b/code/packages/fsharp/fenwick-tree/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-16
+
+### Added
+
+- Literate `FenwickTree` type covering prefix sums, range sums, point updates,
+  and order-statistic search
+- Explicit error types for empty-tree and index-range failures
+- Deterministic tests for construction, updates, and brute-force correctness

--- a/code/packages/fsharp/fenwick-tree/CodingAdventures.FenwickTree.fsproj
+++ b/code/packages/fsharp/fenwick-tree/CodingAdventures.FenwickTree.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.FenwickTree.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Fenwick tree for prefix sums, range sums, and point updates</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="FenwickTree.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/fenwick-tree/FenwickTree.fs
+++ b/code/packages/fsharp/fenwick-tree/FenwickTree.fs
@@ -1,0 +1,176 @@
+namespace CodingAdventures.FenwickTree
+
+open System
+open System.Globalization
+
+module private FenwickHelpers =
+    let lowBit index = index &&& -index
+
+    let highestPowerOfTwoAtMost value =
+        let mutable result = 1
+
+        while result <= value / 2 do
+            result <- result <<< 1
+
+        result
+
+    let formatFloat (value: float) =
+        value.ToString("G17", CultureInfo.InvariantCulture)
+
+// FenwickTree.fs -- Prefix sums encoded as overlapping power-of-two ranges
+// ==========================================================================
+//
+// A Fenwick tree stores partial sums in a 1-based array. Index i is
+// responsible for the range whose width is lowBit(i):
+//
+//   i = 12 = 1100b
+//   lowBit(i) = 0100b = 4
+//
+// So slot 12 stores the total for the last four values ending at 12.
+// Moving upward by adding lowBit(i) reaches larger covering ranges; moving
+// downward by subtracting lowBit(i) peels those ranges back off.
+
+/// Base class for Fenwick-tree specific errors.
+type FenwickError(message: string) =
+    inherit Exception(message)
+
+/// Raised when an operation uses an index outside the legal range.
+type FenwickIndexOutOfRangeError(message: string) =
+    inherit FenwickError(message)
+
+/// Raised when findKth is called on an empty tree.
+type FenwickEmptyTreeError(message: string) =
+    inherit FenwickError(message)
+
+/// Binary Indexed Tree for prefix sums with point updates.
+type FenwickTree(length: int) =
+    let treeLength = length
+    let bit = Array.zeroCreate<float> (length + 1)
+
+    do
+        if length < 0 then
+            raise (FenwickError(sprintf "Size must be a non-negative integer, got %d" length))
+
+    static member FromList(values: seq<float>) =
+        if isNull (box values) then
+            nullArg "values"
+
+        let data = values |> Seq.toArray
+        let tree = FenwickTree(data.Length)
+
+        for index in 1 .. tree.Length do
+            tree.SetTreeValue(index, tree.GetTreeValue(index) + data[index - 1])
+            let parent = index + FenwickHelpers.lowBit index
+
+            if parent <= tree.Length then
+                tree.SetTreeValue(parent, tree.GetTreeValue(parent) + tree.GetTreeValue(index))
+
+        tree
+
+    /// Number of values stored in the logical array.
+    member _.Length = treeLength
+
+    /// Whether the tree has zero elements.
+    member _.IsEmpty = treeLength = 0
+
+    /// Add delta to the value at index.
+    member this.Update(index: int, delta: float) =
+        this.CheckIndex(index)
+        let mutable current = index
+
+        while current <= treeLength do
+            bit[current] <- bit[current] + delta
+            current <- current + FenwickHelpers.lowBit current
+
+    /// Return the sum of elements in the inclusive range 1..index.
+    member _.PrefixSum(index: int) =
+        if index < 0 || index > treeLength then
+            raise (
+                FenwickIndexOutOfRangeError(
+                    sprintf "prefixSum index %d out of range [0, %d]" index treeLength
+                )
+            )
+
+        let mutable total = 0.0
+        let mutable current = index
+
+        while current > 0 do
+            total <- total + bit[current]
+            current <- current - FenwickHelpers.lowBit current
+
+        total
+
+    /// Return the sum of the inclusive range left..right.
+    member this.RangeSum(left: int, right: int) =
+        if left > right then
+            raise (FenwickError(sprintf "left (%d) must be <= right (%d)" left right))
+
+        this.CheckIndex(left)
+        this.CheckIndex(right)
+
+        if left = 1 then
+            this.PrefixSum(right)
+        else
+            this.PrefixSum(right) - this.PrefixSum(left - 1)
+
+    /// Return the exact value stored at one index.
+    member this.PointQuery(index: int) =
+        this.CheckIndex(index)
+        this.RangeSum(index, index)
+
+    /// Find the smallest index whose prefix sum is at least target.
+    member this.FindKth(target: float) =
+        if treeLength = 0 then
+            raise (FenwickEmptyTreeError("findKth called on empty tree"))
+
+        if target <= 0.0 then
+            raise (FenwickError(sprintf "k must be positive, got %s" (FenwickHelpers.formatFloat target)))
+
+        let total = this.PrefixSum(treeLength)
+
+        if target > total then
+            raise (
+                FenwickError(
+                    sprintf
+                        "k (%s) exceeds total sum of the tree (%s)"
+                        (FenwickHelpers.formatFloat target)
+                        (FenwickHelpers.formatFloat total)
+                )
+            )
+
+        let mutable index = 0
+        let mutable remaining = target
+        let mutable step = FenwickHelpers.highestPowerOfTwoAtMost treeLength
+
+        while step > 0 do
+            let nextIndex = index + step
+
+            if nextIndex <= treeLength && bit[nextIndex] < remaining then
+                index <- nextIndex
+                remaining <- remaining - bit[nextIndex]
+
+            step <- step >>> 1
+
+        index + 1
+
+    override _.ToString() =
+        let rendered =
+            bit
+            |> Array.skip 1
+            |> Array.map FenwickHelpers.formatFloat
+            |> String.concat ", "
+
+        sprintf "FenwickTree(n=%d, bit=[%s])" treeLength rendered
+
+    member private _.CheckIndex(index: int) =
+        if index < 1 || index > treeLength then
+            raise (
+                FenwickIndexOutOfRangeError(
+                    sprintf "Index %d out of range [1, %d]" index treeLength
+                )
+            )
+
+    member private _.GetTreeValue(index: int) = bit[index]
+
+    member private _.SetTreeValue(index: int, value: float) =
+        bit[index] <- value

--- a/code/packages/fsharp/fenwick-tree/README.md
+++ b/code/packages/fsharp/fenwick-tree/README.md
@@ -1,0 +1,35 @@
+# fenwick-tree
+
+Fenwick tree, also called a Binary Indexed Tree, for prefix sums, range sums,
+and point updates in `O(log n)` time.
+
+## Layer 1
+
+This package is part of Layer 1 of the coding-adventures computing stack.
+
+## What It Includes
+
+- `FenwickTree(length)` for zero-filled construction
+- `FenwickTree.FromList` for linear-time building from existing values
+- `Update`, `PrefixSum`, `RangeSum`, and `PointQuery`
+- `FindKth` for prefix-sum order statistics
+- Inline commentary on why `lowBit(index)` reveals each node's covered range
+
+## Example
+
+```fsharp
+open CodingAdventures.FenwickTree
+
+let tree = FenwickTree.FromList([ 3.0; 2.0; 1.0; 7.0; 4.0 ])
+
+printfn "%f" (tree.PrefixSum(4)) // 13.000000
+tree.Update(3, 5.0)
+printfn "%f" (tree.PointQuery(3)) // 6.000000
+```
+
+## Development
+
+```bash
+# Run tests
+bash BUILD
+```

--- a/code/packages/fsharp/fenwick-tree/required_capabilities.json
+++ b/code/packages/fsharp/fenwick-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/fenwick-tree",
+  "capabilities": [],
+  "justification": "Pure in-memory data structure and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/fenwick-tree/tests/CodingAdventures.FenwickTree.Tests/CodingAdventures.FenwickTree.Tests.fsproj
+++ b/code/packages/fsharp/fenwick-tree/tests/CodingAdventures.FenwickTree.Tests/CodingAdventures.FenwickTree.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.FenwickTree.fsproj" />
+    <Compile Include="FenwickTreeTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/fenwick-tree/tests/CodingAdventures.FenwickTree.Tests/FenwickTreeTests.fs
+++ b/code/packages/fsharp/fenwick-tree/tests/CodingAdventures.FenwickTree.Tests/FenwickTreeTests.fs
@@ -1,0 +1,157 @@
+namespace CodingAdventures.FenwickTree.Tests
+
+open System
+open Xunit
+open CodingAdventures.FenwickTree
+
+type FenwickTreeTests() =
+    let epsilon = 1e-9
+
+    let assertClose actual expected =
+        Assert.True(
+            abs (actual - expected) < epsilon,
+            sprintf "Expected %f, got %f" expected actual
+        )
+
+    let brutePrefix (values: float array) index =
+        values[.. index - 1] |> Array.sum
+
+    let bruteRange (values: float array) left right =
+        values[left - 1 .. right - 1] |> Array.sum
+
+    [<Fact>]
+    member _.``construction validates size and tracks length``() =
+        let empty = FenwickTree(0)
+        Assert.Equal(0, empty.Length)
+        Assert.True(empty.IsEmpty)
+        Assert.Equal(0.0, empty.PrefixSum(0))
+
+        let sized = FenwickTree(5)
+        Assert.Equal(5, sized.Length)
+        Assert.False(sized.IsEmpty)
+
+        Assert.Throws<FenwickError>(fun () -> FenwickTree(-1) |> ignore)
+        |> ignore
+
+    [<Fact>]
+    member _.``fromList builds expected prefix totals``() =
+        let tree = FenwickTree.FromList([ 3.0; 2.0; 1.0; 7.0; 4.0 ])
+
+        assertClose (tree.PrefixSum(1)) 3.0
+        assertClose (tree.PrefixSum(2)) 5.0
+        assertClose (tree.PrefixSum(3)) 6.0
+        assertClose (tree.PrefixSum(4)) 13.0
+        assertClose (tree.PrefixSum(5)) 17.0
+
+    [<Fact>]
+    member _.``prefix range and point queries match expected values``() =
+        let tree = FenwickTree.FromList([ 3.0; 2.0; 1.0; 7.0; 4.0 ])
+
+        assertClose (tree.PrefixSum(0)) 0.0
+        assertClose (tree.RangeSum(1, 5)) 17.0
+        assertClose (tree.RangeSum(2, 4)) 10.0
+        assertClose (tree.PointQuery(4)) 7.0
+
+    [<Fact>]
+    member _.``update applies positive and negative deltas``() =
+        let tree = FenwickTree.FromList([ 3.0; 2.0; 1.0; 7.0; 4.0 ])
+
+        tree.Update(3, 5.0)
+        assertClose (tree.PointQuery(3)) 6.0
+        assertClose (tree.PrefixSum(3)) 11.0
+
+        tree.Update(2, -1.0)
+        assertClose (tree.PointQuery(2)) 1.0
+        assertClose (tree.PrefixSum(3)) 10.0
+
+    [<Fact>]
+    member _.``update from index one propagates across power-of-two parents``() =
+        let tree = FenwickTree.FromList(Array.zeroCreate<float> 8)
+
+        tree.Update(1, 10.0)
+
+        for index in 1 .. 8 do
+            assertClose (tree.PrefixSum(index)) 10.0
+
+    [<Fact>]
+    member _.``query operations validate bounds``() =
+        let tree = FenwickTree.FromList([ 1.0; 2.0; 3.0 ])
+
+        Assert.Throws<FenwickIndexOutOfRangeError>(fun () -> tree.PrefixSum(-1) |> ignore)
+        |> ignore
+        Assert.Throws<FenwickIndexOutOfRangeError>(fun () -> tree.PrefixSum(4) |> ignore)
+        |> ignore
+        Assert.Throws<FenwickIndexOutOfRangeError>(fun () -> tree.Update(0, 1.0))
+        |> ignore
+        Assert.Throws<FenwickIndexOutOfRangeError>(fun () -> tree.RangeSum(0, 2) |> ignore)
+        |> ignore
+        Assert.Throws<FenwickIndexOutOfRangeError>(fun () -> tree.PointQuery(4) |> ignore)
+        |> ignore
+        Assert.Throws<FenwickError>(fun () -> tree.RangeSum(3, 1) |> ignore)
+        |> ignore
+
+    [<Fact>]
+    member _.``findKth matches documented examples and validation rules``() =
+        let tree = FenwickTree.FromList([ 1.0; 2.0; 3.0; 4.0; 5.0 ])
+
+        Assert.Equal(1, tree.FindKth(1.0))
+        Assert.Equal(2, tree.FindKth(2.0))
+        Assert.Equal(2, tree.FindKth(3.0))
+        Assert.Equal(3, tree.FindKth(4.0))
+        Assert.Equal(4, tree.FindKth(10.0))
+        Assert.Equal(5, tree.FindKth(11.0))
+
+        Assert.Throws<FenwickError>(fun () -> tree.FindKth(0.0) |> ignore)
+        |> ignore
+        Assert.Throws<FenwickError>(fun () -> tree.FindKth(100.0) |> ignore)
+        |> ignore
+        Assert.Throws<FenwickEmptyTreeError>(fun () -> FenwickTree(0).FindKth(1.0) |> ignore)
+        |> ignore
+
+    [<Fact>]
+    member _.``prefix and range queries match brute force across random arrays``() =
+        let mutable seed = 1337
+
+        let next () =
+            seed <- int (((int64 seed * 1103515245L) + 12345L) &&& 0x7fffffffL)
+            seed
+
+        for _ in 0 .. 119 do
+            let n = (next () % 30) + 1
+            let values = Array.init n (fun _ -> float ((next () % 101) - 50))
+            let tree = FenwickTree.FromList(values)
+
+            for index in 1 .. n do
+                assertClose (tree.PrefixSum(index)) (brutePrefix values index)
+
+            for left in 1 .. n do
+                for right in left .. n do
+                    assertClose (tree.RangeSum(left, right)) (bruteRange values left right)
+
+    [<Fact>]
+    member _.``tree stays consistent under interleaved updates and queries``() =
+        let mutable seed = 99u
+
+        let next () =
+            seed <- seed * 1664525u + 1013904223u
+            seed
+
+        let size = 60
+        let values = Array.init size (fun _ -> float ((int (next () % 20u)) + 1))
+        let tree = FenwickTree.FromList(values)
+
+        for _ in 0 .. 1199 do
+            if next () % 10u < 4u then
+                let left = (int (next () % uint32 size)) + 1
+                let right = left + int (next () % uint32 (size - left + 1))
+                assertClose (tree.RangeSum(left, right)) (bruteRange values left right)
+            else
+                let index = (int (next () % uint32 size)) + 1
+                let delta = float ((int (next () % 41u)) - 20)
+                values[index - 1] <- values[index - 1] + delta
+                tree.Update(index, delta)
+
+    [<Fact>]
+    member _.``toString renders logical shape``() =
+        let tree = FenwickTree.FromList([ 1.0; 2.0; 3.0 ])
+        Assert.Equal("FenwickTree(n=3, bit=[1, 3, 3])", tree.ToString())

--- a/code/packages/fsharp/gf256/BUILD
+++ b/code/packages/fsharp/gf256/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Gf256.Tests/CodingAdventures.Gf256.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/gf256/BUILD_windows
+++ b/code/packages/fsharp/gf256/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Gf256.Tests/CodingAdventures.Gf256.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/gf256/CHANGELOG.md
+++ b/code/packages/fsharp/gf256/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-16
+
+### Added
+
+- GF(2^8) arithmetic over the Reed-Solomon polynomial `0x11D`
+- Public `LOG` and `ALOG` tables plus core field operations
+- Parameterizable `Gf256Field` type for alternate polynomials such as AES

--- a/code/packages/fsharp/gf256/CodingAdventures.Gf256.fsproj
+++ b/code/packages/fsharp/gf256/CodingAdventures.Gf256.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Gf256.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>GF(2^8) arithmetic for Reed-Solomon and related byte-oriented codes</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Gf256.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/gf256/Gf256.fs
+++ b/code/packages/fsharp/gf256/Gf256.fs
@@ -1,0 +1,167 @@
+namespace CodingAdventures.Gf256
+
+open System
+
+// Gf256.fs -- Byte arithmetic inside a finite field instead of the integers
+// ==========================================================================
+//
+// GF(2^8) uses the byte values 0 through 255 as field elements.
+// Addition is XOR, and multiplication is reduced modulo the primitive
+// polynomial 0x11D so that every non-zero element has an inverse.
+
+[<RequireQualifiedAccess>]
+module Gf256 =
+    [<Literal>]
+    let VERSION = "0.1.0"
+
+    [<Literal>]
+    let ZERO = 0uy
+
+    [<Literal>]
+    let ONE = 1uy
+
+    [<Literal>]
+    let PRIMITIVE_POLYNOMIAL = 0x11D
+
+    let private logTable = Array.zeroCreate<int> 256
+    let private alogTable = Array.zeroCreate<byte> 256
+
+    do
+        let mutable value = 1
+
+        for index in 0 .. 254 do
+            alogTable[index] <- byte value
+            logTable[value] <- index
+            value <- value <<< 1
+
+            if value >= 256 then
+                value <- value ^^^ PRIMITIVE_POLYNOMIAL
+
+        alogTable[255] <- 1uy
+
+    /// Antilog table where ALOG[i] = 2^i in GF(256).
+    let ALOG = Array.copy alogTable
+
+    /// Log table where LOG[x] = i such that 2^i = x in GF(256).
+    let LOG = Array.copy logTable
+
+    /// Add two field elements. In characteristic 2 this is XOR.
+    let add (a: byte) (b: byte) = a ^^^ b
+
+    /// Subtract two field elements. In characteristic 2 this is also XOR.
+    let subtract (a: byte) (b: byte) = a ^^^ b
+
+    /// Multiply two field elements using log and antilog tables.
+    let multiply (a: byte) (b: byte) =
+        if a = 0uy || b = 0uy then
+            0uy
+        else
+            let exponent = (logTable[int a] + logTable[int b]) % 255
+            alogTable[exponent]
+
+    /// Divide a by b in GF(256).
+    let divide (a: byte) (b: byte) =
+        if b = 0uy then
+            raise (InvalidOperationException("GF256: division by zero"))
+
+        if a = 0uy then
+            0uy
+        else
+            let exponent = ((logTable[int a] - logTable[int b] + 255) % 255 + 255) % 255
+            alogTable[exponent]
+
+    /// Raise a field element to a non-negative integer power.
+    let power (baseValue: byte) exponent =
+        if exponent < 0 then
+            raise (ArgumentOutOfRangeException("exponent", "Exponent must be non-negative."))
+
+        if baseValue = 0uy then
+            if exponent = 0 then ONE else ZERO
+        elif exponent = 0 then
+            ONE
+        else
+            let tableIndex = ((logTable[int baseValue] * exponent) % 255 + 255) % 255
+            alogTable[tableIndex]
+
+    /// Compute the multiplicative inverse of a non-zero field element.
+    let inverse (a: byte) =
+        if a = 0uy then
+            raise (InvalidOperationException("GF256: zero has no multiplicative inverse"))
+
+        alogTable[255 - logTable[int a]]
+
+    /// Return the additive identity.
+    let zero () = ZERO
+
+    /// Return the multiplicative identity.
+    let one () = ONE
+
+    /// GF(2^8) field parameterized by an arbitrary primitive polynomial.
+    type Gf256Field(polynomial: int) =
+        do
+            if polynomial <= 0 || polynomial > 0x1FF then
+                raise (ArgumentOutOfRangeException("polynomial", "Polynomial must fit in 9 bits."))
+
+        let reduce = byte (polynomial &&& 0xFF)
+
+        member _.Polynomial = polynomial
+
+        member _.Add(a: byte, b: byte) = a ^^^ b
+
+        member _.Subtract(a: byte, b: byte) = a ^^^ b
+
+        member _.Multiply(a: byte, b: byte) =
+            let mutable result = 0
+            let mutable left = int a
+            let mutable right = int b
+
+            for _ in 0 .. 7 do
+                if (right &&& 1) <> 0 then
+                    result <- result ^^^ left
+
+                let highBit = left &&& 0x80
+                left <- (left <<< 1) &&& 0xFF
+
+                if highBit <> 0 then
+                    left <- left ^^^ int reduce
+
+                right <- right >>> 1
+
+            byte result
+
+        member this.Divide(a: byte, b: byte) =
+            if b = 0uy then
+                raise (InvalidOperationException("GF256Field: division by zero"))
+
+            this.Multiply(a, this.Power(b, 254))
+
+        member this.Power(baseValue: byte, exponent: int) =
+            if exponent < 0 then
+                raise (ArgumentOutOfRangeException("exponent", "Exponent must be non-negative."))
+
+            if baseValue = 0uy then
+                if exponent = 0 then ONE else ZERO
+            elif exponent = 0 then
+                ONE
+            else
+                let mutable result = ONE
+                let mutable factor = baseValue
+                let mutable remaining = exponent
+
+                while remaining > 0 do
+                    if (remaining &&& 1) <> 0 then
+                        result <- this.Multiply(result, factor)
+
+                    factor <- this.Multiply(factor, factor)
+                    remaining <- remaining >>> 1
+
+                result
+
+        member this.Inverse(a: byte) =
+            if a = 0uy then
+                raise (InvalidOperationException("GF256Field: zero has no multiplicative inverse"))
+
+            this.Power(a, 254)
+
+    /// Create a GF(2^8) field for a different primitive polynomial.
+    let createField polynomial = Gf256Field(polynomial)

--- a/code/packages/fsharp/gf256/README.md
+++ b/code/packages/fsharp/gf256/README.md
@@ -1,0 +1,34 @@
+# gf256
+
+Finite-field arithmetic over `GF(2^8)` for byte-oriented coding theory and
+crypto building blocks such as Reed-Solomon, QR, and AES-style field math.
+
+## Layer 1
+
+This package is part of Layer 1 of the coding-adventures computing stack.
+
+## What It Includes
+
+- Reed-Solomon style field operations over primitive polynomial `0x11D`
+- Public `LOG` and `ALOG` tables for learning and debugging
+- `add`, `subtract`, `multiply`, `divide`, `power`, `inverse`
+- `createField` for alternate primitive polynomials such as AES `0x11B`
+
+## Example
+
+```fsharp
+open CodingAdventures.Gf256
+
+let product = Gf256.multiply 0x53uy 0x8cuy
+printfn "%d" product // 1
+
+let aes = Gf256.createField 0x11b
+printfn "%d" (aes.Multiply(0x57uy, 0x83uy)) // 193
+```
+
+## Development
+
+```bash
+# Run tests
+bash BUILD
+```

--- a/code/packages/fsharp/gf256/required_capabilities.json
+++ b/code/packages/fsharp/gf256/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/gf256",
+  "capabilities": [],
+  "justification": "Pure in-memory arithmetic and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/gf256/tests/CodingAdventures.Gf256.Tests/CodingAdventures.Gf256.Tests.fsproj
+++ b/code/packages/fsharp/gf256/tests/CodingAdventures.Gf256.Tests/CodingAdventures.Gf256.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Gf256.fsproj" />
+    <Compile Include="Gf256Tests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/gf256/tests/CodingAdventures.Gf256.Tests/Gf256Tests.fs
+++ b/code/packages/fsharp/gf256/tests/CodingAdventures.Gf256.Tests/Gf256Tests.fs
@@ -1,0 +1,86 @@
+namespace CodingAdventures.Gf256.Tests
+
+open System
+open Xunit
+open CodingAdventures.Gf256
+
+type Gf256Tests() =
+    [<Fact>]
+    member _.``exposes expected constants``() =
+        Assert.Equal("0.1.0", Gf256.VERSION)
+        Assert.Equal(0uy, Gf256.ZERO)
+        Assert.Equal(1uy, Gf256.ONE)
+        Assert.Equal(0x11d, Gf256.PRIMITIVE_POLYNOMIAL)
+
+    [<Fact>]
+    member _.``log and alog tables match known values``() =
+        Assert.Equal(256, Gf256.ALOG.Length)
+        Assert.Equal(256, Gf256.LOG.Length)
+        Assert.Equal(1uy, Gf256.ALOG[0])
+        Assert.Equal(2uy, Gf256.ALOG[1])
+        Assert.Equal(29uy, Gf256.ALOG[8])
+        Assert.Equal(0, Gf256.LOG[1])
+        Assert.Equal(1, Gf256.LOG[2])
+
+        for value in 1 .. 255 do
+            Assert.Equal(byte value, Gf256.ALOG[Gf256.LOG[value]])
+
+    [<Fact>]
+    member _.``add and subtract are xor``() =
+        for value in 0 .. 255 do
+            Assert.Equal(byte value, Gf256.add 0uy (byte value))
+            Assert.Equal(0uy, Gf256.add (byte value) (byte value))
+            Assert.Equal(Gf256.add (byte value) 0x42uy, Gf256.subtract (byte value) 0x42uy)
+
+        Assert.Equal(0x99uy, Gf256.add 0x53uy 0xcauy)
+
+    [<Fact>]
+    member _.``multiply obeys identity zero and known spot checks``() =
+        for value in 0 .. 255 do
+            Assert.Equal(0uy, Gf256.multiply (byte value) 0uy)
+            Assert.Equal(byte value, Gf256.multiply (byte value) 1uy)
+
+        Assert.Equal(1uy, Gf256.multiply 0x53uy 0x8cuy)
+        Assert.Equal(Gf256.multiply 0x34uy 0x56uy, Gf256.multiply 0x56uy 0x34uy)
+
+    [<Fact>]
+    member _.``divide and inverse work for non-zero inputs``() =
+        for value in 1 .. 255 do
+            Assert.Equal(1uy, Gf256.divide (byte value) (byte value))
+            Assert.Equal(byte value, Gf256.divide (byte value) 1uy)
+            Assert.Equal(1uy, Gf256.multiply (byte value) (Gf256.inverse (byte value)))
+
+        Assert.Equal(0uy, Gf256.divide 0uy 1uy)
+        Assert.Throws<InvalidOperationException>(fun () -> Gf256.divide 1uy 0uy |> ignore)
+        |> ignore
+        Assert.Throws<InvalidOperationException>(fun () -> Gf256.inverse 0uy |> ignore)
+        |> ignore
+
+    [<Fact>]
+    member _.``power handles zero and positive exponents``() =
+        Assert.Equal(1uy, Gf256.power 0uy 0)
+        Assert.Equal(0uy, Gf256.power 0uy 5)
+        Assert.Equal(1uy, Gf256.power 0x53uy 0)
+        Assert.Equal(0x53uy, Gf256.power 0x53uy 1)
+        Assert.Equal(Gf256.multiply 0x53uy 0x53uy, Gf256.power 0x53uy 2)
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> Gf256.power 1uy -1 |> ignore)
+        |> ignore
+
+    [<Fact>]
+    member _.``zero and one helpers return field identities``() =
+        Assert.Equal(Gf256.ZERO, Gf256.zero ())
+        Assert.Equal(Gf256.ONE, Gf256.one ())
+
+    [<Fact>]
+    member _.``alternate field supports aes polynomial``() =
+        let aes = Gf256.createField 0x11b
+
+        Assert.Equal(0x11b, aes.Polynomial)
+        Assert.Equal(0x01uy, aes.Multiply(0x53uy, 0xcauy))
+        Assert.Equal(0xc1uy, aes.Multiply(0x57uy, 0x83uy))
+        Assert.Equal(0x53uy, aes.Divide(0x53uy, 1uy))
+        Assert.Equal(0x01uy, aes.Multiply(0x57uy, aes.Inverse(0x57uy)))
+        Assert.Throws<InvalidOperationException>(fun () -> aes.Divide(1uy, 0uy) |> ignore)
+        |> ignore
+        Assert.Throws<InvalidOperationException>(fun () -> aes.Inverse(0uy) |> ignore)
+        |> ignore

--- a/code/packages/fsharp/md5/BUILD
+++ b/code/packages/fsharp/md5/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Md5.Tests/CodingAdventures.Md5.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/md5/BUILD_windows
+++ b/code/packages/fsharp/md5/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Md5.Tests/CodingAdventures.Md5.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/md5/CHANGELOG.md
+++ b/code/packages/fsharp/md5/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-16
+
+### Added
+
+- From-scratch MD5 implementation following RFC 1321
+- One-shot `sumMd5`, `hexString`, and `toHex` helpers
+- Streaming `Md5Hasher` with copy, non-destructive digesting, and chunked update

--- a/code/packages/fsharp/md5/CodingAdventures.Md5.fsproj
+++ b/code/packages/fsharp/md5/CodingAdventures.Md5.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Md5.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>From-scratch MD5 digest implementation with one-shot and streaming APIs</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Md5.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/md5/Md5.fs
+++ b/code/packages/fsharp/md5/Md5.fs
@@ -1,0 +1,245 @@
+namespace CodingAdventures.Md5
+
+open System
+open System.Buffers.Binary
+open System.Numerics
+open System.Text
+
+// Md5.fs -- RFC 1321 digests with explicit little-endian block parsing
+// ====================================================================
+//
+// MD5 is built from 64-byte blocks, four 32-bit state words, and arithmetic
+// modulo 2^32. Its most error-prone detail is endianness: unlike SHA-1 and
+// SHA-256, MD5 reads and writes words in little-endian order.
+
+[<RequireQualifiedAccess>]
+module Md5 =
+    [<Literal>]
+    let VERSION = "0.1.0"
+
+    let private initA = 0x67452301u
+    let private initB = 0xefcdab89u
+    let private initC = 0x98badcfeu
+    let private initD = 0x10325476u
+
+    let private tTable =
+        Array.init 64 (fun index ->
+            uint32 (Math.Floor(Math.Abs(Math.Sin(float (index + 1))) * 4294967296.0)))
+
+    let private shiftTable =
+        [|
+            7; 12; 17; 22; 7; 12; 17; 22; 7; 12; 17; 22; 7; 12; 17; 22
+            5; 9; 14; 20; 5; 9; 14; 20; 5; 9; 14; 20; 5; 9; 14; 20
+            4; 11; 16; 23; 4; 11; 16; 23; 4; 11; 16; 23; 4; 11; 16; 23
+            6; 10; 15; 21; 6; 10; 15; 21; 6; 10; 15; 21; 6; 10; 15; 21
+        |]
+
+    let private wrap32 (value: uint64) = uint32 (value &&& 0xFFFFFFFFUL)
+
+    let private add32 (left: uint32) (right: uint32) =
+        wrap32 (uint64 left + uint64 right)
+
+    let private add32_4 (a: uint32) (b: uint32) (c: uint32) (d: uint32) =
+        wrap32 (uint64 a + uint64 b + uint64 c + uint64 d)
+
+    let toHex (bytes: byte array) =
+        if isNull bytes then
+            nullArg "bytes"
+
+        let builder = StringBuilder(bytes.Length * 2)
+
+        for value in bytes do
+            builder.Append(value.ToString("x2")) |> ignore
+
+        builder.ToString()
+
+    let private pad (data: byte array) =
+        let bitLength = uint64 data.Length * 8UL
+        let afterBit = (data.Length + 1) % 64
+
+        let zeroCount =
+            if afterBit <= 56 then
+                56 - afterBit
+            else
+                64 + 56 - afterBit
+
+        let result = Array.zeroCreate<byte> (data.Length + 1 + zeroCount + 8)
+        Array.Copy(data, result, data.Length)
+        result[data.Length] <- 0x80uy
+        BinaryPrimitives.WriteUInt64LittleEndian(result.AsSpan(result.Length - 8), bitLength)
+        result
+
+    let private stateToBytes a b c d =
+        let digest = Array.zeroCreate<byte> 16
+        BinaryPrimitives.WriteUInt32LittleEndian(digest.AsSpan(0, 4), a)
+        BinaryPrimitives.WriteUInt32LittleEndian(digest.AsSpan(4, 4), b)
+        BinaryPrimitives.WriteUInt32LittleEndian(digest.AsSpan(8, 4), c)
+        BinaryPrimitives.WriteUInt32LittleEndian(digest.AsSpan(12, 4), d)
+        digest
+
+    let private compressState stateA stateB stateC stateD (block: ReadOnlySpan<byte>) =
+        let words = Array.zeroCreate<uint32> 16
+
+        for index in 0 .. 15 do
+            words[index] <- BinaryPrimitives.ReadUInt32LittleEndian(block.Slice(index * 4, 4))
+
+        let mutable a = stateA
+        let mutable b = stateB
+        let mutable c = stateC
+        let mutable d = stateD
+
+        for index in 0 .. 63 do
+            let f, g =
+                if index < 16 then
+                    ((b &&& c) ||| ((~~~b) &&& d), index)
+                elif index < 32 then
+                    ((d &&& b) ||| ((~~~d) &&& c), (5 * index + 1) % 16)
+                elif index < 48 then
+                    (b ^^^ c ^^^ d, (3 * index + 5) % 16)
+                else
+                    (c ^^^ (b ||| (~~~d)), (7 * index) % 16)
+
+            let inner = add32_4 a f words[g] tTable[index]
+            let temp = add32 b (BitOperations.RotateLeft(inner, shiftTable[index]))
+            a <- d
+            d <- c
+            c <- b
+            b <- temp
+
+        add32 stateA a, add32 stateB b, add32 stateC c, add32 stateD d
+
+    let private finalizeDigest a b c d (buffer: byte array) bufferLength byteCount =
+        let afterBit = (bufferLength + 1) % 64
+
+        let zeroCount =
+            if afterBit <= 56 then
+                56 - afterBit
+            else
+                64 + 56 - afterBit
+
+        let finalBlock = Array.zeroCreate<byte> (bufferLength + 1 + zeroCount + 8)
+        Array.Copy(buffer, finalBlock, bufferLength)
+        finalBlock[bufferLength] <- 0x80uy
+        BinaryPrimitives.WriteUInt64LittleEndian(finalBlock.AsSpan(finalBlock.Length - 8), byteCount * 8UL)
+
+        let mutable aState = a
+        let mutable bState = b
+        let mutable cState = c
+        let mutable dState = d
+
+        for offset in 0 .. 64 .. finalBlock.Length - 64 do
+            let nextA, nextB, nextC, nextD =
+                compressState aState bState cState dState (ReadOnlySpan<byte>(finalBlock, offset, 64))
+
+            aState <- nextA
+            bState <- nextB
+            cState <- nextC
+            dState <- nextD
+
+        stateToBytes aState bState cState dState
+
+    /// Compute the 16-byte MD5 digest of the provided data.
+    let sumMd5 (data: byte array) =
+        if isNull data then
+            nullArg "data"
+
+        let padded = pad data
+        let mutable a = initA
+        let mutable b = initB
+        let mutable c = initC
+        let mutable d = initD
+
+        for offset in 0 .. 64 .. padded.Length - 64 do
+            let nextA, nextB, nextC, nextD = compressState a b c d (ReadOnlySpan<byte>(padded, offset, 64))
+            a <- nextA
+            b <- nextB
+            c <- nextC
+            d <- nextD
+
+        stateToBytes a b c d
+
+    /// Compute MD5 and render it as a 32-character lowercase hexadecimal string.
+    let hexString (data: byte array) =
+        sumMd5 data |> toHex
+
+    /// Streaming MD5 hasher that accepts data in multiple chunks.
+    type Md5Hasher
+        (
+            initialA: uint32,
+            initialB: uint32,
+            initialC: uint32,
+            initialD: uint32,
+            initialBuffer: byte array,
+            initialBufferLength: int,
+            initialByteCount: uint64
+        ) =
+        let mutable a = initialA
+        let mutable b = initialB
+        let mutable c = initialC
+        let mutable d = initialD
+        let buffer = Array.zeroCreate<byte> 64
+        let mutable bufferLength = initialBufferLength
+        let mutable byteCount = initialByteCount
+
+        do
+            Array.Copy(initialBuffer, buffer, initialBuffer.Length)
+
+        new () = Md5Hasher(initA, initB, initC, initD, Array.zeroCreate<byte> 64, 0, 0UL)
+
+        /// Feed more bytes into the hash state.
+        member this.Update(data: byte array) =
+            if isNull data then
+                nullArg "data"
+
+            byteCount <- byteCount + uint64 data.Length
+            let mutable offset = 0
+
+            if bufferLength > 0 then
+                let needed = 64 - bufferLength
+                let take = min needed data.Length
+                Array.Copy(data, 0, buffer, bufferLength, take)
+                bufferLength <- bufferLength + take
+                offset <- take
+
+                if bufferLength = 64 then
+                    let nextA, nextB, nextC, nextD =
+                        compressState a b c d (ReadOnlySpan<byte>(buffer, 0, 64))
+
+                    a <- nextA
+                    b <- nextB
+                    c <- nextC
+                    d <- nextD
+                    bufferLength <- 0
+
+            while offset + 64 <= data.Length do
+                let nextA, nextB, nextC, nextD =
+                    compressState a b c d (ReadOnlySpan<byte>(data, offset, 64))
+
+                a <- nextA
+                b <- nextB
+                c <- nextC
+                d <- nextD
+                offset <- offset + 64
+
+            if offset < data.Length then
+                Array.Copy(data, offset, buffer, bufferLength, data.Length - offset)
+                bufferLength <- bufferLength + (data.Length - offset)
+
+            this
+
+        /// Return the current digest without mutating the hasher state.
+        member _.Digest() =
+            let bufferCopy = Array.zeroCreate<byte> bufferLength
+            Array.Copy(buffer, bufferCopy, bufferLength)
+            finalizeDigest a b c d bufferCopy bufferLength byteCount
+
+        /// Alias for Digest.
+        member this.SumMd5() = this.Digest()
+
+        /// Return the current digest as lowercase hexadecimal.
+        member this.HexDigest() =
+            this.Digest() |> toHex
+
+        /// Clone the current streaming state.
+        member _.Copy() =
+            Md5Hasher(a, b, c, d, Array.copy buffer, bufferLength, byteCount)

--- a/code/packages/fsharp/md5/README.md
+++ b/code/packages/fsharp/md5/README.md
@@ -1,0 +1,32 @@
+# md5
+
+From-scratch MD5 implementation following RFC 1321, including both one-shot
+and streaming APIs.
+
+## Layer 1
+
+This package is part of Layer 1 of the coding-adventures computing stack.
+
+## What It Includes
+
+- `Md5.sumMd5` for the 16-byte digest
+- `Md5.hexString` and `Md5.toHex` for lowercase hexadecimal rendering
+- `Md5.Md5Hasher` for incremental hashing across multiple chunks
+- Literate comments on little-endian block parsing and Davies-Meyer feed-forward
+
+## Example
+
+```fsharp
+open System.Text
+open CodingAdventures.Md5
+
+let digest = Md5.hexString (Encoding.UTF8.GetBytes("abc"))
+printfn "%s" digest // 900150983cd24fb0d6963f7d28e17f72
+```
+
+## Development
+
+```bash
+# Run tests
+bash BUILD
+```

--- a/code/packages/fsharp/md5/required_capabilities.json
+++ b/code/packages/fsharp/md5/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/md5",
+  "capabilities": [],
+  "justification": "Pure in-memory digest implementation and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/md5/tests/CodingAdventures.Md5.Tests/CodingAdventures.Md5.Tests.fsproj
+++ b/code/packages/fsharp/md5/tests/CodingAdventures.Md5.Tests/CodingAdventures.Md5.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Md5.fsproj" />
+    <Compile Include="Md5Tests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/md5/tests/CodingAdventures.Md5.Tests/Md5Tests.fs
+++ b/code/packages/fsharp/md5/tests/CodingAdventures.Md5.Tests/Md5Tests.fs
@@ -1,0 +1,111 @@
+namespace CodingAdventures.Md5.Tests
+
+open System
+open System.Linq
+open System.Text
+open Xunit
+open CodingAdventures.Md5
+
+type Md5Tests() =
+    let encode (value: string) = Encoding.UTF8.GetBytes(value)
+    let hex value = Md5.hexString (encode value)
+
+    [<Fact>]
+    member _.``version and hex utilities match expected output``() =
+        Assert.Equal("0.1.0", Md5.VERSION)
+        Assert.Equal(String.Empty, Md5.toHex [||])
+        Assert.Equal("00", Md5.toHex [| 0x00uy |])
+        Assert.Equal("ff", Md5.toHex [| 0xffuy |])
+        Assert.Equal("d41d8cd9", Md5.toHex [| 0xd4uy; 0x1duy; 0x8cuy; 0xd9uy |])
+
+    [<Fact>]
+    member _.``rfc1321 vectors all match``() =
+        Assert.Equal("d41d8cd98f00b204e9800998ecf8427e", hex "")
+        Assert.Equal("0cc175b9c0f1b6a831c399e269772661", hex "a")
+        Assert.Equal("900150983cd24fb0d6963f7d28e17f72", hex "abc")
+        Assert.Equal("f96b697d7cb7938d525a2f31aaf161d0", hex "message digest")
+        Assert.Equal("c3fcd3d76192e4007dfb496cca67e13b", hex "abcdefghijklmnopqrstuvwxyz")
+
+        Assert.Equal(
+            "d174ab98d277d9f5a5611c2c9f419d9f",
+            hex "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+        )
+
+        Assert.Equal(
+            "57edf4a22be3c955ac49da2e2107b67a",
+            hex "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
+        )
+
+    [<Fact>]
+    member _.``known digests and little-endian checks match``() =
+        Assert.Equal("9e107d9d372bb6826bd81d3542a419d6", hex "The quick brown fox jumps over the lazy dog")
+        Assert.Equal("e4d909c290d0fb1ca068ffaddf22cbd0", hex "The quick brown fox jumps over the lazy dog.")
+        Assert.Equal("93b885adfe0da089cdf634904fd59f71", Md5.hexString [| 0x00uy |])
+        Assert.Equal("00594fd4f42ba43fc1ca0427a0576295", Md5.hexString [| 0xffuy |])
+
+        let emptyDigest = Md5.sumMd5 [||]
+        Assert.Equal(16, emptyDigest.Length)
+        Assert.Equal(0xd4uy, emptyDigest[0])
+        Assert.Equal(0x1duy, emptyDigest[1])
+
+    [<Fact>]
+    member _.``one-shot digest always returns sixteen bytes and lowercase hex``() =
+        Assert.Equal(16, (Md5.sumMd5 (encode "")).Length)
+        Assert.Equal(16, (Md5.sumMd5 (encode "abc")).Length)
+        Assert.Equal(16, (Md5.sumMd5 (Array.zeroCreate<byte> 1000)).Length)
+
+        let digestHex = Md5.hexString (encode "hello world")
+        Assert.Equal(32, digestHex.Length)
+        Assert.Matches("^[0-9a-f]{32}$", digestHex)
+        Assert.Equal(digestHex, Md5.toHex (Md5.sumMd5 (encode "hello world")))
+
+    [<Fact>]
+    member _.``block boundary lengths remain stable``() =
+        for length in [| 55; 56; 63; 64; 65; 128 |] do
+            let data = Array.create length (byte 'a')
+            let oneShot = Md5.hexString data
+
+            let hasher = Md5.Md5Hasher()
+            let split = min 13 data.Length
+            hasher.Update(data[.. split - 1]) |> ignore
+            hasher.Update(data[split..]) |> ignore
+
+            Assert.Equal(oneShot, hasher.HexDigest())
+
+    [<Fact>]
+    member _.``streaming hasher matches one-shot across arbitrary chunks``() =
+        let data = Enumerable.Range(0, 256).Select(byte).ToArray()
+        let expected = Md5.hexString data
+
+        let hasher = Md5.Md5Hasher()
+        hasher.Update(data[..6]) |> ignore
+        hasher.Update(data[7..110]) |> ignore
+        hasher.Update(data[111..191]) |> ignore
+        hasher.Update(data[192..]) |> ignore
+
+        Assert.Equal(expected, hasher.HexDigest())
+        Assert.Equal(expected, Md5.toHex (hasher.Digest()))
+
+    [<Fact>]
+    member _.``digest is non-destructive and hasher can continue after digesting``() =
+        let hasher = Md5.Md5Hasher()
+        hasher.Update(encode "hello") |> ignore
+
+        let first = hasher.HexDigest()
+        Assert.Equal(first, hasher.HexDigest())
+        Assert.Equal(Md5.hexString (encode "hello"), first)
+
+        hasher.Update(encode " world") |> ignore
+        Assert.Equal(Md5.hexString (encode "hello world"), hasher.HexDigest())
+
+    [<Fact>]
+    member _.``copy creates independent streaming states``() =
+        let original = Md5.Md5Hasher()
+        original.Update(encode "ab") |> ignore
+
+        let copy = original.Copy()
+        copy.Update(encode "c") |> ignore
+        original.Update(encode "x") |> ignore
+
+        Assert.Equal(Md5.hexString (encode "abc"), copy.HexDigest())
+        Assert.Equal(Md5.hexString (encode "abx"), original.HexDigest())


### PR DESCRIPTION
## What changed

This PR starts the fast pure-leaf catch-up wave for the new .NET package trees by adding four standalone packages to both C# and F#:

- `fenwick-tree`
- `csv-parser`
- `gf256`
- `md5`

Each package includes:

- literate package implementation
- package README and changelog
- `required_capabilities.json`
- package-local `BUILD` and `BUILD_windows`
- xUnit test coverage for both languages

## Why

These were the cleanest pure leaf packages to port first because they do not depend on other missing package families. Landing them grows C# and F# breadth quickly while also unlocking later document, coding-theory, and crypto-adjacent work.

## Impact

C# and F# both gain:

- a reusable prefix-sum data structure via `fenwick-tree`
- RFC 4180 style CSV parsing via `csv-parser`
- finite-field byte arithmetic via `gf256`
- one-shot and streaming MD5 support via `md5`

This keeps the two .NET ecosystems in lockstep and pushes the pure-leaf wave forward before the later document-focused batch.

## Validation

I ran all eight package `BUILD` scripts locally with `.NET` `9.0.313`:

- `code/packages/csharp/fenwick-tree`
- `code/packages/fsharp/fenwick-tree`
- `code/packages/csharp/csv-parser`
- `code/packages/fsharp/csv-parser`
- `code/packages/csharp/gf256`
- `code/packages/fsharp/gf256`
- `code/packages/csharp/md5`
- `code/packages/fsharp/md5`

All passed successfully.