### PR TITLE
feat(storage-sqlite): phase 1 — Header + Pager

### DIFF
--- a/code/packages/python/storage-sqlite/BUILD
+++ b/code/packages/python/storage-sqlite/BUILD
@@ -1,0 +1,4 @@
+uv venv --quiet --clear
+uv pip install -e ".[dev]" --quiet
+.venv/bin/ruff check src/ tests/
+.venv/bin/python -m pytest tests/

--- a/code/packages/python/storage-sqlite/CHANGELOG.md
+++ b/code/packages/python/storage-sqlite/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+## [0.1.0] - 2026-04-19
+
+### Added
+
+- Initial release — phase 1 of the SQLite byte-compatible file backend.
+- `storage_sqlite.header.Header` — dataclass for the 100-byte SQLite
+  database header. Field-by-field layout per the v3 spec; `from_bytes`
+  parses, `to_bytes` serialises, `new_database` constructs a fresh header
+  with the conventional defaults (page size 4096, UTF-8, schema format 4).
+  Validates magic string, page size (power-of-two, 512..65536), and text
+  encoding on parse.
+- `storage_sqlite.pager.Pager` — page-at-a-time I/O against a file, with:
+  - 1-based page numbers (page 0 is never read or written).
+  - Fixed page size of 4096 in v1.
+  - Small LRU page cache (default 32 pages).
+  - `allocate()` to claim a fresh page number at the file tail.
+  - Rollback journal at `<db>-journal`: on first write to a page within a
+    transaction, the original page contents are copied to the journal.
+    `commit()` fsyncs the journal, applies staged writes to the main file,
+    fsyncs the main file, then deletes the journal. `rollback()` discards
+    the staged writes and the journal.
+  - Context-manager protocol (`with Pager.open(path) as pager:`).
+  - Crash-recovery on `open`: if a hot journal is present, its contents are
+    replayed back into the main file before the pager becomes usable.

