### PR TITLE
feat(oct): add oct.tokens, oct.grammar, oct-lexer, oct-parser

### DIFF
--- a/code/grammars/oct.grammar
+++ b/code/grammars/oct.grammar
@@ -1,0 +1,380 @@
+# Parser grammar for Oct
+# @version 1
+#
+# Oct is a small, statically-typed, 8-bit systems programming language designed to
+# compile to the Intel 8008 microprocessor (1972). This grammar defines the syntax
+# rules that the parser reads after the lexer has produced a token stream from
+# oct.tokens.
+#
+# NOTATION (repo standard):
+#   UPPERCASE    token kinds from oct.tokens (operators, literals)
+#   "keyword"    quoted keyword literals (match token.value for keyword tokens)
+#   lowercase    grammar rules (non-terminals, defined below)
+#   |            alternation (or)
+#   { x }        zero or more repetitions of x
+#   [ x ]        optional (zero or one occurrence of x)
+#   ( x )        grouping
+#   ;            rule terminator
+#
+# TOKEN MATCHING RULES:
+#   - UPPERCASE names match by token type (EQ_EQ, NEQ, LEQ, …)
+#   - Quoted literals ("fn", "let", "if", …) match keyword token values
+#   - NAME matches identifier tokens (variables, function names)
+#   - INT_LIT, HEX_LIT, BIN_LIT match their respective literal tokens
+#
+# ENTRY POINT: program
+#
+# KEY DESIGN DECISIONS (documented inline throughout the grammar):
+#   - Intrinsics (in, out, adc, …) have dedicated grammar rules in primary,
+#     listed before call_expr and NAME so the keyword tokens are consumed
+#   - Expression precedence: logical < equality < relational < additive < bitwise < unary
+#   - return statement allows optional expression for void functions
+#   - loop and while are distinct statement kinds (loop has no condition)
+#   - Types (u8, bool) are NAME tokens, not keywords, recognised by value
+
+# ---------------------------------------------------------------------------
+# Top-level structure
+# ---------------------------------------------------------------------------
+
+# An Oct program is a sequence of top-level declarations.
+# There is no module wrapper — the entry point is a function named "main"
+# found by convention. Having only top-level declarations (no top-level
+# statements) keeps the compilation model simple: declarations are collected
+# first, then code-generated.
+#
+# Unlike Nib, Oct has no "const" declarations — compile-time constants are
+# just literals in Oct v1. The two top-level forms are static variables
+# (global memory) and function definitions.
+program       = { top_decl } ;
+
+# Top-level declarations: static (memory-mapped) variables and function
+# definitions. These are the only things allowed at file scope in Oct v1.
+top_decl      = static_decl
+              | fn_decl
+              ;
+
+# ---------------------------------------------------------------------------
+# Static variable declarations
+# ---------------------------------------------------------------------------
+
+# Static variable. Allocates one byte in the 8008's data RAM segment
+# (addresses 0x2000–0x3FFF in the OCT01 memory map). Accessible from any
+# function. Initial value must be a literal (0–255); expressions are not
+# allowed in static initializers in v1 because initialization runs before
+# main() and the 8008 has no easy way to run arbitrary code at startup.
+#
+# Example:
+#   static counter: u8 = 0;
+#   static flag: bool = false;
+static_decl   = "static" NAME COLON type EQ expr SEMICOLON ;
+
+# ---------------------------------------------------------------------------
+# Function declarations
+# ---------------------------------------------------------------------------
+
+# Function declaration. Return type annotation is optional — omitting it
+# declares a void function (no return value).
+#
+# Parameters occupy physical 8008 registers in order: B, C, D, E.
+# At most 4 parameters are allowed (one per available register).
+# Each parameter counts against the 4-local limit for the function.
+#
+# Examples:
+#   fn main() { … }                         void, no parameters
+#   fn clamp(val: u8, limit: u8) -> u8 { … } returns u8, two params
+#   fn tick() { … }                          void helper, no params
+#
+# The ARROW token (->) precedes the return type when present.
+fn_decl       = "fn" NAME LPAREN [ param_list ] RPAREN [ ARROW type ] block ;
+
+# A non-empty parameter list: one or more params separated by commas.
+# The maximum is 4 (limited by the 8008's general-purpose register file).
+param_list    = param { COMMA param } ;
+
+# A single parameter: name followed by colon and type annotation.
+# Example: x: u8
+param         = NAME COLON type ;
+
+# ---------------------------------------------------------------------------
+# Block and statements
+# ---------------------------------------------------------------------------
+
+# A block is a brace-enclosed sequence of statements.
+# All function bodies, if-branches, else-branches, while-bodies, and
+# loop-bodies must be full blocks — single-statement shortcuts are not
+# allowed. This eliminates the dangling-else ambiguity at the grammar level.
+block         = LBRACE { stmt } RBRACE ;
+
+# A statement is one of eight forms.
+# Ordering matters for parsing: let_stmt and static_decl start with unique
+# keywords; assign_stmt and expr_stmt both start with NAME or a keyword (for
+# intrinsic calls). The parser distinguishes them by lookahead:
+#   - NAME followed by EQ → assign_stmt
+#   - anything else starting with an expression → expr_stmt
+#
+# Note: static_decl is allowed inside functions in the grammar (matching Nib's
+# approach); the type-checker restricts static declarations to file scope.
+stmt          = let_stmt
+              | static_decl
+              | assign_stmt
+              | return_stmt
+              | if_stmt
+              | while_stmt
+              | loop_stmt
+              | break_stmt
+              | expr_stmt
+              ;
+
+# Local variable declaration. Binds a name to a physical 8008 register for
+# the lifetime of the enclosing function. The type annotation is mandatory —
+# Oct has no type inference.
+#
+# At most 4 locals (including parameters) may be live in any function.
+# Register exhaustion (>4 locals) is a compile-time error, not a runtime one:
+#   error: register exhaustion — function 'f' needs 5 locals but only B,C,D,E available
+#
+# Example:
+#   let x: u8 = 0;
+#   let flag: bool = carry();
+let_stmt      = "let" NAME COLON type EQ expr SEMICOLON ;
+
+# Assignment to an existing variable (local or static).
+# Simple assignment only — no compound operators (+=, -=) in v1.
+# The assigned name must already be in scope (no re-declaration).
+#
+# Example:
+#   x = x + 1;
+#   counter = 0;
+assign_stmt   = NAME EQ expr SEMICOLON ;
+
+# Return from a function. Non-void functions must provide an expression;
+# void functions use a bare return. At the top level of main(), the compiler
+# substitutes HALT for RET.
+#
+# Examples:
+#   return result;   // non-void
+#   return;          // void (bare return)
+return_stmt   = "return" [ expr ] SEMICOLON ;
+
+# Conditional statement. The condition must be of type bool.
+# Both branches are full blocks — no single-statement shorthand.
+# The else branch is optional; an absent else has no effect.
+#
+# Examples:
+#   if flag { out(1, 0xFF); }
+#   if x > limit { x = limit; } else { x = x + 1; }
+if_stmt       = "if" expr block [ "else" block ] ;
+
+# While loop. Repeats while the condition is true.
+# Condition is checked at the TOP of each iteration (pre-condition loop),
+# unlike the 8008's DJNZ which checks at the bottom.
+#
+# Example:
+#   while n != 0 { n = n - 1; }
+while_stmt    = "while" expr block ;
+
+# Infinite loop. Runs forever until a break statement exits it.
+# Useful for event-driven programs that poll I/O ports in a tight loop.
+#
+# Example:
+#   loop { let b: u8 = in(0); out(8, b); }
+loop_stmt     = "loop" block ;
+
+# Break out of the innermost while or loop. No labeled breaks in v1.
+# A break outside a loop is a compile-time error.
+break_stmt    = "break" SEMICOLON ;
+
+# Expression statement: an expression followed by a semicolon.
+# Used to call functions (including intrinsics like out()) for side effects.
+# The type-checker allows any expression here but warns if the result is
+# discarded from a pure expression (implementation detail: the IR compiler
+# simply does not emit a store for the discarded result).
+#
+# Example:
+#   out(1, result);   // intrinsic call as statement
+#   tick();           // function call as statement
+expr_stmt     = expr SEMICOLON ;
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+# Oct's type system has exactly two value types in v1:
+#
+#   u8   — Unsigned 8-bit integer. Values 0–255.
+#          The native ALU word of the Intel 8008. All arithmetic wraps modulo
+#          256 unless the program explicitly checks carry().
+#          Stored in one of the 8008's general-purpose registers (B, C, D, E)
+#          for locals, or one byte of RAM for statics.
+#
+#   bool — Boolean. true (1) or false (0).
+#          Stored as u8 under the hood — the 8008 has no single-bit type.
+#          A bool may be used wherever u8 is expected (implicit coercion), but
+#          a u8 may not be used where bool is expected without an explicit
+#          comparison.
+#
+# WHY NO SIGNED INTEGERS?
+# The 8008's ALU works on unsigned bytes. Two's complement arithmetic is
+# possible but requires manual carry/borrow tracking. Oct v1 keeps everything
+# unsigned and exposes carry() and sbb() for programs that need signed
+# behaviour.
+#
+# WHY NO u16?
+# The 8008 has no 16-bit registers. 16-bit arithmetic requires two bytes stored
+# in two separate registers or memory cells, with explicit carry propagation.
+# Oct v2 (targeting the 8080, which has 16-bit register pairs) will add u16.
+#
+# Type names are NAME tokens with value "u8" or "bool", not keywords.
+# This keeps the keyword set small and lets the type-checker validate the
+# type annotation value at semantic analysis time.
+type          = NAME ;
+
+# ---------------------------------------------------------------------------
+# Expressions — operator precedence hierarchy
+# ---------------------------------------------------------------------------
+#
+# Precedence levels (lowest to highest):
+#
+#   Level 1 — Logical OR   (||)        or_expr
+#   Level 2 — Logical AND  (&&)        and_expr
+#   Level 3 — Equality     (==, !=)    eq_expr
+#   Level 4 — Comparison   (<,>,<=,>=) cmp_expr
+#   Level 5 — Additive     (+, -)      add_expr
+#   Level 6 — Bitwise      (&, |, ^)   bitwise_expr
+#   Level 7 — Unary        (!, ~)      unary_expr
+#   Level 8 — Primary                  primary
+#
+# WHY THIS ORDERING?
+# Levels 1–4 and 7–8 follow C/Rust/Go conventions — matching programmer
+# expectations coming from any C-family language.
+#
+# The interesting decision is levels 5–6:
+#
+#   Bitwise ABOVE additive — same as Java and Rust.
+#   In C, bitwise is BELOW equality, causing the famous trap:
+#     if (x & MASK == 0) { … }   // intended: (x & MASK) == 0
+#     // but actually: x & (MASK == 0) because == binds tighter than &
+#   By putting bitwise above additive we avoid this. The tradeoff is that
+#   `a + b & c` parses as `a + (b & c)` — but on 8-bit hardware where bit
+#   manipulation and byte arithmetic are equally common, this ordering is more
+#   natural. Parentheses resolve any ambiguity explicitly.
+#
+# All binary operators at the same level are LEFT-ASSOCIATIVE:
+#   a + b + c  =  (a + b) + c
+#   a & b & c  =  (a & b) & c
+#   a == b == c is syntactically allowed; the type checker may warn about
+#   chained comparisons producing unexpected bool-compared-to-bool results.
+
+# Entry point for all expression contexts.
+expr          = or_expr ;
+
+# Logical OR: a || b. Short-circuits — if a is true, b is not evaluated.
+# The 8008 has no single logical-OR instruction; the backend implements this
+# with a conditional branch: if a is non-zero, skip evaluation of b.
+or_expr       = and_expr { LOR and_expr } ;
+
+# Logical AND: a && b. Short-circuits — if a is false, b is not evaluated.
+# Backend: conditional branch on a, evaluate b only if a is non-zero.
+and_expr      = eq_expr { LAND eq_expr } ;
+
+# Equality: == and !=.
+# Both operands must have the same type. Result type is always bool.
+# On the 8008, equality is implemented with CMP r then conditional branch to
+# materialise 0 or 1 in a register.
+# Example: n != 0  →  CMP_NE  →  true/false in a register
+eq_expr       = cmp_expr { ( EQ_EQ | NEQ ) cmp_expr } ;
+
+# Relational comparison: <, >, <=, >=.
+# Operands must be u8 (comparisons are unsigned). Result type is always bool.
+# The 8008 implements these via CMP r followed by conditional branches
+# (JC for carry, JNC for no-carry, etc.) to materialise 0/1.
+cmp_expr      = add_expr { ( LT | GT | LEQ | GEQ ) add_expr } ;
+
+# Additive: + and -.
+# Both wrap modulo 256 on u8 operands. The carry flag from addition can be
+# read with carry(); the borrow flag from subtraction likewise.
+# Maps to 8008 ADD r / SUB r instructions via the IR ADD / SUB opcodes.
+add_expr      = bitwise_expr { ( PLUS | MINUS ) bitwise_expr } ;
+
+# Bitwise: &, |, ^.
+# Maps to 8008 ANA r, ORA r, XRA r instructions via IR AND, OR, XOR opcodes.
+# Note: ~ (bitwise NOT) is a unary operator at the next level up, not binary.
+bitwise_expr  = unary_expr { ( AMP | PIPE | CARET ) unary_expr } ;
+
+# Unary operators: ! (logical NOT) and ~ (bitwise NOT).
+# Both are right-associative: ~~x = ~(~x), !!x = !(!x).
+# The base case delegates to primary.
+#
+# ~ maps to the IR NOT opcode (lowered to XRI 0xFF on the 8008).
+# ! maps to a compare-to-zero sequence.
+unary_expr    = ( BANG | TILDE ) unary_expr
+              | primary
+              ;
+
+# Primary expressions: leaves of the expression tree.
+# Listing order matters for first-match parsing:
+#   1. Intrinsic calls with keyword tokens must come BEFORE call_expr and NAME
+#      (an intrinsic call starts with a keyword token like "in" or "carry";
+#      if NAME were tried first, the keyword token would not match NAME)
+#   2. call_expr comes BEFORE NAME (a call starts with NAME+"("; if NAME were
+#      tried first, the function name would be consumed as a variable reference
+#      before the parser sees the opening parenthesis)
+#   3. Literals and parenthesised expressions last
+primary       = intrinsic_call
+              | call_expr
+              | INT_LIT
+              | HEX_LIT
+              | BIN_LIT
+              | "true"
+              | "false"
+              | NAME
+              | LPAREN expr RPAREN
+              ;
+
+# ---------------------------------------------------------------------------
+# Function calls (user-defined)
+# ---------------------------------------------------------------------------
+
+# User-defined function call: NAME followed by a parenthesised argument list.
+# The argument list is optional — zero-argument calls look like: tick().
+# Must come before NAME in primary (see note above).
+call_expr     = NAME LPAREN [ arg_list ] RPAREN ;
+
+# Argument list: one or more expressions separated by commas.
+arg_list      = expr { COMMA expr } ;
+
+# ---------------------------------------------------------------------------
+# Intrinsic calls
+# ---------------------------------------------------------------------------
+#
+# Intrinsics are first-class language constructs, not library functions. They
+# begin with keyword tokens (not NAME tokens), so they cannot be parsed as
+# call_expr (which requires a NAME). Each intrinsic has a specific arity:
+#
+#   in(PORT)         → 1 expr argument (PORT: compile-time constant 0–7)
+#   out(PORT, val)   → 2 expr arguments (PORT: constant 0–23; val: u8)
+#   adc(a, b)        → 2 expr arguments
+#   sbb(a, b)        → 2 expr arguments
+#   rlc(a)           → 1 expr argument
+#   rrc(a)           → 1 expr argument
+#   ral(a)           → 1 expr argument
+#   rar(a)           → 1 expr argument
+#   carry()          → 0 arguments
+#   parity(a)        → 1 expr argument
+#
+# The grammar uses the same parenthesised-argument syntax as call_expr, with
+# keyword tokens in the function-name position. The type-checker validates
+# argument counts and types, and the IR compiler lowers each intrinsic to its
+# SYSCALL number (see OCT00-oct-language.md, §IR Mapping Summary).
+
+intrinsic_call = "in"     LPAREN expr RPAREN
+               | "out"    LPAREN expr COMMA expr RPAREN
+               | "adc"    LPAREN expr COMMA expr RPAREN
+               | "sbb"    LPAREN expr COMMA expr RPAREN
+               | "rlc"    LPAREN expr RPAREN
+               | "rrc"    LPAREN expr RPAREN
+               | "ral"    LPAREN expr RPAREN
+               | "rar"    LPAREN expr RPAREN
+               | "carry"  LPAREN RPAREN
+               | "parity" LPAREN expr RPAREN
+               ;

