### PR TITLE
feat(symbolic-computation): CAS pipeline — MACSYMA grammar → symbolic VM

### DIFF
--- a/code/grammars/macsyma/macsyma.grammar
+++ b/code/grammars/macsyma/macsyma.grammar
@@ -1,0 +1,77 @@
+# MACSYMA Parser Grammar
+# ============================================================
+#
+# This grammar describes the MACSYMA expression sublanguage as
+# preserved in Maxima. The parser produces a generic ASTNode tree,
+# which is then compiled to the symbolic IR by the macsyma-compiler
+# package.
+#
+# Precedence cascade (from lowest to highest binding):
+#
+#   1. assign          (`:` assignment, `:=` definition — right-assoc)
+#   2. logical_or      (short-circuit OR)
+#   3. logical_and     (short-circuit AND)
+#   4. logical_not     (unary NOT)
+#   5. comparison      (=, #, <, >, <=, >=)
+#   6. additive        (+, -)
+#   7. multiplicative  (*, /)
+#   8. unary           (unary -, +)
+#   9. power           (^ right-associative)
+#  10. postfix         (function calls f(x), subscripting is not here)
+#  11. atom            (numbers, names, parens, lists)
+#
+# The precedence is encoded purely through rule nesting — no priority
+# annotations. Higher precedence means deeper in the parse tree.
+
+# @version 1
+
+# A program is zero or more statements. Each statement is terminated
+# by `;` or `$`. The terminator is kept in the token stream so the
+# display-vs-suppress distinction can be recovered by the compiler.
+program     = { statement } ;
+
+statement   = expression ( SEMI | DOLLAR ) ;
+
+# Assignment and definition are right-associative and have the lowest
+# precedence among operators. `x : expr` binds a value; `f(x) := body`
+# defines a function. Syntactically both sit at the same level.
+expression  = assign ;
+assign      = logical_or [ ( COLON | COLONEQ ) assign ] ;
+
+# Boolean OR / AND / NOT. These arrive as KEYWORD tokens from the
+# lexer with values "and", "or", "not" — so the grammar matches them
+# as string literals rather than named token types.
+logical_or  = logical_and { "or" logical_and } ;
+logical_and = logical_not { "and" logical_not } ;
+logical_not = "not" logical_not | comparison ;
+
+# Comparisons are non-chaining: `a < b < c` is a parse error in
+# MACSYMA. Only one comparison operator per expression level.
+comparison  = additive [ ( EQ | HASH | LT | GT | LEQ | GEQ ) additive ] ;
+
+additive       = multiplicative { ( PLUS | MINUS ) multiplicative } ;
+multiplicative = unary { ( STAR | SLASH ) unary } ;
+
+# Unary minus binds tighter than * and /, so `-x^2` parses as `-(x^2)`
+# and `a * -b` parses as `a * (-b)`.
+unary          = ( MINUS | PLUS ) unary | power ;
+
+# Exponentiation is right-associative: `a^b^c` = `a^(b^c)`. Both `^`
+# and `**` are accepted; the compiler normalizes them.
+power          = postfix [ ( CARET | STAREQ ) unary ] ;
+
+# Function calls chain left-to-right: `f(x)(y)` = `(f(x))(y)`. Though
+# rare in MACSYMA, the mechanic falls out naturally from the repetition.
+postfix        = atom { LPAREN [ arglist ] RPAREN } ;
+arglist        = expression { COMMA expression } ;
+
+atom           = NUMBER
+               | STRING
+               | NAME
+               | "true"
+               | "false"
+               | group
+               | list ;
+
+group          = LPAREN expression RPAREN ;
+list           = LBRACKET [ arglist ] RBRACKET ;

--- a/code/grammars/macsyma/macsyma.tokens
+++ b/code/grammars/macsyma/macsyma.tokens
@@ -1,0 +1,136 @@
+# MACSYMA Token Grammar
+# ============================================================
+#
+# MACSYMA (Project MAC's SYmbolic MAnipulator) was developed at MIT
+# between 1968 and 1982. It is the grandparent of every modern computer
+# algebra system — Maxima (its open-source descendant), Mathematica,
+# Maple, and REDUCE all took direct inspiration from it.
+#
+# This tokenizer targets the core MACSYMA expression language as
+# preserved in its modern descendant Maxima. It does NOT attempt to
+# tokenize the full Maxima programming surface (blocks, declarations,
+# packages) — only the expression sublanguage that matters for
+# symbolic computation.
+#
+# Lexical conventions in MACSYMA:
+#
+#   - Names are case-sensitive (unlike many 1960s languages).
+#   - Identifiers that begin with `%` are system-defined constants:
+#     %pi, %e, %i, %phi, %gamma. These are lexed as a single NAME.
+#   - Two statement terminators exist: `;` displays the result,
+#     `$` suppresses it. The parser treats them identically; the
+#     distinction is preserved in the token stream for later layers.
+#   - `:` is assignment. `:=` is function definition. `=` is equation
+#     (NOT assignment — MACSYMA uses `=` for symbolic equalities
+#     like `x^2 = 4`).
+#   - `#` is "not equal" (an idiosyncrasy — Maxima uses the same
+#     character, which would be a comment marker in most languages).
+#   - Comments use C-style `/* ... */` and do nest (handled in the
+#     skip pattern as a single non-nesting regex for simplicity; true
+#     nesting would require a more sophisticated lexer mode).
+#   - `^` and `**` both mean exponentiation. `^` is canonical.
+
+# @version 1
+
+# Escape sequences in string literals are left as raw text. Downstream
+# layers decode them.
+escapes: none
+
+# ============================================================
+# SECTION 1: Multi-character operators (must come first)
+#
+# Longest-match-wins: `:=` must be tried before `:`, `<=` before `<`,
+# `->` before `-`, and `**` before `*`. Listing them first ensures the
+# lexer attempts them in the right order.
+# ============================================================
+
+COLONEQ = ":="
+STAREQ  = "**"
+LEQ     = "<="
+GEQ     = ">="
+ARROW   = "->"
+
+# ============================================================
+# SECTION 2: Single-character operators and delimiters
+# ============================================================
+
+PLUS      = "+"
+MINUS     = "-"
+STAR      = "*"
+SLASH     = "/"
+CARET     = "^"
+COLON     = ":"
+EQ        = "="
+HASH      = "#"
+LT        = "<"
+GT        = ">"
+BANG      = "!"
+
+LPAREN    = "("
+RPAREN    = ")"
+LBRACKET  = "["
+RBRACKET  = "]"
+LBRACE    = "{"
+RBRACE    = "}"
+
+COMMA     = ","
+SEMI      = ";"
+DOLLAR    = "$"
+
+# ============================================================
+# SECTION 3: Literal value tokens
+#
+# NUMBER matches integers and floats, including scientific notation.
+# The regex intentionally does not capture a leading sign — unary
+# minus is the parser's responsibility. This keeps `1-2` lexable as
+# three tokens (NUMBER MINUS NUMBER) rather than two.
+#
+# NAME also covers the %-prefixed system constants (%pi, %e, %i).
+# Listing the percent form as a separate alternative keeps the regex
+# readable.
+#
+# STRING matches double-quoted text with simple backslash escapes.
+# ============================================================
+
+NUMBER = /[0-9]+\.?[0-9]*([eE][+-]?[0-9]+)?/
+NAME   = /%?[a-zA-Z_][a-zA-Z0-9_]*/
+STRING = /"([^"\\]|\\.)*"/
+
+# ============================================================
+# SECTION 4: Keywords
+#
+# These words are NAMEs at the lexer level but are reclassified to
+# their uppercase keyword form by the grammar-driven lexer. The
+# parser can then match them as AND, OR, NOT, etc.
+# ============================================================
+
+keywords:
+  and
+  or
+  not
+  if
+  then
+  else
+  elseif
+  true
+  false
+  do
+  for
+  while
+  in
+  step
+  thru
+  block
+  return
+
+# ============================================================
+# SECTION 5: Skip patterns
+#
+# Whitespace and comments are consumed silently. MACSYMA newlines
+# are NOT significant — statements end with `;` or `$`, so newlines
+# are just whitespace.
+# ============================================================
+
+skip:
+  WHITESPACE  = /[ \t\r\n]+/
+  LINECOMMENT = /\/\*([^*]|\*[^\/])*\*\//

--- a/code/packages/python/macsyma-compiler/BUILD
+++ b/code/packages/python/macsyma-compiler/BUILD
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../grammar-tools -e ../graph -e ../directed-graph -e ../state-machine -e ../lexer -e ../parser -e ../macsyma-lexer -e ../macsyma-parser -e ../symbolic-ir -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/macsyma-compiler/CHANGELOG.md
+++ b/code/packages/python/macsyma-compiler/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## 0.1.0 — 2026-04-19
+
+Initial release.
+
+- Compiles parsed MACSYMA ASTs to `symbolic_ir` trees.
+- Flattens the grammar's precedence cascade into uniform
+  `IRApply(head, args)` nodes.
+- Rewrites standard MACSYMA functions (`diff`, `integrate`, `sin`,
+  `cos`, `log`, `exp`, `sqrt`) to canonical IR heads.
+- Distinguishes `:` (Assign) from `:=` (Define), and shapes function
+  definitions as `Define(name, List(params), body)`.
+- Flattens `and`/`or` chains into variadic `IRApply` forms.

--- a/code/packages/python/macsyma-compiler/README.md
+++ b/code/packages/python/macsyma-compiler/README.md
@@ -1,0 +1,56 @@
+# macsyma-compiler
+
+Lowers a parsed MACSYMA AST to the universal symbolic IR defined in
+`symbolic-ir`.
+
+## What this package is
+
+This is where the real translation from "MACSYMA surface syntax" to
+"universal symbolic computation" happens. The `macsyma-parser` produces
+a deeply nested AST that mirrors the precedence cascade; this compiler
+flattens it into the uniform `IRApply(head, args)` shape.
+
+Key transformations:
+
+| MACSYMA source   | IR shape                                         |
+|------------------|--------------------------------------------------|
+| `x + 1`          | `Add(x, 1)`                                      |
+| `a - b - c`      | `Sub(Sub(a, b), c)`  (left-associative)          |
+| `a^b^c`          | `Pow(a, Pow(b, c))`  (right-associative)         |
+| `-x`             | `Neg(x)`                                         |
+| `f(x, y)`        | `Apply(Symbol('f'), (x, y))`                     |
+| `diff(f, x)`     | `D(f, x)`  (standard function rewritten)         |
+| `a : 5`          | `Assign(a, 5)`                                   |
+| `f(x) := x^2`    | `Define(f, List(x), Pow(x, 2))`                  |
+| `[1, 2, 3]`      | `List(1, 2, 3)`                                  |
+| `a and b and c`  | `And(a, b, c)`  (variadic, not nested)           |
+
+## Usage
+
+```python
+from macsyma_parser import parse_macsyma
+from macsyma_compiler import compile_macsyma
+
+ast = parse_macsyma("diff(x^2 + 1, x);")
+[ir] = compile_macsyma(ast)
+print(ir)
+# D(Add(Pow(x, 2), 1), x)
+```
+
+## Standard function rewriting
+
+The compiler recognizes a handful of MACSYMA names and rewrites them to
+canonical IR heads so downstream backends can dispatch uniformly:
+
+- `diff` → `D`
+- `integrate` → `Integrate`
+- `sin`, `cos`, `log`, `exp`, `sqrt` → their capitalized heads
+
+Any other name stays as a user-defined `IRSymbol`, so `f(x)` keeps
+`f` as the head when `f` isn't a known MACSYMA builtin.
+
+## Dependencies
+
+- `coding-adventures-symbolic-ir` — the IR types.
+- `coding-adventures-macsyma-parser` — provides the AST.
+- (transitive) the full grammar-tools/lexer/parser stack.

--- a/code/packages/python/macsyma-compiler/pyproject.toml
+++ b/code/packages/python/macsyma-compiler/pyproject.toml
@@ -1,0 +1,57 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-macsyma-compiler"
+version = "0.1.0"
+description = "Lowers parsed MACSYMA ASTs to the universal symbolic IR."
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["macsyma", "compiler", "ast", "ir", "cas", "symbolic", "education"]
+dependencies = [
+    "coding-adventures-directed-graph",
+    "coding-adventures-grammar-tools",
+    "coding-adventures-lexer",
+    "coding-adventures-macsyma-lexer",
+    "coding-adventures-macsyma-parser",
+    "coding-adventures-parser",
+    "coding-adventures-state-machine",
+    "coding-adventures-symbolic-ir",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Education",
+    "Topic :: Education",
+    "Topic :: Scientific/Engineering :: Mathematics",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://github.com/adhithyan15/coding-adventures"
+Repository = "https://github.com/adhithyan15/coding-adventures"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/macsyma_compiler"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=macsyma_compiler --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/packages/python/macsyma-compiler/required_capabilities.json
+++ b/code/packages/python/macsyma-compiler/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "python/macsyma-compiler",
+  "capabilities": [],
+  "justification": "Pure in-memory AST-to-IR transformation. No filesystem, network, or process access of its own (the grammar files are read by the lexer and parser dependencies)."
+}

--- a/code/packages/python/macsyma-compiler/src/macsyma_compiler/__init__.py
+++ b/code/packages/python/macsyma-compiler/src/macsyma_compiler/__init__.py
@@ -1,0 +1,41 @@
+"""MACSYMA compiler — lowers a parsed MACSYMA AST to the universal
+symbolic IR.
+
+The parser produces a deeply nested generic ``ASTNode`` tree whose
+nodes mirror the grammar's precedence cascade:
+``assign → logical_or → logical_and → logical_not → comparison →
+additive → multiplicative → unary → power → postfix → atom``.
+
+This compiler walks that tree and emits a compact ``IRApply``-based
+representation where every compound expression has the uniform shape
+``IRApply(head, args)`` and ``head`` is a standard ``IRSymbol``.
+
+Well-known MACSYMA function names are mapped to canonical IR heads:
+
+- ``diff`` → ``D``
+- ``integrate`` → ``Integrate``
+- ``sin``/``cos``/``log``/``exp``/``sqrt`` → their capitalized IR heads
+
+Other names pass through unchanged (``f(x)`` in MACSYMA becomes
+``IRApply(IRSymbol('f'), (IRSymbol('x'),))`` in IR), so user-defined
+functions coexist with standard library functions without special
+handling.
+
+Usage::
+
+    from macsyma_parser import parse_macsyma
+    from macsyma_compiler import compile_macsyma
+
+    ast = parse_macsyma("diff(x^2 + 1, x);")
+    ir_statements = compile_macsyma(ast)
+    for stmt in ir_statements:
+        print(stmt)
+"""
+
+from macsyma_compiler.compiler import CompileError, compile_expression, compile_macsyma
+
+__all__ = [
+    "compile_macsyma",
+    "compile_expression",
+    "CompileError",
+]

