### PR TITLE
docs(state-machine): specify markup serialization format

### DIFF
--- a/code/specs/F01-state-machine.md
+++ b/code/specs/F01-state-machine.md
@@ -884,6 +884,12 @@ Following the pattern of `.tokens` and `.grammar` files, state machines can be
 defined declaratively in `.states` files. The `grammar-tools` package will be
 extended with a `.states` parser.
 
+**Canonical format note:** `F07-state-machine-markup-language.md` now defines
+the implementation target for serialization and deserialization:
+TOML-compatible `state-machine/v1` documents written as `.states.toml` or
+`.states`. The examples below are the original educational sketch syntax and
+should be treated as conceptual examples until they are migrated to F07.
+
 ### DFA Format
 
 ```
@@ -1096,8 +1102,9 @@ class PDAInternalState:
 
 ## Future Extensions
 
-- **`.states` file parser in grammar-tools:** Parse `.states` files into
-  DFA/NFA/PDA/Modal objects, following the `token_grammar.py` pattern.
+- **`.states` file parser in grammar-tools:** Parse the canonical
+  TOML-compatible `state-machine/v1` format from
+  `F07-state-machine-markup-language.md` into DFA/NFA/PDA/Modal objects.
 - **Lexer mode integration:** Extend the lexer to use `ModalStateMachine` for
   context-sensitive tokenization. Each mode maps to a `.tokens` file.
 - **Transducer:** A state machine that produces output on transitions (Mealy

--- a/code/specs/F07-declarative-tokenizer-state-machines.md
+++ b/code/specs/F07-declarative-tokenizer-state-machines.md
@@ -1,0 +1,568 @@
+# F07: Declarative Tokenizer State Machines
+
+## Overview
+
+This spec defines a portable, text-loadable way to describe **effectful
+tokenizer state machines**. The first target is HTML tokenization, but the
+design is generic enough for XML-ish formats, browser protocols, programming
+language lexers with modes, and any stream format where the next token depends
+on the current lexical state.
+
+The existing `F01-state-machine.md` package gives us formal automata: DFA, NFA,
+PDA, minimization, and modal machines. That is the right mathematical base, but
+HTML tokenization needs one extra layer: transitions do not only change state.
+They also build tokens, append text, track temporary buffers, report parse
+errors, reconsume the current input character in a new state, and sometimes
+call a shared submachine such as character-reference parsing.
+
+So the answer to "can the states and transitions live purely in a text file?"
+is:
+
+- **Yes**, if the file describes a state graph plus a fixed portable action
+  vocabulary.
+- **No**, if "purely" means a bare DFA transition table with no registers,
+  buffers, token-emission actions, EOF handling, or reconsume semantics.
+
+The goal is a declarative file that every language port can load and execute the
+same way, without embedding arbitrary Rust, Go, Ruby, Python, or TypeScript code
+inside the grammar.
+
+## Why This Exists
+
+HTML is not a clean context-free language in the way a teaching compiler grammar
+usually is. Modern browser parsing is split into:
+
+1. **Input preprocessing**: bytes become Unicode scalar values.
+2. **Tokenization**: a state machine turns characters into tokens.
+3. **Tree construction**: insertion modes, stacks, active formatting elements,
+   and error-recovery algorithms turn tokens into a DOM-like tree.
+
+The current `TE04-html1.0-lexer.md` spec hand-describes a small HTML 1.0 lexer.
+That is useful as a first browser milestone, but it does not scale elegantly to
+the WHATWG HTML Living Standard tokenizer, which currently defines dozens of
+named tokenizer states such as data, tag open, attribute name, script data,
+doctype, CDATA, and character-reference states.
+
+We need an intermediate foundation package that lets us write those states once
+as data, validate them, test them, and run them from every implementation
+language.
+
+## Relationship To Existing Specs
+
+- `F01-state-machine.md`: provides the formal automata vocabulary and modal
+  machine foundation.
+- `F04-lexer-pattern-groups.md`: supports grouped pattern lexing with callbacks;
+  this spec is lower level and more deterministic, for byte/code-point state
+  machines like HTML.
+- `F06-haskell-layout-mode.md`: handles a layout-sensitive token transform after
+  physical tokenization; this spec handles the tokenization loop itself.
+- `TE04-html1.0-lexer.md`: should eventually become a thin wrapper around an
+  `html1.tokenizer` definition.
+- `TE05-html1.0-parser.md`: consumes tokens from this system but remains a
+  separate tree-construction concern.
+
+## Design Principles
+
+1. **Data first, code second.** The tokenizer definition is text. Runtime code
+   only implements the generic interpreter and built-in action vocabulary.
+2. **Portable by construction.** A definition loaded in Rust must behave the
+   same way when loaded in Go, TypeScript, Ruby, Python, or future ports.
+3. **No arbitrary host callbacks in definition files.** Escape hatches are how
+   specs become unportable. Add new built-in actions instead.
+4. **Streaming by default.** Tokenizers must accept network-fed chunks without
+   requiring the full document in memory.
+5. **Error recovery is normal behavior.** HTML tokenization must produce tokens
+   and diagnostics for invalid input instead of failing fast.
+6. **Traceability matters.** A developer should be able to ask, "which state
+   consumed this character and why did it emit this token?"
+7. **Versioned standards are first-class.** HTML 1.0, historical HTML profiles,
+   and the living standard can share common definitions while evolving
+   separately.
+
+## Non-Goals
+
+This spec does not define:
+
+- DOM tree construction
+- CSS or JavaScript parsing inside `<style>` or `<script>`
+- network character encoding detection
+- browser scripting reentrancy
+- a complete WHATWG tokenizer definition in phase 1
+- arbitrary regex-based lexing for programming languages
+
+Those can sit above or beside this package. This layer only defines an
+effectful state-machine tokenizer runtime and file format.
+
+## Core Model
+
+A tokenizer definition contains:
+
+- metadata and version requirements
+- token type declarations
+- named input classes
+- registers and buffers
+- states
+- ordered transitions inside each state
+- built-in actions attached to transitions
+- optional included definition files
+- validation expectations and fixture hooks
+
+At runtime, the tokenizer owns:
+
+- an input cursor
+- the current code point or EOF sentinel
+- the current state
+- an output token queue
+- a diagnostics list
+- declared registers such as `current_token`, `current_attribute`,
+  `temporary_buffer`, `return_state`, and `last_start_tag_name`
+- source position tracking for line, column, and byte/code-point offset
+
+Each loop iteration:
+
+1. Reads the current code point, or EOF if the stream is closed.
+2. Finds the first matching transition in the current state.
+3. Consumes the code point unless the transition says `consume: false` or an
+   action requests reconsume.
+4. Executes actions in declaration order.
+5. Switches to the target state.
+6. Emits zero or more tokens.
+
+The machine is deterministic because transition matching is ordered and
+`anything`/`anything_else` matchers are only valid as the last transition in a
+state.
+
+## File Format
+
+The canonical source format is `.tokenizer`. It follows the same plain-text
+spirit as `.tokens`, `.grammar`, and `.states`, but it is a new format because a
+tokenizer state machine needs actions, registers, streaming semantics, and
+token declarations that do not fit cleanly into the existing `.states` examples.
+
+Example filename:
+
+```text
+code/tokenizers/html/html1.tokenizer
+```
+
+The first version is intentionally indentation based and line oriented:
+
+```text
+format: tokenizer-state-machine/v1
+name: html1-tokenizer
+initial: data
+done: done
+
+include:
+  html-common-inputs.tokenizer
+
+tokens:
+  Text(data)
+  StartTag(name, attributes, self_closing)
+  EndTag(name)
+  Comment(data)
+  Doctype(name, force_quirks)
+  EOF
+
+inputs:
+  ascii_whitespace = one_of("\t\n\f\r ")
+  ascii_alpha = range("A", "Z") | range("a", "z")
+  tag_name_char = ascii_alpha | range("0", "9") | one_of("-_:")
+
+registers:
+  text_buffer: string
+  current_token: token?
+  current_attribute: attribute?
+  temporary_buffer: string
+  return_state: state?
+  last_start_tag_name: string?
+
+state data:
+  on "<":
+    actions: flush_text
+    goto: tag_open
+
+  on "&":
+    actions:
+      - set_return_state(data)
+      - consume_character_reference(text)
+    goto: data
+
+  on "\0":
+    actions:
+      - parse_error(unexpected-null-character)
+      - append_text("\uFFFD")
+    goto: data
+
+  on eof:
+    actions:
+      - flush_text
+      - emit(EOF)
+    goto: done
+
+  on anything:
+    actions: append_text(current)
+    goto: data
+```
+
+## Matchers
+
+Matchers describe what a transition can see at the current input position.
+Every implementation must support:
+
+- `"<literal>"`: match one literal code point or literal string
+- `eof`: match the end-of-file sentinel
+- `anything`: match any non-EOF code point
+- `anything_else`: alias for `anything`, intended for readability after
+  specific cases
+- `class(name)`: match a named input class
+- `not_class(name)`: match any non-EOF code point outside a class
+- `one_of("...")`: match one code point from a literal set
+- `range("A", "Z")`: match an inclusive code-point range
+- `lookahead("<literal>")`: match without consuming
+- `lookahead_ascii_case_insensitive("<literal>")`: match ASCII-insensitively
+  without consuming
+
+The file parser lowers these matchers into a canonical AST so language ports do
+not have to preserve the original syntax.
+
+## Actions
+
+Actions are deliberately small and boring. Boring is the portability tax we pay
+once so every runtime behaves the same way.
+
+### Cursor And State Actions
+
+- `reconsume_in(state)`: do not advance the cursor; run the same code point
+  again in `state`.
+- `set_return_state(state)`: store a state name for submachines that return to
+  their caller.
+- `goto_return_state`: switch to the stored return state.
+- `advance(count)`: consume additional code points after a lookahead match.
+
+### Text Actions
+
+- `append_text(current)`: append the current code point to `text_buffer`.
+- `append_text("<literal>")`: append a literal string to `text_buffer`.
+- `append_text_replacement`: append U+FFFD.
+- `flush_text`: emit a `Text` token if `text_buffer` is not empty.
+- `emit_current_as_text`: append the current code point as text and flush.
+
+### Token Construction Actions
+
+- `create_start_tag`: set `current_token` to a new start tag token.
+- `create_end_tag`: set `current_token` to a new end tag token.
+- `create_comment`: set `current_token` to a new comment token.
+- `create_doctype`: set `current_token` to a new doctype token.
+- `append_tag_name(current_lowercase)`: append the lowercased current code point
+  to the current tag token name.
+- `append_tag_name(current)`: append the current code point without casing.
+- `start_attribute`: create an empty current attribute on the current tag.
+- `append_attribute_name(current_lowercase)`: append to the current attribute
+  name.
+- `append_attribute_value(current)`: append to the current attribute value.
+- `commit_attribute`: attach the current attribute to the current tag.
+- `set_self_closing`: mark the current tag token as self-closing.
+- `emit_current_token`: emit `current_token` and clear it.
+- `record_last_start_tag`: remember the emitted start tag name for later raw
+  text and script checks.
+
+### Temporary Buffer Actions
+
+- `clear_temporary_buffer`
+- `append_temporary(current)`
+- `append_temporary(current_lowercase)`
+- `emit_temporary_as_text`
+- `matches_last_start_tag`: a predicate action result used by guarded
+  transitions in RCDATA, RAWTEXT, and script states.
+
+### Diagnostics Actions
+
+- `parse_error(code)`: add a recoverable diagnostic at the current source
+  position.
+- `parse_error_if(condition, code)`: add a diagnostic when a guard is true.
+
+### Submachine Actions
+
+- `consume_character_reference(destination)`: run the character-reference
+  machine and append its result to either `text`, `attribute_value`, or
+  `temporary_buffer`.
+- `call(machine_name)`: run a named submachine that communicates only through
+  declared registers and output tokens.
+
+Submachines must be declared in the same file or an included file. They cannot
+call arbitrary host-language functions.
+
+## Guards
+
+Some HTML tokenizer states depend on small pieces of parser/tokenizer context.
+Transitions may include guards:
+
+```text
+state rcdata_end_tag_name:
+  on class(ascii_alpha) when temporary_is_possible_end_tag:
+    actions:
+      - append_temporary(current)
+      - append_tag_name(current_lowercase)
+    goto: rcdata_end_tag_name
+
+  on ">" when current_tag_name_equals_last_start_tag:
+    actions: emit_current_token
+    goto: data
+```
+
+The first version supports only named built-in guards:
+
+- `current_tag_name_equals_last_start_tag`
+- `temporary_is_possible_end_tag`
+- `current_token_is_start_tag`
+- `current_token_is_end_tag`
+- `current_attribute_is_duplicate`
+- `scripting_enabled`
+- `in_foreign_content`
+
+If a future HTML state needs a new guard, we add it to the portable vocabulary
+and implement it in every runtime. Definition files must not include host
+language expressions.
+
+## Streaming Semantics
+
+The tokenizer supports chunked input:
+
+```text
+let tokenizer = Tokenizer::new(definition)
+tokenizer.push("<di")
+tokenizer.push("v>Hello")
+tokenizer.finish()
+```
+
+A transition that needs more input for a literal or lookahead matcher enters an
+internal `need_more_input` condition instead of guessing. When the caller pushes
+another chunk, matching resumes from the same state and cursor. When the caller
+calls `finish`, unresolved lookahead is evaluated against EOF.
+
+EOF is not a byte and not a code point. It is a sentinel that can only be
+matched by `eof`.
+
+## Tracing
+
+Every runtime should be able to produce optional transition traces:
+
+```text
+offset=0 state=data input="<" transition=on("<") actions=[flush_text] goto=tag_open
+offset=1 state=tag_open input="d" transition=on(class(ascii_alpha)) actions=[create_start_tag,reconsume_in(tag_name)] goto=tag_name
+offset=1 state=tag_name input="d" transition=on(class(tag_name_char)) actions=[append_tag_name(current_lowercase)] goto=tag_name
+```
+
+Tracing is off by default. It is required for tests and debugging because
+declarative machines are otherwise hard to inspect when a single transition is
+wrong.
+
+## HTML Phase 1 Profile
+
+The first HTML definition should target the current HTML 1.0 package shape:
+
+- `Text`
+- `StartTag`
+- `EndTag`
+- `Comment`
+- `Doctype`
+- `EOF`
+- entity handling for the HTML 1.0 named entities already described in
+  `TE04-html1.0-lexer.md`
+- start and end tags with quoted and unquoted attributes
+- error recovery compatible with the current HTML 1.0 lexer spec
+
+This profile proves the generic engine without requiring the whole living
+standard on day one.
+
+## WHATWG HTML Compatibility Path
+
+The modern tokenizer can be represented by this model because it is specified as
+a named state machine that emits doctype, start tag, end tag, comment,
+character, and EOF tokens. The hard part is not whether it is a state machine;
+the hard part is faithfully encoding every effect attached to each transition.
+
+To scale from HTML 1.0 to the living standard, add definitions in layers:
+
+```text
+code/tokenizers/html/
+  html-common-inputs.tokenizer
+  html-common-actions.md
+  html1.tokenizer
+  html4-compatible.tokenizer
+  whatwg-html.tokenizer
+```
+
+The living-standard definition will need:
+
+- RCDATA, RAWTEXT, script data, and PLAINTEXT states
+- comment less-than-sign and comment bang states
+- full DOCTYPE public/system identifier states
+- CDATA states for foreign content
+- full named and numeric character-reference states
+- temporary-buffer based end-tag matching
+- parse-error codes aligned with the standard
+- tokenizer hooks that allow the tree constructor to change tokenizer state for
+  raw text elements
+
+That last point is important: the tokenizer and tree constructor are separate,
+but modern HTML lets tree construction influence tokenizer state when entering
+elements such as `script`, `style`, `title`, and `textarea`. The tokenizer
+runtime must therefore expose a controlled `set_state(state)` API to the tree
+constructor. That API is host code, but the state names and valid states remain
+declared in the tokenizer file.
+
+## Runtime API
+
+Each language port should expose the same conceptual API:
+
+```rust
+let definition = TokenizerDefinition::parse_str(source)?;
+definition.validate()?;
+
+let mut tokenizer = Tokenizer::new(definition);
+tokenizer.push("<p>Hello");
+tokenizer.push(" &amp; bye</p>");
+tokenizer.finish();
+
+let tokens = tokenizer.drain_tokens();
+let diagnostics = tokenizer.diagnostics();
+```
+
+Minimum operations:
+
+- `parse_str(source) -> TokenizerDefinition`
+- `parse_file(path) -> TokenizerDefinition`
+- `validate(definition) -> ValidationReport`
+- `Tokenizer::new(definition)`
+- `push(chunk)`
+- `finish()`
+- `next_token()`
+- `drain_tokens()`
+- `diagnostics()`
+- `trace()`
+- `set_state(state)`
+- `current_state()`
+- `reset()`
+
+The API may look idiomatic in each language, but behavior and naming should stay
+close enough that docs and tests translate mechanically.
+
+## Validation
+
+The definition validator must reject:
+
+- unknown states
+- duplicate state names
+- duplicate token declarations
+- unknown registers
+- unknown actions
+- unknown guards
+- unknown included files
+- transitions after `anything` or `anything_else`
+- unreachable states unless marked `external_entry`
+- EOF states with no `eof` transition unless marked `nonterminal`
+- submachine cycles that can recurse without consuming input
+- action arguments of the wrong type
+- registers referenced before declaration
+- token fields not declared in `tokens:`
+
+The validator should warn about:
+
+- states with no incoming transitions
+- states with no parse-error paths for malformed HTML patterns
+- actions that mutate `current_token` when no token exists
+- definitions that require a runtime feature newer than the package supports
+
+## Test Strategy
+
+### Definition Parser Tests
+
+- parse metadata, token declarations, registers, inputs, includes, states, and
+  transitions
+- reject malformed indentation and unknown top-level sections
+- preserve source locations for diagnostics
+- produce a stable canonical AST
+
+### Runtime Tests
+
+- data-state text buffering
+- tag creation and emission
+- attribute name and value construction
+- self-closing tag marker
+- EOF flushing
+- parse-error recording
+- reconsume behavior
+- lookahead across chunk boundaries
+- character-reference submachine calls
+- traces for representative transitions
+
+### HTML Fixture Tests
+
+Use small `.cases` files:
+
+```text
+case: simple-start-tag
+input: <p>Hello</p>
+tokens:
+  StartTag(name="p", attributes=[], self_closing=false)
+  Text(data="Hello")
+  EndTag(name="p")
+  EOF
+```
+
+Later, the WHATWG profile should import relevant tokenizer fixtures from
+web-platform-tests/html and run them through the same runtime.
+
+## Implementation Plan
+
+1. Add this spec.
+2. Add a `tokenizer-state-machine` package in Rust first, because Rust is the
+   browser implementation direction and gives us strong data modeling.
+3. Port the runtime to Go next, because Go is the other preferred systems
+   direction for this repo.
+4. Add TypeScript, Python, Ruby, and other ports only after the Rust and Go APIs
+   settle.
+5. Add `code/tokenizers/html/html1.tokenizer`.
+6. Rebuild `html1.0-lexer` as a wrapper over the declarative definition.
+7. Add conformance fixtures and transition traces.
+8. Expand toward `whatwg-html.tokenizer` state by state.
+9. Create a later tree-construction spec for insertion modes, stack of open
+   elements, active formatting elements, foster parenting, template insertion
+   modes, and the adoption agency algorithm.
+
+## Open Questions
+
+- Should the canonical serialized AST be JSON, TOML, or a compact binary format
+  for faster package startup?
+- Should `.tokenizer` be parsed directly by every port, or should one reference
+  parser generate a canonical JSON artifact that all ports consume?
+- How much of the WHATWG character-reference table should live in the tokenizer
+  definition versus a shared generated data package?
+- Do we want a visualizer that renders tokenizer states as DOT graphs with
+  action labels?
+
+The recommended first implementation is: parse `.tokenizer` text into a
+canonical in-memory AST in each port, then add JSON export/import once the AST
+stabilizes. That keeps the early system simple while preserving a path to fast,
+prevalidated artifacts.
+
+## Success Criteria
+
+Phase 1 is successful when:
+
+1. a `.tokenizer` file can describe the HTML 1.0 tokenizer states
+2. Rust and Go runtimes can load the same definition file
+3. both runtimes pass the same HTML tokenizer fixtures
+4. traces make transition behavior understandable
+5. the old hand-written HTML 1.0 lexer can be replaced by a wrapper without
+   changing its public token output
+6. the design has a clear path to the WHATWG tokenizer without adding arbitrary
+   host-language callbacks to definition files
+
+## References
+
+- WHATWG HTML Living Standard, "13.2 Parsing HTML documents" and "13.2.5
+  Tokenization": <https://html.spec.whatwg.org/multipage/parsing.html>.
+  Checked on 2026-04-19; the page reported "Last Updated 15 April 2026".

--- a/code/specs/F07-state-machine-markup-language.md
+++ b/code/specs/F07-state-machine-markup-language.md
@@ -1,0 +1,535 @@
+# F07: State Machine Markup Language
+
+## Overview
+
+This spec defines the repo's canonical serialization format for state machines.
+The state-machine libraries should be able to:
+
+- build machines in code
+- export them to a stable text file
+- load the same file back into an equivalent machine
+- emit visualization formats such as DOT
+- import and export a useful subset of existing standards such as SCXML
+
+The format is called **State Machine Markup v1**. Source files use
+`.states.toml` when the file is meant to be parsed by general TOML tooling, and
+`.states` when we want the shorter educational extension. Both extensions carry
+the same TOML-compatible content.
+
+This is intentionally not a brand-new syntax. TOML gives us a readable existing
+text format, and `F03-toml-parser.md` already makes TOML a first-class repo
+foundation. The state-machine model and terminology are inspired by SCXML, the
+W3C statechart XML recommendation, but narrowed to the automata our library
+actually implements today.
+
+## Existing Formats We Should Learn From
+
+### SCXML
+
+SCXML is the closest existing standard. It is a W3C Recommendation for
+state-machine notation and execution, with core constructs such as `state`,
+`transition`, events, entry actions, exit actions, guards, and document-order
+transition priority.
+
+We should borrow these ideas:
+
+- states have stable identifiers
+- transitions react to events
+- transitions may have guards
+- states can have entry and exit actions
+- transition order matters when more than one transition can match
+- machines should be deterministic unless a nondeterministic kind says
+  otherwise
+- serialization should be independent from any one host language
+
+We should not adopt full SCXML as our only source format because:
+
+- XML is noisy for the educational examples in this repo
+- SCXML is event-statechart oriented, while our foundation library also models
+  acceptors such as DFA, NFA, and PDA
+- PDA stack operations and automata accepting states need repo-specific
+  conventions anyway
+- SCXML executable content can embed datamodel-specific expressions, which would
+  make cross-language ports drift
+
+The library should still support a **SCXML core profile** for import/export when
+the machine fits that model.
+
+### XState JSON
+
+XState shows that state machines can be represented as plain data and used by a
+runtime interpreter. It also explicitly aligns with SCXML concepts. The useful
+lesson for us is not to copy JavaScript object syntax, but to keep the machine
+definition serializable as ordinary data with `id`, `initial`, `states`, and
+event-keyed transitions.
+
+### UML/PSSM/XMI
+
+UML state machines and the OMG Precise Semantics of UML State Machines work are
+valuable references, especially for formal statechart semantics. Their XMI
+interchange model is too broad and tool-heavy for this repo's foundation layer,
+so we should treat it as a later interoperability target, not the first
+implementation format.
+
+### DOT
+
+DOT is excellent for graph visualization. Our library already exposes graph-like
+views, and DOT export should remain a first-class debugging feature. DOT is not
+enough as the canonical state-machine format because it does not define
+execution semantics, accepting states, stack actions, guards, or tokenizer
+effects.
+
+## Design Principles
+
+1. **Round-trip first.** If the library writes a `.states.toml` file and reads
+   it back, the resulting machine should be equivalent.
+2. **TOML surface, typed core.** The file is TOML-compatible, but every runtime
+   lowers it into the same typed `StateMachineDocument` model.
+3. **SCXML-compatible where practical.** Use SCXML names and semantics for
+   event machines instead of inventing new vocabulary.
+4. **No host-language code in files.** Actions and guards are named portable
+   operations with structured arguments.
+5. **Stable canonical output.** Serializers sort sections predictably so diffs
+   stay reviewable.
+6. **Typed machine kinds.** DFA, NFA, PDA, modal machines, and later
+   statecharts share one document envelope but validate against different rules.
+7. **Profiles extend, they do not fork.** Tokenizers, protocol machines, and UI
+   machines add profile sections on top of this document model.
+
+## Non-Goals
+
+This spec does not define:
+
+- the full SCXML execution algorithm
+- a full UML/XMI interchange implementation
+- arbitrary embedded JavaScript, Ruby, Python, Rust, or Go code
+- graphical layout metadata beyond optional visualization hints
+- tokenizer-specific actions; those live in `F08`
+
+## Canonical Data Model
+
+Every parser lowers source files into this conceptual model:
+
+```text
+StateMachineDocument
+  format: string
+  name: string
+  kind: dfa | nfa | pda | modal | statechart | transducer
+  version: string?
+  profile: string?
+  metadata: map<string, value>
+  alphabet: list<string>
+  stack_alphabet: list<string>
+  initial: state_id?
+  states: list<StateDefinition>
+  transitions: list<TransitionDefinition>
+  actions: list<ActionDefinition>
+  guards: list<GuardDefinition>
+  modes: list<ModeDefinition>
+  includes: list<IncludeDefinition>
+```
+
+`StateDefinition`:
+
+```text
+id: string
+initial: bool
+accepting: bool
+final: bool
+external_entry: bool
+parent: state_id?
+children: list<state_id>
+on_entry: list<ActionCall>
+on_exit: list<ActionCall>
+metadata: map<string, value>
+```
+
+`TransitionDefinition`:
+
+```text
+id: string?
+from: state_id
+on: event | epsilon | eof | matcher
+to: state_id | list<state_id>
+guard: guard_call?
+actions: list<ActionCall>
+priority: integer?
+consume: bool?
+stack_pop: stack_symbol?
+stack_push: list<stack_symbol>
+metadata: map<string, value>
+```
+
+The exact host-language structs can be idiomatic, but the fields and behavior
+must map back to this model.
+
+## TOML Surface Format
+
+### DFA Example
+
+```toml
+format = "state-machine/v1"
+name = "turnstile"
+kind = "dfa"
+initial = "locked"
+alphabet = ["coin", "push"]
+
+[[states]]
+id = "locked"
+initial = true
+
+[[states]]
+id = "unlocked"
+accepting = true
+
+[[transitions]]
+from = "locked"
+on = "coin"
+to = "unlocked"
+
+[[transitions]]
+from = "locked"
+on = "push"
+to = "locked"
+
+[[transitions]]
+from = "unlocked"
+on = "coin"
+to = "unlocked"
+
+[[transitions]]
+from = "unlocked"
+on = "push"
+to = "locked"
+```
+
+### NFA Example
+
+NFA documents allow repeated `(from, on)` pairs, multiple `to` states, and
+`epsilon` transitions:
+
+```toml
+format = "state-machine/v1"
+name = "contains-abc"
+kind = "nfa"
+initial = "q0"
+alphabet = ["a", "b", "c"]
+
+[[states]]
+id = "q0"
+initial = true
+
+[[states]]
+id = "q1"
+
+[[states]]
+id = "q2"
+
+[[states]]
+id = "q3"
+accepting = true
+
+[[transitions]]
+from = "q0"
+on = "a"
+to = ["q0", "q1"]
+
+[[transitions]]
+from = "q1"
+on = "b"
+to = "q2"
+
+[[transitions]]
+from = "q2"
+on = "c"
+to = "q3"
+
+[[transitions]]
+from = "q3"
+on = "epsilon"
+to = "q0"
+```
+
+### PDA Example
+
+PDA documents add stack alphabet and stack effects:
+
+```toml
+format = "state-machine/v1"
+name = "balanced-parens"
+kind = "pda"
+initial = "scan"
+alphabet = ["(", ")"]
+stack_alphabet = ["(", "$"]
+initial_stack = "$"
+
+[[states]]
+id = "scan"
+initial = true
+
+[[states]]
+id = "accept"
+accepting = true
+
+[[transitions]]
+from = "scan"
+on = "("
+to = "scan"
+stack_pop = "$"
+stack_push = ["(", "$"]
+
+[[transitions]]
+from = "scan"
+on = "("
+to = "scan"
+stack_pop = "("
+stack_push = ["(", "("]
+
+[[transitions]]
+from = "scan"
+on = ")"
+to = "scan"
+stack_pop = "("
+stack_push = []
+
+[[transitions]]
+from = "scan"
+on = "epsilon"
+to = "accept"
+stack_pop = "$"
+stack_push = ["$"]
+```
+
+### Modal Machine Example
+
+Modal machines reference named child machines and mode transitions:
+
+```toml
+format = "state-machine/v1"
+name = "html-tokenizer-modes"
+kind = "modal"
+initial_mode = "data"
+
+[[modes]]
+id = "data"
+initial = true
+machine = "html-data.states.toml"
+
+[[modes]]
+id = "tag_open"
+machine = "html-tag-open.states.toml"
+
+[[mode_transitions]]
+from = "data"
+on = "open_tag"
+to = "tag_open"
+
+[[mode_transitions]]
+from = "tag_open"
+on = "close_angle"
+to = "data"
+```
+
+## Actions And Guards
+
+Actions and guards use a portable call representation:
+
+```toml
+[[actions]]
+id = "record-transition"
+kind = "emit_trace"
+
+[[guards]]
+id = "has-credit"
+kind = "register_equals"
+register = "credit"
+value = true
+
+[[transitions]]
+from = "waiting"
+on = "vend"
+to = "dispensing"
+guard = "has-credit"
+actions = ["record-transition"]
+```
+
+For F01-level DFA/NFA/PDA machines, actions and guards are optional. For
+tokenizers and protocol machines, actions become the portable effect vocabulary
+that lets a text file produce real output without host-language callbacks.
+
+## SCXML Core Profile
+
+The library should implement these mappings:
+
+| SCXML | State Machine Markup |
+|---|---|
+| `<scxml initial="s">` | `initial = "s"` |
+| `<state id="s">` | `[[states]] id = "s"` |
+| `<final id="done">` | `[[states]] id = "done"; final = true` |
+| `<transition event="e" target="t">` | `[[transitions]] on = "e"; to = "t"` |
+| `<transition cond="...">` | named guard, if the condition is in the supported guard profile |
+| `<onentry>` / `<onexit>` | `on_entry` / `on_exit` action calls |
+| document order | `priority` |
+
+Initial SCXML import should reject or explicitly mark unsupported:
+
+- `<parallel>`
+- `<history>`
+- `<invoke>`
+- executable `<script>`
+- datamodel-specific expressions outside the supported guard/action profile
+
+SCXML export is allowed only when the machine fits the supported profile. For a
+plain DFA or modal event machine, export should be straightforward. For PDA and
+NFA machines, export should either use repo-specific `ca:` extension attributes
+or refuse with a clear diagnostic.
+
+## DOT Export
+
+DOT remains an output format:
+
+```text
+DFA -> StateMachineDocument -> DOT
+```
+
+DOT import is not part of phase 1. DOT files are graphs, not executable machine
+definitions. If we add DOT import later, it should require explicit attributes
+for initial, accepting, stack effects, and transition events.
+
+## Serializer API
+
+Each language port should expose the same conceptual operations:
+
+```rust
+let dfa = DFA::new(...)?;
+let document = dfa.to_document();
+let text = document.to_states_toml();
+
+let parsed = StateMachineDocument::from_states_toml(&text)?;
+let round_tripped = DFA::from_document(parsed)?;
+```
+
+Minimum API:
+
+- `to_document(machine) -> StateMachineDocument`
+- `from_document(document) -> Machine`
+- `StateMachineDocument::parse_toml(source)`
+- `StateMachineDocument::to_toml()`
+- `StateMachineDocument::parse_json(source)`
+- `StateMachineDocument::to_json()`
+- `StateMachineDocument::parse_scxml(source)`
+- `StateMachineDocument::to_scxml()`
+- `Machine::to_dot()`
+- `Machine::validate_document(document)`
+
+JSON support is required because some tooling prefers generated machine-readable
+artifacts. TOML remains the hand-authored source format.
+
+## Canonical Output Rules
+
+Serializers must:
+
+- write `format`, `name`, `kind`, and initial fields first
+- write arrays in deterministic order
+- preserve transition declaration order through `priority`
+- omit fields that are empty or false unless required for clarity
+- quote all string event names
+- write one `[[states]]` table per state
+- write one `[[transitions]]` table per transition
+- preserve unknown `metadata` keys under a namespaced table such as
+  `[metadata.visual]`
+
+Serializers must not:
+
+- reorder transitions in a way that changes priority
+- inline host-language code
+- silently drop unsupported actions, guards, stack effects, or modes
+
+## Validation Rules
+
+All documents:
+
+- `format` must be `state-machine/v1`
+- `kind` must be known
+- state IDs must be unique
+- transition source and target states must exist
+- action and guard references must exist
+- include paths must be relative to the current document unless explicitly
+  marked as package imports
+
+DFA documents:
+
+- exactly one initial state
+- `to` is a single state
+- no duplicate `(from, on)` transition pairs
+- no `epsilon` transitions
+- no stack effects
+
+NFA documents:
+
+- exactly one initial state
+- `to` may be one or more states
+- duplicate `(from, on)` pairs are allowed
+- `epsilon` transitions are allowed
+- no stack effects
+
+PDA documents:
+
+- `initial_stack` must exist in `stack_alphabet`
+- `stack_pop` and every `stack_push` symbol must be in `stack_alphabet`
+- accepting-by-final-state is the default; accepting-by-empty-stack can be added
+  later as an explicit option
+
+Modal documents:
+
+- exactly one initial mode
+- every mode references an inline or external machine
+- mode transitions reference known modes
+- mode transition events are declared or inferred from child machine outputs
+
+## Implementation Plan
+
+1. Add this spec as the canonical serialization target.
+2. Update `F01-state-machine.md` so `.states` points to this TOML-compatible v1
+   format instead of the older sketch examples.
+3. Implement `StateMachineDocument` in Rust first.
+4. Add `to_document`, `from_document`, `to_toml`, `from_toml`, `to_json`, and
+   `from_json` for DFA.
+5. Add NFA, PDA, and modal round-tripping.
+6. Add SCXML core import/export for deterministic event machines.
+7. Keep DOT export as visualization-only output.
+8. Build tokenizer profiles from `F08` on top of this document model.
+
+## Test Strategy
+
+- golden TOML round-trip tests for DFA, NFA, PDA, and modal machines
+- JSON round-trip tests for the same canonical documents
+- validation failures for malformed transitions and unknown references
+- SCXML core import tests using small W3C-style examples
+- SCXML export tests for deterministic event machines
+- DOT snapshot tests for visualization output
+- property tests where generated DFAs survive
+  `machine -> document -> TOML -> document -> machine`
+
+## Success Criteria
+
+Phase 1 is successful when:
+
+1. the Rust state-machine package can serialize a DFA to `.states.toml`
+2. the Rust state-machine package can deserialize the same file into an
+   equivalent DFA
+3. the same document can be exported as JSON
+4. DOT export still works for visualization
+5. the format is documented enough for Go and TypeScript ports to follow
+6. tokenizer specs can extend this format instead of inventing a separate
+   serialization language
+
+## References
+
+- W3C SCXML 1.0, "State Chart XML (SCXML): State Machine Notation for Control
+  Abstraction": <https://www.w3.org/TR/scxml/>.
+- Graphviz DOT Language: <https://graphviz.org/doc/info/lang.html>.
+- OMG Precise Semantics of UML State Machines:
+  <https://www.omg.org/spec/PSSM/>.
+- XState API documentation, noting SCXML alignment:
+  <https://xstate.js.org/api/>.

--- a/code/specs/F07-state-machine-markup-language.md
+++ b/code/specs/F07-state-machine-markup-language.md
@@ -456,6 +456,10 @@ All documents:
 - action and guard references must exist
 - include paths must be relative to the current document unless explicitly
   marked as package imports
+- include resolution must canonicalize paths against the current document or
+  package root, reject absolute paths, reject parent-directory traversal,
+  reject symlink escapes outside the allowed root, and reject URL-like imports
+  unless a caller provides an explicit allowlisted resolver
 
 DFA documents:
 

--- a/code/specs/F08-declarative-tokenizer-state-machines.md
+++ b/code/specs/F08-declarative-tokenizer-state-machines.md
@@ -1,31 +1,31 @@
-# F07: Declarative Tokenizer State Machines
+# F08: Declarative Tokenizer State Machines
 
 ## Overview
 
-This spec defines a portable, text-loadable way to describe **effectful
-tokenizer state machines**. The first target is HTML tokenization, but the
-design is generic enough for XML-ish formats, browser protocols, programming
-language lexers with modes, and any stream format where the next token depends
-on the current lexical state.
+This spec defines the **tokenizer profile** for the State Machine Markup
+Language in `F07-state-machine-markup-language.md`. The first target is HTML
+tokenization, but the design is generic enough for XML-ish formats, browser
+protocols, programming language lexers with modes, and any stream format where
+the next token depends on the current lexical state.
 
-The existing `F01-state-machine.md` package gives us formal automata: DFA, NFA,
-PDA, minimization, and modal machines. That is the right mathematical base, but
-HTML tokenization needs one extra layer: transitions do not only change state.
-They also build tokens, append text, track temporary buffers, report parse
-errors, reconsume the current input character in a new state, and sometimes
-call a shared submachine such as character-reference parsing.
+The existing `F01-state-machine.md` package gives us formal automata, and `F07`
+defines how those machines serialize and deserialize. HTML tokenization needs
+one extra profile layer: transitions do not only change state. They also build
+tokens, append text, track temporary buffers, report parse errors, reconsume the
+current input character in a new state, and sometimes call a shared submachine
+such as character-reference parsing.
 
 So the answer to "can the states and transitions live purely in a text file?"
 is:
 
-- **Yes**, if the file describes a state graph plus a fixed portable action
-  vocabulary.
+- **Yes**, if the file is a `state-machine/v1` document with a tokenizer
+  profile and a fixed portable action vocabulary.
 - **No**, if "purely" means a bare DFA transition table with no registers,
   buffers, token-emission actions, EOF handling, or reconsume semantics.
 
 The goal is a declarative file that every language port can load and execute the
 same way, without embedding arbitrary Rust, Go, Ruby, Python, or TypeScript code
-inside the grammar.
+inside the machine definition.
 
 ## Why This Exists
 
@@ -51,20 +51,23 @@ language.
 
 - `F01-state-machine.md`: provides the formal automata vocabulary and modal
   machine foundation.
+- `F07-state-machine-markup-language.md`: defines the generic `.states.toml`
+  document envelope, serializer/deserializer contract, SCXML inspiration, and
+  DOT export boundary.
 - `F04-lexer-pattern-groups.md`: supports grouped pattern lexing with callbacks;
   this spec is lower level and more deterministic, for byte/code-point state
   machines like HTML.
 - `F06-haskell-layout-mode.md`: handles a layout-sensitive token transform after
   physical tokenization; this spec handles the tokenization loop itself.
 - `TE04-html1.0-lexer.md`: should eventually become a thin wrapper around an
-  `html1.tokenizer` definition.
+  `html1.tokenizer.states.toml` definition.
 - `TE05-html1.0-parser.md`: consumes tokens from this system but remains a
   separate tree-construction concern.
 
 ## Design Principles
 
-1. **Data first, code second.** The tokenizer definition is text. Runtime code
-   only implements the generic interpreter and built-in action vocabulary.
+1. **Profile, not fork.** Tokenizers extend the `state-machine/v1` document
+   model instead of inventing a separate serialization language.
 2. **Portable by construction.** A definition loaded in Rust must behave the
    same way when loaded in Go, TypeScript, Ruby, Python, or future ports.
 3. **No arbitrary host callbacks in definition files.** Escape hatches are how
@@ -91,20 +94,17 @@ This spec does not define:
 - arbitrary regex-based lexing for programming languages
 
 Those can sit above or beside this package. This layer only defines an
-effectful state-machine tokenizer runtime and file format.
+effectful state-machine tokenizer runtime and a profile for the generic `F07`
+file format.
 
 ## Core Model
 
-A tokenizer definition contains:
+A tokenizer definition is a `StateMachineDocument` with
+`profile = "tokenizer/v1"`. It contains the generic `F07` fields plus:
 
-- metadata and version requirements
 - token type declarations
 - named input classes
 - registers and buffers
-- states
-- ordered transitions inside each state
-- built-in actions attached to transitions
-- optional included definition files
 - validation expectations and fixture hooks
 
 At runtime, the tokenizer owns:
@@ -134,76 +134,140 @@ state.
 
 ## File Format
 
-The canonical source format is `.tokenizer`. It follows the same plain-text
-spirit as `.tokens`, `.grammar`, and `.states`, but it is a new format because a
-tokenizer state machine needs actions, registers, streaming semantics, and
-token declarations that do not fit cleanly into the existing `.states` examples.
+The canonical source format is `.tokenizer.states.toml`. It is a
+TOML-compatible `state-machine/v1` document with `profile = "tokenizer/v1"`.
+The shorter `.tokenizer` extension may be accepted by repo tools, but writers
+should prefer `.tokenizer.states.toml` for clarity and easy TOML tooling.
 
 Example filename:
 
 ```text
