### PR TITLE
feat(note-frequency): add Swift package

### DIFF
--- a/code/packages/swift/note-frequency/.gitignore
+++ b/code/packages/swift/note-frequency/.gitignore
@@ -1,0 +1,3 @@
+.build/
+.swiftpm/
+Package.resolved

--- a/code/packages/swift/note-frequency/BUILD
+++ b/code/packages/swift/note-frequency/BUILD
@@ -1,0 +1,1 @@
+if command -v xcrun >/dev/null 2>&1; then xcrun swift test --enable-code-coverage --verbose; else swift test --enable-code-coverage --verbose; fi

--- a/code/packages/swift/note-frequency/BUILD_windows
+++ b/code/packages/swift/note-frequency/BUILD_windows
@@ -1,0 +1,1 @@
+where swift >nul 2>nul && swift test || echo Swift not available on this runner - skipping

--- a/code/packages/swift/note-frequency/CHANGELOG.md
+++ b/code/packages/swift/note-frequency/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Added the initial note-to-frequency package.
+- Added note parsing for natural notes plus single sharps and flats.
+- Added equal-tempered frequency mapping anchored at `A4 = 440 Hz`.
+- Added tests that lock down the shared parity vectors across language ports.

--- a/code/packages/swift/note-frequency/Package.swift
+++ b/code/packages/swift/note-frequency/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "note-frequency",
+    products: [
+        .library(name: "NoteFrequency", targets: ["NoteFrequency"]),
+    ],
+    targets: [
+        .target(name: "NoteFrequency"),
+        .testTarget(name: "NoteFrequencyTests", dependencies: ["NoteFrequency"]),
+    ]
+)

--- a/code/packages/swift/note-frequency/README.md
+++ b/code/packages/swift/note-frequency/README.md
@@ -1,0 +1,22 @@
+# swift/note-frequency
+
+
+Parses typed musical note labels such as `A4`, `C#5`, and `Db3` into a structured
+`Note` value and then maps that note to its equal-tempered frequency in Hertz.
+
+This package is the symbolic front door for the music stack:
+
+- users type note names
+- this layer turns them into exact pitches
+- later oscillator and renderer packages will turn those pitches into sound
+
+The core reference point is `A4 = 440 Hz`, and every semitone step multiplies
+frequency by `2^(1/12)`.
+
+
+## Usage
+
+```swift
+let note = try parseNote("A4")
+let frequency = try noteToFrequency("C4")
+```

--- a/code/packages/swift/note-frequency/Sources/NoteFrequency/NoteFrequency.swift
+++ b/code/packages/swift/note-frequency/Sources/NoteFrequency/NoteFrequency.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+public enum NoteFrequencyError: Error, Equatable, CustomStringConvertible {
+    case invalidNote(String)
+    case unsupportedSpelling(String)
+
+    public var description: String {
+        switch self {
+        case let .invalidNote(text):
+            return "Invalid note \(String(reflecting: text)). Expected <letter><optional # or b><octave>, for example 'A4', 'C#5', or 'Db3'."
+        case let .unsupportedSpelling(spelling):
+            return "Unsupported note spelling \(String(reflecting: spelling)). Only natural notes plus single # or b accidentals are supported."
+        }
+    }
+}
+
+public struct Note: Equatable, CustomStringConvertible {
+    public let letter: String
+    public let accidental: String
+    public let octave: Int
+
+    private static let chromaticIndex: [String: Int] = [
+        "C": 0,
+        "C#": 1,
+        "Db": 1,
+        "D": 2,
+        "D#": 3,
+        "Eb": 3,
+        "E": 4,
+        "F": 5,
+        "F#": 6,
+        "Gb": 6,
+        "G": 7,
+        "G#": 8,
+        "Ab": 8,
+        "A": 9,
+        "A#": 10,
+        "Bb": 10,
+        "B": 11,
+    ]
+
+    private static let referenceOctave = 4
+    private static let referenceIndex = 9
+    private static let referenceFrequencyHz = 440.0
+    private static let semitonesPerOctave = 12
+
+    public init(letter: String, accidental: String = "", octave: Int) throws {
+        let canonicalLetter = letter.uppercased()
+        let spelling = canonicalLetter + accidental
+        guard Note.chromaticIndex[spelling] != nil else {
+            throw NoteFrequencyError.unsupportedSpelling(spelling)
+        }
+        self.letter = canonicalLetter
+        self.accidental = accidental
+        self.octave = octave
+    }
+
+    public var spelling: String {
+        letter + accidental
+    }
+
+    public var chromaticIndexValue: Int {
+        Note.chromaticIndex[spelling]!
+    }
+
+    public func semitonesFromA4() -> Int {
+        let octaveOffset = (octave - Note.referenceOctave) * Note.semitonesPerOctave
+        let pitchOffset = chromaticIndexValue - Note.referenceIndex
+        return octaveOffset + pitchOffset
+    }
+
+    public func frequency() -> Double {
+        Note.referenceFrequencyHz * Foundation.pow(2.0, Double(semitonesFromA4()) / Double(Note.semitonesPerOctave))
+    }
+
+    public var description: String {
+        "\(spelling)\(octave)"
+    }
+}
+
+public func parseNote(_ text: String) throws -> Note {
+    guard let first = text.first else {
+        throw NoteFrequencyError.invalidNote(text)
+    }
+
+    let uppercaseLetter = String(first).uppercased()
+    guard ["A", "B", "C", "D", "E", "F", "G"].contains(uppercaseLetter) else {
+        throw NoteFrequencyError.invalidNote(text)
+    }
+
+    let rest = String(text.dropFirst())
+    let accidental: String
+    let octaveText: String
+    if rest.hasPrefix("#") {
+        accidental = "#"
+        octaveText = String(rest.dropFirst())
+    } else if rest.hasPrefix("b") {
+        accidental = "b"
+        octaveText = String(rest.dropFirst())
+    } else {
+        accidental = ""
+        octaveText = rest
+    }
+
+    guard isCanonicalOctave(octaveText), let octave = Int(octaveText) else {
+        throw NoteFrequencyError.invalidNote(text)
+    }
+
+    return try Note(letter: uppercaseLetter, accidental: accidental, octave: octave)
+}
+
+private func isCanonicalOctave(_ text: String) -> Bool {
+    guard !text.isEmpty else {
+        return false
+    }
+
+    let digits: Substring
+    if text.first == "-" {
+        digits = text.dropFirst()
+    } else {
+        digits = text[...]
+    }
+
+    return !digits.isEmpty && digits.allSatisfy { $0 >= "0" && $0 <= "9" }
+}
+
+public func noteToFrequency(_ text: String) throws -> Double {
+    try parseNote(text).frequency()
+}

