### PR TITLE
feat(dartmouth-basic): compiled pipeline — IR compiler + GE-225 backend

### DIFF
--- a/code/packages/python/compiler-ir/src/compiler_ir/opcodes.py
+++ b/code/packages/python/compiler-ir/src/compiler_ir/opcodes.py
@@ -21,7 +21,7 @@ The opcodes are grouped by category:
 
   Constants:    LOAD_IMM, LOAD_ADDR
   Memory:       LOAD_BYTE, STORE_BYTE, LOAD_WORD, STORE_WORD
-  Arithmetic:   ADD, ADD_IMM, SUB, AND, AND_IMM
+  Arithmetic:   ADD, ADD_IMM, SUB, AND, AND_IMM, MUL, DIV
   Comparison:   CMP_EQ, CMP_NE, CMP_LT, CMP_GT
   Control Flow: LABEL, JUMP, BRANCH_Z, BRANCH_NZ, CALL, RET
   System:       SYSCALL, HALT
@@ -103,6 +103,16 @@ class IrOp(IntEnum):
     # Register-immediate bitwise AND: dst = src & immediate.
     #   AND_IMM v2, v2, 255  →  v2 = v2 & 0xFF
     AND_IMM = 10
+
+    # Register-register multiplication: dst = lhs * rhs (signed integer).
+    # For 20-bit targets the result is the low 20 bits of the product.
+    #   MUL v3, v1, v2  →  v3 = v1 * v2
+    MUL = 25
+
+    # Register-register integer division: dst = lhs / rhs (truncates toward zero).
+    # Division by zero is a runtime error; the backend is responsible for detection.
+    #   DIV v3, v1, v2  →  v3 = v1 / v2
+    DIV = 26
 
     # ── Comparison ────────────────────────────────────────────────────────────
     # Set dst = 1 if lhs == rhs, else 0.

--- a/code/packages/python/compiler-ir/tests/test_compiler_ir.py
+++ b/code/packages/python/compiler-ir/tests/test_compiler_ir.py
@@ -75,10 +75,12 @@ class TestIrOp:
         assert IrOp.HALT == 22
         assert IrOp.NOP == 23
         assert IrOp.COMMENT == 24
+        assert IrOp.MUL == 25
+        assert IrOp.DIV == 26
 
     def test_total_opcode_count(self) -> None:
-        """There are exactly 25 opcodes (0–24)."""
-        assert len(IrOp) == 25
+        """There are exactly 27 opcodes (0–24, plus MUL=25 and DIV=26)."""
+        assert len(IrOp) == 27
 
     def test_name_to_op_roundtrip(self) -> None:
         """NAME_TO_OP[op.name] == op for every opcode."""
@@ -754,6 +756,8 @@ class TestAllOpcodesPrintParse:
             IrOp.HALT:       [],
             IrOp.NOP:        [],
             IrOp.COMMENT:    [IrLabel("a test comment")],
+            IrOp.MUL:        [IrRegister(3), IrRegister(1), IrRegister(2)],
+            IrOp.DIV:        [IrRegister(3), IrRegister(1), IrRegister(2)],
         }
         for idx, op in enumerate(IrOp):
             operands = operands_by_opcode[op]

--- a/code/packages/python/dartmouth-basic-ir-compiler/BUILD
+++ b/code/packages/python/dartmouth-basic-ir-compiler/BUILD
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../grammar-tools -e ../graph -e ../directed-graph -e ../state-machine -e ../lexer -e ../parser -e ../dartmouth-basic-lexer -e ../dartmouth-basic-parser -e ../compiler-ir -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/dartmouth-basic-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/dartmouth-basic-ir-compiler/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## 0.1.0 (2026-04-18)
+
+Initial release of the Dartmouth BASIC IR compiler.
+
+### Added
+
+- `compile_basic(ast)` function: lowers a parsed Dartmouth BASIC AST to a target-independent `IrProgram`
+- V1 statement support: `REM`, `LET`, `PRINT` (string literals), `GOTO`, `IF/THEN`, `FOR/NEXT`, `END`, `STOP`
+- All six relational operators for `IF`: `<`, `>`, `=`, `<>`, `<=`, `>=`
+- Expression compilation: addition, subtraction, multiplication, division, unary minus
+- Fixed virtual register assignment: variables A–Z → v1–v26
+- GE-225 typewriter code table for `PRINT` character encoding
+- `CompileError` raised for V1-excluded features (GOSUB, DIM, INPUT, DEF FN, power operator)
+- `CompileResult` dataclass with `program` and `var_regs`

--- a/code/packages/python/dartmouth-basic-ir-compiler/README.md
+++ b/code/packages/python/dartmouth-basic-ir-compiler/README.md
@@ -1,0 +1,55 @@
+# dartmouth-basic-ir-compiler
+
+Dartmouth BASIC 1964 frontend: lowers a parsed BASIC AST to target-independent IR.
+
+## Overview
+
+This package is the compiler frontend in the Dartmouth BASIC compiled pipeline:
+
+```
+BASIC source
+    ↓  dartmouth-basic-lexer     (tokenize)
+    ↓  dartmouth-basic-parser    (parse to AST)
+    ↓  dartmouth-basic-ir-compiler   (this package — lower to IR)
+    ↓  ir-to-ge225-compiler         (emit GE-225 machine words)
+    ↓  ge225-simulator               (execute)
+```
+
+It accepts an `ASTNode` from `dartmouth_basic_parser` and emits a
+`compiler_ir.IrProgram` that any backend (GE-225, WASM, JVM) can compile to
+native code.
+
+## Usage
+
+```python
+from dartmouth_basic_parser import parse_dartmouth_basic
+from dartmouth_basic_ir_compiler import compile_basic
+
+source = "10 FOR I = 1 TO 5\n20 PRINT \"HELLO\"\n30 NEXT I\n40 END\n"
+ast = parse_dartmouth_basic(source)
+result = compile_basic(ast)
+
+# result.program: IrProgram ready for any backend
+# result.var_regs["I"]: virtual register index for BASIC variable I
+```
+
+## V1 Supported Statements
+
+| Statement | Notes |
+|-----------|-------|
+| `REM` | No-op |
+| `LET var = expr` | Scalar variables A–Z only; all arithmetic operators |
+| `PRINT "string"` | String literals only; auto-uppercased |
+| `GOTO lineno` | Unconditional jump |
+| `IF expr relop expr THEN lineno` | All six relational operators |
+| `FOR var = expr TO expr [STEP expr]` | Positive step; pre-test loop |
+| `NEXT var` | Closes innermost FOR |
+| `END` / `STOP` | Halt |
+
+## Historical Note
+
+Dartmouth BASIC was designed in 1964 by John Kemeny and Thomas Kurtz to run on
+the GE-225 mainframe at Dartmouth College. It was the world's first language
+designed for time-sharing: students typed programs on Teletype terminals and
+received results in seconds. This package is a faithful compiled implementation
+of that original language, targeting the same GE-225 hardware architecture.

--- a/code/packages/python/dartmouth-basic-ir-compiler/pyproject.toml
+++ b/code/packages/python/dartmouth-basic-ir-compiler/pyproject.toml
@@ -1,0 +1,45 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-dartmouth-basic-ir-compiler"
+version = "0.1.0"
+description = "Dartmouth BASIC 1964 frontend: lowers a parsed BASIC AST to target-independent IR"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["basic", "dartmouth", "compiler", "ir", "codegen", "history", "education"]
+dependencies = [
+    "coding-adventures-compiler-ir",
+    "coding-adventures-dartmouth-basic-parser",
+]
+
+[project.urls]
+Homepage = "https://github.com/adhithyan15/coding-adventures"
+Repository = "https://github.com/adhithyan15/coding-adventures"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/dartmouth_basic_ir_compiler"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM", "ANN"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=dartmouth_basic_ir_compiler --cov-report=term-missing --cov-fail-under=95"
+
+[tool.coverage.run]
+source = ["src/dartmouth_basic_ir_compiler"]
+
+[tool.coverage.report]
+fail_under = 95
+show_missing = true

--- a/code/packages/python/dartmouth-basic-ir-compiler/src/dartmouth_basic_ir_compiler/__init__.py
+++ b/code/packages/python/dartmouth-basic-ir-compiler/src/dartmouth_basic_ir_compiler/__init__.py
@@ -1,0 +1,40 @@
+"""Dartmouth BASIC IR Compiler — lowers a BASIC AST to target-independent IR.
+
+This package is the Dartmouth BASIC frontend of the ahead-of-time compiler
+pipeline. It accepts a parsed AST from ``dartmouth_basic_parser`` and emits
+a ``compiler_ir.IrProgram`` that any backend (GE-225, WASM, JVM) can compile
+to native code.
+
+V1 supports: LET, FOR/NEXT, IF/THEN, GOTO, PRINT (string literals), END, STOP, REM.
+
+Usage::
+
+    from dartmouth_basic_parser import parse_dartmouth_basic
+    from dartmouth_basic_ir_compiler import compile_basic, CompileError
+
+    source = "10 FOR I = 1 TO 5\\n20 PRINT \"HELLO\"\\n30 NEXT I\\n40 END\\n"
+    ast = parse_dartmouth_basic(source)
+    result = compile_basic(ast)
+    # result.program: IrProgram ready for the GE-225 backend
+    # result.var_regs["I"]: virtual register index for variable I
+"""
+
+from dartmouth_basic_ir_compiler.compiler import (
+    CompileError,
+    CompileResult,
+    compile_basic,
+)
+from dartmouth_basic_ir_compiler.ge225_codes import (
+    CARRIAGE_RETURN_CODE,
+    GE225_CODES,
+    ascii_to_ge225,
+)
+
+__all__ = [
+    "compile_basic",
+    "CompileResult",
+    "CompileError",
+    "GE225_CODES",
+    "CARRIAGE_RETURN_CODE",
+    "ascii_to_ge225",
+]

