### PR TITLE
feat(dotnet-compression): add deflate packages

### DIFF
--- a/code/packages/csharp/deflate/BUILD
+++ b/code/packages/csharp/deflate/BUILD
@@ -1,0 +1,1 @@
+mkdir -p .dotnet .artifacts && HOME="$PWD/.dotnet" DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_CLI_HOME="$PWD/.dotnet" dotnet test tests/CodingAdventures.Deflate.Tests/CodingAdventures.Deflate.Tests.csproj --disable-build-servers --artifacts-path .artifacts /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/deflate/BUILD_windows
+++ b/code/packages/csharp/deflate/BUILD_windows
@@ -1,0 +1,1 @@
+if not exist ".dotnet" mkdir ".dotnet" && if not exist ".artifacts" mkdir ".artifacts" && set "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1" && set "DOTNET_CLI_HOME=%CD%\.dotnet" && dotnet test "tests/CodingAdventures.Deflate.Tests/CodingAdventures.Deflate.Tests.csproj" --disable-build-servers --artifacts-path ".artifacts" /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/deflate/CHANGELOG.md
+++ b/code/packages/csharp/deflate/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-18
+
+### Added
+
+- Pure C# CMP05 DEFLATE implementation built from the native `.NET` `lzss` and `huffman-tree` packages
+- Combined literal/length and distance canonical Huffman coding with LSB-first bit packing
+- CMP05 header and code-length table encoding plus matching decompression support
+- xUnit coverage for empty input, literal-only streams, match-bearing streams, binary round trips, and compression sanity checks

