### PR TITLE
[codex] Add Dart JSON lexer package

### DIFF
--- a/code/packages/dart/json-lexer/.gitignore
+++ b/code/packages/dart/json-lexer/.gitignore
@@ -1,0 +1,2 @@
+.dart_tool/
+pubspec.lock

--- a/code/packages/dart/json-lexer/BUILD
+++ b/code/packages/dart/json-lexer/BUILD
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/json-lexer/BUILD_windows
+++ b/code/packages/dart/json-lexer/BUILD_windows
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/json-lexer/CHANGELOG.md
+++ b/code/packages/dart/json-lexer/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Initial Dart `json-lexer` package.
+- Added grammar-driven JSON tokenization backed by a compiled token grammar.

--- a/code/packages/dart/json-lexer/README.md
+++ b/code/packages/dart/json-lexer/README.md
@@ -1,0 +1,7 @@
+# coding_adventures_json_lexer
+
+Grammar-driven JSON lexer for Dart.
+
+This package is a thin wrapper around the shared Dart `lexer` and
+`grammar-tools` packages. It embeds the `json.tokens` grammar as Dart code and
+delegates tokenization to `grammarTokenize`.

--- a/code/packages/dart/json-lexer/lib/json_lexer.dart
+++ b/code/packages/dart/json-lexer/lib/json_lexer.dart
@@ -1,0 +1,3 @@
+library;
+
+export 'src/tokenizer.dart';

--- a/code/packages/dart/json-lexer/lib/src/_grammar.dart
+++ b/code/packages/dart/json-lexer/lib/src/_grammar.dart
@@ -1,0 +1,91 @@
+import 'package:coding_adventures_grammar_tools/grammar_tools.dart';
+
+final tokenGrammar = TokenGrammar(
+  version: 1,
+  caseInsensitive: false,
+  caseSensitive: true,
+  definitions: [
+    const TokenDefinition(
+      name: 'STRING',
+      pattern: r'"([^"\\]|\\["\\\x2fbfnrt]|\\u[0-9a-fA-F]{4})*"',
+      isRegex: true,
+      lineNumber: 25,
+    ),
+    const TokenDefinition(
+      name: 'NUMBER',
+      pattern: r'-?[0-9]+\.?[0-9]*[eE]?[-+]?[0-9]*',
+      isRegex: true,
+      lineNumber: 31,
+    ),
+    const TokenDefinition(
+      name: 'TRUE',
+      pattern: 'true',
+      isRegex: false,
+      lineNumber: 35,
+    ),
+    const TokenDefinition(
+      name: 'FALSE',
+      pattern: 'false',
+      isRegex: false,
+      lineNumber: 36,
+    ),
+    const TokenDefinition(
+      name: 'NULL',
+      pattern: 'null',
+      isRegex: false,
+      lineNumber: 37,
+    ),
+    const TokenDefinition(
+      name: 'LBRACE',
+      pattern: '{',
+      isRegex: false,
+      lineNumber: 43,
+    ),
+    const TokenDefinition(
+      name: 'RBRACE',
+      pattern: '}',
+      isRegex: false,
+      lineNumber: 44,
+    ),
+    const TokenDefinition(
+      name: 'LBRACKET',
+      pattern: '[',
+      isRegex: false,
+      lineNumber: 45,
+    ),
+    const TokenDefinition(
+      name: 'RBRACKET',
+      pattern: ']',
+      isRegex: false,
+      lineNumber: 46,
+    ),
+    const TokenDefinition(
+      name: 'COLON',
+      pattern: ':',
+      isRegex: false,
+      lineNumber: 47,
+    ),
+    const TokenDefinition(
+      name: 'COMMA',
+      pattern: ',',
+      isRegex: false,
+      lineNumber: 48,
+    ),
+  ],
+  keywords: const [],
+  mode: null,
+  skipDefinitions: [
+    const TokenDefinition(
+      name: 'WHITESPACE',
+      pattern: r'[ \t\r\n]+',
+      isRegex: true,
+      lineNumber: 59,
+    ),
+  ],
+  reservedKeywords: const [],
+  escapeMode: 'none',
+  errorDefinitions: const [],
+  groups: const {},
+  contextKeywords: const [],
+  softKeywords: const [],
+);

--- a/code/packages/dart/json-lexer/lib/src/tokenizer.dart
+++ b/code/packages/dart/json-lexer/lib/src/tokenizer.dart
@@ -1,0 +1,6 @@
+import 'package:coding_adventures_lexer/lexer.dart';
+
+import '_grammar.dart';
+
+List<Token> tokenizeJson(String source) =>
+    grammarTokenize(source, tokenGrammar);

--- a/code/packages/dart/json-lexer/pubspec.yaml
+++ b/code/packages/dart/json-lexer/pubspec.yaml
@@ -1,6 +1,6 @@
-name: coding_adventures_lexer
+name: coding_adventures_json_lexer
 description: >
