### PR TITLE
feat(paint-vm-ascii): add cross-language text backends

### DIFF
--- a/code/packages/elixir/paint_vm_ascii/BUILD
+++ b/code/packages/elixir/paint_vm_ascii/BUILD
@@ -1,0 +1,2 @@
+mix deps.get --quiet
+mix test --cover

--- a/code/packages/elixir/paint_vm_ascii/BUILD_windows
+++ b/code/packages/elixir/paint_vm_ascii/BUILD_windows
@@ -1,0 +1,2 @@
+mix deps.get --quiet
+mix test --cover

--- a/code/packages/elixir/paint_vm_ascii/CHANGELOG.md
+++ b/code/packages/elixir/paint_vm_ascii/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- add the initial Elixir `paint_vm_ascii` backend
+- render filled rect scenes to block-character terminal output
+- add Mix project metadata, tests, and build files

--- a/code/packages/elixir/paint_vm_ascii/README.md
+++ b/code/packages/elixir/paint_vm_ascii/README.md
@@ -1,0 +1,7 @@
+# paint_vm_ascii
+
+Elixir terminal backend for `CodingAdventures.PaintInstructions`.
+
+The current Elixir paint instruction model is rect-only, so this first version
+renders filled rectangles as block-character output and raises for unsupported
+instruction kinds.

--- a/code/packages/elixir/paint_vm_ascii/lib/coding_adventures/paint_vm_ascii.ex
+++ b/code/packages/elixir/paint_vm_ascii/lib/coding_adventures/paint_vm_ascii.ex
@@ -1,0 +1,74 @@
+defmodule CodingAdventures.PaintVmAscii do
+  @moduledoc """
+  Terminal backend for backend-neutral paint scenes.
+
+  The current Elixir paint instruction model is rect-only, so this first
+  version renders filled rectangles as block-character output and raises for
+  unsupported instruction kinds.
+  """
+
+  @type options :: [scale_x: pos_integer(), scale_y: pos_integer()]
+
+  @spec render(map(), options()) :: String.t()
+  def render(scene, opts \\ []) do
+    sx = Keyword.get(opts, :scale_x, 8)
+    sy = Keyword.get(opts, :scale_y, 16)
+    cols = ceil(scene.width / sx)
+    rows = ceil(scene.height / sy)
+    chars = for _row <- 1..rows, do: for(_col <- 1..cols, do: " ")
+    buffer = %{rows: rows, cols: cols, chars: chars}
+
+    buffer =
+      Enum.reduce(scene.instructions, buffer, fn inst, acc ->
+        render_instruction(inst, acc, sx, sy)
+      end)
+
+    buffer_to_string(buffer)
+  end
+
+  defp render_instruction(%{kind: :rect} = inst, buffer, sx, sy), do: render_rect(inst, buffer, sx, sy)
+
+  defp render_instruction(inst, _buffer, _sx, _sy) do
+    raise ArgumentError, "paint_vm_ascii: unsupported paint instruction kind: #{inspect(inst.kind)}"
+  end
+
+  defp render_rect(inst, buffer, _sx, _sy)
+       when inst.fill in [nil, "", "transparent", "none"],
+       do: buffer
+
+  defp render_rect(inst, buffer, sx, sy) do
+    c1 = to_col(inst.x, sx)
+    r1 = to_row(inst.y, sy)
+    c2 = to_col(inst.x + inst.width, sx)
+    r2 = to_row(inst.y + inst.height, sy)
+
+    Enum.reduce(r1..r2, buffer, fn row, acc ->
+      Enum.reduce(c1..c2, acc, fn col, inner ->
+        write_char(inner, row, col, "█")
+      end)
+    end)
+  end
+
+  defp to_col(x, sx), do: round(x / sx)
+  defp to_row(y, sy), do: round(y / sy)
+
+  defp write_char(buffer, row, col, _ch)
+       when row < 0 or row >= buffer.rows or col < 0 or col >= buffer.cols,
+       do: buffer
+
+  defp write_char(buffer, row, col, ch) do
+    updated_row =
+      buffer.chars
+      |> Enum.at(row)
+      |> List.replace_at(col, ch)
+
+    %{buffer | chars: List.replace_at(buffer.chars, row, updated_row)}
+  end
+
+  defp buffer_to_string(buffer) do
+    buffer.chars
+    |> Enum.map(&(Enum.join(&1) |> String.trim_trailing()))
+    |> Enum.join("\n")
+    |> String.trim_trailing()
+  end
+end

--- a/code/packages/elixir/paint_vm_ascii/lib/coding_adventures/paint_vm_ascii/version.ex
+++ b/code/packages/elixir/paint_vm_ascii/lib/coding_adventures/paint_vm_ascii/version.ex
@@ -1,0 +1,8 @@
+defmodule CodingAdventures.PaintVmAscii.Version do
+  @moduledoc false
+
+  @version "0.1.0"
+
+  @spec version() :: String.t()
+  def version, do: @version
+end

--- a/code/packages/elixir/paint_vm_ascii/mix.exs
+++ b/code/packages/elixir/paint_vm_ascii/mix.exs
@@ -1,0 +1,28 @@
+defmodule CodingAdventures.PaintVmAscii.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :coding_adventures_paint_vm_ascii,
+      version: "0.1.0",
+      elixir: "~> 1.14",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      test_coverage: [
+        summary: [threshold: 80]
+      ]
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    [
+      {:coding_adventures_paint_instructions, path: "../paint_instructions"}
+    ]
+  end
+end

--- a/code/packages/elixir/paint_vm_ascii/test/paint_vm_ascii_test.exs
+++ b/code/packages/elixir/paint_vm_ascii/test/paint_vm_ascii_test.exs
@@ -1,0 +1,29 @@
+defmodule CodingAdventures.PaintVmAsciiTest do
+  use ExUnit.Case
+
+  alias CodingAdventures.PaintInstructions
+  alias CodingAdventures.PaintVmAscii
+  alias CodingAdventures.PaintVmAscii.Version
+
+  test "module exposes a version" do
+    assert Version.version() == "0.1.0"
+  end
+
+  test "renders a filled rect with block characters" do
+    scene =
+      PaintInstructions.paint_scene(3, 2, [
+        PaintInstructions.paint_rect(0, 0, 2, 1, "#000000")
+      ])
+
+    assert PaintVmAscii.render(scene, scale_x: 1, scale_y: 1) =~ "█"
+  end
+
+  test "transparent rect is invisible" do
+    scene =
+      PaintInstructions.paint_scene(3, 2, [
+        PaintInstructions.paint_rect(0, 0, 2, 1, "transparent")
+      ])
+
+    assert PaintVmAscii.render(scene, scale_x: 1, scale_y: 1) == ""
+  end
+end

--- a/code/packages/elixir/paint_vm_ascii/test/test_helper.exs
+++ b/code/packages/elixir/paint_vm_ascii/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/code/packages/go/paint-vm-ascii/BUILD
+++ b/code/packages/go/paint-vm-ascii/BUILD
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/paint-vm-ascii/CHANGELOG.md
+++ b/code/packages/go/paint-vm-ascii/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- add the initial Go paint-vm-ascii backend
+- render filled rect instructions to block-character output
+- add basic renderer coverage tests

--- a/code/packages/go/paint-vm-ascii/README.md
+++ b/code/packages/go/paint-vm-ascii/README.md
@@ -1,0 +1,7 @@
+# paint-vm-ascii
+
+Go terminal backend for `paint-instructions`.
+
+This package renders the current Go `PaintScene` model to a plain string. The
+Go paint IR is still rect-focused today, so the initial backend renders filled
+rectangles as block characters and rejects unknown instruction kinds.

--- a/code/packages/go/paint-vm-ascii/go.mod
+++ b/code/packages/go/paint-vm-ascii/go.mod
@@ -1,0 +1,7 @@
+module github.com/adhithyan15/coding-adventures/code/packages/go/paint-vm-ascii
+
+go 1.26
+
+require github.com/adhithyan15/coding-adventures/code/packages/go/paint-instructions v0.0.0
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/paint-instructions => ../paint-instructions

--- a/code/packages/go/paint-vm-ascii/paint_vm_ascii.go
+++ b/code/packages/go/paint-vm-ascii/paint_vm_ascii.go
@@ -1,0 +1,110 @@
+// Package paintvmascii renders PaintScene values to a terminal-friendly string.
+package paintvmascii
+
+import (
+	"fmt"
+	"math"
+	"strings"
+
+	paintinstructions "github.com/adhithyan15/coding-adventures/code/packages/go/paint-instructions"
+)
+
+const Version = "0.1.0"
+
+// AsciiOptions controls how scene coordinates map to character cells.
+type AsciiOptions struct {
+	ScaleX int
+	ScaleY int
+}
+
+func (o *AsciiOptions) defaults() AsciiOptions {
+	if o == nil {
+		return AsciiOptions{ScaleX: 8, ScaleY: 16}
+	}
+	out := *o
+	if out.ScaleX == 0 {
+		out.ScaleX = 8
+	}
+	if out.ScaleY == 0 {
+		out.ScaleY = 16
+	}
+	return out
+}
+
+type charBuffer struct {
+	rows, cols int
+	chars      [][]string
+}
+
+func newCharBuffer(rows, cols int) *charBuffer {
+	chars := make([][]string, rows)
+	for r := 0; r < rows; r++ {
+		chars[r] = make([]string, cols)
+		for c := 0; c < cols; c++ {
+			chars[r][c] = " "
+		}
+	}
+	return &charBuffer{rows: rows, cols: cols, chars: chars}
+}
+
+func (b *charBuffer) writeChar(row, col int, ch string) {
+	if row < 0 || row >= b.rows || col < 0 || col >= b.cols {
+		return
+	}
+	b.chars[row][col] = ch
+}
+
+func (b *charBuffer) String() string {
+	lines := make([]string, b.rows)
+	for r := 0; r < b.rows; r++ {
+		lines[r] = strings.TrimRight(strings.Join(b.chars[r], ""), " ")
+	}
+	return strings.TrimRight(strings.Join(lines, "\n"), "\n ")
+}
+
+func toCol(x float64, scaleX int) int {
+	return int(math.Round(x / float64(scaleX)))
+}
+
+func toRow(y float64, scaleY int) int {
+	return int(math.Round(y / float64(scaleY)))
+}
+
+func renderRect(inst paintinstructions.PaintRectInstruction, buf *charBuffer, sx, sy int) {
+	if inst.Fill == "" || inst.Fill == "transparent" || inst.Fill == "none" {
+		return
+	}
+	c1 := toCol(float64(inst.X), sx)
+	r1 := toRow(float64(inst.Y), sy)
+	c2 := toCol(float64(inst.X+inst.Width), sx)
+	r2 := toRow(float64(inst.Y+inst.Height), sy)
+
+	for r := r1; r <= r2; r++ {
+		for c := c1; c <= c2; c++ {
+			buf.writeChar(r, c, "█")
+		}
+	}
+}
+
+// Render executes a rect-based PaintScene into a terminal string.
+func Render(scene paintinstructions.PaintScene, options *AsciiOptions) (string, error) {
+	opts := options.defaults()
+	cols := int(math.Ceil(float64(scene.Width) / float64(opts.ScaleX)))
+	rows := int(math.Ceil(float64(scene.Height) / float64(opts.ScaleY)))
+	buf := newCharBuffer(rows, cols)
+
+	for _, instruction := range scene.Instructions {
+		switch current := instruction.(type) {
+		case paintinstructions.PaintRectInstruction:
+			renderRect(current, buf, opts.ScaleX, opts.ScaleY)
+		case *paintinstructions.PaintRectInstruction:
+			if current != nil {
+				renderRect(*current, buf, opts.ScaleX, opts.ScaleY)
+			}
+		default:
+			return "", fmt.Errorf("paint-vm-ascii: unsupported paint instruction kind: %s", instruction.InstructionKind())
+		}
+	}
+
+	return buf.String(), nil
+}