--- a/code/packages/python/macsyma-compiler/src/macsyma_compiler/compiler.py
+++ b/code/packages/python/macsyma-compiler/src/macsyma_compiler/compiler.py
@@ -1,0 +1,507 @@
+"""AST → IR compilation.
+
+Design notes
+------------
+
+The grammar-driven parser produces a "concrete" AST — one node per
+grammar rule — which mirrors the precedence cascade literally. Most of
+those nodes carry no information beyond "we descended through this
+level of precedence on the way to the actual operator", so the first
+thing we do is *unwrap* single-child nodes until we reach a node that
+actually carries content.
+
+Once unwrapped, the meaningful shapes we care about are:
+
+- ``atom`` with a single token child → IR literal or symbol
+- ``postfix`` with N children → function call chain
+- ``power`` with 3 children → ``Pow(base, exponent)``
+- ``unary`` with 2 children → ``Neg(expr)`` (unary plus collapses)
+- ``multiplicative``/``additive``/``logical_*`` with 2k+1 children →
+  left-associative chain of binary ops
+- ``comparison`` with 3 children → ``Equal``, ``Less``, etc.
+- ``assign`` with 3 children → ``Assign`` or ``Define``
+- ``group`` → just its inner expression
+- ``list`` → ``List(elem1, elem2, ...)``
+
+This file is one ``Compiler`` class plus a couple of module-level
+helpers. The class is stateful only in the sense that it carries a
+token→value cache for performance; it has no mutation semantics.
+"""
+
+from __future__ import annotations
+
+from lang_parser import ASTNode
+from lexer import Token
+from symbolic_ir import (
+    ADD,
+    ASSIGN,
+    COS,
+    D,
+    DEFINE,
+    DIV,
+    EQUAL,
+    EXP,
+    GREATER,
+    GREATER_EQUAL,
+    INTEGRATE,
+    LESS,
+    LESS_EQUAL,
+    LIST,
+    LOG,
+    MUL,
+    NEG,
+    NOT,
+    NOT_EQUAL,
+    POW,
+    SIN,
+    SQRT,
+    SUB,
+    IRApply,
+    IRFloat,
+    IRInteger,
+    IRNode,
+    IRString,
+    IRSymbol,
+)
+from symbolic_ir.nodes import AND, OR
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class CompileError(Exception):
+    """Raised when the compiler encounters an AST shape it cannot handle.
+
+    This should only happen if the grammar and the compiler fall out of
+    sync — the shapes the compiler expects are documented at the top of
+    this module.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Maps: token type → IR head symbol, function name → canonical head
+# ---------------------------------------------------------------------------
+#
+# Storing these as module-level dicts makes the compiler's dispatch
+# table explicit and easy to extend. Adding support for a new binary
+# operator is a one-line change here.
+
+_BINARY_OP_HEADS: dict[str, IRSymbol] = {
+    "PLUS": ADD,
+    "MINUS": SUB,
+    "STAR": MUL,
+    "SLASH": DIV,
+}
+
+_COMPARISON_HEADS: dict[str, IRSymbol] = {
+    "EQ": EQUAL,
+    "HASH": NOT_EQUAL,
+    "LT": LESS,
+    "GT": GREATER,
+    "LEQ": LESS_EQUAL,
+    "GEQ": GREATER_EQUAL,
+}
+
+# MACSYMA function names that map to a different canonical IR head.
+# Names NOT in this table pass through unchanged — `f(x)` with a
+# user-defined `f` becomes `Apply(Symbol('f'), (Symbol('x'),))`.
+_STANDARD_FUNCTIONS: dict[str, IRSymbol] = {
+    "diff": D,
+    "integrate": INTEGRATE,
+    "sin": SIN,
+    "cos": COS,
+    "log": LOG,
+    "exp": EXP,
+    "sqrt": SQRT,
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _token_type_name(token: Token) -> str:
+    """Return the token's type as a string regardless of enum/str form."""
+    return token.type if isinstance(token.type, str) else token.type.name
+
+
+def _is_token(child: object) -> bool:
+    return isinstance(child, Token)
+
+
+def _unwrap(node: ASTNode) -> ASTNode | Token:
+    """Descend through single-child ``ASTNode`` wrappers until we find
+    a node (or token) with actual structure.
+
+    The precedence cascade produces a lot of chain nodes like
+    ``logical_or(children=[logical_and(children=[logical_not(...)])])``
+    when the expression is a plain atom. This collapses all of that
+    into the first interesting node.
+    """
+    while isinstance(node, ASTNode) and len(node.children) == 1:
+        child = node.children[0]
+        if isinstance(child, ASTNode):
+            node = child
+        else:
+            return child
+    return node
+
+
+# ---------------------------------------------------------------------------
+# Compiler
+# ---------------------------------------------------------------------------
+
+
+class Compiler:
+    """Walks a MACSYMA AST and emits symbolic IR.
+
+    The class carries no mutable state; it is a namespace for the
+    recursive compilation methods. Every ``_compile_*`` method returns
+    an ``IRNode``.
+    """
+
+    def compile_program(self, root: ASTNode) -> list[IRNode]:
+        """Compile a ``program`` AST into a list of IR statements.
+
+        Args:
+            root: The root ``ASTNode`` (must have ``rule_name='program'``).
+
+        Returns:
+            One ``IRNode`` per top-level statement.
+        """
+        if root.rule_name != "program":
+            raise CompileError(
+                f"expected 'program' at root, got {root.rule_name!r}"
+            )
+        statements: list[IRNode] = []
+        for child in root.children:
+            if isinstance(child, ASTNode) and child.rule_name == "statement":
+                statements.append(self._compile_statement(child))
+        return statements
+
+    # ---- statement and expression ----------------------------------------
+
+    def _compile_statement(self, node: ASTNode) -> IRNode:
+        # `statement = expression ( SEMI | DOLLAR ) ;`
+        # The expression is always child 0; the terminator is child 1.
+        expr_node = node.children[0]
+        if not isinstance(expr_node, ASTNode):
+            raise CompileError("statement's first child must be an AST node")
+        return self._compile_node(expr_node)
+
+    def _compile_node(self, node: ASTNode | Token) -> IRNode:
+        """Dispatch to the handler for this node's rule or token type."""
+        if isinstance(node, Token):
+            return self._compile_token(node)
+
+        unwrapped = _unwrap(node)
+        if isinstance(unwrapped, Token):
+            return self._compile_token(unwrapped)
+
+        # unwrapped is an ASTNode with >1 children (or a leaf rule).
+        rule = unwrapped.rule_name
+        handler = self._handlers.get(rule)
+        if handler is None:
+            raise CompileError(f"no handler for rule {rule!r}")
+        return handler(self, unwrapped)
+
+    # ---- leaf tokens -----------------------------------------------------
+
+    def _compile_token(self, tok: Token) -> IRNode:
+        type_name = _token_type_name(tok)
+        if type_name == "NUMBER":
+            return self._parse_number(tok.value)
+        if type_name == "NAME":
+            return IRSymbol(tok.value)
+        if type_name == "STRING":
+            return IRString(tok.value)
+        if type_name == "KEYWORD":
+            # `true` and `false` are the two keywords that reach this
+            # path as atoms. Others (and/or/not) are handled by their
+            # parent expression rules.
+            if tok.value == "true":
+                return IRSymbol("True")
+            if tok.value == "false":
+                return IRSymbol("False")
+        raise CompileError(f"unexpected leaf token {type_name}={tok.value!r}")
+
+    @staticmethod
+    def _parse_number(text: str) -> IRInteger | IRFloat:
+        # The NUMBER regex accepts both ints and floats. If there's
+        # a dot or exponent, it's a float; otherwise it's an integer.
+        if "." in text or "e" in text or "E" in text:
+            return IRFloat(float(text))
+        return IRInteger(int(text))
+
+    # ---- assign / define -------------------------------------------------
+
+    def _compile_assign(self, node: ASTNode) -> IRNode:
+        # `assign` with 3 children: lhs, COLON|COLONEQ, rhs.
+        # (With 1 child it's already unwrapped elsewhere.)
+        if len(node.children) == 1:
+            return self._compile_node(node.children[0])  # type: ignore[arg-type]
+        if len(node.children) != 3:
+            raise CompileError("malformed assign node")
+        lhs_ast, op_tok, rhs_ast = node.children
+        if not isinstance(op_tok, Token):
+            raise CompileError("assign's middle child must be a Token")
+        op = _token_type_name(op_tok)
+        rhs_ir = self._compile_node(rhs_ast)  # type: ignore[arg-type]
+        lhs_ir = self._compile_node(lhs_ast)  # type: ignore[arg-type]
+
+        if op == "COLONEQ":
+            # `f(x) := body` — delayed function definition.
+            # If lhs is `Apply(f, (params...))`, rewrite to
+            # `Define(f, List(params...), body)`.
+            if isinstance(lhs_ir, IRApply) and isinstance(lhs_ir.head, IRSymbol):
+                return IRApply(
+                    DEFINE,
+                    (lhs_ir.head, IRApply(LIST, lhs_ir.args), rhs_ir),
+                )
+            # `x := body` — also a define, bind directly.
+            return IRApply(DEFINE, (lhs_ir, IRApply(LIST, ()), rhs_ir))
+        # op == "COLON": eager assignment.
+        return IRApply(ASSIGN, (lhs_ir, rhs_ir))
+
+    # ---- logical operators -----------------------------------------------
+
+    def _compile_logical_chain(
+        self, node: ASTNode, head: IRSymbol, op_text: str
+    ) -> IRNode:
+        """Left-associative chain: `a OP b OP c` → ``Apply(head, (a, b, c))``.
+
+        MACSYMA's `and` and `or` keyword operators are flattened into a
+        single variadic ``Apply`` rather than nested pairwise applies.
+        This matches how Mathematica stores `And[a, b, c]` and makes
+        rule matching easier.
+        """
+        if len(node.children) == 1:
+            return self._compile_node(node.children[0])  # type: ignore[arg-type]
+        operands: list[IRNode] = []
+        for child in node.children:
+            if isinstance(child, Token):
+                continue  # skip the keyword tokens
+            operands.append(self._compile_node(child))
+        return IRApply(head, tuple(operands))
+
+    def _compile_logical_or(self, node: ASTNode) -> IRNode:
+        return self._compile_logical_chain(node, OR, "or")
+
+    def _compile_logical_and(self, node: ASTNode) -> IRNode:
+        return self._compile_logical_chain(node, AND, "and")
+
+    def _compile_logical_not(self, node: ASTNode) -> IRNode:
+        # 1 child → plain comparison; 2 children → NOT expr.
+        if len(node.children) == 1:
+            return self._compile_node(node.children[0])  # type: ignore[arg-type]
+        return IRApply(NOT, (self._compile_node(node.children[1]),))  # type: ignore[arg-type]
+
+    # ---- comparison ------------------------------------------------------
+
+    def _compile_comparison(self, node: ASTNode) -> IRNode:
+        if len(node.children) == 1:
+            return self._compile_node(node.children[0])  # type: ignore[arg-type]
+        if len(node.children) != 3:
+            raise CompileError("malformed comparison node")
+        lhs_ast, op_tok, rhs_ast = node.children
+        if not isinstance(op_tok, Token):
+            raise CompileError("comparison op must be a Token")
+        head = _COMPARISON_HEADS.get(_token_type_name(op_tok))
+        if head is None:
+            raise CompileError(f"unknown comparison op {op_tok.value!r}")
+        return IRApply(
+            head,
+            (self._compile_node(lhs_ast), self._compile_node(rhs_ast)),  # type: ignore[arg-type]
+        )
+
+    # ---- additive / multiplicative ---------------------------------------
+
+    def _compile_binary_chain(self, node: ASTNode) -> IRNode:
+        """Handle left-associative `operand (OP operand)*`.
+
+        The children alternate: operand, op, operand, op, operand, ...
+        We reduce pairwise from the left, producing nested ``IRApply``
+        nodes. Nested is correct (not flattened) because ``Sub`` and
+        ``Div`` are NOT associative — `a - b - c` must be `(a-b)-c`.
+        """
+        if len(node.children) == 1:
+            return self._compile_node(node.children[0])  # type: ignore[arg-type]
+        result: IRNode | None = None
+        pending_op: IRSymbol | None = None
+        for child in node.children:
+            if isinstance(child, Token):
+                head = _BINARY_OP_HEADS.get(_token_type_name(child))
+                if head is None:
+                    raise CompileError(f"unknown binary op {child.value!r}")
+                pending_op = head
+                continue
+            value = self._compile_node(child)
+            if result is None:
+                result = value
+            else:
+                assert pending_op is not None
+                result = IRApply(pending_op, (result, value))
+                pending_op = None
+        assert result is not None
+        return result
+
+    # ---- unary -----------------------------------------------------------
+
+    def _compile_unary(self, node: ASTNode) -> IRNode:
+        # 1 child → plain power; 2 children → (MINUS|PLUS) unary.
+        if len(node.children) == 1:
+            return self._compile_node(node.children[0])  # type: ignore[arg-type]
+        op_tok, inner = node.children
+        inner_ir = self._compile_node(inner)  # type: ignore[arg-type]
+        if not isinstance(op_tok, Token):
+            raise CompileError("unary op must be a Token")
+        if _token_type_name(op_tok) == "MINUS":
+            return IRApply(NEG, (inner_ir,))
+        # Unary plus is a no-op.
+        return inner_ir
+
+    # ---- power -----------------------------------------------------------
+
+    def _compile_power(self, node: ASTNode) -> IRNode:
+        # 1 child → postfix; 3 children → base CARET|STAREQ exponent.
+        if len(node.children) == 1:
+            return self._compile_node(node.children[0])  # type: ignore[arg-type]
+        if len(node.children) != 3:
+            raise CompileError("malformed power node")
+        base, _op, exp = node.children
+        return IRApply(
+            POW,
+            (self._compile_node(base), self._compile_node(exp)),  # type: ignore[arg-type]
+        )
+
+    # ---- postfix (function call) -----------------------------------------
+
+    def _compile_postfix(self, node: ASTNode) -> IRNode:
+        # 1 child → plain atom.
+        # Otherwise: atom LPAREN [arglist] RPAREN { LPAREN [arglist] RPAREN }
+        if len(node.children) == 1:
+            return self._compile_node(node.children[0])  # type: ignore[arg-type]
+
+        # The first child is the atom; everything after comes in groups
+        # of either (LPAREN, RPAREN) for no-arg calls or
+        # (LPAREN, arglist, RPAREN) for argful calls.
+        result = self._compile_node(node.children[0])  # type: ignore[arg-type]
+
+        i = 1
+        while i < len(node.children):
+            child = node.children[i]
+            # Expect LPAREN here.
+            if not (isinstance(child, Token) and _token_type_name(child) == "LPAREN"):
+                raise CompileError("expected LPAREN in postfix")
+            i += 1
+            # Next is either RPAREN (no args) or arglist.
+            args: tuple[IRNode, ...] = ()
+            next_child = node.children[i]
+            if isinstance(next_child, ASTNode) and next_child.rule_name == "arglist":
+                args = self._compile_arglist(next_child)
+                i += 1
+                # Then RPAREN.
+                if not (
+                    isinstance(node.children[i], Token)
+                    and _token_type_name(node.children[i]) == "RPAREN"  # type: ignore[arg-type]
+                ):
+                    raise CompileError("expected RPAREN after arglist")
+                i += 1
+            else:
+                # Empty arglist: next child should be RPAREN.
+                if not (
+                    isinstance(next_child, Token)
+                    and _token_type_name(next_child) == "RPAREN"
+                ):
+                    raise CompileError("expected RPAREN in empty call")
+                i += 1
+
+            # Substitute well-known function names with canonical heads.
+            head: IRNode = result
+            if isinstance(result, IRSymbol):
+                head = _STANDARD_FUNCTIONS.get(result.name, result)
+            result = IRApply(head, args)
+        return result
+
+    def _compile_arglist(self, node: ASTNode) -> tuple[IRNode, ...]:
+        # `arglist = expression { COMMA expression } ;`
+        out: list[IRNode] = []
+        for child in node.children:
+            if isinstance(child, Token):
+                continue
+            out.append(self._compile_node(child))
+        return tuple(out)
+
+    # ---- list literal ----------------------------------------------------
+
+    def _compile_list(self, node: ASTNode) -> IRNode:
+        # `list = LBRACKET [ arglist ] RBRACKET ;`
+        for child in node.children:
+            if isinstance(child, ASTNode) and child.rule_name == "arglist":
+                return IRApply(LIST, self._compile_arglist(child))
+        return IRApply(LIST, ())
+
+    # ---- group -----------------------------------------------------------
+
+    def _compile_group(self, node: ASTNode) -> IRNode:
+        # `group = LPAREN expression RPAREN ;` — extract the middle.
+        for child in node.children:
+            if isinstance(child, ASTNode):
+                return self._compile_node(child)
+        raise CompileError("empty group")
+
+    # ---- atom (rarely reached at top level) ------------------------------
+
+    def _compile_atom(self, node: ASTNode) -> IRNode:
+        # `atom` should have been unwrapped already in most paths. If
+        # we reach here, its only child is a token or a group/list.
+        if len(node.children) != 1:
+            raise CompileError("atom with non-1 children")
+        return self._compile_node(node.children[0])  # type: ignore[arg-type]
+
+    # ---- dispatch table --------------------------------------------------
+
+    _handlers: dict[str, callable] = {  # type: ignore[type-arg]
+        "assign": _compile_assign,
+        "logical_or": _compile_logical_or,
+        "logical_and": _compile_logical_and,
+        "logical_not": _compile_logical_not,
+        "comparison": _compile_comparison,
+        "additive": _compile_binary_chain,
+        "multiplicative": _compile_binary_chain,
+        "unary": _compile_unary,
+        "power": _compile_power,
+        "postfix": _compile_postfix,
+        "atom": _compile_atom,
+        "group": _compile_group,
+        "list": _compile_list,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Module-level convenience wrappers
+# ---------------------------------------------------------------------------
+
+
+def compile_macsyma(ast: ASTNode) -> list[IRNode]:
+    """Compile a MACSYMA ``program`` AST to a list of IR statements.
+
+    Args:
+        ast: The root ``ASTNode`` produced by ``parse_macsyma``.
+
+    Returns:
+        One ``IRNode`` per top-level statement. Empty programs return
+        an empty list.
+    """
+    return Compiler().compile_program(ast)
+
+
+def compile_expression(ast: ASTNode | Token) -> IRNode:
+    """Compile a single expression AST (no enclosing statement) to IR.
+
+    Useful for tests and for callers that parse expressions
+    individually rather than whole programs.
+    """
+    return Compiler()._compile_node(ast)

--- a/code/packages/python/macsyma-compiler/tests/test_compiler.py
+++ b/code/packages/python/macsyma-compiler/tests/test_compiler.py
@@ -1,0 +1,334 @@
+"""macsyma-compiler tests.
+
+These verify that a parsed MACSYMA program compiles to the expected
+``IRApply`` shape, including all the flattening and head-rewriting
+rules documented in ``compiler.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from macsyma_compiler import CompileError, compile_macsyma
+from macsyma_parser import parse_macsyma
+from symbolic_ir import (
+    ADD,
+    ASSIGN,
+    D,
+    DEFINE,
+    DIV,
+    EQUAL,
+    GREATER,
+    LESS,
+    LIST,
+    MUL,
+    NEG,
+    POW,
+    SIN,
+    SUB,
+    IRApply,
+    IRFloat,
+    IRInteger,
+    IRSymbol,
+)
+from symbolic_ir.nodes import AND, OR
+
+
+def compile_one(source: str):
+    """Compile a source string and return its single statement's IR."""
+    statements = compile_macsyma(parse_macsyma(source))
+    assert len(statements) == 1, f"expected 1 statement, got {len(statements)}"
+    return statements[0]
+
+
+# ---------------------------------------------------------------------------
+# Atoms
+# ---------------------------------------------------------------------------
+
+
+def test_integer_literal() -> None:
+    assert compile_one("42;") == IRInteger(42)
+
+
+def test_float_literal() -> None:
+    assert compile_one("3.14;") == IRFloat(3.14)
+
+
+def test_name_becomes_symbol() -> None:
+    assert compile_one("x;") == IRSymbol("x")
+
+
+def test_percent_constant() -> None:
+    # %pi and friends are still just identifiers at the IR level;
+    # the VM will give them special meaning.
+    assert compile_one("%pi;") == IRSymbol("%pi")
+
+
+# ---------------------------------------------------------------------------
+# Binary arithmetic
+# ---------------------------------------------------------------------------
+
+
+def test_simple_addition() -> None:
+    assert compile_one("x + 1;") == IRApply(ADD, (IRSymbol("x"), IRInteger(1)))
+
+
+def test_subtraction_left_associative() -> None:
+    # (a - b) - c  (not a - (b - c))
+    result = compile_one("a - b - c;")
+    expected = IRApply(
+        SUB,
+        (
+            IRApply(SUB, (IRSymbol("a"), IRSymbol("b"))),
+            IRSymbol("c"),
+        ),
+    )
+    assert result == expected
+
+
+def test_multiplication_division_left_associative() -> None:
+    result = compile_one("a / b * c;")
+    expected = IRApply(
+        MUL,
+        (
+            IRApply(DIV, (IRSymbol("a"), IRSymbol("b"))),
+            IRSymbol("c"),
+        ),
+    )
+    assert result == expected
+
+
+def test_precedence_add_lower_than_mul() -> None:
+    # 1 + 2 * 3 → Add(1, Mul(2, 3))
+    result = compile_one("1 + 2 * 3;")
+    expected = IRApply(
+        ADD,
+        (IRInteger(1), IRApply(MUL, (IRInteger(2), IRInteger(3)))),
+    )
+    assert result == expected
+
+
+def test_parens_override_precedence() -> None:
+    # (1 + 2) * 3 → Mul(Add(1, 2), 3)
+    result = compile_one("(1 + 2) * 3;")
+    expected = IRApply(
+        MUL,
+        (IRApply(ADD, (IRInteger(1), IRInteger(2))), IRInteger(3)),
+    )
+    assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# Power and unary
+# ---------------------------------------------------------------------------
+
+
+def test_power() -> None:
+    assert compile_one("x^2;") == IRApply(
+        POW, (IRSymbol("x"), IRInteger(2))
+    )
+
+
+def test_double_star_power() -> None:
+    assert compile_one("x ** 2;") == IRApply(
+        POW, (IRSymbol("x"), IRInteger(2))
+    )
+
+
+def test_power_right_associative() -> None:
+    # a^b^c = a^(b^c)
+    result = compile_one("a^b^c;")
+    expected = IRApply(
+        POW,
+        (
+            IRSymbol("a"),
+            IRApply(POW, (IRSymbol("b"), IRSymbol("c"))),
+        ),
+    )
+    assert result == expected
+
+
+def test_unary_minus() -> None:
+    assert compile_one("-x;") == IRApply(NEG, (IRSymbol("x"),))
+
+
+def test_unary_plus_is_identity() -> None:
+    assert compile_one("+x;") == IRSymbol("x")
+
+
+def test_unary_minus_binds_tighter_than_mul() -> None:
+    # a * -b → Mul(a, Neg(b))
+    result = compile_one("a * -b;")
+    expected = IRApply(
+        MUL,
+        (IRSymbol("a"), IRApply(NEG, (IRSymbol("b"),))),
+    )
+    assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# Function calls and standard-function rewriting
+# ---------------------------------------------------------------------------
+
+
+def test_user_function_call() -> None:
+    # `f(x, y)` with user-defined f → Apply(Symbol('f'), (x, y))
+    result = compile_one("f(x, y);")
+    expected = IRApply(IRSymbol("f"), (IRSymbol("x"), IRSymbol("y")))
+    assert result == expected
+
+
+def test_diff_rewrites_to_D() -> None:
+    # diff(x^2, x) → Apply(D, (Pow(x, 2), x))
+    result = compile_one("diff(x^2, x);")
+    expected = IRApply(
+        D,
+        (
+            IRApply(POW, (IRSymbol("x"), IRInteger(2))),
+            IRSymbol("x"),
+        ),
+    )
+    assert result == expected
+
+
+def test_sin_rewrites_to_Sin() -> None:
+    result = compile_one("sin(x);")
+    assert result == IRApply(SIN, (IRSymbol("x"),))
+
+
+def test_empty_function_call() -> None:
+    # No-arg function call.
+    result = compile_one("f();")
+    assert result == IRApply(IRSymbol("f"), ())
+
+
+# ---------------------------------------------------------------------------
+# Comparisons and logic
+# ---------------------------------------------------------------------------
+
+
+def test_equality() -> None:
+    assert compile_one("x = 4;") == IRApply(
+        EQUAL, (IRSymbol("x"), IRInteger(4))
+    )
+
+
+def test_less_than() -> None:
+    assert compile_one("a < b;") == IRApply(
+        LESS, (IRSymbol("a"), IRSymbol("b"))
+    )
+
+
+def test_greater_than() -> None:
+    assert compile_one("a > b;") == IRApply(
+        GREATER, (IRSymbol("a"), IRSymbol("b"))
+    )
+
+
+def test_logical_and_variadic() -> None:
+    # a and b and c → And(a, b, c) (not nested).
+    result = compile_one("a and b and c;")
+    expected = IRApply(AND, (IRSymbol("a"), IRSymbol("b"), IRSymbol("c")))
+    assert result == expected
+
+
+def test_logical_or_variadic() -> None:
+    result = compile_one("a or b or c;")
+    expected = IRApply(OR, (IRSymbol("a"), IRSymbol("b"), IRSymbol("c")))
+    assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# Assignment and definition
+# ---------------------------------------------------------------------------
+
+
+def test_simple_assignment() -> None:
+    # a : 5  → Assign(a, 5)
+    result = compile_one("a : 5;")
+    assert result == IRApply(ASSIGN, (IRSymbol("a"), IRInteger(5)))
+
+
+def test_function_definition() -> None:
+    # f(x) := x^2 → Define(f, List(x), Pow(x, 2))
+    result = compile_one("f(x) := x^2;")
+    expected = IRApply(
+        DEFINE,
+        (
+            IRSymbol("f"),
+            IRApply(LIST, (IRSymbol("x"),)),
+            IRApply(POW, (IRSymbol("x"), IRInteger(2))),
+        ),
+    )
+    assert result == expected
+
+
+def test_multi_arg_function_definition() -> None:
+    result = compile_one("add(x, y) := x + y;")
+    expected = IRApply(
+        DEFINE,
+        (
+            IRSymbol("add"),
+            IRApply(LIST, (IRSymbol("x"), IRSymbol("y"))),
+            IRApply(ADD, (IRSymbol("x"), IRSymbol("y"))),
+        ),
+    )
+    assert result == expected
+
+
+def test_variable_definition_delayed() -> None:
+    # `x := 5` is still DEFINE with empty params.
+    result = compile_one("x := 5;")
+    expected = IRApply(
+        DEFINE,
+        (IRSymbol("x"), IRApply(LIST, ()), IRInteger(5)),
+    )
+    assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# Lists
+# ---------------------------------------------------------------------------
+
+
+def test_list_literal() -> None:
+    result = compile_one("[1, 2, 3];")
+    expected = IRApply(
+        LIST, (IRInteger(1), IRInteger(2), IRInteger(3))
+    )
+    assert result == expected
+
+
+def test_empty_list() -> None:
+    assert compile_one("[];") == IRApply(LIST, ())
+
+
+# ---------------------------------------------------------------------------
+# Programs with multiple statements
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_statements() -> None:
+    stmts = compile_macsyma(parse_macsyma("a : 1; b : 2; a + b;"))
+    assert len(stmts) == 3
+    assert stmts[0] == IRApply(ASSIGN, (IRSymbol("a"), IRInteger(1)))
+    assert stmts[1] == IRApply(ASSIGN, (IRSymbol("b"), IRInteger(2)))
+    assert stmts[2] == IRApply(ADD, (IRSymbol("a"), IRSymbol("b")))
+
+
+def test_empty_program() -> None:
+    assert compile_macsyma(parse_macsyma("")) == []
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+def test_non_program_root_raises() -> None:
+    from macsyma_parser import parse_macsyma as _parse
+
+    # Build a parsed tree and try to compile an inner node.
+    ast = _parse("x;")
+    inner = ast.children[0]  # statement
+    with pytest.raises(CompileError):
+        compile_macsyma(inner)  # type: ignore[arg-type]

--- a/code/packages/python/macsyma-lexer/BUILD
+++ b/code/packages/python/macsyma-lexer/BUILD
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../grammar-tools -e ../graph -e ../directed-graph -e ../state-machine -e ../lexer -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/macsyma-lexer/CHANGELOG.md
+++ b/code/packages/python/macsyma-lexer/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## 0.1.0 — 2026-04-19
+
+Initial release.
+
+- Thin wrapper around `GrammarLexer`, configured via
+  `code/grammars/macsyma/macsyma.tokens`.
+- Supports integer/float/scientific numbers, names (including
+  `%`-prefixed constants), strings, all MACSYMA operators (including
+  `:=`, `:`, `=`, `#`, `<=`, `>=`, `->`, `**`), delimiters, two
+  statement terminators (`;` and `$`), C-style comments.
+- Keywords: `and`, `or`, `not`, `true`, `false`, plus control-flow
+  words (`if`, `then`, `else`, `for`, `while`, etc.) carried through
+  for future parser extensions.
+- Full test suite covering every token category and realistic
+  MACSYMA programs.

--- a/code/packages/python/macsyma-lexer/README.md
+++ b/code/packages/python/macsyma-lexer/README.md
@@ -1,0 +1,47 @@
+# macsyma-lexer
+
+A thin wrapper around the repo's generic grammar-driven `GrammarLexer`
+that tokenizes MACSYMA/Maxima source text.
+
+## What this package is
+
+This package exists almost entirely to route `macsyma.tokens` into the
+shared `GrammarLexer` engine. The real work — the regex engine, the
+DFA, the keyword reclassification — lives in the `lexer` package. This
+wrapper just:
+
+1. Locates `code/grammars/macsyma/macsyma.tokens` on disk.
+2. Parses it into a `TokenGrammar`.
+3. Hands that grammar to `GrammarLexer(source, grammar)`.
+
+Everything else is shared infrastructure.
+
+## Usage
+
+```python
+from macsyma_lexer import tokenize_macsyma
+
+tokens = tokenize_macsyma("f(x) := x^2 + 1; diff(f(x), x);")
+for tok in tokens:
+    print(tok.type, tok.value)
+```
+
+## MACSYMA lexical quirks
+
+- `:=` is function definition (one token), distinct from `:`
+  (assignment) and `=` (symbolic equation).
+- `#` is not-equal — a historical MACSYMA choice that confuses
+  readers used to `/=` or `!=`.
+- `%pi`, `%e`, `%i` are single `NAME` tokens — the `%` prefix marks
+  system-defined constants.
+- Statements end with `;` (display result) or `$` (suppress result).
+  Both are preserved as distinct tokens so downstream layers can
+  choose output behavior.
+- Comments are C-style `/* ... */`.
+
+## Dependencies
+
+- `coding-adventures-grammar-tools` — parses `.tokens` files.
+- `coding-adventures-lexer` — the generic grammar-driven lexer engine.
+- (transitive) `coding-adventures-directed-graph`,
+  `coding-adventures-state-machine`.

--- a/code/packages/python/macsyma-lexer/pyproject.toml
+++ b/code/packages/python/macsyma-lexer/pyproject.toml
@@ -1,0 +1,53 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-macsyma-lexer"
+version = "0.1.0"
+description = "Tokenizes MACSYMA/Maxima syntax via the grammar-driven lexer — a thin wrapper that loads macsyma.tokens."
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["macsyma", "maxima", "lexer", "tokenizer", "cas", "symbolic", "education"]
+dependencies = [
+    "coding-adventures-directed-graph",
+    "coding-adventures-grammar-tools",
+    "coding-adventures-lexer",
+    "coding-adventures-state-machine",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Education",
+    "Topic :: Education",
+    "Topic :: Scientific/Engineering :: Mathematics",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://github.com/adhithyan15/coding-adventures"
+Repository = "https://github.com/adhithyan15/coding-adventures"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/macsyma_lexer"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=macsyma_lexer --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/packages/python/macsyma-lexer/required_capabilities.json
+++ b/code/packages/python/macsyma-lexer/required_capabilities.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "python/macsyma-lexer",
+  "capabilities": [
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "../../grammars/macsyma/macsyma.tokens",
+      "justification": "Reads the MACSYMA token grammar at initialization time to configure the generic grammar-driven lexer."
+    }
+  ],
+  "justification": "Reads a single grammar file. No write, network, or process access."
+}

