### PR TITLE
feat(state-machine): import executable definitions

### DIFF
--- a/code/packages/rust/state-machine-markup-deserializer/CHANGELOG.md
+++ b/code/packages/rust/state-machine-markup-deserializer/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this package will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- Extended serializer/deserializer round-trip tests to reconstruct executable
+  DFA, NFA, and PDA machines from parsed `StateMachineDefinition` values.
+
 ## [0.1.0] - 2026-04-20
 
 ### Added

--- a/code/packages/rust/state-machine-markup-deserializer/tests/toml_test.rs
+++ b/code/packages/rust/state-machine-markup-deserializer/tests/toml_test.rs
@@ -54,8 +54,10 @@ fn dfa_serializer_output_round_trips_through_deserializer() {
     let definition = dfa.to_definition("turnstile");
     let toml = definition.to_states_toml();
     let parsed = from_states_toml(&toml).unwrap();
+    let imported = DFA::from_definition(&parsed).unwrap();
 
     assert_eq!(parsed.to_states_toml(), toml);
+    assert!(imported.accepts(&["coin"]));
 }
 
 #[test]
@@ -76,8 +78,11 @@ fn nfa_serializer_output_round_trips_with_epsilon_and_multiple_targets() {
     let definition = nfa.to_definition("contains-ab");
     let toml = definition.to_states_toml();
     let parsed = from_states_toml(&toml).unwrap();
+    let imported = NFA::from_definition(&parsed).unwrap();
 
     assert_eq!(parsed.to_states_toml(), toml);
+    assert!(imported.accepts(&["a", "b"]));
+    assert!(imported.accepts(&["a", "a", "b"]));
 }
 
 #[test]
@@ -118,8 +123,11 @@ fn pda_serializer_output_round_trips_with_stack_effects() {
     let definition = pda.to_definition("balanced-parens");
     let toml = definition.to_states_toml();
     let parsed = from_states_toml(&toml).unwrap();
+    let imported = PushdownAutomaton::from_definition(&parsed).unwrap();
 
     assert_eq!(parsed.to_states_toml(), toml);
+    assert!(imported.accepts(&["(", ")"]));
+    assert!(!imported.accepts(&["("]));
 }
 
 #[test]

--- a/code/packages/rust/state-machine/CHANGELOG.md
+++ b/code/packages/rust/state-machine/CHANGELOG.md
@@ -16,7 +16,8 @@ All notable changes to the `state-machine` crate will be documented in this file
 - Added tests covering DFA, NFA, PDA, epsilon, multi-target, and stack-effect
   definition export behavior.
 - Added definition import tests covering language preservation and rejection of
-  invalid machine-kind, transition-target, epsilon, and stack-effect shapes.
+  invalid machine-kind, transition-target, epsilon, empty-event, and
+  stack-effect shapes.
 
 ### Changed
 

--- a/code/packages/rust/state-machine/CHANGELOG.md
+++ b/code/packages/rust/state-machine/CHANGELOG.md
@@ -11,8 +11,12 @@ All notable changes to the `state-machine` crate will be documented in this file
 - Added export helpers for manually constructed DFAs, NFAs, and PDAs so they can
   feed the build-time state-machine compiler pipeline without runtime text
   loading.
+- Added import helpers for `DFA`, `NFA`, and `PushdownAutomaton` so validated
+  typed definitions can be reconstructed as executable machines.
 - Added tests covering DFA, NFA, PDA, epsilon, multi-target, and stack-effect
   definition export behavior.
+- Added definition import tests covering language preservation and rejection of
+  invalid machine-kind, transition-target, epsilon, and stack-effect shapes.
 
 ### Changed
 

--- a/code/packages/rust/state-machine/README.md
+++ b/code/packages/rust/state-machine/README.md
@@ -102,14 +102,14 @@ cargo test -p state-machine -- --nocapture
 
 ## Test coverage
 
-254 tests across unit and integration test suites:
+255 tests across unit and integration test suites:
 - **types**: 6 unit tests
 - **dfa**: 22 unit + 52 integration tests
 - **nfa**: 18 unit + 41 integration tests
 - **minimize**: 5 unit + 8 integration tests
 - **pda**: 17 unit + 33 integration tests
 - **modal**: 13 unit + 23 integration tests
-- **definitions**: 17 integration tests
+- **definitions**: 18 integration tests
 
 Classic examples tested: turnstile, binary divisibility-by-3, 2-bit branch predictor,
 balanced parentheses PDA, a^n b^n PDA, HTML tokenizer modal machine.

--- a/code/packages/rust/state-machine/README.md
+++ b/code/packages/rust/state-machine/README.md
@@ -27,11 +27,12 @@ The 2-bit branch predictor (D02) is a DFA. The CPU pipeline (D04) is a linear DF
 Regex engines convert patterns to NFAs, then to DFAs via subset construction.
 Parsers use PDAs. HTML tokenizers use modal state machines.
 
-The `definitions` module is the bridge from hand-built machines to the
+The `definitions` module is the bridge between hand-built machines and the
 build-time compiler pipeline. It exports deterministic snapshots of DFAs, NFAs,
-and PDAs as `StateMachineDefinition` values. File formats such as State Machine
-Markup live in sibling serializer/deserializer crates, so this runtime crate
-stays focused on executable automata and typed definitions.
+and PDAs as `StateMachineDefinition` values, and imports validated definitions
+back into executable machines. File formats such as State Machine Markup live in
+sibling serializer/deserializer crates, so this runtime crate stays focused on
+executable automata and typed definitions.
 
 ## Usage
 
@@ -80,13 +81,18 @@ let turnstile = DFA::new(
 ).unwrap();
 
 let definition = turnstile.to_definition("turnstile");
+let imported = DFA::from_definition(&definition).unwrap();
+
 assert_eq!(definition.kind.as_str(), "dfa");
 assert_eq!(definition.initial.as_deref(), Some("locked"));
