### PR TITLE
feat(lz78): add Dart CMP01 package

### DIFF
--- a/code/packages/dart/lz78/.gitignore
+++ b/code/packages/dart/lz78/.gitignore
@@ -1,0 +1,2 @@
+.dart_tool/
+pubspec.lock

--- a/code/packages/dart/lz78/BUILD
+++ b/code/packages/dart/lz78/BUILD
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/lz78/CHANGELOG.md
+++ b/code/packages/dart/lz78/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Added a trie-based dictionary cursor plus token-level `encode` and `decode` APIs.
 - Added one-shot `compress` and `decompress` helpers using the CMP01 wire format.
 - Added malformed-input validation for invalid dictionary indexes and truncated token streams.
+- Added strict wire-length validation so incomplete headers and trailing bytes are rejected.

--- a/code/packages/dart/lz78/CHANGELOG.md
+++ b/code/packages/dart/lz78/CHANGELOG.md
@@ -7,3 +7,4 @@
 - Added one-shot `compress` and `decompress` helpers using the CMP01 wire format.
 - Added malformed-input validation for invalid dictionary indexes and truncated token streams.
 - Added strict wire-length validation so incomplete headers and trailing bytes are rejected.
+- Added declared-output-length validation so tampered streams cannot underflow or overflow the expected decode size.

--- a/code/packages/dart/lz78/CHANGELOG.md
+++ b/code/packages/dart/lz78/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Added the initial Dart implementation of the CMP01 LZ78 compression package.
+- Added a trie-based dictionary cursor plus token-level `encode` and `decode` APIs.
+- Added one-shot `compress` and `decompress` helpers using the CMP01 wire format.
+- Added malformed-input validation for invalid dictionary indexes and truncated token streams.

--- a/code/packages/dart/lz78/README.md
+++ b/code/packages/dart/lz78/README.md
@@ -1,0 +1,41 @@
+# coding_adventures_lz78
+
+LZ78 explicit-dictionary compression for Dart. This package implements the
+CMP01 specification from the coding-adventures compression series and exposes
+both a token-level teaching API and a one-shot byte-oriented API.
+
+## What It Provides
+
+- `Token` values of the form `(dictIndex, nextChar)`
+- `TrieCursor` for step-by-step trie-based dictionary construction
+- `encode` and `decode` for working directly with LZ78 token streams
+- `compress` and `decompress` for one-shot binary compression
+- `serialiseTokens` and `deserialiseTokens` for the fixed-width CMP01 wire format
+
+## Usage
+
+```dart
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:coding_adventures_lz78/lz78.dart';
+
+void main() {
+  final data = Uint8List.fromList(utf8.encode('hello hello hello world'));
+
+  final compressed = compress(data);
+  final original = decompress(compressed);
+
+  final tokens = encode(data);
+  final decoded = decode(tokens, data.length);
+
+  print(original.length == decoded.length);
+}
+```
+
+## Building and Testing
+
+```bash
+dart pub get
+dart test
+```

--- a/code/packages/dart/lz78/lib/lz78.dart
+++ b/code/packages/dart/lz78/lib/lz78.dart
@@ -1,0 +1,1 @@
+export 'src/lz78.dart';

