### PR TITLE
feat(storage-sqlite): phase 7 — SqliteFileBackend (Backend adapter)

### DIFF
--- a/code/packages/python/storage-sqlite/BUILD
+++ b/code/packages/python/storage-sqlite/BUILD
@@ -1,1 +1,1 @@
-uv venv --quiet --clear && uv pip install -e ".[dev]" --quiet && .venv/bin/ruff check src/ tests/ && .venv/bin/python -m pytest tests/
+uv venv --quiet --clear && uv pip install -e ../sql-backend -e ".[dev]" --quiet && .venv/bin/ruff check src/ tests/ && .venv/bin/python -m pytest tests/

--- a/code/packages/python/storage-sqlite/CHANGELOG.md
+++ b/code/packages/python/storage-sqlite/CHANGELOG.md
@@ -1,5 +1,93 @@
 # Changelog
 
+## [0.8.0] - 2026-04-20
+
+### Added
+
+- `storage_sqlite.backend` — phase 7: `SqliteFileBackend`, the
+  `sql_backend.Backend` adapter that wires all lower-level layers (pager,
+  freelist, schema, B-trees) behind the public Backend interface.
+
+  **`SqliteFileBackend(path)`**
+
+  Opens an existing SQLite database file or creates a new one (writing the
+  100-byte database header and an empty `sqlite_schema` leaf on first open).
+  Implements the full `sql_backend.Backend` ABC:
+
+  - **`tables() → list[str]`** — returns table names in insertion order via
+    `Schema.list_tables()`.
+  - **`columns(table) → list[ColumnDef]`** — parses the `CREATE TABLE` SQL
+    stored in `sqlite_schema` and returns column definitions.  Raises
+    `TableNotFound` if the table does not exist.
+  - **`scan(table) → RowIterator`** — opens a `_BTreeCursor` over the
+    table's B-tree.  Rows are yielded in ascending rowid order (insertion
+    order for tables without explicit rowid reuse).  Raises `TableNotFound`.
+  - **`insert(table, row)`** — applies column defaults, enforces `NOT NULL`
+    and `UNIQUE` / `PRIMARY KEY` constraints, chooses the rowid (using the
+    `INTEGER PRIMARY KEY` value when present, otherwise `max + 1`), encodes
+    the row as a SQLite record, and calls `BTree.insert`.  Raises
+    `TableNotFound`, `ColumnNotFound`, `ConstraintViolation`.
+  - **`update(table, cursor, assignments)`** — merges assignments into the
+    current row, re-encodes, and calls `BTree.update` at the cursor's rowid.
+    Enforces `NOT NULL` on the new values.  Raises `ConstraintViolation`,
+    `ColumnNotFound`, `Unsupported` (non-native cursor or no current row).
+  - **`delete(table, cursor)`** — calls `BTree.delete` at the cursor's
+    rowid and clears the cursor's current-row state.  Raises `Unsupported`
+    (non-native cursor or no current row).
+  - **`create_table(table, columns, if_not_exists)`** — serialises the
+    column list to `CREATE TABLE` SQL, inserts the schema row, and allocates
+    a root page.  Raises `TableAlreadyExists` when `if_not_exists=False` and
+    the table already exists; silently returns when `if_not_exists=True`.
+  - **`drop_table(table, if_exists)`** — frees all pages in the table's
+    B-tree, removes the schema row.  Raises `TableNotFound` when
+    `if_exists=False` and the table is missing.
+  - **`begin_transaction() → TransactionHandle`** — records an opaque
+    handle; writes continue to accumulate in the pager's dirty-page table.
+    Raises `Unsupported` if a transaction is already open.
+  - **`commit(handle)`** — fsyncs dirty pages to disk via `pager.commit()`.
+  - **`rollback(handle)`** — discards dirty pages via `pager.rollback()` and
+    reattaches the `Schema` so post-rollback reads see the committed state.
+  - **`close()`** — rolls back any open transaction, then closes the pager.
+  - **Context-manager protocol** (`with SqliteFileBackend(path) as b:`):
+    `__exit__` calls `close()`, so uncommitted writes are rolled back
+    automatically on normal or exceptional exit.
+
+  **`_BTreeCursor`** — internal class implementing both `RowIterator` and
+  `Cursor` protocols.  Wraps a `BTree.scan()` generator; `next()` decodes
+  each record; `current_row()` returns the last decoded row; `close()`
+  stops iteration.  The backend uses the stored `_current_rowid` for
+  positioned `update` and `delete`.
+
+  **SQL helper functions** (module-level, used internally):
+
+  - `_format_literal(value)` — Python value → SQL literal string.
+  - `_columns_to_sql(table, columns)` — `list[ColumnDef]` → `CREATE TABLE`
+    SQL string (parseable by both this module and the real `sqlite3` CLI).
+  - `_tokenize(sql)` — lightweight regex tokeniser (strips comments).
+  - `_parse_literal(tok)` — SQL literal token → Python value.
+  - `_split_column_defs(body)` — comma-split respecting parenthesis depth.
+  - `_parse_one_column(col_sql)` → `ColumnDef | None`.
+  - `_sql_to_columns(sql)` — `CREATE TABLE` SQL → `list[ColumnDef]`.
+  - `_is_ipk(col)` — returns `True` for `INTEGER PRIMARY KEY` columns.
+  - `_encode_row(rowid, row, columns)` — encodes a row as a SQLite record
+    payload, skipping IPK columns.
+  - `_decode_row(rowid, payload, columns)` — decodes a record payload,
+    injecting `rowid` for IPK columns.
+  - `_find_max_rowid(tree)` — full scan to find the current max rowid.
+  - `_choose_rowid(row, columns, tree)` — picks the rowid for a new row.
+  - `_apply_defaults(row, columns)` — fills absent columns from defaults.
+  - `_check_not_null(table, row, columns)` — raises `ConstraintViolation`.
+  - `_check_unique(table, row, columns, tree, ...)` — full-scan uniqueness
+    check; `NULL` values never conflict.
+
+  **`SqliteFileBackend`** and the `_BTreeCursor` class (via `SqliteFileBackend`)
+  are now exported from the package root.
+
+- `pyproject.toml` updated: `dependencies = ["coding-adventures-sql-backend"]`.
+- `BUILD` updated: installs `../sql-backend` before the package itself.
+- Pass all four tiers of `sql_backend.conformance` (required, read-write,
+  DDL, transactions) — 67 new backend tests, 431 total, 96% coverage.
+
 ## [0.7.0] - 2026-04-20
 
 ### Added

--- a/code/packages/python/storage-sqlite/README.md
+++ b/code/packages/python/storage-sqlite/README.md
@@ -28,14 +28,15 @@ mini_sqlite.connect("app.db")
         ├── record   (varint + serial types)      ✓ phase 2
         ├── btree    (leaf + overflow + full recursive splits)  ✓ phases 3 + 4a + 4b
         ├── freelist (trunk/leaf page reuse)       ✓ phase 5
-        └── schema   (sqlite_schema round-trip)   ✓ phase 6
+        ├── schema   (sqlite_schema round-trip)   ✓ phase 6
+        └── backend  (Backend adapter / SqliteFileBackend)     ✓ phase 7
 ```
 
 Nothing above the `Backend` line changes. The full SQL pipeline (lexer →
 parser → planner → optimizer → codegen → VM) runs unmodified against this
 backend.
 
-## What works today (phases 1 + 2 + 3 + 4a + 4b + 5 + 6)
+## What works today (phases 1 + 2 + 3 + 4a + 4b + 5 + 6 + 7)
 
 - **`header` module** — the 100-byte database header at the start of page 1.
   Read and write every field, validate magic string and page size on open.
@@ -90,8 +91,12 @@ backend.
   names in insertion order. `find_table(name)` returns `(rowid, rootpage, sql)`
   or `None`. `get_schema_cookie()` reads the u32 at page-1 offset 40.
 
-What's **not yet** in this package (coming in a later phase):
-The `Backend` adapter that wires the full SQL pipeline into phase 7.
+- **`backend` module** — `SqliteFileBackend` (phase 7).
+  Implements the full `sql_backend.Backend` interface against a real `.db`
+  file.  `tables()`, `columns()`, `scan()`, `insert()`, `update()`,
+  `delete()`, `create_table()`, `drop_table()`, `begin_transaction()`,
+  `commit()`, `rollback()`.  Opens existing files or creates new ones.
+  Passes all four tiers of `sql_backend.conformance`.
 
 ## Installation
 
@@ -99,7 +104,7 @@ The `Backend` adapter that wires the full SQL pipeline into phase 7.
 uv pip install -e .
 ```
 
-## Usage (phases 1 + 2 + 3 + 4a + 4b + 5 + 6)
+## Usage (phases 1 + 2 + 3 + 4a + 4b + 5 + 6 + 7)
 
 ```python
 from storage_sqlite import Header, Pager, record, varint
@@ -198,9 +203,47 @@ with Pager.create("catalog.db") as pager:
     pager.commit()
 ```
 
