### PR TITLE
feat(logic-stdlib): add combinatorial list relations

### DIFF
--- a/code/packages/python/logic-stdlib/CHANGELOG.md
+++ b/code/packages/python/logic-stdlib/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.0] - 2026-04-18
+
+### Added
+
+- combinatorial relations `selecto` and `permuteo`
+- pytest coverage for element selection and permutation enumeration
+
 ## [0.1.0] - 2026-04-18
 
 ### Added

--- a/code/packages/python/logic-stdlib/README.md
+++ b/code/packages/python/logic-stdlib/README.md
@@ -15,16 +15,19 @@ The first slice includes:
 - `tailo(...)`
 - `membero(...)`
 - `appendo(...)`
+- `selecto(...)`
+- `permuteo(...)`
 
 ## Quick Start
 
 ```python
 from logic_engine import atom, logic_list, program, solve_all, solve_n, var
-from logic_stdlib import appendo, membero
+from logic_stdlib import appendo, membero, permuteo
 
 X = var("X")
 Prefix = var("Prefix")
 Suffix = var("Suffix")
+Order = var("Order")
 
 assert solve_all(program(), X, membero(X, logic_list(["tea", "cake"]))) == [
     atom("tea"),
@@ -42,6 +45,16 @@ assert answers == [
     (logic_list([]), logic_list(["tea", "cake"])),
     (logic_list(["tea"]), logic_list(["cake"])),
     (logic_list(["tea", "cake"]), logic_list([])),
+]
+
+assert solve_n(
+    program(),
+    2,
+    Order,
+    permuteo(logic_list(["tea", "cake", "jam"]), Order),
+) == [
+    logic_list(["tea", "cake", "jam"]),
+    logic_list(["tea", "jam", "cake"]),
 ]
 ```
 

--- a/code/packages/python/logic-stdlib/pyproject.toml
+++ b/code/packages/python/logic-stdlib/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-logic-stdlib"
-version = "0.1.0"
-description = "Relational standard library helpers built on top of logic-engine"
+version = "0.2.0"
+description = "Relational standard library helpers and combinators built on top of logic-engine"
 requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]
@@ -25,7 +25,7 @@ classifiers = [
 [project.urls]
 Homepage = "https://github.com/adhithyan15/coding-adventures"
 Repository = "https://github.com/adhithyan15/coding-adventures"
-Documentation = "https://github.com/adhithyan15/coding-adventures/tree/main/code/specs/LP03-relational-stdlib.md"
+Documentation = "https://github.com/adhithyan15/coding-adventures/tree/main/code/specs/LP04-relational-combinators.md"
 
 [project.optional-dependencies]
 dev = [

--- a/code/packages/python/logic-stdlib/src/logic_stdlib/__init__.py
+++ b/code/packages/python/logic-stdlib/src/logic_stdlib/__init__.py
@@ -12,6 +12,8 @@ from logic_stdlib.relations import (
     emptyo,
     heado,
     membero,
+    permuteo,
+    selecto,
     tailo,
 )
 
@@ -22,7 +24,9 @@ __all__ = [
     "emptyo",
     "heado",
     "membero",
+    "permuteo",
+    "selecto",
     "tailo",
 ]
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/code/packages/python/logic-stdlib/src/logic_stdlib/relations.py
+++ b/code/packages/python/logic-stdlib/src/logic_stdlib/relations.py
@@ -21,6 +21,8 @@ __all__ = [
     "emptyo",
     "heado",
     "membero",
+    "permuteo",
+    "selecto",
     "tailo",
 ]
 
@@ -82,6 +84,41 @@ def appendo(left: object, right: object, combined: object) -> GoalExpr:
                 conso(head, left_tail, left),
                 conso(head, out_tail, combined),
                 defer(appendo, left_tail, right, out_tail),
+            ),
+        ),
+    )
+
+
+def selecto(member: object, items: object, remainder: object) -> GoalExpr:
+    """Relate one chosen element to the list with that element removed."""
+
+    return fresh(
+        3,
+        lambda head, tail, rest_tail: disj(
+            conj(
+                conso(member, tail, items),
+                eq(tail, remainder),
+            ),
+            conj(
+                conso(head, tail, items),
+                conso(head, rest_tail, remainder),
+                defer(selecto, member, tail, rest_tail),
+            ),
+        ),
+    )
+
+
+def permuteo(items: object, permutation: object) -> GoalExpr:
+    """Relate a list to every ordering of its elements."""
+
+    return disj(
+        conj(emptyo(items), emptyo(permutation)),
+        fresh(
+            3,
+            lambda head, remaining, perm_tail: conj(
+                selecto(head, items, remaining),
+                conso(head, perm_tail, permutation),
+                defer(permuteo, remaining, perm_tail),
             ),
         ),
     )

