### PR TITLE
feat(window-core): add shared native window abstraction

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -301,4 +301,7 @@ members = [
     "intel-4004-packager",
     "nib-compiler",
     "bitset-c",
+  "window-core",
+  "window-appkit",
+  "window-win32",
 ]

--- a/code/packages/rust/window-appkit/BUILD
+++ b/code/packages/rust/window-appkit/BUILD
@@ -1,0 +1,1 @@
+cargo test -p window-appkit -- --nocapture

--- a/code/packages/rust/window-appkit/CHANGELOG.md
+++ b/code/packages/rust/window-appkit/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-18
+
+### Added
+
+- `AppKitBackend` with AppKit-specific attribute validation.
+- Surface selection rules for normal AppKit views versus Metal-layer hosts.
+- Real `NSApplication` and `NSWindow` creation for the minimal macOS launch path.
+- `AppKitWindow` implementing the shared `Window` trait with AppKit render-target handles.
+- Auto-closing `launch_window` example for macOS smoke testing.
+- Explicit rejection of browser and Windows-only surface requests.
+- Unit tests for AppKit validation and render-target behavior.

--- a/code/packages/rust/window-appkit/Cargo.toml
+++ b/code/packages/rust/window-appkit/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "window-appkit"
+version = "0.1.0"
+edition = "2021"
+description = "AppKit-backed desktop window backend for window-core"
+
+[dependencies]
+window-core = { path = "../window-core" }
+objc-bridge = { path = "../objc-bridge" }

--- a/code/packages/rust/window-appkit/README.md
+++ b/code/packages/rust/window-appkit/README.md
@@ -1,0 +1,32 @@
+# window-appkit
+
+AppKit-backed desktop window backend for `window-core`.
+
+## Layer 11
+
+This package is part of Layer 11 of the coding-adventures computing stack.
+
+## What It Contains
+
+This first slice now supports a real macOS smoke path while staying small:
+
+- validates which `window-core` requests make sense on AppKit
+- creates an `NSApplication` and `NSWindow`
+- exposes AppKit render-target handles on the returned `Window`
+- runs the AppKit event loop for native launch testing
+- rejects renderer preferences that belong to other platforms
+
+The backend still does not translate live AppKit events into `WindowEvent`
+values yet, and Metal-layer attachment is still the next step after the window
+launch path.
+
+## Dependencies
+
+- window-core
+
+## Development
+
+```bash
+cargo test -p window-appkit
+cargo run -p window-appkit --example launch_window
+```

--- a/code/packages/rust/window-appkit/examples/launch_window.rs
+++ b/code/packages/rust/window-appkit/examples/launch_window.rs
@@ -1,0 +1,22 @@
+use window_appkit::AppKitBackend;
+use window_core::{LogicalSize, SurfacePreference, Window, WindowBuilder};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut backend = AppKitBackend::new();
+    let window = WindowBuilder::new()
+        .title("window-appkit smoke test")
+        .initial_size(LogicalSize::new(480.0, 320.0))
+        .preferred_surface(SurfacePreference::Default)
+        .build_with(&mut backend)?;
+
+    println!(
+        "Launched AppKit window {:?} with target kind {}",
+        window.id(),
+        window.render_target().kind()
+    );
+
+    // Keep the smoke test quick and non-interactive.
+    backend.terminate_after(1.5)?;
+    backend.run()?;
+    Ok(())
+}