+assert!(imported.accepts(&["coin"]));
 ```
 
 Use the sibling `state-machine-markup-serializer` crate when you want to turn a
-definition into `.states.toml` text. Future deserializers will perform the
-opposite conversion and hand this crate typed definitions, not raw files.
+definition into `.states.toml` text. Use the sibling
+`state-machine-markup-deserializer` crate when tooling needs to read TOML back
+into a typed definition before calling `DFA::from_definition`,
+`NFA::from_definition`, or `PushdownAutomaton::from_definition`.
 
 ## Building and testing
 
@@ -96,13 +102,14 @@ cargo test -p state-machine -- --nocapture
 
 ## Test coverage
 
-240 tests across unit and integration test suites:
+254 tests across unit and integration test suites:
 - **types**: 6 unit tests
 - **dfa**: 22 unit + 52 integration tests
 - **nfa**: 18 unit + 41 integration tests
 - **minimize**: 5 unit + 8 integration tests
 - **pda**: 17 unit + 33 integration tests
 - **modal**: 13 unit + 23 integration tests
+- **definitions**: 17 integration tests
 
 Classic examples tested: turnstile, binary divisibility-by-3, 2-bit branch predictor,
 balanced parentheses PDA, a^n b^n PDA, HTML tokenizer modal machine.

--- a/code/packages/rust/state-machine/src/definitions.rs
+++ b/code/packages/rust/state-machine/src/definitions.rs
@@ -247,10 +247,19 @@ impl NFA {
                     transition.from
                 ));
             }
-            let event = transition.on.clone().unwrap_or_else(|| EPSILON.to_string());
-            if event != EPSILON {
-                ensure_known_event(&alphabet, &event)?;
-            }
+            let event = match &transition.on {
+                Some(event) if event.is_empty() => {
+                    return Err(
+                        "NFA transition events must use None for epsilon, not an empty string"
+                            .into(),
+                    )
+                }
+                Some(event) => {
+                    ensure_known_event(&alphabet, event)?;
+                    event.clone()
+                }
+                None => EPSILON.to_string(),
+            };
             let key = (transition.from.clone(), event);
             transitions
                 .entry(key)

--- a/code/packages/rust/state-machine/src/definitions.rs
+++ b/code/packages/rust/state-machine/src/definitions.rs
@@ -12,11 +12,11 @@
 //! jobs belong to sibling serializer, deserializer, and compiler crates so the
 //! core state-machine library stays format-agnostic.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use crate::dfa::DFA;
 use crate::nfa::{EPSILON, NFA};
-use crate::pda::PushdownAutomaton;
+use crate::pda::{PDATransition, PushdownAutomaton};
 
 /// Machine families supported by the shared definition model.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -161,6 +161,42 @@ impl DFA {
         definition.transitions = transitions;
         definition
     }
+
+    /// Import a typed DFA definition into an executable DFA.
+    ///
+    /// This is deliberately not a file-loading API.  TOML, JSON, SCXML, and
+    /// future markup readers live in sibling crates; the core crate only
+    /// accepts typed data that has already crossed those parsing boundaries.
+    /// We still validate the DFA-specific shape here because a definition can
+    /// also be built by hand or produced by another language port.
+    pub fn from_definition(definition: &StateMachineDefinition) -> Result<Self, String> {
+        expect_kind(definition, MachineKind::Dfa)?;
+        let (states, initial, accepting) = state_sets(definition)?;
+        let alphabet = unique_string_set("alphabet", &definition.alphabet)?;
+        if !definition.stack_alphabet.is_empty() || definition.initial_stack.is_some() {
+            return Err("DFA definitions must not declare stack alphabet or initial stack".into());
+        }
+
+        let mut transitions = HashMap::new();
+        for transition in &definition.transitions {
+            ensure_transition_states(&states, transition)?;
+            reject_stack_effects("DFA", transition)?;
+            let event = transition.on.clone().ok_or_else(|| {
+                "DFA definitions must not contain epsilon transitions".to_string()
+            })?;
+            ensure_known_event(&alphabet, &event)?;
+            let target = single_target("DFA", transition)?;
+            let key = (transition.from.clone(), event);
+            if transitions.insert(key.clone(), target).is_some() {
+                return Err(format!(
+                    "DFA definition has duplicate transition for ({}, {})",
+                    key.0, key.1
+                ));
+            }
+        }
+
+        DFA::new(states, alphabet, transitions, initial, accepting)
+    }
 }
 
 impl NFA {
@@ -186,6 +222,43 @@ impl NFA {
         }
         definition.transitions = transitions;
         definition
+    }
+
+    /// Import a typed NFA definition into an executable NFA.
+    ///
+    /// Repeated `(from, on)` entries are intentionally merged into one target
+    /// set.  That matches the mathematical transition function, where an NFA
+    /// maps a source/event pair to a set of possible next states.
+    pub fn from_definition(definition: &StateMachineDefinition) -> Result<Self, String> {
+        expect_kind(definition, MachineKind::Nfa)?;
+        let (states, initial, accepting) = state_sets(definition)?;
+        let alphabet = unique_string_set("alphabet", &definition.alphabet)?;
+        if !definition.stack_alphabet.is_empty() || definition.initial_stack.is_some() {
+            return Err("NFA definitions must not declare stack alphabet or initial stack".into());
+        }
+
+        let mut transitions: HashMap<(String, String), HashSet<String>> = HashMap::new();
+        for transition in &definition.transitions {
+            ensure_transition_states(&states, transition)?;
+            reject_stack_effects("NFA", transition)?;
+            if transition.to.is_empty() {
+                return Err(format!(
+                    "NFA transition from '{}' must have at least one target",
+                    transition.from
+                ));
+            }
+            let event = transition.on.clone().unwrap_or_else(|| EPSILON.to_string());
+            if event != EPSILON {
+                ensure_known_event(&alphabet, &event)?;
+            }
+            let key = (transition.from.clone(), event);
+            transitions
+                .entry(key)
+                .or_default()
+                .extend(transition.to.iter().cloned());
+        }
+
+        NFA::new(states, alphabet, transitions, initial, accepting)
     }
 }
 
@@ -213,6 +286,61 @@ impl PushdownAutomaton {
         definition.transitions = transitions;
         definition
     }
+
+    /// Import a typed PDA definition into an executable deterministic PDA.
+    ///
+    /// PDA imports are stricter than plain construction because this boundary
+    /// often receives data from serializer/deserializer tooling.  We validate
+    /// every event and stack symbol before building the runtime transition
+    /// index, so malformed definitions cannot hide behind unused transitions.
+    pub fn from_definition(definition: &StateMachineDefinition) -> Result<Self, String> {
+        expect_kind(definition, MachineKind::Pda)?;
+        let (states, initial, accepting) = state_sets(definition)?;
+        let alphabet = unique_string_set("alphabet", &definition.alphabet)?;
+        let stack_alphabet = unique_string_set("stack_alphabet", &definition.stack_alphabet)?;
+        let initial_stack = definition
+            .initial_stack
+            .clone()
+            .ok_or_else(|| "PDA definitions must declare initial_stack".to_string())?;
+        ensure_known_stack_symbol("initial_stack", &stack_alphabet, &initial_stack)?;
+
+        let mut transitions = Vec::new();
+        for transition in &definition.transitions {
+            ensure_transition_states(&states, transition)?;
+            let target = single_target("PDA", transition)?;
+            if let Some(event) = &transition.on {
+                ensure_known_event(&alphabet, event)?;
+            }
+            let stack_read = transition.stack_pop.clone().ok_or_else(|| {
+                format!(
+                    "PDA transition from '{}' on '{}' must declare stack_pop",
+                    transition.from,
+                    event_label(transition)
+                )
+            })?;
+            ensure_known_stack_symbol("stack_pop", &stack_alphabet, &stack_read)?;
+            for symbol in &transition.stack_push {
+                ensure_known_stack_symbol("stack_push", &stack_alphabet, symbol)?;
+            }
+            transitions.push(PDATransition {
+                source: transition.from.clone(),
+                event: transition.on.clone(),
+                stack_read,
+                target,
+                stack_push: transition.stack_push.clone(),
+            });
+        }
+
+        PushdownAutomaton::new(
+            states,
+            alphabet,
+            stack_alphabet,
+            transitions,
+            initial,
+            initial_stack,
+            accepting,
+        )
+    }
 }
 
 fn state_definitions(
@@ -234,4 +362,160 @@ fn sorted_strings(values: &HashSet<String>) -> Vec<String> {
     let mut sorted: Vec<String> = values.iter().cloned().collect();
     sorted.sort();
     sorted
+}
+
+fn expect_kind(definition: &StateMachineDefinition, expected: MachineKind) -> Result<(), String> {
+    if definition.kind == expected {
+        Ok(())
+    } else {
+        Err(format!(
+            "Definition kind mismatch: expected {}, found {}",
+            expected.as_str(),
+            definition.kind.as_str()
+        ))
+    }
+}
+
+fn state_sets(
+    definition: &StateMachineDefinition,
+) -> Result<(HashSet<String>, String, HashSet<String>), String> {
+    let mut states = HashSet::new();
+    let mut accepting = HashSet::new();
+    let mut flagged_initials = Vec::new();
+
+    for state in &definition.states {
+        if state.id.is_empty() {
+            return Err("State identifiers must not be empty".into());
+        }
+        if !states.insert(state.id.clone()) {
+            return Err(format!("Duplicate state '{}'", state.id));
+        }
+        if state.initial {
+            flagged_initials.push(state.id.clone());
+        }
+        if state.accepting {
+            accepting.insert(state.id.clone());
+        }
+    }
+
+    let initial = definition
+        .initial
+        .clone()
+        .ok_or_else(|| "Definition must declare an initial state".to_string())?;
+    if !states.contains(&initial) {
+        return Err(format!(
+            "Initial state '{}' is not in the definition states",
+            initial
+        ));
+    }
+    match flagged_initials.as_slice() {
+        [flagged] if flagged == &initial => {}
+        [] => return Err("Definition must flag exactly one initial state".into()),
+        [flagged] => {
+            return Err(format!(
+                "Initial state mismatch: root initial '{}' but state '{}' is flagged",
+                initial, flagged
+            ))
+        }
+        many => {
+            return Err(format!(
+                "Definition must flag exactly one initial state, found {:?}",
+                many
+            ))
+        }
+    }
+
+    Ok((states, initial, accepting))
+}
+
+fn unique_string_set(field: &str, values: &[String]) -> Result<HashSet<String>, String> {
+    let mut set = HashSet::new();
+    for value in values {
+        if value.is_empty() {
+            return Err(format!("{field} entries must not be empty"));
+        }
+        if !set.insert(value.clone()) {
+            return Err(format!("Duplicate {field} entry '{value}'"));
+        }
+    }
+    Ok(set)
+}
+
+fn reject_stack_effects(kind: &str, transition: &TransitionDefinition) -> Result<(), String> {
+    if transition.stack_pop.is_some() || !transition.stack_push.is_empty() {
+        Err(format!(
+            "{kind} transition from '{}' must not contain stack effects",
+            transition.from
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn ensure_transition_states(
+    states: &HashSet<String>,
+    transition: &TransitionDefinition,
+) -> Result<(), String> {
+    if !states.contains(&transition.from) {
+        return Err(format!(
+            "Transition source '{}' is not in the definition states",
+            transition.from
+        ));
+    }
+    for target in &transition.to {
+        if !states.contains(target) {
+            return Err(format!(
+                "Transition target '{}' is not in the definition states",
+                target
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn single_target(kind: &str, transition: &TransitionDefinition) -> Result<String, String> {
+    if transition.to.len() == 1 {
+        Ok(transition.to[0].clone())
+    } else {
+        Err(format!(
+            "{kind} transition from '{}' on '{}' must have exactly one target",
+            transition.from,
+            event_label(transition)
+        ))
+    }
+}
+
+fn ensure_known_event(alphabet: &HashSet<String>, event: &str) -> Result<(), String> {
+    if alphabet.contains(event) {
+        Ok(())
+    } else {
+        Err(format!(
+            "Transition event '{}' is not in the alphabet {:?}",
+            event,
+            sorted_strings(alphabet)
+        ))
+    }
+}
+
+fn ensure_known_stack_symbol(
+    field: &str,
+    stack_alphabet: &HashSet<String>,
+    symbol: &str,
+) -> Result<(), String> {
+    if stack_alphabet.contains(symbol) {
+        Ok(())
+    } else {
+        Err(format!(
+            "{field} symbol '{}' is not in the stack alphabet {:?}",
+            symbol,
+            sorted_strings(stack_alphabet)
+        ))
+    }
+}
+
+fn event_label(transition: &TransitionDefinition) -> String {
+    transition
+        .on
+        .clone()
+        .unwrap_or_else(|| "epsilon".to_string())
 }

--- a/code/packages/rust/state-machine/src/dfa.rs
+++ b/code/packages/rust/state-machine/src/dfa.rs
@@ -365,7 +365,10 @@ impl DFA {
     pub fn is_complete(&self) -> bool {
         for state in &self.states {
             for event in &self.alphabet {
-                if !self.transitions.contains_key(&(state.clone(), event.clone())) {
+                if !self
+                    .transitions
+                    .contains_key(&(state.clone(), event.clone()))
+                {
                     return false;
                 }
             }
@@ -384,17 +387,15 @@ impl DFA {
 
         // Check for unreachable states
         let reachable = self.reachable_states();
-        let unreachable: Vec<String> = sorted_set(
-            &self.states.difference(&reachable).cloned().collect(),
-        );
+        let unreachable: Vec<String> =
+            sorted_set(&self.states.difference(&reachable).cloned().collect());
         if !unreachable.is_empty() {
             warnings.push(format!("Unreachable states: {:?}", unreachable));
         }
 
         // Check for unreachable accepting states
-        let unreachable_accepting: Vec<String> = sorted_set(
-            &self.accepting.difference(&reachable).cloned().collect(),
-        );
+        let unreachable_accepting: Vec<String> =
+            sorted_set(&self.accepting.difference(&reachable).cloned().collect());
         if !unreachable_accepting.is_empty() {
             warnings.push(format!(
                 "Unreachable accepting states: {:?}",
@@ -506,16 +507,14 @@ impl DFA {
         let event_width = sorted_events
             .iter()
             .map(|e| e.len())
-            .chain(
-                sorted_states.iter().flat_map(|s| {
-                    sorted_events.iter().map(move |e| {
-                        self.transitions
-                            .get(&(s.clone(), e.clone()))
-                            .map(|t| t.len())
-                            .unwrap_or(1) // for the dash
-                    })
-                }),
-            )
+            .chain(sorted_states.iter().flat_map(|s| {
+                sorted_events.iter().map(move |e| {
+                    self.transitions
+                        .get(&(s.clone(), e.clone()))
+                        .map(|t| t.len())
+                        .unwrap_or(1) // for the dash
+                })
+            }))
             .max()
             .unwrap_or(5)
             .max(5);

--- a/code/packages/rust/state-machine/src/lib.rs
+++ b/code/packages/rust/state-machine/src/lib.rs
@@ -28,18 +28,18 @@
 //! linear DFA. Regex engines convert patterns to NFAs, then to DFAs via subset
 //! construction. Parsers use PDAs. HTML tokenizers use modal state machines.
 
-pub mod types;
 pub mod definitions;
 pub mod dfa;
-pub mod nfa;
 pub mod minimize;
-pub mod pda;
 pub mod modal;
+pub mod nfa;
+pub mod pda;
+pub mod types;
 
-pub use types::*;
 pub use definitions::{MachineKind, StateDefinition, StateMachineDefinition, TransitionDefinition};
 pub use dfa::DFA;
-pub use nfa::{EPSILON, NFA};
 pub use minimize::minimize;
-pub use pda::{PDATraceEntry, PDATransition, PushdownAutomaton};
 pub use modal::{ModalStateMachine, ModeTransitionRecord};
+pub use nfa::{EPSILON, NFA};
+pub use pda::{PDATraceEntry, PDATransition, PushdownAutomaton};
+pub use types::*;

--- a/code/packages/rust/state-machine/src/minimize.rs
+++ b/code/packages/rust/state-machine/src/minimize.rs
@@ -64,7 +64,10 @@ pub fn minimize(dfa: &DFA) -> DFA {
         .collect();
 
     // Step 1: Initial partition -- accepting vs non-accepting
-    let non_accepting: HashSet<String> = reachable.difference(&reachable_accepting).cloned().collect();
+    let non_accepting: HashSet<String> = reachable
+        .difference(&reachable_accepting)
+        .cloned()
+        .collect();
 
     let mut partitions: Vec<HashSet<String>> = Vec::new();
     if !reachable_accepting.is_empty() {

--- a/code/packages/rust/state-machine/src/modal.rs
+++ b/code/packages/rust/state-machine/src/modal.rs
@@ -272,16 +272,16 @@ mod tests {
             HashSet::from(["reading_name".into(), "tag_done".into()]),
             HashSet::from(["char".into(), "close_angle".into()]),
             HashMap::from([
-                (("reading_name".into(), "char".into()), "reading_name".into()),
+                (
+                    ("reading_name".into(), "char".into()),
+                    "reading_name".into(),
+                ),
                 (
                     ("reading_name".into(), "close_angle".into()),
                     "tag_done".into(),
                 ),
                 (("tag_done".into(), "char".into()), "reading_name".into()),
-                (
-                    ("tag_done".into(), "close_angle".into()),
-                    "tag_done".into(),
-                ),
+                (("tag_done".into(), "close_angle".into()), "tag_done".into()),
             ]),
             "reading_name".into(),
             HashSet::from(["tag_done".into()]),

--- a/code/packages/rust/state-machine/src/nfa.rs
+++ b/code/packages/rust/state-machine/src/nfa.rs
@@ -165,7 +165,11 @@ impl NFA {
             graph.add_node(state);
         }
         for ((source, event), targets) in &transitions {
-            let label = if event == EPSILON { EPSILON } else { event.as_str() };
+            let label = if event == EPSILON {
+                EPSILON
+            } else {
+                event.as_str()
+            };
             for target in targets {
                 let _ = graph.add_edge(source, target, label);
             }
@@ -279,15 +283,11 @@ impl NFA {
     /// Returns `Err` if the event is not in the alphabet.
     pub fn process(&mut self, event: &str) -> Result<HashSet<String>, String> {
         if !self.alphabet.contains(event) {
-            return Err(format!(
-                "Event '{}' is not in the alphabet {:?}",
-                event,
-                {
-                    let mut v: Vec<_> = self.alphabet.iter().collect();
-                    v.sort();
-                    v
-                }
-            ));
+            return Err(format!("Event '{}' is not in the alphabet {:?}", event, {
+                let mut v: Vec<_> = self.alphabet.iter().collect();
+                v.sort();
+                v
+            }));
         }
 
         // Collect all target states from all current states
@@ -414,8 +414,7 @@ impl NFA {
                 let next_name = state_set_name(&next_closure);
 
                 // Record this DFA transition
-                dfa_transitions
-                    .insert((current_name.clone(), event.clone()), next_name.clone());
+                dfa_transitions.insert((current_name.clone(), event.clone()), next_name.clone());
 
                 // If this is a new DFA state, add it
                 if !dfa_states.contains(&next_name) {
@@ -435,10 +434,16 @@ impl NFA {
             dfa_states,
             self.alphabet.clone(),
             dfa_transitions,
-            state_set_name(&state_map.values().find(|v| {
-                let initial_set: HashSet<String> = [self.initial.clone()].into_iter().collect();
-                *v == &self.epsilon_closure(&initial_set)
-            }).unwrap()),
+            state_set_name(
+                &state_map
+                    .values()
+                    .find(|v| {
+                        let initial_set: HashSet<String> =
+                            [self.initial.clone()].into_iter().collect();
+                        *v == &self.epsilon_closure(&initial_set)
+                    })
+                    .unwrap(),
+            ),
             dfa_accepting,
         )
         .expect("Subset construction should always produce a valid DFA")
@@ -556,7 +561,10 @@ mod tests {
             HashSet::from(["q0".into(), "q1".into(), "q2".into()]),
             HashSet::from(["a".into(), "b".into()]),
             HashMap::from([
-                (("q0".into(), "a".into()), HashSet::from(["q0".into(), "q1".into()])),
+                (
+                    ("q0".into(), "a".into()),
+                    HashSet::from(["q0".into(), "q1".into()]),
+                ),
                 (("q0".into(), "b".into()), HashSet::from(["q0".into()])),
                 (("q1".into(), "b".into()), HashSet::from(["q2".into()])),
                 (("q2".into(), "a".into()), HashSet::from(["q2".into()])),

--- a/code/packages/rust/state-machine/src/pda.rs
+++ b/code/packages/rust/state-machine/src/pda.rs
@@ -309,17 +309,14 @@ impl PushdownAutomaton {
     ///
     /// Returns `Err` if no transition matches.
     pub fn process(&mut self, event: &str) -> Result<String, String> {
-        let t = self
-            .find_transition(Some(event))
-            .cloned()
-            .ok_or_else(|| {
-                format!(
-                    "No transition for (state='{}', event={:?}, stack_top={:?})",
-                    self.current,
-                    event,
-                    self.stack_top()
-                )
-            })?;
+        let t = self.find_transition(Some(event)).cloned().ok_or_else(|| {
+            format!(
+                "No transition for (state='{}', event={:?}, stack_top={:?})",
+                self.current,
+                event,
+                self.stack_top()
+            )
+        })?;
         self.apply_transition(&t);
         Ok(self.current.clone())
     }

--- a/code/packages/rust/state-machine/tests/definitions_test.rs
+++ b/code/packages/rust/state-machine/tests/definitions_test.rs
@@ -295,6 +295,16 @@ fn nfa_import_rejects_stack_effects_and_empty_targets() {
 }
 
 #[test]
+fn nfa_import_rejects_empty_string_event_as_epsilon() {
+    let mut definition = minimal_definition(MachineKind::Nfa);
+    definition.transitions[0].on = Some(String::new());
+
+    assert!(NFA::from_definition(&definition)
+        .unwrap_err()
+        .contains("None for epsilon"));
+}
+
+#[test]
 fn pda_import_rejects_missing_stack_fields_and_unknown_symbols() {
     let mut definition = minimal_definition(MachineKind::Pda);
     definition.stack_alphabet = vec!["$".to_string()];

--- a/code/packages/rust/state-machine/tests/definitions_test.rs
+++ b/code/packages/rust/state-machine/tests/definitions_test.rs
@@ -1,6 +1,9 @@
 use std::collections::{HashMap, HashSet};
 
-use state_machine::{PDATransition, PushdownAutomaton, DFA, EPSILON, NFA};
+use state_machine::{
+    MachineKind, PDATransition, PushdownAutomaton, StateMachineDefinition, TransitionDefinition,
+    DFA, EPSILON, NFA,
+};
 
 fn set(values: &[&str]) -> HashSet<String> {
     values.iter().map(|value| value.to_string()).collect()
@@ -134,4 +137,310 @@ fn pda_exports_stack_alphabet_and_stack_effects() {
     assert_eq!(push_transition.stack_pop.as_deref(), Some("$"));
     assert_eq!(push_transition.stack_push, vec!["$", "("]);
     assert_eq!(epsilon_transition.to, vec!["accept"]);
+}
+
+#[test]
+fn dfa_import_preserves_exported_language() {
+    let dfa = DFA::new(
+        set(&["locked", "unlocked"]),
+        set(&["coin", "push"]),
+        HashMap::from([
+            (
+                ("locked".to_string(), "coin".to_string()),
+                "unlocked".to_string(),
+            ),
+            (
+                ("locked".to_string(), "push".to_string()),
+                "locked".to_string(),
+            ),
+            (
+                ("unlocked".to_string(), "coin".to_string()),
+                "unlocked".to_string(),
+            ),
+            (
+                ("unlocked".to_string(), "push".to_string()),
+                "locked".to_string(),
+            ),
+        ]),
+        "locked".to_string(),
+        set(&["unlocked"]),
+    )
+    .unwrap();
+
+    let imported = DFA::from_definition(&dfa.to_definition("turnstile")).unwrap();
+
+    assert!(imported.accepts(&["coin"]));
+    assert!(imported.accepts(&["push", "coin"]));
+    assert!(!imported.accepts(&["coin", "push"]));
+}
+
+#[test]
+fn nfa_import_preserves_epsilon_and_branching_behavior() {
+    let nfa = NFA::new(
+        set(&["q0", "q1", "q2"]),
+        set(&["a", "b"]),
+        HashMap::from([
+            (("q0".to_string(), "a".to_string()), set(&["q0", "q1"])),
+            (("q1".to_string(), "b".to_string()), set(&["q2"])),
+            (("q2".to_string(), EPSILON.to_string()), set(&["q0"])),
+        ]),
+        "q0".to_string(),
+        set(&["q2"]),
+    )
+    .unwrap();
+
+    let imported = NFA::from_definition(&nfa.to_definition("contains-ab")).unwrap();
+
+    assert!(imported.accepts(&["a", "b"]));
+    assert!(imported.accepts(&["a", "a", "b"]));
+    assert!(imported.accepts(&["a", "b", "a", "b"]));
+    assert!(!imported.accepts(&["b", "a"]));
+}
+
+#[test]
+fn pda_import_preserves_stack_behavior() {
+    let pda = PushdownAutomaton::new(
+        set(&["scan", "accept"]),
+        set(&["(", ")"]),
+        set(&["(", "$"]),
+        vec![
+            PDATransition {
+                source: "scan".to_string(),
+                event: Some("(".to_string()),
+                stack_read: "$".to_string(),
+                target: "scan".to_string(),
+                stack_push: vec!["$".to_string(), "(".to_string()],
+            },
+            PDATransition {
+                source: "scan".to_string(),
+                event: Some("(".to_string()),
+                stack_read: "(".to_string(),
+                target: "scan".to_string(),
+                stack_push: vec!["(".to_string(), "(".to_string()],
+            },
+            PDATransition {
+                source: "scan".to_string(),
+                event: Some(")".to_string()),
+                stack_read: "(".to_string(),
+                target: "scan".to_string(),
+                stack_push: vec![],
+            },
+            PDATransition {
+                source: "scan".to_string(),
+                event: None,
+                stack_read: "$".to_string(),
+                target: "accept".to_string(),
+                stack_push: vec!["$".to_string()],
+            },
+        ],
+        "scan".to_string(),
+        "$".to_string(),
+        set(&["accept"]),
+    )
+    .unwrap();
+
+    let imported = PushdownAutomaton::from_definition(&pda.to_definition("balanced-parens"))
+        .expect("exported PDA definitions should import cleanly");
+
+    assert!(imported.accepts(&[]));
+    assert!(imported.accepts(&["(", ")"]));
+    assert!(imported.accepts(&["(", "(", ")", ")"]));
+    assert!(!imported.accepts(&["("]));
+    assert!(!imported.accepts(&[")"]));
+}
+
+#[test]
+fn dfa_import_rejects_wrong_kind_epsilon_and_stack_effects() {
+    let mut definition = minimal_definition(MachineKind::Nfa);
+    assert!(DFA::from_definition(&definition)
+        .unwrap_err()
+        .contains("expected dfa"));
+
+    definition.kind = MachineKind::Dfa;
+    definition.transitions[0].on = None;
+    assert!(DFA::from_definition(&definition)
+        .unwrap_err()
+        .contains("epsilon"));
+
+    definition.transitions[0].on = Some("tick".to_string());
+    definition.transitions[0].stack_pop = Some("$".to_string());
+    assert!(DFA::from_definition(&definition)
+        .unwrap_err()
+        .contains("stack"));
+}
+
+#[test]
+fn dfa_import_rejects_multi_target_transitions() {
+    let mut definition = minimal_definition(MachineKind::Dfa);
+    definition.transitions[0].to.push("start".to_string());
+
+    assert!(DFA::from_definition(&definition)
+        .unwrap_err()
+        .contains("exactly one target"));
+}
+
+#[test]
+fn nfa_import_rejects_stack_effects_and_empty_targets() {
+    let mut definition = minimal_definition(MachineKind::Nfa);
+    definition.transitions[0].stack_push = vec!["$".to_string()];
+    assert!(NFA::from_definition(&definition)
+        .unwrap_err()
+        .contains("stack"));
+
+    definition.transitions[0].stack_push.clear();
+    definition.transitions[0].to.clear();
+    assert!(NFA::from_definition(&definition)
+        .unwrap_err()
+        .contains("at least one target"));
+}
+
+#[test]
+fn pda_import_rejects_missing_stack_fields_and_unknown_symbols() {
+    let mut definition = minimal_definition(MachineKind::Pda);
+    definition.stack_alphabet = vec!["$".to_string()];
+    definition.initial_stack = Some("$".to_string());
+    assert!(PushdownAutomaton::from_definition(&definition)
+        .unwrap_err()
+        .contains("stack_pop"));
+
+    definition.transitions[0].stack_pop = Some("!".to_string());
+    assert!(PushdownAutomaton::from_definition(&definition)
+        .unwrap_err()
+        .contains("stack alphabet"));
+}
+
+#[test]
+fn pda_import_rejects_unknown_transition_states() {
+    let mut definition = minimal_pda_definition();
+    definition.transitions[0].from = "missing".to_string();
+    assert!(PushdownAutomaton::from_definition(&definition)
+        .unwrap_err()
+        .contains("source"));
+
+    let mut definition = minimal_pda_definition();
+    definition.transitions[0].to = vec!["missing".to_string()];
+    assert!(PushdownAutomaton::from_definition(&definition)
+        .unwrap_err()
+        .contains("target"));
+}
+
+#[test]
+fn future_machine_kinds_have_stable_definition_names() {
+    assert_eq!(MachineKind::Modal.as_str(), "modal");
+    assert_eq!(MachineKind::Statechart.as_str(), "statechart");
+    assert_eq!(MachineKind::Transducer.as_str(), "transducer");
+}
+
+#[test]
+fn import_rejects_bad_initial_markers() {
+    let mut definition = minimal_definition(MachineKind::Dfa);
+    definition.initial = None;
+    assert!(DFA::from_definition(&definition)
+        .unwrap_err()
+        .contains("initial state"));
+
+    let mut definition = minimal_definition(MachineKind::Dfa);
+    definition.states[0].initial = false;
+    assert!(DFA::from_definition(&definition)
+        .unwrap_err()
+        .contains("exactly one initial"));
+
+    let mut definition = minimal_definition(MachineKind::Dfa);
+    definition.states.push(state("other", true, false));
+    assert!(DFA::from_definition(&definition)
+        .unwrap_err()
+        .contains("exactly one initial"));
+
+    let mut definition = minimal_definition(MachineKind::Dfa);
+    definition.states.push(state("other", false, false));
+    definition.states[0].initial = false;
+    definition.states[1].initial = true;
+    assert!(DFA::from_definition(&definition)
+        .unwrap_err()
+        .contains("mismatch"));
+}
+
+#[test]
+fn import_rejects_duplicate_states_and_alphabet_entries() {
+    let mut definition = minimal_definition(MachineKind::Dfa);
+    definition.states.push(state("start", false, false));
+    assert!(DFA::from_definition(&definition)
+        .unwrap_err()
+        .contains("Duplicate state"));
+
+    let mut definition = minimal_definition(MachineKind::Dfa);
+    definition.alphabet.push("tick".to_string());
+    assert!(DFA::from_definition(&definition)
+        .unwrap_err()
+        .contains("Duplicate alphabet"));
+}
+
+#[test]
+fn dfa_import_rejects_stack_declarations_and_duplicate_transitions() {
+    let mut definition = minimal_definition(MachineKind::Dfa);
+    definition.stack_alphabet = vec!["$".to_string()];
+    assert!(DFA::from_definition(&definition)
+        .unwrap_err()
+        .contains("stack alphabet"));
+
+    let mut definition = minimal_definition(MachineKind::Dfa);
+    definition
+        .transitions
+        .push(definition.transitions[0].clone());
+    assert!(DFA::from_definition(&definition)
+        .unwrap_err()
+        .contains("duplicate transition"));
+}
+
+#[test]
+fn nfa_import_rejects_stack_declarations() {
+    let mut definition = minimal_definition(MachineKind::Nfa);
+    definition.initial_stack = Some("$".to_string());
+    assert!(NFA::from_definition(&definition)
+        .unwrap_err()
+        .contains("initial stack"));
+}
+
+#[test]
+fn pda_import_rejects_unknown_events_and_stack_push_symbols() {
+    let mut definition = minimal_pda_definition();
+    definition.transitions[0].on = Some("missing".to_string());
+    assert!(PushdownAutomaton::from_definition(&definition)
+        .unwrap_err()
+        .contains("alphabet"));
+
+    let mut definition = minimal_pda_definition();
+    definition.transitions[0].stack_push = vec!["!".to_string()];
+    assert!(PushdownAutomaton::from_definition(&definition)
+        .unwrap_err()
+        .contains("stack alphabet"));
+}
+
+fn minimal_definition(kind: MachineKind) -> StateMachineDefinition {
+    let mut definition = StateMachineDefinition::new("minimal", kind);
+    definition.initial = Some("start".to_string());
+    definition.alphabet = vec!["tick".to_string()];
+    definition.states = vec![state("start", true, true)];
+    definition.transitions = vec![TransitionDefinition::new(
+        "start",
+        Some("tick".to_string()),
+        vec!["start".to_string()],
+    )];
+    definition
+}
+
+fn minimal_pda_definition() -> StateMachineDefinition {
+    let mut definition = minimal_definition(MachineKind::Pda);
+    definition.stack_alphabet = vec!["$".to_string()];
+    definition.initial_stack = Some("$".to_string());
+    definition.transitions[0].stack_pop = Some("$".to_string());
+    definition.transitions[0].stack_push = vec!["$".to_string()];
+    definition
+}
+
+fn state(id: &str, initial: bool, accepting: bool) -> state_machine::StateDefinition {
+    let mut state = state_machine::StateDefinition::new(id);
+    state.initial = initial;
+    state.accepting = accepting;
+    state
 }

--- a/code/packages/rust/state-machine/tests/dfa_test.rs
+++ b/code/packages/rust/state-machine/tests/dfa_test.rs
@@ -364,10 +364,10 @@ fn test_accepts_undefined_transition_returns_false() {
 #[test]
 fn test_div_by_3() {
     let dfa = div_by_3();
-    assert!(dfa.accepts(&[]));             // 0 is div by 3
-    assert!(!dfa.accepts(&["1"]));         // 1
-    assert!(!dfa.accepts(&["1", "0"]));    // 2
-    assert!(dfa.accepts(&["1", "1"]));     // 3
+    assert!(dfa.accepts(&[])); // 0 is div by 3
+    assert!(!dfa.accepts(&["1"])); // 1
+    assert!(!dfa.accepts(&["1", "0"])); // 2
+    assert!(dfa.accepts(&["1", "1"])); // 3
     assert!(!dfa.accepts(&["1", "0", "0"])); // 4
     assert!(dfa.accepts(&["1", "1", "0"])); // 6
     assert!(dfa.accepts(&["1", "0", "0", "1"])); // 9
@@ -384,7 +384,10 @@ fn test_div_by_3_comprehensive() {
         let bits: Vec<&str> = if n == 0 {
             vec![]
         } else {
-            binary.chars().map(|c| if c == '0' { "0" } else { "1" }).collect()
+            binary
+                .chars()
+                .map(|c| if c == '0' { "0" } else { "1" })
+                .collect()
         };
         let expected = n % 3 == 0;
         assert_eq!(
@@ -420,14 +423,16 @@ fn test_branch_predictor_warmup_to_st() {
 #[test]
 fn test_branch_predictor_saturation_st() {
     let mut dfa = branch_predictor();
-    dfa.process_sequence(&["taken", "taken", "taken", "taken"]).unwrap();
+    dfa.process_sequence(&["taken", "taken", "taken", "taken"])
+        .unwrap();
     assert_eq!(dfa.current_state(), "ST");
 }
 
 #[test]
 fn test_branch_predictor_saturation_snt() {
     let mut dfa = branch_predictor();
-    dfa.process_sequence(&["not_taken", "not_taken", "not_taken"]).unwrap();
+    dfa.process_sequence(&["not_taken", "not_taken", "not_taken"])
+        .unwrap();
     assert_eq!(dfa.current_state(), "SNT");
 }
 

--- a/code/packages/rust/state-machine/tests/minimize_test.rs
+++ b/code/packages/rust/state-machine/tests/minimize_test.rs
@@ -133,7 +133,10 @@ fn test_nfa_to_dfa_to_minimized() {
         HashSet::from(["q0".into(), "q1".into()]),
         HashSet::from(["a".into(), "b".into()]),
         HashMap::from([
-            (("q0".into(), "a".into()), HashSet::from(["q0".into(), "q1".into()])),
+            (
+                ("q0".into(), "a".into()),
+                HashSet::from(["q0".into(), "q1".into()]),
+            ),
             (("q0".into(), "b".into()), HashSet::from(["q0".into()])),
         ]),
         "q0".into(),
@@ -160,7 +163,10 @@ fn test_minimized_preserves_language_exhaustive() {
         HashSet::from(["q0".into(), "q1".into(), "q2".into()]),
         HashSet::from(["a".into(), "b".into()]),
         HashMap::from([
-            (("q0".into(), "a".into()), HashSet::from(["q0".into(), "q1".into()])),
+            (
+                ("q0".into(), "a".into()),
+                HashSet::from(["q0".into(), "q1".into()]),
+            ),
             (("q0".into(), "b".into()), HashSet::from(["q0".into()])),
             (("q1".into(), "a".into()), HashSet::from(["q2".into()])),
             (("q2".into(), "a".into()), HashSet::from(["q2".into()])),
@@ -188,12 +194,7 @@ fn test_minimized_preserves_language_exhaustive() {
     }
 
     for s in &all_strings {
-        assert_eq!(
-            nfa.accepts(s),
-            minimized.accepts(s),
-            "Mismatch on {:?}",
-            s
-        );
+        assert_eq!(nfa.accepts(s), minimized.accepts(s), "Mismatch on {:?}", s);
     }
 }
 

--- a/code/packages/rust/state-machine/tests/modal_test.rs
+++ b/code/packages/rust/state-machine/tests/modal_test.rs
@@ -17,7 +17,10 @@ fn make_data_mode() -> DFA {
             (("text".into(), "char".into()), "text".into()),
             (("text".into(), "open_angle".into()), "tag_detected".into()),
             (("tag_detected".into(), "char".into()), "text".into()),
-            (("tag_detected".into(), "open_angle".into()), "tag_detected".into()),
+            (
+                ("tag_detected".into(), "open_angle".into()),
+                "tag_detected".into(),
+            ),
         ]),
         "text".into(),
         HashSet::from(["text".into()]),
@@ -30,8 +33,14 @@ fn make_tag_mode() -> DFA {
         HashSet::from(["reading_name".into(), "tag_done".into()]),
         HashSet::from(["char".into(), "close_angle".into()]),
         HashMap::from([
-            (("reading_name".into(), "char".into()), "reading_name".into()),
-            (("reading_name".into(), "close_angle".into()), "tag_done".into()),
+            (
+                ("reading_name".into(), "char".into()),
+                "reading_name".into(),
+            ),
+            (
+                ("reading_name".into(), "close_angle".into()),
+                "tag_done".into(),
+            ),
             (("tag_done".into(), "char".into()), "reading_name".into()),
             (("tag_done".into(), "close_angle".into()), "tag_done".into()),
         ]),

--- a/code/packages/rust/state-machine/tests/nfa_test.rs
+++ b/code/packages/rust/state-machine/tests/nfa_test.rs
@@ -22,7 +22,10 @@ fn contains_ab() -> NFA {
         HashSet::from(["q0".into(), "q1".into(), "q2".into()]),
         HashSet::from(["a".into(), "b".into()]),
         HashMap::from([
-            (("q0".into(), "a".into()), HashSet::from(["q0".into(), "q1".into()])),
+            (
+                ("q0".into(), "a".into()),
+                HashSet::from(["q0".into(), "q1".into()]),
+            ),
             (("q0".into(), "b".into()), HashSet::from(["q0".into()])),
             (("q1".into(), "b".into()), HashSet::from(["q2".into()])),
             (("q2".into(), "a".into()), HashSet::from(["q2".into()])),
@@ -54,12 +57,19 @@ fn epsilon_chain() -> NFA {
 fn a_or_ab() -> NFA {
     NFA::new(
         HashSet::from([
-            "q0".into(), "q1".into(), "q2".into(),
-            "q3".into(), "q4".into(), "q5".into(),
+            "q0".into(),
+            "q1".into(),
+            "q2".into(),
+            "q3".into(),
+            "q4".into(),
+            "q5".into(),
         ]),
         HashSet::from(["a".into(), "b".into()]),
         HashMap::from([
-            (("q0".into(), EPSILON.into()), HashSet::from(["q1".into(), "q3".into()])),
+            (
+                ("q0".into(), EPSILON.into()),
+                HashSet::from(["q1".into(), "q3".into()]),
+            ),
             (("q1".into(), "a".into()), HashSet::from(["q2".into()])),
             (("q3".into(), "a".into()), HashSet::from(["q4".into()])),
             (("q4".into(), "b".into()), HashSet::from(["q5".into()])),
@@ -479,7 +489,10 @@ fn test_comprehensive_language_equivalence() {
         HashSet::from(["q0".into(), "q1".into(), "q2".into()]),
         HashSet::from(["a".into(), "b".into()]),
         HashMap::from([
-            (("q0".into(), "a".into()), HashSet::from(["q0".into(), "q1".into()])),
+            (
+                ("q0".into(), "a".into()),
+                HashSet::from(["q0".into(), "q1".into()]),
+            ),
             (("q0".into(), "b".into()), HashSet::from(["q0".into()])),
             (("q1".into(), "b".into()), HashSet::from(["q2".into()])),
         ]),

--- a/code/specs/F07-state-machine-markup-language.md
+++ b/code/specs/F07-state-machine-markup-language.md
@@ -453,6 +453,47 @@ machine-readable artifacts. TOML remains the hand-authored source format.
 Source generation is the production artifact path: applications link generated
 code rather than loading TOML or JSON dynamically.
 
+## Definition Import Rules
+
+The core state-machine library owns conversion between typed definitions and
+executable machines. That import layer is intentionally not a file parser: it
+receives an already-built `StateMachineDefinition`, validates the shape required
+by the target machine family, and delegates to the normal eager constructors.
+
+Phase 1 imports cover DFA, NFA, and PDA definitions:
+
+- `DFA::from_definition(definition)` accepts only `kind = "dfa"`, requires one
+  initial state, requires every transition to have exactly one target, rejects
+  epsilon transitions, rejects duplicate `(from, on)` pairs, and rejects all
+  stack effects.
+- `NFA::from_definition(definition)` accepts only `kind = "nfa"`, requires one
+  initial state, allows epsilon transitions, allows one or more targets per
+  transition, and rejects all stack effects.
+- `PushdownAutomaton::from_definition(definition)` accepts only `kind = "pda"`,
+  requires one initial state and one initial stack symbol, requires every
+  transition to have exactly one target and one `stack_pop` symbol, validates
+  every stack symbol against `stack_alphabet`, and preserves epsilon
+  transitions as `None`.
+
+Importing a definition should produce the same observable behavior as the
+machine that exported it:
+
+```text
+machine -> StateMachineDefinition -> executable machine
+```
+
+When the definition came from a serializer/deserializer pair, the complete
+tooling round trip should also preserve behavior:
+
+```text
+machine -> definition -> .states.toml -> definition -> executable machine
+```
+
+Modal, statechart, transducer, action, and guard imports are later phases. Until
+their runtime semantics are implemented in the core library, executable-machine
+imports must reject those definitions with explicit diagnostics instead of
+silently dropping behavior.
+
 ## Canonical Output Rules
 
 Serializers must:
@@ -552,12 +593,15 @@ runtime deserialization package.
    `.states.toml` output.
 6. Add a Rust `state-machine-markup-deserializer` package for TOML input and
    validation.
-7. Add NFA, PDA, and modal round-tripping through definitions.
-8. Add SCXML core import/export packages for deterministic event machines.
-9. Keep DOT export as visualization-only output.
-10. Add the build-time source compiler from
+7. Add executable-machine imports for DFA, NFA, and PDA definitions so
+   serializer/deserializer round trips can return to runnable machines.
+8. Add modal round-tripping through definitions once modal definitions can
+   represent child-machine references and mode transitions.
+9. Add SCXML core import/export packages for deterministic event machines.
+10. Keep DOT export as visualization-only output.
+11. Add the build-time source compiler from
    `F09-state-machine-source-compiler.md`.
-11. Build tokenizer profiles from `F08` on top of this definition model.
+12. Build tokenizer profiles from `F08` on top of this definition model.
 
 ## Test Strategy
 

--- a/code/specs/F07-state-machine-markup-language.md
+++ b/code/specs/F07-state-machine-markup-language.md
@@ -468,7 +468,8 @@ Phase 1 imports cover DFA, NFA, and PDA definitions:
   stack effects.
 - `NFA::from_definition(definition)` accepts only `kind = "nfa"`, requires one
   initial state, allows epsilon transitions, allows one or more targets per
-  transition, and rejects all stack effects.
+  transition, rejects empty-string events because epsilon is represented by
+  `None`, and rejects all stack effects.
 - `PushdownAutomaton::from_definition(definition)` accepts only `kind = "pda"`,
   requires one initial state and one initial stack symbol, requires every
   transition to have exactly one target and one `stack_pop` symbol, validates

--- a/lessons.md
+++ b/lessons.md
@@ -2923,3 +2923,19 @@ of returning a normal Rust panic.
 **Rule:** In wasm-bindgen wrapper crates that run native tests, keep JS error construction behind a
 `#[cfg(target_arch = "wasm32")]` helper. Use a simple native placeholder such as `JsValue::NULL` for
 test-only error values when the test only needs to assert that the wrapper returned `Err`.