--- a/code/packages/python/logic-stdlib/tests/test_logic_stdlib.py
+++ b/code/packages/python/logic-stdlib/tests/test_logic_stdlib.py
@@ -5,6 +5,8 @@ from logic_engine import (
 )
 from logic_engine import (
     atom,
+    conj,
+    eq,
     logic_list,
     program,
     solve_all,
@@ -19,6 +21,8 @@ from logic_stdlib import (
     emptyo,
     heado,
     membero,
+    permuteo,
+    selecto,
     tailo,
 )
 
@@ -27,7 +31,7 @@ class TestVersion:
     """Verify the package is importable and wired to the engine layer."""
 
     def test_version_exists(self) -> None:
-        assert __version__ == "0.1.0"
+        assert __version__ == "0.2.0"
         assert logic_engine_version == "0.3.0"
 
 
@@ -99,3 +103,57 @@ class TestListRelations:
             (logic_list(["tea"]), logic_list(["cake"])),
             (logic_list(["tea", "cake"]), logic_list([])),
         ]
+
+    def test_selecto_can_remove_a_known_element(self) -> None:
+        remainder = var("Remainder")
+
+        assert solve_all(
+            program(),
+            remainder,
+            selecto("cake", logic_list(["tea", "cake", "jam"]), remainder),
+        ) == [logic_list(["tea", "jam"])]
+
+    def test_selecto_enumerates_all_element_and_remainder_pairs(self) -> None:
+        item = var("Item")
+        remainder = var("Remainder")
+
+        assert solve_all(
+            program(),
+            (item, remainder),
+            selecto(item, logic_list(["tea", "cake", "jam"]), remainder),
+        ) == [
+            (atom("tea"), logic_list(["cake", "jam"])),
+            (atom("cake"), logic_list(["tea", "jam"])),
+            (atom("jam"), logic_list(["tea", "cake"])),
+        ]
+
+    def test_permuteo_enumerates_every_permutation_of_a_small_list(self) -> None:
+        order = var("Order")
+
+        assert solve_all(
+            program(),
+            order,
+            permuteo(logic_list(["tea", "cake", "jam"]), order),
+        ) == [
+            logic_list(["tea", "cake", "jam"]),
+            logic_list(["tea", "jam", "cake"]),
+            logic_list(["cake", "tea", "jam"]),
+            logic_list(["cake", "jam", "tea"]),
+            logic_list(["jam", "tea", "cake"]),
+            logic_list(["jam", "cake", "tea"]),
+        ]
+
+    def test_permuteo_can_validate_a_specific_ordering(self) -> None:
+        marker = var("Marker")
+
+        assert solve_all(
+            program(),
+            marker,
+            conj(
+                eq(marker, "ok"),
+                permuteo(
+                    logic_list(["tea", "jam"]),
+                    logic_list(["jam", "tea"]),
+                ),
+            ),
+        ) == [atom("ok")]

--- a/code/specs/LP03-relational-stdlib.md
+++ b/code/specs/LP03-relational-stdlib.md
@@ -288,8 +288,6 @@ Later milestones may add:
 - `listo`
 - `lengtho`
 - `reverseo`
-- `selecto`
-- `permuteo`
 - arithmetic relations
 - finite-domain helpers
 

