### PR TITLE
[codex] add haskell crypto digest and kdf packages

### DIFF
--- a/code/packages/haskell/hkdf/BUILD
+++ b/code/packages/haskell/hkdf/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/hkdf/BUILD_windows
+++ b/code/packages/haskell/hkdf/BUILD_windows
@@ -1,0 +1,1 @@
+if exist "%ProgramFiles%\\cabal\\bin\\cabal.exe" (cabal test all) else (echo cabal not found -- skipping)

--- a/code/packages/haskell/hkdf/CHANGELOG.md
+++ b/code/packages/haskell/hkdf/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/hkdf/README.md
+++ b/code/packages/haskell/hkdf/README.md
@@ -1,0 +1,13 @@
+# hkdf
+
+HKDF key derivation for SHA-256 and SHA-512
+
+## Type
+
+library
+
+## Dependencies
+
+- hmac
+- sha256
+- sha512

--- a/code/packages/haskell/hkdf/cabal.project
+++ b/code/packages/haskell/hkdf/cabal.project
@@ -1,0 +1,5 @@
+packages: .
+          ../hmac
+          ../sha1
+          ../sha256
+          ../sha512

--- a/code/packages/haskell/hkdf/hkdf.cabal
+++ b/code/packages/haskell/hkdf/hkdf.cabal
@@ -1,0 +1,27 @@
+cabal-version: 3.0
+name:          hkdf
+version:       0.1.0
+synopsis:      HKDF key derivation for SHA-256 and SHA-512
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  Hkdf
+    build-depends:    base >=4.14
+                    , hmac
+                    , sha256
+                    , sha512
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    HkdfSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , hkdf
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/hkdf/src/Hkdf.hs
+++ b/code/packages/haskell/hkdf/src/Hkdf.hs
@@ -1,0 +1,61 @@
+module Hkdf
+    ( description
+    , HashAlgorithm(..)
+    , hkdfExtract
+    , hkdfExpand
+    , hkdf
+    ) where
+
+import Data.Word (Word8)
+import Hmac (hmac)
+import Sha256 (sha256)
+import Sha512 (sha512)
+
+description :: String
+description = "HKDF key derivation for SHA-256 and SHA-512"
+
+data HashAlgorithm
+    = HkdfSha256
+    | HkdfSha512
+    deriving (Eq, Show)
+
+hkdfExtract :: HashAlgorithm -> [Word8] -> [Word8] -> [Word8]
+hkdfExtract algorithm salt ikm =
+    hmacFor algorithm effectiveSalt ikm
+  where
+    effectiveSalt =
+        if null salt
+            then replicate (hashLength algorithm) 0
+            else salt
+
+hkdfExpand :: HashAlgorithm -> [Word8] -> [Word8] -> Int -> Either String [Word8]
+hkdfExpand algorithm prk info outputLength
+    | outputLength <= 0 = Left "HKDF output length must be positive"
+    | outputLength > maxLength =
+        Left "HKDF output length exceeds 255 * HashLen"
+    | otherwise = Right (take outputLength (go [] 1 []))
+  where
+    hashLen = hashLength algorithm
+    maxLength = 255 * hashLen
+    blocksNeeded = ceilingDiv outputLength hashLen
+    go previous counter blocks
+        | counter > blocksNeeded = concat (reverse blocks)
+        | otherwise =
+            let block = hmacFor algorithm prk (previous ++ info ++ [fromIntegral counter])
+             in go block (counter + 1) (block : blocks)
+
+hkdf :: HashAlgorithm -> [Word8] -> [Word8] -> [Word8] -> Int -> Either String [Word8]
+hkdf algorithm salt ikm info outputLength =
+    hkdfExpand algorithm (hkdfExtract algorithm salt ikm) info outputLength
+
+hashLength :: HashAlgorithm -> Int
+hashLength HkdfSha256 = 32
+hashLength HkdfSha512 = 64
+
+hmacFor :: HashAlgorithm -> [Word8] -> [Word8] -> [Word8]
+hmacFor HkdfSha256 = hmac 64 sha256
+hmacFor HkdfSha512 = hmac 128 sha512
+
+ceilingDiv :: Int -> Int -> Int
+ceilingDiv numerator denominator =
+    (numerator + denominator - 1) `div` denominator

