### PR TITLE
feat(haskell-wasm): add Brainfuck and Nib pipelines

### DIFF
--- a/code/packages/haskell/brainfuck-ir-compiler/BUILD
+++ b/code/packages/haskell/brainfuck-ir-compiler/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/brainfuck-ir-compiler/BUILD_windows
+++ b/code/packages/haskell/brainfuck-ir-compiler/BUILD_windows
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/brainfuck-ir-compiler/CHANGELOG.md
+++ b/code/packages/haskell/brainfuck-ir-compiler/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add a Haskell Brainfuck-to-IR compiler package for the Wasm convergence lane.

--- a/code/packages/haskell/brainfuck-ir-compiler/README.md
+++ b/code/packages/haskell/brainfuck-ir-compiler/README.md
@@ -1,0 +1,6 @@
+# brainfuck-ir-compiler
+
+This package lowers the Haskell Brainfuck AST into the local `compiler-ir`
+representation. The first convergence implementation preserves the pipeline
+shape and emits a runnable `_start` shell while retaining source operations as
+IR comments for downstream diagnostics.

--- a/code/packages/haskell/brainfuck-ir-compiler/README.md
+++ b/code/packages/haskell/brainfuck-ir-compiler/README.md
@@ -1,6 +1,5 @@
 # brainfuck-ir-compiler
 
 This package lowers the Haskell Brainfuck AST into the local `compiler-ir`
-representation. The first convergence implementation preserves the pipeline
-shape and emits a runnable `_start` shell while retaining source operations as
-IR comments for downstream diagnostics.
+representation. It emits tape-backed IR with byte loads/stores, pointer
+movement, structured loop labels, and syscall markers for Brainfuck I/O.

--- a/code/packages/haskell/brainfuck-ir-compiler/brainfuck-ir-compiler.cabal
+++ b/code/packages/haskell/brainfuck-ir-compiler/brainfuck-ir-compiler.cabal
@@ -1,0 +1,28 @@
+cabal-version: 3.0
+name:          brainfuck-ir-compiler
+version:       0.1.0
+synopsis:      Haskell Brainfuck to compiler IR frontend
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  BrainfuckIRCompiler
+    build-depends:    base >=4.14
+                    , brainfuck
+                    , compiler-ir
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    BrainfuckIRCompilerSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , brainfuck
+                    , brainfuck-ir-compiler
+                    , compiler-ir
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/brainfuck-ir-compiler/cabal.project
+++ b/code/packages/haskell/brainfuck-ir-compiler/cabal.project
@@ -1,0 +1,4 @@
+packages:
+  .
+  ../brainfuck
+  ../compiler-ir

--- a/code/packages/haskell/brainfuck-ir-compiler/src/BrainfuckIRCompiler.hs
+++ b/code/packages/haskell/brainfuck-ir-compiler/src/BrainfuckIRCompiler.hs
@@ -1,0 +1,147 @@
+module BrainfuckIRCompiler
+    ( description
+    , BuildConfig(..)
+    , CompileResult(..)
+    , releaseConfig
+    , compileOps
+    , compileSource
+    ) where
+
+import Brainfuck (BrainfuckError, BrainfuckOp(..), parseSource)
+import CompilerIR hiding (description)
+
+description :: String
+description = "Haskell Brainfuck to compiler IR frontend"
+
+data CompileResult = CompileResult
+    { compileResultProgram :: IrProgram
+    , compileResultAst :: [BrainfuckOp]
+    }
+    deriving (Eq, Show)
+
+data BuildConfig = BuildConfig
+    { buildConfigTapeSize :: Int
+    , buildConfigMaskByteArithmetic :: Bool
+    }
+    deriving (Eq, Show)
+
+releaseConfig :: BuildConfig
+releaseConfig =
+    BuildConfig
+        { buildConfigTapeSize = 30000
+        , buildConfigMaskByteArithmetic = True
+        }
+
+compileSource :: String -> Either BrainfuckError CompileResult
+compileSource source = do
+    ast <- parseSource source
+    Right (CompileResult (compileOps ast) ast)
+
+compileOps :: [BrainfuckOp] -> IrProgram
+compileOps = compileOpsWithConfig releaseConfig
+
+compileOpsWithConfig :: BuildConfig -> [BrainfuckOp] -> IrProgram
+compileOpsWithConfig config ops =
+    let initialProgram =
+            appendMany
+                ((emptyProgram "_start") {irDataDecls = [IrDataDecl "tape" (buildConfigTapeSize config) 0]})
+                [ instruction Label [LabelRef "_start"] (-1)
+                , instruction LoadAddr [Register regTapeBase, LabelRef "tape"] 0
+                , instruction LoadImm [Register regTapePtr, Immediate 0] 1
+                ]
+        (nextId, _, bodyProgram) = compileProgram config 2 0 initialProgram ops
+     in appendInstruction bodyProgram (instruction Halt [] nextId)
+
+regTapeBase :: Int
+regTapeBase = 0
+
+regTapePtr :: Int
+regTapePtr = 1
+
+regTemp :: Int
+regTemp = 2
+
+regSysArg :: Int
+regSysArg = 4
+
+syscallWrite :: Integer
+syscallWrite = 1
+
+syscallRead :: Integer
+syscallRead = 2
+
+compileProgram :: BuildConfig -> Int -> Int -> IrProgram -> [BrainfuckOp] -> (Int, Int, IrProgram)
+compileProgram config nextId loopIndex program ops =
+    foldl step (nextId, loopIndex, program) ops
+  where
+    step (ident, currentLoop, currentProgram) op =
+        compileOp config ident currentLoop currentProgram op
+
+compileOp :: BuildConfig -> Int -> Int -> IrProgram -> BrainfuckOp -> (Int, Int, IrProgram)
+compileOp config ident loopIndex program op =
+    case op of
+        MoveRight ->
+            emitOne ident loopIndex program (instruction AddImm [Register regTapePtr, Register regTapePtr, Immediate 1] ident)
+        MoveLeft ->
+            emitOne ident loopIndex program (instruction AddImm [Register regTapePtr, Register regTapePtr, Immediate (-1)] ident)
+        Increment ->
+            emitCellMutation config ident loopIndex program 1
+        Decrement ->
+            emitCellMutation config ident loopIndex program (-1)
+        Output ->
+            emitMany
+                ident
+                loopIndex
+                program
+                [ instruction LoadByte [Register regTemp, Register regTapeBase, Register regTapePtr] ident
+                , instruction AddImm [Register regSysArg, Register regTemp, Immediate 0] (ident + 1)
+                , instruction Syscall [Immediate syscallWrite] (ident + 2)
+                ]
+        Input ->
+            emitMany
+                ident
+                loopIndex
+                program
+                [ instruction Syscall [Immediate syscallRead] ident
+                , instruction StoreByte [Register regSysArg, Register regTapeBase, Register regTapePtr] (ident + 1)
+                ]
+        Loop body ->
+            let startLabel = "loop_" ++ show loopIndex ++ "_start"
+                endLabel = "loop_" ++ show loopIndex ++ "_end"
+                withHeader =
+                    appendMany
+                        program
+                        [ instruction Label [LabelRef startLabel] (-1)
+                        , instruction LoadByte [Register regTemp, Register regTapeBase, Register regTapePtr] ident
+                        , instruction BranchZ [Register regTemp, LabelRef endLabel] (ident + 1)
+                        ]
+                (afterBodyId, afterBodyLoop, afterBodyProgram) = compileProgram config (ident + 2) (loopIndex + 1) withHeader body
+                withBackedge =
+                    appendMany
+                        afterBodyProgram
+                        [ instruction Jump [LabelRef startLabel] afterBodyId
+                        , instruction Label [LabelRef endLabel] (-1)
+                        ]
+             in (afterBodyId + 1, afterBodyLoop, withBackedge)
+
+emitCellMutation :: BuildConfig -> Int -> Int -> IrProgram -> Integer -> (Int, Int, IrProgram)
+emitCellMutation config ident loopIndex program delta =
+    emitMany ident loopIndex program instructions
+  where
+    instructions =
+        [ instruction LoadByte [Register regTemp, Register regTapeBase, Register regTapePtr] ident
+        , instruction AddImm [Register regTemp, Register regTemp, Immediate delta] (ident + 1)
+        ]
+            ++ [instruction AndImm [Register regTemp, Register regTemp, Immediate 255] (ident + 2) | buildConfigMaskByteArithmetic config]
+            ++ [instruction StoreByte [Register regTemp, Register regTapeBase, Register regTapePtr] (ident + if buildConfigMaskByteArithmetic config then 3 else 2)]
+
+emitOne :: Int -> Int -> IrProgram -> IrInstruction -> (Int, Int, IrProgram)
+emitOne ident loopIndex program inst =
+    (ident + 1, loopIndex, appendInstruction program inst)
+
+emitMany :: Int -> Int -> IrProgram -> [IrInstruction] -> (Int, Int, IrProgram)
+emitMany ident loopIndex program instructions =
+    (ident + length instructions, loopIndex, appendMany program instructions)
+
+appendMany :: IrProgram -> [IrInstruction] -> IrProgram
+appendMany = foldl appendInstruction

--- a/code/packages/haskell/brainfuck-ir-compiler/test/BrainfuckIRCompilerSpec.hs
+++ b/code/packages/haskell/brainfuck-ir-compiler/test/BrainfuckIRCompilerSpec.hs
@@ -1,0 +1,25 @@
+module BrainfuckIRCompilerSpec (spec) where
+
+import BrainfuckIRCompiler
+import CompilerIR
+import Test.Hspec
+
+spec :: Spec
+spec = describe "BrainfuckIRCompiler" $ do
+    it "lowers Brainfuck tape operations into semantic IR" $ do
+        result <- unwrapEither (compileSource "++[>+<-]")
+        let program = compileResultProgram result
+            ops = map irOpcode (irInstructions program)
+        irEntryLabel program `shouldBe` "_start"
+        irDataDecls program `shouldBe` [IrDataDecl "tape" 30000 0]
+        ops `shouldSatisfy` \opcodes ->
+            all (`elem` opcodes) [LoadAddr, LoadByte, StoreByte, BranchZ, Jump, Halt]
+
+    it "surfaces parser errors" $ do
+        compileSource "[" `shouldSatisfy` either (const True) (const False)
+
+unwrapEither :: Show err => Either err value -> IO value
+unwrapEither result =
+    case result of
+        Left err -> expectationFailure (show err) >> error "unreachable after expectationFailure"
+        Right value -> pure value

--- a/code/packages/haskell/brainfuck-ir-compiler/test/Spec.hs
+++ b/code/packages/haskell/brainfuck-ir-compiler/test/Spec.hs
@@ -1,0 +1,5 @@
+import qualified BrainfuckIRCompilerSpec
+import Test.Hspec
+
+main :: IO ()
+main = hspec BrainfuckIRCompilerSpec.spec

--- a/code/packages/haskell/brainfuck-wasm-compiler/BUILD
+++ b/code/packages/haskell/brainfuck-wasm-compiler/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/brainfuck-wasm-compiler/BUILD_windows
+++ b/code/packages/haskell/brainfuck-wasm-compiler/BUILD_windows
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/brainfuck-wasm-compiler/CHANGELOG.md
+++ b/code/packages/haskell/brainfuck-wasm-compiler/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add the Haskell Brainfuck-to-Wasm orchestration package.

--- a/code/packages/haskell/brainfuck-wasm-compiler/README.md
+++ b/code/packages/haskell/brainfuck-wasm-compiler/README.md
@@ -1,0 +1,5 @@
+# brainfuck-wasm-compiler
+
+Haskell `brainfuck-wasm-compiler` connects the local Brainfuck frontend, the
+local compiler IR, the Haskell IR optimizer, the Haskell IR-to-Wasm lowerer,
+the Wasm validator, and the Wasm encoder into one source-to-bytes package.

--- a/code/packages/haskell/brainfuck-wasm-compiler/brainfuck-wasm-compiler.cabal
+++ b/code/packages/haskell/brainfuck-wasm-compiler/brainfuck-wasm-compiler.cabal
@@ -1,0 +1,39 @@
+cabal-version: 3.0
+name:          brainfuck-wasm-compiler
+version:       0.1.0
+synopsis:      Haskell Brainfuck to WebAssembly orchestrator
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  BrainfuckWasmCompiler
+    build-depends:    base >=4.14
+                    , brainfuck
+                    , brainfuck-ir-compiler
+                    , bytestring
+                    , compiler-ir
+                    , ir-optimizer
+                    , ir-to-wasm-compiler
+                    , ir-to-wasm-validator
+                    , wasm-module-encoder
+                    , wasm-types
+                    , wasm-validator
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    BrainfuckWasmCompilerSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , brainfuck-wasm-compiler
+                    , bytestring
+                    , directory
+                    , filepath
+                    , hspec == 2.*
+                    , wasm-execution
+                    , wasm-runtime
+    default-language: Haskell2010

--- a/code/packages/haskell/brainfuck-wasm-compiler/cabal.project
+++ b/code/packages/haskell/brainfuck-wasm-compiler/cabal.project
@@ -1,0 +1,16 @@
+packages:
+  .
+  ../compiler-ir
+  ../brainfuck
+  ../brainfuck-ir-compiler
+  ../ir-optimizer
+  ../ir-to-wasm-validator
+  ../wasm-leb128
+  ../wasm-types
+  ../wasm-module-encoder
+  ../wasm-module-parser
+  ../wasm-opcodes
+  ../wasm-execution
+  ../wasm-validator
+  ../wasm-runtime
+  ../ir-to-wasm-compiler

