### PR TITLE
spec(ui04): amend text path for pre-shaped PaintGlyphRun

### DIFF
--- a/code/specs/UI04-layout-to-paint.md
+++ b/code/specs/UI04-layout-to-paint.md
@@ -48,8 +48,40 @@ LayoutToPaintOptions {
   devicePixelRatio: float   // default 1.0; physical pixels per logical unit
                             // applied to all coordinates and sizes before
                             // emitting PaintInstructions
+
+  // --- Required for text content ---
+  //
+  // A text shaper (TXT00) that converts strings into positioned glyph
+  // runs. The layout engine MUST supply one if any PositionedNode in
+  // the input tree carries TextContent. If a TextContent node is
+  // encountered without a shaper in options, layout_to_paint throws
+  // MissingTextShaperError.
+  //
+  // The shaper's binding (e.g. "font-parser:<hash>", "coretext:<id>")
+  // propagates into every emitted PaintGlyphRun via the font_ref field.
+  // Paint backends route glyph_run dispatch on this prefix — see P2D06.
+  shaper:      TextShaper?
+
+  // A font metrics provider (TXT00) paired with the shaper. Used to
+  // compute baseline positions from the top-of-bbox position that the
+  // layout produces. Must be backend-compatible with the shaper (same
+  // FontHandle type). Optional only when shaper is also null.
+  metrics:     FontMetrics?
+
+  // A font resolver (TXT05) that maps CSS-style font family/weight/
+  // style queries to FontHandle values the shaper understands. Used
+  // once per distinct TextContent.font combination per call.
+  // Optional only when shaper is also null.
+  resolver:    FontResolver?
 }
 ```
+
+The `shaper`/`metrics`/`resolver` trio MUST share a font binding —
+they are a matched set. A caller using the device-independent path
+passes a `font-parser`-backed trio; a caller on macOS native passes
+a CoreText-backed trio (TXT03a). They are not mix-and-matchable
+across backends; that would violate the font-binding invariant
+(see TXT00 §"The font-binding invariant").
 
 ---
 
@@ -113,26 +145,89 @@ For each node, emit `PaintInstruction` values in this order:
 
 #### `TextContent` → `PaintGlyphRun`
 
+**This subsection supersedes the earlier "top-of-bbox y / text /
+maxWidth / align" description that shipped before the TXT-series
+was specified.** PaintGlyphRun as defined in P2D00 is a *pre-shaped*
+instruction: glyph IDs and positions are baked in by the layout
+engine using the caller-supplied TextShaper. The paint backend only
+rasterizes; it never sees the source string, never re-measures,
+never re-wraps.
+
+The conversion:
+
 ```
