### PR TITLE
[codex] Rescue remaining PR #654 graph/build-tool parity

### DIFF
--- a/code/packages/lua/graph/BUILD
+++ b/code/packages/lua/graph/BUILD
@@ -1,0 +1,1 @@
+lua tests/test_graph.lua

--- a/code/packages/lua/graph/BUILD_windows
+++ b/code/packages/lua/graph/BUILD_windows
@@ -1,0 +1,1 @@
+lua tests/test_graph.lua

--- a/code/packages/lua/graph/CHANGELOG.md
+++ b/code/packages/lua/graph/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0 - 2026-04-12
+
+- Initial DT00 graph package for Lua.

--- a/code/packages/lua/graph/README.md
+++ b/code/packages/lua/graph/README.md
@@ -1,0 +1,31 @@
+# lua/graph - Graph (DT00)
+
+An undirected weighted graph implementation in pure Lua with both adjacency-list
+and adjacency-matrix storage, plus the core DT00 algorithms.
+
+## API
+
+```lua
+local graph = require("coding_adventures.graph")
+local Graph = graph.Graph
+local GraphRepr = graph.GraphRepr
+
+local g = Graph.new({ repr = GraphRepr.ADJACENCY_LIST })
+g:add_edge("London", "Paris", 300)
+g:add_edge("London", "Amsterdam", 520)
+
+local path = graph.shortest_path(g, "London", "Paris")
+local mst = graph.minimum_spanning_tree(g)
+```
+
+## Exports
+
+- `Graph`
+- `GraphRepr`
+- `bfs(graph, start)`
+- `dfs(graph, start)`
+- `is_connected(graph)`
+- `connected_components(graph)`
+- `has_cycle(graph)`
+- `shortest_path(graph, start, goal)`
+- `minimum_spanning_tree(graph)`

--- a/code/packages/lua/graph/coding-adventures-graph-0.1.0-1.rockspec
+++ b/code/packages/lua/graph/coding-adventures-graph-0.1.0-1.rockspec
@@ -1,0 +1,19 @@
+package = "coding-adventures-graph"
+version = "0.1.0-1"
+source = {
+    url = "git://github.com/adhithyan15/coding-adventures.git",
+}
+description = {
+    summary = "Undirected weighted graph with DT00 algorithms in Lua",
+    homepage = "https://github.com/adhithyan15/coding-adventures",
+    license = "MIT",
+}
+dependencies = {
+    "lua >= 5.4",
+}
+build = {
+    type = "builtin",
+    modules = {
+        ["coding_adventures.graph"] = "src/coding_adventures/graph/init.lua",
+    },
+}

