### PR TITLE
feat(dart-scaffold-generator): add Dart bootstrap generator

### DIFF
--- a/code/programs/dart/scaffold-generator/.gitignore
+++ b/code/programs/dart/scaffold-generator/.gitignore
@@ -1,0 +1,2 @@
+.dart_tool/
+pubspec.lock

--- a/code/programs/dart/scaffold-generator/BUILD
+++ b/code/programs/dart/scaffold-generator/BUILD
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/programs/dart/scaffold-generator/CHANGELOG.md
+++ b/code/programs/dart/scaffold-generator/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [0.1.0] - 2026-04-18
+
+### Added
+
+- Initial Dart scaffold-generator program for generating Dart libraries and
+  programs with CI-ready package layouts.

--- a/code/programs/dart/scaffold-generator/README.md
+++ b/code/programs/dart/scaffold-generator/README.md
@@ -1,0 +1,34 @@
+# Scaffold Generator
+
+Generate CI-ready Dart package and program scaffolding for the
+coding-adventures monorepo.
+
+## What it does
+
+This is the Dart bootstrap implementation of `scaffold-generator`. It focuses
+on the Dart lane first so future Dart ports can start from a correct package
+layout instead of hand-crafting `pubspec.yaml`, `BUILD`, `README.md`,
+`CHANGELOG.md`, `.gitignore`, `lib/`, `bin/`, and `test/` files.
+
+## Usage
+
+```bash
+dart run bin/scaffold_generator.dart my-package --description "My new package"
+dart run bin/scaffold_generator.dart my-tool --type program
+dart run bin/scaffold_generator.dart nib-lexer --depends-on lexer,grammar-tools
+dart run bin/scaffold_generator.dart parser --dry-run
+```
+
+## Current scope
+
+- Scaffolds Dart libraries under `code/packages/dart/`
+- Scaffolds Dart programs under `code/programs/dart/`
+- Validates direct dependencies against the existing Dart tree
+- Computes the transitive Dart dependency closure from `pubspec.yaml`
+- Uses the shared Dart `cli-builder` package for argument parsing
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/programs/dart/scaffold-generator/bin/scaffold_generator.dart
+++ b/code/programs/dart/scaffold-generator/bin/scaffold_generator.dart
@@ -1,0 +1,7 @@
+import 'dart:io';
+
+import 'package:scaffold_generator/scaffold_generator.dart';
+
+void main(List<String> args) {
+  exit(run(args));
+}

--- a/code/programs/dart/scaffold-generator/lib/scaffold_generator.dart
+++ b/code/programs/dart/scaffold-generator/lib/scaffold_generator.dart
@@ -1,0 +1,3 @@
+library;
+
+export 'src/scaffold_generator.dart';

--- a/code/programs/dart/scaffold-generator/lib/src/scaffold_generator.dart
+++ b/code/programs/dart/scaffold-generator/lib/src/scaffold_generator.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:coding_adventures_cli_builder/cli_builder.dart';
@@ -104,6 +105,8 @@ String wrapDescription(String description) {
   }
   return 'description: >\n  ${lines.join('\n  ')}';
 }
