### PR TITLE
feat(note-frequency): add Dart and Elixir packages

### DIFF
--- a/code/packages/dart/note-frequency/.gitignore
+++ b/code/packages/dart/note-frequency/.gitignore
@@ -1,0 +1,2 @@
+.dart_tool/
+pubspec.lock

--- a/code/packages/dart/note-frequency/BUILD
+++ b/code/packages/dart/note-frequency/BUILD
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/note-frequency/BUILD_windows
+++ b/code/packages/dart/note-frequency/BUILD_windows
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/note-frequency/CHANGELOG.md
+++ b/code/packages/dart/note-frequency/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Added the initial note-to-frequency package.
+- Added note parsing for natural notes plus single sharps and flats.
+- Added equal-tempered frequency mapping anchored at `A4 = 440 Hz`.
+- Added tests that lock down the shared parity vectors across language ports.

--- a/code/packages/dart/note-frequency/README.md
+++ b/code/packages/dart/note-frequency/README.md
@@ -1,0 +1,22 @@
+# coding_adventures_note_frequency
+
+
+Parses typed musical note labels such as `A4`, `C#5`, and `Db3` into a structured
+`Note` value and then maps that note to its equal-tempered frequency in Hertz.
+
+This package is the symbolic front door for the music stack:
+
+- users type note names
+- this layer turns them into exact pitches
+- later oscillator and renderer packages will turn those pitches into sound
+
+The core reference point is `A4 = 440 Hz`, and every semitone step multiplies
+frequency by `2^(1/12)`.
+
+
+## Usage
+
+```dart
+final note = parseNote("A4");
+final frequency = noteToFrequency("C4");
+```

--- a/code/packages/dart/note-frequency/lib/note_frequency.dart
+++ b/code/packages/dart/note-frequency/lib/note_frequency.dart
@@ -1,0 +1,78 @@
+import 'dart:math' as math;
+
+const Map<String, int> _chromaticIndex = {
+  'C': 0,
+  'C#': 1,
+  'Db': 1,
+  'D': 2,
+  'D#': 3,
+  'Eb': 3,
+  'E': 4,
+  'F': 5,
+  'F#': 6,
+  'Gb': 6,
+  'G': 7,
+  'G#': 8,
+  'Ab': 8,
+  'A': 9,
+  'A#': 10,
+  'Bb': 10,
+  'B': 11,
+};
+
+const int _referenceOctave = 4;
+const int _referenceIndex = 9;
+const double _referenceFrequencyHz = 440.0;
+const int _semitonesPerOctave = 12;
+final RegExp _notePattern = RegExp(r'^([A-Ga-g])([#b]?)(-?\d+)$');
+
+class Note {
+  Note(String letter, String accidental, int octave)
+      : letter = letter.toUpperCase(),
+        accidental = accidental,
+        octave = octave {
+    if (!_chromaticIndex.containsKey(spelling)) {
+      throw ArgumentError(
+        'Unsupported note spelling $spelling. Only natural notes plus single # or b accidentals are supported.',
+      );
+    }
+  }
+
+  final String letter;
+  final String accidental;
+  final int octave;
+
+  String get spelling => '$letter$accidental';
+
+  int chromaticIndex() => _chromaticIndex[spelling]!;
+
+  int semitonesFromA4() {
+    final octaveOffset = (octave - _referenceOctave) * _semitonesPerOctave;
+    final pitchOffset = chromaticIndex() - _referenceIndex;
+    return octaveOffset + pitchOffset;
+  }
+
+  double frequency() =>
+      _referenceFrequencyHz *
+      math.pow(2.0, semitonesFromA4() / _semitonesPerOctave).toDouble();
+
+  @override
+  String toString() => '$spelling$octave';
+}
+
+Note parseNote(String text) {
+  final match = _notePattern.firstMatch(text);
+  if (match == null) {
+    throw ArgumentError(
+      "Invalid note $text. Expected <letter><optional # or b><octave>, for example 'A4', 'C#5', or 'Db3'.",
+    );
+  }
+
+  return Note(
+    match.group(1)!,
+    match.group(2)!,
+    int.parse(match.group(3)!),
+  );
+}
+
+double noteToFrequency(String text) => parseNote(text).frequency();