--- a/code/packages/python/macsyma-lexer/src/macsyma_lexer/__init__.py
+++ b/code/packages/python/macsyma-lexer/src/macsyma_lexer/__init__.py
@@ -1,0 +1,25 @@
+"""MACSYMA Lexer — tokenizes MACSYMA/Maxima expression syntax.
+
+This package is a thin wrapper around the generic ``GrammarLexer``. It
+loads ``macsyma.tokens`` from the ``code/grammars/macsyma/`` directory
+and produces a stream of ``Token`` objects ready for the parser.
+
+MACSYMA is the grandparent of every modern computer-algebra system —
+its lexical conventions (``:`` for assignment, ``:=`` for function
+definition, ``;`` vs ``$`` terminators, ``#`` for not-equal, ``/* */``
+comments) are shared by Maxima and influenced Mathematica, Maple, and
+REDUCE.
+
+Usage::
+
+    from macsyma_lexer import tokenize_macsyma
+
+    tokens = tokenize_macsyma("f(x) := x^2; diff(f(x), x);")
+"""
+
+from macsyma_lexer.tokenizer import create_macsyma_lexer, tokenize_macsyma
+
+__all__ = [
+    "create_macsyma_lexer",
+    "tokenize_macsyma",
+]

--- a/code/packages/python/macsyma-lexer/src/macsyma_lexer/tokenizer.py
+++ b/code/packages/python/macsyma-lexer/src/macsyma_lexer/tokenizer.py
@@ -1,0 +1,97 @@
+"""MACSYMA Lexer — thin wrapper around the grammar-driven lexer.
+
+This module reads ``macsyma.tokens`` from the repo's ``code/grammars/``
+directory and hands it to the generic ``GrammarLexer``. Adding a new
+CAS dialect (Mathematica, Maple, etc.) means writing a new ``.tokens``
+file — not a line of lexer code.
+
+File location
+-------------
+
+The grammar file lives at::
+
+    code/grammars/macsyma/macsyma.tokens
+
+relative to the repository root. This module finds it by walking up
+from its own path::
+
+    tokenizer.py
+    └── macsyma_lexer/   (parent)
+        └── src/         (parent)
+            └── macsyma-lexer/  (parent)
+                └── python/     (parent)
+                    └── packages/ (parent)
+                        └── code/ (parent)
+                            └── grammars/
+                                └── macsyma/
+                                    └── macsyma.tokens
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from grammar_tools import parse_token_grammar
+from lexer import GrammarLexer, Token
+
+# Navigate up from src/macsyma_lexer/tokenizer.py to reach code/grammars/.
+# Five .parent calls get us from the file to code/packages/python/; one
+# more parent reaches code/packages/; one more reaches code/.
+GRAMMAR_DIR = Path(__file__).parent.parent.parent.parent.parent.parent / "grammars"
+MACSYMA_TOKENS_PATH = GRAMMAR_DIR / "macsyma" / "macsyma.tokens"
+
+
+def create_macsyma_lexer(source: str) -> GrammarLexer:
+    """Create a ``GrammarLexer`` configured for MACSYMA syntax.
+
+    Reads ``macsyma.tokens``, parses it into a ``TokenGrammar``, and
+    constructs a ``GrammarLexer`` ready to tokenize the given source.
+
+    Args:
+        source: The MACSYMA source text to tokenize.
+
+    Returns:
+        A ``GrammarLexer`` instance. Call ``.tokenize()`` to get tokens.
+
+    Raises:
+        FileNotFoundError: If the ``macsyma.tokens`` file cannot be found.
+    """
+    grammar = parse_token_grammar(MACSYMA_TOKENS_PATH.read_text())
+    return GrammarLexer(source, grammar)
+
+
+def tokenize_macsyma(source: str) -> list[Token]:
+    """Tokenize MACSYMA source text and return a list of tokens.
+
+    This is the main entry point. Pass in a MACSYMA expression or
+    program, get back a flat token list ending in ``EOF``.
+
+    Token types produced include:
+
+    - ``NUMBER`` — integer or float literal.
+    - ``NAME`` — identifier (including ``%pi``, ``%e``, ``%i``).
+    - ``STRING`` — double-quoted string literal.
+    - ``KEYWORD`` — reserved word (``and``, ``or``, ``not``, ``true``,
+      ``false``, ``if``, ``then``, ``else``, ``for``, ``while``, etc.).
+      The ``value`` field holds the actual keyword text.
+    - Operator tokens: ``PLUS``, ``MINUS``, ``STAR``, ``SLASH``,
+      ``CARET``, ``STAREQ``, ``COLON``, ``COLONEQ``, ``EQ``, ``HASH``,
+      ``LT``, ``GT``, ``LEQ``, ``GEQ``, ``ARROW``, ``BANG``.
+    - Delimiter tokens: ``LPAREN``, ``RPAREN``, ``LBRACKET``,
+      ``RBRACKET``, ``LBRACE``, ``RBRACE``, ``COMMA``, ``SEMI``,
+      ``DOLLAR``.
+    - ``EOF`` — always the last token.
+
+    Args:
+        source: The MACSYMA source text.
+
+    Returns:
+        A list of ``Token`` objects. The last is always EOF.
+
+    Example::
+
+        tokens = tokenize_macsyma("x^2 + 1;")
+        # NAME('x'), CARET('^'), NUMBER('2'), PLUS('+'),
+        # NUMBER('1'), SEMI(';'), EOF
+    """
+    return create_macsyma_lexer(source).tokenize()

--- a/code/packages/python/macsyma-lexer/tests/test_tokenizer.py
+++ b/code/packages/python/macsyma-lexer/tests/test_tokenizer.py
@@ -1,0 +1,258 @@
+"""MACSYMA lexer tests.
+
+These tests exercise every token type in the MACSYMA grammar and verify
+edge cases: percent-prefixed constants, the distinction between ``:``
+(assignment), ``:=`` (definition), and ``=`` (equation), and the two
+statement terminators ``;`` and ``$``.
+"""
+
+from __future__ import annotations
+
+from macsyma_lexer import tokenize_macsyma
+
+
+def types_of(source: str) -> list[str]:
+    """Return the list of token type names for a given source string.
+
+    The ``tokenize_macsyma`` function returns ``Token`` objects whose
+    ``type`` is either an enum or a raw string. This helper normalizes
+    them to strings (stripping the trailing ``EOF``) for cleaner
+    assertions.
+    """
+    tokens = tokenize_macsyma(source)
+    names = []
+    for tok in tokens:
+        name = tok.type if isinstance(tok.type, str) else tok.type.name
+        if name == "EOF":
+            continue
+        names.append(name)
+    return names
+
+
+def values_of(source: str) -> list[str]:
+    tokens = tokenize_macsyma(source)
+    return [t.value for t in tokens if (t.type if isinstance(t.type, str) else t.type.name) != "EOF"]
+
+
+# ---------------------------------------------------------------------------
+# Basic tokens
+# ---------------------------------------------------------------------------
+
+
+def test_integer_number() -> None:
+    assert types_of("42") == ["NUMBER"]
+    assert values_of("42") == ["42"]
+
+
+def test_float_number() -> None:
+    assert types_of("3.14") == ["NUMBER"]
+    assert values_of("3.14") == ["3.14"]
+
+
+def test_scientific_notation() -> None:
+    assert types_of("1.5e10") == ["NUMBER"]
+
+
+def test_simple_name() -> None:
+    assert types_of("x") == ["NAME"]
+    assert values_of("x") == ["x"]
+
+
+def test_percent_prefixed_name() -> None:
+    # %pi, %e, %i — MACSYMA's system-defined constants.
+    assert types_of("%pi") == ["NAME"]
+    assert values_of("%pi") == ["%pi"]
+
+
+def test_string_literal() -> None:
+    assert types_of('"hello"') == ["STRING"]
+
+
+# ---------------------------------------------------------------------------
+# Operators
+# ---------------------------------------------------------------------------
+
+
+def test_arithmetic_operators() -> None:
+    assert types_of("1 + 2 - 3 * 4 / 5 ^ 6") == [
+        "NUMBER",
+        "PLUS",
+        "NUMBER",
+        "MINUS",
+        "NUMBER",
+        "STAR",
+        "NUMBER",
+        "SLASH",
+        "NUMBER",
+        "CARET",
+        "NUMBER",
+    ]
+
+
+def test_double_star_power() -> None:
+    # MACSYMA accepts both `^` and `**` for exponentiation.
+    assert types_of("x ** 2") == ["NAME", "STAREQ", "NUMBER"]
+
+
+def test_assignment_vs_definition() -> None:
+    # `:` is single-char; `:=` must be lexed as one two-char token.
+    assert types_of("a : 5") == ["NAME", "COLON", "NUMBER"]
+    assert types_of("f(x) := x") == [
+        "NAME",
+        "LPAREN",
+        "NAME",
+        "RPAREN",
+        "COLONEQ",
+        "NAME",
+    ]
+
+
+def test_equation_operator() -> None:
+    # `=` is the equation operator, distinct from `:` assignment.
+    assert types_of("x = 4") == ["NAME", "EQ", "NUMBER"]
+
+
+def test_not_equal_hash() -> None:
+    # MACSYMA uses `#` for not-equal. Unusual but correct.
+    assert types_of("a # b") == ["NAME", "HASH", "NAME"]
+
+
+def test_comparison_operators() -> None:
+    assert types_of("a <= b >= c < d > e") == [
+        "NAME",
+        "LEQ",
+        "NAME",
+        "GEQ",
+        "NAME",
+        "LT",
+        "NAME",
+        "GT",
+        "NAME",
+    ]
+
+
+def test_arrow_operator() -> None:
+    # `->` for rule arrows. Must be tried before `-`.
+    assert types_of("x -> y") == ["NAME", "ARROW", "NAME"]
+
+
+# ---------------------------------------------------------------------------
+# Delimiters
+# ---------------------------------------------------------------------------
+
+
+def test_parens_brackets_braces() -> None:
+    assert types_of("( [ { } ] )") == [
+        "LPAREN",
+        "LBRACKET",
+        "LBRACE",
+        "RBRACE",
+        "RBRACKET",
+        "RPAREN",
+    ]
+
+
+def test_statement_terminators() -> None:
+    # `;` displays the result; `$` suppresses it. Both are valid
+    # terminators and are lexed as distinct tokens.
+    assert types_of("x;") == ["NAME", "SEMI"]
+    assert types_of("x$") == ["NAME", "DOLLAR"]
+
+
+# ---------------------------------------------------------------------------
+# Keywords
+# ---------------------------------------------------------------------------
+
+
+def test_boolean_keywords() -> None:
+    # Keywords come through as type KEYWORD with their value in .value.
+    tokens = tokenize_macsyma("x and y or not z")
+    # Filter out EOF.
+    non_eof = [t for t in tokens if (t.type if isinstance(t.type, str) else t.type.name) != "EOF"]
+    # The shape we expect: NAME KEYWORD(and) NAME KEYWORD(or) KEYWORD(not) NAME
+    types = [t.type if isinstance(t.type, str) else t.type.name for t in non_eof]
+    values = [t.value for t in non_eof]
+    assert types == ["NAME", "KEYWORD", "NAME", "KEYWORD", "KEYWORD", "NAME"]
+    assert values == ["x", "and", "y", "or", "not", "z"]
+
+
+def test_true_false_keywords() -> None:
+    tokens = tokenize_macsyma("true false")
+    non_eof = [t for t in tokens if (t.type if isinstance(t.type, str) else t.type.name) != "EOF"]
+    values = [t.value for t in non_eof]
+    assert values == ["true", "false"]
+
+
+# ---------------------------------------------------------------------------
+# Comments and whitespace
+# ---------------------------------------------------------------------------
+
+
+def test_comments_are_skipped() -> None:
+    # Comments should not produce any tokens.
+    assert types_of("/* this is ignored */ x") == ["NAME"]
+
+
+def test_multiline_comment() -> None:
+    source = """
+    /* Multi-line
+       comment that
+       spans lines */
+    42
+    """
+    assert types_of(source) == ["NUMBER"]
+
+
+def test_whitespace_is_skipped() -> None:
+    assert types_of("   x   +   y   ") == ["NAME", "PLUS", "NAME"]
+
+
+def test_newlines_are_skipped() -> None:
+    # MACSYMA doesn't care about newlines — statements end with `;` or `$`.
+    assert types_of("x\n+\ny") == ["NAME", "PLUS", "NAME"]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end realistic MACSYMA
+# ---------------------------------------------------------------------------
+
+
+def test_function_definition_and_use() -> None:
+    source = "f(x) := x^2 + 1; diff(f(x), x);"
+    assert types_of(source) == [
+        # f ( x ) := x ^ 2 + 1 ;
+        "NAME",
+        "LPAREN",
+        "NAME",
+        "RPAREN",
+        "COLONEQ",
+        "NAME",
+        "CARET",
+        "NUMBER",
+        "PLUS",
+        "NUMBER",
+        "SEMI",
+        # diff ( f ( x ) , x ) ;
+        "NAME",
+        "LPAREN",
+        "NAME",
+        "LPAREN",
+        "NAME",
+        "RPAREN",
+        "COMMA",
+        "NAME",
+        "RPAREN",
+        "SEMI",
+    ]
+
+
+def test_list_literal() -> None:
+    assert types_of("[1, 2, 3]") == [
+        "LBRACKET",
+        "NUMBER",
+        "COMMA",
+        "NUMBER",
+        "COMMA",
+        "NUMBER",
+        "RBRACKET",
+    ]

--- a/code/packages/python/macsyma-parser/BUILD
+++ b/code/packages/python/macsyma-parser/BUILD
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../grammar-tools -e ../graph -e ../directed-graph -e ../state-machine -e ../lexer -e ../parser -e ../macsyma-lexer -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/macsyma-parser/CHANGELOG.md
+++ b/code/packages/python/macsyma-parser/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## 0.1.0 — 2026-04-19
+
+Initial release.
+
+- Thin wrapper around `GrammarParser`, configured via
+  `code/grammars/macsyma/macsyma.grammar`.
+- Parses the MACSYMA expression sublanguage: arithmetic, comparisons,
+  boolean operators, function calls, lists, assignment, and function
+  definition.
+- Full test suite covering every production in the grammar.

--- a/code/packages/python/macsyma-parser/README.md
+++ b/code/packages/python/macsyma-parser/README.md
@@ -1,0 +1,43 @@
+# macsyma-parser
+
+A thin wrapper around the repo's grammar-driven `GrammarParser` that
+parses MACSYMA/Maxima source into a generic `ASTNode` tree.
+
+## What this package is
+
+This package does the bare minimum: load `macsyma.grammar`, tokenize
+the source via `macsyma-lexer`, hand both to the generic `GrammarParser`.
+No hand-written recursion, no precedence-climbing code — the entire
+expression grammar lives in `code/grammars/macsyma/macsyma.grammar`.
+
+## Usage
+
+```python
+from macsyma_parser import parse_macsyma
+from lang_parser import find_nodes
+
+ast = parse_macsyma("f(x) := x^2; diff(f(x), x);")
+print(ast.rule_name)  # "program"
+print(len(find_nodes(ast, "statement")))  # 2
+```
+
+## The AST
+
+The parser produces a generic `ASTNode` tree. Each node has:
+
+- `rule_name` — the grammar rule that matched (e.g. `"program"`,
+  `"statement"`, `"assign"`, `"power"`, `"postfix"`, `"atom"`).
+- `children` — a list of child `ASTNode`s and `Token`s.
+
+The grammar's precedence cascade makes the tree deeper than strictly
+necessary (every expression traverses `assign → logical_or →
+logical_and → logical_not → comparison → additive → multiplicative →
+unary → power → postfix → atom`). The `macsyma-compiler` package
+flattens this into the uniform `IRApply(head, args)` shape on its way
+to the symbolic IR.
+
+## Dependencies
+
+- `coding-adventures-macsyma-lexer` — tokenizes the source.
+- `coding-adventures-parser` — the generic grammar-driven parser.
+- `coding-adventures-grammar-tools` — parses `.grammar` files.

--- a/code/packages/python/macsyma-parser/pyproject.toml
+++ b/code/packages/python/macsyma-parser/pyproject.toml
@@ -1,0 +1,55 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-macsyma-parser"
+version = "0.1.0"
+description = "Parses MACSYMA/Maxima syntax via the grammar-driven parser — a thin wrapper that loads macsyma.grammar."
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["macsyma", "maxima", "parser", "ast", "cas", "symbolic", "education"]
+dependencies = [
+    "coding-adventures-directed-graph",
+    "coding-adventures-grammar-tools",
+    "coding-adventures-lexer",
+    "coding-adventures-macsyma-lexer",
+    "coding-adventures-parser",
+    "coding-adventures-state-machine",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Education",
+    "Topic :: Education",
+    "Topic :: Scientific/Engineering :: Mathematics",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://github.com/adhithyan15/coding-adventures"
+Repository = "https://github.com/adhithyan15/coding-adventures"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/macsyma_parser"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=macsyma_parser --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/packages/python/macsyma-parser/required_capabilities.json
+++ b/code/packages/python/macsyma-parser/required_capabilities.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "python/macsyma-parser",
+  "capabilities": [
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "../../grammars/macsyma/macsyma.grammar",
+      "justification": "Reads the MACSYMA parser grammar at initialization time to configure the generic grammar-driven parser."
+    }
+  ],
+  "justification": "Reads a single grammar file (plus the tokens file via the macsyma-lexer dependency). No write, network, or process access."
+}

--- a/code/packages/python/macsyma-parser/src/macsyma_parser/__init__.py
+++ b/code/packages/python/macsyma-parser/src/macsyma_parser/__init__.py
@@ -1,0 +1,24 @@
+"""MACSYMA Parser — parses MACSYMA tokens into a generic AST.
+
+A thin wrapper around the repo's grammar-driven ``GrammarParser``. It
+loads ``macsyma.grammar``, tokenizes via ``macsyma-lexer``, and produces
+an ``ASTNode`` tree — the same generic AST type used by every other
+language parser in the repo.
+
+The resulting AST is consumed by ``macsyma-compiler`` which converts it
+to the universal symbolic IR.
+
+Usage::
+
+    from macsyma_parser import parse_macsyma
+
+    ast = parse_macsyma("f(x) := x^2; diff(f(x), x);")
+    print(ast.rule_name)  # "program"
+"""
+
+from macsyma_parser.parser import create_macsyma_parser, parse_macsyma
+
+__all__ = [
+    "create_macsyma_parser",
+    "parse_macsyma",
+]

--- a/code/packages/python/macsyma-parser/src/macsyma_parser/parser.py
+++ b/code/packages/python/macsyma-parser/src/macsyma_parser/parser.py
@@ -1,0 +1,68 @@
+"""MACSYMA parser — grammar-driven wrapper.
+
+Reads ``macsyma.grammar`` from the repo's ``code/grammars/macsyma/``
+directory, tokenizes source via the MACSYMA lexer, and runs the
+generic ``GrammarParser`` over the tokens.
+
+The result is an ``ASTNode`` tree whose ``rule_name`` values correspond
+directly to the nonterminals in ``macsyma.grammar`` — ``program``,
+``statement``, ``expression``, ``assign``, ``additive``, ``power``,
+``postfix``, ``atom``, etc. The tree is deliberately "flat" and
+concrete: later passes in ``macsyma-compiler`` flatten the precedence
+cascade into the uniform ``IRApply`` form.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from grammar_tools import parse_parser_grammar
+from lang_parser import ASTNode, GrammarParser
+from macsyma_lexer import tokenize_macsyma
+
+GRAMMAR_DIR = Path(__file__).parent.parent.parent.parent.parent.parent / "grammars"
+MACSYMA_GRAMMAR_PATH = GRAMMAR_DIR / "macsyma" / "macsyma.grammar"
+
+
+def create_macsyma_parser(source: str) -> GrammarParser:
+    """Create a ``GrammarParser`` configured for MACSYMA source.
+
+    Tokenizes via ``macsyma_lexer.tokenize_macsyma``, reads
+    ``macsyma.grammar``, and constructs a ``GrammarParser`` ready to
+    produce an AST.
+
+    Args:
+        source: The MACSYMA source text.
+
+    Returns:
+        A ``GrammarParser``. Call ``.parse()`` to get the ``ASTNode``.
+    """
+    tokens = tokenize_macsyma(source)
+    grammar = parse_parser_grammar(MACSYMA_GRAMMAR_PATH.read_text())
+    return GrammarParser(tokens, grammar)
+
+
+def parse_macsyma(source: str) -> ASTNode:
+    """Parse MACSYMA source and return the AST.
+
+    This is the main entry point. The returned ``ASTNode`` has
+    ``rule_name="program"`` at the root, with children that are
+    ``statement`` subtrees.
+
+    Args:
+        source: The MACSYMA source text.
+
+    Returns:
+        An ``ASTNode`` with ``rule_name="program"``.
+
+    Raises:
+        FileNotFoundError: If the grammar file cannot be found.
+        LexerError: If tokenization fails.
+        GrammarParseError: If the source does not parse.
+
+    Example::
+
+        ast = parse_macsyma("x + 1;")
+        assert ast.rule_name == "program"
+    """
+    return create_macsyma_parser(source).parse()

