### PR TITLE
feat(dotnet-compression): add brotli packages

### DIFF
--- a/code/packages/csharp/brotli/BUILD
+++ b/code/packages/csharp/brotli/BUILD
@@ -1,0 +1,1 @@
+mkdir -p .dotnet .artifacts && HOME="$PWD/.dotnet" DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_CLI_HOME="$PWD/.dotnet" dotnet test tests/CodingAdventures.Brotli.Tests/CodingAdventures.Brotli.Tests.csproj --disable-build-servers --artifacts-path .artifacts /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/brotli/BUILD_windows
+++ b/code/packages/csharp/brotli/BUILD_windows
@@ -1,0 +1,1 @@
+if not exist ".dotnet" mkdir ".dotnet" && if not exist ".artifacts" mkdir ".artifacts" && set "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1" && set "DOTNET_CLI_HOME=%CD%\.dotnet" && dotnet test "tests/CodingAdventures.Brotli.Tests/CodingAdventures.Brotli.Tests.csproj" --disable-build-servers --artifacts-path ".artifacts" /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/brotli/Brotli.cs
+++ b/code/packages/csharp/brotli/Brotli.cs
@@ -1,0 +1,670 @@
+using System.Buffers.Binary;
+using System.Text;
+using CodingAdventures.HuffmanTree;
+using HuffmanCodec = CodingAdventures.HuffmanTree.HuffmanTree;
+
+namespace CodingAdventures.Brotli;
+
+internal readonly record struct IccEntry(int InsertBase, int InsertExtra, int CopyBase, int CopyExtra);
+
+internal readonly record struct DistEntry(int Code, int Base, int ExtraBits);
+
+internal readonly record struct Command(int InsertLength, int CopyLength, int CopyDistance, byte[] Literals);
+
+internal sealed class BitBuilder
+{
+    private int _buffer;
+    private int _bitPos;
+    private readonly List<byte> _output = [];
+
+    public void WriteBitString(string bits)
+    {
+        foreach (var bit in bits)
+        {
+            if (bit == '1')
+            {
+                _buffer |= 1 << _bitPos;
+            }
+
+            _bitPos++;
+            if (_bitPos == 8)
+            {
+                _output.Add((byte)(_buffer & 0xFF));
+                _buffer = 0;
+                _bitPos = 0;
+            }
+        }
+    }
+
+    public void WriteRawBitsLsb(int value, int count)
+    {
+        for (var index = 0; index < count; index++)
+        {
+            if (((value >> index) & 1) != 0)
+            {
+                _buffer |= 1 << _bitPos;
+            }
+
+            _bitPos++;
+            if (_bitPos == 8)
+            {
+                _output.Add((byte)(_buffer & 0xFF));
+                _buffer = 0;
+                _bitPos = 0;
+            }
+        }
+    }
+
+    public byte[] ToArray()
+    {
+        if (_bitPos > 0)
+        {
+            _output.Add((byte)(_buffer & 0xFF));
+            _buffer = 0;
+            _bitPos = 0;
+        }
+
+        return [.. _output];
+    }
+}
+
+public static class Brotli
+{
+    private const int MaxWindow = 65535;
+    private const int MinMatch = 4;
+    private const int MaxMatch = 258;
+    private const int MaxInsertPerIcc = 32;
+
+    private static readonly IccEntry[] IccTable =
+    [
+        new(0, 0, 4, 0), new(0, 0, 5, 0), new(0, 0, 6, 0), new(0, 0, 8, 1),
+        new(0, 0, 10, 1), new(0, 0, 14, 2), new(0, 0, 18, 2), new(0, 0, 26, 3),
+        new(0, 0, 34, 3), new(0, 0, 50, 4), new(0, 0, 66, 4), new(0, 0, 98, 5),
+        new(0, 0, 130, 5), new(0, 0, 194, 6), new(0, 0, 258, 7), new(0, 0, 514, 8),
+        new(1, 0, 4, 0), new(1, 0, 5, 0), new(1, 0, 6, 0), new(1, 0, 8, 1),
+        new(1, 0, 10, 1), new(1, 0, 14, 2), new(1, 0, 18, 2), new(1, 0, 26, 3),
+        new(2, 0, 4, 0), new(2, 0, 5, 0), new(2, 0, 6, 0), new(2, 0, 8, 1),
+        new(2, 0, 10, 1), new(2, 0, 14, 2), new(2, 0, 18, 2), new(2, 0, 26, 3),
+        new(3, 1, 4, 0), new(3, 1, 5, 0), new(3, 1, 6, 0), new(3, 1, 8, 1),
+        new(3, 1, 10, 1), new(3, 1, 14, 2), new(3, 1, 18, 2), new(3, 1, 26, 3),
+        new(5, 2, 4, 0), new(5, 2, 5, 0), new(5, 2, 6, 0), new(5, 2, 8, 1),
+        new(5, 2, 10, 1), new(5, 2, 14, 2), new(5, 2, 18, 2), new(5, 2, 26, 3),
+        new(9, 3, 4, 0), new(9, 3, 5, 0), new(9, 3, 6, 0), new(9, 3, 8, 1),
+        new(9, 3, 10, 1), new(9, 3, 14, 2), new(9, 3, 18, 2), new(9, 3, 26, 3),
+        new(17, 4, 4, 0), new(17, 4, 5, 0), new(17, 4, 6, 0), new(17, 4, 8, 1),
+        new(17, 4, 10, 1), new(17, 4, 14, 2), new(17, 4, 18, 2), new(0, 0, 0, 0)
+    ];
+
+    private static readonly DistEntry[] DistTable =
+    [
+        new(0, 1, 0), new(1, 2, 0), new(2, 3, 0), new(3, 4, 0),
+        new(4, 5, 1), new(5, 7, 1), new(6, 9, 2), new(7, 13, 2),
+        new(8, 17, 3), new(9, 25, 3), new(10, 33, 4), new(11, 49, 4),
+        new(12, 65, 5), new(13, 97, 5), new(14, 129, 6), new(15, 193, 6),
+        new(16, 257, 7), new(17, 385, 7), new(18, 513, 8), new(19, 769, 8),
+        new(20, 1025, 9), new(21, 1537, 9), new(22, 2049, 10), new(23, 3073, 10),
+        new(24, 4097, 11), new(25, 6145, 11), new(26, 8193, 12), new(27, 12289, 12),
+        new(28, 16385, 13), new(29, 24577, 13), new(30, 32769, 14), new(31, 49153, 14)
+    ];
+
+    public static byte[] Compress(byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+
+        if (data.Length == 0)
+        {
+            return
+            [
+                0, 0, 0, 0,
+                1, 0, 0, 0, 0, 0,
+                63, 1,
+                0
+            ];
+        }
+
+        var (commands, flushLiterals) = BuildCommands(data);
+
+        var literalFrequencies = Enumerable.Range(0, 4)
+            .Select(_ => new Dictionary<int, int>())
+            .ToArray();
+        var iccFrequencies = new Dictionary<int, int>();
+        var distFrequencies = new Dictionary<int, int>();
+        var history = new List<byte>();
+
+        foreach (var command in commands)
+        {
+            if (command.CopyLength == 0)
+            {
+                break;
+            }
+
+            var icc = FindIccCode(command.InsertLength, command.CopyLength);
+            iccFrequencies[icc] = iccFrequencies.GetValueOrDefault(icc) + 1;
+
+            var distanceCode = DistCode(command.CopyDistance);
+            distFrequencies[distanceCode] = distFrequencies.GetValueOrDefault(distanceCode) + 1;
+
+            foreach (var literal in command.Literals)
+            {
+                var ctx = LiteralContext(history.Count > 0 ? history[^1] : -1);
+                literalFrequencies[ctx][literal] = literalFrequencies[ctx].GetValueOrDefault(literal) + 1;
+                history.Add(literal);
+            }
+
+            var start = history.Count - command.CopyDistance;
+            for (var index = 0; index < command.CopyLength; index++)
+            {
+                history.Add(history[start + index]);
+            }
+        }
+
+        iccFrequencies[63] = iccFrequencies.GetValueOrDefault(63) + 1;
+
+        var previousFlush = history.Count > 0 ? history[^1] : -1;
+        foreach (var literal in flushLiterals)
+        {
+            var ctx = LiteralContext(previousFlush);
+            literalFrequencies[ctx][literal] = literalFrequencies[ctx].GetValueOrDefault(literal) + 1;
+            previousFlush = literal;
+        }
+
+        var iccCodeTable = HuffmanCodec.Build(iccFrequencies.Select(pair => (pair.Key, pair.Value))).CanonicalCodeTable();
+
+        IReadOnlyDictionary<int, string> distCodeTable = new Dictionary<int, string>();
+        if (distFrequencies.Count > 0)
+        {
+            distCodeTable = HuffmanCodec.Build(distFrequencies.Select(pair => (pair.Key, pair.Value))).CanonicalCodeTable();
+        }
+
+        var literalCodeTables = new IReadOnlyDictionary<int, string>[4];
+        for (var ctx = 0; ctx < 4; ctx++)
+        {
+            literalCodeTables[ctx] = literalFrequencies[ctx].Count > 0
+                ? HuffmanCodec.Build(literalFrequencies[ctx].Select(pair => (pair.Key, pair.Value))).CanonicalCodeTable()
+                : new Dictionary<int, string>();
+        }
+
+        var builder = new BitBuilder();
+        var encodedHistory = new List<byte>();
+
+        foreach (var command in commands)
+        {
+            if (command.CopyLength == 0)
+            {
+                builder.WriteBitString(iccCodeTable[63]);
+
+                var flushPrevious = encodedHistory.Count > 0 ? encodedHistory[^1] : -1;
+                foreach (var literal in flushLiterals)
+                {
+                    var ctx = LiteralContext(flushPrevious);
+                    builder.WriteBitString(literalCodeTables[ctx][literal]);
+                    flushPrevious = literal;
+                }
+
+                break;
+            }
+
+            var icc = FindIccCode(command.InsertLength, command.CopyLength);
+            var entry = IccTable[icc];
+            builder.WriteBitString(iccCodeTable[icc]);
+            builder.WriteRawBitsLsb(command.InsertLength - entry.InsertBase, entry.InsertExtra);
+            builder.WriteRawBitsLsb(command.CopyLength - entry.CopyBase, entry.CopyExtra);
+
+            foreach (var literal in command.Literals)
+            {
+                var ctx = LiteralContext(encodedHistory.Count > 0 ? encodedHistory[^1] : -1);
+                builder.WriteBitString(literalCodeTables[ctx][literal]);
+                encodedHistory.Add(literal);
+            }
+
+            var distanceCode = DistCode(command.CopyDistance);
+            var distanceEntry = DistTable[distanceCode];
+            builder.WriteBitString(distCodeTable[distanceCode]);
+            builder.WriteRawBitsLsb(command.CopyDistance - distanceEntry.Base, distanceEntry.ExtraBits);
+
+            var start = encodedHistory.Count - command.CopyDistance;
+            for (var index = 0; index < command.CopyLength; index++)
+            {
+                encodedHistory.Add(encodedHistory[start + index]);
+            }
+        }
+
+        var packedBits = builder.ToArray();
+        var iccPairs = SortedPairs(iccCodeTable);
+        var distPairs = SortedPairs(distCodeTable);
+        var literalPairs = literalCodeTables.Select(SortedPairs).ToArray();
+
+        EnsureCountFits("ICC entries", iccPairs.Count);
+        EnsureCountFits("distance entries", distPairs.Count);
+        for (var ctx = 0; ctx < literalPairs.Length; ctx++)
+        {
+            EnsureCountFits($"literal context {ctx} entries", literalPairs[ctx].Count);
+        }
+
+        var totalSize = 10
+            + (iccPairs.Count * 2)
+            + (distPairs.Count * 2)
+            + literalPairs.Sum(pairs => pairs.Count * 3)
+            + packedBits.Length;
+
+        var output = new byte[totalSize];
+        BinaryPrimitives.WriteUInt32BigEndian(output.AsSpan(0, 4), (uint)data.Length);
+        output[4] = (byte)iccPairs.Count;
+        output[5] = (byte)distPairs.Count;
+        output[6] = (byte)literalPairs[0].Count;
+        output[7] = (byte)literalPairs[1].Count;
+        output[8] = (byte)literalPairs[2].Count;
+        output[9] = (byte)literalPairs[3].Count;
+
+        var offset = 10;
+        foreach (var (symbol, length) in iccPairs)
+        {
+            output[offset] = (byte)symbol;
+            output[offset + 1] = (byte)length;
+            offset += 2;
+        }
+
+        foreach (var (symbol, length) in distPairs)
+        {
+            output[offset] = (byte)symbol;
+            output[offset + 1] = (byte)length;
+            offset += 2;
+        }
+
+        foreach (var pairs in literalPairs)
+        {
+            foreach (var (symbol, length) in pairs)
+            {
+                BinaryPrimitives.WriteUInt16BigEndian(output.AsSpan(offset, 2), (ushort)symbol);
+                output[offset + 2] = (byte)length;
+                offset += 3;
+            }
+        }
+
+        packedBits.CopyTo(output, offset);
+        return output;
+    }
+
+    public static byte[] Decompress(byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+
+        if (data.Length < 10)
+        {
+            return [];
+        }
+
+        var originalLength = (int)BinaryPrimitives.ReadUInt32BigEndian(data.AsSpan(0, 4));
+        if (originalLength == 0)
+        {
+            return [];
+        }
+
+        var iccEntryCount = data[4];
+        var distEntryCount = data[5];
+        var literalEntryCounts = new[] { data[6], data[7], data[8], data[9] };
+
+        var offset = 10;
+        if (offset + (iccEntryCount * 2) > data.Length)
+        {
+            return [];
+        }
+
+        var iccLengths = new List<(int Symbol, int Length)>(iccEntryCount);
+        for (var index = 0; index < iccEntryCount; index++)
+        {
+            iccLengths.Add((data[offset], data[offset + 1]));
+            offset += 2;
+        }
+
+        if (offset + (distEntryCount * 2) > data.Length)
+        {
+            return [];
+        }
+
+        var distLengths = new List<(int Symbol, int Length)>(distEntryCount);
+        for (var index = 0; index < distEntryCount; index++)
+        {
+            distLengths.Add((data[offset], data[offset + 1]));
+            offset += 2;
+        }
+
+        var literalLengths = new List<(int Symbol, int Length)>[4];
+        for (var ctx = 0; ctx < 4; ctx++)
+        {
+            var count = literalEntryCounts[ctx];
+            if (offset + (count * 3) > data.Length)
+            {
+                return [];
+            }
+
+            literalLengths[ctx] = [];
+            for (var index = 0; index < count; index++)
+            {
+                literalLengths[ctx].Add((
+                    BinaryPrimitives.ReadUInt16BigEndian(data.AsSpan(offset, 2)),
+                    data[offset + 2]));
+                offset += 3;
+            }
+        }
+
+        var iccCodes = ReconstructCanonicalCodes(iccLengths);
+        var distCodes = ReconstructCanonicalCodes(distLengths);
+        var literalCodes = literalLengths.Select(ReconstructCanonicalCodes).ToArray();
+        var bits = UnpackBits(data.AsSpan(offset));
+        var bitPos = 0;
+        var output = new List<byte>(originalLength);
+        var previous = -1;
+
+        while (output.Count < originalLength)
+        {
+            var icc = NextHuffmanSymbol(iccCodes, bits, ref bitPos);
+
+            if (icc == 63)
+            {
+                while (output.Count < originalLength)
+                {
+                    var ctx = LiteralContext(previous);
+                    var literal = NextHuffmanSymbol(literalCodes[ctx], bits, ref bitPos);
+                    output.Add((byte)literal);
+                    previous = literal;
+                }
+
+                break;
+            }
+
+            var entry = IccTable[icc];
+            var insertLength = entry.InsertBase + ReadRawBits(bits, ref bitPos, entry.InsertExtra);
+            var copyLength = entry.CopyBase + ReadRawBits(bits, ref bitPos, entry.CopyExtra);
+
+            for (var index = 0; index < insertLength; index++)
+            {
+                var ctx = LiteralContext(previous);
+                var literal = NextHuffmanSymbol(literalCodes[ctx], bits, ref bitPos);
+                output.Add((byte)literal);
+                previous = literal;
+            }
+
+            if (copyLength == 0)
+            {
+                continue;
+            }
+
+            if (distCodes.Count == 0)
+            {
+                throw new InvalidOperationException("Compressed stream references a distance code without a distance tree");
+            }
+
+            var distanceCode = NextHuffmanSymbol(distCodes, bits, ref bitPos);
+            var distanceEntry = DistTable[distanceCode];
+            var copyDistance = distanceEntry.Base + ReadRawBits(bits, ref bitPos, distanceEntry.ExtraBits);
+            var start = output.Count - copyDistance;
+            if (start < 0)
+            {
+                throw new InvalidOperationException("Distance extends before the output buffer");
+            }
+
+            for (var index = 0; index < copyLength; index++)
+            {
+                var value = output[start + index];
+                output.Add(value);
+                previous = value;
+            }
+        }
+
+        return output.Take(originalLength).ToArray();
+    }
+
+    private static int LiteralContext(int previousByte)
+    {
+        if (previousByte is >= 0x61 and <= 0x7A)
+        {
+            return 3;
+        }
+
+        if (previousByte is >= 0x41 and <= 0x5A)
+        {
+            return 2;
+        }
+
+        return previousByte is >= 0x30 and <= 0x39 ? 1 : 0;
+    }
+
+    private static int FindIccCode(int insertLength, int copyLength)
+    {
+        for (var code = 0; code < 63; code++)
+        {
+            var entry = IccTable[code];
+            var maxInsert = entry.InsertBase + (1 << entry.InsertExtra) - 1;
+            var maxCopy = entry.CopyBase + (1 << entry.CopyExtra) - 1;
+            if (insertLength >= entry.InsertBase
+                && insertLength <= maxInsert
+                && copyLength >= entry.CopyBase
+                && copyLength <= maxCopy)
+            {
+                return code;
+            }
+        }
+
+        for (var code = 0; code < 16; code++)
+        {
+            var entry = IccTable[code];
+            var maxCopy = entry.CopyBase + (1 << entry.CopyExtra) - 1;
+            if (copyLength >= entry.CopyBase && copyLength <= maxCopy)
+            {
+                return code;
+            }
+        }
+
+        return 0;
+    }
+
+    private static int FindBestIccCopy(int insertLength, int copyLength)
+    {
+        var best = 0;
+        for (var code = 0; code < 63; code++)
+        {
+            var entry = IccTable[code];
+            var maxInsert = entry.InsertBase + (1 << entry.InsertExtra) - 1;
+            if (insertLength < entry.InsertBase || insertLength > maxInsert)
+            {
+                continue;
+            }
+
+            var maxCopy = entry.CopyBase + (1 << entry.CopyExtra) - 1;
+            if (copyLength >= entry.CopyBase && copyLength <= maxCopy)
+            {
+                return copyLength;
+            }
+
+            if (maxCopy <= copyLength && maxCopy > best)
+            {
+                best = maxCopy;
+            }
+        }
+
+        return Math.Max(best, MinMatch);
+    }
+
+    private static int DistCode(int distance)
+    {
+        foreach (var entry in DistTable)
+        {
+            var maxDistance = entry.Base + (1 << entry.ExtraBits) - 1;
+            if (distance <= maxDistance)
+            {
+                return entry.Code;
+            }
+        }
+
+        return 31;
+    }
+
+    private static (int Offset, int Length) FindLongestMatch(byte[] data, int pos)
+    {
+        var windowStart = Math.Max(0, pos - MaxWindow);
+        var bestLength = 0;
+        var bestOffset = 0;
+
+        for (var start = pos - 1; start >= windowStart; start--)
+        {
+            if (data[start] != data[pos])
+            {
+                continue;
+            }
+
+            var maxLength = Math.Min(MaxMatch, data.Length - pos);
+            var matchLength = 0;
+            while (matchLength < maxLength && data[start + matchLength] == data[pos + matchLength])
+            {
+                matchLength++;
+            }
+
+            if (matchLength > bestLength)
+            {
+                bestLength = matchLength;
+                bestOffset = pos - start;
+                if (bestLength == MaxMatch)
+                {
+                    break;
+                }
+            }
+        }
+
+        return bestLength < MinMatch ? (0, 0) : (bestOffset, bestLength);
+    }
+
+    private static (List<Command> Commands, List<byte> FlushLiterals) BuildCommands(byte[] data)
+    {
+        var commands = new List<Command>();
+        var insertBuffer = new List<byte>();
+        var pos = 0;
+
+        while (pos < data.Length)
+        {
+            var (offset, length) = FindLongestMatch(data, pos);
+            if (length >= MinMatch && insertBuffer.Count <= MaxInsertPerIcc)
+            {
+                var actualCopy = FindBestIccCopy(insertBuffer.Count, length);
+                commands.Add(new Command(insertBuffer.Count, actualCopy, offset, [.. insertBuffer]));
+                insertBuffer.Clear();
+                pos += actualCopy;
+            }
+            else
+            {
+                insertBuffer.Add(data[pos]);
+                pos++;
+            }
+        }
+
+        var flushLiterals = insertBuffer.ToList();
+        commands.Add(new Command(0, 0, 0, []));
+        return (commands, flushLiterals);
+    }
+
+    private static List<(int Symbol, int Length)> SortedPairs(IReadOnlyDictionary<int, string> table) =>
+        table.Select(pair => (Symbol: pair.Key, Length: pair.Value.Length))
+            .OrderBy(pair => pair.Length)
+            .ThenBy(pair => pair.Symbol)
+            .Select(pair => (pair.Symbol, pair.Length))
+            .ToList();
+
+    private static void EnsureCountFits(string label, int count)
+    {
+        if (count > byte.MaxValue)
+        {
+            throw new InvalidOperationException($"{label} exceed the CMP06 one-byte header limit");
+        }
+    }
+
+    private static Dictionary<string, int> ReconstructCanonicalCodes(IEnumerable<(int Symbol, int Length)> lengths)
+    {
+        var ordered = lengths
+            .Where(pair => pair.Length > 0)
+            .OrderBy(pair => pair.Length)
+            .ThenBy(pair => pair.Symbol)
+            .ToList();
+
+        if (ordered.Count == 0)
+        {
+            return [];
+        }
+
+        if (ordered.Count == 1)
+        {
+            return new Dictionary<string, int> { ["0"] = ordered[0].Symbol };
+        }
+
+        var codes = new Dictionary<string, int>();
+        var codeValue = 0;
+        var previousLength = ordered[0].Length;
+        foreach (var (symbol, length) in ordered)
+        {
+            if (length > previousLength)
+            {
+                codeValue <<= length - previousLength;
+            }
+
+            codes[Convert.ToString(codeValue, 2).PadLeft(length, '0')] = symbol;
+            codeValue++;
+            previousLength = length;
+        }
+
+        return codes;
+    }
+
+    private static string UnpackBits(ReadOnlySpan<byte> data)
+    {
+        var builder = new StringBuilder(data.Length * 8);
+        foreach (var value in data)
+        {
+            for (var bit = 0; bit < 8; bit++)
+            {
+                builder.Append(((value >> bit) & 1) != 0 ? '1' : '0');
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    private static int ReadRawBits(string bits, ref int bitPos, int count)
+    {
+        var value = 0;
+        for (var index = 0; index < count; index++)
+        {
+            if (bitPos + index >= bits.Length)
+            {
+                throw new InvalidOperationException("Unexpected end of compressed bit stream");
+            }
+
+            if (bits[bitPos + index] == '1')
+            {
+                value |= 1 << index;
+            }
+        }
+
+        bitPos += count;
+        return value;
+    }
+
+    private static int NextHuffmanSymbol(IReadOnlyDictionary<string, int> codes, string bits, ref int bitPos)
+    {
+        if (codes.Count == 0)
+        {
+            throw new InvalidOperationException("Missing Huffman codes");
+        }
+
+        var builder = new StringBuilder();
+        while (bitPos < bits.Length)
+        {
+            builder.Append(bits[bitPos]);
+            bitPos++;
+            if (codes.TryGetValue(builder.ToString(), out var symbol))
+            {
+                return symbol;
+            }
+        }
+
+        throw new InvalidOperationException("Unexpected end of compressed bit stream");
+    }
+}

--- a/code/packages/csharp/brotli/CHANGELOG.md
+++ b/code/packages/csharp/brotli/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-18
+
+### Added
+
+- Pure C# CMP06 Brotli-style implementation with insert-copy commands, literal contexts, and long-distance matches
+- Canonical Huffman table emission for ICC, distance, and per-context literal alphabets
+- One-shot `Compress` and `Decompress` helpers using the repo's teaching wire format
+- xUnit coverage for spec vectors, deterministic output, manual wire payloads, long-distance copies, and compression sanity checks

--- a/code/packages/csharp/brotli/CodingAdventures.Brotli.csproj
+++ b/code/packages/csharp/brotli/CodingAdventures.Brotli.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.Brotli.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure C# Brotli-style compression in the repo's CMP06 wire format</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\huffman-tree\CodingAdventures.HuffmanTree.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/brotli/README.md
+++ b/code/packages/csharp/brotli/README.md
@@ -1,0 +1,29 @@
+# brotli
+
+Pure C# Brotli-style compression for the CMP06 context-aware insert-copy stage.
+
+## What It Includes
+
+- The CMP06 insert-and-copy command table with sentinel handling
+- Four literal-context Huffman trees keyed off the previous emitted byte
+- An in-language sliding-window matcher up to the CMP06 `65535` byte window
+- Canonical Huffman wire-format encoding for ICC, distance, and literal tables
+- One-shot `Compress` and `Decompress` helpers over the pure codec
+
+## Example
+
+```csharp
+using System.Text;
+using CodingAdventures.Brotli;
+
+var compressed = Brotli.Compress(Encoding.UTF8.GetBytes("abc123ABC"));
+var roundTrip = Encoding.UTF8.GetString(Brotli.Decompress(compressed));
+
+Console.WriteLine(roundTrip); // abc123ABC
+```
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/csharp/brotli/required_capabilities.json
+++ b/code/packages/csharp/brotli/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/brotli",
+  "capabilities": [],
+  "justification": "Pure in-memory C# CMP06 Brotli-style implementation and tests."
+}

--- a/code/packages/csharp/brotli/tests/CodingAdventures.Brotli.Tests/BrotliTests.cs
+++ b/code/packages/csharp/brotli/tests/CodingAdventures.Brotli.Tests/BrotliTests.cs
@@ -1,0 +1,166 @@
+using System.Buffers.Binary;
+using System.Text;
+using CodingAdventures.Brotli;
+
+namespace CodingAdventures.Brotli.Tests;
+
+public sealed class BrotliTests
+{
+    [Fact]
+    public void EmptyInputUsesMinimalEncoding()
+    {
+        var compressed = Brotli.Compress([]);
+        Assert.Equal(13, compressed.Length);
+        Assert.Equal(0u, BinaryPrimitives.ReadUInt32BigEndian(compressed.AsSpan(0, 4)));
+        Assert.Equal((byte)1, compressed[4]);
+        Assert.Equal((byte)0, compressed[5]);
+        Assert.Equal([], Brotli.Decompress(compressed));
+    }
+
+    [Theory]
+    [InlineData((byte)0x42)]
+    [InlineData((byte)0x00)]
+    [InlineData((byte)0xFF)]
+    public void SingleByteValuesRoundTrip(byte value)
+    {
+        var data = new[] { value };
+        Assert.Equal(data, Brotli.Decompress(Brotli.Compress(data)));
+    }
+
+    [Fact]
+    public void RepeatedADataCompressesWell()
+    {
+        var data = new byte[1024];
+        Array.Fill(data, (byte)'A');
+        var compressed = Brotli.Compress(data);
+
+        Assert.Equal(data, Brotli.Decompress(compressed));
+        Assert.True(compressed.Length < data.Length / 2.0);
+        Assert.True(compressed[5] > 0);
+    }
+
+    [Fact]
+    public void EnglishProseRoundTrips()
+    {
+        var data = Bytes(string.Concat(Enumerable.Repeat(
+            "The quick brown fox jumps over the lazy dog. Pack my box with five dozen liquor jugs. ",
+            16)));
+
+        var compressed = Brotli.Compress(data);
+        Assert.Equal(data, Brotli.Decompress(compressed));
+        Assert.True(compressed.Length < data.Length * 0.8);
+    }
+
+    [Fact]
+    public void BinaryDataRoundTrips()
+    {
+        var data = new byte[512];
+        uint state = 0xDEADBEEF;
+        for (var index = 0; index < data.Length; index++)
+        {
+            state = (state >> 1) ^ ((state & 1) == 0 ? 0u : 0xEDB88320u);
+            data[index] = (byte)(state & 0xFF);
+        }
+
+        Assert.Equal(data, Brotli.Decompress(Brotli.Compress(data)));
+    }
+
+    [Fact]
+    public void ContextTransitionsRoundTrip()
+    {
+        var data = Bytes("abc123ABCabc");
+        var compressed = Brotli.Compress(data);
+
+        Assert.Equal(data, Brotli.Decompress(compressed));
+        Assert.True(compressed[6] > 0);
+        Assert.True(compressed[7] > 0);
+        Assert.True(compressed[8] > 0);
+    }
+
+    [Fact]
+    public void LongDistanceMatchRoundTrips()
+    {
+        var marker = Bytes("XYZABCDEFG");
+        var filler = Enumerable.Repeat((byte)'B', 4200).ToArray();
+        var data = new byte[marker.Length + filler.Length + marker.Length];
+        marker.CopyTo(data, 0);
+        filler.CopyTo(data, marker.Length);
+        marker.CopyTo(data, marker.Length + filler.Length);
+
+        var compressed = Brotli.Compress(data);
+        Assert.Equal(data, Brotli.Decompress(compressed));
+        Assert.True(compressed[5] > 0);
+    }
+
+    [Fact]
+    public void CompressionIsDeterministic()
+    {
+        var data = Bytes("The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog.");
+        var a = Brotli.Compress(data);
+        var b = Brotli.Compress(data);
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    public void ManualPayloadForSingleADecompresses()
+    {
+        var payload = new byte[]
+        {
+            0x00, 0x00, 0x00, 0x01,
+            0x01,
+            0x00,
+            0x01,
+            0x00,
+            0x00,
+            0x00,
+            0x3F, 0x01,
+            0x00, 0x41, 0x01,
+            0x00
+        };
+
+        Assert.Equal(Bytes("A"), Brotli.Decompress(payload));
+    }
+
+    [Fact]
+    public void ManualPayloadForEmptyInputDecompresses()
+    {
+        var payload = new byte[]
+        {
+            0x00, 0x00, 0x00, 0x00,
+            0x01,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x3F, 0x01,
+            0x00
+        };
+
+        Assert.Equal([], Brotli.Decompress(payload));
+    }
+
+    [Fact]
+    public void HeaderStoresOriginalLength()
+    {
+        var data = Bytes("Hello, Brotli!");
+        var compressed = Brotli.Compress(data);
+        Assert.Equal((uint)data.Length, BinaryPrimitives.ReadUInt32BigEndian(compressed.AsSpan(0, 4)));
+    }
+
+    [Fact]
+    public void IccSentinelAlwaysPresent()
+    {
+        var compressed = Brotli.Compress(Bytes("test"));
+        Assert.True(compressed[4] > 0);
+    }
+
+    [Fact]
+    public void AllDistinctByteValuesRoundTrip()
+    {
+        var data = Enumerable.Range(0, 256).Select(value => (byte)value).ToArray();
+        Assert.Equal(data, Brotli.Decompress(Brotli.Compress(data)));
+    }
+
+    private static byte[] Bytes(string value) => Encoding.UTF8.GetBytes(value);
+}

--- a/code/packages/csharp/brotli/tests/CodingAdventures.Brotli.Tests/CodingAdventures.Brotli.Tests.csproj
+++ b/code/packages/csharp/brotli/tests/CodingAdventures.Brotli.Tests/CodingAdventures.Brotli.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Brotli.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/brotli/BUILD
+++ b/code/packages/fsharp/brotli/BUILD
@@ -1,0 +1,1 @@
+mkdir -p .dotnet .artifacts && HOME="$PWD/.dotnet" DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_CLI_HOME="$PWD/.dotnet" dotnet test tests/CodingAdventures.Brotli.Tests/CodingAdventures.Brotli.Tests.fsproj --disable-build-servers --artifacts-path .artifacts /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/brotli/BUILD_windows
+++ b/code/packages/fsharp/brotli/BUILD_windows
@@ -1,0 +1,1 @@
+if not exist ".dotnet" mkdir ".dotnet" && if not exist ".artifacts" mkdir ".artifacts" && set "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1" && set "DOTNET_CLI_HOME=%CD%\.dotnet" && dotnet test "tests/CodingAdventures.Brotli.Tests/CodingAdventures.Brotli.Tests.fsproj" --disable-build-servers --artifacts-path ".artifacts" /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/brotli/Brotli.fs
+++ b/code/packages/fsharp/brotli/Brotli.fs
@@ -1,0 +1,598 @@
+namespace CodingAdventures.Brotli.FSharp
+
+open System
+open System.Buffers.Binary
+open System.Collections.Generic
+open System.Text
+open CodingAdventures.HuffmanTree.FSharp
+
+type private IccEntry =
+    {
+        InsertBase: int
+        InsertExtra: int
+        CopyBase: int
+        CopyExtra: int
+    }
+
+type private DistEntry =
+    {
+        Code: int
+        Base: int
+        ExtraBits: int
+    }
+
+type private Command =
+    {
+        InsertLength: int
+        CopyLength: int
+        CopyDistance: int
+        Literals: byte array
+    }
+
+module private Tables =
+    let IccTable =
+        [|
+            { InsertBase = 0; InsertExtra = 0; CopyBase = 4; CopyExtra = 0 }
+            { InsertBase = 0; InsertExtra = 0; CopyBase = 5; CopyExtra = 0 }
+            { InsertBase = 0; InsertExtra = 0; CopyBase = 6; CopyExtra = 0 }
+            { InsertBase = 0; InsertExtra = 0; CopyBase = 8; CopyExtra = 1 }
+            { InsertBase = 0; InsertExtra = 0; CopyBase = 10; CopyExtra = 1 }
+            { InsertBase = 0; InsertExtra = 0; CopyBase = 14; CopyExtra = 2 }
+            { InsertBase = 0; InsertExtra = 0; CopyBase = 18; CopyExtra = 2 }
+            { InsertBase = 0; InsertExtra = 0; CopyBase = 26; CopyExtra = 3 }
+            { InsertBase = 0; InsertExtra = 0; CopyBase = 34; CopyExtra = 3 }
+            { InsertBase = 0; InsertExtra = 0; CopyBase = 50; CopyExtra = 4 }
+            { InsertBase = 0; InsertExtra = 0; CopyBase = 66; CopyExtra = 4 }
+            { InsertBase = 0; InsertExtra = 0; CopyBase = 98; CopyExtra = 5 }
+            { InsertBase = 0; InsertExtra = 0; CopyBase = 130; CopyExtra = 5 }
+            { InsertBase = 0; InsertExtra = 0; CopyBase = 194; CopyExtra = 6 }
+            { InsertBase = 0; InsertExtra = 0; CopyBase = 258; CopyExtra = 7 }
+            { InsertBase = 0; InsertExtra = 0; CopyBase = 514; CopyExtra = 8 }
+            { InsertBase = 1; InsertExtra = 0; CopyBase = 4; CopyExtra = 0 }
+            { InsertBase = 1; InsertExtra = 0; CopyBase = 5; CopyExtra = 0 }
+            { InsertBase = 1; InsertExtra = 0; CopyBase = 6; CopyExtra = 0 }
+            { InsertBase = 1; InsertExtra = 0; CopyBase = 8; CopyExtra = 1 }
+            { InsertBase = 1; InsertExtra = 0; CopyBase = 10; CopyExtra = 1 }
+            { InsertBase = 1; InsertExtra = 0; CopyBase = 14; CopyExtra = 2 }
+            { InsertBase = 1; InsertExtra = 0; CopyBase = 18; CopyExtra = 2 }
+            { InsertBase = 1; InsertExtra = 0; CopyBase = 26; CopyExtra = 3 }
+            { InsertBase = 2; InsertExtra = 0; CopyBase = 4; CopyExtra = 0 }
+            { InsertBase = 2; InsertExtra = 0; CopyBase = 5; CopyExtra = 0 }
+            { InsertBase = 2; InsertExtra = 0; CopyBase = 6; CopyExtra = 0 }
+            { InsertBase = 2; InsertExtra = 0; CopyBase = 8; CopyExtra = 1 }
+            { InsertBase = 2; InsertExtra = 0; CopyBase = 10; CopyExtra = 1 }
+            { InsertBase = 2; InsertExtra = 0; CopyBase = 14; CopyExtra = 2 }
+            { InsertBase = 2; InsertExtra = 0; CopyBase = 18; CopyExtra = 2 }
+            { InsertBase = 2; InsertExtra = 0; CopyBase = 26; CopyExtra = 3 }
+            { InsertBase = 3; InsertExtra = 1; CopyBase = 4; CopyExtra = 0 }
+            { InsertBase = 3; InsertExtra = 1; CopyBase = 5; CopyExtra = 0 }
+            { InsertBase = 3; InsertExtra = 1; CopyBase = 6; CopyExtra = 0 }
+            { InsertBase = 3; InsertExtra = 1; CopyBase = 8; CopyExtra = 1 }
+            { InsertBase = 3; InsertExtra = 1; CopyBase = 10; CopyExtra = 1 }
+            { InsertBase = 3; InsertExtra = 1; CopyBase = 14; CopyExtra = 2 }
+            { InsertBase = 3; InsertExtra = 1; CopyBase = 18; CopyExtra = 2 }
+            { InsertBase = 3; InsertExtra = 1; CopyBase = 26; CopyExtra = 3 }
+            { InsertBase = 5; InsertExtra = 2; CopyBase = 4; CopyExtra = 0 }
+            { InsertBase = 5; InsertExtra = 2; CopyBase = 5; CopyExtra = 0 }
+            { InsertBase = 5; InsertExtra = 2; CopyBase = 6; CopyExtra = 0 }
+            { InsertBase = 5; InsertExtra = 2; CopyBase = 8; CopyExtra = 1 }
+            { InsertBase = 5; InsertExtra = 2; CopyBase = 10; CopyExtra = 1 }
+            { InsertBase = 5; InsertExtra = 2; CopyBase = 14; CopyExtra = 2 }
+            { InsertBase = 5; InsertExtra = 2; CopyBase = 18; CopyExtra = 2 }
+            { InsertBase = 5; InsertExtra = 2; CopyBase = 26; CopyExtra = 3 }
+            { InsertBase = 9; InsertExtra = 3; CopyBase = 4; CopyExtra = 0 }
+            { InsertBase = 9; InsertExtra = 3; CopyBase = 5; CopyExtra = 0 }
+            { InsertBase = 9; InsertExtra = 3; CopyBase = 6; CopyExtra = 0 }
+            { InsertBase = 9; InsertExtra = 3; CopyBase = 8; CopyExtra = 1 }
+            { InsertBase = 9; InsertExtra = 3; CopyBase = 10; CopyExtra = 1 }
+            { InsertBase = 9; InsertExtra = 3; CopyBase = 14; CopyExtra = 2 }
+            { InsertBase = 9; InsertExtra = 3; CopyBase = 18; CopyExtra = 2 }
+            { InsertBase = 9; InsertExtra = 3; CopyBase = 26; CopyExtra = 3 }
+            { InsertBase = 17; InsertExtra = 4; CopyBase = 4; CopyExtra = 0 }
+            { InsertBase = 17; InsertExtra = 4; CopyBase = 5; CopyExtra = 0 }
+            { InsertBase = 17; InsertExtra = 4; CopyBase = 6; CopyExtra = 0 }
+            { InsertBase = 17; InsertExtra = 4; CopyBase = 8; CopyExtra = 1 }
+            { InsertBase = 17; InsertExtra = 4; CopyBase = 10; CopyExtra = 1 }
+            { InsertBase = 17; InsertExtra = 4; CopyBase = 14; CopyExtra = 2 }
+            { InsertBase = 17; InsertExtra = 4; CopyBase = 18; CopyExtra = 2 }
+            { InsertBase = 0; InsertExtra = 0; CopyBase = 0; CopyExtra = 0 }
+        |]
+
+    let DistTable =
+        [|
+            { Code = 0; Base = 1; ExtraBits = 0 }
+            { Code = 1; Base = 2; ExtraBits = 0 }
+            { Code = 2; Base = 3; ExtraBits = 0 }
+            { Code = 3; Base = 4; ExtraBits = 0 }
+            { Code = 4; Base = 5; ExtraBits = 1 }
+            { Code = 5; Base = 7; ExtraBits = 1 }
+            { Code = 6; Base = 9; ExtraBits = 2 }
+            { Code = 7; Base = 13; ExtraBits = 2 }
+            { Code = 8; Base = 17; ExtraBits = 3 }
+            { Code = 9; Base = 25; ExtraBits = 3 }
+            { Code = 10; Base = 33; ExtraBits = 4 }
+            { Code = 11; Base = 49; ExtraBits = 4 }
+            { Code = 12; Base = 65; ExtraBits = 5 }
+            { Code = 13; Base = 97; ExtraBits = 5 }
+            { Code = 14; Base = 129; ExtraBits = 6 }
+            { Code = 15; Base = 193; ExtraBits = 6 }
+            { Code = 16; Base = 257; ExtraBits = 7 }
+            { Code = 17; Base = 385; ExtraBits = 7 }
+            { Code = 18; Base = 513; ExtraBits = 8 }
+            { Code = 19; Base = 769; ExtraBits = 8 }
+            { Code = 20; Base = 1025; ExtraBits = 9 }
+            { Code = 21; Base = 1537; ExtraBits = 9 }
+            { Code = 22; Base = 2049; ExtraBits = 10 }
+            { Code = 23; Base = 3073; ExtraBits = 10 }
+            { Code = 24; Base = 4097; ExtraBits = 11 }
+            { Code = 25; Base = 6145; ExtraBits = 11 }
+            { Code = 26; Base = 8193; ExtraBits = 12 }
+            { Code = 27; Base = 12289; ExtraBits = 12 }
+            { Code = 28; Base = 16385; ExtraBits = 13 }
+            { Code = 29; Base = 24577; ExtraBits = 13 }
+            { Code = 30; Base = 32769; ExtraBits = 14 }
+            { Code = 31; Base = 49153; ExtraBits = 14 }
+        |]
+
+type BitBuilder() =
+    let output = ResizeArray<byte>()
+    let mutable buffer = 0
+    let mutable bitPos = 0
+
+    member _.WriteBitString(bits: string) =
+        for bit in bits do
+            if bit = '1' then
+                buffer <- buffer ||| (1 <<< bitPos)
+
+            bitPos <- bitPos + 1
+            if bitPos = 8 then
+                output.Add(byte (buffer &&& 0xFF))
+                buffer <- 0
+                bitPos <- 0
+
+    member _.WriteRawBitsLsb(value: int, count: int) =
+        for index in 0 .. count - 1 do
+            if ((value >>> index) &&& 1) <> 0 then
+                buffer <- buffer ||| (1 <<< bitPos)
+
+            bitPos <- bitPos + 1
+            if bitPos = 8 then
+                output.Add(byte (buffer &&& 0xFF))
+                buffer <- 0
+                bitPos <- 0
+
+    member _.ToArray() =
+        if bitPos > 0 then
+            output.Add(byte (buffer &&& 0xFF))
+            buffer <- 0
+            bitPos <- 0
+
+        output.ToArray()
+
+[<AbstractClass; Sealed>]
+type Brotli =
+    static member private MaxWindow = 65535
+    static member private MinMatch = 4
+    static member private MaxMatch = 258
+    static member private MaxInsertPerIcc = 32
+
+    static member Compress(data: byte array) =
+        if isNull data then nullArg "data"
+
+        if data.Length = 0 then
+            [|
+                0uy; 0uy; 0uy; 0uy
+                1uy; 0uy; 0uy; 0uy; 0uy; 0uy
+                63uy; 1uy
+                0uy
+            |]
+        else
+            let commands, flushLiterals = Brotli.BuildCommands(data)
+            let literalFreq =
+                [|
+                    Dictionary<int, int>()
+                    Dictionary<int, int>()
+                    Dictionary<int, int>()
+                    Dictionary<int, int>()
+                |]
+
+            let iccFreq = Dictionary<int, int>()
+            let distFreq = Dictionary<int, int>()
+            let history = ResizeArray<byte>()
+
+            for command in commands do
+                if command.CopyLength > 0 then
+                    let icc = Brotli.FindIccCode(command.InsertLength, command.CopyLength)
+                    iccFreq[icc] <- (if iccFreq.ContainsKey icc then iccFreq[icc] else 0) + 1
+
+                    let distanceCode = Brotli.DistCode(command.CopyDistance)
+                    distFreq[distanceCode] <- (if distFreq.ContainsKey distanceCode then distFreq[distanceCode] else 0) + 1
+
+                    for literal in command.Literals do
+                        let ctx = Brotli.LiteralContext(if history.Count > 0 then int history[history.Count - 1] else -1)
+                        literalFreq[ctx][int literal] <- (if literalFreq[ctx].ContainsKey(int literal) then literalFreq[ctx][int literal] else 0) + 1
+                        history.Add(literal)
+
+                    let start = history.Count - command.CopyDistance
+                    for index in 0 .. command.CopyLength - 1 do
+                        history.Add(history[start + index])
+
+            iccFreq[63] <- (if iccFreq.ContainsKey 63 then iccFreq[63] else 0) + 1
+
+            let mutable previousFlush = if history.Count > 0 then int history[history.Count - 1] else -1
+            for literal in flushLiterals do
+                let ctx = Brotli.LiteralContext(previousFlush)
+                literalFreq[ctx][int literal] <- (if literalFreq[ctx].ContainsKey(int literal) then literalFreq[ctx][int literal] else 0) + 1
+                previousFlush <- int literal
+
+            let iccCodeTable =
+                HuffmanTree.Build(iccFreq |> Seq.map (fun pair -> pair.Key, pair.Value)).CanonicalCodeTable()
+
+            let distCodeTable : IReadOnlyDictionary<int, string> =
+                if distFreq.Count > 0 then
+                    HuffmanTree.Build(distFreq |> Seq.map (fun pair -> pair.Key, pair.Value)).CanonicalCodeTable()
+                else
+                    upcast Dictionary<int, string>()
+
+            let literalCodeTables =
+                [|
+                    for ctx in 0 .. 3 ->
+                        if literalFreq[ctx].Count > 0 then
+                            HuffmanTree.Build(literalFreq[ctx] |> Seq.map (fun pair -> pair.Key, pair.Value)).CanonicalCodeTable()
+                        else
+                            upcast Dictionary<int, string>()
+                |]
+
+            let builder = BitBuilder()
+            let encodedHistory = ResizeArray<byte>()
+
+            for command in commands do
+                if command.CopyLength = 0 then
+                    builder.WriteBitString(iccCodeTable[63])
+
+                    let mutable flushPrevious = if encodedHistory.Count > 0 then int encodedHistory[encodedHistory.Count - 1] else -1
+                    for literal in flushLiterals do
+                        let ctx = Brotli.LiteralContext(flushPrevious)
+                        builder.WriteBitString(literalCodeTables[ctx][int literal])
+                        flushPrevious <- int literal
+                else
+                    let icc = Brotli.FindIccCode(command.InsertLength, command.CopyLength)
+                    let entry = Tables.IccTable[icc]
+                    builder.WriteBitString(iccCodeTable[icc])
+                    builder.WriteRawBitsLsb(command.InsertLength - entry.InsertBase, entry.InsertExtra)
+                    builder.WriteRawBitsLsb(command.CopyLength - entry.CopyBase, entry.CopyExtra)
+
+                    for literal in command.Literals do
+                        let ctx = Brotli.LiteralContext(if encodedHistory.Count > 0 then int encodedHistory[encodedHistory.Count - 1] else -1)
+                        builder.WriteBitString(literalCodeTables[ctx][int literal])
+                        encodedHistory.Add(literal)
+
+                    let distanceCode = Brotli.DistCode(command.CopyDistance)
+                    let distanceEntry = Tables.DistTable[distanceCode]
+                    builder.WriteBitString(distCodeTable[distanceCode])
+                    builder.WriteRawBitsLsb(command.CopyDistance - distanceEntry.Base, distanceEntry.ExtraBits)
+
+                    let start = encodedHistory.Count - command.CopyDistance
+                    for index in 0 .. command.CopyLength - 1 do
+                        encodedHistory.Add(encodedHistory[start + index])
+
+            let packedBits = builder.ToArray()
+            let iccPairs = Brotli.SortedPairs(iccCodeTable)
+            let distPairs = Brotli.SortedPairs(distCodeTable)
+            let literalPairs = literalCodeTables |> Array.map Brotli.SortedPairs
+
+            Brotli.EnsureCountFits("ICC entries", iccPairs.Length)
+            Brotli.EnsureCountFits("distance entries", distPairs.Length)
+            for ctx in 0 .. literalPairs.Length - 1 do
+                Brotli.EnsureCountFits($"literal context {ctx} entries", literalPairs[ctx].Length)
+
+            let totalSize =
+                10
+                + (iccPairs.Length * 2)
+                + (distPairs.Length * 2)
+                + (literalPairs |> Array.sumBy (fun pairs -> pairs.Length * 3))
+                + packedBits.Length
+
+            let output = Array.zeroCreate<byte> totalSize
+            BinaryPrimitives.WriteUInt32BigEndian(output.AsSpan(0, 4), uint32 data.Length)
+            output[4] <- byte iccPairs.Length
+            output[5] <- byte distPairs.Length
+            output[6] <- byte literalPairs[0].Length
+            output[7] <- byte literalPairs[1].Length
+            output[8] <- byte literalPairs[2].Length
+            output[9] <- byte literalPairs[3].Length
+
+            let mutable offset = 10
+            for (symbol, length) in iccPairs do
+                output[offset] <- byte symbol
+                output[offset + 1] <- byte length
+                offset <- offset + 2
+
+            for (symbol, length) in distPairs do
+                output[offset] <- byte symbol
+                output[offset + 1] <- byte length
+                offset <- offset + 2
+
+            for pairs in literalPairs do
+                for (symbol, length) in pairs do
+                    BinaryPrimitives.WriteUInt16BigEndian(output.AsSpan(offset, 2), uint16 symbol)
+                    output[offset + 2] <- byte length
+                    offset <- offset + 3
+
+            Array.Copy(packedBits, 0, output, offset, packedBits.Length)
+            output
+
+    static member Decompress(data: byte array) =
+        if isNull data then nullArg "data"
+        if data.Length < 10 then
+            Array.empty
+        else
+            let originalLength = int (BinaryPrimitives.ReadUInt32BigEndian(data.AsSpan(0, 4)))
+            if originalLength = 0 then
+                Array.empty
+            else
+                let iccEntryCount = int data[4]
+                let distEntryCount = int data[5]
+                let literalEntryCounts = [| int data[6]; int data[7]; int data[8]; int data[9] |]
+                let mutable offset = 10
+
+                if offset + (iccEntryCount * 2) > data.Length then
+                    Array.empty
+                else
+                    let iccLengths = ResizeArray<int * int>()
+                    for _ in 0 .. iccEntryCount - 1 do
+                        iccLengths.Add(int data[offset], int data[offset + 1])
+                        offset <- offset + 2
+
+                    if offset + (distEntryCount * 2) > data.Length then
+                        Array.empty
+                    else
+                        let distLengths = ResizeArray<int * int>()
+                        for _ in 0 .. distEntryCount - 1 do
+                            distLengths.Add(int data[offset], int data[offset + 1])
+                            offset <- offset + 2
+
+                        let literalLengths = Array.init 4 (fun _ -> ResizeArray<int * int>())
+                        let mutable valid = true
+                        for ctx in 0 .. 3 do
+                            let count = literalEntryCounts[ctx]
+                            if offset + (count * 3) > data.Length then
+                                valid <- false
+                            elif count > 0 then
+                                for _ in 0 .. count - 1 do
+                                    literalLengths[ctx].Add(
+                                        int (BinaryPrimitives.ReadUInt16BigEndian(data.AsSpan(offset, 2))),
+                                        int data[offset + 2])
+                                    offset <- offset + 3
+
+                        if not valid then
+                            Array.empty
+                        else
+                            let iccCodes = Brotli.ReconstructCanonicalCodes(iccLengths)
+                            let distCodes = Brotli.ReconstructCanonicalCodes(distLengths)
+                            let literalCodes = literalLengths |> Array.map Brotli.ReconstructCanonicalCodes
+                            let bits = Brotli.UnpackBits(data.AsSpan(offset))
+                            let output = ResizeArray<byte>(originalLength)
+                            let mutable bitPos = 0
+                            let mutable previous = -1
+
+                            while output.Count < originalLength do
+                                let icc = Brotli.NextHuffmanSymbol(iccCodes, bits, &bitPos)
+
+                                if icc = 63 then
+                                    while output.Count < originalLength do
+                                        let ctx = Brotli.LiteralContext(previous)
+                                        let literal = Brotli.NextHuffmanSymbol(literalCodes[ctx], bits, &bitPos)
+                                        output.Add(byte literal)
+                                        previous <- literal
+                                else
+                                    let entry = Tables.IccTable[icc]
+                                    let insertLength = entry.InsertBase + Brotli.ReadRawBits(bits, &bitPos, entry.InsertExtra)
+                                    let copyLength = entry.CopyBase + Brotli.ReadRawBits(bits, &bitPos, entry.CopyExtra)
+
+                                    for _ in 0 .. insertLength - 1 do
+                                        let ctx = Brotli.LiteralContext(previous)
+                                        let literal = Brotli.NextHuffmanSymbol(literalCodes[ctx], bits, &bitPos)
+                                        output.Add(byte literal)
+                                        previous <- literal
+
+                                    if copyLength > 0 then
+                                        if distCodes.Count = 0 then
+                                            invalidOp "Compressed stream references a distance code without a distance tree"
+
+                                        let distanceCode = Brotli.NextHuffmanSymbol(distCodes, bits, &bitPos)
+                                        let distanceEntry = Tables.DistTable[distanceCode]
+                                        let copyDistance = distanceEntry.Base + Brotli.ReadRawBits(bits, &bitPos, distanceEntry.ExtraBits)
+                                        let start = output.Count - copyDistance
+                                        if start < 0 then
+                                            invalidOp "Distance extends before the output buffer"
+
+                                        for index in 0 .. copyLength - 1 do
+                                            let value = output[start + index]
+                                            output.Add(value)
+                                            previous <- int value
+
+                            output |> Seq.truncate originalLength |> Array.ofSeq
+
+    static member private LiteralContext(previousByte: int) =
+        if previousByte >= 0x61 && previousByte <= 0x7A then
+            3
+        elif previousByte >= 0x41 && previousByte <= 0x5A then
+            2
+        elif previousByte >= 0x30 && previousByte <= 0x39 then
+            1
+        else
+            0
+
+    static member private FindIccCode(insertLength: int, copyLength: int) =
+        let mutable result = -1
+        for code in 0 .. 62 do
+            if result = -1 then
+                let entry = Tables.IccTable[code]
+                let maxInsert = entry.InsertBase + (1 <<< entry.InsertExtra) - 1
+                let maxCopy = entry.CopyBase + (1 <<< entry.CopyExtra) - 1
+                if insertLength >= entry.InsertBase
+                   && insertLength <= maxInsert
+                   && copyLength >= entry.CopyBase
+                   && copyLength <= maxCopy then
+                    result <- code
+
+        if result >= 0 then
+            result
+        else
+            let mutable fallback = 0
+            let mutable found = false
+            for code in 0 .. 15 do
+                if not found then
+                    let entry = Tables.IccTable[code]
+                    let maxCopy = entry.CopyBase + (1 <<< entry.CopyExtra) - 1
+                    if copyLength >= entry.CopyBase && copyLength <= maxCopy then
+                        fallback <- code
+                        found <- true
+
+            fallback
+
+    static member private FindBestIccCopy(insertLength: int, copyLength: int) =
+        let mutable best = 0
+        for code in 0 .. 62 do
+            let entry = Tables.IccTable[code]
+            let maxInsert = entry.InsertBase + (1 <<< entry.InsertExtra) - 1
+            if insertLength >= entry.InsertBase && insertLength <= maxInsert then
+                let maxCopy = entry.CopyBase + (1 <<< entry.CopyExtra) - 1
+                if copyLength >= entry.CopyBase && copyLength <= maxCopy then
+                    best <- copyLength
+                elif maxCopy <= copyLength && maxCopy > best then
+                    best <- maxCopy
+
+        max best Brotli.MinMatch
+
+    static member private DistCode(distance: int) =
+        let mutable code = 31
+        let mutable found = false
+        for entry in Tables.DistTable do
+            if not found then
+                let maxDistance = entry.Base + (1 <<< entry.ExtraBits) - 1
+                if distance <= maxDistance then
+                    code <- entry.Code
+                    found <- true
+
+        code
+
+    static member private FindLongestMatch(data: byte array, pos: int) =
+        let windowStart = max 0 (pos - Brotli.MaxWindow)
+        let mutable bestLength = 0
+        let mutable bestOffset = 0
+
+        for start = pos - 1 downto windowStart do
+            if data[start] = data[pos] then
+                let maxLength = min Brotli.MaxMatch (data.Length - pos)
+                let mutable matchLength = 0
+                while matchLength < maxLength && data[start + matchLength] = data[pos + matchLength] do
+                    matchLength <- matchLength + 1
+
+                if matchLength > bestLength then
+                    bestLength <- matchLength
+                    bestOffset <- pos - start
+
+        if bestLength < Brotli.MinMatch then
+            0, 0
+        else
+            bestOffset, bestLength
+
+    static member private BuildCommands(data: byte array) =
+        let commands = ResizeArray<Command>()
+        let insertBuffer = ResizeArray<byte>()
+        let mutable pos = 0
+
+        while pos < data.Length do
+            let offset, length = Brotli.FindLongestMatch(data, pos)
+            if length >= Brotli.MinMatch && insertBuffer.Count <= Brotli.MaxInsertPerIcc then
+                let actualCopy = Brotli.FindBestIccCopy(insertBuffer.Count, length)
+                commands.Add(
+                    {
+                        InsertLength = insertBuffer.Count
+                        CopyLength = actualCopy
+                        CopyDistance = offset
+                        Literals = insertBuffer.ToArray()
+                    })
+                insertBuffer.Clear()
+                pos <- pos + actualCopy
+            else
+                insertBuffer.Add(data[pos])
+                pos <- pos + 1
+
+        let flushLiterals = insertBuffer.ToArray()
+        commands.Add({ InsertLength = 0; CopyLength = 0; CopyDistance = 0; Literals = Array.empty })
+        commands.ToArray(), flushLiterals
+
+    static member private SortedPairs(table: IReadOnlyDictionary<int, string>) : (int * int) array =
+        table
+        |> Seq.map (fun pair -> pair.Key, pair.Value.Length)
+        |> Seq.sortBy (fun (symbol, length) -> length, symbol)
+        |> Seq.toArray
+
+    static member private EnsureCountFits(label: string, count: int) =
+        if count > int Byte.MaxValue then
+            invalidOp $"{label} exceed the CMP06 one-byte header limit"
+
+    static member private ReconstructCanonicalCodes(lengths: seq<int * int>) : IReadOnlyDictionary<string, int> =
+        let ordered =
+            lengths
+            |> Seq.filter (fun (_, length) -> length > 0)
+            |> Seq.sortBy (fun (symbol, length) -> length, symbol)
+            |> Seq.toArray
+
+        let codes = Dictionary<string, int>()
+        if ordered.Length = 0 then
+            codes :> IReadOnlyDictionary<string, int>
+        elif ordered.Length = 1 then
+            let (symbol, _) = ordered[0]
+            codes["0"] <- symbol
+            codes :> IReadOnlyDictionary<string, int>
+        else
+            let mutable codeValue = 0
+            let mutable previousLength = ordered[0] |> snd
+            for (symbol, length) in ordered do
+                if length > previousLength then
+                    codeValue <- codeValue <<< (length - previousLength)
+
+                codes[Convert.ToString(codeValue, 2).PadLeft(length, '0')] <- symbol
+                codeValue <- codeValue + 1
+                previousLength <- length
+
+            codes :> IReadOnlyDictionary<string, int>
+
+    static member private UnpackBits(data: Span<byte>) =
+        let builder = StringBuilder(data.Length * 8)
+        for value in data do
+            for bit = 0 to 7 do
+                builder.Append(if (((int value) >>> bit) &&& 1) <> 0 then '1' else '0') |> ignore
+
+        builder.ToString()
+
+    static member private ReadRawBits(bits: string, bitPos: byref<int>, count: int) =
+        let mutable value = 0
+        for index in 0 .. count - 1 do
+            if bitPos + index >= bits.Length then
+                invalidOp "Unexpected end of compressed bit stream"
+
+            if bits[bitPos + index] = '1' then
+                value <- value ||| (1 <<< index)
+
+        bitPos <- bitPos + count
+        value
+
+    static member private NextHuffmanSymbol(codes: IReadOnlyDictionary<string, int>, bits: string, bitPos: byref<int>) =
+        if codes.Count = 0 then
+            invalidOp "Missing Huffman codes"
+
+        let builder = StringBuilder()
+        let mutable result: int option = None
+        while Option.isNone result && bitPos < bits.Length do
+            builder.Append(bits[bitPos]) |> ignore
+            bitPos <- bitPos + 1
+            match codes.TryGetValue(builder.ToString()) with
+            | true, symbol -> result <- Some symbol
+            | _ -> ()
+
+        result |> Option.defaultWith (fun () -> invalidOp "Unexpected end of compressed bit stream")

--- a/code/packages/fsharp/brotli/CHANGELOG.md
+++ b/code/packages/fsharp/brotli/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-18
+
+### Added
+
+- Pure F# CMP06 Brotli-style implementation with insert-copy commands, literal contexts, and long-distance matches
+- Canonical Huffman table emission for ICC, distance, and per-context literal alphabets
+- One-shot `Compress` and `Decompress` helpers using the repo's teaching wire format
+- xUnit coverage for spec vectors, deterministic output, manual wire payloads, long-distance copies, and compression sanity checks

--- a/code/packages/fsharp/brotli/CodingAdventures.Brotli.fsproj
+++ b/code/packages/fsharp/brotli/CodingAdventures.Brotli.fsproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AssemblyName>CodingAdventures.Brotli.FSharp</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Brotli.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure F# Brotli-style compression in the repo's CMP06 wire format</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../fsharp/huffman-tree/CodingAdventures.HuffmanTree.fsproj" />
+    <Compile Include="Brotli.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/brotli/README.md
+++ b/code/packages/fsharp/brotli/README.md
@@ -1,0 +1,29 @@
+# brotli
+
+Pure F# Brotli-style compression for the CMP06 context-aware insert-copy stage.
+
+## What It Includes
+
+- The CMP06 insert-and-copy command table with sentinel handling
+- Four literal-context Huffman trees keyed off the previous emitted byte
+- An in-language sliding-window matcher up to the CMP06 `65535` byte window
+- Canonical Huffman wire-format encoding for ICC, distance, and literal tables
+- One-shot `Compress` and `Decompress` helpers over the pure codec
+
+## Example
+
+```fsharp
+open System.Text
+open CodingAdventures.Brotli.FSharp
+
+let compressed = Brotli.Compress(Encoding.UTF8.GetBytes("abc123ABC"))
+let roundTrip = Encoding.UTF8.GetString(Brotli.Decompress compressed)
+
+printfn "%s" roundTrip
+```
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/fsharp/brotli/required_capabilities.json
+++ b/code/packages/fsharp/brotli/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/brotli",
+  "capabilities": [],
+  "justification": "Pure in-memory F# CMP06 Brotli-style implementation and tests."
+}

--- a/code/packages/fsharp/brotli/tests/CodingAdventures.Brotli.Tests/BrotliTests.fs
+++ b/code/packages/fsharp/brotli/tests/CodingAdventures.Brotli.Tests/BrotliTests.fs
@@ -1,0 +1,137 @@
+namespace CodingAdventures.Brotli.FSharp.Tests
+
+open System
+open System.Buffers.Binary
+open System.Text
+open CodingAdventures.Brotli.FSharp
+open Xunit
+
+module private Helpers =
+    let bytes (value: string) = Encoding.UTF8.GetBytes(value)
+
+type BrotliTests() =
+    [<Fact>]
+    member _.``Empty input uses minimal encoding``() =
+        let compressed = Brotli.Compress(Array.empty)
+        Assert.Equal(13, compressed.Length)
+        Assert.Equal(0u, BinaryPrimitives.ReadUInt32BigEndian(compressed.AsSpan(0, 4)))
+        Assert.Equal(1uy, compressed[4])
+        Assert.Equal(0uy, compressed[5])
+        Assert.Equal<byte array>(Array.empty, Brotli.Decompress(compressed))
+
+    [<Theory>]
+    [<InlineData(0x42uy)>]
+    [<InlineData(0x00uy)>]
+    [<InlineData(0xFFuy)>]
+    member _.``Single byte values round trip``(value: byte) =
+        let data = [| value |]
+        Assert.Equal<byte array>(data, Brotli.Decompress(Brotli.Compress(data)))
+
+    [<Fact>]
+    member _.``Repeated A data compresses well``() =
+        let data = Array.create 1024 (byte 'A')
+        let compressed = Brotli.Compress(data)
+
+        Assert.Equal<byte array>(data, Brotli.Decompress(compressed))
+        Assert.True(float compressed.Length < float data.Length / 2.0)
+        Assert.True(compressed[5] > 0uy)
+
+    [<Fact>]
+    member _.``English prose round trips``() =
+        let passage = "The quick brown fox jumps over the lazy dog. Pack my box with five dozen liquor jugs. "
+        let data = Helpers.bytes(String.Concat(Array.replicate 16 passage))
+        let compressed = Brotli.Compress(data)
+
+        Assert.Equal<byte array>(data, Brotli.Decompress(compressed))
+        Assert.True(float compressed.Length < float data.Length * 0.8)
+
+    [<Fact>]
+    member _.``Binary data round trips``() =
+        let data = Array.zeroCreate<byte> 512
+        let mutable state = 0xDEADBEEFu
+        for index in 0 .. data.Length - 1 do
+            state <- (state >>> 1) ^^^ (if (state &&& 1u) = 0u then 0u else 0xEDB88320u)
+            data[index] <- byte (state &&& 0xFFu)
+
+        Assert.Equal<byte array>(data, Brotli.Decompress(Brotli.Compress(data)))
+
+    [<Fact>]
+    member _.``Context transitions round trip``() =
+        let data = Helpers.bytes "abc123ABCabc"
+        let compressed = Brotli.Compress(data)
+
+        Assert.Equal<byte array>(data, Brotli.Decompress(compressed))
+        Assert.True(compressed[6] > 0uy)
+        Assert.True(compressed[7] > 0uy)
+        Assert.True(compressed[8] > 0uy)
+
+    [<Fact>]
+    member _.``Long-distance match round trips``() =
+        let marker = Helpers.bytes "XYZABCDEFG"
+        let filler = Array.create 4200 (byte 'B')
+        let data = Array.zeroCreate<byte> (marker.Length + filler.Length + marker.Length)
+        Array.Copy(marker, 0, data, 0, marker.Length)
+        Array.Copy(filler, 0, data, marker.Length, filler.Length)
+        Array.Copy(marker, 0, data, marker.Length + filler.Length, marker.Length)
+
+        let compressed = Brotli.Compress(data)
+        Assert.Equal<byte array>(data, Brotli.Decompress(compressed))
+        Assert.True(compressed[5] > 0uy)
+
+    [<Fact>]
+    member _.``Compression is deterministic``() =
+        let data = Helpers.bytes "The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog."
+        let a = Brotli.Compress(data)
+        let b = Brotli.Compress(data)
+        Assert.Equal<byte array>(a, b)
+
+    [<Fact>]
+    member _.``Manual payload for single A decompresses``() =
+        let payload =
+            [|
+                0x00uy; 0x00uy; 0x00uy; 0x01uy
+                0x01uy
+                0x00uy
+                0x01uy
+                0x00uy
+                0x00uy
+                0x00uy
+                0x3Fuy; 0x01uy
+                0x00uy; 0x41uy; 0x01uy
+                0x00uy
+            |]
+
+        Assert.Equal<byte array>(Helpers.bytes "A", Brotli.Decompress(payload))
+
+    [<Fact>]
+    member _.``Manual payload for empty input decompresses``() =
+        let payload =
+            [|
+                0x00uy; 0x00uy; 0x00uy; 0x00uy
+                0x01uy
+                0x00uy
+                0x00uy
+                0x00uy
+                0x00uy
+                0x00uy
+                0x3Fuy; 0x01uy
+                0x00uy
+            |]
+
+        Assert.Equal<byte array>(Array.empty, Brotli.Decompress(payload))
+
+    [<Fact>]
+    member _.``Header stores original length``() =
+        let data = Helpers.bytes "Hello, Brotli!"
+        let compressed = Brotli.Compress(data)
+        Assert.Equal(uint32 data.Length, BinaryPrimitives.ReadUInt32BigEndian(compressed.AsSpan(0, 4)))
+
+    [<Fact>]
+    member _.``ICC sentinel always present``() =
+        let compressed = Brotli.Compress(Helpers.bytes "test")
+        Assert.True(compressed[4] > 0uy)
+
+    [<Fact>]
+    member _.``All distinct byte values round trip``() =
+        let data = Array.init 256 byte
+        Assert.Equal<byte array>(data, Brotli.Decompress(Brotli.Compress(data)))

--- a/code/packages/fsharp/brotli/tests/CodingAdventures.Brotli.Tests/CodingAdventures.Brotli.Tests.fsproj
+++ b/code/packages/fsharp/brotli/tests/CodingAdventures.Brotli.Tests/CodingAdventures.Brotli.Tests.fsproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Brotli.fsproj" />
+    <Compile Include="BrotliTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/specs/TE11-dotnet-compression-brotli-tranche.md
+++ b/code/specs/TE11-dotnet-compression-brotli-tranche.md
@@ -1,0 +1,71 @@
+# TE11 - .NET Compression Brotli Tranche
+
+## Goal
+
+Port the CMP06 `brotli` package to both C# and F# as pure in-language implementations.
+
+This tranche builds on the already-ported `.NET` `huffman-tree` package and keeps the
+repo's teaching-oriented CMP06 wire format rather than aiming for RFC 7932 bitstream
+compatibility.
+
+## Scope
+
+Add these publishable packages:
+
+- `code/packages/csharp/brotli`
+- `code/packages/fsharp/brotli`
+
+Each package must include:
+
+- native implementation code only
+- tests
+- `BUILD`
+- `BUILD_windows`
+- `README.md`
+- `CHANGELOG.md`
+- package metadata
+- `required_capabilities.json`
+
+## Functional Requirements
+
+Both implementations should:
+
+- implement the CMP06 insert-and-copy command table with the sentinel code `63`
+- implement the CMP06 extended distance-code table up to the `65535` sliding window
+- implement the four literal context buckets from the spec
+- perform their own sliding-window match search in-language
+- emit the documented 10-byte header and code-length tables
+- pack Huffman codes and raw extra bits LSB-first
+- expose:
+  - `Compress`
+  - `Decompress`
+
+## Behavioral Notes
+
+- Empty input should produce the minimal CMP06 encoding with only the sentinel ICC tree.
+- Literal-only inputs should still emit the sentinel and then flush remaining literals.
+- Match decoding must support overlapping back-references.
+- The F# package must be implemented directly in F# and must not wrap the C# package.
+- No external compression or bitstream libraries may be used.
+
+## Test Coverage Targets
+
+Tests should cover at least:
+
+- empty input
+- single-byte values
+- all-`A` repetitive input
+- English prose round trips
+- binary round trips
+- mixed-context literals such as `abc123ABC`
+- long-distance matches above the DEFLATE-sized window ranges
+- deterministic output for repeated compressions of the same input
+- manual wire-format payloads for empty input and a one-byte payload
+- simple compression-ratio sanity checks on repetitive input
+
+## Out of Scope
+
+- RFC 7932 stream interoperability
+- Brotli static dictionaries
+- custom quality/parameter tuning knobs
+- `reed-solomon`


### PR DESCRIPTION
## Summary
- add pure C# and pure F# CMP06 brotli packages
- add the Brotli tranche spec, BUILD files, READMEs, changelogs, and package metadata
- cover deterministic wire format, manual payloads, context transitions, and long-distance matches

## Verification
- `bash BUILD` in `code/packages/csharp/brotli`
- `bash BUILD` in `code/packages/fsharp/brotli`