### PR TITLE
feat(huffman): add Dart DT27 and CMP04 packages

### DIFF
--- a/code/packages/dart/huffman-compression/.gitignore
+++ b/code/packages/dart/huffman-compression/.gitignore
@@ -1,0 +1,2 @@
+.dart_tool/
+pubspec.lock

--- a/code/packages/dart/huffman-compression/BUILD
+++ b/code/packages/dart/huffman-compression/BUILD
@@ -1,0 +1,5 @@
+cd ../huffman-tree
+dart pub get
+cd ../huffman-compression
+dart pub get
+dart test

--- a/code/packages/dart/huffman-compression/CHANGELOG.md
+++ b/code/packages/dart/huffman-compression/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [0.1.0] - 2026-04-18
+
+### Added
+
+- Added the Dart CMP04 Huffman compression and decompression implementation.
+- Added canonical code-length serialisation, LSB-first bit packing, and strict decoder validation.
+- Added regression tests for malformed headers, invalid code tables, truncated streams, and padding errors.

--- a/code/packages/dart/huffman-compression/README.md
+++ b/code/packages/dart/huffman-compression/README.md
@@ -1,0 +1,49 @@
+# Huffman Compression
+
+Canonical Huffman compression and decompression for Dart.
+
+## What it does
+
+`coding_adventures_huffman_compression` implements CMP04 in the Dart lane. It
+counts byte frequencies, builds a DT27 `HuffmanTree`, serialises the canonical
+code lengths into the CMP04 header, and packs the compressed bit stream
+LSB-first.
+
+## Wire format
+
+Each payload is:
+
+- 4 bytes: original length as big-endian uint32
+- 4 bytes: symbol count as big-endian uint32
+- `2 * symbol_count` bytes: `(symbol, code_length)` pairs sorted by
+  `(code_length, symbol)`
+- remaining bytes: the canonical Huffman bit stream packed LSB-first
+
+The decoder fails closed on malformed headers, duplicate symbols, invalid code
+lengths, impossible canonical tables, truncated streams, invalid prefixes, and
+non-zero padding bits.
+
+## Usage
+
+```dart
+import 'dart:typed_data';
+
+import 'package:coding_adventures_huffman_compression/huffman_compression.dart';
+
+void main() {
+  final input = Uint8List.fromList('AAABBC'.codeUnits);
+  final compressed = compress(input);
+  final recovered = decompress(compressed);
+  print(String.fromCharCodes(recovered)); // AAABBC
+}
+```
+
+## How it fits in the stack
+
+This package is the Dart CMP04 compression layer and depends on
+`coding_adventures_huffman_tree` for deterministic tree construction and
+canonical code generation.
+
+## Direct dependencies
+
+huffman-tree

--- a/code/packages/dart/huffman-compression/lib/huffman_compression.dart
+++ b/code/packages/dart/huffman-compression/lib/huffman_compression.dart
@@ -1,0 +1,3 @@
+library;
+
+export 'src/huffman_compression.dart';

