### PR TITLE
feat(benchmarks): add TCP RESP load generation

### DIFF
--- a/code/programs/go/benchmark-tool/CHANGELOG.md
+++ b/code/programs/go/benchmark-tool/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.3.0 - 2026-04-20
+
+- Add the phase-three TCP/RESP load generator inside `benchmark-tool`.
+- Start service subjects on allocated local TCP ports and wait for
+  `ready_check = "tcp-connect"` before loading them.
+- Execute `driver = "tcp-resp"` workloads with RESP frame-aware reads,
+  correctness validation, per-connection samples, and trial-level throughput
+  metrics.
+- Support one-shot, preconnect-then-fire, pipelined, and idle TCP workload
+  modes.
+- Add tests for RESP parsing, concurrent TCP load generation, pipelined
+  request validation, and service lifecycle startup.
+
 ## 0.2.0 - 2026-04-20
 
 - Add phase-two git-ref comparison groundwork for command benchmarks.

--- a/code/programs/go/benchmark-tool/README.md
+++ b/code/programs/go/benchmark-tool/README.md
@@ -19,14 +19,17 @@ The current implementation supports:
 - overriding subject checkouts with repeated `--subject name=ref` flags
 - preparing checkout-backed subjects in clean temporary git worktrees
 - pinning per-subject commit metadata in `subjects/<name>/subject.json`
+- starting local TCP service subjects with `ready_check = "tcp-connect"`
+- executing `driver = "tcp-resp"` workloads with RESP frame-aware reads
+- running one-shot, preconnect-then-fire, pipelined, and idle TCP modes
 - writing `samples.jsonl`, `trials.jsonl`, `summary.json`, `environment.json`,
   and `report.md`
 - regenerating reports from an existing result directory
 - comparing two result directories at a high level
 
-The TCP / RESP load generator described by `code/specs/benchmarking-tools.md`
-is the next layer. This tool already validates those manifests, but it only
-executes workloads whose driver is `command`.
+The TCP / RESP driver is intentionally correctness-first: every expected
+response must parse as complete RESP frames and match the manifest before a
+trial is considered successful.
 
 ## Usage
 
@@ -44,6 +47,7 @@ go build -o benchmark-tool .
 ./benchmark-tool doctor
 ./benchmark-tool validate ../../../benchmarks/examples/command/benchmark.toml
 ./benchmark-tool run ../../../benchmarks/examples/command/benchmark.toml --out /tmp/bench-result
+./benchmark-tool run ../../../benchmarks/mini-redis/benchmark.toml --out /tmp/mini-redis-bench
 ./benchmark-tool run ../../../benchmarks/examples/command/benchmark.toml \
   --subject current=HEAD \
   --subject baseline=origin/main \

--- a/code/programs/go/benchmark-tool/main.go
+++ b/code/programs/go/benchmark-tool/main.go
@@ -1,15 +1,12 @@
 // benchmark-tool is the repository's language-neutral benchmark runner.
 //
-// The first slice deliberately keeps the hot path simple:
+// The first slices deliberately keep the hot path simple:
 //   - read the benchmark manifest format from code/specs/benchmarking-tools.md
 //   - validate ambiguous benchmark definitions before they become folklore
 //   - run command-style subjects with warmup and measured trials
+//   - start local TCP service subjects and drive RESP-framed workloads
 //   - write raw samples, trial rows, environment metadata, summaries, and a
 //     Markdown report into one self-contained result directory
