### PR TITLE
[codex] add haskell symmetric crypto packages

### DIFF
--- a/code/packages/haskell/aes-modes/BUILD
+++ b/code/packages/haskell/aes-modes/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/aes-modes/BUILD_windows
+++ b/code/packages/haskell/aes-modes/BUILD_windows
@@ -1,0 +1,1 @@
+if exist "%ProgramFiles%\\cabal\\bin\\cabal.exe" (cabal test all) else (echo cabal not found -- skipping)

--- a/code/packages/haskell/aes-modes/CHANGELOG.md
+++ b/code/packages/haskell/aes-modes/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/aes-modes/README.md
+++ b/code/packages/haskell/aes-modes/README.md
@@ -1,0 +1,11 @@
+# aes-modes
+
+AES modes of operation including ECB, CBC, CTR, and GCM
+
+## Type
+
+library
+
+## Dependencies
+
+- aes

--- a/code/packages/haskell/aes-modes/aes-modes.cabal
+++ b/code/packages/haskell/aes-modes/aes-modes.cabal
@@ -1,0 +1,25 @@
+cabal-version: 3.0
+name:          aes-modes
+version:       0.1.0
+synopsis:      AES modes of operation including ECB, CBC, CTR, and GCM
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  AesModes
+    build-depends:    aes
+                    , base >=4.14
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    AesModesSpec
+    hs-source-dirs:   test
+    build-depends:    aes-modes
+                    , base >=4.14
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/aes-modes/cabal.project
+++ b/code/packages/haskell/aes-modes/cabal.project
@@ -1,0 +1,2 @@
+packages: .
+          ../aes

