### PR TITLE
feat(note-audio): split reusable audio stages

### DIFF
--- a/code/packages/python/note-audio/BUILD_windows
+++ b/code/packages/python/note-audio/BUILD_windows
@@ -2,6 +2,10 @@ uv venv --quiet --clear
 uv pip install --no-deps -e ../note-frequency --quiet
 uv pip install --no-deps -e ../trig --quiet
 uv pip install --no-deps -e ../oscillator --quiet
+uv pip install --no-deps -e ../pcm-audio --quiet
+uv pip install --no-deps -e ../virtual-dac --quiet
+uv pip install --no-deps -e ../virtual-speaker --quiet
+uv pip install --no-deps -e ../wav-sink --quiet
 uv pip install --no-deps -e . --quiet
 uv pip install pytest pytest-cov ruff --quiet
 uv run --no-project ruff check src/ tests/

--- a/code/packages/python/note-audio/CHANGELOG.md
+++ b/code/packages/python/note-audio/CHANGELOG.md
@@ -15,3 +15,10 @@ All notable changes to this package will be documented in this file.
 - Added deterministic mono WAV byte/file helpers as an optional sink.
 - Added tests for parity vectors, validation, clipping, DAC hold behavior, WAV
   output, and the visible `A4` rendering chain.
+
+### Changed
+
+- Split reusable PCM, virtual DAC, virtual speaker, and WAV behavior into
+  dedicated stage packages.
+- Kept `note-audio` as the thin teaching/orchestration layer that wires the
+  stages together and re-exports the familiar V1 helpers.

--- a/code/packages/python/note-audio/README.md
+++ b/code/packages/python/note-audio/README.md
@@ -1,6 +1,7 @@
 # note-audio
 
-`note-audio` is the first Python proof of `MUS01: Note-to-Sound Signal Chain`.
+`note-audio` is the teaching/orchestration package for
+`MUS01: Note-to-Sound Signal Chain`.
 
 It deliberately does not jump from `"A4"` straight to a speaker. Instead, it
 keeps the whole chain visible:
@@ -12,6 +13,20 @@ note -> frequency -> oscillator -> sampler -> PCM -> DAC -> speaker model
 The package is virtual and deterministic. It does not open a real audio device,
 sleep in real time, or talk to hardware. That makes it useful for learning,
 debugging, and tests.
+
+The reusable stages now live in smaller packages:
+
+| Stage | Package |
+|-------|---------|
+| note parsing and frequency | `note-frequency` |
+| oscillator and sampler | `oscillator` |
+| PCM encoding | `pcm-audio` |
+| virtual DAC | `virtual-dac` |
+| virtual speaker | `virtual-speaker` |
+| WAV file/container sink | `wav-sink` |
+
+`note-audio` wires those packages together and returns an inspectable
+`RenderedNote`.
 
 ## Example
 
@@ -34,8 +49,10 @@ wav_bytes = to_wav_bytes(chain.pcm_buffer)
 `NoteEvent` stores the human-level note, duration, amplitude, and start time.
 
 `render_note_to_sound_chain()` parses the note with `note-frequency`, creates a
-sine oscillator with `oscillator`, samples it, encodes signed 16-bit PCM, builds
-a zero-order-hold virtual DAC, and wraps that in a linear virtual speaker model.
+sine oscillator with `oscillator`, samples it, delegates signed 16-bit PCM
+encoding to `pcm-audio`, builds a zero-order-hold virtual DAC with
+`virtual-dac`, and wraps that in a linear virtual speaker model from
+`virtual-speaker`.
 
 `PCMBuffer` stores machine-friendly signed 16-bit samples and timing metadata.
 
