### PR TITLE
feat(dotnet-compression): add lzw packages

### DIFF
--- a/code/packages/csharp/lzw/BUILD
+++ b/code/packages/csharp/lzw/BUILD
@@ -1,0 +1,1 @@
+mkdir -p .dotnet .artifacts && HOME="$PWD/.dotnet" DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_CLI_HOME="$PWD/.dotnet" dotnet test tests/CodingAdventures.Lzw.Tests/CodingAdventures.Lzw.Tests.csproj --disable-build-servers --artifacts-path .artifacts /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/lzw/BUILD_windows
+++ b/code/packages/csharp/lzw/BUILD_windows
@@ -1,0 +1,1 @@
+if not exist ".dotnet" mkdir ".dotnet" && if not exist ".artifacts" mkdir ".artifacts" && set "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1" && set "DOTNET_CLI_HOME=%CD%\.dotnet" && dotnet test "tests/CodingAdventures.Lzw.Tests/CodingAdventures.Lzw.Tests.csproj" --disable-build-servers --artifacts-path ".artifacts" /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/lzw/CHANGELOG.md
+++ b/code/packages/csharp/lzw/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-18
+
+### Added
+
+- Pure C# CMP03 LZW implementation with pre-seeded dictionary encoding and decoding
+- Public `BitWriter` and `BitReader` helpers for LSB-first variable-width code streams
+- Code-level `EncodeCodes`, `DecodeCodes`, `PackCodes`, and `UnpackCodes` helpers
+- Byte-level `Compress` and `Decompress` helpers with big-endian original-length header
+- xUnit coverage for spec vectors, tricky-token decoding, bit-packing symmetry, and binary round trips

