### PR TITLE
feat(dartmouth-basic-wasm-compiler): add WASM pipeline with dispatch-loop lowering

### DIFF
--- a/code/packages/python/dartmouth-basic-ir-compiler/src/dartmouth_basic_ir_compiler/compiler.py
+++ b/code/packages/python/dartmouth-basic-ir-compiler/src/dartmouth_basic_ir_compiler/compiler.py
@@ -242,7 +242,11 @@ class CompileError(ValueError):
 # ---------------------------------------------------------------------------
 
 
-def compile_basic(ast: ASTNode) -> CompileResult:
+def compile_basic(
+    ast: ASTNode,
+    *,
+    char_encoding: str = "ge225",
+) -> CompileResult:
     """Compile a Dartmouth BASIC AST to an IrProgram.
 
     This is the main entry point. It takes the root AST node from
@@ -250,7 +254,12 @@ def compile_basic(ast: ASTNode) -> CompileResult:
     target-independent ``IrProgram``.
 
     Args:
-        ast: Root ``ASTNode`` with ``rule_name == "program"``.
+        ast:           Root ``ASTNode`` with ``rule_name == "program"``.
+        char_encoding: Character encoding used for PRINT char codes in the IR.
+                       ``"ge225"`` (default) emits GE-225 typewriter codes —
+                       compatible with the GE-225 backend.
+                       ``"ascii"`` emits standard ASCII byte values — compatible
+                       with the WASM backend's WASI ``fd_write`` syscall.
 
     Returns:
         A ``CompileResult`` containing the IR program and variable register map.
@@ -275,7 +284,9 @@ def compile_basic(ast: ASTNode) -> CompileResult:
         raise ValueError(
             f"expected 'program' AST node, got {ast.rule_name!r}"
         )
-    c = _Compiler()
+    if char_encoding not in ("ge225", "ascii"):
+        raise ValueError(f"char_encoding must be 'ge225' or 'ascii'; got {char_encoding!r}")
+    c = _Compiler(char_encoding=char_encoding)
     return c.compile(ast)
 
 
@@ -305,6 +316,7 @@ class _Compiler:
     _loop_count: int = field(default=0)
     _label_count: int = field(default=0)
     _for_stack: list[_ForRecord] = field(default_factory=list)
+    char_encoding: str = field(default="ge225")
 
     def __post_init__(self) -> None:
         """Initialize the IR program."""
@@ -490,9 +502,11 @@ class _Compiler:
                 print_list = child
                 break
 
+        cr = ord('\n') if self.char_encoding == "ascii" else CARRIAGE_RETURN_CODE
+
         if print_list is None:
             # Bare PRINT → just a carriage return
-            self._emit_print_code(CARRIAGE_RETURN_CODE)
+            self._emit_print_code(cr)
             return
 
         # Walk each print_item (print_sep nodes are ignored)
@@ -500,7 +514,7 @@ class _Compiler:
             if isinstance(item_node, ASTNode) and item_node.rule_name == "print_item":
                 self._compile_print_item(item_node)
 
-        self._emit_print_code(CARRIAGE_RETURN_CODE)
+        self._emit_print_code(cr)
 
     def _compile_print_item(self, node: ASTNode) -> None:
         """Compile one item from a PRINT argument list.
@@ -515,13 +529,14 @@ class _Compiler:
             if isinstance(child, Token) and _type_is(child.type, "STRING"):
                 text = child.value.strip('"\'')
                 for ch in text:
-                    code = ascii_to_ge225(ch)
-                    if code is None:
+                    ge225_code = ascii_to_ge225(ch)
+                    if ge225_code is None:
                         raise CompileError(
                             f"character {ch!r} has no GE-225 typewriter equivalent; "
                             f"V1 supports A-Z, 0-9, space, and basic punctuation"
                         )
-                    self._emit_print_code(code)
+                    emit_code = ord(ch) if self.char_encoding == "ascii" else ge225_code
+                    self._emit_print_code(emit_code)
                 return
             elif isinstance(child, ASTNode):
                 # Numeric expression: compile, then emit decimal digit sequence
@@ -530,10 +545,12 @@ class _Compiler:
                 return
 
     def _emit_print_code(self, code: int) -> None:
-        """Emit LOAD_IMM + SYSCALL 1 to print one character by its GE-225 code.
+        """Emit LOAD_IMM + SYSCALL 1 to print one character.
 
         Args:
-            code: The 6-bit GE-225 typewriter code to print.
+            code: Character code to print.  Interpretation depends on
+                  ``char_encoding``: a GE-225 typewriter code (6-bit) when
+                  ``"ge225"``, or an ASCII byte value when ``"ascii"``.
         """
         self._emit(
             IrOp.LOAD_IMM,
@@ -556,9 +573,10 @@ class _Compiler:
              else: print r_dig; started = 1
         4. Units digit: always print r_work (handles the value 0 correctly).
 
-        GE-225 typewriter codes for the digits 0-9 equal the digit values
-        (code 0 → '0', …, code 9 → '9'), so the digit can be loaded directly
-        into v0 and dispatched via SYSCALL 1.
+        For ``char_encoding="ge225"``: GE-225 typewriter codes for the digits
+        0-9 equal the digit values, so the digit can be loaded directly into v0.
+        For ``char_encoding="ascii"``: ASCII '0' = 48, so each digit is offset
+        by 48 (``ADD_IMM v0, r_dig, 48``) before SYSCALL 1.
 
         Leading-zero suppression trick:
           r_dig ≥ 0 and r_started ∈ {0, 1}, so r_dig + r_started == 0 iff
@@ -588,14 +606,19 @@ class _Compiler:
         self._emit(IrOp.LOAD_IMM, IrRegister(r_started), IrImmediate(0))
 
         # Sign handling: if r_work < 0, print '-' then negate
+        minus_code = ord('-') if self.char_encoding == "ascii" else _GE225_MINUS_CODE
         l_pos = f"_pnum_{label_id}_pos"
         self._emit(IrOp.CMP_LT, IrRegister(r_is_neg), IrRegister(r_work), IrRegister(r_zero))
         self._emit(IrOp.BRANCH_Z, IrRegister(r_is_neg), IrLabel(l_pos))
-        self._emit_print_code(_GE225_MINUS_CODE)                             # '-'
+        self._emit_print_code(minus_code)                                    # '-'
         r_neg = self._new_reg()
         self._emit(IrOp.SUB, IrRegister(r_neg),  IrRegister(r_zero), IrRegister(r_work))
         self._emit(IrOp.ADD_IMM, IrRegister(r_work), IrRegister(r_neg), IrImmediate(0))
         self._emit_label(l_pos)
+
+        # For ASCII encoding, digits 0-9 must be offset by 48 to reach '0'-'9'.
+        # For GE-225 encoding, typewriter codes 0-9 already map to '0'-'9'.
+        digit_offset = 48 if self.char_encoding == "ascii" else 0
 
         # Unrolled digit extraction for each power of ten above the units place
         for pos_idx, power in enumerate([100000, 10000, 1000, 100, 10]):
@@ -612,14 +635,14 @@ class _Compiler:
             self._emit(IrOp.ADD,      IrRegister(r_sum),   IrRegister(r_dig),   IrRegister(r_started))
             self._emit(IrOp.BRANCH_Z, IrRegister(r_sum),   IrLabel(l_skip))
 
-            # Print this digit (digit value == GE-225 typewriter code for 0-9)
-            self._emit(IrOp.ADD_IMM, IrRegister(_REG_SYSCALL_ARG), IrRegister(r_dig), IrImmediate(0))
+            # Print this digit (add digit_offset to convert to printable code)
+            self._emit(IrOp.ADD_IMM, IrRegister(_REG_SYSCALL_ARG), IrRegister(r_dig), IrImmediate(digit_offset))
             self._emit(IrOp.SYSCALL,  IrImmediate(_SYSCALL_PRINT_CHAR))
             self._emit(IrOp.ADD_IMM,  IrRegister(r_started), IrRegister(r_one), IrImmediate(0))
             self._emit_label(l_skip)
 
         # Units digit: always print (this correctly handles the value 0)
-        self._emit(IrOp.ADD_IMM, IrRegister(_REG_SYSCALL_ARG), IrRegister(r_work), IrImmediate(0))
+        self._emit(IrOp.ADD_IMM, IrRegister(_REG_SYSCALL_ARG), IrRegister(r_work), IrImmediate(digit_offset))
         self._emit(IrOp.SYSCALL, IrImmediate(_SYSCALL_PRINT_CHAR))
 
     # ------------------------------------------------------------------

--- a/code/packages/python/dartmouth-basic-ir-compiler/tests/test_dartmouth_basic_ir_compiler.py
+++ b/code/packages/python/dartmouth-basic-ir-compiler/tests/test_dartmouth_basic_ir_compiler.py
@@ -352,6 +352,50 @@ class TestPrint:
         result = compile_source("10 PRINT \"123\"\n20 END\n")
         assert IrOp.SYSCALL in opcodes(result)
 
+    def test_ascii_encoding_emits_ascii_codes_for_string(self) -> None:
+        ast = parse_dartmouth_basic("10 PRINT \"AB\"\n20 END\n")
+        result = compile_basic(ast, char_encoding="ascii")
+        load_imm_ops = find_all(result, IrOp.LOAD_IMM)
+        char_codes = [
+            op[1].value
+            for op in load_imm_ops
+            if isinstance(op[0], IrRegister) and op[0].index == 0
+            and isinstance(op[1], IrImmediate)
+        ]
+        assert ord("A") in char_codes
+        assert ord("B") in char_codes
+        assert GE225_CODES["A"] not in char_codes
+
+    def test_ascii_encoding_emits_newline_for_cr(self) -> None:
+        ast = parse_dartmouth_basic("10 PRINT \"X\"\n20 END\n")
+        result = compile_basic(ast, char_encoding="ascii")
+        load_imm_ops = find_all(result, IrOp.LOAD_IMM)
+        char_codes = [
+            op[1].value
+            for op in load_imm_ops
+            if isinstance(op[0], IrRegister) and op[0].index == 0
+            and isinstance(op[1], IrImmediate)
+        ]
+        assert ord("\n") in char_codes
+        assert CARRIAGE_RETURN_CODE not in char_codes
+
+    def test_ascii_encoding_digit_offset_48(self) -> None:
+        ast = parse_dartmouth_basic("10 PRINT 5\n20 END\n")
+        result = compile_basic(ast, char_encoding="ascii")
+        add_imm_ops = find_all(result, IrOp.ADD_IMM)
+        offsets = [
+            op[2].value
+            for op in add_imm_ops
+            if isinstance(op[0], IrRegister) and op[0].index == 0
+            and isinstance(op[2], IrImmediate)
+        ]
+        assert 48 in offsets
+
+    def test_invalid_char_encoding_raises(self) -> None:
+        ast = parse_dartmouth_basic("10 END\n")
+        with pytest.raises(ValueError, match="char_encoding"):
+            compile_basic(ast, char_encoding="utf8")
+
 
 # ---------------------------------------------------------------------------
 # GOTO

--- a/code/packages/python/dartmouth-basic-wasm-compiler/BUILD
+++ b/code/packages/python/dartmouth-basic-wasm-compiler/BUILD
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../grammar-tools -e ../graph -e ../directed-graph -e ../state-machine -e ../lexer -e ../parser -e ../dartmouth-basic-lexer -e ../dartmouth-basic-parser -e ../compiler-ir -e ../dartmouth-basic-ir-compiler -e ../virtual-machine -e ../wasm-leb128 -e ../wasm-types -e ../wasm-opcodes -e ../wasm-module-parser -e ../wasm-validator -e ../wasm-execution -e ../wasm-runtime -e ../wasm-module-encoder -e ../ir-to-wasm-compiler -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/dartmouth-basic-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/dartmouth-basic-wasm-compiler/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+## [0.1.0] — 2026-04-19
+
+### Added
+
+- Initial release of `dartmouth-basic-wasm-compiler`.
+- `run_basic(source)` — compiles a Dartmouth BASIC program through the full
+  five-stage pipeline and returns its standard output:
+  1. Lex & parse via `dartmouth_basic_parser`
+  2. IR compilation via `dartmouth_basic_ir_compiler` with `char_encoding="ascii"`
+  3. WASM backend via `ir_to_wasm_compiler` with `strategy="dispatch_loop"` —
+     the dispatch-loop strategy handles arbitrary `GOTO` and `IF … THEN` jumps
+     emitted by the BASIC IR compiler without any structured-CF restrictions
+  4. Binary encoding via `wasm_module_encoder`
+  5. WASI runtime execution via `wasm_runtime`
+- `RunResult` dataclass with `output`, `var_values` (always `{}`), `steps`
+  (always `0`), and `halt_address` (always `0`).
+- `BasicError` exception wrapping parse, compile, lower, encode, and runtime
+  failures.
+- 60 end-to-end tests covering LET/arithmetic, PRINT (strings and numerics),
+  FOR/NEXT loops, IF/THEN conditionals (all six relational operators), GOTO
+  (forward and backward), classic programs (Fibonacci, Gauss sum, Collatz,
+  countdown, multiplication table, factorial), REM, STOP, and error paths
+  (parse errors, IR compile errors, WASM lowering errors, encode errors, runtime
+  errors).

--- a/code/packages/python/dartmouth-basic-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/dartmouth-basic-wasm-compiler/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.1.1] — 2026-04-19
+
+### Fixed
+
+- Pass `syscall_arg_reg=0` explicitly to `IrToWasmCompiler().compile()`.  The
+  BASIC IR compiler assigns register 0 as the SYSCALL print argument, but
+  `ir-to-wasm-compiler` v0.3.0 restored its default to 4 (the Brainfuck
+  convention).  Without this fix, PRINT statements would output null bytes
+  instead of the intended character because the WASM lowerer was reading the
+  wrong local variable.
+
 ## [0.1.0] — 2026-04-19
 
 ### Added

--- a/code/packages/python/dartmouth-basic-wasm-compiler/README.md
+++ b/code/packages/python/dartmouth-basic-wasm-compiler/README.md
@@ -1,0 +1,110 @@
+# dartmouth-basic-wasm-compiler
+
+Compiles [Dartmouth BASIC](https://en.wikipedia.org/wiki/Dartmouth_BASIC)
+programs to [WebAssembly](https://webassembly.org/) and executes them,
+capturing standard output.
+
+## Position in the stack
+
+```
+dartmouth_basic_parser          — tokenise + parse BASIC source → AST
+        ↓
+dartmouth_basic_ir_compiler     — lower AST → target-independent IR
+        ↓  (char_encoding="ascii")
+ir_to_wasm_compiler             — lower IR → WasmModule (WASI preview-1 ABI)
+        ↓
+wasm_module_encoder             — serialise WasmModule → raw bytes
+        ↓
+wasm_runtime                    — instantiate WASM binary, bind WASI host, run
+```
+
+This package is the WASM counterpart of `dartmouth-basic-ge225-compiler`.
+Both share the same parser and IR compiler; they differ only in the backend
+that lowers IR to a target binary.
+
+## Usage
+
+```python
+from dartmouth_basic_wasm_compiler import run_basic
+
+result = run_basic("""
+10 LET S = 0
+20 FOR I = 1 TO 100
+30 LET S = S + I
+40 NEXT I
+50 PRINT S
+60 END
+""")
+print(result.output)   # "5050\n"
+```
+
+## API
+
+### `run_basic(source, *, max_steps=100_000) → RunResult`
+
+Compile and run a Dartmouth BASIC program through the full WASM pipeline.
+
+- **`source`** — BASIC source text; each line must start with a line number.
+- **`max_steps`** — accepted for API parity with the GE-225 runner; not
+  enforced (the WASM runtime has no instruction counter).
+
+Returns a `RunResult`.  Raises `BasicError` on parse error, unsupported
+feature (GOSUB, DIM, INPUT, arrays, `^` operator), character not in the
+ASCII/GE-225 character set, or runtime failure.
+
+### `RunResult`
+
+| Field | Type | Value |
+|-------|------|-------|
+| `output` | `str` | Standard output from `PRINT` statements |
+| `var_values` | `dict[str, int]` | Always `{}` — WASM locals vanish after `_start` returns |
+| `steps` | `int` | Always `0` — no instruction counter in the WASM runtime |
+| `halt_address` | `int` | Always `0` — halt is a function return, not a fixed address |
+
+### `BasicError`
+
+Raised when the program cannot be compiled or run.  The original exception
+is available as `__cause__`.
+
+## Supported BASIC features (V1)
+
+| Feature | Supported |
+|---------|-----------|
+| `LET` (integer arithmetic: `+` `-` `*` `/`) | ✅ |
+| `PRINT` string literals | ✅ |
+| `PRINT` numeric expressions | ✅ |
+| `PRINT` mixed (e.g. `PRINT "X =", X`) | ✅ |
+| `FOR` / `NEXT` (with `STEP`) | ✅ |
+| `IF` / `THEN` (all six relational ops) | ✅ |
+| `GOTO` | ✅ |
+| `REM` (comments) | ✅ |
+| `STOP` | ✅ |
+| `END` | ✅ |
+| `GOSUB` / `RETURN` | ❌ (raises `BasicError`) |
+| `DIM` / arrays | ❌ |
+| `INPUT` | ❌ |
+| `^` exponentiation | ❌ |
+| Floating-point | ❌ |
+
+## Character encoding note
+
+The GE-225 typewriter used a proprietary 6-bit character code that is
+incompatible with ASCII.  Because WASM's `fd_write` WASI syscall writes raw
+bytes to stdout, the IR compiler runs in `char_encoding="ascii"` mode:
+
+- String characters are emitted as their `ord()` values.
+- Digits 0-9 are emitted as `ord('0') + digit` (ASCII 48–57).
+- Minus sign is emitted as `ord('-')` (ASCII 45).
+- Newline is emitted as `ord('\n')` (ASCII 10).
+
+Only characters that exist in both the GE-225 typewriter table and ASCII are
+accepted; others raise `BasicError`.
+
+## Development
+
+```bash
+cd code/packages/python/dartmouth-basic-wasm-compiler
+uv venv
+uv pip install -e ".[dev]"
+pytest tests/ -v
+```

--- a/code/packages/python/dartmouth-basic-wasm-compiler/pyproject.toml
+++ b/code/packages/python/dartmouth-basic-wasm-compiler/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-dartmouth-basic-wasm-compiler"
+version = "0.1.0"
+description = "Dartmouth BASIC → WebAssembly compiled pipeline: parser → IR compiler (ASCII) → WASM backend → WASM runtime"
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.12"
+dependencies = [
+    "coding-adventures-dartmouth-basic-parser",
+    "coding-adventures-dartmouth-basic-ir-compiler",
+    "coding-adventures-ir-to-wasm-compiler",
+    "coding-adventures-wasm-module-encoder",
+    "coding-adventures-wasm-runtime",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/dartmouth_basic_wasm_compiler"]
+
+[tool.pytest.ini_options]
+addopts = "--cov=dartmouth_basic_wasm_compiler --cov-report=term-missing --cov-fail-under=90"
+testpaths = ["tests"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM"]

--- a/code/packages/python/dartmouth-basic-wasm-compiler/src/dartmouth_basic_wasm_compiler/__init__.py
+++ b/code/packages/python/dartmouth-basic-wasm-compiler/src/dartmouth_basic_wasm_compiler/__init__.py
@@ -1,0 +1,28 @@
+"""Dartmouth BASIC → WebAssembly compiled pipeline.
+
+This package ties together every stage of the Dartmouth BASIC ahead-of-time
+compiler targeting WebAssembly into a single ``run_basic()`` call:
+
+::
+
+    BASIC source  →  lexer/parser  →  IR compiler  →  WASM backend  →  WASM runtime
+
+The IR compiler runs in ASCII char-encoding mode so that WASM's ``fd_write``
+syscall receives standard ASCII bytes rather than GE-225 typewriter codes.
+
+Usage::
+
+    from dartmouth_basic_wasm_compiler import run_basic
+
+    result = run_basic(\"\"\"
+    10 FOR I = 1 TO 5
+    20 PRINT I
+    30 NEXT I
+    40 END
+    \"\"\")
+    print(result.output)   # "1\\n2\\n3\\n4\\n5\\n"
+"""
+
+from dartmouth_basic_wasm_compiler.runner import BasicError, RunResult, run_basic
+
+__all__ = ["run_basic", "RunResult", "BasicError"]

--- a/code/packages/python/dartmouth-basic-wasm-compiler/src/dartmouth_basic_wasm_compiler/runner.py
+++ b/code/packages/python/dartmouth-basic-wasm-compiler/src/dartmouth_basic_wasm_compiler/runner.py
@@ -1,0 +1,177 @@
+"""Dartmouth BASIC → WebAssembly pipeline runner.
+
+This module is the public interface for the full compiled WASM pipeline.  It
+chains four independent packages — parser, IR compiler, WASM backend, and WASM
+runtime — into one ``run_basic()`` call that accepts a BASIC source string and
+returns the program's standard output.
+
+Pipeline
+--------
+
+1. **Lex & parse** (``dartmouth_basic_parser``) — tokenise the BASIC source
+   and build an AST.
+2. **IR compile** (``dartmouth_basic_ir_compiler``) — lower the AST to a
+   target-independent ``IrProgram``.  The ``char_encoding="ascii"`` flag makes
+   all ``PRINT`` char codes use standard ASCII byte values so the WASM
+   ``fd_write`` syscall produces correct output.
+3. **WASM backend** (``ir_to_wasm_compiler``) — lower the ``IrProgram`` to a
+   ``WasmModule`` targeting the WASI preview-1 ABI.
+4. **Encode** (``wasm_module_encoder``) — serialise the ``WasmModule`` to raw
+   WebAssembly 1.0 bytes.
+5. **Run** (``wasm_runtime``) — instantiate the binary, bind a WASI host that
+   captures stdout, and call the ``_start`` export.
+
+Character encoding note
+-----------------------
+
+The GE-225 typewriter used a proprietary 6-bit character code.  The WASM
+backend writes raw bytes to stdout via the WASI ``fd_write`` syscall, which
+expects standard ASCII.  The IR compiler therefore runs in ``char_encoding=
+"ascii"`` mode: string literals are emitted as their ``ord()`` values and
+numeric digits are offset by 48 (``ord('0')``) before printing.
+
+Variable values
+---------------
+
+Unlike the GE-225 backend (which stores all registers as memory words that
+can be read after halting), the WASM backend maps each IR virtual register to
+a WASM local variable.  WASM locals are stack-allocated and disappear when the
+``_start`` function returns, so ``RunResult.var_values`` is always empty for
+the WASM backend.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+class BasicError(Exception):
+    """Raised when the BASIC program cannot be compiled or executed.
+
+    Wraps ``CompileError`` from the IR compiler, ``WasmLoweringError`` from
+    the WASM backend, and runtime errors from the WASM runtime.  The original
+    exception is available as ``__cause__``.
+
+    Examples::
+
+        try:
+            run_basic("10 GOSUB 100\\n20 END\\n")
+        except BasicError as e:
+            print(e)  # "GOSUB is not supported in V1 of the compiled pipeline"
+    """
+
+
+@dataclass
+class RunResult:
+    """Outcome of a successful ``run_basic()`` call.
+
+    Attributes:
+        output:      Standard output produced by ``PRINT`` statements (ASCII
+                     text, newline-terminated).
+        var_values:  Always ``{}`` for the WASM backend.  WASM locals vanish
+                     when ``_start`` returns, so variable state is not
+                     recoverable after execution.
+        steps:       Always ``0`` for the WASM backend (no instruction
+                     counter in the WASM runtime).
+        halt_address: Always ``0`` for the WASM backend (halt is a function
+                      return, not a self-loop at a fixed address).
+
+    Example::
+
+        result = run_basic("10 LET A = 6 * 7\\n20 PRINT A\\n30 END\\n")
+        assert result.output == "42\\n"
+    """
+
+    output: str
+    var_values: dict[str, int] = field(default_factory=dict)
+    steps: int = 0
+    halt_address: int = 0
+
+
+def run_basic(
+    source: str,
+    *,
+    max_steps: int = 100_000,  # noqa: ARG001 — accepted for API parity with GE-225 runner
+) -> RunResult:
+    """Compile and run a Dartmouth BASIC program via WebAssembly.
+
+    This is the single public entry point.  It chains all five pipeline stages
+    and returns the program's standard output.
+
+    Args:
+        source:    Dartmouth BASIC source text.  Lines must begin with a line
+                   number followed by a statement.  Newlines between lines are
+                   required.
+        max_steps: Accepted for interface parity with the GE-225 runner but
+                   not enforced; the WASM runtime has no step counter.
+
+    Returns:
+        A ``RunResult`` with the standard output.  ``var_values``, ``steps``,
+        and ``halt_address`` are always zero/empty for the WASM backend.
+
+    Raises:
+        BasicError: If the program cannot be parsed, uses a V1-unsupported
+                    feature (GOSUB, DIM, INPUT, arrays, ``^`` operator), the
+                    string contains a character with no GE-225 typewriter code,
+                    or the WASM runtime raises an unexpected error.
+
+    Example — sum of 1 to 100::
+
+        result = run_basic(\"\"\"
+        10 LET S = 0
+        20 FOR I = 1 TO 100
+        30 LET S = S + I
+        40 NEXT I
+        50 PRINT S
+        60 END
+        \"\"\")
+        assert result.output == "5050\\n"
+    """
+    # ── Stage 1: parse ───────────────────────────────────────────────────────
+    try:
+        from dartmouth_basic_parser import parse_dartmouth_basic
+        ast = parse_dartmouth_basic(source)
+    except Exception as exc:
+        raise BasicError(f"parse error: {exc}") from exc
+
+    # ── Stage 2: IR compilation (ASCII char encoding for WASM) ───────────────
+    try:
+        from dartmouth_basic_ir_compiler import compile_basic
+        ir_result = compile_basic(ast, char_encoding="ascii")
+    except Exception as exc:
+        raise BasicError(str(exc)) from exc
+
+    # ── Stage 3: WASM backend ────────────────────────────────────────────────
+    try:
+        from ir_to_wasm_compiler import FunctionSignature, IrToWasmCompiler, WasmLoweringError
+        wasm_module = IrToWasmCompiler().compile(
+            ir_result.program,
+            function_signatures=[
+                FunctionSignature(label="_start", param_count=0, export_name="_start")
+            ],
+            strategy="dispatch_loop",
+        )
+    except Exception as exc:
+        raise BasicError(str(exc)) from exc
+
+    # ── Stage 4: encode to bytes ─────────────────────────────────────────────
+    try:
+        from wasm_module_encoder import encode_module
+        wasm_bytes = encode_module(wasm_module)
+    except Exception as exc:
+        raise BasicError(f"WASM encode error: {exc}") from exc
+
+    # ── Stage 5: run ─────────────────────────────────────────────────────────
+    try:
+        from wasm_runtime import WasiConfig, WasiHost, WasmRuntime
+        output_chunks: list[str] = []
+        config = WasiConfig(stdout=output_chunks.append)
+        host = WasiHost(config=config)
+        runtime = WasmRuntime(host=host)
+        runtime.load_and_run(wasm_bytes, "_start", [])
+    except BasicError:
+        raise
+    except Exception as exc:
+        raise BasicError(f"runtime error: {exc}") from exc
+
+    return RunResult(output="".join(output_chunks))

--- a/code/packages/python/dartmouth-basic-wasm-compiler/src/dartmouth_basic_wasm_compiler/runner.py
+++ b/code/packages/python/dartmouth-basic-wasm-compiler/src/dartmouth_basic_wasm_compiler/runner.py
@@ -150,6 +150,7 @@ def run_basic(
                 FunctionSignature(label="_start", param_count=0, export_name="_start")
             ],
             strategy="dispatch_loop",
+            syscall_arg_reg=0,
         )
     except Exception as exc:
         raise BasicError(str(exc)) from exc

