### PR TITLE
feat(dotnet-compression): add lz78 and lzss packages

### DIFF
--- a/code/packages/csharp/lz78/BUILD
+++ b/code/packages/csharp/lz78/BUILD
@@ -1,0 +1,1 @@
+mkdir -p .dotnet .artifacts && HOME="$PWD/.dotnet" DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_CLI_HOME="$PWD/.dotnet" dotnet test tests/CodingAdventures.Lz78.Tests/CodingAdventures.Lz78.Tests.csproj --disable-build-servers --artifacts-path .artifacts /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/lz78/BUILD_windows
+++ b/code/packages/csharp/lz78/BUILD_windows
@@ -1,0 +1,1 @@
+if not exist ".dotnet" mkdir ".dotnet" && if not exist ".artifacts" mkdir ".artifacts" && set "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1" && set "DOTNET_CLI_HOME=%CD%\.dotnet" && dotnet test "tests/CodingAdventures.Lz78.Tests/CodingAdventures.Lz78.Tests.csproj" --disable-build-servers --artifacts-path ".artifacts" /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/lz78/CHANGELOG.md
+++ b/code/packages/csharp/lz78/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-18
+
+### Added
+
+- Pure C# LZ78 encoder, decoder, and CMP01 teaching-format serialisation helpers
+- Dictionary-growth, flush-token, and bounded-deserialisation behavior for explicit-dictionary compression
+- xUnit coverage for spec vectors, binary round trips, capped dictionary size, and serialisation symmetry
+- BUILD scripts that isolate `.NET` artifacts and first-run state for Linux and Windows CI

--- a/code/packages/csharp/lz78/CodingAdventures.Lz78.csproj
+++ b/code/packages/csharp/lz78/CodingAdventures.Lz78.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Lz78.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure C# LZ78 compression and CMP01 token serialisation helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\\**\\*.cs" />
+    <EmbeddedResource Remove="tests\\**" />
+    <None Remove="tests\\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/lz78/Lz78.cs
+++ b/code/packages/csharp/lz78/Lz78.cs
@@ -1,0 +1,167 @@
+using System.Buffers.Binary;
+
+namespace CodingAdventures.Lz78;
+
+public readonly record struct Lz78Token(int DictIndex, byte NextChar);
+
+public static class Lz78
+{
+    public static Lz78Token Token(int dictIndex, byte nextChar) => new(dictIndex, nextChar);
+
+    public static List<Lz78Token> Encode(byte[] data, int maxDictSize = 65_536)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        if (maxDictSize <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxDictSize), "maxDictSize must be positive");
+        }
+
+        var dictionary = new Dictionary<(int ParentId, byte Byte), int>();
+        var nextId = 1;
+        var currentId = 0;
+        var tokens = new List<Lz78Token>();
+
+        foreach (var value in data)
+        {
+            if (dictionary.TryGetValue((currentId, value), out var childId))
+            {
+                currentId = childId;
+            }
+            else
+            {
+                tokens.Add(new Lz78Token(currentId, value));
+                if (nextId < maxDictSize)
+                {
+                    dictionary[(currentId, value)] = nextId;
+                    nextId++;
+                }
+
+                currentId = 0;
+            }
+        }
+
+        if (currentId != 0)
+        {
+            tokens.Add(new Lz78Token(currentId, 0));
+        }
+
+        return tokens;
+    }
+
+    public static byte[] Decode(IEnumerable<Lz78Token> tokens, int originalLength = -1)
+    {
+        ArgumentNullException.ThrowIfNull(tokens);
+
+        var table = new List<(int ParentId, byte Byte)> { (0, 0) };
+        var output = new List<byte>();
+
+        foreach (var token in tokens)
+        {
+            if (token.DictIndex < 0 || token.DictIndex >= table.Count)
+            {
+                throw new InvalidOperationException("Token references a dictionary entry that does not exist");
+            }
+
+            output.AddRange(Reconstruct(table, token.DictIndex));
+            if (originalLength < 0 || output.Count < originalLength)
+            {
+                output.Add(token.NextChar);
+            }
+
+            table.Add((token.DictIndex, token.NextChar));
+        }
+
+        return originalLength >= 0 ? [.. output.Take(originalLength)] : [.. output];
+    }
+
+    public static byte[] SerialiseTokens(IReadOnlyList<Lz78Token> tokens, int originalLength)
+    {
+        ArgumentNullException.ThrowIfNull(tokens);
+        if (originalLength < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(originalLength), "originalLength must be non-negative");
+        }
+
+        var output = new byte[8 + (tokens.Count * 4)];
+        BinaryPrimitives.WriteUInt32BigEndian(output.AsSpan(0, 4), (uint)originalLength);
+        BinaryPrimitives.WriteUInt32BigEndian(output.AsSpan(4, 4), (uint)tokens.Count);
+
+        for (var i = 0; i < tokens.Count; i++)
+        {
+            var token = tokens[i];
+            if (token.DictIndex < 0 || token.DictIndex > ushort.MaxValue)
+            {
+                throw new InvalidOperationException("Dictionary index does not fit in the teaching uint16 token format");
+            }
+
+            var index = 8 + (i * 4);
+            BinaryPrimitives.WriteUInt16BigEndian(output.AsSpan(index, 2), (ushort)token.DictIndex);
+            output[index + 2] = token.NextChar;
+            output[index + 3] = 0;
+        }
+
+        return output;
+    }
+
+    public static (List<Lz78Token> Tokens, int OriginalLength) DeserialiseTokens(byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        if (data.Length < 8)
+        {
+            return ([], 0);
+        }
+
+        var originalLength = (int)BinaryPrimitives.ReadUInt32BigEndian(data.AsSpan(0, 4));
+        var tokenCount = BinaryPrimitives.ReadUInt32BigEndian(data.AsSpan(4, 4));
+        var tokens = new List<Lz78Token>();
+
+        for (var i = 0u; i < tokenCount; i++)
+        {
+            var index = 8 + ((int)i * 4);
+            if (index + 4 > data.Length)
+            {
+                break;
+            }
+
+            tokens.Add(new Lz78Token(
+                BinaryPrimitives.ReadUInt16BigEndian(data.AsSpan(index, 2)),
+                data[index + 2]));
+        }
+
+        return (tokens, originalLength);
+    }
+
+    public static byte[] Compress(byte[] data, int maxDictSize = 65_536)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        var tokens = Encode(data, maxDictSize);
+        return SerialiseTokens(tokens, data.Length);
+    }
+
+    public static byte[] Decompress(byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        var (tokens, originalLength) = DeserialiseTokens(data);
+        return Decode(tokens, originalLength);
+    }
+
+    private static IEnumerable<byte> Reconstruct(IReadOnlyList<(int ParentId, byte Byte)> table, int index)
+    {
+        if (index == 0)
+        {
+            return [];
+        }
+
+        var reversed = new List<byte>();
+        var current = index;
+        while (current != 0)
+        {
+            var entry = table[current];
+            reversed.Add(entry.Byte);
+            current = entry.ParentId;
+        }
+
+        reversed.Reverse();
+        return reversed;
+    }
+}

--- a/code/packages/csharp/lz78/README.md
+++ b/code/packages/csharp/lz78/README.md
@@ -1,0 +1,27 @@
+# lz78
+
+Pure C# LZ78 compression for the CMP01 explicit-dictionary foundation.
+
+## What It Includes
+
+- Byte-array encoder and decoder using `(dictIndex, nextChar)` tokens
+- CMP01 teaching-format serialisation helpers with original-length metadata
+- One-shot `Compress` / `Decompress` helpers over the pure token API
+
+## Example
+
+```csharp
+using System.Text;
+using CodingAdventures.Lz78;
+
+var compressed = Lz78.Compress(Encoding.UTF8.GetBytes("ABABAB"));
+var roundTrip = Encoding.UTF8.GetString(Lz78.Decompress(compressed));
+
+Console.WriteLine(roundTrip); // ABABAB
+```
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/csharp/lz78/required_capabilities.json
+++ b/code/packages/csharp/lz78/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/lz78",
+  "capabilities": [],
+  "justification": "Pure in-memory C# LZ78 implementation and tests."
+}

