### PR TITLE
Add sequence relations to logic-stdlib

### DIFF
--- a/code/packages/python/logic-stdlib/CHANGELOG.md
+++ b/code/packages/python/logic-stdlib/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.4.0] - 2026-04-18
+
+### Added
+
+- sequence relations `lasto` and `subsequenceo`
+- pytest coverage for final-element reasoning and ordered-subsequence search
+
 ## [0.3.0] - 2026-04-18
 
 ### Added

--- a/code/packages/python/logic-stdlib/README.md
+++ b/code/packages/python/logic-stdlib/README.md
@@ -13,18 +13,20 @@ The first slice includes:
 - `conso(...)`
 - `heado(...)`
 - `tailo(...)`
+- `lasto(...)`
 - `listo(...)`
 - `membero(...)`
 - `appendo(...)`
 - `selecto(...)`
 - `permuteo(...)`
+- `subsequenceo(...)`
 - `reverseo(...)`
 
 ## Quick Start
 
 ```python
 from logic_engine import atom, conj, eq, logic_list, program, solve_all, solve_n, var
-from logic_stdlib import appendo, listo, membero, permuteo, reverseo
+from logic_stdlib import appendo, lasto, listo, membero, permuteo, reverseo, subsequenceo
 
 X = var("X")
 Prefix = var("Prefix")
@@ -70,6 +72,23 @@ assert solve_all(
     Order,
     conj(eq(Order, logic_list(["tea", "cake"])), listo(Order)),
 ) == [logic_list(["tea", "cake"])]
+
+assert solve_all(
+    program(),
+    X,
+    lasto(logic_list(["tea", "cake", "jam"]), X),
+) == [atom("jam")]
+
+assert solve_all(
+    program(),
+    Order,
+    subsequenceo(logic_list(["tea", "cake"]), Order),
+) == [
+    logic_list(["tea", "cake"]),
+    logic_list(["tea"]),
+    logic_list(["cake"]),
+    logic_list([]),
+]
 ```
 
 ## Dependencies

--- a/code/packages/python/logic-stdlib/pyproject.toml
+++ b/code/packages/python/logic-stdlib/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-logic-stdlib"
-version = "0.3.0"
-description = "Relational standard library helpers, combinators, and structural list relations built on top of logic-engine"
+version = "0.4.0"
+description = "Relational standard library helpers, combinators, and sequence relations built on top of logic-engine"
 requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]
@@ -25,7 +25,7 @@ classifiers = [
 [project.urls]
 Homepage = "https://github.com/adhithyan15/coding-adventures"
 Repository = "https://github.com/adhithyan15/coding-adventures"
-Documentation = "https://github.com/adhithyan15/coding-adventures/tree/main/code/specs/LP05-structural-list-relations.md"
+Documentation = "https://github.com/adhithyan15/coding-adventures/tree/main/code/specs/LP06-sequence-relations.md"
 
 [project.optional-dependencies]
 dev = [

--- a/code/packages/python/logic-stdlib/src/logic_stdlib/__init__.py
+++ b/code/packages/python/logic-stdlib/src/logic_stdlib/__init__.py
@@ -11,11 +11,13 @@ from logic_stdlib.relations import (
     conso,
     emptyo,
     heado,
+    lasto,
     listo,
     membero,
     permuteo,
     reverseo,
     selecto,
+    subsequenceo,
     tailo,
 )
 
@@ -25,12 +27,14 @@ __all__ = [
     "conso",
     "emptyo",
     "heado",
+    "lasto",
     "listo",
     "membero",
     "permuteo",
     "reverseo",
     "selecto",
+    "subsequenceo",
     "tailo",
 ]
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/code/packages/python/logic-stdlib/src/logic_stdlib/relations.py
+++ b/code/packages/python/logic-stdlib/src/logic_stdlib/relations.py
@@ -20,11 +20,13 @@ __all__ = [
     "conso",
     "emptyo",
     "heado",
+    "lasto",
     "listo",
     "membero",
     "permuteo",
     "reverseo",
     "selecto",
+    "subsequenceo",
     "tailo",
 ]
 
@@ -51,6 +53,21 @@ def tailo(items: object, tail: object) -> GoalExpr:
     """Relate ``tail`` to everything after the first element of a list."""
 
     return fresh(1, lambda head: conso(head, tail, items))
+
+
+def lasto(items: object, last: object) -> GoalExpr:
+    """Relate ``last`` to the final element of a non-empty list."""
+
+    return disj(
+        conso(last, logic_list([]), items),
+        fresh(
+            2,
+            lambda head, tail: conj(
+                conso(head, tail, items),
+                defer(lasto, tail, last),
+            ),
+        ),
+    )
 
 
 def listo(value: object) -> GoalExpr:
@@ -142,6 +159,27 @@ def permuteo(items: object, permutation: object) -> GoalExpr:
                 selecto(head, items, remaining),
                 conso(head, perm_tail, permutation),
                 defer(permuteo, remaining, perm_tail),
+            ),
+        ),
+    )
+
+
+def subsequenceo(items: object, subsequence: object) -> GoalExpr:
+    """Relate ``subsequence`` to any order-preserving deletion of ``items``."""
+
+    return disj(
+        conj(emptyo(items), emptyo(subsequence)),
+        fresh(
+            3,
+            lambda head, tail, sub_tail: conj(
+                conso(head, tail, items),
+                disj(
+                    conj(
+                        conso(head, sub_tail, subsequence),
+                        defer(subsequenceo, tail, sub_tail),
+                    ),
+                    defer(subsequenceo, tail, subsequence),
+                ),
             ),
         ),
     )

