### PR TITLE
Add Prolog-style term metaprogramming builtins

### DIFF
--- a/code/packages/python/logic-builtins/CHANGELOG.md
+++ b/code/packages/python/logic-builtins/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.5.0] - 2026-04-20
+
+### Added
+
+- term metaprogramming predicates: `univo`, `copytermo`, `same_termo`, `atomico`, and `callableo`
+- construction-mode `functoro` for atoms and compounds with fresh argument variables
+- tests covering Prolog-style term decomposition, construction, variable-refreshing copies, strict identity, and callable/atomic classification
+
 ## [0.4.0] - 2026-04-20
 
 ### Added

--- a/code/packages/python/logic-builtins/README.md
+++ b/code/packages/python/logic-builtins/README.md
@@ -18,8 +18,11 @@ ordinary logic goal expressions.
 - `groundo(term)`
 - `varo(term)` and `nonvaro(term)`
 - `atomo(term)`, `numbero(term)`, `stringo(term)`, and `compoundo(term)`
-- `functoro(term, name, arity)`
+- `atomico(term)` and `callableo(term)`
+- `functoro(term, name, arity)` for inspection and construction
 - `argo(index, term, value)`
+- `univo(term, parts)` for Prolog-style `=../2` term decomposition/construction
+- `copytermo(source, copy)` and `same_termo(left, right)`
 - arithmetic expression constructors: `add`, `sub`, `mul`, `div`, `floordiv`, `mod`, and `neg`
 - `iso(result, expression)` for Prolog-style evaluative arithmetic
 - `numeqo(left, right)`, `numneqo(left, right)`, `lto(left, right)`, `leqo(left, right)`, `gto(left, right)`, and `geqo(left, right)`
@@ -40,6 +43,8 @@ from logic_builtins import (
     iso,
     noto,
     onceo,
+    same_termo,
+    univo,
 )
 from logic_engine import atom, conj, eq, fail, logic_list, num, program, solve_all, term, var
 
@@ -80,6 +85,17 @@ assert solve_all(
     X,
     forallo(conj(eq(X, 7)), geqo(X, 7)),
 ) == [X]