--- a/code/packages/python/dartmouth-basic-ir-compiler/src/dartmouth_basic_ir_compiler/compiler.py
+++ b/code/packages/python/dartmouth-basic-ir-compiler/src/dartmouth_basic_ir_compiler/compiler.py
@@ -1,0 +1,1097 @@
+"""Dartmouth BASIC IR Compiler — lowers a BASIC AST to target-independent IR.
+
+Overview
+--------
+
+This module is the Dartmouth BASIC-specific frontend of the AOT compiler
+pipeline. It walks the AST produced by ``dartmouth_basic_parser`` and emits
+IR instructions for each BASIC statement and expression.
+
+The compiler knows nothing about machine architecture. It produces a generic
+``IrProgram`` that any backend (GE-225, WASM, JVM) can translate to native code.
+
+Historical Note
+---------------
+
+Dartmouth BASIC was the world's first general-purpose programming language
+designed to be compiled and run on shared, time-sliced hardware. In 1964,
+John Kemeny and Thomas Kurtz ran the first BASIC programs on a GE-225 mainframe
+at Dartmouth College. Students typed programs on Teletype terminals and received
+printed output within seconds — a radical departure from the batch-processing
+model where a programmer submitted a deck of punched cards and waited overnight.
+
+The language was intentionally simple: 17 statement types, floating-point only,
+1-based arrays, and line numbers as the sole control-flow mechanism. GOTO and
+GOSUB were not bugs — they were the entire control structure, and they worked
+well at the scale of programs that fit on a single teletype page.
+
+V1 Scope
+--------
+
+This first version compiles the subset needed to run meaningful integer programs:
+
+  - REM    — no-op comments
+  - LET    — variable assignment (scalar only) with all arithmetic operators
+  - PRINT  — string literal output only (no numeric variables)
+  - GOTO   — unconditional jump to a line number
+  - IF … THEN — conditional jump; all six relational operators
+  - FOR … TO [STEP] — pre-test counted loop with positive integer step
+  - NEXT   — ends the innermost FOR loop
+  - END    — halt execution
+  - STOP   — halt execution (synonym for END in V1)
+
+Virtual Register Layout
+-----------------------
+
+Every BASIC variable gets a fixed virtual register. The GE-225 backend will
+assign each register a dedicated spill slot (memory word). This fixed layout
+means that GOTO targets and loop iterations always read/write the correct register:
+
+  v0       — syscall argument (char code to print for SYSCALL 1)
+  v1–v26   — BASIC scalar variables A–Z (v1=A, v2=B, …, v26=Z)
+  v27–v286 — BASIC two-character variables A0–Z9 (v27=A0, v28=A1, …)
+  v287+    — expression temporaries (fresh register per intermediate value)
+
+Expression temporaries are never recycled — the counter only moves forward.
+This keeps the IR simple and avoids liveness analysis, at the cost of a larger
+spill area. For the GE-225 simulator this is irrelevant; memory is plentiful.
+
+Label Conventions
+-----------------
+
+  _start          — program entry point
+  _line_N         — BASIC line number N (GOTO/IF target)
+  _for_N_check    — top of FOR loop N's pre-test
+  _for_N_end      — label after FOR loop N's body (NEXT target)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from compiler_ir import (
+    IDGenerator,
+    IrImmediate,
+    IrInstruction,
+    IrLabel,
+    IrOp,
+    IrProgram,
+    IrRegister,
+)
+from lang_parser import ASTNode
+from lexer import Token
+
+from dartmouth_basic_ir_compiler.ge225_codes import (
+    CARRIAGE_RETURN_CODE,
+    ascii_to_ge225,
+)
+
+
+# ---------------------------------------------------------------------------
+# Token type comparison helper
+# ---------------------------------------------------------------------------
+#
+# The lexer uses both string token types (e.g., "LINE_NUM", "EQ") and enum
+# token types (e.g., TokenType.NAME, TokenType.NUMBER). This helper normalises
+# both so the rest of the compiler can compare with plain string names.
+
+
+def _type_is(token_type: object, name: str) -> bool:
+    """Return True if token_type matches the given type name string.
+
+    Handles both string types (``"EQ"``) and enum types (``TokenType.NAME``).
+
+    Args:
+        token_type: The ``token.type`` value (str or enum member).
+        name: The canonical type name to compare against.
+
+    Returns:
+        True if the type's name equals ``name``.
+
+    Example::
+
+        _type_is("NAME", "NAME")          # True
+        _type_is(TokenType.NAME, "NAME")  # True
+        _type_is(TokenType.NUMBER, "NAME") # False
+    """
+    if isinstance(token_type, str):
+        return token_type == name
+    return getattr(token_type, "name", None) == name
+
+# ---------------------------------------------------------------------------
+# Fixed virtual register indices
+# ---------------------------------------------------------------------------
+
+_REG_SYSCALL_ARG = 0   # v0: argument to SYSCALL 1 (typewriter char code)
+
+# BASIC scalar variable A–Z → v1–v26
+_VAR_BASE = 1                       # v1 = A
+_VAR_LETTER_DIGIT_BASE = 27         # v27 = A0
+
+# Expression temporaries start at v287 (after all variable registers)
+_TEMP_BASE = 287
+
+# Syscall number for "print char in v0"
+_SYSCALL_PRINT_CHAR = 1
+
+
+def _scalar_reg(name: str) -> int:
+    """Map a BASIC scalar variable name to its fixed virtual register index.
+
+    Single-letter variables (A–Z) map to v1–v26.
+    Two-character variables (A0–Z9) map to v27–v286.
+
+    Args:
+        name: The BASIC variable name (e.g., ``"A"``, ``"B3"``).
+
+    Returns:
+        The virtual register index.
+
+    Example::
+
+        _scalar_reg("A")   # 1
+        _scalar_reg("Z")   # 26
+        _scalar_reg("A0")  # 27
+        _scalar_reg("Z9")  # 286
+    """
+    if len(name) == 1:
+        return _VAR_BASE + (ord(name.upper()) - ord("A"))
+    # Two-character: letter (0..25) * 10 + digit (0..9)
+    letter_index = ord(name[0].upper()) - ord("A")
+    digit_index = int(name[1])
+    return _VAR_LETTER_DIGIT_BASE + letter_index * 10 + digit_index
+
+
+# ---------------------------------------------------------------------------
+# FOR stack record
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _ForRecord:
+    """State kept while compiling a FOR loop.
+
+    Pushed onto ``_Compiler._for_stack`` when FOR is encountered.
+    Popped when the matching NEXT is encountered.
+
+    Attributes:
+        var_name:    The BASIC variable name of the loop counter.
+        var_reg:     Virtual register for the loop counter.
+        limit_reg:   Virtual register holding the limit (upper bound).
+        step_reg:    Virtual register holding the step value.
+        check_label: Label at the top of the pre-test (jump back here on NEXT).
+        end_label:   Label after the loop body (jump here when counter > limit).
+        loop_num:    Unique integer N for this loop (used in label names).
+    """
+
+    var_name: str
+    var_reg: int
+    limit_reg: int
+    step_reg: int
+    check_label: str
+    end_label: str
+    loop_num: int
+
+
+# ---------------------------------------------------------------------------
+# CompileResult and CompileError
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CompileResult:
+    """The outputs of a successful BASIC compilation.
+
+    Attributes:
+        program:  The compiled ``IrProgram`` containing all IR instructions.
+        var_regs: Maps BASIC variable names to their virtual register indices.
+                  Useful for debugging: after execution, the value of BASIC
+                  variable A is in the memory word for register ``var_regs["A"]``.
+
+    Example::
+
+        result = compile_basic(ast)
+        print(result.var_regs["I"])   # register index for variable I
+    """
+
+    program: IrProgram
+    var_regs: dict[str, int]
+
+
+class CompileError(ValueError):
+    """Raised when the BASIC program contains a feature not supported in V1.
+
+    Examples:
+        - GOSUB / RETURN (subroutine calls)
+        - DIM (array declarations)
+        - INPUT, DATA, READ, RESTORE
+        - DEF FN (user-defined functions)
+        - PRINT with numeric variables or formatting
+        - Exponentiation (^ operator)
+        - NEXT without a matching FOR
+        - NEXT naming the wrong variable
+        - String characters without a GE-225 typewriter code
+    """
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def compile_basic(ast: ASTNode) -> CompileResult:
+    """Compile a Dartmouth BASIC AST to an IrProgram.
+
+    This is the main entry point. It takes the root AST node from
+    ``dartmouth_basic_parser.parse_dartmouth_basic()`` and lowers it to a
+    target-independent ``IrProgram``.
+
+    Args:
+        ast: Root ``ASTNode`` with ``rule_name == "program"``.
+
+    Returns:
+        A ``CompileResult`` containing the IR program and variable register map.
+
+    Raises:
+        CompileError: If the program uses a V1-excluded feature (GOSUB, DIM,
+                      INPUT, DEF FN, PRINT with variables, exponentiation,
+                      NEXT without FOR, or unsupported string characters).
+        ValueError:   If ``ast.rule_name != "program"``.
+
+    Example::
+
+        from dartmouth_basic_parser import parse_dartmouth_basic
+        from dartmouth_basic_ir_compiler import compile_basic
+
+        ast = parse_dartmouth_basic("10 LET A = 5\\n20 END\\n")
+        result = compile_basic(ast)
+        # result.program contains the IrProgram
+        # result.var_regs["A"] == 1 (virtual register for variable A)
+    """
+    if ast.rule_name != "program":
+        raise ValueError(
+            f"expected 'program' AST node, got {ast.rule_name!r}"
+        )
+    c = _Compiler()
+    return c.compile(ast)
+
+
+# ---------------------------------------------------------------------------
+# Internal compiler
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Compiler:
+    """Internal compiler state — not part of the public API.
+
+    Created by ``compile_basic()`` and discarded after compilation.
+
+    Attributes:
+        _program:    The IR program being built.
+        _id_gen:     Produces unique monotonic instruction IDs.
+        _next_reg:   Next expression-temporary register index.
+        _loop_count: Counter for unique FOR loop names.
+        _for_stack:  Stack of open FOR loop records (innermost last).
+    """
+
+    _program: IrProgram = field(init=False)
+    _id_gen: IDGenerator = field(default_factory=IDGenerator)
+    _next_reg: int = field(default=_TEMP_BASE)
+    _loop_count: int = field(default=0)
+    _for_stack: list[_ForRecord] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        """Initialize the IR program."""
+        self._program = IrProgram(entry_label="_start")
+
+    # ------------------------------------------------------------------
+    # Top-level compilation
+    # ------------------------------------------------------------------
+
+    def compile(self, ast: ASTNode) -> CompileResult:
+        """Run the full compilation and return the result."""
+        self._emit_label("_start")
+        for child in ast.children:
+            if isinstance(child, ASTNode) and child.rule_name == "line":
+                self._compile_line(child)
+        # Epilogue: catch programs that fall through without END
+        self._emit(IrOp.HALT)
+        var_regs = {
+            chr(ord("A") + i): _VAR_BASE + i for i in range(26)
+        }
+        return CompileResult(program=self._program, var_regs=var_regs)
+
+    # ------------------------------------------------------------------
+    # Line compilation
+    # ------------------------------------------------------------------
+
+    def _compile_line(self, node: ASTNode) -> None:
+        """Compile one numbered BASIC line.
+
+        Emits a LABEL for the line number, then dispatches the statement.
+
+        Args:
+            node: An ``ASTNode`` with ``rule_name == "line"``.
+        """
+        line_num: int | None = None
+        stmt_node: ASTNode | None = None
+
+        for child in node.children:
+            if isinstance(child, Token) and _type_is(child.type, "LINE_NUM"):
+                line_num = int(child.value)
+            elif isinstance(child, ASTNode) and child.rule_name == "statement":
+                stmt_node = child
+
+        if line_num is None:
+            return
+        self._emit_label(f"_line_{line_num}")
+        if stmt_node is not None:
+            self._compile_statement(stmt_node)
+
+    # ------------------------------------------------------------------
+    # Statement dispatch
+    # ------------------------------------------------------------------
+
+    def _compile_statement(self, node: ASTNode) -> None:
+        """Dispatch to the handler for the concrete statement type.
+
+        Args:
+            node: An ``ASTNode`` with ``rule_name == "statement"``.
+        """
+        for child in node.children:
+            if isinstance(child, ASTNode):
+                rule = child.rule_name
+                if rule == "rem_stmt":
+                    self._compile_rem(child)
+                elif rule == "let_stmt":
+                    self._compile_let(child)
+                elif rule == "print_stmt":
+                    self._compile_print(child)
+                elif rule == "goto_stmt":
+                    self._compile_goto(child)
+                elif rule == "if_stmt":
+                    self._compile_if(child)
+                elif rule == "for_stmt":
+                    self._compile_for(child)
+                elif rule == "next_stmt":
+                    self._compile_next(child)
+                elif rule in ("end_stmt", "stop_stmt"):
+                    self._emit(IrOp.HALT)
+                elif rule in (
+                    "gosub_stmt", "return_stmt", "dim_stmt",
+                    "def_stmt", "input_stmt", "read_stmt",
+                    "data_stmt", "restore_stmt",
+                ):
+                    raise CompileError(
+                        f"'{rule.replace('_stmt', '').upper()}' is not "
+                        f"supported in V1 of the compiled pipeline"
+                    )
+                return
+
+    # ------------------------------------------------------------------
+    # REM
+    # ------------------------------------------------------------------
+
+    def _compile_rem(self, node: ASTNode) -> None:
+        """Emit a COMMENT instruction for a REM statement.
+
+        The COMMENT opcode produces no machine code on any backend. It is
+        emitted purely for human-readable IR output.
+
+        Args:
+            node: An ``ASTNode`` with ``rule_name == "rem_stmt"``.
+        """
+        # Gather the remark text from any token children after REM
+        parts: list[str] = []
+        for child in node.children:
+            if isinstance(child, Token) and child.type != "KEYWORD":
+                parts.append(child.value)
+        text = " ".join(parts).strip() if parts else ""
+        self._emit(IrOp.COMMENT, IrLabel(name=text or "REM"))
+
+    # ------------------------------------------------------------------
+    # LET
+    # ------------------------------------------------------------------
+
+    def _compile_let(self, node: ASTNode) -> None:
+        """Compile a LET assignment: LET var = expr.
+
+        The expression is compiled into a fresh register, then copied into
+        the variable's fixed register via ADD_IMM v_var, v_val, 0.
+
+        Args:
+            node: An ``ASTNode`` with ``rule_name == "let_stmt"``.
+        """
+        var_node: ASTNode | None = None
+        expr_node: ASTNode | None = None
+        seen_eq = False
+
+        for child in node.children:
+            if isinstance(child, Token):
+                if _type_is(child.type, "EQ"):
+                    seen_eq = True
+            elif isinstance(child, ASTNode):
+                if child.rule_name == "variable" and not seen_eq:
+                    var_node = child
+                elif seen_eq and expr_node is None:
+                    expr_node = child
+
+        if var_node is None or expr_node is None:
+            raise CompileError("malformed LET statement")
+
+        var_name = self._extract_var_name(var_node)
+        if var_name is None:
+            raise CompileError("malformed LET: could not extract variable name")
+
+        v_var = _scalar_reg(var_name)
+        v_val = self._compile_expr(expr_node)
+
+        # Copy expression result into the variable's register.
+        # ADD_IMM v_var, v_val, 0 means: v_var = v_val + 0 = v_val.
+        self._emit(
+            IrOp.ADD_IMM,
+            IrRegister(index=v_var),
+            IrRegister(index=v_val),
+            IrImmediate(value=0),
+        )
+
+    # ------------------------------------------------------------------
+    # PRINT
+    # ------------------------------------------------------------------
+
+    def _compile_print(self, node: ASTNode) -> None:
+        """Compile a PRINT statement.
+
+        V1 supports PRINT with a single string literal only. Each character is
+        converted at compile time to its GE-225 typewriter code; SYSCALL 1
+        prints it. A carriage return is appended automatically.
+
+        Args:
+            node: An ``ASTNode`` with ``rule_name == "print_stmt"``.
+
+        Raises:
+            CompileError: If the PRINT argument is not a string literal, or if
+                          the string contains a character with no GE-225 code.
+        """
+        string_val: str | None = None
+        for child in node.children:
+            if isinstance(child, ASTNode):
+                string_val = self._extract_string_literal(child)
+                if string_val is None:
+                    raise CompileError(
+                        "PRINT with non-string-literal arguments is not "
+                        "supported in V1 (only PRINT \"...\") is supported"
+                    )
+                break
+
+        if string_val is None:
+            # PRINT with no arguments → just a carriage return
+            self._emit_print_code(CARRIAGE_RETURN_CODE)
+            return
+
+        for ch in string_val:
+            code = ascii_to_ge225(ch)
+            if code is None:
+                raise CompileError(
+                    f"character {ch!r} has no GE-225 typewriter equivalent; "
+                    f"V1 supports: A-Z, 0-9, space, and basic punctuation"
+                )
+            self._emit_print_code(code)
+
+        self._emit_print_code(CARRIAGE_RETURN_CODE)
+
+    def _emit_print_code(self, code: int) -> None:
+        """Emit LOAD_IMM + SYSCALL 1 to print one character.
+
+        Args:
+            code: The 6-bit GE-225 typewriter code to print.
+        """
+        self._emit(
+            IrOp.LOAD_IMM,
+            IrRegister(index=_REG_SYSCALL_ARG),
+            IrImmediate(value=code),
+        )
+        self._emit(IrOp.SYSCALL, IrImmediate(value=_SYSCALL_PRINT_CHAR))
+
+    def _extract_string_literal(self, node: ASTNode) -> str | None:
+        """Extract the string value from a print_list or print_item node.
+
+        Returns the raw string content (without quotes) if the print argument
+        is a string literal, or ``None`` if it is anything else.
+
+        Args:
+            node: A child of ``print_stmt``.
+
+        Returns:
+            The string content, or ``None`` if not a string literal.
+        """
+        # Walk through print_list / print_item wrappers to find STRING token
+        if isinstance(node, ASTNode):
+            for child in node.children:
+                if isinstance(child, Token) and _type_is(child.type, "STRING"):
+                    # Strip surrounding quotes
+                    return child.value.strip('"\'')
+                if isinstance(child, ASTNode):
+                    result = self._extract_string_literal(child)
+                    if result is not None:
+                        return result
+            # If any non-string token is present (NAME, NUMBER etc.), not V1-safe
+            for child in node.children:
+                if isinstance(child, Token) and not any(
+                    _type_is(child.type, t) for t in ("KEYWORD", "COMMA", "SEMICOLON", "STRING")
+                ):
+                    return None
+        return None
+
+    # ------------------------------------------------------------------
+    # GOTO
+    # ------------------------------------------------------------------
+
+    def _compile_goto(self, node: ASTNode) -> None:
+        """Compile a GOTO statement: GOTO lineno.
+
+        Emits an unconditional JUMP to the label for the target line.
+
+        Args:
+            node: An ``ASTNode`` with ``rule_name == "goto_stmt"``.
+        """
+        lineno = self._extract_lineno(node)
+        self._emit(IrOp.JUMP, IrLabel(name=f"_line_{lineno}"))
+
+    # ------------------------------------------------------------------
+    # IF … THEN
+    # ------------------------------------------------------------------
+
+    def _compile_if(self, node: ASTNode) -> None:
+        """Compile an IF expression relop expression THEN lineno statement.
+
+        The six relational operators map to IR comparison opcodes.
+        ``<=`` and ``>=`` are derived by flipping ``>`` and ``<`` with a
+        NOT idiom (subtract 1, mask low bit).
+
+        Args:
+            node: An ``ASTNode`` with ``rule_name == "if_stmt"``.
+        """
+        # Collect sub-nodes: [expr1, relop_node, expr2, THEN, NUMBER]
+        exprs: list[ASTNode] = []
+        relop_token: Token | None = None
+        lineno: int | None = None
+
+        for child in node.children:
+            if isinstance(child, Token):
+                if _type_is(child.type, "NUMBER"):
+                    lineno = int(child.value)
+            elif isinstance(child, ASTNode):
+                if child.rule_name == "relop":
+                    relop_token = self._first_token(child)
+                elif child.rule_name in (
+                    "expr", "term", "power", "unary", "primary"
+                ):
+                    exprs.append(child)
+
+        if lineno is None or relop_token is None or len(exprs) < 2:
+            raise CompileError("malformed IF statement")
+
+        v_lhs = self._compile_expr(exprs[0])
+        v_rhs = self._compile_expr(exprs[1])
+        relop = relop_token.value
+
+        v_cmp = self._new_reg()
+        label = f"_line_{lineno}"
+
+        if relop == "<":
+            self._emit(IrOp.CMP_LT, IrRegister(v_cmp), IrRegister(v_lhs), IrRegister(v_rhs))
+            self._emit(IrOp.BRANCH_NZ, IrRegister(v_cmp), IrLabel(label))
+
+        elif relop == ">":
+            self._emit(IrOp.CMP_GT, IrRegister(v_cmp), IrRegister(v_lhs), IrRegister(v_rhs))
+            self._emit(IrOp.BRANCH_NZ, IrRegister(v_cmp), IrLabel(label))
+
+        elif relop == "=":
+            self._emit(IrOp.CMP_EQ, IrRegister(v_cmp), IrRegister(v_lhs), IrRegister(v_rhs))
+            self._emit(IrOp.BRANCH_NZ, IrRegister(v_cmp), IrLabel(label))
+
+        elif relop == "<>":
+            self._emit(IrOp.CMP_NE, IrRegister(v_cmp), IrRegister(v_lhs), IrRegister(v_rhs))
+            self._emit(IrOp.BRANCH_NZ, IrRegister(v_cmp), IrLabel(label))
+
+        elif relop == "<=":
+            # LE = NOT GT: v_cmp = (lhs > rhs); flip to (lhs <= rhs)
+            self._emit(IrOp.CMP_GT, IrRegister(v_cmp), IrRegister(v_lhs), IrRegister(v_rhs))
+            v_flipped = self._not_bool(v_cmp)
+            self._emit(IrOp.BRANCH_NZ, IrRegister(v_flipped), IrLabel(label))
+
+        elif relop == ">=":
+            # GE = NOT LT: v_cmp = (lhs < rhs); flip to (lhs >= rhs)
+            self._emit(IrOp.CMP_LT, IrRegister(v_cmp), IrRegister(v_lhs), IrRegister(v_rhs))
+            v_flipped = self._not_bool(v_cmp)
+            self._emit(IrOp.BRANCH_NZ, IrRegister(v_flipped), IrLabel(label))
+
+        else:
+            raise CompileError(f"unknown relational operator: {relop!r}")
+
+    def _not_bool(self, v_in: int) -> int:
+        """Flip a boolean register: 0 → 1, 1 → 0.
+
+        Implemented as: v_out = (v_in - 1) & 1.
+        When v_in = 1: (1-1) & 1 = 0 & 1 = 0.
+        When v_in = 0: (0-1) & 1 = (-1) & 1... but in two's complement,
+        -1 in 20 bits = 0xFFFFF, and 0xFFFFF & 1 = 1. ✓
+
+        Args:
+            v_in: The register holding 0 or 1.
+
+        Returns:
+            A fresh register holding the flipped value.
+        """
+        v_sub = self._new_reg()
+        v_out = self._new_reg()
+        self._emit(
+            IrOp.ADD_IMM,
+            IrRegister(v_sub),
+            IrRegister(v_in),
+            IrImmediate(-1),
+        )
+        self._emit(
+            IrOp.AND_IMM,
+            IrRegister(v_out),
+            IrRegister(v_sub),
+            IrImmediate(1),
+        )
+        return v_out
+
+    # ------------------------------------------------------------------
+    # FOR … TO [STEP]
+    # ------------------------------------------------------------------
+
+    def _compile_for(self, node: ASTNode) -> None:
+        """Compile a FOR statement.
+
+        Emits:
+        1. Evaluate start, limit, step expressions into registers.
+        2. Copy start into the variable register.
+        3. Emit the pre-test label.
+        4. Emit CMP_GT (var > limit) → BRANCH_NZ to end label.
+
+        The body and NEXT are compiled later. NEXT pops this record and emits
+        the increment and backward jump.
+
+        Args:
+            node: An ``ASTNode`` with ``rule_name == "for_stmt"``.
+        """
+        # Extract: FOR NAME EQ expr TO expr [STEP expr]
+        var_name: str | None = None
+        exprs: list[ASTNode] = []
+        has_step = False
+
+        for child in node.children:
+            if isinstance(child, Token) and _type_is(child.type, "NAME"):
+                var_name = child.value.upper()
+            elif isinstance(child, Token) and _type_is(child.type, "KEYWORD") and child.value.upper() == "STEP":
+                has_step = True
+            elif isinstance(child, ASTNode) and child.rule_name in (
+                "expr", "term", "power", "unary", "primary"
+            ):
+                exprs.append(child)
+
+        if var_name is None or len(exprs) < 2:
+            raise CompileError("malformed FOR statement")
+
+        v_var = _scalar_reg(var_name)
+
+        # Compile start and limit expressions
+        v_start = self._compile_expr(exprs[0])
+        v_limit = self._compile_expr(exprs[1])
+
+        # Compile step expression or default to 1
+        if has_step and len(exprs) >= 3:
+            v_step = self._compile_expr(exprs[2])
+        else:
+            v_step = self._new_reg()
+            self._emit(
+                IrOp.LOAD_IMM,
+                IrRegister(v_step),
+                IrImmediate(1),
+            )
+
+        # Initialize loop variable: var = start
+        self._emit(
+            IrOp.ADD_IMM,
+            IrRegister(v_var),
+            IrRegister(v_start),
+            IrImmediate(0),
+        )
+
+        loop_num = self._loop_count
+        self._loop_count += 1
+        check_label = f"_for_{loop_num}_check"
+        end_label = f"_for_{loop_num}_end"
+
+        self._emit_label(check_label)
+
+        # Pre-test: exit if var > limit
+        v_cmp = self._new_reg()
+        self._emit(
+            IrOp.CMP_GT,
+            IrRegister(v_cmp),
+            IrRegister(v_var),
+            IrRegister(v_limit),
+        )
+        self._emit(IrOp.BRANCH_NZ, IrRegister(v_cmp), IrLabel(end_label))
+
+        # Push record for NEXT to use
+        self._for_stack.append(
+            _ForRecord(
+                var_name=var_name,
+                var_reg=v_var,
+                limit_reg=v_limit,
+                step_reg=v_step,
+                check_label=check_label,
+                end_label=end_label,
+                loop_num=loop_num,
+            )
+        )
+
+    # ------------------------------------------------------------------
+    # NEXT
+    # ------------------------------------------------------------------
+
+    def _compile_next(self, node: ASTNode) -> None:
+        """Compile a NEXT statement.
+
+        Pops the innermost FOR record, verifies the variable name matches,
+        emits the increment and backward jump, then emits the loop end label.
+
+        Args:
+            node: An ``ASTNode`` with ``rule_name == "next_stmt"``.
+        """
+        if not self._for_stack:
+            raise CompileError("NEXT without matching FOR")
+
+        # Extract NEXT variable name
+        next_var: str | None = None
+        for child in node.children:
+            if isinstance(child, Token) and _type_is(child.type, "NAME"):
+                next_var = child.value.upper()
+
+        rec = self._for_stack[-1]
+
+        if next_var is not None and next_var != rec.var_name:
+            raise CompileError(
+                f"NEXT {next_var} does not match innermost FOR {rec.var_name}"
+            )
+
+        self._for_stack.pop()
+
+        # Increment: var += step
+        self._emit(
+            IrOp.ADD,
+            IrRegister(rec.var_reg),
+            IrRegister(rec.var_reg),
+            IrRegister(rec.step_reg),
+        )
+
+        # Jump back to pre-test
+        self._emit(IrOp.JUMP, IrLabel(rec.check_label))
+
+        # End label (BRANCH_NZ target when var > limit)
+        self._emit_label(rec.end_label)
+
+    # ------------------------------------------------------------------
+    # Expression compilation
+    # ------------------------------------------------------------------
+
+    def _compile_expr(self, node: ASTNode) -> int:
+        """Recursively compile an expression node and return its result register.
+
+        Walks the grammar's precedence tower:
+          expr → term { (PLUS | MINUS) term }
+          term → power { (STAR | SLASH) power }
+          power → unary [CARET unary]
+          unary → MINUS unary | primary
+          primary → variable | NUMBER | LPAREN expr RPAREN
+
+        Args:
+            node: An ``ASTNode`` at any expression level.
+
+        Returns:
+            The virtual register index holding the expression result.
+
+        Raises:
+            CompileError: If the expression uses ``^`` (power), array indexing,
+                          or any other V1-excluded feature.
+        """
+        rule = node.rule_name
+
+        if rule == "primary":
+            return self._compile_primary(node)
+        if rule == "unary":
+            return self._compile_unary(node)
+        if rule in ("expr", "term"):
+            return self._compile_binop_chain(node)
+        if rule == "power":
+            return self._compile_power(node)
+        if rule == "variable":
+            return self._compile_variable_expr(node)
+
+        # Single-child pass-through for wrapper rules
+        ast_children = [c for c in node.children if isinstance(c, ASTNode)]
+        if len(ast_children) == 1:
+            return self._compile_expr(ast_children[0])
+
+        raise CompileError(f"unexpected expression node: {rule!r}")
+
+    def _compile_primary(self, node: ASTNode) -> int:
+        """Compile a primary expression (number literal, variable, or parenthesized expr).
+
+        Args:
+            node: An ``ASTNode`` with ``rule_name == "primary"``.
+
+        Returns:
+            The virtual register holding the result.
+        """
+        for child in node.children:
+            if isinstance(child, Token):
+                if _type_is(child.type, "NUMBER"):
+                    v = self._new_reg()
+                    val = int(float(child.value))   # truncate float literals
+                    self._emit(IrOp.LOAD_IMM, IrRegister(v), IrImmediate(val))
+                    return v
+            elif isinstance(child, ASTNode):
+                if child.rule_name == "variable":
+                    return self._compile_variable_expr(child)
+                return self._compile_expr(child)
+
+        raise CompileError("empty primary expression")
+
+    def _compile_variable_expr(self, node: ASTNode) -> int:
+        """Return the fixed register for a scalar variable reference.
+
+        Array element access (``NAME(expr)``) raises CompileError in V1.
+
+        Args:
+            node: An ``ASTNode`` with ``rule_name == "variable"``.
+
+        Returns:
+            The fixed virtual register for the scalar variable.
+        """
+        # Check for array syntax: if there's a LPAREN child, it's an array
+        has_paren = any(
+            isinstance(c, Token) and _type_is(c.type, "LPAREN")
+            for c in node.children
+        )
+        if has_paren:
+            raise CompileError(
+                "array element access is not supported in V1"
+            )
+
+        name = self._extract_var_name(node)
+        if name is None:
+            raise CompileError("could not extract variable name from AST")
+        return _scalar_reg(name)
+
+    def _compile_unary(self, node: ASTNode) -> int:
+        """Compile a unary expression (optional leading minus).
+
+        Args:
+            node: An ``ASTNode`` with ``rule_name == "unary"``.
+
+        Returns:
+            The virtual register holding the result.
+        """
+        has_minus = False
+        inner_node: ASTNode | None = None
+
+        for child in node.children:
+            if isinstance(child, Token) and _type_is(child.type, "MINUS"):
+                has_minus = True
+            elif isinstance(child, ASTNode):
+                inner_node = child
+
+        if inner_node is None:
+            raise CompileError("empty unary expression")
+
+        v_inner = self._compile_expr(inner_node)
+
+        if not has_minus:
+            return v_inner
+
+        # Negate: v_result = 0 - v_inner
+        v_zero = self._new_reg()
+        v_result = self._new_reg()
+        self._emit(IrOp.LOAD_IMM, IrRegister(v_zero), IrImmediate(0))
+        self._emit(
+            IrOp.SUB,
+            IrRegister(v_result),
+            IrRegister(v_zero),
+            IrRegister(v_inner),
+        )
+        return v_result
+
+    def _compile_power(self, node: ASTNode) -> int:
+        """Compile a power expression (unary [^ unary]).
+
+        The ``^`` operator is not supported in V1. If detected, raises
+        ``CompileError``. Otherwise, passes through to the unary child.
+
+        Args:
+            node: An ``ASTNode`` with ``rule_name == "power"``.
+
+        Returns:
+            The virtual register holding the result.
+        """
+        has_caret = any(
+            isinstance(c, Token) and _type_is(c.type, "CARET")
+            for c in node.children
+        )
+        if has_caret:
+            raise CompileError(
+                "the ^ (power) operator is not supported in V1"
+            )
+        # Single unary child
+        for child in node.children:
+            if isinstance(child, ASTNode):
+                return self._compile_expr(child)
+        raise CompileError("empty power expression")
+
+    def _compile_binop_chain(self, node: ASTNode) -> int:
+        """Compile a left-associative binary operator chain.
+
+        Used for both ``expr`` (PLUS/MINUS) and ``term`` (STAR/SLASH).
+        Processes children left to right:
+          [operand, op_token, operand, op_token, operand, ...]
+
+        Args:
+            node: An ``ASTNode`` with ``rule_name == "expr"`` or ``"term"``.
+
+        Returns:
+            The virtual register holding the final result.
+        """
+        # Collect alternating (operand_node, op_token) pairs
+        operands: list[int] = []
+        operators: list[str] = []
+
+        for child in node.children:
+            if isinstance(child, Token) and any(
+                _type_is(child.type, t) for t in ("PLUS", "MINUS", "STAR", "SLASH")
+            ):
+                operators.append(child.value)
+            elif isinstance(child, ASTNode):
+                operands.append(self._compile_expr(child))
+
+        if not operands:
+            raise CompileError(f"empty {node.rule_name} expression")
+
+        result = operands[0]
+        for i, op in enumerate(operators):
+            rhs = operands[i + 1]
+            v_out = self._new_reg()
+            if op == "+":
+                self._emit(
+                    IrOp.ADD,
+                    IrRegister(v_out),
+                    IrRegister(result),
+                    IrRegister(rhs),
+                )
+            elif op == "-":
+                self._emit(
+                    IrOp.SUB,
+                    IrRegister(v_out),
+                    IrRegister(result),
+                    IrRegister(rhs),
+                )
+            elif op == "*":
+                self._emit(
+                    IrOp.MUL,
+                    IrRegister(v_out),
+                    IrRegister(result),
+                    IrRegister(rhs),
+                )
+            elif op == "/":
+                self._emit(
+                    IrOp.DIV,
+                    IrRegister(v_out),
+                    IrRegister(result),
+                    IrRegister(rhs),
+                )
+            else:
+                raise CompileError(f"unknown binary operator: {op!r}")
+            result = v_out
+
+        return result
+
+    # ------------------------------------------------------------------
+    # Helper utilities
+    # ------------------------------------------------------------------
+
+    def _new_reg(self) -> int:
+        """Allocate and return the next fresh expression-temporary register."""
+        reg = self._next_reg
+        self._next_reg += 1
+        return reg
+
+    def _emit(self, opcode: IrOp, *operands: IrRegister | IrImmediate | IrLabel) -> int:
+        """Add one instruction to the program and return its unique ID."""
+        instr_id = self._id_gen.next()
+        self._program.add_instruction(
+            IrInstruction(opcode=opcode, operands=list(operands), id=instr_id)
+        )
+        return instr_id
+
+    def _emit_label(self, name: str) -> None:
+        """Add a LABEL pseudo-instruction (labels have ID = -1)."""
+        self._program.add_instruction(
+            IrInstruction(
+                opcode=IrOp.LABEL,
+                operands=[IrLabel(name=name)],
+                id=-1,
+            )
+        )
+
+    def _extract_var_name(self, node: ASTNode) -> str | None:
+        """Extract the variable name from a ``variable`` AST node.
+
+        Returns the uppercase name string, or ``None`` if not found.
+
+        Args:
+            node: An ``ASTNode`` with ``rule_name == "variable"``.
+
+        Returns:
+            The variable name (e.g., ``"A"``, ``"B3"``), or ``None``.
+        """
+        for child in node.children:
+            if isinstance(child, Token) and _type_is(child.type, "NAME"):
+                return child.value.upper()
+        return None
+
+    def _extract_lineno(self, node: ASTNode) -> int:
+        """Extract an integer line number from a statement node.
+
+        Args:
+            node: An ``ASTNode`` containing a ``NUMBER`` token.
+
+        Returns:
+            The integer line number.
+
+        Raises:
+            CompileError: If no NUMBER token is found.
+        """
+        for child in node.children:
+            if isinstance(child, Token) and _type_is(child.type, "NUMBER"):
+                return int(child.value)
+        raise CompileError(f"could not find line number in {node.rule_name}")
+
+    def _first_token(self, node: ASTNode) -> Token | None:
+        """Return the first Token child of an AST node.
+
+        Args:
+            node: Any ``ASTNode``.
+
+        Returns:
+            The first ``Token`` child, or ``None``.
+        """
+        for child in node.children:
+            if isinstance(child, Token):
+                return child
+        return None

--- a/code/packages/python/dartmouth-basic-ir-compiler/src/dartmouth_basic_ir_compiler/ge225_codes.py
+++ b/code/packages/python/dartmouth-basic-ir-compiler/src/dartmouth_basic_ir_compiler/ge225_codes.py
@@ -1,0 +1,94 @@
+"""GE-225 typewriter character codes for PRINT statement compilation.
+
+The GE-225 typewriter uses a 6-bit character code stored in the N register.
+These codes are not ASCII — they are a character set specific to the GE-225's
+typewriter peripheral, documented in the GE-225 programming manual.
+
+When a BASIC PRINT statement contains a string literal, each character is
+converted at compile time to its GE-225 typewriter code. The compiled IR then
+loads this code into v0 (the syscall argument register) and calls SYSCALL 1,
+which the GE-225 backend translates into the SAN 6 + TYP sequence.
+
+Historical note: the 1964 BASIC teletype could only print uppercase letters,
+digits, and a handful of punctuation characters. String literals like "HELLO"
+worked perfectly; lowercase letters were uppercased automatically by this
+compiler as a convenience.
+
+The codes are given in octal to match the GE-225 manual notation:
+
+  0o00 = '0'   0o01 = '1'   0o02 = '2'   0o03 = '3'   0o04 = '4'
+  0o05 = '5'   0o06 = '6'   0o07 = '7'   0o10 = '8'   0o11 = '9'
+  0o13 = '/'   0o21 = 'A'   0o22 = 'B'   ...          0o71 = 'Z'
+
+Character 0o37 (decimal 31) is a carriage return, appended automatically at
+the end of every PRINT statement (as the original DTSS system did).
+"""
+
+from __future__ import annotations
+
+GE225_CODES: dict[str, int] = {
+    "0": 0o00,
+    "1": 0o01,
+    "2": 0o02,
+    "3": 0o03,
+    "4": 0o04,
+    "5": 0o05,
+    "6": 0o06,
+    "7": 0o07,
+    "8": 0o10,
+    "9": 0o11,
+    "/": 0o13,
+    "A": 0o21,
+    "B": 0o22,
+    "C": 0o23,
+    "D": 0o24,
+    "E": 0o25,
+    "F": 0o26,
+    "G": 0o27,
+    "H": 0o30,
+    "I": 0o31,
+    "-": 0o33,
+    ".": 0o40,
+    "J": 0o41,
+    "K": 0o42,
+    "L": 0o43,
+    "M": 0o44,
+    "N": 0o45,
+    "O": 0o46,
+    "P": 0o47,
+    "Q": 0o50,
+    "R": 0o51,
+    "$": 0o53,
+    " ": 0o60,
+    "S": 0o62,
+    "T": 0o63,
+    "U": 0o64,
+    "V": 0o65,
+    "W": 0o66,
+    "X": 0o67,
+    "Y": 0o70,
+    "Z": 0o71,
+}
+
+CARRIAGE_RETURN_CODE: int = 0o37
+
+
+def ascii_to_ge225(ch: str) -> int | None:
+    """Convert a single character to its GE-225 typewriter code.
+
+    Lowercase letters are uppercased before lookup. Characters that have no
+    GE-225 equivalent return ``None``.
+
+    Args:
+        ch: A single character string.
+
+    Returns:
+        The 6-bit GE-225 typewriter code, or ``None`` if unsupported.
+
+    Example::
+
+        ascii_to_ge225("H")   # 0o30 = 24
+        ascii_to_ge225("h")   # 0o30 = 24 (lowercase uppercased)
+        ascii_to_ge225("@")   # None (no GE-225 equivalent)
+    """
+    return GE225_CODES.get(ch.upper())

--- a/code/packages/python/dartmouth-basic-ir-compiler/tests/test_dartmouth_basic_ir_compiler.py
+++ b/code/packages/python/dartmouth-basic-ir-compiler/tests/test_dartmouth_basic_ir_compiler.py
@@ -1,0 +1,870 @@
+"""Tests for the dartmouth_basic_ir_compiler package.
+
+Tests cover:
+- GE225_CODES mapping and ascii_to_ge225 helper
+- compile_basic: REM, LET, PRINT, GOTO, IF/THEN, FOR/NEXT, END, STOP
+- Expression compilation: literals, variables, arithmetic, unary minus
+- Relational operators: <, >, =, <>, <=, >=
+- FOR/NEXT: default step, explicit step, pre-test
+- Error cases: GOSUB, DIM, INPUT, DEF FN, power operator, bad NEXT, bad PRINT chars
+- Label conventions: _start, _line_N, _for_N_check, _for_N_end
+- Variable register assignment: A=v1, Z=v26, A0=v27
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from compiler_ir import IrImmediate, IrLabel, IrOp, IrRegister
+from dartmouth_basic_parser import parse_dartmouth_basic
+
+from dartmouth_basic_ir_compiler import (
+    CARRIAGE_RETURN_CODE,
+    GE225_CODES,
+    CompileError,
+    CompileResult,
+    ascii_to_ge225,
+    compile_basic,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def compile_source(source: str) -> CompileResult:
+    """Parse and compile a BASIC source string."""
+    ast = parse_dartmouth_basic(source)
+    return compile_basic(ast)
+
+
+def opcodes(result: CompileResult) -> list[IrOp]:
+    """Return the list of opcodes (excluding LABELs) in the compiled program."""
+    return [
+        instr.opcode
+        for instr in result.program.instructions
+        if instr.opcode != IrOp.LABEL
+    ]
+
+
+def labels(result: CompileResult) -> list[str]:
+    """Return the list of label names defined in the compiled program."""
+    return [
+        str(instr.operands[0])
+        for instr in result.program.instructions
+        if instr.opcode == IrOp.LABEL
+    ]
+
+
+def find_first(result: CompileResult, opcode: IrOp) -> list:
+    """Return operands of the first instruction with the given opcode."""
+    for instr in result.program.instructions:
+        if instr.opcode == opcode:
+            return instr.operands
+    return []
+
+
+def find_all(result: CompileResult, opcode: IrOp) -> list[list]:
+    """Return operands lists for all instructions with the given opcode."""
+    return [
+        instr.operands
+        for instr in result.program.instructions
+        if instr.opcode == opcode
+    ]
+
+
+# ---------------------------------------------------------------------------
+# GE225 Codes
+# ---------------------------------------------------------------------------
+
+
+class TestGE225Codes:
+    """Tests for the GE-225 typewriter code mapping."""
+
+    def test_uppercase_letters_present(self) -> None:
+        """A–Z all have codes."""
+        for ch in "ABCDEFGHIJKLMNOPQRSTUVWXYZ":
+            assert ch in GE225_CODES, f"missing {ch!r}"
+
+    def test_digits_present(self) -> None:
+        """0–9 all have codes."""
+        for ch in "0123456789":
+            assert ch in GE225_CODES
+
+    def test_space_present(self) -> None:
+        assert " " in GE225_CODES
+
+    def test_carriage_return_code_is_037(self) -> None:
+        assert CARRIAGE_RETURN_CODE == 0o37
+
+    def test_ascii_to_ge225_uppercase(self) -> None:
+        assert ascii_to_ge225("A") == GE225_CODES["A"]
+        assert ascii_to_ge225("Z") == GE225_CODES["Z"]
+
+    def test_ascii_to_ge225_lowercase_converted(self) -> None:
+        assert ascii_to_ge225("a") == GE225_CODES["A"]
+        assert ascii_to_ge225("z") == GE225_CODES["Z"]
+
+    def test_ascii_to_ge225_unsupported_returns_none(self) -> None:
+        assert ascii_to_ge225("@") is None
+        assert ascii_to_ge225("~") is None
+        assert ascii_to_ge225("!") is None
+
+    def test_ascii_to_ge225_digit(self) -> None:
+        assert ascii_to_ge225("5") == GE225_CODES["5"]
+
+    def test_ascii_to_ge225_space(self) -> None:
+        assert ascii_to_ge225(" ") == GE225_CODES[" "]
+
+
+# ---------------------------------------------------------------------------
+# Variable register assignment
+# ---------------------------------------------------------------------------
+
+
+class TestVariableRegisters:
+    """Tests for the fixed variable → register mapping."""
+
+    def test_variable_a_is_register_1(self) -> None:
+        result = compile_source("10 LET A = 5\n20 END\n")
+        assert result.var_regs["A"] == 1
+
+    def test_variable_z_is_register_26(self) -> None:
+        result = compile_source("10 LET Z = 1\n20 END\n")
+        assert result.var_regs["Z"] == 26
+
+    def test_all_az_variables_present_in_map(self) -> None:
+        result = compile_source("10 END\n")
+        for ch in "ABCDEFGHIJKLMNOPQRSTUVWXYZ":
+            assert ch in result.var_regs
+
+    def test_a_through_z_registers_are_1_through_26(self) -> None:
+        result = compile_source("10 END\n")
+        for i, ch in enumerate("ABCDEFGHIJKLMNOPQRSTUVWXYZ"):
+            assert result.var_regs[ch] == i + 1
+
+
+# ---------------------------------------------------------------------------
+# Program structure
+# ---------------------------------------------------------------------------
+
+
+class TestProgramStructure:
+    """Tests for program-level IR structure."""
+
+    def test_entry_label_is_start(self) -> None:
+        result = compile_source("10 END\n")
+        assert result.program.entry_label == "_start"
+
+    def test_start_label_emitted(self) -> None:
+        result = compile_source("10 END\n")
+        assert "_start" in labels(result)
+
+    def test_line_label_emitted(self) -> None:
+        result = compile_source("10 END\n")
+        assert "_line_10" in labels(result)
+
+    def test_line_label_before_statement(self) -> None:
+        """_line_N label must appear before any instructions for that line."""
+        result = compile_source("10 END\n")
+        instrs = result.program.instructions
+        line_idx = next(
+            i for i, ins in enumerate(instrs)
+            if ins.opcode == IrOp.LABEL and str(ins.operands[0]) == "_line_10"
+        )
+        halt_idx = next(
+            i for i, ins in enumerate(instrs)
+            if ins.opcode == IrOp.HALT
+        )
+        assert line_idx < halt_idx
+
+    def test_epilogue_halt_always_present(self) -> None:
+        """The compiler appends a HALT even if no END is in the program."""
+        result = compile_source("10 LET A = 1\n")
+        assert IrOp.HALT in opcodes(result)
+
+    def test_unique_instruction_ids(self) -> None:
+        result = compile_source("10 LET A = 1\n20 END\n")
+        ids = [
+            ins.id for ins in result.program.instructions if ins.id != -1
+        ]
+        assert len(ids) == len(set(ids))
+
+
+# ---------------------------------------------------------------------------
+# REM
+# ---------------------------------------------------------------------------
+
+
+class TestRem:
+    """Tests for REM (comment) statement."""
+
+    def test_rem_emits_comment(self) -> None:
+        result = compile_source("10 REM THIS IS A COMMENT\n20 END\n")
+        assert IrOp.COMMENT in opcodes(result)
+
+    def test_rem_no_other_non_label_instructions_on_rem_line(self) -> None:
+        """REM should produce no runtime instructions."""
+        result = compile_source("10 REM ONLY A COMMENT\n20 END\n")
+        non_meta = [
+            op for op in opcodes(result)
+            if op not in (IrOp.COMMENT, IrOp.HALT)
+        ]
+        assert non_meta == []
+
+
+# ---------------------------------------------------------------------------
+# LET
+# ---------------------------------------------------------------------------
+
+
+class TestLet:
+    """Tests for LET assignment."""
+
+    def test_let_constant_emits_load_imm_and_add_imm(self) -> None:
+        result = compile_source("10 LET A = 5\n20 END\n")
+        ops = opcodes(result)
+        assert IrOp.LOAD_IMM in ops
+        assert IrOp.ADD_IMM in ops
+
+    def test_let_constant_value_correct(self) -> None:
+        result = compile_source("10 LET A = 42\n20 END\n")
+        load_ops = find_all(result, IrOp.LOAD_IMM)
+        values = [op[1].value for op in load_ops if isinstance(op[1], IrImmediate)]
+        assert 42 in values
+
+    def test_let_copies_to_variable_register(self) -> None:
+        """The copy (ADD_IMM v_var, v_temp, 0) must write to variable A's register (v1)."""
+        result = compile_source("10 LET A = 7\n20 END\n")
+        add_imm_ops = find_all(result, IrOp.ADD_IMM)
+        destinations = [op[0].index for op in add_imm_ops if isinstance(op[0], IrRegister)]
+        assert 1 in destinations  # v1 = A
+
+    def test_let_addition(self) -> None:
+        result = compile_source("10 LET A = 2 + 3\n20 END\n")
+        assert IrOp.ADD in opcodes(result)
+
+    def test_let_subtraction(self) -> None:
+        result = compile_source("10 LET A = 10 - 4\n20 END\n")
+        assert IrOp.SUB in opcodes(result)
+
+    def test_let_multiplication(self) -> None:
+        result = compile_source("10 LET A = 3 * 7\n20 END\n")
+        assert IrOp.MUL in opcodes(result)
+
+    def test_let_division(self) -> None:
+        result = compile_source("10 LET A = 10 / 2\n20 END\n")
+        assert IrOp.DIV in opcodes(result)
+
+    def test_let_unary_minus(self) -> None:
+        result = compile_source("10 LET A = -5\n20 END\n")
+        assert IrOp.SUB in opcodes(result)
+
+    def test_let_complex_expression_precedence(self) -> None:
+        """2 + 3 * 4 should have MUL before ADD (3*4 computed first)."""
+        result = compile_source("10 LET A = 2 + 3 * 4\n20 END\n")
+        ops = opcodes(result)
+        mul_idx = next(i for i, op in enumerate(ops) if op == IrOp.MUL)
+        add_idx = next(i for i, op in enumerate(ops) if op == IrOp.ADD)
+        assert mul_idx < add_idx
+
+    def test_let_variable_assignment_from_variable(self) -> None:
+        """LET B = A should use A's register as source."""
+        result = compile_source("10 LET A = 1\n20 LET B = A\n30 END\n")
+        # B is v2, A is v1. The copy for B's LET should write to v2.
+        add_imm_ops = find_all(result, IrOp.ADD_IMM)
+        b_writes = [op for op in add_imm_ops if isinstance(op[0], IrRegister) and op[0].index == 2]
+        assert len(b_writes) >= 1
+
+
+# ---------------------------------------------------------------------------
+# PRINT
+# ---------------------------------------------------------------------------
+
+
+class TestPrint:
+    """Tests for PRINT statement."""
+
+    def test_print_emits_load_imm_and_syscall(self) -> None:
+        result = compile_source("10 PRINT \"HI\"\n20 END\n")
+        assert IrOp.LOAD_IMM in opcodes(result)
+        assert IrOp.SYSCALL in opcodes(result)
+
+    def test_print_loads_correct_ge225_codes(self) -> None:
+        result = compile_source("10 PRINT \"AB\"\n20 END\n")
+        load_imm_ops = find_all(result, IrOp.LOAD_IMM)
+        # Filter to SYSCALL arg register (v0 = index 0)
+        char_codes = [
+            op[1].value
+            for op in load_imm_ops
+            if isinstance(op[0], IrRegister) and op[0].index == 0
+            and isinstance(op[1], IrImmediate)
+        ]
+        assert GE225_CODES["A"] in char_codes
+        assert GE225_CODES["B"] in char_codes
+
+    def test_print_appends_carriage_return(self) -> None:
+        result = compile_source("10 PRINT \"X\"\n20 END\n")
+        load_imm_ops = find_all(result, IrOp.LOAD_IMM)
+        char_codes = [
+            op[1].value
+            for op in load_imm_ops
+            if isinstance(op[0], IrRegister) and op[0].index == 0
+            and isinstance(op[1], IrImmediate)
+        ]
+        assert CARRIAGE_RETURN_CODE in char_codes
+
+    def test_print_syscall_arg_is_one(self) -> None:
+        result = compile_source("10 PRINT \"X\"\n20 END\n")
+        syscall_ops = find_all(result, IrOp.SYSCALL)
+        args = [op[0].value for op in syscall_ops if isinstance(op[0], IrImmediate)]
+        assert all(a == 1 for a in args)
+
+    def test_print_empty_string_only_cr(self) -> None:
+        result = compile_source("10 PRINT \"\"\n20 END\n")
+        load_imm_ops = find_all(result, IrOp.LOAD_IMM)
+        char_codes = [
+            op[1].value
+            for op in load_imm_ops
+            if isinstance(op[0], IrRegister) and op[0].index == 0
+            and isinstance(op[1], IrImmediate)
+        ]
+        assert char_codes == [CARRIAGE_RETURN_CODE]
+
+    def test_print_lowercase_converted(self) -> None:
+        """Lowercase in string literals is quietly uppercased."""
+        result = compile_source("10 PRINT \"hello\"\n20 END\n")
+        load_imm_ops = find_all(result, IrOp.LOAD_IMM)
+        char_codes = [
+            op[1].value
+            for op in load_imm_ops
+            if isinstance(op[0], IrRegister) and op[0].index == 0
+            and isinstance(op[1], IrImmediate)
+        ]
+        assert GE225_CODES["H"] in char_codes
+
+    def test_print_unsupported_char_raises(self) -> None:
+        with pytest.raises(CompileError, match="has no GE-225 typewriter"):
+            compile_source("10 PRINT \"@#$\"\n20 END\n")
+
+    def test_print_number_char_works(self) -> None:
+        result = compile_source("10 PRINT \"123\"\n20 END\n")
+        assert IrOp.SYSCALL in opcodes(result)
+
+
+# ---------------------------------------------------------------------------
+# GOTO
+# ---------------------------------------------------------------------------
+
+
+class TestGoto:
+    """Tests for GOTO statement."""
+
+    def test_goto_emits_jump(self) -> None:
+        result = compile_source("10 GOTO 30\n20 END\n30 END\n")
+        assert IrOp.JUMP in opcodes(result)
+
+    def test_goto_targets_correct_label(self) -> None:
+        result = compile_source("10 GOTO 30\n20 END\n30 END\n")
+        jump_ops = find_all(result, IrOp.JUMP)
+        targets = [str(op[0]) for op in jump_ops if isinstance(op[0], IrLabel)]
+        assert "_line_30" in targets
+
+
+# ---------------------------------------------------------------------------
+# IF / THEN
+# ---------------------------------------------------------------------------
+
+
+class TestIf:
+    """Tests for IF … THEN conditional jump."""
+
+    def test_if_less_than_emits_cmp_lt_and_branch_nz(self) -> None:
+        result = compile_source("10 IF A < B THEN 50\n20 END\n50 END\n")
+        assert IrOp.CMP_LT in opcodes(result)
+        assert IrOp.BRANCH_NZ in opcodes(result)
+
+    def test_if_greater_than_emits_cmp_gt(self) -> None:
+        result = compile_source("10 IF A > B THEN 50\n20 END\n50 END\n")
+        assert IrOp.CMP_GT in opcodes(result)
+
+    def test_if_equal_emits_cmp_eq(self) -> None:
+        result = compile_source("10 IF A = B THEN 50\n20 END\n50 END\n")
+        assert IrOp.CMP_EQ in opcodes(result)
+
+    def test_if_not_equal_emits_cmp_ne(self) -> None:
+        result = compile_source("10 IF A <> B THEN 50\n20 END\n50 END\n")
+        assert IrOp.CMP_NE in opcodes(result)
+
+    def test_if_less_equal_emits_cmp_gt_and_and_imm(self) -> None:
+        """<= is NOT GT, implemented via AND_IMM 1."""
+        result = compile_source("10 IF A <= B THEN 50\n20 END\n50 END\n")
+        assert IrOp.CMP_GT in opcodes(result)
+        assert IrOp.AND_IMM in opcodes(result)
+
+    def test_if_greater_equal_emits_cmp_lt_and_and_imm(self) -> None:
+        """<= is NOT LT, implemented via AND_IMM 1."""
+        result = compile_source("10 IF A >= B THEN 50\n20 END\n50 END\n")
+        assert IrOp.CMP_LT in opcodes(result)
+        assert IrOp.AND_IMM in opcodes(result)
+
+    def test_if_branch_targets_correct_line(self) -> None:
+        result = compile_source("10 IF A < B THEN 99\n20 END\n99 END\n")
+        branch_ops = find_all(result, IrOp.BRANCH_NZ)
+        targets = [str(op[1]) for op in branch_ops if len(op) > 1 and isinstance(op[1], IrLabel)]
+        assert "_line_99" in targets
+
+    def test_if_with_constant_expressions(self) -> None:
+        """IF 1 < 2 THEN 99 should compile without error."""
+        result = compile_source("10 IF 1 < 2 THEN 99\n20 END\n99 END\n")
+        assert IrOp.CMP_LT in opcodes(result)
+
+
+# ---------------------------------------------------------------------------
+# FOR / NEXT
+# ---------------------------------------------------------------------------
+
+
+class TestForNext:
+    """Tests for FOR … TO … NEXT loop compilation."""
+
+    def test_for_next_emits_labels(self) -> None:
+        result = compile_source("10 FOR I = 1 TO 3\n20 NEXT I\n30 END\n")
+        lbl = labels(result)
+        assert "_for_0_check" in lbl
+        assert "_for_0_end" in lbl
+
+    def test_for_initializes_variable(self) -> None:
+        """FOR I = 1 TO 3 should emit ADD_IMM to copy start into I's register."""
+        result = compile_source("10 FOR I = 1 TO 3\n20 NEXT I\n30 END\n")
+        # I maps to v9 (ord('I') - ord('A') + 1 = 9)
+        add_imm_ops = find_all(result, IrOp.ADD_IMM)
+        destinations = [op[0].index for op in add_imm_ops if isinstance(op[0], IrRegister)]
+        assert 9 in destinations  # v9 = BASIC variable I
+
+    def test_for_default_step_is_one(self) -> None:
+        """A FOR with no STEP should load a constant 1 for the step."""
+        result = compile_source("10 FOR I = 1 TO 10\n20 NEXT I\n30 END\n")
+        load_imm_ops = find_all(result, IrOp.LOAD_IMM)
+        values = [op[1].value for op in load_imm_ops if isinstance(op[1], IrImmediate)]
+        assert 1 in values
+
+    def test_for_emits_cmp_gt_for_pre_test(self) -> None:
+        result = compile_source("10 FOR I = 1 TO 5\n20 NEXT I\n30 END\n")
+        assert IrOp.CMP_GT in opcodes(result)
+
+    def test_for_emits_branch_nz_to_end(self) -> None:
+        result = compile_source("10 FOR I = 1 TO 5\n20 NEXT I\n30 END\n")
+        branch_ops = find_all(result, IrOp.BRANCH_NZ)
+        targets = [str(op[1]) for op in branch_ops if len(op) > 1 and isinstance(op[1], IrLabel)]
+        assert "_for_0_end" in targets
+
+    def test_for_next_emits_add_for_increment(self) -> None:
+        result = compile_source("10 FOR I = 1 TO 5\n20 NEXT I\n30 END\n")
+        assert IrOp.ADD in opcodes(result)
+
+    def test_for_next_emits_jump_back_to_check(self) -> None:
+        result = compile_source("10 FOR I = 1 TO 5\n20 NEXT I\n30 END\n")
+        jump_ops = find_all(result, IrOp.JUMP)
+        targets = [str(op[0]) for op in jump_ops if isinstance(op[0], IrLabel)]
+        assert "_for_0_check" in targets
+
+    def test_for_explicit_step(self) -> None:
+        """FOR I = 0 TO 10 STEP 2 should compile without error."""
+        result = compile_source("10 FOR I = 0 TO 10 STEP 2\n20 NEXT I\n30 END\n")
+        assert "_for_0_check" in labels(result)
+
+    def test_nested_for_loops(self) -> None:
+        """Two nested FOR loops should produce labels _for_0_* and _for_1_*."""
+        source = (
+            "10 FOR I = 1 TO 3\n"
+            "20 FOR J = 1 TO 3\n"
+            "30 NEXT J\n"
+            "40 NEXT I\n"
+            "50 END\n"
+        )
+        result = compile_source(source)
+        lbl = labels(result)
+        assert "_for_0_check" in lbl
+        assert "_for_1_check" in lbl
+
+    def test_next_without_for_raises(self) -> None:
+        with pytest.raises(CompileError, match="NEXT without matching FOR"):
+            compile_source("10 NEXT I\n20 END\n")
+
+    def test_next_wrong_variable_raises(self) -> None:
+        with pytest.raises(CompileError, match="does not match"):
+            compile_source("10 FOR I = 1 TO 3\n20 NEXT J\n30 END\n")
+
+
+# ---------------------------------------------------------------------------
+# END / STOP
+# ---------------------------------------------------------------------------
+
+
+class TestEndStop:
+    """Tests for END and STOP statements."""
+
+    def test_end_emits_halt(self) -> None:
+        result = compile_source("10 END\n")
+        assert IrOp.HALT in opcodes(result)
+
+    def test_stop_emits_halt(self) -> None:
+        result = compile_source("10 STOP\n")
+        assert IrOp.HALT in opcodes(result)
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+class TestErrors:
+    """Tests for CompileError on unsupported V1 features."""
+
+    def test_gosub_raises(self) -> None:
+        with pytest.raises(CompileError, match="GOSUB"):
+            compile_source("10 GOSUB 100\n100 RETURN\n")
+
+    def test_dim_raises(self) -> None:
+        with pytest.raises(CompileError, match="DIM"):
+            compile_source("10 DIM A(10)\n20 END\n")
+
+    def test_power_operator_raises(self) -> None:
+        with pytest.raises(CompileError, match="power"):
+            compile_source("10 LET A = 2 ^ 8\n20 END\n")
+
+    def test_array_access_raises(self) -> None:
+        with pytest.raises(CompileError, match="array"):
+            compile_source("10 LET A = B(3)\n20 END\n")
+
+    def test_wrong_ast_root_raises_value_error(self) -> None:
+        from lang_parser import ASTNode
+        bad_node = ASTNode(rule_name="let_stmt", children=[])
+        with pytest.raises(ValueError, match="expected 'program'"):
+            compile_basic(bad_node)
+
+    def test_print_variable_raises(self) -> None:
+        """PRINT with a variable (not a string literal) raises CompileError."""
+        with pytest.raises(CompileError, match="non-string-literal"):
+            compile_source("10 PRINT A\n20 END\n")
+
+    def test_print_numeric_expression_raises(self) -> None:
+        """PRINT with a numeric expression raises CompileError."""
+        with pytest.raises(CompileError, match="non-string-literal"):
+            compile_source("10 PRINT 42\n20 END\n")
+
+
+# ---------------------------------------------------------------------------
+# Full program integration
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Tests for edge cases and less-common code paths."""
+
+    def test_two_character_variable_a0(self) -> None:
+        """Letter+digit variable A0 maps to register 27."""
+        result = compile_source("10 LET A0 = 5\n20 END\n")
+        # A0 = v27; the ADD_IMM copy should write to v27
+        add_imm_ops = find_all(result, IrOp.ADD_IMM)
+        destinations = {op[0].index for op in add_imm_ops if isinstance(op[0], IrRegister)}
+        assert 27 in destinations
+
+    def test_two_character_variable_z9(self) -> None:
+        """Letter+digit variable Z9 maps to register 286."""
+        result = compile_source("10 LET Z9 = 1\n20 END\n")
+        add_imm_ops = find_all(result, IrOp.ADD_IMM)
+        destinations = {op[0].index for op in add_imm_ops if isinstance(op[0], IrRegister)}
+        assert 286 in destinations
+
+    def test_print_no_args_emits_only_carriage_return(self) -> None:
+        """Bare PRINT with no arguments emits just a carriage return."""
+        result = compile_source("10 PRINT\n20 END\n")
+        load_imm_ops = find_all(result, IrOp.LOAD_IMM)
+        char_codes = [
+            op[1].value
+            for op in load_imm_ops
+            if isinstance(op[0], IrRegister) and op[0].index == 0
+            and isinstance(op[1], IrImmediate)
+        ]
+        assert char_codes == [CARRIAGE_RETURN_CODE]
+
+    def test_parenthesized_expression(self) -> None:
+        """Parenthesized subexpressions compile correctly."""
+        result = compile_source("10 LET A = (2 + 3) * 4\n20 END\n")
+        ops = opcodes(result)
+        assert IrOp.ADD in ops
+        assert IrOp.MUL in ops
+
+    def test_chained_addition(self) -> None:
+        """Left-associative addition chain compiles to two ADD instructions."""
+        result = compile_source("10 LET A = 1 + 2 + 3\n20 END\n")
+        add_count = sum(1 for op in opcodes(result) if op == IrOp.ADD)
+        assert add_count == 2
+
+    def test_empty_rem_statement(self) -> None:
+        """REM with no text compiles without error."""
+        result = compile_source("10 REM\n20 END\n")
+        assert IrOp.COMMENT in opcodes(result)
+
+    def test_float_literal_truncated(self) -> None:
+        """Float literals are truncated to integers."""
+        result = compile_source("10 LET A = 3\n20 END\n")
+        load_imm_ops = find_all(result, IrOp.LOAD_IMM)
+        values = [op[1].value for op in load_imm_ops if isinstance(op[1], IrImmediate)]
+        assert 3 in values
+
+    def test_line_with_only_comment_skipped(self) -> None:
+        """Line numbers appear as labels even when the statement is REM."""
+        result = compile_source("10 REM SKIP ME\n20 END\n")
+        assert "_line_10" in labels(result)
+
+
+class TestFullPrograms:
+    """End-to-end compilation tests for representative programs."""
+
+    def test_hello_world(self) -> None:
+        """Classic hello world program compiles without error."""
+        source = "10 PRINT \"HELLO WORLD\"\n20 END\n"
+        result = compile_source(source)
+        assert result.program.entry_label == "_start"
+        assert IrOp.SYSCALL in opcodes(result)
+        assert IrOp.HALT in opcodes(result)
+
+    def test_count_down_loop(self) -> None:
+        """A countdown FOR loop compiles correctly."""
+        source = (
+            "10 FOR I = 3 TO 1\n"
+            "20 NEXT I\n"
+            "30 END\n"
+        )
+        result = compile_source(source)
+        assert "_for_0_check" in labels(result)
+        assert "_for_0_end" in labels(result)
+
+    def test_conditional_jump(self) -> None:
+        source = (
+            "10 LET A = 5\n"
+            "20 IF A > 3 THEN 40\n"
+            "30 END\n"
+            "40 END\n"
+        )
+        result = compile_source(source)
+        assert IrOp.CMP_GT in opcodes(result)
+        assert IrOp.BRANCH_NZ in opcodes(result)
+
+    def test_conditional_loop_with_if(self) -> None:
+        """IF/THEN looping back emits CMP_LT + BRANCH_NZ (not JUMP — that's GOTO)."""
+        source = (
+            "10 LET A = 1\n"
+            "20 LET A = A + 1\n"
+            "30 IF A < 5 THEN 20\n"
+            "40 END\n"
+        )
+        result = compile_source(source)
+        assert IrOp.BRANCH_NZ in opcodes(result)
+        assert IrOp.CMP_LT in opcodes(result)
+
+    def test_multiple_variables(self) -> None:
+        source = (
+            "10 LET A = 3\n"
+            "20 LET B = 4\n"
+            "30 LET C = A + B\n"
+            "40 END\n"
+        )
+        result = compile_source(source)
+        assert IrOp.ADD in opcodes(result)
+        # A=v1, B=v2, C=v3 all referenced as destinations
+        add_imm_ops = find_all(result, IrOp.ADD_IMM)
+        destinations = {op[0].index for op in add_imm_ops if isinstance(op[0], IrRegister)}
+        assert 1 in destinations  # A
+        assert 2 in destinations  # B
+        assert 3 in destinations  # C
+
+
+# ---------------------------------------------------------------------------
+# Synthetic AST tests — cover defensive error paths unreachable via the parser
+# ---------------------------------------------------------------------------
+
+
+def _tok(type_: str, value: str) -> "Token":  # type: ignore[name-defined]
+    from lexer import Token
+    return Token(type=type_, value=value, line=1, column=1)
+
+
+def _node(rule: str, *children: object) -> "ASTNode":  # type: ignore[name-defined]
+    from lang_parser import ASTNode
+    return ASTNode(rule_name=rule, children=list(children))
+
+
+def _wrap_in_program(stmt_node: object, line_num: int = 10) -> object:
+    """Wrap a single statement node in a fully-formed program ASTNode."""
+    return _node(
+        "program",
+        _node(
+            "line",
+            _tok("LINE_NUM", str(line_num)),
+            _node("statement", stmt_node),
+        ),
+    )
+
+
+def _let(var: str, expr_node: object) -> object:
+    """Construct a let_stmt node: LET var = expr."""
+    return _node(
+        "let_stmt",
+        _node("variable", _tok("NAME", var)),
+        _tok("EQ", "="),
+        expr_node,
+    )
+
+
+def _primary_number(value: str) -> object:
+    """Construct a primary node wrapping a NUMBER token."""
+    return _node("primary", _tok("NUMBER", value))
+
+
+class TestSyntheticAST:
+    """Covers defensive error paths by constructing ASTs directly."""
+
+    def test_line_without_line_num_is_skipped(self) -> None:
+        """A 'line' node with no LINE_NUM token is silently skipped (line 347)."""
+        program = _node("program", _node("line"))  # no LINE_NUM token
+        result = compile_basic(program)
+        # Epilogue HALT still emitted
+        assert IrOp.HALT in opcodes(result)
+
+    def test_malformed_let_no_expr_raises(self) -> None:
+        """let_stmt with no expr after EQ raises CompileError (line 441)."""
+        # variable child present, but no EQ token so seen_eq=False and expr_node=None
+        stmt = _node("let_stmt", _node("variable", _tok("NAME", "A")))
+        with pytest.raises(CompileError, match="malformed LET"):
+            compile_basic(_wrap_in_program(stmt))
+
+    def test_malformed_let_variable_no_name_raises(self) -> None:
+        """let_stmt with empty variable node raises CompileError (lines 1066, 445)."""
+        # variable before EQ has no NAME token → _extract_var_name returns None
+        stmt = _node(
+            "let_stmt",
+            _node("variable"),        # no NAME token inside → line 1066 return None
+            _tok("EQ", "="),
+            _primary_number("1"),
+        )
+        with pytest.raises(CompileError, match="could not extract variable name"):
+            compile_basic(_wrap_in_program(stmt))
+
+    def test_if_relop_with_no_token_raises(self) -> None:
+        """relop node with no Token causes malformed IF (lines 1097, 594)."""
+        # relop has no children → _first_token returns None (line 1097)
+        # lineno is present + 2 exprs, but relop_token is None → line 594
+        if_node = _node(
+            "if_stmt",
+            _primary_number("1"),
+            _node("relop"),           # no Token children → _first_token → None (line 1097)
+            _primary_number("2"),
+            _tok("NUMBER", "50"),
+        )
+        with pytest.raises(CompileError, match="malformed IF"):
+            compile_basic(_wrap_in_program(if_node))
+
+    def test_if_unknown_relop_raises(self) -> None:
+        """relop with an unrecognised value raises CompileError (line 632)."""
+        # relop token exists but its value is not <, >, =, <>, <=, >=
+        if_node = _node(
+            "if_stmt",
+            _primary_number("1"),
+            _node("relop", _tok("EQ", "!=")),  # value "!=" is unknown
+            _primary_number("2"),
+            _tok("NUMBER", "50"),
+        )
+        with pytest.raises(CompileError, match="unknown relational operator"):
+            compile_basic(_wrap_in_program(if_node))
+
+    def test_malformed_for_no_children_raises(self) -> None:
+        """for_stmt with no children raises CompileError (line 699)."""
+        stmt = _node("for_stmt")  # var_name=None, exprs=[]
+        with pytest.raises(CompileError, match="malformed FOR"):
+            compile_basic(_wrap_in_program(stmt))
+
+    def test_expr_variable_node_directly_compiles(self) -> None:
+        """variable node passed directly to _compile_expr succeeds (lines 835-836)."""
+        # expr → [variable(A)] — unusual but valid: binop chain calls _compile_expr(variable)
+        var_as_child = _node("variable", _tok("NAME", "A"))
+        expr_node = _node("expr", var_as_child)
+        program = _wrap_in_program(_let("B", expr_node))
+        result = compile_basic(program)
+        assert IrOp.ADD_IMM in opcodes(result)  # LET B = A emits ADD_IMM copy
+
+    def test_expr_single_child_pass_through_compiles(self) -> None:
+        """Unknown-rule node with one ASTNode child is passed through (lines 838-841)."""
+        # paren_group is not a known expr rule; _compile_expr delegates to its sole child
+        inner = _primary_number("5")
+        wrapper = _node("paren_group", inner)  # unknown rule, single ASTNode child
+        expr_node = _node("expr", wrapper)
+        program = _wrap_in_program(_let("A", expr_node))
+        result = compile_basic(program)
+        # LET A = 5 via wrapper — should produce LOAD_IMM 5 and ADD_IMM copy
+        load_imm_ops = find_all(result, IrOp.LOAD_IMM)
+        values = [op[1].value for op in load_imm_ops if isinstance(op[1], IrImmediate)]
+        assert 5 in values
+
+    def test_expr_unexpected_node_raises(self) -> None:
+        """Unknown-rule node with multiple ASTNode children raises CompileError (line 843)."""
+        child1 = _primary_number("1")
+        child2 = _primary_number("2")
+        bad_wrapper = _node("paren_group", child1, child2)  # 2 children → not pass-through
+        expr_node = _node("expr", bad_wrapper)
+        with pytest.raises(CompileError, match="unexpected expression node"):
+            compile_basic(_wrap_in_program(_let("A", expr_node)))
+
+    def test_empty_primary_raises(self) -> None:
+        """primary with no children raises CompileError (line 866)."""
+        empty_primary = _node("primary")
+        expr_node = _node("expr", empty_primary)
+        with pytest.raises(CompileError, match="empty primary expression"):
+            compile_basic(_wrap_in_program(_let("A", expr_node)))
+
+    def test_variable_expr_no_name_raises(self) -> None:
+        """variable node with no NAME token raises in _compile_variable_expr (lines 891, 1066)."""
+        # variable has no NAME token → _extract_var_name returns None → line 891
+        empty_var = _node("variable")  # no NAME token, no LPAREN
+        expr_node = _node("expr", empty_var)
+        with pytest.raises(CompileError, match="could not extract variable name"):
+            compile_basic(_wrap_in_program(_let("B", expr_node)))
+
+    def test_empty_unary_raises(self) -> None:
+        """unary node with no inner expression raises CompileError (line 913)."""
+        empty_unary = _node("unary")  # no children → inner_node=None
+        expr_node = _node("expr", empty_unary)
+        with pytest.raises(CompileError, match="empty unary expression"):
+            compile_basic(_wrap_in_program(_let("A", expr_node)))
+
+    def test_empty_power_raises(self) -> None:
+        """power node with no children raises CompileError (line 956)."""
+        empty_power = _node("power")  # no children → loop finds nothing
+        expr_node = _node("expr", empty_power)
+        with pytest.raises(CompileError, match="empty power expression"):
+            compile_basic(_wrap_in_program(_let("A", expr_node)))
+
+    def test_empty_binop_chain_raises(self) -> None:
+        """expr node with only operator tokens (no operand nodes) raises (line 984)."""
+        # Only a PLUS token — type matches operator check, but no ASTNode operands
+        expr_node = _node("expr", _tok("PLUS", "+"))
+        with pytest.raises(CompileError, match="empty expr expression"):
+            compile_basic(_wrap_in_program(_let("A", expr_node)))
+
+    def test_unknown_binary_operator_raises(self) -> None:
+        """Operator token with unexpected value raises CompileError (line 1019)."""
+        # Token type is PLUS (matches operator check) but value is garbage
+        fake_op = _tok("PLUS", "@@@")
+        expr_node = _node("expr", _primary_number("1"), fake_op, _primary_number("2"))
+        with pytest.raises(CompileError, match="unknown binary operator"):
+            compile_basic(_wrap_in_program(_let("A", expr_node)))
+
+    def test_goto_without_line_number_raises(self) -> None:
+        """goto_stmt with no NUMBER token raises CompileError (line 1083)."""
+        goto_node = _node("goto_stmt", _tok("KEYWORD", "GOTO"))  # no NUMBER
+        with pytest.raises(CompileError, match="could not find line number"):
+            compile_basic(_wrap_in_program(goto_node))

--- a/code/packages/python/ge225-simulator/CHANGELOG.md
+++ b/code/packages/python/ge225-simulator/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the ge225-simulator package will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2026-04-19
+
+### Fixed
+- `_execute_branch_test`: the conditional was inverted (`if not cond: skip`) instead of
+  the correct GE-225 semantics (`if cond: skip`). All skip-test instructions (BZE, BNZ,
+  BMI, BPL, BOD, BEV, BOV, BNO, BPE, BPC, BNR, BNN) now correctly skip the next word
+  when their named condition is **true**, matching the historical GE-225 programming manual.
+  The bug had no observable effect on the existing tests because the affected branch tests
+  coincidentally produced the same PC values by different code paths.
+
 ## [0.1.0] - 2026-04-15
 
 ### Added

--- a/code/packages/python/ge225-simulator/src/ge225_simulator/simulator.py
+++ b/code/packages/python/ge225-simulator/src/ge225_simulator/simulator.py
@@ -754,7 +754,7 @@ class GE225Simulator:
             self._overflow = False
         if mnemonic in {"BPE", "BPC"}:
             self._parity_error = False
-        if not cond:
+        if cond:
             self._pc = (self._pc + 1) % self._memory_size
 
     def _execute_shift(self, mnemonic: str, count: int) -> None:

--- a/code/packages/python/ge225-simulator/tests/test_ge225.py
+++ b/code/packages/python/ge225-simulator/tests/test_ge225.py
@@ -251,6 +251,85 @@ class TestExecution:
         assert sim.disassemble_word(ins(0o00, 10)) == "LDA 0x00A,X0"
 
 
+class TestBranchSemantics:
+    """Verify skip-if-TRUE semantics for all conditional branch instructions.
+
+    The GE-225 branch-test instructions skip the *next* word when their named
+    condition is TRUE.  Pattern used::
+
+        addr 0..n-1 : setup instructions
+        addr n      : B??          (branch-test under test)
+        addr n+1    : BRU 99       (jumped to when condition is FALSE)
+        addr n+2    : NOP          (skipped over when condition is TRUE)
+        addr n+3..  : NOP padding  (BRU-99 target is here)
+
+    After ``n + 3`` steps:
+    - TRUE path:  branch skips BRU → NOP at n+2 → NOP padding → pc = n+4
+    - FALSE path: BRU 99 executes → NOP at 99 → pc = 100
+    """
+
+    def _probe(self, setup_words: list[int], branch_word: int, steps: int | None = None) -> int:
+        """Return PC after running the probe program."""
+        sim = GE225Simulator()
+        n = len(setup_words)
+        program = setup_words + [
+            branch_word,
+            ins(0o26, 99),         # BRU 99: taken when condition is FALSE
+            assemble_fixed("NOP"), # skipped when condition is TRUE
+        ] + [assemble_fixed("NOP")] * 100
+        sim.load_words(program)
+        sim.run(max_steps=steps if steps is not None else n + 3)
+        return sim.get_state().pc
+
+    def test_bze_skips_when_a_is_zero(self) -> None:
+        # A=0 → BZE condition TRUE → skip BRU → pc = 1+4 = 5
+        assert self._probe([assemble_fixed("LDZ")], assemble_fixed("BZE")) == 5
+
+    def test_bze_does_not_skip_when_a_is_nonzero(self) -> None:
+        # A=1 → BZE condition FALSE → BRU 99 → pc = 100
+        assert self._probe([assemble_fixed("LDO")], assemble_fixed("BZE")) == 100
+
+    def test_bnz_skips_when_a_is_nonzero(self) -> None:
+        # A=1 → BNZ condition TRUE → skip BRU → pc = 5
+        assert self._probe([assemble_fixed("LDO")], assemble_fixed("BNZ")) == 5
+
+    def test_bnz_does_not_skip_when_a_is_zero(self) -> None:
+        # A=0 → BNZ condition FALSE → BRU 99 → pc = 100
+        assert self._probe([assemble_fixed("LDZ")], assemble_fixed("BNZ")) == 100
+
+    def test_bpl_skips_when_a_is_nonnegative(self) -> None:
+        # A=0 → BPL condition TRUE → skip BRU → pc = 5
+        assert self._probe([assemble_fixed("LDZ")], assemble_fixed("BPL")) == 5
+
+    def test_bpl_does_not_skip_when_a_is_negative(self) -> None:
+        # A=-1 (LDO + NEG) → BPL condition FALSE → BRU 99 → pc = 100
+        assert self._probe(
+            [assemble_fixed("LDO"), assemble_fixed("NEG")], assemble_fixed("BPL"), steps=5
+        ) == 100
+
+    def test_bmi_skips_when_a_is_negative(self) -> None:
+        # A=-1 (LDO + NEG) → BMI condition TRUE → skip BRU → pc = 2+4 = 6
+        assert self._probe(
+            [assemble_fixed("LDO"), assemble_fixed("NEG")], assemble_fixed("BMI"), steps=5
+        ) == 6
+
+    def test_bod_skips_when_a_is_odd(self) -> None:
+        # A=1 → BOD condition TRUE → skip BRU → pc = 5
+        assert self._probe([assemble_fixed("LDO")], assemble_fixed("BOD")) == 5
+
+    def test_bod_does_not_skip_when_a_is_even(self) -> None:
+        # A=0 → BOD condition FALSE → BRU 99 → pc = 100
+        assert self._probe([assemble_fixed("LDZ")], assemble_fixed("BOD")) == 100
+
+    def test_bev_skips_when_a_is_even(self) -> None:
+        # A=0 → BEV condition TRUE → skip BRU → pc = 5
+        assert self._probe([assemble_fixed("LDZ")], assemble_fixed("BEV")) == 5
+
+    def test_bev_does_not_skip_when_a_is_odd(self) -> None:
+        # A=1 → BEV condition FALSE → BRU 99 → pc = 100
+        assert self._probe([assemble_fixed("LDO")], assemble_fixed("BEV")) == 100
+
+
 class TestProtocolExecution:
     def test_execute_returns_execution_result(self) -> None:
         sim = GE225Simulator()

--- a/code/packages/python/ir-to-ge225-compiler/BUILD
+++ b/code/packages/python/ir-to-ge225-compiler/BUILD
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../compiler-ir -e ../simulator-protocol -e ../ge225-simulator -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/ir-to-ge225-compiler/CHANGELOG.md
+++ b/code/packages/python/ir-to-ge225-compiler/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## 0.1.0 (2026-04-19)
+
+Initial release of the IR-to-GE-225 compiler backend.
+
+### Added
+
+- `compile_to_ge225(program)` function: translates a target-independent `IrProgram`
+  into a GE-225 binary image (packed 3-bytes-per-word)
+- Two-pass assembler: pass 1 assigns label addresses; pass 2 emits machine words
+- Pass 0 pre-scan: collects virtual register indices and builds a constants table
+- V1 IR opcode support: NOP, HALT, LOAD_IMM, ADD, ADD_IMM, SUB, AND_IMM (imm=1),
+  MUL, DIV, CMP_EQ, CMP_NE, CMP_LT, CMP_GT, JUMP, BRANCH_Z, BRANCH_NZ, SYSCALL 1
+- Prologue: `TON` (typewriter on) emitted at address 0 before all IR code
+- Halt stub: `BRU code_end` self-loop appended after all code words
+- Data section: zero-initialised spill slots (one per virtual register) + constants table
+- `CompileResult` dataclass: `binary`, `halt_address`, `data_base`, `label_map`
+- `CodeGenError` raised for unsupported opcodes, non-1 AND_IMM immediates, undefined labels

--- a/code/packages/python/ir-to-ge225-compiler/README.md
+++ b/code/packages/python/ir-to-ge225-compiler/README.md
@@ -1,0 +1,89 @@
+# ir-to-ge225-compiler
+
+GE-225 backend: lowers a target-independent `IrProgram` to GE-225 20-bit machine words.
+
+## Overview
+
+This package is the machine-code backend in the Dartmouth BASIC compiled pipeline:
+
+```
+BASIC source
+    ↓  dartmouth-basic-lexer     (tokenize)
+    ↓  dartmouth-basic-parser    (parse to AST)
+    ↓  dartmouth-basic-ir-compiler   (lower to IR)
+    ↓  ir-to-ge225-compiler          (this package — emit GE-225 words)
+    ↓  ge225-simulator               (execute)
+```
+
+It accepts a `compiler_ir.IrProgram` and emits a binary blob of GE-225 20-bit
+words (packed as 3 bytes per word, big-endian) ready to load into `GE225Simulator`.
+
+## Usage
+
+```python
+from compiler_ir import IrProgram, IrInstruction, IrOp, IrRegister, IrImmediate, IrLabel
+from ir_to_ge225_compiler import compile_to_ge225
+from ge225_simulator import GE225Simulator, unpack_words
+
+# Build a simple program: v1 = 3 + 4; HALT
+program = IrProgram(entry_label="_start")
+# ... populate program.instructions ...
+
+result = compile_to_ge225(program)
+
+sim = GE225Simulator(memory_words=4096)
+sim.load_program_bytes(result.binary)
+
+# Run until halt
+while True:
+    trace = sim.step()
+    if trace.address == result.halt_address:
+        break
+
+# Read variable A (v1) from its spill slot
+a_value = sim.read_word(result.data_base + 1)
+```
+
+## Memory Layout
+
+```
+┌─────────────────────────────────────┐
+│  addr 0       : TON (prologue)      │
+│  addr 1…      : compiled IR code    │
+│  addr code_end: BRU code_end (halt) │
+│  addr data_base…: spill slots (v0…) │
+│  addr …       : constants table     │
+└─────────────────────────────────────┘
+```
+
+- `spill_addr(N) = data_base + N`
+- `const_addr(K) = data_base + n_regs + K`
+
+## V1 Supported IR Opcodes
+
+| IR Opcode | GE-225 Words |
+|-----------|-------------|
+| LABEL / COMMENT | 0 |
+| NOP | 1 |
+| HALT | 1 |
+| JUMP | 1 |
+| LOAD_IMM | 2 |
+| ADD / SUB | 3 |
+| ADD_IMM (copy) | 2 |
+| ADD_IMM (±1) | 3 |
+| ADD_IMM (other) | 3 |
+| AND_IMM (imm=1) | 7 |
+| MUL | 6 |
+| DIV | 5 |
+| CMP_EQ / CMP_NE / CMP_LT / CMP_GT | 8 |
+| BRANCH_Z / BRANCH_NZ | 3 |
+| SYSCALL 1 | 3 |
+
+## Historical Note
+
+The GE-225 was a 20-bit word-addressed accumulator machine built by General Electric
+in 1960. Dartmouth's time-sharing BASIC system, designed in 1964 by John Kemeny and
+Thomas Kurtz, ran on this hardware. All arithmetic flows through the single accumulator
+register A; every variable is stored in a spill slot (a dedicated memory word). This
+backend faithfully mirrors that architecture: no register allocation, pure spill-based
+code generation.

--- a/code/packages/python/ir-to-ge225-compiler/pyproject.toml
+++ b/code/packages/python/ir-to-ge225-compiler/pyproject.toml
@@ -1,0 +1,45 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-ir-to-ge225-compiler"
+version = "0.1.0"
+description = "IR to GE-225 backend: translates a target-independent IrProgram into GE-225 machine words"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["ge-225", "mainframe", "compiler", "ir", "codegen", "dartmouth-basic", "education"]
+dependencies = [
+    "coding-adventures-compiler-ir",
+    "coding-adventures-ge225-simulator",
+]
+
+[project.urls]
+Homepage = "https://github.com/adhithyan15/coding-adventures"
+Repository = "https://github.com/adhithyan15/coding-adventures"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/ir_to_ge225_compiler"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=ir_to_ge225_compiler --cov-report=term-missing --cov-fail-under=90"
+
+[tool.coverage.run]
+source = ["src/ir_to_ge225_compiler"]
+
+[tool.coverage.report]
+fail_under = 90
+show_missing = true

--- a/code/packages/python/ir-to-ge225-compiler/src/ir_to_ge225_compiler/__init__.py
+++ b/code/packages/python/ir-to-ge225-compiler/src/ir_to_ge225_compiler/__init__.py
@@ -1,0 +1,9 @@
+"""IR to GE-225 compiler backend.
+
+Translates a target-independent IrProgram into a binary image of GE-225
+20-bit machine words ready to load into the GE-225 simulator.
+"""
+
+from ir_to_ge225_compiler.codegen import CodeGenError, CompileResult, compile_to_ge225
+
+__all__ = ["CodeGenError", "CompileResult", "compile_to_ge225"]

--- a/code/packages/python/ir-to-ge225-compiler/src/ir_to_ge225_compiler/codegen.py
+++ b/code/packages/python/ir-to-ge225-compiler/src/ir_to_ge225_compiler/codegen.py
@@ -1,0 +1,814 @@
+"""GE-225 two-pass code generator.
+
+Overview
+--------
+
+This module translates a target-independent ``IrProgram`` into a flat binary
+image of GE-225 20-bit machine words. The GE-225 is the 1960-era General
+Electric mainframe that ran Dartmouth's BASIC time-sharing system in 1964.
+
+Architecture summary
+--------------------
+
+The GE-225 is a *word-addressed accumulator machine*:
+
+- Memory: 20-bit words, addressed from 0.
+- Accumulator (A): the sole arithmetic register. All computation routes through it.
+- Q register: the lower half of the 40-bit double-word used by multiply/divide.
+- N register: 6-bit typewriter code latch (loaded via shift, printed via TYP).
+
+Every IR virtual register maps to a *spill slot* — a dedicated memory word in
+the data segment. Operations follow a strict load-compute-store rhythm:
+
+  LDA [vA]      ; A = spill[vA]
+  ADD [vB]      ; A = A + spill[vB]
+  STA [vDst]    ; spill[vDst] = A
+
+Instruction encoding
+--------------------
+
+Memory-reference instructions pack into one 20-bit word::
+
+  [19:15] opcode   (5 bits)
+  [14:13] modifier (2 bits — X register group; always 0 in this backend)
+  [12:0]  address  (13 bits — direct word address)
+
+Fixed-word instructions use pre-defined 20-bit constants (documented octal
+values from the GE-225 manual, retrieved via ``assemble_fixed``).
+
+Conditional branches (BZE/BNZ/BMI/BPL) are *skip-next-if-true*: when the
+condition holds they advance PC by 2 (skipping the next word); otherwise by 1.
+Far conditional jumps therefore require a two-word pair::
+
+  BZE               ; skip next if A==0
+  BRU target        ; jump (executed only when A==0)
+
+Halt convention
+---------------
+
+The GE-225 has no HALT instruction. We use a self-loop stub::
+
+  code_end: BRU code_end   ; spin forever
+
+The ``HALT`` IR opcode emits ``BRU code_end``. The integration layer detects
+halt by checking ``trace.address == halt_address`` after each ``step()``.
+
+Memory layout
+-------------
+
+::
+
+  ┌──────────────────────────────────────┐
+  │ addr 0           : TON (prologue)    │
+  │ addr 1 … code_end-1 : IR code        │
+  │ addr code_end    : BRU code_end      │  ← halt stub
+  │ addr data_base …: spill slots (v0…)  │
+  │ addr …           : constants table   │
+  └──────────────────────────────────────┘
+
+- ``data_base = code_end + 1``
+- ``spill_addr(N) = data_base + N``
+- ``const_addr(K) = data_base + n_regs + K``
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from compiler_ir import IrImmediate, IrInstruction, IrLabel, IrOp, IrProgram, IrRegister
+from ge225_simulator import assemble_fixed, assemble_shift, encode_instruction, pack_words
+
+# ---------------------------------------------------------------------------
+# GE-225 base memory-reference opcodes (5-bit field, octal)
+# ---------------------------------------------------------------------------
+
+_OP_LDA = 0o00  # A = mem[ea]
+_OP_ADD = 0o01  # A = A + mem[ea]
+_OP_SUB = 0o02  # A = A - mem[ea]
+_OP_STA = 0o03  # mem[ea] = A
+_OP_MPY = 0o15  # A,Q = Q × mem[ea] + A  (40-bit accumulate multiply)
+_OP_DVD = 0o16  # A = (A,Q) ÷ mem[ea]  Q = remainder
+_OP_BRU = 0o26  # PC = ea  (unconditional branch)
+
+# ---------------------------------------------------------------------------
+# GE-225 fixed-word instruction constants
+# ---------------------------------------------------------------------------
+# These are the documented 20-bit words from the GE-225 programming manual.
+# ``assemble_fixed(mnemonic)`` looks them up by name and returns the word.
+
+_W_TON = assemble_fixed("TON")   # turn typewriter on; required before any TYP
+_W_TYP = assemble_fixed("TYP")   # print character code held in N register
+_W_NOP = assemble_fixed("NOP")   # no operation
+_W_LDZ = assemble_fixed("LDZ")   # A = 0
+_W_LDO = assemble_fixed("LDO")   # A = 1
+_W_LAQ = assemble_fixed("LAQ")   # A = Q  (copy lower product word after MPY)
+_W_LQA = assemble_fixed("LQA")   # Q = A  (seed Q before MPY or DVD)
+_W_ADO = assemble_fixed("ADO")   # A = A + 1  (add one, no memory access)
+_W_SBO = assemble_fixed("SBO")   # A = A - 1  (subtract one)
+_W_BMI = assemble_fixed("BMI")   # skip next if A < 0 (sign bit set)
+_W_BPL = assemble_fixed("BPL")   # skip next if A >= 0 (sign bit clear)
+_W_BZE = assemble_fixed("BZE")   # skip next if A == 0
+_W_BNZ = assemble_fixed("BNZ")   # skip next if A != 0
+_W_BOD = assemble_fixed("BOD")   # skip next if A is odd (bit 0 == 1)
+_W_SAN6 = assemble_shift("SAN", 6)  # shift A[5:0] into N; used before TYP
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CompileResult:
+    """Output of ``compile_to_ge225``.
+
+    Attributes:
+        binary:       Packed GE-225 binary image (3 bytes per word, big-endian).
+        halt_address: Word address of the halt stub (``BRU halt_address``).
+        data_base:    First data-segment word address (= ``code_end + 1``).
+        label_map:    Maps IR label names to their resolved code word addresses.
+    """
+
+    binary: bytes
+    halt_address: int
+    data_base: int
+    label_map: dict[str, int]
+
+
+class CodeGenError(Exception):
+    """Raised when the IR program cannot be translated to GE-225 code.
+
+    Causes include unsupported IR opcodes, ``AND_IMM`` with a non-1 immediate,
+    or a branch to an undefined label.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Public function
+# ---------------------------------------------------------------------------
+
+
+def compile_to_ge225(program: IrProgram) -> CompileResult:
+    """Compile an ``IrProgram`` to a GE-225 binary image.
+
+    This is a three-pass process:
+
+    - Pass 0: scan all instructions to collect virtual register indices and
+      build the constants table (unique integer values for ``LOAD_IMM`` and
+      ``ADD_IMM`` with non-trivial immediates).
+    - Pass 1: walk the instruction list to compute each instruction's code-word
+      address; record label addresses in the label map.
+    - Pass 2: emit GE-225 machine words for each instruction, using the fully
+      resolved addresses from pass 1.
+
+    Args:
+        program: A validated ``IrProgram`` (all branch targets must be defined).
+
+    Returns:
+        A ``CompileResult`` containing the binary, halt address, data base, and
+        the resolved label map.
+
+    Raises:
+        CodeGenError: if the program uses an unsupported IR opcode, if
+            ``AND_IMM`` uses a non-1 immediate, or if a branch target label is
+            undefined.
+    """
+    return _CodeGen(program).compile()
+
+
+# ---------------------------------------------------------------------------
+# Internal two-pass assembler
+# ---------------------------------------------------------------------------
+
+
+class _CodeGen:
+    """Three-pass GE-225 assembler (internal implementation).
+
+    The three passes are:
+
+    Pass 0 — ``_pass0()``
+        Scan every operand to find the maximum virtual register index (which
+        determines how many spill slots are needed) and to assign a consecutive
+        index to each unique constant value referenced by ``LOAD_IMM`` and non-
+        trivial ``ADD_IMM`` instructions.
+
+    Pass 1 — ``_pass1()``
+        Walk the instruction list, computing the GE-225 word count for each IR
+        instruction and accumulating a ``word_addr`` counter. Labels record their
+        address in ``_label_map`` at zero cost. After pass 1, ``_code_end`` and
+        ``_data_base`` are known.
+
+    Pass 2 — ``_pass2()``
+        Walk the instruction list again, emitting the exact GE-225 words for
+        each instruction using the addresses computed in pass 1.
+    """
+
+    def __init__(self, program: IrProgram) -> None:
+        self._program = program
+        self._max_reg: int = 0
+        self._const_map: dict[int, int] = {}  # value → const_index (insertion order)
+        self._label_map: dict[str, int] = {}
+        self._code_end: int = 0
+        self._data_base: int = 0
+
+    # ------------------------------------------------------------------
+    # Top-level
+    # ------------------------------------------------------------------
+
+    def compile(self) -> CompileResult:
+        """Run all three passes and return the compiled result."""
+        self._pass0()
+        self._pass1()
+        words = self._pass2()
+        return CompileResult(
+            binary=pack_words(words),
+            halt_address=self._code_end,
+            data_base=self._data_base,
+            label_map=self._label_map,
+        )
+
+    # ------------------------------------------------------------------
+    # Pass 0: collect registers and constants
+    # ------------------------------------------------------------------
+
+    def _pass0(self) -> None:
+        """Scan all instructions to find the maximum register index and build
+        the constants table.
+
+        After this pass:
+        - ``_max_reg``: highest virtual register index seen anywhere.
+        - ``_const_map``: maps each unique LOAD_IMM / non-trivial ADD_IMM
+          constant value to its sequential table index.
+        """
+        for instr in self._program.instructions:
+            for operand in instr.operands:
+                if isinstance(operand, IrRegister):
+                    self._max_reg = max(self._max_reg, operand.index)
+            self._record_constants(instr)
+
+    def _record_constants(self, instr: IrInstruction) -> None:
+        """Register any immediate values that need a slot in the constants table.
+
+        ``LOAD_IMM`` always puts its immediate in the table (constants are loaded
+        via ``LDA const_addr``).  ``ADD_IMM`` only needs the table for immediates
+        other than 0, +1, and −1 (those three use the copy, ADO, or SBO paths).
+        """
+        if instr.opcode == IrOp.LOAD_IMM:
+            # Operands: [IrRegister(dst), IrImmediate(value)]
+            for operand in instr.operands:
+                if isinstance(operand, IrImmediate):
+                    self._intern_const(operand.value)
+        elif instr.opcode == IrOp.ADD_IMM:
+            # Operands: [IrRegister(dst), IrRegister(src), IrImmediate(imm)]
+            for operand in instr.operands:
+                if isinstance(operand, IrImmediate) and operand.value not in (0, 1, -1):
+                    self._intern_const(operand.value)
+
+    def _intern_const(self, value: int) -> None:
+        """Add ``value`` to the constants table if not already present."""
+        if value not in self._const_map:
+            self._const_map[value] = len(self._const_map)
+
+    # ------------------------------------------------------------------
+    # Derived layout helpers (depend on pass 0 results + pass 1 code_end)
+    # ------------------------------------------------------------------
+
+    def _n_regs(self) -> int:
+        """Number of spill slots = max_reg + 1 (covers v0 through v_max_reg)."""
+        return self._max_reg + 1
+
+    def _spill(self, reg_index: int) -> int:
+        """Absolute word address of the spill slot for virtual register vN."""
+        return self._data_base + reg_index
+
+    def _const_addr(self, value: int) -> int:
+        """Absolute word address of ``value`` in the constants table."""
+        idx = self._const_map[value]
+        return self._data_base + self._n_regs() + idx
+
+    # ------------------------------------------------------------------
+    # Instruction encoding helpers
+    # ------------------------------------------------------------------
+
+    def _lda(self, addr: int) -> int:
+        return encode_instruction(_OP_LDA, 0, addr)
+
+    def _add(self, addr: int) -> int:
+        return encode_instruction(_OP_ADD, 0, addr)
+
+    def _sub(self, addr: int) -> int:
+        return encode_instruction(_OP_SUB, 0, addr)
+
+    def _sta(self, addr: int) -> int:
+        return encode_instruction(_OP_STA, 0, addr)
+
+    def _mpy(self, addr: int) -> int:
+        return encode_instruction(_OP_MPY, 0, addr)
+
+    def _dvd(self, addr: int) -> int:
+        return encode_instruction(_OP_DVD, 0, addr)
+
+    def _bru(self, addr: int) -> int:
+        return encode_instruction(_OP_BRU, 0, addr)
+
+    # ------------------------------------------------------------------
+    # Pass 1: label assignment and code-size calculation
+    # ------------------------------------------------------------------
+
+    def _word_count(self, instr: IrInstruction) -> int:
+        """Return the number of GE-225 words this IR instruction occupies.
+
+        Used in pass 1 to assign consecutive addresses to all labels and
+        instructions before any words are actually emitted.
+
+        Raises:
+            CodeGenError: for unsupported IR opcodes in V1.
+        """
+        op = instr.opcode
+
+        if op in (IrOp.LABEL, IrOp.COMMENT):
+            return 0
+        if op in (IrOp.NOP, IrOp.HALT, IrOp.JUMP):
+            return 1
+        if op == IrOp.LOAD_IMM:
+            # LDA const_addr; STA spill(dst)
+            return 2
+        if op == IrOp.ADD_IMM:
+            imm = self._get_imm(instr)
+            if imm == 0:
+                # Copy: LDA spill(src); STA spill(dst)
+                return 2
+            # +1: ADO, -1: SBO, other: ADD const — all 3 words
+            return 3
+        if op in (IrOp.ADD, IrOp.SUB):
+            # LDA; ADD/SUB; STA
+            return 3
+        if op == IrOp.AND_IMM:
+            # BOD-branch pattern for bit-0 extraction (see _emit_and_imm)
+            return 7
+        if op == IrOp.MUL:
+            # LDA; LQA; LDZ; MPY; LAQ; STA
+            return 6
+        if op == IrOp.DIV:
+            # LDA; LQA; LDZ; DVD; STA
+            return 5
+        if op in (IrOp.CMP_EQ, IrOp.CMP_NE, IrOp.CMP_LT, IrOp.CMP_GT):
+            # LDA; SUB; skip; BRU; result0; BRU; result1; STA
+            return 8
+        if op in (IrOp.BRANCH_Z, IrOp.BRANCH_NZ):
+            # LDA; BZE/BNZ; BRU target
+            return 3
+        if op == IrOp.SYSCALL:
+            self._check_syscall_num(instr)
+            # LDA spill(v0); SAN 6; TYP
+            return 3
+        raise CodeGenError(f"unsupported IR opcode in V1 GE-225 backend: {op!r}")
+
+    def _pass1(self) -> None:
+        """Assign code addresses to all labels.
+
+        The prologue (TON) occupies word 0. All IR instructions follow from
+        word 1 onwards. After the loop, ``_code_end`` is the address immediately
+        past all code words; the halt stub lives there, and the data segment
+        starts at ``_code_end + 1``.
+        """
+        word_addr = 1  # word 0 = TON prologue
+        for instr in self._program.instructions:
+            if instr.opcode == IrOp.LABEL:
+                name = str(instr.operands[0])
+                self._label_map[name] = word_addr
+            word_addr += self._word_count(instr)
+
+        self._code_end = word_addr
+        self._data_base = self._code_end + 1  # halt stub is one word at code_end
+
+    # ------------------------------------------------------------------
+    # Pass 2: word emission
+    # ------------------------------------------------------------------
+
+    def _pass2(self) -> list[int]:
+        """Emit the complete GE-225 word list.
+
+        Layout of the returned list:
+          [TON, <IR code words>, <halt stub>, <spill slots>, <constants>]
+        """
+        words: list[int] = [_W_TON]  # prologue at address 0
+        emit_addr = 1  # address of the next word to be appended
+
+        for instr in self._program.instructions:
+            new_words = self._emit(instr, emit_addr)
+            words.extend(new_words)
+            emit_addr += len(new_words)
+
+        # Halt stub: self-referencing branch at code_end
+        words.append(self._bru(self._code_end))
+
+        # Data section: n_regs zero-initialised spill slots
+        words.extend([0] * self._n_regs())
+
+        # Constants table (in insertion order from pass 0)
+        for value, _ in sorted(self._const_map.items(), key=lambda kv: kv[1]):
+            words.append(value & 0xFFFFF)  # 20-bit two's-complement
+
+        return words
+
+    def _emit(self, instr: IrInstruction, start_addr: int) -> list[int]:
+        """Emit GE-225 words for a single IR instruction.
+
+        ``start_addr`` is the code-word address at which the first emitted word
+        will reside. Inline jump targets within a multi-word sequence (e.g.
+        the compare and AND_IMM patterns) are computed relative to ``start_addr``.
+
+        Args:
+            instr:      The IR instruction to translate.
+            start_addr: The code address of the first emitted word.
+
+        Returns:
+            A list of 20-bit integers (GE-225 machine words).
+        """
+        op = instr.opcode
+
+        if op in (IrOp.LABEL, IrOp.COMMENT):
+            return []
+        if op == IrOp.NOP:
+            return [_W_NOP]
+        if op == IrOp.HALT:
+            # Jump to the halt stub (BRU code_end)
+            return [self._bru(self._code_end)]
+        if op == IrOp.LOAD_IMM:
+            return self._emit_load_imm(instr)
+        if op == IrOp.ADD_IMM:
+            return self._emit_add_imm(instr)
+        if op == IrOp.ADD:
+            return self._emit_binop(_OP_ADD, instr)
+        if op == IrOp.SUB:
+            return self._emit_binop(_OP_SUB, instr)
+        if op == IrOp.AND_IMM:
+            return self._emit_and_imm(instr, start_addr)
+        if op == IrOp.MUL:
+            return self._emit_mul(instr)
+        if op == IrOp.DIV:
+            return self._emit_div(instr)
+        if op == IrOp.CMP_EQ:
+            return self._emit_cmp(instr, start_addr, eq=True, negate=False)
+        if op == IrOp.CMP_NE:
+            return self._emit_cmp(instr, start_addr, eq=True, negate=True)
+        if op == IrOp.CMP_LT:
+            return self._emit_cmp_signed(instr, start_addr, gt_mode=False)
+        if op == IrOp.CMP_GT:
+            return self._emit_cmp_signed(instr, start_addr, gt_mode=True)
+        if op == IrOp.JUMP:
+            return self._emit_jump(instr)
+        if op == IrOp.BRANCH_Z:
+            return self._emit_branch(instr, zero=True)
+        if op == IrOp.BRANCH_NZ:
+            return self._emit_branch(instr, zero=False)
+        if op == IrOp.SYSCALL:
+            return self._emit_syscall(instr)
+
+        raise CodeGenError(f"unsupported IR opcode in V1 GE-225 backend: {op!r}")
+
+    # ------------------------------------------------------------------
+    # Per-opcode emitters
+    # ------------------------------------------------------------------
+
+    def _emit_load_imm(self, instr: IrInstruction) -> list[int]:
+        """LOAD_IMM vDst, imm → LDA const_addr; STA spill(vDst).
+
+        The constant was pre-stored in the data segment during pass 0.
+        Two words.
+        """
+        dst = self._reg(instr, 0)
+        imm = self._get_imm(instr)
+        return [
+            self._lda(self._const_addr(imm)),
+            self._sta(self._spill(dst)),
+        ]
+
+    def _emit_add_imm(self, instr: IrInstruction) -> list[int]:
+        """ADD_IMM vDst, vSrc, imm — three specialisations.
+
+        imm == 0:   register copy  → LDA; STA  (2 words)
+        imm == +1:  increment      → LDA; ADO; STA  (3 words)
+        imm == -1:  decrement      → LDA; SBO; STA  (3 words)
+        other:      add constant   → LDA; ADD const_addr; STA  (3 words)
+
+        The ADD-constant path requires the immediate to have been interned in
+        the constants table during pass 0.
+        """
+        dst = self._reg(instr, 0)
+        src = self._reg(instr, 1)
+        imm = self._get_imm(instr)
+
+        lda = self._lda(self._spill(src))
+        sta = self._sta(self._spill(dst))
+
+        if imm == 0:
+            return [lda, sta]
+        if imm == 1:
+            return [lda, _W_ADO, sta]
+        if imm == -1:
+            return [lda, _W_SBO, sta]
+        return [lda, self._add(self._const_addr(imm)), sta]
+
+    def _emit_binop(self, ge225_op: int, instr: IrInstruction) -> list[int]:
+        """ADD or SUB vDst, vA, vB → LDA spill(vA); OP spill(vB); STA spill(vDst).
+
+        Three words.
+        """
+        dst = self._reg(instr, 0)
+        reg_a = self._reg(instr, 1)
+        reg_b = self._reg(instr, 2)
+        return [
+            self._lda(self._spill(reg_a)),
+            encode_instruction(ge225_op, 0, self._spill(reg_b)),
+            self._sta(self._spill(dst)),
+        ]
+
+    def _emit_and_imm(self, instr: IrInstruction, start_addr: int) -> list[int]:
+        """AND_IMM vDst, vSrc, 1 — extract parity bit using BOD.
+
+        Only ``imm == 1`` is supported in V1.  Other values raise ``CodeGenError``.
+
+        GE-225 branch-test semantics: ``BOD`` skips the next word when the
+        condition is **TRUE** (A is odd).  Therefore when A is odd the BRU at
+        +2 is skipped and execution falls to LDO at +3; when A is even the
+        BRU executes and jumps to LDZ at +5.
+
+        Seven words::
+
+            addr+0:  LDA  spill(vSrc)
+            addr+1:  BOD                         ; skip next (BRU) if A is ODD
+            addr+2:  BRU  addr+5 (__zero)        ; A is EVEN → jump to LDZ
+            addr+3:  LDO                          ; A is ODD (BOD skipped BRU) → A=1
+            addr+4:  BRU  addr+6 (__done)
+            addr+5:  LDZ                          ; A is EVEN → A=0  [__zero]
+            addr+6:  STA  spill(vDst)             [__done]
+        """
+        dst = self._reg(instr, 0)
+        src = self._reg(instr, 1)
+        imm = self._get_imm(instr)
+        if imm != 1:
+            raise CodeGenError(
+                f"AND_IMM with immediate {imm!r} is not supported in V1; only imm=1 is allowed"
+            )
+        zero_addr = start_addr + 5  # LDZ (result=0) for EVEN inputs
+        done_addr = start_addr + 6  # STA
+        return [
+            self._lda(self._spill(src)),   # +0: load source value
+            _W_BOD,                         # +1: skip +2 if A is ODD (TRUE)
+            self._bru(zero_addr),           # +2: A is EVEN (BOD didn't skip) → jump to LDZ
+            _W_LDO,                         # +3: A is ODD (BOD skipped +2) → A=1
+            self._bru(done_addr),           # +4: jump to STA
+            _W_LDZ,                         # +5: A is EVEN → A=0  [zero_addr]
+            self._sta(self._spill(dst)),    # +6: store result  [done_addr]
+        ]
+
+    def _emit_mul(self, instr: IrInstruction) -> list[int]:
+        """MUL vDst, vA, vB → MPY sequence.
+
+        The GE-225 MPY instruction computes ``A,Q = Q × mem + A``. To multiply
+        vA × vB::
+
+            LDA  spill(vA)    ; A = vA
+            LQA               ; Q = A = vA  (seed the Q register)
+            LDZ               ; A = 0  (accumulator part of 40-bit state)
+            MPY  spill(vB)    ; A,Q = Q*vB + A = vA*vB + 0
+            LAQ               ; A = Q  (take the low 20 bits of the product)
+            STA  spill(vDst)
+
+        Six words.  Note: for products larger than 2^19 the high 20 bits spill
+        into A after MPY. V1 ignores overflow.
+        """
+        dst = self._reg(instr, 0)
+        reg_a = self._reg(instr, 1)
+        reg_b = self._reg(instr, 2)
+        return [
+            self._lda(self._spill(reg_a)),
+            _W_LQA,
+            _W_LDZ,
+            self._mpy(self._spill(reg_b)),
+            _W_LAQ,
+            self._sta(self._spill(dst)),
+        ]
+
+    def _emit_div(self, instr: IrInstruction) -> list[int]:
+        """DIV vDst, vA, vB → DVD sequence.
+
+        The GE-225 DVD instruction takes a 40-bit dividend from (A,Q) and
+        divides by a memory word.  To compute vA ÷ vB (integer quotient)::
+
+            LDA  spill(vA)    ; A = vA  (low dividend word)
+            LQA               ; Q = A = vA
+            LDZ               ; A = 0  (high dividend word — zero for small values)
+            DVD  spill(vB)    ; A = quotient; Q = remainder
+            STA  spill(vDst)
+
+        Five words.  Division by zero propagates a ``ZeroDivisionError`` from
+        the GE-225 simulator's Python implementation.
+        """
+        dst = self._reg(instr, 0)
+        reg_a = self._reg(instr, 1)
+        reg_b = self._reg(instr, 2)
+        return [
+            self._lda(self._spill(reg_a)),
+            _W_LQA,
+            _W_LDZ,
+            self._dvd(self._spill(reg_b)),
+            self._sta(self._spill(dst)),
+        ]
+
+    def _emit_cmp(
+        self, instr: IrInstruction, start_addr: int, *, eq: bool, negate: bool
+    ) -> list[int]:
+        """CMP_EQ or CMP_NE — compare two registers for equality.
+
+        The GE-225 has no compare instruction.  We subtract and test the result::
+
+            LDA  spill(vA)
+            SUB  spill(vB)         ; A = vA - vB  (zero iff equal)
+            BNZ                    ; if A≠0 → skip next  (skip true branch for EQ)
+            BRU  addr+6 (__true)
+            LDZ                    ; not equal → result 0
+            BRU  addr+7 (__done)
+            LDO                    ; equal → result 1    [__true]
+            STA  spill(vDst)                             [__done]
+
+        For CMP_NE, swap the skip sense (BZE instead of BNZ) and the result labels.
+
+        Eight words.
+        """
+        dst = self._reg(instr, 0)
+        reg_a = self._reg(instr, 1)
+        reg_b = self._reg(instr, 2)
+
+        true_addr = start_addr + 6
+        done_addr = start_addr + 7
+
+        # BNZ skips when A≠0; BZE skips when A=0.
+        # For EQ: skip to BRU-true when A≠0 → use BNZ (skip past the BRU when not equal)
+        # For NE: skip to BRU-true when A=0  → use BZE (skip past the BRU when equal)
+        skip_word = _W_BNZ if eq else _W_BZE
+
+        # Result words: if negate (CMP_NE) swap 0 and 1.
+        zero_word = _W_LDO if negate else _W_LDZ  # result when A==0 after SUB
+        one_word  = _W_LDZ if negate else _W_LDO  # result when A!=0 after SUB
+
+        return [
+            self._lda(self._spill(reg_a)),    # +0
+            self._sub(self._spill(reg_b)),     # +1
+            skip_word,                          # +2: conditional skip
+            self._bru(true_addr),              # +3: jump to non-zero branch
+            zero_word,                          # +4: result for A==0
+            self._bru(done_addr),              # +5: jump past non-zero branch
+            one_word,                           # +6: result for A!=0  [__true]
+            self._sta(self._spill(dst)),       # +7  [__done]
+        ]
+
+    def _emit_cmp_signed(
+        self, instr: IrInstruction, start_addr: int, *, gt_mode: bool
+    ) -> list[int]:
+        """CMP_LT or CMP_GT — signed integer comparison.
+
+        For CMP_LT (vA < vB): compute vA - vB; negative result means vA < vB::
+
+            LDA  spill(vA)
+            SUB  spill(vB)         ; A = vA - vB
+            BPL                    ; if A>=0 → skip next (not less than)
+            BRU  addr+6 (__true)
+            LDZ                    ; >=0 → result 0
+            BRU  addr+7 (__done)
+            LDO                    ; <0  → result 1   [__true]
+            STA  spill(vDst)                          [__done]
+
+        For CMP_GT (vA > vB): swap vA and vB (vA > vB iff vB < vA).
+
+        Eight words.
+        """
+        dst = self._reg(instr, 0)
+        reg_a = self._reg(instr, 1)
+        reg_b = self._reg(instr, 2)
+
+        true_addr = start_addr + 6
+        done_addr = start_addr + 7
+
+        # CMP_GT: swap: compute vB - vA (negative iff vB < vA, i.e., vA > vB)
+        lhs = reg_b if gt_mode else reg_a
+        rhs = reg_a if gt_mode else reg_b
+
+        # BPL skips when A >= 0 (non-negative). When the difference is negative
+        # (lhs < rhs) we do NOT skip, so BRU jumps to __true → LDO.
+        return [
+            self._lda(self._spill(lhs)),    # +0
+            self._sub(self._spill(rhs)),     # +1
+            _W_BPL,                          # +2: skip next if A>=0 (not less)
+            self._bru(true_addr),            # +3: jump to true (A<0)
+            _W_LDZ,                          # +4: A>=0 → result 0
+            self._bru(done_addr),            # +5
+            _W_LDO,                          # +6: A<0 → result 1  [__true]
+            self._sta(self._spill(dst)),     # +7  [__done]
+        ]
+
+    def _emit_jump(self, instr: IrInstruction) -> list[int]:
+        """JUMP label → BRU label_addr. One word."""
+        label = self._resolve_label(instr, 0)
+        return [self._bru(label)]
+
+    def _emit_branch(self, instr: IrInstruction, *, zero: bool) -> list[int]:
+        """BRANCH_Z or BRANCH_NZ — conditional far branch.
+
+        The GE-225 conditional branches are skip-next-if-true, not jump-if-true.
+        A far conditional branch requires a two-word pair after the load::
+
+            LDA  spill(vN)
+            BNZ               ; BRANCH_Z:  skip BRU when A≠0 (fall through); execute BRU when A==0
+            BRU  target       ; (executed only when A==0)
+            ; fall through when A≠0
+
+        For BRANCH_NZ, swap BNZ → BZE.  Three words.
+        """
+        reg_n = self._reg(instr, 0)
+        target = self._resolve_label(instr, 1)
+        # To jump when zero: BZE skips BRU when zero... wait, we need to jump
+        # when zero, so when A==0 we should NOT skip the BRU.
+        # BZE skips next IF A==0 → opposite of what we want for BRANCH_Z.
+        # For BRANCH_Z (jump when A==0): use BNZ (skip when A!=0, so don't skip when A==0)
+        # For BRANCH_NZ (jump when A!=0): use BZE (skip when A==0, so don't skip when A!=0)
+        skip_word = _W_BNZ if zero else _W_BZE
+        return [
+            self._lda(self._spill(reg_n)),
+            skip_word,
+            self._bru(target),
+        ]
+
+    def _emit_syscall(self, instr: IrInstruction) -> list[int]:
+        """SYSCALL 1 — print the character whose code is in spill_v0.
+
+        The GE-225 typewriter subsystem requires the character code in the N
+        register (6 bits).  The SAN 6 instruction loads N from the low 6 bits
+        of A::
+
+            LDA  spill(v0)    ; load 6-bit typewriter code
+            SAN  6            ; shift low 6 bits of A into N register
+            TYP               ; print the character whose code is in N
+
+        Three words.
+        """
+        self._check_syscall_num(instr)
+        return [
+            self._lda(self._spill(0)),  # spill(v0) = the syscall argument register
+            _W_SAN6,
+            _W_TYP,
+        ]
+
+    # ------------------------------------------------------------------
+    # Operand extraction helpers
+    # ------------------------------------------------------------------
+
+    def _reg(self, instr: IrInstruction, idx: int) -> int:
+        """Extract the register index from the idx-th operand."""
+        operand = instr.operands[idx]
+        if not isinstance(operand, IrRegister):
+            raise CodeGenError(
+                f"expected IrRegister at operand {idx} of {instr.opcode!r}, "
+                f"got {type(operand).__name__}"
+            )
+        return operand.index
+
+    def _get_imm(self, instr: IrInstruction) -> int:
+        """Extract the integer value from the last IrImmediate operand."""
+        for operand in reversed(instr.operands):
+            if isinstance(operand, IrImmediate):
+                return operand.value
+        raise CodeGenError(f"no IrImmediate operand in {instr.opcode!r} instruction")
+
+    def _resolve_label(self, instr: IrInstruction, idx: int) -> int:
+        """Resolve a label operand to its absolute code address.
+
+        Raises:
+            CodeGenError: if the label has no entry in the label map.
+        """
+        operand = instr.operands[idx]
+        if not isinstance(operand, IrLabel):
+            raise CodeGenError(
+                f"expected IrLabel at operand {idx} of {instr.opcode!r}, "
+                f"got {type(operand).__name__}"
+            )
+        name = operand.name
+        if name not in self._label_map:
+            raise CodeGenError(f"undefined label: {name!r}")
+        return self._label_map[name]
+
+    def _check_syscall_num(self, instr: IrInstruction) -> None:
+        """Verify the SYSCALL number is 1.
+
+        Only SYSCALL 1 (print char from v0) is supported in V1.
+        """
+        for operand in instr.operands:
+            if isinstance(operand, IrImmediate):
+                if operand.value != 1:
+                    raise CodeGenError(
+                        f"only SYSCALL 1 is supported in V1; got SYSCALL {operand.value}"
+                    )
+                return
+        raise CodeGenError("SYSCALL instruction has no numeric operand")

--- a/code/packages/python/ir-to-ge225-compiler/tests/test_ir_to_ge225_compiler.py
+++ b/code/packages/python/ir-to-ge225-compiler/tests/test_ir_to_ge225_compiler.py
@@ -1,0 +1,783 @@
+"""Tests for the ir_to_ge225_compiler package.
+
+Each test compiles an IrProgram, loads the binary into a GE225Simulator, runs
+it to completion, and then verifies the simulator state (memory contents or
+typewriter output).  This approach validates both the code generator and its
+interaction with the real GE-225 simulator.
+
+Test coverage plan (from spec IR01):
+- HALT: PC reaches halt_address; simulator stops there.
+- LOAD_IMM + ADD: arithmetic in memory.
+- SUB, MUL, DIV.
+- CMP_EQ / CMP_NE / CMP_LT / CMP_GT: true and false cases.
+- JUMP: unconditional skip.
+- BRANCH_Z / BRANCH_NZ: conditional skip.
+- FOR-like countdown loop.
+- SYSCALL 1: typewriter output.
+- AND_IMM 1: parity extraction (0 and 1 inputs).
+- AND_IMM non-1: CodeGenError.
+- ADD_IMM imm=0 (copy), +1, -1, other.
+- Negative constants.
+- Undefined label: CodeGenError.
+- Unsupported opcode: CodeGenError.
+- CompileResult fields: binary, halt_address, data_base, label_map.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from compiler_ir import (
+    IrImmediate,
+    IrInstruction,
+    IrLabel,
+    IrOp,
+    IrProgram,
+    IrRegister,
+)
+from ge225_simulator import GE225Simulator
+from ir_to_ge225_compiler import CodeGenError, CompileResult, compile_to_ge225
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_MASK20 = (1 << 20) - 1
+_SIGN_BIT = 1 << 19
+
+
+def _instr(op: IrOp, *operands: IrImmediate | IrRegister | IrLabel) -> IrInstruction:
+    """Convenience constructor for IrInstruction."""
+    return IrInstruction(opcode=op, operands=list(operands), id=-1)
+
+
+def _reg(n: int) -> IrRegister:
+    return IrRegister(index=n)
+
+
+def _imm(v: int) -> IrImmediate:
+    return IrImmediate(value=v)
+
+
+def _lbl(name: str) -> IrLabel:
+    return IrLabel(name=name)
+
+
+def _prog(*instrs: IrInstruction) -> IrProgram:
+    """Build an IrProgram from a flat instruction list."""
+    prog = IrProgram(entry_label="_start")
+    for instr in instrs:
+        prog.add_instruction(instr)
+    return prog
+
+
+def _compile(program: IrProgram) -> tuple[GE225Simulator, CompileResult]:
+    """Compile and run a program to completion.
+
+    Returns ``(sim, result)`` where ``sim`` is the post-execution simulator and
+    ``result`` is the CompileResult.
+
+    Runs at most 10 000 steps to guard against accidental infinite loops in
+    buggy test programs.
+    """
+    result = compile_to_ge225(program)
+    sim = GE225Simulator(memory_words=8192)
+    sim.load_program_bytes(result.binary)
+    for _ in range(10_000):
+        trace = sim.step()
+        if trace.address == result.halt_address:
+            break
+    return sim, result
+
+
+def _read_signed(sim: GE225Simulator, addr: int) -> int:
+    """Read a GE-225 memory word and sign-extend it to a Python int."""
+    raw = sim.read_word(addr)
+    return raw - (1 << 20) if raw & _SIGN_BIT else raw
+
+
+def _spill(result: CompileResult, reg_index: int) -> int:
+    """Return the absolute address of spill slot for virtual register vN."""
+    return result.data_base + reg_index
+
+
+# ---------------------------------------------------------------------------
+# HALT
+# ---------------------------------------------------------------------------
+
+
+class TestHalt:
+    """Programs that end with HALT."""
+
+    def test_halt_only_reaches_halt_address(self) -> None:
+        """A program with only HALT should execute the halt stub."""
+        program = _prog(
+            _instr(IrOp.LABEL, _lbl("_start")),
+            _instr(IrOp.HALT),
+        )
+        result = compile_to_ge225(program)
+        sim = GE225Simulator(memory_words=4096)
+        sim.load_program_bytes(result.binary)
+        trace = sim.step()  # TON (prologue)
+        trace = sim.step()  # BRU halt_address (the HALT IR instruction)
+        trace = sim.step()  # BRU halt_address (the halt stub itself)
+        assert trace.address == result.halt_address
+
+    def test_compile_result_fields(self) -> None:
+        """CompileResult carries binary, halt_address, data_base, label_map."""
+        program = _prog(
+            _instr(IrOp.LABEL, _lbl("_start")),
+            _instr(IrOp.HALT),
+        )
+        result = compile_to_ge225(program)
+        assert isinstance(result.binary, bytes)
+        assert result.halt_address > 0
+        assert result.data_base == result.halt_address + 1
+        assert "_start" in result.label_map
+        assert result.label_map["_start"] == 1  # TON is at addr 0, _start at addr 1
+
+
+# ---------------------------------------------------------------------------
+# LOAD_IMM
+# ---------------------------------------------------------------------------
+
+
+class TestLoadImm:
+    """LOAD_IMM stores a constant in a virtual register's spill slot."""
+
+    def test_load_imm_positive(self) -> None:
+        """LOAD_IMM v1, 42 → spill(v1) == 42."""
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(42)),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 1)) == 42
+
+    def test_load_imm_zero(self) -> None:
+        """LOAD_IMM v1, 0 → spill(v1) == 0."""
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(0)),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 1)) == 0
+
+    def test_load_imm_negative(self) -> None:
+        """LOAD_IMM v1, -7 → spill(v1) holds -7 in two's complement."""
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(-7)),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert _read_signed(sim, _spill(result, 1)) == -7
+
+    def test_same_constant_used_twice_shares_table_entry(self) -> None:
+        """Two LOAD_IMM with the same value use one constants-table entry."""
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(99)),
+            _instr(IrOp.LOAD_IMM, _reg(2), _imm(99)),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 1)) == 99
+        assert sim.read_word(_spill(result, 2)) == 99
+
+
+# ---------------------------------------------------------------------------
+# ADD / SUB
+# ---------------------------------------------------------------------------
+
+
+class TestAddSub:
+    """Register-register addition and subtraction."""
+
+    def test_add(self) -> None:
+        """v3 = v1 + v2 → 3 + 4 = 7."""
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(3)),
+            _instr(IrOp.LOAD_IMM, _reg(2), _imm(4)),
+            _instr(IrOp.ADD, _reg(3), _reg(1), _reg(2)),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 3)) == 7
+
+    def test_sub(self) -> None:
+        """v3 = v1 - v2 → 10 - 3 = 7."""
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(10)),
+            _instr(IrOp.LOAD_IMM, _reg(2), _imm(3)),
+            _instr(IrOp.SUB, _reg(3), _reg(1), _reg(2)),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 3)) == 7
+
+    def test_add_negative_result(self) -> None:
+        """v3 = 2 - 5 = -3."""
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(2)),
+            _instr(IrOp.LOAD_IMM, _reg(2), _imm(5)),
+            _instr(IrOp.SUB, _reg(3), _reg(1), _reg(2)),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert _read_signed(sim, _spill(result, 3)) == -3
+
+
+# ---------------------------------------------------------------------------
+# ADD_IMM
+# ---------------------------------------------------------------------------
+
+
+class TestAddImm:
+    """ADD_IMM specialisations: copy (0), ±1, and general constant."""
+
+    def test_add_imm_copy(self) -> None:
+        """ADD_IMM v2, v1, 0 is a register copy."""
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(55)),
+            _instr(IrOp.ADD_IMM, _reg(2), _reg(1), _imm(0)),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 2)) == 55
+
+    def test_add_imm_plus_one(self) -> None:
+        """ADD_IMM v2, v1, 1 increments by one."""
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(10)),
+            _instr(IrOp.ADD_IMM, _reg(2), _reg(1), _imm(1)),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 2)) == 11
+
+    def test_add_imm_minus_one(self) -> None:
+        """ADD_IMM v2, v1, -1 decrements by one."""
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(7)),
+            _instr(IrOp.ADD_IMM, _reg(2), _reg(1), _imm(-1)),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 2)) == 6
+
+    def test_add_imm_general(self) -> None:
+        """ADD_IMM v2, v1, 100 adds via constants table."""
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(5)),
+            _instr(IrOp.ADD_IMM, _reg(2), _reg(1), _imm(100)),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 2)) == 105
+
+    def test_add_imm_negative_general(self) -> None:
+        """ADD_IMM v2, v1, -10 adds a negative constant (two's complement)."""
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(15)),
+            _instr(IrOp.ADD_IMM, _reg(2), _reg(1), _imm(-10)),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 2)) == 5
+
+
+# ---------------------------------------------------------------------------
+# MUL / DIV
+# ---------------------------------------------------------------------------
+
+
+class TestMulDiv:
+    """Multiply and integer divide."""
+
+    def test_mul(self) -> None:
+        """v3 = v1 * v2 → 6 × 7 = 42."""
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(6)),
+            _instr(IrOp.LOAD_IMM, _reg(2), _imm(7)),
+            _instr(IrOp.MUL, _reg(3), _reg(1), _reg(2)),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 3)) == 42
+
+    def test_div_quotient(self) -> None:
+        """v3 = v1 / v2 → 15 ÷ 4 = 3 (truncates)."""
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(15)),
+            _instr(IrOp.LOAD_IMM, _reg(2), _imm(4)),
+            _instr(IrOp.DIV, _reg(3), _reg(1), _reg(2)),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 3)) == 3
+
+    def test_div_exact(self) -> None:
+        """v3 = 12 / 3 = 4 (no remainder)."""
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(12)),
+            _instr(IrOp.LOAD_IMM, _reg(2), _imm(3)),
+            _instr(IrOp.DIV, _reg(3), _reg(1), _reg(2)),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 3)) == 4
+
+    def test_mul_by_zero(self) -> None:
+        """v3 = v1 * 0 = 0."""
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(99)),
+            _instr(IrOp.LOAD_IMM, _reg(2), _imm(0)),
+            _instr(IrOp.MUL, _reg(3), _reg(1), _reg(2)),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 3)) == 0
+
+
+# ---------------------------------------------------------------------------
+# CMP_EQ / CMP_NE
+# ---------------------------------------------------------------------------
+
+
+class TestCmpEqNe:
+    """Equality comparisons produce 0 (false) or 1 (true)."""
+
+    def test_cmp_eq_true(self) -> None:
+        """Equal inputs → result 1."""
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(5)),
+            _instr(IrOp.LOAD_IMM, _reg(2), _imm(5)),
+            _instr(IrOp.CMP_EQ, _reg(3), _reg(1), _reg(2)),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 3)) == 1
+
+    def test_cmp_eq_false(self) -> None:
+        """Unequal inputs → result 0."""
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(3)),
+            _instr(IrOp.LOAD_IMM, _reg(2), _imm(7)),
+            _instr(IrOp.CMP_EQ, _reg(3), _reg(1), _reg(2)),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 3)) == 0
+
+    def test_cmp_ne_true(self) -> None:
+        """Unequal inputs → CMP_NE result 1."""
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(3)),
+            _instr(IrOp.LOAD_IMM, _reg(2), _imm(7)),
+            _instr(IrOp.CMP_NE, _reg(3), _reg(1), _reg(2)),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 3)) == 1
+
+    def test_cmp_ne_false(self) -> None:
+        """Equal inputs → CMP_NE result 0."""
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(5)),
+            _instr(IrOp.LOAD_IMM, _reg(2), _imm(5)),
+            _instr(IrOp.CMP_NE, _reg(3), _reg(1), _reg(2)),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 3)) == 0
+
+
+# ---------------------------------------------------------------------------
+# CMP_LT / CMP_GT
+# ---------------------------------------------------------------------------
+
+
+class TestCmpLtGt:
+    """Signed less-than and greater-than comparisons."""
+
+    def test_cmp_lt_true(self) -> None:
+        """2 < 5 → 1."""
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(2)),
+            _instr(IrOp.LOAD_IMM, _reg(2), _imm(5)),
+            _instr(IrOp.CMP_LT, _reg(3), _reg(1), _reg(2)),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 3)) == 1
+
+    def test_cmp_lt_false_equal(self) -> None:
+        """5 < 5 → 0 (equal is not less than)."""
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(5)),
+            _instr(IrOp.LOAD_IMM, _reg(2), _imm(5)),
+            _instr(IrOp.CMP_LT, _reg(3), _reg(1), _reg(2)),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 3)) == 0
+
+    def test_cmp_lt_false_greater(self) -> None:
+        """7 < 3 → 0."""
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(7)),
+            _instr(IrOp.LOAD_IMM, _reg(2), _imm(3)),
+            _instr(IrOp.CMP_LT, _reg(3), _reg(1), _reg(2)),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 3)) == 0
+
+    def test_cmp_gt_true(self) -> None:
+        """5 > 2 → 1."""
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(5)),
+            _instr(IrOp.LOAD_IMM, _reg(2), _imm(2)),
+            _instr(IrOp.CMP_GT, _reg(3), _reg(1), _reg(2)),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 3)) == 1
+
+    def test_cmp_gt_false(self) -> None:
+        """2 > 5 → 0."""
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(2)),
+            _instr(IrOp.LOAD_IMM, _reg(2), _imm(5)),
+            _instr(IrOp.CMP_GT, _reg(3), _reg(1), _reg(2)),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 3)) == 0
+
+    def test_cmp_gt_false_equal(self) -> None:
+        """5 > 5 → 0."""
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(5)),
+            _instr(IrOp.LOAD_IMM, _reg(2), _imm(5)),
+            _instr(IrOp.CMP_GT, _reg(3), _reg(1), _reg(2)),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 3)) == 0
+
+
+# ---------------------------------------------------------------------------
+# JUMP
+# ---------------------------------------------------------------------------
+
+
+class TestJump:
+    """Unconditional branch."""
+
+    def test_jump_skips_instruction(self) -> None:
+        """JUMP over a LOAD_IMM: the skipped instruction's register stays 0."""
+        program = _prog(
+            _instr(IrOp.LABEL, _lbl("_start")),
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(10)),
+            _instr(IrOp.JUMP, _lbl("_after")),
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(99)),  # should be skipped
+            _instr(IrOp.LABEL, _lbl("_after")),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 1)) == 10  # 99 was never written
+
+
+# ---------------------------------------------------------------------------
+# BRANCH_Z / BRANCH_NZ
+# ---------------------------------------------------------------------------
+
+
+class TestBranch:
+    """Conditional branches."""
+
+    def test_branch_z_taken_when_zero(self) -> None:
+        """BRANCH_Z with zero register jumps over the skipped LOAD_IMM."""
+        program = _prog(
+            _instr(IrOp.LABEL, _lbl("_start")),
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(0)),   # v1 = 0 → condition zero
+            _instr(IrOp.LOAD_IMM, _reg(2), _imm(42)),   # v2 = 42 (sentinel)
+            _instr(IrOp.BRANCH_Z, _reg(1), _lbl("_skip")),
+            _instr(IrOp.LOAD_IMM, _reg(2), _imm(99)),   # skipped when zero
+            _instr(IrOp.LABEL, _lbl("_skip")),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 2)) == 42
+
+    def test_branch_z_not_taken_when_nonzero(self) -> None:
+        """BRANCH_Z with non-zero register falls through."""
+        program = _prog(
+            _instr(IrOp.LABEL, _lbl("_start")),
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(5)),    # v1 = 5 → not zero
+            _instr(IrOp.LOAD_IMM, _reg(2), _imm(0)),
+            _instr(IrOp.BRANCH_Z, _reg(1), _lbl("_skip")),
+            _instr(IrOp.LOAD_IMM, _reg(2), _imm(77)),   # executed (not skipped)
+            _instr(IrOp.LABEL, _lbl("_skip")),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 2)) == 77
+
+    def test_branch_nz_taken_when_nonzero(self) -> None:
+        """BRANCH_NZ with non-zero register jumps."""
+        program = _prog(
+            _instr(IrOp.LABEL, _lbl("_start")),
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(3)),
+            _instr(IrOp.LOAD_IMM, _reg(2), _imm(55)),
+            _instr(IrOp.BRANCH_NZ, _reg(1), _lbl("_skip")),
+            _instr(IrOp.LOAD_IMM, _reg(2), _imm(99)),   # skipped
+            _instr(IrOp.LABEL, _lbl("_skip")),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 2)) == 55
+
+    def test_branch_nz_not_taken_when_zero(self) -> None:
+        """BRANCH_NZ with zero register falls through."""
+        program = _prog(
+            _instr(IrOp.LABEL, _lbl("_start")),
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(0)),
+            _instr(IrOp.LOAD_IMM, _reg(2), _imm(0)),
+            _instr(IrOp.BRANCH_NZ, _reg(1), _lbl("_skip")),
+            _instr(IrOp.LOAD_IMM, _reg(2), _imm(33)),   # executed
+            _instr(IrOp.LABEL, _lbl("_skip")),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 2)) == 33
+
+
+# ---------------------------------------------------------------------------
+# Loop (FOR-like countdown)
+# ---------------------------------------------------------------------------
+
+
+class TestLoop:
+    """A countdown loop demonstrates LABEL, CMP_GT, BRANCH_NZ, ADD_IMM, JUMP."""
+
+    def test_countdown_loop(self) -> None:
+        """Count from 3 down to 0, accumulating into v2.
+
+        v1 = 3 (counter), v2 = 0 (accumulator), v3 = 0 (limit)
+        while v1 > v3:
+            v2 += 1
+            v1 -= 1
+
+        After the loop, v1 == 0, v2 == 3.
+        """
+        program = _prog(
+            _instr(IrOp.LABEL, _lbl("_start")),
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(3)),   # counter = 3
+            _instr(IrOp.LOAD_IMM, _reg(2), _imm(0)),   # accumulator = 0
+            _instr(IrOp.LOAD_IMM, _reg(3), _imm(0)),   # limit = 0
+            _instr(IrOp.LABEL, _lbl("_check")),
+            _instr(IrOp.CMP_GT, _reg(4), _reg(1), _reg(3)),    # v4 = (v1 > v3)
+            _instr(IrOp.BRANCH_NZ, _reg(4), _lbl("_body")),    # jump if v1 > 0
+            _instr(IrOp.JUMP, _lbl("_end")),
+            _instr(IrOp.LABEL, _lbl("_body")),
+            _instr(IrOp.ADD_IMM, _reg(2), _reg(2), _imm(1)),   # acc += 1
+            _instr(IrOp.ADD_IMM, _reg(1), _reg(1), _imm(-1)),  # counter -= 1
+            _instr(IrOp.JUMP, _lbl("_check")),
+            _instr(IrOp.LABEL, _lbl("_end")),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 1)) == 0  # counter exhausted
+        assert sim.read_word(_spill(result, 2)) == 3  # accumulator = 3
+
+
+# ---------------------------------------------------------------------------
+# AND_IMM
+# ---------------------------------------------------------------------------
+
+
+class TestAndImm:
+    """AND_IMM v, v, 1 — parity bit extraction."""
+
+    def test_and_imm_1_even_input(self) -> None:
+        """AND_IMM of an even value produces 0."""
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(6)),   # 6 is even
+            _instr(IrOp.AND_IMM, _reg(2), _reg(1), _imm(1)),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 2)) == 0
+
+    def test_and_imm_1_odd_input(self) -> None:
+        """AND_IMM of an odd value produces 1."""
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(7)),   # 7 is odd
+            _instr(IrOp.AND_IMM, _reg(2), _reg(1), _imm(1)),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 2)) == 1
+
+    def test_and_imm_1_value_1(self) -> None:
+        """AND_IMM with input 1 (odd) → result 1."""
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(1)),
+            _instr(IrOp.AND_IMM, _reg(2), _reg(1), _imm(1)),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 2)) == 1
+
+    def test_and_imm_non_1_raises(self) -> None:
+        """AND_IMM with immediate != 1 raises CodeGenError."""
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(0xFF)),
+            _instr(IrOp.AND_IMM, _reg(2), _reg(1), _imm(0xFF)),
+            _instr(IrOp.HALT),
+        )
+        with pytest.raises(CodeGenError, match="AND_IMM"):
+            compile_to_ge225(program)
+
+
+# ---------------------------------------------------------------------------
+# SYSCALL 1 (typewriter output)
+# ---------------------------------------------------------------------------
+
+
+class TestSyscall:
+    """SYSCALL 1 prints the GE-225 typewriter character whose code is in v0."""
+
+    def test_syscall_prints_character(self) -> None:
+        """Print 'A' (GE-225 typewriter code 0o21 = 17)."""
+        a_code = 0o21  # octal 21 = 17 decimal = 'A' in GE-225 typewriter codes
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(0), _imm(a_code)),
+            _instr(IrOp.SYSCALL, _imm(1)),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.get_typewriter_output() == "A"
+
+    def test_syscall_prints_multiple_characters(self) -> None:
+        """Print 'HI' — two sequential SYSCALL 1 invocations."""
+        # H = 0o30 = 24; I = 0o31 = 25
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(0), _imm(0o30)),
+            _instr(IrOp.SYSCALL, _imm(1)),
+            _instr(IrOp.LOAD_IMM, _reg(0), _imm(0o31)),
+            _instr(IrOp.SYSCALL, _imm(1)),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.get_typewriter_output() == "HI"
+
+    def test_syscall_non_1_raises(self) -> None:
+        """SYSCALL with number != 1 raises CodeGenError."""
+        program = _prog(
+            _instr(IrOp.SYSCALL, _imm(2)),
+            _instr(IrOp.HALT),
+        )
+        with pytest.raises(CodeGenError, match="SYSCALL"):
+            compile_to_ge225(program)
+
+
+# ---------------------------------------------------------------------------
+# NOP
+# ---------------------------------------------------------------------------
+
+
+class TestNop:
+    """NOP is a no-operation."""
+
+    def test_nop_does_nothing(self) -> None:
+        """NOP leaves a register's spill slot unchanged."""
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(7)),
+            _instr(IrOp.NOP),
+            _instr(IrOp.HALT),
+        )
+        sim, result = _compile(program)
+        assert sim.read_word(_spill(result, 1)) == 7
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+class TestErrors:
+    """CodeGenError for unsupported features."""
+
+    def test_undefined_label_raises(self) -> None:
+        """A branch to an undefined label raises CodeGenError."""
+        program = _prog(
+            _instr(IrOp.JUMP, _lbl("_nowhere")),
+            _instr(IrOp.HALT),
+        )
+        with pytest.raises(CodeGenError, match="undefined label"):
+            compile_to_ge225(program)
+
+    def test_unsupported_opcode_load_byte_raises(self) -> None:
+        """LOAD_BYTE is not supported in V1."""
+        program = _prog(
+            _instr(IrOp.LOAD_BYTE, _reg(1), _reg(2)),
+            _instr(IrOp.HALT),
+        )
+        with pytest.raises(CodeGenError, match="unsupported"):
+            compile_to_ge225(program)
+
+    def test_unsupported_opcode_call_raises(self) -> None:
+        """CALL is not supported in V1."""
+        program = _prog(
+            _instr(IrOp.CALL, _lbl("_func")),
+            _instr(IrOp.HALT),
+        )
+        with pytest.raises(CodeGenError, match="unsupported"):
+            compile_to_ge225(program)
+
+    def test_unsupported_opcode_and_raises(self) -> None:
+        """AND (register-register) is not supported in V1."""
+        program = _prog(
+            _instr(IrOp.AND, _reg(3), _reg(1), _reg(2)),
+            _instr(IrOp.HALT),
+        )
+        with pytest.raises(CodeGenError, match="unsupported"):
+            compile_to_ge225(program)
+
+    def test_label_map_contains_defined_labels(self) -> None:
+        """CompileResult.label_map contains all LABEL instructions."""
+        program = _prog(
+            _instr(IrOp.LABEL, _lbl("_start")),
+            _instr(IrOp.LABEL, _lbl("_loop")),
+            _instr(IrOp.HALT),
+        )
+        result = compile_to_ge225(program)
+        assert "_start" in result.label_map
+        assert "_loop" in result.label_map
+
+    def test_data_base_is_code_end_plus_one(self) -> None:
+        """data_base == halt_address + 1."""
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(1)),
+            _instr(IrOp.HALT),
+        )
+        result = compile_to_ge225(program)
+        assert result.data_base == result.halt_address + 1
+
+    def test_binary_length_correct(self) -> None:
+        """Binary length = (code_end + 1 + n_regs + n_consts) × 3 bytes."""
+        # v1 and one constant (5)
+        program = _prog(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(5)),
+            _instr(IrOp.HALT),
+        )
+        result = compile_to_ge225(program)
+        # code: TON(1) + LOAD_IMM(2) + HALT(1) = 4 words; halt_stub = 1 word
+        # data: n_regs=2 (v0, v1) + n_consts=1 (5) = 3 words; total = 8 words = 24 bytes
+        assert len(result.binary) % 3 == 0  # always a multiple of 3
+        n_words = len(result.binary) // 3
+        # data_base + n_regs + n_consts = total size
+        expected = result.data_base + 2 + 1  # 2 spill slots (v0,v1), 1 const
+        assert n_words == expected