--- a/code/packages/python/macsyma-parser/tests/test_parser.py
+++ b/code/packages/python/macsyma-parser/tests/test_parser.py
@@ -1,0 +1,131 @@
+"""MACSYMA parser tests.
+
+These verify that the grammar-driven parser produces the expected
+``ASTNode`` shapes for representative MACSYMA programs. We don't pin
+down every child position (that would make the tests brittle against
+grammar tweaks); instead we check structural properties — root rule
+name, number of statements, key nonterminal types appearing.
+"""
+
+from __future__ import annotations
+
+from lang_parser import ASTNode, find_nodes
+from macsyma_parser import parse_macsyma
+
+
+def test_single_expression_statement() -> None:
+    ast = parse_macsyma("x;")
+    assert ast.rule_name == "program"
+    statements = find_nodes(ast, "statement")
+    assert len(statements) == 1
+
+
+def test_arithmetic_expression() -> None:
+    ast = parse_macsyma("1 + 2 * 3;")
+    # Expect at least one `additive` and one `multiplicative` node,
+    # since the grammar's precedence cascade uses both.
+    assert len(find_nodes(ast, "additive")) >= 1
+    assert len(find_nodes(ast, "multiplicative")) >= 1
+
+
+def test_power_expression() -> None:
+    ast = parse_macsyma("x^2;")
+    powers = find_nodes(ast, "power")
+    assert len(powers) >= 1
+
+
+def test_parenthesized_expression() -> None:
+    # `(1 + 2) * 3` should force the `additive` inside `multiplicative`
+    # via the explicit `group` rule.
+    ast = parse_macsyma("(1 + 2) * 3;")
+    assert len(find_nodes(ast, "group")) >= 1
+
+
+def test_function_call() -> None:
+    ast = parse_macsyma("f(x, y);")
+    postfix_nodes = find_nodes(ast, "postfix")
+    assert len(postfix_nodes) >= 1
+
+
+def test_assignment() -> None:
+    ast = parse_macsyma("a : 5;")
+    assign_nodes = find_nodes(ast, "assign")
+    assert len(assign_nodes) >= 1
+
+
+def test_function_definition() -> None:
+    ast = parse_macsyma("f(x) := x^2;")
+    assert ast.rule_name == "program"
+    # The `assign` rule handles both `:` and `:=`, so we expect an
+    # assign node in the tree.
+    assert len(find_nodes(ast, "assign")) >= 1
+
+
+def test_list_literal() -> None:
+    ast = parse_macsyma("[1, 2, 3];")
+    lists = find_nodes(ast, "list")
+    assert len(lists) >= 1
+
+
+def test_multiple_statements() -> None:
+    ast = parse_macsyma("a : 5; b : 10; a + b;")
+    statements = find_nodes(ast, "statement")
+    assert len(statements) == 3
+
+
+def test_suppress_output_dollar() -> None:
+    # Both `;` and `$` are valid terminators.
+    ast = parse_macsyma("x$")
+    assert ast.rule_name == "program"
+    assert len(find_nodes(ast, "statement")) == 1
+
+
+def test_mixed_terminators() -> None:
+    ast = parse_macsyma("a : 5$ b : 10; a + b;")
+    assert len(find_nodes(ast, "statement")) == 3
+
+
+def test_nested_function_calls() -> None:
+    ast = parse_macsyma("diff(f(x), x);")
+    # f(x) is one postfix with a call suffix; diff(...) is another.
+    postfix_nodes = find_nodes(ast, "postfix")
+    assert len(postfix_nodes) >= 2
+
+
+def test_percent_constants() -> None:
+    ast = parse_macsyma("%pi + %e;")
+    # No crash; the atoms should parse as NAME tokens.
+    assert ast.rule_name == "program"
+
+
+def test_comparison() -> None:
+    ast = parse_macsyma("x = 4;")
+    assert len(find_nodes(ast, "comparison")) >= 1
+
+
+def test_logical_operators() -> None:
+    ast = parse_macsyma("a and b or not c;")
+    assert len(find_nodes(ast, "logical_or")) >= 1
+    assert len(find_nodes(ast, "logical_and")) >= 1
+
+
+def test_unary_minus() -> None:
+    ast = parse_macsyma("-x;")
+    assert len(find_nodes(ast, "unary")) >= 1
+
+
+def test_comment_ignored() -> None:
+    ast = parse_macsyma("/* a note */ 42;")
+    assert len(find_nodes(ast, "statement")) == 1
+
+
+def test_empty_program() -> None:
+    # Zero statements is valid — the grammar uses `{ statement }`.
+    ast = parse_macsyma("")
+    assert ast.rule_name == "program"
+    assert len(find_nodes(ast, "statement")) == 0
+
+
+def test_returns_ast_node() -> None:
+    ast = parse_macsyma("1;")
+    assert isinstance(ast, ASTNode)

--- a/code/packages/python/symbolic-ir/BUILD
+++ b/code/packages/python/symbolic-ir/BUILD
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/symbolic-ir/CHANGELOG.md
+++ b/code/packages/python/symbolic-ir/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## 0.1.0 — 2026-04-19
+
+Initial release.
+
+- Six immutable node types: `IRSymbol`, `IRInteger`, `IRRational`,
+  `IRFloat`, `IRString`, `IRApply`.
+- `IRRational` normalization (gcd reduction, sign in numerator,
+  division-by-zero validation).
+- Standard head symbols (`ADD`, `MUL`, `POW`, `D`, `Integrate`, etc.)
+  as module-level singletons.
+- Full test suite covering construction, equality, hashing,
+  immutability, and nested-tree round trips.

--- a/code/packages/python/symbolic-ir/README.md
+++ b/code/packages/python/symbolic-ir/README.md
@@ -1,0 +1,70 @@
+# symbolic-ir
+
+The universal symbolic expression IR — the shared tree representation
+that every computer-algebra-system frontend compiles to and every CAS
+backend consumes.
+
+## What this package is
+
+Six immutable node types that can represent any symbolic expression:
+
+| Node | Purpose | Example |
+|------|---------|---------|
+| `IRSymbol(name)` | Named atom (variable, constant, or operation head) | `x`, `Pi`, `Add` |
+| `IRInteger(value)` | Arbitrary-precision integer | `42`, `-7`, `10**200` |
+| `IRRational(n, d)` | Exact fraction, always reduced | `1/2`, `-3/7` |
+| `IRFloat(value)` | Double-precision float | `3.14` |
+| `IRString(value)` | String literal | `"hello"` |
+| `IRApply(head, args)` | Compound expression: `head(args...)` | `Add(x, 1)` |
+
+Every compound expression is an `IRApply`. The head is always an
+`IRSymbol` naming an operation. This Lisp-like uniformity is what lets a
+single tree walker handle expressions from any CAS dialect.
+
+## Why this exists
+
+CAS systems like MACSYMA, Mathematica, Maple, and REDUCE all represent
+expressions as trees with a head and arguments. Only the surface syntax
+differs. By compiling every frontend to this single IR, we can share
+every downstream operation (simplification, differentiation, evaluation,
+rendering) across all dialects.
+
+## Example
+
+Representing the polynomial `x^2 + 2*x + 1`:
+
+```python
+from symbolic_ir import ADD, MUL, POW, IRApply, IRInteger, IRSymbol
+
+x = IRSymbol("x")
+expr = IRApply(ADD, (
+    IRApply(POW, (x, IRInteger(2))),
+    IRApply(MUL, (IRInteger(2), x)),
+    IRInteger(1),
+))
+```
+
+The uniform `IRApply(head, args)` shape means any tree walker — a
+simplifier, a pretty-printer, a numeric evaluator — has exactly one
+case to handle for compound expressions.
+
+## Design choices
+
+- **Frozen dataclasses.** Every node is immutable and hashable, so
+  nodes can be dict keys (essential for rewrite-rule caches) and safely
+  shared across threads.
+- **No auto-canonicalization.** `IRApply(Add, (x, 1))` and
+  `IRApply(Add, (1, x))` are distinct. Canonicalization is the VM's
+  job — different backends may have different notions of "canonical."
+- **Standard head singletons.** `ADD`, `MUL`, etc. are shared
+  `IRSymbol` constants. Equality is by value (`==`), not identity,
+  but using the singletons keeps equality checks cheap.
+
+## Dependencies
+
+None beyond the Python standard library.
+
+## Next steps
+
+- `symbolic-vm` — the generic tree-walking evaluator
+- `macsyma-compiler` — compiles a parsed MACSYMA AST into this IR

--- a/code/packages/python/symbolic-ir/pyproject.toml
+++ b/code/packages/python/symbolic-ir/pyproject.toml
@@ -1,0 +1,48 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-symbolic-ir"
+version = "0.1.0"
+description = "Universal symbolic expression IR — the shared tree representation that every CAS frontend compiles to and every CAS backend consumes."
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["symbolic", "computer-algebra", "cas", "ir", "education"]
+dependencies = []
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Education",
+    "Topic :: Education",
+    "Topic :: Scientific/Engineering :: Mathematics",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://github.com/adhithyan15/coding-adventures"
+Repository = "https://github.com/adhithyan15/coding-adventures"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/symbolic_ir"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=symbolic_ir --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/packages/python/symbolic-ir/required_capabilities.json
+++ b/code/packages/python/symbolic-ir/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "python/symbolic-ir",
+  "capabilities": [],
+  "justification": "Pure data types. No filesystem, network, or process access — only the standard library's math module (gcd)."
+}

--- a/code/packages/python/symbolic-ir/src/symbolic_ir/__init__.py
+++ b/code/packages/python/symbolic-ir/src/symbolic_ir/__init__.py
@@ -1,0 +1,105 @@
+"""Symbolic IR — the universal expression tree for computer algebra systems.
+
+Every CAS frontend (MACSYMA, Mathematica, Maple, REDUCE, SymPy syntax)
+compiles to this single IR. Every CAS backend (strict evaluation,
+symbolic rewriting, LaTeX rendering, transpilation) consumes this IR.
+
+The IR has exactly six node types:
+
+- ``IRSymbol(name)``        — an identifier: ``x``, ``%pi``, ``Add``.
+- ``IRInteger(value)``      — an arbitrary-precision integer.
+- ``IRRational(n, d)``      — an exact fraction, always reduced.
+- ``IRFloat(value)``        — a double-precision float.
+- ``IRString(value)``       — a string literal.
+- ``IRApply(head, args)``   — an operation: head(args...).
+
+All nodes are immutable and hashable. The compound form is always
+``IRApply`` — there are no `BinaryOp` or `FunctionCall` sub-types. The
+head of an ``IRApply`` is always an ``IRSymbol`` (by convention), which
+keeps the structure uniformly Lisp-like.
+
+Example::
+
+    from symbolic_ir import IRSymbol, IRInteger, IRApply, ADD, POW
+
+    # Represent x^2 + 1
+    x = IRSymbol("x")
+    expr = IRApply(ADD, (IRApply(POW, (x, IRInteger(2))), IRInteger(1)))
+"""
+
+from symbolic_ir.nodes import (
+    ADD,
+    AND,
+    ASSIGN,
+    COS,
+    D,
+    DEFINE,
+    DIV,
+    EQUAL,
+    EXP,
+    GREATER,
+    GREATER_EQUAL,
+    IF,
+    INTEGRATE,
+    INV,
+    LESS,
+    LESS_EQUAL,
+    LIST,
+    LOG,
+    MUL,
+    NEG,
+    NOT,
+    NOT_EQUAL,
+    OR,
+    POW,
+    RULE,
+    SIN,
+    SQRT,
+    SUB,
+    IRApply,
+    IRFloat,
+    IRInteger,
+    IRNode,
+    IRRational,
+    IRString,
+    IRSymbol,
+)
+
+__all__ = [
+    "IRNode",
+    "IRSymbol",
+    "IRInteger",
+    "IRRational",
+    "IRFloat",
+    "IRString",
+    "IRApply",
+    # Standard head symbols
+    "ADD",
+    "SUB",
+    "MUL",
+    "DIV",
+    "POW",
+    "NEG",
+    "INV",
+    "EXP",
+    "LOG",
+    "SIN",
+    "COS",
+    "SQRT",
+    "D",
+    "INTEGRATE",
+    "EQUAL",
+    "NOT_EQUAL",
+    "LESS",
+    "GREATER",
+    "LESS_EQUAL",
+    "GREATER_EQUAL",
+    "AND",
+    "OR",
+    "NOT",
+    "IF",
+    "LIST",
+    "ASSIGN",
+    "DEFINE",
+    "RULE",
+]

--- a/code/packages/python/symbolic-ir/src/symbolic_ir/nodes.py
+++ b/code/packages/python/symbolic-ir/src/symbolic_ir/nodes.py
@@ -1,0 +1,213 @@
+"""The six IR node types and the set of standard head symbols.
+
+Design notes
+------------
+
+Every node is a ``@dataclass(frozen=True, slots=True)``. Frozen makes them
+immutable (so they're hashable and safe to share); slots avoids the
+overhead of per-instance ``__dict__`` (important for trees with thousands
+of nodes).
+
+``IRRational`` always normalizes on construction: ``IRRational(2, 4)``
+becomes ``IRRational(1, 2)``. Negative rationals keep the sign in the
+numerator: ``IRRational(1, -2)`` becomes ``IRRational(-1, 2)``. Division
+by zero raises ``ValueError``.
+
+``IRApply`` stores its arguments as a ``tuple`` (not a ``list``) so the
+node stays hashable. The head is an arbitrary ``IRNode``, but in practice
+it is always an ``IRSymbol`` — we don't enforce this at the type level
+because higher-order heads (e.g. a function returned from another call)
+are conceivable in future dialects.
+
+The standard head symbols at the bottom of this module are singletons.
+Every place in the system that wants to refer to ``Add`` uses the shared
+``ADD`` constant, which keeps equality checks cheap and avoids
+proliferation of equivalent symbol objects.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import gcd
+
+
+class IRNode:
+    """Abstract base for every node in the symbolic IR.
+
+    This class exists purely for ``isinstance()`` checks. All real node
+    types are the six frozen dataclasses defined below.
+    """
+
+    __slots__ = ()
+
+
+@dataclass(frozen=True, slots=True)
+class IRSymbol(IRNode):
+    """A named atom — a variable, constant, or operation head.
+
+    Examples: ``IRSymbol("x")``, ``IRSymbol("Pi")``, ``IRSymbol("Add")``.
+    The name is case-sensitive (like MACSYMA and Mathematica).
+    """
+
+    name: str
+
+    def __str__(self) -> str:
+        return self.name
+
+
+@dataclass(frozen=True, slots=True)
+class IRInteger(IRNode):
+    """An arbitrary-precision integer literal.
+
+    Python's ``int`` is already arbitrary-precision, so no bigint class is
+    needed. Negative values are allowed directly; we do not wrap them in
+    ``IRApply(Neg, ...)`` at the IR level — that's a surface-syntax
+    concern.
+    """
+
+    value: int
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+
+@dataclass(frozen=True, slots=True)
+class IRRational(IRNode):
+    """An exact fraction numerator/denominator, always in reduced form.
+
+    Two invariants hold after construction:
+
+    1. ``denom > 0`` — the sign lives in the numerator.
+    2. ``gcd(abs(numer), denom) == 1`` — the fraction is reduced.
+
+    We do NOT auto-collapse rationals with denominator 1 to ``IRInteger``
+    here, because that would change the constructor's return type in a
+    surprising way. Callers that want that collapse should use the
+    :func:`rational` factory below.
+    """
+
+    numer: int
+    denom: int
+
+    def __post_init__(self) -> None:
+        # Can't mutate frozen fields directly — use object.__setattr__.
+        if self.denom == 0:
+            raise ValueError("IRRational denominator cannot be zero")
+        numer, denom = self.numer, self.denom
+        if denom < 0:
+            numer, denom = -numer, -denom
+        g = gcd(abs(numer), denom)
+        if g > 1:
+            numer //= g
+            denom //= g
+        object.__setattr__(self, "numer", numer)
+        object.__setattr__(self, "denom", denom)
+
+    def __str__(self) -> str:
+        return f"{self.numer}/{self.denom}"
+
+
+@dataclass(frozen=True, slots=True)
+class IRFloat(IRNode):
+    """A double-precision floating-point literal.
+
+    Floats in a CAS are always suspicious: they destroy the exactness
+    that makes symbolic computation valuable. We include ``IRFloat`` for
+    completeness (MACSYMA has ``1.5`` literals) but the default
+    simplification path avoids introducing them from integer/rational
+    arithmetic.
+    """
+
+    value: float
+
+    def __str__(self) -> str:
+        return repr(self.value)
+
+
+@dataclass(frozen=True, slots=True)
+class IRString(IRNode):
+    """A string literal. Rare in CAS use but present in MACSYMA output
+    (e.g. ``print("x=", x)``) and in some rewrite rule conditions."""
+
+    value: str
+
+    def __str__(self) -> str:
+        return f'"{self.value}"'
+
+
+@dataclass(frozen=True, slots=True)
+class IRApply(IRNode):
+    """A compound expression: ``head`` applied to a tuple of ``args``.
+
+    The single compound form in the IR. Everything from ``x + y`` to
+    ``diff(f(x), x)`` to ``matrix([a, b], [c, d])`` is an ``IRApply``.
+    The uniform shape is what makes tree-walking code simple.
+
+    The args tuple is stored as-is; we do not sort or canonicalize for
+    commutative operators like ``Add`` at the IR level. That's the VM's
+    job — canonicalization depends on what the backend considers
+    "equivalent" and should not be hardcoded here.
+    """
+
+    head: IRNode
+    args: tuple[IRNode, ...]
+
+    def __str__(self) -> str:
+        return f"{self.head}({', '.join(str(a) for a in self.args)})"
+
+
+# ---------------------------------------------------------------------------
+# Standard head symbols — the vocabulary every backend understands.
+# ---------------------------------------------------------------------------
+#
+# These are plain ``IRSymbol`` singletons. Using them instead of
+# ``IRSymbol("Add")`` everywhere keeps equality checks cheap (identity
+# comparison works) and provides a single place to discover the standard
+# vocabulary.
+#
+# Frontends that need custom operations (a Mathematica-specific
+# ``HoldForm``, for example) simply introduce new ``IRSymbol`` values;
+# the VM treats them the same as the standard ones, falling back to
+# "leave unevaluated" in symbolic mode.
+
+# Arithmetic
+ADD = IRSymbol("Add")
+SUB = IRSymbol("Sub")
+MUL = IRSymbol("Mul")
+DIV = IRSymbol("Div")
+POW = IRSymbol("Pow")
+NEG = IRSymbol("Neg")
+INV = IRSymbol("Inv")
+
+# Elementary functions
+EXP = IRSymbol("Exp")
+LOG = IRSymbol("Log")
+SIN = IRSymbol("Sin")
+COS = IRSymbol("Cos")
+SQRT = IRSymbol("Sqrt")
+
+# Calculus
+D = IRSymbol("D")
+INTEGRATE = IRSymbol("Integrate")
+
+# Relations
+EQUAL = IRSymbol("Equal")
+NOT_EQUAL = IRSymbol("NotEqual")
+LESS = IRSymbol("Less")
+GREATER = IRSymbol("Greater")
+LESS_EQUAL = IRSymbol("LessEqual")
+GREATER_EQUAL = IRSymbol("GreaterEqual")
+
+# Logic
+AND = IRSymbol("And")
+OR = IRSymbol("Or")
+NOT = IRSymbol("Not")
+IF = IRSymbol("If")
+
+# Containers
+LIST = IRSymbol("List")
+
+# Binding
+ASSIGN = IRSymbol("Assign")  # x : expr  — evaluate rhs, bind
+DEFINE = IRSymbol("Define")  # f(x) := expr  — delayed, for functions
+RULE = IRSymbol("Rule")  # pattern -> replacement (rewrite rules)

--- a/code/packages/python/symbolic-ir/tests/test_nodes.py
+++ b/code/packages/python/symbolic-ir/tests/test_nodes.py
@@ -1,0 +1,207 @@
+"""Tests for the symbolic IR node types.
+
+The IR is the foundation everything else depends on, so we test it
+exhaustively: construction, normalization, equality, hashing, and the
+no-mutation guarantee of frozen dataclasses.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from symbolic_ir import (
+    ADD,
+    MUL,
+    POW,
+    IRApply,
+    IRFloat,
+    IRInteger,
+    IRNode,
+    IRRational,
+    IRString,
+    IRSymbol,
+)
+
+
+# ---------------------------------------------------------------------------
+# Construction and basic attributes
+# ---------------------------------------------------------------------------
+
+
+def test_symbol_stores_name() -> None:
+    assert IRSymbol("x").name == "x"
+    assert str(IRSymbol("x")) == "x"
+
+
+def test_integer_stores_value() -> None:
+    assert IRInteger(42).value == 42
+    assert IRInteger(-7).value == -7
+    assert IRInteger(0).value == 0
+
+
+def test_integer_arbitrary_precision() -> None:
+    # Python ints are already arbitrary precision — verify it works.
+    huge = 10**200
+    assert IRInteger(huge).value == huge
+
+
+def test_float_stores_value() -> None:
+    assert IRFloat(3.14).value == 3.14
+
+
+def test_string_stores_value() -> None:
+    assert IRString("hello").value == "hello"
+
+
+# ---------------------------------------------------------------------------
+# IRRational normalization
+# ---------------------------------------------------------------------------
+
+
+def test_rational_reduces_on_construction() -> None:
+    r = IRRational(2, 4)
+    assert r.numer == 1
+    assert r.denom == 2
+
+
+def test_rational_normalizes_negative_denom() -> None:
+    r = IRRational(1, -2)
+    assert r.numer == -1
+    assert r.denom == 2
+
+
+def test_rational_double_negative() -> None:
+    r = IRRational(-3, -6)
+    assert r.numer == 1
+    assert r.denom == 2
+
+
+def test_rational_already_reduced() -> None:
+    r = IRRational(3, 5)
+    assert r.numer == 3
+    assert r.denom == 5
+
+
+def test_rational_zero_numerator() -> None:
+    # 0/n should reduce to 0/1 (though we keep IRRational type).
+    r = IRRational(0, 5)
+    assert r.numer == 0
+    assert r.denom == 1
+
+
+def test_rational_division_by_zero_raises() -> None:
+    with pytest.raises(ValueError, match="denominator cannot be zero"):
+        IRRational(1, 0)
+
+
+# ---------------------------------------------------------------------------
+# Equality and hashing
+# ---------------------------------------------------------------------------
+
+
+def test_symbols_equal_by_name() -> None:
+    assert IRSymbol("x") == IRSymbol("x")
+    assert IRSymbol("x") != IRSymbol("y")
+
+
+def test_symbols_hashable() -> None:
+    # Must be usable as dict keys — essential for rule caching.
+    d = {IRSymbol("x"): 1, IRSymbol("y"): 2}
+    assert d[IRSymbol("x")] == 1
+
+
+def test_integers_equal_by_value() -> None:
+    assert IRInteger(5) == IRInteger(5)
+    assert IRInteger(5) != IRInteger(6)
+
+
+def test_different_types_not_equal() -> None:
+    # Critical: IRInteger(1) and IRRational(1, 1) are not equal, even
+    # though they represent the same mathematical value. The VM decides
+    # when to collapse representations.
+    assert IRInteger(1) != IRRational(1, 1)
+
+
+def test_apply_equal_structurally() -> None:
+    a = IRApply(ADD, (IRSymbol("x"), IRInteger(1)))
+    b = IRApply(ADD, (IRSymbol("x"), IRInteger(1)))
+    assert a == b
+    assert hash(a) == hash(b)
+
+
+def test_apply_order_matters() -> None:
+    # Add is commutative semantically, but the IR preserves order
+    # until the VM chooses to canonicalize.
+    a = IRApply(ADD, (IRSymbol("x"), IRInteger(1)))
+    b = IRApply(ADD, (IRInteger(1), IRSymbol("x")))
+    assert a != b
+
+
+# ---------------------------------------------------------------------------
+# Immutability
+# ---------------------------------------------------------------------------
+
+
+def test_nodes_are_frozen() -> None:
+    x = IRSymbol("x")
+    with pytest.raises((AttributeError, TypeError)):
+        x.name = "y"  # type: ignore[misc]
+
+
+def test_apply_args_are_tuple() -> None:
+    e = IRApply(ADD, (IRSymbol("x"), IRInteger(1)))
+    assert isinstance(e.args, tuple)
+
+
+# ---------------------------------------------------------------------------
+# IRNode isinstance relationship
+# ---------------------------------------------------------------------------
+
+
+def test_all_types_are_irnode() -> None:
+    assert isinstance(IRSymbol("x"), IRNode)
+    assert isinstance(IRInteger(1), IRNode)
+    assert isinstance(IRRational(1, 2), IRNode)
+    assert isinstance(IRFloat(1.0), IRNode)
+    assert isinstance(IRString("s"), IRNode)
+    assert isinstance(IRApply(ADD, ()), IRNode)
+
+
+# ---------------------------------------------------------------------------
+# Deeply nested trees
+# ---------------------------------------------------------------------------
+
+
+def test_nested_apply_roundtrip() -> None:
+    # (x + 1) * x^2  =  Mul(Add(x, 1), Pow(x, 2))
+    x = IRSymbol("x")
+    inner = IRApply(ADD, (x, IRInteger(1)))
+    squared = IRApply(POW, (x, IRInteger(2)))
+    full = IRApply(MUL, (inner, squared))
+    assert full.head == MUL
+    assert len(full.args) == 2
+    assert full.args[0] == inner
+    assert full.args[1] == squared
+
+
+def test_str_representation() -> None:
+    expr = IRApply(ADD, (IRSymbol("x"), IRInteger(1)))
+    # We don't pin the exact format but verify the essential parts appear.
+    s = str(expr)
+    assert "Add" in s
+    assert "x" in s
+    assert "1" in s
+
+
+# ---------------------------------------------------------------------------
+# Standard head symbols are singletons
+# ---------------------------------------------------------------------------
+
+
+def test_standard_heads_are_singletons() -> None:
+    from symbolic_ir import ADD, MUL
+
+    # Re-importing gives the same object (enables identity comparison).
+    assert ADD is ADD  # noqa: PLR0124
+    assert MUL is MUL  # noqa: PLR0124
+    assert ADD != MUL

