### PR TITLE
Add advanced Prolog control builtins

### DIFF
--- a/code/packages/python/logic-builtins/CHANGELOG.md
+++ b/code/packages/python/logic-builtins/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.4.0] - 2026-04-20
+
+### Added
+
+- advanced control predicates: `trueo`, `failo`, `iftheno`, `ifthenelseo`, and `forallo`
+- tests covering committed-condition behavior, then-branch backtracking, else-state isolation, and forall binding discipline
+- documentation explaining why real Prolog cut is deferred until the solver can prune scoped choicepoints
+
 ## [0.3.0] - 2026-04-20
 
 ### Added

--- a/code/packages/python/logic-builtins/README.md
+++ b/code/packages/python/logic-builtins/README.md
@@ -12,6 +12,9 @@ ordinary logic goal expressions.
 - `callo(goal)`
 - `onceo(goal)`
 - `noto(goal)` for negation as failure
+- `trueo()` and `failo()`
+- `iftheno(condition, then_goal)` and `ifthenelseo(condition, then_goal, else_goal)`
+- `forallo(generator, test)`
 - `groundo(term)`
 - `varo(term)` and `nonvaro(term)`
 - `atomo(term)`, `numbero(term)`, `stringo(term)`, and `compoundo(term)`
@@ -25,7 +28,19 @@ ordinary logic goal expressions.
 ## Quick Start
 
 ```python
-from logic_builtins import argo, findallo, functoro, geqo, groundo, iso, add, noto, onceo
+from logic_builtins import (
+    add,
+    argo,
+    findallo,
+    forallo,
+    functoro,
+    geqo,
+    groundo,
+    ifthenelseo,
+    iso,
+    noto,
+    onceo,
+)
 from logic_engine import atom, conj, eq, fail, logic_list, num, program, solve_all, term, var
 
 X = var("X")
@@ -55,6 +70,16 @@ assert solve_all(
     Results,
     findallo(X, conj(eq(X, 7), geqo(add(X, 1), 8)), Results),
 ) == [logic_list([7])]
+assert solve_all(
+    program(),
+    X,
+    ifthenelseo(eq(X, "tea"), eq(X, "tea"), eq(X, "coffee")),
+) == [atom("tea")]
+assert solve_all(
+    program(),
+    X,
+    forallo(conj(eq(X, 7)), geqo(X, 7)),
+) == [X]
 ```
 
 Arithmetic is evaluative, not a constraint system yet. `iso(Y, add(X, 1))`
@@ -64,6 +89,13 @@ instantiated it.
 Collections are observations over a nested proof search. `findallo` succeeds
 with an empty list when the inner goal fails, while `bagofo` and `setofo` fail
 for empty collections.
+
+Advanced control is intentionally honest about the current solver. `iftheno`
+and `ifthenelseo` commit to the first condition proof while allowing the chosen
+branch to keep backtracking. `forallo` checks every generated proof without
+leaking generator bindings to the outer query. Full Prolog cut is not included
+yet because it needs solver-level choicepoint pruning rather than a simple
+library predicate.
 
 ## Dependencies
 

--- a/code/packages/python/logic-builtins/pyproject.toml
+++ b/code/packages/python/logic-builtins/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-logic-builtins"
-version = "0.3.0"
+version = "0.4.0"
 description = "Prolog-inspired control, term, arithmetic, and collection builtins for the Python logic stack"
 requires-python = ">=3.12"
 license = "MIT"
@@ -17,7 +17,7 @@ dependencies = [
 [project.urls]
 Homepage = "https://github.com/adhithyan15/coding-adventures"
 Repository = "https://github.com/adhithyan15/coding-adventures"
-Documentation = "https://github.com/adhithyan15/coding-adventures/tree/main/code/specs/LP13-logic-collection-builtins.md"
+Documentation = "https://github.com/adhithyan15/coding-adventures/tree/main/code/specs/LP14-logic-advanced-control-builtins.md"
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]

