### PR TITLE
feat(symbolic-vm): Phase 3 transcendental integration (linear extensions)

### DIFF
--- a/code/packages/python/symbolic-vm/CHANGELOG.md
+++ b/code/packages/python/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## 0.8.0 — 2026-04-20
+
+Phase 3 of the integration roadmap — transcendental integration for the
+most common single-extension cases. Extends the integrator to handle
+polynomials multiplied by `exp`, `log`, `sin`, or `cos` of a **linear**
+argument `a·x + b`.
+
+Five new cases, two algorithms:
+
+- **Case 3a**: `∫ exp(ax+b) dx = exp(ax+b)/a` — generalises the
+  existing Phase 1 `exp(x)` rule to any linear argument.
+- **Case 3b**: `∫ sin(ax+b) dx = −cos(ax+b)/a` — generalises `sin(x)`.
+- **Case 3c**: `∫ cos(ax+b) dx = sin(ax+b)/a` — generalises `cos(x)`.
+- **Case 3d**: `∫ p(x)·exp(ax+b) dx` for `p ∈ Q[x]` — solved by the
+  **Risch differential equation** `g′ + a·g = p` via back-substitution;
+  result is `g(x)·exp(ax+b)`.
+- **Case 3e**: `∫ p(x)·log(ax+b) dx` for `p ∈ Q[x]` — solved by
+  **integration by parts** followed by polynomial long division; result
+  is `[P(x) − P(−b/a)]·log(ax+b) − S(x)`.
+
+New modules:
+- `symbolic_vm.exp_integral`: `exp_integral(poly, a, b, x_sym)` —
+  implements cases 3a and 3d.
+- `symbolic_vm.log_integral`: `log_poly_integral(poly, a, b, x_sym)` —
+  implements case 3e (and the `log(x)` case of 3e extends Phase 1's
+  hard-coded result to arbitrary linear arguments).
+
+`polynomial_bridge.py` gains a public `linear_to_ir(a, b, x)` helper
+shared by both new modules.
+
+`_integrate` in `integrate.py` gains:
+- Extended elementary-function section recognising `EXP`/`SIN`/`COS`/
+  `LOG` of linear arguments (cases 3a–3c, 3e-bare).
+- Two new helper functions `_try_exp_product` and `_try_log_product`
+  wired into the `MUL` branch to handle cases 3d and 3e.
+- `_try_linear` helper that recognises `a·x + b` in the IR.
+
+New spec `code/specs/phase3-transcendental.md` documents all five
+cases with step-by-step algorithms and worked examples.
+
+33 new tests (`tests/test_phase3.py`). Package at 280 tests, 89% coverage.
+
 ## 0.7.0 — 2026-04-20
 
 Phase 2f of the integration roadmap — mixed partial-fraction integration

--- a/code/packages/python/symbolic-vm/pyproject.toml
+++ b/code/packages/python/symbolic-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-symbolic-vm"
-version = "0.7.0"
+version = "0.8.0"
 description = "Pluggable symbolic VM — evaluates symbolic-ir trees through swappable backends (strict numeric vs. Mathematica-style symbolic rewriting)."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/exp_integral.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/exp_integral.py
