### PR TITLE
feat(oscillator): add python virtual oscillator package

### DIFF
--- a/code/packages/python/oscillator/BUILD
+++ b/code/packages/python/oscillator/BUILD
@@ -1,0 +1,6 @@
+uv venv --quiet --clear
+uv pip install --no-deps -e ../trig --quiet
+uv pip install --no-deps -e . --quiet
+uv pip install pytest pytest-cov ruff --quiet
+uv run --no-project ruff check src/ tests/
+uv run --no-project python -m pytest tests/ -v

--- a/code/packages/python/oscillator/BUILD_windows
+++ b/code/packages/python/oscillator/BUILD_windows
@@ -1,0 +1,6 @@
+uv venv --quiet --clear
+uv pip install --no-deps -e ../trig --quiet
+uv pip install --no-deps -e . --quiet
+uv pip install pytest pytest-cov ruff --quiet
+uv run --no-project ruff check src/ tests/
+uv run --no-project python -m pytest tests/ -v

--- a/code/packages/python/oscillator/CHANGELOG.md
+++ b/code/packages/python/oscillator/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.1.0 - 2026-04-20
+
+- Added the initial virtual oscillator package for Python.
+- Added `ContinuousSignal`, `SineOscillator`, `SquareOscillator`,
+  `UniformSampler`, and `SampleBuffer`.
+- Added helper functions for sample counts, sample times, and Nyquist
+  frequency.
+- Added parity tests from `OSC00: Oscillator and Sampler`.

--- a/code/packages/python/oscillator/README.md
+++ b/code/packages/python/oscillator/README.md
@@ -1,0 +1,118 @@
+# Oscillator
+
+`coding-adventures-oscillator` is the first virtual implementation of
+`OSC00: Oscillator and Sampler`.
+
+It models an oscillator as a pure mathematical signal:
+
+```text
+time in seconds -> signal value
+```
+
+Then it models a sampler as the layer that turns that smooth virtual signal
+into ordinary numbers:
+
+```text
+continuous signal -> uniform sampler -> sample buffer
+```
+
+This is the next rung after `note-frequency`. `note-frequency` answers
+"what frequency is `A4`?" This package answers "given a frequency, what value
+does the signal have at each time?"
+
+## Why This Is Virtual
+
+This package does not talk to speakers, sound cards, Arduino pins, timers, DACs,
+or radios. It is intentionally pure and deterministic. That makes it good for
+learning and testing:
+
+- the same oscillator at the same time always returns the same value
+- the same sampler always produces the same sample buffer
+- no method sleeps or reads wall-clock time
+
+Later packages can put real outputs underneath the same ideas.
+
+## Usage
+
+```python
+from oscillator import SineOscillator, UniformSampler
+
+tone = SineOscillator(frequency_hz=440.0)
+sampler = UniformSampler(sample_rate_hz=44_100.0)
+
+buffer = sampler.sample(tone, duration_seconds=0.01)
+
+print(buffer.sample_count())          # 441
+print(buffer.sample_period_seconds()) # 1 / 44100
+print(buffer.samples[:5])             # first five floating-point samples
+```
+
+## Sine Oscillator
+
+```python
+from oscillator import SineOscillator
+
+wave = SineOscillator(frequency_hz=1.0)
+
+wave.value_at(0.00) # 0.0
+wave.value_at(0.25) # 1.0
+wave.value_at(0.50) # 0.0
+wave.value_at(0.75) # -1.0
+```
+
+The formula is:
+
+```text
+offset + amplitude * sin(2 * pi * (frequency_hz * time_seconds + phase_cycles))
+```
+
+## Square Oscillator
+
+```python
+from oscillator import SquareOscillator
+
+clock_line = SquareOscillator(
+    frequency_hz=2.0,
+    low=0.0,
+    high=1.0,
+    duty_cycle=0.5,
+)
+
+clock_line.value_at(0.000) # 1.0
+clock_line.value_at(0.250) # 0.0
+clock_line.value_at(0.500) # 1.0
+```
+
+This is the virtual signal shape that a clock package can use internally. Clock
+consumers should still consume clock edges; they should not have to manually
+sample square waves.
+
+## Sampling
+
+A uniform sampler chooses evenly spaced times:
+
+```text
+t_n = start_time_seconds + n / sample_rate_hz
+```
+
+At 4 Hz for one second, the sample times are:
+
+```text
+0.00, 0.25, 0.50, 0.75
+```
+
+The endpoint `1.00` is not included because the sampler uses the half-open
+interval `[start, end)`.
+
+## Aliasing
+
+The sampler exposes the Nyquist frequency:
+
+```python
+from oscillator import nyquist_frequency
+
+nyquist_frequency(44_100.0) # 22050.0
+```
+
+This package only reports the limit. It does not implement anti-aliasing
+filters yet.

