### PR TITLE
[codex] add JVM mini-redis AOF persistence

### DIFF
--- a/code/packages/java/in-memory-data-store/CHANGELOG.md
+++ b/code/packages/java/in-memory-data-store/CHANGELOG.md
@@ -7,3 +7,4 @@ All notable changes to this package will be documented in this file.
 ### Added
 
 - Initial JVM mini-redis core package
+- RESP-backed AOF persistence and replay support for durable manager instances

--- a/code/packages/java/in-memory-data-store/README.md
+++ b/code/packages/java/in-memory-data-store/README.md
@@ -2,6 +2,15 @@
 
 Composable JVM in-memory data store facade
 
+The package exposes a RESP-facing `DataStoreManager` on top of the shared
+engine and protocol layers. It can be used in pure in-memory mode or with an
+append-only file (AOF) path for command replay across restarts.
+
+```java
+DataStoreManager manager = new DataStoreManager();
+DataStoreManager durable = new DataStoreManager(Path.of("appendonly.aof"));
+```
+
 ## Development
 
 ```bash

--- a/code/packages/java/in-memory-data-store/src/main/java/com/codingadventures/inmemorydatastore/DataStoreManager.java
+++ b/code/packages/java/in-memory-data-store/src/main/java/com/codingadventures/inmemorydatastore/DataStoreManager.java
@@ -6,13 +6,56 @@ import com.codingadventures.inmemorydatastoreprotocol.EngineResponse;
 import com.codingadventures.respprotocol.RespCodec;
 import com.codingadventures.respprotocol.RespValue;
 
+import java.io.Closeable;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
-public final class DataStoreManager {
-    private final DataStoreEngine engine = new DataStoreEngine();
+public final class DataStoreManager implements Closeable {
+    private static final Set<String> AOF_COMMANDS = Set.of(
+            "SET", "DEL", "RENAME", "INCR", "DECR", "INCRBY", "DECRBY", "APPEND",
+            "HSET", "HDEL", "LPUSH", "RPUSH", "LPOP", "RPOP",
+            "SADD", "SREM", "ZADD", "ZREM", "PFADD", "PFMERGE",
+            "EXPIRE", "EXPIREAT", "PERSIST", "SELECT", "FLUSHDB", "FLUSHALL"
+    );
+
+    private final DataStoreEngine engine;
+    private final FileOutputStream aofStream;
+    private final AofSyncPolicy aofSyncPolicy;
+
+    public DataStoreManager() {
+        this.engine = new DataStoreEngine();
+        this.aofStream = null;
+        this.aofSyncPolicy = AofSyncPolicy.ALWAYS;
+    }
+
+    public DataStoreManager(Path aofPath) throws IOException {
+        this(aofPath, AofSyncPolicy.ALWAYS);
+    }
+
+    public DataStoreManager(Path aofPath, AofSyncPolicy aofSyncPolicy) throws IOException {
+        this.engine = new DataStoreEngine();
+        this.aofSyncPolicy = aofSyncPolicy;
+        replayAof(aofPath);
+        Path parent = aofPath.toAbsolutePath().getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+        this.aofStream = new FileOutputStream(
+                aofPath.toFile(),
+                true
+        );
+    }
 
     public EngineResponse executeFrame(CommandFrame frame) {
-        return engine.executeFrame(frame);
+        EngineResponse response = engine.executeFrame(frame);
+        appendToAof(frame, response);
+        return response;
     }
 
     public EngineResponse executeParts(List<byte[]> parts) {
@@ -30,5 +73,72 @@ public final class DataStoreManager {
 
     public RespValue executeRespValue(RespValue value) {
         return executeFrame(CommandFrame.fromRespValue(value)).toRespValue();
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (aofStream != null) {
+            aofStream.close();
+        }
+    }
+
+    private void replayAof(Path aofPath) throws IOException {
+        if (!Files.exists(aofPath)) {
+            return;
+        }
+        byte[] bytes = Files.readAllBytes(aofPath);
+        int offset = 0;
+        while (offset < bytes.length) {
+            RespCodec.DecodeResult decoded = RespCodec.decode(bytes, offset);
+            if (decoded == null) {
+                break;
+            }
+            engine.executeFrame(CommandFrame.fromRespValue(decoded.value()));
+            offset = decoded.nextOffset();
+        }
+    }
+
+    private void appendToAof(CommandFrame frame, EngineResponse response) {
+        if (frame == null || aofStream == null || response instanceof EngineResponse.ErrorString || !AOF_COMMANDS.contains(frame.command())) {
+            return;
+        }
+        try {
+            aofStream.write(RespCodec.encode(commandValue(canonicalCommand(frame))));
+            aofStream.flush();
+            if (aofSyncPolicy == AofSyncPolicy.ALWAYS) {
+                aofStream.getChannel().force(true);
+            }
+        } catch (IOException error) {
+            throw new IllegalStateException("Failed to append command to AOF", error);
+        }
+    }
+
+    private static CommandFrame canonicalCommand(CommandFrame frame) {
+        if (!frame.command().equals("EXPIRE") || frame.args().size() != 2) {
+            return frame;
+        }
+        long seconds = Long.parseLong(new String(frame.args().get(1), StandardCharsets.UTF_8));
+        long absoluteSeconds = (DataStoreEngine.currentTimeMs() / 1000L) + seconds;
+        return new CommandFrame(
+                "EXPIREAT",
+                List.of(
+                        frame.args().getFirst(),
+                        Long.toString(absoluteSeconds).getBytes(StandardCharsets.UTF_8)
+                )
+        );
+    }
+
+    private static RespValue.ArrayValue commandValue(CommandFrame frame) {
+        ArrayList<RespValue> values = new ArrayList<>();
+        values.add(new RespValue.BulkString(frame.command().getBytes(StandardCharsets.UTF_8)));
+        for (byte[] arg : frame.args()) {
+            values.add(new RespValue.BulkString(arg));
+        }
+        return new RespValue.ArrayValue(values);
+    }
+
+    public enum AofSyncPolicy {
+        ALWAYS,
+        NONE
     }
 }

--- a/code/packages/java/in-memory-data-store/src/test/java/com/codingadventures/inmemorydatastore/DataStoreManagerTest.java
+++ b/code/packages/java/in-memory-data-store/src/test/java/com/codingadventures/inmemorydatastore/DataStoreManagerTest.java
@@ -3,8 +3,13 @@ package com.codingadventures.inmemorydatastore;
 import com.codingadventures.respprotocol.RespCodec;
 import com.codingadventures.respprotocol.RespValue;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -26,5 +31,72 @@ class DataStoreManagerTest {
         ))));
         RespValue.BulkString bulk = (RespValue.BulkString) RespCodec.decode(getResponse).value();
         assertEquals("1", new String(bulk.value(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void replaysAofAcrossRestart(@TempDir Path tempDir) throws IOException {
+        Path aofPath = tempDir.resolve("appendonly.aof");
+        try (DataStoreManager manager = new DataStoreManager(aofPath)) {
+            assertInstanceOf(RespValue.SimpleString.class, decode(manager.executeRespBytes(command("SET", "persistent", "yes"))));
+            assertEquals(1L, ((RespValue.IntegerValue) decode(manager.executeRespBytes(command("INCR", "count")))).value());
+            assertEquals(2L, ((RespValue.IntegerValue) decode(manager.executeRespBytes(command("INCR", "count")))).value());
+            assertInstanceOf(RespValue.SimpleString.class, decode(manager.executeRespBytes(command("SELECT", "1"))));
+            assertInstanceOf(RespValue.SimpleString.class, decode(manager.executeRespBytes(command("SET", "db1", "value"))));
+            assertInstanceOf(RespValue.SimpleString.class, decode(manager.executeRespBytes(command("SELECT", "0"))));
+            assertInstanceOf(RespValue.SimpleString.class, decode(manager.executeRespBytes(command("SET", "ttl", "value"))));
+            assertEquals(1L, ((RespValue.IntegerValue) decode(manager.executeRespBytes(command("EXPIRE", "ttl", "60")))).value());
+        }
+
+        byte[] rawAof = Files.readAllBytes(aofPath);
+        ArrayList<List<String>> frames = new ArrayList<>();
+        int offset = 0;
+        while (offset < rawAof.length) {
+            RespCodec.DecodeResult decoded = RespCodec.decode(rawAof, offset);
+            assertNotNull(decoded);
+            frames.add(arrayStrings((RespValue.ArrayValue) decoded.value()));
+            offset = decoded.nextOffset();
+        }
+        assertEquals(List.of("SET", "persistent", "yes"), frames.get(0));
+        assertTrue(frames.contains(List.of("SELECT", "1")));
+        assertTrue(frames.contains(List.of("SET", "db1", "value")));
+        assertTrue(frames.stream().anyMatch(parts -> parts.size() == 3 && parts.get(0).equals("EXPIREAT") && parts.get(1).equals("ttl")));
+
+        try (DataStoreManager manager = new DataStoreManager(aofPath)) {
+            RespValue.BulkString persisted = (RespValue.BulkString) decode(manager.executeRespBytes(command("GET", "persistent")));
+            assertEquals("yes", new String(persisted.value(), StandardCharsets.UTF_8));
+
+            RespValue.BulkString count = (RespValue.BulkString) decode(manager.executeRespBytes(command("GET", "count")));
+            assertEquals("2", new String(count.value(), StandardCharsets.UTF_8));
+
+            assertInstanceOf(RespValue.SimpleString.class, decode(manager.executeRespBytes(command("SELECT", "1"))));
+            RespValue.BulkString db1 = (RespValue.BulkString) decode(manager.executeRespBytes(command("GET", "db1")));
+            assertEquals("value", new String(db1.value(), StandardCharsets.UTF_8));
+
+            assertInstanceOf(RespValue.SimpleString.class, decode(manager.executeRespBytes(command("SELECT", "0"))));
+            RespValue.IntegerValue ttl = (RespValue.IntegerValue) decode(manager.executeRespBytes(command("TTL", "ttl")));
+            assertTrue(ttl.value() >= 0 && ttl.value() <= 60);
+        }
+    }
+
+    private static byte[] command(String... parts) {
+        ArrayList<RespValue> values = new ArrayList<>();
+        for (String part : parts) {
+            values.add(new RespValue.BulkString(part.getBytes(StandardCharsets.UTF_8)));
+        }
+        return RespCodec.encode(new RespValue.ArrayValue(values));
+    }
+
+    private static RespValue decode(byte[] bytes) {
+        RespCodec.DecodeResult decoded = RespCodec.decode(bytes);
+        assertNotNull(decoded);
+        return decoded.value();
+    }
+
+    private static List<String> arrayStrings(RespValue.ArrayValue value) {
+        ArrayList<String> parts = new ArrayList<>();
+        for (RespValue item : value.value()) {
+            parts.add(new String(((RespValue.BulkString) item).value(), StandardCharsets.UTF_8));
+        }
+        return parts;
     }
 }

--- a/code/packages/kotlin/in-memory-data-store/CHANGELOG.md
+++ b/code/packages/kotlin/in-memory-data-store/CHANGELOG.md
@@ -7,3 +7,4 @@ All notable changes to this package will be documented in this file.
 ### Added
 
 - Initial JVM mini-redis core package
+- RESP-backed AOF persistence and replay support for durable manager instances

--- a/code/packages/kotlin/in-memory-data-store/README.md
+++ b/code/packages/kotlin/in-memory-data-store/README.md
@@ -2,6 +2,15 @@
 
 Composable JVM in-memory data store facade
 
+The package exposes a RESP-facing `DataStoreManager` on top of the shared
+engine and protocol layers. It can run purely in memory or write an
+append-only file (AOF) that replays on startup.
+
+```kotlin
+val manager = DataStoreManager()
+val durable = DataStoreManager(Path.of("appendonly.aof"))
+```
+
 ## Development
 
 ```bash

