### PR TITLE
feat(tetrad): full pipeline spec TET00–TET05 (lexer→parser→compiler→VM→JIT)

### DIFF
--- a/code/specs/TET00-tetrad-language.md
+++ b/code/specs/TET00-tetrad-language.md
@@ -1,0 +1,468 @@
+# TET00 — Tetrad Language Specification
+
+## Overview
+
+Tetrad is a small, statically-scoped, interpreted programming language whose bytecode
+can be executed by a register-based virtual machine small enough to run on an Intel 4004
+microprocessor. The name is a pun on "tetrad" — the precise technical term for a 4-bit
+group (a nibble), the native data size of the 4004.
+
+Tetrad is the **interpreted counterpart** to Nib (spec NIB00), which compiled directly
+to 4004 machine code. The key difference in approach:
+
+```
+Nib:    source → compiler → 4004 machine code → 4004 runs the program
+Tetrad: source → compiler → bytecode          → 4004 runs the interpreter
+                                                  interpreter executes bytecode
+```
+
+The indirection of an interpreter buys significant expressive power:
+
+| Capability | Nib (compiled) | Tetrad (interpreted) |
+|---|---|---|
+| Variables with dynamic names | Not possible | Resolved by interpreter |
+| While loops with variable bounds | Not possible | Interpreter handles jump |
+| Software call stack > 3 deep | Not possible | Interpreter manages RAM stack |
+| Arithmetic (mul, div) | Not supported v1 | Interpreter runs software loop |
+| Extensible without recompiling | No | Add opcodes to interpreter |
+
+The 4004 pays a ~30× speed cost — running ~20,000–37,000 interpreted instructions per
+second versus ~740,000 native instructions per second — but gets a language that feels
+like modern procedural code.
+
+---
+
+## Design Goals
+
+1. **Interpretable on Intel 4004.** The VM dispatch loop must fit within 4 KB of ROM
+   alongside the bytecode program. VM state must fit within 128 bytes of usable RAM.
+
+2. **Accumulator-centric register VM.** Following V8 Ignition: one implicit accumulator
+   register, 8 explicit named registers R0–R7. Most instructions read from / write to
+   the accumulator; the register operand is always named explicitly.
+
+3. **Feedback vectors from day one.** Every binary operation and every call site carries
+   a feedback slot index. The VM records observed types and call shapes into these slots.
+   This is the substrate that makes adding a JIT compiler straightforward.
+
+4. **Broadens to Lisp.** The bytecode instruction set and VM metrics API are designed so
+   that a Lisp front-end can compile to the same bytecode. Where Tetrad's types are
+   statically monomorphic (all values are u8), a Lisp front-end will generate polymorphic
+   feedback — and the JIT can specialize on it.
+
+5. **Literate, learnable source.** Tetrad programs should be readable by someone who
+   knows any procedural language. Syntax is deliberately minimal.
+
+---
+
+## Intel 4004 Interpreter Model
+
+The physical hardware model this spec targets:
+
+```
+4004 ROM (4 KB)
+  ┌──────────────────────────────────────┐
+  │  Tetrad Interpreter (4004 assembly)  │  ~2 KB
+  │  ──────────────────────────────────  │
+  │  Tetrad Program (bytecode)           │  ~2 KB
+  └──────────────────────────────────────┘
+
+4004 RAM (128 bytes usable general RAM)
+  ┌──────────────────────────────────────┐
+  │  Accumulator          1 byte         │
+  │  Registers R0–R7      8 bytes        │
+  │  Program counter      2 bytes        │
+  │  Frame pointer        1 byte         │
+  │  Call stack           32 bytes       │  4 frames × 8 bytes/frame
+  │  Variable pool        84 bytes       │  up to 84 named u8 variables
+  └──────────────────────────────────────┘
+```
+
+### Call Stack Frame Layout (8 bytes each, 4 frames max)
+
+```
+Byte 0–1  Return instruction pointer (12-bit, zero-padded to 16 bits)
+Byte 2    Saved frame pointer (variable pool base index)
+Byte 3–3  Register save: R0 (so callee can clobber R0 for its own use)
+Byte 4–7  Padding / future use (keeps frame power-of-2 aligned)
+```
+
+With 4 call frames (interpreter occupies 1 hardware stack level), the maximum
+user-visible call depth is 4. This is enforced by the VM at runtime.
+
+### Why RAM Fits
+
+```
+Accumulator:   1 byte
+Registers:     8 bytes (R0–R7, each 1 byte = 8-bit value)
+PC:            2 bytes
+Frame pointer: 1 byte
+Call stack:    32 bytes (4 frames × 8 bytes)
+──────────────────────
+Fixed overhead: 44 bytes
+
+Available for variables: 128 − 44 = 84 bytes → 84 distinct u8 variables
+```
+
+84 variables is enough for embedded control programs. A Busicom-style calculator needs
+fewer than 20.
+
+---
+
+## Type System
+
+Tetrad v1 has a single type: **u8** — an unsigned 8-bit integer (0–255).
+
+This is the only type that makes practical sense given the 4004's architecture:
+- Stored in one 4004 register pair (two 4-bit nibbles = one 8-bit byte)
+- Wraps on overflow (modular arithmetic)
+- No sign bit, no fractions, no pointers
+
+Arithmetic wraps at 256. There are no overflow errors — this matches the 4004's hardware
+behavior for 8-bit register pairs.
+
+### Why Only u8?
+
+The feedback vector machinery (spec TET03) is present in v1 even though all values are
+u8 and feedback is always monomorphic. This is intentional: when a Lisp front-end later
+compiles to the same bytecode, it will introduce dynamically-typed values (integers,
+pairs, symbols, closures). The JIT will read those feedback slots and specialize. By
+wiring the slots in from the start, the interpreter does not need to change when the
+Lisp compiler arrives.
+
+---
+
+## Operators
+
+### Arithmetic
+
+| Operator | Description | Wraps on overflow |
+|---|---|---|
+| `+` | Addition | Yes |
+| `-` | Subtraction | Yes (wraps below 0) |
+| `*` | Multiplication | Yes |
+| `/` | Integer division | Halts if divisor is 0 |
+| `%` | Remainder | Halts if divisor is 0 |
+
+### Bitwise
+
+| Operator | Description |
+|---|---|
+| `&` | Bitwise AND |
+| `\|` | Bitwise OR |
+| `^` | Bitwise XOR |
+| `~` | Bitwise NOT (unary) |
+| `<<` | Left shift |
+| `>>` | Right shift (logical, zero fill) |
+
+### Comparison (result is 1 if true, 0 if false)
+
+| Operator | Description |
+|---|---|
+| `==` | Equal |
+| `!=` | Not equal |
+| `<` | Less than |
+| `<=` | Less than or equal |
+| `>` | Greater than |
+| `>=` | Greater than or equal |
+
+### Logical
+
+| Operator | Description |
+|---|---|
+| `&&` | Logical AND (short-circuit) |
+| `\|\|` | Logical OR (short-circuit) |
+| `!` | Logical NOT (unary) |
+
+Logical operators treat 0 as false, any non-zero value as true. Result is 1 or 0.
+
+### Operator Precedence (lowest to highest)
+
+| Level | Operators | Associativity |
+|---|---|---|
+| 1 | `\|\|` | Left |
+| 2 | `&&` | Left |
+| 3 | `==`, `!=` | Left |
+| 4 | `<`, `>`, `<=`, `>=` | Left |
+| 5 | `\|` | Left |
+| 6 | `^` | Left |
+| 7 | `&` | Left |
+| 8 | `<<`, `>>` | Left |
+| 9 | `+`, `-` | Left |
+| 10 | `*`, `/`, `%` | Left |
+| 11 | `!`, `~`, unary `-` | Right (prefix) |
+| 12 | primary | — |
+
+---
+
+## Grammar Reference
+
+Full grammar in EBNF notation:
+
+```ebnf
+program       = { top_decl } EOF ;
+
+top_decl      = fn_decl | global_decl ;
+
+global_decl   = "let" NAME "=" expr ";" ;
+
+fn_decl       = "fn" NAME "(" [ param_list ] ")" block ;
+param_list    = NAME { "," NAME } ;
+
+block         = "{" { stmt } "}" ;
+
+stmt          = let_stmt
+              | assign_stmt
+              | if_stmt
+              | while_stmt
+              | return_stmt
+              | expr_stmt
+              ;
+
+let_stmt      = "let" NAME "=" expr ";" ;
+assign_stmt   = NAME "=" expr ";" ;
+if_stmt       = "if" expr block [ "else" block ] ;
+while_stmt    = "while" expr block ;
+return_stmt   = "return" [ expr ] ";" ;
+expr_stmt     = expr ";" ;
+
+expr          = or_expr ;
+
+or_expr       = and_expr { "||" and_expr } ;
+and_expr      = bitor_expr { "&&" bitor_expr } ;
+bitor_expr    = bitxor_expr { "|" bitxor_expr } ;
+bitxor_expr   = bitand_expr { "^" bitand_expr } ;
+bitand_expr   = eq_expr { "&" eq_expr } ;
+eq_expr       = cmp_expr { ( "==" | "!=" ) cmp_expr } ;
+cmp_expr      = shift_expr { ( "<" | ">" | "<=" | ">=" ) shift_expr } ;
+shift_expr    = add_expr { ( "<<" | ">>" ) add_expr } ;
+add_expr      = mul_expr { ( "+" | "-" ) mul_expr } ;
+mul_expr      = unary_expr { ( "*" | "/" | "%" ) unary_expr } ;
+unary_expr    = ( "!" | "~" | "-" ) unary_expr
+              | primary
+              ;
+primary       = INT_LIT
+              | HEX_LIT
+              | NAME
+              | call_expr
+              | "in" "(" ")"
+              | "(" expr ")"
+              ;
+call_expr     = NAME "(" [ arg_list ] ")" ;
+arg_list      = expr { "," expr } ;
+```
+
+### Notes on the Grammar
+
+- There is no `for` statement in v1. Use `while` with a manual counter.
+- `in()` is a keyword-expression that reads one byte from the I/O port.
+- `out(expr)` is a statement-level call to the I/O output port.
+- All variables are `u8`. There are no type annotations.
+- `let` in a block creates a local variable scoped to that block.
+- `let` at the top level creates a global variable.
+
+---
+
+## Reserved Words
+
+```
+fn  let  if  else  while  return  in  out
+```
+
+---
+
+## Examples
+
+### Example 1: Counting Down
+
+```tetrad
+fn count_down(n) {
+    while n > 0 {
+        out(n);
+        n = n - 1;
+    }
+}
+
+fn main() {
+    count_down(10);
+}
+```
+
+### Example 2: Bitwise Nibble Extraction
+
+```tetrad
+fn high_nibble(x) {
+    return (x >> 4) & 15;
+}
+
+fn low_nibble(x) {
+    return x & 15;
+}
+
+fn main() {
+    let val = 171;   // 0xAB
+    out(high_nibble(val));   // outputs 10 (0xA)
+    out(low_nibble(val));    // outputs 11 (0xB)
+}
+```
+
+### Example 3: BCD Digit Sum (replicating Busicom logic)
+
+```tetrad
+fn bcd_add(a, b) {
+    let sum = a + b;
+    if sum >= 10 {
+        sum = sum - 10;
+        out(1);      // carry signal
+    } else {
+        out(0);      // no carry
+    }
+    return sum;
+}
+
+fn main() {
+    let result = bcd_add(7, 5);   // 7 + 5 = 12 → result=2, carry=1
+    out(result);
+}
+```
+
+### Example 4: Software Multiply (no hardware MUL on 4004)
+
+```tetrad
+fn multiply(a, b) {
+    let result = 0;
+    while b > 0 {
+        result = result + a;
+        b = b - 1;
+    }
+    return result;
+}
+
+fn main() {
+    out(multiply(6, 7));   // outputs 42
+}
+```
+
+### Example 5: Reading from I/O
+
+```tetrad
+fn echo_loop() {
+    let running = 1;
+    while running {
+        let byte = in();
+        if byte == 0 {
+            running = 0;
+        } else {
+            out(byte);
+        }
+    }
+}
+
+fn main() {
+    echo_loop();
+}
+```
+
+---
+
+## Relationship to Nib
+
+Tetrad is a sibling to Nib, not a replacement. They coexist in the stack:
+
+| Aspect | Nib | Tetrad |
+|---|---|---|
+| Execution model | Compiled → 4004 machine code | Interpreted via bytecode VM |
+| Speed | Fast (~740 kHz native) | Slow (~20–37 kHz interpreted) |
+| Language expressiveness | Limited by 4004 ISA | Limited only by VM RAM budget |
+| Call depth | 2 (hardware 3-level stack) | 4 (software stack in RAM) |
+| While with variable bounds | Not supported | Supported |
+| Multiplication, division | Not supported v1 | Supported (software loop) |
+| Type system | u4, u8, bcd, bool | u8 only |
+| Feedback for JIT | Not applicable | Built-in feedback vector |
+| Future Lisp support | Not planned | Yes — bytecode broadens to Lisp |
+
+Use Nib when you need raw speed and know the loop bounds at compile time.
+Use Tetrad when you need a more expressive language and can afford the interpreter overhead.
+
+---
+
+## Relationship to OCT
+
+OCT (spec OCT00) targets the Intel 8008. Tetrad targets the 4004. The 4004 is
+significantly more constrained than the 8008:
+
+| | Intel 4004 | Intel 8008 |
+|---|---|---|
+| Year | 1971 | 1972 |
+| Data width | 4-bit | 8-bit |
+| Registers | 16 × 4-bit | 7 × 8-bit |
+| Usable RAM | 128 bytes | 16 KB |
+| ROM | 4 KB | 16 KB |
+| Hardware stack | 3 levels | 8 levels |
+
+OCT programs would not fit on a 4004 without significant redesign. Tetrad is
+intentionally designed around the more severe 4004 constraints.
+
+---
+
+## What Is NOT in Tetrad v1
+
+| Feature | Reason for exclusion |
+|---|---|
+| Strings | No RAM budget; no string instructions on 4004 |
+| Floating-point | No FPU; software float not practical in 128 bytes |
+| Arrays | Dynamic indexing requires addressing not available in 128-byte VM state |
+| Closures | Capture would exceed per-frame RAM budget |
+| Recursion | Allowed but limited to 4 deep by software stack; no TCO in v1 |
+| Modules / imports | Single-file programs only in v1 |
+| Multiple types | v1 is u8-only; Lisp front-end will introduce dynamic types |
+| Structs / records | No compound types in v1 |
+
+---
+
+## Implementation Pipeline
+
+The full Tetrad pipeline across five packages:
+
+```
+Tetrad Source Text
+    │
+    ▼
+tetrad-lexer      TET01   Produces token stream
+    │
+    ▼
+tetrad-parser     TET02   Produces AST (Pratt parser)
+    │
+    ▼
+tetrad-compiler   TET03   Produces bytecode (CodeObject with feedback slots)
+    │
+    ▼
+tetrad-vm         TET04   Executes bytecode, populates feedback vectors, exposes metrics API
+    │
+    ▼
+tetrad-jit        TET05   Reads feedback vectors, emits x86-64 native code for hot functions
+```
+
+Each stage is a standalone Python package with its own `pyproject.toml`, tests,
+README, and CHANGELOG. The implementation language is Python 3.12 throughout.
+
+---
+
+## Implementation Status
+
+| Phase | Package | Spec | Status |
+|---|---|---|---|
+| 1 | Language spec | TET00 | This document |
+| 2 | Lexer | tetrad-lexer | TET01 — Planned |
+| 3 | Parser | tetrad-parser | TET02 — Planned |
+| 4 | Bytecode compiler | tetrad-compiler | TET03 — Planned |
+| 5 | Register VM | tetrad-vm | TET04 — Planned |
+| 6 | JIT compiler | tetrad-jit | TET05 — Planned |
+
+---
+
+## Version History
+
+| Version | Date | Description |
+|---|---|---|
+| 0.1.0 | 2026-04-20 | Initial specification draft |

--- a/code/specs/TET00-tetrad-language.md
+++ b/code/specs/TET00-tetrad-language.md
@@ -111,24 +111,44 @@ fewer than 20.
 
 ## Type System
 
-Tetrad v1 has a single type: **u8** — an unsigned 8-bit integer (0–255).
+Tetrad uses **gradual typing**: type annotations on function parameters and return values
+are optional. A program with no annotations behaves exactly as Tetrad v1. A fully-typed
+program unlocks a faster compilation path.
 
-This is the only type that makes practical sense given the 4004's architecture:
+### Concrete Type
+
+In v1 there is exactly one concrete type: **u8** — an unsigned 8-bit integer (0–255).
 - Stored in one 4004 register pair (two 4-bit nibbles = one 8-bit byte)
 - Wraps on overflow (modular arithmetic)
 - No sign bit, no fractions, no pointers
 
-Arithmetic wraps at 256. There are no overflow errors — this matches the 4004's hardware
-behavior for 8-bit register pairs.
+When a Lisp front-end is added, the type vocabulary expands: `u8`, `pair`, `symbol`,
+`closure`, `bool`, `nil`. The type checker infrastructure (spec TET02b) accommodates
+this without structural change.
 
-### Why Only u8?
+### The Three-Tier Acceleration Model
 
-The feedback vector machinery (spec TET03) is present in v1 even though all values are
-u8 and feedback is always monomorphic. This is intentional: when a Lisp front-end later
-compiles to the same bytecode, it will introduce dynamically-typed values (integers,
-pairs, symbols, closures). The JIT will read those feedback slots and specialize. By
-wiring the slots in from the start, the interpreter does not need to change when the
-Lisp compiler arrives.
+Type annotations determine how aggressively the pipeline optimises a function:
+
+| Tier | Annotations present | Feedback slots emitted | JIT compilation trigger |
+|---|---|---|---|
+| **FULLY_TYPED** | All params + return typed; all ops infer `u8` | None — no slots needed | First call — no warmup |
+| **PARTIALLY_TYPED** | Some annotations present | Only for ops with unknown operands | After 10 calls |
+| **UNTYPED** | No annotations | All binary ops and calls | After 100 calls |
+
+Concretely for the Intel 4004:
+- Each untyped binary op costs **3 ROM bytes** (opcode + register + slot index)
+- Each typed binary op costs **2 ROM bytes** (opcode + register only)
+- A fully-typed function with 5 ops saves 5 bytes of ROM and eliminates feedback-vector
+  RAM allocation entirely
+
+### Feedback Slots Still Present for Untyped Code
+
+The feedback vector machinery (spec TET03) is present for untyped ops. This is
+intentional: when a Lisp front-end compiles to the same bytecode, it will produce
+dynamically-typed code for unannoted procedures. The JIT reads those feedback slots
+and specializes. Annotated Lisp procedures (via `declare`) compile as FULLY_TYPED and
+get immediate JIT compilation.
 
 ---
 
@@ -204,10 +224,13 @@ program       = { top_decl } EOF ;
 
 top_decl      = fn_decl | global_decl ;
 
