### PR TITLE
feat(note-frequency): add Java and Kotlin packages

### DIFF
--- a/code/packages/java/note-frequency/.gitignore
+++ b/code/packages/java/note-frequency/.gitignore
@@ -1,0 +1,2 @@
+gradle-build/
+.gradle/

--- a/code/packages/java/note-frequency/BUILD
+++ b/code/packages/java/note-frequency/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/note-frequency/CHANGELOG.md
+++ b/code/packages/java/note-frequency/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Added the initial note-to-frequency package.
+- Added note parsing for natural notes plus single sharps and flats.
+- Added equal-tempered frequency mapping anchored at `A4 = 440 Hz`.
+- Added tests that lock down the shared parity vectors across language ports.

--- a/code/packages/java/note-frequency/README.md
+++ b/code/packages/java/note-frequency/README.md
@@ -1,0 +1,22 @@
+# java/note-frequency
+
+
+Parses typed musical note labels such as `A4`, `C#5`, and `Db3` into a structured
+`Note` value and then maps that note to its equal-tempered frequency in Hertz.
+
+This package is the symbolic front door for the music stack:
+
+- users type note names
+- this layer turns them into exact pitches
+- later oscillator and renderer packages will turn those pitches into sound
+
+The core reference point is `A4 = 440 Hz`, and every semitone step multiplies
+frequency by `2^(1/12)`.
+
+
+## Usage
+
+```java
+Note note = NoteFrequency.parseNote("A4");
+double frequency = NoteFrequency.noteToFrequency("C4");
+```

--- a/code/packages/java/note-frequency/build.gradle.kts
+++ b/code/packages/java/note-frequency/build.gradle.kts
@@ -1,0 +1,18 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/note-frequency/settings.gradle.kts
+++ b/code/packages/java/note-frequency/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "note-frequency"

--- a/code/packages/java/note-frequency/src/main/java/com/codingadventures/notefrequency/Note.java
+++ b/code/packages/java/note-frequency/src/main/java/com/codingadventures/notefrequency/Note.java
@@ -1,0 +1,66 @@
+package com.codingadventures.notefrequency;
+
+import java.util.Map;
+
+public final class Note {
+    private static final Map<String, Integer> CHROMATIC_INDEX = Map.ofEntries(
+        Map.entry("C", 0),
+        Map.entry("C#", 1),
+        Map.entry("Db", 1),
+        Map.entry("D", 2),
+        Map.entry("D#", 3),
+        Map.entry("Eb", 3),
+        Map.entry("E", 4),
+        Map.entry("F", 5),
+        Map.entry("F#", 6),
+        Map.entry("Gb", 6),
+        Map.entry("G", 7),
+        Map.entry("G#", 8),
+        Map.entry("Ab", 8),
+        Map.entry("A", 9),
+        Map.entry("A#", 10),
+        Map.entry("Bb", 10),
+        Map.entry("B", 11)
+    );
+
+    private static final int REFERENCE_OCTAVE = 4;
+    private static final int REFERENCE_INDEX = 9;
+    private static final double REFERENCE_FREQUENCY_HZ = 440.0;
+    private static final int SEMITONES_PER_OCTAVE = 12;
+
+    private final String letter;
+    private final String accidental;
+    private final int octave;
+
+    public Note(String letter, String accidental, int octave) {
+        String canonicalLetter = letter.toUpperCase();
+        String spelling = canonicalLetter + accidental;
+        if (!CHROMATIC_INDEX.containsKey(spelling)) {
+            throw new IllegalArgumentException(
+                "Unsupported note spelling " + spelling + ". Only natural notes plus single # or b accidentals are supported."
+            );
+        }
+        this.letter = canonicalLetter;
+        this.accidental = accidental;
+        this.octave = octave;
+    }
+
+    public String letter() { return letter; }
+    public String accidental() { return accidental; }
+    public int octave() { return octave; }
+    public String spelling() { return letter + accidental; }
+    public int chromaticIndex() { return CHROMATIC_INDEX.get(spelling()); }
+
+    public int semitonesFromA4() {
+        int octaveOffset = (octave - REFERENCE_OCTAVE) * SEMITONES_PER_OCTAVE;
+        int pitchOffset = chromaticIndex() - REFERENCE_INDEX;
+        return octaveOffset + pitchOffset;
+    }
+
+    public double frequency() {
+        return REFERENCE_FREQUENCY_HZ * Math.pow(2.0, semitonesFromA4() / (double) SEMITONES_PER_OCTAVE);
+    }
+
+    @Override
+    public String toString() { return spelling() + octave; }
+}