-This intentionally looks low-level — the `Backend` adapter that makes
-`mini_sqlite.connect("app.db")` work will land in phase 7 once all the
-intermediate layers (records, B-trees, schema) are in place.
+```python
+# --- Backend (phase 7: full sql_backend.Backend adapter) ---
+from sql_backend import ColumnDef
+from storage_sqlite import SqliteFileBackend
+
+# Create and populate a database — fully Backend-compatible.
+with SqliteFileBackend("app.db") as b:
+    b.create_table(
+        "users",
+        [
+            ColumnDef(name="id",    type_name="INTEGER", primary_key=True),
+            ColumnDef(name="name",  type_name="TEXT",    not_null=True),
+            ColumnDef(name="email", type_name="TEXT",    unique=True),
+        ],
+        if_not_exists=True,
+    )
+    b.insert("users", {"id": 1, "name": "Alice", "email": "alice@example.com"})
+    b.insert("users", {"id": 2, "name": "Bob",   "email": "bob@example.com"})
+
+    # Explicit transaction for atomic writes.
+    h = b.begin_transaction()
+    b.insert("users", {"id": 3, "name": "Carol", "email": None})
+    b.commit(h)
+
+# Read it back in a new session — data survived on disk.
+with SqliteFileBackend("app.db") as b:
+    it = b.scan("users")
+    while (row := it.next()) is not None:
+        print(row)          # {'id': 1, 'name': 'Alice', 'email': 'alice@example.com'}
+    it.close()
+
+# Positioned update and delete via _open_cursor().
+with SqliteFileBackend("app.db") as b:
+    cursor = b._open_cursor("users")
+    row = cursor.next()           # first row
+    b.update("users", cursor, {"email": "newalice@example.com"})
+    cursor.close()
+
+    h = b.begin_transaction()
+    b.commit(h)
+```
 
 ## Design notes
 

--- a/code/packages/python/storage-sqlite/pyproject.toml
+++ b/code/packages/python/storage-sqlite/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-storage-sqlite"
-version = "0.7.0"
+version = "0.8.0"
 description = "SQLite byte-compatible file backend for the sql-backend interface."
 requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]
 readme = "README.md"
 keywords = ["sqlite", "storage", "backend", "database", "file-format", "pager", "b-tree", "education"]
