### PR TITLE
[codex] add dart json parser package

### DIFF
--- a/code/packages/dart/json-parser/BUILD
+++ b/code/packages/dart/json-parser/BUILD
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/json-parser/BUILD_windows
+++ b/code/packages/dart/json-parser/BUILD_windows
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/json-parser/CHANGELOG.md
+++ b/code/packages/dart/json-parser/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Initial release.
+- Added a grammar-driven JSON parser backed by the shared Dart parser runtime.

--- a/code/packages/dart/json-parser/README.md
+++ b/code/packages/dart/json-parser/README.md
@@ -1,0 +1,7 @@
+# coding_adventures_json_parser
+
+Grammar-driven JSON parser for Dart.
+
+This package is a thin wrapper around `coding_adventures_json_lexer`,
+`coding_adventures_parser`, and the shared `ParserGrammar` format compiled from
+`json.grammar`.

--- a/code/packages/dart/json-parser/lib/json_parser.dart
+++ b/code/packages/dart/json-parser/lib/json_parser.dart
@@ -1,0 +1,3 @@
+library;
+
+export 'src/parser.dart';

--- a/code/packages/dart/json-parser/lib/src/_grammar.dart
+++ b/code/packages/dart/json-parser/lib/src/_grammar.dart
@@ -1,0 +1,83 @@
+import 'package:coding_adventures_grammar_tools/grammar_tools.dart';
+
+final parserGrammar = ParserGrammar(
+  version: 1,
+  rules: [
+    GrammarRule(
+      name: 'value',
+      body: Alternation(
+        choices: [
+          const RuleReference('object', isToken: false),
+          const RuleReference('array', isToken: false),
+          const RuleReference('STRING', isToken: true),
+          const RuleReference('NUMBER', isToken: true),
+          const RuleReference('TRUE', isToken: true),
+          const RuleReference('FALSE', isToken: true),
+          const RuleReference('NULL', isToken: true),
+        ],
+      ),
+      lineNumber: 28,
+    ),
+    GrammarRule(
+      name: 'object',
+      body: Sequence(
+        elements: [
+          const RuleReference('LBRACE', isToken: true),
+          Optional(
+            element: Sequence(
+              elements: [
+                const RuleReference('pair', isToken: false),
+                Repetition(
+                  element: Sequence(
+                    elements: [
+                      const RuleReference('COMMA', isToken: true),
+                      const RuleReference('pair', isToken: false),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const RuleReference('RBRACE', isToken: true),
+        ],
+      ),
+      lineNumber: 34,
+    ),
+    GrammarRule(
+      name: 'pair',
+      body: Sequence(
+        elements: [
+          const RuleReference('STRING', isToken: true),
+          const RuleReference('COLON', isToken: true),
+          const RuleReference('value', isToken: false),
+        ],
+      ),
+      lineNumber: 38,
+    ),
+    GrammarRule(
+      name: 'array',
+      body: Sequence(
+        elements: [
+          const RuleReference('LBRACKET', isToken: true),
+          Optional(
+            element: Sequence(
+              elements: [
+                const RuleReference('value', isToken: false),
+                Repetition(
+                  element: Sequence(
+                    elements: [
+                      const RuleReference('COMMA', isToken: true),
+                      const RuleReference('value', isToken: false),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const RuleReference('RBRACKET', isToken: true),
+        ],
+      ),
+      lineNumber: 42,
+    ),
+  ],
+);

--- a/code/packages/dart/json-parser/lib/src/parser.dart
+++ b/code/packages/dart/json-parser/lib/src/parser.dart
@@ -1,0 +1,14 @@
+import 'package:coding_adventures_json_lexer/json_lexer.dart';
+import 'package:coding_adventures_parser/parser.dart';
+
+import '_grammar.dart';
+
+GrammarParser createJsonParser(String source, {GrammarParserOptions? options}) {
+  final tokens = tokenizeJson(source);
+  return GrammarParser(tokens, parserGrammar, options: options);
+}
+
+ASTNode parseJson(String source, {GrammarParserOptions? options}) {
+  final parser = createJsonParser(source, options: options);
+  return parser.parse();
+}

--- a/code/packages/dart/json-parser/pubspec.yaml
+++ b/code/packages/dart/json-parser/pubspec.yaml
@@ -1,6 +1,6 @@
-name: coding_adventures_parser
+name: coding_adventures_json_parser
 description: >
-  Recursive-descent parser for the generic token stream produced by the Dart lexer package.
+  Grammar-driven JSON parser for Dart backed by the shared ParserGrammar format.
 version: 0.1.0
 repository: https://github.com/adhithyan15/coding-adventures
 publish_to: none
@@ -11,8 +11,10 @@ environment:
 dependencies:
   coding_adventures_grammar_tools:
     path: ../grammar-tools
-  coding_adventures_lexer:
-    path: ../lexer
+  coding_adventures_json_lexer:
+    path: ../json-lexer
+  coding_adventures_parser:
+    path: ../parser
 
 dev_dependencies:
   test: ^1.25.0

--- a/code/packages/dart/json-parser/required_capabilities.json
+++ b/code/packages/dart/json-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "dart/json-parser",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/dart/json-parser/test/json_parser_test.dart
+++ b/code/packages/dart/json-parser/test/json_parser_test.dart
@@ -1,0 +1,57 @@
+import 'package:coding_adventures_json_parser/json_parser.dart';
+import 'package:coding_adventures_parser/parser.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('parseJson', () {
+    test('parses primitive values', () {
+      expect(parseJson('"hello"').ruleName, 'value');
+      expect(collectTokens(parseJson('"hello"'), type: 'STRING'), hasLength(1));
+      expect(collectTokens(parseJson('42'), type: 'NUMBER'), hasLength(1));
+      expect(collectTokens(parseJson('true'), type: 'TRUE'), hasLength(1));
+      expect(collectTokens(parseJson('false'), type: 'FALSE'), hasLength(1));
+      expect(collectTokens(parseJson('null'), type: 'NULL'), hasLength(1));
+    });
+
+    test('parses objects and arrays', () {
+      final objectAst = parseJson('{"name": "Alice", "age": 30}');
+      expect(findNodes(objectAst, 'object'), hasLength(1));
+      expect(findNodes(objectAst, 'pair'), hasLength(2));
+
+      final arrayAst = parseJson('[1, 2, 3]');
+      expect(findNodes(arrayAst, 'array'), hasLength(1));
+      expect(collectTokens(arrayAst, type: 'NUMBER'), hasLength(3));
+    });
+
+    test('parses nested structures', () {
+      final ast = parseJson(
+        '{"users": [{"name": "Alice"}, {"name": "Bob", "active": true}]}',
+      );
+
+      expect(ast.ruleName, 'value');
+      expect(findNodes(ast, 'object'), hasLength(3));
+      expect(findNodes(ast, 'array'), hasLength(1));
+      expect(findNodes(ast, 'pair'), hasLength(4));
+    });
+
+    test('tracks source positions across pretty-printed JSON', () {
+      final ast = parseJson('''
+{
+  "name": "Alice",
+  "scores": [1, 2]
+}
+''');
+
+      expect(ast.startLine, 1);
+      expect(ast.startColumn, 1);
+      expect(ast.endLine, 4);
+      expect(ast.endColumn, 1);
+    });
+
+    test('rejects invalid JSON', () {
+      expect(() => parseJson(''), throwsA(isA<GrammarParseError>()));
+      expect(() => parseJson('{"a": 1,}'), throwsA(isA<GrammarParseError>()));
+      expect(() => parseJson('[1, 2,]'), throwsA(isA<GrammarParseError>()));
+    });
+  });
+}

--- a/code/packages/dart/parser/CHANGELOG.md
+++ b/code/packages/dart/parser/CHANGELOG.md
@@ -3,4 +3,4 @@
 ## 0.1.0
 
 - Initial release.
-
+- Added grammar-driven parsing support with generic `ASTNode` helpers.

--- a/code/packages/dart/parser/README.md
+++ b/code/packages/dart/parser/README.md
@@ -1,5 +1,9 @@
 # coding_adventures_parser
 
-Recursive-descent parser for the generic Dart token stream from
-`coding_adventures_lexer`.
+Recursive-descent parser package for Dart.
 
+This package now includes:
+
+- A handwritten `Parser` that builds typed expression AST nodes.
+- A reusable `GrammarParser` that interprets shared `.grammar` definitions and
+  produces generic `ASTNode` trees.

--- a/code/packages/dart/parser/lib/parser.dart
+++ b/code/packages/dart/parser/lib/parser.dart
@@ -1,5 +1,5 @@
 library;
 
 export 'src/ast.dart';
+export 'src/grammar_parser.dart';
 export 'src/parser_impl.dart';
-

--- a/code/packages/dart/parser/lib/src/ast.dart
+++ b/code/packages/dart/parser/lib/src/ast.dart
@@ -4,6 +4,69 @@ abstract class AstNode {
   const AstNode();
 }
 
+class ASTNode extends AstNode {
+  ASTNode({
+    required this.ruleName,
+    required List<Object> children,
+    this.startLine,
+    this.startColumn,
+    this.endLine,
+    this.endColumn,
+  }) : children = List<Object>.unmodifiable(children);
+
+  final String ruleName;
+  final List<Object> children;
+  final int? startLine;
+  final int? startColumn;
+  final int? endLine;
+  final int? endColumn;
+
+  bool get isLeaf => children.length == 1 && children.first is Token;
+
+  Token? get token => isLeaf ? children.first as Token : null;
+
+  ASTNode copyWith({
+    String? ruleName,
+    List<Object>? children,
+    int? startLine,
+    int? startColumn,
+    int? endLine,
+    int? endColumn,
+  }) {
+    return ASTNode(
+      ruleName: ruleName ?? this.ruleName,
+      children: children ?? this.children,
+      startLine: startLine ?? this.startLine,
+      startColumn: startColumn ?? this.startColumn,
+      endLine: endLine ?? this.endLine,
+      endColumn: endColumn ?? this.endColumn,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is ASTNode &&
+        other.ruleName == ruleName &&
+        _listEquals(other.children, children) &&
+        other.startLine == startLine &&
+        other.startColumn == startColumn &&
+        other.endLine == endLine &&
+        other.endColumn == endColumn;
+  }
+
+  @override
+  int get hashCode {
+    return Object.hash(
+      ruleName,
+      Object.hashAll(children),
+      startLine,
+      startColumn,
+      endLine,
+      endColumn,
+    );
+  }
+}
+
 abstract class Expression extends AstNode {
   const Expression();
 }
@@ -18,7 +81,8 @@ class NumberLiteral extends Expression implements Statement {
   final int value;
 
   @override
-  bool operator ==(Object other) => other is NumberLiteral && other.value == value;
+  bool operator ==(Object other) =>
+      other is NumberLiteral && other.value == value;
 
   @override
   int get hashCode => value.hashCode;
@@ -30,7 +94,8 @@ class StringLiteral extends Expression implements Statement {
   final String value;
 
   @override
-  bool operator ==(Object other) => other is StringLiteral && other.value == value;
+  bool operator ==(Object other) =>
+      other is StringLiteral && other.value == value;
 
   @override
   int get hashCode => value.hashCode;
@@ -49,11 +114,7 @@ class Name extends Expression implements Statement {
 }
 
 class BinaryOp extends Expression implements Statement {
-  const BinaryOp({
-    required this.left,
-    required this.op,
-    required this.right,
-  });
+  const BinaryOp({required this.left, required this.op, required this.right});
 
   final Expression left;
   final String op;
@@ -72,10 +133,7 @@ class BinaryOp extends Expression implements Statement {
 }
 
 class Assignment extends Statement {
-  const Assignment({
-    required this.target,
-    required this.value,
-  });
+  const Assignment({required this.target, required this.value});
 
   final Name target;
   final Expression value;
@@ -102,7 +160,8 @@ class Program extends AstNode {
   }
 
   @override
-  int get hashCode => statements.fold<int>(0, (value, item) => value ^ item.hashCode);
+  int get hashCode =>
+      statements.fold<int>(0, (value, item) => value ^ item.hashCode);
 }
 
 class ParseError implements Exception {
@@ -114,6 +173,12 @@ class ParseError implements Exception {
   @override
   String toString() => '$message at line ${token.line}, column ${token.column}';
 }
+
+bool isASTNode(Object child) => child is ASTNode;
+
+bool isLeafNode(ASTNode node) => node.isLeaf;
+
+Token? getLeafToken(ASTNode node) => node.token;
 
 bool _listEquals(List<Object?> left, List<Object?> right) {
   if (identical(left, right)) {

--- a/code/packages/dart/parser/lib/src/grammar_parser.dart
+++ b/code/packages/dart/parser/lib/src/grammar_parser.dart
@@ -1,0 +1,607 @@
+import 'package:coding_adventures_grammar_tools/grammar_tools.dart';
+import 'package:coding_adventures_lexer/lexer.dart';
+
+import 'ast.dart';
+
+typedef GrammarPreParseHook = List<Token> Function(List<Token> tokens);
+typedef GrammarPostParseHook = ASTNode Function(ASTNode ast);
+typedef ASTNodeTransform = ASTNode? Function(ASTNode node, ASTNode? parent);
+
+class GrammarParserOptions {
+  const GrammarParserOptions({this.trace = false, this.traceWriter});
+
+  final bool trace;
+  final void Function(String message)? traceWriter;
+}
+
+class ASTVisitor {
+  const ASTVisitor({this.enter, this.leave});
+
+  final ASTNodeTransform? enter;
+  final ASTNodeTransform? leave;
+}
+
+class GrammarParseError implements Exception {
+  GrammarParseError(this.message, [this.token]);
+
+  final String message;
+  final Token? token;
+
+  @override
+  String toString() {
+    if (token == null) {
+      return 'Parse error: $message';
+    }
+    return 'Parse error at ${token!.line}:${token!.column}: $message';
+  }
+}
+
+class _MemoEntry {
+  const _MemoEntry({
+    required this.children,
+    required this.endPos,
+    required this.ok,
+  });
+
+  final List<Object>? children;
+  final int endPos;
+  final bool ok;
+}
+
+class GrammarParser {
+  GrammarParser(
+    List<Token> tokens,
+    this.grammar, {
+    GrammarParserOptions? options,
+  })  : _tokens = List<Token>.from(tokens),
+        _trace = options?.trace ?? false,
+        _traceWriter = options?.traceWriter {
+    for (var index = 0; index < grammar.rules.length; index++) {
+      final rule = grammar.rules[index];
+      _rules[rule.name] = rule;
+      _ruleIndex[rule.name] = index;
+    }
+    _newlinesSignificant = _grammarReferencesNewline();
+  }
+
+  List<Token> _tokens;
+  final ParserGrammar grammar;
+  final Map<String, GrammarRule> _rules = <String, GrammarRule>{};
+  final Map<String, int> _ruleIndex = <String, int>{};
+  final Map<String, _MemoEntry> _memo = <String, _MemoEntry>{};
+  final bool _trace;
+  final void Function(String message)? _traceWriter;
+  final List<GrammarPreParseHook> _preParseHooks = <GrammarPreParseHook>[];
+  final List<GrammarPostParseHook> _postParseHooks = <GrammarPostParseHook>[];
+
+  late final bool _newlinesSignificant;
+  int _position = 0;
+  int _furthestPos = 0;
+  final List<String> _furthestExpected = <String>[];
+
+  bool get newlinesSignificant => _newlinesSignificant;
+
+  void addPreParse(GrammarPreParseHook hook) {
+    _preParseHooks.add(hook);
+  }
+
+  void addPostParse(GrammarPostParseHook hook) {
+    _postParseHooks.add(hook);
+  }
+
+  ASTNode parse() {
+    if (_preParseHooks.isNotEmpty) {
+      var mutableTokens = List<Token>.from(_tokens);
+      for (final hook in _preParseHooks) {
+        mutableTokens = hook(mutableTokens);
+      }
+      _tokens = mutableTokens;
+    }
+
+    if (grammar.rules.isEmpty) {
+      throw GrammarParseError('Grammar has no rules');
+    }
+
+    final entryRule = grammar.rules.first;
+    final result = _parseRule(entryRule.name);
+    if (result == null) {
+      final token = _current();
+      if (_furthestExpected.isNotEmpty) {
+        final furthestToken = _furthestToken(token);
+        throw GrammarParseError(
+          'Expected ${_furthestExpected.join(' or ')}, got '
+          '${_quoted(furthestToken.value)}',
+          furthestToken,
+        );
+      }
+      throw GrammarParseError('Failed to parse', token);
+    }
+
+    while (_position < _tokens.length && _current().type == 'NEWLINE') {
+      _position += 1;
+    }
+
+    if (_position < _tokens.length && _current().type != 'EOF') {
+      final token = _current();
+      if (_furthestExpected.isNotEmpty && _furthestPos > _position) {
+        final furthestToken = _furthestToken(token);
+        throw GrammarParseError(
+          'Expected ${_furthestExpected.join(' or ')}, got '
+          '${_quoted(furthestToken.value)}',
+          furthestToken,
+        );
+      }
+      throw GrammarParseError(
+        'Unexpected token: ${_quoted(token.value)}',
+        token,
+      );
+    }
+
+    var ast = result;
+    for (final hook in _postParseHooks) {
+      ast = hook(ast);
+    }
+    return ast;
+  }
+
+  Token _current() {
+    if (_position < _tokens.length) {
+      return _tokens[_position];
+    }
+    return _tokens.last;
+  }
+
+  void _recordFailure(String expected) {
+    if (_position > _furthestPos) {
+      _furthestPos = _position;
+      _furthestExpected
+        ..clear()
+        ..add(expected);
+      return;
+    }
+    if (_position == _furthestPos && !_furthestExpected.contains(expected)) {
+      _furthestExpected.add(expected);
+    }
+  }
+
+  Token _furthestToken(Token fallback) {
+    if (_furthestPos < _tokens.length) {
+      return _tokens[_furthestPos];
+    }
+    return fallback;
+  }
+
+  bool _grammarReferencesNewline() {
+    for (final rule in grammar.rules) {
+      if (_elementReferencesNewline(rule.body)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool _elementReferencesNewline(GrammarElement element) {
+    if (element is RuleReference) {
+      return element.isToken && element.name == 'NEWLINE';
+    }
+    if (element is Sequence) {
+      return element.elements.any(_elementReferencesNewline);
+    }
+    if (element is Alternation) {
+      return element.choices.any(_elementReferencesNewline);
+    }
+    if (element is Repetition) {
+      return _elementReferencesNewline(element.element);
+    }
+    if (element is Optional) {
+      return _elementReferencesNewline(element.element);
+    }
+    if (element is Group) {
+      return _elementReferencesNewline(element.element);
+    }
+    if (element is PositiveLookahead) {
+      return _elementReferencesNewline(element.element);
+    }
+    if (element is NegativeLookahead) {
+      return _elementReferencesNewline(element.element);
+    }
+    if (element is OneOrMoreRepetition) {
+      return _elementReferencesNewline(element.element);
+    }
+    if (element is SeparatedRepetition) {
+      return _elementReferencesNewline(element.element) ||
+          _elementReferencesNewline(element.separator);
+    }
+    return false;
+  }
+
+  ASTNode? _parseRule(String ruleName) {
+    final rule = _rules[ruleName];
+    if (rule == null) {
+      return null;
+    }
+
+    final idx = _ruleIndex[ruleName];
+    if (idx != null) {
+      final key = '$idx,$_position';
+      final cached = _memo[key];
+      if (cached != null) {
+        _position = cached.endPos;
+        if (!cached.ok) {
+          return null;
+        }
+        return _createNode(ruleName, cached.children!);
+      }
+    }
+
+    final startPos = _position;
+    if (idx != null) {
+      final key = '$idx,$startPos';
+      _memo[key] = _MemoEntry(children: null, endPos: startPos, ok: false);
+    }
+
+    if (_trace) {
+      final token = _current();
+      _emitTrace(
+        "[TRACE] rule '$ruleName' at token $startPos "
+        "(${token.type} ${_quoted(token.value)}) -> ",
+        newline: false,
+      );
+    }
+
+    var children = _matchElement(rule.body);
+
+    if (_trace) {
+      _emitTrace(children != null ? 'match' : 'fail');
+    }
+
+    if (idx != null) {
+      final key = '$idx,$startPos';
+      if (children != null) {
+        _memo[key] = _MemoEntry(
+          children: List<Object>.unmodifiable(children),
+          endPos: _position,
+          ok: true,
+        );
+      } else {
+        _memo[key] = _MemoEntry(children: null, endPos: _position, ok: false);
+      }
+
+      if (children != null) {
+        while (true) {
+          final previousEnd = _position;
+          _position = startPos;
+          _memo[key] = _MemoEntry(
+            children: List<Object>.unmodifiable(children!),
+            endPos: previousEnd,
+            ok: true,
+          );
+          final newChildren = _matchElement(rule.body);
+          if (newChildren == null || _position <= previousEnd) {
+            _position = previousEnd;
+            _memo[key] = _MemoEntry(
+              children: List<Object>.unmodifiable(children),
+              endPos: previousEnd,
+              ok: true,
+            );
+            break;
+          }
+          children = newChildren;
+        }
+      }
+    }
+
+    if (children == null) {
+      _position = startPos;
+      _recordFailure(ruleName);
+      return null;
+    }
+
+    return _createNode(ruleName, children);
+  }
+
+  ASTNode _createNode(String ruleName, List<Object> children) {
+    final position = _computeNodePosition(children);
+    return ASTNode(
+      ruleName: ruleName,
+      children: children,
+      startLine: position?.startLine,
+      startColumn: position?.startColumn,
+      endLine: position?.endLine,
+      endColumn: position?.endColumn,
+    );
+  }
+
+  List<Object>? _matchElement(GrammarElement element) {
+    final savedPosition = _position;
+
+    if (element is Sequence) {
+      final children = <Object>[];
+      for (final subElement in element.elements) {
+        final result = _matchElement(subElement);
+        if (result == null) {
+          _position = savedPosition;
+          return null;
+        }
+        children.addAll(result);
+      }
+      return children;
+    }
+
+    if (element is Alternation) {
+      for (final choice in element.choices) {
+        _position = savedPosition;
+        final result = _matchElement(choice);
+        if (result != null) {
+          return result;
+        }
+      }
+      _position = savedPosition;
+      return null;
+    }
+
+    if (element is Repetition) {
+      final children = <Object>[];
+      while (true) {
+        final repetitionPosition = _position;
+        final result = _matchElement(element.element);
+        if (result == null) {
+          _position = repetitionPosition;
+          break;
+        }
+        children.addAll(result);
+      }
+      return children;
+    }
+
+    if (element is Optional) {
+      final result = _matchElement(element.element);
+      return result ?? <Object>[];
+    }
+
+    if (element is Group) {
+      return _matchElement(element.element);
+    }
+
+    if (element is RuleReference) {
+      if (element.isToken) {
+        return _matchTokenReference(element.name);
+      }
+      final node = _parseRule(element.name);
+      if (node == null) {
+        _position = savedPosition;
+        return null;
+      }
+      return <Object>[node];
+    }
+
+    if (element is Literal) {
+      var token = _current();
+      if (!_newlinesSignificant) {
+        while (token.type == 'NEWLINE') {
+          _position += 1;
+          token = _current();
+        }
+      }
+      if (token.value == element.value) {
+        _position += 1;
+        return <Object>[token];
+      }
+      _recordFailure(_quoted(element.value));
+      return null;
+    }
+
+    if (element is PositiveLookahead) {
+      final result = _matchElement(element.element);
+      _position = savedPosition;
+      return result != null ? <Object>[] : null;
+    }
+
+    if (element is NegativeLookahead) {
+      final result = _matchElement(element.element);
+      _position = savedPosition;
+      return result == null ? <Object>[] : null;
+    }
+
+    if (element is OneOrMoreRepetition) {
+      final first = _matchElement(element.element);
+      if (first == null) {
+        _position = savedPosition;
+        return null;
+      }
+      final children = <Object>[...first];
+      while (true) {
+        final repetitionPosition = _position;
+        final result = _matchElement(element.element);
+        if (result == null) {
+          _position = repetitionPosition;
+          break;
+        }
+        children.addAll(result);
+      }
+      return children;
+    }
+
+    if (element is SeparatedRepetition) {
+      final first = _matchElement(element.element);
+      if (first == null) {
+        _position = savedPosition;
+        return element.atLeastOne ? null : <Object>[];
+      }
+      final children = <Object>[...first];
+      while (true) {
+        final separatorPosition = _position;
+        final separator = _matchElement(element.separator);
+        if (separator == null) {
+          _position = separatorPosition;
+          break;
+        }
+        final next = _matchElement(element.element);
+        if (next == null) {
+          _position = separatorPosition;
+          break;
+        }
+        children
+          ..addAll(separator)
+          ..addAll(next);
+      }
+      return children;
+    }
+
+    return null;
+  }
+
+  List<Object>? _matchTokenReference(String expectedType) {
+    var token = _current();
+    if (!_newlinesSignificant && expectedType != 'NEWLINE') {
+      while (token.type == 'NEWLINE') {
+        _position += 1;
+        token = _current();
+      }
+    }
+
+    if (token.type == expectedType) {
+      _position += 1;
+      return <Object>[token];
+    }
+
+    _recordFailure(expectedType);
+    return null;
+  }
+
+  void _emitTrace(String message, {bool newline = true}) {
+    if (!_trace) {
+      return;
+    }
+    final text = newline ? message : message;
+    if (_traceWriter != null) {
+      _traceWriter!(newline ? '$text\n' : text);
+    }
+  }
+}
+
+class _NodePosition {
+  const _NodePosition({
+    required this.startLine,
+    required this.startColumn,
+    required this.endLine,
+    required this.endColumn,
+  });
+
+  final int startLine;
+  final int startColumn;
+  final int endLine;
+  final int endColumn;
+}
+
+_NodePosition? _computeNodePosition(List<Object> children) {
+  final first = _findFirstToken(children);
+  final last = _findLastToken(children);
+  if (first == null || last == null) {
+    return null;
+  }
+  return _NodePosition(
+    startLine: first.line,
+    startColumn: first.column,
+    endLine: last.line,
+    endColumn: last.column,
+  );
+}
+
+Token? _findFirstToken(List<Object> children) {
+  for (final child in children) {
+    if (child is ASTNode) {
+      final token = _findFirstToken(child.children);
+      if (token != null) {
+        return token;
+      }
+      continue;
+    }
+    if (child is Token) {
+      return child;
+    }
+  }
+  return null;
+}
+
+Token? _findLastToken(List<Object> children) {
+  for (var index = children.length - 1; index >= 0; index -= 1) {
+    final child = children[index];
+    if (child is ASTNode) {
+      final token = _findLastToken(child.children);
+      if (token != null) {
+        return token;
+      }
+      continue;
+    }
+    if (child is Token) {
+      return child;
+    }
+  }
+  return null;
+}
+
+ASTNode walkAST(ASTNode node, ASTVisitor visitor) {
+  return _walkNode(node, null, visitor);
+}
+
+ASTNode _walkNode(ASTNode node, ASTNode? parent, ASTVisitor visitor) {
+  var current = visitor.enter?.call(node, parent) ?? node;
+
+  var childrenChanged = false;
+  final newChildren = <Object>[];
+  for (final child in current.children) {
+    if (child is ASTNode) {
+      final walked = _walkNode(child, current, visitor);
+      if (walked != child) {
+        childrenChanged = true;
+      }
+      newChildren.add(walked);
+      continue;
+    }
+    newChildren.add(child);
+  }
+
+  if (childrenChanged) {
+    current = current.copyWith(children: newChildren);
+  }
+
+  return visitor.leave?.call(current, parent) ?? current;
+}
+
+List<ASTNode> findNodes(ASTNode node, String ruleName) {
+  final results = <ASTNode>[];
+  walkAST(
+    node,
+    ASTVisitor(
+      enter: (current, _) {
+        if (current.ruleName == ruleName) {
+          results.add(current);
+        }
+        return null;
+      },
+    ),
+  );
+  return results;
+}
+
+List<Token> collectTokens(ASTNode node, {String? type}) {
+  final results = <Token>[];
+
+  void walk(ASTNode current) {
+    for (final child in current.children) {
+      if (child is ASTNode) {
+        walk(child);
+      } else if (child is Token) {
+        if (type == null || child.type == type) {
+          results.add(child);
+        }
+      }
+    }
+  }
+
+  walk(node);
+  return results;
+}
+
+String _quoted(String value) => '"$value"';

--- a/code/packages/dart/parser/lib/src/parser_impl.dart
+++ b/code/packages/dart/parser/lib/src/parser_impl.dart
@@ -136,4 +136,3 @@ class Parser {
 }
 
 String _quoted(String value) => '"$value"';
-

--- a/code/packages/dart/parser/test/grammar_parser_test.dart
+++ b/code/packages/dart/parser/test/grammar_parser_test.dart
@@ -1,0 +1,143 @@
+import 'package:coding_adventures_grammar_tools/grammar_tools.dart';
+import 'package:coding_adventures_lexer/lexer.dart';
+import 'package:coding_adventures_parser/parser.dart';
+import 'package:test/test.dart';
+
+void main() {
+  Token tok(String type, String value, [int line = 1, int column = 1]) {
+    return Token(type: type, value: value, line: line, column: column);
+  }
+
+  Token eof([int line = 1, int column = 1]) {
+    return Token(type: 'EOF', value: '', line: line, column: column);
+  }
+
+  ParserGrammar grammar(String source) => parseParserGrammar(source);
+
+  group('GrammarParser', () {
+    test('parses JSON-like structures into AST nodes', () {
+      final parser = GrammarParser(
+        [
+          tok('LBRACE', '{'),
+          tok('STRING', 'name', 1, 2),
+          tok('COLON', ':', 1, 8),
+          tok('STRING', 'Alice', 1, 10),
+          tok('RBRACE', '}', 1, 17),
+          eof(1, 18),
+        ],
+        grammar('''
+          value = object | STRING ;
+          object = LBRACE pair RBRACE ;
+          pair = STRING COLON value ;
+        '''),
+      );
+
+      final ast = parser.parse();
+
+      expect(ast.ruleName, 'value');
+      expect(findNodes(ast, 'object'), hasLength(1));
+      expect(findNodes(ast, 'pair'), hasLength(1));
+      expect(collectTokens(ast, type: 'STRING').map((token) => token.value), [
+        'name',
+        'Alice',
+      ]);
+      expect(ast.startLine, 1);
+      expect(ast.startColumn, 1);
+      expect(ast.endLine, 1);
+      expect(ast.endColumn, 17);
+    });
+
+    test('skips insignificant newlines', () {
+      final parser = GrammarParser([
+        tok('NEWLINE', '\n'),
+        tok('NUMBER', '42', 2, 1),
+        eof(2, 3),
+      ], grammar('value = NUMBER ;'));
+
+      final ast = parser.parse();
+      expect(ast.ruleName, 'value');
+      expect(getLeafToken(ast), isNotNull);
+      expect(getLeafToken(ast)!.value, '42');
+    });
+
+    test('treats newlines as significant when grammar references them', () {
+      final parser = GrammarParser([
+        tok('NUMBER', '1'),
+        tok('NEWLINE', '\n', 1, 2),
+        tok('NUMBER', '2', 2, 1),
+        eof(2, 2),
+      ], grammar('program = NUMBER NEWLINE NUMBER ;'));
+
+      final ast = parser.parse();
+      expect(ast.ruleName, 'program');
+      expect(collectTokens(ast).map((token) => token.type), [
+        'NUMBER',
+        'NEWLINE',
+        'NUMBER',
+      ]);
+    });
+
+    test('matches literal tokens by value', () {
+      final parser = GrammarParser([
+        tok('KEYWORD', 'let'),
+        tok('NAME', 'answer', 1, 5),
+        eof(1, 11),
+      ], grammar('binding = "let" NAME ;'));
+
+      final ast = parser.parse();
+      expect(ast.ruleName, 'binding');
+      expect(collectTokens(ast).map((token) => token.value), ['let', 'answer']);
+    });
+
+    test('walkAST can rewrite nodes', () {
+      final parser = GrammarParser([
+        tok('NUMBER', '42', 3, 4),
+        eof(3, 6),
+      ], grammar('value = NUMBER ;'));
+
+      final ast = parser.parse();
+      final rewritten = walkAST(
+        ast,
+        ASTVisitor(
+          leave: (node, _) {
+            if (node.ruleName == 'value') {
+              return ASTNode(
+                ruleName: 'literal',
+                children: node.children,
+                startLine: node.startLine,
+                startColumn: node.startColumn,
+                endLine: node.endLine,
+                endColumn: node.endColumn,
+              );
+            }
+            return null;
+          },
+        ),
+      );
+
+      expect(rewritten.ruleName, 'literal');
+      expect(collectTokens(rewritten).single.value, '42');
+    });
+
+    test('reports parse errors with the furthest token', () {
+      final parser = GrammarParser([
+        tok('LBRACKET', '[', 4, 1),
+        tok('NUMBER', '1', 4, 2),
+        tok('COMMA', ',', 4, 3),
+        tok('RBRACKET', ']', 4, 4),
+        eof(4, 5),
+      ], grammar('array = LBRACKET NUMBER COMMA NUMBER RBRACKET ;'));
+
+      expect(
+        () => parser.parse(),
+        throwsA(
+          isA<GrammarParseError>().having(
+            (error) => error.token?.column,
+            'token column',
+            4,
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/code/packages/dart/parser/test/parser_test.dart
+++ b/code/packages/dart/parser/test/parser_test.dart
@@ -19,9 +19,18 @@ void main() {
 
   group('parser', () {
     test('parses literals and names', () {
-      expect(parseTokens([tok('NUMBER', '42'), eof()]), Program([const NumberLiteral(42)]));
-      expect(parseTokens([tok('STRING', 'hello'), eof()]), Program([const StringLiteral('hello')]));
-      expect(parseTokens([tok('NAME', 'x'), eof()]), Program([const Name('x')]));
+      expect(
+        parseTokens([tok('NUMBER', '42'), eof()]),
+        Program([const NumberLiteral(42)]),
+      );
+      expect(
+        parseTokens([tok('STRING', 'hello'), eof()]),
+        Program([const StringLiteral('hello')]),
+      );
+      expect(
+        parseTokens([tok('NAME', 'x'), eof()]),
+        Program([const Name('x')]),
+      );
     });
 
     test('parses binary operators with precedence', () {
@@ -99,7 +108,10 @@ void main() {
       ]);
 
       expect(program.statements, hasLength(2));
-      expect(program.statements.first, const Assignment(target: Name('x'), value: NumberLiteral(1)));
+      expect(
+        program.statements.first,
+        const Assignment(target: Name('x'), value: NumberLiteral(1)),
+      );
       expect(
         program.statements.last,
         const BinaryOp(left: Name('x'), op: '+', right: NumberLiteral(2)),
@@ -113,7 +125,11 @@ void main() {
 
     test('throws parse errors with location', () {
       expect(
-        () => parseTokens([tok('LPAREN', '(', 3, 7), tok('NUMBER', '1', 3, 8), eof(3, 9)]),
+        () => parseTokens([
+          tok('LPAREN', '(', 3, 7),
+          tok('NUMBER', '1', 3, 8),
+          eof(3, 9),
+        ]),
         throwsA(isA<ParseError>()),
       );
       try {


### PR DESCRIPTION
## What changed
- add a reusable grammar-driven `GrammarParser` path to the Dart `parser` package alongside the existing handwritten parser
- add generic `ASTNode` helpers, AST traversal/query utilities, parse errors, and parser tests for the shared runtime
- add a new `dart/json-parser` package with a compiled `json.grammar` and focused JSON parser tests

## Why
Dart already has `grammar-tools` and the grammar-driven `json-lexer`, but it was still missing the shared parser runtime needed to port parser packages cleanly. This PR establishes that runtime and proves the end-to-end flow with JSON as the first grammar-driven parser package.

## Impact
- downstream Dart parser ports can now be thin wrappers over compiled grammars instead of handwritten one-offs
- `dart/json-parser` becomes the first consumer of the shared grammar-driven parser runtime
- the existing handwritten Dart parser remains available for the learning-oriented expression parser path

## Validation
- `dart test` in `code/packages/dart/parser`
- `dart analyze` in `code/packages/dart/parser`
- `dart test` in `code/packages/dart/json-parser`
- `dart analyze` in `code/packages/dart/json-parser`