--- a/code/packages/java/note-frequency/src/main/java/com/codingadventures/notefrequency/NoteFrequency.java
+++ b/code/packages/java/note-frequency/src/main/java/com/codingadventures/notefrequency/NoteFrequency.java
@@ -1,0 +1,25 @@
+package com.codingadventures.notefrequency;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class NoteFrequency {
+    private static final Pattern NOTE_PATTERN = Pattern.compile("^([A-Ga-g])([#b]?)(-?\\d+)$");
+
+    private NoteFrequency() {
+    }
+
+    public static Note parseNote(String text) {
+        Matcher matcher = NOTE_PATTERN.matcher(text);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException(
+                "Invalid note " + text + ". Expected <letter><optional # or b><octave>, for example 'A4', 'C#5', or 'Db3'."
+            );
+        }
+        return new Note(matcher.group(1), matcher.group(2), Integer.parseInt(matcher.group(3)));
+    }
+
+    public static double noteToFrequency(String text) {
+        return parseNote(text).frequency();
+    }
+}

--- a/code/packages/java/note-frequency/src/test/java/com/codingadventures/notefrequency/NoteFrequencyTest.java
+++ b/code/packages/java/note-frequency/src/test/java/com/codingadventures/notefrequency/NoteFrequencyTest.java
@@ -1,0 +1,50 @@
+package com.codingadventures.notefrequency;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class NoteFrequencyTest {
+    @Test
+    void parseNoteExtractsFields() {
+        Note note = NoteFrequency.parseNote("C#5");
+        assertEquals("C", note.letter());
+        assertEquals("#", note.accidental());
+        assertEquals(5, note.octave());
+    }
+
+    @Test
+    void lowercaseLettersAreNormalized() {
+        assertEquals("G4", NoteFrequency.parseNote("g4").toString());
+    }
+
+    @Test
+    void malformedNotesThrow() {
+        for (String value : new String[] {"", "A", "H4", "#4", "4A", "A##4", "Bb"}) {
+            assertThrows(IllegalArgumentException.class, () -> NoteFrequency.parseNote(value));
+        }
+    }
+
+    @Test
+    void unsupportedSpellingsThrow() {
+        assertThrows(IllegalArgumentException.class, () -> new Note("E", "#", 4));
+    }
+
+    @Test
+    void semitoneOffsetsMatchExamples() {
+        assertEquals(0, NoteFrequency.parseNote("A4").semitonesFromA4());
+        assertEquals(12, NoteFrequency.parseNote("A5").semitonesFromA4());
+        assertEquals(-12, NoteFrequency.parseNote("A3").semitonesFromA4());
+        assertEquals(-9, NoteFrequency.parseNote("C4").semitonesFromA4());
+    }
+
+    @Test
+    void frequenciesMatchExamples() {
+        assertEquals(440.0, NoteFrequency.parseNote("A4").frequency(), 1.0e-12);
+        assertEquals(880.0, NoteFrequency.parseNote("A5").frequency(), 1.0e-12);
+        assertEquals(220.0, NoteFrequency.parseNote("A3").frequency(), 1.0e-12);
+        assertEquals(261.6255653005986, NoteFrequency.noteToFrequency("C4"), 1.0e-12);
+        assertEquals(NoteFrequency.noteToFrequency("C#4"), NoteFrequency.noteToFrequency("Db4"), 1.0e-12);
+    }
+}

