### PR TITLE
feat(logic-constraints): add disequality support

### DIFF
--- a/code/packages/python/logic-core/CHANGELOG.md
+++ b/code/packages/python/logic-core/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.0] - 2026-04-18
+
+### Added
+
+- `Disequality` constraints stored directly on search states
+- `neq(...)` for delayed disequality checks
+- constraint-aware `eq(...)` that revalidates stored disequalities after unification
+- pytest coverage for delayed constraint storage, violation, and satisfaction
+
 ## [0.1.0] - 2026-04-18
 
 ### Added

--- a/code/packages/python/logic-core/README.md
+++ b/code/packages/python/logic-core/README.md
@@ -8,6 +8,7 @@ It deliberately starts with the reusable semantic pieces:
 - atoms, numbers, strings, variables, and compound terms
 - substitutions and unification
 - goals and backtracking search
+- delayed disequality constraints via `neq(...)`
 - helpers like `fresh`, `conj`, `disj`, `run_all`, and `run_n`
 
 The later Prolog implementation should lower parsed clauses and queries into
@@ -16,19 +17,20 @@ this API instead of inventing a second execution model.
 ## Quick Start
 
 ```python
-from logic_core import atom, disj, eq, run_all, term, var
+from logic_core import State, atom, conj, eq, neq, run_all, var
 
 X = var("X")
 
-answers = run_all(
+assert run_all(
     X,
-    disj(
-        eq(term("parent", X, atom("bart")), term("parent", atom("homer"), atom("bart"))),
+    conj(
+        neq(X, atom("homer")),
         eq(X, atom("marge")),
     ),
-)
+) == [atom("marge")]
 
-assert answers == [atom("homer"), atom("marge")]
+state = list(neq(X, atom("homer"))(State()))[0]
+assert state.constraints
 ```
 
 ## Dependencies

--- a/code/packages/python/logic-core/pyproject.toml
+++ b/code/packages/python/logic-core/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-logic-core"
-version = "0.1.0"
-description = "Logic programming core: terms, unification, goals, and search"
+version = "0.2.0"
+description = "Logic programming core: terms, unification, goals, search, and disequality constraints"
 requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]
@@ -25,7 +25,7 @@ classifiers = [
 [project.urls]
 Homepage = "https://github.com/adhithyan15/coding-adventures"
 Repository = "https://github.com/adhithyan15/coding-adventures"
-Documentation = "https://github.com/adhithyan15/coding-adventures/tree/main/code/specs/LP00-logic-core.md"
+Documentation = "https://github.com/adhithyan15/coding-adventures/tree/main/code/specs/LP02-disequality-constraints.md"
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]