--- a/code/packages/csharp/lz78/tests/CodingAdventures.Lz78.Tests/CodingAdventures.Lz78.Tests.csproj
+++ b/code/packages/csharp/lz78/tests/CodingAdventures.Lz78.Tests/CodingAdventures.Lz78.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Lz78.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/lz78/tests/CodingAdventures.Lz78.Tests/Lz78Tests.cs
+++ b/code/packages/csharp/lz78/tests/CodingAdventures.Lz78.Tests/Lz78Tests.cs
@@ -1,0 +1,114 @@
+using System.Text;
+using CodingAdventures.Lz78;
+
+namespace CodingAdventures.Lz78.Tests;
+
+public sealed class Lz78Tests
+{
+    private static byte[] EncodeText(string value) => Encoding.UTF8.GetBytes(value);
+
+    private static string DecodeText(byte[] value) => Encoding.UTF8.GetString(value);
+
+    [Fact]
+    public void EmptyInput_ProducesNoTokens()
+    {
+        Assert.Empty(Lz78.Encode([]));
+        Assert.Empty(Lz78.Decode([], 0));
+    }
+
+    [Fact]
+    public void SingleByte_ProducesSingleLiteralToken()
+    {
+        var tokens = Lz78.Encode(EncodeText("A"));
+        Assert.Equal([new Lz78Token(0, (byte)'A')], tokens);
+        Assert.Equal("A", DecodeText(Lz78.Decode(tokens, 1)));
+    }
+
+    [Fact]
+    public void Aabcbbabc_MatchesSpecVector()
+    {
+        var tokens = Lz78.Encode(EncodeText("AABCBBABC"));
+        Assert.Equal(
+            [
+                new Lz78Token(0, (byte)'A'),
+                new Lz78Token(1, (byte)'B'),
+                new Lz78Token(0, (byte)'C'),
+                new Lz78Token(0, (byte)'B'),
+                new Lz78Token(4, (byte)'A'),
+                new Lz78Token(4, (byte)'C')
+            ],
+            tokens);
+        Assert.Equal("AABCBBABC", DecodeText(Lz78.Decompress(Lz78.Compress(EncodeText("AABCBBABC")))));
+    }
+
+    [Fact]
+    public void Ababab_UsesFlushToken()
+    {
+        var tokens = Lz78.Encode(EncodeText("ABABAB"));
+        Assert.Equal(
+            [
+                new Lz78Token(0, (byte)'A'),
+                new Lz78Token(0, (byte)'B'),
+                new Lz78Token(1, (byte)'B'),
+                new Lz78Token(3, 0)
+            ],
+            tokens);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("A")]
+    [InlineData("ABCDE")]
+    [InlineData("AAAAAAA")]
+    [InlineData("ABABABAB")]
+    [InlineData("hello world")]
+    public void CompressAndDecompress_RoundTripAsciiInputs(string value)
+    {
+        var data = EncodeText(value);
+        Assert.Equal(data, Lz78.Decompress(Lz78.Compress(data)));
+    }
+
+    [Fact]
+    public void BinaryInputs_RoundTrip()
+    {
+        var data = new byte[] { 0, 0, 0, 255, 255, 0, 1, 2, 0, 1, 2 };
+        Assert.Equal(data, Lz78.Decompress(Lz78.Compress(data)));
+    }
+
+    [Fact]
+    public void MaxDictionarySize_IsRespected()
+    {
+        var tokens = Lz78.Encode(EncodeText("ABCABCABCABCABC"), maxDictSize: 10);
+        Assert.All(tokens, token => Assert.InRange(token.DictIndex, 0, 9));
+    }
+
+    [Fact]
+    public void MaxDictionarySizeOne_ForcesAllLiterals()
+    {
+        var tokens = Lz78.Encode(EncodeText("AAAA"), maxDictSize: 1);
+        Assert.All(tokens, token => Assert.Equal(0, token.DictIndex));
+    }
+
+    [Fact]
+    public void SerialiseAndDeserialise_AreSymmetric()
+    {
+        var tokens = new List<Lz78Token>
+        {
+            new(0, (byte)'A'),
+            new(1, (byte)'B')
+        };
+
+        var serialised = Lz78.SerialiseTokens(tokens, 3);
+        var (deserialised, originalLength) = Lz78.DeserialiseTokens(serialised);
+
+        Assert.Equal(3, originalLength);
+        Assert.Equal(tokens, deserialised);
+    }
+
+    [Fact]
+    public void Decode_RejectsUnknownDictionaryIndex()
+    {
+        var error = Assert.Throws<InvalidOperationException>(() => Lz78.Decode([new Lz78Token(1, (byte)'A')]));
+        Assert.Contains("does not exist", error.Message);
+    }
+}

--- a/code/packages/csharp/lzss/BUILD
+++ b/code/packages/csharp/lzss/BUILD
@@ -1,0 +1,1 @@
+mkdir -p .dotnet .artifacts && HOME="$PWD/.dotnet" DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_CLI_HOME="$PWD/.dotnet" dotnet test tests/CodingAdventures.Lzss.Tests/CodingAdventures.Lzss.Tests.csproj --disable-build-servers --artifacts-path .artifacts /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/lzss/BUILD_windows
+++ b/code/packages/csharp/lzss/BUILD_windows
@@ -1,0 +1,1 @@
+if not exist ".dotnet" mkdir ".dotnet" && if not exist ".artifacts" mkdir ".artifacts" && set "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1" && set "DOTNET_CLI_HOME=%CD%\.dotnet" && dotnet test "tests/CodingAdventures.Lzss.Tests/CodingAdventures.Lzss.Tests.csproj" --disable-build-servers --artifacts-path ".artifacts" /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/lzss/CHANGELOG.md
+++ b/code/packages/csharp/lzss/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-18
+
+### Added
+
+- Pure C# LZSS encoder, decoder, and CMP02 flag-block serialisation helpers
+- Overlap-safe match decoding and bounded block deserialisation for the LZ77-with-flags variant
+- xUnit coverage for spec vectors, wire-format symmetry, binary round trips, and compression behavior
+- BUILD scripts that isolate `.NET` artifacts and first-run state for Linux and Windows CI