-code/tokenizers/html/html1.tokenizer
+code/tokenizers/html/html1.tokenizer.states.toml
 ```
 
-The first version is intentionally indentation based and line oriented:
+The first version uses the same document envelope as `F07`:
 
-```text
-format: tokenizer-state-machine/v1
-name: html1-tokenizer
-initial: data
-done: done
+```toml
+format = "state-machine/v1"
+profile = "tokenizer/v1"
+name = "html1-tokenizer"
+kind = "transducer"
+initial = "data"
+done = "done"
+includes = ["html-common-inputs.states.toml"]
 
-include:
-  html-common-inputs.tokenizer
+[[tokens]]
+name = "Text"
+fields = ["data"]
 
-tokens:
-  Text(data)
-  StartTag(name, attributes, self_closing)
-  EndTag(name)
-  Comment(data)
-  Doctype(name, force_quirks)
-  EOF
+[[tokens]]
+name = "StartTag"
+fields = ["name", "attributes", "self_closing"]
 
-inputs:
-  ascii_whitespace = one_of("\t\n\f\r ")
-  ascii_alpha = range("A", "Z") | range("a", "z")
-  tag_name_char = ascii_alpha | range("0", "9") | one_of("-_:")
+[[tokens]]
+name = "EndTag"
+fields = ["name"]
 
-registers:
-  text_buffer: string
-  current_token: token?
-  current_attribute: attribute?
-  temporary_buffer: string
-  return_state: state?
-  last_start_tag_name: string?
+[[tokens]]
+name = "Comment"
+fields = ["data"]
 
-state data:
-  on "<":
-    actions: flush_text
-    goto: tag_open
+[[tokens]]
+name = "Doctype"
+fields = ["name", "force_quirks"]
 
-  on "&":
-    actions:
-      - set_return_state(data)
-      - consume_character_reference(text)
-    goto: data
+[[tokens]]
+name = "EOF"
+fields = []
 
-  on "\0":
-    actions:
-      - parse_error(unexpected-null-character)
-      - append_text("\uFFFD")
-    goto: data
+[[inputs]]
+id = "ascii_whitespace"
+matcher = { one_of = "\t\n\f\r " }
 
-  on eof:
-    actions:
-      - flush_text
-      - emit(EOF)
-    goto: done
+[[inputs]]
+id = "ascii_upper"
+matcher = { range = ["A", "Z"] }
 
-  on anything:
-    actions: append_text(current)
-    goto: data
+[[inputs]]
+id = "ascii_lower"
+matcher = { range = ["a", "z"] }
+
+[[inputs]]
+id = "ascii_alpha"
+matcher = { any_of_classes = ["ascii_upper", "ascii_lower"] }
+
+[[registers]]
+id = "text_buffer"
+type = "string"
+
+[[registers]]
+id = "current_token"
+type = "token?"
+
+[[registers]]
+id = "current_attribute"
+type = "attribute?"
+
+[[registers]]
+id = "temporary_buffer"
+type = "string"
+
+[[registers]]
+id = "return_state"
+type = "state?"
+
+[[registers]]
+id = "last_start_tag_name"
+type = "string?"
+
+[[states]]
+id = "data"
+initial = true
+
+[[states]]
+id = "done"
+final = true
+
+[[transitions]]
+from = "data"
+matcher = { literal = "<" }
+to = "tag_open"
+actions = ["flush_text"]
+
+[[transitions]]
+from = "data"
+matcher = { literal = "&" }
+to = "data"
+actions = [
+  "set_return_state(data)",
+  "consume_character_reference(text)",
+]
+
+[[transitions]]
+from = "data"
+matcher = { literal = "\\0" }
+to = "data"
+actions = [
+  "parse_error(unexpected-null-character)",
+  "append_text_replacement",
+]
+
+[[transitions]]
+from = "data"
+matcher = { eof = true }
+to = "done"
+actions = ["flush_text", "emit(EOF)"]
+
+[[transitions]]
+from = "data"
+matcher = { anything = true }
+to = "data"
+actions = ["append_text(current)"]
 ```
