### PR TITLE
[codex] Add Ruby Brainfuck WASM backend

### DIFF
--- a/code/packages/ruby/brainfuck_wasm_compiler/BUILD
+++ b/code/packages/ruby/brainfuck_wasm_compiler/BUILD
@@ -1,0 +1,3 @@
+bundle config set path vendor/bundle
+bundle install --quiet
+bundle exec rake test

--- a/code/packages/ruby/brainfuck_wasm_compiler/CHANGELOG.md
+++ b/code/packages/ruby/brainfuck_wasm_compiler/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial Brainfuck source to WebAssembly compiler for Ruby.

--- a/code/packages/ruby/brainfuck_wasm_compiler/Gemfile
+++ b/code/packages/ruby/brainfuck_wasm_compiler/Gemfile
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+gemspec
+
+gem "coding_adventures_brainfuck", path: "../brainfuck"
+gem "coding_adventures_brainfuck_ir_compiler", path: "../brainfuck-ir-compiler"
+gem "coding_adventures_compiler_ir", path: "../compiler-ir"
+gem "coding_adventures_compiler_source_map", path: "../compiler-source-map"
+gem "coding_adventures_grammar_tools", path: "../grammar_tools"
+gem "coding_adventures_directed_graph", path: "../directed_graph"
+gem "coding_adventures_graph", path: "../graph"
+gem "coding_adventures_state_machine", path: "../state_machine"
+gem "coding_adventures_lexer", path: "../lexer"
+gem "coding_adventures_parser", path: "../parser"
+gem "coding_adventures_ir_to_wasm_compiler", path: "../ir_to_wasm_compiler"
+gem "coding_adventures_ir_to_wasm_validator", path: "../ir_to_wasm_validator"
+gem "coding_adventures_wasm_module_encoder", path: "../wasm_module_encoder"
+gem "coding_adventures_wasm_runtime", "~> 0.1", path: "../wasm_runtime"
+gem "coding_adventures_wasm_validator", path: "../wasm_validator"
+gem "coding_adventures_wasm_leb128", path: "../wasm_leb128"
+gem "coding_adventures_wasm_types", path: "../wasm_types"
+gem "coding_adventures_wasm_opcodes", path: "../wasm_opcodes"
+gem "coding_adventures_wasm_module_parser", path: "../wasm_module_parser"
+gem "coding_adventures_wasm_execution", path: "../wasm_execution"
+gem "coding_adventures_virtual_machine", path: "../virtual_machine"

--- a/code/packages/ruby/brainfuck_wasm_compiler/README.md
+++ b/code/packages/ruby/brainfuck_wasm_compiler/README.md
@@ -1,0 +1,3 @@
+# coding_adventures_brainfuck_wasm_compiler
+
+Compiles Brainfuck source code into runnable WebAssembly binaries using the generic IR pipeline.

--- a/code/packages/ruby/brainfuck_wasm_compiler/Rakefile
+++ b/code/packages/ruby/brainfuck_wasm_compiler/Rakefile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rake/testtask"
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList["test/**/test_*.rb"]
+end
+
+task default: :test

--- a/code/packages/ruby/brainfuck_wasm_compiler/coding_adventures_brainfuck_wasm_compiler.gemspec
+++ b/code/packages/ruby/brainfuck_wasm_compiler/coding_adventures_brainfuck_wasm_compiler.gemspec
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative "lib/coding_adventures/brainfuck_wasm_compiler/version"
+
+Gem::Specification.new do |spec|
+  spec.name          = "coding_adventures_brainfuck_wasm_compiler"
+  spec.version       = CodingAdventures::BrainfuckWasmCompiler::VERSION
+  spec.authors       = ["Adhithya Rajasekaran"]
+  spec.summary       = "Brainfuck source to WebAssembly compiler"
+  spec.description   = "Packages the Ruby Brainfuck frontend and the generic IR-to-WASM backend into an end-to-end compiler."
+  spec.homepage      = "https://github.com/adhithyan15/coding-adventures"
+  spec.license       = "MIT"
+  spec.required_ruby_version = ">= 3.4.0"
+  spec.files         = Dir["lib/**/*.rb", "README.md", "CHANGELOG.md"]
+  spec.require_paths = ["lib"]
+  spec.metadata      = {
+    "source_code_uri" => "https://github.com/adhithyan15/coding-adventures",
+    "rubygems_mfa_required" => "true"
+  }
+
+  spec.add_dependency "coding_adventures_brainfuck", "~> 0.1"
+  spec.add_dependency "coding_adventures_brainfuck_ir_compiler", "~> 0.1"
+  spec.add_dependency "coding_adventures_ir_to_wasm_compiler", "~> 0.1"
+  spec.add_dependency "coding_adventures_ir_to_wasm_validator", "~> 0.1"
+  spec.add_dependency "coding_adventures_wasm_module_encoder", "~> 0.1"
+  spec.add_dependency "coding_adventures_wasm_validator", "~> 0.1"
+  spec.add_development_dependency "coding_adventures_wasm_runtime", "~> 0.1"
+  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "simplecov", "~> 0.22"
+  spec.add_development_dependency "rake", "~> 13.0"
+end

--- a/code/packages/ruby/brainfuck_wasm_compiler/lib/coding_adventures/brainfuck_wasm_compiler/compiler.rb
+++ b/code/packages/ruby/brainfuck_wasm_compiler/lib/coding_adventures/brainfuck_wasm_compiler/compiler.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module BrainfuckWasmCompiler
+    PackageResult = Struct.new(
+      :source,
+      :filename,
+      :ast,
+      :raw_ir,
+      :optimized_ir,
+      :module,
+      :validated_module,
+      :binary,
+      :wasm_path,
+      keyword_init: true
+    )
+
+    class PackageError < StandardError
+      attr_reader :stage, :cause
+
+      def initialize(stage, message, cause = nil)
+        @stage = stage
+        @cause = cause
+        @detail_message = message
+        super(message)
+      end
+
+      def to_s
+        "[#{stage}] #{@detail_message}"
+      end
+    end
+
+    class Compiler
+      def initialize(filename: "program.bf", build_config: nil)
+        @filename = filename
+        @build_config = build_config
+      end
+
+      def compile_source(source, filename: @filename, build_config: @build_config)
+        config = build_config || CodingAdventures::BrainfuckIrCompiler::BuildConfig.release_config
+        signatures = [
+          CodingAdventures::IrToWasmCompiler::FunctionSignature.new(
+            label: "_start",
+            param_count: 0,
+            export_name: "_start"
+          )
+        ]
+
+        ast = CodingAdventures::Brainfuck::Parser.parse(source)
+        ir_result = CodingAdventures::BrainfuckIrCompiler.compile(ast, filename, config)
+
+        lowering_errors = CodingAdventures::IrToWasmValidator.validate(ir_result.program, signatures)
+        unless lowering_errors.empty?
+          raise PackageError.new("validate-ir", lowering_errors.first.message)
+        end
+
+        wasm_module = CodingAdventures::IrToWasmCompiler.compile(ir_result.program, signatures)
+        validated_module = CodingAdventures::WasmValidator.validate(wasm_module)
+        binary = CodingAdventures::WasmModuleEncoder.encode_module(wasm_module)
+
+        PackageResult.new(
+          source: source,
+          filename: filename,
+          ast: ast,
+          raw_ir: ir_result.program,
+          optimized_ir: ir_result.program,
+          module: wasm_module,
+          validated_module: validated_module,
+          binary: binary
+        )
+      rescue PackageError
+        raise
+      rescue StandardError => error
+        raise self.class.wrap_stage(infer_stage(error), error)
+      end
+
+      def write_wasm_file(source, output_path, filename: @filename, build_config: @build_config)
+        result = compile_source(source, filename:, build_config:)
+        File.binwrite(output_path, result.binary)
+        result.wasm_path = output_path
+        result
+      rescue PackageError
+        raise
+      rescue StandardError => error
+        raise self.class.wrap_stage("write", error)
+      end
+
+      def self.wrap_stage(stage, error)
+        return error if error.is_a?(PackageError)
+
+        PackageError.new(stage, error.message, error)
+      end
+
+      private
+
+      def infer_stage(error)
+        case error
+        when CodingAdventures::IrToWasmCompiler::WasmLoweringError
+          "lower"
+        when CodingAdventures::WasmValidator::ValidationError
+          "validate-wasm"
+        when CodingAdventures::WasmModuleEncoder::WasmEncodeError
+          "encode"
+        else
+          "parse"
+        end
+      end
+    end
+
+    module_function
+
+    def compile_source(source, filename: "program.bf", build_config: nil)
+      Compiler.new(filename:, build_config:).compile_source(source, filename:, build_config:)
+    end
+
+    def pack_source(source, filename: "program.bf", build_config: nil)
+      compile_source(source, filename:, build_config:)
+    end
+
+    def write_wasm_file(source, output_path, filename: "program.bf", build_config: nil)
+      Compiler.new(filename:, build_config:).write_wasm_file(source, output_path, filename:, build_config:)
+    end
+  end
+end

--- a/code/packages/ruby/brainfuck_wasm_compiler/lib/coding_adventures/brainfuck_wasm_compiler/version.rb
+++ b/code/packages/ruby/brainfuck_wasm_compiler/lib/coding_adventures/brainfuck_wasm_compiler/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module BrainfuckWasmCompiler
+    VERSION = "0.1.0"
+  end
+end

--- a/code/packages/ruby/brainfuck_wasm_compiler/lib/coding_adventures_brainfuck_wasm_compiler.rb
+++ b/code/packages/ruby/brainfuck_wasm_compiler/lib/coding_adventures_brainfuck_wasm_compiler.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "coding_adventures_brainfuck"
+require "coding_adventures_brainfuck_ir_compiler"
+require "coding_adventures_ir_to_wasm_compiler"
+require "coding_adventures_ir_to_wasm_validator"
+require "coding_adventures_wasm_module_encoder"
+require "coding_adventures_wasm_validator"
+
+require_relative "coding_adventures/brainfuck_wasm_compiler/version"
+require_relative "coding_adventures/brainfuck_wasm_compiler/compiler"
+
+module CodingAdventures
+  module BrainfuckWasmCompiler
+  end
+end

