### PR TITLE
feat(note-audio): add python signal chain package

### DIFF
--- a/code/packages/python/note-audio/.gitignore
+++ b/code/packages/python/note-audio/.gitignore
@@ -1,0 +1,5 @@
+.coverage
+.pytest_cache/
+.ruff_cache/
+.venv/
+__pycache__/

--- a/code/packages/python/note-audio/BUILD
+++ b/code/packages/python/note-audio/BUILD
@@ -1,0 +1,8 @@
+uv venv --quiet --clear
+uv pip install --no-deps -e ../note-frequency --quiet
+uv pip install --no-deps -e ../trig --quiet
+uv pip install --no-deps -e ../oscillator --quiet
+uv pip install --no-deps -e . --quiet
+uv pip install pytest pytest-cov ruff --quiet
+uv run --no-project ruff check src/ tests/
+uv run --no-project python -m pytest tests/ -v

--- a/code/packages/python/note-audio/BUILD_windows
+++ b/code/packages/python/note-audio/BUILD_windows
@@ -1,0 +1,8 @@
+uv venv --quiet --clear
+uv pip install --no-deps -e ../note-frequency --quiet
+uv pip install --no-deps -e ../trig --quiet
+uv pip install --no-deps -e ../oscillator --quiet
+uv pip install --no-deps -e . --quiet
+uv pip install pytest pytest-cov ruff --quiet
+uv run --no-project ruff check src/ tests/
+uv run --no-project python -m pytest tests/ -v

--- a/code/packages/python/note-audio/CHANGELOG.md
+++ b/code/packages/python/note-audio/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-20
+
+### Added
+
+- Added the initial Python implementation of `MUS01: Note-to-Sound Signal Chain`.
+- Added `NoteEvent`, `PCMFormat`, `PCMBuffer`, `ZeroOrderHoldDACSignal`,
+  `LinearSpeakerSignal`, and `RenderedNote`.
+- Added `render_note_to_sound_chain()` to compose note-frequency, oscillator,
+  sampler, PCM encoding, virtual DAC, and virtual speaker layers.
+- Added signed 16-bit PCM encoding with explicit clipping counts.
+- Added deterministic mono WAV byte/file helpers as an optional sink.
+- Added tests for parity vectors, validation, clipping, DAC hold behavior, WAV
+  output, and the visible `A4` rendering chain.

--- a/code/packages/python/note-audio/README.md
+++ b/code/packages/python/note-audio/README.md
@@ -1,0 +1,71 @@
+# note-audio
+
+`note-audio` is the first Python proof of `MUS01: Note-to-Sound Signal Chain`.
+
+It deliberately does not jump from `"A4"` straight to a speaker. Instead, it
+keeps the whole chain visible:
+
+```text
+note -> frequency -> oscillator -> sampler -> PCM -> DAC -> speaker model
+```
+
+The package is virtual and deterministic. It does not open a real audio device,
+sleep in real time, or talk to hardware. That makes it useful for learning,
+debugging, and tests.
+
+## Example
+
+```python
+from note_audio import render_note_to_sound_chain, to_wav_bytes
+
+chain = render_note_to_sound_chain("A4", duration_seconds=1.0)
+
+print(chain.frequency_hz)              # 440.0
+print(chain.floating_samples.samples[:5])
+print(chain.pcm_buffer.samples[:5])
+print(chain.dac_signal.value_at(0.001))
+print(chain.speaker_signal.value_at(0.001))
+
+wav_bytes = to_wav_bytes(chain.pcm_buffer)
+```
+
+## Layers
+
+`NoteEvent` stores the human-level note, duration, amplitude, and start time.
+
+`render_note_to_sound_chain()` parses the note with `note-frequency`, creates a
+sine oscillator with `oscillator`, samples it, encodes signed 16-bit PCM, builds
+a zero-order-hold virtual DAC, and wraps that in a linear virtual speaker model.
+
+`PCMBuffer` stores machine-friendly signed 16-bit samples and timing metadata.
+
+`ZeroOrderHoldDACSignal` turns PCM integers back into voltage-like values over
+time.
+
+`LinearSpeakerSignal` is a deliberately simple speaker placeholder:
+
+```text
+speaker_pressure_proxy(t) = speaker_gain * dac_voltage(t)
+```
+
+## WAV
+
+WAV support is an optional file/container sink:
+
+```python
+from note_audio import render_note_to_sound_chain, write_wav
+
+chain = render_note_to_sound_chain("C4", duration_seconds=0.5)
+write_wav("c4.wav", chain.pcm_buffer)
+```
+
+The WAV writer supports mono signed 16-bit PCM. It is included so the digital
+stage can be handed to normal audio software, but it does not replace the DAC
+and speaker abstractions.
+
+## Development
+
+```bash
+bash BUILD
+```
+