--- a/code/grammars/oct.tokens
+++ b/code/grammars/oct.tokens
@@ -1,0 +1,348 @@
+# Token definitions for Oct
+# @version 1
+#
+# Oct is a small, statically-typed, 8-bit systems programming language designed to
+# compile to the Intel 8008 microprocessor (1972). The name comes from "octet" —
+# the networking/communications term for exactly 8 bits, the native word size of
+# the 8008's ALU.
+#
+# WHY A NEW LANGUAGE FOR THE 8008?
+# The Intel 8008 (1972) was Intel's first 8-bit microprocessor, predating the 8080.
+# It has 7 general-purpose registers (A, B, C, D, E, H, L), a 14-bit address space
+# (16 KB), an 8-level push-down call stack (7 levels usable), and separate I/O port
+# spaces (8 input ports, 24 output ports). Writing 8008 assembly by hand is tedious
+# and error-prone. Oct gives us a higher-level notation with static safety guarantees
+# while remaining faithful to the hardware.
+#
+# Oct is the sister language to Nib (which targets the 4-bit Intel 4004). Where Nib
+# exposes u4 types and 4004-specific wrapping/saturating operators, Oct exposes u8
+# types and 8008-specific intrinsics: port I/O, carry arithmetic, and byte rotations.
+#
+# SAFETY MODEL
+# Oct enforces a strict subset of operations suited to the 8008:
+#   - Types are u8 (unsigned 8-bit) or bool — no larger integers
+#   - At most 4 local variables per function (registers B, C, D, E)
+#   - Call depth statically bounded to 7 (8008 stack minus current frame)
+#   - No recursion (call graph must be acyclic)
+#   - Port numbers are compile-time constants (embedded in opcode)
+#   - Integer literals 0–255 only; literals outside this range are errors
+#
+# DESIGN PHILOSOPHY
+# Token ordering follows first-match-wins semantics. The lexer scans the input
+# character by character, trying each pattern in the order they appear in this file.
+# When two patterns could both match at the current position, the one listed first
+# wins. This is why multi-character operators appear before single-character ones,
+# and why BIN_LIT and HEX_LIT appear before INT_LIT.
+#
+# Key ordering rules:
+#   ==  must come before  =   (EQ_EQ before EQ)
+#   !=  must come before  !   (NEQ before BANG)
+#   <=  must come before  <   (LEQ before LT)
+#   >=  must come before  >   (GEQ before GT)
+#   &&  must come before  &   (LAND before AMP)
+#   ||  must come before  |   (LOR before PIPE)
+#   ->  must come before  -   (ARROW before MINUS)
+#   BIN_LIT must come before INT_LIT (0b101 must not lex as INT_LIT("0") then NAME("b101"))
+#   HEX_LIT must come before INT_LIT (0xFF must not lex as INT_LIT("0") then NAME("xFF"))
+
+# ---------------------------------------------------------------------------
+# Multi-character operators — must appear before single-character versions
+# ---------------------------------------------------------------------------
+
+# Equality comparison: ==
+# Oct uses = for assignment and == for equality (C/Rust/Go convention).
+# The double-equals avoids the classic C bug of writing = when == is intended.
+# Must come before EQ so "==" is not lexed as two EQ tokens.
+EQ_EQ       = "=="
+
+# Not-equal comparison: !=
+# Standard C-family syntax. The ! prefix is also used as logical NOT, so !=
+# must be tokenized atomically. Must come before BANG so "!=" is one token.
+NEQ         = "!="
+
+# Less-or-equal: <=
+# Must come before LT so "<=" is not lexed as LT EQ.
+LEQ         = "<="
+
+# Greater-or-equal: >=
+# Must come before GT so ">=" is not lexed as GT EQ.
+GEQ         = ">="
+
+# Logical AND: &&
+# Short-circuit: if the left operand is false, right is not evaluated.
+# Double-ampersand distinguishes logical AND (&&) from bitwise AND (&).
+# The 8008 has a bitwise AND instruction (ANA r), so this distinction matters.
+# Must come before AMP so "&&" is not lexed as two AMP tokens.
+LAND        = "&&"
+
+# Logical OR: ||
+# Short-circuit: if the left operand is true, right is not evaluated.
+# The 8008 has a bitwise OR instruction (ORA r), so || vs | matters.
+# Must come before PIPE so "||" is not lexed as two PIPE tokens.
+LOR         = "||"
+
+# Function return type arrow: ->
+# Function signatures look like: fn add(a: u8, b: u8) -> u8 { ... }
+# Arrow notation (borrowed from Rust) reads as "produces".
+# Must come before MINUS so "->" is not lexed as MINUS GT.
+ARROW       = "->"
+
+# ---------------------------------------------------------------------------
+# Single-character arithmetic operators
+# ---------------------------------------------------------------------------
+
+# Addition. On u8 operands, wraps modulo 256.
+# Maps to the 8008's ADD r instruction (add register to accumulator).
+# Example: let sum: u8 = x + y;
+PLUS        = "+"
+
+# Subtraction. Wraps modulo 256 (borrow is tracked via carry flag).
+# Maps to the 8008's SUB r instruction.
+# Example: let diff: u8 = x - y;
+MINUS       = "-"
+
+# ---------------------------------------------------------------------------
+# Single-character bitwise operators
+# ---------------------------------------------------------------------------
+
+# Bitwise AND. Maps to the 8008's ANA r instruction.
+# Useful for masking: x & 0x0F extracts the low nibble of a byte.
+# AMP is the single-& version; LAND (&&) is logical and.
+AMP         = "&"
+
+# Bitwise OR. Maps to the 8008's ORA r instruction.
+# Sets specific bits: x | 0x80 sets the high bit.
+# PIPE is single-|; LOR (||) is logical or.
+PIPE        = "|"
+
+# Bitwise XOR. Maps to the 8008's XRA r instruction.
+# Also used to zero-test (XOR a register with itself clears it and sets Z).
+# Flip all bits: x ^ 0xFF is the canonical NOT-a-byte idiom for the 8008.
+CARET       = "^"
+
+# Bitwise NOT (complement). Flips every bit in the operand.
+# On the 8008, lowered to XRI 0xFF (XOR-immediate with 0xFF).
+# Example: ~x flips all 8 bits. ~0b00001111 = 0b11110000.
+TILDE       = "~"
+
+# ---------------------------------------------------------------------------
+# Single-character comparison and logical operators
+# ---------------------------------------------------------------------------
+
+# Logical NOT (boolean negation). Only valid on bool expressions.
+# !true = false, !false = true.
+# Distinct from TILDE (~) which is bitwise NOT on u8 values.
+BANG        = "!"
+
+# Less-than comparison (unsigned). Uses CMP + branch on 8008.
+LT          = "<"
+
+# Greater-than comparison (unsigned).
+GT          = ">"
+
+# ---------------------------------------------------------------------------
+# Assignment
+# ---------------------------------------------------------------------------
+
+# Assignment in let/static declarations and assignment statements.
+# Example: let x: u8 = 5;  or  x = x + 1;
+EQ          = "="
+
+# ---------------------------------------------------------------------------
+# Delimiters
+# ---------------------------------------------------------------------------
+
+# Block delimiters for function bodies, if-branches, while-bodies, loop-bodies.
+# Braces are required (no single-statement shorthand), eliminating dangling-else.
+LBRACE      = "{"
+RBRACE      = "}"
+
+# Grouping for expressions and argument/parameter lists.
+LPAREN      = "("
+RPAREN      = ")"
+
+# Type annotation separator: let x: u8 = ...
+# Also used in parameter lists: fn add(a: u8, b: u8) -> u8
+COLON       = ":"
+
+# Statement terminator. Every statement ends with a semicolon.
+# Explicit semicolons keep the grammar unambiguous without JavaScript-style
+# automatic semicolon insertion rules.
+SEMICOLON   = ";"
+
+# Argument/parameter separator.
+COMMA       = ","
+
+# ---------------------------------------------------------------------------
+# Literals
+# ---------------------------------------------------------------------------
+
+# Binary integer literal: 0b followed by one or more binary digits.
+# Examples: 0b00000000, 0b11111111, 0b10110011
+# WHY BIN FIRST: 0b101 must be lexed as one BIN_LIT token, not INT_LIT("0")
+# then NAME("b101"). Placing BIN_LIT before INT_LIT ensures the full binary
+# token is consumed before the decimal rule fires on the leading "0".
+# Binary literals are particularly useful for 8008 programming: bit masks,
+# flags, and port control bytes are much clearer in binary than decimal.
+BIN_LIT     = /0b[01]+/
+
+# Hexadecimal integer literal: 0x followed by one or more hex digits.
+# Examples: 0x00, 0xFF, 0x3A, 0xfe
+# WHY HEX BEFORE INT: same reason as BIN — 0xFF must not lex as INT("0")+"xFF".
+# Hex is natural for port addresses, bit masks, and ASCII codes.
+HEX_LIT     = /0x[0-9A-Fa-f]+/
+
+# Decimal integer literal: one or more decimal digits.
+# Must come after BIN_LIT and HEX_LIT. Examples: 0, 42, 255.
+# Valid u8 literals are 0–255. Out-of-range values are a compile-time error.
+INT_LIT     = /[0-9]+/
+
+# Identifier: letter or underscore, followed by letters, digits, or underscores.
+# Keywords are reclassified from NAME after a full-token match.
+# The token is named NAME so the GrammarLexer's keyword promotion logic fires:
+# it checks token_name == "NAME" && value in keyword_set.
+# Type names (u8, bool) are also NAME tokens, not keywords — they appear in
+# type annotation positions only and the parser distinguishes them by value.
+NAME        = /[a-zA-Z_][a-zA-Z0-9_]*/
+
+# ---------------------------------------------------------------------------
+# Keywords — reclassified from NAME after a full-token match
+# ---------------------------------------------------------------------------
+#
+# Case-sensitive: Oct uses lowercase-only keywords (matching Rust/Go convention).
+# Partial matches do NOT qualify: "while_count" is NAME, not keyword "while"
+# followed by NAME("_count"). The keyword match fires only on the complete token.
+#
+# Keyword groups:
+#
+#   Control flow:  fn, let, static, if, else, while, loop, break, return
+#   Literals:      true, false
+#   Intrinsics:    in, out, adc, sbb, rlc, rrc, ral, rar, carry, parity
+#
+# The intrinsics (in, out, adc, …) are keywords rather than identifiers so that
+# the type checker can reject re-use of intrinsic names as variable names without
+# any ambiguity. They are called with function-call syntax (e.g. in(0), adc(a, b))
+# and have dedicated grammar rules in oct.grammar.
+
+keywords:
+  # Function declaration. Defines a named function with optional parameters and
+  # an optional return type. Maps to a CALL/RET pair in the 8008 backend.
+  fn
+
+  # Local variable declaration. Binds a name to one of the 4 available registers
+  # (B, C, D, E). All 4 locals (including parameters) are live for the lifetime
+  # of the function. Register exhaustion (>4 locals) is a compile-time error.
+  let
+
+  # Static variable declaration. Allocates a byte in the data segment (RAM region
+  # 0x2000–0x3FFF on the 8008). Accessible from all functions. Initial value must
+  # be a literal (0–255).
+  static
+
+  # Conditional: if expr { ... } or if expr { ... } else { ... }
+  # Condition must be bool. Braces are required on both branches.
+  if
+
+  # Else branch of conditional.
+  else
+
+  # While loop: while expr { ... }
+  # Repeats while condition is true. Condition checked at the top of each iteration.
+  while
+
+  # Infinite loop: loop { ... }
+  # Runs forever until a break statement. Useful for event-driven programs that
+  # poll I/O ports continuously.
+  loop
+
+  # Break out of the innermost while or loop. No labeled breaks in v1.
+  break
+
+  # Return from a function. Void functions use bare "return;"; non-void functions
+  # use "return expr;". At the top level of main, compiles to HALT.
+  return
+
+  # Boolean literal true (encoded as 1).
+  true
+
+  # Boolean literal false (encoded as 0).
+  false
+
+  # ── Intrinsics ──────────────────────────────────────────────────────────────
+
+  # Read from input port: in(PORT) -> u8
+  # PORT must be a compile-time constant 0–7. The 8008 has 8 input ports wired
+  # directly to external hardware (keyboards, ADCs, sensors). Compiles to the
+  # 8008's INP p instruction (IN p in common mnemonics), which moves the port
+  # data to the accumulator.
+  in
+
+  # Write to output port: out(PORT, val)
+  # PORT must be a compile-time constant 0–23. The 8008 has 24 output ports
+  # wired to displays, DACs, LEDs, serial transmitters. Compiles to MOV A, Rval
+  # then OUT p (OUT p sends accumulator to port).
+  out
+
+  # Add with carry: adc(a, b) -> u8
+  # Computes a + b + carry_flag. The carry flag comes from the previous arithmetic
+  # operation. Used as the high-byte addition when implementing 16-bit math.
+  # Compiles to: MOV A, Ra; ADC Rb (add register to A plus carry).
+  adc
+
+  # Subtract with borrow: sbb(a, b) -> u8
+  # Computes a - b - carry_flag. Mirrors adc for subtraction.
+  # Compiles to: MOV A, Ra; SBB Rb (subtract register from A with borrow).
+  sbb
+
+  # Rotate Left Circular: rlc(a) -> u8
+  # Shifts a left by 1. Bit 7 wraps to bit 0 and also goes into carry.
+  #   CY ← bit7;  A ← (A << 1) | bit7
+  # Maps directly to the 8008's RLC instruction (one clock cycle).
+  rlc
+
+  # Rotate Right Circular: rrc(a) -> u8
+  # Shifts a right by 1. Bit 0 wraps to bit 7 and also goes into carry.
+  #   CY ← bit0;  A ← (A >> 1) | (bit0 << 7)
+  # Maps to the 8008's RRC instruction.
+  rrc
+
+  # Rotate Left through Carry (9-bit): ral(a) -> u8
+  # Rotates a and the carry flag together as a 9-bit value shifted left.
+  #   new_CY ← bit7;  A ← (A << 1) | old_CY
+  # The canonical instruction for "multiply by 2" or "shift high bit into carry".
+  # Maps to the 8008's RAL instruction.
+  ral
+
+  # Rotate Right through Carry (9-bit): rar(a) -> u8
+  # Mirrors ral for right rotation.
+  #   new_CY ← bit0;  A ← (old_CY << 7) | (A >> 1)
+  # Maps to the 8008's RAR instruction.
+  rar
+
+  # Read carry flag: carry() -> bool
+  # Returns true if the carry/borrow flag is set, false otherwise.
+  # Valid immediately after +, -, adc(), sbb(), or a rotation.
+  # The carry flag is clobbered by AND, OR, and XOR operations.
+  # Compiles to: MVI A, 0; ACI 0; MOV Rdst, A (ACI adds carry to immediate).
+  carry
+
+  # Read parity flag: parity(a) -> bool
+  # Returns true if a has even parity (an even number of 1-bits), false if odd.
+  # The 8008 computes the P (parity) flag in parallel with every ALU result.
+  # Compiles to: MOV A, Ra; ORA A (refreshes flags); conditional branch to
+  # materialise 0 or 1.
+  parity
+
+# ---------------------------------------------------------------------------
+# Skip patterns — consumed silently, no tokens emitted
+# ---------------------------------------------------------------------------
+
+skip:
+  # Whitespace is insignificant in Oct.
+  # Spaces, tabs, carriage returns, and newlines between tokens are ignored.
+  WHITESPACE    = /[ \t\r\n]+/
+
+  # Line comments start with // and extend to end of line.
+  # Block comments (/* ... */) are not supported in Oct v1.
+  # Example: // This is a comment.
+  LINE_COMMENT  = /\/\/[^\n]*/

--- a/code/packages/python/oct-lexer/BUILD
+++ b/code/packages/python/oct-lexer/BUILD
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../graph -e ../directed-graph -e ../grammar-tools -e ../lexer -e ../state-machine -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/oct-lexer/CHANGELOG.md
+++ b/code/packages/python/oct-lexer/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+## [0.1.0] - 2026-04-20
+
+### Added
+
+- Initial implementation of the Oct lexer — a thin wrapper around the generic
+  `GrammarLexer` that loads `code/grammars/oct.tokens`.
+- `create_oct_lexer(source)` — creates a `GrammarLexer` configured for Oct,
+  returning a lexer instance whose `.tokenize()` method produces the raw token
+  list.
+- `tokenize_oct(source)` — the main entry point; tokenizes Oct source text and
+  applies a post-processing pass that promotes `TokenType.KEYWORD` tokens to
+  use the keyword string as their type (e.g. `Token("fn", "fn")`), matching the
+  convention expected by `oct-parser` and downstream consumers.
+- `OCT_TOKENS_PATH` — the path constant pointing at `code/grammars/oct.tokens`,
+  resolved relative to the module file so the package works correctly regardless
+  of the current working directory.
+- Token definitions in `code/grammars/oct.tokens` (committed alongside this
+  package):
+  - Multi-character operators: `EQ_EQ` (`==`), `NEQ` (`!=`), `LEQ` (`<=`),
+    `GEQ` (`>=`), `LAND` (`&&`), `LOR` (`||`), `ARROW` (`->`)
+  - Single-character arithmetic: `PLUS` (`+`), `MINUS` (`-`)
+  - Single-character bitwise: `AMP` (`&`), `PIPE` (`|`), `CARET` (`^`),
+    `TILDE` (`~`), `BANG` (`!`), `LT` (`<`), `GT` (`>`)
+  - Assignment: `EQ` (`=`)
+  - Delimiters: `LBRACE`, `RBRACE`, `LPAREN`, `RPAREN`, `COLON`, `SEMICOLON`,
+    `COMMA`
+  - Literals: `BIN_LIT` (`0b…`), `HEX_LIT` (`0x…`), `INT_LIT` (decimal),
+    `NAME` (identifiers including type names `u8` and `bool`)
+  - Keywords: `fn`, `let`, `static`, `if`, `else`, `while`, `loop`, `break`,
+    `return`, `true`, `false`, `in`, `out`, `adc`, `sbb`, `rlc`, `rrc`,
+    `ral`, `rar`, `carry`, `parity`
+  - Skip patterns: `WHITESPACE`, `LINE_COMMENT` (`// …`)
+- Comprehensive test suite (`tests/test_oct_lexer.py`):
+  - `TestTokenizeOct` — 60 tests covering all token kinds, keyword promotion,
+    intrinsic keyword tokens, binary/hex/decimal literals, operator precedence
+    ordering, whitespace/comment skipping, multi-token expressions, and all
+    five complete Oct program examples from the OCT00 spec.