--- a/code/packages/ruby/brainfuck_wasm_compiler/test/test_brainfuck_wasm_compiler.rb
+++ b/code/packages/ruby/brainfuck_wasm_compiler/test/test_brainfuck_wasm_compiler.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class TestBrainfuckWasmCompiler < Minitest::Test
+  def run_binary(binary, stdin_text = "")
+    output = []
+    offset = 0
+    host = WR::WasiHost.new(
+      stdin: lambda { |count|
+        return "".b if offset >= stdin_text.bytesize
+
+        chunk = stdin_text.byteslice(offset, count) || "".b
+        offset += chunk.bytesize
+        chunk
+      },
+      stdout: ->(text) { output << text }
+    )
+
+    runtime = WR::Runtime.new(host)
+    [runtime.load_and_run(binary, "_start", []), output]
+  end
+
+  def test_compile_source_returns_pipeline_artifacts
+    result = BWC.compile_source("+.")
+
+    assert_equal "program.bf", result.filename
+    assert_operator result.raw_ir.instructions.length, :>, 0
+    assert_operator result.optimized_ir.instructions.length, :>, 0
+    assert_operator result.binary.bytesize, :>, 0
+    assert_includes result.module.exports.map(&:name), "_start"
+  end
+
+  def test_pack_source_aliases_compile_source
+    compiled = BWC.compile_source("+.")
+    packed = BWC.pack_source("+.")
+
+    assert_equal compiled.binary, packed.binary
+  end
+
+  def test_write_wasm_file_writes_binary_to_disk
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "program.wasm")
+      result = BWC.write_wasm_file("+.", path)
+
+      assert_equal result.binary, File.binread(path)
+      assert_equal path, result.wasm_path
+    end
+  end
+
+  def test_runs_compiled_output_programs_in_runtime
+    result = BWC.compile_source("+" * 65 + ".")
+    execution_result, output = run_binary(result.binary)
+
+    assert_equal [0], execution_result
+    assert_equal ["A"], output
+  end
+
+  def test_runs_compiled_input_programs_in_runtime
+    result = BWC.compile_source(",.")
+    execution_result, output = run_binary(result.binary, "Z")
+
+    assert_equal [0], execution_result
+    assert_equal ["Z"], output
+  end
+
+  def test_runs_compiled_cat_programs_in_runtime
+    result = BWC.compile_source(",[.,]")
+    execution_result, output = run_binary(result.binary, "Hi")
+
+    assert_equal [0], execution_result
+    assert_equal ["H", "i"], output
+  end
+
+  def test_honors_custom_filename
+    compiler = BWC::Compiler.new(filename: "hello.bf")
+    result = compiler.compile_source("+")
+
+    assert_equal "hello.bf", result.filename
+  end
+
+  def test_wraps_parse_errors_with_stage_information
+    error = assert_raises(BWC::PackageError) do
+      BWC.compile_source("[")
+    end
+
+    assert_equal "parse", error.stage
+    assert_match(/\[parse\]/, error.to_s)
+  end
+
+  def test_wraps_write_errors_with_stage_information
+    compiler = BWC::Compiler.new
+
+    Dir.mktmpdir do |dir|
+      error = assert_raises(BWC::PackageError) do
+        compiler.write_wasm_file("+", dir)
+      end
+
+      assert_equal "write", error.stage
+      refute_nil error.cause
+    end
+  end
+end

--- a/code/packages/ruby/brainfuck_wasm_compiler/test/test_helper.rb
+++ b/code/packages/ruby/brainfuck_wasm_compiler/test/test_helper.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "simplecov"
+SimpleCov.start do
+  enable_coverage :branch
+  minimum_coverage 80
+end
+
+require "minitest/autorun"
+require "tmpdir"
+require "coding_adventures_brainfuck_wasm_compiler"
+require "coding_adventures_wasm_runtime"
+
+BWC = CodingAdventures::BrainfuckWasmCompiler
+WR = CodingAdventures::WasmRuntime

--- a/code/packages/ruby/ir_to_wasm_compiler/BUILD
+++ b/code/packages/ruby/ir_to_wasm_compiler/BUILD
@@ -1,0 +1,3 @@
+bundle config set path vendor/bundle
+bundle install --quiet
+bundle exec rake test

--- a/code/packages/ruby/ir_to_wasm_compiler/CHANGELOG.md
+++ b/code/packages/ruby/ir_to_wasm_compiler/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial IR to WebAssembly lowering backend for Ruby.

--- a/code/packages/ruby/ir_to_wasm_compiler/Gemfile
+++ b/code/packages/ruby/ir_to_wasm_compiler/Gemfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+gemspec
+
+gem "coding_adventures_compiler_ir", path: "../compiler-ir"
+gem "coding_adventures_wasm_leb128", path: "../wasm_leb128"
+gem "coding_adventures_wasm_opcodes", path: "../wasm_opcodes"
+gem "coding_adventures_wasm_types", path: "../wasm_types"

--- a/code/packages/ruby/ir_to_wasm_compiler/README.md
+++ b/code/packages/ruby/ir_to_wasm_compiler/README.md
@@ -1,0 +1,3 @@
+# coding_adventures_ir_to_wasm_compiler
+
+Lowers generic compiler IR into `CodingAdventures::WasmTypes::WasmModule`.

--- a/code/packages/ruby/ir_to_wasm_compiler/Rakefile
+++ b/code/packages/ruby/ir_to_wasm_compiler/Rakefile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rake/testtask"
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList["test/**/test_*.rb"]
+end
+
+task default: :test

--- a/code/packages/ruby/ir_to_wasm_compiler/coding_adventures_ir_to_wasm_compiler.gemspec
+++ b/code/packages/ruby/ir_to_wasm_compiler/coding_adventures_ir_to_wasm_compiler.gemspec
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative "lib/coding_adventures/ir_to_wasm_compiler/version"
+
+Gem::Specification.new do |spec|
+  spec.name          = "coding_adventures_ir_to_wasm_compiler"
+  spec.version       = CodingAdventures::IrToWasmCompiler::VERSION
+  spec.authors       = ["Adhithya Rajasekaran"]
+  spec.summary       = "Generic IR to WebAssembly 1.0 compiler"
+  spec.description   = "Lowers CodingAdventures compiler IR into WebAssembly modules, including WASI-backed syscall lowering."
+  spec.homepage      = "https://github.com/adhithyan15/coding-adventures"
+  spec.license       = "MIT"
+  spec.required_ruby_version = ">= 3.4.0"
+  spec.files         = Dir["lib/**/*.rb", "README.md", "CHANGELOG.md"]
+  spec.require_paths = ["lib"]
+  spec.metadata      = {
+    "source_code_uri" => "https://github.com/adhithyan15/coding-adventures",
+    "rubygems_mfa_required" => "true"
+  }
+
+  spec.add_dependency "coding_adventures_compiler_ir", "~> 0.1"
+  spec.add_dependency "coding_adventures_wasm_leb128", "~> 0.1"
+  spec.add_dependency "coding_adventures_wasm_opcodes", "~> 0.1"
+  spec.add_dependency "coding_adventures_wasm_types", "~> 0.1"
+  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "simplecov", "~> 0.22"
+  spec.add_development_dependency "rake", "~> 13.0"
+end