--- a/code/packages/python/note-audio/pyproject.toml
+++ b/code/packages/python/note-audio/pyproject.toml
@@ -1,0 +1,46 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-note-audio"
+version = "0.1.0"
+description = "Visible note-to-sound signal chain for virtual audio playback"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+dependencies = [
+    "coding-adventures-note-frequency>=0.1.0",
+    "coding-adventures-oscillator>=0.1.0",
+    "coding-adventures-trig>=0.1.0",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4"]
+
+[tool.uv.sources]
+coding-adventures-note-frequency = { path = "../note-frequency", editable = true }
+coding-adventures-oscillator = { path = "../oscillator", editable = true }
+coding-adventures-trig = { path = "../trig", editable = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/note_audio"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM", "ANN"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=note_audio --cov-report=term-missing --cov-fail-under=95"
+
+[tool.coverage.run]
+source = ["src/note_audio"]
+
+[tool.coverage.report]
+fail_under = 95
+show_missing = true

--- a/code/packages/python/note-audio/required_capabilities.json
+++ b/code/packages/python/note-audio/required_capabilities.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "python/note-audio",
+  "capabilities": [
+    {
+      "category": "fs",
+      "action": "write",
+      "target": "caller-provided WAV output path",
+      "justification": "The optional write_wav helper writes deterministic WAV bytes to a caller-selected file path."
+    }
+  ],
+  "justification": "Pure signal-chain computation except for the explicit optional WAV file sink."
+}

--- a/code/packages/python/note-audio/src/note_audio/__init__.py
+++ b/code/packages/python/note-audio/src/note_audio/__init__.py
@@ -1,0 +1,50 @@
+"""Visible note-to-sound signal chain for virtual audio playback."""
+
+from .note_audio import (
+    DEFAULT_AMPLITUDE,
+    DEFAULT_BIT_DEPTH,
+    DEFAULT_CHANNEL_COUNT,
+    DEFAULT_FULL_SCALE_VOLTAGE,
+    DEFAULT_MAX_SAMPLE_COUNT,
+    DEFAULT_SAMPLE_RATE_HZ,
+    DEFAULT_SPEAKER_GAIN,
+    LinearSpeakerSignal,
+    NoteEvent,
+    PCMBuffer,
+    PCMFormat,
+    RenderedNote,
+    ZeroOrderHoldDACSignal,
+    encode_sample_buffer,
+    float_to_pcm16,
+    pcm16_to_voltage,
+    render_note_to_sound_chain,
+    samples_to_pcm_buffer,
+    to_wav_bytes,
+    write_wav,
+)
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "DEFAULT_AMPLITUDE",
+    "DEFAULT_BIT_DEPTH",
+    "DEFAULT_CHANNEL_COUNT",
+    "DEFAULT_FULL_SCALE_VOLTAGE",
+    "DEFAULT_MAX_SAMPLE_COUNT",
+    "DEFAULT_SAMPLE_RATE_HZ",
+    "DEFAULT_SPEAKER_GAIN",
+    "LinearSpeakerSignal",
+    "NoteEvent",
+    "PCMBuffer",
+    "PCMFormat",
+    "RenderedNote",
+    "ZeroOrderHoldDACSignal",
+    "__version__",
+    "encode_sample_buffer",
+    "float_to_pcm16",
+    "pcm16_to_voltage",
+    "render_note_to_sound_chain",
+    "samples_to_pcm_buffer",
+    "to_wav_bytes",
+    "write_wav",
+]