-  Generic hand-written tokenizer for Dart with a formal tokenizer dispatch DFA.
+  Grammar-driven JSON lexer for Dart backed by the shared TokenGrammar format.
 version: 0.1.0
 repository: https://github.com/adhithyan15/coding-adventures
 publish_to: none
@@ -11,8 +11,8 @@ environment:
 dependencies:
   coding_adventures_grammar_tools:
     path: ../grammar-tools
-  coding_adventures_state_machine:
-    path: ../state-machine
+  coding_adventures_lexer:
+    path: ../lexer
 
 dev_dependencies:
   test: ^1.25.0

--- a/code/packages/dart/json-lexer/required_capabilities.json
+++ b/code/packages/dart/json-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "dart/json-lexer",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/dart/json-lexer/test/json_lexer_test.dart
+++ b/code/packages/dart/json-lexer/test/json_lexer_test.dart
@@ -1,0 +1,62 @@
+import 'package:coding_adventures_lexer/lexer.dart';
+import 'package:coding_adventures_json_lexer/json_lexer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('tokenizeJson', () {
+    test('tokenizes numbers and literals', () {
+      expect(
+        tokenizeJson(
+          '[42, -0.5, true, false, null]',
+        ).map((token) => token.type).toList(),
+        [
+          'LBRACKET',
+          'NUMBER',
+          'COMMA',
+          'NUMBER',
+          'COMMA',
+          'TRUE',
+          'COMMA',
+          'FALSE',
+          'COMMA',
+          'NULL',
+          'RBRACKET',
+          'EOF',
+        ],
+      );
+    });
+
+    test('strips quotes and preserves raw escapes for strings', () {
+      final tokens = tokenizeJson(r'"line1\nline2"');
+      expect(tokens.first.type, 'STRING');
+      expect(tokens.first.value, r'line1\nline2');
+    });
+
+    test('skips insignificant whitespace', () {
+      final compact = tokenizeJson('{"a":1}');
+      final spaced = tokenizeJson('{\n  "a" : 1 \n}');
+      expect(
+        spaced.map((token) => token.type).toList(),
+        compact.map((token) => token.type).toList(),
+      );
+      expect(
+        spaced.map((token) => token.value).toList(),
+        compact.map((token) => token.value).toList(),
+      );
+    });
+
+    test('tracks line and column positions', () {
+      final tokens = tokenizeJson('{\n  "key": 1\n}');
+      expect(tokens[0].line, 1);
+      expect(tokens[0].column, 1);
+      expect(tokens[1].type, 'STRING');
+      expect(tokens[1].line, 2);
+      expect(tokens[1].column, 3);
+    });
+
+    test('throws on invalid JSON source', () {
+      expect(() => tokenizeJson("undefined"), throwsA(isA<LexerError>()));
+      expect(() => tokenizeJson("'hello'"), throwsA(isA<LexerError>()));
+    });
+  });
+}

--- a/code/packages/dart/lexer/CHANGELOG.md
+++ b/code/packages/dart/lexer/CHANGELOG.md
@@ -3,4 +3,4 @@
 ## 0.1.0
 
 - Initial release.
-
+- Added `grammarTokenize()` for grammar-driven lexers backed by `TokenGrammar`.

--- a/code/packages/dart/lexer/lib/lexer.dart
+++ b/code/packages/dart/lexer/lib/lexer.dart
@@ -1,6 +1,6 @@
 library;
 
+export 'src/grammar_lexer.dart';
 export 'src/token.dart';
 export 'src/tokenizer.dart';
 export 'src/tokenizer_dfa.dart';
-