--- a/code/packages/dart/huffman-compression/lib/src/huffman_compression.dart
+++ b/code/packages/dart/huffman-compression/lib/src/huffman_compression.dart
@@ -1,0 +1,381 @@
+import 'dart:typed_data';
+
+import 'package:coding_adventures_huffman_tree/huffman_tree.dart';
+
+/// Maximum code length allowed by the CMP04 wire format.
+const int maxCodeLength = 16;
+
+/// Default cap for output length declared by untrusted compressed payloads.
+const int defaultMaxDecompressedSize = 64 * 1024 * 1024;
+
+/// Compress [data] into the CMP04 canonical Huffman wire format.
+///
+/// The output layout is:
+///
+/// - 4 bytes: original length as big-endian uint32
+/// - 4 bytes: distinct symbol count as big-endian uint32
+/// - `2 * symbol_count` bytes: `(symbol, code_length)` pairs sorted by
+///   `(code_length, symbol)` ascending
+/// - variable bytes: bit stream packed LSB-first and zero-padded to the byte
+///   boundary
+Uint8List compress(Uint8List data) {
+  if (data.isEmpty) {
+    return Uint8List(8);
+  }
+
+  final frequencies = <int, int>{};
+  for (final byte in data) {
+    frequencies[byte] = (frequencies[byte] ?? 0) + 1;
+  }
+
+  final tree = HuffmanTree.build(
+    frequencies.entries
+        .map<(int, int)>((entry) => (entry.key, entry.value))
+        .toList(),
+  );
+  final canonicalTable = tree.canonicalCodeTable();
+  final lengths = canonicalTable.entries
+      .map<(int, int)>((entry) => (entry.key, entry.value.length))
+      .toList()
+    ..sort(
+      (left, right) => left.$2 != right.$2
+          ? left.$2.compareTo(right.$2)
+          : left.$1.compareTo(right.$1),
+    );
+
+  for (final (_, length) in lengths) {
+    if (length > maxCodeLength)
+      throw StateError(
+          'Huffman tree produced a code longer than $maxCodeLength bits.');
+  }
+
+  final bits = StringBuffer();
+  for (final byte in data) {
+    bits.write(canonicalTable[byte]!);
+  }
+
+  final bitBytes = _packBitsLsbFirst(bits.toString());
+  final symbolCount = lengths.length;
+  final output = Uint8List(8 + symbolCount * 2 + bitBytes.length);
+  final header = ByteData.sublistView(output);
+  header.setUint32(0, data.length, Endian.big);
+  header.setUint32(4, symbolCount, Endian.big);
+
+  for (var index = 0; index < symbolCount; index += 1) {
+    final (symbol, length) = lengths[index];
+    output[8 + index * 2] = symbol;
+    output[8 + index * 2 + 1] = length;
+  }
+  output.setRange(8 + symbolCount * 2, output.length, bitBytes);
+  return output;
+}
+
+/// Decompress a CMP04 canonical Huffman payload.
+///
+/// The decoder validates the header, the code-length table, the canonical code
+/// space, truncated bit streams, invalid prefixes, and non-zero padding bits.
+Uint8List decompress(
+  Uint8List data, [
+  int maxDecompressedSize = defaultMaxDecompressedSize,
+]) {
+  _validateMaxDecompressedSize(maxDecompressedSize);
+
+  if (data.isEmpty) {
+    return Uint8List(0);
+  }
+  if (data.length < 8) {
+    throw const FormatException(
+      'Malformed Huffman stream: header is incomplete.',
+    );
+  }
+
+  final header = ByteData.sublistView(data);
+  final originalLength = header.getUint32(0, Endian.big);
+  final symbolCount = header.getUint32(4, Endian.big);
+
+  if (originalLength == 0) {
+    if (symbolCount != 0) {
+      throw const FormatException(
+        'Malformed Huffman stream: empty output cannot declare symbols.',
+      );
+    }
+    if (data.length != 8) {
+      throw const FormatException(
+        'Malformed Huffman stream: empty output must not include table or bit data.',
+      );
+    }
+    return Uint8List(0);
+  }
+
+  if (originalLength > maxDecompressedSize) {
+    throw FormatException(
+      'Malformed Huffman stream: declared output length $originalLength exceeds the configured limit $maxDecompressedSize.',
+    );
+  }
+  if (symbolCount == 0) {
+    throw const FormatException(
+      'Malformed Huffman stream: non-empty output requires at least one symbol.',
+    );
+  }
+  if (symbolCount > 256) {
+    throw FormatException(
+      'Malformed Huffman stream: symbol count $symbolCount exceeds the byte alphabet.',
+    );
+  }
+
+  final tableOffset = 8;
+  final tableSize = symbolCount * 2;
+  final bitOffset = tableOffset + tableSize;
+  if (data.length < bitOffset) {
+    throw const FormatException(
+      'Malformed Huffman stream: code-length table is truncated.',
+    );
+  }
+
+  final lengths = <(int, int)>[];
+  final seenSymbols = <int>{};
+  var previousLength = -1;
+  var previousSymbol = -1;
+  for (var index = 0; index < symbolCount; index += 1) {
+    final symbol = data[tableOffset + index * 2];
+    final length = data[tableOffset + index * 2 + 1];
+
+    if (!seenSymbols.add(symbol)) {
+      throw FormatException(
+        'Malformed Huffman stream: duplicate symbol $symbol in code-length table.',
+      );
+    }
+    if (length == 0) {
+      throw FormatException(
+        'Malformed Huffman stream: symbol $symbol has invalid code length 0.',
+      );
+    }
+    if (length > maxCodeLength) {
+      throw FormatException(
+        'Malformed Huffman stream: symbol $symbol has code length $length, which exceeds $maxCodeLength.',
+      );
+    }
+    if (previousLength > length ||
+        (previousLength == length && previousSymbol > symbol)) {
+      throw const FormatException(
+        'Malformed Huffman stream: code-length table must be sorted by (length, symbol).',
+      );
+    }
+
+    previousLength = length;
+    previousSymbol = symbol;
+    lengths.add((symbol, length));
+  }
+
+  final decoder = _canonicalDecoderFromLengths(lengths);
+  final bitReader = _BitReader(data.sublist(bitOffset));
+  final output = Uint8List(originalLength);
+  var decoded = 0;
+  var currentCode = 0;
+  var currentLength = 0;
+
+  while (decoded < originalLength) {
+    final bit = bitReader.readBit();
+    if (bit == null) {
+      throw FormatException(
+        'Malformed Huffman stream: bit stream exhausted after $decoded symbols; expected $originalLength.',
+      );
+    }
+
+    currentCode = (currentCode << 1) | bit;
+    currentLength += 1;
+
+    if (currentLength > decoder.maxLength) {
+      throw const FormatException(
+        'Malformed Huffman stream: encountered a bit prefix that matches no canonical code.',
+      );
+    }
+
+    final symbol = decoder.codesByLength[currentLength]?[currentCode];
+    if (symbol != null) {
+      output[decoded] = symbol;
+      decoded += 1;
+      currentCode = 0;
+      currentLength = 0;
+      continue;
+    }
+
+    final canStillGrow =
+        decoder.validPrefixesByLength[currentLength]?.contains(currentCode) ??
+            false;
+    if (!canStillGrow) {
+      throw const FormatException(
+        'Malformed Huffman stream: encountered a bit prefix that matches no canonical code.',
+      );
+    }
+  }
+
+  if (currentLength != 0) {
+    throw const FormatException(
+      'Malformed Huffman stream: decoding ended in the middle of a code word.',
+    );
+  }
+  if (bitReader.hasNonZeroRemainingBits()) {
+    throw const FormatException(
+      'Malformed Huffman stream: trailing padding bits must be zero.',
+    );
+  }
+
+  return output;
+}
+
+Uint8List _packBitsLsbFirst(String bits) {
+  final output = Uint8List((bits.length + 7) ~/ 8);
+  for (var index = 0; index < bits.length; index += 1) {
+    final bit = bits[index];
+    if (bit == '1') {
+      output[index ~/ 8] |= 1 << (index % 8);
+    }
+  }
+  return output;
+}
+
+_CanonicalDecoder _canonicalDecoderFromLengths(List<(int, int)> lengths) {
+  if (lengths.isEmpty) {
+    throw const FormatException(
+      'Malformed Huffman stream: code-length table must not be empty.',
+    );
+  }
+
+  if (lengths.length == 1) {
+    final (symbol, length) = lengths.single;
+    if (length != 1) {
+      throw const FormatException(
+        'Malformed Huffman stream: single-symbol tables must use a one-bit code.',
+      );
+    }
+    return _CanonicalDecoder(
+      <int, Map<int, int>>{
+        1: <int, int>{0: symbol}
+      },
+      <int, Set<int>>{},
+      1,
+    );
+  }
+
+  final countsByLength = <int, int>{};
+  var maxLength = 0;
+  for (final (_, length) in lengths) {
+    countsByLength[length] = (countsByLength[length] ?? 0) + 1;
+    if (length > maxLength) {
+      maxLength = length;
+    }
+  }
+
+  var availableSlots = 1;
+  for (var depth = 1; depth <= maxLength; depth += 1) {
+    availableSlots <<= 1;
+    availableSlots -= countsByLength[depth] ?? 0;
+    if (availableSlots < 0) {
+      throw const FormatException(
+        'Malformed Huffman stream: canonical code lengths oversubscribe the prefix tree.',
+      );
+    }
+  }
+  if (availableSlots != 0) {
+    throw const FormatException(
+      'Malformed Huffman stream: canonical code lengths do not form a complete prefix tree.',
+    );
+  }
+
+  final codesByLength = <int, Map<int, int>>{};
+  final validPrefixesByLength = <int, Set<int>>{};
+  var currentCode = 0;
+  var previousLength = lengths.first.$2;
+  for (final (symbol, length) in lengths) {
+    if (length > previousLength) {
+      currentCode <<= length - previousLength;
+    }
+    if (currentCode >= (1 << length)) {
+      throw const FormatException(
+        'Malformed Huffman stream: canonical code value overflowed its declared length.',
+      );
+    }
+    codesByLength.putIfAbsent(length, () => <int, int>{})[currentCode] = symbol;
+    for (var prefixLength = 1; prefixLength < length; prefixLength += 1) {
+      final prefix = currentCode >> (length - prefixLength);
+      validPrefixesByLength
+          .putIfAbsent(prefixLength, () => <int>{})
+          .add(prefix);
+    }
+    currentCode += 1;
+    previousLength = length;
+  }
+
+  return _CanonicalDecoder(codesByLength, validPrefixesByLength, maxLength);
+}
+
+void _validateMaxDecompressedSize(int maxDecompressedSize) {
+  if (maxDecompressedSize <= 0) {
+    throw RangeError.value(
+      maxDecompressedSize,
+      'maxDecompressedSize',
+      'Must be positive.',
+    );
+  }
+}
+
+final class _CanonicalDecoder {
+  const _CanonicalDecoder(
+    this.codesByLength,
+    this.validPrefixesByLength,
+    this.maxLength,
+  );
+
+  final Map<int, Map<int, int>> codesByLength;
+  final Map<int, Set<int>> validPrefixesByLength;
+  final int maxLength;
+}
+
+final class _BitReader {
+  _BitReader(this._data);
+
+  final Uint8List _data;
+  int _byteIndex = 0;
+  int _bitIndex = 0;
+
+  int? readBit() {
+    if (_byteIndex >= _data.length) {
+      return null;
+    }
+
+    final bit = (_data[_byteIndex] >> _bitIndex) & 1;
+    _bitIndex += 1;
+    if (_bitIndex == 8) {
+      _bitIndex = 0;
+      _byteIndex += 1;
+    }
+    return bit;
+  }
+
+  bool hasNonZeroRemainingBits() {
+    if (_byteIndex >= _data.length) {
+      return false;
+    }
+
+    if (_bitIndex > 0) {
+      final mask = ((1 << (8 - _bitIndex)) - 1) << _bitIndex;
+      if ((_data[_byteIndex] & mask) != 0) {
+        return true;
+      }
+      for (var index = _byteIndex + 1; index < _data.length; index += 1) {
+        if (_data[index] != 0) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    for (var index = _byteIndex; index < _data.length; index += 1) {
+      if (_data[index] != 0) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/code/packages/dart/huffman-compression/pubspec.yaml
+++ b/code/packages/dart/huffman-compression/pubspec.yaml
@@ -1,0 +1,16 @@
+name: coding_adventures_huffman_compression
+description: >
+  Canonical Huffman compression and decompression for Dart.
+version: 0.1.0
+repository: https://github.com/adhithyan15/coding-adventures
+publish_to: none
+
+environment:
+  sdk: ^3.0.0
+
+dependencies:
+  coding_adventures_huffman_tree:
+    path: ../huffman-tree
+
+dev_dependencies:
+  test: ^1.25.0

--- a/code/packages/dart/huffman-compression/test/huffman_compression_test.dart
+++ b/code/packages/dart/huffman-compression/test/huffman_compression_test.dart
@@ -1,0 +1,392 @@
+import 'dart:typed_data';
+
+import 'package:coding_adventures_huffman_compression/huffman_compression.dart';
+import 'package:test/test.dart';
+
+Uint8List _ascii(String value) => Uint8List.fromList(value.codeUnits);
+
+String _decodeAscii(Uint8List bytes) => String.fromCharCodes(bytes);
+
+int _readUint32BE(Uint8List data, int offset) =>
+    ByteData.sublistView(data).getUint32(offset, Endian.big);
+
+void main() {
+  group('round-trip compression', () {
+    test('round-trips AAABBC', () {
+      final original = _ascii('AAABBC');
+      expect(_decodeAscii(decompress(compress(original))), 'AAABBC');
+    });
+
+    test('round-trips hello world', () {
+      final original = _ascii('hello world');
+      expect(_decodeAscii(decompress(compress(original))), 'hello world');
+    });
+
+    test('round-trips repeated text', () {
+      final original = _ascii('aaaaabbbbbcccccdddddeeeeefffffggggg');
+      expect(
+        _decodeAscii(decompress(compress(original))),
+        'aaaaabbbbbcccccdddddeeeeefffffggggg',
+      );
+    });
+
+    test('round-trips unique characters', () {
+      final original = _ascii('abcdefghijklmnopqrstuvwxyz');
+      expect(
+        _decodeAscii(decompress(compress(original))),
+        'abcdefghijklmnopqrstuvwxyz',
+      );
+    });
+
+    test('round-trips all 256 byte values', () {
+      final original = Uint8List.fromList(List<int>.generate(256, (i) => i));
+      expect(decompress(compress(original)), original);
+    });
+
+    test('round-trips a single repeated byte', () {
+      final original = Uint8List.fromList(<int>[0, 0, 0, 0, 0]);
+      expect(decompress(compress(original)), original);
+    });
+  });
+
+  group('wire format for AAABBC', () {
+    final compressed = compress(_ascii('AAABBC'));
+
+    test('stores the expected header', () {
+      expect(_readUint32BE(compressed, 0), 6);
+      expect(_readUint32BE(compressed, 4), 3);
+    });
+
+    test('stores the sorted code-length table', () {
+      expect(compressed[8], 65);
+      expect(compressed[9], 1);
+      expect(compressed[10], 66);
+      expect(compressed[11], 2);
+      expect(compressed[12], 67);
+      expect(compressed[13], 2);
+    });
+
+    test('packs the bit stream LSB-first', () {
+      expect(compressed[14], 0xa8);
+      expect(compressed[15], 0x01);
+    });
+  });
+
+  group('edge cases', () {
+    test('empty input compresses to the 8-byte header', () {
+      final compressed = compress(Uint8List(0));
+      expect(compressed.length, 8);
+      expect(_readUint32BE(compressed, 0), 0);
+      expect(_readUint32BE(compressed, 4), 0);
+      expect(decompress(compressed), Uint8List(0));
+      expect(decompress(Uint8List(0)), Uint8List(0));
+    });
+
+    test('single distinct symbol uses a one-bit canonical code', () {
+      final compressed = compress(_ascii('AAAA'));
+      expect(_readUint32BE(compressed, 0), 4);
+      expect(_readUint32BE(compressed, 4), 1);
+      expect(compressed[8], 65);
+      expect(compressed[9], 1);
+      expect(_decodeAscii(decompress(compressed)), 'AAAA');
+    });
+  });
+
+  group('decoder validation', () {
+    test('rejects truncated headers', () {
+      expect(
+        () => decompress(Uint8List.fromList(<int>[0x00])),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('header is incomplete'),
+          ),
+        ),
+      );
+    });
+
+    test('rejects contradictory empty headers', () {
+      final bad = Uint8List(8);
+      ByteData.sublistView(bad).setUint32(4, 1, Endian.big);
+      expect(
+        () => decompress(bad),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('empty output cannot declare symbols'),
+          ),
+        ),
+      );
+    });
+
+    test('rejects symbol count zero for non-empty output', () {
+      final bad = Uint8List(8);
+      ByteData.sublistView(bad).setUint32(0, 1, Endian.big);
+      expect(
+        () => decompress(bad),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('requires at least one symbol'),
+          ),
+        ),
+      );
+    });
+
+    test('rejects symbol counts above the byte alphabet', () {
+      final bad = Uint8List(8);
+      final header = ByteData.sublistView(bad);
+      header.setUint32(0, 1, Endian.big);
+      header.setUint32(4, 257, Endian.big);
+      expect(
+        () => decompress(bad),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('exceeds the byte alphabet'),
+          ),
+        ),
+      );
+    });
+
+    test('rejects truncated code-length tables', () {
+      final bad = Uint8List(9);
+      final header = ByteData.sublistView(bad);
+      header.setUint32(0, 1, Endian.big);
+      header.setUint32(4, 1, Endian.big);
+      bad[8] = 65;
+      expect(
+        () => decompress(bad),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('code-length table is truncated'),
+          ),
+        ),
+      );
+    });
+
+    test('rejects code length 0', () {
+      final bad = Uint8List(10);
+      final header = ByteData.sublistView(bad);
+      header.setUint32(0, 1, Endian.big);
+      header.setUint32(4, 1, Endian.big);
+      bad[8] = 65;
+      bad[9] = 0;
+      expect(
+        () => decompress(bad),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('invalid code length 0'),
+          ),
+        ),
+      );
+    });
+
+    test('rejects code lengths above the CMP04 limit', () {
+      final bad = Uint8List(10);
+      final header = ByteData.sublistView(bad);
+      header.setUint32(0, 1, Endian.big);
+      header.setUint32(4, 1, Endian.big);
+      bad[8] = 65;
+      bad[9] = 17;
+      expect(
+        () => decompress(bad),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('exceeds 16'),
+          ),
+        ),
+      );
+    });
+
+    test('rejects duplicate symbols', () {
+      final bad = Uint8List(14);
+      final header = ByteData.sublistView(bad);
+      header.setUint32(0, 2, Endian.big);
+      header.setUint32(4, 2, Endian.big);
+      bad[8] = 65;
+      bad[9] = 1;
+      bad[10] = 65;
+      bad[11] = 1;
+      bad[12] = 0;
+      bad[13] = 0;
+      expect(
+        () => decompress(bad),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('duplicate symbol 65'),
+          ),
+        ),
+      );
+    });
+
+    test('rejects unsorted code-length tables', () {
+      final bad = Uint8List(14);
+      final header = ByteData.sublistView(bad);
+      header.setUint32(0, 2, Endian.big);
+      header.setUint32(4, 2, Endian.big);
+      bad[8] = 66;
+      bad[9] = 2;
+      bad[10] = 65;
+      bad[11] = 1;
+      bad[12] = 0;
+      bad[13] = 0;
+      expect(
+        () => decompress(bad),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('must be sorted by (length, symbol)'),
+          ),
+        ),
+      );
+    });
+
+    test('rejects incomplete canonical code spaces', () {
+      final bad = Uint8List(12);
+      final header = ByteData.sublistView(bad);
+      header.setUint32(0, 1, Endian.big);
+      header.setUint32(4, 2, Endian.big);
+      bad[8] = 65;
+      bad[9] = 1;
+      bad[10] = 66;
+      bad[11] = 3;
+      expect(
+        () => decompress(bad),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('do not form a complete prefix tree'),
+          ),
+        ),
+      );
+    });
+
+    test('rejects truncated bit streams', () {
+      final bad = Uint8List(10);
+      final header = ByteData.sublistView(bad);
+      header.setUint32(0, 10, Endian.big);
+      header.setUint32(4, 1, Endian.big);
+      bad[8] = 65;
+      bad[9] = 1;
+      expect(
+        () => decompress(bad),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('bit stream exhausted'),
+          ),
+        ),
+      );
+    });
+
+    test('rejects invalid prefixes that never match a code', () {
+      final bad = Uint8List(11);
+      final header = ByteData.sublistView(bad);
+      header.setUint32(0, 1, Endian.big);
+      header.setUint32(4, 1, Endian.big);
+      bad[8] = 65;
+      bad[9] = 1;
+      bad[10] = 0x01;
+      expect(
+        () => decompress(bad),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('matches no canonical code'),
+          ),
+        ),
+      );
+    });
+
+    test('rejects non-zero padding bits after the final symbol', () {
+      final bad = Uint8List(15);
+      final header = ByteData.sublistView(bad);
+      header.setUint32(0, 1, Endian.big);
+      header.setUint32(4, 1, Endian.big);
+      bad[8] = 65;
+      bad[9] = 1;
+      bad[14] = 0x02;
+      expect(
+        () => decompress(bad),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('padding bits must be zero'),
+          ),
+        ),
+      );
+    });
+
+    test('enforces the decompressed-size cap', () {
+      final bad = Uint8List(10);
+      final header = ByteData.sublistView(bad);
+      header.setUint32(0, 5, Endian.big);
+      header.setUint32(4, 1, Endian.big);
+      bad[8] = 65;
+      bad[9] = 1;
+      expect(
+        () => decompress(bad, 4),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('exceeds the configured limit 4'),
+          ),
+        ),
+      );
+    });
+
+    test('rejects non-positive decompressed-size caps', () {
+      expect(
+        () => decompress(Uint8List(0), 0),
+        throwsA(
+          isA<RangeError>().having(
+            (error) => error.message,
+            'message',
+            contains('Must be positive'),
+          ),
+        ),
+      );
+    });
+
+    test('rejects non-zero trailing bytes after finishing at a byte boundary',
+        () {
+      final bad = Uint8List(12);
+      final header = ByteData.sublistView(bad);
+      header.setUint32(0, 1, Endian.big);
+      header.setUint32(4, 1, Endian.big);
+      bad[8] = 65;
+      bad[9] = 1;
+      bad[10] = 0x00;
+      bad[11] = 0x80;
+      expect(
+        () => decompress(bad),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('padding bits must be zero'),
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/code/packages/dart/huffman-tree/.gitignore
+++ b/code/packages/dart/huffman-tree/.gitignore
@@ -1,0 +1,2 @@
+.dart_tool/
+pubspec.lock

--- a/code/packages/dart/huffman-tree/BUILD
+++ b/code/packages/dart/huffman-tree/BUILD
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/huffman-tree/CHANGELOG.md
+++ b/code/packages/dart/huffman-tree/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [0.1.0] - 2026-04-18
+
+### Added
+
+- Added the DT27 Huffman tree implementation for Dart.
+- Added deterministic tie-breaking, walk-based codes, canonical codes, and bit-string decoding.
+- Added validation-heavy tests for single-symbol, canonical, and tie-breaking edge cases.

--- a/code/packages/dart/huffman-tree/README.md
+++ b/code/packages/dart/huffman-tree/README.md
@@ -1,0 +1,36 @@
+# Huffman Tree
+
+Deterministic Huffman tree construction and canonical code tables for Dart.
+
+## What it does
+
+`coding_adventures_huffman_tree` implements DT27 in the Dart lane. It builds a
+full binary Huffman tree from `(symbol, frequency)` pairs, exposes the
+walk-based and canonical code tables, decodes bit strings back to symbols, and
+lets tests verify the core structural invariants.
+
+## Why it exists
+
+CMP04 Huffman compression depends on DT27 rather than rebuilding tree logic in
+every compression package. That keeps the layering honest:
+
+- `huffman-tree` owns deterministic tree construction and code derivation
+- `huffman-compression` owns the wire format and bit packing
+
+## Usage
+
+```dart
+import 'package:coding_adventures_huffman_tree/huffman_tree.dart';
+
+void main() {
+  final tree = HuffmanTree.build(<(int, int)>[(65, 3), (66, 2), (67, 1)]);
+  print(tree.codeTable());          // {65: 0, 67: 10, 66: 11}
+  print(tree.canonicalCodeTable()); // {65: 0, 66: 10, 67: 11}
+  print(tree.decodeAll('001011', 4)); // [65, 65, 67, 66]
+}
+```
+
+## How it fits in the stack
+
+This package is part of the Dart data-structure lane and serves as the
+foundation for Dart CMP04 Huffman compression.

--- a/code/packages/dart/huffman-tree/lib/huffman_tree.dart
+++ b/code/packages/dart/huffman-tree/lib/huffman_tree.dart
@@ -1,0 +1,3 @@
+library;
+
+export 'src/huffman_tree.dart';

--- a/code/packages/dart/huffman-tree/lib/src/huffman_tree.dart
+++ b/code/packages/dart/huffman-tree/lib/src/huffman_tree.dart
@@ -1,0 +1,455 @@
+/// DT27: Huffman tree construction with deterministic tie-breaking.
+///
+/// A Huffman tree gives each symbol a prefix-free bit string where common
+/// symbols get shorter codes than rare ones. The implementation here keeps the
+/// build deterministic across languages by using the spec's exact tie-break
+/// order:
+///
+/// 1. lower weight first
+/// 2. leaves before internal nodes at equal weight
+/// 3. lower symbol value first among equal-weight leaves
+/// 4. FIFO order among equal-weight internal nodes
+///
+/// That determinism matters because CMP04 Huffman compression stores only the
+/// canonical code lengths. If every language builds the same tree shape, every
+/// language also derives the same canonical table.
+
+/// A node in the Huffman tree.
+sealed class Node {
+  const Node();
+
+  /// The combined weight of this node's subtree.
+  int get weight;
+}
+
+/// A leaf node that stores one symbol and its frequency.
+final class Leaf extends Node {
+  const Leaf(this.symbol, this.weight);
+
+  /// Symbol value carried by this leaf.
+  final int symbol;
+
+  @override
+  final int weight;
+
+  @override
+  bool operator ==(Object other) =>
+      other is Leaf && other.symbol == symbol && other.weight == weight;
+
+  @override
+  int get hashCode => Object.hash(symbol, weight);
+
+  @override
+  String toString() => 'Leaf(symbol: $symbol, weight: $weight)';
+}
+
+/// An internal node created by merging two lighter subtrees.
+final class Internal extends Node {
+  const Internal({
+    required this.left,
+    required this.right,
+    required this.weight,
+    required this.order,
+  });
+
+  /// Left subtree, corresponding to a `'0'` edge while encoding.
+  final Node left;
+
+  /// Right subtree, corresponding to a `'1'` edge while encoding.
+  final Node right;
+
+  @override
+  final int weight;
+
+  /// Monotonic creation order used for FIFO tie-breaking.
+  final int order;
+
+  @override
+  bool operator ==(Object other) =>
+      other is Internal &&
+      other.left == left &&
+      other.right == right &&
+      other.weight == weight &&
+      other.order == order;
+
+  @override
+  int get hashCode => Object.hash(left, right, weight, order);
+
+  @override
+  String toString() =>
+      'Internal(weight: $weight, order: $order, left: $left, right: $right)';
+}
+
+/// Deterministic Huffman tree with helpers for code generation and decoding.
+final class HuffmanTree {
+  const HuffmanTree._(this._root, this._symbolCount);
+
+  final Node _root;
+  final int _symbolCount;
+
+  /// Build a Huffman tree from `(symbol, frequency)` pairs.
+  ///
+  /// Frequencies must be positive, and each symbol may appear at most once.
+  /// Duplicate symbols would create an invalid code table where one symbol had
+  /// multiple leaves, so the constructor rejects them up front.
+  static HuffmanTree build(List<(int, int)> weights) {
+    if (weights.isEmpty) {
+      throw ArgumentError('weights must not be empty');
+    }
+
+    final seenSymbols = <int>{};
+    final heap = _MinHeap<_HeapEntry>(_compareHeapEntries);
+    var orderCounter = 0;
+
+    for (final (symbol, frequency) in weights) {
+      if (frequency <= 0) {
+        throw ArgumentError(
+          'frequency must be positive; got symbol=$symbol, freq=$frequency',
+        );
+      }
+      if (!seenSymbols.add(symbol)) {
+        throw ArgumentError('symbol $symbol appears more than once');
+      }
+      heap.push(_HeapEntry.leaf(Leaf(symbol, frequency)));
+    }
+
+    while (heap.length > 1) {
+      final left = heap.pop().node;
+      final right = heap.pop().node;
+      final internal = Internal(
+        left: left,
+        right: right,
+        weight: left.weight + right.weight,
+        order: orderCounter,
+      );
+      orderCounter += 1;
+      heap.push(_HeapEntry.internal(internal));
+    }
+
+    return HuffmanTree._(heap.pop().node, weights.length);
+  }
+
+  /// Return `{symbol -> bit_string}` from a left=`0`, right=`1` tree walk.
+  ///
+  /// Single-symbol trees use `'0'` by convention. A zero-length code would be
+  /// mathematically valid, but one-bit codes keep the teaching examples and the
+  /// compression wire format straightforward.
+  Map<int, String> codeTable() {
+    final table = <int, String>{};
+    _walkTree(_root, '', table);
+    return Map<int, String>.unmodifiable(table);
+  }
+
+  /// Return the bit string for [symbol], or `null` if the symbol is absent.
+  String? codeFor(int symbol) => _findCode(_root, symbol, '');
+
+  /// Return the canonical Huffman code table.
+  ///
+  /// Canonical codes preserve the code lengths from the tree walk but normalize
+  /// the actual bit patterns so the decoder only needs `(symbol, length)` pairs
+  /// to reconstruct the table.
+  Map<int, String> canonicalCodeTable() {
+    final lengths = <int, int>{};
+    _collectLengths(_root, 0, lengths);
+
+    if (lengths.length == 1) {
+      final symbol = lengths.keys.single;
+      return Map<int, String>.unmodifiable(<int, String>{symbol: '0'});
+    }
+
+    final sorted = lengths.entries.toList()
+      ..sort(
+        (left, right) => left.value != right.value
+            ? left.value.compareTo(right.value)
+            : left.key.compareTo(right.key),
+      );
+
+    var codeValue = 0;
+    var previousLength = sorted.first.value;
+    final result = <int, String>{};
+
+    for (final entry in sorted) {
+      final length = entry.value;
+      if (length > previousLength) {
+        codeValue <<= length - previousLength;
+      }
+
+      result[entry.key] = codeValue.toRadixString(2).padLeft(length, '0');
+      codeValue += 1;
+      previousLength = length;
+    }
+
+    return Map<int, String>.unmodifiable(result);
+  }
+
+  /// Decode exactly [count] symbols from a bit string.
+  ///
+  /// The DT27 spec intentionally allows `decodeAll('', 1)` for a single-leaf
+  /// tree. The symbol is already known at the root, so the implementation emits
+  /// it and only consumes a `'0'` bit when one is present.
+  List<int> decodeAll(String bits, int count) {
+    if (count < 0)
+      throw RangeError.value(count, 'count', 'Must be non-negative.');
+
+    final result = <int>[];
+    var current = _root;
+    var position = 0;
+    final singleLeaf = _root is Leaf;
+
+    while (result.length < count) {
+      if (current is Leaf) {
+        result.add(current.symbol);
+        current = _root;
+        if (singleLeaf && position < bits.length) {
+          position += 1;
+        }
+        continue;
+      }
+
+      if (position >= bits.length) {
+        throw FormatException(
+          'Bit stream exhausted after ${result.length} symbols; expected $count.',
+        );
+      }
+
+      final bit = bits[position];
+      if (bit != '0' && bit != '1') {
+        throw FormatException(
+          'Bit stream must contain only 0 and 1 characters; got "$bit".',
+        );
+      }
+
+      position += 1;
+      final branch = current as Internal;
+      current = bit == '0' ? branch.left : branch.right;
+    }
+
+    return List<int>.unmodifiable(result);
+  }
+
+  /// Sum of all leaf frequencies.
+  int weight() => _root.weight;
+
+  /// Maximum depth among all leaves.
+  int depth() => _maxDepth(_root, 0);
+
+  /// Number of distinct symbols in the tree.
+  int symbolCount() => _symbolCount;
+
+  /// Leaves listed left-to-right alongside their walk-based codes.
+  List<(int, String)> leaves() {
+    final table = codeTable();
+    final result = <(int, String)>[];
+    _inOrderLeaves(_root, result, table);
+    return List<(int, String)>.unmodifiable(result);
+  }
+
+  /// Check the core DT27 invariants.
+  ///
+  /// This is primarily a testing helper:
+  /// - internal nodes must be full binary nodes
+  /// - internal weights must equal the sum of their children
+  /// - no symbol may appear more than once
+  /// - the stored symbol count must match the actual leaf count
+  bool isValid() {
+    final seenSymbols = <int>{};
+    final leafCount = _validateNode(_root, seenSymbols);
+    return leafCount == _symbolCount;
+  }
+}
+
+void _walkTree(Node node, String prefix, Map<int, String> table) {
+  if (node is Leaf) {
+    table[node.symbol] = prefix.isEmpty ? '0' : prefix;
+    return;
+  }
+
+  final branch = node as Internal;
+  _walkTree(branch.left, '${prefix}0', table);
+  _walkTree(branch.right, '${prefix}1', table);
+}
+
+String? _findCode(Node node, int symbol, String prefix) {
+  if (node is Leaf) {
+    return node.symbol == symbol ? (prefix.isEmpty ? '0' : prefix) : null;
+  }
+
+  final branch = node as Internal;
+  final left = _findCode(branch.left, symbol, '${prefix}0');
+  return left ?? _findCode(branch.right, symbol, '${prefix}1');
+}
+
+void _collectLengths(Node node, int depth, Map<int, int> lengths) {
+  if (node is Leaf) {
+    lengths[node.symbol] = depth == 0 ? 1 : depth;
+    return;
+  }
+
+  final branch = node as Internal;
+  _collectLengths(branch.left, depth + 1, lengths);
+  _collectLengths(branch.right, depth + 1, lengths);
+}
+
+int _maxDepth(Node node, int depth) {
+  if (node is Leaf) {
+    return depth;
+  }
+
+  final branch = node as Internal;
+  final leftDepth = _maxDepth(branch.left, depth + 1);
+  final rightDepth = _maxDepth(branch.right, depth + 1);
+  return leftDepth > rightDepth ? leftDepth : rightDepth;
+}
+
+void _inOrderLeaves(
+  Node node,
+  List<(int, String)> result,
+  Map<int, String> table,
+) {
+  if (node is Leaf) {
+    result.add((node.symbol, table[node.symbol]!));
+    return;
+  }
+
+  final branch = node as Internal;
+  _inOrderLeaves(branch.left, result, table);
+  _inOrderLeaves(branch.right, result, table);
+}
+
+int _validateNode(Node node, Set<int> seenSymbols) {
+  if (node is Leaf) {
+    return seenSymbols.add(node.symbol) ? 1 : -1;
+  }
+
+  final branch = node as Internal;
+  final leftLeaves = _validateNode(branch.left, seenSymbols);
+  if (leftLeaves < 0) return -1;
+
+  final rightLeaves = _validateNode(branch.right, seenSymbols);
+  if (rightLeaves < 0) return -1;
+
+  if (branch.weight != branch.left.weight + branch.right.weight) return -1;
+
+  return leftLeaves + rightLeaves;
+}
+
+final class _HeapEntry {
+  const _HeapEntry._({
+    required this.weight,
+    required this.isInternal,
+    required this.symbolOrMax,
+    required this.orderOrMax,
+    required this.node,
+  });
+
+  factory _HeapEntry.leaf(Leaf leaf) {
+    return _HeapEntry._(
+      weight: leaf.weight,
+      isInternal: 0,
+      symbolOrMax: leaf.symbol,
+      orderOrMax: _maxSentinel,
+      node: leaf,
+    );
+  }
+
+  factory _HeapEntry.internal(Internal internal) {
+    return _HeapEntry._(
+      weight: internal.weight,
+      isInternal: 1,
+      symbolOrMax: _maxSentinel,
+      orderOrMax: internal.order,
+      node: internal,
+    );
+  }
+
+  final int weight;
+  final int isInternal;
+  final int symbolOrMax;
+  final int orderOrMax;
+  final Node node;
+}
+
+const int _maxSentinel = 1 << 30;
+
+int _compareHeapEntries(_HeapEntry left, _HeapEntry right) {
+  if (left.weight != right.weight) {
+    return left.weight.compareTo(right.weight);
+  }
+  if (left.isInternal != right.isInternal) {
+    return left.isInternal.compareTo(right.isInternal);
+  }
+  if (left.symbolOrMax != right.symbolOrMax) {
+    return left.symbolOrMax.compareTo(right.symbolOrMax);
+  }
+  return left.orderOrMax.compareTo(right.orderOrMax);
+}
+
+/// Tiny binary min-heap used only inside tree construction.
+///
+/// The Dart lane does not yet have a shared heap package, so DT27 keeps the
+/// priority queue local and intentionally small.
+final class _MinHeap<T> {
+  _MinHeap(this._compare);
+
+  final int Function(T left, T right) _compare;
+  final List<T> _values = <T>[];
+
+  int get length => _values.length;
+
+  void push(T value) {
+    _values.add(value);
+    _bubbleUp(_values.length - 1);
+  }
+
+  T pop() {
+    if (_values.isEmpty) throw StateError('Cannot pop from an empty heap.');
+
+    final first = _values.first;
+    final last = _values.removeLast();
+    if (_values.isNotEmpty) {
+      _values[0] = last;
+      _bubbleDown(0);
+    }
+    return first;
+  }
+
+  void _bubbleUp(int index) {
+    var current = index;
+    while (current > 0) {
+      final parent = (current - 1) ~/ 2;
+      if (_compare(_values[current], _values[parent]) >= 0) {
+        return;
+      }
+      final temporary = _values[current];
+      _values[current] = _values[parent];
+      _values[parent] = temporary;
+      current = parent;
+    }
+  }
+
+  void _bubbleDown(int index) {
+    var current = index;
+    while (true) {
+      final left = current * 2 + 1;
+      final right = left + 1;
+      var smallest = current;
+
+      if (left < _values.length &&
+          _compare(_values[left], _values[smallest]) < 0) {
+        smallest = left;
+      }
+      if (right < _values.length &&
+          _compare(_values[right], _values[smallest]) < 0) {
+        smallest = right;
+      }
+      if (smallest == current) {
+        return;
+      }
+
+      final temporary = _values[current];
+      _values[current] = _values[smallest];
+      _values[smallest] = temporary;
+      current = smallest;
+    }
+  }
+}

--- a/code/packages/dart/huffman-tree/pubspec.yaml
+++ b/code/packages/dart/huffman-tree/pubspec.yaml
@@ -1,0 +1,14 @@
+name: coding_adventures_huffman_tree
+description: >
+  Deterministic Huffman tree construction and canonical code tables for Dart.
+version: 0.1.0
+repository: https://github.com/adhithyan15/coding-adventures
+publish_to: none
+
+environment:
+  sdk: ^3.0.0
+
+dependencies: {}
+
+dev_dependencies:
+  test: ^1.25.0

--- a/code/packages/dart/huffman-tree/test/huffman_tree_test.dart
+++ b/code/packages/dart/huffman-tree/test/huffman_tree_test.dart
@@ -1,0 +1,213 @@
+import 'package:coding_adventures_huffman_tree/huffman_tree.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('HuffmanTree.build validation', () {
+    test('rejects empty weights', () {
+      expect(
+        () => HuffmanTree.build(<(int, int)>[]),
+        throwsA(
+          isA<ArgumentError>().having(
+            (error) => error.message,
+            'message',
+            'weights must not be empty',
+          ),
+        ),
+      );
+    });
+
+    test('rejects non-positive frequencies', () {
+      expect(
+        () => HuffmanTree.build(<(int, int)>[(42, 0)]),
+        throwsA(
+          isA<ArgumentError>().having(
+            (error) => error.message,
+            'message',
+            contains('symbol=42, freq=0'),
+          ),
+        ),
+      );
+    });
+
+    test('rejects duplicate symbols', () {
+      expect(
+        () => HuffmanTree.build(<(int, int)>[(65, 2), (65, 1)]),
+        throwsA(
+          isA<ArgumentError>().having(
+            (error) => error.message,
+            'message',
+            contains('symbol 65 appears more than once'),
+          ),
+        ),
+      );
+    });
+  });
+
+  group('single-symbol tree', () {
+    final tree = HuffmanTree.build(<(int, int)>[(65, 5)]);
+
+    test('reports basic inspection values', () {
+      expect(tree.symbolCount(), 1);
+      expect(tree.weight(), 5);
+      expect(tree.depth(), 0);
+      expect(tree.isValid(), isTrue);
+    });
+
+    test('uses 0 for both walk and canonical tables', () {
+      expect(tree.codeTable(), <int, String>{65: '0'});
+      expect(tree.canonicalCodeTable(), <int, String>{65: '0'});
+      expect(tree.codeFor(65), '0');
+      expect(tree.codeFor(99), isNull);
+    });
+
+    test('decodes repeated symbols, even with an empty bit string', () {
+      expect(tree.decodeAll('000', 3), <int>[65, 65, 65]);
+      expect(tree.decodeAll('', 1), <int>[65]);
+    });
+
+    test('returns the in-order leaves', () {
+      expect(tree.leaves(), <(int, String)>[(65, '0')]);
+    });
+  });
+
+  test('Leaf and Internal value types expose stable equality and text', () {
+    const left = Leaf(65, 3);
+    const right = Leaf(66, 2);
+    const internalA = Internal(left: left, right: right, weight: 5, order: 7);
+    const internalB = Internal(left: left, right: right, weight: 5, order: 7);
+
+    expect(left, const Leaf(65, 3));
+    expect(left.hashCode, const Leaf(65, 3).hashCode);
+    expect(left.toString(), 'Leaf(symbol: 65, weight: 3)');
+    expect(internalA, internalB);
+    expect(internalA.hashCode, internalB.hashCode);
+    expect(
+      internalA.toString(),
+      'Internal(weight: 5, order: 7, left: Leaf(symbol: 65, weight: 3), right: Leaf(symbol: 66, weight: 2))',
+    );
+  });
+
+  group('AAABBC example', () {
+    final tree = HuffmanTree.build(<(int, int)>[(65, 3), (66, 2), (67, 1)]);
+
+    test('builds the expected deterministic walk table', () {
+      expect(tree.symbolCount(), 3);
+      expect(tree.weight(), 6);
+      expect(tree.depth(), 2);
+      expect(tree.codeTable(), <int, String>{65: '0', 67: '10', 66: '11'});
+      expect(tree.codeFor(67), '10');
+      expect(tree.codeFor(66), '11');
+      expect(tree.codeFor(99), isNull);
+    });
+
+    test('builds the expected canonical table', () {
+      expect(tree.canonicalCodeTable(), <int, String>{
+        65: '0',
+        66: '10',
+        67: '11',
+      });
+    });
+
+    test('decodes the expected symbol sequence', () {
+      expect(tree.decodeAll('001011', 4), <int>[65, 65, 67, 66]);
+      expect(
+        () => tree.decodeAll('1', 1),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('Bit stream exhausted'),
+          ),
+        ),
+      );
+    });
+
+    test('lists leaves in-order and validates structure', () {
+      expect(tree.leaves(), <(int, String)>[(65, '0'), (67, '10'), (66, '11')]);
+      expect(tree.isValid(), isTrue);
+    });
+  });
+
+  group('tie-breaking', () {
+    test('prefers leaves over internal nodes at equal weight', () {
+      final tree = HuffmanTree.build(<(int, int)>[(65, 1), (66, 1), (67, 2)]);
+      expect(tree.codeTable(), <int, String>{67: '0', 65: '10', 66: '11'});
+    });
+
+    test('prefers lower symbols among equal-weight leaves', () {
+      final tree = HuffmanTree.build(<(int, int)>[(66, 1), (65, 1)]);
+      expect(tree.codeFor(65), '0');
+      expect(tree.codeFor(66), '1');
+    });
+
+    test('uses FIFO order for equal-weight internal nodes', () {
+      final tree = HuffmanTree.build(<(int, int)>[
+        (65, 1),
+        (66, 1),
+        (67, 1),
+        (68, 1),
+      ]);
+      expect(tree.codeTable(), <int, String>{
+        65: '00',
+        66: '01',
+        67: '10',
+        68: '11',
+      });
+      expect(tree.canonicalCodeTable(), tree.codeTable());
+    });
+  });
+
+  test('larger trees remain prefix-free and round-trip through decodeAll', () {
+    final tree = HuffmanTree.build(<(int, int)>[
+      (65, 15),
+      (66, 7),
+      (67, 6),
+      (68, 6),
+      (69, 5),
+    ]);
+    final table = tree.codeTable();
+    final codes = table.values.toList();
+
+    for (var left = 0; left < codes.length; left += 1) {
+      for (var right = 0; right < codes.length; right += 1) {
+        if (left == right) {
+          continue;
+        }
+        expect(codes[right].startsWith(codes[left]), isFalse);
+      }
+    }
+
+    final message = <int>[65, 65, 66, 67, 69];
+    final bits = message.map((symbol) => table[symbol]!).join();
+    expect(tree.decodeAll(bits, message.length), message);
+    expect(tree.isValid(), isTrue);
+  });
+
+  test('decodeAll rejects characters other than 0 and 1', () {
+    final tree = HuffmanTree.build(<(int, int)>[(65, 2), (66, 1)]);
+    expect(
+      () => tree.decodeAll('2', 1),
+      throwsA(
+        isA<FormatException>().having(
+          (error) => error.message,
+          'message',
+          contains('must contain only 0 and 1'),
+        ),
+      ),
+    );
+  });
+
+  test('decodeAll rejects negative counts', () {
+    final tree = HuffmanTree.build(<(int, int)>[(65, 1)]);
+    expect(
+      () => tree.decodeAll('0', -1),
+      throwsA(
+        isA<RangeError>().having(
+          (error) => error.message,
+          'message',
+          contains('Must be non-negative'),
+        ),
+      ),
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- add Dart `huffman-tree` implementing DT27 with deterministic tie-breaking, walk-based codes, canonical codes, and decode helpers
- add Dart `huffman-compression` implementing CMP04 with canonical code-length headers, LSB-first bit packing, and strict decoder validation
- add package docs, changelogs, BUILD files, and comprehensive tests for both packages

## Verification
- `/tmp/dart-sdk-install/dart-sdk/bin/dart test` in `code/packages/dart/huffman-tree`
- `/tmp/dart-sdk-install/dart-sdk/bin/dart test --coverage=coverage && /tmp/dart-sdk-install/dart-sdk/bin/dart run coverage:format_coverage --packages=.dart_tool/package_config.json --report-on=lib --lcov --in=coverage --out=coverage/lcov.info` in `code/packages/dart/huffman-tree` (`100.00%` lib coverage)
- `/tmp/dart-sdk-install/dart-sdk/bin/dart test` in `code/packages/dart/huffman-compression`
- `/tmp/dart-sdk-install/dart-sdk/bin/dart test --coverage=coverage && /tmp/dart-sdk-install/dart-sdk/bin/dart run coverage:format_coverage --packages=.dart_tool/package_config.json --report-on=lib --lcov --in=coverage --out=coverage/lcov.info` in `code/packages/dart/huffman-compression` (`98.00%` lib coverage)

## Security
- security review passed in 1 round with no findings