+
+String dartStringLiteral(String value) => jsonEncode(value);
 
 String findRepoRoot([String? startPath]) {
   var current = Directory(startPath ?? Directory.current.path).absolute;
@@ -294,7 +297,9 @@ List<String> readDartDependencies(String packageDir) {
 }
 
 List<String> transitiveClosure(
-    List<String> directDependencies, String repoRoot) {
+  List<String> directDependencies,
+  String repoRoot,
+) {
   final visited = <String>{};
   final queue = List<String>.from(directDependencies);
 
@@ -503,7 +508,8 @@ const String packageName = 'coding_adventures_$snake';
 const String packageVersion = '0.1.0';
 
 /// Describe the scaffold in one sentence for smoke tests and REPL sessions.
-String describePackage() => '$description $layerContext';
+String describePackage() =>
+    ${dartStringLiteral('$description $layerContext')};
 ''';
 
   final testFile = '''
@@ -514,7 +520,7 @@ void main() {
   test('exposes starter metadata', () {
     expect(packageName, 'coding_adventures_$snake');
     expect(packageVersion, '0.1.0');
-    expect(describePackage(), contains('$description'));
+    expect(describePackage(), contains(${dartStringLiteral(description)}));
   });
 }
 ''';

--- a/code/programs/dart/scaffold-generator/lib/src/scaffold_generator.dart
+++ b/code/programs/dart/scaffold-generator/lib/src/scaffold_generator.dart
@@ -1,0 +1,758 @@
+import 'dart:io';
+
+import 'package:coding_adventures_cli_builder/cli_builder.dart';
+
+const List<String> validLanguages = <String>['dart'];
+final RegExp kebabCasePattern = RegExp(r'^[a-z][a-z0-9]*(-[a-z0-9]+)*$');
+
+enum PackageType { library, program }
+
+enum DartTargetKind { package, program }
+
+class CliOptions {
+  const CliOptions({
+    required this.packageName,
+    required this.packageType,
+    required this.languages,
+    required this.directDependencies,
+    required this.layer,
+    required this.description,
+    required this.dryRun,
+  });
+
+  final String packageName;
+  final PackageType packageType;
+  final List<String> languages;
+  final List<String> directDependencies;
+  final int? layer;
+  final String description;
+  final bool dryRun;
+}
+
+class DependencyRef {
+  const DependencyRef({
+    required this.name,
+    required this.kind,
+    required this.absolutePath,
+  });
+
+  final String name;
+  final DartTargetKind kind;
+  final String absolutePath;
+}
+
+class ScaffoldFile {
+  const ScaffoldFile({required this.relativePath, required this.content});
+
+  final String relativePath;
+  final String content;
+}
+
+class ScaffoldPlan {
+  const ScaffoldPlan({
+    required this.targetDir,
+    required this.files,
+    required this.transitiveDependencies,
+  });
+
+  final String targetDir;
+  final List<ScaffoldFile> files;
+  final List<String> transitiveDependencies;
+}
+
+String toSnakeCase(String kebab) => kebab.replaceAll('-', '_');
+
+String toTitleCase(String kebab) {
+  return kebab
+      .split('-')
+      .where((segment) => segment.isNotEmpty)
+      .map((segment) => '${segment[0].toUpperCase()}${segment.substring(1)}')
+      .join(' ');
+}
+
+String todayIso([DateTime? now]) {
+  final value = now ?? DateTime.now();
+  final year = value.year.toString().padLeft(4, '0');
+  final month = value.month.toString().padLeft(2, '0');
+  final day = value.day.toString().padLeft(2, '0');
+  return '$year-$month-$day';
+}
+
+String defaultDescription(String packageName, PackageType packageType) {
+  if (packageType == PackageType.program) {
+    return 'A Dart program scaffold for $packageName.';
+  }
+  return 'A Dart package scaffold for $packageName.';
+}
+
+String buildLayerContext(int? layer, PackageType packageType) {
+  final subject = packageType == PackageType.program ? 'program' : 'package';
+  if (layer == null) {
+    return 'This $subject is part of the coding-adventures Dart lane.';
+  }
+  return 'This $subject sits at layer $layer of the coding-adventures stack.';
+}
+
+String wrapDescription(String description) {
+  final lines = description
+      .split('\n')
+      .map((line) => line.trim())
+      .where((line) => line.isNotEmpty)
+      .toList();
+  if (lines.isEmpty) {
+    return 'description: >\n  TODO: add a package description.';
+  }
+  return 'description: >\n  ${lines.join('\n  ')}';
+}
+
+String findRepoRoot([String? startPath]) {
+  var current = Directory(startPath ?? Directory.current.path).absolute;
+  while (true) {
+    final codeDir = Directory('${current.path}/code');
+    final lessons = File('${current.path}/lessons.md');
+    if (codeDir.existsSync() && lessons.existsSync()) {
+      return current.path;
+    }
+
+    final parent = current.parent;
+    if (parent.path == current.path) {
+      throw ArgumentError(
+        'Could not find the coding-adventures repo root from ${current.path}.',
+      );
+    }
+    current = parent;
+  }
+}
+
+String defaultSpecPath([Uri? script]) {
+  final scriptFile = File.fromUri(script ?? Platform.script);
+  return '${scriptFile.parent.parent.path}/scaffold-generator.json';
+}
+
+List<String> parseLanguages(String rawValue) {
+  final raw = rawValue.trim();
+  if (raw.isEmpty || raw == 'all') {
+    return validLanguages;
+  }
+
+  final values = raw
+      .split(',')
+      .map((value) => value.trim())
+      .where((value) => value.isNotEmpty)
+      .toSet()
+      .toList()
+    ..sort();
+
+  for (final value in values) {
+    if (value != 'dart') {
+      throw ArgumentError(
+        'Unsupported language "$value". The Dart bootstrap implementation accepts only dart or all.',
+      );
+    }
+  }
+  return values;
+}
+
+List<String> parseDependencyList(String rawValue) {
+  final raw = rawValue.trim();
+  if (raw.isEmpty) {
+    return const <String>[];
+  }
+
+  final values = raw
+      .split(',')
+      .map((value) => value.trim())
+      .where((value) => value.isNotEmpty)
+      .toSet()
+      .toList()
+    ..sort();
+
+  for (final value in values) {
+    if (!kebabCasePattern.hasMatch(value)) {
+      throw ArgumentError('Dependency "$value" is not valid kebab-case.');
+    }
+  }
+  return values;
+}
+
+CliOptions optionsFromParseResult(ParseResult result) {
+  final packageName = (result.arguments['package-name'] ??
+      result.arguments['PACKAGE_NAME']) as String;
+  final typeFlag = (result.flags['type'] as String?) ?? 'library';
+  final packageType =
+      typeFlag == 'program' ? PackageType.program : PackageType.library;
+  final descriptionFlag =
+      ((result.flags['description'] as String?) ?? '').trim();
+  return CliOptions(
+    packageName: packageName,
+    packageType: packageType,
+    languages: parseLanguages((result.flags['language'] as String?) ?? 'dart'),
+    directDependencies: parseDependencyList(
+      (result.flags['depends-on'] as String?) ?? '',
+    ),
+    layer: result.flags['layer'] as int?,
+    description: descriptionFlag.isEmpty
+        ? defaultDescription(packageName, packageType)
+        : descriptionFlag,
+    dryRun: (result.flags['dry-run'] as bool?) ?? false,
+  );
+}
+
+DependencyRef resolveDependency(String repoRoot, String dependencyName) {
+  final packagePath = '$repoRoot/code/packages/dart/$dependencyName';
+  if (Directory(packagePath).existsSync()) {
+    return DependencyRef(
+      name: dependencyName,
+      kind: DartTargetKind.package,
+      absolutePath: packagePath,
+    );
+  }
+
+  final programPath = '$repoRoot/code/programs/dart/$dependencyName';
+  if (Directory(programPath).existsSync()) {
+    return DependencyRef(
+      name: dependencyName,
+      kind: DartTargetKind.program,
+      absolutePath: programPath,
+    );
+  }
+
+  throw ArgumentError(
+    'Dependency "$dependencyName" does not exist under code/packages/dart/ or code/programs/dart/.',
+  );
+}
+
+String normalizeDependencyKey(String rawKey) {
+  final trimmed = rawKey.trim().toLowerCase();
+  if (trimmed.startsWith('coding_adventures_')) {
+    return trimmed.substring('coding_adventures_'.length).replaceAll('_', '-');
+  }
+  return trimmed.replaceAll('_', '-');
+}
+
+List<String> readDartDependencies(String packageDir) {
+  final pubspecFile = File('$packageDir/pubspec.yaml');
+  if (!pubspecFile.existsSync()) {
+    return const <String>[];
+  }
+
+  final dependencies = <String>{};
+  String? activeBlock;
+  String? pendingDependency;
+  for (final line in pubspecFile.readAsLinesSync()) {
+    final trimmed = line.trim();
+    if (trimmed.isEmpty || trimmed.startsWith('#')) {
+      continue;
+    }
+
+    final indent = line.length - line.trimLeft().length;
+    if (indent == 0 && trimmed.endsWith(':')) {
+      final blockName = trimmed.substring(0, trimmed.length - 1);
+      if (blockName == 'dependencies' || blockName == 'dev_dependencies') {
+        activeBlock = blockName;
+        pendingDependency = null;
+      } else {
+        activeBlock = null;
+        pendingDependency = null;
+      }
+      continue;
+    }
+
+    if (activeBlock == null) {
+      continue;
+    }
+
+    if (indent == 2 && trimmed.contains(':')) {
+      final key = trimmed.split(':').first.trim();
+      final value = trimmed.split(':').skip(1).join(':').trim();
+      if (key == 'sdk') {
+        pendingDependency = null;
+        continue;
+      }
+      if (trimmed.endsWith(':') && value.isEmpty) {
+        pendingDependency = key;
+      } else {
+        pendingDependency = null;
+      }
+      continue;
+    }
+
+    if (indent >= 4 &&
+        pendingDependency != null &&
+        trimmed.startsWith('path:')) {
+      dependencies.add(normalizeDependencyKey(pendingDependency));
+      pendingDependency = null;
+      continue;
+    }
+
+    if (indent <= 2) {
+      pendingDependency = null;
+    }
+  }
+
+  return dependencies.toList()..sort();
+}
+
+List<String> transitiveClosure(
+    List<String> directDependencies, String repoRoot) {
+  final visited = <String>{};
+  final queue = List<String>.from(directDependencies);
+
+  while (queue.isNotEmpty) {
+    final dependency = queue.removeAt(0);
+    if (!visited.add(dependency)) {
+      continue;
+    }
+
+    final resolved = resolveDependency(repoRoot, dependency);
+    for (final nextDependency in readDartDependencies(resolved.absolutePath)) {
+      if (!visited.contains(nextDependency)) {
+        queue.add(nextDependency);
+      }
+    }
+  }
+
+  return visited.toList()..sort();
+}
+
+List<String> topologicalSort(List<String> allDependencies, String repoRoot) {
+  final remaining = allDependencies.toSet();
+  final graph = <String, Set<String>>{};
+  final inDegree = <String, int>{};
+
+  for (final dependency in allDependencies) {
+    final resolved = resolveDependency(repoRoot, dependency);
+    final localDependencies = readDartDependencies(
+      resolved.absolutePath,
+    ).where(remaining.contains).toSet();
+    graph[dependency] = localDependencies;
+    inDegree[dependency] = localDependencies.length;
+  }
+
+  final queue = inDegree.entries
+      .where((entry) => entry.value == 0)
+      .map((entry) => entry.key)
+      .toList()
+    ..sort();
+
+  final ordered = <String>[];
+  while (queue.isNotEmpty) {
+    final current = queue.removeAt(0);
+    ordered.add(current);
+    for (final entry in graph.entries) {
+      if (entry.value.remove(current)) {
+        final nextDegree = (inDegree[entry.key] ?? 0) - 1;
+        inDegree[entry.key] = nextDegree;
+        if (nextDegree == 0) {
+          queue.add(entry.key);
+          queue.sort();
+        }
+      }
+    }
+  }
+
+  if (ordered.length != allDependencies.length) {
+    throw StateError(
+      'Circular Dart dependency detected in ${allDependencies.join(', ')}.',
+    );
+  }
+
+  return ordered;
+}
+
+String dependencyPathForTarget(
+  PackageType packageType,
+  DependencyRef dependency,
+) {
+  if (packageType == PackageType.library) {
+    return dependency.kind == DartTargetKind.package
+        ? '../${dependency.name}'
+        : '../../programs/dart/${dependency.name}';
+  }
+  return dependency.kind == DartTargetKind.package
+      ? '../../../packages/dart/${dependency.name}'
+      : '../${dependency.name}';
+}
+
+String renderDependencyBlock(
+  PackageType packageType,
+  String repoRoot,
+  List<String> directDependencies,
+) {
+  if (directDependencies.isEmpty) {
+    return 'dependencies: {}';
+  }
+
+  final buffer = StringBuffer('dependencies:\n');
+  for (final dependencyName in directDependencies) {
+    final dependency = resolveDependency(repoRoot, dependencyName);
+    final packageKey = dependency.kind == DartTargetKind.package
+        ? 'coding_adventures_${toSnakeCase(dependency.name)}'
+        : toSnakeCase(dependency.name);
+    buffer.writeln('  $packageKey:');
+    buffer.writeln(
+      '    path: ${dependencyPathForTarget(packageType, dependency)}',
+    );
+  }
+  return buffer.toString().trimRight();
+}
+
+List<ScaffoldFile> generateCommonFiles({
+  required String packageName,
+  required PackageType packageType,
+  required String description,
+  required int? layer,
+  required List<String> directDependencies,
+}) {
+  final snake = toSnakeCase(packageName);
+  final title = packageType == PackageType.library
+      ? 'coding_adventures_$snake'
+      : toTitleCase(packageName);
+  final subject = packageType == PackageType.library ? 'package' : 'program';
+  final usage = packageType == PackageType.library
+      ? "Import `package:coding_adventures_$snake/$snake.dart` and replace the starter API with real functionality."
+      : 'Run `dart run bin/$snake.dart` after filling in the starter logic.';
+
+  final readme = StringBuffer()
+    ..writeln('# $title')
+    ..writeln()
+    ..writeln(description)
+    ..writeln()
+    ..writeln('## What it does')
+    ..writeln()
+    ..writeln(
+      'This scaffold creates a Dart $subject with the standard coding-adventures layout: metadata, tests, documentation, and source files from day one.',
+    )
+    ..writeln()
+    ..writeln('## Usage')
+    ..writeln()
+    ..writeln(usage)
+    ..writeln()
+    ..writeln('## How it fits in the stack')
+    ..writeln()
+    ..writeln(buildLayerContext(layer, packageType));
+
+  if (directDependencies.isNotEmpty) {
+    readme
+      ..writeln()
+      ..writeln('## Direct dependencies')
+      ..writeln()
+      ..writeln(directDependencies.join(', '));
+  }
+
+  final changelog = StringBuffer()
+    ..writeln('# Changelog')
+    ..writeln()
+    ..writeln('## [0.1.0] - ${todayIso()}')
+    ..writeln()
+    ..writeln('### Added')
+    ..writeln()
+    ..writeln('- Initial Dart $subject scaffold for $packageName.');
+
+  return <ScaffoldFile>[
+    ScaffoldFile(
+      relativePath: '.gitignore',
+      content: '.dart_tool/\npubspec.lock\n',
+    ),
+    ScaffoldFile(
+      relativePath: 'README.md',
+      content: '${readme.toString().trimRight()}\n',
+    ),
+    ScaffoldFile(
+      relativePath: 'CHANGELOG.md',
+      content: '${changelog.toString().trimRight()}\n',
+    ),
+  ];
+}
+
+List<ScaffoldFile> generateDartLibrary({
+  required String packageName,
+  required String description,
+  required int? layer,
+  required String repoRoot,
+  required List<String> directDependencies,
+}) {
+  final snake = toSnakeCase(packageName);
+  final layerContext = buildLayerContext(layer, PackageType.library);
+  final pubspec = StringBuffer()
+    ..writeln('name: coding_adventures_$snake')
+    ..writeln(wrapDescription(description))
+    ..writeln('version: 0.1.0')
+    ..writeln('repository: https://github.com/adhithyan15/coding-adventures')
+    ..writeln('publish_to: none')
+    ..writeln()
+    ..writeln('environment:')
+    ..writeln('  sdk: ^3.0.0')
+    ..writeln()
+    ..writeln(
+      renderDependencyBlock(PackageType.library, repoRoot, directDependencies),
+    )
+    ..writeln()
+    ..writeln('dev_dependencies:')
+    ..writeln('  test: ^1.25.0');
+
+  final libraryFile = 'library;\n\nexport \'src/$snake.dart\';\n';
+
+  final sourceFile = '''
+/// Public starter API for $packageName.
+///
+/// This file exists so a new package starts with one tiny, testable surface
+/// area instead of an empty directory. Teams can grow the implementation from
+/// here without having to backfill the standard Dart layout first.
+const String packageName = 'coding_adventures_$snake';
+const String packageVersion = '0.1.0';
+
+/// Describe the scaffold in one sentence for smoke tests and REPL sessions.
+String describePackage() => '$description $layerContext';
+''';
+
+  final testFile = '''
+import 'package:coding_adventures_$snake/$snake.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('exposes starter metadata', () {
+    expect(packageName, 'coding_adventures_$snake');
+    expect(packageVersion, '0.1.0');
+    expect(describePackage(), contains('$description'));
+  });
+}
+''';
+
+  return <ScaffoldFile>[
+    ...generateCommonFiles(
+      packageName: packageName,
+      packageType: PackageType.library,
+      description: description,
+      layer: layer,
+      directDependencies: directDependencies,
+    ),
+    ScaffoldFile(
+      relativePath: 'pubspec.yaml',
+      content: '${pubspec.toString().trimRight()}\n',
+    ),
+    ScaffoldFile(relativePath: 'BUILD', content: 'dart pub get\ndart test\n'),
+    ScaffoldFile(relativePath: 'lib/$snake.dart', content: libraryFile),
+    ScaffoldFile(relativePath: 'lib/src/$snake.dart', content: sourceFile),
+    ScaffoldFile(relativePath: 'test/${snake}_test.dart', content: testFile),
+  ];
+}
+
+List<ScaffoldFile> generateDartProgram({
+  required String packageName,
+  required String description,
+  required int? layer,
+  required String repoRoot,
+  required List<String> directDependencies,
+}) {
+  final snake = toSnakeCase(packageName);
+  final pubspec = StringBuffer()
+    ..writeln('name: $snake')
+    ..writeln(wrapDescription(description))
+    ..writeln('version: 0.1.0')
+    ..writeln('publish_to: none')
+    ..writeln()
+    ..writeln('environment:')
+    ..writeln('  sdk: ^3.0.0')
+    ..writeln()
+    ..writeln(
+      renderDependencyBlock(PackageType.program, repoRoot, directDependencies),
+    )
+    ..writeln()
+    ..writeln('dev_dependencies:')
+    ..writeln('  test: ^1.25.0');
+
+  final libraryFile = 'library;\n\nexport \'src/$snake.dart\';\n';
+
+  final sourceFile = '''
+/// Core behavior for the $packageName program.
+///
+/// The side effect stays in `bin/`, while this file carries the logic we can
+/// test from day one.
+String renderMessage() => 'TODO: implement $packageName.';
+''';
+
+  final binFile = '''
+import 'package:$snake/$snake.dart';
+
+void main() {
+  print(renderMessage());
+}
+''';
+
+  final testFile = '''
+import 'package:$snake/$snake.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('renders a starter message', () {
+    expect(renderMessage(), contains('$packageName'));
+  });
+}
+''';
+
+  return <ScaffoldFile>[
+    ...generateCommonFiles(
+      packageName: packageName,
+      packageType: PackageType.program,
+      description: description,
+      layer: layer,
+      directDependencies: directDependencies,
+    ),
+    ScaffoldFile(
+      relativePath: 'pubspec.yaml',
+      content: '${pubspec.toString().trimRight()}\n',
+    ),
+    ScaffoldFile(
+      relativePath: 'BUILD',
+      content: 'dart pub get\ndart test\ndart run bin/$snake.dart\n',
+    ),
+    ScaffoldFile(relativePath: 'lib/$snake.dart', content: libraryFile),
+    ScaffoldFile(relativePath: 'lib/src/$snake.dart', content: sourceFile),
+    ScaffoldFile(relativePath: 'bin/$snake.dart', content: binFile),
+    ScaffoldFile(relativePath: 'test/${snake}_test.dart', content: testFile),
+  ];
+}
+
+ScaffoldPlan scaffoldPlan({
+  required String repoRoot,
+  required CliOptions options,
+}) {
+  if (!kebabCasePattern.hasMatch(options.packageName)) {
+    throw ArgumentError(
+      'Package name "${options.packageName}" is not valid kebab-case.',
+    );
+  }
+
+  final typeDir =
+      options.packageType == PackageType.library ? 'packages' : 'programs';
+  final targetDir = '$repoRoot/code/$typeDir/dart/${options.packageName}';
+  if (Directory(targetDir).existsSync()) {
+    throw ArgumentError('Target directory already exists: $targetDir');
+  }
+
+  for (final language in options.languages) {
+    if (!validLanguages.contains(language)) {
+      throw ArgumentError(
+        'Unsupported language "$language". This implementation only scaffolds Dart.',
+      );
+    }
+  }
+
+  for (final dependency in options.directDependencies) {
+    resolveDependency(repoRoot, dependency);
+  }
+
+  final closure = transitiveClosure(options.directDependencies, repoRoot);
+  final orderedDependencies = topologicalSort(closure, repoRoot);
+  final files = options.packageType == PackageType.library
+      ? generateDartLibrary(
+          packageName: options.packageName,
+          description: options.description,
+          layer: options.layer,
+          repoRoot: repoRoot,
+          directDependencies: options.directDependencies,
+        )
+      : generateDartProgram(
+          packageName: options.packageName,
+          description: options.description,
+          layer: options.layer,
+          repoRoot: repoRoot,
+          directDependencies: options.directDependencies,
+        );
+
+  return ScaffoldPlan(
+    targetDir: targetDir,
+    files: files,
+    transitiveDependencies: orderedDependencies,
+  );
+}
+
+void writePlan(ScaffoldPlan plan) {
+  final targetDir = Directory(plan.targetDir);
+  targetDir.createSync(recursive: true);
+  for (final file in plan.files) {
+    final output = File('${plan.targetDir}/${file.relativePath}');
+    output.parent.createSync(recursive: true);
+    output.writeAsStringSync(file.content);
+  }
+}
+
+String renderDryRun(ScaffoldPlan plan) {
+  final buffer = StringBuffer()
+    ..writeln('Would create ${plan.targetDir}')
+    ..writeln();
+
+  if (plan.transitiveDependencies.isEmpty) {
+    buffer.writeln('Transitive Dart dependencies: (none)');
+  } else {
+    buffer.writeln(
+      'Transitive Dart dependencies: ${plan.transitiveDependencies.join(', ')}',
+    );
+  }
+  buffer.writeln();
+
+  for (final file in plan.files) {
+    buffer.writeln('=== ${file.relativePath} ===');
+    buffer.writeln(file.content.trimRight());
+    buffer.writeln();
+  }
+  return buffer.toString();
+}
+
+int run(
+  List<String> args, {
+  String? repoRoot,
+  StringSink? out,
+  StringSink? err,
+  String? specPath,
+}) {
+  final stdoutSink = out ?? stdout;
+  final stderrSink = err ?? stderr;
+
+  try {
+    final result = Parser.fromPath(specPath ?? defaultSpecPath(), <String>[
+      'scaffold-generator',
+      ...args,
+    ]).parse();
+
+    if (result is HelpResult) {
+      stdoutSink.writeln(result.text);
+      return 0;
+    }
+    if (result is VersionResult) {
+      stdoutSink.writeln(result.version);
+      return 0;
+    }
+    if (result is! ParseResult) {
+      stderrSink.writeln('Unexpected CLI Builder result: $result');
+      return 1;
+    }
+
+    final options = optionsFromParseResult(result);
+    final root = repoRoot ?? findRepoRoot();
+    final plan = scaffoldPlan(repoRoot: root, options: options);
+    if (options.dryRun) {
+      stdoutSink.write(renderDryRun(plan));
+      return 0;
+    }
+
+    writePlan(plan);
+    stdoutSink.writeln('Created ${plan.targetDir}');
+    return 0;
+  } on ParseErrors catch (error) {
+    for (final parseError in error.errors) {
+      stderrSink.writeln(parseError.message);
+      if (parseError.suggestion != null) {
+        stderrSink.writeln(parseError.suggestion);
+      }
+    }
+    return 1;
+  } on ArgumentError catch (error) {
+    stderrSink.writeln(error.message);
+    return 1;
+  } on StateError catch (error) {
+    stderrSink.writeln(error.message);
+    return 1;
+  }
+}

--- a/code/programs/dart/scaffold-generator/pubspec.yaml
+++ b/code/programs/dart/scaffold-generator/pubspec.yaml
@@ -1,0 +1,16 @@
+name: scaffold_generator
+description: >
+  Generate CI-ready Dart package and program scaffolding for the
+  coding-adventures monorepo.
+version: 0.1.0
+publish_to: none
+
+environment:
+  sdk: ^3.0.0
+
+dependencies:
+  coding_adventures_cli_builder:
+    path: ../../../packages/dart/cli-builder
+
+dev_dependencies:
+  test: ^1.25.0

--- a/code/programs/dart/scaffold-generator/scaffold-generator.json
+++ b/code/programs/dart/scaffold-generator/scaffold-generator.json
@@ -1,0 +1,66 @@
+{
+  "cli_builder_spec_version": "1.0",
+  "name": "scaffold-generator",
+  "display_name": "Scaffold Generator",
+  "description": "Generate CI-ready Dart package scaffolding for the coding-adventures monorepo",
+  "version": "0.1.0",
+  "parsing_mode": "gnu",
+  "builtin_flags": { "help": true, "version": true },
+  "flags": [
+    {
+      "id": "type",
+      "short": "t",
+      "long": "type",
+      "description": "Package type: 'library' goes in code/packages/, 'program' goes in code/programs/",
+      "type": "enum",
+      "enum_values": ["library", "program"],
+      "default": "library"
+    },
+    {
+      "id": "language",
+      "short": "l",
+      "long": "language",
+      "description": "Target language. This bootstrap implementation accepts 'dart' or 'all' (which resolves to the Dart lane).",
+      "type": "string",
+      "default": "dart"
+    },
+    {
+      "id": "depends-on",
+      "short": "d",
+      "long": "depends-on",
+      "description": "Comma-separated list of sibling Dart package names this scaffold depends on",
+      "type": "string",
+      "default": ""
+    },
+    {
+      "id": "layer",
+      "long": "layer",
+      "description": "Layer number for README context",
+      "type": "integer"
+    },
+    {
+      "id": "description",
+      "long": "description",
+      "description": "One-line description of the package",
+      "type": "string",
+      "default": ""
+    },
+    {
+      "id": "dry-run",
+      "long": "dry-run",
+      "description": "Print what would be generated without writing files",
+      "type": "boolean"
+    }
+  ],
+  "arguments": [
+    {
+      "id": "package-name",
+      "name": "PACKAGE_NAME",
+      "description": "Name of the package in kebab-case (for example 'my-package')",
+      "type": "string",
+      "required": true
+    }
+  ],
+  "commands": [],
+  "mutually_exclusive_groups": []
+}

--- a/code/programs/dart/scaffold-generator/test/scaffold_generator_test.dart
+++ b/code/programs/dart/scaffold-generator/test/scaffold_generator_test.dart
@@ -1,0 +1,262 @@
+import 'dart:io';
+
+import 'package:scaffold_generator/scaffold_generator.dart';
+import 'package:test/test.dart';
+
+void writeFile(String repoRoot, String relativePath, String content) {
+  final file = File('$repoRoot/$relativePath');
+  file.parent.createSync(recursive: true);
+  file.writeAsStringSync(content);
+}
+
+void writeDartPackage(
+  String repoRoot,
+  String packageName, {
+  List<String> dependencies = const <String>[],
+}) {
+  final snake = toSnakeCase(packageName);
+  final dependencyBlock = dependencies.isEmpty
+      ? 'dependencies: {}\n'
+      : [
+          'dependencies:',
+          ...dependencies.expand(
+            (dependency) => <String>[
+              '  coding_adventures_${toSnakeCase(dependency)}:',
+              '    path: ../$dependency',
+            ],
+          ),
+        ].join('\n');
+
+  writeFile(
+    repoRoot,
+    'code/packages/dart/$packageName/pubspec.yaml',
+    [
+      'name: coding_adventures_$snake',
+      wrapDescription('Fixture package for $packageName.'),
+      'version: 0.1.0',
+      'publish_to: none',
+      '',
+      'environment:',
+      '  sdk: ^3.0.0',
+      '',
+      dependencyBlock.trimRight(),
+      '',
+      'dev_dependencies:',
+      '  test: ^1.25.0',
+      '',
+    ].join('\n'),
+  );
+}
+
+void main() {
+  group('name helpers', () {
+    test('snake and title case conversions match repo conventions', () {
+      expect(toSnakeCase('nib-parser'), 'nib_parser');
+      expect(toTitleCase('nib-parser'), 'Nib Parser');
+    });
+
+    test('formats ISO dates', () {
+      expect(todayIso(DateTime(2026, 4, 18)), '2026-04-18');
+    });
+  });
+
+  group('Dart dependency parsing', () {
+    late Directory tempDir;
+    late String repoRoot;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('dart-scaffold-generator-');
+      repoRoot = tempDir.path;
+      writeFile(repoRoot, 'lessons.md', '# Lessons\n');
+      writeDartPackage(repoRoot, 'graph');
+      writeDartPackage(repoRoot, 'lexer', dependencies: <String>['graph']);
+      writeDartPackage(repoRoot, 'parser', dependencies: <String>['lexer']);
+    });
+
+    tearDown(() {
+      tempDir.deleteSync(recursive: true);
+    });
+
+    test('reads dependency keys from pubspec blocks', () {
+      expect(
+        readDartDependencies('$repoRoot/code/packages/dart/parser'),
+        <String>['lexer'],
+      );
+    });
+
+    test('computes transitive closure and topological order', () {
+      final closure = transitiveClosure(<String>['parser'], repoRoot);
+      expect(closure, <String>['graph', 'lexer', 'parser']);
+      expect(topologicalSort(closure, repoRoot), <String>[
+        'graph',
+        'lexer',
+        'parser',
+      ]);
+    });
+  });
+
+  group('scaffolding', () {
+    late Directory tempDir;
+    late String repoRoot;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('dart-scaffold-generator-');
+      repoRoot = tempDir.path;
+      writeFile(repoRoot, 'lessons.md', '# Lessons\n');
+      writeDartPackage(repoRoot, 'grammar-tools');
+      writeDartPackage(
+        repoRoot,
+        'lexer',
+        dependencies: <String>['grammar-tools'],
+      );
+    });
+
+    tearDown(() {
+      tempDir.deleteSync(recursive: true);
+    });
+
+    test('creates a Dart library scaffold', () {
+      final plan = scaffoldPlan(
+        repoRoot: repoRoot,
+        options: const CliOptions(
+          packageName: 'nib-parser',
+          packageType: PackageType.library,
+          languages: <String>['dart'],
+          directDependencies: <String>['lexer'],
+          layer: 3,
+          description: 'Nib parser for Dart.',
+          dryRun: false,
+        ),
+      );
+
+      writePlan(plan);
+
+      final targetDir = Directory('$repoRoot/code/packages/dart/nib-parser');
+      expect(targetDir.existsSync(), isTrue);
+      expect(
+        File('${targetDir.path}/pubspec.yaml').readAsStringSync(),
+        contains('name: coding_adventures_nib_parser'),
+      );
+      expect(
+        File('${targetDir.path}/pubspec.yaml').readAsStringSync(),
+        contains('path: ../lexer'),
+      );
+      expect(
+        File('${targetDir.path}/test/nib_parser_test.dart').readAsStringSync(),
+        contains('describePackage()'),
+      );
+    });
+
+    test('creates a Dart program scaffold', () {
+      final plan = scaffoldPlan(
+        repoRoot: repoRoot,
+        options: const CliOptions(
+          packageName: 'nib-demo',
+          packageType: PackageType.program,
+          languages: <String>['dart'],
+          directDependencies: <String>['lexer'],
+          layer: null,
+          description: 'Nib demo program for Dart.',
+          dryRun: false,
+        ),
+      );
+
+      writePlan(plan);
+
+      final targetDir = Directory('$repoRoot/code/programs/dart/nib-demo');
+      expect(targetDir.existsSync(), isTrue);
+      expect(
+        File('${targetDir.path}/bin/nib_demo.dart').readAsStringSync(),
+        contains("print(renderMessage())"),
+      );
+      expect(
+        File('${targetDir.path}/BUILD').readAsStringSync(),
+        contains('dart run bin/nib_demo.dart'),
+      );
+      expect(
+        File('${targetDir.path}/pubspec.yaml').readAsStringSync(),
+        contains('path: ../../../packages/dart/lexer'),
+      );
+    });
+
+    test('renders dry-run output for a scaffold plan', () {
+      final plan = scaffoldPlan(
+        repoRoot: repoRoot,
+        options: const CliOptions(
+          packageName: 'nib-lexer',
+          packageType: PackageType.library,
+          languages: <String>['dart'],
+          directDependencies: <String>['lexer'],
+          layer: 2,
+          description: 'Nib lexer for Dart.',
+          dryRun: true,
+        ),
+      );
+
+      final preview = renderDryRun(plan);
+      expect(preview, contains('Would create'));
+      expect(preview, contains('pubspec.yaml'));
+      expect(preview, contains('Transitive Dart dependencies'));
+    });
+  });
+
+  group('CLI entrypoints', () {
+    late Directory tempDir;
+    late String repoRoot;
+    late String specPath;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('dart-scaffold-generator-');
+      repoRoot = tempDir.path;
+      writeFile(repoRoot, 'lessons.md', '# Lessons\n');
+      writeDartPackage(repoRoot, 'lexer');
+      specPath =
+          Directory.current.uri.resolve('scaffold-generator.json').toFilePath();
+    });
+
+    tearDown(() {
+      tempDir.deleteSync(recursive: true);
+    });
+
+    test('dry-run uses the CLI spec and leaves the tree untouched', () {
+      final stdoutBuffer = StringBuffer();
+      final stderrBuffer = StringBuffer();
+      final exitCode = run(
+        <String>[
+          'nib-lexer',
+          '--depends-on',
+          'lexer',
+          '--description',
+          'Nib lexer for Dart.',
+          '--dry-run',
+        ],
+        repoRoot: repoRoot,
+        out: stdoutBuffer,
+        err: stderrBuffer,
+        specPath: specPath,
+      );
+
+      expect(exitCode, 0);
+      expect(stdoutBuffer.toString(), contains('Would create'));
+      expect(stdoutBuffer.toString(), contains('pubspec.yaml'));
+      expect(
+        Directory('$repoRoot/code/packages/dart/nib-lexer').existsSync(),
+        isFalse,
+      );
+      expect(stderrBuffer.toString(), isEmpty);
+    });
+
+    test('reports invalid kebab-case names', () {
+      final stderrBuffer = StringBuffer();
+      final exitCode = run(
+        <String>['NibLexer'],
+        repoRoot: repoRoot,
+        err: stderrBuffer,
+        specPath: specPath,
+      );
+
+      expect(exitCode, 1);
+      expect(stderrBuffer.toString(), contains('kebab-case'));
+    });
+  });
+}

--- a/code/programs/dart/scaffold-generator/test/scaffold_generator_test.dart
+++ b/code/programs/dart/scaffold-generator/test/scaffold_generator_test.dart
@@ -58,6 +58,13 @@ void main() {
     test('formats ISO dates', () {
       expect(todayIso(DateTime(2026, 4, 18)), '2026-04-18');
     });
+
+    test('escapes strings for generated Dart code', () {
+      expect(
+        dartStringLiteral("it's \"fine\"\nnext"),
+        '"it\'s \\"fine\\"\\nnext"',
+      );
+    });
   });
 
   group('Dart dependency parsing', () {
@@ -144,6 +151,31 @@ void main() {
       expect(
         File('${targetDir.path}/test/nib_parser_test.dart').readAsStringSync(),
         contains('describePackage()'),
+      );
+    });
+
+    test('escapes quotes inside generated descriptions', () {
+      final plan = scaffoldPlan(
+        repoRoot: repoRoot,
+        options: const CliOptions(
+          packageName: 'quoted-package',
+          packageType: PackageType.library,
+          languages: <String>['dart'],
+          directDependencies: <String>['lexer'],
+          layer: 3,
+          description: 'Parser for "quoted" input and it\'s safe.',
+          dryRun: false,
+        ),
+      );
+
+      writePlan(plan);
+
+      final source = File(
+        '$repoRoot/code/packages/dart/quoted-package/lib/src/quoted_package.dart',
+      ).readAsStringSync();
+      expect(
+        source,
+        contains("Parser for \\\"quoted\\\" input and it's safe."),
       );
     });
 

--- a/code/specs/scaffold-generator-spec.md
+++ b/code/specs/scaffold-generator-spec.md
@@ -1,8 +1,10 @@
-# Scaffold Generator — Package Scaffolding for All Six Languages
+# Scaffold Generator — Package Scaffolding with a Dart Bootstrap Lane
 
 A CLI tool, powered by CLI Builder, that generates correct-by-construction,
-CI-ready package scaffolding across Python, Go, Ruby, Rust, TypeScript, and
-Elixir.
+CI-ready package scaffolding across the monorepo's implementation languages.
+The first published versions covered Python, Go, Ruby, Rust, TypeScript, and
+Elixir; this spec now also defines a Dart bootstrap implementation focused on
+generating Dart packages and programs correctly.
 
 ---
 
@@ -10,7 +12,7 @@ Elixir.
 
 ### 1.1 The Problem
 
-The coding-adventures monorepo contains 400+ packages across six languages.
+The coding-adventures monorepo contains 400+ packages across many languages.
 Every package follows a precise file structure, and getting any detail wrong
 causes CI failures. The `lessons.md` file documents at least twelve recurring
 categories of failure that all stem from the same root cause: **agents
@@ -63,8 +65,26 @@ generated package:
    need to remember them.
 4. **Built on CLI Builder** — the tool's own interface is defined in a JSON
    spec file, consistent with how all CLI tools in this repo are built.
-5. **One tool, six languages** — the same conceptual tool is implemented in
-   each of the six languages, following the same pattern as `pwd`.
+5. **One tool, multiple implementation lanes** — the same conceptual tool is
+   implemented in multiple languages, following the same pattern as `pwd`.
+
+### 1.3.1 Dart Bootstrap Phase
+
+The Dart implementation is intentionally narrower than the older cross-language
+generators. Its near-term job is to unblock future Dart package work so agents
+do not hand-craft `pubspec.yaml`, `BUILD`, `README.md`, `CHANGELOG.md`,
+`.gitignore`, `lib/`, `bin/`, and `test/` layouts from memory.
+
+In this bootstrap phase:
+
+- the Dart program supports scaffolding **Dart libraries** under
+  `code/packages/dart/`
+- it also supports scaffolding **Dart programs** under `code/programs/dart/`
+- its local CLI spec accepts `dart` explicitly and may treat `all` as the
+  Dart bootstrap lane for compatibility with the broader scaffold-generator
+  interface
+- it reads existing Dart `pubspec.yaml` files to validate direct dependencies
+  and compute transitive Dart dependency closures
 
 ### 1.4 How Agents Should Use This Tool
 
@@ -115,7 +135,7 @@ Options:
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--type` / `-t` | enum | `library` | `library` → `code/packages/<lang>/`, `program` → `code/programs/<lang>/` |
-| `--language` / `-l` | string | `all` | One of: `python`, `ruby`, `go`, `typescript`, `rust`, `elixir`, `all`. Multiple languages can be comma-separated: `python,go,rust`. |
+| `--language` / `-l` | string | implementation-defined | The accepted language set is implementation-specific. The Dart bootstrap implementation accepts `dart` and `all`, where `all` resolves to the Dart lane. |
 | `--depends-on` / `-d` | string | (none) | Comma-separated list of sibling package names (in kebab-case). These are direct dependencies. The tool computes transitive dependencies automatically. |
 | `--layer` | integer | (none) | Layer number in the computing stack (e.g., 1 for logic-gates, 2 for arithmetic). Used in README context. |
 | `--description` | string | (none) | One-line description. Used in metadata files and README. |
@@ -123,8 +143,10 @@ Options:
 
 ### 2.4 The JSON Spec
 
-The CLI interface is declared in `scaffold-generator.json`, shared by all six
-language implementations (same pattern as `pwd.json`):
+The CLI interface is declared in `scaffold-generator.json`. Mature
+implementations may share one root JSON spec; bootstrap implementations may
+carry a local variant as long as they preserve the same flag names and core
+semantics (same pattern as `pwd.json`):
 
 ```json
 {
@@ -149,7 +171,7 @@ language implementations (same pattern as `pwd.json`):
       "id": "language",
       "short": "l",
       "long": "language",
-      "description": "Target language(s). Comma-separated or 'all' for all 6 languages",
+      "description": "Target language(s). The accepted set is implementation-specific; the Dart bootstrap lane accepts 'dart' and 'all'",
       "type": "string",
       "default": "all"
     },
@@ -203,8 +225,9 @@ Before generating any files, the tool validates:
    Reject names with uppercase, underscores, leading/trailing hyphens, or
    consecutive hyphens.
 
-2. **Language values** — each comma-separated value must be one of the six
-   recognized languages or `all`.
+2. **Language values** — each comma-separated value must be recognized by the
+   active implementation. The Dart bootstrap implementation accepts `dart` and
+   `all`.
 
 3. **Dependencies exist** — for each dependency in `--depends-on`, verify that
    the directory `code/packages/<lang>/<dep>` (or `code/programs/<lang>/<dep>`)
@@ -242,14 +265,14 @@ to_joined_lower("my-package") → "mypackage"     # remove hyphens, no underscor
 
 Given the input `my-package`:
 
-| Context | Python | Ruby | Go | TypeScript | Rust | Elixir |
-|---------|--------|------|----|-----------|------|--------|
-| **Directory name** | `my-package` | `my_package` | `my-package` | `my-package` | `my-package` | `my_package` |
-| **Package/crate/gem/app name** | `coding-adventures-my-package` | `coding_adventures_my_package` | (module path) | `@coding-adventures/my-package` | `my-package` | `:coding_adventures_my_package` |
-| **Module/namespace** | `my_package` | `CodingAdventures::MyPackage` | `mypackage` | (ESM exports) | `my_package` | `CodingAdventures.MyPackage` |
-| **Import in code** | `from my_package import ...` | `require "coding_adventures_my_package"` | `import mypackage` | `import { ... } from "@coding-adventures/my-package"` | `use my_package::...` | `alias CodingAdventures.MyPackage` |
-| **Source directory** | `src/my_package/` | `lib/coding_adventures/my_package/` | (flat) | `src/` | `src/` | `lib/coding_adventures/my_package/` |
-| **Test file** | `tests/test_my_package.py` | `test/test_my_package.rb` | `my_package_test.go` | `tests/my-package.test.ts` | `tests/my_package_test.rs` | `test/my_package_test.exs` |
+| Context | Python | Ruby | Go | TypeScript | Rust | Elixir | Dart |
+|---------|--------|------|----|-----------|------|--------|------|
+| **Directory name** | `my-package` | `my_package` | `my-package` | `my-package` | `my-package` | `my_package` | `my-package` |
+| **Package/crate/gem/app name** | `coding-adventures-my-package` | `coding_adventures_my_package` | (module path) | `@coding-adventures/my-package` | `my-package` | `:coding_adventures_my_package` | `coding_adventures_my_package` for libraries, `my_package` for programs |
+| **Module/namespace** | `my_package` | `CodingAdventures::MyPackage` | `mypackage` | (ESM exports) | `my_package` | `CodingAdventures.MyPackage` | top-level library file `lib/my_package.dart` |
+| **Import in code** | `from my_package import ...` | `require "coding_adventures_my_package"` | `import mypackage` | `import { ... } from "@coding-adventures/my-package"` | `use my_package::...` | `alias CodingAdventures.MyPackage` | `import 'package:coding_adventures_my_package/my_package.dart';` for libraries |
+| **Source directory** | `src/my_package/` | `lib/coding_adventures/my_package/` | (flat) | `src/` | `src/` | `lib/coding_adventures/my_package/` | `lib/` and `lib/src/`, plus `bin/` for programs |
+| **Test file** | `tests/test_my_package.py` | `test/test_my_package.rb` | `my_package_test.go` | `tests/my-package.test.ts` | `tests/my_package_test.rs` | `test/my_package_test.exs` | `test/my_package_test.dart` |
 
 ### 3.3 Dependency Name Normalization
 
@@ -1333,7 +1356,7 @@ print a warning but not prevent generation.
 
 ## 11. Implementation Priority
 
-Not all six language implementations need to ship simultaneously. The
+Not all language implementations need to ship simultaneously. The
 recommended priority order:
 
 1. **Go** — the primary build tool and most programs are in Go; fast compilation
@@ -1344,7 +1367,9 @@ recommended priority order:
    here has the highest impact
 4. **Ruby** — moderate complexity, well-understood patterns
 5. **Rust** — important for workspace integration, but cargo handles deps well
-6. **Elixir** — fewest packages, lowest priority but still needed for parity
+6. **Dart** — bootstrap the Dart ecosystem so future lexer/parser and runtime
+   ports start from correct templates instead of hand-written package layouts
+7. **Elixir** — fewest packages, lowest priority but still needed for parity
 
 ---
 


### PR DESCRIPTION
## Summary
- add a Dart-native `scaffold-generator` program for scaffolding Dart packages and programs
- wire the CLI through the shared Dart `cli-builder` package and document the Dart bootstrap lane in the scaffold-generator spec
- add tests for dependency resolution, dry runs, generated layouts, and escaped description literals

## Testing
- `/tmp/dart-sdk-install/dart-sdk/bin/dart format lib test`
- `/tmp/dart-sdk-install/dart-sdk/bin/dart test`
- `/tmp/dart-sdk-install/dart-sdk/bin/dart run bin/scaffold_generator.dart --help`