--- a/code/packages/ruby/ir_to_wasm_compiler/lib/coding_adventures/ir_to_wasm_compiler/compiler.rb
+++ b/code/packages/ruby/ir_to_wasm_compiler/lib/coding_adventures/ir_to_wasm_compiler/compiler.rb
@@ -1,0 +1,775 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module IrToWasmCompiler
+    IR = CodingAdventures::CompilerIr
+    WT = CodingAdventures::WasmTypes
+    LEB128 = CodingAdventures::WasmLeb128
+
+    LOOP_START_RE = /^loop_\d+_start$/
+    IF_ELSE_RE = /^if_\d+_else$/
+    FUNCTION_COMMENT_RE = /^function:\s*([A-Za-z_][A-Za-z0-9_]*)\((.*)\)$/
+
+    SYSCALL_WRITE = 1
+    SYSCALL_READ = 2
+    SYSCALL_EXIT = 10
+    SYSCALL_ARG0 = 4
+
+    WASI_MODULE = "wasi_snapshot_preview1"
+    WASI_IOVEC_OFFSET = 0
+    WASI_COUNT_OFFSET = 8
+    WASI_BYTE_OFFSET = 12
+    WASI_SCRATCH_SIZE = 16
+
+    REG_SCRATCH = 1
+    REG_VAR_BASE = 2
+
+    MEMORY_OPS = [
+      IR::IrOp::LOAD_ADDR,
+      IR::IrOp::LOAD_BYTE,
+      IR::IrOp::STORE_BYTE,
+      IR::IrOp::LOAD_WORD,
+      IR::IrOp::STORE_WORD
+    ].freeze
+
+    FunctionSignature = Struct.new(:label, :param_count, :export_name, keyword_init: true)
+    FunctionIR = Struct.new(:label, :instructions, :signature, :max_reg, keyword_init: true)
+    WasiImport = Struct.new(:syscall_number, :name, :func_type, keyword_init: true) do
+      def type_key
+        "wasi::#{name}"
+      end
+    end
+    WasiContext = Struct.new(:function_indices, :scratch_base, keyword_init: true)
+
+    class WasmLoweringError < StandardError; end
+
+    OPCODE = begin
+      names = %w[
+        nop block loop if else end br br_if return call
+        local.get local.set i32.load i32.load8_u i32.store i32.store8
+        i32.const i32.eqz i32.eq i32.ne i32.lt_s i32.gt_s i32.add i32.sub i32.and
+      ]
+      names.each_with_object({}) do |name, table|
+        entry = CodingAdventures::WasmOpcodes::OPCODES_BY_NAME[name]
+        raise WasmLoweringError, "missing wasm opcode #{name}" unless entry
+
+        table[name] = entry.opcode
+      end.freeze
+    end
+
+    class Compiler
+      def compile(program, function_signatures = nil)
+        signatures = IrToWasmCompiler.infer_function_signatures_from_comments(program)
+        Array(function_signatures).each do |signature|
+          signatures[signature.label] = signature
+        end
+
+        functions = split_functions(program, signatures)
+        imports = collect_wasi_imports(program)
+        type_indices, types = build_type_table(functions, imports)
+        data_offsets = layout_data(program.data)
+
+        scratch_base = nil
+        if needs_wasi_scratch?(program)
+          scratch_base = IrToWasmCompiler.align_up(program.data.sum(&:size), 4)
+        end
+
+        wasm_module = WT::WasmModule.new
+        wasm_module.types.concat(types)
+        imports.each do |import_value|
+          wasm_module.imports << WT::Import.new(
+            WASI_MODULE,
+            import_value.name,
+            WT::EXTERNAL_KIND[:function],
+            type_indices[import_value.type_key]
+          )
+        end
+
+        function_index_base = imports.length
+        function_indices = {}
+        functions.each_with_index do |function, index|
+          function_indices[function.label] = function_index_base + index
+          wasm_module.functions << type_indices[function.label]
+        end
+
+        total_bytes = program.data.sum(&:size)
+        total_bytes = [total_bytes, scratch_base + WASI_SCRATCH_SIZE].max unless scratch_base.nil?
+
+        if needs_memory?(program) || !scratch_base.nil?
+          page_count = total_bytes.zero? ? 1 : [1, (total_bytes.to_f / 65_536).ceil].max
+          wasm_module.memories << WT::MemoryType.new(WT::Limits.new(page_count, nil))
+          wasm_module.exports << WT::Export.new("memory", WT::EXTERNAL_KIND[:memory], 0)
+          program.data.each do |decl|
+            payload = ([decl.init & 0xFF] * decl.size).pack("C*").b
+            wasm_module.data << WT::DataSegment.new(0, IrToWasmCompiler.const_expr(data_offsets[decl.label]), payload)
+          end
+        end
+
+        wasi_context = WasiContext.new(
+          function_indices: imports.each_with_index.each_with_object({}) do |(import_value, index), table|
+            table[import_value.syscall_number] = index
+          end,
+          scratch_base: scratch_base
+        )
+
+        functions.each do |function|
+          wasm_module.code << FunctionLowerer.new(
+            function: function,
+            signatures: signatures,
+            function_indices: function_indices,
+            data_offsets: data_offsets,
+            wasi_context: wasi_context
+          ).lower
+          next if function.signature.export_name.nil?
+
+          wasm_module.exports << WT::Export.new(
+            function.signature.export_name,
+            WT::EXTERNAL_KIND[:function],
+            function_indices[function.label]
+          )
+        end
+
+        wasm_module
+      end
+
+      private
+
+      def build_type_table(functions, imports)
+        type_indices = {}
+        function_types = []
+        function_to_type_index = {}
+
+        imports.each do |import_value|
+          unless type_indices.key?(import_value.func_type)
+            type_indices[import_value.func_type] = function_types.length
+            function_types << import_value.func_type
+          end
+          function_to_type_index[import_value.type_key] = type_indices[import_value.func_type]
+        end
+
+        functions.each do |function|
+          func_type = WT::FuncType.new(
+            [WT::VALUE_TYPE[:i32]] * function.signature.param_count,
+            [WT::VALUE_TYPE[:i32]]
+          )
+          unless type_indices.key?(func_type)
+            type_indices[func_type] = function_types.length
+            function_types << func_type
+          end
+          function_to_type_index[function.label] = type_indices[func_type]
+        end
+
+        [function_to_type_index, function_types]
+      end
+
+      def layout_data(decls)
+        cursor = 0
+        decls.each_with_object({}) do |decl, offsets|
+          offsets[decl.label] = cursor
+          cursor += decl.size
+        end
+      end
+
+      def needs_memory?(program)
+        return true unless program.data.empty?
+
+        program.instructions.any? { |instruction| MEMORY_OPS.include?(instruction.opcode) }
+      end
+
+      def needs_wasi_scratch?(program)
+        program.instructions.any? do |instruction|
+          next false unless instruction.opcode == IR::IrOp::SYSCALL && !instruction.operands.empty?
+
+          syscall = IrToWasmCompiler.expect_immediate(instruction.operands[0], "SYSCALL number").value
+          [SYSCALL_WRITE, SYSCALL_READ].include?(syscall)
+        end
+      end
+
+      def collect_wasi_imports(program)
+        required_syscalls = program.instructions.each_with_object([]) do |instruction, syscalls|
+          next unless instruction.opcode == IR::IrOp::SYSCALL && !instruction.operands.empty?
+
+          syscalls << IrToWasmCompiler.expect_immediate(instruction.operands[0], "SYSCALL number").value
+        end.uniq
+
+        ordered_imports = [
+          WasiImport.new(
+            syscall_number: SYSCALL_WRITE,
+            name: "fd_write",
+            func_type: WT::FuncType.new([WT::VALUE_TYPE[:i32]] * 4, [WT::VALUE_TYPE[:i32]])
+          ),
+          WasiImport.new(
+            syscall_number: SYSCALL_READ,
+            name: "fd_read",
+            func_type: WT::FuncType.new([WT::VALUE_TYPE[:i32]] * 4, [WT::VALUE_TYPE[:i32]])
+          ),
+          WasiImport.new(
+            syscall_number: SYSCALL_EXIT,
+            name: "proc_exit",
+            func_type: WT::FuncType.new([WT::VALUE_TYPE[:i32]], [])
+          )
+        ]
+
+        supported = ordered_imports.map(&:syscall_number)
+        unsupported = required_syscalls - supported
+        unless unsupported.empty?
+          raise WasmLoweringError, "unsupported SYSCALL number(s): #{unsupported.sort.join(', ')}"
+        end
+
+        ordered_imports.select { |import_value| required_syscalls.include?(import_value.syscall_number) }
+      end
+
+      def split_functions(program, signatures)
+        functions = []
+        start_index = nil
+        start_label = nil
+
+        program.instructions.each_with_index do |instruction, index|
+          label_name = IrToWasmCompiler.function_label_name(instruction)
+          next if label_name.nil?
+
+          unless start_label.nil? || start_index.nil?
+            functions << IrToWasmCompiler.make_function_ir(
+              label: start_label,
+              instructions: program.instructions[start_index...index],
+              signatures: signatures
+            )
+          end
+
+          start_label = label_name
+          start_index = index
+        end
+
+        unless start_label.nil? || start_index.nil?
+          functions << IrToWasmCompiler.make_function_ir(
+            label: start_label,
+            instructions: program.instructions[start_index..],
+            signatures: signatures
+          )
+        end
+
+        functions
+      end
+    end
+
+    class FunctionLowerer
+      def initialize(function:, signatures:, function_indices:, data_offsets:, wasi_context:)
+        @function = function
+        @signatures = signatures
+        @function_indices = function_indices
+        @data_offsets = data_offsets
+        @wasi_context = wasi_context
+        @param_count = function.signature.param_count
+        @bytes = +"".b
+        @instructions = function.instructions
+        @label_to_index = {}
+        @instructions.each_with_index do |instruction, index|
+          label = IrToWasmCompiler.label_name(instruction)
+          @label_to_index[label] = index unless label.nil?
+        end
+      end
+
+      def lower
+        copy_params_into_ir_registers
+        emit_region(1, @instructions.length)
+        emit_opcode("end")
+
+        WT::FunctionBody.new(
+          [WT::VALUE_TYPE[:i32]] * (@function.max_reg + 1),
+          @bytes
+        )
+      end
+
+      private
+
+      def copy_params_into_ir_registers
+        @param_count.times do |param_index|
+          emit_opcode("local.get")
+          emit_u32(param_index)
+          emit_opcode("local.set")
+          emit_u32(local_index(REG_VAR_BASE + param_index))
+        end
+      end
+
+      def emit_region(start_index, end_index)
+        index = start_index
+        while index < end_index
+          instruction = @instructions[index]
+
+          if instruction.opcode == IR::IrOp::COMMENT
+            index += 1
+            next
+          end
+
+          label_name = IrToWasmCompiler.label_name(instruction)
+          if label_name&.match?(LOOP_START_RE)
+            index = emit_loop(index)
+            next
+          end
+
+          if [IR::IrOp::BRANCH_Z, IR::IrOp::BRANCH_NZ].include?(instruction.opcode) &&
+              instruction.operands.length == 2 &&
+              instruction.operands[1].is_a?(IR::IrLabel) &&
+              instruction.operands[1].name.match?(IF_ELSE_RE)
+            index = emit_if(index)
+            next
+          end
+
+          if instruction.opcode == IR::IrOp::LABEL
+            index += 1
+            next
+          end
+
+          if [IR::IrOp::JUMP, IR::IrOp::BRANCH_Z, IR::IrOp::BRANCH_NZ].include?(instruction.opcode)
+            raise WasmLoweringError, "unexpected unstructured control flow in #{@function.label}"
+          end
+
+          emit_simple(instruction)
+          index += 1
+        end
+      end
+
+      def emit_if(branch_index)
+        branch = @instructions[branch_index]
+        cond_reg = IrToWasmCompiler.expect_register(branch.operands[0], "if condition")
+        else_label = IrToWasmCompiler.expect_label(branch.operands[1], "if else label").name
+        end_label = "#{else_label.delete_suffix("_else")}_end"
+
+        else_index = require_label_index(else_label)
+        end_index = require_label_index(end_label)
+        jump_index = find_last_jump_to_label(branch_index + 1, else_index, end_label)
+
+        emit_local_get(cond_reg.index)
+        emit_opcode("i32.eqz") if branch.opcode == IR::IrOp::BRANCH_NZ
+        emit_opcode("if")
+        @bytes << [WT::BLOCK_TYPE_EMPTY].pack("C")
+
+        emit_region(branch_index + 1, jump_index)
+
+        if else_index + 1 < end_index
+          emit_opcode("else")
+          emit_region(else_index + 1, end_index)
+        end
+
+        emit_opcode("end")
+        end_index + 1
+      end
+
+      def emit_loop(label_index)
+        start_label = IrToWasmCompiler.label_name(@instructions[label_index])
+        raise WasmLoweringError, "loop lowering expected a start label" if start_label.nil?
+
+        end_label = "#{start_label.delete_suffix("_start")}_end"
+        end_index = require_label_index(end_label)
+        branch_index = find_first_branch_to_label(label_index + 1, end_index, end_label)
+        backedge_index = find_last_jump_to_label(branch_index + 1, end_index, start_label)
+        branch = @instructions[branch_index]
+        cond_reg = IrToWasmCompiler.expect_register(branch.operands[0], "loop condition")
+
+        emit_opcode("block")
+        @bytes << [WT::BLOCK_TYPE_EMPTY].pack("C")
+        emit_opcode("loop")
+        @bytes << [WT::BLOCK_TYPE_EMPTY].pack("C")
+
+        emit_region(label_index + 1, branch_index)
+
+        emit_local_get(cond_reg.index)
+        emit_opcode("i32.eqz") if branch.opcode == IR::IrOp::BRANCH_Z
+        emit_opcode("br_if")
+        emit_u32(1)
+
+        emit_region(branch_index + 1, backedge_index)
+        emit_opcode("br")
+        emit_u32(0)
+
+        emit_opcode("end")
+        emit_opcode("end")
+        end_index + 1
+      end
+
+      def emit_simple(instruction)
+        case instruction.opcode
+        when IR::IrOp::LOAD_IMM
+          dst = IrToWasmCompiler.expect_register(instruction.operands[0], "LOAD_IMM dst")
+          imm = IrToWasmCompiler.expect_immediate(instruction.operands[1], "LOAD_IMM imm")
+          emit_i32_const(imm.value)
+          emit_local_set(dst.index)
+        when IR::IrOp::LOAD_ADDR
+          dst = IrToWasmCompiler.expect_register(instruction.operands[0], "LOAD_ADDR dst")
+          label = IrToWasmCompiler.expect_label(instruction.operands[1], "LOAD_ADDR label")
+          raise WasmLoweringError, "unknown data label: #{label.name}" unless @data_offsets.key?(label.name)
+
+          emit_i32_const(@data_offsets[label.name])
+          emit_local_set(dst.index)
+        when IR::IrOp::LOAD_BYTE
+          dst = IrToWasmCompiler.expect_register(instruction.operands[0], "LOAD_BYTE dst")
+          base = IrToWasmCompiler.expect_register(instruction.operands[1], "LOAD_BYTE base")
+          offset = IrToWasmCompiler.expect_register(instruction.operands[2], "LOAD_BYTE offset")
+          emit_address(base.index, offset.index)
+          emit_opcode("i32.load8_u")
+          emit_memarg(0, 0)
+          emit_local_set(dst.index)
+        when IR::IrOp::STORE_BYTE
+          src = IrToWasmCompiler.expect_register(instruction.operands[0], "STORE_BYTE src")
+          base = IrToWasmCompiler.expect_register(instruction.operands[1], "STORE_BYTE base")
+          offset = IrToWasmCompiler.expect_register(instruction.operands[2], "STORE_BYTE offset")
+          emit_address(base.index, offset.index)
+          emit_local_get(src.index)
+          emit_opcode("i32.store8")
+          emit_memarg(0, 0)
+        when IR::IrOp::LOAD_WORD
+          dst = IrToWasmCompiler.expect_register(instruction.operands[0], "LOAD_WORD dst")
+          base = IrToWasmCompiler.expect_register(instruction.operands[1], "LOAD_WORD base")
+          offset = IrToWasmCompiler.expect_register(instruction.operands[2], "LOAD_WORD offset")
+          emit_address(base.index, offset.index)
+          emit_opcode("i32.load")
+          emit_memarg(2, 0)
+          emit_local_set(dst.index)
+        when IR::IrOp::STORE_WORD
+          src = IrToWasmCompiler.expect_register(instruction.operands[0], "STORE_WORD src")
+          base = IrToWasmCompiler.expect_register(instruction.operands[1], "STORE_WORD base")
+          offset = IrToWasmCompiler.expect_register(instruction.operands[2], "STORE_WORD offset")
+          emit_address(base.index, offset.index)
+          emit_local_get(src.index)
+          emit_opcode("i32.store")
+          emit_memarg(2, 0)
+        when IR::IrOp::ADD
+          emit_binary_numeric("i32.add", instruction)
+        when IR::IrOp::ADD_IMM
+          dst = IrToWasmCompiler.expect_register(instruction.operands[0], "ADD_IMM dst")
+          src = IrToWasmCompiler.expect_register(instruction.operands[1], "ADD_IMM src")
+          imm = IrToWasmCompiler.expect_immediate(instruction.operands[2], "ADD_IMM imm")
+          emit_local_get(src.index)
+          emit_i32_const(imm.value)
+          emit_opcode("i32.add")
+          emit_local_set(dst.index)
+        when IR::IrOp::SUB
+          emit_binary_numeric("i32.sub", instruction)
+        when IR::IrOp::AND
+          emit_binary_numeric("i32.and", instruction)
+        when IR::IrOp::AND_IMM
+          dst = IrToWasmCompiler.expect_register(instruction.operands[0], "AND_IMM dst")
+          src = IrToWasmCompiler.expect_register(instruction.operands[1], "AND_IMM src")
+          imm = IrToWasmCompiler.expect_immediate(instruction.operands[2], "AND_IMM imm")
+          emit_local_get(src.index)
+          emit_i32_const(imm.value)
+          emit_opcode("i32.and")
+          emit_local_set(dst.index)
+        when IR::IrOp::CMP_EQ
+          emit_binary_numeric("i32.eq", instruction)
+        when IR::IrOp::CMP_NE
+          emit_binary_numeric("i32.ne", instruction)
+        when IR::IrOp::CMP_LT
+          emit_binary_numeric("i32.lt_s", instruction)
+        when IR::IrOp::CMP_GT
+          emit_binary_numeric("i32.gt_s", instruction)
+        when IR::IrOp::CALL
+          label = IrToWasmCompiler.expect_label(instruction.operands[0], "CALL target")
+          signature = @signatures[label.name]
+          raise WasmLoweringError, "missing function signature for #{label.name}" if signature.nil?
+          raise WasmLoweringError, "unknown function label: #{label.name}" unless @function_indices.key?(label.name)
+
+          signature.param_count.times do |param_index|
+            emit_local_get(REG_VAR_BASE + param_index)
+          end
+          emit_opcode("call")
+          emit_u32(@function_indices[label.name])
+          emit_local_set(REG_SCRATCH)
+        when IR::IrOp::RET, IR::IrOp::HALT
+          emit_local_get(REG_SCRATCH)
+          emit_opcode("return")
+        when IR::IrOp::NOP
+          emit_opcode("nop")
+        when IR::IrOp::SYSCALL
+          emit_syscall(instruction)
+        else
+          raise WasmLoweringError, "unsupported opcode: #{IR::IrOp.op_name(instruction.opcode)}"
+        end
+      end
+
+      def emit_syscall(instruction)
+        syscall = IrToWasmCompiler.expect_immediate(instruction.operands[0], "SYSCALL number").value
+
+        case syscall
+        when SYSCALL_WRITE then emit_wasi_write
+        when SYSCALL_READ then emit_wasi_read
+        when SYSCALL_EXIT then emit_wasi_exit
+        else
+          raise WasmLoweringError, "unsupported SYSCALL number: #{syscall}"
+        end
+      end
+
+      def emit_wasi_write
+        scratch_base = require_wasi_scratch
+        iovec_ptr = scratch_base + WASI_IOVEC_OFFSET
+        nwritten_ptr = scratch_base + WASI_COUNT_OFFSET
+        byte_ptr = scratch_base + WASI_BYTE_OFFSET
+
+        emit_i32_const(byte_ptr)
+        emit_local_get(SYSCALL_ARG0)
+        emit_opcode("i32.store8")
+        emit_memarg(0, 0)
+
+        emit_store_const_i32(iovec_ptr, byte_ptr)
+        emit_store_const_i32(iovec_ptr + 4, 1)
+
+        emit_i32_const(1)
+        emit_i32_const(iovec_ptr)
+        emit_i32_const(1)
+        emit_i32_const(nwritten_ptr)
+        emit_wasi_call(SYSCALL_WRITE)
+        emit_local_set(REG_SCRATCH)
+      end
+
+      def emit_wasi_read
+        scratch_base = require_wasi_scratch
+        iovec_ptr = scratch_base + WASI_IOVEC_OFFSET
+        nread_ptr = scratch_base + WASI_COUNT_OFFSET
+        byte_ptr = scratch_base + WASI_BYTE_OFFSET
+
+        emit_i32_const(byte_ptr)
+        emit_i32_const(0)
+        emit_opcode("i32.store8")
+        emit_memarg(0, 0)
+
+        emit_store_const_i32(iovec_ptr, byte_ptr)
+        emit_store_const_i32(iovec_ptr + 4, 1)
+
+        emit_i32_const(0)
+        emit_i32_const(iovec_ptr)
+        emit_i32_const(1)
+        emit_i32_const(nread_ptr)
+        emit_wasi_call(SYSCALL_READ)
+        emit_local_set(REG_SCRATCH)
+
+        emit_i32_const(byte_ptr)
+        emit_opcode("i32.load8_u")
+        emit_memarg(0, 0)
+        emit_local_set(SYSCALL_ARG0)
+      end
+
+      def emit_wasi_exit
+        emit_local_get(SYSCALL_ARG0)
+        emit_wasi_call(SYSCALL_EXIT)
+        emit_i32_const(0)
+        emit_opcode("return")
+      end
+
+      def emit_store_const_i32(address, value)
+        emit_i32_const(address)
+        emit_i32_const(value)
+        emit_opcode("i32.store")
+        emit_memarg(2, 0)
+      end
+
+      def emit_wasi_call(syscall_number)
+        function_index = @wasi_context.function_indices[syscall_number]
+        raise WasmLoweringError, "missing WASI import for SYSCALL #{syscall_number}" if function_index.nil?
+
+        emit_opcode("call")
+        emit_u32(function_index)
+      end
+
+      def require_wasi_scratch
+        raise WasmLoweringError, "SYSCALL lowering requires WASM scratch memory" if @wasi_context.scratch_base.nil?
+
+        @wasi_context.scratch_base
+      end
+
+      def emit_binary_numeric(wasm_op, instruction)
+        opname = IR::IrOp.op_name(instruction.opcode)
+        dst = IrToWasmCompiler.expect_register(instruction.operands[0], "#{opname} dst")
+        left = IrToWasmCompiler.expect_register(instruction.operands[1], "#{opname} lhs")
+        right = IrToWasmCompiler.expect_register(instruction.operands[2], "#{opname} rhs")
+        emit_local_get(left.index)
+        emit_local_get(right.index)
+        emit_opcode(wasm_op)
+        emit_local_set(dst.index)
+      end
+
+      def emit_address(base_index, offset_index)
+        emit_local_get(base_index)
+        emit_local_get(offset_index)
+        emit_opcode("i32.add")
+      end
+
+      def emit_local_get(reg_index)
+        emit_opcode("local.get")
+        emit_u32(local_index(reg_index))
+      end
+
+      def emit_local_set(reg_index)
+        emit_opcode("local.set")
+        emit_u32(local_index(reg_index))
+      end
+
+      def emit_i32_const(value)
+        emit_opcode("i32.const")
+        @bytes << LEB128.encode_signed(value)
+      end
+
+      def emit_memarg(align, offset)
+        emit_u32(align)
+        emit_u32(offset)
+      end
+
+      def emit_opcode(name)
+        @bytes << [OPCODE.fetch(name)].pack("C")
+      end
+
+      def emit_u32(value)
+        @bytes << LEB128.encode_unsigned(value)
+      end
+
+      def local_index(reg_index)
+        @param_count + reg_index
+      end
+
+      def require_label_index(label)
+        index = @label_to_index[label]
+        raise WasmLoweringError, "missing label #{label} in #{@function.label}" if index.nil?
+
+        index
+      end
+
+      def find_first_branch_to_label(start_index, end_index, label)
+        (start_index...end_index).each do |index|
+          instruction = @instructions[index]
+          next unless [IR::IrOp::BRANCH_Z, IR::IrOp::BRANCH_NZ].include?(instruction.opcode)
+
+          target = IrToWasmCompiler.label_name_from_operand(instruction.operands[1])
+          return index if target == label
+        end
+        raise WasmLoweringError, "expected branch to #{label} in #{@function.label}"
+      end
+
+      def find_last_jump_to_label(start_index, end_index, label)
+        (end_index - 1).downto(start_index) do |index|
+          instruction = @instructions[index]
+          next unless instruction.opcode == IR::IrOp::JUMP
+
+          target = IrToWasmCompiler.label_name_from_operand(instruction.operands[0])
+          return index if target == label
+        end
+        raise WasmLoweringError, "expected jump to #{label} in #{@function.label}"
+      end
+    end
+
+    module_function
+
+    def compile(program, function_signatures = nil)
+      Compiler.new.compile(program, function_signatures)
+    end
+
+    def new_function_signature(label, param_count, export_name = nil)
+      FunctionSignature.new(label:, param_count:, export_name:)
+    end
+
+    def infer_function_signatures_from_comments(program)
+      signatures = {}
+      pending_comment = nil
+
+      program.instructions.each do |instruction|
+        if instruction.opcode == IR::IrOp::COMMENT
+          pending_comment = label_name_from_operand(instruction.operands[0])
+          next
+        end
+
+        label = function_label_name(instruction)
+        if label
+          if label == "_start"
+            signatures[label] = FunctionSignature.new(label: label, param_count: 0, export_name: "_start")
+          elsif label.start_with?("_fn_") && !pending_comment.nil?
+            export_name = label.delete_prefix("_fn_")
+            match = FUNCTION_COMMENT_RE.match(pending_comment)
+            if match && match[1] == export_name
+              params_blob = match[2].to_s.strip
+              param_count = params_blob.empty? ? 0 : params_blob.split(",").count { |piece| !piece.strip.empty? }
+              signatures[label] = FunctionSignature.new(label: label, param_count: param_count, export_name: export_name)
+            end
+          end
+          pending_comment = nil
+        elsif instruction.opcode != IR::IrOp::COMMENT
+          pending_comment = nil
+        end
+      end
+
+      signatures
+    end
+
+    def make_function_ir(label:, instructions:, signatures:)
+      signature =
+        if label == "_start"
+          signatures.fetch(label, FunctionSignature.new(label: label, param_count: 0, export_name: "_start"))
+        else
+          signatures[label]
+        end
+      raise WasmLoweringError, "missing function signature for #{label}" if signature.nil?
+
+      max_reg = [1, REG_VAR_BASE + [signature.param_count - 1, 0].max].max
+      instructions.each do |instruction|
+        max_reg = [max_reg, SYSCALL_ARG0].max if instruction.opcode == IR::IrOp::SYSCALL
+        instruction.operands.each do |operand|
+          next unless operand.is_a?(IR::IrRegister)
+
+          max_reg = [max_reg, operand.index].max
+        end
+      end
+
+      FunctionIR.new(
+        label: label,
+        instructions: instructions,
+        signature: signature,
+        max_reg: max_reg
+      )
+    end
+
+    def const_expr(value)
+      [OPCODE.fetch("i32.const")].pack("C") + LEB128.encode_signed(value) + [OPCODE.fetch("end")].pack("C")
+    end
+
+    def function_label_name(instruction)
+      label = label_name(instruction)
+      return label if label == "_start"
+      return label if !label.nil? && label.start_with?("_fn_")
+
+      nil
+    end
+
+    def label_name(instruction)
+      return nil unless instruction.opcode == IR::IrOp::LABEL
+      return nil if instruction.operands.empty?
+      return nil unless instruction.operands[0].is_a?(IR::IrLabel)
+
+      instruction.operands[0].name
+    end
+
+    def label_name_from_operand(operand)
+      raise WasmLoweringError, "expected label operand, got #{operand.inspect}" unless operand.is_a?(IR::IrLabel)
+
+      operand.name
+    end
+
+    def expect_register(operand, context)
+      raise WasmLoweringError, "#{context}: expected register, got #{operand.inspect}" unless operand.is_a?(IR::IrRegister)
+
+      operand
+    end
+
+    def expect_immediate(operand, context)
+      raise WasmLoweringError, "#{context}: expected immediate, got #{operand.inspect}" unless operand.is_a?(IR::IrImmediate)
+
+      operand
+    end
+
+    def expect_label(operand, context)
+      raise WasmLoweringError, "#{context}: expected label, got #{operand.inspect}" unless operand.is_a?(IR::IrLabel)
+
+      operand
+    end
+
+    def align_up(value, alignment)
+      ((value + alignment - 1) / alignment) * alignment
+    end
+  end
+end