--- a/code/packages/go/paint-vm-ascii/paint_vm_ascii_test.go
+++ b/code/packages/go/paint-vm-ascii/paint_vm_ascii_test.go
@@ -1,0 +1,42 @@
+package paintvmascii
+
+import (
+	"strings"
+	"testing"
+
+	paintinstructions "github.com/adhithyan15/coding-adventures/code/packages/go/paint-instructions"
+)
+
+func TestVersion(t *testing.T) {
+	if Version != "0.1.0" {
+		t.Fatalf("Version = %q", Version)
+	}
+}
+
+func TestRenderFilledRect(t *testing.T) {
+	scene := paintinstructions.CreateScene(3, 2, []paintinstructions.PaintInstruction{
+		paintinstructions.PaintRect(0, 0, 2, 1, "#000000", nil),
+	}, "#ffffff", nil)
+
+	result, err := Render(scene, &AsciiOptions{ScaleX: 1, ScaleY: 1})
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+	if !strings.Contains(result, "█") {
+		t.Fatalf("expected output to contain block characters, got %q", result)
+	}
+}
+
+func TestRenderTransparentRectProducesEmptyOutput(t *testing.T) {
+	scene := paintinstructions.CreateScene(3, 2, []paintinstructions.PaintInstruction{
+		paintinstructions.PaintRect(0, 0, 2, 1, "transparent", nil),
+	}, "#ffffff", nil)
+
+	result, err := Render(scene, &AsciiOptions{ScaleX: 1, ScaleY: 1})
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+	if result != "" {
+		t.Fatalf("expected empty output, got %q", result)
+	}
+}

--- a/code/packages/lua/paint_vm_ascii/BUILD
+++ b/code/packages/lua/paint_vm_ascii/BUILD
@@ -1,0 +1,3 @@
+luarocks show coding-adventures-paint-instructions >/dev/null 2>&1 || (cd ../paint_instructions && luarocks make --local --deps-mode=none coding-adventures-paint-instructions-0.1.0-1.rockspec)
+luarocks make --local --deps-mode=none coding-adventures-paint-vm-ascii-0.1.0-1.rockspec
+busted tests --verbose --pattern=test_

--- a/code/packages/lua/paint_vm_ascii/BUILD_windows
+++ b/code/packages/lua/paint_vm_ascii/BUILD_windows
@@ -1,0 +1,3 @@
+luarocks show coding-adventures-paint-instructions 1>NUL 2>NUL || (cd ../paint_instructions && luarocks make --local --deps-mode=none coding-adventures-paint-instructions-0.1.0-1.rockspec)
+luarocks make --local --no-manifest coding-adventures-paint-vm-ascii-0.1.0-1.rockspec
+busted tests --verbose --pattern=test_

--- a/code/packages/lua/paint_vm_ascii/CHANGELOG.md
+++ b/code/packages/lua/paint_vm_ascii/CHANGELOG.md
@@ -5,3 +5,4 @@
 - add the initial Lua `paint_vm_ascii` backend
 - render filled rect scenes to block-character terminal output
 - add rockspec, tests, and build scripts
+- pin the Lua rockspec source to the package commit for reproducible installs

--- a/code/packages/lua/paint_vm_ascii/CHANGELOG.md
+++ b/code/packages/lua/paint_vm_ascii/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- add the initial Lua `paint_vm_ascii` backend
+- render filled rect scenes to block-character terminal output
+- add rockspec, tests, and build scripts

--- a/code/packages/lua/paint_vm_ascii/README.md
+++ b/code/packages/lua/paint_vm_ascii/README.md
@@ -1,0 +1,7 @@
+# paint_vm_ascii
+
+Lua terminal backend for `coding_adventures.paint_instructions`.
+
+The current Lua paint scene model is rect-only, so this first version renders
+filled rectangles as block-character output and raises an error for unsupported
+instruction kinds.

