### PR TITLE
feat(benchmarks): add git ref subject preparation

### DIFF
--- a/code/programs/go/benchmark-tool/CHANGELOG.md
+++ b/code/programs/go/benchmark-tool/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.2.0 - 2026-04-20
+
+- Add phase-two git-ref comparison groundwork for command benchmarks.
+- Support repeated `--subject name=ref` CLI overrides for manifest subject
+  checkouts.
+- Support `--subjects` and `--workloads` filters for focused local and CI runs.
+- Prepare checkout-backed subjects in detached temporary git worktrees, run
+  builds and command workloads from those worktrees, and remove them after the
+  run.
+- Write per-subject metadata to `subjects/<name>/subject.json`, including the
+  exact pinned commit SHA, working directory, checkout ref, dirty state, and
+  temporary worktree path.
+
 ## 0.1.0 - 2026-04-20
 
 - Add the phase-one benchmark-tool CLI.

--- a/code/programs/go/benchmark-tool/README.md
+++ b/code/programs/go/benchmark-tool/README.md
@@ -9,12 +9,16 @@ runtime as long as the subject can be built and invoked from a shell.
 
 ## Current Scope
 
-Phase one supports:
+The current implementation supports:
 
 - validating benchmark manifests
 - parsing the CLI through the repository's declarative Go `cli-builder`
 - capturing basic environment metadata
 - running command-style workloads with warmup and measured trials
+- filtering runs with `--subjects` and `--workloads`
+- overriding subject checkouts with repeated `--subject name=ref` flags
+- preparing checkout-backed subjects in clean temporary git worktrees
+- pinning per-subject commit metadata in `subjects/<name>/subject.json`
 - writing `samples.jsonl`, `trials.jsonl`, `summary.json`, `environment.json`,
   and `report.md`
 - regenerating reports from an existing result directory
@@ -31,12 +35,20 @@ file sitting next to the executable.
 Manifest `working_directory` values are resolved relative to the manifest's git
 repository root when available, which lets you run the binary from your shell
 without first `cd`-ing to the repository root.
+When a subject declares `checkout`, the runner creates a detached temporary git
+worktree for that ref, runs the subject build and command from that checkout,
+records the exact commit SHA, and removes the worktree before returning.
 
 ```bash
 go build -o benchmark-tool .
 ./benchmark-tool doctor
 ./benchmark-tool validate ../../../benchmarks/examples/command/benchmark.toml
 ./benchmark-tool run ../../../benchmarks/examples/command/benchmark.toml --out /tmp/bench-result
+./benchmark-tool run ../../../benchmarks/examples/command/benchmark.toml \
+  --subject current=HEAD \
+  --subject baseline=origin/main \
+  --subjects current,baseline \
+  --workloads print-once
 ./benchmark-tool report /tmp/bench-result
 ./benchmark-tool compare /tmp/baseline /tmp/candidate
 ```