--- a/code/packages/csharp/lzw/CodingAdventures.Lzw.csproj
+++ b/code/packages/csharp/lzw/CodingAdventures.Lzw.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Lzw.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure C# LZW compression and CMP03 bit-packed code helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\\**\\*.cs" />
+    <EmbeddedResource Remove="tests\\**" />
+    <None Remove="tests\\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/lzw/Lzw.cs
+++ b/code/packages/csharp/lzw/Lzw.cs
@@ -1,0 +1,334 @@
+using System.Buffers.Binary;
+
+namespace CodingAdventures.Lzw;
+
+public sealed class BitWriter
+{
+    private ulong _buffer;
+    private int _bitCount;
+    private readonly List<byte> _bytes = [];
+
+    public void Write(int code, int codeSize)
+    {
+        if (codeSize <= 0 || codeSize > Lzw.MAX_CODE_SIZE)
+        {
+            throw new ArgumentOutOfRangeException(nameof(codeSize), "codeSize must be between 1 and MAX_CODE_SIZE");
+        }
+
+        _buffer |= (ulong)(uint)code << _bitCount;
+        _bitCount += codeSize;
+
+        while (_bitCount >= 8)
+        {
+            _bytes.Add((byte)(_buffer & 0xFF));
+            _buffer >>= 8;
+            _bitCount -= 8;
+        }
+    }
+
+    public void Flush()
+    {
+        if (_bitCount > 0)
+        {
+            _bytes.Add((byte)(_buffer & 0xFF));
+            _buffer = 0;
+            _bitCount = 0;
+        }
+    }
+
+    public byte[] ToArray() => [.. _bytes];
+}
+
+public sealed class BitReader(byte[] data)
+{
+    private readonly byte[] _data = data ?? throw new ArgumentNullException(nameof(data));
+    private int _position;
+    private ulong _buffer;
+    private int _bitCount;
+
+    public int Read(int codeSize)
+    {
+        if (codeSize <= 0 || codeSize > Lzw.MAX_CODE_SIZE)
+        {
+            throw new ArgumentOutOfRangeException(nameof(codeSize), "codeSize must be between 1 and MAX_CODE_SIZE");
+        }
+
+        while (_bitCount < codeSize)
+        {
+            if (_position >= _data.Length)
+            {
+                throw new InvalidOperationException("unexpected end of bit stream");
+            }
+
+            _buffer |= (ulong)_data[_position] << _bitCount;
+            _position++;
+            _bitCount += 8;
+        }
+
+        var mask = (1UL << codeSize) - 1UL;
+        var code = (int)(_buffer & mask);
+        _buffer >>= codeSize;
+        _bitCount -= codeSize;
+        return code;
+    }
+
+    public bool Exhausted() => _position >= _data.Length && _bitCount == 0;
+}
+
+public static class Lzw
+{
+    public const int CLEAR_CODE = 256;
+    public const int STOP_CODE = 257;
+    public const int INITIAL_NEXT_CODE = 258;
+    public const int INITIAL_CODE_SIZE = 9;
+    public const int MAX_CODE_SIZE = 16;
+
+    private const int MaxEntries = 1 << MAX_CODE_SIZE;
+
+    public static (List<int> Codes, int OriginalLength) EncodeCodes(byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+
+        var dictionary = CreateEncoderDictionary();
+        var codes = new List<int> { CLEAR_CODE };
+        var nextCode = INITIAL_NEXT_CODE;
+        var current = string.Empty;
+
+        foreach (var value in data)
+        {
+            var candidate = current + (char)value;
+            if (dictionary.ContainsKey(candidate))
+            {
+                current = candidate;
+                continue;
+            }
+
+            codes.Add(dictionary[current]);
+
+            if (nextCode < MaxEntries)
+            {
+                dictionary[candidate] = nextCode;
+                nextCode++;
+            }
+            else
+            {
+                codes.Add(CLEAR_CODE);
+                dictionary = CreateEncoderDictionary();
+                nextCode = INITIAL_NEXT_CODE;
+            }
+
+            current = SingleByteString(value);
+        }
+
+        if (current.Length > 0)
+        {
+            codes.Add(dictionary[current]);
+        }
+
+        codes.Add(STOP_CODE);
+        return (codes, data.Length);
+    }
+
+    public static byte[] DecodeCodes(IEnumerable<int> codes, int originalLength = -1)
+    {
+        ArgumentNullException.ThrowIfNull(codes);
+
+        var dictionary = CreateDecoderDictionary();
+        var output = new List<byte>();
+        var nextCode = INITIAL_NEXT_CODE;
+        int? previousCode = null;
+
+        foreach (var code in codes)
+        {
+            if (code == CLEAR_CODE)
+            {
+                ResetDecoderDictionary(dictionary);
+                nextCode = INITIAL_NEXT_CODE;
+                previousCode = null;
+                continue;
+            }
+
+            if (code == STOP_CODE)
+            {
+                break;
+            }
+
+            byte[] entry;
+            if (code >= 0 && code < dictionary.Count)
+            {
+                entry = dictionary[code];
+            }
+            else if (code == nextCode && previousCode.HasValue)
+            {
+                var previous = dictionary[previousCode.Value];
+                entry = AppendByte(previous, previous[0]);
+            }
+            else
+            {
+                throw new InvalidOperationException("invalid LZW code");
+            }
+
+            output.AddRange(entry);
+
+            if (previousCode.HasValue && nextCode < MaxEntries)
+            {
+                var previous = dictionary[previousCode.Value];
+                dictionary.Add(AppendByte(previous, entry[0]));
+                nextCode++;
+            }
+
+            previousCode = code;
+        }
+
+        return originalLength >= 0 ? [.. output.Take(originalLength)] : [.. output];
+    }
+
+    public static byte[] PackCodes(IReadOnlyList<int> codes, int originalLength)
+    {
+        ArgumentNullException.ThrowIfNull(codes);
+        if (originalLength < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(originalLength), "originalLength must be non-negative");
+        }
+
+        var writer = new BitWriter();
+        var nextCode = INITIAL_NEXT_CODE;
+        var codeSize = INITIAL_CODE_SIZE;
+
+        foreach (var code in codes)
+        {
+            if (code < 0 || code >= MaxEntries)
+            {
+                throw new InvalidOperationException("Code does not fit in the CMP03 code space");
+            }
+
+            writer.Write(code, codeSize);
+
+            if (code == CLEAR_CODE)
+            {
+                nextCode = INITIAL_NEXT_CODE;
+                codeSize = INITIAL_CODE_SIZE;
+            }
+            else if (code != STOP_CODE && nextCode < MaxEntries)
+            {
+                nextCode++;
+                if (nextCode > (1 << codeSize) && codeSize < MAX_CODE_SIZE)
+                {
+                    codeSize++;
+                }
+            }
+        }
+
+        writer.Flush();
+        var payload = writer.ToArray();
+        var output = new byte[4 + payload.Length];
+        BinaryPrimitives.WriteUInt32BigEndian(output.AsSpan(0, 4), (uint)originalLength);
+        payload.CopyTo(output, 4);
+        return output;
+    }
+
+    public static (List<int> Codes, int OriginalLength) UnpackCodes(byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        if (data.Length < 4)
+        {
+            return ([], 0);
+        }
+
+        var originalLength = (int)BinaryPrimitives.ReadUInt32BigEndian(data.AsSpan(0, 4));
+        var reader = new BitReader(data[4..]);
+        var codes = new List<int>();
+        var nextCode = INITIAL_NEXT_CODE;
+        var codeSize = INITIAL_CODE_SIZE;
+
+        while (true)
+        {
+            int code;
+            try
+            {
+                code = reader.Read(codeSize);
+            }
+            catch (InvalidOperationException)
+            {
+                break;
+            }
+
+            codes.Add(code);
+
+            if (code == STOP_CODE)
+            {
+                break;
+            }
+
+            if (code == CLEAR_CODE)
+            {
+                nextCode = INITIAL_NEXT_CODE;
+                codeSize = INITIAL_CODE_SIZE;
+            }
+            else if (nextCode < MaxEntries)
+            {
+                nextCode++;
+                if (nextCode > (1 << codeSize) && codeSize < MAX_CODE_SIZE)
+                {
+                    codeSize++;
+                }
+            }
+        }
+
+        return (codes, originalLength);
+    }
+
+    public static byte[] Compress(byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        var (codes, originalLength) = EncodeCodes(data);
+        return PackCodes(codes, originalLength);
+    }
+
+    public static byte[] Decompress(byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        var (codes, originalLength) = UnpackCodes(data);
+        return DecodeCodes(codes, originalLength);
+    }
+
+    private static Dictionary<string, int> CreateEncoderDictionary()
+    {
+        var dictionary = new Dictionary<string, int>(512);
+        for (var value = 0; value < 256; value++)
+        {
+            dictionary[SingleByteString((byte)value)] = value;
+        }
+
+        return dictionary;
+    }
+
+    private static List<byte[]> CreateDecoderDictionary()
+    {
+        var dictionary = new List<byte[]>(258);
+        ResetDecoderDictionary(dictionary);
+        return dictionary;
+    }
+
+    private static void ResetDecoderDictionary(List<byte[]> dictionary)
+    {
+        dictionary.Clear();
+        for (var value = 0; value < 256; value++)
+        {
+            dictionary.Add([(byte)value]);
+        }
+
+        dictionary.Add([]);
+        dictionary.Add([]);
+    }
+
+    private static string SingleByteString(byte value) => new((char)value, 1);
+
+    private static byte[] AppendByte(byte[] prefix, byte value)
+    {
+        var output = new byte[prefix.Length + 1];
+        prefix.CopyTo(output, 0);
+        output[^1] = value;
+        return output;
+    }
+}