--- a/code/packages/swift/note-frequency/Tests/NoteFrequencyTests/NoteFrequencyTests.swift
+++ b/code/packages/swift/note-frequency/Tests/NoteFrequencyTests/NoteFrequencyTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import NoteFrequency
+
+final class NoteFrequencyTests: XCTestCase {
+    func testParseNote() throws {
+        let note = try parseNote("C#5")
+        XCTAssertEqual(note.letter, "C")
+        XCTAssertEqual(note.accidental, "#")
+        XCTAssertEqual(note.octave, 5)
+    }
+
+    func testLowercaseNormalization() throws {
+        XCTAssertEqual(try parseNote("g4").description, "G4")
+    }
+
+    func testMalformedNotesThrow() {
+        for value in ["", "A", "H4", "#4", "4A", "A##4", "Bb", "A+4", "A 4"] {
+            XCTAssertThrowsError(try parseNote(value))
+        }
+    }
+
+    func testUnsupportedSpellingsThrow() {
+        XCTAssertThrowsError(try Note(letter: "E", accidental: "#", octave: 4))
+    }
+
+    func testSemitoneOffsets() throws {
+        XCTAssertEqual(try parseNote("A4").semitonesFromA4(), 0)
+        XCTAssertEqual(try parseNote("A5").semitonesFromA4(), 12)
+        XCTAssertEqual(try parseNote("A3").semitonesFromA4(), -12)
+        XCTAssertEqual(try parseNote("C4").semitonesFromA4(), -9)
+    }
+
+    func testFrequencies() throws {
+        XCTAssertEqual(try parseNote("A4").frequency(), 440.0, accuracy: 1e-12)
+        XCTAssertEqual(try parseNote("A5").frequency(), 880.0, accuracy: 1e-12)
+        XCTAssertEqual(try parseNote("A3").frequency(), 220.0, accuracy: 1e-12)
+        XCTAssertEqual(try noteToFrequency("C4"), 261.6255653005986, accuracy: 1e-12)
+        XCTAssertEqual(try noteToFrequency("C#4"), try noteToFrequency("Db4"), accuracy: 1e-12)
+    }
+}

--- a/code/packages/swift/note-frequency/required_capabilities.json
+++ b/code/packages/swift/note-frequency/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "swift/note-frequency",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}


### PR DESCRIPTION
## Summary
- Add the Swift note-frequency package with parseNote, Note, and noteToFrequency.
- Include package README, changelog, BUILD/BUILD_windows, required capabilities, and SwiftPM manifest.
- Add package-local .gitignore before testing/building so Swift artifacts cannot be staged.
- Tighten octave parsing to match the shared note grammar: optional minus followed by digits.

## Validation
- swift build --verbose
- /tmp/ca-build-tool-note-swift -root /Users/adhithya/Downloads/coding-adventures-note-frequency-swift -detect-languages -emit-plan /tmp/note-frequency-swift-plan.json -diff-base origin/main -validate-build-files
- Local swift test attempted but blocked by this local CommandLineTools Swift missing XCTest: `error: no such module 'XCTest'`
- Local security-review checklist passed; no vulnerabilities found.