### PR TITLE
feat(dart-lzw): add Dart CMP03 package

### DIFF
--- a/code/packages/dart/lzw/.gitignore
+++ b/code/packages/dart/lzw/.gitignore
@@ -1,0 +1,2 @@
+.dart_tool/
+pubspec.lock

--- a/code/packages/dart/lzw/BUILD
+++ b/code/packages/dart/lzw/BUILD
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/lzw/CHANGELOG.md
+++ b/code/packages/dart/lzw/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0
+
+- Added the initial Dart implementation of the CMP03 LZW compression package.
+- Added logical-code `encodeCodes` and `decodeCodes` APIs with tricky-token support.
+- Added packed-wire `packCodes` and `unpackCodes` helpers for LSB-first CMP03 bit streams.
+- Added one-shot `compress` and `decompress` helpers plus strict malformed-input validation.
+- Added a configurable decompressed-size cap so hostile headers cannot force unbounded output allocation.

--- a/code/packages/dart/lzw/README.md
+++ b/code/packages/dart/lzw/README.md
@@ -1,0 +1,41 @@
+# coding_adventures_lzw
+
+LZW lossless compression for Dart. This package implements the CMP03
+specification from the coding-adventures compression series and exposes both
+the logical code stream and the packed byte-oriented wire format.
+
+## What It Provides
+
+- `encodeCodes` and `decodeCodes` for working with logical LZW code streams
+- `packCodes` and `unpackCodes` for the CMP03 bit-packed wire format
+- `compress` and `decompress` for one-shot binary compression
+- `BitWriter` and `BitReader` helpers for LSB-first variable-width codes
+- Strict malformed-input validation, including header checks and padding checks
+- A configurable decompressed-size cap for hostile or untrusted inputs
+
+## Usage
+
+```dart
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:coding_adventures_lzw/lzw.dart';
+
+void main() {
+  final data = Uint8List.fromList(utf8.encode('ABABABABAB'));
+
+  final codes = encodeCodes(data);
+  final packed = packCodes(codes, data.length);
+  final original = decompress(packed);
+
+  print(codes);
+  print(utf8.decode(original));
+}
+```
+
+## Building and Testing
+
+```bash
+dart pub get
+dart test
+```

--- a/code/packages/dart/lzw/lib/lzw.dart
+++ b/code/packages/dart/lzw/lib/lzw.dart
@@ -1,0 +1,3 @@
+library;
+
+export 'src/lzw.dart';