--- a/code/specs/LP04-relational-combinators.md
+++ b/code/specs/LP04-relational-combinators.md
@@ -1,0 +1,235 @@
+# LP04 — Relational Combinators For Choice And Permutation
+
+## Overview
+
+`logic-stdlib` now gives us:
+
+- `emptyo`
+- `conso`
+- `heado`
+- `tailo`
+- `membero`
+- `appendo`
+
+That is enough for basic list decomposition and concatenation problems.
+
+It is still awkward to express a very common class of logic problems:
+
+- pick one value from a set of candidates
+- continue solving with the remaining candidates
+- enumerate permutations of a list
+- model seating orders, assignments, and ordering puzzles
+
+This milestone adds the next small but powerful vocabulary for those tasks.
+
+## Design Goal
+
+Add the smallest combinatorial relations that unlock a large family of logic
+problems without introducing a new evaluator or a constraint system.
+
+The first slice should include:
+
+- `selecto`
+- `permuteo`
+
+These should live in `logic-stdlib`, continue using `logic-engine` goal
+expressions, and rely on the existing `defer(...)` mechanism for recursive
+host-language expansion.
+
+## Layer Position
+
+```text
+SYM00 Symbol Core
+    ↓
+LP00 Logic Core
+    ↓
+LP01 Logic Engine
+    ↓
+LP02 Disequality Constraints
+    ↓
+LP03 Relational Standard Library
+    ↓
+LP04 Relational Combinators   ← this milestone
+    - choice from a list
+    - permutation search
+```
+
+## Why These Two Relations
+
+`selecto` is the relational form of:
+
+```text
+pick one item and return the remaining list
+```
+
+`permuteo` is the relational form of:
+
+```text
+reorder a list in every possible way
+```
+
+Together they make it much easier to express:
+
+- “assign each person a unique seat”
+- “try each ordering of these values”
+- “choose one unused option and recurse”
+- “search all possible arrangements, then filter with constraints”
+
+## API
+
+Extend `logic-stdlib` with:
+
+```python
+selecto(member: object, items: object, remainder: object) -> GoalExpr
+permuteo(items: object, permutation: object) -> GoalExpr
+```
+
+These should compose naturally with:
+
+- `membero(...)`
+- `appendo(...)`
+- `neq(...)`
+- `all_different(...)`
+- `conj(...)`
+- `disj(...)`
+
+## Semantics
+
+### `selecto`
+
+`selecto(X, Items, Rest)` means:
+
+> `X` is one element of `Items`, and `Rest` is `Items` with that one occurrence
+> removed.
+
+Examples:
+
+```python
+selecto(X, [tea, cake, jam], Rest)
+⇒ X = tea, Rest = [cake, jam]
+⇒ X = cake, Rest = [tea, jam]
+⇒ X = jam, Rest = [tea, cake]
+```
+
+Operationally, the first version should encode:
+
+```text
+selecto(X, [X | Tail], Tail).
+selecto(X, [Head | Tail], [Head | RestTail]) :-
+    selecto(X, Tail, RestTail).
+```
+
+This is the relational building block for “use one choice and keep the
+remaining choices for later.”
+
+### `permuteo`
+
+`permuteo(Items, Permutation)` means:
+
+> `Permutation` is one ordering of the elements of `Items`.
+
+Examples:
+
+```python
+permuteo([red, green, blue], X)
+⇒ X = [red, green, blue]
+⇒ X = [red, blue, green]
+⇒ X = [green, red, blue]
+⇒ ...
+```
+
+Operationally, the first version should encode:
+
+```text
+permuteo([], []).
+permuteo(Items, [Head | Tail]) :-
+    selecto(Head, Items, Remaining),
+    permuteo(Remaining, Tail).
+```
+
+## Why This Matters For Logic Problems
+
+Many hand-solved logic puzzles are fundamentally “generate permutations, then
+constrain them.”
+
+With `permuteo(...)` and existing disequality support, users can write much more
+natural host-language logic programs for:
+
+- seating arrangements
+- small scheduling problems
+- ordering puzzles
+- cryptarithmetic-style candidate assignment scaffolds
+
+This is still library-first. We are improving the reusable substrate that the
+future Prolog frontend will compile into.
+
+## Package Impact
+
+This milestone updates the existing Python package:
+
+```text
+code/packages/python/logic-stdlib
+```
+
+No new package is needed. These combinators are a natural extension of the
+existing relational standard library.
+
+## Usage Example
+
+```python
+from logic_engine import logic_list, program, solve_n, var
+from logic_stdlib import permuteo
+
+Order = var("Order")
+
+answers = solve_n(
+    program(),
+    3,
+    Order,
+    permuteo(logic_list(["tea", "cake", "jam"]), Order),
+)
+```
+
+The answers should be the first three permutations in search order.
+
+## Search Notes
+
+The current engine is still:
+
+- depth-first
+- left-biased
+- not tabled
+
+That means open-ended permutation queries can get expensive quickly. This is
+acceptable for the first slice as long as:
+
+- examples stay small
+- tests use concrete finite inputs
+- docs encourage bounded search with `solve_n(...)` where helpful
+
+## Test Strategy
+
+Required tests:
+
+- `selecto` can remove a known element from a concrete list
+- `selecto` can enumerate all element/remainder pairs of a concrete list
+- `permuteo` enumerates every permutation of a small list
+- `permuteo` works as a relational helper inside ordinary `solve_all(...)`
+
+## Future Extensions
+
+Later milestones may add:
+
+- `listo`
+- `lengtho`
+- `reverseo`
+- `subsequenceo`
+- finite-domain labeling helpers
+- puzzle-specific helper packages
+
+## Why This Milestone Matters
+
+LP03 made the library feel like a usable relational list toolkit.
+
+LP04 makes it feel much closer to a real logic-problem workbench by adding the
+combinatorial relations that many puzzle and search problems naturally need.


### PR DESCRIPTION
## Summary
- add the LP04 combinator spec and sync LP03 now that `selecto` and `permuteo` have graduated out of the future-ideas list
- extend Python `logic-stdlib` with `selecto(...)` and `permuteo(...)` for choice-from-list and permutation search
- add docs and tests that cover concrete selection, full permutation enumeration, and finite validation of a specific ordering

## Testing
- `/Users/adhithya/.local/bin/python3.12 -m venv .venv` plus editable installs for sibling packages in `code/packages/python/logic-stdlib`
- `.venv/bin/python -m pytest tests -v`
- `.venv/bin/python -m ruff check src tests`

## Notes
- security review passed with no findings
- the validation test for `permuteo` intentionally uses a finite concrete source list because the current engine is depth-first and left-biased, so open-ended inverse permutation search is not yet a good fit