--- a/code/packages/csharp/lzw/README.md
+++ b/code/packages/csharp/lzw/README.md
@@ -1,0 +1,29 @@
+# lzw
+
+Pure C# LZW compression for the CMP03 bit-packed dictionary stage.
+
+## What It Includes
+
+- Public LZW constants for the shared CMP03 code space
+- `BitWriter` and `BitReader` helpers for LSB-first variable-width code streams
+- `EncodeCodes` and `DecodeCodes` for code-level teaching traces
+- `PackCodes` and `UnpackCodes` for the CMP03 wire format
+- One-shot `Compress` and `Decompress` helpers over the pure codec
+
+## Example
+
+```csharp
+using System.Text;
+using CodingAdventures.Lzw;
+
+var compressed = Lzw.Compress(Encoding.UTF8.GetBytes("ABABAB"));
+var roundTrip = Encoding.UTF8.GetString(Lzw.Decompress(compressed));
+
+Console.WriteLine(roundTrip); // ABABAB
+```
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/csharp/lzw/required_capabilities.json
+++ b/code/packages/csharp/lzw/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/lzw",
+  "capabilities": [],
+  "justification": "Pure in-memory C# LZW implementation and tests."
+}

--- a/code/packages/csharp/lzw/tests/CodingAdventures.Lzw.Tests/CodingAdventures.Lzw.Tests.csproj
+++ b/code/packages/csharp/lzw/tests/CodingAdventures.Lzw.Tests/CodingAdventures.Lzw.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Lzw.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/lzw/tests/CodingAdventures.Lzw.Tests/LzwTests.cs
+++ b/code/packages/csharp/lzw/tests/CodingAdventures.Lzw.Tests/LzwTests.cs
@@ -1,0 +1,194 @@
+using System.Buffers.Binary;
+using System.Text;
+using CodingAdventures.Lzw;
+
+namespace CodingAdventures.Lzw.Tests;
+
+public sealed class ConstantTests
+{
+    [Fact]
+    public void ConstantsMatchCmp03()
+    {
+        Assert.Equal(256, Lzw.CLEAR_CODE);
+        Assert.Equal(257, Lzw.STOP_CODE);
+        Assert.Equal(258, Lzw.INITIAL_NEXT_CODE);
+        Assert.Equal(9, Lzw.INITIAL_CODE_SIZE);
+        Assert.Equal(16, Lzw.MAX_CODE_SIZE);
+    }
+}
+
+public sealed class BitIoTests
+{
+    [Fact]
+    public void SingleNineBitCodeRoundTrips()
+    {
+        var writer = new BitWriter();
+        writer.Write(256, 9);
+        writer.Flush();
+
+        var reader = new BitReader(writer.ToArray());
+        Assert.Equal(256, reader.Read(9));
+    }
+
+    [Fact]
+    public void MultipleNineBitCodesRoundTrip()
+    {
+        var writer = new BitWriter();
+        foreach (var code in new[] { Lzw.CLEAR_CODE, 65, 66, 258, Lzw.STOP_CODE })
+        {
+            writer.Write(code, 9);
+        }
+
+        writer.Flush();
+        var reader = new BitReader(writer.ToArray());
+
+        Assert.Equal(Lzw.CLEAR_CODE, reader.Read(9));
+        Assert.Equal(65, reader.Read(9));
+        Assert.Equal(66, reader.Read(9));
+        Assert.Equal(258, reader.Read(9));
+        Assert.Equal(Lzw.STOP_CODE, reader.Read(9));
+    }
+
+    [Fact]
+    public void ExhaustedReaderThrows()
+    {
+        var reader = new BitReader([]);
+        Assert.Throws<InvalidOperationException>(() => reader.Read(9));
+    }
+}
+
+public sealed class EncodeDecodeCodeTests
+{
+    private static byte[] Bytes(string value) => Encoding.UTF8.GetBytes(value);
+
+    [Fact]
+    public void EmptyInputEncodesToClearAndStop()
+    {
+        var (codes, originalLength) = Lzw.EncodeCodes([]);
+        Assert.Equal(0, originalLength);
+        Assert.Equal([Lzw.CLEAR_CODE, Lzw.STOP_CODE], codes);
+    }
+
+    [Fact]
+    public void AbEncodesToExpectedVector()
+    {
+        var (codes, _) = Lzw.EncodeCodes(Bytes("AB"));
+        Assert.Equal([Lzw.CLEAR_CODE, 65, 66, Lzw.STOP_CODE], codes);
+    }
+
+    [Fact]
+    public void AbababEncodesToExpectedVector()
+    {
+        var (codes, _) = Lzw.EncodeCodes(Bytes("ABABAB"));
+        Assert.Equal([Lzw.CLEAR_CODE, 65, 66, 258, 258, Lzw.STOP_CODE], codes);
+    }
+
+    [Fact]
+    public void AaaaaaaEncodesToTrickyTokenVector()
+    {
+        var (codes, _) = Lzw.EncodeCodes(Bytes("AAAAAAA"));
+        Assert.Equal([Lzw.CLEAR_CODE, 65, 258, 259, 65, Lzw.STOP_CODE], codes);
+    }
+
+    [Fact]
+    public void AbababDecodesFromExpectedVector()
+    {
+        var decoded = Lzw.DecodeCodes([Lzw.CLEAR_CODE, 65, 66, 258, 258, Lzw.STOP_CODE]);
+        Assert.Equal(Bytes("ABABAB"), decoded);
+    }
+
+    [Fact]
+    public void TrickyTokenVectorDecodes()
+    {
+        var decoded = Lzw.DecodeCodes([Lzw.CLEAR_CODE, 65, 258, 259, 65, Lzw.STOP_CODE]);
+        Assert.Equal(Bytes("AAAAAAA"), decoded);
+    }
+
+    [Fact]
+    public void ClearResetsDictionary()
+    {
+        var decoded = Lzw.DecodeCodes([Lzw.CLEAR_CODE, 65, Lzw.CLEAR_CODE, 66, Lzw.STOP_CODE]);
+        Assert.Equal(Bytes("AB"), decoded);
+    }
+
+    [Fact]
+    public void InvalidCodeThrows()
+    {
+        var error = Assert.Throws<InvalidOperationException>(() => Lzw.DecodeCodes([Lzw.CLEAR_CODE, 9999, 65, Lzw.STOP_CODE]));
+        Assert.Contains("invalid LZW code", error.Message);
+    }
+}
+
+public sealed class PackUnpackTests
+{
+    [Fact]
+    public void HeaderStoresOriginalLengthBigEndian()
+    {
+        var packed = Lzw.PackCodes([Lzw.CLEAR_CODE, Lzw.STOP_CODE], 42);
+        Assert.Equal(42u, BinaryPrimitives.ReadUInt32BigEndian(packed.AsSpan(0, 4)));
+    }
+
+    [Fact]
+    public void AbababCodesRoundTripThroughWireFormat()
+    {
+        var codes = new List<int> { Lzw.CLEAR_CODE, 65, 66, 258, 258, Lzw.STOP_CODE };
+        var packed = Lzw.PackCodes(codes, 6);
+        var (unpacked, originalLength) = Lzw.UnpackCodes(packed);
+
+        Assert.Equal(6, originalLength);
+        Assert.Equal(codes, unpacked);
+    }
+
+    [Fact]
+    public void TruncatedDataDoesNotCrashUnpack()
+    {
+        var (codes, originalLength) = Lzw.UnpackCodes([0, 0]);
+        Assert.Empty(codes);
+        Assert.Equal(0, originalLength);
+    }
+}
+
+public sealed class CompressDecompressTests
+{
+    [Theory]
+    [InlineData("")]
+    [InlineData("A")]
+    [InlineData("AB")]
+    [InlineData("ABABAB")]
+    [InlineData("AAAAAAA")]
+    [InlineData("AABABC")]
+    public void StringVectorsRoundTrip(string value)
+    {
+        var bytes = Bytes(value);
+        Assert.Equal(bytes, Lzw.Decompress(Lzw.Compress(bytes)));
+    }
+
+    [Fact]
+    public void RepetitiveTextRoundTrips()
+    {
+        var value = Bytes(string.Concat(Enumerable.Repeat("the quick brown fox jumps over the lazy dog ", 20)));
+        Assert.Equal(value, Lzw.Decompress(Lzw.Compress(value)));
+    }
+
+    [Fact]
+    public void BinaryDataRoundTrips()
+    {
+        var value = new byte[1024];
+        for (var index = 0; index < value.Length; index++)
+        {
+            value[index] = (byte)(index % 256);
+        }
+
+        Assert.Equal(value, Lzw.Decompress(Lzw.Compress(value)));
+    }
+
+    [Fact]
+    public void HeaderContainsOriginalLength()
+    {
+        var input = Bytes("hello world");
+        var compressed = Lzw.Compress(input);
+        Assert.Equal((uint)input.Length, BinaryPrimitives.ReadUInt32BigEndian(compressed.AsSpan(0, 4)));
+    }
+
+    private static byte[] Bytes(string value) => Encoding.UTF8.GetBytes(value);
+}

