### PR TITLE
feat(lexer-parser): preserve optional rich source info

### DIFF
--- a/code/packages/typescript/lexer/CHANGELOG.md
+++ b/code/packages/typescript/lexer/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.3.0] - 2026-04-18
+
+### Added
+
+- Optional rich source preservation for `GrammarLexer` and `grammarTokenize()`
+  via `{ preserveSourceInfo: true }`.
+- `Trivia` type for preserved skip matches such as whitespace and comments.
+- Optional token metadata fields:
+  - `startOffset` / `endOffset`
+  - `endLine` / `endColumn`
+  - `tokenIndex`
+  - `leadingTrivia`
+- `typeName?: string` on `Token` so layout-mode virtual tokens and similar
+  source-preserving callers can remain type-safe.
+
 ## [0.2.0] - 2026-03-21
 
 ### Added

--- a/code/packages/typescript/lexer/README.md
+++ b/code/packages/typescript/lexer/README.md
@@ -13,6 +13,8 @@ NAME("x")  EQUALS("=")  NUMBER("1")  PLUS("+")  NUMBER("2")  EOF
 ```
 
 Each token has a **type** (what kind of thing it is), a **value** (the actual text), and a **position** (line and column numbers for error reporting).
+Formatter-oriented callers can also opt into richer source preservation so
+comments, whitespace, and exact offsets survive lexing.
 
 ## Two Lexer Implementations
 
@@ -45,6 +47,11 @@ import { grammarTokenize } from "@coding-adventures/lexer";
 
 const grammar = parseTokenGrammar(readFileSync("python.tokens", "utf-8"));
 const tokens = grammarTokenize("x = 1 + 2", grammar);
+
+// Rich source mode for formatter pipelines:
+const richTokens = grammarTokenize("  // lead\nx = 1", grammar, {
+  preserveSourceInfo: true,
+});
 ```
 
 ## Token Format