--- a/code/packages/dart/lz78/lib/src/lz78.dart
+++ b/code/packages/dart/lz78/lib/src/lz78.dart
@@ -49,7 +49,9 @@ class _CursorNode {
 /// sequence, and [reset]s to the trie root.
 class TrieCursor {
   /// Creates an empty trie cursor positioned at the root.
-  TrieCursor() : _root = _CursorNode(0), _current = _CursorNode(0) {
+  TrieCursor()
+      : _root = _CursorNode(0),
+        _current = _CursorNode(0) {
     _current = _root;
   }
 
@@ -185,7 +187,9 @@ Uint8List serialiseTokens(List<Token> tokens, int originalLength) {
 /// Deserialises the CMP01 wire format back into tokens and original length.
 ({List<Token> tokens, int originalLength}) deserialiseTokens(Uint8List data) {
   if (data.length < 8) {
-    return (tokens: const <Token>[], originalLength: 0);
+    throw const FormatException(
+      'Malformed LZ78 token stream: header is incomplete.',
+    );
   }
 
   final view = ByteData.view(
@@ -195,16 +199,16 @@ Uint8List serialiseTokens(List<Token> tokens, int originalLength) {
   );
   final originalLength = view.getUint32(0, Endian.big);
   final tokenCount = view.getUint32(4, Endian.big);
+  final expectedLength = 8 + tokenCount * 4;
+  if (data.length != expectedLength) {
+    throw FormatException(
+      'Malformed LZ78 token stream: expected $expectedLength bytes, got ${data.length}.',
+    );
+  }
   final tokens = <Token>[];
 
   for (var index = 0; index < tokenCount; index++) {
     final base = 8 + index * 4;
-    if (base + 4 > data.length) {
-      throw const FormatException(
-        'Malformed LZ78 token stream: truncated data.',
-      );
-    }
-
     final current = token(
       view.getUint16(base, Endian.big),
       view.getUint8(base + 2),

--- a/code/packages/dart/lz78/lib/src/lz78.dart
+++ b/code/packages/dart/lz78/lib/src/lz78.dart
@@ -132,18 +132,30 @@ Uint8List decode(List<Token> tokens, [int originalLength = -1]) {
 
     final sequence = _reconstruct(table, current.dictIndex);
     output.addAll(sequence);
+    if (originalLength >= 0 && output.length > originalLength) {
+      throw FormatException(
+        'Malformed LZ78 token stream: decoded output exceeds declared length $originalLength.',
+      );
+    }
 
     if (originalLength < 0 || output.length < originalLength) {
       output.add(current.nextChar);
+    } else if (current.nextChar != 0) {
+      throw FormatException(
+        'Malformed LZ78 token stream: token data exceeds declared length $originalLength.',
+      );
     }
 
     table.add((parentId: current.dictIndex, byte: current.nextChar));
   }
 
-  final result = originalLength >= 0
-      ? output.take(originalLength).toList(growable: false)
-      : output;
-  return Uint8List.fromList(result);
+  if (originalLength >= 0 && output.length != originalLength) {
+    throw FormatException(
+      'Malformed LZ78 token stream: decoded output length ${output.length} does not match declared length $originalLength.',
+    );
+  }
+
+  return Uint8List.fromList(output);
 }
 
 List<int> _reconstruct(List<({int parentId, int byte})> table, int index) {
@@ -253,11 +265,6 @@ void _validateDecodedToken(Token current, int dictionaryLength) {
 }
 
 void _validateDeserialisedToken(Token current, int originalLength) {
-  if (current.dictIndex > 65535) {
-    throw const FormatException(
-      'Malformed LZ78 token stream: dictIndex exceeds uint16 range.',
-    );
-  }
   if (originalLength == 0 && current.dictIndex != 0) {
     throw const FormatException(
       'Malformed LZ78 token stream: non-empty dictionary reference for empty output.',

--- a/code/packages/dart/lz78/lib/src/lz78.dart
+++ b/code/packages/dart/lz78/lib/src/lz78.dart
@@ -1,0 +1,262 @@
+import 'dart:typed_data';
+
+/// One LZ78 token represented as `(dictIndex, nextChar)`.
+///
+/// `dictIndex` points at the longest dictionary prefix that matches the
+/// current input. `nextChar` is the following byte, or `0` when a flush token
+/// terminates a partial match at end of stream.
+class Token {
+  /// Creates a token with the given LZ78 fields.
+  const Token(this.dictIndex, this.nextChar);
+
+  /// Dictionary entry ID for the longest prefix match, or `0` for a literal.
+  final int dictIndex;
+
+  /// Byte following the matched prefix, or the flush sentinel `0`.
+  final int nextChar;
+
+  @override
+  bool operator ==(Object other) {
+    return other is Token &&
+        other.dictIndex == dictIndex &&
+        other.nextChar == nextChar;
+  }
+
+  @override
+  int get hashCode => Object.hash(dictIndex, nextChar);
+
+  @override
+  String toString() {
+    return 'Token(dictIndex: $dictIndex, nextChar: $nextChar)';
+  }
+}
+
+/// Creates a [Token] without needing to call the constructor directly.
+Token token(int dictIndex, int nextChar) => Token(dictIndex, nextChar);
+
+/// Internal trie node used by [TrieCursor].
+class _CursorNode {
+  _CursorNode(this.dictId);
+
+  final int dictId;
+  final Map<int, _CursorNode> children = <int, _CursorNode>{};
+}
+
+/// A byte-at-a-time trie cursor for streaming dictionary algorithms.
+///
+/// The encoder keeps the cursor on the current matched prefix. When [step]
+/// fails for a byte, the encoder emits a token, optionally [insert]s the new
+/// sequence, and [reset]s to the trie root.
+class TrieCursor {
+  /// Creates an empty trie cursor positioned at the root.
+  TrieCursor() : _root = _CursorNode(0), _current = _CursorNode(0) {
+    _current = _root;
+  }
+
+  final _CursorNode _root;
+  late _CursorNode _current;
+
+  /// Tries to follow the edge for [byte] from the current position.
+  ///
+  /// Returns `true` and advances the cursor if the edge exists. Returns
+  /// `false` and leaves the cursor unchanged on a miss.
+  bool step(int byte) {
+    final child = _current.children[byte];
+    if (child == null) {
+      return false;
+    }
+
+    _current = child;
+    return true;
+  }
+
+  /// Inserts a child edge for [byte] with the given [dictId].
+  void insert(int byte, int dictId) {
+    _current.children[byte] = _CursorNode(dictId);
+  }
+
+  /// Resets the cursor back to the trie root.
+  void reset() {
+    _current = _root;
+  }
+
+  /// Dictionary ID at the current cursor position.
+  int get dictId => _current.dictId;
+
+  /// Whether the cursor is currently at the root.
+  bool get atRoot => identical(_current, _root);
+}
+
+/// Encodes [data] into an LZ78 token stream.
+///
+/// The encoder walks an explicit trie one byte at a time. On a miss, it emits
+/// the current dictionary prefix plus the unmatched byte, records the new
+/// sequence in the dictionary if space allows, and resets to the root.
+List<Token> encode(Uint8List data, [int maxDictSize = 65536]) {
+  final cursor = TrieCursor();
+  var nextId = 1;
+  final tokens = <Token>[];
+
+  for (final byte in data) {
+    if (!cursor.step(byte)) {
+      tokens.add(token(cursor.dictId, byte));
+
+      if (nextId < maxDictSize) {
+        cursor.insert(byte, nextId);
+        nextId += 1;
+      }
+
+      cursor.reset();
+    }
+  }
+
+  if (!cursor.atRoot) {
+    tokens.add(token(cursor.dictId, 0));
+  }
+
+  return List<Token>.unmodifiable(tokens);
+}
+
+/// Decodes an LZ78 token stream back into the original bytes.
+///
+/// If [originalLength] is provided, the decoded output is truncated to that
+/// many bytes so the flush sentinel is not returned to the caller.
+Uint8List decode(List<Token> tokens, [int originalLength = -1]) {
+  final table = <({int parentId, int byte})>[(parentId: 0, byte: 0)];
+  final output = <int>[];
+
+  for (final current in tokens) {
+    _validateDecodedToken(current, table.length);
+
+    final sequence = _reconstruct(table, current.dictIndex);
+    output.addAll(sequence);
+
+    if (originalLength < 0 || output.length < originalLength) {
+      output.add(current.nextChar);
+    }
+
+    table.add((parentId: current.dictIndex, byte: current.nextChar));
+  }
+
+  final result = originalLength >= 0
+      ? output.take(originalLength).toList(growable: false)
+      : output;
+  return Uint8List.fromList(result);
+}
+
+List<int> _reconstruct(List<({int parentId, int byte})> table, int index) {
+  if (index == 0) {
+    return const <int>[];
+  }
+
+  final reversed = <int>[];
+  var current = index;
+  while (current != 0) {
+    final entry = table[current];
+    reversed.add(entry.byte);
+    current = entry.parentId;
+  }
+
+  return reversed.reversed.toList(growable: false);
+}
+
+/// Serialises [tokens] to the fixed-width CMP01 wire format.
+///
+/// Layout:
+/// - 4 bytes: original length as big-endian uint32
+/// - 4 bytes: token count as big-endian uint32
+/// - N x 4 bytes: `(dictIndex: uint16, nextChar: uint8, reserved: uint8)`
+Uint8List serialiseTokens(List<Token> tokens, int originalLength) {
+  final bytes = ByteData(8 + tokens.length * 4);
+  bytes.setUint32(0, originalLength, Endian.big);
+  bytes.setUint32(4, tokens.length, Endian.big);
+
+  for (var index = 0; index < tokens.length; index++) {
+    final base = 8 + index * 4;
+    final current = tokens[index];
+    bytes.setUint16(base, current.dictIndex, Endian.big);
+    bytes.setUint8(base + 2, current.nextChar);
+    bytes.setUint8(base + 3, 0);
+  }
+
+  return bytes.buffer.asUint8List();
+}
+
+/// Deserialises the CMP01 wire format back into tokens and original length.
+({List<Token> tokens, int originalLength}) deserialiseTokens(Uint8List data) {
+  if (data.length < 8) {
+    return (tokens: const <Token>[], originalLength: 0);
+  }
+
+  final view = ByteData.view(
+    data.buffer,
+    data.offsetInBytes,
+    data.lengthInBytes,
+  );
+  final originalLength = view.getUint32(0, Endian.big);
+  final tokenCount = view.getUint32(4, Endian.big);
+  final tokens = <Token>[];
+
+  for (var index = 0; index < tokenCount; index++) {
+    final base = 8 + index * 4;
+    if (base + 4 > data.length) {
+      throw const FormatException(
+        'Malformed LZ78 token stream: truncated data.',
+      );
+    }
+
+    final current = token(
+      view.getUint16(base, Endian.big),
+      view.getUint8(base + 2),
+    );
+    _validateDeserialisedToken(current, originalLength);
+    tokens.add(current);
+  }
+
+  return (
+    tokens: List<Token>.unmodifiable(tokens),
+    originalLength: originalLength,
+  );
+}
+
+/// Compresses [data] using LZ78 and serialises to the CMP01 wire format.
+Uint8List compress(Uint8List data, [int maxDictSize = 65536]) {
+  return serialiseTokens(encode(data, maxDictSize), data.length);
+}
+
+/// Decompresses bytes produced by [compress].
+Uint8List decompress(Uint8List data) {
+  final decoded = deserialiseTokens(data);
+  return decode(decoded.tokens, decoded.originalLength);
+}
+
+void _validateDecodedToken(Token current, int dictionaryLength) {
+  if (current.dictIndex < 0) {
+    throw FormatException(
+      'Malformed LZ78 token: dictIndex must be non-negative, got ${current.dictIndex}.',
+    );
+  }
+  if (current.dictIndex >= dictionaryLength) {
+    throw FormatException(
+      'Malformed LZ78 token: dictIndex ${current.dictIndex} exceeds dictionary size ${dictionaryLength - 1}.',
+    );
+  }
+  if (current.nextChar < 0 || current.nextChar > 255) {
+    throw FormatException(
+      'Malformed LZ78 token: nextChar must be in 0..255, got ${current.nextChar}.',
+    );
+  }
+}
+
+void _validateDeserialisedToken(Token current, int originalLength) {
+  if (current.dictIndex > 65535) {
+    throw const FormatException(
+      'Malformed LZ78 token stream: dictIndex exceeds uint16 range.',
+    );
+  }
+  if (originalLength == 0 && current.dictIndex != 0) {
+    throw const FormatException(
+      'Malformed LZ78 token stream: non-empty dictionary reference for empty output.',
+    );
+  }
+}

--- a/code/packages/dart/lz78/pubspec.yaml
+++ b/code/packages/dart/lz78/pubspec.yaml
@@ -1,0 +1,14 @@
+name: coding_adventures_lz78
+description: >
+  LZ78 explicit-dictionary compression with token-level and one-shot byte APIs.
+version: 0.1.0
+repository: https://github.com/adhithyan15/coding-adventures
+publish_to: none
+
+environment:
+  sdk: ^3.0.0
+
+dependencies: {}
+
+dev_dependencies:
+  test: ^1.25.0

--- a/code/packages/dart/lz78/test/lz78_test.dart
+++ b/code/packages/dart/lz78/test/lz78_test.dart
@@ -197,6 +197,27 @@ void main() {
         throwsA(isA<FormatException>()),
       );
     });
+
+    test('decode rejects declared lengths that are too large', () {
+      expect(
+        () => decode(<Token>[token(0, 65)], 2),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('decode rejects declared lengths that are too small', () {
+      expect(
+        () => decode(<Token>[token(0, 65)], 0),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('decode rejects overflow caused by reconstructed sequences', () {
+      expect(
+        () => decode(<Token>[token(0, 65), token(1, 0)], 1),
+        throwsA(isA<FormatException>()),
+      );
+    });
   });
 
   group('serialisation', () {
@@ -250,21 +271,7 @@ void main() {
     test('trailing bytes beyond the declared token stream are rejected', () {
       expect(
         () => deserialiseTokens(
-          Uint8List.fromList(<int>[
-            0,
-            0,
-            0,
-            1,
-            0,
-            0,
-            0,
-            1,
-            0,
-            0,
-            65,
-            0,
-            99,
-          ]),
+          Uint8List.fromList(<int>[0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 65, 0, 99]),
         ),
         throwsA(isA<FormatException>()),
       );

--- a/code/packages/dart/lz78/test/lz78_test.dart
+++ b/code/packages/dart/lz78/test/lz78_test.dart
@@ -239,6 +239,36 @@ void main() {
         throwsA(isA<FormatException>()),
       );
     });
+
+    test('incomplete headers are rejected', () {
+      expect(
+        () => deserialiseTokens(Uint8List.fromList(<int>[0, 0, 0, 2])),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('trailing bytes beyond the declared token stream are rejected', () {
+      expect(
+        () => deserialiseTokens(
+          Uint8List.fromList(<int>[
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            65,
+            0,
+            99,
+          ]),
+        ),
+        throwsA(isA<FormatException>()),
+      );
+    });
   });
 
   group('behaviour', () {

--- a/code/packages/dart/lz78/test/lz78_test.dart
+++ b/code/packages/dart/lz78/test/lz78_test.dart
@@ -1,0 +1,268 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:coding_adventures_lz78/lz78.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('spec vectors', () {
+    test('empty input', () {
+      expect(encode(Uint8List(0)), isEmpty);
+      expect(decode(const <Token>[], 0), isEmpty);
+    });
+
+    test('single byte', () {
+      final tokens = encode(_enc('A'));
+      expect(tokens, <Token>[token(0, 65)]);
+      expect(decode(tokens, 1), _enc('A'));
+    });
+
+    test('no repetition emits literal-only tokens', () {
+      final tokens = encode(_enc('ABCDE'));
+      expect(tokens, hasLength(5));
+      for (final current in tokens) {
+        expect(current.dictIndex, 0);
+      }
+    });
+
+    test('AABCBBABC matches the spec trace', () {
+      final want = <Token>[
+        token(0, 65),
+        token(1, 66),
+        token(0, 67),
+        token(0, 66),
+        token(4, 65),
+        token(4, 67),
+      ];
+      expect(encode(_enc('AABCBBABC')), want);
+      expect(_roundTripString('AABCBBABC'), 'AABCBBABC');
+    });
+
+    test('ABABAB ends with a flush token', () {
+      final want = <Token>[
+        token(0, 65),
+        token(0, 66),
+        token(1, 66),
+        token(3, 0),
+      ];
+      expect(encode(_enc('ABABAB')), want);
+      expect(_roundTripString('ABABAB'), 'ABABAB');
+    });
+
+    test('all identical bytes produce dictionary growth', () {
+      final tokens = encode(_enc('AAAAAAA'));
+      expect(tokens, hasLength(4));
+      expect(tokens[0], token(0, 65));
+      expect(tokens[1], token(1, 65));
+      expect(tokens[2], token(2, 65));
+      expect(tokens[3], token(1, 0));
+    });
+
+    test('repeated pairs compress', () {
+      expect(_roundTripString('ABABABAB'), 'ABABABAB');
+      expect(encode(_enc('ABABABAB')).length, lessThan(8));
+    });
+  });
+
+  group('round trip', () {
+    for (final sample in <String>[
+      '',
+      'A',
+      'ABCDE',
+      'AAAAAAA',
+      'ABABABAB',
+      'AABCBBABC',
+      'hello world',
+      'the quick brown fox',
+      'ababababab',
+      'aaaaaaaaaa',
+    ]) {
+      test('ascii round-trip: $sample', () {
+        expect(_roundTripString(sample), sample);
+      });
+    }
+
+    test('binary zeros', () {
+      final data = Uint8List(3);
+      expect(decompress(compress(data)), data);
+    });
+
+    test('binary 255s', () {
+      final data = Uint8List.fromList(<int>[255, 255, 255]);
+      expect(decompress(compress(data)), data);
+    });
+
+    test('full byte range', () {
+      final data = Uint8List.fromList(
+        List<int>.generate(256, (index) => index),
+      );
+      expect(decompress(compress(data)), data);
+    });
+
+    test('binary repeat', () {
+      final data = Uint8List.fromList(<int>[0, 1, 2, 0, 1, 2]);
+      expect(decompress(compress(data)), data);
+    });
+
+    test('binary null and max mix', () {
+      final data = Uint8List.fromList(<int>[0, 0, 0, 255, 255]);
+      expect(decompress(compress(data)), data);
+    });
+  });
+
+  group('parameters', () {
+    test('maxDictSize is respected', () {
+      final tokens = encode(_enc('ABCABCABCABCABC'), 10);
+      for (final current in tokens) {
+        expect(current.dictIndex, lessThan(10));
+      }
+    });
+
+    test('maxDictSize 1 keeps everything literal', () {
+      final tokens = encode(_enc('AAAA'), 1);
+      for (final current in tokens) {
+        expect(current.dictIndex, 0);
+      }
+    });
+  });
+
+  group('trie cursor', () {
+    test('step insert and reset mirror the encoder model', () {
+      final cursor = TrieCursor();
+      expect(cursor.atRoot, isTrue);
+      expect(cursor.dictId, 0);
+
+      expect(cursor.step(65), isFalse);
+      cursor.insert(65, 1);
+      expect(cursor.step(65), isTrue);
+      expect(cursor.dictId, 1);
+      expect(cursor.atRoot, isFalse);
+
+      cursor.reset();
+      expect(cursor.atRoot, isTrue);
+      expect(cursor.dictId, 0);
+    });
+  });
+
+  group('edge cases', () {
+    test('single byte stays literal', () {
+      expect(encode(_enc('X')), <Token>[token(0, 88)]);
+    });
+
+    test('two literals decode cleanly', () {
+      final tokens = <Token>[token(0, 65), token(0, 66)];
+      expect(decode(tokens), _enc('AB'));
+    });
+
+    test('flush token round-trip', () {
+      expect(_roundTripString('ABABAB'), 'ABABAB');
+    });
+
+    test('all null bytes round-trip', () {
+      final data = Uint8List(100);
+      expect(decompress(compress(data)), data);
+    });
+
+    test('all max bytes round-trip', () {
+      final data = Uint8List.fromList(List<int>.filled(100, 255));
+      expect(decompress(compress(data)), data);
+    });
+
+    test('very long inputs round-trip', () {
+      final repeated = _enc(List<String>.filled(100, 'Hello, World! ').join());
+      final suffix = Uint8List.fromList(
+        List<int>.generate(256, (index) => index),
+      );
+      final data = Uint8List.fromList(<int>[...repeated, ...suffix]);
+      expect(decompress(compress(data)), data);
+    });
+
+    test('decode rejects dictionary indexes beyond the built table', () {
+      expect(
+        () => decode(<Token>[token(1, 65)]),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('decode rejects negative dictionary indexes', () {
+      expect(
+        () => decode(<Token>[token(-1, 65)]),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('decode rejects nextChar outside byte range', () {
+      expect(
+        () => decode(<Token>[token(0, 256)]),
+        throwsA(isA<FormatException>()),
+      );
+    });
+  });
+
+  group('serialisation', () {
+    test('wire format is eight bytes plus four per token', () {
+      final compressed = compress(_enc('AB'));
+      final tokens = encode(_enc('AB'));
+      expect(compressed.length, 8 + tokens.length * 4);
+    });
+
+    test('deserialise round-trip', () {
+      final tokens = <Token>[token(0, 65), token(1, 66)];
+      final decoded = deserialiseTokens(serialiseTokens(tokens, 3));
+      expect(decoded.tokens, tokens);
+      expect(decoded.originalLength, 3);
+    });
+
+    test('all spec vectors survive compress and decompress', () {
+      for (final sample in <String>[
+        '',
+        'A',
+        'ABCDE',
+        'AAAAAAA',
+        'ABABABAB',
+        'AABCBBABC',
+      ]) {
+        expect(_roundTripString(sample), sample);
+      }
+    });
+
+    test('compression is deterministic', () {
+      final data = _enc('hello world test data repeated');
+      expect(compress(data), compress(data));
+    });
+
+    test('truncated token streams are rejected', () {
+      expect(
+        () => deserialiseTokens(
+          Uint8List.fromList(<int>[0, 0, 0, 2, 0, 0, 0, 1, 0, 1]),
+        ),
+        throwsA(isA<FormatException>()),
+      );
+    });
+  });
+
+  group('behaviour', () {
+    test('repetitive data compresses', () {
+      final data = _enc(List<String>.filled(1000, 'ABC').join());
+      expect(compress(data).length, lessThan(data.length));
+    });
+
+    test('incompressible data does not expand excessively', () {
+      final data = Uint8List.fromList(
+        List<int>.generate(256, (index) => index),
+      );
+      expect(compress(data).length, lessThanOrEqualTo(4 * data.length + 10));
+    });
+
+    test('single-byte repetitions compress and round-trip', () {
+      final data = Uint8List.fromList(List<int>.filled(10000, 65));
+      expect(compress(data).length, lessThan(data.length));
+      expect(decompress(compress(data)), data);
+    });
+  });
+}
+
+Uint8List _enc(String value) => Uint8List.fromList(utf8.encode(value));
+
+String _roundTripString(String value) =>
+    utf8.decode(decompress(compress(_enc(value))));

--- a/lessons.md
+++ b/lessons.md
@@ -34,8 +34,9 @@ accepts incomplete headers or trailing attacker-controlled bytes instead of
 failing closed.
 
 **Rule:** For Dart binary formats, validate the exact expected byte length from
-the header before decoding any entries. Reject both incomplete payloads and
-extra trailing bytes with `FormatException`.
+the header before decoding any entries, and validate that the reconstructed
+payload length exactly matches any declared output length. Reject incomplete
+payloads, extra trailing bytes, underflow, and overflow with `FormatException`.
 
 ---
 

--- a/lessons.md
+++ b/lessons.md
@@ -22,6 +22,23 @@ token fields before copying. Backreferences need `offset > 0` and
 
 ---
 
+### 2026-04-18: Dart binary deserializers should reject both short and padded payloads
+
+When a package defines a fixed-width wire format, accepting undersized payloads
+as "empty" messages or silently ignoring extra bytes creates a fail-open
+boundary. That can hide tampering and lets callers treat malformed compressed
+data as if it were valid.
+
+**Symptom:** Security review flags insecure deserialization because a parser
+accepts incomplete headers or trailing attacker-controlled bytes instead of
+failing closed.
+
+**Rule:** For Dart binary formats, validate the exact expected byte length from
+the header before decoding any entries. Reject both incomplete payloads and
+extra trailing bytes with `FormatException`.
+
+---
+
 ### 2026-04-18: Lua rockspecs must pin immutable source refs, not just HTTPS URLs
 
 Switching a Lua rockspec from `git://` to `https://` fixes transport security,


### PR DESCRIPTION
## Summary
- add a new Dart `coding_adventures_lz78` package implementing the CMP01 LZ78 compression spec
- include the trie cursor, token-level and one-shot APIs, and the standard repo metadata/docs files
- harden deserialization and decoding so malformed lengths, trailing bytes, and output-length mismatches fail closed, and record the lesson in `lessons.md`

## Verification
- `/tmp/dart-sdk-install/dart-sdk/bin/dart pub get`
- `/tmp/dart-sdk-install/dart-sdk/bin/dart format lib test`
- `/tmp/dart-sdk-install/dart-sdk/bin/dart test`
- `/tmp/dart-sdk-install/dart-sdk/bin/dart test --coverage=coverage`
- `/tmp/dart-sdk-install/dart-sdk/bin/dart run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --packages=.dart_tool/package_config.json --report-on=lib`
- library coverage: `96.46%`

## Security Review
- round 1 found fail-open wire parsing for incomplete or padded payloads
- round 2 found missing validation that decoded output exactly matches the declared original length
- both issues were fixed with regression tests, and the final review passed with no remaining findings