-dependencies = []
+dependencies = ["coding-adventures-sql-backend"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",

--- a/code/packages/python/storage-sqlite/src/storage_sqlite/__init__.py
+++ b/code/packages/python/storage-sqlite/src/storage_sqlite/__init__.py
@@ -13,11 +13,12 @@ Phases shipped so far:
 - :mod:`storage_sqlite.freelist` — SQLite trunk/leaf freelist for page reuse.
 - :mod:`storage_sqlite.schema` — sqlite_schema catalog table (CREATE / DROP
   TABLE, schema cookie management).
-
-Everything else (the Backend adapter) lands in a subsequent phase.
+- :mod:`storage_sqlite.backend` — :class:`SqliteFileBackend`, the
+  ``sql_backend.Backend`` adapter that wires all layers together (phase 7).
 """
 
 from storage_sqlite import btree, record, varint
+from storage_sqlite.backend import SqliteFileBackend
 from storage_sqlite.btree import BTree, BTreeError, DuplicateRowidError, PageFullError
 from storage_sqlite.errors import (
     CorruptDatabaseError,
@@ -43,6 +44,7 @@ __all__ = [
     "Pager",
     "Schema",
     "SchemaError",
+    "SqliteFileBackend",
     "StorageError",
     "TRUNK_CAPACITY",
     "Value",

--- a/code/packages/python/storage-sqlite/src/storage_sqlite/backend.py
+++ b/code/packages/python/storage-sqlite/src/storage_sqlite/backend.py
@@ -1,0 +1,924 @@
+"""
+SqliteFileBackend — the Backend adapter for real SQLite files (phase 7).
+
+This module wires all the lower-level layers (pager, record, btree, freelist,
+schema) together behind the :class:`~sql_backend.Backend` interface so that
+``mini_sqlite.connect("foo.db")`` works end-to-end against a real SQLite file.
+
+Architecture
+------------
+
+The class hierarchy is::
+
+    sql_backend.Backend  (abstract interface)
+        └── SqliteFileBackend
+                ├── Pager          (page I/O, rollback journal)
+                ├── Freelist       (page reuse)
+                ├── Schema         (sqlite_schema catalog)
+                └── BTree          (per-table B-trees, opened on demand)
+
+Every DML or DDL operation opens the relevant B-tree fresh via the pager —
+no stale state is cached. The pager's dirty-page table acts as the implicit
+write buffer: changes are invisible to other connections until
+``pager.commit()`` is called.
+
+Row encoding
+------------
+
+SQLite stores rows as **records** (see :mod:`storage_sqlite.record`): a
+header of serial-type varints followed by the value bytes, in column
+declaration order. One special case: a column declared ``INTEGER PRIMARY
+KEY`` is a **rowid alias** — its value IS the B-tree row key and is NOT
+stored inside the record payload. Reading it back, we inject the rowid
+directly into the decoded dict.
+
+Transaction semantics
+---------------------
+
+* ``begin_transaction()`` — record an opaque handle; does not flush or lock.
+  All writes go to the pager's dirty-page table immediately (they are
+  visible to reads within the same connection but not persisted to disk).
+* ``commit(handle)`` — call ``pager.commit()``, which fsyncs the journal,
+  writes all dirty pages to the main file, fsyncs the main file, and
+  removes the journal.
+* ``rollback(handle)`` — call ``pager.rollback()``, which discards all
+  dirty pages and leaves the file in its pre-transaction state.
+
+Operations that happen *without* an explicit ``begin_transaction`` still
+work: writes accumulate in dirty pages and reads see them within the same
+session. They are silently lost on process exit unless eventually committed
+via an explicit transaction.
+
+Column parsing
+--------------
+
+The SQL string stored in ``sqlite_schema`` is the canonical source of truth
+for column definitions. We generate it in :func:`_columns_to_sql` and parse
+it back in :func:`_sql_to_columns`. The format is::
+
+    CREATE TABLE <name> (<col> <type> [PRIMARY KEY] [NOT NULL] [UNIQUE]
+                                      [DEFAULT <literal>], ...)
+
+The parser handles the subset of SQLite column syntax used by this backend
+and by real ``sqlite3`` for the same subset of table definitions (lowercase
+keywords, implicit NOT NULL from PRIMARY KEY, etc.).
+
+v1 limitations
+--------------
+
+* No index support. All scans are full table scans. The B-tree rows are
+  in rowid order (insertion order for non-IPK tables).
+* AUTOINCREMENT is not supported. ``INTEGER PRIMARY KEY`` is a plain rowid
+  alias without the monotonicity guarantee of AUTOINCREMENT.
+* The uniqueness check on insert is O(n) — a full scan per UNIQUE column.
+* No ALTER TABLE. Tables must be recreated to change their schema.
+* Single connection only. No advisory locking between processes.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import TYPE_CHECKING
+
+from sql_backend import (
+    Backend,
+    ColumnDef,
+    ColumnNotFound,
+    ConstraintViolation,
+    Row,
+    RowIterator,
+    TableAlreadyExists,
+    TableNotFound,
+    TransactionHandle,
+    Unsupported,
+)
+from sql_backend.schema import NO_DEFAULT
+
+from storage_sqlite import record as _record
+from storage_sqlite.btree import BTree, DuplicateRowidError
+from storage_sqlite.freelist import Freelist
+from storage_sqlite.pager import Pager
+from storage_sqlite.schema import Schema, SchemaError, initialize_new_database
+
+if TYPE_CHECKING:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# SQL column-definition helpers
+# ---------------------------------------------------------------------------
+
+
+def _format_literal(value: object) -> str:
+    """Format a Python value as a SQL literal string.
+
+    Used when generating DEFAULT clauses inside ``CREATE TABLE`` SQL.
+    Handles the five SQL value types: NULL, integer, float, text, blob.
+    """
+    if value is None:
+        return "NULL"
+    if isinstance(value, bool):
+        # Python bool is a subclass of int — emit 1/0, not True/False.
+        return "1" if value else "0"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        return repr(value)
+    if isinstance(value, str):
+        escaped = value.replace("'", "''")
+        return f"'{escaped}'"
+    if isinstance(value, bytes):
+        return f"X'{value.hex()}'"
+    return repr(value)  # fallback — should not happen with SqlValue types
+
+
+def _columns_to_sql(table: str, columns: list[ColumnDef]) -> str:
+    """Serialise a list of :class:`ColumnDef` objects as a ``CREATE TABLE``
+    statement.
+
+    The generated SQL is parseable by both this module's :func:`_sql_to_columns`
+    and by the real ``sqlite3`` CLI.
+
+    Examples::
+
+        _columns_to_sql("users", [
+            ColumnDef(name="id", type_name="INTEGER", primary_key=True),
+            ColumnDef(name="name", type_name="TEXT", not_null=True),
+        ])
+        # → "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)"
+    """
+    parts: list[str] = []
+    for col in columns:
+        tokens: list[str] = [col.name, col.type_name]
+        if col.primary_key:
+            tokens.append("PRIMARY KEY")
+        # NOT NULL: emit only when not implied by PRIMARY KEY to match sqlite3's
+        # output style; PRIMARY KEY already implies NOT NULL in SQLite.
+        if col.not_null and not col.primary_key:
+            tokens.append("NOT NULL")
+        if col.unique and not col.primary_key:
+            tokens.append("UNIQUE")
+        if col.has_default():
+            tokens.append(f"DEFAULT {_format_literal(col.default)}")
+        parts.append(" ".join(tokens))
+    return f"CREATE TABLE {table} ({', '.join(parts)})"
+
+
+# ---------------------------------------------------------------------------
+# SQL → ColumnDef parser
+# ---------------------------------------------------------------------------
+
+# A minimal tokeniser that handles identifiers/keywords, numbers, single-
+# quoted strings, and X'…' blob literals. Comments are stripped before this
+# runs.
+_SQL_TOKEN = re.compile(
+    r"X'[0-9A-Fa-f]*'"            # blob literal X'DEADBEEF'
+    r"|'(?:[^']|'')*'"            # single-quoted string ('' = escaped quote)
+    r"|-?\d+(?:\.\d+)?(?:[Ee][+-]?\d+)?"  # number (int or float)
+    r"|\w+"                       # identifier or keyword
+    r"|[(),;]",                   # punctuation
+    re.IGNORECASE,
+)
+
+
+def _tokenize(sql: str) -> list[str]:
+    """Return a flat list of tokens from *sql*, stripping SQL comments.
+
+    Only the token types needed for CREATE TABLE column definitions are
+    recognised: identifiers, keywords, numbers, single-quoted strings,
+    X'' blob literals, and punctuation. Whitespace is discarded.
+    """
+    # Strip line comments first so they don't confuse the regex.
+    stripped = re.sub(r"--[^\n]*", "", sql)
+    return _SQL_TOKEN.findall(stripped)
+
+
+def _parse_literal(tok: str) -> object:
+    """Convert a raw SQL literal token to a Python :data:`~sql_backend.SqlValue`.
+
+    Token forms handled:
+
+    * ``NULL``  → ``None``
+    * Integer   → ``int``
+    * Float     → ``float``
+    * ``'…'``   → ``str`` (undoes ``''`` escaping)
+    * ``X'…'``  → ``bytes``
+    """
+    if tok.upper() == "NULL":
+        return None
+    if tok.upper().startswith("X'"):
+        hex_part = tok[2:-1]
+        return bytes.fromhex(hex_part)
+    if tok.startswith("'"):
+        # Strip surrounding single quotes and unescape doubled single quotes.
+        inner = tok[1:-1].replace("''", "'")
+        return inner
+    # Try integer first, then float.
+    try:
+        return int(tok)
+    except ValueError:
+        return float(tok)
+
+
+def _split_column_defs(body: str) -> list[str]:
+    """Split a comma-separated list of column definitions.
+
+    Respects parenthesis depth so that expressions like ``DEFAULT (1+2)``
+    are not split at the inner comma (though we don't generate such forms;
+    this makes the parser robust against real ``sqlite3`` output).
+    """
+    parts: list[str] = []
+    depth = 0
+    buf: list[str] = []
+    for ch in body:
+        if ch == "(":
+            depth += 1
+            buf.append(ch)
+        elif ch == ")":
+            depth -= 1
+            buf.append(ch)
+        elif ch == "," and depth == 0:
+            parts.append("".join(buf))
+            buf = []
+        else:
+            buf.append(ch)
+    if buf:
+        parts.append("".join(buf))
+    return parts
+
+
+def _parse_one_column(col_sql: str) -> ColumnDef | None:
+    """Parse a single column definition string into a :class:`ColumnDef`.
+
+    Returns ``None`` for table-level constraints (e.g. ``PRIMARY KEY(id)``
+    on a separate line) which start with a constraint keyword rather than a
+    column name.
+
+    Recognises::
+
+        <name> <type> [PRIMARY KEY] [NOT NULL] [UNIQUE] [DEFAULT <literal>]
+
+    Keywords are matched case-insensitively. Unknown tokens are skipped so
+    the parser stays permissive when reading SQL produced by the real
+    ``sqlite3`` CLI.
+    """
+    tokens = _tokenize(col_sql)
+    if len(tokens) < 2:
+        return None
+
+    # Table-level constraints start with a keyword, not a column name.
+    first_upper = tokens[0].upper()
+    if first_upper in ("PRIMARY", "UNIQUE", "CHECK", "FOREIGN", "CONSTRAINT"):
+        return None
+
+    name = tokens[0]
+    type_name = tokens[1]
+
+    not_null = False
+    primary_key = False
+    unique = False
+    default: object = NO_DEFAULT
+
+    i = 2
+    while i < len(tokens):
+        tok_upper = tokens[i].upper()
+        if tok_upper == "PRIMARY" and i + 1 < len(tokens) and tokens[i + 1].upper() == "KEY":
+            primary_key = True
+            i += 2
+        elif tok_upper == "NOT" and i + 1 < len(tokens) and tokens[i + 1].upper() == "NULL":
+            not_null = True
+            i += 2
+        elif tok_upper == "UNIQUE":
+            unique = True
+            i += 1
+        elif tok_upper == "DEFAULT" and i + 1 < len(tokens):
+            default = _parse_literal(tokens[i + 1])
+            i += 2
+        else:
+            i += 1  # skip unknown token (e.g. AUTO_INCREMENT, REFERENCES, …)
+
+    return ColumnDef(
+        name=name,
+        type_name=type_name,
+        not_null=not_null,
+        primary_key=primary_key,
+        unique=unique,
+        default=default,
+    )
+
+
+def _sql_to_columns(sql: str) -> list[ColumnDef]:
+    """Extract :class:`ColumnDef` objects from a ``CREATE TABLE`` SQL string.
+
+    Locates the opening and closing parentheses that delimit the column list,
+    splits by comma, and delegates each column definition to
+    :func:`_parse_one_column`. Table-level constraints (``PRIMARY KEY(…)``
+    etc.) are silently skipped.
+
+    Raises :class:`ValueError` if the SQL string contains no parentheses.
+
+    Example::
+
+        _sql_to_columns("CREATE TABLE t (id INTEGER PRIMARY KEY, x TEXT NOT NULL)")
+        # → [ColumnDef(name='id', ..., primary_key=True),
+        #    ColumnDef(name='x', ..., not_null=True)]
+    """
+    start = sql.index("(")
+    end = sql.rindex(")")
+    body = sql[start + 1 : end]
+    col_parts = _split_column_defs(body)
+    columns: list[ColumnDef] = []
+    for part in col_parts:
+        col = _parse_one_column(part.strip())
+        if col is not None:
+            columns.append(col)
+    return columns
+
+
+# ---------------------------------------------------------------------------
+# Row encode / decode helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_ipk(col: ColumnDef) -> bool:
+    """Return True if *col* is an INTEGER PRIMARY KEY (the SQLite rowid alias).
+
+    In SQLite a column declared ``INTEGER PRIMARY KEY`` (the type must be
+    exactly "INTEGER" or "INT", case-insensitive) is an alias for the rowid.
+    Its value is stored as the B-tree cell key, **not** in the record payload.
+    """
+    return col.primary_key and col.type_name.upper() in ("INTEGER", "INT")
+
+
+def _encode_row(rowid: int, row: Row, columns: list[ColumnDef]) -> bytes:
+    """Encode *row* as a SQLite record payload.
+
+    Columns are encoded in declaration order. INTEGER PRIMARY KEY columns are
+    skipped because their value IS the rowid (already stored as the cell key).
+    Absent columns are treated as SQL NULL.
+
+    Args:
+        rowid: The B-tree row key for this row (used to inject NULL for an IPK
+               column whose value is somehow absent — should not happen in
+               normal usage).
+        row:   Mapping of column name → value.
+        columns: Column definitions in declaration order.
+
+    Returns:
+        Raw record bytes suitable for passing to :meth:`~storage_sqlite.btree.BTree.insert`.
+    """
+    values: list[object] = []
+    for col in columns:
+        if _is_ipk(col):
+            continue  # rowid alias — stored as the cell key, not in payload
+        values.append(row.get(col.name))  # absent → None (SQL NULL)
+    return _record.encode(values)
+
+
+def _decode_row(rowid: int, payload: bytes, columns: list[ColumnDef]) -> Row:
+    """Decode a raw record payload back into a :data:`~sql_backend.Row` dict.
+
+    The inverse of :func:`_encode_row`. INTEGER PRIMARY KEY columns have
+    their value injected from *rowid* rather than from the payload.
+
+    Args:
+        rowid:   The B-tree cell key for this row.
+        payload: Raw record bytes as returned by a B-tree scan.
+        columns: Column definitions in declaration order (same order as encoding).
+
+    Returns:
+        A dict mapping column name → decoded SqlValue.
+    """
+    decoded_values, _ = _record.decode(payload)
+    result: Row = {}
+    payload_idx = 0
+    for col in columns:
+        if _is_ipk(col):
+            result[col.name] = rowid  # inject rowid as the IPK value
+        else:
+            val = decoded_values[payload_idx] if payload_idx < len(decoded_values) else None
+            result[col.name] = val
+            payload_idx += 1
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Rowid helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_max_rowid(tree: BTree) -> int:
+    """Return the maximum rowid currently stored in *tree*, or 0 if empty.
+
+    Performs a full scan (O(n)). For v1 this is acceptable; a future
+    optimisation can walk to the rightmost leaf in O(log n).
+    """
+    max_rid = 0
+    for rowid, _ in tree.scan():
+        if rowid > max_rid:
+            max_rid = rowid
+    return max_rid
+
+
+def _choose_rowid(row: Row, columns: list[ColumnDef], tree: BTree) -> int:
+    """Determine the rowid to use when inserting *row*.
+
+    Rules (mirroring SQLite's behaviour):
+
+    1. If the table has an INTEGER PRIMARY KEY column AND the row supplies a
+       non-NULL value for it, use that value as the rowid.
+    2. Otherwise (no IPK, or IPK column is absent/NULL in this row), assign
+       ``max_existing_rowid + 1``.
+    """
+    for col in columns:
+        if _is_ipk(col):
+            val = row.get(col.name)
+            if val is not None and isinstance(val, int):
+                return val
+            # IPK absent or NULL → fall through to auto-assign.
+            break
+
+    return _find_max_rowid(tree) + 1
+
+
+# ---------------------------------------------------------------------------
+# Constraint checkers
+# ---------------------------------------------------------------------------
+
+
+def _apply_defaults(row: Row, columns: list[ColumnDef]) -> Row:
+    """Return a copy of *row* with missing columns filled from their defaults.
+
+    Columns absent from *row* that have a DEFAULT clause get the default value.
+    Columns absent with no default are set to ``None`` (SQL NULL), so that
+    subsequent NOT NULL checks can fire correctly.
+    """
+    out: Row = dict(row)
+    for col in columns:
+        if col.name not in out:
+            if col.has_default():
+                # col.default is ColumnDefault = SqlValue | _NoDefault.
+                # has_default() ruled out the sentinel so this cast is safe.
+                out[col.name] = col.default  # type: ignore[assignment]
+            else:
+                out[col.name] = None  # absent + no default → NULL
+    return out
+
+
+def _check_not_null(table: str, row: Row, columns: list[ColumnDef]) -> None:
+    """Raise :class:`~sql_backend.ConstraintViolation` if a NOT NULL column
+    contains NULL in *row*.
+
+    PRIMARY KEY implies NOT NULL (via :meth:`~sql_backend.ColumnDef.effective_not_null`).
+    """
+    for col in columns:
+        if col.effective_not_null() and row.get(col.name) is None:
+            raise ConstraintViolation(
+                table=table,
+                column=col.name,
+                message=f"NOT NULL constraint failed: {table}.{col.name}",
+            )
+
+
+def _check_unique(
+    table: str,
+    row: Row,
+    columns: list[ColumnDef],
+    tree: BTree,
+    tree_columns: list[ColumnDef],
+    ignore_rowid: int | None = None,
+) -> None:
+    """Raise :class:`~sql_backend.ConstraintViolation` if a UNIQUE column
+    already contains the value being inserted/updated.
+
+    NULL values never conflict (SQL semantics). *ignore_rowid* is the rowid
+    of the row being updated so it is not compared against itself.
+
+    This is O(n) per unique column. Acceptable for v1; future versions can
+    add in-memory uniqueness indexes.
+    """
+    unique_cols = [c for c in columns if c.effective_unique()]
+    if not unique_cols:
+        return
+
+    new_vals = {col.name: row.get(col.name) for col in unique_cols}
+    # Optimisation: if none of the unique-column values are non-NULL we can
+    # skip the scan entirely.
+    if all(v is None for v in new_vals.values()):
+        return
+
+    for existing_rowid, payload in tree.scan():
+        if existing_rowid == ignore_rowid:
+            continue
+        existing_row = _decode_row(existing_rowid, payload, tree_columns)
+        for col in unique_cols:
+            new_val = new_vals[col.name]
+            if new_val is None:
+                continue  # NULL never conflicts
+            if existing_row.get(col.name) == new_val:
+                label = "PRIMARY KEY" if col.primary_key else "UNIQUE"
+                raise ConstraintViolation(
+                    table=table,
+                    column=col.name,
+                    message=f"{label} constraint failed: {table}.{col.name}",
+                )
+
+
+# ---------------------------------------------------------------------------
+# BTreeCursor
+# ---------------------------------------------------------------------------
+
+
+class _BTreeCursor:
+    """A :class:`~sql_backend.Cursor` backed by a B-tree scan.
+
+    Satisfies both :class:`~sql_backend.RowIterator` (for use as a plain
+    scan return value) and :class:`~sql_backend.Cursor` (for positioned
+    ``UPDATE``/``DELETE``).
+
+    The cursor reads B-tree cells lazily through a Python generator. Each
+    ``next()`` call advances the generator and decodes one record.
+
+    Row identity is the B-tree rowid (:attr:`_current_rowid`). The backend
+    uses this rowid to locate and mutate the correct cell.
+    """
+
+    __slots__ = (
+        "_columns",
+        "_current_row",
+        "_current_rowid",
+        "_gen",
+        "_closed",
+    )
+
+    def __init__(self, tree: BTree, columns: list[ColumnDef]) -> None:
+        self._columns = columns
+        # tree.scan() yields (rowid, payload) pairs in ascending rowid order.
+        self._gen = tree.scan()
+        self._current_rowid: int | None = None
+        self._current_row: Row | None = None
+        self._closed = False
+
+    def next(self) -> Row | None:
+        """Advance to the next row; return it as a dict, or ``None`` at end."""
+        if self._closed:
+            return None
+        try:
+            rowid, payload = next(self._gen)
+        except StopIteration:
+            self._current_rowid = None
+            self._current_row = None
+            return None
+        self._current_rowid = rowid
+        self._current_row = _decode_row(rowid, payload, self._columns)
+        return dict(self._current_row)
+
+    def current_row(self) -> Row | None:
+        """Return the most recent row returned by :meth:`next`, or ``None``."""
+        if self._current_row is None:
+            return None
+        return dict(self._current_row)
+
+    def close(self) -> None:
+        """Release the cursor. Safe to call multiple times."""
+        self._closed = True
+        self._current_rowid = None
+        self._current_row = None
+
+
+# ---------------------------------------------------------------------------
+# SqliteFileBackend
+# ---------------------------------------------------------------------------
+
+
+class SqliteFileBackend(Backend):
+    """A :class:`~sql_backend.Backend` that reads and writes real SQLite files.
+
+    This is the file-backed sibling of :class:`~sql_backend.InMemoryBackend`.
+    It implements the same interface but persists data to a SQLite-compatible
+    ``.db`` file. Files produced by this backend are readable by the
+    ``sqlite3`` command-line tool, and files produced by ``sqlite3`` are
+    readable by this backend (for the v1 subset of features).
+
+    Parameters
+    ----------
+    path:
+        Filesystem path to the ``.db`` file. The file is created if it does
+        not exist. Pass ``":memory:"`` to get an :class:`~sql_backend.InMemoryBackend`
+        — that routing is done by the mini-sqlite facade; this class does not
+        handle ``":memory:"`` itself.
+
+    Examples
+    --------
+    ::
+
+        with SqliteFileBackend("app.db") as backend:
+            backend.create_table("users", [
+                ColumnDef(name="id", type_name="INTEGER", primary_key=True),
+                ColumnDef(name="name", type_name="TEXT", not_null=True),
+            ], if_not_exists=False)
+            backend.insert("users", {"id": 1, "name": "Alice"})
+            h = backend.begin_transaction()
+            backend.commit(h)  # flush to disk
+    """
+
+    def __init__(self, path: str) -> None:
+        abs_path = os.path.abspath(path)
+        if os.path.exists(abs_path):
+            self._pager = Pager.open(abs_path)
+        else:
+            self._pager = Pager.create(abs_path)
+            # Write the initial page-1 (database header + empty sqlite_schema
+            # leaf) and commit immediately so the file is valid on disk before
+            # any DML starts.
+            initialize_new_database(self._pager)
+            self._pager.commit()
+
+        self._freelist = Freelist(self._pager)
+        self._schema = Schema(self._pager, freelist=self._freelist)
+
+        # Transaction tracking.
+        self._next_handle: int = 1
+        self._active_handle: int | None = None
+
+    # ── Context manager ──────────────────────────────────────────────────────
+
+    def __enter__(self) -> SqliteFileBackend:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: object,
+    ) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """Close the backend, rolling back any uncommitted transaction."""
+        if self._active_handle is not None:
+            self._pager.rollback()
+            self._active_handle = None
+        self._pager.close()
+
+    # ── Schema helpers ───────────────────────────────────────────────────────
+
+    def _require_table(self, table: str) -> tuple[int, list[ColumnDef]]:
+        """Return ``(rootpage, columns)`` for *table*, raising
+        :class:`~sql_backend.TableNotFound` if the table does not exist.
+        """
+        result = self._schema.find_table(table)
+        if result is None:
+            raise TableNotFound(table=table)
+        _, rootpage, sql = result
+        try:
+            columns = _sql_to_columns(sql)
+        except (ValueError, IndexError) as exc:
+            raise TableNotFound(table=table) from exc
+        return rootpage, columns
+
+    def _open_tree(self, rootpage: int) -> BTree:
+        """Open a B-tree for *rootpage* with the freelist attached."""
+        return BTree.open(self._pager, rootpage, freelist=self._freelist)
+
+    # ── Backend interface: Schema ─────────────────────────────────────────────
+
+    def tables(self) -> list[str]:
+        """Return the names of all user tables in insertion order."""
+        return self._schema.list_tables()
+
+    def columns(self, table: str) -> list[ColumnDef]:
+        """Return the columns of *table* in declaration order.
+
+        Raises :class:`~sql_backend.TableNotFound` if *table* is unknown.
+        """
+        _, cols = self._require_table(table)
+        return cols
+
+    # ── Backend interface: Read ───────────────────────────────────────────────
+
+    def scan(self, table: str) -> RowIterator:
+        """Return a row iterator over all rows in *table*.
+
+        Raises :class:`~sql_backend.TableNotFound` if *table* is unknown.
+        Rows are yielded in ascending rowid order (i.e. insertion order for
+        tables without an explicit rowid reuse).
+        """
+        rootpage, columns = self._require_table(table)
+        tree = self._open_tree(rootpage)
+        return _BTreeCursor(tree, columns)
+
+    def _open_cursor(self, table: str) -> _BTreeCursor:
+        """Return a :class:`_BTreeCursor` for *table*.
+
+        Not part of the public Backend interface, but expected by the
+        conformance test suite which needs a cursor to test positioned
+        UPDATE and DELETE.
+        """
+        rootpage, columns = self._require_table(table)
+        tree = self._open_tree(rootpage)
+        return _BTreeCursor(tree, columns)
+
+    # ── Backend interface: Write ──────────────────────────────────────────────
+
+    def insert(self, table: str, row: Row) -> None:
+        """Insert *row* into *table*.
+
+        Applies column defaults for absent columns, enforces NOT NULL and
+        UNIQUE / PRIMARY KEY constraints, then encodes and inserts the row
+        into the table's B-tree.
+
+        Raises :class:`~sql_backend.TableNotFound`, :class:`~sql_backend.ColumnNotFound`,
+        or :class:`~sql_backend.ConstraintViolation`.
+        """
+        rootpage, columns = self._require_table(table)
+
+        # Fill in defaults and map absent columns to NULL.
+        full_row = _apply_defaults(row, columns)
+
+        # Reject columns not in the schema.
+        known = {col.name for col in columns}
+        for key in full_row:
+            if key not in known:
+                raise ColumnNotFound(table=table, column=key)
+
+        # Constraint checks.
+        _check_not_null(table, full_row, columns)
+
+        tree = self._open_tree(rootpage)
+
+        # Determine the rowid and check primary-key uniqueness.
+        rowid = _choose_rowid(full_row, columns, tree)
+
+        # For non-IPK UNIQUE columns, scan for duplicates before inserting.
+        non_pk_unique = [c for c in columns if c.effective_unique() and not _is_ipk(c)]
+        if non_pk_unique:
+            _check_unique(table, full_row, non_pk_unique, tree, columns)
+
+        payload = _encode_row(rowid, full_row, columns)
+        try:
+            tree.insert(rowid, payload)
+        except DuplicateRowidError:
+            # The IPK column value already exists → PRIMARY KEY violation.
+            pk_cols = [c for c in columns if _is_ipk(c)]
+            if pk_cols:
+                raise ConstraintViolation(
+                    table=table,
+                    column=pk_cols[0].name,
+                    message=f"PRIMARY KEY constraint failed: {table}.{pk_cols[0].name}",
+                ) from None
+            raise  # Should not happen for non-IPK tables; propagate as-is.
+
+    def update(
+        self,
+        table: str,
+        cursor: object,
+        assignments: dict[str, object],
+    ) -> None:
+        """Apply *assignments* to the row the cursor is currently on.
+
+        Validates column names, enforces NOT NULL on the new values, then
+        re-encodes the row and calls :meth:`BTree.update` at the cursor's
+        current rowid.
+
+        Raises :class:`~sql_backend.TableNotFound`, :class:`~sql_backend.ColumnNotFound`,
+        :class:`~sql_backend.ConstraintViolation`, or :class:`~sql_backend.Unsupported`
+        if the cursor is not a native :class:`_BTreeCursor`.
+        """
+        if not isinstance(cursor, _BTreeCursor):
+            raise Unsupported(operation="update with non-native cursor")
+        if cursor._current_rowid is None:  # noqa: SLF001
+            raise Unsupported(operation="update without current row")
+
+        rootpage, columns = self._require_table(table)
+
+        # Validate column names before applying any change.
+        col_names = {c.name for c in columns}
+        for col_name in assignments:
+            if col_name not in col_names:
+                raise ColumnNotFound(table=table, column=col_name)
+
+        # Build the proposed new row.
+        current_row = cursor._current_row or {}  # noqa: SLF001
+        proposed: Row = {**current_row, **assignments}  # type: ignore[arg-type]
+
+        # Constraint checks on proposed row.
+        _check_not_null(table, proposed, columns)
+
+        tree = self._open_tree(rootpage)
+        rowid = cursor._current_rowid  # noqa: SLF001
+        new_payload = _encode_row(rowid, proposed, columns)
+        tree.update(rowid, new_payload)
+
+        # Update cursor's cached row so further reads are consistent.
+        cursor._current_row = proposed  # noqa: SLF001
+
+    def delete(self, table: str, cursor: object) -> None:
+        """Delete the row the cursor is currently on.
+
+        After deletion the cursor's current row is cleared (``current_row()``
+        returns ``None``). The cursor's generator is still live so ``next()``
+        will advance to the row that USED TO follow the deleted one.
+
+        Raises :class:`~sql_backend.Unsupported` if the cursor is not a native
+        :class:`_BTreeCursor`.
+        """
+        if not isinstance(cursor, _BTreeCursor):
+            raise Unsupported(operation="delete with non-native cursor")
+        if cursor._current_rowid is None:  # noqa: SLF001
+            raise Unsupported(operation="delete without current row")
+
+        rootpage, _ = self._require_table(table)
+        tree = self._open_tree(rootpage)
+        rowid = cursor._current_rowid  # noqa: SLF001
+        tree.delete(rowid)
+
+        # Clear cursor position — the row no longer exists.
+        cursor._current_rowid = None  # noqa: SLF001
+        cursor._current_row = None  # noqa: SLF001
+
+    # ── Backend interface: DDL ────────────────────────────────────────────────
+
+    def create_table(
+        self,
+        table: str,
+        columns: list[ColumnDef],
+        if_not_exists: bool,
+    ) -> None:
+        """Create a new table.
+
+        Generates the ``CREATE TABLE`` SQL, stores it in ``sqlite_schema``,
+        and allocates a fresh root page for the new B-tree.
+
+        If *if_not_exists* is ``True`` and the table already exists, this is a
+        no-op. Otherwise raises :class:`~sql_backend.TableAlreadyExists`.
+        """
+        if self._schema.find_table(table) is not None:
+            if if_not_exists:
+                return
+            raise TableAlreadyExists(table=table)
+
+        sql = _columns_to_sql(table, columns)
+        self._schema.create_table(table, sql)
+
+    def drop_table(self, table: str, if_exists: bool) -> None:
+        """Drop *table*, freeing all its pages.
+
+        Raises :class:`~sql_backend.TableNotFound` if the table does not
+        exist and *if_exists* is ``False``.
+        """
+        try:
+            self._schema.drop_table(table)
+        except SchemaError:
+            if if_exists:
+                return
+            raise TableNotFound(table=table) from None
+
+    # ── Backend interface: Transactions ───────────────────────────────────────
+
+    def begin_transaction(self) -> TransactionHandle:
+        """Begin a transaction and return an opaque handle.
+
+        The pager already accumulates all writes in its dirty-page table, so
+        no additional action is needed at the storage level. We just record
+        the handle so :meth:`commit` and :meth:`rollback` can validate it.
+
+        Raises :class:`~sql_backend.Unsupported` if a transaction is already
+        open (nested transactions are not supported).
+        """
+        if self._active_handle is not None:
+            raise Unsupported(operation="nested transactions")
+        handle = TransactionHandle(self._next_handle)
+        self._next_handle += 1
+        self._active_handle = int(handle)
+        return handle
+
+    def commit(self, handle: TransactionHandle) -> None:
+        """Commit the transaction identified by *handle*.
+
+        Flushes all dirty pages to disk via ``pager.commit()``.
+        """
+        self._require_active(handle)
+        self._pager.commit()
+        self._active_handle = None
+
+    def rollback(self, handle: TransactionHandle) -> None:
+        """Roll back the transaction identified by *handle*.
+
+        Discards all dirty pages, restoring the file to its state at the
+        time of the last ``commit()``.
+        """
+        self._require_active(handle)
+        self._pager.rollback()
+        self._active_handle = None
+        # Reattach the schema object so it reads fresh pages after rollback.
+        self._schema = Schema(self._pager, freelist=self._freelist)
+
+    # ── Internal helpers ─────────────────────────────────────────────────────
+
+    def _require_active(self, handle: TransactionHandle) -> None:
+        if self._active_handle is None:
+            raise Unsupported(operation="no active transaction")
+        if int(handle) != self._active_handle:
+            raise Unsupported(operation="stale transaction handle")