--- a/code/packages/fsharp/lzw/BUILD
+++ b/code/packages/fsharp/lzw/BUILD
@@ -1,0 +1,1 @@
+mkdir -p .dotnet .artifacts && HOME="$PWD/.dotnet" DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_CLI_HOME="$PWD/.dotnet" dotnet test tests/CodingAdventures.Lzw.Tests/CodingAdventures.Lzw.Tests.fsproj --disable-build-servers --artifacts-path .artifacts /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/lzw/BUILD_windows
+++ b/code/packages/fsharp/lzw/BUILD_windows
@@ -1,0 +1,1 @@
+if not exist ".dotnet" mkdir ".dotnet" && if not exist ".artifacts" mkdir ".artifacts" && set "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1" && set "DOTNET_CLI_HOME=%CD%\.dotnet" && dotnet test "tests/CodingAdventures.Lzw.Tests/CodingAdventures.Lzw.Tests.fsproj" --disable-build-servers --artifacts-path ".artifacts" /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/lzw/CHANGELOG.md
+++ b/code/packages/fsharp/lzw/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-18
+
+### Added
+
+- Pure F# CMP03 LZW implementation with pre-seeded dictionary encoding and decoding
+- Public `BitWriter` and `BitReader` helpers for LSB-first variable-width code streams
+- Code-level `EncodeCodes`, `DecodeCodes`, `PackCodes`, and `UnpackCodes` helpers
+- Byte-level `Compress` and `Decompress` helpers with big-endian original-length header
+- xUnit coverage for spec vectors, tricky-token decoding, bit-packing symmetry, and binary round trips

