### PR TITLE
feat(note-frequency): add WASM package

### DIFF
--- a/code/packages/wasm/note-frequency/BUILD
+++ b/code/packages/wasm/note-frequency/BUILD
@@ -1,0 +1,1 @@
+cargo test -- --nocapture

--- a/code/packages/wasm/note-frequency/BUILD_windows
+++ b/code/packages/wasm/note-frequency/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -- --nocapture

--- a/code/packages/wasm/note-frequency/CHANGELOG.md
+++ b/code/packages/wasm/note-frequency/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Added the initial note-to-frequency package.
+- Added note parsing for natural notes plus single sharps and flats.
+- Added equal-tempered frequency mapping anchored at `A4 = 440 Hz`.
+- Added tests that lock down the shared parity vectors across language ports.

--- a/code/packages/wasm/note-frequency/Cargo.toml
+++ b/code/packages/wasm/note-frequency/Cargo.toml
@@ -1,0 +1,16 @@
+[workspace]
+
+[package]
+name = "note-frequency-wasm"
+version = "0.1.0"
+edition = "2021"
+description = "WebAssembly bindings for the Rust note-frequency package"
+license = "MIT"
+readme = "README.md"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+note_frequency = { package = "coding-adventures-note-frequency", path = "../../rust/note-frequency" }
+wasm-bindgen = "0.2"

--- a/code/packages/wasm/note-frequency/README.md
+++ b/code/packages/wasm/note-frequency/README.md
@@ -1,0 +1,22 @@
+# wasm/note-frequency
+
+
+Parses typed musical note labels such as `A4`, `C#5`, and `Db3` into a structured
+`Note` value and then maps that note to its equal-tempered frequency in Hertz.
+
+This package is the symbolic front door for the music stack:
+
+- users type note names
+- this layer turns them into exact pitches
+- later oscillator and renderer packages will turn those pitches into sound
+
+The core reference point is `A4 = 440 Hz`, and every semitone step multiplies
+frequency by `2^(1/12)`.
+
+
+## Usage
+
+```javascript
+const note = parseNote("A4");
+const frequency = noteToFrequency("C4");
+```

--- a/code/packages/wasm/note-frequency/required_capabilities.json
+++ b/code/packages/wasm/note-frequency/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "wasm/note-frequency",
+  "capabilities": [],
+  "justification": "Pure computation compiled to WebAssembly. No host capabilities required."
+}

--- a/code/packages/wasm/note-frequency/src/lib.rs
+++ b/code/packages/wasm/note-frequency/src/lib.rs
@@ -1,0 +1,92 @@
+use note_frequency::{note_to_frequency, parse_note, Note};
+use wasm_bindgen::prelude::*;
+
+#[cfg(target_arch = "wasm32")]
+fn to_js_error(message: impl Into<String>) -> JsValue {
+    JsValue::from_str(&message.into())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn to_js_error(_message: impl Into<String>) -> JsValue {
+    JsValue::NULL
+}
+
+#[wasm_bindgen]
+pub struct WasmNote {
+    inner: Note,
+}
+
+#[wasm_bindgen]
+impl WasmNote {
+    #[wasm_bindgen(getter)]
+    pub fn letter(&self) -> String {
+        self.inner.letter.clone()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn accidental(&self) -> String {
+        self.inner.accidental.clone()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn octave(&self) -> i32 {
+        self.inner.octave
+    }
+
+    #[wasm_bindgen(js_name = "spelling")]
+    pub fn spelling(&self) -> String {
+        self.inner.spelling()
+    }
+
+    #[wasm_bindgen(js_name = "semitonesFromA4")]
+    pub fn semitones_from_a4(&self) -> i32 {
+        self.inner.semitones_from_a4()
+    }
+
+    pub fn frequency(&self) -> f64 {
+        self.inner.frequency()
+    }
+
+    #[wasm_bindgen(js_name = "toString")]
+    pub fn to_string_value(&self) -> String {
+        self.inner.to_string()
+    }
+}
+
+#[wasm_bindgen(js_name = "parseNote")]
+pub fn parse_note_js(text: &str) -> Result<WasmNote, JsValue> {
+    Ok(WasmNote {
+        inner: parse_note(text).map_err(to_js_error)?,
+    })
+}
+
+#[wasm_bindgen(js_name = "noteToFrequency")]
+pub fn note_to_frequency_js(text: &str) -> Result<f64, JsValue> {
+    note_to_frequency(text).map_err(to_js_error)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wrapper_preserves_fields() {
+        let note = parse_note_js("C#5").unwrap();
+        assert_eq!(note.letter(), "C");
+        assert_eq!(note.accidental(), "#");
+        assert_eq!(note.octave(), 5);
+    }
+
+    #[test]
+    fn wrapper_maps_frequencies() {
+        assert!((note_to_frequency_js("C4").unwrap() - 261.6255653005986).abs() < 1e-12);
+    }
+
+    #[test]
+    fn wrapper_rejects_malformed_notes() {
+        for value in ["", "A", "H4", "A+4", "A 4"] {
+            assert!(parse_note_js(value).is_err(), "expected {value:?} to fail");
+        }
+    }
+}

--- a/lessons.md
+++ b/lessons.md
@@ -2855,3 +2855,18 @@ correctly limited the build plan to the current package and its test suite.
 **Rule:** For single-package Haskell validation in this repo, run plain `cabal test` from the
 package directory unless you explicitly want the parent project. Do not append the `all` target for
 isolated package PRs.
+
+---
+
+## wasm-bindgen `JsValue::from_str` is not safe in native error-path tests
+
+**Date:** 2026-04-19
+
+**What happened:** A native `cargo test` for a WASM wrapper passed success-path tests but aborted
+when an error-path test tried to convert a Rust error string with `JsValue::from_str`. On
+non-wasm32 targets, that wasm-bindgen constructor can hit a "function not implemented" abort instead
+of returning a normal Rust panic.
+
+**Rule:** In wasm-bindgen wrapper crates that run native tests, keep JS error construction behind a
+`#[cfg(target_arch = "wasm32")]` helper. Use a simple native placeholder such as `JsValue::NULL` for
+test-only error values when the test only needs to assert that the wrapper returned `Err`.


### PR DESCRIPTION
## Summary
- add the wasm-bindgen note-frequency wrapper package
- expose parseNote, noteToFrequency, and WasmNote accessors for browser/JS callers
- include BUILD files, README, changelog, required capabilities metadata, and native wrapper tests
- document the wasm-bindgen native-test error-value gotcha in lessons.md

## Validation
- cargo test -- --nocapture
- /tmp/ca-build-tool-note-wasm -root /Users/adhithya/Downloads/coding-adventures-note-frequency-wasm -detect-languages -emit-plan /tmp/note-frequency-wasm-plan.json -diff-base origin/main -validate-build-files
- /tmp/ca-build-tool-note-wasm -root /Users/adhithya/Downloads/coding-adventures-note-frequency-wasm -plan-file /tmp/note-frequency-wasm-plan.json -jobs 2

Audit note: latest origin/main already has note-frequency packages for csharp, dart, elixir, fsharp, go, haskell, java, kotlin, lua, perl, python, ruby, rust, swift, and typescript. WASM was the only supported non-Starlark package missing from main.

Security review: local checklist passed; wrapper uses safe Rust and deterministic parsing/math with no filesystem, network, process, environment, or host-capability access.