### PR TITLE
Add structural list relations to logic-stdlib

### DIFF
--- a/code/packages/python/logic-stdlib/CHANGELOG.md
+++ b/code/packages/python/logic-stdlib/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.3.0] - 2026-04-18
+
+### Added
+
+- structural list relations `listo` and `reverseo`
+- pytest coverage for proper-list validation, improper dotted-pair rejection,
+  and list reversal
+
 ## [0.2.0] - 2026-04-18
 
 ### Added

--- a/code/packages/python/logic-stdlib/README.md
+++ b/code/packages/python/logic-stdlib/README.md
@@ -13,16 +13,18 @@ The first slice includes:
 - `conso(...)`
 - `heado(...)`
 - `tailo(...)`
+- `listo(...)`
 - `membero(...)`
 - `appendo(...)`
 - `selecto(...)`
 - `permuteo(...)`
+- `reverseo(...)`
 
 ## Quick Start
 
 ```python
-from logic_engine import atom, logic_list, program, solve_all, solve_n, var
-from logic_stdlib import appendo, membero, permuteo
+from logic_engine import atom, conj, eq, logic_list, program, solve_all, solve_n, var
+from logic_stdlib import appendo, listo, membero, permuteo, reverseo
 
 X = var("X")
 Prefix = var("Prefix")
@@ -56,6 +58,18 @@ assert solve_n(
     logic_list(["tea", "cake", "jam"]),
     logic_list(["tea", "jam", "cake"]),
 ]
+
+assert solve_all(
+    program(),
+    Order,
+    reverseo(logic_list(["tea", "cake", "jam"]), Order),
+) == [logic_list(["jam", "cake", "tea"])]
+
+assert solve_all(
+    program(),
+    Order,
+    conj(eq(Order, logic_list(["tea", "cake"])), listo(Order)),
+) == [logic_list(["tea", "cake"])]
 ```
 
 ## Dependencies

--- a/code/packages/python/logic-stdlib/pyproject.toml
+++ b/code/packages/python/logic-stdlib/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-logic-stdlib"
-version = "0.2.0"
-description = "Relational standard library helpers and combinators built on top of logic-engine"
+version = "0.3.0"
+description = "Relational standard library helpers, combinators, and structural list relations built on top of logic-engine"
 requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]
@@ -25,7 +25,7 @@ classifiers = [
 [project.urls]
 Homepage = "https://github.com/adhithyan15/coding-adventures"
 Repository = "https://github.com/adhithyan15/coding-adventures"
-Documentation = "https://github.com/adhithyan15/coding-adventures/tree/main/code/specs/LP04-relational-combinators.md"
+Documentation = "https://github.com/adhithyan15/coding-adventures/tree/main/code/specs/LP05-structural-list-relations.md"
 
 [project.optional-dependencies]
 dev = [

--- a/code/packages/python/logic-stdlib/src/logic_stdlib/__init__.py
+++ b/code/packages/python/logic-stdlib/src/logic_stdlib/__init__.py
@@ -11,8 +11,10 @@ from logic_stdlib.relations import (
     conso,
     emptyo,
     heado,
+    listo,
     membero,
     permuteo,
+    reverseo,
     selecto,
     tailo,
 )
@@ -23,10 +25,12 @@ __all__ = [
     "conso",
     "emptyo",
     "heado",
+    "listo",
     "membero",
     "permuteo",
+    "reverseo",
     "selecto",
     "tailo",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/code/packages/python/logic-stdlib/src/logic_stdlib/relations.py
+++ b/code/packages/python/logic-stdlib/src/logic_stdlib/relations.py
@@ -20,8 +20,10 @@ __all__ = [
     "conso",
     "emptyo",
     "heado",
+    "listo",
     "membero",
     "permuteo",
+    "reverseo",
     "selecto",
     "tailo",
 ]
@@ -49,6 +51,27 @@ def tailo(items: object, tail: object) -> GoalExpr:
     """Relate ``tail`` to everything after the first element of a list."""
 
     return fresh(1, lambda head: conso(head, tail, items))
+
+
+def listo(value: object) -> GoalExpr:
+    """Succeed exactly when ``value`` is a proper finite list.
+
+    A canonical list is either:
+
+    - the empty list ``[]``
+    - or a cons cell whose tail is itself a proper list
+    """
+
+    return disj(
+        emptyo(value),
+        fresh(
+            2,
+            lambda head, tail: conj(
+                conso(head, tail, value),
+                defer(listo, tail),
+            ),
+        ),
+    )
 
 
 def membero(member: object, items: object) -> GoalExpr:
@@ -119,6 +142,22 @@ def permuteo(items: object, permutation: object) -> GoalExpr:
                 selecto(head, items, remaining),
                 conso(head, perm_tail, permutation),
                 defer(permuteo, remaining, perm_tail),
+            ),
+        ),
+    )
+
+
+def reverseo(items: object, reversed_items: object) -> GoalExpr:
+    """Relate ``reversed_items`` to the reverse ordering of ``items``."""
+
+    return disj(
+        conj(emptyo(items), emptyo(reversed_items)),
+        fresh(
+            3,
+            lambda head, tail, reversed_tail: conj(
+                conso(head, tail, items),
+                defer(reverseo, tail, reversed_tail),
+                appendo(reversed_tail, logic_list([head]), reversed_items),
             ),
         ),
     )