--- a/code/packages/csharp/lzss/CodingAdventures.Lzss.csproj
+++ b/code/packages/csharp/lzss/CodingAdventures.Lzss.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Lzss.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure C# LZSS compression and CMP02 flag-block serialisation helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\\**\\*.cs" />
+    <EmbeddedResource Remove="tests\\**" />
+    <None Remove="tests\\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/lzss/Lzss.cs
+++ b/code/packages/csharp/lzss/Lzss.cs
@@ -1,0 +1,259 @@
+using System.Buffers.Binary;
+
+namespace CodingAdventures.Lzss;
+
+public abstract record LzssToken;
+
+public sealed record LzssLiteral(byte Byte) : LzssToken;
+
+public sealed record LzssMatch(int Offset, int Length) : LzssToken;
+
+public static class Lzss
+{
+    public const int DefaultWindowSize = 4096;
+    public const int DefaultMaxMatch = 255;
+    public const int DefaultMinMatch = 3;
+
+    public static LzssLiteral Literal(byte value) => new(value);
+
+    public static LzssMatch Match(int offset, int length) => new(offset, length);
+
+    public static List<LzssToken> Encode(
+        byte[] data,
+        int windowSize = DefaultWindowSize,
+        int maxMatch = DefaultMaxMatch,
+        int minMatch = DefaultMinMatch)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        ValidateParameters(windowSize, maxMatch, minMatch);
+
+        var tokens = new List<LzssToken>();
+        var cursor = 0;
+
+        while (cursor < data.Length)
+        {
+            var windowStart = Math.Max(0, cursor - windowSize);
+            var (offset, length) = FindLongestMatch(data, cursor, windowStart, maxMatch);
+            if (length >= minMatch)
+            {
+                tokens.Add(new LzssMatch(offset, length));
+                cursor += length;
+            }
+            else
+            {
+                tokens.Add(new LzssLiteral(data[cursor]));
+                cursor++;
+            }
+        }
+
+        return tokens;
+    }
+
+    public static byte[] Decode(IEnumerable<LzssToken> tokens, int originalLength = -1)
+    {
+        ArgumentNullException.ThrowIfNull(tokens);
+
+        var output = new List<byte>();
+        foreach (var token in tokens)
+        {
+            switch (token)
+            {
+                case LzssLiteral literal:
+                    output.Add(literal.Byte);
+                    break;
+
+                case LzssMatch match:
+                {
+                    if (match.Offset <= 0)
+                    {
+                        throw new InvalidOperationException("Match offsets must be positive");
+                    }
+
+                    var start = output.Count - match.Offset;
+                    if (start < 0)
+                    {
+                        throw new InvalidOperationException("Match offset extends before the output buffer");
+                    }
+
+                    for (var index = 0; index < match.Length; index++)
+                    {
+                        output.Add(output[start + index]);
+                    }
+
+                    break;
+                }
+
+                default:
+                    throw new InvalidOperationException("Unknown LZSS token type");
+            }
+        }
+
+        return originalLength >= 0 ? [.. output.Take(originalLength)] : [.. output];
+    }
+
+    public static byte[] SerialiseTokens(IReadOnlyList<LzssToken> tokens, int originalLength)
+    {
+        ArgumentNullException.ThrowIfNull(tokens);
+        if (originalLength < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(originalLength), "originalLength must be non-negative");
+        }
+
+        var blocks = new List<byte[]>();
+        for (var tokenIndex = 0; tokenIndex < tokens.Count; tokenIndex += 8)
+        {
+            var chunk = tokens.Skip(tokenIndex).Take(8).ToList();
+            var flag = (byte)0;
+            var bytes = new List<byte>();
+            for (var bit = 0; bit < chunk.Count; bit++)
+            {
+                switch (chunk[bit])
+                {
+                    case LzssMatch match:
+                        flag |= (byte)(1 << bit);
+                        bytes.Add((byte)((match.Offset >> 8) & 0xff));
+                        bytes.Add((byte)(match.Offset & 0xff));
+                        bytes.Add((byte)(match.Length & 0xff));
+                        break;
+
+                    case LzssLiteral literal:
+                        bytes.Add(literal.Byte);
+                        break;
+
+                    default:
+                        throw new InvalidOperationException("Unknown LZSS token type");
+                }
+            }
+
+            blocks.Add([flag, .. bytes]);
+        }
+
+        var totalSize = 8 + blocks.Sum(block => block.Length);
+        var output = new byte[totalSize];
+        BinaryPrimitives.WriteUInt32BigEndian(output.AsSpan(0, 4), (uint)originalLength);
+        BinaryPrimitives.WriteUInt32BigEndian(output.AsSpan(4, 4), (uint)blocks.Count);
+
+        var position = 8;
+        foreach (var block in blocks)
+        {
+            block.CopyTo(output, position);
+            position += block.Length;
+        }
+
+        return output;
+    }
+
+    public static (List<LzssToken> Tokens, int OriginalLength) DeserialiseTokens(byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        if (data.Length < 8)
+        {
+            return ([], 0);
+        }
+
+        var originalLength = (int)BinaryPrimitives.ReadUInt32BigEndian(data.AsSpan(0, 4));
+        var blockCount = BinaryPrimitives.ReadUInt32BigEndian(data.AsSpan(4, 4));
+        var maxPossibleBlocks = (uint)(data.Length - 8);
+        if (blockCount > maxPossibleBlocks)
+        {
+            blockCount = maxPossibleBlocks;
+        }
+
+        var tokens = new List<LzssToken>();
+        var position = 8;
+
+        for (var block = 0u; block < blockCount; block++)
+        {
+            if (position >= data.Length)
+            {
+                break;
+            }
+
+            var flag = data[position];
+            position++;
+
+            for (var bit = 0; bit < 8 && position < data.Length; bit++)
+            {
+                if ((flag & (1 << bit)) != 0)
+                {
+                    if (position + 3 > data.Length)
+                    {
+                        break;
+                    }
+
+                    tokens.Add(new LzssMatch(
+                        (data[position] << 8) | data[position + 1],
+                        data[position + 2]));
+                    position += 3;
+                }
+                else
+                {
+                    tokens.Add(new LzssLiteral(data[position]));
+                    position++;
+                }
+            }
+        }
+
+        return (tokens, originalLength);
+    }
+
+    public static byte[] Compress(
+        byte[] data,
+        int windowSize = DefaultWindowSize,
+        int maxMatch = DefaultMaxMatch,
+        int minMatch = DefaultMinMatch)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        var tokens = Encode(data, windowSize, maxMatch, minMatch);
+        return SerialiseTokens(tokens, data.Length);
+    }
+
+    public static byte[] Decompress(byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        var (tokens, originalLength) = DeserialiseTokens(data);
+        return Decode(tokens, originalLength);
+    }
+
+    private static void ValidateParameters(int windowSize, int maxMatch, int minMatch)
+    {
+        if (windowSize <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(windowSize), "windowSize must be positive");
+        }
+
+        if (maxMatch <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxMatch), "maxMatch must be positive");
+        }
+
+        if (minMatch <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(minMatch), "minMatch must be positive");
+        }
+    }
+
+    private static (int Offset, int Length) FindLongestMatch(byte[] data, int cursor, int windowStart, int maxMatch)
+    {
+        var bestLength = 0;
+        var bestOffset = 0;
+        var lookaheadEnd = Math.Min(cursor + maxMatch, data.Length);
+
+        for (var position = windowStart; position < cursor; position++)
+        {
+            var length = 0;
+            while (cursor + length < lookaheadEnd && data[position + length] == data[cursor + length])
+            {
+                length++;
+            }
+
+            if (length > bestLength)
+            {
+                bestLength = length;
+                bestOffset = cursor - position;
+            }
+        }
+
+        return (bestOffset, bestLength);
+    }
+}

--- a/code/packages/csharp/lzss/README.md
+++ b/code/packages/csharp/lzss/README.md
@@ -1,0 +1,27 @@
+# lzss
+
+Pure C# LZSS compression for the CMP02 flagged sliding-window refinement.
+
+## What It Includes
+
+- Literal and match token types over the classic LZSS sliding-window model
+- CMP02 block-flag serialisation with `originalLength` and `blockCount` headers
+- One-shot `Compress` / `Decompress` helpers over the pure token API
+
+## Example
+
+```csharp
+using System.Text;
+using CodingAdventures.Lzss;
+
+var compressed = Lzss.Compress(Encoding.UTF8.GetBytes("ABABAB"));
+var roundTrip = Encoding.UTF8.GetString(Lzss.Decompress(compressed));
+
+Console.WriteLine(roundTrip); // ABABAB
+```
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/csharp/lzss/required_capabilities.json
+++ b/code/packages/csharp/lzss/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/lzss",
+  "capabilities": [],
+  "justification": "Pure in-memory C# LZSS implementation and tests."
+}