--- a/code/packages/python/logic-builtins/src/logic_builtins/__init__.py
+++ b/code/packages/python/logic-builtins/src/logic_builtins/__init__.py
@@ -12,12 +12,16 @@ from logic_builtins.builtins import (
     callo,
     compoundo,
     div,
+    failo,
     findallo,
     floordiv,
+    forallo,
     functoro,
     geqo,
     groundo,
     gto,
+    ifthenelseo,
+    iftheno,
     iso,
     leqo,
     lto,
@@ -33,6 +37,7 @@ from logic_builtins.builtins import (
     setofo,
     stringo,
     sub,
+    trueo,
     varo,
 )
 
@@ -45,12 +50,16 @@ __all__ = [
     "callo",
     "compoundo",
     "div",
+    "failo",
     "findallo",
     "floordiv",
+    "forallo",
     "functoro",
     "geqo",
     "gto",
     "groundo",
+    "ifthenelseo",
+    "iftheno",
     "iso",
     "leqo",
     "lto",
@@ -66,7 +75,8 @@ __all__ = [
     "setofo",
     "stringo",
     "sub",
+    "trueo",
     "varo",
 ]
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/code/packages/python/logic-builtins/src/logic_builtins/builtins.py
+++ b/code/packages/python/logic-builtins/src/logic_builtins/builtins.py
@@ -34,7 +34,11 @@ from logic_engine import (
     num,
     reify,
     solve_from,
+    succeed,
     term,
+)
+from logic_engine import (
+    fail as engine_fail,
 )
 
 __all__ = [
@@ -44,12 +48,16 @@ __all__ = [
     "callo",
     "compoundo",
     "div",
+    "failo",
     "findallo",
     "floordiv",
+    "forallo",
     "functoro",
     "geqo",
     "gto",
     "groundo",
+    "ifthenelseo",
+    "iftheno",
     "iso",
     "leqo",
     "lto",
@@ -66,6 +74,7 @@ __all__ = [
     "setofo",
     "stringo",
     "sub",
+    "trueo",
     "varo",
 ]
 
@@ -220,6 +229,68 @@ def setofo(template: object, goal: object, results: object) -> GoalExpr:
         )
 
     return native_goal(run, template, results)
+
+
+def trueo() -> GoalExpr:
+    """Succeed once without changing the current logic state."""
+
+    return succeed()
+
+
+def failo() -> GoalExpr:
+    """Fail without yielding any successor states."""
+
+    return engine_fail()
+
+
+def iftheno(condition: object, then_goal: object) -> GoalExpr:
+    """Run `then_goal` from the first proof of `condition`, or fail."""
+
+    condition_goal = _as_goal(condition)
+    called_then = _as_goal(then_goal)
+
+    def run(program_value: Program, state: State, _args: NativeArgs) -> Iterator[State]:
+        condition_proofs = solve_from(program_value, condition_goal, state)
+        first_condition_state = next(condition_proofs, None)
+        if first_condition_state is None:
+            return
+        yield from solve_from(program_value, called_then, first_condition_state)
+
+    return native_goal(run)
+
+
+def ifthenelseo(condition: object, then_goal: object, else_goal: object) -> GoalExpr:
+    """Choose a committed then branch or an else branch from the original state."""
+
+    condition_goal = _as_goal(condition)
+    called_then = _as_goal(then_goal)
+    called_else = _as_goal(else_goal)
+
+    def run(program_value: Program, state: State, _args: NativeArgs) -> Iterator[State]:
+        condition_proofs = solve_from(program_value, condition_goal, state)
+        first_condition_state = next(condition_proofs, None)
+        if first_condition_state is None:
+            yield from solve_from(program_value, called_else, state)
+            return
+        yield from solve_from(program_value, called_then, first_condition_state)
+
+    return native_goal(run)
+
+
+def forallo(generator: object, test: object) -> GoalExpr:
+    """Succeed once when every generated proof satisfies `test` at least once."""
+
+    generator_goal = _as_goal(generator)
+    test_goal = _as_goal(test)
+
+    def run(program_value: Program, state: State, _args: NativeArgs) -> Iterator[State]:
+        for generated_state in solve_from(program_value, generator_goal, state):
+            test_proofs = solve_from(program_value, test_goal, generated_state)
+            if next(test_proofs, None) is None:
+                return
+        yield state
+
+    return native_goal(run)
 
 
 def add(left: object, right: object) -> Compound:

--- a/code/packages/python/logic-builtins/tests/test_logic_builtins.py
+++ b/code/packages/python/logic-builtins/tests/test_logic_builtins.py
@@ -30,12 +30,16 @@ from logic_builtins import (
     callo,
     compoundo,
     div,
+    failo,
     findallo,
     floordiv,
+    forallo,
     functoro,
     geqo,
     groundo,
     gto,
+    ifthenelseo,
+    iftheno,
     iso,
     leqo,
     lto,
@@ -51,6 +55,7 @@ from logic_builtins import (
     setofo,
     stringo,
     sub,
+    trueo,
     varo,
 )
 
@@ -59,7 +64,139 @@ class TestVersion:
     """Verify the package is importable and versioned."""
 
     def test_version_exists(self) -> None:
-        assert __version__ == "0.3.0"
+        assert __version__ == "0.4.0"
+
+
+class TestAdvancedControlBuiltins:
+    """Advanced control should stay honest about committed search behavior."""
+
+    def test_trueo_succeeds_once_and_preserves_state(self) -> None:
+        item = var("Item")
+
+        assert solve_all(program(), item, conj(eq(item, "tea"), trueo())) == [
+            atom("tea"),
+        ]
+
+    def test_failo_fails_without_successor_states(self) -> None:
+        item = var("Item")
+
+        assert solve_all(program(), item, conj(eq(item, "tea"), failo())) == []
+
+    def test_iftheno_commits_to_first_condition_proof(self) -> None:
+        guard = var("Guard")
+        result = var("Result")
+
+        assert solve_all(
+            program(),
+            result,
+            iftheno(
+                disj(eq(guard, "first"), eq(guard, "second")),
+                eq(result, guard),
+            ),
+        ) == [atom("first")]
+
+    def test_iftheno_keeps_then_branch_backtracking(self) -> None:
+        guard = var("Guard")
+        result = var("Result")
+
+        assert solve_all(
+            program(),
+            result,
+            iftheno(
+                disj(eq(guard, "first"), eq(guard, "second")),
+                disj(
+                    eq(result, term("choice", guard, "a")),
+                    eq(result, term("choice", guard, "b")),
+                ),
+            ),
+        ) == [
+            term("choice", "first", "a"),
+            term("choice", "first", "b"),
+        ]
+
+    def test_iftheno_fails_when_condition_fails(self) -> None:
+        result = var("Result")
+
+        assert solve_all(program(), result, iftheno(fail(), eq(result, "then"))) == []
+
+    def test_ifthenelseo_chooses_then_branch_when_condition_succeeds(self) -> None:
+        guard = var("Guard")
+        result = var("Result")
+
+        assert solve_all(
+            program(),
+            result,
+            ifthenelseo(
+                disj(eq(guard, "first"), eq(guard, "second")),
+                eq(result, term("then", guard)),
+                eq(result, "else"),
+            ),
+        ) == [term("then", "first")]
+
+    def test_ifthenelseo_chooses_else_from_original_state(self) -> None:
+        item = var("Item")
+
+        assert solve_all(
+            program(),
+            item,
+            ifthenelseo(
+                conj(eq(item, "condition-binding"), fail()),
+                eq(item, "then"),
+                eq(item, "else"),
+            ),
+        ) == [atom("else")]
+
+    def test_forallo_succeeds_when_every_generated_proof_passes(self) -> None:
+        marker = var("Marker")
+        item = var("Item")
+
+        assert solve_all(
+            program(),
+            marker,
+            conj(
+                eq(marker, "ok"),
+                forallo(disj(eq(item, 1), eq(item, 2)), lto(item, 3)),
+            ),
+        ) == [atom("ok")]
+
+    def test_forallo_fails_when_any_generated_proof_fails_test(self) -> None:
+        marker = var("Marker")
+        item = var("Item")
+
+        assert solve_all(
+            program(),
+            marker,
+            conj(
+                eq(marker, "ok"),
+                forallo(disj(eq(item, 1), eq(item, 4)), lto(item, 3)),
+            ),
+        ) == []
+
+    def test_forallo_succeeds_vacuously_and_does_not_leak_bindings(self) -> None:
+        item = var("Item")
+
+        assert solve_all(program(), item, forallo(fail(), fail())) == [item]
+        assert solve_all(
+            program(),
+            item,
+            forallo(disj(eq(item, 1), eq(item, 2)), numbero(item)),
+        ) == [item]
+
+    def test_advanced_control_rejects_non_goals(self) -> None:
+        with pytest.raises(TypeError):
+            iftheno(object(), trueo())
+        with pytest.raises(TypeError):
+            iftheno(trueo(), object())
+        with pytest.raises(TypeError):
+            ifthenelseo(object(), trueo(), failo())
+        with pytest.raises(TypeError):
+            ifthenelseo(trueo(), object(), failo())
+        with pytest.raises(TypeError):
+            ifthenelseo(trueo(), failo(), object())
+        with pytest.raises(TypeError):
+            forallo(object(), trueo())
+        with pytest.raises(TypeError):
+            forallo(trueo(), object())
 
 
 class TestCollectionBuiltins:

--- a/code/specs/LP14-logic-advanced-control-builtins.md
+++ b/code/specs/LP14-logic-advanced-control-builtins.md
@@ -1,0 +1,160 @@
+# LP14 - Logic Advanced Control Builtins
+
+## Overview
+
+LP11 introduced the first Prolog-style control helpers: `callo`, `onceo`, and
+`noto`. LP12 added evaluative arithmetic, and LP13 added solution collection.
+The next functionality-level gap is richer control flow that lets library users
+write programs that look more like practical Prolog without needing Prolog
+syntax yet.
+
+LP14 extends the Python `logic-builtins` package with truth, failure,
+if-then-style control, and universal quantification.
+
+## Design Goal
+
+Add a small advanced-control layer that is honest about the current solver's
+capabilities:
+
+- expose explicit truth and failure predicates
+- support committed-condition if-then and if-then-else goals
+- support `forall`-style checks over generated solutions
+- document why full Prolog cut is deferred
+
+These are ordinary Python functions that return `logic-engine` goal
+expressions. They are not syntax and they do not require a parser.
+
+## Package
+
+Update:
+
+```text
+code/packages/python/logic-builtins
+```
+
+The package version should move from `0.3.0` to `0.4.0`.
+
+## Public API
+
+Add:
+
+```python
+trueo()
+failo()
+iftheno(condition, then_goal)
+ifthenelseo(condition, then_goal, else_goal)
+forallo(generator, test)
+```
+
+The `o` suffix keeps the package convention that public predicates return
+logic goals.
+
+## Semantics
+
+### `trueo()`
+
+Succeed once without changing the current state.
+
+This is the library spelling of Prolog's `true/0` and mirrors
+`logic_engine.succeed()`.
+
+### `failo()`
+
+Fail without yielding any successor states.
+
+This is the library spelling of Prolog's `fail/0` and mirrors
+`logic_engine.fail()`.
+
+### `iftheno(condition, then_goal)`
+
+Run `condition` from the current state. If `condition` has at least one proof,
+commit to the first condition proof and run `then_goal` from that proof state.
+If `condition` has no proof, fail.
+
+This is equivalent to Prolog's `Condition -> Then` form without an else branch.
+The condition is committed to one proof; the then branch may still produce
+multiple solutions.
+
+### `ifthenelseo(condition, then_goal, else_goal)`
+
+Run `condition` from the current state.
+
+- If `condition` has at least one proof, commit to its first proof and run
+  `then_goal` from that proof state.
+- If `condition` has no proofs, run `else_goal` from the original state.
+
+The else branch must not see bindings from a failed condition attempt.
+
+### `forallo(generator, test)`
+
+Run `generator` from the current state. For every generated proof state, run
+`test` from that proof state. `forallo` succeeds once from the original state if
+every generated proof satisfies `test` at least once.
+
+Important details:
+
+- `forallo` succeeds vacuously when `generator` has no proofs.
+- bindings produced by `generator` and `test` do not leak to the outer state
+- if any generated proof fails `test`, the whole `forallo` goal fails
+
+This is the library spelling of Prolog's `forall/2`, implemented as an
+operational check over the proof stream rather than as classical universal
+quantification.
+
+## Cut Boundary
+
+LP14 deliberately does not add `cuto()`.
+
+Prolog cut (`!/0`) prunes choicepoints created to the left of the cut inside a
+clause. The current solver exposes generator-based proof streams and native
+goals, but it does not yet represent scoped choicepoints or a "commit" signal
+that can prune surrounding disjunctions and clause alternatives. A fake `cuto`
+that merely succeeds once would be actively misleading.
+
+A future milestone can add real cut by extending the solver protocol with
+scoped choicepoint pruning. Until then, `onceo`, `iftheno`, and
+`ifthenelseo` provide honest committed-choice building blocks.
+
+## Error Model
+
+Passing a non-goal object where a goal is required is host-language API misuse
+and should raise `TypeError`.
+
+Logical failure remains logical:
+
+- failed conditions make `iftheno` fail
+- failed conditions choose the else branch in `ifthenelseo`
+- failed tests make `forallo` fail
+
+## Test Strategy
+
+Required tests:
+
+- `trueo` succeeds once and preserves the current state
+- `failo` fails
+- `iftheno` commits to the first condition proof
+- `iftheno` allows the then branch to produce multiple solutions
+- `iftheno` fails when the condition fails
+- `ifthenelseo` chooses the then branch when the condition succeeds
+- `ifthenelseo` chooses the else branch from the original state when the
+  condition fails
+- `forallo` succeeds when every generated proof satisfies the test
+- `forallo` fails when any generated proof fails the test
+- `forallo` succeeds vacuously for an empty generator
+- advanced control helpers reject non-goals
+
+## Future Extensions
+
+Later control milestones can add:
+
+- scoped solver support for real Prolog cut
+- soft-cut variants
+- cleanup/finalization control such as `setup_call_cleanup`
+- bounded search helpers such as `limit` and `call_nth`
+
+## Summary
+
+LP14 gives the library enough control flow to express more realistic Prolog
+programs while keeping the implementation aligned with the current
+backtracking engine. It adds useful committed-choice and universal-check
+building blocks without pretending that the solver already has full cut.


### PR DESCRIPTION
## Summary
- add LP14 spec for advanced control builtins and the current cut boundary
- extend logic-builtins with trueo, failo, iftheno, ifthenelseo, and forallo
- document committed-condition semantics, forall binding discipline, and why real cut needs solver-level choicepoint pruning
- update package docs, changelog, version, and tests

## Testing
- cd code/packages/python/logic-builtins && bash BUILD
- cd code/packages/python/logic-builtins && .venv/bin/python -m ruff check src tests
- cd code/programs/go/build-tool && ./build-tool -language python -diff-base origin/main -root /Users/adhithya/Downloads/coding-adventures-worktrees/prolog-negation

## Security
- manual pre-push security scan found no risky Python APIs in the changed code
- no file, network, subprocess, deserialization, or dynamic-code execution APIs were added

## Note
- LP14 intentionally defers full Prolog cut until the solver has scoped choicepoint-pruning support; this PR only adds control predicates the current engine can model faithfully.