### PR TITLE
Add Prolog-style collection builtins

### DIFF
--- a/code/packages/python/logic-builtins/CHANGELOG.md
+++ b/code/packages/python/logic-builtins/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.3.0] - 2026-04-20
+
+### Added
+
+- collection predicates: `findallo`, `bagofo`, and `setofo`
+- deterministic term sorting and duplicate removal for first-pass `setofo`
+- tests and examples showing collectors with relation search, arithmetic, and control builtins
+
 ## [0.2.0] - 2026-04-20
 
 ### Added

--- a/code/packages/python/logic-builtins/README.md
+++ b/code/packages/python/logic-builtins/README.md
@@ -1,7 +1,7 @@
 # logic-builtins
 
-`logic-builtins` adds practical Prolog-inspired control, term inspection, and
-arithmetic predicates to the Python logic stack.
+`logic-builtins` adds practical Prolog-inspired control, term inspection,
+arithmetic, and collection predicates to the Python logic stack.
 
 These functions are library goals, not syntax. They compose with
 `logic-engine`, `logic-stdlib`, and the VM/bytecode layers because they return
@@ -20,18 +20,20 @@ ordinary logic goal expressions.
 - arithmetic expression constructors: `add`, `sub`, `mul`, `div`, `floordiv`, `mod`, and `neg`
 - `iso(result, expression)` for Prolog-style evaluative arithmetic
 - `numeqo(left, right)`, `numneqo(left, right)`, `lto(left, right)`, `leqo(left, right)`, `gto(left, right)`, and `geqo(left, right)`
+- `findallo(template, goal, results)`, `bagofo(template, goal, results)`, and `setofo(template, goal, results)`
 
 ## Quick Start
 
 ```python
-from logic_builtins import argo, functoro, geqo, groundo, iso, add, noto, onceo
-from logic_engine import atom, conj, eq, fail, num, program, solve_all, term, var
+from logic_builtins import argo, findallo, functoro, geqo, groundo, iso, add, noto, onceo
+from logic_engine import atom, conj, eq, fail, logic_list, num, program, solve_all, term, var
 
 X = var("X")
 Name = var("Name")
 Arity = var("Arity")
 Arg = var("Arg")
 Score = var("Score")
+Results = var("Results")
 
 assert solve_all(program(), X, onceo(eq(X, "first"))) == [atom("first")]
 assert solve_all(program(), X, noto(fail())) == [X]
@@ -48,11 +50,20 @@ assert solve_all(
 ) == [(atom("box"), num(1), atom("tea"))]
 assert solve_all(program(), Score, iso(Score, add(40, 2))) == [num(42)]
 assert solve_all(program(), X, conj(eq(X, 7), geqo(add(X, 1), 8))) == [num(7)]
+assert solve_all(
+    program(),
+    Results,
+    findallo(X, conj(eq(X, 7), geqo(add(X, 1), 8)), Results),
+) == [logic_list([7])]
 ```
 
 Arithmetic is evaluative, not a constraint system yet. `iso(Y, add(X, 1))`
 fails while `X` is unbound, and succeeds after a goal such as `eq(X, 4)` has
 instantiated it.
+
+Collections are observations over a nested proof search. `findallo` succeeds
+with an empty list when the inner goal fails, while `bagofo` and `setofo` fail
+for empty collections.
 
 ## Dependencies
 

--- a/code/packages/python/logic-builtins/pyproject.toml
+++ b/code/packages/python/logic-builtins/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-logic-builtins"
-version = "0.2.0"
-description = "Prolog-inspired control, term, and arithmetic builtins for the Python logic stack"
+version = "0.3.0"
+description = "Prolog-inspired control, term, arithmetic, and collection builtins for the Python logic stack"
 requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]