--- a/code/packages/rust/window-appkit/src/lib.rs
+++ b/code/packages/rust/window-appkit/src/lib.rs
@@ -1,0 +1,524 @@
+//! # window-appkit
+//!
+//! AppKit-backed desktop window backend for `window-core`.
+//!
+//! This crate now provides a minimal but real macOS launch path:
+//!
+//! - validate `window-core` attributes for AppKit
+//! - create an `NSApplication`
+//! - create and show an `NSWindow`
+//! - expose AppKit render-target handles on the returned window
+//! - run the AppKit event loop when requested
+//!
+//! It is intentionally still small. The point is to prove the boundary between
+//! `window-core` and a native backend before adding richer event translation.
+
+use std::ffi::{c_int, c_ulong};
+
+#[cfg(target_vendor = "apple")]
+use std::ffi::{c_void, CString};
+
+#[cfg(target_vendor = "apple")]
+use objc_bridge::{
+    class, msg, msg_send_class, nsstring, object_getInstanceVariable, object_setInstanceVariable,
+    objc_allocateClassPair, objc_registerClassPair, release, sel, ClassPtr, CGPoint, CGRect, Id,
+    Sel, CGSize, NS_BACKING_STORE_BUFFERED, NS_WINDOW_STYLE_MASK_CLOSABLE,
+    NS_WINDOW_STYLE_MASK_MINIATURIZABLE, NS_WINDOW_STYLE_MASK_RESIZABLE,
+    NS_WINDOW_STYLE_MASK_TITLED, NIL, class_addIvar, class_addMethod,
+};
+use window_core::{
+    AppKitRenderTarget, LogicalSize, MountTarget, PhysicalSize, RenderTarget, SurfacePreference,
+    Window, WindowAttributes, WindowBackend, WindowError, WindowEvent, WindowId,
+};
+
+/// Crate version, kept explicit for examples and integration tests.
+pub const VERSION: &str = "0.1.0";
+
+/// Which AppKit-side surface family the renderer should expect.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AppKitSurfaceChoice {
+    /// A normal `NSView` or equivalent host view.
+    View,
+    /// A Metal-friendly host with a `CAMetalLayer`.
+    ///
+    /// The minimal launch path still exposes the content view immediately. A
+    /// concrete `CAMetalLayer` attachment is the next step once the renderer
+    /// integration lands.
+    MetalLayer,
+}
+
+/// A created AppKit window host.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct AppKitWindow {
+    id: WindowId,
+    logical_size: LogicalSize,
+    physical_size: PhysicalSize,
+    scale_factor: f64,
+    ns_window: usize,
+    ns_view: usize,
+    metal_layer: Option<usize>,
+}
+
+impl AppKitWindow {
+    /// Return the AppKit-native render target handles for this window.
+    pub fn appkit_target(&self) -> AppKitRenderTarget {
+        AppKitRenderTarget {
+            ns_window: self.ns_window,
+            ns_view: self.ns_view,
+            metal_layer: self.metal_layer,
+        }
+    }
+}
+
+impl Window for AppKitWindow {
+    fn id(&self) -> WindowId {
+        self.id
+    }
+
+    fn logical_size(&self) -> LogicalSize {
+        self.logical_size
+    }
+
+    fn physical_size(&self) -> PhysicalSize {
+        self.physical_size
+    }
+
+    fn scale_factor(&self) -> f64 {
+        self.scale_factor
+    }
+
+    fn request_redraw(&self) -> Result<(), WindowError> {
+        #[cfg(target_vendor = "apple")]
+        unsafe {
+            let view = self.ns_view as Id;
+            msg!(view, "setNeedsDisplay:", true as c_int);
+            Ok(())
+        }
+
+        #[cfg(not(target_vendor = "apple"))]
+        {
+            Err(WindowError::UnsupportedPlatform(
+                "AppKit windows are only available on Apple platforms",
+            ))
+        }
+    }
+
+    fn set_title(&self, title: &str) -> Result<(), WindowError> {
+        #[cfg(target_vendor = "apple")]
+        unsafe {
+            let title_ns = nsstring(title);
+            msg!(self.ns_window as Id, "setTitle:", title_ns);
+            objc_bridge::CFRelease(title_ns);
+            Ok(())
+        }
+
+        #[cfg(not(target_vendor = "apple"))]
+        {
+            let _ = title;
+            Err(WindowError::UnsupportedPlatform(
+                "AppKit windows are only available on Apple platforms",
+            ))
+        }
+    }
+
+    fn set_visible(&self, visible: bool) -> Result<(), WindowError> {
+        #[cfg(target_vendor = "apple")]
+        unsafe {
+            if visible {
+                msg!(self.ns_window as Id, "makeKeyAndOrderFront:", NIL);
+            } else {
+                msg!(self.ns_window as Id, "orderOut:", NIL);
+            }
+            Ok(())
+        }
+
+        #[cfg(not(target_vendor = "apple"))]
+        {
+            let _ = visible;
+            Err(WindowError::UnsupportedPlatform(
+                "AppKit windows are only available on Apple platforms",
+            ))
+        }
+    }
+
+    fn render_target(&self) -> RenderTarget {
+        RenderTarget::AppKit(self.appkit_target())
+    }
+}
+
+/// AppKit backend with minimal native window support.
+#[derive(Debug, Default)]
+pub struct AppKitBackend {
+    next_id: u64,
+    #[cfg(target_vendor = "apple")]
+    app: Option<usize>,
+}
+
+impl AppKitBackend {
+    /// Construct a new backend.
+    pub const fn new() -> Self {
+        Self {
+            next_id: 0,
+            #[cfg(target_vendor = "apple")]
+            app: None,
+        }
+    }
+
+    /// Human-readable backend name.
+    pub const fn backend_name(&self) -> &'static str {
+        "appkit"
+    }
+
+    /// Choose the AppKit host surface implied by the renderer preference.
+    pub fn choose_surface(
+        &self,
+        preference: SurfacePreference,
+    ) -> Result<AppKitSurfaceChoice, WindowError> {
+        match preference {
+            SurfacePreference::Default | SurfacePreference::Cairo => Ok(AppKitSurfaceChoice::View),
+            SurfacePreference::Metal => Ok(AppKitSurfaceChoice::MetalLayer),
+            SurfacePreference::Direct2D => Err(WindowError::UnsupportedConfiguration(
+                "Direct2D is a Windows renderer and cannot target AppKit",
+            )),
+            SurfacePreference::Canvas2D => Err(WindowError::UnsupportedConfiguration(
+                "Canvas2D is a browser renderer and cannot target AppKit",
+            )),
+        }
+    }
+
+    /// Validate a `window-core` request against AppKit expectations.
+    pub fn validate_attributes(
+        &self,
+        attributes: &WindowAttributes,
+    ) -> Result<AppKitSurfaceChoice, WindowError> {
+        attributes.validate()?;
+        if attributes.mount_target != MountTarget::Native {
+            return Err(WindowError::UnsupportedConfiguration(
+                "AppKit windows must use MountTarget::Native",
+            ));
+        }
+        self.choose_surface(attributes.preferred_surface)
+    }
+
+    /// Create a real AppKit window on macOS.
+    pub fn create_native_window(
+        &mut self,
+        attributes: WindowAttributes,
+    ) -> Result<AppKitWindow, WindowError> {
+        self.create_window(attributes)
+    }
+
+    /// Run the AppKit message loop.
+    pub fn run(&mut self) -> Result<(), WindowError> {
+        #[cfg(target_vendor = "apple")]
+        unsafe {
+            let app = self.shared_application()?;
+            msg!(app, "run");
+            Ok(())
+        }
+
+        #[cfg(not(target_vendor = "apple"))]
+        {
+            Err(WindowError::UnsupportedPlatform(
+                "AppKit windows are only available on Apple platforms",
+            ))
+        }
+    }
+
+    /// Request that the current AppKit app terminates after the given delay.
+    pub fn terminate_after(&mut self, seconds: f64) -> Result<(), WindowError> {
+        #[cfg(target_vendor = "apple")]
+        unsafe {
+            let app = self.shared_application()?;
+            let terminate_sel = sel("terminate:");
+            msg!(
+                app,
+                "performSelector:withObject:afterDelay:",
+                terminate_sel,
+                NIL,
+                seconds
+            );
+            Ok(())
+        }
+
+        #[cfg(not(target_vendor = "apple"))]
+        {
+            let _ = seconds;
+            Err(WindowError::UnsupportedPlatform(
+                "AppKit windows are only available on Apple platforms",
+            ))
+        }
+    }
+
+    #[cfg(target_vendor = "apple")]
+    unsafe fn shared_application(&mut self) -> Result<Id, WindowError> {
+        if let Some(app) = self.app {
+            return Ok(app as Id);
+        }
+
+        let app_class = class("NSApplication");
+        let app: Id = msg_send_class(app_class, "sharedApplication");
+        if app.is_null() {
+            return Err(WindowError::backend(
+                "NSApplication sharedApplication returned nil",
+            ));
+        }
+
+        // NSApplicationActivationPolicyRegular = 0
+        msg!(app, "setActivationPolicy:", 0 as c_ulong);
+        msg!(app, "finishLaunching");
+        self.app = Some(app as usize);
+        Ok(app)
+    }
+
+    #[cfg(target_vendor = "apple")]
+    unsafe fn create_window_inner(
+        &mut self,
+        attributes: WindowAttributes,
+        surface: AppKitSurfaceChoice,
+    ) -> Result<AppKitWindow, WindowError> {
+        let app = self.shared_application()?;
+        self.next_id += 1;
+
+        let frame = CGRect {
+            origin: CGPoint { x: 200.0, y: 200.0 },
+            size: CGSize {
+                width: attributes.initial_size.width.max(1.0),
+                height: attributes.initial_size.height.max(1.0),
+            },
+        };
+
+        let mut style_mask = if attributes.decorations {
+            NS_WINDOW_STYLE_MASK_TITLED
+                | NS_WINDOW_STYLE_MASK_CLOSABLE
+                | NS_WINDOW_STYLE_MASK_MINIATURIZABLE
+        } else {
+            0
+        };
+        if attributes.resizable {
+            style_mask |= NS_WINDOW_STYLE_MASK_RESIZABLE;
+        }
+
+        let window_class = class("NSWindow");
+        let window: Id = msg!(
+            msg_send_class(window_class, "alloc"),
+            "initWithContentRect:styleMask:backing:defer:",
+            frame,
+            style_mask,
+            NS_BACKING_STORE_BUFFERED,
+            false as c_int
+        );
+        if window.is_null() {
+            return Err(WindowError::backend("NSWindow allocation failed"));
+        }
+
+        let title_ns = nsstring(&attributes.title);
+        msg!(window, "setTitle:", title_ns);
+        objc_bridge::CFRelease(title_ns);
+
+        let view: Id = msg!(window, "contentView");
+        if view.is_null() {
+            release(window);
+            return Err(WindowError::backend("NSWindow contentView returned nil"));
+        }
+
+        setup_window_delegate(window, app)?;
+
+        if attributes.visible {
+            msg!(window, "makeKeyAndOrderFront:", NIL);
+            msg!(app, "activateIgnoringOtherApps:", true as c_int);
+        }
+
+        let scale_factor = 1.0;
+        let physical_size = attributes.initial_size.to_physical(scale_factor)?;
+
+        Ok(AppKitWindow {
+            id: WindowId(self.next_id),
+            logical_size: attributes.initial_size,
+            physical_size,
+            scale_factor,
+            ns_window: window as usize,
+            ns_view: view as usize,
+            metal_layer: match surface {
+                AppKitSurfaceChoice::View => None,
+                AppKitSurfaceChoice::MetalLayer => None,
+            },
+        })
+    }
+}
+
+impl WindowBackend for AppKitBackend {
+    type Window = AppKitWindow;
+
+    fn backend_name(&self) -> &'static str {
+        self.backend_name()
+    }
+
+    fn create_window(
+        &mut self,
+        attributes: WindowAttributes,
+    ) -> Result<Self::Window, WindowError> {
+        let surface = self.validate_attributes(&attributes)?;
+
+        #[cfg(target_vendor = "apple")]
+        unsafe {
+            self.create_window_inner(attributes, surface)
+        }
+
+        #[cfg(not(target_vendor = "apple"))]
+        {
+            let _ = surface;
+            let _ = attributes;
+            Err(WindowError::UnsupportedPlatform(
+                "AppKit windows are only available on Apple platforms",
+            ))
+        }
+    }
+
+    fn pump_events(&mut self) -> Result<Vec<WindowEvent>, WindowError> {
+        Ok(Vec::new())
+    }
+}
+
+#[cfg(target_vendor = "apple")]
+unsafe fn setup_window_delegate(window: Id, app: Id) -> Result<(), WindowError> {
+    let delegate_class = ensure_delegate_class()?;
+    let delegate: Id = msg!(delegate_class as Id, "alloc");
+    let delegate = msg!(delegate, "init");
+    let app_ivar_name = CString::new("_app").expect("static ivar name");
+    object_setInstanceVariable(delegate, app_ivar_name.as_ptr(), app as *mut _);
+    msg!(window, "setDelegate:", delegate);
+    Ok(())
+}
+
+#[cfg(target_vendor = "apple")]
+unsafe fn ensure_delegate_class() -> Result<ClassPtr, WindowError> {
+    let class_name = CString::new("WindowAppKitDelegate").expect("static class name");
+    let existing = objc_bridge::objc_getClass(class_name.as_ptr());
+    if !existing.is_null() {
+        return Ok(existing);
+    }
+
+    let superclass = class("NSObject");
+    let delegate_class = objc_allocateClassPair(superclass, class_name.as_ptr(), 0);
+    if delegate_class.is_null() {
+        return Err(WindowError::backend(
+            "objc_allocateClassPair failed for WindowAppKitDelegate",
+        ));
+    }
+
+    let ivar_name = CString::new("_app").expect("static ivar name");
+    let ivar_type = CString::new("@").expect("static ivar type");
+    class_addIvar(
+        delegate_class,
+        ivar_name.as_ptr(),
+        std::mem::size_of::<Id>(),
+        std::mem::align_of::<Id>() as u8,
+        ivar_type.as_ptr(),
+    );
+
+    let method_types = CString::new("v@:@").expect("static method type");
+    class_addMethod(
+        delegate_class,
+        sel("windowWillClose:"),
+        window_will_close as *const _,
+        method_types.as_ptr(),
+    );
+
+    objc_registerClassPair(delegate_class);
+    Ok(delegate_class)
+}
+
+#[cfg(target_vendor = "apple")]
+extern "C" fn window_will_close(this: Id, _sel: Sel, _notification: Id) {
+    unsafe {
+        let ivar_name = CString::new("_app").expect("static ivar name");
+        let mut app_ptr: *mut c_void = std::ptr::null_mut();
+        object_getInstanceVariable(this, ivar_name.as_ptr(), &mut app_ptr);
+        let app = app_ptr as Id;
+        if !app.is_null() {
+            msg!(app, "terminate:", NIL);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_and_cairo_prefer_a_normal_view() {
+        let backend = AppKitBackend::new();
+        assert_eq!(
+            backend.choose_surface(SurfacePreference::Default).unwrap(),
+            AppKitSurfaceChoice::View
+        );
+        assert_eq!(
+            backend.choose_surface(SurfacePreference::Cairo).unwrap(),
+            AppKitSurfaceChoice::View
+        );
+    }
+
+    #[test]
+    fn metal_prefers_a_metal_layer() {
+        let backend = AppKitBackend::new();
+        assert_eq!(
+            backend.choose_surface(SurfacePreference::Metal).unwrap(),
+            AppKitSurfaceChoice::MetalLayer
+        );
+    }
+
+    #[test]
+    fn appkit_rejects_non_native_mount_targets() {
+        let backend = AppKitBackend::new();
+        let attributes = WindowAttributes {
+            mount_target: MountTarget::BrowserBody,
+            ..WindowAttributes::default()
+        };
+
+        let err = backend.validate_attributes(&attributes).unwrap_err();
+        assert_eq!(
+            err,
+            WindowError::UnsupportedConfiguration(
+                "AppKit windows must use MountTarget::Native"
+            )
+        );
+    }
+
+    #[test]
+    fn appkit_rejects_direct2d_requests() {
+        let backend = AppKitBackend::new();
+        let err = backend
+            .choose_surface(SurfacePreference::Direct2D)
+            .unwrap_err();
+        assert_eq!(
+            err,
+            WindowError::UnsupportedConfiguration(
+                "Direct2D is a Windows renderer and cannot target AppKit"
+            )
+        );
+    }
+
+    #[test]
+    fn appkit_window_reports_an_appkit_render_target() {
+        let window = AppKitWindow {
+            id: WindowId(7),
+            logical_size: LogicalSize::new(320.0, 200.0),
+            physical_size: PhysicalSize::new(320, 200),
+            scale_factor: 1.0,
+            ns_window: 10,
+            ns_view: 20,
+            metal_layer: None,
+        };
+
+        assert_eq!(window.render_target().kind(), "appkit");
+        assert_eq!(
+            window.appkit_target(),
+            AppKitRenderTarget {
+                ns_window: 10,
+                ns_view: 20,
+                metal_layer: None
+            }
+        );
+    }
+}

--- a/code/packages/rust/window-core/BUILD
+++ b/code/packages/rust/window-core/BUILD
@@ -1,0 +1,1 @@
+cargo test -p window-core -- --nocapture

--- a/code/packages/rust/window-core/CHANGELOG.md
+++ b/code/packages/rust/window-core/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-18
+
+### Added
+
+- `WindowId`, `LogicalSize`, `PhysicalSize`, and scale-conversion helpers.
+- `WindowAttributes` and `WindowBuilder` with backend-neutral validation.
+- Normalized `WindowEvent`, key, pointer, modifier, and render-target types.
+- `Window` and `WindowBackend` traits for Rust native backends.
+- Mock-backed unit tests covering builder validation and event-surface behavior.

--- a/code/packages/rust/window-core/Cargo.toml
+++ b/code/packages/rust/window-core/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "window-core"
+version = "0.1.0"
+edition = "2021"
+description = "Backend-neutral windowing primitives and renderer-facing host handles"
+
+[dependencies]

--- a/code/packages/rust/window-core/README.md
+++ b/code/packages/rust/window-core/README.md
@@ -1,0 +1,29 @@
+# window-core
+
+Backend-neutral windowing primitives and renderer-facing host handles.
+
+## Layer 11
+
+This package is part of Layer 11 of the coding-adventures computing stack.
+
+## What It Contains
+
+`window-core` defines the shared native-window contract that other languages can
+mirror:
+
+- `WindowId`, logical sizes, and physical sizes
+- `WindowAttributes` and `WindowBuilder`
+- normalized `WindowEvent` values for resize, redraw, focus, pointer, and key
+  input
+- explicit renderer targets such as AppKit and Win32 handles
+- `Window` and `WindowBackend` traits for Rust native implementations
+
+This crate is the Rust-native reference for the shared abstraction. The pure
+browser canvas backend is intentionally not implemented here; it belongs in
+TypeScript while preserving the same contract.
+
+## Development
+
+```bash
+cargo test -p window-core
+```

--- a/code/packages/rust/window-core/src/lib.rs
+++ b/code/packages/rust/window-core/src/lib.rs
@@ -1,0 +1,845 @@
+//! # window-core
+//!
+//! Backend-neutral windowing primitives and renderer-facing host handles.
+//!
+//! The central idea is simple:
+//!
+//! - a backend creates a presentation host
+//! - the host emits normalized window and input events
+//! - renderers receive an explicit render target for that host
+//!
+//! On desktop platforms the host is a real native window. In the browser the
+//! host is a mounted HTML canvas that behaves like a window from the renderer's
+//! perspective: it has identity, size, scale factor, redraw cadence, and input.
+//! Rust owns the native backend contract; other languages are expected to mirror
+//! these semantics even when their concrete runtime types differ.
+
+use std::error::Error;
+use std::fmt;
+
+/// Crate version, kept explicit for examples and integration tests.
+pub const VERSION: &str = "0.1.0";
+
+/// Stable identifier for one presentation host.
+///
+/// Desktop backends usually map this to one native top-level window. Browser
+/// backends map it to one mounted canvas host.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct WindowId(pub u64);
+
+/// A size in logical units.
+///
+/// Logical units are:
+///
+/// - desktop points on high-DPI platforms
+/// - CSS pixels in the browser
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LogicalSize {
+    pub width: f64,
+    pub height: f64,
+}
+
+impl LogicalSize {
+    /// Construct a logical size.
+    pub const fn new(width: f64, height: f64) -> Self {
+        Self { width, height }
+    }
+
+    /// Validate that the size can safely participate in layout and window
+    /// creation.
+    pub fn validate(self) -> Result<Self, WindowError> {
+        if !self.width.is_finite() || !self.height.is_finite() {
+            return Err(WindowError::InvalidAttributes(
+                "window sizes must be finite numbers",
+            ));
+        }
+        if self.width < 0.0 || self.height < 0.0 {
+            return Err(WindowError::InvalidAttributes(
+                "window sizes must be non-negative",
+            ));
+        }
+        Ok(self)
+    }
+
+    /// Convert a logical size into physical pixels using the provided scale.
+    pub fn to_physical(self, scale_factor: f64) -> Result<PhysicalSize, WindowError> {
+        self.validate()?;
+        validate_scale_factor(scale_factor)?;
+
+        let width = round_dimension(self.width * scale_factor)?;
+        let height = round_dimension(self.height * scale_factor)?;
+        Ok(PhysicalSize { width, height })
+    }
+}
+
+impl Default for LogicalSize {
+    fn default() -> Self {
+        Self::new(800.0, 600.0)
+    }
+}
+
+/// A size in physical pixels.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PhysicalSize {
+    pub width: u32,
+    pub height: u32,
+}
+
+impl PhysicalSize {
+    /// Construct a physical size.
+    pub const fn new(width: u32, height: u32) -> Self {
+        Self { width, height }
+    }
+
+    /// Convert a physical size back into logical units.
+    pub fn to_logical(self, scale_factor: f64) -> Result<LogicalSize, WindowError> {
+        validate_scale_factor(scale_factor)?;
+        Ok(LogicalSize {
+            width: self.width as f64 / scale_factor,
+            height: self.height as f64 / scale_factor,
+        })
+    }
+}
+
+/// Which kind of drawing surface the caller hopes to use.
+///
+/// This is a preference, not a guarantee. Backends may reject impossible
+/// combinations such as `Direct2D` on AppKit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SurfacePreference {
+    Default,
+    Metal,
+    Direct2D,
+    Cairo,
+    Canvas2D,
+}
+
+/// Where a backend should mount or create the presentation host.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MountTarget {
+    /// Create a normal native top-level host.
+    Native,
+    /// Browser-only: create or attach under `<body>`.
+    BrowserBody,
+    /// Browser-only: attach to a DOM element with this `id`.
+    ElementId(String),
+    /// Browser-only: attach using a DOM query selector.
+    QuerySelector(String),
+}
+
+impl MountTarget {
+    /// True when the target refers to browser DOM mounting.
+    pub fn is_browser_target(&self) -> bool {
+        !matches!(self, Self::Native)
+    }
+
+    /// Validate any backend-neutral invariants.
+    pub fn validate(&self) -> Result<(), WindowError> {
+        match self {
+            Self::ElementId(id) if id.trim().is_empty() => Err(WindowError::InvalidAttributes(
+                "element ids must not be blank",
+            )),
+            Self::QuerySelector(selector) if selector.trim().is_empty() => {
+                Err(WindowError::InvalidAttributes(
+                    "query selectors must not be blank",
+                ))
+            }
+            _ => Ok(()),
+        }
+    }
+}
+
+impl Default for MountTarget {
+    fn default() -> Self {
+        Self::Native
+    }
+}
+
+/// Shared creation attributes for a presentation host.
+#[derive(Debug, Clone, PartialEq)]
+pub struct WindowAttributes {
+    pub title: String,
+    pub initial_size: LogicalSize,
+    pub min_size: Option<LogicalSize>,
+    pub max_size: Option<LogicalSize>,
+    pub visible: bool,
+    pub resizable: bool,
+    pub decorations: bool,
+    pub transparent: bool,
+    pub preferred_surface: SurfacePreference,
+    pub mount_target: MountTarget,
+}
+
+impl WindowAttributes {
+    /// Validate the backend-neutral contract.
+    pub fn validate(&self) -> Result<(), WindowError> {
+        self.initial_size.validate()?;
+        self.mount_target.validate()?;
+
+        if let Some(min_size) = self.min_size {
+            min_size.validate()?;
+            if min_size.width > self.initial_size.width || min_size.height > self.initial_size.height
+            {
+                return Err(WindowError::InvalidAttributes(
+                    "minimum size must not exceed the initial size",
+                ));
+            }
+        }
+
+        if let Some(max_size) = self.max_size {
+            max_size.validate()?;
+            if max_size.width < self.initial_size.width || max_size.height < self.initial_size.height
+            {
+                return Err(WindowError::InvalidAttributes(
+                    "maximum size must not be smaller than the initial size",
+                ));
+            }
+        }
+
+        if let (Some(min_size), Some(max_size)) = (self.min_size, self.max_size) {
+            if min_size.width > max_size.width || min_size.height > max_size.height {
+                return Err(WindowError::InvalidAttributes(
+                    "minimum size must not exceed maximum size",
+                ));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Default for WindowAttributes {
+    fn default() -> Self {
+        Self {
+            title: "Coding Adventures Window".to_string(),
+            initial_size: LogicalSize::default(),
+            min_size: None,
+            max_size: None,
+            visible: true,
+            resizable: true,
+            decorations: true,
+            transparent: false,
+            preferred_surface: SurfacePreference::Default,
+            mount_target: MountTarget::Native,
+        }
+    }
+}
+
+/// Fluent construction helper for [`WindowAttributes`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct WindowBuilder {
+    attributes: WindowAttributes,
+}
+
+impl WindowBuilder {
+    /// Start a builder with sensible defaults.
+    pub fn new() -> Self {
+        Self {
+            attributes: WindowAttributes::default(),
+        }
+    }
+
+    /// Replace the window title.
+    pub fn title(mut self, title: impl Into<String>) -> Self {
+        self.attributes.title = title.into();
+        self
+    }
+
+    /// Set the initial logical size.
+    pub fn initial_size(mut self, size: LogicalSize) -> Self {
+        self.attributes.initial_size = size;
+        self
+    }
+
+    /// Set the optional minimum size.
+    pub fn min_size(mut self, size: LogicalSize) -> Self {
+        self.attributes.min_size = Some(size);
+        self
+    }
+
+    /// Set the optional maximum size.
+    pub fn max_size(mut self, size: LogicalSize) -> Self {
+        self.attributes.max_size = Some(size);
+        self
+    }
+
+    /// Control initial visibility.
+    pub fn visible(mut self, visible: bool) -> Self {
+        self.attributes.visible = visible;
+        self
+    }
+
+    /// Control whether the host is resizable.
+    pub fn resizable(mut self, resizable: bool) -> Self {
+        self.attributes.resizable = resizable;
+        self
+    }
+
+    /// Control whether system decorations are requested.
+    pub fn decorations(mut self, decorations: bool) -> Self {
+        self.attributes.decorations = decorations;
+        self
+    }
+
+    /// Request a transparent host when the backend supports it.
+    pub fn transparent(mut self, transparent: bool) -> Self {
+        self.attributes.transparent = transparent;
+        self
+    }
+
+    /// Express the renderer's preferred surface family.
+    pub fn preferred_surface(mut self, preference: SurfacePreference) -> Self {
+        self.attributes.preferred_surface = preference;
+        self
+    }
+
+    /// Select where the host should be mounted or created.
+    pub fn mount_target(mut self, mount_target: MountTarget) -> Self {
+        self.attributes.mount_target = mount_target;
+        self
+    }
+
+    /// Borrow the underlying attributes.
+    pub fn attributes(&self) -> &WindowAttributes {
+        &self.attributes
+    }
+
+    /// Finish construction and return the validated attributes.
+    pub fn build(self) -> Result<WindowAttributes, WindowError> {
+        self.attributes.validate()?;
+        Ok(self.attributes)
+    }
+
+    /// Validate and hand the request to a backend.
+    pub fn build_with<B: WindowBackend>(
+        self,
+        backend: &mut B,
+    ) -> Result<B::Window, WindowError> {
+        let attributes = self.build()?;
+        backend.create_window(attributes)
+    }
+}
+
+impl Default for WindowBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Press or release state for keyboard and pointer events.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ElementState {
+    Pressed,
+    Released,
+}
+
+/// Common pointer buttons.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PointerButton {
+    Primary,
+    Secondary,
+    Middle,
+    Other(u16),
+}
+
+/// Named non-text keys.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NamedKey {
+    Escape,
+    Enter,
+    Tab,
+    Backspace,
+    Space,
+    ArrowLeft,
+    ArrowRight,
+    ArrowUp,
+    ArrowDown,
+    Home,
+    End,
+    PageUp,
+    PageDown,
+}
+
+/// A normalized key identity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Key {
+    Named(NamedKey),
+    Character(String),
+}
+
+/// Keyboard modifier state captured at the time of an event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ModifiersState {
+    pub shift: bool,
+    pub control: bool,
+    pub alt: bool,
+    pub meta: bool,
+}
+
+/// Window and input events normalized across backends.
+#[derive(Debug, Clone, PartialEq)]
+pub enum WindowEvent {
+    Created {
+        window_id: WindowId,
+    },
+    Resized {
+        window_id: WindowId,
+        logical_size: LogicalSize,
+        physical_size: PhysicalSize,
+        scale_factor: f64,
+    },
+    RedrawRequested {
+        window_id: WindowId,
+    },
+    CloseRequested {
+        window_id: WindowId,
+    },
+    Destroyed {
+        window_id: WindowId,
+    },
+    FocusChanged {
+        window_id: WindowId,
+        focused: bool,
+    },
+    VisibilityChanged {
+        window_id: WindowId,
+        visible: bool,
+    },
+    PointerMoved {
+        window_id: WindowId,
+        x: f64,
+        y: f64,
+    },
+    PointerButton {
+        window_id: WindowId,
+        button: PointerButton,
+        state: ElementState,
+    },
+    Scroll {
+        window_id: WindowId,
+        delta_x: f64,
+        delta_y: f64,
+    },
+    Key {
+        window_id: WindowId,
+        key: Key,
+        state: ElementState,
+        modifiers: ModifiersState,
+        text: Option<String>,
+    },
+    TextInput {
+        window_id: WindowId,
+        text: String,
+    },
+}
+
+/// AppKit-specific render target information.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AppKitRenderTarget {
+    pub ns_window: usize,
+    pub ns_view: usize,
+    pub metal_layer: Option<usize>,
+}
+
+/// Win32-specific render target information.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Win32RenderTarget {
+    pub hwnd: usize,
+}
+
+/// Browser canvas render target information.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BrowserCanvasRenderTarget {
+    pub mount_target: MountTarget,
+    pub logical_size: LogicalSize,
+    pub physical_size: PhysicalSize,
+    pub device_pixel_ratio: f64,
+}
+
+/// Future Wayland render target information.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WaylandRenderTarget {
+    pub display: usize,
+    pub surface: usize,
+}
+
+/// Future X11 render target information.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct X11RenderTarget {
+    pub display: usize,
+    pub window: u64,
+}
+
+/// Renderer-facing native target handle.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RenderTarget {
+    AppKit(AppKitRenderTarget),
+    Win32(Win32RenderTarget),
+    BrowserCanvas(BrowserCanvasRenderTarget),
+    Wayland(WaylandRenderTarget),
+    X11(X11RenderTarget),
+}
+
+impl RenderTarget {
+    /// Human-readable kind tag for diagnostics and tests.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::AppKit(_) => "appkit",
+            Self::Win32(_) => "win32",
+            Self::BrowserCanvas(_) => "browser-canvas",
+            Self::Wayland(_) => "wayland",
+            Self::X11(_) => "x11",
+        }
+    }
+}
+
+/// Errors produced by builder validation or backend work.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WindowError {
+    InvalidAttributes(&'static str),
+    UnsupportedConfiguration(&'static str),
+    UnsupportedPlatform(&'static str),
+    Backend(String),
+}
+
+impl WindowError {
+    /// Convenience helper for backend-specific string messages.
+    pub fn backend(message: impl Into<String>) -> Self {
+        Self::Backend(message.into())
+    }
+}
+
+impl fmt::Display for WindowError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidAttributes(message) => write!(f, "invalid window attributes: {message}"),
+            Self::UnsupportedConfiguration(message) => {
+                write!(f, "unsupported window configuration: {message}")
+            }
+            Self::UnsupportedPlatform(message) => write!(f, "unsupported platform: {message}"),
+            Self::Backend(message) => write!(f, "backend error: {message}"),
+        }
+    }
+}
+
+impl Error for WindowError {}
+
+/// Common behaviour exposed by all created hosts.
+pub trait Window {
+    fn id(&self) -> WindowId;
+    fn logical_size(&self) -> LogicalSize;
+    fn physical_size(&self) -> PhysicalSize;
+    fn scale_factor(&self) -> f64;
+    fn request_redraw(&self) -> Result<(), WindowError>;
+    fn set_title(&self, title: &str) -> Result<(), WindowError>;
+    fn set_visible(&self, visible: bool) -> Result<(), WindowError>;
+    fn render_target(&self) -> RenderTarget;
+}
+
+/// Backend contract for creating hosts and pumping events.
+pub trait WindowBackend {
+    type Window: Window;
+
+    /// Human-readable backend name for diagnostics.
+    fn backend_name(&self) -> &'static str;
+
+    /// Create one presentation host.
+    fn create_window(
+        &mut self,
+        attributes: WindowAttributes,
+    ) -> Result<Self::Window, WindowError>;
+
+    /// Return all currently available window events without blocking forever.
+    fn pump_events(&mut self) -> Result<Vec<WindowEvent>, WindowError>;
+}
+
+fn validate_scale_factor(scale_factor: f64) -> Result<(), WindowError> {
+    if !scale_factor.is_finite() || scale_factor <= 0.0 {
+        return Err(WindowError::InvalidAttributes(
+            "scale factors must be finite positive numbers",
+        ));
+    }
+    Ok(())
+}
+
+fn round_dimension(value: f64) -> Result<u32, WindowError> {
+    if value < 0.0 || value > u32::MAX as f64 {
+        return Err(WindowError::InvalidAttributes(
+            "scaled dimensions must fit into u32",
+        ));
+    }
+    Ok(value.round() as u32)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::{Cell, RefCell};
+
+    #[derive(Debug, Clone)]
+    struct MockWindow {
+        id: WindowId,
+        logical_size: LogicalSize,
+        physical_size: PhysicalSize,
+        scale_factor: f64,
+        render_target: RenderTarget,
+        redraw_requests: Cell<u32>,
+        visibility: Cell<bool>,
+        title: RefCell<String>,
+    }
+
+    impl Window for MockWindow {
+        fn id(&self) -> WindowId {
+            self.id
+        }
+
+        fn logical_size(&self) -> LogicalSize {
+            self.logical_size
+        }
+
+        fn physical_size(&self) -> PhysicalSize {
+            self.physical_size
+        }
+
+        fn scale_factor(&self) -> f64 {
+            self.scale_factor
+        }
+
+        fn request_redraw(&self) -> Result<(), WindowError> {
+            self.redraw_requests.set(self.redraw_requests.get() + 1);
+            Ok(())
+        }
+
+        fn set_title(&self, title: &str) -> Result<(), WindowError> {
+            *self.title.borrow_mut() = title.to_string();
+            Ok(())
+        }
+
+        fn set_visible(&self, visible: bool) -> Result<(), WindowError> {
+            self.visibility.set(visible);
+            Ok(())
+        }
+
+        fn render_target(&self) -> RenderTarget {
+            self.render_target.clone()
+        }
+    }
+
+    #[derive(Default)]
+    struct MockBackend {
+        last_attributes: Option<WindowAttributes>,
+        next_id: u64,
+    }
+
+    impl WindowBackend for MockBackend {
+        type Window = MockWindow;
+
+        fn backend_name(&self) -> &'static str {
+            "mock"
+        }
+
+        fn create_window(
+            &mut self,
+            attributes: WindowAttributes,
+        ) -> Result<Self::Window, WindowError> {
+            self.last_attributes = Some(attributes.clone());
+            self.next_id += 1;
+
+            Ok(MockWindow {
+                id: WindowId(self.next_id),
+                logical_size: attributes.initial_size,
+                physical_size: attributes.initial_size.to_physical(2.0)?,
+                scale_factor: 2.0,
+                render_target: RenderTarget::BrowserCanvas(BrowserCanvasRenderTarget {
+                    mount_target: attributes.mount_target.clone(),
+                    logical_size: attributes.initial_size,
+                    physical_size: attributes.initial_size.to_physical(2.0)?,
+                    device_pixel_ratio: 2.0,
+                }),
+                redraw_requests: Cell::new(0),
+                visibility: Cell::new(attributes.visible),
+                title: RefCell::new(attributes.title),
+            })
+        }
+
+        fn pump_events(&mut self) -> Result<Vec<WindowEvent>, WindowError> {
+            Ok(vec![WindowEvent::Created {
+                window_id: WindowId(self.next_id),
+            }])
+        }
+    }
+
+    #[test]
+    fn logical_size_rejects_non_finite_values() {
+        let err = LogicalSize::new(f64::NAN, 10.0).validate().unwrap_err();
+        assert_eq!(
+            err,
+            WindowError::InvalidAttributes("window sizes must be finite numbers")
+        );
+    }
+
+    #[test]
+    fn logical_size_rejects_negative_values() {
+        let err = LogicalSize::new(-1.0, 10.0).validate().unwrap_err();
+        assert_eq!(
+            err,
+            WindowError::InvalidAttributes("window sizes must be non-negative")
+        );
+    }
+
+    #[test]
+    fn logical_size_converts_to_physical_pixels() {
+        let physical = LogicalSize::new(320.0, 200.0)
+            .to_physical(2.0)
+            .unwrap();
+        assert_eq!(physical, PhysicalSize::new(640, 400));
+    }
+
+    #[test]
+    fn physical_size_converts_back_to_logical_units() {
+        let logical = PhysicalSize::new(960, 540).to_logical(1.5).unwrap();
+        assert_eq!(logical, LogicalSize::new(640.0, 360.0));
+    }
+
+    #[test]
+    fn scale_factor_must_be_positive_and_finite() {
+        let err = LogicalSize::new(100.0, 100.0).to_physical(0.0).unwrap_err();
+        assert_eq!(
+            err,
+            WindowError::InvalidAttributes("scale factors must be finite positive numbers")
+        );
+    }
+
+    #[test]
+    fn mount_targets_validate_non_blank_browser_strings() {
+        let err = MountTarget::ElementId("   ".to_string()).validate().unwrap_err();
+        assert_eq!(
+            err,
+            WindowError::InvalidAttributes("element ids must not be blank")
+        );
+    }
+
+    #[test]
+    fn browser_mount_detection_matches_variant() {
+        assert!(MountTarget::BrowserBody.is_browser_target());
+        assert!(MountTarget::QuerySelector("#app canvas".to_string()).is_browser_target());
+        assert!(!MountTarget::Native.is_browser_target());
+    }
+
+    #[test]
+    fn attributes_reject_min_size_above_initial_size() {
+        let attributes = WindowAttributes {
+            min_size: Some(LogicalSize::new(900.0, 700.0)),
+            ..WindowAttributes::default()
+        };
+
+        let err = attributes.validate().unwrap_err();
+        assert_eq!(
+            err,
+            WindowError::InvalidAttributes("minimum size must not exceed the initial size")
+        );
+    }
+
+    #[test]
+    fn attributes_reject_max_size_below_initial_size() {
+        let attributes = WindowAttributes {
+            max_size: Some(LogicalSize::new(400.0, 300.0)),
+            ..WindowAttributes::default()
+        };
+
+        let err = attributes.validate().unwrap_err();
+        assert_eq!(
+            err,
+            WindowError::InvalidAttributes("maximum size must not be smaller than the initial size")
+        );
+    }
+
+    #[test]
+    fn builder_defaults_match_default_attributes() {
+        let builder = WindowBuilder::new();
+        assert_eq!(builder.attributes(), &WindowAttributes::default());
+    }
+
+    #[test]
+    fn builder_produces_valid_custom_attributes() {
+        let attributes = WindowBuilder::new()
+            .title("Window Lab")
+            .initial_size(LogicalSize::new(1024.0, 768.0))
+            .min_size(LogicalSize::new(400.0, 300.0))
+            .max_size(LogicalSize::new(1200.0, 900.0))
+            .visible(false)
+            .transparent(true)
+            .preferred_surface(SurfacePreference::Metal)
+            .build()
+            .unwrap();
+
+        assert_eq!(attributes.title, "Window Lab");
+        assert_eq!(attributes.initial_size, LogicalSize::new(1024.0, 768.0));
+        assert_eq!(attributes.min_size, Some(LogicalSize::new(400.0, 300.0)));
+        assert_eq!(attributes.max_size, Some(LogicalSize::new(1200.0, 900.0)));
+        assert!(!attributes.visible);
+        assert!(attributes.transparent);
+        assert_eq!(attributes.preferred_surface, SurfacePreference::Metal);
+    }
+
+    #[test]
+    fn builder_can_create_windows_through_a_backend() {
+        let mut backend = MockBackend::default();
+        let window = WindowBuilder::new()
+            .title("Canvas Host")
+            .mount_target(MountTarget::BrowserBody)
+            .preferred_surface(SurfacePreference::Canvas2D)
+            .build_with(&mut backend)
+            .unwrap();
+
+        assert_eq!(window.id(), WindowId(1));
+        assert_eq!(backend.last_attributes.unwrap().title, "Canvas Host");
+    }
+
+    #[test]
+    fn windows_expose_render_targets_and_state_mutators() {
+        let mut backend = MockBackend::default();
+        let window = WindowBuilder::new()
+            .mount_target(MountTarget::BrowserBody)
+            .build_with(&mut backend)
+            .unwrap();
+
+        assert_eq!(window.render_target().kind(), "browser-canvas");
+        assert_eq!(window.scale_factor(), 2.0);
+
+        window.request_redraw().unwrap();
+        window.request_redraw().unwrap();
+        window.set_title("Retitled").unwrap();
+        window.set_visible(false).unwrap();
+
+        assert_eq!(window.redraw_requests.get(), 2);
+        assert_eq!(&*window.title.borrow(), "Retitled");
+        assert!(!window.visibility.get());
+    }
+
+    #[test]
+    fn backend_can_pump_normalized_events() {
+        let mut backend = MockBackend::default();
+        let window = WindowBuilder::new().build_with(&mut backend).unwrap();
+        let events = backend.pump_events().unwrap();
+
+        assert_eq!(
+            events,
+            vec![WindowEvent::Created {
+                window_id: window.id()
+            }]
+        );
+    }
+
+    #[test]
+    fn render_target_kind_reports_the_variant_name() {
+        let target = RenderTarget::Win32(Win32RenderTarget { hwnd: 42 });
+        assert_eq!(target.kind(), "win32");
+    }
+
+    #[test]
+    fn window_error_backend_helper_wraps_strings() {
+        let err = WindowError::backend("message pump failed");
+        assert_eq!(err.to_string(), "backend error: message pump failed");
+    }
+}

