### PR TITLE
feat(logic-stdlib): add recursive relational list helpers

### DIFF
--- a/code/packages/python/logic-engine/CHANGELOG.md
+++ b/code/packages/python/logic-engine/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.3.0] - 2026-04-18
+
+### Added
+
+- `defer(...)` and `DeferredExpr` for solve-time expansion of recursive host-language goal builders
+- pytest coverage proving deferred recursive helper goals work over concrete lists
+
 ## [0.2.0] - 2026-04-18
 
 ### Added

--- a/code/packages/python/logic-engine/README.md
+++ b/code/packages/python/logic-engine/README.md
@@ -10,6 +10,7 @@ that make relational programs feel like programs:
 - facts and rules
 - immutable clause databases
 - recursive solving with depth-first backtracking
+- deferred recursive goal builders via `defer(...)`
 - disequality constraints via `neq(...)`
 - `all_different(...)` for small puzzle-style searches
 - end-to-end query helpers like `solve_all()` and `solve_n()`

--- a/code/packages/python/logic-engine/src/logic_engine/__init__.py
+++ b/code/packages/python/logic-engine/src/logic_engine/__init__.py
@@ -11,6 +11,7 @@ from logic_engine.engine import (
     Clause,
     Compound,
     ConjExpr,
+    DeferredExpr,
     Disequality,
     DisjExpr,
     EqExpr,
@@ -31,6 +32,7 @@ from logic_engine.engine import (
     all_different,
     atom,
     conj,
+    defer,
     disj,
     eq,
     fact,
@@ -58,6 +60,7 @@ __all__ = [
     "Clause",
     "Compound",
     "ConjExpr",
+    "DeferredExpr",
     "DisjExpr",
     "EqExpr",
     "FailExpr",
@@ -77,6 +80,7 @@ __all__ = [
     "all_different",
     "atom",
     "conj",
+    "defer",
     "disj",
     "eq",
     "fact",
@@ -97,4 +101,4 @@ __all__ = [
     "var",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/code/packages/python/logic-engine/src/logic_engine/engine.py
+++ b/code/packages/python/logic-engine/src/logic_engine/engine.py
@@ -53,6 +53,7 @@ __all__ = [
     "Clause",
     "Compound",
     "ConjExpr",
+    "DeferredExpr",
     "DisjExpr",
     "Disequality",
     "EqExpr",
@@ -73,6 +74,7 @@ __all__ = [
     "all_different",
     "atom",
     "conj",
+    "defer",
     "disj",
     "eq",
     "fact",
@@ -239,12 +241,26 @@ class FreshExpr:
     body: GoalExpr
 
 
+@dataclass(frozen=True, slots=True)
+class DeferredExpr:
+    """A goal builder call that should expand only when the solver reaches it.
+
+    This is the adapter that lets host-language helper libraries define
+    recursive relations without triggering eager Python recursion while the
+    goal tree is still being built.
+    """
+
+    builder: Callable[..., object]
+    args: tuple[Term, ...]
+
+
 type GoalExpr = (
     RelationCall
     | SucceedExpr
     | FailExpr
     | EqExpr
     | NeqExpr
+    | DeferredExpr
     | ConjExpr
     | DisjExpr
     | FreshExpr
@@ -262,6 +278,7 @@ def _coerce_goal(goal: object) -> GoalExpr:
             | FailExpr
             | EqExpr
             | NeqExpr
+            | DeferredExpr
             | ConjExpr
             | DisjExpr
             | FreshExpr
@@ -295,6 +312,20 @@ def neq(left: object, right: object) -> GoalExpr:
     """Construct a disequality goal expression."""
 
     return NeqExpr(left=_coerce_term(left), right=_coerce_term(right))
+
+
+def defer(builder: Callable[..., object], *args: object) -> GoalExpr:
+    """Delay a helper-goal expansion until solve time.
+
+    ``fresh(...)`` builds expression trees eagerly. Recursive host-language
+    helper functions therefore need a way to store recursive calls as data and
+    expand them only when the solver actually reaches them.
+    """
+
+    return DeferredExpr(
+        builder=builder,
+        args=tuple(_coerce_term(argument) for argument in args),
+    )
 
 
 def conj(*goals: object) -> GoalExpr:
@@ -478,6 +509,11 @@ def _rename_goal(goal: GoalExpr, mapping: dict[LogicVar, LogicVar]) -> GoalExpr:
             left=_rename_term(goal.left, mapping),
             right=_rename_term(goal.right, mapping),
         )
+    if isinstance(goal, DeferredExpr):
+        return DeferredExpr(
+            builder=goal.builder,
+            args=tuple(_rename_term(argument, mapping) for argument in goal.args),
+        )
     if isinstance(goal, ConjExpr):
         return ConjExpr(
             goals=tuple(_rename_goal(child, mapping) for child in goal.goals),
@@ -559,6 +595,21 @@ def _freshen_goal(
         left, running_id = _freshen_term(goal.left, mapping, next_var_id)
         right, running_id = _freshen_term(goal.right, mapping, running_id)
         return NeqExpr(left=left, right=right), running_id
+
+    if isinstance(goal, DeferredExpr):
+        renamed_args: list[Term] = []
+        running_id = next_var_id
+        for argument in goal.args:
+            renamed_argument, running_id = _freshen_term(
+                argument,
+                mapping,
+                running_id,
+            )
+            renamed_args.append(renamed_argument)
+        return (
+            DeferredExpr(builder=goal.builder, args=tuple(renamed_args)),
+            running_id,
+        )
 
     if isinstance(goal, ConjExpr):
         running_id = next_var_id
@@ -654,6 +705,11 @@ def _solve_goal(
     if isinstance(goal, DisjExpr):
         for branch in goal.goals:
             yield from _solve_goal(program_value, branch, state)
+        return
+
+    if isinstance(goal, DeferredExpr):
+        expanded_goal = _coerce_goal(goal.builder(*goal.args))
+        yield from _solve_goal(program_value, expanded_goal, state)
         return
 
     if isinstance(goal, FreshExpr):

--- a/code/packages/python/logic-engine/tests/test_logic_engine.py
+++ b/code/packages/python/logic-engine/tests/test_logic_engine.py
@@ -11,6 +11,7 @@ import pytest
 
 from logic_engine import (
     Clause,
+    DeferredExpr,
     Disequality,
     Program,
     State,
@@ -18,6 +19,7 @@ from logic_engine import (
     all_different,
     atom,
     conj,
+    defer,
     disj,
     eq,
     fact,
@@ -40,7 +42,7 @@ class TestVersion:
     """Verify the package is importable and versioned."""
 
     def test_version_exists(self) -> None:
-        assert __version__ == "0.2.0"
+        assert __version__ == "0.3.0"
 
 
 class TestRelationsAndClauses:
@@ -261,6 +263,11 @@ class TestQueryHelpers:
         with pytest.raises(TypeError):
             solve_all(program(), var("X"), object())
 
+    def test_defer_creates_a_goal_expression(self) -> None:
+        deferred = defer(eq, "tea", "tea")
+
+        assert isinstance(deferred, DeferredExpr)
+
 
 class TestDisequalityConstraints:
     """Disequality is the first real puzzle-oriented constraint."""
@@ -315,6 +322,31 @@ class TestDisequalityConstraints:
             (atom("red"), atom("blue"), atom("green")),
             (atom("green"), atom("red"), atom("blue")),
         ]
+
+
+class TestDeferredRecursiveHelpers:
+    """Deferred goal builders unlock recursive Python helper libraries."""
+
+    def test_defer_supports_recursive_helper_goals(self) -> None:
+        def member_like(item: object, items: object) -> object:
+            return fresh(
+                2,
+                lambda head, tail: disj(
+                    eq(items, term(".", item, tail)),
+                    conj(
+                        eq(items, term(".", head, tail)),
+                        defer(member_like, item, tail),
+                    ),
+                ),
+            )
+
+        item = var("Item")
+
+        assert solve_all(
+            program(),
+            item,
+            member_like(item, logic_list(["tea", "cake", "jam"])),
+        ) == [atom("tea"), atom("cake"), atom("jam")]
 
 
 class TestListRelations:

--- a/code/packages/python/logic-stdlib/BUILD
+++ b/code/packages/python/logic-stdlib/BUILD
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../symbol-core -e ../logic-core -e ../logic-engine -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/logic-stdlib/CHANGELOG.md
+++ b/code/packages/python/logic-stdlib/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-18
+
+### Added
+
+- the first `logic-stdlib` package on top of `logic-engine`
+- relational list helpers: `emptyo`, `conso`, `heado`, `tailo`, `membero`, and `appendo`
+- pytest coverage for list construction, deconstruction, membership, and concatenation

--- a/code/packages/python/logic-stdlib/README.md
+++ b/code/packages/python/logic-stdlib/README.md
@@ -1,0 +1,56 @@
+# logic-stdlib
+
+`logic-stdlib` is the first relational standard library built on top of
+[`logic-engine`](../logic-engine/).
+
+It does not add a new evaluator. It adds reusable relational vocabulary so
+users can solve list-shaped problems directly in Python without hand-writing the
+same recursive helper relations every time.
+
+The first slice includes:
+
+- `emptyo(...)`
+- `conso(...)`
+- `heado(...)`
+- `tailo(...)`
+- `membero(...)`
+- `appendo(...)`
+
+## Quick Start
+
+```python
+from logic_engine import atom, logic_list, program, solve_all, solve_n, var
+from logic_stdlib import appendo, membero
+
+X = var("X")
+Prefix = var("Prefix")
+Suffix = var("Suffix")
+
+assert solve_all(program(), X, membero(X, logic_list(["tea", "cake"]))) == [
+    atom("tea"),
+    atom("cake"),
+]
+
+answers = solve_n(
+    program(),
+    3,
+    (Prefix, Suffix),
+    appendo(Prefix, Suffix, logic_list(["tea", "cake"])),
+)
+
+assert answers == [
+    (logic_list([]), logic_list(["tea", "cake"])),
+    (logic_list(["tea"]), logic_list(["cake"])),
+    (logic_list(["tea", "cake"]), logic_list([])),
+]
+```
+
+## Dependencies
+
+- [`logic-engine`](../logic-engine/)
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/python/logic-stdlib/pyproject.toml
+++ b/code/packages/python/logic-stdlib/pyproject.toml
@@ -3,15 +3,15 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "coding-adventures-logic-engine"
-version = "0.3.0"
-description = "Logic programming engine: relations, clauses, programs, resolution, and disequality"
+name = "coding-adventures-logic-stdlib"
+version = "0.1.0"
+description = "Relational standard library helpers built on top of logic-engine"
 requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]
 readme = "README.md"
-dependencies = ["coding-adventures-logic-core>=0.2.0"]
-keywords = ["logic-programming", "prolog", "resolution", "backtracking", "education"]
+dependencies = ["coding-adventures-logic-engine>=0.3.0"]
+keywords = ["logic-programming", "prolog", "kanren", "relations", "education"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Education",
@@ -25,10 +25,11 @@ classifiers = [
 [project.urls]
 Homepage = "https://github.com/adhithyan15/coding-adventures"
 Repository = "https://github.com/adhithyan15/coding-adventures"
-Documentation = "https://github.com/adhithyan15/coding-adventures/tree/main/code/specs/LP02-disequality-constraints.md"
+Documentation = "https://github.com/adhithyan15/coding-adventures/tree/main/code/specs/LP03-relational-stdlib.md"
 
 [project.optional-dependencies]
 dev = [
+    "coding-adventures-logic-core>=0.2.0",
     "coding-adventures-symbol-core>=0.1.0",
     "pytest>=8.0",
     "pytest-cov>=5.0",
@@ -37,11 +38,12 @@ dev = [
 ]
 
 [tool.uv.sources]
+coding-adventures-logic-engine = { path = "../logic-engine", editable = true }
 coding-adventures-logic-core = { path = "../logic-core", editable = true }
 coding-adventures-symbol-core = { path = "../symbol-core", editable = true }
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/logic_engine"]
+packages = ["src/logic_stdlib"]
 
 [tool.ruff]
 target-version = "py312"
@@ -52,10 +54,10 @@ select = ["E", "W", "F", "I", "UP", "B", "SIM", "ANN"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--cov=logic_engine --cov-report=term-missing --cov-fail-under=80"
+addopts = "--cov=logic_stdlib --cov-report=term-missing --cov-fail-under=80"
 
 [tool.coverage.run]
-source = ["src/logic_engine"]
+source = ["src/logic_stdlib"]
 
 [tool.coverage.report]
 fail_under = 80

--- a/code/packages/python/logic-stdlib/src/logic_stdlib/__init__.py
+++ b/code/packages/python/logic-stdlib/src/logic_stdlib/__init__.py
@@ -1,0 +1,28 @@
+"""Relational standard library helpers built on top of ``logic-engine``.
+
+The core and engine layers are intentionally small. That keeps the execution
+model crisp, but it means users quickly end up rewriting the same recursive
+list relations in every example. This package starts factoring that vocabulary
+out into reusable host-language helpers.
+"""
+
+from logic_stdlib.relations import (
+    appendo,
+    conso,
+    emptyo,
+    heado,
+    membero,
+    tailo,
+)
+
+__all__ = [
+    "__version__",
+    "appendo",
+    "conso",
+    "emptyo",
+    "heado",
+    "membero",
+    "tailo",
+]
+
+__version__ = "0.1.0"

--- a/code/packages/python/logic-stdlib/src/logic_stdlib/relations.py
+++ b/code/packages/python/logic-stdlib/src/logic_stdlib/relations.py
@@ -1,0 +1,87 @@
+"""Reusable list relations for the host-language logic library.
+
+These helpers are written directly in terms of ``logic-engine`` goal
+expressions. That is an important architectural point:
+
+- the standard library does not get its own evaluator
+- the Prolog implementation later should still lower into the same engine
+- users can learn relational programming concepts from ordinary Python imports
+
+The functions here use the miniKanren-style ``o`` suffix to emphasize that they
+describe relations, not one-way deterministic computations.
+"""
+
+from __future__ import annotations
+
+from logic_engine import GoalExpr, conj, defer, disj, eq, fresh, logic_list, term
+
+__all__ = [
+    "appendo",
+    "conso",
+    "emptyo",
+    "heado",
+    "membero",
+    "tailo",
+]
+
+
+def emptyo(value: object) -> GoalExpr:
+    """Succeed exactly when ``value`` is the canonical empty list."""
+
+    return eq(value, logic_list([]))
+
+
+def conso(head: object, tail: object, pair: object) -> GoalExpr:
+    """Relate ``pair`` to a list whose first cell is ``head`` and ``tail``."""
+
+    return eq(pair, term(".", head, tail))
+
+
+def heado(items: object, head: object) -> GoalExpr:
+    """Relate ``head`` to the first element of a non-empty list."""
+
+    return fresh(1, lambda tail: conso(head, tail, items))
+
+
+def tailo(items: object, tail: object) -> GoalExpr:
+    """Relate ``tail`` to everything after the first element of a list."""
+
+    return fresh(1, lambda head: conso(head, tail, items))
+
+
+def membero(member: object, items: object) -> GoalExpr:
+    """Relate ``member`` to each element that appears inside ``items``.
+
+    The relation says: an element is a member of a list if it is either the
+    head of that list or a member of the tail.
+    """
+
+    return fresh(
+        2,
+        lambda head, tail: disj(
+            conso(member, tail, items),
+            conj(conso(head, tail, items), defer(membero, member, tail)),
+        ),
+    )
+
+
+def appendo(left: object, right: object, combined: object) -> GoalExpr:
+    """Relate two lists to their concatenation.
+
+    This is the classic recursive append relation:
+
+    - appending ``[]`` to ``right`` yields ``right``
+    - otherwise peel one head cell from ``left`` and mirror it into ``combined``
+    """
+
+    return disj(
+        conj(emptyo(left), eq(right, combined)),
+        fresh(
+            3,
+            lambda head, left_tail, out_tail: conj(
+                conso(head, left_tail, left),
+                conso(head, out_tail, combined),
+                defer(appendo, left_tail, right, out_tail),
+            ),
+        ),
+    )

--- a/code/packages/python/logic-stdlib/tests/test_logic_stdlib.py
+++ b/code/packages/python/logic-stdlib/tests/test_logic_stdlib.py
@@ -1,0 +1,101 @@
+"""Tests for the first relational standard-library helpers."""
+
+from logic_engine import (
+    __version__ as logic_engine_version,
+)
+from logic_engine import (
+    atom,
+    logic_list,
+    program,
+    solve_all,
+    solve_n,
+    var,
+)
+
+from logic_stdlib import (
+    __version__,
+    appendo,
+    conso,
+    emptyo,
+    heado,
+    membero,
+    tailo,
+)
+
+
+class TestVersion:
+    """Verify the package is importable and wired to the engine layer."""
+
+    def test_version_exists(self) -> None:
+        assert __version__ == "0.1.0"
+        assert logic_engine_version == "0.3.0"
+
+
+class TestListRelations:
+    """The first standard-library helpers should cover common list relations."""
+
+    def test_emptyo_recognizes_the_empty_list(self) -> None:
+        items = var("Items")
+
+        assert solve_all(program(), items, emptyo(items)) == [logic_list([])]
+
+    def test_conso_can_deconstruct_a_non_empty_list(self) -> None:
+        head = var("Head")
+        tail = var("Tail")
+
+        assert solve_all(
+            program(),
+            (head, tail),
+            conso(head, tail, logic_list(["tea", "cake"])),
+        ) == [(atom("tea"), logic_list(["cake"]))]
+
+    def test_heado_extracts_the_first_element(self) -> None:
+        head = var("Head")
+
+        assert solve_all(
+            program(),
+            head,
+            heado(logic_list(["tea", "cake", "jam"]), head),
+        ) == [atom("tea")]
+
+    def test_tailo_extracts_the_remaining_list(self) -> None:
+        tail = var("Tail")
+
+        assert solve_all(
+            program(),
+            tail,
+            tailo(logic_list(["tea", "cake", "jam"]), tail),
+        ) == [logic_list(["cake", "jam"])]
+
+    def test_membero_enumerates_members_of_a_concrete_list(self) -> None:
+        item = var("Item")
+
+        assert solve_all(
+            program(),
+            item,
+            membero(item, logic_list(["tea", "cake", "jam"])),
+        ) == [atom("tea"), atom("cake"), atom("jam")]
+
+    def test_appendo_concatenates_two_concrete_lists(self) -> None:
+        combined = var("Combined")
+
+        assert solve_all(
+            program(),
+            combined,
+            appendo(logic_list(["tea"]), logic_list(["cake", "jam"]), combined),
+        ) == [logic_list(["tea", "cake", "jam"])]
+
+    def test_appendo_can_split_a_concrete_list(self) -> None:
+        prefix = var("Prefix")
+        suffix = var("Suffix")
+
+        assert solve_n(
+            program(),
+            4,
+            (prefix, suffix),
+            appendo(prefix, suffix, logic_list(["tea", "cake"])),
+        ) == [
+            (logic_list([]), logic_list(["tea", "cake"])),
+            (logic_list(["tea"]), logic_list(["cake"])),
+            (logic_list(["tea", "cake"]), logic_list([])),
+        ]

--- a/code/specs/LP01-logic-engine.md
+++ b/code/specs/LP01-logic-engine.md
@@ -145,6 +145,7 @@ The engine should support:
 
 - `eq(left, right)`
 - `neq(left, right)`
+- `defer(builder, *args)`
 - `succeed()`
 - `fail()`
 - `conj(g1, g2, ...)`
@@ -164,6 +165,7 @@ GoalExpr :=
   | Fail
   | Eq(term, term)
   | Neq(term, term)
+  | Defer(builder, term[])
   | Conj(goal[])
   | Disj(goal[])
   | Fresh(vars, goal)
@@ -233,6 +235,7 @@ The first Python API should look like this:
 
 ```python
 from logic_engine import (
+    defer,
     atom,
     conj,
     disj,
@@ -294,6 +297,7 @@ succeed() -> GoalExpr
 fail() -> GoalExpr
 eq(left: object, right: object) -> GoalExpr
 neq(left: object, right: object) -> GoalExpr
+defer(builder: Callable[..., GoalExpr], *args: object) -> GoalExpr
 conj(*goals: GoalExpr) -> GoalExpr
 disj(*goals: GoalExpr) -> GoalExpr
 fresh(count: int, fn: Callable[..., GoalExpr]) -> GoalExpr
@@ -303,6 +307,10 @@ solve(program: Program, goal: GoalExpr) -> Iterator[State]
 solve_all(program: Program, query: object | tuple[object, ...], goal: GoalExpr) -> list[Term | tuple[Term, ...]]
 solve_n(program: Program, n: int, query: object | tuple[object, ...], goal: GoalExpr) -> list[Term | tuple[Term, ...]]
 ```
+
+`defer(...)` exists so higher-level helper libraries can define recursive
+goal builders without forcing eager Python recursion while the expression tree
+is still being constructed.
 
 The package should also re-export the core term constructors from LP00:
 

--- a/code/specs/LP03-relational-stdlib.md
+++ b/code/specs/LP03-relational-stdlib.md
@@ -1,0 +1,310 @@
+# LP03 — Relational Standard Library
+
+## Overview
+
+`logic-core` gives us terms, unification, and search.
+`logic-engine` gives us relations, clauses, and recursive solving.
+
+That is enough to *express* many logic programs, but it is still missing the
+small reusable vocabulary that makes relational programming pleasant in a
+host-language library.
+
+Right now, if a user wants a `member` relation or list concatenation, they have
+to hand-write the rules every time:
+
+```python
+member = relation("member", 2)
+
+members = program(
+    rule(member(x, term(".", x, tail)), succeed()),
+    rule(member(x, term(".", head, tail)), member(x, tail)),
+)
+```
+
+That is educational once. It is noise after that.
+
+This milestone adds a tiny standard library package of reusable relational
+helpers built directly on top of `logic-engine`.
+
+## Design Goal
+
+Add the smallest useful relational vocabulary that lets users solve list-shaped
+logic problems directly in Python without first building their own helper
+relations.
+
+The first slice should include:
+
+- `emptyo`
+- `conso`
+- `heado`
+- `tailo`
+- `membero`
+- `appendo`
+
+Because Python helper functions are evaluated eagerly, this milestone also
+depends on one small engine capability:
+
+- `defer(builder, *args)` for solve-time recursive goal expansion
+
+The naming follows the common miniKanren-style `o` suffix to signal that these
+are *relations*, not ordinary Python functions.
+
+## Layer Position
+
+```text
+SYM00 Symbol Core
+    ↓
+LP00 Logic Core
+    ↓
+LP01 Logic Engine
+    ↓
+LP02 Disequality Constraints
+    ↓
+LP03 Relational Standard Library   ← this milestone
+    - list relations
+    - reusable host-language vocabulary
+```
+
+## Why A Separate Package
+
+These helpers should live in a new package rather than in `logic-engine`
+itself.
+
+That keeps the stack clean:
+
+- `logic-engine` remains the execution substrate
+- `logic-stdlib` becomes reusable vocabulary on top of that substrate
+
+This is a good fit for the larger project vision:
+
+- the engine stays small and language-neutral
+- the standard library can grow incrementally
+- a future Prolog implementation can still compile down to the same engine
+
+## First API
+
+The first Python package should expose:
+
+```python
+emptyo(value: object) -> GoalExpr
+conso(head: object, tail: object, pair: object) -> GoalExpr
+heado(items: object, head: object) -> GoalExpr
+tailo(items: object, tail: object) -> GoalExpr
+membero(member: object, items: object) -> GoalExpr
+appendo(left: object, right: object, combined: object) -> GoalExpr
+```
+
+These all return `logic-engine` goal expressions and should compose with:
+
+- `conj(...)`
+- `disj(...)`
+- `fresh(...)`
+- `defer(...)`
+- `neq(...)`
+- relation calls from user-defined programs
+
+## Semantics
+
+### `emptyo`
+
+Succeed exactly when the value is the empty list.
+
+```python
+emptyo(X)
+```
+
+means:
+
+```python
+eq(X, [])
+```
+
+### `conso`
+
+Relate a list to its head and tail.
+
+```python
+conso(H, T, L)
+```
+
+means:
+
+```text
+L = .(H, T)
+```
+
+This is the fundamental list-construction relation.
+
+### `heado`
+
+Expose the first element of a non-empty list.
+
+```python
+heado([tea, cake], X)
+⇒ X = tea
+```
+
+### `tailo`
+
+Expose the tail of a non-empty list.
+
+```python
+tailo([tea, cake], X)
+⇒ X = [cake]
+```
+
+### `membero`
+
+Relate an element to a list when the element appears anywhere in that list.
+
+Examples:
+
+```python
+membero(X, [tea, cake])
+⇒ X = tea ; X = cake
+
+membero(cake, [tea, cake])
+⇒ success
+```
+
+Operationally, the first version should encode the standard recursive rule:
+
+```text
+membero(X, [X | _]).
+membero(X, [_ | Tail]) :- membero(X, Tail).
+```
+
+### `appendo`
+
+Relate two lists to their concatenation.
+
+Examples:
+
+```python
+appendo([tea], [cake], X)
+⇒ X = [tea, cake]
+
+appendo(X, Y, [tea, cake])
+⇒ X = [], Y = [tea, cake]
+⇒ X = [tea], Y = [cake]
+⇒ X = [tea, cake], Y = []
+```
+
+Operationally, the first version should encode:
+
+```text
+appendo([], Right, Right).
+appendo([Head | LeftTail], Right, [Head | OutTail]) :-
+    appendo(LeftTail, Right, OutTail).
+```
+
+## Representation
+
+The package should reuse the canonical list representation already established
+in `logic-core`:
+
+- `[]` is the atom `[]`
+- non-empty lists are nested `.(Head, Tail)` terms
+
+The standard library must not invent a second list encoding.
+
+## Package
+
+Create a new Python package:
+
+```text
+code/packages/python/logic-stdlib
+```
+
+Suggested publishable package metadata:
+
+- distribution: `coding-adventures-logic-stdlib`
+- module: `logic_stdlib`
+
+Dependencies:
+
+- `coding-adventures-logic-engine`
+
+## Usage Example
+
+```python
+from logic_engine import logic_list, program, solve_n, var
+from logic_stdlib import appendo
+
+prefix = var("Prefix")
+suffix = var("Suffix")
+
+answers = solve_n(
+    program(),
+    3,
+    (prefix, suffix),
+    appendo(prefix, suffix, logic_list(["tea", "cake"])),
+)
+```
+
+The answers should be:
+
+```text
+([], [tea, cake])
+([tea], [cake])
+([tea, cake], [])
+```
+
+## Search Notes
+
+The standard library inherits `logic-engine`'s current execution strategy:
+
+- depth-first
+- left-biased
+- no tabling
+
+That means some highly open-ended queries may diverge. This is acceptable for
+the first slice as long as:
+
+- the relations are correct
+- the docs use bounded examples where appropriate
+- tests focus on finite or deliberately truncated queries
+
+The package should use `defer(...)` internally for recursive relations such as
+`membero` and `appendo`, so users get recursion without manually building
+auxiliary clause databases.
+
+## Test Strategy
+
+Required tests:
+
+- `emptyo` recognizes the empty list
+- `conso` can construct and deconstruct lists
+- `heado` extracts the first list element
+- `tailo` extracts the remaining list tail
+- `membero` enumerates members of a concrete list
+- `appendo` concatenates concrete lists
+- `appendo` can split a concrete list into prefixes and suffixes
+
+## Future Extensions
+
+Later milestones may add:
+
+- `listo`
+- `lengtho`
+- `reverseo`
+- `selecto`
+- `permuteo`
+- arithmetic relations
+- finite-domain helpers
+
+This milestone should stay intentionally small and crisp.
+
+## Why This Milestone Matters
+
+LP03 is where the Python library starts to feel like a genuine relational
+toolkit instead of just a raw execution engine.
+
+Users will be able to write:
+
+- list decomposition problems
+- prefix/suffix search problems
+- membership constraints
+- small symbolic puzzles
+
+without first re-deriving the same recursive list relations every time.


### PR DESCRIPTION
## Summary
- add the LP03 relational-stdlib spec and sync LP01 with solve-time deferred goal builders
- teach `logic-engine` about `defer(...)` so recursive host-language helper goals can expand at solve time instead of during eager Python construction
- add a new Python `logic-stdlib` package with `emptyo`, `conso`, `heado`, `tailo`, `membero`, and `appendo`

## Testing
- `/Users/adhithya/.local/bin/python3.12 -m venv .venv` plus editable installs for sibling packages in `code/packages/python/logic-engine`, then `.venv/bin/python -m pytest tests -v`
- `.venv/bin/python -m ruff check src tests` in `code/packages/python/logic-engine`
- `/Users/adhithya/.local/bin/python3.12 -m venv .venv` plus editable installs for sibling packages in `code/packages/python/logic-stdlib`, then `.venv/bin/python -m pytest tests -v`
- `.venv/bin/python -m ruff check src tests` in `code/packages/python/logic-stdlib`

## Notes
- security review passed with no findings
- local `uv` is unavailable in this shell, so I verified with Python 3.12 virtualenvs instead of running the package `BUILD` scripts directly