--- a/code/packages/fsharp/lzw/CodingAdventures.Lzw.fsproj
+++ b/code/packages/fsharp/lzw/CodingAdventures.Lzw.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Lzw.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure F# LZW compression and CMP03 bit-packed code helpers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Lzw.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/lzw/Lzw.fs
+++ b/code/packages/fsharp/lzw/Lzw.fs
@@ -1,0 +1,270 @@
+namespace CodingAdventures.Lzw.FSharp
+
+open System
+open System.Buffers.Binary
+open System.Collections.Generic
+
+module private Constants =
+    [<Literal>]
+    let ClearCode = 256
+
+    [<Literal>]
+    let StopCode = 257
+
+    [<Literal>]
+    let InitialNextCode = 258
+
+    [<Literal>]
+    let InitialCodeSize = 9
+
+    [<Literal>]
+    let MaxCodeSize = 16
+
+    let MaxEntries = 1 <<< MaxCodeSize
+
+type BitWriter() =
+    let bytes = ResizeArray<byte>()
+    let mutable buffer = 0UL
+    let mutable bitCount = 0
+
+    member _.Write(code: int, codeSize: int) =
+        if codeSize <= 0 || codeSize > Constants.MaxCodeSize then
+            invalidArg "codeSize" "codeSize must be between 1 and MAX_CODE_SIZE"
+
+        buffer <- buffer ||| ((uint64 code) <<< bitCount)
+        bitCount <- bitCount + codeSize
+
+        while bitCount >= 8 do
+            bytes.Add(byte (buffer &&& 0xFFUL))
+            buffer <- buffer >>> 8
+            bitCount <- bitCount - 8
+
+    member _.Flush() =
+        if bitCount > 0 then
+            bytes.Add(byte (buffer &&& 0xFFUL))
+            buffer <- 0UL
+            bitCount <- 0
+
+    member _.ToArray() = bytes.ToArray()
+
+type BitReader(data: byte array) =
+    do
+        if isNull data then nullArg "data"
+
+    let mutable position = 0
+    let mutable buffer = 0UL
+    let mutable bitCount = 0
+
+    member _.Read(codeSize: int) =
+        if codeSize <= 0 || codeSize > Constants.MaxCodeSize then
+            invalidArg "codeSize" "codeSize must be between 1 and MAX_CODE_SIZE"
+
+        while bitCount < codeSize do
+            if position >= data.Length then
+                invalidOp "unexpected end of bit stream"
+
+            buffer <- buffer ||| ((uint64 data[position]) <<< bitCount)
+            position <- position + 1
+            bitCount <- bitCount + 8
+
+        let mask = (1UL <<< codeSize) - 1UL
+        let code = int (buffer &&& mask)
+        buffer <- buffer >>> codeSize
+        bitCount <- bitCount - codeSize
+        code
+
+    member _.Exhausted = position >= data.Length && bitCount = 0
+
+[<AbstractClass; Sealed>]
+type Lzw =
+    static member CLEAR_CODE = Constants.ClearCode
+    static member STOP_CODE = Constants.StopCode
+    static member INITIAL_NEXT_CODE = Constants.InitialNextCode
+    static member INITIAL_CODE_SIZE = Constants.InitialCodeSize
+    static member MAX_CODE_SIZE = Constants.MaxCodeSize
+
+    static member private SingleByteString(value: byte) = string (char value)
+
+    static member private CreateEncoderDictionary() =
+        let dictionary = Dictionary<string, int>(512)
+        for value in 0 .. 255 do
+            dictionary[Lzw.SingleByteString(byte value)] <- value
+
+        dictionary
+
+    static member private ResetDecoderDictionary(dictionary: ResizeArray<byte array>) =
+        dictionary.Clear()
+        for value in 0 .. 255 do
+            dictionary.Add([| byte value |])
+
+        dictionary.Add(Array.empty<byte>)
+        dictionary.Add(Array.empty<byte>)
+
+    static member private CreateDecoderDictionary() =
+        let dictionary = ResizeArray<byte array>(258)
+        Lzw.ResetDecoderDictionary(dictionary)
+        dictionary
+
+    static member private AppendByte(prefix: byte array, value: byte) =
+        let output = Array.zeroCreate<byte> (prefix.Length + 1)
+        Array.Copy(prefix, output, prefix.Length)
+        output[output.Length - 1] <- value
+        output
+
+    static member EncodeCodes(data: byte array) =
+        if isNull data then
+            nullArg "data"
+
+        let mutable dictionary = Lzw.CreateEncoderDictionary()
+        let codes = ResizeArray<int>()
+        codes.Add(Constants.ClearCode)
+        let mutable nextCode = Constants.InitialNextCode
+        let mutable current = String.Empty
+
+        for value in data do
+            let candidate = current + Lzw.SingleByteString(value)
+            match dictionary.TryGetValue(candidate) with
+            | true, _ ->
+                current <- candidate
+            | _ ->
+                codes.Add(dictionary[current])
+
+                if nextCode < Constants.MaxEntries then
+                    dictionary[candidate] <- nextCode
+                    nextCode <- nextCode + 1
+                else
+                    codes.Add(Constants.ClearCode)
+                    dictionary <- Lzw.CreateEncoderDictionary()
+                    nextCode <- Constants.InitialNextCode
+
+                current <- Lzw.SingleByteString(value)
+
+        if current.Length > 0 then
+            codes.Add(dictionary[current])
+
+        codes.Add(Constants.StopCode)
+        List.ofSeq codes, data.Length
+
+    static member DecodeCodes(codes: seq<int>, ?originalLength: int) =
+        if isNull (box codes) then
+            nullArg "codes"
+
+        let originalLength = defaultArg originalLength -1
+        let dictionary = Lzw.CreateDecoderDictionary()
+        let output = ResizeArray<byte>()
+        let mutable nextCode = Constants.InitialNextCode
+        let mutable previousCode: int option = None
+        let mutable stop = false
+
+        for code in codes do
+            if not stop then
+                if code = Constants.ClearCode then
+                    Lzw.ResetDecoderDictionary(dictionary)
+                    nextCode <- Constants.InitialNextCode
+                    previousCode <- None
+                elif code = Constants.StopCode then
+                    stop <- true
+                else
+                    let entry =
+                        if code >= 0 && code < dictionary.Count then
+                            dictionary[code]
+                        elif code = nextCode then
+                            match previousCode with
+                            | Some previous ->
+                                let previousEntry = dictionary[previous]
+                                Lzw.AppendByte(previousEntry, previousEntry[0])
+                            | None -> invalidOp "invalid LZW code"
+                        else
+                            invalidOp "invalid LZW code"
+
+                    output.AddRange(entry)
+
+                    match previousCode with
+                    | Some previous when nextCode < Constants.MaxEntries ->
+                        let previousEntry = dictionary[previous]
+                        dictionary.Add(Lzw.AppendByte(previousEntry, entry[0]))
+                        nextCode <- nextCode + 1
+                    | _ -> ()
+
+                    previousCode <- Some code
+
+        let finalOutput = output.ToArray()
+        if originalLength >= 0 then
+            finalOutput |> Seq.truncate originalLength |> Array.ofSeq
+        else
+            finalOutput
+
+    static member PackCodes(codes: seq<int>, originalLength: int) =
+        if isNull (box codes) then
+            nullArg "codes"
+        if originalLength < 0 then
+            invalidArg "originalLength" "originalLength must be non-negative"
+
+        let writer = BitWriter()
+        let mutable nextCode = Constants.InitialNextCode
+        let mutable codeSize = Constants.InitialCodeSize
+
+        for code in codes do
+            if code < 0 || code >= Constants.MaxEntries then
+                invalidOp "Code does not fit in the CMP03 code space"
+
+            writer.Write(code, codeSize)
+
+            if code = Constants.ClearCode then
+                nextCode <- Constants.InitialNextCode
+                codeSize <- Constants.InitialCodeSize
+            elif code <> Constants.StopCode && nextCode < Constants.MaxEntries then
+                nextCode <- nextCode + 1
+                if nextCode > (1 <<< codeSize) && codeSize < Constants.MaxCodeSize then
+                    codeSize <- codeSize + 1
+
+        writer.Flush()
+        let payload = writer.ToArray()
+        let output = Array.zeroCreate<byte> (4 + payload.Length)
+        BinaryPrimitives.WriteUInt32BigEndian(output.AsSpan(0, 4), uint32 originalLength)
+        Array.Copy(payload, 0, output, 4, payload.Length)
+        output
+
+    static member UnpackCodes(data: byte array) =
+        if isNull data then
+            nullArg "data"
+        if data.Length < 4 then
+            [], 0
+        else
+            let originalLength = int (BinaryPrimitives.ReadUInt32BigEndian(data.AsSpan(0, 4)))
+            let reader = BitReader(data[4..])
+            let codes = ResizeArray<int>()
+            let mutable nextCode = Constants.InitialNextCode
+            let mutable codeSize = Constants.InitialCodeSize
+            let mutable keepReading = true
+
+            while keepReading do
+                try
+                    let code = reader.Read(codeSize)
+                    codes.Add(code)
+
+                    if code = Constants.StopCode then
+                        keepReading <- false
+                    elif code = Constants.ClearCode then
+                        nextCode <- Constants.InitialNextCode
+                        codeSize <- Constants.InitialCodeSize
+                    elif nextCode < Constants.MaxEntries then
+                        nextCode <- nextCode + 1
+                        if nextCode > (1 <<< codeSize) && codeSize < Constants.MaxCodeSize then
+                            codeSize <- codeSize + 1
+                with :? InvalidOperationException ->
+                    keepReading <- false
+
+            List.ofSeq codes, originalLength
+
+    static member Compress(data: byte array) =
+        if isNull data then
+            nullArg "data"
+        let codes, originalLength = Lzw.EncodeCodes(data)
+        Lzw.PackCodes(codes, originalLength)
+
+    static member Decompress(data: byte array) =
+        if isNull data then
+            nullArg "data"
+        let codes, originalLength = Lzw.UnpackCodes(data)
+        Lzw.DecodeCodes(codes, originalLength)