--- a/code/packages/rust/window-win32/BUILD
+++ b/code/packages/rust/window-win32/BUILD
@@ -1,0 +1,1 @@
+cargo test -p window-win32 -- --nocapture

--- a/code/packages/rust/window-win32/CHANGELOG.md
+++ b/code/packages/rust/window-win32/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-18
+
+### Added
+
+- `Win32Backend` shell with Win32-specific attribute validation.
+- Surface selection rules for `HWND`-backed native hosts.
+- Explicit rejection of Apple-only and browser-only surface requests.
+- Unit tests for Win32 validation and shell behavior.

--- a/code/packages/rust/window-win32/Cargo.toml
+++ b/code/packages/rust/window-win32/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "window-win32"
+version = "0.1.0"
+edition = "2021"
+description = "Win32 desktop window backend for window-core"
+
+[dependencies]
+window-core = { path = "../window-core" }

--- a/code/packages/rust/window-win32/README.md
+++ b/code/packages/rust/window-win32/README.md
@@ -1,0 +1,27 @@
+# window-win32
+
+Win32 desktop window backend for `window-core`.
+
+## Layer 11
+
+This package is part of Layer 11 of the coding-adventures computing stack.
+
+## What It Contains
+
+This first slice is a Win32 backend shell. It currently:
+
+- validates which `window-core` requests make sense for Win32
+- chooses the `HWND` host model expected by Direct2D or software renderers
+- rejects Apple-only and browser-only surface requests
+
+Actual `HWND` creation and message-pump integration are the next step.
+
+## Dependencies
+
+- window-core
+
+## Development
+
+```bash
+cargo test -p window-win32
+```

