### PR TITLE
feat(jvm-wasm): add Java and Kotlin source pipelines

### DIFF
--- a/code/packages/java/brainfuck-wasm-compiler/.gitignore
+++ b/code/packages/java/brainfuck-wasm-compiler/.gitignore
@@ -1,0 +1,3 @@
+.gradle/
+build/
+gradle-build/

--- a/code/packages/java/brainfuck-wasm-compiler/BUILD
+++ b/code/packages/java/brainfuck-wasm-compiler/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/brainfuck-wasm-compiler/BUILD
+++ b/code/packages/java/brainfuck-wasm-compiler/BUILD
@@ -1,1 +1,1 @@
-gradle test
+mkdir -p ../../../../.build-locks && while ! mkdir ../../../../.build-locks/jvm-wasm.lock 2>/dev/null; do sleep 1; done; gradle --no-daemon --no-build-cache --max-workers=1 test; status=$?; rmdir ../../../../.build-locks/jvm-wasm.lock; exit $status

--- a/code/packages/java/brainfuck-wasm-compiler/BUILD_windows
+++ b/code/packages/java/brainfuck-wasm-compiler/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/brainfuck-wasm-compiler/CHANGELOG.md
+++ b/code/packages/java/brainfuck-wasm-compiler/CHANGELOG.md
@@ -1,0 +1,5 @@
+# brainfuck-wasm-compiler
+
+## 0.1.0
+
+- Add initial Java Brainfuck-to-Wasm convergence package.

--- a/code/packages/java/brainfuck-wasm-compiler/README.md
+++ b/code/packages/java/brainfuck-wasm-compiler/README.md
@@ -1,0 +1,5 @@
+# brainfuck-wasm-compiler
+
+Native Java Brainfuck-to-Wasm package. It parses Brainfuck source, emits a
+small Wasm module exporting `_start`, and provides `compileSource`,
+`packSource`, and `writeWasmFile` helpers for the convergence pipeline.

--- a/code/packages/java/brainfuck-wasm-compiler/build.gradle.kts
+++ b/code/packages/java/brainfuck-wasm-compiler/build.gradle.kts
@@ -1,0 +1,29 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation("com.codingadventures:wasm-runtime")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/brainfuck-wasm-compiler/settings.gradle.kts
+++ b/code/packages/java/brainfuck-wasm-compiler/settings.gradle.kts
@@ -1,0 +1,9 @@
+rootProject.name = "brainfuck-wasm-compiler"
+
+includeBuild("../wasm-leb128")
+includeBuild("../wasm-types")
+includeBuild("../wasm-opcodes")
+includeBuild("../wasm-module-parser")
+includeBuild("../wasm-validator")
+includeBuild("../wasm-execution")
+includeBuild("../wasm-runtime")

--- a/code/packages/java/brainfuck-wasm-compiler/src/main/java/com/codingadventures/brainfuckwasmcompiler/BrainfuckWasmCompiler.java
+++ b/code/packages/java/brainfuck-wasm-compiler/src/main/java/com/codingadventures/brainfuckwasmcompiler/BrainfuckWasmCompiler.java
@@ -1,0 +1,407 @@
+package com.codingadventures.brainfuckwasmcompiler;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class BrainfuckWasmCompiler {
+    public static final String VERSION = "0.1.0";
+
+    private BrainfuckWasmCompiler() {}
+
+    public record PackageResult(String source, List<Character> operations, byte[] wasmBytes, Path wasmPath) {
+        public PackageResult {
+            operations = List.copyOf(operations);
+            wasmBytes = wasmBytes.clone();
+        }
+    }
+
+    public static final class PackageError extends RuntimeException {
+        private final String stage;
+
+        public PackageError(String stage, String message) {
+            super(message);
+            this.stage = stage;
+        }
+
+        public String stage() {
+            return stage;
+        }
+    }
+
+    public static PackageResult compileSource(String source) {
+        List<Character> operations = parse(source);
+        return new PackageResult(source, operations, emitModule(operations), null);
+    }
+
+    public static PackageResult packSource(String source) {
+        return compileSource(source);
+    }
+
+    public static PackageResult writeWasmFile(String source, Path path) {
+        PackageResult result = compileSource(source);
+        try {
+            Files.write(path, result.wasmBytes());
+        } catch (IOException error) {
+            throw new PackageError("write", error.getMessage());
+        }
+        return new PackageResult(result.source(), result.operations(), result.wasmBytes(), path);
+    }
+
+    private static List<Character> parse(String source) {
+        List<Character> ops = new ArrayList<>();
+        int depth = 0;
+        for (int index = 0; index < source.length(); index++) {
+            char ch = source.charAt(index);
+            if ("><+-.,[]".indexOf(ch) < 0) {
+                continue;
+            }
+            if (ch == '[') {
+                depth++;
+            } else if (ch == ']') {
+                depth--;
+                if (depth < 0) {
+                    throw new PackageError("parse", "unmatched ] at byte " + index);
+                }
+            }
+            ops.add(ch);
+        }
+        if (depth != 0) {
+            throw new PackageError("parse", "unmatched [");
+        }
+        return ops;
+    }
+
+    private static byte[] emitModule(List<Character> operations) {
+        boolean needsWrite = operations.contains('.');
+        boolean needsRead = operations.contains(',');
+        int importCount = (needsWrite ? 1 : 0) + (needsRead ? 1 : 0);
+        int writeIndex = needsWrite ? 0 : -1;
+        int readIndex = needsRead ? (needsWrite ? 1 : 0) : -1;
+        int startTypeIndex = importCount;
+        int startFunctionIndex = importCount;
+
+        ByteArrayOutputStream module = new ByteArrayOutputStream();
+        writeAll(module, new byte[] {0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00});
+
+        Section types = new Section();
+        types.u32(importCount + 1);
+        if (needsWrite) {
+            types.funcType(4, 1);
+        }
+        if (needsRead) {
+            types.funcType(4, 1);
+        }
+        types.funcType(0, 0);
+        module.writeBytes(section(1, types.bytes()));
+
+        if (importCount > 0) {
+            Section imports = new Section();
+            imports.u32(importCount);
+            if (needsWrite) {
+                imports.importFunction("wasi_snapshot_preview1", "fd_write", writeIndex);
+            }
+            if (needsRead) {
+                imports.importFunction("wasi_snapshot_preview1", "fd_read", readIndex);
+            }
+            module.writeBytes(section(2, imports.bytes()));
+        }
+
+        Section functions = new Section();
+        functions.u32(1);
+        functions.u32(startTypeIndex);
+        module.writeBytes(section(3, functions.bytes()));
+
+        Section memory = new Section();
+        memory.u32(1);
+        memory.write(0x00);
+        memory.u32(1);
+        module.writeBytes(section(5, memory.bytes()));
+
+        Section exports = new Section();
+        exports.u32(2);
+        exports.export("_start", 0x00, startFunctionIndex);
+        exports.export("memory", 0x02, 0);
+        module.writeBytes(section(7, exports.bytes()));
+
+        Section code = new Section();
+        byte[] body = functionBody(operations, writeIndex, readIndex);
+        code.u32(1);
+        code.u32(body.length);
+        code.write(body);
+        module.writeBytes(section(10, code.bytes()));
+        return module.toByteArray();
+    }
+
+    private static byte[] functionBody(List<Character> operations, int writeIndex, int readIndex) {
+        Section body = new Section();
+        body.u32(1);
+        body.u32(3);
+        body.write(0x7f);
+        emitOps(body, operations, 0, operations.size(), writeIndex, readIndex);
+        body.write(0x0b);
+        return body.bytes();
+    }
+
+    private static int emitOps(Section out, List<Character> ops, int start, int end, int writeIndex, int readIndex) {
+        int index = start;
+        while (index < end) {
+            char op = ops.get(index);
+            switch (op) {
+                case '>' -> addToLocal(out, 0, 1);
+                case '<' -> addToLocal(out, 0, -1);
+                case '+' -> mutateCell(out, 1);
+                case '-' -> mutateCell(out, -1);
+                case '.' -> emitWrite(out, writeIndex);
+                case ',' -> emitRead(out, readIndex);
+                case '[' -> {
+                    int close = matchingClose(ops, index);
+                    out.write(0x02);
+                    out.write(0x40);
+                    out.write(0x03);
+                    out.write(0x40);
+                    loadCell(out);
+                    out.write(0x45);
+                    out.write(0x0d);
+                    out.u32(1);
+                    emitOps(out, ops, index + 1, close, writeIndex, readIndex);
+                    out.write(0x0c);
+                    out.u32(0);
+                    out.write(0x0b);
+                    out.write(0x0b);
+                    index = close;
+                }
+                default -> {
+                }
+            }
+            index++;
+        }
+        return index;
+    }
+
+    private static int matchingClose(List<Character> ops, int open) {
+        int depth = 0;
+        for (int index = open; index < ops.size(); index++) {
+            char op = ops.get(index);
+            if (op == '[') {
+                depth++;
+            } else if (op == ']') {
+                depth--;
+                if (depth == 0) {
+                    return index;
+                }
+            }
+        }
+        throw new PackageError("parse", "unmatched [");
+    }
+
+    private static void loadCell(Section out) {
+        out.write(0x20);
+        out.u32(0);
+        out.write(0x2d);
+        out.u32(0);
+        out.u32(0);
+    }
+
+    private static void mutateCell(Section out, int delta) {
+        loadCell(out);
+        out.write(0x41);
+        out.s32(delta);
+        out.write(0x6a);
+        out.write(0x41);
+        out.s32(255);
+        out.write(0x71);
+        out.write(0x21);
+        out.u32(1);
+        out.write(0x20);
+        out.u32(0);
+        out.write(0x20);
+        out.u32(1);
+        out.write(0x3a);
+        out.u32(0);
+        out.u32(0);
+    }
+
+    private static void addToLocal(Section out, int local, int delta) {
+        out.write(0x20);
+        out.u32(local);
+        out.write(0x41);
+        out.s32(delta);
+        out.write(0x6a);
+        out.write(0x21);
+        out.u32(local);
+    }
+
+    private static void emitWrite(Section out, int writeIndex) {
+        if (writeIndex < 0) {
+            return;
+        }
+        loadCell(out);
+        out.write(0x21);
+        out.u32(1);
+        storeByteConstAddress(out, 30012, 1);
+        storeI32Const(out, 30000, 30012);
+        storeI32Const(out, 30004, 1);
+        out.i32(1);
+        out.i32(30000);
+        out.i32(1);
+        out.i32(30008);
+        out.write(0x10);
+        out.u32(writeIndex);
+        out.write(0x21);
+        out.u32(2);
+    }
+
+    private static void emitRead(Section out, int readIndex) {
+        if (readIndex < 0) {
+            return;
+        }
+        storeByteConstAddress(out, 30012, 0);
+        storeI32Const(out, 30000, 30012);
+        storeI32Const(out, 30004, 1);
+        out.i32(0);
+        out.i32(30000);
+        out.i32(1);
+        out.i32(30008);
+        out.write(0x10);
+        out.u32(readIndex);
+        out.write(0x21);
+        out.u32(2);
+        out.i32(30012);
+        out.write(0x2d);
+        out.u32(0);
+        out.u32(0);
+        out.write(0x21);
+        out.u32(1);
+        out.write(0x20);
+        out.u32(0);
+        out.write(0x20);
+        out.u32(1);
+        out.write(0x3a);
+        out.u32(0);
+        out.u32(0);
+    }
+
+    private static void storeByteConstAddress(Section out, int address, int local) {
+        out.i32(address);
+        out.write(0x20);
+        out.u32(local);
+        out.write(0x3a);
+        out.u32(0);
+        out.u32(0);
+    }
+
+    private static void storeI32Const(Section out, int address, int value) {
+        out.i32(address);
+        out.i32(value);
+        out.write(0x36);
+        out.u32(2);
+        out.u32(0);
+    }
+
+    private static byte[] section(int id, byte[] payload) {
+        Section out = new Section();
+        out.write(id);
+        out.u32(payload.length);
+        out.write(payload);
+        return out.bytes();
+    }
+
+    private static void writeAll(ByteArrayOutputStream out, byte[] bytes) {
+        out.writeBytes(bytes);
+    }
+
+    private static final class Section {
+        private final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        void write(int value) {
+            out.write(value & 0xff);
+        }
+
+        void write(byte[] bytes) {
+            out.writeBytes(bytes);
+        }
+
+        void i32(int value) {
+            write(0x41);
+            s32(value);
+        }
+
+        void u32(int value) {
+            write(encodeUnsigned(value));
+        }
+
+        void s32(int value) {
+            write(encodeSigned(value));
+        }
+
+        void funcType(int paramCount, int resultCount) {
+            write(0x60);
+            u32(paramCount);
+            for (int index = 0; index < paramCount; index++) {
+                write(0x7f);
+            }
+            u32(resultCount);
+            for (int index = 0; index < resultCount; index++) {
+                write(0x7f);
+            }
+        }
+
+        void importFunction(String module, String name, int typeIndex) {
+            name(module);
+            name(name);
+            write(0x00);
+            u32(typeIndex);
+        }
+
+        void export(String name, int kind, int index) {
+            name(name);
+            write(kind);
+            u32(index);
+        }
+
+        void name(String value) {
+            byte[] bytes = value.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+            u32(bytes.length);
+            write(bytes);
+        }
+
+        byte[] bytes() {
+            return out.toByteArray();
+        }
+    }
+
+    private static byte[] encodeUnsigned(int value) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int remaining = value;
+        do {
+            int b = remaining & 0x7f;
+            remaining >>>= 7;
+            if (remaining != 0) {
+                b |= 0x80;
+            }
+            out.write(b);
+        } while (remaining != 0);
+        return out.toByteArray();
+    }
+
+    private static byte[] encodeSigned(int value) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int remaining = value;
+        boolean more;
+        do {
+            int b = remaining & 0x7f;
+            remaining >>= 7;
+            boolean signBit = (b & 0x40) != 0;
+            more = !((remaining == 0 && !signBit) || (remaining == -1 && signBit));
+            if (more) {
+                b |= 0x80;
+            }
+            out.write(b);
+        } while (more);
+        return out.toByteArray();
+    }
+}

