### PR TITLE
feat(tcp-runtime): add first TCP runtime layer

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -314,4 +314,5 @@ members = [
   "window-core",
   "window-appkit",
   "window-win32",
+  "tcp-runtime",
 ]

--- a/code/packages/rust/tcp-runtime/BUILD
+++ b/code/packages/rust/tcp-runtime/BUILD
@@ -1,0 +1,1 @@
+cargo test -p tcp-runtime -- --nocapture

--- a/code/packages/rust/tcp-runtime/CHANGELOG.md
+++ b/code/packages/rust/tcp-runtime/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-18
+
+### Added
+
+- `TcpRuntime` as the first TCP-specific runtime facade above `stream-reactor`
+- `TcpRuntimeOptions` for listener policy, stream policy, and runtime limits
+- `TcpConnectionInfo` with both peer and local listener addresses
+- `TcpHandlerResult` for queued writes plus close-after-flush intent
+- host-OS convenience constructors for `kqueue`, `epoll`, and Windows transport
+  providers
+- macOS / BSD end-to-end tests for echo behavior, local-address metadata,
+  connection caps, queued-write overflow, and stop-handle shutdown

--- a/code/packages/rust/tcp-runtime/Cargo.toml
+++ b/code/packages/rust/tcp-runtime/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "tcp-runtime"
+version = "0.1.0"
+edition = "2021"
+description = "TCP-specific runtime layer above stream-reactor"
+license = "MIT"
+
+[dependencies]
+stream-reactor = { path = "../stream-reactor" }
+transport-platform = { path = "../transport-platform" }

--- a/code/packages/rust/tcp-runtime/README.md
+++ b/code/packages/rust/tcp-runtime/README.md
@@ -1,0 +1,35 @@
+# tcp-runtime (Rust)
+
+TCP-specific runtime layer above `stream-reactor`.
+
+## What is this?
+
+This crate turns the generic byte-stream engine into a concrete TCP runtime.
+
+It owns:
+
+- TCP listener and stream option policy
+- TCP-flavored connection metadata for handlers
+- a runtime surface that Redis-, IRC-, and protocol-focused crates can bind to
+
+It deliberately delegates byte-stream progression to `stream-reactor` instead
+of reimplementing another reactor loop.
+
+## Current Scope
+
+Phase one supports:
+
+- one listener
+- many concurrent TCP connections
+- configurable backlog, `TCP_NODELAY`, keepalive, and socket buffer defaults
+- queued-write and connection caps inherited from `stream-reactor`
+- cooperative shutdown through a stop handle
+- host-OS convenience constructors for macOS / BSD, Linux, and Windows
+
+## Development
+
+```bash
+cargo test -p tcp-runtime -- --nocapture
+cargo check -p tcp-runtime --tests --target x86_64-unknown-linux-gnu
+cargo check -p tcp-runtime --tests --target x86_64-pc-windows-msvc
+```

--- a/code/packages/rust/tcp-runtime/required_capabilities.json
+++ b/code/packages/rust/tcp-runtime/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/tcp-runtime",
+  "capabilities": [],
+  "justification": "The tcp-runtime crate provides TCP-specific runtime policy above stream-reactor. It configures listeners and surfaces connection metadata, but it does not itself cross a new trust boundary or expose an FFI surface."
+}