--- a/code/packages/csharp/lzss/tests/CodingAdventures.Lzss.Tests/CodingAdventures.Lzss.Tests.csproj
+++ b/code/packages/csharp/lzss/tests/CodingAdventures.Lzss.Tests/CodingAdventures.Lzss.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Lzss.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/lzss/tests/CodingAdventures.Lzss.Tests/LzssTests.cs
+++ b/code/packages/csharp/lzss/tests/CodingAdventures.Lzss.Tests/LzssTests.cs
@@ -1,0 +1,112 @@
+using System.Buffers.Binary;
+using System.Text;
+using CodingAdventures.Lzss;
+
+namespace CodingAdventures.Lzss.Tests;
+
+public sealed class LzssTests
+{
+    private static byte[] EncodeText(string value) => Encoding.UTF8.GetBytes(value);
+
+    [Fact]
+    public void EmptyInput_ProducesNoTokens()
+    {
+        Assert.Empty(Lzss.Encode([]));
+    }
+
+    [Fact]
+    public void SingleByte_ProducesLiteral()
+    {
+        Assert.Equal([new LzssLiteral((byte)'A')], Lzss.Encode(EncodeText("A")));
+    }
+
+    [Fact]
+    public void Aabcbbabc_MatchesSpecVectorTail()
+    {
+        var tokens = Lzss.Encode(EncodeText("AABCBBABC"));
+        Assert.Equal(7, tokens.Count);
+        Assert.Equal(new LzssMatch(5, 3), tokens[^1]);
+    }
+
+    [Fact]
+    public void Ababab_UsesMatchToken()
+    {
+        Assert.Equal(
+            [new LzssLiteral((byte)'A'), new LzssLiteral((byte)'B'), new LzssMatch(2, 4)],
+            Lzss.Encode(EncodeText("ABABAB")));
+    }
+
+    [Fact]
+    public void AllSameBytes_UseSelfReferentialMatch()
+    {
+        Assert.Equal(
+            [new LzssLiteral((byte)'A'), new LzssMatch(1, 6)],
+            Lzss.Encode(EncodeText("AAAAAAA")));
+    }
+
+    [Fact]
+    public void Decode_HandlesOverlappingMatches()
+    {
+        var output = Lzss.Decode([new LzssLiteral((byte)'A'), new LzssMatch(1, 6)], 7);
+        Assert.Equal(EncodeText("AAAAAAA"), output);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("A")]
+    [InlineData("ABCDE")]
+    [InlineData("AAAAAAA")]
+    [InlineData("ABABAB")]
+    [InlineData("AABCBBABC")]
+    [InlineData("hello world")]
+    public void CompressAndDecompress_RoundTripAsciiInputs(string value)
+    {
+        var data = EncodeText(value);
+        Assert.Equal(data, Lzss.Decompress(Lzss.Compress(data)));
+    }
+
+    [Fact]
+    public void BinaryAndRepeatedData_RoundTrip()
+    {
+        var data = new byte[300];
+        for (var index = 0; index < data.Length; index++)
+        {
+            data[index] = (byte)(index % 3);
+        }
+
+        Assert.Equal(data, Lzss.Decompress(Lzss.Compress(data)));
+    }
+
+    [Fact]
+    public void SerialiseAndDeserialise_AreSymmetric()
+    {
+        var tokens = new List<LzssToken>
+        {
+            new LzssLiteral((byte)'A'),
+            new LzssLiteral((byte)'B'),
+            new LzssMatch(2, 4)
+        };
+
+        var bytes = Lzss.SerialiseTokens(tokens, 6);
+        var (recovered, originalLength) = Lzss.DeserialiseTokens(bytes);
+
+        Assert.Equal(6, originalLength);
+        Assert.Equal(tokens, recovered);
+    }
+
+    [Fact]
+    public void Deserialise_CapsCraftedLargeBlockCount()
+    {
+        var bad = new byte[16];
+        BinaryPrimitives.WriteUInt32BigEndian(bad.AsSpan(4, 4), 0x40000000);
+        var output = Lzss.Decompress(bad);
+        Assert.NotNull(output);
+    }
+
+    [Fact]
+    public void Decode_RejectsOffsetsBeforeOutputBuffer()
+    {
+        var error = Assert.Throws<InvalidOperationException>(() => Lzss.Decode([new LzssMatch(4, 1)]));
+        Assert.Contains("before the output buffer", error.Message);
+    }
+}

--- a/code/packages/fsharp/lz78/BUILD
+++ b/code/packages/fsharp/lz78/BUILD
@@ -1,0 +1,1 @@
+mkdir -p .dotnet .artifacts && HOME="$PWD/.dotnet" DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_CLI_HOME="$PWD/.dotnet" dotnet test tests/CodingAdventures.Lz78.Tests/CodingAdventures.Lz78.Tests.fsproj --disable-build-servers --artifacts-path .artifacts /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/lz78/BUILD_windows
+++ b/code/packages/fsharp/lz78/BUILD_windows
@@ -1,0 +1,1 @@
+if not exist ".dotnet" mkdir ".dotnet" && if not exist ".artifacts" mkdir ".artifacts" && set "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1" && set "DOTNET_CLI_HOME=%CD%\.dotnet" && dotnet test "tests/CodingAdventures.Lz78.Tests/CodingAdventures.Lz78.Tests.fsproj" --disable-build-servers --artifacts-path ".artifacts" /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/lz78/CHANGELOG.md
+++ b/code/packages/fsharp/lz78/CHANGELOG.md
@@ -10,3 +10,4 @@ All notable changes to this package will be documented in this file.
 - Dictionary-growth, flush-token, and bounded-deserialisation behavior for explicit-dictionary compression
 - xUnit coverage for spec vectors, binary round trips, capped dictionary size, and serialisation symmetry
 - BUILD scripts that isolate `.NET` artifacts and first-run state for Linux and Windows CI
+- Deserialisation now caps token counts against the available payload so crafted headers cannot force oversized decode loops

--- a/code/packages/fsharp/lz78/CHANGELOG.md
+++ b/code/packages/fsharp/lz78/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-18
+
+### Added
+
+- Pure F# LZ78 encoder, decoder, and CMP01 teaching-format serialisation helpers
+- Dictionary-growth, flush-token, and bounded-deserialisation behavior for explicit-dictionary compression
+- xUnit coverage for spec vectors, binary round trips, capped dictionary size, and serialisation symmetry
+- BUILD scripts that isolate `.NET` artifacts and first-run state for Linux and Windows CI

--- a/code/packages/fsharp/lz78/CodingAdventures.Lz78.fsproj
+++ b/code/packages/fsharp/lz78/CodingAdventures.Lz78.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Lz78.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure F# LZ78 compression and CMP01 token serialisation helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Lz78.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/lz78/Lz78.fs
+++ b/code/packages/fsharp/lz78/Lz78.fs
@@ -104,16 +104,18 @@ type Lz78 =
             [], 0
         else
             let originalLength = int (BinaryPrimitives.ReadUInt32BigEndian(data.AsSpan(0, 4)))
-            let tokenCount = BinaryPrimitives.ReadUInt32BigEndian(data.AsSpan(4, 4))
+            let mutable tokenCount = BinaryPrimitives.ReadUInt32BigEndian(data.AsSpan(4, 4))
+            let maxPossibleTokens = uint32 ((data.Length - 8) / 4)
+            if tokenCount > maxPossibleTokens then
+                tokenCount <- maxPossibleTokens
             let tokens = ResizeArray<Lz78Token>()
 
             if tokenCount > 0u then
                 for index in 0u .. tokenCount - 1u do
                     let start = 8 + (int index * 4)
-                    if start + 4 <= data.Length then
-                        tokens.Add(
-                            { DictIndex = int (BinaryPrimitives.ReadUInt16BigEndian(data.AsSpan(start, 2)))
-                              NextChar = data[start + 2] })
+                    tokens.Add(
+                        { DictIndex = int (BinaryPrimitives.ReadUInt16BigEndian(data.AsSpan(start, 2)))
+                          NextChar = data[start + 2] })
 
             List.ofSeq tokens, originalLength
 

