### PR TITLE
fix(haskell): include grammar-tools in lexer projects

### DIFF
--- a/code/packages/haskell/asciidoc-parser/cabal.project
+++ b/code/packages/haskell/asciidoc-parser/cabal.project
@@ -4,4 +4,5 @@ packages:
   ../graph
   ../directed-graph
   ../state-machine
+  ../grammar-tools
   ../lexer

--- a/code/packages/haskell/commonmark-parser/cabal.project
+++ b/code/packages/haskell/commonmark-parser/cabal.project
@@ -4,4 +4,5 @@ packages:
   ../graph
   ../directed-graph
   ../state-machine
+  ../grammar-tools
   ../lexer

--- a/code/packages/haskell/csv-parser/cabal.project
+++ b/code/packages/haskell/csv-parser/cabal.project
@@ -4,4 +4,5 @@ packages:
   ../graph
   ../directed-graph
   ../state-machine
+  ../grammar-tools
   ../lexer

--- a/code/packages/haskell/font-parser/cabal.project
+++ b/code/packages/haskell/font-parser/cabal.project
@@ -4,4 +4,5 @@ packages:
   ../graph
   ../directed-graph
   ../state-machine
+  ../grammar-tools
   ../lexer

--- a/code/packages/haskell/gfm-parser/cabal.project
+++ b/code/packages/haskell/gfm-parser/cabal.project
@@ -4,4 +4,5 @@ packages:
   ../graph
   ../directed-graph
   ../state-machine
+  ../grammar-tools
   ../lexer

--- a/code/packages/haskell/url-parser/cabal.project
+++ b/code/packages/haskell/url-parser/cabal.project
@@ -4,4 +4,5 @@ packages:
   ../graph
   ../directed-graph
   ../state-machine
+  ../grammar-tools
   ../lexer

--- a/code/packages/haskell/xml-lexer/cabal.project
+++ b/code/packages/haskell/xml-lexer/cabal.project
@@ -1,5 +1,6 @@
 packages:
   .
+  ../grammar-tools
   ../lexer
   ../graph
   ../directed-graph

--- a/lessons.md
+++ b/lessons.md
@@ -36,6 +36,22 @@ test in `internal/gitdiff/ci_workflow_test.go` proving the hunk remains
 toolchain-scoped. Keep the allowlist narrow and tied to commands that only
 support the already-detected language setup.
 
+### 2026-04-18: Haskell cabal.project files must list transitive local packages
+
+Cabal does not discover sibling packages from another sibling's
+`cabal.project`. If a package includes `../lexer`, and `lexer.cabal` depends on
+the local `grammar-tools` package, the top-level package's own
+`cabal.project` must also list `../grammar-tools`.
+
+**Symptom:** a full Haskell build fails with `unknown package: grammar-tools`
+while trying to solve dependencies for `lexer`, even though
+`code/packages/haskell/grammar-tools` exists in the repo.
+
+**Rule:** When adding or maintaining a Haskell `cabal.project`, include every
+local package in the transitive dependency closure. Do not rely on nested
+`cabal.project` files from dependencies to make their local dependencies
+visible.
+
 ### 2026-04-18: TypeScript BUILD files that touch the paint stack must install `pixel-container` explicitly
 
 The build-plan validator checks standalone BUILD prerequisites by looking at


### PR DESCRIPTION
## Summary

This PR isolates the Haskell build bug that the oversized note-frequency PR exposed during a forced full build.

- Add `../grammar-tools` to the seven Haskell `cabal.project` files that include local `../lexer` but did not expose `lexer`'s local `grammar-tools` dependency to Cabal.
- Document the Cabal local transitive dependency lesson in `lessons.md`.

## Why

The failed CI run reported `unknown package: grammar-tools (dependency of lexer)` for these packages:

- `haskell/asciidoc-parser`
- `haskell/commonmark-parser`
- `haskell/csv-parser`
- `haskell/font-parser`
- `haskell/gfm-parser`
- `haskell/url-parser`
- `haskell/xml-lexer`

## Verification

- `git diff --check origin/main...HEAD`
- Build-plan smoke test: 7 packages affected; only Haskell and Go toolchains enabled.

I could not run Cabal locally in this fresh worktree because neither `cabal` nor `ghc` is currently available on PATH, so CI is the first full solver verification for this Haskell-only fix.