--- a/code/packages/haskell/hkdf/test/HkdfSpec.hs
+++ b/code/packages/haskell/hkdf/test/HkdfSpec.hs
@@ -1,0 +1,65 @@
+module HkdfSpec (spec) where
+
+import Data.Word (Word8)
+import Hkdf
+import Numeric (showHex)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Hkdf" $ do
+    it "matches the RFC 5869 SHA-256 extract vector" $ do
+        bytesToHex (hkdfExtract HkdfSha256 salt ikm)
+            `shouldBe` "077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5"
+
+    it "matches the RFC 5869 SHA-256 expand vector" $ do
+        hkdfExpand HkdfSha256 prk info 42
+            `shouldBe` Right okmSha256
+
+    it "derives SHA-512 output" $ do
+        hkdf HkdfSha512 (ascii "salt") (ascii "input") (ascii "info") 42
+            `shouldBe` Right okmSha512
+
+    it "rejects zero-length output" $ do
+        hkdfExpand HkdfSha256 prk info 0
+            `shouldBe` Left "HKDF output length must be positive"
+
+salt :: [Word8]
+salt = hexToBytes "000102030405060708090a0b0c"
+
+ikm :: [Word8]
+ikm = hexToBytes "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"
+
+info :: [Word8]
+info = hexToBytes "f0f1f2f3f4f5f6f7f8f9"
+
+prk :: [Word8]
+prk = hexToBytes "077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5"
+
+okmSha256 :: [Word8]
+okmSha256 = hexToBytes "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865"
+
+okmSha512 :: [Word8]
+okmSha512 = hexToBytes "93976f7542be922e353cf5440313ab4a877870039432e019c3b87b806713980b0781ec4dbe263624a457"
+
+bytesToHex :: [Word8] -> String
+bytesToHex =
+    concatMap renderByte
+  where
+    renderByte byteValue =
+        let rendered = showHex byteValue ""
+         in if length rendered == 1 then '0' : rendered else rendered
+
+hexToBytes :: String -> [Word8]
+hexToBytes [] = []
+hexToBytes (a : b : rest) = fromIntegral (hexDigit a * 16 + hexDigit b) : hexToBytes rest
+hexToBytes _ = []
+
+hexDigit :: Char -> Int
+hexDigit character
+    | character >= '0' && character <= '9' = fromEnum character - fromEnum '0'
+    | character >= 'a' && character <= 'f' = 10 + fromEnum character - fromEnum 'a'
+    | character >= 'A' && character <= 'F' = 10 + fromEnum character - fromEnum 'A'
+    | otherwise = 0
+
+ascii :: String -> [Word8]
+ascii = map (fromIntegral . fromEnum)

--- a/code/packages/haskell/hkdf/test/Spec.hs
+++ b/code/packages/haskell/hkdf/test/Spec.hs
@@ -1,0 +1,7 @@
+module Main (main) where
+
+import HkdfSpec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/hmac/BUILD
+++ b/code/packages/haskell/hmac/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/hmac/BUILD_windows
+++ b/code/packages/haskell/hmac/BUILD_windows
@@ -1,0 +1,1 @@
+if exist "%ProgramFiles%\\cabal\\bin\\cabal.exe" (cabal test all) else (echo cabal not found -- skipping)

--- a/code/packages/haskell/hmac/CHANGELOG.md
+++ b/code/packages/haskell/hmac/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/hmac/README.md
+++ b/code/packages/haskell/hmac/README.md
@@ -1,0 +1,13 @@
+# hmac
+
+HMAC authentication codes for SHA-1, SHA-256, and SHA-512
+
+## Type
+
+library
+
+## Dependencies
+
+- sha1
+- sha256
+- sha512

--- a/code/packages/haskell/hmac/cabal.project
+++ b/code/packages/haskell/hmac/cabal.project
@@ -1,0 +1,4 @@
+packages: .
+          ../sha1
+          ../sha256
+          ../sha512