--- a/code/packages/python/storage-sqlite/README.md
+++ b/code/packages/python/storage-sqlite/README.md
@@ -1,0 +1,116 @@
+# coding-adventures-storage-sqlite
+
+**SQLite byte-compatible file backend** — a file-backed implementation of the
+`sql-backend` `Backend` interface that reads and writes real SQLite
+(`sqlite3`-compatible) database files.
+
+## What this package is
+
+The existing `sql-backend` package ships an `InMemoryBackend`. `mini_sqlite`
+uses it today when you call `connect(":memory:")`. This package is the
+*file-backed* sibling — the thing that will let `connect("app.db")` open a
+real on-disk SQLite database file that the `sqlite3` CLI can also read.
+
+It does that by implementing the [SQLite database file format](
+https://www.sqlite.org/fileformat2.html) from scratch, layer by layer, in
+pure Python.
+
+## Where this fits in the stack
+
+```
+mini_sqlite.connect("app.db")
+    → Connection(SqliteFileBackend("app.db"))
+    → sql-vm (unchanged)
+    → Backend interface
+    → SqliteFileBackend  (this package)
+        ├── pager    (page I/O + LRU cache + rollback journal)
+        ├── header   (100-byte database header at offset 0)
+        ├── record   (varint + serial types)      [v1 phase 2]
+        ├── btree    (table B-trees with overflow)[v1 phase 3–4]
+        ├── freelist (page reuse)                 [v1 phase 5]
+        └── schema   (sqlite_schema round-trip)   [v1 phase 6]
+```
+
+Nothing above the `Backend` line changes. The full SQL pipeline (lexer →
+parser → planner → optimizer → codegen → VM) runs unmodified against this
+backend.
+
+## What works in this phase (phase 1)
+
+Phase 1 covers the bottom two boxes:
+
+- **`header` module** — the 100-byte database header at the start of page 1.
+  Read and write every field, validate magic string and page size on open.
+- **`pager` module** — page-at-a-time I/O against the file, a small LRU cache,
+  `allocate()` for new pages, and a rollback journal that guarantees durability:
+  `commit()` flushes the journal, applies pending writes, flushes the main
+  file, then deletes the journal; `rollback()` throws away pending writes and
+  the journal.
+
+What's **not yet** in this package (coming in later phases): varint/record
+encoding, B-tree pages, `sqlite_schema`, the `Backend` adapter that wires
+the pipeline in. This phase is the unglamorous plumbing every later phase
+sits on top of.
+
+## Installation
+
+```bash
+uv pip install -e .
+```
+
+## Usage (phase 1 — primitives only)
+
+```python
+from storage_sqlite.header import Header
+from storage_sqlite.pager import Pager
+
+# Create a fresh database file.
+with Pager.create("app.db") as pager:
+    # Page 1 holds the 100-byte header at offset 0. The Header class
+    # handles field layout; Pager handles on-disk I/O.
+    header = Header.new_database(page_size=4096)
+    page1 = bytearray(pager.page_size)
+    page1[:100] = header.to_bytes()
+    pager.write(1, bytes(page1))
+    pager.commit()
+
+# Open it again — magic + page size verified.
+with Pager.open("app.db") as pager:
+    raw = pager.read(1)
+    header = Header.from_bytes(raw[:100])
+    assert header.magic == b"SQLite format 3\x00"
+    assert header.page_size == 4096
+```
+
+This intentionally looks low-level — the `Backend` adapter that makes
+`mini_sqlite.connect("app.db")` work will land in phase 7 once all the
+intermediate layers (records, B-trees, schema) are in place.
+
+## Design notes
+
+- **Page size is pinned to 4096 in v1.** SQLite supports 512–65536; variable
+  sizes land in v2.
+- **Text encoding is UTF-8.** UTF-16LE/BE are v2.
+- **Rollback journal only.** WAL is a separate, larger effort and is
+  deliberately deferred.
+- **Single-process, single-writer.** No POSIX advisory locks in v1.
+- **Pure Python.** No C extensions, no `ctypes`. Speed is not the goal —
+  faithfulness to the file format is.
+
+See [`code/specs/storage-sqlite.md`](../../../specs/storage-sqlite.md) for
+the full specification, including deferred-to-v2 items and the phased build
+order.
+
+## Testing
+
+```bash
+./BUILD
+```
+
+Runs `ruff` over `src/` and `tests/`, then `pytest` with `--cov-fail-under=95`.
+
+## References
+
+- [SQLite file format 2](https://www.sqlite.org/fileformat2.html)
+- Internal: [`sql-backend.md`](../../../specs/sql-backend.md)
+- Internal: [`storage-sqlite.md`](../../../specs/storage-sqlite.md)

--- a/code/packages/python/storage-sqlite/pyproject.toml
+++ b/code/packages/python/storage-sqlite/pyproject.toml
@@ -1,0 +1,51 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-storage-sqlite"
+version = "0.1.0"
+description = "SQLite byte-compatible file backend for the sql-backend interface."
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["sqlite", "storage", "backend", "database", "file-format", "pager", "b-tree", "education"]
+dependencies = []
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Education",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Database",
+    "Topic :: Database :: Database Engines/Servers",
+    "Topic :: Education",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4"]
+
+[project.urls]
+Homepage = "https://github.com/adhithyan15/coding-adventures"
+Repository = "https://github.com/adhithyan15/coding-adventures"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/storage_sqlite"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=storage_sqlite --cov-report=term-missing --cov-fail-under=95"
+
+[tool.ruff]
+target-version = "py312"
+line-length = 100
+src = ["src", "tests"]
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM", "ANN"]
+ignore = ["ANN401"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["ANN"]

--- a/code/packages/python/storage-sqlite/src/storage_sqlite/__init__.py
+++ b/code/packages/python/storage-sqlite/src/storage_sqlite/__init__.py
@@ -1,0 +1,30 @@
+"""
+storage-sqlite — a SQLite byte-compatible file backend.
+
+Phase 1 ships the bottom two layers of the file format:
+
+- :mod:`storage_sqlite.header` — the 100-byte database header at the start
+  of page 1.
+- :mod:`storage_sqlite.pager` — page-at-a-time I/O with an LRU cache and a
+  rollback journal.
+
+Everything else (record codec, B-trees, sqlite_schema, the Backend adapter)
+lands in subsequent phases.
+"""
+
+from storage_sqlite.errors import (
+    CorruptDatabaseError,
+    JournalError,
+    StorageError,
+)
+from storage_sqlite.header import Header
+from storage_sqlite.pager import PAGE_SIZE, Pager
+
+__all__ = [
+    "PAGE_SIZE",
+    "CorruptDatabaseError",
+    "Header",
+    "JournalError",
+    "Pager",
+    "StorageError",
+]

--- a/code/packages/python/storage-sqlite/src/storage_sqlite/errors.py
+++ b/code/packages/python/storage-sqlite/src/storage_sqlite/errors.py
@@ -1,0 +1,31 @@
+"""
+Storage-level exceptions.
+
+These live at a layer below the SQL pipeline — they describe things that
+went wrong with the file, not with the query. The SQL facade translates
+them into PEP 249 classes at a higher level.
+"""
+
+from __future__ import annotations
+
+
+class StorageError(Exception):
+    """Base class for everything in this package."""
+
+
+class CorruptDatabaseError(StorageError):
+    """The file on disk does not look like a valid SQLite database.
+
+    Examples: wrong magic string, page size not a supported power of two,
+    file shorter than a single page, journal out of sync with the main file.
+    """
+
+
+class JournalError(StorageError):
+    """Something went wrong with the rollback journal.
+
+    Raised when a recovery replay encounters an inconsistent journal (e.g.
+    truncated, bad length prefix). Distinct from :class:`CorruptDatabaseError`
+    because a corrupt journal is often recoverable — we can just throw the
+    journal away and trust the main file.
+    """

--- a/code/packages/python/storage-sqlite/src/storage_sqlite/header.py
+++ b/code/packages/python/storage-sqlite/src/storage_sqlite/header.py
@@ -1,0 +1,303 @@
+"""
+The 100-byte SQLite database header.
+
+Every SQLite database file begins with a 100-byte header at byte offset 0.
+The header lives on page 1 — after it, the rest of page 1 (bytes 100 through
+``page_size - 1``) is the beginning of the ``sqlite_schema`` B-tree. That
+overlap makes page 1 special: every *other* page is a full ``page_size``
+bytes of one thing (B-tree page, overflow page, freelist page, etc.), but
+page 1's first 100 bytes are this fixed metadata block.
+
+We model the header as a frozen dataclass with one field per header slot.
+``from_bytes`` parses, ``to_bytes`` serialises, and ``new_database``
+constructs a fresh header for writing a new file.
+
+Byte layout (all multi-byte integers big-endian):
+
+::
+
+    offset  size  field
+       0    16    magic                  b"SQLite format 3\\0"
+      16     2    page_size              u16 (4096 in v1)
+      18     1    file_format_write_version   1 (legacy) / 2 (WAL)
+      19     1    file_format_read_version    1 (legacy) / 2 (WAL)
+      20     1    reserved_per_page           0
+      21     1    max_embedded_payload_fraction  64
+      22     1    min_embedded_payload_fraction  32
+      23     1    leaf_payload_fraction          32
+      24     4    file_change_counter    u32 (bumped on every write txn)
+      28     4    database_size_pages    u32 (size in pages per header)
+      32     4    first_freelist_trunk   u32 (0 if none)
+      36     4    freelist_page_count    u32
+      40     4    schema_cookie          u32 (bumped when sqlite_schema changes)
+      44     4    schema_format          u32 (4 — supports everything we need)
+      48     4    default_cache_size     u32
+      52     4    largest_root_btree     u32 (incremental vacuum — 0 in v1)
+      56     4    text_encoding          u32 (1 = UTF-8)
+      60     4    user_version           u32
+      64     4    incremental_vacuum     u32
+      68     4    application_id         u32
+      72    20    reserved               20 zero bytes
+      92     4    version_valid_for      u32 (== file_change_counter)
+      96     4    sqlite_version_number  u32 (arbitrary; we pick 3046002)
+
+Notes:
+
+- ``max_embedded_payload_fraction`` and ``min_embedded_payload_fraction``
+  have fixed values in every SQLite database ever written (64 and 32). We
+  accept only those values on parse. Same for ``leaf_payload_fraction``.
+- Page size 1 is a legal SQLite encoding that *means* 65536 (the format
+  could not fit 65536 in a u16). v1 only uses 4096, but we accept the
+  encoded form for forward-compat on parse — storing ``page_size = 65536``
+  after decoding.
+
+References: `SQLite file format §1.3 <https://www.sqlite.org/fileformat2.html>`_.
+"""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass, field
+from typing import ClassVar
+
+from storage_sqlite.errors import CorruptDatabaseError
+
+# The first 16 bytes of every SQLite database: ASCII "SQLite format 3" plus
+# a trailing NUL. If a file starts with anything else, it's not ours.
+MAGIC: bytes = b"SQLite format 3\x00"
+
+# The header is *exactly* 100 bytes, always. The format has no variable-
+# length fields in this region.
+HEADER_SIZE: int = 100
+
+# Valid SQLite page sizes are powers of two from 512 to 32768 inclusive,
+# plus the special value 65536 (encoded as 1 in the u16 slot). v1 pins on
+# 4096 — the default and by far the most common size.
+_VALID_PAGE_SIZES: frozenset[int] = frozenset({512, 1024, 2048, 4096, 8192, 16384, 32768, 65536})
+
+# Text encodings — only UTF-8 is supported in v1. Reading a file that
+# declares UTF-16 (2 or 3) is a "not yet supported" error, not corruption.
+_UTF8: int = 1
+
+# ``struct`` format string that packs/unpacks every fixed-size field from
+# offset 16 onward. The 16-byte magic and the 20-byte reserved block are
+# handled separately because ``struct`` doesn't have a clean way to express
+# "these bytes are fixed literals and we validate them".
+#
+#   >   big-endian
+#   H   page_size                    (u16)
+#   B   file_format_write_version    (u8)
+#   B   file_format_read_version     (u8)
+#   B   reserved_per_page            (u8)
+#   B   max_embedded_payload_fraction(u8)
+#   B   min_embedded_payload_fraction(u8)
+#   B   leaf_payload_fraction        (u8)
+#   I   file_change_counter          (u32)
+#   I   database_size_pages          (u32)
+#   I   first_freelist_trunk         (u32)
+#   I   freelist_page_count          (u32)
+#   I   schema_cookie                (u32)
+#   I   schema_format                (u32)
+#   I   default_cache_size           (u32)
+#   I   largest_root_btree           (u32)
+#   I   text_encoding                (u32)
+#   I   user_version                 (u32)
+#   I   incremental_vacuum           (u32)
+#   I   application_id               (u32)
+_AFTER_MAGIC_FMT: str = ">HBBBBBBIIIIIIIIIIII"
+
+# Fields at the tail: version_valid_for (u32) then sqlite_version_number
+# (u32). Separated from the middle block by the 20-byte reserved zero
+# region at offset 72.
+_TAIL_FMT: str = ">II"
+
+
+@dataclass(frozen=True, slots=True)
+class Header:
+    """The 100-byte SQLite database header.
+
+    Use :meth:`new_database` to construct a fresh one, :meth:`from_bytes` to
+    parse an existing file's first 100 bytes, and :meth:`to_bytes` to
+    serialise.
+    """
+
+    magic: bytes = MAGIC
+    page_size: int = 4096
+    file_format_write_version: int = 1
+    file_format_read_version: int = 1
+    reserved_per_page: int = 0
+    max_embedded_payload_fraction: int = 64
+    min_embedded_payload_fraction: int = 32
+    leaf_payload_fraction: int = 32
+    file_change_counter: int = 0
+    database_size_pages: int = 1
+    first_freelist_trunk: int = 0
+    freelist_page_count: int = 0
+    schema_cookie: int = 0
+    schema_format: int = 4
+    default_cache_size: int = 0
+    largest_root_btree: int = 0
+    text_encoding: int = _UTF8
+    user_version: int = 0
+    incremental_vacuum: int = 0
+    application_id: int = 0
+    reserved: bytes = field(default=b"\x00" * 20)
+    version_valid_for: int = 0
+    # A fixed SQLite version tag so tools like ``sqlite3 .dbinfo`` show
+    # something plausible. The value is arbitrary from our perspective —
+    # SQLite ignores it on read. 3.46.2 → 3 046 002.
+    sqlite_version_number: int = 3_046_002
+
+    SIZE: ClassVar[int] = HEADER_SIZE
+
+    # ------------------------------------------------------------------
+    # Construction.
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def new_database(cls, *, page_size: int = 4096) -> Header:
+        """Return a brand-new header for an empty database.
+
+        ``database_size_pages`` defaults to 1 because a freshly-created file
+        has exactly one page — page 1, which contains just this header.
+        """
+        if page_size not in _VALID_PAGE_SIZES:
+            raise ValueError(
+                f"page_size must be one of {sorted(_VALID_PAGE_SIZES)}, got {page_size}"
+            )
+        return cls(page_size=page_size)
+
+    # ------------------------------------------------------------------
+    # Parsing.
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> Header:
+        """Parse 100 bytes into a :class:`Header`.
+
+        Raises :class:`CorruptDatabaseError` if the magic string is wrong,
+        the page size is invalid, or a field has an impossible value.
+        """
+        if len(data) < HEADER_SIZE:
+            raise CorruptDatabaseError(
+                f"header must be at least {HEADER_SIZE} bytes, got {len(data)}"
+            )
+
+        magic = bytes(data[:16])
+        if magic != MAGIC:
+            raise CorruptDatabaseError(f"not a SQLite database: bad magic {magic!r}")
+
+        # Unpack every fixed-size field from offset 16..72 in one go.
+        (
+            encoded_page_size,
+            write_v,
+            read_v,
+            reserved_pp,
+            max_payload,
+            min_payload,
+            leaf_payload,
+            change_counter,
+            db_size_pages,
+            first_freelist,
+            freelist_count,
+            schema_cookie,
+            schema_format,
+            default_cache,
+            largest_root,
+            text_encoding,
+            user_version,
+            incremental_vacuum,
+            application_id,
+        ) = struct.unpack_from(_AFTER_MAGIC_FMT, data, 16)
+
+        # The u16 at offset 16 encodes 65536 as 1 — that's the only page
+        # size that doesn't fit in 16 bits.
+        page_size = 65536 if encoded_page_size == 1 else encoded_page_size
+        if page_size not in _VALID_PAGE_SIZES:
+            raise CorruptDatabaseError(f"invalid page_size {page_size}")
+
+        # These three are *always* 64/32/32 in valid SQLite databases. If
+        # they differ, the file was produced by something broken or
+        # intentionally malformed — refuse rather than guess.
+        if (max_payload, min_payload, leaf_payload) != (64, 32, 32):
+            raise CorruptDatabaseError(
+                "invalid payload fractions: expected (64, 32, 32), got "
+                f"({max_payload}, {min_payload}, {leaf_payload})"
+            )
+
+        if text_encoding != _UTF8:
+            raise CorruptDatabaseError(
+                f"unsupported text encoding {text_encoding}: v1 supports only UTF-8 (1)"
+            )
+
+        # The 20-byte reserved block at offset 72 must be all zeros per spec.
+        reserved = bytes(data[72:92])
+        if reserved != b"\x00" * 20:
+            raise CorruptDatabaseError("reserved bytes at offset 72..91 are non-zero")
+
+        version_valid_for, sqlite_version_number = struct.unpack_from(_TAIL_FMT, data, 92)
+
+        return cls(
+            magic=magic,
+            page_size=page_size,
+            file_format_write_version=write_v,
+            file_format_read_version=read_v,
+            reserved_per_page=reserved_pp,
+            max_embedded_payload_fraction=max_payload,
+            min_embedded_payload_fraction=min_payload,
+            leaf_payload_fraction=leaf_payload,
+            file_change_counter=change_counter,
+            database_size_pages=db_size_pages,
+            first_freelist_trunk=first_freelist,
+            freelist_page_count=freelist_count,
+            schema_cookie=schema_cookie,
+            schema_format=schema_format,
+            default_cache_size=default_cache,
+            largest_root_btree=largest_root,
+            text_encoding=text_encoding,
+            user_version=user_version,
+            incremental_vacuum=incremental_vacuum,
+            application_id=application_id,
+            reserved=reserved,
+            version_valid_for=version_valid_for,
+            sqlite_version_number=sqlite_version_number,
+        )
+
+    # ------------------------------------------------------------------
+    # Serialisation.
+    # ------------------------------------------------------------------
+
+    def to_bytes(self) -> bytes:
+        """Serialise to exactly 100 bytes, ready to splice into page 1."""
+        # 65536 is encoded as 1 because it doesn't fit in the u16 slot.
+        encoded_page_size = 1 if self.page_size == 65536 else self.page_size
+
+        buf = bytearray(HEADER_SIZE)
+        buf[:16] = self.magic
+        struct.pack_into(
+            _AFTER_MAGIC_FMT,
+            buf,
+            16,
+            encoded_page_size,
+            self.file_format_write_version,
+            self.file_format_read_version,
+            self.reserved_per_page,
+            self.max_embedded_payload_fraction,
+            self.min_embedded_payload_fraction,
+            self.leaf_payload_fraction,
+            self.file_change_counter,
+            self.database_size_pages,
+            self.first_freelist_trunk,
+            self.freelist_page_count,
+            self.schema_cookie,
+            self.schema_format,
+            self.default_cache_size,
+            self.largest_root_btree,
+            self.text_encoding,
+            self.user_version,
+            self.incremental_vacuum,
+            self.application_id,
+        )
+        buf[72:92] = self.reserved
+        struct.pack_into(_TAIL_FMT, buf, 92, self.version_valid_for, self.sqlite_version_number)
+        return bytes(buf)

--- a/code/packages/python/storage-sqlite/src/storage_sqlite/pager.py
+++ b/code/packages/python/storage-sqlite/src/storage_sqlite/pager.py
@@ -1,0 +1,498 @@
+"""
+The pager: the bottom of the storage stack.
+
+The pager is the only thing that touches the database file. Everything
+above — B-trees, records, ``sqlite_schema`` — reads and writes pages
+through this object and never seeks raw bytes on the file.
+
+What the pager guarantees
+-------------------------
+
+**Page I/O.** Fixed-size 4096-byte pages, 1-based numbering (page 1 at
+byte offset 0, page 2 at byte offset 4096, …). Reads return exactly
+4096 bytes; writes take exactly 4096 bytes. Page 0 is illegal.
+
+**Caching.** A small LRU cache (default 32 pages) holds recently-read
+clean pages. Writes go first to an in-memory dirty-page table; they
+don't touch the file until :meth:`commit`.
+
+**Atomic commit via a rollback journal.** A transaction's writes are
+staged in memory. :meth:`commit` does this sequence:
+
+    1. Build a journal of *original* contents for every page being
+       modified that existed before this transaction.
+    2. Write the journal header with a sentinel record-count and fsync
+       the journal.
+    3. Finalise the journal header with the real record-count, fsync
+       the journal.
+    4. Apply every dirty page to the main file, fsync the main file.
+    5. Delete the journal.
+
+A crash anywhere in steps 1–3 leaves a non-finalised journal that
+recovery discards (main file untouched). A crash in step 4 leaves a
+finalised journal that recovery replays, rolling the main file back to
+its pre-transaction state (no partial commit). A crash in step 5 also
+replays — the user hadn't received a "commit succeeded" signal yet so
+the rollback is legitimate. This is the standard SQLite undo-log
+protocol.
+
+:meth:`rollback` just drops the in-memory dirty-page table. Nothing has
+been written to disk mid-transaction, so there is no journal file to
+clean up on the mid-transaction path.
+
+:meth:`open` performs crash recovery before returning: if a journal
+file is present, it is replayed (if finalised) or deleted (if not) so
+the main file is consistent before any caller sees it.
+
+**v1 limitations** (deferred per ``code/specs/storage-sqlite.md``):
+
+- Page size is pinned at 4096. Other sizes are valid SQLite but not yet
+  supported here.
+- Large transactions hold every dirty page in memory until commit. Real
+  SQLite spills to disk; we don't (yet).
+- Single-process, single-writer. No POSIX advisory locking.
+- Journal format is our own simple layout, not the real SQLite rollback
+  journal byte layout. That's fine because the journal file is transient
+  and only relevant to *our* crash recovery — the *main* file is what
+  must be byte-compatible with SQLite, and this module doesn't impose a
+  format on the main file at all.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import struct
+from collections import OrderedDict
+from pathlib import Path
+from types import TracebackType
+
+from storage_sqlite.errors import CorruptDatabaseError, JournalError
+
+PAGE_SIZE: int = 4096
+"""Fixed page size for v1. SQLite supports 512..65536 in powers of two;
+we'll add the rest in v2."""
+
+_DEFAULT_CACHE_PAGES: int = 32
+
+# Our rollback journal format. See module docstring for the protocol.
+#
+#   [20-byte header]
+#     0..8   magic      b"RJRNL\\0\\1\\0"   (8 bytes, arbitrary — not SQLite's)
+#     8..12  page_size  u32 BE
+#     12..16 record_cnt u32 BE  (sentinel 0xFFFFFFFF while mid-flight;
+#                                 real count after finalisation)
+#     16..20 initial_size_pages u32 BE  (file size at txn start — used
+#                                        to truncate the main file back
+#                                        on replay)
+#   [each record]
+#     0..4   page_no    u32 BE
+#     4..4 + PAGE_SIZE  original page contents
+_JOURNAL_MAGIC: bytes = b"RJRNL\x00\x01\x00"
+_JOURNAL_HEADER_FMT: str = ">8sIII"
+_JOURNAL_HEADER_SIZE: int = 20
+_JOURNAL_SENTINEL: int = 0xFFFFFFFF
+_RECORD_PREFIX_FMT: str = ">I"
+_RECORD_PREFIX_SIZE: int = 4
+
+
+class Pager:
+    """Page-at-a-time I/O with LRU cache and rollback journal.
+
+    Lifecycle: :meth:`create` for a brand-new file, :meth:`open` for an
+    existing one. Both return an instance usable as a context manager;
+    :meth:`close` is idempotent.
+    """
+
+    __slots__ = (
+        "_cache",
+        "_cache_pages",
+        "_closed",
+        "_dirty",
+        "_f",
+        "_initial_size_pages",
+        "_journal_path",
+        "_journaled",
+        "_originals",
+        "_path",
+        "_size_pages",
+    )
+
+    def __init__(
+        self,
+        path: str | os.PathLike[str],
+        *,
+        cache_pages: int = _DEFAULT_CACHE_PAGES,
+    ) -> None:
+        self._path: str = str(path)
+        self._journal_path: str = self._path + "-journal"
+        self._cache_pages: int = cache_pages
+        # Opened lazily in ``create`` / ``open``.
+        self._f = None  # type: ignore[assignment]
+        self._size_pages: int = 0
+        self._initial_size_pages: int = 0
+        self._cache: OrderedDict[int, bytes] = OrderedDict()
+        self._dirty: dict[int, bytes] = {}
+        self._journaled: set[int] = set()
+        self._originals: dict[int, bytes] = {}
+        self._closed: bool = False
+
+    # ------------------------------------------------------------------
+    # Public surface properties.
+    # ------------------------------------------------------------------
+
+    @property
+    def page_size(self) -> int:
+        return PAGE_SIZE
+
+    @property
+    def size_pages(self) -> int:
+        """Current logical size of the database in pages, including any
+        pages allocated (but not yet committed) in the current transaction.
+        """
+        return self._size_pages
+
+    # ------------------------------------------------------------------
+    # Construction.
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def create(
+        cls,
+        path: str | os.PathLike[str],
+        *,
+        cache_pages: int = _DEFAULT_CACHE_PAGES,
+    ) -> Pager:
+        """Create a fresh zero-page file and return a pager over it.
+
+        Raises :class:`FileExistsError` if the path already exists — the
+        caller should explicitly delete first if they want to overwrite.
+        """
+        p = Path(path)
+        if p.exists():
+            raise FileExistsError(f"refusing to overwrite existing file: {p}")
+        p.touch()
+        pager = cls(p, cache_pages=cache_pages)
+        pager._open_file()
+        return pager
+
+    @classmethod
+    def open(
+        cls,
+        path: str | os.PathLike[str],
+        *,
+        cache_pages: int = _DEFAULT_CACHE_PAGES,
+    ) -> Pager:
+        """Open an existing file. Replays a hot journal if present."""
+        p = Path(path)
+        if not p.exists():
+            raise FileNotFoundError(str(p))
+        pager = cls(p, cache_pages=cache_pages)
+        pager._open_file()
+        return pager
+
+    def _open_file(self) -> None:
+        self._f = open(self._path, "r+b")  # noqa: SIM115 — lifetime is the pager
+        file_size = os.path.getsize(self._path)
+        if file_size % PAGE_SIZE != 0:
+            self._f.close()
+            raise CorruptDatabaseError(
+                f"file size {file_size} is not a multiple of page size {PAGE_SIZE}"
+            )
+        self._size_pages = file_size // PAGE_SIZE
+        self._initial_size_pages = self._size_pages
+
+        # Recover before returning: a hot journal must be resolved before
+        # any caller reads a page, or they might see a partially-committed
+        # main file.
+        if os.path.exists(self._journal_path):
+            self._recover()
+
+    # ------------------------------------------------------------------
+    # Transaction-level operations.
+    # ------------------------------------------------------------------
+
+    def read(self, page_no: int) -> bytes:
+        """Return the 4096-byte contents of ``page_no``.
+
+        Looks in the dirty-page table first (so writes are visible within
+        the same transaction), then the LRU cache, then falls through to
+        the main file.
+        """
+        self._assert_open()
+        self._check_page_no(page_no)
+
+        if page_no in self._dirty:
+            return self._dirty[page_no]
+
+        if page_no in self._cache:
+            self._cache.move_to_end(page_no)
+            return self._cache[page_no]
+
+        data = self._read_from_main(page_no)
+        self._cache_put(page_no, data)
+        return data
+
+    def write(self, page_no: int, data: bytes) -> None:
+        """Stage a write to ``page_no``.
+
+        The write lands on disk only at :meth:`commit`. If this is the
+        first write to ``page_no`` in the current transaction *and*
+        ``page_no`` existed before the transaction, the original contents
+        are snapshotted so the journal can restore them on a crashed
+        commit.
+        """
+        self._assert_open()
+        self._check_page_no(page_no)
+        if len(data) != PAGE_SIZE:
+            raise ValueError(f"data must be exactly {PAGE_SIZE} bytes, got {len(data)}")
+
+        # Snapshot the original once, on the first write in this txn,
+        # *if* the page existed pre-txn. Pages newly allocated this txn
+        # have no "original" — on rollback they simply cease to exist.
+        if page_no <= self._initial_size_pages and page_no not in self._journaled:
+            self._originals[page_no] = self._read_from_main(page_no)
+            self._journaled.add(page_no)
+
+        # ``data`` is stored by reference — callers must not mutate a
+        # bytearray they handed in. We copy to ``bytes`` defensively.
+        self._dirty[page_no] = bytes(data)
+
+    def allocate(self) -> int:
+        """Reserve the next page number.
+
+        The freshly-allocated page is initialised to zeros in the
+        dirty-page table, so subsequent reads see a defined state. The
+        page number is one past the current size.
+        """
+        self._assert_open()
+        self._size_pages += 1
+        new_no = self._size_pages
+        self._dirty[new_no] = b"\x00" * PAGE_SIZE
+        return new_no
+
+    def commit(self) -> None:
+        """Atomically apply every dirty page to the main file.
+
+        No-op if nothing is dirty — no journal file is created in that
+        case. Callers can call ``commit`` freely at transaction
+        boundaries regardless of whether anything was actually written.
+        """
+        self._assert_open()
+        if not self._dirty:
+            return
+
+        try:
+            self._write_journal()
+            self._apply_dirty_to_main()
+            # The journal becoming unlinked is the "this transaction
+            # committed" signal. A crash before this point → recovery
+            # replays. A crash after → nothing to replay.
+            os.remove(self._journal_path)
+        except Exception:
+            # Leave state as-is; the caller must rollback or close. We
+            # don't attempt a partial cleanup because the journal /
+            # main-file state could be anywhere between "untouched" and
+            # "fully applied" and guessing wrong would corrupt the file.
+            raise
+
+        # Success: the txn boundary moves forward. Clear in-memory
+        # bookkeeping.
+        self._initial_size_pages = self._size_pages
+        self._dirty.clear()
+        self._originals.clear()
+        self._journaled.clear()
+
+    def rollback(self) -> None:
+        """Discard every pending write. No disk I/O."""
+        self._assert_open()
+        self._dirty.clear()
+        self._originals.clear()
+        self._journaled.clear()
+        # Drop any pages allocated this txn by shrinking back to the
+        # pre-txn size. The file itself wasn't extended yet, so there's
+        # nothing to truncate — the extension only happens in ``commit``.
+        self._size_pages = self._initial_size_pages
+
+    # ------------------------------------------------------------------
+    # Lifecycle.
+    # ------------------------------------------------------------------
+
+    def close(self) -> None:
+        """Release the file handle.
+
+        Pending dirty writes are discarded silently — for durability the
+        caller must ``commit`` first. Idempotent.
+        """
+        if self._closed:
+            return
+        self._closed = True
+        self._dirty.clear()
+        self._originals.clear()
+        self._journaled.clear()
+        self._cache.clear()
+        if self._f is not None:
+            self._f.close()
+            self._f = None  # type: ignore[assignment]
+
+    def __enter__(self) -> Pager:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        self.close()
+
+    # ------------------------------------------------------------------
+    # Internals.
+    # ------------------------------------------------------------------
+
+    def _check_page_no(self, page_no: int) -> None:
+        if page_no < 1:
+            raise ValueError(f"page number must be >= 1, got {page_no}")
+        if page_no > self._size_pages and page_no not in self._dirty:
+            raise ValueError(
+                f"page {page_no} out of range (size={self._size_pages})"
+            )
+
+    def _read_from_main(self, page_no: int) -> bytes:
+        # Pages allocated this txn but not yet committed are served from
+        # ``_dirty`` by the caller — we should never be asked to read them
+        # from main. Defensively return zeros if asked.
+        if page_no > self._initial_size_pages:
+            return b"\x00" * PAGE_SIZE
+        assert self._f is not None
+        self._f.seek((page_no - 1) * PAGE_SIZE)
+        data = self._f.read(PAGE_SIZE)
+        if len(data) != PAGE_SIZE:
+            raise CorruptDatabaseError(
+                f"short read: page {page_no} returned {len(data)} bytes"
+            )
+        return data
+
+    def _cache_put(self, page_no: int, data: bytes) -> None:
+        self._cache[page_no] = data
+        self._cache.move_to_end(page_no)
+        while len(self._cache) > self._cache_pages:
+            self._cache.popitem(last=False)
+
+    def _assert_open(self) -> None:
+        if self._closed:
+            raise RuntimeError("pager is closed")
+
+    # ---- Journal write path (commit side). ----
+
+    def _write_journal(self) -> None:
+        """Write every ``_originals`` entry to the journal, then finalise.
+
+        Two fsyncs: once after the records are written (so we can finalise
+        on top of durable data), once after the finalised header (so a
+        crash after this returns is recoverable).
+        """
+        # If nothing pre-existing changed (e.g. txn only allocated new
+        # pages), the journal has zero records but we still write a
+        # finalised header — recovery for such a journal is a no-op but
+        # the presence of *any* journal file on disk during the apply
+        # phase is what makes the commit atomic.
+        with open(self._journal_path, "wb") as j:
+            j.write(
+                struct.pack(
+                    _JOURNAL_HEADER_FMT,
+                    _JOURNAL_MAGIC,
+                    PAGE_SIZE,
+                    _JOURNAL_SENTINEL,
+                    self._initial_size_pages,
+                )
+            )
+            for page_no in sorted(self._originals):
+                j.write(struct.pack(_RECORD_PREFIX_FMT, page_no))
+                j.write(self._originals[page_no])
+            j.flush()
+            os.fsync(j.fileno())
+            # Finalise: rewrite header with the real record count.
+            j.seek(0)
+            j.write(
+                struct.pack(
+                    _JOURNAL_HEADER_FMT,
+                    _JOURNAL_MAGIC,
+                    PAGE_SIZE,
+                    len(self._originals),
+                    self._initial_size_pages,
+                )
+            )
+            j.flush()
+            os.fsync(j.fileno())
+
+    def _apply_dirty_to_main(self) -> None:
+        """Write every dirty page to the main file and fsync."""
+        assert self._f is not None
+        # Sort for deterministic on-disk write order — makes tests and
+        # golden-file diffs behave predictably.
+        for page_no in sorted(self._dirty):
+            self._f.seek((page_no - 1) * PAGE_SIZE)
+            self._f.write(self._dirty[page_no])
+        # Shrink if this txn allocated pages that rollback later undid —
+        # _size_pages at this point is the *committed* size.
+        self._f.truncate(self._size_pages * PAGE_SIZE)
+        self._f.flush()
+        os.fsync(self._f.fileno())
+
+    # ---- Crash recovery (open path). ----
+
+    def _recover(self) -> None:
+        """Replay or discard a hot journal left by a crashed writer."""
+        try:
+            with open(self._journal_path, "rb") as j:
+                header = j.read(_JOURNAL_HEADER_SIZE)
+                if len(header) < _JOURNAL_HEADER_SIZE:
+                    # Partial header → commit never began → discard.
+                    self._drop_journal()
+                    return
+                magic, page_size, record_count, initial_size = struct.unpack(
+                    _JOURNAL_HEADER_FMT, header
+                )
+                if magic != _JOURNAL_MAGIC:
+                    raise JournalError(f"bad journal magic: {magic!r}")
+                if page_size != PAGE_SIZE:
+                    raise JournalError(
+                        f"journal page size {page_size} != main {PAGE_SIZE}"
+                    )
+                if record_count == _JOURNAL_SENTINEL:
+                    # Not finalised → commit aborted mid-flight → main is
+                    # still pre-txn → no replay needed.
+                    self._drop_journal()
+                    return
+
+                # Finalised: replay every record to undo the partial
+                # application on main.
+                assert self._f is not None
+                for _ in range(record_count):
+                    prefix = j.read(_RECORD_PREFIX_SIZE)
+                    if len(prefix) < _RECORD_PREFIX_SIZE:
+                        raise JournalError("journal record prefix truncated")
+                    (page_no,) = struct.unpack(_RECORD_PREFIX_FMT, prefix)
+                    payload = j.read(PAGE_SIZE)
+                    if len(payload) < PAGE_SIZE:
+                        raise JournalError("journal record payload truncated")
+                    self._f.seek((page_no - 1) * PAGE_SIZE)
+                    self._f.write(payload)
+                # Truncate main back to the pre-txn size so any pages
+                # allocated during the failed txn disappear.
+                self._f.truncate(initial_size * PAGE_SIZE)
+                self._f.flush()
+                os.fsync(self._f.fileno())
+                self._size_pages = initial_size
+                self._initial_size_pages = initial_size
+        except JournalError:
+            raise
+        except OSError as e:
+            raise JournalError(f"journal recovery failed: {e}") from e
+
+        self._drop_journal()
+
+    def _drop_journal(self) -> None:
+        with contextlib.suppress(FileNotFoundError):
+            os.remove(self._journal_path)

--- a/code/packages/python/storage-sqlite/tests/test_header.py
+++ b/code/packages/python/storage-sqlite/tests/test_header.py
@@ -1,0 +1,124 @@
+"""Tests for the 100-byte SQLite database header."""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from storage_sqlite.errors import CorruptDatabaseError
+from storage_sqlite.header import HEADER_SIZE, MAGIC, Header
+
+
+def test_new_database_defaults() -> None:
+    h = Header.new_database()
+    assert h.magic == MAGIC
+    assert h.page_size == 4096
+    assert h.text_encoding == 1
+    assert h.schema_format == 4
+    assert h.database_size_pages == 1
+    assert h.max_embedded_payload_fraction == 64
+    assert h.min_embedded_payload_fraction == 32
+    assert h.leaf_payload_fraction == 32
+
+
+@pytest.mark.parametrize("ps", [512, 1024, 2048, 4096, 8192, 16384, 32768, 65536])
+def test_new_database_accepts_all_valid_page_sizes(ps: int) -> None:
+    h = Header.new_database(page_size=ps)
+    assert h.page_size == ps
+
+
+def test_new_database_rejects_invalid_page_size() -> None:
+    with pytest.raises(ValueError, match="page_size must be one of"):
+        Header.new_database(page_size=3000)
+
+
+def test_to_bytes_is_exactly_100_bytes() -> None:
+    h = Header.new_database()
+    assert len(h.to_bytes()) == HEADER_SIZE
+
+
+def test_round_trip_default() -> None:
+    h = Header.new_database()
+    reparsed = Header.from_bytes(h.to_bytes())
+    assert reparsed == h
+
+
+def test_round_trip_with_all_fields_set() -> None:
+    h = Header(
+        page_size=8192,
+        file_format_write_version=1,
+        file_format_read_version=1,
+        reserved_per_page=0,
+        file_change_counter=42,
+        database_size_pages=17,
+        first_freelist_trunk=5,
+        freelist_page_count=3,
+        schema_cookie=99,
+        schema_format=4,
+        default_cache_size=2000,
+        largest_root_btree=0,
+        text_encoding=1,
+        user_version=7,
+        incremental_vacuum=0,
+        application_id=0x12345678,
+        version_valid_for=42,
+        sqlite_version_number=3_046_002,
+    )
+    assert Header.from_bytes(h.to_bytes()) == h
+
+
+def test_round_trip_page_size_65536() -> None:
+    h = Header.new_database(page_size=65536)
+    raw = h.to_bytes()
+    # 65536 encodes as 1 in the u16 slot.
+    assert struct.unpack_from(">H", raw, 16)[0] == 1
+    assert Header.from_bytes(raw).page_size == 65536
+
+
+def test_from_bytes_rejects_short_input() -> None:
+    with pytest.raises(CorruptDatabaseError, match="at least"):
+        Header.from_bytes(b"\x00" * 50)
+
+
+def test_from_bytes_rejects_bad_magic() -> None:
+    raw = bytearray(Header.new_database().to_bytes())
+    raw[:16] = b"NotSQLite\x00\x00\x00\x00\x00\x00\x00"
+    with pytest.raises(CorruptDatabaseError, match="bad magic"):
+        Header.from_bytes(bytes(raw))
+
+
+def test_from_bytes_rejects_invalid_page_size() -> None:
+    raw = bytearray(Header.new_database().to_bytes())
+    # 3000 isn't in the valid set.
+    struct.pack_into(">H", raw, 16, 3000)
+    with pytest.raises(CorruptDatabaseError, match="invalid page_size"):
+        Header.from_bytes(bytes(raw))
+
+
+def test_from_bytes_rejects_bad_payload_fractions() -> None:
+    raw = bytearray(Header.new_database().to_bytes())
+    raw[21] = 60  # max_embedded_payload_fraction should be 64
+    with pytest.raises(CorruptDatabaseError, match="payload fractions"):
+        Header.from_bytes(bytes(raw))
+
+
+def test_from_bytes_rejects_non_utf8_encoding() -> None:
+    raw = bytearray(Header.new_database().to_bytes())
+    struct.pack_into(">I", raw, 56, 2)  # UTF-16le
+    with pytest.raises(CorruptDatabaseError, match="text encoding"):
+        Header.from_bytes(bytes(raw))
+
+
+def test_from_bytes_rejects_nonzero_reserved() -> None:
+    raw = bytearray(Header.new_database().to_bytes())
+    raw[80] = 0x01
+    with pytest.raises(CorruptDatabaseError, match="reserved bytes"):
+        Header.from_bytes(bytes(raw))
+
+
+def test_from_bytes_accepts_encoded_65536() -> None:
+    # Build a valid header and flip page_size to the encoded 65536 form.
+    raw = bytearray(Header.new_database(page_size=65536).to_bytes())
+    h = Header.from_bytes(bytes(raw))
+    assert h.page_size == 65536

--- a/code/packages/python/storage-sqlite/tests/test_pager.py
+++ b/code/packages/python/storage-sqlite/tests/test_pager.py
@@ -1,0 +1,511 @@
+"""Tests for the Pager — page I/O, LRU cache, rollback journal, recovery."""
+
+from __future__ import annotations
+
+import os
+import struct
+from pathlib import Path
+
+import pytest
+
+from storage_sqlite.errors import CorruptDatabaseError, JournalError
+from storage_sqlite.pager import (
+    _JOURNAL_HEADER_FMT,
+    _JOURNAL_HEADER_SIZE,
+    _JOURNAL_MAGIC,
+    _JOURNAL_SENTINEL,
+    PAGE_SIZE,
+    Pager,
+)
+
+
+def _page(byte: int) -> bytes:
+    return bytes([byte]) * PAGE_SIZE
+
+
+# ------------------------------------------------------------------
+# Create / open / close basics.
+# ------------------------------------------------------------------
+
+
+def test_create_then_open(tmp_path: Path) -> None:
+    p = tmp_path / "db"
+    pager = Pager.create(p)
+    assert pager.page_size == PAGE_SIZE
+    assert pager.size_pages == 0
+    pager.close()
+
+    pager2 = Pager.open(p)
+    assert pager2.size_pages == 0
+    pager2.close()
+
+
+def test_create_refuses_to_overwrite(tmp_path: Path) -> None:
+    p = tmp_path / "db"
+    p.touch()
+    with pytest.raises(FileExistsError):
+        Pager.create(p)
+
+
+def test_open_refuses_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        Pager.open(tmp_path / "missing")
+
+
+def test_open_rejects_unaligned_file(tmp_path: Path) -> None:
+    p = tmp_path / "db"
+    p.write_bytes(b"\x00" * (PAGE_SIZE + 5))
+    with pytest.raises(CorruptDatabaseError, match="multiple of page size"):
+        Pager.open(p)
+
+
+def test_close_is_idempotent(tmp_path: Path) -> None:
+    p = tmp_path / "db"
+    pager = Pager.create(p)
+    pager.close()
+    pager.close()  # no-op the second time
+
+
+def test_context_manager_closes(tmp_path: Path) -> None:
+    p = tmp_path / "db"
+    with Pager.create(p) as pager:
+        assert pager.size_pages == 0
+    # After exit, calls should fail.
+    with pytest.raises(RuntimeError, match="closed"):
+        pager.read(1)
+
+
+# ------------------------------------------------------------------
+# allocate / read / write.
+# ------------------------------------------------------------------
+
+
+def test_allocate_returns_sequential_page_numbers(tmp_path: Path) -> None:
+    with Pager.create(tmp_path / "db") as pager:
+        assert pager.allocate() == 1
+        assert pager.allocate() == 2
+        assert pager.allocate() == 3
+        assert pager.size_pages == 3
+
+
+def test_newly_allocated_page_reads_as_zeros(tmp_path: Path) -> None:
+    with Pager.create(tmp_path / "db") as pager:
+        n = pager.allocate()
+        assert pager.read(n) == b"\x00" * PAGE_SIZE
+
+
+def test_write_then_read_within_txn(tmp_path: Path) -> None:
+    with Pager.create(tmp_path / "db") as pager:
+        n = pager.allocate()
+        pager.write(n, _page(0xAB))
+        assert pager.read(n) == _page(0xAB)
+
+
+def test_write_rejects_unallocated_page(tmp_path: Path) -> None:
+    with Pager.create(tmp_path / "db") as pager, pytest.raises(ValueError, match="out of range"):
+        pager.write(1, _page(0))
+
+
+def test_write_rejects_wrong_size(tmp_path: Path) -> None:
+    with Pager.create(tmp_path / "db") as pager:
+        pager.allocate()
+        with pytest.raises(ValueError, match="exactly"):
+            pager.write(1, b"\x00" * 10)
+
+
+def test_read_rejects_page_zero(tmp_path: Path) -> None:
+    with Pager.create(tmp_path / "db") as pager, pytest.raises(ValueError, match=">= 1"):
+        pager.read(0)
+
+
+def test_read_rejects_out_of_range(tmp_path: Path) -> None:
+    with Pager.create(tmp_path / "db") as pager, pytest.raises(ValueError, match="out of range"):
+        pager.read(5)
+
+
+# ------------------------------------------------------------------
+# Commit / rollback.
+# ------------------------------------------------------------------
+
+
+def test_commit_persists_writes(tmp_path: Path) -> None:
+    p = tmp_path / "db"
+    with Pager.create(p) as pager:
+        n = pager.allocate()
+        pager.write(n, _page(0xCD))
+        pager.commit()
+
+    with Pager.open(p) as pager:
+        assert pager.size_pages == 1
+        assert pager.read(1) == _page(0xCD)
+
+
+def test_commit_is_noop_without_dirty(tmp_path: Path) -> None:
+    p = tmp_path / "db"
+    with Pager.create(p) as pager:
+        pager.commit()  # nothing staged
+    assert not (tmp_path / "db-journal").exists()
+
+
+def test_commit_deletes_journal(tmp_path: Path) -> None:
+    p = tmp_path / "db"
+    with Pager.create(p) as pager:
+        pager.allocate()
+        pager.write(1, _page(1))
+        pager.commit()
+    assert not (tmp_path / "db-journal").exists()
+
+
+def test_rollback_discards_writes(tmp_path: Path) -> None:
+    p = tmp_path / "db"
+    with Pager.create(p) as pager:
+        n1 = pager.allocate()
+        pager.write(n1, _page(0xAA))
+        pager.commit()
+
+        # Now modify & rollback.
+        pager.write(n1, _page(0xBB))
+        pager.allocate()  # page 2
+        assert pager.size_pages == 2
+        pager.rollback()
+        assert pager.size_pages == 1
+        assert pager.read(1) == _page(0xAA)
+
+
+def test_rollback_before_any_commit(tmp_path: Path) -> None:
+    with Pager.create(tmp_path / "db") as pager:
+        pager.allocate()
+        pager.allocate()
+        pager.rollback()
+        assert pager.size_pages == 0
+
+
+def test_commit_then_rollback_does_nothing_dangerous(tmp_path: Path) -> None:
+    p = tmp_path / "db"
+    with Pager.create(p) as pager:
+        pager.allocate()
+        pager.write(1, _page(0x11))
+        pager.commit()
+        pager.rollback()
+        assert pager.read(1) == _page(0x11)
+
+
+def test_second_write_to_same_page_does_not_journal_twice(tmp_path: Path) -> None:
+    p = tmp_path / "db"
+    with Pager.create(p) as pager:
+        pager.allocate()
+        pager.write(1, _page(0x01))
+        pager.commit()
+
+        # Snapshot original, overwrite twice.
+        pager.write(1, _page(0x02))
+        pager.write(1, _page(0x03))
+        pager.commit()
+
+    with Pager.open(p) as pager:
+        assert pager.read(1) == _page(0x03)
+
+
+# ------------------------------------------------------------------
+# LRU cache behaviour.
+# ------------------------------------------------------------------
+
+
+def test_lru_evicts_least_recent(tmp_path: Path) -> None:
+    p = tmp_path / "db"
+    with Pager.create(p) as pager:
+        for i in range(1, 6):
+            pager.allocate()
+            pager.write(i, _page(i))
+        pager.commit()
+
+    with Pager.open(p, cache_pages=2) as pager:
+        pager.read(1)
+        pager.read(2)
+        pager.read(3)  # evicts page 1
+        # Access page 2 to bump it — page 3 is now LRU.
+        pager.read(2)
+        pager.read(4)  # evicts page 3
+        # Re-reading still works (cache miss falls through to main).
+        assert pager.read(3) == _page(3)
+
+
+def test_cached_read_returns_same_bytes(tmp_path: Path) -> None:
+    p = tmp_path / "db"
+    with Pager.create(p) as pager:
+        pager.allocate()
+        pager.write(1, _page(0x77))
+        pager.commit()
+
+    with Pager.open(p) as pager:
+        a = pager.read(1)
+        b = pager.read(1)  # cache hit
+        assert a == b == _page(0x77)
+
+
+# ------------------------------------------------------------------
+# Crash recovery.
+# ------------------------------------------------------------------
+
+
+def test_recover_finalised_journal_restores_original(tmp_path: Path) -> None:
+    """A finalised journal means we crashed mid-apply — replay restores."""
+    p = tmp_path / "db"
+    with Pager.create(p) as pager:
+        pager.allocate()
+        pager.write(1, _page(0xAA))
+        pager.commit()
+
+    # Simulate a crashed commit: partially-applied main file + finalised
+    # journal. We do this by running a transaction, then hand-crafting the
+    # post-crash state.
+    original = (tmp_path / "db").read_bytes()
+
+    with Pager.open(p) as pager:
+        pager.write(1, _page(0xBB))  # snapshot original to _originals
+        pager._write_journal()
+        pager._apply_dirty_to_main()
+        # Crash before os.remove(journal) — leave journal on disk.
+
+    # Main file now has 0xBB; journal is finalised with 0xAA as the original.
+    assert (tmp_path / "db").read_bytes() != original
+    assert (tmp_path / "db-journal").exists()
+
+    with Pager.open(p) as pager:
+        assert pager.read(1) == _page(0xAA)
+    assert not (tmp_path / "db-journal").exists()
+
+
+def test_recover_non_finalised_journal_discards(tmp_path: Path) -> None:
+    """Sentinel record count ⇒ commit aborted pre-apply ⇒ discard."""
+    p = tmp_path / "db"
+    with Pager.create(p) as pager:
+        pager.allocate()
+        pager.write(1, _page(0xAA))
+        pager.commit()
+
+    # Write a non-finalised journal by hand.
+    (tmp_path / "db-journal").write_bytes(
+        struct.pack(
+            _JOURNAL_HEADER_FMT,
+            _JOURNAL_MAGIC,
+            PAGE_SIZE,
+            _JOURNAL_SENTINEL,
+            1,
+        )
+    )
+    with Pager.open(p) as pager:
+        assert pager.read(1) == _page(0xAA)
+    assert not (tmp_path / "db-journal").exists()
+
+
+def test_recover_truncated_journal_discards(tmp_path: Path) -> None:
+    p = tmp_path / "db"
+    with Pager.create(p) as pager:
+        pager.allocate()
+        pager.write(1, _page(0xAA))
+        pager.commit()
+
+    (tmp_path / "db-journal").write_bytes(b"\x00" * 4)  # partial header
+    with Pager.open(p) as pager:
+        assert pager.read(1) == _page(0xAA)
+    assert not (tmp_path / "db-journal").exists()
+
+
+def test_recover_rejects_bad_journal_magic(tmp_path: Path) -> None:
+    p = tmp_path / "db"
+    with Pager.create(p) as pager:
+        pager.allocate()
+        pager.write(1, _page(0xAA))
+        pager.commit()
+
+    (tmp_path / "db-journal").write_bytes(
+        struct.pack(_JOURNAL_HEADER_FMT, b"BADMAGIC", PAGE_SIZE, 0, 1)
+    )
+    with pytest.raises(JournalError, match="bad journal magic"):
+        Pager.open(p)
+
+
+def test_recover_rejects_wrong_page_size_journal(tmp_path: Path) -> None:
+    p = tmp_path / "db"
+    with Pager.create(p) as pager:
+        pager.allocate()
+        pager.write(1, _page(0xAA))
+        pager.commit()
+
+    (tmp_path / "db-journal").write_bytes(
+        struct.pack(_JOURNAL_HEADER_FMT, _JOURNAL_MAGIC, 8192, 0, 1)
+    )
+    with pytest.raises(JournalError, match="page size"):
+        Pager.open(p)
+
+
+def test_recover_rejects_truncated_record_prefix(tmp_path: Path) -> None:
+    p = tmp_path / "db"
+    with Pager.create(p) as pager:
+        pager.allocate()
+        pager.write(1, _page(0xAA))
+        pager.commit()
+
+    # Finalised header claiming one record but no record bytes follow.
+    (tmp_path / "db-journal").write_bytes(
+        struct.pack(_JOURNAL_HEADER_FMT, _JOURNAL_MAGIC, PAGE_SIZE, 1, 1)
+    )
+    with pytest.raises(JournalError, match="prefix truncated"):
+        Pager.open(p)
+
+
+def test_recover_rejects_truncated_record_payload(tmp_path: Path) -> None:
+    p = tmp_path / "db"
+    with Pager.create(p) as pager:
+        pager.allocate()
+        pager.write(1, _page(0xAA))
+        pager.commit()
+
+    header = struct.pack(_JOURNAL_HEADER_FMT, _JOURNAL_MAGIC, PAGE_SIZE, 1, 1)
+    prefix = struct.pack(">I", 1)
+    # Only 10 bytes of payload instead of 4096.
+    (tmp_path / "db-journal").write_bytes(header + prefix + b"\x00" * 10)
+    with pytest.raises(JournalError, match="payload truncated"):
+        Pager.open(p)
+
+
+def test_recover_finalised_truncates_new_pages(tmp_path: Path) -> None:
+    """Finalised journal: pages allocated during the crashed txn get chopped."""
+    p = tmp_path / "db"
+    with Pager.create(p) as pager:
+        pager.allocate()
+        pager.write(1, _page(0x11))
+        pager.commit()
+
+    with Pager.open(p) as pager:
+        pager.allocate()  # page 2
+        pager.write(2, _page(0x22))
+        pager._write_journal()
+        pager._apply_dirty_to_main()
+        # Crash: leave journal.
+
+    # Main file now has 2 pages; journal's initial_size=1 so replay truncates.
+    assert os.path.getsize(p) == 2 * PAGE_SIZE
+
+    with Pager.open(p) as pager:
+        assert pager.size_pages == 1
+        assert pager.read(1) == _page(0x11)
+    assert os.path.getsize(p) == PAGE_SIZE
+
+
+# ------------------------------------------------------------------
+# Journal error paths on open helpers.
+# ------------------------------------------------------------------
+
+
+def test_recover_wraps_os_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    p = tmp_path / "db"
+    with Pager.create(p) as pager:
+        pager.allocate()
+        pager.write(1, _page(0xAA))
+        pager.commit()
+
+    # Create a finalised journal pointing at page 1.
+    with Pager.open(p) as pager:
+        pager.write(1, _page(0xBB))
+        pager._write_journal()
+        pager._apply_dirty_to_main()
+
+    # Force a write failure during replay.
+    real_open = open
+
+    def bad_open(path, *args, **kwargs):  # type: ignore[no-untyped-def]
+        f = real_open(path, *args, **kwargs)
+        if str(path).endswith("-journal"):
+            real_read = f.read
+
+            def boom(*_a, **_k):  # type: ignore[no-untyped-def]
+                raise OSError("simulated")
+
+            # Read header OK; read record-prefix blows up.
+            state = {"call": 0}
+
+            def read(*a, **k):  # type: ignore[no-untyped-def]
+                state["call"] += 1
+                if state["call"] == 1:
+                    return real_read(*a, **k)
+                boom()
+                return b""
+
+            f.read = read  # type: ignore[method-assign]
+        return f
+
+    monkeypatch.setattr("builtins.open", bad_open)
+    with pytest.raises(JournalError, match="recovery failed"):
+        Pager.open(p)
+
+
+# ------------------------------------------------------------------
+# Misc.
+# ------------------------------------------------------------------
+
+
+def test_operations_after_close_fail(tmp_path: Path) -> None:
+    pager = Pager.create(tmp_path / "db")
+    pager.close()
+    with pytest.raises(RuntimeError, match="closed"):
+        pager.read(1)
+    with pytest.raises(RuntimeError, match="closed"):
+        pager.write(1, _page(0))
+    with pytest.raises(RuntimeError, match="closed"):
+        pager.allocate()
+    with pytest.raises(RuntimeError, match="closed"):
+        pager.commit()
+    with pytest.raises(RuntimeError, match="closed"):
+        pager.rollback()
+
+
+def test_short_read_raises_corrupt(tmp_path: Path) -> None:
+    """If file shrinks out from under us, a read should refuse to lie."""
+    p = tmp_path / "db"
+    with Pager.create(p) as pager:
+        pager.allocate()
+        pager.write(1, _page(0x42))
+        pager.commit()
+
+    pager = Pager.open(p)
+    # Sabotage: truncate the underlying file mid-life.
+    with open(p, "r+b") as f:
+        f.truncate(10)
+    # Reset initial_size so _read_from_main actually hits disk.
+    pager._initial_size_pages = 1
+    with pytest.raises(CorruptDatabaseError, match="short read"):
+        pager.read(1)
+    pager.close()
+
+
+def test_journal_header_size_constant() -> None:
+    assert struct.calcsize(_JOURNAL_HEADER_FMT) == _JOURNAL_HEADER_SIZE
+
+
+def test_drop_journal_tolerates_missing_file(tmp_path: Path) -> None:
+    """``_drop_journal`` should swallow FileNotFoundError."""
+    with Pager.create(tmp_path / "db") as pager:
+        pager._drop_journal()  # no journal exists
+
+
+def test_write_on_pre_existing_page_journals_original(tmp_path: Path) -> None:
+    """First write to a pre-txn page must snapshot to originals."""
+    p = tmp_path / "db"
+    with Pager.create(p) as pager:
+        pager.allocate()
+        pager.write(1, _page(0xAA))
+        pager.commit()
+
+    with Pager.open(p) as pager:
+        pager.write(1, _page(0xBB))
+        assert 1 in pager._originals
+        assert pager._originals[1] == _page(0xAA)
+
+
+def test_newly_allocated_page_not_in_originals(tmp_path: Path) -> None:
+    with Pager.create(tmp_path / "db") as pager:
+        pager.allocate()
+        pager.write(1, _page(0xCC))
+        assert 1 not in pager._originals

--- a/code/specs/storage-sqlite.md
+++ b/code/specs/storage-sqlite.md
@@ -1,0 +1,361 @@
+# Storage SQLite Specification
+
+## Overview
+
+This document specifies the `storage-sqlite` package: a **SQLite-byte-compatible
+file-backed implementation** of the `Backend` interface.
+
+The goal is literal byte-compatibility with the real SQLite on-disk format —
+a file written by `storage-sqlite` must be openable by the `sqlite3` CLI, and
+a file written by `sqlite3` must be readable by `storage-sqlite`. That
+constraint is what makes this package interesting and forces the design.
+
+It plugs into the existing pipeline without changing anything above:
+
+```
+mini_sqlite.connect("app.db")        ← today: raises InterfaceError
+    │
+    ▼
+Connection(SqliteFileBackend("app.db"))
+    │
+    ▼
+sql-vm (unchanged) ──► Backend interface ──► SqliteFileBackend
+                                                 │
+                                                 ├── Pager     (page I/O + cache)
+                                                 ├── BTree     (table B-trees)
+                                                 ├── Record    (varint + serial types)
+                                                 └── Schema    (sqlite_schema table)
+```
+
+Everything above the `Backend` line — lexer, parser, adapter, planner,
+optimizer, codegen, VM — is untouched. This package slots in behind the
+interface and is what makes `connect("myfile.db")` start working.
+
+---
+
+## Where It Fits
+
+```
+Depends on: sql-backend               (interface being implemented)
+            (internal modules only — no other sql-pipeline deps)
+
+Used by:    mini-sqlite                (selected when database != ":memory:")
+            anything else that calls Backend (planner schema queries, etc.)
+```
+
+This is deliberately a **leaf-ish** package — it does not know about SQL. It
+knows about pages, B-tree cells, varints, records, and `sqlite_schema`. The
+SQL pipeline talks to it through the narrow `Backend` interface.
+
+---
+
+## Supported Languages
+
+v1 ships **Python only**, matching the rest of the SQL pipeline. Other
+language implementations are deferred until the Python reference is stable
+and the conformance tests are known-good against real `.sqlite` files.
+
+---
+
+## Goals
+
+1. **Round-trip byte-compat** for the v1 subset: a file written by this
+   package is bit-identical to what `sqlite3` would write for an equivalent
+   sequence of statements (where bit-identicality is achievable — free-page
+   ordering has legitimate non-determinism, so the test oracle is "sqlite3
+   can open and read every row back" rather than literal `diff`).
+2. **Implements the `Backend` interface** — no new API invented here. Every
+   method on `Backend` works against a real on-disk file.
+3. **Single-process, single-writer** durability via a rollback journal.
+4. **Pluggable**: `mini_sqlite.connect("foo.db")` just works; the backend
+   selection happens at connect time and nothing else changes.
+5. **Specs first**: every on-disk layout is documented with a byte diagram
+   before the code lands.
+
+## Non-goals (v1)
+
+- **WAL mode** — rollback journal only in v1. WAL is a separate, larger effort.
+- **Index B-trees** — `CREATE INDEX` stores the `sqlite_schema` row but the
+  planner does not yet consult indexes. Scans remain full table scans.
+- **Multiple page sizes** — v1 pins page size at 4096 bytes. SQLite supports
+  512–65536; we will add the rest in v2 once one size is solid.
+- **Multi-process locking** — no POSIX advisory locks in v1. Concurrent
+  writers are undefined behaviour. Single-process safe.
+- **AUTOINCREMENT** — the internal `sqlite_sequence` table is not maintained.
+  `INTEGER PRIMARY KEY` (without AUTOINCREMENT) works and behaves as a rowid
+  alias.
+- **Triggers, views, foreign keys, CHECK, PRAGMA, VACUUM** — out of v1 scope.
+- **Encrypted databases** (SEE / SQLCipher) — out of scope entirely.
+
+---
+
+## The SQLite file format — layers
+
+The file format is documented at <https://www.sqlite.org/fileformat2.html>.
+v1 implements the subset below. Each layer corresponds to a Python module
+inside `storage-sqlite`.
+
+### Layer 1 — Pager (`pager.py`)
+
+**Responsibility**: read and write fixed-size pages to/from the file; hold a
+small in-memory cache; coordinate writes with the rollback journal.
+
+- Page size: **4096 bytes** (fixed).
+- Page numbers: 1-based. Page 1 is the database header page.
+- API:
+  - `Pager.open(path) -> Pager`
+  - `Pager.read(page_no: int) -> bytes`  — returns a 4096-byte view
+  - `Pager.write(page_no: int, data: bytes)`  — stages into write-set
+  - `Pager.allocate() -> int`  — returns a fresh page number
+  - `Pager.commit()` — fsync journal, apply write-set to main file, fsync main, delete journal
+  - `Pager.rollback()` — discard write-set, discard journal
+- Cache: simple LRU, default 32 pages. Invalidated on rollback.
+- **Rollback journal**: hot-journal file at `<db>-journal`. Before any page
+  is written for the first time in a transaction, its original bytes are
+  copied to the journal. On crash, recovery replays the journal back into
+  the main file.
+
+### Layer 2 — Database header (`header.py`)
+
+**Responsibility**: read and write the 100-byte header at the start of page 1.
+
+Fixed byte layout:
+
+```
+offset  size  meaning
+   0    16    "SQLite format 3\0"  (magic string)
+  16     2    page size in bytes   (u16-be, 4096 = 0x1000)
+  18     1    file format write version (1 = legacy)
+  19     1    file format read version  (1 = legacy)
+  20     1    reserved space per page (0)
+  21     1    max embedded payload fraction (64)
+  22     1    min embedded payload fraction (32)
+  23     1    leaf payload fraction (32)
+  24     4    file change counter (u32-be) — bumped on every write txn
+  28     4    in-header database size in pages (u32-be)
+  32     4    page number of first freelist trunk page (u32-be, 0 if none)
+  36     4    total number of freelist pages (u32-be)
+  40     4    schema cookie (u32-be) — bumped when sqlite_schema changes
+  44     4    schema format number (4 — supports everything we need)
+  48     4    default cache size (0)
+  52     4    largest root b-tree page before incremental vacuum (0, feature off)
+  56     4    text encoding (1 = UTF-8)
+  60     4    user version (0)
+  64     4    incremental vacuum mode (0)
+  68     4    application ID (0)
+  72    20    reserved zero bytes
+  92     4    version-valid-for number (== change counter)
+  96     4    SQLite version number (3 046 002 — matches 3.46.2, arbitrary)
+```
+
+v1 writes these values exactly; most are fixed constants.
+
+### Layer 3 — Varint and record codec (`record.py`)
+
+**Varint**: 1–9 byte big-endian encoding used throughout the format. Bytes
+1–8 have a continuation bit in MSB; byte 9 uses all 8 bits. We need read
+and write, both widely tested against golden fixtures.
+
+**Serial types** (varint):
+
+| serial type | meaning          | content size |
+|-------------|------------------|--------------|
+| 0           | NULL             | 0            |
+| 1           | 8-bit int        | 1            |
+| 2           | 16-bit int BE    | 2            |
+| 3           | 24-bit int BE    | 3            |
+| 4           | 32-bit int BE    | 4            |
+| 5           | 48-bit int BE    | 6            |
+| 6           | 64-bit int BE    | 8            |
+| 7           | 64-bit float BE  | 8            |
+| 8           | constant 0       | 0            |
+| 9           | constant 1       | 0            |
+| 10, 11      | internal/reserved| — (unused)   |
+| N ≥ 12 even | BLOB of (N−12)/2 | variable     |
+| N ≥ 13 odd  | TEXT of (N−13)/2 | variable     |
+
+**Record** layout: `[header-length-varint] [serial-type-varint …] [payload …]`.
+Pick the *smallest* serial type that fits each value (e.g. the integer 3
+uses serial type 1, not 6) — that's what `sqlite3` does, and matters for
+byte-compat on round-trip.
+
+### Layer 4 — Table B-tree pages (`btree.py`)
+
+SQLite uses two B-tree variants: **table** (keyed by rowid) and **index**
+(keyed by record). v1 implements **table** only.
+
+Each B-tree page has this layout:
+
+```
+offset  size  meaning
+   0     1    page type byte:
+                 0x0D = leaf table
+                 0x05 = interior table
+   1     2    first freeblock offset (0 = none)
+   3     2    number of cells on the page
+   5     2    cell content area start (grows down from end of page)
+   7     1    fragmented free bytes
+   8     4    (interior pages only) right-most child pointer
+  8/12   2*N  cell pointer array (2 bytes per cell, growing up)
+  …          free space (shrinking)
+  …          cell content (growing down)
+```
+
+**Leaf table cell**: `[payload-bytes-varint] [rowid-varint] [record bytes]`.
+If the record is too large to fit in the page, the tail spills into an
+**overflow chain**: the first 4 bytes of the cell payload become a page
+pointer to the first overflow page; overflow pages are linked by a u32 at
+their start. v1 supports overflow chains end-to-end.
+
+**Interior table cell**: `[left-child-page-varint] [rowid-varint]`. The
+right-most child is stored in the page header, not in a cell.
+
+Operations: `find(rowid)`, `insert(rowid, record)`, `update(rowid, record)`,
+`delete(rowid)`, `range_scan()`. The existing `b-tree` package covers the
+algorithmic shape; this module re-implements against the SQLite-specific
+page layout rather than bending the generic one.
+
+### Layer 5 — `sqlite_schema` (`schema.py`)
+
+The `sqlite_schema` table (on page 2 at fixed rootpage 1 — same page as the
+header on page 1, cell area starting at offset 100) is itself a normal table
+B-tree whose rows have five columns:
+
+```
+type     TEXT   -- 'table' | 'index' | 'view' | 'trigger'
+name     TEXT   -- object name
+tbl_name TEXT   -- owning table (same as name for 'table' rows)
+rootpage INTEGER -- page number of the B-tree root for this object
+sql      TEXT   -- CREATE statement as the user typed it (for round-trip)
+```
+
+CREATE TABLE:
+1. Append a `sqlite_schema` row for the new table.
+2. Allocate a fresh leaf page, write empty-leaf bytes, set as the table's
+   rootpage.
+3. Bump the schema cookie in the header.
+
+DROP TABLE:
+1. Free all pages reachable from the rootpage.
+2. Delete the `sqlite_schema` row.
+3. Bump the schema cookie.
+
+### Layer 6 — Backend adapter (`backend.py`)
+
+Implements the `Backend` interface in terms of the lower layers:
+
+- `tables()` → scan `sqlite_schema`, filter `type = 'table'`, return names.
+- `columns(t)` → parse the stored `CREATE TABLE sql` from sqlite_schema and
+  return column defs. (Reuses the existing `sql-parser` — the facade is allowed
+  to depend up here.)
+- `scan(t)` → resolve rootpage, return an iterator over the B-tree's leaf
+  cells decoding each record.
+- `insert(t, row)` → encode record, pick next rowid, B-tree insert.
+- `update(t, cursor, assignments)` / `delete(t, cursor)` — cursor holds
+  `(rootpage, rowid)`.
+- `create_table(stmt)` / `drop_table(name)` — delegate to `schema.py`.
+- `begin_transaction()` → `pager.begin()` returning a handle.
+- `commit(handle)` / `rollback(handle)` → pager methods.
+
+### Layer 7 — Freelist (`freelist.py`)
+
+Pages freed by DELETE or DROP are prepended to a linked list of trunk pages
+pointed to from offset 32 of the header. Allocations prefer reusing freelist
+pages before extending the file. v1 implements the trunk/leaf layout SQLite
+uses so a `sqlite3` `VACUUM` on our file wouldn't find surprises.
+
+---
+
+## v1 scope — checkpoint
+
+At end of v1 this sequence works:
+
+```python
+# Python side — our code writes the file.
+with mini_sqlite.connect("demo.db") as c:
+    c.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
+    c.executemany("INSERT INTO t VALUES (?, ?)",
+                  [(1, "Ada"), (2, "Grace")])
+
+# Shell side — real sqlite3 opens the same file.
+$ sqlite3 demo.db "SELECT * FROM t"
+1|Ada
+2|Grace
+
+# And the reverse direction:
+$ sqlite3 fresh.db "CREATE TABLE u(x INTEGER); INSERT INTO u VALUES (42)"
+$ python -c "import mini_sqlite; \
+             c = mini_sqlite.connect('fresh.db'); \
+             print(list(c.execute('SELECT * FROM u')))"
+[(42,)]
+```
+
+If those two scenarios pass end-to-end, v1 is done.
+
+---
+
+## Testing strategy
+
+Three test tiers:
+
+1. **Unit** — each module in isolation (`test_varint.py`, `test_record.py`,
+   `test_header.py`, `test_btree_leaf.py`, …). Golden byte fixtures taken
+   from `sqlite3`-produced files.
+2. **Round-trip** — write via our backend, read via `sqlite3` CLI (skipped
+   in CI if `sqlite3` unavailable, asserted locally and in CI if installed);
+   and the reverse direction. This is the **byte-compat oracle**.
+3. **Conformance** — run the existing `sql-backend` conformance suite against
+   `SqliteFileBackend`, so it passes every test that `InMemoryBackend` passes.
+
+Target coverage: 95%+ (library code — the threshold that libraries in this
+repo hold to).
+
+---
+
+## Phased build order
+
+Build leaf-to-root. Each phase commits as its own feature branch / PR.
+
+| Phase | Module | Deliverable |
+|-------|--------|-------------|
+| 1 | `pager.py` + `header.py` | Open an empty file, read/write page 1, rollback journal |
+| 2 | `record.py` (varint + serial types) | Unit-tested round-trip of every scalar SQL value |
+| 3 | `btree.py` (leaf + overflow) | Insert/lookup/scan a single B-tree, no splits |
+| 4 | `btree.py` (splits + interior pages) | Full B-tree that grows beyond one page |
+| 5 | `freelist.py` | Pages freed by DELETE return to a freelist |
+| 6 | `schema.py` + DDL round-trip | CREATE/DROP TABLE via sqlite_schema |
+| 7 | `backend.py` — wire it all up and pass the conformance suite | `connect("foo.db")` works end-to-end |
+| 8 | **The byte-compat oracle** — `sqlite3` CLI round-trip tests pass | v1 ships |
+
+Each phase is a spec-then-tests-then-implementation cycle and should fit in
+its own reviewable PR.
+
+---
+
+## Deferred to v2+
+
+These will each get their own spec document when picked up:
+
+- **WAL mode**: `-wal` + `-shm` file, checkpointer, concurrent readers.
+- **Index B-trees**: `CREATE INDEX`, index-driven scans in the planner.
+- **Autoincrement**: `sqlite_sequence` maintenance and 63-bit monotonic rowids.
+- **Variable page sizes**: 512, 1024, …, 65536.
+- **File locking**: POSIX advisory locks for multi-process safety.
+- **Incremental vacuum / full vacuum**.
+- **Foreign-key enforcement, CHECK constraints, triggers, views**.
+- **Encoding other than UTF-8**: UTF-16LE, UTF-16BE.
+
+---
+
+## References
+
+- [SQLite file format 2](https://www.sqlite.org/fileformat2.html) — the
+  authoritative spec this document tracks.
+- [SQLite VFS](https://www.sqlite.org/vfs.html) — relevant when WAL lands.
+- [Database File Format](https://www.sqlite.org/fileformat.html) (older,
+  superseded by `fileformat2.html` but still useful for context).
+- Internal: [`sql-backend.md`](sql-backend.md) — the interface this package
+  implements.
+- Internal: [`mini-sqlite-python.md`](mini-sqlite-python.md) — the facade
+  that selects this backend when `connect(path)` is called with a non-
+  `:memory:` path.


### PR DESCRIPTION
## Summary

- Phase 1 of the SQLite byte-compatible file backend (per [code/specs/storage-sqlite.md](code/specs/storage-sqlite.md)).
- **Header**: frozen dataclass for the 100-byte database header — parses, serialises, validates magic / page size / payload fractions / text encoding / reserved zeros. Handles the 65536-encoded-as-1 page-size quirk.
- **Pager**: page-at-a-time I/O over a file with a 32-page LRU cache. Transactions stage writes in memory; `commit()` writes an undo-log rollback journal (sentinel-then-finalise protocol), applies dirty pages, fsyncs, unlinks the journal. `open()` replays a hot journal on startup — finalised replays, non-finalised or truncated is discarded.

## Scope & phasing

This is phase 1 only — the bottom two layers of the storage stack. Record codec, B-trees, sqlite_schema, and the Backend adapter land in subsequent phases. v1 pins page size to 4096.

## Test plan

- [x] `./BUILD` passes — ruff clean, 58 tests, 99% coverage (≥95% gate)
- [x] Header round-trip for every valid page size (512..65536)
- [x] Header rejects bad magic / bad page size / bad payload fractions / non-UTF-8 / non-zero reserved / short input
- [x] Pager create/open/read/write/allocate/commit/rollback
- [x] LRU eviction behaviour
- [x] Crash recovery: finalised journal replayed; sentinel journal discarded; truncated journal discarded
- [x] Crash recovery truncates pages allocated during the failed txn
- [x] Security review (sub-agent) — passed, no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)