--- a/code/packages/lua/graph/src/coding_adventures/graph/init.lua
+++ b/code/packages/lua/graph/src/coding_adventures/graph/init.lua
@@ -1,0 +1,606 @@
+local function node_sort_key(node)
+    local value_type = type(node)
+    if value_type == "string" or value_type == "number" or value_type == "boolean" then
+        return value_type .. ":" .. tostring(node)
+    end
+    return value_type .. ":" .. tostring(node)
+end
+
+local function compare_nodes(left, right)
+    local left_key = node_sort_key(left)
+    local right_key = node_sort_key(right)
+    if left_key < right_key then
+        return -1
+    elseif left_key > right_key then
+        return 1
+    end
+    return 0
+end
+
+local function compare_nodes_less(left, right)
+    return compare_nodes(left, right) < 0
+end
+
+local function canonical_endpoints(left, right)
+    if compare_nodes(left, right) <= 0 then
+        return left, right
+    end
+    return right, left
+end
+
+local function NodeNotFoundError(node)
+    return {
+        type = "node_not_found",
+        node = node,
+        message = string.format("node not found: %q", tostring(node)),
+    }
+end
+
+local function EdgeNotFoundError(left, right)
+    return {
+        type = "edge_not_found",
+        left = left,
+        right = right,
+        message = string.format("edge not found: %q -- %q", tostring(left), tostring(right)),
+    }
+end
+
+local function DisconnectedGraphError()
+    return {
+        type = "disconnected_graph",
+        message = "graph is not connected and has no spanning tree",
+    }
+end
+
+local GraphRepr = {
+    ADJACENCY_LIST = "adjacency_list",
+    ADJACENCY_MATRIX = "adjacency_matrix",
+}
+
+local Graph = {}
+Graph.__index = Graph
+
+function Graph.new(opts)
+    opts = opts or {}
+    local repr = opts.repr or GraphRepr.ADJACENCY_LIST
+    local self = setmetatable({}, Graph)
+    self._repr = repr
+    self._adj = {}
+    self._node_list = {}
+    self._node_index = {}
+    self._matrix = {}
+    return self
+end
+
+function Graph:repr()
+    return self._repr
+end
+
+function Graph:add_node(node)
+    if self._repr == GraphRepr.ADJACENCY_LIST then
+        if self._adj[node] == nil then
+            self._adj[node] = {}
+        end
+        return
+    end
+
+    if self._node_index[node] ~= nil then
+        return
+    end
+
+    local index = #self._node_list + 1
+    self._node_list[index] = node
+    self._node_index[node] = index
+
+    for _, row in ipairs(self._matrix) do
+        row[index] = nil
+    end
+
+    local new_row = {}
+    for i = 1, index do
+        new_row[i] = nil
+    end
+    self._matrix[index] = new_row
+end
+
+function Graph:remove_node(node)
+    if self._repr == GraphRepr.ADJACENCY_LIST then
+        local neighbors = self._adj[node]
+        if neighbors == nil then
+            return nil, NodeNotFoundError(node)
+        end
+
+        for neighbor, _ in pairs(neighbors) do
+            self._adj[neighbor][node] = nil
+        end
+        self._adj[node] = nil
+        return true
+    end
+
+    local index = self._node_index[node]
+    if index == nil then
+        return nil, NodeNotFoundError(node)
+    end
+
+    table.remove(self._node_list, index)
+    table.remove(self._matrix, index)
+    for _, row in ipairs(self._matrix) do
+        table.remove(row, index)
+    end
+
+    self._node_index = {}
+    for i, current in ipairs(self._node_list) do
+        self._node_index[current] = i
+    end
+    return true
+end
+
+function Graph:has_node(node)
+    if self._repr == GraphRepr.ADJACENCY_LIST then
+        return self._adj[node] ~= nil
+    end
+    return self._node_index[node] ~= nil
+end
+
+function Graph:nodes()
+    local result = {}
+    if self._repr == GraphRepr.ADJACENCY_LIST then
+        for node, _ in pairs(self._adj) do
+            result[#result + 1] = node
+        end
+    else
+        for i = 1, #self._node_list do
+            result[i] = self._node_list[i]
+        end
+    end
+    table.sort(result, compare_nodes_less)
+    return result
+end
+
+function Graph:size()
+    if self._repr == GraphRepr.ADJACENCY_LIST then
+        local count = 0
+        for _ in pairs(self._adj) do
+            count = count + 1
+        end
+        return count
+    end
+    return #self._node_list
+end
+
+function Graph:add_edge(left, right, weight)
+    weight = weight == nil and 1.0 or weight
+    self:add_node(left)
+    self:add_node(right)
+
+    if self._repr == GraphRepr.ADJACENCY_LIST then
+        self._adj[left][right] = weight
+        self._adj[right][left] = weight
+        return
+    end
+
+    local left_index = self._node_index[left]
+    local right_index = self._node_index[right]
+    self._matrix[left_index][right_index] = weight
+    self._matrix[right_index][left_index] = weight
+end
+
+function Graph:remove_edge(left, right)
+    if self._repr == GraphRepr.ADJACENCY_LIST then
+        local left_neighbors = self._adj[left]
+        local right_neighbors = self._adj[right]
+        if left_neighbors == nil or right_neighbors == nil or left_neighbors[right] == nil then
+            return nil, EdgeNotFoundError(left, right)
+        end
+
+        left_neighbors[right] = nil
+        right_neighbors[left] = nil
+        return true
+    end
+
+    local left_index = self._node_index[left]
+    local right_index = self._node_index[right]
+    if left_index == nil or right_index == nil or self._matrix[left_index][right_index] == nil then
+        return nil, EdgeNotFoundError(left, right)
+    end
+
+    self._matrix[left_index][right_index] = nil
+    self._matrix[right_index][left_index] = nil
+    return true
+end
+
+function Graph:has_edge(left, right)
+    if self._repr == GraphRepr.ADJACENCY_LIST then
+        local neighbors = self._adj[left]
+        return neighbors ~= nil and neighbors[right] ~= nil
+    end
+
+    local left_index = self._node_index[left]
+    local right_index = self._node_index[right]
+    return left_index ~= nil and right_index ~= nil and self._matrix[left_index][right_index] ~= nil
+end
+
+function Graph:edge_weight(left, right)
+    if self._repr == GraphRepr.ADJACENCY_LIST then
+        local neighbors = self._adj[left]
+        if neighbors == nil or neighbors[right] == nil then
+            return nil, EdgeNotFoundError(left, right)
+        end
+        return neighbors[right]
+    end
+
+    local left_index = self._node_index[left]
+    local right_index = self._node_index[right]
+    if left_index == nil or right_index == nil or self._matrix[left_index][right_index] == nil then
+        return nil, EdgeNotFoundError(left, right)
+    end
+    return self._matrix[left_index][right_index]
+end
+
+function Graph:edges()
+    local result = {}
+    local seen = {}
+
+    if self._repr == GraphRepr.ADJACENCY_LIST then
+        for left, neighbors in pairs(self._adj) do
+            for right, weight in pairs(neighbors) do
+                local first, second = canonical_endpoints(left, right)
+                local key = node_sort_key(first) .. "\0" .. node_sort_key(second)
+                if not seen[key] then
+                    seen[key] = true
+                    result[#result + 1] = { first, second, weight }
+                end
+            end
+        end
+    else
+        for row = 1, #self._node_list do
+            for col = row, #self._node_list do
+                local weight = self._matrix[row][col]
+                if weight ~= nil then
+                    result[#result + 1] = { self._node_list[row], self._node_list[col], weight }
+                end
+            end
+        end
+    end
+
+    table.sort(result, function(left, right)
+        if left[3] ~= right[3] then
+            return left[3] < right[3]
+        end
+        local by_left = compare_nodes(left[1], right[1])
+        if by_left ~= 0 then
+            return by_left < 0
+        end
+        return compare_nodes(left[2], right[2]) < 0
+    end)
+    return result
+end
+
+function Graph:neighbors(node)
+    if self._repr == GraphRepr.ADJACENCY_LIST then
+        local neighbors = self._adj[node]
+        if neighbors == nil then
+            return nil, NodeNotFoundError(node)
+        end
+
+        local result = {}
+        for neighbor, _ in pairs(neighbors) do
+            result[#result + 1] = neighbor
+        end
+        table.sort(result, compare_nodes_less)
+        return result
+    end
+
+    local index = self._node_index[node]
+    if index == nil then
+        return nil, NodeNotFoundError(node)
+    end
+
+    local result = {}
+    for col = 1, #self._node_list do
+        if self._matrix[index][col] ~= nil then
+            result[#result + 1] = self._node_list[col]
+        end
+    end
+    table.sort(result, compare_nodes_less)
+    return result
+end
+
+function Graph:neighbors_weighted(node)
+    if self._repr == GraphRepr.ADJACENCY_LIST then
+        local neighbors = self._adj[node]
+        if neighbors == nil then
+            return nil, NodeNotFoundError(node)
+        end
+
+        local copy = {}
+        for neighbor, weight in pairs(neighbors) do
+            copy[neighbor] = weight
+        end
+        return copy
+    end
+
+    local index = self._node_index[node]
+    if index == nil then
+        return nil, NodeNotFoundError(node)
+    end
+
+    local result = {}
+    for col = 1, #self._node_list do
+        local weight = self._matrix[index][col]
+        if weight ~= nil then
+            result[self._node_list[col]] = weight
+        end
+    end
+    return result
+end
+
+function Graph:degree(node)
+    local neighbors, err = self:neighbors(node)
+    if not neighbors then
+        return nil, err
+    end
+    return #neighbors
+end
+
+function Graph:__tostring()
+    return string.format("Graph(nodes=%d, edges=%d, repr=%s)", self:size(), #self:edges(), self._repr)
+end
+
+local function bfs(graph, start)
+    if not graph:has_node(start) then
+        return nil, NodeNotFoundError(start)
+    end
+
+    local visited = { [start] = true }
+    local queue = { start }
+    local head = 1
+    local result = {}
+
+    while head <= #queue do
+        local node = queue[head]
+        head = head + 1
+        result[#result + 1] = node
+
+        local neighbors = graph:neighbors(node)
+        for _, neighbor in ipairs(neighbors) do
+            if not visited[neighbor] then
+                visited[neighbor] = true
+                queue[#queue + 1] = neighbor
+            end
+        end
+    end
+
+    return result
+end
+
+local function dfs(graph, start)
+    if not graph:has_node(start) then
+        return nil, NodeNotFoundError(start)
+    end
+
+    local visited = {}
+    local stack = { start }
+    local result = {}
+
+    while #stack > 0 do
+        local node = table.remove(stack)
+        if not visited[node] then
+            visited[node] = true
+            result[#result + 1] = node
+
+            local neighbors = graph:neighbors(node)
+            for i = #neighbors, 1, -1 do
+                local neighbor = neighbors[i]
+                if not visited[neighbor] then
+                    stack[#stack + 1] = neighbor
+                end
+            end
+        end
+    end
+
+    return result
+end
+
+local function is_connected(graph)
+    local nodes = graph:nodes()
+    if #nodes == 0 then
+        return true
+    end
+    local visited = bfs(graph, nodes[1])
+    return #visited == #nodes
+end
+
+local function connected_components(graph)
+    local result = {}
+    local visited = {}
+
+    for _, node in ipairs(graph:nodes()) do
+        if not visited[node] then
+            local component = bfs(graph, node)
+            for _, member in ipairs(component) do
+                visited[member] = true
+            end
+            result[#result + 1] = component
+        end
+    end
+
+    return result
+end
+
+local function has_cycle(graph)
+    local visited = {}
+
+    local function visit(node, parent)
+        visited[node] = true
+        local neighbors = graph:neighbors(node)
+        for _, neighbor in ipairs(neighbors) do
+            if not visited[neighbor] then
+                if visit(neighbor, node) then
+                    return true
+                end
+            elseif neighbor ~= parent then
+                return true
+            end
+        end
+        return false
+    end
+
+    for _, node in ipairs(graph:nodes()) do
+        if not visited[node] and visit(node, nil) then
+            return true
+        end
+    end
+
+    return false
+end
+
+local function shortest_path(graph, start, goal)
+    if not graph:has_node(start) then
+        return nil, NodeNotFoundError(start)
+    end
+    if not graph:has_node(goal) then
+        return nil, NodeNotFoundError(goal)
+    end
+    if start == goal then
+        return { start }
+    end
+
+    local inf = math.huge
+    local distances = {}
+    local previous = {}
+    local frontier = {}
+    local sequence = 0
+
+    for _, node in ipairs(graph:nodes()) do
+        distances[node] = inf
+    end
+    distances[start] = 0
+    frontier[1] = { priority = 0, seq = 0, node = start }
+
+    local function pop_min()
+        local best_index = 1
+        for i = 2, #frontier do
+            local left = frontier[i]
+            local right = frontier[best_index]
+            if left.priority < right.priority or
+               (left.priority == right.priority and left.seq < right.seq) then
+                best_index = i
+            end
+        end
+        return table.remove(frontier, best_index)
+    end
+
+    while #frontier > 0 do
+        local current = pop_min()
+        if current.priority <= distances[current.node] then
+            if current.node == goal then
+                break
+            end
+
+            local neighbors = graph:neighbors_weighted(current.node)
+            local keys = {}
+            for neighbor, _ in pairs(neighbors) do
+                keys[#keys + 1] = neighbor
+            end
+            table.sort(keys, compare_nodes_less)
+
+            for _, neighbor in ipairs(keys) do
+                local next_distance = distances[current.node] + neighbors[neighbor]
+                if next_distance < distances[neighbor] then
+                    distances[neighbor] = next_distance
+                    previous[neighbor] = current.node
+                    sequence = sequence + 1
+                    frontier[#frontier + 1] = {
+                        priority = next_distance,
+                        seq = sequence,
+                        node = neighbor,
+                    }
+                end
+            end
+        end
+    end
+
+    if distances[goal] == inf then
+        return {}
+    end
+
+    local path = {}
+    local current = goal
+    while current ~= nil do
+        table.insert(path, 1, current)
+        current = previous[current]
+    end
+    return path
+end
+
+local function minimum_spanning_tree(graph)
+    if graph:size() <= 1 then
+        return {}
+    end
+    if not is_connected(graph) then
+        return nil, DisconnectedGraphError()
+    end
+
+    local parent = {}
+    local rank = {}
+    for _, node in ipairs(graph:nodes()) do
+        parent[node] = node
+        rank[node] = 0
+    end
+
+    local function find(node)
+        if parent[node] ~= node then
+            parent[node] = find(parent[node])
+        end
+        return parent[node]
+    end
+
+    local function union(left, right)
+        local left_root = find(left)
+        local right_root = find(right)
+        if left_root == right_root then
+            return
+        end
+
+        if rank[left_root] < rank[right_root] then
+            parent[left_root] = right_root
+        elseif rank[left_root] > rank[right_root] then
+            parent[right_root] = left_root
+        else
+            parent[right_root] = left_root
+            rank[left_root] = rank[left_root] + 1
+        end
+    end
+
+    local result = {}
+    for _, edge in ipairs(graph:edges()) do
+        if find(edge[1]) ~= find(edge[2]) then
+            union(edge[1], edge[2])
+            result[#result + 1] = edge
+            if #result == graph:size() - 1 then
+                break
+            end
+        end
+    end
+
+    return result
+end
+
+local graph = {
+    VERSION = "0.1.0",
+    Graph = Graph,
+    GraphRepr = GraphRepr,
+    NodeNotFoundError = NodeNotFoundError,
+    EdgeNotFoundError = EdgeNotFoundError,
+    DisconnectedGraphError = DisconnectedGraphError,
+    bfs = bfs,
+    dfs = dfs,
+    is_connected = is_connected,
+    connected_components = connected_components,
+    has_cycle = has_cycle,
+    shortest_path = shortest_path,
+    minimum_spanning_tree = minimum_spanning_tree,
+}
+
+return graph

--- a/code/packages/lua/graph/tests/test_graph.lua
+++ b/code/packages/lua/graph/tests/test_graph.lua
@@ -1,0 +1,96 @@
+local script = arg and arg[0] or "tests/test_graph.lua"
+local script_dir = script:match("^(.*)[/\\][^/\\]+$") or "."
+local package_root = script_dir:gsub("[/\\]tests$", "")
+if package_root == "tests" then
+    package_root = "."
+end
+
+package.path = package_root .. "/src/?.lua;" .. package_root .. "/src/?/init.lua;" .. package.path
+
+local graph = require("coding_adventures.graph")
+local Graph = graph.Graph
+local GraphRepr = graph.GraphRepr
+
+local function assert_true(value, message)
+    if not value then
+        error(message or "expected true")
+    end
+end
+
+local function assert_equals(expected, actual, message)
+    if expected ~= actual then
+        error((message or "values differ") .. string.format(" (expected=%s actual=%s)", tostring(expected), tostring(actual)))
+    end
+end
+
+local function assert_list_equals(expected, actual, message)
+    assert_equals(#expected, #actual, (message or "list length mismatch"))
+    for i = 1, #expected do
+        assert_equals(expected[i], actual[i], message or ("list mismatch at index " .. i))
+    end
+end
+
+local function make_graph(repr)
+    local g = Graph.new({ repr = repr })
+    g:add_edge("London", "Paris", 300)
+    g:add_edge("London", "Amsterdam", 520)
+    g:add_edge("Paris", "Berlin", 878)
+    g:add_edge("Amsterdam", "Berlin", 655)
+    g:add_edge("Amsterdam", "Brussels", 180)
+    return g
+end
+
+local function run_for_repr(repr)
+    local g = make_graph(repr)
+    assert_true(g:has_node("London"))
+    assert_true(g:has_edge("London", "Paris"))
+    assert_equals(5, g:size())
+    assert_equals(520, assert(g:edge_weight("London", "Amsterdam")))
+
+    local neighbors = assert(g:neighbors("Amsterdam"))
+    assert_list_equals({ "Berlin", "Brussels", "London" }, neighbors)
+    assert_equals(3, assert(g:degree("Amsterdam")))
+
+    local bfs_order = assert(graph.bfs(g, "London"))
+    assert_list_equals({ "London", "Amsterdam", "Paris", "Berlin", "Brussels" }, bfs_order)
+
+    local dfs_order = assert(graph.dfs(g, "London"))
+    assert_list_equals({ "London", "Amsterdam", "Berlin", "Paris", "Brussels" }, dfs_order)
+
+    assert_true(graph.is_connected(g))
+    assert_true(graph.has_cycle(g))
+
+    local path = assert(graph.shortest_path(g, "London", "Berlin"))
+    assert_list_equals({ "London", "Amsterdam", "Berlin" }, path)
+
+    local mst = assert(graph.minimum_spanning_tree(g))
+    assert_equals(4, #mst)
+    assert_equals("Amsterdam", mst[1][1])
+    assert_equals("Brussels", mst[1][2])
+    assert_equals(180, mst[1][3])
+end
+
+run_for_repr(GraphRepr.ADJACENCY_LIST)
+run_for_repr(GraphRepr.ADJACENCY_MATRIX)
+
+do
+    local g = Graph.new()
+    g:add_edge("A", "B")
+    g:add_edge("C", "D")
+    local components = graph.connected_components(g)
+    assert_equals(2, #components)
+    assert_list_equals({ "A", "B" }, components[1])
+    assert_list_equals({ "C", "D" }, components[2])
+    assert_true(not graph.is_connected(g), "expected disconnected graph")
+end
+
+do
+    local g = Graph.new()
+    g:add_edge("A", "B")
+    assert_true(g:remove_edge("A", "B"))
+    assert_true(not g:has_edge("A", "B"))
+    assert_true(g:remove_node("A"))
+    assert_true(not g:has_node("A"))
+end
+
+print("lua/graph tests passed")

--- a/code/packages/wasm/b-plus-tree/src/lib.rs
+++ b/code/packages/wasm/b-plus-tree/src/lib.rs
@@ -53,7 +53,7 @@ impl WasmBPlusTree {
             self.inner
                 .range_scan(&low, &high)
                 .into_iter()
-                .map(|(&k, v)| (k, v.clone())),
+                .map(|(key, value)| (*key, value.clone())),
         )
     }
 
@@ -63,12 +63,12 @@ impl WasmBPlusTree {
             self.inner
                 .full_scan()
                 .into_iter()
-                .map(|(&k, v)| (k, v.clone())),
+                .map(|(key, value)| (*key, value.clone())),
         )
     }
 
     pub fn iter_keys(&self) -> Vec<i32> {
-        self.inner.iter().map(|(k, _)| *k).collect()
+        self.inner.iter().map(|(key, _)| *key).collect()
     }
 
     pub fn items(&self) -> Array {
@@ -76,7 +76,7 @@ impl WasmBPlusTree {
             self.inner
                 .full_scan()
                 .into_iter()
-                .map(|(&k, v)| (k, v.clone())),
+                .map(|(key, value)| (*key, value.clone())),
         )
     }
 
@@ -109,7 +109,12 @@ impl WasmBPlusTree {
 
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string_value(&self) -> String {
-        format!("BPlusTree {{ len: {}, height: {} }}", self.inner.len(), self.inner.height())
+        format!(
+            "BPlusTree(len={}, height={}, valid={})",
+            self.inner.len(),
+            self.inner.height(),
+            self.inner.is_valid()
+        )
     }
 }
 
@@ -144,6 +149,6 @@ mod tests {
         assert_eq!(tree.inner.range_scan(&10, &30).len(), 3);
         assert_eq!(tree.inner.full_scan().len(), 3);
         assert_eq!(tree.iter_keys(), vec![10, 20, 30]);
-        assert_eq!(tree.inner.full_scan().len(), 3);
+        assert_eq!(tree.inner.iter().count(), 3);
     }
 }

--- a/code/packages/wasm/b-tree/src/lib.rs
+++ b/code/packages/wasm/b-tree/src/lib.rs
@@ -63,7 +63,7 @@ impl WasmBTree {
             self.inner
                 .range_query(&low, &high)
                 .into_iter()
-                .map(|(&k, v)| (k, v.clone())),
+                .map(|(key, value)| (*key, value.clone())),
         )
     }
 
@@ -72,7 +72,7 @@ impl WasmBTree {
             self.inner
                 .inorder()
                 .into_iter()
-                .map(|(&k, v)| (k, v.clone())),
+                .map(|(key, value)| (*key, value.clone())),
         )
     }
 
@@ -95,7 +95,12 @@ impl WasmBTree {
 
     #[wasm_bindgen(js_name = "toString")]
     pub fn to_string_value(&self) -> String {
-        format!("BTree {{ len: {}, height: {} }}", self.inner.len(), self.inner.height())
+        format!(
+            "BTree(len={}, height={}, valid={})",
+            self.inner.len(),
+            self.inner.height(),
+            self.inner.is_valid()
+        )
     }
 }
 
@@ -129,6 +134,6 @@ mod tests {
         tree.insert(30, "thirty");
         assert_eq!(tree.inner.range_query(&10, &30).len(), 3);
         assert_eq!(tree.inner.inorder().len(), 3);
-        assert_eq!(tree.height(), 0);
+        assert!(tree.height() <= 1);
     }
 }

--- a/code/programs/elixir/build-tool/lib/build_tool/cli.ex
+++ b/code/programs/elixir/build-tool/lib/build_tool/cli.ex
@@ -57,6 +57,8 @@ defmodule BuildTool.CLI do
 
   alias CodingAdventures.ProgressBar
 
+  @all_toolchains ["python", "ruby", "go", "typescript", "rust", "elixir", "lua", "perl", "swift", "haskell", "dotnet"]
+
   # ---------------------------------------------------------------------------
   # Entry point
   # ---------------------------------------------------------------------------
@@ -92,6 +94,7 @@ defmodule BuildTool.CLI do
           diff_base: :string,
           cache_file: :string,
           validate_build_files: :boolean,
+          detect_languages: :boolean,
           emit_plan: :string,
           plan_file: :string
         ],
@@ -112,6 +115,7 @@ defmodule BuildTool.CLI do
     diff_base = Keyword.get(opts, :diff_base, "origin/main")
     cache_file = Keyword.get(opts, :cache_file, ".build-cache.json")
     validate_build_files = Keyword.get(opts, :validate_build_files, false)
+    detect_languages = Keyword.get(opts, :detect_languages, false)
     emit_plan_path = Keyword.get(opts, :emit_plan, nil)
     plan_file_path = Keyword.get(opts, :plan_file, nil)
 
@@ -137,6 +141,7 @@ defmodule BuildTool.CLI do
         diff_base,
         cache_file,
         validate_build_files,
+        detect_languages,
         emit_plan_path,
         plan_file_path
       )
@@ -152,6 +157,7 @@ defmodule BuildTool.CLI do
          diff_base,
          cache_file,
          validate_build_files,
+         detect_languages,
          emit_plan_path,
          plan_file_path
        ) do
@@ -200,6 +206,7 @@ defmodule BuildTool.CLI do
                   jobs,
                   diff_base,
                   cache_file,
+                  detect_languages,
                   emit_plan_path,
                   plan_file_path
                 )
@@ -224,6 +231,7 @@ defmodule BuildTool.CLI do
               jobs,
               diff_base,
               cache_file,
+              detect_languages,
               emit_plan_path,
               plan_file_path
             )
@@ -240,6 +248,7 @@ defmodule BuildTool.CLI do
          jobs,
          diff_base,
          cache_file,
+         detect_languages,
          emit_plan_path,
          _plan_file_path
        ) do
@@ -304,7 +313,12 @@ defmodule BuildTool.CLI do
     # --emit-plan: write the build plan to a file and exit without building.
     # This is used by CI to compute the plan in a fast "detect" job and
     # share it across build jobs on multiple platforms.
-    if emit_plan_path != nil do
+    cond do
+      detect_languages ->
+        languages_needed = compute_languages_needed(packages, affected_set, force_override)
+        output_language_flags(languages_needed)
+
+      emit_plan_path != nil ->
       return_emit_plan(
         packages,
         graph,
@@ -314,7 +328,8 @@ defmodule BuildTool.CLI do
         affected_set,
         emit_plan_path
       )
-    else
+
+      true ->
       do_execute_builds(
         packages,
         graph,
@@ -380,11 +395,7 @@ defmodule BuildTool.CLI do
       |> Enum.sort()
 
     # Determine which languages are needed.
-    langs_needed =
-      packages
-      |> Enum.map(& &1.language)
-      |> Enum.uniq()
-      |> Map.new(fn lang -> {lang, true} end)
+    langs_needed = compute_languages_needed(packages, affected_set, force)
 
     plan = %Plan{
       diff_base: diff_base,
@@ -555,5 +566,53 @@ defmodule BuildTool.CLI do
         do_find_repo_root(parent)
       end
     end
+  end
+
+  defp compute_languages_needed(_packages, _affected_set, true) do
+    Map.new(@all_toolchains, fn toolchain -> {toolchain, true} end)
+  end
+
+  defp compute_languages_needed(_packages, nil, _force) do
+    Map.new(@all_toolchains, fn toolchain -> {toolchain, true} end)
+    |> Map.put("go", true)
+  end
+
+  defp compute_languages_needed(packages, affected_set, _force) do
+    Enum.reduce(
+      packages,
+      Map.new(@all_toolchains, fn toolchain -> {toolchain, false} end),
+      fn pkg, acc ->
+        if MapSet.member?(affected_set, pkg.name) do
+          Map.put(acc, toolchain_for_language(pkg.language), true)
+        else
+          acc
+        end
+      end
+    )
+    |> Map.put("go", true)
+  end
+
+  defp toolchain_for_language(language) do
+    case language do
+      "wasm" -> "rust"
+      lang when lang in ["csharp", "fsharp", "dotnet"] -> "dotnet"
+      _ -> language
+    end
+  end
+
+  defp output_language_flags(languages_needed) do
+    github_output = System.get_env("GITHUB_OUTPUT")
+
+    Enum.each(@all_toolchains, fn toolchain ->
+      value = Map.get(languages_needed, toolchain, false)
+      line = "needs_#{toolchain}=#{if value, do: "true", else: "false"}"
+      IO.puts(line)
+
+      if github_output not in [nil, ""] do
+        File.write!(github_output, line <> "\n", [:append])
+      end
+    end)
+
+    0
   end
 end

--- a/code/programs/elixir/build-tool/lib/build_tool/discovery.ex
+++ b/code/programs/elixir/build-tool/lib/build_tool/discovery.ex
@@ -86,7 +86,22 @@ defmodule BuildTool.Discovery do
   # Known languages
   # ---------------------------------------------------------------------------
 
-  @known_languages ["python", "ruby", "go", "rust", "typescript", "elixir", "lua", "perl"]
+  @known_languages [
+    "python",
+    "ruby",
+    "go",
+    "rust",
+    "typescript",
+    "elixir",
+    "lua",
+    "perl",
+    "swift",
+    "haskell",
+    "wasm",
+    "csharp",
+    "fsharp",
+    "dotnet"
+  ]
 
   # ---------------------------------------------------------------------------
   # Public API

--- a/code/programs/elixir/build-tool/lib/build_tool/resolver.ex
+++ b/code/programs/elixir/build-tool/lib/build_tool/resolver.ex
@@ -79,11 +79,15 @@ defmodule BuildTool.Resolver do
       end)
 
     # Build the ecosystem-specific name mapping table.
-    known_names = build_known_names(packages)
+    known_names_by_scope =
+      packages
+      |> Enum.map(&dependency_scope(&1.language))
+      |> Enum.uniq()
+      |> Map.new(fn scope -> {scope, build_known_names(packages, scope)} end)
 
     # Parse dependencies for each package and add edges.
     Enum.reduce(packages, graph, fn pkg, g ->
-      deps = parse_deps(pkg, known_names)
+      deps = parse_deps(pkg, Map.fetch!(known_names_by_scope, dependency_scope(pkg.language)))
 
       Enum.reduce(deps, g, fn dep_name, g2 ->
         # Edge direction: dep -> pkg means "dep must be built before pkg".
@@ -102,8 +106,11 @@ defmodule BuildTool.Resolver do
 
   Exported for testing.
   """
-  def build_known_names(packages) do
+  def build_known_names(packages, language \\ nil) do
     Enum.reduce(packages, %{}, fn pkg, acc ->
+      if language != nil and not in_dependency_scope?(pkg.language, language) do
+        acc
+      else
       case pkg.language do
         "python" ->
           # Convert dir name to PyPI name: "logic-gates" -> "coding-adventures-logic-gates"
@@ -147,7 +154,17 @@ defmodule BuildTool.Resolver do
         "rust" ->
           # Rust crate names use the directory name directly (kebab-case).
           crate_name = String.downcase(Path.basename(pkg.path))
-          Map.put(acc, crate_name, pkg.name)
+
+          acc
+          |> Map.put(crate_name, pkg.name)
+          |> maybe_put(read_cargo_package_name(pkg.path), pkg.name)
+
+        "wasm" ->
+          crate_name = String.downcase(Path.basename(pkg.path))
+
+          acc
+          |> Map.put(crate_name, pkg.name)
+          |> maybe_put(read_cargo_package_name(pkg.path), pkg.name)
 
         "elixir" ->
           # Elixir mix names: "logic-gates" -> "coding_adventures_logic_gates"
@@ -177,8 +194,18 @@ defmodule BuildTool.Resolver do
           cabal_name = "coding-adventures-" <> String.downcase(Path.basename(pkg.path))
           Map.put(acc, cabal_name, pkg.name)
 
+        "csharp" ->
+          Map.put(acc, String.downcase(Path.basename(pkg.path)), pkg.name)
+
+        "fsharp" ->
+          Map.put(acc, String.downcase(Path.basename(pkg.path)), pkg.name)
+
+        "dotnet" ->
+          Map.put(acc, String.downcase(Path.basename(pkg.path)), pkg.name)
+
         _ ->
           acc
+      end
       end
     end)
   end
@@ -199,10 +226,14 @@ defmodule BuildTool.Resolver do
       "go" -> parse_go_deps(pkg, known_names)
       "typescript" -> parse_typescript_deps(pkg, known_names)
       "rust" -> parse_rust_deps(pkg, known_names)
+      "wasm" -> parse_rust_deps(pkg, known_names)
       "elixir" -> parse_elixir_deps(pkg, known_names)
       "lua" -> parse_lua_deps(pkg, known_names)
       "perl" -> parse_perl_deps(pkg, known_names)
       "haskell" -> parse_haskell_deps(pkg, known_names)
+      "csharp" -> parse_dotnet_deps(pkg, known_names)
+      "fsharp" -> parse_dotnet_deps(pkg, known_names)
+      "dotnet" -> parse_dotnet_deps(pkg, known_names)
       _ -> []
     end
   end
@@ -498,6 +529,39 @@ defmodule BuildTool.Resolver do
     end
   end
 
+  defp parse_dotnet_deps(pkg, known_names) do
+    pkg.path
+    |> project_files()
+    |> Enum.flat_map(fn project_file ->
+      case File.read(project_file) do
+        {:ok, data} ->
+          ~r/<ProjectReference\s+Include\s*=\s*"\.\.[\\\/]+([^\/\\"]+)[\\\/][^"]*"/
+          |> Regex.scan(data)
+          |> Enum.flat_map(fn
+            [_, dep_dir] ->
+              dep_dir = String.downcase(dep_dir)
+
+              cond do
+                String.contains?(dep_dir, "/") or String.contains?(dep_dir, "\\") or dep_dir == ".." ->
+                  []
+
+                true ->
+                  case Map.get(known_names, dep_dir) do
+                    nil -> []
+                    pkg_name -> [pkg_name]
+                  end
+              end
+
+            _ ->
+              []
+          end)
+
+        {:error, _} ->
+          []
+      end
+    end)
+  end
+
   defp parse_rust_lines([], _known, _in_deps, acc), do: Enum.reverse(acc)
 
   defp parse_rust_lines([line | rest], known, in_deps, acc) do
@@ -717,6 +781,55 @@ defmodule BuildTool.Resolver do
       {:error, _} -> []
     end
   end
+
+  defp dependency_scope(language) do
+    case language do
+      lang when lang in ["csharp", "fsharp", "dotnet"] -> "dotnet"
+      "wasm" -> "wasm"
+      _ -> language
+    end
+  end
+
+  defp in_dependency_scope?(package_language, scope) do
+    case scope do
+      "dotnet" -> package_language in ["csharp", "fsharp", "dotnet"]
+      "wasm" -> package_language in ["wasm", "rust"]
+      _ -> package_language == scope
+    end
+  end
+
+  defp read_cargo_package_name(path) do
+    cargo_toml = Path.join(path, "Cargo.toml")
+
+    case File.read(cargo_toml) do
+      {:ok, data} ->
+        case Regex.run(~r/^\s*name\s*=\s*"([^"]+)"/m, data) do
+          [_, name] -> String.downcase(String.trim(name))
+          _ -> nil
+        end
+
+      {:error, _} ->
+        nil
+    end
+  end
+
+  defp project_files(path) do
+    case File.ls(path) do
+      {:ok, entries} ->
+        entries
+        |> Enum.sort()
+        |> Enum.filter(fn entry ->
+          String.ends_with?(entry, ".csproj") or String.ends_with?(entry, ".fsproj")
+        end)
+        |> Enum.map(&Path.join(path, &1))
+
+      {:error, _} ->
+        []
+    end
+  end
+
+  defp maybe_put(map, nil, _value), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
 
   defp extract_lua_deps(line, known_names) do
     ~r/"([^"]+)"/

--- a/code/programs/lua/build-tool/lib/build_tool/discovery.lua
+++ b/code/programs/lua/build-tool/lib/build_tool/discovery.lua
@@ -33,7 +33,8 @@ local Discovery = {}
 -- KNOWN_LANGUAGES lists the language directory names we look for when
 -- inferring which ecosystem a package belongs to.
 local KNOWN_LANGUAGES = {
-    "python", "ruby", "go", "rust", "typescript", "elixir", "lua", "perl", "haskell",
+    "python", "ruby", "go", "rust", "typescript", "elixir", "lua", "perl",
+    "swift", "haskell", "starlark", "wasm", "csharp", "fsharp", "dotnet",
 }
 
 -- SKIP_DIRS is the set of directory names that should never be traversed

--- a/code/programs/lua/build-tool/lib/build_tool/resolver.lua
+++ b/code/programs/lua/build-tool/lib/build_tool/resolver.lua
@@ -38,6 +38,40 @@ local function read_file(path)
     return content
 end
 
+local function normalize_path(path)
+    local normalized = path:gsub("\\", "/")
+    local prefix = ""
+    local segments = {}
+
+    if normalized:match("^[A-Za-z]:/") then
+        prefix = normalized:sub(1, 2):lower()
+        normalized = normalized:sub(3)
+    elseif normalized:sub(1, 1) == "/" then
+        prefix = "/"
+        normalized = normalized:sub(2)
+    end
+
+    for segment in normalized:gmatch("[^/]+") do
+        if segment == ".." then
+            if #segments > 0 and segments[#segments] ~= ".." then
+                table.remove(segments)
+            elseif prefix == "" then
+                segments[#segments + 1] = segment
+            end
+        elseif segment ~= "." and segment ~= "" then
+            segments[#segments + 1] = segment
+        end
+    end
+
+    local joined = table.concat(segments, "/")
+    if prefix == "/" then
+        return joined == "" and "/" or "/" .. joined
+    elseif prefix ~= "" then
+        return joined == "" and (prefix .. "/") or (prefix .. "/" .. joined)
+    end
+    return joined
+end
+
 -- =========================================================================
 -- Helper: find a file by extension in a directory.
 -- =========================================================================
@@ -79,6 +113,69 @@ local function find_file_by_extension(directory, extension)
         end
     end
     return nil
+end
+
+local function find_files_by_extensions(directory, extensions)
+    local files = {}
+    local seen = {}
+
+    for _, extension in ipairs(extensions) do
+        local filepath = find_file_by_extension(directory, extension)
+        if filepath then
+            local normalized = normalize_path(filepath)
+            if not seen[normalized] then
+                seen[normalized] = true
+                files[#files + 1] = filepath
+            end
+        end
+    end
+
+    table.sort(files)
+    return files
+end
+
+local function dependency_scope(language)
+    if language == "csharp" or language == "fsharp" or language == "dotnet" then
+        return "dotnet"
+    elseif language == "wasm" then
+        return "rust"
+    end
+    return language
+end
+
+local function in_dependency_scope(package_language, scope)
+    if scope == "dotnet" then
+        return package_language == "csharp" or package_language == "fsharp" or package_language == "dotnet"
+    elseif scope == "rust" then
+        return package_language == "rust" or package_language == "wasm"
+    end
+    return package_language == scope
+end
+
+local function read_cargo_package_name(pkg)
+    local text = read_file(pkg.path .. "/Cargo.toml")
+    if not text then return nil end
+
+    for line in text:gmatch("[^\n]+") do
+        local name = line:match('^%s*name%s*=%s*"([^"]+)"')
+        if name then
+            return name:lower()
+        end
+    end
+
+    return nil
+end
+
+local function set_known(known, key, pkg)
+    if not known[key] then
+        known[key] = pkg.name
+        return
+    end
+
+    local normalized = pkg.path:gsub("\\", "/"):lower()
+    if not normalized:match("/programs/") then
+        known[key] = pkg.name
+    end
 end
 
 -- =========================================================================
@@ -273,6 +370,27 @@ local function parse_rust_deps(pkg, known_names)
     return deps
 end
 
+local function parse_swift_deps(pkg, known_names)
+    local text = read_file(pkg.path .. "/Package.swift")
+    if not text then return {} end
+
+    local deps = {}
+    for dep_path in text:gmatch('%.package%s*%(%s*path%s*:%s*"([^"]+)"') do
+        local cleaned = normalize_path(dep_path)
+        if not cleaned:match("^[A-Za-z]:/") and cleaned:sub(1, 1) ~= "/" then
+            local dep_dir = cleaned:match("([^/]+)$")
+            if dep_dir and dep_dir ~= "." and dep_dir ~= ".." then
+                dep_dir = dep_dir:lower()
+                if known_names[dep_dir] then
+                    deps[#deps + 1] = known_names[dep_dir]
+                end
+            end
+        end
+    end
+
+    return deps
+end
+
 -- =========================================================================
 -- Elixir dependency parsing
 -- =========================================================================
@@ -437,6 +555,26 @@ local function parse_haskell_deps(pkg, known_names)
     return deps
 end
 
+local function parse_dotnet_deps(pkg, known_names)
+    local project_files = find_files_by_extensions(pkg.path, {"csproj", "fsproj"})
+    if #project_files == 0 then return {} end
+
+    local deps = {}
+    for _, project_file in ipairs(project_files) do
+        local text = read_file(project_file)
+        if text then
+            for include_path in text:gmatch('<ProjectReference%s+Include%s*=%s*"([^"]+)"') do
+                local normalized = normalize_path(pkg.path .. "/" .. include_path)
+                if known_names[normalized] then
+                    deps[#deps + 1] = known_names[normalized]
+                end
+            end
+        end
+    end
+
+    return deps
+end
+
 -- =========================================================================
 
 --- Build a mapping from ecosystem-specific dependency names to internal
@@ -455,58 +593,64 @@ end
 --
 -- @param packages table List of package records.
 -- @return table Mapping from ecosystem name to package name.
-function Resolver.build_known_names(packages)
+function Resolver.build_known_names(packages, language)
     local known = {}
+    local scope = language or ""
 
     for _, pkg in ipairs(packages) do
-        -- Extract the directory basename.
-        local basename = pkg.path:gsub("\\", "/"):match("([^/]+)$"):lower()
+        if scope == "" or in_dependency_scope(pkg.language, scope) then
+            local basename = pkg.path:gsub("\\", "/"):match("([^/]+)$"):lower()
 
-        if pkg.language == "python" then
-            local pypi_name = "coding-adventures-" .. basename
-            known[pypi_name] = pkg.name
+            if pkg.language == "python" then
+                set_known(known, "coding-adventures-" .. basename, pkg)
 
-        elseif pkg.language == "ruby" then
-            local gem_name = "coding_adventures_" .. basename
-            known[gem_name] = pkg.name
+            elseif pkg.language == "ruby" then
+                set_known(known, "coding_adventures_" .. basename, pkg)
 
-        elseif pkg.language == "go" then
-            local text = read_file(pkg.path .. "/go.mod")
-            if text then
-                for line in text:gmatch("[^\n]+") do
-                    if line:match("^module ") then
-                        local module_path = line:gsub("^module%s+", ""):match("^%s*(.-)%s*$"):lower()
-                        known[module_path] = pkg.name
-                        break
+            elseif pkg.language == "go" then
+                local text = read_file(pkg.path .. "/go.mod")
+                if text then
+                    for line in text:gmatch("[^\n]+") do
+                        if line:match("^module ") then
+                            local module_path = line:gsub("^module%s+", ""):match("^%s*(.-)%s*$"):lower()
+                            known[module_path] = pkg.name
+                            break
+                        end
                     end
                 end
+
+            elseif pkg.language == "typescript" then
+                set_known(known, "@coding-adventures/" .. basename, pkg)
+                set_known(known, basename, pkg)
+
+            elseif pkg.language == "rust" or pkg.language == "wasm" then
+                set_known(known, basename, pkg)
+                local cargo_name = read_cargo_package_name(pkg)
+                if cargo_name then
+                    set_known(known, cargo_name, pkg)
+                end
+
+            elseif pkg.language == "elixir" then
+                set_known(known, "coding_adventures_" .. basename:gsub("%-", "_"), pkg)
+                set_known(known, basename:gsub("%-", "_"), pkg)
+
+            elseif pkg.language == "lua" then
+                set_known(known, "coding-adventures-" .. basename:gsub("_", "-"), pkg)
+
+            elseif pkg.language == "perl" then
+                set_known(known, "coding-adventures-" .. basename, pkg)
+
+            elseif pkg.language == "swift" then
+                set_known(known, basename, pkg)
+
+            elseif pkg.language == "haskell" then
+                set_known(known, "coding-adventures-" .. basename:gsub("_", "-"), pkg)
+
+            elseif pkg.language == "csharp" or pkg.language == "fsharp" or pkg.language == "dotnet" then
+                for _, project_file in ipairs(find_files_by_extensions(pkg.path, {"csproj", "fsproj"})) do
+                    known[normalize_path(project_file)] = pkg.name
+                end
             end
-
-        elseif pkg.language == "typescript" then
-            local npm_name = "@coding-adventures/" .. basename
-            known[npm_name] = pkg.name
-
-        elseif pkg.language == "rust" then
-            known[basename] = pkg.name
-
-        elseif pkg.language == "elixir" then
-            local app_name = "coding_adventures_" .. basename:gsub("%-", "_")
-            known[app_name] = pkg.name
-
-        elseif pkg.language == "lua" then
-            -- Lua dirs use underscores, rockspec names use hyphens.
-            local rockspec_name = "coding-adventures-" .. basename:gsub("_", "-")
-            known[rockspec_name] = pkg.name
-
-        elseif pkg.language == "perl" then
-            -- Perl CPAN dist names use hyphens: "logic-gates" -> "coding-adventures-logic-gates"
-            -- This matches the Python convention exactly.
-            local cpan_name = "coding-adventures-" .. basename
-            known[cpan_name] = pkg.name
-
-        elseif pkg.language == "haskell" then
-            local cabal_name = "coding-adventures-" .. basename:gsub("_", "-")
-            known[cabal_name] = pkg.name
         end
     end
 
@@ -533,8 +677,13 @@ function Resolver.resolve_dependencies(packages)
         graph:add_node(pkg.name)
     end
 
-    -- Build the ecosystem-specific name mapping table.
-    local known_names = Resolver.build_known_names(packages)
+    local known_names_by_scope = {}
+    for _, pkg in ipairs(packages) do
+        local scope = dependency_scope(pkg.language)
+        if not known_names_by_scope[scope] then
+            known_names_by_scope[scope] = Resolver.build_known_names(packages, scope)
+        end
+    end
 
     -- Dispatch table for language-specific parsers.
     local parsers = {
@@ -543,16 +692,22 @@ function Resolver.resolve_dependencies(packages)
         go         = parse_go_deps,
         typescript = parse_typescript_deps,
         rust       = parse_rust_deps,
+        wasm       = parse_rust_deps,
         elixir     = parse_elixir_deps,
         lua        = parse_lua_deps,
         perl       = parse_perl_deps,
+        swift      = parse_swift_deps,
         haskell    = parse_haskell_deps,
+        csharp     = parse_dotnet_deps,
+        fsharp     = parse_dotnet_deps,
+        dotnet     = parse_dotnet_deps,
     }
 
     -- Parse dependencies for each package and add edges.
     for _, pkg in ipairs(packages) do
         local parser = parsers[pkg.language]
         if parser then
+            local known_names = known_names_by_scope[dependency_scope(pkg.language)] or {}
             local deps = parser(pkg, known_names)
             for _, dep_name in ipairs(deps) do
                 -- Edge direction: dep → pkg means "dep must be built before pkg".

--- a/code/programs/lua/build-tool/tests/test_discovery.lua
+++ b/code/programs/lua/build-tool/tests/test_discovery.lua
@@ -39,6 +39,22 @@ describe("Discovery", function()
             assert.are.equal("elixir", Discovery.infer_language("/repo/code/packages/elixir/logic_gates"))
         end)
 
+        it("detects swift from path", function()
+            assert.are.equal("swift", Discovery.infer_language("/repo/code/packages/swift/graph"))
+        end)
+
+        it("detects wasm from path", function()
+            assert.are.equal("wasm", Discovery.infer_language("/repo/code/packages/wasm/graph"))
+        end)
+
+        it("detects csharp from path", function()
+            assert.are.equal("csharp", Discovery.infer_language("/repo/code/packages/csharp/graph"))
+        end)
+
+        it("detects fsharp from path", function()
+            assert.are.equal("fsharp", Discovery.infer_language("/repo/code/packages/fsharp/graph"))
+        end)
+
         it("returns unknown for unrecognized paths", function()
             assert.are.equal("unknown", Discovery.infer_language("/repo/code/packages/fortran/matrix"))
         end)

--- a/code/programs/lua/build-tool/tests/test_resolver.lua
+++ b/code/programs/lua/build-tool/tests/test_resolver.lua
@@ -91,6 +91,30 @@ describe("Resolver", function()
             assert.are.equal("python/arithmetic", known["coding-adventures-arithmetic"])
             assert.are.equal("ruby/arithmetic", known["coding_adventures_arithmetic"])
         end)
+
+        it("maps wasm crates into the rust dependency scope", function()
+            local tmpbase = os.tmpname()
+            os.remove(tmpbase)
+            os.execute('mkdir "' .. tmpbase .. '"')
+            os.execute('mkdir "' .. tmpbase .. '/wasm_graph"')
+
+            local cargo = io.open(tmpbase .. "/wasm_graph/Cargo.toml", "w")
+            cargo:write('[package]\nname = "graph-wasm"\n')
+            cargo:close()
+
+            local packages = {{
+                name = "wasm/graph",
+                path = tmpbase .. "/wasm_graph",
+                language = "wasm",
+            }}
+
+            local known = Resolver.build_known_names(packages, "rust")
+            assert.are.equal("wasm/graph", known["graph-wasm"])
+
+            os.remove(tmpbase .. "/wasm_graph/Cargo.toml")
+            os.execute('rmdir "' .. tmpbase .. '/wasm_graph"')
+            os.execute('rmdir "' .. tmpbase .. '"')
+        end)
     end)
 
     describe("resolve_dependencies", function()
@@ -164,6 +188,45 @@ describe("Resolver", function()
             local graph = Resolver.resolve_dependencies(packages)
             assert.is_true(graph:has_node("lua/empty"))
             assert.are.equal(0, #graph:predecessors("lua/empty"))
+        end)
+
+        it("parses .NET project references across C# and F#", function()
+            local tmpbase = os.tmpname()
+            os.remove(tmpbase)
+            os.execute('mkdir "' .. tmpbase .. '"')
+            os.execute('mkdir "' .. tmpbase .. '/graph"')
+            os.execute('mkdir "' .. tmpbase .. '/graph-tests"')
+
+            local dep = io.open(tmpbase .. "/graph/CodingAdventures.Graph.csproj", "w")
+            dep:write('<Project Sdk="Microsoft.NET.Sdk"></Project>\n')
+            dep:close()
+
+            local app = io.open(tmpbase .. "/graph-tests/CodingAdventures.Graph.Tests.fsproj", "w")
+            app:write('<Project Sdk="Microsoft.NET.Sdk">\n')
+            app:write('  <ItemGroup>\n')
+            app:write('    <ProjectReference Include="../graph/CodingAdventures.Graph.csproj" />\n')
+            app:write('  </ItemGroup>\n')
+            app:write('</Project>\n')
+            app:close()
+
+            local packages = {
+                {name = "csharp/graph", path = tmpbase .. "/graph", language = "csharp", build_commands = {}},
+                {name = "fsharp/graph-tests", path = tmpbase .. "/graph-tests", language = "fsharp", build_commands = {}},
+            }
+
+            local graph = Resolver.resolve_dependencies(packages)
+            local preds = graph:predecessors("fsharp/graph-tests")
+            local found = false
+            for _, pred in ipairs(preds) do
+                if pred == "csharp/graph" then found = true end
+            end
+            assert.is_true(found, "csharp/graph should be a predecessor of fsharp/graph-tests")
+
+            os.remove(tmpbase .. "/graph/CodingAdventures.Graph.csproj")
+            os.remove(tmpbase .. "/graph-tests/CodingAdventures.Graph.Tests.fsproj")
+            os.execute('rmdir "' .. tmpbase .. '/graph"')
+            os.execute('rmdir "' .. tmpbase .. '/graph-tests"')
+            os.execute('rmdir "' .. tmpbase .. '"')
         end)
     end)
 end)

--- a/code/programs/perl/build-tool/BUILD
+++ b/code/programs/perl/build-tool/BUILD
@@ -1,2 +1,2 @@
-cpanm --with-test --installdeps --quiet .
+cpanm --installdeps --quiet .
 prove -l -v t/

--- a/code/programs/perl/build-tool/lib/CodingAdventures/BuildTool/Discovery.pm
+++ b/code/programs/perl/build-tool/lib/CodingAdventures/BuildTool/Discovery.pm
@@ -45,7 +45,8 @@ our $VERSION = '0.01';
 # which ecosystem a package belongs to. The order does not matter for
 # correctness but we list them alphabetically for readability.
 my @KNOWN_LANGUAGES = qw(
-    elixir go lua perl python ruby rust starlark typescript
+    python ruby go rust typescript elixir lua perl swift wasm haskell starlark
+    java kotlin csharp fsharp dotnet
 );
 
 # SKIP_DIRS -- directory names that we never descend into during the walk.
@@ -56,7 +57,7 @@ my @KNOWN_LANGUAGES = qw(
 my %SKIP_DIRS = map { $_ => 1 } qw(
     .git .hg .svn .venv .tox .mypy_cache .pytest_cache .ruff_cache
     __pycache__ node_modules vendor dist build target .claude Pods
-    _build blib
+    _build blib .build .gradle gradle-build
 );
 
 # new -- Constructor.
@@ -142,7 +143,11 @@ sub discover {
                 # (Avoids registering the same package multiple times when
                 # both BUILD and BUILD_mac exist.)
                 my $canonical = File::Spec->catfile($dir, $build_file);
-                return unless $fullpath eq $canonical;
+                my $normalized_fullpath = $fullpath;
+                my $normalized_canonical = $canonical;
+                $normalized_fullpath =~ s{\\}{/}g;
+                $normalized_canonical =~ s{\\}{/}g;
+                return unless $normalized_fullpath eq $normalized_canonical;
 
                 # Read the BUILD commands — non-blank, non-comment lines.
                 my @commands = _read_commands($canonical);

--- a/code/programs/perl/build-tool/lib/CodingAdventures/BuildTool/Executor.pm
+++ b/code/programs/perl/build-tool/lib/CodingAdventures/BuildTool/Executor.pm
@@ -50,8 +50,11 @@ package CodingAdventures::BuildTool::Executor;
 use strict;
 use warnings;
 use POSIX qw(WIFEXITED WEXITSTATUS WNOHANG);
+use Cwd ();
+use File::Spec ();
 
 our $VERSION = '0.01';
+our $WINDOWS_BASH;
 
 # new -- Constructor.
 #
@@ -284,13 +287,7 @@ sub _run_single {
     my $status = 'pass';
 
     for my $cmd (@cmds) {
-        # Run the command in the package directory.
-        # We capture combined stdout and stderr using a shell redirect.
-        # The backtick operator (`) is Perl's shorthand for command substitution.
-        # We use system() instead to stream output and check the exit code.
-        my $full_cmd = "cd \Q$path\E && $cmd 2>&1";
-        my $out = `$full_cmd`;
-        my $exit_code = $? >> 8;
+        my ($out, $exit_code) = $self->_run_command_in_dir($path, $cmd);
 
         push @output, "\$ $cmd\n$out";  # \$ is a literal $ ($ $cmd would deref $cmd)
 
@@ -308,6 +305,77 @@ sub _run_single {
         duration => $duration,
         output   => join("\n", @output),
     };
+}
+
+sub _run_command_in_dir {
+    my ($self, $path, $cmd) = @_;
+
+    my $cwd = Cwd::getcwd();
+    if (!chdir $path) {
+        return ("chdir $path failed: $!\n", 1);
+    }
+
+    my @shell = _shell_argv($cmd);
+    my $output = '';
+
+    my $opened = open(my $fh, '-|', @shell);
+    if (!$opened) {
+        my $err = "failed to start command: $!\n";
+        chdir $cwd or die "chdir $cwd failed: $!";
+        return ($err, 1);
+    }
+
+    local $/;
+    $output = <$fh> // '';
+    close $fh;
+    my $exit_code = $? >> 8;
+
+    chdir $cwd or die "chdir $cwd failed: $!";
+    return ($output, $exit_code);
+}
+
+sub _shell_argv {
+    my ($cmd) = @_;
+    my $redirected = "$cmd 2>&1";
+
+    if ($^O eq 'MSWin32') {
+        my $bash = _windows_bash();
+        return ($bash, '-lc', _command_for_windows_bash($redirected)) if defined $bash;
+        return ('cmd', '/d', '/s', '/c', $redirected);
+    }
+
+    return ('sh', '-lc', $redirected);
+}
+
+sub _command_for_windows_bash {
+    my ($cmd) = @_;
+    $cmd =~ s{([A-Za-z]):([\\/][^\s'"]*)}{_bashify_windows_path($1, $2)}ge;
+    return $cmd;
+}
+
+sub _bashify_windows_path {
+    my ($drive, $rest) = @_;
+    $rest =~ s{\\}{/}g;
+    return '/' . lc($drive) . $rest;
+}
+
+sub _windows_bash {
+    return $WINDOWS_BASH if defined $WINDOWS_BASH;
+
+    my @candidates = grep { defined $_ && $_ ne '' } (
+        File::Spec->catfile($ENV{ProgramFiles} // '', 'Git', 'bin', 'bash.exe'),
+        File::Spec->catfile($ENV{'ProgramFiles(x86)'} // '', 'Git', 'bin', 'bash.exe'),
+    );
+
+    for my $candidate (@candidates) {
+        if (-f $candidate) {
+            $WINDOWS_BASH = $candidate;
+            return $WINDOWS_BASH;
+        }
+    }
+
+    $WINDOWS_BASH = undef;
+    return $WINDOWS_BASH;
 }
 
 # _cpu_count -- Detect the number of logical CPUs.

--- a/code/programs/perl/build-tool/lib/CodingAdventures/BuildTool/GitDiff.pm
+++ b/code/programs/perl/build-tool/lib/CodingAdventures/BuildTool/GitDiff.pm
@@ -116,9 +116,11 @@ sub affected_packages {
     for my $file (@changed_files) {
         # Make the file path absolute for prefix matching.
         my $abs_file = File::Spec->catfile($root, $file);
+        $abs_file =~ s{\\}{/}g;
 
         for my $pkg (@{$packages_ref}) {
             my $pkg_path = $pkg->{path};
+            $pkg_path =~ s{\\}{/}g;
             # Use \Q...\E to escape any regex metacharacters in the path.
             # The path separator is a metacharacter on Windows.
             if ($abs_file =~ /^\Q$pkg_path\E(\/|$)/) {

--- a/code/programs/perl/build-tool/lib/CodingAdventures/BuildTool/Resolver.pm
+++ b/code/programs/perl/build-tool/lib/CodingAdventures/BuildTool/Resolver.pm
@@ -50,6 +50,7 @@ use strict;
 use warnings;
 use File::Spec ();
 use File::Basename ();
+use File::Find ();
 use Scalar::Util qw(blessed);
 
 our $VERSION = '0.01';
@@ -236,6 +237,55 @@ sub new {
     return bless {}, $class;
 }
 
+sub _dependency_scope {
+    my ($language) = @_;
+    return 'dotnet' if $language eq 'csharp' || $language eq 'fsharp' || $language eq 'dotnet';
+    return 'rust' if $language eq 'wasm';
+    return $language;
+}
+
+sub _in_dependency_scope {
+    my ($package_language, $scope) = @_;
+    return $package_language eq 'csharp' || $package_language eq 'fsharp' || $package_language eq 'dotnet'
+        if $scope eq 'dotnet';
+    return $package_language eq 'rust' || $package_language eq 'wasm'
+        if $scope eq 'rust';
+    return $package_language eq $scope;
+}
+
+sub _normalize_path {
+    my ($path) = @_;
+    return lc File::Spec->canonpath($path);
+}
+
+sub _read_cargo_package_name {
+    my ($pkg) = @_;
+    my $cargo = File::Spec->catfile($pkg->{path}, 'Cargo.toml');
+    my $text = _slurp($cargo) // return undef;
+
+    for my $line (split /\n/, $text) {
+        if ($line =~ /^\s*name\s*=\s*"([^"]+)"/) {
+            return lc $1;
+        }
+    }
+
+    return undef;
+}
+
+sub _set_known {
+    my ($known_ref, $key, $pkg) = @_;
+    if (!exists $known_ref->{$key}) {
+        $known_ref->{$key} = $pkg->{name};
+        return;
+    }
+
+    my $normalized = $pkg->{path};
+    $normalized =~ s{\\}{/}g;
+    if ($normalized !~ m{/programs/}i) {
+        $known_ref->{$key} = $pkg->{name};
+    }
+}
+
 # resolve -- Build a dependency graph from a list of packages.
 #
 # For each package, reads its metadata file and extracts internal dependencies.
@@ -247,16 +297,20 @@ sub resolve {
     my ($self, $packages_ref) = @_;
 
     my $graph = CodingAdventures::BuildTool::Graph->new();
-    my %known_names = $self->build_known_names($packages_ref);
+    my %known_names_by_scope;
 
     # Add all packages as nodes first — even isolated packages with no deps.
     for my $pkg (@{$packages_ref}) {
         $graph->add_node($pkg->{name});
+        my $language = $pkg->{language};
+        if (!exists $known_names_by_scope{$language}) {
+            $known_names_by_scope{$language} = { $self->build_known_names($packages_ref, $language) };
+        }
     }
 
     # Parse dependencies for each package and add edges.
     for my $pkg (@{$packages_ref}) {
-        my @deps = $self->resolve_dependencies($pkg, \%known_names);
+        my @deps = $self->resolve_dependencies($pkg, $known_names_by_scope{$pkg->{language}});
         for my $dep (@deps) {
             # Edge: dep -> pkg (dep must be built before pkg).
             $graph->add_edge($dep, $pkg->{name});
@@ -281,10 +335,13 @@ sub resolve {
 # @param \@packages -- arrayref of package hashrefs.
 # @return hash mapping ecosystem name -> graph node name.
 sub build_known_names {
-    my ($self, $packages_ref) = @_;
+    my ($self, $packages_ref, $language) = @_;
     my %known;
+    $language //= '';
+    my $scope = $language eq '' ? '' : _dependency_scope($language);
 
     for my $pkg (@{$packages_ref}) {
+        next if $scope ne '' && !_in_dependency_scope($pkg->{language}, $scope);
         my $dir_name  = File::Basename::basename($pkg->{path});
         my $lang      = $pkg->{language};
 
@@ -292,14 +349,14 @@ sub build_known_names {
             # Python: coding-adventures-<kebab> (hyphens, lowercase).
             my $cpan_name = "coding-adventures-$dir_name";
             $cpan_name =~ tr/A-Z/a-z/;
-            $known{$cpan_name} = $pkg->{name};
+            _set_known(\%known, $cpan_name, $pkg);
 
         } elsif ($lang eq 'ruby') {
             # Ruby: coding_adventures_<snake> (underscores, lowercase).
             my $gem_name = "coding_adventures_$dir_name";
             $gem_name =~ s/-/_/g;
             $gem_name =~ tr/A-Z/a-z/;
-            $known{$gem_name} = $pkg->{name};
+            _set_known(\%known, $gem_name, $pkg);
 
         } elsif ($lang eq 'go') {
             # Go: full module path github.com/adhithyan15/.../go/<name>.
@@ -311,39 +368,71 @@ sub build_known_names {
             # TypeScript: @coding-adventures/<kebab> (npm scoped package).
             my $npm_name = "\@coding-adventures/$dir_name";
             $npm_name =~ tr/A-Z/a-z/;
-            $known{$npm_name} = $pkg->{name};
+            _set_known(\%known, $npm_name, $pkg);
+            _set_known(\%known, lc($dir_name), $pkg);
 
         } elsif ($lang eq 'rust') {
             # Rust: bare crate name (hyphens, lowercase).
             my $crate_name = $dir_name;
             $crate_name =~ tr/A-Z/a-z/;
-            $known{$crate_name} = $pkg->{name};
+            _set_known(\%known, $crate_name, $pkg);
+            my $cargo_name = _read_cargo_package_name($pkg);
+            _set_known(\%known, $cargo_name, $pkg) if defined $cargo_name;
+
+        } elsif ($lang eq 'wasm') {
+            # WASM wrappers should resolve through their explicit Cargo package
+            # names (for example "graph-wasm"), not bare Rust crate names.
+            my $cargo_name = _read_cargo_package_name($pkg);
+            _set_known(\%known, $cargo_name, $pkg) if defined $cargo_name;
 
         } elsif ($lang eq 'elixir') {
             # Elixir: :coding_adventures_<snake> atom (underscores).
             my $mix_name = "coding_adventures_$dir_name";
             $mix_name =~ s/-/_/g;
             $mix_name =~ tr/A-Z/a-z/;
-            $known{$mix_name}          = $pkg->{name};
-            $known{":$mix_name"}       = $pkg->{name};
+            _set_known(\%known, $mix_name, $pkg);
+            _set_known(\%known, ":$mix_name", $pkg);
 
         } elsif ($lang eq 'lua') {
             # Lua: coding-adventures-<kebab> (same as Python).
             my $rock_name = "coding-adventures-$dir_name";
             $rock_name =~ tr/A-Z/a-z/;
-            $known{$rock_name} = $pkg->{name};
+            _set_known(\%known, $rock_name, $pkg);
 
         } elsif ($lang eq 'perl') {
             # Perl: coding-adventures-<kebab> (same convention as Python/Lua).
             my $dist_name = "coding-adventures-$dir_name";
             $dist_name =~ tr/A-Z/a-z/;
-            $known{$dist_name} = $pkg->{name};
+            _set_known(\%known, $dist_name, $pkg);
+
+        } elsif ($lang eq 'swift') {
+            _set_known(\%known, lc($dir_name), $pkg);
 
         } elsif ($lang eq 'haskell') {
             # Haskell: coding-adventures-<kebab>
             my $cabal_name = "coding-adventures-$dir_name";
             $cabal_name =~ tr/A-Z/a-z/;
-            $known{$cabal_name} = $pkg->{name};
+            _set_known(\%known, $cabal_name, $pkg);
+
+        } elsif ($lang eq 'csharp' || $lang eq 'fsharp' || $lang eq 'dotnet') {
+            # .NET packages refer to sibling package directories via
+            # <ProjectReference Include="../graph/Graph.csproj" />.
+            _set_known(\%known, lc($dir_name), $pkg);
+            my @project_files;
+            File::Find::find(
+                {
+                    wanted => sub {
+                        return if -d $File::Find::name;
+                        return unless $_ =~ /\.(?:csproj|fsproj)\z/;
+                        push @project_files, $File::Find::name;
+                    },
+                    no_chdir => 1,
+                },
+                $pkg->{path},
+            );
+            for my $project_file (@project_files) {
+                $known{ _normalize_path($project_file) } = $pkg->{name};
+            }
         }
     }
 
@@ -370,7 +459,7 @@ sub resolve_dependencies {
         return $self->_parse_go_deps($pkg, $known_ref);
     } elsif ($lang eq 'typescript') {
         return $self->_parse_typescript_deps($pkg, $known_ref);
-    } elsif ($lang eq 'rust') {
+    } elsif ($lang eq 'rust' || $lang eq 'wasm') {
         return $self->_parse_rust_deps($pkg, $known_ref);
     } elsif ($lang eq 'elixir') {
         return $self->_parse_elixir_deps($pkg, $known_ref);
@@ -378,8 +467,12 @@ sub resolve_dependencies {
         return $self->_parse_lua_deps($pkg, $known_ref);
     } elsif ($lang eq 'perl') {
         return $self->_parse_perl_deps($pkg, $known_ref);
+    } elsif ($lang eq 'swift') {
+        return $self->_parse_swift_deps($pkg, $known_ref);
     } elsif ($lang eq 'haskell') {
         return $self->_parse_haskell_deps($pkg, $known_ref);
+    } elsif ($lang eq 'csharp' || $lang eq 'fsharp' || $lang eq 'dotnet') {
+        return $self->_parse_dotnet_deps($pkg, $known_ref);
     }
     return ();
 }
@@ -581,6 +674,59 @@ sub _parse_haskell_deps {
         next unless exists $known_ref->{$dep};
         next if $known_ref->{$dep} eq $pkg->{name};
         push @deps, $known_ref->{$dep};
+    }
+    return @deps;
+}
+
+sub _parse_swift_deps {
+    my ($self, $pkg, $known_ref) = @_;
+    my $manifest = File::Spec->catfile($pkg->{path}, 'Package.swift');
+    my $text = _slurp($manifest) // return ();
+
+    my @deps;
+    while ($text =~ /\.package\s*\(\s*path\s*:\s*"([^"]+)"/g) {
+        my $dep_path = $1;
+        next if File::Spec->file_name_is_absolute($dep_path);
+        my $cleaned = File::Spec->canonpath($dep_path);
+        my @parts = grep { defined $_ && $_ ne '' } File::Spec->splitdir($cleaned);
+        my $dep_dir = $parts[-1];
+        next if !defined $dep_dir || $dep_dir eq '.' || $dep_dir eq '..';
+        my $key = lc $dep_dir;
+        push @deps, $known_ref->{$key} if exists $known_ref->{$key};
+    }
+    return @deps;
+}
+
+sub _parse_dotnet_deps {
+    my ($self, $pkg, $known_ref) = @_;
+
+    my @project_files;
+    File::Find::find(
+        {
+            wanted => sub {
+                return if -d $File::Find::name;
+                return unless $_ =~ /\.(?:csproj|fsproj)\z/;
+                push @project_files, $File::Find::name;
+            },
+            no_chdir => 1,
+        },
+        $pkg->{path},
+    );
+
+    my @deps;
+    for my $project_file (@project_files) {
+        my $text = _slurp($project_file) // next;
+        while ($text =~ /<ProjectReference\s+Include\s*=\s*"([^"]+)"/g) {
+            my $include = $1;
+            next if File::Spec->file_name_is_absolute($include);
+            my $cleaned = File::Spec->canonpath($include);
+            my @parts = grep { defined $_ && $_ ne '' } File::Spec->splitdir($cleaned);
+            next if !@parts;
+            my $dep_dir = @parts >= 2 ? $parts[-2] : $parts[0];
+            next if !defined $dep_dir || $dep_dir eq '.' || $dep_dir eq '..';
+            my $key = lc $dep_dir;
+            push @deps, $known_ref->{$key} if exists $known_ref->{$key};
+        }
     }
     return @deps;
 }

--- a/code/programs/perl/build-tool/t/00-discovery.t
+++ b/code/programs/perl/build-tool/t/00-discovery.t
@@ -101,6 +101,34 @@ subtest 'infer python language' => sub {
 };
 
 # ---------------------------------------------------------------------------
+# Test 4b: Infer C# language
+# ---------------------------------------------------------------------------
+subtest 'infer csharp language' => sub {
+    my $root = tempdir(CLEANUP => 1);
+    make_pkg($root, 'packages/csharp/graph');
+
+    my $d = CodingAdventures::BuildTool::Discovery->new(root => $root);
+    $d->discover();
+    my @pkgs = @{ $d->packages() };
+
+    is($pkgs[0]{language}, 'csharp', 'language is csharp');
+};
+
+# ---------------------------------------------------------------------------
+# Test 4c: Infer wasm language
+# ---------------------------------------------------------------------------
+subtest 'infer wasm language' => sub {
+    my $root = tempdir(CLEANUP => 1);
+    make_pkg($root, 'packages/wasm/graph');
+
+    my $d = CodingAdventures::BuildTool::Discovery->new(root => $root);
+    $d->discover();
+    my @pkgs = @{ $d->packages() };
+
+    is($pkgs[0]{language}, 'wasm', 'language is wasm');
+};
+
+# ---------------------------------------------------------------------------
 # Test 5: Skip .git directories
 # ---------------------------------------------------------------------------
 subtest 'skip .git directories' => sub {

--- a/code/programs/perl/build-tool/t/01-resolver.t
+++ b/code/programs/perl/build-tool/t/01-resolver.t
@@ -14,6 +14,7 @@ use lib "$Bin/../lib";
 use Test2::V0;
 use File::Temp qw(tempdir);
 use File::Path qw(make_path);
+use File::Spec ();
 
 use CodingAdventures::BuildTool::Resolver;
 
@@ -132,6 +133,19 @@ subtest 'rust dep parsed from Cargo.toml' => sub {
     is($deps[0],     'rust/logic-gates', 'dep is rust/logic-gates');
 };
 
+subtest 'wasm dep parsed through rust scope' => sub {
+    my $pkg     = make_pkg(name => 'wasm/arithmetic',  language => 'wasm');
+    my $dep_pkg = make_pkg(name => 'rust/logic-gates', language => 'rust');
+    write_file("$pkg->{path}/Cargo.toml",
+        "[package]\nname = \"arithmetic-wasm\"\n\n[dependencies]\nlogic-gates = { path = \"../../packages/rust/logic-gates\" }\n");
+
+    my %known = $r->build_known_names([$pkg, $dep_pkg], 'rust');
+    my @deps  = $r->resolve_dependencies($pkg, \%known);
+
+    is(scalar @deps, 1,                 'one dep');
+    is($deps[0],     'rust/logic-gates', 'dep is rust/logic-gates');
+};
+
 subtest 'elixir dep parsed from mix.exs' => sub {
     my $pkg     = make_pkg(name => 'elixir/arithmetic',  language => 'elixir');
     my $dep_pkg = make_pkg(name => 'elixir/logic-gates', language => 'elixir');
@@ -156,6 +170,21 @@ subtest 'lua dep parsed from rockspec' => sub {
 
     is(scalar @deps, 1,               'one dep');
     is($deps[0],     'lua/logic-gates', 'dep is lua/logic-gates');
+};
+
+subtest '.NET dep parsed from project reference' => sub {
+    my $pkg     = make_pkg(name => 'fsharp/graph-tests', language => 'fsharp');
+    my $dep_pkg = make_pkg(name => 'csharp/graph',      language => 'csharp');
+    write_file("$dep_pkg->{path}/CodingAdventures.Graph.csproj",
+        "<Project Sdk=\"Microsoft.NET.Sdk\"></Project>\n");
+    write_file("$pkg->{path}/CodingAdventures.Graph.Tests.fsproj",
+        "<Project Sdk=\"Microsoft.NET.Sdk\">\n  <ItemGroup>\n    <ProjectReference Include=\"../graph/CodingAdventures.Graph.csproj\" />\n  </ItemGroup>\n</Project>\n");
+
+    my %known = $r->build_known_names([$pkg, $dep_pkg], 'dotnet');
+    my @deps  = $r->resolve_dependencies($pkg, \%known);
+
+    is(scalar @deps, 1,           'one dep');
+    is($deps[0],     'csharp/graph', 'dep is csharp/graph');
 };
 
 # ---------------------------------------------------------------------------
@@ -275,6 +304,17 @@ subtest 'known name for Rust' => sub {
     my $pkg   = make_pkg(name => 'rust/logic-gates', language => 'rust');
     my %known = $r->build_known_names([$pkg]);
     ok(exists $known{'logic-gates'}, 'rust known name registered');
+};
+
+subtest 'known name for .NET project file' => sub {
+    my $pkg = make_pkg(name => 'csharp/graph', language => 'csharp');
+    write_file("$pkg->{path}/CodingAdventures.Graph.csproj",
+        "<Project Sdk=\"Microsoft.NET.Sdk\"></Project>\n");
+
+    my %known = $r->build_known_names([$pkg], 'dotnet');
+    my $expected = lc File::Spec->canonpath("$pkg->{path}/CodingAdventures.Graph.csproj");
+    ok(exists $known{$expected}, 'dotnet project path registered');
+    is($known{$expected}, 'csharp/graph', 'maps correctly');
 };
 
 # ---------------------------------------------------------------------------

--- a/code/programs/ruby/build-tool/build.rb
+++ b/code/programs/ruby/build-tool/build.rb
@@ -66,7 +66,10 @@ module BuildTool
     module_function
 
     # ALL_LANGUAGES is the canonical list of package languages this CLI builds.
-    ALL_LANGUAGES = %w[python ruby go typescript rust elixir lua perl swift haskell].freeze
+    ALL_LANGUAGES = %w[
+      python ruby go typescript rust elixir lua perl swift java kotlin
+      haskell wasm csharp fsharp dotnet
+    ].freeze
 
     # ALL_TOOLCHAINS is the canonical list of CI toolchains we can request.
     ALL_TOOLCHAINS = %w[
@@ -184,7 +187,7 @@ module BuildTool
         end
 
         opts.on("--language LANG",
-                "Only build packages of this language (#{ALL_LANGUAGES.join('/')}//all)") do |lang|
+                "Only build packages of this language (#{ALL_LANGUAGES.join('/')}/all)") do |lang|
           options[:language] = lang
         end
 

--- a/code/programs/ruby/build-tool/lib/build_tool/discovery.rb
+++ b/code/programs/ruby/build-tool/lib/build_tool/discovery.rb
@@ -61,7 +61,10 @@ module BuildTool
     # KNOWN_LANGUAGES lists the language directory names we look for when
     # inferring which ecosystem a package belongs to. If a package lives
     # under a directory with one of these names, we tag it accordingly.
-    KNOWN_LANGUAGES = %w[python ruby go rust typescript elixir lua perl swift java kotlin].freeze
+    KNOWN_LANGUAGES = %w[
+      python ruby go rust typescript elixir lua perl swift haskell wasm
+      csharp fsharp dotnet java kotlin
+    ].freeze
 
     # SKIP_DIRS is the set of directory names that should never be traversed
     # during package discovery. These are known to contain non-source files

--- a/code/programs/ruby/build-tool/lib/build_tool/resolver.rb
+++ b/code/programs/ruby/build-tool/lib/build_tool/resolver.rb
@@ -510,6 +510,36 @@ module BuildTool
       internal_deps
     end
 
+    # parse_dotnet_deps -- Extract internal deps from .csproj/.fsproj.
+    #
+    # .NET packages declare sibling package dependencies via ProjectReference:
+    #
+    #   <ProjectReference Include="../logic-gates/logic-gates.csproj" />
+    #
+    # We extract the sibling directory name after "../" and map it back to
+    # the internal package name using the known names table.
+    def parse_dotnet_deps(package, known_names)
+      project_files = package.path.glob("*.csproj").to_a + package.path.glob("*.fsproj").to_a
+      return [] if project_files.empty?
+
+      internal_deps = []
+      pattern = /<ProjectReference\s+Include\s*=\s*"\.\.[\\\/]([^\/\\"]+)[\\\/][^"]*"/
+
+      project_files.each do |project_file|
+        project_file.read.lines.each do |line|
+          match = line.match(pattern)
+          next unless match
+
+          dep_dir = match[1].strip.downcase
+          next if dep_dir.include?("/") || dep_dir.include?("\\") || dep_dir == ".."
+
+          internal_deps << known_names[dep_dir] if known_names.key?(dep_dir)
+        end
+      end
+
+      internal_deps
+    end
+
     # SWIFT_DEP_RE -- Matches .package(path: "../dep-name") in Package.swift.
     SWIFT_DEP_RE = /\.package\s*\(\s*path\s*:\s*"\.\.\/(.*?)"/
 
@@ -661,7 +691,33 @@ module BuildTool
     #
     # @param packages [Array<Package>]
     # @return [Hash<String, String>]
-    def build_known_names(packages)
+    def dependency_scope(language)
+      return "dotnet" if %w[csharp fsharp dotnet].include?(language)
+      return "wasm" if language == "wasm"
+
+      language
+    end
+
+    def in_dependency_scope?(package_language, scope)
+      case scope
+      when "dotnet"
+        %w[csharp fsharp dotnet].include?(package_language)
+      when "wasm"
+        %w[wasm rust].include?(package_language)
+      else
+        package_language == scope
+      end
+    end
+
+    def read_cargo_package_name(pkg)
+      cargo_toml = pkg.path / "Cargo.toml"
+      return nil unless cargo_toml.exist?
+
+      match = cargo_toml.read.match(/^\s*name\s*=\s*"([^"]+)"/)
+      match && match[1].strip.downcase
+    end
+
+    def build_known_names(packages, language = nil)
       known = {}
 
       # set_known inserts key->value, letting library packages overwrite programs
@@ -676,6 +732,8 @@ module BuildTool
       end
 
       packages.each do |pkg|
+        next if language && !in_dependency_scope?(pkg.language, language)
+
         case pkg.language
         when "python"
           pypi_name = "coding-adventures-#{pkg.path.basename}".downcase
@@ -708,10 +766,12 @@ module BuildTool
             match = package_json.read.match(/"name"\s*:\s*"([^"]+)"/)
             set_known.call(match[1].strip.downcase, pkg.name, pkg.path) if match
           end
-        when "rust"
+        when "rust", "wasm"
           # Rust crate names use the directory name directly (kebab-case).
           crate_name = pkg.path.basename.to_s.downcase
           set_known.call(crate_name, pkg.name, pkg.path)
+          cargo_name = read_cargo_package_name(pkg)
+          set_known.call(cargo_name, pkg.name, pkg.path) if cargo_name
         when "elixir"
           # Elixir mix names replace hyphens with underscores.
           base_name = pkg.path.basename.to_s.gsub("-", "_").downcase
@@ -741,9 +801,10 @@ module BuildTool
           # Haskell Cabal package names use hyphens: "logic-gates" -> "coding-adventures-logic-gates"
           cabal_name = "coding-adventures-#{pkg.path.basename}".downcase
           set_known.call(cabal_name, pkg.name, pkg.path)
-        when "java", "kotlin"
+        when "java", "kotlin", "csharp", "fsharp", "dotnet"
           # Java and Kotlin use Gradle composite builds. Dependencies are
-          # referenced by directory name in settings.gradle.kts.
+          # referenced by directory name in settings.gradle.kts. .NET uses the
+          # sibling directory name from ProjectReference paths.
           dir_base = pkg.path.basename.to_s.downcase
           set_known.call(dir_base, pkg.name, pkg.path)
         end
@@ -768,23 +829,28 @@ module BuildTool
       # Add all packages as nodes first.
       packages.each { |pkg| graph.add_node(pkg.name) }
 
-      # Build the name-mapping table.
-      known_names = build_known_names(packages)
+      known_names_by_scope = {}
+      packages.each do |pkg|
+        scope = dependency_scope(pkg.language)
+        known_names_by_scope[scope] ||= build_known_names(packages, scope)
+      end
 
       # Parse dependencies for each package and add edges.
       packages.each do |pkg|
+        known_names = known_names_by_scope.fetch(dependency_scope(pkg.language))
         deps = case pkg.language
                when "python"     then parse_python_deps(pkg, known_names)
                when "ruby"       then parse_ruby_deps(pkg, known_names)
                when "go"         then parse_go_deps(pkg, known_names)
                when "typescript" then parse_typescript_deps(pkg, known_names)
-               when "rust"       then parse_rust_deps(pkg, known_names)
+               when "rust", "wasm" then parse_rust_deps(pkg, known_names)
                when "elixir"     then parse_elixir_deps(pkg, known_names)
                when "lua"        then parse_lua_deps(pkg, known_names)
                when "perl"       then parse_perl_deps(pkg, known_names)
                when "swift"      then parse_swift_deps(pkg, known_names)
                when "haskell"    then parse_haskell_deps(pkg, known_names)
                when "java", "kotlin" then parse_gradle_deps(pkg, known_names)
+               when "csharp", "fsharp", "dotnet" then parse_dotnet_deps(pkg, known_names)
                else []
                end
 

--- a/code/programs/ruby/build-tool/test/test_discovery.rb
+++ b/code/programs/ruby/build-tool/test/test_discovery.rb
@@ -66,7 +66,7 @@ class TestDiscovery < Minitest::Test
 
   def test_infer_language_unknown
     path = Pathname("/repo/code/packages/haskell/something")
-    assert_equal "unknown", BuildTool::Discovery.infer_language(path)
+    assert_equal "haskell", BuildTool::Discovery.infer_language(path)
   end
 
   # -- infer_package_name tests ------------------------------------------------

--- a/code/programs/rust/build-tool/src/discovery.rs
+++ b/code/programs/rust/build-tool/src/discovery.rs
@@ -117,7 +117,22 @@ fn infer_language(path: &Path) -> String {
     let path_str = path.to_string_lossy().replace('\\', "/");
     let parts: Vec<&str> = path_str.split('/').collect();
 
-    for lang in &["python", "ruby", "go", "rust", "typescript", "elixir", "lua", "perl"] {
+    for lang in &[
+        "python",
+        "ruby",
+        "go",
+        "rust",
+        "typescript",
+        "elixir",
+        "lua",
+        "perl",
+        "swift",
+        "haskell",
+        "wasm",
+        "csharp",
+        "fsharp",
+        "dotnet",
+    ] {
         for part in &parts {
             if part == lang {
                 return lang.to_string();

--- a/code/programs/rust/build-tool/src/main.rs
+++ b/code/programs/rust/build-tool/src/main.rs
@@ -80,7 +80,8 @@ struct Args {
     #[arg(long)]
     jobs: Option<usize>,
 
-    /// Filter to language: python, ruby, go, rust, haskell, or all.
+    /// Filter to language: python, ruby, go, typescript, rust, elixir, lua,
+    /// perl, swift, java, kotlin, haskell, wasm, csharp, fsharp, dotnet, or all.
     #[arg(long, default_value = "all")]
     language: String,
 

--- a/code/programs/rust/build-tool/src/resolver.rs
+++ b/code/programs/rust/build-tool/src/resolver.rs
@@ -34,8 +34,6 @@
 
 use std::collections::HashMap;
 use std::fs;
-use std::path::Path;
-
 use crate::discovery::Package;
 use crate::graph::Graph;
 
@@ -57,9 +55,41 @@ use crate::graph::Graph;
 /// By building this mapping upfront, we can resolve dependencies across
 /// languages without hard-coding specific package names.
 pub fn build_known_names(packages: &[Package]) -> HashMap<String, String> {
+    build_known_names_for_scope(packages, "")
+}
+
+fn dependency_scope(language: &str) -> &str {
+    match language {
+        "csharp" | "fsharp" | "dotnet" => "dotnet",
+        "wasm" => "wasm",
+        _ => language,
+    }
+}
+
+fn in_dependency_scope(package_language: &str, scope: &str) -> bool {
+    match scope {
+        "dotnet" => matches!(package_language, "csharp" | "fsharp" | "dotnet"),
+        "wasm" => matches!(package_language, "wasm" | "rust"),
+        _ => package_language == scope,
+    }
+}
+
+fn read_cargo_package_name(pkg: &Package) -> Option<String> {
+    let cargo_toml = pkg.path.join("Cargo.toml");
+    let data = fs::read_to_string(cargo_toml).ok()?;
+    let parsed = data.parse::<toml::Table>().ok()?;
+    let package = parsed.get("package")?;
+    let name = package.get("name")?.as_str()?;
+    Some(name.to_lowercase())
+}
+
+fn build_known_names_for_scope(packages: &[Package], scope: &str) -> HashMap<String, String> {
     let mut known = HashMap::new();
 
     for pkg in packages {
+        if !scope.is_empty() && !in_dependency_scope(&pkg.language, scope) {
+            continue;
+        }
         let dir_name = pkg
             .path
             .file_name()
@@ -93,7 +123,7 @@ pub fn build_known_names(packages: &[Package]) -> HashMap<String, String> {
                     }
                 }
             }
-            "rust" => {
+            "rust" | "wasm" => {
                 // For Rust, read the package name from Cargo.toml.
                 // The crate name in dependencies should match this.
                 let cargo_toml = pkg.path.join("Cargo.toml");
@@ -107,6 +137,9 @@ pub fn build_known_names(packages: &[Package]) -> HashMap<String, String> {
                             }
                         }
                     }
+                }
+                if let Some(cargo_name) = read_cargo_package_name(pkg) {
+                    known.insert(cargo_name, pkg.name.clone());
                 }
             }
             "elixir" => {
@@ -129,6 +162,9 @@ pub fn build_known_names(packages: &[Package]) -> HashMap<String, String> {
                 // Haskell Cabal package names use hyphens.
                 let cabal_name = format!("coding-adventures-{}", dir_name);
                 known.insert(cabal_name, pkg.name.clone());
+            }
+            "csharp" | "fsharp" | "dotnet" => {
+                known.insert(dir_name, pkg.name.clone());
             }
             _ => {}
         }
@@ -377,6 +413,58 @@ fn parse_rust_deps(pkg: &Package, known_names: &HashMap<String, String>) -> Vec<
         for (name, _value) in deps {
             let lower_name = name.to_lowercase();
             if let Some(pkg_name) = known_names.get(&lower_name) {
+                internal_deps.push(pkg_name.clone());
+            }
+        }
+    }
+
+    internal_deps
+}
+
+fn parse_dotnet_deps(pkg: &Package, known_names: &HashMap<String, String>) -> Vec<String> {
+    let entries = match fs::read_dir(&pkg.path) {
+        Ok(e) => e,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut internal_deps = Vec::new();
+
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if !name.ends_with(".csproj") && !name.ends_with(".fsproj") {
+            continue;
+        }
+
+        let data = match fs::read_to_string(entry.path()) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+
+        for line in data.lines() {
+            let Some(include_pos) = line.find("<ProjectReference") else {
+                continue;
+            };
+            let line = &line[include_pos..];
+            let Some(attr_pos) = line.find("Include=\"") else {
+                continue;
+            };
+            let include = &line[attr_pos + "Include=\"".len()..];
+            let Some(end_quote) = include.find('"') else {
+                continue;
+            };
+            let project_path = &include[..end_quote];
+            let normalized = project_path.replace('\\', "/");
+            let Some(remainder) = normalized.strip_prefix("../") else {
+                continue;
+            };
+            let Some(dep_dir) = remainder.split('/').next() else {
+                continue;
+            };
+            let dep_dir = dep_dir.to_lowercase();
+            if dep_dir.contains('/') || dep_dir.contains('\\') || dep_dir == ".." {
+                continue;
+            }
+            if let Some(pkg_name) = known_names.get(&dep_dir) {
                 internal_deps.push(pkg_name.clone());
             }
         }
@@ -660,19 +748,29 @@ pub fn resolve_dependencies(packages: &[Package]) -> Graph {
     }
 
     // Build the ecosystem-specific name mapping table.
-    let known_names = build_known_names(packages);
+    let mut known_names_by_scope: HashMap<String, HashMap<String, String>> = HashMap::new();
+    for pkg in packages {
+        let scope = dependency_scope(&pkg.language).to_string();
+        known_names_by_scope
+            .entry(scope.clone())
+            .or_insert_with(|| build_known_names_for_scope(packages, &scope));
+    }
 
     // Parse dependencies for each package and add edges.
     for pkg in packages {
+        let known_names = known_names_by_scope
+            .get(dependency_scope(&pkg.language))
+            .expect("known name scope must exist");
         let deps = match pkg.language.as_str() {
-            "python" => parse_python_deps(pkg, &known_names),
-            "ruby" => parse_ruby_deps(pkg, &known_names),
-            "go" => parse_go_deps(pkg, &known_names),
-            "rust" => parse_rust_deps(pkg, &known_names),
-            "elixir" => parse_elixir_deps(pkg, &known_names),
-            "lua" => parse_lua_deps(pkg, &known_names),
-            "perl" => parse_perl_deps(pkg, &known_names),
-            "haskell" => parse_haskell_deps(pkg, &known_names),
+            "python" => parse_python_deps(pkg, known_names),
+            "ruby" => parse_ruby_deps(pkg, known_names),
+            "go" => parse_go_deps(pkg, known_names),
+            "rust" | "wasm" => parse_rust_deps(pkg, known_names),
+            "elixir" => parse_elixir_deps(pkg, known_names),
+            "lua" => parse_lua_deps(pkg, known_names),
+            "perl" => parse_perl_deps(pkg, known_names),
+            "haskell" => parse_haskell_deps(pkg, known_names),
+            "csharp" | "fsharp" | "dotnet" => parse_dotnet_deps(pkg, known_names),
             _ => Vec::new(),
         };
 

--- a/code/programs/swift/build-tool/Sources/BuildToolCore/Discovery.swift
+++ b/code/programs/swift/build-tool/Sources/BuildToolCore/Discovery.swift
@@ -32,7 +32,7 @@ public enum Discovery {
             .replacingOccurrences(of: "\\", with: "/")
             .split(separator: "/")
             .map(String.init)
-        for language in allLanguages where parts.contains(language) {
+        for language in allPackageLanguages where parts.contains(language) {
             return language
         }
         return "unknown"

--- a/code/programs/swift/build-tool/Sources/BuildToolCore/Models.swift
+++ b/code/programs/swift/build-tool/Sources/BuildToolCore/Models.swift
@@ -240,7 +240,7 @@ public struct CLIOptions: Equatable {
     }
 }
 
-public let allLanguages = [
+public let allPackageLanguages = [
     "python",
     "ruby",
     "go",
@@ -250,8 +250,16 @@ public let allLanguages = [
     "lua",
     "perl",
     "swift",
+    "java",
+    "kotlin",
     "haskell",
+    "wasm",
+    "csharp",
+    "fsharp",
+    "dotnet",
 ]
+
+public let allLanguages = allPackageLanguages
 
 public let allToolchains = [
     "python",

--- a/code/programs/swift/build-tool/Sources/BuildToolCore/Resolver.swift
+++ b/code/programs/swift/build-tool/Sources/BuildToolCore/Resolver.swift
@@ -7,9 +7,16 @@ public enum Resolver {
             graph.addNode(package.name)
         }
 
-        let knownNames = buildKnownNames(packages: packages)
+        var knownNamesByScope: [String: [String: String]] = [:]
+        for package in packages {
+            let scope = dependencyScope(for: package.language)
+            if knownNamesByScope[scope] == nil {
+                knownNamesByScope[scope] = buildKnownNames(packages: packages, language: scope)
+            }
+        }
 
         for package in packages {
+            let knownNames = knownNamesByScope[dependencyScope(for: package.language)] ?? [:]
             let deps: [String]
             switch package.language {
             case "python":
@@ -20,7 +27,7 @@ public enum Resolver {
                 deps = parseGoDeps(package: package, knownNames: knownNames)
             case "typescript":
                 deps = parseTypeScriptDeps(package: package, knownNames: knownNames)
-            case "rust":
+            case "rust", "wasm":
                 deps = parseRustDeps(package: package, knownNames: knownNames)
             case "elixir":
                 deps = parseElixirDeps(package: package, knownNames: knownNames)
@@ -32,6 +39,8 @@ public enum Resolver {
                 deps = parseSwiftDeps(package: package, knownNames: knownNames)
             case "haskell":
                 deps = parseHaskellDeps(package: package, knownNames: knownNames)
+            case "csharp", "fsharp", "dotnet":
+                deps = parseDotnetDeps(package: package, knownNames: knownNames)
             default:
                 deps = []
             }
@@ -44,7 +53,7 @@ public enum Resolver {
         return graph
     }
 
-    public static func buildKnownNames(packages: [BuildPackage]) -> [String: String] {
+    public static func buildKnownNames(packages: [BuildPackage], language: String? = nil) -> [String: String] {
         var known: [String: String] = [:]
 
         func setKnown(_ key: String, _ value: String, path: String) {
@@ -55,6 +64,9 @@ public enum Resolver {
         }
 
         for package in packages {
+            if let language, !isPackageLanguage(package.language, in: language) {
+                continue
+            }
             let packageDirName = (package.path as NSString).lastPathComponent.lowercased()
             switch package.language {
             case "python":
@@ -81,8 +93,11 @@ public enum Resolver {
                    let match = content.firstMatch(for: #""name"\s*:\s*"([^"]+)""#) {
                     setKnown(match.lowercased(), package.name, path: package.path)
                 }
-            case "rust":
+            case "rust", "wasm":
                 setKnown(packageDirName, package.name, path: package.path)
+                if let cargoName = readCargoPackageName(in: package.path) {
+                    setKnown(cargoName, package.name, path: package.path)
+                }
             case "elixir":
                 let baseName = packageDirName.replacingOccurrences(of: "-", with: "_")
                 setKnown("coding_adventures_\(baseName)", package.name, path: package.path)
@@ -100,6 +115,8 @@ public enum Resolver {
                 setKnown(packageDirName, package.name, path: package.path)
             case "haskell":
                 setKnown("coding-adventures-\(packageDirName.replacingOccurrences(of: "_", with: "-"))", package.name, path: package.path)
+            case "csharp", "fsharp", "dotnet":
+                setKnown(packageDirName, package.name, path: package.path)
             default:
                 break
             }
@@ -128,6 +145,31 @@ public enum Resolver {
             }
             if let packageName = knownNames[depDirectory] {
                 dependencies.append(packageName)
+            }
+        }
+
+        return dependencies
+    }
+
+    private static func parseDotnetDeps(package: BuildPackage, knownNames: [String: String]) -> [String] {
+        let projectFiles = filePaths(in: package.path, suffixes: [".csproj", ".fsproj"])
+        guard !projectFiles.isEmpty else {
+            return []
+        }
+
+        var dependencies: [String] = []
+        for projectFile in projectFiles {
+            guard let content = try? String(contentsOfFile: projectFile, encoding: .utf8) else {
+                continue
+            }
+            for match in content.matches(for: #"<ProjectReference\s+Include\s*=\s*"\.\.[\\/]+([^/\\"]+)[\\/][^"]*""#) {
+                let depDir = match.lowercased()
+                if depDir.contains("/") || depDir.contains("\\") || depDir == ".." {
+                    continue
+                }
+                if let packageName = knownNames[depDir] {
+                    dependencies.append(packageName)
+                }
             }
         }
 
@@ -333,6 +375,46 @@ public enum Resolver {
                 }
                 return pkgName
             }
+    }
+
+    private static func dependencyScope(for language: String) -> String {
+        switch language {
+        case "csharp", "fsharp", "dotnet":
+            return "dotnet"
+        case "wasm":
+            return "wasm"
+        default:
+            return language
+        }
+    }
+
+    private static func isPackageLanguage(_ packageLanguage: String, in scope: String) -> Bool {
+        switch scope {
+        case "dotnet":
+            return ["csharp", "fsharp", "dotnet"].contains(packageLanguage)
+        case "wasm":
+            return ["wasm", "rust"].contains(packageLanguage)
+        default:
+            return packageLanguage == scope
+        }
+    }
+
+    private static func readCargoPackageName(in directory: String) -> String? {
+        let cargoPath = (directory as NSString).appendingPathComponent("Cargo.toml")
+        guard let content = try? String(contentsOfFile: cargoPath, encoding: .utf8) else {
+            return nil
+        }
+        return content.firstMatch(for: #"(?m)^\s*name\s*=\s*"([^"]+)""#)?.lowercased()
+    }
+
+    private static func filePaths(in directory: String, suffixes: [String]) -> [String] {
+        guard let entries = try? FileManager.default.contentsOfDirectory(atPath: directory) else {
+            return []
+        }
+        return entries
+            .sorted()
+            .filter { entry in suffixes.contains { entry.hasSuffix($0) } }
+            .map { (directory as NSString).appendingPathComponent($0) }
     }
 
     private static func extractQuotedDeps(from line: String, knownNames: [String: String], into dependencies: inout [String]) {


### PR DESCRIPTION
## Summary

This is the focused rescue for the parts of [#654](https://github.com/adhithyan15/coding-adventures/pull/654) that were still missing on current `main`.

## What changed

- added the missing `code/packages/lua/graph` DT00 package
- rescued the remaining build-tool parity work across Elixir, Lua, Perl, Ruby, Rust, and Swift
- added the missing cross-language discovery / resolver handling for `wasm`, `csharp`, `fsharp`, and `.NET` package families where those implementations were still behind
- restored Elixir `--detect-languages` support while preserving the newer CI workflow scoping logic already on `main`
- fixed Perl Windows command execution and Windows-safe path matching without regressing the newer CI workflow handling
- tightened the WASM B-tree and B+ tree wrappers so their iter/scan/string helpers match the current Rust package behavior
- added / updated regression coverage for the rescued Lua and Perl build-tool behavior

## Why

`#654` was no longer a good merge candidate because parts of it had already landed in later focused PRs, while other parts were still missing. The missing pieces were still useful though:

- `lua/graph` was still absent
- several non-Go build-tool implementations still did not understand the newer `wasm` / `.NET` package families consistently
- the Perl Windows fixes from the original branch were still not on `main`

This PR carries only the remaining useful work onto current `main`.

## Validation

Passed locally:

- `mix deps.get && mix test` in `code/programs/elixir/build-tool`
- `cargo test` in `code/programs/rust/build-tool`
- `cargo test` in `code/packages/wasm/b-tree`
- `cargo test` in `code/packages/wasm/b-plus-tree`
- `prove -l t/00-discovery.t t/01-resolver.t` in `code/programs/perl/build-tool`
- `swift test` in `code/programs/swift/build-tool`
- `LUA_PATH='src/?.lua;src/?/init.lua;lib/?.lua;lib/?/init.lua;;' busted tests/test_discovery.lua tests/test_resolver.lua` in `code/programs/lua/build-tool`
- `LUA_PATH='src/?.lua;src/?/init.lua;;' busted tests/test_graph.lua` in `code/packages/lua/graph`
- `PATH="$(dirname \"$(mise which ruby)\"):$PATH" "$(mise which ruby)" -S bundle exec rake test` in `code/programs/ruby/build-tool`

Additional sanity checks:

- `git diff --check`
- `ruby -c build.rb && ruby -c lib/build_tool/discovery.rb && ruby -c lib/build_tool/resolver.rb && ruby -c test/test_discovery.rb` in `code/programs/ruby/build-tool`

Ruby validation was run with the repo-managed `mise` Ruby toolchain (`ruby@3.4`) and local Bundler install in `vendor/bundle`.