--- a/code/packages/ruby/ir_to_wasm_compiler/lib/coding_adventures/ir_to_wasm_compiler/version.rb
+++ b/code/packages/ruby/ir_to_wasm_compiler/lib/coding_adventures/ir_to_wasm_compiler/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module IrToWasmCompiler
+    VERSION = "0.1.0"
+  end
+end

--- a/code/packages/ruby/ir_to_wasm_compiler/lib/coding_adventures_ir_to_wasm_compiler.rb
+++ b/code/packages/ruby/ir_to_wasm_compiler/lib/coding_adventures_ir_to_wasm_compiler.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "coding_adventures_compiler_ir"
+require "coding_adventures_wasm_leb128"
+require "coding_adventures_wasm_opcodes"
+require "coding_adventures_wasm_types"
+
+require_relative "coding_adventures/ir_to_wasm_compiler/version"
+require_relative "coding_adventures/ir_to_wasm_compiler/compiler"
+
+module CodingAdventures
+  module IrToWasmCompiler
+  end
+end

--- a/code/packages/ruby/ir_to_wasm_compiler/test/test_helper.rb
+++ b/code/packages/ruby/ir_to_wasm_compiler/test/test_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "simplecov"
+SimpleCov.start do
+  enable_coverage :branch
+  minimum_coverage 80
+end
+
+require "minitest/autorun"
+require "coding_adventures_ir_to_wasm_compiler"
+
+IR = CodingAdventures::CompilerIr
+ITWC = CodingAdventures::IrToWasmCompiler
+WT = CodingAdventures::WasmTypes