--- a/code/packages/kotlin/note-frequency/.gitignore
+++ b/code/packages/kotlin/note-frequency/.gitignore
@@ -1,0 +1,2 @@
+gradle-build/
+.gradle/

--- a/code/packages/kotlin/note-frequency/BUILD
+++ b/code/packages/kotlin/note-frequency/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/note-frequency/CHANGELOG.md
+++ b/code/packages/kotlin/note-frequency/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Added the initial note-to-frequency package.
+- Added note parsing for natural notes plus single sharps and flats.
+- Added equal-tempered frequency mapping anchored at `A4 = 440 Hz`.
+- Added tests that lock down the shared parity vectors across language ports.

--- a/code/packages/kotlin/note-frequency/README.md
+++ b/code/packages/kotlin/note-frequency/README.md
@@ -1,0 +1,22 @@
+# kotlin/note-frequency
+
+
+Parses typed musical note labels such as `A4`, `C#5`, and `Db3` into a structured
+`Note` value and then maps that note to its equal-tempered frequency in Hertz.
+
+This package is the symbolic front door for the music stack:
+
+- users type note names
+- this layer turns them into exact pitches
+- later oscillator and renderer packages will turn those pitches into sound
+
+The core reference point is `A4 = 440 Hz`, and every semitone step multiplies
+frequency by `2^(1/12)`.
+
+
+## Usage
+
+```kotlin
+val note = NoteFrequency.parseNote("A4")
+val frequency = NoteFrequency.noteToFrequency("C4")
+```

--- a/code/packages/kotlin/note-frequency/build.gradle.kts
+++ b/code/packages/kotlin/note-frequency/build.gradle.kts
@@ -1,0 +1,32 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_21
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/note-frequency/settings.gradle.kts
+++ b/code/packages/kotlin/note-frequency/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "note-frequency"

--- a/code/packages/kotlin/note-frequency/src/main/kotlin/com/codingadventures/notefrequency/NoteFrequency.kt
+++ b/code/packages/kotlin/note-frequency/src/main/kotlin/com/codingadventures/notefrequency/NoteFrequency.kt
@@ -1,0 +1,64 @@
+package com.codingadventures.notefrequency
+
+private val chromaticIndexMap = mapOf(
+    "C" to 0,
+    "C#" to 1,
+    "Db" to 1,
+    "D" to 2,
+    "D#" to 3,
+    "Eb" to 3,
+    "E" to 4,
+    "F" to 5,
+    "F#" to 6,
+    "Gb" to 6,
+    "G" to 7,
+    "G#" to 8,
+    "Ab" to 8,
+    "A" to 9,
+    "A#" to 10,
+    "Bb" to 10,
+    "B" to 11,
+)
+
+private const val REFERENCE_OCTAVE = 4
+private const val REFERENCE_INDEX = 9
+private const val REFERENCE_FREQUENCY_HZ = 440.0
+private const val SEMITONES_PER_OCTAVE = 12
+
+data class Note(private val rawLetter: String, val accidental: String = "", val octave: Int) {
+    val letter: String = rawLetter.uppercase()
+    val spelling: String = letter + accidental
+
+    init {
+        require(chromaticIndexMap.containsKey(spelling)) {
+            "Unsupported note spelling $spelling. Only natural notes plus single # or b accidentals are supported."
+        }
+    }
+
+    fun chromaticIndex(): Int = chromaticIndexMap.getValue(spelling)
+
+    fun semitonesFromA4(): Int {
+        val octaveOffset = (octave - REFERENCE_OCTAVE) * SEMITONES_PER_OCTAVE
+        val pitchOffset = chromaticIndex() - REFERENCE_INDEX
+        return octaveOffset + pitchOffset
+    }
+
+    fun frequency(): Double = REFERENCE_FREQUENCY_HZ * Math.pow(2.0, semitonesFromA4().toDouble() / SEMITONES_PER_OCTAVE)
+
+    override fun toString(): String = "$spelling$octave"
+}
+
+object NoteFrequency {
+    private val notePattern = Regex("^([A-Ga-g])([#b]?)(-?\\d+)$")
+
+    fun parseNote(text: String): Note {
+        val match = notePattern.matchEntire(text)
+            ?: throw IllegalArgumentException(
+                "Invalid note $text. Expected <letter><optional # or b><octave>, for example 'A4', 'C#5', or 'Db3'."
+            )
+        val (letter, accidental, octaveText) = match.destructured
+        return Note(letter, accidental, octaveText.toInt())
+    }
+
+    fun noteToFrequency(text: String): Double = parseNote(text).frequency()
+}

