### PR TITLE
spec(txt01): FontMetrics adapter over font-parser (FNT00)

### DIFF
--- a/code/specs/TXT00-text-interfaces.md
+++ b/code/specs/TXT00-text-interfaces.md
@@ -1,0 +1,598 @@
+# TXT00 — Text Interfaces: FontMetrics, TextShaper, TextMeasurer
+
+## Overview
+
+TXT00 defines the three **independent, pluggable interfaces** that sit between
+the layout layer and the paint layer for all text rendering in the
+coding-adventures stack.
+
+```
+Document producer (CommonMark parser, LaTeX parser, chart generator)
+    │
+    ▼
+Layout engine  ─────────── asks about font globals ──▶  FontMetrics    (TXT00)
+    │                ─────── asks to shape strings ───▶  TextShaper    (TXT00)
+    │                ───── asks for a line width ─────▶  TextMeasurer  (TXT00)
+    │
+    ▼  emits positioned glyph runs
+PaintScene (P2D00)  — contains PaintGlyphRun instructions
+    │
+    ▼
+PaintVM (P2D01)  →  backend glyph rasterizer  →  pixels
+```
+
+The three interfaces are deliberately **orthogonal**. A consumer can mix and
+match implementations: a `font-parser`-backed `FontMetrics`, a hand-written
+HarfBuzz-style `TextShaper`, and the default `TextMeasurer`. Swapping one
+does not force re-implementation of the others.
+
+This separation is the central design commitment of this spec. Every
+implementation package (TXT01, TXT02, TXT03, TXT04) targets exactly one of the
+three interfaces. No package is allowed to bundle metrics retrieval with
+shaping or shaping with measurement.
+
+### What text is, in this stack
+
+Text rendering is a four-stage pipeline. Each stage has distinct inputs,
+outputs, and failure modes. This spec covers the first three stages; the
+fourth is owned by the paint backends (P2D02–P2D05).
+
+```
+Stage 1 — FontMetrics         font handle       → global metrics (ascent, x-height, …)
+Stage 2 — TextShaper          codepoints + font → positioned glyph run
+Stage 3 — TextMeasurer        shaper output     → bounding box / line count
+Stage 4 — Paint rasterizer    glyph run         → pixels
+```
+
+Only stage 2 (shaping) is computationally heavy and algorithmically subtle.
+Stages 1 and 3 are cheap and mechanical. Splitting them into separate
+interfaces prevents a "simple measurement" request from dragging in a full
+shaping implementation, and conversely lets a complex shaper be written
+without re-implementing metrics lookup.
+
+---
+
+## Why three interfaces and not one
+
+A naive design would fold all three concerns into a single `TextEngine` trait
+with `measure()`, `shape()`, and `metrics()` methods. This spec rejects that
+design for three reasons:
+
+1. **Shaping is pluggable, metrics is trivial.** Text shaping is an
+   open-ended research problem (GSUB, GPOS, complex scripts, OpenType
+   feature tuning). A contributor writing a new shaper should not have to
+   re-derive `ascent` from the `hhea` table — that is a 20-line function
+   that lives in `font-parser`. Keeping metrics in its own trait means every
+   shaper gets metrics for free, and a metrics-only consumer (e.g., a
+   line-height calculation in a layout engine) doesn't drag in a shaper.
+
+2. **Measurement is usually a thin wrapper over shaping.** The width of a
+   shaped line is the sum of its glyph advances. If measurement is its own
+   trait, every implementation re-implements the same summation. If
+   measurement is instead a function that *takes* a shaper, the logic is
+   written once and every new shaper automatically gets measurement.
+
+3. **Pluggability is asymmetric across the three.** Expect many
+   `TextShaper` implementations (device-independent, CoreText, DirectWrite,
+   Pango, and hand-rolled HarfBuzz-likes). Expect few `FontMetrics`
+   implementations — font-parser is enough for most use cases. Expect zero
+   third-party `TextMeasurer` implementations, since the default one (shape
+   + sum advances) is correct by construction. Splitting the traits lets
+   each interface evolve at its own rate.
+
+---
+
+## Interface 1: FontMetrics
+
+```
+FontMetrics {
+  // All values are in the font's design units unless otherwise noted.
+  // Divide by units_per_em and multiply by font_size to convert to user-space.
+
+  units_per_em(font: FontHandle) → int
+  // The font's design grid size. Common values: 1000 (PostScript), 2048
+  // (TrueType), 1024 (some Asian fonts). A glyph 1000 units wide in a
+  // font with units_per_em=2048 is half an em wide.
+
+  ascent(font: FontHandle)      → int
+  // Distance from baseline to the top of the tallest glyph (positive).
+  // Used to compute the top of a line of text: line_top = baseline - ascent.
+
+  descent(font: FontHandle)     → int
+  // Distance from baseline to the bottom of the deepest descender
+  // (returned as a NON-NEGATIVE integer; the sign convention is
+  // "distance below baseline", not the signed value from the hhea table).
+
+  line_gap(font: FontHandle)    → int
+  // Recommended extra vertical space between consecutive lines of text.
+  // Typical line height = (ascent + descent + line_gap) * font_size / units_per_em.
+
+  x_height(font: FontHandle)    → int | null
+  // Height of lowercase 'x' above the baseline. Null if the font does not
+  // define it (older TrueType fonts without OS/2 table, or symbol fonts).
+
+  cap_height(font: FontHandle)  → int | null
+  // Height of a capital 'H' above the baseline. Null if not defined.
+
+  family_name(font: FontHandle) → string
+  // Human-readable family name from the font's `name` table.
+  // Used for debug output, not for resolution. FontResolver (TXT05) owns
+  // the mapping from name strings to FontHandle values.
+}
+```
+
+### What goes in FontMetrics and what does not
+
+FontMetrics is a **global** view of a font. Nothing in this interface takes
+a string, a codepoint, or a glyph ID. Anything per-character is shaping
+territory.
+
+Specifically, the following are NOT in FontMetrics:
+
+- **Glyph advance widths** — per-glyph, belongs in the shaper's output.
+- **Kerning pair lookups** — per-glyph-pair, belongs in the shaper.
+- **cmap lookup (codepoint → glyph_id)** — per-codepoint, belongs in the
+  shaper.
+- **Glyph bounding boxes** — per-glyph, belongs in glyph-parser (FNT02).
+- **Glyph outlines** — per-glyph raster data, belongs in glyph-parser.
+
+A consumer that only needs line height calls FontMetrics. A consumer that
+needs to know how wide "Hello" is calls a TextShaper. This split keeps the
+cheap path cheap.
+
+### Why `FontHandle` and not a font file path
+
+The `FontHandle` type is **implementation-defined** by each FontMetrics
+backend. For the font-parser backend it is a parsed-font struct. For the
+CoreText backend it is a `CTFontRef`. For the DirectWrite backend it is an
+`IDWriteFont`. FontMetrics does not specify how handles are created; that
+is FontResolver's job (TXT05).
+
+The contract is: **a handle obtained from one backend's resolver is only
+valid with that backend's FontMetrics and TextShaper**. This is enforced
+by the font-binding invariant (see below).
+
+---
+
+## Interface 2: TextShaper
+
+```
+TextShaper {
+  shape(
+    text:     string,
+    font:     FontHandle,
+    size:     float,             // in user-space units (typically pixels)
+    options:  ShapeOptions
+  ) → ShapedRun
+
+  // The shaper MUST also expose the font_ref string that is safe to embed
+  // in PaintGlyphRun.font_ref. This is how the paint backend knows which
+  // rasterizer to use. See "The font-binding invariant" below.
+  font_ref(font: FontHandle) → string
+}
+
+ShapeOptions {
+  script:    string | null
+  // ISO-15924 script code, e.g. "Latn", "Arab", "Hans", "Deva".
+  // Null = auto-detect from the text's dominant script.
+  // Shapers that do not support a script (e.g., a Latin-only shaper asked
+  // for "Arab") MUST throw UnsupportedScriptError, not silently fall back.
+
+  language:  string | null
+  // BCP-47 language tag, e.g. "en", "tr", "vi". Affects shaping for
+  // language-specific OpenType features (e.g., Turkish dotted-i).
+  // Null = no language hint; shapers use their default mapping.
+
+  direction: "ltr" | "rtl" | "ttb" | "btt"
+  // Explicit direction. Bidi resolution is NOT done by the shaper — the
+  // caller must split mixed-direction text into runs before calling.
+
+  features:  { [tag: string]: bool | int }
+  // OpenType feature toggles. Keys are 4-character OT tags ("liga", "kern",
+  // "smcp", "ss01", …). Values are bool (on/off) or int (alt index).
+  // Shapers that do not understand a tag MUST ignore it silently.
+  // Shapers that support a tag MUST default to the OpenType-recommended
+  // default state when the tag is absent.
+}
+
+ShapedRun {
+  glyphs: Array<{
+    glyph_id:  int      // backend-specific glyph ID — only meaningful to
+                        // the shaper that produced it AND to a rasterizer
+                        // bound to the same font.
+    cluster:   int      // byte offset into the original text string for
+                        // the codepoint(s) this glyph represents. Used for
+                        // cursor positioning and hit-testing.
+    x_advance: float    // how far the pen moves after this glyph, in
+                        // user-space units at the requested size.
+    y_advance: float    // usually 0 for horizontal text, non-zero for
+                        // vertical writing.
+    x_offset:  float    // position adjustment for this glyph relative to
+                        // the pen (e.g., for combining marks, kerning).
+    y_offset:  float    // vertical offset (e.g., superscript, diacritics).
+  }>;
+
+  // Total advance width of the run, equal to sum of glyph x_advance values.
+  // Pre-computed so consumers don't re-sum it.
+  x_advance_total: float
+
+  // The font_ref string for the font binding that produced these glyph IDs.
+  // MUST be embedded verbatim in any PaintGlyphRun that renders this run.
+  font_ref: string
+}
+```
+
+### What the shaper does, step by step
+
+A shaper implementation is free to use any algorithm it wants, but
+conceptually the pipeline is:
+
+```
+1. Unicode normalization     (NFC by default; not the shaper's job to re-do)
+2. Script/language tagging   (from ShapeOptions or auto-detection)
+3. cmap lookup               (codepoint → glyph_id via font's cmap table)
+4. Apply GSUB substitutions  (ligatures, contextual forms, stylistic sets)
+5. Apply GPOS positioning    (kerning, mark positioning, cursive attachment)
+6. Apply fallback kerning    (if no GPOS, use the legacy 'kern' table)
+7. Emit ShapedRun            (glyph_id + advance + offset per glyph)
+```
+
+A **naive shaper** (TXT02) skips steps 4 and 5 entirely, emits one glyph per
+codepoint via cmap, and optionally applies legacy `kern`. This is enough
+for basic Latin rendering of CommonMark content and is the minimum viable
+implementation.
+
+A **full shaper** (TXT04, hand-rolled HarfBuzz-like) implements the entire
+OpenType shaping pipeline. This spec does not prescribe the algorithm.
+What it prescribes is the *interface* — any shaper that produces a valid
+`ShapedRun` for a given input is a conforming implementation, regardless of
+which OpenType features it supports or how it implements them.
+
+### What the shaper does NOT do
+
+- **Line breaking.** Shapers receive a single line (or a single
+  directional run). Breaking text into lines that fit a width is the
+  layout engine's job, using measurement in a feedback loop.
+- **Bidi resolution.** The layout engine splits mixed-direction text into
+  uniform-direction runs before calling the shaper. The Unicode Bidi
+  Algorithm (UAX #9) is a separate concern.
+- **Vertical metrics for line height.** That is FontMetrics.
+- **Font fallback for missing glyphs.** If the shaper encounters a
+  codepoint that the font cannot map, it emits the font's `.notdef` glyph
+  (conventionally glyph_id 0). Cross-font fallback ("if this font lacks
+  it, try another") is a higher-level concern owned by the layout engine
+  or a wrapping shaper.
+
+---
+
+## Interface 3: TextMeasurer
+
+`TextMeasurer` is **not a parallel trait**. It is a concrete function that
+wraps a `TextShaper` and returns a bounding box.
+
+```
+MeasureResult {
+  width:      float   // total x-advance of the shaped run
+  ascent:     float   // in user-space units at the requested size
+  descent:    float   // in user-space units, non-negative
+  line_count: int     // 1 for single-line; >1 if wrapped (see below)
+}
+
+measure(
+  shaper:   TextShaper,
+  metrics:  FontMetrics,
+  text:     string,
+  font:     FontHandle,
+  size:     float,
+  max_width: float | null,
+  options:  ShapeOptions
+) → MeasureResult
+```
+
+### The default implementation
+
+```
+function measure(shaper, metrics, text, font, size, max_width, options):
+  if max_width is null:
+    run = shaper.shape(text, font, size, options)
+    units_per_em = metrics.units_per_em(font)
+    scale = size / units_per_em
+    return MeasureResult {
+      width:      run.x_advance_total,
+      ascent:     metrics.ascent(font)  * scale,
+      descent:    metrics.descent(font) * scale,
+      line_count: 1
+    }
+
+  // Wrapped path: shape the whole string, then walk glyphs to find
+  // word-break opportunities that fit in max_width.
+  run = shaper.shape(text, font, size, options)
+  lines = greedy_wrap(run, max_width, text)  // splits on Unicode line break opportunities
+  return MeasureResult {
+    width:      max(line.x_advance_total for line in lines),
+    ascent:     metrics.ascent(font)  * scale,
+    descent:    (metrics.descent(font) + metrics.line_gap(font)) * scale * (len(lines) - 1)
+                + metrics.descent(font) * scale,
+    line_count: len(lines)
+  }
+```
+
+`greedy_wrap` uses the `cluster` field in each glyph to map back to
+codepoint positions and split on line-break opportunities (UAX #14).
+Line breaking is described in more detail in TXT06 (future, optional).
+
+### Why measurement is not a trait
+
+A trait would imply there are meaningfully different ways to implement it.
+There aren't. Every correct implementation does the same thing: call the
+shaper, look at the total advance, optionally wrap, return the bounding
+box. Making it a trait would invite incorrect re-implementations that
+diverge from the shaper's view of the world (e.g., a measurer that sums
+advance widths from the font's `hmtx` table without going through the
+shaper, missing kerning and ligatures).
+
+Consumers that need to customize measurement (e.g., to add tracking or
+letter-spacing) should compose: call `shape()`, adjust advances, then
+sum. They do not need a new trait for that.
+
+---
+
+## The font-binding invariant
+
+This is the load-bearing rule of the entire text pipeline:
+
+> Glyph IDs are **opaque tokens** that belong to the font binding that
+> produced them. A `ShapedRun` produced by shaper A over font handle
+> `f_A` can only be correctly rendered by a rasterizer that understands
+> `f_A` through the same binding.
+
+In concrete terms:
+
+- Glyph IDs from a `font-parser`-backed shaper index into the font file's
+  `glyf` / `CFF` tables. A rasterizer that wants to draw these glyphs
+  must use `glyph-parser` (FNT02) to look up outlines in the same font
+  file.
+- Glyph IDs from CoreText are opaque `CGGlyph` values bound to a
+  specific `CTFontRef`. They can only be rendered via CoreText (e.g.,
+  `CTFontDrawGlyphs`) using the same `CTFontRef`.
+- Glyph IDs from DirectWrite are bound to an `IDWriteFontFace`. They can
+  only be rendered via `ID2D1RenderTarget::DrawGlyphRun` with the same
+  font face.
+
+Mixing bindings is undefined behavior. A `CGGlyph` value of 42 is not the
+same glyph as a font-parser glyph ID of 42 in the same font file. They
+happen to be derived from the same `glyf` table but they are routed
+through different code paths and may differ (e.g., CoreText synthesizes
+glyphs for characters missing from the font).
+
+### How the invariant is enforced in practice
+
+Every `ShapedRun` carries a `font_ref: string` field. Every
+`PaintGlyphRun` instruction carries the same `font_ref` field (defined in
+P2D00). Paint backends use `font_ref` as a routing key:
+
+```
+font_ref begins with "font-parser:" → use glyph-parser rasterization path
+font_ref begins with "coretext:"    → use CoreText drawing path
+font_ref begins with "directwrite:" → use DirectWrite drawing path
+font_ref begins with "pango:"       → use Pango/FreeType drawing path
+```
+
+A paint backend that encounters an unknown `font_ref` scheme MUST throw
+`UnsupportedFontBindingError`. This keeps wrong-binding bugs loud and
+early — the same principle as P2D01's `UnknownInstructionError`.
+
+The exact `font_ref` scheme strings are registered in TXT05 (FontResolver)
+so that there is a single source of truth.
+
+### Analogy
+
+This is the same invariant as file descriptors: a file descriptor of 3
+from process A is not meaningful to process B, even if both processes
+opened the same file. The OS kernel treats each process's descriptor
+table as a local namespace.
+
+Glyph IDs are shaper-local descriptors into a font-binding-local glyph
+table. They do not survive crossing the binding boundary.
+
+---
+
+## Relationship to P2D00 PaintGlyphRun
+
+`PaintGlyphRun` (defined in P2D00) is the wire-format output of shaping.
+Every `ShapedRun` maps directly to a `PaintGlyphRun`:
+
+```
+ShapedRun → PaintGlyphRun conversion (done by the layout engine):
+
+PaintGlyphRun {
+  kind:      "glyph_run",
+  x:         baseline_origin_x,       // layout engine's chosen baseline
+  y:         baseline_origin_y,
+  font_ref:  shaped_run.font_ref,     // propagated verbatim
+  font_size: size,                    // the size passed to shape()
+  glyphs:    shaped_run.glyphs.map(g => ({
+    glyph_id: g.glyph_id,
+    x_offset: g.x_offset,             // NOTE: relative to pen position,
+                                      // cumulative sum of x_advance is the pen.
+    y_offset: g.y_offset
+  })),
+  fill:      color_from_layout
+}
+```
+
+One subtlety: P2D00's `PaintGlyphRun.glyphs[i].x_offset` is the
+**absolute x offset from the baseline origin**, while the shaper's
+`ShapedRun.glyphs[i].x_offset` is a **per-glyph adjustment relative to
+the running pen position**. The conversion walks the run accumulating
+`x_advance` and adds `x_offset` to produce the baked absolute offset.
+This conversion is done once at layout time, so the paint VM never has
+to track a running pen.
+
+---
+
+## Relationship to UI09 (layout-text-measure)
+
+UI09 defines an earlier, simpler `TextMeasurer` interface that predates
+TXT00. TXT00 **supersedes UI09** as the canonical text interface spec.
+Implementations should migrate.
+
+Key differences:
+
+| Aspect                | UI09 `TextMeasurer`        | TXT00 three-trait split               |
+|-----------------------|----------------------------|---------------------------------------|
+| Scope                 | Measurement only           | Metrics + shaping + measurement       |
+| Output                | `{width, height, lineCount}` | `ShapedRun` (+ measurement wrapper)   |
+| Glyph positions       | Not exposed                | Full per-glyph positions              |
+| Pluggable shaping     | No                         | Yes — separate trait                  |
+| Font-binding explicit | No                         | Yes — `font_ref` contract             |
+| Feeds PaintGlyphRun   | Indirectly via UI04 rewrite | Directly — shaper output is the wire format |
+
+The UI09 measurer packages (`layout-text-measure-estimated`,
+`layout-text-measure-canvas`, `layout-text-measure-rs`) remain valid for
+callers that only need an approximate bounding box. They will be
+re-expressed over TXT00 in a follow-up:
+
+- `layout-text-measure-estimated` → a degenerate `TextShaper` that emits
+  one glyph per codepoint with constant advance, plus the default measurer.
+- `layout-text-measure-canvas` → a `TextShaper` wrapping
+  `ctx.measureText()`; does not expose real glyph positions but returns
+  correct widths.
+- `layout-text-measure-rs` → replaced by TXT01 + TXT02.
+
+UI09 will be marked "superseded by TXT00" in a future doc-only PR. No
+existing code is broken by this spec.
+
+---
+
+## Relationship to UI04 (layout-to-paint)
+
+UI04's current text section describes a simplified `PaintGlyphRun` with
+fields like `text`, `maxWidth`, and `align`. This is **inconsistent with
+P2D00's actual `PaintGlyphRun`**, which uses pre-shaped glyph IDs.
+
+UI04 will be amended in a follow-up to:
+
+1. Stop carrying `text` in paint instructions — strings are layout-layer
+   only, converted to shaped glyphs before the paint layer sees them.
+2. Drop `maxWidth` and `align` — these are layout-time concerns that
+   must be resolved before emitting paint instructions.
+3. Wire in a `TextShaper` as a required parameter to the
+   layout-to-paint conversion.
+
+This amendment is deferred to keep TXT00 focused. It is tracked as part
+of the roadmap below.
+
+---
+
+## Error conditions
+
+| Error                         | When                                                                     | How to fix                                                   |
+|-------------------------------|--------------------------------------------------------------------------|--------------------------------------------------------------|
+| `UnsupportedScriptError`      | Shaper called with a script code it cannot handle                        | Use a shaper that supports the script, or split the run      |
+| `UnsupportedFontBindingError` | Paint backend received a `PaintGlyphRun` whose `font_ref` scheme is unknown | Use a paint backend that understands the shaper's binding   |
+| `FontResolutionError`         | FontResolver could not map an abstract font ref to a concrete handle     | Install the font, or choose a different family               |
+| `InvalidFontHandleError`      | FontMetrics or TextShaper received a handle from a different backend     | Don't cross bindings — use handles from the matching resolver |
+| `ShapingFailedError`          | Shaper failed internally (e.g., malformed font, out-of-memory)           | Bug report; fall back to a different shaper if available     |
+
+All of these are recoverable at the layout level (the layout engine can
+retry with a different font or shaper). None of them should be caught
+and silently ignored.
+
+---
+
+## Roadmap — sibling specs
+
+TXT00 is the interface. The following specs are the implementations and
+the integration points:
+
+| Spec  | Package                    | Description                                                                  |
+|-------|----------------------------|------------------------------------------------------------------------------|
+| TXT00 | (this spec)                | FontMetrics, TextShaper, TextMeasurer interfaces                             |
+| TXT01 | `text-metrics-font-parser` | `FontMetrics` over `font-parser`. Reproducible, cross-platform.              |
+| TXT02 | `text-shaper-naive`        | Minimal device-independent `TextShaper`: cmap + legacy `kern`, no GSUB/GPOS. |
+| TXT03 | `text-shaper-native`       | Device-dependent `TextShaper` per OS. Split into sub-specs:                  |
+|       | TXT03a                     | CoreText shaper (macOS/iOS)                                                  |
+|       | TXT03b                     | DirectWrite shaper (Windows)                                                 |
+|       | TXT03c                     | Pango/HarfBuzz shaper (Linux)                                                |
+| TXT04 | `text-shaper-harfbuzz`     | Hand-rolled HarfBuzz-like shaper. Replaces TXT02 once GSUB/GPOS are in.      |
+| TXT05 | `font-resolver`            | Abstract font refs ("sans-serif", CSS family lists) → FontHandle values.    |
+| TXT06 | `line-breaker` (optional)  | UAX #14 line breaking, used by the default measurer's wrap path.            |
+
+Two integration amendments are also required:
+
+- **UI04 amendment** — remove the `text` field from paint-layer text
+  description; require a `TextShaper` parameter in layout-to-paint.
+- **P2D02–P2D05 amendments** — each paint backend specifies how it
+  dispatches `glyph_run` based on the `font_ref` scheme (font-parser path
+  via glyph-parser outlines, or native path via OS text API).
+
+The first end-to-end target is **CommonMark markdown → Metal** via:
+
+```
+commonmark-parser → document-ast → layout (with TXT01 + TXT03a)
+  → PaintScene → paint-vm-metal (CoreText rasterizer for coretext: font_refs)
+```
+
+The later target is **LaTeX → any backend** via:
+
+```
+latex-parser → layout (with TXT01 + TXT04 once HarfBuzz-like is ready)
+  → PaintScene → any paint-vm (glyph-parser rasterizer for font-parser: font_refs)
+```
+
+Both targets use the same TXT00 interfaces; only the shaper
+implementation differs.
+
+---
+
+## Non-goals
+
+TXT00 explicitly does NOT cover:
+
+**Bidi resolution.** UAX #9 is owned by the layout engine. The shaper
+receives uniform-direction runs.
+
+**Line breaking and justification.** UAX #14 line breaking lives in a
+future optional spec (TXT06). The default measurer can call it but does
+not define it.
+
+**Font subsetting / embedding.** Producing a subset font for PDF
+embedding is a codec concern, not a text-interface concern.
+
+**Glyph rasterization.** The process of turning a glyph ID into pixels is
+owned by the paint backend (via glyph-parser for font-parser bindings, or
+via OS APIs for native bindings).
+
+**Font loading I/O.** The act of reading font bytes from a file, network,
+or system font registry is owned by FontResolver (TXT05). TXT00 assumes
+handles are already resolved.
+
+**Typesetting above the line level.** Paragraph layout, page breaking,
+widow/orphan control, column balancing — these are higher-level
+concerns that build on top of TXT00.
+
+---
+
+## Open questions
+
+The following design decisions are deliberately left to the first
+implementation PRs and will be finalized then:
+
+- Whether `FontHandle` needs a type-level tag (e.g., Rust phantom types,
+  TypeScript branded types) to make cross-binding misuse a compile error
+  rather than a runtime error. This is more easily decided when writing
+  the first Rust implementation.
+
+- Whether `ShapedRun` should carry an explicit `FontMetrics` reference
+  so that consumers can call `measure()` without separately passing
+  metrics. The current design keeps them separate for orthogonality;
+  ergonomics may argue for coupling.
+
+- Whether `ShapeOptions.features` should be typed (enum of known OT tags)
+  or string-typed (open-ended). The current design uses strings to allow
+  unknown tags to pass through; a typed variant would catch typos.
+
+These are not blockers for TXT01 or TXT02 implementations; they affect
+only the Rust/TypeScript trait signatures, which can evolve before the
+first shaper lands.

--- a/code/specs/TXT01-text-metrics-font-parser.md
+++ b/code/specs/TXT01-text-metrics-font-parser.md
@@ -1,0 +1,482 @@
+# TXT01 — text-metrics-font-parser: FontMetrics over font-parser
+
+## Overview
+
+TXT01 is the **first concrete implementation** of the `FontMetrics` interface
+defined in TXT00. It is a thin adapter over the existing `font-parser`
+package (FNT00), producing numeric font metrics directly from OpenType/
+TrueType binary tables with no OS involvement.
+
+```
+┌─────────────────────────────────┐
+│  Layout / TextShaper consumer   │
+└────────────────┬────────────────┘
+                 │ calls
+                 ▼
+┌─────────────────────────────────┐
+│  TXT00 FontMetrics trait        │
+└────────────────┬────────────────┘
+                 │ implemented by
+                 ▼
+┌─────────────────────────────────┐
+│  TXT01 text-metrics-font-parser │
+└────────────────┬────────────────┘
+                 │ delegates table lookups to
+                 ▼
+┌─────────────────────────────────┐
+│  FNT00 font-parser              │
+└─────────────────────────────────┘
+```
+
+This is the **device-independent** metrics path. Given the same font
+bytes, every machine that runs this code returns bit-identical metric
+values — the same property LaTeX needs for reproducible typesetting.
+
+TXT01 is deliberately small. It contains no novel algorithm; every
+interesting number already exists in `font-parser`. The job of this
+spec (and its implementations) is to expose those numbers through the
+TXT00-shaped interface and to bind them to a `font_ref` string that
+downstream rasterizers can route on.
+
+---
+
+## Scope
+
+TXT01 implements **only** the `FontMetrics` interface from TXT00. It
+does not implement `TextShaper` — that is TXT02's job. A package that
+follows this spec exports exactly the methods listed below and nothing
+more.
+
+Per-glyph measurements (advance widths, kerning) are **shaper territory**
+even though `font-parser` exposes them. TXT01 adapters MUST NOT surface
+`glyph_metrics()` or `kerning()` through the FontMetrics trait. If a
+consumer wants per-glyph data, it must go through a `TextShaper`.
+
+The rationale is strict separation of concerns: future replacements of
+FontMetrics (e.g. a CoreText-backed one) may not be able to answer
+per-glyph questions in isolation from the shaper. Keeping the TXT01
+surface narrow preserves substitutability.
+
+---
+
+## The FontHandle type for this backend
+
+```
+FontHandle  for  text-metrics-font-parser
+  ≔  a reference (or pointer, or language-appropriate handle) to a
+     parsed font file from font-parser, PLUS its font_ref string.
+
+In Rust:
+
+  pub struct FontParserHandle<'a> {
+      pub file: &'a font_parser::FontFile,
+      pub font_ref: String,   // "font-parser:<key>", see below
+      // Cached metrics — lazily computed on first access, then frozen.
+      cached: OnceCell<font_parser::FontMetrics>,
+  }
+```
+
+Equivalent struct shapes apply in other languages. The crucial
+properties are:
+
+- The handle **borrows** the parsed font; it does not own font bytes.
+  Ownership lives one layer up (in the font loader / FontResolver).
+- The handle carries its `font_ref` string so callers do not need to
+  recompute it on every access.
+- Cached metrics are allowed and recommended — a parsed
+  `font_parser::FontMetrics` is ~40 bytes and immutable for the
+  font's lifetime.
+
+### Why not expose `FontFile` directly?
+
+The TXT00 `FontHandle` type is implementation-defined, not universal.
+A CoreText-backed FontMetrics cannot use a `FontFile`. Keeping each
+backend's handle private (behind a type it also defines) means the
+adapter layer is the single point where font-parser and TXT00
+vocabulary meet.
+
+Callers hold handles opaquely and pass them back to the same
+FontMetrics instance that minted them. That matches the font-binding
+invariant laid out in TXT00.
+
+---
+
+## The font_ref scheme
+
+Every handle produced by this backend has a `font_ref` of the form:
+
+```
+font-parser:<key>
+```
+
+Where `<key>` is a **stable identifier** for the font bytes. Adapters
+MUST use one of the following choices, in preference order:
+
+1. **Content hash** — `blake2b(font_bytes)[0..16]` as lowercase hex.
+   This is the canonical form. It is reproducible, collision-resistant,
+   and makes identical font bytes produce identical font_refs across
+   processes.
+
+2. **Caller-supplied id** — if the caller wants a human-readable key
+   (`"inter-regular-v3.19"`), they supply it at load time and the
+   adapter prefixes `font-parser:` to it. The caller is responsible
+   for uniqueness; adapters MUST NOT attempt to detect collisions.
+
+A paint backend that sees `font_ref = "font-parser:abc123..."` MUST
+route this glyph run through the `glyph-parser` (FNT02) /
+`glyph-rasterizer` (FNT03) pipeline — NOT through CoreText or
+DirectWrite. The paint backend MUST reject any `font-parser:`
+font_ref it has not been given the matching font bytes for, by
+throwing `UnsupportedFontBindingError` (from TXT00).
+
+This routing key is the concrete realization of the **font-binding
+invariant** from TXT00 §"The font-binding invariant". It is the
+single piece of wire data that keeps the device-independent path
+and the device-dependent path from contaminating each other.
+
+### Why blake2b and not sha256
+
+`blake2b` is already the content-hash primitive of record in this
+repo (see `HF06-blake2b.md` and the `blake2b` packages across nine
+languages). Using it here avoids pulling a second hash implementation
+into every TXT01 package. 16 hex bytes (64 bits of entropy) is
+sufficient for font content-addressing — far below the birthday
+collision threshold for any realistic font set.
+
+---
+
+## Method-by-method implementation
+
+Each method in the TXT00 `FontMetrics` interface maps to a
+straightforward call into `font-parser`. Cached metrics are denoted
+`m = font_parser::font_metrics(handle.file)` and are computed once
+per handle.
+
+### `units_per_em(font)`
+
+```
+→  m.units_per_em   (u16 in font-parser, widened to int)
+```
+
+Direct passthrough. Guaranteed non-zero for any font that parsed
+successfully.
+
+### `ascent(font)`
+
+```
+→  m.ascender       (i16 in font-parser)
+```
+
+`font_parser::font_metrics` already prefers `OS/2.typoAscender` over
+`hhea.ascender` when both are present, which matches TXT00's
+expected semantics. The sign is already positive (distance *above*
+the baseline).
+
+### `descent(font)`
+
+```
+→  abs(m.descender)
+```
+
+**Sign conversion required.** `font-parser` returns the signed
+`hhea.descender` / `OS/2.typoDescender` value, which is conventionally
+negative (e.g., `-512` for Inter Regular). TXT00 specifies that
+descent is returned as a non-negative "distance below baseline".
+Adapters MUST take the absolute value.
+
+A font with `descender == 0` is valid (no glyphs below the baseline,
+like an all-caps display font). Return `0`, not an error.
+
+### `line_gap(font)`
+
+```
+→  m.line_gap       (i16 in font-parser; typically 0)
+```
+
+Passthrough, unsigned at the TXT00 layer. Most modern fonts have
+`line_gap == 0`; extra line spacing is a consumer concern (CSS
+`line-height`, TeX `\baselineskip`).
+
+### `x_height(font)`
+
+```
+→  m.x_height      (Option<i16> in Rust, null in TS/Python/etc.)
+```
+
+`font-parser` already returns `None` when the OS/2 table is absent
+or version < 2. Propagate that.
+
+### `cap_height(font)`
+
+```
+→  m.cap_height    (Option<i16>)
+```
+
+Same handling as `x_height`.
+
+### `family_name(font)`
+
+```
+→  m.family_name   (String)
+```
+
+Direct passthrough. `font-parser` reads this from `name` table
+nameID 1, platform 3 encoding 1 (UTF-16 BE). Callers should treat
+this as display-only — do NOT use it for font resolution (TXT05's
+job) or for `font_ref` construction.
+
+---
+
+## Package layout
+
+TXT01 has one package per supported language. The naming convention is:
+
+```
+text-metrics-font-parser    (TypeScript, Python, Ruby, Go, Perl, Lua,
+                             Haskell, Swift, C#, F#, Elixir, Rust)
+
+coding_adventures_text_metrics_font_parser   (for languages that use
+                                               snake_case package names)
+```
+
+Each package:
+
+- Depends on that language's `font-parser` package.
+- Depends on that language's `text-interfaces` package (TXT00).
+- Depends on that language's `blake2b` package for the default
+  content-hashed `font_ref` path.
+- Exposes a single constructor that takes a `FontFile` (or raw bytes
+  plus the language's `font-parser` load call) and returns a value
+  implementing the TXT00 `FontMetrics` trait.
+- Exposes an explicit constructor variant that takes a caller-supplied
+  id string to bypass hashing (useful for tests and for cases where
+  the caller already has a content-addressed identifier).
+
+### Rust reference layout
+
+```
+code/packages/rust/text-metrics-font-parser/
+├── Cargo.toml              # depends on font-parser, text-interfaces, blake2b
+├── CHANGELOG.md
+├── README.md
+├── BUILD
+├── required_capabilities.json
+└── src/
+    └── lib.rs
+```
+
+Reference API (other languages follow the same shape with idiomatic
+naming):
+
+```rust
+pub struct FontParserMetrics<'a> {
+    file: &'a font_parser::FontFile,
+    font_ref: String,
+    cached: OnceCell<font_parser::FontMetrics>,
+}
+
+impl<'a> FontParserMetrics<'a> {
+    /// Construct from an already-parsed FontFile. The font_ref is
+    /// derived from the content hash of the original bytes, which
+    /// must be supplied (font-parser does not retain them).
+    pub fn from_file(file: &'a font_parser::FontFile, bytes: &[u8])
+        -> Self { ... }
+
+    /// Construct with a caller-supplied id. The final font_ref is
+    /// "font-parser:<id>". The caller owns collision avoidance.
+    pub fn with_id(file: &'a font_parser::FontFile, id: impl Into<String>)
+        -> Self { ... }
+}
+
+impl<'a> text_interfaces::FontMetrics for FontParserMetrics<'a> {
+    type Handle = &'a font_parser::FontFile;
+
+    fn units_per_em(&self, _: Self::Handle) -> u32 { ... }
+    fn ascent       (&self, _: Self::Handle) -> i32 { ... }
+    fn descent      (&self, _: Self::Handle) -> i32 { ... }  // abs()
+    fn line_gap     (&self, _: Self::Handle) -> i32 { ... }
+    fn x_height     (&self, _: Self::Handle) -> Option<i32> { ... }
+    fn cap_height   (&self, _: Self::Handle) -> Option<i32> { ... }
+    fn family_name  (&self, _: Self::Handle) -> &str { ... }
+}
+```
+
+### Cross-language consistency
+
+A given font file's metrics values MUST match across all TXT01
+implementations to the bit. This is testable via a shared fixture:
+a fixed font file (e.g., Inter Regular, a known-good open-license
+font) and a JSON file of expected metric values. Every language's
+package runs the same fixture through its adapter and asserts
+equality. Divergences indicate a bug in that language's
+`font-parser` port, not in TXT01.
+
+---
+
+## Testing strategy
+
+Every TXT01 package MUST include the following tests:
+
+1. **Passthrough correctness.** For a known font (Inter Regular,
+   ships as a test fixture), each method returns the documented
+   expected value. Fixture values are committed to the repo and
+   shared across language packages.
+
+2. **Descent sign conversion.** A font with a negative `hhea.descender`
+   produces a positive `descent()` result. A font with
+   `descender == 0` produces `0`.
+
+3. **Optional metrics.** A synthetic "OS/2-less" font (old-style
+   TrueType with no OS/2 table) produces `None` / `null` from
+   `x_height()` and `cap_height()`, and does not throw.
+
+4. **font_ref stability.** Two `FontParserMetrics` instances
+   constructed from the same bytes produce the same `font_ref`
+   string. A one-byte change in the font bytes produces a
+   different `font_ref`.
+
+5. **Caching.** Two consecutive `ascent(h)` calls on the same
+   handle do not both call `font_parser::font_metrics`. Observable
+   via a mock or via a counter in a test-only wrapper.
+
+6. **Interface conformance.** The adapter satisfies the TXT00
+   `FontMetrics` trait's signature exactly — tested via a
+   compile-time check in Rust, a structural type check in
+   TypeScript, and runtime assertion in dynamic languages.
+
+Coverage target: **95%+**, per the repo-wide standard for library
+packages. Since TXT01 is a thin adapter, hitting this is trivial.
+
+### Integration test — layout line height
+
+A cross-language integration test computes the CSS-style line
+height for a known font at a known size and asserts it matches
+across languages:
+
+```
+font            = Inter Regular
+size            = 16 (user-space units)
+units_per_em    = 2048
+ascent          = 1984 design units  → 1984 × 16 / 2048 = 15.5 px
+descent         = 494  design units  → 494  × 16 / 2048 ≈ 3.86 px
+line_gap        = 0
+line_height     ≈ 15.5 + 3.86 + 0    = 19.36 px
+```
+
+(Actual Inter values; the test asserts to three decimal places.)
+
+---
+
+## Error conditions
+
+TXT01 is thin enough that it introduces no new error types. It
+propagates errors from `font-parser`:
+
+| Source                     | When                                                                 | TXT00-layer mapping             |
+|----------------------------|----------------------------------------------------------------------|---------------------------------|
+| `FontError::TableNotFound` | The font is missing a required table (`head`, `hhea`, `name`)        | `FontResolutionError` at load time, not observable at the FontMetrics layer |
+| `FontError::BadMagic`      | The `head` table's magic number is wrong (not a valid OpenType file) | Same — caught at load time      |
+| `FontError::Utf16Decode`   | The `name` table has malformed UTF-16 BE data                        | Fall back to an empty string for `family_name`; do NOT propagate |
+
+Once a `FontFile` has been successfully parsed and a
+`FontParserMetrics` is built from it, every method is infallible.
+No TXT01 method returns `Result` / throws. This is a deliberate
+choice: metrics retrieval on a known-good parsed font is pure
+reading of already-validated fields.
+
+---
+
+## Non-goals
+
+TXT01 explicitly does NOT cover:
+
+**Glyph-level metrics.** Per-glyph advance widths, kerning pairs,
+and glyph bounding boxes live in `TextShaper` output, not in
+`FontMetrics`. Adapters MUST NOT leak `font_parser::glyph_metrics`
+or `font_parser::kerning` through this interface.
+
+**Font loading I/O.** Reading font bytes from disk, network, or a
+system font directory is `FontResolver`'s job (TXT05). TXT01
+assumes a parsed `FontFile` already exists.
+
+**Font file parsing.** That is `font-parser` (FNT00). TXT01 is an
+adapter, not a parser.
+
+**Variable-font axis resolution.** OpenType variable fonts expose
+multiple instances along design axes (weight, width, optical size).
+Selecting a specific instance is FontResolver's job. Once a variable
+font has been "instanced" to a concrete set of metrics, TXT01 reads
+them like any static font.
+
+**CFF / PostScript-flavored OpenType fonts.** As of this writing,
+`font-parser` v0.1.0 only handles TrueType-flavored outlines
+(`sfntVersion == 0x00010000`). TXT01 inherits that limitation.
+When `font-parser` gains CFF support, TXT01 gets CFF support
+automatically — no adapter changes needed.
+
+**Color fonts (COLRv0 / COLRv1 / SVG / sbix).** Color layer data
+is a rendering concern owned by glyph-parser / rasterizer. TXT01
+is metrics-only.
+
+---
+
+## Relationship to sibling specs
+
+| Spec  | Relationship                                                                     |
+|-------|----------------------------------------------------------------------------------|
+| TXT00 | Provides the `FontMetrics` trait that TXT01 implements.                          |
+| TXT02 | Will consume TXT01 indirectly — naive shaper needs cmap + glyph metrics + kerning from `font-parser` directly, and line-height metrics via TXT01. |
+| TXT03 | Orthogonal sibling — device-dependent `FontMetrics` adapters (CoreText, DirectWrite). A caller picks one or the other; they are not composed. |
+| TXT05 | Supplies the `FontFile` that TXT01 wraps. FontResolver handles "Helvetica" → bytes; TXT01 takes it from there. |
+| FNT00 | Upstream dependency. `font-parser` is the table parser; TXT01 is the trait adapter. |
+
+The device-independent font pipeline, end to end:
+
+```
+  user names a font           ─ "Inter Regular"
+        │
+        ▼
+  FontResolver (TXT05)        ─ resolves to bytes on disk, loads them
+        │
+        ▼
+  font-parser (FNT00)         ─ parses tables into a FontFile
+        │
+        ▼
+  TXT01 adapter               ─ wraps FontFile, mints font_ref
+        │                         "font-parser:abc123..."
+        ▼
+  Layout / TextShaper         ─ reads metrics, shapes text
+        │
+        ▼
+  PaintGlyphRun (P2D00)       ─ carries font_ref through
+        │
+        ▼
+  Paint backend               ─ sees "font-parser:abc123...",
+                                routes to glyph-parser rasterizer
+```
+
+No step in this pipeline calls an OS font API. The same bytes in
+produce the same pixels out on macOS, Windows, Linux, iOS, Android,
+and WASM.
+
+---
+
+## Open questions
+
+- Whether to expose a "metrics fingerprint" alongside `font_ref` —
+  a content hash of the parsed metrics values only (ignoring glyph
+  data). Useful for cache invalidation at the layout layer. Deferred
+  until a concrete caller needs it.
+
+- Whether adapters should accept `Arc<FontFile>` (or
+  language-equivalent reference counting) in addition to borrowed
+  references. The current design assumes the caller owns the
+  `FontFile` and outlives the adapter. Some consumers (async
+  servers) may need shared ownership. Add when a real call site
+  asks for it; do not speculatively generalize.
+
+- Whether the `font_ref` key should include font version
+  (`head.fontRevision` or the `name` table version string). Two
+  versions of the same font have different bytes and therefore
+  different content hashes, so the question is cosmetic. Leaving
+  it out keeps keys shorter.


### PR DESCRIPTION
## Summary

- Introduces **TXT01**, the first concrete \`FontMetrics\` implementation from the TXT00 trio. A thin adapter over the existing \`font-parser\` (FNT00) — no OS involvement, bit-identical results across platforms.
- Defines the **\`font-parser:<key>\`** \`font_ref\` scheme (blake2b-16 content hash by default) so paint backends can route these glyph runs to the \`glyph-parser\` / \`glyph-rasterizer\` pipeline rather than CoreText / DirectWrite.
- Documents the one non-trivial mapping (\`descent\` requires \`abs()\` because \`font-parser\` returns the signed hhea/OS2 value; TXT00 specifies non-negative). Everything else is direct passthrough from \`font_parser::font_metrics()\`, cached on the handle.

## Why this shape

- \`font-parser\` already exposes a \`FontMetrics\` **data struct** with all the fields we need (\`ascender\`, \`descender\`, \`line_gap\`, \`x_height\`, \`cap_height\`, \`units_per_em\`, \`family_name\`). TXT00's \`FontMetrics\` is an **interface**. TXT01 is the adapter that closes that gap.
- Explicitly scopes out glyph-level metrics (advance widths, kerning) even though \`font-parser\` exposes them. Those belong to \`TextShaper\` (TXT02), not \`FontMetrics\`. Keeping the TXT01 surface narrow preserves substitutability with future device-dependent backends (CoreText, DirectWrite) that cannot answer per-glyph questions independently of their shapers.
- \`blake2b\` is the repo's content-hash primitive of record (\`HF06-blake2b.md\` + 9-language packages). Reusing it avoids dragging a second hash into every TXT01 package. 64-bit key space is far below birthday threshold for any realistic font set.

## What this unblocks

| Downstream              | Why it needs TXT01                                                                      |
|-------------------------|-----------------------------------------------------------------------------------------|
| TXT02 (naive shaper)    | Shaper needs line-height metrics; also validates the \`font-parser:\` font_ref scheme  |
| Layout engine           | Can finally compute CSS-style line heights without calling into the OS                  |
| LaTeX renderer (future) | Reproducible metrics on every platform — same bytes in, same pixels out                 |

## Test plan

- [ ] Doc-only PR — no code tests to run.
- [ ] \`/security-review\` passed (done — no findings).
- [ ] Reviewer sanity-check: descent sign handling is correct, blake2b-16 is appropriate for content-addressing (not security), TXT00 method contract matches one-to-one with font-parser calls.
- [ ] Cross-check \`font_ref\` scheme against TXT00's font-binding invariant — paint backends should reject any \`font-parser:<key>\` they lack bytes for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)