--- a/code/packages/ruby/ir_to_wasm_compiler/test/test_ir_to_wasm_compiler.rb
+++ b/code/packages/ruby/ir_to_wasm_compiler/test/test_ir_to_wasm_compiler.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class TestIrToWasmCompiler < Minitest::Test
+  def test_infers_nib_style_function_signatures_from_comments
+    program = IR::IrProgram.new("_start")
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::COMMENT, [IR::IrLabel.new("function:add(a, b)")], 0))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::LABEL, [IR::IrLabel.new("_fn_add")], -1))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::HALT, [], 1))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::LABEL, [IR::IrLabel.new("_start")], -1))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::HALT, [], 2))
+
+    signatures = ITWC.infer_function_signatures_from_comments(program)
+
+    assert_equal 2, signatures["_fn_add"].param_count
+    assert_equal "add", signatures["_fn_add"].export_name
+    assert_equal "_start", signatures["_start"].export_name
+  end
+
+  def test_lowers_minimal_start_function
+    program = IR::IrProgram.new("_start")
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::LABEL, [IR::IrLabel.new("_start")], -1))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::HALT, [], 0))
+
+    wasm_module = ITWC.compile(program, [ITWC::FunctionSignature.new(label: "_start", param_count: 0, export_name: "_start")])
+
+    assert_equal 1, wasm_module.types.length
+    assert_equal 1, wasm_module.functions.length
+    assert_equal 1, wasm_module.code.length
+    assert_equal "_start", wasm_module.exports.last.name
+  end
+
+  def test_lowers_wasi_write_to_import_and_memory
+    program = IR::IrProgram.new("_start")
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::LABEL, [IR::IrLabel.new("_start")], -1))
+    program.add_instruction(
+      IR::IrInstruction.new(
+        IR::IrOp::LOAD_IMM,
+        [IR::IrRegister.new(4), IR::IrImmediate.new(65)],
+        0
+      )
+    )
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::SYSCALL, [IR::IrImmediate.new(1)], 1))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::HALT, [], 2))
+
+    wasm_module = ITWC.compile(program, [ITWC::FunctionSignature.new(label: "_start", param_count: 0, export_name: "_start")])
+
+    assert_equal ["fd_write"], wasm_module.imports.map(&:name)
+    assert_equal 1, wasm_module.memories.length
+    assert_includes wasm_module.exports.map(&:name), "memory"
+    assert_includes wasm_module.exports.map(&:name), "_start"
+  end
+
+  def test_rejects_unsupported_syscalls
+    program = IR::IrProgram.new("_start")
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::LABEL, [IR::IrLabel.new("_start")], -1))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::SYSCALL, [IR::IrImmediate.new(99)], 0))
+
+    error = assert_raises(ITWC::WasmLoweringError) do
+      ITWC.compile(program, [ITWC::FunctionSignature.new(label: "_start", param_count: 0, export_name: "_start")])
+    end
+
+    assert_match(/unsupported SYSCALL/, error.message)
+  end
+
+  def test_lowers_memory_arithmetic_and_all_supported_syscalls
+    program = IR::IrProgram.new("_start")
+    program.add_data(IR::IrDataDecl.new("tape", 16, 0))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::LABEL, [IR::IrLabel.new("_start")], -1))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::LOAD_ADDR, [IR::IrRegister.new(0), IR::IrLabel.new("tape")], 0))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::LOAD_IMM, [IR::IrRegister.new(1), IR::IrImmediate.new(0)], 1))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::LOAD_IMM, [IR::IrRegister.new(2), IR::IrImmediate.new(65)], 2))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::STORE_BYTE, [IR::IrRegister.new(2), IR::IrRegister.new(0), IR::IrRegister.new(1)], 3))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::LOAD_BYTE, [IR::IrRegister.new(3), IR::IrRegister.new(0), IR::IrRegister.new(1)], 4))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::STORE_WORD, [IR::IrRegister.new(3), IR::IrRegister.new(0), IR::IrRegister.new(1)], 5))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::LOAD_WORD, [IR::IrRegister.new(4), IR::IrRegister.new(0), IR::IrRegister.new(1)], 6))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::ADD, [IR::IrRegister.new(5), IR::IrRegister.new(2), IR::IrRegister.new(3)], 7))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::ADD_IMM, [IR::IrRegister.new(6), IR::IrRegister.new(5), IR::IrImmediate.new(1)], 8))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::SUB, [IR::IrRegister.new(7), IR::IrRegister.new(6), IR::IrRegister.new(2)], 9))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::AND, [IR::IrRegister.new(8), IR::IrRegister.new(6), IR::IrRegister.new(7)], 10))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::AND_IMM, [IR::IrRegister.new(9), IR::IrRegister.new(8), IR::IrImmediate.new(255)], 11))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::CMP_EQ, [IR::IrRegister.new(10), IR::IrRegister.new(2), IR::IrRegister.new(3)], 12))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::CMP_NE, [IR::IrRegister.new(11), IR::IrRegister.new(2), IR::IrRegister.new(3)], 13))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::CMP_LT, [IR::IrRegister.new(12), IR::IrRegister.new(1), IR::IrRegister.new(2)], 14))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::CMP_GT, [IR::IrRegister.new(13), IR::IrRegister.new(2), IR::IrRegister.new(1)], 15))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::NOP, [], 16))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::LOAD_IMM, [IR::IrRegister.new(4), IR::IrImmediate.new(65)], 17))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::SYSCALL, [IR::IrImmediate.new(1)], 18))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::SYSCALL, [IR::IrImmediate.new(2)], 19))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::LOAD_IMM, [IR::IrRegister.new(4), IR::IrImmediate.new(0)], 20))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::SYSCALL, [IR::IrImmediate.new(10)], 21))
+
+    wasm_module = ITWC.compile(program, [ITWC::FunctionSignature.new(label: "_start", param_count: 0, export_name: "_start")])
+
+    assert_equal %w[fd_write fd_read proc_exit], wasm_module.imports.map(&:name)
+    assert_equal 1, wasm_module.memories.length
+    assert_equal 1, wasm_module.data.length
+    assert_operator wasm_module.code.first.code.bytesize, :>, 20
+  end
+
+  def test_lowers_structured_if_and_loop_patterns
+    program = IR::IrProgram.new("_start")
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::LABEL, [IR::IrLabel.new("_start")], -1))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::LOAD_IMM, [IR::IrRegister.new(2), IR::IrImmediate.new(1)], 0))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::BRANCH_Z, [IR::IrRegister.new(2), IR::IrLabel.new("if_0_else")], 1))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::NOP, [], 2))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::JUMP, [IR::IrLabel.new("if_0_end")], 3))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::LABEL, [IR::IrLabel.new("if_0_else")], -1))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::NOP, [], 4))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::LABEL, [IR::IrLabel.new("if_0_end")], -1))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::LABEL, [IR::IrLabel.new("loop_0_start")], -1))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::NOP, [], 5))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::BRANCH_Z, [IR::IrRegister.new(2), IR::IrLabel.new("loop_0_end")], 6))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::NOP, [], 7))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::JUMP, [IR::IrLabel.new("loop_0_start")], 8))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::LABEL, [IR::IrLabel.new("loop_0_end")], -1))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::HALT, [], 9))
+
+    wasm_module = ITWC.compile(program, [ITWC::FunctionSignature.new(label: "_start", param_count: 0, export_name: "_start")])
+
+    assert_equal 1, wasm_module.code.length
+    assert_includes wasm_module.code.first.code.bytes, ITWC::OPCODE["if"]
+    assert_includes wasm_module.code.first.code.bytes, ITWC::OPCODE["loop"]
+    assert_includes wasm_module.code.first.code.bytes, ITWC::OPCODE["br_if"]
+  end
+
+  def test_lowers_calls_and_infers_callee_signature_from_comment
+    program = IR::IrProgram.new("_start")
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::COMMENT, [IR::IrLabel.new("function:callee(a)")], 0))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::LABEL, [IR::IrLabel.new("_fn_callee")], -1))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::LOAD_IMM, [IR::IrRegister.new(1), IR::IrImmediate.new(7)], 1))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::RET, [], 2))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::LABEL, [IR::IrLabel.new("_start")], -1))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::LOAD_IMM, [IR::IrRegister.new(2), IR::IrImmediate.new(42)], 3))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::CALL, [IR::IrLabel.new("_fn_callee")], 4))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::HALT, [], 5))
+
+    wasm_module = ITWC.compile(program)
+
+    assert_equal 2, wasm_module.functions.length
+    assert_includes wasm_module.exports.map(&:name), "callee"
+    assert_includes wasm_module.exports.map(&:name), "_start"
+  end
+
+  def test_exposes_helper_primitives_and_validation_errors
+    assert_equal 8, ITWC.align_up(5, 4)
+    assert_equal "_start", ITWC.function_label_name(IR::IrInstruction.new(IR::IrOp::LABEL, [IR::IrLabel.new("_start")], -1))
+    assert_nil ITWC.function_label_name(IR::IrInstruction.new(IR::IrOp::LABEL, [IR::IrLabel.new("plain")], -1))
+    assert_equal "plain", ITWC.label_name_from_operand(IR::IrLabel.new("plain"))
+    assert_equal [ITWC::OPCODE["i32.const"], 0x00, ITWC::OPCODE["end"]], ITWC.const_expr(0).bytes
+
+    error = assert_raises(ITWC::WasmLoweringError) do
+      ITWC.expect_register(IR::IrImmediate.new(1), "bad register")
+    end
+    assert_match(/expected register/, error.message)
+
+    error = assert_raises(ITWC::WasmLoweringError) do
+      ITWC.expect_immediate(IR::IrLabel.new("x"), "bad immediate")
+    end
+    assert_match(/expected immediate/, error.message)
+
+    error = assert_raises(ITWC::WasmLoweringError) do
+      ITWC.expect_label(IR::IrRegister.new(1), "bad label")
+    end
+    assert_match(/expected label/, error.message)
+
+    error = assert_raises(ITWC::WasmLoweringError) do
+      ITWC.make_function_ir(
+        label: "_fn_missing",
+        instructions: [IR::IrInstruction.new(IR::IrOp::LABEL, [IR::IrLabel.new("_fn_missing")], -1)],
+        signatures: {}
+      )
+    end
+    assert_match(/missing function signature/, error.message)
+  end
+end