--- a/code/packages/python/logic-stdlib/tests/test_logic_stdlib.py
+++ b/code/packages/python/logic-stdlib/tests/test_logic_stdlib.py
@@ -20,11 +20,13 @@ from logic_stdlib import (
     conso,
     emptyo,
     heado,
+    lasto,
     listo,
     membero,
     permuteo,
     reverseo,
     selecto,
+    subsequenceo,
     tailo,
 )
 
@@ -33,7 +35,7 @@ class TestVersion:
     """Verify the package is importable and wired to the engine layer."""
 
     def test_version_exists(self) -> None:
-        assert __version__ == "0.3.0"
+        assert __version__ == "0.4.0"
         assert logic_engine_version == "0.3.0"
 
 
@@ -99,6 +101,24 @@ class TestListRelations:
             marker,
             conj(eq(marker, "ok"), listo(logic_list(["tea"], tail="cake"))),
         ) == []
+
+    def test_lasto_extracts_the_final_element(self) -> None:
+        last = var("Last")
+
+        assert solve_all(
+            program(),
+            last,
+            lasto(logic_list(["tea", "cake", "jam"]), last),
+        ) == [atom("jam")]
+
+    def test_lasto_handles_single_element_lists(self) -> None:
+        last = var("Last")
+
+        assert solve_all(
+            program(),
+            last,
+            lasto(logic_list(["tea"]), last),
+        ) == [atom("tea")]
 
     def test_membero_enumerates_members_of_a_concrete_list(self) -> None:
         item = var("Item")
@@ -210,3 +230,47 @@ class TestListRelations:
                 ),
             ),
         ) == [atom("ok")]
+
+    def test_subsequenceo_enumerates_all_subsequences_of_a_small_list(self) -> None:
+        sequence = var("Sequence")
+
+        assert solve_all(
+            program(),
+            sequence,
+            subsequenceo(logic_list(["tea", "cake"]), sequence),
+        ) == [
+            logic_list(["tea", "cake"]),
+            logic_list(["tea"]),
+            logic_list(["cake"]),
+            logic_list([]),
+        ]
+
+    def test_subsequenceo_can_validate_a_known_ordered_subsequence(self) -> None:
+        marker = var("Marker")
+
+        assert solve_all(
+            program(),
+            marker,
+            conj(
+                eq(marker, "ok"),
+                subsequenceo(
+                    logic_list(["tea", "cake", "jam"]),
+                    logic_list(["tea", "jam"]),
+                ),
+            ),
+        ) == [atom("ok")]
+
+    def test_subsequenceo_rejects_out_of_order_candidates(self) -> None:
+        marker = var("Marker")
+
+        assert solve_all(
+            program(),
+            marker,
+            conj(
+                eq(marker, "ok"),
+                subsequenceo(
+                    logic_list(["tea", "cake", "jam"]),
+                    logic_list(["jam", "tea"]),
+                ),
+            ),
+        ) == []