+
+The compact action-call strings above are a human-friendly TOML surface. The
+canonical JSON form expands them into structured action calls with `name` and
+`args` fields.
 
 ## Matchers
 
@@ -216,6 +280,7 @@ Every implementation must support:
 - `anything_else`: alias for `anything`, intended for readability after
   specific cases
 - `class(name)`: match a named input class
+- `any_of_classes([name, ...])`: match any one of several named input classes
 - `not_class(name)`: match any non-EOF code point outside a class
 - `one_of("...")`: match one code point from a literal set
 - `range("A", "Z")`: match an inclusive code-point range
@@ -387,11 +452,11 @@ To scale from HTML 1.0 to the living standard, add definitions in layers:
 
 ```text
 code/tokenizers/html/
-  html-common-inputs.tokenizer
+  html-common-inputs.states.toml
   html-common-actions.md
-  html1.tokenizer
-  html4-compatible.tokenizer
-  whatwg-html.tokenizer
+  html1.tokenizer.states.toml
+  html4-compatible.tokenizer.states.toml
+  whatwg-html.tokenizer.states.toml
 ```
 
 The living-standard definition will need:
@@ -481,7 +546,7 @@ The validator should warn about:
 
 - parse metadata, token declarations, registers, inputs, includes, states, and
   transitions