--- a/code/packages/ruby/ir_to_wasm_validator/BUILD
+++ b/code/packages/ruby/ir_to_wasm_validator/BUILD
@@ -1,0 +1,3 @@
+bundle config set path vendor/bundle
+bundle install --quiet
+bundle exec rake test

--- a/code/packages/ruby/ir_to_wasm_validator/CHANGELOG.md
+++ b/code/packages/ruby/ir_to_wasm_validator/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial IR-to-WASM compatibility validator for Ruby.

--- a/code/packages/ruby/ir_to_wasm_validator/Gemfile
+++ b/code/packages/ruby/ir_to_wasm_validator/Gemfile
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+gemspec
+
+gem "coding_adventures_ir_to_wasm_compiler", path: "../ir_to_wasm_compiler"
+gem "coding_adventures_compiler_ir", path: "../compiler-ir"
+gem "coding_adventures_wasm_leb128", path: "../wasm_leb128"
+gem "coding_adventures_wasm_opcodes", path: "../wasm_opcodes"
+gem "coding_adventures_wasm_types", path: "../wasm_types"

--- a/code/packages/ruby/ir_to_wasm_validator/README.md
+++ b/code/packages/ruby/ir_to_wasm_validator/README.md
@@ -1,0 +1,3 @@
+# coding_adventures_ir_to_wasm_validator
+
+Validates whether generic compiler IR can be lowered into the Ruby WebAssembly backend.

--- a/code/packages/ruby/ir_to_wasm_validator/Rakefile
+++ b/code/packages/ruby/ir_to_wasm_validator/Rakefile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rake/testtask"
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList["test/**/test_*.rb"]
+end
+
+task default: :test

--- a/code/packages/ruby/ir_to_wasm_validator/coding_adventures_ir_to_wasm_validator.gemspec
+++ b/code/packages/ruby/ir_to_wasm_validator/coding_adventures_ir_to_wasm_validator.gemspec
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative "lib/coding_adventures/ir_to_wasm_validator/version"
+
+Gem::Specification.new do |spec|
+  spec.name          = "coding_adventures_ir_to_wasm_validator"
+  spec.version       = CodingAdventures::IrToWasmValidator::VERSION
+  spec.authors       = ["Adhithya Rajasekaran"]
+  spec.summary       = "Validator for IR-to-WASM lowering compatibility"
+  spec.description   = "Runs the IR-to-WASM compiler in validation mode and reports lowering errors without requiring a full packaging step."
+  spec.homepage      = "https://github.com/adhithyan15/coding-adventures"
+  spec.license       = "MIT"
+  spec.required_ruby_version = ">= 3.4.0"
+  spec.files         = Dir["lib/**/*.rb", "README.md", "CHANGELOG.md"]
+  spec.require_paths = ["lib"]
+  spec.metadata      = {
+    "source_code_uri" => "https://github.com/adhithyan15/coding-adventures",
+    "rubygems_mfa_required" => "true"
+  }
+
+  spec.add_dependency "coding_adventures_ir_to_wasm_compiler", "~> 0.1"
+  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "simplecov", "~> 0.22"
+  spec.add_development_dependency "rake", "~> 13.0"
+end

--- a/code/packages/ruby/ir_to_wasm_validator/lib/coding_adventures/ir_to_wasm_validator/validator.rb
+++ b/code/packages/ruby/ir_to_wasm_validator/lib/coding_adventures/ir_to_wasm_validator/validator.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module IrToWasmValidator
+    ValidationIssue = Struct.new(:rule, :message, keyword_init: true)
+
+    class WasmIrValidator
+      def validate(program, function_signatures = nil)
+        CodingAdventures::IrToWasmCompiler.compile(program, function_signatures)
+        []
+      rescue CodingAdventures::IrToWasmCompiler::WasmLoweringError => error
+        [ValidationIssue.new(rule: "lowering", message: error.message)]
+      end
+    end
+
+    module_function
+
+    def validate(program, function_signatures = nil)
+      WasmIrValidator.new.validate(program, function_signatures)
+    end
+  end
+end

--- a/code/packages/ruby/ir_to_wasm_validator/lib/coding_adventures/ir_to_wasm_validator/version.rb
+++ b/code/packages/ruby/ir_to_wasm_validator/lib/coding_adventures/ir_to_wasm_validator/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module IrToWasmValidator
+    VERSION = "0.1.0"
+  end
+end

--- a/code/packages/ruby/ir_to_wasm_validator/lib/coding_adventures_ir_to_wasm_validator.rb
+++ b/code/packages/ruby/ir_to_wasm_validator/lib/coding_adventures_ir_to_wasm_validator.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "coding_adventures_ir_to_wasm_compiler"
+
+require_relative "coding_adventures/ir_to_wasm_validator/version"
+require_relative "coding_adventures/ir_to_wasm_validator/validator"
+
+module CodingAdventures
+  module IrToWasmValidator
+  end
+end

--- a/code/packages/ruby/ir_to_wasm_validator/test/test_helper.rb
+++ b/code/packages/ruby/ir_to_wasm_validator/test/test_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "simplecov"
+SimpleCov.start do
+  enable_coverage :branch
+  minimum_coverage 80
+end
+
+require "minitest/autorun"
+require "coding_adventures_ir_to_wasm_validator"
+
+IR = CodingAdventures::CompilerIr
+ITWV = CodingAdventures::IrToWasmValidator
+ITWC = CodingAdventures::IrToWasmCompiler

--- a/code/packages/ruby/ir_to_wasm_validator/test/test_ir_to_wasm_validator.rb
+++ b/code/packages/ruby/ir_to_wasm_validator/test/test_ir_to_wasm_validator.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class TestIrToWasmValidator < Minitest::Test
+  def test_returns_empty_for_lowerable_program
+    program = IR::IrProgram.new("_start")
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::LABEL, [IR::IrLabel.new("_start")], -1))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::HALT, [], 0))
+
+    issues = ITWV.validate(program, [ITWC::FunctionSignature.new(label: "_start", param_count: 0, export_name: "_start")])
+
+    assert_empty issues
+  end
+
+  def test_returns_issue_for_unsupported_syscall
+    program = IR::IrProgram.new("_start")
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::LABEL, [IR::IrLabel.new("_start")], -1))
+    program.add_instruction(IR::IrInstruction.new(IR::IrOp::SYSCALL, [IR::IrImmediate.new(99)], 0))
+
+    issues = ITWV.validate(program, [ITWC::FunctionSignature.new(label: "_start", param_count: 0, export_name: "_start")])
+
+    assert_equal 1, issues.length
+    assert_equal "lowering", issues.first.rule
+    assert_match(/unsupported SYSCALL/, issues.first.message)
+  end
+end