--- a/code/packages/haskell/brainfuck-wasm-compiler/src/BrainfuckWasmCompiler.hs
+++ b/code/packages/haskell/brainfuck-wasm-compiler/src/BrainfuckWasmCompiler.hs
@@ -1,0 +1,82 @@
+module BrainfuckWasmCompiler
+    ( description
+    , PackageError(..)
+    , PackageResult(..)
+    , compileSource
+    , packSource
+    , writeWasmFile
+    ) where
+
+import qualified Data.ByteString as BS
+import Data.ByteString (ByteString)
+import Brainfuck (BrainfuckOp)
+import qualified BrainfuckIRCompiler
+import CompilerIR hiding (description)
+import IRToWasmCompiler hiding (description)
+import IRToWasmValidator hiding (description)
+import IROptimizer hiding (description)
+import WasmModuleEncoder hiding (description)
+import WasmTypes hiding (description)
+import WasmValidator hiding (description)
+
+description :: String
+description = "Haskell Brainfuck to WebAssembly orchestration package"
+
+data PackageError = PackageError
+    { packageErrorStage :: String
+    , packageErrorMessage :: String
+    }
+    deriving (Eq, Show)
+
+data PackageResult = PackageResult
+    { resultSource :: String
+    , resultAst :: [BrainfuckOp]
+    , resultRawIr :: IrProgram
+    , resultOptimizedIr :: IrProgram
+    , resultModule :: WasmModule
+    , resultValidatedModule :: ValidatedModule
+    , resultBytes :: ByteString
+    , resultWasmPath :: Maybe FilePath
+    }
+    deriving (Eq, Show)
+
+compileSource :: String -> Either PackageError PackageResult
+compileSource source = do
+    compiled <- mapLeft "parse" (BrainfuckIRCompiler.compileSource source)
+    let rawIr = BrainfuckIRCompiler.compileResultProgram compiled
+        optimizedIr = optimizationProgram (optimizeProgram rawIr)
+        signatures = [FunctionSignature "_start" 0 (Just "_start")]
+    case validateProgram optimizedIr of
+        [] -> pure ()
+        errors -> Left (PackageError "validate-ir" (show errors))
+    moduleValue <- mapLeft "lower" (compileProgram optimizedIr signatures)
+    validated <- mapLeft "validate-wasm" (validateModule moduleValue)
+    bytesValue <- mapLeft "encode" (encodeModule moduleValue)
+    Right
+        PackageResult
+            { resultSource = source
+            , resultAst = BrainfuckIRCompiler.compileResultAst compiled
+            , resultRawIr = rawIr
+            , resultOptimizedIr = optimizedIr
+            , resultModule = moduleValue
+            , resultValidatedModule = validated
+            , resultBytes = bytesValue
+            , resultWasmPath = Nothing
+            }
+
+packSource :: String -> Either PackageError PackageResult
+packSource = compileSource
+
+writeWasmFile :: String -> FilePath -> IO (Either PackageError PackageResult)
+writeWasmFile source path =
+    case compileSource source of
+        Left err -> pure (Left err)
+        Right result -> do
+            BS.writeFile path (resultBytes result)
+            pure (Right result {resultWasmPath = Just path})
+
+mapLeft :: Show err => String -> Either err value -> Either PackageError value
+mapLeft stage result =
+    case result of
+        Left err -> Left (PackageError stage (show err))
+        Right value -> Right value

--- a/code/packages/haskell/brainfuck-wasm-compiler/test/BrainfuckWasmCompilerSpec.hs
+++ b/code/packages/haskell/brainfuck-wasm-compiler/test/BrainfuckWasmCompilerSpec.hs
@@ -1,0 +1,41 @@
+module BrainfuckWasmCompilerSpec (spec) where
+
+import qualified Data.ByteString as BS
+import BrainfuckWasmCompiler
+import System.Directory
+import System.FilePath
+import Test.Hspec
+import WasmRuntime
+
+spec :: Spec
+spec = describe "BrainfuckWasmCompiler" $ do
+    it "compiles source into Wasm bytes" $ do
+        result <- unwrapEither (compileSource "++>+")
+        resultBytes result `shouldSatisfy` (not . BS.null)
+
+    it "lowers structured Brainfuck loops into Wasm bytes" $ do
+        result <- unwrapEither (compileSource "++[>+<-]")
+        resultBytes result `shouldSatisfy` (not . BS.null)
+
+    it "aliases packSource to compileSource" $ do
+        compiled <- unwrapEither (compileSource "+")
+        packed <- unwrapEither (packSource "+")
+        resultBytes packed `shouldBe` resultBytes compiled
+
+    it "writes Wasm bytes" $ do
+        tempDir <- getTemporaryDirectory
+        let path = tempDir </> "haskell-brainfuck-smoke.wasm"
+        result <- writeWasmFile "+" path >>= unwrapEither
+        resultWasmPath result `shouldBe` Just path
+        doesFileExist path `shouldReturn` True
+
+    it "runs emitted tape-mutating code through the local runtime" $ do
+        result <- unwrapEither (compileSource "+")
+        runResult <- loadAndRun (newRuntime Nothing) (resultBytes result) "_start" []
+        runResult `shouldBe` Right []
+
+unwrapEither :: Show err => Either err value -> IO value
+unwrapEither result =
+    case result of
+        Left err -> expectationFailure (show err) >> error "unreachable after expectationFailure"
+        Right value -> pure value

--- a/code/packages/haskell/brainfuck-wasm-compiler/test/Spec.hs
+++ b/code/packages/haskell/brainfuck-wasm-compiler/test/Spec.hs
@@ -1,0 +1,5 @@
+import qualified BrainfuckWasmCompilerSpec
+import Test.Hspec
+
+main :: IO ()
+main = hspec BrainfuckWasmCompilerSpec.spec

--- a/code/packages/haskell/brainfuck/BUILD
+++ b/code/packages/haskell/brainfuck/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/brainfuck/BUILD_windows
+++ b/code/packages/haskell/brainfuck/BUILD_windows
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/brainfuck/CHANGELOG.md
+++ b/code/packages/haskell/brainfuck/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add a Haskell Brainfuck tokenizer/parser package for compiler pipeline
+  convergence.

--- a/code/packages/haskell/brainfuck/README.md
+++ b/code/packages/haskell/brainfuck/README.md
@@ -1,0 +1,5 @@
+# brainfuck
+
+Haskell Brainfuck provides a tiny local frontend for the eight Brainfuck
+instructions. It filters comments, validates loop balance, and returns a nested
+AST used by the Haskell IR compiler package.

--- a/code/packages/haskell/brainfuck/brainfuck.cabal
+++ b/code/packages/haskell/brainfuck/brainfuck.cabal
@@ -1,0 +1,24 @@
+cabal-version: 3.0
+name:          brainfuck
+version:       0.1.0
+synopsis:      Haskell Brainfuck frontend
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  Brainfuck
+    build-depends:    base >=4.14
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    BrainfuckSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , brainfuck
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/brainfuck/cabal.project
+++ b/code/packages/haskell/brainfuck/cabal.project
@@ -1,0 +1,2 @@
+packages:
+  .

--- a/code/packages/haskell/brainfuck/src/Brainfuck.hs
+++ b/code/packages/haskell/brainfuck/src/Brainfuck.hs
@@ -1,0 +1,77 @@
+module Brainfuck
+    ( description
+    , BrainfuckOp(..)
+    , BrainfuckError(..)
+    , tokenize
+    , parseSource
+    ) where
+
+description :: String
+description = "Haskell Brainfuck frontend for compiler convergence"
+
+data BrainfuckOp
+    = MoveRight
+    | MoveLeft
+    | Increment
+    | Decrement
+    | Output
+    | Input
+    | Loop [BrainfuckOp]
+    deriving (Eq, Show)
+
+data BrainfuckError = BrainfuckError
+    { brainfuckErrorMessage :: String
+    , brainfuckErrorOffset :: Int
+    }
+    deriving (Eq, Show)
+
+tokenize :: String -> String
+tokenize = filter (`elem` "><+-.,[]")
+
+parseSource :: String -> Either BrainfuckError [BrainfuckOp]
+parseSource source =
+    case parseMany 0 (tokenize source) of
+        Left err -> Left err
+        Right (ops, rest, offset) ->
+            case rest of
+                [] -> Right ops
+                ']' : _ ->
+                    Left
+                        BrainfuckError
+                            { brainfuckErrorMessage = "unmatched closing bracket"
+                            , brainfuckErrorOffset = offset
+                            }
+                _ -> Right ops
+
+parseMany :: Int -> String -> Either BrainfuckError ([BrainfuckOp], String, Int)
+parseMany offset input =
+    go offset input []
+  where
+    go current rest acc =
+        case rest of
+            [] -> Right (acc, [], current)
+            ']' : _ -> Right (acc, rest, current)
+            '[' : more ->
+                case parseMany (current + 1) more of
+                    Left err -> Left err
+                    Right (body, afterBody, afterOffset) ->
+                        case afterBody of
+                            ']' : finalRest -> go (afterOffset + 1) finalRest (acc ++ [Loop body])
+                            _ ->
+                                Left
+                                    BrainfuckError
+                                        { brainfuckErrorMessage = "unmatched opening bracket"
+                                        , brainfuckErrorOffset = current
+                                        }
+            ch : more -> go (current + 1) more (acc ++ [toOp ch])
+
+toOp :: Char -> BrainfuckOp
+toOp ch =
+    case ch of
+        '>' -> MoveRight
+        '<' -> MoveLeft
+        '+' -> Increment
+        '-' -> Decrement
+        '.' -> Output
+        ',' -> Input
+        _ -> error "toOp called with non-Brainfuck token"

--- a/code/packages/haskell/brainfuck/test/BrainfuckSpec.hs
+++ b/code/packages/haskell/brainfuck/test/BrainfuckSpec.hs
@@ -1,0 +1,15 @@
+module BrainfuckSpec (spec) where
+
+import Brainfuck
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Brainfuck" $ do
+    it "filters comments during tokenization" $ do
+        tokenize "++ hello >." `shouldBe` "++>."
+
+    it "parses nested loops" $ do
+        parseSource "+[->+<]" `shouldBe` Right [Increment, Loop [Decrement, MoveRight, Increment, MoveLeft]]
+
+    it "rejects unbalanced loops" $ do
+        parseSource "+[" `shouldSatisfy` either (const True) (const False)

--- a/code/packages/haskell/brainfuck/test/Spec.hs
+++ b/code/packages/haskell/brainfuck/test/Spec.hs
@@ -1,0 +1,5 @@
+import qualified BrainfuckSpec
+import Test.Hspec
+
+main :: IO ()
+main = hspec BrainfuckSpec.spec

--- a/code/packages/haskell/compiler-ir/BUILD
+++ b/code/packages/haskell/compiler-ir/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/compiler-ir/BUILD_windows
+++ b/code/packages/haskell/compiler-ir/BUILD_windows
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/compiler-ir/CHANGELOG.md
+++ b/code/packages/haskell/compiler-ir/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add the Haskell `compiler-ir` package with a small register-based IR used by
+  source-to-Wasm convergence packages.

--- a/code/packages/haskell/compiler-ir/README.md
+++ b/code/packages/haskell/compiler-ir/README.md
@@ -1,0 +1,8 @@
+# compiler-ir
+
+Haskell `compiler-ir` defines the tiny register-based intermediate
+representation shared by the Haskell Brainfuck and Nib compiler pipelines.
+
+The package is intentionally small: instructions carry an opcode, operands, and
+a stable id; programs carry data declarations, an entry label, and a linear
+instruction stream.

--- a/code/packages/haskell/compiler-ir/cabal.project
+++ b/code/packages/haskell/compiler-ir/cabal.project
@@ -1,0 +1,2 @@
+packages:
+  .

--- a/code/packages/haskell/compiler-ir/compiler-ir.cabal
+++ b/code/packages/haskell/compiler-ir/compiler-ir.cabal
@@ -1,0 +1,24 @@
+cabal-version: 3.0
+name:          compiler-ir
+version:       0.1.0
+synopsis:      Haskell register-based compiler intermediate representation
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  CompilerIR
+    build-depends:    base >=4.14
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    CompilerIRSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , compiler-ir
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/compiler-ir/src/CompilerIR.hs
+++ b/code/packages/haskell/compiler-ir/src/CompilerIR.hs
@@ -1,0 +1,91 @@
+module CompilerIR
+    ( description
+    , IrOp(..)
+    , IrOperand(..)
+    , IrInstruction(..)
+    , IrDataDecl(..)
+    , IrProgram(..)
+    , emptyProgram
+    , appendInstruction
+    , instruction
+    , maxRegister
+    ) where
+
+description :: String
+description = "Haskell compiler IR for source-to-Wasm pipeline packages"
+
+data IrOp
+    = Comment
+    | Label
+    | LoadImm
+    | LoadAddr
+    | LoadByte
+    | StoreByte
+    | Add
+    | AddImm
+    | Sub
+    | And
+    | AndImm
+    | Jump
+    | BranchZ
+    | BranchNz
+    | Call
+    | Ret
+    | Syscall
+    | Halt
+    | Nop
+    deriving (Eq, Ord, Show)
+
+data IrOperand
+    = Register Int
+    | Immediate Integer
+    | LabelRef String
+    deriving (Eq, Ord, Show)
+
+data IrInstruction = IrInstruction
+    { irOpcode :: IrOp
+    , irOperands :: [IrOperand]
+    , irInstructionId :: Int
+    }
+    deriving (Eq, Ord, Show)
+
+data IrDataDecl = IrDataDecl
+    { irDataLabel :: String
+    , irDataSize :: Int
+    , irDataInit :: Int
+    }
+    deriving (Eq, Ord, Show)
+
+data IrProgram = IrProgram
+    { irEntryLabel :: String
+    , irInstructions :: [IrInstruction]
+    , irDataDecls :: [IrDataDecl]
+    }
+    deriving (Eq, Ord, Show)
+
+emptyProgram :: String -> IrProgram
+emptyProgram entryLabel =
+    IrProgram
+        { irEntryLabel = entryLabel
+        , irInstructions = []
+        , irDataDecls = []
+        }
+
+appendInstruction :: IrProgram -> IrInstruction -> IrProgram
+appendInstruction program inst =
+    program {irInstructions = irInstructions program ++ [inst]}
+
+instruction :: IrOp -> [IrOperand] -> Int -> IrInstruction
+instruction opcode operands ident =
+    IrInstruction
+        { irOpcode = opcode
+        , irOperands = operands
+        , irInstructionId = ident
+        }
+
+maxRegister :: IrProgram -> Int
+maxRegister program =
+    maximum (0 : concatMap instructionRegisters (irInstructions program))
+  where
+    instructionRegisters inst =
+        [register | Register register <- irOperands inst]