--- a/code/packages/python/logic-core/src/logic_core/__init__.py
+++ b/code/packages/python/logic-core/src/logic_core/__init__.py
@@ -26,6 +26,7 @@ from symbol_core import Symbol, sym
 __all__ = [
     "Atom",
     "Compound",
+    "Disequality",
     "Goal",
     "LogicVar",
     "Number",
@@ -41,6 +42,7 @@ __all__ = [
     "fail",
     "fresh",
     "logic_list",
+    "neq",
     "num",
     "reify",
     "run",
@@ -53,7 +55,7 @@ __all__ = [
     "var",
 ]
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 
 @dataclass(frozen=True, slots=True)
@@ -193,7 +195,10 @@ def _coerce_term(value: object) -> Term:
     if isinstance(value, Symbol):
         return atom(value)
     if isinstance(value, bool):
-        msg = "bool values are ambiguous in logic-core; use atoms or numbers explicitly"
+        msg = (
+            "bool values are ambiguous in logic-core; use atoms or "
+            "numbers explicitly"
+        )
         raise TypeError(msg)
     if isinstance(value, int | float):
         return num(value)
@@ -263,10 +268,19 @@ class Substitution:
 
 
 @dataclass(frozen=True, slots=True)
+class Disequality:
+    """A delayed constraint that two terms must never become equal."""
+
+    left: Term
+    right: Term
+
+
+@dataclass(frozen=True, slots=True)
 class State:
     """One point in the search tree."""
 
     substitution: Substitution = field(default_factory=Substitution)
+    constraints: tuple[Disequality, ...] = ()
     next_var_id: int = 0
 
 
@@ -353,6 +367,36 @@ def reify(value: object, substitution: Substitution) -> Term:
     return walked
 
 
+def _reconcile_disequalities(
+    substitution: Substitution,
+    constraints: tuple[Disequality, ...],
+) -> tuple[Disequality, ...] | None:
+    """Re-check delayed disequalities after a substitution changes.
+
+    Each constraint falls into one of three buckets:
+
+    - violated: the two sides are equal now -> fail the whole state
+    - satisfied: the two sides can no longer unify -> drop the constraint
+    - pending: equality is still possible later -> keep a normalized copy
+    """
+
+    pending: list[Disequality] = []
+    for constraint in constraints:
+        left = reify(constraint.left, substitution)
+        right = reify(constraint.right, substitution)
+
+        if left == right:
+            return None
+
+        trial = unify(left, right, substitution)
+        if trial is None:
+            continue
+
+        pending.append(Disequality(left=left, right=right))
+
+    return tuple(pending)
+
+
 def succeed() -> Goal:
     """Return a goal that yields its input state unchanged."""
 
@@ -379,7 +423,53 @@ def eq(left: object, right: object) -> Goal:
         unified = unify(left, right, state.substitution)
         if unified is None:
             return
-        yield State(substitution=unified, next_var_id=state.next_var_id)
+        constraints = _reconcile_disequalities(unified, state.constraints)
+        if constraints is None:
+            return
+        yield State(
+            substitution=unified,
+            constraints=constraints,
+            next_var_id=state.next_var_id,
+        )
+
+    return goal
+
+
+def neq(left: object, right: object) -> Goal:
+    """Create a goal that enforces disequality, immediately or lazily.
+
+    If the terms are already provably different, the goal succeeds immediately.
+    If they are already equal, the goal fails immediately.
+    Otherwise the engine stores a delayed disequality constraint that future
+    unifications must continue to respect.
+    """
+
+    def goal(state: State) -> Iterator[State]:
+        normalized = Disequality(
+            left=reify(left, state.substitution),
+            right=reify(right, state.substitution),
+        )
+
+        if normalized.left == normalized.right:
+            return
+
+        trial = unify(normalized.left, normalized.right, state.substitution)
+        if trial is None:
+            yield state
+            return
+
+        constraints = _reconcile_disequalities(
+            state.substitution,
+            state.constraints + (normalized,),
+        )
+        if constraints is None:
+            return
+
+        yield State(
+            substitution=state.substitution,
+            constraints=constraints,
+            next_var_id=state.next_var_id,
+        )
 
     return goal
 
@@ -425,6 +515,7 @@ def fresh(count: int, fn: Callable[..., Goal]) -> Goal:
         )
         next_state = State(
             substitution=state.substitution,
+            constraints=state.constraints,
             next_var_id=state.next_var_id + count,
         )
         produced_goal = fn(*variables)

--- a/code/packages/python/logic-core/tests/test_logic_core.py
+++ b/code/packages/python/logic-core/tests/test_logic_core.py
@@ -13,6 +13,7 @@ from symbol_core import sym
 from logic_core import (
     Atom,
     Compound,
+    Disequality,
     LogicVar,
     Number,
     State,
@@ -26,6 +27,7 @@ from logic_core import (
     fail,
     fresh,
     logic_list,
+    neq,
     num,
     reify,
     run_all,
@@ -42,7 +44,7 @@ class TestVersion:
     """Verify the package is importable and versioned."""
 
     def test_version_exists(self) -> None:
-        assert __version__ == "0.1.0"
+        assert __version__ == "0.2.0"
 
 
 class TestTermConstruction:
@@ -152,6 +154,41 @@ class TestGoalsAndSearch:
         x = var("X")
 
         assert run_all(x, eq(x, atom("homer"))) == [atom("homer")]
+
+    def test_neq_fails_on_equal_terms(self) -> None:
+        assert run_all(var("X"), neq(atom("homer"), atom("homer"))) == []
+
+    def test_neq_succeeds_immediately_on_obviously_different_terms(self) -> None:
+        x = var("X")
+
+        assert run_all(x, neq(atom("homer"), atom("marge"))) == [x]
+
+    def test_neq_records_delayed_constraints_for_open_terms(self) -> None:
+        x = var("X")
+        states = list(neq(x, atom("homer"))(State()))
+
+        assert len(states) == 1
+        assert states[0].substitution == Substitution()
+        assert states[0].constraints == (
+            Disequality(left=x, right=atom("homer")),
+        )
+
+    def test_eq_fails_when_it_would_violate_a_stored_disequality(self) -> None:
+        x = var("X")
+        goal = conj(
+            neq(x, atom("homer")),
+            eq(x, atom("homer")),
+        )
+
+        assert run_all(x, goal) == []
+
+    def test_eq_satisfies_and_drops_disequality_constraints(self) -> None:
+        x = var("X")
+        states = list(conj(neq(x, atom("homer")), eq(x, atom("marge")))(State()))
+
+        assert len(states) == 1
+        assert states[0].constraints == ()
+        assert states[0].substitution.reify(x) == atom("marge")
 
     def test_disjunction_emits_multiple_answers(self) -> None:
         x = var("X")

--- a/code/packages/python/logic-engine/CHANGELOG.md
+++ b/code/packages/python/logic-engine/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.0] - 2026-04-18
+
+### Added
+
+- `neq(...)` goal expressions delegated to `logic-core` disequality constraints
+- `all_different(...)` for pairwise-distinct puzzle variables
+- end-to-end tests for delayed disequality and a small coloring problem
+
 ## [0.1.0] - 2026-04-18
 
 ### Added

--- a/code/packages/python/logic-engine/README.md
+++ b/code/packages/python/logic-engine/README.md
@@ -10,30 +10,41 @@ that make relational programs feel like programs:
 - facts and rules
 - immutable clause databases
 - recursive solving with depth-first backtracking
+- disequality constraints via `neq(...)`
+- `all_different(...)` for small puzzle-style searches
 - end-to-end query helpers like `solve_all()` and `solve_n()`
 
 ## Quick Start
 
 ```python
-from logic_engine import atom, conj, fact, fresh, program, relation, rule, solve_all, var
+from logic_engine import all_different, atom, conj, fact, neq, program, relation, solve_n, var
 
-parent = relation("parent", 2)
-ancestor = relation("ancestor", 2)
+color = relation("color", 1)
 
-X = var("X")
-Y = var("Y")
+WA = var("WA")
+NT = var("NT")
+SA = var("SA")
 
-family = program(
-    fact(parent("homer", "bart")),
-    fact(parent("homer", "lisa")),
-    rule(ancestor(X, Y), parent(X, Y)),
-    rule(
-        ancestor(X, Y),
-        fresh(1, lambda z: conj(parent(X, z), ancestor(z, Y))),
+palette = program(
+    fact(color("red")),
+    fact(color("green")),
+    fact(color("blue")),
+)
+
+answers = solve_n(
+    palette,
+    3,
+    (WA, NT, SA),
+    conj(
+        color(WA),
+        color(NT),
+        color(SA),
+        all_different(WA, NT, SA),
+        neq(WA, atom("blue")),
     ),
 )
 
-assert solve_all(family, Y, ancestor("homer", Y)) == [atom("bart"), atom("lisa")]
+assert answers
 ```
 
 ## Dependencies

--- a/code/packages/python/logic-engine/pyproject.toml
+++ b/code/packages/python/logic-engine/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-logic-engine"
-version = "0.1.0"
-description = "Logic programming engine: relations, clauses, programs, and resolution"
+version = "0.2.0"
+description = "Logic programming engine: relations, clauses, programs, resolution, and disequality"
 requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]
 readme = "README.md"
-dependencies = ["coding-adventures-logic-core>=0.1.0"]
+dependencies = ["coding-adventures-logic-core>=0.2.0"]
 keywords = ["logic-programming", "prolog", "resolution", "backtracking", "education"]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -25,7 +25,7 @@ classifiers = [
 [project.urls]
 Homepage = "https://github.com/adhithyan15/coding-adventures"
 Repository = "https://github.com/adhithyan15/coding-adventures"
-Documentation = "https://github.com/adhithyan15/coding-adventures/tree/main/code/specs/LP01-logic-engine.md"
+Documentation = "https://github.com/adhithyan15/coding-adventures/tree/main/code/specs/LP02-disequality-constraints.md"
 
 [project.optional-dependencies]
 dev = [

--- a/code/packages/python/logic-engine/src/logic_engine/__init__.py
+++ b/code/packages/python/logic-engine/src/logic_engine/__init__.py
@@ -11,12 +11,14 @@ from logic_engine.engine import (
     Clause,
     Compound,
     ConjExpr,
+    Disequality,
     DisjExpr,
     EqExpr,
     FailExpr,
     FreshExpr,
     GoalExpr,
     LogicVar,
+    NeqExpr,
     Number,
     Program,
     Relation,
@@ -26,6 +28,7 @@ from logic_engine.engine import (
     Substitution,
     SucceedExpr,
     Term,
+    all_different,
     atom,
     conj,
     disj,
@@ -34,6 +37,7 @@ from logic_engine.engine import (
     fail,
     fresh,
     logic_list,
+    neq,
     num,
     program,
     relation,
@@ -50,6 +54,7 @@ from logic_engine.engine import (
 __all__ = [
     "__version__",
     "Atom",
+    "Disequality",
     "Clause",
     "Compound",
     "ConjExpr",
@@ -59,6 +64,7 @@ __all__ = [
     "FreshExpr",
     "GoalExpr",
     "LogicVar",
+    "NeqExpr",
     "Number",
     "Program",
     "Relation",
@@ -68,6 +74,7 @@ __all__ = [
     "Substitution",
     "SucceedExpr",
     "Term",
+    "all_different",
     "atom",
     "conj",
     "disj",
@@ -76,6 +83,7 @@ __all__ = [
     "fail",
     "fresh",
     "logic_list",
+    "neq",
     "num",
     "program",
     "relation",
@@ -89,4 +97,4 @@ __all__ = [
     "var",
 ]
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/code/packages/python/logic-engine/src/logic_engine/engine.py
+++ b/code/packages/python/logic-engine/src/logic_engine/engine.py
@@ -24,6 +24,7 @@ from itertools import count, islice
 from logic_core import (
     Atom,
     Compound,
+    Disequality,
     LogicVar,
     Number,
     State,
@@ -39,6 +40,12 @@ from logic_core import (
     unify,
     var,
 )
+from logic_core import (
+    eq as core_eq,
+)
+from logic_core import (
+    neq as core_neq,
+)
 from symbol_core import Symbol, sym
 
 __all__ = [
@@ -47,11 +54,13 @@ __all__ = [
     "Compound",
     "ConjExpr",
     "DisjExpr",
+    "Disequality",
     "EqExpr",
     "FailExpr",
     "FreshExpr",
     "GoalExpr",
     "LogicVar",
+    "NeqExpr",
     "Number",
     "Program",
     "Relation",
@@ -61,6 +70,7 @@ __all__ = [
     "Substitution",
     "SucceedExpr",
     "Term",
+    "all_different",
     "atom",
     "conj",
     "disj",
@@ -69,6 +79,7 @@ __all__ = [
     "fail",
     "fresh",
     "logic_list",
+    "neq",
     "num",
     "program",
     "relation",
@@ -194,6 +205,14 @@ class EqExpr:
 
 
 @dataclass(frozen=True, slots=True)
+class NeqExpr:
+    """A structured disequality goal delegated to ``logic-core`` constraints."""
+
+    left: Term
+    right: Term
+
+
+@dataclass(frozen=True, slots=True)
 class ConjExpr:
     """A conjunction of goal expressions."""
 
@@ -221,7 +240,14 @@ class FreshExpr:
 
 
 type GoalExpr = (
-    RelationCall | SucceedExpr | FailExpr | EqExpr | ConjExpr | DisjExpr | FreshExpr
+    RelationCall
+    | SucceedExpr
+    | FailExpr
+    | EqExpr
+    | NeqExpr
+    | ConjExpr
+    | DisjExpr
+    | FreshExpr
 )
 
 
@@ -235,6 +261,7 @@ def _coerce_goal(goal: object) -> GoalExpr:
             | SucceedExpr
             | FailExpr
             | EqExpr
+            | NeqExpr
             | ConjExpr
             | DisjExpr
             | FreshExpr
@@ -262,6 +289,12 @@ def eq(left: object, right: object) -> GoalExpr:
     """Construct an equality goal expression."""
 
     return EqExpr(left=_coerce_term(left), right=_coerce_term(right))
+
+
+def neq(left: object, right: object) -> GoalExpr:
+    """Construct a disequality goal expression."""
+
+    return NeqExpr(left=_coerce_term(left), right=_coerce_term(right))
 
 
 def conj(*goals: object) -> GoalExpr:
@@ -304,6 +337,20 @@ def disj(*goals: object) -> GoalExpr:
     if len(flattened) == 1:
         return flattened[0]
     return DisjExpr(goals=tuple(flattened))
+
+
+def all_different(*terms: object) -> GoalExpr:
+    """Require every supplied term to remain pairwise distinct.
+
+    This is the first convenience combinator for puzzle-style search. It lowers
+    to a conjunction of pairwise disequalities.
+    """
+
+    goals: list[GoalExpr] = []
+    for index, left in enumerate(terms):
+        for right in terms[index + 1 :]:
+            goals.append(neq(left, right))
+    return conj(*goals)
 
 
 def fresh(count: int, fn: Callable[..., object]) -> GoalExpr:
@@ -426,6 +473,11 @@ def _rename_goal(goal: GoalExpr, mapping: dict[LogicVar, LogicVar]) -> GoalExpr:
             left=_rename_term(goal.left, mapping),
             right=_rename_term(goal.right, mapping),
         )
+    if isinstance(goal, NeqExpr):
+        return NeqExpr(
+            left=_rename_term(goal.left, mapping),
+            right=_rename_term(goal.right, mapping),
+        )
     if isinstance(goal, ConjExpr):
         return ConjExpr(
             goals=tuple(_rename_goal(child, mapping) for child in goal.goals),
@@ -502,6 +554,11 @@ def _freshen_goal(
         left, running_id = _freshen_term(goal.left, mapping, next_var_id)
         right, running_id = _freshen_term(goal.right, mapping, running_id)
         return EqExpr(left=left, right=right), running_id
+
+    if isinstance(goal, NeqExpr):
+        left, running_id = _freshen_term(goal.left, mapping, next_var_id)
+        right, running_id = _freshen_term(goal.right, mapping, running_id)
+        return NeqExpr(left=left, right=right), running_id
 
     if isinstance(goal, ConjExpr):
         running_id = next_var_id
@@ -583,9 +640,11 @@ def _solve_goal(
         return
 
     if isinstance(goal, EqExpr):
-        unified = unify(goal.left, goal.right, state.substitution)
-        if unified is not None:
-            yield State(substitution=unified, next_var_id=state.next_var_id)
+        yield from core_eq(goal.left, goal.right)(state)
+        return
+
+    if isinstance(goal, NeqExpr):
+        yield from core_neq(goal.left, goal.right)(state)
         return
 
     if isinstance(goal, ConjExpr):

--- a/code/packages/python/logic-engine/tests/test_logic_engine.py
+++ b/code/packages/python/logic-engine/tests/test_logic_engine.py
@@ -11,9 +11,11 @@ import pytest
 
 from logic_engine import (
     Clause,
+    Disequality,
     Program,
     State,
     __version__,
+    all_different,
     atom,
     conj,
     disj,
@@ -22,6 +24,7 @@ from logic_engine import (
     fail,
     fresh,
     logic_list,
+    neq,
     program,
     relation,
     rule,
@@ -37,7 +40,7 @@ class TestVersion:
     """Verify the package is importable and versioned."""
 
     def test_version_exists(self) -> None:
-        assert __version__ == "0.1.0"
+        assert __version__ == "0.2.0"
 
 
 class TestRelationsAndClauses:
@@ -257,6 +260,61 @@ class TestQueryHelpers:
     def test_invalid_goal_expressions_are_rejected(self) -> None:
         with pytest.raises(TypeError):
             solve_all(program(), var("X"), object())
+
+
+class TestDisequalityConstraints:
+    """Disequality is the first real puzzle-oriented constraint."""
+
+    def test_neq_can_live_inside_engine_goals(self) -> None:
+        x = var("X")
+
+        assert solve_all(program(), x, conj(neq(x, "homer"), eq(x, "marge"))) == [
+            atom("marge"),
+        ]
+
+    def test_neq_blocks_later_equal_bindings(self) -> None:
+        x = var("X")
+
+        assert solve_all(program(), x, conj(neq(x, "homer"), eq(x, "homer"))) == []
+
+    def test_solve_exposes_pending_constraints_on_states(self) -> None:
+        x = var("X")
+        states = list(solve(program(), neq(x, "homer")))
+
+        assert len(states) == 1
+        assert states[0].constraints == (
+            Disequality(left=x, right=atom("homer")),
+        )
+
+    def test_all_different_solves_a_small_coloring_problem(self) -> None:
+        color = relation("color", 1)
+        wa = var("WA")
+        nt = var("NT")
+        sa = var("SA")
+
+        palette = program(
+            fact(color("red")),
+            fact(color("green")),
+            fact(color("blue")),
+        )
+
+        answers = solve_n(
+            palette,
+            3,
+            (wa, nt, sa),
+            conj(
+                color(wa),
+                color(nt),
+                color(sa),
+                all_different(wa, nt, sa),
+            ),
+        )
+
+        assert answers == [
+            (atom("red"), atom("green"), atom("blue")),
+            (atom("red"), atom("blue"), atom("green")),
+            (atom("green"), atom("red"), atom("blue")),
+        ]
 
 
 class TestListRelations:

--- a/code/specs/LP00-logic-core.md
+++ b/code/specs/LP00-logic-core.md
@@ -15,6 +15,7 @@ The package provides:
 - logic variables
 - substitutions
 - unification
+- delayed disequality constraints
 - reification
 - goals
 - states
@@ -260,6 +261,7 @@ This is the relational core of the system.
 The first package version should include:
 
 - `eq(a, b)` — unify two terms
+- `neq(a, b)` — require two terms to remain different
 - `succeed()`
 - `fail()`
 - `conj(g1, g2, ...)`
@@ -277,18 +279,19 @@ Goal : State → Stream[State]
 A state should minimally contain:
 
 - current substitution
+- current disequality constraints
 - fresh-variable counter
 
 ```python
 @dataclass(frozen=True, slots=True)
 class State:
     substitution: Substitution
+    constraints: tuple[Disequality, ...]
     next_var_id: int
 ```
 
 Later extensions may add:
 
-- constraint store
 - trace / proof tree metadata
 - search depth counters
 
@@ -333,6 +336,7 @@ from logic_core import (
     atom,
     term,
     var,
+    neq,
     eq,
     conj,
     disj,
@@ -378,6 +382,7 @@ LogicVar
 Compound
 Substitution
 State
+Disequality
 
 atom(name: str | Symbol) -> Atom
 num(value: int | float) -> Number
@@ -392,6 +397,7 @@ reify(term: Term, subst: Substitution) -> Term
 succeed() -> Goal
 fail() -> Goal
 eq(left: Term, right: Term) -> Goal
+neq(left: Term, right: Term) -> Goal
 conj(*goals: Goal) -> Goal
 disj(*goals: Goal) -> Goal
 fresh(count: int, fn: Callable[..., Goal]) -> Goal
@@ -412,7 +418,7 @@ To keep the first version teachable and correct, it should not include:
 - arithmetic predicates
 - dynamic predicates (`assert`, `retract`)
 - tabling
-- CLP constraints
+- finite-domain / CLP constraints
 
 Those all belong in higher layers.
 
@@ -469,6 +475,8 @@ Required tests:
 - substitution walking resolves chains
 - reification fully resolves nested structures
 - `eq` yields one state on success and zero on failure
+- `neq` stores delayed constraints when disequality is undecided
+- `eq` rechecks stored disequalities after unification
 - conjunction threads substitutions correctly
 - disjunction yields multiple answers
 - `fresh` produces distinct variables
@@ -479,8 +487,6 @@ Required tests:
 
 - fair interleaving search in addition to depth-first search
 - proof traces / explanation trees
-- constraint store
-- disequality constraints
 - arithmetic relations
 - tabling / memoization
 - Datalog subset on the same term substrate

--- a/code/specs/LP01-logic-engine.md
+++ b/code/specs/LP01-logic-engine.md
@@ -144,11 +144,13 @@ This package introduces a *declarative expression layer* above LP00.
 The engine should support:
 
 - `eq(left, right)`
+- `neq(left, right)`
 - `succeed()`
 - `fail()`
 - `conj(g1, g2, ...)`
 - `disj(g1, g2, ...)`
 - `fresh(count, fn)`
+- `all_different(...)`
 - relation calls like `parent(X, Y)`
 
 Unlike LP00, these are not plain `State -> Iterator[State]` functions. They are
@@ -161,6 +163,7 @@ GoalExpr :=
     Succeed
   | Fail
   | Eq(term, term)
+  | Neq(term, term)
   | Conj(goal[])
   | Disj(goal[])
   | Fresh(vars, goal)
@@ -237,9 +240,11 @@ from logic_engine import (
     fact,
     fresh,
     logic_list,
+    neq,
     program,
     relation,
     rule,
+    all_different,
     solve_all,
     solve_n,
     term,
@@ -288,9 +293,11 @@ program(*clauses: Clause) -> Program
 succeed() -> GoalExpr
 fail() -> GoalExpr
 eq(left: object, right: object) -> GoalExpr
+neq(left: object, right: object) -> GoalExpr
 conj(*goals: GoalExpr) -> GoalExpr
 disj(*goals: GoalExpr) -> GoalExpr
 fresh(count: int, fn: Callable[..., GoalExpr]) -> GoalExpr
+all_different(*terms: object) -> GoalExpr
 
 solve(program: Program, goal: GoalExpr) -> Iterator[State]
 solve_all(program: Program, query: object | tuple[object, ...], goal: GoalExpr) -> list[Term | tuple[Term, ...]]
@@ -329,7 +336,7 @@ To keep the first engine slice focused, it should not yet include:
 - dynamic predicates (`assert`, `retract`)
 - arithmetic built-ins
 - tabling
-- constraints
+- finite-domain constraints beyond disequality
 - module systems
 
 ## Python Package Location

--- a/code/specs/LP02-disequality-constraints.md
+++ b/code/specs/LP02-disequality-constraints.md
@@ -1,0 +1,298 @@
+# LP02 — Disequality Constraints For Real Logic Problems
+
+## Overview
+
+`logic-core` and `logic-engine` can now express:
+
+- terms
+- unification
+- facts and rules
+- recursive relation solving
+
+That is enough for relation expansion problems like family trees and graph
+reachability.
+
+It is **not** enough for many real logic problems, because those need to say:
+
+> these two things must **not** become equal
+
+Examples:
+
+- two neighboring regions on a map must have different colors
+- two people cannot occupy the same seat
+- two houses in a logic puzzle cannot share the same attribute value
+- a value must not equal a forbidden choice
+
+This milestone adds that missing idea.
+
+## Design Goal
+
+Add the smallest correct constraint feature that materially increases what the
+library can solve:
+
+- delayed disequality constraints
+- constraint-aware search states
+- engine support for `neq(...)`
+- a convenience helper for pairwise distinct values
+
+This keeps the roadmap engine-first and puzzle-oriented without jumping yet to
+finite-domain solving or full CLP.
+
+## Layer Position
+
+```text
+SYM00 Symbol Core
+    ↓
+LP00 Logic Core
+    - terms
+    - unification
+    - goals
+    - state / search
+    ↓
+LP01 Logic Engine
+    - relations
+    - clauses
+    - recursive resolution
+    ↓
+LP02 Disequality Constraints   ← this milestone
+    - neq
+    - constraint store
+    - all_different helper
+```
+
+## What Problem This Solves
+
+Consider a map-coloring fragment:
+
+```python
+color = relation("color", 1)
+
+goal = conj(
+    color(WA),
+    color(NT),
+    color(SA),
+    neq(WA, NT),
+    neq(WA, SA),
+    neq(NT, SA),
+)
+```
+
+Without disequality, the engine happily gives:
+
+```text
+WA = red, NT = red, SA = red
+```
+
+because nothing forbids those values from collapsing together.
+
+With disequality constraints, that assignment is rejected and the solver keeps
+searching for assignments where adjacent variables stay distinct.
+
+## Core Semantics
+
+### Immediate Failure
+
+If two terms are already equal under the current substitution:
+
+```python
+neq(atom("red"), atom("red"))
+```
+
+then the goal fails immediately.
+
+### Immediate Success
+
+If two terms can already be proven different:
+
+```python
+neq(atom("red"), atom("blue"))
+neq(term("f", "x"), term("g", "x"))
+```
+
+then the goal succeeds immediately and stores no new constraint.
+
+### Delayed Constraint
+
+If the terms are not equal now, but *could* become equal later depending on how
+variables are bound, the solver must keep a pending constraint.
+
+Examples:
+
+```python
+neq(X, atom("red"))
+neq(X, Y)
+neq(term("pair", X, atom("a")), term("pair", atom("red"), Y))
+```
+
+These should succeed for now, but add a constraint to the search state.
+
+## Constraint Store
+
+The search `State` should gain a constraint store.
+
+The first version only needs one constraint kind:
+
+- `Disequality(left, right)`
+
+Conceptually:
+
+```python
+@dataclass(frozen=True, slots=True)
+class State:
+    substitution: Substitution
+    constraints: tuple[Disequality, ...]
+    next_var_id: int
+```
+
+Whenever the substitution changes, the stored disequalities must be rechecked.
+
+Each stored constraint then lands in one of three categories:
+
+1. **violated** — the two sides are equal now → fail the state
+2. **satisfied** — the two sides can no longer unify → drop the constraint
+3. **still pending** — equality is not forced yet, but still possible → keep it
+
+## API Changes
+
+### In `logic-core`
+
+Add:
+
+```python
+Disequality
+neq(left: object, right: object) -> Goal
+```
+
+`eq(...)` must become constraint-aware. A successful unification is only valid
+if all stored disequalities remain consistent with the new substitution.
+
+### In `logic-engine`
+
+Add:
+
+```python
+NeqExpr
+neq(left: object, right: object) -> GoalExpr
+all_different(*terms: object) -> GoalExpr
+```
+
+`all_different` is a convenience combinator that lowers to pairwise `neq(...)`
+constraints:
+
+```text
+all_different(A, B, C)
+⇒ conj(neq(A, B), neq(A, C), neq(B, C))
+```
+
+## Constraint-Aware Search
+
+The search model stays:
+
+- depth-first
+- left-biased
+- generator-based
+
+The new behavior is that states now carry delayed disequalities alongside the
+substitution.
+
+This means backtracking automatically restores both:
+
+- the previous substitution
+- the previous constraint store
+
+That is exactly what we want from a persistent state model.
+
+## Interaction With Reification
+
+Reification should continue to resolve query terms as before.
+
+The first version does **not** need to expose unresolved constraints in the
+returned answer values. Returning the reified query terms is enough.
+
+Advanced callers can still inspect raw `State` values if they want to see the
+remaining pending constraints.
+
+## Engine Example
+
+```python
+from logic_engine import (
+    all_different,
+    fact,
+    conj,
+    program,
+    relation,
+    solve_n,
+    var,
+)
+
+color = relation("color", 1)
+
+palette = program(
+    fact(color("red")),
+    fact(color("green")),
+    fact(color("blue")),
+)
+
+WA = var("WA")
+NT = var("NT")
+SA = var("SA")
+
+answers = solve_n(
+    palette,
+    3,
+    (WA, NT, SA),
+    conj(
+        color(WA),
+        color(NT),
+        color(SA),
+        all_different(WA, NT, SA),
+    ),
+)
+```
+
+The answers should include only colorings where the three variables are pairwise
+different.
+
+## What This Milestone Does NOT Include Yet
+
+To keep scope focused, LP02 does not yet add:
+
+- finite-domain propagation
+- arithmetic constraints
+- CLP(FD)
+- reified constraints
+- optimization / labeling strategies
+- tabling
+- negation-as-failure
+
+This is just the first, smallest useful constraint feature.
+
+## Packages Affected
+
+This milestone should update the existing Python packages:
+
+- `code/packages/python/logic-core`
+- `code/packages/python/logic-engine`
+
+No new package is required yet because disequality is fundamental enough to
+belong directly in the core search model and the engine expression layer.
+
+## Test Strategy
+
+Required tests:
+
+- `neq` fails on already-equal terms
+- `neq` succeeds immediately on obviously different terms
+- `neq` stores a delayed constraint for undecided terms
+- later `eq` that violates a stored constraint fails
+- later `eq` that satisfies a stored constraint drops it
+- `logic-engine` can use `neq` inside solved goals
+- `all_different` works on a small assignment / coloring example
+
+## Why This Milestone Matters
+
+LP01 proved that the repo can solve recursive relational programs.
+
+LP02 makes those programs far more useful by adding the first real constraint
+mechanism. That is the step that starts turning the Python library into a
+genuine logic-problem toolkit rather than only a relation expander.


### PR DESCRIPTION
## Summary
- add the LP02 disequality-constraints spec and sync LP00/LP01 with the new milestone
- teach `logic-core` states and `eq(...)` about delayed disequality constraints via `Disequality` and `neq(...)`
- extend `logic-engine` with `NeqExpr`, `neq(...)`, and `all_different(...)` so we can solve small puzzle-style problems end to end

## Testing
- `.venv/bin/python -m pytest code/packages/python/logic-core/tests -v`
- `.venv/bin/python -m pytest code/packages/python/logic-engine/tests -v`
- `.venv/bin/python -m ruff check code/packages/python/logic-core/src code/packages/python/logic-core/tests code/packages/python/logic-engine/src code/packages/python/logic-engine/tests`

## Notes
- security review passed with no findings
- package-local test runs were used because cross-package collection from the shared Python root currently collides on the `tests` module name