--- a/code/packages/ruby/wasm_execution/lib/coding_adventures/wasm_execution/instructions/control.rb
+++ b/code/packages/ruby/wasm_execution/lib/coding_adventures/wasm_execution/instructions/control.rb
@@ -180,9 +180,17 @@ module CodingAdventures
               vm.advance_pc
               "end (block)"
             else
-              ctx[:returned] = true
-              vm.halted = true
-              "end (function)"
+              # Branches can legally jump to a block's `end` instruction after
+              # its label has already been popped. Only the final `end` of the
+              # function should stop execution.
+              if vm.pc >= ctx[:current_instructions].length - 1
+                ctx[:returned] = true
+                vm.halted = true
+                "end (function)"
+              else
+                vm.advance_pc
+                "end (continue)"
+              end
             end
           })
 

--- a/code/packages/ruby/wasm_module_encoder/BUILD
+++ b/code/packages/ruby/wasm_module_encoder/BUILD
@@ -1,0 +1,3 @@
+bundle config set path vendor/bundle
+bundle install --quiet
+bundle exec rake test

--- a/code/packages/ruby/wasm_module_encoder/CHANGELOG.md
+++ b/code/packages/ruby/wasm_module_encoder/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial WebAssembly module encoder for Ruby.

--- a/code/packages/ruby/wasm_module_encoder/Gemfile
+++ b/code/packages/ruby/wasm_module_encoder/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+gemspec
+
+gem "coding_adventures_wasm_leb128", path: "../wasm_leb128"
+gem "coding_adventures_wasm_types", path: "../wasm_types"

--- a/code/packages/ruby/wasm_module_encoder/README.md
+++ b/code/packages/ruby/wasm_module_encoder/README.md
@@ -1,0 +1,3 @@
+# coding_adventures_wasm_module_encoder
+
+Encodes `CodingAdventures::WasmTypes::WasmModule` values into raw `.wasm` bytes.

--- a/code/packages/ruby/wasm_module_encoder/Rakefile
+++ b/code/packages/ruby/wasm_module_encoder/Rakefile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rake/testtask"
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList["test/**/test_*.rb"]
+end
+
+task default: :test

--- a/code/packages/ruby/wasm_module_encoder/coding_adventures_wasm_module_encoder.gemspec
+++ b/code/packages/ruby/wasm_module_encoder/coding_adventures_wasm_module_encoder.gemspec
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative "lib/coding_adventures/wasm_module_encoder/version"
+
+Gem::Specification.new do |spec|
+  spec.name          = "coding_adventures_wasm_module_encoder"
+  spec.version       = CodingAdventures::WasmModuleEncoder::VERSION
+  spec.authors       = ["Adhithya Rajasekaran"]
+  spec.summary       = "WebAssembly 1.0 module encoder"
+  spec.description   = "Encodes CodingAdventures::WasmTypes::WasmModule values into raw WebAssembly bytes."
+  spec.homepage      = "https://github.com/adhithyan15/coding-adventures"
+  spec.license       = "MIT"
+  spec.required_ruby_version = ">= 3.4.0"
+  spec.files         = Dir["lib/**/*.rb", "README.md", "CHANGELOG.md"]
+  spec.require_paths = ["lib"]
+  spec.metadata      = {
+    "source_code_uri" => "https://github.com/adhithyan15/coding-adventures",
+    "rubygems_mfa_required" => "true"
+  }
+
+  spec.add_dependency "coding_adventures_wasm_leb128", "~> 0.1"
+  spec.add_dependency "coding_adventures_wasm_types", "~> 0.1"
+  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "simplecov", "~> 0.22"
+  spec.add_development_dependency "rake", "~> 13.0"
+end

--- a/code/packages/ruby/wasm_module_encoder/lib/coding_adventures/wasm_module_encoder/encoder.rb
+++ b/code/packages/ruby/wasm_module_encoder/lib/coding_adventures/wasm_module_encoder/encoder.rb
@@ -1,0 +1,221 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module WasmModuleEncoder
+    class WasmEncodeError < StandardError; end
+
+    WASM_MAGIC = "\0asm".b
+    WASM_VERSION = [0x01, 0x00, 0x00, 0x00].pack("C*").b
+
+    IMPORT_KIND_BY_NAME = {
+      func: 0,
+      function: 0,
+      table: 1,
+      mem: 2,
+      memory: 2,
+      global: 3
+    }.freeze
+
+    module_function
+
+    def encode_module(wasm_module)
+      sections = +"".b
+
+      (wasm_module.customs || []).each do |custom|
+        sections << section(0, encode_custom(custom))
+      end
+      sections << section(1, encode_vector(wasm_module.types, method(:encode_func_type))) if wasm_module.types.any?
+      sections << section(2, encode_vector(wasm_module.imports, method(:encode_import))) if wasm_module.imports.any?
+      sections << section(3, encode_vector(wasm_module.functions, method(:u32))) if wasm_module.functions.any?
+      sections << section(4, encode_vector(wasm_module.tables, method(:encode_table_type))) if wasm_module.tables.any?
+      sections << section(5, encode_vector(wasm_module.memories, method(:encode_memory_type))) if wasm_module.memories.any?
+      sections << section(6, encode_vector(wasm_module.globals, method(:encode_global))) if wasm_module.globals.any?
+      sections << section(7, encode_vector(wasm_module.exports, method(:encode_export))) if wasm_module.exports.any?
+      sections << section(8, u32(wasm_module.start)) unless wasm_module.start.nil?
+      sections << section(9, encode_vector(wasm_module.elements, method(:encode_element))) if wasm_module.elements.any?
+      sections << section(10, encode_vector(wasm_module.code, method(:encode_function_body))) if wasm_module.code.any?
+      sections << section(11, encode_vector(wasm_module.data, method(:encode_data_segment))) if wasm_module.data.any?
+
+      WASM_MAGIC + WASM_VERSION + sections
+    end
+
+    def section(section_id, payload)
+      [section_id].pack("C") + u32(payload.bytesize) + payload
+    end
+
+    def u32(value)
+      CodingAdventures::WasmLeb128.encode_unsigned(value)
+    end
+
+    def encode_name(text)
+      utf8 = text.encode("UTF-8")
+      u32(utf8.bytesize) + utf8.b
+    end
+
+    def encode_vector(values, encoder)
+      values.reduce(u32(values.length)) { |bytes, value| bytes << encoder.call(value) }
+    end
+
+    def encode_value_types(types)
+      u32(types.length) + types.pack("C*")
+    end
+
+    def encode_func_type(func_type)
+      [0x60].pack("C") +
+        encode_value_types(func_type.params || []) +
+        encode_value_types(func_type.results || [])
+    end
+
+    def encode_limits(limits)
+      if limits.max.nil?
+        [0x00].pack("C") + u32(limits.min)
+      else
+        [0x01].pack("C") + u32(limits.min) + u32(limits.max)
+      end
+    end
+
+    def encode_memory_type(memory_type)
+      encode_limits(memory_type.limits || memory_type)
+    end
+
+    def encode_table_type(table_type)
+      [table_type.element_type || table_type.ref_type].pack("C") + encode_limits(table_type.limits)
+    end
+
+    def encode_global_type(global_type)
+      [
+        global_type.value_type || global_type.val_type,
+        global_type.mutable ? 0x01 : 0x00
+      ].pack("C*")
+    end
+
+    def encode_import(import_value)
+      kind = kind_byte(import_value.kind || import_value.desc&.kind)
+      payload = +"".b
+      payload << encode_name(import_value.module_name || import_value.mod)
+      payload << encode_name(import_value.name)
+      payload << [kind].pack("C")
+
+      case kind
+      when 0
+        type_index = optional_attr(import_value, :type_index) ||
+          optional_attr(import_value, :type_info) ||
+          optional_attr(import_value, :typeInfo) ||
+          import_value.desc&.type_idx
+        raise WasmEncodeError, "function imports require an integer type index" unless type_index.is_a?(Integer)
+
+        payload << u32(type_index)
+      when 1
+        table_type = optional_attr(import_value, :type_info) || optional_attr(import_value, :typeInfo)
+        table_type ||= CodingAdventures::WasmTypes::TableType.new(import_value.desc.ref_type, import_value.desc.limits) if import_value.respond_to?(:desc) && import_value.desc
+        raise WasmEncodeError, "table imports require TableType metadata" unless table_type
+
+        payload << encode_table_type(table_type)
+      when 2
+        memory_type = optional_attr(import_value, :type_info) || optional_attr(import_value, :typeInfo)
+        memory_type ||= CodingAdventures::WasmTypes::MemoryType.new(import_value.desc.limits) if import_value.respond_to?(:desc) && import_value.desc
+        raise WasmEncodeError, "memory imports require MemoryType metadata" unless memory_type
+
+        payload << encode_memory_type(memory_type)
+      when 3
+        global_type = optional_attr(import_value, :type_info) || optional_attr(import_value, :typeInfo)
+        if global_type.nil? && import_value.respond_to?(:desc) && import_value.desc
+          global_type = CodingAdventures::WasmTypes::GlobalType.new(import_value.desc.val_type, import_value.desc.mutable)
+        end
+        raise WasmEncodeError, "global imports require GlobalType metadata" unless global_type
+
+        payload << encode_global_type(global_type)
+      else
+        raise WasmEncodeError, "unsupported import kind: #{import_value.kind.inspect}"
+      end
+
+      payload
+    end
+
+    def encode_export(export_value)
+      kind = kind_byte(export_value.kind || export_value.desc&.kind)
+      index = export_value.index
+      index = export_value.desc.idx if export_value.respond_to?(:desc) && export_value.desc
+
+      encode_name(export_value.name) + [kind].pack("C") + u32(index)
+    end
+
+    def encode_global(global_value)
+      encode_global_type(global_value.global_type || global_value.type_info || global_value) +
+        bytes_from_value(global_value.init_expr || global_value.init)
+    end
+
+    def encode_element(element)
+      payload = +"".b
+      payload << u32(element.table_index)
+      payload << bytes_from_value(element.offset_expr)
+      payload << u32((element.function_indices || []).length)
+      (element.function_indices || []).each do |func_index|
+        payload << u32(func_index)
+      end
+      payload
+    end
+
+    def encode_data_segment(segment)
+      data = bytes_from_value(segment.data)
+      u32(segment.memory_index) + bytes_from_value(segment.offset_expr) + u32(data.bytesize) + data
+    end
+
+    def encode_function_body(body)
+      local_groups = group_locals(body.locals || [])
+      payload = +"".b
+      payload << u32(local_groups.length)
+      local_groups.each do |count, value_type|
+        payload << u32(count)
+        payload << [value_type].pack("C")
+      end
+      payload << bytes_from_value(body.code || body.body)
+      u32(payload.bytesize) + payload
+    end
+
+    def group_locals(locals_)
+      return [] if locals_.empty?
+
+      groups = []
+      current_type = locals_.first
+      count = 1
+
+      locals_[1..].each do |value_type|
+        if value_type == current_type
+          count += 1
+        else
+          groups << [count, current_type]
+          current_type = value_type
+          count = 1
+        end
+      end
+      groups << [count, current_type]
+      groups
+    end
+
+    def encode_custom(custom)
+      encode_name(custom.name) + bytes_from_value(custom.data)
+    end
+
+    def kind_byte(kind)
+      return kind if kind.is_a?(Integer)
+
+      mapped = IMPORT_KIND_BY_NAME[kind]
+      raise WasmEncodeError, "unsupported external kind: #{kind.inspect}" if mapped.nil?
+
+      mapped
+    end
+
+    def bytes_from_value(value)
+      return +"".b if value.nil?
+      return value.b if value.is_a?(String)
+      return value.pack("C*").b if value.is_a?(Array)
+
+      value.to_s.b
+    end
+
+    def optional_attr(object, name)
+      object.public_send(name) if object.respond_to?(name)
+    end
+  end
+end