--- a/code/packages/haskell/aes-modes/src/AesModes.hs
+++ b/code/packages/haskell/aes-modes/src/AesModes.hs
@@ -1,0 +1,219 @@
+module AesModes
+    ( description
+    , pkcs7Pad
+    , pkcs7Unpad
+    , ecbEncrypt
+    , ecbDecrypt
+    , cbcEncrypt
+    , cbcDecrypt
+    , ctrEncrypt
+    , ctrDecrypt
+    , gcmEncrypt
+    , gcmDecrypt
+    ) where
+
+import Aes (decryptBlock, encryptBlock)
+import Data.Bits
+    ( (.|.)
+    , shiftL
+    , shiftR
+    , testBit
+    , xor
+    )
+import Data.List (foldl')
+import Data.Word (Word8)
+
+description :: String
+description = "AES modes of operation including ECB, CBC, CTR, and GCM"
+
+blockSize :: Int
+blockSize = 16
+
+pkcs7Pad :: [Word8] -> [Word8]
+pkcs7Pad inputBytes =
+    inputBytes ++ replicate padLength (fromIntegral padLength)
+  where
+    padLength = blockSize - (length inputBytes `mod` blockSize)
+
+pkcs7Unpad :: [Word8] -> Either String [Word8]
+pkcs7Unpad inputBytes
+    | null inputBytes || length inputBytes `mod` blockSize /= 0 =
+        Left "Invalid padded data: length must be a positive multiple of 16"
+    | padLength == 0 || padLength > blockSize =
+        Left "Invalid PKCS#7 padding"
+    | any (/= fromIntegral padLength) (drop (length inputBytes - padLength) inputBytes) =
+        Left "Invalid PKCS#7 padding"
+    | otherwise =
+        Right (take (length inputBytes - padLength) inputBytes)
+  where
+    padLength = fromIntegral (last inputBytes)
+
+ecbEncrypt :: [Word8] -> [Word8] -> Either String [Word8]
+ecbEncrypt plaintext keyBytes =
+    fmap concat (mapM (`encryptBlock` keyBytes) (chunksOf 16 (pkcs7Pad plaintext)))
+
+ecbDecrypt :: [Word8] -> [Word8] -> Either String [Word8]
+ecbDecrypt ciphertext keyBytes
+    | null ciphertext || length ciphertext `mod` blockSize /= 0 =
+        Left "ECB ciphertext must be a non-empty multiple of 16 bytes"
+    | otherwise = do
+        decrypted <- fmap concat (mapM (`decryptBlock` keyBytes) (chunksOf 16 ciphertext))
+        pkcs7Unpad decrypted
+
+cbcEncrypt :: [Word8] -> [Word8] -> [Word8] -> Either String [Word8]
+cbcEncrypt plaintext keyBytes iv
+    | length iv /= blockSize =
+        Left ("CBC IV must be 16 bytes, got " ++ show (length iv))
+    | otherwise =
+        fmap fst (foldM encryptChunk ([], iv) (chunksOf 16 (pkcs7Pad plaintext)))
+  where
+    encryptChunk (accumulator, previousBlock) chunk = do
+        encrypted <- encryptBlock (xorBytes chunk previousBlock) keyBytes
+        Right (accumulator ++ encrypted, encrypted)
+
+cbcDecrypt :: [Word8] -> [Word8] -> [Word8] -> Either String [Word8]
+cbcDecrypt ciphertext keyBytes iv
+    | length iv /= blockSize =
+        Left ("CBC IV must be 16 bytes, got " ++ show (length iv))
+    | null ciphertext || length ciphertext `mod` blockSize /= 0 =
+        Left "CBC ciphertext must be a non-empty multiple of 16 bytes"
+    | otherwise = do
+        decrypted <- fmap fst (foldM decryptChunk ([], iv) (chunksOf 16 ciphertext))
+        pkcs7Unpad decrypted
+  where
+    decryptChunk (accumulator, previousBlock) chunk = do
+        decrypted <- decryptBlock chunk keyBytes
+        let plaintext = xorBytes decrypted previousBlock
+        Right (accumulator ++ plaintext, chunk)
+
+ctrEncrypt :: [Word8] -> [Word8] -> [Word8] -> Either String [Word8]
+ctrEncrypt inputBytes keyBytes nonce
+    | length nonce /= 12 =
+        Left ("CTR nonce must be 12 bytes, got " ++ show (length nonce))
+    | otherwise =
+        fmap concat (sequence (zipWith xorWithCounter [1 ..] (chunksOf 16 inputBytes)))
+  where
+    xorWithCounter counter chunk = do
+        keystream <- encryptBlock (buildCounterBlock nonce counter) keyBytes
+        Right (zipWith xor chunk keystream)
+
+ctrDecrypt :: [Word8] -> [Word8] -> [Word8] -> Either String [Word8]
+ctrDecrypt = ctrEncrypt
+
+gcmEncrypt :: [Word8] -> [Word8] -> [Word8] -> [Word8] -> Either String ([Word8], [Word8])
+gcmEncrypt plaintext keyBytes iv aad
+    | length iv /= 12 =
+        Left ("GCM IV must be 12 bytes, got " ++ show (length iv))
+    | otherwise = do
+        hashSubkey <- encryptBlock (replicate 16 0) keyBytes
+        let j0 = iv ++ [0, 0, 0, 1]
+        ciphertext <- ctrFromCounter plaintext keyBytes j0 2
+        encryptedJ0 <- encryptBlock j0 keyBytes
+        let tag = xorBytes (ghash hashSubkey aad ciphertext) encryptedJ0
+        Right (ciphertext, tag)
+
+gcmDecrypt :: [Word8] -> [Word8] -> [Word8] -> [Word8] -> [Word8] -> Either String [Word8]
+gcmDecrypt ciphertext keyBytes iv aad tag
+    | length iv /= 12 =
+        Left ("GCM IV must be 12 bytes, got " ++ show (length iv))
+    | length tag /= 16 =
+        Left ("GCM tag must be 16 bytes, got " ++ show (length tag))
+    | otherwise = do
+        hashSubkey <- encryptBlock (replicate 16 0) keyBytes
+        let j0 = iv ++ [0, 0, 0, 1]
+        encryptedJ0 <- encryptBlock j0 keyBytes
+        let computedTag = xorBytes (ghash hashSubkey aad ciphertext) encryptedJ0
+        if constantTimeEq computedTag tag
+            then ctrFromCounter ciphertext keyBytes j0 2
+            else Left "GCM authentication failed: tag mismatch"
+
+ctrFromCounter :: [Word8] -> [Word8] -> [Word8] -> Word32Like -> Either String [Word8]
+ctrFromCounter inputBytes keyBytes initialCounterBlock initialCounter =
+    fmap concat (sequence (zipWith xorWithCounter [initialCounter ..] (chunksOf 16 inputBytes)))
+  where
+    nonce = take 12 initialCounterBlock
+    xorWithCounter counter chunk = do
+        keystream <- encryptBlock (buildCounterBlock nonce counter) keyBytes
+        Right (zipWith xor chunk keystream)
+
+type Word32Like = Int
+
+buildCounterBlock :: [Word8] -> Word32Like -> [Word8]
+buildCounterBlock nonce counter =
+    nonce ++ word32ToBytesBE counter
+
+word32ToBytesBE :: Int -> [Word8]
+word32ToBytesBE value =
+    [ fromIntegral (shiftR value 24)
+    , fromIntegral (shiftR value 16)
+    , fromIntegral (shiftR value 8)
+    , fromIntegral value
+    ]
+
+ghash :: [Word8] -> [Word8] -> [Word8] -> [Word8]
+ghash hashSubkey aad ciphertext =
+    integerToBytes16BE finalValue
+  where
+    hValue = bytesToIntegerBE hashSubkey
+    process accumulator block = gf128Mul (accumulator `xor` bytesToIntegerBE block) hValue
+    aadBlocks = map padTo16 (chunksOf 16 aad)
+    ciphertextBlocks = map padTo16 (chunksOf 16 ciphertext)
+    accumulated = foldl' process 0 (aadBlocks ++ ciphertextBlocks)
+    lengthBlock =
+        integerToBytes16BE
+            ((fromIntegral (length aad) * 8 `shiftL` 64) + fromIntegral (length ciphertext) * 8)
+    finalValue = process accumulated lengthBlock
+
+gf128Mul :: Integer -> Integer -> Integer
+gf128Mul xValue yValue =
+    go 0 yValue 0
+  where
+    reduction = bytesToIntegerBE [0xe1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    go result vValue bitIndex
+        | bitIndex >= 128 = result
+        | otherwise =
+            let result' =
+                    if testBit xValue (127 - bitIndex)
+                        then result `xor` vValue
+                        else result
+                carry = odd vValue
+                vValue' =
+                    if carry
+                        then shiftR vValue 1 `xor` reduction
+                        else shiftR vValue 1
+             in go result' vValue' (bitIndex + 1)
+
+bytesToIntegerBE :: [Word8] -> Integer
+bytesToIntegerBE =
+    foldl' (\accumulator byteValue -> shiftL accumulator 8 + fromIntegral byteValue) 0
+
+integerToBytes16BE :: Integer -> [Word8]
+integerToBytes16BE value =
+    [ fromIntegral (shiftR value (8 * offset))
+    | offset <- [15, 14 .. 0]
+    ]
+
+padTo16 :: [Word8] -> [Word8]
+padTo16 chunk =
+    take 16 (chunk ++ repeat 0)
+
+xorBytes :: [Word8] -> [Word8] -> [Word8]
+xorBytes = zipWith xor
+
+constantTimeEq :: [Word8] -> [Word8] -> Bool
+constantTimeEq left right =
+    length left == length right
+        && foldl' (.|.) 0 (zipWith xor left right) == 0
+
+chunksOf :: Int -> [a] -> [[a]]
+chunksOf _ [] = []
+chunksOf size values =
+    let (chunk, rest) = splitAt size values
+     in chunk : chunksOf size rest
+
+foldM :: (b -> a -> Either String b) -> b -> [a] -> Either String b
+foldM _ accumulator [] = Right accumulator
+foldM step accumulator (value : rest) =
+    case step accumulator value of
+        Left err -> Left err
+        Right accumulator' -> foldM step accumulator' rest

--- a/code/packages/haskell/aes-modes/test/AesModesSpec.hs
+++ b/code/packages/haskell/aes-modes/test/AesModesSpec.hs
@@ -1,0 +1,73 @@
+module AesModesSpec (spec) where
+
+import AesModes
+import Data.Bits (xor)
+import Data.Word (Word8)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "AesModes" $ do
+    it "pads and unpads with PKCS#7" $ do
+        pkcs7Unpad (pkcs7Pad [1, 2, 3, 4, 5]) `shouldBe` Right [1, 2, 3, 4, 5]
+
+    it "round-trips ECB" $ do
+        let plaintext = ascii "Sixteen byte msg plus tail"
+        (ecbEncrypt plaintext key >>= (`ecbDecrypt` key))
+            `shouldBe` Right plaintext
+
+    it "round-trips CBC" $ do
+        let plaintext = ascii "CBC mode keeps chaining honest."
+        (cbcEncrypt plaintext key iv >>= (\ciphertext -> cbcDecrypt ciphertext key iv))
+            `shouldBe` Right plaintext
+
+    it "round-trips CTR" $ do
+        let plaintext = ascii "CTR mode behaves like a stream cipher."
+        (ctrEncrypt plaintext key nonce12 >>= (\ciphertext -> ctrDecrypt ciphertext key nonce12))
+            `shouldBe` Right plaintext
+
+    it "round-trips GCM and authenticates AAD" $ do
+        let plaintext = ascii "GCM gives confidentiality and integrity."
+        let aad = ascii "header"
+        (gcmEncrypt plaintext key nonce12 aad >>= (\(ciphertext, tag) -> gcmDecrypt ciphertext key nonce12 aad tag))
+            `shouldBe` Right plaintext
+
+    it "rejects tampered GCM ciphertext" $ do
+        let plaintext = ascii "tamper me"
+        let aad = ascii "aad"
+        case gcmEncrypt plaintext key nonce12 aad of
+            Left err -> expectationFailure err
+            Right (ciphertext, tag) ->
+                gcmDecrypt (flipFirstBit ciphertext) key nonce12 aad tag
+                    `shouldSatisfy` isLeft
+
+key :: [Word8]
+key = hexToBytes "2b7e151628aed2a6abf7158809cf4f3c"
+
+iv :: [Word8]
+iv = replicate 16 0
+
+nonce12 :: [Word8]
+nonce12 = take 12 [0 ..]
+
+flipFirstBit :: [Word8] -> [Word8]
+flipFirstBit [] = []
+flipFirstBit (value : rest) = (value `xor` 1) : rest
+
+isLeft :: Either a b -> Bool
+isLeft (Left _) = True
+isLeft _ = False
+
+ascii :: String -> [Word8]
+ascii = map (fromIntegral . fromEnum)
+
+hexToBytes :: String -> [Word8]
+hexToBytes [] = []
+hexToBytes (a : b : rest) = fromIntegral (hexDigit a * 16 + hexDigit b) : hexToBytes rest
+hexToBytes _ = []
+
+hexDigit :: Char -> Int
+hexDigit character
+    | character >= '0' && character <= '9' = fromEnum character - fromEnum '0'
+    | character >= 'a' && character <= 'f' = 10 + fromEnum character - fromEnum 'a'
+    | character >= 'A' && character <= 'F' = 10 + fromEnum character - fromEnum 'A'
+    | otherwise = 0

--- a/code/packages/haskell/aes-modes/test/Spec.hs
+++ b/code/packages/haskell/aes-modes/test/Spec.hs
@@ -1,0 +1,7 @@
+module Main (main) where
+
+import AesModesSpec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/aes/BUILD
+++ b/code/packages/haskell/aes/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/aes/BUILD_windows
+++ b/code/packages/haskell/aes/BUILD_windows
@@ -1,0 +1,1 @@
+if exist "%ProgramFiles%\\cabal\\bin\\cabal.exe" (cabal test all) else (echo cabal not found -- skipping)

--- a/code/packages/haskell/aes/CHANGELOG.md
+++ b/code/packages/haskell/aes/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/aes/README.md
+++ b/code/packages/haskell/aes/README.md
@@ -1,0 +1,11 @@
+# aes
+
+AES block cipher (FIPS 197) for 128-bit blocks and 128/192/256-bit keys
+
+## Type
+
+library
+
+## Dependencies
+
+- array

--- a/code/packages/haskell/aes/aes.cabal
+++ b/code/packages/haskell/aes/aes.cabal
@@ -1,0 +1,26 @@
+cabal-version: 3.0
+name:          aes
+version:       0.1.0
+synopsis:      AES block cipher (FIPS 197) for 128-bit blocks and 128/192/256-bit keys
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  Aes
+    build-depends:    base >=4.14
+                    , array
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    AesSpec
+    hs-source-dirs:   test
+    build-depends:    aes
+                    , array
+                    , base >=4.14
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/aes/cabal.project
+++ b/code/packages/haskell/aes/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/code/packages/haskell/aes/src/Aes.hs
+++ b/code/packages/haskell/aes/src/Aes.hs
@@ -1,0 +1,284 @@
+module Aes
+    ( description
+    , expandKey
+    , encryptBlock
+    , decryptBlock
+    ) where
+
+import Data.Array (Array, (!), array)
+import Data.Bits
+    ( (.&.)
+    , rotateL
+    , shiftL
+    , shiftR
+    , testBit
+    , xor
+    )
+import Data.List (foldl')
+import Data.Word (Word8)
+
+description :: String
+description = "AES block cipher (FIPS 197) for 128-bit blocks and 128/192/256-bit keys"
+
+type Word4 = [Word8]
+type State = [[Word8]]
+
+expandKey :: [Word8] -> Either String [[Word8]]
+expandKey keyBytes
+    | length keyBytes `notElem` [16, 24, 32] =
+        Left ("AES key must be 16, 24, or 32 bytes; got " ++ show (length keyBytes))
+    | otherwise =
+        Right (map roundKeyToBytes (roundKeys keyBytes))
+
+encryptBlock :: [Word8] -> [Word8] -> Either String [Word8]
+encryptBlock block keyBytes
+    | length block /= 16 =
+        Left ("AES block must be 16 bytes; got " ++ show (length block))
+    | otherwise =
+        do
+            let keys = roundKeys keyBytes
+            if null keys
+                then Left "AES key expansion failed"
+                else Right (stateToBytes (encryptWithKeys (bytesToState block) keys))
+
+decryptBlock :: [Word8] -> [Word8] -> Either String [Word8]
+decryptBlock block keyBytes
+    | length block /= 16 =
+        Left ("AES block must be 16 bytes; got " ++ show (length block))
+    | otherwise =
+        do
+            let keys = roundKeys keyBytes
+            if null keys
+                then Left "AES key expansion failed"
+                else Right (stateToBytes (decryptWithKeys (bytesToState block) keys))
+
+roundKeys :: [Word8] -> [State]
+roundKeys keyBytes
+    | length keyBytes `notElem` [16, 24, 32] = []
+    | otherwise = map wordsToState (chunksOf 4 expandedWords)
+  where
+    nk = length keyBytes `div` 4
+    nr
+        | nk == 4 = 10
+        | nk == 6 = 12
+        | otherwise = 14
+    totalWords = 4 * (nr + 1)
+    initialWords = chunksOf 4 keyBytes
+    expandedWords = expandWords nk totalWords initialWords nk
+
+expandWords :: Int -> Int -> [Word4] -> Int -> [Word4]
+expandWords nk totalWords wordsSoFar index
+    | index >= totalWords = wordsSoFar
+    | otherwise = expandWords nk totalWords (wordsSoFar ++ [nextWord]) (index + 1)
+  where
+    previousWord = last wordsSoFar
+    adjustedWord
+        | index `mod` nk == 0 =
+            xorWord (subWord (rotWord previousWord)) [rcon !! (index `div` nk), 0, 0, 0]
+        | nk == 8 && index `mod` nk == 4 =
+            subWord previousWord
+        | otherwise = previousWord
+    nextWord = xorWord (wordsSoFar !! (index - nk)) adjustedWord
+
+rcon :: [Word8]
+rcon = [0x00, 0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1b, 0x36, 0x6c, 0xd8, 0xab, 0x4d]
+
+rotWord :: Word4 -> Word4
+rotWord [a, b, c, d] = [b, c, d, a]
+rotWord values = values
+
+subWord :: Word4 -> Word4
+subWord = map subByte
+
+xorWord :: Word4 -> Word4 -> Word4
+xorWord = zipWith xor
+
+encryptWithKeys :: State -> [State] -> State
+encryptWithKeys state [] = state
+encryptWithKeys state [onlyKey] = addRoundKey state onlyKey
+encryptWithKeys state (firstKey : remainingKeys) =
+    case reverse remainingKeys of
+        [] -> addRoundKey state firstKey
+        finalKey : reversedMiddleKeys ->
+            addRoundKey finalState finalKey
+          where
+            middleKeys = reverse reversedMiddleKeys
+            firstState = addRoundKey state firstKey
+            preFinalState =
+                foldl'
+                    (\currentState roundKeyState -> addRoundKey (mixColumns (shiftRows (subBytes currentState))) roundKeyState)
+                    firstState
+                    middleKeys
+            finalState = shiftRows (subBytes preFinalState)
+
+decryptWithKeys :: State -> [State] -> State
+decryptWithKeys state [] = state
+decryptWithKeys state [onlyKey] = addRoundKey state onlyKey
+decryptWithKeys state keys =
+    case reverse keys of
+        [] -> state
+        firstKey : remainingKeys ->
+            case reverse remainingKeys of
+                [] -> addRoundKey state firstKey
+                finalKey : reversedMiddleKeys ->
+                    addRoundKey finalState finalKey
+                  where
+                    middleKeys = reverse reversedMiddleKeys
+                    firstState = addRoundKey state firstKey
+                    preFinalState =
+                        foldl'
+                            (\currentState roundKeyState -> invMixColumns (addRoundKey (invSubBytes (invShiftRows currentState)) roundKeyState))
+                            firstState
+                            middleKeys
+                    finalState = invSubBytes (invShiftRows preFinalState)
+
+bytesToState :: [Word8] -> State
+bytesToState block =
+    [ [ block !! (row + 4 * column)
+      | column <- [0 .. 3]
+      ]
+    | row <- [0 .. 3]
+    ]
+
+stateToBytes :: State -> [Word8]
+stateToBytes state =
+    [ state !! row !! column
+    | column <- [0 .. 3]
+    , row <- [0 .. 3]
+    ]
+
+roundKeyToBytes :: State -> [Word8]
+roundKeyToBytes = stateToBytes
+
+wordsToState :: [Word4] -> State
+wordsToState wordsForRound =
+    [ [ wordsForRound !! column !! row
+      | column <- [0 .. 3]
+      ]
+    | row <- [0 .. 3]
+    ]
+
+addRoundKey :: State -> State -> State
+addRoundKey =
+    zipWith (zipWith xor)
+
+subBytes :: State -> State
+subBytes = map (map subByte)
+
+invSubBytes :: State -> State
+invSubBytes = map (map invSubByte)
+
+shiftRows :: State -> State
+shiftRows state =
+    [ shiftLeft rowIndex rowValues
+    | (rowIndex, rowValues) <- zip [0 ..] state
+    ]
+
+invShiftRows :: State -> State
+invShiftRows state =
+    [ shiftRight rowIndex rowValues
+    | (rowIndex, rowValues) <- zip [0 ..] state
+    ]
+
+shiftLeft :: Int -> [a] -> [a]
+shiftLeft count values =
+    drop offset values ++ take offset values
+  where
+    offset = count `mod` length values
+
+shiftRight :: Int -> [a] -> [a]
+shiftRight count values =
+    drop offset values ++ take offset values
+  where
+    offset = (length values - (count `mod` length values)) `mod` length values
+
+mixColumns :: State -> State
+mixColumns state =
+    transposeColumns (map mixColumn (columns state))
+
+invMixColumns :: State -> State
+invMixColumns state =
+    transposeColumns (map invMixColumn (columns state))
+
+columns :: State -> [[Word8]]
+columns state =
+    [ [ state !! row !! column
+      | row <- [0 .. 3]
+      ]
+    | column <- [0 .. 3]
+    ]
+
+transposeColumns :: [[Word8]] -> State
+transposeColumns cols =
+    [ [ cols !! column !! row
+      | column <- [0 .. 3]
+      ]
+    | row <- [0 .. 3]
+    ]
+
+mixColumn :: [Word8] -> [Word8]
+mixColumn [s0, s1, s2, s3] =
+    [ gfMul 0x02 s0 `xor` gfMul 0x03 s1 `xor` s2 `xor` s3
+    , s0 `xor` gfMul 0x02 s1 `xor` gfMul 0x03 s2 `xor` s3
+    , s0 `xor` s1 `xor` gfMul 0x02 s2 `xor` gfMul 0x03 s3
+    , gfMul 0x03 s0 `xor` s1 `xor` s2 `xor` gfMul 0x02 s3
+    ]
+mixColumn values = values
+
+invMixColumn :: [Word8] -> [Word8]
+invMixColumn [s0, s1, s2, s3] =
+    [ gfMul 0x0e s0 `xor` gfMul 0x0b s1 `xor` gfMul 0x0d s2 `xor` gfMul 0x09 s3
+    , gfMul 0x09 s0 `xor` gfMul 0x0e s1 `xor` gfMul 0x0b s2 `xor` gfMul 0x0d s3
+    , gfMul 0x0d s0 `xor` gfMul 0x09 s1 `xor` gfMul 0x0e s2 `xor` gfMul 0x0b s3
+    , gfMul 0x0b s0 `xor` gfMul 0x0d s1 `xor` gfMul 0x09 s2 `xor` gfMul 0x0e s3
+    ]
+invMixColumn values = values
+
+gfMul :: Word8 -> Word8 -> Word8
+gfMul aValue bValue =
+    go aValue bValue 0 0
+  where
+    go multiplicand multiplier result 8 = result
+    go multiplicand multiplier result step =
+        let result' =
+                if multiplier .&. 1 /= 0
+                    then result `xor` multiplicand
+                    else result
+            highBit = testBit multiplicand 7
+            multiplicand' =
+                if highBit
+                    then shiftL multiplicand 1 `xor` 0x1b
+                    else shiftL multiplicand 1
+            multiplier' = shiftR multiplier 1
+         in go multiplicand' multiplier' result' (step + 1)
+
+subByte :: Word8 -> Word8
+subByte value = sbox ! fromIntegral value
+
+invSubByte :: Word8 -> Word8
+invSubByte value = invSbox ! fromIntegral value
+
+sbox :: Array Int Word8
+sbox =
+    array (0, 255) [(index, affineTransform (multiplicativeInverse (fromIntegral index))) | index <- [0 .. 255]]
+
+invSbox :: Array Int Word8
+invSbox =
+    array (0, 255) [(fromIntegral substituted, fromIntegral original) | original <- [0 .. 255], let substituted = subByte (fromIntegral original)]
+
+multiplicativeInverse :: Word8 -> Word8
+multiplicativeInverse 0 = 0
+multiplicativeInverse value =
+    case [candidate | candidate <- [1 .. 255], gfMul value candidate == 1] of
+        candidate : _ -> candidate
+        [] -> 0
+
+affineTransform :: Word8 -> Word8
+affineTransform byteValue =
+    foldl' xor 0x63 [rotateL byteValue rotation | rotation <- [0 .. 4]]
+
+chunksOf :: Int -> [a] -> [[a]]
+chunksOf _ [] = []
+chunksOf size values =
+    let (chunk, rest) = splitAt size values
+     in chunk : chunksOf size rest

--- a/code/packages/haskell/aes/test/AesSpec.hs
+++ b/code/packages/haskell/aes/test/AesSpec.hs
@@ -1,0 +1,54 @@
+module AesSpec (spec) where
+
+import Aes
+import Data.Word (Word8)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Aes" $ do
+    it "encrypts the AES-128 FIPS vector" $ do
+        encryptBlock plain key128
+            `shouldBe` Right cipher128
+
+    it "decrypts the AES-128 FIPS vector" $ do
+        decryptBlock cipher128 key128
+            `shouldBe` Right plain
+
+    it "encrypts the AES-256 FIPS vector" $ do
+        encryptBlock plain key256
+            `shouldBe` Right cipher256
+
+    it "rejects invalid key sizes" $ do
+        encryptBlock plain [0 .. 14]
+            `shouldSatisfy` isLeft
+
+plain :: [Word8]
+plain = hexToBytes "00112233445566778899aabbccddeeff"
+
+key128 :: [Word8]
+key128 = hexToBytes "000102030405060708090a0b0c0d0e0f"
+
+cipher128 :: [Word8]
+cipher128 = hexToBytes "69c4e0d86a7b0430d8cdb78070b4c55a"
+
+key256 :: [Word8]
+key256 = hexToBytes "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+
+cipher256 :: [Word8]
+cipher256 = hexToBytes "8ea2b7ca516745bfeafc49904b496089"
+
+isLeft :: Either a b -> Bool
+isLeft (Left _) = True
+isLeft _ = False
+
+hexToBytes :: String -> [Word8]
+hexToBytes [] = []
+hexToBytes (a : b : rest) = fromIntegral (hexDigit a * 16 + hexDigit b) : hexToBytes rest
+hexToBytes _ = []
+
+hexDigit :: Char -> Int
+hexDigit character
+    | character >= '0' && character <= '9' = fromEnum character - fromEnum '0'
+    | character >= 'a' && character <= 'f' = 10 + fromEnum character - fromEnum 'a'
+    | character >= 'A' && character <= 'F' = 10 + fromEnum character - fromEnum 'A'
+    | otherwise = 0

--- a/code/packages/haskell/aes/test/Spec.hs
+++ b/code/packages/haskell/aes/test/Spec.hs
@@ -1,0 +1,7 @@
+module Main (main) where
+
+import AesSpec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/chacha20-poly1305/BUILD
+++ b/code/packages/haskell/chacha20-poly1305/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/chacha20-poly1305/BUILD_windows
+++ b/code/packages/haskell/chacha20-poly1305/BUILD_windows
@@ -1,0 +1,1 @@
+if exist "%ProgramFiles%\\cabal\\bin\\cabal.exe" (cabal test all) else (echo cabal not found -- skipping)

--- a/code/packages/haskell/chacha20-poly1305/CHANGELOG.md
+++ b/code/packages/haskell/chacha20-poly1305/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/chacha20-poly1305/README.md
+++ b/code/packages/haskell/chacha20-poly1305/README.md
@@ -1,0 +1,11 @@
+# chacha20-poly1305
+
+ChaCha20-Poly1305 authenticated encryption (RFC 8439)
+
+## Type
+
+library
+
+## Dependencies
+
+(none)

--- a/code/packages/haskell/chacha20-poly1305/cabal.project
+++ b/code/packages/haskell/chacha20-poly1305/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/code/packages/haskell/chacha20-poly1305/chacha20-poly1305.cabal
+++ b/code/packages/haskell/chacha20-poly1305/chacha20-poly1305.cabal
@@ -1,0 +1,24 @@
+cabal-version: 3.0
+name:          chacha20-poly1305
+version:       0.1.0
+synopsis:      ChaCha20-Poly1305 authenticated encryption (RFC 8439)
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  Chacha20Poly1305
+    build-depends:    base >=4.14
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    Chacha20Poly1305Spec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , chacha20-poly1305
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/chacha20-poly1305/src/Chacha20Poly1305.hs
+++ b/code/packages/haskell/chacha20-poly1305/src/Chacha20Poly1305.hs
@@ -1,0 +1,212 @@
+module Chacha20Poly1305
+    ( description
+    , chacha20Encrypt
+    , poly1305Mac
+    , aeadEncrypt
+    , aeadDecrypt
+    ) where
+
+import Data.Bits
+    ( (.&.)
+    , (.|.)
+    , rotateL
+    , shiftL
+    , shiftR
+    , xor
+    )
+import Data.List (foldl')
+import Data.Word (Word8, Word32, Word64)
+
+description :: String
+description = "ChaCha20-Poly1305 authenticated encryption (RFC 8439)"
+
+constants :: [Word32]
+constants = [0x61707865, 0x3320646e, 0x79622d32, 0x6b206574]
+
+chacha20Encrypt :: [Word8] -> [Word8] -> [Word8] -> Word32 -> Either String [Word8]
+chacha20Encrypt plaintext keyBytes nonce counter
+    | length keyBytes /= 32 =
+        Left ("ChaCha20 key must be 32 bytes, got " ++ show (length keyBytes))
+    | length nonce /= 12 =
+        Left ("ChaCha20 nonce must be 12 bytes, got " ++ show (length nonce))
+    | otherwise =
+        Right (go plaintext counter)
+  where
+    go [] _ = []
+    go remaining currentCounter =
+        let keystream = chacha20Block keyBytes nonce currentCounter
+            chunk = take 64 remaining
+         in zipWith xor chunk keystream ++ go (drop 64 remaining) (currentCounter + 1)
+
+poly1305Mac :: [Word8] -> [Word8] -> Either String [Word8]
+poly1305Mac message keyBytes
+    | length keyBytes /= 32 =
+        Left ("Poly1305 key must be 32 bytes, got " ++ show (length keyBytes))
+    | otherwise =
+        Right (integerToBytes16LE ((accumulator + sValue) `mod` twoPower128))
+  where
+    rValue = clampR (bytesToIntegerLE (take 16 keyBytes))
+    sValue = bytesToIntegerLE (drop 16 keyBytes)
+    prime = (2 ^ (130 :: Int)) - 5
+    accumulator =
+        foldl'
+            (\current chunk ->
+                let chunkValue = bytesToIntegerLE chunk + 2 ^ (8 * length chunk)
+                 in ((current + chunkValue) * rValue) `mod` prime
+            )
+            0
+            (chunksOf 16 message)
+    twoPower128 = 2 ^ (128 :: Int)
+
+aeadEncrypt :: [Word8] -> [Word8] -> [Word8] -> [Word8] -> Either String ([Word8], [Word8])
+aeadEncrypt plaintext keyBytes nonce aad = do
+    polyKeyStream <- chacha20Encrypt (replicate 64 0) keyBytes nonce 0
+    let polyKey = take 32 polyKeyStream
+    ciphertext <- chacha20Encrypt plaintext keyBytes nonce 1
+    tag <- poly1305Mac (buildMacData aad ciphertext) polyKey
+    Right (ciphertext, tag)
+
+aeadDecrypt :: [Word8] -> [Word8] -> [Word8] -> [Word8] -> [Word8] -> Either String [Word8]
+aeadDecrypt ciphertext keyBytes nonce aad tag = do
+    polyKeyStream <- chacha20Encrypt (replicate 64 0) keyBytes nonce 0
+    let polyKey = take 32 polyKeyStream
+    computedTag <- poly1305Mac (buildMacData aad ciphertext) polyKey
+    if constantTimeEq computedTag tag
+        then chacha20Encrypt ciphertext keyBytes nonce 1
+        else Left "ChaCha20-Poly1305 authentication failed"
+
+chacha20Block :: [Word8] -> [Word8] -> Word32 -> [Word8]
+chacha20Block keyBytes nonce counter =
+    concatMap word32ToBytesLE finalState
+  where
+    initialState =
+        constants
+            ++ map bytesToWord32LE (chunksOf 4 keyBytes)
+            ++ [counter]
+            ++ map bytesToWord32LE (chunksOf 4 nonce)
+    workingState = applyRounds 10 initialState
+    finalState = zipWith (+) workingState initialState
+
+applyRounds :: Int -> [Word32] -> [Word32]
+applyRounds 0 state = state
+applyRounds roundsRemaining state =
+    applyRounds (roundsRemaining - 1) (diagonalRounds (columnRounds state))
+
+columnRounds :: [Word32] -> [Word32]
+columnRounds state =
+    quarterRound 3 7 11 15
+        (quarterRound 2 6 10 14
+            (quarterRound 1 5 9 13
+                (quarterRound 0 4 8 12 state)))
+
+diagonalRounds :: [Word32] -> [Word32]
+diagonalRounds state =
+    quarterRound 3 4 9 14
+        (quarterRound 2 7 8 13
+            (quarterRound 1 6 11 12
+                (quarterRound 0 5 10 15 state)))
+
+quarterRound :: Int -> Int -> Int -> Int -> [Word32] -> [Word32]
+quarterRound aIndex bIndex cIndex dIndex state8 =
+    replaceMany
+        [ (aIndex, a4)
+        , (bIndex, b4)
+        , (cIndex, c4)
+        , (dIndex, d4)
+        ]
+        state8
+  where
+    a0 = state8 !! aIndex
+    b0 = state8 !! bIndex
+    c0 = state8 !! cIndex
+    d0 = state8 !! dIndex
+    a1 = a0 + b0
+    d1 = rotateL (d0 `xor` a1) 16
+    c1 = c0 + d1
+    b1 = rotateL (b0 `xor` c1) 12
+    a2 = a1 + b1
+    d2 = rotateL (d1 `xor` a2) 8
+    c2 = c1 + d2
+    b2 = rotateL (b1 `xor` c2) 7
+    a4 = a2
+    b4 = b2
+    c4 = c2
+    d4 = d2
+
+replaceMany :: [(Int, a)] -> [a] -> [a]
+replaceMany replacements values =
+    [ maybe originalValue id (lookup index replacements)
+    | (index, originalValue) <- zip [0 ..] values
+    ]
+
+buildMacData :: [Word8] -> [Word8] -> [Word8]
+buildMacData aad ciphertext =
+    aad
+        ++ pad16 aad
+        ++ ciphertext
+        ++ pad16 ciphertext
+        ++ word64ToBytesLE (fromIntegral (length aad))
+        ++ word64ToBytesLE (fromIntegral (length ciphertext))
+
+pad16 :: [Word8] -> [Word8]
+pad16 values
+    | remainder == 0 = []
+    | otherwise = replicate (16 - remainder) 0
+  where
+    remainder = length values `mod` 16
+
+clampR :: Integer -> Integer
+clampR value =
+    value .&. bytesToIntegerLE [0xff, 0xff, 0xff, 0x0f, 0xfc, 0xff, 0xff, 0x0f, 0xfc, 0xff, 0xff, 0x0f, 0xfc, 0xff, 0xff, 0x0f]
+
+constantTimeEq :: [Word8] -> [Word8] -> Bool
+constantTimeEq left right =
+    length left == length right
+        && foldl' (.|.) 0 (zipWith xor left right) == 0
+
+bytesToWord32LE :: [Word8] -> Word32
+bytesToWord32LE [a, b, c, d] =
+    fromIntegral a
+        + shiftL (fromIntegral b) 8
+        + shiftL (fromIntegral c) 16
+        + shiftL (fromIntegral d) 24
+bytesToWord32LE _ = 0
+
+word32ToBytesLE :: Word32 -> [Word8]
+word32ToBytesLE wordValue =
+    [ fromIntegral wordValue
+    , fromIntegral (shiftR wordValue 8)
+    , fromIntegral (shiftR wordValue 16)
+    , fromIntegral (shiftR wordValue 24)
+    ]
+
+word64ToBytesLE :: Word64 -> [Word8]
+word64ToBytesLE wordValue =
+    [ fromIntegral wordValue
+    , fromIntegral (shiftR wordValue 8)
+    , fromIntegral (shiftR wordValue 16)
+    , fromIntegral (shiftR wordValue 24)
+    , fromIntegral (shiftR wordValue 32)
+    , fromIntegral (shiftR wordValue 40)
+    , fromIntegral (shiftR wordValue 48)
+    , fromIntegral (shiftR wordValue 56)
+    ]
+
+bytesToIntegerLE :: [Word8] -> Integer
+bytesToIntegerLE bytes =
+    sum
+        [ shiftL (fromIntegral byteValue) (8 * index)
+        | (index, byteValue) <- zip [0 ..] bytes
+        ]
+
+integerToBytes16LE :: Integer -> [Word8]
+integerToBytes16LE value =
+    [ fromIntegral (shiftR value (8 * index))
+    | index <- [0 .. 15]
+    ]
+
+chunksOf :: Int -> [a] -> [[a]]
+chunksOf _ [] = []
+chunksOf size values =
+    let (chunk, rest) = splitAt size values
+     in chunk : chunksOf size rest

--- a/code/packages/haskell/chacha20-poly1305/test/Chacha20Poly1305Spec.hs
+++ b/code/packages/haskell/chacha20-poly1305/test/Chacha20Poly1305Spec.hs
@@ -1,0 +1,79 @@
+module Chacha20Poly1305Spec (spec) where
+
+import Chacha20Poly1305
+import Data.Bits (xor)
+import Data.Word (Word8, Word32)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Chacha20Poly1305" $ do
+    it "matches the RFC 8439 ChaCha20 keystream block" $ do
+        chacha20Encrypt (replicate 64 0) key nonce counter
+            `shouldBe` Right expectedKeystream
+
+    it "matches the RFC 8439 Poly1305 vector" $ do
+        poly1305Mac (ascii "Cryptographic Forum Research Group") polyKey
+            `shouldBe` Right expectedTag
+
+    it "round-trips AEAD encryption" $ do
+        let plaintext = ascii "ChaCha20-Poly1305 protects messages."
+        let aad = ascii "aad"
+        (aeadEncrypt plaintext key nonce aad >>= (\(ciphertext, tag) -> aeadDecrypt ciphertext key nonce aad tag))
+            `shouldBe` Right plaintext
+
+    it "rejects tampered AEAD ciphertext" $ do
+        let plaintext = ascii "tamper"
+        case aeadEncrypt plaintext key nonce [] of
+            Left err -> expectationFailure err
+            Right (ciphertext, tag) ->
+                aeadDecrypt (flipFirstBit ciphertext) key nonce [] tag
+                    `shouldSatisfy` isLeft
+
+key :: [Word8]
+key = hexToBytes "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+
+nonce :: [Word8]
+nonce = hexToBytes "000000090000004a00000000"
+
+counter :: Word32
+counter = 1
+
+expectedKeystream :: [Word8]
+expectedKeystream =
+    hexToBytes
+        "10f1e7e4d13b5915500fdd1fa32071c4"
+            ++ hexToBytes
+                "c7d1f4c733c068030422aa9ac3d46c4e"
+            ++ hexToBytes
+                "d2826446079faa0914c2d705d98b02a2"
+            ++ hexToBytes
+                "b5129cd1de164eb9cbd083e8a2503c4e"
+
+polyKey :: [Word8]
+polyKey = hexToBytes "85d6be7857556d337f4452fe42d506a80103808afb0db2fd4abff6af4149f51b"
+
+expectedTag :: [Word8]
+expectedTag = hexToBytes "a8061dc1305136c6c22b8baf0c0127a9"
+
+flipFirstBit :: [Word8] -> [Word8]
+flipFirstBit [] = []
+flipFirstBit (value : rest) = (value `xor` 1) : rest
+
+isLeft :: Either a b -> Bool
+isLeft (Left _) = True
+isLeft _ = False
+
+ascii :: String -> [Word8]
+ascii = map (fromIntegral . fromEnum)
+
+hexToBytes :: String -> [Word8]
+hexToBytes [] = []
+hexToBytes (a : b : rest) = fromIntegral (hexDigit a * 16 + hexDigit b) : hexToBytes rest
+hexToBytes _ = []
+
+hexDigit :: Char -> Int
+hexDigit character
+    | character >= '0' && character <= '9' = fromEnum character - fromEnum '0'
+    | character >= 'a' && character <= 'f' = 10 + fromEnum character - fromEnum 'a'
+    | character >= 'A' && character <= 'F' = 10 + fromEnum character - fromEnum 'A'
+    | otherwise = 0

--- a/code/packages/haskell/chacha20-poly1305/test/Spec.hs
+++ b/code/packages/haskell/chacha20-poly1305/test/Spec.hs
@@ -1,0 +1,7 @@
+module Main (main) where
+
+import Chacha20Poly1305Spec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/md5/BUILD
+++ b/code/packages/haskell/md5/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/md5/BUILD_windows
+++ b/code/packages/haskell/md5/BUILD_windows
@@ -1,0 +1,1 @@
+if exist "%ProgramFiles%\\cabal\\bin\\cabal.exe" (cabal test all) else (echo cabal not found -- skipping)

--- a/code/packages/haskell/md5/CHANGELOG.md
+++ b/code/packages/haskell/md5/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial scaffold.

--- a/code/packages/haskell/md5/README.md
+++ b/code/packages/haskell/md5/README.md
@@ -1,0 +1,11 @@
+# md5
+
+MD5 message digest algorithm (RFC 1321) implemented from scratch
+
+## Type
+
+library
+
+## Dependencies
+
+(none)

--- a/code/packages/haskell/md5/cabal.project
+++ b/code/packages/haskell/md5/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/code/packages/haskell/md5/md5.cabal
+++ b/code/packages/haskell/md5/md5.cabal
@@ -1,0 +1,24 @@
+cabal-version: 3.0
+name:          md5
+version:       0.1.0
+synopsis:      MD5 message digest algorithm (RFC 1321) implemented from scratch
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  Md5
+    build-depends:    base >=4.14
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    Md5Spec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , md5
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/md5/src/Md5.hs
+++ b/code/packages/haskell/md5/src/Md5.hs
@@ -1,0 +1,152 @@
+module Md5
+    ( description
+    , sumMd5
+    , hexString
+    ) where
+
+import Data.Bits
+    ( (.&.)
+    , (.|.)
+    , complement
+    , rotateL
+    , shiftL
+    , shiftR
+    , xor
+    )
+import Data.List (foldl')
+import Data.Word (Word8, Word32, Word64)
+import Numeric (showHex)
+
+description :: String
+description = "MD5 message digest algorithm (RFC 1321) implemented from scratch"
+
+initialState :: [Word32]
+initialState =
+    [ 0x67452301
+    , 0xefcdab89
+    , 0x98badcfe
+    , 0x10325476
+    ]
+
+tTable :: [Word32]
+tTable =
+    [ 0xd76aa478, 0xe8c7b756, 0x242070db, 0xc1bdceee
+    , 0xf57c0faf, 0x4787c62a, 0xa8304613, 0xfd469501
+    , 0x698098d8, 0x8b44f7af, 0xffff5bb1, 0x895cd7be
+    , 0x6b901122, 0xfd987193, 0xa679438e, 0x49b40821
+    , 0xf61e2562, 0xc040b340, 0x265e5a51, 0xe9b6c7aa
+    , 0xd62f105d, 0x02441453, 0xd8a1e681, 0xe7d3fbc8
+    , 0x21e1cde6, 0xc33707d6, 0xf4d50d87, 0x455a14ed
+    , 0xa9e3e905, 0xfcefa3f8, 0x676f02d9, 0x8d2a4c8a
+    , 0xfffa3942, 0x8771f681, 0x6d9d6122, 0xfde5380c
+    , 0xa4beea44, 0x4bdecfa9, 0xf6bb4b60, 0xbebfbc70
+    , 0x289b7ec6, 0xeaa127fa, 0xd4ef3085, 0x04881d05
+    , 0xd9d4d039, 0xe6db99e5, 0x1fa27cf8, 0xc4ac5665
+    , 0xf4292244, 0x432aff97, 0xab9423a7, 0xfc93a039
+    , 0x655b59c3, 0x8f0ccc92, 0xffeff47d, 0x85845dd1
+    , 0x6fa87e4f, 0xfe2ce6e0, 0xa3014314, 0x4e0811a1
+    , 0xf7537e82, 0xbd3af235, 0x2ad7d2bb, 0xeb86d391
+    ]
+
+shiftTable :: [Int]
+shiftTable =
+    [ 7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22
+    , 5, 9, 14, 20, 5, 9, 14, 20, 5, 9, 14, 20, 5, 9, 14, 20
+    , 4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23
+    , 6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21
+    ]
+
+sumMd5 :: [Word8] -> [Word8]
+sumMd5 inputBytes =
+    concatMap word32ToBytesLE (foldl' compress initialState (chunksOf 64 (pad inputBytes)))
+
+hexString :: [Word8] -> String
+hexString =
+    concatMap renderByte . sumMd5
+  where
+    renderByte byteValue =
+        let rendered = showHex byteValue ""
+         in if length rendered == 1 then '0' : rendered else rendered
+
+pad :: [Word8] -> [Word8]
+pad inputBytes =
+    inputBytes ++ [0x80] ++ replicate paddingLength 0 ++ word64ToBytesLE bitLength
+  where
+    bitLength :: Word64
+    bitLength = fromIntegral (length inputBytes) * 8
+    paddingLength =
+        let remainder = (length inputBytes + 1 + 8) `mod` 64
+         in if remainder == 0 then 0 else 64 - remainder
+
+compress :: [Word32] -> [Word8] -> [Word32]
+compress state block =
+    zipWith (+) state [a', b', c', d']
+  where
+    messageWords = map bytesToWord32LE (chunksOf 4 block)
+    [a0, b0, c0, d0] = state
+    (a', b', c', d') =
+        foldl'
+            roundStep
+            (a0, b0, c0, d0)
+            [0 .. 63]
+
+    roundStep :: (Word32, Word32, Word32, Word32) -> Int -> (Word32, Word32, Word32, Word32)
+    roundStep (a, b, c, d) roundIndex =
+        ( d
+        , b + rotateL (a + functionValue + selectedWord + tValue) shiftCount
+        , b
+        , c
+        )
+      where
+        functionValue = roundFunction roundIndex b c d
+        tValue = tTable !! roundIndex
+        shiftCount = shiftTable !! roundIndex
+        selectedWord = scheduleWord roundIndex
+        scheduleWord index =
+            let wordIndex
+                    | index < 16 = index
+                    | index < 32 = (5 * index + 1) `mod` 16
+                    | index < 48 = (3 * index + 5) `mod` 16
+                    | otherwise = (7 * index) `mod` 16
+             in messageWords !! wordIndex
+
+roundFunction :: Int -> Word32 -> Word32 -> Word32 -> Word32
+roundFunction roundIndex b c d
+    | roundIndex < 16 = (b .&. c) `xor` (complement b .&. d)
+    | roundIndex < 32 = (d .&. b) `xor` (complement d .&. c)
+    | roundIndex < 48 = b `xor` c `xor` d
+    | otherwise = c `xor` (b .|. complement d)
+
+bytesToWord32LE :: [Word8] -> Word32
+bytesToWord32LE [a, b, c, d] =
+    fromIntegral a
+        + shiftL (fromIntegral b) 8
+        + shiftL (fromIntegral c) 16
+        + shiftL (fromIntegral d) 24
+bytesToWord32LE _ = 0
+
+word32ToBytesLE :: Word32 -> [Word8]
+word32ToBytesLE wordValue =
+    [ fromIntegral wordValue
+    , fromIntegral (wordValue `shiftR` 8)
+    , fromIntegral (wordValue `shiftR` 16)
+    , fromIntegral (wordValue `shiftR` 24)
+    ]
+
+word64ToBytesLE :: Word64 -> [Word8]
+word64ToBytesLE wordValue =
+    [ fromIntegral wordValue
+    , fromIntegral (wordValue `shiftR` 8)
+    , fromIntegral (wordValue `shiftR` 16)
+    , fromIntegral (wordValue `shiftR` 24)
+    , fromIntegral (wordValue `shiftR` 32)
+    , fromIntegral (wordValue `shiftR` 40)
+    , fromIntegral (wordValue `shiftR` 48)
+    , fromIntegral (wordValue `shiftR` 56)
+    ]
+
+chunksOf :: Int -> [a] -> [[a]]
+chunksOf _ [] = []
+chunksOf size values =
+    let (chunk, rest) = splitAt size values
+     in chunk : chunksOf size rest

--- a/code/packages/haskell/md5/test/Md5Spec.hs
+++ b/code/packages/haskell/md5/test/Md5Spec.hs
@@ -1,0 +1,23 @@
+module Md5Spec (spec) where
+
+import Data.Char (ord)
+import Data.Word (Word8)
+import Md5
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Md5" $ do
+    it "hashes the empty string" $ do
+        hexString [] `shouldBe` "d41d8cd98f00b204e9800998ecf8427e"
+
+    it "hashes abc" $ do
+        hexString (ascii "abc") `shouldBe` "900150983cd24fb0d6963f7d28e17f72"
+
+    it "hashes message digest" $ do
+        hexString (ascii "message digest") `shouldBe` "f96b697d7cb7938d525a2f31aaf161d0"
+
+    it "returns a 16-byte digest" $ do
+        length (sumMd5 (ascii "coding adventures")) `shouldBe` 16
+
+ascii :: String -> [Word8]
+ascii = map (fromIntegral . ord)

--- a/code/packages/haskell/md5/test/Spec.hs
+++ b/code/packages/haskell/md5/test/Spec.hs
@@ -1,0 +1,7 @@
+module Main (main) where
+
+import Md5Spec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec


### PR DESCRIPTION
## What changed
- added a new Haskell `md5` package with RFC 1321 message-digest vectors
- added a new Haskell `aes` package with AES-128 and AES-256 block encryption/decryption support
- added a new Haskell `aes-modes` package with PKCS#7 padding plus ECB, CBC, CTR, and GCM flows
- added a new Haskell `chacha20-poly1305` package with ChaCha20 stream encryption, Poly1305 MAC, and AEAD helpers

## Why
This continues the Haskell crypto wave with the symmetric side of the stack after the digest/MAC/KDF batch. It fills most of the remaining Rust-aligned reusable crypto surface before we move on to the curve and signature packages.

## Impact
- Haskell now has both legacy checksum coverage (`md5`) and modern symmetric primitives (`aes`, `aes-modes`, `chacha20-poly1305`)
- higher-level packages can build on reusable block encryption, authenticated encryption, and standard mode helpers instead of embedding ad hoc crypto logic
- the new packages stay consistent with the existing Haskell package style: simple `[Word8]`-based APIs and package-local vector tests

## Validation
- `cabal test` in `code/packages/haskell/md5`
- `cabal test` in `code/packages/haskell/aes`
- `cabal test` in `code/packages/haskell/aes-modes`
- `cabal test` in `code/packages/haskell/chacha20-poly1305`