@@ -1,0 +1,75 @@
+"""Polynomial × exp(linear) integration — Phase 3d.
+
+Integrates ``p(x) · exp(a·x + b)`` for ``p ∈ Q[x]`` and ``a ∈ Q \\ {0}``
+by solving the Risch differential equation
+
+    g′(x) + a·g(x) = p(x)
+
+over ``Q[x]``.  The solution always exists and is unique when ``a ≠ 0``
+and ``p`` is a polynomial: ``g`` has the same degree as ``p``, and its
+coefficients are determined by back-substitution starting from the
+leading term:
+
+    gₙ = pₙ / a
+    gₖ = (pₖ − (k+1)·gₖ₊₁) / a     for k = n−1, ..., 0
+
+The antiderivative is ``g(x) · exp(a·x + b)``.
+
+See ``code/specs/phase3-transcendental.md`` for the full derivation.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+from polynomial import Polynomial, normalize
+from symbolic_ir import EXP, MUL, IRApply, IRNode, IRSymbol
+
+from symbolic_vm.polynomial_bridge import from_polynomial, linear_to_ir
+
+
+def exp_integral(
+    poly: Polynomial,
+    a: Fraction,
+    b: Fraction,
+    x_sym: IRSymbol,
+) -> IRNode:
+    """Return the IR for ``∫ poly(x) · exp(a·x + b) dx``.
+
+    Pre-conditions (caller's responsibility):
+    - ``a ≠ 0``
+    - ``poly`` is a non-empty polynomial with ``Fraction`` coefficients.
+
+    The result is always a closed-form IR.  The caller must verify ``a ≠ 0``
+    before calling (otherwise the Risch DE has no polynomial solution).
+    """
+    p = tuple(Fraction(c) for c in normalize(poly))
+    if not p:
+        p = (Fraction(0),)
+
+    g = _solve_risch_de_poly(p, a)
+
+    exp_arg = linear_to_ir(a, b, x_sym)
+    exp_ir = IRApply(EXP, (exp_arg,))
+    g_ir = from_polynomial(g, x_sym)
+    return IRApply(MUL, (g_ir, exp_ir))
+
+
+def _solve_risch_de_poly(p: Polynomial, a: Fraction) -> Polynomial:
+    """Solve ``g′ + a·g = p`` in ``Q[x]``, returning ``g`` as a tuple.
+
+    ``p`` must be non-empty (non-zero polynomial).  ``a`` must be non-zero.
+    The result has the same degree as ``p``.
+    """
+    n = len(p) - 1  # degree of p (and g)
+    g: list[Fraction] = [Fraction(0)] * (n + 1)
+
+    # Back-substitution from the leading coefficient downward.
+    g[n] = p[n] / a
+    for k in range(n - 1, -1, -1):
+        g[k] = (p[k] - Fraction(k + 1) * g[k + 1]) / a
+
+    return tuple(g)
+
+
+__all__ = ["exp_integral"]

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/integrate.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/integrate.py
@@ -42,10 +42,10 @@ What this phase can't do (yet)
 ------------------------------
 
 - Integration by substitution (except trivial constant-factor / sum).
-- Integration by parts (except the hard-coded ``log`` case).
+- Rational × transcendental (e.g. ``(1/x)·eˣ``).
+- Products of two transcendentals (e.g. ``exp(x)·log(x)``).
 - Irreducible denominators of degree > 2 (e.g. ``1/(x³+x+1)``).
 - Mixed denominators with both linear and quadratic irreducible factors.
-- Any expression with two x-dependent, non-rational factors.
 
 Anything we can't integrate comes back as ``Integrate(f, x)`` unchanged,
 exactly as ``D`` does for unknown heads. The CAS stays consistent — it
@@ -88,9 +88,15 @@ from symbolic_ir import (
 
 from symbolic_vm.arctan_integral import arctan_integral
 from symbolic_vm.backend import Handler
+from symbolic_vm.exp_integral import exp_integral
 from symbolic_vm.hermite import hermite_reduce
+from symbolic_vm.log_integral import log_poly_integral
 from symbolic_vm.mixed_integral import mixed_integral
-from symbolic_vm.polynomial_bridge import from_polynomial, rt_pairs_to_ir, to_rational
+from symbolic_vm.polynomial_bridge import (
+    from_polynomial,
+    rt_pairs_to_ir,
+    to_rational,
+)
 from symbolic_vm.rothstein_trager import rothstein_trager
 
 ONE = IRInteger(1)
@@ -347,9 +353,12 @@ def _integrate(f: IRNode, x: IRSymbol) -> IRNode | None:
         if not _depends_on(b, x):
             ia = _integrate(a, x)
             return None if ia is None else IRApply(MUL, (b, ia))
-        # Both factors depend on x — Phase 1 gives up. Integration by
-        # parts lives in a later phase.
-        return None
+        # Both factors depend on x — try Phase 3 (exp/log products).
+        result = _try_exp_product(a, b, x) or _try_exp_product(b, a, x)
+        if result is not None:
+            return result
+        result = _try_log_product(a, b, x) or _try_log_product(b, a, x)
+        return result  # None if all Phase 3 patterns failed
 
     # --- Quotient (limited: constant denominator, or 1/x) -------------
     if head == DIV:
@@ -393,10 +402,7 @@ def _integrate(f: IRNode, x: IRSymbol) -> IRNode | None:
             return IRApply(DIV, (f, IRApply(LOG, (base,))))
         return None
 
-    # --- Elementary functions at x ------------------------------------
-    # These only fire for the direct ``head(x)`` shape. Chain-rule
-    # composition (e.g. ``sin(2*x)``) is left for later phases; a full
-    # answer requires substitution.
+    # --- Elementary functions at x  (Phase 1: argument must be bare x)
     if len(f.args) == 1 and f.args[0] == x:
         if head == SIN:
             return IRApply(NEG, (IRApply(COS, (x,)),))
@@ -405,8 +411,7 @@ def _integrate(f: IRNode, x: IRSymbol) -> IRNode | None:
         if head == EXP:
             return IRApply(EXP, (x,))
         if head == LOG:
-            # ∫ log(x) dx = x·log(x) - x  (integration by parts,
-            # hard-coded because it's the canonical example).
+            # ∫ log(x) dx = x·log(x) - x.
             return IRApply(
                 SUB,
                 (IRApply(MUL, (x, IRApply(LOG, (x,)))), x),
@@ -420,6 +425,35 @@ def _integrate(f: IRNode, x: IRSymbol) -> IRNode | None:
                     IRApply(POW, (x, IRRational(3, 2))),
                 ),
             )
+
+    # --- Phase 3a/3b/3c: elementary function of a linear argument ------
+    # Generalises the Phase 1 rules above to any a·x + b argument.
+    # Only fires when the argument is strictly linear with a ≠ 0 and
+    # (a, b) ≠ (1, 0) — otherwise the Phase 1 rules above already fired.
+    if len(f.args) == 1 and head in {EXP, SIN, COS, LOG}:
+        lin = _try_linear(f.args[0], x)
+        if lin is not None:
+            a_frac, b_frac = lin
+            if a_frac != 0:
+                if head == EXP:
+                    # ∫ exp(ax+b) dx = exp(ax+b)/a  (case 3a).
+                    # Delegate to exp_integral with p = (1,).
+                    from fractions import Fraction as _F
+                    return exp_integral((_F(1),), a_frac, b_frac, x)
+                if head == SIN:
+                    # ∫ sin(ax+b) dx = -cos(ax+b)/a  (case 3b).
+                    cos_ir = IRApply(COS, (f.args[0],))
+                    a_ir = _frac_ir(a_frac)
+                    return IRApply(NEG, (IRApply(DIV, (cos_ir, a_ir)),))
+                if head == COS:
+                    # ∫ cos(ax+b) dx = sin(ax+b)/a  (case 3c).
+                    sin_ir = IRApply(SIN, (f.args[0],))
+                    a_ir = _frac_ir(a_frac)
+                    return IRApply(DIV, (sin_ir, a_ir))
+                if head == LOG:
+                    # ∫ log(ax+b) dx = case 3e with p = (1,).
+                    from fractions import Fraction as _F
+                    return log_poly_integral((_F(1),), a_frac, b_frac, x)
 
     # Unknown shape — signal "no rule" to the caller.
     return None
@@ -441,6 +475,146 @@ def _is_minus_one(node: IRNode) -> bool:
         and isinstance(node.args[0], IRInteger)
         and node.args[0].value == 1
     )
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 helpers
+# ---------------------------------------------------------------------------
+
+
+def _try_linear(node: IRNode, x: IRSymbol) -> tuple[Fraction, Fraction] | None:
+    """Return ``(a, b)`` if ``node`` represents ``a·x + b`` over Q, else ``None``.
+
+    Handles the IR shapes that the MACSYMA compiler and ``from_polynomial``
+    emit for linear polynomials: bare ``x``, integer/rational constants,
+    ``Neg``, ``Mul(coef, x)``, ``Add(u, v)``, ``Sub(u, v)``.
+    Returns ``None`` for any quadratic or higher term, any float, or any
+    free symbol other than ``x``.
+    """
+    if isinstance(node, IRInteger):
+        return (Fraction(0), Fraction(node.value))
+    if isinstance(node, IRRational):
+        return (Fraction(0), Fraction(node.numer, node.denom))
+    if isinstance(node, IRFloat):
+        return None  # floats break exact arithmetic
+    if isinstance(node, IRSymbol):
+        if node == x:
+            return (Fraction(1), Fraction(0))
+        return None  # free symbol — can't treat as rational constant
+    if not isinstance(node, IRApply):
+        return None
+
+    head = node.head
+    if head == NEG:
+        inner = _try_linear(node.args[0], x)
+        if inner is None:
+            return None
+        a, b = inner
+        return (-a, -b)
+    if head == MUL:
+        left, right = node.args
+        # c·x or x·c where c is free of x.
+        if right == x and not _depends_on(left, x):
+            c = _node_to_frac(left)
+            return (c, Fraction(0)) if c is not None else None
+        if left == x and not _depends_on(right, x):
+            c = _node_to_frac(right)
+            return (c, Fraction(0)) if c is not None else None
+        # Both depend on x — quadratic or higher.
+        return None
+    if head == ADD:
+        u = _try_linear(node.args[0], x)
+        v = _try_linear(node.args[1], x)
+        if u is None or v is None:
+            return None
+        return (u[0] + v[0], u[1] + v[1])
+    if head == SUB:
+        u = _try_linear(node.args[0], x)
+        v = _try_linear(node.args[1], x)
+        if u is None or v is None:
+            return None
+        return (u[0] - v[0], u[1] - v[1])
+    return None
+
+
+def _node_to_frac(node: IRNode) -> Fraction | None:
+    """Return a ``Fraction`` if ``node`` is a numeric literal, else ``None``."""
+    if isinstance(node, IRInteger):
+        return Fraction(node.value)
+    if isinstance(node, IRRational):
+        return Fraction(node.numer, node.denom)
+    return None
+
+
+def _frac_ir(c: Fraction) -> IRNode:
+    """Lift a Fraction to its canonical IR literal."""
+    if c.denominator == 1:
+        return IRInteger(c.numerator)
+    return IRRational(c.numerator, c.denominator)
+
+
+def _try_exp_product(
+    transcendental: IRNode, poly_candidate: IRNode, x: IRSymbol
+) -> IRNode | None:
+    """Return ``∫ poly_candidate · exp(linear) dx`` or ``None``.
+
+    Checks whether ``transcendental`` is ``Exp(linear)`` and
+    ``poly_candidate`` is a polynomial (rational with denominator 1).
+    """
+    if not isinstance(transcendental, IRApply):
+        return None
+    if transcendental.head != EXP:
+        return None
+    lin = _try_linear(transcendental.args[0], x)
+    if lin is None:
+        return None
+    a_frac, b_frac = lin
+    if a_frac == 0:
+        return None  # exp(b) is a constant — constant-factor rule handles it
+
+    r = to_rational(poly_candidate, x)
+    if r is None:
+        return None
+    num, den = r
+    from polynomial import normalize as _norm
+    if len(_norm(den)) > 1:
+        return None  # denominator is not 1 — rational, not polynomial
+    poly = tuple(Fraction(c) for c in _norm(num))
+    if not poly:
+        return None
+    return exp_integral(poly, a_frac, b_frac, x)
+
+
+def _try_log_product(
+    transcendental: IRNode, poly_candidate: IRNode, x: IRSymbol
+) -> IRNode | None:
+    """Return ``∫ poly_candidate · log(linear) dx`` or ``None``.
+
+    Checks whether ``transcendental`` is ``Log(linear)`` and
+    ``poly_candidate`` is a polynomial (rational with denominator 1).
+    """
+    if not isinstance(transcendental, IRApply):
+        return None
+    if transcendental.head != LOG:
+        return None
+    lin = _try_linear(transcendental.args[0], x)
+    if lin is None:
+        return None
+    a_frac, b_frac = lin
+    if a_frac == 0:
+        return None  # log(b) is a constant — constant-factor rule handles it
+
+    r = to_rational(poly_candidate, x)
+    if r is None:
+        return None
+    num, den = r
+    from polynomial import normalize as _norm
+    if len(_norm(den)) > 1:
+        return None  # rational, not polynomial
+    poly = tuple(Fraction(c) for c in _norm(num))
+    if not poly:
+        return None
+    return log_poly_integral(poly, a_frac, b_frac, x)
 
 
 def _depends_on(node: IRNode, var: IRSymbol) -> bool:

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/log_integral.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/log_integral.py
@@ -1,0 +1,136 @@
+"""Polynomial × log(linear) integration — Phase 3e.
+
+Integrates ``p(x) · log(a·x + b)`` for ``p ∈ Q[x]`` and ``a ∈ Q \\ {0}``
+via integration by parts:
+
+    ∫ p(x)·log(a·x + b) dx  =  P(x)·log(a·x + b)  −  ∫ P(x)·a/(a·x + b) dx
+
+where ``P(x) = ∫ p(x) dx`` (polynomial antiderivative, constant = 0).
+
+The residual integral reduces entirely to polynomial arithmetic via long
+division of ``P(x)·a`` by ``(a·x + b)``:
+
+    P(x)·a = Q(x)·(a·x + b) + r        (r = P(−b/a)·a ∈ Q)
+
+    ∫ P(x)·a/(a·x + b) dx  =  S(x)  +  P(−b/a)·log(a·x + b)
+
+where ``S(x) = ∫ Q(x) dx`` is a polynomial.  The final answer is:
+
+    ∫ p(x)·log(a·x + b) dx  =  [P(x) − P(−b/a)] · log(a·x + b) − S(x)
+
+The constant ``P(−b/a)`` is the log coefficient evaluated at the
+singularity ``x = −b/a`` — it cancels the log divergence exactly.
+
+See ``code/specs/phase3-transcendental.md`` for the full derivation and
+worked examples.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+from polynomial import (
+    Polynomial,
+    divmod_poly,
+    multiply,
+    normalize,
+)
+from symbolic_ir import LOG, MUL, SUB, IRApply, IRInteger, IRNode, IRSymbol
+
+from symbolic_vm.polynomial_bridge import from_polynomial, linear_to_ir
+
+
+def log_poly_integral(
+    poly: Polynomial,
+    a: Fraction,
+    b: Fraction,
+    x_sym: IRSymbol,
+) -> IRNode:
+    """Return the IR for ``∫ poly(x) · log(a·x + b) dx``.
+
+    Pre-conditions (caller's responsibility):
+    - ``a ≠ 0``
+    - ``poly`` is a polynomial with ``Fraction`` coefficients.
+
+    Always returns a closed-form IR.
+    """
+    p = tuple(Fraction(c) for c in normalize(poly))
+    if not p:
+        return IRInteger(0)
+
+    # P(x) = ∫ p(x) dx  (polynomial antiderivative, constant = 0).
+    P = _integrate_poly(p)
+
+    # r/a = P(−b/a) — the constant correction to the log coefficient.
+    root = -b / a
+    r_over_a = _poly_eval_exact(P, root)   # = P(−b/a)
+
+    # Q(x) such that P(x)·a = Q(x)·(a·x + b) + r.
+    Pa = multiply(P, (a,))                      # P(x) · a
+    Pa_minus_r = _subtract_constant(Pa, r_over_a * a)  # P(x)·a − r
+    divisor: Polynomial = (b, a)                # constant-first: a·x + b
+    Q_quot, _ = divmod_poly(Pa_minus_r, divisor)
+    Q = normalize(Q_quot)
+
+    # S(x) = ∫ Q(x) dx.
+    S = _integrate_poly(Q) if Q else ()
+
+    # log coefficient: P(x) − P(−b/a).
+    log_coef = _subtract_constant(P, r_over_a)
+
+    # Build IR: [P − P(−b/a)]·log(a·x + b) − S(x).
+    log_arg = linear_to_ir(a, b, x_sym)
+    log_ir = IRApply(LOG, (log_arg,))
+    log_term = _poly_times_log(log_coef, log_ir, x_sym)
+
+    if not normalize(S):
+        return log_term
+
+    s_ir = from_polynomial(S, x_sym)
+    return IRApply(SUB, (log_term, s_ir))
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _integrate_poly(p: Polynomial) -> Polynomial:
+    """Polynomial antiderivative: ``aᵢ·xⁱ → aᵢ/(i+1)·xⁱ⁺¹``."""
+    if not p:
+        return ()
+    result: list[Fraction] = [Fraction(0)]
+    for i, c in enumerate(p):
+        result.append(Fraction(c) / Fraction(i + 1))
+    return normalize(tuple(result))
+
+
+def _poly_eval_exact(p: Polynomial, x_val: Fraction) -> Fraction:
+    """Evaluate polynomial ``p`` at ``x_val`` using Horner's method."""
+    result = Fraction(0)
+    for c in reversed(p):
+        result = result * x_val + Fraction(c)
+    return result
+
+
+def _subtract_constant(p: Polynomial, c: Fraction) -> Polynomial:
+    """Return ``p(x) − c`` as a ``Polynomial`` tuple."""
+    if not p:
+        return ((-c),) if c != 0 else ()
+    lst = [Fraction(coef) for coef in p]
+    lst[0] = lst[0] - c
+    return normalize(tuple(lst))
+
+
+def _poly_times_log(coef_poly: Polynomial, log_ir: IRNode, x_sym: IRSymbol) -> IRNode:
+    """Build IR for ``coef_poly(x) · log_ir``."""
+    n = normalize(coef_poly)
+    if not n:
+        return IRInteger(0)
+    coef_ir = from_polynomial(n, x_sym)
+    if coef_ir == IRInteger(1):
+        return log_ir
+    return IRApply(MUL, (coef_ir, log_ir))
+
+
+__all__ = ["log_poly_integral"]

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/polynomial_bridge.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/polynomial_bridge.py
@@ -302,6 +302,37 @@ def _coef(c) -> IRNode:
 
 
 # ---------------------------------------------------------------------------
+# Linear-argument IR builder (shared by exp_integral.py and log_integral.py)
+# ---------------------------------------------------------------------------
+
+
+def linear_to_ir(a: Fraction, b: Fraction, x: IRSymbol) -> IRNode:
+    """Build IR for ``a·x + b``.
+
+    Produces the simplest canonical form:
+    - ``a == 0``         → constant ``b``
+    - ``a == 1, b == 0`` → bare ``x``
+    - ``b == 0``         → ``a·x``  (or ``Neg(x)`` for ``a == −1``)
+    - general            → ``Add(a·x, b)``
+    """
+    if a == 0:
+        return _coef(Fraction(b))
+
+    # Build the a·x term.
+    if a == 1:
+        ax: IRNode = x
+    elif a == -1:
+        ax = IRApply(NEG, (x,))
+    else:
+        ax = IRApply(MUL, (_coef(Fraction(a)), x))
+
+    if b == 0:
+        return ax
+
+    return IRApply(ADD, (ax, _coef(Fraction(b))))
+
+
+# ---------------------------------------------------------------------------
 # Log-sum IR builder (shared by integrate.py and mixed_integral.py)
 # ---------------------------------------------------------------------------
 

--- a/code/packages/python/symbolic-vm/tests/test_integrate.py
+++ b/code/packages/python/symbolic-vm/tests/test_integrate.py
@@ -253,11 +253,12 @@ def test_integrate_two_x_factors_unevaluated(vm: VM) -> None:
     assert vm.eval(expr) == IRApply(INTEGRATE, (inner, X))
 
 
-def test_integrate_composed_trig_unevaluated(vm: VM) -> None:
-    # ∫ sin(2·x) dx needs substitution — Phase 1 leaves it.
+def test_integrate_composed_trig_now_closed_by_phase3(vm: VM) -> None:
+    # ∫ sin(2·x) dx = −cos(2x)/2  (Phase 3b closes this).
     inner = IRApply(SIN, (IRApply(MUL, (IRInteger(2), X)),))
-    expr = _integrate(inner)
-    assert vm.eval(expr) == IRApply(INTEGRATE, (inner, X))
+    result = vm.eval(_integrate(inner))
+    # Must NOT be unevaluated.
+    assert not (isinstance(result, IRApply) and result.head.name == "Integrate")
 
 
 def test_integrate_unknown_function_unevaluated(vm: VM) -> None:

--- a/code/packages/python/symbolic-vm/tests/test_phase3.py
+++ b/code/packages/python/symbolic-vm/tests/test_phase3.py
@@ -1,0 +1,421 @@
+"""Tests for Phase 3 transcendental integration.
+
+Correctness gate: **numerical re-differentiation** at several x values.
+Every test that expects a closed-form result differentiates the returned
+IR tree numerically and confirms it matches the integrand.
+
+Architecture:
+- ``TestExpIntegral``       — unit tests for exp_integral directly.
+- ``TestLogIntegral``       — unit tests for log_poly_integral directly.
+- ``TestLinearArgTrig``     — sin/cos with linear arguments via VM.
+- ``TestFallsThrough``      — expressions that should stay unevaluated.
+- ``TestEndToEnd``          — full VM Integrate handler, various shapes.
+- ``TestRegressions``       — Phase 1 cases unchanged by Phase 3.
+"""
+
+from __future__ import annotations
+
+import math
+from fractions import Fraction
+
+from symbolic_ir import (
+    ATAN,
+    COS,
+    EXP,
+    INTEGRATE,
+    LOG,
+    SIN,
+    IRApply,
+    IRInteger,
+    IRNode,
+    IRRational,
+    IRSymbol,
+)
+
+from symbolic_vm.backends import SymbolicBackend
+from symbolic_vm.exp_integral import exp_integral
+from symbolic_vm.log_integral import log_poly_integral
+from symbolic_vm.vm import VM
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+X = IRSymbol("x")
+
+
+def P(*coefs: int | float) -> tuple:
+    """Polynomial tuple with Fraction coefficients, constant-first."""
+    return tuple(Fraction(c) for c in coefs)
+
+
+def _eval_ir(node: IRNode, x_val: float) -> float:  # noqa: PLR0911
+    """Numerically evaluate an IR tree at x = x_val."""
+    if isinstance(node, IRInteger):
+        return float(node.value)
+    if isinstance(node, IRRational):
+        return node.numer / node.denom
+    if isinstance(node, IRSymbol):
+        if node.name == "x":
+            return x_val
+        raise ValueError(f"Unknown symbol: {node.name}")
+    if not isinstance(node, IRApply):
+        raise TypeError(f"Unexpected node: {node!r}")
+    head = node.head.name
+    if head == "Add":
+        return _eval_ir(node.args[0], x_val) + _eval_ir(node.args[1], x_val)
+    if head == "Sub":
+        return _eval_ir(node.args[0], x_val) - _eval_ir(node.args[1], x_val)
+    if head == "Mul":
+        return _eval_ir(node.args[0], x_val) * _eval_ir(node.args[1], x_val)
+    if head == "Div":
+        return _eval_ir(node.args[0], x_val) / _eval_ir(node.args[1], x_val)
+    if head == "Neg":
+        return -_eval_ir(node.args[0], x_val)
+    if head == "Inv":
+        return 1.0 / _eval_ir(node.args[0], x_val)
+    if head == "Exp":
+        return math.exp(_eval_ir(node.args[0], x_val))
+    if head == "Log":
+        return math.log(abs(_eval_ir(node.args[0], x_val)))
+    if head == "Sin":
+        return math.sin(_eval_ir(node.args[0], x_val))
+    if head == "Cos":
+        return math.cos(_eval_ir(node.args[0], x_val))
+    if head == "Pow":
+        return _eval_ir(node.args[0], x_val) ** _eval_ir(node.args[1], x_val)
+    if head == "Sqrt":
+        return math.sqrt(_eval_ir(node.args[0], x_val))
+    raise ValueError(f"Unhandled head: {head}")
+
+
+def _numerical_deriv(node: IRNode, x_val: float, h: float = 1e-7) -> float:
+    return (_eval_ir(node, x_val + h) - _eval_ir(node, x_val - h)) / (2 * h)
+
+
+def _integrand_eval(f: IRNode, x_val: float) -> float:
+    return _eval_ir(f, x_val)
+
+
+def assert_antideriv(
+    integrand: IRNode,
+    antideriv: IRNode,
+    test_xs: tuple = (0.5, 1.0, 2.0, 3.0),
+    rtol: float = 1e-5,
+    atol: float = 1e-5,
+) -> None:
+    """Assert d/dx[antideriv] == integrand at every test x.
+
+    Uses a combined absolute + relative tolerance so that tests at large
+    x values (where exp(a·x) is big) don't fail on rounding.
+    """
+    for xv in test_xs:
+        d = _numerical_deriv(antideriv, xv)
+        expected = _integrand_eval(integrand, xv)
+        tol = atol + rtol * abs(expected)
+        assert abs(d - expected) < tol, (
+            f"Re-differentiation failed at x={xv}: "
+            f"d/dx = {d:.8f}, expected = {expected:.8f}"
+        )
+
+
+def _vm_integrate(f: IRNode) -> IRNode:
+    vm = VM(SymbolicBackend())
+    return vm.eval(IRApply(INTEGRATE, (f, X)))
+
+
+def _mul(a: IRNode, b: IRNode) -> IRNode:
+    from symbolic_ir import MUL
+    return IRApply(MUL, (a, b))
+
+
+def _exp(arg: IRNode) -> IRNode:
+    return IRApply(EXP, (arg,))
+
+
+def _sin(arg: IRNode) -> IRNode:
+    return IRApply(SIN, (arg,))
+
+
+def _cos(arg: IRNode) -> IRNode:
+    return IRApply(COS, (arg,))
+
+
+def _log(arg: IRNode) -> IRNode:
+    return IRApply(LOG, (arg,))
+
+
+def _add(a: IRNode, b: IRNode) -> IRNode:
+    from symbolic_ir import ADD
+    return IRApply(ADD, (a, b))
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — exp_integral
+# ---------------------------------------------------------------------------
+
+
+class TestExpIntegral:
+    def test_exp_x(self):
+        # ∫ eˣ dx = eˣ  (a=1, b=0, p=(1,))
+        result = exp_integral(P(1), Fraction(1), Fraction(0), X)
+        assert_antideriv(_exp(X), result)
+
+    def test_exp_2x(self):
+        # ∫ e^(2x) dx = e^(2x)/2
+        a = Fraction(2)
+        arg = _mul(IRInteger(2), X)
+        result = exp_integral(P(1), a, Fraction(0), X)
+        assert_antideriv(_exp(arg), result)
+
+    def test_exp_3x_plus_1(self):
+        # ∫ e^(3x+1) dx = e^(3x+1)/3
+        from symbolic_ir import ADD
+        arg = IRApply(ADD, (_mul(IRInteger(3), X), IRInteger(1)))
+        result = exp_integral(P(1), Fraction(3), Fraction(1), X)
+        assert_antideriv(_exp(arg), result)
+
+    def test_exp_neg_x(self):
+        # ∫ e^(-x) dx = -e^(-x)
+        from symbolic_ir import NEG
+        arg = IRApply(NEG, (X,))
+        result = exp_integral(P(1), Fraction(-1), Fraction(0), X)
+        assert_antideriv(_exp(arg), result)
+
+    def test_x_times_exp_x(self):
+        # ∫ x·eˣ dx = (x-1)·eˣ
+        integrand = _mul(X, _exp(X))
+        result = exp_integral(P(0, 1), Fraction(1), Fraction(0), X)
+        assert_antideriv(integrand, result)
+
+    def test_xsq_times_exp_x(self):
+        # ∫ x²·eˣ dx = (x²-2x+2)·eˣ
+        from symbolic_ir import POW
+        xsq = IRApply(POW, (X, IRInteger(2)))
+        integrand = _mul(xsq, _exp(X))
+        result = exp_integral(P(0, 0, 1), Fraction(1), Fraction(0), X)
+        assert_antideriv(integrand, result)
+
+    def test_poly_times_exp_2x(self):
+        # ∫ (x²+2x+3)·e^(2x) dx
+        from symbolic_ir import POW
+        xsq = IRApply(POW, (X, IRInteger(2)))
+        poly_ir = _add(_add(xsq, _mul(IRInteger(2), X)), IRInteger(3))
+        arg2x = _mul(IRInteger(2), X)
+        integrand = _mul(poly_ir, _exp(arg2x))
+        result = exp_integral(P(3, 2, 1), Fraction(2), Fraction(0), X)
+        assert_antideriv(integrand, result)
+
+    def test_poly_times_exp_neg_x(self):
+        # ∫ (x²+2x+3)·e^(-x) dx
+        from symbolic_ir import NEG, POW
+        xsq = IRApply(POW, (X, IRInteger(2)))
+        poly_ir = _add(_add(xsq, _mul(IRInteger(2), X)), IRInteger(3))
+        neg_x = IRApply(NEG, (X,))
+        integrand = _mul(poly_ir, _exp(neg_x))
+        result = exp_integral(P(3, 2, 1), Fraction(-1), Fraction(0), X)
+        assert_antideriv(integrand, result)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — log_poly_integral
+# ---------------------------------------------------------------------------
+
+
+class TestLogIntegral:
+    def test_log_x(self):
+        # ∫ log(x) dx = x·log(x) - x  (regression: matches Phase 1 result)
+        result = log_poly_integral(P(1), Fraction(1), Fraction(0), X)
+        assert_antideriv(_log(X), result, test_xs=(0.5, 1.0, 2.0, 3.0))
+
+    def test_log_2x_plus_1(self):
+        # ∫ log(2x+1) dx = (x + 1/2)·log(2x+1) - x
+        from symbolic_ir import ADD
+        arg = IRApply(ADD, (_mul(IRInteger(2), X), IRInteger(1)))
+        result = log_poly_integral(P(1), Fraction(2), Fraction(1), X)
+        assert_antideriv(_log(arg), result, test_xs=(0.5, 1.0, 2.0, 3.0))
+
+    def test_x_times_log_x(self):
+        # ∫ x·log(x) dx = (x²/2)·log(x) - x²/4
+        integrand = _mul(X, _log(X))
+        result = log_poly_integral(P(0, 1), Fraction(1), Fraction(0), X)
+        assert_antideriv(integrand, result, test_xs=(0.5, 1.0, 2.0, 3.0))
+
+    def test_xsq_times_log_x(self):
+        # ∫ x²·log(x) dx = (x³/3)·log(x) - x³/9
+        from symbolic_ir import POW
+        xsq = IRApply(POW, (X, IRInteger(2)))
+        integrand = _mul(xsq, _log(X))
+        result = log_poly_integral(P(0, 0, 1), Fraction(1), Fraction(0), X)
+        assert_antideriv(integrand, result, test_xs=(0.5, 1.0, 2.0, 3.0))
+
+    def test_x_times_log_2x_plus_1(self):
+        # ∫ x·log(2x+1) dx
+        from symbolic_ir import ADD
+        arg = IRApply(ADD, (_mul(IRInteger(2), X), IRInteger(1)))
+        integrand = _mul(X, _log(arg))
+        result = log_poly_integral(P(0, 1), Fraction(2), Fraction(1), X)
+        assert_antideriv(integrand, result, test_xs=(0.5, 1.0, 2.0, 3.0))
+
+    def test_const_times_log_x(self):
+        # ∫ 3·log(x) dx = 3·(x·log(x) - x)
+        integrand = _mul(IRInteger(3), _log(X))
+        result = _vm_integrate(integrand)
+        assert_antideriv(integrand, result, test_xs=(0.5, 1.0, 2.0, 3.0))
+
+
+# ---------------------------------------------------------------------------
+# Linear-argument trig via the VM
+# ---------------------------------------------------------------------------
+
+
+class TestLinearArgTrig:
+    def test_sin_2x(self):
+        # ∫ sin(2x) dx = -cos(2x)/2
+        arg = _mul(IRInteger(2), X)
+        integrand = _sin(arg)
+        result = _vm_integrate(integrand)
+        assert_antideriv(integrand, result, test_xs=(0.5, 1.0, 2.0, 3.0))
+
+    def test_cos_3x(self):
+        # ∫ cos(3x) dx = sin(3x)/3
+        arg = _mul(IRInteger(3), X)
+        integrand = _cos(arg)
+        result = _vm_integrate(integrand)
+        assert_antideriv(integrand, result, test_xs=(0.5, 1.0, 2.0, 3.0))
+
+    def test_sin_x_plus_1(self):
+        # ∫ sin(x+1) dx = -cos(x+1)
+        from symbolic_ir import ADD
+        arg = IRApply(ADD, (X, IRInteger(1)))
+        integrand = _sin(arg)
+        result = _vm_integrate(integrand)
+        assert_antideriv(integrand, result, test_xs=(0.5, 1.0, 2.0, 3.0))
+
+    def test_cos_half_x(self):
+        # ∫ cos(x/2) dx = 2·sin(x/2)
+        arg = _mul(IRRational(1, 2), X)
+        integrand = _cos(arg)
+        result = _vm_integrate(integrand)
+        assert_antideriv(integrand, result, test_xs=(0.5, 1.0, 2.0, 3.0))
+
+    def test_sin_neg_x(self):
+        # ∫ sin(-x) dx = cos(-x) = cos(x)
+        from symbolic_ir import NEG
+        arg = IRApply(NEG, (X,))
+        integrand = _sin(arg)
+        result = _vm_integrate(integrand)
+        assert_antideriv(integrand, result, test_xs=(0.5, 1.0, 2.0, 3.0))
+
+
+# ---------------------------------------------------------------------------
+# Fall-through: integrands that should remain unevaluated
+# ---------------------------------------------------------------------------
+
+
+class TestFallsThrough:
+    def test_rational_times_exp_stays_unevaluated(self):
+        # ∫ (1/x)·eˣ dx — rational × exp, not polynomial × exp.
+        from symbolic_ir import DIV
+        integrand = _mul(IRApply(DIV, (IRInteger(1), X)), _exp(X))
+        result = _vm_integrate(integrand)
+        assert isinstance(result, IRApply) and result.head == INTEGRATE
+
+    def test_exp_xsq_stays_unevaluated(self):
+        # ∫ exp(x²) dx — non-linear argument, non-elementary.
+        from symbolic_ir import POW
+        integrand = _exp(IRApply(POW, (X, IRInteger(2))))
+        result = _vm_integrate(integrand)
+        assert isinstance(result, IRApply) and result.head == INTEGRATE
+
+    def test_exp_times_log_stays_unevaluated(self):
+        # ∫ exp(x)·log(x) dx — two transcendentals, no rule.
+        integrand = _mul(_exp(X), _log(X))
+        result = _vm_integrate(integrand)
+        assert isinstance(result, IRApply) and result.head == INTEGRATE
+
+
+# ---------------------------------------------------------------------------
+# End-to-end via the full VM
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEnd:
+    def test_xp1_times_exp_x(self):
+        # ∫ (x+1)·eˣ dx — both factors depend on x.
+        from symbolic_ir import ADD
+        integrand = _mul(IRApply(ADD, (X, IRInteger(1))), _exp(X))
+        result = _vm_integrate(integrand)
+        assert_antideriv(integrand, result, test_xs=(0.5, 1.0, 2.0, 3.0))
+
+    def test_xsq_times_log_x(self):
+        # ∫ x²·log(x) dx  (both arguments depend on x).
+        from symbolic_ir import POW
+        xsq = IRApply(POW, (X, IRInteger(2)))
+        integrand = _mul(xsq, _log(X))
+        result = _vm_integrate(integrand)
+        assert_antideriv(integrand, result, test_xs=(0.5, 1.0, 2.0, 3.0))
+
+    def test_3_times_sin_2x(self):
+        # ∫ 3·sin(2x) dx = −(3/2)·cos(2x).
+        arg = _mul(IRInteger(2), X)
+        integrand = _mul(IRInteger(3), _sin(arg))
+        result = _vm_integrate(integrand)
+        assert_antideriv(integrand, result, test_xs=(0.5, 1.0, 2.0, 3.0))
+
+    def test_exp_2x_via_vm(self):
+        # ∫ e^(2x) dx = e^(2x)/2 via the VM route (arg is not bare x).
+        arg = _mul(IRInteger(2), X)
+        integrand = _exp(arg)
+        result = _vm_integrate(integrand)
+        assert_antideriv(integrand, result, test_xs=(0.5, 1.0, 2.0, 3.0))
+
+    def test_x_times_exp_2x_via_vm(self):
+        # ∫ x·e^(2x) dx — MUL with both factors depending on x.
+        arg = _mul(IRInteger(2), X)
+        integrand = _mul(X, _exp(arg))
+        result = _vm_integrate(integrand)
+        assert_antideriv(integrand, result, test_xs=(0.5, 1.0, 2.0, 3.0))
+
+    def test_log_x_via_vm(self):
+        # ∫ log(x) dx = x·log(x) - x — regression via VM.
+        result = _vm_integrate(_log(X))
+        assert_antideriv(_log(X), result, test_xs=(0.5, 1.0, 2.0, 3.0))
+
+
+# ---------------------------------------------------------------------------
+# Regression: Phase 1 cases unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestRegressions:
+    def test_exp_x_unchanged(self):
+        # ∫ exp(x) dx = exp(x) — Phase 1 result, not broken by Phase 3.
+        result = _vm_integrate(_exp(X))
+        assert result == _exp(X)
+
+    def test_sin_x_unchanged(self):
+        # ∫ sin(x) dx = −cos(x).
+        from symbolic_ir import NEG
+        result = _vm_integrate(_sin(X))
+        assert result == IRApply(NEG, (_cos(X),))
+
+    def test_cos_x_unchanged(self):
+        # ∫ cos(x) dx = sin(x).
+        result = _vm_integrate(_cos(X))
+        assert result == _sin(X)
+
+    def test_log_x_unchanged(self):
+        # ∫ log(x) dx = x·log(x) − x.
+        from symbolic_ir import MUL, SUB
+        result = _vm_integrate(_log(X))
+        expected = IRApply(SUB, (IRApply(MUL, (X, _log(X))), X))
+        assert result == expected
+
+    def test_rational_route_unchanged(self):
+        # ∫ 1/(x²+1) dx = atan(x) — Phase 2e, not broken by Phase 3.
+        from symbolic_ir import ADD, DIV, POW
+        xsq_p1 = IRApply(ADD, (IRApply(POW, (X, IRInteger(2))), IRInteger(1)))
+        integrand = IRApply(DIV, (IRInteger(1), xsq_p1))
+        result = _vm_integrate(integrand)
+        assert isinstance(result, IRApply) and result.head == ATAN

--- a/code/specs/phase3-transcendental.md
+++ b/code/specs/phase3-transcendental.md
@@ -1,0 +1,318 @@
+# Phase 3 — Transcendental Integration
+
+## Status
+
+Phase 3 of the symbolic integration roadmap. Extends the integrator
+beyond rational functions to handle the most common transcendental
+integrands: products of polynomials with a single exponential or
+logarithm of a **linear** argument, plus bare sin/cos/exp of a linear
+argument. After Phase 3, the only integrands still unevaluated are
+those that genuinely require algebraic extensions (Phase 4) or the full
+Risch differential-equation machinery for rational × transcendental
+products (a future Phase 3 extension).
+
+## Scope
+
+### What this phase handles
+
+All five cases share the same restriction: the transcendental argument
+is a **linear** polynomial `a·x + b` with `a ∈ Q \ {0}`, `b ∈ Q`.
+
+| Case | Integrand | Antiderivative |
+|------|-----------|----------------|
+| 3a | `exp(a·x + b)` | `exp(a·x + b) / a` |
+| 3b | `sin(a·x + b)` | `−cos(a·x + b) / a` |
+| 3c | `cos(a·x + b)` | `sin(a·x + b) / a` |
+| 3d | `p(x) · exp(a·x + b)` | `g(x) · exp(a·x + b)` (Risch DE) |
+| 3e | `p(x) · log(a·x + b)` | `[P(x) − r/a] · log(a·x+b) − S(x)` (IBP) |
+
+For cases 3a–3c the special case `a = 1, b = 0` was already handled by
+Phase 1 (`∫ exp(x) = exp(x)`, `∫ sin(x) = −cos(x)`, etc.). Phase 3
+generalises these to any linear argument.
+
+### What this phase does NOT handle
+
+- **Rational × transcendental**: `∫ (1/x)·eˣ dx`, `∫ r(x)·eˣ dx` for
+  general rational `r`. The Risch DE over the rational field requires
+  partial-fraction decomposition of `r` and yields a decision procedure
+  for non-elementarity. Deferred to a future Phase 3 extension.
+- **Non-linear transcendental argument**: `∫ exp(x²) dx` (Gaussian,
+  non-elementary), `∫ exp(1/x) dx`.
+- **Products of two transcendentals**: `∫ exp(x)·log(x) dx`,
+  `∫ sin(x)·eˣ dx`. These require integration by parts in two
+  variables or complex Risch extensions.
+- **Nested towers**: `∫ exp(exp(x)) dx`. Phase 4 territory.
+- **Trig × polynomial**: `∫ x·sin(x) dx` etc. Phase 1 currently handles
+  only bare `sin(x)` and `cos(x)`; extending to polynomial × trig is
+  straightforward with the same IBP mechanism but is out of scope here
+  to keep the phase focused.
+
+## Algorithm — Case 3d: Polynomial × Exp (Risch DE)
+
+### Overview
+
+Given `∫ p(x)·exp(a·x + b) dx` with `p ∈ Q[x]` and `a ∈ Q \ {0}`:
+
+Seek `g ∈ Q[x]` such that `d/dx[g(x)·exp(a·x + b)] = p(x)·exp(a·x + b)`.
+
+Differentiation gives `[g′(x) + a·g(x)]·exp(a·x + b)`, so we need
+to solve the **Risch differential equation** in `Q[x]`:
+
+    g′(x) + a·g(x) = p(x)
+
+### Why `g` must be a polynomial of the same degree
+
+If `p` has degree `n`, then `a·g` contributes the leading term of `g′ + a·g`,
+which means `g` must also have degree `n` (if `a ≠ 0`). The leading
+coefficient of `g′` has degree `n−1`, so it does not affect the degree-`n`
+equation.
+
+### Step-by-step coefficient recovery
+
+Write `p(x) = Σᵢ pᵢ·xⁱ` and `g(x) = Σᵢ gᵢ·xⁱ` (both degree `n`).
+
+From `g′ + a·g = p`, matching `xⁿ`:
+
+    a·gₙ = pₙ  →  gₙ = pₙ / a
+
+Matching `xᵏ` for `k = n−1, n−2, ..., 0`:
+
+    (k+1)·gₖ₊₁ + a·gₖ = pₖ  →  gₖ = (pₖ − (k+1)·gₖ₊₁) / a
+
+This is a clean **back-substitution** over `Q` — no GCDs, no resultants.
+
+### Worked example
+
+`∫ x²·eˣ dx`:
+
+- `p = (0, 0, 1)` (representing `x²`), `a = 1`, `b = 0`, `n = 2`
+- `g₂ = p₂ / 1 = 1`
+- `g₁ = (p₁ − 2·g₂) / 1 = 0 − 2 = −2`
+- `g₀ = (p₀ − 1·g₁) / 1 = 0 − (−2) = 2`
+- Result: `g(x) = x² − 2x + 2`
+- Antiderivative: `(x² − 2x + 2)·eˣ`
+
+Verification: `d/dx[(x²−2x+2)eˣ] = (2x−2)eˣ + (x²−2x+2)eˣ = x²eˣ` ✓
+
+### Special case: bare `exp(a·x + b)` (constant polynomial `p = 1`)
+
+`g₀ = 1/a`, giving antiderivative `(1/a)·exp(a·x + b)`. This unifies
+case 3a with case 3d.
+
+---
+
+## Algorithm — Case 3e: Polynomial × Log (Integration by Parts)
+
+### Overview
+
+Given `∫ p(x)·log(a·x + b) dx` with `p ∈ Q[x]` and `a ∈ Q \ {0}`:
+
+Use the IBP identity `d/dx[P(x)·log(a·x+b)] = p(x)·log(a·x+b) + P(x)·a/(a·x+b)`:
+
+    ∫ p(x)·log(a·x+b) dx  =  P(x)·log(a·x+b)  −  ∫ P(x)·a/(a·x+b) dx
+
+where `P(x) = ∫ p(x) dx` (polynomial antiderivative via power rule).
+
+### Reducing the residual integral
+
+`P(x)·a/(a·x+b)` is a rational function (polynomial over linear). Apply
+polynomial long division:
+
+    P(x)·a = Q(x)·(a·x + b) + r       (r ∈ Q, the remainder)
+
+The remainder is `r = P(−b/a)·a` (the value of `P(x)·a` at the root of
+the denominator). Then:
+
+    ∫ P(x)·a/(a·x+b) dx  =  ∫ Q(x) dx  +  r · ∫ 1/(a·x+b) dx
+                          =  S(x)  +  (r/a)·log(a·x+b)
+
+where `S(x) = ∫ Q(x) dx` is a polynomial.
+
+### Assembling the result
+
+    ∫ p(x)·log(a·x+b) dx  =  [P(x) − r/a]·log(a·x+b) − S(x)
+
+All arithmetic is over `Q[x]` — no transcendental sub-integrals, no
+recursion into Phase 2. The log coefficient `P(x) − r/a` is a polynomial
+in `x` (specifically, `r/a = P(−b/a)` is a constant, so we're subtracting
+a scalar from a polynomial).
+
+### Correctness: why the log coefficient is P(x) − P(−b/a)
+
+From the definition `r = P(−b/a)·a` and `r/a = P(−b/a)`:
+
+    P(x) − r/a  =  P(x) − P(−b/a)
+
+This polynomial vanishes at `x = −b/a` — which makes sense because the
+antiderivative must be well-defined there (the log is undefined at `−b/a`
+and would blow up unless the coefficient goes to zero at the same point).
+
+### Worked examples
+
+**Example 1**: `∫ x·log(x) dx`
+
+- `p = (0, 1)`, `P = (0, 0, 1/2)` (i.e., `x²/2`), `a = 1`, `b = 0`
+- `P(x)·a = x²/2`, divide by `x`: `Q = x/2`, remainder `r = 0`
+- `S = ∫ (x/2) dx = x²/4`
+- Result: `(x²/2 − 0)·log(x) − x²/4 = (x²/2)·log(x) − x²/4`
+- Verify: `d/dx = x·log(x) + (x²/2)·(1/x) − x/2 = x·log(x) + x/2 − x/2 = x·log(x)` ✓
+
+**Example 2**: `∫ log(2x + 1) dx`
+
+- `p = (1,)` (constant `1`), `P = (0, 1)` (i.e., `x`), `a = 2`, `b = 1`
+- `P(x)·a = 2x`, divide by `(2x+1)`: `Q = 1`, remainder `r = −1`
+  (check: `2x = 1·(2x+1) + (−1)`)
+- `S = ∫ 1 dx = x`
+- `r/a = −1/2`
+- Result: `(x − (−1/2))·log(2x+1) − x = (x + 1/2)·log(2x+1) − x`
+- Verify: `d/dx = log(2x+1) + (x+1/2)·2/(2x+1) − 1 = log(2x+1) + 1 − 1 = log(2x+1)` ✓
+
+**Example 3** (shows the cancellation): `∫ log(x) dx`
+
+- `p = (1,)`, `P = (0, 1)` (i.e., `x`), `a = 1`, `b = 0`
+- `P(x)·a = x`, divide by `x`: `Q = 1`, `r = 0`
+- `S = ∫ 1 dx = x`
+- Result: `x·log(x) − x` — matches the hard-coded Phase 1 result. ✓
+
+---
+
+## Recognition in the IR
+
+### Detecting a linear argument
+
+A helper `_try_linear(node, x) → (a: Fraction, b: Fraction) | None`
+walks the IR and returns `(a, b)` if `node` represents `a·x + b`, else
+`None`. Cases handled:
+
+| IR shape | a | b |
+|----------|---|---|
+| `IRSymbol(x)` | `1` | `0` |
+| `IRInteger(n)` | `0` | `n` |
+| `IRRational(p,q)` | `0` | `p/q` |
+| `Neg(v)` | `−aᵥ` | `−bᵥ` |
+| `Mul(c, x)` with c free of x | `c` | `0` |
+| `Mul(x, c)` with c free of x | `c` | `0` |
+| `Add(u, v)` | `aᵤ+aᵥ` | `bᵤ+bᵥ` |
+| `Sub(u, v)` | `aᵤ−aᵥ` | `bᵤ−bᵥ` |
+
+Returns `None` if the expression has a quadratic or higher term, or if
+it contains any non-rational constant or non-x symbol.
+
+### Splitting a product into polynomial × transcendental
+
+For a `Mul(f₁, f₂)` node, the recogniser checks both orderings:
+- Is one factor `Exp(linear)` and the other `to_rational(·, x)` with
+  denominator 1 (i.e., it's a polynomial)?
+- Is one factor `Log(linear)` and the other a polynomial?
+
+Both `Exp` and `Log` are single-argument IR nodes, so the check is:
+`f.head ∈ {EXP, LOG} and _try_linear(f.args[0], x) is not None`.
+
+### Where Phase 3 fires in `_integrate`
+
+Phase 3 is wired into the existing `_integrate` function at two points:
+
+1. **Elementary function section** (currently handles `head(x)` only):
+   Extended to call `_try_linear` on the argument. If linear with `a ≠ 1`
+   or `b ≠ 0`, applies the case 3a/3b/3c formula.
+
+2. **`MUL` branch** (currently bails when both factors depend on `x`):
+   Before returning `None`, tries `_try_exp_product` and `_try_log_product`
+   to handle cases 3d and 3e.
+
+No new "route" is needed (unlike Phase 2's rational route); Phase 3 extends
+Phase 1's existing pattern table.
+
+---
+
+## New modules
+
+### `symbolic_vm/exp_integral.py`
+
+```
+exp_integral(poly: Polynomial, a: Fraction, b: Fraction, x: IRSymbol) → IRNode
+```
+
+Implements case 3d (and 3a as the `poly = (1,)` degenerate). Given a
+polynomial `p` (as a `Polynomial` tuple) and the linear-arg coefficients
+`a, b`, returns the IR for `g(x)·exp(a·x + b)` where `g` solves
+`g′ + a·g = p`.
+
+```
+_solve_risch_de_poly(p: Polynomial, a: Fraction) → Polynomial
+```
+
+Private helper: computes `g` from `p` and `a` by back-substitution.
+Returns the `Polynomial` tuple for `g`.
+
+### `symbolic_vm/log_integral.py`
+
+```
+log_poly_integral(poly: Polynomial, a: Fraction, b: Fraction, x: IRSymbol) → IRNode
+```
+
+Implements case 3e (and case `p = 1, a = 1, b = 0` = bare `log(x)` as
+handled by Phase 1, extended to linear argument). Computes
+`[P − r/a]·log(a·x+b) − S` entirely in `Q[x]`, emitting the result as IR.
+
+---
+
+## Integration into the Integrate handler
+
+The `_integrate` function in `integrate.py` gains the following additions:
+
+```
+# Case 3a/3b/3c: elementary function of linear argument
+if head in {EXP, SIN, COS} and len(f.args) == 1:
+    lin = _try_linear(f.args[0], x)
+    if lin is not None:
+        a, b = lin
+        if a != 0:
+            # exp(ax+b)/a, -cos(ax+b)/a, sin(ax+b)/a
+            ...
+
+# Cases 3d/3e: product with both factors depending on x
+if head == MUL:
+    ...
+    # (after the constant-factor checks fail)
+    result = _try_exp_product(f.args[0], f.args[1], x)
+    if result is None:
+        result = _try_exp_product(f.args[1], f.args[0], x)
+    if result is not None:
+        return result
+    result = _try_log_product(f.args[0], f.args[1], x)
+    if result is None:
+        result = _try_log_product(f.args[1], f.args[0], x)
+    return result  # None if both fail → unevaluated
+```
+
+---
+
+## Dependency changes
+
+No new IR primitives required. All five cases use existing IR nodes
+(`EXP`, `LOG`, `SIN`, `COS`, `MUL`, `ADD`, `SUB`, `DIV`, `NEG`).
+
+Depends on:
+- `coding-adventures-symbolic-ir ≥ 0.2.0` (already the minimum)
+- `coding-adventures-polynomial ≥ 0.4.0` (for `divmod_poly`,
+  `multiply`, `normalize`; already the minimum)
+
+---
+
+## Test strategy
+
+| Test class | Cases |
+|---|---|
+| `TestExpIntegral` | `exp(2x)`, `exp(3x+1)`, `x·eˣ`, `x²·eˣ`, `(x²+2x+3)·e^(−x)` |
+| `TestLogIntegral` | `log(x)` (regression), `x·log(x)`, `x²·log(x)`, `log(2x+1)`, `x·log(2x+1)` |
+| `TestLinearArgTrig` | `sin(2x)`, `cos(3x)`, `sin(x+1)`, `cos(2x+π/3)` |
+| `TestFallsThrough` | `(1/x)·eˣ` → unevaluated, `exp(x²)` → unevaluated, `exp(x)·log(x)` → unevaluated |
+| `TestEndToEnd` | via full VM: `(x+1)·eˣ`, `x²·log(x)`, `sin(2x)·3` |
+
+All correctness tests use numerical re-differentiation (same pattern as
+`test_mixed_integral.py`).
+
+Regression tests verify that Phase 1 cases (`∫ exp(x)`, `∫ log(x)`,
+`∫ sin(x)`, `∫ cos(x)`) still produce the same output after Phase 3 is
+wired in.

--- a/code/specs/symbolic-computation.md
+++ b/code/specs/symbolic-computation.md
@@ -347,13 +347,25 @@ reviewed independently:
   integration for all denominators of the form L·Q with deg Q ≤ 2. See
   `mixed-integral.md`.
 
-### Phase 3 — Risch transcendental case
+### Phase 3 — Transcendental integration (single linear extension)
 
-Full Risch over towers of exp/log extensions (no algebraics). Decides
-whether an elementary antiderivative exists for any expression built
-from `{rationals, exp, log, trig-as-exp}` and constructs it when one
-does. Requires differential-field machinery: derivation on a tower,
-the structure theorem, the Rothstein–Trager resultant.
+Extends integration to the most common transcendental integrands:
+polynomials multiplied by `exp`, `log`, `sin`, or `cos` of a **linear**
+argument `a·x + b`. Five cases, two algorithms:
+
+- **Cases 3a–3c** — Bare `exp(ax+b)`, `sin(ax+b)`, `cos(ax+b)`:
+  antiderivative by dividing by the inner-argument coefficient `a`.
+- **Case 3d** — `p(x)·exp(ax+b)` for `p ∈ Q[x]`: solve the Risch
+  differential equation `g′ + a·g = p` by back-substitution; result
+  is `g(x)·exp(ax+b)`.
+- **Case 3e** — `p(x)·log(ax+b)` for `p ∈ Q[x]`: integration by parts
+  reduces to polynomial arithmetic; result is
+  `[P(x) − P(−b/a)]·log(ax+b) − S(x)`.
+
+No new IR primitives required. See `phase3-transcendental.md`.
+
+The full Risch algorithm for rational × transcendental products and
+multi-level towers is deferred to a later Phase 3 extension.
 
 ### Phase 4 — Algebraic extensions (full Risch)
 


### PR DESCRIPTION
## Summary

- Extends the symbolic integrator to handle five new cases for transcendental integrands with **linear** arguments `a·x + b`
- Case 3a–3c: bare `exp(ax+b)`, `sin(ax+b)`, `cos(ax+b)` — divide-by-`a` rule
- Case 3d: `p(x)·exp(ax+b)` — solved via Risch differential equation `g′ + a·g = p` by back-substitution
- Case 3e: `p(x)·log(ax+b)` — solved via integration by parts + polynomial long division

## New modules

- `symbolic_vm.exp_integral`: `exp_integral(poly, a, b, x_sym)` — cases 3a and 3d
- `symbolic_vm.log_integral`: `log_poly_integral(poly, a, b, x_sym)` — case 3e
- `polynomial_bridge.linear_to_ir(a, b, x)` — shared IR builder for `a·x + b`

## Test plan

- [x] 33 new tests in `tests/test_phase3.py` covering all five cases including edge cases (a=1, b=0, degree 0/1/2 polynomials)
- [x] Combined absolute+relative tolerance for numerical derivative checks at large x values
- [x] Updated `test_integrate_composed_trig_unevaluated` → now asserts Phase 3 closes `sin(2x)` instead of leaving it unevaluated
- [x] 280 total tests, 89% coverage
- [x] ruff clean, security review passed

## Spec

`code/specs/phase3-transcendental.md` — step-by-step algorithms and worked examples for all five cases.

Version bumped to 0.8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)