--- a/code/packages/dart/lexer/lib/src/grammar_lexer.dart
+++ b/code/packages/dart/lexer/lib/src/grammar_lexer.dart
@@ -1,0 +1,260 @@
+import 'package:coding_adventures_grammar_tools/grammar_tools.dart';
+
+import 'token.dart';
+import 'tokenizer.dart';
+
+class _CompiledPattern {
+  _CompiledPattern({
+    required this.definition,
+    required this.caseSensitive,
+  }) : regex = definition.isRegex
+            ? RegExp(
+                '^(?:${definition.pattern})',
+                caseSensitive: caseSensitive,
+                unicode: true,
+                dotAll: true,
+              )
+            : null;
+
+  final TokenDefinition definition;
+  final bool caseSensitive;
+  final RegExp? regex;
+
+  String? match(String source, int position) {
+    if (definition.isRegex) {
+      final slice = source.substring(position);
+      final match = regex!.firstMatch(slice);
+      if (match == null) {
+        return null;
+      }
+      final value = match.group(0)!;
+      return value.isEmpty ? null : value;
+    }
+
+    final literal = definition.pattern;
+    if (position + literal.length > source.length) {
+      return null;
+    }
+    final candidate = source.substring(position, position + literal.length);
+    if (caseSensitive) {
+      return candidate == literal ? candidate : null;
+    }
+    return candidate.toLowerCase() == literal.toLowerCase() ? candidate : null;
+  }
+}
+
+List<Token> grammarTokenize(String source, TokenGrammar grammar) {
+  final effectiveCaseSensitive =
+      grammar.caseSensitive && !grammar.caseInsensitive;
+  final compiledDefinitions = grammar.definitions
+      .map(
+        (definition) => _CompiledPattern(
+          definition: definition,
+          caseSensitive: effectiveCaseSensitive,
+        ),
+      )
+      .toList(growable: false);
+  final compiledSkips = grammar.skipDefinitions
+      .map(
+        (definition) => _CompiledPattern(
+          definition: definition,
+          caseSensitive: effectiveCaseSensitive,
+        ),
+      )
+      .toList(growable: false);
+
+  final keywordSet =
+      grammar.keywords.map(_normalizeForLookup(effectiveCaseSensitive)).toSet();
+  final reservedSet = grammar.reservedKeywords
+      .map(_normalizeForLookup(effectiveCaseSensitive))
+      .toSet();
+
+  final tokens = <Token>[];
+  var position = 0;
+  var line = 1;
+  var column = 1;
+
+  void advanceText(String text) {
+    for (final codePoint in text.runes) {
+      position += 1;
+      if (codePoint == 0x0A) {
+        line += 1;
+        column = 1;
+      } else {
+        column += 1;
+      }
+    }
+  }
+
+  void skipIgnored() {
+    while (true) {
+      var matched = false;
+      for (final pattern in compiledSkips) {
+        final text = pattern.match(source, position);
+        if (text == null) {
+          continue;
+        }
+        advanceText(text);
+        matched = true;
+        break;
+      }
+      if (!matched) {
+        return;
+      }
+    }
+  }
+
+  while (true) {
+    skipIgnored();
+
+    if (position >= source.length) {
+      break;
+    }
+
+    final current = source[position];
+    if (current == '\n') {
+      tokens.add(
+        Token(type: 'NEWLINE', value: r'\n', line: line, column: column),
+      );
+      advanceText('\n');
+      continue;
+    }
+
+    TokenDefinition? matchedDefinition;
+    String? matchedText;
+    for (final pattern in compiledDefinitions) {
+      final text = pattern.match(source, position);
+      if (text == null) {
+        continue;
+      }
+      matchedDefinition = pattern.definition;
+      matchedText = text;
+      break;
+    }
+
+    if (matchedDefinition == null || matchedText == null) {
+      throw LexerError(
+        'Unexpected character: "${source[position]}"',
+        line,
+        column,
+      );
+    }
+
+    final startLine = line;
+    final startColumn = column;
+    advanceText(matchedText);
+
+    final type = _resolveTokenType(
+      matchedDefinition,
+      matchedText,
+      grammar,
+      keywordSet,
+      reservedSet,
+      effectiveCaseSensitive,
+      startLine,
+      startColumn,
+    );
+    final value = _resolveTokenValue(matchedText, type, grammar.escapeMode);
+
+    tokens.add(
+      Token(type: type, value: value, line: startLine, column: startColumn),
+    );
+  }
+
+  tokens.add(Token(type: 'EOF', value: '', line: line, column: column));
+  return List<Token>.unmodifiable(tokens);
+}
+
+String _resolveTokenType(
+  TokenDefinition definition,
+  String matchedText,
+  TokenGrammar grammar,
+  Set<String> keywordSet,
+  Set<String> reservedSet,
+  bool caseSensitive,
+  int line,
+  int column,
+) {
+  final normalizedText = _normalizeValue(matchedText, caseSensitive);
+  if (definition.name == 'NAME' && reservedSet.contains(normalizedText)) {
+    throw LexerError(
+      "Reserved keyword '$matchedText' cannot be used as an identifier",
+      line,
+      column,
+    );
+  }
+
+  if (definition.name == 'NAME' && keywordSet.contains(normalizedText)) {
+    return 'KEYWORD';
+  }
+
+  return definition.alias ?? definition.name;
+}
+
+String _resolveTokenValue(String matchedText, String type, String? escapeMode) {
+  if (type == 'STRING' &&
+      matchedText.length >= 2 &&
+      matchedText.startsWith('"') &&
+      matchedText.endsWith('"')) {
+    final inner = matchedText.substring(1, matchedText.length - 1);
+    if (escapeMode == 'none') {
+      return inner;
+    }
+    return _decodeEscapes(inner);
+  }
+  return matchedText;
+}
+
+String _decodeEscapes(String value) {
+  final buffer = StringBuffer();
+  var index = 0;
+  while (index < value.length) {
+    final current = value[index];
+    if (current != r'\' || index + 1 >= value.length) {
+      buffer.write(current);
+      index += 1;
+      continue;
+    }
+
+    final escaped = value[index + 1];
+    switch (escaped) {
+      case 'n':
+        buffer.write('\n');
+      case 't':
+        buffer.write('\t');
+      case 'r':
+        buffer.write('\r');
+      case 'b':
+        buffer.write('\b');
+      case 'f':
+        buffer.write('\f');
+      case '"':
+        buffer.write('"');
+      case r'\':
+        buffer.write(r'\');
+      case '/':
+        buffer.write('/');
+      case 'u':
+        if (index + 5 < value.length) {
+          final hex = value.substring(index + 2, index + 6);
+          final codePoint = int.tryParse(hex, radix: 16);
+          if (codePoint != null) {
+            buffer.write(String.fromCharCode(codePoint));
+            index += 6;
+            continue;
+          }
+        }
+        buffer.write(r'\u');
+      default:
+        buffer.write(escaped);
+    }
+    index += 2;
+  }
+  return buffer.toString();
+}
+
+String Function(String) _normalizeForLookup(bool caseSensitive) =>
+    (value) => _normalizeValue(value, caseSensitive);
+
+String _normalizeValue(String value, bool caseSensitive) =>
+    caseSensitive ? value : value.toLowerCase();

--- a/code/packages/dart/lexer/test/grammar_lexer_test.dart
+++ b/code/packages/dart/lexer/test/grammar_lexer_test.dart
@@ -1,0 +1,62 @@
+import 'package:coding_adventures_grammar_tools/grammar_tools.dart';
+import 'package:coding_adventures_lexer/lexer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('grammarTokenize', () {
+    test('tokenizes a minimal grammar with skip patterns', () {
+      final grammar = parseTokenGrammar('''
+NUMBER = /[0-9]+/
+PLUS = "+"
+skip:
+  SPACE = /[ \t]+/
+''');
+
+      final tokens = grammarTokenize('12 + 34', grammar);
+      expect(tokens.map((token) => token.type).toList(), [
+        'NUMBER',
+        'PLUS',
+        'NUMBER',
+        'EOF',
+      ]);
+      expect(tokens.map((token) => token.value).toList(), [
+        '12',
+        '+',
+        '34',
+        '',
+      ]);
+    });
+
+    test('respects aliases and string unescaping by default', () {
+      final grammar = parseTokenGrammar(
+        'STRING_DQ = /"([^"\\\\]|\\\\.)*"/ -> STRING',
+      );
+
+      final tokens = grammarTokenize(r'"line1\nline2"', grammar);
+      expect(tokens.first.type, 'STRING');
+      expect(tokens.first.value, 'line1\nline2');
+    });
+
+    test('keeps raw string escapes when escapes none is enabled', () {
+      final grammar = parseTokenGrammar('''
+escapes: none
+STRING = /"([^"\\\\]|\\\\.)*"/
+''');
+
+      final tokens = grammarTokenize(r'"line1\nline2"', grammar);
+      expect(tokens.first.value, r'line1\nline2');
+    });
+
+    test('emits NEWLINE when newline is not skipped', () {
+      final grammar = parseTokenGrammar('NUMBER = /[0-9]+/');
+
+      final tokens = grammarTokenize('1\n2', grammar);
+      expect(tokens.map((token) => token.type).toList(), [
+        'NUMBER',
+        'NEWLINE',
+        'NUMBER',
+        'EOF',
+      ]);
+    });
+  });
+}


