### PR TITLE
feat(state-machine): add canonical JSON markup serializer

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -331,4 +331,5 @@ members = [
     "udp-client",
     "state-machine-markup-serializer",
     "state-machine-markup-deserializer",
+    "state-machine-markup-json-serializer",
 ]

--- a/code/packages/rust/state-machine-markup-json-serializer/BUILD
+++ b/code/packages/rust/state-machine-markup-json-serializer/BUILD
@@ -1,0 +1,1 @@
+cargo test -p state-machine-markup-json-serializer -- --nocapture

--- a/code/packages/rust/state-machine-markup-json-serializer/CHANGELOG.md
+++ b/code/packages/rust/state-machine-markup-json-serializer/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-20
+
+### Added
+
+- Added the initial canonical `.states.json` serializer package.
+- Added deterministic JSON output for typed `StateMachineDefinition` values.
+- Added golden coverage for DFA, NFA, PDA, epsilon, multi-target,
+  stack-effect, and JSON string escaping behavior.

--- a/code/packages/rust/state-machine-markup-json-serializer/Cargo.toml
+++ b/code/packages/rust/state-machine-markup-json-serializer/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "state-machine-markup-json-serializer"
+version = "0.1.0"
+edition = "2021"
+description = "Canonical JSON serialization for typed state-machine definitions"
+
+[dependencies]
+state-machine = { path = "../state-machine" }

--- a/code/packages/rust/state-machine-markup-json-serializer/README.md
+++ b/code/packages/rust/state-machine-markup-json-serializer/README.md
@@ -1,0 +1,49 @@
+# state-machine-markup-json-serializer
+
+Canonical JSON serialization for typed state-machine definitions.
+
+## Where It Fits
+
+The core `state-machine` crate exposes executable automata and
+`StateMachineDefinition` values. This crate is the format layer that turns those
+definitions into deterministic `.states.json` text for build tooling, source
+compiler snapshots, and cross-language package tests.
+
+This package intentionally only writes JSON. Reading JSON is a separate
+deserializer concern because parsed files are an untrusted boundary and need
+their own size limits, validation, and diagnostics.
+
+## Usage
+
+```rust
+use std::collections::{HashMap, HashSet};
+use state_machine::DFA;
+use state_machine_markup_json_serializer::StateMachineJsonSerializer;
+
+let turnstile = DFA::new(
+    HashSet::from(["locked".into(), "unlocked".into()]),
+    HashSet::from(["coin".into(), "push".into()]),
+    HashMap::from([
+        (("locked".into(), "coin".into()), "unlocked".into()),
+        (("locked".into(), "push".into()), "locked".into()),
+        (("unlocked".into(), "coin".into()), "unlocked".into()),
+        (("unlocked".into(), "push".into()), "locked".into()),
+    ]),
+    "locked".into(),
+    HashSet::from(["unlocked".into()]),
+).unwrap();
+
+let json = turnstile.to_definition("turnstile").to_states_json();
+assert!(json.contains("\"kind\": \"dfa\""));
+```
+
+## Dependencies
+
+- state-machine
+
+## Development
+
+```bash
+# Run tests
+bash BUILD
+```

--- a/code/packages/rust/state-machine-markup-json-serializer/src/lib.rs
+++ b/code/packages/rust/state-machine-markup-json-serializer/src/lib.rs
@@ -9,7 +9,7 @@
 //! format-agnostic runtime boundary and leaves JSON parsing to a separate,
 //! defensive deserializer package.
 
-use state_machine::{StateMachineDefinition, TransitionDefinition};
+use state_machine::StateMachineDefinition;
 
 /// The current State Machine Markup document version.
 pub const STATE_MACHINE_MARKUP_FORMAT: &str = "state-machine/v1";