--- a/code/packages/haskell/compiler-ir/test/CompilerIRSpec.hs
+++ b/code/packages/haskell/compiler-ir/test/CompilerIRSpec.hs
@@ -1,0 +1,17 @@
+module CompilerIRSpec (spec) where
+
+import CompilerIR
+import Test.Hspec
+
+spec :: Spec
+spec = describe "CompilerIR" $ do
+    it "stores linear instructions" $ do
+        let program =
+                appendInstruction
+                    (emptyProgram "_start")
+                    (instruction LoadImm [Register 1, Immediate 7] 0)
+        irEntryLabel program `shouldBe` "_start"
+        maxRegister program `shouldBe` 1
+
+    it "describes the package" $ do
+        description `shouldSatisfy` (not . null)

--- a/code/packages/haskell/compiler-ir/test/Spec.hs
+++ b/code/packages/haskell/compiler-ir/test/Spec.hs
@@ -1,0 +1,5 @@
+import qualified CompilerIRSpec
+import Test.Hspec
+
+main :: IO ()
+main = hspec CompilerIRSpec.spec

--- a/code/packages/haskell/ir-optimizer/BUILD
+++ b/code/packages/haskell/ir-optimizer/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/ir-optimizer/BUILD_windows
+++ b/code/packages/haskell/ir-optimizer/BUILD_windows
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/ir-optimizer/CHANGELOG.md
+++ b/code/packages/haskell/ir-optimizer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add a conservative no-op optimizer wrapper for Haskell IR pipelines.

--- a/code/packages/haskell/ir-optimizer/README.md
+++ b/code/packages/haskell/ir-optimizer/README.md
@@ -1,0 +1,5 @@
+# ir-optimizer
+
+Haskell `ir-optimizer` currently exposes the same stage boundary as the other
+language lanes while preserving programs exactly. Later Haskell passes can slot
+behind the same result type without changing orchestrators.

--- a/code/packages/haskell/ir-optimizer/cabal.project
+++ b/code/packages/haskell/ir-optimizer/cabal.project
@@ -1,0 +1,3 @@
+packages:
+  .
+  ../compiler-ir

--- a/code/packages/haskell/ir-optimizer/ir-optimizer.cabal
+++ b/code/packages/haskell/ir-optimizer/ir-optimizer.cabal
@@ -1,0 +1,26 @@
+cabal-version: 3.0
+name:          ir-optimizer
+version:       0.1.0
+synopsis:      Haskell compiler IR optimization stage
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  IROptimizer
+    build-depends:    base >=4.14
+                    , compiler-ir
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    IROptimizerSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , compiler-ir
+                    , hspec == 2.*
+                    , ir-optimizer
+    default-language: Haskell2010

--- a/code/packages/haskell/ir-optimizer/src/IROptimizer.hs
+++ b/code/packages/haskell/ir-optimizer/src/IROptimizer.hs
@@ -1,0 +1,23 @@
+module IROptimizer
+    ( description
+    , OptimizationResult(..)
+    , optimizeProgram
+    ) where
+
+import CompilerIR hiding (description)
+
+description :: String
+description = "Haskell no-op optimization stage for compiler IR"
+
+data OptimizationResult = OptimizationResult
+    { optimizationProgram :: IrProgram
+    , optimizationChanged :: Bool
+    }
+    deriving (Eq, Show)
+
+optimizeProgram :: IrProgram -> OptimizationResult
+optimizeProgram program =
+    OptimizationResult
+        { optimizationProgram = program
+        , optimizationChanged = False
+        }

--- a/code/packages/haskell/ir-optimizer/test/IROptimizerSpec.hs
+++ b/code/packages/haskell/ir-optimizer/test/IROptimizerSpec.hs
@@ -1,0 +1,13 @@
+module IROptimizerSpec (spec) where
+
+import CompilerIR
+import IROptimizer
+import Test.Hspec
+
+spec :: Spec
+spec = describe "IROptimizer" $ do
+    it "preserves programs for the initial convergence pass" $ do
+        let program = appendInstruction (emptyProgram "_start") (instruction Halt [] 0)
+            result = optimizeProgram program
+        optimizationProgram result `shouldBe` program
+        optimizationChanged result `shouldBe` False

--- a/code/packages/haskell/ir-optimizer/test/Spec.hs
+++ b/code/packages/haskell/ir-optimizer/test/Spec.hs
@@ -1,0 +1,5 @@
+import qualified IROptimizerSpec
+import Test.Hspec
+
+main :: IO ()
+main = hspec IROptimizerSpec.spec

--- a/code/packages/haskell/ir-to-wasm-compiler/BUILD
+++ b/code/packages/haskell/ir-to-wasm-compiler/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/ir-to-wasm-compiler/BUILD_windows
+++ b/code/packages/haskell/ir-to-wasm-compiler/BUILD_windows
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/ir-to-wasm-compiler/CHANGELOG.md
+++ b/code/packages/haskell/ir-to-wasm-compiler/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add a Haskell IR-to-Wasm lowerer for function-oriented convergence programs.

--- a/code/packages/haskell/ir-to-wasm-compiler/README.md
+++ b/code/packages/haskell/ir-to-wasm-compiler/README.md
@@ -1,0 +1,5 @@
+# ir-to-wasm-compiler
+
+Haskell `ir-to-wasm-compiler` lowers the local `compiler-ir` function subset
+into `wasm-types` modules. It currently supports labels, integer arithmetic,
+calls, returns, and exported function signatures.

--- a/code/packages/haskell/ir-to-wasm-compiler/cabal.project
+++ b/code/packages/haskell/ir-to-wasm-compiler/cabal.project
@@ -1,0 +1,11 @@
+packages:
+  .
+  ../compiler-ir
+  ../wasm-leb128
+  ../wasm-types
+  ../wasm-module-encoder
+  ../wasm-module-parser
+  ../wasm-opcodes
+  ../wasm-execution
+  ../wasm-validator
+  ../wasm-runtime

--- a/code/packages/haskell/ir-to-wasm-compiler/ir-to-wasm-compiler.cabal
+++ b/code/packages/haskell/ir-to-wasm-compiler/ir-to-wasm-compiler.cabal
@@ -1,0 +1,37 @@
+cabal-version: 3.0
+name:          ir-to-wasm-compiler
+version:       0.1.0
+synopsis:      Haskell compiler IR to WebAssembly lowerer
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  IRToWasmCompiler
+    build-depends:    base >=4.14
+                    , bytestring
+                    , compiler-ir
+                    , containers
+                    , wasm-leb128
+                    , wasm-types
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    IRToWasmCompilerSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , bytestring
+                    , compiler-ir
+                    , containers
+                    , hspec == 2.*
+                    , ir-to-wasm-compiler
+                    , wasm-execution
+                    , wasm-module-encoder
+                    , wasm-runtime
+                    , wasm-types
+                    , wasm-validator
+    default-language: Haskell2010