--- a/code/packages/python/oscillator/pyproject.toml
+++ b/code/packages/python/oscillator/pyproject.toml
@@ -1,0 +1,30 @@
+[project]
+name = "coding-adventures-oscillator"
+version = "0.1.0"
+description = "Virtual continuous oscillators and uniform samplers"
+requires-python = ">=3.9"
+dependencies = ["coding-adventures-trig"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=oscillator --cov-report=term-missing --cov-fail-under=95"
+
+[tool.coverage.run]
+source = ["src/oscillator"]
+
+[tool.coverage.report]
+fail_under = 95
+show_missing = true
+
+[tool.ruff]
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM", "ANN"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/oscillator"]

--- a/code/packages/python/oscillator/required_capabilities.json
+++ b/code/packages/python/oscillator/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "python/oscillator",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/python/oscillator/src/oscillator/__init__.py
+++ b/code/packages/python/oscillator/src/oscillator/__init__.py
@@ -1,0 +1,21 @@
+from .oscillator import (
+    ContinuousSignal,
+    SampleBuffer,
+    SineOscillator,
+    SquareOscillator,
+    UniformSampler,
+    nyquist_frequency,
+    sample_count_for_duration,
+    time_at_sample,
+)
+
+__all__ = [
+    "ContinuousSignal",
+    "SampleBuffer",
+    "SineOscillator",
+    "SquareOscillator",
+    "UniformSampler",
+    "nyquist_frequency",
+    "sample_count_for_duration",
+    "time_at_sample",
+]