--- a/code/packages/dart/note-frequency/pubspec.yaml
+++ b/code/packages/dart/note-frequency/pubspec.yaml
@@ -1,0 +1,13 @@
+name: coding_adventures_note_frequency
+description: >
+  Parse note names like A4 and map them to equal-tempered frequencies.
+version: 0.1.0
+repository: https://github.com/adhithyan15/coding-adventures
+
+environment:
+  sdk: ^3.0.0
+
+dependencies: {}
+
+dev_dependencies:
+  test: ^1.25.0

--- a/code/packages/dart/note-frequency/required_capabilities.json
+++ b/code/packages/dart/note-frequency/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "dart/note-frequency",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/dart/note-frequency/test/note_frequency_test.dart
+++ b/code/packages/dart/note-frequency/test/note_frequency_test.dart
@@ -1,0 +1,40 @@
+import 'package:test/test.dart';
+import 'package:coding_adventures_note_frequency/note_frequency.dart';
+
+void main() {
+  test('parseNote extracts fields', () {
+    final note = parseNote('C#5');
+    expect(note.letter, 'C');
+    expect(note.accidental, '#');
+    expect(note.octave, 5);
+  });
+
+  test('lowercase letters are normalized', () {
+    expect(parseNote('g4').toString(), 'G4');
+  });
+
+  test('malformed notes throw', () {
+    for (final value in ['', 'A', 'H4', '#4', '4A', 'A##4', 'Bb']) {
+      expect(() => parseNote(value), throwsArgumentError);
+    }
+  });
+
+  test('unsupported spellings throw', () {
+    expect(() => Note('E', '#', 4), throwsArgumentError);
+  });
+
+  test('semitone offsets match examples', () {
+    expect(parseNote('A4').semitonesFromA4(), 0);
+    expect(parseNote('A5').semitonesFromA4(), 12);
+    expect(parseNote('A3').semitonesFromA4(), -12);
+    expect(parseNote('C4').semitonesFromA4(), -9);
+  });
+
+  test('frequencies match examples', () {
+    expect(parseNote('A4').frequency(), closeTo(440.0, 1e-12));
+    expect(parseNote('A5').frequency(), closeTo(880.0, 1e-12));
+    expect(parseNote('A3').frequency(), closeTo(220.0, 1e-12));
+    expect(noteToFrequency('C4'), closeTo(261.6255653005986, 1e-12));
+    expect(noteToFrequency('C#4'), closeTo(noteToFrequency('Db4'), 1e-12));
+  });
+}

--- a/code/packages/elixir/note-frequency/.gitignore
+++ b/code/packages/elixir/note-frequency/.gitignore
@@ -1,0 +1,4 @@
+cover/
+_build/
+deps/
+.elixir_ls/

--- a/code/packages/elixir/note-frequency/BUILD
+++ b/code/packages/elixir/note-frequency/BUILD
@@ -1,0 +1,2 @@
+mix deps.get --quiet
+mix test --cover

--- a/code/packages/elixir/note-frequency/BUILD_windows
+++ b/code/packages/elixir/note-frequency/BUILD_windows
@@ -1,0 +1,2 @@
+mix deps.get --quiet
+mix test --cover

--- a/code/packages/elixir/note-frequency/CHANGELOG.md
+++ b/code/packages/elixir/note-frequency/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Added the initial note-to-frequency package.
+- Added note parsing for natural notes plus single sharps and flats.
+- Added equal-tempered frequency mapping anchored at `A4 = 440 Hz`.
+- Added tests that lock down the shared parity vectors across language ports.