--- a/code/packages/fsharp/lz78/Lz78.fs
+++ b/code/packages/fsharp/lz78/Lz78.fs
@@ -1,0 +1,128 @@
+namespace CodingAdventures.Lz78.FSharp
+
+open System
+open System.Buffers.Binary
+open System.Collections.Generic
+
+type Lz78Token =
+    { DictIndex: int
+      NextChar: byte }
+
+[<AbstractClass; Sealed>]
+type Lz78 =
+    static member Token(dictIndex: int, nextChar: byte) =
+        { DictIndex = dictIndex
+          NextChar = nextChar }
+
+    static member Encode(data: byte array, ?maxDictSize: int) =
+        if isNull data then nullArg "data"
+
+        let maxDictSize = defaultArg maxDictSize 65536
+        if maxDictSize <= 0 then
+            invalidArg "maxDictSize" "maxDictSize must be positive"
+
+        let dictionary = Dictionary<(int * byte), int>()
+        let tokens = ResizeArray<Lz78Token>()
+        let mutable nextId = 1
+        let mutable currentId = 0
+
+        for value in data do
+            match dictionary.TryGetValue((currentId, value)) with
+            | true, childId -> currentId <- childId
+            | _ ->
+                tokens.Add(Lz78.Token(currentId, value))
+                if nextId < maxDictSize then
+                    dictionary[(currentId, value)] <- nextId
+                    nextId <- nextId + 1
+
+                currentId <- 0
+
+        if currentId <> 0 then
+            tokens.Add(Lz78.Token(currentId, 0uy))
+
+        List.ofSeq tokens
+
+    static member private Reconstruct(table: IReadOnlyList<int * byte>, index: int) =
+        if index = 0 then
+            []
+        else
+            let reversed = ResizeArray<byte>()
+            let mutable current = index
+            while current <> 0 do
+                let parentId, value = table[current]
+                reversed.Add value
+                current <- parentId
+
+            reversed |> Seq.rev |> Array.ofSeq |> List.ofArray
+
+    static member Decode(tokens: seq<Lz78Token>, ?originalLength: int) =
+        if isNull (box tokens) then nullArg "tokens"
+
+        let originalLength = defaultArg originalLength -1
+        let table = ResizeArray<int * byte>()
+        table.Add(0, 0uy)
+        let output = ResizeArray<byte>()
+
+        for token in tokens do
+            if token.DictIndex < 0 || token.DictIndex >= table.Count then
+                invalidOp "Token references a dictionary entry that does not exist"
+
+            output.AddRange(Lz78.Reconstruct(table, token.DictIndex))
+            if originalLength < 0 || output.Count < originalLength then
+                output.Add token.NextChar
+
+            table.Add(token.DictIndex, token.NextChar)
+
+        if originalLength >= 0 then
+            output |> Seq.truncate originalLength |> Array.ofSeq
+        else
+            output.ToArray()
+
+    static member SerialiseTokens(tokens: IReadOnlyList<Lz78Token>, originalLength: int) =
+        if isNull (box tokens) then nullArg "tokens"
+        if originalLength < 0 then invalidArg "originalLength" "originalLength must be non-negative"
+
+        let output = Array.zeroCreate<byte> (8 + (tokens.Count * 4))
+        BinaryPrimitives.WriteUInt32BigEndian(output.AsSpan(0, 4), uint32 originalLength)
+        BinaryPrimitives.WriteUInt32BigEndian(output.AsSpan(4, 4), uint32 tokens.Count)
+
+        for index in 0 .. tokens.Count - 1 do
+            let token = tokens[index]
+            if token.DictIndex < 0 || token.DictIndex > int UInt16.MaxValue then
+                invalidOp "Dictionary index does not fit in the teaching uint16 token format"
+
+            let start = 8 + (index * 4)
+            BinaryPrimitives.WriteUInt16BigEndian(output.AsSpan(start, 2), uint16 token.DictIndex)
+            output[start + 2] <- token.NextChar
+            output[start + 3] <- 0uy
+
+        output
+
+    static member DeserialiseTokens(data: byte array) =
+        if isNull data then nullArg "data"
+        if data.Length < 8 then
+            [], 0
+        else
+            let originalLength = int (BinaryPrimitives.ReadUInt32BigEndian(data.AsSpan(0, 4)))
+            let tokenCount = BinaryPrimitives.ReadUInt32BigEndian(data.AsSpan(4, 4))
+            let tokens = ResizeArray<Lz78Token>()
+
+            if tokenCount > 0u then
+                for index in 0u .. tokenCount - 1u do
+                    let start = 8 + (int index * 4)
+                    if start + 4 <= data.Length then
+                        tokens.Add(
+                            { DictIndex = int (BinaryPrimitives.ReadUInt16BigEndian(data.AsSpan(start, 2)))
+                              NextChar = data[start + 2] })
+
+            List.ofSeq tokens, originalLength
+
+    static member Compress(data: byte array, ?maxDictSize: int) =
+        if isNull data then nullArg "data"
+        let tokens = Lz78.Encode(data, ?maxDictSize = maxDictSize)
+        Lz78.SerialiseTokens(tokens, data.Length)
+
+    static member Decompress(data: byte array) =
+        if isNull data then nullArg "data"
+        let tokens, originalLength = Lz78.DeserialiseTokens(data)
+        Lz78.Decode(tokens, originalLength)

--- a/code/packages/fsharp/lz78/README.md
+++ b/code/packages/fsharp/lz78/README.md
@@ -1,0 +1,27 @@
+# lz78
+
+Pure F# LZ78 compression for the CMP01 explicit-dictionary foundation.
+
+## What It Includes
+
+- Byte-array encoder and decoder using `(dictIndex, nextChar)` tokens
+- CMP01 teaching-format serialisation helpers with original-length metadata
+- One-shot `Compress` / `Decompress` helpers over the pure token API
+
+## Example
+
+```fsharp
+open System.Text
+open CodingAdventures.Lz78.FSharp
+
+let compressed = Lz78.Compress(Encoding.UTF8.GetBytes("ABABAB"))
+let roundTrip = Encoding.UTF8.GetString(Lz78.Decompress compressed)
+
+printfn "%s" roundTrip
+```
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/fsharp/lz78/required_capabilities.json
+++ b/code/packages/fsharp/lz78/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/lz78",
+  "capabilities": [],
+  "justification": "Pure in-memory F# LZ78 implementation and tests."
+}

--- a/code/packages/fsharp/lz78/tests/CodingAdventures.Lz78.Tests/CodingAdventures.Lz78.Tests.fsproj
+++ b/code/packages/fsharp/lz78/tests/CodingAdventures.Lz78.Tests/CodingAdventures.Lz78.Tests.fsproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Lz78.fsproj" />
+    <Compile Include="Lz78Tests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/lz78/tests/CodingAdventures.Lz78.Tests/Lz78Tests.fs
+++ b/code/packages/fsharp/lz78/tests/CodingAdventures.Lz78.Tests/Lz78Tests.fs
@@ -1,0 +1,89 @@
+namespace CodingAdventures.Lz78.FSharp.Tests
+
+open System
+open System.Text
+open CodingAdventures.Lz78.FSharp
+open Xunit
+
+type Lz78Tests() =
+    let encodeText (value: string) = Encoding.UTF8.GetBytes value
+    let decodeText (value: byte array) = Encoding.UTF8.GetString value
+
+    [<Fact>]
+    member _.``empty input produces no tokens``() =
+        Assert.Empty(Lz78.Encode [||])
+        Assert.Empty(Lz78.Decode([], 0))
+
+    [<Fact>]
+    member _.``single byte produces single literal token``() =
+        let tokens = Lz78.Encode(encodeText "A")
+        Assert.Equal<Lz78Token list>([ { DictIndex = 0; NextChar = byte 'A' } ], tokens)
+        Assert.Equal("A", decodeText (Lz78.Decode(tokens, 1)))
+
+    [<Fact>]
+    member _.``AABCBBABC matches spec vector``() =
+        let tokens = Lz78.Encode(encodeText "AABCBBABC")
+
+        Assert.Equal<Lz78Token list>(
+            [ { DictIndex = 0; NextChar = byte 'A' }
+              { DictIndex = 1; NextChar = byte 'B' }
+              { DictIndex = 0; NextChar = byte 'C' }
+              { DictIndex = 0; NextChar = byte 'B' }
+              { DictIndex = 4; NextChar = byte 'A' }
+              { DictIndex = 4; NextChar = byte 'C' } ],
+            tokens)
+
+        Assert.Equal("AABCBBABC", decodeText (Lz78.Decompress(Lz78.Compress(encodeText "AABCBBABC"))))
+
+    [<Fact>]
+    member _.``ABABAB uses flush token``() =
+        let tokens = Lz78.Encode(encodeText "ABABAB")
+        Assert.Equal<Lz78Token list>(
+            [ { DictIndex = 0; NextChar = byte 'A' }
+              { DictIndex = 0; NextChar = byte 'B' }
+              { DictIndex = 1; NextChar = byte 'B' }
+              { DictIndex = 3; NextChar = 0uy } ],
+            tokens)
+
+    [<Theory>]
+    [<InlineData("")>]
+    [<InlineData("A")>]
+    [<InlineData("ABCDE")>]
+    [<InlineData("AAAAAAA")>]
+    [<InlineData("ABABABAB")>]
+    [<InlineData("hello world")>]
+    member _.``compress and decompress round trip ascii inputs``(value: string) =
+        let data = encodeText value
+        Assert.Equal<byte array>(data, Lz78.Decompress(Lz78.Compress data))
+
+    [<Fact>]
+    member _.``binary inputs round trip``() =
+        let data = [| 0uy; 0uy; 0uy; 255uy; 255uy; 0uy; 1uy; 2uy; 0uy; 1uy; 2uy |]
+        Assert.Equal<byte array>(data, Lz78.Decompress(Lz78.Compress data))
+
+    [<Fact>]
+    member _.``max dictionary size is respected``() =
+        let tokens = Lz78.Encode(encodeText "ABCABCABCABCABC", maxDictSize = 10)
+        Assert.All(tokens, fun token -> Assert.InRange(token.DictIndex, 0, 9))
+
+    [<Fact>]
+    member _.``max dictionary size one forces all literals``() =
+        let tokens = Lz78.Encode(encodeText "AAAA", maxDictSize = 1)
+        Assert.All(tokens, fun token -> Assert.Equal(0, token.DictIndex))
+
+    [<Fact>]
+    member _.``serialise and deserialise are symmetric``() =
+        let tokens =
+            [ { DictIndex = 0; NextChar = byte 'A' }
+              { DictIndex = 1; NextChar = byte 'B' } ]
+
+        let serialised = Lz78.SerialiseTokens(tokens, 3)
+        let deserialised, originalLength = Lz78.DeserialiseTokens serialised
+
+        Assert.Equal(3, originalLength)
+        Assert.Equal<Lz78Token list>(tokens, deserialised)
+
+    [<Fact>]
+    member _.``decode rejects unknown dictionary index``() =
+        let error = Assert.Throws<InvalidOperationException>(fun () -> Lz78.Decode([ { DictIndex = 1; NextChar = byte 'A' } ]) |> ignore)
+        Assert.Contains("does not exist", error.Message)

