### PR TITLE
feat(note-frequency): add Haskell package

### DIFF
--- a/code/packages/haskell/.gitignore
+++ b/code/packages/haskell/.gitignore
@@ -1,0 +1,1 @@
+dist-newstyle/

--- a/code/packages/haskell/note-frequency/.gitignore
+++ b/code/packages/haskell/note-frequency/.gitignore
@@ -1,0 +1,1 @@
+dist-newstyle/

--- a/code/packages/haskell/note-frequency/BUILD
+++ b/code/packages/haskell/note-frequency/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/note-frequency/BUILD_windows
+++ b/code/packages/haskell/note-frequency/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/note-frequency/CHANGELOG.md
+++ b/code/packages/haskell/note-frequency/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Added the initial note-to-frequency package.
+- Added note parsing for natural notes plus single sharps and flats.
+- Added equal-tempered frequency mapping anchored at `A4 = 440 Hz`.
+- Added tests that lock down the shared parity vectors across language ports.

--- a/code/packages/haskell/note-frequency/README.md
+++ b/code/packages/haskell/note-frequency/README.md
@@ -1,0 +1,22 @@
+# haskell/note-frequency
+
+
+Parses typed musical note labels such as `A4`, `C#5`, and `Db3` into a structured
+`Note` value and then maps that note to its equal-tempered frequency in Hertz.
+
+This package is the symbolic front door for the music stack:
+
+- users type note names
+- this layer turns them into exact pitches
+- later oscillator and renderer packages will turn those pitches into sound
+
+The core reference point is `A4 = 440 Hz`, and every semitone step multiplies
+frequency by `2^(1/12)`.
+
+
+## Usage
+
+```haskell
+let note = parseNote "A4"
+let frequency = noteToFrequency "C4"
+```

--- a/code/packages/haskell/note-frequency/note-frequency.cabal
+++ b/code/packages/haskell/note-frequency/note-frequency.cabal
@@ -1,0 +1,27 @@
+cabal-version:      2.4
+name:               note-frequency
+version:            0.1.0.0
+synopsis:           Parse note names and map them to equal-tempered frequencies.
+description:        Educational package implementing the symbolic note-to-frequency layer.
+category:           Music
+license:            MIT
+author:             Coding Adventures
+maintainer:         contact@coding-adventures.com
+extra-doc-files:    README.md
+                  , CHANGELOG.md
+
+library
+    exposed-modules:  NoteFrequency
+    build-depends:    base >= 4.7 && < 5
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite note-frequency-test
+    default-language: Haskell2010
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   test
+    main-is:          Spec.hs
+    other-modules:    NoteFrequencySpec
+    build-depends:    base >= 4.7 && < 5
+                    , hspec == 2.*
+                    , note-frequency

--- a/code/packages/haskell/note-frequency/src/NoteFrequency.hs
+++ b/code/packages/haskell/note-frequency/src/NoteFrequency.hs
@@ -1,0 +1,98 @@
+module NoteFrequency
+    ( Note(..)
+    , spelling
+    , chromaticIndex
+    , semitonesFromA4
+    , frequency
+    , parseNote
+    , noteToFrequency
+    ) where
+
+import Data.Char (toUpper)
+import Text.Read (readMaybe)
+
+data Note = Note
+    { letter :: Char
+    , accidental :: String
+    , octave :: Int
+    } deriving (Eq)
+
+instance Show Note where
+    show note = spelling note ++ show (octave note)
+
+spelling :: Note -> String
+spelling note = [letter note] ++ accidental note
+
+chromaticIndexFor :: String -> Maybe Int
+chromaticIndexFor name = case name of
+    "C"  -> Just 0
+    "C#" -> Just 1
+    "Db" -> Just 1
+    "D"  -> Just 2
+    "D#" -> Just 3
+    "Eb" -> Just 3
+    "E"  -> Just 4
+    "F"  -> Just 5
+    "F#" -> Just 6
+    "Gb" -> Just 6
+    "G"  -> Just 7
+    "G#" -> Just 8
+    "Ab" -> Just 8
+    "A"  -> Just 9
+    "A#" -> Just 10
+    "Bb" -> Just 10
+    "B"  -> Just 11
+    _     -> Nothing
+
+createNote :: Char -> String -> Int -> Either String Note
+createNote rawLetter accidentalValue octaveValue =
+    let canonicalLetter = toUpper rawLetter
+        note = Note canonicalLetter accidentalValue octaveValue
+    in case chromaticIndexFor (spelling note) of
+        Nothing -> Left ("Unsupported note spelling " ++ show (spelling note) ++ ". Only natural notes plus single # or b accidentals are supported.")
+        Just _ -> Right note
+
+chromaticIndex :: Note -> Int
+chromaticIndex note = case chromaticIndexFor (spelling note) of
+    Just indexValue -> indexValue
+    Nothing -> error "chromaticIndex called on invalid note"
+
+semitonesFromA4 :: Note -> Int
+semitonesFromA4 note = octaveOffset + pitchOffset
+  where
+    octaveOffset = (octave note - 4) * 12
+    pitchOffset = chromaticIndex note - 9
+
+frequency :: Note -> Double
+frequency note = 440.0 * 2 ** (fromIntegral (semitonesFromA4 note) / 12.0)
+
+parseNote :: String -> Either String Note
+parseNote input = case input of
+    [] -> Left invalidShape
+    (rawLetter:rest) ->
+        let canonicalLetter = toUpper rawLetter
+        in if canonicalLetter `notElem` "ABCDEFG"
+           then Left invalidShape
+           else do
+            let (accidentalValue, octaveText) = case rest of
+                    '#':xs -> ("#", xs)
+                    'b':xs -> ("b", xs)
+                    xs     -> ("", xs)
+            if not (isCanonicalOctave octaveText)
+               then Left invalidShape
+               else do
+                octaveValue <- maybe (Left invalidShape) Right (readMaybe octaveText)
+                createNote canonicalLetter accidentalValue octaveValue
+  where
+    invalidShape = "Invalid note. Expected <letter><optional # or b><octave>, for example 'A4', 'C#5', or 'Db3'."
+
+isCanonicalOctave :: String -> Bool
+isCanonicalOctave [] = False
+isCanonicalOctave ('-':digits) = not (null digits) && all isDigitAscii digits
+isCanonicalOctave digits = all isDigitAscii digits
+
+isDigitAscii :: Char -> Bool
+isDigitAscii character = character >= '0' && character <= '9'
+
+noteToFrequency :: String -> Either String Double
+noteToFrequency input = frequency <$> parseNote input