-PaintGlyphRun {
-  x:        abs_x × dpr
-  y:        abs_y × dpr
-  text:     content.value
-  font:     {
-    family: content.font.family,
-    size:   content.font.size × dpr,
-    weight: content.font.weight,
-    italic: content.font.italic
-  }
-  color:    content.color
-  maxWidth: node.width × dpr     // clip/wrap text to node width
-  align:    content.textAlign
-}
+1. Resolve the font once per distinct TextContent.font combination:
+     handle = resolver.resolve(FontQuery {
+       family_names: [content.font.family, ...fallbacks],
+       weight:       content.font.weight,
+       style:        Italic if content.font.italic else Normal,
+       stretch:      Normal,
+     })
+
+2. Shape the text:
+     run = shaper.shape(
+       content.value,
+       handle,
+       content.font.size × dpr,
+       ShapeOptions { script: null, language: null,
+                      direction: "ltr", features: {} }
+     )
+
+3. Compute baseline origin from top-of-bbox + ascender:
+     units_per_em  = metrics.units_per_em(handle)
+     ascent_scaled = metrics.ascent(handle) × content.font.size × dpr
+                   / units_per_em
+     baseline_x    = abs_x × dpr
+     baseline_y    = abs_y × dpr + ascent_scaled
+
+4. Bake per-glyph absolute x_offset from the shaper's per-glyph
+   pen-relative adjustments (see TXT00 §"Relationship to P2D00
+   PaintGlyphRun" — the shaper returns adjustments relative to a
+   running pen; PaintGlyphRun.glyphs[i].x_offset is absolute from
+   the baseline origin):
+
+     pen = 0
+     for i in 0..run.glyphs.len():
+         glyph_absolute_x_offset[i] = pen + run.glyphs[i].x_offset
+         pen += run.glyphs[i].x_advance
+
+5. Emit:
+     PaintGlyphRun {
+       kind:      "glyph_run",
+       x:         baseline_x,
+       y:         baseline_y,
+       font_ref:  run.font_ref,               // verbatim from shaper
+       font_size: content.font.size × dpr,
+       glyphs:    run.glyphs.map((g, i) => ({
+         glyph_id: g.glyph_id,
+         x_offset: glyph_absolute_x_offset[i],
+         y_offset: g.y_offset,
+       })),
+       fill:      content.color,
+     }
 ```
 
-The `y` coordinate is the **top** of the text bounding box (not the baseline).
-PaintVM backends that need baseline positioning (e.g. Canvas `fillText`)
-must add the ascender metric internally. This is backend responsibility.
+**Multi-line text.** If the shaper was called with a `max_width`
+parameter and produced a line-broken run (layout engines may use
+the `line-breaker` package — FNT04/TXT06 — for this), the layout
+engine calls `shape()` once per line and emits one PaintGlyphRun
+per line, stacking baseline origins vertically by
+`metrics.line_gap + metrics.ascent + metrics.descent`.
+
+**Text alignment.** The old `align` field is gone. Alignment
+(`left` / `center` / `right` / `justify`) is resolved by the layout
+engine *before* calling this function: the `abs_x` position of the
+TextContent node already reflects the alignment choice. A centered
+line at x=0 in a 200-wide container with run width 120 has
+`abs_x = 40` coming in; layout-to-paint does not re-center.
+
+**Why the rewrite.** The earlier version of this section predated
+the TXT-series and carried a string-plus-font-plus-maxWidth shape
+that paint backends had to re-shape at render time, forcing every
+backend to embed a shaper. That design is now deprecated; all
+shaping happens in the layout engine (once, using the
+caller-supplied shaper) and paint backends only ever see
+pre-positioned glyph IDs.
 
 #### `ImageContent` → `PaintImage`
 
@@ -196,9 +291,34 @@ This ensures opacity composites correctly across the entire subtree.
 ## What this package does NOT do
 
 - Does not run any layout algorithm — positions must already be resolved
-- Does not load fonts, images, or other resources
+- Does not load fonts, images, or other resources (fonts are resolved
+  via the caller-supplied `resolver`; this package does not fetch
+  bytes, only turns FontQueries into handles)
 - Does not validate that the `PositionedNode` tree is well-formed
 - Does not clip children to their parent's bounds by default (use
   `ext["paint"]["cornerRadius"]` or add explicit clip nodes in the tree)
 - Does not handle scrolling or interactive hit regions
 - Does not produce accessibility metadata
+- Does not shape or measure text directly — delegates to the
+  caller-supplied `shaper` and `metrics` (TXT00 interfaces). See
+  Step 4 above.
+
+---
+
+## Error conditions
+
+| Error                      | When                                                             |
+|----------------------------|------------------------------------------------------------------|
+| `MissingTextShaperError`   | A TextContent node was encountered but options.shaper is null    |
+| `MissingFontMetricsError`  | A TextContent node was encountered but options.metrics is null   |
+| `MissingFontResolverError` | A TextContent node was encountered but options.resolver is null  |
+| `FontBindingMismatchError` | options.shaper/metrics/resolver do not share a font binding      |
+| (propagated)               | Errors from resolver.resolve(), shaper.shape(), metrics.*()      |
+
+The first three are programmer errors — the caller built an
+options bundle without the text trio but passed in text content.
+`FontBindingMismatchError` is a cross-binding misuse (e.g., a
+CoreText resolver paired with a font-parser shaper). In
+statically-typed languages the binding-mismatch check is a
+compile-time type error via the generic `<H>` parameter on all
+three traits; dynamic languages check at runtime.


### PR DESCRIPTION
## Summary

- Amends UI04's \`TextContent → PaintGlyphRun\` section to match P2D00's actual pre-shaped \`PaintGlyphRun\` shape (glyph IDs + baked offsets, not string + font + maxWidth).
- Adds \`shaper\`/\`metrics\`/\`resolver\` (TXT00/TXT05) to \`LayoutToPaintOptions\`. The trio must share a font binding; cross-binding is a compile error in statically-typed languages, runtime in dynamic ones.
- Documents the conversion explicitly: resolve the font, shape, compute baseline, bake per-glyph absolute offsets from the shaper's pen-relative output, emit \`PaintGlyphRun\`.

## Why

Original UI04 predated the TXT-series and carried a string-plus-font-plus-maxWidth description that forced every paint backend to embed a shaper. Now shaping happens once in the layout engine and backends only see pre-positioned glyph IDs.

## Test plan

- [ ] Doc-only PR.
- [ ] \`/security-review\` passed.
- [ ] Reviewer sanity-check: baseline math (top-of-bbox + ascent × dpr / units_per_em) is correct and the pen → absolute offset conversion is correctly documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)