### PR TITLE
feat(note-frequency): add Lua package

### DIFF
--- a/code/packages/lua/note-frequency/BUILD
+++ b/code/packages/lua/note-frequency/BUILD
@@ -1,0 +1,2 @@
+luarocks make --local coding-adventures-note-frequency-0.1.0-1.rockspec
+cd tests && busted . --verbose --pattern=test_

--- a/code/packages/lua/note-frequency/BUILD_windows
+++ b/code/packages/lua/note-frequency/BUILD_windows
@@ -1,0 +1,2 @@
+luarocks make --local coding-adventures-note-frequency-0.1.0-1.rockspec
+cd tests && busted . --verbose --pattern=test_

--- a/code/packages/lua/note-frequency/CHANGELOG.md
+++ b/code/packages/lua/note-frequency/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Added the initial note-to-frequency package.
+- Added note parsing for natural notes plus single sharps and flats.
+- Added equal-tempered frequency mapping anchored at `A4 = 440 Hz`.
+- Added tests that lock down the shared parity vectors across language ports.

--- a/code/packages/lua/note-frequency/README.md
+++ b/code/packages/lua/note-frequency/README.md
@@ -1,0 +1,23 @@
+# coding-adventures-note-frequency
+
+
+Parses typed musical note labels such as `A4`, `C#5`, and `Db3` into a structured
+`Note` value and then maps that note to its equal-tempered frequency in Hertz.
+
+This package is the symbolic front door for the music stack:
+
+- users type note names
+- this layer turns them into exact pitches
+- later oscillator and renderer packages will turn those pitches into sound
+
+The core reference point is `A4 = 440 Hz`, and every semitone step multiplies
+frequency by `2^(1/12)`.
+
+
+## Usage
+
+```lua
+local note_frequency = require("coding_adventures.note_frequency")
+local note = note_frequency.parse_note("A4")
+local frequency = note_frequency.note_to_frequency("C4")
+```

--- a/code/packages/lua/note-frequency/coding-adventures-note-frequency-0.1.0-1.rockspec
+++ b/code/packages/lua/note-frequency/coding-adventures-note-frequency-0.1.0-1.rockspec
@@ -1,0 +1,18 @@
+package = "coding-adventures-note-frequency"
+version = "0.1.0-1"
+source = {
+    url = "https://github.com/adhithyan15/coding-adventures.git",
+}
+description = {
+    summary = "Parse note names like A4 and map them to equal-tempered frequencies",
+    license = "MIT",
+}
+dependencies = {
+    "lua >= 5.4",
+}
+build = {
+    type = "builtin",
+    modules = {
+        ["coding_adventures.note_frequency"] = "src/coding_adventures/note_frequency/init.lua",
+    },
+}