-//
-// TCP/RESP load generation is intentionally left for the next program slice.
-// This tool already validates those manifests so the contract can stabilize
-// before we teach a load generator to execute them.
 package main
 
 import (
@@ -23,6 +20,7 @@ import (
 	"io"
 	"math"
 	"math/rand"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -30,6 +28,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	_ "embed"
@@ -37,7 +36,24 @@ import (
 	clibuilder "github.com/adhithyan15/coding-adventures/code/packages/go/cli-builder"
 )
 
-const version = "0.2.0"
+const version = "0.3.0"
+
+const (
+	defaultTCPTimeout          = 10 * time.Second
+	serviceReadyTimeout        = 10 * time.Second
+	serviceReadyProbeTimeout   = 100 * time.Millisecond
+	maxTCPConnections          = 10000
+	maxTCPConcurrency          = 10000
+	maxTCPRequestsPerConn      = 10000
+	maxTCPFrameBytes           = 16 * 1024 * 1024
+	maxTCPPayloadBytes         = 16 * 1024 * 1024
+	respDriver                 = "tcp-resp"
+	respReadMode               = "resp-frame"
+	respModeOneShot            = "one-shot"
+	respModePreconnectThenFire = "preconnect-then-fire"
+	respModePipeline           = "pipeline"
+	respModeIdle               = "idle"
+)
 
 //go:embed benchmark-tool.json
 var cliSpec []byte
@@ -872,11 +888,47 @@ func ValidateManifest(m Manifest) error {
 		if w.Driver == "command" && w.ReadMode == "eof" && !w.ProtocolClosesAfterResponse {
 			problems = append(problems, where+" uses EOF reads without protocol_closes_after_response = true")
 		}
-		if strings.Contains(w.Driver, "resp") && w.ReadMode != "resp-frame" {
+		if w.Driver == respDriver {
+			mode := tcpWorkloadMode(w)
+			if w.ReadMode != respReadMode {
+				problems = append(problems, where+" must use read_mode = \"resp-frame\" for RESP workloads")
+			}
+			if mode != respModeIdle && w.Expect == "" {
+				problems = append(problems, where+".expect is required for RESP workloads")
+			}
+			if !isSupportedTCPRESPMode(mode) {
+				problems = append(problems, where+".mode must be one-shot, preconnect-then-fire, pipeline, or idle")
+			}
+			if w.Connections < 0 {
+				problems = append(problems, where+".connections must be non-negative")
+			}
+			if w.Connections > maxTCPConnections {
+				problems = append(problems, fmt.Sprintf("%s.connections must be <= %d", where, maxTCPConnections))
+			}
+			if w.Concurrency < 0 {
+				problems = append(problems, where+".concurrency must be non-negative")
+			}
+			if w.Concurrency > maxTCPConcurrency {
+				problems = append(problems, fmt.Sprintf("%s.concurrency must be <= %d", where, maxTCPConcurrency))
+			}
+			if w.RequestsPerConnection < 0 {
+				problems = append(problems, where+".requests_per_connection must be non-negative")
+			}
+			if w.RequestsPerConnection > maxTCPRequestsPerConn {
+				problems = append(problems, fmt.Sprintf("%s.requests_per_connection must be <= %d", where, maxTCPRequestsPerConn))
+			}
+			if len(w.Request) > maxTCPPayloadBytes {
+				problems = append(problems, fmt.Sprintf("%s.request must be <= %d bytes", where, maxTCPPayloadBytes))
+			}
+			if len(w.Expect) > maxTCPPayloadBytes {
+				problems = append(problems, fmt.Sprintf("%s.expect must be <= %d bytes", where, maxTCPPayloadBytes))
+			}
+			requestRepeats := tcpRequestsPerConnection(w)
+			if len(w.Request) > 0 && requestRepeats > maxTCPPayloadBytes/len(w.Request) {
+				problems = append(problems, fmt.Sprintf("%s repeated request payload must be <= %d bytes", where, maxTCPPayloadBytes))
+			}
+		} else if strings.Contains(w.Driver, "resp") && w.ReadMode != respReadMode {
 			problems = append(problems, where+" must use read_mode = \"resp-frame\" for RESP workloads")
-		}
-		if strings.Contains(w.Driver, "resp") && w.Expect == "" {
-			problems = append(problems, where+".expect is required for RESP workloads")
 		}
 		if w.TimeoutMS < 0 {
 			problems = append(problems, where+".timeout_ms must be non-negative")
@@ -948,14 +1000,39 @@ func RunManifest(manifestPath string, manifest Manifest, outDir string) error {
 				fmt.Fprintln(os.Stderr, "Build error:", err)
 			}
 		}
-		for _, workload := range manifest.Workloads {
-			if workload.Driver != "command" {
-				fmt.Fprintf(os.Stderr, "Skipping workload %s: driver %s is not implemented in phase one\n", workload.Name, workload.Driver)
-				continue
-			}
-			allTrials, err := runCommandWorkload(prepared, workload, manifest.Defaults, samplesFile, trialsFile)
+		var service *RunningService
+		if subjectNeedsTCPService(prepared.Subject, manifest.Workloads) {
+			var err error
+			service, err = startServiceSubject(prepared, subjectDir)
 			if err != nil {
 				if manifest.Defaults.FailFast {
+					return err
+				}
+				fmt.Fprintln(os.Stderr, "Service error:", err)
+				continue
+			}
+		}
+		for _, workload := range manifest.Workloads {
+			var allTrials []Trial
+			var err error
+			switch workload.Driver {
+			case "command":
+				allTrials, err = runCommandWorkload(prepared, workload, manifest.Defaults, samplesFile, trialsFile)
+			case respDriver:
+				if service == nil {
+					err = fmt.Errorf("workload %s requires a running service subject", workload.Name)
+				} else {
+					allTrials, err = runTCPRESPWorkload(prepared, workload, manifest.Defaults, service.Address, samplesFile, trialsFile)
+				}
+			default:
+				fmt.Fprintf(os.Stderr, "Skipping workload %s: driver %s is not implemented\n", workload.Name, workload.Driver)
+				continue
+			}
+			if err != nil {
+				if manifest.Defaults.FailFast {
+					if service != nil {
+						_ = service.Stop()
+					}
 					return err
 				}
 				fmt.Fprintln(os.Stderr, "Workload error:", err)
@@ -964,6 +1041,13 @@ func RunManifest(manifestPath string, manifest Manifest, outDir string) error {
 				if trial.Phase == "measurement" && trial.OK {
 					measured = append(measured, trial)
 				}
+			}
+		}
+		if service != nil {
+			if err := service.Stop(); err != nil && manifest.Defaults.FailFast {
+				return err
+			} else if err != nil {
+				fmt.Fprintln(os.Stderr, "Service cleanup error:", err)
 			}
 		}
 	}
@@ -1076,6 +1160,133 @@ func runBuild(subject PreparedSubject, subjectDir string) error {
 	return nil
 }
 
+type RunningService struct {
+	Command string
+	Address string
+	Port    int
+	cmd     *exec.Cmd
+	done    chan error
+	log     *os.File
+}
+
+func subjectNeedsTCPService(subject Subject, workloads []Workload) bool {
+	for _, workload := range workloads {
+		if workload.Driver == respDriver {
+			return subject.Kind == "service"
+		}
+	}
+	return false
+}
+
+func startServiceSubject(subject PreparedSubject, subjectDir string) (*RunningService, error) {
+	if subject.Subject.Kind != "service" {
+		return nil, fmt.Errorf("subject %s must be kind = service for TCP workloads", subject.Subject.Name)
+	}
+	if subject.Subject.ReadyCheck != "tcp-connect" {
+		return nil, fmt.Errorf("subject %s uses unsupported ready_check %q", subject.Subject.Name, subject.Subject.ReadyCheck)
+	}
+	port, err := allocateTCPPort()
+	if err != nil {
+		return nil, err
+	}
+	address := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+	command := strings.ReplaceAll(subject.Subject.Command, "{port}", strconv.Itoa(port))
+	workingDir := resolveSubjectWorkingDirectory(subject.Subject, subject.BenchmarkRoot)
+	logPath := filepath.Join(subjectDir, "service.log")
+	logFile, err := os.Create(logPath)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Fprintf(logFile, "command: %s\nworking_directory: %s\naddress: %s\n\n", command, workingDir, address)
+	cmd := shellCommand(command)
+	cmd.Dir = workingDir
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	if err := cmd.Start(); err != nil {
+		_ = logFile.Close()
+		return nil, err
+	}
+	service := &RunningService{
+		Command: command,
+		Address: address,
+		Port:    port,
+		cmd:     cmd,
+		done:    make(chan error, 1),
+		log:     logFile,
+	}
+	go func() {
+		service.done <- cmd.Wait()
+	}()
+	if err := waitForTCPReady(address, serviceReadyTimeout); err != nil {
+		_ = service.Stop()
+		return nil, fmt.Errorf("service %s did not become ready: %w", subject.Subject.Name, err)
+	}
+	return service, nil
+}
+
+func (s *RunningService) Stop() error {
+	if s == nil || s.cmd == nil {
+		return nil
+	}
+	var waitErr error
+	select {
+	case waitErr = <-s.done:
+	default:
+		if s.cmd.Process != nil {
+			if err := s.cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+				_ = s.log.Close()
+				return err
+			}
+		}
+		waitErr = <-s.done
+	}
+	if s.log != nil {
+		_, _ = fmt.Fprintf(s.log, "\nservice_exit: %v\n", waitErr)
+		if err := s.log.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func allocateTCPPort() (int, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer listener.Close()
+	addr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		return 0, fmt.Errorf("unexpected TCP listener address %T", listener.Addr())
+	}
+	return addr.Port, nil
+}
+
+func waitForTCPReady(address string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", address, serviceReadyProbeTimeout)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		lastErr = err
+		time.Sleep(25 * time.Millisecond)
+	}
+	if lastErr != nil {
+		return lastErr
+	}
+	return errors.New("readiness timeout")
+}
+
+func shellCommand(command string) *exec.Cmd {
+	if runtime.GOOS == "windows" {
+		return exec.Command("cmd", "/C", command)
+	}
+	return exec.Command("sh", "-c", command)
+}
+
 func runCommandWorkload(subject PreparedSubject, workload Workload, defaults Defaults, samplesFile, trialsFile *os.File) ([]Trial, error) {
 	var trials []Trial
 	total := defaults.WarmupTrials + defaults.MeasurementTrials
@@ -1128,6 +1339,523 @@ func runCommandWorkload(subject PreparedSubject, workload Workload, defaults Def
 		}
 	}
 	return trials, nil
+}
+
+type tcpRequestResult struct {
+	OK      bool
+	Metrics map[string]float64
+	Error   string
+}
+
+func runTCPRESPWorkload(subject PreparedSubject, workload Workload, defaults Defaults, address string, samplesFile, trialsFile *os.File) ([]Trial, error) {
+	expectedFrames, err := splitRESPFrames([]byte(workload.Expect))
+	if err != nil && tcpWorkloadMode(workload) != respModeIdle {
+		return nil, fmt.Errorf("parse expected RESP frames for workload %s: %w", workload.Name, err)
+	}
+	total := defaults.WarmupTrials + defaults.MeasurementTrials
+	trials := make([]Trial, 0, total)
+	for i := 0; i < total; i++ {
+		phase := "measurement"
+		trialNumber := i - defaults.WarmupTrials + 1
+		if i < defaults.WarmupTrials {
+			phase = "warmup"
+			trialNumber = i + 1
+		}
+		start := time.Now()
+		results := executeTCPRESPTrial(address, workload, expectedFrames)
+		elapsedMS := float64(time.Since(start).Microseconds()) / 1000.0
+		samples := tcpSamplesFromResults(subject.Subject.Name, workload.Name, trialNumber, phase, results)
+		trial := tcpTrialFromSamples(subject.Subject.Name, workload, trialNumber, phase, samples, elapsedMS)
+		for _, sample := range samples {
+			if err := writeJSONLine(samplesFile, sample); err != nil {
+				return trials, err
+			}
+		}
+		if err := writeJSONLine(trialsFile, trial); err != nil {
+			return trials, err
+		}
+		trials = append(trials, trial)
+		if defaults.CooldownMS > 0 {
+			time.Sleep(time.Duration(defaults.CooldownMS) * time.Millisecond)
+		}
+	}
+	return trials, nil
+}
+
+func executeTCPRESPTrial(address string, workload Workload, expectedFrames [][]byte) []tcpRequestResult {
+	mode := tcpWorkloadMode(workload)
+	timeout := tcpTimeout(workload)
+	connections := tcpConnections(workload)
+	concurrency := tcpConcurrency(workload, connections)
+	request := []byte(workload.Request)
+	switch mode {
+	case respModeOneShot:
+		return runTCPRESPParallel(connections, concurrency, func(_ int) tcpRequestResult {
+			return executeRESPDialExchange(address, request, expectedFrames, 1, timeout)
+		})
+	case respModePreconnectThenFire:
+		return executeRESPPreconnectThenFire(address, request, expectedFrames, connections, concurrency, timeout)
+	case respModePipeline:
+		repeats := tcpRequestsPerConnection(workload)
+		return runTCPRESPParallel(connections, concurrency, func(_ int) tcpRequestResult {
+			return executeRESPDialExchange(address, request, expectedFrames, repeats, timeout)
+		})
+	case respModeIdle:
+		return runTCPRESPParallel(connections, concurrency, func(_ int) tcpRequestResult {
+			return executeTCPIdle(address, timeout)
+		})
+	default:
+		return []tcpRequestResult{{
+			OK:      false,
+			Metrics: map[string]float64{},
+			Error:   "unsupported tcp-resp mode " + mode,
+		}}
+	}
+}
+
+func runTCPRESPParallel(total int, concurrency int, fn func(int) tcpRequestResult) []tcpRequestResult {
+	if total <= 0 {
+		return nil
+	}
+	if concurrency <= 0 || concurrency > total {
+		concurrency = total
+	}
+	results := make([]tcpRequestResult, total)
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
+	for i := 0; i < total; i++ {
+		sem <- struct{}{}
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			results[index] = fn(index)
+		}(i)
+	}
+	wg.Wait()
+	return results
+}
+
+type preconnectedRESPConn struct {
+	conn      net.Conn
+	connectMS float64
+	err       error
+}
+
+func executeRESPPreconnectThenFire(address string, request []byte, expectedFrames [][]byte, connections int, concurrency int, timeout time.Duration) []tcpRequestResult {
+	preconnected := make([]preconnectedRESPConn, connections)
+	connectResults := runTCPRESPParallel(connections, concurrency, func(index int) tcpRequestResult {
+		conn, connectMS, err := dialTCP(address, timeout)
+		if err != nil {
+			return tcpRequestResult{
+				OK:      false,
+				Metrics: map[string]float64{"connect_ms": connectMS},
+				Error:   err.Error(),
+			}
+		}
+		preconnected[index] = preconnectedRESPConn{conn: conn, connectMS: connectMS}
+		return tcpRequestResult{OK: true, Metrics: map[string]float64{"connect_ms": connectMS}}
+	})
+	results := runTCPRESPParallel(connections, concurrency, func(index int) tcpRequestResult {
+		entry := preconnected[index]
+		if entry.conn == nil {
+			return connectResults[index]
+		}
+		defer entry.conn.Close()
+		return executeRESPOnConn(entry.conn, request, expectedFrames, 1, timeout, entry.connectMS, time.Now())
+	})
+	return results
+}
+
+func executeRESPDialExchange(address string, request []byte, expectedFrames [][]byte, repeats int, timeout time.Duration) tcpRequestResult {
+	start := time.Now()
+	conn, connectMS, err := dialTCP(address, timeout)
+	if err != nil {
+		return tcpRequestResult{
+			OK:      false,
+			Metrics: map[string]float64{"connect_ms": connectMS, "total_ms": elapsedMillis(start)},
+			Error:   err.Error(),
+		}
+	}
+	defer conn.Close()
+	return executeRESPOnConn(conn, request, expectedFrames, repeats, timeout, connectMS, start)
+}
+
+func executeRESPOnConn(conn net.Conn, request []byte, expectedFrames [][]byte, repeats int, timeout time.Duration, connectMS float64, start time.Time) tcpRequestResult {
+	if repeats <= 0 {
+		repeats = 1
+	}
+	if err := conn.SetDeadline(time.Now().Add(timeout)); err != nil {
+		return tcpRequestResult{
+			OK:      false,
+			Metrics: map[string]float64{"connect_ms": connectMS, "total_ms": elapsedMillis(start)},
+			Error:   err.Error(),
+		}
+	}
+	payload := bytes.Repeat(request, repeats)
+	writeStart := time.Now()
+	if err := writeFull(conn, payload); err != nil {
+		return tcpRequestResult{
+			OK:      false,
+			Metrics: map[string]float64{"connect_ms": connectMS, "write_ms": elapsedMillis(writeStart), "total_ms": elapsedMillis(start)},
+			Error:   err.Error(),
+		}
+	}
+	writeMS := elapsedMillis(writeStart)
+	reader := bufio.NewReader(conn)
+	expectedCount := len(expectedFrames) * repeats
+	readStart := time.Now()
+	var firstByteMS float64
+	var frameMS float64
+	for i := 0; i < expectedCount; i++ {
+		if _, err := reader.Peek(1); err != nil {
+			return tcpRequestResult{
+				OK:      false,
+				Metrics: tcpMetrics(connectMS, writeMS, firstByteMS, frameMS, elapsedMillis(start), i),
+				Error:   err.Error(),
+			}
+		}
+		if i == 0 {
+			firstByteMS = elapsedMillis(readStart)
+		}
+		frameStart := time.Now()
+		frame, err := readRESPFrame(reader, maxTCPFrameBytes)
+		frameMS += elapsedMillis(frameStart)
+		if err != nil {
+			return tcpRequestResult{
+				OK:      false,
+				Metrics: tcpMetrics(connectMS, writeMS, firstByteMS, frameMS, elapsedMillis(start), i),
+				Error:   err.Error(),
+			}
+		}
+		expected := expectedFrames[i%len(expectedFrames)]
+		if !bytes.Equal(frame, expected) {
+			return tcpRequestResult{
+				OK:      false,
+				Metrics: tcpMetrics(connectMS, writeMS, firstByteMS, frameMS, elapsedMillis(start), i),
+				Error:   fmt.Sprintf("unexpected RESP frame %d: got %q want %q", i, string(frame), string(expected)),
+			}
+		}
+	}
+	operations := expectedCount
+	if operations == 0 {
+		operations = repeats
+	}
+	return tcpRequestResult{
+		OK:      true,
+		Metrics: tcpMetrics(connectMS, writeMS, firstByteMS, frameMS, elapsedMillis(start), operations),
+	}
+}
+
+func executeTCPIdle(address string, timeout time.Duration) tcpRequestResult {
+	start := time.Now()
+	conn, connectMS, err := dialTCP(address, timeout)
+	if err != nil {
+		return tcpRequestResult{
+			OK:      false,
+			Metrics: map[string]float64{"connect_ms": connectMS, "total_ms": elapsedMillis(start)},
+			Error:   err.Error(),
+		}
+	}
+	defer conn.Close()
+	hold := timeout
+	if hold > 100*time.Millisecond {
+		hold = 100 * time.Millisecond
+	}
+	time.Sleep(hold)
+	return tcpRequestResult{
+		OK:      true,
+		Metrics: map[string]float64{"connect_ms": connectMS, "total_ms": elapsedMillis(start), "operations": 1},
+	}
+}
+
+func dialTCP(address string, timeout time.Duration) (net.Conn, float64, error) {
+	start := time.Now()
+	conn, err := net.DialTimeout("tcp", address, timeout)
+	return conn, elapsedMillis(start), err
+}
+
+func writeFull(w io.Writer, data []byte) error {
+	for len(data) > 0 {
+		n, err := w.Write(data)
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return io.ErrShortWrite
+		}
+		data = data[n:]
+	}
+	return nil
+}
+
+func tcpSamplesFromResults(subject string, workload string, trialNumber int, phase string, results []tcpRequestResult) []Sample {
+	samples := make([]Sample, 0, len(results))
+	for _, result := range results {
+		samples = append(samples, Sample{
+			SampleKind: "tcp_request",
+			Subject:    subject,
+			Workload:   workload,
+			Trial:      trialNumber,
+			Phase:      phase,
+			OK:         result.OK,
+			Metrics:    result.Metrics,
+			Error:      result.Error,
+		})
+	}
+	return samples
+}
+
+func tcpTrialFromSamples(subject string, workload Workload, trialNumber int, phase string, samples []Sample, elapsedMS float64) Trial {
+	metrics := map[string]float64{
+		"elapsed_ms":  elapsedMS,
+		"connections": float64(tcpConnections(workload)),
+		"concurrency": float64(tcpConcurrency(workload, tcpConnections(workload))),
+	}
+	ok := true
+	var firstError string
+	var operations float64
+	var failed float64
+	values := map[string][]float64{}
+	for _, sample := range samples {
+		if !sample.OK {
+			ok = false
+			failed++
+			if firstError == "" {
+				firstError = sample.Error
+			}
+		}
+		if sample.Metrics != nil {
+			operations += sample.Metrics["operations"]
+			for metric, value := range sample.Metrics {
+				if metric == "operations" {
+					continue
+				}
+				values[metric] = append(values[metric], value)
+			}
+		}
+	}
+	metrics["operations"] = operations
+	metrics["failed_operations"] = failed
+	if elapsedMS > 0 {
+		metrics["ops_per_second"] = operations / (elapsedMS / 1000.0)
+	}
+	for metric, metricValues := range values {
+		sort.Float64s(metricValues)
+		metrics[metric] = percentile(metricValues, 50)
+	}
+	return Trial{
+		Subject:  subject,
+		Workload: workload.Name,
+		Trial:    trialNumber,
+		Phase:    phase,
+		OK:       ok,
+		Metrics:  metrics,
+		Error:    firstError,
+	}
+}
+
+func tcpMetrics(connectMS, writeMS, firstByteMS, frameMS, totalMS float64, operations int) map[string]float64 {
+	return map[string]float64{
+		"connect_ms":    connectMS,
+		"write_ms":      writeMS,
+		"first_byte_ms": firstByteMS,
+		"frame_ms":      frameMS,
+		"total_ms":      totalMS,
+		"operations":    float64(operations),
+	}
+}
+
+func tcpWorkloadMode(workload Workload) string {
+	if workload.Mode == "" {
+		return respModeOneShot
+	}
+	return workload.Mode
+}
+
+func isSupportedTCPRESPMode(mode string) bool {
+	switch mode {
+	case respModeOneShot, respModePreconnectThenFire, respModePipeline, respModeIdle:
+		return true
+	default:
+		return false
+	}
+}
+
+func tcpConnections(workload Workload) int {
+	if workload.Connections > 0 {
+		return workload.Connections
+	}
+	if workload.Operations > 0 {
+		return workload.Operations
+	}
+	return 1
+}
+
+func tcpConcurrency(workload Workload, connections int) int {
+	if workload.Concurrency > 0 {
+		if workload.Concurrency > connections {
+			return connections
+		}
+		return workload.Concurrency
+	}
+	return connections
+}
+
+func tcpRequestsPerConnection(workload Workload) int {
+	if workload.RequestsPerConnection > 0 {
+		return workload.RequestsPerConnection
+	}
+	return 1
+}
+
+func tcpTimeout(workload Workload) time.Duration {
+	if workload.TimeoutMS > 0 {
+		return time.Duration(workload.TimeoutMS) * time.Millisecond
+	}
+	return defaultTCPTimeout
+}
+
+func elapsedMillis(start time.Time) float64 {
+	return float64(time.Since(start).Microseconds()) / 1000.0
+}
+
+type respAccumulator struct {
+	bytes.Buffer
+	max int
+}
+
+func (a *respAccumulator) addByte(b byte) error {
+	if a.Len()+1 > a.max {
+		return errors.New("RESP frame exceeds maximum size")
+	}
+	return a.WriteByte(b)
+}
+
+func (a *respAccumulator) addBytes(data []byte) error {
+	if a.Len()+len(data) > a.max {
+		return errors.New("RESP frame exceeds maximum size")
+	}
+	_, err := a.Write(data)
+	return err
+}
+
+func readRESPFrame(reader *bufio.Reader, maxBytes int) ([]byte, error) {
+	acc := &respAccumulator{max: maxBytes}
+	if err := readRESPValue(reader, acc); err != nil {
+		return nil, err
+	}
+	return acc.Bytes(), nil
+}
+
+func readRESPValue(reader *bufio.Reader, acc *respAccumulator) error {
+	prefix, err := reader.ReadByte()
+	if err != nil {
+		return err
+	}
+	if err := acc.addByte(prefix); err != nil {
+		return err
+	}
+	switch prefix {
+	case '+', '-', ':':
+		_, err := readRESPLine(reader, acc)
+		return err
+	case '$':
+		line, err := readRESPLine(reader, acc)
+		if err != nil {
+			return err
+		}
+		length, err := strconv.Atoi(line)
+		if err != nil {
+			return fmt.Errorf("invalid RESP bulk string length %q", line)
+		}
+		if length < -1 {
+			return fmt.Errorf("invalid RESP bulk string length %d", length)
+		}
+		if length == -1 {
+			return nil
+		}
+		if length > acc.max-acc.Len()-2 {
+			return errors.New("RESP frame exceeds maximum size")
+		}
+		body := make([]byte, length+2)
+		if _, err := io.ReadFull(reader, body); err != nil {
+			return err
+		}
+		if len(body) < 2 || body[len(body)-2] != '\r' || body[len(body)-1] != '\n' {
+			return errors.New("RESP bulk string missing CRLF terminator")
+		}
+		return acc.addBytes(body)
+	case '*':
+		line, err := readRESPLine(reader, acc)
+		if err != nil {
+			return err
+		}
+		count, err := strconv.Atoi(line)
+		if err != nil {
+			return fmt.Errorf("invalid RESP array length %q", line)
+		}
+		if count < -1 {
+			return fmt.Errorf("invalid RESP array length %d", count)
+		}
+		if count > acc.max/3 {
+			return errors.New("RESP array exceeds maximum size")
+		}
+		for i := 0; i < count; i++ {
+			if err := readRESPValue(reader, acc); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("unknown RESP prefix %q", prefix)
+	}
+}
+
+func readRESPLine(reader *bufio.Reader, acc *respAccumulator) (string, error) {
+	var line []byte
+	for {
+		fragment, err := reader.ReadSlice('\n')
+		line = append(line, fragment...)
+		if acc.Len()+len(line) > acc.max {
+			return "", errors.New("RESP frame exceeds maximum size")
+		}
+		if err == nil {
+			break
+		}
+		if !errors.Is(err, bufio.ErrBufferFull) {
+			return "", err
+		}
+	}
+	if len(line) < 2 || line[len(line)-2] != '\r' || line[len(line)-1] != '\n' {
+		return "", errors.New("RESP line missing CRLF terminator")
+	}
+	if err := acc.addBytes(line); err != nil {
+		return "", err
+	}
+	return string(line[:len(line)-2]), nil
+}
+
+func splitRESPFrames(data []byte) ([][]byte, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	reader := bufio.NewReader(bytes.NewReader(data))
+	var frames [][]byte
+	for {
+		_, err := reader.Peek(1)
+		if errors.Is(err, io.EOF) {
+			return frames, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+		frame, err := readRESPFrame(reader, maxTCPFrameBytes)
+		if err != nil {
+			return nil, err
+		}
+		frames = append(frames, frame)
+	}
 }
 
 type commandResult struct {

--- a/code/programs/go/benchmark-tool/main_test.go
+++ b/code/programs/go/benchmark-tool/main_test.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"errors"
 	"math"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -84,6 +86,44 @@ func TestValidateRejectsRespWithoutFrameReads(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsUnsafeTCPRESPShapes(t *testing.T) {
+	manifest := validTinyManifest()
+	manifest.Subjects[0].Kind = "service"
+	manifest.Subjects[0].ReadyCheck = "tcp-connect"
+	manifest.Workloads[0] = Workload{
+		Name:                  "bad-resp",
+		Driver:                respDriver,
+		Mode:                  "warp-speed",
+		ReadMode:              respReadMode,
+		Request:               strings.Repeat("x", maxTCPPayloadBytes+1),
+		Expect:                "+PONG\r\n",
+		Connections:           maxTCPConnections + 1,
+		Concurrency:           maxTCPConcurrency + 1,
+		RequestsPerConnection: maxTCPRequestsPerConn + 1,
+	}
+
+	err := ValidateManifest(manifest)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	for _, want := range []string{"mode", "connections", "concurrency", "requests_per_connection", "request"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("validation error should mention %s: %v", want, err)
+		}
+	}
+
+	manifest.Workloads[0] = Workload{
+		Name:      "idle",
+		Driver:    respDriver,
+		Mode:      respModeIdle,
+		ReadMode:  respReadMode,
+		TimeoutMS: 10,
+	}
+	if err := ValidateManifest(manifest); err != nil {
+		t.Fatalf("idle RESP workload should not require expect: %v", err)
+	}
+}
+
 func TestValidateRejectsEOFReadsWithoutProtocolClose(t *testing.T) {
 	manifest := validTinyManifest()
 	manifest.Workloads[0].ReadMode = "eof"
@@ -135,6 +175,188 @@ func TestRunCommandManifestWritesBenchmarkArtifacts(t *testing.T) {
 	trials := readLinesForTest(t, filepath.Join(resultDir, "trials.jsonl"))
 	if len(trials) != 3 {
 		t.Fatalf("expected 3 trials including warmup, got %d", len(trials))
+	}
+}
+
+func TestRunTCPRESPWorkloadsAgainstLocalServer(t *testing.T) {
+	address := startRESPTestServer(t)
+	dir := t.TempDir()
+	samplesPath := filepath.Join(dir, "samples.jsonl")
+	trialsPath := filepath.Join(dir, "trials.jsonl")
+	samplesFile, err := os.Create(samplesPath)
+	if err != nil {
+		t.Fatalf("create samples: %v", err)
+	}
+	defer samplesFile.Close()
+	trialsFile, err := os.Create(trialsPath)
+	if err != nil {
+		t.Fatalf("create trials: %v", err)
+	}
+	defer trialsFile.Close()
+	subject := PreparedSubject{Subject: Subject{Name: "resp-server"}}
+	defaults := Defaults{WarmupTrials: 0, MeasurementTrials: 1, CooldownMS: 0, FailFast: true}
+
+	workloads := []Workload{
+		{
+			Name:        "one-shot",
+			Driver:      respDriver,
+			Mode:        respModeOneShot,
+			ReadMode:    respReadMode,
+			Request:     "*1\r\n$4\r\nPING\r\n",
+			Expect:      "+PONG\r\n",
+			Connections: 16,
+			Concurrency: 8,
+			TimeoutMS:   2000,
+		},
+		{
+			Name:        "preconnect",
+			Driver:      respDriver,
+			Mode:        respModePreconnectThenFire,
+			ReadMode:    respReadMode,
+			Request:     "*1\r\n$4\r\nPING\r\n",
+			Expect:      "+PONG\r\n",
+			Connections: 16,
+			Concurrency: 8,
+			TimeoutMS:   2000,
+		},
+		{
+			Name:                  "pipeline",
+			Driver:                respDriver,
+			Mode:                  respModePipeline,
+			ReadMode:              respReadMode,
+			Request:               "*3\r\n$3\r\nSET\r\n$3\r\nkey\r\n$5\r\nvalue\r\n*2\r\n$3\r\nGET\r\n$3\r\nkey\r\n",
+			Expect:                "+OK\r\n$5\r\nvalue\r\n",
+			Connections:           4,
+			Concurrency:           2,
+			RequestsPerConnection: 5,
+			TimeoutMS:             2000,
+		},
+	}
+	for _, workload := range workloads {
+		trials, err := runTCPRESPWorkload(subject, workload, defaults, address, samplesFile, trialsFile)
+		if err != nil {
+			t.Fatalf("run %s: %v", workload.Name, err)
+		}
+		if len(trials) != 1 {
+			t.Fatalf("%s trial count = %d", workload.Name, len(trials))
+		}
+		if !trials[0].OK {
+			t.Fatalf("%s trial failed: %#v", workload.Name, trials[0])
+		}
+		if trials[0].Metrics["ops_per_second"] <= 0 {
+			t.Fatalf("%s should report throughput: %#v", workload.Name, trials[0].Metrics)
+		}
+	}
+	if lines := readLinesForTest(t, samplesPath); len(lines) < 36 {
+		t.Fatalf("expected per-connection samples, got %d", len(lines))
+	}
+}
+
+func TestTCPRESPWorkloadFailsWrongResponsesAndSupportsIdle(t *testing.T) {
+	address := startRESPTestServer(t)
+	dir := t.TempDir()
+	samplesFile, err := os.Create(filepath.Join(dir, "samples.jsonl"))
+	if err != nil {
+		t.Fatalf("create samples: %v", err)
+	}
+	defer samplesFile.Close()
+	trialsFile, err := os.Create(filepath.Join(dir, "trials.jsonl"))
+	if err != nil {
+		t.Fatalf("create trials: %v", err)
+	}
+	defer trialsFile.Close()
+	subject := PreparedSubject{Subject: Subject{Name: "resp-server"}}
+	defaults := Defaults{WarmupTrials: 0, MeasurementTrials: 1, CooldownMS: 0, FailFast: true}
+
+	wrong := Workload{
+		Name:        "wrong",
+		Driver:      respDriver,
+		Mode:        respModeOneShot,
+		ReadMode:    respReadMode,
+		Request:     "*1\r\n$4\r\nPING\r\n",
+		Expect:      "+NOPE\r\n",
+		Connections: 2,
+		Concurrency: 2,
+		TimeoutMS:   2000,
+	}
+	trials, err := runTCPRESPWorkload(subject, wrong, defaults, address, samplesFile, trialsFile)
+	if err != nil {
+		t.Fatalf("wrong response run should produce failed trial, not harness error: %v", err)
+	}
+	if len(trials) != 1 || trials[0].OK {
+		t.Fatalf("expected failed correctness trial: %#v", trials)
+	}
+	if trials[0].Metrics["failed_operations"] == 0 {
+		t.Fatalf("expected failed operation metric: %#v", trials[0].Metrics)
+	}
+
+	idle := Workload{
+		Name:        "idle",
+		Driver:      respDriver,
+		Mode:        respModeIdle,
+		ReadMode:    respReadMode,
+		Connections: 2,
+		Concurrency: 2,
+		TimeoutMS:   20,
+	}
+	trials, err = runTCPRESPWorkload(subject, idle, defaults, address, samplesFile, trialsFile)
+	if err != nil {
+		t.Fatalf("idle run: %v", err)
+	}
+	if len(trials) != 1 || !trials[0].OK {
+		t.Fatalf("expected successful idle trial: %#v", trials)
+	}
+}
+
+func TestRunManifestStartsTCPServiceSubject(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go is required for service lifecycle tests")
+	}
+	dir := t.TempDir()
+	resultDir := filepath.Join(dir, "results")
+	writeFileForTest(t, filepath.Join(dir, "resp_server.go"), respServerProgramForTest())
+	writeFileForTest(t, filepath.Join(dir, "benchmark.toml"), tcpServiceManifestText(dir))
+	manifestPath := filepath.Join(dir, "benchmark.toml")
+	manifest, err := LoadManifest(manifestPath)
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	if err := ValidateManifest(manifest); err != nil {
+		t.Fatalf("manifest should validate: %v", err)
+	}
+	if err := RunManifest(manifestPath, manifest, resultDir); err != nil {
+		t.Fatalf("run manifest: %v", err)
+	}
+	summary := readSummaryForTest(t, filepath.Join(resultDir, "summary.json"))
+	if !hasSummaryMetric(summary, "ops_per_second") {
+		t.Fatalf("expected TCP throughput summary, got %#v", summary.Summaries)
+	}
+	if !hasSummaryMetric(summary, "first_byte_ms") {
+		t.Fatalf("expected TCP latency summary, got %#v", summary.Summaries)
+	}
+	if _, err := os.Stat(filepath.Join(resultDir, "subjects", "resp-service", "service.log")); err != nil {
+		t.Fatalf("expected service log: %v", err)
+	}
+}
+
+func TestRESPFrameParsingHandlesNestedFramesAndLimits(t *testing.T) {
+	frames, err := splitRESPFrames([]byte("+OK\r\n$5\r\nvalue\r\n*2\r\n$3\r\nGET\r\n$3\r\nkey\r\n"))
+	if err != nil {
+		t.Fatalf("split RESP frames: %v", err)
+	}
+	if len(frames) != 3 {
+		t.Fatalf("frame count = %d", len(frames))
+	}
+	if string(frames[2]) != "*2\r\n$3\r\nGET\r\n$3\r\nkey\r\n" {
+		t.Fatalf("nested frame = %q", string(frames[2]))
+	}
+	_, err = readRESPFrame(bufioReaderForTest("$20\r\nshort\r\n"), 8)
+	if err == nil {
+		t.Fatal("expected max frame size error")
+	}
+	_, err = readRESPFrame(bufioReaderForTest("+missing-lf"), maxTCPFrameBytes)
+	if err == nil {
+		t.Fatal("expected malformed frame error")
 	}
 }
 
@@ -539,6 +761,181 @@ name = "go-version"
 driver = "command"
 operations = 1
 timeout_ms = 10000
+`
+}
+
+func tcpServiceManifestText(dir string) string {
+	return `name = "tcp-service-benchmark"
+
+[defaults]
+warmup_trials = 0
+measurement_trials = 1
+cooldown_ms = 0
+fail_fast = true
+
+[[subjects]]
+name = "resp-service"
+kind = "service"
+prebuilt = true
+working_directory = "` + escapeManifestStringForTest(dir) + `"
+command = "go run resp_server.go --port {port}"
+ready_check = "tcp-connect"
+
+[[workloads]]
+name = "ping"
+driver = "tcp-resp"
+mode = "one-shot"
+read_mode = "resp-frame"
+request = "*1\r\n$4\r\nPING\r\n"
+expect = "+PONG\r\n"
+connections = 8
+concurrency = 4
+timeout_ms = 5000
+`
+}
+
+func escapeManifestStringForTest(value string) string {
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	return strings.ReplaceAll(value, `"`, `\"`)
+}
+
+func startRESPTestServer(t *testing.T) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go handleRESPTestConn(conn)
+		}
+	}()
+	return listener.Addr().String()
+}
+
+func handleRESPTestConn(conn net.Conn) {
+	defer conn.Close()
+	reader := bufio.NewReader(conn)
+	for {
+		frame, err := readRESPFrame(reader, maxTCPFrameBytes)
+		if err != nil {
+			return
+		}
+		text := string(frame)
+		switch {
+		case strings.Contains(text, "$4\r\nPING\r\n"):
+			_, _ = conn.Write([]byte("+PONG\r\n"))
+		case strings.Contains(text, "$3\r\nSET\r\n"):
+			_, _ = conn.Write([]byte("+OK\r\n"))
+		case strings.Contains(text, "$3\r\nGET\r\n"):
+			_, _ = conn.Write([]byte("$5\r\nvalue\r\n"))
+		default:
+			_, _ = conn.Write([]byte("-ERR unknown command\r\n"))
+		}
+	}
+}
+
+func bufioReaderForTest(input string) *bufio.Reader {
+	return bufio.NewReader(strings.NewReader(input))
+}
+
+func respServerProgramForTest() string {
+	return `package main
+
+import (
+	"bufio"
+	"flag"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+)
+
+func main() {
+	port := flag.String("port", "0", "port")
+	flag.Parse()
+	listener, err := net.Listen("tcp", "127.0.0.1:"+*port)
+	if err != nil {
+		panic(err)
+	}
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		go handle(conn)
+	}
+}
+
+func handle(conn net.Conn) {
+	defer conn.Close()
+	reader := bufio.NewReader(conn)
+	for {
+		frame, err := readFrame(reader)
+		if err != nil {
+			return
+		}
+		if strings.Contains(string(frame), "$4\r\nPING\r\n") {
+			_, _ = conn.Write([]byte("+PONG\r\n"))
+		} else {
+			_, _ = conn.Write([]byte("-ERR unknown command\r\n"))
+		}
+	}
+}
+
+func readFrame(reader *bufio.Reader) ([]byte, error) {
+	var b strings.Builder
+	prefix, err := reader.ReadByte()
+	if err != nil {
+		return nil, err
+	}
+	b.WriteByte(prefix)
+	switch prefix {
+	case '+', '-', ':':
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		b.WriteString(line)
+	case '$':
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		b.WriteString(line)
+		length, err := strconv.Atoi(strings.TrimSuffix(line, "\r\n"))
+		if err != nil || length < 0 {
+			return []byte(b.String()), err
+		}
+		body := make([]byte, length+2)
+		_, err = io.ReadFull(reader, body)
+		b.WriteString(string(body))
+		return []byte(b.String()), err
+	case '*':
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		b.WriteString(line)
+		count, err := strconv.Atoi(strings.TrimSuffix(line, "\r\n"))
+		if err != nil {
+			return nil, err
+		}
+		for i := 0; i < count; i++ {
+			nested, err := readFrame(reader)
+			if err != nil {
+				return nil, err
+			}
+			b.WriteString(string(nested))
+		}
+	}
+	return []byte(b.String()), nil
+}
 `
 }
 