--- a/code/packages/haskell/note-frequency/test/NoteFrequencySpec.hs
+++ b/code/packages/haskell/note-frequency/test/NoteFrequencySpec.hs
@@ -1,0 +1,38 @@
+module NoteFrequencySpec (spec) where
+
+import Test.Hspec
+import NoteFrequency
+
+spec :: Spec
+spec = do
+    describe "parseNote" $ do
+        it "extracts fields" $ do
+            parseNote "C#5" `shouldBe` Right (Note 'C' "#" 5)
+
+        it "normalizes lowercase letters" $ do
+            fmap show (parseNote "g4") `shouldBe` Right "G4"
+
+        it "rejects malformed notes" $ do
+            map parseNote ["", "A", "H4", "#4", "4A", "A##4", "Bb", "A+4", "A 4"] `shouldSatisfy` all isLeft
+
+        it "rejects unsupported spellings" $ do
+            parseNote "E#4" `shouldSatisfy` isLeft
+
+    describe "semitonesFromA4" $ do
+        it "matches the reference examples" $ do
+            fmap semitonesFromA4 (parseNote "A4") `shouldBe` Right 0
+            fmap semitonesFromA4 (parseNote "A5") `shouldBe` Right 12
+            fmap semitonesFromA4 (parseNote "A3") `shouldBe` Right (-12)
+            fmap semitonesFromA4 (parseNote "C4") `shouldBe` Right (-9)
+
+    describe "frequency mapping" $ do
+        it "matches the reference examples" $ do
+            fmap frequency (parseNote "A4") `shouldBe` Right 440.0
+            fmap frequency (parseNote "A5") `shouldBe` Right 880.0
+            fmap frequency (parseNote "A3") `shouldBe` Right 220.0
+            fmap (\value -> abs (value - 261.6255653005986) < 1e-12) (noteToFrequency "C4") `shouldBe` Right True
+            fmap (\value -> abs (value - either (const 0) id (noteToFrequency "Db4")) < 1e-12) (noteToFrequency "C#4") `shouldBe` Right True
+
+isLeft :: Either a b -> Bool
+isLeft (Left _) = True
+isLeft _ = False

--- a/code/packages/haskell/note-frequency/test/Spec.hs
+++ b/code/packages/haskell/note-frequency/test/Spec.hs
@@ -1,0 +1,7 @@
+module Main where
+
+import Test.Hspec
+import qualified NoteFrequencySpec
+
+main :: IO ()
+main = hspec NoteFrequencySpec.spec

--- a/lessons.md
+++ b/lessons.md
@@ -2840,3 +2840,18 @@ interpolation made the parser unhappy even though the logic itself was fine.
 **Rule:** In F#, avoid putting expressions with quoted string literals directly inside interpolated
 strings. Bind those values first with `let`, or switch to `sprintf` when composing dense XML/HTML
 attribute strings.
+
+---
+
+## Haskell package-local builds should not target `all`
+
+**Date:** 2026-04-19
+
+**What happened:** While validating an isolated Haskell package, running `cabal test all` from the
+package directory picked up the parent `code/packages/haskell/cabal.project` and attempted to build
+the whole Haskell package universe. The package-local `BUILD` command used plain `cabal test`, which
+correctly limited the build plan to the current package and its test suite.
+
+**Rule:** For single-package Haskell validation in this repo, run plain `cabal test` from the
+package directory unless you explicitly want the parent project. Do not append the `all` target for
+isolated package PRs.


### PR DESCRIPTION
## Summary
- add the Haskell note-frequency package with parser, semitone, and frequency mapping APIs
- include Hspec coverage, README, changelog, BUILD files, and Cabal package metadata
- document the Cabal package-local build gotcha in lessons.md

## Validation
- cabal test
- cabal check
- /tmp/ca-build-tool-note-haskell -root /Users/adhithya/Downloads/coding-adventures-note-frequency-haskell -detect-languages -emit-plan /tmp/note-frequency-haskell-plan.json -diff-base origin/main -validate-build-files
- /tmp/ca-build-tool-note-haskell -root /Users/adhithya/Downloads/coding-adventures-note-frequency-haskell -plan-file /tmp/note-frequency-haskell-plan.json -jobs 2

Security review: local checklist passed; package is deterministic parsing/math only with no I/O, network, filesystem, shell execution, or unsafe memory access.