--- a/code/packages/elixir/note-frequency/README.md
+++ b/code/packages/elixir/note-frequency/README.md
@@ -1,0 +1,22 @@
+# note_frequency
+
+
+Parses typed musical note labels such as `A4`, `C#5`, and `Db3` into a structured
+`Note` value and then maps that note to its equal-tempered frequency in Hertz.
+
+This package is the symbolic front door for the music stack:
+
+- users type note names
+- this layer turns them into exact pitches
+- later oscillator and renderer packages will turn those pitches into sound
+
+The core reference point is `A4 = 440 Hz`, and every semitone step multiplies
+frequency by `2^(1/12)`.
+
+
+## Usage
+
+```elixir
+note = NoteFrequency.parse_note("A4")
+frequency = NoteFrequency.note_to_frequency("C4")
+```

--- a/code/packages/elixir/note-frequency/lib/note_frequency.ex
+++ b/code/packages/elixir/note-frequency/lib/note_frequency.ex
@@ -1,0 +1,77 @@
+defmodule NoteFrequency.Note do
+  @enforce_keys [:letter, :accidental, :octave]
+  defstruct [:letter, :accidental, :octave]
+
+  @chromatic_index %{
+    "C" => 0,
+    "C#" => 1,
+    "Db" => 1,
+    "D" => 2,
+    "D#" => 3,
+    "Eb" => 3,
+    "E" => 4,
+    "F" => 5,
+    "F#" => 6,
+    "Gb" => 6,
+    "G" => 7,
+    "G#" => 8,
+    "Ab" => 8,
+    "A" => 9,
+    "A#" => 10,
+    "Bb" => 10,
+    "B" => 11
+  }
+  @reference_octave 4
+  @reference_index Map.fetch!(@chromatic_index, "A")
+  @reference_frequency_hz 440.0
+  @semitones_per_octave 12
+
+  def new!(letter, accidental, octave) do
+    canonical_letter = String.upcase(letter)
+    spelling = canonical_letter <> accidental
+
+    unless Map.has_key?(@chromatic_index, spelling) do
+      raise ArgumentError,
+            "Unsupported note spelling #{inspect(spelling)}. " <>
+              "Only natural notes plus single # or b accidentals are supported."
+    end
+
+    %__MODULE__{letter: canonical_letter, accidental: accidental, octave: octave}
+  end
+
+  def spelling(note), do: note.letter <> note.accidental
+  def chromatic_index(note), do: Map.fetch!(@chromatic_index, spelling(note))
+
+  def semitones_from_a4(note) do
+    octave_offset = (note.octave - @reference_octave) * @semitones_per_octave
+    pitch_offset = chromatic_index(note) - @reference_index
+    octave_offset + pitch_offset
+  end
+
+  def frequency(note) do
+    @reference_frequency_hz * :math.pow(2.0, semitones_from_a4(note) / @semitones_per_octave)
+  end
+
+  def to_string(note), do: spelling(note) <> Integer.to_string(note.octave)
+end
+
+defmodule NoteFrequency do
+  alias NoteFrequency.Note
+  @note_pattern ~r/^([A-Ga-g])([#b]?)(-?\d+)$/
+
+  def parse_note(text) when is_binary(text) do
+    case Regex.run(@note_pattern, text) do
+      [_, letter, accidental, octave_text] ->
+        Note.new!(letter, accidental, String.to_integer(octave_text))
+
+      nil ->
+        raise ArgumentError,
+              "Invalid note #{inspect(text)}. Expected <letter><optional # or b><octave>, " <>
+                "for example 'A4', 'C#5', or 'Db3'."
+    end
+  end
+
+  def note_to_frequency(text) do
+    text |> parse_note() |> Note.frequency()
+  end
+end

--- a/code/packages/elixir/note-frequency/mix.exs
+++ b/code/packages/elixir/note-frequency/mix.exs
@@ -1,0 +1,11 @@
+defmodule NoteFrequency.MixProject do
+  use Mix.Project
+
+  def project do
+    [app: :note_frequency, version: "0.1.0", elixir: "~> 1.14", deps: deps()]
+  end
+
+  defp deps do
+    []
+  end
+end

--- a/code/packages/elixir/note-frequency/required_capabilities.json
+++ b/code/packages/elixir/note-frequency/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "elixir/note-frequency",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/elixir/note-frequency/test/note_frequency_test.exs
+++ b/code/packages/elixir/note-frequency/test/note_frequency_test.exs
@@ -1,0 +1,48 @@
+defmodule NoteFrequencyTest do
+  use ExUnit.Case, async: true
+
+  alias NoteFrequency.Note
+
+  test "parse_note extracts the note fields" do
+    note = NoteFrequency.parse_note("C#5")
+    assert note.letter == "C"
+    assert note.accidental == "#"
+    assert note.octave == 5
+  end
+
+  test "lowercase letters are normalized" do
+    assert NoteFrequency.parse_note("g4") |> Note.to_string() == "G4"
+  end
+
+  test "malformed notes raise" do
+    for value <- ["", "A", "H4", "#4", "4A", "A##4", "Bb"] do
+      assert_raise ArgumentError, ~r/Invalid note/, fn ->
+        NoteFrequency.parse_note(value)
+      end
+    end
+  end
+
+  test "unsupported spellings raise" do
+    assert_raise ArgumentError, ~r/Unsupported note spelling/, fn ->
+      Note.new!("E", "#", 4)
+    end
+  end
+
+  test "semitone offsets match the reference examples" do
+    assert NoteFrequency.parse_note("A4") |> Note.semitones_from_a4() == 0
+    assert NoteFrequency.parse_note("A5") |> Note.semitones_from_a4() == 12
+    assert NoteFrequency.parse_note("A3") |> Note.semitones_from_a4() == -12
+    assert NoteFrequency.parse_note("C4") |> Note.semitones_from_a4() == -9
+  end
+
+  test "frequencies match the reference examples" do
+    assert_in_delta NoteFrequency.parse_note("A4") |> Note.frequency(), 440.0, 1.0e-12
+    assert_in_delta NoteFrequency.parse_note("A5") |> Note.frequency(), 880.0, 1.0e-12
+    assert_in_delta NoteFrequency.parse_note("A3") |> Note.frequency(), 220.0, 1.0e-12
+    assert_in_delta NoteFrequency.note_to_frequency("C4"), 261.6255653005986, 1.0e-12
+
+    assert_in_delta NoteFrequency.note_to_frequency("C#4"),
+                    NoteFrequency.note_to_frequency("Db4"),
+                    1.0e-12
+  end
+end

--- a/code/packages/elixir/note-frequency/test/test_helper.exs
+++ b/code/packages/elixir/note-frequency/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
## Summary
- Adds Dart and Elixir `note-frequency` packages for the shared MUS00 note-to-frequency contract.
- Includes package READMEs, CHANGELOGs, BUILD/BUILD_windows files, tests, and capability declarations.
- Keeps the split intentionally small so CI should only build Dart + Elixir plus the Go build-tool detect step.

## Verification
- `dart pub get`
- `dart format --set-exit-if-changed lib test`
- `dart analyze`
- `dart test`
- `mix deps.get --quiet && mix test --cover` (100% coverage)
- `mix format --check-formatted lib/note_frequency.ex test/note_frequency_test.exs test/test_helper.exs`
- `/tmp/ca-build-tool-dart-elixir -root /Users/adhithya/Downloads/coding-adventures-note-frequency-dart-elixir -detect-languages -emit-plan /tmp/note-frequency-dart-elixir-plan.json -diff-base origin/main -validate-build-files`

## Security Review
- Security review completed before push.
- Only LOW findings: Dart/Elixir currently accept arbitrarily long octave digit strings, matching the shared contract and existing language behavior. Recommend handling octave/input bounds as a follow-up across the spec and all ports together.