--- a/code/specs/benchmarking-tools.md
+++ b/code/specs/benchmarking-tools.md
@@ -655,8 +655,8 @@ surface before the full TCP benchmark surface:
   the tool can be run locally from any directory.
 - `validate` currently validates benchmark manifests. Result-directory schema
   validation remains future work.
-- `run` currently executes `driver = "command"` workloads and validates, but
-  skips, TCP/RESP workloads until the load generator lands.
+- `run` initially executed only `driver = "command"` workloads. Phase three
+  adds service startup and the first TCP/RESP workload driver.
 - The initial implemented run flags were `--out`, `--trials`, and `--warmup`.
   Phase two adds subject checkout overrides and focused subject/workload
   filters. Seeds, build reuse, and CLI-level fail-fast overrides remain future
@@ -680,6 +680,26 @@ benchmarks:
   logs remain in `subjects/<name>/build.log`.
 - Randomized or paired trial ordering and richer in-result comparison reports
   remain future work.
+
+### Phase-Three Implementation Note
+
+The first TCP load-generation slice is implemented directly inside
+`benchmark-tool` so the Mini Redis manifest can run locally and in CI without a
+second binary yet:
+
+- Service subjects allocate a loopback TCP port, replace `{port}` in the
+  subject command, write `subjects/<name>/service.log`, and wait for
+  `ready_check = "tcp-connect"`.
+- `driver = "tcp-resp"` supports `one-shot`, `preconnect-then-fire`,
+  `pipeline`, and `idle` modes.
+- RESP reads are frame-aware. The client parses complete RESP values, validates
+  them against the manifest's expected frames, and marks the trial failed if any
+  response is malformed or wrong.
+- Per-connection samples include connect, write, first-byte, frame, total, and
+  operation metrics; trial summaries include throughput and median client-side
+  phase timings.
+- The standalone `benchmark-load-tcp` binary remains a future extraction point
+  once the protocol and result contracts settle.
 
 ---
 