--- a/code/packages/fsharp/lzss/BUILD
+++ b/code/packages/fsharp/lzss/BUILD
@@ -1,0 +1,1 @@
+mkdir -p .dotnet .artifacts && HOME="$PWD/.dotnet" DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_CLI_HOME="$PWD/.dotnet" dotnet test tests/CodingAdventures.Lzss.Tests/CodingAdventures.Lzss.Tests.fsproj --disable-build-servers --artifacts-path .artifacts /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/lzss/BUILD_windows
+++ b/code/packages/fsharp/lzss/BUILD_windows
@@ -1,0 +1,1 @@
+if not exist ".dotnet" mkdir ".dotnet" && if not exist ".artifacts" mkdir ".artifacts" && set "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1" && set "DOTNET_CLI_HOME=%CD%\.dotnet" && dotnet test "tests/CodingAdventures.Lzss.Tests/CodingAdventures.Lzss.Tests.fsproj" --disable-build-servers --artifacts-path ".artifacts" /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/lzss/CHANGELOG.md
+++ b/code/packages/fsharp/lzss/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-18
+
+### Added
+
+- Pure F# LZSS encoder, decoder, and CMP02 flag-block serialisation helpers
+- Overlap-safe match decoding and bounded block deserialisation for the LZ77-with-flags variant
+- xUnit coverage for spec vectors, wire-format symmetry, binary round trips, and compression behavior
+- BUILD scripts that isolate `.NET` artifacts and first-run state for Linux and Windows CI

--- a/code/packages/fsharp/lzss/CHANGELOG.md
+++ b/code/packages/fsharp/lzss/CHANGELOG.md
@@ -10,3 +10,4 @@ All notable changes to this package will be documented in this file.
 - Overlap-safe match decoding and bounded block deserialisation for the LZ77-with-flags variant
 - xUnit coverage for spec vectors, wire-format symmetry, binary round trips, and compression behavior
 - BUILD scripts that isolate `.NET` artifacts and first-run state for Linux and Windows CI
+- Empty and crafted block headers now stay inside bounded deserialiser loops instead of relying on unchecked unsigned ranges

--- a/code/packages/fsharp/lzss/CodingAdventures.Lzss.fsproj
+++ b/code/packages/fsharp/lzss/CodingAdventures.Lzss.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Lzss.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure F# LZSS compression and CMP02 flag-block serialisation helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Lzss.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/lzss/Lzss.fs
+++ b/code/packages/fsharp/lzss/Lzss.fs
@@ -136,19 +136,20 @@ type Lzss =
             let tokens = ResizeArray<LzssToken>()
             let mutable position = 8
 
-            for _ in 0u .. blockCount - 1u do
-                if position < data.Length then
-                    let flag = data[position]
-                    position <- position + 1
-                    for bit = 0 to 7 do
-                        if position < data.Length then
-                            if (flag &&& byte (1 <<< bit)) <> 0uy then
-                                if position + 3 <= data.Length then
-                                    tokens.Add(Match(((int data[position]) <<< 8) ||| int data[position + 1], int data[position + 2]))
-                                    position <- position + 3
-                            else
-                                tokens.Add(Literal data[position])
-                                position <- position + 1
+            if blockCount > 0u then
+                for _ in 0u .. blockCount - 1u do
+                    if position < data.Length then
+                        let flag = data[position]
+                        position <- position + 1
+                        for bit = 0 to 7 do
+                            if position < data.Length then
+                                if (flag &&& byte (1 <<< bit)) <> 0uy then
+                                    if position + 3 <= data.Length then
+                                        tokens.Add(Match(((int data[position]) <<< 8) ||| int data[position + 1], int data[position + 2]))
+                                        position <- position + 3
+                                else
+                                    tokens.Add(Literal data[position])
+                                    position <- position + 1
 
             List.ofSeq tokens, originalLength
 