### PR DESCRIPTION
## What changed

This adds the next Dart grammar-driven package slice after `dart/grammar-tools`.

The PR includes:

- a reusable `grammarTokenize()` path in `code/packages/dart/lexer`
- a new `code/packages/dart/json-lexer` package backed by a compiled JSON token grammar
- targeted tests for the generic grammar-driven lexer path and for JSON tokenization behavior

## Why

`dart/grammar-tools` gave Dart the shared grammar description layer, but Dart still lacked a grammar-driven lexer runtime and a first real consumer package.

This PR closes that gap by:

- teaching the Dart `lexer` package how to tokenize from `TokenGrammar`
- proving the end-to-end path with JSON, the smallest practical grammar in the repo

That gives us a reusable base for the next Dart grammar-driven ports like `json-parser`, `toml-lexer`, and `toml-parser`.

## Impact

- establishes a reusable grammar-driven lexer path in Dart instead of a one-off package implementation
- adds a Dart JSON lexer package with behavior aligned to the shared grammar files
- reduces the work required for the next lexer/parser ports in Dart

## Validation

Ran in `code/packages/dart/lexer`:

- `dart pub get`
- `dart test`
- `dart analyze`

Ran in `code/packages/dart/json-lexer`:

- `dart pub get`
- `dart test`
- `dart analyze`