+assert solve_all(
+    program(),
+    Results,
+    univo(term("box", "tea", "cake"), Results),
+) == [logic_list(["box", "tea", "cake"])]
+assert solve_all(
+    program(),
+    X,
+    univo(X, logic_list(["box", "tea", "cake"])),
+) == [term("box", "tea", "cake")]
+assert solve_all(program(), X, same_termo(X, X)) == [X]
 ```
 
 Arithmetic is evaluative, not a constraint system yet. `iso(Y, add(X, 1))`
@@ -96,6 +112,12 @@ branch to keep backtracking. `forallo` checks every generated proof without
 leaking generator bindings to the outer query. Full Prolog cut is not included
 yet because it needs solver-level choicepoint pruning rather than a simple
 library predicate.
+
+Term metaprogramming treats terms as ordinary data. `univo` decomposes
+`box(tea, cake)` into `[box, tea, cake]` and can construct the term back from
+that list. `functoro` now constructs atoms and compounds when supplied a name
+and arity. `copytermo` refreshes variables in a copied term, while
+`same_termo` checks strict identity without binding variables.
 
 ## Dependencies
 

--- a/code/packages/python/logic-builtins/pyproject.toml
+++ b/code/packages/python/logic-builtins/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-logic-builtins"
-version = "0.4.0"
-description = "Prolog-inspired control, term, arithmetic, and collection builtins for the Python logic stack"
+version = "0.5.0"
+description = "Prolog-inspired control, term, arithmetic, collection, and metaprogramming builtins for the Python logic stack"
 requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]
@@ -17,7 +17,7 @@ dependencies = [
 [project.urls]
 Homepage = "https://github.com/adhithyan15/coding-adventures"
 Repository = "https://github.com/adhithyan15/coding-adventures"
-Documentation = "https://github.com/adhithyan15/coding-adventures/tree/main/code/specs/LP14-logic-advanced-control-builtins.md"
+Documentation = "https://github.com/adhithyan15/coding-adventures/tree/main/code/specs/LP15-logic-term-metaprogramming-builtins.md"
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]

--- a/code/packages/python/logic-builtins/src/logic_builtins/__init__.py
+++ b/code/packages/python/logic-builtins/src/logic_builtins/__init__.py
@@ -7,10 +7,13 @@ the first state-aware builtins layer for the library-first Prolog path.
 from logic_builtins.builtins import (
     add,
     argo,
+    atomico,
     atomo,
     bagofo,
+    callableo,
     callo,
     compoundo,
+    copytermo,
     div,
     failo,
     findallo,
@@ -34,10 +37,12 @@ from logic_builtins.builtins import (
     numeqo,
     numneqo,
     onceo,
+    same_termo,
     setofo,
     stringo,
     sub,
     trueo,
+    univo,
     varo,
 )
 
@@ -45,10 +50,13 @@ __all__ = [
     "__version__",
     "add",
     "argo",
+    "atomico",
     "atomo",
     "bagofo",
     "callo",
+    "callableo",
     "compoundo",
+    "copytermo",
     "div",
     "failo",
     "findallo",
@@ -72,11 +80,13 @@ __all__ = [
     "numneqo",
     "numbero",
     "onceo",
+    "same_termo",
     "setofo",
     "stringo",
     "sub",
     "trueo",
+    "univo",
     "varo",
 ]
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/code/packages/python/logic-builtins/src/logic_builtins/builtins.py
+++ b/code/packages/python/logic-builtins/src/logic_builtins/builtins.py
@@ -44,9 +44,12 @@ from logic_engine import (
 __all__ = [
     "add",
     "argo",
+    "atomico",
     "atomo",
     "callo",
+    "callableo",
     "compoundo",
+    "copytermo",
     "div",
     "failo",
     "findallo",
@@ -71,10 +74,12 @@ __all__ = [
     "numbero",
     "onceo",
     "bagofo",
+    "same_termo",
     "setofo",
     "stringo",
     "sub",
     "trueo",
+    "univo",
     "varo",
 ]
 
@@ -105,6 +110,85 @@ def _is_ground(term_value: Term) -> bool:
     if isinstance(term_value, Compound):
         return all(_is_ground(argument) for argument in term_value.args)
     return True
+
+
+def _is_empty_list(term_value: Term) -> bool:
+    """Return True when a term is the canonical empty logic list."""
+
+    return (
+        isinstance(term_value, Atom)
+        and term_value.symbol.namespace is None
+        and term_value.symbol.name == "[]"
+    )
+
+
+def _is_cons(term_value: Term) -> bool:
+    """Return True when a term is a canonical logic-list cons cell."""
+
+    return (
+        isinstance(term_value, Compound)
+        and term_value.functor.namespace is None
+        and term_value.functor.name == "."
+        and len(term_value.args) == 2
+    )
+
+
+def _proper_list_items(term_value: Term) -> list[Term] | None:
+    """Decode a reified proper logic list into host-language items."""
+
+    items: list[Term] = []
+    current = term_value
+    while not _is_empty_list(current):
+        if not _is_cons(current):
+            return None
+        head, tail = current.args
+        items.append(head)
+        current = tail
+    return items
+
+
+def _fresh_copy(
+    term_value: Term,
+    mapping: dict[LogicVar, LogicVar],
+    next_var_id: int,
+) -> tuple[Term, int]:
+    """Copy one term, replacing every source variable with a fresh variable."""
+
+    if isinstance(term_value, LogicVar):
+        existing = mapping.get(term_value)
+        if existing is not None:
+            return existing, next_var_id
+
+        copied = LogicVar(
+            id=next_var_id,
+            display_name=term_value.display_name,
+        )
+        mapping[term_value] = copied
+        return copied, next_var_id + 1
+
+    if isinstance(term_value, Compound):
+        copied_args: list[Term] = []
+        running_id = next_var_id
+        for argument in term_value.args:
+            copied_argument, running_id = _fresh_copy(
+                argument,
+                mapping,
+                running_id,
+            )
+            copied_args.append(copied_argument)
+        return Compound(functor=term_value.functor, args=tuple(copied_args)), running_id
+
+    return term_value, next_var_id
+
+
+def _state_with_next_var_id(state: State, next_var_id: int) -> State:
+    """Preserve the logical state while reserving freshly allocated variables."""
+
+    return State(
+        substitution=state.substitution,
+        constraints=state.constraints,
+        next_var_id=next_var_id,
+    )
 
 
 def _succeed_if(condition: bool, state: State) -> Iterator[State]:
@@ -588,25 +672,88 @@ def compoundo(term_value: object) -> GoalExpr:
     return _type_checko(term_value, Compound)
 
 
-def functoro(term_value: object, name: object, arity: object) -> GoalExpr:
-    """Inspect a compound term's functor name and arity.
+def atomico(term_value: object) -> GoalExpr:
+    """Succeed when the current value is an atomic term."""
 
-    This first slice supports inspection mode. Construction mode can come later
-    once the runtime has a clearer policy for using partially instantiated
-    structural builtins to allocate new compound terms.
-    """
+    def run(_program: Program, state: State, args: NativeArgs) -> Iterator[State]:
+        (target,) = args
+        reified_target = _reified(target, state)
+        yield from _succeed_if(
+            isinstance(reified_target, Atom | Number | String),
+            state,
+        )
+
+    return native_goal(run, term_value)
+
+
+def callableo(term_value: object) -> GoalExpr:
+    """Succeed when the current value can represent a callable term."""
+
+    def run(_program: Program, state: State, args: NativeArgs) -> Iterator[State]:
+        (target,) = args
+        reified_target = _reified(target, state)
+        yield from _succeed_if(
+            isinstance(reified_target, Atom | Compound),
+            state,
+        )
+
+    return native_goal(run, term_value)
+
+
+def functoro(term_value: object, name: object, arity: object) -> GoalExpr:
+    """Inspect or construct a term from a functor name and arity."""
 
     def run(program_value: Program, state: State, args: NativeArgs) -> Iterator[State]:
         target, name_target, arity_target = args
         reified_target = _reified(target, state)
-        if not isinstance(reified_target, Compound):
+
+        if isinstance(reified_target, Compound):
+            goal = conj(
+                eq(name_target, atom(reified_target.functor)),
+                eq(arity_target, num(len(reified_target.args))),
+            )
+            yield from solve_from(program_value, goal, state)
             return
 
-        goal = conj(
-            eq(name_target, atom(reified_target.functor)),
-            eq(arity_target, num(len(reified_target.args))),
+        if isinstance(reified_target, Atom | Number | String):
+            yield from solve_from(
+                program_value,
+                conj(eq(name_target, reified_target), eq(arity_target, num(0))),
+                state,
+            )
+            return
+
+        reified_name = _reified(name_target, state)
+        reified_arity = _reified(arity_target, state)
+        if not isinstance(reified_arity, Number):
+            return
+        raw_arity = reified_arity.value
+        if not isinstance(raw_arity, int) or raw_arity < 0:
+            return
+
+        if raw_arity == 0:
+            if not isinstance(reified_name, Atom | Number | String):
+                return
+            yield from solve_from(program_value, eq(target, reified_name), state)
+            return
+
+        if not isinstance(reified_name, Atom):
+            return
+
+        arguments = tuple(
+            LogicVar(id=state.next_var_id + offset)
+            for offset in range(raw_arity)
         )
-        yield from solve_from(program_value, goal, state)
+        constructed = Compound(functor=reified_name.symbol, args=arguments)
+        construction_state = _state_with_next_var_id(
+            state,
+            state.next_var_id + raw_arity,
+        )
+        yield from solve_from(
+            program_value,
+            eq(target, constructed),
+            construction_state,
+        )
 
     return native_goal(run, term_value, name, arity)
 
@@ -636,3 +783,73 @@ def argo(index: object, term_value: object, value: object) -> GoalExpr:
         )
 
     return native_goal(run, index, term_value, value)
+
+
+def univo(term_value: object, parts: object) -> GoalExpr:
+    """Decompose or construct a term using a Prolog-style functor-first list."""
+
+    def run(program_value: Program, state: State, args: NativeArgs) -> Iterator[State]:
+        target, parts_target = args
+        reified_target = _reified(target, state)
+
+        if isinstance(reified_target, Compound):
+            decomposed = logic_list(
+                [atom(reified_target.functor), *reified_target.args],
+            )
+            yield from solve_from(program_value, eq(parts_target, decomposed), state)
+            return
+
+        if isinstance(reified_target, Atom | Number | String):
+            yield from solve_from(
+                program_value,
+                eq(parts_target, logic_list([reified_target])),
+                state,
+            )
+            return
+
+        reified_parts = _reified(parts_target, state)
+        items = _proper_list_items(reified_parts)
+        if not items:
+            return
+
+        if len(items) == 1:
+            yield from solve_from(program_value, eq(target, items[0]), state)
+            return
+
+        functor_term = items[0]
+        if not isinstance(functor_term, Atom):
+            return
+
+        constructed = Compound(functor=functor_term.symbol, args=tuple(items[1:]))
+        yield from solve_from(program_value, eq(target, constructed), state)
+
+    return native_goal(run, term_value, parts)
+
+
+def copytermo(source: object, copy: object) -> GoalExpr:
+    """Copy a term while replacing source variables with fresh variables."""
+
+    def run(program_value: Program, state: State, args: NativeArgs) -> Iterator[State]:
+        source_term, copy_target = args
+        copied_source, next_var_id = _fresh_copy(
+            _reified(source_term, state),
+            {},
+            state.next_var_id,
+        )
+        copy_state = _state_with_next_var_id(state, next_var_id)
+        yield from solve_from(program_value, eq(copy_target, copied_source), copy_state)
+
+    return native_goal(run, source, copy)
+
+
+def same_termo(left: object, right: object) -> GoalExpr:
+    """Succeed when two reified terms are strictly identical without binding."""
+
+    def run(_program: Program, state: State, args: NativeArgs) -> Iterator[State]:
+        left_term, right_term = args
+        yield from _succeed_if(
+            _reified(left_term, state) == _reified(right_term, state),
+            state,
+        )
+
+    return native_goal(run, left, right)

--- a/code/packages/python/logic-builtins/tests/test_logic_builtins.py
+++ b/code/packages/python/logic-builtins/tests/test_logic_builtins.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import pytest
 from logic_engine import (
+    Compound,
+    LogicVar,
     atom,
     conj,
     disj,
@@ -25,10 +27,13 @@ from logic_builtins import (
     __version__,
     add,
     argo,
+    atomico,
     atomo,
     bagofo,
+    callableo,
     callo,
     compoundo,
+    copytermo,
     div,
     failo,
     findallo,
@@ -52,10 +57,12 @@ from logic_builtins import (
     numeqo,
     numneqo,
     onceo,
+    same_termo,
     setofo,
     stringo,
     sub,
     trueo,
+    univo,
     varo,
 )
 
@@ -64,7 +71,7 @@ class TestVersion:
     """Verify the package is importable and versioned."""
 
     def test_version_exists(self) -> None:
-        assert __version__ == "0.4.0"
+        assert __version__ == "0.5.0"
 
 
 class TestAdvancedControlBuiltins:
@@ -485,6 +492,156 @@ class TestControlBuiltins:
             noto(object())
 
 
+class TestTermMetaprogrammingBuiltins:
+    """Term metaprogramming should expose Prolog-style term-as-data tools."""
+
+    def test_univo_decomposes_compounds_in_functor_first_order(self) -> None:
+        parts = var("Parts")
+
+        assert solve_all(
+            program(),
+            parts,
+            univo(term("box", "tea", "cake"), parts),
+        ) == [logic_list(["box", "tea", "cake"])]
+
+    def test_univo_decomposes_atomic_terms_to_singleton_lists(self) -> None:
+        parts = var("Parts")
+
+        assert solve_all(program(), parts, univo("tea", parts)) == [
+            logic_list(["tea"]),
+        ]
+        assert solve_all(program(), parts, univo(3, parts)) == [logic_list([3])]
+        assert solve_all(program(), parts, univo(string("tea"), parts)) == [
+            logic_list([string("tea")]),
+        ]
+
+    def test_univo_constructs_compounds_and_atomic_terms(self) -> None:
+        value = var("Value")
+
+        assert solve_all(
+            program(),
+            value,
+            univo(value, logic_list(["box", "tea", "cake"])),
+        ) == [term("box", "tea", "cake")]
+        assert solve_all(program(), value, univo(value, logic_list([3]))) == [num(3)]
+
+    def test_univo_fails_for_invalid_construction_parts(self) -> None:
+        value = var("Value")
+
+        assert solve_all(program(), value, univo(value, logic_list([]))) == []
+        assert solve_all(program(), value, univo(value, logic_list([1, "tea"]))) == []
+        assert solve_all(program(), value, univo(value, term(".", "box", "open"))) == []
+
+    def test_functoro_inspects_compound_and_atomic_terms(self) -> None:
+        name = var("Name")
+        arity = var("Arity")
+
+        assert solve_all(
+            program(),
+            (name, arity),
+            functoro(term("box", "tea", "cake"), name, arity),
+        ) == [(atom("box"), num(2))]
+        assert solve_all(program(), (name, arity), functoro("tea", name, arity)) == [
+            (atom("tea"), num(0)),
+        ]
+        assert solve_all(program(), (name, arity), functoro(3, name, arity)) == [
+            (num(3), num(0)),
+        ]
+
+    def test_functoro_constructs_atoms_and_compounds(self) -> None:
+        value = var("Value")
+
+        assert solve_all(program(), value, functoro(value, "tea", 0)) == [atom("tea")]
+
+        constructed = solve_all(program(), value, functoro(value, "box", 2))
+        assert len(constructed) == 1
+        [box] = constructed
+        assert isinstance(box, Compound)
+        assert box.functor == atom("box").symbol
+        assert len(box.args) == 2
+        assert all(isinstance(argument, LogicVar) for argument in box.args)
+        assert box.args[0] != box.args[1]
+
+    def test_functoro_fails_for_invalid_construction_inputs(self) -> None:
+        value = var("Value")
+        name = var("Name")
+
+        assert solve_all(program(), value, functoro(value, name, 1)) == []
+        assert solve_all(program(), value, functoro(value, "box", -1)) == []
+        assert solve_all(program(), value, functoro(value, "box", 1.5)) == []
+        assert solve_all(program(), value, functoro(value, 3, 1)) == []
+
+    def test_copytermo_copies_ground_terms_and_refreshes_variables(self) -> None:
+        copy = var("Copy")
+        original = var("Original")
+
+        assert solve_all(program(), copy, copytermo(term("box", "tea"), copy)) == [
+            term("box", "tea"),
+        ]
+
+        [copied] = solve_all(
+            program(),
+            copy,
+            copytermo(term("pair", original, original), copy),
+        )
+        assert isinstance(copied, Compound)
+        assert copied.functor == atom("pair").symbol
+        assert copied.args[0] == copied.args[1]
+        assert copied.args[0] != original
+
+    def test_copytermo_respects_existing_bindings_before_copying(self) -> None:
+        source = var("Source")
+        inner = var("Inner")
+        copy = var("Copy")
+
+        assert solve_all(
+            program(),
+            copy,
+            conj(
+                eq(source, term("box", inner)),
+                eq(inner, "tea"),
+                copytermo(source, copy),
+            ),
+        ) == [term("box", "tea")]
+
+    def test_same_termo_checks_strict_identity_without_unifying(self) -> None:
+        left = var("Left")
+        right = var("Right")
+
+        assert solve_all(program(), left, same_termo(left, left)) == [left]
+        assert solve_all(program(), (left, right), same_termo(left, right)) == []
+        assert solve_all(
+            program(),
+            (left, right),
+            conj(eq(left, right), same_termo(left, right)),
+        ) == [(right, right)]
+
+    def test_atomico_and_callableo_classify_reified_terms(self) -> None:
+        value = var("Value")
+
+        assert solve_all(program(), value, conj(eq(value, "tea"), atomico(value))) == [
+            atom("tea"),
+        ]
+        assert solve_all(program(), value, conj(eq(value, 3), atomico(value))) == [
+            num(3),
+        ]
+        assert solve_all(
+            program(),
+            value,
+            conj(eq(value, term("box", "tea")), atomico(value)),
+        ) == []
+        assert solve_all(
+            program(),
+            value,
+            conj(eq(value, term("box", "tea")), callableo(value)),
+        ) == [term("box", "tea")]
+        assert solve_all(
+            program(),
+            value,
+            conj(eq(value, string("tea")), callableo(value)),
+        ) == []
+
+
 class TestTermStateBuiltins:
     """Term predicates should observe the current substitution."""
 
@@ -539,11 +696,14 @@ class TestTermStateBuiltins:
             functoro(term("box", "tea", "cake"), name, arity),
         ) == [(atom("box"), num(2))]
 
-    def test_functoro_fails_for_non_compound_terms(self) -> None:
+    def test_functoro_fails_for_unbound_terms_without_construction_inputs(
+        self,
+    ) -> None:
+        target = var("Target")
         name = var("Name")
         arity = var("Arity")
 
-        assert solve_all(program(), (name, arity), functoro("tea", name, arity)) == []
+        assert solve_all(program(), (name, arity), functoro(target, name, arity)) == []
 
     def test_argo_extracts_one_based_compound_arguments(self) -> None:
         value = var("Value")

--- a/code/specs/LP15-logic-term-metaprogramming-builtins.md
+++ b/code/specs/LP15-logic-term-metaprogramming-builtins.md
@@ -1,0 +1,181 @@
+# LP15 - Logic Term Metaprogramming Builtins
+
+## Overview
+
+LP11 through LP14 made the Python logic stack useful for real relational
+programming: control predicates, type checks, arithmetic, collections, and
+advanced committed-choice helpers now exist as library goals. The next
+Prolog-level functionality gap is metaprogramming over terms.
+
+Prolog programs often treat clauses and goals as data. Before the parser layer
+exists, the Python library should still let callers inspect, construct, and
+copy logic terms in a Prolog-shaped way.
+
+LP15 extends `logic-builtins` with term metaprogramming predicates.
+
+## Design Goal
+
+Add a first library layer for working with terms as data:
+
+- decompose and construct terms with `univo`, the library spelling of `=../2`
+- extend `functoro` from inspection-only into construction mode
+- copy terms while refreshing variables
+- test strict term identity without unifying
+- add small atomic/callable classification helpers
+
+These predicates should compose with the existing `logic-engine` solver and
+should remain ordinary goal constructors, not syntax.
+
+## Package
+
+Update:
+
+```text
+code/packages/python/logic-builtins
+```
+
+The package version should move from `0.4.0` to `0.5.0`.
+
+## Public API
+
+Add:
+
+```python
+univo(term, parts)
+copytermo(source, copy)
+same_termo(left, right)
+atomico(term)
+callableo(term)
+```
+
+Extend:
+
+```python
+functoro(term, name, arity)
+```
+
+## Semantics
+
+### `univo(term, parts)`
+
+`univo` is the library spelling of Prolog's `=../2`.
+
+In decomposition mode, when `term` is instantiated:
+
+- a compound term `box(tea, cake)` decomposes to `[box, tea, cake]`
+- an atomic term such as `tea`, `3`, or `"tea"` decomposes to `[tea]`, `[3]`,
+  or `["tea"]`
+
+In construction mode, when `term` is unbound and `parts` is a proper list:
+
+- a one-item list constructs that atomic item
+- a multi-item list constructs a compound whose first item is an atom functor
+  and whose remaining items are arguments
+- an empty list fails
+- a multi-item list whose first item is not an atom fails
+
+LP15 does not support partial-list generation. `parts` must either be a proper
+list after reification or be unified from an instantiated `term`.
+
+### `functoro(term, name, arity)`
+
+`functoro` should now support both inspection and construction.
+
+Inspection mode:
+
+- for a compound, unify `name` with its functor atom and `arity` with its
+  argument count
+- for an atomic term, unify `name` with the term itself and `arity` with `0`
+
+Construction mode:
+
+- if `term` is unbound, `name` is instantiated, and `arity` is a non-negative
+  integer number, build a term
+- `arity == 0` builds the atomic `name`
+- `arity > 0` requires `name` to be an atom and builds a compound with fresh
+  logic variables as arguments
+
+This mirrors the useful Prolog behavior while staying finite and predictable.
+
+### `copytermo(source, copy)`
+
+`copytermo` duplicates a term and replaces every unbound variable in the source
+with a fresh variable in the copy. Repeated references to the same source
+variable must map to the same fresh copy variable.
+
+Bindings that already exist in the active substitution should be respected
+before copying. In other words, `copytermo(X, Copy)` after `X = box(Y)` copies
+`box(Y)`, not the original unbound `X`.
+
+### `same_termo(left, right)`
+
+`same_termo` is strict identity/equality over reified terms. It succeeds when
+the two reified terms are structurally equal, including variable identity. It
+does not bind variables.
+
+This is the library spelling of Prolog's `==/2`, not unification.
+
+### `atomico(term)`
+
+Succeeds when the current reified term is atomic:
+
+- atom
+- number
+- string
+
+Unbound variables and compound terms fail.
+
+### `callableo(term)`
+
+Succeeds when the current reified term can be called as a goal-like term:
+
+- atom
+- compound
+
+Numbers, strings, and unbound variables fail in this first slice.
+
+## Error Model
+
+These predicates should use logical failure for ordinary mode failures:
+
+- invalid `univo` parts fail
+- construction-mode `functoro` with a non-integer or negative arity fails
+- construction-mode `functoro` with a positive arity and non-atom functor fails
+
+Host-language coercion errors from unsupported Python objects may still raise
+`TypeError`, following the existing package convention.
+
+## Test Strategy
+
+Required tests:
+
+- `univo` decomposes compounds in functor-first order
+- `univo` decomposes atomic values to singleton lists
+- `univo` constructs compounds from proper lists
+- `univo` constructs atomic values from singleton lists
+- `univo` fails for empty lists and invalid compound functors
+- `functoro` inspects compound and atomic terms
+- `functoro` constructs atoms for arity zero
+- `functoro` constructs compounds with fresh argument variables
+- `functoro` fails for invalid construction inputs
+- `copytermo` copies ground terms unchanged
+- `copytermo` refreshes variables while preserving aliasing inside the copy
+- `same_termo` observes strict equality without binding variables
+- `atomico` and `callableo` classify reified terms
+
+## Future Extensions
+
+Later term-metaprogramming milestones can add:
+
+- `term_eqo` / `term_neqo` names for `==/2` and `\==/2`
+- full standard term ordering predicates such as `@</2`
+- `numbervars`-style variable naming
+- richer goal construction once callable terms can be safely lowered into
+  relation calls
+
+## Summary
+
+LP15 gives Python callers the first Prolog-style metaprogramming surface over
+terms. That makes the library feel much closer to Prolog even before language
+syntax exists, and it also creates reusable machinery for the future parser and
+VM layers.


### PR DESCRIPTION
## Summary

- Adds LP15 spec for Prolog-style term metaprogramming predicates in the Python logic builtins layer.
- Implements `univo`, `copytermo`, `same_termo`, `atomico`, and `callableo`.
- Extends `functoro` with atomic inspection and construction mode so the library can construct callable terms without going through parser syntax.
- Updates package exports, versioning, README examples, changelog, and tests.

## Testing

- `cd code/packages/python/logic-builtins && bash BUILD`
- `cd code/packages/python/logic-builtins && .venv/bin/python -m ruff check src tests`
- `cd code/programs/go/build-tool && ./build-tool -language python -diff-base origin/main -root /Users/adhithya/Downloads/coding-adventures-worktrees/prolog-term-meta`

## Security review

- Manual security scan found no dynamic code execution, deserialization, shell, network, filesystem, token, or secret-handling APIs in the changed package/spec files.
- The new predicates only transform in-memory symbolic terms and logic substitutions.

## Notes

This keeps term ordering and full `=..` generation over partial lists out of scope for now. The goal is a practical metaprogramming layer that can support library-authored Prolog-like programs before parser/language work deepens.