--- a/code/packages/haskell/ir-to-wasm-compiler/src/IRToWasmCompiler.hs
+++ b/code/packages/haskell/ir-to-wasm-compiler/src/IRToWasmCompiler.hs
@@ -1,0 +1,483 @@
+module IRToWasmCompiler
+    ( description
+    , FunctionSignature(..)
+    , LoweringError(..)
+    , compileProgram
+    ) where
+
+import qualified Data.ByteString as BS
+import Data.ByteString (ByteString)
+import qualified Data.List as List
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
+import CompilerIR hiding (description)
+import WasmLeb128 (encodeSigned, encodeUnsigned)
+import WasmTypes hiding (description)
+
+description :: String
+description = "Haskell compiler IR to WebAssembly lowerer"
+
+data FunctionSignature = FunctionSignature
+    { signatureLabel :: String
+    , signatureParamCount :: Int
+    , signatureExportName :: Maybe String
+    }
+    deriving (Eq, Ord, Show)
+
+data LoweringError = LoweringError
+    { loweringErrorMessage :: String
+    }
+    deriving (Eq, Show)
+
+data FunctionIR = FunctionIR
+    { functionLabel :: String
+    , functionInstructions :: [IrInstruction]
+    , functionSignature :: FunctionSignature
+    }
+    deriving (Eq, Show)
+
+data WasiImport = WasiImport
+    { wasiSyscallNumber :: Integer
+    , wasiImportName :: String
+    , wasiImportType :: FuncType
+    }
+    deriving (Eq, Show)
+
+data LoweringContext = LoweringContext
+    { contextFunctionIndices :: Map String Integer
+    , contextAllFunctions :: [FunctionIR]
+    , contextDataOffsets :: Map String Integer
+    , contextWasiImports :: Map Integer Integer
+    , contextWasiScratchBase :: Maybe Integer
+    }
+    deriving (Eq, Show)
+
+regSysArg :: Int
+regSysArg = 4
+
+regSysScratch :: Int
+regSysScratch = 7
+
+syscallWrite :: Integer
+syscallWrite = 1
+
+syscallRead :: Integer
+syscallRead = 2
+
+syscallExit :: Integer
+syscallExit = 10
+
+wasiScratchSize :: Integer
+wasiScratchSize = 16
+
+compileProgram :: IrProgram -> [FunctionSignature] -> Either LoweringError WasmModule
+compileProgram program extraSignatures = do
+    functions <- splitFunctions program signatures
+    importsValue <- collectWasiImports program
+    let importedTypes = map wasiImportType importsValue
+        localTypes = map functionType functions
+        functionTypeStart = toInteger (length importedTypes)
+        functionIndices =
+            Map.fromList
+                [ (functionLabel functionValue, toInteger indexValue + toInteger (length importsValue))
+                | (functionValue, indexValue) <- zip functions [0 :: Int ..]
+                ]
+        wasiImportIndices =
+            Map.fromList
+                [ (wasiSyscallNumber importValue, toInteger indexValue)
+                | (importValue, indexValue) <- zip importsValue [0 :: Int ..]
+                ]
+        dataOffsets = layoutData (irDataDecls program)
+        scratchBase =
+            if needsWasiScratch program
+                then Just (alignUp (totalDataSize (irDataDecls program)) 4)
+                else Nothing
+        memoryByteCount =
+            maybe (totalDataSize (irDataDecls program)) (+ wasiScratchSize) scratchBase
+        memoryExports =
+            [Export "memory" ExternalMemory 0 | needsMemory program || scratchBase /= Nothing]
+        functionExports =
+            [ Export exportLabel ExternalFunction indexValue
+            | functionValue <- functions
+            , Just exportLabel <- [signatureExportName (functionSignature functionValue)]
+            , Just indexValue <- [Map.lookup (functionLabel functionValue) functionIndices]
+            ]
+        context =
+            LoweringContext
+                { contextFunctionIndices = functionIndices
+                , contextAllFunctions = functions
+                , contextDataOffsets = dataOffsets
+                , contextWasiImports = wasiImportIndices
+                , contextWasiScratchBase = scratchBase
+                }
+    bodies <- mapM (lowerFunction context) functions
+    Right
+        emptyModule
+            { wasmTypes = importedTypes ++ localTypes
+            , wasmImports =
+                [ Import "wasi_snapshot_preview1" (wasiImportName importValue) ExternalFunction (ImportFunctionType (toInteger indexValue))
+                | (importValue, indexValue) <- zip importsValue [0 :: Int ..]
+                ]
+            , wasmFunctions = [functionTypeStart .. functionTypeStart + toInteger (length functions) - 1]
+            , wasmMemories = [MemoryType (Limits (pagesFor memoryByteCount) Nothing) | needsMemory program || scratchBase /= Nothing]
+            , wasmExports = memoryExports ++ functionExports
+            , wasmCode = bodies
+            , wasmDataSegments =
+                [ DataSegment 0 (constExpr offset) (BS.replicate sizeValue (fromIntegral initValue))
+                | decl <- irDataDecls program
+                , let offset = Map.findWithDefault 0 (irDataLabel decl) dataOffsets
+                , let sizeValue = irDataSize decl
+                , let initValue = irDataInit decl
+                ]
+            }
+  where
+    signatures = Map.union (Map.fromList [(signatureLabel sig, sig) | sig <- extraSignatures]) (inferSignatures program)
+
+inferSignatures :: IrProgram -> Map String FunctionSignature
+inferSignatures program =
+    Map.fromList
+        [ (labelName, FunctionSignature labelName 0 (Just labelName))
+        | IrInstruction Label [LabelRef labelName] _ <- irInstructions program
+        , labelName == irEntryLabel program
+        ]
+
+splitFunctions :: IrProgram -> Map String FunctionSignature -> Either LoweringError [FunctionIR]
+splitFunctions program signatures =
+    Right (finish (foldl step ([], Nothing) (irInstructions program)))
+  where
+    finish (done, Nothing) = done
+    finish (done, Just current) = done ++ [current]
+    isFunctionLabel labelName = Map.member labelName signatures || labelName == irEntryLabel program || "_fn_" `List.isPrefixOf` labelName
+    step (done, current) inst =
+        case inst of
+            IrInstruction Label [LabelRef labelName] _
+                | isFunctionLabel labelName ->
+                    let signatureValue =
+                            Map.findWithDefault
+                                (FunctionSignature labelName 0 (Just labelName))
+                                labelName
+                                signatures
+                        nextFunction = FunctionIR labelName [] signatureValue
+                     in (maybe done (\functionValue -> done ++ [functionValue]) current, Just nextFunction)
+            _ ->
+                case current of
+                    Nothing -> (done, current)
+                    Just functionValue ->
+                        (done, Just functionValue {functionInstructions = functionInstructions functionValue ++ [inst]})
+
+functionType :: FunctionIR -> FuncType
+functionType functionValue =
+    let params = replicate (signatureParamCount (functionSignature functionValue)) I32
+        results =
+            if functionLabel functionValue == "_start"
+                then []
+                else [I32]
+     in FuncType params results
+
+lowerFunction :: LoweringContext -> FunctionIR -> Either LoweringError FunctionBody
+lowerFunction context functionValue = do
+    body <- lowerRegion context functionValue labels 0 (length instructions)
+    let localCount = maximum (0 : map instructionMaxRegister instructions ++ syscallRegisters) + 1
+    Right (FunctionBody (replicate localCount I32) (body <> BS.pack [0x0B]))
+  where
+    instructions = functionInstructions functionValue
+    labels =
+        Map.fromList
+            [ (labelName, indexValue)
+            | (inst, indexValue) <- zip instructions [0 :: Int ..]
+            , IrInstruction Label [LabelRef labelName] _ <- [inst]
+            ]
+    syscallRegisters =
+        [regSysScratch | any ((== Syscall) . irOpcode) instructions]
+
+lowerRegion :: LoweringContext -> FunctionIR -> Map String Int -> Int -> Int -> Either LoweringError ByteString
+lowerRegion context functionValue labels startIndex endIndex =
+    go startIndex BS.empty
+  where
+    instructions = functionInstructions functionValue
+    go indexValue bytesValue
+        | indexValue >= endIndex = Right bytesValue
+        | otherwise =
+            case instructions !! indexValue of
+                IrInstruction Comment _ _ -> go (indexValue + 1) bytesValue
+                IrInstruction Label [LabelRef labelName] _
+                    | isLoopStart labelName -> do
+                        (loopBytes, nextIndex) <- lowerLoop context functionValue labels indexValue endIndex labelName
+                        go nextIndex (bytesValue <> loopBytes)
+                    | otherwise -> go (indexValue + 1) bytesValue
+                inst
+                    | irOpcode inst == Jump || irOpcode inst == BranchZ || irOpcode inst == BranchNz ->
+                        Left (LoweringError ("unexpected unstructured control flow in " ++ functionLabel functionValue))
+                    | otherwise -> do
+                        chunk <- lowerInstruction context functionValue inst
+                        go (indexValue + 1) (bytesValue <> chunk)
+
+lowerLoop :: LoweringContext -> FunctionIR -> Map String Int -> Int -> Int -> String -> Either LoweringError (ByteString, Int)
+lowerLoop context functionValue labels labelIndex regionEnd startLabel = do
+    endIndex <- requireLabel labels endLabel
+    branchIndex <- findFirstBranchToLabel instructions (labelIndex + 1) endIndex endLabel
+    backedgeIndex <- findLastJumpToLabel instructions (branchIndex + 1) endIndex startLabel
+    condReg <- branchRegister (instructions !! branchIndex)
+    preludeBytes <- lowerRegion context functionValue labels (labelIndex + 1) branchIndex
+    bodyBytes <- lowerRegion context functionValue labels (branchIndex + 1) backedgeIndex
+    let branchOp = irOpcode (instructions !! branchIndex)
+        conditionBytes =
+            localGet (localIndex functionValue condReg)
+                <> if branchOp == BranchZ then BS.pack [0x45] else BS.empty
+        loopBytes =
+            BS.pack [0x02, 0x40, 0x03, 0x40]
+                <> preludeBytes
+                <> conditionBytes
+                <> BS.pack [0x0D]
+                <> encodeUnsigned 1
+                <> bodyBytes
+                <> BS.pack [0x0C]
+                <> encodeUnsigned 0
+                <> BS.pack [0x0B, 0x0B]
+    if endIndex >= regionEnd
+        then Left (LoweringError ("loop end label " ++ endLabel ++ " escapes the current region"))
+        else Right (loopBytes, endIndex + 1)
+  where
+    instructions = functionInstructions functionValue
+    endLabel = matchingLoopEnd startLabel
+
+lowerInstruction :: LoweringContext -> FunctionIR -> IrInstruction -> Either LoweringError ByteString
+lowerInstruction context functionValue inst =
+    case (irOpcode inst, irOperands inst) of
+        (Comment, _) -> Right BS.empty
+        (Nop, []) -> Right (BS.pack [0x01])
+        (LoadImm, [Register dst, Immediate value]) ->
+            Right (i32Const value <> localSet (localIndex functionValue dst))
+        (LoadAddr, [Register dst, LabelRef labelName]) ->
+            case Map.lookup labelName (contextDataOffsets context) of
+                Nothing -> Left (LoweringError ("unknown data label " ++ labelName))
+                Just offset -> Right (i32Const offset <> localSet (localIndex functionValue dst))
+        (LoadByte, [Register dst, Register base, Register offset]) ->
+            Right (address functionValue base offset <> BS.pack [0x2D] <> memarg 0 0 <> localSet (localIndex functionValue dst))
+        (StoreByte, [Register src, Register base, Register offset]) ->
+            Right (address functionValue base offset <> localGet (localIndex functionValue src) <> BS.pack [0x3A] <> memarg 0 0)
+        (Add, [Register dst, Register lhs, Register rhs]) ->
+            Right (localGet (localIndex functionValue lhs) <> localGet (localIndex functionValue rhs) <> BS.pack [0x6A] <> localSet (localIndex functionValue dst))
+        (AddImm, [Register dst, Register src, Immediate value]) ->
+            Right (localGet (localIndex functionValue src) <> i32Const value <> BS.pack [0x6A] <> localSet (localIndex functionValue dst))
+        (Sub, [Register dst, Register lhs, Register rhs]) ->
+            Right (localGet (localIndex functionValue lhs) <> localGet (localIndex functionValue rhs) <> BS.pack [0x6B] <> localSet (localIndex functionValue dst))
+        (And, [Register dst, Register lhs, Register rhs]) ->
+            Right (localGet (localIndex functionValue lhs) <> localGet (localIndex functionValue rhs) <> BS.pack [0x71] <> localSet (localIndex functionValue dst))
+        (AndImm, [Register dst, Register src, Immediate value]) ->
+            Right (localGet (localIndex functionValue src) <> i32Const value <> BS.pack [0x71] <> localSet (localIndex functionValue dst))
+        (Call, [LabelRef labelName]) ->
+            case Map.lookup labelName (contextFunctionIndices context) of
+                Nothing -> Left (LoweringError ("unknown call target " ++ labelName))
+                Just indexValue ->
+                    let targetParamCount = maybe 0 (signatureParamCount . functionSignature) (findFunction labelName)
+                        args = BS.concat [localGet (localIndex functionValue register) | register <- take targetParamCount [2 ..]]
+                        storeResult =
+                            if labelName == "_start"
+                                then BS.empty
+                                else localSet (localIndex functionValue 1)
+                     in Right (args <> BS.pack [0x10] <> encodeUnsigned indexValue <> storeResult)
+        (Ret, []) ->
+            Right
+                ( if functionLabel functionValue == "_start"
+                    then BS.pack [0x0F]
+                    else localGet (localIndex functionValue 1) <> BS.pack [0x0F]
+                )
+        (Halt, []) -> Right (BS.pack [0x0F])
+        (Syscall, [Immediate number]) -> lowerSyscall context functionValue number
+        _ -> Left (LoweringError ("unsupported IR instruction " ++ show inst))
+  where
+    findFunction labelName =
+        List.find ((== labelName) . functionLabel) (contextAllFunctions context)
+
+lowerSyscall :: LoweringContext -> FunctionIR -> Integer -> Either LoweringError ByteString
+lowerSyscall context functionValue number =
+    case number of
+        1 -> do
+            scratch <- requireScratch context
+            indexValue <- requireWasiImport context syscallWrite
+            let iovecPtr = scratch
+                nwrittenPtr = scratch + 8
+                bytePtr = scratch + 12
+            Right
+                ( i32Const bytePtr
+                    <> localGet (localIndex functionValue regSysArg)
+                    <> BS.pack [0x3A]
+                    <> memarg 0 0
+                    <> storeConstI32 iovecPtr bytePtr
+                    <> storeConstI32 (iovecPtr + 4) 1
+                    <> i32Const 1
+                    <> i32Const iovecPtr
+                    <> i32Const 1
+                    <> i32Const nwrittenPtr
+                    <> BS.pack [0x10]
+                    <> encodeUnsigned indexValue
+                    <> localSet (localIndex functionValue regSysScratch)
+                )
+        2 -> do
+            scratch <- requireScratch context
+            indexValue <- requireWasiImport context syscallRead
+            let iovecPtr = scratch
+                nreadPtr = scratch + 8
+                bytePtr = scratch + 12
+            Right
+                ( i32Const bytePtr
+                    <> i32Const 0
+                    <> BS.pack [0x3A]
+                    <> memarg 0 0
+                    <> storeConstI32 iovecPtr bytePtr
+                    <> storeConstI32 (iovecPtr + 4) 1
+                    <> i32Const 0
+                    <> i32Const iovecPtr
+                    <> i32Const 1
+                    <> i32Const nreadPtr
+                    <> BS.pack [0x10]
+                    <> encodeUnsigned indexValue
+                    <> localSet (localIndex functionValue regSysScratch)
+                    <> i32Const bytePtr
+                    <> BS.pack [0x2D]
+                    <> memarg 0 0
+                    <> localSet (localIndex functionValue regSysArg)
+                )
+        10 -> do
+            indexValue <- requireWasiImport context syscallExit
+            Right (localGet (localIndex functionValue regSysArg) <> BS.pack [0x10] <> encodeUnsigned indexValue <> BS.pack [0x0F])
+        _ -> Left (LoweringError ("unsupported SYSCALL number " ++ show number))
+
+collectWasiImports :: IrProgram -> Either LoweringError [WasiImport]
+collectWasiImports program =
+    let required =
+            List.nub
+                [ number
+                | IrInstruction Syscall [Immediate number] _ <- irInstructions program
+                ]
+        unsupported = filter (`notElem` [syscallWrite, syscallRead, syscallExit]) required
+     in if null unsupported
+            then Right [entry | entry <- orderedWasiImports, wasiSyscallNumber entry `elem` required]
+            else Left (LoweringError ("unsupported SYSCALL number(s) " ++ show unsupported))
+
+orderedWasiImports :: [WasiImport]
+orderedWasiImports =
+    [ WasiImport syscallWrite "fd_write" (FuncType [I32, I32, I32, I32] [I32])
+    , WasiImport syscallRead "fd_read" (FuncType [I32, I32, I32, I32] [I32])
+    , WasiImport syscallExit "proc_exit" (FuncType [I32] [])
+    ]
+
+requireWasiImport :: LoweringContext -> Integer -> Either LoweringError Integer
+requireWasiImport context number =
+    case Map.lookup number (contextWasiImports context) of
+        Just indexValue -> Right indexValue
+        Nothing -> Left (LoweringError ("missing WASI import for SYSCALL " ++ show number))
+
+requireScratch :: LoweringContext -> Either LoweringError Integer
+requireScratch context =
+    case contextWasiScratchBase context of
+        Just scratch -> Right scratch
+        Nothing -> Left (LoweringError "SYSCALL lowering requires WASM scratch memory")
+
+needsMemory :: IrProgram -> Bool
+needsMemory program =
+    not (null (irDataDecls program))
+        || any
+            ((`elem` [LoadAddr, LoadByte, StoreByte]) . irOpcode)
+            (irInstructions program)
+
+needsWasiScratch :: IrProgram -> Bool
+needsWasiScratch program =
+    any isScratchSyscall (irInstructions program)
+  where
+    isScratchSyscall (IrInstruction Syscall [Immediate number] _) = number == syscallWrite || number == syscallRead
+    isScratchSyscall _ = False
+
+layoutData :: [IrDataDecl] -> Map String Integer
+layoutData decls =
+    snd (foldl step (0, Map.empty) decls)
+  where
+    step (offset, mapping) decl =
+        (offset + toInteger (irDataSize decl), Map.insert (irDataLabel decl) offset mapping)
+
+totalDataSize :: [IrDataDecl] -> Integer
+totalDataSize = sum . map (toInteger . irDataSize)
+
+alignUp :: Integer -> Integer -> Integer
+alignUp value alignment =
+    ((value + alignment - 1) `div` alignment) * alignment
+
+pagesFor :: Integer -> Integer
+pagesFor bytesValue =
+    max 1 ((bytesValue + 65535) `div` 65536)
+
+instructionMaxRegister :: IrInstruction -> Int
+instructionMaxRegister inst =
+    maximum (0 : [register | Register register <- irOperands inst])
+
+localIndex :: FunctionIR -> Int -> Integer
+localIndex functionValue register
+    | register >= 2 && register < 2 + paramCount = toInteger (register - 2)
+    | otherwise = toInteger (paramCount + register)
+  where
+    paramCount = signatureParamCount (functionSignature functionValue)
+
+address :: FunctionIR -> Int -> Int -> ByteString
+address functionValue base offset =
+    localGet (localIndex functionValue base) <> localGet (localIndex functionValue offset) <> BS.pack [0x6A]
+
+i32Const :: Integer -> ByteString
+i32Const value = BS.pack [0x41] <> encodeSigned value
+
+constExpr :: Integer -> ByteString
+constExpr value = i32Const value <> BS.pack [0x0B]
+
+localGet :: Integer -> ByteString
+localGet indexValue = BS.pack [0x20] <> encodeUnsigned indexValue
+
+localSet :: Integer -> ByteString
+localSet indexValue = BS.pack [0x21] <> encodeUnsigned indexValue
+
+memarg :: Integer -> Integer -> ByteString
+memarg alignment offset =
+    encodeUnsigned alignment <> encodeUnsigned offset
+
+storeConstI32 :: Integer -> Integer -> ByteString
+storeConstI32 addressValue value =
+    i32Const addressValue <> i32Const value <> BS.pack [0x36] <> memarg 2 0
+
+isLoopStart :: String -> Bool
+isLoopStart labelName =
+    "loop_" `List.isPrefixOf` labelName && "_start" `List.isSuffixOf` labelName
+
+matchingLoopEnd :: String -> String
+matchingLoopEnd labelName =
+    take (length labelName - length ("_start" :: String)) labelName ++ "_end"
+
+requireLabel :: Map String Int -> String -> Either LoweringError Int
+requireLabel labels labelName =
+    case Map.lookup labelName labels of
+        Just indexValue -> Right indexValue
+        Nothing -> Left (LoweringError ("missing label " ++ labelName))
+
+findFirstBranchToLabel :: [IrInstruction] -> Int -> Int -> String -> Either LoweringError Int
+findFirstBranchToLabel instructions startIndex endIndex labelName =
+    case [indexValue | indexValue <- [startIndex .. endIndex - 1], branchesTo labelName (instructions !! indexValue)] of
+        indexValue : _ -> Right indexValue
+        [] -> Left (LoweringError ("expected branch to " ++ labelName))
+
+findLastJumpToLabel :: [IrInstruction] -> Int -> Int -> String -> Either LoweringError Int
+findLastJumpToLabel instructions startIndex endIndex labelName =
+    case [indexValue | indexValue <- reverse [startIndex .. endIndex - 1], jumpsTo labelName (instructions !! indexValue)] of
+        indexValue : _ -> Right indexValue
+        [] -> Left (LoweringError ("expected jump to " ++ labelName))
+
+branchesTo :: String -> IrInstruction -> Bool
+branchesTo labelName (IrInstruction opcode [Register _, LabelRef target] _) =
+    (opcode == BranchZ || opcode == BranchNz) && target == labelName
+branchesTo _ _ = False
+
+jumpsTo :: String -> IrInstruction -> Bool
+jumpsTo labelName (IrInstruction Jump [LabelRef target] _) = target == labelName
+jumpsTo _ _ = False
+
+branchRegister :: IrInstruction -> Either LoweringError Int
+branchRegister (IrInstruction opcode [Register register, LabelRef _] _)
+    | opcode == BranchZ || opcode == BranchNz = Right register
+branchRegister inst = Left (LoweringError ("expected branch instruction, got " ++ show inst))