--- a/code/specs/IR01-ir-to-ge225-compiler.md
+++ b/code/specs/IR01-ir-to-ge225-compiler.md
@@ -1,0 +1,726 @@
+# IR01 — IR to GE-225 Compiler
+
+## Overview
+
+This spec defines the `ir-to-ge225-compiler` Python package: a backend that translates a
+`compiler_ir.IrProgram` into a binary image of GE-225 20-bit machine words ready to load
+into the GE-225 simulator.
+
+The GE-225 was a 20-bit word-addressed accumulator machine built by General Electric in
+the early 1960s. Dartmouth's time-sharing system ran on it in 1964, executing the world's
+first BASIC programs. Every variable, every loop counter, every comparison result lives in
+a 20-bit word in memory; the single accumulator register A is the bottleneck through which
+all arithmetic flows.
+
+This backend sits at layer 4 in the compiled pipeline:
+
+```
+IrProgram  (from dartmouth-basic-ir-compiler, spec PL02)
+    ↓  ir-to-ge225-compiler   (this spec — emit machine words)
+    ↓  ge225-simulator         (execute)
+```
+
+The backend knows nothing about BASIC syntax. Its input is a generic `IrProgram`; a future
+`ir-to-wasm-compiler` or `ir-to-jvm-compiler` would accept the same input.
+
+## GE-225 Architecture Primer
+
+### Word Format
+
+All memory cells are 20-bit words, stored as three bytes (big-endian, top 4 bits unused):
+
+```
+Bit 19: sign bit (1 = negative, two's complement)
+Bits 18–0: data/address/opcode field
+```
+
+### Instruction Encoding
+
+Memory-reference instructions (the majority) pack into one 20-bit word:
+
+```
+[19:15]  opcode    (5 bits — 32 possible opcodes)
+[14:13]  modifier  (2 bits — X register group for indexed addressing)
+[12:0]   address   (13 bits — direct address 0–8191)
+```
+
+Effective address = `address + X[modifier]` when modifier ≠ 0, or `address` when modifier = 0.
+
+### Key Instructions for This Backend
+
+**Memory reference (OP modifier, address):**
+
+| Mnemonic | Opcode | Effect |
+|----------|--------|--------|
+| `LDA` | 0o00 | A = mem[ea] |
+| `ADD` | 0o01 | A = A + mem[ea] |
+| `SUB` | 0o02 | A = A - mem[ea] |
+| `STA` | 0o03 | mem[ea] = A |
+| `MPY` | 0o15 | A,Q = Q × mem[ea] + A (40-bit accumulate multiply) |
+| `DVD` | 0o16 | A = (A,Q) ÷ mem[ea] (quotient); Q = remainder |
+| `BRU` | 0o26 | PC = ea (unconditional branch) |
+| `SPB` | 0o07 | X[mod] = PC; PC = ea (subroutine call) |
+
+**Fixed-word instructions (no address field — full 20-bit word is constant):**
+
+| Mnemonic | Word (octal) | Effect |
+|----------|-------------|--------|
+| `LDZ` | 2504002 | A = 0 |
+| `LDO` | 2504022 | A = 1 |
+| `LMO` | 2504102 | A = all ones (0xFFFFF) |
+| `NOP` | 2504012 | No operation |
+| `NEG` | 2504522 | A = −A |
+| `LAQ` | 2504001 | A = Q |
+| `LQA` | 2504004 | Q = A |
+| `TON` | 2500007 | Turn on typewriter |
+| `TYP` | 2500006 | Print character code in N register |
+| `BMI` | 2514001 | Skip next if A < 0 (negative) |
+| `BPL` | 2516001 | Skip next if A ≥ 0 (non-negative) |
+| `BZE` | 2514002 | Skip next if A = 0 |
+| `BNZ` | 2516002 | Skip next if A ≠ 0 |
+
+**Shift instruction (parametric fixed word):**
+
+| Mnemonic | Effect |
+|----------|--------|
+| `SAN k`  | Right-shift the concatenation of A[18:0] and N[5:0] by k bits; bits from A enter N from the top. Used to load the N register. |
+
+`SAN k` encodes as `assemble_shift("SAN", k)` from the simulator's API.
+
+### The Accumulator Model
+
+The GE-225 has no general-purpose register file. All arithmetic flows through a single
+accumulator (A). To compute `A + B`, the sequence is:
+
+```
+LDA [A]      ; A_reg = mem[A]
+ADD [B]      ; A_reg = A_reg + mem[B]
+STA [result] ; mem[result] = A_reg
+```
+
+Every IR virtual register is mapped to a *spill slot*: a dedicated memory word. Operations
+read from spill slots into A, compute, and write back. This makes every operation 2–8 words
+but is completely correct. Future versions could optimize with peephole passes.
+
+### Branch Semantics
+
+The GE-225 conditional branches are **skip-next-if-condition** instructions, not
+jump-if-condition. To jump to a far label on a condition, a two-word sequence is needed:
+
+```
+; Jump to LABEL if A == 0:
+BNZ            ; if A ≠ 0, skip next word (don't jump)
+BRU LABEL      ; executed only when A == 0
+; fall through here when A ≠ 0
+```
+
+```
+; Jump to LABEL if A ≠ 0:
+BZE            ; if A = 0, skip next word (don't jump)
+BRU LABEL      ; executed only when A ≠ 0
+```
+
+```
+; Jump to LABEL if A < 0 (negative):
+BPL            ; if A ≥ 0, skip next word
+BRU LABEL
+```
+
+This pattern is used for all conditional branches in this backend.
+
+### Halt Convention
+
+The GE-225 has no HALT instruction. Programs that finish are expected to wait for I/O or
+return to the OS. For our simulator, we use the **self-loop halt stub**:
+
+```
+__halt: BRU __halt   ; PC loops to itself forever
+```
+
+The `HALT` IR instruction compiles to `BRU __halt`. After compilation the backend returns
+the `halt_address` alongside the binary. The integration layer calls `simulator.step()` in
+a loop and stops when `trace.address == halt_address` (the step that *executes* the BRU to
+itself is the last meaningful step).
+
+### Typewriter Output
+
+The GE-225's typewriter (Teletype) output works through the 6-bit N register:
+
+1. `TON` — turn on typewriter power (must precede any TYP)
+2. Load a 6-bit typewriter code into N via `SAN 6`:
+   - Place the 6-bit code in the low bits of A
+   - `SAN 6` shifts those 6 bits from A into N
+3. `TYP` — print the character whose GE-225 code is in N
+
+`SAN 6` derivation (from the simulator source):
+
+```
+combined = (A_data[18:0] << 6) | N[5:0]    ; 25 bits
+combined >>= 6                               ; shift right by 6
+new_A_data = (combined >> 6) & 0x7FFFF      ; high 19 bits
+new_N = combined & 0x3F                      ; low 6 bits
+```
+
+For a 6-bit code X stored in A (A = X, 0 ≤ X < 64):
+- combined = X << 6 | old_N
+- after >>= 6: combined = X (the high 6 bits of X<<6 shifted back)
+- new_N = X & 0x3F = X ✓
+- new_A = (X >> 6) & mask = 0 (for X < 64) ✓
+
+So `LDA [spill_v0]; SAN 6; TYP` correctly prints the character.
+
+## Memory Layout
+
+The compiled binary occupies a contiguous region of GE-225 memory starting at word 0:
+
+```
+┌─────────────────────────────────────────────────┐
+│  0 … code_end-1 : Code words                    │
+│                   (compiled IR instructions)     │
+├─────────────────────────────────────────────────┤
+│  code_end       : Halt stub                      │
+│                   BRU code_end  (self-loop)      │
+├─────────────────────────────────────────────────┤
+│  data_base … :  Data words                       │
+│                   spill_v0, spill_v1, …          │
+│                   (one word per virtual register) │
+│                   const_0, const_1, …            │
+│                   (constants table for LOAD_IMM) │
+└─────────────────────────────────────────────────┘
+```
+
+- `data_base = code_end + 1`
+- All BASIC variables (v1–v26 for A–Z) are spill slots.
+- The constants table holds unique integer values referenced by `LOAD_IMM` instructions.
+  If the same constant appears 50 times in the program, it appears once in the table.
+
+## Spill-Slot and Constants Table Allocation
+
+### Pass 0: Collect Virtual Registers and Constants
+
+Before the two-pass assembly, scan all IR instructions once:
+
+1. For each `IrRegister` operand, record `reg.index` in a set.
+2. For each `IrImmediate` operand in a `LOAD_IMM` instruction, record the value in a dict
+   mapping `value → const_index`. Constants are assigned indices in encounter order.
+
+After pass 0:
+- `max_reg` = maximum register index seen
+- `n_regs` = max_reg + 1 (number of spill slots)
+- `n_consts` = number of unique constants
+- `spill_addr(N) = data_base + N`
+- `const_addr(K) = data_base + n_regs + K`
+
+**Note:** `data_base` is not yet known — it depends on the size of the code region, which
+is determined in pass 1. The constants and spill offsets are *relative to data_base* during
+passes 1 and 2; absolute addresses are resolved in a final link step.
+
+## Two-Pass Assembly
+
+### Pass 1: Size and Label Assignment
+
+Walk the IR instruction list. For each instruction, compute how many GE-225 words it
+produces and record the starting code address.
+
+Maintain a counter `word_addr` starting at 0.
+
+For each IR instruction:
+- `LABEL name`: record `labels[name] = word_addr` (labels occupy 0 words).
+- `COMMENT text`: 0 words.
+- All others: add the word count from the table below to `word_addr`.
+
+After pass 1:
+- `code_end = word_addr` (first address after all code words).
+- `data_base = code_end + 1` (halt stub is one word at code_end).
+- All label addresses in `labels` are now absolute.
+
+### Pass 2: Emit Words
+
+Walk the IR instruction list again. For each instruction, emit the appropriate GE-225 words
+using the now-known `data_base` and `labels` map. Collect all emitted words into a list.
+
+After pass 2, append:
+1. The halt stub: `encode_instruction(OP_BRU, 0, code_end)` (self-loop).
+2. Data words: `n_regs` zero-initialized spill slots, then `n_consts` constant values (each
+   in the low 20 bits as a signed two's complement 20-bit integer).
+
+The final binary is `pack_words(code_words + [halt_stub_word] + data_words)`.
+
+## IR Opcode to GE-225 Word Sequence
+
+Notation:
+- `spill(vN)` = `data_base + N` = absolute memory address of register vN's spill slot
+- `const(K)` = `data_base + n_regs + K` = absolute memory address of constant K
+- `label(name)` = resolved code address from the label map
+
+### LABEL name
+
+*0 words.* Side effect: records `labels[name] = current_word_addr` in pass 1.
+
+### COMMENT text
+
+*0 words.*
+
+### NOP
+
+```
+NOP                            ; 1 word: fixed word 2504012₈
+```
+
+*1 word.*
+
+### HALT
+
+```
+BRU code_end                   ; 1 word: jump to halt stub
+```
+
+*1 word.*
+
+### LOAD_IMM vDst, imm
+
+```
+LDA const_addr                 ; 1 word: A = mem[const_addr]
+STA spill(vDst)                ; 1 word: store to dst spill slot
+```
+
+*2 words.*
+
+The constant `imm` is pre-stored in the data region at `const_addr`.
+
+### ADD vDst, vA, vB
+
+```
+LDA spill(vA)                  ; 1 word: A = vA
+ADD spill(vB)                  ; 1 word: A = A + vB
+STA spill(vDst)                ; 1 word: store result
+```
+
+*3 words.*
+
+### ADD_IMM vDst, vSrc, imm
+
+For immediates that are 0 (register copy):
+
+```
+LDA spill(vSrc)                ; 1 word
+STA spill(vDst)                ; 1 word
+```
+
+For +1:
+
+```
+LDA spill(vSrc)                ; 1 word: A = vSrc
+ADO                            ; 1 word (fixed): A = A + 1
+STA spill(vDst)                ; 1 word: store
+```
+
+*3 words.*
+
+For -1:
+
+```
+LDA spill(vSrc)
+SBO                            ; A = A - 1
+STA spill(vDst)
+```
+
+*3 words.*
+
+For all other immediates, store the immediate in the constants table and use ADD:
+
+```
+LDA spill(vSrc)
+ADD const_addr                 ; A = vSrc + imm
+STA spill(vDst)
+```
+
+*3 words.*
+
+### SUB vDst, vA, vB
+
+```
+LDA spill(vA)
+SUB spill(vB)                  ; A = vA - vB
+STA spill(vDst)
+```
+
+*3 words.*
+
+### AND_IMM vDst, vSrc, imm
+
+The GE-225 has no direct AND-immediate instruction. The immediate is stored in the
+constants table and the backend emits:
+
+```
+LDA spill(vSrc)
+EXT const_addr                 ; A = A & ~mem[const_addr]  ← NOT what we want
+```
+
+The EXT (extract) instruction computes `A = A & ~mask`, which is NOT a logical AND.
+
+For `AND_IMM v, v, 1` (used to mask the low bit), we can avoid EXT entirely:
+
+```
+; A = vSrc & 1 — get parity bit
+LDA spill(vSrc)
+BOD                            ; skip next if A is odd (bit 0 = 1)
+BRU __and_imm_N_zero
+LDO                            ; A = 1 (odd: bit 0 was 1)
+BRU __and_imm_N_done
+__and_imm_N_zero:
+LDZ                            ; A = 0 (even: bit 0 was 0)
+__and_imm_N_done:
+STA spill(vDst)
+```
+
+*8 words.* This handles the `AND_IMM v, v, 1` pattern from the `<=` / `>=` NOT idiom
+(spec PL02). General AND with arbitrary immediates is deferred to V2 (not needed for V1).
+
+Raise `CodeGenError` if AND_IMM is used with an immediate other than 1 in V1.
+
+### MUL vDst, vA, vB
+
+GE-225 multiply: `MPY mem` computes `A,Q = Q × mem + A`. Setup Q = vA, A = 0,
+then MPY vB, then extract the product from Q (for values fitting in 20 bits).
+
+```
+LDA  spill(vA)                 ; A = vA
+LQA                            ; Q = A = vA
+LDZ                            ; A = 0 (accumulator part)
+MPY  spill(vB)                 ; A,Q = Q*vB + A = vA*vB + 0
+LAQ                            ; A = Q (low 20 bits = product for small values)
+STA  spill(vDst)               ; store result
+```
+
+*6 words.*
+
+**Note on overflow:** For large products (|vA × vB| ≥ 2¹⁹), the result spills into the A
+register (high 20 bits). V1 does not check for overflow and silently gives a wrong result.
+A V2 addition would check the A register after LAQ and raise a runtime overflow signal.
+
+### DIV vDst, vA, vB
+
+GE-225 divide: `DVD mem` computes quotient into A, remainder into Q, given 40-bit
+dividend in (A, Q). Setup A = 0 (high half), Q = vA (low half of dividend).
+
+```
+LDA  spill(vA)                 ; A = vA
+LQA                            ; Q = vA
+LDZ                            ; A = 0 (high half of 40-bit dividend)
+DVD  spill(vB)                 ; A = (A,Q) / vB (quotient); Q = remainder
+STA  spill(vDst)               ; store quotient
+```
+
+*5 words.*
+
+**Divide by zero:** The GE-225 simulator raises `ZeroDivisionError` in Python. The integration
+layer catches this and wraps it in a `RuntimeError`.
+
+### CMP_EQ vDst, vA, vB
+
+```
+LDA  spill(vA)
+SUB  spill(vB)                 ; A = vA - vB (zero iff equal)
+BNZ                            ; if A≠0, skip next (go to not-equal branch)
+BRU  __cmp_eq_N_true           ; A==0 → jump to true case
+LDZ                            ; A = 0 (not equal)
+BRU  __cmp_eq_N_done
+__cmp_eq_N_true:
+LDO                            ; A = 1 (equal)
+__cmp_eq_N_done:
+STA  spill(vDst)
+```
+
+*8 words* (two labels at zero cost).
+
+### CMP_NE vDst, vA, vB
+
+```
+LDA  spill(vA)
+SUB  spill(vB)                 ; A = vA - vB
+BZE                            ; if A==0, skip next (they're equal, NE is false)
+BRU  __cmp_ne_N_true
+LDZ                            ; equal → result 0
+BRU  __cmp_ne_N_done
+__cmp_ne_N_true:
+LDO                            ; not equal → result 1
+__cmp_ne_N_done:
+STA  spill(vDst)
+```
+
+*8 words.*
+
+### CMP_LT vDst, vA, vB (vA < vB)
+
+A negative difference means vA < vB:
+
+```
+LDA  spill(vA)
+SUB  spill(vB)                 ; A = vA - vB (negative iff vA < vB)
+BPL                            ; if A ≥ 0, skip next (not less than)
+BRU  __cmp_lt_N_true
+LDZ                            ; ≥ 0 → result 0
+BRU  __cmp_lt_N_done
+__cmp_lt_N_true:
+LDO                            ; negative → result 1
+__cmp_lt_N_done:
+STA  spill(vDst)
+```
+
+*8 words.*
+
+### CMP_GT vDst, vA, vB (vA > vB)
+
+Swap operands: vA > vB iff vB < vA:
+
+```
+LDA  spill(vB)
+SUB  spill(vA)                 ; A = vB - vA (negative iff vB < vA, i.e., vA > vB)
+BPL
+BRU  __cmp_gt_N_true
+LDZ
+BRU  __cmp_gt_N_done
+__cmp_gt_N_true:
+LDO
+__cmp_gt_N_done:
+STA  spill(vDst)
+```
+
+*8 words.*
+
+### JUMP label
+
+```
+BRU  label(name)               ; 1 word
+```
+
+*1 word.*
+
+### BRANCH_Z vN, label  (jump if vN == 0)
+
+```
+LDA  spill(vN)                 ; 1 word: A = vN
+BNZ                            ; 1 word: if A≠0, skip next
+BRU  label(name)               ; 1 word: jump (executed when A==0)
+; fall through when A≠0
+```
+
+*3 words.*
+
+### BRANCH_NZ vN, label  (jump if vN ≠ 0)
+
+```
+LDA  spill(vN)
+BZE                            ; if A==0, skip next
+BRU  label(name)               ; jump (executed when A≠0)
+```
+
+*3 words.*
+
+### SYSCALL IrImmediate(1)  (print char from v0)
+
+The char's GE-225 typewriter code is already in spill_v0 (put there by the preceding
+`LOAD_IMM v0, code` instruction from the BASIC compiler):
+
+```
+LDA  spill(v0)                 ; A = typewriter code (6-bit value)
+SAN  6                         ; shift A[5:0] into N register
+TYP                            ; print N as typewriter character
+```
+
+*3 words.*
+
+`TON` (typewriter on) is emitted once in the program prologue (see below), not per
+character.
+
+### Unsupported opcodes
+
+All other IR opcodes (`LOAD_BYTE`, `STORE_BYTE`, `LOAD_WORD`, `STORE_WORD`, `LOAD_ADDR`,
+`AND`, `CALL`, `RET`, `SYSCALL` with other numbers) raise `CodeGenError` in V1.
+
+## Prologue and Epilogue
+
+The backend prepends and appends a small number of fixed words before and after the
+compiled IR:
+
+**Prologue** (before all IR code):
+
+```
+LABEL _start               ; marks address 0 (where simulator PC begins)
+TON                        ; turn on typewriter (enables TYP)
+```
+
+The prologue is prepended to the instruction list before pass 1, so the first code word
+is always `TON` at address 0.
+
+**Epilogue** (after all IR code):
+
+None — the halt stub is handled structurally as part of the memory layout.
+
+## Word Count Reference Table
+
+| IR Opcode | GE-225 Words |
+|-----------|-------------|
+| LABEL | 0 |
+| COMMENT | 0 |
+| NOP | 1 |
+| HALT | 1 |
+| JUMP | 1 |
+| LOAD_IMM | 2 |
+| ADD | 3 |
+| ADD_IMM (imm=0, copy) | 2 |
+| ADD_IMM (imm=±1) | 3 |
+| ADD_IMM (other) | 3 |
+| SUB | 3 |
+| AND_IMM (imm=1 only) | 8 |
+| MUL | 6 |
+| DIV | 5 |
+| CMP_EQ | 8 |
+| CMP_NE | 8 |
+| CMP_LT | 8 |
+| CMP_GT | 8 |
+| BRANCH_Z | 3 |
+| BRANCH_NZ | 3 |
+| SYSCALL 1 | 3 |
+
+These counts are used in pass 1 to assign absolute addresses to all labels.
+
+## Public API
+
+```python
+from ir_to_ge225_compiler import compile_to_ge225, CompileResult, CodeGenError
+
+@dataclass
+class CompileResult:
+    binary: bytes           # packed 3-bytes-per-word GE-225 image
+    halt_address: int       # code word address of the halt stub (self-loop)
+    data_base: int          # first data word address
+    label_map: dict[str, int]   # label name → code word address
+
+def compile_to_ge225(program: IrProgram) -> CompileResult:
+    """Compile an IrProgram to a GE-225 binary image.
+
+    Args:
+        program: A validated IrProgram (all LABEL targets must be defined).
+
+    Returns:
+        CompileResult with the binary image and metadata.
+
+    Raises:
+        CodeGenError: if the program uses an unsupported IR opcode (V1 subset),
+                      if an AND_IMM uses a non-1 immediate, or if a referenced
+                      label is undefined.
+    """
+```
+
+## Package Structure
+
+```
+packages/python/ir-to-ge225-compiler/
+├── pyproject.toml
+├── README.md
+├── CHANGELOG.md
+└── src/
+    └── ir_to_ge225_compiler/
+        ├── __init__.py           (exports compile_to_ge225, CompileResult, CodeGenError)
+        ├── codegen.py            (internal two-pass _CodeGen class)
+        └── ge225_encoding.py     (re-exports encode_instruction, assemble_fixed,
+                                   assemble_shift, pack_words from ge225_simulator)
+```
+
+## Dependencies
+
+```toml
+[project]
+dependencies = [
+    "coding-adventures-compiler-ir",
+    "coding-adventures-ge225-simulator",
+]
+
+[tool.uv.sources]
+coding-adventures-compiler-ir = { path = "../compiler-ir", editable = true }
+coding-adventures-ge225-simulator = { path = "../ge225-simulator", editable = true }
+```
+
+## Test Plan
+
+Each test verifies correct word emission by loading the binary into a `GE225Simulator`
+and executing it, then inspecting the simulator state.
+
+- **HALT**: program with only HALT → PC reaches halt_address; simulator stays there.
+- **LOAD_IMM + ADD**: `v1 = 3; v2 = 4; v3 = v1 + v2` → `spill(v3)` holds 7.
+- **SUB**: `v1 = 10; v2 = 3; v3 = v1 - v2` → `spill(v3)` holds 7.
+- **MUL**: `v1 = 6; v2 = 7; v3 = v1 * v2` → `spill(v3)` holds 42.
+- **DIV**: `v1 = 15; v2 = 4; v3 = v1 / v2` → `spill(v3)` holds 3.
+- **CMP_EQ true**: equal inputs → `spill(vDst)` = 1.
+- **CMP_EQ false**: unequal inputs → `spill(vDst)` = 0.
+- **CMP_LT true/false**: both directions.
+- **CMP_GT true/false**: both directions.
+- **JUMP**: unconditional jump skips an intervening LOAD_IMM.
+- **BRANCH_Z**: conditional skip when register is zero and non-zero.
+- **BRANCH_NZ**: same.
+- **FOR-like pattern**: LABEL + CMP + BRANCH + ADD + JUMP + LABEL forms a working countdown.
+- **SYSCALL 1**: after compilation, typewriter output contains the expected characters.
+- **Undefined label**: `CodeGenError` raised with the missing label name.
+- **AND_IMM 1**: low-bit masking correct (0 and 1 inputs).
+- **AND_IMM non-1**: `CodeGenError` in V1.
+- **Negative numbers**: LOAD_IMM with negative immediate stored and retrieved correctly.
+
+Coverage target: 90%.
+
+## Example: Full Trace for `1 + 2`
+
+BASIC `10 LET A = 1 + 2` → IR:
+
+```
+LABEL _start
+LABEL _line_10
+LOAD_IMM v287, 1          ; temp: 1
+LOAD_IMM v288, 2          ; temp: 2
+ADD      v289, v287, v288 ; temp: 1 + 2
+ADD_IMM  v1, v289, 0      ; A = temp (copy)
+HALT
+```
+
+With 1 variable (A=v1), one syscall reg (v0), and temporaries v287–v289:
+- `max_reg` = 289
+- `n_regs` = 290 (one spill slot per v0..v289)
+- `n_consts` = 2 (constants: 1 and 2)
+
+Pass 1 (word address assignment):
+
+| IR | Words | Code addr |
+|----|-------|----------|
+| TON (prologue) | 1 | 0 |
+| LABEL _start | 0 | 1 |
+| LABEL _line_10 | 0 | 1 |
+| LOAD_IMM v287, 1 | 2 | 1 |
+| LOAD_IMM v288, 2 | 2 | 3 |
+| ADD v289, v287, v288 | 3 | 5 |
+| ADD_IMM v1, v289, 0 | 2 | 8 |
+| HALT | 1 | 10 |
+
+`code_end = 11`, `halt_stub at 11`, `data_base = 12`.
+
+Pass 2 emitted words (decimal addresses):
+
+```
+addr 0:  TON                    (fixed word 2500007₈)
+addr 1:  LDA const(1)=302       ; 1 at data_base + n_regs + 0 = 12+290+0=302
+addr 2:  STA spill(287)=299     ; 299 = 12 + 287
+addr 3:  LDA const(2)=303       ; 2 at 12+290+1=303
+addr 4:  STA spill(288)=300
+addr 5:  LDA spill(287)=299     ; vA
+addr 6:  ADD spill(288)=300     ; vB
+addr 7:  STA spill(289)=301     ; result
+addr 8:  LDA spill(289)=301     ; copy
+addr 9:  STA spill(1)=13        ; store to v1 (BASIC variable A)
+addr 10: BRU 11                 ; HALT → jump to halt stub
+addr 11: BRU 11                 ; halt stub self-loop
+addr 12-301: 290 zero words     ; spill slots v0..v289
+addr 302: 1                     ; constant 1
+addr 303: 2                     ; constant 2
+```
+
+After execution, `simulator.read_word(13)` = 3 (variable A = 3). ✓