-global_decl   = "let" NAME "=" expr ";" ;
+global_decl   = "let" NAME [ ":" type ] "=" expr ";" ;
 
-fn_decl       = "fn" NAME "(" [ param_list ] ")" block ;
-param_list    = NAME { "," NAME } ;
+fn_decl       = "fn" NAME "(" [ param_list ] ")" [ "->" type ] block ;
+param_list    = param { "," param } ;
+param         = NAME [ ":" type ] ;
+
+type          = "u8" ;
 
 block         = "{" { stmt } "}" ;
 
@@ -219,7 +242,7 @@ stmt          = let_stmt
               | expr_stmt
               ;
 
-let_stmt      = "let" NAME "=" expr ";" ;
+let_stmt      = "let" NAME [ ":" type ] "=" expr ";" ;
 assign_stmt   = NAME "=" expr ";" ;
 if_stmt       = "if" expr block [ "else" block ] ;
 while_stmt    = "while" expr block ;
@@ -257,7 +280,12 @@ arg_list      = expr { "," expr } ;
 - There is no `for` statement in v1. Use `while` with a manual counter.
 - `in()` is a keyword-expression that reads one byte from the I/O port.
 - `out(expr)` is a statement-level call to the I/O output port.
-- All variables are `u8`. There are no type annotations.
+- Type annotations on parameters and return values are optional (gradual typing).
+- The only available type in v1 is `u8`. Using `u8` on everything is equivalent to
+  explicit static typing.
+- `->` is a two-character token (scanned greedily before `-`).
+- A `let` binding may carry an optional `: u8` annotation; the type checker verifies
+  the inferred type matches.
 - `let` in a block creates a local variable scoped to that block.
 - `let` at the top level creates a global variable.
 
@@ -266,8 +294,10 @@ arg_list      = expr { "," expr } ;
 ## Reserved Words
 
 ```
-fn  let  if  else  while  return  in  out
+fn  let  if  else  while  return  in  out  u8
 ```
+
+`u8` is reserved as a type keyword. It may not be used as a variable or function name.
 
 ---
 