--- a/code/packages/haskell/ir-to-wasm-compiler/test/IRToWasmCompilerSpec.hs
+++ b/code/packages/haskell/ir-to-wasm-compiler/test/IRToWasmCompilerSpec.hs
@@ -1,0 +1,34 @@
+module IRToWasmCompilerSpec (spec) where
+
+import CompilerIR
+import IRToWasmCompiler
+import Test.Hspec
+import WasmExecution
+import WasmModuleEncoder
+import WasmRuntime
+import WasmTypes
+import WasmValidator
+
+spec :: Spec
+spec = describe "IRToWasmCompiler" $ do
+    it "lowers a constant-returning function" $ do
+        let program =
+                foldl
+                    appendInstruction
+                    (emptyProgram "_start")
+                    [ instruction Label [LabelRef "_fn_answer"] 0
+                    , instruction LoadImm [Register 1, Immediate 7] 1
+                    , instruction Ret [] 2
+                    ]
+            signatures = [FunctionSignature "_fn_answer" 0 (Just "answer")]
+        moduleValue <- unwrapEither (compileProgram program signatures)
+        validateModule moduleValue `shouldSatisfy` either (const False) (const True)
+        bytesValue <- unwrapEither (encodeModule moduleValue)
+        result <- loadAndRun (newRuntime Nothing) bytesValue "answer" []
+        result `shouldBe` Right [WasmI32 7]
+
+unwrapEither :: Show err => Either err value -> IO value
+unwrapEither result =
+    case result of
+        Left err -> expectationFailure (show err) >> error "unreachable after expectationFailure"
+        Right value -> pure value

--- a/code/packages/haskell/ir-to-wasm-compiler/test/Spec.hs
+++ b/code/packages/haskell/ir-to-wasm-compiler/test/Spec.hs
@@ -1,0 +1,5 @@
+import qualified IRToWasmCompilerSpec
+import Test.Hspec
+
+main :: IO ()
+main = hspec IRToWasmCompilerSpec.spec

--- a/code/packages/haskell/ir-to-wasm-validator/BUILD
+++ b/code/packages/haskell/ir-to-wasm-validator/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/ir-to-wasm-validator/BUILD_windows
+++ b/code/packages/haskell/ir-to-wasm-validator/BUILD_windows
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/ir-to-wasm-validator/CHANGELOG.md
+++ b/code/packages/haskell/ir-to-wasm-validator/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add Haskell IR-to-Wasm validation for the convergence lowering subset.

--- a/code/packages/haskell/ir-to-wasm-validator/README.md
+++ b/code/packages/haskell/ir-to-wasm-validator/README.md
@@ -1,0 +1,5 @@
+# ir-to-wasm-validator
+
+This package validates the subset of Haskell `compiler-ir` currently accepted
+by the local Haskell Wasm lowerer. It catches malformed operand shapes before
+the backend emits bytes.

--- a/code/packages/haskell/ir-to-wasm-validator/cabal.project
+++ b/code/packages/haskell/ir-to-wasm-validator/cabal.project
@@ -1,0 +1,3 @@
+packages:
+  .
+  ../compiler-ir

--- a/code/packages/haskell/ir-to-wasm-validator/ir-to-wasm-validator.cabal
+++ b/code/packages/haskell/ir-to-wasm-validator/ir-to-wasm-validator.cabal
@@ -1,0 +1,26 @@
+cabal-version: 3.0
+name:          ir-to-wasm-validator
+version:       0.1.0
+synopsis:      Haskell compiler IR to Wasm validation stage
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  IRToWasmValidator
+    build-depends:    base >=4.14
+                    , compiler-ir
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    IRToWasmValidatorSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , compiler-ir
+                    , hspec == 2.*
+                    , ir-to-wasm-validator
+    default-language: Haskell2010

--- a/code/packages/haskell/ir-to-wasm-validator/src/IRToWasmValidator.hs
+++ b/code/packages/haskell/ir-to-wasm-validator/src/IRToWasmValidator.hs
@@ -1,0 +1,44 @@
+module IRToWasmValidator
+    ( description
+    , ValidationError(..)
+    , validateProgram
+    ) where
+
+import CompilerIR hiding (description)
+
+description :: String
+description = "Haskell validator for the IR-to-Wasm lowering subset"
+
+data ValidationError = ValidationError
+    { validationErrorMessage :: String
+    , validationErrorInstructionId :: Int
+    }
+    deriving (Eq, Show)
+
+validateProgram :: IrProgram -> [ValidationError]
+validateProgram program =
+    concatMap validateInstruction (irInstructions program)
+
+validateInstruction :: IrInstruction -> [ValidationError]
+validateInstruction inst =
+    case (irOpcode inst, irOperands inst) of
+        (Comment, [LabelRef _]) -> []
+        (Label, [LabelRef _]) -> []
+        (LoadImm, [Register _, Immediate _]) -> []
+        (LoadAddr, [Register _, LabelRef _]) -> []
+        (LoadByte, [Register _, Register _, Register _]) -> []
+        (StoreByte, [Register _, Register _, Register _]) -> []
+        (Add, [Register _, Register _, Register _]) -> []
+        (AddImm, [Register _, Register _, Immediate _]) -> []
+        (Sub, [Register _, Register _, Register _]) -> []
+        (And, [Register _, Register _, Register _]) -> []
+        (AndImm, [Register _, Register _, Immediate _]) -> []
+        (Jump, [LabelRef _]) -> []
+        (BranchZ, [Register _, LabelRef _]) -> []
+        (BranchNz, [Register _, LabelRef _]) -> []
+        (Call, [LabelRef _]) -> []
+        (Ret, []) -> []
+        (Syscall, [Immediate _]) -> []
+        (Halt, []) -> []
+        (Nop, []) -> []
+        _ -> [ValidationError "instruction has operands unsupported by the Haskell Wasm lowerer" (irInstructionId inst)]

--- a/code/packages/haskell/ir-to-wasm-validator/test/IRToWasmValidatorSpec.hs
+++ b/code/packages/haskell/ir-to-wasm-validator/test/IRToWasmValidatorSpec.hs
@@ -1,0 +1,21 @@
+module IRToWasmValidatorSpec (spec) where
+
+import CompilerIR
+import IRToWasmValidator
+import Test.Hspec
+
+spec :: Spec
+spec = describe "IRToWasmValidator" $ do
+    it "accepts the lowering subset" $ do
+        let program =
+                appendInstruction
+                    (emptyProgram "_start")
+                    (instruction LoadImm [Register 1, Immediate 7] 0)
+        validateProgram program `shouldBe` []
+
+    it "rejects malformed operands" $ do
+        let program =
+                appendInstruction
+                    (emptyProgram "_start")
+                    (instruction LoadImm [LabelRef "bad"] 9)
+        validateProgram program `shouldSatisfy` (not . null)

--- a/code/packages/haskell/ir-to-wasm-validator/test/Spec.hs
+++ b/code/packages/haskell/ir-to-wasm-validator/test/Spec.hs
@@ -1,0 +1,5 @@
+import qualified IRToWasmValidatorSpec
+import Test.Hspec
+
+main :: IO ()
+main = hspec IRToWasmValidatorSpec.spec

--- a/code/packages/haskell/nib-ir-compiler/BUILD
+++ b/code/packages/haskell/nib-ir-compiler/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/nib-ir-compiler/BUILD_windows
+++ b/code/packages/haskell/nib-ir-compiler/BUILD_windows
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/nib-ir-compiler/CHANGELOG.md
+++ b/code/packages/haskell/nib-ir-compiler/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add Haskell Nib-to-IR lowering for the convergence smoke subset.

--- a/code/packages/haskell/nib-ir-compiler/README.md
+++ b/code/packages/haskell/nib-ir-compiler/README.md
@@ -1,0 +1,6 @@
+# nib-ir-compiler
+
+Haskell `nib-ir-compiler` lowers checked Nib ASTs into the local
+`compiler-ir` package. It follows the shared Nib ABI: function parameters live
+in `v2+`, return values leave in `v1`, and source functions are labeled
+`_fn_NAME`.

--- a/code/packages/haskell/nib-ir-compiler/cabal.project
+++ b/code/packages/haskell/nib-ir-compiler/cabal.project
@@ -1,0 +1,12 @@
+packages:
+  .
+  ../compiler-ir
+  ../grammar-tools
+  ../parser
+  ../graph
+  ../directed-graph
+  ../state-machine
+  ../lexer
+  ../nib-lexer
+  ../nib-parser
+  ../nib-type-checker

--- a/code/packages/haskell/nib-ir-compiler/nib-ir-compiler.cabal
+++ b/code/packages/haskell/nib-ir-compiler/nib-ir-compiler.cabal
@@ -1,0 +1,31 @@
+cabal-version: 3.0
+name:          nib-ir-compiler
+version:       0.1.0
+synopsis:      Haskell Nib to compiler IR frontend
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  NibIRCompiler
+    build-depends:    base >=4.14
+                    , compiler-ir
+                    , containers
+                    , lexer
+                    , nib-type-checker
+                    , parser
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    NibIRCompilerSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , compiler-ir
+                    , hspec == 2.*
+                    , nib-ir-compiler
+                    , nib-type-checker
+    default-language: Haskell2010