--- a/code/packages/python/logic-stdlib/tests/test_logic_stdlib.py
+++ b/code/packages/python/logic-stdlib/tests/test_logic_stdlib.py
@@ -20,8 +20,10 @@ from logic_stdlib import (
     conso,
     emptyo,
     heado,
+    listo,
     membero,
     permuteo,
+    reverseo,
     selecto,
     tailo,
 )
@@ -31,7 +33,7 @@ class TestVersion:
     """Verify the package is importable and wired to the engine layer."""
 
     def test_version_exists(self) -> None:
-        assert __version__ == "0.2.0"
+        assert __version__ == "0.3.0"
         assert logic_engine_version == "0.3.0"
 
 
@@ -70,6 +72,33 @@ class TestListRelations:
             tail,
             tailo(logic_list(["tea", "cake", "jam"]), tail),
         ) == [logic_list(["cake", "jam"])]
+
+    def test_listo_recognizes_the_empty_list(self) -> None:
+        marker = var("Marker")
+
+        assert solve_all(
+            program(),
+            marker,
+            conj(eq(marker, "ok"), listo(logic_list([]))),
+        ) == [atom("ok")]
+
+    def test_listo_succeeds_for_a_concrete_proper_list(self) -> None:
+        marker = var("Marker")
+
+        assert solve_all(
+            program(),
+            marker,
+            conj(eq(marker, "ok"), listo(logic_list(["tea", "cake", "jam"]))),
+        ) == [atom("ok")]
+
+    def test_listo_rejects_an_improper_dotted_pair(self) -> None:
+        marker = var("Marker")
+
+        assert solve_all(
+            program(),
+            marker,
+            conj(eq(marker, "ok"), listo(logic_list(["tea"], tail="cake"))),
+        ) == []
 
     def test_membero_enumerates_members_of_a_concrete_list(self) -> None:
         item = var("Item")
@@ -154,6 +183,30 @@ class TestListRelations:
                 permuteo(
                     logic_list(["tea", "jam"]),
                     logic_list(["jam", "tea"]),
+                ),
+            ),
+        ) == [atom("ok")]
+
+    def test_reverseo_reverses_a_concrete_list(self) -> None:
+        reversed_items = var("ReversedItems")
+
+        assert solve_all(
+            program(),
+            reversed_items,
+            reverseo(logic_list(["tea", "cake", "jam"]), reversed_items),
+        ) == [logic_list(["jam", "cake", "tea"])]
+
+    def test_reverseo_can_validate_a_specific_reverse_ordering(self) -> None:
+        marker = var("Marker")
+
+        assert solve_all(
+            program(),
+            marker,
+            conj(
+                eq(marker, "ok"),
+                reverseo(
+                    logic_list(["tea", "cake", "jam"]),
+                    logic_list(["jam", "cake", "tea"]),
                 ),
             ),
         ) == [atom("ok")]

--- a/code/specs/LP04-relational-combinators.md
+++ b/code/specs/LP04-relational-combinators.md
@@ -220,9 +220,7 @@ Required tests:
 
 Later milestones may add:
 
-- `listo`
 - `lengtho`
-- `reverseo`
 - `subsequenceo`
 - finite-domain labeling helpers
 - puzzle-specific helper packages

