### PR TITLE
feat(note-frequency): add Rust package

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -92,6 +92,7 @@ members = [
     "logic-gates",
     "loss-functions",
     "markov-chain",
+    "note-frequency",
     "matrix",
     "ml-framework-core",
     "ml-framework-keras",

--- a/code/packages/rust/note-frequency/BUILD
+++ b/code/packages/rust/note-frequency/BUILD
@@ -1,0 +1,2 @@
+cargo build
+cargo test

--- a/code/packages/rust/note-frequency/BUILD_windows
+++ b/code/packages/rust/note-frequency/BUILD_windows
@@ -1,0 +1,2 @@
+cargo build
+cargo test

--- a/code/packages/rust/note-frequency/CHANGELOG.md
+++ b/code/packages/rust/note-frequency/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Added the initial note-to-frequency package.
+- Added note parsing for natural notes plus single sharps and flats.
+- Added equal-tempered frequency mapping anchored at `A4 = 440 Hz`.
+- Added tests that lock down the shared parity vectors across language ports.

--- a/code/packages/rust/note-frequency/Cargo.toml
+++ b/code/packages/rust/note-frequency/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "coding-adventures-note-frequency"
+version = "0.1.0"
+edition = "2021"
+description = "Parse note names like A4 and map them to equal-tempered frequencies"
+license = "MIT"
+readme = "README.md"

--- a/code/packages/rust/note-frequency/README.md
+++ b/code/packages/rust/note-frequency/README.md
@@ -1,0 +1,22 @@
+# rust/note-frequency
+
+
+Parses typed musical note labels such as `A4`, `C#5`, and `Db3` into a structured
+`Note` value and then maps that note to its equal-tempered frequency in Hertz.
+
+This package is the symbolic front door for the music stack:
+
+- users type note names
+- this layer turns them into exact pitches
+- later oscillator and renderer packages will turn those pitches into sound
+
+The core reference point is `A4 = 440 Hz`, and every semitone step multiplies
+frequency by `2^(1/12)`.
+
+
+## Usage
+
+```rust
+let note = coding_adventures_note_frequency::parse_note("A4")?;
+let frequency = coding_adventures_note_frequency::note_to_frequency("C4")?;
+```

--- a/code/packages/rust/note-frequency/required_capabilities.json
+++ b/code/packages/rust/note-frequency/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/note-frequency",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/rust/note-frequency/src/lib.rs
+++ b/code/packages/rust/note-frequency/src/lib.rs
@@ -1,0 +1,120 @@
+const REFERENCE_OCTAVE: i32 = 4;
+const REFERENCE_INDEX: i32 = 9;
+const REFERENCE_FREQUENCY_HZ: f64 = 440.0;
+const SEMITONES_PER_OCTAVE: i32 = 12;
+
+fn chromatic_index_for(spelling: &str) -> Option<i32> {
+    match spelling {
+        "C" => Some(0),
+        "C#" | "Db" => Some(1),
+        "D" => Some(2),
+        "D#" | "Eb" => Some(3),
+        "E" => Some(4),
+        "F" => Some(5),
+        "F#" | "Gb" => Some(6),
+        "G" => Some(7),
+        "G#" | "Ab" => Some(8),
+        "A" => Some(9),
+        "A#" | "Bb" => Some(10),
+        "B" => Some(11),
+        _ => None,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Note {
+    pub letter: String,
+    pub accidental: String,
+    pub octave: i32,
+}
+
+impl Note {
+    pub fn new(letter: &str, accidental: &str, octave: i32) -> Result<Self, String> {
+        let canonical_letter = letter.to_uppercase();
+        let spelling = format!("{}{}", canonical_letter, accidental);
+        if chromatic_index_for(&spelling).is_none() {
+            return Err(format!(
+                "Unsupported note spelling {:?}. Only natural notes plus single # or b accidentals are supported.",
+                spelling
+            ));
+        }
+        Ok(Self {
+            letter: canonical_letter,
+            accidental: accidental.to_string(),
+            octave,
+        })
+    }
+
+    pub fn spelling(&self) -> String {
+        format!("{}{}", self.letter, self.accidental)
+    }
+
+    pub fn chromatic_index(&self) -> i32 {
+        chromatic_index_for(&self.spelling()).expect("validated spelling")
+    }
+
+    pub fn semitones_from_a4(&self) -> i32 {
+        let octave_offset = (self.octave - REFERENCE_OCTAVE) * SEMITONES_PER_OCTAVE;
+        let pitch_offset = self.chromatic_index() - REFERENCE_INDEX;
+        octave_offset + pitch_offset
+    }
+
+    pub fn frequency(&self) -> f64 {
+        REFERENCE_FREQUENCY_HZ
+            * 2f64.powf(self.semitones_from_a4() as f64 / SEMITONES_PER_OCTAVE as f64)
+    }
+}
+
+impl std::fmt::Display for Note {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}{}", self.spelling(), self.octave)
+    }
+}
+
+pub fn parse_note(text: &str) -> Result<Note, String> {
+    let mut chars = text.chars();
+    let letter = chars.next().ok_or_else(|| invalid_note_message(text))?;
+    if !matches!(
+        letter.to_ascii_uppercase(),
+        'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G'
+    ) {
+        return Err(invalid_note_message(text));
+    }
+
+    let rest: String = chars.collect();
+    let (accidental, octave_text) = if let Some(stripped) = rest.strip_prefix('#') {
+        ("#", stripped)
+    } else if let Some(stripped) = rest.strip_prefix('b') {
+        ("b", stripped)
+    } else {
+        ("", rest.as_str())
+    };
+
+    if octave_text.is_empty() {
+        return Err(invalid_note_message(text));
+    }
+    if !is_canonical_octave(octave_text) {
+        return Err(invalid_note_message(text));
+    }
+
+    let octave = octave_text
+        .parse::<i32>()
+        .map_err(|_| invalid_note_message(text))?;
+    Note::new(&letter.to_string(), accidental, octave)
+}
+
+pub fn note_to_frequency(text: &str) -> Result<f64, String> {
+    Ok(parse_note(text)?.frequency())
+}
+
+fn invalid_note_message(text: &str) -> String {
+    format!(
+        "Invalid note {:?}. Expected <letter><optional # or b><octave>, for example 'A4', 'C#5', or 'Db3'.",
+        text
+    )
+}
+
+fn is_canonical_octave(text: &str) -> bool {
+    let digits = text.strip_prefix('-').unwrap_or(text);
+    !digits.is_empty() && digits.chars().all(|character| character.is_ascii_digit())
+}

--- a/code/packages/rust/note-frequency/tests/note_frequency_tests.rs
+++ b/code/packages/rust/note-frequency/tests/note_frequency_tests.rs
@@ -1,0 +1,61 @@
+use coding_adventures_note_frequency::{note_to_frequency, parse_note, Note};
+
+fn approx_equal(left: f64, right: f64) {
+    assert!(
+        (left - right).abs() < 1e-12,
+        "expected {left} to equal {right}"
+    );
+}
+
+#[test]
+fn parse_note_extracts_components() {
+    let note = parse_note("C#5").unwrap();
+    assert_eq!(note.letter, "C");
+    assert_eq!(note.accidental, "#");
+    assert_eq!(note.octave, 5);
+}
+
+#[test]
+fn lowercase_note_is_normalized() {
+    assert_eq!(parse_note("g4").unwrap().to_string(), "G4");
+}
+
+#[test]
+fn malformed_notes_are_rejected() {
+    for value in ["", "A", "H4", "#4", "4A", "A##4", "Bb", "A+4", "A 4"] {
+        assert!(parse_note(value).is_err(), "expected {value:?} to fail");
+    }
+}
+
+#[test]
+fn unsupported_spelling_is_rejected() {
+    assert!(Note::new("E", "#", 4).is_err());
+}
+
+#[test]
+fn semitone_offsets_match_reference_examples() {
+    assert_eq!(parse_note("A4").unwrap().semitones_from_a4(), 0);
+    assert_eq!(parse_note("A5").unwrap().semitones_from_a4(), 12);
+    assert_eq!(parse_note("A3").unwrap().semitones_from_a4(), -12);
+    assert_eq!(parse_note("C4").unwrap().semitones_from_a4(), -9);
+}
+
+#[test]
+fn frequency_mapping_matches_reference_examples() {
+    approx_equal(parse_note("A4").unwrap().frequency(), 440.0);
+    approx_equal(parse_note("A5").unwrap().frequency(), 880.0);
+    approx_equal(parse_note("A3").unwrap().frequency(), 220.0);
+}
+
+#[test]
+fn middle_c_matches_equal_temperament() {
+    approx_equal(note_to_frequency("C4").unwrap(), 261.6255653005986);
+}
+
+#[test]
+fn enharmonic_spellings_match() {
+    approx_equal(
+        note_to_frequency("C#4").unwrap(),
+        note_to_frequency("Db4").unwrap(),
+    );
+}


### PR DESCRIPTION
## Summary
- add the Rust note-frequency crate with parser, semitone, and frequency APIs
- register the crate in the Rust workspace manifest
- include package BUILD files, tests, README, changelog, and required capabilities metadata

## Validation
- cargo fmt --manifest-path code/packages/rust/note-frequency/Cargo.toml
- cargo test -p coding-adventures-note-frequency
- sh code/packages/rust/note-frequency/BUILD
- /tmp/ca-build-tool-note-rust -root /Users/adhithya/Downloads/coding-adventures-note-frequency-rust -detect-languages -emit-plan /tmp/note-frequency-rust-plan.json -diff-base origin/main -validate-build-files
- /tmp/ca-build-tool-note-rust -root /Users/adhithya/Downloads/coding-adventures-note-frequency-rust -plan-file /tmp/note-frequency-rust-plan.json -jobs 2

Security review: local checklist passed; crate uses safe Rust only and performs deterministic note parsing/math with no I/O, network, filesystem, process, or unsafe memory access.