@@ -57,8 +64,19 @@ interface Token {
   value: string;   // e.g., "x", "42", "+", "if"
   line: number;    // 1-based line number
   column: number;  // 1-based column number
+  // Optional in rich source mode:
+  startOffset?: number;
+  endOffset?: number;
+  endLine?: number;
+  endColumn?: number;
+  tokenIndex?: number;
+  leadingTrivia?: Trivia[];
 }
 ```
+
+When `preserveSourceInfo` is enabled on `GrammarLexer` or `grammarTokenize()`,
+the lexer also preserves named skip matches as `Trivia` values attached to the
+next emitted token.
 
 ## How It Fits in the Stack
 

--- a/code/packages/typescript/lexer/src/grammar-lexer.ts
+++ b/code/packages/typescript/lexer/src/grammar-lexer.ts
@@ -56,7 +56,7 @@
 
 import type { TokenGrammar } from "@coding-adventures/grammar-tools";
 
-import type { Token } from "./token.js";
+import type { Token, Trivia } from "./token.js";
 import { TOKEN_CONTEXT_KEYWORD } from "./token.js";
 import { LexerError } from "./tokenizer.js";
 
@@ -191,6 +191,10 @@ function processEscapes(s: string): string {
  * - The EOF token
  */
 export type OnTokenCallback = (token: Token, ctx: LexerContext) => void;
+
+export interface GrammarLexerOptions {
+  readonly preserveSourceInfo?: boolean;
+}
 
 // ---------------------------------------------------------------------------
 // Lexer Context — Callback Interface for Group Transitions
@@ -544,7 +548,7 @@ export class GrammarLexer {
   private readonly _patterns: CompiledPattern[];
 
   /** Compiled skip patterns (comments, whitespace). */
-  private readonly _skipPatterns: RegExp[];
+  private readonly _skipPatterns: CompiledPattern[];
 
   /** Compiled patterns per group. "default" + named groups. */
   private readonly _groupPatterns: Record<string, CompiledPattern[]>;
@@ -613,8 +617,18 @@ export class GrammarLexer {
   /** Post-tokenize hooks: transform token list after lexing. */
   private _postTokenizeHooks: Array<(tokens: Token[]) => Token[]> = [];
 
-  constructor(source: string, grammar: TokenGrammar) {
+  /** Whether token/trivia source metadata should be preserved. */
+  private readonly _preserveSourceInfo: boolean;
+
+  /** Trivia collected since the previous emitted token. */
+  private _pendingTrivia: Trivia[] = [];
+
+  /** Sequential token index assigned in emission order. */
+  private _nextTokenIndex: number = 0;
+
+  constructor(source: string, grammar: TokenGrammar, options?: GrammarLexerOptions) {
     this._grammar = grammar;
+    this._preserveSourceInfo = options?.preserveSourceInfo === true;
     this._caseInsensitive = grammar.caseInsensitive === true;
     this._caseSensitive = grammar.caseSensitive !== false && !this._caseInsensitive;
     // Only lowercase the source for the legacy caseSensitive:false pattern-level mode.
@@ -670,7 +684,10 @@ export class GrammarLexer {
     // These are tried before token patterns at each position.
     this._skipPatterns = (grammar.skipDefinitions ?? []).map((defn) => {
       const patternSource = defn.isRegex ? defn.pattern : escapeRegExp(defn.pattern);
-      return new RegExp(patternSource, reFlags);
+      return {
+        name: defn.name,
+        pattern: new RegExp(patternSource, reFlags),
+      };
     });
 
     // --- Pattern groups ---
@@ -814,6 +831,8 @@ export class GrammarLexer {
     // Reset extension state for reuse.
     this._lastEmittedToken = null;
     this._bracketDepths = { paren: 0, bracket: 0, brace: 0 };
+    this._pendingTrivia = [];
+    this._nextTokenIndex = 0;
 
     // Stage 2: Core tokenization.
     let tokens: Token[];
@@ -874,7 +893,7 @@ export class GrammarLexer {
         // Without skip patterns, use the hardcoded behavior: skip
         // spaces, tabs, carriage returns silently.
         if (char === " " || char === "\t" || char === "\r") {
-          this._advance();
+          this._consumeDefaultWhitespace();
           continue;
         }
       }
@@ -888,9 +907,9 @@ export class GrammarLexer {
           line: this._line,
           column: this._column,
         };
-        tokens.push(newlineTok);
-        this._lastEmittedToken = newlineTok;
+        const startOffset = this._pos;
         this._advance();
+        this._emitToken(tokens, this._withOptionalSourceInfo(newlineTok, startOffset));
         continue;
       }
 
@@ -921,14 +940,12 @@ export class GrammarLexer {
           // Apply suppression: if the callback suppressed this
           // token, don't add it to the output.
           if (!ctx._suppressed) {
-            tokens.push(token);
-            this._lastEmittedToken = token;
+            this._emitToken(tokens, token);
           }
 
           // Append any tokens emitted by the callback.
           for (const emitted of ctx._emitted) {
-            tokens.push(emitted);
-            this._lastEmittedToken = emitted;
+            this._emitToken(tokens, emitted);
           }
 
           // Apply group stack actions in order.
@@ -945,8 +962,7 @@ export class GrammarLexer {
             this._skipEnabled = ctx._skipEnabled;
           }
         } else {
-          tokens.push(token);
-          this._lastEmittedToken = token;
+          this._emitToken(tokens, token);
         }
         continue;
       }
@@ -959,12 +975,13 @@ export class GrammarLexer {
     }
 
     // --- Append EOF sentinel ---
-    tokens.push({
+    const eof: Token = {
       type: "EOF",
       value: "",
       line: this._line,
       column: this._column,
-    });
+    };
+    this._emitToken(tokens, this._withOptionalSourceInfo(eof, this._pos));
 
     // Reset group stack and skip flag for reuse (in case tokenize is
     // called again on the same instance).
@@ -1017,7 +1034,9 @@ export class GrammarLexer {
         if (result === "skip") {
           continue;
         }
-        tokens.push(...result);
+        for (const token of result) {
+          this._emitToken(tokens, token);
+        }
         atLineStart = false;
         if (this._pos >= this._source.length) {
           break;
@@ -1029,14 +1048,18 @@ export class GrammarLexer {
       // Newline handling
       if (char === "\n") {
         if (bracketDepth === 0) {
-          tokens.push({
+          const newlineTok: Token = {
             type: "NEWLINE",
             value: "\\n",
             line: this._line,
             column: this._column,
-          });
+          };
+          const startOffset = this._pos;
+          this._advance();
+          this._emitToken(tokens, this._withOptionalSourceInfo(newlineTok, startOffset));
+        } else {
+          this._advance();
         }
-        this._advance();
         atLineStart = true;
         continue;
       }
@@ -1046,7 +1069,7 @@ export class GrammarLexer {
         bracketDepth > 0 &&
         (char === " " || char === "\t" || char === "\r")
       ) {
-        this._advance();
+        this._consumeDefaultWhitespace();
         continue;
       }
 
@@ -1070,8 +1093,7 @@ export class GrammarLexer {
         }
         // Track bracket depth (shared for callback access)
         this._updateBracketDepth(tok.value);
-        tokens.push(tok);
-        this._lastEmittedToken = tok;
+        this._emitToken(tokens, tok);
         continue;
       }
 
@@ -1085,12 +1107,12 @@ export class GrammarLexer {
     // EOF: emit remaining DEDENTs
     while (indentStack.length > 1) {
       indentStack.pop();
-      tokens.push({
+      this._emitToken(tokens, this._withOptionalSourceInfo({
         type: "DEDENT",
         value: "",
         line: this._line,
         column: this._column,
-      });
+      }, this._pos));
     }
 
     // Final NEWLINE if needed
@@ -1098,20 +1120,20 @@ export class GrammarLexer {
       tokens.length === 0 ||
       tokens[tokens.length - 1].type !== "NEWLINE"
     ) {
-      tokens.push({
+      this._emitToken(tokens, this._withOptionalSourceInfo({
         type: "NEWLINE",
         value: "\\n",
         line: this._line,
         column: this._column,
-      });
+      }, this._pos));
     }
 
-    tokens.push({
+    this._emitToken(tokens, this._withOptionalSourceInfo({
       type: "EOF",
       value: "",
       line: this._line,
       column: this._column,
-    });
+    }, this._pos));
 
     // Reset group stack for reuse.
     this._groupStack = ["default"];
@@ -1205,13 +1227,13 @@ export class GrammarLexer {
   }
 
   private _virtualLayoutToken(typeName: string, value: string, anchor: Token): Token {
-    return {
+    return this._withOptionalSourceInfo({
       type: typeName,
       typeName,
       value,
       line: anchor.line,
       column: anchor.column,
-    };
+    }, anchor.startOffset ?? this._pos);
   }
 
   private _isVirtualLayoutToken(token: Token): boolean {
@@ -1234,6 +1256,9 @@ export class GrammarLexer {
    */
   private _processLineStart(indentStack: number[]): "skip" | Token[] {
     let indent = 0;
+    const indentStartLine = this._line;
+    const indentStartColumn = this._column;
+    const indentStartOffset = this._pos;
     while (this._pos < this._source.length) {
       const char = this._source[this._pos];
       if (char === " ") {
@@ -1250,33 +1275,73 @@ export class GrammarLexer {
       }
     }
 
+    if (indent > 0 && this._preserveSourceInfo) {
+      this._pushTrivia(
+        "WHITESPACE",
+        this._source.slice(indentStartOffset, this._pos),
+        indentStartLine,
+        indentStartColumn,
+        indentStartOffset,
+      );
+    }
+
     // Blank line or EOF
     if (this._pos >= this._source.length) {
       return "skip";
     }
     if (this._source[this._pos] === "\n") {
+      const newlineStartLine = this._line;
+      const newlineStartColumn = this._column;
+      const newlineStartOffset = this._pos;
       this._advance(); // Consume newline to avoid infinite loop
+      this._pushTrivia(
+        "NEWLINE",
+        "\n",
+        newlineStartLine,
+        newlineStartColumn,
+        newlineStartOffset,
+      );
       return "skip";
     }
 
     // Comment-only line — check skip patterns
     const remaining = this._source.slice(this._pos);
     for (const pat of this._skipPatterns) {
-      const match = pat.exec(remaining);
+      const match = pat.pattern.exec(remaining);
       if (match !== null && match.index === 0) {
         const peekPos = this._pos + match[0].length;
         if (
           peekPos >= this._source.length ||
           this._source[peekPos] === "\n"
         ) {
+          const triviaStartLine = this._line;
+          const triviaStartColumn = this._column;
+          const triviaStartOffset = this._pos;
           for (let i = 0; i < match[0].length; i++) {
             this._advance();
           }
+          this._pushTrivia(
+            pat.name,
+            match[0],
+            triviaStartLine,
+            triviaStartColumn,
+            triviaStartOffset,
+          );
           if (
             this._pos < this._source.length &&
             this._source[this._pos] === "\n"
           ) {
+            const newlineStartLine = this._line;
+            const newlineStartColumn = this._column;
+            const newlineStartOffset = this._pos;
             this._advance();
+            this._pushTrivia(
+              "NEWLINE",
+              "\n",
+              newlineStartLine,
+              newlineStartColumn,
+              newlineStartOffset,
+            );
           }
           return "skip";
         }
@@ -1289,24 +1354,24 @@ export class GrammarLexer {
 
     if (indent > currentIndent) {
       indentStack.push(indent);
-      indentTokens.push({
+      indentTokens.push(this._withOptionalSourceInfo({
         type: "INDENT",
         value: "",
         line: this._line,
         column: 1,
-      });
+      }, this._pos));
     } else if (indent < currentIndent) {
       while (
         indentStack.length > 1 &&
         indentStack[indentStack.length - 1] > indent
       ) {
         indentStack.pop();
-        indentTokens.push({
+        indentTokens.push(this._withOptionalSourceInfo({
           type: "DEDENT",
           value: "",
           line: this._line,
           column: 1,
-        });
+        }, this._pos));
       }
       if (indentStack[indentStack.length - 1] !== indent) {
         throw new LexerError(
@@ -1334,11 +1399,15 @@ export class GrammarLexer {
   private _trySkip(): boolean {
     const remaining = this._source.slice(this._pos);
     for (const pat of this._skipPatterns) {
-      const match = pat.exec(remaining);
+      const match = pat.pattern.exec(remaining);
       if (match !== null && match.index === 0) {
+        const startLine = this._line;
+        const startColumn = this._column;
+        const startOffset = this._pos;
         for (let i = 0; i < match[0].length; i++) {
           this._advance();
         }
+        this._pushTrivia(pat.name, match[0], startLine, startColumn, startOffset);
         return true;
       }
     }
@@ -1365,6 +1434,7 @@ export class GrammarLexer {
         let value = match[0];
         const startLine = this._line;
         const startColumn = this._column;
+        const startOffset = this._pos;
 
         // For case-insensitive grammars, normalize NAME tokens to uppercase for
         // keyword lookup. Keywords are stored uppercase in _keywordSet.
@@ -1441,10 +1511,83 @@ export class GrammarLexer {
           this._advance();
         }
 
-        return tok;
+        return this._withOptionalSourceInfo(tok, startOffset);
       }
     }
     return null;
+  }
+
+  private _consumeDefaultWhitespace(): void {
+    const startLine = this._line;
+    const startColumn = this._column;
+    const startOffset = this._pos;
+    while (this._pos < this._source.length) {
+      const char = this._source[this._pos];
+      if (char !== " " && char !== "\t" && char !== "\r") {
+        break;
+      }
+      this._advance();
+    }
+    if (this._pos > startOffset) {
+      this._pushTrivia(
+        "WHITESPACE",
+        this._source.slice(startOffset, this._pos),
+        startLine,
+        startColumn,
+        startOffset,
+      );
+    }
+  }
+
+  private _pushTrivia(
+    type: string,
+    value: string,
+    line: number,
+    column: number,
+    startOffset: number,
+  ): void {
+    if (!this._preserveSourceInfo) {
+      return;
+    }
+    this._pendingTrivia.push({
+      type,
+      value,
+      line,
+      column,
+      endLine: this._line,
+      endColumn: this._column,
+      startOffset,
+      endOffset: this._pos,
+    });
+  }
+
+  private _withOptionalSourceInfo(token: Token, startOffset: number): Token {
+    if (!this._preserveSourceInfo) {
+      return token;
+    }
+    return {
+      ...token,
+      startOffset,
+      endOffset: this._pos,
+      endLine: this._line,
+      endColumn: this._column,
+    };
+  }
+
+  private _emitToken(tokens: Token[], token: Token): void {
+    let finalized = token;
+    if (this._preserveSourceInfo) {
+      finalized = {
+        ...token,
+        tokenIndex: this._nextTokenIndex++,
+        ...(this._pendingTrivia.length > 0
+          ? { leadingTrivia: [...this._pendingTrivia] }
+          : {}),
+      };
+      this._pendingTrivia = [];
+    }
+    tokens.push(finalized);
+    this._lastEmittedToken = finalized;
   }
 
   /**
@@ -1488,6 +1631,7 @@ export class GrammarLexer {
 export function grammarTokenize(
   source: string,
   grammar: TokenGrammar,
+  options?: GrammarLexerOptions,
 ): Token[] {
-  return new GrammarLexer(source, grammar).tokenize();
+  return new GrammarLexer(source, grammar, options).tokenize();
 }

--- a/code/packages/typescript/lexer/src/index.ts
+++ b/code/packages/typescript/lexer/src/index.ts
@@ -43,7 +43,7 @@
  *     const tokens = lexer.tokenize();
  */
 
-export type { Token } from "./token.js";
+export type { Token, Trivia } from "./token.js";
 export {
   TOKEN_PRECEDED_BY_NEWLINE,
   TOKEN_CONTEXT_KEYWORD,
@@ -51,4 +51,4 @@ export {
 export { tokenize, LexerError } from "./tokenizer.js";
 export type { LexerConfig } from "./tokenizer.js";
 export { grammarTokenize, GrammarLexer, LexerContext } from "./grammar-lexer.js";
-export type { OnTokenCallback } from "./grammar-lexer.js";
+export type { OnTokenCallback, GrammarLexerOptions } from "./grammar-lexer.js";

--- a/code/packages/typescript/lexer/src/token.ts
+++ b/code/packages/typescript/lexer/src/token.ts
@@ -60,12 +60,30 @@
  *   line: The 1-based line number where this token starts.
  *   column: The 1-based column number where this token starts.
  */
+export interface Trivia {
+  readonly type: string;
+  readonly value: string;
+  readonly line: number;
+  readonly column: number;
+  readonly endLine: number;
+  readonly endColumn: number;
+  readonly startOffset: number;
+  readonly endOffset: number;
+}
+
 export interface Token {
   readonly type: string;
   readonly value: string;
   readonly line: number;
   readonly column: number;
+  readonly typeName?: string;
   readonly flags?: number;
+  readonly endLine?: number;
+  readonly endColumn?: number;
+  readonly startOffset?: number;
+  readonly endOffset?: number;
+  readonly tokenIndex?: number;
+  readonly leadingTrivia?: readonly Trivia[];
 }
 
 // ---------------------------------------------------------------------------

--- a/code/packages/typescript/lexer/tests/grammar-lexer.test.ts
+++ b/code/packages/typescript/lexer/tests/grammar-lexer.test.ts
@@ -1199,3 +1199,122 @@ describe("GrammarLexer — case-insensitive keywords", () => {
     expect(tokens2[0].value).toBe("select");
   });
 });
+
+// ============================================================================
+// Rich source info tests
+// ============================================================================
+
+function makeRichSourceGrammar(): TokenGrammar {
+  return {
+    definitions: [
+      { name: "NAME", pattern: "[a-zA-Z_][a-zA-Z0-9_]*", isRegex: true, lineNumber: 1 },
+      { name: "EQ", pattern: "=", isRegex: false, lineNumber: 2 },
+    ],
+    keywords: [],
+    skipDefinitions: [
+      { name: "WHITESPACE", pattern: "[ \\t\\r\\n]+", isRegex: true, lineNumber: 3 },
+      { name: "LINE_COMMENT", pattern: "\\/\\/[^\\n]*", isRegex: true, lineNumber: 4 },
+    ],
+    version: 0,
+    caseInsensitive: false,
+  };
+}
+
+describe("GrammarLexer — rich source preservation", () => {
+  it("keeps the default path lean when preserveSourceInfo is disabled", () => {
+    const grammar = makeRichSourceGrammar();
+    const tokens = grammarTokenize("foo=bar", grammar);
+    expect(tokens[0].startOffset).toBeUndefined();
+    expect(tokens[0].leadingTrivia).toBeUndefined();
+    expect(tokens[0].tokenIndex).toBeUndefined();
+  });
+
+  it("attaches leading trivia, offsets, and token indices when enabled", () => {
+    const grammar = makeRichSourceGrammar();
+    const tokens = grammarTokenize(
+      "  // lead\nfoo=bar",
+      grammar,
+      { preserveSourceInfo: true },
+    );
+
+    expect(tokens.map((token) => token.type)).toEqual(["NAME", "EQ", "NAME", "EOF"]);
+
+    expect(tokens[0].tokenIndex).toBe(0);
+    expect(tokens[1].tokenIndex).toBe(1);
+    expect(tokens[2].tokenIndex).toBe(2);
+    expect(tokens[3].tokenIndex).toBe(3);
+
+    expect(tokens[0].startOffset).toBe(10);
+    expect(tokens[0].endOffset).toBe(13);
+    expect(tokens[0].line).toBe(2);
+    expect(tokens[0].column).toBe(1);
+    expect(tokens[0].endLine).toBe(2);
+    expect(tokens[0].endColumn).toBe(4);
+
+    expect(tokens[0].leadingTrivia).toEqual([
+      {
+        type: "WHITESPACE",
+        value: "  ",
+        line: 1,
+        column: 1,
+        endLine: 1,
+        endColumn: 3,
+        startOffset: 0,
+        endOffset: 2,
+      },
+      {
+        type: "LINE_COMMENT",
+        value: "// lead",
+        line: 1,
+        column: 3,
+        endLine: 1,
+        endColumn: 10,
+        startOffset: 2,
+        endOffset: 9,
+      },
+      {
+        type: "WHITESPACE",
+        value: "\n",
+        line: 1,
+        column: 10,
+        endLine: 2,
+        endColumn: 1,
+        startOffset: 9,
+        endOffset: 10,
+      },
+    ]);
+  });
+
+  it("attaches trailing trivia to EOF when enabled", () => {
+    const grammar = makeRichSourceGrammar();
+    const tokens = grammarTokenize(
+      "foo // tail",
+      grammar,
+      { preserveSourceInfo: true },
+    );
+    const eof = tokens[tokens.length - 1];
+    expect(eof.type).toBe("EOF");
+    expect(eof.leadingTrivia).toEqual([
+      {
+        type: "WHITESPACE",
+        value: " ",
+        line: 1,
+        column: 4,
+        endLine: 1,
+        endColumn: 5,
+        startOffset: 3,
+        endOffset: 4,
+      },
+      {
+        type: "LINE_COMMENT",
+        value: "// tail",
+        line: 1,
+        column: 5,
+        endLine: 1,
+        endColumn: 12,
+        startOffset: 4,
+        endOffset: 11,
+      },
+    ]);
+  });
+});

--- a/code/packages/typescript/parser/CHANGELOG.md
+++ b/code/packages/typescript/parser/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the `@coding-adventures/parser` package will be documented in this file.
 
+## [0.3.0] - 2026-04-18
+
+### Added
+
+- Optional rich source preservation for `GrammarParser` via
+  `{ preserveSourceInfo: true }`.
+- Optional AST node metadata fields:
+  - `startOffset` / `endOffset`
+  - `firstTokenIndex` / `lastTokenIndex`
+  - `leadingTrivia`
+- Cached grammar-parser nodes now rebuild token-derived metadata instead of
+  dropping it on memoized parses.
+
 ## [0.2.0] - 2026-03-23
 
 ### Added

--- a/code/packages/typescript/parser/README.md
+++ b/code/packages/typescript/parser/README.md
@@ -62,14 +62,19 @@ const ast = parser.parse();
 ### Grammar-driven parser
 
 ```typescript