--- a/code/packages/lua/paint_vm_ascii/coding-adventures-paint-vm-ascii-0.1.0-1.rockspec
+++ b/code/packages/lua/paint_vm_ascii/coding-adventures-paint-vm-ascii-0.1.0-1.rockspec
@@ -2,7 +2,7 @@ package = "coding-adventures-paint-vm-ascii"
 version = "0.1.0-1"
 
 source = {
-    url = "git://github.com/adhithyan15/coding-adventures.git",
+    url = "https://github.com/adhithyan15/coding-adventures.git",
 }
 
 description = {

--- a/code/packages/lua/paint_vm_ascii/coding-adventures-paint-vm-ascii-0.1.0-1.rockspec
+++ b/code/packages/lua/paint_vm_ascii/coding-adventures-paint-vm-ascii-0.1.0-1.rockspec
@@ -3,6 +3,7 @@ version = "0.1.0-1"
 
 source = {
     url = "https://github.com/adhithyan15/coding-adventures.git",
+    tag = "fdb7fc4228d726fe376301d46b4343b0634b3d0b",
 }
 
 description = {

--- a/code/packages/lua/paint_vm_ascii/coding-adventures-paint-vm-ascii-0.1.0-1.rockspec
+++ b/code/packages/lua/paint_vm_ascii/coding-adventures-paint-vm-ascii-0.1.0-1.rockspec
@@ -1,0 +1,25 @@
+package = "coding-adventures-paint-vm-ascii"
+version = "0.1.0-1"
+
+source = {
+    url = "git://github.com/adhithyan15/coding-adventures.git",
+}
+
+description = {
+    summary = "Terminal backend for backend-neutral paint scenes",
+    homepage = "https://github.com/adhithyan15/coding-adventures",
+    license = "MIT",
+}
+
+dependencies = {
+    "lua >= 5.4",
+    "coding-adventures-paint-instructions == 0.1.0-1",
+}
+
+build = {
+    type = "builtin",
+    modules = {
+        ["coding_adventures.paint_vm_ascii"] =
+            "src/coding_adventures/paint_vm_ascii/init.lua",
+    },
+}

--- a/code/packages/lua/paint_vm_ascii/src/coding_adventures/paint_vm_ascii/init.lua
+++ b/code/packages/lua/paint_vm_ascii/src/coding_adventures/paint_vm_ascii/init.lua
@@ -1,0 +1,93 @@
+local M = {}
+
+M.VERSION = "0.1.0"
+
+local function scale_x(options)
+    if options == nil or options.scale_x == nil or options.scale_x == 0 then
+        return 8
+    end
+    return options.scale_x
+end
+
+local function scale_y(options)
+    if options == nil or options.scale_y == nil or options.scale_y == 0 then
+        return 16
+    end
+    return options.scale_y
+end
+
+local function to_col(x, sx)
+    return math.floor((x / sx) + 0.5)
+end
+
+local function to_row(y, sy)
+    return math.floor((y / sy) + 0.5)
+end
+
+local function new_buffer(rows, cols)
+    local chars = {}
+    for row = 1, rows do
+        chars[row] = {}
+        for col = 1, cols do
+            chars[row][col] = " "
+        end
+    end
+    return {
+        rows = rows,
+        cols = cols,
+        chars = chars,
+    }
+end
+
+local function write_char(buffer, row, col, ch)
+    if row < 0 or row >= buffer.rows or col < 0 or col >= buffer.cols then
+        return
+    end
+    buffer.chars[row + 1][col + 1] = ch
+end
+
+local function buffer_to_string(buffer)
+    local lines = {}
+    for row = 1, buffer.rows do
+        local line = table.concat(buffer.chars[row]):gsub("%s+$", "")
+        lines[#lines + 1] = line
+    end
+    return table.concat(lines, "\n"):gsub("[%s\n]+$", "")
+end
+
+local function render_rect(inst, buffer, sx, sy)
+    if inst.fill == nil or inst.fill == "" or inst.fill == "transparent" or inst.fill == "none" then
+        return
+    end
+
+    local c1 = to_col(inst.x, sx)
+    local r1 = to_row(inst.y, sy)
+    local c2 = to_col(inst.x + inst.width, sx)
+    local r2 = to_row(inst.y + inst.height, sy)
+
+    for row = r1, r2 do
+        for col = c1, c2 do
+            write_char(buffer, row, col, "█")
+        end
+    end
+end
+
+function M.render(scene, options)
+    local sx = scale_x(options)
+    local sy = scale_y(options)
+    local cols = math.ceil(scene.width / sx)
+    local rows = math.ceil(scene.height / sy)
+    local buffer = new_buffer(rows, cols)
+
+    for _, inst in ipairs(scene.instructions or {}) do
+        if inst.kind == "rect" then
+            render_rect(inst, buffer, sx, sy)
+        else
+            error("paint_vm_ascii: unsupported paint instruction kind: " .. tostring(inst.kind))
+        end
+    end
+
+    return buffer_to_string(buffer)
+end
+
+return M

--- a/code/packages/lua/paint_vm_ascii/tests/test_paint_vm_ascii.lua
+++ b/code/packages/lua/paint_vm_ascii/tests/test_paint_vm_ascii.lua
@@ -1,0 +1,34 @@
+package.path = table.concat({
+    "src/?.lua",
+    "src/?/init.lua",
+    "../paint_instructions/src/?.lua",
+    "../paint_instructions/src/?/init.lua",
+    package.path,
+}, ";")
+
+local paint_instructions = require("coding_adventures.paint_instructions")
+local paint_vm_ascii = require("coding_adventures.paint_vm_ascii")
+
+describe("paint_vm_ascii", function()
+    it("exposes a version", function()
+        assert.are.equal("0.1.0", paint_vm_ascii.VERSION)
+    end)
+
+    it("renders filled rects as block characters", function()
+        local scene = paint_instructions.paint_scene(3, 2, {
+            paint_instructions.paint_rect(0, 0, 2, 1, "#000000"),
+        })
+
+        local result = paint_vm_ascii.render(scene, { scale_x = 1, scale_y = 1 })
+        assert.is_true(result:find("█", 1, true) ~= nil)
+    end)
+
+    it("ignores transparent rects", function()
+        local scene = paint_instructions.paint_scene(3, 2, {
+            paint_instructions.paint_rect(0, 0, 2, 1, "transparent"),
+        })
+
+        local result = paint_vm_ascii.render(scene, { scale_x = 1, scale_y = 1 })
+        assert.are.equal("", result)
+    end)
+end)

--- a/code/packages/perl/paint-vm-ascii/BUILD
+++ b/code/packages/perl/paint-vm-ascii/BUILD
@@ -1,0 +1,2 @@
+cpanm --quiet --notest Test2::V0
+prove -l -I../paint-instructions/lib -v t/

--- a/code/packages/perl/paint-vm-ascii/CHANGELOG.md
+++ b/code/packages/perl/paint-vm-ascii/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- add the initial Perl paint-vm-ascii backend
+- render filled rectangles to block-character terminal output
+- add publishable package metadata and tests

--- a/code/packages/perl/paint-vm-ascii/Makefile.PL
+++ b/code/packages/perl/paint-vm-ascii/Makefile.PL
@@ -1,0 +1,16 @@
+use strict;
+use warnings;
+use ExtUtils::MakeMaker;
+
+WriteMakefile(
+    NAME             => 'CodingAdventures::PaintVmAscii',
+    VERSION_FROM     => 'lib/CodingAdventures/PaintVmAscii.pm',
+    ABSTRACT         => 'Terminal backend for backend-neutral paint scenes',
+    AUTHOR           => 'coding-adventures',
+    LICENSE          => 'mit',
+    MIN_PERL_VERSION => '5.026000',
+    PREREQ_PM        => {
+        'CodingAdventures::PaintInstructions' => 0,
+    },
+    TEST_REQUIRES    => { 'Test2::V0' => 0 },
+);

--- a/code/packages/perl/paint-vm-ascii/README.md
+++ b/code/packages/perl/paint-vm-ascii/README.md
@@ -1,0 +1,6 @@
+# paint-vm-ascii
+
+Perl terminal backend for `CodingAdventures::PaintInstructions`.
+
+The initial backend renders filled rectangle instructions to block-character
+output and fails loudly for unsupported instruction kinds.

--- a/code/packages/perl/paint-vm-ascii/cpanfile
+++ b/code/packages/perl/paint-vm-ascii/cpanfile
@@ -1,0 +1,4 @@
+requires 'CodingAdventures::PaintInstructions';
+on test => sub {
+    requires 'Test2::V0';
+};

--- a/code/packages/perl/paint-vm-ascii/lib/CodingAdventures/PaintVmAscii.pm
+++ b/code/packages/perl/paint-vm-ascii/lib/CodingAdventures/PaintVmAscii.pm
@@ -1,0 +1,104 @@
+package CodingAdventures::PaintVmAscii;
+
+use strict;
+use warnings;
+use utf8;
+
+use CodingAdventures::PaintInstructions;
+
+our $VERSION = '0.1.0';
+
+sub _scale_x {
+    my ($options) = @_;
+    return 8 if !defined $options || !defined $options->{scale_x} || !$options->{scale_x};
+    return $options->{scale_x};
+}
+
+sub _scale_y {
+    my ($options) = @_;
+    return 16 if !defined $options || !defined $options->{scale_y} || !$options->{scale_y};
+    return $options->{scale_y};
+}
+
+sub _to_col {
+    my ($x, $scale_x) = @_;
+    return sprintf('%.0f', $x / $scale_x) + 0;
+}
+
+sub _to_row {
+    my ($y, $scale_y) = @_;
+    return sprintf('%.0f', $y / $scale_y) + 0;
+}
+
+sub _new_buffer {
+    my ($rows, $cols) = @_;
+    my @chars;
+    for my $row (0 .. $rows - 1) {
+        $chars[$row] = [ (' ') x $cols ];
+    }
+    return {
+        rows  => $rows,
+        cols  => $cols,
+        chars => \@chars,
+    };
+}
+
+sub _write_char {
+    my ($buffer, $row, $col, $ch) = @_;
+    return if $row < 0 || $row >= $buffer->{rows};
+    return if $col < 0 || $col >= $buffer->{cols};
+    $buffer->{chars}[$row][$col] = $ch;
+}
+
+sub _buffer_to_string {
+    my ($buffer) = @_;
+    my @lines;
+    for my $row (0 .. $buffer->{rows} - 1) {
+        my $line = join('', @{ $buffer->{chars}[$row] });
+        $line =~ s/\s+$//;
+        push @lines, $line;
+    }
+    my $result = join("\n", @lines);
+    $result =~ s/[\s\n]+$//;
+    return $result;
+}
+
+sub _render_rect {
+    my ($instruction, $buffer, $scale_x, $scale_y) = @_;
+    my $fill = $instruction->{fill} // '#000000';
+    return if $fill eq '' || $fill eq 'transparent' || $fill eq 'none';
+
+    my $c1 = _to_col($instruction->{x}, $scale_x);
+    my $r1 = _to_row($instruction->{y}, $scale_y);
+    my $c2 = _to_col($instruction->{x} + $instruction->{width}, $scale_x);
+    my $r2 = _to_row($instruction->{y} + $instruction->{height}, $scale_y);
+
+    for my $row ($r1 .. $r2) {
+        for my $col ($c1 .. $c2) {
+            _write_char($buffer, $row, $col, "\x{2588}");
+        }
+    }
+}
+
+sub render {
+    my ($class, $scene, $options) = @_;
+    my $scale_x = _scale_x($options);
+    my $scale_y = _scale_y($options);
+
+    my $cols = int((($scene->{width} // 0) + $scale_x - 1) / $scale_x);
+    my $rows = int((($scene->{height} // 0) + $scale_y - 1) / $scale_y);
+    my $buffer = _new_buffer($rows, $cols);
+
+    for my $instruction (@{ $scene->{instructions} // [] }) {
+        my $kind = $instruction->{kind} // '';
+        if ($kind eq 'rect') {
+            _render_rect($instruction, $buffer, $scale_x, $scale_y);
+            next;
+        }
+        die "paint-vm-ascii: unsupported paint instruction kind: $kind";
+    }
+
+    return _buffer_to_string($buffer);
+}
+
+1;

--- a/code/packages/perl/paint-vm-ascii/t/01-basic.t
+++ b/code/packages/perl/paint-vm-ascii/t/01-basic.t
@@ -1,0 +1,45 @@
+use strict;
+use warnings;
+use utf8;
+
+use Test2::V0;
+
+use lib '../paint-instructions/lib';
+use lib 'lib';
+
+use CodingAdventures::PaintInstructions;
+use CodingAdventures::PaintVmAscii;
+
+is(CodingAdventures::PaintVmAscii->VERSION, '0.1.0', 'version matches');
+
+my $filled_scene = CodingAdventures::PaintInstructions->paint_scene(
+    3,
+    2,
+    [
+        CodingAdventures::PaintInstructions->paint_rect(0, 0, 2, 1, '#000000'),
+    ],
+    '#ffffff',
+);
+
+like(
+    CodingAdventures::PaintVmAscii->render($filled_scene, { scale_x => 1, scale_y => 1 }),
+    qr/\x{2588}/,
+    'filled rect renders block characters',
+);
+
+my $transparent_scene = CodingAdventures::PaintInstructions->paint_scene(
+    3,
+    2,
+    [
+        CodingAdventures::PaintInstructions->paint_rect(0, 0, 2, 1, 'transparent'),
+    ],
+    '#ffffff',
+);
+
+is(
+    CodingAdventures::PaintVmAscii->render($transparent_scene, { scale_x => 1, scale_y => 1 }),
+    '',
+    'transparent rect produces empty output',
+);
+
+done_testing;

--- a/code/packages/python/paint-vm-ascii/BUILD
+++ b/code/packages/python/paint-vm-ascii/BUILD
@@ -1,0 +1,4 @@
+uv venv --quiet --clear
+uv pip install -e ../paint-instructions --quiet
+uv pip install -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/paint-vm-ascii/BUILD_windows
+++ b/code/packages/python/paint-vm-ascii/BUILD_windows
@@ -1,0 +1,4 @@
+uv venv --quiet --clear
+uv pip install -e ../paint-instructions --quiet
+uv pip install -e ".[dev]" --quiet
+.venv/Scripts/python.exe -m pytest tests/ -v

--- a/code/packages/python/paint-vm-ascii/CHANGELOG.md
+++ b/code/packages/python/paint-vm-ascii/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- add the initial Python paint-vm-ascii backend
+- render filled rectangles as block-character output
+- add renderer tests and package metadata

--- a/code/packages/python/paint-vm-ascii/README.md
+++ b/code/packages/python/paint-vm-ascii/README.md
@@ -1,0 +1,6 @@
+# coding-adventures-paint-vm-ascii
+
+Python terminal backend for `paint_instructions`.
+
+The current Python paint IR is rect-focused, so the first version renders filled
+rectangles to block-character output and rejects unsupported instruction kinds.

--- a/code/packages/python/paint-vm-ascii/pyproject.toml
+++ b/code/packages/python/paint-vm-ascii/pyproject.toml
@@ -1,0 +1,40 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-paint-vm-ascii"
+version = "0.1.0"
+description = "Terminal backend for backend-neutral paint scenes"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+dependencies = ["coding-adventures-paint-instructions"]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/paint_vm_ascii"]
+
+[tool.uv.sources]
+coding-adventures-paint-instructions = { path = "../paint-instructions" }
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM", "ANN"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=paint_vm_ascii --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.run]
+source = ["src/paint_vm_ascii"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/packages/python/paint-vm-ascii/src/paint_vm_ascii/__init__.py
+++ b/code/packages/python/paint-vm-ascii/src/paint_vm_ascii/__init__.py
@@ -1,0 +1,78 @@
+"""Terminal backend for backend-neutral paint scenes."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from paint_instructions import PaintRectInstruction, PaintScene
+
+__version__ = "0.1.0"
+
+
+@dataclass(frozen=True)
+class AsciiOptions:
+    """How scene coordinates map to character cells."""
+
+    scale_x: int = 8
+    scale_y: int = 16
+
+
+class _CharBuffer:
+    def __init__(self, rows: int, cols: int) -> None:
+        self.rows = rows
+        self.cols = cols
+        self.chars: list[list[str]] = [[" "] * cols for _ in range(rows)]
+
+    def write_char(self, row: int, col: int, ch: str) -> None:
+        if row < 0 or row >= self.rows or col < 0 or col >= self.cols:
+            return
+        self.chars[row][col] = ch
+
+    def to_string(self) -> str:
+        return "\n".join("".join(row).rstrip() for row in self.chars).rstrip()
+
+
+def _to_col(x: int, scale_x: int) -> int:
+    return round(x / scale_x)
+
+
+def _to_row(y: int, scale_y: int) -> int:
+    return round(y / scale_y)
+
+
+def _render_rect(
+    inst: PaintRectInstruction,
+    buf: _CharBuffer,
+    *,
+    scale_x: int,
+    scale_y: int,
+) -> None:
+    if inst.fill in {"", "transparent", "none"}:
+        return
+
+    c1 = _to_col(inst.x, scale_x)
+    r1 = _to_row(inst.y, scale_y)
+    c2 = _to_col(inst.x + inst.width, scale_x)
+    r2 = _to_row(inst.y + inst.height, scale_y)
+
+    for row in range(r1, r2 + 1):
+        for col in range(c1, c2 + 1):
+            buf.write_char(row, col, "\u2588")
+
+
+def render(scene: PaintScene, options: AsciiOptions | None = None) -> str:
+    """Render a paint scene as a plain terminal string."""
+
+    opts = options or AsciiOptions()
+    cols = math.ceil(scene.width / opts.scale_x)
+    rows = math.ceil(scene.height / opts.scale_y)
+    buf = _CharBuffer(rows, cols)
+
+    for inst in scene.instructions:
+        if isinstance(inst, PaintRectInstruction):
+            _render_rect(inst, buf, scale_x=opts.scale_x, scale_y=opts.scale_y)
+            continue
+        raise ValueError(f"paint-vm-ascii: unsupported paint instruction kind: {inst.kind}")
+
+    return buf.to_string()

--- a/code/packages/python/paint-vm-ascii/tests/test_paint_vm_ascii.py
+++ b/code/packages/python/paint-vm-ascii/tests/test_paint_vm_ascii.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from paint_instructions import paint_rect, paint_scene
+from paint_vm_ascii import AsciiOptions, __version__, render
+
+
+def test_version() -> None:
+    assert __version__ == "0.1.0"
+
+
+def test_render_filled_rect() -> None:
+    scene = paint_scene(3, 2, [paint_rect(0, 0, 2, 1, "#000000")])
+    result = render(scene, AsciiOptions(scale_x=1, scale_y=1))
+    assert "\u2588" in result
+
+
+def test_transparent_rect_is_empty() -> None:
+    scene = paint_scene(3, 2, [paint_rect(0, 0, 2, 1, "transparent")])
+    result = render(scene, AsciiOptions(scale_x=1, scale_y=1))
+    assert result == ""

--- a/code/packages/ruby/paint_vm_ascii/BUILD
+++ b/code/packages/ruby/paint_vm_ascii/BUILD
@@ -1,0 +1,1 @@
+ruby -Ilib -I../paint_instructions/lib test/test_paint_vm_ascii.rb

--- a/code/packages/ruby/paint_vm_ascii/CHANGELOG.md
+++ b/code/packages/ruby/paint_vm_ascii/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- add the initial Ruby `paint_vm_ascii` backend
+- render filled rect scenes to block-character terminal output
+- add gem metadata, tests, and build files

--- a/code/packages/ruby/paint_vm_ascii/Gemfile
+++ b/code/packages/ruby/paint_vm_ascii/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gemspec
+
+gem "coding_adventures_paint_instructions", path: "../paint_instructions"

--- a/code/packages/ruby/paint_vm_ascii/README.md
+++ b/code/packages/ruby/paint_vm_ascii/README.md
@@ -1,0 +1,7 @@
+# coding_adventures_paint_vm_ascii
+
+Ruby terminal backend for `CodingAdventures::PaintInstructions`.
+
+The current Ruby paint instruction model is rect-only, so this first version
+renders filled rectangles as block-character output and raises for unsupported
+instruction kinds.

--- a/code/packages/ruby/paint_vm_ascii/Rakefile
+++ b/code/packages/ruby/paint_vm_ascii/Rakefile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rake/testtask"
+
+Rake::TestTask.new do |t|
+  t.libs << "lib"
+  t.libs << "../paint_instructions/lib"
+  t.pattern = "test/**/*_test.rb"
+end
+
+task default: :test

--- a/code/packages/ruby/paint_vm_ascii/coding_adventures_paint_vm_ascii.gemspec
+++ b/code/packages/ruby/paint_vm_ascii/coding_adventures_paint_vm_ascii.gemspec
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative "lib/coding_adventures/paint_vm_ascii/version"
+
+Gem::Specification.new do |spec|
+  spec.name          = "coding_adventures_paint_vm_ascii"
+  spec.version       = CodingAdventures::PaintVmAscii::VERSION
+  spec.authors       = ["Adhithya Rajasekaran"]
+  spec.summary       = "Terminal backend for backend-neutral paint scenes"
+  spec.homepage      = "https://github.com/adhithyan15/coding-adventures"
+  spec.license       = "MIT"
+  spec.required_ruby_version = ">= 3.3.0"
+
+  spec.files         = Dir["lib/**/*.rb", "README.md", "CHANGELOG.md"]
+  spec.require_paths = ["lib"]
+
+  spec.metadata = {
+    "source_code_uri" => "https://github.com/adhithyan15/coding-adventures",
+    "rubygems_mfa_required" => "true",
+  }
+
+  spec.add_dependency "coding_adventures_paint_instructions", "~> 0.1"
+  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "rake", "~> 13.0"
+end

--- a/code/packages/ruby/paint_vm_ascii/lib/coding_adventures/paint_vm_ascii/version.rb
+++ b/code/packages/ruby/paint_vm_ascii/lib/coding_adventures/paint_vm_ascii/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module PaintVmAscii
+    VERSION = "0.1.0"
+  end
+end

--- a/code/packages/ruby/paint_vm_ascii/lib/coding_adventures_paint_vm_ascii.rb
+++ b/code/packages/ruby/paint_vm_ascii/lib/coding_adventures_paint_vm_ascii.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "coding_adventures_paint_instructions"
+require_relative "coding_adventures/paint_vm_ascii/version"
+
+module CodingAdventures
+  module PaintVmAscii
+    module_function
+
+    def render(scene, scale_x: 8, scale_y: 16)
+      cols = (scene.width.to_f / scale_x).ceil
+      rows = (scene.height.to_f / scale_y).ceil
+      chars = Array.new(rows) { Array.new(cols, " ") }
+
+      scene.instructions.each do |inst|
+        case inst.kind.to_s
+        when "rect"
+          render_rect(inst, chars, scale_x, scale_y)
+        else
+          raise ArgumentError, "paint_vm_ascii: unsupported paint instruction kind: #{inst.kind}"
+        end
+      end
+
+      chars.map { |row| row.join.rstrip }.join("\n").rstrip
+    end
+
+    def render_rect(inst, chars, scale_x, scale_y)
+      fill = inst.fill
+      return if fill.nil? || fill.empty? || fill == "transparent" || fill == "none"
+
+      c1 = (inst.x.to_f / scale_x).round
+      r1 = (inst.y.to_f / scale_y).round
+      c2 = ((inst.x + inst.width).to_f / scale_x).round
+      r2 = ((inst.y + inst.height).to_f / scale_y).round
+
+      (r1..r2).each do |row|
+        next if row.negative? || row >= chars.length
+
+        (c1..c2).each do |col|
+          next if col.negative? || col >= chars[row].length
+
+          chars[row][col] = "\u2588"
+        end
+      end
+    end
+    private_class_method :render_rect
+  end
+end

--- a/code/packages/ruby/paint_vm_ascii/test/test_paint_vm_ascii.rb
+++ b/code/packages/ruby/paint_vm_ascii/test/test_paint_vm_ascii.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "coding_adventures_paint_vm_ascii"
+
+class TestPaintVmAscii < Minitest::Test
+  PI = CodingAdventures::PaintInstructions
+  PVA = CodingAdventures::PaintVmAscii
+
+  def test_version_exists
+    assert_equal "0.1.0", PVA::VERSION
+  end
+
+  def test_filled_rect_renders_block_characters
+    scene = PI.create_scene(width: 3, height: 2, instructions: [
+      PI.paint_rect(x: 0, y: 0, width: 2, height: 1, fill: "#000000")
+    ])
+
+    assert_includes PVA.render(scene, scale_x: 1, scale_y: 1), "\u2588"
+  end
+
+  def test_transparent_rect_is_invisible
+    scene = PI.create_scene(width: 3, height: 2, instructions: [
+      PI.paint_rect(x: 0, y: 0, width: 2, height: 1, fill: "transparent")
+    ])
+
+    assert_equal "", PVA.render(scene, scale_x: 1, scale_y: 1)
+  end
+end

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -228,6 +228,7 @@ members = [
     "paint-codec-png",
     "paint-codec-png-c",
     "paint-instructions",
+    "paint-vm-ascii",
     "paint-metal",
     "paint-vm-direct2d-c",
     "paint-vm-direct2d",

--- a/code/packages/rust/paint-vm-ascii/BUILD
+++ b/code/packages/rust/paint-vm-ascii/BUILD
@@ -1,0 +1,1 @@
+cargo test -- --nocapture

--- a/code/packages/rust/paint-vm-ascii/CHANGELOG.md
+++ b/code/packages/rust/paint-vm-ascii/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- add the initial Rust paint-vm-ascii backend
+- render filled rect scenes to terminal text
+- return explicit errors for unsupported instruction kinds

--- a/code/packages/rust/paint-vm-ascii/Cargo.toml
+++ b/code/packages/rust/paint-vm-ascii/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "paint-vm-ascii"
+version = "0.1.0"
+edition = "2021"
+description = "Terminal backend for backend-neutral paint scenes"
+
+[dependencies]
+paint-instructions = { path = "../paint-instructions" }

--- a/code/packages/rust/paint-vm-ascii/README.md
+++ b/code/packages/rust/paint-vm-ascii/README.md
@@ -1,0 +1,7 @@
+# paint-vm-ascii
+
+Rust terminal backend for `paint-instructions`.
+
+The first version renders filled rectangles to block-character output and
+returns explicit errors for instruction kinds that the backend does not yet
+support.

--- a/code/packages/rust/paint-vm-ascii/src/lib.rs
+++ b/code/packages/rust/paint-vm-ascii/src/lib.rs
@@ -1,0 +1,192 @@
+//! Terminal backend for `paint-instructions`.
+
+use paint_instructions::{PaintInstruction, PaintRect, PaintScene};
+
+pub const VERSION: &str = "0.1.0";
+
+/// How scene coordinates map to character cells.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AsciiOptions {
+    pub scale_x: u32,
+    pub scale_y: u32,
+}
+
+impl Default for AsciiOptions {
+    fn default() -> Self {
+        Self {
+            scale_x: 8,
+            scale_y: 16,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum PaintVmAsciiError {
+    UnsupportedInstruction(&'static str),
+}
+
+struct CharBuffer {
+    rows: usize,
+    cols: usize,
+    chars: Vec<Vec<char>>,
+}
+
+impl CharBuffer {
+    fn new(rows: usize, cols: usize) -> Self {
+        Self {
+            rows,
+            cols,
+            chars: vec![vec![' '; cols]; rows],
+        }
+    }
+
+    fn write_char(&mut self, row: i32, col: i32, ch: char) {
+        if row < 0 || col < 0 {
+            return;
+        }
+        let row = row as usize;
+        let col = col as usize;
+        if row >= self.rows || col >= self.cols {
+            return;
+        }
+        self.chars[row][col] = ch;
+    }
+
+    fn to_text(&self) -> String {
+        self.chars
+            .iter()
+            .map(|row| row.iter().collect::<String>().trim_end().to_string())
+            .collect::<Vec<_>>()
+            .join("\n")
+            .trim_end()
+            .to_string()
+    }
+}
+
+fn to_col(x: f64, scale_x: u32) -> i32 {
+    (x / scale_x as f64).round() as i32
+}
+
+fn to_row(y: f64, scale_y: u32) -> i32 {
+    (y / scale_y as f64).round() as i32
+}
+
+fn render_rect(rect: &PaintRect, buf: &mut CharBuffer, options: AsciiOptions) {
+    let fill = rect.fill.as_deref().unwrap_or("#000000");
+    if fill.is_empty() || fill == "transparent" || fill == "none" {
+        return;
+    }
+
+    let c1 = to_col(rect.x, options.scale_x);
+    let r1 = to_row(rect.y, options.scale_y);
+    let c2 = to_col(rect.x + rect.width, options.scale_x);
+    let r2 = to_row(rect.y + rect.height, options.scale_y);
+
+    for row in r1..=r2 {
+        for col in c1..=c2 {
+            buf.write_char(row, col, '\u{2588}');
+        }
+    }
+}
+
+/// Render a paint scene to a terminal-friendly string.
+pub fn render(scene: &PaintScene, options: AsciiOptions) -> Result<String, PaintVmAsciiError> {
+    let cols = (scene.width / options.scale_x as f64).ceil() as usize;
+    let rows = (scene.height / options.scale_y as f64).ceil() as usize;
+    let mut buf = CharBuffer::new(rows, cols);
+
+    for instruction in &scene.instructions {
+        match instruction {
+            PaintInstruction::Rect(rect) => render_rect(rect, &mut buf, options),
+            PaintInstruction::Ellipse(_) => {
+                return Err(PaintVmAsciiError::UnsupportedInstruction("ellipse"))
+            }
+            PaintInstruction::Path(_) => {
+                return Err(PaintVmAsciiError::UnsupportedInstruction("path"))
+            }
+            PaintInstruction::GlyphRun(_) => {
+                return Err(PaintVmAsciiError::UnsupportedInstruction("glyph_run"))
+            }
+            PaintInstruction::Group(_) => {
+                return Err(PaintVmAsciiError::UnsupportedInstruction("group"))
+            }
+            PaintInstruction::Layer(_) => {
+                return Err(PaintVmAsciiError::UnsupportedInstruction("layer"))
+            }
+            PaintInstruction::Line(_) => {
+                return Err(PaintVmAsciiError::UnsupportedInstruction("line"))
+            }
+            PaintInstruction::Clip(_) => {
+                return Err(PaintVmAsciiError::UnsupportedInstruction("clip"))
+            }
+            PaintInstruction::Gradient(_) => {
+                return Err(PaintVmAsciiError::UnsupportedInstruction("gradient"))
+            }
+            PaintInstruction::Image(_) => {
+                return Err(PaintVmAsciiError::UnsupportedInstruction("image"))
+            }
+        }
+    }
+
+    Ok(buf.to_text())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use paint_instructions::{PaintInstruction, PaintLine};
+
+    #[test]
+    fn version_matches() {
+        assert_eq!(VERSION, "0.1.0");
+    }
+
+    #[test]
+    fn renders_filled_rect() {
+        let scene = PaintScene {
+            width: 3.0,
+            height: 2.0,
+            background: "#ffffff".to_string(),
+            instructions: vec![PaintInstruction::Rect(PaintRect::filled(
+                0.0, 0.0, 2.0, 1.0, "#000000",
+            ))],
+            id: None,
+            metadata: None,
+        };
+
+        let output = render(
+            &scene,
+            AsciiOptions {
+                scale_x: 1,
+                scale_y: 1,
+            },
+        )
+        .expect("rect scene should render");
+
+        assert!(output.contains('\u{2588}'));
+    }
+
+    #[test]
+    fn rejects_unsupported_instruction_kinds() {
+        let scene = PaintScene {
+            width: 3.0,
+            height: 2.0,
+            background: "#ffffff".to_string(),
+            instructions: vec![PaintInstruction::Line(PaintLine {
+                base: Default::default(),
+                x1: 0.0,
+                y1: 0.0,
+                x2: 2.0,
+                y2: 0.0,
+                stroke: "#000000".to_string(),
+                stroke_width: None,
+                stroke_cap: None,
+            })],
+            id: None,
+            metadata: None,
+        };
+
+        let err = render(&scene, AsciiOptions::default()).unwrap_err();
+        assert_eq!(err, PaintVmAsciiError::UnsupportedInstruction("line"));
+    }
+}

--- a/code/packages/typescript/paint-instructions/CHANGELOG.md
+++ b/code/packages/typescript/paint-instructions/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog — @coding-adventures/paint-instructions
 
+## Unreleased
+
+### Fixed
+
+- import the `PixelContainer` type locally as well as re-exporting it so sibling TypeScript packages can type-check against `paintImage()` and `PaintImage.src`
+
 ## 0.1.0 — 2026-04-03
 
 Initial release implementing the P2D00 PaintInstructions IR spec.

--- a/code/packages/typescript/paint-instructions/src/index.ts
+++ b/code/packages/typescript/paint-instructions/src/index.ts
@@ -35,6 +35,8 @@
  */
 export const VERSION = "0.1.0";
 
+import type { PixelContainer } from "@coding-adventures/pixel-container";
+
 // ============================================================================
 // PaintBase — shared fields on every instruction
 // ============================================================================

--- a/code/packages/typescript/paint-vm-ascii/BUILD
+++ b/code/packages/typescript/paint-vm-ascii/BUILD
@@ -1,0 +1,5 @@
+cd ../pixel-container && npm install --silent
+cd ../paint-instructions && npm install --silent
+cd ../paint-vm && npm install --silent
+npm install --silent
+npx vitest run --coverage

--- a/code/packages/typescript/paint-vm-ascii/CHANGELOG.md
+++ b/code/packages/typescript/paint-vm-ascii/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- add the initial PaintVM ASCII backend
+- render rects, lines, glyph runs, groups, clips, and plain layers to text
+- add tests for clipping, intersections, and PaintVM integration

--- a/code/packages/typescript/paint-vm-ascii/README.md
+++ b/code/packages/typescript/paint-vm-ascii/README.md
@@ -1,0 +1,33 @@
+# @coding-adventures/paint-vm-ascii
+
+Terminal/ASCII backend for `paint-vm`.
+
+This package executes a `PaintScene` into a Unicode character grid using:
+
+- box-drawing characters for strokes and lines
+- block characters for fills
+- direct character placement for `glyph_run`
+
+## Usage
+
+```typescript
+import { paintRect, paintScene } from "@coding-adventures/paint-instructions";
+import { renderToAscii } from "@coding-adventures/paint-vm-ascii";
+
+const scene = paintScene(5, 3, "#ffffff", [
+  paintRect(0, 0, 4, 2, { fill: "transparent", stroke: "#000000" }),
+]);
+
+console.log(renderToAscii(scene, { scaleX: 1, scaleY: 1 }));
+```
+
+## Supported kinds
+
+- `rect`
+- `line`
+- `glyph_run`
+- `group`
+- `clip`
+- plain `layer` values with no filters, transforms, or non-default opacity
+
+Unsupported features fail loudly.

--- a/code/packages/typescript/paint-vm-ascii/package-lock.json
+++ b/code/packages/typescript/paint-vm-ascii/package-lock.json
@@ -1,0 +1,2513 @@
+{
+  "name": "@coding-adventures/paint-vm-ascii",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/paint-vm-ascii",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/paint-instructions": "file:../paint-instructions",
+        "@coding-adventures/paint-vm": "file:../paint-vm"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../draw-instructions": {
+      "name": "@coding-adventures/draw-instructions",
+      "version": "0.1.0",
+      "extraneous": true,
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../paint-instructions": {
+      "name": "@coding-adventures/paint-instructions",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/pixel-container": "file:../pixel-container"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../paint-vm": {
+      "name": "@coding-adventures/paint-vm",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/paint-instructions": "file:../paint-instructions"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@coding-adventures/paint-instructions": {
+      "resolved": "../paint-instructions",
+      "link": true
+    },
+    "node_modules/@coding-adventures/paint-vm": {
+      "resolved": "../paint-vm",
+      "link": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/paint-vm-ascii/package.json
+++ b/code/packages/typescript/paint-vm-ascii/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@coding-adventures/paint-vm-ascii",
+  "version": "0.1.0",
+  "description": "Terminal/ASCII backend for PaintVM",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "dependencies": {
+    "@coding-adventures/paint-instructions": "file:../paint-instructions",
+    "@coding-adventures/paint-vm": "file:../paint-vm"
+  },
+  "devDependencies": {
+    "@vitest/coverage-v8": "^3.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/paint-vm-ascii/src/index.ts
+++ b/code/packages/typescript/paint-vm-ascii/src/index.ts
@@ -1,0 +1,410 @@
+/**
+ * @coding-adventures/paint-vm-ascii
+ *
+ * Terminal/ASCII backend for PaintVM.
+ *
+ * This backend executes a PaintScene into a character grid using Unicode
+ * box-drawing characters, block fills, and direct glyph placement. It is the
+ * text-mode counterpart to the SVG and Canvas backends.
+ */
+
+import { ExportNotSupportedError, PaintVM } from "@coding-adventures/paint-vm";
+import type {
+  PaintClip,
+  PaintGlyphRun,
+  PaintGroup,
+  PaintInstruction,
+  PaintLayer,
+  PaintLine,
+  PaintRect,
+  PaintScene,
+} from "@coding-adventures/paint-instructions";
+
+export const VERSION = "0.1.0";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface AsciiOptions {
+  scaleX?: number;
+  scaleY?: number;
+}
+
+export interface AsciiContext {
+  buffer: CharBuffer;
+  clipStack: ClipBounds[];
+}
+
+// ---------------------------------------------------------------------------
+// Direction flags
+// ---------------------------------------------------------------------------
+
+const UP = 1;
+const RIGHT = 2;
+const DOWN = 4;
+const LEFT = 8;
+const FILL = 16;
+const TEXT = 32;
+
+interface ClipBounds {
+  minCol: number;
+  minRow: number;
+  maxCol: number;
+  maxRow: number;
+}
+
+const BOX_CHARS: Record<number, string> = {
+  [LEFT | RIGHT]: "─",
+  [UP | DOWN]: "│",
+  [DOWN | RIGHT]: "┌",
+  [DOWN | LEFT]: "┐",
+  [UP | RIGHT]: "└",
+  [UP | LEFT]: "┘",
+  [LEFT | RIGHT | DOWN]: "┬",
+  [LEFT | RIGHT | UP]: "┴",
+  [UP | DOWN | RIGHT]: "├",
+  [UP | DOWN | LEFT]: "┤",
+  [UP | DOWN | LEFT | RIGHT]: "┼",
+  [RIGHT]: "─",
+  [LEFT]: "─",
+  [UP]: "│",
+  [DOWN]: "│",
+};
+
+function resolveBoxChar(tag: number): string {
+  if (tag & FILL) return "█";
+  if (tag & TEXT) return "";
+  return BOX_CHARS[tag & (UP | DOWN | LEFT | RIGHT)] ?? "+";
+}
+
+// ---------------------------------------------------------------------------
+// Buffer
+// ---------------------------------------------------------------------------
+
+class CharBuffer {
+  readonly rows: number;
+  readonly cols: number;
+  private readonly chars: string[][];
+  private readonly tags: number[][];
+
+  constructor(rows: number, cols: number) {
+    this.rows = rows;
+    this.cols = cols;
+    this.chars = Array.from({ length: rows }, () =>
+      Array.from({ length: cols }, () => " "),
+    );
+    this.tags = Array.from({ length: rows }, () =>
+      Array.from({ length: cols }, () => 0),
+    );
+  }
+
+  writeTag(row: number, col: number, dirFlags: number, clip: ClipBounds): void {
+    if (row < clip.minRow || row >= clip.maxRow) return;
+    if (col < clip.minCol || col >= clip.maxCol) return;
+    if (row < 0 || row >= this.rows || col < 0 || col >= this.cols) return;
+
+    const existing = this.tags[row]![col]!;
+    if (existing & TEXT) return;
+
+    const merged = existing | dirFlags;
+    this.tags[row]![col] = merged;
+    this.chars[row]![col] = dirFlags & FILL ? "█" : resolveBoxChar(merged);
+  }
+
+  writeChar(row: number, col: number, ch: string, clip: ClipBounds): void {
+    if (row < clip.minRow || row >= clip.maxRow) return;
+    if (col < clip.minCol || col >= clip.maxCol) return;
+    if (row < 0 || row >= this.rows || col < 0 || col >= this.cols) return;
+
+    this.chars[row]![col] = ch;
+    this.tags[row]![col] = TEXT;
+  }
+
+  toString(): string {
+    return this.chars
+      .map((row) => row.join("").trimEnd())
+      .join("\n")
+      .trimEnd();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function toCol(x: number, scaleX: number): number {
+  return Math.round(x / scaleX);
+}
+
+function toRow(y: number, scaleY: number): number {
+  return Math.round(y / scaleY);
+}
+
+function topClip(ctx: AsciiContext): ClipBounds {
+  return ctx.clipStack[ctx.clipStack.length - 1]!;
+}
+
+function fullClip(cols: number, rows: number): ClipBounds {
+  return { minCol: 0, minRow: 0, maxCol: cols, maxRow: rows };
+}
+
+function isIdentityTransform(
+  transform: [number, number, number, number, number, number] | undefined,
+): boolean {
+  return (
+    transform === undefined ||
+    (transform[0] === 1 &&
+      transform[1] === 0 &&
+      transform[2] === 0 &&
+      transform[3] === 1 &&
+      transform[4] === 0 &&
+      transform[5] === 0)
+  );
+}
+
+function assertPlainGroup(group: PaintGroup): void {
+  if (!isIdentityTransform(group.transform)) {
+    throw new Error("paint-vm-ascii does not support transformed groups");
+  }
+  if (group.opacity !== undefined && group.opacity !== 1) {
+    throw new Error("paint-vm-ascii does not support group opacity");
+  }
+}
+
+function assertPlainLayer(layer: PaintLayer): void {
+  if (!isIdentityTransform(layer.transform)) {
+    throw new Error("paint-vm-ascii does not support transformed layers");
+  }
+  if (layer.opacity !== undefined && layer.opacity !== 1) {
+    throw new Error("paint-vm-ascii does not support layer opacity");
+  }
+  if (layer.filters && layer.filters.length > 0) {
+    throw new Error("paint-vm-ascii does not support layer filters");
+  }
+  if (layer.blend_mode && layer.blend_mode !== "normal") {
+    throw new Error("paint-vm-ascii does not support layer blend modes");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+function handleRect(
+  inst: PaintRect,
+  ctx: AsciiContext,
+  scaleX: number,
+  scaleY: number,
+): void {
+  const clip = topClip(ctx);
+  const c1 = toCol(inst.x, scaleX);
+  const r1 = toRow(inst.y, scaleY);
+  const c2 = toCol(inst.x + inst.width, scaleX);
+  const r2 = toRow(inst.y + inst.height, scaleY);
+
+  const hasStroke = inst.stroke !== undefined && inst.stroke !== "";
+  const hasFill =
+    inst.fill !== undefined &&
+    inst.fill !== "" &&
+    inst.fill !== "transparent" &&
+    inst.fill !== "none";
+
+  if (hasFill) {
+    for (let r = r1; r <= r2; r++) {
+      for (let c = c1; c <= c2; c++) {
+        ctx.buffer.writeTag(r, c, FILL, clip);
+      }
+    }
+  }
+
+  if (!hasStroke) return;
+
+  ctx.buffer.writeTag(r1, c1, DOWN | RIGHT, clip);
+  ctx.buffer.writeTag(r1, c2, DOWN | LEFT, clip);
+  ctx.buffer.writeTag(r2, c1, UP | RIGHT, clip);
+  ctx.buffer.writeTag(r2, c2, UP | LEFT, clip);
+
+  for (let c = c1 + 1; c < c2; c++) {
+    ctx.buffer.writeTag(r1, c, LEFT | RIGHT, clip);
+    ctx.buffer.writeTag(r2, c, LEFT | RIGHT, clip);
+  }
+
+  for (let r = r1 + 1; r < r2; r++) {
+    ctx.buffer.writeTag(r, c1, UP | DOWN, clip);
+    ctx.buffer.writeTag(r, c2, UP | DOWN, clip);
+  }
+}
+
+function handleLine(
+  inst: PaintLine,
+  ctx: AsciiContext,
+  scaleX: number,
+  scaleY: number,
+): void {
+  const clip = topClip(ctx);
+  const c1 = toCol(inst.x1, scaleX);
+  const r1 = toRow(inst.y1, scaleY);
+  const c2 = toCol(inst.x2, scaleX);
+  const r2 = toRow(inst.y2, scaleY);
+
+  if (r1 === r2) {
+    const minC = Math.min(c1, c2);
+    const maxC = Math.max(c1, c2);
+    for (let c = minC; c <= maxC; c++) {
+      let flags = 0;
+      if (c > minC) flags |= LEFT;
+      if (c < maxC) flags |= RIGHT;
+      if (c === minC && c === maxC) flags = LEFT | RIGHT;
+      ctx.buffer.writeTag(r1, c, flags, clip);
+    }
+    return;
+  }
+
+  if (c1 === c2) {
+    const minR = Math.min(r1, r2);
+    const maxR = Math.max(r1, r2);
+    for (let r = minR; r <= maxR; r++) {
+      let flags = 0;
+      if (r > minR) flags |= UP;
+      if (r < maxR) flags |= DOWN;
+      if (r === minR && r === maxR) flags = UP | DOWN;
+      ctx.buffer.writeTag(r, c1, flags, clip);
+    }
+    return;
+  }
+
+  const dr = Math.abs(r2 - r1);
+  const dc = Math.abs(c2 - c1);
+  const sr = r1 < r2 ? 1 : -1;
+  const sc = c1 < c2 ? 1 : -1;
+  let err = dc - dr;
+  let r = r1;
+  let c = c1;
+
+  while (true) {
+    ctx.buffer.writeTag(r, c, dc > dr ? LEFT | RIGHT : UP | DOWN, clip);
+    if (r === r2 && c === c2) break;
+    const e2 = 2 * err;
+    if (e2 > -dr) {
+      err -= dr;
+      c += sc;
+    }
+    if (e2 < dc) {
+      err += dc;
+      r += sr;
+    }
+  }
+}
+
+function handleGlyphRun(
+  inst: PaintGlyphRun,
+  ctx: AsciiContext,
+  scaleX: number,
+  scaleY: number,
+): void {
+  const clip = topClip(ctx);
+  for (const glyph of inst.glyphs) {
+    let ch = "?";
+    try {
+      ch = String.fromCodePoint(glyph.glyph_id);
+    } catch {
+      ch = "?";
+    }
+    ctx.buffer.writeChar(toRow(glyph.y, scaleY), toCol(glyph.x, scaleX), ch, clip);
+  }
+}
+
+function handleClip(
+  inst: PaintClip,
+  ctx: AsciiContext,
+  vm: PaintVM<AsciiContext>,
+  scaleX: number,
+  scaleY: number,
+): void {
+  const parent = topClip(ctx);
+  const next: ClipBounds = {
+    minCol: Math.max(parent.minCol, toCol(inst.x, scaleX)),
+    minRow: Math.max(parent.minRow, toRow(inst.y, scaleY)),
+    maxCol: Math.min(parent.maxCol, toCol(inst.x + inst.width, scaleX)),
+    maxRow: Math.min(parent.maxRow, toRow(inst.y + inst.height, scaleY)),
+  };
+  ctx.clipStack.push(next);
+  try {
+    for (const child of inst.children) vm.dispatch(child, ctx);
+  } finally {
+    ctx.clipStack.pop();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function createAsciiContext(): AsciiContext {
+  return {
+    buffer: new CharBuffer(0, 0),
+    clipStack: [fullClip(0, 0)],
+  };
+}
+
+export function createAsciiVM(options: AsciiOptions = {}): PaintVM<AsciiContext> {
+  const scaleX = options.scaleX ?? 8;
+  const scaleY = options.scaleY ?? 16;
+
+  const vm = new PaintVM<AsciiContext>(
+    (ctx, _background, width, height) => {
+      const cols = Math.ceil(width / scaleX);
+      const rows = Math.ceil(height / scaleY);
+      ctx.buffer = new CharBuffer(rows, cols);
+      ctx.clipStack = [fullClip(cols, rows)];
+    },
+    () => {
+      throw new ExportNotSupportedError("paint-vm-ascii");
+    },
+  );
+
+  vm.register("rect", (instruction, ctx) => {
+    if (instruction.kind !== "rect") return;
+    handleRect(instruction, ctx, scaleX, scaleY);
+  });
+
+  vm.register("line", (instruction, ctx) => {
+    if (instruction.kind !== "line") return;
+    handleLine(instruction, ctx, scaleX, scaleY);
+  });
+
+  vm.register("glyph_run", (instruction, ctx) => {
+    if (instruction.kind !== "glyph_run") return;
+    handleGlyphRun(instruction, ctx, scaleX, scaleY);
+  });
+
+  vm.register("group", (instruction, ctx, innerVm) => {
+    if (instruction.kind !== "group") return;
+    assertPlainGroup(instruction);
+    for (const child of instruction.children) innerVm.dispatch(child, ctx);
+  });
+
+  vm.register("clip", (instruction, ctx, innerVm) => {
+    if (instruction.kind !== "clip") return;
+    handleClip(instruction, ctx, innerVm, scaleX, scaleY);
+  });
+
+  vm.register("layer", (instruction, ctx, innerVm) => {
+    if (instruction.kind !== "layer") return;
+    assertPlainLayer(instruction);
+    for (const child of instruction.children) innerVm.dispatch(child, ctx);
+  });
+
+  return vm;
+}
+
+export function renderToAscii(
+  scene: PaintScene,
+  options: AsciiOptions = {},
+): string {
+  const vm = createAsciiVM(options);
+  const ctx = createAsciiContext();
+  vm.execute(scene, ctx);
+  return ctx.buffer.toString();
+}

--- a/code/packages/typescript/paint-vm-ascii/src/index.ts
+++ b/code/packages/typescript/paint-vm-ascii/src/index.ts
@@ -149,6 +149,17 @@ function fullClip(cols: number, rows: number): ClipBounds {
   return { minCol: 0, minRow: 0, maxCol: cols, maxRow: rows };
 }
 
+function isSafeTerminalCodePoint(codePoint: number): boolean {
+  if (codePoint < 0x20) return false;
+  if (codePoint >= 0x7f && codePoint <= 0x9f) return false;
+  if (codePoint === 0x200e || codePoint === 0x200f || codePoint === 0x061c) {
+    return false;
+  }
+  if (codePoint >= 0x202a && codePoint <= 0x202e) return false;
+  if (codePoint >= 0x2066 && codePoint <= 0x2069) return false;
+  return true;
+}
+
 function isIdentityTransform(
   transform: [number, number, number, number, number, number] | undefined,
 ): boolean {
@@ -307,7 +318,9 @@ function handleGlyphRun(
   for (const glyph of inst.glyphs) {
     let ch = "?";
     try {
-      ch = String.fromCodePoint(glyph.glyph_id);
+      ch = isSafeTerminalCodePoint(glyph.glyph_id)
+        ? String.fromCodePoint(glyph.glyph_id)
+        : "?";
     } catch {
       ch = "?";
     }

--- a/code/packages/typescript/paint-vm-ascii/tests/paint-vm-ascii.test.ts
+++ b/code/packages/typescript/paint-vm-ascii/tests/paint-vm-ascii.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import {
+  paintClip,
+  paintGroup,
+  paintLine,
+  paintRect,
+  paintScene,
+} from "@coding-adventures/paint-instructions";
+import { VERSION, createAsciiContext, createAsciiVM, renderToAscii } from "../src/index.js";
+
+describe("VERSION", () => {
+  it("is 0.1.0", () => {
+    expect(VERSION).toBe("0.1.0");
+  });
+});
+
+describe("renderToAscii()", () => {
+  const opts = { scaleX: 1, scaleY: 1 };
+
+  it("draws a stroked rectangle", () => {
+    const scene = paintScene(5, 3, "#fff", [
+      paintRect(0, 0, 4, 2, { fill: "transparent", stroke: "#000", stroke_width: 1 }),
+    ]);
+    expect(renderToAscii(scene, opts)).toBe("┌───┐\n│   │\n└───┘");
+  });
+
+  it("fills a rectangle with block characters", () => {
+    const scene = paintScene(3, 2, "#fff", [
+      paintRect(0, 0, 2, 1, { fill: "#000" }),
+    ]);
+    expect(renderToAscii(scene, opts)).toContain("█");
+  });
+
+  it("renders horizontal and vertical lines with intersections", () => {
+    const scene = paintScene(5, 3, "#fff", [
+      paintLine(0, 1, 4, 1, "#000"),
+      paintLine(2, 0, 2, 2, "#000"),
+    ]);
+    const lines = renderToAscii(scene, opts).split("\n");
+    expect(lines[0]![2]).toBe("│");
+    expect(lines[1]![2]).toBe("┼");
+    expect(lines[2]![2]).toBe("│");
+  });
+
+  it("renders glyph runs as direct characters", () => {
+    const scene = paintScene(5, 1, "#fff", [
+      {
+        kind: "glyph_run",
+        glyphs: [
+          { glyph_id: "H".codePointAt(0)!, x: 0, y: 0 },
+          { glyph_id: "i".codePointAt(0)!, x: 1, y: 0 },
+        ],
+        font_ref: "mono",
+        font_size: 12,
+      },
+    ]);
+    expect(renderToAscii(scene, opts)).toBe("Hi");
+  });
+
+  it("clips child output", () => {
+    const scene = paintScene(10, 1, "#fff", [
+      paintClip(0, 0, 3, 1, [
+        {
+          kind: "glyph_run",
+          glyphs: [
+            { glyph_id: "H".codePointAt(0)!, x: 0, y: 0 },
+            { glyph_id: "e".codePointAt(0)!, x: 1, y: 0 },
+            { glyph_id: "l".codePointAt(0)!, x: 2, y: 0 },
+            { glyph_id: "l".codePointAt(0)!, x: 3, y: 0 },
+            { glyph_id: "o".codePointAt(0)!, x: 4, y: 0 },
+          ],
+          font_ref: "mono",
+          font_size: 12,
+        },
+      ]),
+    ]);
+    expect(renderToAscii(scene, opts)).toBe("Hel");
+  });
+
+  it("recurses through plain groups and layers", () => {
+    const scene = paintScene(5, 1, "#fff", [
+      paintGroup([
+        {
+          kind: "layer",
+          children: [
+            {
+              kind: "glyph_run",
+              glyphs: [
+                { glyph_id: "A".codePointAt(0)!, x: 0, y: 0 },
+                { glyph_id: "B".codePointAt(0)!, x: 1, y: 0 },
+              ],
+              font_ref: "mono",
+              font_size: 12,
+            },
+          ],
+        },
+        {
+          kind: "glyph_run",
+          glyphs: [
+            { glyph_id: "C".codePointAt(0)!, x: 3, y: 0 },
+            { glyph_id: "D".codePointAt(0)!, x: 4, y: 0 },
+          ],
+          font_ref: "mono",
+          font_size: 12,
+        },
+      ]),
+    ]);
+    expect(renderToAscii(scene, opts)).toBe("AB CD");
+  });
+
+  it("rejects transformed groups", () => {
+    const scene = paintScene(5, 1, "#fff", [
+      paintGroup([], { transform: [1, 0, 0, 1, 1, 0] }),
+    ]);
+    expect(() => renderToAscii(scene, opts)).toThrow(/transformed groups/);
+  });
+});
+
+describe("createAsciiVM()", () => {
+  it("executes through the PaintVM interface", () => {
+    const vm = createAsciiVM({ scaleX: 1, scaleY: 1 });
+    const ctx = createAsciiContext();
+    const scene = paintScene(2, 1, "#fff", [
+      {
+        kind: "glyph_run",
+        glyphs: [{ glyph_id: "O".codePointAt(0)!, x: 0, y: 0 }],
+        font_ref: "mono",
+        font_size: 12,
+      },
+    ]);
+    vm.execute(scene, ctx);
+    expect(ctx.buffer.toString()).toBe("O");
+  });
+});

--- a/code/packages/typescript/paint-vm-ascii/tests/paint-vm-ascii.test.ts
+++ b/code/packages/typescript/paint-vm-ascii/tests/paint-vm-ascii.test.ts
@@ -57,6 +57,21 @@ describe("renderToAscii()", () => {
     expect(renderToAscii(scene, opts)).toBe("Hi");
   });
 
+  it("replaces unsafe terminal control glyphs", () => {
+    const scene = paintScene(2, 1, "#fff", [
+      {
+        kind: "glyph_run",
+        glyphs: [
+          { glyph_id: 0x1b, x: 0, y: 0 },
+          { glyph_id: "A".codePointAt(0)!, x: 1, y: 0 },
+        ],
+        font_ref: "mono",
+        font_size: 12,
+      },
+    ]);
+    expect(renderToAscii(scene, opts)).toBe("?A");
+  });
+
   it("clips child output", () => {
     const scene = paintScene(10, 1, "#fff", [
       paintClip(0, 0, 3, 1, [

--- a/code/packages/typescript/paint-vm-ascii/tsconfig.json
+++ b/code/packages/typescript/paint-vm-ascii/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/paint-vm-ascii/vitest.config.ts
+++ b/code/packages/typescript/paint-vm-ascii/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      thresholds: {
+        lines: 80,
+      },
+    },
+  },
+});

--- a/code/specs/P2D02-paint-vm-ascii.md
+++ b/code/specs/P2D02-paint-vm-ascii.md
@@ -1,0 +1,161 @@
+# P2D02 — PaintVM ASCII Backend
+
+## Overview
+
+`paint-vm-ascii` is the terminal/text backend for the PaintVM family. It
+executes a `PaintScene` and produces a plain string made from Unicode
+box-drawing characters, block fill characters, and literal text glyphs.
+
+This backend matters for two reasons:
+
+1. It proves the paint IR is not tied to pixel or vector output.
+2. It gives the future document pipeline a text-mode target:
+
+```text
+Doc
+  -> layout tree
+  -> PaintScene
+  -> paint-vm-ascii
+  -> terminal string
+```
+
+`paint-vm-ascii` is the canonical text-mode PaintVM backend. The older
+`draw-instructions-text` packages are deprecated and should not receive new
+features.
+
+---
+
+## Output Model
+
+The backend maps scene coordinates to a fixed-width character grid:
+
+```text
+char_col = round(scene_x / scale_x)
+char_row = round(scene_y / scale_y)
+```
+
+Default scale factors:
+
+- `scale_x = 8`
+- `scale_y = 16`
+
+These defaults roughly match monospace glyph metrics and preserve the behavior
+of the older text renderer packages.
+
+---
+
+## Character Palette
+
+### Filled rectangles
+
+Filled cells use `█`.
+
+### Stroked rectangles and lines
+
+The backend uses box-drawing characters:
+
+- `┌` `┐` `└` `┘`
+- `─` `│`
+- `┬` `┴` `├` `┤`
+- `┼`
+
+### Glyph runs
+
+`glyph_run` is rendered by converting each `glyph_id` into a Unicode scalar
+value and writing that character directly into the grid at the glyph's mapped
+position.
+
+This backend intentionally ignores `font_ref`, `font_size`, and `fill`. In a
+terminal there is no general way to honor arbitrary font selection or precise
+glyph shaping.
+
+This means `paint-vm-ascii` is best suited to glyph runs whose `glyph_id`
+values are already ordinary Unicode code points.
+
+---
+
+## Supported Instructions
+
+The canonical backend behavior is:
+
+| Kind | Behavior |
+|---|---|
+| `rect` | fill and/or stroke via block and box-drawing characters |
+| `line` | horizontal/vertical line drawing, diagonal approximation allowed |
+| `glyph_run` | direct character placement from `glyph_id` |
+| `group` | recurse into children |
+| `clip` | intersect clip bounds, recurse into children |
+| `layer` | recurse only when it carries no filters, blend mode, transform, or non-default opacity |
+
+Unsupported instructions must fail loudly with an error rather than degrade
+silently.
+
+Examples:
+
+- `gradient` -> error
+- `image` -> error
+- transformed `group` -> error
+- filtered `layer` -> error
+
+This matches the PaintVM principle that unsupported instruction kinds or
+unsupported backend features are programmer errors, not silent no-ops.
+
+---
+
+## Rendering Rules
+
+### Background
+
+The scene background color is ignored. The terminal provides the background.
+
+### Stroke priority
+
+If a rectangle has both fill and stroke:
+
+- the border cells use box-drawing characters
+- interior cells use `█`
+
+### Text priority
+
+Literal glyphs overwrite box-drawing and fill characters already present in a
+cell. Later drawing operations must not overwrite an existing glyph cell.
+
+This preserves readable text inside boxes and tables.
+
+### Clipping
+
+`clip` instructions define rectangular clip regions in scene coordinates.
+Children can only write within the intersection of the parent clip and the new
+clip rectangle.
+
+### Trimming
+
+The final string:
+
+- trims trailing spaces on each line
+- trims trailing blank lines at the end of the document
+
+---
+
+## Public API
+
+Every language package should expose:
+
+- an options type with `scale_x` / `scale_y` equivalents
+- a convenience `render(scene, options?) -> string`
+
+Languages with a reusable PaintVM host should also expose:
+
+- `createAsciiVM()` or equivalent factory
+
+---
+
+## Porting Guidance
+
+The repository currently has different PaintVM maturity levels across
+languages. TypeScript has the full generic `paint-vm` package. Other languages
+may expose `paint-vm-ascii` as a direct renderer over `paint-instructions`
+until they grow a reusable VM host.
+
+That is acceptable. The important contract is the backend behavior, not that
+every port shares the same internal implementation structure on day one.

--- a/lessons.md
+++ b/lessons.md
@@ -4,6 +4,23 @@ This file tracks mistakes made during development so they are not repeated. Chec
 
 ---
 
+### 2026-04-18: Lua rockspecs must pin immutable source refs, not just HTTPS URLs
+
+Switching a Lua rockspec from `git://` to `https://` fixes transport security,
+but it does not make installs reproducible. If the rockspec points at a moving
+branch tip with no immutable tag or commit, the published package version can
+resolve to different source code over time.
+
+**Symptom:** Security review flags a supply-chain integrity issue because a
+`0.1.0-1` rockspec can fetch whatever happens to be at the repository head at
+install time.
+
+**Rule:** Every Lua rockspec that installs from GitHub must use `https://` and
+must pin the `source` table to an immutable git ref, such as a release tag or
+commit SHA.
+
+---
+
 ### 2026-04-17: Use a fresh git worktree before editing shared manifests in a noisy repo
 
 When a worktree already contains unrelated untracked package directories or


### PR DESCRIPTION
## Summary
- add a `paint-vm-ascii` backend spec and new backend packages across TypeScript, Go, Python, Perl, Rust, Lua, Elixir, and Ruby
- make TypeScript the reference implementation with richer Paint VM coverage, while matching the current rect-oriented paint instruction surface in the other language ports
- harden terminal output by sanitizing unsafe glyph code points and pin the Lua rockspec to an immutable HTTPS git ref

## Verification
- TypeScript: `npx tsc --noEmit` and `npx vitest run --coverage`
- Go: `go test ./... -v -cover` and `go vet ./...`
- Rust: `cargo test -p paint-vm-ascii -- --nocapture`
- Perl: `prove -l -I../paint-instructions/lib -v t/`
- Ruby: `ruby -Ilib -I../paint_instructions/lib test/test_paint_vm_ascii.rb`

## Notes
- Python implementation is included, but local verification was blocked by the host only having Python 3.9.6 while the package targets newer tooling.
- Elixir and Lua implementations are included, but local verification was blocked here because `mix`/`elixir` and `lua`/`luarocks`/`busted` are not installed in this environment.