-- reject malformed indentation and unknown top-level sections
+- reject malformed TOML and unknown top-level sections
 - preserve source locations for diagnostics
 - produce a stable canonical AST
 
@@ -524,35 +589,33 @@ web-platform-tests/html and run them through the same runtime.
    direction for this repo.
 4. Add TypeScript, Python, Ruby, and other ports only after the Rust and Go APIs
    settle.
-5. Add `code/tokenizers/html/html1.tokenizer`.
+5. Add `code/tokenizers/html/html1.tokenizer.states.toml`.
 6. Rebuild `html1.0-lexer` as a wrapper over the declarative definition.
 7. Add conformance fixtures and transition traces.
-8. Expand toward `whatwg-html.tokenizer` state by state.
+8. Expand toward `whatwg-html.tokenizer.states.toml` state by state.
 9. Create a later tree-construction spec for insertion modes, stack of open
    elements, active formatting elements, foster parenting, template insertion
    modes, and the adoption agency algorithm.
 
 ## Open Questions
 
-- Should the canonical serialized AST be JSON, TOML, or a compact binary format
-  for faster package startup?
-- Should `.tokenizer` be parsed directly by every port, or should one reference
-  parser generate a canonical JSON artifact that all ports consume?
+- Should tokenizer runtimes parse TOML directly in every port, or should one
+  reference parser generate a canonical JSON artifact that all ports consume?
 - How much of the WHATWG character-reference table should live in the tokenizer
   definition versus a shared generated data package?
 - Do we want a visualizer that renders tokenizer states as DOT graphs with
   action labels?
 