--- a/code/packages/kotlin/in-memory-data-store/src/main/kotlin/com/codingadventures/inmemorydatastore/DataStoreManager.kt
+++ b/code/packages/kotlin/in-memory-data-store/src/main/kotlin/com/codingadventures/inmemorydatastore/DataStoreManager.kt
@@ -1,16 +1,30 @@
 package com.codingadventures.inmemorydatastore
 
+import com.codingadventures.inmemorydatastoreengine.DataStoreEngine.Companion.currentTimeMs
 import com.codingadventures.inmemorydatastoreengine.DataStoreEngine
 import com.codingadventures.inmemorydatastoreprotocol.CommandFrame
 import com.codingadventures.inmemorydatastoreprotocol.EngineResponse
 import com.codingadventures.inmemorydatastoreprotocol.error
 import com.codingadventures.respprotocol.RespCodec
 import com.codingadventures.respprotocol.RespValue
+import java.io.Closeable
+import java.io.FileOutputStream
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
 
-class DataStoreManager {
+class DataStoreManager @JvmOverloads constructor(
+    aofPath: Path? = null,
+    private val aofSyncPolicy: AofSyncPolicy = AofSyncPolicy.ALWAYS,
+) : Closeable {
     private val engine = DataStoreEngine()
+    private val aofStream: FileOutputStream? = aofPath?.let { path ->
+        replayAof(path)
+        path.toAbsolutePath().parent?.let(Files::createDirectories)
+        FileOutputStream(path.toFile(), true)
+    }
 
-    fun executeFrame(frame: CommandFrame?): EngineResponse = engine.executeFrame(frame)
+    fun executeFrame(frame: CommandFrame?): EngineResponse = engine.executeFrame(frame).also { appendToAof(frame, it) }
     fun executeParts(parts: List<ByteArray>): EngineResponse = executeFrame(CommandFrame.fromParts(parts))
 
     fun executeRespBytes(request: ByteArray): ByteArray {
@@ -20,4 +34,56 @@ class DataStoreManager {
     }
 
     fun executeRespValue(value: RespValue): RespValue = executeFrame(CommandFrame.fromRespValue(value)).toRespValue()
+
+    override fun close() {
+        aofStream?.close()
+    }
+
+    private fun replayAof(aofPath: Path) {
+        if (!Files.exists(aofPath)) return
+        val bytes = Files.readAllBytes(aofPath)
+        var offset = 0
+        while (offset < bytes.size) {
+            val decoded = RespCodec.decode(bytes, offset) ?: break
+            engine.executeFrame(CommandFrame.fromRespValue(decoded.value))
+            offset = decoded.nextOffset
+        }
+    }
+
+    private fun appendToAof(frame: CommandFrame?, response: EngineResponse) {
+        if (frame == null || aofStream == null || response is EngineResponse.ErrorString || frame.command !in AOF_COMMANDS) return
+        val command = canonicalCommand(frame)
+        aofStream.write(RespCodec.encode(commandValue(command)))
+        aofStream.flush()
+        if (aofSyncPolicy == AofSyncPolicy.ALWAYS) {
+            aofStream.channel.force(true)
+        }
+    }
+
+    private fun canonicalCommand(frame: CommandFrame): CommandFrame {
+        if (frame.command != "EXPIRE" || frame.args.size != 2) return frame
+        val seconds = frame.args[1].decodeToString().toLong()
+        val absoluteSeconds = (currentTimeMs() / 1000L) + seconds
+        return CommandFrame(
+            "EXPIREAT",
+            listOf(frame.args[0], absoluteSeconds.toString().toByteArray(StandardCharsets.UTF_8)),
+        )
+    }
+
+    private fun commandValue(frame: CommandFrame): RespValue.ArrayValue =
+        RespValue.ArrayValue(listOf(RespValue.BulkString(frame.command.toByteArray(StandardCharsets.UTF_8))) + frame.args.map { RespValue.BulkString(it) })
+
+    enum class AofSyncPolicy {
+        ALWAYS,
+        NONE,
+    }
+
+    companion object {
+        private val AOF_COMMANDS = setOf(
+            "SET", "DEL", "RENAME", "INCR", "DECR", "INCRBY", "DECRBY", "APPEND",
+            "HSET", "HDEL", "LPUSH", "RPUSH", "LPOP", "RPOP",
+            "SADD", "SREM", "ZADD", "ZREM", "PFADD", "PFMERGE",
+            "EXPIRE", "EXPIREAT", "PERSIST", "SELECT", "FLUSHDB", "FLUSHALL",
+        )
+    }
 }

--- a/code/packages/kotlin/in-memory-data-store/src/test/kotlin/com/codingadventures/inmemorydatastore/DataStoreManagerTest.kt
+++ b/code/packages/kotlin/in-memory-data-store/src/test/kotlin/com/codingadventures/inmemorydatastore/DataStoreManagerTest.kt
@@ -5,6 +5,9 @@ import com.codingadventures.respprotocol.RespValue
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.test.assertNotNull
+import java.nio.file.Files
+import kotlin.io.path.createTempDirectory
 
 class DataStoreManagerTest {
     @Test
@@ -36,4 +39,62 @@ class DataStoreManagerTest {
         val bulk = decoded?.value as RespValue.BulkString
         assertEquals("1", bulk.value?.decodeToString())
     }
+
+    @Test
+    fun replaysAofAcrossRestart() {
+        val tempDir = createTempDirectory("aof-replay")
+        val aofPath = tempDir.resolve("appendonly.aof")
+        DataStoreManager(aofPath).use { manager ->
+            manager.executeRespBytes(command("SET", "persistent", "yes"))
+            assertEquals(1, (decode(manager.executeRespBytes(command("INCR", "count"))) as RespValue.IntegerValue).value)
+            assertEquals(2, (decode(manager.executeRespBytes(command("INCR", "count"))) as RespValue.IntegerValue).value)
+            manager.executeRespBytes(command("SELECT", "1"))
+            manager.executeRespBytes(command("SET", "db1", "value"))
+            manager.executeRespBytes(command("SELECT", "0"))
+            manager.executeRespBytes(command("SET", "ttl", "value"))
+            assertEquals(1, (decode(manager.executeRespBytes(command("EXPIRE", "ttl", "60"))) as RespValue.IntegerValue).value)
+        }
+
+        val rawAof = Files.readAllBytes(aofPath)
+        val frames = mutableListOf<List<String>>()
+        var offset = 0
+        while (offset < rawAof.size) {
+            val decoded = RespCodec.decode(rawAof, offset)
+            assertNotNull(decoded)
+            frames += arrayStrings(decoded.value as RespValue.ArrayValue)
+            offset = decoded.nextOffset
+        }
+        assertEquals(listOf("SET", "persistent", "yes"), frames.first())
+        assertTrue(frames.contains(listOf("SELECT", "1")))
+        assertTrue(frames.contains(listOf("SET", "db1", "value")))
+        assertTrue(frames.any { it.size == 3 && it[0] == "EXPIREAT" && it[1] == "ttl" })
+
+        DataStoreManager(aofPath).use { manager ->
+            val persisted = decode(manager.executeRespBytes(command("GET", "persistent"))) as RespValue.BulkString
+            assertEquals("yes", persisted.value?.decodeToString())
+
+            val count = decode(manager.executeRespBytes(command("GET", "count"))) as RespValue.BulkString
+            assertEquals("2", count.value?.decodeToString())
+
+            manager.executeRespBytes(command("SELECT", "1"))
+            val db1 = decode(manager.executeRespBytes(command("GET", "db1"))) as RespValue.BulkString
+            assertEquals("value", db1.value?.decodeToString())
+
+            manager.executeRespBytes(command("SELECT", "0"))
+            val ttl = decode(manager.executeRespBytes(command("TTL", "ttl"))) as RespValue.IntegerValue
+            assertTrue(ttl.value in 0..60)
+        }
+    }
+
+    private fun command(vararg parts: String): ByteArray =
+        RespCodec.encode(RespValue.ArrayValue(parts.map { RespValue.BulkString(it.encodeToByteArray()) }))
+
+    private fun decode(bytes: ByteArray): RespValue {
+        val decoded = RespCodec.decode(bytes)
+        assertNotNull(decoded)
+        return decoded.value
+    }
+
+    private fun arrayStrings(value: RespValue.ArrayValue): List<String> =
+        value.value!!.map { (it as RespValue.BulkString).value!!.decodeToString() }
 }


### PR DESCRIPTION
## What changed
- add optional append-only file (AOF) support to the Java and Kotlin `in-memory-data-store` managers
- replay RESP command frames from the AOF on startup before opening the append stream
- append successful mutating commands plus `SELECT` back to the AOF using RESP encoding so DB selection is preserved across restart
- canonicalize recorded `EXPIRE` commands to `EXPIREAT` with absolute epoch seconds so TTLs replay consistently after restart
- add restart-style tests that verify durable string/integer data, cross-database writes, and TTL state survive manager recreation
- update the JVM package READMEs and changelogs to document the durable manager mode

## Why
DT25 Phase 10 is AOF persistence, and it still belongs to the internal core rather than the future TCP layer. This keeps the JVM Mini-Redis stack transport-agnostic while making the manager durable enough for restart/replay scenarios.

## Validation
- `gradle test --rerun-tasks` in `code/packages/java/in-memory-data-store`
- `gradle clean test --rerun-tasks --no-daemon` in `code/packages/kotlin/in-memory-data-store`

## Notes
- the AOF file is plain RESP command frames written sequentially
- `SELECT` is intentionally recorded even though it is not a data mutation so replay restores the correct active database before later writes