--- a/code/packages/lua/note-frequency/coding-adventures-note-frequency-0.1.0-1.rockspec
+++ b/code/packages/lua/note-frequency/coding-adventures-note-frequency-0.1.0-1.rockspec
@@ -2,6 +2,7 @@ package = "coding-adventures-note-frequency"
 version = "0.1.0-1"
 source = {
     url = "https://github.com/adhithyan15/coding-adventures.git",
+    tag = "131cb3cacda192b556bd913281e5a37cbf4f99ff",
 }
 description = {
     summary = "Parse note names like A4 and map them to equal-tempered frequencies",

--- a/code/packages/lua/note-frequency/required_capabilities.json
+++ b/code/packages/lua/note-frequency/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "lua/note-frequency",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/lua/note-frequency/src/coding_adventures/note_frequency/init.lua
+++ b/code/packages/lua/note-frequency/src/coding_adventures/note_frequency/init.lua
@@ -1,0 +1,82 @@
+local note_frequency = {}
+local Note = {}
+Note.__index = Note
+
+local NOTE_PATTERN = "^([A-Ga-g])([#b]?)(%-?%d+)$"
+local CHROMATIC_INDEX = {
+    ["C"] = 0,
+    ["C#"] = 1,
+    ["Db"] = 1,
+    ["D"] = 2,
+    ["D#"] = 3,
+    ["Eb"] = 3,
+    ["E"] = 4,
+    ["F"] = 5,
+    ["F#"] = 6,
+    ["Gb"] = 6,
+    ["G"] = 7,
+    ["G#"] = 8,
+    ["Ab"] = 8,
+    ["A"] = 9,
+    ["A#"] = 10,
+    ["Bb"] = 10,
+    ["B"] = 11,
+}
+
+local REFERENCE_OCTAVE = 4
+local REFERENCE_INDEX = CHROMATIC_INDEX["A"]
+local REFERENCE_FREQUENCY_HZ = 440.0
+local SEMITONES_PER_OCTAVE = 12
+
+function Note.new(letter, accidental, octave)
+    local canonical_letter = string.upper(letter)
+    local spelling = canonical_letter .. accidental
+    if CHROMATIC_INDEX[spelling] == nil then
+        error("Unsupported note spelling " .. string.format("%q", spelling) .. ". Only natural notes plus single # or b accidentals are supported.")
+    end
+
+    return setmetatable({
+        letter = canonical_letter,
+        accidental = accidental,
+        octave = octave,
+    }, Note)
+end
+
+function Note:spelling()
+    return self.letter .. self.accidental
+end
+
+function Note:chromatic_index()
+    return CHROMATIC_INDEX[self:spelling()]
+end
+
+function Note:semitones_from_a4()
+    local octave_offset = (self.octave - REFERENCE_OCTAVE) * SEMITONES_PER_OCTAVE
+    local pitch_offset = self:chromatic_index() - REFERENCE_INDEX
+    return octave_offset + pitch_offset
+end
+
+function Note:frequency()
+    return REFERENCE_FREQUENCY_HZ * (2 ^ (self:semitones_from_a4() / SEMITONES_PER_OCTAVE))
+end
+
+function Note:__tostring()
+    return self:spelling() .. tostring(self.octave)
+end
+
+function note_frequency.parse_note(text)
+    local letter, accidental, octave_text = string.match(text, NOTE_PATTERN)
+    if letter == nil then
+        error("Invalid note " .. string.format("%q", text) .. ". Expected <letter><optional # or b><octave>, for example 'A4', 'C#5', or 'Db3'.")
+    end
+
+    return Note.new(letter, accidental, tonumber(octave_text))
+end
+
+function note_frequency.note_to_frequency(text)
+    return note_frequency.parse_note(text):frequency()
+end
+
+note_frequency.Note = Note
+
+return note_frequency

--- a/code/packages/lua/note-frequency/tests/test_note_frequency.lua
+++ b/code/packages/lua/note-frequency/tests/test_note_frequency.lua
@@ -1,0 +1,51 @@
+package.path = "../src/?.lua;" .. "../src/?/init.lua;" .. package.path
+
+local note_frequency = require("coding_adventures.note_frequency")
+
+describe("note_frequency", function()
+    it("parses note fields", function()
+        local note = note_frequency.parse_note("C#5")
+        assert.are.equal("C", note.letter)
+        assert.are.equal("#", note.accidental)
+        assert.are.equal(5, note.octave)
+    end)
+
+    it("normalizes lowercase note letters", function()
+        assert.are.equal("G4", tostring(note_frequency.parse_note("g4")))
+    end)
+
+    it("rejects malformed note strings", function()
+        for _, value in ipairs({"", "A", "H4", "#4", "4A", "A##4", "Bb"}) do
+            local ok, err = pcall(function()
+                note_frequency.parse_note(value)
+            end)
+
+            assert.is_false(ok)
+            assert.is_truthy(string.find(err, "Invalid note", 1, true))
+        end
+    end)
+
+    it("rejects unsupported spellings", function()
+        local ok, err = pcall(function()
+            note_frequency.Note.new("E", "#", 4)
+        end)
+
+        assert.is_false(ok)
+        assert.is_truthy(string.find(err, "Unsupported note spelling", 1, true))
+    end)
+
+    it("matches semitone reference examples", function()
+        assert.are.equal(0, note_frequency.parse_note("A4"):semitones_from_a4())
+        assert.are.equal(12, note_frequency.parse_note("A5"):semitones_from_a4())
+        assert.are.equal(-12, note_frequency.parse_note("A3"):semitones_from_a4())
+        assert.are.equal(-9, note_frequency.parse_note("C4"):semitones_from_a4())
+    end)
+
+    it("matches frequency reference examples", function()
+        assert.is_true(math.abs(note_frequency.parse_note("A4"):frequency() - 440.0) < 1e-12)
+        assert.is_true(math.abs(note_frequency.parse_note("A5"):frequency() - 880.0) < 1e-12)
+        assert.is_true(math.abs(note_frequency.parse_note("A3"):frequency() - 220.0) < 1e-12)
+        assert.is_true(math.abs(note_frequency.note_to_frequency("C4") - 261.6255653005986) < 1e-12)
+        assert.is_true(math.abs(note_frequency.note_to_frequency("C#4") - note_frequency.note_to_frequency("Db4")) < 1e-12)
+    end)
+end)


### PR DESCRIPTION
## Summary
- Adds the Lua `note-frequency` package for the shared MUS00 note-to-frequency contract.
- Includes LuaRocks metadata, BUILD/BUILD_windows files, package README, changelog, tests, and required capability declaration.
- Pins the LuaRocks source to the first immutable source-containing commit and uses HTTPS rather than `git://`.
- Adds explicit `package.path` source wiring in tests so Windows and local source runs do not depend on global LuaRocks state.

## Verification
- `HOME=/tmp/ca-luarocks-home bash BUILD` in `code/packages/lua/note-frequency` — 6 successes
- `cd tests && busted . --verbose --pattern=test_` — 6 successes
- `GOCACHE=/tmp/go-build-cache GOMODCACHE=/tmp/go-mod-cache GOTOOLCHAIN=auto go build -o /tmp/ca-build-tool-lua .`
- `/tmp/ca-build-tool-lua -root /tmp/coding-adventures-note-frequency-lua-clean -detect-languages -emit-plan /tmp/note-frequency-lua-plan.json -diff-base github/main -validate-build-files` — 1 changed/affected package; needs Go + Lua only
- `git diff --check github/main...HEAD`
- Security review sub-agent — passed, no vulnerabilities found

## Notes
- Work was validated in a clean `/tmp` checkout because the main local checkout is intentionally noisy and the sandbox blocked `git worktree add` from writing branch refs under the launcher repo `.git`. The branch itself was created through the GitHub API from current `main`.