--- a/code/packages/fsharp/lzw/README.md
+++ b/code/packages/fsharp/lzw/README.md
@@ -1,0 +1,29 @@
+# lzw
+
+Pure F# LZW compression for the CMP03 bit-packed dictionary stage.
+
+## What It Includes
+
+- Public LZW constants for the shared CMP03 code space
+- `BitWriter` and `BitReader` helpers for LSB-first variable-width code streams
+- `EncodeCodes` and `DecodeCodes` for code-level teaching traces
+- `PackCodes` and `UnpackCodes` for the CMP03 wire format
+- One-shot `Compress` and `Decompress` helpers over the pure codec
+
+## Example
+
+```fsharp
+open System.Text
+open CodingAdventures.Lzw.FSharp
+
+let compressed = Lzw.Compress(Encoding.UTF8.GetBytes("ABABAB"))
+let roundTrip = Encoding.UTF8.GetString(Lzw.Decompress compressed)
+
+printfn "%s" roundTrip
+```
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/fsharp/lzw/required_capabilities.json
+++ b/code/packages/fsharp/lzw/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/lzw",
+  "capabilities": [],
+  "justification": "Pure in-memory F# LZW implementation and tests."
+}

--- a/code/packages/fsharp/lzw/tests/CodingAdventures.Lzw.Tests/CodingAdventures.Lzw.Tests.fsproj
+++ b/code/packages/fsharp/lzw/tests/CodingAdventures.Lzw.Tests/CodingAdventures.Lzw.Tests.fsproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Lzw.fsproj" />
+    <Compile Include="LzwTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/lzw/tests/CodingAdventures.Lzw.Tests/LzwTests.fs
+++ b/code/packages/fsharp/lzw/tests/CodingAdventures.Lzw.Tests/LzwTests.fs
@@ -1,0 +1,143 @@
+namespace CodingAdventures.Lzw.FSharp.Tests
+
+open System
+open System.Buffers.Binary
+open System.Text
+open CodingAdventures.Lzw.FSharp
+open Xunit
+
+module private Helpers =
+    let bytes (value: string) = Encoding.UTF8.GetBytes(value)
+
+type ConstantTests() =
+    [<Fact>]
+    member _.``Constants match CMP03``() =
+        Assert.Equal(256, Lzw.CLEAR_CODE)
+        Assert.Equal(257, Lzw.STOP_CODE)
+        Assert.Equal(258, Lzw.INITIAL_NEXT_CODE)
+        Assert.Equal(9, Lzw.INITIAL_CODE_SIZE)
+        Assert.Equal(16, Lzw.MAX_CODE_SIZE)
+
+type BitIoTests() =
+    [<Fact>]
+    member _.``Single 9-bit code round trips``() =
+        let writer = BitWriter()
+        writer.Write(256, 9)
+        writer.Flush()
+
+        let reader = BitReader(writer.ToArray())
+        Assert.Equal(256, reader.Read(9))
+
+    [<Fact>]
+    member _.``Multiple 9-bit codes round trip``() =
+        let writer = BitWriter()
+        for code in [ Lzw.CLEAR_CODE; 65; 66; 258; Lzw.STOP_CODE ] do
+            writer.Write(code, 9)
+
+        writer.Flush()
+
+        let reader = BitReader(writer.ToArray())
+        Assert.Equal(Lzw.CLEAR_CODE, reader.Read(9))
+        Assert.Equal(65, reader.Read(9))
+        Assert.Equal(66, reader.Read(9))
+        Assert.Equal(258, reader.Read(9))
+        Assert.Equal(Lzw.STOP_CODE, reader.Read(9))
+
+    [<Fact>]
+    member _.``Exhausted reader throws``() =
+        let reader = BitReader(Array.empty)
+        Assert.Throws<InvalidOperationException>(fun () -> reader.Read(9) |> ignore) |> ignore
+
+type EncodeDecodeCodeTests() =
+    [<Fact>]
+    member _.``Empty input encodes to CLEAR and STOP``() =
+        let codes, originalLength = Lzw.EncodeCodes(Array.empty)
+        Assert.Equal(0, originalLength)
+        Assert.Equal<int list>([ Lzw.CLEAR_CODE; Lzw.STOP_CODE ], codes)
+
+    [<Fact>]
+    member _.``AB encodes to expected vector``() =
+        let codes, _ = Lzw.EncodeCodes(Helpers.bytes "AB")
+        Assert.Equal<int list>([ Lzw.CLEAR_CODE; 65; 66; Lzw.STOP_CODE ], codes)
+
+    [<Fact>]
+    member _.``ABABAB encodes to expected vector``() =
+        let codes, _ = Lzw.EncodeCodes(Helpers.bytes "ABABAB")
+        Assert.Equal<int list>([ Lzw.CLEAR_CODE; 65; 66; 258; 258; Lzw.STOP_CODE ], codes)
+
+    [<Fact>]
+    member _.``AAAAAAA encodes to tricky token vector``() =
+        let codes, _ = Lzw.EncodeCodes(Helpers.bytes "AAAAAAA")
+        Assert.Equal<int list>([ Lzw.CLEAR_CODE; 65; 258; 259; 65; Lzw.STOP_CODE ], codes)
+
+    [<Fact>]
+    member _.``ABABAB decodes from expected vector``() =
+        let decoded = Lzw.DecodeCodes([ Lzw.CLEAR_CODE; 65; 66; 258; 258; Lzw.STOP_CODE ])
+        Assert.Equal<byte array>(Helpers.bytes "ABABAB", decoded)
+
+    [<Fact>]
+    member _.``Tricky token vector decodes``() =
+        let decoded = Lzw.DecodeCodes([ Lzw.CLEAR_CODE; 65; 258; 259; 65; Lzw.STOP_CODE ])
+        Assert.Equal<byte array>(Helpers.bytes "AAAAAAA", decoded)
+
+    [<Fact>]
+    member _.``CLEAR resets dictionary``() =
+        let decoded = Lzw.DecodeCodes([ Lzw.CLEAR_CODE; 65; Lzw.CLEAR_CODE; 66; Lzw.STOP_CODE ])
+        Assert.Equal<byte array>(Helpers.bytes "AB", decoded)
+
+    [<Fact>]
+    member _.``Invalid code throws``() =
+        let error =
+            Assert.Throws<InvalidOperationException>(fun () ->
+                Lzw.DecodeCodes([ Lzw.CLEAR_CODE; 9999; 65; Lzw.STOP_CODE ]) |> ignore)
+
+        Assert.Contains("invalid LZW code", error.Message)
+
+type PackUnpackTests() =
+    [<Fact>]
+    member _.``Header stores original length big endian``() =
+        let packed = Lzw.PackCodes([ Lzw.CLEAR_CODE; Lzw.STOP_CODE ], 42)
+        Assert.Equal(42u, BinaryPrimitives.ReadUInt32BigEndian(packed.AsSpan(0, 4)))
+
+    [<Fact>]
+    member _.``ABABAB codes round trip through wire format``() =
+        let codes = [ Lzw.CLEAR_CODE; 65; 66; 258; 258; Lzw.STOP_CODE ]
+        let packed = Lzw.PackCodes(codes, 6)
+        let unpacked, originalLength = Lzw.UnpackCodes(packed)
+
+        Assert.Equal(6, originalLength)
+        Assert.Equal<int list>(codes, unpacked)
+
+    [<Fact>]
+    member _.``Truncated input does not crash unpack``() =
+        let codes, originalLength = Lzw.UnpackCodes([| 0uy; 0uy |])
+        Assert.Empty(codes)
+        Assert.Equal(0, originalLength)
+
+type CompressDecompressTests() =
+    [<Theory>]
+    [<InlineData("")>]
+    [<InlineData("A")>]
+    [<InlineData("AB")>]
+    [<InlineData("ABABAB")>]
+    [<InlineData("AAAAAAA")>]
+    [<InlineData("AABABC")>]
+    member _.``String vectors round trip``(value: string) =
+        let input = Helpers.bytes value
+        Assert.Equal<byte array>(input, Lzw.Decompress(Lzw.Compress input))
+
+    [<Fact>]
+    member _.``Repetitive text round trips``() =
+        let input = Helpers.bytes(String.Concat(Array.replicate 20 "the quick brown fox jumps over the lazy dog "))
+        Assert.Equal<byte array>(input, Lzw.Decompress(Lzw.Compress input))
+
+    [<Fact>]
+    member _.``Binary data round trips``() =
+        let input = Array.init 1024 (fun index -> byte (index % 256))
+        Assert.Equal<byte array>(input, Lzw.Decompress(Lzw.Compress input))
+
+    [<Fact>]
+    member _.``Header contains original length``() =
+        let input = Helpers.bytes "hello world"
+        let compressed = Lzw.Compress(input)
+        Assert.Equal(uint32 input.Length, BinaryPrimitives.ReadUInt32BigEndian(compressed.AsSpan(0, 4)))