--- a/code/packages/csharp/deflate/CodingAdventures.Deflate.csproj
+++ b/code/packages/csharp/deflate/CodingAdventures.Deflate.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.Deflate.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure C# DEFLATE compression in the repo's CMP05 wire format</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\huffman-tree\CodingAdventures.HuffmanTree.csproj" />
+    <ProjectReference Include="..\lzss\CodingAdventures.Lzss.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/deflate/Deflate.cs
+++ b/code/packages/csharp/deflate/Deflate.cs
@@ -1,0 +1,435 @@
+using System.Buffers.Binary;
+using System.Text;
+using CodingAdventures.HuffmanTree;
+using CodingAdventures.Lzss;
+
+namespace CodingAdventures.Deflate;
+
+internal readonly record struct LengthEntry(int Symbol, int Base, int ExtraBits);
+
+internal readonly record struct DistEntry(int Code, int Base, int ExtraBits);
+
+internal sealed class BitBuilder
+{
+    private int _buffer;
+    private int _bitPos;
+    private readonly List<byte> _output = [];
+
+    public void WriteBitString(string bits)
+    {
+        foreach (var bit in bits)
+        {
+            if (bit == '1')
+            {
+                _buffer |= 1 << _bitPos;
+            }
+
+            _bitPos++;
+            if (_bitPos == 8)
+            {
+                _output.Add((byte)(_buffer & 0xFF));
+                _buffer = 0;
+                _bitPos = 0;
+            }
+        }
+    }
+
+    public void WriteRawBitsLsb(int value, int count)
+    {
+        for (var index = 0; index < count; index++)
+        {
+            if (((value >> index) & 1) != 0)
+            {
+                _buffer |= 1 << _bitPos;
+            }
+
+            _bitPos++;
+            if (_bitPos == 8)
+            {
+                _output.Add((byte)(_buffer & 0xFF));
+                _buffer = 0;
+                _bitPos = 0;
+            }
+        }
+    }
+
+    public byte[] ToArray()
+    {
+        if (_bitPos > 0)
+        {
+            _output.Add((byte)(_buffer & 0xFF));
+            _buffer = 0;
+            _bitPos = 0;
+        }
+
+        return [.. _output];
+    }
+}
+
+public static class Deflate
+{
+    private static readonly LengthEntry[] LengthTable =
+    [
+        new(257, 3, 0), new(258, 4, 0), new(259, 5, 0), new(260, 6, 0),
+        new(261, 7, 0), new(262, 8, 0), new(263, 9, 0), new(264, 10, 0),
+        new(265, 11, 1), new(266, 13, 1), new(267, 15, 1), new(268, 17, 1),
+        new(269, 19, 2), new(270, 23, 2), new(271, 27, 2), new(272, 31, 2),
+        new(273, 35, 3), new(274, 43, 3), new(275, 51, 3), new(276, 59, 3),
+        new(277, 67, 4), new(278, 83, 4), new(279, 99, 4), new(280, 115, 4),
+        new(281, 131, 5), new(282, 163, 5), new(283, 195, 5), new(284, 227, 5)
+    ];
+
+    private static readonly DistEntry[] DistTable =
+    [
+        new(0, 1, 0), new(1, 2, 0), new(2, 3, 0), new(3, 4, 0),
+        new(4, 5, 1), new(5, 7, 1), new(6, 9, 2), new(7, 13, 2),
+        new(8, 17, 3), new(9, 25, 3), new(10, 33, 4), new(11, 49, 4),
+        new(12, 65, 5), new(13, 97, 5), new(14, 129, 6), new(15, 193, 6),
+        new(16, 257, 7), new(17, 385, 7), new(18, 513, 8), new(19, 769, 8),
+        new(20, 1025, 9), new(21, 1537, 9), new(22, 2049, 10), new(23, 3073, 10)
+    ];
+
+    public static byte[] Compress(
+        byte[] data,
+        int windowSize = Lzss.Lzss.DefaultWindowSize,
+        int maxMatch = Lzss.Lzss.DefaultMaxMatch,
+        int minMatch = Lzss.Lzss.DefaultMinMatch)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+
+        if (data.Length == 0)
+        {
+            var empty = new byte[12];
+            BinaryPrimitives.WriteUInt32BigEndian(empty.AsSpan(0, 4), 0u);
+            BinaryPrimitives.WriteUInt16BigEndian(empty.AsSpan(4, 2), 1);
+            BinaryPrimitives.WriteUInt16BigEndian(empty.AsSpan(6, 2), 0);
+            BinaryPrimitives.WriteUInt16BigEndian(empty.AsSpan(8, 2), 256);
+            empty[10] = 1;
+            empty[11] = 0;
+            return empty;
+        }
+
+        var tokens = Lzss.Lzss.Encode(data, windowSize, maxMatch, minMatch);
+        var llFreq = new Dictionary<int, int>();
+        var distFreq = new Dictionary<int, int>();
+
+        foreach (var token in tokens)
+        {
+            switch (token)
+            {
+                case LzssLiteral literal:
+                    llFreq[literal.Byte] = llFreq.GetValueOrDefault(literal.Byte) + 1;
+                    break;
+
+                case LzssMatch match:
+                {
+                    var lengthSymbol = FindLengthEntry(match.Length).Symbol;
+                    var distanceCode = FindDistEntry(match.Offset).Code;
+                    llFreq[lengthSymbol] = llFreq.GetValueOrDefault(lengthSymbol) + 1;
+                    distFreq[distanceCode] = distFreq.GetValueOrDefault(distanceCode) + 1;
+                    break;
+                }
+
+                default:
+                    throw new InvalidOperationException("Unknown LZSS token type");
+            }
+        }
+
+        llFreq[256] = llFreq.GetValueOrDefault(256) + 1;
+
+        var llTree = CodingAdventures.HuffmanTree.HuffmanTree.Build(llFreq.Select(pair => (pair.Key, pair.Value)));
+        var llCodes = llTree.CanonicalCodeTable();
+
+        IReadOnlyDictionary<int, string> distCodes = new Dictionary<int, string>();
+        if (distFreq.Count > 0)
+        {
+            var distTree = CodingAdventures.HuffmanTree.HuffmanTree.Build(distFreq.Select(pair => (pair.Key, pair.Value)));
+            distCodes = distTree.CanonicalCodeTable();
+        }
+
+        var bits = new BitBuilder();
+        foreach (var token in tokens)
+        {
+            switch (token)
+            {
+                case LzssLiteral literal:
+                    bits.WriteBitString(llCodes[literal.Byte]);
+                    break;
+
+                case LzssMatch match:
+                {
+                    var lengthEntry = FindLengthEntry(match.Length);
+                    bits.WriteBitString(llCodes[lengthEntry.Symbol]);
+                    bits.WriteRawBitsLsb(match.Length - lengthEntry.Base, lengthEntry.ExtraBits);
+
+                    var distEntry = FindDistEntry(match.Offset);
+                    bits.WriteBitString(distCodes[distEntry.Code]);
+                    bits.WriteRawBitsLsb(match.Offset - distEntry.Base, distEntry.ExtraBits);
+                    break;
+                }
+            }
+        }
+
+        bits.WriteBitString(llCodes[256]);
+        var packedBits = bits.ToArray();
+
+        var llPairs = llCodes
+            .Select(pair => (Symbol: pair.Key, Length: pair.Value.Length))
+            .OrderBy(pair => pair.Length)
+            .ThenBy(pair => pair.Symbol)
+            .ToList();
+
+        var distPairs = distCodes
+            .Select(pair => (Symbol: pair.Key, Length: pair.Value.Length))
+            .OrderBy(pair => pair.Length)
+            .ThenBy(pair => pair.Symbol)
+            .ToList();
+
+        var totalSize = 8 + (llPairs.Count * 3) + (distPairs.Count * 3) + packedBits.Length;
+        var output = new byte[totalSize];
+        BinaryPrimitives.WriteUInt32BigEndian(output.AsSpan(0, 4), (uint)data.Length);
+        BinaryPrimitives.WriteUInt16BigEndian(output.AsSpan(4, 2), (ushort)llPairs.Count);
+        BinaryPrimitives.WriteUInt16BigEndian(output.AsSpan(6, 2), (ushort)distPairs.Count);
+
+        var offset = 8;
+        foreach (var pair in llPairs)
+        {
+            BinaryPrimitives.WriteUInt16BigEndian(output.AsSpan(offset, 2), (ushort)pair.Symbol);
+            output[offset + 2] = (byte)pair.Length;
+            offset += 3;
+        }
+
+        foreach (var pair in distPairs)
+        {
+            BinaryPrimitives.WriteUInt16BigEndian(output.AsSpan(offset, 2), (ushort)pair.Symbol);
+            output[offset + 2] = (byte)pair.Length;
+            offset += 3;
+        }
+
+        packedBits.CopyTo(output, offset);
+        return output;
+    }
+
+    public static byte[] Decompress(byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        if (data.Length < 8)
+        {
+            return [];
+        }
+
+        var originalLength = (int)BinaryPrimitives.ReadUInt32BigEndian(data.AsSpan(0, 4));
+        var llEntryCount = BinaryPrimitives.ReadUInt16BigEndian(data.AsSpan(4, 2));
+        var distEntryCount = BinaryPrimitives.ReadUInt16BigEndian(data.AsSpan(6, 2));
+
+        if (originalLength == 0)
+        {
+            return [];
+        }
+
+        var offset = 8;
+        var llLengths = new List<(int Symbol, int Length)>();
+        for (var index = 0; index < llEntryCount; index++)
+        {
+            if (offset + 3 > data.Length)
+            {
+                return [];
+            }
+
+            llLengths.Add((
+                BinaryPrimitives.ReadUInt16BigEndian(data.AsSpan(offset, 2)),
+                data[offset + 2]));
+            offset += 3;
+        }
+
+        var distLengths = new List<(int Symbol, int Length)>();
+        for (var index = 0; index < distEntryCount; index++)
+        {
+            if (offset + 3 > data.Length)
+            {
+                return [];
+            }
+
+            distLengths.Add((
+                BinaryPrimitives.ReadUInt16BigEndian(data.AsSpan(offset, 2)),
+                data[offset + 2]));
+            offset += 3;
+        }
+
+        var llCodes = ReconstructCanonicalCodes(llLengths);
+        var distCodes = ReconstructCanonicalCodes(distLengths);
+        var bits = UnpackBits(data.AsSpan(offset));
+        var bitPos = 0;
+        var output = new List<byte>(originalLength);
+
+        while (true)
+        {
+            var llSymbol = NextHuffmanSymbol(llCodes, bits, ref bitPos);
+            if (llSymbol == 256)
+            {
+                break;
+            }
+
+            if (llSymbol < 256)
+            {
+                output.Add((byte)llSymbol);
+                continue;
+            }
+
+            var lengthEntry = FindLengthEntryBySymbol(llSymbol);
+            var length = lengthEntry.Base + ReadRawBits(bits, ref bitPos, lengthEntry.ExtraBits);
+
+            if (distCodes.Count == 0)
+            {
+                throw new InvalidOperationException("Compressed stream references distance codes without a distance tree");
+            }
+
+            var distSymbol = NextHuffmanSymbol(distCodes, bits, ref bitPos);
+            var distEntry = FindDistEntryByCode(distSymbol);
+            var distance = distEntry.Base + ReadRawBits(bits, ref bitPos, distEntry.ExtraBits);
+
+            var start = output.Count - distance;
+            if (start < 0)
+            {
+                throw new InvalidOperationException("Distance extends before the output buffer");
+            }
+
+            for (var index = 0; index < length; index++)
+            {
+                output.Add(output[start + index]);
+            }
+        }
+
+        return [.. output.Take(originalLength)];
+    }
+
+    private static LengthEntry FindLengthEntry(int length)
+    {
+        foreach (var entry in LengthTable)
+        {
+            var max = entry.Base + ((1 << entry.ExtraBits) - 1);
+            if (length <= max)
+            {
+                return entry;
+            }
+        }
+
+        return LengthTable[^1];
+    }
+
+    private static LengthEntry FindLengthEntryBySymbol(int symbol) =>
+        LengthTable.FirstOrDefault(entry => entry.Symbol == symbol) is var entry && entry.Symbol != 0
+            ? entry
+            : throw new InvalidOperationException($"Unknown length symbol {symbol}");
+
+    private static DistEntry FindDistEntry(int distance)
+    {
+        foreach (var entry in DistTable)
+        {
+            var max = entry.Base + ((1 << entry.ExtraBits) - 1);
+            if (distance <= max)
+            {
+                return entry;
+            }
+        }
+
+        return DistTable[^1];
+    }
+
+    private static DistEntry FindDistEntryByCode(int code) =>
+        DistTable.FirstOrDefault(entry => entry.Code == code) is var entry && entry.Base != 0
+            ? entry
+            : throw new InvalidOperationException($"Unknown distance symbol {code}");
+
+    private static Dictionary<string, int> ReconstructCanonicalCodes(IEnumerable<(int Symbol, int Length)> lengths)
+    {
+        var ordered = lengths
+            .Where(pair => pair.Length > 0)
+            .OrderBy(pair => pair.Length)
+            .ThenBy(pair => pair.Symbol)
+            .ToList();
+
+        var result = new Dictionary<string, int>();
+        if (ordered.Count == 0)
+        {
+            return result;
+        }
+
+        if (ordered.Count == 1)
+        {
+            result["0"] = ordered[0].Symbol;
+            return result;
+        }
+
+        var code = 0;
+        var previousLength = ordered[0].Length;
+        foreach (var (symbol, length) in ordered)
+        {
+            if (length > previousLength)
+            {
+                code <<= length - previousLength;
+            }
+
+            result[Convert.ToString(code, 2).PadLeft(length, '0')] = symbol;
+            code++;
+            previousLength = length;
+        }
+
+        return result;
+    }
+
+    private static string UnpackBits(ReadOnlySpan<byte> data)
+    {
+        var builder = new StringBuilder(data.Length * 8);
+        foreach (var value in data)
+        {
+            for (var bit = 0; bit < 8; bit++)
+            {
+                builder.Append(((value >> bit) & 1) != 0 ? '1' : '0');
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    private static int ReadRawBits(string bits, ref int bitPos, int count)
+    {
+        var value = 0;
+        for (var index = 0; index < count; index++)
+        {
+            if (bitPos + index >= bits.Length)
+            {
+                throw new InvalidOperationException("Unexpected end of compressed bit stream");
+            }
+
+            if (bits[bitPos + index] == '1')
+            {
+                value |= 1 << index;
+            }
+        }
+
+        bitPos += count;
+        return value;
+    }
+
+    private static int NextHuffmanSymbol(IReadOnlyDictionary<string, int> codes, string bits, ref int bitPos)
+    {
+        if (codes.Count == 0)
+        {
+            throw new InvalidOperationException("Missing Huffman codes");
+        }
+
+        var builder = new StringBuilder();
+        while (bitPos < bits.Length)
+        {
+            builder.Append(bits[bitPos]);
+            bitPos++;
+            if (codes.TryGetValue(builder.ToString(), out var symbol))
+            {
+                return symbol;
+            }
+        }
+
+        throw new InvalidOperationException("Unexpected end of compressed bit stream");
+    }
+}

--- a/code/packages/csharp/deflate/README.md
+++ b/code/packages/csharp/deflate/README.md
@@ -1,0 +1,28 @@
+# deflate
+
+Pure C# DEFLATE compression for the repo's CMP05 teaching wire format.
+
+## What It Includes
+
+- Composition of the native `.NET` `lzss` and `huffman-tree` packages
+- Combined literal/length and distance Huffman coding
+- CMP05 header and code-length table encoding
+- One-shot `Compress` and `Decompress` helpers
+
+## Example
+
+```csharp
+using System.Text;
+using CodingAdventures.Deflate;
+
+var compressed = Deflate.Compress(Encoding.UTF8.GetBytes("AABCBBABC"));
+var roundTrip = Encoding.UTF8.GetString(Deflate.Decompress(compressed));
+
+Console.WriteLine(roundTrip); // AABCBBABC
+```
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/csharp/deflate/required_capabilities.json
+++ b/code/packages/csharp/deflate/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/deflate",
+  "capabilities": [],
+  "justification": "Pure in-memory C# CMP05 DEFLATE implementation and tests."
+}

--- a/code/packages/csharp/deflate/tests/CodingAdventures.Deflate.Tests/CodingAdventures.Deflate.Tests.csproj
+++ b/code/packages/csharp/deflate/tests/CodingAdventures.Deflate.Tests/CodingAdventures.Deflate.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Deflate.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/deflate/tests/CodingAdventures.Deflate.Tests/DeflateTests.cs
+++ b/code/packages/csharp/deflate/tests/CodingAdventures.Deflate.Tests/DeflateTests.cs
@@ -1,0 +1,94 @@
+using System.Buffers.Binary;
+using System.Text;
+using CodingAdventures.Deflate;
+
+namespace CodingAdventures.Deflate.Tests;
+
+public sealed class DeflateTests
+{
+    [Fact]
+    public void EmptyInputUsesMinimalHeader()
+    {
+        var compressed = Deflate.Compress([]);
+        Assert.Equal(12, compressed.Length);
+        Assert.Equal(0u, BinaryPrimitives.ReadUInt32BigEndian(compressed.AsSpan(0, 4)));
+        Assert.Equal((ushort)1, BinaryPrimitives.ReadUInt16BigEndian(compressed.AsSpan(4, 2)));
+        Assert.Equal((ushort)0, BinaryPrimitives.ReadUInt16BigEndian(compressed.AsSpan(6, 2)));
+        Assert.Equal([], Deflate.Decompress(compressed));
+    }
+
+    [Theory]
+    [InlineData((byte)0x00)]
+    [InlineData((byte)0xFF)]
+    public void SingleByteValuesRoundTrip(byte value)
+    {
+        var data = new[] { value };
+        Assert.Equal(data, Deflate.Decompress(Deflate.Compress(data)));
+    }
+
+    [Fact]
+    public void LiteralOnlyExampleHasNoDistanceTree()
+    {
+        var data = Bytes("AAABBC");
+        var compressed = Deflate.Compress(data);
+        Assert.Equal(data, Deflate.Decompress(compressed));
+        Assert.Equal((ushort)0, BinaryPrimitives.ReadUInt16BigEndian(compressed.AsSpan(6, 2)));
+    }
+
+    [Fact]
+    public void SpecMatchExampleHasDistanceTree()
+    {
+        var data = Bytes("AABCBBABC");
+        var compressed = Deflate.Compress(data);
+        Assert.Equal((uint)9, BinaryPrimitives.ReadUInt32BigEndian(compressed.AsSpan(0, 4)));
+        Assert.True(BinaryPrimitives.ReadUInt16BigEndian(compressed.AsSpan(6, 2)) > 0);
+        Assert.Equal(data, Deflate.Decompress(compressed));
+    }
+
+    [Theory]
+    [InlineData("AAAAAAA")]
+    [InlineData("ABABABABABAB")]
+    [InlineData("ABCABCABCABC")]
+    [InlineData("hello hello hello world")]
+    [InlineData("AABABC")]
+    public void MatchHeavyExamplesRoundTrip(string value)
+    {
+        var data = Bytes(value);
+        Assert.Equal(data, Deflate.Decompress(Deflate.Compress(data)));
+    }
+
+    [Fact]
+    public void LongRepetitiveTextRoundTrips()
+    {
+        var data = Bytes(string.Concat(Enumerable.Repeat("the quick brown fox jumps over the lazy dog ", 10)));
+        Assert.Equal(data, Deflate.Decompress(Deflate.Compress(data)));
+    }
+
+    [Fact]
+    public void BinaryDataRoundTrips()
+    {
+        var data = new byte[1000];
+        for (var index = 0; index < data.Length; index++)
+        {
+            data[index] = (byte)(index % 256);
+        }
+
+        Assert.Equal(data, Deflate.Decompress(Deflate.Compress(data)));
+    }
+
+    [Fact]
+    public void RepetitiveDataCompressesBelowHalf()
+    {
+        var baseBytes = Bytes("ABCABC");
+        var data = new byte[baseBytes.Length * 100];
+        for (var index = 0; index < 100; index++)
+        {
+            baseBytes.CopyTo(data, index * baseBytes.Length);
+        }
+
+        var compressed = Deflate.Compress(data);
+        Assert.True(compressed.Length < data.Length / 2.0);
+    }
+
+    private static byte[] Bytes(string value) => Encoding.UTF8.GetBytes(value);
+}

--- a/code/packages/fsharp/deflate/BUILD
+++ b/code/packages/fsharp/deflate/BUILD
@@ -1,0 +1,1 @@
+mkdir -p .dotnet .artifacts && HOME="$PWD/.dotnet" DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_CLI_HOME="$PWD/.dotnet" dotnet test tests/CodingAdventures.Deflate.Tests/CodingAdventures.Deflate.Tests.fsproj --disable-build-servers --artifacts-path .artifacts /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/deflate/BUILD_windows
+++ b/code/packages/fsharp/deflate/BUILD_windows
@@ -1,0 +1,1 @@
+if not exist ".dotnet" mkdir ".dotnet" && if not exist ".artifacts" mkdir ".artifacts" && set "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1" && set "DOTNET_CLI_HOME=%CD%\.dotnet" && dotnet test "tests/CodingAdventures.Deflate.Tests/CodingAdventures.Deflate.Tests.fsproj" --disable-build-servers --artifacts-path ".artifacts" /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/deflate/CHANGELOG.md
+++ b/code/packages/fsharp/deflate/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-18
+
+### Added
+
+- Pure F# CMP05 DEFLATE implementation built from the native `.NET` `lzss` and `huffman-tree` packages
+- Combined literal/length and distance canonical Huffman coding with LSB-first bit packing
+- CMP05 header and code-length table encoding plus matching decompression support
+- xUnit coverage for empty input, literal-only streams, match-bearing streams, binary round trips, and compression sanity checks

--- a/code/packages/fsharp/deflate/CodingAdventures.Deflate.fsproj
+++ b/code/packages/fsharp/deflate/CodingAdventures.Deflate.fsproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AssemblyName>CodingAdventures.Deflate.FSharp</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Deflate.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure F# DEFLATE compression in the repo's CMP05 wire format</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../fsharp/huffman-tree/CodingAdventures.HuffmanTree.fsproj" />
+    <ProjectReference Include="../../fsharp/lzss/CodingAdventures.Lzss.fsproj" />
+    <Compile Include="Deflate.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/deflate/Deflate.fs
+++ b/code/packages/fsharp/deflate/Deflate.fs
@@ -1,0 +1,318 @@
+namespace CodingAdventures.Deflate.FSharp
+
+open System
+open System.Buffers.Binary
+open System.Collections.Generic
+open System.Text
+open CodingAdventures.HuffmanTree.FSharp
+open CodingAdventures.Lzss.FSharp
+
+module private Tables =
+    let LengthTable =
+        [|
+            (257, 3, 0); (258, 4, 0); (259, 5, 0); (260, 6, 0)
+            (261, 7, 0); (262, 8, 0); (263, 9, 0); (264, 10, 0)
+            (265, 11, 1); (266, 13, 1); (267, 15, 1); (268, 17, 1)
+            (269, 19, 2); (270, 23, 2); (271, 27, 2); (272, 31, 2)
+            (273, 35, 3); (274, 43, 3); (275, 51, 3); (276, 59, 3)
+            (277, 67, 4); (278, 83, 4); (279, 99, 4); (280, 115, 4)
+            (281, 131, 5); (282, 163, 5); (283, 195, 5); (284, 227, 5)
+        |]
+
+    let DistTable =
+        [|
+            (0, 1, 0); (1, 2, 0); (2, 3, 0); (3, 4, 0)
+            (4, 5, 1); (5, 7, 1); (6, 9, 2); (7, 13, 2)
+            (8, 17, 3); (9, 25, 3); (10, 33, 4); (11, 49, 4)
+            (12, 65, 5); (13, 97, 5); (14, 129, 6); (15, 193, 6)
+            (16, 257, 7); (17, 385, 7); (18, 513, 8); (19, 769, 8)
+            (20, 1025, 9); (21, 1537, 9); (22, 2049, 10); (23, 3073, 10)
+        |]
+
+type BitBuilder() =
+    let output = ResizeArray<byte>()
+    let mutable buffer = 0
+    let mutable bitPos = 0
+
+    member _.WriteBitString(bits: string) =
+        for bit in bits do
+            if bit = '1' then
+                buffer <- buffer ||| (1 <<< bitPos)
+
+            bitPos <- bitPos + 1
+            if bitPos = 8 then
+                output.Add(byte (buffer &&& 0xFF))
+                buffer <- 0
+                bitPos <- 0
+
+    member _.WriteRawBitsLsb(value: int, count: int) =
+        for index in 0 .. count - 1 do
+            if ((value >>> index) &&& 1) <> 0 then
+                buffer <- buffer ||| (1 <<< bitPos)
+
+            bitPos <- bitPos + 1
+            if bitPos = 8 then
+                output.Add(byte (buffer &&& 0xFF))
+                buffer <- 0
+                bitPos <- 0
+
+    member _.ToArray() =
+        if bitPos > 0 then
+            output.Add(byte (buffer &&& 0xFF))
+            buffer <- 0
+            bitPos <- 0
+
+        output.ToArray()
+
+[<AbstractClass; Sealed>]
+type Deflate =
+    static member Compress
+        (
+            data: byte array,
+            ?windowSize: int,
+            ?maxMatch: int,
+            ?minMatch: int
+        ) =
+        if isNull data then nullArg "data"
+
+        let windowSize = defaultArg windowSize Lzss.DefaultWindowSize
+        let maxMatch = defaultArg maxMatch Lzss.DefaultMaxMatch
+        let minMatch = defaultArg minMatch Lzss.DefaultMinMatch
+
+        if data.Length = 0 then
+            let empty = Array.zeroCreate<byte> 12
+            BinaryPrimitives.WriteUInt32BigEndian(empty.AsSpan(0, 4), 0u)
+            BinaryPrimitives.WriteUInt16BigEndian(empty.AsSpan(4, 2), 1us)
+            BinaryPrimitives.WriteUInt16BigEndian(empty.AsSpan(6, 2), 0us)
+            BinaryPrimitives.WriteUInt16BigEndian(empty.AsSpan(8, 2), 256us)
+            empty[10] <- 1uy
+            empty[11] <- 0uy
+            empty
+        else
+            let tokens = Lzss.Encode(data, windowSize, maxMatch, minMatch)
+            let llFreq = Dictionary<int, int>()
+            let distFreq = Dictionary<int, int>()
+
+            for token in tokens do
+                match token with
+                | Literal value ->
+                    llFreq[value |> int] <- (if llFreq.ContainsKey(int value) then llFreq[int value] else 0) + 1
+                | Match(offset, length) ->
+                    let lengthSymbol, _, _ = Deflate.FindLengthEntry(length)
+                    let distanceCode, _, _ = Deflate.FindDistEntry(offset)
+                    llFreq[lengthSymbol] <- (if llFreq.ContainsKey(lengthSymbol) then llFreq[lengthSymbol] else 0) + 1
+                    distFreq[distanceCode] <- (if distFreq.ContainsKey(distanceCode) then distFreq[distanceCode] else 0) + 1
+
+            llFreq[256] <- (if llFreq.ContainsKey(256) then llFreq[256] else 0) + 1
+
+            let llCodes =
+                HuffmanTree.Build(llFreq |> Seq.map (fun pair -> pair.Key, pair.Value)).CanonicalCodeTable()
+
+            let distCodes : IReadOnlyDictionary<int, string> =
+                if distFreq.Count > 0 then
+                    HuffmanTree.Build(distFreq |> Seq.map (fun pair -> pair.Key, pair.Value)).CanonicalCodeTable()
+                else
+                    upcast Dictionary<int, string>()
+
+            let bits = BitBuilder()
+            for token in tokens do
+                match token with
+                | Literal value ->
+                    bits.WriteBitString(llCodes[int value])
+                | Match(offset, length) ->
+                    let lengthSymbol, lengthBase, lengthExtra = Deflate.FindLengthEntry(length)
+                    bits.WriteBitString(llCodes[lengthSymbol])
+                    bits.WriteRawBitsLsb(length - lengthBase, lengthExtra)
+
+                    let distanceCode, distBase, distExtra = Deflate.FindDistEntry(offset)
+                    bits.WriteBitString(distCodes[distanceCode])
+                    bits.WriteRawBitsLsb(offset - distBase, distExtra)
+
+            bits.WriteBitString(llCodes[256])
+            let packedBits = bits.ToArray()
+
+            let llPairs =
+                llCodes
+                |> Seq.map (fun pair -> pair.Key, pair.Value.Length)
+                |> Seq.sortBy (fun (symbol, length) -> length, symbol)
+                |> Seq.toList
+
+            let distPairs =
+                distCodes
+                |> Seq.map (fun pair -> pair.Key, pair.Value.Length)
+                |> Seq.sortBy (fun (symbol, length) -> length, symbol)
+                |> Seq.toList
+
+            let totalSize = 8 + (llPairs.Length * 3) + (distPairs.Length * 3) + packedBits.Length
+            let output = Array.zeroCreate<byte> totalSize
+            BinaryPrimitives.WriteUInt32BigEndian(output.AsSpan(0, 4), uint32 data.Length)
+            BinaryPrimitives.WriteUInt16BigEndian(output.AsSpan(4, 2), uint16 llPairs.Length)
+            BinaryPrimitives.WriteUInt16BigEndian(output.AsSpan(6, 2), uint16 distPairs.Length)
+
+            let mutable offset = 8
+            for (symbol, length) in llPairs do
+                BinaryPrimitives.WriteUInt16BigEndian(output.AsSpan(offset, 2), uint16 symbol)
+                output[offset + 2] <- byte length
+                offset <- offset + 3
+
+            for (symbol, length) in distPairs do
+                BinaryPrimitives.WriteUInt16BigEndian(output.AsSpan(offset, 2), uint16 symbol)
+                output[offset + 2] <- byte length
+                offset <- offset + 3
+
+            Array.Copy(packedBits, 0, output, offset, packedBits.Length)
+            output
+
+    static member Decompress(data: byte array) =
+        if isNull data then nullArg "data"
+        if data.Length < 8 then
+            Array.empty
+        else
+            let originalLength = int (BinaryPrimitives.ReadUInt32BigEndian(data.AsSpan(0, 4)))
+            let llEntryCount = int (BinaryPrimitives.ReadUInt16BigEndian(data.AsSpan(4, 2)))
+            let distEntryCount = int (BinaryPrimitives.ReadUInt16BigEndian(data.AsSpan(6, 2)))
+
+            if originalLength = 0 then
+                Array.empty
+            else
+                let mutable offset = 8
+                let llLengths = ResizeArray<int * int>()
+                let distLengths = ResizeArray<int * int>()
+
+                let mutable valid = true
+                for _ in 0 .. llEntryCount - 1 do
+                    if offset + 3 > data.Length then
+                        valid <- false
+                    elif valid then
+                        llLengths.Add(
+                            int (BinaryPrimitives.ReadUInt16BigEndian(data.AsSpan(offset, 2))),
+                            int data[offset + 2]
+                        )
+                        offset <- offset + 3
+
+                for _ in 0 .. distEntryCount - 1 do
+                    if offset + 3 > data.Length then
+                        valid <- false
+                    elif valid then
+                        distLengths.Add(
+                            int (BinaryPrimitives.ReadUInt16BigEndian(data.AsSpan(offset, 2))),
+                            int data[offset + 2]
+                        )
+                        offset <- offset + 3
+
+                if not valid then
+                    Array.empty
+                else
+                    let llCodes = Deflate.ReconstructCanonicalCodes(llLengths)
+                    let distCodes = Deflate.ReconstructCanonicalCodes(distLengths)
+                    let bits = Deflate.UnpackBits(data[offset..])
+                    let output = ResizeArray<byte>(originalLength)
+                    let mutable bitPos = 0
+                    let mutable keepReading = true
+
+                    while keepReading do
+                        let llSymbol = Deflate.NextHuffmanSymbol(llCodes, bits, &bitPos)
+                        if llSymbol = 256 then
+                            keepReading <- false
+                        elif llSymbol < 256 then
+                            output.Add(byte llSymbol)
+                        else
+                            let _, lengthBase, lengthExtra = Deflate.FindLengthEntryBySymbol(llSymbol)
+                            let length = lengthBase + Deflate.ReadRawBits(bits, &bitPos, lengthExtra)
+
+                            if distCodes.Count = 0 then
+                                invalidOp "Compressed stream references distance codes without a distance tree"
+
+                            let distSymbol = Deflate.NextHuffmanSymbol(distCodes, bits, &bitPos)
+                            let _, distBase, distExtra = Deflate.FindDistEntryByCode(distSymbol)
+                            let distance = distBase + Deflate.ReadRawBits(bits, &bitPos, distExtra)
+
+                            let start = output.Count - distance
+                            if start < 0 then
+                                invalidOp "Distance extends before the output buffer"
+
+                            for index in 0 .. length - 1 do
+                                output.Add(output[start + index])
+
+                    output |> Seq.truncate originalLength |> Array.ofSeq
+
+    static member private FindLengthEntry(length: int) =
+        Tables.LengthTable
+        |> Array.tryFind (fun (_, baseLength, extraBits) -> length <= baseLength + ((1 <<< extraBits) - 1))
+        |> Option.defaultValue Tables.LengthTable[Tables.LengthTable.Length - 1]
+
+    static member private FindLengthEntryBySymbol(symbol: int) =
+        Tables.LengthTable
+        |> Array.tryFind (fun (entrySymbol, _, _) -> entrySymbol = symbol)
+        |> Option.defaultWith (fun () -> invalidOp $"Unknown length symbol {symbol}")
+
+    static member private FindDistEntry(distance: int) =
+        Tables.DistTable
+        |> Array.tryFind (fun (_, baseDistance, extraBits) -> distance <= baseDistance + ((1 <<< extraBits) - 1))
+        |> Option.defaultValue Tables.DistTable[Tables.DistTable.Length - 1]
+
+    static member private FindDistEntryByCode(code: int) =
+        Tables.DistTable
+        |> Array.tryFind (fun (entryCode, _, _) -> entryCode = code)
+        |> Option.defaultWith (fun () -> invalidOp $"Unknown distance symbol {code}")
+
+    static member private ReconstructCanonicalCodes(lengths: seq<int * int>) =
+        let ordered =
+            lengths
+            |> Seq.filter (fun (_, length) -> length > 0)
+            |> Seq.sortBy (fun (symbol, length) -> length, symbol)
+            |> Seq.toList
+
+        let result = Dictionary<string, int>()
+        match ordered with
+        | [] -> result :> IReadOnlyDictionary<string, int>
+        | [ symbol, _ ] ->
+            result["0"] <- symbol
+            result :> IReadOnlyDictionary<string, int>
+        | _ ->
+            let mutable code = 0
+            let mutable previousLength = ordered |> List.head |> snd
+            for (symbol, length) in ordered do
+                if length > previousLength then
+                    code <- code <<< (length - previousLength)
+
+                result[Convert.ToString(code, 2).PadLeft(length, '0')] <- symbol
+                code <- code + 1
+                previousLength <- length
+
+            result :> IReadOnlyDictionary<string, int>
+
+    static member private UnpackBits(data: byte array) =
+        let builder = StringBuilder(data.Length * 8)
+        for value in data do
+            for bit = 0 to 7 do
+                builder.Append(if ((int value >>> bit) &&& 1) <> 0 then '1' else '0') |> ignore
+
+        builder.ToString()
+
+    static member private ReadRawBits(bits: string, bitPos: byref<int>, count: int) =
+        let mutable value = 0
+        for index in 0 .. count - 1 do
+            if bitPos + index >= bits.Length then
+                invalidOp "Unexpected end of compressed bit stream"
+
+            if bits[bitPos + index] = '1' then
+                value <- value ||| (1 <<< index)
+
+        bitPos <- bitPos + count
+        value
+
+    static member private NextHuffmanSymbol(codes: IReadOnlyDictionary<string, int>, bits: string, bitPos: byref<int>) =
+        if codes.Count = 0 then
+            invalidOp "Missing Huffman codes"
+
+        let builder = StringBuilder()
+        let mutable found: int option = None
+        while Option.isNone found && bitPos < bits.Length do
+            builder.Append(bits[bitPos]) |> ignore
+            bitPos <- bitPos + 1
+            match codes.TryGetValue(builder.ToString()) with
+            | true, symbol -> found <- Some symbol
+            | _ -> ()
+
+        found |> Option.defaultWith (fun () -> invalidOp "Unexpected end of compressed bit stream")

--- a/code/packages/fsharp/deflate/README.md
+++ b/code/packages/fsharp/deflate/README.md
@@ -1,0 +1,28 @@
+# deflate
+
+Pure F# DEFLATE compression for the repo's CMP05 teaching wire format.
+
+## What It Includes
+
+- Composition of the native `.NET` `lzss` and `huffman-tree` packages
+- Combined literal/length and distance Huffman coding
+- CMP05 header and code-length table encoding
+- One-shot `Compress` and `Decompress` helpers
+
+## Example
+
+```fsharp
+open System.Text
+open CodingAdventures.Deflate.FSharp
+
+let compressed = Deflate.Compress(Encoding.UTF8.GetBytes("AABCBBABC"))
+let roundTrip = Encoding.UTF8.GetString(Deflate.Decompress compressed)
+
+printfn "%s" roundTrip
+```
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/fsharp/deflate/required_capabilities.json
+++ b/code/packages/fsharp/deflate/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/deflate",
+  "capabilities": [],
+  "justification": "Pure in-memory F# CMP05 DEFLATE implementation and tests."
+}