--- a/code/packages/rust/tcp-runtime/src/lib.rs
+++ b/code/packages/rust/tcp-runtime/src/lib.rs
@@ -1,0 +1,439 @@
+//! # tcp-runtime
+//!
+//! TCP-specific runtime layer above `stream-reactor`.
+//!
+//! `stream-reactor` owns generic byte-stream progression. This crate adds the
+//! TCP-facing surface that application servers want to depend on: listener
+//! options, stream options, concrete connection metadata, and host-OS
+//! convenience constructors.
+
+use std::net::{SocketAddr, ToSocketAddrs};
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+pub use stream_reactor::{ConnectionId, StopHandle};
+use stream_reactor::{
+    StreamConnectionInfo, StreamHandlerResult, StreamReactor, StreamReactorOptions,
+};
+use transport_platform::TransportPlatform;
+pub use transport_platform::{BindAddress, ListenerOptions, PlatformError, StreamOptions};
+
+/// `TcpConnectionInfo` is the TCP-flavored metadata that handlers see for each
+/// read chunk. It includes both sides of the socket so protocols can log,
+/// route, or enforce policy without consulting lower layers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TcpConnectionInfo {
+    pub id: ConnectionId,
+    pub peer_addr: SocketAddr,
+    pub local_addr: SocketAddr,
+}
+
+/// `TcpHandlerResult` keeps the phase-one handler contract intentionally small:
+/// queue these bytes, and optionally close once the queued output drains.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct TcpHandlerResult {
+    pub write: Vec<u8>,
+    pub close: bool,
+}
+
+impl TcpHandlerResult {
+    pub fn write(bytes: impl Into<Vec<u8>>) -> Self {
+        Self {
+            write: bytes.into(),
+            close: false,
+        }
+    }
+
+    pub const fn close() -> Self {
+        Self {
+            write: Vec::new(),
+            close: true,
+        }
+    }
+
+    pub fn write_and_close(bytes: impl Into<Vec<u8>>) -> Self {
+        Self {
+            write: bytes.into(),
+            close: true,
+        }
+    }
+}
+
+/// `TcpRuntimeOptions` is the TCP policy surface that callers configure.
+/// Listener options feed binding defaults, stream options shape accepted socket
+/// policy, and the remaining knobs forward into the generic stream runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TcpRuntimeOptions {
+    pub listener: ListenerOptions,
+    pub stream: StreamOptions,
+    pub read_buffer_size: usize,
+    pub max_connections: usize,
+    pub max_pending_write_bytes: usize,
+    pub poll_timeout: Duration,
+}
+
+impl Default for TcpRuntimeOptions {
+    fn default() -> Self {
+        let defaults = StreamReactorOptions::default();
+        Self {
+            listener: defaults.listener,
+            stream: defaults.stream,
+            read_buffer_size: defaults.read_buffer_size,
+            max_connections: defaults.max_connections,
+            max_pending_write_bytes: defaults.max_pending_write_bytes,
+            poll_timeout: defaults.poll_timeout,
+        }
+    }
+}
+
+impl From<TcpRuntimeOptions> for StreamReactorOptions {
+    fn from(value: TcpRuntimeOptions) -> Self {
+        Self {
+            listener: value.listener,
+            stream: value.stream,
+            read_buffer_size: value.read_buffer_size,
+            max_connections: value.max_connections,
+            max_pending_write_bytes: value.max_pending_write_bytes,
+            poll_timeout: value.poll_timeout,
+        }
+    }
+}
+
+pub struct TcpRuntime<P> {
+    reactor: StreamReactor<P>,
+    local_addr: SocketAddr,
+}
+
+impl<P: TransportPlatform> TcpRuntime<P> {
+    pub fn bind<F>(
+        platform: P,
+        address: BindAddress,
+        options: TcpRuntimeOptions,
+        handler: F,
+    ) -> Result<Self, PlatformError>
+    where
+        F: Fn(TcpConnectionInfo, &[u8]) -> TcpHandlerResult + Send + Sync + 'static,
+    {
+        // The listener address is only known after bind succeeds, so a small
+        // one-time cell bridges that value into the per-read handler closure.
+        let local_addr_cell = Arc::new(OnceLock::new());
+        let handler_local_addr = Arc::clone(&local_addr_cell);
+
+        let reactor = StreamReactor::bind(
+            platform,
+            address,
+            options.into(),
+            move |info: StreamConnectionInfo, bytes: &[u8]| {
+                let local_addr = *handler_local_addr
+                    .get()
+                    .expect("tcp-runtime initializes the local listener address before serving");
+                let result = handler(
+                    TcpConnectionInfo {
+                        id: info.id,
+                        peer_addr: info.peer_addr,
+                        local_addr,
+                    },
+                    bytes,
+                );
+                StreamHandlerResult {
+                    write: result.write,
+                    close: result.close,
+                }
+            },
+        )?;
+
+        let local_addr = reactor.local_addr();
+        local_addr_cell
+            .set(local_addr)
+            .expect("local listener address should be set exactly once");
+
+        Ok(Self {
+            reactor,
+            local_addr,
+        })
+    }
+
+    pub fn set_max_connections(&mut self, max_connections: usize) {
+        self.reactor.set_max_connections(max_connections);
+    }
+
+    pub fn set_max_pending_write_bytes(&mut self, max_pending_write_bytes: usize) {
+        self.reactor
+            .set_max_pending_write_bytes(max_pending_write_bytes);
+    }
+
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+
+    pub fn stop_handle(&self) -> StopHandle {
+        self.reactor.stop_handle()
+    }
+
+    pub fn serve(&mut self) -> Result<(), PlatformError> {
+        self.reactor.serve()
+    }
+}
+
+#[cfg(any(
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly"
+))]
+impl TcpRuntime<transport_platform::bsd::KqueueTransportPlatform> {
+    pub fn bind_kqueue<A, F>(
+        addr: A,
+        options: TcpRuntimeOptions,
+        handler: F,
+    ) -> Result<Self, PlatformError>
+    where
+        A: ToSocketAddrs,
+        F: Fn(TcpConnectionInfo, &[u8]) -> TcpHandlerResult + Send + Sync + 'static,
+    {
+        let address = resolve_first_socket_addr(addr)?;
+        let platform = transport_platform::bsd::KqueueTransportPlatform::new()?;
+        Self::bind(platform, BindAddress::Ip(address), options, handler)
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl TcpRuntime<transport_platform::linux::EpollTransportPlatform> {
+    pub fn bind_epoll<A, F>(
+        addr: A,
+        options: TcpRuntimeOptions,
+        handler: F,
+    ) -> Result<Self, PlatformError>
+    where
+        A: ToSocketAddrs,
+        F: Fn(TcpConnectionInfo, &[u8]) -> TcpHandlerResult + Send + Sync + 'static,
+    {
+        let address = resolve_first_socket_addr(addr)?;
+        let platform = transport_platform::linux::EpollTransportPlatform::new()?;
+        Self::bind(platform, BindAddress::Ip(address), options, handler)
+    }
+}
+
+#[cfg(target_os = "windows")]
+impl TcpRuntime<transport_platform::windows::WindowsTransportPlatform> {
+    pub fn bind_windows<A, F>(
+        addr: A,
+        options: TcpRuntimeOptions,
+        handler: F,
+    ) -> Result<Self, PlatformError>
+    where
+        A: ToSocketAddrs,
+        F: Fn(TcpConnectionInfo, &[u8]) -> TcpHandlerResult + Send + Sync + 'static,
+    {
+        let address = resolve_first_socket_addr(addr)?;
+        let platform = transport_platform::windows::WindowsTransportPlatform::new()?;
+        Self::bind(platform, BindAddress::Ip(address), options, handler)
+    }
+}
+
+fn resolve_first_socket_addr<A: ToSocketAddrs>(addr: A) -> Result<SocketAddr, PlatformError> {
+    addr.to_socket_addrs()
+        .map_err(PlatformError::from)?
+        .next()
+        .ok_or_else(|| PlatformError::Io("no socket addresses resolved".into()))
+}
+
+#[cfg(all(
+    test,
+    any(
+        target_os = "macos",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "dragonfly"
+    )
+))]
+mod tests {
+    use super::*;
+    use std::io::{self, Read, Write};
+    use std::net::{Shutdown, TcpStream};
+    use std::sync::{Arc, Barrier, Mutex};
+    use std::thread;
+
+    #[test]
+    fn serves_many_concurrent_echo_clients_without_crashing() {
+        let mut runtime = TcpRuntime::bind_kqueue(
+            ("127.0.0.1", 0),
+            TcpRuntimeOptions::default(),
+            |_, bytes| TcpHandlerResult::write(bytes.to_vec()),
+        )
+        .expect("bind");
+        let addr = runtime.local_addr();
+        let stop = runtime.stop_handle();
+
+        let server = thread::spawn(move || runtime.serve());
+
+        let client_count = 24usize;
+        let barrier = Arc::new(Barrier::new(client_count));
+        let mut clients = Vec::new();
+
+        for i in 0..client_count {
+            let barrier = Arc::clone(&barrier);
+            clients.push(thread::spawn(move || -> Result<Vec<u8>, String> {
+                barrier.wait();
+                let mut stream = TcpStream::connect(addr).map_err(|e| e.to_string())?;
+                let payload = format!("client-{i}-payload").into_bytes();
+                stream.write_all(&payload).map_err(|e| e.to_string())?;
+                stream
+                    .shutdown(Shutdown::Write)
+                    .map_err(|e| e.to_string())?;
+
+                let mut echoed = Vec::new();
+                stream.read_to_end(&mut echoed).map_err(|e| e.to_string())?;
+                Ok(echoed)
+            }));
+        }
+
+        for (i, client) in clients.into_iter().enumerate() {
+            let echoed = client.join().expect("client thread").expect("client io");
+            assert_eq!(echoed, format!("client-{i}-payload").into_bytes());
+        }
+
+        stop.stop();
+        let result = server.join().expect("server thread");
+        assert!(result.is_ok(), "server should exit cleanly: {result:?}");
+    }
+
+    #[test]
+    fn handler_receives_the_listener_local_address() {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let seen_in_handler = Arc::clone(&seen);
+        let mut runtime = TcpRuntime::bind_kqueue(
+            ("127.0.0.1", 0),
+            TcpRuntimeOptions::default(),
+            move |info, bytes| {
+                seen_in_handler
+                    .lock()
+                    .expect("seen mutex poisoned")
+                    .push(info.local_addr);
+                TcpHandlerResult::write(bytes.to_vec())
+            },
+        )
+        .expect("bind");
+        let addr = runtime.local_addr();
+        let stop = runtime.stop_handle();
+
+        let server = thread::spawn(move || runtime.serve());
+
+        let mut client = TcpStream::connect(addr).expect("connect");
+        client.write_all(b"local-address").expect("write request");
+        client.shutdown(Shutdown::Write).expect("shutdown write");
+
+        let mut echoed = Vec::new();
+        client.read_to_end(&mut echoed).expect("read echoed bytes");
+        assert_eq!(echoed, b"local-address");
+
+        stop.stop();
+        let result = server.join().expect("server thread");
+        assert!(result.is_ok(), "server should exit cleanly: {result:?}");
+
+        let seen = seen.lock().expect("seen mutex poisoned");
+        assert!(
+            !seen.is_empty(),
+            "handler should record at least one local address"
+        );
+        assert!(seen.iter().all(|candidate| *candidate == addr));
+    }
+
+    #[test]
+    fn rejects_connections_above_the_configured_cap() {
+        let options = TcpRuntimeOptions {
+            max_connections: 2,
+            ..TcpRuntimeOptions::default()
+        };
+        let mut runtime = TcpRuntime::bind_kqueue(("127.0.0.1", 0), options, |_, bytes| {
+            TcpHandlerResult::write(bytes.to_vec())
+        })
+        .expect("bind");
+        let addr = runtime.local_addr();
+        let stop = runtime.stop_handle();
+
+        let server = thread::spawn(move || runtime.serve());
+
+        let _client_a = TcpStream::connect(addr).expect("connect a");
+        let _client_b = TcpStream::connect(addr).expect("connect b");
+        thread::sleep(Duration::from_millis(50));
+
+        let mut client_c = TcpStream::connect(addr).expect("connect c");
+        let outcome = attempt_round_trip(&mut client_c, b"overflow");
+        match outcome {
+            Ok(response) => assert_ne!(response, b"overflow"),
+            Err(err) => assert!(matches!(
+                err.kind(),
+                io::ErrorKind::BrokenPipe
+                    | io::ErrorKind::ConnectionReset
+                    | io::ErrorKind::ConnectionAborted
+                    | io::ErrorKind::NotConnected
+            )),
+        }
+
+        stop.stop();
+        let result = server.join().expect("server thread");
+        assert!(result.is_ok(), "server should exit cleanly: {result:?}");
+    }
+
+    #[test]
+    fn closes_connections_that_exceed_the_pending_write_budget() {
+        let options = TcpRuntimeOptions {
+            max_pending_write_bytes: 32,
+            ..TcpRuntimeOptions::default()
+        };
+        let mut runtime = TcpRuntime::bind_kqueue(("127.0.0.1", 0), options, |_, _| {
+            TcpHandlerResult::write(vec![1u8; 64])
+        })
+        .expect("bind");
+        let addr = runtime.local_addr();
+        let stop = runtime.stop_handle();
+
+        let server = thread::spawn(move || runtime.serve());
+
+        let mut client = TcpStream::connect(addr).expect("connect");
+        let outcome = attempt_round_trip(&mut client, b"trigger");
+        match outcome {
+            Ok(response) => assert_ne!(response, vec![1u8; 64]),
+            Err(err) => assert!(matches!(
+                err.kind(),
+                io::ErrorKind::BrokenPipe
+                    | io::ErrorKind::ConnectionReset
+                    | io::ErrorKind::ConnectionAborted
+                    | io::ErrorKind::NotConnected
+            )),
+        }
+
+        stop.stop();
+        let result = server.join().expect("server thread");
+        assert!(result.is_ok(), "server should exit cleanly: {result:?}");
+    }
+
+    #[test]
+    fn stop_handle_shuts_down_the_server() {
+        let mut runtime = TcpRuntime::bind_kqueue(
+            ("127.0.0.1", 0),
+            TcpRuntimeOptions::default(),
+            |_, bytes| TcpHandlerResult::write(bytes.to_vec()),
+        )
+        .expect("bind");
+        let stop = runtime.stop_handle();
+
+        let server = thread::spawn(move || runtime.serve());
+        thread::sleep(Duration::from_millis(20));
+        stop.stop();
+
+        let result = server.join().expect("server thread");
+        assert!(result.is_ok(), "server should exit cleanly: {result:?}");
+    }
+
+    fn attempt_round_trip(stream: &mut TcpStream, payload: &[u8]) -> io::Result<Vec<u8>> {
+        stream.write_all(payload)?;
+        stream.shutdown(Shutdown::Write)?;
+        let mut response = Vec::new();
+        stream.read_to_end(&mut response)?;
+        Ok(response)
+    }
+}