+
+---
+
+## Typed epsilon transitions must not accept empty-string aliases at import boundaries
+
+**Date:** 2026-04-20
+
+**What happened:** Security review of the first Rust `StateMachineDefinition` import helpers caught
+that `NFA::from_definition()` treated `Some("")` the same as `None`. The runtime NFA uses an empty
+string sentinel internally for epsilon transitions, but the typed definition contract says epsilon is
+represented by `None`. Accepting both shapes would let malformed definitions smuggle free moves past
+the import validator.
+
+**Rule:** At typed import or deserialization boundaries, reject empty-string event names explicitly.
+Only lower `None` to the runtime epsilon sentinel inside the core automaton constructor path. Add
+regression tests for this distinction whenever a runtime uses sentinel values internally.


### PR DESCRIPTION
## Summary

- Specify the phase 1 definition import contract for DFA, NFA, and PDA machines.
- Add `from_definition` constructors for Rust DFA, NFA, and `PushdownAutomaton` with validation for kind, initial markers, duplicate states, alphabet entries, transition shape, stack effects, and PDA stack symbols/state references.
- Extend serializer/deserializer round-trip coverage so parsed TOML definitions reconstruct runnable machines.
- Fix the security-review edge case where `Some("")` could be treated as NFA epsilon; epsilon is now accepted only as `None` at the typed boundary.

## Verification

- `cargo fmt -p state-machine -p state-machine-markup-deserializer`
- `cargo test -p state-machine -p state-machine-markup-serializer -p state-machine-markup-deserializer -- --nocapture`
- `cargo build -p state-machine -p state-machine-markup-serializer -p state-machine-markup-deserializer`
- `cargo tarpaulin -p state-machine --out Stdout --skip-clean`  
  Package source coverage from tarpaulin per-file output: `942/967` lines, about `97.4%`.
- `git diff --check`
- Security review re-check: no findings.

## Notes

- `cargo build --workspace` was attempted on macOS and reached the known unrelated `paint-vm-direct2d requires Windows` compile error.