--- a/code/packages/python/oct-lexer/README.md
+++ b/code/packages/python/oct-lexer/README.md
@@ -1,0 +1,112 @@
+# oct-lexer
+
+Tokenizes **Oct** source text using the grammar-driven lexer — a thin wrapper around `GrammarLexer` that loads `oct.tokens`.
+
+**Oct** is a small, statically-typed, 8-bit systems programming language designed to compile to the Intel 8008 microprocessor (1972). The name comes from *octet* — the networking term for exactly 8 bits, the native word size of the 8008 ALU. Oct is the sister language to Nib (which targets the 4-bit Intel 4004).
+
+## Overview
+
+This package is part of the Oct compiler pipeline:
+
+```
+Oct source (.oct)
+    ↓  [oct-lexer]        tokenise
+    ↓  [oct-parser]       parse to AST
+    ↓  [oct-type-checker] type check
+    ↓  [oct-ir-compiler]  lower to compiler_ir
+    ↓  [ir-to-intel-8008-compiler] code generate
+    ↓  [intel-8008-assembler] assemble to binary
+    ↓  [intel-8008-packager]  produce Intel HEX
+```
+
+`oct-lexer` occupies the first stage. It converts raw Oct source text into a flat list of `Token` objects, which `oct-parser` consumes.
+
+## Usage
+
+```python
+from oct_lexer import tokenize_oct
+
+tokens = tokenize_oct('let x: u8 = 0xFF;')
+for tok in tokens:
+    print(tok.type, repr(tok.value))
+# let     'let'
+# NAME    'x'
+# COLON   ':'
+# NAME    'u8'
+# EQ      '='
+# HEX_LIT '0xFF'
+# SEMICOLON ';'
+# EOF     ''
+```
+
+For full control (e.g. to call `.tokenize()` yourself):
+
+```python
+from oct_lexer import create_oct_lexer
+
+lexer = create_oct_lexer('fn main() { }')
+tokens = lexer.tokenize()
+```
+
+## Token Set
+
+**Multi-character operators** (matched before single-character versions):
+
+| Token | Value | Meaning |
+|-------|-------|---------|
+| `EQ_EQ` | `==` | Equality |
+| `NEQ` | `!=` | Not-equal |
+| `LEQ` | `<=` | Less-or-equal |
+| `GEQ` | `>=` | Greater-or-equal |
+| `LAND` | `&&` | Logical AND |
+| `LOR` | `\|\|` | Logical OR |
+| `ARROW` | `->` | Return type separator |
+
+**Arithmetic & bitwise** (single-character):
+
+| Token | Value | 8008 instruction |
+|-------|-------|-----------------|
+| `PLUS` | `+` | ADD r |
+| `MINUS` | `-` | SUB r |
+| `AMP` | `&` | ANA r |
+| `PIPE` | `\|` | ORA r |
+| `CARET` | `^` | XRA r |
+| `TILDE` | `~` | XRI 0xFF |
+| `BANG` | `!` | (logical NOT) |
+
+**Literals**:
+
+| Token | Examples | Notes |
+|-------|---------|-------|
+| `BIN_LIT` | `0b00001111` | Must precede `INT_LIT` |
+| `HEX_LIT` | `0xFF` | Must precede `INT_LIT` |
+| `INT_LIT` | `42`, `255` | Decimal; valid range 0–255 |
+| `NAME` | `x`, `u8`, `bool` | Identifiers and type names |
+
+**Keywords** (promoted from `NAME`):
+
+- Control flow: `fn`, `let`, `static`, `if`, `else`, `while`, `loop`, `break`, `return`
+- Boolean literals: `true`, `false`
+- Intrinsics: `in`, `out`, `adc`, `sbb`, `rlc`, `rrc`, `ral`, `rar`, `carry`, `parity`
+
+**Skipped silently**: whitespace (spaces, tabs, `\r`, `\n`) and line comments (`// …`).
+
+## Intel 8008 Background
+
+The Intel 8008 (1972) was Intel's first commercial 8-bit microprocessor:
+
+- **8-bit accumulator** — values 0–255, arithmetic wraps modulo 256
+- **7 registers** — A (accumulator), B, C, D, E (GP), H:L (memory pointer pair)
+- **4 GP registers for locals** — B, C, D, E only; H:L reserved for memory addressing
+- **8-level push-down call stack** — 7 usable levels (one always occupied by the PC)
+- **16 KB address space** — 14-bit bus (0x0000–0x3FFF)
+- **8 input ports + 24 output ports** — port number encoded in instruction opcode
+- **4 flags** — CY (carry), Z (zero), S (sign), P (parity)
+
+Oct exposes the carry flag via `carry()`, `adc()`, `sbb()`, and the four rotation intrinsics `rlc()`, `rrc()`, `ral()`, `rar()` directly in the language.
+
+## Dependencies
+
+- `coding-adventures-lexer` — `GrammarLexer` engine
+- `coding-adventures-grammar-tools` — `parse_token_grammar`
+- `coding-adventures-directed-graph`, `coding-adventures-state-machine` — transitive deps of `lexer`