@@ -106,8 +106,27 @@ fn json_state_array(definition: &StateMachineDefinition) -> String {
 }
 
 fn json_transition_array(definition: &StateMachineDefinition) -> String {
-    let mut transitions = definition.transitions.clone();
-    transitions.sort_by(compare_transitions);
+    let mut transitions: Vec<JsonTransition> = definition
+        .transitions
+        .iter()
+        .map(JsonTransition::from_definition)
+        .collect();
+    transitions.sort_by(|left, right| {
+        (
+            &left.from,
+            &left.on_sort,
+            &left.to,
+            &left.stack_pop,
+            &left.stack_push,
+        )
+            .cmp(&(
+                &right.from,
+                &right.on_sort,
+                &right.to,
+                &right.stack_pop,
+                &right.stack_push,
+            ))
+    });
 
     if transitions.is_empty() {
         return "[]".to_string();
@@ -118,17 +137,11 @@ fn json_transition_array(definition: &StateMachineDefinition) -> String {
     for (index, transition) in transitions.iter().enumerate() {
         let mut fields = Vec::new();
         fields.push(json_property("from", json_string(&transition.from)));
-        fields.push(json_property(
-            "on",
-            json_string(transition.on.as_deref().unwrap_or("epsilon")),
-        ));
+        fields.push(json_property("on", json_string(&transition.on)));
         if transition.to.len() == 1 {
             fields.push(json_property("to", json_string(&transition.to[0])));
         } else {
-            fields.push(json_property(
-                "to",
-                json_array(&sorted_strings(&transition.to)),
-            ));
+            fields.push(json_property("to", json_array(&transition.to)));
         }
         if let Some(stack_pop) = &transition.stack_pop {
             fields.push(json_property("stack_pop", json_string(stack_pop)));
@@ -150,24 +163,34 @@ fn json_transition_array(definition: &StateMachineDefinition) -> String {
     lines.join("\n")
 }
 
-fn compare_transitions(
-    left: &TransitionDefinition,
-    right: &TransitionDefinition,
-) -> std::cmp::Ordering {
-    (
-        &left.from,
-        left.on.as_deref().unwrap_or(""),
-        sorted_strings(&left.to),
-        &left.stack_pop,
-        &left.stack_push,
-    )
-        .cmp(&(
-            &right.from,
-            right.on.as_deref().unwrap_or(""),
-            sorted_strings(&right.to),
-            &right.stack_pop,
-            &right.stack_push,
-        ))
+struct JsonTransition {
+    from: String,
+    on: String,
+    on_sort: String,
+    to: Vec<String>,
+    stack_pop: Option<String>,
+    stack_push: Vec<String>,
+}
+
+impl JsonTransition {
+    fn from_definition(transition: &state_machine::TransitionDefinition) -> Self {
+        let mut to = transition.to.clone();
+        if to.len() > 1 {
+            to.sort();
+        }
+
+        Self {
+            from: transition.from.clone(),
+            on: transition
+                .on
+                .clone()
+                .unwrap_or_else(|| "epsilon".to_string()),
+            on_sort: transition.on.clone().unwrap_or_default(),
+            to,
+            stack_pop: transition.stack_pop.clone(),
+            stack_push: transition.stack_push.clone(),
+        }
+    }
 }
 
 fn sorted_strings(values: &[String]) -> Vec<String> {

--- a/code/packages/rust/state-machine-markup-json-serializer/src/lib.rs
+++ b/code/packages/rust/state-machine-markup-json-serializer/src/lib.rs
@@ -1,0 +1,193 @@
+//! # state-machine-markup-json-serializer
+//!
+//! Canonical JSON serialization for typed state-machine definitions.
+//!
+//! The core `state-machine` crate owns executable automata and the neutral
+//! `StateMachineDefinition` model. This crate owns one narrow write concern:
+//! turning that typed model into deterministic `.states.json` text for build
+//! tools and source compiler snapshots. Keeping the writer here preserves the
+//! format-agnostic runtime boundary and leaves JSON parsing to a separate,
+//! defensive deserializer package.
+
+use state_machine::{StateMachineDefinition, TransitionDefinition};
+
+/// The current State Machine Markup document version.
+pub const STATE_MACHINE_MARKUP_FORMAT: &str = "state-machine/v1";
+
+/// Convenience extension trait for serializing typed definitions.
+pub trait StateMachineJsonSerializer {
+    /// Render this definition as deterministic `.states.json` text.
+    fn to_states_json(&self) -> String;
+}
+
+impl StateMachineJsonSerializer for StateMachineDefinition {
+    fn to_states_json(&self) -> String {
+        to_states_json(self)
+    }
+}
+
+/// Render a typed state-machine definition as canonical State Machine Markup
+/// JSON. The writer only emits trusted typed data; reading JSON is deliberately
+/// a separate package because that path must enforce input limits and perform
+/// validation before constructing a definition.
+pub fn to_states_json(definition: &StateMachineDefinition) -> String {
+    let mut fields = Vec::new();
+    fields.push(json_property(
+        "format",
+        json_string(STATE_MACHINE_MARKUP_FORMAT),
+    ));
+    fields.push(json_property("name", json_string(&definition.name)));
+    fields.push(json_property("kind", json_string(definition.kind.as_str())));
+    if let Some(initial) = &definition.initial {
+        fields.push(json_property("initial", json_string(initial)));
+    }
+    if !definition.alphabet.is_empty() {
+        fields.push(json_property("alphabet", json_array(&definition.alphabet)));
+    }
+    if !definition.stack_alphabet.is_empty() {
+        fields.push(json_property(
+            "stack_alphabet",
+            json_array(&definition.stack_alphabet),
+        ));
+    }
+    if let Some(initial_stack) = &definition.initial_stack {
+        fields.push(json_property("initial_stack", json_string(initial_stack)));
+    }
+    fields.push(json_property("states", json_state_array(definition)));
+    fields.push(json_property(
+        "transitions",
+        json_transition_array(definition),
+    ));
+
+    let mut lines = Vec::new();
+    lines.push("{".to_string());
+    for (index, field) in fields.iter().enumerate() {
+        let comma = if index + 1 == fields.len() { "" } else { "," };
+        lines.push(format!("  {field}{comma}"));
+    }
+    lines.push("}".to_string());
+    lines.push(String::new());
+    lines.join("\n")
+}
+
+fn json_state_array(definition: &StateMachineDefinition) -> String {
+    let mut states = definition.states.clone();
+    states.sort_by(|a, b| a.id.cmp(&b.id));
+
+    if states.is_empty() {
+        return "[]".to_string();
+    }
+
+    let mut lines = Vec::new();
+    lines.push("[".to_string());
+    for (index, state) in states.iter().enumerate() {
+        let mut fields = Vec::new();
+        fields.push(json_property("id", json_string(&state.id)));
+        if state.initial {
+            fields.push(json_property("initial", "true".to_string()));
+        }
+        if state.accepting {
+            fields.push(json_property("accepting", "true".to_string()));
+        }
+        if state.final_state {
+            fields.push(json_property("final", "true".to_string()));
+        }
+        if state.external_entry {
+            fields.push(json_property("external_entry", "true".to_string()));
+        }
+        let comma = if index + 1 == states.len() { "" } else { "," };
+        lines.push(format!("    {{{}}}{comma}", fields.join(", ")));
+    }
+    lines.push("  ]".to_string());
+    lines.join("\n")
+}
+
+fn json_transition_array(definition: &StateMachineDefinition) -> String {
+    let mut transitions = definition.transitions.clone();
+    transitions.sort_by(compare_transitions);
+
+    if transitions.is_empty() {
+        return "[]".to_string();
+    }
+
+    let mut lines = Vec::new();
+    lines.push("[".to_string());
+    for (index, transition) in transitions.iter().enumerate() {
+        let mut fields = Vec::new();
+        fields.push(json_property("from", json_string(&transition.from)));
+        fields.push(json_property(
+            "on",
+            json_string(transition.on.as_deref().unwrap_or("epsilon")),
+        ));
+        if transition.to.len() == 1 {
+            fields.push(json_property("to", json_string(&transition.to[0])));
+        } else {
+            fields.push(json_property("to", json_array(&transition.to)));
+        }
+        if let Some(stack_pop) = &transition.stack_pop {
+            fields.push(json_property("stack_pop", json_string(stack_pop)));
+        }
+        if !transition.stack_push.is_empty() || transition.stack_pop.is_some() {
+            fields.push(json_property(
+                "stack_push",
+                json_array(&transition.stack_push),
+            ));
+        }
+        let comma = if index + 1 == transitions.len() {
+            ""
+        } else {
+            ","
+        };
+        lines.push(format!("    {{{}}}{comma}", fields.join(", ")));
+    }
+    lines.push("  ]".to_string());
+    lines.join("\n")
+}
+
+fn compare_transitions(
+    left: &TransitionDefinition,
+    right: &TransitionDefinition,
+) -> std::cmp::Ordering {
+    (
+        &left.from,
+        left.on.as_deref().unwrap_or(""),
+        &left.to,
+        &left.stack_pop,
+        &left.stack_push,
+    )
+        .cmp(&(
+            &right.from,
+            right.on.as_deref().unwrap_or(""),
+            &right.to,
+            &right.stack_pop,
+            &right.stack_push,
+        ))
+}
+
+fn json_property(name: &str, value: String) -> String {
+    format!("{}: {value}", json_string(name))
+}
+
+fn json_array(values: &[String]) -> String {
+    let parts: Vec<String> = values.iter().map(|value| json_string(value)).collect();
+    format!("[{}]", parts.join(", "))
+}
+
+fn json_string(value: &str) -> String {
+    let mut out = String::from("\"");
+    for ch in value.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\u{08}' => out.push_str("\\b"),
+            '\u{0C}' => out.push_str("\\f"),
+            ch if ch.is_control() => out.push_str(&format!("\\u{:04X}", ch as u32)),
+            ch => out.push(ch),
+        }
+    }
+    out.push('"');
+    out
+}

--- a/code/packages/rust/state-machine-markup-json-serializer/src/lib.rs
+++ b/code/packages/rust/state-machine-markup-json-serializer/src/lib.rs
@@ -137,7 +137,7 @@ fn json_transition_array(definition: &StateMachineDefinition) -> String {
     for (index, transition) in transitions.iter().enumerate() {
         let mut fields = Vec::new();
         fields.push(json_property("from", json_string(&transition.from)));
-        fields.push(json_property("on", json_string(&transition.on)));
+        fields.push(json_property("on", json_event(&transition.on)));
         if transition.to.len() == 1 {
             fields.push(json_property("to", json_string(&transition.to[0])));
         } else {
@@ -165,7 +165,7 @@ fn json_transition_array(definition: &StateMachineDefinition) -> String {
 
 struct JsonTransition {
     from: String,
-    on: String,
+    on: Option<String>,
     on_sort: String,
     to: Vec<String>,
     stack_pop: Option<String>,
@@ -181,15 +181,19 @@ impl JsonTransition {
 
         Self {
             from: transition.from.clone(),
-            on: transition
-                .on
-                .clone()
-                .unwrap_or_else(|| "epsilon".to_string()),
+            on: transition.on.clone(),
             on_sort: transition.on.clone().unwrap_or_default(),
             to,
             stack_pop: transition.stack_pop.clone(),
             stack_push: transition.stack_push.clone(),
         }
+    }
+}
+
+fn json_event(event: &Option<String>) -> String {
+    match event {
+        Some(event) => json_string(event),
+        None => "null".to_string(),
     }
 }
 

--- a/code/packages/rust/state-machine-markup-json-serializer/src/lib.rs
+++ b/code/packages/rust/state-machine-markup-json-serializer/src/lib.rs
@@ -42,12 +42,15 @@ pub fn to_states_json(definition: &StateMachineDefinition) -> String {
         fields.push(json_property("initial", json_string(initial)));
     }
     if !definition.alphabet.is_empty() {
-        fields.push(json_property("alphabet", json_array(&definition.alphabet)));
+        fields.push(json_property(
+            "alphabet",
+            json_array(&sorted_strings(&definition.alphabet)),
+        ));
     }
     if !definition.stack_alphabet.is_empty() {
         fields.push(json_property(
             "stack_alphabet",
-            json_array(&definition.stack_alphabet),
+            json_array(&sorted_strings(&definition.stack_alphabet)),
         ));
     }
     if let Some(initial_stack) = &definition.initial_stack {
@@ -122,7 +125,10 @@ fn json_transition_array(definition: &StateMachineDefinition) -> String {
         if transition.to.len() == 1 {
             fields.push(json_property("to", json_string(&transition.to[0])));
         } else {
-            fields.push(json_property("to", json_array(&transition.to)));
+            fields.push(json_property(
+                "to",
+                json_array(&sorted_strings(&transition.to)),
+            ));
         }
         if let Some(stack_pop) = &transition.stack_pop {
             fields.push(json_property("stack_pop", json_string(stack_pop)));
@@ -151,17 +157,23 @@ fn compare_transitions(
     (
         &left.from,
         left.on.as_deref().unwrap_or(""),
-        &left.to,
+        sorted_strings(&left.to),
         &left.stack_pop,
         &left.stack_push,
     )
         .cmp(&(
             &right.from,
             right.on.as_deref().unwrap_or(""),
-            &right.to,
+            sorted_strings(&right.to),
             &right.stack_pop,
             &right.stack_push,
         ))
+}
+
+fn sorted_strings(values: &[String]) -> Vec<String> {
+    let mut sorted = values.to_vec();
+    sorted.sort();
+    sorted
 }
 
 fn json_property(name: &str, value: String) -> String {

--- a/code/packages/rust/state-machine-markup-json-serializer/tests/json_test.rs
+++ b/code/packages/rust/state-machine-markup-json-serializer/tests/json_test.rs
@@ -1,0 +1,205 @@
+use std::collections::{HashMap, HashSet};
+
+use state_machine::{
+    MachineKind, PDATransition, PushdownAutomaton, StateDefinition, StateMachineDefinition,
+    TransitionDefinition, DFA, EPSILON, NFA,
+};
+use state_machine_markup_json_serializer::StateMachineJsonSerializer;
+
+fn set(values: &[&str]) -> HashSet<String> {
+    values.iter().map(|value| value.to_string()).collect()
+}
+
+#[test]
+fn dfa_definition_serializes_to_canonical_json() {
+    let dfa = DFA::new(
+        set(&["locked", "unlocked"]),
+        set(&["coin", "push"]),
+        HashMap::from([
+            (
+                ("locked".to_string(), "coin".to_string()),
+                "unlocked".to_string(),
+            ),
+            (
+                ("locked".to_string(), "push".to_string()),
+                "locked".to_string(),
+            ),
+            (
+                ("unlocked".to_string(), "coin".to_string()),
+                "unlocked".to_string(),
+            ),
+            (
+                ("unlocked".to_string(), "push".to_string()),
+                "locked".to_string(),
+            ),
+        ]),
+        "locked".to_string(),
+        set(&["unlocked"]),
+    )
+    .unwrap();
+
+    assert_eq!(
+        dfa.to_definition("turnstile").to_states_json(),
+        r#"{
+  "format": "state-machine/v1",
+  "name": "turnstile",
+  "kind": "dfa",
+  "initial": "locked",
+  "alphabet": ["coin", "push"],
+  "states": [
+    {"id": "locked", "initial": true},
+    {"id": "unlocked", "accepting": true}
+  ],
+  "transitions": [
+    {"from": "locked", "on": "coin", "to": "unlocked"},
+    {"from": "locked", "on": "push", "to": "locked"},
+    {"from": "unlocked", "on": "coin", "to": "unlocked"},
+    {"from": "unlocked", "on": "push", "to": "locked"}
+  ]
+}
+"#
+    );
+}
+
+#[test]
+fn nfa_definition_serializes_multiple_targets_and_epsilon() {
+    let nfa = NFA::new(
+        set(&["q0", "q1", "q2"]),
+        set(&["a", "b"]),
+        HashMap::from([
+            (("q0".to_string(), "a".to_string()), set(&["q0", "q1"])),
+            (("q1".to_string(), "b".to_string()), set(&["q2"])),
+            (("q2".to_string(), EPSILON.to_string()), set(&["q0"])),
+        ]),
+        "q0".to_string(),
+        set(&["q2"]),
+    )
+    .unwrap();
+
+    assert_eq!(
+        nfa.to_definition("contains-ab").to_states_json(),
+        r#"{
+  "format": "state-machine/v1",
+  "name": "contains-ab",
+  "kind": "nfa",
+  "initial": "q0",
+  "alphabet": ["a", "b"],
+  "states": [
+    {"id": "q0", "initial": true},
+    {"id": "q1"},
+    {"id": "q2", "accepting": true}
+  ],
+  "transitions": [
+    {"from": "q0", "on": "a", "to": ["q0", "q1"]},
+    {"from": "q1", "on": "b", "to": "q2"},
+    {"from": "q2", "on": "epsilon", "to": "q0"}
+  ]
+}
+"#
+    );
+}
+
+#[test]
+fn pda_definition_serializes_stack_effects() {
+    let pda = PushdownAutomaton::new(
+        set(&["scan", "accept"]),
+        set(&["(", ")"]),
+        set(&["(", "$"]),
+        vec![
+            PDATransition {
+                source: "scan".to_string(),
+                event: Some("(".to_string()),
+                stack_read: "$".to_string(),
+                target: "scan".to_string(),
+                stack_push: vec!["$".to_string(), "(".to_string()],
+            },
+            PDATransition {
+                source: "scan".to_string(),
+                event: Some(")".to_string()),
+                stack_read: "(".to_string(),
+                target: "scan".to_string(),
+                stack_push: vec![],
+            },
+            PDATransition {
+                source: "scan".to_string(),
+                event: None,
+                stack_read: "$".to_string(),
+                target: "accept".to_string(),
+                stack_push: vec!["$".to_string()],
+            },
+        ],
+        "scan".to_string(),
+        "$".to_string(),
+        set(&["accept"]),
+    )
+    .unwrap();
+
+    assert_eq!(
+        pda.to_definition("balanced-parens").to_states_json(),
+        r#"{
+  "format": "state-machine/v1",
+  "name": "balanced-parens",
+  "kind": "pda",
+  "initial": "scan",
+  "alphabet": ["(", ")"],
+  "stack_alphabet": ["$", "("],
+  "initial_stack": "$",
+  "states": [
+    {"id": "accept", "accepting": true},
+    {"id": "scan", "initial": true}
+  ],
+  "transitions": [
+    {"from": "scan", "on": "epsilon", "to": "accept", "stack_pop": "$", "stack_push": ["$"]},
+    {"from": "scan", "on": "(", "to": "scan", "stack_pop": "$", "stack_push": ["$", "("]},
+    {"from": "scan", "on": ")", "to": "scan", "stack_pop": "(", "stack_push": []}
+  ]
+}
+"#
+    );
+}
+
+#[test]
+fn json_serializer_escapes_strings() {
+    let mut definition = StateMachineDefinition::new("escape\nmachine", MachineKind::Dfa);
+    definition.initial = Some("needs\"quote".to_string());
+    definition.alphabet = vec!["slash\\event".to_string(), "control\u{001F}".to_string()];
+    definition.states = vec![
+        StateDefinition {
+            initial: true,
+            ..StateDefinition::new("needs\"quote")
+        },
+        StateDefinition {
+            accepting: true,
+            ..StateDefinition::new("line\nbreak")
+        },
+    ];
+    definition.transitions = vec![TransitionDefinition::new(
+        "needs\"quote",
+        Some("slash\\event".to_string()),
+        vec!["line\nbreak".to_string()],
+    )];
+
+    let json = definition.to_states_json();
+
+    assert!(json.contains("\"name\": \"escape\\nmachine\""));
+    assert!(json.contains("\"initial\": \"needs\\\"quote\""));
+    assert!(json.contains("\"alphabet\": [\"slash\\\\event\", \"control\\u001F\"]"));
+    assert!(json.contains("\"id\": \"line\\nbreak\""));
+}
+
+#[test]
+fn empty_definition_serializes_required_arrays() {
+    let definition = StateMachineDefinition::new("empty", MachineKind::Modal);
+
+    assert_eq!(
+        definition.to_states_json(),
+        r#"{
+  "format": "state-machine/v1",
+  "name": "empty",
+  "kind": "modal",
+  "states": [],
+  "transitions": []
+}
+"#
+    );
+}

--- a/code/packages/rust/state-machine-markup-json-serializer/tests/json_test.rs
+++ b/code/packages/rust/state-machine-markup-json-serializer/tests/json_test.rs
@@ -188,6 +188,22 @@ fn json_serializer_escapes_strings() {
 }
 
 #[test]
+fn json_serializer_emits_state_flags_and_control_escapes() {
+    let mut definition = StateMachineDefinition::new("flags", MachineKind::Statechart);
+    definition.states = vec![StateDefinition {
+        final_state: true,
+        external_entry: true,
+        ..StateDefinition::new("return\r\t\u{08}\u{0C}point")
+    }];
+
+    let json = definition.to_states_json();
+
+    assert!(json.contains("\"id\": \"return\\r\\t\\b\\fpoint\""));
+    assert!(json.contains("\"final\": true"));
+    assert!(json.contains("\"external_entry\": true"));
+}
+
+#[test]
 fn empty_definition_serializes_required_arrays() {
     let definition = StateMachineDefinition::new("empty", MachineKind::Modal);
 

--- a/code/packages/rust/state-machine-markup-json-serializer/tests/json_test.rs
+++ b/code/packages/rust/state-machine-markup-json-serializer/tests/json_test.rs
@@ -92,7 +92,7 @@ fn nfa_definition_serializes_multiple_targets_and_epsilon() {
   "transitions": [
     {"from": "q0", "on": "a", "to": ["q0", "q1"]},
     {"from": "q1", "on": "b", "to": "q2"},
-    {"from": "q2", "on": "epsilon", "to": "q0"}
+    {"from": "q2", "on": null, "to": "q0"}
   ]
 }
 "#
@@ -149,7 +149,7 @@ fn pda_definition_serializes_stack_effects() {
     {"id": "scan", "initial": true}
   ],
   "transitions": [
-    {"from": "scan", "on": "epsilon", "to": "accept", "stack_pop": "$", "stack_push": ["$"]},
+    {"from": "scan", "on": null, "to": "accept", "stack_pop": "$", "stack_push": ["$"]},
     {"from": "scan", "on": "(", "to": "scan", "stack_pop": "$", "stack_push": ["$", "("]},
     {"from": "scan", "on": ")", "to": "scan", "stack_pop": "(", "stack_push": []}
   ]
@@ -215,6 +215,27 @@ fn json_serializer_canonicalizes_set_like_arrays() {
     assert!(json.contains("\"stack_alphabet\": [\"base\", \"top\"]"));
     assert!(json.contains("\"to\": [\"q1\", \"q2\"]"));
     assert!(json.contains("\"stack_push\": [\"top\", \"base\"]"));
+}
+
+#[test]
+fn json_serializer_distinguishes_literal_epsilon_events_from_epsilon_moves() {
+    let mut definition = StateMachineDefinition::new("literal-epsilon", MachineKind::Dfa);
+    definition.initial = Some("q0".to_string());
+    definition.alphabet = vec!["epsilon".to_string()];
+    definition.states = vec![StateDefinition {
+        initial: true,
+        accepting: true,
+        ..StateDefinition::new("q0")
+    }];
+    definition.transitions = vec![
+        TransitionDefinition::new("q0", None, vec!["q0".to_string()]),
+        TransitionDefinition::new("q0", Some("epsilon".to_string()), vec!["q0".to_string()]),
+    ];
+
+    let json = definition.to_states_json();
+
+    assert!(json.contains("\"on\": null"));
+    assert!(json.contains("\"on\": \"epsilon\""));
 }
 
 #[test]

--- a/code/packages/rust/state-machine-markup-json-serializer/tests/json_test.rs
+++ b/code/packages/rust/state-machine-markup-json-serializer/tests/json_test.rs
@@ -183,8 +183,38 @@ fn json_serializer_escapes_strings() {
 
     assert!(json.contains("\"name\": \"escape\\nmachine\""));
     assert!(json.contains("\"initial\": \"needs\\\"quote\""));
-    assert!(json.contains("\"alphabet\": [\"slash\\\\event\", \"control\\u001F\"]"));
+    assert!(json.contains("\"alphabet\": [\"control\\u001F\", \"slash\\\\event\"]"));
     assert!(json.contains("\"id\": \"line\\nbreak\""));
+}
+
+#[test]
+fn json_serializer_canonicalizes_set_like_arrays() {
+    let mut definition = StateMachineDefinition::new("canonical", MachineKind::Nfa);
+    definition.initial = Some("q0".to_string());
+    definition.alphabet = vec!["z".to_string(), "a".to_string()];
+    definition.stack_alphabet = vec!["top".to_string(), "base".to_string()];
+    definition.states = vec![
+        StateDefinition {
+            initial: true,
+            ..StateDefinition::new("q0")
+        },
+        StateDefinition::new("q1"),
+        StateDefinition::new("q2"),
+    ];
+    definition.transitions = vec![TransitionDefinition {
+        from: "q0".to_string(),
+        on: Some("a".to_string()),
+        to: vec!["q2".to_string(), "q1".to_string()],
+        stack_pop: Some("base".to_string()),
+        stack_push: vec!["top".to_string(), "base".to_string()],
+    }];
+
+    let json = definition.to_states_json();
+
+    assert!(json.contains("\"alphabet\": [\"a\", \"z\"]"));
+    assert!(json.contains("\"stack_alphabet\": [\"base\", \"top\"]"));
+    assert!(json.contains("\"to\": [\"q1\", \"q2\"]"));
+    assert!(json.contains("\"stack_push\": [\"top\", \"base\"]"));
 }
 
 #[test]

--- a/code/specs/F07-state-machine-markup-language.md
+++ b/code/specs/F07-state-machine-markup-language.md
@@ -14,10 +14,12 @@ state-machine definitions. The state-machine ecosystem should be able to:
 - emit visualization formats such as DOT
 - import and export a useful subset of existing standards such as SCXML
 
-The format is called **State Machine Markup v1**. Source files use
+The format is called **State Machine Markup v1**. Hand-authored source files use
 `.states.toml` when the file is meant to be parsed by general TOML tooling, and
 `.states` when we want the shorter educational extension. Both extensions carry
-the same TOML-compatible content.
+the same TOML-compatible content. Build tooling may also emit canonical
+`.states.json` artifacts as normalized machine-readable snapshots of the same
+typed definition model.
 
 This is intentionally not a brand-new syntax. TOML gives us a readable existing
 text format, and `F03-toml-parser.md` already makes TOML a first-class repo
@@ -39,6 +41,7 @@ definition layer:
 state-machine                  -> executable automata + StateMachineDefinition
 state-machine-markup-serializer -> StateMachineDefinition -> .states.toml
 state-machine-markup-deserializer -> .states.toml -> StateMachineDefinition
+state-machine-markup-json-serializer -> StateMachineDefinition -> .states.json
 state-machine-source-compiler  -> StateMachineDefinition -> static source
 ```
 
@@ -354,6 +357,60 @@ on = "close_angle"
 to = "data"
 ```
 
+## JSON Surface Format
+
+JSON is a canonical build artifact, not the preferred human authoring format.
+It exists so tools can snapshot expanded definitions, compare generated
+intermediates, and hand the same typed model to source compilers without keeping
+TOML syntax around.
+
+The JSON surface uses the same root fields, state objects, and transition
+objects as the TOML surface:
+
+```json
+{
+  "format": "state-machine/v1",
+  "name": "turnstile",
+  "kind": "dfa",
+  "initial": "locked",
+  "alphabet": ["coin", "push"],
+  "states": [
+    {"id": "locked", "initial": true},
+    {"id": "unlocked", "accepting": true}
+  ],
+  "transitions": [
+    {"from": "locked", "on": "coin", "to": "unlocked"},
+    {"from": "locked", "on": "push", "to": "locked"},
+    {"from": "unlocked", "on": "coin", "to": "unlocked"},
+    {"from": "unlocked", "on": "push", "to": "locked"}
+  ]
+}
+```
+
+JSON transition `to` follows the same compact rule as TOML: single-target DFA
+and PDA transitions write a string, while multi-target NFA transitions write a
+string array. Epsilon transitions are written as `"on": "epsilon"` at the JSON
+file boundary, matching TOML. The typed in-memory representation still uses
+`None` for epsilon, and import boundaries must continue rejecting empty-string
+event aliases.
+
+The first JSON serializer profile covers the same phase 1 DFA, NFA, and PDA
+fields as the TOML serializer:
+
+- root string fields: `format`, `name`, `kind`, `initial`, `initial_stack`
+- root string arrays: `alphabet`, `stack_alphabet`
+- `states` array entries with `id`, `initial`, `accepting`, `final`, and
+  `external_entry`
+- `transitions` array entries with `from`, `on`, `to`, `stack_pop`, and
+  `stack_push`
+
+The JSON serializer must be deterministic and dependency-light. A hand-written
+writer is acceptable for the phase 1 subset because it only emits strings,
+booleans, arrays, and objects from trusted typed definitions. A future JSON
+deserializer is a separate trust boundary and must apply its own source-size,
+nesting, array-length, and validation limits before constructing a
+`StateMachineDefinition`.
+
 ## Actions And Guards
 
 Actions and guards use a portable call representation:
@@ -440,8 +497,8 @@ Minimum API:
 - core state-machine: `from_definition(definition) -> Machine`
 - TOML serializer: `to_states_toml(definition) -> string`
 - TOML deserializer: `from_states_toml(source) -> StateMachineDefinition`
-- JSON serializer: `to_json(definition) -> string`
-- JSON deserializer: `from_json(source) -> StateMachineDefinition`
+- JSON serializer: `to_states_json(definition) -> string`
+- JSON deserializer: `from_states_json(source) -> StateMachineDefinition`
 - source compiler: `to_source(definition, target_language)`
 - SCXML serializer: `to_scxml(definition) -> string`
 - SCXML deserializer: `from_scxml(source) -> StateMachineDefinition`
@@ -508,6 +565,13 @@ Serializers must:
 - write one `[[transitions]]` table per transition
 - preserve unknown `metadata` keys under a namespaced table such as
   `[metadata.visual]`
+
+For the phase 1 Rust TOML and JSON serializers, the executable machine export
+helpers already sort states, alphabets, and transition sets before constructing
+the typed definition. The serializer packages may defensively sort states and
+transitions by their stable identifiers when no explicit `priority` field
+exists. Once prioritized statecharts and tokenizers land, serializers must
+prefer the explicit priority/order field over lexical sorting.
 
 Serializers must not:
 
@@ -596,13 +660,15 @@ runtime deserialization package.
    validation.
 7. Add executable-machine imports for DFA, NFA, and PDA definitions so
    serializer/deserializer round trips can return to runnable machines.
-8. Add modal round-tripping through definitions once modal definitions can
+8. Add a Rust `state-machine-markup-json-serializer` package for deterministic
+   `.states.json` output.
+9. Add modal round-tripping through definitions once modal definitions can
    represent child-machine references and mode transitions.
-9. Add SCXML core import/export packages for deterministic event machines.
-10. Keep DOT export as visualization-only output.
-11. Add the build-time source compiler from
+10. Add SCXML core import/export packages for deterministic event machines.
+11. Keep DOT export as visualization-only output.
+12. Add the build-time source compiler from
    `F09-state-machine-source-compiler.md`.
-12. Build tokenizer profiles from `F08` on top of this definition model.
+13. Build tokenizer profiles from `F08` on top of this definition model.
 
 ## Test Strategy
 

--- a/code/specs/F07-state-machine-markup-language.md
+++ b/code/specs/F07-state-machine-markup-language.md
@@ -389,10 +389,11 @@ objects as the TOML surface:
 
 JSON transition `to` follows the same compact rule as TOML: single-target DFA
 and PDA transitions write a string, while multi-target NFA transitions write a
-string array. Epsilon transitions are written as `"on": "epsilon"` at the JSON
-file boundary, matching TOML. The typed in-memory representation still uses
-`None` for epsilon, and import boundaries must continue rejecting empty-string
-event aliases.
+string array. Epsilon transitions are written as `"on": null` at the JSON file
+boundary. That differs from TOML's `"epsilon"` spelling on purpose: JSON can
+represent absence directly, so a real event named `"epsilon"` remains distinct
+from the typed in-memory `None` used for epsilon. Import boundaries must
+continue rejecting empty-string event aliases.
 
 The first JSON serializer profile covers the same phase 1 DFA, NFA, and PDA
 fields as the TOML serializer:

--- a/code/specs/F07-state-machine-markup-language.md
+++ b/code/specs/F07-state-machine-markup-language.md
@@ -568,10 +568,14 @@ Serializers must:
 
 For the phase 1 Rust TOML and JSON serializers, the executable machine export
 helpers already sort states, alphabets, and transition sets before constructing
-the typed definition. The serializer packages may defensively sort states and
-transitions by their stable identifiers when no explicit `priority` field
-exists. Once prioritized statecharts and tokenizers land, serializers must
-prefer the explicit priority/order field over lexical sorting.
+the typed definition. The JSON serializer must also defensively sort set-like
+arrays that can be constructed by hand, including `alphabet`, `stack_alphabet`,
+and multi-target NFA `to` arrays. Order-sensitive arrays such as PDA
+`stack_push` must stay in declaration order. Serializer packages may
+defensively sort states and transitions by their stable identifiers when no
+explicit `priority` field exists. Once prioritized statecharts and tokenizers
+land, serializers must prefer the explicit priority/order field over lexical
+sorting.
 
 Serializers must not:
 

--- a/code/specs/F09-state-machine-source-compiler.md
+++ b/code/specs/F09-state-machine-source-compiler.md
@@ -13,7 +13,7 @@ The production path is:
 hand-written machine in code
         -> StateMachineDefinition
         -> optional serializer output: canonical .states.toml / .states.json
-        -> deserializer or direct definition input
+        -> deserializer or direct typed definition input
         -> state-machine source compiler
         -> generated Rust / Go / TypeScript / Python / Ruby / ...
         -> normal package compiler or interpreter
@@ -95,7 +95,10 @@ html-living.tokenizer.expanded.states.json
 ```
 
 They contain no unresolved includes, have deterministic ordering, and are ideal
-for snapshot tests. They are not meant to be loaded by production packages.
+for snapshot tests. They are not meant to be loaded by production packages. The
+canonical JSON writer is its own serializer package so source compiler crates can
+consume typed definitions without depending on TOML writing, TOML parsing, or
+runtime file loading.
 
 ### Generated Source Artifacts
 
@@ -194,7 +197,8 @@ Phase 2 export support:
 
 - modal machines with external child-machine references
 - modal machines with inline child-machine documents
-- JSON writer in a separate serializer package
+- JSON writer in a separate serializer package, exposed as
+  `to_states_json(definition) -> string`
 - TOML/JSON parser in separate deserializer packages for tooling only
 
 Phase 3 export support:


### PR DESCRIPTION
## Summary

- Specify canonical `.states.json` output for State Machine Markup and source-compiler intermediates.
- Add `state-machine-markup-json-serializer` as a separate Rust writer package with README, CHANGELOG, BUILD, workspace membership, and deterministic output.
- Encode JSON epsilon transitions as `null` so literal `"epsilon"` events remain distinct; sort set-like arrays while preserving order-sensitive stack pushes.

## Verification

- `cargo fmt -p state-machine-markup-json-serializer`
- `cargo test -p state-machine-markup-json-serializer -- --nocapture`
- `cargo test -p state-machine -p state-machine-markup-serializer -p state-machine-markup-deserializer -p state-machine-markup-json-serializer -- --nocapture`
- `cargo build -p state-machine-markup-json-serializer`
- `cargo tarpaulin -p state-machine-markup-json-serializer --out Stdout --skip-clean` (`state-machine-markup-json-serializer/src/lib.rs`: 131/131 lines)
- `./build-tool -root /tmp/coding-adventures-json-serializer --diff-base origin/main` (3 affected packages built)
- `cargo build --workspace` attempted; blocked by existing macOS-incompatible `paint-vm-direct2d` `compile_error!` for Windows-only crate
- Security review sub-agent passed after fixes