--- a/code/packages/dart/lzw/lib/src/lzw.dart
+++ b/code/packages/dart/lzw/lib/src/lzw.dart
@@ -1,0 +1,464 @@
+import 'dart:typed_data';
+
+/// Instructs the decoder to reset the dictionary to its initial 256-entry state.
+const int clearCode = 256;
+
+/// Marks the end of a logical LZW code stream.
+const int stopCode = 257;
+
+/// First dynamically assigned dictionary code after the two reserved control codes.
+const int initialNextCode = 258;
+
+/// Starting bit width for code packing and unpacking.
+const int initialCodeSize = 9;
+
+/// Maximum bit width for packed codes.
+const int maxCodeSize = 16;
+
+/// Default upper bound for output declared by untrusted compressed payloads.
+const int defaultMaxDecompressedSize = 64 * 1024 * 1024;
+
+/// Writes variable-width codes into a byte stream, LSB-first.
+///
+/// LZW's packed wire format fills the least-significant bits of each byte
+/// first. That matches GIF and the Unix `compress` family.
+class BitWriter {
+  final List<int> _bytes = <int>[];
+  int _buffer = 0;
+  int _bitCount = 0;
+
+  /// Appends [code] using exactly [codeSize] bits.
+  void write(int code, int codeSize) {
+    if (codeSize <= 0 || codeSize > maxCodeSize) {
+      throw RangeError.value(
+        codeSize,
+        'codeSize',
+        'Must be in 1..$maxCodeSize.',
+      );
+    }
+    if (code < 0 || code >= (1 << codeSize)) {
+      throw RangeError.value(code, 'code', 'Must fit within $codeSize bits.');
+    }
+
+    _buffer |= code << _bitCount;
+    _bitCount += codeSize;
+
+    while (_bitCount >= 8) {
+      _bytes.add(_buffer & 0xff);
+      _buffer >>= 8;
+      _bitCount -= 8;
+    }
+  }
+
+  /// Flushes the final partial byte, padding with zeros to the byte boundary.
+  void flush() {
+    if (_bitCount > 0) {
+      _bytes.add(_buffer & 0xff);
+      _buffer = 0;
+      _bitCount = 0;
+    }
+  }
+
+  /// Returns the emitted bytes so far.
+  Uint8List bytes() => Uint8List.fromList(_bytes);
+}
+
+/// Reads variable-width codes from a byte stream, LSB-first.
+class BitReader {
+  /// Creates a reader over the provided packed byte payload.
+  BitReader(this._data);
+
+  final Uint8List _data;
+  int _position = 0;
+  int _buffer = 0;
+  int _bitCount = 0;
+
+  /// Reads the next [codeSize]-bit code.
+  int read(int codeSize) {
+    if (codeSize <= 0 || codeSize > maxCodeSize) {
+      throw RangeError.value(
+        codeSize,
+        'codeSize',
+        'Must be in 1..$maxCodeSize.',
+      );
+    }
+
+    while (_bitCount < codeSize) {
+      if (_position >= _data.length) {
+        throw const FormatException(
+          'Malformed LZW bit stream: unexpected end of input.',
+        );
+      }
+
+      _buffer |= _data[_position] << _bitCount;
+      _position += 1;
+      _bitCount += 8;
+    }
+
+    final mask = (1 << codeSize) - 1;
+    final code = _buffer & mask;
+    _buffer >>= codeSize;
+    _bitCount -= codeSize;
+    return code;
+  }
+
+  /// Whether extra unread bytes remain after the current buffered bits.
+  bool get hasUnreadBytes => _position < _data.length;
+
+  /// Whether the unread buffered bits contain any non-zero padding.
+  bool get hasNonZeroPaddingBits => _buffer != 0;
+}
+
+/// Encodes [data] into a logical LZW code stream including CLEAR and STOP.
+List<int> encodeCodes(Uint8List data) {
+  final dictionary = <String, int>{};
+  for (var byte = 0; byte < 256; byte += 1) {
+    dictionary[String.fromCharCode(byte)] = byte;
+  }
+
+  final codes = <int>[clearCode];
+  final maxEntries = 1 << maxCodeSize;
+  var nextCode = initialNextCode;
+  var current = '';
+
+  for (final byte in data) {
+    final character = String.fromCharCode(byte);
+    final extended = '$current$character';
+
+    if (dictionary.containsKey(extended)) {
+      current = extended;
+      continue;
+    }
+
+    codes.add(dictionary[current]!);
+
+    if (nextCode < maxEntries) {
+      dictionary[extended] = nextCode;
+      nextCode += 1;
+    } else {
+      codes.add(clearCode);
+      dictionary
+        ..clear()
+        ..addEntries(
+          Iterable<MapEntry<String, int>>.generate(
+            256,
+            (index) => MapEntry<String, int>(String.fromCharCode(index), index),
+          ),
+        );
+      nextCode = initialNextCode;
+    }
+
+    current = character;
+  }
+
+  if (current.isNotEmpty) {
+    codes.add(dictionary[current]!);
+  }
+
+  codes.add(stopCode);
+  return List<int>.unmodifiable(codes);
+}
+
+/// Decodes a logical LZW code stream back into the original bytes.
+///
+/// If [originalLength] is supplied, the decoded output must match it exactly.
+Uint8List decodeCodes(List<int> codes, [int originalLength = -1]) {
+  if (originalLength < -1) {
+    throw RangeError.value(
+      originalLength,
+      'originalLength',
+      'Must be -1 or a non-negative byte length.',
+    );
+  }
+  if (codes.isEmpty) {
+    throw const FormatException(
+      'Malformed LZW code stream: at least CLEAR_CODE and STOP_CODE are required.',
+    );
+  }
+  if (codes.first != clearCode) {
+    throw FormatException(
+      'Malformed LZW code stream: expected CLEAR_CODE ($clearCode) at start, got ${codes.first}.',
+    );
+  }
+
+  final dictionary = _initialDecodeDictionary();
+  var nextCode = initialNextCode;
+  int? previousCode;
+  var sawStop = false;
+  final output = <int>[];
+
+  for (var index = 1; index < codes.length; index += 1) {
+    final code = codes[index];
+    _validateCodeValue(code);
+
+    if (code == clearCode) {
+      _resetDecodeDictionary(dictionary);
+      nextCode = initialNextCode;
+      previousCode = null;
+      continue;
+    }
+
+    if (code == stopCode) {
+      if (index != codes.length - 1) {
+        throw const FormatException(
+          'Malformed LZW code stream: codes appear after STOP_CODE.',
+        );
+      }
+      sawStop = true;
+      break;
+    }
+
+    final Uint8List entry;
+    if (code < dictionary.length) {
+      entry = dictionary[code];
+    } else if (code == nextCode) {
+      if (previousCode == null) {
+        throw const FormatException(
+          'Malformed LZW code stream: tricky token appeared without a previous code.',
+        );
+      }
+
+      final previousEntry = dictionary[previousCode];
+      entry = Uint8List(previousEntry.length + 1)
+        ..setAll(0, previousEntry)
+        ..[previousEntry.length] = previousEntry[0];
+    } else {
+      throw FormatException(
+        'Malformed LZW code stream: invalid code $code for dictionary size ${dictionary.length}.',
+      );
+    }
+
+    if (originalLength >= 0 && output.length + entry.length > originalLength) {
+      throw FormatException(
+        'Malformed LZW code stream: decoded output exceeds declared length $originalLength.',
+      );
+    }
+    output.addAll(entry);
+
+    if (previousCode != null && nextCode < (1 << maxCodeSize)) {
+      final previousEntry = dictionary[previousCode];
+      final newEntry = Uint8List(previousEntry.length + 1)
+        ..setAll(0, previousEntry)
+        ..[previousEntry.length] = entry[0];
+      dictionary.add(newEntry);
+      nextCode += 1;
+    }
+
+    previousCode = code;
+  }
+
+  if (!sawStop) {
+    throw const FormatException(
+      'Malformed LZW code stream: missing STOP_CODE terminator.',
+    );
+  }
+  if (originalLength >= 0 && output.length != originalLength) {
+    throw FormatException(
+      'Malformed LZW code stream: decoded output length ${output.length} does not match declared length $originalLength.',
+    );
+  }
+
+  return Uint8List.fromList(output);
+}
+
+/// Packs logical LZW [codes] into the CMP03 wire format.
+Uint8List packCodes(List<int> codes, int originalLength) {
+  _validateOriginalLength(originalLength);
+  if (codes.isEmpty) {
+    throw const FormatException(
+      'Malformed LZW code stream: at least CLEAR_CODE and STOP_CODE are required.',
+    );
+  }
+  if (codes.first != clearCode) {
+    throw FormatException(
+      'Malformed LZW code stream: expected CLEAR_CODE ($clearCode) at start, got ${codes.first}.',
+    );
+  }
+  if (codes.last != stopCode) {
+    throw FormatException(
+      'Malformed LZW code stream: expected STOP_CODE ($stopCode) at end, got ${codes.last}.',
+    );
+  }
+
+  final writer = BitWriter();
+  var codeSize = initialCodeSize;
+  var nextCode = initialNextCode;
+
+  for (var index = 0; index < codes.length; index += 1) {
+    final code = codes[index];
+    _validateCodeValue(code);
+    if (code >= (1 << codeSize)) {
+      throw FormatException(
+        'Malformed LZW code stream: code $code at index $index does not fit in $codeSize bits.',
+      );
+    }
+
+    writer.write(code, codeSize);
+
+    if (code == clearCode) {
+      codeSize = initialCodeSize;
+      nextCode = initialNextCode;
+    } else if (code != stopCode && nextCode < (1 << maxCodeSize)) {
+      nextCode += 1;
+      if (nextCode > (1 << codeSize) && codeSize < maxCodeSize) {
+        codeSize += 1;
+      }
+    }
+  }
+
+  writer.flush();
+  final body = writer.bytes();
+  final result = Uint8List(4 + body.length);
+  final view = ByteData.sublistView(result);
+  view.setUint32(0, originalLength, Endian.big);
+  result.setRange(4, result.length, body);
+  return result;
+}
+
+/// Unpacks CMP03 wire-format bytes into a logical LZW code stream.
+({List<int> codes, int originalLength}) unpackCodes(
+  Uint8List data, [
+  int maxOriginalLength = defaultMaxDecompressedSize,
+]) {
+  _validateMaxDecompressedSize(maxOriginalLength);
+  if (data.length < 4) {
+    throw const FormatException(
+      'Malformed LZW bit stream: header is incomplete.',
+    );
+  }
+
+  final view = ByteData.view(
+    data.buffer,
+    data.offsetInBytes,
+    data.lengthInBytes,
+  );
+  final originalLength = view.getUint32(0, Endian.big);
+  if (originalLength > maxOriginalLength) {
+    throw FormatException(
+      'Malformed LZW bit stream: declared output length $originalLength exceeds limit $maxOriginalLength.',
+    );
+  }
+
+  final reader = BitReader(Uint8List.sublistView(data, 4));
+  final codes = <int>[];
+  var codeSize = initialCodeSize;
+  var nextCode = initialNextCode;
+
+  final firstCode = _readPackedCode(
+    reader,
+    codeSize,
+    'Malformed LZW bit stream: missing CLEAR_CODE at start.',
+  );
+  if (firstCode != clearCode) {
+    throw FormatException(
+      'Malformed LZW bit stream: expected CLEAR_CODE ($clearCode) at start, got $firstCode.',
+    );
+  }
+  codes.add(firstCode);
+
+  while (true) {
+    final code = _readPackedCode(
+      reader,
+      codeSize,
+      'Malformed LZW bit stream: unexpected end before STOP_CODE.',
+    );
+    _validateCodeValue(code);
+    codes.add(code);
+
+    if (code == stopCode) {
+      break;
+    }
+
+    if (code == clearCode) {
+      codeSize = initialCodeSize;
+      nextCode = initialNextCode;
+      continue;
+    }
+
+    if (nextCode < (1 << maxCodeSize)) {
+      nextCode += 1;
+      if (nextCode > (1 << codeSize) && codeSize < maxCodeSize) {
+        codeSize += 1;
+      }
+    }
+  }
+
+  if (reader.hasUnreadBytes) {
+    throw const FormatException(
+      'Malformed LZW bit stream: trailing bytes remain after STOP_CODE.',
+    );
+  }
+  if (reader.hasNonZeroPaddingBits) {
+    throw const FormatException(
+      'Malformed LZW bit stream: non-zero padding bits remain after STOP_CODE.',
+    );
+  }
+
+  return (codes: List<int>.unmodifiable(codes), originalLength: originalLength);
+}
+
+/// Compresses [data] to the packed CMP03 wire format.
+Uint8List compress(Uint8List data) => packCodes(encodeCodes(data), data.length);
+
+/// Decompresses packed CMP03 bytes back into the original data.
+Uint8List decompress(
+  Uint8List data, [
+  int maxDecompressedSize = defaultMaxDecompressedSize,
+]) {
+  final unpacked = unpackCodes(data, maxDecompressedSize);
+  return decodeCodes(unpacked.codes, unpacked.originalLength);
+}
+
+int _readPackedCode(BitReader reader, int codeSize, String message) {
+  try {
+    return reader.read(codeSize);
+  } on FormatException {
+    throw FormatException(message);
+  }
+}
+
+List<Uint8List> _initialDecodeDictionary() {
+  final dictionary = List<Uint8List>.generate(
+    256,
+    (index) => Uint8List.fromList(<int>[index]),
+    growable: true,
+  );
+  dictionary
+    ..add(Uint8List(0))
+    ..add(Uint8List(0));
+  return dictionary;
+}
+
+void _resetDecodeDictionary(List<Uint8List> dictionary) {
+  dictionary
+    ..clear()
+    ..addAll(_initialDecodeDictionary());
+}
+
+void _validateCodeValue(int code) {
+  if (code < 0 || code >= (1 << maxCodeSize)) {
+    throw FormatException(
+      'Malformed LZW code stream: code must be in 0..65535, got $code.',
+    );
+  }
+}
+
+void _validateOriginalLength(int originalLength) {
+  if (originalLength < 0) {
+    throw RangeError.value(
+      originalLength,
+      'originalLength',
+      'Must be a non-negative byte length.',
+    );
+  }
+}
+
+void _validateMaxDecompressedSize(int maxDecompressedSize) {
+  if (maxDecompressedSize <= 0) {
+    throw RangeError.value(
+      maxDecompressedSize,
+      'maxDecompressedSize',
+      'Must be a positive byte limit.',
+    );
+  }
+}