--- a/code/packages/python/note-audio/src/note_audio/note_audio.py
+++ b/code/packages/python/note-audio/src/note_audio/note_audio.py
@@ -1,0 +1,502 @@
+"""Compose typed notes, oscillators, sampling, PCM, DAC, and speaker models.
+
+This package intentionally keeps every box in the signal chain visible. A
+caller can inspect the note frequency, the continuous oscillator, the floating
+samples, the PCM integers, the virtual DAC voltage, and the virtual speaker
+pressure proxy before choosing any real playback sink.
+"""
+
+from __future__ import annotations
+
+import wave
+from collections.abc import Iterable
+from dataclasses import dataclass
+from io import BytesIO
+from math import floor, isfinite
+from numbers import Integral, Real
+from os import PathLike
+from pathlib import Path
+from typing import Protocol
+
+from note_frequency import Note, parse_note
+from oscillator import (
+    SampleBuffer,
+    SineOscillator,
+    UniformSampler,
+    sample_count_for_duration,
+)
+
+DEFAULT_SAMPLE_RATE_HZ = 44_100.0
+DEFAULT_AMPLITUDE = 0.8
+DEFAULT_BIT_DEPTH = 16
+DEFAULT_CHANNEL_COUNT = 1
+DEFAULT_FULL_SCALE_VOLTAGE = 1.0
+DEFAULT_SPEAKER_GAIN = 1.0
+DEFAULT_MAX_SAMPLE_COUNT = 10_000_000
+INTEGER_TOLERANCE = 1e-9
+PCM16_MIN = -32_768
+PCM16_MAX = 32_767
+
+NoteInput = Note | str
+OutputPath = str | PathLike[str]
+
+
+class AnalogSignal(Protocol):
+    """A virtual analog signal that can be queried at any time in seconds."""
+
+    def value_at(self, time_seconds: Real) -> float:
+        """Return the signal value at ``time_seconds``."""
+
+
+def _finite_float(name: str, value: Real) -> float:
+    """Convert a finite real value to ``float`` and reject slippery inputs."""
+
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a finite real number, got {value!r}")
+
+    converted = float(value)
+    if not isfinite(converted):
+        raise ValueError(f"{name} must be finite, got {value!r}")
+
+    return converted
+
+
+def _non_negative_float(name: str, value: Real) -> float:
+    converted = _finite_float(name, value)
+    if converted < 0.0:
+        raise ValueError(f"{name} must be >= 0.0, got {converted}")
+    return converted
+
+
+def _positive_float(name: str, value: Real) -> float:
+    converted = _finite_float(name, value)
+    if converted <= 0.0:
+        raise ValueError(f"{name} must be > 0.0, got {converted}")
+    return converted
+
+
+def _non_negative_int(name: str, value: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise ValueError(f"{name} must be an integer >= 0, got {value!r}")
+    converted = int(value)
+    if converted < 0:
+        raise ValueError(f"{name} must be >= 0, got {converted}")
+    return converted
+
+
+def _positive_int(name: str, value: int) -> int:
+    converted = _non_negative_int(name, value)
+    if converted == 0:
+        raise ValueError(f"{name} must be > 0, got 0")
+    return converted
+
+
+def _integer_sample_rate(sample_rate_hz: float) -> int:
+    rounded = round(sample_rate_hz)
+    if abs(sample_rate_hz - rounded) > INTEGER_TOLERANCE:
+        raise ValueError(
+            "sample_rate_hz must be an integer-valued rate for WAV output, "
+            f"got {sample_rate_hz}"
+        )
+    return int(rounded)
+
+
+def _parse_note_input(note: NoteInput) -> Note:
+    if isinstance(note, Note):
+        return note
+    if isinstance(note, str):
+        return parse_note(note)
+    raise ValueError(f"note must be a note string or Note, got {note!r}")
+
+
+@dataclass(frozen=True)
+class NoteEvent:
+    """A human note label plus the timing and loudness needed to render it."""
+
+    note: NoteInput
+    duration_seconds: float
+    amplitude: float = DEFAULT_AMPLITUDE
+    start_time_seconds: float = 0.0
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "note", _parse_note_input(self.note))
+        object.__setattr__(
+            self,
+            "duration_seconds",
+            _non_negative_float("duration_seconds", self.duration_seconds),
+        )
+        object.__setattr__(
+            self,
+            "amplitude",
+            _non_negative_float("amplitude", self.amplitude),
+        )
+        object.__setattr__(
+            self,
+            "start_time_seconds",
+            _finite_float("start_time_seconds", self.start_time_seconds),
+        )
+
+
+@dataclass(frozen=True)
+class PCMFormat:
+    """Metadata for the first digital audio representation: mono 16-bit PCM."""
+
+    sample_rate_hz: float = DEFAULT_SAMPLE_RATE_HZ
+    channel_count: int = DEFAULT_CHANNEL_COUNT
+    bit_depth: int = DEFAULT_BIT_DEPTH
+    full_scale_voltage: float = DEFAULT_FULL_SCALE_VOLTAGE
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "sample_rate_hz",
+            _positive_float("sample_rate_hz", self.sample_rate_hz),
+        )
+        channel_count = _positive_int("channel_count", self.channel_count)
+        if channel_count != DEFAULT_CHANNEL_COUNT:
+            raise ValueError("only mono PCM is supported in V1")
+        object.__setattr__(self, "channel_count", channel_count)
+
+        bit_depth = _positive_int("bit_depth", self.bit_depth)
+        if bit_depth != DEFAULT_BIT_DEPTH:
+            raise ValueError("only signed 16-bit PCM is supported in V1")
+        object.__setattr__(self, "bit_depth", bit_depth)
+        object.__setattr__(
+            self,
+            "full_scale_voltage",
+            _positive_float("full_scale_voltage", self.full_scale_voltage),
+        )
+
+    @property
+    def minimum_integer(self) -> int:
+        """Return the lowest signed PCM integer for this format."""
+
+        return PCM16_MIN
+
+    @property
+    def maximum_integer(self) -> int:
+        """Return the highest signed PCM integer for this format."""
+
+        return PCM16_MAX
+
+    @property
+    def sample_width_bytes(self) -> int:
+        """Return the number of bytes per PCM sample."""
+
+        return self.bit_depth // 8
+
+    def integer_sample_rate(self) -> int:
+        """Return a WAV-compatible integer sample rate."""
+
+        return _integer_sample_rate(self.sample_rate_hz)
+
+
+@dataclass(frozen=True)
+class PCMBuffer:
+    """PCM samples plus the timing metadata needed by DAC and file sinks."""
+
+    samples: tuple[int, ...]
+    pcm_format: PCMFormat
+    start_time_seconds: float = 0.0
+    clipped_sample_count: int = 0
+
+    def __post_init__(self) -> None:
+        checked_samples: list[int] = []
+        for index, sample in enumerate(self.samples):
+            if isinstance(sample, bool) or not isinstance(sample, Integral):
+                raise ValueError(f"samples[{index}] must be a PCM integer")
+            converted = int(sample)
+            if converted < PCM16_MIN or converted > PCM16_MAX:
+                raise ValueError(
+                    f"samples[{index}] must fit signed 16-bit PCM, got {converted}"
+                )
+            checked_samples.append(converted)
+
+        object.__setattr__(self, "samples", tuple(checked_samples))
+        if not isinstance(self.pcm_format, PCMFormat):
+            raise ValueError("pcm_format must be a PCMFormat")
+        object.__setattr__(
+            self,
+            "start_time_seconds",
+            _finite_float("start_time_seconds", self.start_time_seconds),
+        )
+        object.__setattr__(
+            self,
+            "clipped_sample_count",
+            _non_negative_int("clipped_sample_count", self.clipped_sample_count),
+        )
+
+    def sample_count(self) -> int:
+        """Return the number of PCM samples."""
+
+        return len(self.samples)
+
+    def sample_period_seconds(self) -> float:
+        """Return the time spacing between adjacent samples."""
+
+        return 1.0 / self.pcm_format.sample_rate_hz
+
+    def duration_seconds(self) -> float:
+        """Return the half-open duration covered by this PCM buffer."""
+
+        return self.sample_count() / self.pcm_format.sample_rate_hz
+
+    def time_at(self, index: int) -> float:
+        """Return the timestamp for a PCM sample index."""
+
+        if isinstance(index, bool) or not isinstance(index, Integral):
+            raise ValueError(f"index must be an integer, got {index!r}")
+        converted = int(index)
+        if not 0 <= converted < self.sample_count():
+            raise ValueError(
+                f"index must be in [0, {self.sample_count()}), got {converted}"
+            )
+        return self.start_time_seconds + converted / self.pcm_format.sample_rate_hz
+
+    def to_little_endian_bytes(self) -> bytes:
+        """Pack signed 16-bit PCM integers as little-endian bytes."""
+
+        return b"".join(
+            sample.to_bytes(2, "little", signed=True) for sample in self.samples
+        )
+
+
+@dataclass(frozen=True)
+class ZeroOrderHoldDACSignal:
+    """Virtual DAC output using a simple zero-order hold staircase."""
+
+    pcm_buffer: PCMBuffer
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.pcm_buffer, PCMBuffer):
+            raise ValueError("pcm_buffer must be a PCMBuffer")
+
+    def value_at(self, time_seconds: Real) -> float:
+        """Return the held DAC voltage at ``time_seconds``."""
+
+        time = _finite_float("time_seconds", time_seconds)
+        start = self.pcm_buffer.start_time_seconds
+        end = start + self.pcm_buffer.duration_seconds()
+        if time < start or time >= end or self.pcm_buffer.sample_count() == 0:
+            return 0.0
+
+        index = int(floor((time - start) * self.pcm_buffer.pcm_format.sample_rate_hz))
+        if index < 0 or index >= self.pcm_buffer.sample_count():
+            return 0.0
+        return pcm16_to_voltage(
+            self.pcm_buffer.samples[index],
+            self.pcm_buffer.pcm_format,
+        )
+
+
+@dataclass(frozen=True)
+class LinearSpeakerSignal:
+    """Toy speaker model that turns DAC voltage into a pressure-like signal."""
+
+    analog_signal: AnalogSignal
+    speaker_gain: float = DEFAULT_SPEAKER_GAIN
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "speaker_gain",
+            _finite_float("speaker_gain", self.speaker_gain),
+        )
+
+    def value_at(self, time_seconds: Real) -> float:
+        """Return a normalized pressure proxy for the supplied time."""
+
+        return self.speaker_gain * self.analog_signal.value_at(time_seconds)
+
+
+@dataclass(frozen=True)
+class RenderedNote:
+    """The full inspectable chain from a note event to virtual speaker output."""
+
+    note_event: NoteEvent
+    frequency_hz: float
+    oscillator: SineOscillator
+    floating_samples: SampleBuffer
+    pcm_buffer: PCMBuffer
+    dac_signal: ZeroOrderHoldDACSignal
+    speaker_signal: LinearSpeakerSignal
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "frequency_hz",
+            _positive_float("frequency_hz", self.frequency_hz),
+        )
+
+
+def float_to_pcm16(sample: Real) -> tuple[int, bool]:
+    """Convert one normalized floating sample to signed 16-bit PCM.
+
+    The boolean return value tells the caller whether clipping was required.
+    """
+
+    value = _finite_float("sample", sample)
+    clipped = value < -1.0 or value > 1.0
+    bounded = min(1.0, max(-1.0, value))
+    if bounded >= 0.0:
+        return int(round(bounded * PCM16_MAX)), clipped
+    return int(round(bounded * abs(PCM16_MIN))), clipped
+
+
+def pcm16_to_voltage(sample: int, pcm_format: PCMFormat | None = None) -> float:
+    """Map a signed 16-bit PCM integer to virtual DAC voltage."""
+
+    active_format = pcm_format if pcm_format is not None else PCMFormat()
+    checked = PCMBuffer((sample,), active_format).samples[0]
+    if checked >= 0:
+        return checked / PCM16_MAX * active_format.full_scale_voltage
+    return checked / abs(PCM16_MIN) * active_format.full_scale_voltage
+
+
+def encode_sample_buffer(
+    sample_buffer: SampleBuffer,
+    pcm_format: PCMFormat | None = None,
+) -> PCMBuffer:
+    """Quantize floating oscillator samples into signed 16-bit PCM."""
+
+    if not isinstance(sample_buffer, SampleBuffer):
+        raise ValueError("sample_buffer must be an oscillator.SampleBuffer")
+
+    active_format = pcm_format if pcm_format is not None else PCMFormat(
+        sample_rate_hz=sample_buffer.sample_rate_hz
+    )
+    pcm_samples: list[int] = []
+    clipped_count = 0
+    for sample in sample_buffer.samples:
+        pcm_sample, clipped = float_to_pcm16(sample)
+        pcm_samples.append(pcm_sample)
+        if clipped:
+            clipped_count += 1
+
+    return PCMBuffer(
+        samples=tuple(pcm_samples),
+        pcm_format=active_format,
+        start_time_seconds=sample_buffer.start_time_seconds,
+        clipped_sample_count=clipped_count,
+    )
+
+
+def _validate_sample_budget(sample_count: int, max_sample_count: int) -> None:
+    limit = _non_negative_int("max_sample_count", max_sample_count)
+    if sample_count > limit:
+        raise ValueError(
+            f"render would create {sample_count} samples, "
+            f"above max_sample_count={limit}"
+        )
+
+
+def render_note_to_sound_chain(
+    note: NoteInput,
+    duration_seconds: Real,
+    *,
+    sample_rate_hz: Real = DEFAULT_SAMPLE_RATE_HZ,
+    amplitude: Real = DEFAULT_AMPLITUDE,
+    phase_cycles: Real = 0.0,
+    start_time_seconds: Real = 0.0,
+    full_scale_voltage: Real = DEFAULT_FULL_SCALE_VOLTAGE,
+    speaker_gain: Real = DEFAULT_SPEAKER_GAIN,
+    max_sample_count: int = DEFAULT_MAX_SAMPLE_COUNT,
+) -> RenderedNote:
+    """Render a note while keeping every MUS01 layer available for inspection."""
+
+    event = NoteEvent(
+        note=note,
+        duration_seconds=_non_negative_float("duration_seconds", duration_seconds),
+        amplitude=_non_negative_float("amplitude", amplitude),
+        start_time_seconds=_finite_float("start_time_seconds", start_time_seconds),
+    )
+    sample_rate = _positive_float("sample_rate_hz", sample_rate_hz)
+    frequency = event.note.frequency()
+    if frequency >= sample_rate / 2.0:
+        raise ValueError(
+            f"frequency_hz {frequency} must be below Nyquist {sample_rate / 2.0}"
+        )
+
+    count = sample_count_for_duration(event.duration_seconds, sample_rate)
+    _validate_sample_budget(count, max_sample_count)
+
+    oscillator = SineOscillator(
+        frequency_hz=frequency,
+        amplitude=event.amplitude,
+        phase_cycles=_finite_float("phase_cycles", phase_cycles),
+        offset=0.0,
+    )
+    floating_samples = UniformSampler(sample_rate).sample(
+        oscillator,
+        event.duration_seconds,
+        event.start_time_seconds,
+    )
+    pcm_format = PCMFormat(
+        sample_rate_hz=sample_rate,
+        channel_count=DEFAULT_CHANNEL_COUNT,
+        bit_depth=DEFAULT_BIT_DEPTH,
+        full_scale_voltage=_positive_float("full_scale_voltage", full_scale_voltage),
+    )
+    pcm_buffer = encode_sample_buffer(floating_samples, pcm_format)
+    dac_signal = ZeroOrderHoldDACSignal(pcm_buffer)
+    speaker_signal = LinearSpeakerSignal(
+        analog_signal=dac_signal,
+        speaker_gain=_finite_float("speaker_gain", speaker_gain),
+    )
+
+    return RenderedNote(
+        note_event=event,
+        frequency_hz=frequency,
+        oscillator=oscillator,
+        floating_samples=floating_samples,
+        pcm_buffer=pcm_buffer,
+        dac_signal=dac_signal,
+        speaker_signal=speaker_signal,
+    )
+
+
+def to_wav_bytes(pcm_buffer: PCMBuffer) -> bytes:
+    """Write a mono signed-16-bit PCM buffer into a deterministic WAV container."""
+
+    if not isinstance(pcm_buffer, PCMBuffer):
+        raise ValueError("pcm_buffer must be a PCMBuffer")
+
+    sample_rate = pcm_buffer.pcm_format.integer_sample_rate()
+    output = BytesIO()
+    with wave.open(output, "wb") as wav_file:
+        wav_file.setnchannels(pcm_buffer.pcm_format.channel_count)
+        wav_file.setsampwidth(pcm_buffer.pcm_format.sample_width_bytes)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(pcm_buffer.to_little_endian_bytes())
+    return output.getvalue()
+
+
+def write_wav(path: OutputPath, pcm_buffer: PCMBuffer) -> Path:
+    """Write a WAV file and return the resolved ``Path`` object used."""
+
+    output_path = Path(path)
+    output_path.write_bytes(to_wav_bytes(pcm_buffer))
+    return output_path
+
+
+def samples_to_pcm_buffer(
+    samples: Iterable[Real],
+    *,
+    sample_rate_hz: Real,
+    start_time_seconds: Real = 0.0,
+    pcm_format: PCMFormat | None = None,
+) -> PCMBuffer:
+    """Convenience helper for tests and demos that start with raw float samples."""
+
+    sample_buffer = SampleBuffer(
+        samples=tuple(float_to_pcm_input(sample) for sample in samples),
+        sample_rate_hz=_positive_float("sample_rate_hz", sample_rate_hz),
+        start_time_seconds=_finite_float("start_time_seconds", start_time_seconds),
+    )
+    return encode_sample_buffer(sample_buffer, pcm_format)
+
+
+def float_to_pcm_input(sample: Real) -> float:
+    """Validate a raw floating sample before putting it in a SampleBuffer."""
+
+    return _finite_float("sample", sample)

