### PR TITLE
spec(img): image model, convolution, LUTs, and GPU bridge (IMG00–IMG02, IMG06)

### DIFF
--- a/code/specs/IMG00-image-model.md
+++ b/code/specs/IMG00-image-model.md
@@ -1,0 +1,642 @@
+# IMG00 — The Raster Image Model
+
+## Overview
+
+A **raster image** is a finite, rectangular grid of discrete color samples called
+**pixels** (picture elements). Every pixel lives at an integer coordinate (x, y)
+and holds a color value. The full image is simply a 2D matrix:
+
+```
+Image(W, H) = { pixel(x, y) | 0 ≤ x < W, 0 ≤ y < H }
+```
+
+Mathematically an image is a function:
+
+```
+f : ℤ × ℤ → P
+```
+
+where **P** is the **pixel type** — the set of possible color values — and the
+domain is finite: x ∈ [0, W), y ∈ [0, H).
+
+This spec defines the data model shared by every package in the IMG series. It
+answers three questions before any code is written:
+
+1. What is the structure of a pixel? (pixel types and channel formats)
+2. How are pixels arranged in memory? (layout, stride, planar vs. interleaved)
+3. What coordinate conventions does this series follow?
+
+It also provides a roadmap of the full operation taxonomy so that later specs
+(IMG01–IMG07) can position themselves within the larger whole.
+
+---
+
+## Series Overview
+
+```
+IMG00  (this spec)   Image model — pixel types, colorspaces, memory layout, coordinates
+IMG01               Convolution and spatial filters — Gaussian blur, edge detection, kernels
+IMG02               LUTs — 1D tone curves, 3D LUT (.cube format), GPU LUT textures
+IMG03               Point operations — brightness, contrast, gamma, sRGB↔linear
+IMG04               Geometric transforms — affine, perspective, scale, rotate, sampling
+IMG05               Image I/O — pure PNG, JPEG, and BMP codec implementations
+IMG06               GPU acceleration bridge — Rust+wgpu core, TypeScript+WebGPU, C-ABI FFI
+IMG07               Morphological operations — erosion, dilation, opening, closing
+```
+
+Specs IMG01–IMG05 define CPU-only implementations in every supported language
+(Python, TypeScript, Rust, Go, Ruby, etc.). IMG06 then provides a Rust crate
+that runs the same operations on the GPU and exposes a C-ABI so every language
+can call it. TypeScript additionally calls the browser's native WebGPU API
+directly.
+
+---
+
+## 1. Pixels and Channel Formats
+
+A **channel** is a single numeric component of a pixel. The numeric type of a
+channel determines its precision and the operations you can perform on it.
+
+### Primitive channel types
+
+| Type   | Width  | Range          | Typical use                          |
+|--------|--------|----------------|--------------------------------------|
+| u8     | 8-bit  | [0, 255]       | sRGB display, web images             |
+| u16    | 16-bit | [0, 65535]     | 16-bit PNG, RAW camera files         |
+| f16    | 16-bit | ≈[0.0, 65504]  | GPU textures, HDR intermediate       |
+| f32    | 32-bit | ≈[−3.4×10³⁸, …]| Linear-light computation, HDR output |
+
+The rule of thumb: **u8** for final display output (you have 8 bits of precision,
+which is enough for the human eye at typical viewing conditions); **f32** for
+anything involving arithmetic (blending, convolution, color-space conversions)
+because rounding errors accumulate fast in repeated u8 operations.
+
+### Pixel formats
+
+A pixel format specifies the number of channels, their types, and their
+semantics.
+
+```
+Format       Channels  Channel type  Bits/pixel  Notes
+───────────────────────────────────────────────────────────────────
+Luma8        1         u8            8           Grayscale
+LumaA8       2         u8            16          Grayscale + alpha
+RGB8         3         u8            24          sRGB — the web default
+RGBA8        4         u8            32          sRGB + alpha
+RGB16        3         u16           48          16-bit HDR
+RGBA16       4         u16           64          16-bit HDR + alpha
+RGB32F       3         f32           96          Linear-light HDR
+RGBA32F      4         f32           128         Linear-light HDR + alpha
+```
+
+The **alpha** channel encodes opacity: 0 = fully transparent, 255 (or 1.0) =
+fully opaque. When blending two images A and B:
+
+```
+out = A.rgb * A.alpha + B.rgb * (1 - A.alpha)   (alpha pre-multiplied: A.rgb already multiplied)
+out = A.rgb * A.alpha + B.rgb * (1 - A.alpha)   (straight alpha: A.rgb is not pre-multiplied)
+```
+
+Pre-multiplied alpha is preferred for compositing because blending is a single
+multiply-add; straight alpha requires an extra divide on output. Most render
+pipelines use pre-multiplied internally and convert at the image boundary.
+
+---
+
+## 2. Colorspaces
+
+A colorspace defines what the numbers in a pixel *mean*. Two images with
+identical byte patterns but different colorspace tags look different on screen.
+
+### sRGB — the default
+
+sRGB (IEC 61966-2-1, 1999) is the colorspace of the web, JPEG, PNG, and most
+consumer cameras. It has three properties that matter for implementation:
+
+1. **Primaries**: the CIE xy chromaticity coordinates of the red, green, and
+   blue primaries. These are device-dependent (sRGB's primaries are based on
+   the 1990s CRT phosphors), but are the world's most common convention.
+
+2. **White point**: D65 (6500 K daylight), the CIE standard illuminant used for
+   TV, print, and the web.
+
+3. **Transfer function (gamma)**: sRGB uses a piecewise function that
+   approximates a power curve with exponent ≈ 2.2:
+
+```
+sRGB → linear  (decode):
+  if C_srgb ≤ 0.04045:
+      C_linear = C_srgb / 12.92
+  else:
+      C_linear = ((C_srgb + 0.055) / 1.055) ^ 2.4
+
+linear → sRGB  (encode):
+  if C_linear ≤ 0.0031308:
+      C_srgb = C_linear × 12.92
+  else:
+      C_srgb = 1.055 × C_linear^(1/2.4) − 0.055
+```
+
+The gamma curve is the single most common source of subtle image-processing
+bugs. The rule is absolute: **convert to linear light before any arithmetic
+(blending, convolution, scaling), then convert back to sRGB for storage or
+display.**
+
+To see why, consider blending 50% black (0) and 50% white (255) in sRGB u8:
+
+```
+sRGB blend (wrong):  (0 + 255) / 2 = 127   → perceived as darker than 50% grey
+Linear blend (right):
+  linear_black = 0.0
+  linear_white = 1.0
+  linear_mid   = 0.5
+  srgb_mid     = encode_srgb(0.5) ≈ 188    → perceptually correct 50% grey
+```
+
+The difference is 127 vs 188 — a visually significant error. Every Gaussian
+blur, every scale, every image composite should happen in linear light.
+
+### Linear RGB
+
+Same primaries and white point as sRGB, but no gamma transfer: numbers are
+proportional to physical luminance. This is the correct space for:
+
+- Gaussian blur and convolution
+- Image scaling / downsampling
+- Alpha blending
+- Lighting and shading calculations
+
+### HSV and HSL
+
+HSV (Hue–Saturation–Value) and HSL (Hue–Saturation–Lightness) are cylindrical
+re-parameterisations of RGB, designed to be more intuitive for artists:
+
+```
+H (hue)        ∈ [0°, 360°)   — the "color wheel" position
+S (saturation) ∈ [0, 1]       — 0 = grey, 1 = fully saturated
+V (value)      ∈ [0, 1]       — 0 = black, 1 = as bright as the primary allows
+```
+
+```
+Color wheel — hue H:
+      60°   120°
+   Yellow   Green
+ 30°              150°
+Chartreuse       Cyan-green
+
+0°  Red                Cyan  180°
+
+300°            210°
+Magenta       Blue-green
+     240°  300°
+      Blue  Violet
+```
+
+HSV is useful for color pickers and color-range selection (e.g., "select all
+orange pixels"). It is not suitable for blending or convolution — convert to
+linear RGB first.
+
+Conversion (HSV → RGB, for H ∈ [0°, 360°), S,V ∈ [0,1]):
+
+```
+C = V × S                 (chroma)
+X = C × (1 − |H/60° mod 2 − 1|)
+m = V − C
+
+       H in [0°,60°):  (R',G',B') = (C, X, 0)
+       H in [60°,120°): (R',G',B') = (X, C, 0)
+       H in [120°,180°):(R',G',B') = (0, C, X)
+       H in [180°,240°):(R',G',B') = (0, X, C)
+       H in [240°,300°):(R',G',B') = (X, 0, C)
+       H in [300°,360°):(R',G',B') = (C, 0, X)
+
+(R, G, B) = (R'+m, G'+m, B'+m)
+```
+
+### CIE L*a*b* (CIELAB)
+
+CIELAB (CIE 1976) is a **perceptually uniform** colorspace: equal numeric
+distances correspond to equal perceived color differences for an average human
+observer under a specified viewing condition.
+
+```
+L* ∈ [0, 100]       — lightness: 0 = black, 100 = diffuse white
+a* ∈ [−128, 127]    — green (−) to red (+) opponent axis
+b* ∈ [−128, 127]    — blue (−) to yellow (+) opponent axis
+```
+
+The principal use of CIELAB is **color difference measurement**:
+
+```
+ΔE₇₆ = √(ΔL*² + Δa*² + Δb*²)
+```
+
+A ΔE of 1 is approximately the just-noticeable difference (JND) for an average
+observer. ΔE < 2 is considered acceptable for print; ΔE < 1 for critical
+colour-matching work.
+
+Conversion goes through XYZ (not reproduced in full here; see IMG03).
+
+### Oklab (Björn Ottosson, 2020)
+
+Oklab is a modern perceptually uniform colorspace with two advantages over
+CIELAB:
+
+1. **Better hue linearity**: hues do not shift when you interpolate or increase
+   saturation. A gradient from blue to red through Oklab stays vivid in the
+   middle; through HSV or sRGB it often turns muddy grey.
+2. **Simpler derivation**: a direct matrix + per-channel cube root, no
+   discontinuous cases.
+
+```
+L ∈ [0, 1]     — lightness
+a ∈ [−0.5, 0.5] — approx. green–red
+b ∈ [−0.5, 0.5] — approx. blue–yellow
+```
+
+Preferred over CIELAB for color interpolation, gradient generation, and palette
+manipulation.
+
+### YCbCr
+
+YCbCr separates **luma** (Y, the brightness signal) from two **chroma**
+channels (Cb = blue-difference, Cr = red-difference). It is the native
+colorspace of JPEG, H.264, and H.265.
+
+```
+Y  ∈ [0, 1]          — luma (weighted average of linear R, G, B)
+Cb ∈ [−0.5, 0.5]     — blue-difference chroma
+Cr ∈ [−0.5, 0.5]     — red-difference chroma
+```
+
+The reason YCbCr dominates video codecs: human vision is far more sensitive to
+luma detail than to chroma detail. So chroma can be **subsampled** — stored at
+half or quarter resolution — without visible quality loss. The most common
+scheme is **4:2:0**: luma at full resolution, both chroma channels at half
+horizontal and half vertical resolution. This saves roughly 50% bandwidth.
+
+---
+
+## 3. Memory Layout
+
+The pixel type tells us what one pixel looks like. The memory layout tells us
+how an entire image is arranged as a flat byte buffer.
+
+### Dimensions and stride
+
+```
+Field      Symbol  Description
+──────────────────────────────────────────────────────────────
+width        W     number of columns (x direction)
+height       H     number of rows (y direction)
+channels     C     components per pixel (1 for Luma, 3 for RGB, 4 for RGBA)
+bit depth    D     bits per channel (8, 16, or 32)
+stride       S     bytes from start of row i to start of row i+1
+```
+
+The minimum possible stride (tightly packed) is:
+
+```
+S_min = W × C × (D / 8)
+```
+
+Most libraries pad rows to a multiple of 4 or 16 bytes for SIMD alignment. The
+extra bytes are called **row padding** and must not be interpreted as pixel
+data.
+
+```
+Row y = 0: [pixel(0,0)][pixel(1,0)]...[pixel(W-1,0)][padding]
+Row y = 1: [pixel(0,1)][pixel(1,1)]...[pixel(W-1,1)][padding]
+...
+Row y = H-1: [pixel(0,H-1)]...[pixel(W-1,H-1)][padding]
+```
+
+Byte offset of pixel (x, y):
+
+```
+offset(x, y) = y × S + x × bytes_per_pixel
+             = y × S + x × C × (D / 8)
+```
+
+### Interleaved layout (packed)
+
+All channels of one pixel are stored together:
+
+```
+RGBA8 (interleaved):
+  R₀ G₀ B₀ A₀  R₁ G₁ B₁ A₁  R₂ G₂ B₂ A₂  ...
+  ◄── pixel 0 ──►◄── pixel 1 ──►◄── pixel 2 ──►
+```
+
+This is the default for this series. Advantages:
+
+- Cache-friendly when processing one pixel at a time (all channels adjacent)
+- The format expected by OpenGL, Metal, WebGPU textures
+- The format produced by PNG, JPEG, and BMP decoders
+
+### Planar layout
+
+All values of one channel are grouped together:
+
+```
+RGB planar (3 separate planes):
+  plane R: R₀ R₁ R₂ R₃ ... R_{W×H-1}
+  plane G: G₀ G₁ G₂ G₃ ... G_{W×H-1}
+  plane B: B₀ B₁ B₂ B₃ ... B_{W×H-1}
+```
+
+Advantages:
+
+- Excellent for SIMD: load 16 consecutive red values in a single AVX2 load
+- Used by many video codecs for YCbCr data
+- Allows different subsampling per channel (4:2:0)
+
+The GPU acceleration layer (IMG06) accepts both layouts via a layout descriptor
+passed to the shader. CPU code in this series defaults to interleaved.
+
+### Byte order for multi-byte channels
+
+For u16 and f32 channels, the byte order of the host CPU matters:
+
+- x86, ARM (LE mode): **little-endian** — least-significant byte at the lower address
+- Network byte order, most file formats: **big-endian** — most-significant byte first
+
+16-bit PNG uses big-endian u16. A little-endian CPU must byte-swap when reading:
+
+```
+u16 from big-endian bytes [hi, lo]:
+  value = (uint16_t)hi << 8 | lo
+
+u16 from little-endian bytes [lo, hi]:
+  value = lo | (uint16_t)hi << 8
+```
+
+f32 values are almost always stored in the native endianness of the host
+machine. File formats that store f32 (e.g., OpenEXR) specify endianness in
+their header.
+
+---
+
+## 4. Coordinate System
+
+This series uses the **raster coordinate system** throughout:
+
+```
+(0,0) ─────────────────── x ────────────────► (W-1, 0)
+  │
+  │    (0,0) is the TOP-LEFT corner of the top-left pixel.
+  │
+  y    x increases to the RIGHT  (column index).
+  │    y increases DOWNWARD      (row index).
+  │
+  ▼
+(0, H-1)                               (W-1, H-1)
+```
+
+This convention matches PNG, JPEG, BMP, HTML Canvas, Metal, DirectX, and
+WebGPU. It is the opposite of the mathematical Cartesian convention (y-up) used
+by OpenGL and PDF. A y-flip is one of the most common pitfalls when mixing
+rendering APIs.
+
+### Sub-pixel coordinates
+
+Geometric transforms (IMG04) and image sampling operate at sub-pixel precision.
+A sub-pixel coordinate (u, v) where u ∈ ℝ refers to a position *within* the
+image. The conversion between sub-pixel coordinates and integer pixel indices
+depends on the **sample model**:
+
+- **Pixel-centre model** (used by this series): integer (i, j) refers to the
+  centre of pixel (i, j). The pixel occupies the square [i−0.5, i+0.5) ×
+  [j−0.5, j+0.5). To sample at (u, v) bilinearly, take the four nearest
+  integer centres.
+
+- **Pixel-corner model** (used by some OpenGL code): integer (i, j) refers to
+  the top-left corner of pixel (i, j). This shifts all sample positions by
+  (0.5, 0.5) relative to the pixel-centre model.
+
+Mixing the two models is a common half-pixel alignment bug. This series always
+uses the pixel-centre model.
+
+---
+
+## 5. Categories of Image Operations
+
+Every image operation takes one or more images as input, applies a
+transformation, and produces one or more images as output. The categories below
+partition the operation space by **locality** — how far from the current pixel
+each output sample depends.
+
+### 5.1 Point operations (zero neighbourhood)
+
+Each output pixel depends only on the corresponding input pixel. The operation
+is a pure function P → P applied independently at every (x, y).
+
+```
+O(x, y) = f( I(x, y) )
+```
+
+The work is trivially parallelisable: no data dependencies between pixels.
+Modern CPUs process 16–32 u8 pixels per clock with SIMD; GPUs process millions
+per microsecond.
+
+**Examples**:
+
+| Operation           | Mapping                                                     |
+|---------------------|-------------------------------------------------------------|
+| Invert              | O = 255 − I  (u8 domain)                                   |
+| Brightness +Δ       | O = clamp(I + Δ, 0, 255)                                   |
+| Contrast ×k         | O = clamp((I − 128) × k + 128, 0, 255)                     |
+| Gamma γ             | O = (I / 255)^γ × 255                                       |
+| sRGB → linear       | piecewise function (see §2)                                 |
+| Threshold at t      | O = 255 if I ≥ t else 0                                     |
+| Channel swap        | O.R = I.B; O.G = I.G; O.B = I.R                            |
+| Colour matrix       | [O.R,O.G,O.B]ᵀ = M × [I.R,I.G,I.B]ᵀ (3×3 or 4×4 matrix)  |
+
+Point operations are specified fully in IMG03.
+
+### 5.2 Geometric transforms (coordinate remapping)
+
+The output image is formed by mapping each output coordinate (x', y') back to a
+source coordinate (u, v) and sampling the input image there. Because (u, v) is
+generally non-integer, **interpolation** is required.
+
+```
+(u, v) = T⁻¹(x', y')          (inverse warp)
+O(x', y') = sample( I, u, v )  (bilinear, bicubic, …)
+```
+
+**Examples**:
+
+| Transform          | T(x, y)                                            |
+|--------------------|----------------------------------------------------|
+| Flip horizontal    | (W−1−x, y)                                         |
+| Flip vertical      | (x, H−1−y)                                         |
+| 90° rotation (CW)  | (y, W−1−x)                                         |
+| Scale by (sx, sy)  | (x/sx, y/sy)                                       |
+| Affine warp        | M × [x, y, 1]ᵀ  where M is a 2×3 matrix           |
+| Perspective warp   | homogeneous divide: M × [x, y, 1]ᵀ / w             |
+
+Geometric transforms are specified fully in IMG04.
+
+### 5.3 Spatial filters (neighbourhood operations)
+
+Each output pixel depends on a rectangular **neighbourhood** of input pixels,
+combined using a small weight matrix called the **kernel**. This is the costliest
+operation family and the subject of IMG01.
+
+```
+O(x, y) = Σᵢ Σⱼ  K(i, j) × I(x+i, y+j)
+```
+
+**Examples**:
+
+| Filter              | What the kernel measures / applies                          |
+|---------------------|-------------------------------------------------------------|
+| Box blur            | Uniform average of the neighbourhood                        |
+| Gaussian blur       | Weighted average, weights fall off as a Gaussian            |
+| Sobel horizontal    | Approximates ∂I/∂x — detects vertical edges                |
+| Sobel vertical      | Approximates ∂I/∂y — detects horizontal edges              |
+| Laplacian           | Approximates ∇²I — highlights regions of rapid change      |
+| Sharpen             | Center minus Laplacian: accentuates edges                   |
+| Unsharp mask        | I + k × (I − blur(I)) — selective sharpening               |
+| Emboss              | Directional edge with lighting bias                         |
+
+### 5.4 LUTs and colour transforms (structured point operations)
+
+A special class of point operations where the mapping P → P is stored as a
+precomputed table rather than evaluated algebraically. The table can encode
+transformations too complex for a closed-form formula.
+
+- **1D LUT**: one table per channel; maps each channel value independently.
+  Stores arbitrary tone curves.
+- **3D LUT**: one N×N×N colour cube; maps an (R,G,B) triple to a new (R',G',B').
+  Stores arbitrary colour grades, ICC profile approximations, film looks.
+
+LUTs are the subject of IMG02.
+
+### 5.5 Frequency-domain operations (global operations)
+
+These decompose the entire image into spatial-frequency components via the
+2D Discrete Fourier Transform (DFT), operate in frequency space, then
+reconstruct.
+
+```
+F = DFT(I)          — W×H complex values, each a spatial frequency component
+F' = op(F)          — e.g., multiply by a Gaussian to low-pass filter
+O = IDFT(F')        — inverse transform back to spatial domain
+```
+
+Because the DFT is global, a single operation touches every pixel in the output.
+This makes frequency-domain operations expensive to compose but extremely
+powerful: a Gaussian blur via the DFT has O(WH log(WH)) cost compared to
+O(WHr²) for a direct spatial convolution — advantageous for very large kernels.
+
+This series does not implement full DFT-based filtering in the initial set of
+specs, but it is named here so that IMG01 (convolution) can explain when the
+spatial vs frequency tradeoff tips.
+
+---
+
+## 6. The `Image<P>` Type
+
+Every implementation package in this series provides an `Image<P>` container
+parameterised by pixel type P. The container must satisfy the following
+interface (pseudocode; language-specific syntax in each package):
+
+```
+type Image<P> {
+    width  : uint32
+    height : uint32
+    stride : uint32        // bytes per row (≥ width × sizeof(P))
+    data   : &mut [u8]     // raw byte buffer, length = stride × height
+}
+
+impl Image<P> {
+    fn new(width, height) -> Image<P>                 // stride = width × sizeof(P) (tightly packed)
+    fn new_with_stride(width, height, stride) -> Image<P>
+    fn pixel(x, y) -> &P                              // read pixel at (x, y)
+    fn pixel_mut(x, y) -> &mut P                      // write pixel at (x, y)
+    fn row(y) -> &[P]                                 // slice of one row
+    fn row_mut(y) -> &mut [P]
+    fn as_bytes() -> &[u8]                            // raw byte view
+    fn crop(x, y, w, h) -> Image<P>                  // new image backed by same buffer (zero-copy)
+}
+```
+
+The `crop` operation returns a **view** into the original buffer, not a copy.
+The cropped image has a stride that matches the original image's stride (the
+full row width), not the cropped width. This is standard practice and allows
+zero-copy region processing.
+
+---
+
+## 7. Precision and Overflow
+
+Before implementing any operation, pin down the arithmetic precision rules:
+
+### Rule 1: work in the precision of the output
+
+If the output format is f32, do all intermediate arithmetic in f32. If the
+output is u8, intermediate results may temporarily exceed [0, 255] (e.g., a
+convolution sum) and must be **clamped** before storing.
+
+### Rule 2: clamp, do not wrap
+
+u8 overflow must clamp to [0, 255], not wrap around modulo 256. A brightness
+increase that pushes 200 to 320 should produce 255, not 64 (320 mod 256).
+Wrapping produces vivid but wrong colour artefacts. Language-specific notes:
+
+- Rust: use `u8::saturating_add` / `saturating_sub`, or cast via f32.
+- C/C++: unsigned arithmetic wraps (defined behaviour); add explicit clamp.
+- Python: integers do not overflow; cast to float, clamp, then cast back.
+
+### Rule 3: accumulate convolutions in f32 or f64
+
+A 5×5 kernel times a u8 image accumulates up to 25 products. Each product ≤
+255 × 1.0 (normalised kernel) ≤ 255. The sum ≤ 255. But intermediate values
+during accumulation can reach 25 × 255 = 6375, which overflows u8 and i16.
+Always accumulate convolution sums in f32 (or i32 for integer kernels), then
+clamp to the output range.
+
+---
+
+## 8. Relationship to the Paint Stack
+
+The image model defined here is independent of the PaintVM (P2D) stack used for
+vector graphics and text rendering. The two meet at **raster compositing**:
+
+```
+PaintVM emits PaintScene instructions
+    │
+    ▼  PaintRasterizer (P2D05, P2D06)
+    │  converts vector + text → pixel buffer
+    │
+    ▼  Image<RGBA8>          ← this series
+    │
+    ▼  Display / export pipeline
+```
+
+A `PaintGlyphRun` or `PaintFillPath` instruction eventually writes pixels into
+an `Image<RGBA8>`. The image processing operations in this series (blur, LUTs,
+transforms) can be applied to that buffer before final display.
+
+---
+
+## 9. Terminology Reference
+
+| Term            | Definition                                                         |
+|-----------------|--------------------------------------------------------------------|
+| Pixel           | One sample in the image grid; a tuple of channel values            |
+| Channel         | A single numeric component of a pixel (e.g. Red, Green, Blue)     |
+| Pixel format    | The combination of channel count, type, and semantic               |
+| Stride          | Bytes from the start of row y to the start of row y+1             |
+| Interleaved     | Layout: all channels of one pixel stored together                  |
+| Planar          | Layout: all values of one channel stored together                  |
+| Colorspace      | The interpretation of pixel values as physical colours             |
+| Gamma           | The non-linear transfer function between physical and stored light |
+| Linear light    | Pixel values proportional to physical luminance; no gamma          |
+| Premultiplied α | RGB channels already multiplied by alpha                           |
+| Kernel          | A small weight matrix used in spatial convolution (IMG01)          |
+| LUT             | Look-Up Table: precomputed colour mapping (IMG02)                  |
+| Affine          | Linear transform + translation; preserves parallel lines (IMG04)   |
+| Perspective     | Projective transform; preserves straight lines but not parallelism |

--- a/code/specs/IMG01-convolution.md
+++ b/code/specs/IMG01-convolution.md
@@ -1,0 +1,748 @@
+# IMG01 — Convolution and Spatial Filters
+
+## Overview
+
+A **spatial filter** transforms each pixel of an image by computing a weighted
+combination of its neighbours. The filter is described by a small 2D matrix of
+weights called a **kernel** (or *convolution kernel*, *filter mask*). The kernel
+is slid across every pixel of the image; at each position the weights multiply
+the neighbourhood pixel values and the products are summed to produce one output
+value.
+
+```
+Input image I  ──────────────────────────────────► Output image O
+                 kernel K slides over every (x,y)
+                 O(x,y) = weighted sum of neighbourhood
+```
+
+This operation is called **discrete 2D convolution** (in practice, most
+libraries implement cross-correlation, which differs only in the sign convention
+for the kernel indices — discussed in §3).
+
+Spatial convolution underlies a huge fraction of image processing:
+
+| Goal                         | Kernel type              |
+|------------------------------|--------------------------|
+| Smooth / denoise             | Gaussian, box blur       |
+| Detect edges                 | Sobel, Prewitt, Canny    |
+| Measure curvature            | Laplacian, LoG           |
+| Sharpen                      | Unsharp mask             |
+| Emboss / stylise             | Emboss kernel            |
+| Feature extraction (CNNs)    | Learned kernels           |
+
+This spec covers: the mathematical definition, padding modes, the separable
+kernel optimisation, a library of standard kernels with examples, precision
+rules, and the computational complexity analysis that motivates GPU offloading
+(IMG06).
+
+---
+
+## 1. Motivation: Why Weighted Neighbourhoods?
+
+Before diving into the formula, consider what we want to achieve.
+
+### Smoothing (noise reduction)
+
+Raw sensor output from a camera contains random per-pixel noise: each pixel
+deviates from the "true" colour by a small random amount. If we replace each
+pixel with the **average** of its neighbours, random high-frequency fluctuations
+cancel out while the underlying image — which changes slowly — is preserved.
+
+```
+Before (noisy):   10  12  200  11  9   ← one noisy pixel (200)
+Box average (3):  (10+12+200)/3 ≈ 74   ← still high, but attenuated
+```
+
+A plain average (box blur) is the simplest kernel. A **Gaussian-weighted**
+average gives more weight to the centre pixel and less to the periphery,
+preserving the image better while still smoothing.
+
+### Edge detection
+
+An edge is a location where the image value changes rapidly. The **gradient**
+of the image — the rate of change in x and y — is high at edges and near-zero
+in flat regions. A kernel that approximates the partial derivative ∂I/∂x
+highlights vertical edges; ∂I/∂y highlights horizontal edges.
+
+```
+Smooth region:   100 100 100 101 100   gradient ≈ 0
+Edge:            10  10  10  90  90    gradient ≈ 80  ← large change
+```
+
+### Sharpening
+
+Sharpening inverts the blur idea: add a scaled version of the high-frequency
+content back to the image. The Laplacian measures high-frequency content;
+subtracting it from the image enhances edges.
+
+```
+Sharpened = I − λ × Laplacian(I)   (λ > 0)
+```
+
+All three goals follow from the same kernel machinery.
+
+---
+
+## 2. The Kernel
+
+A kernel K is a 2D array of real-valued weights. We index it with coordinates
+centred at (0, 0):
+
+```
+K has size (2r+1) × (2r+1), radius r.
+
+   col:  -r  ...  0  ...  +r
+row -r: [ K(-r,-r) ... K(0,-r) ... K(r,-r) ]
+   ...
+row  0: [ K(-r, 0) ... K( 0, 0) ... K(r, 0) ]
+   ...
+row +r: [ K(-r,+r) ... K(0,+r) ... K(r,+r) ]
+```
+
+Common kernel sizes: 3×3 (r=1), 5×5 (r=2), 7×7 (r=3). For separable
+Gaussian blurs, larger sizes (11×11, 15×15) are common.
+
+### Kernel visualisation conventions
+
+When kernels are written as boxes in code or diagrams, the top-left cell is
+(−r, −r) and the bottom-right is (+r, +r). The centre cell (0, 0) is the
+kernel element that aligns with the current pixel (x, y).
+
+```
+3×3 kernel stored as a flat array [k0, k1, …, k8]:
+
+  k0  k1  k2       K(-1,-1)  K(0,-1)  K(1,-1)
+  k3  k4  k5   =   K(-1, 0)  K(0, 0)  K(1, 0)
+  k6  k7  k8       K(-1, 1)  K(0, 1)  K(1, 1)
+```
+
+In memory the kernel is typically stored row-by-row (row-major), top to bottom.
+
+---
+
+## 3. The Discrete Convolution Formula
+
+For a kernel K of radius r, the **2D cross-correlation** of image I at pixel
+(x, y) is:
+
+```
+O(x, y) = Σᵢ₌₋ᵣ^r  Σⱼ₌₋ᵣ^r  K(i, j) × I(x+i, y+j)
+```
+
+The output pixel is a weighted sum of the (2r+1)² pixels in the neighbourhood
+centred at (x, y).
+
+### Cross-correlation vs. true convolution
+
+True mathematical 2D convolution flips the kernel:
+
+```
+(K ★ I)(x, y) = Σᵢ Σⱼ  K(i, j) × I(x−i, y−j)
+```
+
+The only difference is the sign of the offsets into I. For **symmetric**
+kernels (K(i,j) = K(−i,−j)), which includes all the common blur and edge
+kernels in §7, the two definitions produce identical output. For asymmetric
+kernels (e.g., Sobel with explicit directionality), the distinction matters.
+
+In this series we implement **cross-correlation** (matching the convention of
+most frameworks: PyTorch, TensorFlow, PIL, OpenCV) and call it convolution
+throughout. If a future package requires true convolution with an asymmetric
+kernel, flip the kernel indices before calling the standard routine.
+
+### Worked example: 3×3 box blur on a grayscale patch
+
+```
+Input patch (5×5 u8):
+   80  82  85  83  80
+   81  90 200  88  79    ← single "hot" pixel at (2,1)
+   82  85  87  84  81
+   80  83  86  85  82
+   79  81  84  82  80
+
+Box blur kernel (3×3), all weights = 1/9:
+   1/9  1/9  1/9
+   1/9  1/9  1/9
+   1/9  1/9  1/9
+
+Output at centre pixel (2,2):
+  O(2,2) = (90 + 200 + 88 + 85 + 87 + 84 + 85 + 87 + 84) / 9
+          = 790 / 9 ≈ 87.8  → 88
+
+The hot pixel (200) has been strongly attenuated. The surrounding pixels
+are barely changed.
+```
+
+---
+
+## 4. Padding Modes
+
+The kernel extends r pixels beyond each edge. For the pixels in the r-wide
+border of the image, some kernel positions would fall outside the image
+boundaries. The **padding mode** specifies what value to use for those
+out-of-bounds positions.
+
+Let W, H be image dimensions. For pixel (x, y) and offset (i, j), the
+out-of-bounds case occurs when x+i < 0, x+i ≥ W, y+j < 0, or y+j ≥ H.
+
+### Zero / constant padding
+
+```
+I(x, y) = C  for (x, y) outside image bounds  (C = 0 by default)
+```
+
+The image is treated as if surrounded by a constant-colour border.
+
+```
+Image row: [A, B, C, D, E]  with r=1
+
+Extended:  [0, A, B, C, D, E, 0]
+```
+
+Pros: simple. Cons: creates a dark (or coloured) halo around the image edge.
+Best for: edge detection (the artificial border produces a strong edge
+response, which is usually acceptable since image boundaries are not subject
+to the same processing rules as interior content).
+
+### Replicate (clamp-to-edge)
+
+```
+I(x, y) clamps:  x → clamp(x, 0, W-1),  y → clamp(y, 0, H-1)
+```
+
+The edge pixel is repeated indefinitely outside the boundary.
+
+```
+Extended:  [A, A, B, C, D, E, E]
+```
+
+Pros: no border artefact in smooth regions. Best for: blur (avoids the
+dark halo from zero-padding).
+
+### Reflect
+
+```
+I(x, y) reflects:  x → reflect(x, 0, W-1)
+where reflect(v, lo, hi):
+    period = 2*(hi - lo)
+    v = ((v - lo) mod period + period) mod period
+    if v > hi - lo: v = period - v
+    return v + lo
+```
+
+The image tiles by mirroring at its boundary (without repeating the edge pixel).
+
+```
+Original:       [A, B, C, D, E]
+Extended:  [C, B, A, B, C, D, E, D, C]
+                    ─── reflect at left ───
+```
+
+Pros: smooth continuation; no artificial edge. Best for: textures, seamless
+patterns, and any filter where you need the derivative at the boundary to match
+the interior.
+
+### Wrap (periodic / torus)
+
+```
+I(x, y) wraps:  x → x mod W,  y → y mod H  (with correct handling of negatives)
+```
+
+The image tiles to fill the plane.
+
+```
+Original:      [A, B, C, D, E]
+Extended: [D, E, A, B, C, D, E, A, B]
+```
+
+Pros: mathematically exact for FFT-based filtering (where the DFT assumes
+periodic input). Best for: frequency-domain operations, tileable textures.
+
+### Choosing a padding mode
+
+```
+Use case                         Recommended mode
+──────────────────────────────────────────────────
+General blur / smoothing         Replicate (no edge halo)
+Edge detection                   Zero (boundary gives strong response)
+Seamless texture processing      Reflect
+FFT-paired spatial filtering     Wrap
+Neural network convolutions      Zero (PyTorch / TensorFlow default)
+```
+
+---
+
+## 5. Separable Kernels
+
+A 2D kernel K is **separable** if it can be written as the outer product of two
+1D vectors:
+
+```
+K(i, j) = h(i) × v(j)
+
+where h is a 1D horizontal filter (length 2r+1)
+      v is a 1D vertical filter   (length 2r+1)
+```
+
+If K is separable, the 2D convolution decomposes into two sequential 1D passes:
+
+```
+Step 1 (horizontal):  T(x, y) = Σᵢ h(i) × I(x+i, y)
+Step 2 (vertical):    O(x, y) = Σⱼ v(j) × T(x, y+j)
+```
+
+### Why this matters
+
+The cost of a direct 2D convolution on an W×H image with a (2r+1)×(2r+1)
+kernel is:
+
+```
+ops_2d = W × H × (2r+1)²
+```
+
+The cost of two 1D passes is:
+
+```
+ops_1d = W × H × (2r+1)  [horizontal]
+       + W × H × (2r+1)  [vertical]
+       = 2 × W × H × (2r+1)
+```
+
+The ratio:
+
+```
+ops_2d / ops_1d = (2r+1)² / (2 × (2r+1)) = (2r+1) / 2
+
+r = 1  (3×3  kernel):  1.5× speedup
+r = 2  (5×5  kernel):  2.5× speedup
+r = 4  (9×9  kernel):  4.5× speedup
+r = 7  (15×15 kernel): 7.5× speedup
+```
+
+For large blur kernels the speedup is substantial.
+
+### Proof of separability for the Gaussian kernel
+
+The 2D Gaussian with standard deviation σ is:
+
+```
+G(i, j) = (1 / (2πσ²)) × exp(−(i² + j²) / (2σ²))
+```
+
+By the rules of exponentials:
+
+```
+G(i, j) = (1 / √(2πσ²)) × exp(−i² / (2σ²))
+         × (1 / √(2πσ²)) × exp(−j² / (2σ²))
+         = g(i) × g(j)
+```
+
+where g(x) = (1/√(2πσ²)) × exp(−x²/(2σ²)) is the 1D Gaussian. The 2D
+Gaussian is the outer product of two identical 1D Gaussians — it is separable.
+
+### Generating Gaussian 1D kernel coefficients
+
+For a kernel of half-width r (total width 2r+1), sample the 1D Gaussian at
+integer positions and normalise:
+
+```
+k[i] = exp(−i² / (2σ²))    for i ∈ {−r, …, +r}
+k[i] /= Σ k[i]             (normalise so weights sum to 1)
+```
+
+Choosing σ given r: a common heuristic is σ = (2r+1) / 6 so that ±3σ ≈ ±r
+(the kernel captures ~99.7% of the Gaussian mass). Another heuristic used by
+OpenCV: σ = 0.3 × (r − 1) + 0.8.
+
+Example for r=1 (3-element kernel), σ = 1.0:
+
+```
+k[-1] = exp(−1/2) ≈ 0.6065
+k[ 0] = exp(0)   = 1.0000
+k[+1] = exp(−1/2) ≈ 0.6065
+
+sum = 2.2130
+normalised: [0.274, 0.452, 0.274]  (matches the [1, 2, 1]/4 Pascal approximation)
+```
+
+---
+
+## 6. Padding and Border Handling in the Separable Pass
+
+When applying the horizontal pass first, the intermediate image T has the same
+dimensions as I. The border handling is applied independently in each pass:
+
+- Horizontal pass: only the left and right edges require clamping/padding.
+- Vertical pass: only the top and bottom edges require clamping/padding.
+
+This keeps the implementation simple: the 1D convolution routine takes a
+padding mode parameter and handles it uniformly.
+
+---
+
+## 7. Standard Kernel Library
+
+### 7.1 Box blur
+
+Uniform average over a (2r+1)×(2r+1) neighbourhood:
+
+```
+K(i, j) = 1 / (2r+1)²    for all (i, j)
+
+3×3 box blur:
+  1/9  1/9  1/9
+  1/9  1/9  1/9
+  1/9  1/9  1/9
+```
+
+Not separable in the Gaussian sense, but separable as [1,1,1]/3 × [1,1,1]/3
+(horizontal pass of uniform 1/3, then vertical). Fast in integer arithmetic:
+use a sliding-window sum that subtracts the leaving column and adds the
+entering column for O(1) amortised cost per pixel.
+
+Effect: strong blur, equal-weight average of the neighbourhood. Box blurs
+are not ideal because they have significant high-frequency ringing (their
+frequency response has large sidelobes). Gaussian blurs are preferable for
+anything that will be viewed by a human; box blurs are fine for preprocessing
+pipelines where exact visual quality is less important.
+
+### 7.2 Gaussian blur
+
+Described in §5. The canonical smoothing kernel.
+
+```
+3×3, σ≈0.85 (normalised):
+  0.0625  0.125  0.0625
+  0.125   0.25   0.125
+  0.0625  0.125  0.0625
+
+Often written as integer approximation [1 2 1 ; 2 4 2 ; 1 2 1] / 16
+```
+
+Effect: smooth, isotropic blur. The frequency-domain interpretation: a Gaussian
+kernel is a **low-pass filter** that multiplies each frequency component by
+exp(−2π²σ²f²) — it perfectly attenuates high frequencies (sharp detail) while
+leaving low frequencies (gradual colour changes) intact.
+
+Increasing σ increases the blur radius. The bandwidth of the resulting
+low-pass filter decreases with σ.
+
+### 7.3 Sobel edge detector
+
+Approximates the image gradient ∂I/∂x (horizontal) and ∂I/∂y (vertical).
+
+```
+Sobel horizontal Kₓ (detects vertical edges, gradient in x direction):
+  -1   0  +1
+  -2   0  +2
+  -1   0  +1
+
+Sobel vertical Kᵧ (detects horizontal edges, gradient in y direction):
+  -1  -2  -1
+   0   0   0
+  +1  +2  +1
+```
+
+Note: Kₓ and Kᵧ are separable:
+
+```
+Kₓ = [+1, 0, −1]ᵀ × [1, 2, 1]     (outer product: vertical smoothing × horizontal differentiation)
+Kᵧ = [1, 2, 1]ᵀ  × [+1, 0, −1]   (outer product: vertical differentiation × horizontal smoothing)
+```
+
+The magnitude of the gradient (edge strength) and its direction (edge angle):
+
+```
+Gₓ = Kₓ ★ I
+Gᵧ = Kᵧ ★ I
+
+magnitude  M(x,y) = √(Gₓ² + Gᵧ²)   (or |Gₓ| + |Gᵧ| for speed)
+direction  θ(x,y) = atan2(Gᵧ, Gₓ)   in radians
+```
+
+Example: vertical edge between left dark region and right bright region:
+
+```
+Input (grayscale):
+  10  10  10   90  90
+  10  10  10   90  90
+  10  10  10   90  90
+
+Kₓ response at the centre column (x=2):
+  −1×10 + 0×10 + 1×90  = 80   ← large response: vertical edge
+  −1×10 + 0×10 + 1×90  = 80
+  −1×10 + 0×10 + 1×90  = 80
+
+Kᵧ response at the centre row:
+  all rows are identical, so vertical difference = 0   ← no horizontal edge
+```
+
+### 7.4 Prewitt edge detector
+
+A simpler alternative to Sobel (no centre weighting):
+
+```
+Prewitt Kₓ:          Prewitt Kᵧ:
+  -1  0  +1            -1  -1  -1
+  -1  0  +1             0   0   0
+  -1  0  +1            +1  +1  +1
+```
+
+Slightly noisier than Sobel (no smoothing in the perpendicular direction) but
+marginally faster (all non-zero weights are ±1 — no multiplication needed,
+only addition/subtraction).
+
+### 7.5 Laplacian
+
+The Laplacian ∇²I = ∂²I/∂x² + ∂²I/∂y² measures the **curvature** of the
+image: it is zero in flat regions, large in magnitude at edges, and changes
+sign across an edge. Because the Laplacian is positive inside a bright blob
+and negative outside (or vice versa), zero-crossings of the Laplacian are
+precise edge locations.
+
+```
+4-connected Laplacian:        8-connected Laplacian:
+   0   1   0                   1   1   1
+   1  -4   1                   1  -8   1
+   0   1   0                   1   1   1
+```
+
+The 4-connected version approximates ∂²I/∂x² + ∂²I/∂y² using only axial
+neighbours. The 8-connected version also includes diagonal neighbours,
+making it more isotropic (less orientation-dependent).
+
+Effect: highlights regions of rapid change. Flat regions → 0. Edges →
+large positive or negative values. The output must be treated as a signed
+quantity (use i16 or f32, not u8).
+
+### 7.6 Laplacian of Gaussian (LoG)
+
+The LoG combines Gaussian smoothing (to suppress noise) with the Laplacian
+(to detect edges). Apply Gaussian first, then Laplacian. The result is
+equivalent to a single kernel:
+
+```
+LoG(x,y) = −(1/(πσ⁴)) × (1 − (x²+y²)/(2σ²)) × exp(−(x²+y²)/(2σ²))
+```
+
+Commonly approximated as a 5×5 or 9×9 kernel. The kernel has a characteristic
+"Mexican hat" profile: negative in the centre, positive ring around it, then
+zero beyond.
+
+```
+LoG approximation (5×5, σ≈1.4):
+   0   0  −1   0   0
+   0  −1  −2  −1   0
+  −1  −2  16  −2  −1
+   0  −1  −2  −1   0
+   0   0  −1   0   0
+```
+
+Zero-crossings of the LoG response mark edge positions.
+
+### 7.7 Sharpen (Laplacian subtraction)
+
+Sharpening adds back high-frequency content that was attenuated by blur or
+camera optics. The standard approach: compute the Laplacian, then subtract it
+scaled by a strength parameter λ.
+
+```
+O = I − λ × ∇²I
+
+Equivalent single kernel (λ=1, 4-connected Laplacian):
+   0  -1   0
+  -1   5  -1
+   0  -1   0
+
+= identity − Laplacian(4-connected)
+= [0,0,0; 0,1,0; 0,0,0] − [0,1,0; 1,-4,1; 0,1,0]
+= [0,-1,0; -1,5,-1; 0,-1,0]  ✓
+```
+
+Higher λ → more aggressive sharpening → more haloing around edges.
+λ = 0.5 is a gentle sharpen; λ = 2–3 is noticeable. Beyond λ ≈ 4 on typical
+images, the output begins to look over-sharpened with strong ringing.
+
+### 7.8 Unsharp mask (USM)
+
+The "unsharp mask" name is historical (it originated in darkroom photography
+where a blurred — "unsharp" — copy of the negative was used as a mask). The
+algorithm:
+
+```
+O = I + k × (I − blur(I, σ))   for some strength k > 0
+```
+
+`I − blur(I, σ)` is the **high-pass residual**: the detail the blur removed.
+Adding it back, scaled by k, enhances fine detail without the ringing of the
+direct Laplacian subtraction.
+
+Unsharp mask is separable (blur is separable; subtraction and addition are
+point operations). Typical parameters: σ = 1.0–2.0, k = 0.5–2.0.
+
+### 7.9 Emboss
+
+Highlights edges in a single diagonal direction, creating the appearance of
+a raised relief carved into metal:
+
+```
+Emboss (top-left light source):
+  -2  -1   0
+  -1   1   1
+   0   1   2
+```
+
+After applying, add 128 (or 0.5 for float) to bias the zero-centred output
+into a displayable [0, 255] range. Flat regions → 128 (grey). Edges facing
+the light source → brighter; edges facing away → darker.
+
+---
+
+## 8. Multi-Channel Images
+
+For RGB or RGBA images, apply the kernel **independently to each channel**:
+
+```
+O.R(x,y) = Σᵢ Σⱼ K(i,j) × I.R(x+i, y+j)
+O.G(x,y) = Σᵢ Σⱼ K(i,j) × I.G(x+i, y+j)
+O.B(x,y) = Σᵢ Σⱼ K(i,j) × I.B(x+i, y+j)
+```
+
+Exception: **alpha-premultiplied** images require special treatment. If an
+image uses pre-multiplied alpha, blur the RGB channels *as-is* (they already
+encode alpha-weighted colour). Blurring straight-alpha RGB separately then
+re-compositing produces colour fringing at semi-transparent edges.
+
+For edge detection on colour images, a common approach: convert to
+luminance first (Y = 0.2126R + 0.7152G + 0.0722B in linear light), detect
+edges on Y, then optionally combine with colour-channel gradient magnitudes.
+
+---
+
+## 9. Precision Rules
+
+Building on IMG00 §7:
+
+1. **Convert to linear light** before filtering. Gaussian blur in sRGB space
+   darkens edges because the gamma curve is non-linear. The error is subtle but
+   visually measurable on strong gradients.
+
+2. **Accumulate in f32**. Even for u8 input images, load each channel as f32
+   before the kernel multiply-accumulate. Store back to u8 at the end.
+
+3. **Clamp, not wrap**. After accumulation, clamp to [0, 255] before casting
+   to u8. Edge detection outputs (signed) may intentionally exceed [0, 255];
+   those should stay in f32/i16 until visualised.
+
+4. **Normalise kernels** for blurs. A blur kernel whose weights sum to 1.0
+   preserves the overall image brightness. Unnormalised kernels (like the raw
+   integer Sobel) should not be normalised — their outputs are gradient
+   measurements, not brightness.
+
+---
+
+## 10. Computational Complexity
+
+For an W×H image and a kernel of radius r:
+
+| Algorithm              | Operations per pixel | Total                    | Notes                     |
+|------------------------|---------------------|--------------------------|---------------------------|
+| Direct 2D              | (2r+1)²             | WH(2r+1)²               | Baseline                  |
+| Separable 1D (2 pass)  | 2(2r+1)             | 2WH(2r+1)               | Requires separable kernel |
+| Box blur (sliding sum) | O(1)                | O(WH)                   | Only for uniform weights  |
+| FFT-based              | —                   | O(WH log(WH))           | Good for r > ~30          |
+
+Breakeven for FFT vs separable: roughly when 2r+1 > log₂(WH)/2. For a 1024×1024
+image (log₂ ≈ 20), breakeven is around r ≈ 5 (11×11 kernel). In practice FFT
+overhead (forward and inverse transforms, complex multiply) means the breakeven
+is closer to r ≈ 15 on modern hardware with SIMD.
+
+---
+
+## 11. GPU Acceleration (Forward Reference)
+
+A spatial convolution is embarrassingly parallel at the pixel level: each output
+pixel is independent. The GPU acceleration layer (IMG06) provides WGSL compute
+shaders for:
+
+- Generic 2D kernel convolution up to 15×15
+- Separable Gaussian blur (two 1D passes)
+- Sobel edge detection (returns two output textures: Gₓ and Gᵧ)
+- LoG
+
+The GPU versions share the same precision rules (f32 intermediate) and padding
+mode interface as the CPU implementations. The CPU and GPU implementations are
+tested against each other on a suite of reference images to guarantee identical
+numerical output (within f32 rounding).
+
+---
+
+## 12. Interface
+
+Every implementation package for IMG01 must provide the following operations
+(pseudocode):
+
+```
+// Apply a 2D kernel to a single-channel or multi-channel image.
+// kernel: flat array of (2r+1)*(2r+1) f32 weights, row-major, indexed [−r..r, −r..r]
+// padding: Zero | Replicate | Reflect | Wrap
+fn convolve2d(src: &Image<P>, kernel: &[f32], radius: u32, padding: PaddingMode) -> Image<P>
+
+// Separable convolution (two 1D passes). h_kernel and v_kernel have length 2*radius+1.
+fn convolve_separable(src: &Image<P>, h: &[f32], v: &[f32], radius: u32, padding: PaddingMode) -> Image<P>
+
+// Convenience wrappers built on convolve_separable or convolve2d:
+fn gaussian_blur(src: &Image<P>, sigma: f32, padding: PaddingMode) -> Image<P>
+fn box_blur(src: &Image<P>, radius: u32, padding: PaddingMode) -> Image<P>
+fn sobel(src: &Image<Luma32F>) -> (Image<Luma32F>, Image<Luma32F>)   // returns (Gx, Gy)
+fn laplacian(src: &Image<Luma32F>, connected: Connectivity) -> Image<Luma32F>
+fn sharpen(src: &Image<P>, lambda: f32) -> Image<P>
+fn unsharp_mask(src: &Image<P>, sigma: f32, strength: f32) -> Image<P>
+```
+
+---
+
+## Appendix A: Relationship to CNN Convolutions
+
+Neural-network libraries (PyTorch, TensorFlow, JAX) expose a `conv2d` operation
+that is almost identical to what this spec defines, with these differences:
+
+| Dimension     | This spec             | CNN conv2d                                      |
+|---------------|-----------------------|-------------------------------------------------|
+| Input shape   | H × W × C            | N × C_in × H × W (batch-first, channels-first) |
+| Kernel shape  | (2r+1) × (2r+1)       | C_out × C_in × kH × kW (learned, cross-channel) |
+| Weights       | Fixed, hand-designed  | Learned during training                         |
+| Bias          | None (or baked in)    | Separate per-output-channel bias term           |
+| Stride        | Always 1              | Configurable stride for downsampling            |
+| Dilation      | Always 1              | Configurable dilation for atrous convolution    |
+
+The math is the same; the machinery around it differs. The kernels defined in
+§7 can be loaded directly into a CNN's first fixed-weight convolutional layer
+as **feature extractors**, and the output activations will be exactly the
+images described in this spec.
+
+---
+
+## Appendix B: Frequency Domain Interpretation
+
+Every kernel has a **frequency response** — the factor by which it multiplies
+each spatial frequency when applied to the image. This is the magnitude of the
+kernel's 2D DFT.
+
+```
+Kernel type        Frequency response
+─────────────────────────────────────────────────────────
+Box blur           Sinc function — good suppression of high freq,
+                   but significant ringing (sidelobes)
+Gaussian blur      Gaussian — monotone rolloff, no ringing;
+                   low-pass filter with bandwidth ∝ 1/σ
+Laplacian          ∝ f² — high-pass filter; zero DC response
+Sobel (Kₓ)        ∝ sin(2πfₓ) — differentiator in x, smoother in y
+Identity           Flat (1 everywhere) — all-pass, no change
+```
+
+The frequency-domain view explains why Gaussian blur is preferred over box blur:
+the Gaussian has no sidelobes in the frequency domain, so it does not introduce
+any ringing artefacts. Box blur's sinc frequency response has sidelobes that
+cause "ringing" — faint copies of edges — visible as concentric bright/dark bands
+around hard boundaries when the blur radius is large.

--- a/code/specs/IMG02-luts.md
+++ b/code/specs/IMG02-luts.md
@@ -1,0 +1,643 @@
+# IMG02 — LUTs: Look-Up Tables for Colour Remapping
+
+## Overview
+
+A **Look-Up Table** (LUT) replaces a computation with a table lookup. For image
+processing, LUTs store precomputed colour mappings. At runtime, each pixel's
+colour is used as an index into the table to retrieve the output colour — an
+array access is cheaper than re-evaluating the original formula.
+
+LUTs appear across the entire image-processing pipeline:
+
+| Use case                     | LUT type      | Typical size       |
+|------------------------------|---------------|--------------------|
+| Per-channel tone curves       | 1D LUT        | 256 entries (u8)   |
+| Gamma encode / decode        | 1D LUT        | 1024 entries (f32) |
+| Film look ("colour grade")   | 3D LUT        | 17³ or 33³         |
+| ICC colour profile           | 3D LUT        | 17³                |
+| Night-vision / thermal       | 3D LUT        | 33³                |
+| Hue-saturation curves        | 1D LUT × 3   | 360 entries (hue)  |
+
+This spec covers:
+
+- **1D LUTs**: per-channel tone curves, discrete and floating-point variants
+- **3D LUTs**: the full (R,G,B) → (R′,G′,B′) colour cube, the `.cube` format,
+  trilinear interpolation, tetrahedral interpolation
+- **Identity LUTs** and LUT composition
+- GPU LUTs: 3D LUTs as 3D textures for hardware-accelerated lookup
+
+---
+
+## 1. The Core Idea: Precompute Once, Lookup Many Times
+
+Any pure function f : P → P applied to every pixel of an N-megapixel image
+requires N evaluations of f. If f is cheap (one multiply) the cost is trivial.
+If f is expensive (trigonometric functions, matrix inversion, ICC profile
+interpolation), it dominates the processing budget.
+
+A LUT solves this by precomputing f at a discrete set of input values:
+
+```
+Build phase (once):
+  for i in 0..LUT_SIZE:
+      lut[i] = f(i / (LUT_SIZE - 1))    // f evaluated at uniform samples
+
+Apply phase (once per pixel):
+  output = lut[input]                    // O(1) array access
+```
+
+The trade-off: the LUT is an approximation if f is evaluated at input values
+between sample points. The approximation error is controlled by LUT size and
+interpolation method.
+
+---
+
+## 2. 1D LUTs
+
+A 1D LUT maps a single channel value to a new single channel value:
+
+```
+lut1d : C → C
+```
+
+For 8-bit images the table has exactly 256 entries — one per possible input
+value — and no interpolation is needed:
+
+```
+u8 lut[256];
+for x in 0..W:
+    for y in 0..H:
+        out.R(x,y) = lut[in.R(x,y)]
+        out.G(x,y) = lut[in.G(x,y)]   // same or different LUT per channel
+        out.B(x,y) = lut[in.B(x,y)]
+```
+
+For floating-point images the input domain [0.0, 1.0] is continuous, so
+the LUT stores n+1 breakpoints and the lookup interpolates between adjacent
+entries (§2.2).
+
+### 2.1 Building a 1D LUT
+
+Any monotone or non-monotone tone curve can be baked into a 1D LUT. Common
+examples:
+
+**Brightness and contrast** (linear transformation):
+
+```
+f(x) = contrast × x + brightness
+lut[i] = clamp(contrast × (i/255) + brightness, 0, 1) × 255
+```
+
+**Gamma correction** (power law):
+
+```
+f(x) = x^γ
+lut[i] = round( (i/255)^γ × 255 )
+
+γ < 1.0 → brightens midtones (used in display calibration)
+γ > 1.0 → darkens midtones
+γ = 1.0 → identity (no change)
+```
+
+**sRGB ↔ linear conversion** (the piecewise function from IMG00 §2):
+
+```
+// sRGB → linear:
+for i in 0..=255:
+    c = i / 255.0
+    if c <= 0.04045:
+        linear_lut[i] = c / 12.92
+    else:
+        linear_lut[i] = ((c + 0.055) / 1.055) ^ 2.4
+
+// linear → sRGB:
+for i in 0..=255:
+    c = i / 255.0
+    if c <= 0.0031308:
+        srgb_lut[i] = c * 12.92
+    else:
+        srgb_lut[i] = 1.055 * c^(1/2.4) - 0.055
+```
+
+Both conversion directions can be baked once at library initialisation and
+reused for every image. The piecewise function, evaluated naively on every
+pixel, takes ~10 ns per pixel on a modern CPU core; the LUT lookup takes
+~1 ns.
+
+**Inversion**:
+
+```
+lut[i] = 255 - i
+```
+
+**Sigmoid contrast enhancement** (S-curve):
+
+```
+f(x) = 1 / (1 + exp(−k × (x − 0.5)))   (logistic, centred at 0.5)
+```
+
+Controls: k governs the steepness of the S. k=4 is subtle; k=12 is aggressive.
+
+**Equalization** (histogram equalisation):
+
+```
+Build the CDF of the image's histogram:
+  hist[v] = count of pixels with value v
+  cdf[v]  = Σ_{u=0}^{v} hist[u]
+  cdf_min = first non-zero cdf entry
+
+Equalisation mapping:
+  lut[v] = round( (cdf[v] − cdf_min) / (W*H − cdf_min) × 255 )
+```
+
+This stretches the histogram to fill [0, 255], enhancing low-contrast images.
+
+### 2.2 Floating-Point 1D LUT with Interpolation
+
+For f32 images (linear-light pipeline), the input is in [0.0, 1.0]. A 1D LUT
+with n+1 entries stores:
+
+```
+lut_f32[k] = f(k / n)    for k in 0..=n
+```
+
+Lookup for input x ∈ [0.0, 1.0]:
+
+```
+t = x * n
+k = floor(t)                          // lower entry index
+frac = t - k                          // fractional part ∈ [0, 1)
+k = clamp(k, 0, n-1)
+output = lerp(lut_f32[k], lut_f32[k+1], frac)
+       = lut_f32[k] * (1 - frac) + lut_f32[k+1] * frac
+```
+
+Error analysis: for a function with second derivative bounded by |f''| ≤ M,
+the linear interpolation error is:
+
+```
+|error| ≤ M / (8n²)
+```
+
+For sRGB gamma (M ≈ 60 near zero), n = 1024 gives error < 60 / (8×1024²) ≈
+7×10⁻⁶ — well below the precision of f32 storage.
+
+### 2.3 Channel Independence
+
+A 1D LUT can be the **same** for all channels (e.g., overall gamma correction)
+or **different** per channel (e.g., a colour grade that brightens reds while
+leaving blues flat). The implementation stores up to three separate tables
+(R_lut, G_lut, B_lut).
+
+---
+
+## 3. 3D LUTs
+
+A 1D LUT maps each channel independently. A **3D LUT** maps an (R, G, B)
+triple as a whole to a new (R′, G′, B′) triple:
+
+```
+lut3d : (R, G, B) → (R′, G′, B′)
+```
+
+This allows any colour remapping that cannot be expressed as three independent
+channel curves — for example:
+
+- Skin tones need to be warmer (shift orange hue) without affecting other colours
+- Teal and orange film look: push blues/greens toward teal, reds/yellows toward
+  orange
+- Convert between device colour gamuts (sRGB → DCI-P3) where the mapping
+  depends on all three channels jointly
+
+### 3.1 The Lattice
+
+A 3D LUT stores output values at a regularly-spaced **N×N×N lattice** of input
+(R, G, B) points:
+
+```
+lattice[r][g][b] = (R′, G′, B′)
+
+where r, g, b ∈ {0, 1, …, N−1}
+input coordinates: R = r/(N−1),  G = g/(N−1),  B = b/(N−1)
+```
+
+Common lattice sizes:
+
+```
+N = 2  →   8 entries     (identity LUT, testing only)
+N = 17 → 4913 entries    (cinema standard; 2017 ACES interchange)
+N = 33 → 35937 entries   (high-precision colour grading)
+N = 65 → 274625 entries  (reference; used in ICC workflows)
+```
+
+Total storage: N³ × 3 × 4 bytes (three f32 per lattice point).
+
+```
+N=17: 4913 × 12 bytes ≈ 58 KB     (fits in L1 cache)
+N=33: 35937 × 12 bytes ≈ 431 KB   (fits in L2 cache)
+N=65: 274625 × 12 bytes ≈ 3.2 MB  (L3 cache or main memory)
+```
+
+### 3.2 Trilinear Interpolation
+
+To look up an arbitrary input (r, g, b) ∈ [0,1]³, locate the surrounding
+lattice cube and interpolate:
+
+```
+Step 1: find the lattice cell
+
+r_scaled = r * (N-1)
+g_scaled = g * (N-1)
+b_scaled = b * (N-1)
+
+r0 = floor(r_scaled);  r1 = r0 + 1;  fr = r_scaled - r0
+g0 = floor(g_scaled);  g1 = g0 + 1;  fg = g_scaled - g0
+b0 = floor(b_scaled);  b1 = b0 + 1;  fb = b_scaled - b0
+
+(clamp r0,g0,b0 to [0, N-2])
+
+Step 2: fetch the 8 corners of the cube
+
+c000 = lattice[r0][g0][b0]
+c001 = lattice[r0][g0][b1]
+c010 = lattice[r0][g1][b0]
+c011 = lattice[r0][g1][b1]
+c100 = lattice[r1][g0][b0]
+c101 = lattice[r1][g0][b1]
+c110 = lattice[r1][g1][b0]
+c111 = lattice[r1][g1][b1]
+
+Step 3: trilinear interpolation (blend along each axis in turn)
+
+c00 = lerp(c000, c001, fb)    // blend along B axis
+c01 = lerp(c010, c011, fb)
+c10 = lerp(c100, c101, fb)
+c11 = lerp(c110, c111, fb)
+
+c0  = lerp(c00, c01, fg)      // blend along G axis
+c1  = lerp(c10, c11, fg)
+
+out = lerp(c0, c1, fr)        // blend along R axis
+```
+
+Each `lerp` is applied independently to the three output components (R′, G′, B′).
+
+**Error of trilinear interpolation**: For a smooth colour grade, the
+interpolation error between adjacent lattice points is proportional to the
+second derivative of the mapping function and inversely proportional to N².
+For N=33 the error is below perceptual threshold (ΔE < 0.5) for typical
+photographic colour grades.
+
+### 3.3 Tetrahedral Interpolation
+
+Trilinear divides the unit cube into 8 regions (one per octant) and uses
+trilinear blending. **Tetrahedral interpolation** (Sakamoto, 1996) divides
+the cube into 6 tetrahedra and uses barycentric coordinates within the
+tetrahedron containing the input point.
+
+The 6 tetrahedra partition the cube based on the sorted order of (fr, fg, fb):
+
+```
+If fr ≥ fg ≥ fb:  vertices: (0,0,0) (1,0,0) (1,1,0) (1,1,1)
+If fr ≥ fb ≥ fg:  vertices: (0,0,0) (1,0,0) (1,0,1) (1,1,1)
+If fg ≥ fr ≥ fb:  vertices: (0,0,0) (0,1,0) (1,1,0) (1,1,1)
+If fg ≥ fb ≥ fr:  vertices: (0,0,0) (0,1,0) (0,1,1) (1,1,1)
+If fb ≥ fr ≥ fg:  vertices: (0,0,0) (0,0,1) (1,0,1) (1,1,1)
+If fb ≥ fg ≥ fr:  vertices: (0,0,0) (0,0,1) (0,1,1) (1,1,1)
+```
+
+Within the matching tetrahedron, the output is a weighted sum of the 4 vertex
+lattice values. The weights are the barycentric coordinates, which are simple
+differences of the fractional parts.
+
+Example (fr ≥ fg ≥ fb case):
+
+```
+w0 = 1 - fr
+w1 = fr - fg
+w2 = fg - fb
+w3 = fb
+
+out = w0 * c000 + w1 * c100 + w2 * c110 + w3 * c111
+```
+
+**Advantages over trilinear**:
+
+1. **More accurate**: tetrahedral interpolation exactly reproduces affine
+   (matrix) colour transforms because an affine transform is linear in 3D, and
+   barycentric coordinates within a tetrahedron preserve linearity. Trilinear
+   does not reproduce affine transforms exactly (the trilinear blend is a
+   trilinear polynomial, not a linear one).
+
+2. **Fewer memory accesses**: 4 lattice reads vs 8 for trilinear.
+
+3. **Industry standard**: DaVinci Resolve, Nuke, and After Effects all use
+   tetrahedral interpolation for 3D LUTs.
+
+---
+
+## 4. The .cube Format
+
+The `.cube` format (originally from Iridas/Adobe, now de facto standard) is the
+most widely supported LUT interchange format. It is a plain-text file.
+
+### 4.1 1D .cube (CUBE_1D_SIZE)
+
+```
+# Optional comments start with #
+TITLE "Example 1D LUT"
+LUT_1D_SIZE 4           # number of entries per channel
+# One line per entry: R G B  (0.0 to 1.0)
+0.0 0.0 0.0
+0.3 0.2 0.1
+0.8 0.7 0.6
+1.0 1.0 1.0
+```
+
+Each line gives the output (R′, G′, B′) for the corresponding input value.
+Input values are implicitly `i / (N-1)` for i in 0..N.
+
+### 4.2 3D .cube (LUT_3D_SIZE)
+
+```
+# 3D LUT example
+TITLE "Film look"
+LUT_3D_SIZE 4           # lattice dimension N; this gives a 4×4×4 = 64-entry LUT
+DOMAIN_MIN 0.0 0.0 0.0  # optional: min input value per channel
+DOMAIN_MAX 1.0 1.0 1.0  # optional: max input value per channel
+
+# Entries listed B-major, G-medium, R-slow:
+# i.e., first iterate b from 0 to N-1, then g, then r
+# r=0,g=0,b=0:
+0.000000 0.000000 0.000000
+# r=0,g=0,b=1:
+0.000000 0.000000 0.250000
+# ...
+1.000000 1.000000 1.000000
+```
+
+**Critical detail — axis ordering**: in the `.cube` format the entries are
+ordered with the **B axis varying fastest**, then G, then R:
+
+```
+for r in 0..N:
+    for g in 0..N:
+        for b in 0..N:
+            write entry for (R = r/(N-1), G = g/(N-1), B = b/(N-1))
+```
+
+When reading a `.cube` file, populate the lattice with this ordering. Reversing
+the axis order is a common bug that produces a transposed LUT (the colour grade
+is still consistent at lattice corners but interpolates incorrectly elsewhere).
+
+### 4.3 DOMAIN_MIN and DOMAIN_MAX
+
+These optional fields extend the input domain beyond [0, 1]. For example, a
+LUT that operates in scene-linear light (HDR) might specify:
+
+```
+DOMAIN_MIN 0.0 0.0 0.0
+DOMAIN_MAX 16.0 16.0 16.0
+```
+
+Before looking up, remap the input:
+
+```
+r_normalised = (r_input - domain_min.R) / (domain_max.R - domain_min.R)
+```
+
+then proceed with the standard [0,1] lookup. Clamp normalised values to [0,1].
+
+---
+
+## 5. The Identity LUT
+
+An identity LUT maps every colour to itself. It is the baseline and the
+starting point for LUT editing tools.
+
+### 1D identity LUT
+
+```
+lut[i] = i / (N - 1)    // output equals input for every entry
+```
+
+### 3D identity LUT
+
+```
+lattice[r][g][b] = (r/(N-1), g/(N-1), b/(N-1))    // output equals input
+```
+
+A useful debugging tool: generate an identity 3D LUT, write it to a `.cube`
+file, import it into the application under test, and verify that the output
+image matches the input pixel-for-pixel. Any deviation indicates a bug in the
+LUT parsing or application code.
+
+---
+
+## 6. LUT Composition
+
+Two LUTs can be **composed** (baked together) into a single LUT:
+
+```
+(A after B)(x) = A(B(x))
+```
+
+To compose a 3D LUT A and a 3D LUT B (both size N³) into a new LUT C:
+
+```
+for r in 0..N:
+    for g in 0..N:
+        for b in 0..N:
+            input = (r/(N-1), g/(N-1), b/(N-1))
+            intermediate = B.lookup(input)            // apply B to lattice point
+            C.lattice[r][g][b] = A.lookup(intermediate)  // then apply A
+```
+
+Composition avoids a double lookup at runtime: instead of applying LUT B then
+LUT A to every pixel, apply the composed LUT C once.
+
+**Precision note**: composition introduces interpolation errors twice (once
+when evaluating B at the lattice point, once when evaluating A). For N=33 this
+is acceptable; for N=17 use N=33 or 65 for the composed LUT to keep errors low.
+
+---
+
+## 7. GPU LUTs
+
+On modern GPUs, a 3D LUT maps directly to a **3D texture**:
+
+```
+CPU:
+  Upload lattice data as a 3D texture of size N×N×N, format RGB32F.
+
+GPU shader (WGSL):
+  @group(0) @binding(0) var lut_texture : texture_3d<f32>;
+  @group(0) @binding(1) var lut_sampler : sampler;
+
+  fn apply_lut(colour: vec3<f32>) -> vec3<f32> {
+      // Scale from [0,1] to [0.5/N, 1 - 0.5/N] to avoid edge clamping
+      let n = f32(textureDimensions(lut_texture).x);
+      let uv = colour * (n - 1.0) / n + 0.5 / n;
+      return textureSample(lut_texture, lut_sampler, uv).rgb;
+  }
+```
+
+The GPU's texture hardware performs **trilinear interpolation in hardware** at
+effectively zero cost — it is the same operation as trilinear texture mapping,
+which all GPUs are optimised for.
+
+Performance: applying a 33³ 3D LUT to a 4K image (3840×2160 ≈ 8 million pixels)
+takes < 1 ms on a mid-range GPU (2023), compared to ~100 ms on a single CPU
+core. The GPU turns LUT application into a free operation in a real-time
+pipeline.
+
+### Sampler configuration
+
+For trilinear interpolation on the GPU, configure the sampler with:
+
+```
+WGSL sampler descriptor:
+  addressModeU = clamp-to-edge
+  addressModeV = clamp-to-edge
+  addressModeW = clamp-to-edge
+  magFilter    = linear
+  minFilter    = linear
+```
+
+The `linear` filter enables the hardware trilinear interpolation. `nearest`
+would give nearest-lattice-point lookup (incorrect for smooth LUTs).
+
+**Note on WebGPU**: `texture_3d` with `sampler` and linear filtering is
+supported since WebGPU spec 1.0. The same WGSL code works in both the browser
+(WebGPU) and in Rust via wgpu (targeting Metal / Vulkan / DX12).
+
+---
+
+## 8. Precision and Colour Accuracy
+
+### 8.1 Floating-point LUT storage
+
+Store lattice values as f32 (or f16 if memory is constrained). The f32 format
+has 24-bit mantissa ≈ 7 decimal digits of precision. For a normalised [0,1]
+output this is far more than required.
+
+Avoid u8 LUT storage for 3D LUTs: u8 has only 8-bit per channel precision
+(256 levels), introducing quantisation error up to 1/255 ≈ 0.004 before
+interpolation. For creative colour grades this is typically invisible, but for
+technical workflows (ICC profile conversion) it fails the accuracy requirements.
+
+### 8.2 Input domain clamping
+
+Always clamp the input to [domain_min, domain_max] before lookup. Out-of-domain
+input values (from HDR images or negative values in a linear-light pipeline)
+must be clamped, not wrapped, to the nearest domain boundary.
+
+### 8.3 Applying LUTs to sRGB images
+
+A 3D LUT designed for a **linear-light** pipeline should only be applied to
+linear-light image data. Applying it to an sRGB-encoded image without prior
+gamma decode produces incorrect results (the LUT "sees" the gamma-encoded
+values, not the physical colours).
+
+Correct workflow for film look on an sRGB JPEG:
+
+```
+1. Decode JPEG → sRGB u8 image
+2. sRGB → linear f32 (apply linear_lut from §2.1)
+3. Apply 3D LUT (in linear light)
+4. linear → sRGB f32 (apply sRGB encode)
+5. Clamp to [0,1], convert to u8, encode JPEG
+```
+
+Some `.cube` files are designed for sRGB input (they have the gamma decode
+baked into the lattice). Such LUTs are typically labelled with "sRGB input" or
+"log input" in their TITLE line.
+
+---
+
+## 9. Interface
+
+Every implementation package for IMG02 must provide:
+
+```
+// 1D LUT — 256 entry (u8 domain)
+type Lut1dU8 = [u8; 256]
+
+fn build_gamma_lut(gamma: f32) -> Lut1dU8
+fn build_brightness_contrast_lut(brightness: f32, contrast: f32) -> Lut1dU8
+fn build_srgb_to_linear_lut() -> [f32; 256]
+fn build_linear_to_srgb_lut() -> [f32; 256]
+fn apply_lut1d_u8(src: &Image<RGB8>, r: &Lut1dU8, g: &Lut1dU8, b: &Lut1dU8) -> Image<RGB8>
+
+// 1D LUT — floating-point domain
+type Lut1dF32 = Vec<f32>   // n+1 entries; input domain [0,1]
+
+fn build_lut1d_f32(n: usize, f: impl Fn(f32) -> f32) -> Lut1dF32
+fn lookup_lut1d_f32(lut: &Lut1dF32, x: f32) -> f32   // linear interpolation
+fn apply_lut1d_f32(src: &Image<RGB32F>, lut: &Lut1dF32) -> Image<RGB32F>
+
+// 3D LUT
+struct Lut3d {
+    size:         usize,          // N (lattice dimension)
+    domain_min:   [f32; 3],
+    domain_max:   [f32; 3],
+    lattice:      Vec<[f32; 3]>,  // N^3 entries, B-major ordering
+}
+
+fn parse_cube(data: &str) -> Result<Lut3d, ParseError>
+fn write_cube(lut: &Lut3d) -> String
+fn identity_lut3d(size: usize) -> Lut3d
+fn compose_luts(outer: &Lut3d, inner: &Lut3d) -> Lut3d
+fn lookup_trilinear(lut: &Lut3d, r: f32, g: f32, b: f32) -> [f32; 3]
+fn lookup_tetrahedral(lut: &Lut3d, r: f32, g: f32, b: f32) -> [f32; 3]
+fn apply_lut3d(src: &Image<RGB32F>, lut: &Lut3d, method: Interpolation) -> Image<RGB32F>
+```
+
+---
+
+## Appendix A: LUT File Format Comparison
+
+| Format   | Ext      | Dim  | Max Size | Organisation                | Notes                        |
+|----------|----------|------|----------|-----------------------------|------------------------------|
+| .cube    | .cube    | 1D,3D| 65³      | Text, B-major               | Adobe/Iridas; industry std   |
+| .3dl     | .3dl     | 3D   | 64³      | Text, float or u16          | Autodesk Lustre               |
+| .csp     | .csp     | 1D,3D| —        | Text, Adobe/Cineform variant | Pre-shaper + 3D cube         |
+| .lut     | .lut     | 1D   | —        | Text, old After Effects      | Rarely used                   |
+| CLF      | .xml     | 1D,3D| —        | XML (ACES Common LUT Format) | The eventual open standard    |
+
+This series implements `.cube` only (the universal de facto standard). CLF
+(Academy S-2014-006) is the eventual open replacement and may be added later.
+
+---
+
+## Appendix B: Example .cube — Teal-and-Orange Film Look
+
+The "teal and orange" look is the most recognisable film grade of the 2010s
+blockbuster era: push midtone blues/greens toward teal, push midtone
+reds/yellows toward warm orange. Skin tones (which are orange-adjacent) are
+accentuated; the complementary teal shadows create visual contrast.
+
+A 4×4×4 identity LUT with manual teal-and-orange adjustments at a few
+key lattice points illustrates the `.cube` structure:
+
+```
+TITLE "Teal and Orange (pedagogical 4^3)"
+LUT_3D_SIZE 4
+# axes: R slow, G medium, B fast
+# Lattice at (0/3, 0/3, 0/3) = (0.0, 0.0, 0.0): black → black
+0.000 0.000 0.000
+# (0/3, 0/3, 1/3): dark blue → pushed toward teal (add green)
+0.000 0.050 0.333
+# (0/3, 0/3, 2/3): medium blue → teal
+0.000 0.200 0.667
+# (0/3, 0/3, 3/3): (0, 0, 1) pure blue → cooler teal
+0.000 0.333 0.900
+# …
+# (3/3, 1/3, 0/3): red-orange → pushed warmer
+1.080 0.250 0.000
+# (3/3, 3/3, 3/3): (1, 1, 1) white → white (no cast in highlights)
+1.000 1.000 1.000
+```
+
+A real creative LUT would have entries for all N³ lattice points; this
+abbreviated example is for illustration only.

--- a/code/specs/IMG06-gpu-bridge.md
+++ b/code/specs/IMG06-gpu-bridge.md
@@ -1,0 +1,784 @@
+# IMG06 — GPU Acceleration Bridge
+
+## Overview
+
+The CPU implementations in IMG01–IMG05 are correct and portable. They are also
+slow for large images: a Gaussian blur on a 4K frame at 24 fps requires ~2
+billion multiply-accumulates per second. A single CPU core delivers roughly
+100–200 million f32 FLOPS in a scalar loop; with SIMD, perhaps 4–8× more.
+The arithmetic cannot fit in real time on CPU alone.
+
+A modern GPU turns this budget around:
+
+```
+CPU (12 cores, AVX2):      ~50–100 GFLOPS f32
+Entry-level discrete GPU:  ~2000 GFLOPS f32  (40× faster)
+Mid-range GPU (2024):      ~15000 GFLOPS f32 (300× faster)
+```
+
+The reason is architecture. A GPU contains thousands of small shader cores that
+execute the **same program on different data** simultaneously (SIMT — Single
+Instruction, Multiple Threads). Image processing is a near-perfect fit: the
+same kernel is applied independently to every pixel (or small tile of pixels).
+
+IMG06 defines two GPU back-ends that share a common WGSL shader library:
+
+```
+Back-end A:  Rust crate  image-gpu-core
+             API: Rust   →  wgpu  →  Metal (macOS) / Vulkan (Linux) / DX12 (Windows)
+             FFI: C-ABI exported from the crate → callable from Python, Ruby, Go, …
+
+Back-end B:  TypeScript  image-gpu-ts
+             API: TypeScript → navigator.gpu (WebGPU) → native driver in browser
+```
+
+Both back-ends run identical WGSL compute shaders and produce bit-identical
+output (within f32 rounding) to the CPU reference implementations in IMG01–IMG05.
+
+---
+
+## 1. Why Two Back-Ends?
+
+### Rust + wgpu (native)
+
+**wgpu** is a Rust implementation of the WebGPU API that targets real native
+GPU APIs:
+
+```
+wgpu on macOS    → Metal
+wgpu on Linux    → Vulkan (preferred) or OpenGL 4.3
+wgpu on Windows  → Direct3D 12 (preferred) or Vulkan
+wgpu anywhere    → software (wgpu's own CPU WGSL interpreter, for CI)
+```
+
+The key advantage: one codebase, one shader language (WGSL), every desktop
+platform. No conditional compilation for Metal vs Vulkan vs DX12. The wgpu
+crate handles backend selection at runtime.
+
+A Rust crate can expose a **C-ABI** (`extern "C"` functions, `#[no_mangle]`)
+that any language with a C FFI can call. Every language in this repo already has
+a pattern for calling C libraries:
+
+```
+Python:    ctypes / cffi
+Ruby:      Fiddle / ffi gem
+Go:        cgo
+TypeScript (Node): node-ffi-napi or N-API native addon
+Java/Kotlin:   JNI or JNA
+Rust itself:   direct crate dependency
+```
+
+### TypeScript + WebGPU (browser)
+
+In the browser there is no Rust, no wgpu, no native driver access. The browser
+exposes the **WebGPU API** (`navigator.gpu`), which speaks the same conceptual
+model as wgpu. The same WGSL shaders run unchanged. The TypeScript package calls
+`navigator.gpu` directly, with no Rust in the loop.
+
+This means a web application can apply GPU-accelerated convolutions and LUTs
+without shipping a WASM binary or a native module.
+
+---
+
+## 2. WGSL Shader Library
+
+WGSL (WebGPU Shading Language) is the single shader language supported by both
+wgpu and the browser WebGPU implementation. It is a statically-typed, memory-
+safe language with no undefined behaviour. All shaders in this series are
+written in WGSL and stored in the shared directory `shaders/`.
+
+### 2.1 Compute shader model
+
+Each GPU operation is implemented as a **compute shader** dispatched over a
+2D workgroup grid:
+
+```
+Workgroup size: 8×8 threads (64 threads per workgroup)
+
+Dispatch for a W×H image:
+  groups_x = ceil(W / 8)
+  groups_y = ceil(H / 8)
+  dispatch(groups_x, groups_y, 1)
+```
+
+Each thread handles one output pixel at coordinates:
+
+```wgsl
+@compute @workgroup_size(8, 8)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let x = gid.x;
+    let y = gid.y;
+    if x >= uniforms.width || y >= uniforms.height { return; }
+    // ... process pixel (x, y) ...
+}
+```
+
+The early-return guards against threads that fall outside the image boundary
+when the image dimensions are not multiples of 8.
+
+### 2.2 Texture layout
+
+Images are uploaded to the GPU as `texture_2d<f32>` in RGBA32F format:
+
+```
+Even for RGB images: upload with a dummy alpha channel (α = 1.0).
+Even for grayscale:  upload R=G=B=value, α=1.0.
+```
+
+This uniformity simplifies shader code: every shader reads `vec4<f32>` and the
+caller strips unused channels on readback.
+
+Storage textures (`texture_storage_2d<rgba32float, write>`) are used for
+output, because compute shaders cannot write to sampled textures.
+
+### 2.3 Uniform buffer layout
+
+Each shader receives a uniform buffer with at minimum:
+
+```wgsl
+struct Uniforms {
+    width:  u32,
+    height: u32,
+    // operation-specific parameters follow
+}
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+```
+
+All uniform structs must be `16`-byte aligned (WebGPU requirement). Pad with
+dummy fields if necessary.
+
+---
+
+## 3. Shader Catalogue
+
+### 3.1 Point operations (`shaders/point_ops.wgsl`)
+
+Generic shader parameterised by a 4×4 colour matrix M applied per pixel.
+Covers brightness, contrast, colour balance, channel swap, and any linear
+colour transform:
+
+```wgsl
+struct Uniforms {
+    width:  u32,
+    height: u32,
+    matrix: mat4x4<f32>,   // applied to (R, G, B, 1) homogeneous column vector
+    _pad:   vec2<f32>,
+}
+
+@compute @workgroup_size(8, 8)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let x = gid.x;  let y = gid.y;
+    if x >= uniforms.width || y >= uniforms.height { return; }
+    let coord = vec2<i32>(i32(x), i32(y));
+    let colour = textureLoad(src, coord, 0);
+    let out = uniforms.matrix * vec4<f32>(colour.rgb, 1.0);
+    textureStore(dst, coord, vec4<f32>(clamp(out.xyz, vec3(0.0), vec3(1.0)), colour.a));
+}
+```
+
+For non-linear operations (gamma, sRGB conversion), the host builds a 1D LUT
+texture and the shader samples it (§3.4).
+
+### 3.2 2D convolution (`shaders/conv2d.wgsl`)
+
+Supports kernels up to 15×15 (radius ≤ 7). The kernel is uploaded as a uniform
+array of 225 f32 values (15×15 maximum, padded with zeros for smaller kernels).
+
+Padding mode is selected by a uniform integer:
+
+```wgsl
+const PAD_ZERO      : u32 = 0u;
+const PAD_REPLICATE : u32 = 1u;
+const PAD_REFLECT   : u32 = 2u;
+const PAD_WRAP      : u32 = 3u;
+```
+
+The shader loads the neighbourhood for each pixel, multiplies by the kernel
+weights, and accumulates in f32:
+
+```wgsl
+var acc = vec4<f32>(0.0);
+for (var j: i32 = -radius; j <= radius; j++) {
+    for (var i: i32 = -radius; i <= radius; i++) {
+        let sample_coord = pad_coord(vec2<i32>(ix + i, iy + j), uniforms.padding_mode);
+        let sample = textureLoad(src, sample_coord, 0);
+        let w = uniforms.kernel[(j + radius) * (2 * radius + 1) + (i + radius)];
+        acc += sample * w;
+    }
+}
+textureStore(dst, vec2<i32>(ix, iy), acc);
+```
+
+### 3.3 Separable convolution (`shaders/conv_sep_h.wgsl`, `shaders/conv_sep_v.wgsl`)
+
+Two-pass separable convolution for Gaussian blur and other separable filters.
+Runs two dispatches: horizontal then vertical, with an intermediate texture.
+
+The horizontal shader:
+
+```wgsl
+// Reads from src, writes to tmp (intermediate texture).
+// Kernel: 1D array of 2*radius+1 weights, applied in X direction.
+```
+
+The vertical shader:
+
+```wgsl
+// Reads from tmp, writes to dst.
+// Same kernel, applied in Y direction.
+```
+
+Using a shared intermediate texture avoids allocating a new buffer per frame.
+The host is responsible for creating `tmp` at the same dimensions as `src`.
+
+### 3.4 1D LUT application (`shaders/lut1d.wgsl`)
+
+The LUT is uploaded as a 1D texture (`texture_1d<f32>`) of N entries per
+channel. The shader samples it with linear interpolation:
+
+```wgsl
+@group(0) @binding(2) var lut_r: texture_1d<f32>;
+@group(0) @binding(3) var lut_g: texture_1d<f32>;
+@group(0) @binding(4) var lut_b: texture_1d<f32>;
+@group(0) @binding(5) var lut_sampler: sampler;
+
+fn apply_1d_luts(colour: vec3<f32>) -> vec3<f32> {
+    let r = textureSample(lut_r, lut_sampler, colour.r).r;
+    let g = textureSample(lut_g, lut_sampler, colour.g).g;
+    let b = textureSample(lut_b, lut_sampler, colour.b).b;
+    return vec3<f32>(r, g, b);
+}
+```
+
+### 3.5 3D LUT application (`shaders/lut3d.wgsl`)
+
+The 3D LUT lattice is uploaded as a `texture_3d<f32>` of size N×N×N:
+
+```wgsl
+@group(0) @binding(2) var lut3d:    texture_3d<f32>;
+@group(0) @binding(3) var lut_samp: sampler;
+
+fn apply_3d_lut(colour: vec3<f32>) -> vec3<f32> {
+    let n  = f32(textureDimensions(lut3d).x);
+    // Map [0,1] to [0.5/N, 1-0.5/N] to sample at texel centres.
+    let uv = colour * ((n - 1.0) / n) + (0.5 / n);
+    return textureSample(lut3d, lut_samp, uv).rgb;
+}
+```
+
+Hardware trilinear interpolation is used (sampler `minFilter = linear`,
+`magFilter = linear`). This matches the CPU trilinear implementation in IMG02.
+
+---
+
+## 4. The Rust Crate: `image-gpu-core`
+
+### 4.1 Crate structure
+
+```
+code/packages/rust/image-gpu-core/
+├── src/
+│   ├── lib.rs          — public Rust API + C-ABI exports
+│   ├── device.rs       — wgpu device/queue/adapter initialisation
+│   ├── pipeline.rs     — shader compilation and pipeline cache
+│   ├── texture.rs      — Image<P> ↔ wgpu texture upload/download helpers
+│   ├── ops/
+│   │   ├── conv.rs     — convolve2d, gaussian_blur, separable
+│   │   ├── lut.rs      — apply_lut1d, apply_lut3d
+│   │   └── point.rs    — colour matrix, gamma
+│   └── ffi.rs          — extern "C" functions for cross-language binding
+├── shaders/            — WGSL source files (compiled at build time via naga)
+│   ├── conv2d.wgsl
+│   ├── conv_sep_h.wgsl
+│   ├── conv_sep_v.wgsl
+│   ├── lut1d.wgsl
+│   ├── lut3d.wgsl
+│   └── point_ops.wgsl
+├── tests/
+│   ├── reference_images/ — small PNG test images
+│   └── compare_cpu_gpu.rs — pixel-by-pixel diff against CPU reference
+├── Cargo.toml
+├── BUILD
+├── README.md
+└── CHANGELOG.md
+```
+
+### 4.2 Device initialisation
+
+```rust
+pub struct GpuContext {
+    instance: wgpu::Instance,
+    adapter:  wgpu::Adapter,
+    device:   wgpu::Device,
+    queue:    wgpu::Queue,
+}
+
+impl GpuContext {
+    pub async fn new() -> Result<Self, GpuError> {
+        let instance = wgpu::Instance::default();
+        let adapter  = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::HighPerformance,
+                ..Default::default()
+            })
+            .await
+            .ok_or(GpuError::NoAdapter)?;
+        let (device, queue) = adapter
+            .request_device(&wgpu::DeviceDescriptor::default(), None)
+            .await?;
+        Ok(GpuContext { instance, adapter, device, queue })
+    }
+}
+```
+
+A global `OnceCell<GpuContext>` is initialised on the first GPU call and
+reused for the lifetime of the process. The heavy adapter/device creation
+happens once; individual operations pay only the shader-dispatch cost.
+
+### 4.3 Texture upload and download
+
+```rust
+// Upload Image<RGBA32F> to a wgpu texture.
+fn upload_texture(ctx: &GpuContext, image: &Image<RGBA32F>) -> wgpu::Texture { … }
+
+// Download a wgpu texture to Image<RGBA32F> (blocking — waits for GPU).
+fn download_texture(ctx: &GpuContext, texture: &wgpu::Texture, w: u32, h: u32) -> Image<RGBA32F> { … }
+```
+
+Both functions exist because the GPU/CPU data transfer is the dominant latency
+in short pipelines. Callers that chain multiple GPU operations should keep the
+image on the GPU (pass the texture between operations) and only download at the
+end.
+
+### 4.4 Rust public API
+
+```rust
+// All functions are synchronous from the caller's perspective.
+// Internally they submit a command buffer and wait for completion.
+
+pub fn gpu_convolve2d(
+    ctx:     &GpuContext,
+    src:     &Image<RGBA32F>,
+    kernel:  &[f32],        // (2r+1)^2 entries, row-major
+    radius:  u32,
+    padding: PaddingMode,
+) -> Result<Image<RGBA32F>, GpuError>
+
+pub fn gpu_gaussian_blur(
+    ctx:     &GpuContext,
+    src:     &Image<RGBA32F>,
+    sigma:   f32,
+    padding: PaddingMode,
+) -> Result<Image<RGBA32F>, GpuError>
+
+pub fn gpu_apply_lut3d(
+    ctx:    &GpuContext,
+    src:    &Image<RGBA32F>,
+    lut:    &Lut3d,
+) -> Result<Image<RGBA32F>, GpuError>
+
+pub fn gpu_apply_lut1d(
+    ctx:     &GpuContext,
+    src:     &Image<RGBA32F>,
+    r_lut:   &Lut1dF32,
+    g_lut:   &Lut1dF32,
+    b_lut:   &Lut1dF32,
+) -> Result<Image<RGBA32F>, GpuError>
+
+pub fn gpu_colour_matrix(
+    ctx:    &GpuContext,
+    src:    &Image<RGBA32F>,
+    matrix: &[[f32; 4]; 4],
+) -> Result<Image<RGBA32F>, GpuError>
+```
+
+---
+
+## 5. The C-ABI FFI Layer (`ffi.rs`)
+
+Every function in the public Rust API has a corresponding `extern "C"` wrapper.
+The wrappers use only C-compatible types: raw pointers, primitive integers,
+C-style structs.
+
+### 5.1 Opaque handle pattern
+
+The GPU context and image buffers are returned as opaque pointers:
+
+```rust
+// Opaque handle to GpuContext (heap-allocated, caller must free).
+pub type ImgGpuCtx = *mut GpuContext;
+
+// Opaque handle to Image<RGBA32F> (heap-allocated, caller must free).
+pub type ImgBuffer = *mut Image<RGBA32F>;
+
+#[no_mangle]
+pub extern "C" fn img_gpu_ctx_new() -> ImgGpuCtx {
+    match pollster::block_on(GpuContext::new()) {
+        Ok(ctx) => Box::into_raw(Box::new(ctx)),
+        Err(_)  => std::ptr::null_mut(),
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn img_gpu_ctx_free(ctx: ImgGpuCtx) {
+    if !ctx.is_null() { unsafe { drop(Box::from_raw(ctx)) }; }
+}
+
+#[no_mangle]
+pub extern "C" fn img_buffer_free(buf: ImgBuffer) {
+    if !buf.is_null() { unsafe { drop(Box::from_raw(buf)) }; }
+}
+```
+
+### 5.2 Image data in/out
+
+Images cross the FFI boundary as raw byte arrays with explicit dimensions:
+
+```rust
+// Create an ImgBuffer from a raw RGBA32F byte slice.
+// data: pointer to width*height*4 f32 values, row-major, interleaved RGBA.
+#[no_mangle]
+pub extern "C" fn img_buffer_from_bytes(
+    data:   *const f32,
+    width:  u32,
+    height: u32,
+) -> ImgBuffer { … }
+
+// Copy ImgBuffer pixels into a caller-provided f32 array.
+// out must be pre-allocated to width*height*4 f32 values.
+#[no_mangle]
+pub extern "C" fn img_buffer_to_bytes(buf: ImgBuffer, out: *mut f32) { … }
+
+#[no_mangle]
+pub extern "C" fn img_buffer_width(buf: ImgBuffer) -> u32 { … }
+
+#[no_mangle]
+pub extern "C" fn img_buffer_height(buf: ImgBuffer) -> u32 { … }
+```
+
+### 5.3 Operation wrappers
+
+```rust
+// Gaussian blur. Returns a new ImgBuffer (caller must free).
+#[no_mangle]
+pub extern "C" fn img_gpu_gaussian_blur(
+    ctx:          ImgGpuCtx,
+    src:          ImgBuffer,
+    sigma:        f32,
+    padding_mode: u32,   // 0=zero, 1=replicate, 2=reflect, 3=wrap
+) -> ImgBuffer { … }
+
+// Apply a 3D LUT.
+// lattice: N*N*N*3 f32 values, B-major ordering (matching .cube format).
+#[no_mangle]
+pub extern "C" fn img_gpu_apply_lut3d(
+    ctx:     ImgGpuCtx,
+    src:     ImgBuffer,
+    lattice: *const f32,
+    n:       u32,        // lattice dimension
+) -> ImgBuffer { … }
+```
+
+The full set of wrappers mirrors the Rust public API one-to-one. Every function
+that allocates returns a pointer that must be freed with `img_buffer_free`.
+
+### 5.4 Header file (`image_gpu.h`)
+
+The crate generates a C header file (via `cbindgen`) at build time:
+
+```
+code/packages/rust/image-gpu-core/image_gpu.h
+```
+
+This header is the single source of truth for the C-ABI contract. Language
+bindings in Python, Ruby, Go, etc. load the shared library and declare
+functions by referencing this header.
+
+---
+
+## 6. Per-Language Bindings
+
+Each language's binding package is a thin wrapper around the C-ABI. It handles:
+
+1. Loading the shared library (`libimage_gpu_core.so` / `.dylib` / `.dll`)
+2. Declaring the C functions
+3. Converting native image types (NumPy array, Ruby Fiddle, etc.) to/from the
+   raw byte representation expected by the FFI
+4. Calling `img_gpu_ctx_new()` lazily and caching the context
+5. Ensuring handles are freed when the native wrapper object is garbage-collected
+
+### Python (ctypes)
+
+```python
+import ctypes, numpy as np
+_lib = ctypes.CDLL("libimage_gpu_core.so")
+
+_lib.img_gpu_ctx_new.restype  = ctypes.c_void_p
+_lib.img_gpu_gaussian_blur.argtypes = [
+    ctypes.c_void_p,  # ctx
+    ctypes.c_void_p,  # src
+    ctypes.c_float,   # sigma
+    ctypes.c_uint32,  # padding_mode
+]
+_lib.img_gpu_gaussian_blur.restype = ctypes.c_void_p
+
+def gaussian_blur(image: np.ndarray, sigma: float, padding="replicate") -> np.ndarray:
+    """image: H×W×4 float32 array (RGBA, linear light)"""
+    h, w, _ = image.shape
+    src = _lib.img_buffer_from_bytes(image.ctypes.data_as(ctypes.POINTER(ctypes.c_float)), w, h)
+    dst = _lib.img_gpu_gaussian_blur(_ctx(), src, sigma, _padding_int(padding))
+    out = np.empty((h, w, 4), dtype=np.float32)
+    _lib.img_buffer_to_bytes(dst, out.ctypes.data_as(ctypes.POINTER(ctypes.c_float)))
+    _lib.img_buffer_free(dst)
+    _lib.img_buffer_free(src)
+    return out
+```
+
+### Go (cgo)
+
+```go
+// #cgo LDFLAGS: -L${SRCDIR} -limage_gpu_core
+// #include "image_gpu.h"
+import "C"
+import "unsafe"
+
+func GaussianBlur(pixels []float32, w, h int, sigma float32) []float32 {
+    ctx := C.img_gpu_ctx_new()
+    src := C.img_buffer_from_bytes((*C.float)(unsafe.Pointer(&pixels[0])), C.uint32_t(w), C.uint32_t(h))
+    dst := C.img_gpu_gaussian_blur(ctx, src, C.float(sigma), 1 /*replicate*/)
+    out := make([]float32, w*h*4)
+    C.img_buffer_to_bytes(dst, (*C.float)(unsafe.Pointer(&out[0])))
+    C.img_buffer_free(dst)
+    C.img_buffer_free(src)
+    return out
+}
+```
+
+---
+
+## 7. TypeScript + WebGPU (`image-gpu-ts`)
+
+The TypeScript package provides the same operations as the Rust crate, calling
+`navigator.gpu` directly. It shares the WGSL shader sources with the Rust crate
+(copied into the package's `shaders/` directory at build time).
+
+### 7.1 Package structure
+
+```
+code/packages/typescript/image-gpu-ts/
+├── src/
+│   ├── index.ts        — public API (re-exports)
+│   ├── context.ts      — GPUDevice acquisition and caching
+│   ├── texture.ts      — ImageData / Float32Array ↔ GPUTexture helpers
+│   ├── pipeline.ts     — shader module compilation and pipeline cache
+│   ├── ops/
+│   │   ├── conv.ts     — convolve2d, gaussianBlur
+│   │   ├── lut.ts      — applyLut1d, applyLut3d
+│   │   └── point.ts    — colourMatrix
+├── shaders/            — WGSL files (same as Rust crate's shaders/)
+├── tests/
+└── package.json
+```
+
+### 7.2 Device acquisition
+
+```typescript
+let _device: GPUDevice | null = null;
+
+async function getDevice(): Promise<GPUDevice> {
+    if (_device) return _device;
+    if (!navigator.gpu) throw new Error("WebGPU not supported");
+    const adapter = await navigator.gpu.requestAdapter({ powerPreference: "high-performance" });
+    if (!adapter) throw new Error("No GPU adapter found");
+    _device = await adapter.requestDevice();
+    return _device;
+}
+```
+
+### 7.3 Image ↔ GPUTexture
+
+Images enter the TypeScript API as `Float32Array` with layout identical to the
+Rust FFI (width × height × 4 f32 values, RGBA interleaved, row-major):
+
+```typescript
+function uploadTexture(device: GPUDevice, data: Float32Array, w: number, h: number): GPUTexture {
+    const texture = device.createTexture({
+        size: [w, h],
+        format: "rgba32float",
+        usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST,
+    });
+    device.queue.writeTexture(
+        { texture },
+        data,
+        { bytesPerRow: w * 16 },   // 4 channels × 4 bytes
+        [w, h],
+    );
+    return texture;
+}
+
+async function downloadTexture(device: GPUDevice, texture: GPUTexture, w: number, h: number): Promise<Float32Array> {
+    const bufferSize = w * h * 16;
+    const readBuf = device.createBuffer({ size: bufferSize, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ });
+    const encoder = device.createCommandEncoder();
+    encoder.copyTextureToBuffer({ texture }, { buffer: readBuf, bytesPerRow: w * 16 }, [w, h]);
+    device.queue.submit([encoder.finish()]);
+    await readBuf.mapAsync(GPUMapMode.READ);
+    const result = new Float32Array(readBuf.getMappedRange().slice(0));
+    readBuf.unmap();
+    readBuf.destroy();
+    return result;
+}
+```
+
+### 7.4 Gaussian blur example
+
+```typescript
+export async function gaussianBlur(
+    src:     Float32Array,
+    width:   number,
+    height:  number,
+    sigma:   number,
+    padding: PaddingMode = "replicate",
+): Promise<Float32Array> {
+    const device  = await getDevice();
+    const srcTex  = uploadTexture(device, src, width, height);
+    const dstTex  = device.createTexture({
+        size: [width, height],
+        format: "rgba32float",
+        usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.COPY_SRC,
+    });
+    const tmpTex  = device.createTexture({ /* same as dstTex */ });
+
+    const { hKernel, vKernel } = buildGaussianKernels(sigma);
+    // Pass 1: horizontal
+    await runSeparablePass(device, srcTex, tmpTex, hKernel, "horizontal", padding, width, height);
+    // Pass 2: vertical
+    await runSeparablePass(device, tmpTex, dstTex, vKernel, "vertical",   padding, width, height);
+
+    const result = await downloadTexture(device, dstTex, width, height);
+    srcTex.destroy();  dstTex.destroy();  tmpTex.destroy();
+    return result;
+}
+```
+
+---
+
+## 8. Testing Strategy
+
+### 8.1 CPU–GPU bit parity
+
+Every GPU operation is tested against the CPU reference implementation:
+
+```
+for each test image (small, medium, large, edge cases):
+    cpu_out = cpu_gaussian_blur(image, sigma=2.0, padding=replicate)
+    gpu_out = gpu_gaussian_blur(image, sigma=2.0, padding=replicate)
+    max_diff = max over all pixels of |cpu_out[p] - gpu_out[p]|
+    assert max_diff < 1e-4   // within f32 rounding
+```
+
+The tolerance of 1e-4 accommodates the hardware's fused multiply-add
+(FMA) units on the GPU, which can accumulate sums in a different order than
+the CPU loop. Bit-exact agreement is not possible across platforms; f32
+rounding tolerance is.
+
+### 8.2 WebGPU fallback in CI
+
+CI runs on Linux without a discrete GPU. The wgpu CI configuration uses:
+
+```
+WGPU_BACKEND=vulkan   (if Vulkan software renderer is available)
+WGPU_BACKEND=gl       (Mesa OpenGL software renderer on Ubuntu)
+```
+
+The wgpu software backend is slow (~100× slower than hardware) but functionally
+correct. All parity tests pass in CI.
+
+For the TypeScript WebGPU tests, CI uses a headless Chrome with the
+`--enable-unsafe-webgpu` flag and the Swiftshader software rasteriser.
+
+### 8.3 Cross-language FFI tests
+
+A separate test suite calls the C-ABI from a small C test binary, Python, and
+Go. These tests verify:
+
+1. The shared library loads and the symbols resolve.
+2. `img_gpu_ctx_new()` returns a non-null pointer.
+3. A round-trip `img_buffer_from_bytes` → `img_buffer_to_bytes` preserves pixel
+   values exactly.
+4. `img_gpu_gaussian_blur` on a known test image matches the pre-computed
+   CPU reference output (stored as a `.fbin` binary float file in `tests/`).
+
+---
+
+## 9. Performance Notes
+
+### Pipelining
+
+The dominant cost for a single GPU operation on a small image is not the shader
+execution — it is the CPU/GPU data transfer. Upload + download for a 1920×1080
+RGBA32F image transfers 8 MB; at PCIe 3.0 ×16 bandwidth (~12 GB/s), that is
+~0.7 ms. The shader itself runs in ~0.05 ms.
+
+Callers that need to apply multiple operations to the same image should keep the
+data on the GPU between operations:
+
+```rust
+// Efficient: single upload, multiple GPU operations, single download.
+let tex = upload_texture(&ctx, &src);
+let tex = run_gaussian_blur(&ctx, &tex, sigma, padding);
+let tex = run_apply_lut3d(&ctx, &tex, &lut);
+let result = download_texture(&ctx, &tex);
+```
+
+### Workgroup size tuning
+
+The 8×8 workgroup size (64 threads) is a conservative default that works on
+all GPUs. High-end GPUs (e.g., Apple M-series with 32-wide SIMT) can benefit
+from 16×16 (256 threads per workgroup). This is configurable at pipeline
+compilation time; the default workgroup size is queried from
+`adapter.limits().max_compute_invocations_per_workgroup` and rounded down to
+the nearest power-of-two-square.
+
+### Separable vs direct convolution on GPU
+
+Unlike the CPU case where separability gives a large speedup, on the GPU the
+crossover is different. GPU memory bandwidth is the bottleneck for large
+kernels, and the intermediate texture in the separable pass doubles the memory
+traffic. For radius ≤ 4 (9×9 or smaller), direct 2D convolution is often
+faster on GPU; for radius ≥ 5, separable wins.
+
+The API exposes both; `gpu_gaussian_blur` chooses automatically based on σ.
+
+---
+
+## 10. Interface Summary
+
+```
+image-gpu-core (Rust crate):
+  GpuContext::new() -> GpuContext
+  gpu_convolve2d(ctx, src, kernel, radius, padding) -> Image<RGBA32F>
+  gpu_convolve_separable(ctx, src, h, v, radius, padding) -> Image<RGBA32F>
+  gpu_gaussian_blur(ctx, src, sigma, padding) -> Image<RGBA32F>
+  gpu_sobel(ctx, src) -> (Image<RGBA32F>, Image<RGBA32F>)
+  gpu_apply_lut1d(ctx, src, r_lut, g_lut, b_lut) -> Image<RGBA32F>
+  gpu_apply_lut3d(ctx, src, lut) -> Image<RGBA32F>
+  gpu_colour_matrix(ctx, src, matrix) -> Image<RGBA32F>
+
+C-ABI exports (same operations, prefixed img_gpu_):
+  img_gpu_ctx_new() -> ImgGpuCtx
+  img_gpu_ctx_free(ctx)
+  img_buffer_from_bytes(data, w, h) -> ImgBuffer
+  img_buffer_to_bytes(buf, out)
+  img_buffer_free(buf)
+  img_gpu_gaussian_blur(ctx, src, sigma, padding_mode) -> ImgBuffer
+  img_gpu_apply_lut3d(ctx, src, lattice, n) -> ImgBuffer
+  img_gpu_colour_matrix(ctx, src, matrix_16f) -> ImgBuffer
+
+image-gpu-ts (TypeScript, browser WebGPU):
+  gaussianBlur(src, w, h, sigma, padding) -> Promise<Float32Array>
+  convolve2d(src, w, h, kernel, radius, padding) -> Promise<Float32Array>
+  applyLut3d(src, w, h, lut3d) -> Promise<Float32Array>
+  applyLut1d(src, w, h, rLut, gLut, bLut) -> Promise<Float32Array>
+  colourMatrix(src, w, h, matrix) -> Promise<Float32Array>
+```


### PR DESCRIPTION
## Summary

- **IMG00** — foundational raster image model: pixel formats, colorspaces (sRGB, linear, Oklab, HSV, YCbCr), row-major interleaved memory layout with stride, raster coordinate system (top-left, y-down), and a taxonomy of the five image operation families
- **IMG01** — convolution and spatial filters: discrete 2D formula, four padding modes, separable kernel optimisation, full kernel library (Gaussian, Sobel, Laplacian, LoG, sharpen, unsharp mask, emboss), frequency-domain interpretation
- **IMG02** — LUTs: 1D tone curves (sRGB↔linear bake, gamma, S-curve), 3D LUT lattice (N³), trilinear and tetrahedral interpolation, `.cube` format, identity/composition, GPU 3D textures in WGSL
- **IMG06** — GPU acceleration bridge: Rust+wgpu crate with C-ABI FFI (callable from Python, Ruby, Go, etc.) and TypeScript+WebGPU browser package; shared WGSL compute shaders for all operations; CPU/GPU parity test strategy

## Test plan

- [ ] Read all four specs for internal consistency and completeness
- [ ] Verify IMG00 series overview matches the files committed
- [ ] Verify IMG01 separable speedup table arithmetic is correct
- [ ] Verify IMG02 `.cube` axis ordering matches the Adobe spec
- [ ] Verify IMG06 WGSL snippets are syntactically valid
- [ ] Confirm no implementation code was committed (specs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)