--- a/code/packages/fsharp/deflate/tests/CodingAdventures.Deflate.Tests/CodingAdventures.Deflate.Tests.fsproj
+++ b/code/packages/fsharp/deflate/tests/CodingAdventures.Deflate.Tests/CodingAdventures.Deflate.Tests.fsproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Deflate.fsproj" />
+    <Compile Include="DeflateTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/deflate/tests/CodingAdventures.Deflate.Tests/DeflateTests.fs
+++ b/code/packages/fsharp/deflate/tests/CodingAdventures.Deflate.Tests/DeflateTests.fs
@@ -1,0 +1,72 @@
+namespace CodingAdventures.Deflate.FSharp.Tests
+
+open System
+open System.Buffers.Binary
+open System.Text
+open CodingAdventures.Deflate.FSharp
+open Xunit
+
+module private Helpers =
+    let bytes (value: string) = Encoding.UTF8.GetBytes(value)
+
+type DeflateTests() =
+    [<Fact>]
+    member _.``Empty input uses minimal header``() =
+        let compressed = Deflate.Compress(Array.empty)
+        Assert.Equal(12, compressed.Length)
+        Assert.Equal(0u, BinaryPrimitives.ReadUInt32BigEndian(compressed.AsSpan(0, 4)))
+        Assert.Equal(1us, BinaryPrimitives.ReadUInt16BigEndian(compressed.AsSpan(4, 2)))
+        Assert.Equal(0us, BinaryPrimitives.ReadUInt16BigEndian(compressed.AsSpan(6, 2)))
+        Assert.Equal<byte array>(Array.empty, Deflate.Decompress(compressed))
+
+    [<Theory>]
+    [<InlineData(0uy)>]
+    [<InlineData(255uy)>]
+    member _.``Single byte values round trip``(value: byte) =
+        let data = [| value |]
+        Assert.Equal<byte array>(data, Deflate.Decompress(Deflate.Compress(data)))
+
+    [<Fact>]
+    member _.``Literal-only example has no distance tree``() =
+        let data = Helpers.bytes "AAABBC"
+        let compressed = Deflate.Compress(data)
+        Assert.Equal<byte array>(data, Deflate.Decompress(compressed))
+        Assert.Equal(0us, BinaryPrimitives.ReadUInt16BigEndian(compressed.AsSpan(6, 2)))
+
+    [<Fact>]
+    member _.``Spec match example has distance tree``() =
+        let data = Helpers.bytes "AABCBBABC"
+        let compressed = Deflate.Compress(data)
+        Assert.Equal(9u, BinaryPrimitives.ReadUInt32BigEndian(compressed.AsSpan(0, 4)))
+        Assert.True(BinaryPrimitives.ReadUInt16BigEndian(compressed.AsSpan(6, 2)) > 0us)
+        Assert.Equal<byte array>(data, Deflate.Decompress(compressed))
+
+    [<Theory>]
+    [<InlineData("AAAAAAA")>]
+    [<InlineData("ABABABABABAB")>]
+    [<InlineData("ABCABCABCABC")>]
+    [<InlineData("hello hello hello world")>]
+    [<InlineData("AABABC")>]
+    member _.``Match-heavy examples round trip``(value: string) =
+        let data = Helpers.bytes value
+        Assert.Equal<byte array>(data, Deflate.Decompress(Deflate.Compress(data)))
+
+    [<Fact>]
+    member _.``Long repetitive text round trips``() =
+        let data = Helpers.bytes(String.Concat(Array.replicate 10 "the quick brown fox jumps over the lazy dog "))
+        Assert.Equal<byte array>(data, Deflate.Decompress(Deflate.Compress(data)))
+
+    [<Fact>]
+    member _.``Binary data round trips``() =
+        let data = Array.init 1000 (fun index -> byte (index % 256))
+        Assert.Equal<byte array>(data, Deflate.Decompress(Deflate.Compress(data)))
+
+    [<Fact>]
+    member _.``Repetitive data compresses below half``() =
+        let baseBytes = Helpers.bytes "ABCABC"
+        let data = Array.zeroCreate<byte> (baseBytes.Length * 100)
+        for index in 0 .. 99 do
+            Array.Copy(baseBytes, 0, data, index * baseBytes.Length, baseBytes.Length)
+
+        let compressed = Deflate.Compress(data)
+        Assert.True(float compressed.Length < float data.Length / 2.0)

