### PR TITLE
feat(lz77): add Dart CMP00 package

### DIFF
--- a/code/packages/dart/lz77/.gitignore
+++ b/code/packages/dart/lz77/.gitignore
@@ -1,0 +1,2 @@
+.dart_tool/
+pubspec.lock

--- a/code/packages/dart/lz77/BUILD
+++ b/code/packages/dart/lz77/BUILD
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/lz77/CHANGELOG.md
+++ b/code/packages/dart/lz77/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Added token-level `encode` and `decode` APIs for teaching and experimentation.
 - Added one-shot `compress` and `decompress` helpers using a fixed-width token format.
 - Added overlap-safe decoding and round-trip coverage for literals, backreferences, and binary data.
+- Added malformed-input validation so invalid backreferences and truncated token streams raise `FormatException`.

--- a/code/packages/dart/lz77/CHANGELOG.md
+++ b/code/packages/dart/lz77/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Added the initial Dart implementation of the CMP00 LZ77 compression package.
+- Added token-level `encode` and `decode` APIs for teaching and experimentation.
+- Added one-shot `compress` and `decompress` helpers using a fixed-width token format.
+- Added overlap-safe decoding and round-trip coverage for literals, backreferences, and binary data.

--- a/code/packages/dart/lz77/README.md
+++ b/code/packages/dart/lz77/README.md
@@ -1,0 +1,40 @@
+# coding_adventures_lz77
+
+LZ77 sliding-window compression for Dart. This package implements the CMP00
+specification from the coding-adventures compression series and exposes both a
+token-level teaching API and a one-shot byte-oriented API.
+
+## What It Provides
+
+- `Token` values of the form `(offset, length, nextChar)`
+- `encode` and `decode` for working directly with LZ77 token streams
+- `compress` and `decompress` for one-shot binary compression
+- `serialiseTokens` and `deserialiseTokens` for the fixed-width teaching format
+
+## Usage
+
+```dart
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:coding_adventures_lz77/lz77.dart';
+
+void main() {
+  final data = Uint8List.fromList(utf8.encode('hello hello hello world'));
+
+  final compressed = compress(data);
+  final original = decompress(compressed);
+
+  final tokens = encode(data);
+  final decoded = decode(tokens);
+
+  print(original.length == decoded.length);
+}
+```
+
+## Building and Testing
+
+```bash
+dart pub get
+dart test
+```

--- a/code/packages/dart/lz77/lib/lz77.dart
+++ b/code/packages/dart/lz77/lib/lz77.dart
@@ -1,0 +1,1 @@
+export 'src/lz77.dart';