--- a/code/packages/fsharp/lzss/Lzss.fs
+++ b/code/packages/fsharp/lzss/Lzss.fs
@@ -1,0 +1,163 @@
+namespace CodingAdventures.Lzss.FSharp
+
+open System
+open System.Buffers.Binary
+open System.Collections.Generic
+
+type LzssToken =
+    | Literal of byte: byte
+    | Match of offset: int * length: int
+
+[<AbstractClass; Sealed>]
+type Lzss =
+    static member DefaultWindowSize = 4096
+    static member DefaultMaxMatch = 255
+    static member DefaultMinMatch = 3
+
+    static member Literal(value: byte) = Literal value
+    static member Match(offset: int, length: int) = Match(offset, length)
+
+    static member private ValidateParameters(windowSize: int, maxMatch: int, minMatch: int) =
+        if windowSize <= 0 then invalidArg "windowSize" "windowSize must be positive"
+        if maxMatch <= 0 then invalidArg "maxMatch" "maxMatch must be positive"
+        if minMatch <= 0 then invalidArg "minMatch" "minMatch must be positive"
+
+    static member private FindLongestMatch(data: byte array, cursor: int, windowStart: int, maxMatch: int) =
+        let mutable bestLength = 0
+        let mutable bestOffset = 0
+        let lookaheadEnd = min (cursor + maxMatch) data.Length
+
+        for position in windowStart .. cursor - 1 do
+            let mutable length = 0
+            while cursor + length < lookaheadEnd && data[position + length] = data[cursor + length] do
+                length <- length + 1
+
+            if length > bestLength then
+                bestLength <- length
+                bestOffset <- cursor - position
+
+        bestOffset, bestLength
+
+    static member Encode(data: byte array, ?windowSize: int, ?maxMatch: int, ?minMatch: int) =
+        if isNull data then nullArg "data"
+
+        let windowSize = defaultArg windowSize Lzss.DefaultWindowSize
+        let maxMatch = defaultArg maxMatch Lzss.DefaultMaxMatch
+        let minMatch = defaultArg minMatch Lzss.DefaultMinMatch
+        Lzss.ValidateParameters(windowSize, maxMatch, minMatch)
+
+        let tokens = ResizeArray<LzssToken>()
+        let mutable cursor = 0
+
+        while cursor < data.Length do
+            let windowStart = max 0 (cursor - windowSize)
+            let offset, length = Lzss.FindLongestMatch(data, cursor, windowStart, maxMatch)
+            if length >= minMatch then
+                tokens.Add(Match(offset, length))
+                cursor <- cursor + length
+            else
+                tokens.Add(Literal data[cursor])
+                cursor <- cursor + 1
+
+        List.ofSeq tokens
+
+    static member Decode(tokens: seq<LzssToken>, ?originalLength: int) =
+        if isNull (box tokens) then nullArg "tokens"
+
+        let originalLength = defaultArg originalLength -1
+        let output = ResizeArray<byte>()
+
+        for token in tokens do
+            match token with
+            | Literal value -> output.Add value
+            | Match(offset, length) ->
+                if offset <= 0 then
+                    invalidOp "Match offsets must be positive"
+
+                let start = output.Count - offset
+                if start < 0 then
+                    invalidOp "Match offset extends before the output buffer"
+
+                for index in 0 .. length - 1 do
+                    output.Add(output[start + index])
+
+        if originalLength >= 0 then
+            output |> Seq.truncate originalLength |> Array.ofSeq
+        else
+            output.ToArray()
+
+    static member SerialiseTokens(tokens: IReadOnlyList<LzssToken>, originalLength: int) =
+        if isNull (box tokens) then nullArg "tokens"
+        if originalLength < 0 then invalidArg "originalLength" "originalLength must be non-negative"
+
+        let blocks = ResizeArray<byte array>()
+        let mutable tokenIndex = 0
+        while tokenIndex < tokens.Count do
+            let chunk = tokens |> Seq.skip tokenIndex |> Seq.take (min 8 (tokens.Count - tokenIndex)) |> Seq.toList
+            let bytes = ResizeArray<byte>()
+            let mutable flag = 0uy
+
+            for bit = 0 to chunk.Length - 1 do
+                match chunk[bit] with
+                | Match(offset, length) ->
+                    flag <- flag ||| byte (1 <<< bit)
+                    bytes.Add(byte ((offset >>> 8) &&& 0xff))
+                    bytes.Add(byte (offset &&& 0xff))
+                    bytes.Add(byte (length &&& 0xff))
+                | Literal value ->
+                    bytes.Add value
+
+            blocks.Add(Array.append [| flag |] (bytes.ToArray()))
+            tokenIndex <- tokenIndex + 8
+
+        let totalSize = 8 + (blocks |> Seq.sumBy _.Length)
+        let output = Array.zeroCreate<byte> totalSize
+        BinaryPrimitives.WriteUInt32BigEndian(output.AsSpan(0, 4), uint32 originalLength)
+        BinaryPrimitives.WriteUInt32BigEndian(output.AsSpan(4, 4), uint32 blocks.Count)
+
+        let mutable position = 8
+        for block in blocks do
+            block.CopyTo(output, position)
+            position <- position + block.Length
+
+        output
+
+    static member DeserialiseTokens(data: byte array) =
+        if isNull data then nullArg "data"
+        if data.Length < 8 then
+            [], 0
+        else
+            let originalLength = int (BinaryPrimitives.ReadUInt32BigEndian(data.AsSpan(0, 4)))
+            let mutable blockCount = BinaryPrimitives.ReadUInt32BigEndian(data.AsSpan(4, 4))
+            let maxPossibleBlocks = uint32 (data.Length - 8)
+            if blockCount > maxPossibleBlocks then
+                blockCount <- maxPossibleBlocks
+
+            let tokens = ResizeArray<LzssToken>()
+            let mutable position = 8
+
+            for _ in 0u .. blockCount - 1u do
+                if position < data.Length then
+                    let flag = data[position]
+                    position <- position + 1
+                    for bit = 0 to 7 do
+                        if position < data.Length then
+                            if (flag &&& byte (1 <<< bit)) <> 0uy then
+                                if position + 3 <= data.Length then
+                                    tokens.Add(Match(((int data[position]) <<< 8) ||| int data[position + 1], int data[position + 2]))
+                                    position <- position + 3
+                            else
+                                tokens.Add(Literal data[position])
+                                position <- position + 1
+
+            List.ofSeq tokens, originalLength
+
+    static member Compress(data: byte array, ?windowSize: int, ?maxMatch: int, ?minMatch: int) =
+        if isNull data then nullArg "data"
+        let tokens = Lzss.Encode(data, ?windowSize = windowSize, ?maxMatch = maxMatch, ?minMatch = minMatch)
+        Lzss.SerialiseTokens(tokens, data.Length)
+
+    static member Decompress(data: byte array) =
+        if isNull data then nullArg "data"
+        let tokens, originalLength = Lzss.DeserialiseTokens(data)
+        Lzss.Decode(tokens, originalLength)

--- a/code/packages/fsharp/lzss/README.md
+++ b/code/packages/fsharp/lzss/README.md
@@ -1,0 +1,27 @@
+# lzss
+
+Pure F# LZSS compression for the CMP02 flagged sliding-window refinement.
+
+## What It Includes
+
+- Literal and match token types over the classic LZSS sliding-window model
+- CMP02 block-flag serialisation with `originalLength` and `blockCount` headers
+- One-shot `Compress` / `Decompress` helpers over the pure token API
+
+## Example
+
+```fsharp
+open System.Text
+open CodingAdventures.Lzss.FSharp
+
+let compressed = Lzss.Compress(Encoding.UTF8.GetBytes("ABABAB"))
+let roundTrip = Encoding.UTF8.GetString(Lzss.Decompress compressed)
+
+printfn "%s" roundTrip
+```
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/fsharp/lzss/required_capabilities.json
+++ b/code/packages/fsharp/lzss/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/lzss",
+  "capabilities": [],
+  "justification": "Pure in-memory F# LZSS implementation and tests."
+}