--- a/code/packages/dart/lzw/pubspec.yaml
+++ b/code/packages/dart/lzw/pubspec.yaml
@@ -1,0 +1,14 @@
+name: coding_adventures_lzw
+description: >
+  LZW lossless compression with logical code-stream and packed byte APIs.
+version: 0.1.0
+repository: https://github.com/adhithyan15/coding-adventures
+publish_to: none
+
+environment:
+  sdk: ^3.0.0
+
+dependencies: {}
+
+dev_dependencies:
+  test: ^1.25.0

--- a/code/packages/dart/lzw/test/lzw_test.dart
+++ b/code/packages/dart/lzw/test/lzw_test.dart
@@ -1,0 +1,377 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:coding_adventures_lzw/lzw.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('constants', () {
+    test('match the CMP03 specification', () {
+      expect(clearCode, 256);
+      expect(stopCode, 257);
+      expect(initialNextCode, 258);
+      expect(initialCodeSize, 9);
+      expect(maxCodeSize, 16);
+    });
+  });
+
+  group('BitWriter and BitReader', () {
+    test('empty writer flushes to an empty byte list', () {
+      final writer = BitWriter();
+      writer.flush();
+      expect(writer.bytes(), isEmpty);
+    });
+
+    test('round-trips a single 9-bit code', () {
+      final writer = BitWriter()
+        ..write(clearCode, 9)
+        ..flush();
+      final reader = BitReader(writer.bytes());
+      expect(reader.read(9), clearCode);
+    });
+
+    test('round-trips multiple 9-bit codes', () {
+      const codes = <int>[clearCode, 65, 66, 258, stopCode];
+      final writer = BitWriter();
+      for (final code in codes) {
+        writer.write(code, 9);
+      }
+      writer.flush();
+
+      final reader = BitReader(writer.bytes());
+      for (final code in codes) {
+        expect(reader.read(9), code);
+      }
+    });
+
+    test('reader rejects exhausted streams', () {
+      final reader = BitReader(Uint8List(0));
+      expect(() => reader.read(9), throwsA(isA<FormatException>()));
+    });
+
+    test('writer rejects codes that do not fit in the requested width', () {
+      final writer = BitWriter();
+      expect(() => writer.write(512, 9), throwsRangeError);
+    });
+
+    test('writer rejects non-positive code widths', () {
+      final writer = BitWriter();
+      expect(() => writer.write(1, 0), throwsRangeError);
+    });
+
+    test('reader rejects non-positive code widths', () {
+      final reader = BitReader(Uint8List.fromList(<int>[0]));
+      expect(() => reader.read(0), throwsRangeError);
+    });
+  });
+
+  group('encodeCodes', () {
+    test('empty input becomes CLEAR then STOP', () {
+      expect(encodeCodes(Uint8List(0)), <int>[clearCode, stopCode]);
+    });
+
+    test('single byte becomes CLEAR 65 STOP', () {
+      expect(encodeCodes(_enc('A')), <int>[clearCode, 65, stopCode]);
+    });
+
+    test('two distinct bytes become CLEAR 65 66 STOP', () {
+      expect(encodeCodes(_enc('AB')), <int>[clearCode, 65, 66, stopCode]);
+    });
+
+    test('ABABAB matches the spec trace', () {
+      expect(encodeCodes(_enc('ABABAB')), <int>[
+        clearCode,
+        65,
+        66,
+        258,
+        258,
+        stopCode,
+      ]);
+    });
+
+    test('AAAAAAA matches the tricky-token trace', () {
+      expect(encodeCodes(_enc('AAAAAAA')), <int>[
+        clearCode,
+        65,
+        258,
+        259,
+        65,
+        stopCode,
+      ]);
+    });
+  });
+
+  group('decodeCodes', () {
+    test('CLEAR STOP decodes to empty output', () {
+      expect(decodeCodes(const <int>[clearCode, stopCode]), isEmpty);
+    });
+
+    test('CLEAR 65 STOP decodes to A', () {
+      expect(decodeCodes(const <int>[clearCode, 65, stopCode]), _enc('A'));
+    });
+
+    test('CLEAR 65 66 258 258 STOP decodes to ABABAB', () {
+      expect(
+        decodeCodes(const <int>[clearCode, 65, 66, 258, 258, stopCode]),
+        _enc('ABABAB'),
+      );
+    });
+
+    test('tricky-token stream decodes to AAAAAAA', () {
+      expect(
+        decodeCodes(const <int>[clearCode, 65, 258, 259, 65, stopCode]),
+        _enc('AAAAAAA'),
+      );
+    });
+
+    test('CLEAR mid-stream resets the dictionary', () {
+      expect(
+        decodeCodes(const <int>[clearCode, 65, clearCode, 66, stopCode]),
+        _enc('AB'),
+      );
+    });
+
+    test('requires CLEAR_CODE at the start', () {
+      expect(
+        () => decodeCodes(const <int>[65, stopCode]),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('requires STOP_CODE at the end', () {
+      expect(
+        () => decodeCodes(const <int>[clearCode, 65]),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('rejects codes after STOP_CODE', () {
+      expect(
+        () => decodeCodes(const <int>[clearCode, 65, stopCode, 66]),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('rejects invalid codes beyond the next dictionary slot', () {
+      expect(
+        () => decodeCodes(const <int>[clearCode, 9999, stopCode]),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('rejects negative codes', () {
+      expect(
+        () => decodeCodes(const <int>[clearCode, -1, stopCode]),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('rejects tricky tokens without a previous code', () {
+      expect(
+        () => decodeCodes(const <int>[clearCode, 258, stopCode]),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('rejects negative declared lengths', () {
+      expect(
+        () => decodeCodes(const <int>[clearCode, stopCode], -2),
+        throwsRangeError,
+      );
+    });
+
+    test('rejects outputs that exceed the declared length', () {
+      expect(
+        () => decodeCodes(const <int>[clearCode, 65, stopCode], 0),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('rejects outputs that fall short of the declared length', () {
+      expect(
+        () => decodeCodes(const <int>[clearCode, 65, stopCode], 2),
+        throwsA(isA<FormatException>()),
+      );
+    });
+  });
+
+  group('packCodes and unpackCodes', () {
+    test('store original_length in the header', () {
+      final packed = packCodes(const <int>[clearCode, stopCode], 42);
+      final view = ByteData.sublistView(packed);
+      expect(view.getUint32(0, Endian.big), 42);
+    });
+
+    test('round-trip ABABAB codes through the wire format', () {
+      const codes = <int>[clearCode, 65, 66, 258, 258, stopCode];
+      final unpacked = unpackCodes(packCodes(codes, 6));
+      expect(unpacked.originalLength, 6);
+      expect(unpacked.codes, codes);
+    });
+
+    test('round-trip AAAAAAA codes through the wire format', () {
+      const codes = <int>[clearCode, 65, 258, 259, 65, stopCode];
+      final unpacked = unpackCodes(packCodes(codes, 7));
+      expect(unpacked.originalLength, 7);
+      expect(unpacked.codes, codes);
+    });
+
+    test('empty input packs to a 4-byte header plus 3-byte payload', () {
+      expect(compress(Uint8List(0)).length, 7);
+    });
+
+    test('rejects incomplete headers', () {
+      expect(
+        () => unpackCodes(Uint8List.fromList(<int>[0, 0, 0])),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('rejects empty payloads after the header', () {
+      expect(
+        () => unpackCodes(Uint8List.fromList(<int>[0, 0, 0, 0])),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('rejects missing CLEAR_CODE at the start', () {
+      final writer = BitWriter()
+        ..write(65, 9)
+        ..flush();
+      final bytes = Uint8List(4 + writer.bytes().length)
+        ..setAll(4, writer.bytes());
+      expect(() => unpackCodes(bytes), throwsA(isA<FormatException>()));
+    });
+
+    test('rejects streams that end before STOP_CODE', () {
+      final writer = BitWriter()
+        ..write(clearCode, 9)
+        ..write(65, 9)
+        ..flush();
+      final bytes = Uint8List(4 + writer.bytes().length)
+        ..setAll(4, writer.bytes());
+      expect(() => unpackCodes(bytes), throwsA(isA<FormatException>()));
+    });
+
+    test('rejects non-zero padding bits after STOP_CODE', () {
+      final packed = packCodes(const <int>[clearCode, stopCode], 0);
+      packed[packed.length - 1] |= 0x04;
+      expect(() => unpackCodes(packed), throwsA(isA<FormatException>()));
+    });
+
+    test('rejects trailing bytes after STOP_CODE', () {
+      final packed = packCodes(const <int>[clearCode, stopCode], 0);
+      final tampered = Uint8List.fromList(<int>[...packed, 0]);
+      expect(() => unpackCodes(tampered), throwsA(isA<FormatException>()));
+    });
+
+    test('rejects non-positive decompression limits', () {
+      expect(
+        () => unpackCodes(packCodes(const <int>[clearCode, stopCode], 0), 0),
+        throwsRangeError,
+      );
+      expect(
+        () => decompress(packCodes(const <int>[clearCode, stopCode], 0), 0),
+        throwsRangeError,
+      );
+    });
+
+    test('rejects declared output lengths above the configured cap', () {
+      final packed = packCodes(const <int>[clearCode, stopCode], 5);
+      expect(() => unpackCodes(packed, 4), throwsA(isA<FormatException>()));
+      expect(() => decompress(packed, 4), throwsA(isA<FormatException>()));
+    });
+
+    test('packCodes validates stream shape and code widths', () {
+      expect(
+        () => packCodes(const <int>[65, stopCode], 1),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => packCodes(const <int>[clearCode, 600, stopCode], 1),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => packCodes(const <int>[clearCode, 65], 1),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => packCodes(const <int>[clearCode, -1, stopCode], 1),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => packCodes(const <int>[clearCode, stopCode], -1),
+        throwsRangeError,
+      );
+    });
+  });
+
+  group('compress and decompress', () {
+    for (final sample in <String>[
+      '',
+      'A',
+      'AB',
+      'ABABAB',
+      'AAAAAAA',
+      'AABABC',
+      'hello world',
+      'the quick brown fox',
+      'ababababab',
+      'aaaaaaaaaa',
+    ]) {
+      test('ascii round-trip: $sample', () {
+        expect(_roundTripString(sample), sample);
+      });
+    }
+
+    test('full byte range round-trips', () {
+      final data = Uint8List.fromList(
+        List<int>.generate(256, (index) => index),
+      );
+      expect(decompress(compress(data)), data);
+    });
+
+    test('all zeros round-trip', () {
+      expect(decompress(compress(Uint8List(100))), Uint8List(100));
+    });
+
+    test('all 0xFF bytes round-trip', () {
+      final data = Uint8List.fromList(List<int>.filled(100, 0xff));
+      expect(decompress(compress(data)), data);
+    });
+
+    test('binary repeating data round-trips', () {
+      final data = Uint8List.fromList(
+        List<int>.generate(512, (index) => index % 256),
+      );
+      expect(decompress(compress(data)), data);
+    });
+
+    test('long repetitive text compresses', () {
+      final data = _enc('ABCABC' * 100);
+      expect(compress(data).length, lessThan(data.length));
+    });
+
+    test('all-same data compresses', () {
+      final data = Uint8List.fromList(List<int>.filled(10000, 0x42));
+      expect(compress(data).length, lessThan(data.length));
+    });
+
+    test('compress is deterministic', () {
+      final data = _enc('hello world test');
+      expect(compress(data), compress(data));
+    });
+
+    test('code-size growth past 9 bits still round-trips', () {
+      final data = Uint8List.fromList(
+        List<int>.generate(1024, (index) => index % 256),
+      );
+      expect(decompress(compress(data)), data);
+    });
+  });
+}
+
+Uint8List _enc(String value) => Uint8List.fromList(utf8.encode(value));
+
+String _roundTripString(String value) =>
+    utf8.decode(decompress(compress(_enc(value))));


### PR DESCRIPTION
## Summary
- add a new Dart `lzw` package implementing the CMP03 logical code stream and packed wire format
- include bit-level helpers, tricky-token decoding, and strict malformed-input validation
- cap declared decompressed size for untrusted payloads and cover the boundary cases in tests

## Verification
- `/tmp/dart-sdk-install/dart-sdk/bin/dart pub get`
- `/tmp/dart-sdk-install/dart-sdk/bin/dart format lib test`
- `/tmp/dart-sdk-install/dart-sdk/bin/dart test`
- `/tmp/dart-sdk-install/dart-sdk/bin/dart test --coverage=coverage`
- `coverage:format_coverage` over `lib` (`97.21%`)

## Notes
- package layout was generated with the Dart scaffold generator before implementation
- required security review passed in 1 round with no findings