--- a/code/packages/dart/lz77/lib/src/lz77.dart
+++ b/code/packages/dart/lz77/lib/src/lz77.dart
@@ -1,0 +1,201 @@
+import 'dart:typed_data';
+
+/// A single LZ77 token represented as `(offset, length, nextChar)`.
+///
+/// The encoder emits either a literal token `(0, 0, byte)` or a backreference
+/// token where `offset` points backwards into the sliding search buffer,
+/// `length` says how many bytes to copy, and `nextChar` finishes the phrase.
+class Token {
+  /// Creates a token with the given LZ77 fields.
+  const Token(this.offset, this.length, this.nextChar);
+
+  /// Distance back from the cursor where the match starts.
+  final int offset;
+
+  /// Number of bytes covered by the backreference match.
+  final int length;
+
+  /// Literal byte appended after the match is copied.
+  final int nextChar;
+
+  @override
+  bool operator ==(Object other) {
+    return other is Token &&
+        other.offset == offset &&
+        other.length == length &&
+        other.nextChar == nextChar;
+  }
+
+  @override
+  int get hashCode => Object.hash(offset, length, nextChar);
+
+  @override
+  String toString() {
+    return 'Token(offset: $offset, length: $length, nextChar: $nextChar)';
+  }
+}
+
+/// Creates a [Token] without needing to call the constructor directly.
+Token token(int offset, int length, int nextChar) {
+  return Token(offset, length, nextChar);
+}
+
+/// Finds the longest match in the sliding search buffer.
+///
+/// The encoder compares every candidate start in the previous `windowSize`
+/// bytes and keeps the longest prefix match against the current cursor.
+({int offset, int length}) _findLongestMatch(
+  Uint8List data,
+  int cursor,
+  int windowSize,
+  int maxMatch,
+) {
+  var bestOffset = 0;
+  var bestLength = 0;
+
+  final searchStart = cursor - windowSize < 0 ? 0 : cursor - windowSize;
+  final lookaheadEnd = _min(cursor + maxMatch, data.length - 1);
+
+  for (var position = searchStart; position < cursor; position++) {
+    var length = 0;
+    while (cursor + length < lookaheadEnd &&
+        data[position + length] == data[cursor + length]) {
+      length += 1;
+    }
+
+    if (length > bestLength) {
+      bestLength = length;
+      bestOffset = cursor - position;
+    }
+  }
+
+  return (offset: bestOffset, length: bestLength);
+}
+
+/// Encodes [data] into LZ77 tokens.
+///
+/// The encoder walks left to right. At each cursor position it finds the
+/// longest match in the previous `windowSize` bytes. If that match is at least
+/// `minMatch` bytes long it becomes a backreference token; otherwise the byte
+/// is emitted as a literal token.
+List<Token> encode(
+  Uint8List data, [
+  int windowSize = 4096,
+  int maxMatch = 255,
+  int minMatch = 3,
+]) {
+  final tokens = <Token>[];
+  var cursor = 0;
+
+  while (cursor < data.length) {
+    // The last byte cannot start a backreference because there would be no
+    // room left to store the required trailing literal `nextChar`.
+    if (cursor == data.length - 1) {
+      tokens.add(token(0, 0, data[cursor]));
+      cursor += 1;
+      continue;
+    }
+
+    final match = _findLongestMatch(data, cursor, windowSize, maxMatch);
+    if (match.length >= minMatch) {
+      final nextChar = data[cursor + match.length];
+      tokens.add(token(match.offset, match.length, nextChar));
+      cursor += match.length + 1;
+    } else {
+      tokens.add(token(0, 0, data[cursor]));
+      cursor += 1;
+    }
+  }
+
+  return List<Token>.unmodifiable(tokens);
+}
+
+/// Decodes LZ77 [tokens] back into the original bytes.
+///
+/// Backreferences are copied byte by byte instead of in bulk so overlapping
+/// matches like `(offset: 1, length: 5)` expand correctly.
+Uint8List decode(
+  List<Token> tokens, [
+  Uint8List? initialBuffer,
+]) {
+  final output = (initialBuffer ?? Uint8List(0)).toList(growable: true);
+
+  for (final current in tokens) {
+    if (current.length > 0) {
+      final start = output.length - current.offset;
+      for (var index = 0; index < current.length; index++) {
+        output.add(output[start + index]);
+      }
+    }
+
+    output.add(current.nextChar);
+  }
+
+  return Uint8List.fromList(output);
+}
+
+/// Serialises a token stream to a fixed-width teaching format.
+///
+/// Layout:
+/// - 4 bytes: token count as big-endian uint32
+/// - N x 4 bytes: `(offset: uint16, length: uint8, nextChar: uint8)`
+Uint8List serialiseTokens(List<Token> tokens) {
+  final bytes = ByteData(4 + tokens.length * 4);
+  bytes.setUint32(0, tokens.length, Endian.big);
+
+  for (var index = 0; index < tokens.length; index++) {
+    final base = 4 + index * 4;
+    final current = tokens[index];
+    bytes.setUint16(base, current.offset, Endian.big);
+    bytes.setUint8(base + 2, current.length);
+    bytes.setUint8(base + 3, current.nextChar);
+  }
+
+  return bytes.buffer.asUint8List();
+}
+
+/// Deserialises the fixed-width teaching format back into tokens.
+List<Token> deserialiseTokens(Uint8List data) {
+  if (data.length < 4) {
+    return const <Token>[];
+  }
+
+  final view =
+      ByteData.view(data.buffer, data.offsetInBytes, data.lengthInBytes);
+  final count = view.getUint32(0, Endian.big);
+  final tokens = <Token>[];
+
+  for (var index = 0; index < count; index++) {
+    final base = 4 + index * 4;
+    if (base + 4 > data.length) {
+      break;
+    }
+
+    tokens.add(
+      token(
+        view.getUint16(base, Endian.big),
+        view.getUint8(base + 2),
+        view.getUint8(base + 3),
+      ),
+    );
+  }
+
+  return List<Token>.unmodifiable(tokens);
+}
+
+/// Compresses [data] using the one-shot LZ77 API.
+Uint8List compress(
+  Uint8List data, [
+  int windowSize = 4096,
+  int maxMatch = 255,
+  int minMatch = 3,
+]) {
+  return serialiseTokens(encode(data, windowSize, maxMatch, minMatch));
+}
+
+/// Decompresses data produced by [compress].
+Uint8List decompress(Uint8List data) {
+  return decode(deserialiseTokens(data));
+}
+
+int _min(int left, int right) => left < right ? left : right;