--- a/code/packages/python/dartmouth-basic-wasm-compiler/tests/test_dartmouth_basic_wasm_compiler.py
+++ b/code/packages/python/dartmouth-basic-wasm-compiler/tests/test_dartmouth_basic_wasm_compiler.py
@@ -1,0 +1,437 @@
+"""End-to-end tests for the Dartmouth BASIC → WebAssembly pipeline.
+
+Every test compiles a BASIC program to WASM and runs it through the WASM
+runtime, asserting on stdout output.  This mirrors the GE-225 integration
+tests but targets the WASM backend.
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import patch
+
+from dartmouth_basic_wasm_compiler import BasicError, RunResult, run_basic
+
+
+# ---------------------------------------------------------------------------
+# LET / arithmetic
+# ---------------------------------------------------------------------------
+
+
+class TestLet:
+    """Variable assignment and arithmetic are compiled and executed correctly."""
+
+    def test_let_constant(self) -> None:
+        result = run_basic("10 LET A = 42\n20 PRINT A\n30 END\n")
+        assert result.output == "42\n"
+
+    def test_let_addition(self) -> None:
+        result = run_basic("10 LET A = 3\n20 LET B = 4\n30 LET C = A + B\n40 PRINT C\n50 END\n")
+        assert result.output == "7\n"
+
+    def test_let_subtraction(self) -> None:
+        result = run_basic("10 LET A = 10\n20 LET B = 3\n30 PRINT A - B\n40 END\n")
+        assert result.output == "7\n"
+
+    def test_let_multiplication(self) -> None:
+        result = run_basic("10 LET A = 6\n20 LET B = 7\n30 PRINT A * B\n40 END\n")
+        assert result.output == "42\n"
+
+    def test_let_division(self) -> None:
+        result = run_basic("10 LET A = 10\n20 LET B = 2\n30 PRINT A / B\n40 END\n")
+        assert result.output == "5\n"
+
+    def test_let_chained_variables(self) -> None:
+        result = run_basic(
+            "10 LET A = 5\n20 LET B = A * 2\n30 LET C = B + 1\n40 PRINT C\n50 END\n"
+        )
+        assert result.output == "11\n"
+
+    def test_let_negative_result(self) -> None:
+        result = run_basic("10 LET A = 3 - 10\n20 PRINT A\n30 END\n")
+        assert result.output == "-7\n"
+
+    def test_let_complex_expression(self) -> None:
+        result = run_basic("10 LET A = (2 + 3) * (4 - 1)\n20 PRINT A\n30 END\n")
+        assert result.output == "15\n"
+
+    def test_let_overwrites_previous_value(self) -> None:
+        result = run_basic(
+            "10 LET A = 1\n20 LET A = 2\n30 LET A = 3\n40 PRINT A\n50 END\n"
+        )
+        assert result.output == "3\n"
+
+
+# ---------------------------------------------------------------------------
+# PRINT — string literals
+# ---------------------------------------------------------------------------
+
+
+class TestPrintString:
+    """PRINT of string literals produces correct ASCII output."""
+
+    def test_hello_world(self) -> None:
+        result = run_basic("10 PRINT \"HELLO WORLD\"\n20 END\n")
+        assert result.output == "HELLO WORLD\n"
+
+    def test_print_appends_newline(self) -> None:
+        result = run_basic("10 PRINT \"X\"\n20 END\n")
+        assert result.output.endswith("\n")
+
+    def test_print_empty_string(self) -> None:
+        result = run_basic("10 PRINT \"\"\n20 END\n")
+        assert result.output == "\n"
+
+    def test_print_bare(self) -> None:
+        result = run_basic("10 PRINT\n20 END\n")
+        assert result.output == "\n"
+
+    def test_print_digits_as_string(self) -> None:
+        result = run_basic("10 PRINT \"123\"\n20 END\n")
+        assert result.output == "123\n"
+
+    def test_print_multiple_lines(self) -> None:
+        result = run_basic(
+            "10 PRINT \"FIRST\"\n20 PRINT \"SECOND\"\n30 END\n"
+        )
+        assert result.output == "FIRST\nSECOND\n"
+
+
+# ---------------------------------------------------------------------------
+# PRINT — numeric expressions
+# ---------------------------------------------------------------------------
+
+
+class TestPrintNumeric:
+    """PRINT of numeric expressions produces correct decimal ASCII output."""
+
+    def test_print_zero(self) -> None:
+        result = run_basic("10 PRINT 0\n20 END\n")
+        assert result.output == "0\n"
+
+    def test_print_positive_integer(self) -> None:
+        result = run_basic("10 PRINT 42\n20 END\n")
+        assert result.output == "42\n"
+
+    def test_print_negative_integer(self) -> None:
+        result = run_basic("10 PRINT -7\n20 END\n")
+        assert result.output == "-7\n"
+
+    def test_print_variable(self) -> None:
+        result = run_basic("10 LET X = 99\n20 PRINT X\n30 END\n")
+        assert result.output == "99\n"
+
+    def test_print_expression_result(self) -> None:
+        result = run_basic("10 PRINT 3 * 3 + 1\n20 END\n")
+        assert result.output == "10\n"
+
+    def test_print_large_number(self) -> None:
+        result = run_basic("10 PRINT 12345\n20 END\n")
+        assert result.output == "12345\n"
+
+    def test_print_powers_of_ten(self) -> None:
+        result = run_basic(
+            "10 PRINT 1\n20 PRINT 10\n30 PRINT 100\n40 PRINT 1000\n50 END\n"
+        )
+        assert result.output == "1\n10\n100\n1000\n"
+
+    def test_print_leading_zero_suppressed(self) -> None:
+        result = run_basic("10 PRINT 5\n20 END\n")
+        assert result.output == "5\n"
+        assert not result.output.startswith("0")
+
+    def test_print_mixed_string_and_number(self) -> None:
+        result = run_basic(
+            "10 LET X = 42\n20 PRINT \"ANSWER IS \", X\n30 END\n"
+        )
+        assert result.output == "ANSWER IS 42\n"
+
+    def test_print_arithmetic_in_print(self) -> None:
+        result = run_basic("10 PRINT 2 + 2\n20 END\n")
+        assert result.output == "4\n"
+
+
+# ---------------------------------------------------------------------------
+# FOR / NEXT
+# ---------------------------------------------------------------------------
+
+
+class TestForNext:
+    """FOR/NEXT loops execute the correct number of iterations."""
+
+    def test_for_prints_sequence(self) -> None:
+        result = run_basic(
+            "10 FOR I = 1 TO 5\n20 PRINT I\n30 NEXT I\n40 END\n"
+        )
+        assert result.output == "1\n2\n3\n4\n5\n"
+
+    def test_for_sum_one_to_ten(self) -> None:
+        result = run_basic(
+            "10 LET S = 0\n20 FOR I = 1 TO 10\n30 LET S = S + I\n"
+            "40 NEXT I\n50 PRINT S\n60 END\n"
+        )
+        assert result.output == "55\n"
+
+    def test_for_sum_one_to_hundred(self) -> None:
+        result = run_basic(
+            "10 LET S = 0\n20 FOR I = 1 TO 100\n30 LET S = S + I\n"
+            "40 NEXT I\n50 PRINT S\n60 END\n"
+        )
+        assert result.output == "5050\n"
+
+    def test_for_with_step(self) -> None:
+        result = run_basic(
+            "10 FOR I = 0 TO 10 STEP 2\n20 PRINT I\n30 NEXT I\n40 END\n"
+        )
+        assert result.output == "0\n2\n4\n6\n8\n10\n"
+
+    def test_for_loop_zero_iterations(self) -> None:
+        result = run_basic(
+            "10 LET X = 0\n20 FOR I = 5 TO 1\n30 LET X = X + 1\n"
+            "40 NEXT I\n50 PRINT X\n60 END\n"
+        )
+        assert result.output == "0\n"
+
+    def test_factorial_5(self) -> None:
+        result = run_basic(
+            "10 LET F = 1\n20 FOR I = 1 TO 5\n30 LET F = F * I\n"
+            "40 NEXT I\n50 PRINT F\n60 END\n"
+        )
+        assert result.output == "120\n"
+
+
+# ---------------------------------------------------------------------------
+# IF / THEN
+# ---------------------------------------------------------------------------
+
+
+class TestIfThen:
+    """Conditional branches take/skip correctly for all six relational operators."""
+
+    def test_if_eq_true_branches(self) -> None:
+        result = run_basic(
+            "10 LET A = 5\n20 IF A = 5 THEN 40\n30 PRINT \"NO\"\n"
+            "40 PRINT \"YES\"\n50 END\n"
+        )
+        assert result.output == "YES\n"
+
+    def test_if_eq_false_falls_through(self) -> None:
+        result = run_basic(
+            "10 LET A = 3\n20 IF A = 5 THEN 40\n30 PRINT \"NO\"\n"
+            "40 END\n"
+        )
+        assert result.output == "NO\n"
+
+    def test_if_lt_true(self) -> None:
+        result = run_basic(
+            "10 IF 3 < 5 THEN 30\n20 PRINT \"NO\"\n30 PRINT \"YES\"\n40 END\n"
+        )
+        assert result.output == "YES\n"
+
+    def test_if_gt_true(self) -> None:
+        result = run_basic(
+            "10 IF 7 > 2 THEN 30\n20 PRINT \"NO\"\n30 PRINT \"YES\"\n40 END\n"
+        )
+        assert result.output == "YES\n"
+
+    def test_if_ne_true(self) -> None:
+        result = run_basic(
+            "10 IF 3 <> 4 THEN 30\n20 PRINT \"NO\"\n30 PRINT \"YES\"\n40 END\n"
+        )
+        assert result.output == "YES\n"
+
+    def test_if_le_true(self) -> None:
+        result = run_basic(
+            "10 IF 5 <= 5 THEN 30\n20 PRINT \"NO\"\n30 PRINT \"YES\"\n40 END\n"
+        )
+        assert result.output == "YES\n"
+
+    def test_if_ge_true(self) -> None:
+        result = run_basic(
+            "10 IF 6 >= 6 THEN 30\n20 PRINT \"NO\"\n30 PRINT \"YES\"\n40 END\n"
+        )
+        assert result.output == "YES\n"
+
+    def test_if_used_to_implement_max(self) -> None:
+        result = run_basic(
+            "10 LET A = 7\n20 LET B = 3\n30 LET M = A\n"
+            "40 IF B > A THEN 60\n50 GOTO 70\n60 LET M = B\n"
+            "70 PRINT M\n80 END\n"
+        )
+        assert result.output == "7\n"
+
+
+# ---------------------------------------------------------------------------
+# GOTO
+# ---------------------------------------------------------------------------
+
+
+class TestGoto:
+    """GOTO branches forward and backward correctly."""
+
+    def test_goto_skips_code(self) -> None:
+        result = run_basic(
+            "10 GOTO 30\n20 PRINT \"SKIP\"\n30 PRINT \"AFTER\"\n40 END\n"
+        )
+        assert result.output == "AFTER\n"
+
+    def test_goto_backward_counts(self) -> None:
+        result = run_basic(
+            "10 LET N = 3\n20 PRINT N\n30 LET N = N - 1\n"
+            "40 IF N > 0 THEN 20\n50 END\n"
+        )
+        assert result.output == "3\n2\n1\n"
+
+
+# ---------------------------------------------------------------------------
+# Classic programs
+# ---------------------------------------------------------------------------
+
+
+class TestClassicPrograms:
+    """Complete programs that exercise multiple BASIC features together."""
+
+    def test_fibonacci_first_ten(self) -> None:
+        result = run_basic(
+            "10 LET A = 0\n20 LET B = 1\n"
+            "30 FOR I = 1 TO 10\n"
+            "40 LET C = A + B\n50 LET A = B\n60 LET B = C\n"
+            "70 NEXT I\n80 PRINT B\n90 END\n"
+        )
+        assert result.output == "89\n"
+
+    def test_gauss_sum(self) -> None:
+        result = run_basic(
+            "10 LET S = 0\n20 FOR I = 1 TO 100\n30 LET S = S + I\n"
+            "40 NEXT I\n50 PRINT S\n60 END\n"
+        )
+        assert result.output == "5050\n"
+
+    def test_multiplication_table_row(self) -> None:
+        result = run_basic(
+            "10 FOR I = 1 TO 5\n20 PRINT 3 * I\n30 NEXT I\n40 END\n"
+        )
+        assert result.output == "3\n6\n9\n12\n15\n"
+
+    def test_countdown(self) -> None:
+        result = run_basic(
+            "10 LET N = 5\n20 PRINT N\n30 LET N = N - 1\n"
+            "40 IF N > 0 THEN 20\n50 END\n"
+        )
+        assert result.output == "5\n4\n3\n2\n1\n"
+
+    def test_collatz_steps_for_6(self) -> None:
+        result = run_basic(
+            "10 LET N = 6\n20 LET S = 0\n"
+            "30 IF N = 1 THEN 80\n"
+            "40 LET R = N / 2\n"
+            "50 LET R = R * 2\n"
+            "60 IF N = R THEN 70\n"
+            "61 LET N = 3 * N + 1\n62 GOTO 65\n"
+            "70 LET N = N / 2\n"
+            "65 LET S = S + 1\n"
+            "66 GOTO 30\n"
+            "80 PRINT S\n90 END\n"
+        )
+        assert result.output == "8\n"
+
+    def test_rem_is_comment(self) -> None:
+        result = run_basic(
+            "10 REM THIS IS A COMMENT\n20 PRINT \"OK\"\n30 END\n"
+        )
+        assert result.output == "OK\n"
+
+    def test_stop_halts_like_end(self) -> None:
+        result = run_basic(
+            "10 PRINT \"BEFORE\"\n20 STOP\n30 PRINT \"AFTER\"\n40 END\n"
+        )
+        assert result.output == "BEFORE\n"
+
+    def test_hello_world_wasm_style(self) -> None:
+        result = run_basic(
+            "10 PRINT \"HELLO FROM WASM\"\n20 END\n"
+        )
+        assert result.output == "HELLO FROM WASM\n"
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+class TestErrors:
+    """BasicError is raised for unsupported features and bad input."""
+
+    def test_gosub_raises(self) -> None:
+        with pytest.raises(BasicError):
+            run_basic("10 GOSUB 100\n20 END\n100 RETURN\n")
+
+    def test_unsupported_char_raises(self) -> None:
+        with pytest.raises(BasicError):
+            run_basic("10 PRINT \"@#$\"\n20 END\n")
+
+    def test_parse_error_wraps_as_basic_error(self) -> None:
+        """A parser failure in stage 1 is wrapped as BasicError."""
+        with patch("dartmouth_basic_parser.parse_dartmouth_basic", side_effect=ValueError("bad input")):
+            with pytest.raises(BasicError, match="parse error"):
+                run_basic("10 END\n")
+
+    def test_wasm_lowering_error_wraps_as_basic_error(self) -> None:
+        """A WasmLoweringError in stage 3 is wrapped as BasicError."""
+        with patch(
+            "ir_to_wasm_compiler.IrToWasmCompiler.compile",
+            side_effect=RuntimeError("lowering failed"),
+        ):
+            with pytest.raises(BasicError):
+                run_basic("10 END\n")
+
+    def test_encode_error_wraps_as_basic_error(self) -> None:
+        """An exception from the WASM encoder in stage 4 is wrapped as BasicError."""
+        with patch("wasm_module_encoder.encode_module", side_effect=ValueError("encode fail")):
+            with pytest.raises(BasicError, match="WASM encode error"):
+                run_basic("10 END\n")
+
+    def test_runtime_error_wraps_as_basic_error(self) -> None:
+        """An unexpected exception from the WASM runtime in stage 5 is wrapped as BasicError."""
+        with patch(
+            "wasm_runtime.WasmRuntime.load_and_run",
+            side_effect=RuntimeError("execution fault"),
+        ):
+            with pytest.raises(BasicError, match="runtime error"):
+                run_basic("10 END\n")
+
+    def test_basic_error_from_runtime_propagates_unchanged(self) -> None:
+        """A BasicError raised during stage 5 is re-raised without wrapping."""
+        original = BasicError("inner error")
+        with patch(
+            "wasm_runtime.WasmRuntime.load_and_run",
+            side_effect=original,
+        ):
+            with pytest.raises(BasicError) as exc_info:
+                run_basic("10 END\n")
+        assert exc_info.value is original
+
+
+# ---------------------------------------------------------------------------
+# RunResult fields
+# ---------------------------------------------------------------------------
+
+
+class TestRunResult:
+    """RunResult has the expected field values for the WASM backend."""
+
+    def test_output_is_string(self) -> None:
+        result = run_basic("10 PRINT \"HI\"\n20 END\n")
+        assert isinstance(result.output, str)
+
+    def test_var_values_is_empty(self) -> None:
+        result = run_basic("10 LET A = 5\n20 END\n")
+        assert result.var_values == {}
+
+    def test_steps_is_zero(self) -> None:
+        result = run_basic("10 END\n")
+        assert result.steps == 0
+
+    def test_halt_address_is_zero(self) -> None:
+        result = run_basic("10 END\n")
+        assert result.halt_address == 0

--- a/code/packages/python/ir-to-wasm-assembly/tests/test_ir_to_wasm_assembly.py
+++ b/code/packages/python/ir-to-wasm-assembly/tests/test_ir_to_wasm_assembly.py
@@ -80,7 +80,7 @@ def test_emit_imported_wasi_function_assembly_and_run_it() -> None:
     program = IrProgram(entry_label="_start")
     program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_start")], id=-1))
     program.add_instruction(
-        IrInstruction(IrOp.LOAD_IMM, [IrRegister(0), IrImmediate(66)], id=gen.next())
+        IrInstruction(IrOp.LOAD_IMM, [IrRegister(4), IrImmediate(66)], id=gen.next())
     )
     program.add_instruction(IrInstruction(IrOp.SYSCALL, [IrImmediate(1)], id=gen.next()))
     program.add_instruction(IrInstruction(IrOp.HALT, [], id=gen.next()))

--- a/code/packages/python/ir-to-wasm-assembly/tests/test_ir_to_wasm_assembly.py
+++ b/code/packages/python/ir-to-wasm-assembly/tests/test_ir_to_wasm_assembly.py
@@ -80,7 +80,7 @@ def test_emit_imported_wasi_function_assembly_and_run_it() -> None:
     program = IrProgram(entry_label="_start")
     program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_start")], id=-1))
     program.add_instruction(
-        IrInstruction(IrOp.LOAD_IMM, [IrRegister(4), IrImmediate(66)], id=gen.next())
+        IrInstruction(IrOp.LOAD_IMM, [IrRegister(0), IrImmediate(66)], id=gen.next())
     )
     program.add_instruction(IrInstruction(IrOp.SYSCALL, [IrImmediate(1)], id=gen.next()))
     program.add_instruction(IrInstruction(IrOp.HALT, [], id=gen.next()))

--- a/code/packages/python/ir-to-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/ir-to-wasm-compiler/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+## [0.2.0] — 2026-04-19
+
+### Added
+
+- **Dispatch-loop lowering strategy** (`_DispatchLoopLowerer`): a second
+  lowering strategy that handles arbitrary unstructured control flow (arbitrary
+  `JUMP` and `BRANCH_Z`/`BRANCH_NZ` targets).  Enabled via
+  `IrToWasmCompiler.compile(..., strategy="dispatch_loop")`.
+
+  The strategy wraps all function segments in a `block { loop { … } }` dispatch
+  table driven by a virtual program counter (`$pc`) stored in a WASM `i32`
+  local.  Each IR `LABEL` becomes a "segment block" that is skipped unless
+  `$pc` matches its index.  `JUMP` / `BRANCH` instructions set `$pc` and
+  restart the loop; `HALT`/`RET` break out of the outer block.  See
+  `code/specs/IR02-dispatch-loop-wasm-strategy.md` for the full design.
+
+- **`strategy` parameter** on `IrToWasmCompiler.compile()` (keyword-only,
+  default `"structured"`):
+  - `"structured"` — existing behaviour; raises `WasmLoweringError` on
+    unstructured control flow.
+  - `"dispatch_loop"` — new behaviour; handles arbitrary jumps.
+  - Any other value raises `WasmLoweringError: unknown lowering strategy`.
+
+- `TestDispatchLoopLowerer` test class in `tests/test_ir_to_wasm_compiler.py`
+  covering: simple HALT, forward JUMP, backward JUMP (loop), `BRANCH_NZ`
+  taken/not-taken, `BRANCH_Z` taken, fall-through between segments, unknown
+  strategy error, SYSCALL through the dispatch loop, and a mixed multi-jump
+  program.
+
+## [0.1.0] — 2026-04-13
+
+### Added
+
+- Initial release of `ir-to-wasm-compiler`.
+- `IrToWasmCompiler.compile(program, function_signatures)` — lowers a generic
+  `IrProgram` to a `WasmModule` targeting the WASI preview-1 ABI.
+- `_FunctionLowerer` — structured control-flow lowerer that recognises
+  `loop_N_start`/`loop_N_end` and `if_N_else`/`if_N_end` label patterns.
+- Full WASI support: `fd_write` (SYSCALL 1), `fd_read` (SYSCALL 2),
+  `proc_exit` (SYSCALL 10).
+- `FunctionSignature` dataclass; `infer_function_signatures_from_comments()`
+  helper.
+- `WasmLoweringError` exception.
+- Support for `i32.mul` and `i32.div_s` opcodes (`IrOp.MUL`, `IrOp.DIV`).
+- `_SYSCALL_ARG0 = 0` (corrected from 4 — register 0 is the SYSCALL argument
+  register).

--- a/code/packages/python/ir-to-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/ir-to-wasm-compiler/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.3.0] — 2026-04-19
+
+### Fixed
+
+- **Brainfuck SYSCALL register mismatch**: `_SYSCALL_ARG0` was previously
+  hard-coded to 0 (BASIC convention), breaking `brainfuck-wasm-compiler` which
+  uses register 4 as the SYSCALL print argument.  The constant is restored to 4
+  (Brainfuck default) and the lowerer now accepts an explicit `syscall_arg_reg`
+  parameter so BASIC can pass `syscall_arg_reg=0` without affecting Brainfuck.
+
+- **WASI errno clobber** (`_emit_wasi_write` / `_emit_wasi_read`): the errno
+  return value from `fd_write`/`fd_read` is now discarded with `drop` instead
+  of being stored in `_REG_SCRATCH` (register 1).  Previously, every `PRINT`
+  in a Brainfuck or BASIC program silently zeroed register 1, corrupting
+  variable values mid-loop (e.g., Fibonacci producing `0,1,1,1,1...`).
+
 ## [0.2.0] — 2026-04-19
 
 ### Added
@@ -44,5 +60,14 @@
   helper.
 - `WasmLoweringError` exception.
 - Support for `i32.mul` and `i32.div_s` opcodes (`IrOp.MUL`, `IrOp.DIV`).
-- `_SYSCALL_ARG0 = 0` (corrected from 4 — register 0 is the SYSCALL argument
-  register).
+- `_SYSCALL_ARG0 = 4` default (Brainfuck IR convention: register 4 holds the
+  SYSCALL print argument).
+
+### Changed
+
+- `IrToWasmCompiler.compile()` now accepts a `syscall_arg_reg: int` keyword
+  parameter (default 4, the Brainfuck register convention).  Callers whose IR
+  uses a different register for the SYSCALL argument (e.g. Dartmouth BASIC IR
+  which uses register 0) must pass `syscall_arg_reg=0` explicitly.  This
+  makes the WASM lowerer IR-frontend-agnostic instead of hard-coding one
+  convention.

--- a/code/packages/python/ir-to-wasm-compiler/src/ir_to_wasm_compiler/compiler.py
+++ b/code/packages/python/ir-to-wasm-compiler/src/ir_to_wasm_compiler/compiler.py
@@ -86,6 +86,7 @@ _OPCODE = {
         "i32.and",
         "i32.mul",
         "i32.div_s",
+        "drop",
     )
 }
 
@@ -616,7 +617,7 @@ class _FunctionLowerer:
         self._emit_i32_const(1)
         self._emit_i32_const(nwritten_ptr)
         self._emit_wasi_call(_SYSCALL_WRITE)
-        self._emit_local_set(_REG_SCRATCH)
+        self._emit_opcode("drop")  # discard fd_write errno; storing in _REG_SCRATCH would clobber variable A
 
     def _emit_wasi_read(self) -> None:
         scratch_base = self._require_wasi_scratch()
@@ -637,7 +638,7 @@ class _FunctionLowerer:
         self._emit_i32_const(1)
         self._emit_i32_const(nread_ptr)
         self._emit_wasi_call(_SYSCALL_READ)
-        self._emit_local_set(_REG_SCRATCH)
+        self._emit_opcode("drop")  # discard fd_read errno
 
         self._emit_i32_const(byte_ptr)
         self._emit_opcode("i32.load8_u")

--- a/code/packages/python/ir-to-wasm-compiler/src/ir_to_wasm_compiler/compiler.py
+++ b/code/packages/python/ir-to-wasm-compiler/src/ir_to_wasm_compiler/compiler.py
@@ -38,7 +38,7 @@ _FUNCTION_COMMENT_RE = re.compile(r"^function:\s*([A-Za-z_][A-Za-z0-9_]*)\((.*)\
 _SYSCALL_WRITE = 1
 _SYSCALL_READ = 2
 _SYSCALL_EXIT = 10
-_SYSCALL_ARG0 = 0
+_SYSCALL_ARG0 = 4
 
 _WASI_MODULE = "wasi_snapshot_preview1"
 _WASI_IOVEC_OFFSET = 0
@@ -138,13 +138,14 @@ class IrToWasmCompiler:
         function_signatures: list[FunctionSignature] | None = None,
         *,
         strategy: str = "structured",
+        syscall_arg_reg: int = _SYSCALL_ARG0,
     ) -> WasmModule:
         signatures = infer_function_signatures_from_comments(program)
         if function_signatures:
             for signature in function_signatures:
                 signatures[signature.label] = signature
 
-        functions = self._split_functions(program, signatures)
+        functions = self._split_functions(program, signatures, syscall_arg_reg=syscall_arg_reg)
         imports = self._collect_wasi_imports(program)
         type_indices, types = self._build_type_table(functions, imports)
         data_offsets = self._layout_data(program.data)
@@ -205,6 +206,7 @@ class IrToWasmCompiler:
                     function_indices=function_indices,
                     data_offsets=data_offsets,
                     wasi_context=wasi_context,
+                    syscall_arg_reg=syscall_arg_reg,
                 ).lower()
             )
             if function.signature.export_name is not None:
@@ -312,6 +314,8 @@ class IrToWasmCompiler:
         self,
         program: IrProgram,
         signatures: dict[str, FunctionSignature],
+        *,
+        syscall_arg_reg: int = _SYSCALL_ARG0,
     ) -> list[_FunctionIR]:
         functions: list[_FunctionIR] = []
         start_index: int | None = None
@@ -328,6 +332,7 @@ class IrToWasmCompiler:
                         label=start_label,
                         instructions=program.instructions[start_index:index],
                         signatures=signatures,
+                        syscall_arg_reg=syscall_arg_reg,
                     )
                 )
 
@@ -340,6 +345,7 @@ class IrToWasmCompiler:
                     label=start_label,
                     instructions=program.instructions[start_index:],
                     signatures=signatures,
+                    syscall_arg_reg=syscall_arg_reg,
                 )
             )
 
@@ -355,12 +361,14 @@ class _FunctionLowerer:
         function_indices: dict[str, int],
         data_offsets: dict[str, int],
         wasi_context: _WasiContext,
+        syscall_arg_reg: int = _SYSCALL_ARG0,
     ) -> None:
         self.function = function
         self.signatures = signatures
         self.function_indices = function_indices
         self.data_offsets = data_offsets
         self.wasi_context = wasi_context
+        self.syscall_arg_reg = syscall_arg_reg
         self.param_count = function.signature.param_count
         self._bytes = bytearray()
         self._instructions = function.instructions
@@ -605,7 +613,7 @@ class _FunctionLowerer:
         byte_ptr = scratch_base + _WASI_BYTE_OFFSET
 
         self._emit_i32_const(byte_ptr)
-        self._emit_local_get(_SYSCALL_ARG0)
+        self._emit_local_get(self.syscall_arg_reg)
         self._emit_opcode("i32.store8")
         self._emit_memarg(0, 0)
 
@@ -643,10 +651,10 @@ class _FunctionLowerer:
         self._emit_i32_const(byte_ptr)
         self._emit_opcode("i32.load8_u")
         self._emit_memarg(0, 0)
-        self._emit_local_set(_SYSCALL_ARG0)
+        self._emit_local_set(self.syscall_arg_reg)
 
     def _emit_wasi_exit(self) -> None:
-        self._emit_local_get(_SYSCALL_ARG0)
+        self._emit_local_get(self.syscall_arg_reg)
         self._emit_wasi_call(_SYSCALL_EXIT)
         self._emit_i32_const(0)
         self._emit_opcode("return")
@@ -957,6 +965,7 @@ def _make_function_ir(
     label: str,
     instructions: list[IrInstruction],
     signatures: dict[str, FunctionSignature],
+    syscall_arg_reg: int = _SYSCALL_ARG0,
 ) -> _FunctionIR:
     if label == "_start":
         signature = signatures.get(label, FunctionSignature(label=label, param_count=0, export_name="_start"))
@@ -974,7 +983,7 @@ def _make_function_ir(
             if isinstance(operand, IrRegister)
         ]
         + [
-            _SYSCALL_ARG0
+            syscall_arg_reg
             for instruction in instructions
             if instruction.opcode == IrOp.SYSCALL
         ]

--- a/code/packages/python/ir-to-wasm-compiler/src/ir_to_wasm_compiler/compiler.py
+++ b/code/packages/python/ir-to-wasm-compiler/src/ir_to_wasm_compiler/compiler.py
@@ -38,7 +38,7 @@ _FUNCTION_COMMENT_RE = re.compile(r"^function:\s*([A-Za-z_][A-Za-z0-9_]*)\((.*)\
 _SYSCALL_WRITE = 1
 _SYSCALL_READ = 2
 _SYSCALL_EXIT = 10
-_SYSCALL_ARG0 = 4
+_SYSCALL_ARG0 = 0
 
 _WASI_MODULE = "wasi_snapshot_preview1"
 _WASI_IOVEC_OFFSET = 0
@@ -84,6 +84,8 @@ _OPCODE = {
         "i32.add",
         "i32.sub",
         "i32.and",
+        "i32.mul",
+        "i32.div_s",
     )
 }
 
@@ -133,6 +135,8 @@ class IrToWasmCompiler:
         self,
         program: IrProgram,
         function_signatures: list[FunctionSignature] | None = None,
+        *,
+        strategy: str = "structured",
     ) -> WasmModule:
         signatures = infer_function_signatures_from_comments(program)
         if function_signatures:
@@ -182,13 +186,19 @@ class IrToWasmCompiler:
                 for decl, offset in ((decl, data_offsets[decl.label]) for decl in program.data)
             )
 
+        if strategy not in ("structured", "dispatch_loop"):
+            raise WasmLoweringError(f"unknown lowering strategy: {strategy!r}")
+        lowerer_class: type[_FunctionLowerer] = (
+            _DispatchLoopLowerer if strategy == "dispatch_loop" else _FunctionLowerer
+        )
+
         wasi_context = _WasiContext(
             function_indices={imp.syscall_number: index for index, imp in enumerate(imports)},
             scratch_base=scratch_base,
         )
         for function in functions:
             module.code.append(
-                _FunctionLowerer(
+                lowerer_class(
                     function=function,
                     signatures=signatures,
                     function_indices=function_indices,
@@ -531,6 +541,10 @@ class _FunctionLowerer:
                 self._emit_binary_numeric("i32.sub", instruction)
             case IrOp.AND:
                 self._emit_binary_numeric("i32.and", instruction)
+            case IrOp.MUL:
+                self._emit_binary_numeric("i32.mul", instruction)
+            case IrOp.DIV:
+                self._emit_binary_numeric("i32.div_s", instruction)
             case IrOp.AND_IMM:
                 dst = _expect_register(instruction.operands[0], "AND_IMM dst")
                 src = _expect_register(instruction.operands[1], "AND_IMM src")
@@ -717,6 +731,183 @@ class _FunctionLowerer:
             if target == label:
                 return index
         raise WasmLoweringError(f"expected jump to {label} in {self.function.label}")
+
+
+class _DispatchLoopLowerer(_FunctionLowerer):
+    """Lower a function with unstructured control flow using a virtual program counter.
+
+    The resulting WASM looks like::
+
+        [copy params into IR registers]
+        i32.const 0 ; local.set $pc          ← start at segment 0
+        block $prog_end (void)
+          loop $dispatch (void)
+            block $seg_0 (void)              ← one block per label
+              local.get $pc; i32.const 0; i32.ne; br_if 0   ← skip if wrong
+              [instructions for segment 0]
+              i32.const 1; local.set $pc; br 1              ← fall-through
+            end
+            block $seg_1 (void)
+              local.get $pc; i32.const 1; i32.ne; br_if 0
+              [instructions for segment 1]
+              ...
+            end
+          end loop                           ← falls through on out-of-range $pc
+        end block
+        local.get _REG_SCRATCH              ← function return value
+        end function
+
+    br depth table (from inside block $seg_N):
+        br 0 → block $seg_N   (skip this segment)
+        br 1 → loop $dispatch (continue dispatch — loop restart)
+        br 2 → block $prog_end (exit program)
+
+    Inside a generated ``if`` block (for BRANCH_Z / BRANCH_NZ):
+        br 0 → if block
+        br 1 → block $seg_N
+        br 2 → loop $dispatch
+        br 3 → block $prog_end
+    """
+
+    def lower(self) -> FunctionBody:
+        label_to_seg, segments = self._index_segments()
+        # $pc lives at the local slot just past all IR virtual registers
+        pc_reg = self.function.max_reg + 1
+
+        self._copy_params_into_ir_registers()
+
+        # Initialise $pc = 0 (start at segment 0)
+        self._emit_i32_const(0)
+        self._emit_local_set(pc_reg)
+
+        # block $prog_end (void)
+        self._emit_opcode("block")
+        self._bytes.append(int(BlockType.EMPTY))
+        # loop $dispatch (void)
+        self._emit_opcode("loop")
+        self._bytes.append(int(BlockType.EMPTY))
+
+        for seg_idx, instrs in enumerate(segments):
+            self._emit_segment(seg_idx, instrs, pc_reg, label_to_seg)
+
+        # end loop
+        self._emit_opcode("end")
+        # end block $prog_end
+        self._emit_opcode("end")
+
+        # Function return value (0 on normal exit; HALT via br 2 lands here)
+        self._emit_local_get(_REG_SCRATCH)
+        self._emit_opcode("end")
+
+        return FunctionBody(
+            # max_reg + 1 IR virtual-register slots, plus one for $pc
+            locals=(ValueType.I32,) * (self.function.max_reg + 2),
+            code=bytes(self._bytes),
+        )
+
+    def _index_segments(
+        self,
+    ) -> tuple[dict[str, int], list[list[IrInstruction]]]:
+        """Assign each LABEL a segment index and split instructions between labels."""
+        label_to_seg: dict[str, int] = {}
+        # segment_starts[i] = instruction index *after* the i-th LABEL
+        segment_starts: list[int] = []
+
+        for i, instr in enumerate(self._instructions):
+            if (
+                instr.opcode == IrOp.LABEL
+                and instr.operands
+                and isinstance(instr.operands[0], IrLabel)
+            ):
+                label_to_seg[instr.operands[0].name] = len(segment_starts)
+                segment_starts.append(i + 1)
+
+        segments: list[list[IrInstruction]] = []
+        for i, start in enumerate(segment_starts):
+            # The next LABEL is at segment_starts[i+1]-1; exclude it from this segment.
+            end = segment_starts[i + 1] - 1 if i + 1 < len(segment_starts) else len(self._instructions)
+            segments.append(list(self._instructions[start:end]))
+
+        return label_to_seg, segments
+
+    def _emit_segment(
+        self,
+        seg_idx: int,
+        instrs: list[IrInstruction],
+        pc_reg: int,
+        label_to_seg: dict[str, int],
+    ) -> None:
+        # block $seg_N (void)
+        self._emit_opcode("block")
+        self._bytes.append(int(BlockType.EMPTY))
+
+        # Skip this segment when $pc ≠ seg_idx
+        self._emit_local_get(pc_reg)
+        self._emit_i32_const(seg_idx)
+        self._emit_opcode("i32.ne")
+        self._emit_opcode("br_if")
+        self._emit_u32(0)  # br 0 → end of block $seg_N
+
+        terminated = False
+        for instr in instrs:
+            if terminated:
+                break
+
+            if instr.opcode == IrOp.COMMENT:
+                continue
+
+            if instr.opcode == IrOp.JUMP:
+                target = _expect_label(instr.operands[0], "JUMP target").name
+                target_idx = label_to_seg.get(target)
+                if target_idx is None:
+                    raise WasmLoweringError(f"JUMP to unknown label: {target!r}")
+                self._emit_i32_const(target_idx)
+                self._emit_local_set(pc_reg)
+                self._emit_opcode("br")
+                self._emit_u32(1)  # br 1 → loop $dispatch (restart)
+                terminated = True
+
+            elif instr.opcode in (IrOp.BRANCH_Z, IrOp.BRANCH_NZ):
+                # Conditional jump: set $pc and continue dispatch *if* condition fires.
+                # Does NOT terminate the segment — falls through to next instruction.
+                cond_reg = _expect_register(instr.operands[0], "BRANCH condition").index
+                target = _expect_label(instr.operands[1], "BRANCH target").name
+                target_idx = label_to_seg.get(target)
+                if target_idx is None:
+                    raise WasmLoweringError(f"BRANCH to unknown label: {target!r}")
+                self._emit_local_get(cond_reg)
+                if instr.opcode == IrOp.BRANCH_Z:
+                    # Branch when zero: invert so WASM if fires when reg == 0
+                    self._emit_opcode("i32.eqz")
+                self._emit_opcode("if")
+                self._bytes.append(int(BlockType.EMPTY))
+                self._emit_i32_const(target_idx)
+                self._emit_local_set(pc_reg)
+                self._emit_opcode("br")
+                self._emit_u32(2)  # br 2 (inside if) → loop $dispatch
+                self._emit_opcode("end")
+                # Intentionally NOT setting terminated — execution continues
+
+            elif instr.opcode in (IrOp.HALT, IrOp.RET):
+                self._emit_opcode("br")
+                self._emit_u32(2)  # br 2 → block $prog_end (exit program)
+                terminated = True
+
+            elif instr.opcode == IrOp.SYSCALL:
+                self._emit_syscall(instr)
+
+            else:
+                self._emit_simple(instr)
+
+        if not terminated:
+            # Fall-through: advance $pc to the next segment in source order
+            self._emit_i32_const(seg_idx + 1)
+            self._emit_local_set(pc_reg)
+            self._emit_opcode("br")
+            self._emit_u32(1)  # br 1 → loop $dispatch (restart)
+
+        # end block $seg_N
+        self._emit_opcode("end")
 
 
 def infer_function_signatures_from_comments(program: IrProgram) -> dict[str, FunctionSignature]:

--- a/code/packages/python/ir-to-wasm-compiler/tests/test_ir_to_wasm_compiler.py
+++ b/code/packages/python/ir-to-wasm-compiler/tests/test_ir_to_wasm_compiler.py
@@ -200,7 +200,7 @@ def test_compile_syscall_write_uses_wasi_fd_write() -> None:
     program = IrProgram(entry_label="_start")
     program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_start")], id=-1))
     program.add_instruction(
-        IrInstruction(IrOp.LOAD_IMM, [IrRegister(4), IrImmediate(65)], id=gen.next())
+        IrInstruction(IrOp.LOAD_IMM, [IrRegister(0), IrImmediate(65)], id=gen.next())
     )
     program.add_instruction(IrInstruction(IrOp.SYSCALL, [IrImmediate(1)], id=gen.next()))
     program.add_instruction(IrInstruction(IrOp.HALT, [], id=gen.next()))
@@ -223,7 +223,7 @@ def test_compile_syscall_read_uses_wasi_fd_read() -> None:
     program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_start")], id=-1))
     program.add_instruction(IrInstruction(IrOp.SYSCALL, [IrImmediate(2)], id=gen.next()))
     program.add_instruction(
-        IrInstruction(IrOp.ADD_IMM, [IrRegister(1), IrRegister(4), IrImmediate(0)], id=gen.next())
+        IrInstruction(IrOp.ADD_IMM, [IrRegister(1), IrRegister(0), IrImmediate(0)], id=gen.next())
     )
     program.add_instruction(IrInstruction(IrOp.HALT, [], id=gen.next()))
 
@@ -242,7 +242,7 @@ def test_compile_syscall_exit_uses_wasi_proc_exit() -> None:
     program = IrProgram(entry_label="_start")
     program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_start")], id=-1))
     program.add_instruction(
-        IrInstruction(IrOp.LOAD_IMM, [IrRegister(4), IrImmediate(7)], id=gen.next())
+        IrInstruction(IrOp.LOAD_IMM, [IrRegister(0), IrImmediate(7)], id=gen.next())
     )
     program.add_instruction(IrInstruction(IrOp.SYSCALL, [IrImmediate(10)], id=gen.next()))
 
@@ -271,3 +271,272 @@ def test_unsupported_syscall_raises() -> None:
         assert "unsupported SYSCALL" in str(exc)
     else:  # pragma: no cover - defensive branch
         raise AssertionError("expected unsupported syscall error")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Dispatch-loop lowerer tests
+#
+# These tests exercise the _DispatchLoopLowerer directly via
+# IrToWasmCompiler.compile(..., strategy="dispatch_loop").  The lowerer handles
+# arbitrary JUMP/BRANCH targets that the structured lowerer would reject.
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _dispatch(
+    program: IrProgram,
+    function_signatures: list[FunctionSignature] | None = None,
+) -> object:
+    """Compile with the dispatch-loop strategy and return a WasmModule."""
+    sigs = function_signatures or [
+        FunctionSignature(label="_start", param_count=0, export_name="_start")
+    ]
+    return IrToWasmCompiler().compile(program, sigs, strategy="dispatch_loop")
+
+
+def _dispatch_run(
+    program: IrProgram,
+    function_signatures: list[FunctionSignature] | None = None,
+    *,
+    host: object = None,
+) -> list[int | float]:
+    module = _dispatch(program, function_signatures)
+    return _runtime_result(module, "_start", [], host=host)
+
+
+class TestDispatchLoopLowerer:
+    """Verify the dispatch-loop strategy handles arbitrary control flow."""
+
+    def test_simple_halt_exits(self) -> None:
+        """A single segment with HALT should exit cleanly."""
+        gen = IDGenerator()
+        program = IrProgram(entry_label="_start")
+        program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_start")], id=-1))
+        program.add_instruction(
+            IrInstruction(IrOp.LOAD_IMM, [IrRegister(1), IrImmediate(42)], id=gen.next())
+        )
+        program.add_instruction(IrInstruction(IrOp.HALT, [], id=gen.next()))
+
+        assert _dispatch_run(program) == [42]
+
+    def test_unconditional_forward_jump(self) -> None:
+        """JUMP to a forward label skips the code in between."""
+        gen = IDGenerator()
+        program = IrProgram(entry_label="_start")
+        program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_start")], id=-1))
+        program.add_instruction(IrInstruction(IrOp.JUMP, [IrLabel("_end")], id=gen.next()))
+        # This block must be skipped — if reached it would clobber r1
+        program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_skip")], id=-1))
+        program.add_instruction(
+            IrInstruction(IrOp.LOAD_IMM, [IrRegister(1), IrImmediate(99)], id=gen.next())
+        )
+        program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_end")], id=-1))
+        program.add_instruction(
+            IrInstruction(IrOp.LOAD_IMM, [IrRegister(1), IrImmediate(7)], id=gen.next())
+        )
+        program.add_instruction(IrInstruction(IrOp.HALT, [], id=gen.next()))
+
+        assert _dispatch_run(program) == [7]
+
+    def test_unconditional_backward_jump(self) -> None:
+        """JUMP to a backward label implements a loop.
+
+        This program counts from 0 to 3, incrementing r2 each iteration:
+            _start: r2 = 0; r3 = 3
+            _loop:  if r2 >= r3, jump _done
+                    r2 += 1; jump _loop
+            _done:  r1 = r2; HALT
+        """
+        gen = IDGenerator()
+        program = IrProgram(entry_label="_start")
+        program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_start")], id=-1))
+        program.add_instruction(
+            IrInstruction(IrOp.LOAD_IMM, [IrRegister(2), IrImmediate(0)], id=gen.next())
+        )
+        program.add_instruction(
+            IrInstruction(IrOp.LOAD_IMM, [IrRegister(3), IrImmediate(3)], id=gen.next())
+        )
+        program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_loop")], id=-1))
+        # r4 = (r2 >= r3) implemented as r4 = (r3 > r2) = 0 means not-done
+        program.add_instruction(
+            IrInstruction(IrOp.CMP_GT, [IrRegister(4), IrRegister(3), IrRegister(2)], id=gen.next())
+        )
+        # BRANCH_Z: if r4 == 0 (r3 not > r2, so r2 >= r3), jump to _done
+        program.add_instruction(
+            IrInstruction(IrOp.BRANCH_Z, [IrRegister(4), IrLabel("_done")], id=gen.next())
+        )
+        program.add_instruction(
+            IrInstruction(IrOp.ADD_IMM, [IrRegister(2), IrRegister(2), IrImmediate(1)], id=gen.next())
+        )
+        program.add_instruction(IrInstruction(IrOp.JUMP, [IrLabel("_loop")], id=gen.next()))
+        program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_done")], id=-1))
+        program.add_instruction(
+            IrInstruction(IrOp.ADD_IMM, [IrRegister(1), IrRegister(2), IrImmediate(0)], id=gen.next())
+        )
+        program.add_instruction(IrInstruction(IrOp.HALT, [], id=gen.next()))
+
+        assert _dispatch_run(program) == [3]
+
+    def test_branch_nz_conditional_jump(self) -> None:
+        """BRANCH_NZ jumps when the register is nonzero."""
+        gen = IDGenerator()
+        program = IrProgram(entry_label="_start")
+        program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_start")], id=-1))
+        program.add_instruction(
+            IrInstruction(IrOp.LOAD_IMM, [IrRegister(2), IrImmediate(1)], id=gen.next())
+        )
+        # r2 is 1 (nonzero) → should jump to _taken
+        program.add_instruction(
+            IrInstruction(IrOp.BRANCH_NZ, [IrRegister(2), IrLabel("_taken")], id=gen.next())
+        )
+        # Not taken path
+        program.add_instruction(
+            IrInstruction(IrOp.LOAD_IMM, [IrRegister(1), IrImmediate(0)], id=gen.next())
+        )
+        program.add_instruction(IrInstruction(IrOp.HALT, [], id=gen.next()))
+        program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_taken")], id=-1))
+        program.add_instruction(
+            IrInstruction(IrOp.LOAD_IMM, [IrRegister(1), IrImmediate(99)], id=gen.next())
+        )
+        program.add_instruction(IrInstruction(IrOp.HALT, [], id=gen.next()))
+
+        assert _dispatch_run(program) == [99]
+
+    def test_branch_nz_not_taken(self) -> None:
+        """BRANCH_NZ does not jump when the register is zero."""
+        gen = IDGenerator()
+        program = IrProgram(entry_label="_start")
+        program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_start")], id=-1))
+        program.add_instruction(
+            IrInstruction(IrOp.LOAD_IMM, [IrRegister(2), IrImmediate(0)], id=gen.next())
+        )
+        # r2 is 0 → BRANCH_NZ should NOT fire; fall through to r1 = 55
+        program.add_instruction(
+            IrInstruction(IrOp.BRANCH_NZ, [IrRegister(2), IrLabel("_taken")], id=gen.next())
+        )
+        program.add_instruction(
+            IrInstruction(IrOp.LOAD_IMM, [IrRegister(1), IrImmediate(55)], id=gen.next())
+        )
+        program.add_instruction(IrInstruction(IrOp.HALT, [], id=gen.next()))
+        program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_taken")], id=-1))
+        program.add_instruction(
+            IrInstruction(IrOp.LOAD_IMM, [IrRegister(1), IrImmediate(99)], id=gen.next())
+        )
+        program.add_instruction(IrInstruction(IrOp.HALT, [], id=gen.next()))
+
+        assert _dispatch_run(program) == [55]
+
+    def test_branch_z_conditional_jump(self) -> None:
+        """BRANCH_Z jumps when the register is zero."""
+        gen = IDGenerator()
+        program = IrProgram(entry_label="_start")
+        program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_start")], id=-1))
+        program.add_instruction(
+            IrInstruction(IrOp.LOAD_IMM, [IrRegister(2), IrImmediate(0)], id=gen.next())
+        )
+        # r2 == 0 → BRANCH_Z should fire
+        program.add_instruction(
+            IrInstruction(IrOp.BRANCH_Z, [IrRegister(2), IrLabel("_zero_path")], id=gen.next())
+        )
+        program.add_instruction(
+            IrInstruction(IrOp.LOAD_IMM, [IrRegister(1), IrImmediate(11)], id=gen.next())
+        )
+        program.add_instruction(IrInstruction(IrOp.HALT, [], id=gen.next()))
+        program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_zero_path")], id=-1))
+        program.add_instruction(
+            IrInstruction(IrOp.LOAD_IMM, [IrRegister(1), IrImmediate(22)], id=gen.next())
+        )
+        program.add_instruction(IrInstruction(IrOp.HALT, [], id=gen.next()))
+
+        assert _dispatch_run(program) == [22]
+
+    def test_fall_through_between_segments(self) -> None:
+        """A segment with no explicit jump falls through to the next segment."""
+        gen = IDGenerator()
+        program = IrProgram(entry_label="_start")
+        program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_start")], id=-1))
+        program.add_instruction(
+            IrInstruction(IrOp.LOAD_IMM, [IrRegister(2), IrImmediate(10)], id=gen.next())
+        )
+        # _start falls through to _next (no explicit JUMP)
+        program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_next")], id=-1))
+        program.add_instruction(
+            IrInstruction(IrOp.ADD_IMM, [IrRegister(1), IrRegister(2), IrImmediate(5)], id=gen.next())
+        )
+        program.add_instruction(IrInstruction(IrOp.HALT, [], id=gen.next()))
+
+        assert _dispatch_run(program) == [15]
+
+    def test_unknown_strategy_raises(self) -> None:
+        """Passing an unrecognised strategy name raises WasmLoweringError."""
+        program = IrProgram(entry_label="_start")
+        program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_start")], id=-1))
+        program.add_instruction(IrInstruction(IrOp.HALT, [], id=IDGenerator().next()))
+
+        with pytest.raises(WasmLoweringError, match="unknown lowering strategy"):
+            IrToWasmCompiler().compile(
+                program,
+                [FunctionSignature(label="_start", param_count=0, export_name="_start")],
+                strategy="bad_strategy",
+            )
+
+    def test_dispatch_loop_with_syscall_write(self) -> None:
+        """SYSCALL fd_write works correctly through the dispatch loop."""
+        gen = IDGenerator()
+        program = IrProgram(entry_label="_start")
+        program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_start")], id=-1))
+        program.add_instruction(
+            IrInstruction(IrOp.LOAD_IMM, [IrRegister(0), IrImmediate(72)], id=gen.next())  # 'H'
+        )
+        program.add_instruction(IrInstruction(IrOp.SYSCALL, [IrImmediate(1)], id=gen.next()))
+        program.add_instruction(IrInstruction(IrOp.HALT, [], id=gen.next()))
+
+        output: list[str] = []
+        host = WasiHost(config=WasiConfig(stdout=output.append))
+        _dispatch_run(
+            program,
+            [FunctionSignature(label="_start", param_count=0, export_name="_start")],
+            host=host,
+        )
+        assert output == ["H"]
+
+    def test_mixed_jumps_and_fall_throughs(self) -> None:
+        """Program with multiple jumps and fall-throughs produces correct result.
+
+        Computes: r2 = 1 + 2 + 3 = 6
+            _start:  r2 = 0; jump _a
+            _a:      r2 += 1; (fall through to _b)
+            _b:      r2 += 2; jump _c
+            _skip:   r2 += 100   ← must never be reached
+            _c:      r2 += 3; r1 = r2; HALT
+        """
+        gen = IDGenerator()
+        program = IrProgram(entry_label="_start")
+        program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_start")], id=-1))
+        program.add_instruction(
+            IrInstruction(IrOp.LOAD_IMM, [IrRegister(2), IrImmediate(0)], id=gen.next())
+        )
+        program.add_instruction(IrInstruction(IrOp.JUMP, [IrLabel("_a")], id=gen.next()))
+        program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_a")], id=-1))
+        program.add_instruction(
+            IrInstruction(IrOp.ADD_IMM, [IrRegister(2), IrRegister(2), IrImmediate(1)], id=gen.next())
+        )
+        # Fall through to _b
+        program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_b")], id=-1))
+        program.add_instruction(
+            IrInstruction(IrOp.ADD_IMM, [IrRegister(2), IrRegister(2), IrImmediate(2)], id=gen.next())
+        )
+        program.add_instruction(IrInstruction(IrOp.JUMP, [IrLabel("_c")], id=gen.next()))
+        program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_skip")], id=-1))
+        program.add_instruction(
+            IrInstruction(IrOp.ADD_IMM, [IrRegister(2), IrRegister(2), IrImmediate(100)], id=gen.next())
+        )
+        program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_c")], id=-1))
+        program.add_instruction(
+            IrInstruction(IrOp.ADD_IMM, [IrRegister(2), IrRegister(2), IrImmediate(3)], id=gen.next())
+        )
+        program.add_instruction(
+            IrInstruction(IrOp.ADD_IMM, [IrRegister(1), IrRegister(2), IrImmediate(0)], id=gen.next())
+        )
+        program.add_instruction(IrInstruction(IrOp.HALT, [], id=gen.next()))
+
+        assert _dispatch_run(program) == [6]

--- a/code/packages/python/ir-to-wasm-compiler/tests/test_ir_to_wasm_compiler.py
+++ b/code/packages/python/ir-to-wasm-compiler/tests/test_ir_to_wasm_compiler.py
@@ -200,7 +200,7 @@ def test_compile_syscall_write_uses_wasi_fd_write() -> None:
     program = IrProgram(entry_label="_start")
     program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_start")], id=-1))
     program.add_instruction(
-        IrInstruction(IrOp.LOAD_IMM, [IrRegister(0), IrImmediate(65)], id=gen.next())
+        IrInstruction(IrOp.LOAD_IMM, [IrRegister(4), IrImmediate(65)], id=gen.next())
     )
     program.add_instruction(IrInstruction(IrOp.SYSCALL, [IrImmediate(1)], id=gen.next()))
     program.add_instruction(IrInstruction(IrOp.HALT, [], id=gen.next()))
@@ -223,7 +223,7 @@ def test_compile_syscall_read_uses_wasi_fd_read() -> None:
     program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_start")], id=-1))
     program.add_instruction(IrInstruction(IrOp.SYSCALL, [IrImmediate(2)], id=gen.next()))
     program.add_instruction(
-        IrInstruction(IrOp.ADD_IMM, [IrRegister(1), IrRegister(0), IrImmediate(0)], id=gen.next())
+        IrInstruction(IrOp.ADD_IMM, [IrRegister(1), IrRegister(4), IrImmediate(0)], id=gen.next())
     )
     program.add_instruction(IrInstruction(IrOp.HALT, [], id=gen.next()))
 
@@ -242,7 +242,7 @@ def test_compile_syscall_exit_uses_wasi_proc_exit() -> None:
     program = IrProgram(entry_label="_start")
     program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_start")], id=-1))
     program.add_instruction(
-        IrInstruction(IrOp.LOAD_IMM, [IrRegister(0), IrImmediate(7)], id=gen.next())
+        IrInstruction(IrOp.LOAD_IMM, [IrRegister(4), IrImmediate(7)], id=gen.next())
     )
     program.add_instruction(IrInstruction(IrOp.SYSCALL, [IrImmediate(10)], id=gen.next()))
 
@@ -485,7 +485,7 @@ class TestDispatchLoopLowerer:
         program = IrProgram(entry_label="_start")
         program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_start")], id=-1))
         program.add_instruction(
-            IrInstruction(IrOp.LOAD_IMM, [IrRegister(0), IrImmediate(72)], id=gen.next())  # 'H'
+            IrInstruction(IrOp.LOAD_IMM, [IrRegister(4), IrImmediate(72)], id=gen.next())  # 'H'
         )
         program.add_instruction(IrInstruction(IrOp.SYSCALL, [IrImmediate(1)], id=gen.next()))
         program.add_instruction(IrInstruction(IrOp.HALT, [], id=gen.next()))

--- a/code/specs/IR02-dispatch-loop-wasm-strategy.md
+++ b/code/specs/IR02-dispatch-loop-wasm-strategy.md
@@ -1,0 +1,240 @@
+# IR02 — Dispatch-Loop WASM Lowering Strategy
+
+## Problem
+
+The `ir-to-wasm-compiler`'s existing `_FunctionLowerer` requires **structured
+control flow**: it only recognises `JUMP`/`BRANCH` instructions that target
+labels matching the naming conventions `loop_N_start` / `loop_N_end` (for
+loops) and `if_N_else` / `if_N_end` (for if/else).  Any other label target
+raises `WasmLoweringError: unexpected unstructured control flow`.
+
+Languages like Dartmouth BASIC use **unstructured control flow**: `GOTO` jumps
+to an arbitrary line label and `IF … THEN` branches to one.  The IR compiler
+for BASIC therefore emits `JUMP _line_N` and `BRANCH_NZ v_cmp _line_N`
+instructions that the existing lowerer cannot handle.
+
+## Background: How Other Compilers Solve This
+
+Three strategies exist (see research survey in conversation history):
+
+| Strategy | Complexity | Output Quality | Who Uses It |
+|---|---|---|---|
+| **Dispatch loop** | Low (~200 LOC) | Correct but slower | CPython, Lua VM, all classic BASIC |
+| **Relooper** | Medium (~400 LOC) | Good | Emscripten, Binaryen |
+| **Stackifier** | High (~600 LOC) | Near-optimal | LLVM WebAssembly backend |
+
+For BASIC programs (10–200 lines, no performance requirements, always
+reducible CFGs) the **dispatch loop** is the right choice: it is trivially
+correct for all possible control flow and requires far less implementation
+complexity than Relooper or Stackifier.
+
+## Design: Dispatch-Loop Lowering Strategy
+
+### Core Idea
+
+Replace arbitrary labels and jumps with a virtual **program counter** (`$pc`)
+stored in a WASM local variable, and a `block { loop { … } }` dispatch table
+that routes execution to the right segment each iteration.
+
+```
+┌─────────────────────────────────────────┐
+│  block $prog_end                        │
+│    loop $dispatch                       │
+│      block $seg_0   ; label _start      │
+│        pc ≠ 0 → br 0  (skip)           │
+│        [instructions for segment 0]     │
+│        pc = next_idx; br 1 (continue)  │
+│      end                                │
+│      block $seg_1   ; label _line_10    │
+│        pc ≠ 1 → br 0  (skip)           │
+│        [instructions for segment 1]     │
+│        pc = next_idx; br 1             │
+│      end                                │
+│      … one block per label …           │
+│    end loop  ; falls through → exit    │
+│  end block                             │
+└─────────────────────────────────────────┘
+```
+
+### Terminology
+
+| Term | Meaning |
+|---|---|
+| **Segment** | The sequence of IR instructions between two consecutive `LABEL` opcodes |
+| **Segment index** | A small integer assigned to each label in instruction-stream order |
+| `$pc` | A WASM `i32` local that holds the segment index currently being executed |
+
+### br Depth Table
+
+All br depths are measured from *inside a segment block*.
+
+| Instruction | Target depth | Meaning |
+|---|---|---|
+| `br 0` | `block $seg_N` | Skip this segment (pc didn't match) |
+| `br 1` | `loop $dispatch` | Continue dispatch (re-enter loop from top) |
+| `br 2` | `block $prog_end` | Exit program (HALT / END / STOP) |
+
+When the lowerer emits an `if` block to implement `BRANCH_Z` / `BRANCH_NZ`,
+all depths increase by one while inside that `if`:
+
+| Instruction | Target depth (inside `if`) | Meaning |
+|---|---|---|
+| `br 0` | `if` | End of if block |
+| `br 1` | `block $seg_N` | Skip this segment |
+| `br 2` | `loop $dispatch` | Continue dispatch |
+| `br 3` | `block $prog_end` | Exit program |
+
+### Segment Termination
+
+Each segment ends in exactly one of four ways:
+
+| Terminator | IR Opcode | Emitted WASM |
+|---|---|---|
+| Unconditional jump | `JUMP label` | `i32.const target_idx; local.set $pc; br 1` |
+| Conditional branch | `BRANCH_Z reg, label` / `BRANCH_NZ reg, label` | `if { i32.const target_idx; local.set $pc; br 2 } end` + fall-through |
+| Halt | `HALT` | `br 2` |
+| Fall-through | (reaches next `LABEL`) | `i32.const next_idx; local.set $pc; br 1` |
+
+Note that `BRANCH_Z` / `BRANCH_NZ` does **not** terminate the segment — it
+emits a conditional jump but then falls through to the next instruction.  The
+segment is only truly terminated when no more IR instructions remain before
+the next label.
+
+### Local Variable Layout
+
+The dispatch loop lowerer adds exactly **one extra local** (`$pc`) after all
+the IR virtual-register locals:
+
+```
+index 0 .. param_count-1        : function parameters (copied from WASM params)
+index param_count .. param_count+max_reg-1 : IR virtual registers (r0, r1, …)
+index param_count + max_reg     : $pc  (dispatch loop program counter)
+```
+
+The existing `_local_index(reg)` mapping (`param_count + reg`) is unchanged,
+so all existing `_emit_simple` helpers work without modification.
+
+### WASI / Memory
+
+The dispatch loop lowerer uses the **same WASI context** as the structured
+lowerer: the same scratch memory layout (`iovec` at offset 0, `nwritten` at
+8, byte at 12) and the same `fd_write` function-index plumbing.  No new
+memory or import infrastructure is required.
+
+## Interface
+
+### New parameter: `strategy`
+
+```python
+class IrToWasmCompiler:
+    def compile(
+        self,
+        program: IrProgram,
+        function_signatures: list[FunctionSignature] | None = None,
+        *,
+        strategy: str = "structured",   # NEW
+    ) -> WasmModule: ...
+```
+
+`strategy` may be:
+
+| Value | Behaviour |
+|---|---|
+| `"structured"` | Existing behaviour — uses `_FunctionLowerer`; raises `WasmLoweringError` on unstructured CF |
+| `"dispatch_loop"` | New behaviour — uses `_DispatchLoopLowerer`; handles arbitrary jumps |
+
+### New class: `_DispatchLoopLowerer`
+
+Lives in `ir_to_wasm_compiler/compiler.py` alongside `_FunctionLowerer`.
+Same constructor signature as `_FunctionLowerer`.  Implements `.lower() →
+FunctionBody`.
+
+## Algorithm
+
+```
+_DispatchLoopLowerer.lower():
+  1. index_labels()          — walk instructions, assign segment indices
+  2. emit_pc_init()          — i32.const 0; local.set $pc
+  3. emit_block_open()       — block (void)
+  4. emit_loop_open()        — loop (void)
+  5. for each consecutive LABEL in instructions:
+       emit_segment(seg_idx, instructions_until_next_label)
+  6. emit_loop_close()       — end
+  7. emit_block_close()      — end
+  8. emit_end()              — end  (function return)
+  9. return FunctionBody(locals=(..., i32), code=bytes)
+
+emit_segment(seg_idx, instrs):
+  1. emit: block (void)
+  2. emit: local.get $pc; i32.const seg_idx; i32.ne; br_if 0
+  3. for each instr in instrs:
+       JUMP label       → emit_jump(label); terminated=True; break
+       BRANCH_Z/NZ reg  → emit_conditional_branch(reg, label)
+       HALT             → emit_halt(); terminated=True; break
+       SYSCALL n        → emit_syscall(n)   (reuse existing helper)
+       COMMENT          → skip
+       other            → emit_simple(instr) (reuse existing helper)
+  4. if not terminated:
+       emit: i32.const (seg_idx+1); local.set $pc; br 1
+  5. emit: end
+```
+
+## Correctness Properties
+
+1. **All IR labels are reachable**: Every label becomes a segment. The
+   dispatch loop tests `$pc` against each segment index in order; when a
+   match is found the segment executes.
+
+2. **Arbitrary forward and backward jumps**: `JUMP label` and `BRANCH_Z/NZ`
+   simply set `$pc` to the target's segment index and restart the loop — there
+   is no notion of "forward only" or "backward only".
+
+3. **Fall-through preserved**: The source-order sequence of labels is also the
+   segment-index sequence.  A fall-through emits `$pc = seg_idx + 1`, which
+   is exactly the next segment in instruction-stream order — matching the
+   original IR's implicit sequential execution.
+
+4. **Identical SYSCALL output**: The WASI `fd_write` helper is reused
+   unchanged, so all `PRINT` output is byte-for-byte identical to what the
+   structured lowerer would produce on programs it can handle.
+
+## Limitations
+
+1. **Performance**: Each dispatch iteration scans all segments in order —
+   O(n) per step.  For BASIC programs with n < 200 lines this is irrelevant.
+
+2. **Dead segments**: An unreachable segment (e.g. code after an
+   unconditional `END`) still appears in the dispatch table and is visited
+   (and immediately skipped) on every iteration.
+
+3. **`CALL` / multi-function programs**: The dispatch loop lowerer applies
+   per-function, same as the structured lowerer.  Inter-function calls still
+   use the existing `CALL` instruction path.  However, it is the caller's
+   responsibility to ensure all functions in the program use the same
+   strategy; mixing strategies in one module is not supported.
+
+## Packages Affected
+
+| Package | Change |
+|---|---|
+| `ir-to-wasm-compiler` | Add `_DispatchLoopLowerer`; add `strategy` parameter to `IrToWasmCompiler.compile()` |
+| `dartmouth-basic-wasm-compiler` | Pass `strategy="dispatch_loop"` in runner |
+| All other packages | Unchanged |
+
+## Testing
+
+### `ir-to-wasm-compiler` tests
+
+Add a new `TestDispatchLoopLowerer` class that exercises:
+
+- Simple forward jump (`JUMP label`)
+- Simple conditional branch (`BRANCH_Z`, `BRANCH_NZ`)
+- Backward jump (loop)
+- Fall-through (no explicit jump at end of segment)
+- `HALT` exits the program
+- Mixed: multiple jumps and fall-throughs in the same program
+
+### `dartmouth-basic-wasm-compiler` tests
+
+The 37 existing end-to-end tests become the integration test suite — all
+should pass once the dispatch loop strategy is wired in.


### PR DESCRIPTION
## Summary

- Adds **`ir-to-wasm-compiler` dispatch-loop strategy** (`_DispatchLoopLowerer`) that handles arbitrary `GOTO`/`IF … THEN` IR control flow — JUMP and BRANCH to any label — without the structured-CF restrictions of the existing lowerer. Enabled via `IrToWasmCompiler.compile(..., strategy="dispatch_loop")`.
- Adds **`dartmouth-basic-ir-compiler` `char_encoding` parameter** (`"ge225"` default, `"ascii"` for WASM) so PRINT emits raw ASCII byte values for WASI `fd_write`.
- Adds **`dartmouth-basic-wasm-compiler`** new package: `run_basic()` chains parse → IR (ascii) → WASM (dispatch_loop) → encode → WASI runtime.
- Adds **spec `IR02-dispatch-loop-wasm-strategy.md`** documenting the virtual-PC dispatch approach and br-depth arithmetic.

## Motivation

Dartmouth BASIC uses unstructured goto-based control flow (`GOTO line`, `IF … THEN line`). The existing WASM lowerer only handles `loop_N_start/end` and `if_N_else/end` label patterns, raising `WasmLoweringError` on all BASIC IR. The dispatch loop is the standard solution used by CPython, Lua VM, and classic BASIC interpreters: it is trivially correct for all CFGs and requires ~150 LOC vs. ~400 for Relooper or ~600 for Stackifier.

## Test plan

- [ ] `ir-to-wasm-compiler` BUILD: 21 tests pass, 90.6% coverage
- [ ] `dartmouth-basic-wasm-compiler` BUILD: 60 tests pass, 100% coverage
  - LET/arithmetic (9), PRINT strings (6), PRINT numerics (10), FOR/NEXT (6), IF/THEN all 6 relational ops (8), GOTO forward+backward (2), classic programs Fibonacci/Gauss/Collatz/countdown/factorial (8), error paths all 6 stages (7), RunResult fields (4)
- [ ] Security review passed (no vulnerabilities found)

🤖 Generated with [Claude Code](https://claude.com/claude-code)