--- a/code/packages/python/symbolic-vm/BUILD
+++ b/code/packages/python/symbolic-vm/BUILD
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../grammar-tools -e ../graph -e ../directed-graph -e ../state-machine -e ../lexer -e ../parser -e ../macsyma-lexer -e ../macsyma-parser -e ../symbolic-ir -e ../macsyma-compiler -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/symbolic-vm/CHANGELOG.md
+++ b/code/packages/python/symbolic-vm/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+## 0.1.0 — 2026-04-18
+
+Initial release.
+
+- Generic tree-walking `VM` over `symbolic_ir` nodes.
+- `Backend` ABC with `lookup`, `bind`, `on_unresolved`,
+  `on_unknown_head`, `rules`, `handlers`, `hold_heads`.
+- `StrictBackend`: Python-like semantics; raises on unbound names or
+  unknown heads; requires arithmetic operands to be numeric.
+- `SymbolicBackend`: Mathematica-like semantics; leaves unbound names
+  as free symbols; applies identity/zero laws; knows calculus.
+- Shared handler table for arithmetic (`Add`, `Sub`, `Mul`, `Div`,
+  `Pow`, `Neg`, `Inv`), elementary functions (`Sin`, `Cos`, `Exp`,
+  `Log`, `Sqrt`), comparisons, logic, assignment, and definition.
+- `D` handler on the symbolic backend implements sum, difference,
+  product, quotient, power, and chain rules.
+- User-defined functions via `Define(name, List(params), body)` —
+  the VM detects the bound record and performs parameter substitution.
+- `If` is a held head; only the chosen branch is evaluated.
+- End-to-end tests cover the full pipeline (MACSYMA source → tokens
+  → AST → IR → evaluated result).

--- a/code/packages/python/symbolic-vm/README.md
+++ b/code/packages/python/symbolic-vm/README.md
@@ -1,0 +1,101 @@
+# symbolic-vm
+
+A tiny, pluggable virtual machine for evaluating `symbolic_ir` trees.
+
+## What this package is
+
+The VM is a generic tree walker. Every evaluation policy decision — how
+to resolve names, what to do with unknown symbols, which rewrite rules
+to try, how each head is evaluated — is delegated to a `Backend`. Two
+reference backends ship in the box:
+
+| Backend           | Unbound name          | Unknown head          | Arithmetic on symbols |
+|-------------------|------------------------|-----------------------|-----------------------|
+| `StrictBackend`   | raises `NameError`    | raises `NameError`    | raises `TypeError`    |
+| `SymbolicBackend` | returns symbol as-is  | returns expr as-is    | applies identities, else leaves expression |
+
+`StrictBackend` is the "calculator" — bind your variables, get numbers
+back. `SymbolicBackend` is a miniature Mathematica — free variables
+survive, algebraic identities collapse, and a derivative handler
+implements the standard calculus rules.
+
+## How the VM decides
+
+```
+eval(node):
+    atom        → look up / on_unresolved / return literal
+    IRApply:
+      1. evaluate args unless head is held (Assign, Define, If)
+      2. try rewrite rules  → if one matches, eval(transform(expr))
+      3. dispatch to handlers()[head_name]
+      4. if head is bound to a Define record, substitute + eval
+      5. fall through to on_unknown_head
+```
+
+The handler table is shared between strict and symbolic backends; the
+only head that differs is `D` (differentiation), which lives only on
+the symbolic side.
+
+## Usage
+
+```python
+from macsyma_parser import parse_macsyma
+from macsyma_compiler import compile_macsyma
+from symbolic_vm import VM, SymbolicBackend
+
+src = "f(x) := x^2; diff(f(x), x);"
+statements = compile_macsyma(parse_macsyma(src))
+vm = VM(SymbolicBackend())
+print(vm.eval_program(statements))
+# Mul(2, x)
+```
+
+## What is included
+
+- Arithmetic: `Add`, `Sub`, `Mul`, `Div`, `Pow`, `Neg`, `Inv` — exact
+  when possible (Fraction internally), floats contaminate to floats.
+- Elementary: `Sin`, `Cos`, `Exp`, `Log`, `Sqrt` — fold numerics,
+  preserve a handful of exact identities (`Sin(0) = 0`, `Log(1) = 0`,
+  etc.), leave symbolic args alone.
+- Comparisons: `Equal`, `NotEqual`, `Less`, `Greater`, `LessEqual`,
+  `GreaterEqual` — return the `True` / `False` symbols for concrete
+  arguments.
+- Logic: `And`, `Or`, `Not` — short-circuit over literal booleans.
+- Calculus: `D` (symbolic backend only) — sum, difference, product,
+  quotient, general power, and chain rules for `Sin`/`Cos`/`Exp`/
+  `Log`/`Sqrt`.
+- Binding: `Assign` (eager), `Define` (delayed, for function bodies).
+- `If` — held; only the chosen branch runs.
+
+## What is not (yet) included
+
+- No polynomial normalization. `x + x` stays `Add(x, x)`; we don't
+  combine like terms. That's a separate simplification pass.
+- No pattern-variable rewrite rules (`x_` in Mathematica). The
+  `rules()` hook accepts predicate/transform pairs, so a real pattern
+  matcher can be layered on without changing the VM.
+- No symbolic integration. The Risch algorithm is out of scope.
+
+## Extending with a new backend
+
+A new language-specific backend is typically a subclass that adds or
+replaces handlers and rules:
+
+```python
+class MapleBackend(SymbolicBackend):
+    def handlers(self):
+        base = dict(super().handlers())
+        base["Range"] = _range_handler
+        return base
+```
+
+That's the "80% reuse" promise: everything above — the walker, the
+arithmetic fold, the identity rewrites, the derivative engine — comes
+for free.
+
+## Dependencies
+
+- `coding-adventures-symbolic-ir` — the IR node types.
+
+Runtime has zero capabilities (`required_capabilities.json`): the VM
+is a pure in-memory tree walker.