--- a/lessons.md
+++ b/lessons.md
@@ -4,15 +4,32 @@ This file tracks mistakes made during development so they are not repeated. Chec
 
 ---
 
+### 2026-04-20: Do not leak local machine state in commits or PR descriptions
+
+CI fixes sometimes involve local environment problems, but commit messages and
+PR descriptions are permanent project history. They should explain the portable
+engineering lesson without naming private paths, host setup details, account
+state, or other machine-specific facts that do not belong in the repository.
+
+**Symptom:** A fix message or PR description mentions a developer workstation
+condition instead of the general failure mode that future contributors need to
+understand.
+
+**Rule:** Write history in terms of reproducible repository behavior. If a
+local detail helped diagnose the issue, translate it into a general rule before
+committing or opening the PR.
+
+---
+
 ### 2026-04-20: Tests that need a CLI tool must verify the tool actually runs
 
-Checking `exec.LookPath("git")` only proves that a binary exists on `PATH`. On
-macOS, `/usr/bin/git` can exist but fail every invocation behind the Xcode
-license gate, which makes tests fail after they already decided Git was
+Checking `exec.LookPath("git")` only proves that a binary exists on `PATH`. A
+tool can still fail every invocation because of host configuration, permissions,
+or setup policy, which makes tests fail after they already decided the tool was
 available.
 