@@ -343,7 +373,28 @@ fn main() {
 }
 ```
 
-### Example 5: Reading from I/O
+### Example 5b: Fully Typed BCD Addition (no JIT warmup)
+
+```tetrad
+// All params and return annotated → FULLY_TYPED → compiled on first call.
+// The compiler emits 2-byte ADD instructions (no feedback slot bytes).
+fn bcd_add(a: u8, b: u8) -> u8 {
+    let sum: u8 = a + b;
+    if sum >= 10 {
+        sum = sum - 10;
+        out(1);
+    } else {
+        out(0);
+    }
+    return sum;
+}
+
+fn main() {
+    out(bcd_add(7, 5));   // compiles to native code on the very first call
+}
+```
+
+### Example 6: Reading from I/O
 
 ```tetrad
 fn echo_loop() {
@@ -422,25 +473,31 @@ intentionally designed around the more severe 4004 constraints.
 
 ## Implementation Pipeline
 
-The full Tetrad pipeline across five packages:
+The full Tetrad pipeline across six packages:
 
 ```
 Tetrad Source Text
     │
     ▼
-tetrad-lexer      TET01   Produces token stream
+tetrad-lexer         TET01   Token stream
     │
     ▼
-tetrad-parser     TET02   Produces AST (Pratt parser)
+tetrad-parser        TET02   AST (Pratt parser)
     │
     ▼
-tetrad-compiler   TET03   Produces bytecode (CodeObject with feedback slots)
+tetrad-type-checker  TET02b  TypeCheckResult (TypeMap + FunctionTypeStatus per function)
+    │                        ↳ FULLY_TYPED → no feedback slots, immediate JIT
+    │                        ↳ PARTIALLY_TYPED → slots only for unknown-type ops
+    │                        ↳ UNTYPED → all ops get slots (Tetrad v1 behavior)
+    ▼
+tetrad-compiler      TET03   CodeObject (two-path: typed ops skip slot bytes)
     │
     ▼
-tetrad-vm         TET04   Executes bytecode, populates feedback vectors, exposes metrics API
-    │
+tetrad-vm            TET04   Executes bytecode; skips feedback vector for typed fns;
+    │                        exposes metrics API; queues typed fns for immediate JIT
     ▼
-tetrad-jit        TET05   Reads feedback vectors, emits x86-64 native code for hot functions
+tetrad-jit           TET05   Three-tier: typed→compile on call 1, partial→call 10,
+                             untyped→call 100; reads feedback for untyped paths
 ```
 
 Each stage is a standalone Python package with its own `pyproject.toml`, tests,
@@ -455,9 +512,10 @@ README, and CHANGELOG. The implementation language is Python 3.12 throughout.
 | 1 | Language spec | TET00 | This document |
 | 2 | Lexer | tetrad-lexer | TET01 — Planned |
 | 3 | Parser | tetrad-parser | TET02 — Planned |
-| 4 | Bytecode compiler | tetrad-compiler | TET03 — Planned |
-| 5 | Register VM | tetrad-vm | TET04 — Planned |
-| 6 | JIT compiler | tetrad-jit | TET05 — Planned |
+| 4 | Type checker | tetrad-type-checker | TET02b — Planned |
+| 5 | Bytecode compiler | tetrad-compiler | TET03 — Planned |
+| 6 | Register VM | tetrad-vm | TET04 — Planned |
+| 7 | JIT compiler | tetrad-jit | TET05 — Planned |
 
 ---
 

--- a/code/specs/TET01-tetrad-lexer.md
+++ b/code/specs/TET01-tetrad-lexer.md
@@ -45,6 +45,7 @@ token rather than an `IDENT` token. The reserved words and their token types are
 | `return` | `KW_RETURN` |
 | `in` | `KW_IN` |
 | `out` | `KW_OUT` |
+| `u8` | `KW_U8` |
 
 Any identifier that is not a reserved word produces an `IDENT` token carrying the name
 as a string.
@@ -72,8 +73,10 @@ as a string.
 | `>=` | `GT_EQ` | Greedy: `>=` before `>` |
 | `&&` | `AMP_AMP` | |
 | `\|\|` | `PIPE_PIPE` | |
+| `->` | `ARROW` | Return type annotation; greedy: scanned before `-` |
 | `!` | `BANG` | |
 | `=` | `EQ` | Assignment; not equality |
+| `:` | `COLON` | Type annotation separator |
 | `(` | `LPAREN` | |
 | `)` | `RPAREN` | |
 | `{` | `LBRACE` | |
@@ -172,8 +175,8 @@ procedure scan_ident_or_keyword() → Token:
 ### Scanning Punctuation (multi-character operators)
 
 The lexer uses a greedy (maximal munch) strategy: always consume the longest valid token.
-The two-character operators (`<<`, `>>`, `==`, `!=`, `<=`, `>=`, `&&`, `||`) must be
-checked before their one-character prefixes:
+The two-character operators (`<<`, `>>`, `==`, `!=`, `<=`, `>=`, `&&`, `||`, `->`) must
+be checked before their one-character prefixes (`<`, `>`, `=`, `!`, `&`, `|`, `-`):
 
 ```
 procedure scan_punctuation() → Token:
@@ -307,6 +310,7 @@ class TokenType(enum.Enum):
     KW_RETURN = "KW_RETURN"
     KW_IN = "KW_IN"
     KW_OUT = "KW_OUT"
+    KW_U8 = "KW_U8"
     PLUS = "PLUS"
     MINUS = "MINUS"
     STAR = "STAR"
@@ -328,6 +332,8 @@ class TokenType(enum.Enum):
     PIPE_PIPE = "PIPE_PIPE"
     BANG = "BANG"
     EQ = "EQ"
+    ARROW = "ARROW"
+    COLON = "COLON"
     LPAREN = "LPAREN"
     RPAREN = "RPAREN"
     LBRACE = "LBRACE"

--- a/code/specs/TET01-tetrad-lexer.md
+++ b/code/specs/TET01-tetrad-lexer.md
@@ -1,0 +1,401 @@
+# TET01 — Tetrad Lexer Specification
+
+## Overview
+
+The Tetrad lexer (tokenizer) reads a stream of UTF-8 source characters and produces a
+flat sequence of tokens. The parser (spec TET02) consumes this token stream. The lexer
+operates in a single forward pass with one character of lookahead.
+
+The lexer is intentionally simple. Tetrad has no string literals, no floating-point
+literals, and no contextual keywords — every reserved word is unconditionally reserved.
+This keeps the lexer stateless and trivially restartable.
+
+---
+
+## Token Types
+
+Every token belongs to exactly one of these types:
+
+### Integer Literals
+
+| Token type | Pattern | Example | Value |
+|---|---|---|---|
+| `INT` | `[0-9]+` | `42`, `0`, `255` | Decimal integer |
+| `HEX` | `0x[0-9A-Fa-f]+` | `0xFF`, `0x0A` | Hexadecimal integer |
+
+Both `INT` and `HEX` tokens carry their numeric value as a Python `int`. The lexer does
+not check whether the value fits in u8 — range checking is the compiler's responsibility
+(spec TET03).
+
+### Identifiers and Keywords
+
+An identifier begins with a letter or underscore and continues with letters, digits, or
+underscores: `[A-Za-z_][A-Za-z0-9_]*`.
+
+When an identifier's text exactly matches a reserved word, the lexer emits a keyword
+token rather than an `IDENT` token. The reserved words and their token types are:
+
+| Text | Token type |
+|---|---|
+| `fn` | `KW_FN` |
+| `let` | `KW_LET` |
+| `if` | `KW_IF` |
+| `else` | `KW_ELSE` |
+| `while` | `KW_WHILE` |
+| `return` | `KW_RETURN` |
+| `in` | `KW_IN` |
+| `out` | `KW_OUT` |
+
+Any identifier that is not a reserved word produces an `IDENT` token carrying the name
+as a string.
+
+### Operators and Punctuation
+
+| Text | Token type | Notes |
+|---|---|---|
+| `+` | `PLUS` | |
+| `-` | `MINUS` | |
+| `*` | `STAR` | |
+| `/` | `SLASH` | |
+| `%` | `PERCENT` | |
+| `&` | `AMP` | |
+| `\|` | `PIPE` | |
+| `^` | `CARET` | |
+| `~` | `TILDE` | |
+| `<<` | `SHL` | Greedy: `<<` before `<` |
+| `>>` | `SHR` | Greedy: `>>` before `>` |
+| `==` | `EQ_EQ` | |
+| `!=` | `BANG_EQ` | |
+| `<` | `LT` | |
+| `<=` | `LT_EQ` | Greedy: `<=` before `<` |
+| `>` | `GT` | |
+| `>=` | `GT_EQ` | Greedy: `>=` before `>` |
+| `&&` | `AMP_AMP` | |
+| `\|\|` | `PIPE_PIPE` | |
+| `!` | `BANG` | |
+| `=` | `EQ` | Assignment; not equality |
+| `(` | `LPAREN` | |
+| `)` | `RPAREN` | |
+| `{` | `LBRACE` | |
+| `}` | `RBRACE` | |
+| `,` | `COMMA` | |
+| `;` | `SEMI` | |
+
+### End-of-File
+
+| Token type | Description |
+|---|---|
+| `EOF` | Emitted once when the source is exhausted |
+
+The parser uses `EOF` to recognize end-of-input cleanly without needing a length check.
+
+---
+
+## Whitespace and Comments
+
+### Whitespace
+
+Spaces, tabs (`\t`), carriage returns (`\r`), and newlines (`\n`) are all whitespace.
+The lexer skips whitespace between tokens. Whitespace is never significant (there is no
+off-side rule or indentation sensitivity).
+
+### Comments
+
+Tetrad uses C-style line comments:
+
+```
+// This is a comment. Everything from // to end of line is ignored.
+```
+
+Block comments (`/* ... */`) are not supported in v1. A `//` inside a string literal
+would not trigger a comment — but since Tetrad has no string literals, this edge case
+does not exist.
+
+---
+
+## Lexer Algorithm
+
+```
+Tetrad lexer pseudocode:
+
+procedure tokenize(source: str) → list[Token]:
+    pos = 0
+    tokens = []
+
+    while pos < len(source):
+        skip_whitespace_and_comments()
+        if pos >= len(source):
+            break
+
+        ch = source[pos]
+
+        if ch is digit:
+            tokens.append(scan_number())
+        elif ch is letter or '_':
+            tokens.append(scan_ident_or_keyword())
+        else:
+            tokens.append(scan_punctuation())
+
+    tokens.append(Token(EOF, pos=pos))
+    return tokens
+```
+
+### Scanning Numbers
+
+```
+procedure scan_number() → Token:
+    start = pos
+    if source[pos:pos+2] == '0x' or '0X':
+        pos += 2
+        scan while source[pos] is hex digit [0-9A-Fa-f]
+        value = int(source[start:pos], 16)
+        return Token(HEX, value, span(start, pos))
+    else:
+        scan while source[pos] is decimal digit [0-9]
+        value = int(source[start:pos], 10)
+        return Token(INT, value, span(start, pos))
+```
+
+### Scanning Identifiers and Keywords
+
+```
+procedure scan_ident_or_keyword() → Token:
+    start = pos
+    scan while source[pos] is letter, digit, or '_'
+    text = source[start:pos]
+    if text in RESERVED_WORDS:
+        return Token(RESERVED_WORDS[text], text, span(start, pos))
+    else:
+        return Token(IDENT, text, span(start, pos))
+```
+
+### Scanning Punctuation (multi-character operators)
+
+The lexer uses a greedy (maximal munch) strategy: always consume the longest valid token.
+The two-character operators (`<<`, `>>`, `==`, `!=`, `<=`, `>=`, `&&`, `||`) must be
+checked before their one-character prefixes:
+
+```
+procedure scan_punctuation() → Token:
+    start = pos
+    two = source[pos:pos+2]
+    if two in TWO_CHAR_OPERATORS:
+        pos += 2
+        return Token(TWO_CHAR_OPERATORS[two], two, span(start, pos))
+    one = source[pos]
+    pos += 1
+    if one in ONE_CHAR_OPERATORS:
+        return Token(ONE_CHAR_OPERATORS[one], one, span(start, pos))
+    raise LexError(f"unexpected character {one!r}", span(start, pos))
+```
+
+---
+
+## Token Data Structure
+
+Every token carries:
+
+```python
+@dataclass
+class Token:
+    type: TokenType           # The token type (enum)
+    value: str | int | None   # Text for IDENT; int for INT/HEX; None for punctuation/keywords
+    line: int                 # 1-based line number
+    column: int               # 1-based column number of first character
+    offset: int               # 0-based byte offset into source text
+```
+
+The `line` and `column` fields are used to produce helpful error messages in the parser
+and compiler. The lexer increments `line` each time it passes a `\n` and resets
+`column` to 1.
+
+---
+
+## Error Handling
+
+The lexer raises `LexError` for the following conditions:
+
+| Condition | Error message |
+|---|---|
+| Character not in any token pattern | `unexpected character '\x??' at line N col C` |
+| Hex literal with no digits after `0x` | `empty hex literal at line N col C` |
+
+The lexer does not produce partial tokens on error. It raises immediately. The compiler
+(spec TET03) catches `LexError` and includes the position in its error output.
+
+The lexer does **not** check:
+- Whether integer literals exceed 255 (the compiler does this)
+- Whether identifiers shadow reserved words (the compiler does this)
+- Whether `in(` / `out(` are used correctly (the parser does this)
+
+---
+
+## Token Stream Examples
+
+### Source
+
+```tetrad
+fn add(a, b) {
+    return a + b;
+}
+```
+
+### Token Stream
+
+```
+KW_FN      'fn'     line=1 col=1
+IDENT      'add'    line=1 col=4
+LPAREN     '('      line=1 col=7
+IDENT      'a'      line=1 col=8
+COMMA      ','      line=1 col=9
+IDENT      'b'      line=1 col=11
+RPAREN     ')'      line=1 col=12
+LBRACE     '{'      line=1 col=14
+KW_RETURN  'return' line=2 col=5
+IDENT      'a'      line=2 col=12
+PLUS       '+'      line=2 col=14
+IDENT      'b'      line=2 col=16
+SEMI       ';'      line=2 col=17
+RBRACE     '}'      line=3 col=1
+EOF               line=4 col=1
+```
+
+### Source with Comment
+
+```tetrad
+let x = 0xFF;   // 255 in hex
+```
+
+### Token Stream
+
+```
+KW_LET  'let'  line=1 col=1
+IDENT   'x'    line=1 col=5
+EQ      '='    line=1 col=7
+HEX     255    line=1 col=9
+SEMI    ';'    line=1 col=13
+EOF            line=2 col=1
+```
+
+The comment produces no tokens.
+
+---
+
+## Python Package
+
+The lexer lives in `code/packages/python/tetrad-lexer/`.
+
+### Public API
+
+```python
+from tetrad_lexer import tokenize, Token, TokenType, LexError
+
+# Tokenize a source string.
+# Returns a list ending with EOF.
+# Raises LexError on illegal input.
+def tokenize(source: str) -> list[Token]: ...
+
+class TokenType(enum.Enum):
+    INT = "INT"
+    HEX = "HEX"
+    IDENT = "IDENT"
+    KW_FN = "KW_FN"
+    KW_LET = "KW_LET"
+    KW_IF = "KW_IF"
+    KW_ELSE = "KW_ELSE"
+    KW_WHILE = "KW_WHILE"
+    KW_RETURN = "KW_RETURN"
+    KW_IN = "KW_IN"
+    KW_OUT = "KW_OUT"
+    PLUS = "PLUS"
+    MINUS = "MINUS"
+    STAR = "STAR"
+    SLASH = "SLASH"
+    PERCENT = "PERCENT"
+    AMP = "AMP"
+    PIPE = "PIPE"
+    CARET = "CARET"
+    TILDE = "TILDE"
+    SHL = "SHL"
+    SHR = "SHR"
+    EQ_EQ = "EQ_EQ"
+    BANG_EQ = "BANG_EQ"
+    LT = "LT"
+    LT_EQ = "LT_EQ"
+    GT = "GT"
+    GT_EQ = "GT_EQ"
+    AMP_AMP = "AMP_AMP"
+    PIPE_PIPE = "PIPE_PIPE"
+    BANG = "BANG"
+    EQ = "EQ"
+    LPAREN = "LPAREN"
+    RPAREN = "RPAREN"
+    LBRACE = "LBRACE"
+    RBRACE = "RBRACE"
+    COMMA = "COMMA"
+    SEMI = "SEMI"
+    EOF = "EOF"
+
+@dataclass
+class Token:
+    type: TokenType
+    value: str | int | None
+    line: int
+    column: int
+    offset: int
+
+class LexError(Exception):
+    def __init__(self, message: str, line: int, column: int): ...
+```
+
+---
+
+## Test Strategy
+
+### Happy-path token tests
+
+- Single integer literal: `42` → `[INT(42), EOF]`
+- Hex literal: `0xFF` → `[HEX(255), EOF]`
+- All 8 reserved words tokenize to their keyword type
+- Identifier: `counter` → `[IDENT('counter'), EOF]`
+- Every two-character operator tokenizes correctly
+- Every one-character operator tokenizes correctly
+
+### Whitespace and comment tests
+
+- Leading/trailing whitespace is skipped
+- Multiple blank lines produce no tokens
+- Comment on its own line produces no tokens
+- Comment at end of a line with tokens does not consume the newline's effect on
+  line numbering
+
+### Multi-token tests
+
+- Full function declaration: verify token sequence matches expected
+- `<=` is one token, not `<` followed by `=`
+- `<<` is one token, not `<` followed by `<`
+- `==` is one token, not `=` followed by `=`
+
+### Position tests
+
+- Verify `line` and `column` are correct across newlines
+- Verify `offset` matches byte position in source
+
+### Error tests
+
+- `@` produces `LexError`
+- `0x` with no following hex digits produces `LexError`
+- `#` produces `LexError`
+- Error message includes line and column
+
+### Coverage target
+
+95%+ line coverage.
+
+---
+
+## Version History
+
+| Version | Date | Description |
+|---|---|---|
+| 0.1.0 | 2026-04-20 | Initial specification |

--- a/code/specs/TET02-tetrad-parser.md
+++ b/code/specs/TET02-tetrad-parser.md
@@ -47,6 +47,8 @@ The root of every AST.
 class FnDecl:
     name: str
     params: list[str]
+    param_types: list[str | None]   # parallel to params; None = no annotation
+    return_type: str | None         # None = no return type annotation
     body: Block
     line: int
     column: int
@@ -54,6 +56,7 @@ class FnDecl:
 @dataclass
 class GlobalDecl:
     name: str
+    declared_type: str | None       # None = no annotation
     value: Expr
     line: int
     column: int
@@ -74,6 +77,7 @@ class Block:
 @dataclass
 class LetStmt:
     name: str
+    declared_type: str | None       # None = no annotation
     value: Expr
     line: int
     column: int
@@ -288,10 +292,14 @@ def parse_stmt() -> Stmt:
 def parse_let_stmt() -> LetStmt:
     expect(KW_LET)
     name = expect(IDENT).value
+    declared_type = None
+    if peek().type == COLON:
+        advance()
+        declared_type = parse_type()   # currently: expect KW_U8, return "u8"
     expect(EQ)
     value = parse_expr()
     expect(SEMI)
-    return LetStmt(name=name, value=value)
+    return LetStmt(name=name, declared_type=declared_type, value=value)
 ```
 
 ### Assign Statement
@@ -419,14 +427,37 @@ def parse_fn_decl() -> FnDecl:
     name = expect(IDENT).value
     expect(LPAREN)
     params = []
+    param_types = []
     if peek().type != RPAREN:
-        params.append(expect(IDENT).value)
+        pname, ptype = parse_param()
+        params.append(pname)
+        param_types.append(ptype)
         while peek().type == COMMA:
             advance()
-            params.append(expect(IDENT).value)
+            pname, ptype = parse_param()
+            params.append(pname)
+            param_types.append(ptype)
     expect(RPAREN)
+    return_type = None
+    if peek().type == ARROW:
+        advance()
+        return_type = parse_type()
     body = parse_block()
-    return FnDecl(name=name, params=params, body=body)
+    return FnDecl(name=name, params=params, param_types=param_types,
+                  return_type=return_type, body=body)
+
+def parse_param() -> tuple[str, str | None]:
+    """Parse 'NAME' or 'NAME : type'."""
+    name = expect(IDENT).value
+    if peek().type == COLON:
+        advance()
+        return name, parse_type()
+    return name, None
+
+def parse_type() -> str:
+    """Parse a type annotation. Currently only 'u8' is valid."""
+    tok = expect(KW_U8)
+    return "u8"
 ```
 
 ### Global Declaration
@@ -441,10 +472,14 @@ Same syntax as a let-statement, but at the top level it becomes a `GlobalDecl`.
 def parse_global_decl() -> GlobalDecl:
     expect(KW_LET)
     name = expect(IDENT).value
+    declared_type = None
+    if peek().type == COLON:
+        advance()
+        declared_type = parse_type()
     expect(EQ)
     value = parse_expr()
     expect(SEMI)
-    return GlobalDecl(name=name, value=value)
+    return GlobalDecl(name=name, declared_type=declared_type, value=value)
 ```
 
 ---
@@ -460,6 +495,8 @@ The parser raises `ParseError` for:
 | Unexpected token at top level | `expected fn or let at top level, got Y at line N col C` |
 | Call with no closing paren | `unclosed argument list for call to 'name'` |
 | `in` used without `()` | `in must be called as in(), not as a bare name` |
+| `:` followed by unknown type name | `unknown type 'foo'; only 'u8' is valid` |
+| `->` with no following type | `expected type after '->', got EOF` |
 
 The parser does not attempt error recovery in v1. The first `ParseError` aborts parsing.
 

--- a/code/specs/TET02-tetrad-parser.md
+++ b/code/specs/TET02-tetrad-parser.md
@@ -1,0 +1,596 @@
+# TET02 — Tetrad Parser Specification
+
+## Overview
+
+The Tetrad parser consumes the token stream produced by the lexer (spec TET01) and
+builds an Abstract Syntax Tree (AST). The parser is a hand-written **Pratt parser**
+(also called a top-down operator precedence parser) for expressions, combined with a
+recursive descent parser for statements and declarations.
+
+A Pratt parser assigns every token type two optional parsing functions:
+
+- **Null denotation (NUD)**: how to parse a token that appears at the *start* of an
+  expression (e.g., a literal, an identifier, a unary operator, an opening paren)
+- **Left denotation (LED)**: how to parse a token that appears *in the middle* of an
+  expression, with something to its left already parsed (e.g., a binary operator)
+
+Each LED also carries a **binding power** (precedence level). When `parse_expr(min_bp)`
+is called, it keeps consuming infix operators as long as their binding power exceeds
+`min_bp`. This naturally implements precedence and associativity with no special cases.
+
+Pratt parsers are the standard choice for expression parsing in modern language
+implementations — they are used in V8, Clang, Rust's compiler, and Crafting Interpreters.
+The recursive-descent wrapper for statements is universal.
+
+---
+
+## AST Node Types
+
+Every node is a Python dataclass with a `line` and `column` field for error reporting.
+
+### Program
+
+```python
+@dataclass
+class Program:
+    decls: list[FnDecl | GlobalDecl]
+    line: int = 0
+    column: int = 0
+```
+
+The root of every AST.
+
+### Declarations
+
+```python
+@dataclass
+class FnDecl:
+    name: str
+    params: list[str]
+    body: Block
+    line: int
+    column: int
+
+@dataclass
+class GlobalDecl:
+    name: str
+    value: Expr
+    line: int
+    column: int
+```
+
+`FnDecl` represents `fn name(params...) { body }`. `GlobalDecl` represents a top-level
+`let name = expr;`.
+
+### Statements
+
+```python
+@dataclass
+class Block:
+    stmts: list[Stmt]
+    line: int
+    column: int
+
+@dataclass
+class LetStmt:
+    name: str
+    value: Expr
+    line: int
+    column: int
+
+@dataclass
+class AssignStmt:
+    name: str
+    value: Expr
+    line: int
+    column: int
+
+@dataclass
+class IfStmt:
+    condition: Expr
+    then_block: Block
+    else_block: Block | None
+    line: int
+    column: int
+
+@dataclass
+class WhileStmt:
+    condition: Expr
+    body: Block
+    line: int
+    column: int
+
+@dataclass
+class ReturnStmt:
+    value: Expr | None
+    line: int
+    column: int
+
+@dataclass
+class ExprStmt:
+    expr: Expr
+    line: int
+    column: int
+```
+
+`ExprStmt` covers `out(x);` and any other expression used as a statement.
+
+### Expressions
+
+```python
+# Union type alias used throughout
+Expr = (BinaryExpr | UnaryExpr | CallExpr | InExpr |
+        OutExpr | NameExpr | IntLiteral | GroupExpr)
+
+@dataclass
+class IntLiteral:
+    value: int        # 0–255 (range checked in compiler, not parser)
+    line: int
+    column: int
+
+@dataclass
+class NameExpr:
+    name: str
+    line: int
+    column: int
+
+@dataclass
+class BinaryExpr:
+    op: str           # '+', '-', '*', '/', '%', '&', '|', '^',
+                      # '<<', '>>', '==', '!=', '<', '<=', '>', '>=',
+                      # '&&', '||'
+    left: Expr
+    right: Expr
+    line: int
+    column: int
+
+@dataclass
+class UnaryExpr:
+    op: str           # '!', '~', '-'
+    operand: Expr
+    line: int
+    column: int
+
+@dataclass
+class CallExpr:
+    name: str
+    args: list[Expr]
+    line: int
+    column: int
+
+@dataclass
+class InExpr:
+    """Represents in() — read from I/O port."""
+    line: int
+    column: int
+
+@dataclass
+class OutExpr:
+    """Represents out(expr) — write to I/O port.
+    Modelled as an expression so it can appear as ExprStmt.
+    Result value is undefined (void-like).
+    """
+    value: Expr
+    line: int
+    column: int
+
+@dataclass
+class GroupExpr:
+    expr: Expr
+    line: int
+    column: int
+```
+
+`GroupExpr` wraps a parenthesized expression. The compiler treats it as transparent.
+
+---
+
+## Binding Power Table
+
+Pratt parsers assign a numeric binding power to each infix operator. A higher number
+means the operator binds tighter (higher precedence). Right-associative operators use
+`right_bp = left_bp - 1` so the right side re-enters the parser at a lower threshold.
+
+| Operators | Left BP | Right BP | Associativity |
+|---|---|---|---|
+| `\|\|` | 10 | 10 | Left |
+| `&&` | 20 | 20 | Left |
+| `==`, `!=` | 30 | 30 | Left |
+| `<`, `>`, `<=`, `>=` | 40 | 40 | Left |
+| `\|` | 50 | 50 | Left |
+| `^` | 60 | 60 | Left |
+| `&` | 70 | 70 | Left |
+| `<<`, `>>` | 80 | 80 | Left |
+| `+`, `-` | 90 | 90 | Left |
+| `*`, `/`, `%` | 100 | 100 | Left |
+
+Prefix operators (`!`, `~`, unary `-`) have no binding power because they are handled
+by NUD functions (they start an expression, not continue one).
+
+---
+
+## Pratt Parser Algorithm
+
+```python
+def parse_expr(min_bp: int = 0) -> Expr:
+    # Step 1: call the NUD for the current token (left-hand side)
+    token = advance()
+    left = nud(token)
+
+    # Step 2: while next token is an infix operator with bp > min_bp, extend
+    while True:
+        op = peek()
+        bp = left_bp(op)
+        if bp is None or bp <= min_bp:
+            break
+        advance()            # consume the operator
+        left = led(op, left) # build a BinaryExpr using the right-bp threshold
+
+    return left
+```
+
+### NUD handlers
+
+| Token type | NUD action |
+|---|---|
+| `INT` | Return `IntLiteral(token.value)` |
+| `HEX` | Return `IntLiteral(token.value)` |
+| `IDENT` | If next is `LPAREN`: parse call. Else: return `NameExpr(token.value)` |
+| `KW_IN` | Expect `LPAREN RPAREN`, return `InExpr()` |
+| `KW_OUT` | Expect `LPAREN`, parse `expr`, expect `RPAREN`, return `OutExpr(expr)` |
+| `MINUS` | Parse `unary_expr(bp=110)`, return `UnaryExpr('-', operand)` |
+| `BANG` | Parse `unary_expr(bp=110)`, return `UnaryExpr('!', operand)` |
+| `TILDE` | Parse `unary_expr(bp=110)`, return `UnaryExpr('~', operand)` |
+| `LPAREN` | Parse `expr(0)`, expect `RPAREN`, return `GroupExpr(expr)` |
+
+Unary operators use bp=110, which is above all binary operators, so `-a * b` parses as
+`(-a) * b` (the negation binds to `a` alone before multiplication sees it).
+
+### LED handlers
+
+Every infix operator shares the same LED shape:
+
+```python
+def led_binary(op: str, left: Expr, right_bp: int) -> BinaryExpr:
+    right = parse_expr(right_bp)
+    return BinaryExpr(op=op, left=left, right=right)
+```
+
+The `right_bp` value is the operator's binding power (same as left BP for all
+left-associative operators in Tetrad, since Tetrad has no right-associative binaries).
+
+---
+
+## Statement Parsing
+
+Statements are parsed by recursive descent (not Pratt). The entry point is
+`parse_stmt()` which dispatches on the current token:
+
+```python
+def parse_stmt() -> Stmt:
+    tok = peek()
+    if tok.type == KW_LET:    return parse_let_stmt()
+    if tok.type == KW_IF:     return parse_if_stmt()
+    if tok.type == KW_WHILE:  return parse_while_stmt()
+    if tok.type == KW_RETURN: return parse_return_stmt()
+    if tok.type == IDENT and peek_next().type == EQ:
+        return parse_assign_stmt()
+    return parse_expr_stmt()
+```
+
+### Let Statement
+
+```
+"let" NAME "=" expr ";"
+```
+
+```python
+def parse_let_stmt() -> LetStmt:
+    expect(KW_LET)
+    name = expect(IDENT).value
+    expect(EQ)
+    value = parse_expr()
+    expect(SEMI)
+    return LetStmt(name=name, value=value)
+```
+
+### Assign Statement
+
+Disambiguation from an expression statement: a bare `NAME` followed by `=` (not `==`)
+is an assignment. The parser peeks two tokens to distinguish.
+
+```python
+def parse_assign_stmt() -> AssignStmt:
+    name = expect(IDENT).value
+    expect(EQ)
+    value = parse_expr()
+    expect(SEMI)
+    return AssignStmt(name=name, value=value)
+```
+
+### If Statement
+
+```
+"if" expr block [ "else" block ]
+```
+
+The `else` is optional. There is no `elif` keyword; chains are written as:
+
+```tetrad
+if a { ... } else { if b { ... } else { ... } }
+```
+
+```python
+def parse_if_stmt() -> IfStmt:
+    expect(KW_IF)
+    condition = parse_expr()
+    then_block = parse_block()
+    else_block = None
+    if peek().type == KW_ELSE:
+        advance()
+        else_block = parse_block()
+    return IfStmt(condition=condition, then_block=then_block, else_block=else_block)
+```
+
+### While Statement
+
+```
+"while" expr block
+```
+
+```python
+def parse_while_stmt() -> WhileStmt:
+    expect(KW_WHILE)
+    condition = parse_expr()
+    body = parse_block()
+    return WhileStmt(condition=condition, body=body)
+```
+
+### Return Statement
+
+```
+"return" [ expr ] ";"
+```
+
+```python
+def parse_return_stmt() -> ReturnStmt:
+    expect(KW_RETURN)
+    value = None
+    if peek().type != SEMI:
+        value = parse_expr()
+    expect(SEMI)
+    return ReturnStmt(value=value)
+```
+
+### Expression Statement
+
+```
+expr ";"
+```
+
+Covers `out(n);`, function calls, and any expression used for side effects.
+
+```python
+def parse_expr_stmt() -> ExprStmt:
+    expr = parse_expr()
+    expect(SEMI)
+    return ExprStmt(expr=expr)
+```
+
+### Block
+
+```
+"{" stmt* "}"
+```
+
+```python
+def parse_block() -> Block:
+    expect(LBRACE)
+    stmts = []
+    while peek().type not in (RBRACE, EOF):
+        stmts.append(parse_stmt())
+    expect(RBRACE)
+    return Block(stmts=stmts)
+```
+
+---
+
+## Declaration Parsing
+
+```python
+def parse_top_decl() -> FnDecl | GlobalDecl:
+    tok = peek()
+    if tok.type == KW_FN:
+        return parse_fn_decl()
+    if tok.type == KW_LET:
+        return parse_global_decl()
+    raise ParseError(f"expected fn or let at top level", tok)
+```
+
+### Function Declaration
+
+```
+"fn" NAME "(" params? ")" block
+```
+
+```python
+def parse_fn_decl() -> FnDecl:
+    expect(KW_FN)
+    name = expect(IDENT).value
+    expect(LPAREN)
+    params = []
+    if peek().type != RPAREN:
+        params.append(expect(IDENT).value)
+        while peek().type == COMMA:
+            advance()
+            params.append(expect(IDENT).value)
+    expect(RPAREN)
+    body = parse_block()
+    return FnDecl(name=name, params=params, body=body)
+```
+
+### Global Declaration
+
+```
+"let" NAME "=" expr ";"
+```
+
+Same syntax as a let-statement, but at the top level it becomes a `GlobalDecl`.
+
+```python
+def parse_global_decl() -> GlobalDecl:
+    expect(KW_LET)
+    name = expect(IDENT).value
+    expect(EQ)
+    value = parse_expr()
+    expect(SEMI)
+    return GlobalDecl(name=name, value=value)
+```
+
+---
+
+## Error Handling
+
+The parser raises `ParseError` for:
+
+| Condition | Message |
+|---|---|
+| Expected token not found | `expected X, got Y at line N col C` |
+| Unexpected token at expression start | `unexpected token Y in expression at line N col C` |
+| Unexpected token at top level | `expected fn or let at top level, got Y at line N col C` |
+| Call with no closing paren | `unclosed argument list for call to 'name'` |
+| `in` used without `()` | `in must be called as in(), not as a bare name` |
+
+The parser does not attempt error recovery in v1. The first `ParseError` aborts parsing.
+
+---
+
+## Concrete Parse Example
+
+### Source
+
+```tetrad
+fn multiply(a, b) {
+    let result = 0;
+    while b > 0 {
+        result = result + a;
+        b = b - 1;
+    }
+    return result;
+}
+```
+
+### AST
+
+```
+Program
+└── FnDecl name='multiply' params=['a', 'b']
+    └── Block
+        ├── LetStmt name='result'
+        │   └── IntLiteral value=0
+        ├── WhileStmt
+        │   ├── condition: BinaryExpr op='>'
+        │   │   ├── left: NameExpr name='b'
+        │   │   └── right: IntLiteral value=0
+        │   └── body: Block
+        │       ├── AssignStmt name='result'
+        │       │   └── BinaryExpr op='+'
+        │       │       ├── left: NameExpr name='result'
+        │       │       └── right: NameExpr name='a'
+        │       └── AssignStmt name='b'
+        │           └── BinaryExpr op='-'
+        │               ├── left: NameExpr name='b'
+        │               └── right: IntLiteral value=1
+        └── ReturnStmt
+            └── NameExpr name='result'
+```
+
+---
+
+## Python Package
+
+The parser lives in `code/packages/python/tetrad-parser/`.
+
+Depends on `coding-adventures-tetrad-lexer`.
+
+### Public API
+
+```python
+from tetrad_parser import parse, ParseError
+from tetrad_parser.ast import (
+    Program, FnDecl, GlobalDecl, Block,
+    LetStmt, AssignStmt, IfStmt, WhileStmt, ReturnStmt, ExprStmt,
+    IntLiteral, NameExpr, BinaryExpr, UnaryExpr,
+    CallExpr, InExpr, OutExpr, GroupExpr,
+)
+
+# Parse a Tetrad source string into an AST.
+# Calls tokenize() internally.
+# Raises LexError or ParseError on invalid input.
+def parse(source: str) -> Program: ...
+
+class ParseError(Exception):
+    def __init__(self, message: str, line: int, column: int): ...
+```
+
+---
+
+## Test Strategy
+
+### Expression precedence tests
+
+Verify that operator precedence matches the binding power table:
+- `1 + 2 * 3` → `BinaryExpr('+', 1, BinaryExpr('*', 2, 3))` (mul binds tighter)
+- `1 * 2 + 3` → `BinaryExpr('+', BinaryExpr('*', 1, 2), 3)`
+- `a || b && c` → `BinaryExpr('||', a, BinaryExpr('&&', b, c))` (and binds tighter)
+- `~a + b` → `BinaryExpr('+', UnaryExpr('~', a), b)` (unary binds tightest)
+- `(1 + 2) * 3` → `BinaryExpr('*', GroupExpr(BinaryExpr('+', 1, 2)), 3)`
+
+### Statement parsing tests
+
+- `let x = 42;` → `LetStmt(name='x', value=IntLiteral(42))`
+- `x = x + 1;` → `AssignStmt(name='x', value=BinaryExpr('+', NameExpr('x'), IntLiteral(1)))`
+- `if a > 0 { ... }` → `IfStmt` with no `else_block`
+- `if a { ... } else { ... }` → `IfStmt` with `else_block`
+- `while n > 0 { ... }` → `WhileStmt`
+- `return;` → `ReturnStmt(value=None)`
+- `return x + 1;` → `ReturnStmt` with `BinaryExpr`
+- `out(42);` → `ExprStmt(OutExpr(IntLiteral(42)))`
+
+### Call expression tests
+
+- `add(1, 2)` → `CallExpr(name='add', args=[IntLiteral(1), IntLiteral(2)])`
+- `f()` → `CallExpr(name='f', args=[])`
+
+### I/O expression tests
+
+- `in()` → `InExpr()`
+- `out(x)` → `OutExpr(NameExpr('x'))`
+
+### Declaration tests
+
+- `fn f(a, b) { return a; }` → `FnDecl(name='f', params=['a','b'], body=Block(...))`
+- Top-level `let x = 10;` → `GlobalDecl(name='x', value=IntLiteral(10))`
+
+### Error tests
+
+- Missing `{` in block → `ParseError`
+- Extra `)` → `ParseError`
+- `in` without `()` → `ParseError`
+- Bare `=` without left side → `ParseError`
+
+### End-to-end tests
+
+Parse all five example programs from TET00 and verify the top-level structure.
+
+### Coverage target
+
+95%+ line coverage.
+
+---
+
+## Version History
+
+| Version | Date | Description |
+|---|---|---|
+| 0.1.0 | 2026-04-20 | Initial specification |

--- a/code/specs/TET02b-tetrad-type-checker.md
+++ b/code/specs/TET02b-tetrad-type-checker.md
@@ -1,0 +1,502 @@
+# TET02b — Tetrad Type Checker Specification
+
+## Overview
+
+The Tetrad type checker sits between the parser (spec TET02) and the bytecode compiler
+(spec TET03). It walks the AST produced by the parser, resolves type annotations,
+infers types where possible, catches type inconsistencies, and annotates every
+expression node with its inferred type.
+
+The output of the type checker — a `TypeCheckResult` containing the enriched AST and a
+`TypeEnvironment` — is passed directly to the compiler. The compiler reads the type
+annotations to decide whether to emit feedback slots (for untyped ops) or skip them
+(for statically-known ops). This is the mechanism by which optional types accelerate
+both the VM and the JIT.
+
+Tetrad uses **gradual typing**: type annotations are optional. A program with no
+annotations is valid and behaves exactly as in TET03/TET04 v1. A fully-annotated
+program allows the compiler to produce a more compact bytecode with no feedback overhead.
+
+---
+
+## Motivation: Why Types Make the Pipeline Faster
+
+```
+Untyped:  fn add(a, b)      { return a + b; }
+Typed:    fn add(a: u8, b: u8) -> u8 { return a + b; }
+```
+
+For the **untyped** function, the pipeline must:
+1. Emit `ADD r0, slot=N` — 3 bytes (includes slot operand)
+2. Allocate a feedback vector at call time — RAM cost
+3. Record `u8 × u8` into slot N on every execution
+4. Wait for 100 calls before the JIT compiles it
+
+For the **typed** function, the pipeline can:
+1. Emit `ADD r0` — 2 bytes (no slot operand needed)
+2. Skip feedback vector allocation entirely — saves RAM
+3. Mark the function `immediate_jit_eligible = True`
+4. JIT compile it on the **first call**
+
+On the Intel 4004, saving 1 byte per binary op is meaningful. A function with 5
+arithmetic operations saves 5 bytes of ROM. Eliminating feedback vector allocation
+saves RAM proportional to the feedback slot count.
+
+For a future Lisp front-end, this matters even more: `(declare (fixnum x y))` annotates
+a Lisp function with concrete types. The Tetrad type checker converts those into
+`FULLY_TYPED` CodeObjects, and the JIT generates specialized integer code immediately
+without any profiling warmup.
+
+---
+
+## The Three-Tier Type Status
+
+Every function in a Tetrad program is classified into one of three tiers:
+
+```
+FULLY_TYPED      All parameters annotated, return type annotated,
+                 all operations infer to a known type with no
+                 contradictions. Compiler emits no feedback slots.
+                 JIT compiles on first call.
+
+PARTIALLY_TYPED  Some annotations present. The type checker annotates
+                 what it can; the rest remains unknown. Compiler emits
+                 feedback slots only for ops with unknown operand types.
+                 JIT uses a lower threshold (10 calls).
+
+UNTYPED          No annotations whatsoever. Identical to Tetrad v1
+                 behavior. All ops get feedback slots. JIT uses the
+                 standard threshold (100 calls).
+```
+
+A function is `PARTIALLY_TYPED` if it has at least one annotation but is not
+`FULLY_TYPED`. A function with no annotations at all is `UNTYPED`.
+
+---
+
+## Type Language
+
+In Tetrad v1, there is exactly one concrete type:
+
+| Type token | Meaning |
+|---|---|
+| `u8` | Unsigned 8-bit integer, 0–255, wraps on overflow |
+
+The type checker also uses two internal pseudo-types that do not appear in source:
+
+| Internal type | Meaning |
+|---|---|
+| `Unknown` | No annotation and no inference was possible |
+| `Void` | Used for `out(expr)` which has no meaningful value |
+
+When a Lisp front-end is added, the concrete type list will expand:
+`u8`, `pair`, `symbol`, `closure`, `bool`, `nil`. The type checker infrastructure
+is designed to accommodate this without structural change.
+
+---
+
+## AST Enrichment
+
+The type checker does not produce a new AST type hierarchy. Instead, it produces a
+**TypeMap** — a mapping from AST node identity (`id(node)`) to `TypeInfo` — alongside
+the original AST.
+
+```python
+@dataclass
+class TypeInfo:
+    ty: str                  # "u8", "Unknown", "Void"
+    source: str              # "annotation" | "inferred" | "unknown"
+    line: int                # source position for error messages
+    column: int
+```
+
+The compiler passes `(ast, type_map)` to every compilation function, reading
+`type_map[id(expr)]` to determine whether a slot is needed.
+
+---
+
+## Data Structures
+
+### TypeEnvironment
+
+```python
+@dataclass
+class FunctionType:
+    param_types: list[str | None]   # None = unannotated parameter
+    return_type: str | None         # None = unannotated return
+
+@dataclass
+class TypeEnvironment:
+    # Function signatures visible at the call site
+    functions: dict[str, FunctionType]
+
+    # Variable types in scope (populated per-function during checking)
+    variables: dict[str, TypeInfo]
+
+    # Classification of each function
+    function_status: dict[str, FunctionTypeStatus]
+
+    def lookup_var(self, name: str) -> TypeInfo | None: ...
+    def bind_var(self, name: str, info: TypeInfo) -> None: ...
+    def child_scope(self) -> TypeEnvironment: ...   # for block scopes
+```
+
+### FunctionTypeStatus
+
+```python
+from enum import Enum
+
+class FunctionTypeStatus(Enum):
+    FULLY_TYPED     = "fully_typed"
+    PARTIALLY_TYPED = "partially_typed"
+    UNTYPED         = "untyped"
+```
+
+### TypeCheckResult
+
+```python
+@dataclass
+class TypeCheckResult:
+    program: Program                    # original AST (unchanged)
+    type_map: dict[int, TypeInfo]       # id(expr node) → TypeInfo
+    env: TypeEnvironment                # final type environment
+    errors: list[TypeError]             # hard errors (compilation should abort)
+    warnings: list[TypeWarning]         # soft warnings (compilation proceeds)
+```
+
+### TypeError and TypeWarning
+
+```python
+@dataclass
+class TypeError:
+    message: str
+    line: int
+    column: int
+
+@dataclass
+class TypeWarning:
+    message: str
+    line: int
+    column: int
+    hint: str = ""
+```
+
+---
+
+## Type Inference Rules
+
+The type checker walks the AST bottom-up, inferring the type of each expression from
+the types of its sub-expressions and any available annotations.
+
+### Literals
+
+| Expression | Inferred type |
+|---|---|
+| `IntLiteral(N)` | `u8` — always (range check is compiler's job) |
+
+### Variables
+
+| Expression | Inferred type |
+|---|---|
+| `NameExpr(name)` | Look up `name` in current environment. If found and has type → use it. Else `Unknown`. |
+
+### Arithmetic and Bitwise Binary Expressions
+
+Tetrad's type algebra for u8 is closed: `u8 OP u8 → u8`. Any unknown operand
+propagates Unknown upward.
+
+| Left type | Right type | Result type |
+|---|---|---|
+| `u8` | `u8` | `u8` |
+| `u8` | `Unknown` | `Unknown` |
+| `Unknown` | `u8` | `Unknown` |
+| `Unknown` | `Unknown` | `Unknown` |
+
+### Comparison Expressions (`==`, `!=`, `<`, etc.)
+
+Comparisons produce a boolean encoded as `u8` (0 or 1). The type checker treats the
+result as `u8` regardless of operand types (since the result is always 0 or 1).
+
+| Left type | Right type | Result type |
+|---|---|---|
+| any | any | `u8` |
+
+### Logical Expressions (`&&`, `||`, `!`)
+
+Result is always `u8` (0 or 1).
+
+### Call Expressions
+
+```
+CallExpr(name, args)
+  → result type = env.functions[name].return_type ?? Unknown
+```
+
+If the callee has no return type annotation, the result is `Unknown`.
+
+### in()
+
+`InExpr` → type is `Unknown` (value comes from hardware I/O at runtime)
+
+### out(expr)
+
+`OutExpr` → type is `Void` (side effect, no value)
+
+---
+
+## Function Status Classification Algorithm
+
+After checking all expressions in a function, the type checker classifies it:
+
+```python
+def classify_function(fn: FnDecl, env: TypeEnvironment) -> FunctionTypeStatus:
+    has_any_annotation = (
+        any(t is not None for t in fn.param_types) or
+        fn.return_type is not None
+    )
+
+    if not has_any_annotation:
+        return FunctionTypeStatus.UNTYPED
+
+    all_params_typed = all(t is not None for t in fn.param_types)
+    return_typed = fn.return_type is not None
+
+    if not (all_params_typed and return_typed):
+        return FunctionTypeStatus.PARTIALLY_TYPED
+
+    # All params and return are annotated.
+    # Check that all ops inside the body inferred to known types.
+    all_ops_typed = all(
+        type_map[id(expr)].ty != "Unknown"
+        for expr in all_expressions_in(fn.body)
+        if is_binary_op(expr) or is_call(expr)
+    )
+
+    return FunctionTypeStatus.FULLY_TYPED if all_ops_typed else FunctionTypeStatus.PARTIALLY_TYPED
+```
+
+A function can be `FULLY_TYPED` only if every internal operation has a known type.
+If any operation yields `Unknown` (e.g., because it calls an untyped function), the
+function is at best `PARTIALLY_TYPED`.
+
+---
+
+## Type Checking Algorithm
+
+```python
+def check_program(program: Program) -> TypeCheckResult:
+    type_map: dict[int, TypeInfo] = {}
+    errors: list[TypeError] = []
+    warnings: list[TypeWarning] = []
+
+    # Phase 1: Collect all function signatures (forward declarations)
+    env = TypeEnvironment(functions={}, variables={}, function_status={})
+    for decl in program.decls:
+        if isinstance(decl, FnDecl):
+            env.functions[decl.name] = FunctionType(
+                param_types=decl.param_types,
+                return_type=decl.return_type,
+            )
+
+    # Phase 2: Check globals
+    for decl in program.decls:
+        if isinstance(decl, GlobalDecl):
+            inferred = check_expr(decl.value, env, type_map, errors)
+            annotated = decl.declared_type
+            if annotated and inferred.ty != "Unknown" and annotated != inferred.ty:
+                errors.append(TypeError(
+                    f"global '{decl.name}': declared {annotated}, got {inferred.ty}",
+                    decl.line, decl.column
+                ))
+            actual_type = annotated or inferred.ty
+            env.bind_var(decl.name, TypeInfo(ty=actual_type, source="annotation" if annotated else inferred.source, ...))
+
+    # Phase 3: Check each function body
+    for decl in program.decls:
+        if isinstance(decl, FnDecl):
+            check_fn(decl, env, type_map, errors, warnings)
+
+    # Phase 4: Classify each function
+    for decl in program.decls:
+        if isinstance(decl, FnDecl):
+            status = classify_function(decl, env, type_map)
+            env.function_status[decl.name] = status
+            if status == FunctionTypeStatus.UNTYPED:
+                warnings.append(TypeWarning(
+                    f"'{decl.name}' has no type annotations — JIT warmup required",
+                    decl.line, decl.column,
+                    hint="add param types and -> return type to enable immediate JIT compilation"
+                ))
+
+    return TypeCheckResult(program=program, type_map=type_map, env=env,
+                           errors=errors, warnings=warnings)
+```
+
+### check_fn
+
+```python
+def check_fn(fn: FnDecl, env: TypeEnvironment, type_map, errors, warnings):
+    local_env = env.child_scope()
+
+    # Bind parameters with their annotated types (or Unknown)
+    for name, ann_type in zip(fn.params, fn.param_types):
+        ty = ann_type if ann_type else "Unknown"
+        local_env.bind_var(name, TypeInfo(ty=ty, source="annotation" if ann_type else "unknown", ...))
+
+    # Check the body
+    check_block(fn.body, local_env, fn.return_type, type_map, errors, warnings)
+```
+
+### check_expr (bottom-up walk)
+
+```python
+def check_expr(expr, env, type_map, errors) -> TypeInfo:
+    if isinstance(expr, IntLiteral):
+        info = TypeInfo(ty="u8", source="inferred", ...)
+    elif isinstance(expr, NameExpr):
+        found = env.lookup_var(expr.name)
+        info = found if found else TypeInfo(ty="Unknown", source="unknown", ...)
+    elif isinstance(expr, BinaryExpr):
+        left_info  = check_expr(expr.left, env, type_map, errors)
+        right_info = check_expr(expr.right, env, type_map, errors)
+        result_ty = "u8" if left_info.ty == "u8" and right_info.ty == "u8" else "Unknown"
+        info = TypeInfo(ty=result_ty, source="inferred", ...)
+    elif isinstance(expr, CallExpr):
+        fn_type = env.functions.get(expr.name)
+        result_ty = fn_type.return_type if fn_type and fn_type.return_type else "Unknown"
+        info = TypeInfo(ty=result_ty, source="inferred" if result_ty != "Unknown" else "unknown", ...)
+    elif isinstance(expr, InExpr):
+        info = TypeInfo(ty="Unknown", source="unknown", ...)  # runtime I/O
+    elif isinstance(expr, OutExpr):
+        check_expr(expr.value, env, type_map, errors)
+        info = TypeInfo(ty="Void", source="inferred", ...)
+    elif isinstance(expr, UnaryExpr):
+        operand_info = check_expr(expr.operand, env, type_map, errors)
+        info = TypeInfo(ty=operand_info.ty, source="inferred", ...)
+    elif isinstance(expr, GroupExpr):
+        info = check_expr(expr.expr, env, type_map, errors)
+    else:
+        info = TypeInfo(ty="Unknown", source="unknown", ...)
+
+    type_map[id(expr)] = info
+    return info
+```
+
+---
+
+## Errors and Warnings
+
+### Hard Errors (abort compilation)
+
+| Condition | Error message |
+|---|---|
+| `let x: u8 = in()` | `'x' declared u8 but assigned Unknown (I/O value has no static type)` |
+| `fn f(a: u8) -> u8` body returns expression of Unknown type | `'f' declared -> u8 but return expression has unknown type` |
+| Type annotation uses an unknown type name | `unknown type 'foo' at line N col C` |
+
+### Soft Warnings (compilation proceeds)
+
+| Condition | Warning message |
+|---|---|
+| Function has no annotations | `'f' is untyped — JIT requires warmup; add types for immediate compilation` |
+| Calling an untyped function from a typed context | `call to untyped 'g' in typed context 'f' — 'f' downgraded to PARTIALLY_TYPED` |
+| Parameter annotated but return type missing | `'f' has typed params but no return type — classified PARTIALLY_TYPED` |
+
+---
+
+## Interaction with the Compiler (TET03)
+
+The compiler receives `(program: Program, result: TypeCheckResult)` and uses it as
+follows:
+
+```python
+# When compiling a binary op, consult the type map:
+def emit_binary_op(op, left_node, right_node, type_map, code):
+    left_ty  = type_map[id(left_node)].ty
+    right_ty = type_map[id(right_node)].ty
+
+    if left_ty == "u8" and right_ty == "u8":
+        # Both operands statically known — no feedback slot needed
+        emit(opcode_for(op), [r])           # 2-byte instruction
+    else:
+        # At least one operand unknown — emit with feedback slot
+        slot = allocate_slot()
+        emit(opcode_for(op), [r, slot])     # 3-byte instruction
+```
+
+The function-level `FunctionTypeStatus` determines `CodeObject.immediate_jit_eligible`:
+
+```python
+code.type_status = result.env.function_status[fn.name]
+code.immediate_jit_eligible = (code.type_status == FunctionTypeStatus.FULLY_TYPED)
+```
+
+---
+
+## Python Package
+
+The type checker lives in `code/packages/python/tetrad-type-checker/`.
+
+Depends on `coding-adventures-tetrad-parser`.
+
+### Public API
+
+```python
+from tetrad_type_checker import check, TypeCheckResult, TypeError, TypeWarning
+from tetrad_type_checker.types import TypeInfo, FunctionTypeStatus, TypeEnvironment
+
+# Type-check a parsed program.
+# Never raises — errors are returned in TypeCheckResult.errors.
+def check(program: Program) -> TypeCheckResult: ...
+
+# Convenience: lex + parse + type-check in one call.
+def check_source(source: str) -> TypeCheckResult: ...
+```
+
+---
+
+## Test Strategy
+
+### Type inference tests
+
+- `fn f(a: u8, b: u8) -> u8 { return a + b; }` → all nodes inferred `u8`
+- `fn g(a, b) { return a + b; }` → binary op inferred `Unknown`
+- `fn h(a: u8, b) { return a + b; }` → binary op inferred `Unknown` (one unknown operand)
+- `let x = 42;` → `x` type is `u8`
+- `let x = in();` → `x` type is `Unknown`
+
+### Function status tests
+
+- All params + return typed, all body ops u8 → `FULLY_TYPED`
+- No annotations → `UNTYPED`
+- Some annotations → `PARTIALLY_TYPED`
+- Typed function calling untyped function → `PARTIALLY_TYPED`
+
+### Error tests
+
+- `let x: u8 = in();` → `TypeError` (assigning Unknown to u8)
+- `fn f() -> u8 { return in(); }` → `TypeError`
+- `let x: foo = 1;` → `TypeError` (unknown type name)
+
+### Warning tests
+
+- Unannotated function → warning about JIT warmup
+- Typed function calling untyped → warning about downgrade
+
+### End-to-end tests
+
+- Compile and execute: fully-typed `add` → `CodeObject.immediate_jit_eligible == True`
+- Compile and execute: untyped `multiply` → `CodeObject.immediate_jit_eligible == False`
+- Mixed program: typed and untyped functions coexist correctly
+
+### Coverage target
+
+95%+ line coverage.
+
+---
+
+## Version History
+
+| Version | Date | Description |
+|---|---|---|
+| 0.1.0 | 2026-04-20 | Initial specification |

--- a/code/specs/TET03-tetrad-bytecode.md
+++ b/code/specs/TET03-tetrad-bytecode.md
@@ -172,6 +172,8 @@ The Python VM mocks these with stdin/stdout.
 A `CodeObject` is the compiled form of one function or the top-level program.
 
 ```python
+from tetrad_type_checker.types import FunctionTypeStatus
+
 @dataclass
 class CodeObject:
     name: str                       # function name or "<main>"
@@ -182,10 +184,16 @@ class CodeObject:
     functions: list[CodeObject]     # nested function pool (callee CodeObjects)
     register_count: int             # how many registers this function needs (0–8)
     feedback_slot_count: int        # size of feedback vector to allocate at call time
+                                    # 0 for FULLY_TYPED functions (no slots emitted)
+    type_status: FunctionTypeStatus # FULLY_TYPED | PARTIALLY_TYPED | UNTYPED
+    immediate_jit_eligible: bool    # True iff type_status == FULLY_TYPED
     source_map: list[tuple[int,int,int]]
     # source_map[i] = (instruction_offset, line, column)
     # maps bytecode offsets back to source positions for error messages
 ```
+
+`immediate_jit_eligible` is a convenience flag derived from `type_status`. The VM and
+JIT read this flag rather than re-checking the type status on every call.
 
 ### Instruction Format
 
@@ -210,6 +218,48 @@ uses the index. The names are kept in the CodeObject for debuggers and error mes
 Top-level functions go into the main program's `functions` list.
 
 ---
+
+## Two-Path Compilation (Typed vs Untyped)
+
+The compiler receives a `TypeCheckResult` alongside the AST. For each binary operation,
+it consults the type map to decide which instruction format to emit:
+
+```
+Op with both operands known u8 (from type map):
+  → emit 2-byte instruction (opcode + register, NO slot)
+  → feedback_slot_count unchanged
+
+Op with at least one Unknown operand:
+  → emit 3-byte instruction (opcode + register + slot index)
+  → feedback_slot_count++
+```
+
+This is the **core payoff of the type checker**. A fully-typed function emits no slot
+bytes anywhere in its body. On the 4004, this saves ROM and eliminates the feedback
+vector RAM allocation entirely.
+
+A FULLY_TYPED function also has `immediate_jit_eligible = True`, which the VM uses to
+queue it for JIT compilation before it even runs once.
+
+```python
+def emit_binary_op(op: int, r: int, left_node: Expr, right_node: Expr,
+                   type_map: dict, state: CompilerState):
+    left_ty  = type_map.get(id(left_node), TypeInfo("Unknown")).ty
+    right_ty = type_map.get(id(right_node), TypeInfo("Unknown")).ty
+    if left_ty == "u8" and right_ty == "u8":
+        # Statically typed — no feedback slot
+        state.code.instructions.append(Instruction(op, [r]))
+    else:
+        # Dynamic — allocate and emit slot
+        slot = state.next_slot
+        state.next_slot += 1
+        state.code.instructions.append(Instruction(op | 0x80, [r, slot]))
+        # (The high bit convention differentiates slotted from non-slotted variants;
+        #  the VM dispatch loop checks this bit to decide whether to record feedback)
+```
+
+Note: the instruction set (section above) lists both variants explicitly. The compiler
+always emits the correct variant; no runtime switch is needed.
 
 ## Compiler Algorithm
 
@@ -524,15 +574,16 @@ Depends on `coding-adventures-tetrad-lexer` and `coding-adventures-tetrad-parser
 ### Public API
 
 ```python
-from tetrad_compiler import compile_program, CompilerError
+from tetrad_compiler import compile_program, compile_checked, CompilerError
 from tetrad_compiler.bytecode import CodeObject, Instruction
 
-# Compile a Tetrad source string to a CodeObject.
-# Raises LexError, ParseError, or CompilerError on failure.
+# Lex + parse + type-check + compile in one call.
+# Raises LexError, ParseError, TypeError, or CompilerError on failure.
 def compile_program(source: str) -> CodeObject: ...
 
-# Compile an already-parsed AST.
-def compile_ast(program: Program) -> CodeObject: ...
+# Compile from a pre-built TypeCheckResult (preferred — avoids re-running the checker).
+# Raises CompilerError if TypeCheckResult.errors is non-empty.
+def compile_checked(result: TypeCheckResult) -> CodeObject: ...
 
 class CompilerError(Exception):
     def __init__(self, message: str, line: int, column: int): ...

--- a/code/specs/TET03-tetrad-bytecode.md
+++ b/code/specs/TET03-tetrad-bytecode.md
@@ -1,0 +1,589 @@
+# TET03 — Tetrad Bytecode Compiler Specification
+
+## Overview
+
+The Tetrad bytecode compiler walks the AST produced by the parser (spec TET02) and
+emits a register-based bytecode program. The output is a `CodeObject` — a self-contained
+bundle of instructions, constants, and metadata needed to execute one function or the
+top-level program.
+
+The bytecode format follows the V8 Ignition model: an **accumulator** register (implicit,
+always implied) plus 8 named general-purpose registers R0–R7. Most instructions read
+from or write to the accumulator; the named register operand specifies the second operand.
+This keeps instruction encoding small, which matters for fitting within 4 KB of 4004 ROM.
+
+Every instruction that performs a binary operation or function call carries a **feedback
+slot index**. The VM (spec TET04) writes type observations into these slots at runtime.
+The JIT (spec TET05) reads them to decide what native code to emit.
+
+---
+
+## Instruction Set
+
+### Encoding Overview
+
+Instructions are variably-sized. Each instruction starts with a 1-byte opcode. The
+number of operand bytes depends on the opcode:
+
+```
+Format 0: opcode (1 byte)             — no operands
+Format 1: opcode reg (2 bytes)        — one register operand
+Format 2: opcode imm8 (2 bytes)       — one 8-bit immediate
+Format 3: opcode reg slot (3 bytes)   — register + feedback slot
+Format 4: opcode idx (2 bytes)        — one pool index (constant / name / function)
+Format 5: opcode offset (3 bytes)     — signed 16-bit jump offset
+Format 6: opcode func argc (3 bytes)  — function index + argument count
+```
+
+Register operands are a 1-byte index (0–7 for R0–R7). Feedback slot operands are a
+1-byte index into the function's feedback vector.
+
+### 0x00–0x0F — Accumulator Loads
+
+| Opcode | Mnemonic | Format | Effect |
+|---|---|---|---|
+| 0x00 | `LDA_IMM imm8` | 2 | `acc = imm8` |
+| 0x01 | `LDA_ZERO` | 0 | `acc = 0` (common fast path) |
+| 0x02 | `LDA_REG r` | 1 | `acc = R[r]` |
+| 0x03 | `LDA_VAR idx` | 4 | `acc = vars[idx]` |
+
+`LDA_ZERO` is an optimization for the extremely common `let x = 0` pattern. On the 4004,
+loading 0 has a dedicated path (CLB instruction) that saves one byte.
+
+### 0x10–0x1F — Accumulator Stores
+
+| Opcode | Mnemonic | Format | Effect |
+|---|---|---|---|
+| 0x10 | `STA_REG r` | 1 | `R[r] = acc` |
+| 0x11 | `STA_VAR idx` | 4 | `vars[idx] = acc` |
+
+### 0x20–0x2F — Arithmetic (binary, acc ← acc OP R[r])
+
+All arithmetic ops update the accumulator and record operand types in the feedback slot.
+
+| Opcode | Mnemonic | Format | Effect |
+|---|---|---|---|
+| 0x20 | `ADD r, slot` | 3 | `acc = (acc + R[r]) % 256` |
+| 0x21 | `SUB r, slot` | 3 | `acc = (acc - R[r]) % 256` |
+| 0x22 | `MUL r, slot` | 3 | `acc = (acc * R[r]) % 256` |
+| 0x23 | `DIV r, slot` | 3 | `acc = acc / R[r]` (halt if R[r]==0) |
+| 0x24 | `MOD r, slot` | 3 | `acc = acc % R[r]` (halt if R[r]==0) |
+| 0x25 | `ADD_IMM imm8, slot` | 3 | `acc = (acc + imm8) % 256` (common fast path) |
+| 0x26 | `SUB_IMM imm8, slot` | 3 | `acc = (acc - imm8) % 256` (common fast path) |
+
+`ADD_IMM` / `SUB_IMM` avoid a register allocation for the common `n = n + 1` and
+`n = n - 1` patterns. The compiler emits these when the right-hand operand is a literal.
+
+### 0x30–0x3F — Bitwise Operations
+
+| Opcode | Mnemonic | Format | Effect |
+|---|---|---|---|
+| 0x30 | `AND r` | 1 | `acc = acc & R[r]` |
+| 0x31 | `OR r` | 1 | `acc = acc \| R[r]` |
+| 0x32 | `XOR r` | 1 | `acc = acc ^ R[r]` |
+| 0x33 | `NOT` | 0 | `acc = (~acc) & 0xFF` |
+| 0x34 | `SHL r` | 1 | `acc = (acc << R[r]) & 0xFF` |
+| 0x35 | `SHR r` | 1 | `acc = acc >> R[r]` (logical, zero fill) |
+| 0x36 | `AND_IMM imm8` | 2 | `acc = acc & imm8` (common: masking nibbles) |
+
+Bitwise operations do not take a feedback slot because the operand types are always u8
+in Tetrad v1. When a Lisp front-end introduces dynamic types, it will use a different
+opcode range.
+
+### 0x40–0x4F — Comparisons (result: 1 if true, 0 if false)
+
+| Opcode | Mnemonic | Format | Effect |
+|---|---|---|---|
+| 0x40 | `EQ r, slot` | 3 | `acc = 1 if acc == R[r] else 0` |
+| 0x41 | `NEQ r, slot` | 3 | `acc = 1 if acc != R[r] else 0` |
+| 0x42 | `LT r, slot` | 3 | `acc = 1 if acc < R[r] else 0` |
+| 0x43 | `LTE r, slot` | 3 | `acc = 1 if acc <= R[r] else 0` |
+| 0x44 | `GT r, slot` | 3 | `acc = 1 if acc > R[r] else 0` |
+| 0x45 | `GTE r, slot` | 3 | `acc = 1 if acc >= R[r] else 0` |
+
+Comparisons carry feedback slots because they are the primary polymorphic dispatch points
+in a Lisp front-end (`equal?`, `<`, `>` dispatch on cons, number, symbol, etc.).
+
+### 0x50–0x5F — Logical Operations
+
+| Opcode | Mnemonic | Format | Effect |
+|---|---|---|---|
+| 0x50 | `LOGICAL_NOT` | 0 | `acc = 0 if acc != 0 else 1` |
+| 0x51 | `LOGICAL_AND r` | 1 | `acc = 0 if acc == 0 else (1 if R[r] != 0 else 0)` |
+| 0x52 | `LOGICAL_OR r` | 1 | `acc = 1 if acc != 0 else (1 if R[r] != 0 else 0)` |
+
+Note: The compiler implements short-circuit `&&` and `||` using jumps (JZ/JNZ), not
+these instructions. `LOGICAL_AND` / `LOGICAL_OR` are available for cases where both
+sides are already in registers without branching.
+
+### 0x60–0x6F — Control Flow
+
+| Opcode | Mnemonic | Format | Effect |
+|---|---|---|---|
+| 0x60 | `JMP offset` | 5 | `ip += offset` (signed 16-bit relative) |
+| 0x61 | `JZ offset` | 5 | `if acc == 0: ip += offset` |
+| 0x62 | `JNZ offset` | 5 | `if acc != 0: ip += offset` |
+| 0x63 | `JMP_LOOP offset` | 5 | backward jump (separate opcode for JIT loop detection) |
+
+`JMP_LOOP` is functionally identical to `JMP` but uses a distinct opcode so the VM can
+cheaply detect loop back-edges and increment the loop iteration counter for the hot-loop
+detector (spec TET04).
+
+Jump offsets are signed 16-bit values relative to the instruction following the jump.
+An offset of 0 means "jump to the instruction immediately after this one" (no-op jump).
+
+### 0x70–0x7F — Function Calls
+
+| Opcode | Mnemonic | Format | Effect |
+|---|---|---|---|
+| 0x70 | `CALL func_idx, argc, slot` | — | Push frame, jump to function |
+| 0x71 | `RET` | 0 | Pop frame; return acc to caller |
+
+`CALL` has a 4-byte encoding: opcode (1) + function pool index (1) + argument count
+(1) + feedback slot (1). The function pool index refers to an entry in the `CodeObject`'s
+`functions` array.
+
+The feedback slot for `CALL` records the call site shape:
+- `:monomorphic` — always calls the same function
+- `:polymorphic` — calls 2–4 different functions
+- `:megamorphic` — calls 5+ different functions (JIT gives up inlining)
+
+### 0x80–0x8F — I/O
+
+| Opcode | Mnemonic | Format | Effect |
+|---|---|---|---|
+| 0x80 | `IO_IN` | 0 | `acc = read_io_port()` |
+| 0x81 | `IO_OUT` | 0 | `write_io_port(acc)` |
+
+On a real 4004, `IO_IN` maps to the WRM/RDM instruction sequence that reads from a RAM
+data port. `IO_OUT` maps to the WMP instruction that writes to output port latches.
+The Python VM mocks these with stdin/stdout.
+
+### 0xFF — VM Control
+
+| Opcode | Mnemonic | Format | Effect |
+|---|---|---|---|
+| 0xFF | `HALT` | 0 | Stop execution |
+
+---
+
+## CodeObject Format
+
+A `CodeObject` is the compiled form of one function or the top-level program.
+
+```python
+@dataclass
+class CodeObject:
+    name: str                       # function name or "<main>"
+    params: list[str]               # parameter names (for debug/error messages)
+    instructions: list[Instruction] # the bytecode
+    constants: list[int]            # constant pool: u8 values
+    var_names: list[str]            # variable name pool
+    functions: list[CodeObject]     # nested function pool (callee CodeObjects)
+    register_count: int             # how many registers this function needs (0–8)
+    feedback_slot_count: int        # size of feedback vector to allocate at call time
+    source_map: list[tuple[int,int,int]]
+    # source_map[i] = (instruction_offset, line, column)
+    # maps bytecode offsets back to source positions for error messages
+```
+
+### Instruction Format
+
+```python
+@dataclass
+class Instruction:
+    opcode: int               # 0x00–0xFF
+    operands: list[int]       # 0, 1, 2, or 3 operand bytes depending on opcode
+```
+
+### Why Separate Pools?
+
+**constants** holds u8 integer literals. `LDA_IMM` can embed values 0–255 directly in
+the instruction stream (one byte operand), so the constant pool is only needed for
+values that appear multiple times and benefit from pool deduplication.
+
+**var_names** holds the string names of variables. On the 4004, names are never stored
+at runtime (too much RAM); the compiler assigns each name a numeric index and the VM
+uses the index. The names are kept in the CodeObject for debuggers and error messages.
+
+**functions** holds nested CodeObjects. `CALL func_idx` uses the index into this array.
+Top-level functions go into the main program's `functions` list.
+
+---
+
+## Compiler Algorithm
+
+The compiler maintains a `CompilerState` per function:
+
+```python
+@dataclass
+class CompilerState:
+    code: CodeObject              # being built
+    locals: dict[str, int]        # name → var_names index for this scope
+    next_register: int            # which register to allocate next (0–7)
+    free_registers: list[int]     # registers available for reuse
+    loop_starts: list[int]        # instruction offsets of enclosing while loop starts
+    loop_end_patches: list[list[int]]  # lists of JMP offsets to patch on loop exit
+```
+
+### Expression Compilation
+
+Expressions compile to a sequence of instructions that leaves the result in `acc`.
+The key helper is `compile_expr(node) -> None`.
+
+#### Integer Literal
+
+```
+node: IntLiteral(value=N)
+→ emit LDA_IMM N          (or LDA_ZERO if N == 0)
+```
+
+#### Name Expression
+
+Names can be in local variables or (for globals) in a global variable pool. The compiler
+looks up the name in `locals` first, then in the global scope.
+
+```
+node: NameExpr(name='x')
+→ emit LDA_VAR idx       where idx = var_names.index('x')
+```
+
+#### Binary Expression
+
+```
+node: BinaryExpr(op='+', left=L, right=R)
+
+1. compile_expr(L)        → result in acc
+2. emit STA_REG r         where r = allocate_register()
+3. compile_expr(R)        → result in acc
+   (right side is now in acc; left side in R[r])
+4. swap acc and R[r]:
+   emit STA_REG tmp_r     save right to tmp
+   emit LDA_REG r         load left into acc
+   emit ADD tmp_r, slot   acc = left + right
+5. free_register(r)
+6. free_register(tmp_r)
+```
+
+Wait — the accumulator already has R's value. The convention is:
+**acc holds the left operand, R[r] holds the right operand** at the point of the binary
+instruction. So the sequence is:
+
+```
+1. compile_expr(L)        → acc = left
+2. emit STA_REG r_left    → R[r_left] = acc (save left)
+3. compile_expr(R)        → acc = right
+4. emit STA_REG r_right   → R[r_right] = acc (save right)
+5. emit LDA_REG r_left    → acc = left
+6. emit ADD r_right, slot → acc = left + right
+7. free r_left, r_right
+```
+
+The compiler simplifies this when the right side is an integer literal:
+```
+1. compile_expr(L)        → acc = left
+2. emit ADD_IMM N, slot   → acc = left + N
+```
+
+#### Short-Circuit Binary (&&, ||)
+
+Short-circuit operators compile using conditional jumps, not the LOGICAL_AND/LOGICAL_OR
+instructions:
+
+```
+a && b:
+  compile_expr(a)       → acc = a
+  JZ  (to false_label)  → if a is 0, skip b
+  compile_expr(b)       → acc = b (result is b's truthiness)
+  JMP (to end_label)
+false_label:
+  LDA_IMM 0             → acc = 0
+end_label:
+```
+
+```
+a || b:
+  compile_expr(a)       → acc = a
+  JNZ (to true_label)   → if a is non-zero, skip b
+  compile_expr(b)       → acc = b
+  JMP (to end_label)
+true_label:
+  LDA_IMM 1             → acc = 1
+end_label:
+```
+
+#### Unary Expression
+
+```
+~x:
+  compile_expr(x)       → acc = x
+  emit NOT              → acc = ~acc & 0xFF
+
+!x:
+  compile_expr(x)       → acc = x
+  emit LOGICAL_NOT      → acc = (acc==0 ? 1 : 0)
+
+-x:
+  compile_expr(x)       → acc = x
+  emit STA_REG r
+  emit LDA_ZERO
+  emit SUB r, slot      → acc = 0 - x (wrapping negation)
+```
+
+#### Call Expression
+
+```
+f(arg1, arg2):
+  compile_expr(arg1)    → acc = arg1
+  STA_REG r0
+  compile_expr(arg2)    → acc = arg2
+  STA_REG r1
+  CALL func_idx, 2, slot
+  (result is in acc after return)
+```
+
+Arguments are evaluated left-to-right and placed in registers R0..R(argc-1). The
+callee reads its parameters from those same registers.
+
+#### in() and out(expr)
+
+```
+in():
+  emit IO_IN
+
+out(expr):
+  compile_expr(expr)
+  emit IO_OUT
+```
+
+### Statement Compilation
+
+#### Let Statement
+
+```
+let x = expr;
+→ compile_expr(expr)
+→ idx = add_var_name('x')
+→ emit STA_VAR idx
+```
+
+#### Assign Statement
+
+```
+x = expr;
+→ compile_expr(expr)
+→ idx = var_names.index('x')  (must already exist)
+→ emit STA_VAR idx
+```
+
+#### If Statement
+
+```
+if cond { then } else { else }
+
+→ compile_expr(cond)
+→ emit JZ  (patch_1: offset unknown)
+→ compile_block(then)
+→ emit JMP (patch_2: offset unknown)
+→ patch_1 to here
+→ compile_block(else_block)  (or nothing if no else)
+→ patch_2 to here
+```
+
+#### While Statement
+
+```
+while cond { body }
+
+loop_start:
+→ compile_expr(cond)
+→ emit JZ  (patch_exit: offset unknown)
+→ compile_block(body)
+→ emit JMP_LOOP (back to loop_start)
+→ patch_exit to here
+```
+
+`JMP_LOOP` is used for the backward jump so the VM can count loop iterations.
+
+#### Return Statement
+
+```
+return expr;
+→ compile_expr(expr)
+→ emit RET
+
+return;
+→ emit LDA_ZERO
+→ emit RET
+```
+
+### Jump Patching
+
+Forward jumps use a two-pass approach:
+
+```
+1. emit_jump(opcode) → returns instruction index
+2. ... compile intervening code ...
+3. patch_jump(index) → fills in the offset from step 1 to current position
+```
+
+The offset is relative to the instruction following the jump (standard convention).
+
+---
+
+## Register Allocation
+
+Tetrad uses a simple linear allocator. Each function gets registers R0–R7. The
+compiler tracks which registers are in use and allocates the next free one. Registers
+are freed when their holding value is no longer needed.
+
+```python
+def allocate_register() -> int:
+    if free_registers:
+        return free_registers.pop()
+    r = next_register
+    next_register += 1
+    if next_register > 7:
+        raise CompilerError("register spill: expression too complex (max 8 registers)")
+    return r
+
+def free_register(r: int):
+    free_registers.append(r)
+```
+
+Register spill (needing more than 8 registers) is a `CompilerError`. In practice,
+Tetrad's expression grammar cannot produce more than 8 live values simultaneously,
+but deeply nested calls could hit this limit. If so, the user must split the expression.
+
+---
+
+## Feedback Slot Assignment
+
+The compiler assigns feedback slot indices at emit time. A counter `next_slot` starts
+at 0 for each function and increments each time an instruction needs a slot:
+
+```python
+def emit_binary_op(opcode: int, r: int) -> int:
+    slot = next_slot
+    next_slot += 1
+    emit(opcode, [r, slot])
+    return slot
+```
+
+The total `next_slot` value at the end of compilation is stored as
+`feedback_slot_count` in the `CodeObject`. The VM allocates a vector of that size at
+function call time.
+
+---
+
+## Compile-Time Checks
+
+The compiler rejects:
+
+| Condition | Error |
+|---|---|
+| Integer literal > 255 | `integer literal N out of u8 range (0–255)` |
+| Hex literal > 0xFF | `hex literal 0xN out of u8 range` |
+| Reference to undeclared variable | `undefined variable 'name'` |
+| Call to undeclared function | `undefined function 'name'` |
+| Call with wrong number of arguments | `'name' expects M args, got N` |
+| Register spill | `expression too complex: exceeds 8 virtual registers` |
+| `return` outside function | `'return' outside function` |
+
+---
+
+## CodeObject Binary Serialization (optional, for 4004 ROM)
+
+When targeting the physical 4004, the CodeObject is serialized to bytes for embedding
+in the ROM image alongside the interpreter. The serialization format is:
+
+```
+[1 byte]  function_count (number of functions including main)
+For each function:
+  [1 byte]  param_count
+  [1 byte]  register_count
+  [1 byte]  feedback_slot_count
+  [2 bytes] instruction_count (little-endian)
+  [N bytes] instructions (raw bytes, variable length)
+  [1 byte]  var_count
+  [1 byte]  const_count
+  [M bytes] constants (each 1 byte, u8)
+```
+
+Variable names are not serialized for the ROM image (no RAM to store strings). The
+var_names list is used only in the Python VM for debugging.
+
+---
+
+## Python Package
+
+The compiler lives in `code/packages/python/tetrad-compiler/`.
+
+Depends on `coding-adventures-tetrad-lexer` and `coding-adventures-tetrad-parser`.
+
+### Public API
+
+```python
+from tetrad_compiler import compile_program, CompilerError
+from tetrad_compiler.bytecode import CodeObject, Instruction
+
+# Compile a Tetrad source string to a CodeObject.
+# Raises LexError, ParseError, or CompilerError on failure.
+def compile_program(source: str) -> CodeObject: ...
+
+# Compile an already-parsed AST.
+def compile_ast(program: Program) -> CodeObject: ...
+
+class CompilerError(Exception):
+    def __init__(self, message: str, line: int, column: int): ...
+```
+
+---
+
+## Test Strategy
+
+### Instruction emission tests
+
+- `let x = 0;` → `[LDA_ZERO, STA_VAR 0, HALT]`
+- `let x = 42;` → `[LDA_IMM 42, STA_VAR 0, HALT]`
+- `x = x + 1;` → involves `LDA_VAR`, `ADD_IMM 1`, `STA_VAR`
+- `a + b * c` → multiply compiled before add (precedence from parser)
+
+### Feedback slot tests
+
+- `a + b` → emitted `ADD` carries slot 0
+- Two binary ops → slots 0 and 1 respectively
+- `feedback_slot_count` equals number of slotted instructions
+
+### Control flow tests
+
+- `if cond { body }` → verify `JZ` target skips body
+- `if cond { a } else { b }` → verify `JZ` + `JMP` structure
+- `while cond { body }` → verify backward `JMP_LOOP` and forward `JZ`
+
+### Call tests
+
+- `fn add(a, b) { return a + b; }` compiles to a CodeObject with 2 params
+- `add(1, 2)` emits `LDA_IMM 1, STA_REG 0, LDA_IMM 2, STA_REG 1, CALL 0 2 slot`
+
+### Error tests
+
+- `let x = 300;` → `CompilerError` (overflow)
+- `let y = x + 1;` where `x` undeclared → `CompilerError`
+- `f(1, 2, 3)` where `f` declared with 2 params → `CompilerError`
+
+### End-to-end tests
+
+Compile + execute all five TET00 example programs and verify output matches expected.
+
+### Coverage target
+
+95%+ line coverage.
+
+---
+
+## Version History
+
+| Version | Date | Description |
+|---|---|---|
+| 0.1.0 | 2026-04-20 | Initial specification |

--- a/code/specs/TET04-tetrad-vm.md
+++ b/code/specs/TET04-tetrad-vm.md
@@ -69,8 +69,12 @@ uses software RAM to emulate the stack, giving 4 total levels.
 
 ## Feedback Vector
 
-Each `CallFrame` allocates a feedback vector of `code.feedback_slot_count` slots,
-initialized to `:uninitialized`.
+For **FULLY_TYPED** functions (`code.feedback_slot_count == 0`), no feedback vector is
+allocated. The call frame's `feedback_vector` field is set to an empty list `[]` and
+the VM never writes to it. This saves both RAM and one Python list allocation per call.
+
+For all other functions, each `CallFrame` allocates a feedback vector of
+`code.feedback_slot_count` slots, initialized to `:uninitialized`.
 
 ```python
 class SlotKind(enum.Enum):
@@ -108,6 +112,26 @@ megamorphic   → megamorphic    (stays megamorphic forever)
 Once megamorphic, the slot is never downgraded. This matches V8's behavior.
 
 ---
+
+## Pre-execution: Immediate JIT Queue Population
+
+Before the dispatch loop begins, the VM walks all top-level function `CodeObject`s and
+populates the `immediate_jit_queue` with any that have `immediate_jit_eligible = True`:
+
+```python
+def execute(self, code: CodeObject) -> int:
+    # Populate the immediate JIT queue before first instruction
+    for fn in code.functions:
+        if fn.immediate_jit_eligible:
+            self.metrics.immediate_jit_queue.append(fn.name)
+    # The JIT (if attached) drains this queue and compiles before the loop starts.
+    # The interpreter proceeds regardless — compiled code is used on first call.
+    ...
+```
+
+When the JIT is attached (via `TetradJIT.execute_with_jit`), it drains this queue and
+compiles each FULLY_TYPED function **before the first instruction of main executes**.
+This guarantees zero-warmup for typed functions: the very first call goes to native code.
 
 ## Dispatch Loop
 
@@ -223,6 +247,11 @@ class VMMetrics:
 
     # Total instructions executed
     total_instructions: int
+
+    # Functions queued for immediate JIT compilation (FULLY_TYPED functions).
+    # The JIT reads this queue and compiles these before they are first called.
+    # This is the mechanism by which typed functions skip warmup entirely.
+    immediate_jit_queue: list[str]   # function names, in declaration order
 
 @dataclass
 class BranchStats:

--- a/code/specs/TET04-tetrad-vm.md
+++ b/code/specs/TET04-tetrad-vm.md
@@ -1,0 +1,453 @@
+# TET04 — Tetrad Register VM Specification
+
+## Overview
+
+The Tetrad VM executes `CodeObject`s produced by the bytecode compiler (spec TET03).
+It is a **register-based virtual machine** with an accumulator (following the V8 Ignition
+model), an 8-register file, a software-managed call stack, and a built-in **metrics
+layer** that records runtime observations into feedback vectors.
+
+The metrics layer is the key contribution of this VM. Current Lisp implementations lack
+a VM that cleanly exposes type feedback, branch statistics, and call-site shape in an
+API that an external JIT can consume. The Tetrad VM provides this API from day one,
+so the JIT compiler (spec TET05) — and any future Lisp front-end — can consume it
+without modifying the interpreter core.
+
+---
+
+## Execution Model
+
+```
+CodeObject
+    │
+    ▼
+┌──────────────────────────────────────────────────────┐
+│                    VM State                          │
+│                                                      │
+│  acc           (current accumulator value: u8)       │
+│  registers[8]  (R0–R7, each u8)                      │
+│  ip            (instruction pointer: int)            │
+│  call_stack    (list[CallFrame], max depth 4)        │
+│  globals       (dict[str, u8])                       │
+│  feedback_vectors  (dict[fn_name, list[SlotState]])  │
+│  metrics       (VMMetrics, see below)                │
+└──────────────────────────────────────────────────────┘
+```
+
+The VM is single-threaded. There is no concurrency model in v1.
+
+---
+
+## Call Frame
+
+Each function call pushes a `CallFrame`. When the function returns, the frame is popped
+and the accumulator value is passed back to the caller.
+
+```python
+@dataclass
+class CallFrame:
+    code: CodeObject               # function being executed
+    ip: int                        # instruction pointer within this frame
+    acc: int                       # accumulator value (u8, 0–255)
+    registers: list[int]           # R0–R7 snapshot for this activation (8 ints)
+    feedback_vector: list[SlotState]  # per-call feedback vector
+    locals: dict[str, int]         # local variables (name → u8 value)
+    caller_frame: CallFrame | None # back-pointer to caller
+```
+
+The `registers` array is per-frame, so callee functions cannot accidentally clobber the
+caller's registers. On return, the caller's registers are restored from the saved frame.
+
+The software call stack allows a maximum of 4 active frames (1 main + 3 nested calls).
+This limit is enforced at runtime. Attempting a 5th level raises `VMError`.
+
+This maps directly to the 4004 hardware model: the 4004's 3-level hardware call stack
+supports at most 3 nested JMS instructions. The Tetrad VM adds one level for "main" and
+uses software RAM to emulate the stack, giving 4 total levels.
+
+---
+
+## Feedback Vector
+
+Each `CallFrame` allocates a feedback vector of `code.feedback_slot_count` slots,
+initialized to `:uninitialized`.
+
+```python
+class SlotKind(enum.Enum):
+    UNINITIALIZED = "uninitialized"
+    MONOMORPHIC   = "monomorphic"
+    POLYMORPHIC   = "polymorphic"
+    MEGAMORPHIC   = "megamorphic"
+
+@dataclass
+class SlotState:
+    kind: SlotKind
+    observations: list[str]  # type strings seen, e.g. ["u8"] or ["u8", "pair", "symbol"]
+    count: int                # how many times this slot has been reached
+```
+
+For Tetrad v1, all values are `u8`, so every binary op slot stays `:monomorphic` with
+`observations=["u8"]`. This data is still written — so the JIT can verify that it
+reads the feedback correctly — it just never sees a polymorphic slot.
+
+When a Lisp front-end is added, the slot for `(+ x y)` might see `["u8", "pair"]`
+(if `+` is called with both numbers and pairs in the same loop), triggering the
+polymorphic path and inhibiting the fast JIT specialization.
+
+### Feedback Update Rules
+
+```
+uninitialized → monomorphic    (first observation, any type)
+monomorphic   → monomorphic    (same type observed again)
+monomorphic   → polymorphic    (new type seen; 2–4 types)
+polymorphic   → polymorphic    (additional type, up to 4)
+polymorphic   → megamorphic    (5th distinct type seen)
+megamorphic   → megamorphic    (stays megamorphic forever)
+```
+
+Once megamorphic, the slot is never downgraded. This matches V8's behavior.
+
+---
+
+## Dispatch Loop
+
+The VM's inner loop is a fetch-decode-execute cycle:
+
+```python
+def run(frame: CallFrame) -> int:
+    while True:
+        instr = frame.code.instructions[frame.ip]
+        opcode = instr.opcode
+        frame.ip += 1
+
+        # --- Accumulator loads ---
+        if opcode == 0x00:   # LDA_IMM
+            frame.acc = instr.operands[0]
+
+        elif opcode == 0x01: # LDA_ZERO
+            frame.acc = 0
+
+        elif opcode == 0x02: # LDA_REG
+            frame.acc = frame.registers[instr.operands[0]]
+
+        elif opcode == 0x03: # LDA_VAR
+            idx = instr.operands[0]
+            name = frame.code.var_names[idx]
+            frame.acc = frame.locals.get(name, globals.get(name, 0))
+
+        # --- Stores ---
+        elif opcode == 0x10: # STA_REG
+            frame.registers[instr.operands[0]] = frame.acc
+
+        elif opcode == 0x11: # STA_VAR
+            idx = instr.operands[0]
+            name = frame.code.var_names[idx]
+            if name in frame.locals:
+                frame.locals[name] = frame.acc
+            else:
+                globals[name] = frame.acc
+
+        # --- Arithmetic ---
+        elif opcode == 0x20: # ADD r, slot
+            r, slot = instr.operands
+            result = (frame.acc + frame.registers[r]) % 256
+            record_binary_op(frame, slot, "u8", "u8")
+            metrics.record_instruction(0x20)
+            frame.acc = result
+
+        # ... (all other opcodes follow same pattern)
+
+        # --- Control flow ---
+        elif opcode == 0x60: # JMP
+            offset = signed16(instr.operands[0], instr.operands[1])
+            frame.ip += offset
+
+        elif opcode == 0x61: # JZ
+            offset = signed16(instr.operands[0], instr.operands[1])
+            slot_idx = instr.operands[2] if len(instr.operands) > 2 else None
+            taken = (frame.acc == 0)
+            if slot_idx is not None:
+                record_branch(frame, slot_idx, taken)
+            if taken:
+                frame.ip += offset
+
+        elif opcode == 0x63: # JMP_LOOP (backward jump)
+            offset = signed16(instr.operands[0], instr.operands[1])
+            metrics.record_loop_back_edge(frame.code.name, frame.ip)
+            frame.ip += offset
+
+        # --- Calls ---
+        elif opcode == 0x70: # CALL
+            func_idx, argc, slot = instr.operands
+            callee = frame.code.functions[func_idx]
+            record_call_site(frame, slot, callee.name)
+            # ... push new frame, copy arg registers, run callee
+
+        elif opcode == 0x71: # RET
+            result = frame.acc
+            if frame.caller_frame is None:
+                return result   # top-level return → exit
+            caller = frame.caller_frame
+            caller.acc = result
+            frame = caller      # pop frame
+
+        # --- Halt ---
+        elif opcode == 0xFF:
+            return frame.acc
+```
+
+---
+
+## Metrics Layer
+
+The metrics layer is the distinguishing feature of the Tetrad VM. It is a first-class
+subsystem, not an afterthought. Every meaningful runtime event is recorded.
+
+### VMMetrics Structure
+
+```python
+@dataclass
+class VMMetrics:
+    # Per-instruction execution counts (opcode → count)
+    instruction_counts: dict[int, int]
+
+    # Per-function execution counts (function name → invocation count)
+    function_call_counts: dict[str, int]
+
+    # Per-loop back-edge counts (function name → list of (ip, count) pairs)
+    # ip is the position of the JMP_LOOP instruction
+    loop_back_edge_counts: dict[str, dict[int, int]]
+
+    # Per-branch statistics (function name → slot → BranchStats)
+    branch_stats: dict[str, dict[int, BranchStats]]
+
+    # Total instructions executed
+    total_instructions: int
+
+@dataclass
+class BranchStats:
+    taken_count: int
+    not_taken_count: int
+
+    @property
+    def taken_ratio(self) -> float:
+        total = self.taken_count + self.not_taken_count
+        return self.taken_count / total if total > 0 else 0.0
+```
+
+### Metrics API (for JIT and external consumers)
+
+```python
+class TetradVM:
+
+    # Execute a compiled CodeObject. Returns the final accumulator value.
+    def execute(self, code: CodeObject) -> int: ...
+
+    # Execute with full step-by-step trace (slow path, for debugging).
+    def execute_traced(self, code: CodeObject) -> tuple[int, list[VMTrace]]: ...
+
+    # Return hot functions: those called more than `threshold` times.
+    def hot_functions(self, threshold: int = 100) -> list[str]: ...
+
+    # Return the feedback vector for a named function after execution.
+    # Indexed by feedback slot. Returns None if function not yet called.
+    def feedback_vector(self, fn_name: str) -> list[SlotState] | None: ...
+
+    # Return the type profile for one feedback slot in one function.
+    # Returns the SlotState (kind + observations).
+    def type_profile(self, fn_name: str, slot: int) -> SlotState | None: ...
+
+    # Return branch statistics for one feedback slot (JZ/JNZ) in one function.
+    def branch_profile(self, fn_name: str, slot: int) -> BranchStats | None: ...
+
+    # Return loop iteration counts for all back-edges in a function.
+    # dict maps instruction offset of JMP_LOOP → iteration count.
+    def loop_iterations(self, fn_name: str) -> dict[int, int]: ...
+
+    # Return call site shape for a slot (monomorphic/polymorphic/megamorphic).
+    def call_site_shape(self, fn_name: str, slot: int) -> SlotKind: ...
+
+    # Return the raw VMMetrics object (for external analysis tools).
+    def metrics(self) -> VMMetrics: ...
+
+    # Reset all metrics (useful for benchmarking steady state).
+    def reset_metrics(self) -> None: ...
+```
+
+### Why These Metrics?
+
+Each metric directly informs a JIT optimization decision:
+
+| Metric | JIT decision it enables |
+|---|---|
+| `hot_functions` | Which functions to compile at all |
+| `type_profile` | Type specialization (emit integer-specific add instead of generic dispatch) |
+| `branch_profile` | Branch layout: put the hot path first, cold path last |
+| `loop_iterations` | Loop unrolling threshold; OSR (on-stack replacement) trigger |
+| `call_site_shape` | Inlining: monomorphic sites are safe to inline; megamorphic are not |
+
+### Lisp-specific metrics (future)
+
+When a Lisp front-end is added, the same API gains meaning that v1 doesn't exercise:
+
+- `type_profile` will return polymorphic slots for `(car x)` called on both pairs and
+  numbers — the JIT will generate a type guard + fast path.
+- `call_site_shape` will become megamorphic for `(apply fn args)` — the JIT skips
+  inlining and falls through to the dispatch table.
+- `branch_profile` will show `(null? x)` at 99% taken — the JIT inverts the branch
+  and makes the rare non-null case a deoptimization point.
+
+This is the design intent: the metrics API is stable and rich enough to support both
+the simple u8-typed Tetrad front-end and a future dynamically-typed Lisp front-end,
+without any change to the VM.
+
+---
+
+## Execution Trace (debug path)
+
+When `execute_traced` is called, the VM records a `VMTrace` for every instruction:
+
+```python
+@dataclass
+class VMTrace:
+    frame_depth: int           # call depth (0 = top level)
+    fn_name: str               # function being executed
+    ip: int                    # instruction pointer before this step
+    instruction: Instruction   # the instruction executed
+    acc_before: int            # accumulator value before
+    acc_after: int             # accumulator value after
+    registers_before: list[int]  # register file snapshot before
+    registers_after: list[int]   # register file snapshot after
+    feedback_delta: list[tuple[int, SlotState]]
+    # list of (slot_index, new_state) pairs changed by this instruction
+```
+
+The trace is expensive (one object per instruction) and is intended only for
+debuggers, unit tests, and the literate explanations in the spec.
+
+---
+
+## Error Handling
+
+The VM raises `VMError` for:
+
+| Condition | Message |
+|---|---|
+| Division by zero | `division by zero at fn 'name' ip N` |
+| Call stack overflow | `call stack overflow: max depth 4 exceeded` |
+| Unknown opcode | `unknown opcode 0xNN at fn 'name' ip N` |
+| Undefined variable | `undefined variable 'name' at fn 'fn_name' ip N` |
+| Undefined function | `undefined function index N at fn 'fn_name'` |
+| Wrong argument count | `'name' expects M args, got N` |
+
+---
+
+## RAM Budget on Intel 4004
+
+When the VM is implemented in 4004 assembly (the physical target), the VM state maps
+to the 4004's RAM as follows:
+
+```
+Address  Size  Content
+──────────────────────────────────────────────────────────
+0x00     1     Accumulator (current u8 value)
+0x01     8     Registers R0–R7 (one byte each)
+0x09     2     IP (instruction pointer, 12-bit in 2 bytes)
+0x0B     1     Current frame index (0–3)
+0x0C     32    Call stack (4 frames × 8 bytes):
+                 Frame N+0: return IP low byte
+                 Frame N+1: return IP high byte
+                 Frame N+2: saved register R0
+                 Frame N+3: variable pool base (frame offset)
+                 Frame N+4–7: reserved
+0x2C     84    Variable pool (84 × 1-byte u8 variables)
+──────────────────────────────────────────────────────────
+Total:   128 bytes  (exactly the 4004's usable general RAM)
+```
+
+The feedback vector and metrics are **not** stored in 4004 RAM — there is no room.
+They exist only in the Python VM running on a host. When running on physical 4004 silicon,
+the metrics API is simply absent (the interpreter runs without instrumentation).
+
+---
+
+## Python Package
+
+The VM lives in `code/packages/python/tetrad-vm/`.
+
+Depends on `coding-adventures-tetrad-compiler`.
+
+### Public API
+
+```python
+from tetrad_vm import TetradVM, VMError, VMTrace
+from tetrad_vm.metrics import VMMetrics, SlotState, SlotKind, BranchStats
+
+vm = TetradVM()
+result = vm.execute(code_object)       # fast path
+result, trace = vm.execute_traced(code_object)  # slow path with trace
+
+# Metrics inspection
+hot = vm.hot_functions(threshold=50)
+profile = vm.type_profile("multiply", slot=0)
+branches = vm.branch_profile("count_down", slot=0)
+loops = vm.loop_iterations("count_down")
+shape = vm.call_site_shape("main", slot=0)
+```
+
+---
+
+## Test Strategy
+
+### Opcode tests (unit)
+
+Test each opcode in isolation: construct a `CodeObject` with one or two instructions,
+execute, verify accumulator and register values.
+
+- `LDA_IMM 42` → acc == 42
+- `LDA_ZERO` → acc == 0
+- `STA_REG 3` → R[3] == acc
+- `ADD r=0, slot=0` with acc=10, R[0]=5 → acc == 15; slot 0 is monomorphic u8
+- `SUB r=0, slot=0` with acc=5, R[0]=10 → acc == 251 (wraps at 256)
+- `MUL r=0, slot=0` with acc=3, R[0]=4 → acc == 12
+- `DIV r=0, slot=0` with R[0]=0 → VMError (division by zero)
+- `AND r=0` with acc=0xFF, R[0]=0x0F → acc == 0x0F
+- `NOT` with acc=0x0F → acc == 0xF0
+- `JZ offset` with acc=0 → ip advances by offset
+- `JZ offset` with acc=5 → ip does not jump
+- `JMP_LOOP` → loop_back_edge count increments
+
+### Feedback vector tests
+
+- After `ADD r=0, slot=0`: `feedback_vector('f')[0].kind == MONOMORPHIC`
+- After same slot observes same type twice: kind stays MONOMORPHIC, count == 2
+
+### Metrics API tests
+
+- `hot_functions(100)` returns empty list after <100 calls
+- `hot_functions(100)` returns `['f']` after f called 101 times
+- `loop_iterations('count_down')` counts backward jumps
+- `branch_profile('count_down', slot=0)` tracks taken/not-taken correctly
+
+### Call stack tests
+
+- Nested call pushes new frame; registers are isolated between frames
+- Return transfers acc value to caller's acc
+- 5th call level raises `VMError` (stack overflow)
+
+### End-to-end tests
+
+Execute all five TET00 example programs, capture `IO_OUT` output, verify against
+expected output sequence.
+
+### Coverage target
+
+95%+ line coverage.
+
+---
+
+## Version History
+
+| Version | Date | Description |
+|---|---|---|
+| 0.1.0 | 2026-04-20 | Initial specification |

--- a/code/specs/TET05-tetrad-jit.md
+++ b/code/specs/TET05-tetrad-jit.md
@@ -75,18 +75,32 @@ trigger), it falls back to the interpreter for that activation.
 
 ---
 
-## Hot-Function Detection
+## Three-Tier Compilation Strategy
 
-The hot-function detector checks after each VM instruction (or periodically, to reduce
-overhead):
+Optional type annotations create three distinct compilation tiers. Each tier has a
+different trigger for when JIT compilation occurs:
+
+| Tier | `CodeObject.type_status` | JIT trigger | Warmup cost |
+|---|---|---|---|
+| **FULLY_TYPED** | `FULLY_TYPED` | Compiled **before first call** (from `immediate_jit_queue`) | None |
+| **PARTIALLY_TYPED** | `PARTIALLY_TYPED` | Compiled after **10 calls** | 10 interpreted runs |
+| **UNTYPED** | `UNTYPED` | Compiled after **100 calls** or 500 loop iterations | 100 interpreted runs |
 
 ```python
-CALL_COUNT_THRESHOLD = 100      # calls before function is JIT-compiled
-LOOP_ITERATION_THRESHOLD = 500  # loop iterations before OSR is attempted
+THRESHOLDS = {
+    FunctionTypeStatus.FULLY_TYPED:     0,    # immediate — drain from queue before main
+    FunctionTypeStatus.PARTIALLY_TYPED: 10,   # quick warmup for partially annotated code
+    FunctionTypeStatus.UNTYPED:         100,  # conservative — avoid compiling cold code
+}
 
-def should_jit(vm: TetradVM, fn_name: str) -> bool:
+LOOP_ITERATION_THRESHOLD = 500   # OSR trigger (all tiers)
+
+def should_jit(vm: TetradVM, fn_name: str, code: CodeObject) -> bool:
+    if code.immediate_jit_eligible:
+        return True   # already queued before main; this path should not be reached
+    threshold = THRESHOLDS[code.type_status]
     call_count = vm.metrics().function_call_counts.get(fn_name, 0)
-    if call_count >= CALL_COUNT_THRESHOLD:
+    if call_count >= threshold:
         return True
     loop_iters = vm.loop_iterations(fn_name)
     if any(count >= LOOP_ITERATION_THRESHOLD for count in loop_iters.values()):
@@ -94,9 +108,46 @@ def should_jit(vm: TetradVM, fn_name: str) -> bool:
     return False
 ```
 
-Once a function is compiled, it is placed in the **JIT code cache** and all future
-calls use the compiled version. The call count threshold can be tuned; 100 is a
-conservative default that avoids compiling cold functions.
+### Immediate Compilation (FULLY_TYPED)
+
+`execute_with_jit` drains the `immediate_jit_queue` before running any bytecode:
+
+```python
+def execute_with_jit(self, code: CodeObject) -> int:
+    # Phase 1: compile all FULLY_TYPED functions before the interpreter starts
+    for fn_name in self.vm.metrics.immediate_jit_queue:
+        fn_code = find_function(code, fn_name)
+        self.compile(fn_code)   # emits x86-64; puts in cache
+
+    # Phase 2: run the interpreter; hot PARTIALLY_TYPED/UNTYPED fns compile as they warm up
+    return self.vm.execute(code)
+```
+
+The JIT can compile typed functions immediately because it does not need feedback data
+for them: the type annotations guarantee `u8 × u8 → u8` for every op. The generated
+code has no type guards and no deopt paths.
+
+### Optimized Code for Typed Functions
+
+For a FULLY_TYPED function, the JIT skips the type-specialization pass (Pass 3) because
+the type checker already guaranteed all operands are `u8`. The emitted x86-64 is clean
+integer arithmetic with no type guards:
+
+```
+# Typed fn add(a: u8, b: u8) -> u8 { return a + b; }
+push rbp
+mov  rbp, rsp
+mov  rax, rdi      # load a
+add  rax, rsi      # a + b
+and  rax, 0xFF     # u8 wrap
+pop  rbp
+ret
+
+# No type checks. No deopt calls. No guards. Pure arithmetic.
+```
+
+For PARTIALLY_TYPED and UNTYPED functions, the type-specialization pass (Pass 3) runs
+as before, reading feedback slots to determine which ops can be specialized.
 
 ---
 

--- a/code/specs/TET05-tetrad-jit.md
+++ b/code/specs/TET05-tetrad-jit.md
@@ -1,0 +1,631 @@
+# TET05 — Tetrad JIT Compiler Specification
+
+## Overview
+
+The Tetrad JIT compiler is a **profile-guided native code generator**. It reads the
+feedback vectors and metrics collected by the VM (spec TET04), identifies hot functions
+and loops, and emits x86-64 machine code that runs those functions at hardware speed
+rather than interpreted speed.
+
+The JIT is the payoff for the careful design of the feedback vector and metrics API.
+Every design decision in TET03 (feedback slots) and TET04 (metrics layer) was made with
+this consumer in mind.
+
+This spec covers:
+1. Hot-function detection and triggering
+2. The JIT compilation pipeline (bytecode → IR → x86-64)
+3. Optimization passes (constant folding, dead code, type specialization)
+4. x86-64 code generation using Python `ctypes`
+5. On-stack replacement (OSR) for hot loops
+6. The deoptimization path (when speculation fails)
+
+---
+
+## Why a JIT? The Lisp Context
+
+Most Lisp implementations today (SBCL, Racket, Guile, Chez) have AOT compilers or
+simple interpreters. SBCL has a native compiler but it is not a tracing/profiling JIT —
+it compiles whole functions with type declarations, not hot paths with type feedback.
+
+The gap: **no major Lisp VM exposes a clean metrics API** that an external JIT can
+consume to make type-specialization decisions. Tetrad fills this gap by design.
+
+A future Lisp front-end that compiles to Tetrad bytecode will get the JIT almost for
+free: the feedback vectors it generates will tell the JIT which slots are
+monomorphic integer operations (compile to a single `add` instruction), which are
+polymorphic (compile a type dispatch), and which are megamorphic (bail to the
+interpreter). This is exactly how V8 makes JavaScript fast.
+
+---
+
+## JIT Architecture
+
+```
+VM executes program (interpreted)
+    │
+    │  metrics accumulate per instruction
+    ▼
+Hot-function detector (threshold: 100 calls or 500 loop iterations)
+    │
+    │  hot function identified
+    ▼
+JIT Compiler
+    ├── Step 1: Bytecode → JIT IR (SSA form)
+    ├── Step 2: Optimization passes
+    │     ├── Constant folding
+    │     ├── Dead code elimination
+    │     ├── Type specialization (using feedback vectors)
+    │     └── Branch layout (hot path first)
+    ├── Step 3: Register allocation (linear scan)
+    └── Step 4: x86-64 code generation → bytes
+    │
+    ▼
+Compiled function (Python bytes object)
+    │
+    │  ctypes maps bytes to callable
+    ▼
+JIT Code Cache (fn_name → callable)
+    │
+    ▼
+VM calls compiled version on next invocation
+```
+
+When a compiled function needs a feature the JIT doesn't support (deoptimization
+trigger), it falls back to the interpreter for that activation.
+
+---
+
+## Hot-Function Detection
+
+The hot-function detector checks after each VM instruction (or periodically, to reduce
+overhead):
+
+```python
+CALL_COUNT_THRESHOLD = 100      # calls before function is JIT-compiled
+LOOP_ITERATION_THRESHOLD = 500  # loop iterations before OSR is attempted
+
+def should_jit(vm: TetradVM, fn_name: str) -> bool:
+    call_count = vm.metrics().function_call_counts.get(fn_name, 0)
+    if call_count >= CALL_COUNT_THRESHOLD:
+        return True
+    loop_iters = vm.loop_iterations(fn_name)
+    if any(count >= LOOP_ITERATION_THRESHOLD for count in loop_iters.values()):
+        return True
+    return False
+```
+
+Once a function is compiled, it is placed in the **JIT code cache** and all future
+calls use the compiled version. The call count threshold can be tuned; 100 is a
+conservative default that avoids compiling cold functions.
+
+---
+
+## JIT IR (Intermediate Representation)
+
+Between bytecode and x86-64, the JIT uses a simple SSA-based IR. Each IR instruction
+operates on **virtual variables** (vN) rather than the accumulator and registers. This
+makes the optimization passes easier to implement.
+
+### IR Instructions
+
+```python
+@dataclass
+class IRInstr:
+    op: str              # operation name
+    dst: str | None      # destination virtual variable (e.g. "v3"), or None for effects
+    srcs: list[str|int]  # source virtual variables or integer constants
+    ty: str              # type annotation: "u8" | "unknown" (from feedback)
+    comment: str = ""    # optional debug comment
+```
+
+### IR Instruction Set
+
+| Op | Effect |
+|---|---|
+| `const` | `dst = srcs[0]` (integer constant) |
+| `load_var` | `dst = vars[srcs[0]]` |
+| `store_var` | `vars[srcs[0]] = srcs[1]` |
+| `add` | `dst = (srcs[0] + srcs[1]) % 256` |
+| `sub` | `dst = (srcs[0] - srcs[1]) % 256` |
+| `mul` | `dst = (srcs[0] * srcs[1]) % 256` |
+| `div` | `dst = srcs[0] / srcs[1]` |
+| `mod` | `dst = srcs[0] % srcs[1]` |
+| `and` | `dst = srcs[0] & srcs[1]` |
+| `or` | `dst = srcs[0] \| srcs[1]` |
+| `xor` | `dst = srcs[0] ^ srcs[1]` |
+| `not` | `dst = ~srcs[0] & 0xFF` |
+| `shl` | `dst = (srcs[0] << srcs[1]) & 0xFF` |
+| `shr` | `dst = srcs[0] >> srcs[1]` |
+| `cmp_eq` | `dst = 1 if srcs[0] == srcs[1] else 0` |
+| `cmp_lt` | `dst = 1 if srcs[0] < srcs[1] else 0` |
+| (other cmps) | similar |
+| `jmp` | unconditional jump to `srcs[0]` (label name) |
+| `jz` | jump to `srcs[1]` if `srcs[0] == 0` |
+| `jnz` | jump to `srcs[1]` if `srcs[0] != 0` |
+| `label` | marks a branch target |
+| `call` | `dst = call srcs[0](srcs[1..])` |
+| `ret` | return `srcs[0]` |
+| `io_in` | `dst = read_io()` |
+| `io_out` | write `srcs[0]` to io |
+| `deopt` | bail to interpreter |
+
+### Bytecode → IR Translation
+
+The translation is a straight-line pass that creates a new virtual variable for each
+`LDA_*` result and each arithmetic result:
+
+```
+LDA_IMM 42        →  v0 = const 42          type=u8
+STA_REG r0        →  (r0 slot = v0)
+LDA_VAR x         →  v1 = load_var "x"      type=u8
+ADD r0, slot=0    →  v2 = add v1, v0        type=u8 (from feedback: monomorphic u8)
+STA_VAR x         →  store_var "x", v2
+```
+
+The accumulator is modelled as an implicit "current value" tracked by the translator,
+not as an IR variable. This keeps the IR clean.
+
+---
+
+## Optimization Passes
+
+### Pass 1: Constant Folding
+
+Evaluates operations on known constants at compile time:
+
+```
+v0 = const 10
+v1 = const 5
+v2 = add v0, v1    →    v2 = const 15   (folded)
+```
+
+Implementation: forward pass that maintains a `values: dict[str, int | None]` map.
+If both sources are known constants, evaluate and replace with `const`.
+
+```python
+def constant_fold(ir: list[IRInstr]) -> list[IRInstr]:
+    values: dict[str, int | None] = {}
+    result = []
+    for instr in ir:
+        if instr.op == "const":
+            values[instr.dst] = instr.srcs[0]
+            result.append(instr)
+        elif instr.op in ARITHMETIC_OPS:
+            a = values.get(instr.srcs[0]) if isinstance(instr.srcs[0], str) else instr.srcs[0]
+            b = values.get(instr.srcs[1]) if isinstance(instr.srcs[1], str) else instr.srcs[1]
+            if a is not None and b is not None:
+                folded = evaluate_op(instr.op, a, b)
+                values[instr.dst] = folded
+                result.append(IRInstr(op="const", dst=instr.dst, srcs=[folded], ty="u8"))
+            else:
+                values[instr.dst] = None
+                result.append(instr)
+        else:
+            result.append(instr)
+    return result
+```
+
+### Pass 2: Dead Code Elimination
+
+Removes IR instructions whose destination is never read:
+
+```
+v3 = add v1, v2    (v3 never used)   →   (removed)
+```
+
+Implementation: backward liveness pass. Build a set of "live" virtual variables by
+scanning uses in reverse. Any `dst` not in the live set is dead.
+
+```python
+def dead_code_eliminate(ir: list[IRInstr]) -> list[IRInstr]:
+    live: set[str] = set()
+    # Collect all uses (backwards)
+    for instr in reversed(ir):
+        for src in instr.srcs:
+            if isinstance(src, str):
+                live.add(src)
+    # Keep instructions whose dst is live (or has side effects)
+    SIDE_EFFECT_OPS = {"store_var", "io_out", "jmp", "jz", "jnz", "call", "ret", "deopt"}
+    return [i for i in ir if i.dst in live or i.op in SIDE_EFFECT_OPS or i.op == "label"]
+```
+
+### Pass 3: Type Specialization
+
+The most important pass. For each arithmetic op, read the feedback vector to determine
+the observed operand types:
+
+```python
+def type_specialize(ir: list[IRInstr], feedback: list[SlotState]) -> list[IRInstr]:
+    result = []
+    slot_idx = 0
+    for instr in ir:
+        if instr.op in BINARY_OPS_WITH_SLOTS:
+            state = feedback[slot_idx]
+            slot_idx += 1
+            if state.kind == SlotKind.MEGAMORPHIC:
+                # Cannot specialize — emit deopt
+                result.append(IRInstr(op="deopt", dst=None, srcs=[], ty="unknown",
+                                      comment=f"megamorphic at slot {slot_idx-1}"))
+            elif state.kind in (SlotKind.MONOMORPHIC, SlotKind.POLYMORPHIC):
+                if state.observations == ["u8"]:
+                    # Fully monomorphic u8: emit direct integer op, no type check
+                    result.append(dataclasses.replace(instr, ty="u8"))
+                else:
+                    # Polymorphic: emit type guard + fast path
+                    result.extend(emit_type_guard(instr, state))
+            else:
+                # Uninitialized — never reached. Emit deopt.
+                result.append(IRInstr(op="deopt", dst=None, srcs=[], ty="unknown"))
+        else:
+            result.append(instr)
+    return result
+```
+
+For Tetrad v1, every slot will be monomorphic u8, so this pass simply annotates
+every arithmetic op with `ty="u8"` and emits the direct path. The deopt paths are
+present but never triggered.
+
+### Pass 4: Branch Layout
+
+Reorders basic blocks so that the hot branch (high `taken_ratio`) comes first in the
+generated code. This improves instruction cache locality and branch predictor accuracy.
+
+```python
+def branch_layout(ir: list[IRInstr], branch_stats: dict[int, BranchStats]) -> list[IRInstr]:
+    # For each JZ/JNZ, if the NOT-taken path is hotter, invert the condition
+    # and swap the branch targets.
+    result = []
+    for instr in ir:
+        if instr.op == "jz" and instr in branch_stats:
+            stats = branch_stats[instr]
+            if stats.taken_ratio < 0.2:   # rarely taken → invert
+                result.append(IRInstr(op="jnz", dst=instr.dst, srcs=instr.srcs, ty=instr.ty))
+            else:
+                result.append(instr)
+        else:
+            result.append(instr)
+    return result
+```
+
+---
+
+## Register Allocation
+
+The JIT uses a **linear scan** register allocator over x86-64 registers. For Tetrad's
+small functions (typically ≤ 8 virtual variables), linear scan is optimal.
+
+Available x86-64 registers (caller-saved, safe to clobber):
+- `rax`, `rcx`, `rdx`, `rsi`, `rdi`, `r8`, `r9`, `r10`, `r11`
+
+The allocator assigns each live range (virtual variable + its uses) to a physical
+register. Spills go to the stack frame.
+
+```python
+@dataclass
+class LiveRange:
+    var: str             # virtual variable name
+    start: int           # IR instruction index where defined
+    end: int             # IR instruction index of last use
+
+def linear_scan_alloc(ir: list[IRInstr]) -> dict[str, str | int]:
+    """Returns mapping: virtual var → x86 reg name or stack offset."""
+    ranges = compute_live_ranges(ir)
+    active: list[LiveRange] = []
+    free_regs = ["rax", "rcx", "rdx", "rsi", "rdi", "r8", "r9", "r10"]
+    allocation: dict[str, str | int] = {}
+    stack_offset = 0
+
+    for lr in sorted(ranges, key=lambda r: r.start):
+        # Expire old intervals
+        active = [a for a in active if a.end >= lr.start]
+
+        if free_regs:
+            reg = free_regs.pop(0)
+            allocation[lr.var] = reg
+            active.append(lr)
+        else:
+            # Spill: evict the interval with the furthest end
+            spill = max(active, key=lambda a: a.end)
+            if spill.end > lr.end:
+                allocation[lr.var] = allocation.pop(spill.var)
+                stack_offset -= 8
+                allocation[spill.var] = stack_offset
+                active.remove(spill)
+                active.append(lr)
+            else:
+                stack_offset -= 8
+                allocation[lr.var] = stack_offset
+
+    return allocation
+```
+
+---
+
+## x86-64 Code Generation
+
+The code generator emits raw x86-64 machine code bytes. The Python `ctypes` module
+maps those bytes to a callable function pointer.
+
+### x86-64 Calling Convention (System V AMD64 ABI)
+
+The JIT-compiled function follows the System V AMD64 ABI:
+- Arguments: `rdi`, `rsi`, `rdx`, `rcx`, `r8`, `r9`
+- Return value: `rax`
+- Caller-saved: `rax`, `rcx`, `rdx`, `rsi`, `rdi`, `r8`–`r11`
+- Callee-saved: `rbx`, `rbp`, `r12`–`r15`
+
+Each Tetrad function receives its arguments as u8 values in the argument registers.
+It returns its result in `rax` (u8, zero-extended to 64 bits).
+
+### Prologue and Epilogue
+
+```
+; Prologue
+push rbp
+mov  rbp, rsp
+sub  rsp, N      ; stack space for spilled variables
+
+; ... body ...
+
+; Epilogue
+mov  rsp, rbp
+pop  rbp
+ret
+```
+
+### Instruction Encoding Examples
+
+These are the core x86-64 encodings the code generator needs:
+
+```python
+def emit_mov_reg_imm(buf: bytearray, dst_reg: str, imm: int):
+    """mov dst, imm8   (zero-extends to 64-bit)"""
+    rex = 0x48 if dst_reg in 64BIT_REGS else 0x00
+    # e.g. mov rax, 42 → 48 C7 C0 2A 00 00 00
+    ...
+
+def emit_mov_reg_reg(buf: bytearray, dst: str, src: str):
+    """mov dst, src"""
+    ...
+
+def emit_add_reg_reg(buf: bytearray, dst: str, src: str):
+    """add dst, src; then: and dst, 0xFF (ensure u8 wrap)"""
+    ...
+
+def emit_sub_reg_reg(buf: bytearray, dst: str, src: str):
+    """sub dst, src; then: and dst, 0xFF"""
+    ...
+
+def emit_imul_reg_reg(buf: bytearray, dst: str, src: str):
+    """imul dst, src; then: and dst, 0xFF"""
+    ...
+
+def emit_jmp_rel32(buf: bytearray, offset: int):
+    """jmp rel32"""
+    buf += b'\xe9' + struct.pack('<i', offset)
+
+def emit_jz_rel32(buf: bytearray, offset: int):
+    """test rax, rax; jz rel32"""
+    buf += b'\x48\x85\xc0'   # test rax, rax
+    buf += b'\x0f\x84' + struct.pack('<i', offset)
+
+def emit_ret(buf: bytearray):
+    buf += b'\xc3'
+```
+
+### Full Compilation Example
+
+Compiling `fn add(a, b) { return a + b; }`:
+
+```
+IR after translation:
+  v0 = load_var "a"    (from register R0 / rdi)
+  v1 = load_var "b"    (from register R1 / rsi)
+  v2 = add v0, v1      type=u8
+  ret v2
+
+After optimization:
+  No constants to fold. No dead code. Type is monomorphic u8.
+
+After register allocation:
+  v0 → rdi (already there, argument 0)
+  v1 → rsi (already there, argument 1)
+  v2 → rax
+
+Generated x86-64:
+  push rbp
+  mov  rbp, rsp
+  ; v2 = add v0(rdi), v1(rsi)
+  mov  rax, rdi
+  add  rax, rsi
+  and  rax, 0xFF       ; u8 wrap
+  ; ret v2 (rax)
+  pop  rbp
+  ret
+```
+
+Machine code bytes: approximately 14 bytes for this function.
+
+---
+
+## Invoking JIT Code with ctypes
+
+```python
+import ctypes
+import mmap
+
+def make_executable(buf: bytes) -> ctypes.CFUNCTYPE:
+    """Map bytes into executable memory and return a callable."""
+    size = len(buf)
+    # Allocate page-aligned executable memory
+    mem = mmap.mmap(-1, size,
+                    prot=mmap.PROT_READ | mmap.PROT_WRITE | mmap.PROT_EXEC)
+    mem.write(buf)
+    mem.seek(0)
+    addr = ctypes.addressof(ctypes.c_char.from_buffer(mem))
+    # Create a ctypes function pointer with correct signature
+    # All Tetrad functions take and return c_uint8 (u8)
+    fn_type = ctypes.CFUNCTYPE(ctypes.c_uint8, *[ctypes.c_uint8] * param_count)
+    return fn_type(addr), mem   # keep mem alive
+```
+
+The `mem` object must be kept alive as long as the function pointer is in use.
+The JIT code cache holds both the callable and the `mmap` object.
+
+---
+
+## JIT Code Cache
+
+```python
+@dataclass
+class JITCacheEntry:
+    fn_name: str
+    compiled_at_call_count: int   # for cache invalidation
+    native_fn: ctypes.CFUNCTYPE   # callable
+    mmap_ref: mmap.mmap           # keep-alive reference
+    compilation_time_ns: int       # for benchmarking
+
+class JITCache:
+    def __init__(self):
+        self._cache: dict[str, JITCacheEntry] = {}
+
+    def get(self, fn_name: str) -> ctypes.CFUNCTYPE | None: ...
+    def put(self, entry: JITCacheEntry) -> None: ...
+    def invalidate(self, fn_name: str) -> None: ...
+    def stats(self) -> dict[str, dict]: ...   # for benchmarking
+```
+
+---
+
+## On-Stack Replacement (OSR)
+
+OSR allows the VM to switch a **currently-executing** function from interpreted to
+compiled mode mid-execution, typically at a loop back-edge.
+
+In v1, OSR is implemented in a simplified form:
+1. The VM checks loop iteration counts on every `JMP_LOOP`.
+2. If a loop exceeds `LOOP_ITERATION_THRESHOLD`, the JIT compiles the entire function.
+3. The **current** activation finishes in the interpreter. New calls use the compiled
+   version.
+
+Full OSR (patching the live stack frame) is deferred to v2. The simplified form still
+achieves the goal for functions called many times with long loops.
+
+---
+
+## Deoptimization
+
+When a JIT-compiled function encounters a condition it was not compiled to handle
+(e.g., a type assumption that turns out to be wrong, or a division by zero), it
+**deoptimizes** back to the interpreter.
+
+In v1, the deoptimization mechanism is:
+
+1. The JIT inserts a `deopt` IR instruction wherever a type assumption might fail.
+2. The code generator emits a call to a `deopt_handler` C function for each `deopt`.
+3. The `deopt_handler` restores the interpreter state (registers, IP, call stack) and
+   resumes execution in the interpreted path.
+
+For Tetrad v1, deoptimization never fires in practice (all values are u8, no assumptions
+fail). The mechanism is present so the Lisp front-end can rely on it.
+
+---
+
+## JIT Public API
+
+```python
+class TetradJIT:
+
+    def __init__(self, vm: TetradVM): ...
+
+    # Compile a function by name, using the VM's current feedback vectors.
+    # Returns True if compilation succeeded.
+    def compile(self, fn_name: str) -> bool: ...
+
+    # Check if a function is already in the cache.
+    def is_compiled(self, fn_name: str) -> bool: ...
+
+    # Execute a function: use compiled version if available, else interpret.
+    def execute(self, fn_name: str, args: list[int]) -> int: ...
+
+    # Run the VM, auto-compiling functions as they get hot.
+    # This is the main entry point for production use.
+    def execute_with_jit(self, code: CodeObject) -> int: ...
+
+    # Return JIT cache statistics.
+    def cache_stats(self) -> dict[str, dict]: ...
+
+    # Dump the IR for a compiled function (for debugging).
+    def dump_ir(self, fn_name: str) -> str: ...
+
+    # Dump the x86-64 disassembly for a compiled function.
+    # Requires the `capstone` Python library for disassembly.
+    def dump_asm(self, fn_name: str) -> str: ...
+```
+
+---
+
+## Python Package
+
+The JIT lives in `code/packages/python/tetrad-jit/`.
+
+Depends on `coding-adventures-tetrad-vm`.
+
+Optional dependency: `capstone` (for `dump_asm`). The package works without it; only
+the disassembly feature is unavailable.
+
+---
+
+## Test Strategy
+
+### IR generation tests
+
+- Verify bytecode → IR translation for each opcode family
+- `LDA_IMM 42; STA_REG 0; LDA_VAR x; ADD r0, slot=0` → correct IR with virtual vars
+
+### Optimization pass tests
+
+- Constant folding: `const 10 + const 5` → `const 15`
+- Dead code: variable computed but never read → instruction removed
+- Type specialization: monomorphic slot → `ty="u8"` annotation; no deopt inserted
+- Branch layout: 99% taken branch stays in-line; rarely taken branch inverted
+
+### Register allocation tests
+
+- 2-variable function: both allocated to registers, no spills
+- 9-variable function: one variable spills to stack
+
+### Code generation tests
+
+- `add(a, b) { return a + b; }` → x86-64 bytes, callable, produces correct result
+- u8 wraparound: `add(200, 100)` → result is 44 (wraps at 256)
+- Zero division via `deopt`: `div(10, 0)` invokes deopt handler without crashing
+
+### Hot-function detection tests
+
+- Execute a function 99 times → not compiled
+- Execute 101 times → compiled (appears in cache)
+- Loop with >500 iterations → triggers OSR threshold
+
+### End-to-end JIT tests
+
+- Execute all five TET00 example programs under `execute_with_jit`
+- Verify output matches interpreter output
+- Verify JIT-compiled functions appear in cache after enough iterations
+
+### Performance smoke test
+
+- `multiply(255, 200)` under JIT vs. interpreter: verify JIT is faster
+  (quantitative threshold: JIT ≥ 5× faster for tight loops)
+
+### Coverage target
+
+90%+ line coverage (lower than 95% due to platform-specific mmap/ctypes paths).
+
+---
+
+## Version History
+
+| Version | Date | Description |
+|---|---|---|
+| 0.1.0 | 2026-04-20 | Initial specification |