--- a/code/packages/ruby/wasm_module_encoder/lib/coding_adventures/wasm_module_encoder/version.rb
+++ b/code/packages/ruby/wasm_module_encoder/lib/coding_adventures/wasm_module_encoder/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module WasmModuleEncoder
+    VERSION = "0.1.0"
+  end
+end

--- a/code/packages/ruby/wasm_module_encoder/lib/coding_adventures_wasm_module_encoder.rb
+++ b/code/packages/ruby/wasm_module_encoder/lib/coding_adventures_wasm_module_encoder.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "coding_adventures_wasm_leb128"
+require "coding_adventures_wasm_types"
+
+require_relative "coding_adventures/wasm_module_encoder/version"
+require_relative "coding_adventures/wasm_module_encoder/encoder"
+
+module CodingAdventures
+  module WasmModuleEncoder
+  end
+end

--- a/code/packages/ruby/wasm_module_encoder/test/test_helper.rb
+++ b/code/packages/ruby/wasm_module_encoder/test/test_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "simplecov"
+SimpleCov.start do
+  enable_coverage :branch
+  minimum_coverage 80
+end
+
+require "minitest/autorun"
+require "coding_adventures_wasm_module_encoder"
+
+WT = CodingAdventures::WasmTypes
+WME = CodingAdventures::WasmModuleEncoder

--- a/code/packages/ruby/wasm_module_encoder/test/test_wasm_module_encoder.rb
+++ b/code/packages/ruby/wasm_module_encoder/test/test_wasm_module_encoder.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class TestWasmModuleEncoder < Minitest::Test
+  def test_encodes_minimal_exported_function_module
+    wasm_module = WT::WasmModule.new
+    wasm_module.types << WT::FuncType.new([], [WT::VALUE_TYPE[:i32]])
+    wasm_module.functions << 0
+    wasm_module.exports << WT::Export.new("_start", WT::EXTERNAL_KIND[:function], 0)
+    wasm_module.code << WT::FunctionBody.new([], [0x41, 0x00, 0x0B].pack("C*"))
+
+    encoded = WME.encode_module(wasm_module)
+
+    assert_equal WME::WASM_MAGIC, encoded[0, 4]
+    assert_equal WME::WASM_VERSION, encoded[4, 4]
+    assert_operator encoded.bytesize, :>, 8
+  end
+
+  def test_encodes_imports_memory_and_data_segments
+    wasm_module = WT::WasmModule.new
+    wasm_module.types << WT::FuncType.new([WT::VALUE_TYPE[:i32]], [WT::VALUE_TYPE[:i32]])
+    wasm_module.imports << WT::Import.new(
+      "wasi_snapshot_preview1",
+      "fd_write",
+      WT::EXTERNAL_KIND[:function],
+      0
+    )
+    wasm_module.memories << WT::MemoryType.new(WT::Limits.new(1, nil))
+    wasm_module.data << WT::DataSegment.new(0, [0x41, 0x00, 0x0B].pack("C*"), "A".b)
+
+    encoded = WME.encode_module(wasm_module)
+
+    assert_includes encoded, "wasi_snapshot_preview1"
+    assert_includes encoded, "fd_write"
+    assert_includes encoded, "A"
+  end
+
+  def test_groups_repeated_locals_in_function_body
+    body = WT::FunctionBody.new(
+      [WT::VALUE_TYPE[:i32], WT::VALUE_TYPE[:i32], WT::VALUE_TYPE[:i64]],
+      [0x0B].pack("C*")
+    )
+
+    encoded = WME.send(:encode_function_body, body)
+
+    assert_operator encoded.bytesize, :>, body.code.bytesize
+  end
+
+  def test_rejects_function_import_without_type_index
+    wasm_module = WT::WasmModule.new
+    wasm_module.types << WT::FuncType.new([], [])
+    wasm_module.imports << WT::Import.new("env", "f", WT::EXTERNAL_KIND[:function], WT::MemoryType.new(WT::Limits.new(1, nil)))
+
+    error = assert_raises(WME::WasmEncodeError) do
+      WME.encode_module(wasm_module)
+    end
+
+    assert_match(/type index/, error.message)
+  end
+
+  def test_encodes_table_global_and_start_sections
+    wasm_module = WT::WasmModule.new
+    wasm_module.types << WT::FuncType.new([], [WT::VALUE_TYPE[:i32]])
+    wasm_module.functions << 0
+    wasm_module.tables << WT::TableType.new(WT::FUNCREF, WT::Limits.new(1, nil))
+    wasm_module.globals << WT::Global.new(
+      WT::GlobalType.new(WT::VALUE_TYPE[:i32], false),
+      [0x41, 0x2A, 0x0B].pack("C*")
+    )
+    wasm_module.start = 0
+    wasm_module.code << WT::FunctionBody.new([], [0x41, 0x00, 0x0B].pack("C*"))
+
+    encoded = WME.encode_module(wasm_module)
+
+    assert_operator encoded.bytesize, :>, 8
+    assert_includes encoded.bytes, 0x08
+  end
+end

--- a/code/packages/ruby/wasm_runtime/test/test_runtime.rb
+++ b/code/packages/ruby/wasm_runtime/test/test_runtime.rb
@@ -175,6 +175,56 @@ class TestRuntime < Minitest::Test
     parts.pack("C*")
   end
 
+  # Build a function that branches to a block end and then continues with
+  # more instructions before the final function end.
+  def build_branch_to_end_then_continue_wasm
+    parts = []
+    parts.push(0x00, 0x61, 0x73, 0x6D)
+    parts.push(0x01, 0x00, 0x00, 0x00)
+
+    # Type section: () -> (i32)
+    type_payload = [0x01, 0x60, 0x00, 0x01, 0x7F]
+    parts.push(0x01)
+    parts.concat(encode_unsigned(type_payload.length))
+    parts.concat(type_payload)
+
+    # Function section
+    func_payload = [0x01, 0x00]
+    parts.push(0x03)
+    parts.concat(encode_unsigned(func_payload.length))
+    parts.concat(func_payload)
+
+    # Export section
+    name_bytes = "branch_then_continue".bytes
+    export_payload = [
+      0x01,
+      *encode_unsigned(name_bytes.length),
+      *name_bytes,
+      0x00, 0x00
+    ]
+    parts.push(0x07)
+    parts.concat(encode_unsigned(export_payload.length))
+    parts.concat(export_payload)
+
+    # Code:
+    #   block
+    #     i32.const 1
+    #     br_if 0
+    #     unreachable
+    #   end
+    #   i32.const 7
+    #   end
+    body_code = [0x02, 0x40, 0x41, 0x01, 0x0D, 0x00, 0x00, 0x0B, 0x41, 0x07, 0x0B]
+    body_payload = [0x00, *body_code]
+    func_body = [*encode_unsigned(body_payload.length), *body_payload]
+    code_payload = [0x01, *func_body]
+    parts.push(0x0A)
+    parts.concat(encode_unsigned(code_payload.length))
+    parts.concat(code_payload)
+
+    parts.pack("C*")
+  end
+
   # ── Load and Parse ─────────────────────────────────────────────────
 
   def test_load_returns_wasm_module
@@ -261,6 +311,12 @@ class TestRuntime < Minitest::Test
     runtime = WR::Runtime.new
     result = runtime.load_and_run(build_add_wasm, "add", [100, 200])
     assert_equal [300], result
+  end
+
+  def test_branch_to_non_final_end_continues_execution
+    runtime = WR::Runtime.new
+    result = runtime.load_and_run(build_branch_to_end_then_continue_wasm, "branch_then_continue", [])
+    assert_equal [7], result
   end
 
   # ── Error Paths ────────────────────────────────────────────────────


### PR DESCRIPTION
## What changed

This adds the missing Ruby Brainfuck -> WASM backend family:

- `ruby/wasm_module_encoder`
- `ruby/ir_to_wasm_compiler`
- `ruby/ir_to_wasm_validator`
- `ruby/brainfuck_wasm_compiler`

It also patches the shared Ruby WASM control-flow runtime path so branches that land on a non-final `end` continue execution instead of halting the function early.

## Why

Lua already proved the generic Brainfuck -> IR -> WASM pipeline shape. Ruby had the Brainfuck frontend and the WASM runtime pieces, but it was still missing the generic backend family that turns IR into runnable `.wasm` binaries.

The new end-to-end Ruby tests exposed the same structured-control-flow edge case that Lua hit earlier, so the PR fixes that at the shared runtime layer and adds a regression test there.

## Impact

Ruby can now:

- validate whether generic IR is lowerable to WASM
- lower generic IR into a real WASM module
- encode that module into `.wasm` bytes
- compile Brainfuck source through the generic pipeline and run it in the Ruby WASM runtime

This keeps the repo moving toward consistent multi-language pipeline parity instead of bespoke per-language backends.

## Validation

I ran:

- `bash BUILD` in `code/packages/ruby/wasm_module_encoder`
- `bash BUILD` in `code/packages/ruby/ir_to_wasm_compiler`
- `bash BUILD` in `code/packages/ruby/ir_to_wasm_validator`
- `bash BUILD` in `code/packages/ruby/brainfuck_wasm_compiler`
- `bash BUILD` in `code/packages/ruby/wasm_runtime`
- `bash BUILD` in `code/packages/ruby/wasm_execution`

Coverage/results:

- `wasm_module_encoder`: 83.52% line coverage
- `ir_to_wasm_compiler`: 98.32% line coverage
- `ir_to_wasm_validator`: 100% line coverage
- `brainfuck_wasm_compiler`: 90.63% line coverage
- `wasm_runtime`: 69 tests passed
- `wasm_execution`: 276 tests passed

The important end-to-end path is covered by the Ruby Brainfuck WASM tests, including the `,[.,]` cat-style program running through the runtime.