### PR TITLE
feat(storage-sqlite): phase 5 — SQLite trunk/leaf freelist for page reuse

### DIFF
--- a/code/packages/python/storage-sqlite/CHANGELOG.md
+++ b/code/packages/python/storage-sqlite/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## [0.5.0] - 2026-04-20
+
+### Added
+
+- `storage_sqlite.btree` — phase 4b: full recursive leaf and interior splits.
+  - **Non-root leaf split**: `BTree.insert` now splits any full non-root leaf
+    page into two halves, rewrites the existing page with the left half,
+    allocates a right sibling, and calls `_push_separator_up` to propagate
+    the separator key up the ancestor path. Trees can grow to arbitrary depth.
+  - **`_push_separator_up`**: recursively inserts a new separator cell into a
+    parent interior page.  If the parent is also full it is split via
+    `_split_interior_page` (non-root) or `_split_root_interior` (root), and
+    the process repeats with the grandparent.
+  - **`_split_interior_page`**: splits a non-root interior page by removing
+    the median cell, rewriting the existing page with the left half (rightmost
+    child = median.left_child), and allocating a right sibling for the right
+    half (rightmost child = original rightmost_child).  Returns
+    `(median_sep_rowid, right_pgno)` for the caller to push further up.
+  - **`_split_root_interior`**: splits the root interior page when it is full.
+    Allocates two new interior children for the left and right halves and
+    rewrites the root with a single separator cell.  The root page number never
+    changes.
+  - **`_find_leaf_with_path`**: extended traversal that records the full
+    ancestor path `(pgno, hdr_off, chosen_idx)` from root to leaf's parent.
+    `_find_leaf_page` is now a thin wrapper that discards the path.
+  - **`_write_interior_page`**: helper that builds an interior page from scratch
+    given a sorted cell list and a rightmost-child pointer.
+  - **`_interior_cells_fit`** (module-level): checks whether a list of interior
+    cells fits within the usable space of an interior page at a given
+    `header_offset`, used by `_push_separator_up` to decide whether to split.
+  - **`_split_leaf`**: splits a non-root leaf page in-place (rewrites existing
+    page with left half, allocates right sibling with right half).
+  - `PageFullError` is retained in the public API but is no longer raised by
+    `BTree.insert` during normal operation.  Recursive splits handle all
+    leaf-overflow cases transparently.
+
+### Changed
+
+- `insert` now uses `_find_leaf_with_path` instead of `_find_leaf_page` so
+  that the ancestor path is available when a non-root leaf is full.
+- Module docstring updated to document the interior split algorithm, the new
+  helper methods, and the v1 limitation that orphaned overflow pages from
+  splits are not reclaimed until phase 5 (freelist).
+
 ## [0.4.0] - 2026-04-20
 
 ### Added

--- a/code/packages/python/storage-sqlite/CHANGELOG.md
+++ b/code/packages/python/storage-sqlite/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## [0.6.0] - 2026-04-20
+
+### Added
+
+- `storage_sqlite.freelist` — phase 5: SQLite trunk/leaf freelist for page reuse.
+  - **`Freelist` class**: wraps a `Pager` and manages the SQLite freelist via the
+    two header fields at offsets 32 (`first_trunk`) and 36 (`total_pages`) of page 1.
+  - **`Freelist.free(pgno)`**: returns a page to the freelist.  If the current trunk
+    has room (fewer than `TRUNK_CAPACITY` = 1 022 leaf entries), *pgno* is appended
+    as a leaf entry.  If the trunk is full or absent, *pgno* is promoted to a new
+    trunk page that points to the old trunk as its successor.
+  - **`Freelist.allocate()`**: pops a page from the freelist (LIFO — last leaf in
+    the current trunk) and zero-fills it before returning.  If the current trunk has
+    no leaf entries, the trunk page itself is returned and `first_trunk` advances to
+    the next trunk.  Falls back to `Pager.allocate()` when the freelist is empty.
+  - **`Freelist.total_pages`** property: reads the total count from the page-1 header.
+  - **`TRUNK_CAPACITY`** module constant (1 022): maximum leaf entries per trunk page
+    for 4 096-byte pages — exported for testing and documentation.
+- `BTree` now accepts an optional `freelist` keyword argument in `__init__`,
+  `create`, and `open`.
+  - **`BTree._allocate_page()`**: new internal helper that calls
+    `freelist.allocate()` when a freelist is injected, otherwise falls back to
+    `pager.allocate()`.  Replaces all direct `pager.allocate()` calls inside the
+    B-tree.
+  - **`BTree._free_page(pgno)`**: new internal helper that calls `freelist.free(pgno)`
+    when a freelist is injected.  Without a freelist, the page is zeroed in the
+    pager's dirty table (backwards-compatible with phases 1–4).
+  - **`BTree._free_overflow`** updated: now calls `_free_page()` for each overflow
+    page in the chain instead of directly zeroing via `pager.write()`.  With a
+    freelist, deleted overflow pages are reclaimed for reuse; without one the
+    behaviour is unchanged.
+
+### Fixed
+
+- **`Pager.commit()` cache coherency bug**: after a successful commit the LRU page
+  cache could hold stale pre-commit values for pages that were read before being
+  dirtied in the same session.  The fix promotes every dirty page into the cache
+  before clearing the dirty table, so reads immediately after commit see the
+  committed data without going back to disk.  This bug had no effect on existing
+  phases (all tests closed and reopened the pager after commit) but was exposed by
+  the new freelist tests that commit mid-session and then re-read the header.
+- **`Pager.rollback()` cache consistency**: dirty pages are now evicted from the
+  cache before the dirty table is cleared, so reads after rollback fall through to
+  the main file (which holds the correct pre-txn state) rather than potentially
+  returning stale cached data from the aborted transaction.
+
 ## [0.5.0] - 2026-04-20
 
 ### Added

--- a/code/packages/python/storage-sqlite/README.md
+++ b/code/packages/python/storage-sqlite/README.md
@@ -27,7 +27,7 @@ mini_sqlite.connect("app.db")
         ├── header   (100-byte database header at offset 0)    ✓ phase 1
         ├── record   (varint + serial types)      ✓ phase 2
         ├── btree    (leaf + overflow + full recursive splits)  ✓ phases 3 + 4a + 4b
-        ├── freelist (page reuse)                 [v1 phase 5]
+        ├── freelist (trunk/leaf page reuse)       ✓ phase 5
         └── schema   (sqlite_schema round-trip)   [v1 phase 6]
 ```
 
@@ -35,7 +35,7 @@ Nothing above the `Backend` line changes. The full SQL pipeline (lexer →
 parser → planner → optimizer → codegen → VM) runs unmodified against this
 backend.
 
-## What works today (phases 1 + 2 + 3 + 4a + 4b)
+## What works today (phases 1 + 2 + 3 + 4a + 4b + 5)
 
 - **`header` module** — the 100-byte database header at the start of page 1.
   Read and write every field, validate magic string and page size on open.
@@ -68,10 +68,20 @@ backend.
     The root page number never changes.
   - Corrupted pages (bad ncells, out-of-range pointers, overflow cycles,
     unknown page types) all raise `CorruptDatabaseError`.
+- **`freelist` module** — SQLite trunk/leaf freelist (phase 5).
+  `Freelist(pager)` manages the linked list of reusable pages rooted in the
+  page-1 header (offsets 32–39). `free(pgno)` adds a page as a leaf entry
+  in the current trunk, or promotes it to a new trunk when the current one
+  is full (capacity: 1 022 leaves per 4 096-byte trunk page). `allocate()`
+  pops the last leaf LIFO — matching SQLite's allocation order — and
+  zero-fills the page before returning it; when the freelist is empty it
+  falls through to `Pager.allocate()`. Pass `freelist=Freelist(pager)` to
+  `BTree.create()` / `BTree.open()` to enable automatic overflow-page reuse
+  on delete and update.
 
-What's **not yet** in this package (coming in later phases): freelist /
-page reuse (phase 5), `sqlite_schema` (phase 6), and the `Backend` adapter
-that wires the full pipeline in (phase 7).
+What's **not yet** in this package (coming in later phases):
+`sqlite_schema` (phase 6) and the `Backend` adapter that wires the full
+pipeline in (phase 7).
 
 ## Installation
 
@@ -79,7 +89,7 @@ that wires the full pipeline in (phase 7).
 uv pip install -e .
 ```
 
-## Usage (phases 1 + 2 + 3 + 4a + 4b)
+## Usage (phases 1 + 2 + 3 + 4a + 4b + 5)
 
 ```python
 from storage_sqlite import Header, Pager, record, varint
@@ -122,6 +132,29 @@ with Pager.open("data.db") as pager:
     for rowid, payload in tree.scan():   # ascending order across all leaves
         cols, _ = record.decode(payload)
         print(rowid, cols[0])   # 1 row1 / 2 row2 / …
+
+# --- Freelist ---
+# Enable overflow-page reuse by injecting a Freelist into BTree.
+# Page 1 must already hold the database header (offsets 32–39 are the
+# freelist fields).
+from storage_sqlite import Freelist
+
+with Pager.create("app.db") as pager:
+    page1 = bytearray(pager.page_size)
+    page1[:100] = Header.new_database(page_size=4096).to_bytes()
+    pager.write(1, bytes(page1))
+    fl = Freelist(pager)
+    tree = BTree.create(pager, freelist=fl)   # root reuses freelist pages
+    tree.insert(1, record.encode([b"X" * 5000]))  # spills to overflow pages
+    pager.commit()
+
+with Pager.open("app.db") as pager:
+    fl = Freelist(pager)
+    tree = BTree.open(pager, root_page=2, freelist=fl)
+    tree.delete(1)          # overflow pages returned to freelist
+    tree.insert(2, record.encode([b"Y" * 5000]))  # reuses those pages
+    print(fl.total_pages)   # 0 — all freed pages were reused
+    pager.commit()
 ```
 
 This intentionally looks low-level — the `Backend` adapter that makes

--- a/code/packages/python/storage-sqlite/README.md
+++ b/code/packages/python/storage-sqlite/README.md
@@ -26,7 +26,7 @@ mini_sqlite.connect("app.db")
         ├── pager    (page I/O + LRU cache + rollback journal) ✓ phase 1
         ├── header   (100-byte database header at offset 0)    ✓ phase 1
         ├── record   (varint + serial types)      ✓ phase 2
-        ├── btree    (leaf + overflow + traversal + root split) ✓ phases 3 + 4a  [recursive splits in phase 4b]
+        ├── btree    (leaf + overflow + full recursive splits)  ✓ phases 3 + 4a + 4b
         ├── freelist (page reuse)                 [v1 phase 5]
         └── schema   (sqlite_schema round-trip)   [v1 phase 6]
 ```
@@ -35,7 +35,7 @@ Nothing above the `Backend` line changes. The full SQL pipeline (lexer →
 parser → planner → optimizer → codegen → VM) runs unmodified against this
 backend.
 
-## What works today (phases 1 + 2 + 3 + 4a)
+## What works today (phases 1 + 2 + 3 + 4a + 4b)
 
 - **`header` module** — the 100-byte database header at the start of page 1.
   Read and write every field, validate magic string and page size on open.
@@ -53,17 +53,25 @@ backend.
   the real `sqlite3` output for simple records.
 - **`btree` module** — table B-tree pages (type `0x0D` leaf + type `0x05`
   interior). `insert`, `find`, `scan`, `delete`, `update` all work on trees
-  with depth ≤ 2. Supports overflow chains for large records. Includes a
-  **root-leaf split**: when the root leaf fills, it is automatically promoted
-  to an interior page with two leaf children, and insertion resumes seamlessly.
-  Corrupted pages (bad ncells, out-of-range pointers, overflow cycles, unknown
-  page types) all raise `CorruptDatabaseError` rather than silently
-  misinterpreting data. Non-root leaf splits (depth > 2) land in phase 4b.
+  of **arbitrary depth**. Supports overflow chains for large records. Split
+  algorithm:
+  - **Root-leaf split**: when the root leaf fills it becomes an interior page
+    with two leaf children.
+  - **Non-root leaf split**: when a non-root leaf fills, the existing page is
+    rewritten with the left half, a right sibling is allocated, and the
+    separator key propagates up to the parent.
+  - **Interior page split** (recursive): if a parent interior page is also
+    full, the median cell is removed and propagated further up the ancestor
+    chain, splitting interior pages all the way to the root if necessary.
+  - **Root interior split**: if the root interior page fills, two new interior
+    children are allocated and the root is rewritten with one separator cell.
+    The root page number never changes.
+  - Corrupted pages (bad ncells, out-of-range pointers, overflow cycles,
+    unknown page types) all raise `CorruptDatabaseError`.
 
-What's **not yet** in this package (coming in later phases): non-root leaf
-splits + 3-level trees (phase 4b), freelist (phase 5), `sqlite_schema`
-(phase 6), and the `Backend` adapter that wires the full pipeline in
-(phase 7).
+What's **not yet** in this package (coming in later phases): freelist /
+page reuse (phase 5), `sqlite_schema` (phase 6), and the `Backend` adapter
+that wires the full pipeline in (phase 7).
 
 ## Installation
 
@@ -71,7 +79,7 @@ splits + 3-level trees (phase 4b), freelist (phase 5), `sqlite_schema`
 uv pip install -e .
 ```
 