--- a/code/programs/go/benchmark-tool/benchmark-tool.json
+++ b/code/programs/go/benchmark-tool/benchmark-tool.json
@@ -3,7 +3,7 @@
   "name": "benchmark-tool",
   "display_name": "benchmark-tool",
   "description": "Run and compare reproducible coding-adventures benchmark manifests",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "parsing_mode": "gnu",
   "builtin_flags": { "help": true, "version": true },
   "commands": [
@@ -57,6 +57,30 @@
           "description": "Override warmup trial count",
           "type": "integer",
           "default": -1
+        },
+        {
+          "id": "subject",
+          "long": "subject",
+          "description": "Override a manifest subject checkout using NAME=REF; may be repeated",
+          "type": "string",
+          "value_name": "NAME=REF",
+          "repeatable": true
+        },
+        {
+          "id": "subjects",
+          "long": "subjects",
+          "description": "Comma-separated subject names to run",
+          "type": "string",
+          "value_name": "NAMES",
+          "default": ""
+        },
+        {
+          "id": "workloads",
+          "long": "workloads",
+          "description": "Comma-separated workload names to run",
+          "type": "string",
+          "value_name": "NAMES",
+          "default": ""
         }
       ],
       "arguments": [

--- a/code/programs/go/benchmark-tool/main.go
+++ b/code/programs/go/benchmark-tool/main.go
@@ -14,6 +14,7 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/json"
@@ -36,7 +37,7 @@ import (
 	clibuilder "github.com/adhithyan15/coding-adventures/code/packages/go/cli-builder"
 )
 
-const version = "0.1.0"
+const version = "0.2.0"
 
 //go:embed benchmark-tool.json
 var cliSpec []byte
@@ -149,6 +150,33 @@ type SummaryFile struct {
 	Summaries    []Summary `json:"summaries"`
 }
 
+type RunOptions struct {
+	MeasurementTrials int
+	WarmupTrials      int
+	SubjectOverrides  map[string]string
+	SubjectFilter     []string
+	WorkloadFilter    []string
+}
+
+type PreparedSubject struct {
+	Subject       Subject         `json:"subject"`
+	BenchmarkRoot string          `json:"benchmark_root"`
+	Metadata      SubjectMetadata `json:"metadata"`
+	Cleanup       func() error    `json:"-"`
+}
+
+type SubjectMetadata struct {
+	Name             string `json:"name"`
+	Checkout         string `json:"checkout,omitempty"`
+	Commit           string `json:"commit,omitempty"`
+	Branch           string `json:"branch,omitempty"`
+	Dirty            bool   `json:"dirty"`
+	Prebuilt         bool   `json:"prebuilt"`
+	BenchmarkRoot    string `json:"benchmark_root"`
+	WorkingDirectory string `json:"working_directory"`
+	WorktreePath     string `json:"worktree_path,omitempty"`
+}
+
 func main() {
 	os.Exit(runCLI(cliSpec, os.Args, os.Stdout, os.Stderr))
 }
@@ -194,11 +222,14 @@ func dispatchCLI(result *clibuilder.ParseResult, stdout io.Writer) error {
 	case "validate":
 		return validateManifestFile(stringArgument(result, "manifest"), stdout)
 	case "run":
+		options, err := runOptionsFromCLI(result)
+		if err != nil {
+			return err
+		}
 		return runManifestFile(
 			stringArgument(result, "manifest"),
 			stringFlag(result, "out"),
-			intFlag(result, "trials", -1),
-			intFlag(result, "warmup", -1),
+			options,
 		)
 	case "report":
 		return reportResultDir(stringArgument(result, "result-dir"), stdout)
@@ -214,6 +245,20 @@ func dispatchCLI(result *clibuilder.ParseResult, stdout io.Writer) error {
 	}
 }
 
+func runOptionsFromCLI(result *clibuilder.ParseResult) (RunOptions, error) {
+	overrides, err := parseSubjectOverrides(stringSliceFlag(result, "subject"))
+	if err != nil {
+		return RunOptions{}, err
+	}
+	return RunOptions{
+		MeasurementTrials: intFlag(result, "trials", -1),
+		WarmupTrials:      intFlag(result, "warmup", -1),
+		SubjectOverrides:  overrides,
+		SubjectFilter:     splitCSVFlag(stringFlag(result, "subjects")),
+		WorkloadFilter:    splitCSVFlag(stringFlag(result, "workloads")),
+	}, nil
+}
+
 func stringArgument(result *clibuilder.ParseResult, id string) string {
 	value, _ := result.Arguments[id].(string)
 	return value
@@ -222,6 +267,30 @@ func stringArgument(result *clibuilder.ParseResult, id string) string {
 func stringFlag(result *clibuilder.ParseResult, id string) string {
 	value, _ := result.Flags[id].(string)
 	return value
+}
+
+func stringSliceFlag(result *clibuilder.ParseResult, id string) []string {
+	switch value := result.Flags[id].(type) {
+	case nil:
+		return nil
+	case string:
+		if value == "" {
+			return nil
+		}
+		return []string{value}
+	case []string:
+		return append([]string(nil), value...)
+	case []any:
+		values := make([]string, 0, len(value))
+		for _, item := range value {
+			if text, ok := item.(string); ok && text != "" {
+				values = append(values, text)
+			}
+		}
+		return values
+	default:
+		return nil
+	}
 }
 
 func stringFlagDefault(result *clibuilder.ParseResult, id string, fallback string) string {
@@ -298,16 +367,14 @@ func validateManifestFile(path string, stdout io.Writer) error {
 	return nil
 }
 
-func runManifestFile(manifestPath string, outDir string, trials int, warmup int) error {
+func runManifestFile(manifestPath string, outDir string, options RunOptions) error {
 	manifest, err := LoadManifest(manifestPath)
 	if err != nil {
 		return err
 	}
-	if trials >= 0 {
-		manifest.Defaults.MeasurementTrials = trials
-	}
-	if warmup >= 0 {
-		manifest.Defaults.WarmupTrials = warmup
+	manifest, err = applyRunOptions(manifest, options)
+	if err != nil {
+		return err
 	}
 	if err := ValidateManifest(manifest); err != nil {
 		return err
@@ -316,6 +383,124 @@ func runManifestFile(manifestPath string, outDir string, trials int, warmup int)
 		outDir = defaultResultDir(manifest.Name)
 	}
 	return RunManifest(manifestPath, manifest, outDir)
+}
+
+func applyRunOptions(manifest Manifest, options RunOptions) (Manifest, error) {
+	if options.MeasurementTrials >= 0 {
+		manifest.Defaults.MeasurementTrials = options.MeasurementTrials
+	}
+	if options.WarmupTrials >= 0 {
+		manifest.Defaults.WarmupTrials = options.WarmupTrials
+	}
+	for name, checkout := range options.SubjectOverrides {
+		found := false
+		for i := range manifest.Subjects {
+			if manifest.Subjects[i].Name == name {
+				manifest.Subjects[i].Checkout = checkout
+				found = true
+			}
+		}
+		if !found {
+			return Manifest{}, fmt.Errorf("subject override references unknown subject %q", name)
+		}
+	}
+	if len(options.SubjectFilter) > 0 {
+		filtered, err := filterSubjects(manifest.Subjects, options.SubjectFilter)
+		if err != nil {
+			return Manifest{}, err
+		}
+		manifest.Subjects = filtered
+	}
+	if len(options.WorkloadFilter) > 0 {
+		filtered, err := filterWorkloads(manifest.Workloads, options.WorkloadFilter)
+		if err != nil {
+			return Manifest{}, err
+		}
+		manifest.Workloads = filtered
+	}
+	return manifest, nil
+}
+
+func parseSubjectOverrides(raw []string) (map[string]string, error) {
+	overrides := map[string]string{}
+	for _, item := range raw {
+		name, ref, ok := strings.Cut(item, "=")
+		name = strings.TrimSpace(name)
+		ref = strings.TrimSpace(ref)
+		if !ok || name == "" || ref == "" {
+			return nil, fmt.Errorf("subject override %q must use name=ref", item)
+		}
+		overrides[name] = ref
+	}
+	if len(overrides) == 0 {
+		return nil, nil
+	}
+	return overrides, nil
+}
+
+func splitCSVFlag(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	values := make([]string, 0, len(parts))
+	for _, part := range parts {
+		value := strings.TrimSpace(part)
+		if value != "" {
+			values = append(values, value)
+		}
+	}
+	return values
+}
+
+func filterSubjects(subjects []Subject, names []string) ([]Subject, error) {
+	wanted := nameSet(names)
+	filtered := make([]Subject, 0, len(subjects))
+	seen := map[string]bool{}
+	for _, subject := range subjects {
+		if wanted[subject.Name] {
+			filtered = append(filtered, subject)
+			seen[subject.Name] = true
+		}
+	}
+	if missing := missingNames(names, seen); len(missing) > 0 {
+		return nil, fmt.Errorf("unknown subject filter(s): %s", strings.Join(missing, ", "))
+	}
+	return filtered, nil
+}
+
+func filterWorkloads(workloads []Workload, names []string) ([]Workload, error) {
+	wanted := nameSet(names)
+	filtered := make([]Workload, 0, len(workloads))
+	seen := map[string]bool{}
+	for _, workload := range workloads {
+		if wanted[workload.Name] {
+			filtered = append(filtered, workload)
+			seen[workload.Name] = true
+		}
+	}
+	if missing := missingNames(names, seen); len(missing) > 0 {
+		return nil, fmt.Errorf("unknown workload filter(s): %s", strings.Join(missing, ", "))
+	}
+	return filtered, nil
+}
+
+func nameSet(names []string) map[string]bool {
+	set := map[string]bool{}
+	for _, name := range names {
+		set[name] = true
+	}
+	return set
+}
+
+func missingNames(names []string, seen map[string]bool) []string {
+	var missing []string
+	for _, name := range names {
+		if !seen[name] {
+			missing = append(missing, name)
+		}
+	}
+	return missing
 }
 
 func reportResultDir(dir string, stdout io.Writer) error {
@@ -737,11 +922,30 @@ func RunManifest(manifestPath string, manifest Manifest, outDir string) error {
 		if err := os.MkdirAll(subjectDir, 0o755); err != nil {
 			return err
 		}
-		if subject.Build != "" {
-			if err := runBuild(subject, subjectDir, benchmarkRoot); err != nil {
+		prepared, err := prepareSubject(subject, subjectDir, benchmarkRoot)
+		if err != nil {
+			if manifest.Defaults.FailFast {
+				return err
+			}
+			fmt.Fprintln(os.Stderr, "Subject preparation error:", err)
+			continue
+		}
+		if prepared.Cleanup != nil {
+			defer func(cleanup func() error) {
+				if err := cleanup(); err != nil {
+					fmt.Fprintln(os.Stderr, "Subject cleanup error:", err)
+				}
+			}(prepared.Cleanup)
+		}
+		if err := writeJSON(filepath.Join(subjectDir, "subject.json"), prepared.Metadata); err != nil {
+			return err
+		}
+		if prepared.Subject.Build != "" {
+			if err := runBuild(prepared, subjectDir); err != nil {
 				if manifest.Defaults.FailFast {
 					return err
 				}
+				fmt.Fprintln(os.Stderr, "Build error:", err)
 			}
 		}
 		for _, workload := range manifest.Workloads {
@@ -749,7 +953,7 @@ func RunManifest(manifestPath string, manifest Manifest, outDir string) error {
 				fmt.Fprintf(os.Stderr, "Skipping workload %s: driver %s is not implemented in phase one\n", workload.Name, workload.Driver)
 				continue
 			}
-			allTrials, err := runCommandWorkload(subject, workload, manifest.Defaults, benchmarkRoot, samplesFile, trialsFile)
+			allTrials, err := runCommandWorkload(prepared, workload, manifest.Defaults, samplesFile, trialsFile)
 			if err != nil {
 				if manifest.Defaults.FailFast {
 					return err
@@ -800,20 +1004,79 @@ func resolveSubjectWorkingDirectory(subject Subject, benchmarkRoot string) strin
 	return filepath.Join(benchmarkRoot, subject.WorkingDirectory)
 }
 
-func runBuild(subject Subject, subjectDir string, benchmarkRoot string) error {
-	workingDir := resolveSubjectWorkingDirectory(subject, benchmarkRoot)
-	result := runShell(subject.Build, workingDir, 0)
-	log := fmt.Sprintf("command: %s\nok: %t\nelapsed_ms: %.3f\n\nstdout:\n%s\n\nstderr:\n%s\n", subject.Build, result.OK, result.ElapsedMS, result.Stdout, result.Stderr)
+func prepareSubject(subject Subject, subjectDir string, benchmarkRoot string) (PreparedSubject, error) {
+	prepared := PreparedSubject{
+		Subject:       subject,
+		BenchmarkRoot: benchmarkRoot,
+		Metadata: SubjectMetadata{
+			Name:             subject.Name,
+			Checkout:         subject.Checkout,
+			Prebuilt:         subject.Prebuilt,
+			BenchmarkRoot:    benchmarkRoot,
+			WorkingDirectory: resolveSubjectWorkingDirectory(subject, benchmarkRoot),
+			Branch:           commandOutput(benchmarkRoot, "git", "rev-parse", "--abbrev-ref", "HEAD"),
+			Commit:           commandOutput(benchmarkRoot, "git", "rev-parse", "HEAD"),
+			Dirty:            commandOutput(benchmarkRoot, "git", "status", "--short") != "",
+		},
+	}
+	if subject.Checkout == "" {
+		return prepared, nil
+	}
+	tempParent, err := os.MkdirTemp("", "benchmark-tool-worktrees-")
+	if err != nil {
+		return PreparedSubject{}, err
+	}
+	worktreePath := filepath.Join(tempParent, safeName(subject.Name))
+	result := runProcess(benchmarkRoot, 30*time.Second, "git", "worktree", "add", "--detach", worktreePath, subject.Checkout)
+	log := fmt.Sprintf("command: git worktree add --detach %s %s\nok: %t\nelapsed_ms: %.3f\n\nstdout:\n%s\n\nstderr:\n%s\n", worktreePath, subject.Checkout, result.OK, result.ElapsedMS, result.Stdout, result.Stderr)
+	if err := os.WriteFile(filepath.Join(subjectDir, "prepare.log"), []byte(log), 0o644); err != nil {
+		_ = os.RemoveAll(tempParent)
+		return PreparedSubject{}, err
+	}
+	if !result.OK {
+		_ = os.RemoveAll(tempParent)
+		return PreparedSubject{}, fmt.Errorf("prepare failed for subject %s: %s", subject.Name, result.Error)
+	}
+	prepared.BenchmarkRoot = worktreePath
+	prepared.Metadata.BenchmarkRoot = worktreePath
+	prepared.Metadata.WorktreePath = worktreePath
+	prepared.Metadata.WorkingDirectory = resolveSubjectWorkingDirectory(subject, worktreePath)
+	prepared.Metadata.Branch = commandOutput(worktreePath, "git", "rev-parse", "--abbrev-ref", "HEAD")
+	prepared.Metadata.Commit = commandOutput(worktreePath, "git", "rev-parse", "HEAD")
+	prepared.Metadata.Dirty = commandOutput(worktreePath, "git", "status", "--short") != ""
+	prepared.Cleanup = func() error {
+		remove := runProcess(benchmarkRoot, 30*time.Second, "git", "worktree", "remove", "--force", worktreePath)
+		if !remove.OK {
+			return fmt.Errorf("remove git worktree %s: %s", worktreePath, remove.Error)
+		}
+		if err := os.RemoveAll(tempParent); err != nil {
+			return err
+		}
+		return nil
+	}
+	if prepared.Metadata.Dirty {
+		if prepared.Cleanup != nil {
+			_ = prepared.Cleanup()
+		}
+		return PreparedSubject{}, fmt.Errorf("subject %s checkout %s is dirty after preparation", subject.Name, subject.Checkout)
+	}
+	return prepared, nil
+}
+
+func runBuild(subject PreparedSubject, subjectDir string) error {
+	workingDir := resolveSubjectWorkingDirectory(subject.Subject, subject.BenchmarkRoot)
+	result := runShell(subject.Subject.Build, workingDir, 0)
+	log := fmt.Sprintf("command: %s\nok: %t\nelapsed_ms: %.3f\nworking_directory: %s\ncommit: %s\n\nstdout:\n%s\n\nstderr:\n%s\n", subject.Subject.Build, result.OK, result.ElapsedMS, workingDir, subject.Metadata.Commit, result.Stdout, result.Stderr)
 	if err := os.WriteFile(filepath.Join(subjectDir, "build.log"), []byte(log), 0o644); err != nil {
 		return err
 	}
 	if !result.OK {
-		return fmt.Errorf("build failed for subject %s: %s", subject.Name, result.Error)
+		return fmt.Errorf("build failed for subject %s: %s", subject.Subject.Name, result.Error)
 	}
 	return nil
 }
 
-func runCommandWorkload(subject Subject, workload Workload, defaults Defaults, benchmarkRoot string, samplesFile, trialsFile *os.File) ([]Trial, error) {
+func runCommandWorkload(subject PreparedSubject, workload Workload, defaults Defaults, samplesFile, trialsFile *os.File) ([]Trial, error) {
 	var trials []Trial
 	total := defaults.WarmupTrials + defaults.MeasurementTrials
 	for i := 0; i < total; i++ {
@@ -823,11 +1086,11 @@ func runCommandWorkload(subject Subject, workload Workload, defaults Defaults, b
 			phase = "warmup"
 			trialNumber = i + 1
 		}
-		command := subject.Command
+		command := subject.Subject.Command
 		if workload.Command != "" {
 			command = workload.Command
 		}
-		workingDir := resolveSubjectWorkingDirectory(subject, benchmarkRoot)
+		workingDir := resolveSubjectWorkingDirectory(subject.Subject, subject.BenchmarkRoot)
 		result := runShell(command, workingDir, time.Duration(workload.TimeoutMS)*time.Millisecond)
 		metrics := map[string]float64{"elapsed_ms": result.ElapsedMS}
 		if workload.Operations > 0 && result.ElapsedMS > 0 {
@@ -836,7 +1099,7 @@ func runCommandWorkload(subject Subject, workload Workload, defaults Defaults, b
 		}
 		sample := Sample{
 			SampleKind: "operation_batch",
-			Subject:    subject.Name,
+			Subject:    subject.Subject.Name,
 			Workload:   workload.Name,
 			Trial:      trialNumber,
 			Phase:      phase,
@@ -845,7 +1108,7 @@ func runCommandWorkload(subject Subject, workload Workload, defaults Defaults, b
 			Error:      result.Error,
 		}
 		trial := Trial{
-			Subject:  subject.Name,
+			Subject:  subject.Subject.Name,
 			Workload: workload.Name,
 			Trial:    trialNumber,
 			Phase:    phase,
@@ -895,6 +1158,36 @@ func runShell(command, dir string, timeout time.Duration) commandResult {
 		OK:        err == nil,
 		ElapsedMS: elapsed,
 		Stdout:    string(out),
+	}
+	if ctx.Err() == context.DeadlineExceeded {
+		result.Error = "timeout"
+		result.OK = false
+	} else if err != nil {
+		result.Error = err.Error()
+	}
+	return result
+}
+
+func runProcess(dir string, timeout time.Duration, name string, args ...string) commandResult {
+	if timeout <= 0 {
+		timeout = 60 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	start := time.Now()
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	elapsed := float64(time.Since(start).Microseconds()) / 1000.0
+	result := commandResult{
+		OK:        err == nil,
+		ElapsedMS: elapsed,
+		Stdout:    stdout.String(),
+		Stderr:    stderr.String(),
 	}
 	if ctx.Err() == context.DeadlineExceeded {
 		result.Error = "timeout"

--- a/code/programs/go/benchmark-tool/main_test.go
+++ b/code/programs/go/benchmark-tool/main_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"math"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -150,7 +152,7 @@ func TestCLICommandFunctionsExerciseHappyPaths(t *testing.T) {
 	if code := runCLI(cliSpec, []string{"benchmark-tool", "validate", manifestPath}, &stdout, &stderr); code != 0 {
 		t.Fatalf("validate command exit=%d stderr=%s", code, stderr.String())
 	}
-	if code := runCLI(cliSpec, []string{"benchmark-tool", "run", manifestPath, "--out", leftDir, "--warmup", "0", "--trials", "1"}, &stdout, &stderr); code != 0 {
+	if code := runCLI(cliSpec, []string{"benchmark-tool", "run", manifestPath, "--out", leftDir, "--warmup", "0", "--trials", "1", "--subjects", "print", "--workloads", "print-once"}, &stdout, &stderr); code != 0 {
 		t.Fatalf("run command left exit=%d stderr=%s", code, stderr.String())
 	}
 	if code := runCLI(cliSpec, []string{"benchmark-tool", "run", "--out", rightDir, "--warmup=0", "--trials=1", manifestPath}, &stdout, &stderr); code != 0 {
@@ -229,14 +231,126 @@ func TestIntFlagConversionsAreBoundsChecked(t *testing.T) {
 	}
 }
 
+func TestRunOptionsApplySubjectOverridesAndFilters(t *testing.T) {
+	manifest := validTinyManifest()
+	manifest.Subjects = append(manifest.Subjects, Subject{
+		Name:     "baseline",
+		Kind:     "command",
+		Prebuilt: true,
+		Command:  "printf baseline",
+	})
+	manifest.Workloads = append(manifest.Workloads, Workload{
+		Name:      "other",
+		Driver:    "command",
+		TimeoutMS: 1000,
+	})
+
+	updated, err := applyRunOptions(manifest, RunOptions{
+		MeasurementTrials: 7,
+		WarmupTrials:      2,
+		SubjectOverrides:  map[string]string{"baseline": "origin/main"},
+		SubjectFilter:     []string{"baseline"},
+		WorkloadFilter:    []string{"other"},
+	})
+	if err != nil {
+		t.Fatalf("apply run options: %v", err)
+	}
+	if updated.Defaults.MeasurementTrials != 7 || updated.Defaults.WarmupTrials != 2 {
+		t.Fatalf("trial overrides were not applied: %#v", updated.Defaults)
+	}
+	if len(updated.Subjects) != 1 || updated.Subjects[0].Name != "baseline" || updated.Subjects[0].Checkout != "origin/main" {
+		t.Fatalf("subject filter/override mismatch: %#v", updated.Subjects)
+	}
+	if len(updated.Workloads) != 1 || updated.Workloads[0].Name != "other" {
+		t.Fatalf("workload filter mismatch: %#v", updated.Workloads)
+	}
+}
+
+func TestParseSubjectOverridesRejectsMalformedValues(t *testing.T) {
+	if _, err := parseSubjectOverrides([]string{"current=HEAD", "baseline=origin/main"}); err != nil {
+		t.Fatalf("valid overrides should parse: %v", err)
+	}
+	if _, err := parseSubjectOverrides([]string{"missing-equals"}); err == nil {
+		t.Fatal("expected malformed subject override to fail")
+	}
+}
+
+func TestRunManifestPreparesGitWorktreeForCheckoutSubjects(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required for worktree tests")
+	}
+	if err := gitUsableForTest(); err != nil {
+		t.Skipf("git is not usable in this environment: %v", err)
+	}
+	dir := t.TempDir()
+	repo := filepath.Join(dir, "repo")
+	resultDir := filepath.Join(dir, "results")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	runGitForTest(t, repo, "init")
+	runGitForTest(t, repo, "config", "user.email", "bench@example.com")
+	runGitForTest(t, repo, "config", "user.name", "Benchmark Test")
+	writeFileForTest(t, filepath.Join(repo, "print_marker.go"), `package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func main() {
+	data, err := os.ReadFile("marker.txt")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Print(strings.TrimSpace(string(data)))
+}
+`)
+	writeFileForTest(t, filepath.Join(repo, "benchmark.toml"), gitWorktreeManifestText())
+	writeFileForTest(t, filepath.Join(repo, "marker.txt"), "baseline\n")
+	runGitForTest(t, repo, "add", ".")
+	runGitForTest(t, repo, "commit", "-m", "baseline")
+	runGitForTest(t, repo, "branch", "baseline-ref")
+	writeFileForTest(t, filepath.Join(repo, "marker.txt"), "current\n")
+	runGitForTest(t, repo, "add", "marker.txt")
+	runGitForTest(t, repo, "commit", "-m", "current")
+	runGitForTest(t, repo, "branch", "current-ref")
+
+	manifestPath := filepath.Join(repo, "benchmark.toml")
+	manifest, err := LoadManifest(manifestPath)
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	if err := RunManifest(manifestPath, manifest, resultDir); err != nil {
+		t.Fatalf("run manifest: %v", err)
+	}
+
+	assertBuildLogContainsForTest(t, resultDir, "baseline", "baseline")
+	assertBuildLogContainsForTest(t, resultDir, "current", "current")
+	metadata := readSubjectMetadataForTest(t, filepath.Join(resultDir, "subjects", "baseline", "subject.json"))
+	if metadata.Commit == "" {
+		t.Fatalf("expected pinned commit metadata: %#v", metadata)
+	}
+	if metadata.WorktreePath == "" {
+		t.Fatalf("expected worktree metadata: %#v", metadata)
+	}
+	if _, err := os.Stat(metadata.WorktreePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("worktree should be cleaned up after the run, stat err=%v", err)
+	}
+}
+
 func TestRunBuildWritesLogsAndPropagatesFailures(t *testing.T) {
 	dir := t.TempDir()
-	okSubject := Subject{
-		Name:             "builder",
-		WorkingDirectory: dir,
-		Build:            "printf build-ok",
+	okSubject := PreparedSubject{
+		Subject: Subject{
+			Name:             "builder",
+			WorkingDirectory: dir,
+			Build:            "printf build-ok",
+		},
+		BenchmarkRoot: dir,
 	}
-	if err := runBuild(okSubject, dir, dir); err != nil {
+	if err := runBuild(okSubject, dir); err != nil {
 		t.Fatalf("run build: %v", err)
 	}
 	logData, err := os.ReadFile(filepath.Join(dir, "build.log"))
@@ -248,8 +362,8 @@ func TestRunBuildWritesLogsAndPropagatesFailures(t *testing.T) {
 	}
 
 	badSubject := okSubject
-	badSubject.Build = shellExitCommand(7)
-	if err := runBuild(badSubject, dir, dir); err == nil {
+	badSubject.Subject.Build = shellExitCommand(7)
+	if err := runBuild(badSubject, dir); err == nil {
 		t.Fatal("expected failing build to return an error")
 	}
 }
@@ -395,6 +509,39 @@ timeout_ms = 10000
 `
 }
 
+func gitWorktreeManifestText() string {
+	return `name = "git-worktree-benchmark"
+
+[defaults]
+warmup_trials = 0
+measurement_trials = 1
+cooldown_ms = 0
+fail_fast = true
+
+[[subjects]]
+name = "baseline"
+kind = "command"
+checkout = "baseline-ref"
+working_directory = "."
+build = "go run print_marker.go"
+command = "go version"
+
+[[subjects]]
+name = "current"
+kind = "command"
+checkout = "current-ref"
+working_directory = "."
+build = "go run print_marker.go"
+command = "go version"
+
+[[workloads]]
+name = "go-version"
+driver = "command"
+operations = 1
+timeout_ms = 10000
+`
+}
+
 func shellExitCommand(code int) string {
 	if runtime.GOOS == "windows" {
 		return "exit " + strconv.Itoa(code)
@@ -463,4 +610,50 @@ func readLinesForTest(t *testing.T, path string) []string {
 		return nil
 	}
 	return strings.Split(text, "\n")
+}
+
+func runGitForTest(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, string(out))
+	}
+}
+
+func gitUsableForTest() error {
+	cmd := exec.Command("git", "--version")
+	return cmd.Run()
+}
+
+func writeFileForTest(t *testing.T, path string, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func assertBuildLogContainsForTest(t *testing.T, resultDir string, subject string, want string) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(resultDir, "subjects", subject, "build.log"))
+	if err != nil {
+		t.Fatalf("read build log for %s: %v", subject, err)
+	}
+	if !strings.Contains(string(data), want) {
+		t.Fatalf("build log for %s should contain %q:\n%s", subject, want, string(data))
+	}
+}
+
+func readSubjectMetadataForTest(t *testing.T, path string) SubjectMetadata {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read subject metadata: %v", err)
+	}
+	var metadata SubjectMetadata
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		t.Fatalf("decode subject metadata: %v", err)
+	}
+	return metadata
 }

--- a/code/specs/benchmarking-tools.md
+++ b/code/specs/benchmarking-tools.md
@@ -657,12 +657,29 @@ surface before the full TCP benchmark surface:
   validation remains future work.
 - `run` currently executes `driver = "command"` workloads and validates, but
   skips, TCP/RESP workloads until the load generator lands.
-- The implemented run flags are `--out`, `--trials`, and `--warmup`; subject
-  filtering, workload filtering, seeds, build reuse, and CLI-level fail-fast
-  overrides remain future work.
+- The initial implemented run flags were `--out`, `--trials`, and `--warmup`.
+  Phase two adds subject checkout overrides and focused subject/workload
+  filters. Seeds, build reuse, and CLI-level fail-fast overrides remain future
+  work.
 - Manifest `working_directory` values are resolved relative to the manifest's
   git repository root when available, so repo-local benchmark manifests work
   when the binary is invoked from outside the repository root.
+
+### Phase-Two Implementation Note
+
+The git-ref comparison slice now has a concrete preparation layer for command
+benchmarks:
+
+- `run` accepts repeated `--subject name=ref` flags to override a manifest
+  subject's `checkout` value at the command line.
+- `run` accepts `--subjects name,name` and `--workloads name,name` filters for
+  focused local runs and smaller CI benchmark jobs.
+- Any subject with a `checkout` value is prepared in a detached temporary git
+  worktree, pinned to an exact commit SHA, and cleaned up when the run returns.
+- Per-subject metadata is written to `subjects/<name>/subject.json`, and build
+  logs remain in `subjects/<name>/build.log`.
+- Randomized or paired trial ordering and richer in-result comparison reports
+  remain future work.
 
 ---
 

--- a/lessons.md
+++ b/lessons.md
@@ -4,6 +4,21 @@ This file tracks mistakes made during development so they are not repeated. Chec
 
 ---
 
+### 2026-04-20: Tests that need a CLI tool must verify the tool actually runs
+
+Checking `exec.LookPath("git")` only proves that a binary exists on `PATH`. On
+macOS, `/usr/bin/git` can exist but fail every invocation behind the Xcode
+license gate, which makes tests fail after they already decided Git was
+available.
+
+**Symptom:** A test guarded by `exec.LookPath("git")` still fails at `git init`
+with an Xcode license error.
+
+**Rule:** Tests that depend on an external CLI should run a harmless probe such
+as `git --version` and skip when that command fails. Presence is not usability.
+
+---
+
 ### 2026-04-20: CodeQL flags unchecked CLI integer downcasts from `int64` to `int`
 
 CodeQL treats parsed CLI integer values as untrusted numeric input. If a Go


### PR DESCRIPTION
## Summary

- add phase-two benchmark-tool run options for `--subject name=ref`, `--subjects`, and `--workloads`
- prepare checkout-backed subjects in detached temporary git worktrees, record pinned commit metadata, and clean worktrees after the run
- update benchmark-tool docs/changelog/spec and record benchmarking workflow lessons

## Validation

- `go test ./... -count=1 -v -cover` in `code/programs/go/benchmark-tool` passes at 81.5% coverage
- `go vet ./...` passes
- `go build -o benchmark-tool .` passes