--- a/code/specs/TE09-dotnet-compression-lzw-tranche.md
+++ b/code/specs/TE09-dotnet-compression-lzw-tranche.md
@@ -1,0 +1,85 @@
+# TE09 - .NET Compression LZW Tranche
+
+## Goal
+
+Port the CMP03 `lzw` package to both C# and F# as pure in-language implementations.
+
+This tranche follows the earlier .NET ports for `huffman-tree`, `lz77`, `lz78`, and
+`lzss`. It is the first .NET compression package that needs explicit bit-packing
+helpers as part of the public API surface, because CMP03 stores variable-width codes
+instead of fixed-width teaching tokens.
+
+## Scope
+
+Add these publishable packages:
+
+- `code/packages/csharp/lzw`
+- `code/packages/fsharp/lzw`
+
+Each package must include:
+
+- native implementation code only
+- tests
+- `BUILD`
+- `BUILD_windows`
+- `README.md`
+- `CHANGELOG.md`
+- package metadata
+- `required_capabilities.json`
+
+## Functional Requirements
+
+Both implementations should expose:
+
+- CMP03 constants:
+  - `CLEAR_CODE = 256`
+  - `STOP_CODE = 257`
+  - `INITIAL_NEXT_CODE = 258`
+  - `INITIAL_CODE_SIZE = 9`
+  - `MAX_CODE_SIZE = 16`
+- bit I/O helpers for LSB-first code packing:
+  - `BitWriter`
+  - `BitReader`
+- code-level helpers:
+  - `EncodeCodes`
+  - `DecodeCodes`
+  - `PackCodes`
+  - `UnpackCodes`
+- byte-level helpers:
+  - `Compress`
+  - `Decompress`
+
+## Behavioral Notes
+
+- The encoder must pre-seed codes `0..255` with all single-byte sequences.
+- Streams should begin with `CLEAR_CODE` and end with `STOP_CODE`.
+- Bit packing must be LSB-first within each byte, matching the CMP03 spec.
+- The decoder must support the LZW "tricky token" case where `code == nextCode`.
+- The packed wire format should begin with a big-endian `original_length` header.
+- The F# package must be implemented directly in F# and must not wrap the C# package.
+- No external compression or bitstream libraries may be used.
+
+## Test Coverage Targets
+
+Tests should cover at least:
+
+- constant values
+- `BitWriter` and `BitReader` round trips
+- empty input
+- single-byte input
+- `AB`
+- `ABABAB`
+- `AAAAAAA` tricky-token case
+- `AABABC`
+- repetitive text round trips
+- binary round trips
+- `PackCodes` / `UnpackCodes` symmetry
+- header `original_length` correctness
+- invalid-code handling in `DecodeCodes`
+
+## Out of Scope
+
+- `deflate`
+- `brotli`
+- custom dictionary sizes or non-default code widths
+- GIF palette-width variants beyond the shared CMP03 package behavior