-## Usage (phases 1 + 2 + 3 + 4a)
+## Usage (phases 1 + 2 + 3 + 4a + 4b)
 
 ```python
 from storage_sqlite import Header, Pager, record, varint
@@ -101,13 +109,12 @@ values, consumed = record.decode(raw)          # → ([None, 7, "hi"], 8)
 # --- BTree (single leaf, or multi-level after root split) ---
 with Pager.create("data.db") as pager:
     tree = BTree.create(pager)
-    # Insert enough rows to trigger the root-leaf split automatically.
-    # The root page is promoted to an interior page; two child leaves hold
-    # the data. Callers see no difference — insert/find/scan/delete work
-    # identically before and after the split.
-    for i in range(1, 600):
+    # Insert any number of rows — splits happen automatically at every level.
+    # Root-leaf split, non-root leaf splits, and interior splits are all
+    # transparent: insert/find/scan/delete work identically at any tree depth.
+    for i in range(1, 5001):
         tree.insert(i, record.encode([f"row{i}"]))
-    print(tree.cell_count())   # 599
+    print(tree.cell_count())   # 5000
     pager.commit()
 
 with Pager.open("data.db") as pager:

--- a/code/packages/python/storage-sqlite/pyproject.toml
+++ b/code/packages/python/storage-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-storage-sqlite"
-version = "0.5.0"
+version = "0.6.0"
 description = "SQLite byte-compatible file backend for the sql-backend interface."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/storage-sqlite/pyproject.toml
+++ b/code/packages/python/storage-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-storage-sqlite"
-version = "0.4.0"
+version = "0.5.0"
 description = "SQLite byte-compatible file backend for the sql-backend interface."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/storage-sqlite/src/storage_sqlite/__init__.py
+++ b/code/packages/python/storage-sqlite/src/storage_sqlite/__init__.py
@@ -9,9 +9,10 @@ Phases shipped so far:
   rollback journal.
 - :mod:`storage_sqlite.varint` — SQLite's 1..9 byte big-endian varints.
 - :mod:`storage_sqlite.record` — record codec (serial types + row values).
+- :mod:`storage_sqlite.btree` — table B-tree with full recursive splits.
+- :mod:`storage_sqlite.freelist` — SQLite trunk/leaf freelist for page reuse.
 
-Everything else (B-trees, sqlite_schema, the Backend adapter) lands in
-subsequent phases.
+Everything else (sqlite_schema, the Backend adapter) lands in subsequent phases.
 """
 
 from storage_sqlite import btree, record, varint
@@ -21,6 +22,7 @@ from storage_sqlite.errors import (
     JournalError,
     StorageError,
 )
+from storage_sqlite.freelist import TRUNK_CAPACITY, Freelist
 from storage_sqlite.header import Header
 from storage_sqlite.pager import PAGE_SIZE, Pager
 from storage_sqlite.record import Value
@@ -31,11 +33,13 @@ __all__ = [
     "BTreeError",
     "CorruptDatabaseError",
     "DuplicateRowidError",
+    "Freelist",
     "Header",
     "JournalError",
     "PageFullError",
     "Pager",
     "StorageError",
+    "TRUNK_CAPACITY",
     "Value",
     "btree",
     "record",

--- a/code/packages/python/storage-sqlite/src/storage_sqlite/btree.py
+++ b/code/packages/python/storage-sqlite/src/storage_sqlite/btree.py
@@ -1,5 +1,5 @@
 """
-Table B-tree pages — phase 4a: interior page traversal + root-leaf split.
+Table B-tree pages — phase 4b: full recursive leaf and interior splits.
 
 Architecture summary
 --------------------
@@ -8,7 +8,22 @@ SQLite organises every table as a **table B-tree**: a balanced tree of
 4 096-byte pages where each leaf holds a sorted array of (rowid, record)
 pairs and each interior node routes a search to the right child page.
 
-Phase 4a adds:
+Phase 4b adds full recursive splitting so the tree can grow to arbitrary
+depth with any number of rows:
+
+* **Non-root leaf split**: when a leaf that is not the root fills up,
+  ``BTree.insert`` splits it into two halves, rewrites the existing page
+  with the left half, allocates a right sibling, and pushes the separator
+  key up to the parent interior page.
+* **Interior page split**: if the parent interior page is also full, it
+  is split recursively. The median cell is removed and becomes the new
+  separator pushed further up the tree.
+* **Root interior split**: if the root itself is an interior page and is
+  full, two new interior child pages are allocated for the left and right
+  halves and the root is rewritten with a single separator cell, keeping
+  the root page number constant.
+
+Phase 4a added (preserved here):
 
 * Reading and traversing **interior pages** (type ``0x05``) so that
   :meth:`BTree.find`, :meth:`BTree.scan`, :meth:`BTree.delete`, and
@@ -16,18 +31,7 @@ Phase 4a adds:
 * A **root-leaf split**: when the root page is a leaf and it is full,
   :meth:`BTree.insert` allocates two new leaf pages, divides the cells
   between them, and promotes the root to an interior page containing a
-  single separator cell. The root page number never changes.
-
-After one root split the tree has depth 2: one interior root + two leaf
-children. If *either* of those leaves subsequently fills up, a
-:class:`PageFullError` is still raised — recursive non-root splits land
-in phase 4b.
-
-Phase 4b will add:
-
-* Full recursive splitting of non-root leaves.
-* Propagation of separators up through a chain of interior pages.
-* Trees of depth 3+.
+  single separator cell.
 
 Page memory layout
 ------------------
@@ -111,14 +115,28 @@ When a record is too large to fit in one page::
 The first ``L`` bytes are inline. The remainder fills overflow pages,
 chained by the u32 at their start.
 
-v1 limitations (phase 4a)
---------------------------
+Interior split algorithm
+------------------------
 
-* Non-root leaf splits still raise :class:`PageFullError`. Phase 4b adds
-  those.
+Given a full interior page with cells ``[C0, C1, ..., Cn-1]`` and
+``rightmost_child = R``::
+
+    mid = n // 2
+    left_page  : cells [C0, ..., C(mid-1)], rightmost_child = Cmid.left_child
+    median key : Cmid.sep_rowid  (pushed up to parent)
+    right_page : cells [C(mid+1), ..., C(n-1)], rightmost_child = R
+
+The median cell is consumed by the split — it disappears from both child
+pages and resurfaces as a separator in the parent.
+
+v1 limitations
+--------------
+
 * No rebalancing or merging on delete — leaf pages can become sparse.
 * No compacting of freeblocks within a page (unused space from deletes is
   not reclaimed until the leaf is rewritten by a subsequent operation).
+* Overflow chains are re-encoded on split (old overflow pages become
+  unreachable until the freelist, phase 5, recycles them).
 * Page size is pinned at 4 096; *reserved_per_page* is always 0.
 * The ``header_offset`` parameter accommodates page 1 (database header
   at bytes 0–99, B-tree header at byte 100). Callers that want a plain
@@ -187,13 +205,12 @@ class BTreeError(StorageError):
 
 
 class PageFullError(BTreeError):
-    """A non-root leaf page has no room for the new cell.
+    """Retained in the public API for external callers.
 
-    Phase 4b will resolve this with recursive splits; for now the caller
-    must either use a larger page, fewer rows, or wait for phase 4b.
-
-    After one root split the tree holds roughly twice the cells of a single
-    page. If either resulting leaf also fills up, this error is raised.
+    After phase 4b, normal :meth:`BTree.insert` calls never raise this
+    exception — recursive splits handle all leaf-overflow cases. The
+    class is kept so that custom callers who build their own backends can
+    still signal page-full conditions if needed.
     """
 
 
@@ -445,6 +462,32 @@ def _interior_cell_encode(left_child: int, sep_rowid: int) -> bytes:
     return struct.pack(">I", left_child) + varint_encode_signed(sep_rowid)
 
 
+def _interior_cells_fit(hdr_off: int, cells: list[tuple[int, int]]) -> bool:
+    """Return ``True`` if *cells* fit on an interior page with header at *hdr_off*.
+
+    The usable space on an interior page is
+    ``PAGE_SIZE - hdr_off - _INTERIOR_HDR`` bytes.  Each cell consumes
+    2 bytes in the pointer array plus its raw cell bytes.
+
+    This is called by :meth:`BTree._push_separator_up` to decide whether
+    adding one new separator cell to a parent interior page requires
+    splitting that page.
+
+    Example — check whether 510 cells fit on a fresh interior root::
+
+        cells_510 = [(i, i * 100) for i in range(1, 511)]
+        assert _interior_cells_fit(0, cells_510)   # probably True
+        cells_511 = cells_510 + [(511, 51100)]
+        assert not _interior_cells_fit(0, cells_511)  # at capacity, False
+    """
+    avail = PAGE_SIZE - hdr_off - _INTERIOR_HDR
+    needed = sum(
+        _CELL_PTR + len(_interior_cell_encode(lc, sep))
+        for lc, sep in cells
+    )
+    return needed <= avail
+
+
 def _write_ptrs(buf: bytearray, hdr_off: int, ptrs: list[int]) -> None:
     """Write the cell pointer array from *ptrs* into *buf* (leaf pages)."""
     base = _ptr_array_base(hdr_off)
@@ -461,22 +504,22 @@ def _init_leaf_page(buf: bytearray, hdr_off: int = 0) -> None:
 
 
 class BTree:
-    """Table B-tree with interior page traversal and root-leaf splits (phase 4a).
+    """Table B-tree with full recursive splits (phase 4b).
 
-    Supports arbitrarily many rows as long as the tree has depth ≤ 2 (one
-    interior root + two leaf children). The first time a leaf fills up and
-    that leaf *is* the root, a root split is performed automatically:
+    Supports an arbitrary number of rows at any depth. Inserts that fill a
+    leaf page trigger an automatic split:
 
-    1. Two new leaf pages are allocated.
-    2. The existing cells are divided at the midpoint between them.
-    3. The root page is rewritten as an interior page containing a single
-       separator cell ``[left_leaf | max_rowid_in_left]`` and a rightmost
-       child pointer to the right leaf.
+    * **Root-leaf split** (depth 1 → 2): the root leaf is promoted to an
+      interior page and two fresh leaves receive the divided cells.
+    * **Non-root leaf split** (depth ≥ 2): the leaf is split in two, and
+      the separator key is pushed up to the parent interior page.
+    * **Interior page split** (recursive): if the parent interior page is
+      also full, it is split too, propagating a new separator further up.
+    * **Root interior split**: if the root interior page is full, two new
+      interior children are allocated and the root is rewritten with one
+      cell.
 
-    After the root split subsequent inserts traverse the interior root to
-    find the correct leaf, then insert there. If that child leaf later
-    fills up, :class:`PageFullError` is raised — phase 4b adds recursive
-    non-root splits.
+    In all cases the :attr:`root_page` number is constant.
 
     All reads and writes go through the injected :class:`~storage_sqlite.pager.Pager`.
     The B-tree itself is stateless between calls.
@@ -561,21 +604,22 @@ class BTree:
         more overflow pages allocated from the pager, and only the local
         portion stays on the leaf.
 
-        If the root is currently a leaf and it is full, a **root split** is
-        performed: the root is promoted to an interior page and two fresh
-        leaf pages receive the existing plus new cells. This happens
-        transparently and the :attr:`root_page` number never changes.
+        When a leaf page is full, it is split automatically:
+
+        * Root leaf → root-leaf split (root promoted to interior, two new
+          leaf children). The root page number never changes.
+        * Non-root leaf → leaf split, separator pushed up.  If the parent
+          interior page is also full, the split propagates recursively up
+          the ancestor path, potentially splitting the root interior page.
 
         Raises
         ------
         DuplicateRowidError
             A cell with the same *rowid* already exists.
-        PageFullError
-            A *non-root* leaf page has insufficient free space. Phase 4b
-            handles this with recursive splits.
         """
-        # Find the leaf page where this rowid belongs.
-        leaf_pgno, leaf_hdr_off = self._find_leaf_page(rowid)
+        # Find the leaf page where this rowid belongs, recording the path
+        # of interior ancestors from root to the leaf's parent.
+        path, leaf_pgno, leaf_hdr_off = self._find_leaf_with_path(rowid)
 
         page_data = bytearray(self._pager.read(leaf_pgno))
         hdr = _read_hdr(page_data, leaf_hdr_off)
@@ -606,24 +650,22 @@ class BTree:
         new_content_start = content_start - cell_size
 
         if new_content_start < ptr_array_end:
-            # The leaf is full.
-            if leaf_pgno == self._root_page:
-                # Root IS a leaf and it's full → split it.
-                survivors = [self._read_cell(page_data, ptr) for ptr in ptrs]
-                # Merge the new cell at the already-computed insert position.
-                all_cells = (
-                    survivors[:insert_idx]
-                    + [(rowid, payload)]
-                    + survivors[insert_idx:]
-                )
-                self._split_root_leaf(all_cells)
-                return
-            # Non-root leaf is full → phase 4b.
-            raise PageFullError(
-                f"leaf page {leaf_pgno} is full "
-                f"(need {cell_size + _CELL_PTR} bytes, "
-                f"only {content_start - ptr_array_end} available)"
+            # The leaf is full.  Gather all existing cells plus the new one
+            # in sorted order and dispatch to the appropriate split path.
+            survivors = [self._read_cell(page_data, ptr) for ptr in ptrs]
+            all_cells = (
+                survivors[:insert_idx]
+                + [(rowid, payload)]
+                + survivors[insert_idx:]
             )
+            if not path:
+                # Leaf IS the root → root-leaf split (phase 4a).
+                self._split_root_leaf(all_cells)
+            else:
+                # Non-root leaf → split, then push separator up.
+                sep, right_pgno = self._split_leaf(leaf_pgno, all_cells)
+                self._push_separator_up(path, leaf_pgno, right_pgno, sep)
+            return
 
         # Leaf has room: now write the overflow chain (if needed).
         local = _local_payload_size(total)
@@ -704,8 +746,8 @@ class BTree:
         freed (zeroed). The containing leaf page is compacted in-place
         after deletion.
 
-        Works correctly on multi-level trees (phase 4a): traverses interior
-        pages to locate the right leaf, modifies only that leaf.
+        Works correctly on multi-level trees: traverses interior pages to
+        locate the right leaf, modifies only that leaf.
         """
         leaf_pgno, leaf_hdr_off = self._find_leaf_page(rowid)
         page_data = bytearray(self._pager.read(leaf_pgno))
@@ -752,32 +794,26 @@ class BTree:
         self.insert(rowid, payload)
         return True
 
-    # ── Internals ─────────────────────────────────────────────────────────────
+    # ── Path-tracking traversal ───────────────────────────────────────────────
 
-    def _find_leaf_page(self, rowid: int) -> tuple[int, int]:
-        """Traverse from the root to the leaf page that would contain *rowid*.
+    def _find_leaf_with_path(
+        self, rowid: int
+    ) -> tuple[list[tuple[int, int, int]], int, int]:
+        """Traverse root → leaf, recording the ancestor path for split propagation.
 
-        Returns ``(leaf_pgno, hdr_off)``. The ``hdr_off`` is
-        :attr:`_header_offset` for the root page and ``0`` for every other
-        page (only the root can have a non-zero header offset, because the
-        100-byte SQLite database header lives only on page 1).
+        Returns ``(path, leaf_pgno, leaf_hdr_off)`` where *path* is a list
+        of ``(pgno, hdr_off, chosen_idx)`` tuples for each interior page
+        visited, ordered from root to the leaf's immediate parent.
 
-        The traversal rule for an interior page cell ``(left_child, sep_rowid)``:
+        ``chosen_idx`` is the index of the interior cell whose
+        ``left_child`` pointer was followed to reach the next level, or
+        ``-1`` when the ``rightmost_child`` was followed.  This bookkeeping
+        is needed by :meth:`_push_separator_up` to locate where the split
+        child lives in the parent's cell array.
 
-        * ``rowid <= sep_rowid``  → follow *left_child*
-        * otherwise              → continue checking the next cell
-
-        If no cell matches, follow ``rightmost_child``.
-
-        Safety guards:
-
-        * Depth limit: raises :class:`~storage_sqlite.errors.CorruptDatabaseError`
-          if depth exceeds :data:`_MAX_BTREE_DEPTH` (corrupt interior chain).
-        * Child pointer validation: raises if a child pointer is 0 or
-          beyond the pager's current page count.
-        * Unknown page type: raises on any type byte other than ``0x05``
-          or ``0x0D``.
+        Safety guards are identical to :meth:`_find_leaf_page`.
         """
+        path: list[tuple[int, int, int]] = []
         pgno = self._root_page
         hdr_off = self._header_offset
         depth = 0
@@ -793,7 +829,7 @@ class BTree:
             hdr = _read_hdr(page_data, hdr_off)
 
             if hdr["page_type"] == PAGE_TYPE_LEAF_TABLE:
-                return pgno, hdr_off
+                return path, pgno, hdr_off
 
             if hdr["page_type"] != PAGE_TYPE_INTERIOR_TABLE:
                 raise CorruptDatabaseError(
@@ -801,24 +837,40 @@ class BTree:
                     f"0x{hdr['page_type']:02x} (expected 0x05 or 0x0D)"
                 )
 
-            # Binary search the interior cells to find which child to follow.
+            # Walk the interior cells to find which child to descend into,
+            # recording the index so _push_separator_up can find it later.
             ptrs = _read_interior_ptrs(page_data, hdr_off, hdr["ncells"])
-            child_pgno = hdr["rightmost_child"]
-            for ptr in ptrs:
+            chosen_child = hdr["rightmost_child"]
+            chosen_idx = -1  # -1 means rightmost_child was chosen
+            for i, ptr in enumerate(ptrs):
                 left_child, sep_rowid = _read_interior_cell(page_data, ptr)
                 if rowid <= sep_rowid:
-                    child_pgno = left_child
+                    chosen_child = left_child
+                    chosen_idx = i
                     break
 
-            if child_pgno == 0 or child_pgno > self._pager.size_pages:
+            if chosen_child == 0 or chosen_child > self._pager.size_pages:
                 raise CorruptDatabaseError(
                     f"interior page {pgno} has invalid child pointer "
-                    f"{child_pgno} (pager has {self._pager.size_pages} pages)"
+                    f"{chosen_child} (pager has {self._pager.size_pages} pages)"
                 )
 
-            pgno = child_pgno
+            path.append((pgno, hdr_off, chosen_idx))
+            pgno = chosen_child
             hdr_off = 0  # only the root page may have a non-zero header offset
             depth += 1
+
+    def _find_leaf_page(self, rowid: int) -> tuple[int, int]:
+        """Return ``(leaf_pgno, hdr_off)`` for the leaf that would contain *rowid*.
+
+        Thin wrapper around :meth:`_find_leaf_with_path` used by
+        :meth:`find`, :meth:`delete`, and :meth:`update`, which only need
+        the leaf location and not the full ancestor path.
+        """
+        _, leaf_pgno, leaf_hdr_off = self._find_leaf_with_path(rowid)
+        return leaf_pgno, leaf_hdr_off
+
+    # ── Scan ──────────────────────────────────────────────────────────────────
 
     def _scan_page(
         self,
@@ -897,6 +949,8 @@ class BTree:
         total += self._count_cells(hdr["rightmost_child"], 0)
         return total
 
+    # ── Split helpers ─────────────────────────────────────────────────────────
+
     def _split_root_leaf(self, all_cells: list[tuple[int, bytes]]) -> None:
         """Promote the root-leaf to an interior page by splitting *all_cells*.
 
@@ -958,6 +1012,264 @@ class BTree:
         struct.pack_into(">H", root_buf, hdr_off + _INTERIOR_HDR, cell_off)
 
         self._pager.write(self._root_page, bytes(root_buf))
+
+    def _split_leaf(
+        self,
+        leaf_pgno: int,
+        all_cells: list[tuple[int, bytes]],
+    ) -> tuple[int, int]:
+        """Split a non-root leaf page into two halves.
+
+        *leaf_pgno* is overwritten with the left half. A new right sibling
+        is allocated for the right half.
+
+        Non-root leaves always have ``hdr_off = 0`` — the 100-byte
+        database header only appears on the root page (page 1).
+
+        Split point: ``mid = len(all_cells) // 2``.
+
+        Returns ``(separator_rowid, right_pgno)`` where *separator_rowid*
+        is the maximum rowid in the left half — the key that propagates
+        upward into the parent interior page.
+
+        .. note::
+            If *all_cells* contains payloads that originally lived on
+            overflow pages, ``_write_cells_to_leaf`` re-encodes them into
+            new overflow chains.  The old overflow pages become unreachable
+            until phase 5 (freelist) recycles them.
+        """
+        mid = len(all_cells) // 2
+        left_cells = all_cells[:mid]
+        right_cells = all_cells[mid:]
+        separator_rowid = left_cells[-1][0]
+
+        right_pgno = self._pager.allocate()
+        # Reuse leaf_pgno for the left half; hdr_off=0 (non-root leaf).
+        self._write_cells_to_leaf(leaf_pgno, 0, left_cells)
+        self._write_cells_to_leaf(right_pgno, 0, right_cells)
+        return separator_rowid, right_pgno
+
+    def _write_interior_page(
+        self,
+        pgno: int,
+        hdr_off: int,
+        cells: list[tuple[int, int]],
+        rightmost_child: int,
+    ) -> None:
+        """Write an interior page with *cells* and *rightmost_child*.
+
+        Cells are written downward from ``PAGE_SIZE`` and pointers upward
+        from ``hdr_off + _INTERIOR_HDR``. Any prefix bytes before *hdr_off*
+        (the 100-byte SQLite database header on page 1) are preserved.
+
+        Parameters
+        ----------
+        pgno:
+            Target page number.
+        hdr_off:
+            Byte offset of the B-tree header within the page (0 or 100).
+        cells:
+            Sorted list of ``(left_child, sep_rowid)`` pairs.
+        rightmost_child:
+            Page number of the rightmost (largest-key) child.
+        """
+        buf = bytearray(PAGE_SIZE)
+        if hdr_off > 0:
+            orig = self._pager.read(pgno)
+            buf[:hdr_off] = orig[:hdr_off]
+
+        content_offset = PAGE_SIZE
+        ptrs: list[int] = []
+        for left_child, sep_rowid in cells:
+            cell = _interior_cell_encode(left_child, sep_rowid)
+            content_offset -= len(cell)
+            buf[content_offset : content_offset + len(cell)] = cell
+            ptrs.append(content_offset)
+
+        _write_interior_hdr(
+            buf,
+            hdr_off,
+            ncells=len(cells),
+            content_start=content_offset,
+            rightmost_child=rightmost_child,
+        )
+        for i, ptr in enumerate(ptrs):
+            struct.pack_into(">H", buf, hdr_off + _INTERIOR_HDR + i * _CELL_PTR, ptr)
+
+        self._pager.write(pgno, bytes(buf))
+
+    def _split_interior_page(
+        self,
+        pgno: int,
+        hdr_off: int,
+        all_cells: list[tuple[int, int]],
+        rightmost_child: int,
+    ) -> tuple[int, int]:
+        """Split a non-root interior page.
+
+        The median cell is promoted out of the page (it is not kept in
+        either half). *pgno* is rewritten with the left half; a new right
+        sibling is allocated for the right half.
+
+        Split convention (n = len(all_cells), mid = n // 2)::
+
+            left_page  : cells [0, mid),   rightmost_child = all_cells[mid].left_child
+            median     : all_cells[mid]    → sep_rowid pushed up to parent
+            right_page : cells [mid+1, n), rightmost_child = rightmost_child
+
+        Returns ``(median_sep_rowid, right_pgno)``.
+        """
+        mid = len(all_cells) // 2
+        left_cells = all_cells[:mid]
+        median_left_child, median_sep = all_cells[mid]
+        right_cells = all_cells[mid + 1 :]
+
+        right_pgno = self._pager.allocate()
+        # Left half: reuse existing page.  Its rightmost_child is the left
+        # child of the median cell (which is consumed by the promotion).
+        self._write_interior_page(pgno, hdr_off, left_cells, median_left_child)
+        # Right half: new page.  Its rightmost_child is the original.
+        self._write_interior_page(right_pgno, 0, right_cells, rightmost_child)
+        return median_sep, right_pgno
+
+    def _split_root_interior(
+        self,
+        all_cells: list[tuple[int, int]],
+        rightmost_child: int,
+    ) -> None:
+        """Split the root interior page into two interior children.
+
+        When the root is an interior page and full, there is no parent to
+        push a separator into. Instead:
+
+        1. Pick the median cell ``all_cells[mid]``.
+        2. Allocate ``left_pgno`` and ``right_pgno``.
+        3. Write left half → ``left_pgno``,  rightmost = median.left_child.
+        4. Write right half → ``right_pgno``, rightmost = *rightmost_child*.
+        5. Rewrite the root with a single cell ``(left_pgno, median_sep)``
+           and ``rightmost_child = right_pgno``.
+
+        The root page number never changes.
+        """
+        mid = len(all_cells) // 2
+        left_cells = all_cells[:mid]
+        median_left_child, median_sep = all_cells[mid]
+        right_cells = all_cells[mid + 1 :]
+
+        left_pgno = self._pager.allocate()
+        right_pgno = self._pager.allocate()
+
+        self._write_interior_page(left_pgno, 0, left_cells, median_left_child)
+        self._write_interior_page(right_pgno, 0, right_cells, rightmost_child)
+
+        # Rewrite the root with a single separator cell.
+        hdr_off = self._header_offset
+        root_buf = bytearray(PAGE_SIZE)
+        if hdr_off > 0:
+            orig = self._pager.read(self._root_page)
+            root_buf[:hdr_off] = orig[:hdr_off]
+
+        cell = _interior_cell_encode(left_pgno, median_sep)
+        cell_off = PAGE_SIZE - len(cell)
+        _write_interior_hdr(
+            root_buf,
+            hdr_off,
+            ncells=1,
+            content_start=cell_off,
+            rightmost_child=right_pgno,
+        )
+        root_buf[cell_off : cell_off + len(cell)] = cell
+        struct.pack_into(">H", root_buf, hdr_off + _INTERIOR_HDR, cell_off)
+
+        self._pager.write(self._root_page, bytes(root_buf))
+
+    def _push_separator_up(
+        self,
+        ancestors: list[tuple[int, int, int]],
+        left_pgno: int,
+        right_pgno: int,
+        sep_rowid: int,
+    ) -> None:
+        """Insert a new separator into the nearest parent interior page.
+
+        Called after any leaf or interior split.  *ancestors* is the path
+        from the root down to the parent of the just-split page, with the
+        direct parent at ``ancestors[-1]``.
+
+        The parent currently holds a reference to *left_pgno* as one of
+        its child pointers.  After the split, *left_pgno* now holds the
+        smaller half and *right_pgno* holds the larger half.  We insert a
+        new interior cell ``(left_pgno, sep_rowid)`` into the parent so
+        that the tree routing is correct.
+
+        Two placement cases arise depending on how the parent was reached:
+
+        **Case A — chosen_idx ≥ 0** (parent cell ``i`` had ``left_child =
+        left_pgno``):  insert new cell ``(left_pgno, sep_rowid)`` at index
+        ``i``; replace cell ``i``'s left_child with ``right_pgno``::
+
+            Before: ..., (left_pgno, old_sep), ...
+            After:  ..., (left_pgno, sep_rowid), (right_pgno, old_sep), ...
+
+        **Case B — chosen_idx = -1** (parent's ``rightmost_child =
+        left_pgno``): append new cell ``(left_pgno, sep_rowid)`` and set
+        ``rightmost_child = right_pgno``::
+
+            Before: ..., (last_lc, last_sep),  rightmost = left_pgno
+            After:  ..., (last_lc, last_sep), (left_pgno, sep_rowid),
+                         rightmost = right_pgno
+
+        If the resulting cell list fits in the parent, it is written
+        directly.  If the parent is also full, it is split via
+        :meth:`_split_interior_page` (or :meth:`_split_root_interior` if
+        it is the root) and the process recurses with the grandparent.
+        """
+        parent_pgno, parent_hdr_off, chosen_idx = ancestors[-1]
+        remaining = ancestors[:-1]
+
+        parent_data = self._pager.read(parent_pgno)
+        parent_hdr = _read_hdr(parent_data, parent_hdr_off)
+        ncells = parent_hdr["ncells"]
+        old_ptrs = _read_interior_ptrs(parent_data, parent_hdr_off, ncells)
+        old_cells = [_read_interior_cell(parent_data, ptr) for ptr in old_ptrs]
+        old_rightmost = parent_hdr["rightmost_child"]
+
+        # Build the updated cell list.
+        if chosen_idx >= 0:
+            # Case A: descended into old_cells[chosen_idx].left_child.
+            # Replace that cell's left_child with right_pgno, and insert
+            # (left_pgno, sep_rowid) before it.
+            new_cells: list[tuple[int, int]] = []
+            for i, (lc, sep) in enumerate(old_cells):
+                if i == chosen_idx:
+                    new_cells.append((left_pgno, sep_rowid))
+                    new_cells.append((right_pgno, sep))
+                else:
+                    new_cells.append((lc, sep))
+            new_rightmost = old_rightmost
+        else:
+            # Case B: descended into rightmost_child = left_pgno.
+            # Append (left_pgno, sep_rowid) and update rightmost_child.
+            new_cells = list(old_cells) + [(left_pgno, sep_rowid)]
+            new_rightmost = right_pgno
+
+        # Write the parent if the new cell list fits.
+        if _interior_cells_fit(parent_hdr_off, new_cells):
+            self._write_interior_page(parent_pgno, parent_hdr_off, new_cells, new_rightmost)
+            return
+
+        # Parent is full — split it and recurse upward.
+        if not remaining:
+            # Parent IS the root interior page.
+            self._split_root_interior(new_cells, new_rightmost)
+        else:
+            # Non-root interior page: split and push the median up.
+            up_sep, new_right_pgno = self._split_interior_page(
+                parent_pgno, parent_hdr_off, new_cells, new_rightmost
+            )
+            self._push_separator_up(remaining, parent_pgno, new_right_pgno, up_sep)
+
+    # ── Cell I/O ──────────────────────────────────────────────────────────────
 
     def _read_cell(self, page_data: bytes | bytearray, ptr: int) -> tuple[int, bytes]:
         """Decode a full (rowid, payload) pair from *ptr*, following any
@@ -1088,7 +1400,8 @@ class BTree:
         """Write a sorted list of (rowid, payload) cells to a leaf page.
 
         Used by :meth:`delete` (page compaction after removing a cell) and
-        by :meth:`_split_root_leaf` (writing the two new child pages).
+        by :meth:`_split_root_leaf` and :meth:`_split_leaf` (writing
+        split child pages).
 
         The byte layout is built from scratch: cells are written downward
         from ``PAGE_SIZE`` and pointers are written upward from

--- a/code/packages/python/storage-sqlite/src/storage_sqlite/btree.py
+++ b/code/packages/python/storage-sqlite/src/storage_sqlite/btree.py
@@ -135,8 +135,10 @@ v1 limitations
 * No rebalancing or merging on delete — leaf pages can become sparse.
 * No compacting of freeblocks within a page (unused space from deletes is
   not reclaimed until the leaf is rewritten by a subsequent operation).
-* Overflow chains are re-encoded on split (old overflow pages become
-  unreachable until the freelist, phase 5, recycles them).
+* Overflow chains are re-encoded on split.  Overflow pages orphaned during
+  a split are returned to the freelist if a :class:`~storage_sqlite.freelist.Freelist`
+  was injected; otherwise they are zeroed and remain allocated (they will
+  be reclaimed by a future phase-6 DROP TABLE or VACUUM).
 * Page size is pinned at 4 096; *reserved_per_page* is always 0.
 * The ``header_offset`` parameter accommodates page 1 (database header
   at bytes 0–99, B-tree header at byte 100). Callers that want a plain
@@ -147,6 +149,7 @@ from __future__ import annotations
 
 import struct
 from collections.abc import Iterator
+from typing import TYPE_CHECKING
 
 from storage_sqlite.errors import CorruptDatabaseError, StorageError
 from storage_sqlite.pager import PAGE_SIZE, Pager
@@ -154,6 +157,9 @@ from storage_sqlite.varint import decode as varint_decode
 from storage_sqlite.varint import decode_signed as varint_decode_signed
 from storage_sqlite.varint import encode as varint_encode
 from storage_sqlite.varint import encode_signed as varint_encode_signed
+
+if TYPE_CHECKING:
+    from storage_sqlite.freelist import Freelist
 
 # ── Page type constants ────────────────────────────────────────────────────────
 
@@ -536,9 +542,17 @@ class BTree:
         100-byte SQLite database header in front of it). Note: only the
         root page is affected; all other pages in the tree always have
         their B-tree header at offset 0.
+    freelist:
+        Optional :class:`~storage_sqlite.freelist.Freelist` to use for
+        page allocation and reclamation.  When provided, overflow pages
+        freed by :meth:`delete` (and :meth:`update`) are returned to the
+        freelist for reuse, and new pages are taken from the freelist
+        before extending the file.  When ``None`` (default), freed overflow
+        pages are zeroed in place and new pages always extend the file —
+        the same behaviour as phases 1–4.
     """
 
-    __slots__ = ("_header_offset", "_pager", "_root_page")
+    __slots__ = ("_freelist", "_header_offset", "_pager", "_root_page")
 
     def __init__(
         self,
@@ -546,10 +560,12 @@ class BTree:
         root_page: int,
         *,
         header_offset: int = 0,
+        freelist: Freelist | None = None,
     ) -> None:
         self._pager: Pager = pager
         self._root_page: int = root_page
         self._header_offset: int = header_offset
+        self._freelist: Freelist | None = freelist
 
     # ── Construction ──────────────────────────────────────────────────────────
 
@@ -559,18 +575,22 @@ class BTree:
         pager: Pager,
         *,
         header_offset: int = 0,
+        freelist: Freelist | None = None,
     ) -> BTree:
         """Allocate a fresh leaf page and initialise it as an empty B-tree.
 
         Returns a :class:`BTree` rooted at the newly allocated page. The
         caller must :meth:`~storage_sqlite.pager.Pager.commit` the pager
         when ready to persist.
+
+        If *freelist* is supplied, the root page is taken from the freelist
+        rather than extending the file.
         """
-        pgno = pager.allocate()
+        pgno = freelist.allocate() if freelist is not None else pager.allocate()
         buf = bytearray(pager.read(pgno))
         _init_leaf_page(buf, header_offset)
         pager.write(pgno, bytes(buf))
-        return cls(pager, pgno, header_offset=header_offset)
+        return cls(pager, pgno, header_offset=header_offset, freelist=freelist)
 
     @classmethod
     def open(
@@ -579,9 +599,14 @@ class BTree:
         root_page: int,
         *,
         header_offset: int = 0,
+        freelist: Freelist | None = None,
     ) -> BTree:
-        """Open an existing B-tree rooted at *root_page*."""
-        return cls(pager, root_page, header_offset=header_offset)
+        """Open an existing B-tree rooted at *root_page*.
+
+        Pass the same *freelist* that was used when the B-tree was created
+        so that subsequent inserts and deletes reuse the same freelist.
+        """
+        return cls(pager, root_page, header_offset=header_offset, freelist=freelist)
 
     # ── Properties ────────────────────────────────────────────────────────────
 
@@ -589,6 +614,30 @@ class BTree:
     def root_page(self) -> int:
         """1-based page number of the B-tree root."""
         return self._root_page
+
+    # ── Internal page allocation / freeing helpers ────────────────────────────
+
+    def _allocate_page(self) -> int:
+        """Return a fresh page number for this B-tree.
+
+        Tries the freelist first.  Falls back to :meth:`Pager.allocate` if
+        no freelist was injected or the freelist is empty.
+        """
+        if self._freelist is not None:
+            return self._freelist.allocate()
+        return self._pager.allocate()
+
+    def _free_page(self, pgno: int) -> None:
+        """Release *pgno* back to the freelist if available.
+
+        If no freelist was injected, the page is zeroed in the pager's
+        dirty-page table so it does not contain stale data.  The page
+        remains allocated in that case (no reuse until phase 6 / VACUUM).
+        """
+        if self._freelist is not None:
+            self._freelist.free(pgno)
+        else:
+            self._pager.write(pgno, b"\x00" * PAGE_SIZE)
 
     # ── Public operations ─────────────────────────────────────────────────────
 
@@ -979,8 +1028,8 @@ class BTree:
         separator_rowid = left_cells[-1][0]  # max rowid in left subtree
 
         # Allocate two fresh leaf pages.
-        left_pgno = self._pager.allocate()
-        right_pgno = self._pager.allocate()
+        left_pgno = self._allocate_page()
+        right_pgno = self._allocate_page()
 
         # Write cell halves to the new leaf pages (hdr_off=0 for non-root).
         self._write_cells_to_leaf(left_pgno, 0, left_cells)
@@ -1043,7 +1092,7 @@ class BTree:
         right_cells = all_cells[mid:]
         separator_rowid = left_cells[-1][0]
 
-        right_pgno = self._pager.allocate()
+        right_pgno = self._allocate_page()
         # Reuse leaf_pgno for the left half; hdr_off=0 (non-root leaf).
         self._write_cells_to_leaf(leaf_pgno, 0, left_cells)
         self._write_cells_to_leaf(right_pgno, 0, right_cells)
@@ -1124,7 +1173,7 @@ class BTree:
         median_left_child, median_sep = all_cells[mid]
         right_cells = all_cells[mid + 1 :]
 
-        right_pgno = self._pager.allocate()
+        right_pgno = self._allocate_page()
         # Left half: reuse existing page.  Its rightmost_child is the left
         # child of the median cell (which is consumed by the promotion).
         self._write_interior_page(pgno, hdr_off, left_cells, median_left_child)
@@ -1156,8 +1205,8 @@ class BTree:
         median_left_child, median_sep = all_cells[mid]
         right_cells = all_cells[mid + 1 :]
 
-        left_pgno = self._pager.allocate()
-        right_pgno = self._pager.allocate()
+        left_pgno = self._allocate_page()
+        right_pgno = self._allocate_page()
 
         self._write_interior_page(left_pgno, 0, left_cells, median_left_child)
         self._write_interior_page(right_pgno, 0, right_cells, rightmost_child)
@@ -1332,7 +1381,7 @@ class BTree:
         prev_buf: bytearray | None = None
 
         while remaining:
-            pgno = self._pager.allocate()
+            pgno = self._allocate_page()
             buf = bytearray(PAGE_SIZE)
             chunk = remaining[:_OVERFLOW_USABLE]
             buf[4 : 4 + len(chunk)] = chunk
@@ -1354,13 +1403,14 @@ class BTree:
         return first_pgno
 
     def _free_overflow(self, page_data: bytes | bytearray, ptr: int) -> None:
-        """Zero out any overflow pages referenced by the cell at *ptr*.
+        """Free all overflow pages referenced by the cell at *ptr*.
 
-        Phase 5 will add proper freelist integration; for now the pages
-        are zeroed so they don't contain stale data.
+        Each overflow page in the chain is passed to :meth:`_free_page`,
+        which either returns it to the injected freelist (phase 5+) or
+        zeroes it in place (backwards-compatible behaviour from phases 1–4).
 
-        Same guards as :meth:`_read_cell`: validate page numbers and detect
-        circular chains before zeroing pages.
+        Same guards as :meth:`_read_cell`: page numbers are validated and
+        circular chains are detected before any page is freed.
         """
         offset = ptr
         total, n = varint_decode(page_data, offset)
@@ -1388,7 +1438,7 @@ class BTree:
             visited.add(overflow_pgno)
             ov_data = self._pager.read(overflow_pgno)
             (next_pgno,) = struct.unpack_from(">I", ov_data, 0)
-            self._pager.write(overflow_pgno, b"\x00" * PAGE_SIZE)
+            self._free_page(overflow_pgno)
             overflow_pgno = next_pgno
 
     def _write_cells_to_leaf(

--- a/code/packages/python/storage-sqlite/src/storage_sqlite/freelist.py
+++ b/code/packages/python/storage-sqlite/src/storage_sqlite/freelist.py
@@ -1,0 +1,298 @@
+"""
+SQLite freelist — trunk/leaf page-reuse mechanism.
+
+When does the freelist grow?
+----------------------------
+
+In SQLite a B-tree page is *never* removed from the tree due to ordinary
+row-level DELETE — the page stays allocated, just with fewer cells.  Pages
+return to the freelist only when their *payload* is released:
+
+* **Overflow page deletion** — when a record that spills into overflow pages
+  is deleted (or updated with a shorter payload), every overflow page in
+  the chain is freed.
+* **DROP TABLE / DROP INDEX** — every page in the entire B-tree is freed
+  (phase 6).
+
+The freelist is therefore primarily an overflow-page recycler in phase 5,
+with DROP TABLE support added in phase 6.
+
+On-disk layout
+--------------
+
+The freelist is rooted by two fields in the 100-byte database header on
+page 1:
+
+======= ===== ============================================================
+offset   size  meaning
+======= ===== ============================================================
+32        4    Page number of the first **trunk page** (0 = freelist empty)
+36        4    Total number of freelist pages (trunk + leaf combined)
+======= ===== ============================================================
+
+Each **trunk page** holds:
+
+======= ===== ============================================================
+offset   size  meaning
+======= ===== ============================================================
+0         4    Next trunk page number (0 = this is the last trunk)
+4         4    Number of leaf entries stored in this trunk page
+8+        4×N  Leaf page numbers (N up to 1 022 for 4 096-byte pages)
+======= ===== ============================================================
+
+**Leaf pages** are just freed data pages.  Their content is zero-filled on
+allocation (so callers always receive clean pages) but their content while
+waiting on the freelist is irrelevant — the freelist is a set of page
+numbers, not a set of page contents.
+
+Trunk-page capacity
+-------------------
+
+A 4 096-byte page has 8 bytes of trunk header, leaving 4 088 bytes for
+leaf pointers of 4 bytes each → **1 022 leaf entries per trunk page**::
+
+    (PAGE_SIZE - 8) // 4 == 1022
+
+Free protocol (``free``)
+------------------------
+
+1. Read the header to get ``first_trunk`` and ``total``.
+2. If there is a current trunk and it has room (count < 1 022): append
+   *pgno* as a new leaf entry in that trunk.
+3. Otherwise (no trunk, or trunk is full): promote *pgno* to a new trunk
+   page with 0 leaf entries, pointing to the old trunk as its successor.
+4. Increment ``total`` in the header.
+
+Allocate protocol (``allocate``)
+---------------------------------
+
+1. If the freelist is empty (``first_trunk == 0``): fall through to
+   ``Pager.allocate()`` to extend the file.
+2. Read the first trunk.
+3. If the trunk has leaf entries: pop the last leaf (LIFO — good locality),
+   decrement trunk's count, zero-fill the leaf page, return it.
+4. If the trunk has **no** leaf entries: the trunk page itself is returned,
+   the header's ``first_trunk`` advances to the next trunk, the page is
+   zero-filled.
+
+Why LIFO?  SQLite pops from the end of the leaf array.  Using the same
+policy helps our files look byte-similar to SQLite's output for the same
+sequence of operations, which is one of the project's goals.
+
+Thread / transaction safety
+----------------------------
+
+v1 is single-process, single-writer.  No locking is needed.  All reads
+and writes go through the :class:`~storage_sqlite.pager.Pager` which
+stages dirty pages in memory until :meth:`~storage_sqlite.pager.Pager.commit`.
+A rollback reverts every freelist update atomically along with all other
+dirty pages.
+
+Invariants maintained
+---------------------
+
+* Page 1 is never freed — it is the database header page.
+* ``total`` in the header equals the sum of all leaf entries across all
+  trunk pages, plus the number of trunk pages themselves.
+* Trunk pages are never listed as leaf entries — a page is either a trunk
+  *or* a leaf, never both.
+"""
+
+from __future__ import annotations
+
+import struct
+
+from storage_sqlite.pager import PAGE_SIZE, Pager
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_HDR_FIRST_TRUNK_OFFSET: int = 32
+"""Offset inside page 1 of the first-trunk-page pointer (u32 BE)."""
+
+_HDR_TOTAL_OFFSET: int = 36
+"""Offset inside page 1 of the total-freelist-page count (u32 BE)."""
+
+_TRUNK_NEXT_OFFSET: int = 0
+"""Offset inside a trunk page of the next-trunk pointer (u32 BE)."""
+
+_TRUNK_COUNT_OFFSET: int = 4
+"""Offset inside a trunk page of the leaf-entry count (u32 BE)."""
+
+_TRUNK_LEAVES_OFFSET: int = 8
+"""Offset inside a trunk page where leaf page numbers begin (u32 BE each)."""
+
+_LEAF_ENTRY_SIZE: int = 4
+"""Bytes per leaf entry (a u32 page number)."""
+
+TRUNK_CAPACITY: int = (PAGE_SIZE - _TRUNK_LEAVES_OFFSET) // _LEAF_ENTRY_SIZE
+"""Maximum leaf entries per trunk page (1 022 for 4 096-byte pages).
+
+Exposed for testing.  Formula: ``(PAGE_SIZE - 8) // 4``.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Freelist class
+# ---------------------------------------------------------------------------
+
+
+class Freelist:
+    """Manages SQLite's trunk/leaf freelist of reusable pages.
+
+    Pass a :class:`~storage_sqlite.pager.Pager` on construction.  The
+    freelist reads and writes only through that pager, so all changes are
+    staged in the pager's dirty-page table and committed or rolled back
+    atomically with the rest of the transaction.
+
+    Usage example::
+
+        with Pager.create("app.db") as pager:
+            fl = Freelist(pager)
+            # ... B-tree operations that free overflow pages ...
+            fl.free(overflow_pgno)          # returns page to freelist
+            reused = fl.allocate()          # reuses it on next alloc
+            pager.commit()
+    """
+
+    __slots__ = ("_pager",)
+
+    def __init__(self, pager: Pager) -> None:
+        self._pager: Pager = pager
+
+    # ── Properties ────────────────────────────────────────────────────────────
+
+    @property
+    def total_pages(self) -> int:
+        """Total number of pages currently on the freelist (trunk + leaf).
+
+        Reads the header field at offset 36 of page 1.  Returns 0 when the
+        freelist is empty.  This value is recomputed from disk on every
+        access — call sparingly in tight loops.
+        """
+        _, total = self._read_header_fields()
+        return total
+
+    # ── Core operations ───────────────────────────────────────────────────────
+
+    def allocate(self) -> int:
+        """Return a reusable page number, or extend the file if the list is empty.
+
+        The returned page is zero-filled in the pager's dirty table, so the
+        caller always starts with a clean page regardless of what it held
+        previously.
+
+        Algorithm:
+
+        1. If ``first_trunk == 0``: fall through to ``Pager.allocate()``.
+        2. Read the first trunk page.
+        3. If the trunk has leaf entries: pop the *last* leaf (LIFO), zero
+           it, return it.
+        4. If the trunk has no leaf entries: the trunk itself is the free
+           page; advance ``first_trunk`` to the next trunk, zero the old
+           trunk, return it.
+        """
+        first_trunk, total = self._read_header_fields()
+        if first_trunk == 0:
+            # Freelist empty — must extend the file.
+            return self._pager.allocate()
+
+        trunk_data = bytearray(self._pager.read(first_trunk))
+        (next_trunk,) = struct.unpack_from(">I", trunk_data, _TRUNK_NEXT_OFFSET)
+        (count,) = struct.unpack_from(">I", trunk_data, _TRUNK_COUNT_OFFSET)
+
+        if count > 0:
+            # Pop the last leaf entry (LIFO, matching SQLite behaviour).
+            leaf_offset = _TRUNK_LEAVES_OFFSET + (count - 1) * _LEAF_ENTRY_SIZE
+            (leaf_pgno,) = struct.unpack_from(">I", trunk_data, leaf_offset)
+            # Decrement the leaf count in the trunk and write it back.
+            struct.pack_into(">I", trunk_data, _TRUNK_COUNT_OFFSET, count - 1)
+            self._pager.write(first_trunk, bytes(trunk_data))
+            # Update the header total.
+            self._write_header_fields(first_trunk, total - 1)
+            # Zero-fill the leaf page so callers receive a clean slate.
+            self._pager.write(leaf_pgno, b"\x00" * PAGE_SIZE)
+            return leaf_pgno
+
+        else:
+            # Trunk has no leaves — return the trunk page itself.
+            # Advance the header's first-trunk pointer to the next trunk.
+            self._write_header_fields(next_trunk, total - 1)
+            # Zero-fill the old trunk page.
+            self._pager.write(first_trunk, b"\x00" * PAGE_SIZE)
+            return first_trunk
+
+    def free(self, pgno: int) -> None:
+        """Add *pgno* to the freelist.
+
+        *pgno* must be a valid, allocated page number other than page 1 (the
+        database header page).  The caller is responsible for ensuring the
+        page is no longer referenced anywhere in the database.
+
+        Algorithm:
+
+        1. If there is a current trunk with room (count < :data:`TRUNK_CAPACITY`):
+           append *pgno* as a new leaf entry.
+        2. Otherwise (no trunk, or current trunk is full): promote *pgno* to a
+           new trunk page with 0 leaf entries, pointing to the old trunk as its
+           successor, and update the header's ``first_trunk``.
+        3. Increment ``total`` in the header.
+        """
+        if pgno <= 0:
+            raise ValueError(f"pgno must be >= 1, got {pgno}")
+        if pgno == 1:
+            raise ValueError("page 1 (the database header page) cannot be freed")
+        if pgno > self._pager.size_pages:
+            raise ValueError(
+                f"pgno {pgno} is beyond the current database size "
+                f"({self._pager.size_pages} pages)"
+            )
+
+        first_trunk, total = self._read_header_fields()
+
+        if first_trunk != 0:
+            trunk_data = bytearray(self._pager.read(first_trunk))
+            (count,) = struct.unpack_from(">I", trunk_data, _TRUNK_COUNT_OFFSET)
+            if count < TRUNK_CAPACITY:
+                # There is room in the current trunk: append *pgno* as a leaf.
+                leaf_offset = _TRUNK_LEAVES_OFFSET + count * _LEAF_ENTRY_SIZE
+                struct.pack_into(">I", trunk_data, leaf_offset, pgno)
+                struct.pack_into(">I", trunk_data, _TRUNK_COUNT_OFFSET, count + 1)
+                self._pager.write(first_trunk, bytes(trunk_data))
+                self._write_header_fields(first_trunk, total + 1)
+                return
+
+        # No trunk exists, or the current trunk is full.
+        # Promote *pgno* to a new trunk page that points to the old trunk.
+        new_trunk = bytearray(PAGE_SIZE)
+        struct.pack_into(">I", new_trunk, _TRUNK_NEXT_OFFSET, first_trunk)
+        struct.pack_into(">I", new_trunk, _TRUNK_COUNT_OFFSET, 0)
+        self._pager.write(pgno, bytes(new_trunk))
+        self._write_header_fields(pgno, total + 1)
+
+    # ── Internal helpers ──────────────────────────────────────────────────────
+
+    def _read_header_fields(self) -> tuple[int, int]:
+        """Read ``(first_trunk_pgno, total_freelist_pages)`` from page 1.
+
+        Both values are u32 BE at fixed offsets in the 100-byte database
+        header.  This reads page 1 through the pager (so dirty updates to
+        page 1 within the current transaction are visible immediately).
+        """
+        page1 = self._pager.read(1)
+        (first_trunk,) = struct.unpack_from(">I", page1, _HDR_FIRST_TRUNK_OFFSET)
+        (total,) = struct.unpack_from(">I", page1, _HDR_TOTAL_OFFSET)
+        return first_trunk, total
+
+    def _write_header_fields(self, first_trunk: int, total: int) -> None:
+        """Update the freelist fields in the page-1 header.
+
+        Reads page 1, overwrites only the two freelist fields, and writes the
+        modified page back through the pager.  All other header bytes
+        (including the B-tree cell area starting at offset 100) are untouched.
+        """
+        buf = bytearray(self._pager.read(1))
+        struct.pack_into(">I", buf, _HDR_FIRST_TRUNK_OFFSET, first_trunk)
+        struct.pack_into(">I", buf, _HDR_TOTAL_OFFSET, total)
+        self._pager.write(1, bytes(buf))

--- a/code/packages/python/storage-sqlite/src/storage_sqlite/pager.py
+++ b/code/packages/python/storage-sqlite/src/storage_sqlite/pager.py
@@ -296,8 +296,18 @@ class Pager:
             # "fully applied" and guessing wrong would corrupt the file.
             raise
 
-        # Success: the txn boundary moves forward. Clear in-memory
-        # bookkeeping.
+        # Success: the txn boundary moves forward.
+        #
+        # Promote every committed page into the LRU cache so that reads
+        # *within the same Pager session* immediately after commit see the
+        # newly-written data without going back to disk.  Without this
+        # promotion the cache can hold stale pre-txn values for pages that
+        # were written during the transaction (the cache is populated on
+        # first *read*, not on write, so a page that was only written in
+        # this txn would not be in the cache yet, but a page that was read
+        # before being modified *would* be in the cache with its old value).
+        for page_no, data in self._dirty.items():
+            self._cache_put(page_no, data)
         self._initial_size_pages = self._size_pages
         self._dirty.clear()
         self._originals.clear()
@@ -306,6 +316,15 @@ class Pager:
     def rollback(self) -> None:
         """Discard every pending write. No disk I/O."""
         self._assert_open()
+        # Evict any dirty pages from the cache before clearing dirty, so
+        # subsequent reads see the *committed* state (from the last commit
+        # or the initial file contents) rather than the discarded dirty
+        # values.  For pages that existed before this transaction the cache
+        # will be repopulated from the main file on the next read; for
+        # freshly-allocated pages the cache entry is simply gone (which is
+        # correct — those page numbers cease to exist after rollback).
+        for page_no in self._dirty:
+            self._cache.pop(page_no, None)
         self._dirty.clear()
         self._originals.clear()
         self._journaled.clear()

--- a/code/packages/python/storage-sqlite/tests/test_btree.py
+++ b/code/packages/python/storage-sqlite/tests/test_btree.py
@@ -1,5 +1,5 @@
 """Tests for the B-tree layer — leaf pages, overflow chains, scan/find/CRUD,
-interior page traversal, and root-leaf splits."""
+interior page traversal, root-leaf splits, and full recursive splits."""
 
 from __future__ import annotations
 
@@ -23,6 +23,7 @@ from storage_sqlite.btree import (
     PageFullError,
     _init_leaf_page,
     _interior_cell_encode,
+    _interior_cells_fit,
     _local_payload_size,
     _read_hdr,
     _read_interior_cell,
@@ -350,20 +351,26 @@ def test_update_inline_to_overflow(tmp_path: Path) -> None:
 
 
 # ------------------------------------------------------------------
-# Page-full detection
+# PageFullError is kept in the API but no longer raised by normal inserts
 # ------------------------------------------------------------------
 
 
-def test_page_full_raises(tmp_path: Path) -> None:
-    """Overfill a page with many cells until PageFullError is raised."""
+def test_page_full_error_is_exported() -> None:
+    """PageFullError must remain importable from storage_sqlite (public API)."""
+    assert issubclass(PageFullError, Exception)
+
+
+def test_many_rows_no_page_full_error(tmp_path: Path) -> None:
+    """Phase 4b: inserting many rows must not raise PageFullError.
+
+    Previously (phase 4a) this would raise once a non-root leaf filled up.
+    Recursive splits now handle all cases transparently.
+    """
     with make_pager(tmp_path) as p:
         b = BTree.create(p)
-        # Each cell with an empty record is ~3 bytes (2 varint + payload).
-        # Header + N*2 pointers + N*3 cell bytes must stay within 4096.
-        # Insert until the page is full.
-        with pytest.raises(PageFullError):
-            for rowid in range(1, 10_000):
-                b.insert(rowid, record_encode([rowid]))
+        for rowid in range(1, 2001):
+            b.insert(rowid, record_encode([rowid]))
+        assert b.cell_count() == 2000
 
 
 # ------------------------------------------------------------------
@@ -999,3 +1006,409 @@ def test_root_split_with_header_offset_100(tmp_path: Path) -> None:
         # All inserted rows must be findable through the split tree.
         for rid in range(1, rowid + 1):
             assert b.find(rid) is not None
+
+
+# ==================================================================
+# Phase 4b — non-root leaf splits and interior node splits
+# ==================================================================
+
+
+# ------------------------------------------------------------------
+# Helper: insert until a non-root leaf split has happened
+# (i.e. root interior page has at least 2 cells)
+# ------------------------------------------------------------------
+
+
+def _fill_until_non_root_split(b: BTree, start: int = 1) -> int:
+    """Insert small rows until the root interior page has ≥ 2 separator cells.
+
+    Returns the rowid of the last inserted row.  At that point at least
+    one non-root leaf split has propagated a separator up to the root.
+    """
+    rowid = start
+    while True:
+        b.insert(rowid, record_encode([rowid]))
+        root_data = b._pager.read(b.root_page)
+        if root_data[0] == PAGE_TYPE_INTERIOR_TABLE:
+            hdr = _read_hdr(root_data, 0)
+            if hdr["ncells"] >= 2:
+                return rowid
+        rowid += 1
+
+
+# ------------------------------------------------------------------
+# Non-root leaf split — basic correctness
+# ------------------------------------------------------------------
+
+
+def test_non_root_leaf_split_triggers(tmp_path: Path) -> None:
+    """Inserting enough rows must cause the root to accumulate multiple cells."""
+    with make_pager(tmp_path) as p:
+        b = BTree.create(p)
+        last = _fill_until_non_root_split(b)
+        root_data = p.read(b.root_page)
+        hdr = _read_hdr(root_data, 0)
+        assert hdr["page_type"] == PAGE_TYPE_INTERIOR_TABLE
+        assert hdr["ncells"] >= 2
+        assert b.cell_count() == last
+
+
+def test_non_root_leaf_split_cell_count(tmp_path: Path) -> None:
+    """cell_count() must equal the number of inserted rows after multiple splits."""
+    with make_pager(tmp_path) as p:
+        b = BTree.create(p)
+        n = 1000
+        for rowid in range(1, n + 1):
+            b.insert(rowid, record_encode([rowid]))
+        assert b.cell_count() == n
+
+
+def test_non_root_leaf_split_scan_all(tmp_path: Path) -> None:
+    """scan() must yield every row in ascending rowid order after many splits."""
+    with make_pager(tmp_path) as p:
+        b = BTree.create(p)
+        n = 1000
+        for rowid in range(1, n + 1):
+            b.insert(rowid, record_encode([rowid]))
+        rows = list(b.scan())
+        assert [r for r, _ in rows] == list(range(1, n + 1))
+        for rowid, raw in rows:
+            values, _ = record_decode(raw)
+            assert values == [rowid]
+
+
+def test_non_root_leaf_split_find_all(tmp_path: Path) -> None:
+    """find() must succeed for every rowid after non-root leaf splits."""
+    with make_pager(tmp_path) as p:
+        b = BTree.create(p)
+        n = 800
+        for rowid in range(1, n + 1):
+            b.insert(rowid, record_encode([rowid]))
+        for rowid in range(1, n + 1):
+            raw = b.find(rowid)
+            assert raw is not None
+            values, _ = record_decode(raw)
+            assert values == [rowid]
+
+
+def test_non_root_leaf_split_find_missing(tmp_path: Path) -> None:
+    """find() returns None for a rowid not in a multi-split tree."""
+    with make_pager(tmp_path) as p:
+        b = BTree.create(p)
+        for rowid in range(1, 601):
+            b.insert(rowid, record_encode([rowid]))
+        assert b.find(99_999) is None
+
+
+def test_non_root_leaf_split_delete(tmp_path: Path) -> None:
+    """delete() removes the correct row from a tree that has undergone multiple splits."""
+    with make_pager(tmp_path) as p:
+        b = BTree.create(p)
+        n = 800
+        for rowid in range(1, n + 1):
+            b.insert(rowid, record_encode([rowid]))
+        # Delete every even rowid.
+        for rowid in range(2, n + 1, 2):
+            assert b.delete(rowid) is True
+        assert b.cell_count() == n // 2
+        rows = list(b.scan())
+        assert [r for r, _ in rows] == list(range(1, n + 1, 2))
+
+
+def test_non_root_leaf_split_update(tmp_path: Path) -> None:
+    """update() replaces payloads correctly in a multi-split tree."""
+    with make_pager(tmp_path) as p:
+        b = BTree.create(p)
+        n = 600
+        for rowid in range(1, n + 1):
+            b.insert(rowid, record_encode([rowid]))
+        # Update a handful of rows on different leaves.
+        for rowid in [1, 100, 300, n]:
+            assert b.update(rowid, record_encode([rowid * 10])) is True
+        for rowid in [1, 100, 300, n]:
+            values, _ = record_decode(b.find(rowid))  # type: ignore[arg-type]
+            assert values == [rowid * 10]
+
+
+def test_non_root_leaf_split_duplicate_rowid(tmp_path: Path) -> None:
+    """DuplicateRowidError is raised even when the tree has multiple leaves."""
+    with make_pager(tmp_path) as p:
+        b = BTree.create(p)
+        for rowid in range(1, 601):
+            b.insert(rowid, record_encode([rowid]))
+        with pytest.raises(DuplicateRowidError):
+            b.insert(300, record_encode(["dup"]))
+
+
+def test_non_root_leaf_split_reverse_order(tmp_path: Path) -> None:
+    """Descending-order inserts still produce a correctly-structured tree."""
+    with make_pager(tmp_path) as p:
+        b = BTree.create(p)
+        n = 800
+        for rowid in range(n, 0, -1):
+            b.insert(rowid, record_encode([rowid]))
+        rows = list(b.scan())
+        assert [r for r, _ in rows] == list(range(1, n + 1))
+
+
+def test_non_root_leaf_split_persist_reopen(tmp_path: Path) -> None:
+    """Multi-split tree committed to disk must round-trip through close/reopen."""
+    p = make_pager(tmp_path)
+    b = BTree.create(p)
+    n = 600
+    for rowid in range(1, n + 1):
+        b.insert(rowid, record_encode([f"row{rowid}"]))
+    p.commit()
+    p.close()
+
+    p2 = Pager.open(tmp_path / "db")
+    b2 = BTree.open(p2, 1)
+    assert b2.cell_count() == n
+    rows = list(b2.scan())
+    assert [r for r, _ in rows] == list(range(1, n + 1))
+    for rowid, raw in rows:
+        values, _ = record_decode(raw)
+        assert values == [f"row{rowid}"]
+    p2.close()
+
+
+# ------------------------------------------------------------------
+# _interior_cells_fit — unit tests
+# ------------------------------------------------------------------
+
+
+def test_interior_cells_fit_empty_list() -> None:
+    """An empty cell list always fits."""
+    assert _interior_cells_fit(0, []) is True
+
+
+def test_interior_cells_fit_small_list() -> None:
+    """A handful of small cells fit on a fresh interior page."""
+    cells = [(i, i * 100) for i in range(1, 11)]
+    assert _interior_cells_fit(0, cells) is True
+
+
+def test_interior_cells_fit_overfull() -> None:
+    """A cell list that exceeds PAGE_SIZE must not fit."""
+    # Each interior cell for small rowids is 4 + 1 = 5 bytes, plus 2 ptr = 7.
+    # Available space = 4096 - 12 = 4084. Forcing 600 cells = 4200 > 4084.
+    cells = [(i, i) for i in range(1, 601)]
+    assert _interior_cells_fit(0, cells) is False
+
+
+def test_interior_cells_fit_with_header_offset() -> None:
+    """header_offset=100 reduces available space by 100 bytes.
+
+    For cells = [(i, i) for i in range(1, n+1)] with small i values:
+    - hdr_off=0  : avail = 4084 bytes, max cells = 526
+    - hdr_off=100: avail = 3984 bytes, max cells = 513
+
+    Using 520 cells sits between the two thresholds: fits at 0, overflows at 100.
+    """
+    cells_520 = [(i, i) for i in range(1, 521)]
+    # Fits at hdr_off=0 (needs ~4033 bytes ≤ 4084 available).
+    assert _interior_cells_fit(0, cells_520) is True
+    # Does not fit at hdr_off=100 (needs ~4033 bytes > 3984 available).
+    assert _interior_cells_fit(100, cells_520) is False
+    # A shorter list fits at both offsets.
+    cells_short = [(i, i) for i in range(1, 200)]
+    assert _interior_cells_fit(0, cells_short) is True
+    assert _interior_cells_fit(100, cells_short) is True
+
+
+# ------------------------------------------------------------------
+# _write_interior_page — unit tests
+# ------------------------------------------------------------------
+
+
+def test_write_interior_page_round_trip(tmp_path: Path) -> None:
+    """_write_interior_page produces a page that _read_hdr + _read_interior_ptrs
+    can decode correctly."""
+    with make_pager(tmp_path) as p:
+        b = BTree.create(p)
+        extra = p.allocate()
+        cells = [(2, 10), (3, 20), (4, 30)]
+        b._write_interior_page(extra, 0, cells, rightmost_child=5)
+        page_data = p.read(extra)
+        hdr = _read_hdr(page_data, 0)
+        assert hdr["page_type"] == PAGE_TYPE_INTERIOR_TABLE
+        assert hdr["ncells"] == 3
+        assert hdr["rightmost_child"] == 5
+        ptrs = _read_interior_ptrs(page_data, 0, 3)
+        decoded = [_read_interior_cell(page_data, ptr) for ptr in ptrs]
+        assert decoded == cells
+
+
+def test_write_interior_page_empty(tmp_path: Path) -> None:
+    """_write_interior_page with no cells writes a valid header."""
+    with make_pager(tmp_path) as p:
+        b = BTree.create(p)
+        extra = p.allocate()
+        b._write_interior_page(extra, 0, [], rightmost_child=7)
+        page_data = p.read(extra)
+        hdr = _read_hdr(page_data, 0)
+        assert hdr["page_type"] == PAGE_TYPE_INTERIOR_TABLE
+        assert hdr["ncells"] == 0
+        assert hdr["rightmost_child"] == 7
+
+
+# ------------------------------------------------------------------
+# Interior node split — triggered end-to-end with large payloads
+#
+# With ~800-byte payloads each leaf holds ~5 cells.  Non-root splits
+# propagate a separator to the root interior page each time a leaf
+# fills.  After ~510 such splits the root interior page fills and
+# _split_root_interior is invoked.  Inserting ~1800 rows reliably
+# triggers that code path.
+# ------------------------------------------------------------------
+
+
+# A payload large enough to make each leaf hold only ~5 cells so that
+# the root interior page fills up within a reasonable row count.
+_LARGE_PAYLOAD = b"X" * 800
+
+
+def test_interior_split_cell_count(tmp_path: Path) -> None:
+    """cell_count() is exact after a root interior split."""
+    with make_pager(tmp_path) as p:
+        b = BTree.create(p)
+        n = 1800
+        for rowid in range(1, n + 1):
+            b.insert(rowid, _LARGE_PAYLOAD)
+        assert b.cell_count() == n
+
+
+def test_interior_split_scan_all(tmp_path: Path) -> None:
+    """scan() returns all rows in ascending order after an interior split."""
+    with make_pager(tmp_path) as p:
+        b = BTree.create(p)
+        n = 1800
+        for rowid in range(1, n + 1):
+            b.insert(rowid, _LARGE_PAYLOAD)
+        rows = list(b.scan())
+        assert [r for r, _ in rows] == list(range(1, n + 1))
+        for _, payload in rows:
+            assert payload == _LARGE_PAYLOAD
+
+
+def test_interior_split_find_all(tmp_path: Path) -> None:
+    """find() works for every rowid after an interior split."""
+    with make_pager(tmp_path) as p:
+        b = BTree.create(p)
+        n = 1800
+        for rowid in range(1, n + 1):
+            b.insert(rowid, _LARGE_PAYLOAD)
+        for rowid in range(1, n + 1):
+            assert b.find(rowid) == _LARGE_PAYLOAD, f"find({rowid}) failed"
+
+
+def test_interior_split_root_has_depth_three(tmp_path: Path) -> None:
+    """After a root interior split the tree must have depth ≥ 3.
+
+    When the root interior page splits, it gains two interior children,
+    making depth = root (interior) + interior child + leaf = 3.
+    The root should have exactly one separator cell after its split.
+    """
+    with make_pager(tmp_path) as p:
+        b = BTree.create(p)
+        for rowid in range(1, 1801):
+            b.insert(rowid, _LARGE_PAYLOAD)
+        root_data = p.read(b.root_page)
+        root_hdr = _read_hdr(root_data, 0)
+        assert root_hdr["page_type"] == PAGE_TYPE_INTERIOR_TABLE
+        # After root interior split the root has exactly 1 cell.
+        assert root_hdr["ncells"] == 1
+        # Both children must also be interior pages.
+        ptrs = _read_interior_ptrs(root_data, 0, 1)
+        left_child, _ = _read_interior_cell(root_data, ptrs[0])
+        right_child = root_hdr["rightmost_child"]
+        left_data = p.read(left_child)
+        right_data = p.read(right_child)
+        assert _read_hdr(left_data, 0)["page_type"] == PAGE_TYPE_INTERIOR_TABLE
+        assert _read_hdr(right_data, 0)["page_type"] == PAGE_TYPE_INTERIOR_TABLE
+
+
+def test_interior_split_persist_reopen(tmp_path: Path) -> None:
+    """Tree with interior splits round-trips through commit + reopen."""
+    p = make_pager(tmp_path)
+    b = BTree.create(p)
+    n = 1800
+    for rowid in range(1, n + 1):
+        b.insert(rowid, _LARGE_PAYLOAD)
+    p.commit()
+    p.close()
+
+    p2 = Pager.open(tmp_path / "db")
+    b2 = BTree.open(p2, 1)
+    assert b2.cell_count() == n
+    rows = list(b2.scan())
+    assert [r for r, _ in rows] == list(range(1, n + 1))
+    p2.close()
+
+
+# ------------------------------------------------------------------
+# _split_root_interior — direct unit test
+# ------------------------------------------------------------------
+
+
+def test_split_root_interior_direct(tmp_path: Path) -> None:
+    """Call _split_root_interior directly with a synthetic full-root cell list.
+
+    We allocate placeholder pages for the children and verify that the
+    resulting root has exactly 1 cell and two interior children.
+    """
+    with make_pager(tmp_path) as p:
+        b = BTree.create(p)
+        # Allocate 512 placeholder child pages.
+        child_pages = [p.allocate() for _ in range(513)]
+        # Build 512 synthetic cells: [(child_pages[0], 0), ..., (child_pages[511], 511)]
+        cells_512 = [(child_pages[i], i * 100) for i in range(512)]
+        all_rightmost = child_pages[512]
+        # Call _split_root_interior with the synthetic cell list.
+        b._split_root_interior(cells_512, all_rightmost)
+        p.commit()
+
+    with Pager.open(tmp_path / "db") as p2:
+        root_data = p2.read(1)
+        root_hdr = _read_hdr(root_data, 0)
+        assert root_hdr["page_type"] == PAGE_TYPE_INTERIOR_TABLE
+        # After splitting 512 cells the root should have 1 cell (the median).
+        assert root_hdr["ncells"] == 1
+        # Both children should be valid (non-zero) interior pages.
+        ptr = struct.unpack_from(">H", root_data, _INTERIOR_HDR)[0]
+        left_child, median_sep = _read_interior_cell(root_data, ptr)
+        right_child = root_hdr["rightmost_child"]
+        assert left_child != 0
+        assert right_child != 0
+        assert left_child != right_child
+        # Median sep must be between 0 and 51100 (the range of our synthetic cells).
+        assert 0 <= median_sep <= 51100
+
+
+# ------------------------------------------------------------------
+# Push-separator-up with full parent — exercises _split_interior_page
+# ------------------------------------------------------------------
+
+
+def test_push_separator_up_full_parent(tmp_path: Path) -> None:
+    """When _push_separator_up encounters a full parent, the parent is split.
+
+    We craft this scenario by:
+    1. Performing enough inserts with large payloads to trigger a non-root
+       leaf split (parent = root interior, has 1+ cells).
+    2. Then filling the root interior completely by inserting many more rows.
+    3. The next non-root leaf split must push a separator into the full root,
+       triggering _split_root_interior.
+
+    After this the tree must be fully navigable (scan all, find all).
+    """
+    with make_pager(tmp_path) as p:
+        b = BTree.create(p)
+        # Insert enough large-payload rows to guarantee at least one root
+        # interior split (same end-to-end as the interior split tests above).
+        n = 2000
+        for rowid in range(1, n + 1):
+            b.insert(rowid, _LARGE_PAYLOAD)
+        assert b.cell_count() == n
+        rows = list(b.scan())
+        assert [r for r, _ in rows] == list(range(1, n + 1))

--- a/code/packages/python/storage-sqlite/tests/test_freelist.py
+++ b/code/packages/python/storage-sqlite/tests/test_freelist.py
@@ -1,0 +1,635 @@
+"""
+Tests for ``storage_sqlite.freelist`` — the SQLite trunk/leaf freelist.
+
+Test organisation
+-----------------
+
+Unit tests for :class:`~storage_sqlite.freelist.Freelist` in isolation:
+
+1. **Empty freelist** — ``total_pages`` is 0, ``allocate()`` falls through to
+   ``Pager.allocate()``, the file grows.
+2. **Single free/allocate round-trip** — free a page, check ``total_pages``
+   becomes 1, then allocate and get the same page back (LIFO).
+3. **Multiple free then allocate (LIFO order)** — pages are returned in
+   last-freed-first order, matching SQLite's behaviour.
+4. **Trunk promotion** — free more than TRUNK_CAPACITY pages; a second trunk
+   is created, and all pages are recoverable.
+5. **Trunk-with-no-leaves is returned itself** — when an empty trunk is the
+   only freelist entry, ``allocate()`` returns the trunk page and sets
+   ``first_trunk`` to 0.
+6. **Header fields on page 1** — ``Freelist`` only touches bytes 32–39 of
+   page 1; all other bytes (including B-tree header at offset 100) are
+   preserved.
+7. **Persist across pager reopen** — commit, reopen, freelist state survives.
+8. **Rollback reverts freelist** — ``Pager.rollback()`` after freelist
+   mutations restores the prior state.
+9. **Validation errors** — freeing page 1, page 0, or out-of-range pages
+   raises ``ValueError``.
+
+Integration tests for BTree + Freelist:
+
+10. **Overflow pages freed and reused** — insert a large record (overflow),
+    delete it, then insert another large record; the new record reuses the
+    old overflow pages rather than extending the file.
+11. **freelist=None preserves old behaviour** — all existing btree tests
+    continue to pass because freelist defaults to None.
+12. **BTree.create with freelist** — creating a tree reuses a freelist page
+    for the root.
+13. **Persist with freelist** — freelist state and B-tree data both survive
+    commit + reopen.
+"""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from storage_sqlite import TRUNK_CAPACITY, BTree, Freelist, Pager, record
+from storage_sqlite.freelist import (
+    _HDR_FIRST_TRUNK_OFFSET,
+    _HDR_TOTAL_OFFSET,
+    _TRUNK_COUNT_OFFSET,
+    _TRUNK_LEAVES_OFFSET,
+    _TRUNK_NEXT_OFFSET,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_db(tmp_path):
+    """Create a minimal 1-page database, return (pager, path).
+
+    Page 1 is written so that the freelist fields at offsets 32 and 36 are
+    initialised to zero (no freelist).  The B-tree uses the page-1 header
+    area (offset 100), so we need the pager to think page 1 exists.
+    """
+    path = str(tmp_path / "test.db")
+    pager = Pager.create(path)
+    # Allocate page 1 and write a zeroed header (freelist fields = 0).
+    pager.allocate()  # page 1
+    pager.write(1, b"\x00" * pager.page_size)
+    pager.commit()
+    return pager, path
+
+
+def _read_header_freelist(pager):
+    """Return (first_trunk, total) from the page-1 header."""
+    page1 = pager.read(1)
+    (first_trunk,) = struct.unpack_from(">I", page1, _HDR_FIRST_TRUNK_OFFSET)
+    (total,) = struct.unpack_from(">I", page1, _HDR_TOTAL_OFFSET)
+    return first_trunk, total
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — Freelist in isolation
+# ---------------------------------------------------------------------------
+
+
+class TestFreelistEmpty:
+    """A freshly initialised freelist with total=0."""
+
+    def test_total_pages_is_zero(self, tmp_path):
+        pager, _ = _make_db(tmp_path)
+        fl = Freelist(pager)
+        assert fl.total_pages == 0
+
+    def test_allocate_extends_file(self, tmp_path):
+        pager, _ = _make_db(tmp_path)
+        fl = Freelist(pager)
+        # Page 1 already exists.  Allocating via freelist falls through to
+        # pager.allocate() which returns page 2.
+        pgno = fl.allocate()
+        assert pgno == 2
+        assert pager.size_pages == 2
+
+    def test_header_fields_unchanged(self, tmp_path):
+        pager, _ = _make_db(tmp_path)
+        fl = Freelist(pager)
+        fl.allocate()
+        first_trunk, total = _read_header_freelist(pager)
+        assert first_trunk == 0
+        assert total == 0
+
+
+class TestFreelistSinglePage:
+    """Free one page, then allocate it back."""
+
+    def test_free_increments_total(self, tmp_path):
+        pager, _ = _make_db(tmp_path)
+        fl = Freelist(pager)
+        # Allocate a data page.
+        pgno = pager.allocate()  # page 2
+        # Return it to the freelist.
+        fl.free(pgno)
+        assert fl.total_pages == 1
+
+    def test_free_sets_first_trunk_in_header(self, tmp_path):
+        pager, _ = _make_db(tmp_path)
+        fl = Freelist(pager)
+        pgno = pager.allocate()  # page 2
+        fl.free(pgno)
+        first_trunk, _ = _read_header_freelist(pager)
+        # pgno became a trunk page (no existing trunk to add a leaf to).
+        assert first_trunk == pgno
+
+    def test_allocate_returns_freed_page(self, tmp_path):
+        pager, _ = _make_db(tmp_path)
+        fl = Freelist(pager)
+        pgno = pager.allocate()  # page 2
+        fl.free(pgno)
+        reused = fl.allocate()
+        assert reused == pgno
+
+    def test_allocate_decrements_total(self, tmp_path):
+        pager, _ = _make_db(tmp_path)
+        fl = Freelist(pager)
+        pgno = pager.allocate()
+        fl.free(pgno)
+        fl.allocate()
+        assert fl.total_pages == 0
+
+    def test_allocate_returns_zeroed_page(self, tmp_path):
+        pager, _ = _make_db(tmp_path)
+        fl = Freelist(pager)
+        pgno = pager.allocate()
+        # Write something to the page to confirm zeroing happens.
+        pager.write(pgno, b"\xFF" * pager.page_size)
+        fl.free(pgno)
+        reused = fl.allocate()
+        assert pager.read(reused) == b"\x00" * pager.page_size
+
+    def test_after_allocate_freelist_empty(self, tmp_path):
+        pager, _ = _make_db(tmp_path)
+        fl = Freelist(pager)
+        pgno = pager.allocate()
+        fl.free(pgno)
+        fl.allocate()
+        first_trunk, total = _read_header_freelist(pager)
+        assert first_trunk == 0
+        assert total == 0
+
+
+class TestFreelistMultiplePages:
+    """Free several pages; verify LIFO order on allocate."""
+
+    def test_lifo_order(self, tmp_path):
+        """Pages are returned last-freed-first."""
+        pager, _ = _make_db(tmp_path)
+        fl = Freelist(pager)
+        # Allocate three data pages.
+        p2 = pager.allocate()  # 2
+        p3 = pager.allocate()  # 3
+        p4 = pager.allocate()  # 4
+        # p2 becomes first trunk (no trunk yet).
+        fl.free(p2)
+        # p3 is added as a leaf to the trunk (p2).
+        fl.free(p3)
+        # p4 is added as a leaf to the trunk (p2).
+        fl.free(p4)
+        assert fl.total_pages == 3
+        # Allocate pops LIFO from the trunk's leaf array: p4, p3, then p2.
+        assert fl.allocate() == p4
+        assert fl.allocate() == p3
+        # p2 is the trunk with no leaves — returned as the trunk itself.
+        assert fl.allocate() == p2
+        assert fl.total_pages == 0
+
+    def test_total_pages_tracks_all_frees(self, tmp_path):
+        pager, _ = _make_db(tmp_path)
+        fl = Freelist(pager)
+        pages = [pager.allocate() for _ in range(10)]
+        # First free creates a trunk, the remaining 9 are leaves.
+        for p in pages:
+            fl.free(p)
+        assert fl.total_pages == 10
+
+    def test_all_pages_recoverable(self, tmp_path):
+        pager, _ = _make_db(tmp_path)
+        fl = Freelist(pager)
+        n = 20
+        freed = [pager.allocate() for _ in range(n)]
+        # First free -> trunk; remaining -> leaves, then new trunks as leaf
+        # entries overflow.  In practice all 20 fit in one trunk (cap = 1022).
+        for p in freed:
+            fl.free(p)
+        recovered = [fl.allocate() for _ in range(n)]
+        assert sorted(recovered) == sorted(freed)
+
+
+class TestFreelistTrunkPromotion:
+    """When the current trunk is full, a new trunk is created."""
+
+    def test_trunk_capacity_constant(self):
+        """TRUNK_CAPACITY == (4096 - 8) // 4 == 1022."""
+        assert TRUNK_CAPACITY == 1022
+
+    def test_new_trunk_when_first_trunk_full(self, tmp_path):
+        """Freeing TRUNK_CAPACITY + 2 pages creates two trunks.
+
+        Trace (pages numbered from 2):
+
+        * pages[0]  → no existing trunk, pages[0] becomes trunk, count=0
+        * pages[1..TRUNK_CAPACITY] → TRUNK_CAPACITY leaves added, count=TRUNK_CAPACITY
+        * pages[TRUNK_CAPACITY+1] → trunk is full, pages[TRUNK_CAPACITY+1] becomes
+          a new trunk pointing to the old trunk as ``next``, count=0
+
+        So ``TRUNK_CAPACITY + 2`` frees are needed to overflow a trunk.
+        """
+        pager, _ = _make_db(tmp_path)
+        fl = Freelist(pager)
+        # Allocate TRUNK_CAPACITY + 2 data pages.
+        pages = [pager.allocate() for _ in range(TRUNK_CAPACITY + 2)]
+        for p in pages:
+            fl.free(p)
+        assert fl.total_pages == TRUNK_CAPACITY + 2
+        # Header's first_trunk should point to the newest (second) trunk.
+        first_trunk, total = _read_header_freelist(pager)
+        assert total == TRUNK_CAPACITY + 2
+        # Read the newest trunk to verify it is a fresh trunk page.
+        trunk_data = pager.read(first_trunk)
+        (nxt,) = struct.unpack_from(">I", trunk_data, _TRUNK_NEXT_OFFSET)
+        (count,) = struct.unpack_from(">I", trunk_data, _TRUNK_COUNT_OFFSET)
+        assert count == 0   # new trunk, no leaves yet
+        assert nxt != 0     # old trunk is the successor
+
+    def test_all_recoverable_across_two_trunks(self, tmp_path):
+        """All TRUNK_CAPACITY + 2 freed pages can be allocated back."""
+        pager, _ = _make_db(tmp_path)
+        fl = Freelist(pager)
+        pages = [pager.allocate() for _ in range(TRUNK_CAPACITY + 2)]
+        for p in pages:
+            fl.free(p)
+        recovered = [fl.allocate() for _ in range(TRUNK_CAPACITY + 2)]
+        assert sorted(recovered) == sorted(pages)
+        assert fl.total_pages == 0
+
+
+class TestFreelistHeaderPreservation:
+    """Freelist only touches bytes 32–39 of page 1; B-tree data is untouched."""
+
+    def test_bytes_outside_freelist_fields_unchanged(self, tmp_path):
+        pager, _ = _make_db(tmp_path)
+        # Write a recognisable pattern to page 1 except at the freelist fields.
+        buf = bytearray(b"\xAB" * pager.page_size)
+        # Zero the freelist fields so Freelist sees an empty freelist.
+        struct.pack_into(">II", buf, _HDR_FIRST_TRUNK_OFFSET, 0, 0)
+        pager.write(1, bytes(buf))
+
+        fl = Freelist(pager)
+        pgno = pager.allocate()  # page 2
+        fl.free(pgno)
+
+        page1_after = pager.read(1)
+        # Bytes 0..31 must still be 0xAB.
+        assert page1_after[:_HDR_FIRST_TRUNK_OFFSET] == b"\xAB" * _HDR_FIRST_TRUNK_OFFSET
+        # Bytes 40..4095 must still be 0xAB.
+        assert page1_after[_HDR_TOTAL_OFFSET + 4 :] == b"\xAB" * (
+            pager.page_size - _HDR_TOTAL_OFFSET - 4
+        )
+
+    def test_btree_header_area_untouched(self, tmp_path):
+        """Bytes 100..4095 (B-tree cell area on page 1) are never touched."""
+        pager, _ = _make_db(tmp_path)
+        buf = bytearray(pager.page_size)
+        # Plant a sentinel in the B-tree area (offset 100).
+        buf[100] = 0x5A
+        pager.write(1, bytes(buf))
+
+        fl = Freelist(pager)
+        pgno = pager.allocate()
+        fl.free(pgno)
+        fl.allocate()
+
+        assert pager.read(1)[100] == 0x5A
+
+
+class TestFreelistPersistence:
+    """Freelist state survives commit + reopen."""
+
+    def test_persist_and_reopen(self, tmp_path):
+        path = str(tmp_path / "fl.db")
+        pager = Pager.create(path)
+        pager.allocate()  # page 1
+        pager.write(1, b"\x00" * pager.page_size)
+
+        fl = Freelist(pager)
+        p2 = pager.allocate()
+        p3 = pager.allocate()
+        fl.free(p3)  # leaf in p2-as-trunk is p3 → actually p2 is trunk, p3 is leaf
+        fl.free(p2)  # wait — let me think: first free(p3): no trunk, p3 becomes trunk
+        # Re-check: free(p3) → p3 is new trunk, count=0. free(p2) → p2 added as leaf to trunk p3
+        # So trunk=p3, leaf=[p2], total=2
+        pager.commit()
+        pager.close()
+
+        pager2 = Pager.open(path)
+        fl2 = Freelist(pager2)
+        assert fl2.total_pages == 2
+        # LIFO: p2 was last leaf → comes out first.
+        assert fl2.allocate() == p2
+        # Now trunk p3 has no leaves → trunk itself is returned.
+        assert fl2.allocate() == p3
+        assert fl2.total_pages == 0
+        pager2.close()
+
+
+class TestFreelistRollback:
+    """Pager.rollback() reverts freelist mutations."""
+
+    def test_rollback_reverts_free(self, tmp_path):
+        pager, _ = _make_db(tmp_path)
+        fl = Freelist(pager)
+        pgno = pager.allocate()
+        fl.free(pgno)
+        assert fl.total_pages == 1
+        pager.rollback()
+        # After rollback page 1 reverts → total should be 0.
+        assert fl.total_pages == 0
+
+    def test_rollback_reverts_allocate(self, tmp_path):
+        pager, _ = _make_db(tmp_path)
+        fl = Freelist(pager)
+        # Seed the freelist.
+        pgno = pager.allocate()
+        fl.free(pgno)
+        pager.commit()  # commit the free so it survives.
+
+        # Now allocate in a new txn and roll back.
+        fl.allocate()
+        assert fl.total_pages == 0  # page was popped
+        pager.rollback()
+        # After rollback the freelist is back to 1.
+        assert fl.total_pages == 1
+
+
+class TestFreelistValidation:
+    """freelist.free() rejects invalid page numbers."""
+
+    def test_free_page_one_raises(self, tmp_path):
+        pager, _ = _make_db(tmp_path)
+        fl = Freelist(pager)
+        with pytest.raises(ValueError, match="page 1"):
+            fl.free(1)
+
+    def test_free_page_zero_raises(self, tmp_path):
+        pager, _ = _make_db(tmp_path)
+        fl = Freelist(pager)
+        with pytest.raises(ValueError, match="pgno must be >= 1"):
+            fl.free(0)
+
+    def test_free_beyond_size_raises(self, tmp_path):
+        pager, _ = _make_db(tmp_path)
+        fl = Freelist(pager)
+        with pytest.raises(ValueError, match="beyond the current database size"):
+            fl.free(9999)
+
+
+# ---------------------------------------------------------------------------
+# Trunk page structure tests
+# ---------------------------------------------------------------------------
+
+
+class TestTrunkPageStructure:
+    """Inspect the raw bytes of trunk pages after free() calls."""
+
+    def test_first_free_creates_trunk_with_zero_count(self, tmp_path):
+        """The first freed page becomes a trunk with count=0, next=0."""
+        pager, _ = _make_db(tmp_path)
+        fl = Freelist(pager)
+        pgno = pager.allocate()  # page 2
+        fl.free(pgno)
+        trunk_data = pager.read(pgno)
+        (nxt,) = struct.unpack_from(">I", trunk_data, _TRUNK_NEXT_OFFSET)
+        (cnt,) = struct.unpack_from(">I", trunk_data, _TRUNK_COUNT_OFFSET)
+        assert nxt == 0
+        assert cnt == 0
+
+    def test_second_free_adds_leaf_to_trunk(self, tmp_path):
+        """Second freed page is stored as a leaf in the first trunk."""
+        pager, _ = _make_db(tmp_path)
+        fl = Freelist(pager)
+        p2 = pager.allocate()  # 2 → will become trunk
+        p3 = pager.allocate()  # 3 → will become leaf
+        fl.free(p2)
+        fl.free(p3)
+        trunk_data = pager.read(p2)
+        (cnt,) = struct.unpack_from(">I", trunk_data, _TRUNK_COUNT_OFFSET)
+        (leaf,) = struct.unpack_from(">I", trunk_data, _TRUNK_LEAVES_OFFSET)
+        assert cnt == 1
+        assert leaf == p3
+
+    def test_allocate_leaf_clears_trunk_count(self, tmp_path):
+        """After popping the sole leaf, the trunk count drops to 0."""
+        pager, _ = _make_db(tmp_path)
+        fl = Freelist(pager)
+        p2 = pager.allocate()  # trunk
+        p3 = pager.allocate()  # leaf
+        fl.free(p2)
+        fl.free(p3)
+        fl.allocate()  # pops p3
+        trunk_data = pager.read(p2)
+        (cnt,) = struct.unpack_from(">I", trunk_data, _TRUNK_COUNT_OFFSET)
+        assert cnt == 0
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — BTree + Freelist
+# ---------------------------------------------------------------------------
+
+
+_LARGE_PAYLOAD = b"Y" * 4500  # > _MAX_LOCAL (4061), forces overflow
+
+
+class TestBTreeFreelistIntegration:
+    """BTree integrates with Freelist for overflow page reuse."""
+
+    def test_overflow_pages_reused_after_delete(self, tmp_path):
+        """File size does not grow when a deleted record's overflow is reused."""
+        path = str(tmp_path / "tree.db")
+        with Pager.create(path) as pager:
+            pager.allocate()  # page 1 (header)
+            pager.write(1, b"\x00" * pager.page_size)
+            fl = Freelist(pager)
+            tree = BTree.create(pager, freelist=fl)
+            # Insert a large record — this allocates overflow pages.
+            tree.insert(1, record.encode([_LARGE_PAYLOAD]))
+            size_after_insert = pager.size_pages
+            pager.commit()
+
+        with Pager.open(path) as pager:
+            fl = Freelist(pager)
+            tree = BTree.open(pager, 2, freelist=fl)  # root was page 2
+            # Delete frees overflow pages back to the freelist.
+            tree.delete(1)
+            size_after_delete = pager.size_pages
+            # Insert another large record — should reuse the freed overflow pages.
+            tree.insert(2, record.encode([_LARGE_PAYLOAD]))
+            size_after_reinsert = pager.size_pages
+            pager.commit()
+
+        # After reinserting a record of the same size, the file must be no
+        # larger than it was right after the first insert.
+        assert size_after_reinsert <= size_after_insert
+        # And the delete must have populated the freelist (not grown the file).
+        assert size_after_delete == size_after_insert  # file didn't shrink
+
+    def test_freelist_total_increases_on_delete(self, tmp_path):
+        """Freelist total grows by ≥1 after deleting a record with overflow."""
+        path = str(tmp_path / "tree2.db")
+        with Pager.create(path) as pager:
+            pager.allocate()
+            pager.write(1, b"\x00" * pager.page_size)
+            fl = Freelist(pager)
+            tree = BTree.create(pager, freelist=fl)
+            tree.insert(1, record.encode([_LARGE_PAYLOAD]))
+            pager.commit()
+
+        with Pager.open(path) as pager:
+            fl = Freelist(pager)
+            before = fl.total_pages
+            tree = BTree.open(pager, 2, freelist=fl)
+            tree.delete(1)
+            after = fl.total_pages
+            assert after > before
+
+    def test_create_reuses_freelist_page(self, tmp_path):
+        """BTree.create uses a freelist page for its root when available."""
+        pager, _ = _make_db(tmp_path)
+        fl = Freelist(pager)
+        # Allocate and free a page so the freelist has one entry.
+        p2 = pager.allocate()
+        fl.free(p2)
+        assert fl.total_pages == 1
+        # Create a B-tree: root should reuse p2 from the freelist.
+        tree = BTree.create(pager, freelist=fl)
+        assert tree.root_page == p2
+        assert fl.total_pages == 0
+
+    def test_no_freelist_still_works(self, tmp_path):
+        """BTree without freelist continues to work exactly as before."""
+        pager, _ = _make_db(tmp_path)
+        tree = BTree.create(pager)  # no freelist
+        for i in range(1, 101):
+            tree.insert(i, record.encode([i]))
+        assert tree.cell_count() == 100
+        tree.delete(50)
+        assert tree.cell_count() == 99
+
+    def test_persist_with_freelist(self, tmp_path):
+        """Data and freelist both survive commit + reopen."""
+        path = str(tmp_path / "persist.db")
+        with Pager.create(path) as pager:
+            pager.allocate()
+            pager.write(1, b"\x00" * pager.page_size)
+            fl = Freelist(pager)
+            tree = BTree.create(pager, freelist=fl)
+            root = tree.root_page
+            for i in range(1, 51):
+                tree.insert(i, record.encode([f"row{i}"]))
+            pager.commit()
+
+        with Pager.open(path) as pager:
+            fl = Freelist(pager)
+            tree = BTree.open(pager, root, freelist=fl)
+            rows = [(rid, record.decode(pl)[0][0]) for rid, pl in tree.scan()]
+            assert rows == [(i, f"row{i}") for i in range(1, 51)]
+
+    def test_multiple_overflow_pages_all_freed(self, tmp_path):
+        """A very large record (multiple overflow pages) frees all of them."""
+        huge_payload = b"Z" * 20_000  # ~5 overflow pages
+        path = str(tmp_path / "huge.db")
+        with Pager.create(path) as pager:
+            pager.allocate()
+            pager.write(1, b"\x00" * pager.page_size)
+            fl = Freelist(pager)
+            tree = BTree.create(pager, freelist=fl)
+            tree.insert(1, record.encode([huge_payload]))
+            size_after_insert = pager.size_pages
+            pager.commit()
+
+        with Pager.open(path) as pager:
+            fl = Freelist(pager)
+            tree = BTree.open(pager, 2, freelist=fl)
+            tree.delete(1)
+            # The freelist now has all the overflow pages.
+            freed_count = fl.total_pages
+            assert freed_count >= 4  # at least 4 overflow pages for 20 000 bytes
+
+            # Reinserting the same payload reuses all of them.
+            tree.insert(2, record.encode([huge_payload]))
+            assert pager.size_pages <= size_after_insert
+
+    def test_update_with_overflow_frees_old_pages(self, tmp_path):
+        """update() frees the old overflow pages via freelist."""
+        path = str(tmp_path / "upd.db")
+        with Pager.create(path) as pager:
+            pager.allocate()
+            pager.write(1, b"\x00" * pager.page_size)
+            fl = Freelist(pager)
+            tree = BTree.create(pager, freelist=fl)
+            tree.insert(1, record.encode([_LARGE_PAYLOAD]))
+            size_after_insert = pager.size_pages
+            pager.commit()
+
+        with Pager.open(path) as pager:
+            fl = Freelist(pager)
+            tree = BTree.open(pager, 2, freelist=fl)
+            # Update with the same large payload — old overflow freed, new reused.
+            tree.update(1, record.encode([_LARGE_PAYLOAD]))
+            assert pager.size_pages <= size_after_insert
+            # Verify data reads back correctly.
+            payload, _ = record.decode(tree.find(1))
+            assert payload[0] == _LARGE_PAYLOAD
+            pager.commit()
+
+
+class TestBTreeFreelistNoOverflow:
+    """Ensure freelist integration doesn't break small-record operations."""
+
+    def test_small_records_no_freelist_interaction(self, tmp_path):
+        """Small records (no overflow) don't touch the freelist."""
+        pager, _ = _make_db(tmp_path)
+        fl = Freelist(pager)
+        tree = BTree.create(pager, freelist=fl)
+        before = fl.total_pages
+        for i in range(1, 200):
+            tree.insert(i, record.encode([i, f"name{i}"]))
+        for i in range(1, 100):
+            tree.delete(i)
+        after = fl.total_pages
+        # No overflow → freelist should be unchanged.
+        assert after == before
+
+    def test_scan_correct_after_freelist_operations(self, tmp_path):
+        """scan() returns correct rows after mixed overflow free/reuse."""
+        path = str(tmp_path / "mixed.db")
+        with Pager.create(path) as pager:
+            pager.allocate()
+            pager.write(1, b"\x00" * pager.page_size)
+            fl = Freelist(pager)
+            tree = BTree.create(pager, freelist=fl)
+            root = tree.root_page
+            # Insert a mix of large and small records.
+            tree.insert(1, record.encode([_LARGE_PAYLOAD]))
+            tree.insert(2, record.encode(["small"]))
+            tree.insert(3, record.encode([_LARGE_PAYLOAD]))
+            pager.commit()
+
+        with Pager.open(path) as pager:
+            fl = Freelist(pager)
+            tree = BTree.open(pager, root, freelist=fl)
+            # Delete the two large records (frees overflow pages).
+            tree.delete(1)
+            tree.delete(3)
+            # Insert a new large record (reuses overflow pages).
+            tree.insert(4, record.encode([_LARGE_PAYLOAD]))
+            rows = list(tree.scan())
+            assert len(rows) == 2  # rowids 2 and 4
+            assert rows[0][0] == 2
+            assert rows[1][0] == 4
+            payload4, _ = record.decode(rows[1][1])
+            assert payload4[0] == _LARGE_PAYLOAD
+            pager.commit()


### PR DESCRIPTION
## Summary

- Adds `storage_sqlite.freelist.Freelist` — a full implementation of SQLite's trunk/leaf freelist format, enabling deleted overflow pages to be reused rather than orphaned.
- Integrates freelist into `BTree` via an optional `freelist=` parameter — all internal page allocations route through `_allocate_page()` and all page releases route through `_free_page()`.
- Fixes two latent `Pager` bugs: stale LRU cache after `commit()` and stale cache after `rollback()`.

## What's new

### `freelist.py` — new module

**`Freelist(pager)`** reads/writes the two header fields at offsets 32–39 of page 1:
- `free(pgno)` — appends as a leaf to the current trunk if room remains; promotes `pgno` to a new trunk when the trunk is full (capacity: 1 022 leaf entries per 4 096-byte page).
- `allocate()` — pops LIFO from the trunk's leaf array (matching SQLite's allocation order), zero-fills the returned page; falls through to `Pager.allocate()` when the freelist is empty.
- `total_pages` property — reads the count from the page-1 header.
- `TRUNK_CAPACITY = 1022` — exported constant.

### `BTree` changes

- New optional `freelist: Freelist | None = None` kwarg on `__init__`, `create`, and `open`.
- `_allocate_page()` — routes to `freelist.allocate()` or `pager.allocate()`.
- `_free_page(pgno)` — routes to `freelist.free(pgno)` or zeroes the page in place.
- `_free_overflow()` updated to call `_free_page()`, enabling overflow-page reuse on delete/update.

### `Pager` bug fixes

- **`commit()` cache coherency**: after commit the LRU cache previously held stale pre-commit values for pages that were read-then-dirtied in the same session. Fix: promote every dirty page into the cache before clearing the dirty table.
- **`rollback()` cache consistency**: dirty pages are now evicted from the cache before clearing, so reads after rollback fetch the correct committed state from the main file.

## Test plan

- [x] `TestFreelistEmpty` — allocate with no freelist falls through to `Pager.allocate()`
- [x] `TestFreelistSinglePage` — free one page, allocate it back (LIFO, zeroed)
- [x] `TestFreelistMultiplePages` — LIFO order, all pages recoverable
- [x] `TestFreelistTrunkPromotion` — freeing TRUNK_CAPACITY + 2 pages creates two trunks
- [x] `TestFreelistHeaderPreservation` — bytes outside offsets 32–39 of page 1 untouched
- [x] `TestFreelistPersistence` — state survives commit + reopen
- [x] `TestFreelistRollback` — `Pager.rollback()` reverts freelist mutations
- [x] `TestFreelistValidation` — invalid page numbers raise `ValueError`
- [x] `TestTrunkPageStructure` — raw bytes of trunk pages match spec
- [x] `TestBTreeFreelistIntegration` — overflow pages reused after delete, file size non-growing
- [x] `TestBTreeFreelistNoOverflow` — small records don't touch freelist; scan correct after mixed ops
- [x] 318 tests total, 97.55% coverage, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)