--- a/code/specs/PL02-dartmouth-basic-ir-compiler.md
+++ b/code/specs/PL02-dartmouth-basic-ir-compiler.md
@@ -1,0 +1,525 @@
+# PL02 — Dartmouth BASIC IR Compiler
+
+## Overview
+
+This spec defines the `dartmouth-basic-ir-compiler` Python package: the Dartmouth BASIC
+frontend that lowers a parsed AST into a `compiler_ir.IrProgram`. The result is a
+target-independent IR that any backend (GE-225, WASM, JVM) can translate to native code.
+
+The package sits at layer 3 in the compiled pipeline:
+
+```
+BASIC source
+    ↓  dartmouth-basic-lexer     (tokenize)
+    ↓  dartmouth-basic-parser    (parse to AST)
+    ↓  dartmouth-basic-ir-compiler   (this spec — lower to IR)
+    ↓  ir-to-ge225-compiler         (spec IR01 — emit machine words)
+    ↓  ge225-simulator               (execute)
+```
+
+Separation of concerns: this compiler knows nothing about GE-225 encoding. Its only job is
+to translate BASIC semantics into target-independent IR instructions.
+
+## V1 Scope
+
+The first version supports a subset of 1964 Dartmouth BASIC sufficient to compile
+and run meaningful integer programs:
+
+| Statement  | Support |
+|------------|---------|
+| `REM`      | No-op (emits COMMENT) |
+| `LET`      | Scalar variable assignment; all arithmetic operators (+, -, *, /, ^) |
+| `PRINT`    | String literal only (e.g., `PRINT "HELLO"`) |
+| `GOTO`     | Unconditional jump to line number |
+| `IF … THEN`| All six relational operators (<, >, <=, >=, =, <>); jump to line number |
+| `FOR … TO [STEP]` | Positive integer step; variable as loop counter |
+| `NEXT`     | Matches innermost FOR |
+| `END`      | Halt |
+| `STOP`     | Halt |
+
+**Excluded from V1** (planned for V2):
+- GOSUB / RETURN
+- DIM (arrays)
+- INPUT / DATA / READ / RESTORE
+- DEF FN (user-defined functions)
+- PRINT with variables, commas, or semicolons (numeric output)
+- Negative or variable STEP in FOR
+
+## Prerequisites: Compiler-IR Extensions
+
+Before this package can be built, `compiler_ir` must be extended with two new opcodes:
+
+```python
+MUL = 25   # dst = lhs * rhs (signed integer)
+DIV = 26   # dst = lhs / rhs (integer quotient; rounds toward zero)
+```
+
+These are appended to the `IrOp` enum without changing existing opcode values, preserving
+forward compatibility with all existing backends.
+
+## Virtual Register Convention
+
+BASIC operates on named variables, not hardware registers. This compiler maps every name
+to a *virtual register index* and never touches physical registers — that is the backend's
+job. Two categories of virtual registers exist:
+
+### Variable Registers (fixed indices)
+
+BASIC scalar variables are assigned fixed virtual register indices so that control flow
+across loop iterations and GOTO targets always reads and writes the same register:
+
+```
+v0   — syscall argument (char code for PRINT; set before each SYSCALL 1)
+v1   — BASIC variable A
+v2   — BASIC variable B
+...
+v26  — BASIC variable Z
+```
+
+Letter+digit variables (A0–Z9) are assigned the next 260 indices (v27–v286) in
+alphabetical order: `v27=A0, v28=A1, …, v36=A9, v37=B0, …`.
+
+These indices are constants, not allocated on first use. The backend allocates a memory
+word (spill slot) for every register that the program ever references.
+
+### Expression Temporaries (dynamic)
+
+Each intermediate value in an expression gets a fresh virtual register. A monotonically
+increasing counter starts at `v287` (after all variable registers). Fresh registers are
+never recycled, which keeps the IR simple and avoids the need for liveness analysis.
+
+A moderately complex expression like `(A + B) * C - 1` would consume registers v287,
+v288, v289, v290 (one per interior node: add, multiply, constant, subtract).
+
+## Source Program Structure
+
+The parser produces an `ASTNode(rule_name="program")` with children:
+
+```
+program
+  line                     ← LINE_NUM token, optional statement, NEWLINE token
+    LINE_NUM "10"
+    statement
+      let_stmt
+        KEYWORD "LET"
+        variable / NAME "X"
+        EQ "="
+        expr / term / power / unary / primary / NUMBER "5"
+    NEWLINE "\n"
+```
+
+The compiler iterates `program.children`, each being a `line` node. For each `line`:
+1. Read the `LINE_NUM` token → integer line number `N`.
+2. Emit `LABEL _line_N` (pseudo-instruction; resolves GOTO targets).
+3. If a `statement` child exists, dispatch to the appropriate handler.
+
+The LABEL is emitted before the statement so that a `GOTO N` or `IF … THEN N` that targets
+the current line jumps to the very beginning of that line's code.
+
+## Prologue and Epilogue
+
+**Prologue** (emitted before any line code):
+
+```
+LABEL _start
+```
+
+Plus, for the GE-225 target, the backend emits TON (typewriter on) as its own prologue.
+The IR compiler itself has no prologue instructions beyond the `_start` label.
+
+**Epilogue** (emitted after all lines):
+
+```
+HALT
+```
+
+`END` and `STOP` statements also emit `HALT`. If a program has no `END`, the epilogue
+`HALT` catches control fall-through.
+
+## Statement Compilation
+
+### REM
+
+```
+COMMENT "remark text"
+```
+
+Produces no machine instructions on any backend.
+
+---
+
+### LET var = expr
+
+```python
+v_val = compile_expr(expr)          # expression result in fresh register
+# variable register is fixed (e.g., v1 for A)
+ADD_IMM v_var, v_val, 0             # copy: v_var = v_val + 0
+```
+
+The `ADD_IMM` with immediate 0 is the canonical register-to-register copy in this IR
+(there is no dedicated MOVE opcode). For literals this is often followed immediately by an
+optimizer fold, though V1 does not include an optimizer.
+
+When the expression result is already in the variable's register (e.g., `LET A = A + 1`),
+the copy is still emitted for uniformity; the backend will produce `LDA [spill_A]; ADO; STA [spill_A]`.
+
+---
+
+### PRINT "string"
+
+Each character in the literal is converted at compile time to the GE-225 typewriter code
+and printed via SYSCALL 1. PRINT always appends a carriage return.
+
+```python
+GE225_CODES = {
+    '0': 0o00, '1': 0o01, '2': 0o02, '3': 0o03, '4': 0o04,
+    '5': 0o05, '6': 0o06, '7': 0o07, '8': 0o10, '9': 0o11,
+    '/': 0o13, 'A': 0o21, 'B': 0o22, 'C': 0o23, 'D': 0o24,
+    'E': 0o25, 'F': 0o26, 'G': 0o27, 'H': 0o30, 'I': 0o31,
+    '-': 0o33, '.': 0o40, 'J': 0o41, 'K': 0o42, 'L': 0o43,
+    'M': 0o44, 'N': 0o45, 'O': 0o46, 'P': 0o47, 'Q': 0o50,
+    'R': 0o51, '$': 0o53, ' ': 0o60, 'S': 0o62, 'T': 0o63,
+    'U': 0o64, 'V': 0o65, 'W': 0o66, 'X': 0o67, 'Y': 0o70,
+    'Z': 0o71,
+}
+CARRIAGE_RETURN_CODE = 0o37
+```
+
+For each character `ch`:
+
+```
+LOAD_IMM v0, GE225_CODES[ch.upper()]
+SYSCALL 1
+```
+
+After all characters:
+
+```
+LOAD_IMM v0, CARRIAGE_RETURN_CODE   ; CR = 0o37
+SYSCALL 1
+```
+
+Characters not in `GE225_CODES` raise a `CompileError` in V1. Lowercase letters are
+uppercased before lookup (1964 BASIC was uppercase-only; lowercase in string literals is
+tolerated as syntactic sugar).
+
+---
+
+### GOTO lineno
+
+```
+JUMP _line_N
+```
+
+If `_line_N` is never defined (the line doesn't exist in the program), the IR assembles
+correctly but the backend's label-resolution pass raises a `CodeGenError`.
+
+---
+
+### IF expr1 relop expr2 THEN lineno
+
+The six relational operators map to IR comparison opcodes:
+
+| BASIC relop | IR | Notes |
+|-------------|-----|-------|
+| `<`  | `CMP_LT vDst, v_lhs, v_rhs` | |
+| `>`  | `CMP_GT vDst, v_lhs, v_rhs` | |
+| `<=` | `CMP_GT vDst, v_lhs, v_rhs` then `NOT` | Derived: LE = NOT GT |
+| `>=` | `CMP_LT vDst, v_lhs, v_rhs` then `NOT` | Derived: GE = NOT LT |
+| `=`  | `CMP_EQ vDst, v_lhs, v_rhs` | |
+| `<>` | `CMP_NE vDst, v_lhs, v_rhs` | |
+
+`NOT` is implemented as: `ADD_IMM vFlipped, vCmp, -1; AND_IMM vFlipped, vFlipped, 1`
+(toggles the low bit, which is 0 or 1).
+
+Full IF/THEN compilation:
+
+```python
+v_lhs = compile_expr(expr1)
+v_rhs = compile_expr(expr2)
+
+if relop == '<':
+    v_cmp = new_reg(); CMP_LT v_cmp, v_lhs, v_rhs
+elif relop == '>':
+    v_cmp = new_reg(); CMP_GT v_cmp, v_lhs, v_rhs
+elif relop == '=':
+    v_cmp = new_reg(); CMP_EQ v_cmp, v_lhs, v_rhs
+elif relop == '<>':
+    v_cmp = new_reg(); CMP_NE v_cmp, v_lhs, v_rhs
+elif relop == '<=':
+    v_gt  = new_reg(); CMP_GT v_gt, v_lhs, v_rhs
+    v_cmp = new_reg(); ADD_IMM v_cmp, v_gt, -1
+                       AND_IMM v_cmp, v_cmp, 1
+elif relop == '>=':
+    v_lt  = new_reg(); CMP_LT v_lt, v_lhs, v_rhs
+    v_cmp = new_reg(); ADD_IMM v_cmp, v_lt, -1
+                       AND_IMM v_cmp, v_cmp, 1
+
+BRANCH_NZ v_cmp, _line_N
+```
+
+`BRANCH_NZ cmp_reg, label` jumps to `label` when `cmp_reg != 0` (i.e., condition is true).
+
+---
+
+### FOR var = expr1 TO expr2 [STEP expr3]
+
+FOR compiles to a pre-test loop: if the initial value already exceeds the limit, the body
+is skipped entirely. This matches the historical 1964 BASIC semantics.
+
+```python
+# Evaluate expressions (may be complex expressions, not just literals)
+v_start = compile_expr(expr1)
+v_limit = compile_expr(expr2)
+v_step  = compile_expr(expr3) if expr3 else new_reg() then LOAD_IMM v_step, 1
+
+# Initialize loop variable
+ADD_IMM v_var, v_start, 0          # var = start (copy)
+
+# Save limit in its own register (persists across loop body)
+# v_limit is already a fresh register, so it's stable across iterations
+
+LABEL _for_N_check
+# Pre-test: exit if var > limit (assumes positive step)
+v_cmp = new_reg()
+CMP_GT v_cmp, v_var, v_limit
+BRANCH_NZ v_cmp, _for_N_end
+
+# ... compile body statements ...
+
+# Increment
+ADD v_var, v_var, v_step           # var += step
+JUMP _for_N_check
+
+LABEL _for_N_end
+```
+
+`N` is a unique loop counter incremented each time a FOR is encountered. Nested loops
+get different N values.
+
+**NEXT var**: the compiler tracks a stack of open FOR loops. NEXT pops the innermost loop,
+verifies the variable name matches (or raises `CompileError`), then emits:
+
+```python
+ADD v_var, v_var, v_step           # var += step
+JUMP _for_N_check
+LABEL _for_N_end
+```
+
+Wait — the increment and jump-back are emitted when NEXT is processed, not when FOR is.
+The FOR statement emits the initialization and the check label; NEXT emits the increment,
+backward jump, and end label. See the FOR stack below.
+
+**FOR stack entry** pushed when FOR is encountered:
+
+```python
+@dataclass
+class ForRecord:
+    var_reg: int          # virtual register for the loop variable
+    limit_reg: int        # virtual register holding the limit value
+    step_reg: int         # virtual register holding the step value
+    check_label: str      # label at the start of the pre-test
+    end_label: str        # label after the loop (patch target)
+    loop_num: int         # unique N for this loop
+```
+
+---
+
+### END / STOP
+
+```
+HALT
+```
+
+---
+
+## Expression Compilation
+
+Expressions are compiled by recursively walking the AST. Each call to `compile_expr(node)`
+returns the virtual register index holding the result. The grammar produces this structure:
+
+```
+expr   → term { (PLUS | MINUS) term }
+term   → power { (STAR | SLASH) power }
+power  → unary [CARET unary]
+unary  → MINUS unary | primary
+primary → variable | NUMBER | LPAREN expr RPAREN
+```
+
+### Primary
+
+- **NUMBER**: `LOAD_IMM v_new, int(token.value)` — note: V1 truncates to integer. Float
+  literals like `3.14` are truncated to `3` with a compile warning.
+- **NAME (scalar variable)**: returns the variable's fixed register (no instruction emitted).
+- **NAME(expr) (array element)**: not supported in V1 (raises `CompileError`).
+- **LPAREN expr RPAREN**: recursively compiles `expr` and returns its register.
+
+### Unary minus
+
+```python
+v_inner = compile_expr(unary.child)
+v_result = new_reg()
+LOAD_IMM v_result, 0
+SUB v_result, v_result, v_inner    # result = 0 - inner = -inner
+```
+
+### Binary arithmetic
+
+For each binary operator, compile both sides then emit one instruction:
+
+| Operator | IR Opcode |
+|----------|-----------|
+| `+` | `ADD v_result, v_lhs, v_rhs` |
+| `-` | `SUB v_result, v_lhs, v_rhs` |
+| `*` | `MUL v_result, v_lhs, v_rhs` |
+| `/` | `DIV v_result, v_lhs, v_rhs` |
+| `^` | Not in V1 (raises `CompileError`) |
+
+### Operator precedence
+
+The grammar already encodes precedence via rule nesting — `term` wraps `power` which wraps
+`unary` which wraps `primary`. No explicit precedence logic is needed in the compiler.
+
+## Label Naming Conventions
+
+| Purpose | Label |
+|---------|-------|
+| Entry point | `_start` |
+| Line N | `_line_N` (e.g., `_line_100`) |
+| FOR check (loop N) | `_for_N_check` |
+| FOR end (loop N) | `_for_N_end` |
+
+Labels beginning with `_` are compiler-generated. User labels (line numbers) use `_line_N`.
+
+## Error Handling
+
+The compiler raises `CompileError` (a subclass of `ValueError`) for:
+- An unsupported statement type (e.g., GOSUB in V1)
+- A NEXT without a matching FOR
+- A FOR with a nested NEXT naming the wrong variable
+- A character in a PRINT string that has no GE-225 typewriter code
+- A power expression (^ operator)
+- An array element reference
+
+Undefined GOTO targets are **not** caught at compile time — they are left as dangling
+`JUMP _line_N` instructions and will fail at backend link time.
+
+## Compiler State
+
+The internal `_Compiler` class tracks:
+
+```python
+@dataclass
+class _Compiler:
+    _program: IrProgram        # being built
+    _next_reg: int             # next fresh register index (starts at 287)
+    _loop_count: int           # unique loop counter for FOR label names
+    _for_stack: list[ForRecord]  # stack of open FOR records
+```
+
+## Public API
+
+```python
+from dartmouth_basic_ir_compiler import compile_basic
+
+def compile_basic(ast: ASTNode) -> CompileResult:
+    """Lower a parsed BASIC AST to an IrProgram.
+
+    Args:
+        ast: Root ASTNode from dartmouth_basic_parser (rule_name == "program").
+
+    Returns:
+        CompileResult(program=IrProgram, var_regs=dict[str, int])
+
+    Raises:
+        CompileError: if the program uses any V1-excluded feature.
+    """
+```
+
+`CompileResult.var_regs` maps BASIC variable names to virtual register indices —
+useful for debugging and for tests that want to inspect final variable values.
+
+## Example: Compiling a FOR Loop
+
+BASIC source:
+
+```
+10 FOR I = 1 TO 3
+20   PRINT "HI"
+30 NEXT I
+40 END
+```
+
+IR output (registers: I=v9, temps start at v287):
+
+```
+LABEL _start
+LABEL _line_10
+LOAD_IMM v287, 1          ; start
+LOAD_IMM v288, 3          ; limit
+LOAD_IMM v289, 1          ; step (default)
+ADD_IMM  v9, v287, 0      ; I = start
+LABEL _for_0_check
+CMP_GT  v290, v9, v288    ; I > limit?
+BRANCH_NZ v290, _for_0_end
+LABEL _line_20
+LOAD_IMM v0, 0o30         ; 'H' = 0o30
+SYSCALL 1
+LOAD_IMM v0, 0o31         ; 'I' = 0o31
+SYSCALL 1
+LOAD_IMM v0, 0o37         ; CR
+SYSCALL 1
+ADD     v9, v9, v289      ; I += step
+JUMP    _for_0_check
+LABEL _for_0_end
+LABEL _line_40
+HALT
+```
+
+## Package Structure
+
+```
+packages/python/dartmouth-basic-ir-compiler/
+├── pyproject.toml
+├── README.md
+├── CHANGELOG.md
+└── src/
+    └── dartmouth_basic_ir_compiler/
+        ├── __init__.py           (exports compile_basic, CompileResult, CompileError)
+        ├── compiler.py           (internal _Compiler class + compile_basic function)
+        └── ge225_codes.py        (GE225_CODES dict + CARRIAGE_RETURN_CODE constant)
+```
+
+## Dependencies
+
+```toml
+[project]
+dependencies = [
+    "coding-adventures-compiler-ir",
+    "coding-adventures-dartmouth-basic-parser",
+]
+
+[tool.uv.sources]
+coding-adventures-compiler-ir = { path = "../compiler-ir", editable = true }
+coding-adventures-dartmouth-basic-parser = { path = "../dartmouth-basic-parser", editable = true }
+```
+
+## Test Plan
+
+- **REM**: verify COMMENT is emitted, no machine instructions in output.
+- **LET with constant**: `LET A = 5` → `LOAD_IMM v1, 5; ADD_IMM v1, v1, 0` (or optimized copy).
+- **LET with arithmetic**: `LET A = 2 + 3 * 4` → correct operator precedence.
+- **GOTO**: `GOTO 100` → `JUMP _line_100`.
+- **IF less-than**: verify `CMP_LT` + `BRANCH_NZ`.
+- **IF less-or-equal**: verify the NOT pattern.
+- **FOR default step**: v_step register initialized to 1.
+- **FOR custom step**: v_step register initialized from expression.
+- **FOR pre-test**: if start > limit, body labels appear but no body instructions execute.
+- **PRINT string**: each char maps to correct GE-225 typewriter code; CR appended.
+- **PRINT unsupported char**: raises `CompileError`.
+- **END/STOP**: both emit `HALT`.
+- **NEXT without FOR**: raises `CompileError`.
+- **GOSUB**: raises `CompileError` (excluded in V1).
+- **Round-trip line labels**: every LINE_NUM has a `LABEL _line_N` immediately before it.
+
+Coverage target: 95%.


### PR DESCRIPTION
## Summary

- **`dartmouth-basic-ir-compiler`**: lowers Dartmouth BASIC AST to a target-independent `IrProgram`; 98 tests, 100% coverage (including 16 synthetic-AST tests to reach defensive error paths)
- **`ir-to-ge225-compiler`**: three-pass assembler that compiles `IrProgram` to GE-225 20-bit machine words; 49 tests, 98% coverage
- **`ge225-simulator` bug fix**: `_execute_branch_test` had inverted semantics (`if not cond: skip` instead of `if cond: skip`); added 11 explicit `TestBranchSemantics` tests to guard against regression

## What was wrong with the simulator

All conditional skip instructions (BZE, BNZ, BPL, BMI, BOD, BEV, …) were skipping when their named condition was **false** instead of **true**. The pre-existing tests passed by coincidence — the two branch-exercising tests happened to produce the same PC values via different code paths under both semantics.

## Test plan

- [ ] `ge225-simulator`: `uv pip install -e ../simulator-protocol -e ".[dev]"` then `pytest tests/ -v` — 33 passed
- [ ] `dartmouth-basic-ir-compiler`: build via `./BUILD` — 98 passed, 100% coverage
- [ ] `ir-to-ge225-compiler`: build via `./BUILD` — 49 passed, 98% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)