--- a/lessons.md
+++ b/lessons.md
@@ -2083,3 +2083,18 @@ a crafted large count could force a huge useless loop or combine badly with unsi
 **Rule:** In F# binary deserialisers, always derive a `maxPossible` item count from the remaining
 payload bytes and cap the header count before looping. Then guard the zero case explicitly before
 writing ranges like `0u .. count - 1u`.
+
+---
+
+## `git worktree add` inherits the current checkout unless you pin the base explicitly
+
+**Date:** 2026-04-18
+
+**What happened:** A new compression worktree was first created with `git worktree add ... -b ...`
+from a checkout that was itself on a feature branch. The new worktree silently inherited that
+feature branch's commit instead of starting from `origin/main`, which would have polluted the next
+PR with unrelated history.
+
+**Rule:** When creating a fresh implementation worktree in this repo, always pin the starting point
+explicitly: `git worktree add <path> -b <branch> origin/main`. Do not rely on the current checkout's
+HEAD being the correct base.


### PR DESCRIPTION
## Summary
- add the TE09 spec for the pure .NET LZW tranche
- add native C# `lzw` with public bit-packing helpers, code-stream helpers, and byte-level compression helpers
- add native F# `lzw` with the same pure in-language API surface
- record the worktree-base lesson discovered while starting the tranche

## Verification
- `bash BUILD` in `code/packages/csharp/lzw`
- `bash BUILD` in `code/packages/fsharp/lzw`

## Notes
- no external compression or bitstream libraries are used
- the F# package is implemented directly in F#, not as a wrapper over the C# package