--- a/code/packages/haskell/nib-ir-compiler/src/NibIRCompiler.hs
+++ b/code/packages/haskell/nib-ir-compiler/src/NibIRCompiler.hs
@@ -1,0 +1,230 @@
+module NibIRCompiler
+    ( description
+    , BuildConfig(..)
+    , CompileResult(..)
+    , releaseConfig
+    , compileNib
+    ) where
+
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
+import CompilerIR hiding (description)
+import Lexer.Token
+import NibTypeChecker hiding (description)
+import Parser.AST
+
+description :: String
+description = "Haskell Nib to compiler IR frontend"
+
+data BuildConfig = BuildConfig
+    { buildConfigOptimize :: Bool
+    }
+    deriving (Eq, Show)
+
+data CompileResult = CompileResult
+    { compileResultProgram :: IrProgram
+    }
+    deriving (Eq, Show)
+
+releaseConfig :: BuildConfig
+releaseConfig = BuildConfig {buildConfigOptimize = True}
+
+compileNib :: TypedAst -> BuildConfig -> CompileResult
+compileNib typedAst _ =
+    CompileResult (compileProgramFromAst (typedAstRoot typedAst))
+
+compileProgramFromAst :: ASTNode -> IrProgram
+compileProgramFromAst root =
+    let initial =
+            appendMany
+                (emptyProgram "_start")
+                [ instruction Label [LabelRef "_start"] 0
+                , if hasMain then instruction Call [LabelRef "_fn_main"] 1 else instruction Comment [LabelRef "no-main"] 1
+                , instruction Halt [] 2
+                ]
+        (_, finalProgram) = foldl compileFunction (3, initial) (functionNodes root)
+     in finalProgram
+  where
+    hasMain = any ((== Just "main") . firstName) (functionNodes root)
+
+compileFunction :: (Int, IrProgram) -> ASTNode -> (Int, IrProgram)
+compileFunction (nextId, program) fn =
+    let functionName = maybe "anonymous" id (firstName fn)
+        withLabel = appendInstruction program (instruction Label [LabelRef ("_fn_" ++ functionName)] nextId)
+        env = Map.fromList [(name, register) | (name, register) <- zip (paramNames fn) [2 ..]]
+        (afterBlockId, afterBlockProgram) =
+            case firstChildRule "block" fn of
+                Nothing -> (nextId + 1, withLabel)
+                Just block -> compileBlock (nextId + 1) withLabel env (2 + length (paramNames fn)) block
+     in (afterBlockId + 1, appendInstruction afterBlockProgram (instruction Ret [] afterBlockId))
+
+compileBlock :: Int -> IrProgram -> Map String Int -> Int -> ASTNode -> (Int, IrProgram)
+compileBlock nextId program env nextRegister block =
+    foldl step (nextId, program, env, nextRegister) (childRules block) |> (\(ident, currentProgram, _, _) -> (ident, currentProgram))
+  where
+    step (ident, currentProgram, currentEnv, registerCursor) stmt =
+        let (nextIdent, nextProgram, nextEnv, nextCursor) = compileStmt ident currentProgram currentEnv registerCursor stmt
+         in (nextIdent, nextProgram, nextEnv, nextCursor)
+
+compileStmt :: Int -> IrProgram -> Map String Int -> Int -> ASTNode -> (Int, IrProgram, Map String Int, Int)
+compileStmt ident program env nextRegister stmt =
+    let actualStmt = unwrapStmt stmt
+     in case actualStmt of
+        RuleNode "let_stmt" _ ->
+            let name = maybe ("tmp" ++ show nextRegister) id (firstName actualStmt)
+                register = Map.findWithDefault nextRegister name env
+                env' = Map.insert name register env
+                (ident', program') =
+                    case firstChildRule "expr" actualStmt of
+                        Nothing -> (ident, program)
+                        Just expr -> emitExpr ident program env' register expr
+             in (ident', program', env', max nextRegister (register + 1))
+        RuleNode "assign_stmt" _ ->
+            case firstName actualStmt >>= (`Map.lookup` env) of
+                Nothing -> (ident, program, env, nextRegister)
+                Just register ->
+                    case firstChildRule "expr" actualStmt of
+                        Nothing -> (ident, program, env, nextRegister)
+                        Just expr ->
+                            let (ident', program') = emitExpr ident program env register expr
+                             in (ident', program', env, nextRegister)
+        RuleNode "return_stmt" _ ->
+            case firstChildRule "expr" actualStmt of
+                Nothing -> (ident, program, env, nextRegister)
+                Just expr ->
+                    let (ident', program') = emitExpr ident program env 1 expr
+                     in (ident', program', env, nextRegister)
+        RuleNode "expr_stmt" _ ->
+            case firstChildRule "expr" actualStmt of
+                Nothing -> (ident, program, env, nextRegister)
+                Just expr ->
+                    let (ident', program') = emitExpr ident program env 1 expr
+                     in (ident', program', env, nextRegister)
+        _ -> (ident, program, env, nextRegister)
+
+emitExpr :: Int -> IrProgram -> Map String Int -> Int -> ASTNode -> (Int, IrProgram)
+emitExpr ident program env dest node =
+    case node of
+        TokenNode token -> emitToken ident program env dest token
+        RuleNode "call_expr" _ -> emitCall ident program env dest node
+        RuleNode "add_expr" _ ->
+            case childRules node of
+                [] -> (ident, program)
+                firstOperand : restOperands ->
+                    let (afterLeftId, afterLeftProgram) = emitExpr ident program env dest firstOperand
+                     in foldl (emitAdd dest env) (afterLeftId, afterLeftProgram) restOperands
+        RuleNode _ children ->
+            case [child | child <- children, isCall child] of
+                callNode : _ -> emitExpr ident program env dest callNode
+                [] ->
+                    case childRules node of
+                        [onlyChild] -> emitExpr ident program env dest onlyChild
+                        firstChild : _ -> emitExpr ident program env dest firstChild
+                        [] ->
+                            case childTokens node of
+                                token : _ -> emitToken ident program env dest token
+                                [] -> (ident, program)
+        _ -> (ident, program)
+
+emitAdd :: Int -> Map String Int -> (Int, IrProgram) -> ASTNode -> (Int, IrProgram)
+emitAdd dest env (ident, program) rhs =
+    case literalValue rhs of
+        Just value ->
+            let addInst = instruction AddImm [Register dest, Register dest, Immediate value] ident
+                maskInst = instruction AndImm [Register dest, Register dest, Immediate 15] (ident + 1)
+             in (ident + 2, appendMany program [addInst, maskInst])
+        Nothing ->
+            let scratch = 32
+                (afterRhsId, afterRhsProgram) = emitExpr ident program env scratch rhs
+                addInst = instruction Add [Register dest, Register dest, Register scratch] afterRhsId
+                maskInst = instruction AndImm [Register dest, Register dest, Immediate 15] (afterRhsId + 1)
+             in (afterRhsId + 2, appendMany afterRhsProgram [addInst, maskInst])
+
+emitCall :: Int -> IrProgram -> Map String Int -> Int -> ASTNode -> (Int, IrProgram)
+emitCall ident program env dest node =
+    let name = maybe "anonymous" id (firstName node)
+        (afterArgsId, afterArgsProgram) =
+            foldl
+                (\(currentId, currentProgram) (arg, register) -> emitExpr currentId currentProgram env register arg)
+                (ident, program)
+                (zip (callArguments node) [2 ..])
+        callInst = instruction Call [LabelRef ("_fn_" ++ name)] afterArgsId
+        copyInst = instruction AddImm [Register dest, Register 1, Immediate 0] (afterArgsId + 1)
+        instructions = if dest == 1 then [callInst] else [callInst, copyInst]
+     in (afterArgsId + length instructions, appendMany afterArgsProgram instructions)
+
+emitToken :: Int -> IrProgram -> Map String Int -> Int -> Token -> (Int, IrProgram)
+emitToken ident program env dest token =
+    case literalTokenValue token of
+        Just value -> (ident + 1, appendInstruction program (instruction LoadImm [Register dest, Immediate value] ident))
+        Nothing ->
+            case Map.lookup (tokenValue token) env of
+                Nothing -> (ident, program)
+                Just source -> (ident + 1, appendInstruction program (instruction AddImm [Register dest, Register source, Immediate 0] ident))
+
+literalValue :: ASTNode -> Maybe Integer
+literalValue (TokenNode token) = literalTokenValue token
+literalValue (RuleNode _ children) = firstJust (map literalValue children)
+literalValue _ = Nothing
+
+literalTokenValue :: Token -> Maybe Integer
+literalTokenValue token =
+    case canonicalTokenName token of
+        "INT_LIT" -> Just (read (tokenValue token))
+        "HEX_LIT" -> Just (read ("0" ++ drop 1 (tokenValue token)))
+        _ ->
+            case tokenValue token of
+                "true" -> Just 1
+                "false" -> Just 0
+                _ -> Nothing
+
+paramNames :: ASTNode -> [String]
+paramNames node =
+    case firstChildRule "param_list" node of
+        Nothing -> []
+        Just paramList -> [name | param <- childRules paramList, Just name <- [firstName param]]
+
+callArguments :: ASTNode -> [ASTNode]
+callArguments node =
+    case firstChildRule "arg_list" node of
+        Nothing -> []
+        Just argList -> [expr | expr@(RuleNode "expr" _) <- childRules argList]
+
+unwrapStmt :: ASTNode -> ASTNode
+unwrapStmt (RuleNode "stmt" children) =
+    case childRules (RuleNode "stmt" children) of
+        firstChild : _ -> firstChild
+        [] -> RuleNode "stmt" children
+unwrapStmt node = node
+
+firstChildRule :: String -> ASTNode -> Maybe ASTNode
+firstChildRule name node =
+    case [child | child@(RuleNode ruleName _) <- childRules node, ruleName == name] of
+        firstChild : _ -> Just firstChild
+        [] -> Nothing
+
+childRules :: ASTNode -> [ASTNode]
+childRules (RuleNode _ children) = [child | child@(RuleNode _ _) <- children]
+childRules _ = []
+
+childTokens :: ASTNode -> [Token]
+childTokens (RuleNode _ children) = [token | TokenNode token <- children]
+childTokens (TokenNode token) = [token]
+childTokens _ = []
+
+isCall :: ASTNode -> Bool
+isCall (RuleNode "call_expr" _) = True
+isCall _ = False
+
+appendMany :: IrProgram -> [IrInstruction] -> IrProgram
+appendMany = foldl appendInstruction
+
+firstJust :: [Maybe a] -> Maybe a
+firstJust values =
+    case values of
+        [] -> Nothing
+        Just value : _ -> Just value
+        Nothing : rest -> firstJust rest
+
+(|>) :: a -> (a -> b) -> b
+value |> f = f value

--- a/code/packages/haskell/nib-ir-compiler/test/NibIRCompilerSpec.hs
+++ b/code/packages/haskell/nib-ir-compiler/test/NibIRCompilerSpec.hs
@@ -1,0 +1,24 @@
+module NibIRCompilerSpec (spec) where
+
+import CompilerIR
+import NibIRCompiler
+import NibTypeChecker
+import Test.Hspec
+
+spec :: Spec
+spec = describe "NibIRCompiler" $ do
+    it "emits entrypoint and function labels" $ do
+        let checked = checkSource "fn answer() -> u4 { return 7; }"
+            program = compileResultProgram (compileNib (typeCheckTypedAst checked) releaseConfig)
+        map irOpcode (irInstructions program) `shouldSatisfy` \ops ->
+            Label `elem` ops && Halt `elem` ops && Ret `elem` ops
+        irInstructions program `shouldSatisfy` any (hasLabel "_fn_answer")
+
+    it "places calls in the IR" $ do
+        let checked = checkSource "fn add(a: u4, b: u4) -> u4 { return a +% b; } fn main() -> u4 { return add(3, 4); }"
+            program = compileResultProgram (compileNib (typeCheckTypedAst checked) releaseConfig)
+        map irOpcode (irInstructions program) `shouldContain` [Call]
+
+hasLabel :: String -> IrInstruction -> Bool
+hasLabel expected inst =
+    irOpcode inst == Label && irOperands inst == [LabelRef expected]

--- a/code/packages/haskell/nib-ir-compiler/test/Spec.hs
+++ b/code/packages/haskell/nib-ir-compiler/test/Spec.hs
@@ -1,0 +1,5 @@
+import qualified NibIRCompilerSpec
+import Test.Hspec
+
+main :: IO ()
+main = hspec NibIRCompilerSpec.spec

--- a/code/packages/haskell/nib-type-checker/BUILD
+++ b/code/packages/haskell/nib-type-checker/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/nib-type-checker/BUILD_windows
+++ b/code/packages/haskell/nib-type-checker/BUILD_windows
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/nib-type-checker/CHANGELOG.md
+++ b/code/packages/haskell/nib-type-checker/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add a Haskell Nib type-checker for the Wasm convergence smoke subset.

--- a/code/packages/haskell/nib-type-checker/README.md
+++ b/code/packages/haskell/nib-type-checker/README.md
@@ -1,0 +1,5 @@
+# nib-type-checker
+
+Haskell `nib-type-checker` performs lightweight semantic checks over the AST
+produced by the local `nib-parser`. It keeps the original AST and reports
+plain diagnostics so later compiler stages can stay stage-aware.

--- a/code/packages/haskell/nib-type-checker/cabal.project
+++ b/code/packages/haskell/nib-type-checker/cabal.project
@@ -1,0 +1,10 @@
+packages:
+  .
+  ../grammar-tools
+  ../parser
+  ../graph
+  ../directed-graph
+  ../state-machine
+  ../lexer
+  ../nib-lexer
+  ../nib-parser

--- a/code/packages/haskell/nib-type-checker/nib-type-checker.cabal
+++ b/code/packages/haskell/nib-type-checker/nib-type-checker.cabal
@@ -1,0 +1,28 @@
+cabal-version: 3.0
+name:          nib-type-checker
+version:       0.1.0
+synopsis:      Haskell Nib semantic checker
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  NibTypeChecker
+    build-depends:    base >=4.14
+                    , containers
+                    , lexer
+                    , nib-parser
+                    , parser
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    NibTypeCheckerSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , hspec == 2.*
+                    , nib-type-checker
+    default-language: Haskell2010

--- a/code/packages/haskell/nib-type-checker/src/NibTypeChecker.hs
+++ b/code/packages/haskell/nib-type-checker/src/NibTypeChecker.hs
@@ -1,0 +1,295 @@
+module NibTypeChecker
+    ( description
+    , NibType(..)
+    , TypeDiagnostic(..)
+    , TypedAst(..)
+    , TypeCheckResult(..)
+    , checkSource
+    , checkAst
+    , functionNodes
+    , firstName
+    , countParams
+    ) where
+
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
+import Lexer.Token
+import NibParser hiding (description)
+import Parser.AST
+
+description :: String
+description = "Haskell Nib semantic checker for the convergence subset"
+
+data NibType
+    = U4
+    | U8
+    | Bcd
+    | Bool
+    | Void
+    deriving (Eq, Ord, Show)
+
+data TypeDiagnostic = TypeDiagnostic
+    { diagnosticMessage :: String
+    , diagnosticLine :: Int
+    , diagnosticColumn :: Int
+    }
+    deriving (Eq, Show)
+
+data TypedAst = TypedAst
+    { typedAstRoot :: ASTNode
+    }
+    deriving (Eq, Show)
+
+data TypeCheckResult = TypeCheckResult
+    { typeCheckOk :: Bool
+    , typeCheckErrors :: [TypeDiagnostic]
+    , typeCheckTypedAst :: TypedAst
+    }
+    deriving (Eq, Show)
+
+type Env = Map String NibType
+type FunctionEnv = Map String ([NibType], NibType)
+
+checkSource :: String -> TypeCheckResult
+checkSource source =
+    case tokenizeAndParseNib source of
+        Left err ->
+            TypeCheckResult
+                { typeCheckOk = False
+                , typeCheckErrors = [TypeDiagnostic (show err) 1 1]
+                , typeCheckTypedAst = TypedAst (RuleNode "program" [])
+                }
+        Right ast -> checkAst ast
+
+checkAst :: ASTNode -> TypeCheckResult
+checkAst ast =
+    let functions = Map.fromList [(name, (paramTypes fn, returnType fn)) | fn <- functionNodes ast, Just name <- [firstName fn]]
+        errors = concatMap (checkFunction functions) (functionNodes ast)
+     in TypeCheckResult
+            { typeCheckOk = null errors
+            , typeCheckErrors = errors
+            , typeCheckTypedAst = TypedAst ast
+            }
+
+checkFunction :: FunctionEnv -> ASTNode -> [TypeDiagnostic]
+checkFunction functions fn =
+    case firstChildRule "block" fn of
+        Nothing -> []
+        Just block -> checkBlock functions (paramEnv fn) (returnType fn) block
+
+checkBlock :: FunctionEnv -> Env -> NibType -> ASTNode -> [TypeDiagnostic]
+checkBlock functions env expectedReturn block =
+    snd (foldl step (env, []) (childRules block))
+  where
+    step (currentEnv, errors) stmt =
+        let (nextEnv, moreErrors) = checkStmt functions currentEnv expectedReturn stmt
+         in (nextEnv, errors ++ moreErrors)
+
+checkStmt :: FunctionEnv -> Env -> NibType -> ASTNode -> (Env, [TypeDiagnostic])
+checkStmt functions env expectedReturn stmt =
+    let actualStmt = unwrapStmt stmt
+     in case actualStmt of
+        RuleNode "let_stmt" _ ->
+            let name = maybe "<unknown>" id (firstName actualStmt)
+                declared = maybe U4 id (firstChildRule "type" actualStmt >>= parseType)
+                actual = firstChildRule "expr" actualStmt >>= inferExpr functions env
+                errors =
+                    case actual of
+                        Just valueType | valueType /= declared -> [diagnostic actualStmt ("let `" ++ name ++ "` expects " ++ show declared ++ ", got " ++ show valueType)]
+                        _ -> []
+             in (Map.insert name declared env, errors)
+        RuleNode "assign_stmt" _ ->
+            let name = maybe "<unknown>" id (firstName actualStmt)
+                actual = firstChildRule "expr" actualStmt >>= inferExpr functions env
+                errors =
+                    case Map.lookup name env of
+                        Nothing -> [diagnostic actualStmt ("unknown variable `" ++ name ++ "`")]
+                        Just expected ->
+                            case actual of
+                                Just valueType | valueType /= expected -> [diagnostic actualStmt ("assignment to `" ++ name ++ "` expects " ++ show expected ++ ", got " ++ show valueType)]
+                                _ -> []
+             in (env, errors)
+        RuleNode "return_stmt" _ ->
+            let actual = firstChildRule "expr" actualStmt >>= inferExpr functions env
+                errors =
+                    case actual of
+                        Just valueType | expectedReturn /= Void && valueType /= expectedReturn -> [diagnostic actualStmt ("return expects " ++ show expectedReturn ++ ", got " ++ show valueType)]
+                        _ -> []
+             in (env, errors)
+        _ -> (env, [])
+
+inferExpr :: FunctionEnv -> Env -> ASTNode -> Maybe NibType
+inferExpr functions env node =
+    case node of
+        TokenNode token -> inferToken functions env token
+        RuleNode "call_expr" _ -> inferCall functions env node
+        RuleNode "add_expr" _ ->
+            let operands = childRules node
+                types = mapMaybeLocal (inferExpr functions env) operands
+             in case types of
+                    [] -> Nothing
+                    firstType : rest
+                        | all (== firstType) rest && isNumeric firstType -> Just firstType
+                        | null rest -> Just firstType
+                        | otherwise -> Nothing
+        RuleNode _ children ->
+            case [child | child <- children, isCall child] of
+                callNode : _ -> inferExpr functions env callNode
+                [] ->
+                    case childRules node of
+                        [onlyChild] -> inferExpr functions env onlyChild
+                        firstChild : _ -> inferExpr functions env firstChild
+                        [] ->
+                            case childTokens node of
+                                token : _ -> inferToken functions env token
+                                [] -> Nothing
+        _ -> Nothing
+
+inferCall :: FunctionEnv -> Env -> ASTNode -> Maybe NibType
+inferCall functions env node = do
+    name <- firstName node
+    (params, resultType) <- Map.lookup name functions
+    let args = callArguments node
+        argTypes = mapMaybeLocal (inferExpr functions env) args
+    if length args == length params && argTypes == params
+        then Just resultType
+        else Nothing
+
+inferToken :: FunctionEnv -> Env -> Token -> Maybe NibType
+inferToken _ env token =
+    case canonicalTokenName token of
+        "INT_LIT" -> Just (if read (tokenValue token) <= (15 :: Integer) then U4 else U8)
+        "HEX_LIT" -> Just U4
+        "NAME" -> Map.lookup (tokenValue token) env
+        _ ->
+            case tokenValue token of
+                "true" -> Just Bool
+                "false" -> Just Bool
+                _ -> Nothing
+
+functionNodes :: ASTNode -> [ASTNode]
+functionNodes node =
+    case node of
+        RuleNode "fn_decl" _ -> [node]
+        RuleNode _ children -> concatMap functionNodes children
+        _ -> []
+
+firstName :: ASTNode -> Maybe String
+firstName node =
+    case node of
+        TokenNode token
+            | canonicalTokenName token == "NAME" -> Just (tokenValue token)
+            | otherwise -> Nothing
+        RuleNode _ children -> firstJust (map firstName children)
+        _ -> Nothing
+
+countParams :: ASTNode -> Int
+countParams node =
+    case firstChildRule "param_list" node of
+        Nothing -> 0
+        Just paramList -> length [param | param@(RuleNode "param" _) <- childRules paramList]
+
+paramTypes :: ASTNode -> [NibType]
+paramTypes node =
+    case firstChildRule "param_list" node of
+        Nothing -> []
+        Just paramList -> [valueType | param <- childRules paramList, Just valueType <- [firstChildRule "type" param >>= parseType]]
+
+paramEnv :: ASTNode -> Env
+paramEnv node =
+    case firstChildRule "param_list" node of
+        Nothing -> Map.empty
+        Just paramList ->
+            Map.fromList
+                [ (name, valueType)
+                | param <- childRules paramList
+                , Just name <- [firstName param]
+                , Just valueType <- [firstChildRule "type" param >>= parseType]
+                ]
+
+returnType :: ASTNode -> NibType
+returnType node =
+    maybe Void id (firstChildRule "type" node >>= parseType)
+
+parseType :: ASTNode -> Maybe NibType
+parseType node =
+    case childTokens node of
+        token : _ ->
+            case tokenValue token of
+                "u4" -> Just U4
+                "u8" -> Just U8
+                "bcd" -> Just Bcd
+                "bool" -> Just Bool
+                _ -> Nothing
+        [] -> Nothing
+
+unwrapStmt :: ASTNode -> ASTNode
+unwrapStmt (RuleNode "stmt" children) =
+    case childRules (RuleNode "stmt" children) of
+        firstChild : _ -> firstChild
+        [] -> RuleNode "stmt" children
+unwrapStmt node = node
+
+callArguments :: ASTNode -> [ASTNode]
+callArguments node =
+    case firstChildRule "arg_list" node of
+        Nothing -> []
+        Just argList -> [expr | expr@(RuleNode "expr" _) <- childRules argList]
+
+firstChildRule :: String -> ASTNode -> Maybe ASTNode
+firstChildRule name node =
+    case [child | child@(RuleNode ruleName _) <- childRules node, ruleName == name] of
+        firstChild : _ -> Just firstChild
+        [] -> Nothing
+
+childRules :: ASTNode -> [ASTNode]
+childRules (RuleNode _ children) = [child | child@(RuleNode _ _) <- children]
+childRules _ = []
+
+childTokens :: ASTNode -> [Token]
+childTokens (RuleNode _ children) = [token | TokenNode token <- children]
+childTokens (TokenNode token) = [token]
+childTokens _ = []
+
+isCall :: ASTNode -> Bool
+isCall (RuleNode "call_expr" _) = True
+isCall _ = False
+
+isNumeric :: NibType -> Bool
+isNumeric valueType = valueType `elem` [U4, U8, Bcd]
+
+diagnostic :: ASTNode -> String -> TypeDiagnostic
+diagnostic node message =
+    TypeDiagnostic message (nodeLine node) (nodeColumn node)
+
+nodeLine :: ASTNode -> Int
+nodeLine (TokenNode token) = tokenLine token
+nodeLine (RuleNode _ children) =
+    case children of
+        firstChild : _ -> nodeLine firstChild
+        [] -> 1
+nodeLine _ = 1
+
+nodeColumn :: ASTNode -> Int
+nodeColumn (TokenNode token) = tokenColumn token
+nodeColumn (RuleNode _ children) =
+    case children of
+        firstChild : _ -> nodeColumn firstChild
+        [] -> 1
+nodeColumn _ = 1
+
+firstJust :: [Maybe a] -> Maybe a
+firstJust values =
+    case values of
+        [] -> Nothing
+        Just value : _ -> Just value
+        Nothing : rest -> firstJust rest
+
+mapMaybeLocal :: (a -> Maybe b) -> [a] -> [b]
+mapMaybeLocal f values =
+    case values of
+        [] -> []
+        value : rest ->
+            case f value of
+                Just result -> result : mapMaybeLocal f rest
+                Nothing -> mapMaybeLocal f rest

--- a/code/packages/haskell/nib-type-checker/test/NibTypeCheckerSpec.hs
+++ b/code/packages/haskell/nib-type-checker/test/NibTypeCheckerSpec.hs
@@ -1,0 +1,20 @@
+module NibTypeCheckerSpec (spec) where
+
+import NibTypeChecker
+import Test.Hspec
+
+spec :: Spec
+spec = describe "NibTypeChecker" $ do
+    it "accepts a simple u4 return" $ do
+        typeCheckOk (checkSource "fn answer() -> u4 { return 7; }") `shouldBe` True
+
+    it "rejects mismatched let initializers" $ do
+        let result = checkSource "fn bad() -> u4 { let x: u4 = true; return 1; }"
+        typeCheckOk result `shouldBe` False
+        typeCheckErrors result `shouldSatisfy` (not . null)
+
+    it "counts function parameters" $ do
+        let typed = checkSource "fn add(a: u4, b: u4) -> u4 { return a +% b; }"
+        case functionNodes (typedAstRoot (typeCheckTypedAst typed)) of
+            fn : _ -> countParams fn `shouldBe` 2
+            [] -> expectationFailure "expected a function"

--- a/code/packages/haskell/nib-type-checker/test/Spec.hs
+++ b/code/packages/haskell/nib-type-checker/test/Spec.hs
@@ -1,0 +1,5 @@
+import qualified NibTypeCheckerSpec
+import Test.Hspec
+
+main :: IO ()
+main = hspec NibTypeCheckerSpec.spec

--- a/code/packages/haskell/nib-wasm-compiler/BUILD
+++ b/code/packages/haskell/nib-wasm-compiler/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/nib-wasm-compiler/BUILD_windows
+++ b/code/packages/haskell/nib-wasm-compiler/BUILD_windows
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/nib-wasm-compiler/CHANGELOG.md
+++ b/code/packages/haskell/nib-wasm-compiler/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add the Haskell Nib-to-Wasm orchestration package.

--- a/code/packages/haskell/nib-wasm-compiler/README.md
+++ b/code/packages/haskell/nib-wasm-compiler/README.md
@@ -1,0 +1,5 @@
+# nib-wasm-compiler
+
+Haskell `nib-wasm-compiler` wires together the local Nib parser, type checker,
+IR compiler, optimizer, IR-to-Wasm lowerer, Wasm validator, and Wasm encoder.
+It is the Haskell source-to-Wasm package for the Nib convergence lane.

--- a/code/packages/haskell/nib-wasm-compiler/cabal.project
+++ b/code/packages/haskell/nib-wasm-compiler/cabal.project
@@ -1,0 +1,24 @@
+packages:
+  .
+  ../compiler-ir
+  ../grammar-tools
+  ../parser
+  ../graph
+  ../directed-graph
+  ../state-machine
+  ../lexer
+  ../nib-lexer
+  ../nib-parser
+  ../nib-type-checker
+  ../nib-ir-compiler
+  ../ir-optimizer
+  ../ir-to-wasm-validator
+  ../wasm-leb128
+  ../wasm-types
+  ../wasm-module-encoder
+  ../wasm-module-parser
+  ../wasm-opcodes
+  ../wasm-execution
+  ../wasm-validator
+  ../wasm-runtime
+  ../ir-to-wasm-compiler

--- a/code/packages/haskell/nib-wasm-compiler/nib-wasm-compiler.cabal
+++ b/code/packages/haskell/nib-wasm-compiler/nib-wasm-compiler.cabal
@@ -1,0 +1,41 @@
+cabal-version: 3.0
+name:          nib-wasm-compiler
+version:       0.1.0
+synopsis:      Haskell Nib to WebAssembly orchestrator
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  NibWasmCompiler
+    build-depends:    base >=4.14
+                    , bytestring
+                    , compiler-ir
+                    , ir-optimizer
+                    , ir-to-wasm-compiler
+                    , ir-to-wasm-validator
+                    , nib-ir-compiler
+                    , nib-parser
+                    , nib-type-checker
+                    , parser
+                    , wasm-module-encoder
+                    , wasm-types
+                    , wasm-validator
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    NibWasmCompilerSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , bytestring
+                    , directory
+                    , filepath
+                    , hspec == 2.*
+                    , nib-wasm-compiler
+                    , wasm-execution
+                    , wasm-runtime
+    default-language: Haskell2010

--- a/code/packages/haskell/nib-wasm-compiler/src/NibWasmCompiler.hs
+++ b/code/packages/haskell/nib-wasm-compiler/src/NibWasmCompiler.hs
@@ -1,0 +1,100 @@
+module NibWasmCompiler
+    ( description
+    , PackageError(..)
+    , PackageResult(..)
+    , compileSource
+    , packSource
+    , writeWasmFile
+    , extractSignatures
+    ) where
+
+import qualified Data.ByteString as BS
+import Data.ByteString (ByteString)
+import CompilerIR hiding (description)
+import IRToWasmCompiler hiding (description)
+import IRToWasmValidator hiding (description)
+import IROptimizer hiding (description)
+import NibIRCompiler hiding (description)
+import NibParser hiding (description)
+import NibTypeChecker hiding (description)
+import Parser.AST
+import WasmModuleEncoder hiding (description)
+import WasmTypes hiding (description)
+import WasmValidator hiding (description)
+
+description :: String
+description = "Haskell Nib to WebAssembly orchestration package"
+
+data PackageError = PackageError
+    { packageErrorStage :: String
+    , packageErrorMessage :: String
+    }
+    deriving (Eq, Show)
+
+data PackageResult = PackageResult
+    { resultSource :: String
+    , resultAst :: ASTNode
+    , resultTypedAst :: TypedAst
+    , resultRawIr :: IrProgram
+    , resultOptimizedIr :: IrProgram
+    , resultModule :: WasmModule
+    , resultValidatedModule :: ValidatedModule
+    , resultBytes :: ByteString
+    , resultWasmPath :: Maybe FilePath
+    }
+    deriving (Eq, Show)
+
+compileSource :: String -> Either PackageError PackageResult
+compileSource source = do
+    ast <- mapLeft "parse" (tokenizeAndParseNib source)
+    let checked = checkAst ast
+    if typeCheckOk checked
+        then pure ()
+        else Left (PackageError "type-check" (show (typeCheckErrors checked)))
+    let typedAst = typeCheckTypedAst checked
+        rawIr = compileResultProgram (compileNib typedAst releaseConfig)
+        optimizedIr = optimizationProgram (optimizeProgram rawIr)
+        signatures = extractSignatures typedAst
+    case validateProgram optimizedIr of
+        [] -> pure ()
+        errors -> Left (PackageError "validate-ir" (show errors))
+    moduleValue <- mapLeft "lower" (compileProgram optimizedIr signatures)
+    validated <- mapLeft "validate-wasm" (validateModule moduleValue)
+    bytesValue <- mapLeft "encode" (encodeModule moduleValue)
+    Right
+        PackageResult
+            { resultSource = source
+            , resultAst = ast
+            , resultTypedAst = typedAst
+            , resultRawIr = rawIr
+            , resultOptimizedIr = optimizedIr
+            , resultModule = moduleValue
+            , resultValidatedModule = validated
+            , resultBytes = bytesValue
+            , resultWasmPath = Nothing
+            }
+
+packSource :: String -> Either PackageError PackageResult
+packSource = compileSource
+
+writeWasmFile :: String -> FilePath -> IO (Either PackageError PackageResult)
+writeWasmFile source path =
+    case compileSource source of
+        Left err -> pure (Left err)
+        Right result -> do
+            BS.writeFile path (resultBytes result)
+            pure (Right result {resultWasmPath = Just path})
+
+extractSignatures :: TypedAst -> [FunctionSignature]
+extractSignatures typedAst =
+    FunctionSignature "_start" 0 (Just "_start")
+        : [ FunctionSignature ("_fn_" ++ name) (countParams fn) (Just name)
+          | fn <- functionNodes (typedAstRoot typedAst)
+          , Just name <- [firstName fn]
+          ]
+
+mapLeft :: Show err => String -> Either err value -> Either PackageError value
+mapLeft stage result =
+    case result of
+        Left err -> Left (PackageError stage (show err))
+        Right value -> Right value

--- a/code/packages/haskell/nib-wasm-compiler/test/NibWasmCompilerSpec.hs
+++ b/code/packages/haskell/nib-wasm-compiler/test/NibWasmCompilerSpec.hs
@@ -1,0 +1,44 @@
+module NibWasmCompilerSpec (spec) where
+
+import qualified Data.ByteString as BS
+import NibWasmCompiler
+import System.Directory
+import System.FilePath
+import Test.Hspec
+import WasmExecution
+import WasmRuntime
+
+spec :: Spec
+spec = describe "NibWasmCompiler" $ do
+    it "compiles a simple function into Wasm bytes" $ do
+        result <- unwrapEither (compileSource "fn answer() -> u4 { return 7; }")
+        resultBytes result `shouldSatisfy` (not . BS.null)
+        length (extractSignatures (resultTypedAst result)) `shouldBe` 2
+
+    it "aliases packSource to compileSource" $ do
+        compiled <- unwrapEither (compileSource "fn answer() -> u4 { return 7; }")
+        packed <- unwrapEither (packSource "fn answer() -> u4 { return 7; }")
+        resultBytes packed `shouldBe` resultBytes compiled
+
+    it "runs exported functions through the local runtime" $ do
+        result <- unwrapEither (compileSource "fn answer() -> u4 { return 7; }")
+        runResult <- loadAndRun (newRuntime Nothing) (resultBytes result) "answer" []
+        runResult `shouldBe` Right [WasmI32 7]
+
+    it "writes Wasm bytes" $ do
+        tempDir <- getTemporaryDirectory
+        let path = tempDir </> "haskell-nib-smoke.wasm"
+        result <- writeWasmFile "fn answer() -> u4 { return 7; }" path >>= unwrapEither
+        resultWasmPath result `shouldBe` Just path
+        doesFileExist path `shouldReturn` True
+
+    it "reports type-check failures with a stage" $ do
+        case compileSource "fn bad() -> u4 { let x: u4 = true; return 1; }" of
+            Left err -> packageErrorStage err `shouldBe` "type-check"
+            Right _ -> expectationFailure "expected type-check failure"
+
+unwrapEither :: Show err => Either err value -> IO value
+unwrapEither result =
+    case result of
+        Left err -> expectationFailure (show err) >> error "unreachable after expectationFailure"
+        Right value -> pure value

--- a/code/packages/haskell/nib-wasm-compiler/test/Spec.hs
+++ b/code/packages/haskell/nib-wasm-compiler/test/Spec.hs
@@ -1,0 +1,5 @@
+import qualified NibWasmCompilerSpec
+import Test.Hspec
+
+main :: IO ()
+main = hspec NibWasmCompilerSpec.spec

--- a/code/packages/haskell/wasm-execution/src/WasmExecution.hs
+++ b/code/packages/haskell/wasm-execution/src/WasmExecution.hs
@@ -310,9 +310,11 @@ executeFunctionBody engine functionType body args = go 0 0 [] initialLocals
                         Right _ -> pure (Left (TrapError "memory.grow expects an i32 page count"))
                 0x41 -> doSignedConst pc stack locals blockDepth (WasmI32 . fromIntegral)
                 0x42 -> doSignedConst pc stack locals blockDepth (WasmI64 . fromIntegral)
+                0x45 -> unaryI32Op pc blockDepth stack locals (\value -> if value == 0 then 1 else 0)
                 0x6A -> binaryI32Op pc blockDepth stack locals (+)
                 0x6B -> binaryI32Op pc blockDepth stack locals (-)
                 0x6C -> binaryI32Op pc blockDepth stack locals (*)
+                0x71 -> binaryI32Op pc blockDepth stack locals (Bits..&.)
                 _ -> pure (Left (TrapError ("unsupported opcode: " ++ show (BS.index codeBytes pc))))
 
     continueWithBlock pc blockDepth stack locals =
@@ -365,6 +367,13 @@ executeFunctionBody engine functionType body args = go 0 0 [] initialLocals
                                         storeAction memory (fromIntegral baseAddress + memOffset) value
                                         go (pc + 1 + consumed) blockDepth restStack locals
                             Right _ -> pure (Left (TrapError "memory store expects an i32 address"))
+
+    unaryI32Op pc blockDepth stack locals operation =
+        case popValue stack of
+            Left err -> pure (Left err)
+            Right (WasmI32 value, restStack) ->
+                go (pc + 1) blockDepth (WasmI32 (operation value) : restStack) locals
+            Right _ -> pure (Left (TrapError "numeric instruction expects an i32 operand"))
 
     binaryI32Op pc blockDepth stack locals operation =
         case popValue stack of

--- a/code/specs/04n-haskell-wasm-convergence.md
+++ b/code/specs/04n-haskell-wasm-convergence.md
@@ -1,0 +1,152 @@
+# 04n - Haskell Brainfuck and Nib Wasm Convergence
+
+## Goal
+
+Close the Haskell end-to-end Wasm gap for the two source languages that are
+already part of the generic IR effort:
+
+```text
+Brainfuck source
+  -> brainfuck
+  -> brainfuck-ir-compiler
+  -> ir-to-wasm-compiler
+  -> wasm-module-encoder
+  -> .wasm bytes
+
+Nib source
+  -> nib-lexer
+  -> nib-parser
+  -> nib-type-checker
+  -> nib-ir-compiler
+  -> ir-to-wasm-compiler
+  -> wasm-module-encoder
+  -> .wasm bytes
+```
+
+This Haskell wave is intentionally separate from the Java/Kotlin and C#/F#
+waves because Haskell package builds are sensitive to `cabal.project`
+dependency ordering in CI.
+
+## Package Set
+
+This wave adds the missing Haskell packages needed for local source-to-Wasm
+pipelines:
+
+- `code/packages/haskell/compiler-ir`
+- `code/packages/haskell/brainfuck`
+- `code/packages/haskell/brainfuck-ir-compiler`
+- `code/packages/haskell/ir-optimizer`
+- `code/packages/haskell/ir-to-wasm-validator`
+- `code/packages/haskell/ir-to-wasm-compiler`
+- `code/packages/haskell/brainfuck-wasm-compiler`
+- `code/packages/haskell/nib-type-checker`
+- `code/packages/haskell/nib-ir-compiler`
+- `code/packages/haskell/nib-wasm-compiler`
+
+Every package must include `BUILD`, `BUILD_windows`, `README.md`,
+`CHANGELOG.md`, a `.cabal` file, a `cabal.project`, and tests.
+
+## Build Footgun Rule
+
+Every Haskell `cabal.project` in this wave must list transitive local packages
+explicitly in leaf-to-root order. Do not rely on Cabal discovering sibling
+packages implicitly. The repo build validator and CI run many packages in
+clean, package-local contexts, so missing transitive project entries should be
+treated as build failures even when a developer machine has cached packages.
+
+## Brainfuck Contract
+
+The Haskell Brainfuck lane must:
+
+- tokenize and parse Brainfuck source into a local AST
+- lower Brainfuck operations into `compiler-ir`
+- lower that IR into a Wasm module
+- validate the Wasm module
+- encode raw Wasm bytes
+- expose `compileSource`, `packSource`, and `writeWasmFile`
+
+The minimum supported source subset is the complete Brainfuck instruction set:
+`>`, `<`, `+`, `-`, `.`, `,`, `[`, and `]`.
+
+## Nib Contract
+
+The Haskell Nib lane must use the existing Haskell `nib-lexer` and `nib-parser`
+and add the semantic/compiler pieces needed for the convergence smoke subset:
+
+- top-level `fn`
+- local `let`
+- assignment
+- `return`
+- integer literals
+- name references
+- function calls
+- wrapping addition for `u4`
+
+The package must derive Wasm exports from source functions:
+
+- `_start` exports as `_start`
+- `_fn_NAME` exports as `NAME`
+- function parameters map to the generic IR ABI registers `v2+`
+- return values leave functions in `v1`
+
+## Public Orchestrator Results
+
+Both source-to-Wasm packages should return stage-rich result values containing:
+
+- source text
+- frontend AST
+- raw IR
+- optimized IR
+- Wasm module
+- validated module
+- encoded bytes
+- optional write path
+
+Nib results must additionally retain the typed AST.
+
+## Error Model
+
+Each orchestrator must report stage-labeled errors. Required stages are:
+
+- `parse`
+- `type-check` for Nib
+- `ir-compile`
+- `validate-ir`
+- `lower`
+- `validate-wasm`
+- `encode`
+- `write`
+
+## Tests
+
+Each package should have focused package-local tests. The orchestrator packages
+must cover:
+
+- successful `compileSource`
+- `packSource` alias behavior
+- `writeWasmFile`
+- stage-labeled failures
+- runtime execution through the local Haskell Wasm runtime when the emitted
+  module does not require unsupported host behavior
+
+Preferred runtime smoke programs:
+
+- Brainfuck: simple arithmetic/loop output or a non-IO pointer/cell program
+- Nib: `fn answer() -> u4 { return 7; }`
+- Nib: `fn add(a: u4, b: u4) -> u4 { return a +% b; }`
+
+## Non-Goals
+
+This wave does not:
+
+- add Haskell JVM class-file generation
+- change the generic IR opcode contract
+- complete Java/Kotlin or C#/F# convergence
+- require the full Nib language beyond the convergence smoke subset
+
+## Completion Definition
+
+The wave is complete when Haskell has honest local Brainfuck-to-Wasm and
+Nib-to-Wasm packages, the package builds pass locally, the build metadata
+validator does not report new Haskell dependency issues, and the branch passes
+security review before push.


### PR DESCRIPTION
## Summary

- Adds the Haskell source-to-Wasm convergence stack for Brainfuck and Nib.
- Adds shared Haskell `compiler-ir`, `ir-optimizer`, `ir-to-wasm-validator`, and `ir-to-wasm-compiler` packages.
- Adds Brainfuck parsing plus semantic tape-backed IR lowering, including byte loads/stores, structured loop lowering, and WASI syscall markers.
- Adds Nib type checking, Nib-to-IR lowering, and Brainfuck/Nib orchestrator packages that emit Wasm bytes.

## Validation

- `cabal test all` in `code/packages/haskell/brainfuck-wasm-compiler`
- `cabal test all` in `code/packages/haskell/nib-wasm-compiler`
- Security review passed in 1 round with no vulnerabilities found.
- Build-plan validator was run; it still reports existing unrelated repo metadata failures for `swift/programs/hash-breaker`, `typescript/arithmetic`, and Dart `deflate`/`huffman-compression`, but no new Haskell dependency issues were reported.

## Notes

Haskell is split out from the Java/Kotlin and C#/F# convergence batches because its package-local `cabal.project` transitive dependency closure is CI-sensitive.