--- a/code/specs/TE10-dotnet-compression-deflate-tranche.md
+++ b/code/specs/TE10-dotnet-compression-deflate-tranche.md
@@ -1,0 +1,71 @@
+# TE10 - .NET Compression DEFLATE Tranche
+
+## Goal
+
+Port the CMP05 `deflate` package to both C# and F# as pure in-language implementations.
+
+This tranche builds on the already-ported `.NET` `lzss` and `huffman-tree` packages and
+keeps the repo's teaching-oriented CMP05 wire format rather than aiming for RFC 1951
+byte-for-byte compatibility.
+
+## Scope
+
+Add these publishable packages:
+
+- `code/packages/csharp/deflate`
+- `code/packages/fsharp/deflate`
+
+Each package must include:
+
+- native implementation code only
+- tests
+- `BUILD`
+- `BUILD_windows`
+- `README.md`
+- `CHANGELOG.md`
+- package metadata
+- `required_capabilities.json`
+
+## Functional Requirements
+
+Both implementations should:
+
+- use the pure `.NET` `lzss` package for tokenization
+- use the pure `.NET` `huffman-tree` package for canonical Huffman code generation
+- implement the CMP05 combined literal/length alphabet
+- implement the CMP05 distance-code table
+- emit the documented 8-byte header and code-length tables
+- pack Huffman codes and raw extra bits LSB-first
+- expose:
+  - `Compress`
+  - `Decompress`
+
+## Behavioral Notes
+
+- Empty input should produce the minimal CMP05 encoding with a single end-of-data symbol.
+- Literal-only inputs should emit an LL tree and no distance tree.
+- Match decoding must support overlapping back-references.
+- The F# package must be implemented directly in F# and must not wrap the C# package.
+- No external compression or bitstream libraries may be used.
+
+## Test Coverage Targets
+
+Tests should cover at least:
+
+- empty input
+- single-byte values
+- literal-only examples
+- the spec's one-match example (`AABCBBABC`)
+- overlapping matches
+- repetitive text
+- binary round trips
+- distance-table presence or absence depending on whether matches exist
+- header `original_length` correctness
+- a simple compression-ratio sanity check on repetitive input
+
+## Out of Scope
+
+- RFC 1951 dynamic-block interoperability
+- zlib or gzip framing
+- `brotli`
+- `reed-solomon`


### PR DESCRIPTION
## Summary
- add the TE10 spec for the pure .NET deflate tranche
- add native C# `deflate` built from the existing `.NET` `lzss` and `huffman-tree` packages
- add native F# `deflate` with the same pure in-language CMP05 implementation
- keep the repo's teaching CMP05 wire format rather than RFC 1951 framing

## Verification
- `bash BUILD` in `code/packages/csharp/deflate`
- `bash BUILD` in `code/packages/fsharp/deflate`

## Notes
- no external compression or bitstream libraries are used
- the F# package is implemented directly in F#, not as a wrapper over the C# package