--- a/code/packages/haskell/hmac/hmac.cabal
+++ b/code/packages/haskell/hmac/hmac.cabal
@@ -1,0 +1,27 @@
+cabal-version: 3.0
+name:          hmac
+version:       0.1.0
+synopsis:      HMAC authentication codes for SHA-1, SHA-256, and SHA-512
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  Hmac
+    build-depends:    base >=4.14
+                    , sha1
+                    , sha256
+                    , sha512
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    HmacSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , hmac
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/hmac/src/Hmac.hs
+++ b/code/packages/haskell/hmac/src/Hmac.hs
@@ -1,0 +1,89 @@
+module Hmac
+    ( description
+    , hmac
+    , hmacSha1
+    , hmacSha1Hex
+    , hmacSha256
+    , hmacSha256Hex
+    , hmacSha512
+    , hmacSha512Hex
+    , verifyTag
+    ) where
+
+import Data.Bits
+    ( (.|.)
+    , xor
+    )
+import Data.List (foldl')
+import Data.Word (Word8)
+import Numeric (showHex)
+import Sha1 (sha1)
+import Sha256 (sha256)
+import Sha512 (sha512)
+
+description :: String
+description = "HMAC authentication code helpers for SHA-1, SHA-256, and SHA-512"
+
+ipad :: Word8
+ipad = 0x36
+
+opad :: Word8
+opad = 0x5C
+
+hmac :: Int -> ([Word8] -> [Word8]) -> [Word8] -> [Word8] -> [Word8]
+hmac blockSize hashFunction key message =
+    hashFunction (outerKey ++ innerDigest)
+  where
+    normalizedKey = normalizeKey blockSize hashFunction key
+    innerKey = map (`xor` ipad) normalizedKey
+    outerKey = map (`xor` opad) normalizedKey
+    innerDigest = hashFunction (innerKey ++ message)
+
+hmacSha1 :: [Word8] -> [Word8] -> [Word8]
+hmacSha1 = hmac 64 sha1
+
+hmacSha1Hex :: [Word8] -> [Word8] -> String
+hmacSha1Hex key message = bytesToHex (hmacSha1 key message)
+
+hmacSha256 :: [Word8] -> [Word8] -> [Word8]
+hmacSha256 = hmac 64 sha256
+
+hmacSha256Hex :: [Word8] -> [Word8] -> String
+hmacSha256Hex key message = bytesToHex (hmacSha256 key message)
+
+hmacSha512 :: [Word8] -> [Word8] -> [Word8]
+hmacSha512 = hmac 128 sha512
+
+hmacSha512Hex :: [Word8] -> [Word8] -> String
+hmacSha512Hex key message = bytesToHex (hmacSha512 key message)
+
+verifyTag :: [Word8] -> [Word8] -> Bool
+verifyTag expected actual =
+    diff == 0
+  where
+    maxLength = max (length expected) (length actual)
+    paddedExpected = take maxLength (expected ++ repeat 0)
+    paddedActual = take maxLength (actual ++ repeat 0)
+    lengthDiff = length expected `xor` length actual
+    diff =
+        foldl'
+            (.|.)
+            lengthDiff
+            (map fromIntegral (zipWith xor paddedExpected paddedActual))
+
+normalizeKey :: Int -> ([Word8] -> [Word8]) -> [Word8] -> [Word8]
+normalizeKey blockSize hashFunction key =
+    take blockSize (baseKey ++ repeat 0)
+  where
+    baseKey =
+        if length key > blockSize
+            then hashFunction key
+            else key
+
+bytesToHex :: [Word8] -> String
+bytesToHex =
+    concatMap renderByte
+  where
+    renderByte byteValue =
+        let rendered = showHex byteValue ""
+         in if length rendered == 1 then '0' : rendered else rendered

--- a/code/packages/haskell/hmac/test/HmacSpec.hs
+++ b/code/packages/haskell/hmac/test/HmacSpec.hs
@@ -1,0 +1,32 @@
+module HmacSpec (spec) where
+
+import Data.Char (ord)
+import Data.Word (Word8)
+import Hmac
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Hmac" $ do
+    it "computes the RFC vector for HMAC-SHA1" $ do
+        hmacSha1Hex keyHiThere (ascii "Hi There")
+            `shouldBe` "b617318655057264e28bc0b6fb378c8ef146be00"
+
+    it "computes the RFC vector for HMAC-SHA256" $ do
+        hmacSha256Hex keyHiThere (ascii "Hi There")
+            `shouldBe` "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7"
+
+    it "computes the RFC vector for HMAC-SHA512" $ do
+        hmacSha512Hex keyHiThere (ascii "Hi There")
+            `shouldBe` "87aa7cdea5ef619d4ff0b4241a1d6cb02379f4e2ce4ec2787ad0b30545e17cdedaa833b7d6b8a702038b274eaea3f4e4be9d914eeb61f1702e696c203a126854"
+
+    it "verifies equal tags" $ do
+        verifyTag [1, 2, 3, 4] [1, 2, 3, 4] `shouldBe` True
+
+    it "rejects unequal tags" $ do
+        verifyTag [1, 2, 3, 4] [1, 2, 3, 5] `shouldBe` False
+
+keyHiThere :: [Word8]
+keyHiThere = replicate 20 0x0b
+
+ascii :: String -> [Word8]
+ascii = map (fromIntegral . ord)

--- a/code/packages/haskell/hmac/test/Spec.hs
+++ b/code/packages/haskell/hmac/test/Spec.hs
@@ -1,0 +1,7 @@
+module Main (main) where
+
+import HmacSpec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/pbkdf2/BUILD
+++ b/code/packages/haskell/pbkdf2/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/pbkdf2/BUILD_windows
+++ b/code/packages/haskell/pbkdf2/BUILD_windows
@@ -1,0 +1,1 @@
+if exist "%ProgramFiles%\\cabal\\bin\\cabal.exe" (cabal test all) else (echo cabal not found -- skipping)

--- a/code/packages/haskell/pbkdf2/CHANGELOG.md
+++ b/code/packages/haskell/pbkdf2/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/pbkdf2/README.md
+++ b/code/packages/haskell/pbkdf2/README.md
@@ -1,0 +1,11 @@
+# pbkdf2
+
+PBKDF2 key derivation using HMAC-SHA1, HMAC-SHA256, and HMAC-SHA512
+
+## Type
+
+library
+
+## Dependencies
+
+- hmac

--- a/code/packages/haskell/pbkdf2/cabal.project
+++ b/code/packages/haskell/pbkdf2/cabal.project
@@ -1,0 +1,5 @@
+packages: .
+          ../hmac
+          ../sha1
+          ../sha256
+          ../sha512

--- a/code/packages/haskell/pbkdf2/pbkdf2.cabal
+++ b/code/packages/haskell/pbkdf2/pbkdf2.cabal
@@ -1,0 +1,25 @@
+cabal-version: 3.0
+name:          pbkdf2
+version:       0.1.0
+synopsis:      PBKDF2 key derivation using HMAC-SHA1, HMAC-SHA256, and HMAC-SHA512
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  Pbkdf2
+    build-depends:    base >=4.14
+                    , hmac
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    Pbkdf2Spec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , pbkdf2
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/pbkdf2/src/Pbkdf2.hs
+++ b/code/packages/haskell/pbkdf2/src/Pbkdf2.hs
@@ -1,0 +1,76 @@
+module Pbkdf2
+    ( description
+    , PrfAlgorithm(..)
+    , pbkdf2
+    , pbkdf2Hex
+    ) where
+
+import Data.Bits (xor)
+import Data.List (foldl')
+import Data.Word (Word8, Word32)
+import Hmac (hmacSha1, hmacSha256, hmacSha512)
+import Numeric (showHex)
+
+description :: String
+description = "PBKDF2 key derivation using HMAC-SHA1, HMAC-SHA256, and HMAC-SHA512"
+
+data PrfAlgorithm
+    = Pbkdf2Sha1
+    | Pbkdf2Sha256
+    | Pbkdf2Sha512
+    deriving (Eq, Show)
+
+pbkdf2 :: PrfAlgorithm -> [Word8] -> [Word8] -> Int -> Int -> Either String [Word8]
+pbkdf2 algorithm password salt iterations keyLength
+    | iterations <= 0 = Left "PBKDF2 iterations must be positive"
+    | keyLength <= 0 = Left "PBKDF2 key length must be positive"
+    | otherwise = Right (take keyLength (concatMap deriveBlock [1 .. blocksNeeded]))
+  where
+    hashLen = hashLength algorithm
+    blocksNeeded = ceilingDiv keyLength hashLen
+    deriveBlock blockIndex =
+        foldl1 xorBytes (take iterations (iterate nextBlock firstBlock))
+      where
+        firstBlock = prf algorithm password (salt ++ word32ToBytes (fromIntegral blockIndex))
+        nextBlock previous = prf algorithm password previous
+
+pbkdf2Hex :: PrfAlgorithm -> [Word8] -> [Word8] -> Int -> Int -> Either String String
+pbkdf2Hex algorithm password salt iterations keyLength =
+    fmap bytesToHex (pbkdf2 algorithm password salt iterations keyLength)
+
+hashLength :: PrfAlgorithm -> Int
+hashLength Pbkdf2Sha1 = 20
+hashLength Pbkdf2Sha256 = 32
+hashLength Pbkdf2Sha512 = 64
+
+prf :: PrfAlgorithm -> [Word8] -> [Word8] -> [Word8]
+prf Pbkdf2Sha1 = hmacSha1
+prf Pbkdf2Sha256 = hmacSha256
+prf Pbkdf2Sha512 = hmacSha512
+
+xorBytes :: [Word8] -> [Word8] -> [Word8]
+xorBytes = zipWith xor
+
+word32ToBytes :: Word32 -> [Word8]
+word32ToBytes wordValue =
+    [ fromIntegral (wordValue `shiftRightWord32` 24)
+    , fromIntegral (wordValue `shiftRightWord32` 16)
+    , fromIntegral (wordValue `shiftRightWord32` 8)
+    , fromIntegral wordValue
+    ]
+
+shiftRightWord32 :: Word32 -> Int -> Word32
+shiftRightWord32 value amount =
+    value `div` (2 ^ amount)
+
+ceilingDiv :: Int -> Int -> Int
+ceilingDiv numerator denominator =
+    (numerator + denominator - 1) `div` denominator
+
+bytesToHex :: [Word8] -> String
+bytesToHex =
+    concatMap renderByte
+  where
+    renderByte byteValue =
+        let rendered = showHex byteValue ""
+         in if length rendered == 1 then '0' : rendered else rendered

--- a/code/packages/haskell/pbkdf2/test/Pbkdf2Spec.hs
+++ b/code/packages/haskell/pbkdf2/test/Pbkdf2Spec.hs
@@ -1,0 +1,26 @@
+module Pbkdf2Spec (spec) where
+
+import Data.Word (Word8)
+import Pbkdf2
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Pbkdf2" $ do
+    it "matches the RFC 6070 SHA-1 vector" $ do
+        pbkdf2Hex Pbkdf2Sha1 (ascii "password") (ascii "salt") 1 20
+            `shouldBe` Right "0c60c80f961f0e71f3a9b524af6012062fe037a6"
+
+    it "matches the common SHA-256 vector" $ do
+        pbkdf2Hex Pbkdf2Sha256 (ascii "password") (ascii "salt") 1 32
+            `shouldBe` Right "120fb6cffcf8b32c43e7225256c4f837a86548c92ccc35480805987cb70be17b"
+
+    it "derives SHA-512 output" $ do
+        pbkdf2Hex Pbkdf2Sha512 (ascii "password") (ascii "salt") 1 64
+            `shouldBe` Right "867f70cf1ade02cff3752599a3a53dc4af34c7a669815ae5d513554e1c8cf252c02d470a285a0501bad999bfe943c08f050235d7d68b1da55e63f73b60a57fce"
+
+    it "rejects zero iterations" $ do
+        pbkdf2 Pbkdf2Sha256 (ascii "password") (ascii "salt") 0 32
+            `shouldBe` Left "PBKDF2 iterations must be positive"
+
+ascii :: String -> [Word8]
+ascii = map (fromIntegral . fromEnum)

--- a/code/packages/haskell/pbkdf2/test/Spec.hs
+++ b/code/packages/haskell/pbkdf2/test/Spec.hs
@@ -1,0 +1,7 @@
+module Main (main) where
+
+import Pbkdf2Spec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/sha1/BUILD
+++ b/code/packages/haskell/sha1/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/sha1/BUILD_windows
+++ b/code/packages/haskell/sha1/BUILD_windows
@@ -1,0 +1,1 @@
+if exist "%ProgramFiles%\\cabal\\bin\\cabal.exe" (cabal test all) else (echo cabal not found -- skipping)

--- a/code/packages/haskell/sha1/CHANGELOG.md
+++ b/code/packages/haskell/sha1/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/sha1/README.md
+++ b/code/packages/haskell/sha1/README.md
@@ -1,0 +1,11 @@
+# sha1
+
+SHA-1 cryptographic hash function (FIPS 180-4) implemented from scratch
+
+## Type
+
+library
+
+## Dependencies
+
+(none)

--- a/code/packages/haskell/sha1/cabal.project
+++ b/code/packages/haskell/sha1/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/code/packages/haskell/sha1/sha1.cabal
+++ b/code/packages/haskell/sha1/sha1.cabal
@@ -1,0 +1,24 @@
+cabal-version: 3.0
+name:          sha1
+version:       0.1.0
+synopsis:      SHA-1 cryptographic hash function (FIPS 180-4) implemented from scratch
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  Sha1
+    build-depends:    base >=4.14
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    Sha1Spec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , sha1
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/sha1/src/Sha1.hs
+++ b/code/packages/haskell/sha1/src/Sha1.hs
@@ -1,0 +1,151 @@
+module Sha1
+    ( description
+    , sha1
+    , sha1Hex
+    ) where
+
+import Data.Bits
+    ( (.&.)
+    , complement
+    , rotateL
+    , shiftR
+    , shiftL
+    , xor
+    )
+import Data.List (foldl')
+import Data.Word (Word8, Word32, Word64)
+import Numeric (showHex)
+
+description :: String
+description = "SHA-1 cryptographic hash function (FIPS 180-4) implemented from scratch"
+
+initialState :: [Word32]
+initialState =
+    [ 0x67452301
+    , 0xEFCDAB89
+    , 0x98BADCFE
+    , 0x10325476
+    , 0xC3D2E1F0
+    ]
+
+roundConstants :: [Word32]
+roundConstants =
+    concat
+        [ replicate 20 0x5A827999
+        , replicate 20 0x6ED9EBA1
+        , replicate 20 0x8F1BBCDC
+        , replicate 20 0xCA62C1D6
+        ]
+
+sha1 :: [Word8] -> [Word8]
+sha1 inputBytes =
+    concatMap word32ToBytes (foldl' compress initialState (chunksOf 64 (pad inputBytes)))
+
+sha1Hex :: [Word8] -> String
+sha1Hex =
+    concatMap renderByte . sha1
+  where
+    renderByte byteValue =
+        let rendered = showHex byteValue ""
+         in if length rendered == 1 then '0' : rendered else rendered
+
+pad :: [Word8] -> [Word8]
+pad inputBytes =
+    inputBytes ++ [0x80] ++ replicate paddingLength 0 ++ lengthBytes
+  where
+    bitLength :: Word64
+    bitLength = fromIntegral (length inputBytes) * 8
+    lengthBytes = word64ToBytes bitLength
+    paddingLength =
+        let remainder = (length inputBytes + 1 + 8) `mod` 64
+         in if remainder == 0 then 0 else 64 - remainder
+
+compress :: [Word32] -> [Word8] -> [Word32]
+compress state block =
+    zipWith (+) state [a', b', c', d', e']
+  where
+    scheduleWords = messageSchedule block
+    [a0, b0, c0, d0, e0] = state
+    (a', b', c', d', e') =
+        foldl'
+            roundStep
+            (a0, b0, c0, d0, e0)
+            (zip3 [0 .. 79] roundConstants scheduleWords)
+
+roundStep :: (Word32, Word32, Word32, Word32, Word32) -> (Int, Word32, Word32) -> (Word32, Word32, Word32, Word32, Word32)
+roundStep (a, b, c, d, e) (roundIndex, constantValue, wordValue) =
+    ( temp
+    , a
+    , rotateLeft32 30 b
+    , c
+    , d
+    )
+  where
+    temp =
+        rotateLeft32 5 a
+            + roundFunction roundIndex b c d
+            + e
+            + constantValue
+            + wordValue
+
+roundFunction :: Int -> Word32 -> Word32 -> Word32 -> Word32
+roundFunction roundIndex b c d
+    | roundIndex < 20 = (b .&. c) `xor` (complement b .&. d)
+    | roundIndex < 40 = b `xor` c `xor` d
+    | roundIndex < 60 = (b .&. c) `xor` (b .&. d) `xor` (c .&. d)
+    | otherwise = b `xor` c `xor` d
+
+messageSchedule :: [Word8] -> [Word32]
+messageSchedule block =
+    initialWords ++ expand initialWords
+  where
+    initialWords = map bytesToWord32 (chunksOf 4 block)
+    expand wordsSoFar
+        | length wordsSoFar == 80 = []
+        | otherwise =
+            let nextValue =
+                    rotateLeft32 1 $
+                        (wordsSoFar !! 13)
+                            `xor` (wordsSoFar !! 8)
+                            `xor` (wordsSoFar !! 2)
+                            `xor` (wordsSoFar !! 0)
+                rotated = drop 1 wordsSoFar ++ [nextValue]
+             in nextValue : expand rotated
+
+rotateLeft32 :: Int -> Word32 -> Word32
+rotateLeft32 count value =
+    rotateL value count
+
+word32ToBytes :: Word32 -> [Word8]
+word32ToBytes wordValue =
+    [ fromIntegral (wordValue `shiftR` 24)
+    , fromIntegral (wordValue `shiftR` 16)
+    , fromIntegral (wordValue `shiftR` 8)
+    , fromIntegral wordValue
+    ]
+
+word64ToBytes :: Word64 -> [Word8]
+word64ToBytes wordValue =
+    [ fromIntegral (wordValue `shiftR` 56)
+    , fromIntegral (wordValue `shiftR` 48)
+    , fromIntegral (wordValue `shiftR` 40)
+    , fromIntegral (wordValue `shiftR` 32)
+    , fromIntegral (wordValue `shiftR` 24)
+    , fromIntegral (wordValue `shiftR` 16)
+    , fromIntegral (wordValue `shiftR` 8)
+    , fromIntegral wordValue
+    ]
+
+bytesToWord32 :: [Word8] -> Word32
+bytesToWord32 [a, b, c, d] =
+    shiftL (fromIntegral a) 24
+        + shiftL (fromIntegral b) 16
+        + shiftL (fromIntegral c) 8
+        + fromIntegral d
+bytesToWord32 _ = 0
+
+chunksOf :: Int -> [a] -> [[a]]
+chunksOf _ [] = []
+chunksOf size values =
+    let (chunk, rest) = splitAt size values
+     in chunk : chunksOf size rest

--- a/code/packages/haskell/sha1/test/Sha1Spec.hs
+++ b/code/packages/haskell/sha1/test/Sha1Spec.hs
@@ -1,0 +1,22 @@
+module Sha1Spec (spec) where
+
+import Data.Char (ord)
+import Data.Word (Word8)
+import Sha1
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Sha1" $ do
+    it "hashes abc to the FIPS vector" $ do
+        sha1Hex (ascii "abc")
+            `shouldBe` "a9993e364706816aba3e25717850c26c9cd0d89d"
+
+    it "hashes the empty string" $ do
+        sha1Hex []
+            `shouldBe` "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+
+    it "returns a 20-byte digest" $ do
+        length (sha1 (ascii "coding adventures")) `shouldBe` 20
+
+ascii :: String -> [Word8]
+ascii = map (fromIntegral . ord)

--- a/code/packages/haskell/sha1/test/Spec.hs
+++ b/code/packages/haskell/sha1/test/Spec.hs
@@ -1,0 +1,7 @@
+module Main (main) where
+
+import Sha1Spec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/sha512/BUILD
+++ b/code/packages/haskell/sha512/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/sha512/BUILD_windows
+++ b/code/packages/haskell/sha512/BUILD_windows
@@ -1,0 +1,1 @@
+if exist "%ProgramFiles%\\cabal\\bin\\cabal.exe" (cabal test all) else (echo cabal not found -- skipping)

--- a/code/packages/haskell/sha512/CHANGELOG.md
+++ b/code/packages/haskell/sha512/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/sha512/README.md
+++ b/code/packages/haskell/sha512/README.md
@@ -1,0 +1,11 @@
+# sha512
+
+SHA-512 cryptographic hash function (FIPS 180-4) implemented from scratch
+
+## Type
+
+library
+
+## Dependencies
+
+(none)

--- a/code/packages/haskell/sha512/cabal.project
+++ b/code/packages/haskell/sha512/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/code/packages/haskell/sha512/sha512.cabal
+++ b/code/packages/haskell/sha512/sha512.cabal
@@ -1,0 +1,24 @@
+cabal-version: 3.0
+name:          sha512
+version:       0.1.0
+synopsis:      SHA-512 cryptographic hash function (FIPS 180-4) implemented from scratch
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  Sha512
+    build-depends:    base >=4.14
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    Sha512Spec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , sha512
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/sha512/src/Sha512.hs
+++ b/code/packages/haskell/sha512/src/Sha512.hs
@@ -1,0 +1,186 @@
+module Sha512
+    ( description
+    , sha512
+    , sha512Hex
+    ) where
+
+import Data.Bits
+    ( (.&.)
+    , rotateR
+    , shiftR
+    , shiftL
+    , xor
+    )
+import Data.List (foldl')
+import Data.Word (Word8, Word64)
+import Numeric (showHex)
+
+description :: String
+description = "SHA-512 cryptographic hash function (FIPS 180-4) implemented from scratch"
+
+initialState :: [Word64]
+initialState =
+    [ 0x6A09E667F3BCC908
+    , 0xBB67AE8584CAA73B
+    , 0x3C6EF372FE94F82B
+    , 0xA54FF53A5F1D36F1
+    , 0x510E527FADE682D1
+    , 0x9B05688C2B3E6C1F
+    , 0x1F83D9ABFB41BD6B
+    , 0x5BE0CD19137E2179
+    ]
+
+roundConstants :: [Word64]
+roundConstants =
+    [ 0x428A2F98D728AE22, 0x7137449123EF65CD, 0xB5C0FBCFEC4D3B2F, 0xE9B5DBA58189DBBC
+    , 0x3956C25BF348B538, 0x59F111F1B605D019, 0x923F82A4AF194F9B, 0xAB1C5ED5DA6D8118
+    , 0xD807AA98A3030242, 0x12835B0145706FBE, 0x243185BE4EE4B28C, 0x550C7DC3D5FFB4E2
+    , 0x72BE5D74F27B896F, 0x80DEB1FE3B1696B1, 0x9BDC06A725C71235, 0xC19BF174CF692694
+    , 0xE49B69C19EF14AD2, 0xEFBE4786384F25E3, 0x0FC19DC68B8CD5B5, 0x240CA1CC77AC9C65
+    , 0x2DE92C6F592B0275, 0x4A7484AA6EA6E483, 0x5CB0A9DCBD41FBD4, 0x76F988DA831153B5
+    , 0x983E5152EE66DFAB, 0xA831C66D2DB43210, 0xB00327C898FB213F, 0xBF597FC7BEEF0EE4
+    , 0xC6E00BF33DA88FC2, 0xD5A79147930AA725, 0x06CA6351E003826F, 0x142929670A0E6E70
+    , 0x27B70A8546D22FFC, 0x2E1B21385C26C926, 0x4D2C6DFC5AC42AED, 0x53380D139D95B3DF
+    , 0x650A73548BAF63DE, 0x766A0ABB3C77B2A8, 0x81C2C92E47EDAEE6, 0x92722C851482353B
+    , 0xA2BFE8A14CF10364, 0xA81A664BBC423001, 0xC24B8B70D0F89791, 0xC76C51A30654BE30
+    , 0xD192E819D6EF5218, 0xD69906245565A910, 0xF40E35855771202A, 0x106AA07032BBD1B8
+    , 0x19A4C116B8D2D0C8, 0x1E376C085141AB53, 0x2748774CDF8EEB99, 0x34B0BCB5E19B48A8
+    , 0x391C0CB3C5C95A63, 0x4ED8AA4AE3418ACB, 0x5B9CCA4F7763E373, 0x682E6FF3D6B2B8A3
+    , 0x748F82EE5DEFB2FC, 0x78A5636F43172F60, 0x84C87814A1F0AB72, 0x8CC702081A6439EC
+    , 0x90BEFFFA23631E28, 0xA4506CEBDE82BDE9, 0xBEF9A3F7B2C67915, 0xC67178F2E372532B
+    , 0xCA273ECEEA26619C, 0xD186B8C721C0C207, 0xEADA7DD6CDE0EB1E, 0xF57D4F7FEE6ED178
+    , 0x06F067AA72176FBA, 0x0A637DC5A2C898A6, 0x113F9804BEF90DAE, 0x1B710B35131C471B
+    , 0x28DB77F523047D84, 0x32CAAB7B40C72493, 0x3C9EBE0A15C9BEBC, 0x431D67C49C100D4C
+    , 0x4CC5D4BECB3E42B6, 0x597F299CFC657E2A, 0x5FCB6FAB3AD6FAEC, 0x6C44198C4A475817
+    ]
+
+sha512 :: [Word8] -> [Word8]
+sha512 inputBytes =
+    concatMap word64ToBytes (foldl' compress initialState (chunksOf 128 (pad inputBytes)))
+
+sha512Hex :: [Word8] -> String
+sha512Hex =
+    concatMap renderByte . sha512
+  where
+    renderByte byteValue =
+        let rendered = showHex byteValue ""
+         in if length rendered == 1 then '0' : rendered else rendered
+
+pad :: [Word8] -> [Word8]
+pad inputBytes =
+    inputBytes ++ [0x80] ++ replicate paddingLength 0 ++ integerToBytes16 bitLength
+  where
+    bitLength :: Integer
+    bitLength = fromIntegral (length inputBytes) * 8
+    paddingLength =
+        let remainder = (length inputBytes + 1 + 16) `mod` 128
+         in if remainder == 0 then 0 else 128 - remainder
+
+compress :: [Word64] -> [Word8] -> [Word64]
+compress state block =
+    zipWith (+) state [a', b', c', d', e', f', g', h']
+  where
+    scheduleWords = messageSchedule block
+    [a0, b0, c0, d0, e0, f0, g0, h0] = state
+    (a', b', c', d', e', f', g', h') =
+        foldl'
+            roundStep
+            (a0, b0, c0, d0, e0, f0, g0, h0)
+            (zip roundConstants scheduleWords)
+
+roundStep :: (Word64, Word64, Word64, Word64, Word64, Word64, Word64, Word64) -> (Word64, Word64) -> (Word64, Word64, Word64, Word64, Word64, Word64, Word64, Word64)
+roundStep (a, b, c, d, e, f, g, h) (constantValue, wordValue) =
+    ( t1 + t2
+    , a
+    , b
+    , c
+    , d + t1
+    , e
+    , f
+    , g
+    )
+  where
+    t1 = h + bigSigma1 e + choose e f g + constantValue + wordValue
+    t2 = bigSigma0 a + majority a b c
+
+messageSchedule :: [Word8] -> [Word64]
+messageSchedule block =
+    initialWords ++ expand initialWords
+  where
+    initialWords = map bytesToWord64 (chunksOf 8 block)
+    expand wordsSoFar
+        | length wordsSoFar == 80 = []
+        | otherwise =
+            let nextValue =
+                    smallSigma1 (wordsSoFar !! 14)
+                        + (wordsSoFar !! 9)
+                        + smallSigma0 (wordsSoFar !! 1)
+                        + (wordsSoFar !! 0)
+                rotated = drop 1 wordsSoFar ++ [nextValue]
+             in nextValue : expand rotated
+
+choose :: Word64 -> Word64 -> Word64 -> Word64
+choose x y z = (x .&. y) `xor` (complement64 x .&. z)
+
+majority :: Word64 -> Word64 -> Word64 -> Word64
+majority x y z = (x .&. y) `xor` (x .&. z) `xor` (y .&. z)
+
+bigSigma0 :: Word64 -> Word64
+bigSigma0 x = rotateRight64 28 x `xor` rotateRight64 34 x `xor` rotateRight64 39 x
+
+bigSigma1 :: Word64 -> Word64
+bigSigma1 x = rotateRight64 14 x `xor` rotateRight64 18 x `xor` rotateRight64 41 x
+
+smallSigma0 :: Word64 -> Word64
+smallSigma0 x = rotateRight64 1 x `xor` rotateRight64 8 x `xor` (x `shiftR` 7)
+
+smallSigma1 :: Word64 -> Word64
+smallSigma1 x = rotateRight64 19 x `xor` rotateRight64 61 x `xor` (x `shiftR` 6)
+
+rotateRight64 :: Int -> Word64 -> Word64
+rotateRight64 count value =
+    rotateR value count
+
+complement64 :: Word64 -> Word64
+complement64 value = maxBound `xor` value
+
+word64ToBytes :: Word64 -> [Word8]
+word64ToBytes wordValue =
+    [ fromIntegral (wordValue `shiftR` 56)
+    , fromIntegral (wordValue `shiftR` 48)
+    , fromIntegral (wordValue `shiftR` 40)
+    , fromIntegral (wordValue `shiftR` 32)
+    , fromIntegral (wordValue `shiftR` 24)
+    , fromIntegral (wordValue `shiftR` 16)
+    , fromIntegral (wordValue `shiftR` 8)
+    , fromIntegral wordValue
+    ]
+
+bytesToWord64 :: [Word8] -> Word64
+bytesToWord64 [a, b, c, d, e, f, g, h] =
+    shiftL (fromIntegral a) 56
+        + shiftL (fromIntegral b) 48
+        + shiftL (fromIntegral c) 40
+        + shiftL (fromIntegral d) 32
+        + shiftL (fromIntegral e) 24
+        + shiftL (fromIntegral f) 16
+        + shiftL (fromIntegral g) 8
+        + fromIntegral h
+bytesToWord64 _ = 0
+
+integerToBytes16 :: Integer -> [Word8]
+integerToBytes16 value =
+    map byteAt [15, 14 .. 0]
+  where
+    byteAt index =
+        fromIntegral ((value `shiftRInteger` (index * 8)) `mod` 256)
+
+shiftRInteger :: Integer -> Int -> Integer
+shiftRInteger value amount =
+    value `div` (2 ^ amount)
+
+chunksOf :: Int -> [a] -> [[a]]
+chunksOf _ [] = []
+chunksOf size values =
+    let (chunk, rest) = splitAt size values
+     in chunk : chunksOf size rest

--- a/code/packages/haskell/sha512/test/Sha512Spec.hs
+++ b/code/packages/haskell/sha512/test/Sha512Spec.hs
@@ -1,0 +1,22 @@
+module Sha512Spec (spec) where
+
+import Data.Char (ord)
+import Data.Word (Word8)
+import Sha512
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Sha512" $ do
+    it "hashes abc to the FIPS vector" $ do
+        sha512Hex (ascii "abc")
+            `shouldBe` "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f"
+
+    it "hashes the empty string" $ do
+        sha512Hex []
+            `shouldBe` "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+
+    it "returns a 64-byte digest" $ do
+        length (sha512 (ascii "coding adventures")) `shouldBe` 64
+
+ascii :: String -> [Word8]
+ascii = map (fromIntegral . ord)

--- a/code/packages/haskell/sha512/test/Spec.hs
+++ b/code/packages/haskell/sha512/test/Spec.hs
@@ -1,0 +1,7 @@
+module Main (main) where
+
+import Sha512Spec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec


### PR DESCRIPTION
## What changed
- added new Haskell `sha1` and `sha512` packages implemented from scratch
- added a new Haskell `hmac` package with SHA-1, SHA-256, and SHA-512 variants plus tag verification
- added a new Haskell `hkdf` package for SHA-256 and SHA-512 extract/expand flows
- added a new Haskell `pbkdf2` package for HMAC-SHA1, HMAC-SHA256, and HMAC-SHA512 derivation

## Why
This starts the Haskell crypto wave with the reusable core primitives we will want before moving into cipher and curve packages: digests, message authentication, and key derivation.

## Impact
- Haskell now has the first shared cryptography foundation beyond `sha256`
- later packages like `aes`, `chacha20-poly1305`, `x25519`, and `ed25519` can build on a real digest/MAC/KDF stack instead of ad hoc helpers
- the APIs stay aligned with the current Haskell package style: simple `[Word8]` inputs and deterministic test vectors

## Validation
- `cabal test` in `code/packages/haskell/sha1`
- `cabal test` in `code/packages/haskell/sha256`
- `cabal test` in `code/packages/haskell/sha512`
- `cabal test` in `code/packages/haskell/hmac`
- `cabal test` in `code/packages/haskell/hkdf`
- `cabal test` in `code/packages/haskell/pbkdf2`