-**Symptom:** A test guarded by `exec.LookPath("git")` still fails at `git init`
-with an Xcode license error.
+**Symptom:** A test guarded by `exec.LookPath("git")` still fails at the first
+real Git command.
 
 **Rule:** Tests that depend on an external CLI should run a harmless probe such
 as `git --version` and skip when that command fails. Presence is not usability.


### PR DESCRIPTION
## Summary

- Add phase-three TCP/RESP load generation to `benchmark-tool`.
- Start service subjects on allocated loopback ports with `ready_check = "tcp-connect"`.
- Execute RESP workloads with frame-aware reads, correctness validation, per-connection samples, and trial throughput metrics.
- Document the implementation slice and update lessons to keep machine-specific details out of durable project history.

## Validation

- `go test ./... -count=1 -v -cover` (`80.7%` statement coverage)
- `go vet ./...`
- `go build -o benchmark-tool .`
- `./benchmark-tool validate ../../../benchmarks/mini-redis/benchmark.toml`
- `git diff --check`
- Mini Redis smoke: `./benchmark-tool run ../../../benchmarks/mini-redis/benchmark.toml --out /tmp/mini-redis-bench-smoke --warmup 0 --trials 1 --subjects current --workloads redis-ping-1000` completed with `ok=true` and `failed_operations=0`