### PR DESCRIPTION
## Summary

- **TET00** — Language overview: `u8`-only, accumulator register VM, software call stack fitting inside 4004's 128-byte RAM budget, full EBNF grammar, five worked examples, explicit contrast with Nib and OCT
- **TET01** — Lexer: single-pass maximal-munch tokenizer, 37 token types, line comments, position tracking
- **TET02** — Parser: Pratt parser for expressions (binding power table), recursive descent for statements, 15 AST node dataclasses
- **TET03** — Bytecode compiler: accumulator + 8-register ISA, feedback slot index in every binary op and call site, jump backpatching, linear register allocator, ROM serialization format for physical 4004
- **TET04** — Register VM: per-frame feedback vectors, `SlotState` lifecycle, explicit **metrics API** (`hot_functions`, `type_profile`, `branch_profile`, `loop_iterations`, `call_site_shape`) — designed as a clean substrate for JITs; full 4004 RAM layout within 128 bytes
- **TET05** — JIT: profile-guided, bytecode→SSA IR, constant folding + DCE + type specialization passes, linear scan register allocator, x86-64 codegen via `ctypes`/`mmap`, simplified OSR, deoptimization path

## Why the metrics API matters

Current Lisp VMs (SBCL, Racket, Guile) do not expose type feedback in an API an external JIT can consume. The TET04 metrics API is designed to fill this gap: the same bytecode format and VM will accept a future Lisp front-end, and the JIT (TET05) will specialize on the observed polymorphic type profiles without any change to the interpreter core.

## Test plan

- [ ] All spec files exist at `code/specs/TET00–TET05`
- [ ] Grammar in TET00 is consistent with token types in TET01
- [ ] Binding power table in TET02 matches operator precedence in TET00
- [ ] Instruction opcodes in TET03 match opcode cases in TET04 dispatch loop
- [ ] Feedback slot API in TET04 matches what TET05 JIT reads
- [ ] Example programs in TET00 are valid per the grammar

🤖 Generated with [Claude Code](https://claude.com/claude-code)