--- a/code/packages/python/oscillator/src/oscillator/oscillator.py
+++ b/code/packages/python/oscillator/src/oscillator/oscillator.py
@@ -1,0 +1,343 @@
+"""
+Virtual oscillators and samplers.
+
+An oscillator in this package is not a real sound card, timer, or circuit. It
+is a mathematical signal: give it a time in seconds and it returns the value the
+signal would have at that instant.
+
+A sampler sits one layer above that. It chooses concrete times, asks the signal
+for values, and stores those values in a `SampleBuffer`. That is the bridge from
+a smooth virtual signal to the stream of numbers that later audio, radio, DAC,
+or clock-edge packages can consume.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from math import floor, isfinite
+from numbers import Integral, Real
+from typing import Protocol
+
+from trig import PI, sin
+
+TWO_PI = 2.0 * PI
+INTEGER_TOLERANCE = 1e-9
+
+
+class ContinuousSignal(Protocol):
+    """Anything that can report its value at a time in seconds."""
+
+    def value_at(self, time_seconds: float) -> float:
+        """Return the signal value at `time_seconds`."""
+
+
+def _finite_float(name: str, value: Real) -> float:
+    """
+    Convert a real number to `float` and reject non-finite values.
+
+    The spec talks about "finite real numbers". Python makes that slightly
+    slippery because `float("nan")`, infinities, strings, and booleans can sneak
+    into numeric-looking APIs. Centralizing the check keeps every public
+    constructor consistent.
+    """
+
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a finite real number, got {value!r}")
+
+    converted = float(value)
+    if not isfinite(converted):
+        raise ValueError(f"{name} must be finite, got {value!r}")
+
+    return converted
+
+
+def _non_negative_float(name: str, value: Real) -> float:
+    converted = _finite_float(name, value)
+    if converted < 0.0:
+        raise ValueError(f"{name} must be >= 0.0, got {converted}")
+    return converted
+
+
+def _positive_float(name: str, value: Real) -> float:
+    converted = _finite_float(name, value)
+    if converted <= 0.0:
+        raise ValueError(f"{name} must be > 0.0, got {converted}")
+    return converted
+
+
+def _fractional_part(value: float) -> float:
+    """
+    Return the fractional part in the half-open interval [0.0, 1.0).
+
+    Python's `%` would also work for positive divisors, but `x - floor(x)`
+    mirrors the spec directly and makes the negative-time behavior obvious.
+    """
+
+    return value - floor(value)
+
+
+def nyquist_frequency(sample_rate_hz: Real) -> float:
+    """Return half the sample rate, the highest cleanly representable frequency."""
+
+    return _positive_float("sample_rate_hz", sample_rate_hz) / 2.0
+
+
+def sample_count_for_duration(duration_seconds: Real, sample_rate_hz: Real) -> int:
+    """
+    Return the default sample count for a half-open sampling interval.
+
+    Mathematically this is `floor(duration_seconds * sample_rate_hz)`. The tiny
+    integer tolerance prevents floating-point spelling accidents such as
+    `479.99999999999994` becoming 479 when the intended mathematical product is
+    480.
+    """
+
+    duration = _non_negative_float("duration_seconds", duration_seconds)
+    sample_rate = _positive_float("sample_rate_hz", sample_rate_hz)
+    raw_count = duration * sample_rate
+    nearest_integer = round(raw_count)
+
+    if abs(raw_count - nearest_integer) <= INTEGER_TOLERANCE:
+        return int(nearest_integer)
+
+    return int(floor(raw_count))
+
+
+def time_at_sample(
+    index: int,
+    sample_rate_hz: Real,
+    start_time_seconds: Real = 0.0,
+) -> float:
+    """Return the time for sample index `index` on a uniform sample grid."""
+
+    if isinstance(index, bool) or not isinstance(index, Integral):
+        raise ValueError(f"index must be an integer >= 0, got {index!r}")
+    if index < 0:
+        raise ValueError(f"index must be >= 0, got {index}")
+
+    sample_rate = _positive_float("sample_rate_hz", sample_rate_hz)
+    start_time = _finite_float("start_time_seconds", start_time_seconds)
+    return start_time + int(index) / sample_rate
+
+
+@dataclass(frozen=True)
+class SineOscillator:
+    """
+    Smooth sine oscillator.
+
+    A 1 Hz default sine oscillator starts at zero, reaches its peak at 0.25
+    seconds, crosses zero again at 0.5 seconds, and reaches its trough at 0.75
+    seconds. Increasing the frequency squeezes more cycles into each second.
+    """
+
+    frequency_hz: float
+    amplitude: float = 1.0
+    phase_cycles: float = 0.0
+    offset: float = 0.0
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "frequency_hz",
+            _non_negative_float("frequency_hz", self.frequency_hz),
+        )
+        object.__setattr__(
+            self,
+            "amplitude",
+            _non_negative_float("amplitude", self.amplitude),
+        )
+        object.__setattr__(
+            self,
+            "phase_cycles",
+            _finite_float("phase_cycles", self.phase_cycles),
+        )
+        object.__setattr__(self, "offset", _finite_float("offset", self.offset))
+
+    def value_at(self, time_seconds: float) -> float:
+        """Evaluate `offset + amplitude * sin(2*pi*(f*t + phase))`."""
+
+        time = _finite_float("time_seconds", time_seconds)
+        phase = self.frequency_hz * time + self.phase_cycles
+        return self.offset + self.amplitude * sin(TWO_PI * phase)
+
+
+@dataclass(frozen=True)
+class SquareOscillator:
+    """
+    High/low oscillator with a configurable duty cycle.
+
+    The square oscillator is what lets the same oscillator abstraction support
+    digital-looking signals. A clock package can hide this inside its own API
+    and expose friendly `ClockEdge` records to consumers.
+    """
+
+    frequency_hz: float
+    low: float = -1.0
+    high: float = 1.0
+    duty_cycle: float = 0.5
+    phase_cycles: float = 0.0
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "frequency_hz",
+            _non_negative_float("frequency_hz", self.frequency_hz),
+        )
+        object.__setattr__(self, "low", _finite_float("low", self.low))
+        object.__setattr__(self, "high", _finite_float("high", self.high))
+        object.__setattr__(
+            self,
+            "duty_cycle",
+            _finite_float("duty_cycle", self.duty_cycle),
+        )
+        object.__setattr__(
+            self,
+            "phase_cycles",
+            _finite_float("phase_cycles", self.phase_cycles),
+        )
+
+        if not 0.0 < self.duty_cycle < 1.0:
+            raise ValueError(
+                f"duty_cycle must satisfy 0.0 < duty_cycle < 1.0, "
+                f"got {self.duty_cycle}"
+            )
+
+    def value_at(self, time_seconds: float) -> float:
+        """Return `high` during the duty-cycle window, otherwise `low`."""
+
+        time = _finite_float("time_seconds", time_seconds)
+        position = _fractional_part(self.frequency_hz * time + self.phase_cycles)
+        if position < self.duty_cycle:
+            return self.high
+        return self.low
+
+
+@dataclass(frozen=True)
+class SampleBuffer:
+    """
+    Samples plus enough timing metadata to interpret them.
+
+    The buffer does not know whether its samples represent audio, radio, a
+    virtual voltage, or something else. It only knows the values and the uniform
+    time grid they came from.
+    """
+
+    samples: tuple[float, ...]
+    sample_rate_hz: float
+    start_time_seconds: float = 0.0
+
+    def __post_init__(self) -> None:
+        converted_samples = tuple(
+            _finite_float(f"samples[{index}]", sample)
+            for index, sample in enumerate(self.samples)
+        )
+        object.__setattr__(self, "samples", converted_samples)
+        object.__setattr__(
+            self,
+            "sample_rate_hz",
+            _positive_float("sample_rate_hz", self.sample_rate_hz),
+        )
+        object.__setattr__(
+            self,
+            "start_time_seconds",
+            _finite_float("start_time_seconds", self.start_time_seconds),
+        )
+
+    def sample_count(self) -> int:
+        """Return the number of stored samples."""
+
+        return len(self.samples)
+
+    def sample_period_seconds(self) -> float:
+        """Return the spacing between adjacent samples."""
+
+        return 1.0 / self.sample_rate_hz
+
+    def duration_seconds(self) -> float:
+        """Return the covered duration of this half-open sample buffer."""
+
+        return self.sample_count() / self.sample_rate_hz
+
+    def time_at(self, index: int) -> float:
+        """Return the time associated with a stored sample index."""
+
+        if isinstance(index, bool) or not isinstance(index, Integral):
+            raise ValueError(f"index must be an integer, got {index!r}")
+        if not 0 <= index < self.sample_count():
+            raise ValueError(
+                f"index must be in [0, {self.sample_count()}), got {index}"
+            )
+
+        return time_at_sample(
+            int(index),
+            self.sample_rate_hz,
+            self.start_time_seconds,
+        )
+
+
+@dataclass(frozen=True)
+class UniformSampler:
+    """Sampler that evaluates a signal at evenly spaced times."""
+
+    sample_rate_hz: float
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "sample_rate_hz",
+            _positive_float("sample_rate_hz", self.sample_rate_hz),
+        )
+
+    def sample(
+        self,
+        signal: ContinuousSignal,
+        duration_seconds: Real,
+        start_time_seconds: Real = 0.0,
+    ) -> SampleBuffer:
+        """Sample `signal` over `[start_time_seconds, end_time_seconds)`."""
+
+        count = sample_count_for_duration(duration_seconds, self.sample_rate_hz)
+        return self.sample_count(signal, count, start_time_seconds)
+
+    def sample_count(
+        self,
+        signal: ContinuousSignal,
+        sample_count: int,
+        start_time_seconds: Real = 0.0,
+    ) -> SampleBuffer:
+        """Sample exactly `sample_count` values from `signal`."""
+
+        samples = tuple(self.samples(signal, sample_count, start_time_seconds))
+        start_time = _finite_float("start_time_seconds", start_time_seconds)
+        return SampleBuffer(
+            samples=samples,
+            sample_rate_hz=self.sample_rate_hz,
+            start_time_seconds=start_time,
+        )
+
+    def samples(
+        self,
+        signal: ContinuousSignal,
+        sample_count: int,
+        start_time_seconds: Real = 0.0,
+    ) -> Iterator[float]:
+        """Yield the same values that `sample_count(...)` would store."""
+
+        if isinstance(sample_count, bool) or not isinstance(sample_count, Integral):
+            raise ValueError(
+                f"sample_count must be an integer >= 0, got {sample_count!r}"
+            )
+        if sample_count < 0:
+            raise ValueError(f"sample_count must be >= 0, got {sample_count}")
+
+        start_time = _finite_float("start_time_seconds", start_time_seconds)
+        for index in range(int(sample_count)):
+            yield signal.value_at(
+                time_at_sample(index, self.sample_rate_hz, start_time)
+            )
+
+    def nyquist_frequency(self) -> float:
+        """Return this sampler's Nyquist frequency."""
+
+        return nyquist_frequency(self.sample_rate_hz)