-The recommended first implementation is: parse `.tokenizer` text into a
-canonical in-memory AST in each port, then add JSON export/import once the AST
-stabilizes. That keeps the early system simple while preserving a path to fast,
-prevalidated artifacts.
+The recommended first implementation is: parse `.tokenizer.states.toml` text
+into the `F07` canonical in-memory AST in each port, then add JSON import/export
+once the AST stabilizes. That keeps the early system simple while preserving a
+path to fast, prevalidated artifacts.
 
 ## Success Criteria
 
 Phase 1 is successful when:
 
-1. a `.tokenizer` file can describe the HTML 1.0 tokenizer states
+1. a `.tokenizer.states.toml` file can describe the HTML 1.0 tokenizer states
 2. Rust and Go runtimes can load the same definition file
 3. both runtimes pass the same HTML tokenizer fixtures
 4. traces make transition behavior understandable


### PR DESCRIPTION
## Summary

- Add F07 State Machine Markup Language as the canonical .states.toml serialization/deserialization format for DFA, NFA, PDA, modal machines, JSON artifacts, SCXML core import/export, and DOT visualization output.
- Move tokenizer work to F08 as a tokenizer/v1 profile over the generic state-machine document model.
- Update F01 to point .states implementers at the F07 canonical format.
- Tighten include resolution rules after security review so implementations reject traversal, absolute paths, symlink escapes, and URL imports without an allowlisted resolver.

## Validation

- git diff --check origin/main...HEAD
- Security review: passed after fixing include path-resolution guidance

## Notes

This is spec-only; no package code or build files changed.