--- a/code/packages/python/oct-lexer/pyproject.toml
+++ b/code/packages/python/oct-lexer/pyproject.toml
@@ -1,0 +1,65 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-oct-lexer"
+version = "0.1.0"
+description = "Tokenizes Oct source text using the grammar-driven lexer — a thin wrapper that loads oct.tokens"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["oct", "intel8008", "lexer", "tokenizer", "grammar-driven", "compiler", "embedded", "education"]
+dependencies = [
+    "coding-adventures-directed-graph",
+    "coding-adventures-grammar-tools",
+    "coding-adventures-lexer",
+    "coding-adventures-state-machine",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Education",
+    "Topic :: Education",
+    "Topic :: Scientific/Engineering",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://github.com/adhithyan15/coding-adventures"
+Repository = "https://github.com/adhithyan15/coding-adventures"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/oct_lexer"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort (import sorting)
+    "UP",   # pyupgrade (modern Python syntax)
+    "B",    # bugbear (common bugs)
+    "SIM",  # simplify
+    "ANN",  # type annotation enforcement
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=oct_lexer --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.run]
+source = ["src/oct_lexer"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/packages/python/oct-lexer/src/oct_lexer/__init__.py
+++ b/code/packages/python/oct-lexer/src/oct_lexer/__init__.py
@@ -1,0 +1,44 @@
+"""Oct Lexer — tokenizes Oct source text using the grammar-driven approach.
+
+This package is a **thin wrapper** around the generic ``GrammarLexer``. It
+demonstrates the grammar-driven architecture applied to Oct — a safe, statically-
+typed toy language targeting the Intel 8008 (the world's first commercial 8-bit
+microprocessor, released by Intel in 1972).
+
+Oct (named after *octet*, the networking term for exactly 8 bits) targets the
+8008's distinctive hardware:
+
+- **8-bit words** — ``u8`` is the native ALU type, values 0–255
+- **7 usable registers** — A (accumulator), B, C, D, E (general-purpose), H:L (pointer)
+- **4 GP registers for locals** — B, C, D, E only; H:L are reserved for memory access
+- **8-level push-down stack** — 7 usable call levels (one always occupied by the PC)
+- **Port I/O** — 8 input ports (INP), 24 output ports (OUT) encoded in opcode
+- **Carry arithmetic** — CY flag exposed via adc(), sbb(), carry() intrinsics
+- **Byte rotations** — RLC, RRC, RAL, RAR exposed as rlc(), rrc(), ral(), rar()
+
+Oct is the sister language to Nib (which targets the 4-bit Intel 4004). Where
+Nib operates in nibbles, Oct operates in full bytes — the step up in word size
+that the 8008 brought over its predecessor.
+
+This package loads ``oct.tokens`` from the ``code/grammars/`` directory and
+uses the same ``GrammarLexer`` engine that powers the Nib, ALGOL 60, JSON,
+Python, and Starlark lexers. One lexer engine handles radically different
+languages — from 1960 ALGOL to a 2024 embedded toy language.
+
+Usage::
+
+    from oct_lexer import tokenize_oct
+
+    tokens = tokenize_oct('let x: u8 = 0xFF;')
+    for token in tokens:
+        print(token)
+"""
+
+from __future__ import annotations
+
+from oct_lexer.tokenizer import create_oct_lexer, tokenize_oct
+
+__all__ = [
+    "create_oct_lexer",
+    "tokenize_oct",
+]

--- a/code/packages/python/oct-lexer/src/oct_lexer/tokenizer.py
+++ b/code/packages/python/oct-lexer/src/oct_lexer/tokenizer.py
@@ -1,0 +1,298 @@
+"""Oct Lexer — tokenizes Oct source text using the grammar-driven approach.
+
+This module is a thin wrapper around the generic ``GrammarLexer``. It loads
+the ``oct.tokens`` file from the ``code/grammars/`` directory and creates a
+lexer configured for Oct tokenization.
+
+What Is Oct?
+-------------
+
+Oct is a safe, statically-typed toy language designed to compile to Intel 8008
+machine code. The name comes from *octet* — the networking/communications term
+for exactly 8 bits, the native word size of the Intel 8008 ALU.
+
+The Intel 8008 (1972) was Intel's first commercial 8-bit microprocessor —
+a direct successor to the 4-bit 4004, and the ancestor of the x86 family.
+Its key hardware constraints:
+
+- **8-bit accumulator (A)**: Each ALU operation works on one byte (0–255).
+- **7 general-purpose registers**: A (accumulator), B, C, D, E (GP), H, L
+  (memory pointer pair). The H:L pair addresses the 14-bit memory space.
+- **4 registers for locals**: Only B, C, D, E are available for function
+  local variables; A is the accumulator (scratch); H:L are the memory pointer.
+  At most 4 locals (including parameters) per function.
+- **16 KB of addressable memory**: 14-bit address bus (0x0000–0x3FFF).
+  ROM occupies 0x0000–0x1FFF; RAM data segment 0x2000–0x3FFF.
+- **8-level push-down call stack**: The hardware maintains an internal stack
+  of 8 program counter registers. One is always in use for the current
+  function, leaving 7 usable levels for nested calls.
+- **Separate I/O port space**: 8 input ports (INP p), 24 output ports (OUT p).
+  Port numbers are encoded in the instruction opcode — there is no "variable
+  port" addressing mode.
+- **4 flags**: CY (carry), Z (zero), S (sign), P (parity).
+  Oct exposes these via carry() and parity() intrinsics.
+
+Writing 8008 assembly by hand is tedious and error-prone. Oct gives us a
+higher-level notation with static safety guarantees while remaining faithful
+to the hardware. Every Oct construct maps to a small, predictable sequence of
+8008 instructions — a student reading the generated assembly should be able
+to trace every Oct expression back to the hardware instructions they studied.
+
+Why Oct Instead of Extending Nib?
+-----------------------------------
+
+Nib targets the Intel 4004 (4-bit). Oct targets the Intel 8008 (8-bit). The
+word sizes, instruction sets, and addressing models are different enough that
+sharing a compiler would produce worse code and worse error messages. Key
+differences:
+
+- Nib's ``u4`` type (4 bits) vs Oct's ``u8`` type (8 bits)
+- Nib's wrapping (``+%``) and saturating (``+?``) operators vs Oct's plain
+  ``+``/``-`` (carry is always available via carry() in Oct)
+- Nib's for-loop with compile-time bounds vs Oct's while/loop/break
+- Nib's 3-level call stack vs Oct's 7-level call stack
+- 4004 port model vs 8008's separate 8-input / 24-output port model
+- 4004's 4 KB ROM vs 8008's 16 KB address space
+
+The Token Set
+-------------
+
+Oct's token set reflects the 8008's capabilities. There are no string literals
+(the 8008 cannot display text), no floating-point (integer-only hardware), and
+no multiplication or division operators (the 8008 has no multiply/divide
+instructions — use repeated addition or shift-and-add).
+
+**Multi-character operators (listed first — first-match-wins)**
+
+== (EQ_EQ)
+    Equality comparison. Oct uses ``=`` for assignment and ``==`` for equality,
+    avoiding the classic C bug of writing ``=`` where ``==`` is intended.
+
+!= (NEQ)
+    Not-equal comparison. Tokenized atomically so ``!=`` is never lexed as
+    ``!`` followed by ``=``.
+
+<= (LEQ), >= (GEQ)
+    Less-or-equal, greater-or-equal (unsigned). Must precede ``<`` and ``>``
+    respectively.
+
+&& (LAND)
+    Logical AND (short-circuit). Distinct from bitwise AND (``&`` / ANA r).
+
+|| (LOR)
+    Logical OR (short-circuit). Distinct from bitwise OR (``|`` / ORA r).
+
+-> (ARROW)
+    Return type annotation separator: ``fn f() -> u8 { … }``.
+
+**Single-character arithmetic operators**
+
++ (PLUS), - (MINUS)
+    Unsigned addition and subtraction, wrapping modulo 256. Map to 8008
+    ADD r and SUB r instructions. There is no ``*`` or ``/`` — the 8008
+    has no multiply or divide hardware.
+
+**Single-character bitwise operators**
+
+& (AMP)
+    Bitwise AND. Maps to 8008 ANA r.
+
+| (PIPE)
+    Bitwise OR. Maps to 8008 ORA r.
+
+^ (CARET)
+    Bitwise XOR. Maps to 8008 XRA r.
+
+~ (TILDE)
+    Bitwise NOT (unary). Flips all 8 bits. Lowered to XRI 0xFF on 8008.
+
+! (BANG)
+    Logical NOT (unary). Negates a bool expression.
+
+**Delimiters**
+
+{ } (LBRACE, RBRACE)
+    Block delimiters. Required on all if/else/while/loop/fn bodies.
+
+( ) (LPAREN, RPAREN)
+    Expression grouping and argument/parameter lists.
+
+: (COLON)
+    Type annotation separator: ``let x: u8 = 5;``
+
+; (SEMICOLON)
+    Statement terminator.
+
+, (COMMA)
+    Argument/parameter separator.
+
+**Literals**
+
+BIN_LIT — ``0b00001111``, ``0b11111111``
+    Binary integer literals. Must precede INT_LIT to avoid ``0b101`` being
+    lexed as ``0`` + NAME(``b101``). Binary is the clearest notation for
+    bit masks, flags, and port control bytes on 8-bit hardware.
+
+HEX_LIT — ``0xFF``, ``0x3A``
+    Hexadecimal integer literals. Must precede INT_LIT for the same reason.
+    Hex is natural for memory addresses and ASCII codes.
+
+INT_LIT — ``0``, ``42``, ``255``
+    Decimal integer literals. Valid u8 range is 0–255 (enforced at compile
+    time, not by the lexer).
+
+NAME — identifiers and type names (``u8``, ``bool``)
+    Type names are NAME tokens with specific values, not keywords. This keeps
+    the keyword set minimal.
+
+**Keywords**
+
+Control: ``fn``, ``let``, ``static``, ``if``, ``else``, ``while``, ``loop``,
+         ``break``, ``return``
+
+Literals: ``true`` (1), ``false`` (0)
+
+Intrinsics (used as function calls):
+  ``in``, ``out``, ``adc``, ``sbb``, ``rlc``, ``rrc``, ``ral``, ``rar``,
+  ``carry``, ``parity``
+
+**Skipped automatically**
+
+Whitespace (spaces, tabs, CR, LF) and line comments (``// …`` to end of line).
+Block comments (``/* … */``) are not supported in Oct v1.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+from grammar_tools import parse_token_grammar
+from lexer import GrammarLexer, Token
+from lexer.tokenizer import TokenType
+
+# ---------------------------------------------------------------------------
+# Grammar File Location
+# ---------------------------------------------------------------------------
+#
+# Navigate from this file's location up to the repository root's grammars/
+# directory. The path is:
+#   src/oct_lexer/tokenizer.py -> src/oct_lexer -> src -> oct-lexer
+#   -> python -> packages -> code -> code/grammars
+# ---------------------------------------------------------------------------
+
+GRAMMAR_DIR = Path(__file__).parent.parent.parent.parent.parent.parent / "grammars"
+OCT_TOKENS_PATH = GRAMMAR_DIR / "oct.tokens"
+
+
+def create_oct_lexer(source: str) -> GrammarLexer:
+    """Create a ``GrammarLexer`` configured for Oct source text.
+
+    This function reads the ``oct.tokens`` file, parses it into a
+    ``TokenGrammar``, and creates a ``GrammarLexer`` ready to tokenize
+    the given source text.
+
+    The lexer handles the following Oct-specific behaviours automatically:
+
+    - **Keyword reclassification**: identifiers like ``fn``, ``let``,
+      ``while``, ``in``, ``carry``, etc. are reclassified from NAME to
+      their keyword token kind after a full-token match. ``invert`` stays
+      NAME because the full token ``invert`` does not match keyword ``in``.
+    - **Case sensitivity**: Oct keywords are lowercase only. ``FN`` stays
+      NAME; only ``fn`` becomes the ``fn`` keyword.
+    - **Multi-character operators**: ``==`` before ``=``, ``!=`` before
+      ``!``, ``<=`` before ``<``, ``>=`` before ``>``, ``&&`` before ``&``,
+      ``||`` before ``|``, ``->`` before ``-``.
+    - **BIN_LIT priority**: ``0b101`` consumed as one token before the
+      decimal digit rule fires on the leading ``0``.
+    - **HEX_LIT priority**: ``0xFF`` consumed as one hex literal token.
+    - **Comment skipping**: ``// text`` to end of line consumed silently.
+    - **Whitespace skipping**: spaces, tabs, CR, LF between tokens ignored.
+
+    Args:
+        source: The Oct source text to tokenize.
+
+    Returns:
+        A ``GrammarLexer`` instance configured with Oct token definitions.
+        Call ``.tokenize()`` on it to get the token list.
+
+    Raises:
+        FileNotFoundError: If the ``oct.tokens`` file cannot be found.
+        TokenGrammarError: If the ``.tokens`` file has syntax errors.
+
+    Example::
+
+        lexer = create_oct_lexer('fn main() { let x: u8 = 0xFF; }')
+        tokens = lexer.tokenize()
+    """
+    grammar = parse_token_grammar(OCT_TOKENS_PATH.read_text())
+    return GrammarLexer(source, grammar)
+
+
+def tokenize_oct(source: str) -> list[Token]:
+    """Tokenize Oct source text and return a list of tokens.
+
+    This is the main entry point for the Oct lexer. It creates a configured
+    ``GrammarLexer`` for Oct, runs it over the source text, and applies a
+    post-processing pass that promotes keyword tokens:
+
+    The ``GrammarLexer`` produces keyword tokens with ``type=TokenType.KEYWORD``
+    and ``value="fn"``, ``"let"``, ``"carry"``, etc.  Oct convention (and all
+    downstream consumers including oct-parser and oct-type-checker) expect the
+    token type to equal the keyword value string — ``Token("fn", "fn")``,
+    ``Token("let", "let")``, ``Token("carry", "carry")``, etc.  The post-
+    processing pass normalises this.
+
+    Intrinsic keywords (``in``, ``out``, ``adc``, ``sbb``, ``rlc``, ``rrc``,
+    ``ral``, ``rar``, ``carry``, ``parity``) are promoted exactly the same way
+    as control-flow keywords. The parser's ``intrinsic_call`` rule matches
+    them by their string value (e.g. ``"carry"``), so no special handling is
+    needed here beyond the standard KEYWORD → value promotion.
+
+    Args:
+        source: The Oct source text to tokenize.
+
+    Returns:
+        A list of ``Token`` objects. The last token is always EOF.
+
+    Raises:
+        FileNotFoundError: If the ``oct.tokens`` file cannot be found.
+        LexerError: If the source contains characters that don't match
+            any token pattern in Oct.
+
+    Example — simple variable declaration::
+
+        tokens = tokenize_oct('let x: u8 = 42;')
+        # [Token('let', 'let'), Token(NAME, 'x'), Token(COLON, ':'),
+        #  Token(NAME, 'u8'), Token(EQ, '='), Token(INT_LIT, '42'),
+        #  Token(SEMICOLON, ';'), Token(EOF, '')]
+
+    Example — binary and hex literals::
+
+        tokens = tokenize_oct('let mask: u8 = 0b11110000 & 0xFF;')
+        # [Token('let', 'let'), Token(NAME, 'mask'), Token(COLON, ':'),
+        #  Token(NAME, 'u8'), Token(EQ, '='), Token(BIN_LIT, '0b11110000'),
+        #  Token(AMP, '&'), Token(HEX_LIT, '0xFF'), Token(SEMICOLON, ';'),
+        #  Token(EOF, '')]
+
+    Example — intrinsic keyword tokens::
+
+        tokens = tokenize_oct('let b: u8 = in(0);')
+        # [Token('let', 'let'), Token(NAME, 'b'), Token(COLON, ':'),
+        #  Token(NAME, 'u8'), Token(EQ, '='), Token('in', 'in'),
+        #  Token(LPAREN, '('), Token(INT_LIT, '0'), Token(RPAREN, ')'),
+        #  Token(SEMICOLON, ';'), Token(EOF, '')]
+    """
+    lexer = create_oct_lexer(source)
+    raw = lexer.tokenize()
+
+    # The GrammarLexer uses the keywords: section in oct.tokens, which causes
+    # keyword tokens to come back with type=TokenType.KEYWORD and value="fn",
+    # "let", "carry", "in", etc.  Oct convention (and all downstream consumers)
+    # expect the token type to equal the lowercase keyword text:
+    #   Token("fn", "fn"), Token("carry", "carry"), Token("in", "in"), etc.
+    # This post-processing pass promotes TokenType.KEYWORD → the value string.
+    return [
+        replace(tok, type=tok.value) if tok.type is TokenType.KEYWORD else tok
+        for tok in raw
+    ]

--- a/code/packages/python/oct-lexer/tests/test_oct_lexer.py
+++ b/code/packages/python/oct-lexer/tests/test_oct_lexer.py
@@ -1,0 +1,770 @@
+"""Tests for the oct_lexer package.
+
+Oct is a small, statically-typed, 8-bit systems programming language targeting
+the Intel 8008 microprocessor (1972).  It exposes the 8008's native word size
+(8 bits), port I/O, carry arithmetic, and byte rotations directly in the
+language.
+
+This test suite validates that ``tokenize_oct`` correctly classifies all token
+kinds, promotes keywords (including intrinsic keywords like ``in``, ``carry``,
+and ``parity``), produces the expected token sequence for representative Oct
+programs, and handles edge cases such as binary literals, hex literals,
+multi-character operators, and comment/whitespace skipping.
+
+Coverage plan:
+  - Empty source produces only EOF
+  - All keyword tokens (control flow + intrinsics)
+  - BIN_LIT, HEX_LIT, INT_LIT literals
+  - All single- and multi-character operators
+  - All delimiter tokens
+  - NAME tokens (identifiers, type names u8/bool)
+  - Boolean literals (true, false)
+  - Whitespace and comment skipping
+  - Multi-token expressions and statements
+  - All five complete program examples from OCT00 spec
+  - Intrinsic keyword promotion
+  - Keyword/identifier boundary (e.g. "invert" is NAME, not "in")
+"""
+
+from __future__ import annotations
+
+from oct_lexer import tokenize_oct
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _types(source: str) -> list[str]:
+    """Return the token type list for source, excluding the trailing EOF."""
+    tokens = tokenize_oct(source)
+    return [t.type for t in tokens if t.type != "EOF"]
+
+
+def _values(source: str) -> list[str]:
+    """Return the token value list for source, excluding the trailing EOF."""
+    tokens = tokenize_oct(source)
+    return [t.value for t in tokens if t.type != "EOF"]
+
+
+def _pairs(source: str) -> list[tuple[str, str]]:
+    """Return (type, value) pairs for source, excluding EOF."""
+    tokens = tokenize_oct(source)
+    return [(t.type, t.value) for t in tokens if t.type != "EOF"]
+
+
+# ---------------------------------------------------------------------------
+# Empty / whitespace-only source
+# ---------------------------------------------------------------------------
+
+class TestEmptySource:
+    """Edge cases: nothing in the source at all."""
+
+    def test_empty_string_produces_only_eof(self) -> None:
+        """An empty string tokenizes to a single EOF token."""
+        tokens = tokenize_oct("")
+        assert len(tokens) == 1
+        assert tokens[0].type == "EOF"
+
+    def test_whitespace_only_produces_only_eof(self) -> None:
+        """Whitespace is silently skipped; only EOF remains."""
+        tokens = tokenize_oct("   \t\n\r\n   ")
+        assert len(tokens) == 1
+        assert tokens[0].type == "EOF"
+
+    def test_comment_only_produces_only_eof(self) -> None:
+        """A lone line comment is silently skipped; only EOF remains."""
+        tokens = tokenize_oct("// This is a comment\n")
+        assert len(tokens) == 1
+        assert tokens[0].type == "EOF"
+
+
+# ---------------------------------------------------------------------------
+# Control-flow keyword tokens
+# ---------------------------------------------------------------------------
+
+class TestControlKeywords:
+    """Every control-flow keyword is reclassified from NAME to its string value."""
+
+    def test_fn_keyword(self) -> None:
+        assert _pairs("fn") == [("fn", "fn")]
+
+    def test_let_keyword(self) -> None:
+        assert _pairs("let") == [("let", "let")]
+
+    def test_static_keyword(self) -> None:
+        assert _pairs("static") == [("static", "static")]
+
+    def test_if_keyword(self) -> None:
+        assert _pairs("if") == [("if", "if")]
+
+    def test_else_keyword(self) -> None:
+        assert _pairs("else") == [("else", "else")]
+
+    def test_while_keyword(self) -> None:
+        assert _pairs("while") == [("while", "while")]
+
+    def test_loop_keyword(self) -> None:
+        assert _pairs("loop") == [("loop", "loop")]
+
+    def test_break_keyword(self) -> None:
+        assert _pairs("break") == [("break", "break")]
+
+    def test_return_keyword(self) -> None:
+        assert _pairs("return") == [("return", "return")]
+
+    def test_true_keyword(self) -> None:
+        assert _pairs("true") == [("true", "true")]
+
+    def test_false_keyword(self) -> None:
+        assert _pairs("false") == [("false", "false")]
+
+
+# ---------------------------------------------------------------------------
+# Intrinsic keyword tokens
+# ---------------------------------------------------------------------------
+
+class TestIntrinsicKeywords:
+    """Intrinsic function names are keywords, not NAME tokens.
+
+    The 8008 exposes special hardware operations (port I/O, carry arithmetic,
+    byte rotations) as first-class language intrinsics.  All are reclassified
+    from NAME to their keyword string so the parser can distinguish them from
+    user-defined function names.
+    """
+
+    def test_in_keyword(self) -> None:
+        """'in' is an intrinsic keyword (port read), not a NAME."""
+        assert _pairs("in") == [("in", "in")]
+
+    def test_out_keyword(self) -> None:
+        """'out' is an intrinsic keyword (port write), not a NAME."""
+        assert _pairs("out") == [("out", "out")]
+
+    def test_adc_keyword(self) -> None:
+        """'adc' (add with carry) is an intrinsic keyword."""
+        assert _pairs("adc") == [("adc", "adc")]
+
+    def test_sbb_keyword(self) -> None:
+        """'sbb' (subtract with borrow) is an intrinsic keyword."""
+        assert _pairs("sbb") == [("sbb", "sbb")]
+
+    def test_rlc_keyword(self) -> None:
+        """'rlc' (rotate left circular) is an intrinsic keyword."""
+        assert _pairs("rlc") == [("rlc", "rlc")]
+
+    def test_rrc_keyword(self) -> None:
+        """'rrc' (rotate right circular) is an intrinsic keyword."""
+        assert _pairs("rrc") == [("rrc", "rrc")]
+
+    def test_ral_keyword(self) -> None:
+        """'ral' (rotate left through carry) is an intrinsic keyword."""
+        assert _pairs("ral") == [("ral", "ral")]
+
+    def test_rar_keyword(self) -> None:
+        """'rar' (rotate right through carry) is an intrinsic keyword."""
+        assert _pairs("rar") == [("rar", "rar")]
+
+    def test_carry_keyword(self) -> None:
+        """'carry' (read carry flag) is an intrinsic keyword."""
+        assert _pairs("carry") == [("carry", "carry")]
+
+    def test_parity_keyword(self) -> None:
+        """'parity' (read parity flag) is an intrinsic keyword."""
+        assert _pairs("parity") == [("parity", "parity")]
+
+    def test_invert_is_name_not_in(self) -> None:
+        """'invert' starts with 'in' but is a NAME — keyword match is whole-token."""
+        assert _pairs("invert") == [("NAME", "invert")]
+
+    def test_outgoing_is_name_not_out(self) -> None:
+        """'outgoing' starts with 'out' but is a NAME."""
+        assert _pairs("outgoing") == [("NAME", "outgoing")]
+
+    def test_carry_flag_is_name_not_carry(self) -> None:
+        """'carry_flag' contains 'carry' but is a single NAME token."""
+        assert _pairs("carry_flag") == [("NAME", "carry_flag")]
+
+
+# ---------------------------------------------------------------------------
+# Literal tokens
+# ---------------------------------------------------------------------------
+
+class TestLiterals:
+    """BIN_LIT, HEX_LIT, INT_LIT: correct classification and value preservation."""
+
+    def test_decimal_zero(self) -> None:
+        assert _pairs("0") == [("INT_LIT", "0")]
+
+    def test_decimal_max_u8(self) -> None:
+        assert _pairs("255") == [("INT_LIT", "255")]
+
+    def test_decimal_mid(self) -> None:
+        assert _pairs("42") == [("INT_LIT", "42")]
+
+    def test_hex_lowercase(self) -> None:
+        """0xff is a valid HEX_LIT — digit letters are case-insensitive."""
+        assert _pairs("0xff") == [("HEX_LIT", "0xff")]
+
+    def test_hex_uppercase(self) -> None:
+        assert _pairs("0xFF") == [("HEX_LIT", "0xFF")]
+
+    def test_hex_zero(self) -> None:
+        assert _pairs("0x00") == [("HEX_LIT", "0x00")]
+
+    def test_hex_max_byte(self) -> None:
+        assert _pairs("0xFF") == [("HEX_LIT", "0xFF")]
+
+    def test_hex_not_split(self) -> None:
+        """0xFF must lex as one HEX_LIT token, not INT_LIT('0') + NAME('xFF')."""
+        tokens = tokenize_oct("0xFF")
+        non_eof = [t for t in tokens if t.type != "EOF"]
+        assert len(non_eof) == 1
+        assert non_eof[0].type == "HEX_LIT"
+
+    def test_binary_zero(self) -> None:
+        assert _pairs("0b00000000") == [("BIN_LIT", "0b00000000")]
+
+    def test_binary_max(self) -> None:
+        assert _pairs("0b11111111") == [("BIN_LIT", "0b11111111")]
+
+    def test_binary_pattern(self) -> None:
+        assert _pairs("0b10110011") == [("BIN_LIT", "0b10110011")]
+
+    def test_binary_not_split(self) -> None:
+        """0b101 must lex as one BIN_LIT token, not INT_LIT('0') + NAME('b101')."""
+        tokens = tokenize_oct("0b101")
+        non_eof = [t for t in tokens if t.type != "EOF"]
+        assert len(non_eof) == 1
+        assert non_eof[0].type == "BIN_LIT"
+
+
+# ---------------------------------------------------------------------------
+# Name and type-name tokens
+# ---------------------------------------------------------------------------
+
+class TestNameTokens:
+    """Identifiers and type names are both NAME tokens."""
+
+    def test_simple_identifier(self) -> None:
+        assert _pairs("x") == [("NAME", "x")]
+
+    def test_underscore_identifier(self) -> None:
+        assert _pairs("_counter") == [("NAME", "_counter")]
+
+    def test_mixed_case_identifier(self) -> None:
+        assert _pairs("myVar2") == [("NAME", "myVar2")]
+
+    def test_type_u8_is_name(self) -> None:
+        """'u8' is a NAME token, not a keyword — types are resolved at parse time."""
+        assert _pairs("u8") == [("NAME", "u8")]
+
+    def test_type_bool_is_name(self) -> None:
+        """'bool' is a NAME token, not a keyword."""
+        assert _pairs("bool") == [("NAME", "bool")]
+
+
+# ---------------------------------------------------------------------------
+# Operator tokens
+# ---------------------------------------------------------------------------
+
+class TestOperatorTokens:
+    """All operator tokens — single- and multi-character."""
+
+    # Multi-character operators
+    def test_eq_eq(self) -> None:
+        assert _pairs("==") == [("EQ_EQ", "==")]
+
+    def test_neq(self) -> None:
+        assert _pairs("!=") == [("NEQ", "!=")]
+
+    def test_leq(self) -> None:
+        assert _pairs("<=") == [("LEQ", "<=")]
+
+    def test_geq(self) -> None:
+        assert _pairs(">=") == [("GEQ", ">=")]
+
+    def test_land(self) -> None:
+        assert _pairs("&&") == [("LAND", "&&")]
+
+    def test_lor(self) -> None:
+        assert _pairs("||") == [("LOR", "||")]
+
+    def test_arrow(self) -> None:
+        assert _pairs("->") == [("ARROW", "->")]
+
+    # Multi-char must not be split into two single-char tokens
+    def test_eq_eq_not_two_eq(self) -> None:
+        """'==' is one EQ_EQ token, not two EQ tokens."""
+        tokens = tokenize_oct("==")
+        non_eof = [t for t in tokens if t.type != "EOF"]
+        assert len(non_eof) == 1
+        assert non_eof[0].type == "EQ_EQ"
+
+    def test_land_not_two_amp(self) -> None:
+        """'&&' is one LAND token, not two AMP tokens."""
+        tokens = tokenize_oct("&&")
+        non_eof = [t for t in tokens if t.type != "EOF"]
+        assert len(non_eof) == 1
+        assert non_eof[0].type == "LAND"
+
+    def test_arrow_not_minus_gt(self) -> None:
+        """'->' is one ARROW token, not MINUS + GT."""
+        tokens = tokenize_oct("->")
+        non_eof = [t for t in tokens if t.type != "EOF"]
+        assert len(non_eof) == 1
+        assert non_eof[0].type == "ARROW"
+
+    # Single-character operators
+    def test_plus(self) -> None:
+        assert _pairs("+") == [("PLUS", "+")]
+
+    def test_minus(self) -> None:
+        assert _pairs("-") == [("MINUS", "-")]
+
+    def test_amp(self) -> None:
+        assert _pairs("&") == [("AMP", "&")]
+
+    def test_pipe(self) -> None:
+        assert _pairs("|") == [("PIPE", "|")]
+
+    def test_caret(self) -> None:
+        assert _pairs("^") == [("CARET", "^")]
+
+    def test_tilde(self) -> None:
+        assert _pairs("~") == [("TILDE", "~")]
+
+    def test_bang(self) -> None:
+        assert _pairs("!") == [("BANG", "!")]
+
+    def test_lt(self) -> None:
+        assert _pairs("<") == [("LT", "<")]
+
+    def test_gt(self) -> None:
+        assert _pairs(">") == [("GT", ">")]
+
+    def test_eq(self) -> None:
+        assert _pairs("=") == [("EQ", "=")]
+
+
+# ---------------------------------------------------------------------------
+# Delimiter tokens
+# ---------------------------------------------------------------------------
+
+class TestDelimiterTokens:
+    """All delimiter tokens."""
+
+    def test_lbrace(self) -> None:
+        assert _pairs("{") == [("LBRACE", "{")]
+
+    def test_rbrace(self) -> None:
+        assert _pairs("}") == [("RBRACE", "}")]
+
+    def test_lparen(self) -> None:
+        assert _pairs("(") == [("LPAREN", "(")]
+
+    def test_rparen(self) -> None:
+        assert _pairs(")") == [("RPAREN", ")")]
+
+    def test_colon(self) -> None:
+        assert _pairs(":") == [("COLON", ":")]
+
+    def test_semicolon(self) -> None:
+        assert _pairs(";") == [("SEMICOLON", ";")]
+
+    def test_comma(self) -> None:
+        assert _pairs(",") == [("COMMA", ",")]
+
+
+# ---------------------------------------------------------------------------
+# Whitespace and comment skipping
+# ---------------------------------------------------------------------------
+
+class TestSkipping:
+    """Whitespace and line comments are consumed silently."""
+
+    def test_inline_comment_skipped(self) -> None:
+        """A comment at the end of a line does not produce a token."""
+        tokens = tokenize_oct("let // comment\n")
+        non_eof = [t for t in tokens if t.type != "EOF"]
+        assert len(non_eof) == 1
+        assert non_eof[0].type == "let"
+
+    def test_leading_whitespace_ignored(self) -> None:
+        assert _types("   fn") == ["fn"]
+
+    def test_tokens_separated_by_newlines(self) -> None:
+        assert _types("let\nstatic") == ["let", "static"]
+
+    def test_mixed_whitespace_between_tokens(self) -> None:
+        assert _types("fn\t  \r\nmain") == ["fn", "NAME"]
+
+
+# ---------------------------------------------------------------------------
+# Multi-token expressions and statements
+# ---------------------------------------------------------------------------
+
+class TestMultiTokenExpressions:
+    """Representative token sequences for common Oct constructs."""
+
+    def test_let_declaration(self) -> None:
+        """let x: u8 = 42;"""
+        assert _pairs("let x: u8 = 42;") == [
+            ("let", "let"),
+            ("NAME", "x"),
+            ("COLON", ":"),
+            ("NAME", "u8"),
+            ("EQ", "="),
+            ("INT_LIT", "42"),
+            ("SEMICOLON", ";"),
+        ]
+
+    def test_let_declaration_hex(self) -> None:
+        """let mask: u8 = 0xFF;"""
+        assert _pairs("let mask: u8 = 0xFF;") == [
+            ("let", "let"),
+            ("NAME", "mask"),
+            ("COLON", ":"),
+            ("NAME", "u8"),
+            ("EQ", "="),
+            ("HEX_LIT", "0xFF"),
+            ("SEMICOLON", ";"),
+        ]
+
+    def test_let_declaration_binary(self) -> None:
+        """let flags: u8 = 0b00001111;"""
+        assert _pairs("let flags: u8 = 0b00001111;") == [
+            ("let", "let"),
+            ("NAME", "flags"),
+            ("COLON", ":"),
+            ("NAME", "u8"),
+            ("EQ", "="),
+            ("BIN_LIT", "0b00001111"),
+            ("SEMICOLON", ";"),
+        ]
+
+    def test_assign_statement(self) -> None:
+        """n = n + 1;"""
+        assert _pairs("n = n + 1;") == [
+            ("NAME", "n"),
+            ("EQ", "="),
+            ("NAME", "n"),
+            ("PLUS", "+"),
+            ("INT_LIT", "1"),
+            ("SEMICOLON", ";"),
+        ]
+
+    def test_fn_signature_no_params(self) -> None:
+        """fn main()"""
+        assert _pairs("fn main()") == [
+            ("fn", "fn"),
+            ("NAME", "main"),
+            ("LPAREN", "("),
+            ("RPAREN", ")"),
+        ]
+
+    def test_fn_signature_with_return_type(self) -> None:
+        """fn clamp(val: u8, limit: u8) -> u8"""
+        assert _pairs("fn clamp(val: u8, limit: u8) -> u8") == [
+            ("fn", "fn"),
+            ("NAME", "clamp"),
+            ("LPAREN", "("),
+            ("NAME", "val"),
+            ("COLON", ":"),
+            ("NAME", "u8"),
+            ("COMMA", ","),
+            ("NAME", "limit"),
+            ("COLON", ":"),
+            ("NAME", "u8"),
+            ("RPAREN", ")"),
+            ("ARROW", "->"),
+            ("NAME", "u8"),
+        ]
+
+    def test_if_condition(self) -> None:
+        """if n != 0 {"""
+        assert _pairs("if n != 0 {") == [
+            ("if", "if"),
+            ("NAME", "n"),
+            ("NEQ", "!="),
+            ("INT_LIT", "0"),
+            ("LBRACE", "{"),
+        ]
+
+    def test_while_with_comparison(self) -> None:
+        """while i != 8 {"""
+        assert _pairs("while i != 8 {") == [
+            ("while", "while"),
+            ("NAME", "i"),
+            ("NEQ", "!="),
+            ("INT_LIT", "8"),
+            ("LBRACE", "{"),
+        ]
+
+    def test_bitwise_and_expression(self) -> None:
+        """checksum = checksum ^ b;"""
+        assert _pairs("checksum = checksum ^ b;") == [
+            ("NAME", "checksum"),
+            ("EQ", "="),
+            ("NAME", "checksum"),
+            ("CARET", "^"),
+            ("NAME", "b"),
+            ("SEMICOLON", ";"),
+        ]
+
+    def test_not_expression(self) -> None:
+        """~x"""
+        assert _pairs("~x") == [("TILDE", "~"), ("NAME", "x")]
+
+    def test_logical_not(self) -> None:
+        """!flag"""
+        assert _pairs("!flag") == [("BANG", "!"), ("NAME", "flag")]
+
+    def test_static_declaration(self) -> None:
+        """static counter: u8 = 0;"""
+        assert _pairs("static counter: u8 = 0;") == [
+            ("static", "static"),
+            ("NAME", "counter"),
+            ("COLON", ":"),
+            ("NAME", "u8"),
+            ("EQ", "="),
+            ("INT_LIT", "0"),
+            ("SEMICOLON", ";"),
+        ]
+
+    def test_bool_variable_declaration(self) -> None:
+        """let flag: bool = false;"""
+        assert _pairs("let flag: bool = false;") == [
+            ("let", "let"),
+            ("NAME", "flag"),
+            ("COLON", ":"),
+            ("NAME", "bool"),
+            ("EQ", "="),
+            ("false", "false"),
+            ("SEMICOLON", ";"),
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Intrinsic call token sequences
+# ---------------------------------------------------------------------------
+
+class TestIntrinsicCallTokens:
+    """Token sequences for all 10 intrinsic calls in Oct."""
+
+    def test_in_call(self) -> None:
+        """in(0) — read from port 0."""
+        assert _pairs("in(0)") == [
+            ("in", "in"),
+            ("LPAREN", "("),
+            ("INT_LIT", "0"),
+            ("RPAREN", ")"),
+        ]
+
+    def test_out_call(self) -> None:
+        """out(1, x) — write x to port 1."""
+        assert _pairs("out(1, x)") == [
+            ("out", "out"),
+            ("LPAREN", "("),
+            ("INT_LIT", "1"),
+            ("COMMA", ","),
+            ("NAME", "x"),
+            ("RPAREN", ")"),
+        ]
+
+    def test_adc_call(self) -> None:
+        """adc(hi_a, hi_b) — add with carry."""
+        assert _pairs("adc(hi_a, hi_b)") == [
+            ("adc", "adc"),
+            ("LPAREN", "("),
+            ("NAME", "hi_a"),
+            ("COMMA", ","),
+            ("NAME", "hi_b"),
+            ("RPAREN", ")"),
+        ]
+
+    def test_sbb_call(self) -> None:
+        """sbb(a, b) — subtract with borrow."""
+        assert _pairs("sbb(a, b)") == [
+            ("sbb", "sbb"),
+            ("LPAREN", "("),
+            ("NAME", "a"),
+            ("COMMA", ","),
+            ("NAME", "b"),
+            ("RPAREN", ")"),
+        ]
+
+    def test_rlc_call(self) -> None:
+        """rlc(x) — rotate left circular."""
+        assert _pairs("rlc(x)") == [
+            ("rlc", "rlc"),
+            ("LPAREN", "("),
+            ("NAME", "x"),
+            ("RPAREN", ")"),
+        ]
+
+    def test_rrc_call(self) -> None:
+        """rrc(x) — rotate right circular."""
+        assert _pairs("rrc(x)") == [
+            ("rrc", "rrc"),
+            ("LPAREN", "("),
+            ("NAME", "x"),
+            ("RPAREN", ")"),
+        ]
+
+    def test_ral_call(self) -> None:
+        """ral(x) — rotate left through carry."""
+        assert _pairs("ral(x)") == [
+            ("ral", "ral"),
+            ("LPAREN", "("),
+            ("NAME", "x"),
+            ("RPAREN", ")"),
+        ]
+
+    def test_rar_call(self) -> None:
+        """rar(x) — rotate right through carry."""
+        assert _pairs("rar(x)") == [
+            ("rar", "rar"),
+            ("LPAREN", "("),
+            ("NAME", "x"),
+            ("RPAREN", ")"),
+        ]
+
+    def test_carry_call(self) -> None:
+        """carry() — read carry flag (zero arguments)."""
+        assert _pairs("carry()") == [
+            ("carry", "carry"),
+            ("LPAREN", "("),
+            ("RPAREN", ")"),
+        ]
+
+    def test_parity_call(self) -> None:
+        """parity(b) — read parity flag of b."""
+        assert _pairs("parity(b)") == [
+            ("parity", "parity"),
+            ("LPAREN", "("),
+            ("NAME", "b"),
+            ("RPAREN", ")"),
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Complete Oct programs from OCT00 spec examples
+# ---------------------------------------------------------------------------
+
+class TestCompletePrograms:
+    """Token counts and key token types for the five spec examples.
+
+    These tests do not assert every token — instead they verify that the
+    tokenizer runs without error and produces tokens with the expected key
+    kinds, validating that the full program is accepted by the lexer.
+    """
+
+    def test_example1_echo_input_to_output(self) -> None:
+        """Echo input to output — uses 'in', 'out', 'loop', 'let'."""
+        source = """
+        fn main() {
+            loop {
+                let b: u8 = in(0);
+                out(8, b);
+            }
+        }
+        """
+        types = _types(source)
+        assert "fn" in types
+        assert "loop" in types
+        assert "let" in types
+        assert "in" in types
+        assert "out" in types
+        assert "SEMICOLON" in types
+
+    def test_example2_count_to_255(self) -> None:
+        """Count from 0 to 255 — uses 'while', 'out', 'let', '!='."""
+        source = """
+        fn main() {
+            let n: u8 = 0;
+            while n != 255 {
+                out(1, n);
+                n = n + 1;
+            }
+            out(1, 255);
+        }
+        """
+        types = _types(source)
+        assert "while" in types
+        assert "NEQ" in types
+        assert "out" in types
+        assert "INT_LIT" in types
+
+    def test_example3_xor_checksum(self) -> None:
+        """XOR checksum — uses bitwise XOR (^), 'in', 'while', 'out'."""
+        source = """
+        fn main() {
+            let checksum: u8 = 0;
+            let i: u8 = 0;
+            while i != 8 {
+                let b: u8 = in(0);
+                checksum = checksum ^ b;
+                i = i + 1;
+            }
+            out(1, checksum);
+        }
+        """
+        types = _types(source)
+        assert "CARET" in types
+        assert "in" in types
+        assert "while" in types
+
+    def test_example4_16bit_counter_with_carry(self) -> None:
+        """16-bit counter using carry() — uses 'static', 'carry', 'if'."""
+        source = """
+        static lo: u8 = 0;
+        static hi: u8 = 0;
+
+        fn tick() {
+            let l: u8 = lo;
+            l = l + 1;
+            lo = l;
+            if carry() {
+                let h: u8 = hi;
+                h = h + 1;
+                hi = h;
+                out(1, h);
+            }
+        }
+
+        fn main() {
+            loop {
+                tick();
+            }
+        }
+        """
+        types = _types(source)
+        assert "static" in types
+        assert "carry" in types
+        assert "if" in types
+        assert "loop" in types
+
+    def test_example5_bit_reversal_with_rotations(self) -> None:
+        """Bit reversal using ral/rar — uses rotation intrinsics."""
+        source = """
+        fn reverse_bits(x: u8) -> u8 {
+            let result: u8 = 0;
+            let i: u8 = 0;
+            while i != 8 {
+                x = ral(x);
+                result = rar(result);
+                i = i + 1;
+            }
+            return result;
+        }
+
+        fn main() {
+            let b: u8 = in(0);
+            out(1, reverse_bits(b));
+        }
+        """
+        types = _types(source)
+        assert "ral" in types
+        assert "rar" in types
+        assert "return" in types
+        assert "ARROW" in types

--- a/code/packages/python/oct-lexer/tests/test_oct_lexer.py
+++ b/code/packages/python/oct-lexer/tests/test_oct_lexer.py
@@ -28,28 +28,42 @@ Coverage plan:
 
 from __future__ import annotations
 
+from lexer import Token
+
 from oct_lexer import tokenize_oct
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
+def _tok_type(tok: Token) -> str:
+    """Normalize a token's type to a plain string.
+
+    ``tokenize_oct`` promotes keyword tokens so their ``type`` field is
+    already a string (e.g. ``"fn"``, ``"carry"``).  All other tokens keep
+    the ``TokenType`` enum value returned by the ``GrammarLexer`` (e.g.
+    ``TokenType.LPAREN``).  This helper normalises both cases so tests can
+    compare uniformly against string names like ``"LPAREN"`` or ``"NAME"``.
+    """
+    return tok.type if isinstance(tok.type, str) else tok.type.name
+
+
 def _types(source: str) -> list[str]:
     """Return the token type list for source, excluding the trailing EOF."""
     tokens = tokenize_oct(source)
-    return [t.type for t in tokens if t.type != "EOF"]
+    return [_tok_type(t) for t in tokens if _tok_type(t) != "EOF"]
 
 
 def _values(source: str) -> list[str]:
     """Return the token value list for source, excluding the trailing EOF."""
     tokens = tokenize_oct(source)
-    return [t.value for t in tokens if t.type != "EOF"]
+    return [t.value for t in tokens if _tok_type(t) != "EOF"]
 
 
 def _pairs(source: str) -> list[tuple[str, str]]:
     """Return (type, value) pairs for source, excluding EOF."""
     tokens = tokenize_oct(source)
-    return [(t.type, t.value) for t in tokens if t.type != "EOF"]
+    return [(_tok_type(t), t.value) for t in tokens if _tok_type(t) != "EOF"]
 
 
 # ---------------------------------------------------------------------------
@@ -63,19 +77,19 @@ class TestEmptySource:
         """An empty string tokenizes to a single EOF token."""
         tokens = tokenize_oct("")
         assert len(tokens) == 1
-        assert tokens[0].type == "EOF"
+        assert _tok_type(tokens[0]) == "EOF"
 
     def test_whitespace_only_produces_only_eof(self) -> None:
         """Whitespace is silently skipped; only EOF remains."""
         tokens = tokenize_oct("   \t\n\r\n   ")
         assert len(tokens) == 1
-        assert tokens[0].type == "EOF"
+        assert _tok_type(tokens[0]) == "EOF"
 
     def test_comment_only_produces_only_eof(self) -> None:
         """A lone line comment is silently skipped; only EOF remains."""
         tokens = tokenize_oct("// This is a comment\n")
         assert len(tokens) == 1
-        assert tokens[0].type == "EOF"
+        assert _tok_type(tokens[0]) == "EOF"
 
 
 # ---------------------------------------------------------------------------
@@ -217,9 +231,9 @@ class TestLiterals:
     def test_hex_not_split(self) -> None:
         """0xFF must lex as one HEX_LIT token, not INT_LIT('0') + NAME('xFF')."""
         tokens = tokenize_oct("0xFF")
-        non_eof = [t for t in tokens if t.type != "EOF"]
+        non_eof = [t for t in tokens if _tok_type(t) != "EOF"]
         assert len(non_eof) == 1
-        assert non_eof[0].type == "HEX_LIT"
+        assert _tok_type(non_eof[0]) == "HEX_LIT"
 
     def test_binary_zero(self) -> None:
         assert _pairs("0b00000000") == [("BIN_LIT", "0b00000000")]
@@ -233,9 +247,9 @@ class TestLiterals:
     def test_binary_not_split(self) -> None:
         """0b101 must lex as one BIN_LIT token, not INT_LIT('0') + NAME('b101')."""
         tokens = tokenize_oct("0b101")
-        non_eof = [t for t in tokens if t.type != "EOF"]
+        non_eof = [t for t in tokens if _tok_type(t) != "EOF"]
         assert len(non_eof) == 1
-        assert non_eof[0].type == "BIN_LIT"
+        assert _tok_type(non_eof[0]) == "BIN_LIT"
 
 
 # ---------------------------------------------------------------------------
@@ -296,23 +310,23 @@ class TestOperatorTokens:
     def test_eq_eq_not_two_eq(self) -> None:
         """'==' is one EQ_EQ token, not two EQ tokens."""
         tokens = tokenize_oct("==")
-        non_eof = [t for t in tokens if t.type != "EOF"]
+        non_eof = [t for t in tokens if _tok_type(t) != "EOF"]
         assert len(non_eof) == 1
-        assert non_eof[0].type == "EQ_EQ"
+        assert _tok_type(non_eof[0]) == "EQ_EQ"
 
     def test_land_not_two_amp(self) -> None:
         """'&&' is one LAND token, not two AMP tokens."""
         tokens = tokenize_oct("&&")
-        non_eof = [t for t in tokens if t.type != "EOF"]
+        non_eof = [t for t in tokens if _tok_type(t) != "EOF"]
         assert len(non_eof) == 1
-        assert non_eof[0].type == "LAND"
+        assert _tok_type(non_eof[0]) == "LAND"
 
     def test_arrow_not_minus_gt(self) -> None:
         """'->' is one ARROW token, not MINUS + GT."""
         tokens = tokenize_oct("->")
-        non_eof = [t for t in tokens if t.type != "EOF"]
+        non_eof = [t for t in tokens if _tok_type(t) != "EOF"]
         assert len(non_eof) == 1
-        assert non_eof[0].type == "ARROW"
+        assert _tok_type(non_eof[0]) == "ARROW"
 
     # Single-character operators
     def test_plus(self) -> None:
@@ -385,9 +399,9 @@ class TestSkipping:
     def test_inline_comment_skipped(self) -> None:
         """A comment at the end of a line does not produce a token."""
         tokens = tokenize_oct("let // comment\n")
-        non_eof = [t for t in tokens if t.type != "EOF"]
+        non_eof = [t for t in tokens if _tok_type(t) != "EOF"]
         assert len(non_eof) == 1
-        assert non_eof[0].type == "let"
+        assert _tok_type(non_eof[0]) == "let"
 
     def test_leading_whitespace_ignored(self) -> None:
         assert _types("   fn") == ["fn"]

--- a/code/packages/python/oct-parser/BUILD
+++ b/code/packages/python/oct-parser/BUILD
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../graph -e ../directed-graph -e ../grammar-tools -e ../lexer -e ../parser -e ../state-machine -e ../oct-lexer -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/oct-parser/CHANGELOG.md
+++ b/code/packages/python/oct-parser/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+## [0.1.0] - 2026-04-20
+
+### Added
+
+- Initial implementation of the Oct parser — a thin wrapper around the generic
+  `GrammarParser` that loads `code/grammars/oct.grammar` and tokenizes input
+  with the `oct-lexer` package.
+- `create_oct_parser(source)` — creates a `GrammarParser` configured for Oct,
+  returning a parser instance whose `.parse()` method produces an `ASTNode` tree.
+- `parse_oct(source)` — the main entry point; tokenizes and parses Oct source
+  text in one call, returning the root `ASTNode` (rule name: `"program"`).
+- `OCT_GRAMMAR_PATH` — the path constant pointing at `code/grammars/oct.grammar`,
+  resolved relative to the module file.
+- Grammar rules in `code/grammars/oct.grammar` (committed alongside this package):
+  - Entry point: `program = { top_decl }`
+  - Top-level: `static_decl`, `fn_decl`
+  - Statements: `let_stmt`, `assign_stmt`, `return_stmt` (optional expr for void
+    functions), `if_stmt` (optional else), `while_stmt`, `loop_stmt`,
+    `break_stmt`, `expr_stmt`
+  - Expressions (8 precedence levels): `or_expr`, `and_expr`, `eq_expr`,
+    `cmp_expr`, `add_expr`, `bitwise_expr`, `unary_expr`, `primary`
+  - Intrinsic calls: `intrinsic_call` covering all 10 Oct intrinsics (`in`,
+    `out`, `adc`, `sbb`, `rlc`, `rrc`, `ral`, `rar`, `carry`, `parity`)
+  - User-defined calls: `call_expr = NAME LPAREN [ arg_list ] RPAREN`
+- Comprehensive test suite (`tests/test_oct_parser.py`):
+  - `TestParseOctBasic` — root node rule name, empty program, single static,
+    single function
+  - `TestStaticDeclarations` — u8 and bool statics, hex/binary/decimal values,
+    multiple statics
+  - `TestFunctionDeclarations` — void no-params, return type, with params,
+    multiple params
+  - `TestStatements` — let, assign, return (with and without expr), if (with
+    and without else), while, loop, break, expr_stmt
+  - `TestExpressions` — all binary operators, unary operators, operator
+    precedence, parenthesised expressions
+  - `TestIntrinsicCalls` — all 10 intrinsics parse without error and produce
+    `intrinsic_call` nodes
+  - `TestCompletePrograms` — all five OCT00 spec examples parse successfully
+    and produce the correct top-level structure

--- a/code/packages/python/oct-parser/README.md
+++ b/code/packages/python/oct-parser/README.md
@@ -1,0 +1,119 @@
+# oct-parser
+
+Parses **Oct** source text into ASTs using the grammar-driven approach — a thin wrapper around `GrammarParser` that loads `oct.grammar`.
+
+**Oct** is a small, statically-typed, 8-bit systems programming language designed to compile to the Intel 8008 microprocessor (1972). The name comes from *octet* — the networking term for exactly 8 bits, the native word size of the 8008 ALU.
+
+## Overview
+
+This package is part of the Oct compiler pipeline:
+
+```
+Oct source (.oct)
+    ↓  [oct-lexer]        tokenise             ← produces tokens
+    ↓  [oct-parser]       parse to AST         ← this package
+    ↓  [oct-type-checker] type check
+    ↓  [oct-ir-compiler]  lower to compiler_ir
+    ↓  [ir-to-intel-8008-compiler] code generate
+    ↓  [intel-8008-assembler] assemble to binary
+    ↓  [intel-8008-packager]  produce Intel HEX
+```
+
+`oct-parser` occupies the second stage. It consumes the token stream from `oct-lexer` and produces a generic `ASTNode` tree using the EBNF rules in `oct.grammar`.
+
+## Usage
+
+```python
+from oct_parser import parse_oct
+
+ast = parse_oct("""
+fn main() {
+    let n: u8 = 0;
+    while n != 255 {
+        out(1, n);
+        n = n + 1;
+    }
+    out(1, 255);
+}
+""")
+
+print(ast.rule_name)  # "program"
+```
+
+For streaming (tokenize then parse separately):
+
+```python
+from oct_parser import create_oct_parser
+
+parser = create_oct_parser("fn main() { let x: u8 = in(0); out(8, x); }")
+ast = parser.parse()
+```
+
+## Grammar Summary
+
+The grammar has two top-level declaration forms and eight statement kinds:
+
+**Top-level**:
+```
+program     = { top_decl }
+top_decl    = static_decl | fn_decl
+static_decl = "static" NAME COLON type EQ expr SEMICOLON
+fn_decl     = "fn" NAME LPAREN [ param_list ] RPAREN [ ARROW type ] block
+```
+
+**Statements**:
+```
+let_stmt    = "let" NAME COLON type EQ expr SEMICOLON
+assign_stmt = NAME EQ expr SEMICOLON
+return_stmt = "return" [ expr ] SEMICOLON
+if_stmt     = "if" expr block [ "else" block ]
+while_stmt  = "while" expr block
+loop_stmt   = "loop" block
+break_stmt  = "break" SEMICOLON
+expr_stmt   = expr SEMICOLON
+```
+
+**Expression precedence** (lowest → highest):
+
+| Level | Rule | Operators |
+|-------|------|-----------|
+| 1 | `or_expr` | `\|\|` |
+| 2 | `and_expr` | `&&` |
+| 3 | `eq_expr` | `==`, `!=` |
+| 4 | `cmp_expr` | `<`, `>`, `<=`, `>=` |
+| 5 | `add_expr` | `+`, `-` |
+| 6 | `bitwise_expr` | `&`, `\|`, `^` |
+| 7 | `unary_expr` | `!`, `~` |
+| 8 | `primary` | literals, names, calls, parens |
+
+**Intrinsic calls** (keyword-started, before `call_expr` in primary):
+
+| Intrinsic | Signature | 8008 lowering |
+|-----------|-----------|--------------|
+| `in(PORT)` | → u8 | INP p |
+| `out(PORT, val)` | void | MOV A, Rv; OUT p |
+| `adc(a, b)` | → u8 | MOV A, Ra; ADC Rb |
+| `sbb(a, b)` | → u8 | MOV A, Ra; SBB Rb |
+| `rlc(a)` | → u8 | RLC |
+| `rrc(a)` | → u8 | RRC |
+| `ral(a)` | → u8 | RAL |
+| `rar(a)` | → u8 | RAR |
+| `carry()` | → bool | MVI A,0; ACI 0; MOV Rdst,A |
+| `parity(a)` | → bool | ORA a; conditional materialise |
+
+## AST Node Types
+
+The root is always a `program` node. Key `rule_name` values you will encounter:
+
+- `top_decl`, `static_decl`, `fn_decl`, `param_list`, `param`
+- `block`, `stmt`
+- `let_stmt`, `assign_stmt`, `return_stmt`, `if_stmt`, `while_stmt`, `loop_stmt`, `break_stmt`, `expr_stmt`
+- `or_expr`, `and_expr`, `eq_expr`, `cmp_expr`, `add_expr`, `bitwise_expr`, `unary_expr`, `primary`
+- `intrinsic_call`, `call_expr`, `arg_list`
+
+## Dependencies
+
+- `coding-adventures-oct-lexer` — tokenises Oct source
+- `coding-adventures-parser` — `GrammarParser` engine
+- `coding-adventures-grammar-tools` — `parse_parser_grammar`
+- `coding-adventures-lexer`, `coding-adventures-directed-graph`, `coding-adventures-state-machine` — transitive deps

--- a/code/packages/python/oct-parser/pyproject.toml
+++ b/code/packages/python/oct-parser/pyproject.toml
@@ -1,0 +1,67 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-oct-parser"
+version = "0.1.0"
+description = "Parses Oct source text into ASTs using the grammar-driven approach — a thin wrapper that loads oct.grammar"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["oct", "intel8008", "parser", "ast", "grammar-driven", "compiler", "embedded", "education"]
+dependencies = [
+    "coding-adventures-directed-graph",
+    "coding-adventures-grammar-tools",
+    "coding-adventures-lexer",
+    "coding-adventures-parser",
+    "coding-adventures-state-machine",
+    "coding-adventures-oct-lexer",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Education",
+    "Topic :: Education",
+    "Topic :: Scientific/Engineering",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://github.com/adhithyan15/coding-adventures"
+Repository = "https://github.com/adhithyan15/coding-adventures"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/oct_parser"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort (import sorting)
+    "UP",   # pyupgrade (modern Python syntax)
+    "B",    # bugbear (common bugs)
+    "SIM",  # simplify
+    "ANN",  # type annotation enforcement
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=oct_parser --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.run]
+source = ["src/oct_parser"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/packages/python/oct-parser/src/oct_parser/__init__.py
+++ b/code/packages/python/oct-parser/src/oct_parser/__init__.py
@@ -1,0 +1,33 @@
+"""Oct Parser — parses Oct source text into ASTs using the grammar-driven approach.
+
+This package is a **thin wrapper** around the generic ``GrammarParser``. It
+tokenizes Oct source using the ``oct-lexer`` package, then parses the token
+stream using the EBNF rules defined in ``oct.grammar``, producing a generic
+``ASTNode`` tree.
+
+Oct (2026) is a safe, statically-typed toy language designed to compile to
+Intel 8008 machine code. The name comes from *octet* — the networking term for
+exactly 8 bits, the native word of the Intel 8008 ALU (1972). Oct brings
+static safety guarantees and structured control flow to a CPU with a 16 KB
+address space and a 7-level push-down call stack.
+
+The same parser engine that handles Nib, ALGOL 60, Python, and JSON also
+handles Oct — only the grammar file changes. This demonstrates the language-
+agnostic nature of the grammar-driven approach.
+
+Usage::
+
+    from oct_parser import parse_oct
+
+    ast = parse_oct("fn main() { let x: u8 = 0xFF; }")
+    print(ast.rule_name)  # "program"
+"""
+
+from __future__ import annotations
+
+from oct_parser.parser import create_oct_parser, parse_oct
+
+__all__ = [
+    "create_oct_parser",
+    "parse_oct",
+]

--- a/code/packages/python/oct-parser/src/oct_parser/parser.py
+++ b/code/packages/python/oct-parser/src/oct_parser/parser.py
@@ -1,0 +1,250 @@
+"""Oct Parser — parses Oct source text into ASTs using the grammar-driven approach.
+
+This module is a thin wrapper around the generic ``GrammarParser``. It loads
+``oct.grammar`` from the ``code/grammars/`` directory, tokenizes input using
+the Oct lexer, and produces a generic ``ASTNode`` tree.
+
+What Is Oct?
+------------
+
+Oct is a safe, statically-typed toy language that compiles to Intel 8008 machine
+code. The name comes from "octet" (8 bits), the native word size of the Intel
+8008 microprocessor — a direct ancestor of the x86 family, released in 1972.
+
+The Intel 8008 is highly constrained by modern standards:
+
+- **8-bit words**: The accumulator (A) and GP registers (B, C, D, E) each hold
+  one byte (0–255). All arithmetic wraps modulo 256 unless carry is checked.
+- **4 registers for locals**: Only B, C, D, E are available for function locals;
+  A is the accumulator (scratch); H:L is the memory pointer pair. At most 4
+  local variables (including parameters) per function.
+- **16 KB address space**: 14-bit address bus (0x0000–0x3FFF). ROM occupies
+  0x0000–0x1FFF; the data segment (static variables) is at 0x2000–0x3FFF.
+- **8-level push-down call stack**: The hardware maintains an internal stack of
+  8 program counter registers. One is always in use, leaving 7 call levels.
+- **Separate I/O space**: 8 input ports (INP p, port 0–7) and 24 output ports
+  (OUT p, port 0–23), with port numbers encoded directly in the instruction.
+- **4 hardware flags**: CY (carry), Z (zero), S (sign), P (parity). Oct exposes
+  CY via carry() and adc()/sbb(), and P via parity().
+
+Writing 8008 assembly by hand is tedious and error-prone. Oct gives us a
+higher-level notation with static safety guarantees while remaining faithful
+to the hardware.
+
+Grammar Structure Overview
+---------------------------
+
+The grammar in ``oct.grammar`` defines 8 expression precedence levels
+(lowest → highest)::
+
+    Level 1 — or_expr      : logical OR   (||)
+    Level 2 — and_expr     : logical AND  (&&)
+    Level 3 — eq_expr      : equality     (==, !=)
+    Level 4 — cmp_expr     : relational   (<, >, <=, >=)
+    Level 5 — add_expr     : additive     (+, -)
+    Level 6 — bitwise_expr : bitwise      (&, |, ^)
+    Level 7 — unary_expr   : unary        (!, ~)
+    Level 8 — primary      : leaves       (literals, names, calls, parens)
+
+Top-level structure::
+
+    program     = { top_decl }
+    top_decl    = static_decl | fn_decl
+    static_decl = "static" NAME COLON type EQ expr SEMICOLON
+    fn_decl     = "fn" NAME LPAREN [ param_list ] RPAREN [ ARROW type ] block
+
+Statement kinds::
+
+    let_stmt    = "let" NAME COLON type EQ expr SEMICOLON
+    assign_stmt = NAME EQ expr SEMICOLON
+    return_stmt = "return" [ expr ] SEMICOLON
+    if_stmt     = "if" expr block [ "else" block ]
+    while_stmt  = "while" expr block
+    loop_stmt   = "loop" block
+    break_stmt  = "break" SEMICOLON
+    expr_stmt   = expr SEMICOLON
+
+Intrinsic calls (all begin with keyword tokens, not NAME)::
+
+    in(PORT)          → reads from 8008 input port 0–7
+    out(PORT, val)    → writes to 8008 output port 0–23
+    adc(a, b)         → add with carry (a + b + CY)
+    sbb(a, b)         → subtract with borrow (a - b - CY)
+    rlc(a)            → rotate left circular (CY ← bit7; A ← (A<<1)|bit7)
+    rrc(a)            → rotate right circular
+    ral(a)            → rotate left through carry (9-bit)
+    rar(a)            → rotate right through carry (9-bit)
+    carry()           → read carry flag → bool
+    parity(a)         → read parity flag of a → bool
+
+Design Decisions
+-----------------
+
+**Intrinsics before call_expr in primary**: Intrinsic calls start with keyword
+tokens (``"in"``, ``"carry"``, etc.), not NAME tokens. If ``call_expr`` (which
+requires a NAME) were tried first, the parser would fail to match. Listing
+``intrinsic_call`` first ensures keyword-started calls are routed correctly.
+
+**call_expr before NAME in primary**: A user-defined call starts with NAME + ``(``.
+If NAME were tried first, the parser would consume the function name as a
+variable reference and never see the ``(``. Listing ``call_expr`` before ``NAME``
+prevents this ambiguity.
+
+**type = NAME**: Type annotations (``u8``, ``bool``) are NAME tokens with
+specific values, not keywords. This keeps the keyword set minimal and moves
+type validation to the type-checker, where it belongs.
+
+**return with optional expr**: ``return;`` (void) and ``return expr;`` (non-void)
+share one grammar rule with an optional expression. The type-checker validates
+that a value is returned when the function declares a return type.
+
+**Both static and let in stmt**: The grammar allows ``static_decl`` inside
+function bodies. The type-checker rejects this — static declarations are
+only valid at file scope. The parser is deliberately permissive; the type-
+checker is where scope rules belong.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from grammar_tools import parse_parser_grammar
+from lang_parser import ASTNode, GrammarParser
+from oct_lexer import tokenize_oct
+
+# ---------------------------------------------------------------------------
+# Grammar File Location
+# ---------------------------------------------------------------------------
+
+GRAMMAR_DIR = Path(__file__).parent.parent.parent.parent.parent.parent / "grammars"
+OCT_GRAMMAR_PATH = GRAMMAR_DIR / "oct.grammar"
+
+
+def create_oct_parser(source: str) -> GrammarParser:
+    """Create a ``GrammarParser`` configured for Oct source text.
+
+    This function:
+
+    1. Tokenizes the source text using the Oct lexer.
+    2. Reads and parses the ``oct.grammar`` file.
+    3. Creates a ``GrammarParser`` with those tokens and grammar rules.
+
+    The parser handles all Oct grammar features, including:
+
+    - Top-level declarations (``static``, ``fn``) with no enclosing module or
+      main block — the entry point is ``fn main()`` found by convention.
+    - Full expression precedence hierarchy with 8 levels (logical OR down to
+      primary). For example, ``a + b & c == d && e`` parses as
+      ``((a + (b & c)) == d) && e`` without explicit parentheses.
+    - Intrinsic calls (``in``, ``out``, ``adc``, ``sbb``, ``rlc``, ``rrc``,
+      ``ral``, ``rar``, ``carry``, ``parity``) matched before user-defined
+      calls, because they begin with keyword tokens not NAME tokens.
+    - User-defined function calls matched before bare NAME references, to avoid
+      consuming the function name as a variable before seeing the ``(``.
+    - Brace-delimited blocks on all if/else/while/loop/fn bodies — no dangling-
+      else ambiguity.
+    - Optional else branch on ``if`` statements.
+    - Optional expression on ``return`` (for void functions: ``return;``).
+    - Both ``while`` and ``loop`` loops; ``break`` exits the innermost one.
+
+    Args:
+        source: The Oct source text to parse.
+
+    Returns:
+        A ``GrammarParser`` instance ready to produce an AST.
+        Call ``.parse()`` on it to get the root ``ASTNode``.
+
+    Raises:
+        FileNotFoundError: If the grammar files cannot be found.
+        LexerError: If the source contains characters not valid in Oct.
+        GrammarParseError: If the source has syntax errors per the Oct grammar.
+
+    Example::
+
+        parser = create_oct_parser("fn main() { let x: u8 = 0xFF; }")
+        ast = parser.parse()
+    """
+    tokens = tokenize_oct(source)
+    grammar = parse_parser_grammar(OCT_GRAMMAR_PATH.read_text())
+    return GrammarParser(tokens, grammar)
+
+
+def parse_oct(source: str) -> ASTNode:
+    """Parse Oct source text and return the root AST node.
+
+    This is the main entry point for the Oct parser. It tokenizes the source
+    with the Oct lexer, parses with the Oct grammar, and returns an ``ASTNode``
+    tree rooted at a ``"program"`` node.
+
+    The AST is a generic tree of ``ASTNode`` and ``Token`` objects — the same
+    structure used by every grammar-driven parser in this repository (Nib,
+    ALGOL 60, Python, JSON, etc.). The ``rule_name`` attribute identifies each
+    interior node; leaf nodes are ``Token`` objects.
+
+    Top-level node types (``rule_name`` values at depth 2):
+
+    - ``static_decl`` — static variable: ``static counter: u8 = 0;``
+    - ``fn_decl`` — function definition with optional return type
+
+    Statement node types (``rule_name`` values you will encounter):
+
+    - ``let_stmt``    — local variable binding: ``let x: u8 = 42;``
+    - ``assign_stmt`` — variable mutation: ``x = x + 1;``
+    - ``return_stmt`` — function return: ``return result;`` or ``return;``
+    - ``if_stmt``     — conditional: ``if carry() { … } else { … }``
+    - ``while_stmt``  — while loop: ``while n != 0 { … }``
+    - ``loop_stmt``   — infinite loop: ``loop { … }``
+    - ``break_stmt``  — loop exit: ``break;``
+    - ``expr_stmt``   — expression as statement: ``out(1, x);``
+
+    Expression node types (lowest to highest precedence):
+
+    - ``or_expr``, ``and_expr``, ``eq_expr``, ``cmp_expr``
+    - ``add_expr``, ``bitwise_expr``, ``unary_expr``, ``primary``
+    - ``intrinsic_call`` — e.g. ``carry()``, ``in(0)``, ``adc(a, b)``
+    - ``call_expr`` — user-defined function call
+
+    A program with no top-level declarations is valid (the grammar uses
+    ``{ top_decl }`` meaning zero or more). An empty string produces a
+    ``program`` node with no children.
+
+    Args:
+        source: The Oct source text to parse.
+
+    Returns:
+        An ``ASTNode`` representing the parse tree. The root node's
+        ``rule_name`` is ``"program"``.
+
+    Raises:
+        FileNotFoundError: If the grammar files cannot be found.
+        LexerError: If the source contains characters not valid in Oct.
+        GrammarParseError: If the source has syntax errors per the Oct grammar.
+
+    Example — simple function::
+
+        ast = parse_oct("fn main() { let x: u8 = 5; }")
+        # ASTNode(rule_name="program", children=[
+        #   ASTNode(rule_name="top_decl", children=[
+        #     ASTNode(rule_name="fn_decl", children=[
+        #       Token(fn, 'fn'),
+        #       Token(NAME, 'main'),
+        #       Token(LPAREN, '('),
+        #       Token(RPAREN, ')'),
+        #       ASTNode(rule_name="block", children=[
+        #         Token(LBRACE, '{'),
+        #         ASTNode(rule_name="stmt", children=[
+        #           ASTNode(rule_name="let_stmt", children=[...])
+        #         ]),
+        #         Token(RBRACE, '}')
+        #       ])
+        #     ])
+        #   ])
+        # ])
+
+    Example — intrinsic call::
+
+        ast = parse_oct("fn main() { let b: u8 = in(0); out(8, b); }")
+        # The 'in(0)' appears as an intrinsic_call node under primary.
+    """
+    parser = create_oct_parser(source)
+    return parser.parse()

--- a/code/packages/python/oct-parser/tests/test_oct_parser.py
+++ b/code/packages/python/oct-parser/tests/test_oct_parser.py
@@ -1,0 +1,515 @@
+"""Tests for the oct_parser package.
+
+Oct is a small, statically-typed, 8-bit systems programming language targeting
+the Intel 8008 microprocessor (1972).  The parser consumes the token stream
+produced by the Oct lexer and produces a generic ``ASTNode`` tree using the
+EBNF rules defined in ``oct.grammar``.
+
+This test suite validates:
+  - The root node has rule_name "program"
+  - Empty source produces a program with no children
+  - All top-level declaration forms parse to the correct rule names
+  - All statement kinds produce their expected AST structure
+  - All 10 intrinsic calls parse without error as intrinsic_call nodes
+  - The complete OCT00 spec program examples parse without error
+  - Operator precedence is respected (tested via structural checks)
+  - Type annotations using NAME tokens are accepted
+"""
+
+from __future__ import annotations
+
+from oct_parser import parse_oct
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _rule(node: object) -> str:
+    """Return the rule_name of an ASTNode, or the type of a Token."""
+    if hasattr(node, "rule_name"):
+        return node.rule_name  # type: ignore[attr-defined]
+    return node.type  # type: ignore[attr-defined]
+
+
+def _children(node: object) -> list[object]:
+    """Return the children of an ASTNode (empty list for Token)."""
+    if hasattr(node, "children"):
+        return node.children  # type: ignore[attr-defined]
+    return []
+
+
+def _find_rules(node: object, rule: str) -> list[object]:
+    """Depth-first search: collect all nodes with rule_name == rule."""
+    results = []
+    if _rule(node) == rule:
+        results.append(node)
+    for child in _children(node):
+        results.extend(_find_rules(child, rule))
+    return results
+
+
+def _find_token_values(node: object, token_type: str) -> list[str]:
+    """Depth-first search: collect Token values where token.type == token_type."""
+    results: list[str] = []
+    if hasattr(node, "type") and node.type == token_type:  # type: ignore[attr-defined]
+        results.append(node.value)  # type: ignore[attr-defined]
+    for child in _children(node):
+        results.extend(_find_token_values(child, token_type))
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Basic structure
+# ---------------------------------------------------------------------------
+
+class TestParseOctBasic:
+    """Root node shape and trivial programs."""
+
+    def test_root_is_program(self) -> None:
+        """parse_oct always returns a 'program' node."""
+        ast = parse_oct("")
+        assert _rule(ast) == "program"
+
+    def test_empty_program_has_no_top_decls(self) -> None:
+        """Empty source → program node with no children (or only non-decl)."""
+        ast = parse_oct("")
+        top_decls = _find_rules(ast, "top_decl")
+        assert top_decls == []
+
+    def test_single_function_parses(self) -> None:
+        """A minimal fn main() { } produces exactly one fn_decl."""
+        ast = parse_oct("fn main() { }")
+        fn_decls = _find_rules(ast, "fn_decl")
+        assert len(fn_decls) == 1
+
+    def test_single_static_parses(self) -> None:
+        """A single static declaration produces exactly one static_decl."""
+        ast = parse_oct("static counter: u8 = 0;")
+        static_decls = _find_rules(ast, "static_decl")
+        assert len(static_decls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Static declarations
+# ---------------------------------------------------------------------------
+
+class TestStaticDeclarations:
+    """static_decl forms: u8/bool types, literal kinds, multiple statics."""
+
+    def test_static_u8_decimal(self) -> None:
+        ast = parse_oct("static counter: u8 = 0;")
+        assert len(_find_rules(ast, "static_decl")) == 1
+
+    def test_static_u8_hex(self) -> None:
+        ast = parse_oct("static mask: u8 = 0xFF;")
+        assert len(_find_rules(ast, "static_decl")) == 1
+
+    def test_static_u8_binary(self) -> None:
+        ast = parse_oct("static flags: u8 = 0b10110011;")
+        assert len(_find_rules(ast, "static_decl")) == 1
+
+    def test_static_bool_false(self) -> None:
+        ast = parse_oct("static ready: bool = false;")
+        assert len(_find_rules(ast, "static_decl")) == 1
+
+    def test_static_bool_true(self) -> None:
+        ast = parse_oct("static done: bool = true;")
+        assert len(_find_rules(ast, "static_decl")) == 1
+
+    def test_multiple_statics(self) -> None:
+        source = "static lo: u8 = 0;\nstatic hi: u8 = 0;"
+        ast = parse_oct(source)
+        assert len(_find_rules(ast, "static_decl")) == 2
+
+    def test_static_and_fn(self) -> None:
+        source = "static x: u8 = 1;\nfn main() { }"
+        ast = parse_oct(source)
+        assert len(_find_rules(ast, "static_decl")) == 1
+        assert len(_find_rules(ast, "fn_decl")) == 1
+
+
+# ---------------------------------------------------------------------------
+# Function declarations
+# ---------------------------------------------------------------------------
+
+class TestFunctionDeclarations:
+    """fn_decl forms: void, return type, parameters."""
+
+    def test_void_no_params(self) -> None:
+        ast = parse_oct("fn main() { }")
+        fn_decls = _find_rules(ast, "fn_decl")
+        assert len(fn_decls) == 1
+
+    def test_with_return_type(self) -> None:
+        ast = parse_oct("fn double(x: u8) -> u8 { return x + x; }")
+        fn_decls = _find_rules(ast, "fn_decl")
+        assert len(fn_decls) == 1
+
+    def test_with_two_params(self) -> None:
+        ast = parse_oct("fn add(a: u8, b: u8) -> u8 { return a + b; }")
+        fn_decls = _find_rules(ast, "fn_decl")
+        assert len(fn_decls) == 1
+        param_list = _find_rules(ast, "param_list")
+        assert len(param_list) == 1
+
+    def test_with_four_params(self) -> None:
+        """Four parameters — the maximum allowed by the 8008 register file."""
+        source = "fn max4(a: u8, b: u8, c: u8, d: u8) -> u8 { return a; }"
+        ast = parse_oct(source)
+        params = _find_rules(ast, "param")
+        assert len(params) == 4
+
+    def test_multiple_functions(self) -> None:
+        source = "fn tick() { }\nfn main() { tick(); }"
+        ast = parse_oct(source)
+        assert len(_find_rules(ast, "fn_decl")) == 2
+
+    def test_empty_body(self) -> None:
+        ast = parse_oct("fn noop() { }")
+        blocks = _find_rules(ast, "block")
+        assert len(blocks) == 1
+
+
+# ---------------------------------------------------------------------------
+# Statements
+# ---------------------------------------------------------------------------
+
+class TestStatements:
+    """All statement kinds: let, assign, return, if, while, loop, break, expr_stmt."""
+
+    def test_let_stmt(self) -> None:
+        ast = parse_oct("fn f() { let x: u8 = 0; }")
+        assert len(_find_rules(ast, "let_stmt")) == 1
+
+    def test_assign_stmt(self) -> None:
+        ast = parse_oct("fn f() { let x: u8 = 0; x = 1; }")
+        assert len(_find_rules(ast, "assign_stmt")) == 1
+
+    def test_return_with_expr(self) -> None:
+        ast = parse_oct("fn f() -> u8 { return 42; }")
+        assert len(_find_rules(ast, "return_stmt")) == 1
+
+    def test_return_without_expr(self) -> None:
+        """Bare return for void functions: return;"""
+        ast = parse_oct("fn f() { return; }")
+        assert len(_find_rules(ast, "return_stmt")) == 1
+
+    def test_if_without_else(self) -> None:
+        ast = parse_oct("fn f() { if true { let x: u8 = 0; } }")
+        if_stmts = _find_rules(ast, "if_stmt")
+        assert len(if_stmts) == 1
+
+    def test_if_with_else(self) -> None:
+        ast = parse_oct("fn f() { if true { } else { } }")
+        if_stmts = _find_rules(ast, "if_stmt")
+        assert len(if_stmts) == 1
+        # Both branches present → 2 blocks inside if_stmt
+        blocks = _find_rules(ast, "block")
+        assert len(blocks) >= 3  # fn body + if-block + else-block
+
+    def test_while_stmt(self) -> None:
+        ast = parse_oct("fn f() { let n: u8 = 5; while n != 0 { n = n - 1; } }")
+        assert len(_find_rules(ast, "while_stmt")) == 1
+
+    def test_loop_stmt(self) -> None:
+        ast = parse_oct("fn f() { loop { } }")
+        assert len(_find_rules(ast, "loop_stmt")) == 1
+
+    def test_break_stmt(self) -> None:
+        ast = parse_oct("fn f() { loop { break; } }")
+        assert len(_find_rules(ast, "break_stmt")) == 1
+
+    def test_expr_stmt_with_call(self) -> None:
+        """A user-defined function call as a statement."""
+        ast = parse_oct("fn g() { }\nfn f() { g(); }")
+        # expr_stmt contains call_expr
+        assert len(_find_rules(ast, "expr_stmt")) == 1
+        assert len(_find_rules(ast, "call_expr")) >= 1
+
+    def test_nested_if_in_while(self) -> None:
+        source = "fn f() { let n: u8 = 8; while n != 0 { if true { } n = n - 1; } }"
+        ast = parse_oct(source)
+        assert len(_find_rules(ast, "while_stmt")) == 1
+        assert len(_find_rules(ast, "if_stmt")) == 1
+
+    def test_multiple_let_stmts(self) -> None:
+        source = "fn f() { let a: u8 = 1; let b: u8 = 2; let c: u8 = 3; }"
+        ast = parse_oct(source)
+        assert len(_find_rules(ast, "let_stmt")) == 3
+
+
+# ---------------------------------------------------------------------------
+# Expression parsing and precedence
+# ---------------------------------------------------------------------------
+
+class TestExpressions:
+    """Expression kinds and operator precedence."""
+
+    def test_addition(self) -> None:
+        ast = parse_oct("fn f() { let x: u8 = 1 + 2; }")
+        assert len(_find_rules(ast, "add_expr")) >= 1
+
+    def test_subtraction(self) -> None:
+        ast = parse_oct("fn f() { let x: u8 = 5 - 3; }")
+        assert len(_find_rules(ast, "add_expr")) >= 1
+
+    def test_bitwise_and(self) -> None:
+        ast = parse_oct("fn f() { let x: u8 = 0xFF & 0x0F; }")
+        assert len(_find_rules(ast, "bitwise_expr")) >= 1
+
+    def test_bitwise_or(self) -> None:
+        ast = parse_oct("fn f() { let x: u8 = 0x0F | 0xF0; }")
+        assert len(_find_rules(ast, "bitwise_expr")) >= 1
+
+    def test_bitwise_xor(self) -> None:
+        ast = parse_oct("fn f() { let x: u8 = a ^ b; }")
+        assert len(_find_rules(ast, "bitwise_expr")) >= 1
+
+    def test_unary_not_bitwise(self) -> None:
+        ast = parse_oct("fn f() { let x: u8 = ~a; }")
+        assert len(_find_rules(ast, "unary_expr")) >= 1
+
+    def test_unary_not_logical(self) -> None:
+        ast = parse_oct("fn f() { let ok: bool = !false; }")
+        assert len(_find_rules(ast, "unary_expr")) >= 1
+
+    def test_equality_eq_eq(self) -> None:
+        ast = parse_oct("fn f() { if a == 0 { } }")
+        assert len(_find_rules(ast, "eq_expr")) >= 1
+
+    def test_equality_neq(self) -> None:
+        ast = parse_oct("fn f() { if n != 255 { } }")
+        assert len(_find_rules(ast, "eq_expr")) >= 1
+
+    def test_comparison_lt(self) -> None:
+        ast = parse_oct("fn f() { if a < b { } }")
+        assert len(_find_rules(ast, "cmp_expr")) >= 1
+
+    def test_comparison_geq(self) -> None:
+        ast = parse_oct("fn f() { if a >= 128 { } }")
+        assert len(_find_rules(ast, "cmp_expr")) >= 1
+
+    def test_logical_and(self) -> None:
+        ast = parse_oct("fn f() { if a == 0 && b == 0 { } }")
+        assert len(_find_rules(ast, "and_expr")) >= 1
+
+    def test_logical_or(self) -> None:
+        ast = parse_oct("fn f() { if a == 0 || b == 0 { } }")
+        assert len(_find_rules(ast, "or_expr")) >= 1
+
+    def test_parenthesised_expression(self) -> None:
+        """Parentheses group correctly: (a + b) & mask."""
+        ast = parse_oct("fn f() { let x: u8 = (a + b) & mask; }")
+        # No parse error means precedence is resolved
+        assert _rule(ast) == "program"
+
+    def test_literal_true_in_expr(self) -> None:
+        ast = parse_oct("fn f() { let ok: bool = true; }")
+        # 'true' should appear as a token value somewhere
+        true_tokens = _find_token_values(ast, "true")
+        assert true_tokens == ["true"]
+
+    def test_literal_false_in_expr(self) -> None:
+        ast = parse_oct("fn f() { let ok: bool = false; }")
+        false_tokens = _find_token_values(ast, "false")
+        assert false_tokens == ["false"]
+
+    def test_hex_literal_in_expr(self) -> None:
+        ast = parse_oct("fn f() { let x: u8 = 0xFF; }")
+        assert len(_find_token_values(ast, "HEX_LIT")) == 1
+
+    def test_binary_literal_in_expr(self) -> None:
+        ast = parse_oct("fn f() { let x: u8 = 0b10110011; }")
+        assert len(_find_token_values(ast, "BIN_LIT")) == 1
+
+
+# ---------------------------------------------------------------------------
+# Intrinsic calls
+# ---------------------------------------------------------------------------
+
+class TestIntrinsicCalls:
+    """All 10 Oct intrinsics parse without error and produce intrinsic_call nodes."""
+
+    def _ast_with_intrinsic(self, call: str) -> object:
+        return parse_oct(f"fn f() {{ let x: u8 = {call}; }}")
+
+    def _void_intrinsic(self, call: str) -> object:
+        return parse_oct(f"fn f() {{ {call}; }}")
+
+    def test_in_call(self) -> None:
+        """in(0) — read from input port 0."""
+        ast = self._ast_with_intrinsic("in(0)")
+        assert len(_find_rules(ast, "intrinsic_call")) >= 1
+
+    def test_out_call_as_stmt(self) -> None:
+        """out(1, x) — write to output port 1 (used as statement)."""
+        ast = self._void_intrinsic("out(1, x)")
+        assert len(_find_rules(ast, "intrinsic_call")) >= 1
+
+    def test_adc_call(self) -> None:
+        """adc(a, b) — add with carry."""
+        ast = self._ast_with_intrinsic("adc(a, b)")
+        assert len(_find_rules(ast, "intrinsic_call")) >= 1
+
+    def test_sbb_call(self) -> None:
+        """sbb(a, b) — subtract with borrow."""
+        ast = self._ast_with_intrinsic("sbb(a, b)")
+        assert len(_find_rules(ast, "intrinsic_call")) >= 1
+
+    def test_rlc_call(self) -> None:
+        """rlc(x) — rotate left circular."""
+        ast = self._ast_with_intrinsic("rlc(x)")
+        assert len(_find_rules(ast, "intrinsic_call")) >= 1
+
+    def test_rrc_call(self) -> None:
+        """rrc(x) — rotate right circular."""
+        ast = self._ast_with_intrinsic("rrc(x)")
+        assert len(_find_rules(ast, "intrinsic_call")) >= 1
+
+    def test_ral_call(self) -> None:
+        """ral(x) — rotate left through carry (9-bit)."""
+        ast = self._ast_with_intrinsic("ral(x)")
+        assert len(_find_rules(ast, "intrinsic_call")) >= 1
+
+    def test_rar_call(self) -> None:
+        """rar(x) — rotate right through carry (9-bit)."""
+        ast = self._ast_with_intrinsic("rar(x)")
+        assert len(_find_rules(ast, "intrinsic_call")) >= 1
+
+    def test_carry_call(self) -> None:
+        """carry() — read carry flag (zero arguments)."""
+        ast = self._ast_with_intrinsic("carry()")
+        assert len(_find_rules(ast, "intrinsic_call")) >= 1
+
+    def test_parity_call(self) -> None:
+        """parity(b) — read parity flag of b."""
+        ast = self._ast_with_intrinsic("parity(b)")
+        assert len(_find_rules(ast, "intrinsic_call")) >= 1
+
+    def test_carry_in_if_condition(self) -> None:
+        """carry() used as a condition: if carry() { … }"""
+        ast = parse_oct("fn f() { if carry() { } }")
+        assert len(_find_rules(ast, "intrinsic_call")) >= 1
+
+    def test_in_with_nested_expr(self) -> None:
+        """in port can be any expr (type-checker validates constant later)."""
+        ast = self._ast_with_intrinsic("in(0)")
+        assert _rule(ast) == "program"
+
+
+# ---------------------------------------------------------------------------
+# Complete programs from OCT00 spec
+# ---------------------------------------------------------------------------
+
+class TestCompletePrograms:
+    """All five OCT00 spec example programs parse without error."""
+
+    def test_example1_echo_input_to_output(self) -> None:
+        """Echo input to output — loop with in() and out()."""
+        source = """
+        fn main() {
+            loop {
+                let b: u8 = in(0);
+                out(8, b);
+            }
+        }
+        """
+        ast = parse_oct(source)
+        assert _rule(ast) == "program"
+        assert len(_find_rules(ast, "fn_decl")) == 1
+        assert len(_find_rules(ast, "loop_stmt")) == 1
+        assert len(_find_rules(ast, "let_stmt")) == 1
+
+    def test_example2_count_to_255(self) -> None:
+        """Count from 0 to 255, output each value."""
+        source = """
+        fn main() {
+            let n: u8 = 0;
+            while n != 255 {
+                out(1, n);
+                n = n + 1;
+            }
+            out(1, 255);
+        }
+        """
+        ast = parse_oct(source)
+        assert _rule(ast) == "program"
+        assert len(_find_rules(ast, "while_stmt")) == 1
+        assert len(_find_rules(ast, "assign_stmt")) == 1
+
+    def test_example3_xor_checksum(self) -> None:
+        """XOR checksum of 8 bytes from port 0, output to port 1."""
+        source = """
+        fn main() {
+            let checksum: u8 = 0;
+            let i: u8 = 0;
+            while i != 8 {
+                let b: u8 = in(0);
+                checksum = checksum ^ b;
+                i = i + 1;
+            }
+            out(1, checksum);
+        }
+        """
+        ast = parse_oct(source)
+        assert _rule(ast) == "program"
+        # checksum, i, b (inside while) = 3 let stmts minimum
+        assert len(_find_rules(ast, "let_stmt")) >= 3
+
+    def test_example4_16bit_counter_with_carry(self) -> None:
+        """16-bit counter using carry() — two statics, two functions."""
+        source = """
+        static lo: u8 = 0;
+        static hi: u8 = 0;
+
+        fn tick() {
+            let l: u8 = lo;
+            l = l + 1;
+            lo = l;
+            if carry() {
+                let h: u8 = hi;
+                h = h + 1;
+                hi = h;
+                out(1, h);
+            }
+        }
+
+        fn main() {
+            loop {
+                tick();
+            }
+        }
+        """
+        ast = parse_oct(source)
+        assert _rule(ast) == "program"
+        assert len(_find_rules(ast, "static_decl")) == 2
+        assert len(_find_rules(ast, "fn_decl")) == 2
+        assert len(_find_rules(ast, "if_stmt")) == 1
+        carry_intrinsics = _find_rules(ast, "intrinsic_call")
+        assert len(carry_intrinsics) >= 1
+
+    def test_example5_bit_reversal_with_rotations(self) -> None:
+        """Bit reversal using ral/rar — two functions, both rotation intrinsics."""
+        source = """
+        fn reverse_bits(x: u8) -> u8 {
+            let result: u8 = 0;
+            let i: u8 = 0;
+            while i != 8 {
+                x = ral(x);
+                result = rar(result);
+                i = i + 1;
+            }
+            return result;
+        }
+
+        fn main() {
+            let b: u8 = in(0);
+            out(1, reverse_bits(b));
+        }
+        """
+        ast = parse_oct(source)
+        assert _rule(ast) == "program"
+        assert len(_find_rules(ast, "fn_decl")) == 2
+        assert len(_find_rules(ast, "return_stmt")) == 1
+        intrinsics = _find_rules(ast, "intrinsic_call")
+        assert len(intrinsics) >= 3  # ral + rar + in + out = 4

--- a/lessons.md
+++ b/lessons.md
@@ -3003,3 +3003,38 @@ already green, and the failed jobs never reached repository code.
 **Rule:** When CI fails in job setup while downloading third-party action archives, inspect the job
 logs before changing package code. If the failure happens before checkout or tool setup commands,
 treat it as infrastructure/transient unless repeated runs prove otherwise.
+
+---
+
+### 2026-04-20: GrammarLexer returns TokenType enum values; test helpers must normalize
+
+When writing tests for grammar-driven lexer wrappers (like `oct-lexer`, `nib-lexer`), the
+`GrammarLexer` returns `Token` objects where:
+- Keyword tokens (after promotion in `tokenize_*`) have `type` set to a **string** (e.g. `"fn"`,
+  `"carry"`)
+- All other tokens keep the `TokenType` **enum** value (e.g. `TokenType.LPAREN`, `TokenType.NAME`)
+
+If test helpers compare `t.type` directly against strings, non-keyword token tests will fail
+with diffs like:
+```
+At index 1 diff: (<TokenType.LPAREN: 11>, '(') != ('LPAREN', '(')
+```
+
+And the EOF filter `t.type != "EOF"` will never exclude EOF tokens because
+`TokenType.EOF != "EOF"` is `True`.
+
+**Fix:** Add a `_tok_type` normalizer helper that converts both forms to a plain string:
+```python
+def _tok_type(tok: Token) -> str:
+    return tok.type if isinstance(tok.type, str) else tok.type.name
+```
+
+Use it everywhere `t.type` is compared or used for filtering. This pattern is established in
+`nib-lexer` and must be replicated in every new `*-lexer` test file.
+
+**Root cause:** The design intentionally keeps non-keyword token types as enums to preserve
+the `TokenType` enum contract for downstream consumers (parsers). Only keyword tokens are
+promoted to string types so the parser's grammar rules can match them by value.
+
+**Rule:** Every grammar-driven lexer test file must use a `_tok_type` normalizer. Never compare
+`t.type` directly against string literals unless you know the token is a keyword.


### PR DESCRIPTION
## Summary

Implements **Phases 5 and 6** of the OCT00 implementation roadmap — the complete Oct language frontend.

- **`code/grammars/oct.tokens`** — token definitions: 21 keywords (including 10 intrinsics: `in`, `out`, `adc`, `sbb`, `rlc`, `rrc`, `ral`, `rar`, `carry`, `parity`), binary/hex/decimal literals, all operators, delimiters, skip patterns
- **`code/grammars/oct.grammar`** — EBNF grammar: 8 expression precedence levels (logical OR → primary), 8 statement kinds (let, assign, return, if/else, while, loop, break, expr_stmt), `intrinsic_call` rule for all 10 Oct intrinsics with keyword-token matching
- **`oct-lexer`** — thin `GrammarLexer` wrapper with `tokenize_oct()` / `create_oct_lexer()`; 60-test suite
- **`oct-parser`** — thin `GrammarParser` wrapper with `parse_oct()` / `create_oct_parser()`; 70-test suite

Both packages follow the exact same architecture as `nib-lexer` / `nib-parser`. All five OCT00 spec program examples are covered by the test suites. All code passes `ruff`.

## Test plan

- [ ] `oct-lexer` CI build passes (lexer tests: empty source, all keywords, all intrinsic keywords, BIN_LIT/HEX_LIT/INT_LIT, all operators, all delimiters, whitespace/comment skipping, all five spec programs)
- [ ] `oct-parser` CI build passes (parser tests: all declaration forms, all statement kinds, all 10 intrinsics, operator precedence, all five spec programs)
- [ ] No merge conflicts with main

🤖 Generated with [Claude Code](https://claude.com/claude-code)