@@ -17,7 +17,7 @@ dependencies = [
 [project.urls]
 Homepage = "https://github.com/adhithyan15/coding-adventures"
 Repository = "https://github.com/adhithyan15/coding-adventures"
-Documentation = "https://github.com/adhithyan15/coding-adventures/tree/main/code/specs/LP12-logic-arithmetic-builtins.md"
+Documentation = "https://github.com/adhithyan15/coding-adventures/tree/main/code/specs/LP13-logic-collection-builtins.md"
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]

--- a/code/packages/python/logic-builtins/src/logic_builtins/__init__.py
+++ b/code/packages/python/logic-builtins/src/logic_builtins/__init__.py
@@ -8,9 +8,11 @@ from logic_builtins.builtins import (
     add,
     argo,
     atomo,
+    bagofo,
     callo,
     compoundo,
     div,
+    findallo,
     floordiv,
     functoro,
     geqo,
@@ -28,6 +30,7 @@ from logic_builtins.builtins import (
     numeqo,
     numneqo,
     onceo,
+    setofo,
     stringo,
     sub,
     varo,
@@ -38,9 +41,11 @@ __all__ = [
     "add",
     "argo",
     "atomo",
+    "bagofo",
     "callo",
     "compoundo",
     "div",
+    "findallo",
     "floordiv",
     "functoro",
     "geqo",
@@ -58,9 +63,10 @@ __all__ = [
     "numneqo",
     "numbero",
     "onceo",
+    "setofo",
     "stringo",
     "sub",
     "varo",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/code/packages/python/logic-builtins/src/logic_builtins/builtins.py
+++ b/code/packages/python/logic-builtins/src/logic_builtins/builtins.py
@@ -29,6 +29,7 @@ from logic_engine import (
     atom,
     conj,
     eq,
+    logic_list,
     native_goal,
     num,
     reify,
@@ -43,6 +44,7 @@ __all__ = [
     "callo",
     "compoundo",
     "div",
+    "findallo",
     "floordiv",
     "functoro",
     "geqo",
@@ -60,6 +62,8 @@ __all__ = [
     "numneqo",
     "numbero",
     "onceo",
+    "bagofo",
+    "setofo",
     "stringo",
     "sub",
     "varo",
@@ -69,6 +73,7 @@ __all__ = [
 type NativeArgs = tuple[Term, ...]
 type NativeRunner = Callable[[Program, State, NativeArgs], Iterator[State]]
 type NumericValue = int | float
+type TermSortKey = tuple[object, ...]
 
 
 def _as_goal(goal: object) -> GoalExpr:
@@ -98,6 +103,123 @@ def _succeed_if(condition: bool, state: State) -> Iterator[State]:
 
     if condition:
         yield state
+
+
+def _term_sort_key(term_value: Term) -> TermSortKey:
+    """Return a deterministic first-pass ordering key for collected terms."""
+
+    if isinstance(term_value, LogicVar):
+        return (0, term_value.id, str(term_value.display_name or ""))
+    if isinstance(term_value, Number):
+        return (1, term_value.value)
+    if isinstance(term_value, Atom):
+        return (2, term_value.symbol.namespace or "", term_value.symbol.name)
+    if isinstance(term_value, String):
+        return (3, term_value.value)
+    return (
+        4,
+        term_value.functor.namespace or "",
+        term_value.functor.name,
+        len(term_value.args),
+        tuple(_term_sort_key(argument) for argument in term_value.args),
+    )
+
+
+def _unique_sorted_terms(values: list[Term]) -> list[Term]:
+    """Remove duplicate terms and return them in deterministic set order."""
+
+    unique: dict[Term, Term] = {}
+    for value in values:
+        unique.setdefault(value, value)
+    return sorted(unique.values(), key=_term_sort_key)
+
+
+def _collect_template_values(
+    program_value: Program,
+    state: State,
+    template: Term,
+    goal: GoalExpr,
+) -> list[Term]:
+    """Collect reified template values for every proof of a nested goal."""
+
+    return [
+        reify(template, inner_state.substitution)
+        for inner_state in solve_from(program_value, goal, state)
+    ]
+
+
+def _unify_collection(
+    program_value: Program,
+    state: State,
+    results: Term,
+    values: list[Term],
+) -> Iterator[State]:
+    """Unify a result term with a canonical logic list from the outer state."""
+
+    yield from solve_from(program_value, eq(results, logic_list(values)), state)
+
+
+def findallo(template: object, goal: object, results: object) -> GoalExpr:
+    """Collect every solution of `goal` into `results`, preserving proof order."""
+
+    called_goal = _as_goal(goal)
+
+    def run(program_value: Program, state: State, args: NativeArgs) -> Iterator[State]:
+        template_term, results_term = args
+        values = _collect_template_values(
+            program_value,
+            state,
+            template_term,
+            called_goal,
+        )
+        yield from _unify_collection(program_value, state, results_term, values)
+
+    return native_goal(run, template, results)
+
+
+def bagofo(template: object, goal: object, results: object) -> GoalExpr:
+    """Collect a non-empty proof-order bag of solutions."""
+
+    called_goal = _as_goal(goal)
+
+    def run(program_value: Program, state: State, args: NativeArgs) -> Iterator[State]:
+        template_term, results_term = args
+        values = _collect_template_values(
+            program_value,
+            state,
+            template_term,
+            called_goal,
+        )
+        if not values:
+            return
+        yield from _unify_collection(program_value, state, results_term, values)
+
+    return native_goal(run, template, results)
+
+
+def setofo(template: object, goal: object, results: object) -> GoalExpr:
+    """Collect a non-empty sorted set of solutions."""
+
+    called_goal = _as_goal(goal)
+
+    def run(program_value: Program, state: State, args: NativeArgs) -> Iterator[State]:
+        template_term, results_term = args
+        values = _collect_template_values(
+            program_value,
+            state,
+            template_term,
+            called_goal,
+        )
+        if not values:
+            return
+        yield from _unify_collection(
+            program_value,
+            state,
+            results_term,
+            _unique_sorted_terms(values),
+        )
+
+    return native_goal(run, template, results)
 
 
 def add(left: object, right: object) -> Compound:

--- a/code/packages/python/logic-builtins/tests/test_logic_builtins.py
+++ b/code/packages/python/logic-builtins/tests/test_logic_builtins.py
@@ -26,9 +26,11 @@ from logic_builtins import (
     add,
     argo,
     atomo,
+    bagofo,
     callo,
     compoundo,
     div,
+    findallo,
     floordiv,
     functoro,
     geqo,
@@ -46,6 +48,7 @@ from logic_builtins import (
     numeqo,
     numneqo,
     onceo,
+    setofo,
     stringo,
     sub,
     varo,
@@ -56,7 +59,124 @@ class TestVersion:
     """Verify the package is importable and versioned."""
 
     def test_version_exists(self) -> None:
-        assert __version__ == "0.2.0"
+        assert __version__ == "0.3.0"
+
+
+class TestCollectionBuiltins:
+    """Collection helpers should turn streams of proofs into logic lists."""
+
+    def test_findallo_collects_answers_in_proof_order(self) -> None:
+        item = var("Item")
+        results = var("Results")
+
+        assert solve_all(
+            program(),
+            results,
+            findallo(item, disj(eq(item, "tea"), eq(item, "cake")), results),
+        ) == [logic_list(["tea", "cake"])]
+
+    def test_findallo_preserves_duplicates(self) -> None:
+        item = var("Item")
+        results = var("Results")
+
+        assert solve_all(
+            program(),
+            results,
+            findallo(item, disj(eq(item, "tea"), eq(item, "tea")), results),
+        ) == [logic_list(["tea", "tea"])]
+
+    def test_findallo_succeeds_with_empty_list_when_goal_fails(self) -> None:
+        item = var("Item")
+        results = var("Results")
+
+        assert solve_all(program(), results, findallo(item, fail(), results)) == [
+            logic_list([]),
+        ]
+
+    def test_findallo_does_not_leak_inner_bindings_outside_results(self) -> None:
+        item = var("Item")
+        results = var("Results")
+
+        assert solve_all(
+            program(),
+            (item, results),
+            findallo(item, disj(eq(item, "tea"), eq(item, "cake")), results),
+        ) == [(item, logic_list(["tea", "cake"]))]
+
+    def test_bagofo_preserves_duplicates_and_fails_when_empty(self) -> None:
+        item = var("Item")
+        results = var("Results")
+
+        assert solve_all(
+            program(),
+            results,
+            bagofo(item, disj(eq(item, "tea"), eq(item, "tea")), results),
+        ) == [logic_list(["tea", "tea"])]
+        assert solve_all(program(), results, bagofo(item, fail(), results)) == []
+
+    def test_setofo_removes_duplicates_and_sorts_terms(self) -> None:
+        item = var("Item")
+        results = var("Results")
+
+        assert solve_all(
+            program(),
+            results,
+            setofo(
+                item,
+                disj(
+                    eq(item, "pear"),
+                    eq(item, 2),
+                    eq(item, "apple"),
+                    eq(item, "pear"),
+                ),
+                results,
+            ),
+        ) == [logic_list([2, "apple", "pear"])]
+        assert solve_all(program(), results, setofo(item, fail(), results)) == []
+
+    def test_collectors_compose_with_arithmetic_predicates(self) -> None:
+        raw = var("Raw")
+        adjusted = var("Adjusted")
+        results = var("Results")
+
+        assert solve_all(
+            program(),
+            results,
+            findallo(
+                adjusted,
+                conj(
+                    disj(eq(raw, 2), eq(raw, 5)),
+                    iso(adjusted, add(raw, 10)),
+                ),
+                results,
+            ),
+        ) == [logic_list([12, 15])]
+
+    def test_collectors_compose_with_relation_search(self) -> None:
+        parent = relation("parent", 2)
+        child = var("Child")
+        results = var("Results")
+        family = program(
+            fact(parent("homer", "bart")),
+            fact(parent("homer", "lisa")),
+            fact(parent("marge", "maggie")),
+        )
+
+        assert solve_all(
+            family,
+            results,
+            findallo(child, parent("homer", child), results),
+        ) == [logic_list(["bart", "lisa"])]
+
+    def test_collectors_reject_non_goals(self) -> None:
+        results = var("Results")
+
+        with pytest.raises(TypeError):
+            findallo("x", object(), results)
+        with pytest.raises(TypeError):
+            bagofo("x", object(), results)
+        with pytest.raises(TypeError):
+            setofo("x", object(), results)
 
 
 class TestArithmeticBuiltins:

--- a/code/specs/LP13-logic-collection-builtins.md
+++ b/code/specs/LP13-logic-collection-builtins.md
@@ -1,0 +1,149 @@
+# LP13 - Logic Collection Builtins
+
+## Overview
+
+LP11 added Prolog-style control and term inspection. LP12 added evaluative
+arithmetic. The next practical runtime feature is solution collection.
+
+Real Prolog programs often need to move between two views of a relation:
+
+- as a stream of individual answers produced by backtracking
+- as one concrete list of answers that can be inspected, counted, filtered, or
+  passed to later goals
+
+LP13 adds the first collection predicates for that bridge.
+
+## Design Goal
+
+Extend the Python `logic-builtins` package with library-level collection goals:
+
+- `findallo(template, goal, results)`
+- `bagofo(template, goal, results)`
+- `setofo(template, goal, results)`
+
+These are goal constructors, not syntax. They should run through the existing
+solver and return ordinary `logic-engine` goals.
+
+## Package
+
+Update:
+
+```text
+code/packages/python/logic-builtins
+```
+
+The package version should move from `0.2.0` to `0.3.0`.
+
+## Public API
+
+Add:
+
+```python
+findallo(template, goal, results)
+bagofo(template, goal, results)
+setofo(template, goal, results)
+```
+
+The `o` suffix keeps the package convention that public predicates return
+logic goals.
+
+## Semantics
+
+### `findallo(template, goal, results)`
+
+Run `goal` from the current solver state. For every solution, reify
+`template` under that solution's substitution, preserving proof order. Unify
+`results` with a logic list containing those reified template values.
+
+`findallo` succeeds once even when the goal has no solutions:
+
+```python
+findallo(X, fail(), Results)  # Results = []
+```
+
+Bindings produced while proving the inner goal should not leak to the outer
+state except through the collected result list.
+
+### `bagofo(template, goal, results)`
+
+`bagofo` is the first bag-style collector. It preserves duplicates and proof
+order like `findallo`, but it fails when the inner goal has no solutions.
+
+This first slice does not yet implement Prolog's full free-variable grouping or
+existential quantification rules. Later language-level work can add that richer
+mode once the runtime has a first-class representation for quantified goal
+variables.
+
+### `setofo(template, goal, results)`
+
+`setofo` collects all template values, removes duplicates, sorts them by a
+stable term ordering, and unifies `results` with the resulting logic list. Like
+`bagofo`, it fails when the inner goal has no solutions.
+
+The LP13 ordering is intentionally simple and deterministic:
+
+1. variables
+2. numbers
+3. atoms
+4. strings
+5. compound terms, ordered by functor and recursively by arguments
+
+This is close enough for a practical first library layer. A later Prolog
+compatibility milestone can refine it toward the exact standard order of terms.
+
+## State Discipline
+
+Collection predicates are state-aware native goals. Each collector should:
+
+1. validate the supplied `goal` as a goal expression
+2. solve it from the active outer `State`
+3. reify the `template` under each inner solution state
+4. build a canonical Prolog-style list with `logic_list(...)`
+5. unify the requested `results` term against that list from the original outer
+   state
+
+That final step is important. Inner goal bindings are observations used to
+build the collection. They should not escape as ordinary outer bindings.
+
+## Error Model
+
+As with LP11 control predicates, passing a non-goal to any collection predicate
+is host-language API misuse and should raise `TypeError`.
+
+Ordinary logical cases should stay logical:
+
+- empty `findallo` succeeds with `[]`
+- empty `bagofo` fails
+- empty `setofo` fails
+- result unification failure causes the collector to fail
+
+## Test Strategy
+
+Required tests:
+
+- `findallo` collects multiple answers in proof order
+- `findallo` preserves duplicates
+- `findallo` succeeds with an empty list when the inner goal fails
+- `findallo` does not leak inner goal bindings outside the result list
+- `bagofo` preserves duplicates and fails on no solutions
+- `setofo` removes duplicates and produces deterministic ordering
+- collectors compose with arithmetic predicates
+- collectors compose with relation search
+- collectors reject non-goals
+
+## Future Extensions
+
+Later collection-related milestones can add:
+
+- full Prolog `bagof/3` free-variable grouping
+- `^` existential quantification for `bagof/3` and `setof/3`
+- standard term ordering compatibility
+- count-oriented helpers such as `counto`
+- bytecode/VM instructions for collection goals
+
+## Summary
+
+LP13 turns backtracking answers into first-class logic lists. This is a major
+step toward practical Prolog-level library programming because callers can now
+ask both "what are the solutions?" and "give me the solutions as data" without
+leaving the relational API.


### PR DESCRIPTION
## Summary
- add the LP13 spec for Prolog-style solution collection predicates
- extend `logic-builtins` with `findallo`, `bagofo`, and `setofo`
- add deterministic first-pass term ordering for `setofo`
- update package docs, changelog, version, and tests for collection composition with relation search and arithmetic

## Testing
- `cd code/packages/python/logic-builtins && bash BUILD`
- `cd code/packages/python/logic-builtins && .venv/bin/python -m ruff check src tests`

## Security
- manual pre-push security scan found no risky Python APIs in the changed code
- no file, network, subprocess, deserialization, or dynamic-code execution APIs were added

## Note
- Local `git fetch` was hanging in the shared checkout, so this PR branch was created directly from the GitHub merge commit for PR #927 and the verified local files were uploaded onto that clean remote base.