--- a/code/packages/fsharp/lzss/tests/CodingAdventures.Lzss.Tests/CodingAdventures.Lzss.Tests.fsproj
+++ b/code/packages/fsharp/lzss/tests/CodingAdventures.Lzss.Tests/CodingAdventures.Lzss.Tests.fsproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Lzss.fsproj" />
+    <Compile Include="LzssTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/lzss/tests/CodingAdventures.Lzss.Tests/LzssTests.fs
+++ b/code/packages/fsharp/lzss/tests/CodingAdventures.Lzss.Tests/LzssTests.fs
@@ -1,0 +1,79 @@
+namespace CodingAdventures.Lzss.FSharp.Tests
+
+open System
+open System.Buffers.Binary
+open System.Text
+open CodingAdventures.Lzss.FSharp
+open Xunit
+
+type LzssTests() =
+    let encodeText (value: string) = Encoding.UTF8.GetBytes value
+
+    [<Fact>]
+    member _.``empty input produces no tokens``() =
+        Assert.Empty(Lzss.Encode [||])
+
+    [<Fact>]
+    member _.``single byte produces literal``() =
+        Assert.Equal<LzssToken list>([ Literal(byte 'A') ], Lzss.Encode(encodeText "A"))
+
+    [<Fact>]
+    member _.``AABCBBABC matches spec vector tail``() =
+        let tokens = Lzss.Encode(encodeText "AABCBBABC")
+        Assert.Equal(7, List.length tokens)
+        Assert.Equal(Match(5, 3), List.last tokens)
+
+    [<Fact>]
+    member _.``ABABAB uses match token``() =
+        Assert.Equal<LzssToken list>(
+            [ Literal(byte 'A'); Literal(byte 'B'); Match(2, 4) ],
+            Lzss.Encode(encodeText "ABABAB"))
+
+    [<Fact>]
+    member _.``all same bytes use self-referential match``() =
+        Assert.Equal<LzssToken list>(
+            [ Literal(byte 'A'); Match(1, 6) ],
+            Lzss.Encode(encodeText "AAAAAAA"))
+
+    [<Fact>]
+    member _.``decode handles overlapping matches``() =
+        let output = Lzss.Decode([ Literal(byte 'A'); Match(1, 6) ], 7)
+        Assert.Equal<byte array>(encodeText "AAAAAAA", output)
+
+    [<Theory>]
+    [<InlineData("")>]
+    [<InlineData("A")>]
+    [<InlineData("ABCDE")>]
+    [<InlineData("AAAAAAA")>]
+    [<InlineData("ABABAB")>]
+    [<InlineData("AABCBBABC")>]
+    [<InlineData("hello world")>]
+    member _.``compress and decompress round trip ascii inputs``(value: string) =
+        let data = encodeText value
+        Assert.Equal<byte array>(data, Lzss.Decompress(Lzss.Compress data))
+
+    [<Fact>]
+    member _.``binary and repeated data round trip``() =
+        let data = Array.init 300 (fun index -> byte (index % 3))
+        Assert.Equal<byte array>(data, Lzss.Decompress(Lzss.Compress data))
+
+    [<Fact>]
+    member _.``serialise and deserialise are symmetric``() =
+        let tokens = [ Literal(byte 'A'); Literal(byte 'B'); Match(2, 4) ]
+        let bytes = Lzss.SerialiseTokens(tokens, 6)
+        let recovered, originalLength = Lzss.DeserialiseTokens bytes
+
+        Assert.Equal(6, originalLength)
+        Assert.Equal<LzssToken list>(tokens, recovered)
+
+    [<Fact>]
+    member _.``deserialise caps crafted large block count``() =
+        let bad = Array.zeroCreate<byte> 16
+        BinaryPrimitives.WriteUInt32BigEndian(bad.AsSpan(4, 4), 0x40000000u)
+        let output = Lzss.Decompress bad
+        Assert.NotNull output
+
+    [<Fact>]
+    member _.``decode rejects offsets before output buffer``() =
+        let error = Assert.Throws<InvalidOperationException>(fun () -> Lzss.Decode([ Match(4, 1) ]) |> ignore)
+        Assert.Contains("before the output buffer", error.Message)

--- a/code/specs/TE08-dotnet-compression-dictionary-and-flag-tranche.md
+++ b/code/specs/TE08-dotnet-compression-dictionary-and-flag-tranche.md
@@ -1,0 +1,97 @@
+# TE08 — Dotnet Compression Dictionary And Flag Tranche
+
+## Overview
+
+This note scopes the second pure .NET compression tranche after the initial
+`huffman-tree` and `lz77` foundations.
+
+The goal here is to cover the two immediate follow-on models in the compression
+series:
+
+- `lz78` — explicit dictionary / trie-based compression
+- `lzss` — flag-bit refinement of the `lz77` sliding-window model
+
+As with the first tranche:
+
+- C# packages must be implemented in C#
+- F# packages must be implemented in F#
+- Neither language may wrap or delegate to the other
+- No external compression libraries are used
+
+## Why These Two Next
+
+`lz78` and `lzss` are the natural second step because they branch directly from
+the foundations already landed:
+
+- `lz78` extends the dictionary side of the compression curriculum and sets up
+  the mental model for `lzw`
+- `lzss` extends the `lz77` sliding-window token model and is the direct
+  conceptual predecessor to `deflate`
+
+Together they advance both major tracks of the compression series without
+jumping straight to higher-composition formats.
+
+## Package Boundaries
+
+### `lz78`
+
+The public API should stay teaching-oriented:
+
+- encode bytes into `(dictIndex, nextChar)` tokens
+- decode tokens back into bytes
+- provide simple serialise/deserialise helpers for the CMP01 wire format
+- provide one-shot `compress` / `decompress` entry points
+
+The encoder may use an internal trie or equivalent byte-keyed dictionary state,
+but that machinery remains package-internal.
+
+### `lzss`
+
+The public API should expose:
+
+- literal and match token constructors or equivalents
+- byte-array encode/decode helpers
+- block-flag serialisation matching the CMP02 teaching format
+- one-shot `compress` / `decompress` entry points
+
+`lzss` should remain independent from `lz77` at the package boundary even if it
+shares the same underlying matching intuition.
+
+## Wire-Format Expectations
+
+### CMP01 / `lz78`
+
+- `original_length` as BE uint32
+- `token_count` as BE uint32
+- fixed-width 4-byte token records
+
+### CMP02 / `lzss`
+
+- `original_length` as BE uint32
+- `block_count` as BE uint32
+- 8-symbol flag groups with 1 byte of flags followed by literal or match data
+
+Both implementations must be careful with short, malformed, or truncated input
+so deserialisers degrade safely instead of indexing past available bytes.
+
+## Edge Cases Worth Testing
+
+The second tranche should explicitly cover:
+
+- empty input
+- single-byte input
+- repetition-free literal-heavy input
+- repeated substrings that force dictionary growth in `lz78`
+- flush-token behavior in `lz78`
+- self-referential overlap in `lzss`
+- capped dictionary or block metadata during serialisation/deserialisation
+- round trips over binary data containing `0x00` and `0xFF`
+
+## Success Criteria
+
+This tranche is successful when:
+
+- both languages expose pure `lz78` and `lzss` implementations
+- both languages pass package-local BUILD verification
+- both languages have tests covering the main spec vectors and edge cases
+- the public APIs are stable enough for `lzw` and `deflate` to build on next

--- a/lessons.md
+++ b/lessons.md
@@ -2069,3 +2069,17 @@ not exist in the current context`.
 **Rule:** When a C# test or package uses `BinaryPrimitives`, always add
 `using System.Buffers.Binary;` explicitly at the top of that file. Do not assume implicit usings
 will cover low-level buffer helpers.
+
+---
+
+## F# deserialisers must cap header counts to the available payload, not just trust the header
+
+**Date:** 2026-04-18
+
+**What happened:** In the new F# compression ports, `lz78` and `lzss` deserialisers initially let
+header-declared token/block counts drive unsigned loops directly. Even when the payload was tiny,
+a crafted large count could force a huge useless loop or combine badly with unsigned range math.
+
+**Rule:** In F# binary deserialisers, always derive a `maxPossible` item count from the remaining
+payload bytes and cap the header count before looping. Then guard the zero case explicitly before
+writing ranges like `0u .. count - 1u`.

--- a/lessons.md
+++ b/lessons.md
@@ -2054,3 +2054,18 @@ empty-input path into a huge bogus loop range and causing an `ArgumentOutOfRange
 **Rule:** When looping over an unsigned count in F#, always guard the zero case before writing
 `count - 1u`. Prefer:
   `if count = 0u then [] else for index in 0u .. count - 1u do ...`
+
+---
+
+## C# tests using `BinaryPrimitives` need an explicit `using System.Buffers.Binary`
+
+**Date:** 2026-04-18
+
+**What happened:** A new C# compression test used `BinaryPrimitives.WriteUInt32BigEndian(...)`
+to craft a malformed header case, but the test file omitted `using System.Buffers.Binary`. The
+package code compiled, yet the test project failed with `CS0103: The name 'BinaryPrimitives' does
+not exist in the current context`.
+
+**Rule:** When a C# test or package uses `BinaryPrimitives`, always add
+`using System.Buffers.Binary;` explicitly at the top of that file. Do not assume implicit usings
+will cover low-level buffer helpers.


### PR DESCRIPTION
## Summary
- add a spec for the second pure .NET compression tranche
- add native C# and native F# `lz78` packages with token encode/decode and serialisation helpers
- add native C# and native F# `lzss` packages with flagged block encode/decode and serialisation helpers
- harden the F# deserialisers against crafted oversized header counts and record the lessons from verification

## Verification
- `bash BUILD` in `code/packages/csharp/lz78`
- `bash BUILD` in `code/packages/csharp/lzss`
- `bash BUILD` in `code/packages/fsharp/lz78`
- `bash BUILD` in `code/packages/fsharp/lzss`

## Notes
- no external compression libraries are used
- the F# packages are implemented directly in F#, not as wrappers over the C# packages