--- a/code/packages/python/symbolic-vm/pyproject.toml
+++ b/code/packages/python/symbolic-vm/pyproject.toml
@@ -13,6 +13,8 @@ readme = "README.md"
 keywords = ["symbolic", "vm", "interpreter", "cas", "term-rewriting", "education"]
 dependencies = [
     "coding-adventures-symbolic-ir",
+    "coding-adventures-macsyma-parser",
+    "coding-adventures-macsyma-compiler",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/code/packages/python/symbolic-vm/pyproject.toml
+++ b/code/packages/python/symbolic-vm/pyproject.toml
@@ -1,0 +1,50 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-symbolic-vm"
+version = "0.1.0"
+description = "Pluggable symbolic VM — evaluates symbolic-ir trees through swappable backends (strict numeric vs. Mathematica-style symbolic rewriting)."
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["symbolic", "vm", "interpreter", "cas", "term-rewriting", "education"]
+dependencies = [
+    "coding-adventures-symbolic-ir",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Education",
+    "Topic :: Education",
+    "Topic :: Scientific/Engineering :: Mathematics",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://github.com/adhithyan15/coding-adventures"
+Repository = "https://github.com/adhithyan15/coding-adventures"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/symbolic_vm"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=symbolic_vm --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/packages/python/symbolic-vm/required_capabilities.json
+++ b/code/packages/python/symbolic-vm/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "python/symbolic-vm",
+  "capabilities": [],
+  "justification": "Pure in-memory tree walker over symbolic-ir. No filesystem, network, or process access — only the standard library's math module for numeric handlers."
+}

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/__init__.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/__init__.py
@@ -1,0 +1,44 @@
+"""Symbolic VM — pluggable evaluator for the universal symbolic IR.
+
+This package provides a generic tree-walking virtual machine for
+:mod:`symbolic_ir` trees, together with two reference evaluation
+policies:
+
+- :class:`StrictBackend` — errors on unbound names, numeric only,
+  Python-like semantics.
+- :class:`SymbolicBackend` — leaves unbound names as free variables,
+  applies algebraic identities, and knows enough calculus to compute
+  derivatives through the standard rules.
+
+Both backends share the same handler table for arithmetic, comparisons,
+logic, binding, and elementary functions; the only difference is what
+happens when an expression can't fold to a value.
+
+Quick start::
+
+    from macsyma_parser import parse_macsyma
+    from macsyma_compiler import compile_macsyma
+    from symbolic_vm import SymbolicBackend, VM
+
+    program = "f(x) := x^2; diff(f(x), x);"
+    statements = compile_macsyma(parse_macsyma(program))
+
+    vm = VM(SymbolicBackend())
+    result = vm.eval_program(statements)
+    print(result)  # 2*x  (more or less)
+"""
+
+from symbolic_vm.backend import Backend, Handler, Rule, RulePredicate, RuleTransform
+from symbolic_vm.backends import StrictBackend, SymbolicBackend
+from symbolic_vm.vm import VM
+
+__all__ = [
+    "VM",
+    "Backend",
+    "StrictBackend",
+    "SymbolicBackend",
+    "Handler",
+    "Rule",
+    "RulePredicate",
+    "RuleTransform",
+]

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/backend.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/backend.py
@@ -1,0 +1,105 @@
+"""The :class:`Backend` abstract base class.
+
+A :class:`~symbolic_vm.vm.VM` delegates every evaluation policy decision
+to a Backend. This is the seam where language-specific behavior lives.
+
+The VM asks the backend four kinds of questions:
+
+1. *How do I look up a name?* — :meth:`Backend.lookup` / :meth:`Backend.bind`.
+2. *What if a name is unbound?* — :meth:`Backend.on_unresolved`.
+3. *Are there any rewrite rules to try first?* — :meth:`Backend.rules`.
+4. *How should I evaluate an* ``IRApply`` *with a given head?* —
+   :meth:`Backend.handlers`.
+
+Backends can also mark certain head names as "held", meaning the VM
+will *not* evaluate the arguments of those applies before handing them
+to the handler. ``Define`` is the archetypal held head: when compiling
+``f(x) := x^2``, you want the body ``x^2`` stored as-is, not evaluated
+right now.
+
+The two reference backends in this package —
+:class:`~symbolic_vm.backends.StrictBackend` and
+:class:`~symbolic_vm.backends.SymbolicBackend` — share almost all of
+their handler table; only the unresolved-name policy and the set of
+rewrite rules differ meaningfully between them.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Callable, Iterable, Mapping
+from typing import TYPE_CHECKING
+
+from symbolic_ir import IRApply, IRNode, IRSymbol
+
+if TYPE_CHECKING:
+    from symbolic_vm.vm import VM
+
+
+# A rewrite rule is a predicate + transform pair. The predicate looks
+# at the already-argument-evaluated ``IRApply``; if it returns True,
+# the transform produces the rewritten ``IRNode``, which the VM then
+# recursively evaluates. Rules are tried in order before head handlers.
+RulePredicate = Callable[[IRApply], bool]
+RuleTransform = Callable[[IRApply], IRNode]
+Rule = tuple[RulePredicate, RuleTransform]
+
+# A handler is the per-head evaluator. It receives the VM itself — so
+# it can call ``vm.eval(...)`` on subexpressions when it produces new
+# IR — and the current ``IRApply`` (whose args have already been
+# evaluated, unless the head was held).
+Handler = Callable[["VM", IRApply], IRNode]
+
+
+class Backend(ABC):
+    """Policy object that the VM consults for every evaluation decision."""
+
+    # ------------------------------------------------------------------
+    # Name binding
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def lookup(self, name: str) -> IRNode | None:
+        """Return the current binding for ``name`` or ``None`` if unset."""
+
+    @abstractmethod
+    def bind(self, name: str, value: IRNode) -> None:
+        """Install or update a binding for ``name``."""
+
+    # ------------------------------------------------------------------
+    # Evaluation policy
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def on_unresolved(self, symbol: IRSymbol) -> IRNode:
+        """Decide what to return when a symbol has no binding.
+
+        Strict backends raise; symbolic backends return the symbol
+        unchanged (so undefined names act as free variables).
+        """
+
+    def on_unknown_head(self, expr: IRApply) -> IRNode:
+        """Decide what to return when no handler exists for the head.
+
+        The default is to leave the expression unchanged. Strict
+        backends override this to raise.
+        """
+        return expr
+
+    def rules(self) -> Iterable[Rule]:
+        """Yield rewrite rules to try before dispatching to a handler."""
+        return ()
+
+    def handlers(self) -> Mapping[str, Handler]:
+        """Return the head-name → handler table."""
+        return {}
+
+    def hold_heads(self) -> frozenset[str]:
+        """Head names whose arguments the VM should NOT evaluate first.
+
+        ``Define`` stores a function body without evaluating it;
+        ``If`` chooses one of its branches; ``Assign`` consumes the
+        lhs symbolically. Handlers for these heads take responsibility
+        for evaluating the parts they actually want evaluated.
+        """
+        return frozenset()

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/backends.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/backends.py
@@ -1,0 +1,111 @@
+"""Two reference backends: :class:`StrictBackend` and :class:`SymbolicBackend`.
+
+They share ~90% of their behavior — the handler table, the held heads,
+the environment storage. The two meaningful differences are:
+
++------------------+---------------------+----------------------------+
+|                  | StrictBackend       | SymbolicBackend            |
++==================+=====================+============================+
+| Unbound symbol   | raises ``NameError``| returns the symbol as-is   |
++------------------+---------------------+----------------------------+
+| Unknown head     | raises ``NameError``| returns the expr as-is     |
++------------------+---------------------+----------------------------+
+| Arith on symbols | raises ``TypeError``| folds identities, else     |
+|                  |                     | leaves the expression      |
++------------------+---------------------+----------------------------+
+| ``D`` handler    | not installed       | installed                  |
++------------------+---------------------+----------------------------+
+
+Adding a new language-specific backend is typically a thin subclass:
+override ``handlers()`` to add/replace a few entries, ``rules()`` if
+you have custom rewrites, and leave everything else alone.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from symbolic_ir import ASSIGN, DEFINE, IF, IRApply, IRNode, IRSymbol
+
+from symbolic_vm.backend import Backend, Handler
+from symbolic_vm.derivative import differentiate
+from symbolic_vm.handlers import FALSE, TRUE, build_handler_table
+
+# Heads whose arguments must NOT be evaluated before dispatch. Shared
+# by both backends — neither strict nor symbolic evaluation wants to
+# pre-evaluate a function body being defined, or pre-evaluate the lhs
+# of an assignment, or pre-evaluate both branches of an if.
+_HELD_HEADS = frozenset({ASSIGN.name, DEFINE.name, IF.name})
+
+
+class _BaseBackend(Backend):
+    """Shared environment + held heads for the two reference backends."""
+
+    def __init__(self) -> None:
+        self._env: dict[str, IRNode] = {
+            # ``True`` and ``False`` are pre-bound to themselves so that
+            # unresolved-symbol policy doesn't kick in for MACSYMA's
+            # ``true``/``false`` keywords. They act as inert symbols.
+            "True": TRUE,
+            "False": FALSE,
+        }
+
+    def lookup(self, name: str) -> IRNode | None:
+        return self._env.get(name)
+
+    def bind(self, name: str, value: IRNode) -> None:
+        self._env[name] = value
+
+    def hold_heads(self) -> frozenset[str]:
+        return _HELD_HEADS
+
+
+class StrictBackend(_BaseBackend):
+    """Python-style numeric evaluator.
+
+    Every name must be bound; every head must have a handler; every
+    arithmetic operation must be fully numeric. Unknown cases raise.
+    Useful for "calculator mode" — load a MACSYMA program with only
+    numeric inputs and get numeric answers out.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._handlers = build_handler_table(simplify=False)
+
+    def on_unresolved(self, symbol: IRSymbol) -> IRNode:
+        raise NameError(f"undefined symbol: {symbol.name!r}")
+
+    def on_unknown_head(self, expr: IRApply) -> IRNode:
+        name = expr.head.name if isinstance(expr.head, IRSymbol) else "?"
+        raise NameError(f"no handler for head: {name!r}")
+
+    def handlers(self) -> Mapping[str, Handler]:
+        return self._handlers
+
+
+class SymbolicBackend(_BaseBackend):
+    """Mathematica-style evaluator.
+
+    Unbound names stay as free symbols; algebraic identities collapse
+    the trivial cases; a derivative handler implements standard calculus
+    rules; everything else stays in IR. The result is a tiny CAS —
+    ``x + x`` won't combine (no polynomial normalization), but
+    ``Add(x, 0)`` does, ``Pow(x, 0)`` is ``1``, ``D(x^2, x)`` is ``2*x``,
+    and unknown functions pass through untouched.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        handlers = dict(build_handler_table(simplify=True))
+        handlers["D"] = differentiate()
+        self._handlers = handlers
+
+    def on_unresolved(self, symbol: IRSymbol) -> IRNode:
+        return symbol
+
+    def on_unknown_head(self, expr: IRApply) -> IRNode:
+        return expr
+
+    def handlers(self) -> Mapping[str, Handler]:
+        return self._handlers

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/derivative.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/derivative.py
@@ -1,0 +1,220 @@
+"""Symbolic differentiation — the ``D`` handler.
+
+Differentiation is just a tree walk driven by the calculus rules every
+student learns: the sum rule, product rule, quotient rule, chain rule,
+and power rule. None of it is numerical — we build new IR and let the
+VM simplify the result through the normal arithmetic handlers. That's
+how ``D(x^2, x)`` turns into ``2*x`` even though this file never
+computes the constant ``2`` itself.
+
+Because we emit binary applies that then re-enter ``vm.eval``, the
+algebraic identities in :mod:`symbolic_vm.handlers` (``0 + x → x``,
+``1 * x → x``, ``x^0 → 1``) clean up the intermediate clutter that a
+naive product/chain rule would otherwise leave behind.
+
+Only installed on :class:`~symbolic_vm.backends.SymbolicBackend`. In
+strict mode ``D`` falls through to :meth:`Backend.on_unknown_head`,
+which raises.
+"""
+
+from __future__ import annotations
+
+from symbolic_ir import (
+    ADD,
+    COS,
+    DIV,
+    EXP,
+    LOG,
+    MUL,
+    NEG,
+    POW,
+    SIN,
+    SQRT,
+    SUB,
+    D,
+    IRApply,
+    IRFloat,
+    IRInteger,
+    IRNode,
+    IRRational,
+    IRSymbol,
+)
+
+from symbolic_vm.backend import Handler
+
+ZERO = IRInteger(0)
+ONE = IRInteger(1)
+
+
+def differentiate() -> Handler:
+    """Return the ``D`` handler for the symbolic backend."""
+
+    def handler(vm, expr: IRApply) -> IRNode:
+        if len(expr.args) != 2:
+            raise TypeError(f"D expects 2 arguments, got {len(expr.args)}")
+        f, x = expr.args
+        if not isinstance(x, IRSymbol):
+            # Differentiation with respect to something other than a
+            # plain symbol is not supported. Leave the expression.
+            return expr
+        return vm.eval(_diff(f, x))
+
+    return handler
+
+
+def _diff(f: IRNode, x: IRSymbol) -> IRNode:
+    """Return ``d f / d x`` as unevaluated IR.
+
+    The caller is expected to feed the result back through ``vm.eval``
+    so arithmetic identities apply.
+    """
+    # df/dx = 0 when f doesn't depend on x. This catches all constants
+    # (integers, floats, rationals, strings) and any free variables
+    # other than x.
+    if not _depends_on(f, x):
+        return ZERO
+
+    # df/dx = 1 when f IS x.
+    if f == x:
+        return ONE
+
+    # Everything else must be an IRApply (only atoms could equal x or
+    # be independent, and we've handled both).
+    if not isinstance(f, IRApply):
+        return IRApply(D, (f, x))
+
+    head = f.head
+
+    # -- Sum and difference --------------------------------------------
+    if head == ADD:
+        return IRApply(ADD, tuple(_diff(a, x) for a in f.args))
+    if head == SUB:
+        a, b = f.args
+        return IRApply(SUB, (_diff(a, x), _diff(b, x)))
+
+    # -- Negation and inverse ------------------------------------------
+    if head == NEG:
+        (a,) = f.args
+        return IRApply(NEG, (_diff(a, x),))
+
+    # -- Product rule --------------------------------------------------
+    if head == MUL:
+        a, b = f.args
+        # d(ab)/dx = a' b + a b'
+        return IRApply(
+            ADD,
+            (
+                IRApply(MUL, (_diff(a, x), b)),
+                IRApply(MUL, (a, _diff(b, x))),
+            ),
+        )
+
+    # -- Quotient rule -------------------------------------------------
+    if head == DIV:
+        a, b = f.args
+        # d(a/b)/dx = (a' b - a b') / b^2
+        return IRApply(
+            DIV,
+            (
+                IRApply(
+                    SUB,
+                    (
+                        IRApply(MUL, (_diff(a, x), b)),
+                        IRApply(MUL, (a, _diff(b, x))),
+                    ),
+                ),
+                IRApply(POW, (b, IRInteger(2))),
+            ),
+        )
+
+    # -- Power rule (handles general case via chain rule) --------------
+    if head == POW:
+        base, exponent = f.args
+        base_depends = _depends_on(base, x)
+        exp_depends = _depends_on(exponent, x)
+        if not exp_depends:
+            # d(f^n)/dx = n * f^(n-1) * f'
+            return IRApply(
+                MUL,
+                (
+                    IRApply(
+                        MUL,
+                        (
+                            exponent,
+                            IRApply(
+                                POW,
+                                (
+                                    base,
+                                    IRApply(SUB, (exponent, ONE)),
+                                ),
+                            ),
+                        ),
+                    ),
+                    _diff(base, x),
+                ),
+            )
+        if not base_depends:
+            # d(c^g)/dx = c^g * ln(c) * g'
+            return IRApply(
+                MUL,
+                (
+                    IRApply(
+                        MUL,
+                        (
+                            f,  # c^g
+                            IRApply(LOG, (base,)),
+                        ),
+                    ),
+                    _diff(exponent, x),
+                ),
+            )
+        # General f(x)^g(x) — use f^g = exp(g*ln(f)) and chain rule.
+        return _diff(
+            IRApply(EXP, (IRApply(MUL, (exponent, IRApply(LOG, (base,)))),)),
+            x,
+        )
+
+    # -- Elementary functions (chain rule) -----------------------------
+    if head == SIN:
+        (inner,) = f.args
+        return IRApply(MUL, (IRApply(COS, (inner,)), _diff(inner, x)))
+    if head == COS:
+        (inner,) = f.args
+        return IRApply(
+            MUL,
+            (IRApply(NEG, (IRApply(SIN, (inner,)),)), _diff(inner, x)),
+        )
+    if head == EXP:
+        (inner,) = f.args
+        return IRApply(MUL, (IRApply(EXP, (inner,)), _diff(inner, x)))
+    if head == LOG:
+        (inner,) = f.args
+        # d/dx ln(u) = u'/u
+        return IRApply(DIV, (_diff(inner, x), inner))
+    if head == SQRT:
+        (inner,) = f.args
+        # d/dx sqrt(u) = u' / (2 sqrt(u))
+        return IRApply(
+            DIV,
+            (
+                _diff(inner, x),
+                IRApply(MUL, (IRInteger(2), IRApply(SQRT, (inner,)))),
+            ),
+        )
+
+    # Unknown function — leave as ``D(f, x)`` unevaluated.
+    return IRApply(D, (f, x))
+
+
+def _depends_on(node: IRNode, var: IRSymbol) -> bool:
+    """True if ``var`` appears anywhere inside ``node``."""
+    if isinstance(node, IRSymbol):
+        return node == var
+    if isinstance(node, IRApply):
+        return _depends_on(node.head, var) or any(
+            _depends_on(a, var) for a in node.args
+        )
+    # Literals never depend on a variable.
+    if isinstance(node, (IRInteger, IRFloat, IRRational)):
+        return False
+    return False

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/handlers.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/handlers.py
@@ -1,0 +1,539 @@
+"""Shared head handlers.
+
+These functions power both :class:`~symbolic_vm.backends.StrictBackend`
+and :class:`~symbolic_vm.backends.SymbolicBackend`. The only difference
+is what happens when an operation can't fold numerically:
+
+- Strict handlers raise :class:`TypeError` — strict mode refuses to
+  leave an expression half-evaluated.
+- Symbolic handlers return the expression as-is — that's the whole
+  point of Mathematica-style evaluation.
+
+To avoid two near-identical handler tables, each handler accepts a
+``simplify`` flag. When ``True`` the handler applies identity/zero
+laws and returns a reduced form; when ``False`` it folds purely
+numeric cases and raises on anything symbolic.
+
+Handler signatures all match :class:`~symbolic_vm.backend.Handler`:
+``(vm, expr) -> IRNode``.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+
+from symbolic_ir import (
+    ADD,
+    AND,
+    ASSIGN,
+    COS,
+    DEFINE,
+    DIV,
+    EQUAL,
+    EXP,
+    GREATER,
+    GREATER_EQUAL,
+    IF,
+    INV,
+    LESS,
+    LESS_EQUAL,
+    LOG,
+    MUL,
+    NEG,
+    NOT,
+    NOT_EQUAL,
+    OR,
+    POW,
+    SIN,
+    SQRT,
+    SUB,
+    IRApply,
+    IRInteger,
+    IRNode,
+    IRSymbol,
+)
+
+from symbolic_vm.backend import Handler
+from symbolic_vm.numeric import Numeric, from_number, is_one, is_zero, to_number
+
+# ---------------------------------------------------------------------------
+# Booleans — stored as the symbols ``True`` / ``False`` to align with the
+# MACSYMA compiler's output for the ``true`` / ``false`` keywords.
+# ---------------------------------------------------------------------------
+
+TRUE = IRSymbol("True")
+FALSE = IRSymbol("False")
+ONE = IRInteger(1)
+ZERO = IRInteger(0)
+
+
+def _bool(value: bool) -> IRNode:
+    return TRUE if value else FALSE
+
+
+def _is_truthy(node: IRNode) -> bool | None:
+    """Return the Python truthiness of ``node`` if it's a boolean literal."""
+    if node == TRUE:
+        return True
+    if node == FALSE:
+        return False
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Arithmetic — binary Add/Sub/Mul/Div/Pow and unary Neg/Inv.
+# ---------------------------------------------------------------------------
+
+
+def add(simplify: bool) -> Handler:
+    """Build an Add handler. See module docstring for the ``simplify`` flag."""
+
+    def handler(_vm, expr: IRApply) -> IRNode:
+        a, b = _binary_args(expr)
+        va, vb = to_number(a), to_number(b)
+        if va is not None and vb is not None:
+            return from_number(va + vb)
+        if not simplify:
+            raise TypeError(f"Add requires numeric arguments: {expr}")
+        # Identity: x + 0 → x, 0 + x → x.
+        if is_zero(va):
+            return b
+        if is_zero(vb):
+            return a
+        return expr
+
+    return handler
+
+
+def sub(simplify: bool) -> Handler:
+    def handler(_vm, expr: IRApply) -> IRNode:
+        a, b = _binary_args(expr)
+        va, vb = to_number(a), to_number(b)
+        if va is not None and vb is not None:
+            return from_number(va - vb)
+        if not simplify:
+            raise TypeError(f"Sub requires numeric arguments: {expr}")
+        # x - 0 → x. (0 - x does NOT simplify to -x here; that's a
+        # separate algebraic rewrite and keeping it explicit is fine.)
+        if is_zero(vb):
+            return a
+        return expr
+
+    return handler
+
+
+def mul(simplify: bool) -> Handler:
+    def handler(_vm, expr: IRApply) -> IRNode:
+        a, b = _binary_args(expr)
+        va, vb = to_number(a), to_number(b)
+        if va is not None and vb is not None:
+            return from_number(va * vb)
+        if not simplify:
+            raise TypeError(f"Mul requires numeric arguments: {expr}")
+        # Absorbing zero wins over everything, even an unknown symbol.
+        if is_zero(va) or is_zero(vb):
+            return ZERO
+        if is_one(va):
+            return b
+        if is_one(vb):
+            return a
+        return expr
+
+    return handler
+
+
+def div(simplify: bool) -> Handler:
+    def handler(_vm, expr: IRApply) -> IRNode:
+        a, b = _binary_args(expr)
+        va, vb = to_number(a), to_number(b)
+        if va is not None and vb is not None:
+            if vb == 0:
+                raise ZeroDivisionError(f"division by zero: {expr}")
+            return from_number(va / vb)
+        if not simplify:
+            raise TypeError(f"Div requires numeric arguments: {expr}")
+        if is_zero(va):
+            return ZERO
+        if is_one(vb):
+            return a
+        return expr
+
+    return handler
+
+
+def pow_(simplify: bool) -> Handler:
+    def handler(_vm, expr: IRApply) -> IRNode:
+        base, exponent = _binary_args(expr)
+        vb, ve = to_number(base), to_number(exponent)
+        if vb is not None and ve is not None:
+            return from_number(_pow_numeric(vb, ve))
+        if not simplify:
+            raise TypeError(f"Pow requires numeric arguments: {expr}")
+        # Standard algebraic identities.
+        if is_zero(ve):
+            return ONE            # x^0 → 1
+        if is_one(ve):
+            return base           # x^1 → x
+        if is_zero(vb):
+            return ZERO           # 0^n → 0 (for n != 0, covered above)
+        if is_one(vb):
+            return ONE            # 1^n → 1
+        return expr
+
+    return handler
+
+
+def neg(simplify: bool) -> Handler:
+    def handler(_vm, expr: IRApply) -> IRNode:
+        (a,) = expr.args
+        va = to_number(a)
+        if va is not None:
+            return from_number(-va)
+        if not simplify:
+            raise TypeError(f"Neg requires a numeric argument: {expr}")
+        # -(-x) → x.
+        if isinstance(a, IRApply) and a.head == NEG and len(a.args) == 1:
+            return a.args[0]
+        return expr
+
+    return handler
+
+
+def inv(simplify: bool) -> Handler:
+    def handler(_vm, expr: IRApply) -> IRNode:
+        (a,) = expr.args
+        va = to_number(a)
+        if va is not None:
+            if va == 0:
+                raise ZeroDivisionError(f"inverse of zero: {expr}")
+            return from_number(1 / va)
+        if not simplify:
+            raise TypeError(f"Inv requires a numeric argument: {expr}")
+        return expr
+
+    return handler
+
+
+def _pow_numeric(base: Numeric, exponent: Numeric) -> Numeric:
+    """Raise ``base`` to ``exponent``, keeping exactness where possible."""
+    # Fraction ** integer stays exact. Fraction ** non-integer goes to
+    # float via math.pow. Any float involvement poisons the result to float.
+    from fractions import Fraction
+
+    if isinstance(base, Fraction) and isinstance(exponent, Fraction):
+        if exponent.denominator == 1:
+            # ``Fraction ** int`` is supported directly and stays exact.
+            return base ** exponent.numerator
+        return math.pow(float(base), float(exponent))
+    return math.pow(float(base), float(exponent))
+
+
+def _binary_args(expr: IRApply) -> tuple[IRNode, IRNode]:
+    if len(expr.args) != 2:
+        raise TypeError(
+            f"{_head_name(expr)} expects 2 arguments, got {len(expr.args)}"
+        )
+    a, b = expr.args
+    return a, b
+
+
+# ---------------------------------------------------------------------------
+# Elementary functions — ``Sin``, ``Cos``, ``Exp``, ``Log``, ``Sqrt``.
+#
+# These only fold when the argument is numeric. In symbolic mode they
+# leave symbolic arguments alone (``Sin(x)`` stays ``Sin(x)``). A few
+# exact identities — ``Sin(0) = 0``, ``Cos(0) = 1``, ``Exp(0) = 1``,
+# ``Log(1) = 0`` — are applied first so the obvious cases don't
+# silently become floats.
+# ---------------------------------------------------------------------------
+
+
+def _elementary(
+    name: str,
+    numeric_fn,
+    exact_identities: Mapping[Numeric, IRNode],
+    simplify: bool,
+) -> Handler:
+    def handler(_vm, expr: IRApply) -> IRNode:
+        (a,) = expr.args
+        va = to_number(a)
+        if va is not None:
+            if va in exact_identities:
+                return exact_identities[va]
+            return from_number(numeric_fn(float(va)))
+        if not simplify:
+            raise TypeError(f"{name} requires a numeric argument: {expr}")
+        return expr
+
+    return handler
+
+
+def sin(simplify: bool) -> Handler:
+    return _elementary("Sin", math.sin, {0: ZERO}, simplify)
+
+
+def cos(simplify: bool) -> Handler:
+    return _elementary("Cos", math.cos, {0: ONE}, simplify)
+
+
+def exp(simplify: bool) -> Handler:
+    return _elementary("Exp", math.exp, {0: ONE}, simplify)
+
+
+def log(simplify: bool) -> Handler:
+    return _elementary("Log", math.log, {1: ZERO}, simplify)
+
+
+def sqrt(simplify: bool) -> Handler:
+    return _elementary("Sqrt", math.sqrt, {0: ZERO, 1: ONE}, simplify)
+
+
+# ---------------------------------------------------------------------------
+# Comparisons
+# ---------------------------------------------------------------------------
+
+
+def _comparison(op, simplify: bool) -> Handler:
+    def handler(_vm, expr: IRApply) -> IRNode:
+        a, b = _binary_args(expr)
+        va, vb = to_number(a), to_number(b)
+        if va is not None and vb is not None:
+            return _bool(op(va, vb))
+        # Structural equality catches ``x = x``.
+        if op is _eq and a == b:
+            return TRUE
+        if op is _neq and a == b:
+            return FALSE
+        if not simplify:
+            raise TypeError(f"comparison requires numeric arguments: {expr}")
+        return expr
+
+    return handler
+
+
+def _eq(a: Numeric, b: Numeric) -> bool:
+    return a == b
+
+
+def _neq(a: Numeric, b: Numeric) -> bool:
+    return a != b
+
+
+def _lt(a: Numeric, b: Numeric) -> bool:
+    return a < b
+
+
+def _gt(a: Numeric, b: Numeric) -> bool:
+    return a > b
+
+
+def _leq(a: Numeric, b: Numeric) -> bool:
+    return a <= b
+
+
+def _geq(a: Numeric, b: Numeric) -> bool:
+    return a >= b
+
+
+def equal(simplify: bool) -> Handler:
+    return _comparison(_eq, simplify)
+
+
+def not_equal(simplify: bool) -> Handler:
+    return _comparison(_neq, simplify)
+
+
+def less(simplify: bool) -> Handler:
+    return _comparison(_lt, simplify)
+
+
+def greater(simplify: bool) -> Handler:
+    return _comparison(_gt, simplify)
+
+
+def less_equal(simplify: bool) -> Handler:
+    return _comparison(_leq, simplify)
+
+
+def greater_equal(simplify: bool) -> Handler:
+    return _comparison(_geq, simplify)
+
+
+# ---------------------------------------------------------------------------
+# Logic — variadic And/Or and unary Not.
+# ---------------------------------------------------------------------------
+
+
+def and_(_simplify: bool) -> Handler:
+    def handler(_vm, expr: IRApply) -> IRNode:
+        remaining: list[IRNode] = []
+        for a in expr.args:
+            t = _is_truthy(a)
+            if t is False:
+                return FALSE            # short-circuit
+            if t is None:
+                remaining.append(a)
+            # True drops out — it's the identity for ``and``.
+        if not remaining:
+            return TRUE
+        if len(remaining) == 1:
+            return remaining[0]
+        return IRApply(AND, tuple(remaining))
+
+    return handler
+
+
+def or_(_simplify: bool) -> Handler:
+    def handler(_vm, expr: IRApply) -> IRNode:
+        remaining: list[IRNode] = []
+        for a in expr.args:
+            t = _is_truthy(a)
+            if t is True:
+                return TRUE
+            if t is None:
+                remaining.append(a)
+        if not remaining:
+            return FALSE
+        if len(remaining) == 1:
+            return remaining[0]
+        return IRApply(OR, tuple(remaining))
+
+    return handler
+
+
+def not_(_simplify: bool) -> Handler:
+    def handler(_vm, expr: IRApply) -> IRNode:
+        (a,) = expr.args
+        t = _is_truthy(a)
+        if t is True:
+            return FALSE
+        if t is False:
+            return TRUE
+        return expr
+
+    return handler
+
+
+# ---------------------------------------------------------------------------
+# ``If`` — a held head. Evaluate the predicate first; based on the result,
+# evaluate one branch. The other branch is thrown away unevaluated.
+# ---------------------------------------------------------------------------
+
+
+def if_(_simplify: bool) -> Handler:
+    def handler(vm, expr: IRApply) -> IRNode:
+        if len(expr.args) not in (2, 3):
+            raise TypeError(
+                f"If expects 2 or 3 arguments, got {len(expr.args)}"
+            )
+        predicate = vm.eval(expr.args[0])
+        t = _is_truthy(predicate)
+        if t is True:
+            return vm.eval(expr.args[1])
+        if t is False:
+            if len(expr.args) == 3:
+                return vm.eval(expr.args[2])
+            return FALSE
+        # Predicate didn't reduce to a boolean. Leave as-is.
+        return IRApply(expr.head, (predicate, *expr.args[1:]))
+
+    return handler
+
+
+# ---------------------------------------------------------------------------
+# Binding — ``Assign`` and ``Define``.
+#
+# ``Assign(x, rhs)``: eagerly evaluate ``rhs``, bind ``x``, return the value.
+# ``Define(name, List(params), body)``: store the whole IRApply under ``name``;
+# the VM recognizes that shape when looking up a function call's head.
+# ---------------------------------------------------------------------------
+
+
+def assign(_simplify: bool) -> Handler:
+    def handler(vm, expr: IRApply) -> IRNode:
+        lhs, rhs = _binary_args(expr)
+        if not isinstance(lhs, IRSymbol):
+            raise TypeError(f"Assign lhs must be a symbol, got {lhs!r}")
+        value = vm.eval(rhs)
+        vm.backend.bind(lhs.name, value)
+        return value
+
+    return handler
+
+
+def define(_simplify: bool) -> Handler:
+    def handler(vm, expr: IRApply) -> IRNode:
+        name, _params, _body = expr.args
+        if not isinstance(name, IRSymbol):
+            raise TypeError(f"Define name must be a symbol, got {name!r}")
+        # Store the entire ``Define(...)`` record under the name, so
+        # the VM's function-call path can find and apply it later.
+        vm.backend.bind(name.name, expr)
+        return name
+
+    return handler
+
+
+# ---------------------------------------------------------------------------
+# ``List`` — a passthrough handler so lists appear as themselves.
+# ---------------------------------------------------------------------------
+
+
+def list_(_simplify: bool) -> Handler:
+    def handler(_vm, expr: IRApply) -> IRNode:
+        return expr
+
+    return handler
+
+
+# ---------------------------------------------------------------------------
+# Shared builder — construct the handler table for a backend.
+# ---------------------------------------------------------------------------
+
+
+def build_handler_table(simplify: bool) -> dict[str, Handler]:
+    """Produce the full handler table for a backend.
+
+    ``simplify=False`` yields a numeric-only evaluator (StrictBackend).
+    ``simplify=True`` yields a symbolic evaluator that applies algebraic
+    identities and leaves irreducible subexpressions alone.
+
+    Note the deliberate absence of ``D`` here — derivatives live in
+    :mod:`symbolic_vm.derivative` and are added by the SymbolicBackend.
+    Strict mode doesn't know how to differentiate a symbol (there's
+    nothing to differentiate *with respect to* when no free variables
+    exist), so StrictBackend simply doesn't install a D handler, and
+    the VM's ``on_unknown_head`` fallback raises.
+    """
+    return {
+        ADD.name: add(simplify),
+        SUB.name: sub(simplify),
+        MUL.name: mul(simplify),
+        DIV.name: div(simplify),
+        POW.name: pow_(simplify),
+        NEG.name: neg(simplify),
+        INV.name: inv(simplify),
+        SIN.name: sin(simplify),
+        COS.name: cos(simplify),
+        EXP.name: exp(simplify),
+        LOG.name: log(simplify),
+        SQRT.name: sqrt(simplify),
+        EQUAL.name: equal(simplify),
+        NOT_EQUAL.name: not_equal(simplify),
+        LESS.name: less(simplify),
+        GREATER.name: greater(simplify),
+        LESS_EQUAL.name: less_equal(simplify),
+        GREATER_EQUAL.name: greater_equal(simplify),
+        AND.name: and_(simplify),
+        OR.name: or_(simplify),
+        NOT.name: not_(simplify),
+        IF.name: if_(simplify),
+        ASSIGN.name: assign(simplify),
+        DEFINE.name: define(simplify),
+        "List": list_(simplify),
+    }
+
+
+def _head_name(expr: IRApply) -> str:
+    return expr.head.name if isinstance(expr.head, IRSymbol) else "?"

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/numeric.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/numeric.py
@@ -1,0 +1,67 @@
+"""Numeric helpers used by arithmetic handlers.
+
+We pass arithmetic through Python's :class:`fractions.Fraction` whenever
+both operands are exact (``IRInteger`` or ``IRRational``). As soon as
+one operand is an :class:`~symbolic_ir.IRFloat`, the whole expression
+collapses to a ``float`` — the same contamination rule SymPy and
+Mathematica use to mark a result as inexact.
+
+The two functions here — :func:`to_number` and :func:`from_number` —
+are the only place the VM converts between IR literals and Python
+numbers, so the "exact vs. inexact" choice lives in one spot.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+from symbolic_ir import IRFloat, IRInteger, IRNode, IRRational
+
+# A "numeric" is anything ``to_number`` might return. It's purposefully
+# narrow so callers know exactly what ``va + vb`` can mean.
+Numeric = Fraction | float
+
+
+def to_number(node: IRNode) -> Numeric | None:
+    """Return the Python numeric value of an IR literal, or ``None``.
+
+    Non-numeric IR nodes (symbols, applies, strings) return ``None``;
+    callers treat that as "this node is symbolic, don't try to fold".
+    """
+    if isinstance(node, IRInteger):
+        return Fraction(node.value)
+    if isinstance(node, IRRational):
+        return Fraction(node.numer, node.denom)
+    if isinstance(node, IRFloat):
+        return node.value
+    return None
+
+
+def from_number(value: Numeric) -> IRNode:
+    """Lift a Python number back to its most specific IR literal.
+
+    - ``Fraction`` with denominator 1 → :class:`IRInteger`.
+    - Other ``Fraction`` → :class:`IRRational`.
+    - ``float`` → :class:`IRFloat`.
+    """
+    if isinstance(value, Fraction):
+        if value.denominator == 1:
+            return IRInteger(value.numerator)
+        return IRRational(value.numerator, value.denominator)
+    if isinstance(value, float):
+        return IRFloat(value)
+    # Plain ``int`` — happens when a caller returned an int literal
+    # instead of going through Fraction. We handle it defensively.
+    if isinstance(value, int):
+        return IRInteger(value)
+    raise TypeError(f"not a numeric value: {value!r}")
+
+
+def is_zero(value: Numeric | None) -> bool:
+    """True if ``value`` is numerically zero. ``None`` is not zero."""
+    return value is not None and value == 0
+
+
+def is_one(value: Numeric | None) -> bool:
+    """True if ``value`` is numerically one."""
+    return value is not None and value == 1

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/vm.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/vm.py
@@ -1,0 +1,186 @@
+"""The generic symbolic :class:`VM` — a tree walker over ``symbolic_ir``.
+
+The walker itself is small: about forty meaningful lines of code. Every
+interesting evaluation decision (how to resolve names, whether to leave
+unknown heads alone, what rewrite rules to try) is delegated to the
+:class:`~symbolic_vm.backend.Backend`.
+
+Evaluation algorithm (applicative order with holds and rules)::
+
+    eval(node):
+        if node is an atom:
+            IRSymbol        → backend.lookup / on_unresolved
+            numeric literal → return as-is
+        if node is IRApply(head, args):
+            if head is a held head:
+                new_args = args                     # unevaluated
+            else:
+                new_args = [eval(a) for a in args]  # applicative
+            for rule in backend.rules():
+                if rule matches: return eval(rule.transform(expr))
+            if backend.handlers()[head_name] exists:
+                return handler(vm, expr)
+            if head is a user-defined function:
+                return eval(substitute(body, params → new_args))
+            return backend.on_unknown_head(expr)
+
+A "user-defined function" is a symbol bound (via :func:`handlers.define`)
+to an ``IRApply(Define, (name, params, body))`` record. The VM checks
+for this just before the "unknown head" fallback, so user functions
+slot neatly into the same dispatch flow as built-ins.
+"""
+
+from __future__ import annotations
+
+from symbolic_ir import DEFINE, LIST, IRApply, IRNode, IRSymbol
+
+from symbolic_vm.backend import Backend
+
+
+class VM:
+    """Evaluates symbolic IR trees under a policy supplied by a Backend."""
+
+    def __init__(self, backend: Backend) -> None:
+        self.backend = backend
+
+    # ------------------------------------------------------------------
+    # Public entry points
+    # ------------------------------------------------------------------
+
+    def eval(self, node: IRNode) -> IRNode:
+        """Evaluate ``node`` and return the resulting IR node."""
+        if isinstance(node, IRSymbol):
+            return self._eval_symbol(node)
+        if isinstance(node, IRApply):
+            return self._eval_apply(node)
+        # Numeric and string literals pass through unchanged.
+        return node
+
+    def eval_program(self, statements: list[IRNode]) -> IRNode | None:
+        """Evaluate a sequence of statements; return the last value.
+
+        Mirrors a MACSYMA REPL: each statement is evaluated in order
+        against the same backend environment, and the value of the
+        program is whatever the final statement evaluated to. An
+        empty program returns ``None``.
+        """
+        result: IRNode | None = None
+        for stmt in statements:
+            result = self.eval(stmt)
+        return result
+
+    # ------------------------------------------------------------------
+    # Internal evaluation
+    # ------------------------------------------------------------------
+
+    def _eval_symbol(self, sym: IRSymbol) -> IRNode:
+        value = self.backend.lookup(sym.name)
+        if value is None:
+            return self.backend.on_unresolved(sym)
+        # Guard against the trivial self-loop ``x : x`` that would
+        # otherwise recurse forever. Any non-trivial binding gets
+        # re-evaluated so transitive bindings work (``a : b; b : 5;``
+        # makes ``a`` resolve to ``5``).
+        if value == sym:
+            return sym
+        return self.eval(value)
+
+    def _eval_apply(self, node: IRApply) -> IRNode:
+        head_name = _head_name(node.head)
+
+        # 1. Evaluate arguments unless the head holds them.
+        if head_name in self.backend.hold_heads():
+            new_args = node.args
+        else:
+            new_args = tuple(self.eval(a) for a in node.args)
+        expr = IRApply(node.head, new_args)
+
+        # 2. Try rewrite rules (cheap syntactic rewrites first).
+        for predicate, transform in self.backend.rules():
+            if predicate(expr):
+                return self.eval(transform(expr))
+
+        # 3. Dispatch to a head-specific handler.
+        handler = self.backend.handlers().get(head_name)
+        if handler is not None:
+            return handler(self, expr)
+
+        # 4. User-defined function? Look up the head symbol; if it's
+        #    bound to a ``Define`` record, inline-substitute and eval.
+        if isinstance(node.head, IRSymbol):
+            bound = self.backend.lookup(head_name)
+            if _is_define_record(bound):
+                return self._apply_user_function(bound, new_args)
+
+        # 5. No handler, no function — fall back per backend policy.
+        return self.backend.on_unknown_head(expr)
+
+    # ------------------------------------------------------------------
+    # User-defined function application
+    # ------------------------------------------------------------------
+
+    def _apply_user_function(
+        self, definition: IRApply, args: tuple[IRNode, ...]
+    ) -> IRNode:
+        """Substitute params → args in a ``Define`` body and evaluate it.
+
+        The binding has the shape produced by the macsyma-compiler:
+        ``Define(name, List(param1, param2, ...), body)``. Substitution
+        is a plain structural walk — we do NOT handle shadowing,
+        because MACSYMA functions are flat (no nested ``lambda``).
+        Adding proper lexical scoping later only means tracking an
+        environment during substitution.
+        """
+        _name, params, body = definition.args
+        if not (isinstance(params, IRApply) and params.head == LIST):
+            raise TypeError(
+                f"user function params must be a List, got {params!r}"
+            )
+        param_names = tuple(
+            p.name for p in params.args if isinstance(p, IRSymbol)
+        )
+        if len(param_names) != len(args):
+            raise TypeError(
+                f"arity mismatch: function expects {len(param_names)} "
+                f"args, got {len(args)}"
+            )
+        substitution = dict(zip(param_names, args, strict=True))
+        return self.eval(_substitute(body, substitution))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _head_name(head: IRNode) -> str:
+    """Return the head's symbol name, or ``""`` for non-symbol heads."""
+    if isinstance(head, IRSymbol):
+        return head.name
+    return ""
+
+
+def _is_define_record(node: IRNode | None) -> bool:
+    """True if ``node`` is an ``IRApply(Define, ...)`` stored binding."""
+    return (
+        isinstance(node, IRApply)
+        and isinstance(node.head, IRSymbol)
+        and node.head == DEFINE
+    )
+
+
+def _substitute(node: IRNode, mapping: dict[str, IRNode]) -> IRNode:
+    """Replace free occurrences of names in ``node`` with values in ``mapping``.
+
+    Walks the tree structurally. Symbols whose names match get
+    swapped for the corresponding IR node; everything else passes
+    through unchanged. Applies recurse into both head and args so
+    substituting ``f`` into ``f(x)`` works too.
+    """
+    if isinstance(node, IRSymbol):
+        return mapping.get(node.name, node)
+    if isinstance(node, IRApply):
+        new_head = _substitute(node.head, mapping)
+        new_args = tuple(_substitute(a, mapping) for a in node.args)
+        return IRApply(new_head, new_args)
+    return node

--- a/code/packages/python/symbolic-vm/tests/test_end_to_end.py
+++ b/code/packages/python/symbolic-vm/tests/test_end_to_end.py
@@ -1,0 +1,145 @@
+"""End-to-end integration tests — MACSYMA source → evaluated result.
+
+These tests exercise the complete pipeline:
+
+    source text
+        → macsyma-lexer (GrammarLexer)
+        → macsyma-parser (GrammarParser → ASTNode)
+        → macsyma-compiler (ASTNode → symbolic IR)
+        → symbolic-vm (IR → IR via a Backend)
+
+Each test constructs a MACSYMA source string and asserts on the final
+evaluated IR. The goal is not to stress any one component; it's to
+prove the whole stack composes as intended.
+"""
+
+from __future__ import annotations
+
+import pytest
+from macsyma_compiler import compile_macsyma
+from macsyma_parser import parse_macsyma
+from symbolic_ir import (
+    COS,
+    IRApply,
+    IRFloat,
+    IRInteger,
+    IRRational,
+    IRSymbol,
+)
+
+from symbolic_vm import VM, StrictBackend, SymbolicBackend
+
+
+def run_strict(source: str):
+    """Compile and evaluate ``source`` in strict mode; return final value."""
+    statements = compile_macsyma(parse_macsyma(source))
+    return VM(StrictBackend()).eval_program(statements)
+
+
+def run_symbolic(source: str):
+    """Compile and evaluate ``source`` in symbolic mode; return final value."""
+    statements = compile_macsyma(parse_macsyma(source))
+    return VM(SymbolicBackend()).eval_program(statements)
+
+
+# ---------------------------------------------------------------------------
+# Calculator mode (StrictBackend)
+# ---------------------------------------------------------------------------
+
+
+def test_strict_simple_arithmetic() -> None:
+    assert run_strict("1 + 2 * 3;") == IRInteger(7)
+
+
+def test_strict_parentheses() -> None:
+    assert run_strict("(1 + 2) * 3;") == IRInteger(9)
+
+
+def test_strict_rationals_stay_exact() -> None:
+    assert run_strict("1 / 2 + 1 / 3;") == IRRational(5, 6)
+
+
+def test_strict_float_contamination() -> None:
+    assert run_strict("1 + 0.5;") == IRFloat(1.5)
+
+
+def test_strict_assignment_and_use() -> None:
+    result = run_strict("a : 3; b : 4; a^2 + b^2;")
+    assert result == IRInteger(25)
+
+
+def test_strict_user_function() -> None:
+    source = "square(x) := x^2; square(6);"
+    assert run_strict(source) == IRInteger(36)
+
+
+def test_strict_user_function_two_args() -> None:
+    source = "hyp(a, b) := a^2 + b^2; hyp(3, 4);"
+    assert run_strict(source) == IRInteger(25)
+
+
+def test_strict_undefined_raises() -> None:
+    with pytest.raises(NameError):
+        run_strict("x + 1;")
+
+
+def test_strict_comparison() -> None:
+    assert run_strict("5 > 3;") == IRSymbol("True")
+
+
+# ---------------------------------------------------------------------------
+# Symbolic mode (SymbolicBackend)
+# ---------------------------------------------------------------------------
+
+
+def test_symbolic_free_variable_survives() -> None:
+    # x is never bound, so it stays symbolic.
+    result = run_symbolic("x + 0;")
+    assert result == IRSymbol("x")
+
+
+def test_symbolic_identity_collapses() -> None:
+    # x * 1 → x, x + 0 → x
+    result = run_symbolic("x * 1 + 0;")
+    assert result == IRSymbol("x")
+
+
+def test_symbolic_partial_numeric_fold() -> None:
+    # x + (2 + 3) → x + 5
+    from symbolic_ir import ADD
+
+    result = run_symbolic("x + (2 + 3);")
+    assert result == IRApply(ADD, (IRSymbol("x"), IRInteger(5)))
+
+
+def test_symbolic_differentiation_polynomial() -> None:
+    # diff(x^2, x) → 2*x
+    from symbolic_ir import MUL
+
+    result = run_symbolic("diff(x^2, x);")
+    assert result == IRApply(MUL, (IRInteger(2), IRSymbol("x")))
+
+
+def test_symbolic_differentiation_trig() -> None:
+    # diff(sin(x), x) → cos(x)
+    result = run_symbolic("diff(sin(x), x);")
+    assert result == IRApply(COS, (IRSymbol("x"),))
+
+
+def test_symbolic_function_then_diff() -> None:
+    # f(x) := x^3; diff(f(x), x) → 3*x^2
+    from symbolic_ir import MUL, POW
+
+    source = "f(x) := x^3; diff(f(x), x);"
+    result = run_symbolic(source)
+    assert result == IRApply(
+        MUL,
+        (IRInteger(3), IRApply(POW, (IRSymbol("x"), IRInteger(2)))),
+    )
+
+
+def test_symbolic_mixed_program() -> None:
+    # Assign a numeric, define a function, then apply both.
+    # k : 10; f(x) := k * x; f(3)  →  30
+    source = "k : 10; f(x) := k * x; f(3);"
+    assert run_symbolic(source) == IRInteger(30)

--- a/code/packages/python/symbolic-vm/tests/test_if.py
+++ b/code/packages/python/symbolic-vm/tests/test_if.py
@@ -1,0 +1,79 @@
+"""Tests for the ``If`` handler in both backends.
+
+``If`` is the canonical held head: both branches appear as args but
+only one should execute. We verify that by giving the unchosen
+branch an expression that would raise if evaluated.
+"""
+
+from __future__ import annotations
+
+import pytest
+from symbolic_ir import (
+    ADD,
+    EQUAL,
+    IF,
+    IRApply,
+    IRInteger,
+    IRSymbol,
+)
+
+from symbolic_vm import VM, StrictBackend, SymbolicBackend
+
+
+def test_if_true_takes_then_branch() -> None:
+    vm = VM(StrictBackend())
+    expr = IRApply(IF, (IRSymbol("True"), IRInteger(1), IRInteger(2)))
+    assert vm.eval(expr) == IRInteger(1)
+
+
+def test_if_false_takes_else_branch() -> None:
+    vm = VM(StrictBackend())
+    expr = IRApply(IF, (IRSymbol("False"), IRInteger(1), IRInteger(2)))
+    assert vm.eval(expr) == IRInteger(2)
+
+
+def test_if_without_else_returns_false() -> None:
+    vm = VM(StrictBackend())
+    expr = IRApply(IF, (IRSymbol("False"), IRInteger(1)))
+    assert vm.eval(expr) == IRSymbol("False")
+
+
+def test_if_unchosen_branch_not_evaluated() -> None:
+    # The else branch would raise (``undef + 1`` hits an unresolved
+    # symbol) but we never take it, so the whole thing evaluates fine.
+    vm = VM(StrictBackend())
+    expr = IRApply(
+        IF,
+        (
+            IRSymbol("True"),
+            IRInteger(42),
+            IRApply(ADD, (IRSymbol("undef"), IRInteger(1))),
+        ),
+    )
+    assert vm.eval(expr) == IRInteger(42)
+
+
+def test_if_with_computed_predicate() -> None:
+    vm = VM(StrictBackend())
+    expr = IRApply(
+        IF,
+        (
+            IRApply(EQUAL, (IRInteger(3), IRInteger(3))),
+            IRInteger(100),
+            IRInteger(200),
+        ),
+    )
+    assert vm.eval(expr) == IRInteger(100)
+
+
+def test_if_symbolic_predicate_stays_unevaluated() -> None:
+    vm = VM(SymbolicBackend())
+    expr = IRApply(IF, (IRSymbol("x"), IRInteger(1), IRInteger(2)))
+    result = vm.eval(expr)
+    assert result == expr
+
+
+def test_if_wrong_arity_raises() -> None:
+    vm = VM(StrictBackend())
+    with pytest.raises(TypeError, match="If expects 2 or 3 arguments"):
+        vm.eval(IRApply(IF, (IRSymbol("True"),)))

--- a/code/packages/python/symbolic-vm/tests/test_strict_backend.py
+++ b/code/packages/python/symbolic-vm/tests/test_strict_backend.py
@@ -1,0 +1,252 @@
+"""Tests for :class:`StrictBackend`.
+
+Strict mode is the "calculator" backend: every name must resolve,
+every head must have a handler, and every arithmetic operation must
+fully fold to a number.
+"""
+
+from __future__ import annotations
+
+import pytest
+from symbolic_ir import (
+    ADD,
+    ASSIGN,
+    COS,
+    DEFINE,
+    DIV,
+    EQUAL,
+    LESS,
+    LIST,
+    MUL,
+    NEG,
+    POW,
+    SIN,
+    SUB,
+    IRApply,
+    IRFloat,
+    IRInteger,
+    IRRational,
+    IRSymbol,
+)
+
+from symbolic_vm import VM, StrictBackend
+
+
+@pytest.fixture
+def vm() -> VM:
+    return VM(StrictBackend())
+
+
+# ---------------------------------------------------------------------------
+# Literals pass through
+# ---------------------------------------------------------------------------
+
+
+def test_integer_literal(vm: VM) -> None:
+    assert vm.eval(IRInteger(7)) == IRInteger(7)
+
+
+def test_float_literal(vm: VM) -> None:
+    assert vm.eval(IRFloat(3.14)) == IRFloat(3.14)
+
+
+def test_rational_literal(vm: VM) -> None:
+    assert vm.eval(IRRational(1, 3)) == IRRational(1, 3)
+
+
+# ---------------------------------------------------------------------------
+# Arithmetic
+# ---------------------------------------------------------------------------
+
+
+def test_add_integers(vm: VM) -> None:
+    expr = IRApply(ADD, (IRInteger(2), IRInteger(3)))
+    assert vm.eval(expr) == IRInteger(5)
+
+
+def test_add_rationals_stays_exact(vm: VM) -> None:
+    expr = IRApply(ADD, (IRRational(1, 2), IRRational(1, 3)))
+    assert vm.eval(expr) == IRRational(5, 6)
+
+
+def test_mul_float_contaminates(vm: VM) -> None:
+    expr = IRApply(MUL, (IRInteger(2), IRFloat(0.5)))
+    assert vm.eval(expr) == IRFloat(1.0)
+
+
+def test_sub(vm: VM) -> None:
+    expr = IRApply(SUB, (IRInteger(10), IRInteger(4)))
+    assert vm.eval(expr) == IRInteger(6)
+
+
+def test_div_stays_exact(vm: VM) -> None:
+    expr = IRApply(DIV, (IRInteger(1), IRInteger(4)))
+    assert vm.eval(expr) == IRRational(1, 4)
+
+
+def test_div_by_zero_raises(vm: VM) -> None:
+    with pytest.raises(ZeroDivisionError):
+        vm.eval(IRApply(DIV, (IRInteger(1), IRInteger(0))))
+
+
+def test_pow_integer(vm: VM) -> None:
+    expr = IRApply(POW, (IRInteger(2), IRInteger(10)))
+    assert vm.eval(expr) == IRInteger(1024)
+
+
+def test_neg(vm: VM) -> None:
+    assert vm.eval(IRApply(NEG, (IRInteger(5),))) == IRInteger(-5)
+
+
+def test_nested_arithmetic(vm: VM) -> None:
+    # (1 + 2) * (4 - 1) → 9
+    expr = IRApply(
+        MUL,
+        (
+            IRApply(ADD, (IRInteger(1), IRInteger(2))),
+            IRApply(SUB, (IRInteger(4), IRInteger(1))),
+        ),
+    )
+    assert vm.eval(expr) == IRInteger(9)
+
+
+# ---------------------------------------------------------------------------
+# Unresolved symbols raise
+# ---------------------------------------------------------------------------
+
+
+def test_unresolved_symbol_raises(vm: VM) -> None:
+    with pytest.raises(NameError, match="undefined symbol: 'x'"):
+        vm.eval(IRSymbol("x"))
+
+
+def test_unknown_head_raises(vm: VM) -> None:
+    with pytest.raises(NameError, match="no handler for head"):
+        vm.eval(IRApply(IRSymbol("zaphod"), (IRInteger(1),)))
+
+
+def test_add_with_symbol_raises(vm: VM) -> None:
+    with pytest.raises(NameError):
+        vm.eval(IRApply(ADD, (IRSymbol("x"), IRInteger(1))))
+
+
+# ---------------------------------------------------------------------------
+# Assignment
+# ---------------------------------------------------------------------------
+
+
+def test_assign_stores_value(vm: VM) -> None:
+    vm.eval(IRApply(ASSIGN, (IRSymbol("a"), IRInteger(5))))
+    assert vm.eval(IRSymbol("a")) == IRInteger(5)
+
+
+def test_assign_then_use(vm: VM) -> None:
+    vm.eval(IRApply(ASSIGN, (IRSymbol("a"), IRInteger(3))))
+    vm.eval(IRApply(ASSIGN, (IRSymbol("b"), IRInteger(4))))
+    expr = IRApply(ADD, (IRSymbol("a"), IRSymbol("b")))
+    assert vm.eval(expr) == IRInteger(7)
+
+
+def test_assign_rhs_is_evaluated(vm: VM) -> None:
+    # a : 2 + 3 → a is bound to 5, not to Add(2, 3).
+    rhs = IRApply(ADD, (IRInteger(2), IRInteger(3)))
+    vm.eval(IRApply(ASSIGN, (IRSymbol("a"), rhs)))
+    assert vm.eval(IRSymbol("a")) == IRInteger(5)
+
+
+# ---------------------------------------------------------------------------
+# Function definition and application
+# ---------------------------------------------------------------------------
+
+
+def test_define_and_call(vm: VM) -> None:
+    # square(x) := x^2
+    defn = IRApply(
+        DEFINE,
+        (
+            IRSymbol("square"),
+            IRApply(LIST, (IRSymbol("x"),)),
+            IRApply(POW, (IRSymbol("x"), IRInteger(2))),
+        ),
+    )
+    vm.eval(defn)
+    # square(7)
+    call = IRApply(IRSymbol("square"), (IRInteger(7),))
+    assert vm.eval(call) == IRInteger(49)
+
+
+def test_define_multi_arg(vm: VM) -> None:
+    defn = IRApply(
+        DEFINE,
+        (
+            IRSymbol("plus"),
+            IRApply(LIST, (IRSymbol("x"), IRSymbol("y"))),
+            IRApply(ADD, (IRSymbol("x"), IRSymbol("y"))),
+        ),
+    )
+    vm.eval(defn)
+    assert vm.eval(
+        IRApply(IRSymbol("plus"), (IRInteger(10), IRInteger(20)))
+    ) == IRInteger(30)
+
+
+def test_user_function_arity_mismatch(vm: VM) -> None:
+    defn = IRApply(
+        DEFINE,
+        (
+            IRSymbol("square"),
+            IRApply(LIST, (IRSymbol("x"),)),
+            IRApply(POW, (IRSymbol("x"), IRInteger(2))),
+        ),
+    )
+    vm.eval(defn)
+    with pytest.raises(TypeError, match="arity mismatch"):
+        vm.eval(IRApply(IRSymbol("square"), (IRInteger(1), IRInteger(2))))
+
+
+# ---------------------------------------------------------------------------
+# Elementary functions
+# ---------------------------------------------------------------------------
+
+
+def test_sin_zero_exact(vm: VM) -> None:
+    assert vm.eval(IRApply(SIN, (IRInteger(0),))) == IRInteger(0)
+
+
+def test_cos_zero_exact(vm: VM) -> None:
+    assert vm.eval(IRApply(COS, (IRInteger(0),))) == IRInteger(1)
+
+
+# ---------------------------------------------------------------------------
+# Comparisons
+# ---------------------------------------------------------------------------
+
+
+def test_equal_true(vm: VM) -> None:
+    assert vm.eval(IRApply(EQUAL, (IRInteger(3), IRInteger(3)))) == IRSymbol("True")
+
+
+def test_less_true(vm: VM) -> None:
+    assert vm.eval(IRApply(LESS, (IRInteger(2), IRInteger(5)))) == IRSymbol("True")
+
+
+def test_less_false(vm: VM) -> None:
+    assert vm.eval(IRApply(LESS, (IRInteger(5), IRInteger(2)))) == IRSymbol("False")
+
+
+# ---------------------------------------------------------------------------
+# Program evaluation
+# ---------------------------------------------------------------------------
+
+
+def test_eval_program_returns_last(vm: VM) -> None:
+    stmts = [
+        IRApply(ASSIGN, (IRSymbol("a"), IRInteger(10))),
+        IRApply(ASSIGN, (IRSymbol("b"), IRInteger(20))),
+        IRApply(ADD, (IRSymbol("a"), IRSymbol("b"))),
+    ]
+    assert vm.eval_program(stmts) == IRInteger(30)
+
+
+def test_eval_program_empty(vm: VM) -> None:
+    assert vm.eval_program([]) is None

--- a/code/packages/python/symbolic-vm/tests/test_symbolic_backend.py
+++ b/code/packages/python/symbolic-vm/tests/test_symbolic_backend.py
@@ -1,0 +1,260 @@
+"""Tests for :class:`SymbolicBackend`.
+
+Symbolic mode leaves unknown symbols alone, applies algebraic identities,
+and implements the standard calculus rules for ``D``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from symbolic_ir import (
+    ADD,
+    COS,
+    DIV,
+    EXP,
+    LOG,
+    MUL,
+    NEG,
+    POW,
+    SIN,
+    SUB,
+    D,
+    IRApply,
+    IRInteger,
+    IRSymbol,
+)
+
+from symbolic_vm import VM, SymbolicBackend
+
+
+@pytest.fixture
+def vm() -> VM:
+    return VM(SymbolicBackend())
+
+
+X = IRSymbol("x")
+Y = IRSymbol("y")
+
+
+# ---------------------------------------------------------------------------
+# Free variables pass through
+# ---------------------------------------------------------------------------
+
+
+def test_free_symbol_passes_through(vm: VM) -> None:
+    assert vm.eval(X) == X
+
+
+def test_unknown_head_passes_through(vm: VM) -> None:
+    expr = IRApply(IRSymbol("mysteryfn"), (IRInteger(1),))
+    assert vm.eval(expr) == expr
+
+
+# ---------------------------------------------------------------------------
+# Identity and zero laws
+# ---------------------------------------------------------------------------
+
+
+def test_add_zero_right_identity(vm: VM) -> None:
+    assert vm.eval(IRApply(ADD, (X, IRInteger(0)))) == X
+
+
+def test_add_zero_left_identity(vm: VM) -> None:
+    assert vm.eval(IRApply(ADD, (IRInteger(0), X))) == X
+
+
+def test_mul_zero_annihilates(vm: VM) -> None:
+    assert vm.eval(IRApply(MUL, (X, IRInteger(0)))) == IRInteger(0)
+    assert vm.eval(IRApply(MUL, (IRInteger(0), X))) == IRInteger(0)
+
+
+def test_mul_one_identity(vm: VM) -> None:
+    assert vm.eval(IRApply(MUL, (X, IRInteger(1)))) == X
+    assert vm.eval(IRApply(MUL, (IRInteger(1), X))) == X
+
+
+def test_pow_zero_exponent(vm: VM) -> None:
+    assert vm.eval(IRApply(POW, (X, IRInteger(0)))) == IRInteger(1)
+
+
+def test_pow_one_exponent(vm: VM) -> None:
+    assert vm.eval(IRApply(POW, (X, IRInteger(1)))) == X
+
+
+def test_neg_neg_cancels(vm: VM) -> None:
+    expr = IRApply(NEG, (IRApply(NEG, (X,)),))
+    assert vm.eval(expr) == X
+
+
+# ---------------------------------------------------------------------------
+# Numeric folding still works with symbols around
+# ---------------------------------------------------------------------------
+
+
+def test_numeric_folds_inside_symbolic(vm: VM) -> None:
+    # Add(x, Add(2, 3)) → Add(x, 5). Inner numeric part folds; outer
+    # stays because x is free.
+    inner = IRApply(ADD, (IRInteger(2), IRInteger(3)))
+    outer = IRApply(ADD, (X, inner))
+    assert vm.eval(outer) == IRApply(ADD, (X, IRInteger(5)))
+
+
+def test_equal_of_same_symbol(vm: VM) -> None:
+    assert vm.eval(IRApply(IRSymbol("Equal"), (X, X))) == IRSymbol("True")
+
+
+# ---------------------------------------------------------------------------
+# Elementary functions keep symbolic args
+# ---------------------------------------------------------------------------
+
+
+def test_sin_symbolic_stays(vm: VM) -> None:
+    expr = IRApply(SIN, (X,))
+    assert vm.eval(expr) == expr
+
+
+def test_sin_zero_folds(vm: VM) -> None:
+    assert vm.eval(IRApply(SIN, (IRInteger(0),))) == IRInteger(0)
+
+
+# ---------------------------------------------------------------------------
+# Differentiation
+# ---------------------------------------------------------------------------
+
+
+def test_diff_constant(vm: VM) -> None:
+    assert vm.eval(IRApply(D, (IRInteger(7), X))) == IRInteger(0)
+
+
+def test_diff_var_wrt_self(vm: VM) -> None:
+    assert vm.eval(IRApply(D, (X, X))) == IRInteger(1)
+
+
+def test_diff_other_var(vm: VM) -> None:
+    assert vm.eval(IRApply(D, (Y, X))) == IRInteger(0)
+
+
+def test_diff_sum(vm: VM) -> None:
+    # d/dx (x + 3) = 1
+    expr = IRApply(D, (IRApply(ADD, (X, IRInteger(3))), X))
+    assert vm.eval(expr) == IRInteger(1)
+
+
+def test_diff_sub(vm: VM) -> None:
+    # d/dx (x - 3) = 1 (via sum rule; 1 - 0 = 1)
+    expr = IRApply(D, (IRApply(SUB, (X, IRInteger(3))), X))
+    assert vm.eval(expr) == IRInteger(1)
+
+
+def test_diff_product(vm: VM) -> None:
+    # d/dx (x * 5) = 5
+    expr = IRApply(D, (IRApply(MUL, (X, IRInteger(5))), X))
+    assert vm.eval(expr) == IRInteger(5)
+
+
+def test_diff_power(vm: VM) -> None:
+    # d/dx (x^2) = 2*x
+    expr = IRApply(D, (IRApply(POW, (X, IRInteger(2))), X))
+    result = vm.eval(expr)
+    # Could come out as Mul(2, x) or Mul(Mul(2, x), 1) depending on
+    # how identities collapse. What we require: it simplifies to
+    # IRApply(MUL, (IRInteger(2), X)).
+    assert result == IRApply(MUL, (IRInteger(2), X))
+
+
+def test_diff_sin(vm: VM) -> None:
+    # d/dx sin(x) = cos(x)
+    expr = IRApply(D, (IRApply(SIN, (X,)), X))
+    assert vm.eval(expr) == IRApply(COS, (X,))
+
+
+def test_diff_cos(vm: VM) -> None:
+    # d/dx cos(x) = -sin(x)
+    expr = IRApply(D, (IRApply(COS, (X,)), X))
+    assert vm.eval(expr) == IRApply(NEG, (IRApply(SIN, (X,)),))
+
+
+def test_diff_exp(vm: VM) -> None:
+    # d/dx exp(x) = exp(x)
+    expr = IRApply(D, (IRApply(EXP, (X,)), X))
+    assert vm.eval(expr) == IRApply(EXP, (X,))
+
+
+def test_diff_log_chain(vm: VM) -> None:
+    # d/dx log(2*x) = 2/(2*x)  (we don't simplify further than that)
+    expr = IRApply(D, (IRApply(LOG, (IRApply(MUL, (IRInteger(2), X)),)), X))
+    result = vm.eval(expr)
+    expected = IRApply(DIV, (IRInteger(2), IRApply(MUL, (IRInteger(2), X))))
+    assert result == expected
+
+
+def test_diff_quotient(vm: VM) -> None:
+    # d/dx (x / 2) = 1/2
+    expr = IRApply(D, (IRApply(DIV, (X, IRInteger(2))), X))
+    from symbolic_ir import IRRational
+
+    assert vm.eval(expr) == IRRational(1, 2)
+
+
+def test_diff_nested_power(vm: VM) -> None:
+    # d/dx (x^3) = 3*x^2
+    expr = IRApply(D, (IRApply(POW, (X, IRInteger(3))), X))
+    result = vm.eval(expr)
+    expected = IRApply(MUL, (IRInteger(3), IRApply(POW, (X, IRInteger(2)))))
+    assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# Assignment and definition
+# ---------------------------------------------------------------------------
+
+
+def test_symbolic_assign(vm: VM) -> None:
+    from symbolic_ir import ASSIGN
+
+    vm.eval(IRApply(ASSIGN, (IRSymbol("a"), IRInteger(5))))
+    assert vm.eval(IRSymbol("a")) == IRInteger(5)
+
+
+def test_symbolic_function_composition(vm: VM) -> None:
+    # f(t) := t^2; f(3) + f(4) → 9 + 16 = 25
+    from symbolic_ir import DEFINE, LIST
+
+    vm.eval(
+        IRApply(
+            DEFINE,
+            (
+                IRSymbol("f"),
+                IRApply(LIST, (IRSymbol("t"),)),
+                IRApply(POW, (IRSymbol("t"), IRInteger(2))),
+            ),
+        )
+    )
+    total = IRApply(
+        ADD,
+        (
+            IRApply(IRSymbol("f"), (IRInteger(3),)),
+            IRApply(IRSymbol("f"), (IRInteger(4),)),
+        ),
+    )
+    assert vm.eval(total) == IRInteger(25)
+
+
+# ---------------------------------------------------------------------------
+# Logic short-circuits
+# ---------------------------------------------------------------------------
+
+
+def test_and_short_circuits_on_false(vm: VM) -> None:
+    from symbolic_ir import AND
+
+    TRUE = IRSymbol("True")
+    FALSE = IRSymbol("False")
+    assert vm.eval(IRApply(AND, (TRUE, FALSE, X))) == FALSE
+
+
+def test_or_short_circuits_on_true(vm: VM) -> None:
+    from symbolic_ir import OR
+
+    TRUE = IRSymbol("True")
+    assert vm.eval(IRApply(OR, (X, TRUE))) == TRUE

--- a/code/specs/symbolic-computation.md
+++ b/code/specs/symbolic-computation.md
@@ -1,0 +1,285 @@
+# Symbolic Computation Pipeline
+
+## Overview
+
+This spec defines a Computer Algebra System (CAS) infrastructure built on the
+grammar-driven lexer/parser machinery already present in the repo. The goal is
+to support multiple CAS language frontends (MACSYMA, Mathematica, Maple, REDUCE,
+SymPy expressions) that all compile down to a single universal **symbolic IR**
+and execute on a single pluggable **symbolic VM** with language-specific
+evaluation policies layered on top.
+
+This spec covers the end-to-end MACSYMA pipeline as the reference
+implementation. MACSYMA is chosen because it is the grandparent of every
+modern CAS — Maxima, Mathematica, Maple, and REDUCE all inherited from it or
+from its immediate contemporaries.
+
+## Why a Universal Pipeline?
+
+A CAS is, at its core, an expression tree walker with rules. The tree
+structure — `head applied to args` — is the same in every CAS that has ever
+existed. Only the surface syntax differs:
+
+| Language    | Source                  | Tree after parsing           |
+|-------------|-------------------------|------------------------------|
+| MACSYMA     | `diff(x^2 + 1, x)`      | `D(Add(Pow(x,2), 1), x)`     |
+| Mathematica | `D[x^2 + 1, x]`         | `D(Add(Pow(x,2), 1), x)`     |
+| Maple       | `diff(x^2 + 1, x)`      | `D(Add(Pow(x,2), 1), x)`     |
+| REDUCE      | `df(x^2 + 1, x)`        | `D(Add(Pow(x,2), 1), x)`     |
+
+Once we parse into the universal IR, every downstream operation —
+differentiation, simplification, integration, numeric evaluation, LaTeX
+rendering, transpilation — runs on the same trees regardless of which
+frontend produced them.
+
+## Architecture
+
+```
+┌───────────────────┐
+│ Source text       │   "f(x) := x^2; diff(f(x), x)"
+└────────┬──────────┘
+         │
+         ▼
+┌───────────────────┐    code/grammars/macsyma/macsyma.tokens
+│ macsyma-lexer     │──▶ uses GrammarLexer
+└────────┬──────────┘    produces Token stream
+         │
+         ▼
+┌───────────────────┐    code/grammars/macsyma/macsyma.grammar
+│ macsyma-parser    │──▶ uses GrammarParser
+└────────┬──────────┘    produces ASTNode tree
+         │
+         ▼
+┌───────────────────┐
+│ macsyma-compiler  │──▶ walks ASTNode tree
+└────────┬──────────┘    emits symbolic IR
+         │
+         ▼
+┌───────────────────┐
+│ symbolic-ir       │    IRNode = Symbol | Integer | Rational | Float
+│                   │            | String | Apply(head, args)
+└────────┬──────────┘
+         │
+         ▼
+┌───────────────────┐
+│ symbolic-vm       │    Backend interface + StrictVM + SymbolicVM
+└───────────────────┘    evaluates IR, returns IR
+```
+
+## The Symbolic IR
+
+The IR is a small set of immutable, hashable node types. Every compound
+expression is an `Apply(head, args)` where `head` is an `IRSymbol` naming a
+standard operation and `args` is a tuple of child `IRNode`s.
+
+### Node Types
+
+```python
+IRNode (abstract)
+├── IRSymbol(name: str)          # x, y, Pi, E
+├── IRInteger(value: int)        # arbitrary precision
+├── IRRational(numer: int, denom: int)  # exact fractions, always normalized
+├── IRFloat(value: float)
+├── IRString(value: str)
+└── IRApply(head: IRNode, args: tuple[IRNode, ...])
+```
+
+All nodes are frozen dataclasses (immutable, hashable) so they can be used as
+dict keys (essential for rule-matching caches) and compared structurally.
+
+### Standard Heads
+
+The head of an `IRApply` is always an `IRSymbol`. The following names are
+reserved as "standard operations" that every backend understands:
+
+```
+Arithmetic:   Add  Mul  Pow  Neg  Inv  Sub  Div
+Elementary:   Exp  Log  Sin  Cos  Tan  Sqrt  Abs
+Calculus:     D  Integrate  Limit  Series  Sum  Product
+Algebra:      Solve  Factor  Expand  Simplify
+Relations:    Equal  NotEqual  Less  Greater  LessEqual  GreaterEqual
+Logic:        And  Or  Not  If
+Containers:   List  Matrix  Set
+Assignment:   Assign   (non-delayed: evaluate rhs, bind to lhs)
+              Define   (delayed: store rhs unevaluated for function defs)
+Rules:        Rule       (x -> expr: rewrite pattern)
+              RuleDelayed (x :> expr)
+```
+
+Any frontend that wants to add domain-specific operations can introduce new
+heads; the VM's behavior when it encounters an unknown head depends on the
+evaluation mode.
+
+## The Pluggable VM
+
+The VM is a generic tree walker. The evaluation strategy lives in a
+`Backend` object that supplies three things: a name lookup policy, a set of
+rewrite rules, and per-head evaluators.
+
+### Backend Interface
+
+```python
+class Backend(Protocol):
+    def lookup(self, name: str) -> IRNode | None: ...
+    def on_unresolved(self, symbol: IRSymbol) -> IRNode: ...
+    def rules(self) -> Iterable[tuple[IRNode, Callable[..., IRNode]]]: ...
+    def handlers(self) -> Mapping[str, Callable[[VM, IRApply], IRNode]]: ...
+```
+
+- `lookup(name)` — returns the stored value for a symbol, or `None`.
+- `on_unresolved(sym)` — what to do when a symbol has no binding:
+  - **Strict backend:** raises `NameError`.
+  - **Symbolic backend:** returns `sym` unchanged.
+- `rules()` — yields `(pattern, transform)` pairs. The VM tries each rule on
+  every `IRApply` before falling back to handlers.
+- `handlers()` — maps head names to specialized evaluators. This is where
+  `Add`, `Mul`, `D`, etc. get their behavior.
+
+### Shared Core (~80% of the VM)
+
+The VM's generic logic is reused across every backend:
+
+1. Walk arguments first (applicative order) unless the head is in a "hold"
+   list (`Define`, `RuleDelayed`, `If`, `Quote`).
+2. After arguments are evaluated, attempt each rewrite rule in `rules()`.
+   If one matches, recursively evaluate the rewritten expression.
+3. If no rule matches, dispatch to the head-specific handler from
+   `handlers()`.
+4. If no handler exists, either leave the expression as-is (symbolic mode)
+   or raise (strict mode).
+
+### Language Quirks via Backend Subclassing
+
+Language-specific quirks are small deltas on the base:
+
+- **MACSYMA**: `:` is assignment (`Assign`), `:=` is definition (`Define`).
+  Boolean `and`/`or` are short-circuited. `%pi`, `%e`, `%i` are constants.
+- **Mathematica**: pattern variables `x_` match any expression;
+  `Hold` attributes prevent argument evaluation; rules have much richer
+  pattern matching.
+- **Maple**: range syntax `a..b` becomes `Apply(Range, [a, b])`.
+
+Each language ships a `Backend` subclass that overrides `handlers()` and
+`rules()` for its quirks while reusing the generic core.
+
+## The MACSYMA Frontend
+
+### Tokens (summary)
+
+- Numbers: integer (`42`), float (`3.14`, `1.5e10`)
+- Names: `[a-zA-Z_][a-zA-Z0-9_]*` and `%pi`, `%e`, `%i`
+- Strings: double-quoted
+- Operators: `+ - * / ^ ** : := = # < > <= >= -> !`
+- Delimiters: `( ) [ ] { } , ; $`
+- Keywords: `and or not if then else elseif true false`
+- Comments: `/* ... */`
+- Skip: whitespace, newlines
+
+### Grammar (summary)
+
+```
+program        = { statement } ;
+statement      = expression ( SEMI | DOLLAR ) ;
+expression     = assign_expr ;
+assign_expr    = logical_or [ ( COLON | COLONEQ ) assign_expr ] ;
+logical_or     = logical_and { OR logical_and } ;
+logical_and    = logical_not { AND logical_not } ;
+logical_not    = [ NOT ] comparison ;
+comparison     = additive [ cmp_op additive ] ;
+cmp_op         = EQ | HASH | LT | GT | LEQ | GEQ ;
+additive       = multiplicative { ( PLUS | MINUS ) multiplicative } ;
+multiplicative = unary { ( STAR | SLASH ) unary } ;
+unary          = ( MINUS | PLUS ) unary | power ;
+power          = postfix [ CARET unary ] ;
+postfix        = atom { call_suffix } ;
+call_suffix    = LPAREN [ arglist ] RPAREN ;
+arglist        = expression { COMMA expression } ;
+atom           = NUMBER | STRING | NAME | group | list ;
+group          = LPAREN expression RPAREN ;
+list           = LBRACKET [ arglist ] RBRACKET ;
+```
+
+Function definitions `f(x) := body` parse naturally: `f(x)` is a `postfix`
+with a call suffix, and `:=` continues as the assign operator, so the whole
+thing is `Assign(Call(f, x), body)` at the AST level. The compiler detects
+`:=` and emits `Define(f, [x], body)` in the IR.
+
+### AST → IR Compilation Rules
+
+| AST shape                                | IR shape                              |
+|------------------------------------------|---------------------------------------|
+| `NUMBER`                                 | `IRInteger` or `IRFloat`              |
+| `NAME`                                   | `IRSymbol(name)`                      |
+| `Call(f, [args...])`                     | `IRApply(IRSymbol(f), [args...])`     |
+| `BinaryOp("+", a, b)`                    | `IRApply(Add, [a, b])`                |
+| `BinaryOp("*", a, b)`                    | `IRApply(Mul, [a, b])`                |
+| `BinaryOp("^", a, b)`                    | `IRApply(Pow, [a, b])`                |
+| `UnaryOp("-", a)`                        | `IRApply(Neg, [a])`                   |
+| `BinaryOp(":", name, rhs)`               | `IRApply(Assign, [IRSymbol(name), rhs])` |
+| `BinaryOp(":=", Call(f, params), body)`  | `IRApply(Define, [IRSymbol(f), List(params), body])` |
+| `List([e1, e2, ...])`                    | `IRApply(List, [e1, e2, ...])`        |
+| Well-known names (`diff`, `integrate`)   | Replace head with standard head (`D`, `Integrate`) |
+
+## The VM Modes
+
+### StrictVM
+
+- `on_unresolved(x)` raises `NameError("symbol 'x' is not defined")`.
+- Numeric handlers evaluate fully (e.g., `Add(2, 3) → 5`).
+- No rewrite rules by default.
+- Behaves like a numeric evaluator that happens to understand MACSYMA syntax.
+
+### SymbolicVM
+
+- `on_unresolved(x)` returns `x` unchanged.
+- Numeric handlers evaluate constants but keep symbols: `Add(x, 2, 3) → Add(x, 5)`.
+- Built-in rewrite rules for:
+  - Identity elements: `Add(x, 0) → x`, `Mul(x, 1) → x`, `Pow(x, 1) → x`.
+  - Zero laws: `Mul(x, 0) → 0`, `Pow(x, 0) → 1`.
+  - Derivative rules: sum rule, product rule, chain rule, power rule.
+- Behaves like a miniature Mathematica.
+
+## Package Layout
+
+```
+code/grammars/
+  macsyma/
+    macsyma.tokens
+    macsyma.grammar
+
+code/packages/python/
+  symbolic-ir/        # IR types, no dependencies
+  symbolic-vm/        # Generic VM + StrictVM + SymbolicVM
+  macsyma-lexer/      # Thin wrapper around GrammarLexer
+  macsyma-parser/     # Thin wrapper around GrammarParser
+  macsyma-compiler/   # ASTNode → IR
+```
+
+Each thin-wrapper package (`macsyma-lexer`, `macsyma-parser`) follows the
+same structure as `json-lexer` and `json-parser` — a `tokenizer.py` or
+`parser.py` module with a 20-line function that reads the grammar file and
+calls the generic engine. The real work lives in the compiler and VM.
+
+## Test Strategy
+
+Every package has pytest tests with ≥80% coverage:
+
+- `symbolic-ir`: constructor normalization (e.g., `IRRational(2, 4) → 1/2`),
+  equality, hashing, structural comparison.
+- `macsyma-lexer`: all token types round-trip on canonical MACSYMA snippets.
+- `macsyma-parser`: grammar produces expected `ASTNode` shapes.
+- `macsyma-compiler`: compiles every AST shape correctly to IR.
+- `symbolic-vm`: both VMs on identity rules, arithmetic, assignment,
+  function definition, and a simple `diff` rewrite.
+
+The integration test (in `symbolic-vm/tests/test_end_to_end.py`) runs full
+MACSYMA programs through the complete pipeline.
+
+## Non-Goals (For This Spec)
+
+- No symbolic integration (Risch algorithm is its own rabbit hole).
+- No polynomial GCD or factoring.
+- No simplification beyond local algebraic identities.
+- No Mathematica, Maple, or REDUCE frontends yet — they reuse every
+  downstream component. Adding them later means writing a new `.tokens`,
+  `.grammar`, and compiler — nothing else.


### PR DESCRIPTION
## Summary

Complete end-to-end Computer Algebra System (CAS) pipeline: MACSYMA source → lexer → parser → compiler → universal symbolic IR → pluggable VM.

**Six commits, bottom-up:**

1. `spec(symbolic-computation)` — Full spec for the CAS pipeline + MACSYMA grammar
2. `feat(symbolic-ir)` — Universal IR (IRSymbol, IRInteger, IRRational, IRFloat, IRString, IRApply) + standard head singletons (Add, Mul, Pow, D, Assign, Define, ...)
3. `feat(macsyma-lexer)` — Grammar-driven lexer package
4. `feat(macsyma-parser)` — Grammar-driven parser producing a generic AST
5. `feat(macsyma-compiler)` — Lowers MACSYMA AST to symbolic IR
6. `feat(symbolic-vm)` — Pluggable tree-walking VM with **StrictBackend** (calculator — every name must resolve) and **SymbolicBackend** (Mathematica-like — free variables pass through, identity laws fire, full differentiation via D)

## Highlights

- **Exact arithmetic**: rationals stay rational (`1/2 + 1/3 → 5/6`); floats contaminate
- **Symbolic simplification**: identity (`x + 0 → x`), zero (`x · 0 → 0`), power (`x^0 → 1`) laws applied automatically
- **Differentiation**: sum, product, quotient, chain, and general power rules — `diff(x^3, x) → 3·x²`, `diff(sin(x), x) → cos(x)`
- **User functions survive differentiation**: `f(x) := x^3; diff(f(x), x); → 3·x²`
- **Held heads** for `Assign`, `Define`, `If` so LHS/body/unchosen-branch aren't pre-evaluated
- **Shared handler table** parameterized by a `simplify` flag — one implementation powers both backends

## Tests

- **symbolic-vm**: 81 tests, 84.14% coverage, all ruff checks pass
- End-to-end tests exercise the full pipeline from source string to evaluated IR
- Security review passed on first pass (no eval/exec, linear regexes, no user-controlled paths)

## Test plan

- [x] `symbolic-ir` unit tests
- [x] `macsyma-lexer` / `macsyma-parser` / `macsyma-compiler` unit tests
- [x] `symbolic-vm` strict + symbolic backend tests
- [x] End-to-end pipeline tests (MACSYMA source → result)
- [x] Security review (passed, zero findings)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)