### PR TITLE
feat(nib-formatter): preserve comments and blank lines

### DIFF
--- a/code/packages/typescript/nib-formatter/CHANGELOG.md
+++ b/code/packages/typescript/nib-formatter/CHANGELOG.md
@@ -6,5 +6,8 @@
 - lower Nib parser ASTs into `format-doc` documents using shared formatter templates
 - expose both `Doc`-level and end-to-end ASCII formatting entry points
 - cover ugly-input normalization, wrapping, and idempotence with unit tests
-- avoid CI failures from an unrelated upstream TypeScript `lexer` error by
-  relying on the package test suite in `BUILD` until the shared typecheck is fixed
+- preserve line comments and blank lines through the source-based formatter path
+- recover EOF comments by formatting from a trivia-rich parsed document rather
+  than from the AST alone
+- cover top-level, block, `else`, trailing, and EOF comment behavior with unit
+  tests

--- a/code/packages/typescript/nib-formatter/README.md
+++ b/code/packages/typescript/nib-formatter/README.md
@@ -33,6 +33,14 @@ const doc = printNibSourceToDoc(ugly);
 const formatted = formatNib(ugly, { printWidth: 24 });
 ```
 
+Comments and blank lines now flow through the source-based path too:
+
+```ts
+const formattedWithComments = formatNib(
+  "// header\nfn main(){let x:u4=5; // keep\n// done\n}",
+);
+```
+
 ## Exports
 
 - `printNibDoc(ast)` — lower a parsed Nib AST into `Doc`
@@ -43,8 +51,9 @@ const formatted = formatNib(ugly, { printWidth: 24 });
 ## Notes
 
 - v1 canonicalizes syntax and spacing for the full Nib grammar
-- v1 does not preserve comments because the current Nib lexer removes them
+- source-based entry points preserve line comments and blank lines using the
+  lexer/parser `preserveSourceInfo` path
+- AST-only entry points preserve node-attached trivia, but cannot recover EOF
+  comments unless the caller carries the token stream separately
 - formatted output has no trailing newline and no trailing whitespace
-- the package `BUILD` currently validates behavior with tests instead of
-  `tsc --noEmit` because the shared TypeScript `lexer` package has an upstream
-  source-level type error on `main` that is outside this formatter change
+- the execution path remains `Doc -> LayoutTree -> PaintScene -> paint-vm-ascii`

--- a/code/packages/typescript/nib-formatter/package-lock.json
+++ b/code/packages/typescript/nib-formatter/package-lock.json
@@ -12,6 +12,7 @@
         "@coding-adventures/format-doc": "file:../format-doc",
         "@coding-adventures/format-doc-std": "file:../format-doc-std",
         "@coding-adventures/format-doc-to-paint": "file:../format-doc-to-paint",
+        "@coding-adventures/lexer": "file:../lexer",
         "@coding-adventures/nib-parser": "file:../nib-parser",
         "@coding-adventures/paint-vm-ascii": "file:../paint-vm-ascii",
         "@coding-adventures/parser": "file:../parser"
@@ -54,6 +55,20 @@
         "@coding-adventures/format-doc": "file:../format-doc",
         "@coding-adventures/paint-instructions": "file:../paint-instructions",
         "@coding-adventures/paint-vm-ascii": "file:../paint-vm-ascii"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../lexer": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/directed-graph": "file:../directed-graph",
+        "@coding-adventures/grammar-tools": "file:../grammar-tools",
+        "@coding-adventures/state-machine": "file:../state-machine"
       },
       "devDependencies": {
         "@vitest/coverage-v8": "^3.0.0",
@@ -187,6 +202,10 @@
     },
     "node_modules/@coding-adventures/format-doc-to-paint": {
       "resolved": "../format-doc-to-paint",
+      "link": true
+    },
+    "node_modules/@coding-adventures/lexer": {
+      "resolved": "../lexer",
       "link": true
     },
     "node_modules/@coding-adventures/nib-parser": {

--- a/code/packages/typescript/nib-formatter/package.json
+++ b/code/packages/typescript/nib-formatter/package.json
@@ -15,6 +15,7 @@
     "@coding-adventures/format-doc": "file:../format-doc",
     "@coding-adventures/format-doc-std": "file:../format-doc-std",
     "@coding-adventures/format-doc-to-paint": "file:../format-doc-to-paint",
+    "@coding-adventures/lexer": "file:../lexer",
     "@coding-adventures/nib-parser": "file:../nib-parser",
     "@coding-adventures/paint-vm-ascii": "file:../paint-vm-ascii",
     "@coding-adventures/parser": "file:../parser"

--- a/code/packages/typescript/nib-formatter/src/index.ts
+++ b/code/packages/typescript/nib-formatter/src/index.ts
@@ -9,6 +9,16 @@
  * exactly the sort of language wrapper this formatter architecture is meant to
  * support: a small amount of AST extraction logic on top of a mostly-shared
  * document algebra toolkit.
+ *
+ * This revision adds the first real trivia-preservation layer on top of that
+ * stack. The lexer/parser now keep line comments and blank-line information
+ * behind an opt-in flag, and this formatter interprets that trivia in a small
+ * number of places:
+ *
+ * - anchored sequences such as top-level declarations and block statements
+ * - boundaries such as `if ... else` and `fn ... {`
+ * - the synthetic EOF token, which is the only place true end-of-file comments
+ *   live after lexing
  */
 
 import {
@@ -23,7 +33,8 @@ import {
 } from "@coding-adventures/format-doc";
 import { docToPaintScene, type DocPaintOptions } from "@coding-adventures/format-doc-to-paint";
 import { callLike, delimitedList, infixChain } from "@coding-adventures/format-doc-std";
-import { parseNib } from "@coding-adventures/nib-parser";
+import type { Token, Trivia } from "@coding-adventures/lexer";
+import { parseNib, parseNibDocument } from "@coding-adventures/nib-parser";
 import { renderToAscii } from "@coding-adventures/paint-vm-ascii";
 import type { ASTNode } from "@coding-adventures/parser";
 
@@ -55,13 +66,33 @@ export interface NibFormatOptions extends LayoutOptions {
   paint?: DocPaintOptions;
 }
 
-/** A minimal structural token shape as it appears inside the grammar AST. */
-interface TokenLike {
-  readonly type: string;
-  readonly value: string;
+interface PrintNibDocOptions {
+  readonly eofTrivia?: readonly Trivia[];
 }
 
-type NodeChild = ASTNode | TokenLike;
+interface TriviaCommentSegment {
+  readonly text: string;
+  readonly newlinesBefore: number;
+}
+
+interface TriviaDisposition {
+  readonly inlineTrailingComment: string | null;
+  readonly leadingComments: readonly TriviaCommentSegment[];
+  readonly trailingNewlinesBeforeAnchor: number;
+}
+
+interface SequenceEntry {
+  doc: Doc;
+  readonly blankLinesBefore: number;
+  readonly attachable: boolean;
+}
+
+interface SequenceItem {
+  readonly anchor: ASTNode;
+  readonly doc: Doc;
+}
+
+type NodeChild = ASTNode | Token;
 
 const DEFAULT_FORMAT_OPTIONS: NibFormatOptions = {
   printWidth: 80,
@@ -75,24 +106,44 @@ const DEFAULT_FORMAT_OPTIONS: NibFormatOptions = {
  * This expects the root `program` AST from `nib-parser`.
  */
 export function printNibDoc(ast: ASTNode): Doc {
-  if (ast.ruleName !== "program") {
-    throw new Error(`printNibDoc() expects a 'program' AST node, got '${ast.ruleName}'`);
-  }
-
-  const declarations = childNodes(ast).map((decl) => printTopLevel(decl));
-  return joinWithBlankLines(declarations);
+  return printNibDocWithOptions(ast, {});
 }
 
 /** Parse Nib source and lower it to `Doc` in one step. */
 export function printNibSourceToDoc(source: string): Doc {
-  return printNibDoc(parseNib(source));
+  const document = parseNibDocument(source, {
+    preserveSourceInfo: true,
+  });
+
+  return printNibDocWithOptions(document.ast, {
+    eofTrivia: getEofTrivia(document.tokens),
+  });
 }
 
 /** Run the full formatter pipeline on a parsed Nib AST. */
 export function formatNibAst(ast: ASTNode, options: NibFormatOptions): string {
+  return renderDocToAscii(printNibDoc(ast), options);
+}
+
+/** Parse and format Nib source into canonical ASCII text. */
+export function formatNib(
+  source: string,
+  options: Partial<NibFormatOptions> = {},
+): string {
+  const document = parseNibDocument(source, {
+    preserveSourceInfo: true,
+  });
+  const doc = printNibDocWithOptions(document.ast, {
+    eofTrivia: getEofTrivia(document.tokens),
+  });
+
+  return renderDocToAscii(doc, resolveOptions(options));
+}
+
+function renderDocToAscii(doc: Doc, options: Partial<NibFormatOptions> = {}): string {
   const resolved = resolveOptions(options);
   const scene = docToPaintScene(
-    printNibDoc(ast),
+    doc,
     {
       printWidth: resolved.printWidth,
       indentWidth: resolved.indentWidth,
@@ -106,12 +157,17 @@ export function formatNibAst(ast: ASTNode, options: NibFormatOptions): string {
   return renderToAscii(scene, { scaleX: 1, scaleY: 1 });
 }
 
-/** Parse and format Nib source into canonical ASCII text. */
-export function formatNib(
-  source: string,
-  options: Partial<NibFormatOptions> = {},
-): string {
-  return formatNibAst(parseNib(source), resolveOptions(options));
+function printNibDocWithOptions(ast: ASTNode, options: PrintNibDocOptions): Doc {
+  if (ast.ruleName !== "program") {
+    throw new Error(`printNibDoc() expects a 'program' AST node, got '${ast.ruleName}'`);
+  }
+
+  const declarations = childRules(ast, "top_decl").map((decl) => ({
+    anchor: decl,
+    doc: printTopLevel(decl),
+  }));
+
+  return printAnchoredSequence(declarations, options.eofTrivia, 1);
 }
 
 function resolveOptions(options: Partial<NibFormatOptions>): NibFormatOptions {
@@ -131,8 +187,8 @@ function childNodes(node: ASTNode): ASTNode[] {
   return node.children.filter(isAstNode);
 }
 
-function childTokens(node: ASTNode): TokenLike[] {
-  const tokens: TokenLike[] = [];
+function childTokens(node: ASTNode): Token[] {
+  const tokens: Token[] = [];
 
   for (const child of node.children) {
     if (!isAstNode(child)) {
@@ -143,9 +199,22 @@ function childTokens(node: ASTNode): TokenLike[] {
   return tokens;
 }
 
-function firstToken(node: ASTNode, tokenType?: string): TokenLike | null {
+function firstToken(node: ASTNode, tokenType?: string): Token | null {
   for (const child of node.children) {
     if (isAstNode(child)) {
+      continue;
+    }
+    if (tokenType === undefined || child.type === tokenType) {
+      return child;
+    }
+  }
+  return null;
+}
+
+function lastToken(node: ASTNode, tokenType?: string): Token | null {
+  for (let index = node.children.length - 1; index >= 0; index -= 1) {
+    const child = node.children[index];
+    if (!child || isAstNode(child)) {
       continue;
     }
     if (tokenType === undefined || child.type === tokenType) {
@@ -175,7 +244,7 @@ function unwrapSingleChild(node: ASTNode): ASTNode {
   return inner;
 }
 
-function requireToken(node: ASTNode, tokenType: string, context: string): TokenLike {
+function requireToken(node: ASTNode, tokenType: string, context: string): Token {
   const token = firstToken(node, tokenType);
   if (!token) {
     throw new Error(`Expected token '${tokenType}' while formatting ${context}`);
@@ -234,7 +303,14 @@ function printFunctionDeclaration(node: ASTNode): Doc {
     returnType ? concat([text(" -> "), printType(returnType)]) : nil(),
   ]);
 
-  return group(concat([signature, text(" "), printBlock(block)]));
+  return group(
+    joinAcrossTrivia(
+      signature,
+      printBlock(block),
+      leadingTriviaOf(firstToken(block, "LBRACE")),
+      " ",
+    ),
+  );
 }
 
 function printParameterList(node: ASTNode | null): Doc {
@@ -259,15 +335,20 @@ function printParam(node: ASTNode): Doc {
 }
 
 function printBlock(node: ASTNode): Doc {
-  const statements = childRules(node, "stmt").map((stmt) => printStatement(unwrapSingleChild(stmt)));
+  const statements = childRules(node, "stmt").map((stmt) => ({
+    anchor: stmt,
+    doc: printStatement(unwrapSingleChild(stmt)),
+  }));
+  const closeBrace = lastToken(node, "RBRACE");
+  const body = printAnchoredSequence(statements, leadingTriviaOf(closeBrace), 0);
 
-  if (statements.length === 0) {
+  if (body.kind === "nil") {
     return concat([text("{"), text(" "), text("}")]);
   }
 
   return concat([
     text("{"),
-    indent(concat([hardline(), joinWithHardlines(statements)])),
+    indent(concat([hardline(), body])),
     hardline(),
     text("}"),
   ]);
@@ -360,19 +441,24 @@ function printForStatement(node: ASTNode): Doc {
     throw new Error("Malformed for_stmt: expected loop type, bounds, and block");
   }
 
+  const header = concat([
+    text("for "),
+    text(loopVar),
+    text(": "),
+    printType(typeNode),
+    text(" in "),
+    printExpression(bounds[0]!),
+    text(".."),
+    printExpression(bounds[1]!),
+  ]);
+
   return group(
-    concat([
-      text("for "),
-      text(loopVar),
-      text(": "),
-      printType(typeNode),
-      text(" in "),
-      printExpression(bounds[0]!),
-      text(".."),
-      printExpression(bounds[1]!),
-      text(" "),
+    joinAcrossTrivia(
+      header,
       printBlock(blockNode),
-    ]),
+      leadingTriviaOf(firstToken(blockNode, "LBRACE")),
+      " ",
+    ),
   );
 }
 
@@ -386,15 +472,35 @@ function printIfStatement(node: ASTNode): Doc {
     throw new Error("Malformed if_stmt: expected condition and then-block");
   }
 
-  return group(
-    concat([
-      text("if "),
-      printExpression(condition),
-      text(" "),
+  const ifHead = concat([text("if "), printExpression(condition)]);
+  const thenDoc = group(
+    joinAcrossTrivia(
+      ifHead,
       printBlock(thenBlock),
-      elseBlock ? concat([text(" else "), printBlock(elseBlock)]) : nil(),
-    ]),
+      leadingTriviaOf(firstToken(thenBlock, "LBRACE")),
+      " ",
+    ),
   );
+
+  if (!elseBlock) {
+    return thenDoc;
+  }
+
+  const elseToken = childTokens(node).find((token) => token.value === "else");
+  if (!elseToken) {
+    throw new Error("Malformed if_stmt: expected else token before else-block");
+  }
+
+  const elseDoc = group(
+    joinAcrossTrivia(
+      text("else"),
+      printBlock(elseBlock),
+      leadingTriviaOf(firstToken(elseBlock, "LBRACE")),
+      " ",
+    ),
+  );
+
+  return group(joinAcrossTrivia(thenDoc, elseDoc, leadingTriviaOf(elseToken), " "));
 }
 
 function printType(node: ASTNode): Doc {
@@ -503,28 +609,197 @@ function printCallExpression(node: ASTNode): Doc {
   return callLike(text(callee), args);
 }
 
-function joinWithHardlines(parts: readonly Doc[]): Doc {
-  const out: Doc[] = [];
-  for (let index = 0; index < parts.length; index += 1) {
-    if (index > 0) {
-      out.push(hardline());
-    }
-    out.push(parts[index]!);
+function printAnchoredSequence(
+  items: readonly SequenceItem[],
+  boundaryTrivia: readonly Trivia[] | undefined,
+  baseBlankLinesBetweenItems: number,
+): Doc {
+  const entries: SequenceEntry[] = [];
+  let lastAttachableIndex: number | null = null;
+
+  for (const item of items) {
+    const disposition = classifyTrivia(leadingTriviaOf(item.anchor), lastAttachableIndex !== null);
+    lastAttachableIndex = applyTriviaDisposition(
+      entries,
+      lastAttachableIndex,
+      disposition,
+      item.doc,
+      baseBlankLinesBetweenItems,
+    );
   }
-  return concat(out);
+
+  const boundaryDisposition = classifyTrivia(boundaryTrivia, lastAttachableIndex !== null);
+  applyTriviaDisposition(entries, lastAttachableIndex, boundaryDisposition, null, 0);
+
+  return renderEntries(entries);
 }
 
-function joinWithBlankLines(parts: readonly Doc[]): Doc {
-  if (parts.length === 0) {
+function joinAcrossTrivia(
+  left: Doc,
+  right: Doc,
+  trivia: readonly Trivia[] | undefined,
+  inlineSeparator: string,
+): Doc {
+  if (!hasCommentTrivia(trivia)) {
+    return concat([left, text(inlineSeparator), right]);
+  }
+
+  const entries: SequenceEntry[] = [
+    { doc: left, blankLinesBefore: 0, attachable: true },
+  ];
+
+  applyTriviaDisposition(
+    entries,
+    0,
+    classifyTrivia(trivia, true),
+    right,
+    0,
+  );
+
+  return renderEntries(entries);
+}
+
+function applyTriviaDisposition(
+  entries: SequenceEntry[],
+  lastAttachableIndex: number | null,
+  disposition: TriviaDisposition,
+  anchorDoc: Doc | null,
+  baseBlankLinesBeforeAnchor: number,
+): number | null {
+  let effectiveLeadingComments = [...disposition.leadingComments];
+
+  if (disposition.inlineTrailingComment !== null) {
+    if (lastAttachableIndex !== null) {
+      const entry = entries[lastAttachableIndex];
+      entry.doc = appendTrailingComment(entry.doc, disposition.inlineTrailingComment);
+    } else {
+      effectiveLeadingComments = [
+        { text: disposition.inlineTrailingComment, newlinesBefore: 0 },
+        ...effectiveLeadingComments,
+      ];
+    }
+  }
+
+  let firstVisibleForAnchor = true;
+  const hadPreviousAttachable = lastAttachableIndex !== null;
+  let nextAttachableIndex = lastAttachableIndex;
+
+  const pushEntry = (doc: Doc, sourceNewlinesBefore: number, attachable: boolean): void => {
+    const sourceBlankLines = blankLinesFromNewlines(sourceNewlinesBefore);
+    const blankLinesBefore =
+      entries.length === 0
+        ? 0
+        : firstVisibleForAnchor && hadPreviousAttachable
+          ? Math.max(baseBlankLinesBeforeAnchor, sourceBlankLines)
+          : sourceBlankLines;
+
+    entries.push({
+      doc,
+      blankLinesBefore,
+      attachable,
+    });
+
+    firstVisibleForAnchor = false;
+    if (attachable) {
+      nextAttachableIndex = entries.length - 1;
+    }
+  };
+
+  for (const comment of effectiveLeadingComments) {
+    pushEntry(text(comment.text), comment.newlinesBefore, false);
+  }
+
+  if (anchorDoc !== null) {
+    pushEntry(anchorDoc, disposition.trailingNewlinesBeforeAnchor, true);
+  }
+
+  return nextAttachableIndex;
+}
+
+function renderEntries(entries: readonly SequenceEntry[]): Doc {
+  if (entries.length === 0) {
     return nil();
   }
 
   const out: Doc[] = [];
-  for (let index = 0; index < parts.length; index += 1) {
+  for (let index = 0; index < entries.length; index += 1) {
     if (index > 0) {
-      out.push(hardline(), hardline());
+      for (let lineIndex = 0; lineIndex < entries[index]!.blankLinesBefore + 1; lineIndex += 1) {
+        out.push(hardline());
+      }
     }
-    out.push(parts[index]!);
+    out.push(entries[index]!.doc);
   }
+
   return concat(out);
+}
+
+function appendTrailingComment(doc: Doc, commentText: string): Doc {
+  return concat([doc, text(" "), text(commentText)]);
+}
+
+function leadingTriviaOf(anchor: ASTNode | Token | null): readonly Trivia[] | undefined {
+  return anchor?.leadingTrivia;
+}
+
+function getEofTrivia(tokens: readonly Token[]): readonly Trivia[] | undefined {
+  const eof = tokens[tokens.length - 1];
+  return eof?.type === "EOF" ? eof.leadingTrivia : undefined;
+}
+
+function hasCommentTrivia(trivia: readonly Trivia[] | undefined): boolean {
+  return (trivia ?? []).some((item) => item.type === "LINE_COMMENT");
+}
+
+function classifyTrivia(
+  trivia: readonly Trivia[] | undefined,
+  canAttachInlineToPrevious: boolean,
+): TriviaDisposition {
+  const comments: TriviaCommentSegment[] = [];
+  let pendingNewlines = 0;
+
+  for (const item of trivia ?? []) {
+    if (item.type === "LINE_COMMENT") {
+      comments.push({
+        text: item.value,
+        newlinesBefore: pendingNewlines,
+      });
+      pendingNewlines = 0;
+      continue;
+    }
+
+    pendingNewlines += countNewlines(item.value);
+  }
+
+  if (
+    canAttachInlineToPrevious
+    && comments.length > 0
+    && comments[0]!.newlinesBefore === 0
+  ) {
+    return {
+      inlineTrailingComment: comments[0]!.text,
+      leadingComments: comments.slice(1),
+      trailingNewlinesBeforeAnchor: pendingNewlines,
+    };
+  }
+
+  return {
+    inlineTrailingComment: null,
+    leadingComments: comments,
+    trailingNewlinesBeforeAnchor: pendingNewlines,
+  };
+}
+
+function countNewlines(value: string): number {
+  let count = 0;
+  for (const ch of value) {
+    if (ch === "\n") {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function blankLinesFromNewlines(newlines: number): number {
+  return Math.max(0, newlines - 1);
 }

--- a/code/packages/typescript/nib-formatter/tests/nib-formatter.test.ts
+++ b/code/packages/typescript/nib-formatter/tests/nib-formatter.test.ts
@@ -93,6 +93,30 @@ describe("formatNib()", () => {
     expect(formatNibAst(ast, { printWidth: 80 })).toBe("fn main() {\n  return 0;\n}");
   });
 
+  it("preserves top-level comments and blank lines through the source-based path", () => {
+    expect(
+      formatNib("// file header\nconst MAX:u4=9;\n\n// entry point\nfn main(){return MAX;}"),
+    ).toBe(
+      "// file header\nconst MAX: u4 = 9;\n\n// entry point\nfn main() {\n  return MAX;\n}",
+    );
+  });
+
+  it("preserves trailing statement comments and comments before closing braces", () => {
+    expect(
+      formatNib("fn main(){let x:u4=5; // keep me\n// before closing\n}"),
+    ).toBe(
+      "fn main() {\n  let x: u4 = 5; // keep me\n  // before closing\n}",
+    );
+  });
+
+  it("preserves comments before else blocks and at end of file", () => {
+    expect(
+      formatNib("fn main(){if ready{return 1;} // not ready yet\nelse{return 0;}} // eof"),
+    ).toBe(
+      "fn main() {\n  if ready {\n    return 1;\n  } // not ready yet\n  else {\n    return 0;\n  }\n} // eof",
+    );
+  });
+
   it("fails loudly on unsupported AST rule names", () => {
     const ast = {
       ruleName: "program",

--- a/code/packages/typescript/nib-lexer/CHANGELOG.md
+++ b/code/packages/typescript/nib-lexer/CHANGELOG.md
@@ -3,3 +3,5 @@
 ## 0.1.0
 
 - add a TypeScript Nib lexer wrapper over the shared grammar-driven lexer
+- add an opt-in `preserveSourceInfo` path so formatter callers can retain
+  offsets, token indices, and leading comment/whitespace trivia

--- a/code/packages/typescript/nib-lexer/README.md
+++ b/code/packages/typescript/nib-lexer/README.md
@@ -6,10 +6,11 @@ Tokenizes Nib source text using the shared grammar-driven TypeScript lexer.
 
 This package is intentionally thin:
 
-- reads [`nib.tokens`](/C:/Users/adhit/Downloads/Codex/coding-adventures/code/grammars/nib.tokens)
+- reads `code/grammars/nib.tokens`
 - parses that grammar with `@coding-adventures/grammar-tools`
 - tokenizes source via `@coding-adventures/lexer`
 - reclassifies `KEYWORD` tokens to the concrete lowercase Nib keyword text
+- optionally preserves source offsets and skip-stream trivia for formatter paths
 
 That keeps the language definition in one place while still giving TypeScript a
 real Nib frontend entry point.
@@ -20,4 +21,14 @@ real Nib frontend entry point.
 import { tokenizeNib } from "@coding-adventures/nib-lexer";
 
 const tokens = tokenizeNib("let x: u4 = 0xF;");
+```
+
+Formatter-oriented callers can opt into richer source information:
+
+```ts
+const richTokens = tokenizeNib("// lead\nconst MAX: u4 = 10;", {
+  preserveSourceInfo: true,
+});
+
+console.log(richTokens[0]?.leadingTrivia);
 ```

--- a/code/packages/typescript/nib-lexer/src/index.ts
+++ b/code/packages/typescript/nib-lexer/src/index.ts
@@ -1,1 +1,2 @@
+export type { TokenizeNibOptions } from "./tokenizer.js";
 export { tokenizeNib } from "./tokenizer.js";

--- a/code/packages/typescript/nib-lexer/src/tokenizer.ts
+++ b/code/packages/typescript/nib-lexer/src/tokenizer.ts
@@ -9,11 +9,20 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const GRAMMARS_DIR = join(__dirname, "..", "..", "..", "..", "grammars");
 const NIB_TOKENS_PATH = join(GRAMMARS_DIR, "nib.tokens");
 
-export function tokenizeNib(source: string): Token[] {
+export interface TokenizeNibOptions {
+  readonly preserveSourceInfo?: boolean;
+}
+
+export function tokenizeNib(
+  source: string,
+  options: TokenizeNibOptions = {},
+): Token[] {
   const grammarText = readFileSync(NIB_TOKENS_PATH, "utf-8");
   const grammar = parseTokenGrammar(grammarText);
 
-  return grammarTokenize(source, grammar).map((token) => {
+  return grammarTokenize(source, grammar, {
+    preserveSourceInfo: options.preserveSourceInfo,
+  }).map((token) => {
     if (token.type === "KEYWORD") {
       return { ...token, type: token.value };
     }

--- a/code/packages/typescript/nib-lexer/tests/nib-lexer.test.ts
+++ b/code/packages/typescript/nib-lexer/tests/nib-lexer.test.ts
@@ -51,4 +51,18 @@ describe("nib-lexer", () => {
       "SEMICOLON",
     ]);
   });
+
+  it("can preserve comment and whitespace trivia for formatter-oriented callers", () => {
+    const tokens = tokenizeNib("// lead\nconst MAX: u4 = 10;", {
+      preserveSourceInfo: true,
+    });
+
+    expect(tokens[0]?.type).toBe("const");
+    expect(tokens[0]?.leadingTrivia?.map((item) => item.type)).toEqual([
+      "LINE_COMMENT",
+      "WHITESPACE",
+    ]);
+    expect(tokens[0]?.startOffset).toBe(8);
+    expect(tokens[0]?.tokenIndex).toBe(0);
+  });
 });

--- a/code/packages/typescript/nib-parser/CHANGELOG.md
+++ b/code/packages/typescript/nib-parser/CHANGELOG.md
@@ -3,3 +3,7 @@
 ## 0.1.0
 
 - add a TypeScript Nib parser wrapper over the shared grammar-driven parser
+- add opt-in `preserveSourceInfo` support to propagate trivia-rich source data
+  onto grammar AST nodes
+- add `parseNibDocument()` for formatter-style callers that need both the AST
+  and the original token stream, including EOF trivia

--- a/code/packages/typescript/nib-parser/README.md
+++ b/code/packages/typescript/nib-parser/README.md
@@ -7,8 +7,8 @@ parser.
 
 This package wires together:
 
-- [`nib.grammar`](/C:/Users/adhit/Downloads/Codex/coding-adventures/code/grammars/nib.grammar)
-- [`@coding-adventures/nib-lexer`](C:/Users/adhit/Downloads/Codex/coding-adventures/code/packages/typescript/nib-lexer)
+- `code/grammars/nib.grammar`
+- `@coding-adventures/nib-lexer`
 - `@coding-adventures/parser`
 
 The result is a thin, language-specific entry point that produces the same kind
@@ -21,4 +21,26 @@ import { parseNib } from "@coding-adventures/nib-parser";
 
 const ast = parseNib("fn main() { let x: u4 = 5; }");
 console.log(ast.ruleName); // "program"
+```
+
+Formatter-oriented callers can preserve source info on AST nodes:
+
+```ts
+const ast = parseNib("// lead\nfn main() { return 0; }", {
+  preserveSourceInfo: true,
+});
+
+console.log(ast.leadingTrivia);
+```
+
+When a formatter also needs EOF trivia, use `parseNibDocument()`:
+
+```ts
+import { parseNibDocument } from "@coding-adventures/nib-parser";
+
+const document = parseNibDocument("fn main() { return 0; } // tail", {
+  preserveSourceInfo: true,
+});
+
+console.log(document.tokens.at(-1)?.leadingTrivia);
 ```

--- a/code/packages/typescript/nib-parser/src/index.ts
+++ b/code/packages/typescript/nib-parser/src/index.ts
@@ -1,1 +1,2 @@
-export { parseNib } from "./parser.js";
+export type { ParseNibOptions, ParsedNibDocument } from "./parser.js";
+export { parseNib, parseNibDocument } from "./parser.js";

--- a/code/packages/typescript/nib-parser/src/parser.ts
+++ b/code/packages/typescript/nib-parser/src/parser.ts
@@ -4,16 +4,39 @@ import { fileURLToPath } from "url";
 
 import { parseParserGrammar } from "@coding-adventures/grammar-tools";
 import { type ASTNode, GrammarParser } from "@coding-adventures/parser";
-import { tokenizeNib } from "@coding-adventures/nib-lexer";
+import { tokenizeNib, type TokenizeNibOptions } from "@coding-adventures/nib-lexer";
+import type { Token } from "@coding-adventures/lexer";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const GRAMMARS_DIR = join(__dirname, "..", "..", "..", "..", "grammars");
 const NIB_GRAMMAR_PATH = join(GRAMMARS_DIR, "nib.grammar");
 
-export function parseNib(source: string): ASTNode {
-  const tokens = tokenizeNib(source);
+export interface ParseNibOptions extends TokenizeNibOptions {}
+
+export interface ParsedNibDocument {
+  readonly ast: ASTNode;
+  readonly tokens: readonly Token[];
+}
+
+export function parseNib(source: string, options: ParseNibOptions = {}): ASTNode {
+  return parseNibDocument(source, options).ast;
+}
+
+export function parseNibDocument(
+  source: string,
+  options: ParseNibOptions = {},
+): ParsedNibDocument {
+  const tokens = tokenizeNib(source, {
+    preserveSourceInfo: options.preserveSourceInfo,
+  });
   const grammarText = readFileSync(NIB_GRAMMAR_PATH, "utf-8");
   const grammar = parseParserGrammar(grammarText);
-  const parser = new GrammarParser(tokens, grammar);
-  return parser.parse();
+  const parser = new GrammarParser(tokens, grammar, {
+    preserveSourceInfo: options.preserveSourceInfo,
+  });
+
+  return {
+    ast: parser.parse(),
+    tokens,
+  };
 }

--- a/code/packages/typescript/nib-parser/tests/nib-parser.test.ts
+++ b/code/packages/typescript/nib-parser/tests/nib-parser.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { parseNib } from "../src/index.js";
+import { parseNib, parseNibDocument } from "../src/index.js";
 
 interface AstLike {
   ruleName: string;
@@ -47,5 +47,32 @@ describe("nib-parser", () => {
 
   it("rejects a missing statement semicolon", () => {
     expect(() => parseNib("fn main() { let x: u4 = 5 }")).toThrow();
+  });
+
+  it("can preserve source info on AST nodes for formatter-oriented callers", () => {
+    const ast = parseNib("// lead\nfn main() { return 0; }", {
+      preserveSourceInfo: true,
+    });
+
+    expect(ast.leadingTrivia?.map((item) => item.type)).toEqual([
+      "LINE_COMMENT",
+      "WHITESPACE",
+    ]);
+    expect(ast.startOffset).toBe(8);
+    expect(ast.firstTokenIndex).toBe(0);
+  });
+
+  it("can return both AST and token stream for formatters that need EOF trivia", () => {
+    const document = parseNibDocument("fn main() { return 0; } // tail", {
+      preserveSourceInfo: true,
+    });
+    const eof = document.tokens[document.tokens.length - 1];
+
+    expect(document.ast.ruleName).toBe("program");
+    expect(eof?.type).toBe("EOF");
+    expect(eof?.leadingTrivia?.map((item) => item.type)).toEqual([
+      "WHITESPACE",
+      "LINE_COMMENT",
+    ]);
   });
 });

--- a/code/specs/NIB03-nib-formatter.md
+++ b/code/specs/NIB03-nib-formatter.md
@@ -17,7 +17,9 @@ Nib source
 
 The goal of v1 is not perfect source preservation. The goal is to make valid,
 badly-formatted Nib code print into one stable canonical form with very little
-language-specific machinery.
+language-specific machinery while still preserving the most important source
+trivia that users expect a formatter to keep: line comments and intentional
+blank lines.
 
 This package is the first proof that:
 
@@ -40,9 +42,18 @@ V1 supports canonical formatting for the full Nib v1 grammar:
 - parenthesized expressions
 - call expressions
 
-V1 intentionally does **not** preserve comments. The current Nib lexer strips
-line comments before parsing, so the formatter has no trivia stream to work
-with yet.
+V1 now preserves comment and blank-line trivia through the source-based
+formatting path:
+
+- line comments from the Nib lexer skip stream
+- blank lines between top-level declarations
+- blank lines between statements inside blocks
+- comments before a closing `}`
+- comments at end of file
+
+The formatter does **not** aim for perfect token-by-token trivia fidelity.
+Instead it normalizes comment placement into a stable canonical form using the
+preserved lexer/parser trivia stream.
 
 ---
 
@@ -94,6 +105,11 @@ Default options:
 `formatNib()` is the main convenience API. It parses source, lowers to `Doc`,
 runs layout, converts the layout to paint, and finally renders through
 `paint-vm-ascii`.
+
+Source-based entry points preserve EOF trivia by parsing through a formatter
+oriented Nib parser path that keeps the original token stream. AST-only entry
+points preserve node-attached trivia, but cannot recover comments that live
+only on the synthetic EOF token.
 
 ---
 
@@ -157,6 +173,19 @@ if condition {
 - A single space around `=`, `->`, and infix operators
 - No trailing whitespace
 
+### Comments and blank lines
+
+- Leading line comments are preserved before the declaration, statement, or
+  closing brace they precede.
+- Line comments written after a declaration or statement stay trailing on that
+  line when the preserved trivia shows the comment began before the next
+  newline.
+- Blank lines between top-level declarations and block statements are preserved
+  in canonical form.
+- End-of-file comments are preserved.
+- Comment text is emitted exactly as written, including the original `//`
+  prefix.
+
 ---
 
 ## Lowering strategy
@@ -176,6 +205,13 @@ Nib-specific logic only handles:
 - distinguishing statement and declaration forms
 - preserving explicit parenthesized expressions
 - stitching the expression precedence ladder together
+- interpreting preserved lexer/parser trivia as leading comments, trailing
+  comments, and blank lines
+
+To preserve comments, the source-based formatter path parses Nib with
+`preserveSourceInfo: true` and retains the original token list long enough to
+recover trivia attached to the synthetic EOF token and to structural tokens
+such as `RBRACE` and `"else"`.
 
 This is the central design goal of the package: most formatting should come
 from the shared document algebra standard library, not from hand-written
@@ -191,6 +227,9 @@ The package must cover:
 - ugly input normalization for complete Nib programs
 - line-wrapping behavior for long parameter lists, argument lists, and infix
   chains
+- comment preservation for top-level declarations, statements, blocks, `else`
+  boundaries, and EOF
+- blank-line preservation for declarations and statements
 - idempotence: formatting already-formatted code should not change it again
 - error handling for unsupported AST shapes and malformed nodes
 


### PR DESCRIPTION
## Summary
- add formatter-oriented rich source entry points to the TypeScript Nib lexer and parser
- preserve line comments, blank lines, closing-brace comments, else-boundary comments, and EOF comments in `@coding-adventures/nib-formatter`
- update the NIB03 spec and package docs/tests to reflect the new trivia-preserving path

## Verification
- `cd code/packages/typescript/nib-lexer && NPM_CONFIG_CACHE=/tmp/coding-adventures-npm-cache npx vitest run --coverage`
- `cd code/packages/typescript/nib-lexer && NPM_CONFIG_CACHE=/tmp/coding-adventures-npm-cache npx tsc --noEmit`
- `cd code/packages/typescript/nib-parser && NPM_CONFIG_CACHE=/tmp/coding-adventures-npm-cache npx vitest run --coverage`
- `cd code/packages/typescript/nib-parser && NPM_CONFIG_CACHE=/tmp/coding-adventures-npm-cache npx tsc --noEmit`
- `cd code/packages/typescript/nib-formatter && NPM_CONFIG_CACHE=/tmp/coding-adventures-npm-cache npx vitest run --coverage`
- `cd code/packages/typescript/nib-formatter && NPM_CONFIG_CACHE=/tmp/coding-adventures-npm-cache npx tsc --noEmit`