--- a/code/specs/LP05-structural-list-relations.md
+++ b/code/specs/LP05-structural-list-relations.md
@@ -233,8 +233,8 @@ Required tests:
 Later milestones may add:
 
 - `lengtho`
-- `subsequenceo`
-- `lasto`
+- `prefixo`
+- `suffixo`
 - finite-domain arithmetic relations
 - puzzle-specific helper packages
 

--- a/code/specs/LP06-sequence-relations.md
+++ b/code/specs/LP06-sequence-relations.md
@@ -1,0 +1,249 @@
+# LP06 — Sequence Relations
+
+## Overview
+
+`logic-stdlib` already gives us:
+
+- `emptyo`
+- `conso`
+- `heado`
+- `tailo`
+- `listo`
+- `membero`
+- `appendo`
+- `selecto`
+- `permuteo`
+- `reverseo`
+
+That means the Python host-language library can already:
+
+- deconstruct lists
+- validate proper lists
+- concatenate lists
+- enumerate members
+- choose one element from a list
+- generate permutations
+- relate a list to its reversal
+
+There is still a useful gap around ordered sequence reasoning:
+
+- there is no reusable relation for the final element of a list
+- there is no reusable relation for order-preserving subsequences
+
+Those relations are small, but they appear constantly in textbook logic
+programs, interview-style list puzzles, and parser-style sequence reasoning.
+
+## Design Goal
+
+Add the next pair of sequence-oriented relations:
+
+- `lasto`
+- `subsequenceo`
+
+These should stay inside `logic-stdlib`, compile to ordinary `logic-engine`
+goal expressions, and use `defer(...)` for recursive host-language expansion.
+
+## Why Not `lengtho` Yet
+
+`lengtho` is a natural future relation, but a satisfying version wants a clear
+story for arithmetic and bidirectional numeric reasoning.
+
+We do not have that yet. Rather than introducing a half-relational `lengtho`
+that only works comfortably in one direction, this milestone focuses on two
+sequence relations that are already a good fit for the current engine.
+
+## Layer Position
+
+```text
+SYM00 Symbol Core
+    ↓
+LP00 Logic Core
+    ↓
+LP01 Logic Engine
+    ↓
+LP02 Disequality Constraints
+    ↓
+LP03 Relational Standard Library
+    ↓
+LP04 Relational Combinators
+    ↓
+LP05 Structural List Relations
+    ↓
+LP06 Sequence Relations   ← this milestone
+    - final-element reasoning
+    - ordered subsequence reasoning
+```
+
+## API
+
+Extend `logic-stdlib` with:
+
+```python
+lasto(items: object, last: object) -> GoalExpr
+subsequenceo(items: object, subsequence: object) -> GoalExpr
+```
+
+These should compose naturally with:
+
+- `membero(...)`
+- `appendo(...)`
+- `selecto(...)`
+- `permuteo(...)`
+- `reverseo(...)`
+- `neq(...)`
+- `conj(...)`
+- `disj(...)`
+
+## Semantics
+
+### `lasto`
+
+`lasto(Items, Last)` means:
+
+> `Last` is the final element of the non-empty proper list `Items`.
+
+Examples:
+
+```python
+lasto([tea, cake, jam], X)
+⇒ X = jam
+
+lasto([tea], X)
+⇒ X = tea
+```
+
+Operationally, the first version should encode:
+
+```text
+lasto([Last], Last).
+lasto([_Head | Tail], Last) :-
+    lasto(Tail, Last).
+```
+
+This relation is especially useful because users often want to talk about
+“whatever comes last” without manually writing a recursive list walker in every
+example.
+
+### `subsequenceo`
+
+`subsequenceo(Items, Subsequence)` means:
+
+> `Subsequence` is formed by deleting zero or more elements from `Items`
+> without changing the relative order of the remaining elements.
+
+This is not a contiguous-slice relation. It is an order-preserving deletion
+relation.
+
+Examples:
+
+```python
+subsequenceo([tea, cake, jam], X)
+⇒ X = [tea, cake, jam]
+⇒ X = [tea, cake]
+⇒ X = [tea, jam]
+⇒ X = [cake]
+⇒ X = []
+```
+
+Operationally, the first version should encode:
+
+```text
+subsequenceo([], []).
+subsequenceo([Head | Tail], [Head | SubTail]) :-
+    subsequenceo(Tail, SubTail).
+subsequenceo([_Head | Tail], Subsequence) :-
+    subsequenceo(Tail, Subsequence).
+```
+
+The keep-first branch should come before the drop branch so the search order
+prefers larger, less-deleted subsequences before smaller ones.
+
+## Why This Matters
+
+These two relations help the host-language library feel more like an actual
+logic-programming toolkit instead of a bag of isolated examples.
+
+They make it easier to express:
+
+- “the answer must appear at the end”
+- “this pattern appears in order, though not necessarily contiguously”
+- “generate candidates by deleting some steps while preserving order”
+- “filter ordered arrangements without collapsing back into manual Python”
+
+## Package Impact
+
+This milestone updates the existing Python package:
+
+```text
+code/packages/python/logic-stdlib
+```
+
+No new package is needed.
+
+## Usage Example
+
+```python
+from logic_engine import atom, logic_list, program, solve_all, var
+from logic_stdlib import lasto, subsequenceo
+
+X = var("X")
+
+assert solve_all(
+    program(),
+    X,
+    lasto(logic_list(["tea", "cake", "jam"]), X),
+) == [atom("jam")]
+
+assert solve_all(
+    program(),
+    X,
+    subsequenceo(logic_list(["tea", "cake"]), X),
+) == [
+    logic_list(["tea", "cake"]),
+    logic_list(["tea"]),
+    logic_list(["cake"]),
+    logic_list([]),
+]
+```
+
+## Search Notes
+
+The current engine is still:
+
+- depth-first
+- left-biased
+- not tabled
+
+So open-ended inverse sequence queries can still diverge. The first slice
+should keep tests and examples finite by:
+
+- using concrete source lists
+- validating known outputs or enumerating from bounded inputs
+- avoiding large open-ended reverse or subsequence synthesis
+
+## Test Strategy
+
+Required tests:
+
+- `lasto` extracts the final element of a concrete list
+- `lasto` works for a single-element list
+- `subsequenceo` enumerates all subsequences of a small concrete list
+- `subsequenceo` can validate a known order-preserving subsequence
+- `subsequenceo` rejects an out-of-order candidate
+
+## Future Extensions
+
+Later milestones may add:
+
+- `lengtho`
+- `prefixo`
+- `suffixo`
+- finite-domain arithmetic relations
+- puzzle-specific helper packages
+
+## Why This Milestone Matters
+
+LP05 made the library stronger at structural list reasoning.
+
+LP06 makes it stronger at talking about ordered sequence structure, which is a
+very common shape in logic problems and later Prolog examples.


### PR DESCRIPTION
## Summary
- add the LP06 sequence-relations spec and update LP05 future work
- extend Python `logic-stdlib` with `lasto(...)` and `subsequenceo(...)`
- add docs and tests for final-element reasoning and ordered subsequence search

## Testing
- `/Users/adhithya/Downloads/coding-adventures-worktrees/prolog-sequence/code/packages/python/logic-stdlib/.venv/bin/python -m pytest tests -v`
- `/Users/adhithya/Downloads/coding-adventures-worktrees/prolog-sequence/code/packages/python/logic-stdlib/.venv/bin/python -m ruff check src tests`

## Notes
- security review passed with no findings
- `lengtho(...)` is intentionally deferred until we have a better arithmetic story for genuinely relational numeric reasoning