-import { parseParserGrammar } from "@coding-adventures/grammar-tools";
-import { tokenize } from "@coding-adventures/lexer";
+import { parseParserGrammar, parseTokenGrammar } from "@coding-adventures/grammar-tools";
+import { grammarTokenize } from "@coding-adventures/lexer";
 import { GrammarParser } from "@coding-adventures/parser";
 import { readFileSync } from "fs";
 
+const tokenGrammar = parseTokenGrammar(readFileSync("python.tokens", "utf-8"));
 const grammar = parseParserGrammar(readFileSync("python.grammar", "utf-8"));
-const tokens = tokenize("x = 1 + 2");
-const parser = new GrammarParser(tokens, grammar);
+const tokens = grammarTokenize("x = 1 + 2", tokenGrammar, {
+  preserveSourceInfo: true,
+});
+const parser = new GrammarParser(tokens, grammar, {
+  preserveSourceInfo: true,
+});
 const ast = parser.parse();
 // ast.ruleName === "program"
 ```
@@ -91,7 +96,14 @@ const ast = parser.parse();
 
 | Type | Description |
 |------|-------------|
-| `ASTNode` | Generic node with `ruleName` and `children` |
+| `ASTNode` | Generic node with `ruleName`, `children`, and optional source spans |
+
+When `preserveSourceInfo` is enabled on `GrammarParser`, grammar-driven AST
+nodes also retain:
+
+- `startOffset` / `endOffset`
+- `firstTokenIndex` / `lastTokenIndex`
+- `leadingTrivia`
 
 ## Dependencies
 

--- a/code/packages/typescript/parser/src/grammar-parser.ts
+++ b/code/packages/typescript/parser/src/grammar-parser.ts
@@ -44,7 +44,7 @@
  * - **Group** (``( A )``): Just a parenthesized sub-expression.
  */
 
-import type { Token } from "@coding-adventures/lexer";
+import type { Token, Trivia } from "@coding-adventures/lexer";
 import type {
   GrammarElement,
   GrammarRule,
@@ -65,6 +65,11 @@ export interface ASTNode {
   readonly startColumn?: number;
   readonly endLine?: number;
   readonly endColumn?: number;
+  readonly startOffset?: number;
+  readonly endOffset?: number;
+  readonly firstTokenIndex?: number;
+  readonly lastTokenIndex?: number;
+  readonly leadingTrivia?: readonly Trivia[];
 }
 
 /**
@@ -144,6 +149,7 @@ interface MemoEntry {
  */
 export interface GrammarParserOptions {
   readonly trace?: boolean;
+  readonly preserveSourceInfo?: boolean;
 }
 
 export class GrammarParser {
@@ -176,6 +182,9 @@ export class GrammarParser {
   /** Whether trace mode is enabled. */
   private readonly trace: boolean;
 
+  /** Whether AST nodes should retain token-derived source info. */
+  private readonly preserveSourceInfo: boolean;
+
   constructor(tokens: readonly Token[], grammar: ParserGrammar, options?: GrammarParserOptions) {
     this.tokens = tokens;
     this.grammar = grammar;
@@ -184,6 +193,7 @@ export class GrammarParser {
     this.furthestPos = 0;
     this.furthestExpected = [];
     this.trace = options?.trace ?? false;
+    this.preserveSourceInfo = options?.preserveSourceInfo ?? false;
 
     const ruleMap = new Map<string, GrammarRule>();
     const ruleIndex = new Map<string, number>();
@@ -378,10 +388,10 @@ export class GrammarParser {
         if (!cached.ok) {
           return null;
         }
-        return {
+        return this.buildNode(
           ruleName,
-          children: cached.children as ReadonlyArray<ASTNode | Token>,
-        };
+          cached.children as ReadonlyArray<ASTNode | Token>,
+        );
       }
     }
 
@@ -455,12 +465,7 @@ export class GrammarParser {
       return null;
     }
 
-    // Compute position info from child tokens.
-    const pos = computeNodePosition(children);
-    if (pos) {
-      return { ruleName, children, ...pos };
-    }
-    return { ruleName, children };
+    return this.buildNode(ruleName, children);
   }
 
   // =========================================================================
@@ -655,6 +660,23 @@ export class GrammarParser {
     this.recordFailure(expectedType);
     return null;
   }
+
+  private buildNode(
+    ruleName: string,
+    children: ReadonlyArray<ASTNode | Token>,
+  ): ASTNode {
+    const pos = computeNodePosition(children);
+    const sourceInfo = this.preserveSourceInfo
+      ? computeNodeSourceInfo(children)
+      : null;
+
+    return {
+      ruleName,
+      children,
+      ...(pos ?? {}),
+      ...(sourceInfo ?? {}),
+    };
+  }
 }
 
 // ===========================================================================
@@ -680,6 +702,48 @@ function computeNodePosition(
     endLine: last.line,
     endColumn: last.column,
   };
+}
+
+function computeNodeSourceInfo(
+  children: ReadonlyArray<ASTNode | Token>,
+): {
+  startOffset?: number;
+  endOffset?: number;
+  firstTokenIndex?: number;
+  lastTokenIndex?: number;
+  leadingTrivia?: readonly Trivia[];
+} | null {
+  const first = findFirstToken(children);
+  const last = findLastToken(children);
+  if (!first || !last) {
+    return null;
+  }
+
+  const info: {
+    startOffset?: number;
+    endOffset?: number;
+    firstTokenIndex?: number;
+    lastTokenIndex?: number;
+    leadingTrivia?: readonly Trivia[];
+  } = {};
+
+  if (first.startOffset !== undefined) {
+    info.startOffset = first.startOffset;
+  }
+  if (last.endOffset !== undefined) {
+    info.endOffset = last.endOffset;
+  }
+  if (first.tokenIndex !== undefined) {
+    info.firstTokenIndex = first.tokenIndex;
+  }
+  if (last.tokenIndex !== undefined) {
+    info.lastTokenIndex = last.tokenIndex;
+  }
+  if (first.leadingTrivia !== undefined) {
+    info.leadingTrivia = first.leadingTrivia;
+  }
+
+  return info;
 }
 
 function findFirstToken(children: ReadonlyArray<ASTNode | Token>): Token | null {

--- a/code/packages/typescript/parser/tests/grammar-parser.test.ts
+++ b/code/packages/typescript/parser/tests/grammar-parser.test.ts
@@ -34,9 +34,9 @@ import { readFileSync } from "fs";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 
-import { parseParserGrammar } from "@coding-adventures/grammar-tools";
+import { parseParserGrammar, parseTokenGrammar } from "@coding-adventures/grammar-tools";
 import type { ParserGrammar } from "@coding-adventures/grammar-tools";
-import { tokenize } from "@coding-adventures/lexer";
+import { grammarTokenize, tokenize } from "@coding-adventures/lexer";
 import type { Token } from "@coding-adventures/lexer";
 
 import {
@@ -114,6 +114,23 @@ function parseSource(source: string): ASTNode {
   const tokens = tokenize(source);
   const parser = new GrammarParser(tokens, grammar);
   return parser.parse();
+}
+
+function makeRichSourceTokenGrammar() {
+  return parseTokenGrammar([
+    "NAME = /[a-zA-Z_][a-zA-Z0-9_]*/",
+    "EQ = \"=\"",
+    "skip:",
+    "  WHITESPACE = /[ \\t\\r\\n]+/",
+    "  LINE_COMMENT = /\\/\\/[^\\n]*/",
+  ].join("\n"));
+}
+
+function makeRichSourceParserGrammar(): ParserGrammar {
+  return parseParserGrammar([
+    "program = assignment ;",
+    "assignment = NAME EQ NAME ;",
+  ].join("\n"));
 }
 
 // =============================================================================
@@ -1192,5 +1209,55 @@ describe("pre-parse and post-parse hooks", () => {
     });
     const result = parser.parse();
     expect(result.ruleName).toBe("transformed_program");
+  });
+});
+
+describe("rich source preservation", () => {
+  it("propagates token-derived offsets, indices, and trivia onto AST nodes", () => {
+    const tokenGrammar = makeRichSourceTokenGrammar();
+    const parserGrammar = makeRichSourceParserGrammar();
+    const tokens = grammarTokenize(
+      "  // lead\nfoo=bar",
+      tokenGrammar,
+      { preserveSourceInfo: true },
+    );
+
+    const parser = new GrammarParser(tokens, parserGrammar, {
+      preserveSourceInfo: true,
+    });
+    const ast = parser.parse();
+    const assignment = findNodes(ast, "assignment")[0];
+
+    expect(ast.startOffset).toBe(10);
+    expect(ast.endOffset).toBe(17);
+    expect(ast.firstTokenIndex).toBe(0);
+    expect(ast.lastTokenIndex).toBe(2);
+    expect(ast.leadingTrivia?.map((item) => item.type)).toEqual([
+      "WHITESPACE",
+      "LINE_COMMENT",
+      "WHITESPACE",
+    ]);
+
+    expect(assignment.startOffset).toBe(10);
+    expect(assignment.endOffset).toBe(17);
+    expect(assignment.firstTokenIndex).toBe(0);
+    expect(assignment.lastTokenIndex).toBe(2);
+  });
+
+  it("keeps AST nodes lean when preserveSourceInfo is disabled", () => {
+    const tokenGrammar = makeRichSourceTokenGrammar();
+    const parserGrammar = makeRichSourceParserGrammar();
+    const tokens = grammarTokenize(
+      "foo=bar",
+      tokenGrammar,
+      { preserveSourceInfo: true },
+    );
+
+    const parser = new GrammarParser(tokens, parserGrammar);
+    const ast = parser.parse();
+
+    expect(ast.startOffset).toBeUndefined();
+    expect(ast.firstTokenIndex).toBeUndefined();
+    expect(ast.leadingTrivia).toBeUndefined();
   });
 });

--- a/code/specs/lexer-parser-extensions.md
+++ b/code/specs/lexer-parser-extensions.md
@@ -407,6 +407,169 @@ For one-or-more: match `element { separator element }`
 
 ---
 
+## Extension 9: Opt-In Rich Source Preservation
+
+### Problem
+
+Formatter pipelines need more than just token types and coarse line/column
+spans. To preserve comments, blank lines, explicit grouping, and precise source
+ranges, the generic lexer and parser need to retain:
+
+- exact source offsets
+- end positions
+- named skip matches such as whitespace and comments
+- a stable mapping from AST nodes back to the token stream
+
+The current lexer consumes skip patterns silently, and the parser only keeps
+`ruleName`, `children`, and coarse start/end line-column information.
+
+### Design Goal
+
+Preserve formatter-grade source detail **without** slowing down ordinary
+parsing. The feature must therefore be opt-in, enabled only by callers such as
+formatter pipelines.
+
+### Solution
+
+Add an optional `preserveSourceInfo` flag to the grammar-driven lexer and
+parser. When the flag is disabled, behavior and performance stay as they are
+today. When enabled:
+
+- the lexer enriches tokens with offsets, end positions, token indices, and
+  leading trivia
+- the parser propagates source ranges and token-index spans onto AST nodes
+
+### Lexer API Additions
+
+```typescript
+export interface Trivia {
+  readonly type: string;
+  readonly value: string;
+  readonly line: number;
+  readonly column: number;
+  readonly endLine: number;
+  readonly endColumn: number;
+  readonly startOffset: number;
+  readonly endOffset: number;
+}
+
+export interface Token {
+  readonly type: string;
+  readonly value: string;
+  readonly line: number;
+  readonly column: number;
+  readonly flags?: number;
+
+  // Present only when preserveSourceInfo is enabled.
+  readonly endLine?: number;
+  readonly endColumn?: number;
+  readonly startOffset?: number;
+  readonly endOffset?: number;
+  readonly tokenIndex?: number;
+  readonly leadingTrivia?: readonly Trivia[];
+}
+
+export interface GrammarLexerOptions {
+  readonly preserveSourceInfo?: boolean;
+}
+
+constructor(source: string, grammar: TokenGrammar, options?: GrammarLexerOptions)
+
+export function grammarTokenize(
+  source: string,
+  grammar: TokenGrammar,
+  options?: GrammarLexerOptions,
+): Token[];
+```
+
+### Lexer Semantics
+
+When `preserveSourceInfo` is enabled:
+
+1. Every emitted token gains:
+   - `startOffset` / `endOffset` as half-open source ranges
+   - `endLine` / `endColumn` as exclusive end positions
+   - `tokenIndex` as the token's stable position in the emitted token stream
+
+2. Skip matches are preserved as `Trivia` values and attached to the next emitted
+   token as `leadingTrivia`.
+   - grammar-defined skip patterns use the skip definition name, such as
+     `WHITESPACE` or `LINE_COMMENT`
+   - default whitespace skipping uses synthetic trivia type `WHITESPACE`
+
+3. Any final trailing trivia at end-of-file is attached to the `EOF` token's
+   `leadingTrivia`.
+
+When `preserveSourceInfo` is disabled:
+
+- no extra fields are attached
+- skip patterns remain fully discarded
+- existing callers see no behavior change
+
+### Parser API Additions
+
+```typescript
+export interface ASTNode {
+  readonly ruleName: string;
+  readonly children: ReadonlyArray<ASTNode | Token>;
+  readonly startLine?: number;
+  readonly startColumn?: number;
+  readonly endLine?: number;
+  readonly endColumn?: number;
+
+  // Present only when preserveSourceInfo is enabled and source-aware tokens
+  // were provided to the parser.
+  readonly startOffset?: number;
+  readonly endOffset?: number;
+  readonly firstTokenIndex?: number;
+  readonly lastTokenIndex?: number;
+  readonly leadingTrivia?: readonly Trivia[];
+}
+
+export interface GrammarParserOptions {
+  readonly trace?: boolean;
+  readonly preserveSourceInfo?: boolean;
+}
+```
+
+### Parser Semantics
+
+When `preserveSourceInfo` is enabled and the parser receives tokens that carry
+rich source metadata:
+
+- every AST node computes `startOffset` and `endOffset` from its first and last
+  leaf tokens
+- every AST node computes `firstTokenIndex` and `lastTokenIndex` from those
+  same leaf tokens
+- every AST node exposes `leadingTrivia` from its first leaf token
+
+Nodes with no leaf tokens keep these fields undefined, just as empty nodes
+already leave coarse position fields undefined.
+
+### Formatter Payoff
+
+This extension does **not** attempt language-specific comment attachment.
+Instead, it preserves the raw information formatters need so that language
+packages can later decide whether a given trivia item is:
+
+- leading
+- trailing
+- dangling
+- blank-line separation
+
+That keeps the generic lexer and parser generic while still making them useful
+for `AST + trivia -> Doc` pipelines.
+
+### Backward Compatibility
+
+This extension is fully backward-compatible:
+
+- all new fields are optional
+- the default mode does not preserve trivia
+- existing grammars and callers continue to work unchanged
+
+---
+
 ## Implementation Scope
 
 These extensions are implemented in:


### PR DESCRIPTION
## Summary
- add opt-in rich source preservation to the generic TypeScript lexer so formatter pipelines can retain offsets, end positions, token indices, and leading trivia
- propagate token-derived source info through the generic TypeScript parser onto AST nodes behind the same opt-in flag
- document the extension and cover the new behavior with lexer/parser tests

## Verification
- `cd code/packages/typescript/lexer && npx vitest run --coverage`
- `cd code/packages/typescript/parser && npx vitest run --coverage`
- `cd code/packages/typescript/lexer && npx tsc --noEmit`

## Notes
- `cd code/packages/typescript/parser && npx tsc --noEmit` is still blocked by the package's pre-existing `rootDir`/default-include configuration, which pulls tests and config files outside the configured root. This PR does not introduce that issue.