@@ -59,13 +76,12 @@ chain = render_note_to_sound_chain("C4", duration_seconds=0.5)
 write_wav("c4.wav", chain.pcm_buffer)
 ```
 
-The WAV writer supports mono signed 16-bit PCM. It is included so the digital
-stage can be handed to normal audio software, but it does not replace the DAC
-and speaker abstractions.
+The WAV writer is re-exported from `wav-sink`. It supports mono signed 16-bit
+PCM so the digital stage can be handed to normal audio software, but it does
+not replace the DAC and speaker abstractions.
 
 ## Development
 
 ```bash
 bash BUILD
 ```
-

--- a/code/packages/python/note-audio/src/note_audio/note_audio.py
+++ b/code/packages/python/note-audio/src/note_audio/note_audio.py
@@ -1,22 +1,21 @@
 """Compose typed notes, oscillators, sampling, PCM, DAC, and speaker models.
 
-This package intentionally keeps every box in the signal chain visible. A
-caller can inspect the note frequency, the continuous oscillator, the floating
-samples, the PCM integers, the virtual DAC voltage, and the virtual speaker
-pressure proxy before choosing any real playback sink.
+`note-audio` is intentionally the teaching/orchestration layer. The reusable
+stage behavior lives in smaller packages:
+
+```text
+note-frequency -> oscillator -> pcm-audio -> virtual-dac -> virtual-speaker
+```
+
+This package wires those boxes together and returns an inspectable chain instead
+of hiding the journey behind a black-box `play()` call.
 """
 
 from __future__ import annotations
 
-import wave
-from collections.abc import Iterable
 from dataclasses import dataclass
-from io import BytesIO
-from math import floor, isfinite
+from math import isfinite
 from numbers import Integral, Real
-from os import PathLike
-from pathlib import Path
-from typing import Protocol
 
 from note_frequency import Note, parse_note
 from oscillator import (
@@ -25,27 +24,59 @@ from oscillator import (
     UniformSampler,
     sample_count_for_duration,
 )
+from pcm_audio import (
+    DEFAULT_BIT_DEPTH,
+    DEFAULT_CHANNEL_COUNT,
+    DEFAULT_FULL_SCALE_VOLTAGE,
+    DEFAULT_SAMPLE_RATE_HZ,
+    PCM16_MAX,
+    PCM16_MIN,
+    PCMBuffer,
+    PCMFormat,
+    encode_sample_buffer,
+    float_to_pcm16,
+    samples_to_pcm_buffer,
+)
+from virtual_dac import ZeroOrderHoldDACSignal, pcm16_to_voltage
+from virtual_speaker import (
+    DEFAULT_SPEAKER_GAIN,
+    AnalogSignal,
+    LinearSpeakerSignal,
+)
+from wav_sink import OutputPath, to_wav_bytes, write_wav
 
-DEFAULT_SAMPLE_RATE_HZ = 44_100.0
 DEFAULT_AMPLITUDE = 0.8
-DEFAULT_BIT_DEPTH = 16
-DEFAULT_CHANNEL_COUNT = 1
-DEFAULT_FULL_SCALE_VOLTAGE = 1.0
-DEFAULT_SPEAKER_GAIN = 1.0
 DEFAULT_MAX_SAMPLE_COUNT = 10_000_000
-INTEGER_TOLERANCE = 1e-9
-PCM16_MIN = -32_768
-PCM16_MAX = 32_767
 
 NoteInput = Note | str
-OutputPath = str | PathLike[str]
 
-
-class AnalogSignal(Protocol):
-    """A virtual analog signal that can be queried at any time in seconds."""
-
-    def value_at(self, time_seconds: Real) -> float:
-        """Return the signal value at ``time_seconds``."""
+__all__ = [
+    "DEFAULT_AMPLITUDE",
+    "DEFAULT_BIT_DEPTH",
+    "DEFAULT_CHANNEL_COUNT",
+    "DEFAULT_FULL_SCALE_VOLTAGE",
+    "DEFAULT_MAX_SAMPLE_COUNT",
+    "DEFAULT_SAMPLE_RATE_HZ",
+    "DEFAULT_SPEAKER_GAIN",
+    "AnalogSignal",
+    "LinearSpeakerSignal",
+    "NoteEvent",
+    "NoteInput",
+    "OutputPath",
+    "PCM16_MAX",
+    "PCM16_MIN",
+    "PCMBuffer",
+    "PCMFormat",
+    "RenderedNote",
+    "ZeroOrderHoldDACSignal",
+    "encode_sample_buffer",
+    "float_to_pcm16",
+    "pcm16_to_voltage",
+    "render_note_to_sound_chain",
+    "samples_to_pcm_buffer",
+    "to_wav_bytes",
+    "write_wav",
+]
 
 
 def _finite_float(name: str, value: Real) -> float:
@@ -82,23 +113,6 @@ def _non_negative_int(name: str, value: int) -> int:
     if converted < 0:
         raise ValueError(f"{name} must be >= 0, got {converted}")
     return converted
-
-
-def _positive_int(name: str, value: int) -> int:
-    converted = _non_negative_int(name, value)
-    if converted == 0:
-        raise ValueError(f"{name} must be > 0, got 0")
-    return converted
-
-
-def _integer_sample_rate(sample_rate_hz: float) -> int:
-    rounded = round(sample_rate_hz)
-    if abs(sample_rate_hz - rounded) > INTEGER_TOLERANCE:
-        raise ValueError(
-            "sample_rate_hz must be an integer-valued rate for WAV output, "
-            f"got {sample_rate_hz}"
-        )
-    return int(rounded)
 
 
 def _parse_note_input(note: NoteInput) -> Note:
@@ -138,178 +152,6 @@ class NoteEvent:
 
 
 @dataclass(frozen=True)
-class PCMFormat:
-    """Metadata for the first digital audio representation: mono 16-bit PCM."""
-
-    sample_rate_hz: float = DEFAULT_SAMPLE_RATE_HZ
-    channel_count: int = DEFAULT_CHANNEL_COUNT
-    bit_depth: int = DEFAULT_BIT_DEPTH
-    full_scale_voltage: float = DEFAULT_FULL_SCALE_VOLTAGE
-
-    def __post_init__(self) -> None:
-        object.__setattr__(
-            self,
-            "sample_rate_hz",
-            _positive_float("sample_rate_hz", self.sample_rate_hz),
-        )
-        channel_count = _positive_int("channel_count", self.channel_count)
-        if channel_count != DEFAULT_CHANNEL_COUNT:
-            raise ValueError("only mono PCM is supported in V1")
-        object.__setattr__(self, "channel_count", channel_count)
-
-        bit_depth = _positive_int("bit_depth", self.bit_depth)
-        if bit_depth != DEFAULT_BIT_DEPTH:
-            raise ValueError("only signed 16-bit PCM is supported in V1")
-        object.__setattr__(self, "bit_depth", bit_depth)
-        object.__setattr__(
-            self,
-            "full_scale_voltage",
-            _positive_float("full_scale_voltage", self.full_scale_voltage),
-        )
-
-    @property
-    def minimum_integer(self) -> int:
-        """Return the lowest signed PCM integer for this format."""
-
-        return PCM16_MIN
-
-    @property
-    def maximum_integer(self) -> int:
-        """Return the highest signed PCM integer for this format."""
-
-        return PCM16_MAX
-
-    @property
-    def sample_width_bytes(self) -> int:
-        """Return the number of bytes per PCM sample."""
-
-        return self.bit_depth // 8
-
-    def integer_sample_rate(self) -> int:
-        """Return a WAV-compatible integer sample rate."""
-
-        return _integer_sample_rate(self.sample_rate_hz)
-
-
-@dataclass(frozen=True)
-class PCMBuffer:
-    """PCM samples plus the timing metadata needed by DAC and file sinks."""
-
-    samples: tuple[int, ...]
-    pcm_format: PCMFormat
-    start_time_seconds: float = 0.0
-    clipped_sample_count: int = 0
-
-    def __post_init__(self) -> None:
-        checked_samples: list[int] = []
-        for index, sample in enumerate(self.samples):
-            if isinstance(sample, bool) or not isinstance(sample, Integral):
-                raise ValueError(f"samples[{index}] must be a PCM integer")
-            converted = int(sample)
-            if converted < PCM16_MIN or converted > PCM16_MAX:
-                raise ValueError(
-                    f"samples[{index}] must fit signed 16-bit PCM, got {converted}"
-                )
-            checked_samples.append(converted)
-
-        object.__setattr__(self, "samples", tuple(checked_samples))
-        if not isinstance(self.pcm_format, PCMFormat):
-            raise ValueError("pcm_format must be a PCMFormat")
-        object.__setattr__(
-            self,
-            "start_time_seconds",
-            _finite_float("start_time_seconds", self.start_time_seconds),
-        )
-        object.__setattr__(
-            self,
-            "clipped_sample_count",
-            _non_negative_int("clipped_sample_count", self.clipped_sample_count),
-        )
-
-    def sample_count(self) -> int:
-        """Return the number of PCM samples."""
-
-        return len(self.samples)
-
-    def sample_period_seconds(self) -> float:
-        """Return the time spacing between adjacent samples."""
-
-        return 1.0 / self.pcm_format.sample_rate_hz
-
-    def duration_seconds(self) -> float:
-        """Return the half-open duration covered by this PCM buffer."""
-
-        return self.sample_count() / self.pcm_format.sample_rate_hz
-
-    def time_at(self, index: int) -> float:
-        """Return the timestamp for a PCM sample index."""
-
-        if isinstance(index, bool) or not isinstance(index, Integral):
-            raise ValueError(f"index must be an integer, got {index!r}")
-        converted = int(index)
-        if not 0 <= converted < self.sample_count():
-            raise ValueError(
-                f"index must be in [0, {self.sample_count()}), got {converted}"
-            )
-        return self.start_time_seconds + converted / self.pcm_format.sample_rate_hz
-
-    def to_little_endian_bytes(self) -> bytes:
-        """Pack signed 16-bit PCM integers as little-endian bytes."""
-
-        return b"".join(
-            sample.to_bytes(2, "little", signed=True) for sample in self.samples
-        )
-
-
-@dataclass(frozen=True)
-class ZeroOrderHoldDACSignal:
-    """Virtual DAC output using a simple zero-order hold staircase."""
-
-    pcm_buffer: PCMBuffer
-
-    def __post_init__(self) -> None:
-        if not isinstance(self.pcm_buffer, PCMBuffer):
-            raise ValueError("pcm_buffer must be a PCMBuffer")
-
-    def value_at(self, time_seconds: Real) -> float:
-        """Return the held DAC voltage at ``time_seconds``."""
-
-        time = _finite_float("time_seconds", time_seconds)
-        start = self.pcm_buffer.start_time_seconds
-        end = start + self.pcm_buffer.duration_seconds()
-        if time < start or time >= end or self.pcm_buffer.sample_count() == 0:
-            return 0.0
-
-        index = int(floor((time - start) * self.pcm_buffer.pcm_format.sample_rate_hz))
-        if index < 0 or index >= self.pcm_buffer.sample_count():
-            return 0.0
-        return pcm16_to_voltage(
-            self.pcm_buffer.samples[index],
-            self.pcm_buffer.pcm_format,
-        )
-
-
-@dataclass(frozen=True)
-class LinearSpeakerSignal:
-    """Toy speaker model that turns DAC voltage into a pressure-like signal."""
-
-    analog_signal: AnalogSignal
-    speaker_gain: float = DEFAULT_SPEAKER_GAIN
-
-    def __post_init__(self) -> None:
-        object.__setattr__(
-            self,
-            "speaker_gain",
-            _finite_float("speaker_gain", self.speaker_gain),
-        )
-
-    def value_at(self, time_seconds: Real) -> float:
-        """Return a normalized pressure proxy for the supplied time."""
-
-        return self.speaker_gain * self.analog_signal.value_at(time_seconds)
-
-
-@dataclass(frozen=True)
 class RenderedNote:
     """The full inspectable chain from a note event to virtual speaker output."""
 
@@ -327,58 +169,6 @@ class RenderedNote:
             "frequency_hz",
             _positive_float("frequency_hz", self.frequency_hz),
         )
-
-
-def float_to_pcm16(sample: Real) -> tuple[int, bool]:
-    """Convert one normalized floating sample to signed 16-bit PCM.
-
-    The boolean return value tells the caller whether clipping was required.
-    """
-
-    value = _finite_float("sample", sample)
-    clipped = value < -1.0 or value > 1.0
-    bounded = min(1.0, max(-1.0, value))
-    if bounded >= 0.0:
-        return int(round(bounded * PCM16_MAX)), clipped
-    return int(round(bounded * abs(PCM16_MIN))), clipped
-
-
-def pcm16_to_voltage(sample: int, pcm_format: PCMFormat | None = None) -> float:
-    """Map a signed 16-bit PCM integer to virtual DAC voltage."""
-
-    active_format = pcm_format if pcm_format is not None else PCMFormat()
-    checked = PCMBuffer((sample,), active_format).samples[0]
-    if checked >= 0:
-        return checked / PCM16_MAX * active_format.full_scale_voltage
-    return checked / abs(PCM16_MIN) * active_format.full_scale_voltage
-
-
-def encode_sample_buffer(
-    sample_buffer: SampleBuffer,
-    pcm_format: PCMFormat | None = None,
-) -> PCMBuffer:
-    """Quantize floating oscillator samples into signed 16-bit PCM."""
-
-    if not isinstance(sample_buffer, SampleBuffer):
-        raise ValueError("sample_buffer must be an oscillator.SampleBuffer")
-
-    active_format = pcm_format if pcm_format is not None else PCMFormat(
-        sample_rate_hz=sample_buffer.sample_rate_hz
-    )
-    pcm_samples: list[int] = []
-    clipped_count = 0
-    for sample in sample_buffer.samples:
-        pcm_sample, clipped = float_to_pcm16(sample)
-        pcm_samples.append(pcm_sample)
-        if clipped:
-            clipped_count += 1
-
-    return PCMBuffer(
-        samples=tuple(pcm_samples),
-        pcm_format=active_format,
-        start_time_seconds=sample_buffer.start_time_seconds,
-        clipped_sample_count=clipped_count,
-    )
 
 
 def _validate_sample_budget(sample_count: int, max_sample_count: int) -> None:
@@ -453,50 +243,3 @@ def render_note_to_sound_chain(
         dac_signal=dac_signal,
         speaker_signal=speaker_signal,
     )
-
-
-def to_wav_bytes(pcm_buffer: PCMBuffer) -> bytes:
-    """Write a mono signed-16-bit PCM buffer into a deterministic WAV container."""
-
-    if not isinstance(pcm_buffer, PCMBuffer):
-        raise ValueError("pcm_buffer must be a PCMBuffer")
-
-    sample_rate = pcm_buffer.pcm_format.integer_sample_rate()
-    output = BytesIO()
-    with wave.open(output, "wb") as wav_file:
-        wav_file.setnchannels(pcm_buffer.pcm_format.channel_count)
-        wav_file.setsampwidth(pcm_buffer.pcm_format.sample_width_bytes)
-        wav_file.setframerate(sample_rate)
-        wav_file.writeframes(pcm_buffer.to_little_endian_bytes())
-    return output.getvalue()
-
-
-def write_wav(path: OutputPath, pcm_buffer: PCMBuffer) -> Path:
-    """Write a WAV file and return the resolved ``Path`` object used."""
-
-    output_path = Path(path)
-    output_path.write_bytes(to_wav_bytes(pcm_buffer))
-    return output_path
-
-
-def samples_to_pcm_buffer(
-    samples: Iterable[Real],
-    *,
-    sample_rate_hz: Real,
-    start_time_seconds: Real = 0.0,
-    pcm_format: PCMFormat | None = None,
-) -> PCMBuffer:
-    """Convenience helper for tests and demos that start with raw float samples."""
-
-    sample_buffer = SampleBuffer(
-        samples=tuple(float_to_pcm_input(sample) for sample in samples),
-        sample_rate_hz=_positive_float("sample_rate_hz", sample_rate_hz),
-        start_time_seconds=_finite_float("start_time_seconds", start_time_seconds),
-    )
-    return encode_sample_buffer(sample_buffer, pcm_format)
-
-
-def float_to_pcm_input(sample: Real) -> float:
-    """Validate a raw floating sample before putting it in a SampleBuffer."""
-
-    return _finite_float("sample", sample)

--- a/code/packages/python/pcm-audio/.gitignore
+++ b/code/packages/python/pcm-audio/.gitignore
@@ -1,0 +1,5 @@
+.coverage
+.pytest_cache/
+.ruff_cache/
+.venv/
+__pycache__/

--- a/code/packages/python/pcm-audio/BUILD
+++ b/code/packages/python/pcm-audio/BUILD
@@ -1,11 +1,6 @@
 uv venv --quiet --clear
-uv pip install --no-deps -e ../note-frequency --quiet
 uv pip install --no-deps -e ../trig --quiet
 uv pip install --no-deps -e ../oscillator --quiet
-uv pip install --no-deps -e ../pcm-audio --quiet
-uv pip install --no-deps -e ../virtual-dac --quiet
-uv pip install --no-deps -e ../virtual-speaker --quiet
-uv pip install --no-deps -e ../wav-sink --quiet
 uv pip install --no-deps -e . --quiet
 uv pip install pytest pytest-cov ruff --quiet
 uv run --no-project ruff check src/ tests/

--- a/code/packages/python/pcm-audio/BUILD_windows
+++ b/code/packages/python/pcm-audio/BUILD_windows
@@ -1,11 +1,6 @@
 uv venv --quiet --clear
-uv pip install --no-deps -e ../note-frequency --quiet
 uv pip install --no-deps -e ../trig --quiet
 uv pip install --no-deps -e ../oscillator --quiet
-uv pip install --no-deps -e ../pcm-audio --quiet
-uv pip install --no-deps -e ../virtual-dac --quiet
-uv pip install --no-deps -e ../virtual-speaker --quiet
-uv pip install --no-deps -e ../wav-sink --quiet
 uv pip install --no-deps -e . --quiet
 uv pip install pytest pytest-cov ruff --quiet
 uv run --no-project ruff check src/ tests/

--- a/code/packages/python/pcm-audio/CHANGELOG.md
+++ b/code/packages/python/pcm-audio/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-20
+
+### Added
+
+- Added reusable signed 16-bit mono PCM format and buffer types.
+- Added normalized float-to-PCM encoding with explicit clipping counts.
+- Added a helper for building PCM buffers from raw floating samples.

--- a/code/packages/python/pcm-audio/README.md
+++ b/code/packages/python/pcm-audio/README.md
@@ -1,0 +1,31 @@
+# pcm-audio
+
+`pcm-audio` owns the digital audio stage in `MUS01`.
+
+It converts normalized floating-point samples, such as values produced by an
+oscillator sampler, into signed 16-bit PCM integers:
+
+```text
+floating samples -> PCMFormat -> PCMBuffer
+```
+
+The package is intentionally small and deterministic. It does not write files,
+talk to speakers, or know where samples came from.
+
+## Example
+
+```python
+from oscillator import SampleBuffer
+from pcm_audio import PCMFormat, encode_sample_buffer
+
+floating = SampleBuffer(samples=(0.0, 1.0, 0.0, -1.0), sample_rate_hz=4.0)
+pcm = encode_sample_buffer(floating, PCMFormat(sample_rate_hz=4.0))
+
+print(pcm.samples)  # (0, 32767, 0, -32768)
+```
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/python/pcm-audio/pyproject.toml
+++ b/code/packages/python/pcm-audio/pyproject.toml
@@ -1,0 +1,44 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-pcm-audio"
+version = "0.1.0"
+description = "Reusable PCM encoding stage for virtual audio pipelines"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+dependencies = [
+    "coding-adventures-oscillator>=0.1.0",
+    "coding-adventures-trig>=0.1.0",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4"]
+
+[tool.uv.sources]
+coding-adventures-oscillator = { path = "../oscillator", editable = true }
+coding-adventures-trig = { path = "../trig", editable = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/pcm_audio"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM", "ANN"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=pcm_audio --cov-report=term-missing --cov-fail-under=95"
+
+[tool.coverage.run]
+source = ["src/pcm_audio"]
+
+[tool.coverage.report]
+fail_under = 95
+show_missing = true

--- a/code/packages/python/pcm-audio/required_capabilities.json
+++ b/code/packages/python/pcm-audio/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "python/pcm-audio",
+  "capabilities": [],
+  "justification": "Pure PCM encoding and metadata helpers with no filesystem, network, process, or device access."
+}

--- a/code/packages/python/pcm-audio/src/pcm_audio/__init__.py
+++ b/code/packages/python/pcm-audio/src/pcm_audio/__init__.py
@@ -1,0 +1,32 @@
+"""Reusable PCM encoding stage for virtual audio pipelines."""
+
+from .pcm_audio import (
+    DEFAULT_BIT_DEPTH,
+    DEFAULT_CHANNEL_COUNT,
+    DEFAULT_FULL_SCALE_VOLTAGE,
+    DEFAULT_SAMPLE_RATE_HZ,
+    PCM16_MAX,
+    PCM16_MIN,
+    PCMBuffer,
+    PCMFormat,
+    encode_sample_buffer,
+    float_to_pcm16,
+    samples_to_pcm_buffer,
+)
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "DEFAULT_BIT_DEPTH",
+    "DEFAULT_CHANNEL_COUNT",
+    "DEFAULT_FULL_SCALE_VOLTAGE",
+    "DEFAULT_SAMPLE_RATE_HZ",
+    "PCM16_MAX",
+    "PCM16_MIN",
+    "PCMBuffer",
+    "PCMFormat",
+    "__version__",
+    "encode_sample_buffer",
+    "float_to_pcm16",
+    "samples_to_pcm_buffer",
+]

--- a/code/packages/python/pcm-audio/src/pcm_audio/pcm_audio.py
+++ b/code/packages/python/pcm-audio/src/pcm_audio/pcm_audio.py
@@ -1,0 +1,252 @@
+"""Encode normalized floating samples into signed 16-bit PCM.
+
+PCM is the first digital audio stage in the note-to-sound chain. It takes the
+smooth world that the sampler observed and stores each value as a finite integer
+that file formats, DACs, and device sinks can understand.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from math import isfinite
+from numbers import Integral, Real
+
+from oscillator import SampleBuffer
+
+DEFAULT_SAMPLE_RATE_HZ = 44_100.0
+DEFAULT_BIT_DEPTH = 16
+DEFAULT_CHANNEL_COUNT = 1
+DEFAULT_FULL_SCALE_VOLTAGE = 1.0
+INTEGER_TOLERANCE = 1e-9
+PCM16_MIN = -32_768
+PCM16_MAX = 32_767
+
+
+def _finite_float(name: str, value: Real) -> float:
+    """Convert a finite real value to ``float`` and reject slippery inputs."""
+
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a finite real number, got {value!r}")
+
+    converted = float(value)
+    if not isfinite(converted):
+        raise ValueError(f"{name} must be finite, got {value!r}")
+
+    return converted
+
+
+def _positive_float(name: str, value: Real) -> float:
+    converted = _finite_float(name, value)
+    if converted <= 0.0:
+        raise ValueError(f"{name} must be > 0.0, got {converted}")
+    return converted
+
+
+def _non_negative_int(name: str, value: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise ValueError(f"{name} must be an integer >= 0, got {value!r}")
+    converted = int(value)
+    if converted < 0:
+        raise ValueError(f"{name} must be >= 0, got {converted}")
+    return converted
+
+
+def _positive_int(name: str, value: int) -> int:
+    converted = _non_negative_int(name, value)
+    if converted == 0:
+        raise ValueError(f"{name} must be > 0, got 0")
+    return converted
+
+
+def _integer_sample_rate(sample_rate_hz: float) -> int:
+    rounded = round(sample_rate_hz)
+    if abs(sample_rate_hz - rounded) > INTEGER_TOLERANCE:
+        raise ValueError(
+            "sample_rate_hz must be an integer-valued rate for WAV output, "
+            f"got {sample_rate_hz}"
+        )
+    return int(rounded)
+
+
+@dataclass(frozen=True)
+class PCMFormat:
+    """Metadata for the first digital audio representation: mono 16-bit PCM."""
+
+    sample_rate_hz: float = DEFAULT_SAMPLE_RATE_HZ
+    channel_count: int = DEFAULT_CHANNEL_COUNT
+    bit_depth: int = DEFAULT_BIT_DEPTH
+    full_scale_voltage: float = DEFAULT_FULL_SCALE_VOLTAGE
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "sample_rate_hz",
+            _positive_float("sample_rate_hz", self.sample_rate_hz),
+        )
+        channel_count = _positive_int("channel_count", self.channel_count)
+        if channel_count != DEFAULT_CHANNEL_COUNT:
+            raise ValueError("only mono PCM is supported in V1")
+        object.__setattr__(self, "channel_count", channel_count)
+
+        bit_depth = _positive_int("bit_depth", self.bit_depth)
+        if bit_depth != DEFAULT_BIT_DEPTH:
+            raise ValueError("only signed 16-bit PCM is supported in V1")
+        object.__setattr__(self, "bit_depth", bit_depth)
+        object.__setattr__(
+            self,
+            "full_scale_voltage",
+            _positive_float("full_scale_voltage", self.full_scale_voltage),
+        )
+
+    @property
+    def minimum_integer(self) -> int:
+        """Return the lowest signed PCM integer for this format."""
+
+        return PCM16_MIN
+
+    @property
+    def maximum_integer(self) -> int:
+        """Return the highest signed PCM integer for this format."""
+
+        return PCM16_MAX
+
+    @property
+    def sample_width_bytes(self) -> int:
+        """Return the number of bytes per PCM sample."""
+
+        return self.bit_depth // 8
+
+    def integer_sample_rate(self) -> int:
+        """Return a WAV-compatible integer sample rate."""
+
+        return _integer_sample_rate(self.sample_rate_hz)
+
+
+@dataclass(frozen=True)
+class PCMBuffer:
+    """PCM samples plus the timing metadata needed by DAC and file sinks."""
+
+    samples: tuple[int, ...]
+    pcm_format: PCMFormat
+    start_time_seconds: float = 0.0
+    clipped_sample_count: int = 0
+
+    def __post_init__(self) -> None:
+        checked_samples: list[int] = []
+        for index, sample in enumerate(self.samples):
+            if isinstance(sample, bool) or not isinstance(sample, Integral):
+                raise ValueError(f"samples[{index}] must be a PCM integer")
+            converted = int(sample)
+            if converted < PCM16_MIN or converted > PCM16_MAX:
+                raise ValueError(
+                    f"samples[{index}] must fit signed 16-bit PCM, got {converted}"
+                )
+            checked_samples.append(converted)
+
+        object.__setattr__(self, "samples", tuple(checked_samples))
+        if not isinstance(self.pcm_format, PCMFormat):
+            raise ValueError("pcm_format must be a PCMFormat")
+        object.__setattr__(
+            self,
+            "start_time_seconds",
+            _finite_float("start_time_seconds", self.start_time_seconds),
+        )
+        object.__setattr__(
+            self,
+            "clipped_sample_count",
+            _non_negative_int("clipped_sample_count", self.clipped_sample_count),
+        )
+
+    def sample_count(self) -> int:
+        """Return the number of PCM samples."""
+
+        return len(self.samples)
+
+    def sample_period_seconds(self) -> float:
+        """Return the time spacing between adjacent samples."""
+
+        return 1.0 / self.pcm_format.sample_rate_hz
+
+    def duration_seconds(self) -> float:
+        """Return the half-open duration covered by this PCM buffer."""
+
+        return self.sample_count() / self.pcm_format.sample_rate_hz
+
+    def time_at(self, index: int) -> float:
+        """Return the timestamp for a PCM sample index."""
+
+        if isinstance(index, bool) or not isinstance(index, Integral):
+            raise ValueError(f"index must be an integer, got {index!r}")
+        converted = int(index)
+        if not 0 <= converted < self.sample_count():
+            raise ValueError(
+                f"index must be in [0, {self.sample_count()}), got {converted}"
+            )
+        return self.start_time_seconds + converted / self.pcm_format.sample_rate_hz
+
+    def to_little_endian_bytes(self) -> bytes:
+        """Pack signed 16-bit PCM integers as little-endian bytes."""
+
+        return b"".join(
+            sample.to_bytes(2, "little", signed=True) for sample in self.samples
+        )
+
+
+def float_to_pcm16(sample: Real) -> tuple[int, bool]:
+    """Convert one normalized floating sample to signed 16-bit PCM.
+
+    The boolean return value tells the caller whether clipping was required.
+    """
+
+    value = _finite_float("sample", sample)
+    clipped = value < -1.0 or value > 1.0
+    bounded = min(1.0, max(-1.0, value))
+    if bounded >= 0.0:
+        return int(round(bounded * PCM16_MAX)), clipped
+    return int(round(bounded * abs(PCM16_MIN))), clipped
+
+
+def encode_sample_buffer(
+    sample_buffer: SampleBuffer,
+    pcm_format: PCMFormat | None = None,
+) -> PCMBuffer:
+    """Quantize floating oscillator samples into signed 16-bit PCM."""
+
+    if not isinstance(sample_buffer, SampleBuffer):
+        raise ValueError("sample_buffer must be an oscillator.SampleBuffer")
+
+    active_format = pcm_format if pcm_format is not None else PCMFormat(
+        sample_rate_hz=sample_buffer.sample_rate_hz
+    )
+    pcm_samples: list[int] = []
+    clipped_count = 0
+    for sample in sample_buffer.samples:
+        pcm_sample, clipped = float_to_pcm16(sample)
+        pcm_samples.append(pcm_sample)
+        if clipped:
+            clipped_count += 1
+
+    return PCMBuffer(
+        samples=tuple(pcm_samples),
+        pcm_format=active_format,
+        start_time_seconds=sample_buffer.start_time_seconds,
+        clipped_sample_count=clipped_count,
+    )
+
+
+def samples_to_pcm_buffer(
+    samples: Iterable[Real],
+    *,
+    sample_rate_hz: Real,
+    start_time_seconds: Real = 0.0,
+    pcm_format: PCMFormat | None = None,
+) -> PCMBuffer:
+    """Convenience helper for demos that start with raw floating samples."""
+
+    sample_buffer = SampleBuffer(
+        samples=tuple(_finite_float("sample", sample) for sample in samples),
+        sample_rate_hz=_positive_float("sample_rate_hz", sample_rate_hz),
+        start_time_seconds=_finite_float("start_time_seconds", start_time_seconds),
+    )
+    return encode_sample_buffer(sample_buffer, pcm_format)

--- a/code/packages/python/pcm-audio/tests/__init__.py
+++ b/code/packages/python/pcm-audio/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for pcm-audio."""

--- a/code/packages/python/pcm-audio/tests/test_pcm_audio.py
+++ b/code/packages/python/pcm-audio/tests/test_pcm_audio.py
@@ -1,0 +1,159 @@
+"""Tests for the reusable PCM encoding stage."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from oscillator import SampleBuffer
+
+from pcm_audio import (
+    DEFAULT_BIT_DEPTH,
+    DEFAULT_CHANNEL_COUNT,
+    DEFAULT_FULL_SCALE_VOLTAGE,
+    DEFAULT_SAMPLE_RATE_HZ,
+    PCM16_MAX,
+    PCM16_MIN,
+    PCMBuffer,
+    PCMFormat,
+    __version__,
+    encode_sample_buffer,
+    float_to_pcm16,
+    samples_to_pcm_buffer,
+)
+
+
+def assert_close(got: float, want: float, tolerance: float = 1e-9) -> None:
+    """Keep timing assertions readable."""
+
+    assert abs(got - want) <= tolerance
+
+
+def test_version_and_defaults_are_visible() -> None:
+    assert __version__ == "0.1.0"
+    assert DEFAULT_SAMPLE_RATE_HZ == 44_100.0
+    assert DEFAULT_CHANNEL_COUNT == 1
+    assert DEFAULT_BIT_DEPTH == 16
+    assert DEFAULT_FULL_SCALE_VOLTAGE == 1.0
+    assert PCM16_MIN == -32_768
+    assert PCM16_MAX == 32_767
+
+
+def test_pcm_format_validates_v1_shape() -> None:
+    pcm_format = PCMFormat(sample_rate_hz=8.0, full_scale_voltage=2.0)
+
+    assert pcm_format.minimum_integer == -32_768
+    assert pcm_format.maximum_integer == 32_767
+    assert pcm_format.sample_width_bytes == 2
+    assert pcm_format.integer_sample_rate() == 8
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"sample_rate_hz": 0.0}, "sample_rate_hz"),
+        ({"sample_rate_hz": math.inf}, "sample_rate_hz"),
+        ({"channel_count": 2}, "mono"),
+        ({"channel_count": True}, "channel_count"),
+        ({"bit_depth": 24}, "16-bit"),
+        ({"bit_depth": 0}, "bit_depth"),
+        ({"full_scale_voltage": 0.0}, "full_scale_voltage"),
+    ],
+)
+def test_pcm_format_rejects_invalid_shapes(
+    kwargs: dict[str, object],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        PCMFormat(**kwargs)
+
+
+def test_integer_sample_rate_rejects_fractional_rates() -> None:
+    with pytest.raises(ValueError, match="integer-valued"):
+        PCMFormat(sample_rate_hz=44_100.5).integer_sample_rate()
+
+
+def test_float_to_pcm16_clips_and_reports_clipping() -> None:
+    assert float_to_pcm16(0.0) == (0, False)
+    assert float_to_pcm16(1.0) == (32767, False)
+    assert float_to_pcm16(-1.0) == (-32768, False)
+    assert float_to_pcm16(2.0) == (32767, True)
+    assert float_to_pcm16(-2.0) == (-32768, True)
+
+
+@pytest.mark.parametrize("sample", [math.nan, math.inf, True, object()])
+def test_float_to_pcm16_rejects_non_finite_or_non_real_samples(
+    sample: object,
+) -> None:
+    with pytest.raises(ValueError, match="sample"):
+        float_to_pcm16(sample)  # type: ignore[arg-type]
+
+
+def test_encode_sample_buffer_tracks_clipping_and_timing() -> None:
+    floating = SampleBuffer(
+        samples=(0.0, 1.0, -1.0, 2.0),
+        sample_rate_hz=4.0,
+        start_time_seconds=10.0,
+    )
+    pcm = encode_sample_buffer(floating)
+
+    assert pcm.samples == (0, 32767, -32768, 32767)
+    assert pcm.clipped_sample_count == 1
+    assert pcm.sample_count() == 4
+    assert_close(pcm.sample_period_seconds(), 0.25)
+    assert_close(pcm.duration_seconds(), 1.0)
+    assert_close(pcm.time_at(2), 10.5)
+
+
+def test_samples_to_pcm_buffer_encodes_raw_float_sequences() -> None:
+    pcm = samples_to_pcm_buffer((0.0, 0.5, -0.5), sample_rate_hz=3.0)
+
+    assert pcm.samples == (0, 16384, -16384)
+    assert_close(pcm.duration_seconds(), 1.0)
+
+
+def test_pcm_buffer_packs_little_endian_bytes() -> None:
+    pcm = PCMBuffer((0, 32767, -32768), PCMFormat(sample_rate_hz=3.0))
+
+    assert pcm.to_little_endian_bytes() == b"\x00\x00\xff\x7f\x00\x80"
+
+
+@pytest.mark.parametrize(
+    ("samples", "message"),
+    [
+        ((True,), "PCM integer"),
+        ((32768,), "signed 16-bit"),
+        ((-32769,), "signed 16-bit"),
+    ],
+)
+def test_pcm_buffer_rejects_invalid_integer_samples(
+    samples: tuple[object, ...],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        PCMBuffer(samples, PCMFormat())
+
+
+def test_pcm_buffer_rejects_invalid_metadata() -> None:
+    with pytest.raises(ValueError, match="pcm_format"):
+        PCMBuffer((0,), object())  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="start_time_seconds"):
+        PCMBuffer((0,), PCMFormat(), start_time_seconds=math.nan)
+    with pytest.raises(ValueError, match="clipped_sample_count"):
+        PCMBuffer((0,), PCMFormat(), clipped_sample_count=-1)
+    with pytest.raises(ValueError, match="clipped_sample_count"):
+        PCMBuffer((0,), PCMFormat(), clipped_sample_count=True)  # type: ignore[arg-type]
+
+
+def test_pcm_buffer_rejects_invalid_indexes() -> None:
+    pcm = PCMBuffer((0,), PCMFormat())
+
+    with pytest.raises(ValueError, match="index"):
+        pcm.time_at(1)
+    with pytest.raises(ValueError, match="index"):
+        pcm.time_at(True)  # type: ignore[arg-type]
+
+
+def test_encode_sample_buffer_rejects_non_sample_buffer() -> None:
+    with pytest.raises(ValueError, match="sample_buffer"):
+        encode_sample_buffer(object())  # type: ignore[arg-type]

--- a/code/packages/python/virtual-dac/.gitignore
+++ b/code/packages/python/virtual-dac/.gitignore
@@ -1,0 +1,5 @@
+.coverage
+.pytest_cache/
+.ruff_cache/
+.venv/
+__pycache__/

--- a/code/packages/python/virtual-dac/BUILD
+++ b/code/packages/python/virtual-dac/BUILD
@@ -1,11 +1,7 @@
 uv venv --quiet --clear
-uv pip install --no-deps -e ../note-frequency --quiet
 uv pip install --no-deps -e ../trig --quiet
 uv pip install --no-deps -e ../oscillator --quiet
 uv pip install --no-deps -e ../pcm-audio --quiet
-uv pip install --no-deps -e ../virtual-dac --quiet
-uv pip install --no-deps -e ../virtual-speaker --quiet
-uv pip install --no-deps -e ../wav-sink --quiet
 uv pip install --no-deps -e . --quiet
 uv pip install pytest pytest-cov ruff --quiet
 uv run --no-project ruff check src/ tests/

--- a/code/packages/python/virtual-dac/BUILD_windows
+++ b/code/packages/python/virtual-dac/BUILD_windows
@@ -1,11 +1,7 @@
 uv venv --quiet --clear
-uv pip install --no-deps -e ../note-frequency --quiet
 uv pip install --no-deps -e ../trig --quiet
 uv pip install --no-deps -e ../oscillator --quiet
 uv pip install --no-deps -e ../pcm-audio --quiet
-uv pip install --no-deps -e ../virtual-dac --quiet
-uv pip install --no-deps -e ../virtual-speaker --quiet
-uv pip install --no-deps -e ../wav-sink --quiet
 uv pip install --no-deps -e . --quiet
 uv pip install pytest pytest-cov ruff --quiet
 uv run --no-project ruff check src/ tests/

--- a/code/packages/python/virtual-dac/CHANGELOG.md
+++ b/code/packages/python/virtual-dac/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-20
+
+### Added
+
+- Added a reusable zero-order-hold virtual DAC signal.
+- Added signed 16-bit PCM integer to voltage conversion.

--- a/code/packages/python/virtual-dac/README.md
+++ b/code/packages/python/virtual-dac/README.md
@@ -1,0 +1,27 @@
+# virtual-dac
+
+`virtual-dac` owns the PCM-to-voltage stage in `MUS01`.
+
+It does not talk to real hardware. It answers one educational question:
+
+```text
+If this PCM sample reached an ideal DAC, what voltage would be held now?
+```
+
+## Example
+
+```python
+from pcm_audio import PCMBuffer, PCMFormat
+from virtual_dac import ZeroOrderHoldDACSignal
+
+pcm = PCMBuffer((0, 32767, 0, -32768), PCMFormat(sample_rate_hz=4.0))
+dac = ZeroOrderHoldDACSignal(pcm)
+
+print(dac.value_at(0.25))  # 1.0
+```
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/python/virtual-dac/pyproject.toml
+++ b/code/packages/python/virtual-dac/pyproject.toml
@@ -3,37 +3,29 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "coding-adventures-note-audio"
+name = "coding-adventures-virtual-dac"
 version = "0.1.0"
-description = "Visible note-to-sound signal chain for virtual audio playback"
+description = "Reusable virtual DAC stage for PCM audio pipelines"
 requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]
 readme = "README.md"
 dependencies = [
-    "coding-adventures-note-frequency>=0.1.0",
     "coding-adventures-oscillator>=0.1.0",
     "coding-adventures-pcm-audio>=0.1.0",
     "coding-adventures-trig>=0.1.0",
-    "coding-adventures-virtual-dac>=0.1.0",
-    "coding-adventures-virtual-speaker>=0.1.0",
-    "coding-adventures-wav-sink>=0.1.0",
 ]
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4"]
 
 [tool.uv.sources]
-coding-adventures-note-frequency = { path = "../note-frequency", editable = true }
 coding-adventures-oscillator = { path = "../oscillator", editable = true }
 coding-adventures-pcm-audio = { path = "../pcm-audio", editable = true }
 coding-adventures-trig = { path = "../trig", editable = true }
-coding-adventures-virtual-dac = { path = "../virtual-dac", editable = true }
-coding-adventures-virtual-speaker = { path = "../virtual-speaker", editable = true }
-coding-adventures-wav-sink = { path = "../wav-sink", editable = true }
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/note_audio"]
+packages = ["src/virtual_dac"]
 
 [tool.ruff]
 target-version = "py312"
@@ -44,10 +36,10 @@ select = ["E", "W", "F", "I", "UP", "B", "SIM", "ANN"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--cov=note_audio --cov-report=term-missing --cov-fail-under=95"
+addopts = "--cov=virtual_dac --cov-report=term-missing --cov-fail-under=95"
 
 [tool.coverage.run]
-source = ["src/note_audio"]
+source = ["src/virtual_dac"]
 
 [tool.coverage.report]
 fail_under = 95

--- a/code/packages/python/virtual-dac/required_capabilities.json
+++ b/code/packages/python/virtual-dac/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "python/virtual-dac",
+  "capabilities": [],
+  "justification": "Pure virtual voltage reconstruction with no filesystem, network, process, or device access."
+}

--- a/code/packages/python/virtual-dac/src/virtual_dac/__init__.py
+++ b/code/packages/python/virtual-dac/src/virtual_dac/__init__.py
@@ -1,0 +1,11 @@
+"""Reusable virtual DAC stage for PCM audio pipelines."""
+
+from .virtual_dac import ZeroOrderHoldDACSignal, pcm16_to_voltage
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "ZeroOrderHoldDACSignal",
+    "__version__",
+    "pcm16_to_voltage",
+]

--- a/code/packages/python/virtual-dac/src/virtual_dac/virtual_dac.py
+++ b/code/packages/python/virtual-dac/src/virtual_dac/virtual_dac.py
@@ -1,0 +1,64 @@
+"""Turn PCM integers into a virtual analog voltage signal.
+
+The first DAC model is intentionally simple: a zero-order hold. Each PCM integer
+becomes a voltage and that voltage is held until the next sample time.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import floor, isfinite
+from numbers import Real
+
+from pcm_audio import PCM16_MAX, PCM16_MIN, PCMBuffer, PCMFormat
+
+
+def _finite_float(name: str, value: Real) -> float:
+    """Convert a finite real value to ``float`` and reject slippery inputs."""
+
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a finite real number, got {value!r}")
+
+    converted = float(value)
+    if not isfinite(converted):
+        raise ValueError(f"{name} must be finite, got {value!r}")
+
+    return converted
+
+
+def pcm16_to_voltage(sample: int, pcm_format: PCMFormat | None = None) -> float:
+    """Map a signed 16-bit PCM integer to virtual DAC voltage."""
+
+    active_format = pcm_format if pcm_format is not None else PCMFormat()
+    checked = PCMBuffer((sample,), active_format).samples[0]
+    if checked >= 0:
+        return checked / PCM16_MAX * active_format.full_scale_voltage
+    return checked / abs(PCM16_MIN) * active_format.full_scale_voltage
+
+
+@dataclass(frozen=True)
+class ZeroOrderHoldDACSignal:
+    """Virtual DAC output using a simple zero-order hold staircase."""
+
+    pcm_buffer: PCMBuffer
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.pcm_buffer, PCMBuffer):
+            raise ValueError("pcm_buffer must be a PCMBuffer")
+
+    def value_at(self, time_seconds: Real) -> float:
+        """Return the held DAC voltage at ``time_seconds``."""
+
+        time = _finite_float("time_seconds", time_seconds)
+        start = self.pcm_buffer.start_time_seconds
+        end = start + self.pcm_buffer.duration_seconds()
+        if time < start or time >= end or self.pcm_buffer.sample_count() == 0:
+            return 0.0
+
+        index = int(floor((time - start) * self.pcm_buffer.pcm_format.sample_rate_hz))
+        if index < 0 or index >= self.pcm_buffer.sample_count():
+            return 0.0
+        return pcm16_to_voltage(
+            self.pcm_buffer.samples[index],
+            self.pcm_buffer.pcm_format,
+        )

--- a/code/packages/python/virtual-dac/tests/__init__.py
+++ b/code/packages/python/virtual-dac/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for virtual-dac."""

--- a/code/packages/python/virtual-dac/tests/test_virtual_dac.py
+++ b/code/packages/python/virtual-dac/tests/test_virtual_dac.py
@@ -1,0 +1,74 @@
+"""Tests for the reusable virtual DAC stage."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from pcm_audio import PCMBuffer, PCMFormat
+
+from virtual_dac import ZeroOrderHoldDACSignal, __version__, pcm16_to_voltage
+
+
+def test_version_exists() -> None:
+    assert __version__ == "0.1.0"
+
+
+def test_pcm16_to_voltage_uses_asymmetric_signed_range() -> None:
+    pcm_format = PCMFormat(sample_rate_hz=4.0, full_scale_voltage=2.0)
+
+    assert pcm16_to_voltage(0, pcm_format) == 0.0
+    assert pcm16_to_voltage(32767, pcm_format) == 2.0
+    assert pcm16_to_voltage(-32768, pcm_format) == -2.0
+
+
+def test_pcm16_to_voltage_uses_default_format() -> None:
+    assert pcm16_to_voltage(32767) == 1.0
+
+
+def test_zero_order_hold_parity_vector() -> None:
+    pcm = PCMBuffer((0, 32767, 0, -32768), PCMFormat(sample_rate_hz=4.0))
+    dac = ZeroOrderHoldDACSignal(pcm)
+
+    assert dac.value_at(0.00) == 0.0
+    assert dac.value_at(0.24) == 0.0
+    assert dac.value_at(0.25) == 1.0
+    assert dac.value_at(0.49) == 1.0
+    assert dac.value_at(0.50) == 0.0
+    assert dac.value_at(0.74) == 0.0
+    assert dac.value_at(0.75) == -1.0
+    assert dac.value_at(0.99) == -1.0
+    assert dac.value_at(1.00) == 0.0
+
+
+def test_zero_order_hold_respects_start_time() -> None:
+    pcm = PCMBuffer(
+        (32767,),
+        PCMFormat(sample_rate_hz=2.0),
+        start_time_seconds=10.0,
+    )
+    dac = ZeroOrderHoldDACSignal(pcm)
+
+    assert dac.value_at(9.999) == 0.0
+    assert dac.value_at(10.0) == 1.0
+    assert dac.value_at(10.49) == 1.0
+    assert dac.value_at(10.5) == 0.0
+
+
+def test_zero_order_hold_returns_silence_for_empty_buffers() -> None:
+    dac = ZeroOrderHoldDACSignal(PCMBuffer((), PCMFormat(sample_rate_hz=4.0)))
+
+    assert dac.value_at(0.0) == 0.0
+
+
+def test_rejects_invalid_inputs() -> None:
+    with pytest.raises(ValueError, match="pcm_buffer"):
+        ZeroOrderHoldDACSignal(object())  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="signed 16-bit"):
+        pcm16_to_voltage(32768)
+
+    dac = ZeroOrderHoldDACSignal(PCMBuffer((0,), PCMFormat()))
+    with pytest.raises(ValueError, match="time_seconds"):
+        dac.value_at(math.inf)
+    with pytest.raises(ValueError, match="time_seconds"):
+        dac.value_at(True)  # type: ignore[arg-type]

--- a/code/packages/python/virtual-speaker/.gitignore
+++ b/code/packages/python/virtual-speaker/.gitignore
@@ -1,0 +1,5 @@
+.coverage
+.pytest_cache/
+.ruff_cache/
+.venv/
+__pycache__/

--- a/code/packages/python/virtual-speaker/BUILD
+++ b/code/packages/python/virtual-speaker/BUILD
@@ -1,0 +1,5 @@
+uv venv --quiet --clear
+uv pip install --no-deps -e . --quiet
+uv pip install pytest pytest-cov ruff --quiet
+uv run --no-project ruff check src/ tests/
+uv run --no-project python -m pytest tests/ -v

--- a/code/packages/python/virtual-speaker/BUILD_windows
+++ b/code/packages/python/virtual-speaker/BUILD_windows
@@ -1,0 +1,5 @@
+uv venv --quiet --clear
+uv pip install --no-deps -e . --quiet
+uv pip install pytest pytest-cov ruff --quiet
+uv run --no-project ruff check src/ tests/
+uv run --no-project python -m pytest tests/ -v

--- a/code/packages/python/virtual-speaker/CHANGELOG.md
+++ b/code/packages/python/virtual-speaker/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-20
+
+### Added
+
+- Added an `AnalogSignal` protocol for time-queryable virtual signals.
+- Added a linear speaker model that scales an input signal into a pressure proxy.

--- a/code/packages/python/virtual-speaker/README.md
+++ b/code/packages/python/virtual-speaker/README.md
@@ -1,0 +1,37 @@
+# virtual-speaker
+
+`virtual-speaker` owns the voltage-to-pressure-proxy stage in `MUS01`.
+
+The first speaker model is deliberately tiny:
+
+```text
+speaker_pressure_proxy(t) = speaker_gain * input_signal(t)
+```
+
+This is not a physics model. It is an educational boundary where a virtual DAC
+voltage can become a sound-pressure-like signal without requiring calculus,
+speaker cones, room acoustics, or hardware.
+
+## Example
+
+```python
+from dataclasses import dataclass
+
+from virtual_speaker import LinearSpeakerSignal
+
+@dataclass(frozen=True)
+class ConstantSignal:
+    value: float
+
+    def value_at(self, time_seconds: float) -> float:
+        return self.value
+
+speaker = LinearSpeakerSignal(ConstantSignal(0.5), speaker_gain=2.0)
+print(speaker.value_at(0.0))  # 1.0
+```
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/python/virtual-speaker/pyproject.toml
+++ b/code/packages/python/virtual-speaker/pyproject.toml
@@ -1,0 +1,37 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-virtual-speaker"
+version = "0.1.0"
+description = "Reusable virtual speaker stage for audio pipelines"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/virtual_speaker"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM", "ANN"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=virtual_speaker --cov-report=term-missing --cov-fail-under=95"
+
+[tool.coverage.run]
+source = ["src/virtual_speaker"]
+
+[tool.coverage.report]
+fail_under = 95
+show_missing = true

--- a/code/packages/python/virtual-speaker/required_capabilities.json
+++ b/code/packages/python/virtual-speaker/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "python/virtual-speaker",
+  "capabilities": [],
+  "justification": "Pure virtual signal transformation with no filesystem, network, process, or device access."
+}

--- a/code/packages/python/virtual-speaker/src/virtual_speaker/__init__.py
+++ b/code/packages/python/virtual-speaker/src/virtual_speaker/__init__.py
@@ -1,0 +1,16 @@
+"""Reusable virtual speaker stage for audio pipelines."""
+
+from .virtual_speaker import (
+    DEFAULT_SPEAKER_GAIN,
+    AnalogSignal,
+    LinearSpeakerSignal,
+)
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "DEFAULT_SPEAKER_GAIN",
+    "AnalogSignal",
+    "LinearSpeakerSignal",
+    "__version__",
+]

--- a/code/packages/python/virtual-speaker/src/virtual_speaker/virtual_speaker.py
+++ b/code/packages/python/virtual-speaker/src/virtual_speaker/virtual_speaker.py
@@ -1,0 +1,58 @@
+"""Turn virtual analog input into a speaker-pressure proxy.
+
+This package is intentionally not a physics simulation yet. It exists so the
+note-to-sound chain has a named, reusable boundary where voltage-like values
+become sound-pressure-like values.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import isfinite
+from numbers import Real
+from typing import Protocol
+
+DEFAULT_SPEAKER_GAIN = 1.0
+
+
+class AnalogSignal(Protocol):
+    """A virtual analog signal that can be queried at any time in seconds."""
+
+    def value_at(self, time_seconds: Real) -> float:
+        """Return the signal value at ``time_seconds``."""
+
+
+def _finite_float(name: str, value: Real) -> float:
+    """Convert a finite real value to ``float`` and reject slippery inputs."""
+
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a finite real number, got {value!r}")
+
+    converted = float(value)
+    if not isfinite(converted):
+        raise ValueError(f"{name} must be finite, got {value!r}")
+
+    return converted
+
+
+@dataclass(frozen=True)
+class LinearSpeakerSignal:
+    """Toy speaker model that scales an input signal into a pressure proxy."""
+
+    analog_signal: AnalogSignal
+    speaker_gain: float = DEFAULT_SPEAKER_GAIN
+
+    def __post_init__(self) -> None:
+        if not hasattr(self.analog_signal, "value_at"):
+            raise ValueError("analog_signal must expose value_at(time_seconds)")
+        object.__setattr__(
+            self,
+            "speaker_gain",
+            _finite_float("speaker_gain", self.speaker_gain),
+        )
+
+    def value_at(self, time_seconds: Real) -> float:
+        """Return a normalized pressure proxy for the supplied time."""
+
+        time = _finite_float("time_seconds", time_seconds)
+        return self.speaker_gain * self.analog_signal.value_at(time)

--- a/code/packages/python/virtual-speaker/tests/__init__.py
+++ b/code/packages/python/virtual-speaker/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for virtual-speaker."""

--- a/code/packages/python/virtual-speaker/tests/test_virtual_speaker.py
+++ b/code/packages/python/virtual-speaker/tests/test_virtual_speaker.py
@@ -1,0 +1,71 @@
+"""Tests for the reusable virtual speaker stage."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from numbers import Real
+
+import pytest
+
+from virtual_speaker import (
+    DEFAULT_SPEAKER_GAIN,
+    AnalogSignal,
+    LinearSpeakerSignal,
+    __version__,
+)
+
+
+@dataclass(frozen=True)
+class ConstantSignal:
+    """Tiny test signal that always returns the same value."""
+
+    value: float
+
+    def value_at(self, time_seconds: Real) -> float:
+        return self.value + float(time_seconds) * 0.0
+
+
+def test_version_and_defaults_are_visible() -> None:
+    assert __version__ == "0.1.0"
+    assert DEFAULT_SPEAKER_GAIN == 1.0
+
+
+def test_constant_signal_satisfies_protocol() -> None:
+    signal: AnalogSignal = ConstantSignal(0.5)
+
+    assert signal.value_at(10.0) == 0.5
+
+
+def test_linear_speaker_gain_scales_input_signal() -> None:
+    speaker = LinearSpeakerSignal(ConstantSignal(0.5), speaker_gain=2.0)
+
+    assert speaker.value_at(0.0) == 1.0
+    assert speaker.value_at(10.0) == 1.0
+
+
+def test_default_gain_is_unity() -> None:
+    speaker = LinearSpeakerSignal(ConstantSignal(-0.25))
+
+    assert speaker.value_at(0.0) == -0.25
+
+
+def test_rejects_invalid_speaker_gain() -> None:
+    with pytest.raises(ValueError, match="speaker_gain"):
+        LinearSpeakerSignal(ConstantSignal(0.0), speaker_gain=math.nan)
+    with pytest.raises(ValueError, match="speaker_gain"):
+        LinearSpeakerSignal(ConstantSignal(0.0), speaker_gain=True)  # type: ignore[arg-type]
+
+
+def test_rejects_invalid_time_values() -> None:
+    speaker = LinearSpeakerSignal(ConstantSignal(0.0))
+
+    with pytest.raises(ValueError, match="time_seconds"):
+        speaker.value_at(math.inf)
+    with pytest.raises(ValueError, match="time_seconds"):
+        speaker.value_at(True)  # type: ignore[arg-type]
+
+
+def test_rejects_objects_without_value_at() -> None:
+    with pytest.raises(ValueError, match="analog_signal"):
+        LinearSpeakerSignal(object())  # type: ignore[arg-type]

--- a/code/packages/python/wav-sink/.gitignore
+++ b/code/packages/python/wav-sink/.gitignore
@@ -1,0 +1,5 @@
+.coverage
+.pytest_cache/
+.ruff_cache/
+.venv/
+__pycache__/

--- a/code/packages/python/wav-sink/BUILD
+++ b/code/packages/python/wav-sink/BUILD
@@ -1,11 +1,7 @@
 uv venv --quiet --clear
-uv pip install --no-deps -e ../note-frequency --quiet
 uv pip install --no-deps -e ../trig --quiet
 uv pip install --no-deps -e ../oscillator --quiet
 uv pip install --no-deps -e ../pcm-audio --quiet
-uv pip install --no-deps -e ../virtual-dac --quiet
-uv pip install --no-deps -e ../virtual-speaker --quiet
-uv pip install --no-deps -e ../wav-sink --quiet
 uv pip install --no-deps -e . --quiet
 uv pip install pytest pytest-cov ruff --quiet
 uv run --no-project ruff check src/ tests/

--- a/code/packages/python/wav-sink/BUILD_windows
+++ b/code/packages/python/wav-sink/BUILD_windows
@@ -1,11 +1,7 @@
 uv venv --quiet --clear
-uv pip install --no-deps -e ../note-frequency --quiet
 uv pip install --no-deps -e ../trig --quiet
 uv pip install --no-deps -e ../oscillator --quiet
 uv pip install --no-deps -e ../pcm-audio --quiet
-uv pip install --no-deps -e ../virtual-dac --quiet
-uv pip install --no-deps -e ../virtual-speaker --quiet
-uv pip install --no-deps -e ../wav-sink --quiet
 uv pip install --no-deps -e . --quiet
 uv pip install pytest pytest-cov ruff --quiet
 uv run --no-project ruff check src/ tests/

--- a/code/packages/python/wav-sink/CHANGELOG.md
+++ b/code/packages/python/wav-sink/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-20
+
+### Added
+
+- Added deterministic RIFF/WAVE serialization for mono signed 16-bit PCM buffers.
+- Added an optional file sink helper for caller-provided output paths.

--- a/code/packages/python/wav-sink/README.md
+++ b/code/packages/python/wav-sink/README.md
@@ -1,0 +1,28 @@
+# wav-sink
+
+`wav-sink` owns the optional file/container sink in `MUS01`.
+
+WAV is not the sound itself. It is a simple container around PCM samples and
+metadata, useful because normal audio tools can open it:
+
+```text
+PCMBuffer -> RIFF/WAVE bytes -> optional file path
+```
+
+## Example
+
+```python
+from pcm_audio import PCMBuffer, PCMFormat
+from wav_sink import to_wav_bytes
+
+pcm = PCMBuffer((0, 32767, -32768), PCMFormat(sample_rate_hz=8.0))
+wav_bytes = to_wav_bytes(pcm)
+
+print(wav_bytes[:4])  # b"RIFF"
+```
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/python/wav-sink/pyproject.toml
+++ b/code/packages/python/wav-sink/pyproject.toml
@@ -3,37 +3,29 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "coding-adventures-note-audio"
+name = "coding-adventures-wav-sink"
 version = "0.1.0"
-description = "Visible note-to-sound signal chain for virtual audio playback"
+description = "Reusable WAV container sink for PCM audio buffers"
 requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]
 readme = "README.md"
 dependencies = [
-    "coding-adventures-note-frequency>=0.1.0",
     "coding-adventures-oscillator>=0.1.0",
     "coding-adventures-pcm-audio>=0.1.0",
     "coding-adventures-trig>=0.1.0",
-    "coding-adventures-virtual-dac>=0.1.0",
-    "coding-adventures-virtual-speaker>=0.1.0",
-    "coding-adventures-wav-sink>=0.1.0",
 ]
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4"]
 
 [tool.uv.sources]
-coding-adventures-note-frequency = { path = "../note-frequency", editable = true }
 coding-adventures-oscillator = { path = "../oscillator", editable = true }
 coding-adventures-pcm-audio = { path = "../pcm-audio", editable = true }
 coding-adventures-trig = { path = "../trig", editable = true }
-coding-adventures-virtual-dac = { path = "../virtual-dac", editable = true }
-coding-adventures-virtual-speaker = { path = "../virtual-speaker", editable = true }
-coding-adventures-wav-sink = { path = "../wav-sink", editable = true }
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/note_audio"]
+packages = ["src/wav_sink"]
 
 [tool.ruff]
 target-version = "py312"
@@ -44,10 +36,10 @@ select = ["E", "W", "F", "I", "UP", "B", "SIM", "ANN"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--cov=note_audio --cov-report=term-missing --cov-fail-under=95"
+addopts = "--cov=wav_sink --cov-report=term-missing --cov-fail-under=95"
 
 [tool.coverage.run]
-source = ["src/note_audio"]
+source = ["src/wav_sink"]
 
 [tool.coverage.report]
 fail_under = 95

--- a/code/packages/python/wav-sink/required_capabilities.json
+++ b/code/packages/python/wav-sink/required_capabilities.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "python/wav-sink",
+  "capabilities": [
+    {
+      "category": "fs",
+      "action": "write",
+      "target": "caller-provided WAV output path",
+      "justification": "The optional write_wav helper writes deterministic WAV bytes to a caller-selected file path."
+    }
+  ],
+  "justification": "Pure WAV byte serialization except for the explicit optional file sink."
+}

--- a/code/packages/python/wav-sink/src/wav_sink/__init__.py
+++ b/code/packages/python/wav-sink/src/wav_sink/__init__.py
@@ -1,0 +1,12 @@
+"""Reusable WAV container sink for PCM audio buffers."""
+
+from .wav_sink import OutputPath, to_wav_bytes, write_wav
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "OutputPath",
+    "__version__",
+    "to_wav_bytes",
+    "write_wav",
+]

--- a/code/packages/python/wav-sink/src/wav_sink/wav_sink.py
+++ b/code/packages/python/wav-sink/src/wav_sink/wav_sink.py
@@ -1,0 +1,36 @@
+"""Serialize PCM buffers into deterministic RIFF/WAVE bytes."""
+
+from __future__ import annotations
+
+import wave
+from io import BytesIO
+from os import PathLike
+from pathlib import Path
+
+from pcm_audio import PCMBuffer
+
+OutputPath = str | PathLike[str]
+
+
+def to_wav_bytes(pcm_buffer: PCMBuffer) -> bytes:
+    """Write a mono signed-16-bit PCM buffer into a deterministic WAV container."""
+
+    if not isinstance(pcm_buffer, PCMBuffer):
+        raise ValueError("pcm_buffer must be a PCMBuffer")
+
+    sample_rate = pcm_buffer.pcm_format.integer_sample_rate()
+    output = BytesIO()
+    with wave.open(output, "wb") as wav_file:
+        wav_file.setnchannels(pcm_buffer.pcm_format.channel_count)
+        wav_file.setsampwidth(pcm_buffer.pcm_format.sample_width_bytes)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(pcm_buffer.to_little_endian_bytes())
+    return output.getvalue()
+
+
+def write_wav(path: OutputPath, pcm_buffer: PCMBuffer) -> Path:
+    """Write a WAV file and return the exact ``Path`` object used."""
+
+    output_path = Path(path)
+    output_path.write_bytes(to_wav_bytes(pcm_buffer))
+    return output_path

--- a/code/packages/python/wav-sink/tests/__init__.py
+++ b/code/packages/python/wav-sink/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for wav-sink."""

--- a/code/packages/python/wav-sink/tests/test_wav_sink.py
+++ b/code/packages/python/wav-sink/tests/test_wav_sink.py
@@ -1,0 +1,52 @@
+"""Tests for the reusable WAV sink."""
+
+from __future__ import annotations
+
+import wave
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+from pcm_audio import PCMBuffer, PCMFormat
+
+from wav_sink import __version__, to_wav_bytes, write_wav
+
+
+def test_version_exists() -> None:
+    assert __version__ == "0.1.0"
+
+
+def test_wav_bytes_are_parseable_mono_pcm() -> None:
+    pcm = PCMBuffer((0, 32767, -32768), PCMFormat(sample_rate_hz=8.0))
+    wav_bytes = to_wav_bytes(pcm)
+
+    assert wav_bytes.startswith(b"RIFF")
+    assert wav_bytes[8:12] == b"WAVE"
+    with wave.open(BytesIO(wav_bytes), "rb") as wav_file:
+        assert wav_file.getnchannels() == 1
+        assert wav_file.getsampwidth() == 2
+        assert wav_file.getframerate() == 8
+        assert wav_file.getnframes() == 3
+        assert wav_file.readframes(3) == b"\x00\x00\xff\x7f\x00\x80"
+
+
+def test_write_wav_writes_the_same_bytes(tmp_path: Path) -> None:
+    pcm = PCMBuffer((0,), PCMFormat(sample_rate_hz=8.0))
+    output_path = tmp_path / "tone.wav"
+
+    returned_path = write_wav(output_path, pcm)
+
+    assert returned_path == output_path
+    assert output_path.read_bytes() == to_wav_bytes(pcm)
+
+
+def test_wav_output_rejects_bad_buffers() -> None:
+    with pytest.raises(ValueError, match="pcm_buffer"):
+        to_wav_bytes(object())  # type: ignore[arg-type]
+
+
+def test_wav_output_rejects_non_integer_sample_rates() -> None:
+    pcm = PCMBuffer((0,), PCMFormat(sample_rate_hz=44_100.5))
+
+    with pytest.raises(ValueError, match="integer-valued"):
+        to_wav_bytes(pcm)

--- a/code/specs/MUS01-note-to-sound-signal-chain.md
+++ b/code/specs/MUS01-note-to-sound-signal-chain.md
@@ -772,13 +772,34 @@ The first implementation target should be Python because:
   dependency
 - tests can inspect objects and bytes easily
 
-Suggested package:
+The first proof was allowed to start as one visible teaching package:
 
 ```text
 code/packages/python/note-audio/
 ```
 
-Suggested package responsibility:
+That package should not remain the permanent owner of every stage. Once the
+chain is proven, each reusable stage should live in its own package so later
+audio, radio, hardware, and visualization packages can reuse the same boxes.
+
+Python V1 stage packages:
+
+| Stage | Package | Responsibility |
+|-------|---------|----------------|
+| note to frequency | `note-frequency` | parse notes and compute Hertz |
+| frequency to oscillator | `oscillator` | expose virtual continuous signals |
+| oscillator to samples | `oscillator` | expose uniform sampling and sample buffers |
+| floating samples to PCM | `pcm-audio` | encode normalized floats into signed PCM buffers |
+| PCM to analog voltage | `virtual-dac` | expose zero-order-hold DAC voltage signals |
+| voltage to pressure proxy | `virtual-speaker` | expose simple speaker response models |
+| PCM to file container | `wav-sink` | write PCM buffers as deterministic WAV bytes/files |
+| teaching composition | `note-audio` | wire the stages together and keep all intermediates visible |
+
+The orchestration package may expose convenience types such as `NoteEvent` and
+`RenderedNote`, but it should delegate the stage-specific work to the stage
+packages above.
+
+Reusable package responsibility:
 
 - compose `note-frequency` and `oscillator`
 - encode signed 16-bit PCM
@@ -786,7 +807,10 @@ Suggested package responsibility:
 - expose a linear virtual speaker model
 - optionally write WAV bytes/files
 
-The package should not:
+After decomposition, those bullets describe the complete system, not one
+monolithic package.
+
+No package in this first rollout should:
 
 - access speakers directly
 - require PortAudio, CoreAudio, ALSA, PulseAudio, WASAPI, or JACK
@@ -814,4 +838,3 @@ The important design rule remains:
 
 > Convenience APIs may be added, but the layers must stay visible for learners
 > who want to peek behind the abstraction.
-

--- a/lessons.md
+++ b/lessons.md
@@ -2956,3 +2956,18 @@ the import validator.
 **Rule:** At typed import or deserialization boundaries, reject empty-string event names explicitly.
 Only lower `None` to the runtime epsilon sentinel inside the core automaton constructor path. Add
 regression tests for this distinction whenever a runtime uses sentinel values internally.
+
+---
+
+## GitHub Actions archive download failures can be transient infrastructure, not package failures
+
+**Date:** 2026-04-20
+
+**What happened:** A Python-only PR failed before checkout/build execution on Ubuntu and Windows
+because the runner could not download action archives from `api.github.com` during the
+"Prepare all required actions" phase. The package-local builds and affected build-tool run were
+already green, and the failed jobs never reached repository code.
+
+**Rule:** When CI fails in job setup while downloading third-party action archives, inspect the job
+logs before changing package code. If the failure happens before checkout or tool setup commands,
+treat it as infrastructure/transient unless repeated runs prove otherwise.


### PR DESCRIPTION
## Summary

- Updates `MUS01` to specify reusable Python stage packages for the note-to-sound chain.
- Adds `pcm-audio`, `virtual-dac`, `virtual-speaker`, and `wav-sink` as independent Python packages with READMEs, CHANGELOGs, BUILD files, capability declarations, and tests.
- Refactors `note-audio` into a thin orchestration package that delegates stage behavior while keeping the original visible chain and familiar helper re-exports.

## Validation

- `sh BUILD` in `code/packages/python/pcm-audio` - 24 tests, 100% coverage.
- `sh BUILD` in `code/packages/python/virtual-dac` - 7 tests, 97.30% coverage.
- `sh BUILD` in `code/packages/python/virtual-speaker` - 7 tests, 100% coverage.
- `sh BUILD` in `code/packages/python/wav-sink` - 5 tests, 100% coverage.
- `sh BUILD` in `code/packages/python/note-audio` - 37 tests, 97.73% coverage.
- `/tmp/coding-adventures-build-tool -root /Users/adhithya/Downloads/coding-adventures-python-audio-stage-packages -diff-base origin/main -language python -jobs 2` - 8 affected packages built, 318 skipped.
- Local security review: PCM/DAC/speaker/orchestration stages have no filesystem/network/process/device access; `wav-sink` only writes deterministic WAV bytes to a caller-provided path.