### PR TITLE
feat(dns-message): add transport-agnostic DNS codec

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -286,6 +286,7 @@ members = [
     "brainfuck-ir-compiler",
     "brainfuck-wasm-compiler",
     "tcp-client",
+    "dns-message",
     "intel8008-simulator",
     "intel8008-gatelevel",
     "upc-a",

--- a/code/packages/rust/dns-message/BUILD
+++ b/code/packages/rust/dns-message/BUILD
@@ -1,0 +1,1 @@
+cargo test -p dns-message -- --nocapture

--- a/code/packages/rust/dns-message/CHANGELOG.md
+++ b/code/packages/rust/dns-message/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this package will be documented in this file.
   messages.
 - Added DNS response parsing with compressed-name pointer support and loop /
   bounds validation.
+- Added parser hardening for attacker-controlled section counts and excessive
+  compression-pointer chains.
 - Added typed decoding for `A`, `AAAA`, and `CNAME` records.
 - Added raw preservation for unknown record types so future DNS extensions can
   be parsed without losing bytes.

--- a/code/packages/rust/dns-message/CHANGELOG.md
+++ b/code/packages/rust/dns-message/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-18
+
+### Added
+
+- Added a transport-agnostic DNS message model for headers, flags, questions,
+  resource records, record classes, record types, and record data.
+- Added query construction and wire-format serialization for standard DNS
+  messages.
+- Added DNS response parsing with compressed-name pointer support and loop /
+  bounds validation.
+- Added typed decoding for `A`, `AAAA`, and `CNAME` records.
+- Added raw preservation for unknown record types so future DNS extensions can
+  be parsed without losing bytes.
+- Added unit coverage for query round trips, compressed names, CNAMEs,
+  `NXDOMAIN`, truncation flags, unknown records, and malformed input.

--- a/code/packages/rust/dns-message/Cargo.toml
+++ b/code/packages/rust/dns-message/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "dns-message"
+version = "0.1.0"
+edition = "2021"
+description = "Transport-agnostic DNS wire-format message codec"
+
+[dependencies]

--- a/code/packages/rust/dns-message/README.md
+++ b/code/packages/rust/dns-message/README.md
@@ -1,0 +1,63 @@
+# dns-message
+
+`dns-message` is a transport-agnostic DNS wire-format codec. It builds DNS
+queries, serializes messages to bytes, parses DNS responses, decodes compressed
+names, and exposes structured questions and resource records.
+
+It intentionally does not open sockets or resolve hostnames by itself. A future
+DNS client can send these bytes over UDP, TCP, a simulated stack, or a test
+fixture without changing the message model.
+
+## What It Provides
+
+- DNS names as structured label lists
+- DNS header flags and response codes
+- Question and resource-record models
+- Query construction for standard recursive `A`, `AAAA`, and other record types
+- Wire-format serialization with uncompressed names
+- Response parsing with DNS compression-pointer support
+- Typed `A`, `AAAA`, and `CNAME` record data
+- Raw preservation for unknown record types
+
+## Example
+
+```rust
+use dns_message::{
+    build_query, parse_dns_message, serialize_dns_message, DnsName, DnsRecordType,
+};
+
+fn main() -> Result<(), dns_message::DnsError> {
+    let query = build_query(
+        0x1234,
+        DnsName::from_ascii("info.cern.ch")?,
+        DnsRecordType::A,
+    );
+
+    let bytes = serialize_dns_message(&query)?;
+
+    // A transport layer can send `bytes` over UDP, TCP, or a test fixture.
+    let parsed = parse_dns_message(&bytes)?;
+    assert_eq!(parsed.questions[0].name.to_string(), "info.cern.ch");
+
+    Ok(())
+}
+```
+
+## How It Fits The Stack
+
+`dns-message` is the protocol-core layer for DNS:
+
+```text
+future dns-client
+  ├── dns-message  // encode and parse DNS wire messages
+  └── udp-client   // send and receive opaque datagrams
+```
+
+This separation keeps DNS message parsing reusable and keeps UDP free of
+application-protocol knowledge.
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/rust/dns-message/src/lib.rs
+++ b/code/packages/rust/dns-message/src/lib.rs
@@ -1,0 +1,1232 @@
+//! # dns-message
+//!
+//! `dns-message` is the transport-agnostic DNS wire-format layer. It knows how
+//! to turn structured DNS questions and answers into bytes, and how to turn
+//! bytes back into structured messages. It does not open sockets, retry
+//! requests, cache answers, or decide which nameserver to use.
+//!
+//! Keeping this crate pure is what lets a future resolver send the same DNS
+//! message over UDP, TCP, a simulated network stack, or test fixtures.
+
+use std::fmt;
+
+const DNS_HEADER_LEN: usize = 12;
+const MAX_LABEL_LEN: usize = 63;
+const MAX_ENCODED_NAME_LEN: usize = 255;
+
+/// A DNS domain name represented as human-readable labels.
+///
+/// DNS encodes `info.cern.ch` as length-prefixed labels on the wire:
+/// `4 info, 4 cern, 2 ch, 0 root`. Keeping labels structured avoids leaking
+/// that byte-level encoding into callers.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DnsName {
+    pub labels: Vec<String>,
+}
+
+impl DnsName {
+    /// Parse a dotted ASCII DNS name.
+    ///
+    /// The first version keeps names ASCII-only. Internationalized domain names
+    /// can be handled later by punycode before constructing `DnsName`.
+    pub fn from_ascii(input: &str) -> Result<Self, DnsError> {
+        let trimmed = input.trim_end_matches('.');
+        if input == "." || trimmed.is_empty() {
+            return Ok(Self { labels: Vec::new() });
+        }
+
+        let mut labels = Vec::new();
+        for label in trimmed.split('.') {
+            if label.is_empty() {
+                return Err(DnsError::Unsupported("empty DNS label"));
+            }
+            validate_label(label.as_bytes())?;
+            labels.push(label.to_string());
+        }
+
+        let name = Self { labels };
+        validate_encoded_name_len(&name)?;
+        Ok(name)
+    }
+
+    /// Return true when this is the root name (`.`).
+    pub fn is_root(&self) -> bool {
+        self.labels.is_empty()
+    }
+}
+
+impl fmt::Display for DnsName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.labels.is_empty() {
+            write!(f, ".")
+        } else {
+            write!(f, "{}", self.labels.join("."))
+        }
+    }
+}
+
+/// DNS operation code from the header flag word.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DnsOpcode {
+    Query,
+    Unknown(u8),
+}
+
+impl DnsOpcode {
+    fn from_bits(bits: u8) -> Self {
+        match bits {
+            0 => Self::Query,
+            other => Self::Unknown(other),
+        }
+    }
+
+    fn to_bits(self) -> u8 {
+        match self {
+            Self::Query => 0,
+            Self::Unknown(value) => value & 0x0f,
+        }
+    }
+}
+
+/// DNS response code from the low bits of the header flag word.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DnsResponseCode {
+    NoError,
+    FormatError,
+    ServerFailure,
+    NameError,
+    NotImplemented,
+    Refused,
+    Unknown(u8),
+}
+
+impl DnsResponseCode {
+    fn from_bits(bits: u8) -> Self {
+        match bits {
+            0 => Self::NoError,
+            1 => Self::FormatError,
+            2 => Self::ServerFailure,
+            3 => Self::NameError,
+            4 => Self::NotImplemented,
+            5 => Self::Refused,
+            other => Self::Unknown(other),
+        }
+    }
+
+    fn to_bits(self) -> u8 {
+        match self {
+            Self::NoError => 0,
+            Self::FormatError => 1,
+            Self::ServerFailure => 2,
+            Self::NameError => 3,
+            Self::NotImplemented => 4,
+            Self::Refused => 5,
+            Self::Unknown(value) => value & 0x0f,
+        }
+    }
+}
+
+/// The DNS header's packed flag word, exposed as named protocol facts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DnsFlags {
+    pub is_response: bool,
+    pub opcode: DnsOpcode,
+    pub authoritative_answer: bool,
+    pub truncated: bool,
+    pub recursion_desired: bool,
+    pub recursion_available: bool,
+    pub response_code: DnsResponseCode,
+}
+
+impl DnsFlags {
+    pub fn query() -> Self {
+        Self {
+            is_response: false,
+            opcode: DnsOpcode::Query,
+            authoritative_answer: false,
+            truncated: false,
+            recursion_desired: true,
+            recursion_available: false,
+            response_code: DnsResponseCode::NoError,
+        }
+    }
+
+    fn parse(word: u16) -> Self {
+        Self {
+            is_response: word & 0x8000 != 0,
+            opcode: DnsOpcode::from_bits(((word >> 11) & 0x0f) as u8),
+            authoritative_answer: word & 0x0400 != 0,
+            truncated: word & 0x0200 != 0,
+            recursion_desired: word & 0x0100 != 0,
+            recursion_available: word & 0x0080 != 0,
+            response_code: DnsResponseCode::from_bits((word & 0x000f) as u8),
+        }
+    }
+
+    fn serialize(&self) -> u16 {
+        let mut word = 0u16;
+        if self.is_response {
+            word |= 0x8000;
+        }
+        word |= (self.opcode.to_bits() as u16) << 11;
+        if self.authoritative_answer {
+            word |= 0x0400;
+        }
+        if self.truncated {
+            word |= 0x0200;
+        }
+        if self.recursion_desired {
+            word |= 0x0100;
+        }
+        if self.recursion_available {
+            word |= 0x0080;
+        }
+        word | self.response_code.to_bits() as u16
+    }
+}
+
+/// The fixed 12-byte DNS message header.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DnsHeader {
+    pub id: u16,
+    pub flags: DnsFlags,
+    pub question_count: u16,
+    pub answer_count: u16,
+    pub authority_count: u16,
+    pub additional_count: u16,
+}
+
+/// DNS resource record type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DnsRecordType {
+    A,
+    NS,
+    CNAME,
+    SOA,
+    PTR,
+    MX,
+    TXT,
+    AAAA,
+    Unknown(u16),
+}
+
+impl DnsRecordType {
+    fn from_u16(value: u16) -> Self {
+        match value {
+            1 => Self::A,
+            2 => Self::NS,
+            5 => Self::CNAME,
+            6 => Self::SOA,
+            12 => Self::PTR,
+            15 => Self::MX,
+            16 => Self::TXT,
+            28 => Self::AAAA,
+            other => Self::Unknown(other),
+        }
+    }
+
+    fn to_u16(self) -> u16 {
+        match self {
+            Self::A => 1,
+            Self::NS => 2,
+            Self::CNAME => 5,
+            Self::SOA => 6,
+            Self::PTR => 12,
+            Self::MX => 15,
+            Self::TXT => 16,
+            Self::AAAA => 28,
+            Self::Unknown(value) => value,
+        }
+    }
+}
+
+/// DNS class. The internet class (`IN`) is the normal class for browser DNS.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DnsClass {
+    IN,
+    Unknown(u16),
+}
+
+impl DnsClass {
+    fn from_u16(value: u16) -> Self {
+        match value {
+            1 => Self::IN,
+            other => Self::Unknown(other),
+        }
+    }
+
+    fn to_u16(self) -> u16 {
+        match self {
+            Self::IN => 1,
+            Self::Unknown(value) => value,
+        }
+    }
+}
+
+/// A DNS question from the question section.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DnsQuestion {
+    pub name: DnsName,
+    pub qtype: DnsRecordType,
+    pub qclass: DnsClass,
+}
+
+/// The interpreted payload of a DNS resource record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DnsRecordData {
+    A([u8; 4]),
+    AAAA([u8; 16]),
+    CNAME(DnsName),
+    Raw(Vec<u8>),
+}
+
+/// A DNS resource record from answer, authority, or additional sections.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DnsResourceRecord {
+    pub name: DnsName,
+    pub rrtype: DnsRecordType,
+    pub class: DnsClass,
+    pub ttl: u32,
+    pub data: DnsRecordData,
+}
+
+/// A complete DNS message with all four RFC 1035 sections.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DnsMessage {
+    pub header: DnsHeader,
+    pub questions: Vec<DnsQuestion>,
+    pub answers: Vec<DnsResourceRecord>,
+    pub authorities: Vec<DnsResourceRecord>,
+    pub additionals: Vec<DnsResourceRecord>,
+}
+
+impl DnsMessage {
+    /// True when this is a successful response.
+    pub fn is_success(&self) -> bool {
+        self.header.flags.is_response && self.header.flags.response_code == DnsResponseCode::NoError
+    }
+
+    /// Return the first answer matching the requested record type.
+    pub fn first_answer_of_type(&self, qtype: DnsRecordType) -> Option<&DnsResourceRecord> {
+        self.answers.iter().find(|record| record.rrtype == qtype)
+    }
+
+    /// Return all IPv4 answers from the answer section.
+    pub fn ipv4_answers(&self) -> Vec<[u8; 4]> {
+        self.answers
+            .iter()
+            .filter_map(|record| match record.data {
+                DnsRecordData::A(address) => Some(address),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Return all IPv6 answers from the answer section.
+    pub fn ipv6_answers(&self) -> Vec<[u8; 16]> {
+        self.answers
+            .iter()
+            .filter_map(|record| match record.data {
+                DnsRecordData::AAAA(address) => Some(address),
+                _ => None,
+            })
+            .collect()
+    }
+}
+
+/// Structural errors found while encoding or decoding DNS messages.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DnsError {
+    TruncatedHeader,
+    UnexpectedEof,
+    LabelTooLong { length: usize },
+    NameTooLong,
+    PointerOutOfBounds { offset: usize },
+    PointerLoop,
+    NonAsciiLabel,
+    InvalidSectionCount,
+    Unsupported(&'static str),
+}
+
+/// Build a standard recursive single-question DNS query.
+pub fn build_query(id: u16, name: DnsName, qtype: DnsRecordType) -> DnsMessage {
+    DnsMessage {
+        header: DnsHeader {
+            id,
+            flags: DnsFlags::query(),
+            question_count: 1,
+            answer_count: 0,
+            authority_count: 0,
+            additional_count: 0,
+        },
+        questions: vec![DnsQuestion {
+            name,
+            qtype,
+            qclass: DnsClass::IN,
+        }],
+        answers: Vec::new(),
+        authorities: Vec::new(),
+        additionals: Vec::new(),
+    }
+}
+
+/// Parse raw DNS wire-format bytes into a structured message.
+pub fn parse_dns_message(input: &[u8]) -> Result<DnsMessage, DnsError> {
+    if input.len() < DNS_HEADER_LEN {
+        return Err(DnsError::TruncatedHeader);
+    }
+
+    let mut cursor = 0;
+    let header = DnsHeader {
+        id: read_u16(input, &mut cursor)?,
+        flags: DnsFlags::parse(read_u16(input, &mut cursor)?),
+        question_count: read_u16(input, &mut cursor)?,
+        answer_count: read_u16(input, &mut cursor)?,
+        authority_count: read_u16(input, &mut cursor)?,
+        additional_count: read_u16(input, &mut cursor)?,
+    };
+
+    let questions = parse_questions(input, &mut cursor, header.question_count)?;
+    let answers = parse_records(input, &mut cursor, header.answer_count)?;
+    let authorities = parse_records(input, &mut cursor, header.authority_count)?;
+    let additionals = parse_records(input, &mut cursor, header.additional_count)?;
+
+    Ok(DnsMessage {
+        header,
+        questions,
+        answers,
+        authorities,
+        additionals,
+    })
+}
+
+/// Serialize a structured DNS message into wire-format bytes.
+///
+/// V1 emits uncompressed names. It can encode common browser-facing records and
+/// raw unknown records, which is enough for fixtures and simple servers.
+pub fn serialize_dns_message(message: &DnsMessage) -> Result<Vec<u8>, DnsError> {
+    if message.questions.len() > u16::MAX as usize
+        || message.answers.len() > u16::MAX as usize
+        || message.authorities.len() > u16::MAX as usize
+        || message.additionals.len() > u16::MAX as usize
+    {
+        return Err(DnsError::InvalidSectionCount);
+    }
+
+    let mut output = Vec::new();
+    write_u16(&mut output, message.header.id);
+    write_u16(&mut output, message.header.flags.serialize());
+    write_u16(&mut output, message.questions.len() as u16);
+    write_u16(&mut output, message.answers.len() as u16);
+    write_u16(&mut output, message.authorities.len() as u16);
+    write_u16(&mut output, message.additionals.len() as u16);
+
+    for question in &message.questions {
+        write_name(&mut output, &question.name)?;
+        write_u16(&mut output, question.qtype.to_u16());
+        write_u16(&mut output, question.qclass.to_u16());
+    }
+
+    for record in &message.answers {
+        write_record(&mut output, record)?;
+    }
+    for record in &message.authorities {
+        write_record(&mut output, record)?;
+    }
+    for record in &message.additionals {
+        write_record(&mut output, record)?;
+    }
+
+    Ok(output)
+}
+
+fn parse_questions(
+    input: &[u8],
+    cursor: &mut usize,
+    count: u16,
+) -> Result<Vec<DnsQuestion>, DnsError> {
+    let mut questions = Vec::with_capacity(count as usize);
+    for _ in 0..count {
+        let name = read_name(input, cursor)?;
+        let qtype = DnsRecordType::from_u16(read_u16(input, cursor)?);
+        let qclass = DnsClass::from_u16(read_u16(input, cursor)?);
+        questions.push(DnsQuestion {
+            name,
+            qtype,
+            qclass,
+        });
+    }
+    Ok(questions)
+}
+
+fn parse_records(
+    input: &[u8],
+    cursor: &mut usize,
+    count: u16,
+) -> Result<Vec<DnsResourceRecord>, DnsError> {
+    let mut records = Vec::with_capacity(count as usize);
+    for _ in 0..count {
+        let name = read_name(input, cursor)?;
+        let rrtype = DnsRecordType::from_u16(read_u16(input, cursor)?);
+        let class = DnsClass::from_u16(read_u16(input, cursor)?);
+        let ttl = read_u32(input, cursor)?;
+        let rdlength = read_u16(input, cursor)? as usize;
+        if input.len().saturating_sub(*cursor) < rdlength {
+            return Err(DnsError::UnexpectedEof);
+        }
+
+        let rdata_start = *cursor;
+        let rdata_end = rdata_start + rdlength;
+        let data = match rrtype {
+            DnsRecordType::A => {
+                if rdlength != 4 {
+                    return Err(DnsError::Unsupported("A record data must be 4 bytes"));
+                }
+                DnsRecordData::A(input[rdata_start..rdata_end].try_into().unwrap())
+            }
+            DnsRecordType::AAAA => {
+                if rdlength != 16 {
+                    return Err(DnsError::Unsupported("AAAA record data must be 16 bytes"));
+                }
+                DnsRecordData::AAAA(input[rdata_start..rdata_end].try_into().unwrap())
+            }
+            DnsRecordType::CNAME => {
+                let mut data_cursor = rdata_start;
+                let cname = read_name(input, &mut data_cursor)?;
+                if data_cursor > rdata_end {
+                    return Err(DnsError::UnexpectedEof);
+                }
+                if data_cursor != rdata_end {
+                    return Err(DnsError::Unsupported(
+                        "CNAME record data must contain exactly one DNS name",
+                    ));
+                }
+                DnsRecordData::CNAME(cname)
+            }
+            _ => DnsRecordData::Raw(input[rdata_start..rdata_end].to_vec()),
+        };
+
+        *cursor = rdata_end;
+        records.push(DnsResourceRecord {
+            name,
+            rrtype,
+            class,
+            ttl,
+            data,
+        });
+    }
+    Ok(records)
+}
+
+fn read_name(input: &[u8], cursor: &mut usize) -> Result<DnsName, DnsError> {
+    let mut labels = Vec::new();
+    let mut offset = *cursor;
+    let mut consumed_cursor = None;
+    let mut visited = Vec::new();
+    let mut encoded_len = 1usize;
+
+    loop {
+        if offset >= input.len() {
+            return Err(DnsError::UnexpectedEof);
+        }
+        if visited.contains(&offset) {
+            return Err(DnsError::PointerLoop);
+        }
+        visited.push(offset);
+
+        let len = input[offset];
+        match len & 0b1100_0000 {
+            0b0000_0000 => {
+                offset += 1;
+                if len == 0 {
+                    *cursor = consumed_cursor.unwrap_or(offset);
+                    let name = DnsName { labels };
+                    validate_encoded_name_len(&name)?;
+                    return Ok(name);
+                }
+
+                let label_len = len as usize;
+                if label_len > MAX_LABEL_LEN {
+                    return Err(DnsError::LabelTooLong {
+                        length: len as usize,
+                    });
+                }
+                if input.len().saturating_sub(offset) < label_len {
+                    return Err(DnsError::UnexpectedEof);
+                }
+
+                let label_bytes = &input[offset..offset + label_len];
+                validate_label(label_bytes)?;
+                encoded_len += 1 + label_len;
+                if encoded_len > MAX_ENCODED_NAME_LEN {
+                    return Err(DnsError::NameTooLong);
+                }
+
+                labels.push(
+                    String::from_utf8(label_bytes.to_vec()).map_err(|_| DnsError::NonAsciiLabel)?,
+                );
+                offset += label_len;
+            }
+            0b1100_0000 => {
+                if input.len().saturating_sub(offset) < 2 {
+                    return Err(DnsError::UnexpectedEof);
+                }
+                if consumed_cursor.is_none() {
+                    consumed_cursor = Some(offset + 2);
+                }
+                let pointer = (((len as usize) & 0x3f) << 8) | input[offset + 1] as usize;
+                if pointer >= input.len() {
+                    return Err(DnsError::PointerOutOfBounds { offset: pointer });
+                }
+                offset = pointer;
+            }
+            _ => return Err(DnsError::Unsupported("reserved DNS label prefix")),
+        }
+    }
+}
+
+fn write_name(output: &mut Vec<u8>, name: &DnsName) -> Result<(), DnsError> {
+    validate_encoded_name_len(name)?;
+    for label in &name.labels {
+        let bytes = label.as_bytes();
+        validate_label(bytes)?;
+        output.push(bytes.len() as u8);
+        output.extend_from_slice(bytes);
+    }
+    output.push(0);
+    Ok(())
+}
+
+fn write_record(output: &mut Vec<u8>, record: &DnsResourceRecord) -> Result<(), DnsError> {
+    write_name(output, &record.name)?;
+    write_u16(output, record.rrtype.to_u16());
+    write_u16(output, record.class.to_u16());
+    write_u32(output, record.ttl);
+
+    let mut data = Vec::new();
+    match &record.data {
+        DnsRecordData::A(address) => data.extend_from_slice(address),
+        DnsRecordData::AAAA(address) => data.extend_from_slice(address),
+        DnsRecordData::CNAME(name) => write_name(&mut data, name)?,
+        DnsRecordData::Raw(bytes) => data.extend_from_slice(bytes),
+    }
+
+    if data.len() > u16::MAX as usize {
+        return Err(DnsError::Unsupported("record data too large"));
+    }
+    write_u16(output, data.len() as u16);
+    output.extend_from_slice(&data);
+    Ok(())
+}
+
+fn validate_label(label: &[u8]) -> Result<(), DnsError> {
+    if label.len() > MAX_LABEL_LEN {
+        return Err(DnsError::LabelTooLong {
+            length: label.len(),
+        });
+    }
+    if !label.is_ascii() {
+        return Err(DnsError::NonAsciiLabel);
+    }
+    Ok(())
+}
+
+fn validate_encoded_name_len(name: &DnsName) -> Result<(), DnsError> {
+    let len = name.labels.iter().try_fold(1usize, |acc, label| {
+        let label_len = label.as_bytes().len();
+        if label_len > MAX_LABEL_LEN {
+            return Err(DnsError::LabelTooLong { length: label_len });
+        }
+        Ok(acc + 1 + label_len)
+    })?;
+    if len > MAX_ENCODED_NAME_LEN {
+        Err(DnsError::NameTooLong)
+    } else {
+        Ok(())
+    }
+}
+
+fn read_u16(input: &[u8], cursor: &mut usize) -> Result<u16, DnsError> {
+    if input.len().saturating_sub(*cursor) < 2 {
+        return Err(DnsError::UnexpectedEof);
+    }
+    let value = u16::from_be_bytes([input[*cursor], input[*cursor + 1]]);
+    *cursor += 2;
+    Ok(value)
+}
+
+fn read_u32(input: &[u8], cursor: &mut usize) -> Result<u32, DnsError> {
+    if input.len().saturating_sub(*cursor) < 4 {
+        return Err(DnsError::UnexpectedEof);
+    }
+    let value = u32::from_be_bytes([
+        input[*cursor],
+        input[*cursor + 1],
+        input[*cursor + 2],
+        input[*cursor + 3],
+    ]);
+    *cursor += 4;
+    Ok(value)
+}
+
+fn write_u16(output: &mut Vec<u8>, value: u16) {
+    output.extend_from_slice(&value.to_be_bytes());
+}
+
+fn write_u32(output: &mut Vec<u8>, value: u32) {
+    output.extend_from_slice(&value.to_be_bytes());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn info_cern_query_bytes() -> Vec<u8> {
+        vec![
+            0x12, 0x34, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, b'i',
+            b'n', b'f', b'o', 0x04, b'c', b'e', b'r', b'n', 0x02, b'c', b'h', 0x00, 0x00, 0x01,
+            0x00, 0x01,
+        ]
+    }
+
+    fn empty_message() -> DnsMessage {
+        DnsMessage {
+            header: DnsHeader {
+                id: 0x9999,
+                flags: DnsFlags::query(),
+                question_count: 0,
+                answer_count: 0,
+                authority_count: 0,
+                additional_count: 0,
+            },
+            questions: vec![],
+            answers: vec![],
+            authorities: vec![],
+            additionals: vec![],
+        }
+    }
+
+    #[test]
+    fn builds_and_serializes_a_query_without_transport_assumptions() {
+        let query = build_query(
+            0x1234,
+            DnsName::from_ascii("info.cern.ch").unwrap(),
+            DnsRecordType::A,
+        );
+
+        assert_eq!(
+            serialize_dns_message(&query).unwrap(),
+            info_cern_query_bytes()
+        );
+    }
+
+    #[test]
+    fn parses_a_query_round_trip() {
+        let parsed = parse_dns_message(&info_cern_query_bytes()).unwrap();
+
+        assert_eq!(parsed.header.id, 0x1234);
+        assert!(!parsed.header.flags.is_response);
+        assert!(parsed.header.flags.recursion_desired);
+        assert_eq!(parsed.questions.len(), 1);
+        assert_eq!(parsed.questions[0].name.to_string(), "info.cern.ch");
+        assert_eq!(parsed.questions[0].qtype, DnsRecordType::A);
+        assert_eq!(parsed.questions[0].qclass, DnsClass::IN);
+    }
+
+    #[test]
+    fn root_names_display_and_report_root() {
+        let root = DnsName::from_ascii(".").unwrap();
+        let trailing_dot = DnsName::from_ascii("example.com.").unwrap();
+
+        assert!(root.is_root());
+        assert_eq!(root.to_string(), ".");
+        assert!(!trailing_dot.is_root());
+        assert_eq!(trailing_dot.to_string(), "example.com");
+    }
+
+    #[test]
+    fn rejects_empty_internal_label() {
+        assert_eq!(
+            DnsName::from_ascii("bad..example"),
+            Err(DnsError::Unsupported("empty DNS label"))
+        );
+    }
+
+    #[test]
+    fn rejects_names_longer_than_wire_limit() {
+        let label = "a".repeat(63);
+        let too_long = format!("{label}.{label}.{label}.{label}");
+
+        assert_eq!(DnsName::from_ascii(&too_long), Err(DnsError::NameTooLong));
+    }
+
+    #[test]
+    fn parses_compressed_a_response() {
+        let mut bytes = info_cern_query_bytes();
+        bytes[2] = 0x81;
+        bytes[3] = 0x80;
+        bytes[6] = 0x00;
+        bytes[7] = 0x01;
+        bytes.extend_from_slice(&[
+            0xc0, 0x0c, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x01, 0x2c, 0x00, 0x04, 188, 184, 21,
+            108,
+        ]);
+
+        let parsed = parse_dns_message(&bytes).unwrap();
+
+        assert!(parsed.is_success());
+        assert_eq!(parsed.answers.len(), 1);
+        assert_eq!(parsed.answers[0].name.to_string(), "info.cern.ch");
+        assert_eq!(parsed.answers[0].ttl, 300);
+        assert_eq!(parsed.ipv4_answers(), vec![[188, 184, 21, 108]]);
+    }
+
+    #[test]
+    fn parses_cname_response_with_compressed_target() {
+        let mut bytes = info_cern_query_bytes();
+        bytes[2] = 0x81;
+        bytes[3] = 0x80;
+        bytes[6] = 0x00;
+        bytes[7] = 0x01;
+        bytes.extend_from_slice(&[
+            0xc0, 0x0c, 0x00, 0x05, 0x00, 0x01, 0x00, 0x00, 0x00, 0x3c, 0x00, 0x08, 0x05, b'a',
+            b'l', b'i', b'a', b's', 0xc0, 0x11,
+        ]);
+
+        let parsed = parse_dns_message(&bytes).unwrap();
+
+        assert_eq!(parsed.answers[0].rrtype, DnsRecordType::CNAME);
+        assert_eq!(
+            parsed.answers[0].data,
+            DnsRecordData::CNAME(DnsName::from_ascii("alias.cern.ch").unwrap())
+        );
+    }
+
+    #[test]
+    fn parses_aaaa_answers() {
+        let name = DnsName::from_ascii("example.com").unwrap();
+        let message = DnsMessage {
+            header: DnsHeader {
+                id: 7,
+                flags: DnsFlags {
+                    is_response: true,
+                    opcode: DnsOpcode::Query,
+                    authoritative_answer: false,
+                    truncated: false,
+                    recursion_desired: true,
+                    recursion_available: true,
+                    response_code: DnsResponseCode::NoError,
+                },
+                question_count: 0,
+                answer_count: 1,
+                authority_count: 0,
+                additional_count: 0,
+            },
+            questions: vec![],
+            answers: vec![DnsResourceRecord {
+                name,
+                rrtype: DnsRecordType::AAAA,
+                class: DnsClass::IN,
+                ttl: 10,
+                data: DnsRecordData::AAAA([
+                    0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+                ]),
+            }],
+            authorities: vec![],
+            additionals: vec![],
+        };
+
+        let parsed = parse_dns_message(&serialize_dns_message(&message).unwrap()).unwrap();
+
+        assert_eq!(parsed.ipv6_answers().len(), 1);
+        assert_eq!(parsed.answers[0].ttl, 10);
+    }
+
+    #[test]
+    fn preserves_unknown_record_data() {
+        let record = DnsResourceRecord {
+            name: DnsName::from_ascii("example.com").unwrap(),
+            rrtype: DnsRecordType::Unknown(65),
+            class: DnsClass::IN,
+            ttl: 1,
+            data: DnsRecordData::Raw(vec![1, 2, 3]),
+        };
+        let message = DnsMessage {
+            header: DnsHeader {
+                id: 1,
+                flags: DnsFlags::query(),
+                question_count: 0,
+                answer_count: 1,
+                authority_count: 0,
+                additional_count: 0,
+            },
+            questions: vec![],
+            answers: vec![record.clone()],
+            authorities: vec![],
+            additionals: vec![],
+        };
+
+        let parsed = parse_dns_message(&serialize_dns_message(&message).unwrap()).unwrap();
+
+        assert_eq!(parsed.answers[0], record);
+    }
+
+    #[test]
+    fn serializes_and_parses_authority_and_additional_sections() {
+        let mut message = empty_message();
+        message.header.flags = DnsFlags {
+            is_response: true,
+            opcode: DnsOpcode::Query,
+            authoritative_answer: true,
+            truncated: false,
+            recursion_desired: true,
+            recursion_available: true,
+            response_code: DnsResponseCode::NoError,
+        };
+        message.authorities.push(DnsResourceRecord {
+            name: DnsName::from_ascii("example.com").unwrap(),
+            rrtype: DnsRecordType::NS,
+            class: DnsClass::Unknown(3),
+            ttl: 60,
+            data: DnsRecordData::Raw(vec![2, b'n', b's', 0]),
+        });
+        message.additionals.push(DnsResourceRecord {
+            name: DnsName::from_ascii("ns.example.com").unwrap(),
+            rrtype: DnsRecordType::A,
+            class: DnsClass::IN,
+            ttl: 60,
+            data: DnsRecordData::A([192, 0, 2, 53]),
+        });
+
+        let parsed = parse_dns_message(&serialize_dns_message(&message).unwrap()).unwrap();
+
+        assert!(parsed.header.flags.authoritative_answer);
+        assert_eq!(parsed.authorities.len(), 1);
+        assert_eq!(parsed.additionals.len(), 1);
+        assert_eq!(parsed.authorities[0].class, DnsClass::Unknown(3));
+    }
+
+    #[test]
+    fn first_answer_of_type_finds_matching_record() {
+        let mut message = empty_message();
+        message.answers.push(DnsResourceRecord {
+            name: DnsName::from_ascii("example.com").unwrap(),
+            rrtype: DnsRecordType::A,
+            class: DnsClass::IN,
+            ttl: 1,
+            data: DnsRecordData::A([203, 0, 113, 7]),
+        });
+
+        assert!(message.first_answer_of_type(DnsRecordType::A).is_some());
+        assert!(message.first_answer_of_type(DnsRecordType::AAAA).is_none());
+    }
+
+    #[test]
+    fn round_trips_common_question_record_types() {
+        let types = [
+            DnsRecordType::NS,
+            DnsRecordType::CNAME,
+            DnsRecordType::SOA,
+            DnsRecordType::PTR,
+            DnsRecordType::MX,
+            DnsRecordType::TXT,
+            DnsRecordType::AAAA,
+            DnsRecordType::Unknown(65400),
+        ];
+
+        for qtype in types {
+            let query = build_query(5, DnsName::from_ascii("example.com").unwrap(), qtype);
+            let parsed = parse_dns_message(&serialize_dns_message(&query).unwrap()).unwrap();
+            assert_eq!(parsed.questions[0].qtype, qtype);
+        }
+    }
+
+    #[test]
+    fn parses_unknown_opcode_and_response_code() {
+        let bytes = [
+            0x00, 0x01, 0xf0, 0x0f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+
+        let parsed = parse_dns_message(&bytes).unwrap();
+
+        assert_eq!(parsed.header.flags.opcode, DnsOpcode::Unknown(14));
+        assert_eq!(
+            parsed.header.flags.response_code,
+            DnsResponseCode::Unknown(15)
+        );
+    }
+
+    #[test]
+    fn serializes_unknown_opcode_and_all_response_codes() {
+        for response_code in [
+            DnsResponseCode::FormatError,
+            DnsResponseCode::ServerFailure,
+            DnsResponseCode::NameError,
+            DnsResponseCode::NotImplemented,
+            DnsResponseCode::Refused,
+            DnsResponseCode::Unknown(9),
+        ] {
+            let mut message = empty_message();
+            message.header.flags = DnsFlags {
+                is_response: true,
+                opcode: DnsOpcode::Unknown(2),
+                authoritative_answer: true,
+                truncated: true,
+                recursion_desired: true,
+                recursion_available: true,
+                response_code,
+            };
+
+            let parsed = parse_dns_message(&serialize_dns_message(&message).unwrap()).unwrap();
+
+            assert_eq!(parsed.header.flags.opcode, DnsOpcode::Unknown(2));
+            assert_eq!(parsed.header.flags.response_code, response_code);
+            assert!(parsed.header.flags.authoritative_answer);
+            assert!(parsed.header.flags.truncated);
+        }
+    }
+
+    #[test]
+    fn parses_nxdomain_response_code() {
+        let mut bytes = info_cern_query_bytes();
+        bytes[2] = 0x81;
+        bytes[3] = 0x83;
+
+        let parsed = parse_dns_message(&bytes).unwrap();
+
+        assert_eq!(
+            parsed.header.flags.response_code,
+            DnsResponseCode::NameError
+        );
+        assert!(!parsed.is_success());
+    }
+
+    #[test]
+    fn exposes_truncated_flag_as_protocol_information() {
+        let mut bytes = info_cern_query_bytes();
+        bytes[2] = 0x82;
+        bytes[3] = 0x80;
+
+        let parsed = parse_dns_message(&bytes).unwrap();
+
+        assert!(parsed.header.flags.truncated);
+    }
+
+    #[test]
+    fn rejects_truncated_header() {
+        assert_eq!(parse_dns_message(&[0; 11]), Err(DnsError::TruncatedHeader));
+    }
+
+    #[test]
+    fn rejects_unexpected_eof_inside_question() {
+        let mut bytes = info_cern_query_bytes();
+        bytes.truncate(bytes.len() - 1);
+
+        assert_eq!(parse_dns_message(&bytes), Err(DnsError::UnexpectedEof));
+    }
+
+    #[test]
+    fn rejects_unexpected_eof_inside_record_header() {
+        let mut bytes = info_cern_query_bytes();
+        bytes[2] = 0x81;
+        bytes[3] = 0x80;
+        bytes[6] = 0x00;
+        bytes[7] = 0x01;
+        bytes.extend_from_slice(&[0xc0, 0x0c, 0x00, 0x01]);
+
+        assert_eq!(parse_dns_message(&bytes), Err(DnsError::UnexpectedEof));
+    }
+
+    #[test]
+    fn rejects_unexpected_eof_inside_rdata() {
+        let mut bytes = info_cern_query_bytes();
+        bytes[2] = 0x81;
+        bytes[3] = 0x80;
+        bytes[6] = 0x00;
+        bytes[7] = 0x01;
+        bytes.extend_from_slice(&[0xc0, 0x0c, 0x00, 0x01, 0x00, 0x01, 0, 0, 0, 1, 0, 4, 1, 2]);
+
+        assert_eq!(parse_dns_message(&bytes), Err(DnsError::UnexpectedEof));
+    }
+
+    #[test]
+    fn rejects_pointer_loop() {
+        let bytes = vec![
+            0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc0, 0x0c,
+            0x00, 0x01, 0x00, 0x01,
+        ];
+
+        assert_eq!(parse_dns_message(&bytes), Err(DnsError::PointerLoop));
+    }
+
+    #[test]
+    fn rejects_pointer_out_of_bounds() {
+        let bytes = vec![
+            0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc0, 0xff,
+            0x00, 0x01, 0x00, 0x01,
+        ];
+
+        assert_eq!(
+            parse_dns_message(&bytes),
+            Err(DnsError::PointerOutOfBounds { offset: 255 })
+        );
+    }
+
+    #[test]
+    fn rejects_pointer_missing_second_byte() {
+        let bytes = vec![
+            0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc0,
+        ];
+
+        assert_eq!(parse_dns_message(&bytes), Err(DnsError::UnexpectedEof));
+    }
+
+    #[test]
+    fn rejects_non_ascii_names() {
+        assert_eq!(
+            DnsName::from_ascii("cafe\u{e9}.example"),
+            Err(DnsError::NonAsciiLabel)
+        );
+    }
+
+    #[test]
+    fn rejects_non_ascii_wire_label() {
+        let bytes = vec![
+            0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0xff,
+            0x00, 0x00, 0x01, 0x00, 0x01,
+        ];
+
+        assert_eq!(parse_dns_message(&bytes), Err(DnsError::NonAsciiLabel));
+    }
+
+    #[test]
+    fn rejects_reserved_wire_label_prefix() {
+        let bytes = vec![
+            0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00,
+            0x01, 0x00, 0x01,
+        ];
+
+        assert_eq!(
+            parse_dns_message(&bytes),
+            Err(DnsError::Unsupported("reserved DNS label prefix"))
+        );
+    }
+
+    #[test]
+    fn rejects_wire_name_longer_than_limit() {
+        let label = vec![b'a'; 63];
+        let mut bytes = vec![
+            0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+        for _ in 0..4 {
+            bytes.push(63);
+            bytes.extend_from_slice(&label);
+        }
+        bytes.extend_from_slice(&[0x00, 0x00, 0x01, 0x00, 0x01]);
+
+        assert_eq!(parse_dns_message(&bytes), Err(DnsError::NameTooLong));
+    }
+
+    #[test]
+    fn rejects_labels_longer_than_sixty_three_octets() {
+        let long = "a".repeat(64);
+
+        assert_eq!(
+            DnsName::from_ascii(&format!("{long}.example")),
+            Err(DnsError::LabelTooLong { length: 64 })
+        );
+    }
+
+    #[test]
+    fn rejects_cname_record_with_trailing_rdata() {
+        let mut bytes = info_cern_query_bytes();
+        bytes[2] = 0x81;
+        bytes[3] = 0x80;
+        bytes[6] = 0x00;
+        bytes[7] = 0x01;
+        bytes.extend_from_slice(&[
+            0xc0, 0x0c, 0x00, 0x05, 0x00, 0x01, 0, 0, 0, 1, 0, 3, 0xc0, 0x0c, 0xff,
+        ]);
+
+        assert_eq!(
+            parse_dns_message(&bytes),
+            Err(DnsError::Unsupported(
+                "CNAME record data must contain exactly one DNS name"
+            ))
+        );
+    }
+
+    #[test]
+    fn encodes_root_name() {
+        let query = build_query(1, DnsName::from_ascii(".").unwrap(), DnsRecordType::NS);
+        let bytes = serialize_dns_message(&query).unwrap();
+
+        assert_eq!(bytes[12], 0);
+    }
+
+    #[test]
+    fn rejects_wrong_a_record_length() {
+        let mut bytes = info_cern_query_bytes();
+        bytes[2] = 0x81;
+        bytes[3] = 0x80;
+        bytes[6] = 0x00;
+        bytes[7] = 0x01;
+        bytes.extend_from_slice(&[
+            0xc0, 0x0c, 0x00, 0x01, 0x00, 0x01, 0, 0, 0, 1, 0, 3, 1, 2, 3,
+        ]);
+
+        assert_eq!(
+            parse_dns_message(&bytes),
+            Err(DnsError::Unsupported("A record data must be 4 bytes"))
+        );
+    }
+
+    #[test]
+    fn rejects_wrong_aaaa_record_length() {
+        let mut bytes = info_cern_query_bytes();
+        bytes[2] = 0x81;
+        bytes[3] = 0x80;
+        bytes[6] = 0x00;
+        bytes[7] = 0x01;
+        bytes.extend_from_slice(&[0xc0, 0x0c, 0x00, 0x1c, 0x00, 0x01, 0, 0, 0, 1, 0, 15]);
+        bytes.extend_from_slice(&[0; 15]);
+
+        assert_eq!(
+            parse_dns_message(&bytes),
+            Err(DnsError::Unsupported("AAAA record data must be 16 bytes"))
+        );
+    }
+
+    #[test]
+    fn rejects_too_many_questions_before_serializing() {
+        let mut message = empty_message();
+        let question = DnsQuestion {
+            name: DnsName::from_ascii(".").unwrap(),
+            qtype: DnsRecordType::A,
+            qclass: DnsClass::IN,
+        };
+        message.questions = vec![question; u16::MAX as usize + 1];
+
+        assert_eq!(
+            serialize_dns_message(&message),
+            Err(DnsError::InvalidSectionCount)
+        );
+    }
+
+    #[test]
+    fn rejects_record_data_larger_than_dns_length_field() {
+        let mut message = empty_message();
+        message.answers.push(DnsResourceRecord {
+            name: DnsName::from_ascii(".").unwrap(),
+            rrtype: DnsRecordType::Unknown(65000),
+            class: DnsClass::IN,
+            ttl: 0,
+            data: DnsRecordData::Raw(vec![0; u16::MAX as usize + 1]),
+        });
+
+        assert_eq!(
+            serialize_dns_message(&message),
+            Err(DnsError::Unsupported("record data too large"))
+        );
+    }
+}

--- a/code/packages/rust/dns-message/src/lib.rs
+++ b/code/packages/rust/dns-message/src/lib.rs
@@ -8,11 +8,15 @@
 //! Keeping this crate pure is what lets a future resolver send the same DNS
 //! message over UDP, TCP, a simulated network stack, or test fixtures.
 
+use std::collections::HashSet;
 use std::fmt;
 
 const DNS_HEADER_LEN: usize = 12;
 const MAX_LABEL_LEN: usize = 63;
 const MAX_ENCODED_NAME_LEN: usize = 255;
+const MIN_QUESTION_WIRE_LEN: usize = 5;
+const MIN_RECORD_WIRE_LEN: usize = 11;
+const MAX_NAME_POINTER_HOPS: usize = 128;
 
 /// A DNS domain name represented as human-readable labels.
 ///
@@ -445,7 +449,12 @@ fn parse_questions(
     cursor: &mut usize,
     count: u16,
 ) -> Result<Vec<DnsQuestion>, DnsError> {
-    let mut questions = Vec::with_capacity(count as usize);
+    let mut questions = Vec::with_capacity(section_capacity(
+        input,
+        *cursor,
+        count,
+        MIN_QUESTION_WIRE_LEN,
+    ));
     for _ in 0..count {
         let name = read_name(input, cursor)?;
         let qtype = DnsRecordType::from_u16(read_u16(input, cursor)?);
@@ -464,7 +473,8 @@ fn parse_records(
     cursor: &mut usize,
     count: u16,
 ) -> Result<Vec<DnsResourceRecord>, DnsError> {
-    let mut records = Vec::with_capacity(count as usize);
+    let mut records =
+        Vec::with_capacity(section_capacity(input, *cursor, count, MIN_RECORD_WIRE_LEN));
     for _ in 0..count {
         let name = read_name(input, cursor)?;
         let rrtype = DnsRecordType::from_u16(read_u16(input, cursor)?);
@@ -522,17 +532,17 @@ fn read_name(input: &[u8], cursor: &mut usize) -> Result<DnsName, DnsError> {
     let mut labels = Vec::new();
     let mut offset = *cursor;
     let mut consumed_cursor = None;
-    let mut visited = Vec::new();
+    let mut visited = HashSet::new();
+    let mut pointer_hops = 0usize;
     let mut encoded_len = 1usize;
 
     loop {
         if offset >= input.len() {
             return Err(DnsError::UnexpectedEof);
         }
-        if visited.contains(&offset) {
+        if !visited.insert(offset) {
             return Err(DnsError::PointerLoop);
         }
-        visited.push(offset);
 
         let len = input[offset];
         match len & 0b1100_0000 {
@@ -574,6 +584,10 @@ fn read_name(input: &[u8], cursor: &mut usize) -> Result<DnsName, DnsError> {
                 if consumed_cursor.is_none() {
                     consumed_cursor = Some(offset + 2);
                 }
+                pointer_hops += 1;
+                if pointer_hops > MAX_NAME_POINTER_HOPS {
+                    return Err(DnsError::PointerLoop);
+                }
                 let pointer = (((len as usize) & 0x3f) << 8) | input[offset + 1] as usize;
                 if pointer >= input.len() {
                     return Err(DnsError::PointerOutOfBounds { offset: pointer });
@@ -583,6 +597,14 @@ fn read_name(input: &[u8], cursor: &mut usize) -> Result<DnsName, DnsError> {
             _ => return Err(DnsError::Unsupported("reserved DNS label prefix")),
         }
     }
+}
+
+fn section_capacity(input: &[u8], cursor: usize, count: u16, minimum_entry_len: usize) -> usize {
+    // Header counts are attacker-controlled. Reserve only what the remaining
+    // bytes could possibly contain; the parser still verifies each entry as it
+    // goes so callers get precise EOF errors for malformed sections.
+    let possible_entries = input.len().saturating_sub(cursor) / minimum_entry_len;
+    usize::from(count).min(possible_entries)
 }
 
 fn write_name(output: &mut Vec<u8>, name: &DnsName) -> Result<(), DnsError> {
@@ -1060,6 +1082,20 @@ mod tests {
     }
 
     #[test]
+    fn rejects_excessive_pointer_chain() {
+        let mut bytes = vec![
+            0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+        for hop in 0..=MAX_NAME_POINTER_HOPS {
+            let target = DNS_HEADER_LEN + ((hop + 1) * 2);
+            bytes.push(0xc0 | ((target >> 8) as u8 & 0x3f));
+            bytes.push((target & 0xff) as u8);
+        }
+
+        assert_eq!(parse_dns_message(&bytes), Err(DnsError::PointerLoop));
+    }
+
+    #[test]
     fn rejects_pointer_out_of_bounds() {
         let bytes = vec![
             0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc0, 0xff,
@@ -1211,6 +1247,15 @@ mod tests {
             serialize_dns_message(&message),
             Err(DnsError::InvalidSectionCount)
         );
+    }
+
+    #[test]
+    fn rejects_huge_question_count_without_large_preallocation() {
+        let bytes = vec![
+            0x00, 0x01, 0x01, 0x00, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+
+        assert_eq!(parse_dns_message(&bytes), Err(DnsError::UnexpectedEof));
     }
 
     #[test]

--- a/code/specs/NET06-dns-message.md
+++ b/code/specs/NET06-dns-message.md
@@ -252,15 +252,17 @@ pub struct DnsName {
 
 impl DnsName {
     /// Parse a dotted ASCII name such as "info.cern.ch" or ".".
-    pub fn from_str(input: &str) -> Result<Self, DnsError>;
+    pub fn from_ascii(input: &str) -> Result<Self, DnsError>;
 
-    /// Convert back to dotted form without a trailing dot, except "." for root.
-    pub fn to_string(&self) -> String;
+    /// Return true when this is the root name (`.`).
+    pub fn is_root(&self) -> bool;
 }
 ```
 
 The first version only requires ASCII labels. Internationalized names can be
-added later through punycode at a higher layer.
+added later through punycode at a higher layer. Rust implementations should
+also implement `Display`, which gives callers the standard `.to_string()` helper
+without requiring a custom inherent method.
 
 ### Header Fields
 
@@ -433,7 +435,7 @@ pub enum DnsError {
     UnexpectedEof,
 
     /// A label length exceeded 63 bytes.
-    LabelTooLong { length: u8 },
+    LabelTooLong { length: usize },
 
     /// The full encoded name exceeded 255 bytes.
     NameTooLong,

--- a/code/specs/NET06-dns-message.md
+++ b/code/specs/NET06-dns-message.md
@@ -1,0 +1,651 @@
+# NET06 — DNS Message Codec
+
+## Overview
+
+DNS (Domain Name System) is the internet's phone book. Humans remember names
+like `info.cern.ch`; computers route packets to numeric IP addresses like
+`188.184.21.108` or `2001:1458:d00:3c::100:47`. A DNS message is the wire-level
+question or answer that bridges those two worlds.
+
+This package specifies a **transport-agnostic DNS message codec**:
+
+- build DNS queries in memory
+- serialize them to the RFC 1035 wire format
+- parse DNS responses from raw bytes
+- expose structured questions, headers, and resource records
+
+It deliberately does **not** open sockets or talk to a nameserver directly.
+That separation matters. DNS runs mostly over UDP, sometimes over TCP, and may
+later run over TLS or HTTPS. The message format should not care which transport
+carried it.
+
+**Analogy:** DNS is like sending an index card to an information desk:
+
+```
+Question card:
+  "What is the address for info.cern.ch?"
+
+Answer card:
+  "info.cern.ch is 188.184.21.108"
+  "This answer is valid for 300 seconds"
+```
+
+This package defines the shape of the card, not the mail truck that delivers
+it.
+
+## Where It Fits
+
+```
+User enters "http://info.cern.ch/"
+     │
+     ▼
+url-parser (NET00)
+     │  host = "info.cern.ch"
+     ▼
+future dns-client (NET07 or later)
+     │
+     ├── dns-message (NET06) ← THIS PACKAGE
+     │     build query bytes / parse answer bytes
+     │
+     └── future udp-client
+           send query to recursive resolver on port 53
+     ▼
+tcp-client (NET01)
+     │  connect to resolved IP address
+     ▼
+http1.0-client (NET05)
+```
+
+For now, `tcp-client` still uses the operating system resolver. NET06 is the
+first step toward replacing that with a real cross-language DNS stack.
+
+**Depends on:** nothing (std only)
+**Depended on by:** future DNS resolver/client packages, browser networking
+stack, any program that needs to encode or decode DNS messages
+
+---
+
+## Concepts
+
+### 1. DNS Is a Question-and-Answer Protocol
+
+At its core, a DNS exchange is tiny:
+
+```
+Client asks:
+  name  = "info.cern.ch"
+  type  = A
+  class = IN
+
+Server answers:
+  name  = "info.cern.ch"
+  type  = A
+  class = IN
+  ttl   = 300
+  data  = 188.184.21.108
+```
+
+The first version of this package focuses on exactly that shape:
+
+- **standard query** messages (`opcode = QUERY`)
+- **Internet class** (`IN`)
+- record types needed by a browser-first stack:
+  - `A`     — IPv4 address
+  - `AAAA`  — IPv6 address
+  - `CNAME` — alias to another name
+
+Unknown record types are still preserved as raw bytes so the parser stays
+forward-compatible.
+
+### 2. Every DNS Message Starts with a 12-Byte Header
+
+The DNS header is fixed-size and always comes first:
+
+```
+0                   1                   2                   3
+0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-------------------------------+-------------------------------+
+|              ID               |QR| Opcode |AA|TC|RD|RA| Z |RC|
++-------------------------------+-------------------------------+
+|           QDCOUNT             |           ANCOUNT             |
++-------------------------------+-------------------------------+
+|           NSCOUNT             |           ARCOUNT             |
++-------------------------------+-------------------------------+
+```
+
+Meaning:
+
+- `ID` — request/response correlation token
+- `QR` — 0 for query, 1 for response
+- `Opcode` — the operation; v1 supports only standard query (`0`)
+- `AA` — authoritative answer
+- `TC` — truncated
+- `RD` — recursion desired
+- `RA` — recursion available
+- `RCODE` — result code (`NOERROR`, `NXDOMAIN`, etc.)
+- `QDCOUNT` — number of questions
+- `ANCOUNT` — number of answer records
+- `NSCOUNT` — number of authority records
+- `ARCOUNT` — number of additional records
+
+This package parses and serializes all header fields, even when the first
+version only acts on a subset of them.
+
+### 3. Domain Names Are Encoded as Length-Prefixed Labels
+
+DNS does not send names as `"info.cern.ch"` text with dots. It sends labels:
+
+```
+"info.cern.ch"
+
+becomes
+
+04 'i' 'n' 'f' 'o'
+04 'c' 'e' 'r' 'n'
+02 'c' 'h'
+00
+```
+
+Rules:
+
+- each label is at most 63 bytes
+- the full encoded name is at most 255 bytes
+- the name ends with a zero-length root label
+- the root domain itself is just `00`
+
+The public API should expose names in a structured way, not as raw on-the-wire
+bytes. The wire encoding is an implementation detail.
+
+### 4. DNS Messages Have Four Sections
+
+After the header, the message contains up to four sections:
+
+1. **Question** — what is being asked
+2. **Answer** — the direct answer
+3. **Authority** — which server is authoritative
+4. **Additional** — extra helpful records, such as glue
+
+For the first resolver slice, the **Question** and **Answer** sections matter
+most. But the parser should still decode all four sections so we do not need to
+redesign the API later.
+
+### 5. Responses Commonly Use Name Compression
+
+DNS reuses repeated names through pointers. Instead of writing the same suffix
+again, a message can say "jump back to byte 12 and continue reading there."
+
+Example:
+
+```
+Question name at byte 12:
+  04 info 04 cern 02 ch 00
+
+Answer name:
+  C0 0C
+
+Meaning:
+  top two bits = 11 → compression pointer
+  remaining 14 bits = 0x000C = byte offset 12
+```
+
+Compression is one of the trickiest parts of DNS parsing, so the first version
+must handle it correctly:
+
+- parser accepts legal compression pointers in names
+- serializer for **queries** does not use compression in v1
+- serializer for general messages may add compression later
+- pointer loops and out-of-bounds jumps are parse errors
+
+This keeps query generation simple without giving up real-world compatibility on
+responses.
+
+### 6. DNS Has Protocol Semantics Above Raw Parsing
+
+A DNS message parser should not stop at "bytes parsed successfully." Some
+message states are semantically meaningful:
+
+- `RCODE = NXDOMAIN` means "the name does not exist"
+- `TC = 1` means "this UDP response was truncated"
+- `ANCOUNT = 0` with `NOERROR` often means "no records of that type"
+- a response can contain a `CNAME` chain before the final `A` or `AAAA`
+
+The codec does not perform network retries or TCP fallback, but it must expose
+these protocol facts clearly so a future client can make the right decision.
+
+### 7. The First Version Is Deliberately Narrow
+
+DNS as deployed today is large:
+
+- `MX`, `TXT`, `NS`, `SOA`, `PTR`, `SRV`, `HTTPS`, `SVCB`, `CAA`, ...
+- EDNS(0)
+- DNSSEC
+- zone transfers
+- dynamic updates
+- IDNA / punycode concerns
+- TCP fallback
+- caching and TTL expiration
+
+NET06 is not trying to solve all of DNS. It defines the smallest reusable
+message layer that still feels like real DNS, not a toy.
+
+---
+
+## Public API
+
+The examples below use Rust syntax because Rust is the primary implementation
+language for the browser networking stack. Other language ports should expose
+the same conceptual model.
+
+### Names
+
+```rust
+/// A DNS domain name expressed as human-meaningful labels.
+///
+/// Examples:
+/// - ["info", "cern", "ch"]
+/// - ["localhost"]
+/// - []  // the root domain
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DnsName {
+    pub labels: Vec<String>,
+}
+
+impl DnsName {
+    /// Parse a dotted ASCII name such as "info.cern.ch" or ".".
+    pub fn from_str(input: &str) -> Result<Self, DnsError>;
+
+    /// Convert back to dotted form without a trailing dot, except "." for root.
+    pub fn to_string(&self) -> String;
+}
+```
+
+The first version only requires ASCII labels. Internationalized names can be
+added later through punycode at a higher layer.
+
+### Header Fields
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DnsOpcode {
+    Query,
+    Unknown(u8),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DnsResponseCode {
+    NoError,
+    FormatError,
+    ServerFailure,
+    NameError,       // NXDOMAIN
+    NotImplemented,
+    Refused,
+    Unknown(u8),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DnsFlags {
+    pub is_response: bool,
+    pub opcode: DnsOpcode,
+    pub authoritative_answer: bool,
+    pub truncated: bool,
+    pub recursion_desired: bool,
+    pub recursion_available: bool,
+    pub response_code: DnsResponseCode,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DnsHeader {
+    pub id: u16,
+    pub flags: DnsFlags,
+    pub question_count: u16,
+    pub answer_count: u16,
+    pub authority_count: u16,
+    pub additional_count: u16,
+}
+```
+
+### Questions
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DnsRecordType {
+    A,
+    NS,
+    CNAME,
+    SOA,
+    PTR,
+    MX,
+    TXT,
+    AAAA,
+    Unknown(u16),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DnsClass {
+    IN,
+    Unknown(u16),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DnsQuestion {
+    pub name: DnsName,
+    pub qtype: DnsRecordType,
+    pub qclass: DnsClass,
+}
+```
+
+Even though v1 primarily targets `A`, `AAAA`, and `CNAME`, the type enum should
+reserve the common numeric codes now so future expansion is additive instead of
+breaking.
+
+### Resource Records
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DnsRecordData {
+    A([u8; 4]),
+    AAAA([u8; 16]),
+    CNAME(DnsName),
+
+    /// Any record type this version does not interpret yet.
+    Raw(Vec<u8>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DnsResourceRecord {
+    pub name: DnsName,
+    pub rrtype: DnsRecordType,
+    pub class: DnsClass,
+    pub ttl: u32,
+    pub data: DnsRecordData,
+}
+```
+
+### Whole Messages
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DnsMessage {
+    pub header: DnsHeader,
+    pub questions: Vec<DnsQuestion>,
+    pub answers: Vec<DnsResourceRecord>,
+    pub authorities: Vec<DnsResourceRecord>,
+    pub additionals: Vec<DnsResourceRecord>,
+}
+```
+
+### Core Functions
+
+```rust
+/// Parse raw DNS message bytes into a structured message.
+pub fn parse_dns_message(input: &[u8]) -> Result<DnsMessage, DnsError>;
+
+/// Serialize a structured message into DNS wire-format bytes.
+///
+/// V1 guarantees query serialization. General response serialization is
+/// supported when the message only contains record kinds this version knows how
+/// to encode.
+pub fn serialize_dns_message(message: &DnsMessage) -> Result<Vec<u8>, DnsError>;
+
+/// Build a standard single-question query suitable for transport over UDP.
+///
+/// Defaults:
+/// - opcode = Query
+/// - QR = query
+/// - RD = true
+/// - QDCOUNT = 1
+/// - no answers / authorities / additionals
+pub fn build_query(id: u16, name: DnsName, qtype: DnsRecordType) -> DnsMessage;
+```
+
+### Convenience Helpers
+
+```rust
+impl DnsMessage {
+    /// True when this is a response with `RCODE = NOERROR`.
+    pub fn is_success(&self) -> bool;
+
+    /// Return the first answer of the requested type, if present.
+    pub fn first_answer_of_type(&self, qtype: DnsRecordType)
+        -> Option<&DnsResourceRecord>;
+
+    /// Return all IPv4 addresses in the answer section.
+    pub fn ipv4_answers(&self) -> Vec<[u8; 4]>;
+
+    /// Return all IPv6 addresses in the answer section.
+    pub fn ipv6_answers(&self) -> Vec<[u8; 16]>;
+}
+```
+
+These helpers are intentionally small. Caching policy, CNAME chasing policy,
+negative caching, and transport retry behavior belong in a future DNS client
+layer, not the codec.
+
+### Error Types
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DnsError {
+    /// Fewer than 12 bytes — not even a complete header.
+    TruncatedHeader,
+
+    /// The message ended unexpectedly while parsing a name, question, or record.
+    UnexpectedEof,
+
+    /// A label length exceeded 63 bytes.
+    LabelTooLong { length: u8 },
+
+    /// The full encoded name exceeded 255 bytes.
+    NameTooLong,
+
+    /// A compression pointer referenced an invalid offset.
+    PointerOutOfBounds { offset: usize },
+
+    /// Compression pointers formed a cycle.
+    PointerLoop,
+
+    /// A label could not be represented by this version's ASCII name model.
+    NonAsciiLabel,
+
+    /// The message declared counts that do not match the available bytes.
+    InvalidSectionCount,
+
+    /// The message uses an unsupported structure for this version.
+    Unsupported(&'static str),
+}
+```
+
+The parser should prefer specific structural errors over vague "invalid input"
+messages. DNS debugging is much easier when the failure says *why*.
+
+---
+
+## Encoding and Parsing Rules
+
+### 1. Query Builder Rules
+
+`build_query()` in v1 should:
+
+- create exactly one question
+- set `QR = 0`
+- set `Opcode = Query`
+- set `RD = true`
+- set all counts consistently
+- encode names without compression
+- use class `IN`
+
+This produces the classic recursive resolver query shape used by almost every
+stub resolver.
+
+### 2. Name Parsing Rules
+
+The name parser must:
+
+- decode ordinary label sequences
+- decode compression pointers
+- allow names that mix inline labels and one pointer suffix
+- reject pointers to offsets beyond the message length
+- reject pointer cycles
+- preserve the distinction between the root name and non-root names
+
+### 3. Record Data Rules
+
+For this first version:
+
+- `A` record data length must be exactly 4 bytes
+- `AAAA` record data length must be exactly 16 bytes
+- `CNAME` record data is itself a DNS name and may use compression
+- unknown record types are kept as `Raw(Vec<u8>)`
+
+This lets the parser be strict where structure is known and permissive where
+future record types may appear.
+
+### 4. Counts Are Trusted Only After Verification
+
+The header's `QDCOUNT`, `ANCOUNT`, `NSCOUNT`, and `ARCOUNT` tell the parser how
+many entries should appear in each section. But a malformed or malicious packet
+can lie.
+
+The parser must:
+
+- use the counts as the intended section sizes
+- verify enough bytes remain for each parsed element
+- fail with `UnexpectedEof` or `InvalidSectionCount` rather than reading past
+  the end
+
+### 5. Truncation Is Exposed, Not Hidden
+
+If `TC = 1`, the parser still returns the message successfully if the message is
+otherwise structurally valid. Truncation is **protocol information**, not
+necessarily a parse failure. A future DNS client may decide to retry over TCP.
+
+---
+
+## Testing Strategy
+
+### 1. Query Serialization
+
+1. **A query:** `build_query(0x1234, "info.cern.ch", A)` serializes to the
+   expected header and question bytes.
+2. **AAAA query:** same shape with `QTYPE = 28`.
+3. **Root query:** `.` encodes as a single zero byte.
+4. **Single-label query:** `localhost` encodes correctly.
+
+### 2. Header Parsing
+
+5. **Response flags:** parse `QR`, `AA`, `TC`, `RD`, `RA`, and `RCODE`.
+6. **NXDOMAIN response:** `RCODE = NameError`.
+7. **Unknown opcode / rcode:** preserved as `Unknown(...)`.
+
+### 3. Name Parsing
+
+8. **Ordinary name:** parse a plain uncompressed label sequence.
+9. **Compressed answer name:** parse `C0 0C` pointer to the question name.
+10. **Mixed name:** inline label followed by pointer suffix.
+11. **Pointer loop:** detect and error.
+12. **Pointer out of bounds:** detect and error.
+13. **Label too long:** reject labels > 63 bytes.
+14. **Name too long:** reject names > 255 bytes.
+
+### 4. Resource Records
+
+15. **A record:** parse IPv4 address bytes.
+16. **AAAA record:** parse IPv6 address bytes.
+17. **CNAME record:** parse compressed canonical-name target.
+18. **Unknown record type:** preserved as raw data.
+19. **Wrong A length:** reject non-4-byte payload.
+20. **Wrong AAAA length:** reject non-16-byte payload.
+
+### 5. Whole-Message Parsing
+
+21. **Simple response:** one question, one A answer.
+22. **CNAME chain response:** one CNAME answer plus one A answer.
+23. **Authority and additional sections:** parse all four sections correctly.
+24. **Truncated but well-formed response:** parse successfully with
+    `header.flags.truncated = true`.
+25. **Unexpected EOF:** fail when the bytes end mid-record.
+
+### 6. Round-Trip Tests
+
+26. **Query round-trip:** build query → serialize → parse → recover equivalent
+    structured query.
+27. **Known response round-trip:** parse structured response, serialize, parse
+    again for record kinds this version can encode.
+
+### 7. Real-World Fixtures
+
+28. **Captured recursive resolver response:** `A` answer for a public domain.
+29. **Captured response with compression:** ensure realistic pointer layouts are
+    accepted.
+30. **Negative response fixture:** `NXDOMAIN` or empty `NOERROR` answer set.
+
+All fixtures should be byte-for-byte local test data. The package tests do not
+need live network access.
+
+---
+
+## Scope
+
+### In Scope
+
+- RFC 1035 DNS message header parsing and serialization
+- DNS name encoding and decoding
+- compression-pointer parsing
+- single-question query construction
+- full-section message parsing (question, answer, authority, additional)
+- `A`, `AAAA`, and `CNAME` typed record decoding
+- raw preservation for unknown record types
+- protocol flags and response codes
+
+### Out of Scope
+
+- opening sockets
+- UDP or TCP transport
+- resolver retry policy
+- TCP fallback on truncation
+- hosts-file integration
+- search domains
+- caching and TTL expiration
+- IDNA / Unicode hostname handling
+- EDNS(0)
+- DNSSEC
+- zone transfers
+- dynamic update
+- mDNS
+
+### Future Follow-On Specs
+
+1. **DNS client / resolver**
+   Build on NET06 plus a future UDP client to issue recursive queries to a real
+   nameserver.
+
+2. **Caching resolver**
+   Add TTL-aware cache entries, negative caching, and in-flight query collapse.
+
+3. **Transport expansion**
+   Add TCP framing for truncated responses and later optional DoT / DoH layers.
+
+4. **Record expansion**
+   Add typed support for `NS`, `SOA`, `MX`, `TXT`, `SRV`, `PTR`, and newer web
+   records.
+
+5. **Browser integration**
+   Teach `tcp-client` or a higher orchestration layer to use the DNS client
+   instead of the OS resolver when desired.
+
+---
+
+## Implementation Languages
+
+- **Rust** (primary, for Venture and the networking stack)
+- **Go**
+- **Python**
+- **TypeScript**
+- **Ruby**
+- **Elixir**
+- **Perl**
+- **Lua**
+- **Swift**
+
+The message model should stay conceptually identical across languages even if
+individual ports adapt to local idioms.

--- a/code/specs/NET07-udp-client.md
+++ b/code/specs/NET07-udp-client.md
@@ -1,0 +1,384 @@
+# NET07 — UDP Client
+
+## Overview
+
+UDP (User Datagram Protocol) is the simplest transport protocol in the normal
+internet stack. Unlike TCP, it does not create a connection, retransmit lost
+packets, preserve ordering across multiple packets, or expose a byte stream. It
+sends **datagrams**: one bounded message at a time.
+
+This package specifies a small, OS-socket-backed UDP client abstraction for
+application protocols such as DNS:
+
+- bind a UDP socket to a local address and port
+- send one datagram to a remote address
+- receive one datagram plus the sender's address
+- configure read/write timeouts
+- keep payload bytes opaque
+
+It deliberately does **not** parse DNS, RTP, QUIC, game packets, or any other
+application protocol. UDP should be as transport-layer-only as TCP client
+`NET01` is byte-stream-only.
+
+**Analogy:** UDP is a postcard:
+
+```
+┌──────────────────────────────────────────────┐
+│ To:   8.8.8.8:53                             │
+│ From: 192.0.2.10:49152                       │
+│                                              │
+│ Payload: [opaque bytes]                      │
+└──────────────────────────────────────────────┘
+
+You drop it in the mail. It may arrive, arrive once, arrive later, or not
+arrive at all. If the application needs retry behavior, the application owns
+that policy.
+```
+
+## Where It Fits
+
+```
+future dns-client
+     │
+     ├── dns-message (NET06)
+     │     build query bytes / parse response bytes
+     │
+     └── udp-client (NET07) ← THIS PACKAGE
+           send and receive opaque datagrams
+```
+
+`NET07` is the real OS-socket counterpart to the simulated UDP layer described
+inside `D17-network-stack.md`.
+
+**Depends on:** nothing (std/socket APIs only)
+**Depended on by:** future DNS client, future datagram protocols
+
+---
+
+## Concepts
+
+### 1. Datagram, Not Stream
+
+TCP gives callers a stream:
+
+```
+write("abc")
+write("def")
+read() -> maybe "abcdef", maybe "abc", maybe "ab"
+```
+
+UDP preserves message boundaries:
+
+```
+send_datagram("abc")
+send_datagram("def")
+recv_datagram() -> "abc"
+recv_datagram() -> "def"
+```
+
+That property is exactly why classic DNS fits UDP well: a query is one datagram,
+and a response is one datagram.
+
+### 2. No Delivery Guarantees
+
+UDP does not promise:
+
+- delivery
+- retry
+- ordering
+- deduplication
+- congestion control
+- flow control
+
+The package should expose timeout errors cleanly, but it should not retry
+automatically. A DNS client may decide to retry the same query ID, try another
+resolver, or fall back to TCP. A game client may simply send the next state
+update. The transport layer should not guess.
+
+### 3. Connected vs Unconnected UDP
+
+Operating systems allow two common UDP modes:
+
+1. **Unconnected socket**
+   - each send specifies a destination
+   - each receive reports the sender
+   - useful for servers and multi-peer clients
+
+2. **Connected UDP socket**
+   - records one default remote peer
+   - send can omit destination
+   - receive filters packets from other peers
+
+The first version should support both, but the unconnected API is the most
+important because DNS clients may switch resolvers and DNS servers receive from
+many clients.
+
+### 4. Payload Size
+
+A UDP datagram has a finite size. IPv4 UDP length is 16 bits, so the absolute
+wire-format maximum is 65,535 bytes including IP and UDP headers. In practice,
+applications should send much smaller packets to avoid IP fragmentation.
+
+This package should not impose DNS-specific limits. It should provide a
+configurable receive-buffer size and return a clear truncation error if the
+incoming datagram is larger than the caller's buffer.
+
+### 5. Address Handling
+
+The UDP layer should work with resolved socket addresses, not hostnames. DNS is
+one of the protocols that resolves hostnames, so making UDP do DNS resolution
+would create an awkward dependency loop.
+
+Callers pass concrete socket addresses:
+
+```
+8.8.8.8:53
+[2001:4860:4860::8888]:53
+127.0.0.1:5353
+```
+
+If a higher-level caller starts with a hostname, that caller must resolve it
+before constructing a UDP destination.
+
+---
+
+## Public API
+
+The examples use Rust syntax as the reference implementation shape. Language
+ports should expose the same concepts with idiomatic local names.
+
+### Core Types
+
+```rust
+use std::net::SocketAddr;
+use std::time::Duration;
+
+pub struct UdpOptions {
+    /// Optional local bind address. Defaults to an ephemeral port on all
+    /// interfaces for the address family implied by the first destination.
+    pub bind_addr: Option<SocketAddr>,
+
+    /// Maximum number of bytes to allocate for one receive.
+    /// Default: 65_535.
+    pub max_datagram_size: usize,
+
+    /// Read timeout applied to receive operations.
+    pub read_timeout: Option<Duration>,
+
+    /// Write timeout applied to send operations when the platform supports it.
+    pub write_timeout: Option<Duration>,
+}
+
+pub struct UdpDatagram {
+    pub source: SocketAddr,
+    pub destination: SocketAddr,
+    pub payload: Vec<u8>,
+}
+
+pub struct UdpClient {
+    // language-specific socket handle
+}
+```
+
+### Client API
+
+```rust
+impl UdpClient {
+    /// Open a UDP socket with the configured options.
+    pub fn bind(options: UdpOptions) -> Result<Self, UdpError>;
+
+    /// Record a default peer for connected-UDP mode.
+    ///
+    /// This should use the OS `connect()` operation for UDP where available.
+    pub fn connect(&mut self, remote: SocketAddr) -> Result<(), UdpError>;
+
+    /// Send one datagram to an explicit destination.
+    pub fn send_to(&self, payload: &[u8], destination: SocketAddr)
+        -> Result<usize, UdpError>;
+
+    /// Send one datagram to the previously connected peer.
+    pub fn send(&self, payload: &[u8]) -> Result<usize, UdpError>;
+
+    /// Receive one datagram and return its payload plus address metadata.
+    pub fn recv_from(&self) -> Result<UdpDatagram, UdpError>;
+
+    /// Return the local socket address assigned by the OS.
+    pub fn local_addr(&self) -> Result<SocketAddr, UdpError>;
+}
+```
+
+### Convenience Function
+
+```rust
+/// Send one datagram and wait for one response from the same peer.
+///
+/// This is useful for simple request/response protocols such as DNS, but it
+/// still treats payloads as opaque bytes.
+pub fn send_and_receive(
+    destination: SocketAddr,
+    payload: &[u8],
+    options: UdpOptions,
+) -> Result<UdpDatagram, UdpError>;
+```
+
+### Error Types
+
+```rust
+#[derive(Debug)]
+pub enum UdpError {
+    /// The socket could not bind to the requested local address.
+    BindFailed(String),
+
+    /// The socket could not record the requested peer.
+    ConnectFailed(String),
+
+    /// Sending failed.
+    SendFailed(String),
+
+    /// Receiving failed.
+    ReceiveFailed(String),
+
+    /// A read or write operation timed out.
+    Timeout,
+
+    /// Caller attempted `send()` without first calling `connect()`.
+    NotConnected,
+
+    /// Payload or receive buffer size is invalid for this package.
+    InvalidDatagramSize { size: usize, max: usize },
+
+    /// The OS reported that a datagram did not fit in the receive buffer.
+    TruncatedDatagram,
+}
+```
+
+Implementations should map platform-specific errors into these semantic
+variants while preserving enough detail in string fields to debug locally.
+
+---
+
+## Behavioral Rules
+
+### 1. Payloads Are Opaque
+
+`udp-client` never inspects payload bytes. The following must be equally valid:
+
+- DNS message bytes
+- game state updates
+- test fixture bytes
+- compressed binary payloads
+- empty datagrams, if the host platform allows them
+
+### 2. No Automatic Retries
+
+`send_and_receive()` sends once and receives once. If receive times out, it
+returns `UdpError::Timeout`. Higher layers decide whether to retry.
+
+### 3. No Hostname Resolution
+
+The public API accepts `SocketAddr`, not `host + port`. This keeps the package
+transport-only and avoids DNS recursion.
+
+### 4. Timeout Behavior
+
+Timeouts should apply to blocking operations:
+
+- `read_timeout` controls `recv_from()`
+- `write_timeout` controls `send_to()`/`send()` where supported
+
+If a platform cannot set a write timeout for UDP, document that and preserve the
+field for API consistency.
+
+### 5. Datagram Size Guard
+
+The implementation must reject caller-provided payloads larger than
+`max_datagram_size` before passing them to the OS. This prevents accidental huge
+allocations and gives deterministic errors in tests.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+1. **Default options:** verify `UdpOptions::default()` chooses a safe buffer
+   size and no unnecessary timeouts.
+2. **Invalid max size:** reject zero-sized receive buffers.
+3. **Oversized send:** reject payloads larger than the configured maximum before
+   sending.
+4. **send without connect:** `send()` returns `NotConnected`.
+
+### Local Socket Tests
+
+These tests use loopback only; they do not need internet access.
+
+5. **bind localhost:** open a UDP socket on `127.0.0.1:0` and verify the OS
+   assigns a port.
+6. **send_to / recv_from:** client sends bytes to a local UDP server; server
+   sees exact payload and client address.
+7. **echo round trip:** local server echoes one datagram; client receives exact
+   response.
+8. **connected UDP:** client connects to server and uses `send()`.
+9. **source metadata:** received datagram includes the sender address.
+10. **timeout:** receive on an idle socket with a short timeout returns
+    `Timeout`.
+
+### Edge Cases
+
+11. **empty datagram:** if supported by the platform, verify it round-trips; if
+    not supported, map the OS error cleanly.
+12. **IPv6 loopback:** run when `::1` is available.
+13. **large but valid datagram:** verify a payload near the configured limit.
+14. **parallel sockets:** bind multiple ephemeral sockets without port clashes.
+
+### Future Integration Tests
+
+When `dns-client` exists, add an ignored/live-network smoke test that sends a
+NET06 DNS query over NET07 UDP to a configured resolver. That test should stay
+outside the core `udp-client` package because UDP itself is protocol-agnostic.
+
+---
+
+## Scope
+
+### In Scope
+
+- OS-backed UDP sockets
+- bind to local address or ephemeral port
+- send one datagram
+- receive one datagram
+- connected and unconnected UDP modes
+- read/write timeout configuration
+- loopback-only tests
+- IPv4 and IPv6 socket addresses where available
+
+### Out of Scope
+
+- DNS parsing or query construction
+- hostname resolution
+- retries
+- connection pooling
+- multicast / broadcast
+- raw IP packet construction
+- UDP checksum implementation
+- simulated D17 stack integration
+- QUIC
+
+### Future Work
+
+- multicast options for mDNS or service discovery
+- broadcast support for LAN discovery protocols
+- async/nonblocking integration with event-loop packages
+- UDP server abstraction
+- TCP fallback support for DNS clients that receive truncated UDP responses
+
+---
+
+## Implementation Languages
+
+- **Rust** (primary first implementation)
+- Future: all supported package languages following the repo scaffold pattern
+
+The first implementation should be intentionally small and transport-only. If a
+test needs to parse a DNS message to prove UDP works, that test belongs in a
+future integration package, not here.


### PR DESCRIPTION
## Summary

- Add NET06 DNS message codec spec and NET07 UDP client spec.
- Add Rust `dns-message` package as a transport-agnostic DNS wire-format codec.
- Support DNS query construction, serialization, response parsing, compression pointers, `A`/`AAAA`/`CNAME`, and raw unknown records.
- Harden parsing against malicious section counts and excessive compression-pointer chains.

## Validation

- `cargo fmt -p dns-message -- --check`
- `cargo test -p dns-message -- --nocapture` (36 tests)
- `bash BUILD` in `code/packages/rust/dns-message`
- `cargo tarpaulin -p dns-message --out stdout` (`dns-message/src/lib.rs`: 313/322 lines, ~97.2%)
- `/security-review` round 2 passed with no vulnerabilities found

## Notes

- `cargo build --workspace` is blocked on macOS by the existing `paint-vm-direct2d` Windows-only compile guard.
- The repository build tool's global metadata validation is currently blocked by unrelated existing BUILD metadata/path issues outside this PR.