--- a/code/packages/python/storage-sqlite/tests/test_backend.py
+++ b/code/packages/python/storage-sqlite/tests/test_backend.py
@@ -1,0 +1,874 @@
+"""
+Tests for SqliteFileBackend (phase 7).
+
+Structure
+---------
+The test file is split into three sections:
+
+1. **Conformance tests** — the four tiers from ``sql_backend.conformance``.
+   These are the same assertions that InMemoryBackend passes; a failure here
+   means our file backend deviates from the contract.
+
+2. **File-persistence tests** — round-trips that open the database in a
+   second backend instance and verify that committed data is still there.
+
+3. **Unit tests** for the SQL helper functions and the row encode/decode
+   helpers that cannot be reached through the Backend interface.
+
+Factory pattern
+---------------
+Each conformance test calls a *factory*: a zero-arg callable that returns a
+fresh, pre-populated backend with the ``users`` table and its five rows.
+
+For the file backend we use ``tmp_path`` (pytest's built-in temporary
+directory fixture) to get a throwaway file.  Because the conformance suite
+calls the factory multiple times (once per sub-test) we build a fresh file
+for each call rather than sharing state across calls.
+
+Transaction note
+----------------
+The conformance fixtures (rows 1–5) are committed to disk before the
+factory returns.  This is necessary for the rollback tests (22) to work:
+``rollback()`` reverts dirty pages to the *last committed* state, so the
+five rows must already be committed when the test starts.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from sql_backend import ColumnDef, ConstraintViolation, TableAlreadyExists, TableNotFound
+from sql_backend.conformance import (
+    USERS_COLUMNS,
+    USERS_ROWS,
+    run_ddl,
+    run_read_write,
+    run_required,
+    run_transaction,
+)
+
+from storage_sqlite import record
+from storage_sqlite.backend import (
+    SqliteFileBackend,
+    _apply_defaults,
+    _check_not_null,
+    _choose_rowid,
+    _columns_to_sql,
+    _decode_row,
+    _encode_row,
+    _find_max_rowid,
+    _format_literal,
+    _is_ipk,
+    _parse_literal,
+    _parse_one_column,
+    _sql_to_columns,
+    _tokenize,
+)
+from storage_sqlite.btree import BTree
+from storage_sqlite.pager import Pager
+from storage_sqlite.schema import initialize_new_database
+
+# ---------------------------------------------------------------------------
+# Factory helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_file_backend(path: str) -> SqliteFileBackend:
+    """Create a SqliteFileBackend at *path* pre-populated with the users table
+    and committed to disk.
+
+    The commit is essential for rollback tests: ``pager.rollback()`` reverts
+    to the last *committed* checkpoint, so the five user rows must be durably
+    persisted before any test that calls ``rollback()`` starts.
+    """
+    b = SqliteFileBackend(path)
+    b.create_table("users", USERS_COLUMNS, if_not_exists=False)
+    for row in USERS_ROWS:
+        b.insert("users", row)
+    h = b.begin_transaction()
+    b.commit(h)
+    return b
+
+
+def _factory_for(tmp_path: Path):
+    """Return a factory callable bound to *tmp_path*.
+
+    Each call to the factory creates a brand-new ``.db`` file so tests
+    never share state.
+    """
+    counter = {"n": 0}
+
+    def factory() -> SqliteFileBackend:
+        counter["n"] += 1
+        path = str(tmp_path / f"test_{counter['n']}.db")
+        return _make_file_backend(path)
+
+    return factory
+
+
+# ---------------------------------------------------------------------------
+# Conformance: tier 1 (required)
+# ---------------------------------------------------------------------------
+
+
+def test_conformance_required(tmp_path: Path) -> None:
+    """Every backend must satisfy schema introspection and read-only scan."""
+    run_required(_factory_for(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# Conformance: tier 2 (read-write)
+# ---------------------------------------------------------------------------
+
+
+def test_conformance_read_write(tmp_path: Path) -> None:
+    """Inserts, updates, deletes, NOT NULL, duplicate PK, defaults."""
+    run_read_write(_factory_for(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# Conformance: tier 3 (DDL)
+# ---------------------------------------------------------------------------
+
+
+def test_conformance_ddl(tmp_path: Path) -> None:
+    """CREATE TABLE, DROP TABLE, IF [NOT] EXISTS variants."""
+    run_ddl(_factory_for(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# Conformance: tier 4 (transactions)
+# ---------------------------------------------------------------------------
+
+
+def test_conformance_transaction(tmp_path: Path) -> None:
+    """Commit persists; rollback restores."""
+    run_transaction(_factory_for(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# File persistence — round-trip via a second backend instance
+# ---------------------------------------------------------------------------
+
+
+def test_data_survives_close_and_reopen(tmp_path: Path) -> None:
+    """Rows committed in one backend instance are visible in a new instance
+    opened on the same file.
+
+    This is the key property that distinguishes SqliteFileBackend from
+    InMemoryBackend: data actually reaches the disk.
+    """
+    path = str(tmp_path / "persist.db")
+    b = _make_file_backend(path)
+    b.close()  # explicit close (commits nothing extra; just closes pager)
+
+    # Open a fresh instance on the same file.
+    b2 = SqliteFileBackend(path)
+    assert "users" in b2.tables()
+    it = b2.scan("users")
+    rows = []
+    while (row := it.next()) is not None:
+        rows.append(row)
+    it.close()
+    b2.close()
+
+    assert [r["id"] for r in rows] == [1, 2, 3, 4, 5]
+    assert rows[0]["name"] == "alice"
+    assert rows[1]["name"] == "bob"
+
+
+def test_new_file_created_automatically(tmp_path: Path) -> None:
+    """Opening a non-existent path creates a valid SQLite database file."""
+    path = str(tmp_path / "brand_new.db")
+    assert not os.path.exists(path)
+
+    b = SqliteFileBackend(path)
+    b.close()
+
+    assert os.path.exists(path)
+    # The file must be readable by a second instance.
+    b2 = SqliteFileBackend(path)
+    assert b2.tables() == []
+    b2.close()
+
+
+def test_existing_file_opened(tmp_path: Path) -> None:
+    """An existing file is opened rather than overwritten."""
+    path = str(tmp_path / "existing.db")
+    b = _make_file_backend(path)
+    b.close()
+
+    b2 = SqliteFileBackend(path)
+    cols = b2.columns("users")
+    assert [c.name for c in cols] == ["id", "name", "age", "email"]
+    b2.close()
+
+
+def test_schema_cookie_persists(tmp_path: Path) -> None:
+    """The schema cookie is bumped and persisted with each CREATE TABLE."""
+    path = str(tmp_path / "cookie.db")
+    b = SqliteFileBackend(path)
+    cookie_0 = b._schema.get_schema_cookie()
+
+    id_col = [ColumnDef(name="id", type_name="INTEGER", primary_key=True)]
+    b.create_table("t1", id_col, if_not_exists=False)
+    h = b.begin_transaction()
+    b.commit(h)
+    cookie_1 = b._schema.get_schema_cookie()
+
+    b.create_table("t2", id_col, if_not_exists=False)
+    h = b.begin_transaction()
+    b.commit(h)
+    cookie_2 = b._schema.get_schema_cookie()
+    b.close()
+
+    assert cookie_1 == cookie_0 + 1
+    assert cookie_2 == cookie_0 + 2
+
+
+def test_multiple_tables_persist(tmp_path: Path) -> None:
+    """Multiple tables survive a close-and-reopen cycle."""
+    path = str(tmp_path / "multi.db")
+    b = SqliteFileBackend(path)
+    id_col = [ColumnDef(name="id", type_name="INTEGER", primary_key=True)]
+    b.create_table("a", id_col, if_not_exists=False)
+    b.create_table("b", [ColumnDef(name="x", type_name="TEXT")], if_not_exists=False)
+    b.insert("a", {"id": 1})
+    b.insert("b", {"x": "hello"})
+    h = b.begin_transaction()
+    b.commit(h)
+    b.close()
+
+    b2 = SqliteFileBackend(path)
+    assert sorted(b2.tables()) == ["a", "b"]
+    b2.close()
+
+
+def test_drop_table_persists(tmp_path: Path) -> None:
+    """Dropping a table and committing makes it absent in the next session."""
+    path = str(tmp_path / "drop.db")
+    b = _make_file_backend(path)
+    b.drop_table("users", if_exists=False)
+    h = b.begin_transaction()
+    b.commit(h)
+    b.close()
+
+    b2 = SqliteFileBackend(path)
+    assert "users" not in b2.tables()
+    b2.close()
+
+
+# ---------------------------------------------------------------------------
+# Transaction semantics
+# ---------------------------------------------------------------------------
+
+
+def test_rollback_reverts_insert(tmp_path: Path) -> None:
+    """An un-committed insert disappears after rollback."""
+    path = str(tmp_path / "rollback_insert.db")
+    b = _make_file_backend(path)
+
+    h = b.begin_transaction()
+    b.insert("users", {"id": 99, "name": "ghost", "age": 0, "email": None})
+    b.rollback(h)
+
+    ids = []
+    it = b.scan("users")
+    while (row := it.next()) is not None:
+        ids.append(row["id"])
+    it.close()
+    b.close()
+
+    assert 99 not in ids
+
+
+def test_commit_then_rollback_still_sees_committed(tmp_path: Path) -> None:
+    """A row committed in txn-1 remains visible after txn-2 is rolled back."""
+    path = str(tmp_path / "commit_rollback.db")
+    b = _make_file_backend(path)
+
+    # Commit id=10.
+    h = b.begin_transaction()
+    b.insert("users", {"id": 10, "name": "ten", "age": 10, "email": None})
+    b.commit(h)
+
+    # Roll back id=11.
+    h = b.begin_transaction()
+    b.insert("users", {"id": 11, "name": "eleven", "age": 11, "email": None})
+    b.rollback(h)
+
+    ids = []
+    it = b.scan("users")
+    while (row := it.next()) is not None:
+        ids.append(row["id"])
+    it.close()
+    b.close()
+
+    assert 10 in ids
+    assert 11 not in ids
+
+
+def test_context_manager_rollback_on_exception(tmp_path: Path) -> None:
+    """Using the backend as a context manager rolls back on unhandled exit."""
+    path = str(tmp_path / "ctx.db")
+    # Create and commit initial state outside the context manager.
+    b_init = SqliteFileBackend(path)
+    id_col = [ColumnDef(name="id", type_name="INTEGER", primary_key=True)]
+    b_init.create_table("t", id_col, if_not_exists=False)
+    h = b_init.begin_transaction()
+    b_init.commit(h)
+    b_init.close()
+
+    with SqliteFileBackend(path) as b:
+        b.insert("t", {"id": 1})
+        # Exit without commit — close() rolls back.
+
+    b2 = SqliteFileBackend(path)
+    it = b2.scan("t")
+    assert it.next() is None  # nothing was committed
+    it.close()
+    b2.close()
+
+
+# ---------------------------------------------------------------------------
+# Constraint enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_not_null_on_insert(tmp_path: Path) -> None:
+    """NOT NULL constraint is enforced on insert."""
+    path = str(tmp_path / "nn.db")
+    b = _make_file_backend(path)
+    with pytest.raises(ConstraintViolation):
+        b.insert("users", {"id": 100, "name": None, "age": 1, "email": None})
+    b.close()
+
+
+def test_duplicate_pk_on_insert(tmp_path: Path) -> None:
+    """Duplicate INTEGER PRIMARY KEY raises ConstraintViolation."""
+    path = str(tmp_path / "dupk.db")
+    b = _make_file_backend(path)
+    with pytest.raises(ConstraintViolation):
+        b.insert("users", {"id": 1, "name": "dup", "age": 0, "email": None})
+    b.close()
+
+
+def test_unique_constraint_on_insert(tmp_path: Path) -> None:
+    """UNIQUE constraint is enforced on insert for non-NULL values."""
+    path = str(tmp_path / "uniq.db")
+    b = _make_file_backend(path)
+    with pytest.raises(ConstraintViolation):
+        b.insert("users", {"id": 99, "name": "x", "age": 0, "email": "alice@example.com"})
+    b.close()
+
+
+def test_unique_null_is_not_a_conflict(tmp_path: Path) -> None:
+    """NULL values in UNIQUE columns never conflict with each other (SQL semantics)."""
+    path = str(tmp_path / "null_uniq.db")
+    b = _make_file_backend(path)
+    # dave (id=4) already has email=None; another NULL should be fine.
+    b.insert("users", {"id": 99, "name": "no-email", "age": 0, "email": None})
+    # Both rows should be present.
+    it = b.scan("users")
+    nulls = 0
+    while (row := it.next()) is not None:
+        if row["email"] is None:
+            nulls += 1
+    it.close()
+    b.close()
+    assert nulls == 2
+
+
+def test_not_null_on_update(tmp_path: Path) -> None:
+    """NOT NULL constraint is enforced on update."""
+    path = str(tmp_path / "nn_update.db")
+    b = _make_file_backend(path)
+    cursor = b._open_cursor("users")
+    cursor.next()  # alice, id=1
+    with pytest.raises(ConstraintViolation):
+        b.update("users", cursor, {"name": None})
+    cursor.close()
+    b.close()
+
+
+# ---------------------------------------------------------------------------
+# DDL edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_create_table_if_not_exists(tmp_path: Path) -> None:
+    """create_table with if_not_exists=True is idempotent."""
+    path = str(tmp_path / "ine.db")
+    b = SqliteFileBackend(path)
+    cols = [ColumnDef(name="id", type_name="INTEGER", primary_key=True)]
+    b.create_table("t", cols, if_not_exists=False)
+    b.create_table("t", cols, if_not_exists=True)  # no-op, no exception
+    assert b.tables() == ["t"]
+    b.close()
+
+
+def test_create_table_already_exists_raises(tmp_path: Path) -> None:
+    """create_table with if_not_exists=False raises TableAlreadyExists."""
+    path = str(tmp_path / "ae.db")
+    b = SqliteFileBackend(path)
+    cols = [ColumnDef(name="id", type_name="INTEGER", primary_key=True)]
+    b.create_table("t", cols, if_not_exists=False)
+    with pytest.raises(TableAlreadyExists):
+        b.create_table("t", cols, if_not_exists=False)
+    b.close()
+
+
+def test_drop_table_if_exists(tmp_path: Path) -> None:
+    """drop_table with if_exists=True on a missing table is a no-op."""
+    path = str(tmp_path / "drop_ie.db")
+    b = SqliteFileBackend(path)
+    b.drop_table("ghost", if_exists=True)  # no exception
+    b.close()
+
+
+def test_drop_table_not_found_raises(tmp_path: Path) -> None:
+    """drop_table with if_exists=False on a missing table raises TableNotFound."""
+    path = str(tmp_path / "drop_nf.db")
+    b = SqliteFileBackend(path)
+    with pytest.raises(TableNotFound):
+        b.drop_table("ghost", if_exists=False)
+    b.close()
+
+
+def test_scan_missing_table_raises(tmp_path: Path) -> None:
+    """scan() on an unknown table raises TableNotFound."""
+    path = str(tmp_path / "scan_nf.db")
+    b = SqliteFileBackend(path)
+    with pytest.raises(TableNotFound):
+        b.scan("missing")
+    b.close()
+
+
+def test_columns_missing_table_raises(tmp_path: Path) -> None:
+    """columns() on an unknown table raises TableNotFound."""
+    path = str(tmp_path / "cols_nf.db")
+    b = SqliteFileBackend(path)
+    with pytest.raises(TableNotFound):
+        b.columns("missing")
+    b.close()
+
+
+# ---------------------------------------------------------------------------
+# Large table — exercises splits and overflow
+# ---------------------------------------------------------------------------
+
+
+def test_large_table_insert_and_scan(tmp_path: Path) -> None:
+    """Inserting many rows forces B-tree splits; scan still returns all rows."""
+    path = str(tmp_path / "large.db")
+    b = SqliteFileBackend(path)
+    b.create_table(
+        "items",
+        [
+            ColumnDef(name="id", type_name="INTEGER", primary_key=True),
+            ColumnDef(name="label", type_name="TEXT"),
+        ],
+        if_not_exists=False,
+    )
+    n = 500
+    for i in range(1, n + 1):
+        b.insert("items", {"id": i, "label": f"item-{i:05d}"})
+
+    h = b.begin_transaction()
+    b.commit(h)
+    b.close()
+
+    # Re-open and verify all rows are there in order.
+    b2 = SqliteFileBackend(path)
+    it = b2.scan("items")
+    seen = []
+    while (row := it.next()) is not None:
+        seen.append(row["id"])
+    it.close()
+    b2.close()
+
+    assert seen == list(range(1, n + 1))
+
+
+def test_overflow_row_round_trips(tmp_path: Path) -> None:
+    """A row with a large text value (>4 KB) is stored across overflow pages
+    and decoded correctly on re-read.
+    """
+    path = str(tmp_path / "overflow.db")
+    b = SqliteFileBackend(path)
+    b.create_table(
+        "blobs",
+        [
+            ColumnDef(name="id", type_name="INTEGER", primary_key=True),
+            ColumnDef(name="data", type_name="TEXT"),
+        ],
+        if_not_exists=False,
+    )
+    big = "x" * 6000  # well above the 4 061-byte max_local threshold
+    b.insert("blobs", {"id": 1, "data": big})
+    h = b.begin_transaction()
+    b.commit(h)
+    b.close()
+
+    b2 = SqliteFileBackend(path)
+    it = b2.scan("blobs")
+    row = it.next()
+    it.close()
+    b2.close()
+
+    assert row is not None
+    assert row["id"] == 1
+    assert row["data"] == big
+
+
+# ---------------------------------------------------------------------------
+# Helper unit tests: _format_literal
+# ---------------------------------------------------------------------------
+
+
+def test_format_literal_null() -> None:
+    assert _format_literal(None) == "NULL"
+
+
+def test_format_literal_int() -> None:
+    assert _format_literal(42) == "42"
+    assert _format_literal(-7) == "-7"
+
+
+def test_format_literal_float() -> None:
+    assert _format_literal(3.14) == repr(3.14)
+
+
+def test_format_literal_bool() -> None:
+    # bool is a subclass of int; must emit 1/0 not True/False.
+    assert _format_literal(True) == "1"
+    assert _format_literal(False) == "0"
+
+
+def test_format_literal_str() -> None:
+    assert _format_literal("hello") == "'hello'"
+    assert _format_literal("it's") == "'it''s'"
+
+
+def test_format_literal_bytes() -> None:
+    assert _format_literal(b"\xde\xad") == "X'dead'"
+
+
+# ---------------------------------------------------------------------------
+# Helper unit tests: _columns_to_sql
+# ---------------------------------------------------------------------------
+
+
+def test_columns_to_sql_simple() -> None:
+    cols = [
+        ColumnDef(name="id", type_name="INTEGER", primary_key=True),
+        ColumnDef(name="name", type_name="TEXT", not_null=True),
+    ]
+    sql = _columns_to_sql("users", cols)
+    assert sql == "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)"
+
+
+def test_columns_to_sql_unique() -> None:
+    cols = [
+        ColumnDef(name="id", type_name="INTEGER", primary_key=True),
+        ColumnDef(name="email", type_name="TEXT", unique=True),
+    ]
+    sql = _columns_to_sql("t", cols)
+    assert "UNIQUE" in sql
+    assert "email TEXT UNIQUE" in sql
+
+
+def test_columns_to_sql_default() -> None:
+    cols = [
+        ColumnDef(name="id", type_name="INTEGER", primary_key=True),
+        ColumnDef(name="score", type_name="INTEGER", default=0),
+    ]
+    sql = _columns_to_sql("t", cols)
+    assert "DEFAULT 0" in sql
+
+
+def test_columns_to_sql_primary_key_no_not_null() -> None:
+    """PRIMARY KEY implies NOT NULL — we should not emit both."""
+    cols = [ColumnDef(name="id", type_name="INTEGER", primary_key=True, not_null=True)]
+    sql = _columns_to_sql("t", cols)
+    assert "NOT NULL" not in sql
+
+
+# ---------------------------------------------------------------------------
+# Helper unit tests: _tokenize and _parse_literal
+# ---------------------------------------------------------------------------
+
+
+def test_tokenize_basic() -> None:
+    tokens = _tokenize("id INTEGER PRIMARY KEY")
+    assert tokens == ["id", "INTEGER", "PRIMARY", "KEY"]
+
+
+def test_tokenize_strips_comments() -> None:
+    tokens = _tokenize("id INTEGER -- this is a comment\nPRIMARY KEY")
+    assert "this" not in tokens
+    assert "PRIMARY" in tokens
+
+
+def test_parse_literal_null() -> None:
+    assert _parse_literal("NULL") is None
+    assert _parse_literal("null") is None
+
+
+def test_parse_literal_int() -> None:
+    assert _parse_literal("42") == 42
+    assert _parse_literal("-7") == -7
+
+
+def test_parse_literal_float() -> None:
+    assert isinstance(_parse_literal("3.14"), float)
+    assert abs(_parse_literal("3.14") - 3.14) < 1e-9  # type: ignore[operator]
+
+
+def test_parse_literal_string() -> None:
+    assert _parse_literal("'hello'") == "hello"
+    assert _parse_literal("'it''s'") == "it's"
+
+
+def test_parse_literal_bytes() -> None:
+    assert _parse_literal("X'deadbeef'") == bytes.fromhex("deadbeef")
+
+
+# ---------------------------------------------------------------------------
+# Helper unit tests: _parse_one_column
+# ---------------------------------------------------------------------------
+
+
+def test_parse_one_column_simple() -> None:
+    col = _parse_one_column("id INTEGER PRIMARY KEY")
+    assert col is not None
+    assert col.name == "id"
+    assert col.type_name == "INTEGER"
+    assert col.primary_key is True
+
+
+def test_parse_one_column_not_null() -> None:
+    col = _parse_one_column("name TEXT NOT NULL")
+    assert col is not None
+    assert col.not_null is True
+
+
+def test_parse_one_column_unique() -> None:
+    col = _parse_one_column("email TEXT UNIQUE")
+    assert col is not None
+    assert col.unique is True
+
+
+def test_parse_one_column_default() -> None:
+    col = _parse_one_column("score INTEGER DEFAULT 7")
+    assert col is not None
+    assert col.default == 7
+
+
+def test_parse_one_column_table_constraint_skipped() -> None:
+    """Table-level PRIMARY KEY(…) constraints return None."""
+    assert _parse_one_column("PRIMARY KEY(id)") is None
+    assert _parse_one_column("UNIQUE(email)") is None
+
+
+def test_parse_one_column_too_short() -> None:
+    assert _parse_one_column("id") is None
+    assert _parse_one_column("") is None
+
+
+# ---------------------------------------------------------------------------
+# Helper unit tests: _sql_to_columns
+# ---------------------------------------------------------------------------
+
+
+def test_sql_to_columns_roundtrip() -> None:
+    """_sql_to_columns(_columns_to_sql(t, cols)) == cols."""
+    original = [
+        ColumnDef(name="id", type_name="INTEGER", primary_key=True),
+        ColumnDef(name="name", type_name="TEXT", not_null=True),
+        ColumnDef(name="score", type_name="INTEGER", default=0),
+        ColumnDef(name="email", type_name="TEXT", unique=True),
+    ]
+    sql = _columns_to_sql("t", original)
+    parsed = _sql_to_columns(sql)
+    assert [c.name for c in parsed] == [c.name for c in original]
+    assert [c.type_name for c in parsed] == [c.type_name for c in original]
+    assert [c.primary_key for c in parsed] == [c.primary_key for c in original]
+    assert [c.not_null for c in parsed] == [c.not_null for c in original]
+    assert [c.unique for c in parsed] == [c.unique for c in original]
+    assert [c.default for c in parsed] == [c.default for c in original]
+
+
+def test_sql_to_columns_no_parens() -> None:
+    with pytest.raises(ValueError):
+        _sql_to_columns("CREATE TABLE t")
+
+
+# ---------------------------------------------------------------------------
+# Helper unit tests: _is_ipk
+# ---------------------------------------------------------------------------
+
+
+def test_is_ipk_true() -> None:
+    assert _is_ipk(ColumnDef(name="id", type_name="INTEGER", primary_key=True))
+    assert _is_ipk(ColumnDef(name="id", type_name="int", primary_key=True))
+    assert _is_ipk(ColumnDef(name="id", type_name="INT", primary_key=True))
+
+
+def test_is_ipk_false_not_pk() -> None:
+    assert not _is_ipk(ColumnDef(name="id", type_name="INTEGER"))
+
+
+def test_is_ipk_false_text_type() -> None:
+    assert not _is_ipk(ColumnDef(name="id", type_name="TEXT", primary_key=True))
+
+
+# ---------------------------------------------------------------------------
+# Helper unit tests: _encode_row / _decode_row
+# ---------------------------------------------------------------------------
+
+
+def test_encode_decode_round_trip() -> None:
+    """_decode_row(_encode_row(rowid, row, cols), cols) == row."""
+    cols = [
+        ColumnDef(name="id", type_name="INTEGER", primary_key=True),
+        ColumnDef(name="name", type_name="TEXT"),
+        ColumnDef(name="age", type_name="INTEGER"),
+    ]
+    row = {"id": 42, "name": "alice", "age": 30}
+    payload = _encode_row(42, row, cols)
+    decoded = _decode_row(42, payload, cols)
+    assert decoded == row
+
+
+def test_encode_skips_ipk() -> None:
+    """IPK column is NOT present in the encoded payload."""
+    cols = [
+        ColumnDef(name="id", type_name="INTEGER", primary_key=True),
+        ColumnDef(name="x", type_name="TEXT"),
+    ]
+    row = {"id": 5, "x": "hi"}
+    payload = _encode_row(5, row, cols)
+    # Payload should only contain the 'x' column — one value.
+    values, _ = record.decode(payload)
+    assert len(values) == 1
+    assert values[0] == "hi"
+
+
+def test_decode_injects_rowid_for_ipk() -> None:
+    """IPK column's value comes from rowid, not the record payload."""
+    cols = [
+        ColumnDef(name="id", type_name="INTEGER", primary_key=True),
+        ColumnDef(name="x", type_name="TEXT"),
+    ]
+    # Payload has only 'x'.
+    payload = record.encode(["world"])
+    decoded = _decode_row(99, payload, cols)
+    assert decoded["id"] == 99
+    assert decoded["x"] == "world"
+
+
+# ---------------------------------------------------------------------------
+# Helper unit tests: _apply_defaults
+# ---------------------------------------------------------------------------
+
+
+def test_apply_defaults_fills_missing() -> None:
+    cols = [
+        ColumnDef(name="id", type_name="INTEGER", primary_key=True),
+        ColumnDef(name="flag", type_name="INTEGER", default=7),
+    ]
+    row = {"id": 1}
+    result = _apply_defaults(row, cols)
+    assert result["flag"] == 7
+
+
+def test_apply_defaults_absent_no_default_is_null() -> None:
+    cols = [
+        ColumnDef(name="id", type_name="INTEGER", primary_key=True),
+        ColumnDef(name="x", type_name="TEXT"),  # no default
+    ]
+    row = {"id": 1}
+    result = _apply_defaults(row, cols)
+    assert result["x"] is None
+
+
+def test_apply_defaults_existing_value_not_overwritten() -> None:
+    cols = [
+        ColumnDef(name="id", type_name="INTEGER", primary_key=True),
+        ColumnDef(name="flag", type_name="INTEGER", default=7),
+    ]
+    row = {"id": 1, "flag": 99}
+    result = _apply_defaults(row, cols)
+    assert result["flag"] == 99
+
+
+# ---------------------------------------------------------------------------
+# Helper unit tests: _check_not_null
+# ---------------------------------------------------------------------------
+
+
+def test_check_not_null_raises_on_null() -> None:
+    cols = [ColumnDef(name="name", type_name="TEXT", not_null=True)]
+    with pytest.raises(ConstraintViolation):
+        _check_not_null("t", {"name": None}, cols)
+
+
+def test_check_not_null_ok_with_value() -> None:
+    cols = [ColumnDef(name="name", type_name="TEXT", not_null=True)]
+    _check_not_null("t", {"name": "alice"}, cols)  # should not raise
+
+
+def test_check_not_null_ipk_implied() -> None:
+    """INTEGER PRIMARY KEY implies NOT NULL."""
+    cols = [ColumnDef(name="id", type_name="INTEGER", primary_key=True)]
+    with pytest.raises(ConstraintViolation):
+        _check_not_null("t", {"id": None}, cols)
+
+
+# ---------------------------------------------------------------------------
+# Helper unit tests: _find_max_rowid / _choose_rowid
+# ---------------------------------------------------------------------------
+
+
+def test_find_max_rowid_empty(tmp_path: Path) -> None:
+    path = str(tmp_path / "empty.db")
+    with Pager.create(path) as pager:
+        initialize_new_database(pager)
+        tree = BTree.create(pager)
+        assert _find_max_rowid(tree) == 0
+
+
+def test_find_max_rowid_with_rows(tmp_path: Path) -> None:
+    path = str(tmp_path / "max.db")
+    with Pager.create(path) as pager:
+        initialize_new_database(pager)
+        tree = BTree.create(pager)
+        for rid in [3, 1, 7, 2]:
+            tree.insert(rid, record.encode([rid]))
+        assert _find_max_rowid(tree) == 7
+
+
+def test_choose_rowid_from_ipk(tmp_path: Path) -> None:
+    """When the row supplies an IPK value, it IS the rowid."""
+    cols = [ColumnDef(name="id", type_name="INTEGER", primary_key=True)]
+    path = str(tmp_path / "ipk.db")
+    with Pager.create(path) as pager:
+        initialize_new_database(pager)
+        tree = BTree.create(pager)
+        rowid = _choose_rowid({"id": 42}, cols, tree)
+        assert rowid == 42
+
+
+def test_choose_rowid_auto_assign(tmp_path: Path) -> None:
+    """Without an IPK, rowid = max_existing + 1."""
+    cols = [ColumnDef(name="x", type_name="TEXT")]
+    path = str(tmp_path / "auto.db")
+    with Pager.create(path) as pager:
+        initialize_new_database(pager)
+        tree = BTree.create(pager)
+        tree.insert(3, record.encode(["three"]))
+        rowid = _choose_rowid({"x": "four"}, cols, tree)
+        assert rowid == 4