--- a/code/specs/LP05-structural-list-relations.md
+++ b/code/specs/LP05-structural-list-relations.md
@@ -1,0 +1,246 @@
+# LP05 — Structural List Relations
+
+## Overview
+
+`logic-stdlib` already gives us:
+
+- `emptyo`
+- `conso`
+- `heado`
+- `tailo`
+- `membero`
+- `appendo`
+- `selecto`
+- `permuteo`
+
+That covers:
+
+- list construction and deconstruction
+- membership search
+- concatenation
+- choice from a list
+- permutation search
+
+There is still an awkward gap in the host-language library:
+
+- there is no direct way to say that a value is a proper list
+- there is no standard relation for list reversal
+
+Those ideas are small, but they show up constantly in logic programming
+examples and puzzle-style code. This milestone fills that gap.
+
+## Design Goal
+
+Add the next pair of foundational structural relations for lists:
+
+- `listo`
+- `reverseo`
+
+These should remain ordinary `logic-engine` goal expressions and should keep
+using `defer(...)` for recursive host-language expansion.
+
+## Layer Position
+
+```text
+SYM00 Symbol Core
+    ↓
+LP00 Logic Core
+    ↓
+LP01 Logic Engine
+    ↓
+LP02 Disequality Constraints
+    ↓
+LP03 Relational Standard Library
+    ↓
+LP04 Relational Combinators
+    ↓
+LP05 Structural List Relations   ← this milestone
+    - proper-list recognition
+    - list reversal
+```
+
+## Why These Two Relations
+
+`listo` is the relational form of:
+
+```text
+this value is a proper list
+```
+
+`reverseo` is the relational form of:
+
+```text
+these two lists are reverses of one another
+```
+
+Together they make it easier to:
+
+- validate recursive list-shaped data
+- write structure-preserving list programs
+- express reverse-order constraints relationally
+- teach the difference between proper lists and arbitrary dotted pairs
+
+## API
+
+Extend `logic-stdlib` with:
+
+```python
+listo(value: object) -> GoalExpr
+reverseo(items: object, reversed_items: object) -> GoalExpr
+```
+
+These should compose naturally with:
+
+- `conso(...)`
+- `appendo(...)`
+- `membero(...)`
+- `selecto(...)`
+- `permuteo(...)`
+- `neq(...)`
+- `conj(...)`
+- `disj(...)`
+
+## Semantics
+
+### `listo`
+
+`listo(Value)` means:
+
+> `Value` is the canonical empty list, or a cons cell whose tail is itself a
+> proper list.
+
+Examples:
+
+```python
+listo([])
+⇒ success
+
+listo([tea, cake])
+⇒ success
+
+listo([tea | cake])
+⇒ failure
+```
+
+Operationally, the first version should encode:
+
+```text
+listo([]).
+listo([_Head | Tail]) :-
+    listo(Tail).
+```
+
+This relation matters because the host-language library currently represents
+lists using ordinary terms. That is powerful, but it also means users can build
+improper dotted pairs. `listo(...)` is the reusable relation that marks the
+difference.
+
+### `reverseo`
+
+`reverseo(Items, ReversedItems)` means:
+
+> `ReversedItems` contains exactly the elements of `Items` in the opposite
+> order.
+
+Examples:
+
+```python
+reverseo([tea, cake, jam], X)
+⇒ X = [jam, cake, tea]
+
+reverseo(X, [jam, cake, tea])
+⇒ X = [tea, cake, jam]
+```
+
+Operationally, the first version should encode:
+
+```text
+reverseo([], []).
+reverseo([Head | Tail], Reversed) :-
+    reverseo(Tail, ReversedTail),
+    appendo(ReversedTail, [Head], Reversed).
+```
+
+The first implementation may use `appendo(...)` plus a one-element list
+constructed through `logic_list([Head])`.
+
+## Why This Matters For The Library-First Vision
+
+The host-language library should be useful before the Prolog frontend exists.
+
+This milestone improves that story in two ways:
+
+- `listo(...)` gives users a standard structural invariant they can assert in
+  ordinary Python logic programs
+- `reverseo(...)` adds a classic recursive relation that many textbooks and
+  tutorials use to explain relational evaluation
+
+That makes the library more educational and more practical at the same time.
+
+## Package Impact
+
+This milestone updates the existing Python package:
+
+```text
+code/packages/python/logic-stdlib
+```
+
+No new package is needed. These relations are a natural extension of the
+current relational standard library.
+
+## Usage Example
+
+```python
+from logic_engine import logic_list, program, solve_all, var
+from logic_stdlib import listo, reverseo
+
+Items = var("Items")
+
+assert solve_all(
+    program(),
+    Items,
+    reverseo(logic_list(["tea", "cake", "jam"]), Items),
+) == [logic_list(["jam", "cake", "tea"])]
+```
+
+## Search Notes
+
+The current engine is still:
+
+- depth-first
+- left-biased
+- not tabled
+
+So some open-ended structural queries can diverge or grow quickly. The first
+slice should keep examples and tests bounded by:
+
+- using concrete finite lists in tests
+- preferring validation and one-directional construction examples
+- avoiding large open-ended reverse enumeration
+
+## Test Strategy
+
+Required tests:
+
+- `listo` succeeds for the empty list
+- `listo` succeeds for a concrete proper list
+- `listo` fails for a concrete improper dotted pair
+- `reverseo` reverses a concrete list
+- `reverseo` can validate a known reverse ordering inside a larger goal
+
+## Future Extensions
+
+Later milestones may add:
+
+- `lengtho`
+- `subsequenceo`
+- `lasto`
+- finite-domain arithmetic relations
+- puzzle-specific helper packages
+
+## Why This Milestone Matters
+
+LP04 made the library good at combinatorial list search.
+
+LP05 makes it better at structural list reasoning, which is a big part of how
+logic programming is taught and how many elegant list relations are built.


### PR DESCRIPTION
## Summary
- add the LP05 structural list relations spec and retire `listo`/`reverseo` from LP04 future work
- extend Python `logic-stdlib` with `listo(...)` and `reverseo(...)`
- cover proper-list validation, dotted-pair rejection, and reversal behavior in tests and docs

## Testing
- `/Users/adhithya/Downloads/coding-adventures-worktrees/prolog-structural/code/packages/python/logic-stdlib/.venv/bin/python -m pytest tests -v`
- `/Users/adhithya/Downloads/coding-adventures-worktrees/prolog-structural/code/packages/python/logic-stdlib/.venv/bin/python -m ruff check src tests`