--- a/code/packages/python/oscillator/src/oscillator/py.typed
+++ b/code/packages/python/oscillator/src/oscillator/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561 typed package consumers.

--- a/code/packages/python/oscillator/tests/test_oscillator.py
+++ b/code/packages/python/oscillator/tests/test_oscillator.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from oscillator import (
+    SampleBuffer,
+    SineOscillator,
+    SquareOscillator,
+    UniformSampler,
+    nyquist_frequency,
+    sample_count_for_duration,
+    time_at_sample,
+)
+
+ABS_TOLERANCE = 1e-9
+
+
+class TestSineOscillator:
+    def test_default_one_hz_parity_vector(self) -> None:
+        signal = SineOscillator(frequency_hz=1.0)
+
+        assert signal.value_at(0.00) == pytest.approx(0.0, abs=ABS_TOLERANCE)
+        assert signal.value_at(0.25) == pytest.approx(1.0, abs=ABS_TOLERANCE)
+        assert signal.value_at(0.50) == pytest.approx(0.0, abs=ABS_TOLERANCE)
+        assert signal.value_at(0.75) == pytest.approx(-1.0, abs=ABS_TOLERANCE)
+        assert signal.value_at(1.00) == pytest.approx(0.0, abs=ABS_TOLERANCE)
+
+    def test_amplitude_and_offset_parity_vector(self) -> None:
+        signal = SineOscillator(frequency_hz=1.0, amplitude=2.0, offset=3.0)
+
+        assert signal.value_at(0.00) == pytest.approx(3.0, abs=ABS_TOLERANCE)
+        assert signal.value_at(0.25) == pytest.approx(5.0, abs=ABS_TOLERANCE)
+        assert signal.value_at(0.75) == pytest.approx(1.0, abs=ABS_TOLERANCE)
+
+    def test_phase_cycles_parity_vector(self) -> None:
+        signal = SineOscillator(frequency_hz=1.0, phase_cycles=0.25)
+
+        assert signal.value_at(0.00) == pytest.approx(1.0, abs=ABS_TOLERANCE)
+        assert signal.value_at(0.25) == pytest.approx(0.0, abs=ABS_TOLERANCE)
+
+    def test_zero_frequency_is_constant_from_initial_phase(self) -> None:
+        signal = SineOscillator(
+            frequency_hz=0.0,
+            amplitude=2.0,
+            phase_cycles=0.25,
+            offset=3.0,
+        )
+
+        assert signal.value_at(0.0) == pytest.approx(5.0, abs=ABS_TOLERANCE)
+        assert signal.value_at(123.456) == pytest.approx(5.0, abs=ABS_TOLERANCE)
+
+    def test_negative_time_is_allowed_for_continuous_evaluation(self) -> None:
+        signal = SineOscillator(frequency_hz=1.0)
+
+        assert signal.value_at(-0.25) == pytest.approx(-1.0, abs=ABS_TOLERANCE)
+
+    def test_sine_is_immutable(self) -> None:
+        signal = SineOscillator(frequency_hz=1.0)
+
+        with pytest.raises(FrozenInstanceError):
+            signal.frequency_hz = 2.0  # type: ignore[misc]
+
+
+class TestSquareOscillator:
+    def test_square_parity_vector(self) -> None:
+        signal = SquareOscillator(
+            frequency_hz=2.0,
+            low=0.0,
+            high=1.0,
+            duty_cycle=0.5,
+        )
+
+        assert signal.value_at(0.000) == 1.0
+        assert signal.value_at(0.125) == 1.0
+        assert signal.value_at(0.250) == 0.0
+        assert signal.value_at(0.375) == 0.0
+        assert signal.value_at(0.500) == 1.0
+
+    def test_negative_time_uses_portable_fractional_part(self) -> None:
+        signal = SquareOscillator(
+            frequency_hz=1.0,
+            low=0.0,
+            high=1.0,
+            duty_cycle=0.5,
+        )
+
+        assert signal.value_at(-0.25) == 0.0
+        assert signal.value_at(-0.75) == 1.0
+
+    def test_phase_cycles_shifts_square_wave(self) -> None:
+        signal = SquareOscillator(
+            frequency_hz=1.0,
+            low=-1.0,
+            high=1.0,
+            duty_cycle=0.5,
+            phase_cycles=0.5,
+        )
+
+        assert signal.value_at(0.0) == -1.0
+        assert signal.value_at(0.5) == 1.0
+
+    def test_zero_frequency_uses_initial_phase(self) -> None:
+        high_signal = SquareOscillator(
+            frequency_hz=0.0,
+            low=0.0,
+            high=1.0,
+            duty_cycle=0.5,
+            phase_cycles=0.25,
+        )
+        low_signal = SquareOscillator(
+            frequency_hz=0.0,
+            low=0.0,
+            high=1.0,
+            duty_cycle=0.5,
+            phase_cycles=0.75,
+        )
+
+        assert high_signal.value_at(999.0) == 1.0
+        assert low_signal.value_at(999.0) == 0.0
+
+
+class TestUniformSampler:
+    def test_uniform_sampler_parity_vector(self) -> None:
+        signal = SineOscillator(frequency_hz=1.0)
+        sampler = UniformSampler(sample_rate_hz=4.0)
+
+        buffer = sampler.sample(signal, duration_seconds=1.0)
+
+        assert [buffer.time_at(index) for index in range(buffer.sample_count())] == [
+            0.0,
+            0.25,
+            0.5,
+            0.75,
+        ]
+        assert buffer.samples == pytest.approx(
+            (0.0, 1.0, 0.0, -1.0),
+            abs=ABS_TOLERANCE,
+        )
+        assert buffer.sample_count() == 4
+        assert buffer.sample_period_seconds() == 0.25
+        assert buffer.duration_seconds() == 1.0
+        assert sampler.nyquist_frequency() == 2.0
+
+    def test_start_time_offsets_sample_grid(self) -> None:
+        signal = SineOscillator(frequency_hz=1.0)
+        sampler = UniformSampler(sample_rate_hz=4.0)
+
+        buffer = sampler.sample(
+            signal,
+            duration_seconds=0.5,
+            start_time_seconds=0.25,
+        )
+
+        assert buffer.samples == pytest.approx((1.0, 0.0), abs=ABS_TOLERANCE)
+        assert buffer.time_at(0) == 0.25
+        assert buffer.time_at(1) == 0.5
+
+    def test_explicit_sample_count_matches_streaming_values(self) -> None:
+        signal = SineOscillator(frequency_hz=1.0)
+        sampler = UniformSampler(sample_rate_hz=4.0)
+
+        buffer = sampler.sample_count(signal, sample_count=3)
+
+        assert buffer.samples == tuple(sampler.samples(signal, sample_count=3))
+        assert buffer.samples == pytest.approx((0.0, 1.0, 0.0), abs=ABS_TOLERANCE)
+
+    def test_zero_duration_produces_empty_buffer(self) -> None:
+        signal = SineOscillator(frequency_hz=1.0)
+        sampler = UniformSampler(sample_rate_hz=44_100.0)
+
+        buffer = sampler.sample(signal, duration_seconds=0.0)
+
+        assert buffer.samples == ()
+        assert buffer.sample_count() == 0
+        assert buffer.duration_seconds() == 0.0
+
+
+class TestSampleBuffer:
+    def test_sample_buffer_derives_metadata(self) -> None:
+        buffer = SampleBuffer(
+            samples=(0.0, 1.0, 0.0),
+            sample_rate_hz=2.0,
+            start_time_seconds=10.0,
+        )
+
+        assert buffer.sample_count() == 3
+        assert buffer.sample_period_seconds() == 0.5
+        assert buffer.duration_seconds() == 1.5
+        assert buffer.time_at(2) == 11.0
+
+    def test_sample_buffer_converts_sample_iterables_to_tuple(self) -> None:
+        buffer = SampleBuffer(samples=[0, 1, -1], sample_rate_hz=1.0)
+
+        assert buffer.samples == (0.0, 1.0, -1.0)
+
+
+class TestHelpers:
+    @pytest.mark.parametrize(
+        ("duration_seconds", "sample_rate_hz", "expected"),
+        [
+            (1.0, 44_100.0, 44_100),
+            (0.5, 48_000.0, 24_000),
+            (0.01, 48_000.0, 480),
+            (0.0, 44_100.0, 0),
+            (1.0 / 3.0, 10.0, 3),
+        ],
+    )
+    def test_sample_count_for_duration(
+        self,
+        duration_seconds: float,
+        sample_rate_hz: float,
+        expected: int,
+    ) -> None:
+        assert sample_count_for_duration(duration_seconds, sample_rate_hz) == expected
+
+    def test_sample_count_tolerates_near_integer_float_products(self) -> None:
+        assert sample_count_for_duration(0.1 + 0.2, 1600.0) == 480
+
+    def test_time_at_sample(self) -> None:
+        assert time_at_sample(3, 4.0) == 0.75
+        assert time_at_sample(3, 4.0, start_time_seconds=10.0) == 10.75
+
+    def test_nyquist_frequency(self) -> None:
+        assert nyquist_frequency(44_100.0) == 22_050.0
+
+
+class TestValidation:
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"frequency_hz": -1.0},
+            {"frequency_hz": float("nan")},
+            {"frequency_hz": float("inf")},
+            {"frequency_hz": True},
+            {"frequency_hz": 1.0, "amplitude": -1.0},
+            {"frequency_hz": 1.0, "phase_cycles": float("nan")},
+            {"frequency_hz": 1.0, "offset": float("inf")},
+        ],
+    )
+    def test_sine_rejects_invalid_parameters(self, kwargs: dict[str, float]) -> None:
+        with pytest.raises(ValueError):
+            SineOscillator(**kwargs)
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"frequency_hz": -1.0},
+            {"frequency_hz": 1.0, "low": float("nan")},
+            {"frequency_hz": 1.0, "high": float("inf")},
+            {"frequency_hz": 1.0, "duty_cycle": 0.0},
+            {"frequency_hz": 1.0, "duty_cycle": 1.0},
+            {"frequency_hz": 1.0, "duty_cycle": float("nan")},
+            {"frequency_hz": 1.0, "phase_cycles": float("inf")},
+        ],
+    )
+    def test_square_rejects_invalid_parameters(self, kwargs: dict[str, float]) -> None:
+        with pytest.raises(ValueError):
+            SquareOscillator(**kwargs)
+
+    @pytest.mark.parametrize(
+        "sample_rate_hz",
+        [0.0, -1.0, float("nan"), float("inf"), False],
+    )
+    def test_sampler_rejects_invalid_sample_rates(
+        self,
+        sample_rate_hz: float,
+    ) -> None:
+        with pytest.raises(ValueError):
+            UniformSampler(sample_rate_hz=sample_rate_hz)
+
+    @pytest.mark.parametrize(
+        ("duration_seconds", "sample_rate_hz"),
+        [(-1.0, 4.0), (float("nan"), 4.0), (1.0, 0.0)],
+    )
+    def test_sample_count_helper_rejects_invalid_inputs(
+        self,
+        duration_seconds: float,
+        sample_rate_hz: float,
+    ) -> None:
+        with pytest.raises(ValueError):
+            sample_count_for_duration(duration_seconds, sample_rate_hz)
+
+    @pytest.mark.parametrize("index", [-1, 1.5, True])
+    def test_time_at_sample_rejects_invalid_index(self, index: int) -> None:
+        with pytest.raises(ValueError):
+            time_at_sample(index, 4.0)
+
+    @pytest.mark.parametrize("sample_count", [-1, 1.5, True])
+    def test_sampler_rejects_invalid_explicit_count(
+        self,
+        sample_count: int,
+    ) -> None:
+        sampler = UniformSampler(sample_rate_hz=4.0)
+        signal = SineOscillator(frequency_hz=1.0)
+
+        with pytest.raises(ValueError):
+            tuple(sampler.samples(signal, sample_count=sample_count))
+
+    def test_sample_buffer_rejects_non_finite_samples(self) -> None:
+        with pytest.raises(ValueError, match="samples\\[1\\]"):
+            SampleBuffer(samples=(0.0, float("nan")), sample_rate_hz=1.0)
+
+    @pytest.mark.parametrize("index", [-1, 2, 1.5, True])
+    def test_sample_buffer_time_at_rejects_invalid_index(self, index: int) -> None:
+        buffer = SampleBuffer(samples=(0.0, 1.0), sample_rate_hz=2.0)
+
+        with pytest.raises(ValueError):
+            buffer.time_at(index)


### PR DESCRIPTION
## Summary

- Adds the first `OSC00` implementation as `code/packages/python/oscillator`.
- Implements `SineOscillator`, `SquareOscillator`, `UniformSampler`, `SampleBuffer`, and helper functions for sample counts, sample times, and Nyquist frequency.
- Adds README, CHANGELOG, required capabilities, Unix/Windows BUILD files, and parity/validation tests.

## Validation

- `sh BUILD` from `code/packages/python/oscillator`
- `/tmp/coding-adventures-build-tool -root /Users/adhithya/Downloads/coding-adventures-python-oscillator -diff-base origin/main -detect-languages -emit-plan /tmp/python-oscillator-plan.json`
- `/tmp/coding-adventures-build-tool -root /Users/adhithya/Downloads/coding-adventures-python-oscillator -diff-base origin/main -language python -jobs 2`

## Security

- Pure computation only; no filesystem, network, process, environment, real-time, or device access is requested by the package.