--- a/code/packages/rust/window-win32/src/lib.rs
+++ b/code/packages/rust/window-win32/src/lib.rs
@@ -1,0 +1,147 @@
+//! # window-win32
+//!
+//! Win32 desktop window backend for `window-core`.
+//!
+//! Like `window-appkit`, this crate is an intentionally honest shell in the
+//! first slice. It teaches the mapping from cross-platform window attributes to
+//! Win32 expectations without pretending the `HWND` creation and message pump
+//! are already implemented.
+
+use window_core::{MountTarget, SurfacePreference, WindowAttributes, WindowError};
+
+/// Crate version, kept explicit for examples and integration tests.
+pub const VERSION: &str = "0.1.0";
+
+/// Which Win32 host family the renderer should expect.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Win32SurfaceChoice {
+    /// A normal `HWND`-backed presentation host.
+    Hwnd,
+}
+
+/// Backend shell for Win32 validation and future native creation.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Win32Backend;
+
+impl Win32Backend {
+    /// Construct a new backend shell.
+    pub const fn new() -> Self {
+        Self
+    }
+
+    /// Human-readable backend name.
+    pub const fn backend_name(&self) -> &'static str {
+        "win32"
+    }
+
+    /// Choose the Win32 host surface implied by the renderer preference.
+    pub fn choose_surface(
+        &self,
+        preference: SurfacePreference,
+    ) -> Result<Win32SurfaceChoice, WindowError> {
+        match preference {
+            SurfacePreference::Default
+            | SurfacePreference::Direct2D
+            | SurfacePreference::Cairo => Ok(Win32SurfaceChoice::Hwnd),
+            SurfacePreference::Metal => Err(WindowError::UnsupportedConfiguration(
+                "Metal is an Apple renderer and cannot target Win32",
+            )),
+            SurfacePreference::Canvas2D => Err(WindowError::UnsupportedConfiguration(
+                "Canvas2D is a browser renderer and cannot target Win32",
+            )),
+        }
+    }
+
+    /// Validate a `window-core` request against Win32 expectations.
+    pub fn validate_attributes(
+        &self,
+        attributes: &WindowAttributes,
+    ) -> Result<Win32SurfaceChoice, WindowError> {
+        attributes.validate()?;
+        if attributes.mount_target != MountTarget::Native {
+            return Err(WindowError::UnsupportedConfiguration(
+                "Win32 windows must use MountTarget::Native",
+            ));
+        }
+        self.choose_surface(attributes.preferred_surface)
+    }
+
+    /// Reserve the place where real `HWND` creation will land next.
+    pub fn create_native_window(
+        &mut self,
+        attributes: WindowAttributes,
+    ) -> Result<Win32SurfaceChoice, WindowError> {
+        let surface = self.validate_attributes(&attributes)?;
+        Err(WindowError::backend(format!(
+            "native Win32 window creation is not wired yet (validated surface: {surface:?})"
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use window_core::LogicalSize;
+
+    #[test]
+    fn default_direct2d_and_cairo_share_the_hwnd_host() {
+        let backend = Win32Backend::new();
+        assert_eq!(
+            backend.choose_surface(SurfacePreference::Default).unwrap(),
+            Win32SurfaceChoice::Hwnd
+        );
+        assert_eq!(
+            backend.choose_surface(SurfacePreference::Direct2D).unwrap(),
+            Win32SurfaceChoice::Hwnd
+        );
+        assert_eq!(
+            backend.choose_surface(SurfacePreference::Cairo).unwrap(),
+            Win32SurfaceChoice::Hwnd
+        );
+    }
+
+    #[test]
+    fn win32_rejects_browser_mount_targets() {
+        let backend = Win32Backend::new();
+        let attributes = WindowAttributes {
+            mount_target: MountTarget::ElementId("app".to_string()),
+            ..WindowAttributes::default()
+        };
+
+        let err = backend.validate_attributes(&attributes).unwrap_err();
+        assert_eq!(
+            err,
+            WindowError::UnsupportedConfiguration(
+                "Win32 windows must use MountTarget::Native"
+            )
+        );
+    }
+
+    #[test]
+    fn win32_rejects_metal_requests() {
+        let backend = Win32Backend::new();
+        let err = backend.choose_surface(SurfacePreference::Metal).unwrap_err();
+        assert_eq!(
+            err,
+            WindowError::UnsupportedConfiguration(
+                "Metal is an Apple renderer and cannot target Win32"
+            )
+        );
+    }
+
+    #[test]
+    fn create_native_window_is_honest_about_being_a_shell() {
+        let mut backend = Win32Backend::new();
+        let err = backend
+            .create_native_window(WindowAttributes {
+                initial_size: LogicalSize::new(640.0, 480.0),
+                preferred_surface: SurfacePreference::Direct2D,
+                ..WindowAttributes::default()
+            })
+            .unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("native Win32 window creation is not wired yet"));
+    }
+}

--- a/code/specs/UI11-window-core.md
+++ b/code/specs/UI11-window-core.md
@@ -1,0 +1,435 @@
+# UI11 — Window Core
+
+## Overview
+
+This spec introduces a cross-platform window abstraction that is shared across
+languages and first anchored in Rust for the native backends. It sits between
+low-level native event facilities and renderer-specific drawing code. Its
+purpose is not to hide every platform quirk. Its purpose is to establish a
+small, honest contract:
+
+- create a presentation host
+- receive normalized window and input events
+- expose renderer-facing handles for the host's drawable surface
+
+On desktop platforms, that presentation host is a real native window. In the
+browser, it is a mounted HTML canvas host that behaves like a window from the
+renderer's point of view: it has a title-like identity, logical size, device
+pixel ratio, redraw cadence, focus, visibility, and input events.
+
+This gives us one Rust-facing model for:
+
+- AppKit + Metal on Apple platforms
+- Win32 + Direct2D on Windows
+- future Wayland/X11 + Cairo or GPU APIs on Linux
+- HTML Canvas in a browser tab
+
+The key boundary is:
+
+- rendering APIs draw into an existing host surface
+- window backends create and manage that host surface
+
+So Metal, Direct2D, and Cairo stay renderers. They do not become the windowing
+layer.
+
+---
+
+## Goals
+
+1. Define one repository-owned window API whose semantics stay the same across
+   languages.
+2. Use Rust crates as the native backend implementations that other languages
+   can call through bridges.
+3. Expose renderer-friendly native handles without forcing the core contract to
+   know how each renderer works.
+4. Support a browser backend without pretending the browser provides OS-style
+   windows.
+5. Stay compatible with the existing `event-loop` and `native-event-core`
+   layers.
+
+## Non-Goals
+
+- A widget toolkit
+- layout, styling, accessibility trees, or menu systems
+- cross-platform text input perfection in the first slice
+- flattening Wayland, Win32, AppKit, and browser DOM semantics into one giant
+  "universal window" interface
+
+---
+
+## Where It Fits
+
+```text
+renderer crates
+paint-metal / paint-vm-direct2d / future cairo renderer / browser canvas renderer
+    ↑
+window-core
+    ↑
+Rust native backends: window-appkit / window-win32 / future window-wayland
+TypeScript browser backend: window-canvas
+    ↑
+AppKit run loop / Win32 message pump / Wayland queue / browser DOM + RAF
+    ↑
+native-event-core / event-loop / platform dispatch
+```
+
+The window layer is above raw readiness/completion backends. A resize or key
+press is not an `epoll` event. It is a window-system event that the backend
+normalizes into a `WindowEvent`.
+
+---
+
+## Package Layout
+
+### `window-core`
+
+The backend-neutral API crate.
+
+Responsibilities:
+
+- window identifiers
+- logical and physical size types
+- builder attributes
+- normalized window and input events
+- renderer-target handle enums
+- `Window` and `WindowBackend` traits
+- error types and validation rules
+
+This Rust crate is the first concrete implementation of the contract, but the
+abstraction itself is language-neutral. Other languages must preserve the same
+names, event meanings, and renderer-target concepts even when their concrete
+runtime types differ.
+
+### `window-appkit`
+
+Apple desktop backend.
+
+Responsibilities:
+
+- create `NSApplication`, `NSWindow`, and content view state
+- translate AppKit events into `WindowEvent`
+- expose AppKit/Metal-friendly handles such as `NSWindow`, `NSView`, and
+  optional `CAMetalLayer`
+
+### `window-win32`
+
+Windows desktop backend.
+
+Responsibilities:
+
+- register a window class and create `HWND`
+- translate Win32 messages into `WindowEvent`
+- expose Win32-friendly handles such as `HWND`
+- leave Direct2D or Direct3D device creation to renderer crates
+
+### `window-canvas` (TypeScript)
+
+Browser backend.
+
+Responsibilities:
+
+- treat a mounted `<canvas>` element as the presentation host
+- map DOM input, resize, visibility, and animation-frame callbacks into
+  `WindowEvent`
+- keep CSS logical size and backing-store pixel size in sync with
+  `devicePixelRatio`
+- expose canvas-focused render targets for browser rendering code
+
+This backend is intentionally implemented in pure TypeScript rather than in a
+Rust crate. Node-based TypeScript can call the Rust native backends; the pure
+browser path should stay browser-native.
+
+### Future Backends
+
+- `window-wayland`
+- `window-x11`
+
+Linux is intentionally deferred because "Linux windowing" is not one thing.
+Wayland and X11 deserve honest backends, not a rushed false abstraction.
+
+---
+
+## Core Concepts
+
+### 1. Window vs Render Target
+
+A window is the thing that owns lifecycle and input:
+
+- open
+- resize
+- focus
+- close
+- visibility
+- redraw requests
+
+A render target is the thing a renderer needs in order to draw:
+
+- an `NSView` / `CAMetalLayer`
+- an `HWND`
+- a Wayland surface
+- an HTML canvas mount
+
+The window abstraction must expose both, but it must not confuse them.
+
+### 2. Browser "Windowing"
+
+The browser backend does not create native top-level OS windows. Instead it
+models each mounted canvas host as a window-like object.
+
+That host gets:
+
+- a `WindowId`
+- logical size in CSS pixels
+- physical size in backing-store pixels
+- focus and blur events
+- pointer and keyboard events
+- `RedrawRequested` from `requestAnimationFrame`
+- `VisibilityChanged` from page or element visibility changes
+- `CloseRequested` from teardown or explicit unmount
+
+This is the correct abstraction boundary. The renderer wants "a thing I can draw
+into that resizes and emits input," and a mounted canvas satisfies that.
+
+### 3. Honest Escape Hatches
+
+Some features are backend-specific:
+
+- AppKit activation policy
+- Win32 class styles
+- browser mount selectors
+- future Wayland protocol extensions
+
+`window-core` therefore defines a compact shared API and allows backend crates
+to expose additional configuration and handle accessors without forcing those
+details into every platform.
+
+---
+
+## Public API
+
+The initial Rust-facing API is:
+
+```rust
+pub struct WindowId(pub u64);
+
+pub struct LogicalSize {
+    pub width: f64,
+    pub height: f64,
+}
+
+pub struct PhysicalSize {
+    pub width: u32,
+    pub height: u32,
+}
+
+pub enum SurfacePreference {
+    Default,
+    Metal,
+    Direct2D,
+    Cairo,
+    Canvas2D,
+}
+
+pub enum MountTarget {
+    Native,
+    BrowserBody,
+    ElementId(String),
+    QuerySelector(String),
+}
+
+pub struct WindowAttributes {
+    pub title: String,
+    pub initial_size: LogicalSize,
+    pub min_size: Option<LogicalSize>,
+    pub max_size: Option<LogicalSize>,
+    pub visible: bool,
+    pub resizable: bool,
+    pub decorations: bool,
+    pub transparent: bool,
+    pub preferred_surface: SurfacePreference,
+    pub mount_target: MountTarget,
+}
+
+pub struct WindowBuilder { ... }
+
+pub trait Window {
+    fn id(&self) -> WindowId;
+    fn logical_size(&self) -> LogicalSize;
+    fn physical_size(&self) -> PhysicalSize;
+    fn scale_factor(&self) -> f64;
+    fn request_redraw(&self) -> Result<(), WindowError>;
+    fn set_title(&self, title: &str) -> Result<(), WindowError>;
+    fn set_visible(&self, visible: bool) -> Result<(), WindowError>;
+    fn render_target(&self) -> RenderTarget;
+}
+
+pub trait WindowBackend {
+    type Window: Window;
+
+    fn create_window(
+        &mut self,
+        attributes: WindowAttributes,
+    ) -> Result<Self::Window, WindowError>;
+
+    fn pump_events(&mut self) -> Result<Vec<WindowEvent>, WindowError>;
+}
+```
+
+### Events
+
+```rust
+pub enum WindowEvent {
+    Created { window_id: WindowId },
+    Resized {
+        window_id: WindowId,
+        logical_size: LogicalSize,
+        physical_size: PhysicalSize,
+        scale_factor: f64,
+    },
+    RedrawRequested { window_id: WindowId },
+    CloseRequested { window_id: WindowId },
+    Destroyed { window_id: WindowId },
+    FocusChanged { window_id: WindowId, focused: bool },
+    VisibilityChanged { window_id: WindowId, visible: bool },
+    PointerMoved { window_id: WindowId, x: f64, y: f64 },
+    PointerButton {
+        window_id: WindowId,
+        button: PointerButton,
+        state: ElementState,
+    },
+    Scroll {
+        window_id: WindowId,
+        delta_x: f64,
+        delta_y: f64,
+    },
+    Key {
+        window_id: WindowId,
+        key: Key,
+        state: ElementState,
+        modifiers: ModifiersState,
+        text: Option<String>,
+    },
+    TextInput { window_id: WindowId, text: String },
+}
+```
+
+### Render Targets
+
+The core crate exposes renderer-facing handles as tagged enums, not as a single
+fake universal pointer:
+
+```rust
+pub enum RenderTarget {
+    AppKit(AppKitRenderTarget),
+    Win32(Win32RenderTarget),
+    BrowserCanvas(BrowserCanvasRenderTarget),
+    Wayland(WaylandRenderTarget),
+    X11(X11RenderTarget),
+}
+```
+
+Examples:
+
+- `AppKitRenderTarget` contains `NSWindow`, `NSView`, and optional
+  `CAMetalLayer` addresses represented opaquely
+- `Win32RenderTarget` contains `HWND`
+- `BrowserCanvasRenderTarget` contains mount metadata and size state
+
+The enum is intentionally explicit so renderer crates can pattern-match on the
+target they actually support.
+
+---
+
+## Validation Rules
+
+`window-core` validates only portable invariants:
+
+- width and height must be finite and non-negative
+- `min_size <= initial_size <= max_size` where bounds exist
+- browser mount targets are only valid for browser backends
+- native-only expectations are rejected by browser backends and vice versa
+
+Backend crates validate platform-specific invariants:
+
+- Win32 class registration state
+- AppKit main-thread requirements
+- browser DOM mount lookup failures
+
+---
+
+## Browser Canvas Approach
+
+The browser backend follows these rules:
+
+1. Logical size is the canvas CSS box in CSS pixels.
+2. Physical size is `logical_size * devicePixelRatio`, rounded to integers.
+3. The backend updates the canvas backing-store size whenever the logical size
+   or DPR changes.
+4. `requestAnimationFrame` becomes `RedrawRequested`.
+5. DOM `pointer*`, `wheel`, `keydown`, `keyup`, `focus`, and `blur` events map
+   to normalized `WindowEvent` values.
+6. `ResizeObserver` or equivalent mount observation produces `Resized`.
+7. Mount lookup is described by `MountTarget`:
+   - `BrowserBody` means create or attach under `<body>`
+   - `ElementId(id)` means attach to that element
+   - `QuerySelector(sel)` means resolve that selector
+
+The browser backend therefore behaves like a tab-local multi-window system where
+each mounted canvas is one window host.
+
+---
+
+## Phased Delivery
+
+### Phase 1
+
+- add `window-core`
+- add backend scaffolding crates:
+  - `window-appkit`
+  - `window-win32`
+- implement the shared Rust API, validation, and mock-driven tests
+- document the browser-canvas host model that TypeScript will implement
+
+### Phase 2
+
+- wire native creation and event translation for AppKit and Win32
+- refactor existing macOS window display crates to consume `window-appkit`
+- implement the pure TypeScript `window-canvas` backend against the same
+  contract
+
+### Phase 3
+
+- add Wayland and/or X11 backends
+- integrate more advanced lifecycle, IME, clipboard, and accessibility support
+
+---
+
+## Testing Strategy
+
+### `window-core`
+
+- builder validation tests
+- size conversion tests
+- render-target tagging tests
+- mock backend integration tests
+
+### Native Backends
+
+- unsupported-platform tests on non-target CI
+- platform-gated smoke tests on supported targets
+- event normalization tests where platform APIs can be mocked
+
+### Browser Backend
+
+- TypeScript unit tests for mount-target logic and backing-store size
+  synchronization math
+- TypeScript browser tests later for DOM event translation
+
+---
+
+## Initial Recommendation
+
+Start with a strong `window-core` and honest backend shells. The first real
+consumer should be a renderer demo that creates a window host and then hands its
+render target to Metal, Direct2D, or Canvas2D code. That proves the boundary is
+correct before we grow into a full UI toolkit.


### PR DESCRIPTION
## Summary
- add the UI11 window-core spec for a shared cross-language window abstraction
- introduce Rust native crates for window-core, window-appkit, and window-win32
- wire a minimal real AppKit smoke path that launches an NSWindow through the new API

## Testing
- cargo test -p window-core -p window-appkit -p window-win32
- cargo run -p window-appkit --example launch_window

## Notes
- security review passed with no vulnerabilities found
- full cargo build --workspace still hits the pre-existing non-Windows paint-vm-gdi compile_error on macOS