--- a/code/packages/kotlin/note-frequency/src/test/kotlin/com/codingadventures/notefrequency/NoteFrequencyTest.kt
+++ b/code/packages/kotlin/note-frequency/src/test/kotlin/com/codingadventures/notefrequency/NoteFrequencyTest.kt
@@ -1,0 +1,49 @@
+package com.codingadventures.notefrequency
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class NoteFrequencyTest {
+    @Test
+    fun `parseNote extracts fields`() {
+        val note = NoteFrequency.parseNote("C#5")
+        assertEquals("C", note.letter)
+        assertEquals("#", note.accidental)
+        assertEquals(5, note.octave)
+    }
+
+    @Test
+    fun `lowercase letters are normalized`() {
+        assertEquals("G4", NoteFrequency.parseNote("g4").toString())
+    }
+
+    @Test
+    fun `malformed notes throw`() {
+        listOf("", "A", "H4", "#4", "4A", "A##4", "Bb").forEach { value ->
+            assertFailsWith<IllegalArgumentException> { NoteFrequency.parseNote(value) }
+        }
+    }
+
+    @Test
+    fun `unsupported spellings throw`() {
+        assertFailsWith<IllegalArgumentException> { Note("E", "#", 4) }
+    }
+
+    @Test
+    fun `semitone offsets match examples`() {
+        assertEquals(0, NoteFrequency.parseNote("A4").semitonesFromA4())
+        assertEquals(12, NoteFrequency.parseNote("A5").semitonesFromA4())
+        assertEquals(-12, NoteFrequency.parseNote("A3").semitonesFromA4())
+        assertEquals(-9, NoteFrequency.parseNote("C4").semitonesFromA4())
+    }
+
+    @Test
+    fun `frequencies match examples`() {
+        assertEquals(440.0, NoteFrequency.parseNote("A4").frequency(), 1.0e-12)
+        assertEquals(880.0, NoteFrequency.parseNote("A5").frequency(), 1.0e-12)
+        assertEquals(220.0, NoteFrequency.parseNote("A3").frequency(), 1.0e-12)
+        assertEquals(261.6255653005986, NoteFrequency.noteToFrequency("C4"), 1.0e-12)
+        assertEquals(NoteFrequency.noteToFrequency("C#4"), NoteFrequency.noteToFrequency("Db4"), 1.0e-12)
+    }
+}


### PR DESCRIPTION
## Summary
- Add Java note-frequency package with parser, Note value object, equal-tempered frequency mapping, README, changelog, and Gradle BUILD file.
- Add Kotlin note-frequency package with the same API contract and parity tests.
- Keep Gradle outputs isolated under gradle-build/ to avoid BUILD-file collisions on case-insensitive filesystems.

## Validation
- gradle test in code/packages/java/note-frequency
- gradle test in code/packages/kotlin/note-frequency
- /tmp/ca-build-tool-jvm -root /Users/adhithya/Downloads/coding-adventures-note-frequency-jvm -detect-languages -emit-plan /tmp/note-frequency-jvm-plan.json -diff-base origin/main -validate-build-files
- /tmp/ca-build-tool-jvm -root /Users/adhithya/Downloads/coding-adventures-note-frequency-jvm -plan-file /tmp/note-frequency-jvm-plan.json -jobs 2
- Local security-review checklist passed; no vulnerabilities found.