### PR TITLE
feat(note-frequency): add C# and F# packages

### DIFF
--- a/code/packages/csharp/note-frequency/BUILD
+++ b/code/packages/csharp/note-frequency/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.NoteFrequency.Tests/CodingAdventures.NoteFrequency.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/note-frequency/BUILD_windows
+++ b/code/packages/csharp/note-frequency/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.NoteFrequency.Tests/CodingAdventures.NoteFrequency.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/note-frequency/CHANGELOG.md
+++ b/code/packages/csharp/note-frequency/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Added the initial note-to-frequency package.
+- Added note parsing for natural notes plus single sharps and flats.
+- Added equal-tempered frequency mapping anchored at `A4 = 440 Hz`.
+- Added tests that lock down the shared parity vectors across language ports.

--- a/code/packages/csharp/note-frequency/CodingAdventures.NoteFrequency.csproj
+++ b/code/packages/csharp/note-frequency/CodingAdventures.NoteFrequency.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.NoteFrequency.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Parse note names like A4 and map them to equal-tempered frequencies</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/note-frequency/NoteFrequency.cs
+++ b/code/packages/csharp/note-frequency/NoteFrequency.cs
@@ -1,0 +1,111 @@
+using System.Text.RegularExpressions;
+
+namespace CodingAdventures.NoteFrequency;
+
+/// <summary>
+/// A parsed musical note label such as A4, C#5, or Db3.
+/// </summary>
+public sealed class Note
+{
+    private static readonly IReadOnlyDictionary<string, int> ChromaticIndex = new Dictionary<string, int>
+    {
+        ["C"] = 0,
+        ["C#"] = 1,
+        ["Db"] = 1,
+        ["D"] = 2,
+        ["D#"] = 3,
+        ["Eb"] = 3,
+        ["E"] = 4,
+        ["F"] = 5,
+        ["F#"] = 6,
+        ["Gb"] = 6,
+        ["G"] = 7,
+        ["G#"] = 8,
+        ["Ab"] = 8,
+        ["A"] = 9,
+        ["A#"] = 10,
+        ["Bb"] = 10,
+        ["B"] = 11,
+    };
+
+    private const int ReferenceOctave = 4;
+    private const int ReferenceIndex = 9;
+    private const double ReferenceFrequencyHz = 440.0;
+    private const int SemitonesPerOctave = 12;
+
+    /// <summary>
+    /// Creates a note from a letter, optional accidental, and octave number.
+    /// </summary>
+    public Note(string letter, string accidental, int octave)
+    {
+        Letter = letter.ToUpperInvariant();
+        Accidental = accidental;
+        Octave = octave;
+
+        if (!ChromaticIndex.ContainsKey(Spelling))
+        {
+            throw new ArgumentException(
+                $"Unsupported note spelling {Spelling}. Only natural notes plus single # or b accidentals are supported.",
+                nameof(letter));
+        }
+    }
+
+    /// <summary>The uppercase note letter, from A through G.</summary>
+    public string Letter { get; }
+
+    /// <summary>The optional accidental spelling: empty, #, or b.</summary>
+    public string Accidental { get; }
+
+    /// <summary>The scientific pitch notation octave number.</summary>
+    public int Octave { get; }
+
+    /// <summary>The note spelling without its octave, such as C# or Db.</summary>
+    public string Spelling => Letter + Accidental;
+
+    /// <summary>The note's semitone index within an octave where C is 0.</summary>
+    public int ChromaticIndexValue => ChromaticIndex[Spelling];
+
+    /// <summary>
+    /// Returns the signed semitone distance from the reference pitch A4.
+    /// </summary>
+    public int SemitonesFromA4()
+    {
+        var octaveOffset = (Octave - ReferenceOctave) * SemitonesPerOctave;
+        var pitchOffset = ChromaticIndexValue - ReferenceIndex;
+        return octaveOffset + pitchOffset;
+    }
+
+    /// <summary>Returns this note's equal-tempered frequency in Hertz.</summary>
+    public double Frequency() => ReferenceFrequencyHz * Math.Pow(2.0, SemitonesFromA4() / (double)SemitonesPerOctave);
+
+    /// <summary>Returns the normalized note label, such as A4 or C#5.</summary>
+    public override string ToString() => $"{Spelling}{Octave}";
+}
+
+/// <summary>
+/// Parses note labels and maps them to equal-tempered frequencies.
+/// </summary>
+public static class NoteFrequency
+{
+    private static readonly Regex NotePattern = new(@"^([A-Ga-g])([#b]?)(-?\d+)$", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Parses a label like A4, C#5, or Db3 into a structured note.
+    /// </summary>
+    public static Note ParseNote(string text)
+    {
+        var match = NotePattern.Match(text);
+        if (!match.Success)
+        {
+            throw new ArgumentException(
+                $"Invalid note {text}. Expected <letter><optional # or b><octave>, for example 'A4', 'C#5', or 'Db3'.",
+                nameof(text));
+        }
+        return new Note(match.Groups[1].Value, match.Groups[2].Value, int.Parse(match.Groups[3].Value));
+    }
+
+    /// <summary>
+    /// Parses a note label and returns its equal-tempered frequency in Hertz.
+    /// </summary>
+    public static double NoteToFrequency(string text) => ParseNote(text).Frequency();
+}

--- a/code/packages/csharp/note-frequency/README.md
+++ b/code/packages/csharp/note-frequency/README.md
@@ -1,0 +1,22 @@
+# csharp/note-frequency
+
+
+Parses typed musical note labels such as `A4`, `C#5`, and `Db3` into a structured
+`Note` value and then maps that note to its equal-tempered frequency in Hertz.
+
+This package is the symbolic front door for the music stack:
+
+- users type note names
+- this layer turns them into exact pitches
+- later oscillator and renderer packages will turn those pitches into sound
+
+The core reference point is `A4 = 440 Hz`, and every semitone step multiplies
+frequency by `2^(1/12)`.
+
+
+## Usage
+
+```csharp
+var note = NoteFrequency.ParseNote("A4");
+var frequency = NoteFrequency.NoteToFrequency("C4");
+```

--- a/code/packages/csharp/note-frequency/required_capabilities.json
+++ b/code/packages/csharp/note-frequency/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/note-frequency",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/csharp/note-frequency/tests/CodingAdventures.NoteFrequency.Tests/CodingAdventures.NoteFrequency.Tests.csproj
+++ b/code/packages/csharp/note-frequency/tests/CodingAdventures.NoteFrequency.Tests/CodingAdventures.NoteFrequency.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.NoteFrequency.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/note-frequency/tests/CodingAdventures.NoteFrequency.Tests/NoteFrequencyTests.cs
+++ b/code/packages/csharp/note-frequency/tests/CodingAdventures.NoteFrequency.Tests/NoteFrequencyTests.cs
@@ -1,0 +1,55 @@
+using CodingAdventures.NoteFrequency;
+
+namespace CodingAdventures.NoteFrequency.Tests;
+
+public class NoteFrequencyTests
+{
+    [Fact]
+    public void ParseNoteExtractsFields()
+    {
+        var note = NoteFrequency.ParseNote("C#5");
+        Assert.Equal("C", note.Letter);
+        Assert.Equal("#", note.Accidental);
+        Assert.Equal(5, note.Octave);
+    }
+
+    [Fact]
+    public void LowercaseLettersAreNormalized()
+    {
+        Assert.Equal("G4", NoteFrequency.ParseNote("g4").ToString());
+    }
+
+    [Fact]
+    public void MalformedNotesThrow()
+    {
+        foreach (var value in new[] { "", "A", "H4", "#4", "4A", "A##4", "Bb" })
+        {
+            Assert.Throws<ArgumentException>(() => NoteFrequency.ParseNote(value));
+        }
+    }
+
+    [Fact]
+    public void UnsupportedSpellingsThrow()
+    {
+        Assert.Throws<ArgumentException>(() => new Note("E", "#", 4));
+    }
+
+    [Fact]
+    public void SemitoneOffsetsMatchExamples()
+    {
+        Assert.Equal(0, NoteFrequency.ParseNote("A4").SemitonesFromA4());
+        Assert.Equal(12, NoteFrequency.ParseNote("A5").SemitonesFromA4());
+        Assert.Equal(-12, NoteFrequency.ParseNote("A3").SemitonesFromA4());
+        Assert.Equal(-9, NoteFrequency.ParseNote("C4").SemitonesFromA4());
+    }
+
+    [Fact]
+    public void FrequenciesMatchExamples()
+    {
+        Assert.Equal(440.0, NoteFrequency.ParseNote("A4").Frequency(), 12);
+        Assert.Equal(880.0, NoteFrequency.ParseNote("A5").Frequency(), 12);
+        Assert.Equal(220.0, NoteFrequency.ParseNote("A3").Frequency(), 12);
+        Assert.Equal(261.6255653005986, NoteFrequency.NoteToFrequency("C4"), 12);
+        Assert.Equal(NoteFrequency.NoteToFrequency("C#4"), NoteFrequency.NoteToFrequency("Db4"), 12);
+    }
+}

--- a/code/packages/fsharp/note-frequency/BUILD
+++ b/code/packages/fsharp/note-frequency/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.NoteFrequency.Tests/CodingAdventures.NoteFrequency.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/note-frequency/BUILD_windows
+++ b/code/packages/fsharp/note-frequency/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.NoteFrequency.Tests/CodingAdventures.NoteFrequency.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/note-frequency/CHANGELOG.md
+++ b/code/packages/fsharp/note-frequency/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Added the initial note-to-frequency package.
+- Added note parsing for natural notes plus single sharps and flats.
+- Added equal-tempered frequency mapping anchored at `A4 = 440 Hz`.
+- Added tests that lock down the shared parity vectors across language ports.

--- a/code/packages/fsharp/note-frequency/CodingAdventures.NoteFrequency.fsproj
+++ b/code/packages/fsharp/note-frequency/CodingAdventures.NoteFrequency.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.NoteFrequency.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Parse note names like A4 and map them to equal-tempered frequencies</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="NoteFrequency.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/note-frequency/NoteFrequency.fs
+++ b/code/packages/fsharp/note-frequency/NoteFrequency.fs
@@ -1,0 +1,53 @@
+module CodingAdventures.NoteFrequency
+
+open System
+open System.Text.RegularExpressions
+
+let private chromaticIndexFor spelling =
+    match spelling with
+    | "C" -> 0
+    | "C#" | "Db" -> 1
+    | "D" -> 2
+    | "D#" | "Eb" -> 3
+    | "E" -> 4
+    | "F" -> 5
+    | "F#" | "Gb" -> 6
+    | "G" -> 7
+    | "G#" | "Ab" -> 8
+    | "A" -> 9
+    | "A#" | "Bb" -> 10
+    | "B" -> 11
+    | _ -> invalidArg "spelling" (sprintf "Unsupported note spelling %s. Only natural notes plus single # or b accidentals are supported." spelling)
+
+[<CLIMutable>]
+type Note =
+    { Letter: string
+      Accidental: string
+      Octave: int }
+    member this.Spelling = this.Letter + this.Accidental
+    member this.ChromaticIndex = chromaticIndexFor this.Spelling
+    member this.SemitonesFromA4() =
+        let octaveOffset = (this.Octave - 4) * 12
+        let pitchOffset = this.ChromaticIndex - 9
+        octaveOffset + pitchOffset
+    member this.Frequency() = 440.0 * Math.Pow(2.0, float (this.SemitonesFromA4()) / 12.0)
+    override this.ToString() = this.Spelling + string this.Octave
+
+let private notePattern = Regex("^([A-Ga-g])([#b]?)(-?\d+)$", RegexOptions.Compiled)
+
+let chromaticIndex spelling = chromaticIndexFor spelling
+
+let createNote (letter: string) (accidental: string) (octave: int) =
+    let canonicalLetter = letter.ToUpperInvariant()
+    let spelling = canonicalLetter + accidental
+    let _ = chromaticIndexFor spelling
+    { Letter = canonicalLetter; Accidental = accidental; Octave = octave }
+
+let parseNote (text: string) =
+    let matchResult = notePattern.Match(text)
+    if not matchResult.Success then
+        invalidArg "text" (sprintf "Invalid note %s. Expected <letter><optional # or b><octave>, for example 'A4', 'C#5', or 'Db3'." text)
+
+    createNote matchResult.Groups[1].Value matchResult.Groups[2].Value (int matchResult.Groups[3].Value)
+
+let noteToFrequency (text: string) = parseNote text |> fun note -> note.Frequency()

--- a/code/packages/fsharp/note-frequency/README.md
+++ b/code/packages/fsharp/note-frequency/README.md
@@ -1,0 +1,22 @@
+# fsharp/note-frequency
+
+
+Parses typed musical note labels such as `A4`, `C#5`, and `Db3` into a structured
+`Note` value and then maps that note to its equal-tempered frequency in Hertz.
+
+This package is the symbolic front door for the music stack:
+
+- users type note names
+- this layer turns them into exact pitches
+- later oscillator and renderer packages will turn those pitches into sound
+
+The core reference point is `A4 = 440 Hz`, and every semitone step multiplies
+frequency by `2^(1/12)`.
+
+
+## Usage
+
+```fsharp
+let note = NoteFrequency.parseNote "A4"
+let frequency = NoteFrequency.noteToFrequency "C4"
+```

--- a/code/packages/fsharp/note-frequency/required_capabilities.json
+++ b/code/packages/fsharp/note-frequency/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/note-frequency",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/fsharp/note-frequency/tests/CodingAdventures.NoteFrequency.Tests/CodingAdventures.NoteFrequency.Tests.fsproj
+++ b/code/packages/fsharp/note-frequency/tests/CodingAdventures.NoteFrequency.Tests/CodingAdventures.NoteFrequency.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.NoteFrequency.fsproj" />
+    <Compile Include="NoteFrequencyTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/note-frequency/tests/CodingAdventures.NoteFrequency.Tests/NoteFrequencyTests.fs
+++ b/code/packages/fsharp/note-frequency/tests/CodingAdventures.NoteFrequency.Tests/NoteFrequencyTests.fs
@@ -1,0 +1,60 @@
+namespace CodingAdventures.NoteFrequency.Tests
+
+open CodingAdventures.NoteFrequency
+open Xunit
+
+module NoteFrequencyTests =
+    [<Fact>]
+    let ``parseNote extracts fields`` () =
+        let note = parseNote "C#5"
+        Assert.Equal("C", note.Letter)
+        Assert.Equal("#", note.Accidental)
+        Assert.Equal(5, note.Octave)
+
+    [<Fact>]
+    let ``lowercase letters are normalized`` () =
+        Assert.Equal("G4", parseNote("g4").ToString())
+
+    [<Fact>]
+    let ``malformed notes throw`` () =
+        for value in [ ""; "A"; "H4"; "#4"; "4A"; "A##4"; "Bb" ] do
+            Assert.Throws<System.ArgumentException>(fun () -> parseNote value |> ignore) |> ignore
+
+    [<Fact>]
+    let ``unsupported spellings throw`` () =
+        Assert.Throws<System.ArgumentException>(fun () -> createNote "E" "#" 4 |> ignore) |> ignore
+
+    [<Fact>]
+    let ``chromatic index covers the supported spellings`` () =
+        Assert.Equal(0, chromaticIndex "C")
+        Assert.Equal(1, chromaticIndex "C#")
+        Assert.Equal(1, chromaticIndex "Db")
+        Assert.Equal(2, chromaticIndex "D")
+        Assert.Equal(3, chromaticIndex "D#")
+        Assert.Equal(3, chromaticIndex "Eb")
+        Assert.Equal(4, chromaticIndex "E")
+        Assert.Equal(5, chromaticIndex "F")
+        Assert.Equal(6, chromaticIndex "F#")
+        Assert.Equal(6, chromaticIndex "Gb")
+        Assert.Equal(7, chromaticIndex "G")
+        Assert.Equal(8, chromaticIndex "G#")
+        Assert.Equal(8, chromaticIndex "Ab")
+        Assert.Equal(9, chromaticIndex "A")
+        Assert.Equal(10, chromaticIndex "A#")
+        Assert.Equal(10, chromaticIndex "Bb")
+        Assert.Equal(11, chromaticIndex "B")
+
+    [<Fact>]
+    let ``semitone offsets match examples`` () =
+        Assert.Equal(0, parseNote("A4").SemitonesFromA4())
+        Assert.Equal(12, parseNote("A5").SemitonesFromA4())
+        Assert.Equal(-12, parseNote("A3").SemitonesFromA4())
+        Assert.Equal(-9, parseNote("C4").SemitonesFromA4())
+
+    [<Fact>]
+    let ``frequencies match examples`` () =
+        Assert.Equal(440.0, parseNote("A4").Frequency(), 12)
+        Assert.Equal(880.0, parseNote("A5").Frequency(), 12)
+        Assert.Equal(220.0, parseNote("A3").Frequency(), 12)
+        Assert.Equal(261.6255653005986, noteToFrequency("C4"), 12)
+        Assert.Equal(noteToFrequency("C#4"), noteToFrequency("Db4"), 12)


### PR DESCRIPTION
## Summary

This is the next small note-frequency implementation PR, scoped to the .NET toolchain.

- Add C# `code/packages/csharp/note-frequency` with note parsing, semitone offsets from `A4`, and equal-tempered frequency calculation.
- Add F# `code/packages/fsharp/note-frequency` with the same semantics and parity tests.
- Include package READMEs, CHANGELOGs, BUILD files, capability metadata, and test projects.
- Added XML docs to the C# public API so the package builds without documentation warnings.

## Verification

- C#: `dotnet test tests/CodingAdventures.NoteFrequency.Tests/CodingAdventures.NoteFrequency.Tests.csproj`
- F#: `dotnet test tests/CodingAdventures.NoteFrequency.Tests/CodingAdventures.NoteFrequency.Tests.fsproj`
- Build-plan smoke test: 2 packages affected; only Go and .NET enabled.

## Security Review

Clean. The runtime code performs deterministic note-label parsing and frequency math only; it does not touch files, shell commands, network APIs, deserialization, credentials, or unsafe operations.