--- a/code/packages/python/note-audio/tests/test_note_audio.py
+++ b/code/packages/python/note-audio/tests/test_note_audio.py
@@ -1,0 +1,321 @@
+"""Tests for the visible note-to-sound signal chain."""
+
+from __future__ import annotations
+
+import math
+import wave
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+from note_frequency import parse_note
+from oscillator import SampleBuffer
+
+from note_audio import (
+    DEFAULT_SAMPLE_RATE_HZ,
+    LinearSpeakerSignal,
+    NoteEvent,
+    PCMBuffer,
+    PCMFormat,
+    ZeroOrderHoldDACSignal,
+    __version__,
+    encode_sample_buffer,
+    float_to_pcm16,
+    pcm16_to_voltage,
+    render_note_to_sound_chain,
+    samples_to_pcm_buffer,
+    to_wav_bytes,
+    write_wav,
+)
+
+ABS_TOLERANCE = 1e-9
+
+
+def assert_close(got: float, want: float, tolerance: float = ABS_TOLERANCE) -> None:
+    """Keep float assertions readable in the tutorial-style tests."""
+
+    assert abs(got - want) <= tolerance
+
+
+def test_version_exists() -> None:
+    assert __version__ == "0.1.0"
+
+
+def test_note_event_parses_strings_and_preserves_timing() -> None:
+    event = NoteEvent(
+        "a4",
+        duration_seconds=0.5,
+        amplitude=0.25,
+        start_time_seconds=2.0,
+    )
+
+    assert str(event.note) == "A4"
+    assert event.duration_seconds == 0.5
+    assert event.amplitude == 0.25
+    assert event.start_time_seconds == 2.0
+
+
+def test_note_event_accepts_parsed_notes() -> None:
+    note = parse_note("C4")
+    event = NoteEvent(note, duration_seconds=1.0)
+
+    assert event.note is note
+    assert_close(event.note.frequency(), 261.6255653005986)
+
+
+def test_render_a4_keeps_every_layer_visible() -> None:
+    chain = render_note_to_sound_chain("A4", duration_seconds=0.01)
+
+    assert str(chain.note_event.note) == "A4"
+    assert chain.frequency_hz == 440.0
+    assert chain.oscillator.frequency_hz == 440.0
+    assert chain.oscillator.amplitude == 0.8
+    assert chain.floating_samples.sample_rate_hz == DEFAULT_SAMPLE_RATE_HZ
+    assert chain.floating_samples.sample_count() == 441
+    assert chain.pcm_buffer.sample_count() == 441
+    assert chain.pcm_buffer.clipped_sample_count == 0
+    assert chain.pcm_buffer.samples[0] == 0
+    assert chain.dac_signal.value_at(0.0) == 0.0
+    assert chain.speaker_signal.value_at(0.0) == 0.0
+
+    first_nonzero_time = chain.pcm_buffer.time_at(1)
+    assert chain.dac_signal.value_at(first_nonzero_time) > 0.0
+    assert chain.speaker_signal.value_at(first_nonzero_time) > 0.0
+
+
+def test_render_uses_start_time_for_samples_and_dac_hold() -> None:
+    chain = render_note_to_sound_chain(
+        "A4",
+        duration_seconds=0.001,
+        start_time_seconds=10.0,
+    )
+
+    assert_close(chain.floating_samples.time_at(0), 10.0)
+    assert chain.dac_signal.value_at(9.999) == 0.0
+    assert chain.dac_signal.value_at(10.0) == 0.0
+    assert chain.dac_signal.value_at(10.0 + chain.pcm_buffer.duration_seconds()) == 0.0
+
+
+def test_zero_duration_render_is_an_empty_but_valid_chain() -> None:
+    chain = render_note_to_sound_chain("A4", duration_seconds=0.0)
+
+    assert chain.floating_samples.sample_count() == 0
+    assert chain.pcm_buffer.sample_count() == 0
+    assert chain.dac_signal.value_at(0.0) == 0.0
+    assert chain.speaker_signal.value_at(0.0) == 0.0
+
+
+def test_pcm_parity_vector_for_one_hz_sampled_at_four_hz() -> None:
+    sample_buffer = SampleBuffer(
+        samples=(0.0, 1.0, 0.0, -1.0),
+        sample_rate_hz=4.0,
+    )
+    pcm_buffer = encode_sample_buffer(sample_buffer, PCMFormat(sample_rate_hz=4.0))
+    dac = ZeroOrderHoldDACSignal(pcm_buffer)
+    speaker = LinearSpeakerSignal(dac)
+
+    assert pcm_buffer.samples == (0, 32767, 0, -32768)
+    assert dac.value_at(0.00) == 0.0
+    assert dac.value_at(0.24) == 0.0
+    assert dac.value_at(0.25) == 1.0
+    assert dac.value_at(0.49) == 1.0
+    assert dac.value_at(0.50) == 0.0
+    assert dac.value_at(0.74) == 0.0
+    assert dac.value_at(0.75) == -1.0
+    assert dac.value_at(0.99) == -1.0
+    assert dac.value_at(1.00) == 0.0
+    assert speaker.value_at(0.75) == -1.0
+
+
+def test_float_to_pcm16_clips_and_reports_clipping() -> None:
+    assert float_to_pcm16(0.0) == (0, False)
+    assert float_to_pcm16(1.0) == (32767, False)
+    assert float_to_pcm16(-1.0) == (-32768, False)
+    assert float_to_pcm16(2.0) == (32767, True)
+    assert float_to_pcm16(-2.0) == (-32768, True)
+
+
+def test_encode_sample_buffer_tracks_clipped_samples() -> None:
+    buffer = SampleBuffer(samples=(2.0, -2.0, 0.5, -0.5), sample_rate_hz=8.0)
+    pcm_buffer = encode_sample_buffer(buffer, PCMFormat(sample_rate_hz=8.0))
+
+    assert pcm_buffer.samples == (32767, -32768, 16384, -16384)
+    assert pcm_buffer.clipped_sample_count == 2
+
+
+def test_samples_to_pcm_buffer_validates_and_encodes_raw_samples() -> None:
+    pcm_buffer = samples_to_pcm_buffer((0.0, 1.0, -1.0), sample_rate_hz=3.0)
+
+    assert pcm_buffer.samples == (0, 32767, -32768)
+    assert pcm_buffer.sample_count() == 3
+    assert_close(pcm_buffer.duration_seconds(), 1.0)
+
+
+def test_pcm_buffer_metadata_and_bytes() -> None:
+    pcm_buffer = PCMBuffer(
+        samples=(0, 32767, -32768),
+        pcm_format=PCMFormat(sample_rate_hz=3.0),
+        start_time_seconds=5.0,
+    )
+
+    assert pcm_buffer.sample_count() == 3
+    assert_close(pcm_buffer.sample_period_seconds(), 1.0 / 3.0)
+    assert_close(pcm_buffer.duration_seconds(), 1.0)
+    assert_close(pcm_buffer.time_at(2), 5.0 + 2.0 / 3.0)
+    assert pcm_buffer.to_little_endian_bytes() == b"\x00\x00\xff\x7f\x00\x80"
+
+
+def test_pcm16_to_voltage_uses_asymmetric_signed_range() -> None:
+    pcm_format = PCMFormat(sample_rate_hz=4.0, full_scale_voltage=2.0)
+
+    assert pcm16_to_voltage(0, pcm_format) == 0.0
+    assert pcm16_to_voltage(32767, pcm_format) == 2.0
+    assert pcm16_to_voltage(-32768, pcm_format) == -2.0
+
+
+def test_linear_speaker_gain_scales_the_dac_signal() -> None:
+    pcm_buffer = PCMBuffer((0, 32767), PCMFormat(sample_rate_hz=2.0))
+    speaker = LinearSpeakerSignal(ZeroOrderHoldDACSignal(pcm_buffer), speaker_gain=0.5)
+
+    assert speaker.value_at(0.0) == 0.0
+    assert speaker.value_at(0.5) == 0.5
+
+
+def test_wav_bytes_are_parseable_mono_pcm() -> None:
+    pcm_buffer = PCMBuffer(
+        samples=(0, 32767, -32768),
+        pcm_format=PCMFormat(sample_rate_hz=8.0),
+    )
+    wav_bytes = to_wav_bytes(pcm_buffer)
+
+    assert wav_bytes.startswith(b"RIFF")
+    assert wav_bytes[8:12] == b"WAVE"
+    with wave.open(BytesIO(wav_bytes), "rb") as wav_file:
+        assert wav_file.getnchannels() == 1
+        assert wav_file.getsampwidth() == 2
+        assert wav_file.getframerate() == 8
+        assert wav_file.getnframes() == 3
+        assert wav_file.readframes(3) == b"\x00\x00\xff\x7f\x00\x80"
+
+
+def test_write_wav_writes_the_same_bytes(tmp_path: Path) -> None:
+    pcm_buffer = PCMBuffer((0,), PCMFormat(sample_rate_hz=8.0))
+    output_path = tmp_path / "tone.wav"
+
+    returned_path = write_wav(output_path, pcm_buffer)
+
+    assert returned_path == output_path
+    assert output_path.read_bytes() == to_wav_bytes(pcm_buffer)
+
+
+@pytest.mark.parametrize(
+    ("note", "message"),
+    [
+        ("H4", "Invalid note"),
+        (object(), "note must be"),
+    ],
+)
+def test_render_rejects_invalid_notes(note: object, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        render_note_to_sound_chain(note, duration_seconds=1.0)
+
+
+def test_render_rejects_nyquist_violation() -> None:
+    with pytest.raises(ValueError, match="below Nyquist"):
+        render_note_to_sound_chain("A4", duration_seconds=1.0, sample_rate_hz=800.0)
+
+
+def test_render_rejects_oversized_sample_budget() -> None:
+    with pytest.raises(ValueError, match="above max_sample_count"):
+        render_note_to_sound_chain("A4", duration_seconds=1.0, max_sample_count=10)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"duration_seconds": -1.0}, "duration_seconds"),
+        ({"duration_seconds": math.nan}, "duration_seconds"),
+        ({"sample_rate_hz": 0.0}, "sample_rate_hz"),
+        ({"amplitude": -0.1}, "amplitude"),
+        ({"phase_cycles": math.inf}, "phase_cycles"),
+        ({"full_scale_voltage": 0.0}, "full_scale_voltage"),
+        ({"speaker_gain": math.nan}, "speaker_gain"),
+        ({"max_sample_count": -1}, "max_sample_count"),
+    ],
+)
+def test_render_rejects_invalid_numeric_inputs(
+    kwargs: dict[str, object],
+    message: str,
+) -> None:
+    render_kwargs = {"duration_seconds": 1.0}
+    render_kwargs.update(kwargs)
+    with pytest.raises(ValueError, match=message):
+        render_note_to_sound_chain("A4", **render_kwargs)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"sample_rate_hz": 0.0}, "sample_rate_hz"),
+        ({"channel_count": 2}, "mono"),
+        ({"bit_depth": 24}, "16-bit"),
+        ({"full_scale_voltage": 0.0}, "full_scale_voltage"),
+    ],
+)
+def test_pcm_format_rejects_unsupported_v1_shapes(
+    kwargs: dict[str, object],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        PCMFormat(**kwargs)
+
+
+@pytest.mark.parametrize(
+    ("samples", "message"),
+    [
+        ((True,), "PCM integer"),
+        ((32768,), "signed 16-bit"),
+        ((-32769,), "signed 16-bit"),
+    ],
+)
+def test_pcm_buffer_rejects_invalid_integer_samples(
+    samples: tuple[object, ...],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        PCMBuffer(samples, PCMFormat())
+
+
+def test_pcm_buffer_rejects_invalid_metadata_and_indexes() -> None:
+    with pytest.raises(ValueError, match="pcm_format"):
+        PCMBuffer((0,), object())  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="clipped_sample_count"):
+        PCMBuffer((0,), PCMFormat(), clipped_sample_count=-1)
+
+    buffer = PCMBuffer((0,), PCMFormat())
+    with pytest.raises(ValueError, match="index"):
+        buffer.time_at(1)
+    with pytest.raises(ValueError, match="index"):
+        buffer.time_at(True)  # type: ignore[arg-type]
+
+
+def test_dac_and_encoder_reject_invalid_inputs() -> None:
+    with pytest.raises(ValueError, match="sample"):
+        float_to_pcm16(math.nan)
+    with pytest.raises(ValueError, match="sample_buffer"):
+        encode_sample_buffer(object())  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="pcm_buffer"):
+        ZeroOrderHoldDACSignal(object())  # type: ignore[arg-type]
+
+    dac = ZeroOrderHoldDACSignal(PCMBuffer((0,), PCMFormat()))
+    with pytest.raises(ValueError, match="time_seconds"):
+        dac.value_at(math.inf)
+
+
+def test_wav_output_rejects_non_integer_sample_rates_and_bad_buffers() -> None:
+    pcm_buffer = PCMBuffer((0,), PCMFormat(sample_rate_hz=44_100.5))
+
+    with pytest.raises(ValueError, match="integer-valued"):
+        to_wav_bytes(pcm_buffer)
+    with pytest.raises(ValueError, match="pcm_buffer"):
+        to_wav_bytes(object())  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

- Adds `code/packages/python/note-audio`, the first Python proof-of-concept for the MUS01 note-to-sound signal chain.
- Keeps each layer visible: note event, note-to-frequency conversion, oscillator-backed floating samples, signed 16-bit PCM encoding, zero-order-hold virtual DAC, linear virtual speaker, and deterministic WAV output.
- Includes package metadata, BUILD files, README, CHANGELOG, capability declaration, and tests covering validation, clipping, metadata, DAC/speaker behavior, and WAV serialization.

## Validation

- `sh BUILD` from `code/packages/python/note-audio` - 37 tests passing, 97.52% coverage.
- `/tmp/coding-adventures-build-tool -root /Users/adhithya/Downloads/coding-adventures-python-note-audio-v1 -diff-base origin/main -language python -jobs 2` - 4 affected packages built, 317 skipped.
- Local security review: no network/process execution/device access; only optional filesystem write is the explicit caller-provided WAV output path.