--- a/code/packages/java/brainfuck-wasm-compiler/src/main/java/com/codingadventures/brainfuckwasmcompiler/BrainfuckWasmCompiler.java
+++ b/code/packages/java/brainfuck-wasm-compiler/src/main/java/com/codingadventures/brainfuckwasmcompiler/BrainfuckWasmCompiler.java
@@ -4,13 +4,25 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public final class BrainfuckWasmCompiler {
     public static final String VERSION = "0.1.0";
+    private static final int MAX_SOURCE_LENGTH = 1_000_000;
+    private static final int MAX_LOOP_NESTING = 512;
 
     private BrainfuckWasmCompiler() {}
+
+    private record ParsedProgram(List<Character> operations, Map<Integer, Integer> loopEnds) {
+        private ParsedProgram {
+            operations = List.copyOf(operations);
+            loopEnds = Map.copyOf(loopEnds);
+        }
+    }
 
     public record PackageResult(String source, List<Character> operations, byte[] wasmBytes, Path wasmPath) {
         public PackageResult {
@@ -33,8 +45,8 @@ public final class BrainfuckWasmCompiler {
     }
 
     public static PackageResult compileSource(String source) {
-        List<Character> operations = parse(source);
-        return new PackageResult(source, operations, emitModule(operations), null);
+        ParsedProgram program = parse(source);
+        return new PackageResult(source, program.operations(), emitModule(program), null);
     }
 
     public static PackageResult packSource(String source) {
@@ -51,31 +63,40 @@ public final class BrainfuckWasmCompiler {
         return new PackageResult(result.source(), result.operations(), result.wasmBytes(), path);
     }
 
-    private static List<Character> parse(String source) {
+    private static ParsedProgram parse(String source) {
+        if (source.length() > MAX_SOURCE_LENGTH) {
+            throw new PackageError("parse", "source exceeds " + MAX_SOURCE_LENGTH + " characters");
+        }
         List<Character> ops = new ArrayList<>();
-        int depth = 0;
+        ArrayDeque<Integer> stack = new ArrayDeque<>();
+        Map<Integer, Integer> loopEnds = new HashMap<>();
         for (int index = 0; index < source.length(); index++) {
             char ch = source.charAt(index);
             if ("><+-.,[]".indexOf(ch) < 0) {
                 continue;
             }
+            int opIndex = ops.size();
             if (ch == '[') {
-                depth++;
+                stack.push(opIndex);
+                if (stack.size() > MAX_LOOP_NESTING) {
+                    throw new PackageError("parse", "loop nesting exceeds " + MAX_LOOP_NESTING);
+                }
             } else if (ch == ']') {
-                depth--;
-                if (depth < 0) {
+                if (stack.isEmpty()) {
                     throw new PackageError("parse", "unmatched ] at byte " + index);
                 }
+                loopEnds.put(stack.pop(), opIndex);
             }
             ops.add(ch);
         }
-        if (depth != 0) {
+        if (!stack.isEmpty()) {
             throw new PackageError("parse", "unmatched [");
         }
-        return ops;
+        return new ParsedProgram(ops, loopEnds);
     }
 
-    private static byte[] emitModule(List<Character> operations) {
+    private static byte[] emitModule(ParsedProgram program) {
+        List<Character> operations = program.operations();
         boolean needsWrite = operations.contains('.');
         boolean needsRead = operations.contains(',');
         int importCount = (needsWrite ? 1 : 0) + (needsRead ? 1 : 0);
@@ -128,7 +149,7 @@ public final class BrainfuckWasmCompiler {
         module.writeBytes(section(7, exports.bytes()));
 
         Section code = new Section();
-        byte[] body = functionBody(operations, writeIndex, readIndex);
+        byte[] body = functionBody(program, writeIndex, readIndex);
         code.u32(1);
         code.u32(body.length);
         code.write(body);
@@ -136,17 +157,25 @@ public final class BrainfuckWasmCompiler {
         return module.toByteArray();
     }
 
-    private static byte[] functionBody(List<Character> operations, int writeIndex, int readIndex) {
+    private static byte[] functionBody(ParsedProgram program, int writeIndex, int readIndex) {
         Section body = new Section();
         body.u32(1);
         body.u32(3);
         body.write(0x7f);
-        emitOps(body, operations, 0, operations.size(), writeIndex, readIndex);
+        emitOps(body, program.operations(), program.loopEnds(), 0, program.operations().size(), writeIndex, readIndex);
         body.write(0x0b);
         return body.bytes();
     }
 
-    private static int emitOps(Section out, List<Character> ops, int start, int end, int writeIndex, int readIndex) {
+    private static int emitOps(
+            Section out,
+            List<Character> ops,
+            Map<Integer, Integer> loopEnds,
+            int start,
+            int end,
+            int writeIndex,
+            int readIndex
+    ) {
         int index = start;
         while (index < end) {
             char op = ops.get(index);
@@ -158,7 +187,7 @@ public final class BrainfuckWasmCompiler {
                 case '.' -> emitWrite(out, writeIndex);
                 case ',' -> emitRead(out, readIndex);
                 case '[' -> {
-                    int close = matchingClose(ops, index);
+                    int close = loopEnds.get(index);
                     out.write(0x02);
                     out.write(0x40);
                     out.write(0x03);
@@ -167,7 +196,7 @@ public final class BrainfuckWasmCompiler {
                     out.write(0x45);
                     out.write(0x0d);
                     out.u32(1);
-                    emitOps(out, ops, index + 1, close, writeIndex, readIndex);
+                    emitOps(out, ops, loopEnds, index + 1, close, writeIndex, readIndex);
                     out.write(0x0c);
                     out.u32(0);
                     out.write(0x0b);
@@ -180,22 +209,6 @@ public final class BrainfuckWasmCompiler {
             index++;
         }
         return index;
-    }
-
-    private static int matchingClose(List<Character> ops, int open) {
-        int depth = 0;
-        for (int index = open; index < ops.size(); index++) {
-            char op = ops.get(index);
-            if (op == '[') {
-                depth++;
-            } else if (op == ']') {
-                depth--;
-                if (depth == 0) {
-                    return index;
-                }
-            }
-        }
-        throw new PackageError("parse", "unmatched [");
     }
 
     private static void loadCell(Section out) {

--- a/code/packages/java/brainfuck-wasm-compiler/src/test/java/com/codingadventures/brainfuckwasmcompiler/BrainfuckWasmCompilerTest.java
+++ b/code/packages/java/brainfuck-wasm-compiler/src/test/java/com/codingadventures/brainfuckwasmcompiler/BrainfuckWasmCompilerTest.java
@@ -48,6 +48,14 @@ class BrainfuckWasmCompilerTest {
     }
 
     @Test
+    void rejectsExcessiveLoopNesting() {
+        String source = "[".repeat(513) + "]".repeat(513);
+        BrainfuckWasmCompiler.PackageError error =
+                assertThrows(BrainfuckWasmCompiler.PackageError.class, () -> BrainfuckWasmCompiler.compileSource(source));
+        assertEquals("parse", error.stage());
+    }
+
+    @Test
     void runsTapeMutationThroughRuntime() {
         BrainfuckWasmCompiler.PackageResult result = BrainfuckWasmCompiler.compileSource("+");
         assertEquals(List.of(), new WasmRuntime().loadAndRun(result.wasmBytes(), "_start", List.of()));

--- a/code/packages/java/brainfuck-wasm-compiler/src/test/java/com/codingadventures/brainfuckwasmcompiler/BrainfuckWasmCompilerTest.java
+++ b/code/packages/java/brainfuck-wasm-compiler/src/test/java/com/codingadventures/brainfuckwasmcompiler/BrainfuckWasmCompilerTest.java
@@ -1,0 +1,55 @@
+package com.codingadventures.brainfuckwasmcompiler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.codingadventures.wasmruntime.WasmRuntime;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class BrainfuckWasmCompilerTest {
+    @Test
+    void compilesSourceIntoWasmBytes() {
+        BrainfuckWasmCompiler.PackageResult result = BrainfuckWasmCompiler.compileSource("++>+");
+        assertTrue(result.wasmBytes().length > 8);
+        assertEquals(List.of('+', '+', '>', '+'), result.operations());
+    }
+
+    @Test
+    void lowersLoopsIntoAValidModule() {
+        BrainfuckWasmCompiler.PackageResult result = BrainfuckWasmCompiler.compileSource("++[>+<-]");
+        assertNotNull(new WasmRuntime().load(result.wasmBytes()));
+    }
+
+    @Test
+    void packSourceAliasesCompileSource() {
+        assertEquals(
+                BrainfuckWasmCompiler.compileSource("+").wasmBytes().length,
+                BrainfuckWasmCompiler.packSource("+").wasmBytes().length);
+    }
+
+    @Test
+    void writesWasmBytes() throws Exception {
+        Path path = Files.createTempFile("java-brainfuck", ".wasm");
+        BrainfuckWasmCompiler.PackageResult result = BrainfuckWasmCompiler.writeWasmFile("+", path);
+        assertEquals(path, result.wasmPath());
+        assertTrue(Files.size(path) > 8);
+    }
+
+    @Test
+    void reportsMalformedLoops() {
+        BrainfuckWasmCompiler.PackageError error =
+                assertThrows(BrainfuckWasmCompiler.PackageError.class, () -> BrainfuckWasmCompiler.compileSource("["));
+        assertEquals("parse", error.stage());
+    }
+
+    @Test
+    void runsTapeMutationThroughRuntime() {
+        BrainfuckWasmCompiler.PackageResult result = BrainfuckWasmCompiler.compileSource("+");
+        assertEquals(List.of(), new WasmRuntime().loadAndRun(result.wasmBytes(), "_start", List.of()));
+    }
+}

--- a/code/packages/java/nib-wasm-compiler/.gitignore
+++ b/code/packages/java/nib-wasm-compiler/.gitignore
@@ -1,0 +1,3 @@
+.gradle/
+build/
+gradle-build/

--- a/code/packages/java/nib-wasm-compiler/BUILD
+++ b/code/packages/java/nib-wasm-compiler/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/nib-wasm-compiler/BUILD
+++ b/code/packages/java/nib-wasm-compiler/BUILD
@@ -1,1 +1,1 @@
-gradle test
+mkdir -p ../../../../.build-locks && while ! mkdir ../../../../.build-locks/jvm-wasm.lock 2>/dev/null; do sleep 1; done; gradle --no-daemon --no-build-cache --max-workers=1 test; status=$?; rmdir ../../../../.build-locks/jvm-wasm.lock; exit $status

--- a/code/packages/java/nib-wasm-compiler/BUILD_windows
+++ b/code/packages/java/nib-wasm-compiler/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/nib-wasm-compiler/CHANGELOG.md
+++ b/code/packages/java/nib-wasm-compiler/CHANGELOG.md
@@ -1,0 +1,5 @@
+# nib-wasm-compiler
+
+## 0.1.0
+
+- Add initial Java Nib-to-Wasm convergence package.

--- a/code/packages/java/nib-wasm-compiler/README.md
+++ b/code/packages/java/nib-wasm-compiler/README.md
@@ -1,0 +1,5 @@
+# nib-wasm-compiler
+
+Native Java Nib-to-Wasm package for the convergence subset. It parses simple
+`u4` functions, emits exported Wasm functions, and provides `compileSource`,
+`packSource`, and `writeWasmFile` helpers.

--- a/code/packages/java/nib-wasm-compiler/build.gradle.kts
+++ b/code/packages/java/nib-wasm-compiler/build.gradle.kts
@@ -1,0 +1,29 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation("com.codingadventures:wasm-runtime")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/nib-wasm-compiler/settings.gradle.kts
+++ b/code/packages/java/nib-wasm-compiler/settings.gradle.kts
@@ -1,0 +1,9 @@
+rootProject.name = "nib-wasm-compiler"
+
+includeBuild("../wasm-leb128")
+includeBuild("../wasm-types")
+includeBuild("../wasm-opcodes")
+includeBuild("../wasm-module-parser")
+includeBuild("../wasm-validator")
+includeBuild("../wasm-execution")
+includeBuild("../wasm-runtime")

--- a/code/packages/java/nib-wasm-compiler/src/main/java/com/codingadventures/nibwasmcompiler/NibWasmCompiler.java
+++ b/code/packages/java/nib-wasm-compiler/src/main/java/com/codingadventures/nibwasmcompiler/NibWasmCompiler.java
@@ -13,6 +13,8 @@ import java.util.regex.Pattern;
 
 public final class NibWasmCompiler {
     public static final String VERSION = "0.1.0";
+    private static final int MAX_SOURCE_LENGTH = 1_000_000;
+    private static final int MAX_EXPR_NESTING = 256;
     private static final Pattern FUNCTION =
             Pattern.compile("fn\\s+([A-Za-z_][A-Za-z0-9_]*)\\s*\\(([^)]*)\\)\\s*->\\s*u4\\s*\\{\\s*return\\s+([^;]+);\\s*\\}", Pattern.DOTALL);
 
@@ -66,6 +68,9 @@ public final class NibWasmCompiler {
     }
 
     private static List<NibFunction> parse(String source) {
+        if (source.length() > MAX_SOURCE_LENGTH) {
+            throw new PackageError("parse", "source exceeds " + MAX_SOURCE_LENGTH + " characters");
+        }
         List<NibFunction> functions = new ArrayList<>();
         Matcher matcher = FUNCTION.matcher(source);
         int cursor = 0;
@@ -105,7 +110,7 @@ public final class NibWasmCompiler {
             }
         }
         for (NibFunction function : functions) {
-            emitExpr(new Section(), function.expression(), byName, paramMap(function), false);
+            emitExpr(new Section(), function.expression(), byName, paramMap(function), false, 0);
         }
     }
 
@@ -143,7 +148,7 @@ public final class NibWasmCompiler {
         for (NibFunction function : functions) {
             Section body = new Section();
             body.u32(0);
-            emitExpr(body, function.expression(), byName, paramMap(function), true);
+            emitExpr(body, function.expression(), byName, paramMap(function), true, 0);
             body.write(0x0b);
             byte[] bytes = body.bytes();
             code.u32(bytes.length);
@@ -153,12 +158,22 @@ public final class NibWasmCompiler {
         return module.bytes();
     }
 
-    private static void emitExpr(Section out, String expression, Map<String, NibFunction> functions, Map<String, Integer> params, boolean emit) {
+    private static void emitExpr(
+            Section out,
+            String expression,
+            Map<String, NibFunction> functions,
+            Map<String, Integer> params,
+            boolean emit,
+            int depth
+    ) {
+        if (depth > MAX_EXPR_NESTING) {
+            throw new PackageError("validate", "expression nesting exceeds " + MAX_EXPR_NESTING);
+        }
         List<String> addParts = splitTopLevel(expression, "+%");
         if (addParts.size() > 1) {
-            emitExpr(out, addParts.get(0), functions, params, emit);
+            emitExpr(out, addParts.get(0), functions, params, emit, depth + 1);
             for (int index = 1; index < addParts.size(); index++) {
-                emitExpr(out, addParts.get(index), functions, params, emit);
+                emitExpr(out, addParts.get(index), functions, params, emit, depth + 1);
                 if (emit) {
                     out.write(0x6a);
                     out.i32(15);
@@ -189,7 +204,7 @@ public final class NibWasmCompiler {
                 throw new PackageError("validate", "wrong arity for `" + target.name() + "`");
             }
             for (String arg : args) {
-                emitExpr(out, arg, functions, params, emit);
+                emitExpr(out, arg, functions, params, emit, depth + 1);
             }
             if (emit) {
                 out.write(0x10);

--- a/code/packages/java/nib-wasm-compiler/src/main/java/com/codingadventures/nibwasmcompiler/NibWasmCompiler.java
+++ b/code/packages/java/nib-wasm-compiler/src/main/java/com/codingadventures/nibwasmcompiler/NibWasmCompiler.java
@@ -1,0 +1,337 @@
+package com.codingadventures.nibwasmcompiler;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class NibWasmCompiler {
+    public static final String VERSION = "0.1.0";
+    private static final Pattern FUNCTION =
+            Pattern.compile("fn\\s+([A-Za-z_][A-Za-z0-9_]*)\\s*\\(([^)]*)\\)\\s*->\\s*u4\\s*\\{\\s*return\\s+([^;]+);\\s*\\}", Pattern.DOTALL);
+
+    private NibWasmCompiler() {}
+
+    public record NibFunction(String name, List<String> params, String expression) {
+        public NibFunction {
+            params = List.copyOf(params);
+            expression = expression.trim();
+        }
+    }
+
+    public record PackageResult(String source, List<NibFunction> functions, byte[] wasmBytes, Path wasmPath) {
+        public PackageResult {
+            functions = List.copyOf(functions);
+            wasmBytes = wasmBytes.clone();
+        }
+    }
+
+    public static final class PackageError extends RuntimeException {
+        private final String stage;
+
+        public PackageError(String stage, String message) {
+            super(message);
+            this.stage = stage;
+        }
+
+        public String stage() {
+            return stage;
+        }
+    }
+
+    public static PackageResult compileSource(String source) {
+        List<NibFunction> functions = parse(source);
+        validate(functions);
+        return new PackageResult(source, functions, emitModule(functions), null);
+    }
+
+    public static PackageResult packSource(String source) {
+        return compileSource(source);
+    }
+
+    public static PackageResult writeWasmFile(String source, Path path) {
+        PackageResult result = compileSource(source);
+        try {
+            Files.write(path, result.wasmBytes());
+        } catch (IOException error) {
+            throw new PackageError("write", error.getMessage());
+        }
+        return new PackageResult(result.source(), result.functions(), result.wasmBytes(), path);
+    }
+
+    private static List<NibFunction> parse(String source) {
+        List<NibFunction> functions = new ArrayList<>();
+        Matcher matcher = FUNCTION.matcher(source);
+        int cursor = 0;
+        while (matcher.find()) {
+            if (!source.substring(cursor, matcher.start()).trim().isEmpty()) {
+                throw new PackageError("parse", "unexpected text before function");
+            }
+            functions.add(new NibFunction(matcher.group(1), parseParams(matcher.group(2)), matcher.group(3)));
+            cursor = matcher.end();
+        }
+        if (!source.substring(cursor).trim().isEmpty() || functions.isEmpty()) {
+            throw new PackageError("parse", "expected one or more Nib functions");
+        }
+        return functions;
+    }
+
+    private static List<String> parseParams(String text) {
+        if (text.trim().isEmpty()) {
+            return List.of();
+        }
+        List<String> params = new ArrayList<>();
+        for (String piece : text.split(",")) {
+            String[] parts = piece.trim().split("\\s*:\\s*");
+            if (parts.length != 2 || !"u4".equals(parts[1]) || !parts[0].matches("[A-Za-z_][A-Za-z0-9_]*")) {
+                throw new PackageError("parse", "parameters must be `name: u4`");
+            }
+            params.add(parts[0]);
+        }
+        return params;
+    }
+
+    private static void validate(List<NibFunction> functions) {
+        Map<String, NibFunction> byName = new LinkedHashMap<>();
+        for (NibFunction function : functions) {
+            if (byName.put(function.name(), function) != null) {
+                throw new PackageError("validate", "duplicate function `" + function.name() + "`");
+            }
+        }
+        for (NibFunction function : functions) {
+            emitExpr(new Section(), function.expression(), byName, paramMap(function), false);
+        }
+    }
+
+    private static byte[] emitModule(List<NibFunction> functions) {
+        Section module = new Section();
+        module.write(new byte[] {0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00});
+
+        Section types = new Section();
+        types.u32(functions.size());
+        for (NibFunction function : functions) {
+            types.funcType(function.params().size(), 1);
+        }
+        module.write(section(1, types.bytes()));
+
+        Section functionSection = new Section();
+        functionSection.u32(functions.size());
+        for (int index = 0; index < functions.size(); index++) {
+            functionSection.u32(index);
+        }
+        module.write(section(3, functionSection.bytes()));
+
+        Section exports = new Section();
+        exports.u32(functions.size());
+        for (int index = 0; index < functions.size(); index++) {
+            exports.export(functions.get(index).name(), 0x00, index);
+        }
+        module.write(section(7, exports.bytes()));
+
+        Map<String, NibFunction> byName = new LinkedHashMap<>();
+        for (NibFunction function : functions) {
+            byName.put(function.name(), function);
+        }
+        Section code = new Section();
+        code.u32(functions.size());
+        for (NibFunction function : functions) {
+            Section body = new Section();
+            body.u32(0);
+            emitExpr(body, function.expression(), byName, paramMap(function), true);
+            body.write(0x0b);
+            byte[] bytes = body.bytes();
+            code.u32(bytes.length);
+            code.write(bytes);
+        }
+        module.write(section(10, code.bytes()));
+        return module.bytes();
+    }
+
+    private static void emitExpr(Section out, String expression, Map<String, NibFunction> functions, Map<String, Integer> params, boolean emit) {
+        List<String> addParts = splitTopLevel(expression, "+%");
+        if (addParts.size() > 1) {
+            emitExpr(out, addParts.get(0), functions, params, emit);
+            for (int index = 1; index < addParts.size(); index++) {
+                emitExpr(out, addParts.get(index), functions, params, emit);
+                if (emit) {
+                    out.write(0x6a);
+                    out.i32(15);
+                    out.write(0x71);
+                }
+            }
+            return;
+        }
+        String trimmed = expression.trim();
+        if (trimmed.matches("\\d+")) {
+            int value = Integer.parseInt(trimmed);
+            if (value < 0 || value > 15) {
+                throw new PackageError("validate", "u4 literal out of range: " + value);
+            }
+            if (emit) {
+                out.i32(value);
+            }
+            return;
+        }
+        Matcher call = Pattern.compile("([A-Za-z_][A-Za-z0-9_]*)\\s*\\((.*)\\)").matcher(trimmed);
+        if (call.matches()) {
+            NibFunction target = functions.get(call.group(1));
+            if (target == null) {
+                throw new PackageError("validate", "unknown function `" + call.group(1) + "`");
+            }
+            List<String> args = splitArgs(call.group(2));
+            if (args.size() != target.params().size()) {
+                throw new PackageError("validate", "wrong arity for `" + target.name() + "`");
+            }
+            for (String arg : args) {
+                emitExpr(out, arg, functions, params, emit);
+            }
+            if (emit) {
+                out.write(0x10);
+                out.u32(new ArrayList<>(functions.keySet()).indexOf(target.name()));
+            }
+            return;
+        }
+        Integer paramIndex = params.get(trimmed);
+        if (paramIndex != null) {
+            if (emit) {
+                out.write(0x20);
+                out.u32(paramIndex);
+            }
+            return;
+        }
+        throw new PackageError("validate", "unsupported expression `" + expression + "`");
+    }
+
+    private static Map<String, Integer> paramMap(NibFunction function) {
+        Map<String, Integer> params = new LinkedHashMap<>();
+        for (int index = 0; index < function.params().size(); index++) {
+            params.put(function.params().get(index), index);
+        }
+        return params;
+    }
+
+    private static List<String> splitArgs(String text) {
+        if (text.trim().isEmpty()) {
+            return List.of();
+        }
+        return splitTopLevel(text, ",");
+    }
+
+    private static List<String> splitTopLevel(String text, String delimiter) {
+        List<String> parts = new ArrayList<>();
+        int depth = 0;
+        int start = 0;
+        for (int index = 0; index < text.length(); index++) {
+            char ch = text.charAt(index);
+            if (ch == '(') {
+                depth++;
+            } else if (ch == ')') {
+                depth--;
+            } else if (depth == 0 && text.startsWith(delimiter, index)) {
+                parts.add(text.substring(start, index).trim());
+                start = index + delimiter.length();
+                index += delimiter.length() - 1;
+            }
+        }
+        parts.add(text.substring(start).trim());
+        return parts;
+    }
+
+    private static byte[] section(int id, byte[] payload) {
+        Section out = new Section();
+        out.write(id);
+        out.u32(payload.length);
+        out.write(payload);
+        return out.bytes();
+    }
+
+    private static final class Section {
+        private final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        void write(int value) {
+            out.write(value & 0xff);
+        }
+
+        void write(byte[] bytes) {
+            out.writeBytes(bytes);
+        }
+
+        void i32(int value) {
+            write(0x41);
+            s32(value);
+        }
+
+        void u32(int value) {
+            write(encodeUnsigned(value));
+        }
+
+        void s32(int value) {
+            write(encodeSigned(value));
+        }
+
+        void funcType(int paramCount, int resultCount) {
+            write(0x60);
+            u32(paramCount);
+            for (int index = 0; index < paramCount; index++) {
+                write(0x7f);
+            }
+            u32(resultCount);
+            for (int index = 0; index < resultCount; index++) {
+                write(0x7f);
+            }
+        }
+
+        void export(String name, int kind, int index) {
+            name(name);
+            write(kind);
+            u32(index);
+        }
+
+        void name(String value) {
+            byte[] bytes = value.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+            u32(bytes.length);
+            write(bytes);
+        }
+
+        byte[] bytes() {
+            return out.toByteArray();
+        }
+    }
+
+    private static byte[] encodeUnsigned(int value) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int remaining = value;
+        do {
+            int b = remaining & 0x7f;
+            remaining >>>= 7;
+            if (remaining != 0) {
+                b |= 0x80;
+            }
+            out.write(b);
+        } while (remaining != 0);
+        return out.toByteArray();
+    }
+
+    private static byte[] encodeSigned(int value) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int remaining = value;
+        boolean more;
+        do {
+            int b = remaining & 0x7f;
+            remaining >>= 7;
+            boolean signBit = (b & 0x40) != 0;
+            more = !((remaining == 0 && !signBit) || (remaining == -1 && signBit));
+            if (more) {
+                b |= 0x80;
+            }
+            out.write(b);
+        } while (more);
+        return out.toByteArray();
+    }
+}

--- a/code/packages/java/nib-wasm-compiler/src/test/java/com/codingadventures/nibwasmcompiler/NibWasmCompilerTest.java
+++ b/code/packages/java/nib-wasm-compiler/src/test/java/com/codingadventures/nibwasmcompiler/NibWasmCompilerTest.java
@@ -1,0 +1,55 @@
+package com.codingadventures.nibwasmcompiler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.codingadventures.wasmruntime.WasmRuntime;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class NibWasmCompilerTest {
+    @Test
+    void compilesSimpleFunction() {
+        NibWasmCompiler.PackageResult result = NibWasmCompiler.compileSource("fn answer() -> u4 { return 7; }");
+        assertTrue(result.wasmBytes().length > 8);
+        assertEquals("answer", result.functions().get(0).name());
+    }
+
+    @Test
+    void aliasesPackSource() {
+        assertEquals(
+                NibWasmCompiler.compileSource("fn answer() -> u4 { return 7; }").wasmBytes().length,
+                NibWasmCompiler.packSource("fn answer() -> u4 { return 7; }").wasmBytes().length);
+    }
+
+    @Test
+    void runsAnswerThroughRuntime() {
+        NibWasmCompiler.PackageResult result = NibWasmCompiler.compileSource("fn answer() -> u4 { return 7; }");
+        assertEquals(List.of(7), new WasmRuntime().loadAndRun(result.wasmBytes(), "answer", List.of()));
+    }
+
+    @Test
+    void runsWrappingAdditionThroughRuntime() {
+        String source = "fn add(a: u4, b: u4) -> u4 { return a +% b; }";
+        NibWasmCompiler.PackageResult result = NibWasmCompiler.compileSource(source);
+        assertEquals(List.of(3), new WasmRuntime().loadAndRun(result.wasmBytes(), "add", List.of(14, 5)));
+    }
+
+    @Test
+    void writesWasmBytes() throws Exception {
+        Path path = Files.createTempFile("java-nib", ".wasm");
+        NibWasmCompiler.PackageResult result = NibWasmCompiler.writeWasmFile("fn answer() -> u4 { return 7; }", path);
+        assertEquals(path, result.wasmPath());
+        assertTrue(Files.size(path) > 8);
+    }
+
+    @Test
+    void reportsInvalidNib() {
+        NibWasmCompiler.PackageError error =
+                assertThrows(NibWasmCompiler.PackageError.class, () -> NibWasmCompiler.compileSource("fn bad() -> u4 { return 99; }"));
+        assertEquals("validate", error.stage());
+    }
+}

--- a/code/packages/java/nib-wasm-compiler/src/test/java/com/codingadventures/nibwasmcompiler/NibWasmCompilerTest.java
+++ b/code/packages/java/nib-wasm-compiler/src/test/java/com/codingadventures/nibwasmcompiler/NibWasmCompilerTest.java
@@ -52,4 +52,16 @@ class NibWasmCompilerTest {
                 assertThrows(NibWasmCompiler.PackageError.class, () -> NibWasmCompiler.compileSource("fn bad() -> u4 { return 99; }"));
         assertEquals("validate", error.stage());
     }
+
+    @Test
+    void rejectsExcessiveExpressionNesting() {
+        String expression = "0";
+        for (int index = 0; index < 258; index++) {
+            expression = "id(" + expression + ")";
+        }
+        String source = "fn id(x: u4) -> u4 { return x; }\nfn main() -> u4 { return " + expression + "; }";
+        NibWasmCompiler.PackageError error =
+                assertThrows(NibWasmCompiler.PackageError.class, () -> NibWasmCompiler.compileSource(source));
+        assertEquals("validate", error.stage());
+    }
 }

--- a/code/packages/kotlin/brainfuck-wasm-compiler/.gitignore
+++ b/code/packages/kotlin/brainfuck-wasm-compiler/.gitignore
@@ -1,0 +1,3 @@
+.gradle/
+build/
+gradle-build/

--- a/code/packages/kotlin/brainfuck-wasm-compiler/BUILD
+++ b/code/packages/kotlin/brainfuck-wasm-compiler/BUILD
@@ -1,0 +1,1 @@
+gradle --no-daemon --no-build-cache --max-workers=1 -Dkotlin.compiler.execution.strategy=in-process -Dkotlin.incremental=false test

--- a/code/packages/kotlin/brainfuck-wasm-compiler/BUILD
+++ b/code/packages/kotlin/brainfuck-wasm-compiler/BUILD
@@ -1,1 +1,1 @@
-gradle --no-daemon --no-build-cache --max-workers=1 -Dkotlin.compiler.execution.strategy=in-process -Dkotlin.incremental=false test
+mkdir -p ../../../../.build-locks && while ! mkdir ../../../../.build-locks/jvm-wasm.lock 2>/dev/null; do sleep 1; done; gradle --no-daemon --no-build-cache --max-workers=1 -Dkotlin.compiler.execution.strategy=in-process -Dkotlin.incremental=false test; status=$?; rmdir ../../../../.build-locks/jvm-wasm.lock; exit $status

--- a/code/packages/kotlin/brainfuck-wasm-compiler/BUILD_windows
+++ b/code/packages/kotlin/brainfuck-wasm-compiler/BUILD_windows
@@ -1,0 +1,1 @@
+gradle --no-daemon --no-build-cache --max-workers=1 -Dkotlin.compiler.execution.strategy=in-process -Dkotlin.incremental=false test

--- a/code/packages/kotlin/brainfuck-wasm-compiler/CHANGELOG.md
+++ b/code/packages/kotlin/brainfuck-wasm-compiler/CHANGELOG.md
@@ -1,0 +1,5 @@
+# brainfuck-wasm-compiler
+
+## 0.1.0
+
+- Add initial Kotlin Brainfuck-to-Wasm convergence package.

--- a/code/packages/kotlin/brainfuck-wasm-compiler/README.md
+++ b/code/packages/kotlin/brainfuck-wasm-compiler/README.md
@@ -1,0 +1,5 @@
+# brainfuck-wasm-compiler
+
+Native Kotlin Brainfuck-to-Wasm package. It parses Brainfuck source, emits a
+small Wasm module exporting `_start`, and provides `compileSource`,
+`packSource`, and `writeWasmFile` helpers for the convergence pipeline.

--- a/code/packages/kotlin/brainfuck-wasm-compiler/build.gradle.kts
+++ b/code/packages/kotlin/brainfuck-wasm-compiler/build.gradle.kts
@@ -1,0 +1,36 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation("com.codingadventures:wasm-runtime")
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/brainfuck-wasm-compiler/settings.gradle.kts
+++ b/code/packages/kotlin/brainfuck-wasm-compiler/settings.gradle.kts
@@ -1,0 +1,3 @@
+rootProject.name = "brainfuck-wasm-compiler"
+
+includeBuild("../../java/wasm-runtime")

--- a/code/packages/kotlin/brainfuck-wasm-compiler/src/main/kotlin/com/codingadventures/brainfuckwasmcompiler/BrainfuckWasmCompiler.kt
+++ b/code/packages/kotlin/brainfuck-wasm-compiler/src/main/kotlin/com/codingadventures/brainfuckwasmcompiler/BrainfuckWasmCompiler.kt
@@ -1,0 +1,364 @@
+package com.codingadventures.brainfuckwasmcompiler
+
+import java.io.ByteArrayOutputStream
+import java.nio.file.Files
+import java.nio.file.Path
+
+data class PackageResult(
+    val source: String,
+    val operations: List<Char>,
+    val wasmBytes: ByteArray,
+    val wasmPath: Path? = null,
+) {
+    override fun equals(other: Any?): Boolean =
+        other is PackageResult &&
+            source == other.source &&
+            operations == other.operations &&
+            wasmBytes.contentEquals(other.wasmBytes) &&
+            wasmPath == other.wasmPath
+
+    override fun hashCode(): Int = 31 * (31 * source.hashCode() + operations.hashCode()) + wasmBytes.contentHashCode()
+}
+
+class PackageError(val stage: String, message: String) : RuntimeException(message)
+
+object BrainfuckWasmCompiler {
+    const val VERSION = "0.1.0"
+
+    fun compileSource(source: String): PackageResult {
+        val operations = parse(source)
+        return PackageResult(source, operations, emitModule(operations))
+    }
+
+    fun packSource(source: String): PackageResult = compileSource(source)
+
+    fun writeWasmFile(source: String, path: Path): PackageResult {
+        val result = compileSource(source)
+        try {
+            Files.write(path, result.wasmBytes)
+        } catch (error: java.io.IOException) {
+            throw PackageError("write", error.message ?: "write failed")
+        }
+        return result.copy(wasmPath = path)
+    }
+
+    private fun parse(source: String): List<Char> {
+        val ops = mutableListOf<Char>()
+        var depth = 0
+        source.forEachIndexed { index, ch ->
+            if (ch !in "><+-.,[]") return@forEachIndexed
+            when (ch) {
+                '[' -> depth++
+                ']' -> {
+                    depth--
+                    if (depth < 0) throw PackageError("parse", "unmatched ] at byte $index")
+                }
+            }
+            ops += ch
+        }
+        if (depth != 0) throw PackageError("parse", "unmatched [")
+        return ops
+    }
+
+    private fun emitModule(operations: List<Char>): ByteArray {
+        val needsWrite = '.' in operations
+        val needsRead = ',' in operations
+        val importCount = (if (needsWrite) 1 else 0) + (if (needsRead) 1 else 0)
+        val writeIndex = if (needsWrite) 0 else -1
+        val readIndex = if (needsRead) if (needsWrite) 1 else 0 else -1
+        val startTypeIndex = importCount
+        val startFunctionIndex = importCount
+
+        val module = Section()
+        module.write(byteArrayOf(0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00))
+
+        val types = Section()
+        types.u32(importCount + 1)
+        if (needsWrite) types.funcType(4, 1)
+        if (needsRead) types.funcType(4, 1)
+        types.funcType(0, 0)
+        module.write(section(1, types.bytes()))
+
+        if (importCount > 0) {
+            val imports = Section()
+            imports.u32(importCount)
+            if (needsWrite) imports.importFunction("wasi_snapshot_preview1", "fd_write", writeIndex)
+            if (needsRead) imports.importFunction("wasi_snapshot_preview1", "fd_read", readIndex)
+            module.write(section(2, imports.bytes()))
+        }
+
+        val functions = Section()
+        functions.u32(1)
+        functions.u32(startTypeIndex)
+        module.write(section(3, functions.bytes()))
+
+        val memory = Section()
+        memory.u32(1)
+        memory.write(0x00)
+        memory.u32(1)
+        module.write(section(5, memory.bytes()))
+
+        val exports = Section()
+        exports.u32(2)
+        exports.export("_start", 0x00, startFunctionIndex)
+        exports.export("memory", 0x02, 0)
+        module.write(section(7, exports.bytes()))
+
+        val code = Section()
+        val body = functionBody(operations, writeIndex, readIndex)
+        code.u32(1)
+        code.u32(body.size)
+        code.write(body)
+        module.write(section(10, code.bytes()))
+        return module.bytes()
+    }
+
+    private fun functionBody(operations: List<Char>, writeIndex: Int, readIndex: Int): ByteArray {
+        val body = Section()
+        body.u32(1)
+        body.u32(3)
+        body.write(0x7f)
+        emitOps(body, operations, 0, operations.size, writeIndex, readIndex)
+        body.write(0x0b)
+        return body.bytes()
+    }
+
+    private fun emitOps(out: Section, ops: List<Char>, start: Int, end: Int, writeIndex: Int, readIndex: Int) {
+        var index = start
+        while (index < end) {
+            when (ops[index]) {
+                '>' -> addToLocal(out, 0, 1)
+                '<' -> addToLocal(out, 0, -1)
+                '+' -> mutateCell(out, 1)
+                '-' -> mutateCell(out, -1)
+                '.' -> emitWrite(out, writeIndex)
+                ',' -> emitRead(out, readIndex)
+                '[' -> {
+                    val close = matchingClose(ops, index)
+                    out.write(0x02)
+                    out.write(0x40)
+                    out.write(0x03)
+                    out.write(0x40)
+                    loadCell(out)
+                    out.write(0x45)
+                    out.write(0x0d)
+                    out.u32(1)
+                    emitOps(out, ops, index + 1, close, writeIndex, readIndex)
+                    out.write(0x0c)
+                    out.u32(0)
+                    out.write(0x0b)
+                    out.write(0x0b)
+                    index = close
+                }
+            }
+            index++
+        }
+    }
+
+    private fun matchingClose(ops: List<Char>, open: Int): Int {
+        var depth = 0
+        for (index in open until ops.size) {
+            when (ops[index]) {
+                '[' -> depth++
+                ']' -> {
+                    depth--
+                    if (depth == 0) return index
+                }
+            }
+        }
+        throw PackageError("parse", "unmatched [")
+    }
+
+    private fun loadCell(out: Section) {
+        out.write(0x20)
+        out.u32(0)
+        out.write(0x2d)
+        out.u32(0)
+        out.u32(0)
+    }
+
+    private fun mutateCell(out: Section, delta: Int) {
+        loadCell(out)
+        out.i32(delta)
+        out.write(0x6a)
+        out.i32(255)
+        out.write(0x71)
+        out.write(0x21)
+        out.u32(1)
+        out.write(0x20)
+        out.u32(0)
+        out.write(0x20)
+        out.u32(1)
+        out.write(0x3a)
+        out.u32(0)
+        out.u32(0)
+    }
+
+    private fun addToLocal(out: Section, local: Int, delta: Int) {
+        out.write(0x20)
+        out.u32(local)
+        out.i32(delta)
+        out.write(0x6a)
+        out.write(0x21)
+        out.u32(local)
+    }
+
+    private fun emitWrite(out: Section, writeIndex: Int) {
+        if (writeIndex < 0) return
+        loadCell(out)
+        out.write(0x21)
+        out.u32(1)
+        storeByteLocal(out, 30012, 1)
+        storeI32Const(out, 30000, 30012)
+        storeI32Const(out, 30004, 1)
+        out.i32(1)
+        out.i32(30000)
+        out.i32(1)
+        out.i32(30008)
+        out.write(0x10)
+        out.u32(writeIndex)
+        out.write(0x21)
+        out.u32(2)
+    }
+
+    private fun emitRead(out: Section, readIndex: Int) {
+        if (readIndex < 0) return
+        storeByteConst(out, 30012, 0)
+        storeI32Const(out, 30000, 30012)
+        storeI32Const(out, 30004, 1)
+        out.i32(0)
+        out.i32(30000)
+        out.i32(1)
+        out.i32(30008)
+        out.write(0x10)
+        out.u32(readIndex)
+        out.write(0x21)
+        out.u32(2)
+        out.i32(30012)
+        out.write(0x2d)
+        out.u32(0)
+        out.u32(0)
+        out.write(0x21)
+        out.u32(1)
+        out.write(0x20)
+        out.u32(0)
+        out.write(0x20)
+        out.u32(1)
+        out.write(0x3a)
+        out.u32(0)
+        out.u32(0)
+    }
+
+    private fun storeByteLocal(out: Section, address: Int, local: Int) {
+        out.i32(address)
+        out.write(0x20)
+        out.u32(local)
+        out.write(0x3a)
+        out.u32(0)
+        out.u32(0)
+    }
+
+    private fun storeByteConst(out: Section, address: Int, value: Int) {
+        out.i32(address)
+        out.i32(value)
+        out.write(0x3a)
+        out.u32(0)
+        out.u32(0)
+    }
+
+    private fun storeI32Const(out: Section, address: Int, value: Int) {
+        out.i32(address)
+        out.i32(value)
+        out.write(0x36)
+        out.u32(2)
+        out.u32(0)
+    }
+
+    private fun section(id: Int, payload: ByteArray): ByteArray =
+        Section().apply {
+            write(id)
+            u32(payload.size)
+            write(payload)
+        }.bytes()
+}
+
+private class Section {
+    private val out = ByteArrayOutputStream()
+
+    fun write(value: Int) {
+        out.write(value and 0xff)
+    }
+
+    fun write(bytes: ByteArray) {
+        out.write(bytes)
+    }
+
+    fun i32(value: Int) {
+        write(0x41)
+        s32(value)
+    }
+
+    fun u32(value: Int) {
+        write(encodeUnsigned(value))
+    }
+
+    fun s32(value: Int) {
+        write(encodeSigned(value))
+    }
+
+    fun funcType(paramCount: Int, resultCount: Int) {
+        write(0x60)
+        u32(paramCount)
+        repeat(paramCount) { write(0x7f) }
+        u32(resultCount)
+        repeat(resultCount) { write(0x7f) }
+    }
+
+    fun importFunction(module: String, name: String, typeIndex: Int) {
+        name(module)
+        name(name)
+        write(0x00)
+        u32(typeIndex)
+    }
+
+    fun export(name: String, kind: Int, index: Int) {
+        name(name)
+        write(kind)
+        u32(index)
+    }
+
+    private fun name(value: String) {
+        val bytes = value.encodeToByteArray()
+        u32(bytes.size)
+        write(bytes)
+    }
+
+    fun bytes(): ByteArray = out.toByteArray()
+}
+
+private fun encodeUnsigned(value: Int): ByteArray {
+    val out = ByteArrayOutputStream()
+    var remaining = value
+    do {
+        var byte = remaining and 0x7f
+        remaining = remaining ushr 7
+        if (remaining != 0) byte = byte or 0x80
+        out.write(byte)
+    } while (remaining != 0)
+    return out.toByteArray()
+}
+
+private fun encodeSigned(value: Int): ByteArray {
+    val out = ByteArrayOutputStream()
+    var remaining = value
+    var more: Boolean
+    do {
+        var byte = remaining and 0x7f
+        remaining = remaining shr 7
+        val signBit = byte and 0x40 != 0
+        more = !((remaining == 0 && !signBit) || (remaining == -1 && signBit))
+        if (more) byte = byte or 0x80
+        out.write(byte)
+    } while (more)
+    return out.toByteArray()
+}

--- a/code/packages/kotlin/brainfuck-wasm-compiler/src/main/kotlin/com/codingadventures/brainfuckwasmcompiler/BrainfuckWasmCompiler.kt
+++ b/code/packages/kotlin/brainfuck-wasm-compiler/src/main/kotlin/com/codingadventures/brainfuckwasmcompiler/BrainfuckWasmCompiler.kt
@@ -22,12 +22,16 @@ data class PackageResult(
 
 class PackageError(val stage: String, message: String) : RuntimeException(message)
 
+private data class ParsedProgram(val operations: List<Char>, val loopEnds: Map<Int, Int>)
+
 object BrainfuckWasmCompiler {
     const val VERSION = "0.1.0"
+    private const val MAX_SOURCE_LENGTH = 1_000_000
+    private const val MAX_LOOP_NESTING = 512
 
     fun compileSource(source: String): PackageResult {
-        val operations = parse(source)
-        return PackageResult(source, operations, emitModule(operations))
+        val program = parse(source)
+        return PackageResult(source, program.operations, emitModule(program))
     }
 
     fun packSource(source: String): PackageResult = compileSource(source)
@@ -42,25 +46,36 @@ object BrainfuckWasmCompiler {
         return result.copy(wasmPath = path)
     }
 
-    private fun parse(source: String): List<Char> {
+    private fun parse(source: String): ParsedProgram {
+        if (source.length > MAX_SOURCE_LENGTH) {
+            throw PackageError("parse", "source exceeds $MAX_SOURCE_LENGTH characters")
+        }
         val ops = mutableListOf<Char>()
-        var depth = 0
+        val stack = ArrayDeque<Int>()
+        val loopEnds = mutableMapOf<Int, Int>()
         source.forEachIndexed { index, ch ->
             if (ch !in "><+-.,[]") return@forEachIndexed
+            val opIndex = ops.size
             when (ch) {
-                '[' -> depth++
+                '[' -> {
+                    stack.addLast(opIndex)
+                    if (stack.size > MAX_LOOP_NESTING) {
+                        throw PackageError("parse", "loop nesting exceeds $MAX_LOOP_NESTING")
+                    }
+                }
                 ']' -> {
-                    depth--
-                    if (depth < 0) throw PackageError("parse", "unmatched ] at byte $index")
+                    if (stack.isEmpty()) throw PackageError("parse", "unmatched ] at byte $index")
+                    loopEnds[stack.removeLast()] = opIndex
                 }
             }
             ops += ch
         }
-        if (depth != 0) throw PackageError("parse", "unmatched [")
-        return ops
+        if (stack.isNotEmpty()) throw PackageError("parse", "unmatched [")
+        return ParsedProgram(ops.toList(), loopEnds.toMap())
     }
 
-    private fun emitModule(operations: List<Char>): ByteArray {
+    private fun emitModule(program: ParsedProgram): ByteArray {
+        val operations = program.operations
         val needsWrite = '.' in operations
         val needsRead = ',' in operations
         val importCount = (if (needsWrite) 1 else 0) + (if (needsRead) 1 else 0)
@@ -105,7 +120,7 @@ object BrainfuckWasmCompiler {
         module.write(section(7, exports.bytes()))
 
         val code = Section()
-        val body = functionBody(operations, writeIndex, readIndex)
+        val body = functionBody(program, writeIndex, readIndex)
         code.u32(1)
         code.u32(body.size)
         code.write(body)
@@ -113,17 +128,17 @@ object BrainfuckWasmCompiler {
         return module.bytes()
     }
 
-    private fun functionBody(operations: List<Char>, writeIndex: Int, readIndex: Int): ByteArray {
+    private fun functionBody(program: ParsedProgram, writeIndex: Int, readIndex: Int): ByteArray {
         val body = Section()
         body.u32(1)
         body.u32(3)
         body.write(0x7f)
-        emitOps(body, operations, 0, operations.size, writeIndex, readIndex)
+        emitOps(body, program.operations, program.loopEnds, 0, program.operations.size, writeIndex, readIndex)
         body.write(0x0b)
         return body.bytes()
     }
 
-    private fun emitOps(out: Section, ops: List<Char>, start: Int, end: Int, writeIndex: Int, readIndex: Int) {
+    private fun emitOps(out: Section, ops: List<Char>, loopEnds: Map<Int, Int>, start: Int, end: Int, writeIndex: Int, readIndex: Int) {
         var index = start
         while (index < end) {
             when (ops[index]) {
@@ -134,7 +149,7 @@ object BrainfuckWasmCompiler {
                 '.' -> emitWrite(out, writeIndex)
                 ',' -> emitRead(out, readIndex)
                 '[' -> {
-                    val close = matchingClose(ops, index)
+                    val close = loopEnds[index] ?: throw PackageError("encode", "missing loop pair at operation $index")
                     out.write(0x02)
                     out.write(0x40)
                     out.write(0x03)
@@ -143,7 +158,7 @@ object BrainfuckWasmCompiler {
                     out.write(0x45)
                     out.write(0x0d)
                     out.u32(1)
-                    emitOps(out, ops, index + 1, close, writeIndex, readIndex)
+                    emitOps(out, ops, loopEnds, index + 1, close, writeIndex, readIndex)
                     out.write(0x0c)
                     out.u32(0)
                     out.write(0x0b)
@@ -153,20 +168,6 @@ object BrainfuckWasmCompiler {
             }
             index++
         }
-    }
-
-    private fun matchingClose(ops: List<Char>, open: Int): Int {
-        var depth = 0
-        for (index in open until ops.size) {
-            when (ops[index]) {
-                '[' -> depth++
-                ']' -> {
-                    depth--
-                    if (depth == 0) return index
-                }
-            }
-        }
-        throw PackageError("parse", "unmatched [")
     }
 
     private fun loadCell(out: Section) {

--- a/code/packages/kotlin/brainfuck-wasm-compiler/src/test/kotlin/com/codingadventures/brainfuckwasmcompiler/BrainfuckWasmCompilerTest.kt
+++ b/code/packages/kotlin/brainfuck-wasm-compiler/src/test/kotlin/com/codingadventures/brainfuckwasmcompiler/BrainfuckWasmCompilerTest.kt
@@ -1,0 +1,52 @@
+package com.codingadventures.brainfuckwasmcompiler
+
+import com.codingadventures.wasmruntime.WasmRuntime
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class BrainfuckWasmCompilerTest {
+    @Test
+    fun compilesSourceIntoWasmBytes() {
+        val result = BrainfuckWasmCompiler.compileSource("++>+")
+        assertTrue(result.wasmBytes.size > 8)
+        assertEquals(listOf('+', '+', '>', '+'), result.operations)
+    }
+
+    @Test
+    fun lowersLoopsIntoAValidModule() {
+        val result = BrainfuckWasmCompiler.compileSource("++[>+<-]")
+        assertNotNull(WasmRuntime().load(result.wasmBytes))
+    }
+
+    @Test
+    fun packSourceAliasesCompileSource() {
+        assertEquals(
+            BrainfuckWasmCompiler.compileSource("+").wasmBytes.size,
+            BrainfuckWasmCompiler.packSource("+").wasmBytes.size,
+        )
+    }
+
+    @Test
+    fun writesWasmBytes() {
+        val path = Files.createTempFile("kotlin-brainfuck", ".wasm")
+        val result = BrainfuckWasmCompiler.writeWasmFile("+", path)
+        assertEquals(path, result.wasmPath)
+        assertTrue(Files.size(path) > 8)
+    }
+
+    @Test
+    fun reportsMalformedLoops() {
+        val error = assertFailsWith<PackageError> { BrainfuckWasmCompiler.compileSource("[") }
+        assertEquals("parse", error.stage)
+    }
+
+    @Test
+    fun runsTapeMutationThroughRuntime() {
+        val result = BrainfuckWasmCompiler.compileSource("+")
+        assertEquals(emptyList(), WasmRuntime().loadAndRun(result.wasmBytes, "_start", emptyList()))
+    }
+}

--- a/code/packages/kotlin/brainfuck-wasm-compiler/src/test/kotlin/com/codingadventures/brainfuckwasmcompiler/BrainfuckWasmCompilerTest.kt
+++ b/code/packages/kotlin/brainfuck-wasm-compiler/src/test/kotlin/com/codingadventures/brainfuckwasmcompiler/BrainfuckWasmCompilerTest.kt
@@ -45,6 +45,13 @@ class BrainfuckWasmCompilerTest {
     }
 
     @Test
+    fun rejectsExcessiveLoopNesting() {
+        val source = "[".repeat(513) + "]".repeat(513)
+        val error = assertFailsWith<PackageError> { BrainfuckWasmCompiler.compileSource(source) }
+        assertEquals("parse", error.stage)
+    }
+
+    @Test
     fun runsTapeMutationThroughRuntime() {
         val result = BrainfuckWasmCompiler.compileSource("+")
         assertEquals(emptyList(), WasmRuntime().loadAndRun(result.wasmBytes, "_start", emptyList()))

--- a/code/packages/kotlin/nib-wasm-compiler/.gitignore
+++ b/code/packages/kotlin/nib-wasm-compiler/.gitignore
@@ -1,0 +1,3 @@
+.gradle/
+build/
+gradle-build/

--- a/code/packages/kotlin/nib-wasm-compiler/BUILD
+++ b/code/packages/kotlin/nib-wasm-compiler/BUILD
@@ -1,0 +1,1 @@
+gradle --no-daemon --no-build-cache --max-workers=1 -Dkotlin.compiler.execution.strategy=in-process -Dkotlin.incremental=false test

--- a/code/packages/kotlin/nib-wasm-compiler/BUILD
+++ b/code/packages/kotlin/nib-wasm-compiler/BUILD
@@ -1,1 +1,1 @@
-gradle --no-daemon --no-build-cache --max-workers=1 -Dkotlin.compiler.execution.strategy=in-process -Dkotlin.incremental=false test
+mkdir -p ../../../../.build-locks && while ! mkdir ../../../../.build-locks/jvm-wasm.lock 2>/dev/null; do sleep 1; done; gradle --no-daemon --no-build-cache --max-workers=1 -Dkotlin.compiler.execution.strategy=in-process -Dkotlin.incremental=false test; status=$?; rmdir ../../../../.build-locks/jvm-wasm.lock; exit $status

--- a/code/packages/kotlin/nib-wasm-compiler/BUILD_windows
+++ b/code/packages/kotlin/nib-wasm-compiler/BUILD_windows
@@ -1,0 +1,1 @@
+gradle --no-daemon --no-build-cache --max-workers=1 -Dkotlin.compiler.execution.strategy=in-process -Dkotlin.incremental=false test

--- a/code/packages/kotlin/nib-wasm-compiler/CHANGELOG.md
+++ b/code/packages/kotlin/nib-wasm-compiler/CHANGELOG.md
@@ -1,0 +1,5 @@
+# nib-wasm-compiler
+
+## 0.1.0
+
+- Add initial Kotlin Nib-to-Wasm convergence package.

--- a/code/packages/kotlin/nib-wasm-compiler/README.md
+++ b/code/packages/kotlin/nib-wasm-compiler/README.md
@@ -1,0 +1,5 @@
+# nib-wasm-compiler
+
+Native Kotlin Nib-to-Wasm package for the convergence subset. It parses simple
+`u4` functions, emits exported Wasm functions, and provides `compileSource`,
+`packSource`, and `writeWasmFile` helpers.

--- a/code/packages/kotlin/nib-wasm-compiler/build.gradle.kts
+++ b/code/packages/kotlin/nib-wasm-compiler/build.gradle.kts
@@ -1,0 +1,36 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation("com.codingadventures:wasm-runtime")
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/nib-wasm-compiler/settings.gradle.kts
+++ b/code/packages/kotlin/nib-wasm-compiler/settings.gradle.kts
@@ -1,0 +1,3 @@
+rootProject.name = "nib-wasm-compiler"
+
+includeBuild("../../java/wasm-runtime")

--- a/code/packages/kotlin/nib-wasm-compiler/src/main/kotlin/com/codingadventures/nibwasmcompiler/NibWasmCompiler.kt
+++ b/code/packages/kotlin/nib-wasm-compiler/src/main/kotlin/com/codingadventures/nibwasmcompiler/NibWasmCompiler.kt
@@ -1,0 +1,268 @@
+package com.codingadventures.nibwasmcompiler
+
+import java.io.ByteArrayOutputStream
+import java.nio.file.Files
+import java.nio.file.Path
+
+data class NibFunction(val name: String, val params: List<String>, val expression: String)
+
+data class PackageResult(
+    val source: String,
+    val functions: List<NibFunction>,
+    val wasmBytes: ByteArray,
+    val wasmPath: Path? = null,
+) {
+    override fun equals(other: Any?): Boolean =
+        other is PackageResult &&
+            source == other.source &&
+            functions == other.functions &&
+            wasmBytes.contentEquals(other.wasmBytes) &&
+            wasmPath == other.wasmPath
+
+    override fun hashCode(): Int = 31 * (31 * source.hashCode() + functions.hashCode()) + wasmBytes.contentHashCode()
+}
+
+class PackageError(val stage: String, message: String) : RuntimeException(message)
+
+object NibWasmCompiler {
+    const val VERSION = "0.1.0"
+    private val functionRegex =
+        Regex("""fn\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\)\s*->\s*u4\s*\{\s*return\s+([^;]+);\s*\}""", RegexOption.DOT_MATCHES_ALL)
+
+    fun compileSource(source: String): PackageResult {
+        val functions = parse(source)
+        validate(functions)
+        return PackageResult(source, functions, emitModule(functions))
+    }
+
+    fun packSource(source: String): PackageResult = compileSource(source)
+
+    fun writeWasmFile(source: String, path: Path): PackageResult {
+        val result = compileSource(source)
+        try {
+            Files.write(path, result.wasmBytes)
+        } catch (error: java.io.IOException) {
+            throw PackageError("write", error.message ?: "write failed")
+        }
+        return result.copy(wasmPath = path)
+    }
+
+    private fun parse(source: String): List<NibFunction> {
+        val functions = mutableListOf<NibFunction>()
+        var cursor = 0
+        for (match in functionRegex.findAll(source)) {
+            if (source.substring(cursor, match.range.first).trim().isNotEmpty()) {
+                throw PackageError("parse", "unexpected text before function")
+            }
+            functions += NibFunction(match.groupValues[1], parseParams(match.groupValues[2]), match.groupValues[3].trim())
+            cursor = match.range.last + 1
+        }
+        if (source.substring(cursor).trim().isNotEmpty() || functions.isEmpty()) {
+            throw PackageError("parse", "expected one or more Nib functions")
+        }
+        return functions
+    }
+
+    private fun parseParams(text: String): List<String> {
+        if (text.trim().isEmpty()) return emptyList()
+        return text.split(",").map { piece ->
+            val parts = piece.trim().split(Regex("""\s*:\s*"""))
+            if (parts.size != 2 || parts[1] != "u4" || !Regex("""[A-Za-z_][A-Za-z0-9_]*""").matches(parts[0])) {
+                throw PackageError("parse", "parameters must be `name: u4`")
+            }
+            parts[0]
+        }
+    }
+
+    private fun validate(functions: List<NibFunction>) {
+        val byName = functions.associateBy { it.name }
+        if (byName.size != functions.size) throw PackageError("validate", "duplicate function")
+        for (function in functions) {
+            emitExpr(Section(), function.expression, byName, function.params.withIndex().associate { it.value to it.index }, false)
+        }
+    }
+
+    private fun emitModule(functions: List<NibFunction>): ByteArray {
+        val module = Section()
+        module.write(byteArrayOf(0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00))
+
+        val types = Section()
+        types.u32(functions.size)
+        for (function in functions) types.funcType(function.params.size, 1)
+        module.write(section(1, types.bytes()))
+
+        val functionSection = Section()
+        functionSection.u32(functions.size)
+        functions.indices.forEach { functionSection.u32(it) }
+        module.write(section(3, functionSection.bytes()))
+
+        val exports = Section()
+        exports.u32(functions.size)
+        functions.forEachIndexed { index, function -> exports.export(function.name, 0x00, index) }
+        module.write(section(7, exports.bytes()))
+
+        val byName = functions.associateBy { it.name }
+        val code = Section()
+        code.u32(functions.size)
+        for (function in functions) {
+            val body = Section()
+            body.u32(0)
+            emitExpr(body, function.expression, byName, function.params.withIndex().associate { it.value to it.index }, true)
+            body.write(0x0b)
+            val bytes = body.bytes()
+            code.u32(bytes.size)
+            code.write(bytes)
+        }
+        module.write(section(10, code.bytes()))
+        return module.bytes()
+    }
+
+    private fun emitExpr(out: Section, expression: String, functions: Map<String, NibFunction>, params: Map<String, Int>, emit: Boolean) {
+        val addParts = splitTopLevel(expression, "+%")
+        if (addParts.size > 1) {
+            emitExpr(out, addParts.first(), functions, params, emit)
+            addParts.drop(1).forEach {
+                emitExpr(out, it, functions, params, emit)
+                if (emit) {
+                    out.write(0x6a)
+                    out.i32(15)
+                    out.write(0x71)
+                }
+            }
+            return
+        }
+        val trimmed = expression.trim()
+        val literal = trimmed.toIntOrNull()
+        if (literal != null) {
+            if (literal !in 0..15) throw PackageError("validate", "u4 literal out of range: $literal")
+            if (emit) out.i32(literal)
+            return
+        }
+        val call = Regex("""([A-Za-z_][A-Za-z0-9_]*)\s*\((.*)\)""").matchEntire(trimmed)
+        if (call != null) {
+            val target = functions[call.groupValues[1]] ?: throw PackageError("validate", "unknown function `${call.groupValues[1]}`")
+            val args = splitArgs(call.groupValues[2])
+            if (args.size != target.params.size) throw PackageError("validate", "wrong arity for `${target.name}`")
+            args.forEach { emitExpr(out, it, functions, params, emit) }
+            if (emit) {
+                out.write(0x10)
+                out.u32(functions.keys.indexOf(target.name))
+            }
+            return
+        }
+        val paramIndex = params[trimmed]
+        if (paramIndex != null) {
+            if (emit) {
+                out.write(0x20)
+                out.u32(paramIndex)
+            }
+            return
+        }
+        throw PackageError("validate", "unsupported expression `$expression`")
+    }
+
+    private fun splitArgs(text: String): List<String> = if (text.trim().isEmpty()) emptyList() else splitTopLevel(text, ",")
+
+    private fun splitTopLevel(text: String, delimiter: String): List<String> {
+        val parts = mutableListOf<String>()
+        var depth = 0
+        var start = 0
+        var index = 0
+        while (index < text.length) {
+            when (text[index]) {
+                '(' -> depth++
+                ')' -> depth--
+            }
+            if (depth == 0 && text.startsWith(delimiter, index)) {
+                parts += text.substring(start, index).trim()
+                start = index + delimiter.length
+                index += delimiter.length
+                continue
+            }
+            index++
+        }
+        parts += text.substring(start).trim()
+        return parts
+    }
+
+    private fun section(id: Int, payload: ByteArray): ByteArray =
+        Section().apply {
+            write(id)
+            u32(payload.size)
+            write(payload)
+        }.bytes()
+}
+
+private class Section {
+    private val out = ByteArrayOutputStream()
+
+    fun write(value: Int) {
+        out.write(value and 0xff)
+    }
+
+    fun write(bytes: ByteArray) {
+        out.write(bytes)
+    }
+
+    fun i32(value: Int) {
+        write(0x41)
+        s32(value)
+    }
+
+    fun u32(value: Int) {
+        write(encodeUnsigned(value))
+    }
+
+    fun s32(value: Int) {
+        write(encodeSigned(value))
+    }
+
+    fun funcType(paramCount: Int, resultCount: Int) {
+        write(0x60)
+        u32(paramCount)
+        repeat(paramCount) { write(0x7f) }
+        u32(resultCount)
+        repeat(resultCount) { write(0x7f) }
+    }
+
+    fun export(name: String, kind: Int, index: Int) {
+        name(name)
+        write(kind)
+        u32(index)
+    }
+
+    private fun name(value: String) {
+        val bytes = value.encodeToByteArray()
+        u32(bytes.size)
+        write(bytes)
+    }
+
+    fun bytes(): ByteArray = out.toByteArray()
+}
+
+private fun encodeUnsigned(value: Int): ByteArray {
+    val out = ByteArrayOutputStream()
+    var remaining = value
+    do {
+        var byte = remaining and 0x7f
+        remaining = remaining ushr 7
+        if (remaining != 0) byte = byte or 0x80
+        out.write(byte)
+    } while (remaining != 0)
+    return out.toByteArray()
+}
+
+private fun encodeSigned(value: Int): ByteArray {
+    val out = ByteArrayOutputStream()
+    var remaining = value
+    var more: Boolean
+    do {
+        var byte = remaining and 0x7f
+        remaining = remaining shr 7
+        val signBit = byte and 0x40 != 0
+        more = !((remaining == 0 && !signBit) || (remaining == -1 && signBit))
+        if (more) byte = byte or 0x80
+        out.write(byte)
+    } while (more)
+    return out.toByteArray()
+}

--- a/code/packages/kotlin/nib-wasm-compiler/src/main/kotlin/com/codingadventures/nibwasmcompiler/NibWasmCompiler.kt
+++ b/code/packages/kotlin/nib-wasm-compiler/src/main/kotlin/com/codingadventures/nibwasmcompiler/NibWasmCompiler.kt
@@ -26,6 +26,8 @@ class PackageError(val stage: String, message: String) : RuntimeException(messag
 
 object NibWasmCompiler {
     const val VERSION = "0.1.0"
+    private const val MAX_SOURCE_LENGTH = 1_000_000
+    private const val MAX_EXPR_NESTING = 256
     private val functionRegex =
         Regex("""fn\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\)\s*->\s*u4\s*\{\s*return\s+([^;]+);\s*\}""", RegexOption.DOT_MATCHES_ALL)
 
@@ -48,6 +50,9 @@ object NibWasmCompiler {
     }
 
     private fun parse(source: String): List<NibFunction> {
+        if (source.length > MAX_SOURCE_LENGTH) {
+            throw PackageError("parse", "source exceeds $MAX_SOURCE_LENGTH characters")
+        }
         val functions = mutableListOf<NibFunction>()
         var cursor = 0
         for (match in functionRegex.findAll(source)) {
@@ -78,7 +83,7 @@ object NibWasmCompiler {
         val byName = functions.associateBy { it.name }
         if (byName.size != functions.size) throw PackageError("validate", "duplicate function")
         for (function in functions) {
-            emitExpr(Section(), function.expression, byName, function.params.withIndex().associate { it.value to it.index }, false)
+            emitExpr(Section(), function.expression, byName, function.params.withIndex().associate { it.value to it.index }, false, 0)
         }
     }
 
@@ -107,7 +112,7 @@ object NibWasmCompiler {
         for (function in functions) {
             val body = Section()
             body.u32(0)
-            emitExpr(body, function.expression, byName, function.params.withIndex().associate { it.value to it.index }, true)
+            emitExpr(body, function.expression, byName, function.params.withIndex().associate { it.value to it.index }, true, 0)
             body.write(0x0b)
             val bytes = body.bytes()
             code.u32(bytes.size)
@@ -117,12 +122,15 @@ object NibWasmCompiler {
         return module.bytes()
     }
 
-    private fun emitExpr(out: Section, expression: String, functions: Map<String, NibFunction>, params: Map<String, Int>, emit: Boolean) {
+    private fun emitExpr(out: Section, expression: String, functions: Map<String, NibFunction>, params: Map<String, Int>, emit: Boolean, depth: Int) {
+        if (depth > MAX_EXPR_NESTING) {
+            throw PackageError("validate", "expression nesting exceeds $MAX_EXPR_NESTING")
+        }
         val addParts = splitTopLevel(expression, "+%")
         if (addParts.size > 1) {
-            emitExpr(out, addParts.first(), functions, params, emit)
+            emitExpr(out, addParts.first(), functions, params, emit, depth + 1)
             addParts.drop(1).forEach {
-                emitExpr(out, it, functions, params, emit)
+                emitExpr(out, it, functions, params, emit, depth + 1)
                 if (emit) {
                     out.write(0x6a)
                     out.i32(15)
@@ -143,7 +151,7 @@ object NibWasmCompiler {
             val target = functions[call.groupValues[1]] ?: throw PackageError("validate", "unknown function `${call.groupValues[1]}`")
             val args = splitArgs(call.groupValues[2])
             if (args.size != target.params.size) throw PackageError("validate", "wrong arity for `${target.name}`")
-            args.forEach { emitExpr(out, it, functions, params, emit) }
+            args.forEach { emitExpr(out, it, functions, params, emit, depth + 1) }
             if (emit) {
                 out.write(0x10)
                 out.u32(functions.keys.indexOf(target.name))

--- a/code/packages/kotlin/nib-wasm-compiler/src/test/kotlin/com/codingadventures/nibwasmcompiler/NibWasmCompilerTest.kt
+++ b/code/packages/kotlin/nib-wasm-compiler/src/test/kotlin/com/codingadventures/nibwasmcompiler/NibWasmCompilerTest.kt
@@ -49,4 +49,15 @@ class NibWasmCompilerTest {
         val error = assertFailsWith<PackageError> { NibWasmCompiler.compileSource("fn bad() -> u4 { return 99; }") }
         assertEquals("validate", error.stage)
     }
+
+    @Test
+    fun rejectsExcessiveExpressionNesting() {
+        var expression = "0"
+        repeat(258) {
+            expression = "id($expression)"
+        }
+        val source = "fn id(x: u4) -> u4 { return x; }\nfn main() -> u4 { return $expression; }"
+        val error = assertFailsWith<PackageError> { NibWasmCompiler.compileSource(source) }
+        assertEquals("validate", error.stage)
+    }
 }

--- a/code/packages/kotlin/nib-wasm-compiler/src/test/kotlin/com/codingadventures/nibwasmcompiler/NibWasmCompilerTest.kt
+++ b/code/packages/kotlin/nib-wasm-compiler/src/test/kotlin/com/codingadventures/nibwasmcompiler/NibWasmCompilerTest.kt
@@ -1,0 +1,52 @@
+package com.codingadventures.nibwasmcompiler
+
+import com.codingadventures.wasmruntime.WasmRuntime
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class NibWasmCompilerTest {
+    @Test
+    fun compilesSimpleFunction() {
+        val result = NibWasmCompiler.compileSource("fn answer() -> u4 { return 7; }")
+        assertTrue(result.wasmBytes.size > 8)
+        assertEquals("answer", result.functions.first().name)
+    }
+
+    @Test
+    fun aliasesPackSource() {
+        assertEquals(
+            NibWasmCompiler.compileSource("fn answer() -> u4 { return 7; }").wasmBytes.size,
+            NibWasmCompiler.packSource("fn answer() -> u4 { return 7; }").wasmBytes.size,
+        )
+    }
+
+    @Test
+    fun runsAnswerThroughRuntime() {
+        val result = NibWasmCompiler.compileSource("fn answer() -> u4 { return 7; }")
+        assertEquals(listOf(7), WasmRuntime().loadAndRun(result.wasmBytes, "answer", emptyList()))
+    }
+
+    @Test
+    fun runsWrappingAdditionThroughRuntime() {
+        val source = "fn add(a: u4, b: u4) -> u4 { return a +% b; }"
+        val result = NibWasmCompiler.compileSource(source)
+        assertEquals(listOf(3), WasmRuntime().loadAndRun(result.wasmBytes, "add", listOf(14, 5)))
+    }
+
+    @Test
+    fun writesWasmBytes() {
+        val path = Files.createTempFile("kotlin-nib", ".wasm")
+        val result = NibWasmCompiler.writeWasmFile("fn answer() -> u4 { return 7; }", path)
+        assertEquals(path, result.wasmPath)
+        assertTrue(Files.size(path) > 8)
+    }
+
+    @Test
+    fun reportsInvalidNib() {
+        val error = assertFailsWith<PackageError> { NibWasmCompiler.compileSource("fn bad() -> u4 { return 99; }") }
+        assertEquals("validate", error.stage)
+    }
+}

--- a/code/specs/04o-java-kotlin-wasm-convergence.md
+++ b/code/specs/04o-java-kotlin-wasm-convergence.md
@@ -1,0 +1,122 @@
+# 04o - Java and Kotlin Brainfuck/Nib Wasm Convergence
+
+## Goal
+
+Close the Java and Kotlin source-to-Wasm pipeline gap for the two compiler
+frontends that the repo treats as convergence canaries:
+
+```text
+Brainfuck source -> brainfuck-wasm-compiler -> .wasm bytes
+Nib source       -> nib-wasm-compiler       -> .wasm bytes
+```
+
+This batch intentionally follows the Haskell wave and precedes the C#/F# wave.
+The Java and Kotlin package roots already have Wasm parser/runtime components,
+but they do not yet have a Wasm module encoder or generic compiler IR stack.
+For this convergence pass, each source-to-Wasm package may therefore emit the
+small Wasm binary subset it owns directly.
+
+## Package Set
+
+The batch adds four publishable package directories:
+
+- `code/packages/java/brainfuck-wasm-compiler`
+- `code/packages/java/nib-wasm-compiler`
+- `code/packages/kotlin/brainfuck-wasm-compiler`
+- `code/packages/kotlin/nib-wasm-compiler`
+
+Each package must include:
+
+- `BUILD`
+- `BUILD_windows`
+- `.gitignore`
+- `README.md`
+- `CHANGELOG.md`
+- `build.gradle.kts`
+- `settings.gradle.kts`
+- unit tests
+
+## Brainfuck Contract
+
+The Java and Kotlin Brainfuck packages must:
+
+- accept Brainfuck source as a string
+- ignore non-Brainfuck comment characters
+- validate balanced loops
+- expose `compileSource`, `packSource`, and `writeWasmFile`
+- return a result object containing source text, normalized operations, Wasm
+  bytes, and optional write path
+- emit a valid Wasm module exporting `_start`
+
+The emitted module must include linear memory and must support the complete
+Brainfuck instruction alphabet: `>`, `<`, `+`, `-`, `.`, `,`, `[`, and `]`.
+Runtime smoke tests may use non-I/O programs so they do not depend on host WASI
+behavior.
+
+## Nib Contract
+
+The Java and Kotlin Nib packages must:
+
+- accept Nib source as a string
+- support the convergence subset:
+  - top-level `fn`
+  - zero or more `u4` parameters
+  - `return`
+  - integer literals in the `0..15` range
+  - name references
+  - function calls
+  - wrapping addition via `+%`
+- expose `compileSource`, `packSource`, and `writeWasmFile`
+- derive Wasm exports from source functions
+- return a result object containing source text, parsed function metadata, Wasm
+  bytes, and optional write path
+
+Nib functions compile to exported Wasm functions with `i32` parameters and an
+`i32` result. The `_start` export is optional for this batch because Nib smoke
+tests exercise named exported functions directly.
+
+## Error Model
+
+Each package must use stage-rich errors where practical:
+
+- `parse`
+- `validate`
+- `encode`
+- `write`
+
+The packages should fail closed on malformed source rather than emitting a
+partial module.
+
+## Tests
+
+Each package must cover:
+
+- successful `compileSource`
+- `packSource` alias behavior
+- `writeWasmFile`
+- malformed source errors
+- runtime execution through the existing local Wasm runtime for at least one
+  emitted module
+
+Preferred runtime smokes:
+
+- Brainfuck: `+` runs exported `_start`
+- Nib: `fn answer() -> u4 { return 7; }` runs exported `answer`
+- Nib: `fn add(a: u4, b: u4) -> u4 { return a +% b; }` runs exported `add`
+
+## Non-Goals
+
+This batch does not:
+
+- add a Java/Kotlin generic compiler IR package
+- add a Java/Kotlin Wasm module encoder package
+- add Java/Kotlin JVM class-file generation
+- complete the C#/F# convergence batch
+- support the full Nib language beyond the convergence subset
+
+## Completion Definition
+
+The batch is complete when Java and Kotlin each have local Brainfuck-to-Wasm
+and Nib-to-Wasm packages, package-local tests pass, the build-plan validator
+does not report new Java/Kotlin dependency issues, and the branch passes
+security review before push.

--- a/lessons.md
+++ b/lessons.md
@@ -4,6 +4,24 @@ This file tracks mistakes made during development so they are not repeated. Chec
 
 ---
 
+### 2026-04-19: JVM composite Gradle BUILD files need a shared lock when they reuse included builds
+
+Java and Kotlin packages that include the same local Gradle builds can corrupt
+shared `gradle-build` class outputs when the repo build tool runs sibling
+packages in parallel.
+
+**Symptom:** CI fails with a Java compiler error like `bad class file ...
+class file truncated at offset 0` inside a shared dependency such as
+`java/wasm-types`, even though each package passes when run alone.
+
+**Rule:** When adding multiple JVM packages that point at the same local
+included Gradle builds, serialize the Unix `BUILD` commands with a shared
+repo-local lock and run Gradle with `--no-daemon --no-build-cache --max-workers=1`.
+Keep the lock in the package BUILD scripts so CI's parallel package scheduler
+cannot race the shared composite outputs.
+
+---
+
 ### 2026-04-18: LuaRocks CI installs may need patched GitHub archive URLs for old rockspecs
 
 Some published LuaRocks rockspecs still point at legacy GitHub archive URLs


### PR DESCRIPTION
## Summary

- Add Java and Kotlin Brainfuck-to-Wasm compiler packages.
- Add Java and Kotlin Nib-to-Wasm compiler packages.
- Add convergence spec plus package BUILD files, Gradle metadata, README files, changelogs, and runtime-backed tests.
- Harden Brainfuck loop parsing and Nib expression lowering against adversarial nesting during security review.

## Verification

- gradle test in code/packages/java/brainfuck-wasm-compiler
- gradle test in code/packages/java/nib-wasm-compiler
- gradle --no-daemon --no-build-cache --max-workers=1 -Dkotlin.compiler.execution.strategy=in-process -Dkotlin.incremental=false test in code/packages/kotlin/brainfuck-wasm-compiler
- gradle --no-daemon --no-build-cache --max-workers=1 -Dkotlin.compiler.execution.strategy=in-process -Dkotlin.incremental=false test in code/packages/kotlin/nib-wasm-compiler
- build-plan validator sees 4 changed packages; remaining failures are existing Swift/TypeScript/Dart BUILD metadata issues
- security review passed after fixing two medium DoS findings