### PR DESCRIPTION
## Summary

- **`SqliteFileBackend`** — implements the full `sql_backend.Backend` interface against real on-disk SQLite files. Opens existing `.db` files or creates new ones. Files are byte-compatible with `sqlite3` CLI output.
- **All four `sql_backend.conformance` tiers pass**: `run_required`, `run_read_write`, `run_ddl`, `run_transaction`.
- **67 new tests** covering conformance, file persistence, transaction semantics, constraints, DDL edge cases, large tables (500 rows, exercises B-tree splits), and overflow rows (6 KB).
- **Dependencies wired**: `pyproject.toml` adds `coding-adventures-sql-backend`; `BUILD` installs it.
- **431 total tests, 96% coverage**.
- Security review: PASSED — no vulnerabilities found.

### Key design decisions

- `INTEGER PRIMARY KEY` columns are rowid aliases: skipped in record payload, injected from rowid on decode.
- SQL round-trip (`_columns_to_sql` ↔ `_sql_to_columns`) uses a minimal regex tokenizer — no dependency on the sql-parser package.
- `rollback()` reattaches `Schema` after discarding dirty pages so post-rollback reads see committed state.
- `_BTreeCursor` satisfies both `RowIterator` and `Cursor` protocols via a lazy `BTree.scan()` generator.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `pytest tests/` — 431 passed, 96% coverage
- [x] All four conformance tiers pass
- [x] File persistence: data survives `close()` + reopen
- [x] Rollback semantics verified
- [x] Security review passed (1 round)

🤖 Generated with [Claude Code](https://claude.com/claude-code)