--- a/code/specs/tcp-runtime.md
+++ b/code/specs/tcp-runtime.md
@@ -1,0 +1,194 @@
+# tcp-runtime
+
+## Overview
+
+`tcp-runtime` is the first TCP-specific runtime layer above `stream-reactor`.
+
+It exists to turn the generic byte-stream substrate into a concrete transport
+surface that application servers can depend on without needing to understand:
+
+- `transport-platform` listener and stream configuration details
+- raw `stream-reactor` handler wiring
+- TCP listener defaults such as backlog, `TCP_NODELAY`, and keepalive policy
+
+Phase one is intentionally not the final transport engine described in
+`tcp-runtime-roadmap.md`. It is the first honest slice that makes the layering
+real:
+
+```text
+Redis / IRC / future TCP protocols
+    ↓
+tcp-runtime
+    ↓
+stream-reactor
+    ↓
+transport-platform
+```
+
+## Why This Exists
+
+The repository now has:
+
+- raw native backends
+- `transport-platform`
+- `stream-reactor`
+- older proof crates such as `tcp-reactor`
+
+What application-facing TCP work still lacks is a concrete runtime surface that
+answers practical questions like:
+
+- how do I bind a TCP listener with the repository's default policy?
+- how do I configure backlog, `TCP_NODELAY`, keepalive, and buffer sizing?
+- how do I receive TCP connection metadata instead of generic stream metadata?
+- how do I run an end-to-end TCP server without touching platform details?
+
+`tcp-runtime` is that missing layer.
+
+## Phase-One Scope
+
+Phase one of `tcp-runtime` supports:
+
+- one TCP listener
+- many accepted TCP connections
+- TCP-specific listener and stream configuration through `TcpRuntimeOptions`
+- TCP-specific connection metadata for handlers
+- queued-write and connection-admission limits inherited from `stream-reactor`
+- cooperative shutdown through a stop handle
+- host-OS convenience constructors:
+  - macOS / BSD: `bind_kqueue`
+  - Linux: `bind_epoll`
+  - Windows: `bind_windows`
+
+Phase one intentionally does not yet require:
+
+- listener groups
+- pause / resume of accepts
+- explicit drain mode
+- idle or write deadlines
+- typed connection-close reasons above `stream-reactor`
+- multi-core reactor sharding
+- a C ABI
+
+## Core Concepts
+
+### `TcpConnectionInfo`
+
+Handlers should receive TCP-flavored metadata:
+
+- repository-owned connection identity
+- peer socket address
+- local listener address
+
+The handler should not need to reconstruct the local address from the platform
+or listener every time it processes bytes.
+
+### `TcpHandlerResult`
+
+The handler result remains intentionally simple:
+
+- bytes to queue for writing
+- whether the connection should close after queued bytes flush
+
+This keeps the runtime useful for:
+
+- echo-style servers
+- request / response protocols such as Redis
+- line-oriented protocols such as IRC
+
+without coupling the runtime to framing rules.
+
+### `TcpRuntimeOptions`
+
+`tcp-runtime` owns the TCP policy surface that applications care about:
+
+- listener options:
+  - backlog
+  - `reuse_address`
+  - `reuse_port`
+  - default `TCP_NODELAY`
+  - default keepalive policy
+- accepted-stream options:
+  - `TCP_NODELAY`
+  - keepalive
+  - receive and send buffer sizing
+- runtime options:
+  - read buffer size
+  - maximum concurrent connections
+  - maximum queued bytes per connection
+  - poll timeout
+
+This is the first place where TCP-specific policy becomes explicit instead of
+being hidden in generic defaults.
+
+## Public API
+
+Phase-one public API:
+
+- `TcpConnectionInfo`
+- `TcpHandlerResult`
+- `TcpRuntimeOptions`
+- `StopHandle`
+- `TcpRuntime::bind(platform, address, options, handler)`
+- `TcpRuntime::serve()`
+- `TcpRuntime::local_addr()`
+- `TcpRuntime::stop_handle()`
+- `TcpRuntime::set_max_connections(max)`
+- `TcpRuntime::set_max_pending_write_bytes(max)`
+- convenience constructors:
+  - `TcpRuntime::bind_kqueue(addr, options, handler)`
+  - `TcpRuntime::bind_epoll(addr, options, handler)`
+  - `TcpRuntime::bind_windows(addr, options, handler)`
+
+## Relationship To `stream-reactor`
+
+`stream-reactor` remains the generic byte-stream engine.
+
+`tcp-runtime` should:
+
+- own TCP listener and socket policy
+- translate generic stream metadata into TCP runtime metadata
+- present the TCP-specific API that Redis, IRC, and future bindings can target
+
+`tcp-runtime` should not:
+
+- duplicate the stream progression logic already solved by `stream-reactor`
+- reintroduce direct dependencies on raw platform details
+
+That means the implementation should delegate event progression and queued-write
+handling to `stream-reactor` rather than forking another reactor loop.
+
+## Error Handling
+
+Phase one should preserve the `stream-reactor` behavior:
+
+- listener-level platform failures terminate `serve()`
+- per-connection platform failures close only that connection
+- close-on-overflow remains the defense when queued outbound bytes exceed the
+  configured budget
+
+The runtime should keep using `transport-platform::PlatformError` for now.
+Future phases can wrap or translate those into a richer TCP error taxonomy.
+
+## Test Strategy
+
+Phase one should include:
+
+- macOS / BSD concurrent echo test through the `TcpRuntime` surface
+- connection-cap test through the `TcpRuntime` surface
+- queued-write-budget overflow test through the `TcpRuntime` surface
+- local-address visibility test for handler metadata
+- Linux and Windows target compile coverage through `cargo check`
+
+## Future Work
+
+Later `tcp-runtime` phases should add:
+
+- listener groups and sharding
+- drain mode and graceful listener shutdown
+- idle and write deadlines
+- statistics and tracing hooks
+- typed lifecycle events
+- FFI-facing runtime handles
+
+This phase should stay focused on making the `stream-reactor` layer usable as a
+real TCP runtime without claiming that the entire roadmap is already complete.


### PR DESCRIPTION
## Summary
- add the first `tcp-runtime` Rust crate above `stream-reactor`
- add the `tcp-runtime` spec, package metadata, README, changelog, and BUILD entry
- validate the new layer locally on macOS and with Linux/Windows target checks

## Validation
- `cargo test -p tcp-runtime -- --nocapture`
- `cargo check -p tcp-runtime --tests --target x86_64-unknown-linux-gnu`
- `cargo check -p tcp-runtime --tests --target x86_64-pc-windows-msvc`
- `cargo metadata --format-version 1 --no-deps`

## Notes
- Security review passed in one round with no findings.
- `cargo build --workspace` still fails outside this change on a pre-existing macOS linkage issue in `font-parser-python`.
- This phase intentionally keeps `tcp-runtime` as a TCP-facing facade over `stream-reactor` instead of trying to solve listener groups, drain mode, or the future C ABI in one step.