--- a/code/packages/dart/lz77/lib/src/lz77.dart
+++ b/code/packages/dart/lz77/lib/src/lz77.dart
@@ -114,13 +114,12 @@ List<Token> encode(
 ///
 /// Backreferences are copied byte by byte instead of in bulk so overlapping
 /// matches like `(offset: 1, length: 5)` expand correctly.
-Uint8List decode(
-  List<Token> tokens, [
-  Uint8List? initialBuffer,
-]) {
+Uint8List decode(List<Token> tokens, [Uint8List? initialBuffer]) {
   final output = (initialBuffer ?? Uint8List(0)).toList(growable: true);
 
   for (final current in tokens) {
+    _validateDecodedToken(current, output.length);
+
     if (current.length > 0) {
       final start = output.length - current.offset;
       for (var index = 0; index < current.length; index++) {
@@ -160,24 +159,29 @@ List<Token> deserialiseTokens(Uint8List data) {
     return const <Token>[];
   }
 
-  final view =
-      ByteData.view(data.buffer, data.offsetInBytes, data.lengthInBytes);
+  final view = ByteData.view(
+    data.buffer,
+    data.offsetInBytes,
+    data.lengthInBytes,
+  );
   final count = view.getUint32(0, Endian.big);
   final tokens = <Token>[];
 
   for (var index = 0; index < count; index++) {
     final base = 4 + index * 4;
     if (base + 4 > data.length) {
-      break;
+      throw const FormatException(
+        'Malformed LZ77 token stream: truncated data.',
+      );
     }
 
-    tokens.add(
-      token(
-        view.getUint16(base, Endian.big),
-        view.getUint8(base + 2),
-        view.getUint8(base + 3),
-      ),
+    final current = token(
+      view.getUint16(base, Endian.big),
+      view.getUint8(base + 2),
+      view.getUint8(base + 3),
     );
+    _validateDeserialisedToken(current);
+    tokens.add(current);
   }
 
   return List<Token>.unmodifiable(tokens);
@@ -199,3 +203,42 @@ Uint8List decompress(Uint8List data) {
 }
 
 int _min(int left, int right) => left < right ? left : right;
+
+void _validateDecodedToken(Token current, int outputLength) {
+  if (current.length < 0) {
+    throw FormatException(
+      'Malformed LZ77 token: length must be non-negative, got ${current.length}.',
+    );
+  }
+  if (current.nextChar < 0 || current.nextChar > 255) {
+    throw FormatException(
+      'Malformed LZ77 token: nextChar must be in 0..255, got ${current.nextChar}.',
+    );
+  }
+  if (current.length == 0) {
+    if (current.offset != 0) {
+      throw FormatException(
+        'Malformed LZ77 token: literal tokens must use offset 0, got ${current.offset}.',
+      );
+    }
+    return;
+  }
+  if (current.offset <= 0) {
+    throw FormatException(
+      'Malformed LZ77 token: backreferences must use a positive offset, got ${current.offset}.',
+    );
+  }
+  if (current.offset > outputLength) {
+    throw FormatException(
+      'Malformed LZ77 token: offset ${current.offset} exceeds decoded prefix length $outputLength.',
+    );
+  }
+}
+
+void _validateDeserialisedToken(Token current) {
+  if (current.length > 0 && current.offset == 0) {
+    throw const FormatException(
+      'Malformed LZ77 token stream: backreferences must use a positive offset.',
+    );
+  }
+}

--- a/code/packages/dart/lz77/pubspec.yaml
+++ b/code/packages/dart/lz77/pubspec.yaml
@@ -1,0 +1,14 @@
+name: coding_adventures_lz77
+description: >
+  LZ77 sliding-window compression with token-level and one-shot byte APIs.
+version: 0.1.0
+repository: https://github.com/adhithyan15/coding-adventures
+publish_to: none
+
+environment:
+  sdk: ^3.0.0
+
+dependencies: {}
+
+dev_dependencies:
+  test: ^1.25.0

--- a/code/packages/dart/lz77/test/lz77_test.dart
+++ b/code/packages/dart/lz77/test/lz77_test.dart
@@ -93,8 +93,9 @@ void main() {
     });
 
     test('all 256 byte values round-trip', () {
-      final data =
-          Uint8List.fromList(List<int>.generate(256, (index) => index));
+      final data = Uint8List.fromList(
+        List<int>.generate(256, (index) => index),
+      );
       expect(decode(encode(data)), data);
     });
 
@@ -160,11 +161,7 @@ void main() {
     });
 
     test('overlapping matches are copied byte by byte', () {
-      final tokens = <Token>[
-        token(0, 0, 65),
-        token(0, 0, 66),
-        token(2, 5, 90),
-      ];
+      final tokens = <Token>[token(0, 0, 65), token(0, 0, 66), token(2, 5, 90)];
 
       expect(_dec(decode(tokens)), 'ABABABAZ');
     });
@@ -192,6 +189,41 @@ void main() {
       final result = decode(<Token>[token(2, 3, 90)], _bytes(65, 66));
       expect(_dec(result), 'ABABAZ');
     });
+
+    test('decode rejects zero-offset backreferences', () {
+      expect(
+        () => decode(<Token>[token(0, 3, 90)]),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('decode rejects offsets beyond the decoded prefix', () {
+      expect(
+        () => decode(<Token>[token(2, 1, 90)], _bytes(65)),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('decode rejects literal tokens with a non-zero offset', () {
+      expect(
+        () => decode(<Token>[token(1, 0, 90)]),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('decode rejects negative match lengths', () {
+      expect(
+        () => decode(<Token>[token(0, -1, 90)]),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('decode rejects nextChar values outside byte range', () {
+      expect(
+        () => decode(<Token>[token(0, 0, 256)]),
+        throwsA(isA<FormatException>()),
+      );
+    });
   });
 
   group('serialisation', () {
@@ -202,17 +234,29 @@ void main() {
     });
 
     test('serialise and deserialise are inverses', () {
-      final tokens = <Token>[
-        token(0, 0, 65),
-        token(1, 3, 66),
-        token(2, 5, 67),
-      ];
+      final tokens = <Token>[token(0, 0, 65), token(1, 3, 66), token(2, 5, 67)];
       final serialised = serialiseTokens(tokens);
       expect(deserialiseTokens(serialised), tokens);
     });
 
     test('empty serialised data yields no tokens', () {
       expect(deserialiseTokens(Uint8List(0)), isEmpty);
+    });
+
+    test('truncated serialised data is rejected', () {
+      expect(
+        () => deserialiseTokens(Uint8List.fromList(<int>[0, 0, 0, 1, 0, 2, 3])),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('deserialised backreferences must use a positive offset', () {
+      expect(
+        () => deserialiseTokens(
+          Uint8List.fromList(<int>[0, 0, 0, 1, 0, 0, 3, 90]),
+        ),
+        throwsA(isA<FormatException>()),
+      );
     });
 
     test('compress and decompress all spec vectors', () {
@@ -231,8 +275,9 @@ void main() {
 
   group('behaviour', () {
     test('incompressible data stays within the fixed-width overhead bound', () {
-      final data =
-          Uint8List.fromList(List<int>.generate(256, (index) => index));
+      final data = Uint8List.fromList(
+        List<int>.generate(256, (index) => index),
+      );
       final compressed = compress(data);
       expect(compressed.length, lessThanOrEqualTo(4 * data.length + 10));
     });
@@ -254,8 +299,13 @@ Uint8List _enc(String value) => Uint8List.fromList(utf8.encode(value));
 
 String _dec(Uint8List bytes) => utf8.decode(bytes);
 
-Uint8List _bytes(int first,
-    [int? second, int? third, int? fourth, int? fifth]) {
+Uint8List _bytes(
+  int first, [
+  int? second,
+  int? third,
+  int? fourth,
+  int? fifth,
+]) {
   final values = <int>[first];
   if (second != null) {
     values.add(second);

--- a/code/packages/dart/lz77/test/lz77_test.dart
+++ b/code/packages/dart/lz77/test/lz77_test.dart
@@ -1,0 +1,273 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:coding_adventures_lz77/lz77.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('spec vectors', () {
+    test('empty input produces no tokens', () {
+      expect(encode(Uint8List(0)), isEmpty);
+      expect(decode(const <Token>[]), isEmpty);
+    });
+
+    test('no repetition emits literal tokens', () {
+      final tokens = encode(_enc('ABCDE'));
+      expect(tokens, hasLength(5));
+      for (final current in tokens) {
+        expect(current.offset, 0);
+        expect(current.length, 0);
+      }
+    });
+
+    test('all identical bytes exploit overlapping matches', () {
+      final tokens = encode(_enc('AAAAAAA'));
+      expect(tokens, hasLength(2));
+      expect(tokens[0], token(0, 0, 65));
+      expect(tokens[1].offset, 1);
+      expect(tokens[1].length, 5);
+      expect(tokens[1].nextChar, 65);
+
+      expect(_dec(decode(tokens)), 'AAAAAAA');
+    });
+
+    test('repeated pairs become a backreference', () {
+      final tokens = encode(_enc('ABABABAB'));
+      expect(tokens, hasLength(3));
+      expect(tokens[0], token(0, 0, 65));
+      expect(tokens[1], token(0, 0, 66));
+      expect(tokens[2].offset, 2);
+      expect(tokens[2].length, 5);
+      expect(tokens[2].nextChar, 66);
+
+      expect(_dec(decode(tokens)), 'ABABABAB');
+    });
+
+    test('AABCBBABC with minMatch 3 stays literal-only', () {
+      final tokens = encode(_enc('AABCBBABC'));
+      expect(tokens, hasLength(9));
+      for (final current in tokens) {
+        expect(current.offset, 0);
+        expect(current.length, 0);
+      }
+
+      expect(_dec(decode(tokens)), 'AABCBBABC');
+    });
+
+    test('AABCBBABC with minMatch 2 still round-trips', () {
+      final tokens = encode(_enc('AABCBBABC'), 4096, 255, 2);
+      expect(_dec(decode(tokens)), 'AABCBBABC');
+    });
+  });
+
+  group('round trip', () {
+    test('empty data round-trips', () {
+      expect(decode(encode(Uint8List(0))), isEmpty);
+    });
+
+    test('single bytes round-trip', () {
+      for (final value in <int>[65, 0, 255]) {
+        expect(decode(encode(_bytes(value))), _bytes(value));
+      }
+    });
+
+    for (final sample in <String>[
+      'hello world',
+      'the quick brown fox',
+      'ababababab',
+      'aaaaaaaaaa',
+    ]) {
+      test('string round-trips: $sample', () {
+        expect(_dec(decode(encode(_enc(sample)))), sample);
+      });
+    }
+
+    test('null bytes round-trip', () {
+      final data = _bytes(0, 0, 0);
+      expect(decode(encode(data)), data);
+    });
+
+    test('0xFF bytes round-trip', () {
+      final data = _bytes(255, 255, 255);
+      expect(decode(encode(data)), data);
+    });
+
+    test('all 256 byte values round-trip', () {
+      final data =
+          Uint8List.fromList(List<int>.generate(256, (index) => index));
+      expect(decode(encode(data)), data);
+    });
+
+    test('compress and decompress round-trip', () {
+      for (final sample in <String>[
+        '',
+        'A',
+        'ABCDE',
+        'AAAAAAA',
+        'ABABABAB',
+        'hello world',
+      ]) {
+        final data = _enc(sample);
+        expect(decompress(compress(data)), data);
+      }
+    });
+  });
+
+  group('parameters', () {
+    test('offsets never exceed window size', () {
+      final data = Uint8List(5002);
+      data[0] = 88;
+      for (var index = 1; index < 5001; index++) {
+        data[index] = 89;
+      }
+      data[5001] = 88;
+
+      final tokens = encode(data, 100);
+      for (final current in tokens) {
+        expect(current.offset, lessThanOrEqualTo(100));
+      }
+    });
+
+    test('lengths never exceed maxMatch', () {
+      final data = Uint8List.fromList(List<int>.filled(1000, 65));
+      final tokens = encode(data, 4096, 50);
+      for (final current in tokens) {
+        expect(current.length, lessThanOrEqualTo(50));
+      }
+    });
+
+    test('short matches stay as literals', () {
+      final tokens = encode(_enc('AABAA'), 4096, 255, 2);
+      for (final current in tokens) {
+        expect(current.length == 0 || current.length >= 2, isTrue);
+      }
+    });
+  });
+
+  group('edge cases', () {
+    test('single byte encodes as a literal token', () {
+      final tokens = encode(_enc('X'));
+      expect(tokens, hasLength(1));
+      expect(tokens[0], token(0, 0, 88));
+    });
+
+    test('exact window boundary matches decode correctly', () {
+      const window = 10;
+      final data = Uint8List.fromList(List<int>.filled(window + 1, 88));
+      final tokens = encode(data, window);
+      expect(tokens.any((current) => current.offset > 0), isTrue);
+      expect(decode(tokens), data);
+    });
+
+    test('overlapping matches are copied byte by byte', () {
+      final tokens = <Token>[
+        token(0, 0, 65),
+        token(0, 0, 66),
+        token(2, 5, 90),
+      ];
+
+      expect(_dec(decode(tokens)), 'ABABABAZ');
+    });
+
+    test('binary data with nulls round-trips', () {
+      final data = _bytes(0, 0, 0, 255, 255);
+      expect(decode(encode(data)), data);
+    });
+
+    test('very long inputs round-trip', () {
+      final repeated = _enc(List<String>.filled(100, 'Hello, World! ').join());
+      final extra = Uint8List.fromList(List<int>.filled(500, 88));
+      final data = Uint8List.fromList(<int>[...repeated, ...extra]);
+      expect(decode(encode(data)), data);
+    });
+
+    test('long runs compress into relatively few tokens', () {
+      final data = Uint8List.fromList(List<int>.filled(10000, 65));
+      final tokens = encode(data);
+      expect(tokens.length, lessThan(50));
+      expect(decode(tokens), data);
+    });
+
+    test('initial buffer participates in decoding', () {
+      final result = decode(<Token>[token(2, 3, 90)], _bytes(65, 66));
+      expect(_dec(result), 'ABABAZ');
+    });
+  });
+
+  group('serialisation', () {
+    test('serialised size is four plus four bytes per token', () {
+      final tokens = <Token>[token(0, 0, 65), token(2, 5, 66)];
+      final serialised = serialiseTokens(tokens);
+      expect(serialised.length, 4 + 2 * 4);
+    });
+
+    test('serialise and deserialise are inverses', () {
+      final tokens = <Token>[
+        token(0, 0, 65),
+        token(1, 3, 66),
+        token(2, 5, 67),
+      ];
+      final serialised = serialiseTokens(tokens);
+      expect(deserialiseTokens(serialised), tokens);
+    });
+
+    test('empty serialised data yields no tokens', () {
+      expect(deserialiseTokens(Uint8List(0)), isEmpty);
+    });
+
+    test('compress and decompress all spec vectors', () {
+      for (final sample in <String>[
+        '',
+        'ABCDE',
+        'AAAAAAA',
+        'ABABABAB',
+        'AABCBBABC',
+      ]) {
+        final data = _enc(sample);
+        expect(decompress(compress(data)), data);
+      }
+    });
+  });
+
+  group('behaviour', () {
+    test('incompressible data stays within the fixed-width overhead bound', () {
+      final data =
+          Uint8List.fromList(List<int>.generate(256, (index) => index));
+      final compressed = compress(data);
+      expect(compressed.length, lessThanOrEqualTo(4 * data.length + 10));
+    });
+
+    test('repetitive data compresses to fewer bytes', () {
+      final data = _enc(List<String>.filled(100, 'ABC').join());
+      final compressed = compress(data);
+      expect(compressed.length, lessThan(data.length));
+    });
+
+    test('compression is deterministic', () {
+      final data = _enc('hello world test');
+      expect(compress(data), compress(data));
+    });
+  });
+}
+
+Uint8List _enc(String value) => Uint8List.fromList(utf8.encode(value));
+
+String _dec(Uint8List bytes) => utf8.decode(bytes);
+
+Uint8List _bytes(int first,
+    [int? second, int? third, int? fourth, int? fifth]) {
+  final values = <int>[first];
+  if (second != null) {
+    values.add(second);
+  }
+  if (third != null) {
+    values.add(third);
+  }
+  if (fourth != null) {
+    values.add(fourth);
+  }
+  if (fifth != null) {
+    values.add(fifth);
+  }
+  return Uint8List.fromList(values);
+}

--- a/lessons.md
+++ b/lessons.md
@@ -4,6 +4,24 @@ This file tracks mistakes made during development so they are not repeated. Chec
 
 ---
 
+### 2026-04-18: Dart decompressors must validate backreferences before indexing decoded output
+
+For byte-oriented compression formats like LZ77, the decoder is a trust
+boundary whenever it accepts token streams or compressed bytes from outside the
+process. A malformed token with `offset == 0` or `offset > decoded_prefix_len`
+can trigger a `RangeError` if the implementation blindly indexes into the
+already-decoded output buffer.
+
+**Symptom:** Security review flags a denial-of-service bug because `decode()`
+crashes on hostile compressed input instead of rejecting it cleanly.
+
+**Rule:** Every Dart decoder for backreference-based formats must validate
+token fields before copying. Backreferences need `offset > 0` and
+`offset <= output.length`, and malformed or truncated streams should throw
+`FormatException` rather than indexing past buffer bounds.
+
+---
+
 ### 2026-04-18: Lua rockspecs must pin immutable source refs, not just HTTPS URLs
 
 Switching a Lua rockspec from `git://` to `https://` fixes transport security,


### PR DESCRIPTION
## Summary
- add a new Dart `coding_adventures_lz77` package implementing the CMP00 LZ77 compression spec
- include token-level and one-shot byte APIs, fixed-width token serialization, and repo-standard docs/metadata files
- harden decompression against malformed backreferences and truncated streams, and document the lesson in `lessons.md`

## Verification
- `/tmp/dart-sdk-install/dart-sdk/bin/dart pub get`
- `/tmp/dart-sdk-install/dart-sdk/bin/dart format lib test`
- `/tmp/dart-sdk-install/dart-sdk/bin/dart test`
- `/tmp/dart-sdk-install/dart-sdk/bin/dart test --coverage=coverage`
- `/tmp/dart-sdk-install/dart-sdk/bin/dart run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --packages=.dart_tool/package_config.json --report-on=lib`
- library coverage: `95.88%`

## Security Review
- round 1 found a malformed-input DoS in `decode()` via invalid backreference offsets
- fixed by validating token fields and truncated serialized streams before indexing decoded output
- round 2 passed with no remaining findings