### PR TITLE
feat(img04): implement image-geometric-transforms in Go, Ruby, Swift (Batch 2/5)

### DIFF
--- a/code/packages/go/image-geometric-transforms/BUILD
+++ b/code/packages/go/image-geometric-transforms/BUILD
@@ -1,0 +1,9 @@
+load("code/packages/starlark/library-rules/go_library.star", "go_library")
+
+_targets = [
+    go_library(
+        name = "image-geometric-transforms",
+        srcs = ["**/*.go"],
+        deps = ["//code/packages/go/pixel-container"],
+    ),
+]

--- a/code/packages/go/image-geometric-transforms/CHANGELOG.md
+++ b/code/packages/go/image-geometric-transforms/CHANGELOG.md
@@ -1,0 +1,76 @@
+# Changelog — image-geometric-transforms
+
+All notable changes to this package are documented here.  The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the package
+version follows [Semantic Versioning](https://semver.org/).
+
+---
+
+## [0.1.0] — 2026-04-20
+
+### Added
+
+- **Package scaffold**: `go.mod`, `BUILD`, `README.md`, `CHANGELOG.md`.
+
+- **Type definitions**:
+  - `Interpolation` enum (`Nearest`, `Bilinear`, `Bicubic`) selecting the
+    resampling filter used by continuous transforms.
+  - `RotateBounds` enum (`Fit`, `Crop`) controlling the output canvas size of
+    `Rotate`.
+  - `OutOfBounds` enum (`Zero`, `Replicate`, `Reflect`, `Wrap`) mirroring the
+    four standard GPU texture-wrapping modes.
+  - `Rgba8` convenience struct for fill colours in `Pad`.
+
+- **sRGB / linear-light infrastructure**:
+  - `var srgbToLinear [256]float64` — 256-entry decode LUT initialised once
+    via `init()`.
+  - `func encode(v float64) byte` — sRGB re-encoding with clamping and rounding.
+
+- **Out-of-bounds resolver**:
+  - `func resolveCoord(x, max int, oob OutOfBounds) (int, bool)` — maps an
+    arbitrary integer coordinate into `[0, max-1]` according to the chosen
+    wrapping policy; returns `(0, false)` for the `Zero` policy to let callers
+    short-circuit to transparent black.
+
+- **Catmull-Rom kernel**:
+  - `func catmullRom(d float64) float64` — Keys (1983) cubic spline with
+    α = 0.5, providing C¹ continuity for smooth bicubic reconstruction.
+
+- **Sampling functions**:
+  - `func sampleNN` — nearest-neighbour, O(1) per output pixel.
+  - `func sampleBilinear` — bilinear blend of 4 neighbours in linear-light
+    space.
+  - `func sampleBicubic` — separable Catmull-Rom blend of a 4×4 neighbourhood
+    in linear-light space.
+  - `func Sample(img, u, v, mode, oob)` — public dispatcher.
+
+- **Lossless geometric transforms** (byte-copy, no colour-space conversion):
+  - `FlipHorizontal` — mirror left-to-right.
+  - `FlipVertical` — mirror top-to-bottom.
+  - `Rotate90CW` — 90° clockwise rotation; dimensions swap.  Output pixel
+    `(x', y')` reads source `(col=y', row=H-1-x')` where `H = src.Height`.
+    Note: the original spec listed the formula as `I[y'][W-1-x']`; the correct
+    derivation uses `H-1-x'` (src height), not `W-1-x'` (src width), to
+    properly invert the CW rotation.
+  - `Rotate90CCW` — 90° counter-clockwise rotation; dimensions swap.  Output
+    pixel `(x', y')` reads source `(col=W-1-y', row=x')` where `W = src.Width`.
+  - `Rotate180` — 180° rotation; dimensions preserved.
+  - `Crop(src, x, y, w, h)` — rectangular sub-image extraction; out-of-bounds
+    area filled with transparent black.
+  - `Pad(src, top, right, bottom, left, fill)` — adds a border of fill pixels.
+
+- **Continuous geometric transforms** (inverse-warp, linear-light sampling):
+  - `Scale(src, outW, outH, mode)` — resize to any dimensions using the
+    pixel-centre model (`u = (x+0.5)*sx - 0.5`); OOB = Replicate.
+  - `Rotate(src, radians, mode, bounds)` — arbitrary-angle rotation with
+    inverse-warp formula; Fit or Crop output canvas; OOB = Zero.
+  - `Affine(src, matrix, outW, outH, mode, oob)` — arbitrary 2×3 affine
+    transform; matrix maps output → source directly (no inversion needed).
+  - `PerspectiveWarp(src, h, outW, outH, mode, oob)` — projective homography
+    via homogeneous division (`u = uh/w`, `v = vh/w`); horizon guard for
+    `w ≈ 0`.
+
+- **Unit test suite** (`image_geometric_transforms_test.go`):
+  - 30 test functions covering lossless round-trips, dimension checks, pixel
+    position correctness, sampling kernel properties, OOB policies, and
+    approximate-identity checks for continuous transforms.

--- a/code/packages/go/image-geometric-transforms/README.md
+++ b/code/packages/go/image-geometric-transforms/README.md
@@ -1,0 +1,151 @@
+# image-geometric-transforms
+
+**IMG04** — Geometric transforms for `PixelContainer` images.
+
+This package implements the spatial-transform layer of the coding-adventures
+image pipeline.  It operates on the `*pc.PixelContainer` type from
+[pixel-container](../pixel-container/README.md) and sits above the point-ops
+layer (IMG03) and below any compositing or text-rendering layers.
+
+---
+
+## What This Package Does
+
+| Category | Operations |
+|---|---|
+| Lossless pixel-copy | `FlipHorizontal`, `FlipVertical`, `Rotate90CW`, `Rotate90CCW`, `Rotate180`, `Crop`, `Pad` |
+| Continuous resampling | `Scale`, `Rotate`, `Affine`, `PerspectiveWarp` |
+| Public sampling API | `Sample(img, u, v, mode, oob)` |
+
+Lossless operations copy pixel bytes verbatim — no colour-space conversion,
+no rounding error.  Continuous operations perform an inverse warp and
+reconstruct source values using one of three interpolation filters.
+
+---
+
+## Stack Position
+
+```
+IMG04  image-geometric-transforms  ← this package
+IMG03  image-point-ops
+IMG02  image-codec-qoi / image-codec-ppm / image-codec-bmp
+IMG01  pixel-container
+```
+
+---
+
+## Key Concepts
+
+### Inverse Warp ("Pull" Sampling)
+
+Every continuous transform iterates over output pixels and asks "which source
+coordinate maps here?" rather than pushing source pixels forward.  This
+guarantees no holes and no double-writes.
+
+### Pixel-Centre Model
+
+A pixel at integer index `x` occupies the interval `[x, x+1)`.  Its centre is
+at `x + 0.5`.  Scale uses:
+
+```
+u = (x' + 0.5) * (srcW / outW) - 0.5
+```
+
+to align source and output pixel centres correctly, avoiding the half-pixel
+shift that occurs with the simpler `u = x' * sx`.
+
+### Linear-Light Interpolation
+
+Pixel bytes are in the sRGB colour space (≈ gamma 2.2).  Averaging sRGB values
+directly produces visually dark results.  All continuous operations decode bytes
+to linear-light floats via a 256-entry LUT, blend in linear space, then
+re-encode to sRGB.
+
+### Interpolation Filters
+
+| Mode | Quality | Speed | When to use |
+|---|---|---|---|
+| `Nearest` | Blocky | Fastest | Pixel art, lossless preview |
+| `Bilinear` | Smooth | Fast | General resizing |
+| `Bicubic` | Very smooth | Moderate | High-quality upscaling |
+
+Bicubic uses the Catmull-Rom kernel (α = 0.5, Keys 1983) over a 4×4
+neighbourhood.
+
+### Out-of-Bounds Policies
+
+| Policy | Behaviour |
+|---|---|
+| `Zero` | Out-of-bounds → transparent black `(0,0,0,0)` |
+| `Replicate` | Clamp to nearest edge pixel |
+| `Reflect` | Mirror at edges |
+| `Wrap` | Tile (modulo) |
+
+---
+
+## Usage
+
+```go
+import (
+    igt "github.com/adhithyan15/coding-adventures/code/packages/go/image-geometric-transforms"
+    pc  "github.com/adhithyan15/coding-adventures/code/packages/go/pixel-container"
+)
+
+src := pc.New(640, 480)
+// ... fill src with pixels ...
+
+// Flip horizontally (lossless).
+flipped := igt.FlipHorizontal(src)
+
+// Scale to thumbnail (bilinear, no colour shift).
+thumb := igt.Scale(src, 160, 120, igt.Bilinear)
+
+// Rotate 30° with Fit canvas, bicubic quality.  Use igt.CropBounds to keep src size.
+rotated := igt.Rotate(src, math.Pi/6, igt.Bicubic, igt.Fit)
+
+// Add a 10-pixel white border on all sides.
+padded := igt.Pad(src, 10, 10, 10, 10, igt.Rgba8{255, 255, 255, 255})
+
+// Crop a 100×80 region starting at (50, 40).
+cropped := igt.Crop(src, 50, 40, 100, 80)
+
+// Arbitrary affine: scale x by 0.5, keep y (inverse matrix).
+matrix := [2][3]float64{{2.0, 0, 0}, {0, 1, 0}}
+stretched := igt.Affine(src, matrix, 320, 480, igt.Bilinear, igt.Zero)
+
+// Perspective homography (identity shown).
+h := [3][3]float64{{1, 0, 0}, {0, 1, 0}, {0, 0, 1}}
+warped := igt.PerspectiveWarp(src, h, 640, 480, igt.Bilinear, igt.Zero)
+
+// Low-level sampling at a continuous coordinate.
+r, g, b, a := igt.Sample(src, 3.7, 2.1, igt.Bicubic, igt.Replicate)
+_ = r; _ = g; _ = b; _ = a
+```
+
+---
+
+## Tests
+
+```
+go test ./...
+```
+
+The test suite contains 30 tests covering:
+
+- Lossless identity round-trips (double-flip, CW+CCW rotation, 180°×2)
+- Dimension invariants for every operation
+- Pixel-position correctness for flips, crops, pads, and 90° rotations
+- Continuous-transform approximate-identity checks (±2–3 per channel)
+- Nearest-neighbour exact-pixel and OOB behaviour
+- Bilinear midpoint blend correctness in linear-light space
+- Bicubic stability on solid images
+
+---
+
+## Module Path
+
+```
+github.com/adhithyan15/coding-adventures/code/packages/go/image-geometric-transforms
+```
+
+Requires Go 1.26.

--- a/code/packages/go/image-geometric-transforms/go.mod
+++ b/code/packages/go/image-geometric-transforms/go.mod
@@ -1,0 +1,7 @@
+module github.com/adhithyan15/coding-adventures/code/packages/go/image-geometric-transforms
+
+go 1.26
+
+require github.com/adhithyan15/coding-adventures/code/packages/go/pixel-container v0.0.0
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/pixel-container => ../pixel-container

--- a/code/packages/go/image-geometric-transforms/image_geometric_transforms.go
+++ b/code/packages/go/image-geometric-transforms/image_geometric_transforms.go
@@ -1,0 +1,716 @@
+// Package imagegeometrictransforms implements IMG04 — geometric transforms on
+// PixelContainer images.
+//
+// # What Is a Geometric Transform?
+//
+// A geometric transform moves pixels spatially rather than changing their
+// colour values.  Flipping a photo horizontally, scaling it to a thumbnail,
+// rotating it 45°, or mapping it through a projective homography are all
+// geometric transforms.  Unlike point operations (IMG03), which change what
+// colour a pixel has, geometric transforms change where pixels live.
+//
+// # The Inverse-Warp Model
+//
+// A naive "forward warp" iterates over every source pixel and asks "where does
+// this pixel land in the output?"  The problem: two source pixels may land on
+// the same output location while other output locations receive nothing — leaving
+// holes.
+//
+// The correct approach is the inverse warp (also called "pull" sampling):
+//
+//  1. Iterate over every output pixel (x', y').
+//  2. Apply the inverse transform to obtain a source coordinate (u, v).
+//  3. Sample the source image at (u, v) using the chosen interpolation filter.
+//  4. Write the sampled colour into (x', y').
+//
+// Because we visit every output pixel exactly once, there are no holes and no
+// double-writes.  Every function in this package follows this pattern.
+//
+// # The Pixel-Centre Model
+//
+// A pixel at integer coordinate x occupies the half-open interval [x, x+1) in
+// continuous space.  Its centre is at x + 0.5.
+//
+// When mapping a W-pixel row to a W'-pixel row (scaling), we want the left
+// edge of the source (continuous 0.0) to align with the left edge of the
+// output, and similarly for the right edge.  Using pixel centres:
+//
+//	sx = float64(srcW) / float64(outW)   // scale factor
+//	u = (float64(x') + 0.5) * sx - 0.5  // source centre for output pixel x'
+//
+// This formula ensures that the first and last output pixels map exactly onto
+// the first and last source pixels, avoiding the half-pixel shift that occurs
+// when using u = x' * sx.
+//
+// # Linear-Light Requirement
+//
+// Pixel bytes are stored in the sRGB colour space — a perceptual encoding with
+// an approximate gamma of 2.2.  Mixing two sRGB values directly (e.g.
+// averaging bytes 0 and 200 to get 100) produces the wrong answer because the
+// perceptual scale is non-linear.
+//
+// Correct interpolation:
+//  1. Decode sRGB bytes to linear-light floats (srgbToLinear LUT).
+//  2. Perform all weighted sums in linear space.
+//  3. Re-encode each result channel back to sRGB bytes (encode function).
+//
+// Lossless pixel-copy operations (flips, 90°/180° rotations, crop) bypass the
+// LUT entirely — they copy bytes verbatim, so no colour-space error is possible.
+//
+// # Catmull-Rom Spline
+//
+// Bicubic interpolation reconstructs a smooth surface through a 4×4
+// neighbourhood of source pixels.  Each axis independently weights four
+// samples using the Catmull-Rom kernel with parameter α = 0.5:
+//
+//	Keys (1983):  w(d) = { (α+2)|d|³ − (α+3)|d|² + 1           for |d| ≤ 1
+//	                     { α|d|³ − 5α|d|² + 8α|d| − 4α          for 1 < |d| ≤ 2
+//	                     { 0                                      otherwise
+//
+// With α = 0.5 the kernel reduces to the standard Catmull-Rom formula and has
+// C¹ continuity — it passes through the control points and has smooth
+// derivatives, making it well suited for image upscaling.
+package imagegeometrictransforms
+
+import (
+	"math"
+
+	pc "github.com/adhithyan15/coding-adventures/code/packages/go/pixel-container"
+)
+
+// ── Type definitions ──────────────────────────────────────────────────────────
+
+// Interpolation selects the filter used when sampling a source image at a
+// non-integer coordinate.
+//
+// Higher-quality filters examine more neighbouring pixels and are therefore
+// slower but produce smoother results, especially during upscaling.
+type Interpolation int
+
+const (
+	// Nearest picks the closest source pixel with no blending.
+	// Fastest; produces a blocky "pixel art" look when upscaling.
+	Nearest Interpolation = iota
+
+	// Bilinear blends the four nearest pixels in linear light using
+	// bilinear interpolation.  Good general-purpose filter.
+	Bilinear
+
+	// Bicubic blends a 4×4 neighbourhood using the Catmull-Rom kernel.
+	// Smoother than Bilinear, especially at large upscale ratios.
+	Bicubic
+)
+
+// RotateBounds controls the output canvas size when rotating by an arbitrary
+// angle.
+type RotateBounds int
+
+const (
+	// Fit expands the canvas to contain the entire rotated source image.
+	// No content is clipped; corners of the original image are always visible.
+	Fit RotateBounds = iota
+
+	// CropBounds keeps the canvas at the source dimensions.
+	// The output has the same size as the input; corners may be clipped.
+	CropBounds
+)
+
+// OutOfBounds determines how sampling behaves when the inverse warp maps an
+// output pixel to a coordinate outside the source image boundary.
+type OutOfBounds int
+
+const (
+	// Zero returns (0, 0, 0, 0) — transparent black — for out-of-bounds reads.
+	// Use this when the source image has a natural "no data" region (e.g.
+	// rotation with empty corners).
+	Zero OutOfBounds = iota
+
+	// Replicate clamps coordinates to the nearest edge pixel.
+	// Equivalent to OpenGL's GL_CLAMP_TO_EDGE.
+	Replicate
+
+	// Reflect mirrors coordinates at the image boundary, creating a mirror-tile
+	// effect.  Equivalent to OpenGL's GL_MIRRORED_REPEAT.
+	Reflect
+
+	// Wrap tiles the image by taking coordinates modulo the dimension.
+	// Equivalent to OpenGL's GL_REPEAT.
+	Wrap
+)
+
+// Rgba8 is a convenience struct for passing a fill colour to Pad.
+type Rgba8 struct{ R, G, B, A uint8 }
+
+// ── sRGB / linear-light LUT ───────────────────────────────────────────────────
+
+// srgbToLinear is a 256-entry decode look-up table mapping sRGB byte values
+// (0–255) to linear-light float64 values (0.0–1.0).
+//
+// The sRGB standard specifies a piecewise transfer function:
+//
+//	c_linear = c_srgb / 12.92                          for c_srgb ≤ 0.04045
+//	c_linear = ((c_srgb + 0.055) / 1.055) ^ 2.4       otherwise
+//
+// where c_srgb = byte / 255.0.  Building the table once at init time means
+// every interpolation call pays a single array lookup instead of a branch +
+// power computation.
+var srgbToLinear [256]float64
+
+func init() {
+	for i := range srgbToLinear {
+		c := float64(i) / 255.0
+		if c <= 0.04045 {
+			srgbToLinear[i] = c / 12.92
+		} else {
+			srgbToLinear[i] = math.Pow((c+0.055)/1.055, 2.4)
+		}
+	}
+}
+
+// encode converts a linear-light value (0.0–1.0) back to an sRGB byte.
+//
+// The inverse transfer function applies the sRGB gamma curve:
+//
+//	c_srgb = c_linear * 12.92                          for c_linear ≤ 0.0031308
+//	c_srgb = 1.055 * c_linear^(1/2.4) − 0.055         otherwise
+//
+// Values are clamped to [0, 1] before scaling to [0, 255] and rounding.
+func encode(v float64) byte {
+	var c float64
+	if v <= 0.0031308 {
+		c = v * 12.92
+	} else {
+		c = 1.055*math.Pow(v, 1.0/2.4) - 0.055
+	}
+	return byte(math.Round(math.Min(1, math.Max(0, c)) * 255))
+}
+
+// ── Out-of-bounds coordinate resolution ──────────────────────────────────────
+
+// resolveCoord maps a potentially out-of-range integer coordinate x into the
+// valid range [0, max-1] according to the OutOfBounds policy.
+//
+// Returns (coordinate, valid).  When oob == Zero and x is out of range, valid
+// is false and the caller should use the zero pixel.  For all other policies
+// the returned coordinate is always valid (within [0, max-1]).
+//
+// The four policies correspond directly to GPU texture wrapping modes:
+//
+//	Zero      — GL_CLAMP_TO_BORDER (border colour = 0)
+//	Replicate — GL_CLAMP_TO_EDGE
+//	Reflect   — GL_MIRRORED_REPEAT
+//	Wrap      — GL_REPEAT
+func resolveCoord(x, max int, oob OutOfBounds) (int, bool) {
+	if x >= 0 && x < max {
+		return x, true
+	}
+	switch oob {
+	case Zero:
+		return 0, false
+
+	case Replicate:
+		if x < 0 {
+			return 0, true
+		}
+		return max - 1, true
+
+	case Reflect:
+		// Mirror-repeat: fold the coordinate back at both ends.
+		// Period is 2*max; the pattern is: 0 1 2 … max-1 max-1 … 1 0 1 2 …
+		period := 2 * max
+		x = ((x % period) + period) % period // normalise to [0, 2*max)
+		if x >= max {
+			x = period - 1 - x
+		}
+		return x, true
+
+	case Wrap:
+		// Simple modulo tiling; handle negative x correctly in Go.
+		x = ((x % max) + max) % max
+		return x, true
+	}
+	return 0, false
+}
+
+// ── Catmull-Rom kernel ─────────────────────────────────────────────────────────
+
+// catmullRom evaluates the Catmull-Rom cubic spline kernel at distance d.
+//
+// The Keys (1983) formula with α = 0.5:
+//
+//	|d| ≤ 1  →  1.5|d|³ − 2.5|d|² + 1
+//	|d| ≤ 2  →  −0.5|d|³ + 2.5|d|² − 4|d| + 2
+//	otherwise →  0
+//
+// This kernel has unit area, passes through control points at d = 0, 1, and
+// has zero first derivatives at those points, giving a smooth C¹ spline.
+func catmullRom(d float64) float64 {
+	d = math.Abs(d)
+	switch {
+	case d < 1:
+		return 1.5*d*d*d - 2.5*d*d + 1
+	case d < 2:
+		return -0.5*d*d*d + 2.5*d*d - 4*d + 2
+	default:
+		return 0
+	}
+}
+
+// ── Sampling functions ────────────────────────────────────────────────────────
+
+// sampleNN samples the source image at (u, v) using nearest-neighbour
+// interpolation.  The continuous coordinate is snapped to the nearest integer
+// pixel using floor(u + 0.5), i.e. conventional rounding.
+func sampleNN(img *pc.PixelContainer, u, v float64, oob OutOfBounds) (byte, byte, byte, byte) {
+	xi := int(math.Floor(u + 0.5))
+	yi := int(math.Floor(v + 0.5))
+
+	cx, validX := resolveCoord(xi, int(img.Width), oob)
+	cy, validY := resolveCoord(yi, int(img.Height), oob)
+	if !validX || !validY {
+		return 0, 0, 0, 0
+	}
+	return pc.PixelAt(img, uint32(cx), uint32(cy))
+}
+
+// sampleBilinear samples the source image at (u, v) using bilinear
+// interpolation in linear-light space.
+//
+// The four nearest pixels form a unit square.  Let (x0, y0) be the
+// integer floor of (u, v), and let (tx, ty) be the fractional parts.
+// The blend weights are:
+//
+//	w00 = (1-tx)(1-ty),  w10 = tx(1-ty)
+//	w01 = (1-tx)ty,      w11 = tx·ty
+//
+// Each channel is decoded to linear light, blended by the four weights, then
+// re-encoded to sRGB.  Alpha is blended directly in the byte domain (it is not
+// gamma-encoded).
+func sampleBilinear(img *pc.PixelContainer, u, v float64, oob OutOfBounds) (byte, byte, byte, byte) {
+	x0 := int(math.Floor(u))
+	y0 := int(math.Floor(v))
+	tx := u - float64(x0)
+	ty := v - float64(y0)
+
+	// Helper to get a pixel, respecting OOB policy.
+	get := func(xi, yi int) (float64, float64, float64, float64) {
+		cx, vx := resolveCoord(xi, int(img.Width), oob)
+		cy, vy := resolveCoord(yi, int(img.Height), oob)
+		if !vx || !vy {
+			return 0, 0, 0, 0
+		}
+		r, g, b, a := pc.PixelAt(img, uint32(cx), uint32(cy))
+		return srgbToLinear[r], srgbToLinear[g], srgbToLinear[b], float64(a) / 255.0
+	}
+
+	r00, g00, b00, a00 := get(x0, y0)
+	r10, g10, b10, a10 := get(x0+1, y0)
+	r01, g01, b01, a01 := get(x0, y0+1)
+	r11, g11, b11, a11 := get(x0+1, y0+1)
+
+	lerp := func(a, b, t float64) float64 { return a*(1-t) + b*t }
+
+	lr := lerp(lerp(r00, r10, tx), lerp(r01, r11, tx), ty)
+	lg := lerp(lerp(g00, g10, tx), lerp(g01, g11, tx), ty)
+	lb := lerp(lerp(b00, b10, tx), lerp(b01, b11, tx), ty)
+	la := lerp(lerp(a00, a10, tx), lerp(a01, a11, tx), ty)
+
+	return encode(lr), encode(lg), encode(lb), byte(math.Round(la * 255))
+}
+
+// sampleBicubic samples the source image at (u, v) using bicubic
+// Catmull-Rom interpolation over a 4×4 neighbourhood in linear-light space.
+//
+// The 4×4 grid is centred on the integer floor of (u, v).  Each row is first
+// collapsed to a single value using 1-D Catmull-Rom weights, and then the four
+// row values are combined with another 1-D pass — the classic separable form.
+//
+// Intermediate values may exceed [0, 1]; the final encode() call clamps them.
+func sampleBicubic(img *pc.PixelContainer, u, v float64, oob OutOfBounds) (byte, byte, byte, byte) {
+	x0 := int(math.Floor(u))
+	y0 := int(math.Floor(v))
+	fx := u - float64(x0)
+	fy := v - float64(y0)
+
+	// Catmull-Rom weights for the 4 taps at distances -1, 0, 1, 2 from x0.
+	wx := [4]float64{catmullRom(fx + 1), catmullRom(fx), catmullRom(1 - fx), catmullRom(2 - fx)}
+	wy := [4]float64{catmullRom(fy + 1), catmullRom(fy), catmullRom(1 - fy), catmullRom(2 - fy)}
+
+	var sumR, sumG, sumB, sumA float64
+
+	for j := 0; j < 4; j++ {
+		// Accumulate one horizontal pass for row y0-1+j.
+		yi := y0 - 1 + j
+		cy, vy := resolveCoord(yi, int(img.Height), oob)
+
+		var rowR, rowG, rowB, rowA float64
+		for i := 0; i < 4; i++ {
+			xi := x0 - 1 + i
+			cx, vx := resolveCoord(xi, int(img.Width), oob)
+
+			var lr, lg, lb, la float64
+			if vx && vy {
+				r, g, b, a := pc.PixelAt(img, uint32(cx), uint32(cy))
+				lr, lg, lb, la = srgbToLinear[r], srgbToLinear[g], srgbToLinear[b], float64(a)/255.0
+			}
+			rowR += wx[i] * lr
+			rowG += wx[i] * lg
+			rowB += wx[i] * lb
+			rowA += wx[i] * la
+		}
+
+		sumR += wy[j] * rowR
+		sumG += wy[j] * rowG
+		sumB += wy[j] * rowB
+		sumA += wy[j] * rowA
+	}
+
+	return encode(sumR), encode(sumG), encode(sumB),
+		byte(math.Round(math.Min(1, math.Max(0, sumA))*255))
+}
+
+// Sample is the public sampling entry point.  It dispatches to the appropriate
+// filter based on mode and handles all out-of-bounds cases.
+//
+// (u, v) are continuous source coordinates in the pixel-centre model: pixel
+// (0, 0) has its centre at (0, 0), and pixel (w-1, h-1) has its centre at
+// (w-1, h-1).
+func Sample(img *pc.PixelContainer, u, v float64, mode Interpolation, oob OutOfBounds) (byte, byte, byte, byte) {
+	switch mode {
+	case Bilinear:
+		return sampleBilinear(img, u, v, oob)
+	case Bicubic:
+		return sampleBicubic(img, u, v, oob)
+	default:
+		return sampleNN(img, u, v, oob)
+	}
+}
+
+// ── Lossless transforms ───────────────────────────────────────────────────────
+
+// FlipHorizontal mirrors the image left-to-right.
+//
+// Each row is reversed in place: output pixel at (x', y) copies from source
+// pixel at (Width-1-x', y).  No colour-space conversion is needed because
+// pixels are copied verbatim.
+func FlipHorizontal(src *pc.PixelContainer) *pc.PixelContainer {
+	w, h := src.Width, src.Height
+	out := pc.New(w, h)
+	for y := uint32(0); y < h; y++ {
+		for x := uint32(0); x < w; x++ {
+			r, g, b, a := pc.PixelAt(src, w-1-x, y)
+			pc.SetPixel(out, x, y, r, g, b, a)
+		}
+	}
+	return out
+}
+
+// FlipVertical mirrors the image top-to-bottom.
+//
+// Output pixel at (x, y') copies from source pixel at (x, Height-1-y').
+func FlipVertical(src *pc.PixelContainer) *pc.PixelContainer {
+	w, h := src.Width, src.Height
+	out := pc.New(w, h)
+	for y := uint32(0); y < h; y++ {
+		for x := uint32(0); x < w; x++ {
+			r, g, b, a := pc.PixelAt(src, x, h-1-y)
+			pc.SetPixel(out, x, y, r, g, b, a)
+		}
+	}
+	return out
+}
+
+// Rotate90CW rotates the image 90° clockwise.
+//
+// The output dimensions swap: output width = src.Height, output height = src.Width.
+//
+// Inverse warp derivation (image coords: x = column right, y = row down):
+//
+//	Forward CW:  (x_src, y_src) → (x'=H-1-y_src, y'=x_src)
+//	Inverse:     (x', y') → x_src=y', y_src=H-1-x'
+//
+// So output pixel (x', y') copies from source pixel (col=y', row=H-1-x').
+func Rotate90CW(src *pc.PixelContainer) *pc.PixelContainer {
+	W, H := src.Width, src.Height
+	// Output: width = H (src height), height = W (src width).
+	out := pc.New(H, W)
+	for y := uint32(0); y < W; y++ { // y' ∈ [0, W)
+		for x := uint32(0); x < H; x++ { // x' ∈ [0, H)
+			// Inverse: source col = y', source row = H-1-x'
+			r, g, b, a := pc.PixelAt(src, y, H-1-x)
+			pc.SetPixel(out, x, y, r, g, b, a)
+		}
+	}
+	return out
+}
+
+// Rotate90CCW rotates the image 90° counter-clockwise.
+//
+// Output dimensions also swap (width = src.Height, height = src.Width).
+//
+// Inverse warp derivation (image coords: x = column right, y = row down):
+//
+//	Forward CCW:  (x_src, y_src) → (x'=y_src, y'=W-1-x_src)
+//	Inverse:      (x', y') → x_src=W-1-y', y_src=x'
+//
+// So output pixel (x', y') copies from source pixel (col=W-1-y', row=x').
+func Rotate90CCW(src *pc.PixelContainer) *pc.PixelContainer {
+	W, H := src.Width, src.Height
+	// Output: width = H (src height), height = W (src width).
+	out := pc.New(H, W)
+	for y := uint32(0); y < W; y++ { // y' ∈ [0, W)
+		for x := uint32(0); x < H; x++ { // x' ∈ [0, H)
+			// Inverse: source col = W-1-y', source row = x'
+			r, g, b, a := pc.PixelAt(src, W-1-y, x)
+			pc.SetPixel(out, x, y, r, g, b, a)
+		}
+	}
+	return out
+}
+
+// Rotate180 rotates the image 180°.  Dimensions are preserved.
+//
+// Output pixel (x', y') copies from source pixel (W-1-x', H-1-y').
+// This is equivalent to applying both FlipHorizontal and FlipVertical.
+func Rotate180(src *pc.PixelContainer) *pc.PixelContainer {
+	W, H := src.Width, src.Height
+	out := pc.New(W, H)
+	for y := uint32(0); y < H; y++ {
+		for x := uint32(0); x < W; x++ {
+			r, g, b, a := pc.PixelAt(src, W-1-x, H-1-y)
+			pc.SetPixel(out, x, y, r, g, b, a)
+		}
+	}
+	return out
+}
+
+// Crop extracts the sub-image with top-left corner (x, y), width w, height h.
+//
+// Any portion of the requested crop rectangle that falls outside the source
+// image is filled with transparent black (0, 0, 0, 0).  This matches common
+// compositing behaviour: out-of-bounds areas are treated as empty space.
+//
+// x, y are the top-left corner in source pixel coordinates.
+// w, h are the width and height of the output image in pixels.
+func Crop(src *pc.PixelContainer, x, y, w, h uint32) *pc.PixelContainer {
+	out := pc.New(w, h)
+	for oy := uint32(0); oy < h; oy++ {
+		for ox := uint32(0); ox < w; ox++ {
+			sx := x + ox
+			sy := y + oy
+			r, g, b, a := pc.PixelAt(src, sx, sy)
+			// PixelAt returns (0,0,0,0) for out-of-bounds, so no extra check needed.
+			pc.SetPixel(out, ox, oy, r, g, b, a)
+		}
+	}
+	return out
+}
+
+// Pad adds a border of fill pixels around the source image.
+//
+// top, right, bottom, left specify the number of pixels to add on each edge.
+// fill specifies the colour of the added border pixels.
+//
+// The output dimensions are:
+//
+//	outW = left + src.Width  + right
+//	outH = top  + src.Height + bottom
+//
+// The original image is placed at offset (left, top) in the output.
+func Pad(src *pc.PixelContainer, top, right, bottom, left uint32, fill Rgba8) *pc.PixelContainer {
+	outW := left + src.Width + right
+	outH := top + src.Height + bottom
+	out := pc.New(outW, outH)
+
+	// Flood the entire output with the fill colour.
+	for i := 0; i < len(out.Data); i += 4 {
+		out.Data[i] = fill.R
+		out.Data[i+1] = fill.G
+		out.Data[i+2] = fill.B
+		out.Data[i+3] = fill.A
+	}
+
+	// Copy the source image into the interior.
+	for y := uint32(0); y < src.Height; y++ {
+		for x := uint32(0); x < src.Width; x++ {
+			r, g, b, a := pc.PixelAt(src, x, y)
+			pc.SetPixel(out, left+x, top+y, r, g, b, a)
+		}
+	}
+	return out
+}
+
+// ── Continuous transforms ─────────────────────────────────────────────────────
+
+// Scale resizes the source image to outW×outH pixels using the pixel-centre
+// model and the chosen interpolation filter.
+//
+// The scale factors are:
+//
+//	sx = float64(src.Width)  / float64(outW)
+//	sy = float64(src.Height) / float64(outH)
+//
+// For output pixel (x', y'), the source coordinate is:
+//
+//	u = (x' + 0.5) * sx - 0.5
+//	v = (y' + 0.5) * sy - 0.5
+//
+// The -0.5 shift converts from a pixel-corner model (where sample 0 starts at
+// 0.0) to a pixel-centre model (where sample 0 is centred at 0.0).  Without
+// this correction, a scale-by-2 would shift the content half a pixel.
+//
+// Out-of-bounds policy is Replicate: edge pixels extend to fill any coordinates
+// that fall fractionally outside the image boundary.
+func Scale(src *pc.PixelContainer, outW, outH uint32, mode Interpolation) *pc.PixelContainer {
+	out := pc.New(outW, outH)
+	sx := float64(src.Width) / float64(outW)
+	sy := float64(src.Height) / float64(outH)
+
+	for y := uint32(0); y < outH; y++ {
+		for x := uint32(0); x < outW; x++ {
+			u := (float64(x)+0.5)*sx - 0.5
+			v := (float64(y)+0.5)*sy - 0.5
+			r, g, b, a := Sample(src, u, v, mode, Replicate)
+			pc.SetPixel(out, x, y, r, g, b, a)
+		}
+	}
+	return out
+}
+
+// Rotate rotates the source image by radians counter-clockwise (positive
+// radians = CCW following the standard mathematical convention where y points
+// up; note that in image coordinates y increases downward, so positive radians
+// rotate CW visually on screen).
+//
+// The bounds parameter controls the output canvas size:
+//
+//	Fit        — canvas expands to contain all rotated pixels
+//	CropBounds — canvas stays at src.Width × src.Height (corners may be clipped)
+//
+// The rotation is performed as an inverse warp.  Let:
+//
+//	cxIn  = (src.Width  - 1) / 2   source image centre x
+//	cyIn  = (src.Height - 1) / 2   source image centre y
+//	cxOut = (outW - 1) / 2         output image centre x
+//	cyOut = (outH - 1) / 2         output image centre y
+//
+// For output pixel (x', y'), the inverse warp to source coordinate (u, v) is:
+//
+//	dx = x' - cxOut
+//	dy = y' - cyOut
+//	u  = cxIn + cos*dx + sin*dy
+//	v  = cyIn - sin*dx + cos*dy
+//
+// Out-of-bounds coordinates use the Zero policy — they sample transparent black
+// — creating the empty corner regions visible after a non-multiple-of-90 rotation.
+func Rotate(src *pc.PixelContainer, radians float64, mode Interpolation, bounds RotateBounds) *pc.PixelContainer {
+	W := float64(src.Width)
+	H := float64(src.Height)
+	cosA := math.Cos(radians)
+	sinA := math.Sin(radians)
+	absCos := math.Abs(cosA)
+	absSin := math.Abs(sinA)
+
+	var outW, outH uint32
+	switch bounds {
+	case Fit:
+		// The bounding box of a W×H rectangle rotated by angle radians.
+		outW = uint32(math.Ceil(W*absCos + H*absSin))
+		outH = uint32(math.Ceil(W*absSin + H*absCos))
+	default: // CropBounds
+		outW = src.Width
+		outH = src.Height
+	}
+
+	out := pc.New(outW, outH)
+
+	// Continuous centres of source and output images.
+	cxIn := (W - 1) / 2
+	cyIn := (H - 1) / 2
+	cxOut := (float64(outW) - 1) / 2
+	cyOut := (float64(outH) - 1) / 2
+
+	for y := uint32(0); y < outH; y++ {
+		for x := uint32(0); x < outW; x++ {
+			dx := float64(x) - cxOut
+			dy := float64(y) - cyOut
+			// Inverse rotation: rotate by -radians
+			u := cxIn + cosA*dx + sinA*dy
+			v := cyIn - sinA*dx + cosA*dy
+			r, g, b, a := Sample(src, u, v, mode, Zero)
+			pc.SetPixel(out, x, y, r, g, b, a)
+		}
+	}
+	return out
+}
+
+// Affine applies an arbitrary 2-D affine transform to the source image.
+//
+// matrix is a 2×3 row-major transform matrix in homogeneous coordinates:
+//
+//	[ m[0][0]  m[0][1]  m[0][2] ]   [u]   [m[0][0]*x' + m[0][1]*y' + m[0][2]]
+//	[ m[1][0]  m[1][1]  m[1][2] ] × [y'] = [m[1][0]*x' + m[1][1]*y' + m[1][2]]
+//	                                 [ 1 ]
+//
+// The matrix maps output coordinates (x', y') to source coordinates (u, v).
+// This is already the inverse-warp direction, so no matrix inversion is needed.
+//
+// Common transform matrices:
+//
+//	Identity:    [[1,0,0],[0,1,0]]
+//	Translate Δx, Δy:  [[1,0,-Δx],[0,1,-Δy]]   (negate because inverse)
+//	Scale sx, sy:      [[1/sx,0,0],[0,1/sy,0]]
+//	Rotate θ (CW):     [[cos,-sin,cx(1-cos)+cy·sin],[sin,cos,cy(1-cos)-cx·sin]]
+//
+// outW and outH specify the dimensions of the output image.
+func Affine(src *pc.PixelContainer, matrix [2][3]float64, outW, outH uint32, mode Interpolation, oob OutOfBounds) *pc.PixelContainer {
+	out := pc.New(outW, outH)
+	m := matrix
+	for y := uint32(0); y < outH; y++ {
+		for x := uint32(0); x < outW; x++ {
+			u := m[0][0]*float64(x) + m[0][1]*float64(y) + m[0][2]
+			v := m[1][0]*float64(x) + m[1][1]*float64(y) + m[1][2]
+			r, g, b, a := Sample(src, u, v, mode, oob)
+			pc.SetPixel(out, x, y, r, g, b, a)
+		}
+	}
+	return out
+}
+
+// PerspectiveWarp applies a projective (perspective) homography to the source
+// image.
+//
+// h is a 3×3 homogeneous transform matrix.  For each output pixel (x', y'),
+// the source coordinate is computed via the homogeneous division:
+//
+//	[uh, vh, w] = H · [x', y', 1]ᵀ
+//	u = uh / w
+//	v = vh / w
+//
+// This is the standard perspective mapping that accounts for the foreshortening
+// effect that occurs when projecting a 3-D plane onto a 2-D sensor.
+//
+// When w ≈ 0 (at the horizon line), the sample is treated as out-of-bounds.
+// outW and outH specify the dimensions of the output image.
+func PerspectiveWarp(src *pc.PixelContainer, h [3][3]float64, outW, outH uint32, mode Interpolation, oob OutOfBounds) *pc.PixelContainer {
+	out := pc.New(outW, outH)
+	for y := uint32(0); y < outH; y++ {
+		for x := uint32(0); x < outW; x++ {
+			xf := float64(x)
+			yf := float64(y)
+			uh := h[0][0]*xf + h[0][1]*yf + h[0][2]
+			vh := h[1][0]*xf + h[1][1]*yf + h[1][2]
+			w := h[2][0]*xf + h[2][1]*yf + h[2][2]
+			if math.Abs(w) < 1e-10 {
+				// At or near the horizon: treat as Zero regardless of policy.
+				pc.SetPixel(out, x, y, 0, 0, 0, 0)
+				continue
+			}
+			u := uh / w
+			v := vh / w
+			r, g, b, a := Sample(src, u, v, mode, oob)
+			pc.SetPixel(out, x, y, r, g, b, a)
+		}
+	}
+	return out
+}

--- a/code/packages/go/image-geometric-transforms/image_geometric_transforms_test.go
+++ b/code/packages/go/image-geometric-transforms/image_geometric_transforms_test.go
@@ -1,0 +1,523 @@
+// Package imagegeometrictransforms_test contains the unit test suite for IMG04.
+//
+// Test philosophy:
+//   - Lossless operations (flip, rotate 90/180, crop, pad) are verified by
+//     checking exact byte equality after round-trip inversions.
+//   - Continuous operations (scale, rotate arbitrary angle, affine, perspective)
+//     are verified approximately: the identity transform should reproduce the
+//     source image to within ±2 per channel to allow for floating-point rounding.
+//   - Sampling tests verify mathematical properties of the interpolation kernels
+//     directly, independent of the transform wrappers.
+package imagegeometrictransforms_test
+
+import (
+	"math"
+	"testing"
+
+	igt "github.com/adhithyan15/coding-adventures/code/packages/go/image-geometric-transforms"
+	pc "github.com/adhithyan15/coding-adventures/code/packages/go/pixel-container"
+)
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+// newSolid creates a w×h image filled with a single RGBA colour.
+func newSolid(w, h uint32, r, g, b, a byte) *pc.PixelContainer {
+	img := pc.New(w, h)
+	for i := 0; i < len(img.Data); i += 4 {
+		img.Data[i] = r
+		img.Data[i+1] = g
+		img.Data[i+2] = b
+		img.Data[i+3] = a
+	}
+	return img
+}
+
+// imagesEqual returns true when every channel of every pixel is equal.
+func imagesEqual(a, b *pc.PixelContainer) bool {
+	if a.Width != b.Width || a.Height != b.Height {
+		return false
+	}
+	for i := range a.Data {
+		if a.Data[i] != b.Data[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// imagesNearlyEqual returns true when every channel of every pixel differs by
+// at most tol.  Used for transforms that pass through floating-point arithmetic.
+func imagesNearlyEqual(a, b *pc.PixelContainer, tol int) bool {
+	if a.Width != b.Width || a.Height != b.Height {
+		return false
+	}
+	for i := range a.Data {
+		diff := int(a.Data[i]) - int(b.Data[i])
+		if diff < -tol || diff > tol {
+			return false
+		}
+	}
+	return true
+}
+
+// newGradient creates a w×h image where R = x, G = y, B = 0, A = 255.
+// Useful because each pixel has a unique colour tied to its position.
+func newGradient(w, h uint32) *pc.PixelContainer {
+	img := pc.New(w, h)
+	for y := uint32(0); y < h; y++ {
+		for x := uint32(0); x < w; x++ {
+			// Clamp x, y to byte range for the test image.
+			rv := byte(x % 256)
+			gv := byte(y % 256)
+			pc.SetPixel(img, x, y, rv, gv, 0, 255)
+		}
+	}
+	return img
+}
+
+// absInt returns the absolute value of an integer.
+func absInt(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+// ── FlipHorizontal ────────────────────────────────────────────────────────────
+
+// TestFlipHorizontalPixelPosition verifies that the pixel at (0, 0) of the
+// flipped image equals the pixel at (W-1, 0) of the source image.
+func TestFlipHorizontalPixelPosition(t *testing.T) {
+	src := newGradient(5, 3)
+	got := igt.FlipHorizontal(src)
+	wantR, wantG, wantB, wantA := pc.PixelAt(src, src.Width-1, 0)
+	gotR, gotG, gotB, gotA := pc.PixelAt(got, 0, 0)
+	if gotR != wantR || gotG != wantG || gotB != wantB || gotA != wantA {
+		t.Errorf("FlipHorizontal: pixel(0,0)=(%d,%d,%d,%d) want (%d,%d,%d,%d)",
+			gotR, gotG, gotB, gotA, wantR, wantG, wantB, wantA)
+	}
+}
+
+// TestFlipHorizontalDimensions confirms that FlipHorizontal preserves image size.
+func TestFlipHorizontalDimensions(t *testing.T) {
+	src := newGradient(7, 4)
+	got := igt.FlipHorizontal(src)
+	if got.Width != src.Width || got.Height != src.Height {
+		t.Errorf("FlipHorizontal: dimensions %dx%d want %dx%d", got.Width, got.Height, src.Width, src.Height)
+	}
+}
+
+// TestFlipHorizontalDoubleIdentity applies FlipHorizontal twice and expects the
+// result to be pixel-perfect equal to the source.
+func TestFlipHorizontalDoubleIdentity(t *testing.T) {
+	src := newGradient(6, 4)
+	got := igt.FlipHorizontal(igt.FlipHorizontal(src))
+	if !imagesEqual(src, got) {
+		t.Error("FlipHorizontal applied twice should return the original image")
+	}
+}
+
+// ── FlipVertical ─────────────────────────────────────────────────────────────
+
+// TestFlipVerticalPixelPosition verifies the pixel at (0, 0) of the flipped
+// image equals the pixel at (0, H-1) of the source.
+func TestFlipVerticalPixelPosition(t *testing.T) {
+	src := newGradient(5, 5)
+	got := igt.FlipVertical(src)
+	wantR, wantG, wantB, wantA := pc.PixelAt(src, 0, src.Height-1)
+	gotR, gotG, gotB, gotA := pc.PixelAt(got, 0, 0)
+	if gotR != wantR || gotG != wantG || gotB != wantB || gotA != wantA {
+		t.Errorf("FlipVertical: pixel(0,0)=(%d,%d,%d,%d) want (%d,%d,%d,%d)",
+			gotR, gotG, gotB, gotA, wantR, wantG, wantB, wantA)
+	}
+}
+
+// TestFlipVerticalDoubleIdentity applies FlipVertical twice and expects the
+// result to be pixel-perfect equal to the source.
+func TestFlipVerticalDoubleIdentity(t *testing.T) {
+	src := newGradient(5, 7)
+	got := igt.FlipVertical(igt.FlipVertical(src))
+	if !imagesEqual(src, got) {
+		t.Error("FlipVertical applied twice should return the original image")
+	}
+}
+
+// ── Rotate90CW / Rotate90CCW ──────────────────────────────────────────────────
+
+// TestRotate90CWDimensions checks that Rotate90CW swaps width and height.
+func TestRotate90CWDimensions(t *testing.T) {
+	src := newGradient(8, 3)
+	got := igt.Rotate90CW(src)
+	if got.Width != src.Height || got.Height != src.Width {
+		t.Errorf("Rotate90CW: dimensions %dx%d want %dx%d", got.Width, got.Height, src.Height, src.Width)
+	}
+}
+
+// TestRotate90CCWDimensions checks that Rotate90CCW swaps width and height.
+func TestRotate90CCWDimensions(t *testing.T) {
+	src := newGradient(8, 3)
+	got := igt.Rotate90CCW(src)
+	if got.Width != src.Height || got.Height != src.Width {
+		t.Errorf("Rotate90CCW: dimensions %dx%d want %dx%d", got.Width, got.Height, src.Height, src.Width)
+	}
+}
+
+// TestRotate90CWThenCCWIsIdentity rotates 90° CW then 90° CCW and checks that
+// the round-trip recovers the original image exactly.
+func TestRotate90CWThenCCWIsIdentity(t *testing.T) {
+	src := newGradient(5, 7)
+	got := igt.Rotate90CCW(igt.Rotate90CW(src))
+	if !imagesEqual(src, got) {
+		t.Error("Rotate90CW followed by Rotate90CCW should be the identity")
+	}
+}
+
+// TestRotate90CWFourTimesIsIdentity verifies that four 90° CW rotations return
+// the original image (360° rotation is the identity).
+func TestRotate90CWFourTimesIsIdentity(t *testing.T) {
+	src := newGradient(4, 6)
+	got := igt.Rotate90CW(igt.Rotate90CW(igt.Rotate90CW(igt.Rotate90CW(src))))
+	if !imagesEqual(src, got) {
+		t.Error("Four Rotate90CW rotations should return the original image")
+	}
+}
+
+// TestRotate90CWPixelCorner checks a known corner pixel after a CW rotation.
+// The top-left pixel of the source should appear at the top-right of the output.
+//
+// For a 4×3 source rotated CW:
+//   - Output dimensions: 3×4 (W'=H_src=3, H'=W_src=4)
+//   - Source (0,0) should end up at output (H-1, 0) = (2, 0) after CW rotation.
+//
+// Forward CW: (x,y) → (H-1-y, x).  So source (0,0) → (H-1, 0) = (2, 0).
+func TestRotate90CWPixelCorner(t *testing.T) {
+	src := newGradient(4, 3)
+	got := igt.Rotate90CW(src)
+	// Source top-left (0,0) should land at output (H_src-1, 0) = (2, 0)
+	srcR, srcG, srcB, srcA := pc.PixelAt(src, 0, 0)
+	dstR, dstG, dstB, dstA := pc.PixelAt(got, src.Height-1, 0)
+	if srcR != dstR || srcG != dstG || srcB != dstB || srcA != dstA {
+		t.Errorf("Rotate90CW corner: got (%d,%d,%d,%d) want (%d,%d,%d,%d)",
+			dstR, dstG, dstB, dstA, srcR, srcG, srcB, srcA)
+	}
+}
+
+// ── Rotate180 ─────────────────────────────────────────────────────────────────
+
+// TestRotate180DimensionsPreserved checks that Rotate180 keeps the image size.
+func TestRotate180DimensionsPreserved(t *testing.T) {
+	src := newGradient(5, 7)
+	got := igt.Rotate180(src)
+	if got.Width != src.Width || got.Height != src.Height {
+		t.Errorf("Rotate180: dimensions changed to %dx%d", got.Width, got.Height)
+	}
+}
+
+// TestRotate180TwiceIsIdentity applies Rotate180 twice and verifies the result
+// is pixel-perfect equal to the source.
+func TestRotate180TwiceIsIdentity(t *testing.T) {
+	src := newGradient(6, 4)
+	got := igt.Rotate180(igt.Rotate180(src))
+	if !imagesEqual(src, got) {
+		t.Error("Rotate180 applied twice should return the original image")
+	}
+}
+
+// TestRotate180EqualsFlipBoth verifies that Rotate180 is equivalent to applying
+// FlipHorizontal and FlipVertical in sequence.
+func TestRotate180EqualsFlipBoth(t *testing.T) {
+	src := newGradient(5, 5)
+	via180 := igt.Rotate180(src)
+	viaFlips := igt.FlipHorizontal(igt.FlipVertical(src))
+	if !imagesEqual(via180, viaFlips) {
+		t.Error("Rotate180 should equal FlipHorizontal(FlipVertical(src))")
+	}
+}
+
+// ── Crop ──────────────────────────────────────────────────────────────────────
+
+// TestCropDimensions verifies that Crop produces exactly the requested size.
+func TestCropDimensions(t *testing.T) {
+	src := newGradient(20, 15)
+	got := igt.Crop(src, 2, 3, 8, 5)
+	if got.Width != 8 || got.Height != 5 {
+		t.Errorf("Crop: dimensions %dx%d want 8x5", got.Width, got.Height)
+	}
+}
+
+// TestCropPixelContent verifies that pixels within the crop region are taken
+// from the correct source positions.
+func TestCropPixelContent(t *testing.T) {
+	src := newGradient(20, 15)
+	x0, y0 := uint32(3), uint32(4)
+	got := igt.Crop(src, x0, y0, 5, 5)
+	// Pixel (0,0) in crop should equal pixel (x0, y0) in source.
+	sr, sg, sb, sa := pc.PixelAt(src, x0, y0)
+	gr, gg, gb, ga := pc.PixelAt(got, 0, 0)
+	if sr != gr || sg != gg || sb != gb || sa != ga {
+		t.Errorf("Crop pixel (0,0): got (%d,%d,%d,%d) want (%d,%d,%d,%d)",
+			gr, gg, gb, ga, sr, sg, sb, sa)
+	}
+}
+
+// TestCropOutOfBoundsFilledWithZero verifies that out-of-bounds crop areas are
+// filled with transparent black.
+func TestCropOutOfBoundsFilledWithZero(t *testing.T) {
+	src := newSolid(4, 4, 200, 100, 50, 255)
+	// Request a crop that extends beyond the source boundary.
+	got := igt.Crop(src, 2, 2, 6, 6)
+	// Pixel (5, 5) is completely outside the source.
+	r, g, b, a := pc.PixelAt(got, 5, 5)
+	if r != 0 || g != 0 || b != 0 || a != 0 {
+		t.Errorf("Crop OOB pixel: got (%d,%d,%d,%d) want (0,0,0,0)", r, g, b, a)
+	}
+}
+
+// ── Pad ───────────────────────────────────────────────────────────────────────
+
+// TestPadDimensions verifies the output is sized to src + border.
+func TestPadDimensions(t *testing.T) {
+	src := newSolid(10, 8, 100, 100, 100, 255)
+	got := igt.Pad(src, 2, 3, 4, 5, igt.Rgba8{0, 0, 0, 255})
+	wantW := uint32(5 + 10 + 3)
+	wantH := uint32(2 + 8 + 4)
+	if got.Width != wantW || got.Height != wantH {
+		t.Errorf("Pad: dimensions %dx%d want %dx%d", got.Width, got.Height, wantW, wantH)
+	}
+}
+
+// TestPadFillColor checks that border pixels carry the fill colour.
+func TestPadFillColor(t *testing.T) {
+	fill := igt.Rgba8{R: 255, G: 128, B: 64, A: 200}
+	src := newSolid(4, 4, 10, 20, 30, 255)
+	got := igt.Pad(src, 3, 3, 3, 3, fill)
+	// Top-left corner pixel should be the fill colour.
+	r, g, b, a := pc.PixelAt(got, 0, 0)
+	if r != fill.R || g != fill.G || b != fill.B || a != fill.A {
+		t.Errorf("Pad fill corner: got (%d,%d,%d,%d) want (%d,%d,%d,%d)",
+			r, g, b, a, fill.R, fill.G, fill.B, fill.A)
+	}
+}
+
+// TestPadOriginalPreserved checks that the interior pixels match the source.
+func TestPadOriginalPreserved(t *testing.T) {
+	src := newGradient(4, 4)
+	top, left := uint32(2), uint32(3)
+	got := igt.Pad(src, top, 2, 2, left, igt.Rgba8{0, 0, 0, 255})
+	// Pixel at source (1, 1) should appear at output (left+1, top+1).
+	sr, sg, sb, sa := pc.PixelAt(src, 1, 1)
+	gr, gg, gb, ga := pc.PixelAt(got, left+1, top+1)
+	if sr != gr || sg != gg || sb != gb || sa != ga {
+		t.Errorf("Pad interior: got (%d,%d,%d,%d) want (%d,%d,%d,%d)",
+			gr, gg, gb, ga, sr, sg, sb, sa)
+	}
+}
+
+// ── Scale ─────────────────────────────────────────────────────────────────────
+
+// TestScaleUpDimensions verifies that Scale produces the requested output size.
+func TestScaleUpDimensions(t *testing.T) {
+	src := newSolid(4, 4, 128, 128, 128, 255)
+	got := igt.Scale(src, 8, 8, igt.Nearest)
+	if got.Width != 8 || got.Height != 8 {
+		t.Errorf("Scale 4→8: dimensions %dx%d want 8x8", got.Width, got.Height)
+	}
+}
+
+// TestScaleDownDimensions verifies Scale produces the correct smaller output.
+func TestScaleDownDimensions(t *testing.T) {
+	src := newSolid(100, 50, 128, 128, 128, 255)
+	got := igt.Scale(src, 25, 12, igt.Bilinear)
+	if got.Width != 25 || got.Height != 12 {
+		t.Errorf("Scale down: dimensions %dx%d want 25x12", got.Width, got.Height)
+	}
+}
+
+// TestScaleReplicateNoPanic checks that Scale with Replicate OOB doesn't panic.
+// This is a regression guard against any accidental out-of-bounds slice access.
+func TestScaleReplicateNoPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Scale panicked: %v", r)
+		}
+	}()
+	src := newGradient(3, 3)
+	_ = igt.Scale(src, 7, 7, igt.Bilinear)
+}
+
+// TestScaleBicubicNoPanic checks that bicubic Scale doesn't panic.
+func TestScaleBicubicNoPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Scale bicubic panicked: %v", r)
+		}
+	}()
+	src := newGradient(5, 5)
+	_ = igt.Scale(src, 10, 10, igt.Bicubic)
+}
+
+// ── Rotate (arbitrary angle) ──────────────────────────────────────────────────
+
+// TestRotateZeroIsApproxIdentity checks that a 0-radian rotation leaves the
+// image content approximately unchanged (within ±2 per channel for sRGB
+// round-trip rounding).
+func TestRotateZeroIsApproxIdentity(t *testing.T) {
+	src := newSolid(8, 8, 100, 150, 200, 255)
+	got := igt.Rotate(src, 0, igt.Bilinear, igt.CropBounds)
+	if !imagesNearlyEqual(src, got, 2) {
+		t.Error("Rotate(0) should be approximately the identity")
+	}
+}
+
+// TestRotateFitDimensionsLarger checks that Fit mode produces a canvas at
+// least as large as the source for a non-trivial angle.
+func TestRotateFitDimensionsLarger(t *testing.T) {
+	src := newSolid(10, 10, 200, 100, 50, 255)
+	got := igt.Rotate(src, math.Pi/4, igt.Nearest, igt.Fit)
+	// A 10×10 image rotated 45° needs a bounding box of ceil(10*√2) ≈ 15 pixels.
+	if got.Width < src.Width || got.Height < src.Height {
+		t.Errorf("Rotate Fit 45°: output %dx%d should not be smaller than source %dx%d",
+			got.Width, got.Height, src.Width, src.Height)
+	}
+}
+
+// TestRotateCropSameDimensions verifies Crop mode preserves source dimensions.
+func TestRotateCropSameDimensions(t *testing.T) {
+	src := newSolid(10, 8, 100, 100, 100, 255)
+	got := igt.Rotate(src, math.Pi/6, igt.Nearest, igt.CropBounds)
+	if got.Width != src.Width || got.Height != src.Height {
+		t.Errorf("Rotate CropBounds: dimensions %dx%d want %dx%d", got.Width, got.Height, src.Width, src.Height)
+	}
+}
+
+// ── Affine ────────────────────────────────────────────────────────────────────
+
+// TestAffineIdentityIsApproxIdentity verifies that the identity matrix produces
+// an image nearly identical to the source.
+func TestAffineIdentityIsApproxIdentity(t *testing.T) {
+	src := newSolid(8, 8, 100, 150, 200, 255)
+	identity := [2][3]float64{{1, 0, 0}, {0, 1, 0}}
+	got := igt.Affine(src, identity, src.Width, src.Height, igt.Bilinear, igt.Replicate)
+	if !imagesNearlyEqual(src, got, 2) {
+		t.Error("Affine with identity matrix should be approximately the identity")
+	}
+}
+
+// TestAffineDimensions verifies that Affine produces the requested output size.
+func TestAffineDimensions(t *testing.T) {
+	src := newSolid(10, 10, 50, 50, 50, 255)
+	identity := [2][3]float64{{1, 0, 0}, {0, 1, 0}}
+	got := igt.Affine(src, identity, 15, 12, igt.Nearest, igt.Zero)
+	if got.Width != 15 || got.Height != 12 {
+		t.Errorf("Affine dimensions: got %dx%d want 15x12", got.Width, got.Height)
+	}
+}
+
+// ── PerspectiveWarp ───────────────────────────────────────────────────────────
+
+// TestPerspectiveWarpIdentityIsApproxIdentity verifies that the 3×3 identity
+// homography reproduces the source image approximately.
+func TestPerspectiveWarpIdentityIsApproxIdentity(t *testing.T) {
+	src := newSolid(8, 8, 200, 100, 50, 255)
+	hIdentity := [3][3]float64{{1, 0, 0}, {0, 1, 0}, {0, 0, 1}}
+	got := igt.PerspectiveWarp(src, hIdentity, src.Width, src.Height, igt.Bilinear, igt.Replicate)
+	if !imagesNearlyEqual(src, got, 2) {
+		t.Error("PerspectiveWarp with identity H should be approximately the identity")
+	}
+}
+
+// TestPerspectiveWarpDimensions checks that PerspectiveWarp produces the
+// requested output dimensions.
+func TestPerspectiveWarpDimensions(t *testing.T) {
+	src := newSolid(10, 10, 50, 50, 50, 255)
+	hIdentity := [3][3]float64{{1, 0, 0}, {0, 1, 0}, {0, 0, 1}}
+	got := igt.PerspectiveWarp(src, hIdentity, 14, 9, igt.Nearest, igt.Zero)
+	if got.Width != 14 || got.Height != 9 {
+		t.Errorf("PerspectiveWarp dimensions: got %dx%d want 14x9", got.Width, got.Height)
+	}
+}
+
+// ── Sample / interpolation unit tests ────────────────────────────────────────
+
+// TestSampleNearestExactPixel verifies that Nearest-neighbour sampling at an
+// exact integer pixel coordinate returns that pixel's values unchanged.
+func TestSampleNearestExactPixel(t *testing.T) {
+	src := pc.New(4, 4)
+	pc.SetPixel(src, 2, 1, 10, 20, 30, 255)
+	r, g, b, a := igt.Sample(src, 2, 1, igt.Nearest, igt.Zero)
+	if r != 10 || g != 20 || b != 30 || a != 255 {
+		t.Errorf("Sample Nearest at (2,1): got (%d,%d,%d,%d) want (10,20,30,255)", r, g, b, a)
+	}
+}
+
+// TestSampleBilinearMidpointBlend verifies bilinear interpolation at the exact
+// midpoint between two pixels on a horizontal gradient.
+//
+// We use a 2×1 image: pixel (0,0) = (0, 0, 0, 255) and (1,0) = (254, 0, 0, 255).
+// The midpoint in continuous coordinates is u = 0.5, v = 0.
+// Bilinear should blend the two pixels 50/50 in linear space.
+//
+// Decoded linear values: decode(0) = 0.0, decode(254) ≈ 0.9911
+// Midpoint linear: 0.4956  → encode ≈ 186 in sRGB
+// We allow ±4 to account for the specific LUT rounding.
+func TestSampleBilinearMidpointBlend(t *testing.T) {
+	src := pc.New(2, 1)
+	pc.SetPixel(src, 0, 0, 0, 0, 0, 255)
+	pc.SetPixel(src, 1, 0, 254, 0, 0, 255)
+
+	r, _, _, _ := igt.Sample(src, 0.5, 0, igt.Bilinear, igt.Replicate)
+
+	// Compute expected: 50% blend in linear light of 0 and 254.
+	// linear(0) = 0.0, linear(254) ≈ 0.9911
+	// mid_linear = 0.4956
+	// encode(0.4956) ≈ 186 (sRGB)
+	// Allow ±4 tolerance.
+	expected := 186
+	diff := absInt(int(r) - expected)
+	if diff > 4 {
+		t.Errorf("Bilinear midpoint blend: got R=%d want ~%d (diff=%d)", r, expected, diff)
+	}
+}
+
+// TestSampleNearestOOBZeroReturnsBlack verifies that Nearest sampling outside
+// image bounds with the Zero policy returns transparent black.
+func TestSampleNearestOOBZeroReturnsBlack(t *testing.T) {
+	src := newSolid(4, 4, 200, 100, 50, 255)
+	r, g, b, a := igt.Sample(src, -1, -1, igt.Nearest, igt.Zero)
+	if r != 0 || g != 0 || b != 0 || a != 0 {
+		t.Errorf("Sample OOB Zero: got (%d,%d,%d,%d) want (0,0,0,0)", r, g, b, a)
+	}
+}
+
+// TestSampleNearestOOBReplicateReturnsEdge verifies that Nearest sampling
+// outside image bounds with Replicate returns the nearest edge pixel.
+func TestSampleNearestOOBReplicateReturnsEdge(t *testing.T) {
+	src := pc.New(4, 4)
+	pc.SetPixel(src, 0, 0, 42, 84, 126, 255)
+	r, g, b, a := igt.Sample(src, -5, -5, igt.Nearest, igt.Replicate)
+	if r != 42 || g != 84 || b != 126 || a != 255 {
+		t.Errorf("Sample OOB Replicate: got (%d,%d,%d,%d) want (42,84,126,255)", r, g, b, a)
+	}
+}
+
+// TestSampleBicubicExactCenter verifies that bicubic sampling at an exact pixel
+// centre returns approximately the pixel's own value.
+// For a solid image, all 4×4 neighbours are identical so the spline collapses
+// to the exact value.
+func TestSampleBicubicExactCenter(t *testing.T) {
+	src := newSolid(8, 8, 180, 90, 45, 255)
+	r, g, b, a := igt.Sample(src, 4, 4, igt.Bicubic, igt.Replicate)
+	if absInt(int(r)-180) > 2 || absInt(int(g)-90) > 2 || absInt(int(b)-45) > 2 || a != 255 {
+		t.Errorf("Bicubic centre on solid: got (%d,%d,%d,%d) want ~(180,90,45,255)", r, g, b, a)
+	}
+}
+
+// TestRotate360IsApproxIdentity rotates a full 2π and checks the result is
+// approximately the identity (within ±2 per channel).
+func TestRotate360IsApproxIdentity(t *testing.T) {
+	src := newSolid(6, 6, 120, 80, 200, 255)
+	got := igt.Rotate(src, 2*math.Pi, igt.Bilinear, igt.CropBounds)
+	if !imagesNearlyEqual(src, got, 3) {
+		t.Error("Rotate(2π) should be approximately the identity")
+	}
+}

--- a/code/packages/ruby/image_geometric_transforms/BUILD
+++ b/code/packages/ruby/image_geometric_transforms/BUILD
@@ -1,0 +1,1 @@
+ruby -I lib -I ../pixel_container/lib test/test_image_geometric_transforms.rb

--- a/code/packages/ruby/image_geometric_transforms/CHANGELOG.md
+++ b/code/packages/ruby/image_geometric_transforms/CHANGELOG.md
@@ -1,0 +1,87 @@
+# Changelog — ImageGeometricTransforms (Ruby)
+
+All notable changes are documented here.
+Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [0.1.0] — 2026-04-20
+
+### Added
+
+- **`ImageGeometricTransforms.flip_horizontal(src)`** — Mirror image left-to-right
+  by remapping each pixel `I[x, y]` to `O[W-1-x, y]`.  Raw-byte copy; no sRGB
+  conversion.
+
+- **`ImageGeometricTransforms.flip_vertical(src)`** — Mirror image top-to-bottom.
+  Raw-byte copy.
+
+- **`ImageGeometricTransforms.rotate_90_cw(src)`** — Rotate 90° clockwise.  Output
+  dimensions swap (W'=H, H'=W).  Backward mapping: `O[x',y'] = I[y', W-1-x']`.
+  Raw-byte copy.
+
+- **`ImageGeometricTransforms.rotate_90_ccw(src)`** — Rotate 90° counter-clockwise.
+  Backward mapping: `O[x',y'] = I[H-1-y', x']`.  Raw-byte copy.
+
+- **`ImageGeometricTransforms.rotate_180(src)`** — Rotate 180°.  Same dimensions.
+  Backward mapping: `O[x,y] = I[W-1-x, H-1-y]`.  Raw-byte copy.
+
+- **`ImageGeometricTransforms.crop(src, x0, y0, w, h)`** — Extract a `w×h`
+  rectangle with top-left at `(x0, y0)`.  Pixels outside source are `[0,0,0,0]`.
+
+- **`ImageGeometricTransforms.pad(src, top, right, bottom, left, fill:)`** — Add a
+  border of configurable width.  Border pixels receive `fill` (default transparent
+  black).  Output size: `W' = left+W+right`, `H' = top+H+bottom`.
+
+- **`ImageGeometricTransforms.scale(src, out_w, out_h, mode:)`** — Resize using the
+  pixel-centre model.  Default mode `:bilinear`.  OOB strategy `:replicate`.
+
+- **`ImageGeometricTransforms.rotate(src, radians, mode:, bounds:)`** — Rotate
+  counter-clockwise about image centre.
+  - `bounds: :fit` (default) — canvas sized to `ceil(W|cos|+H|sin|)` ×
+    `ceil(W|sin|+H|cos|)` so no pixels are clipped.
+  - `bounds: :crop` — canvas matches input dimensions.
+  - OOB strategy `:zero` (outside areas become transparent).
+
+- **`ImageGeometricTransforms.affine(src, matrix, out_w, out_h, mode:, oob:)`** —
+  Apply a 2×3 affine matrix.  Backward mapping solved via 2×2 inverse.  Handles
+  singular matrices gracefully (transparent output).
+
+- **`ImageGeometricTransforms.perspective_warp(src, h, out_w, out_h, mode:, oob:)`** —
+  Apply a 3×3 projective homography.  Backward mapping computed via full 3×3
+  matrix inverse (Cramer's rule).  Handles singular matrices and degenerate
+  `w̃ ≈ 0` gracefully.
+
+- **`SRGB_TO_LINEAR`** — 256-entry precomputed LUT for sRGB→linear decoding,
+  frozen at module load.
+
+- Private helpers: `decode(b)`, `encode(v)`, `resolve_coord(x, max, oob)`,
+  `catmull_rom(d)`, `sample_nearest`, `sample_bilinear`, `sample_bicubic`,
+  `sample` dispatch.
+
+- Interpolation modes: `:nearest`, `:bilinear`, `:bicubic` (Catmull-Rom 4×4).
+
+- Out-of-bounds modes: `:zero`, `:replicate`, `:reflect`, `:wrap`.
+
+- 37 minitest tests covering: flip identity round-trips, rotate-90 CW/CCW
+  round-trip, rotate-180 twice identity, pixel mapping correctness, crop
+  dimensions and OOB behaviour, pad dimensions and fill, scale up/down
+  dimensions, scale solid colour fidelity, rotate zero identity, rotate fit
+  canvas enlargement, rotate crop size preservation, affine identity and
+  translation, perspective-warp identity, nearest-neighbour exact pixel,
+  bilinear midpoint gradient, all four OOB modes smoke-tested, bicubic
+  smoke test.
+
+### Dependencies
+
+- `coding-adventures-pixel-container` (loaded via `LOAD_PATH`)
+
+### Notes
+
+- All continuous transforms use backward (inverse) mapping to avoid holes.
+- Bilinear and bicubic blending is performed in linear light; alpha is always
+  treated as linear.
+- The Catmull-Rom kernel is piecewise cubic, yielding C1-continuous results.
+- Ruby's `%` operator always returns a non-negative value for a positive
+  divisor, making `:wrap` OOB trivial.

--- a/code/packages/ruby/image_geometric_transforms/README.md
+++ b/code/packages/ruby/image_geometric_transforms/README.md
@@ -1,0 +1,138 @@
+# CodingAdventures::ImageGeometricTransforms
+
+IMG04 — Geometric transforms on RGBA8 PixelContainers.
+
+Implements lossless pixel-copy operations (flip, rotate-90, crop, pad) and
+continuous backward-mapping transforms (scale, rotate, affine,
+perspective-warp) with three interpolation modes and four out-of-bounds
+strategies, all using correct sRGB ↔ linear-light conversion where required.
+
+## Stack position
+
+```
+pixel_container  (IMG00)   — raw RGBA8 buffer
+     ↓
+image_point_ops  (IMG03)   — per-pixel transforms
+     ↓
+image_geometric_transforms (IMG04)  ← this package
+```
+
+## Quick Start
+
+```ruby
+$LOAD_PATH.unshift "path/to/pixel_container/lib"
+require "coding_adventures/pixel_container"
+require "coding_adventures/image_geometric_transforms"
+
+PC = CodingAdventures::PixelContainer
+GT = CodingAdventures::ImageGeometricTransforms
+
+src = PC.create(100, 100)
+# ... fill src with pixels ...
+
+# Flip left-to-right
+flipped = GT.flip_horizontal(src)
+
+# Rotate 90° clockwise (dimensions swap: 100×100 → 100×100)
+rotated = GT.rotate_90_cw(src)
+
+# Scale to 200×150 using bilinear interpolation (default)
+scaled = GT.scale(src, 200, 150)
+
+# Scale using nearest-neighbour (fast, pixel-art style)
+scaled_nn = GT.scale(src, 200, 150, mode: :nearest)
+
+# Rotate 30° with fit canvas (no clipping)
+dst = GT.rotate(src, Math::PI / 6, bounds: :fit)
+
+# Affine transform: 2D shear
+matrix = [[1.0, 0.3, 0.0],   # x' = x + 0.3*y
+          [0.0, 1.0, 0.0]]   # y' = y
+sheared = GT.affine(src, matrix, src.width, src.height)
+
+# Perspective warp
+h = [[1.0, 0.0, 0.0],
+     [0.0, 1.0, 0.0],
+     [0.0, 0.0, 1.0]]  # identity
+warped = GT.perspective_warp(src, h, src.width, src.height)
+```
+
+## API
+
+### Lossless transforms (raw-byte copy, no colour-space conversion)
+
+| Method | Description |
+|---|---|
+| `flip_horizontal(src)` | Mirror left-to-right |
+| `flip_vertical(src)` | Mirror top-to-bottom |
+| `rotate_90_cw(src)` | Rotate 90° clockwise; dimensions swap |
+| `rotate_90_ccw(src)` | Rotate 90° counter-clockwise; dimensions swap |
+| `rotate_180(src)` | Rotate 180°; same dimensions |
+| `crop(src, x0, y0, w, h)` | Extract w×h rectangle at (x0, y0) |
+| `pad(src, top, right, bottom, left, fill: [0,0,0,0])` | Add border pixels |
+
+### Continuous transforms (backward mapping with interpolation)
+
+| Method | Signature | Description |
+|---|---|---|
+| `scale` | `(src, out_w, out_h, mode: :bilinear)` | Resize to out_w×out_h |
+| `rotate` | `(src, radians, mode: :bilinear, bounds: :fit)` | Rotate about centre |
+| `affine` | `(src, matrix, out_w, out_h, mode: :bilinear, oob: :replicate)` | 2×3 affine |
+| `perspective_warp` | `(src, h, out_w, out_h, mode: :bilinear, oob: :replicate)` | 3×3 homography |
+
+### Interpolation modes
+
+| Symbol | Description |
+|---|---|
+| `:nearest` | Nearest-neighbour — fast, blocky on scale-up |
+| `:bilinear` | 2×2 weighted average — smooth, slight blur |
+| `:bicubic` | 4×4 Catmull-Rom spline — sharper than bilinear |
+
+### Out-of-bounds (OOB) strategies
+
+| Symbol | Description |
+|---|---|
+| `:zero` | Outside pixels are transparent black `[0,0,0,0]` |
+| `:replicate` | Clamp to the nearest edge pixel |
+| `:reflect` | Mirror at each edge (period = 2 * dimension) |
+| `:wrap` | Tile the image periodically |
+
+## Design notes
+
+### Pixel-centre model
+
+All continuous transforms use the pixel-centre coordinate convention:
+pixel `(x, y)` occupies the unit square centred at `(x + 0.5, y + 0.5)`.
+The mapping for `scale(src, out_w, out_h)` is therefore:
+
+```
+u = (x + 0.5) * (W / out_w) - 0.5
+v = (y + 0.5) * (H / out_h) - 0.5
+```
+
+This ensures the top-left output pixel maps to the top-left input pixel,
+not to the gap between pixels, which prevents a systematic half-pixel offset
+visible as a slight drift in repeated transforms.
+
+### sRGB ↔ linear light
+
+Blending (bilinear, bicubic) is performed in linear light. Doing it in the
+non-linear sRGB encoding produces visually dark transitions — the classic
+"too-dark midpoint" problem. The module pre-computes a 256-entry decode LUT
+to avoid repeated calls to the gamma-expansion formula.
+
+The alpha channel is always treated as linear (it is never gamma-encoded).
+
+### Backward mapping
+
+All continuous transforms iterate over output pixels and compute the
+corresponding source coordinate. This avoids holes (empty output pixels)
+that would occur in forward mapping when the warp contracts the image.
+
+## Running the tests
+
+```bash
+ruby -I lib -I ../pixel_container/lib test/test_image_geometric_transforms.rb
+```
+
+37 tests, >113 assertions.

--- a/code/packages/ruby/image_geometric_transforms/coding-adventures-image-geometric-transforms.gemspec
+++ b/code/packages/ruby/image_geometric_transforms/coding-adventures-image-geometric-transforms.gemspec
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |spec|
+  spec.name          = "coding-adventures-image-geometric-transforms"
+  spec.version       = "0.1.0"
+  spec.authors       = ["Adhithya Rajasekaran"]
+  spec.summary       = "IMG04: Geometric transforms on PixelContainer"
+  spec.description   = "Flip, rotate, crop, pad, scale, rotate, affine, and perspective-warp " \
+                       "operations on RGBA8 PixelContainers. Nearest, bilinear, and bicubic " \
+                       "(Catmull-Rom) interpolation with correct sRGB ↔ linear-light conversion."
+  spec.homepage      = "https://github.com/adhithyan15/coding-adventures"
+  spec.license       = "MIT"
+  spec.required_ruby_version = ">= 3.0.0"
+  spec.files         = Dir["lib/**/*.rb", "README.md", "CHANGELOG.md"]
+  spec.require_paths = ["lib"]
+  spec.metadata      = {
+    "source_code_uri"       => "https://github.com/adhithyan15/coding-adventures",
+    "rubygems_mfa_required" => "true"
+  }
+
+  spec.add_development_dependency "minitest",  "~> 5.0"
+  spec.add_development_dependency "simplecov", "~> 0.22"
+  spec.add_development_dependency "rake",      "~> 13.0"
+end

--- a/code/packages/ruby/image_geometric_transforms/lib/coding_adventures/image_geometric_transforms.rb
+++ b/code/packages/ruby/image_geometric_transforms/lib/coding_adventures/image_geometric_transforms.rb
@@ -1,0 +1,699 @@
+# frozen_string_literal: true
+
+require "coding_adventures/pixel_container"
+
+# =============================================================================
+# CodingAdventures::ImageGeometricTransforms — IMG04 geometric transforms.
+# =============================================================================
+#
+# A geometric transform maps every pixel in an output image back to a
+# (possibly fractional) source coordinate in the input image, samples that
+# location, and writes the result.  This "backward mapping" approach avoids
+# holes and double-sampling artefacts that would occur if we pushed each input
+# pixel forward.
+#
+# ## Coordinate conventions
+#
+# All pixel coordinates use the "pixel-centre" model:
+#
+#   pixel (x, y) occupies the unit square centred at (x + 0.5, y + 0.5)
+#   within the image's [0, W] × [0, H] continuous domain.
+#
+# The centre of a W×H image therefore lies at (W/2.0, H/2.0).
+#
+# ## sRGB ↔ linear light
+#
+# Whenever pixels are blended (bilinear or bicubic interpolation), we must
+# first convert from the non-linear sRGB encoding to linear light, perform
+# the weighted average, then convert back.  Blending in sRGB produces
+# visually dark artefacts at transitions (the "too-dark midpoint" problem).
+#
+# The transforms that copy entire pixels without mixing (flip, rotate-90,
+# crop, pad) are lossless raw-byte copies that bypass sRGB conversion.
+#
+# ## Out-of-bounds strategies (oob)
+#
+#   :zero       — pixels outside the image are transparent black [0,0,0,0]
+#   :replicate  — clamp coordinates to the nearest edge pixel
+#   :reflect    — mirror at each edge (useful for filter borders)
+#   :wrap       — tile the image periodically
+#
+# ## Interpolation modes
+#
+#   :nearest    — snap to the nearest integer pixel (fast, blocky on scale-up)
+#   :bilinear   — 2×2 weighted average (smooth, some blur)
+#   :bicubic    — 4×4 Catmull-Rom spline (sharper edges than bilinear)
+#
+# ## Operations
+#
+# Lossless (raw-byte copy, no sRGB conversion):
+#   flip_horizontal, flip_vertical, rotate_90_cw, rotate_90_ccw,
+#   rotate_180, crop, pad
+#
+# Continuous (backward mapping with interpolation):
+#   scale, rotate, affine, perspective_warp
+# =============================================================================
+
+module CodingAdventures
+  module ImageGeometricTransforms
+    PC = CodingAdventures::PixelContainer
+
+    VERSION = "0.1.0"
+
+    # ── sRGB ↔ linear-light ───────────────────────────────────────────────────
+    #
+    # We precompute a 256-entry lookup table for sRGB→linear decoding.
+    # The piecewise formula from the IEC 61966-2-1 standard:
+    #
+    #   If c/255 ≤ 0.04045:  linear = c / 255 / 12.92
+    #   Otherwise:           linear = ((c/255 + 0.055) / 1.055) ^ 2.4
+    #
+    # The LUT saves ~256 floating-point exponentiations per pixel compared
+    # to calling the formula directly.
+    SRGB_TO_LINEAR = (0..255).map { |i|
+      c = i / 255.0
+      c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055)**2.4
+    }.freeze
+
+    # ── Private helpers ───────────────────────────────────────────────────────
+    # These are internal utilities not part of the public API.
+    # We define them as module_function so they can be called with
+    # `decode(b)` inside the module without `self.`.
+
+    class << self
+      private
+
+      # -----------------------------------------------------------------------
+      # decode(b) → Float
+      #
+      # Convert a single sRGB byte (0..255) to a linear-light Float (0.0..1.0).
+      # Uses the precomputed LUT for speed.
+      # -----------------------------------------------------------------------
+      def decode(b)
+        SRGB_TO_LINEAR[b]
+      end
+
+      # -----------------------------------------------------------------------
+      # encode(v) → Integer
+      #
+      # Convert a linear-light Float (0.0..1.0) back to an sRGB byte (0..255).
+      # The inverse of decode.  Clamps out-of-range values from interpolation
+      # overshoot (Catmull-Rom can produce values slightly outside [0,1]).
+      #
+      #   If v ≤ 0.0031308:  sRGB = v * 12.92
+      #   Otherwise:         sRGB = 1.055 * v^(1/2.4) − 0.055
+      # -----------------------------------------------------------------------
+      def encode(v)
+        v = 0.0 if v < 0.0
+        v = 1.0 if v > 1.0
+        c = if v <= 0.0031308
+              v * 12.92
+            else
+              1.055 * v**(1.0 / 2.4) - 0.055
+            end
+        (c * 255.0).round
+      end
+
+      # -----------------------------------------------------------------------
+      # resolve_coord(x, max, oob) → Integer or nil
+      #
+      # Map a (possibly out-of-bounds) integer coordinate to a valid source
+      # index in [0, max-1], or return nil if the pixel should be transparent.
+      #
+      # Parameters:
+      #   x   — the (integer) coordinate to resolve
+      #   max — the dimension length (width or height)
+      #   oob — one of :zero, :replicate, :reflect, :wrap
+      #
+      # Strategy details:
+      #
+      #   :zero      — outside range → nil (caller returns [0,0,0,0])
+      #   :replicate — clamp to the nearest valid index
+      #   :reflect   — mirror about each edge; the period is 2*max
+      #                so pixel 0 and pixel max-1 are "wall" pixels
+      #   :wrap      — modulo arithmetic; Ruby's % always returns
+      #                non-negative when the divisor is positive
+      # -----------------------------------------------------------------------
+      def resolve_coord(x, max, oob)
+        case oob
+        when :zero
+          return nil if x < 0 || x >= max
+          x
+        when :replicate
+          x.clamp(0, max - 1)
+        when :reflect
+          # Fold x into [0, 2*max) and then map the upper half back.
+          period = 2 * max
+          x = x % period
+          x += period if x < 0   # Ruby % handles negatives, but belt-and-suspenders
+          x = period - 1 - x if x >= max
+          x
+        when :wrap
+          x % max  # Ruby's modulo is always non-negative for positive max
+        end
+      end
+
+      # -----------------------------------------------------------------------
+      # catmull_rom(d) → Float
+      #
+      # Catmull-Rom spline weight for a neighbour at distance |d| from the
+      # sample point.  The piecewise cubic is:
+      #
+      #   |d| < 1:  1.5*|d|^3 − 2.5*|d|^2 + 1
+      #   |d| < 2: -0.5*|d|^3 + 2.5*|d|^2 − 4*|d| + 2
+      #   else:     0
+      #
+      # The weights for the 4 neighbours at offsets -1, 0, +1, +2 (relative
+      # to the floor of u) sum to exactly 1.0 when no extrapolation occurs.
+      # -----------------------------------------------------------------------
+      def catmull_rom(d)
+        d = d.abs
+        if d < 1.0
+          1.5 * d**3 - 2.5 * d**2 + 1.0
+        elsif d < 2.0
+          -0.5 * d**3 + 2.5 * d**2 - 4.0 * d + 2.0
+        else
+          0.0
+        end
+      end
+
+      # -----------------------------------------------------------------------
+      # sample_nearest(img, u, v, oob) → [r, g, b, a]
+      #
+      # Round the continuous coordinates (u, v) to the nearest integer pixel
+      # and return its raw RGBA bytes.  No sRGB conversion is needed because
+      # we copy an exact pixel value unchanged.
+      #
+      # Parameters:
+      #   img — PixelContainer
+      #   u   — continuous x coordinate in image space
+      #   v   — continuous y coordinate in image space
+      #   oob — out-of-bounds mode
+      # -----------------------------------------------------------------------
+      def sample_nearest(img, u, v, oob)
+        xi = u.round
+        yi = v.round
+        rx = resolve_coord(xi, img.width,  oob)
+        ry = resolve_coord(yi, img.height, oob)
+        return [0, 0, 0, 0] if rx.nil? || ry.nil?
+        PC.pixel_at(img, rx, ry)
+      end
+
+      # -----------------------------------------------------------------------
+      # sample_bilinear(img, u, v, oob) → [r, g, b, a]
+      #
+      # Bilinear interpolation: sample a 2×2 grid of neighbours and compute
+      # a weighted average in linear light.
+      #
+      # Let (x0, y0) = floor of (u, v).  The fractional part (fx, fy) gives
+      # the weights for the four corners:
+      #
+      #   (1-fx)(1-fy) · I[x0,  y0  ]
+      #   fx   (1-fy) · I[x0+1, y0  ]
+      #   (1-fx)  fy  · I[x0,   y0+1]
+      #   fx      fy  · I[x0+1, y0+1]
+      #
+      # RGB channels are blended in linear light; alpha is blended linearly
+      # (alpha is never gamma-encoded).
+      # -----------------------------------------------------------------------
+      def sample_bilinear(img, u, v, oob)
+        x0 = u.floor
+        y0 = v.floor
+        fx = u - x0
+        fy = v - y0
+
+        # Gather 2×2 neighbourhood (may hit OOB handling)
+        corners = [
+          [x0,     y0    ],
+          [x0 + 1, y0    ],
+          [x0,     y0 + 1],
+          [x0 + 1, y0 + 1]
+        ]
+        weights = [
+          (1.0 - fx) * (1.0 - fy),
+          fx         * (1.0 - fy),
+          (1.0 - fx) * fy,
+          fx         * fy
+        ]
+
+        r_lin = g_lin = b_lin = a_lin = 0.0
+        corners.each_with_index do |(cx, cy), k|
+          rx = resolve_coord(cx, img.width,  oob)
+          ry = resolve_coord(cy, img.height, oob)
+          pix = (rx.nil? || ry.nil?) ? [0, 0, 0, 0] : PC.pixel_at(img, rx, ry)
+          w = weights[k]
+          r_lin += decode(pix[0]) * w
+          g_lin += decode(pix[1]) * w
+          b_lin += decode(pix[2]) * w
+          a_lin += pix[3] * w    # alpha is linear by convention
+        end
+
+        [encode(r_lin), encode(g_lin), encode(b_lin), a_lin.round.clamp(0, 255)]
+      end
+
+      # -----------------------------------------------------------------------
+      # sample_bicubic(img, u, v, oob) → [r, g, b, a]
+      #
+      # Bicubic (Catmull-Rom) interpolation: sample a 4×4 grid of neighbours.
+      #
+      # Let (x0, y0) = floor of (u, v).  The four column offsets relative to
+      # x0 are {-1, 0, +1, +2}, same for rows.  The Catmull-Rom weight for
+      # column offset dx is catmull_rom(fx - dx) where fx = u - x0.
+      #
+      # The weights are separable: w(x,y) = wx(dx) · wy(dy), so we can
+      # first compute a 4-element row blend, then blend the four rows.
+      #
+      # Like bilinear, RGB is blended in linear light; alpha is linear.
+      # -----------------------------------------------------------------------
+      def sample_bicubic(img, u, v, oob)
+        x0 = u.floor
+        y0 = v.floor
+        fx = u - x0
+        fy = v - y0
+
+        # Catmull-Rom weights for the 4 neighbours in each axis.
+        # Offsets: -1, 0, +1, +2  → distances from sample: fx+1, fx, fx-1, fx-2
+        wx = Array.new(4) { |k| catmull_rom(fx - (k - 1)) }
+        wy = Array.new(4) { |k| catmull_rom(fy - (k - 1)) }
+
+        r_acc = g_acc = b_acc = a_acc = 0.0
+        4.times do |row|
+          cy = y0 + row - 1
+          ry = resolve_coord(cy, img.height, oob)
+          row_r = row_g = row_b = row_a = 0.0
+          4.times do |col|
+            cx = x0 + col - 1
+            rx = resolve_coord(cx, img.width, oob)
+            pix = (rx.nil? || ry.nil?) ? [0, 0, 0, 0] : PC.pixel_at(img, rx, ry)
+            w = wx[col]
+            row_r += decode(pix[0]) * w
+            row_g += decode(pix[1]) * w
+            row_b += decode(pix[2]) * w
+            row_a += pix[3] * w
+          end
+          wy_row = wy[row]
+          r_acc += row_r * wy_row
+          g_acc += row_g * wy_row
+          b_acc += row_b * wy_row
+          a_acc += row_a * wy_row
+        end
+
+        [encode(r_acc), encode(g_acc), encode(b_acc), a_acc.round.clamp(0, 255)]
+      end
+
+      # -----------------------------------------------------------------------
+      # sample(img, u, v, mode, oob) → [r, g, b, a]
+      #
+      # Dispatch table for the three interpolation modes.
+      # -----------------------------------------------------------------------
+      def sample(img, u, v, mode, oob)
+        case mode
+        when :nearest  then sample_nearest(img,  u, v, oob)
+        when :bilinear then sample_bilinear(img, u, v, oob)
+        when :bicubic  then sample_bicubic(img,  u, v, oob)
+        else raise ArgumentError, "unknown interpolation mode: #{mode.inspect}"
+        end
+      end
+    end
+
+    # =========================================================================
+    # PUBLIC API — lossless transforms
+    #
+    # These operations copy pixel bytes without any sRGB conversion.
+    # They are exact and reversible.
+    # =========================================================================
+
+    # -------------------------------------------------------------------------
+    # flip_horizontal(src) → PixelContainer
+    #
+    # Mirror the image left-to-right.  Row y of the output is the reverse of
+    # row y of the input.
+    #
+    #   I[x, y]  →  O[W-1-x, y]
+    #
+    # Equivalently, for each row we write column W-1-x of the input into
+    # column x of the output.
+    # -------------------------------------------------------------------------
+    def self.flip_horizontal(src)
+      dst = PC.create(src.width, src.height)
+      src.height.times do |y|
+        src.width.times do |x|
+          r, g, b, a = PC.pixel_at(src, x, y)
+          PC.set_pixel(dst, src.width - 1 - x, y, r, g, b, a)
+        end
+      end
+      dst
+    end
+
+    # -------------------------------------------------------------------------
+    # flip_vertical(src) → PixelContainer
+    #
+    # Mirror the image top-to-bottom.  Column x of the output is the reverse
+    # of column x of the input.
+    #
+    #   I[x, y]  →  O[x, H-1-y]
+    # -------------------------------------------------------------------------
+    def self.flip_vertical(src)
+      dst = PC.create(src.width, src.height)
+      src.height.times do |y|
+        src.width.times do |x|
+          r, g, b, a = PC.pixel_at(src, x, y)
+          PC.set_pixel(dst, x, src.height - 1 - y, r, g, b, a)
+        end
+      end
+      dst
+    end
+
+    # -------------------------------------------------------------------------
+    # rotate_90_cw(src) → PixelContainer
+    #
+    # Rotate 90 degrees clockwise.  The output dimensions swap: W'=H, H'=W.
+    #
+    # Derivation — rotating the unit square 90° CW maps (x,y) → (H-1-y, x):
+    #
+    #   (0,0) → (H-1, 0)   top-left  → top-right
+    #   (W-1,0) → (H-1, W-1)
+    #
+    # Written as a backward-mapping read: output pixel (x', y') comes from
+    # input pixel (y', W-1-x').
+    #
+    #   O[x', y'] = I[y', W-1-x']   where W' = H, H' = W
+    # -------------------------------------------------------------------------
+    def self.rotate_90_cw(src)
+      out_w = src.height
+      out_h = src.width
+      dst = PC.create(out_w, out_h)
+      out_h.times do |yp|
+        out_w.times do |xp|
+          r, g, b, a = PC.pixel_at(src, yp, src.width - 1 - xp)
+          PC.set_pixel(dst, xp, yp, r, g, b, a)
+        end
+      end
+      dst
+    end
+
+    # -------------------------------------------------------------------------
+    # rotate_90_ccw(src) → PixelContainer
+    #
+    # Rotate 90 degrees counter-clockwise.  W'=H, H'=W.
+    #
+    # Backward mapping: O[x', y'] = I[H-1-y', x']
+    #   (0,0) → (0, H-1)   top-left → bottom-left
+    # -------------------------------------------------------------------------
+    def self.rotate_90_ccw(src)
+      out_w = src.height
+      out_h = src.width
+      dst = PC.create(out_w, out_h)
+      out_h.times do |yp|
+        out_w.times do |xp|
+          r, g, b, a = PC.pixel_at(src, src.height - 1 - yp, xp)
+          PC.set_pixel(dst, xp, yp, r, g, b, a)
+        end
+      end
+      dst
+    end
+
+    # -------------------------------------------------------------------------
+    # rotate_180(src) → PixelContainer
+    #
+    # Rotate 180 degrees.  Same dimensions as input.
+    #
+    # Equivalent to flip_horizontal ∘ flip_vertical (commutative).
+    # Backward mapping: O[x, y] = I[W-1-x, H-1-y]
+    # -------------------------------------------------------------------------
+    def self.rotate_180(src)
+      dst = PC.create(src.width, src.height)
+      src.height.times do |y|
+        src.width.times do |x|
+          r, g, b, a = PC.pixel_at(src, src.width - 1 - x, src.height - 1 - y)
+          PC.set_pixel(dst, x, y, r, g, b, a)
+        end
+      end
+      dst
+    end
+
+    # -------------------------------------------------------------------------
+    # crop(src, x0, y0, w, h) → PixelContainer
+    #
+    # Extract a w×h rectangle with its top-left corner at (x0, y0).
+    # Pixels outside the source image boundary read as [0,0,0,0] (zero OOB).
+    # -------------------------------------------------------------------------
+    def self.crop(src, x0, y0, w, h)
+      raise ArgumentError, "crop width must be positive"  unless w > 0
+      raise ArgumentError, "crop height must be positive" unless h > 0
+      dst = PC.create(w, h)
+      h.times do |dy|
+        w.times do |dx|
+          # pixel_at already returns [0,0,0,0] for OOB coordinates
+          r, g, b, a = PC.pixel_at(src, x0 + dx, y0 + dy)
+          PC.set_pixel(dst, dx, dy, r, g, b, a)
+        end
+      end
+      dst
+    end
+
+    # -------------------------------------------------------------------------
+    # pad(src, top, right, bottom, left, fill: [0,0,0,0]) → PixelContainer
+    #
+    # Add a border of fill pixels around the image.  Output dimensions:
+    #   W' = left + W + right
+    #   H' = top  + H + bottom
+    #
+    # Interior pixels (those that map to a valid source coordinate) are copied
+    # verbatim; border pixels receive the fill colour.
+    # -------------------------------------------------------------------------
+    def self.pad(src, top, right, bottom, left, fill: [0, 0, 0, 0])
+      out_w = left + src.width  + right
+      out_h = top  + src.height + bottom
+      fr, fg, fb, fa = fill
+      dst = PC.create(out_w, out_h)
+      out_h.times do |y|
+        out_w.times do |x|
+          sx = x - left
+          sy = y - top
+          if sx >= 0 && sx < src.width && sy >= 0 && sy < src.height
+            r, g, b, a = PC.pixel_at(src, sx, sy)
+            PC.set_pixel(dst, x, y, r, g, b, a)
+          else
+            PC.set_pixel(dst, x, y, fr, fg, fb, fa)
+          end
+        end
+      end
+      dst
+    end
+
+    # =========================================================================
+    # PUBLIC API — continuous transforms
+    #
+    # All use backward mapping: for each output pixel we compute a floating-
+    # point source coordinate and sample the input with the chosen interpolator.
+    # =========================================================================
+
+    # -------------------------------------------------------------------------
+    # scale(src, out_w, out_h, mode: :bilinear) → PixelContainer
+    #
+    # Resize the image to out_w × out_h pixels using the pixel-centre model.
+    #
+    # Pixel-centre mapping:
+    #   The output pixel at (x, y) corresponds to the input location
+    #   u = (x + 0.5) * (W / out_w) − 0.5
+    #   v = (y + 0.5) * (H / out_h) − 0.5
+    #
+    # This ensures that:
+    #   • The top-left output pixel maps to the top-left input pixel.
+    #   • The bottom-right output pixel maps to the bottom-right input pixel.
+    #   • Upscaling and downscaling are both handled symmetrically.
+    #
+    # OOB strategy: :replicate (edge pixels are extended, no black borders).
+    # -------------------------------------------------------------------------
+    def self.scale(src, out_w, out_h, mode: :bilinear)
+      raise ArgumentError, "output width must be positive"  unless out_w > 0
+      raise ArgumentError, "output height must be positive" unless out_h > 0
+      dst = PC.create(out_w, out_h)
+      x_ratio = src.width.to_f  / out_w
+      y_ratio = src.height.to_f / out_h
+      out_h.times do |y|
+        out_w.times do |x|
+          u = (x + 0.5) * x_ratio - 0.5
+          v = (y + 0.5) * y_ratio - 0.5
+          r, g, b, a = sample(src, u, v, mode, :replicate)
+          PC.set_pixel(dst, x, y, r, g, b, a)
+        end
+      end
+      dst
+    end
+
+    # -------------------------------------------------------------------------
+    # rotate(src, radians, mode: :bilinear, bounds: :fit) → PixelContainer
+    #
+    # Rotate the image counter-clockwise by `radians` about its centre.
+    #
+    # bounds:
+    #   :fit  — output canvas is sized to contain the entire rotated image
+    #           (no clipping).  New areas outside the original image are zero.
+    #   :crop — output canvas matches the input size; corners may be clipped.
+    #
+    # Backward mapping derivation:
+    #   Let cx_in  = (W-1)/2.0,  cy_in  = (H-1)/2.0
+    #       cx_out = (W'-1)/2.0, cy_out = (H'-1)/2.0
+    #   For output pixel (x', y'):
+    #     dx = x' − cx_out,  dy = y' − cy_out
+    #     u  = cx_in + cos·dx + sin·dy
+    #     v  = cy_in − sin·dx + cos·dy
+    #
+    #   (Rotating the output offset by −θ to find the input source.)
+    #
+    # :fit canvas size:
+    #   W' = ceil(W·|cos| + H·|sin|)
+    #   H' = ceil(W·|sin| + H·|cos|)
+    # -------------------------------------------------------------------------
+    def self.rotate(src, radians, mode: :bilinear, bounds: :fit)
+      cos_r = Math.cos(radians)
+      sin_r = Math.sin(radians)
+      w     = src.width
+      h     = src.height
+
+      if bounds == :fit
+        out_w = (w * cos_r.abs + h * sin_r.abs).ceil
+        out_h = (w * sin_r.abs + h * cos_r.abs).ceil
+      else
+        out_w = w
+        out_h = h
+      end
+
+      cx_in  = (w - 1) / 2.0
+      cy_in  = (h - 1) / 2.0
+      cx_out = (out_w - 1) / 2.0
+      cy_out = (out_h - 1) / 2.0
+
+      dst = PC.create(out_w, out_h)
+      out_h.times do |yp|
+        out_w.times do |xp|
+          dx = xp - cx_out
+          dy = yp - cy_out
+          u  = cx_in + cos_r * dx + sin_r * dy
+          v  = cy_in - sin_r * dx + cos_r * dy
+          r, g, b, a = sample(src, u, v, mode, :zero)
+          PC.set_pixel(dst, xp, yp, r, g, b, a)
+        end
+      end
+      dst
+    end
+
+    # -------------------------------------------------------------------------
+    # affine(src, matrix, out_w, out_h, mode: :bilinear, oob: :replicate)
+    #   → PixelContainer
+    #
+    # Apply a 2D affine transform expressed as a 2×3 matrix:
+    #
+    #   matrix = [[m00, m01, m02],
+    #             [m10, m11, m12]]
+    #
+    # The forward mapping is:
+    #   x' = m00·x + m01·y + m02
+    #   y' = m10·x + m11·y + m12
+    #
+    # We need the backward mapping (output → input), so we solve the 2×2 linear
+    # system.  Given output pixel (xp, yp):
+    #
+    #   [m00 m01] [u]   [xp - m02]
+    #   [m10 m11] [v] = [yp - m12]
+    #
+    # det = m00·m11 − m01·m10
+    # u   = (m11·(xp−m02) − m01·(yp−m12)) / det
+    # v   = (m00·(yp−m12) − m10·(xp−m02)) / det
+    #
+    # If det ≈ 0 (singular matrix), the result is undefined; we return
+    # transparent pixels.
+    # -------------------------------------------------------------------------
+    def self.affine(src, matrix, out_w, out_h, mode: :bilinear, oob: :replicate)
+      m00, m01, m02 = matrix[0]
+      m10, m11, m12 = matrix[1]
+      det = m00 * m11 - m01 * m10
+      dst = PC.create(out_w, out_h)
+      out_h.times do |yp|
+        out_w.times do |xp|
+          if det.abs < 1e-10
+            PC.set_pixel(dst, xp, yp, 0, 0, 0, 0)
+            next
+          end
+          dx = xp - m02
+          dy = yp - m12
+          u = (m11 * dx - m01 * dy) / det
+          v = (m00 * dy - m10 * dx) / det
+          r, g, b, a = sample(src, u, v, mode, oob)
+          PC.set_pixel(dst, xp, yp, r, g, b, a)
+        end
+      end
+      dst
+    end
+
+    # -------------------------------------------------------------------------
+    # perspective_warp(src, h, out_w, out_h, mode: :bilinear, oob: :replicate)
+    #   → PixelContainer
+    #
+    # Apply a projective (homographic) transform defined by a 3×3 homography
+    # matrix H:
+    #
+    #   h = [[h00, h01, h02],
+    #        [h10, h11, h12],
+    #        [h20, h21, h22]]
+    #
+    # Forward mapping of input point (x, y) to output (x', y'):
+    #   w̃  = h20·x + h21·y + h22
+    #   x' = (h00·x + h01·y + h02) / w̃
+    #   y' = (h10·x + h11·y + h12) / w̃
+    #
+    # For backward mapping we invert H and apply the same formula.
+    #
+    # 3×3 matrix inverse (Cramer's rule / adjugate / determinant):
+    #   We compute the adjugate and divide by the determinant.
+    # -------------------------------------------------------------------------
+    def self.perspective_warp(src, h_mat, out_w, out_h, mode: :bilinear, oob: :replicate)
+      # Unpack the 3×3 homography.
+      h00, h01, h02 = h_mat[0]
+      h10, h11, h12 = h_mat[1]
+      h20, h21, h22 = h_mat[2]
+
+      # Compute the determinant.
+      det = h00 * (h11 * h22 - h12 * h21) \
+          - h01 * (h10 * h22 - h12 * h20) \
+          + h02 * (h10 * h21 - h11 * h20)
+
+      dst = PC.create(out_w, out_h)
+
+      if det.abs < 1e-10
+        # Singular matrix — return all transparent.
+        return dst
+      end
+
+      # Adjugate (transpose of cofactor matrix).
+      inv_det = 1.0 / det
+      i00 = ( h11 * h22 - h12 * h21) * inv_det
+      i01 = (-h01 * h22 + h02 * h21) * inv_det
+      i02 = ( h01 * h12 - h02 * h11) * inv_det
+      i10 = (-h10 * h22 + h12 * h20) * inv_det
+      i11 = ( h00 * h22 - h02 * h20) * inv_det
+      i12 = (-h00 * h12 + h02 * h10) * inv_det
+      i20 = ( h10 * h21 - h11 * h20) * inv_det
+      i21 = (-h00 * h21 + h01 * h20) * inv_det
+      i22 = ( h00 * h11 - h01 * h10) * inv_det
+
+      out_h.times do |yp|
+        out_w.times do |xp|
+          # Apply inverse homography H^{-1} to map output → input.
+          w_tilde = i20 * xp + i21 * yp + i22
+          if w_tilde.abs < 1e-10
+            PC.set_pixel(dst, xp, yp, 0, 0, 0, 0)
+            next
+          end
+          u = (i00 * xp + i01 * yp + i02) / w_tilde
+          v = (i10 * xp + i11 * yp + i12) / w_tilde
+          r, g, b, a = sample(src, u, v, mode, oob)
+          PC.set_pixel(dst, xp, yp, r, g, b, a)
+        end
+      end
+      dst
+    end
+  end
+end

--- a/code/packages/ruby/image_geometric_transforms/test/test_image_geometric_transforms.rb
+++ b/code/packages/ruby/image_geometric_transforms/test/test_image_geometric_transforms.rb
@@ -1,0 +1,453 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+
+$LOAD_PATH.unshift File.join(__dir__, "../../pixel_container/lib")
+$LOAD_PATH.unshift File.join(__dir__, "../lib")
+
+require "coding_adventures/pixel_container"
+require "coding_adventures/image_geometric_transforms"
+
+PC  = CodingAdventures::PixelContainer
+GT  = CodingAdventures::ImageGeometricTransforms
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+# Create a 1×1 image containing a single RGBA pixel.
+def solid_1x1(r, g, b, a)
+  img = PC.create(1, 1)
+  PC.set_pixel(img, 0, 0, r, g, b, a)
+  img
+end
+
+# Create a 2×2 image with four distinct corner pixels.
+#   (0,0)=top-left  (1,0)=top-right
+#   (0,1)=bottom-left (1,1)=bottom-right
+def checkerboard_2x2
+  img = PC.create(2, 2)
+  PC.set_pixel(img, 0, 0,   10,  20,  30, 255)   # top-left     — dark blue-ish
+  PC.set_pixel(img, 1, 0,  200,  10,  10, 255)   # top-right    — red
+  PC.set_pixel(img, 0, 1,   10, 200,  10, 255)   # bottom-left  — green
+  PC.set_pixel(img, 1, 1,  200, 200,  10, 255)   # bottom-right — yellow
+  img
+end
+
+# Create a 3×3 image filled with a gradient for scale tests.
+def gradient_3x3
+  img = PC.create(3, 3)
+  3.times do |y|
+    3.times do |x|
+      v = (x + y * 3) * 28
+      PC.set_pixel(img, x, y, v, v, v, 255)
+    end
+  end
+  img
+end
+
+# Assert two pixel arrays are approximately equal within tolerance.
+def assert_pixel_near(expected, actual, tol = 2, msg = nil)
+  4.times do |i|
+    diff = (expected[i] - actual[i]).abs
+    assert diff <= tol, "#{msg}: channel #{i}: expected #{expected[i]}, got #{actual[i]} (diff #{diff} > #{tol})"
+  end
+end
+
+# =============================================================================
+# Tests: flip_horizontal
+# =============================================================================
+
+class TestFlipHorizontal < Minitest::Test
+  def test_flips_left_and_right_pixels
+    src = checkerboard_2x2
+    dst = GT.flip_horizontal(src)
+    # top-left of dst should be what was top-right of src
+    assert_equal [200, 10, 10, 255], PC.pixel_at(dst, 0, 0)
+    assert_equal [10, 20, 30, 255],  PC.pixel_at(dst, 1, 0)
+  end
+
+  def test_dimensions_unchanged
+    src = checkerboard_2x2
+    dst = GT.flip_horizontal(src)
+    assert_equal 2, dst.width
+    assert_equal 2, dst.height
+  end
+
+  def test_double_flip_is_identity
+    src = checkerboard_2x2
+    dst = GT.flip_horizontal(GT.flip_horizontal(src))
+    2.times do |y|
+      2.times do |x|
+        assert_equal PC.pixel_at(src, x, y), PC.pixel_at(dst, x, y)
+      end
+    end
+  end
+end
+
+# =============================================================================
+# Tests: flip_vertical
+# =============================================================================
+
+class TestFlipVertical < Minitest::Test
+  def test_flips_top_and_bottom_pixels
+    src = checkerboard_2x2
+    dst = GT.flip_vertical(src)
+    # top-left of dst should be what was bottom-left of src
+    assert_equal [10, 200, 10, 255],  PC.pixel_at(dst, 0, 0)
+    assert_equal [200, 200, 10, 255], PC.pixel_at(dst, 1, 0)
+  end
+
+  def test_double_flip_is_identity
+    src = checkerboard_2x2
+    dst = GT.flip_vertical(GT.flip_vertical(src))
+    2.times do |y|
+      2.times do |x|
+        assert_equal PC.pixel_at(src, x, y), PC.pixel_at(dst, x, y)
+      end
+    end
+  end
+end
+
+# =============================================================================
+# Tests: rotate_90_cw
+# =============================================================================
+
+class TestRotate90Cw < Minitest::Test
+  # A 2×2 CW rotation swaps dimensions (2×2→2×2 here, since square).
+  # For a non-square 3×1 image the swap is visible.
+  def test_dimensions_swap
+    img = PC.create(3, 1)
+    dst = GT.rotate_90_cw(img)
+    assert_equal 1, dst.width
+    assert_equal 3, dst.height
+  end
+
+  def test_pixel_mapping
+    # I[0,0]=TL, I[1,0]=TR, I[0,1]=BL, I[1,1]=BR on 2×2
+    # CW 90°: TL→TR, TR→BR, BR→BL, BL→TL in output
+    src = checkerboard_2x2
+    dst = GT.rotate_90_cw(src)
+    # O[x',y'] = I[y', W-1-x']  (W=2)
+    # O[0,0] = I[0, 1] = BL = [10,200,10,255]
+    assert_equal [10, 200, 10, 255], PC.pixel_at(dst, 0, 0)
+    # O[1,0] = I[0, 0] = TL = [10,20,30,255]
+    assert_equal [10, 20, 30, 255], PC.pixel_at(dst, 1, 0)
+  end
+
+  def test_round_trip_with_ccw
+    src = checkerboard_2x2
+    dst = GT.rotate_90_ccw(GT.rotate_90_cw(src))
+    2.times do |y|
+      2.times do |x|
+        assert_equal PC.pixel_at(src, x, y), PC.pixel_at(dst, x, y)
+      end
+    end
+  end
+end
+
+# =============================================================================
+# Tests: rotate_90_ccw
+# =============================================================================
+
+class TestRotate90Ccw < Minitest::Test
+  def test_dimensions_swap
+    img = PC.create(1, 4)
+    dst = GT.rotate_90_ccw(img)
+    assert_equal 4, dst.width
+    assert_equal 1, dst.height
+  end
+
+  def test_pixel_mapping
+    src = checkerboard_2x2
+    dst = GT.rotate_90_ccw(src)
+    # O[x',y'] = I[H-1-y', x']  (H=2)
+    # O[0,0] = I[1, 0] = TR = [200,10,10,255]
+    assert_equal [200, 10, 10, 255], PC.pixel_at(dst, 0, 0)
+  end
+end
+
+# =============================================================================
+# Tests: rotate_180
+# =============================================================================
+
+class TestRotate180 < Minitest::Test
+  def test_dimensions_unchanged
+    src = checkerboard_2x2
+    dst = GT.rotate_180(src)
+    assert_equal src.width,  dst.width
+    assert_equal src.height, dst.height
+  end
+
+  def test_twice_is_identity
+    src = checkerboard_2x2
+    dst = GT.rotate_180(GT.rotate_180(src))
+    2.times do |y|
+      2.times do |x|
+        assert_equal PC.pixel_at(src, x, y), PC.pixel_at(dst, x, y)
+      end
+    end
+  end
+
+  def test_pixel_values
+    src = checkerboard_2x2
+    dst = GT.rotate_180(src)
+    # TL of dst = BR of src
+    assert_equal [200, 200, 10, 255], PC.pixel_at(dst, 0, 0)
+    # BR of dst = TL of src
+    assert_equal [10, 20, 30, 255], PC.pixel_at(dst, 1, 1)
+  end
+end
+
+# =============================================================================
+# Tests: crop
+# =============================================================================
+
+class TestCrop < Minitest::Test
+  def test_correct_dimensions
+    src = gradient_3x3
+    dst = GT.crop(src, 0, 0, 2, 2)
+    assert_equal 2, dst.width
+    assert_equal 2, dst.height
+  end
+
+  def test_pixel_values_match_source
+    src = gradient_3x3
+    dst = GT.crop(src, 1, 1, 2, 2)
+    # dst[0,0] == src[1,1], dst[1,0] == src[2,1], etc.
+    assert_equal PC.pixel_at(src, 1, 1), PC.pixel_at(dst, 0, 0)
+    assert_equal PC.pixel_at(src, 2, 1), PC.pixel_at(dst, 1, 0)
+  end
+
+  def test_oob_crop_returns_transparent
+    src = solid_1x1(100, 100, 100, 255)
+    # Crop from position (0,0) but also extend outside source
+    dst = GT.crop(src, 0, 0, 3, 1)
+    assert_equal [100, 100, 100, 255], PC.pixel_at(dst, 0, 0)
+    assert_equal [0, 0, 0, 0],         PC.pixel_at(dst, 1, 0)
+  end
+end
+
+# =============================================================================
+# Tests: pad
+# =============================================================================
+
+class TestPad < Minitest::Test
+  def test_dimensions
+    src = solid_1x1(50, 60, 70, 255)
+    dst = GT.pad(src, 1, 2, 3, 4)
+    # left=4 + src.w=1 + right=2 = 7
+    assert_equal 4 + 1 + 2, dst.width
+    # top=1 + src.h=1 + bottom=3 = 5
+    assert_equal 1 + 1 + 3, dst.height
+  end
+
+  def test_border_filled_with_default_fill
+    src = solid_1x1(50, 60, 70, 255)
+    dst = GT.pad(src, 1, 1, 1, 1)
+    # corner pixels should be transparent black
+    assert_equal [0, 0, 0, 0], PC.pixel_at(dst, 0, 0)
+    assert_equal [0, 0, 0, 0], PC.pixel_at(dst, 2, 2)
+  end
+
+  def test_interior_pixel_preserved
+    src = solid_1x1(50, 60, 70, 255)
+    dst = GT.pad(src, 1, 1, 1, 1)
+    assert_equal [50, 60, 70, 255], PC.pixel_at(dst, 1, 1)
+  end
+
+  def test_custom_fill_colour
+    src = solid_1x1(50, 60, 70, 255)
+    dst = GT.pad(src, 1, 0, 0, 0, fill: [255, 0, 0, 255])
+    assert_equal [255, 0, 0, 255], PC.pixel_at(dst, 0, 0)
+  end
+end
+
+# =============================================================================
+# Tests: scale
+# =============================================================================
+
+class TestScale < Minitest::Test
+  def test_scale_up_doubles_dimensions
+    src = checkerboard_2x2
+    dst = GT.scale(src, 4, 4)
+    assert_equal 4, dst.width
+    assert_equal 4, dst.height
+  end
+
+  def test_scale_down_halves_dimensions
+    src = gradient_3x3
+    dst = GT.scale(src, 1, 1)
+    assert_equal 1, dst.width
+    assert_equal 1, dst.height
+  end
+
+  def test_scale_solid_colour_unchanged
+    # Scaling a solid-colour image should keep the colour exactly.
+    src = PC.create(4, 4)
+    PC.fill_pixels(src, 80, 120, 200, 255) rescue nil
+    4.times do |y|
+      4.times do |x|
+        PC.set_pixel(src, x, y, 80, 120, 200, 255)
+      end
+    end
+    dst = GT.scale(src, 8, 8)
+    assert_pixel_near([80, 120, 200, 255], PC.pixel_at(dst, 4, 4), 2, "solid colour scale")
+  end
+end
+
+# =============================================================================
+# Tests: rotate
+# =============================================================================
+
+class TestRotate < Minitest::Test
+  def test_rotate_zero_is_near_identity
+    src = checkerboard_2x2
+    dst = GT.rotate(src, 0.0, mode: :nearest)
+    assert_pixel_near(PC.pixel_at(src, 0, 0), PC.pixel_at(dst, 0, 0), 2, "rotate 0 TL")
+    assert_pixel_near(PC.pixel_at(src, 1, 1), PC.pixel_at(dst, 1, 1), 2, "rotate 0 BR")
+  end
+
+  def test_rotate_fit_enlarges_canvas_for_diagonal
+    src = PC.create(10, 10)
+    dst = GT.rotate(src, Math::PI / 4, bounds: :fit)
+    # A 10×10 image rotated 45° should have a canvas at least sqrt(2)*10 ≈ 14 wide
+    assert dst.width >= 14, "expected width >= 14, got #{dst.width}"
+    assert dst.height >= 14, "expected height >= 14, got #{dst.height}"
+  end
+
+  def test_rotate_crop_preserves_dimensions
+    src = checkerboard_2x2
+    dst = GT.rotate(src, Math::PI / 6, bounds: :crop)
+    assert_equal src.width,  dst.width
+    assert_equal src.height, dst.height
+  end
+end
+
+# =============================================================================
+# Tests: affine
+# =============================================================================
+
+class TestAffine < Minitest::Test
+  # Identity matrix: [[1,0,0],[0,1,0]]
+  IDENTITY = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]].freeze
+
+  def test_identity_affine_near_identity
+    src = checkerboard_2x2
+    dst = GT.affine(src, IDENTITY, src.width, src.height, mode: :nearest)
+    2.times do |y|
+      2.times do |x|
+        assert_pixel_near(PC.pixel_at(src, x, y), PC.pixel_at(dst, x, y), 2, "affine identity (#{x},#{y})")
+      end
+    end
+  end
+
+  def test_affine_translation
+    src = solid_1x1(200, 100, 50, 255)
+    # Translate by (+1, +1): output at (1,1) should reflect the source pixel
+    matrix = [[1.0, 0.0, 1.0], [0.0, 1.0, 1.0]]
+    dst = GT.affine(src, matrix, 3, 3, mode: :nearest, oob: :zero)
+    # Output pixel at (1,1) maps back to input (0,0)
+    assert_pixel_near([200, 100, 50, 255], PC.pixel_at(dst, 1, 1), 2, "translated pixel")
+  end
+end
+
+# =============================================================================
+# Tests: perspective_warp
+# =============================================================================
+
+class TestPerspectiveWarp < Minitest::Test
+  # Identity homography: [[1,0,0],[0,1,0],[0,0,1]]
+  IDENTITY_H = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]].freeze
+
+  def test_identity_warp_near_identity
+    src = checkerboard_2x2
+    dst = GT.perspective_warp(src, IDENTITY_H, src.width, src.height, mode: :nearest)
+    2.times do |y|
+      2.times do |x|
+        assert_pixel_near(PC.pixel_at(src, x, y), PC.pixel_at(dst, x, y), 2, "persp identity (#{x},#{y})")
+      end
+    end
+  end
+
+  def test_perspective_warp_produces_correct_dimensions
+    src = checkerboard_2x2
+    dst = GT.perspective_warp(src, IDENTITY_H, 4, 3)
+    assert_equal 4, dst.width
+    assert_equal 3, dst.height
+  end
+end
+
+# =============================================================================
+# Tests: nearest neighbour interpolation
+# =============================================================================
+
+class TestNearestNeighbour < Minitest::Test
+  def test_nearest_returns_exact_pixel_for_integer_coord
+    src = checkerboard_2x2
+    # Scale 2×2 → 2×2 with nearest: should preserve exact values
+    dst = GT.scale(src, 2, 2, mode: :nearest)
+    2.times do |y|
+      2.times do |x|
+        assert_equal PC.pixel_at(src, x, y), PC.pixel_at(dst, x, y)
+      end
+    end
+  end
+end
+
+# =============================================================================
+# Tests: bilinear interpolation
+# =============================================================================
+
+class TestBilinear < Minitest::Test
+  def test_midpoint_of_two_pixel_gradient
+    # Create a 2×1 image: left pixel pure white (linear), right pixel black.
+    src = PC.create(2, 1)
+    PC.set_pixel(src, 0, 0, 255, 255, 255, 255)
+    PC.set_pixel(src, 1, 0,   0,   0,   0, 255)
+    # Scale to 3 wide: centre pixel (index 1) should be approximately mid-grey
+    # in linear light → ~188 in sRGB (√0.5 ≈ 0.707 → sRGB ≈ 188)
+    dst = GT.scale(src, 3, 1, mode: :bilinear)
+    mid = PC.pixel_at(dst, 1, 0)
+    # Mid-grey in sRGB is about 188; accept ±10 tolerance for sampling position
+    assert mid[0] > 100 && mid[0] < 240, "midpoint R=#{mid[0]} out of expected range"
+  end
+end
+
+# =============================================================================
+# Tests: OOB modes (smoke tests — must not raise)
+# =============================================================================
+
+class TestOobModes < Minitest::Test
+  def test_replicate_oob_does_not_raise
+    src = checkerboard_2x2
+    dst = GT.scale(src, 4, 4, mode: :bilinear)  # uses :replicate internally
+    refute_nil dst
+  end
+
+  def test_reflect_oob_does_not_raise
+    src = checkerboard_2x2
+    mat = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]
+    dst = GT.affine(src, mat, 6, 6, mode: :bilinear, oob: :reflect)
+    refute_nil dst
+  end
+
+  def test_wrap_oob_does_not_raise
+    src = checkerboard_2x2
+    mat = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]
+    dst = GT.affine(src, mat, 6, 6, mode: :bilinear, oob: :wrap)
+    refute_nil dst
+  end
+
+  def test_zero_oob_does_not_raise
+    src = checkerboard_2x2
+    dst = GT.rotate(src, 1.0, mode: :nearest)  # uses :zero internally
+    refute_nil dst
+  end
+
+  def test_bicubic_does_not_raise
+    src = gradient_3x3
+    dst = GT.scale(src, 6, 6, mode: :bicubic)
+    refute_nil dst
+  end
+end

--- a/code/packages/swift/ImageGeometricTransforms/.gitignore
+++ b/code/packages/swift/ImageGeometricTransforms/.gitignore
@@ -1,0 +1,4 @@
+.build/
+*.xcodeproj
+*.xcworkspace
+.swiftpm/

--- a/code/packages/swift/ImageGeometricTransforms/BUILD
+++ b/code/packages/swift/ImageGeometricTransforms/BUILD
@@ -1,0 +1,1 @@
+swift test

--- a/code/packages/swift/ImageGeometricTransforms/CHANGELOG.md
+++ b/code/packages/swift/ImageGeometricTransforms/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog — ImageGeometricTransforms (Swift)
+
+## [0.1.0] — 2026-04-20
+
+### Added
+
+- Initial release implementing IMG04 (geometric / spatial transforms) over `PixelContainer`.
+
+- **Lossless pixel-copy operations** (no interpolation, no colour-space conversion):
+  - `flipHorizontal` — mirror left ↔ right.
+  - `flipVertical` — mirror top ↔ bottom.
+  - `rotate90CW` — 90° clockwise; swaps width and height.
+  - `rotate90CCW` — 90° counter-clockwise; swaps width and height.
+  - `rotate180` — 180° rotation; equivalent to flipH ∘ flipV.
+  - `crop` — extract a rectangular sub-region.
+  - `pad` — add constant-colour border rows/columns.
+
+- **Continuous-coordinate resampling operations** (correct linear-light blending):
+  - `scale` — resize to arbitrary (outW, outH) with pixel-centre mapping.
+  - `rotate` — arbitrary-angle rotation with `.fit` or `.crop` canvas sizing.
+  - `affine` — general 2×3 affine warp (rotation, scale, shear, translate).
+  - `perspectiveWarp` — general 3×3 homogeneous perspective warp.
+
+- **Interpolation modes** (`Interpolation` enum):
+  - `.nearest` — round to nearest integer pixel.
+  - `.bilinear` — 2×2 neighbourhood linear blend in linear light.
+  - `.bicubic` — 4×4 Catmull-Rom cubic blend in linear light.
+
+- **Out-of-bounds modes** (`OutOfBounds` enum):
+  - `.zero` — transparent black.
+  - `.replicate` — clamp to border pixel.
+  - `.reflect` — mirror across border.
+  - `.wrap` — periodic tiling.
+
+- **Canvas sizing** (`RotateBounds` enum):
+  - `.fit` — expand canvas to contain entire rotated source.
+  - `.crop` — keep original canvas size, clip corners.
+
+- Module-level 256-entry `srgbToLinear` decode LUT (built once at module load).
+- Full XCTest suite with 28 tests covering every public function,
+  round-trip identities, dimension checks, exact pixel values (lossless
+  ops), near-identity checks ±2 per channel (resampling ops), and OOB
+  smoke tests.

--- a/code/packages/swift/ImageGeometricTransforms/Package.swift
+++ b/code/packages/swift/ImageGeometricTransforms/Package.swift
@@ -1,0 +1,39 @@
+// swift-tools-version: 5.9
+// ============================================================================
+// Package.swift — ImageGeometricTransforms
+// ============================================================================
+//
+// Swift Package Manager manifest for the ImageGeometricTransforms library.
+//
+// ImageGeometricTransforms is IMG04 in the coding-adventures image processing
+// stack. It provides spatial (geometric) transforms over PixelContainer (IC00):
+// flip, rotate (90/180/arbitrary), crop, pad, scale, affine warp, and
+// perspective warp — with nearest, bilinear, and bicubic (Catmull-Rom)
+// interpolation modes and configurable out-of-bounds handling.
+//
+// Part of the coding-adventures educational computing stack.
+// ============================================================================
+
+import PackageDescription
+
+let package = Package(
+    name: "ImageGeometricTransforms",
+    products: [
+        .library(name: "ImageGeometricTransforms", targets: ["ImageGeometricTransforms"]),
+    ],
+    dependencies: [
+        .package(path: "../PixelContainer"),
+    ],
+    targets: [
+        .target(
+            name: "ImageGeometricTransforms",
+            dependencies: ["PixelContainer"],
+            path: "Sources/ImageGeometricTransforms"
+        ),
+        .testTarget(
+            name: "ImageGeometricTransformsTests",
+            dependencies: ["ImageGeometricTransforms", "PixelContainer"],
+            path: "Tests/ImageGeometricTransformsTests"
+        ),
+    ]
+)

--- a/code/packages/swift/ImageGeometricTransforms/README.md
+++ b/code/packages/swift/ImageGeometricTransforms/README.md
@@ -1,0 +1,109 @@
+# ImageGeometricTransforms (Swift)
+
+**IMG04** — Spatial / geometric image transforms for the `PixelContainer` image type.
+
+## Stack position
+
+```
+IMG04 ImageGeometricTransforms
+ └── IC00 PixelContainer   (RGBA8 raster store)
+```
+
+## What it does
+
+ImageGeometricTransforms provides operations that rearrange pixels spatially —
+flipping, rotating, cropping, padding, scaling, and warping — as opposed to
+point operations (IMG03) that change pixel values in place.
+
+## Operations
+
+| Category          | Functions |
+|-------------------|-----------|
+| Lossless flips    | `flipHorizontal`, `flipVertical` |
+| Lossless rotation | `rotate90CW`, `rotate90CCW`, `rotate180` |
+| Lossless crop/pad | `crop`, `pad` |
+| Resampling scale  | `scale` |
+| Resampling rotate | `rotate` |
+| Affine warp       | `affine` |
+| Perspective warp  | `perspectiveWarp` |
+
+## Types
+
+```swift
+public enum Interpolation { case nearest, bilinear, bicubic }
+public enum RotateBounds  { case fit, crop }
+public enum OutOfBounds   { case zero, replicate, reflect, wrap }
+public typealias Rgba8 = (UInt8, UInt8, UInt8, UInt8)
+```
+
+## Interpolation
+
+All resampling operations accept an `Interpolation` mode:
+
+- **`.nearest`** — round the source coordinate to the nearest integer pixel.
+  Fastest; produces a "pixelated" look when upscaling.
+- **`.bilinear`** — blend the 2×2 neighbourhood with linear weights.
+  Smooth at moderate magnification.
+- **`.bicubic`** — blend the 4×4 neighbourhood with Catmull-Rom cubic weights.
+  Sharpest; may show slight ringing at high-contrast edges.
+
+All blending is performed in **linear light** (sRGB decoded via the EOTF)
+and re-encoded to sRGB on output, which is the physically correct approach.
+
+## Out-of-bounds handling
+
+When a sampler requests a coordinate outside the source image, the `OutOfBounds`
+parameter controls the response:
+
+| Mode         | Behaviour |
+|--------------|-----------|
+| `.zero`      | Return transparent black `(0,0,0,0)` |
+| `.replicate` | Clamp to the nearest border pixel |
+| `.reflect`   | Mirror-reflect across the border |
+| `.wrap`      | Tile the image periodically |
+
+## Usage
+
+```swift
+import PixelContainer
+import ImageGeometricTransforms
+
+// Load an image into src: PixelContainer ...
+
+// Lossless flips and rotations
+let hFlipped  = flipHorizontal(src)
+let rotated90 = rotate90CW(src)
+let flipped   = rotate180(src)
+
+// Crop a 100×100 region from (50, 50)
+let thumb = crop(src, x: 50, y: 50, w: 100, h: 100)
+
+// Add a 10-pixel white border
+let framed = pad(src, top: 10, right: 10, bottom: 10, left: 10,
+                 fill: (255, 255, 255, 255))
+
+// Scale to half size with bilinear interpolation (default)
+let half = scale(src, width: src.width / 2, height: src.height / 2)
+
+// Rotate 30° counter-clockwise, expanding canvas to fit
+let tilted = rotate(src, radians: Float.pi / 6, mode: .bicubic, bounds: .fit)
+
+// Affine shear (2×3 matrix)
+let shear: [[Float]] = [[1, 0.3, 0], [0, 1, 0]]
+let sheared = affine(src, matrix: shear, width: src.width, height: src.height)
+
+// Perspective warp (3×3 homogeneous matrix)
+let h: [[Float]] = [[1, 0.001, 0], [0, 1, 0], [0, 0.001, 1]]
+let warped = perspectiveWarp(src, matrix: h, width: src.width, height: src.height)
+```
+
+## Testing
+
+```
+swift test
+```
+
+All 28 tests should pass.  Coverage targets every public function, including
+round-trip identities, dimension assertions, exact pixel-value checks for
+lossless operations, and near-identity checks (±2 per channel) for resampling
+operations.

--- a/code/packages/swift/ImageGeometricTransforms/Sources/ImageGeometricTransforms/ImageGeometricTransforms.swift
+++ b/code/packages/swift/ImageGeometricTransforms/Sources/ImageGeometricTransforms/ImageGeometricTransforms.swift
@@ -1,0 +1,820 @@
+// ImageGeometricTransforms.swift
+// Part of coding-adventures — an educational computing stack.
+//
+// ============================================================================
+// MARK: - IMG04: Spatial / Geometric Image Transforms
+// ============================================================================
+//
+// A geometric (spatial) transform remaps pixel *positions*, rather than
+// changing pixel *values* in place.  The fundamental question is:
+//
+//   "For output pixel (x', y'), which input pixel (u, v) should I copy?"
+//
+// This is the **inverse mapping** (output → input).  Inverse mapping is
+// always preferred over forward mapping because it guarantees that every
+// output pixel is filled — forward mapping can leave holes.
+//
+// ## Two classes of operations
+//
+// ### 1. Lossless pixel-copy operations
+// Flip, 90°/180° rotation, crop, and pad copy pixels exactly.  No
+// colour-space conversion is needed because no channel values are mixed.
+//
+// ### 2. Continuous-coordinate resampling operations
+// Scale, arbitrary rotation, affine warp, and perspective warp compute a
+// real-valued source coordinate (u, v) for each output pixel and then
+// *sample* the source image at that fractional location using one of three
+// interpolation kernels:
+//
+//   Nearest-neighbour — round (u,v) to the closest integer pixel.
+//                       Fastest; produces visible staircase ("pixelated") edges.
+//
+//   Bilinear          — blend the 2×2 neighbourhood with linear weights.
+//                       Smooth at moderate magnification; slight blur.
+//
+//   Bicubic (Catmull-Rom) — blend the 4×4 neighbourhood with cubic spline
+//                       weights.  Sharper than bilinear; may ring slightly
+//                       at very high-contrast edges.
+//
+// ## sRGB and interpolation
+//
+// Interpolation blends channel values.  Blending in raw sRGB space is
+// geometrically incorrect: the sRGB transfer curve is perceptually uniform
+// but not linearly proportional to light intensity.  Averaging the bytes
+// 0 (black) and 255 (white) gives 128, which looks too dark.
+//
+// The correct procedure is:
+//   1. Decode sRGB bytes to linear-light Float via the sRGB EOTF.
+//   2. Perform weighted blending in linear light.
+//   3. Re-encode to sRGB bytes via the inverse EOTF.
+//
+// All interpolating samplers in this module follow this procedure.
+//
+// ## Out-of-bounds (OOB) strategies
+//
+// When a sampler requests a coordinate outside the source image:
+//
+//   .zero      — return transparent black (0,0,0,0).  Good for padding.
+//   .replicate — clamp to the nearest border pixel.  Avoids dark halos.
+//   .reflect   — mirror the image at each border.  Good for convolutions.
+//   .wrap      — tile the image periodically.  Good for textures.
+//
+// ============================================================================
+
+import Foundation
+import PixelContainer
+
+// ============================================================================
+// MARK: - Public Types
+// ============================================================================
+
+/// Interpolation kernel used when resampling at a fractional source coordinate.
+///
+/// Choose based on the quality/speed trade-off required:
+///   - `.nearest`  — fastest, blocky at large upscales
+///   - `.bilinear` — smooth, slight blur, good general purpose
+///   - `.bicubic`  — sharpest, based on Catmull-Rom cubic spline
+public enum Interpolation {
+    case nearest
+    case bilinear
+    case bicubic
+}
+
+/// Controls the output canvas size for arbitrary-angle rotation.
+///
+///   `.fit`  — enlarge the canvas to contain the entire rotated source image.
+///             No pixels are clipped; corners of the source appear against
+///             a transparent-black background.
+///   `.crop` — keep the same dimensions as the source image.  Corners of
+///             the rotated image are clipped to the canvas boundary.
+public enum RotateBounds {
+    case fit
+    case crop
+}
+
+/// Determines what colour to return when a sampler looks outside the source.
+///
+///   `.zero`      — transparent black (0,0,0,0)
+///   `.replicate` — nearest border pixel (edge padding)
+///   `.reflect`   — mirror-reflect across the border
+///   `.wrap`      — tile periodically
+public enum OutOfBounds {
+    case zero
+    case replicate
+    case reflect
+    case wrap
+}
+
+/// Convenience alias: a pixel as (red, green, blue, alpha), each 0–255.
+public typealias Rgba8 = (UInt8, UInt8, UInt8, UInt8)
+
+// ============================================================================
+// MARK: - sRGB ↔ Linear LUT
+// ============================================================================
+//
+// The sRGB standard defines a piecewise transfer function ("gamma curve")
+// that maps device signal (0–255) to linear light intensity (0–1):
+//
+//   Decode  c = byte / 255
+//           c ≤ 0.04045   →  c / 12.92
+//           else          →  ((c + 0.055) / 1.055) ^ 2.4
+//
+//   Encode  c ≤ 0.0031308 →  12.92 * c
+//           else          →  1.055 * c^(1/2.4) − 0.055
+//
+// We precompute a 256-entry decode LUT at module load to avoid repeated
+// calls to `pow` in the inner loops of the interpolation kernels.
+
+/// 256-entry sRGB-byte → linear-Float decode table.
+private let srgbToLinear: [Float] = (0..<256).map { i -> Float in
+    let c = Float(i) / 255.0
+    return c <= 0.04045 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4)
+}
+
+/// Decode one sRGB byte to a linear-light Float in [0, 1].
+private func decode(_ b: UInt8) -> Float { srgbToLinear[Int(b)] }
+
+/// Encode a linear-light Float back to a clamped sRGB byte.
+///
+/// Values below 0 or above 1 are clamped before encoding.
+private func encode(_ v: Float) -> UInt8 {
+    let c = v <= 0.0031308 ? 12.92 * v : 1.055 * pow(v, 1.0 / 2.4) - 0.055
+    let clamped = min(1.0 as Float, max(0.0 as Float, c))
+    return UInt8(min(255, max(0, Int((clamped * 255).rounded()))))
+}
+
+// ============================================================================
+// MARK: - Out-of-Bounds Coordinate Resolution
+// ============================================================================
+//
+// Before reading from the source image at integer coordinates (ix, iy), every
+// sampler passes those coordinates through `resolveCoord` to handle the four
+// OOB strategies:
+//
+//   .zero      — nil signals "return transparent black"
+//   .replicate — clamp: [0, max−1]
+//   .reflect   — fold coordinates back into [0, max−1] with mirror symmetry
+//   .wrap      — modulo with positive-remainder correction
+//
+// The reflect formula uses period = 2 * max:
+//
+//   r = ((x mod period) + period) mod period
+//   if r >= max: r = period − 1 − r
+//
+// Example with max=4 (pixels 0,1,2,3):
+//   x = -1 → r = 3  (mirror: edge pixel 0 reflects to edge pixel 0, -1 → 1)
+//             Actually: period=8, r = ((-1 % 8)+8)%8 = 7; 7 >= 4 → 8-1-7 = 0.
+//   x =  4 → r = 3  (period=8, r=4; 4>=4 → 8-1-4=3)
+//   x =  5 → r = 2  (r=5; 5>=4 → 8-1-5=2)
+
+/// Resolve a 1-D integer coordinate under a given out-of-bounds strategy.
+///
+/// - Parameters:
+///   - x:   The (possibly out-of-range) coordinate.
+///   - max:  One past the last valid index (= image width or height).
+///   - oob:  The out-of-bounds handling mode.
+/// - Returns: A valid coordinate in [0, max), or `nil` for `.zero`.
+private func resolveCoord(_ x: Int, max: Int, oob: OutOfBounds) -> Int? {
+    switch oob {
+    case .zero:
+        // If in range, return as-is; otherwise signal "use transparent black".
+        return (x >= 0 && x < max) ? x : nil
+
+    case .replicate:
+        // Clamp to the nearest valid coordinate.
+        // x < 0 → 0;  x >= max → max − 1.
+        return min(max - 1, Swift.max(0, x))
+
+    case .reflect:
+        // Mirror-pad: fold the coordinate with period = 2 * max.
+        let period = 2 * max
+        var r = ((x % period) + period) % period
+        if r >= max { r = period - 1 - r }
+        return r
+
+    case .wrap:
+        // Tile periodically with positive-remainder modulo.
+        return ((x % max) + max) % max
+    }
+}
+
+// ============================================================================
+// MARK: - Catmull-Rom Cubic Kernel
+// ============================================================================
+//
+// Catmull-Rom is a piecewise cubic spline that passes through its knot points,
+// making it suitable for bicubic image interpolation.  The kernel weight for a
+// distance `d` (in pixels) is:
+//
+//   |d| < 1 :  1.5|d|³ − 2.5|d|² + 1
+//   |d| < 2 : −0.5|d|³ + 2.5|d|² − 4|d| + 2
+//   else    :  0
+//
+// It integrates (sums over integer d) to 1, so colour is conserved.
+// The 4×4 bicubic pass samples at d ∈ {−1, 0, 1, 2} relative to the
+// floored source coordinate.
+
+/// Catmull-Rom cubic weight for distance `d` (in pixels, may be fractional).
+private func catmullRom(_ d: Float) -> Float {
+    let d = abs(d)
+    if d < 1 { return 1.5 * d * d * d - 2.5 * d * d + 1 }
+    if d < 2 { return -0.5 * d * d * d + 2.5 * d * d - 4 * d + 2 }
+    return 0
+}
+
+// ============================================================================
+// MARK: - Samplers (private)
+// ============================================================================
+//
+// Each sampler takes a real-valued source coordinate (u, v) and returns the
+// interpolated colour as Rgba8.  The alpha channel is interpolated in linear
+// space just like the colour channels.
+
+/// Nearest-neighbour sampler.
+///
+/// Rounds (u, v) to the nearest integer pixel and returns it unchanged.
+/// No blending, no colour-space conversion — the fastest possible sampler.
+private func sampleNearest(
+    _ img: PixelContainer,
+    u: Float, v: Float,
+    oob: OutOfBounds
+) -> Rgba8 {
+    let ix = Int(u.rounded())
+    let iy = Int(v.rounded())
+    guard let rx = resolveCoord(ix, max: Int(img.width),  oob: oob),
+          let ry = resolveCoord(iy, max: Int(img.height), oob: oob)
+    else { return (0, 0, 0, 0) }
+    return pixelAt(img, x: UInt32(rx), y: UInt32(ry))
+}
+
+/// Bilinear sampler.
+///
+/// Blends the 2×2 neighbourhood of (u, v) with linear weights.
+/// Decodes each neighbour to linear light, blends, then re-encodes to sRGB.
+///
+/// Let (ix, iy) = floor(u, v), and (tx, ty) = fractional parts.
+/// The four neighbours are at offsets (0,0), (1,0), (0,1), (1,1).
+/// The blend is:
+///
+///   result = (1-tx)(1-ty)*P00 + tx(1-ty)*P10 + (1-tx)ty*P01 + tx*ty*P11
+private func sampleBilinear(
+    _ img: PixelContainer,
+    u: Float, v: Float,
+    oob: OutOfBounds
+) -> Rgba8 {
+    let ix = Int(floor(u))
+    let iy = Int(floor(v))
+    let tx = u - Float(ix)   // fractional x in [0, 1)
+    let ty = v - Float(iy)   // fractional y in [0, 1)
+
+    // Helper: read one neighbour (possibly out-of-bounds) as linear Floats.
+    func linearPixel(dx: Int, dy: Int) -> (Float, Float, Float, Float) {
+        if let rx = resolveCoord(ix + dx, max: Int(img.width),  oob: oob),
+           let ry = resolveCoord(iy + dy, max: Int(img.height), oob: oob) {
+            let (r, g, b, a) = pixelAt(img, x: UInt32(rx), y: UInt32(ry))
+            return (decode(r), decode(g), decode(b), Float(a) / 255.0)
+        }
+        return (0, 0, 0, 0)
+    }
+
+    let (r00, g00, b00, a00) = linearPixel(dx: 0, dy: 0)
+    let (r10, g10, b10, a10) = linearPixel(dx: 1, dy: 0)
+    let (r01, g01, b01, a01) = linearPixel(dx: 0, dy: 1)
+    let (r11, g11, b11, a11) = linearPixel(dx: 1, dy: 1)
+
+    // Bilinear blend weights.
+    let w00 = (1 - tx) * (1 - ty)
+    let w10 =      tx  * (1 - ty)
+    let w01 = (1 - tx) *      ty
+    let w11 =      tx  *      ty
+
+    let r = w00 * r00 + w10 * r10 + w01 * r01 + w11 * r11
+    let g = w00 * g00 + w10 * g10 + w01 * g01 + w11 * g11
+    let b = w00 * b00 + w10 * b10 + w01 * b01 + w11 * b11
+    let a = w00 * a00 + w10 * a10 + w01 * a01 + w11 * a11
+
+    return (encode(r), encode(g), encode(b), UInt8(min(255, max(0, Int((a * 255).rounded())))))
+}
+
+/// Bicubic (Catmull-Rom) sampler.
+///
+/// Blends a 4×4 neighbourhood using the Catmull-Rom spline kernel.
+/// Two-pass implementation: first blend each of the 4 rows horizontally,
+/// then blend those 4 row-results vertically.
+///
+/// For source coordinate u with floor ix:
+///   columns: ix−1, ix, ix+1, ix+2   (offsets −1, 0, 1, 2)
+///   rows:    iy−1, iy, iy+1, iy+2
+///
+/// Each weight wx[j] = catmullRom(tx − (j − 1)) where tx = u − ix.
+private func sampleBicubic(
+    _ img: PixelContainer,
+    u: Float, v: Float,
+    oob: OutOfBounds
+) -> Rgba8 {
+    let ix = Int(floor(u))
+    let iy = Int(floor(v))
+    let tx = u - Float(ix)
+    let ty = v - Float(iy)
+
+    // 1-D Catmull-Rom weights for offsets −1, 0, 1, 2.
+    let wx = (0..<4).map { j in catmullRom(tx - Float(j - 1)) }
+    let wy = (0..<4).map { j in catmullRom(ty - Float(j - 1)) }
+
+    // Helper: decode pixel at (ix+dx, iy+dy) as linear Floats.
+    func lp(dx: Int, dy: Int) -> (Float, Float, Float, Float) {
+        if let rx = resolveCoord(ix + dx, max: Int(img.width),  oob: oob),
+           let ry = resolveCoord(iy + dy, max: Int(img.height), oob: oob) {
+            let (r, g, b, a) = pixelAt(img, x: UInt32(rx), y: UInt32(ry))
+            return (decode(r), decode(g), decode(b), Float(a) / 255.0)
+        }
+        return (0, 0, 0, 0)
+    }
+
+    // Blend each row horizontally.
+    var rowR = [Float](repeating: 0, count: 4)
+    var rowG = [Float](repeating: 0, count: 4)
+    var rowB = [Float](repeating: 0, count: 4)
+    var rowA = [Float](repeating: 0, count: 4)
+    for row in 0..<4 {
+        for col in 0..<4 {
+            let (r, g, b, a) = lp(dx: col - 1, dy: row - 1)
+            rowR[row] += wx[col] * r
+            rowG[row] += wx[col] * g
+            rowB[row] += wx[col] * b
+            rowA[row] += wx[col] * a
+        }
+    }
+
+    // Blend those row-results vertically.
+    var r: Float = 0, g: Float = 0, b: Float = 0, a: Float = 0
+    for row in 0..<4 {
+        r += wy[row] * rowR[row]
+        g += wy[row] * rowG[row]
+        b += wy[row] * rowB[row]
+        a += wy[row] * rowA[row]
+    }
+
+    return (encode(r), encode(g), encode(b), UInt8(min(255, max(0, Int((a * 255).rounded())))))
+}
+
+/// Dispatch to the selected interpolation kernel.
+private func sample(
+    _ img: PixelContainer,
+    u: Float, v: Float,
+    mode: Interpolation,
+    oob: OutOfBounds
+) -> Rgba8 {
+    switch mode {
+    case .nearest:  return sampleNearest(img, u: u, v: v, oob: oob)
+    case .bilinear: return sampleBilinear(img, u: u, v: v, oob: oob)
+    case .bicubic:  return sampleBicubic(img, u: u, v: v, oob: oob)
+    }
+}
+
+// ============================================================================
+// MARK: - Lossless Pixel-Copy Transforms
+// ============================================================================
+//
+// These operations rearrange pixels without mixing values, so they are
+// completely lossless — no sRGB conversion is needed.
+
+// ── Flip ──────────────────────────────────────────────────────────────────
+
+/// Flip the image horizontally (mirror left ↔ right).
+///
+/// Output pixel (x', y') = input pixel (W−1−x', y').
+///
+/// Applying `flipHorizontal` twice returns the original because
+/// W−1−(W−1−x) == x.
+public func flipHorizontal(_ src: PixelContainer) -> PixelContainer {
+    let W = src.width, H = src.height
+    var out = PixelContainer(width: W, height: H)
+    for y: UInt32 in 0..<H {
+        for x: UInt32 in 0..<W {
+            let (r, g, b, a) = pixelAt(src, x: W - 1 - x, y: y)
+            setPixel(&out, x: x, y: y, r: r, g: g, b: b, a: a)
+        }
+    }
+    return out
+}
+
+/// Flip the image vertically (mirror top ↔ bottom).
+///
+/// Output pixel (x', y') = input pixel (x', H−1−y').
+public func flipVertical(_ src: PixelContainer) -> PixelContainer {
+    let W = src.width, H = src.height
+    var out = PixelContainer(width: W, height: H)
+    for y: UInt32 in 0..<H {
+        for x: UInt32 in 0..<W {
+            let (r, g, b, a) = pixelAt(src, x: x, y: H - 1 - y)
+            setPixel(&out, x: x, y: y, r: r, g: g, b: b, a: a)
+        }
+    }
+    return out
+}
+
+// ── 90° / 180° Rotation ───────────────────────────────────────────────────
+//
+// 90° CW rotation of a W×H source produces an H×W output.
+//
+// Deriving the inverse map by tracking the four corners:
+//
+//   Source (W×H) corner   →   Output (H×W) corner
+//   top-left    (0,   0)  →   top-right    (H−1, 0)
+//   top-right   (W−1, 0)  →   bottom-right (H−1, W−1)
+//   bottom-left (0,   H−1)→   top-left     (0,   0)
+//   bottom-right(W−1, H−1)→   bottom-left  (0,   W−1)
+//
+// For output (x', y') where x' ∈ [0, H−1] and y' ∈ [0, W−1]:
+//   Inverse map:  x_src = y'   (range [0, W−1], valid for src.width=W)
+//                 y_src = H−1−x'  (range [0, H−1], valid for src.height=H)
+//
+// For 90° CCW (W×H source → H×W output):
+//   Inverse map:  x_src = W−1−y'  (range [0, W−1], valid for src.width=W)
+//                 y_src = x'       (range [0, H−1], valid for src.height=H)
+//
+// Note: the spec document contains the formula "O[x'][y'] = I[y'][W−1−x']"
+// which uses W where H is required for y_src, and similarly for CCW.  The
+// correct expressions use src.height (H) for CW and src.width (W) for CCW.
+
+/// Rotate the image 90° clockwise.
+///
+/// Output dimensions: W' = src.height, H' = src.width.
+/// Inverse map: x_src = y', y_src = src.height − 1 − x'.
+public func rotate90CW(_ src: PixelContainer) -> PixelContainer {
+    let W = src.width, H = src.height
+    // After 90° CW: new width = old height, new height = old width.
+    var out = PixelContainer(width: H, height: W)
+    for y: UInt32 in 0..<W {           // output row:    0 ..< old width
+        for x: UInt32 in 0..<H {       // output column: 0 ..< old height
+            // x_src = y (output row → source column)
+            // y_src = H-1-x (output column maps into source row, reversed)
+            let (r, g, b, a) = pixelAt(src, x: y, y: H - 1 - x)
+            setPixel(&out, x: x, y: y, r: r, g: g, b: b, a: a)
+        }
+    }
+    return out
+}
+
+/// Rotate the image 90° counter-clockwise.
+///
+/// Output dimensions: W' = src.height, H' = src.width.
+/// Inverse map: x_src = src.width − 1 − y', y_src = x'.
+public func rotate90CCW(_ src: PixelContainer) -> PixelContainer {
+    let W = src.width, H = src.height
+    var out = PixelContainer(width: H, height: W)
+    for y: UInt32 in 0..<W {           // output row:    0 ..< old width
+        for x: UInt32 in 0..<H {       // output column: 0 ..< old height
+            // x_src = W-1-y (output row, reversed, → source column)
+            // y_src = x     (output column → source row)
+            let (r, g, b, a) = pixelAt(src, x: W - 1 - y, y: x)
+            setPixel(&out, x: x, y: y, r: r, g: g, b: b, a: a)
+        }
+    }
+    return out
+}
+
+/// Rotate the image 180°.
+///
+/// Output dimensions are unchanged.
+/// Mapping: O[x'][y'] = I[W−1−x'][H−1−y'].
+/// Equivalent to flipHorizontal ∘ flipVertical (or vice versa).
+public func rotate180(_ src: PixelContainer) -> PixelContainer {
+    let W = src.width, H = src.height
+    var out = PixelContainer(width: W, height: H)
+    for y: UInt32 in 0..<H {
+        for x: UInt32 in 0..<W {
+            let (r, g, b, a) = pixelAt(src, x: W - 1 - x, y: H - 1 - y)
+            setPixel(&out, x: x, y: y, r: r, g: g, b: b, a: a)
+        }
+    }
+    return out
+}
+
+// ── Crop ──────────────────────────────────────────────────────────────────
+
+/// Crop a rectangular region from the source image.
+///
+/// Returns a new image of size (w × h) whose top-left corner maps to
+/// source pixel (x, y).  If the crop window extends beyond the source
+/// boundary, out-of-bounds source pixels return transparent black.
+///
+/// - Parameters:
+///   - src: Source image.
+///   - x:   Left edge of the crop window (source column).
+///   - y:   Top edge of the crop window (source row).
+///   - w:   Width of the output image in pixels.
+///   - h:   Height of the output image in pixels.
+public func crop(
+    _ src: PixelContainer,
+    x: UInt32, y: UInt32,
+    w: UInt32, h: UInt32
+) -> PixelContainer {
+    var out = PixelContainer(width: w, height: h)
+    for oy: UInt32 in 0..<h {
+        for ox: UInt32 in 0..<w {
+            // Source coordinate: offset into src from the crop origin.
+            let sx = x + ox
+            let sy = y + oy
+            let (r, g, b, a) = pixelAt(src, x: sx, y: sy)
+            // pixelAt returns (0,0,0,0) for out-of-bounds; that is exactly
+            // what we want for crops that extend past the source boundary.
+            setPixel(&out, x: ox, y: oy, r: r, g: g, b: b, a: a)
+        }
+    }
+    return out
+}
+
+// ── Pad ───────────────────────────────────────────────────────────────────
+
+/// Add a border of constant-colour padding around the source image.
+///
+/// The output image is (left + src.width + right) × (top + src.height + bottom).
+/// Interior pixels are copied from the source; border pixels are filled with
+/// `fill` (default transparent black).
+///
+/// - Parameters:
+///   - src:    Source image.
+///   - top:    Rows of padding above the source.
+///   - right:  Columns of padding to the right of the source.
+///   - bottom: Rows of padding below the source.
+///   - left:   Columns of padding to the left of the source.
+///   - fill:   Colour for the border pixels.  Default (0, 0, 0, 0).
+public func pad(
+    _ src: PixelContainer,
+    top: UInt32, right: UInt32, bottom: UInt32, left: UInt32,
+    fill: Rgba8 = (0, 0, 0, 0)
+) -> PixelContainer {
+    let outW = left + src.width  + right
+    let outH = top  + src.height + bottom
+    var out = PixelContainer(width: outW, height: outH)
+
+    // Fill the entire canvas with the border colour first.
+    for y: UInt32 in 0..<outH {
+        for x: UInt32 in 0..<outW {
+            setPixel(&out, x: x, y: y, r: fill.0, g: fill.1, b: fill.2, a: fill.3)
+        }
+    }
+
+    // Copy source pixels into the interior.
+    for sy: UInt32 in 0..<src.height {
+        for sx: UInt32 in 0..<src.width {
+            let (r, g, b, a) = pixelAt(src, x: sx, y: sy)
+            setPixel(&out, x: left + sx, y: top + sy, r: r, g: g, b: b, a: a)
+        }
+    }
+    return out
+}
+
+// ============================================================================
+// MARK: - Continuous-Coordinate Resampling Transforms
+// ============================================================================
+
+// ── Scale ─────────────────────────────────────────────────────────────────
+//
+// Scaling maps each output pixel (x', y') back to a source coordinate (u, v).
+// We use the pixel-centre convention: pixel x occupies [x, x+1), so its centre
+// is at x + 0.5.
+//
+// If the source has width W and the output has width W', the scale factor
+// is sx = W' / W (output pixels per source pixel).  The source centre that
+// maps to output centre x' + 0.5 is:
+//
+//   u = (x' + 0.5) / sx − 0.5
+//     = (x' + 0.5) * (W / W') − 0.5
+//
+// This ensures that the leftmost output pixel samples near the leftmost source
+// pixel, and the rightmost output pixel samples near the rightmost source
+// pixel, with no padding artefact.
+
+/// Resize the image to (outW × outH) using the selected interpolation.
+///
+/// Uses pixel-centre mapping with `.replicate` out-of-bounds handling so that
+/// the single-pixel border of the source is correctly extended rather than
+/// replaced with transparent black.
+///
+/// - Parameters:
+///   - src:   Source image.
+///   - outW:  Output width in pixels.
+///   - outH:  Output height in pixels.
+///   - mode:  Interpolation kernel.  Default `.bilinear`.
+public func scale(
+    _ src: PixelContainer,
+    width outW: UInt32,
+    height outH: UInt32,
+    mode: Interpolation = .bilinear
+) -> PixelContainer {
+    var out = PixelContainer(width: outW, height: outH)
+    // Scale factors: how many source pixels per output pixel.
+    let sx = Float(src.width)  / Float(outW)
+    let sy = Float(src.height) / Float(outH)
+
+    for oy: UInt32 in 0..<outH {
+        for ox: UInt32 in 0..<outW {
+            // Pixel-centre mapping: map output centre → source centre.
+            let u = (Float(ox) + 0.5) * sx - 0.5
+            let v = (Float(oy) + 0.5) * sy - 0.5
+            let px = sample(src, u: u, v: v, mode: mode, oob: .replicate)
+            setPixel(&out, x: ox, y: oy, r: px.0, g: px.1, b: px.2, a: px.3)
+        }
+    }
+    return out
+}
+
+// ── Arbitrary-Angle Rotation ──────────────────────────────────────────────
+//
+// Rotation by angle θ (radians, CCW positive) maps output coordinates to
+// source coordinates via an inverse rotation:
+//
+//   dx = x' − cxOut       (offset from output centre)
+//   dy = y' − cyOut
+//
+//   u = cxIn + cos(θ)*dx + sin(θ)*dy
+//   v = cyIn − sin(θ)*dx + cos(θ)*dy
+//
+// Note: adding sin(θ)*dy (not −sin) gives the inverse (CW) rotation.
+//
+// For `.fit` bounds, the output canvas is expanded to contain all four
+// rotated corners of the source:
+//
+//   outW = ceil(W |cos θ| + H |sin θ|)
+//   outH = ceil(W |sin θ| + H |cos θ|)
+
+/// Rotate the image by `radians` around its centre.
+///
+/// Positive `radians` rotates counter-clockwise (standard mathematical
+/// convention).  The `.fit` bounds mode expands the canvas so no source
+/// pixels are clipped; the `.crop` mode keeps the original canvas size.
+///
+/// Pixels outside the source image are filled with transparent black (`.zero`
+/// OOB).  Use `pad` before rotating if you need a different border colour.
+///
+/// - Parameters:
+///   - src:     Source image.
+///   - radians: Rotation angle.  Positive = CCW.
+///   - mode:    Interpolation kernel.  Default `.bilinear`.
+///   - bounds:  Output canvas sizing strategy.  Default `.fit`.
+public func rotate(
+    _ src: PixelContainer,
+    radians: Float,
+    mode: Interpolation = .bilinear,
+    bounds: RotateBounds = .fit
+) -> PixelContainer {
+    let W = Float(src.width)
+    let H = Float(src.height)
+    let cosA = Foundation.cos(radians)
+    let sinA = Foundation.sin(radians)
+
+    // Compute output dimensions.
+    let outW: UInt32
+    let outH: UInt32
+    switch bounds {
+    case .fit:
+        // Enlarge canvas to contain all four rotated corners.
+        outW = UInt32(ceil(W * abs(cosA) + H * abs(sinA)))
+        outH = UInt32(ceil(W * abs(sinA) + H * abs(cosA)))
+    case .crop:
+        outW = src.width
+        outH = src.height
+    }
+
+    let cxOut = Float(outW) / 2.0
+    let cyOut = Float(outH) / 2.0
+    let cxIn  = W / 2.0
+    let cyIn  = H / 2.0
+
+    var out = PixelContainer(width: outW, height: outH)
+    for oy: UInt32 in 0..<outH {
+        for ox: UInt32 in 0..<outW {
+            // Offset from output centre.
+            let dx = Float(ox) - cxOut
+            let dy = Float(oy) - cyOut
+
+            // Inverse-rotate to find source coordinate.
+            // (Using CCW rotation angle θ, the inverse is CW by −θ, but
+            //  written out it becomes: u = cx + cos·dx + sin·dy,
+            //                          v = cy − sin·dx + cos·dy)
+            let u = cxIn + cosA * dx + sinA * dy
+            let v = cyIn - sinA * dx + cosA * dy
+
+            let px = sample(src, u: u, v: v, mode: mode, oob: .zero)
+            setPixel(&out, x: ox, y: oy, r: px.0, g: px.1, b: px.2, a: px.3)
+        }
+    }
+    return out
+}
+
+// ── Affine Warp ────────────────────────────────────────────────────────────
+//
+// An affine transform maps output pixel (x', y') to source coordinate (u, v)
+// via a 2×3 matrix M:
+//
+//   u = M[0][0]*x' + M[0][1]*y' + M[0][2]
+//   v = M[1][0]*x' + M[1][1]*y' + M[1][2]
+//
+// The 2×3 form is the standard for 2-D affine maps: it encodes a 2×2 linear
+// part (rotation, scale, shear) plus a 2×1 translation column.
+//
+// Common matrices:
+//   Identity:  [[1,0,0],[0,1,0]]
+//   Scale 2×:  [[0.5,0,0],[0,0.5,0]]   (map output → half source)
+//   Translate: [[1,0,tx],[0,1,ty]]
+
+/// Apply a 2×3 affine matrix to warp the source into an (outW × outH) canvas.
+///
+/// Matrix layout (row-major, 2 rows × 3 columns):
+///
+/// ```
+/// [ m00  m01  m02 ]     u = m00*x' + m01*y' + m02
+/// [ m10  m11  m12 ]     v = m10*x' + m11*y' + m12
+/// ```
+///
+/// - Parameters:
+///   - src:    Source image.
+///   - matrix: 2×3 Float array (outer index = row, inner = column).
+///   - outW:   Output width.
+///   - outH:   Output height.
+///   - mode:   Interpolation.  Default `.bilinear`.
+///   - oob:    Out-of-bounds handling.  Default `.replicate`.
+public func affine(
+    _ src: PixelContainer,
+    matrix: [[Float]],
+    width outW: UInt32,
+    height outH: UInt32,
+    mode: Interpolation = .bilinear,
+    oob: OutOfBounds = .replicate
+) -> PixelContainer {
+    var out = PixelContainer(width: outW, height: outH)
+    let m = matrix
+    for oy: UInt32 in 0..<outH {
+        for ox: UInt32 in 0..<outW {
+            let xf = Float(ox)
+            let yf = Float(oy)
+            let u = m[0][0] * xf + m[0][1] * yf + m[0][2]
+            let v = m[1][0] * xf + m[1][1] * yf + m[1][2]
+            let px = sample(src, u: u, v: v, mode: mode, oob: oob)
+            setPixel(&out, x: ox, y: oy, r: px.0, g: px.1, b: px.2, a: px.3)
+        }
+    }
+    return out
+}
+
+// ── Perspective Warp ──────────────────────────────────────────────────────
+//
+// A perspective (projective) transform is the most general linear map between
+// planes.  It is described by a 3×3 homogeneous matrix H.
+//
+// Given output pixel (x', y'), the source coordinate is:
+//
+//   w  = H[2][0]*x' + H[2][1]*y' + H[2][2]
+//   u  = (H[0][0]*x' + H[0][1]*y' + H[0][2]) / w
+//   v  = (H[1][0]*x' + H[1][1]*y' + H[1][2]) / w
+//
+// When w = 1 for all (x', y'), this reduces to an affine transform (the
+// 3×3 bottom row is [0, 0, 1]).
+//
+// The division by w is the perspective division; it is what produces the
+// "vanishing point" effect where parallel lines appear to converge.
+
+/// Apply a 3×3 homogeneous perspective matrix to warp the source.
+///
+/// Matrix layout (row-major, 3×3):
+///
+/// ```
+/// [ h00  h01  h02 ]     w = h20*x' + h21*y' + h22
+/// [ h10  h11  h12 ]     u = (h00*x' + h01*y' + h02) / w
+/// [ h20  h21  h22 ]     v = (h10*x' + h11*y' + h12) / w
+/// ```
+///
+/// - Parameters:
+///   - src:    Source image.
+///   - h:      3×3 Float array.
+///   - outW:   Output width.
+///   - outH:   Output height.
+///   - mode:   Interpolation.  Default `.bilinear`.
+///   - oob:    Out-of-bounds handling.  Default `.replicate`.
+public func perspectiveWarp(
+    _ src: PixelContainer,
+    matrix h: [[Float]],
+    width outW: UInt32,
+    height outH: UInt32,
+    mode: Interpolation = .bilinear,
+    oob: OutOfBounds = .replicate
+) -> PixelContainer {
+    var out = PixelContainer(width: outW, height: outH)
+    for oy: UInt32 in 0..<outH {
+        for ox: UInt32 in 0..<outW {
+            let xf = Float(ox)
+            let yf = Float(oy)
+            let w = h[2][0] * xf + h[2][1] * yf + h[2][2]
+            // Guard against degenerate (w ≈ 0) projective points.
+            guard abs(w) > 1e-9 else { continue }
+            let u = (h[0][0] * xf + h[0][1] * yf + h[0][2]) / w
+            let v = (h[1][0] * xf + h[1][1] * yf + h[1][2]) / w
+            let px = sample(src, u: u, v: v, mode: mode, oob: oob)
+            setPixel(&out, x: ox, y: oy, r: px.0, g: px.1, b: px.2, a: px.3)
+        }
+    }
+    return out
+}

--- a/code/packages/swift/ImageGeometricTransforms/Tests/ImageGeometricTransformsTests/ImageGeometricTransformsTests.swift
+++ b/code/packages/swift/ImageGeometricTransforms/Tests/ImageGeometricTransformsTests/ImageGeometricTransformsTests.swift
@@ -1,0 +1,508 @@
+// ImageGeometricTransformsTests.swift
+// Part of coding-adventures — an educational computing stack.
+//
+// ============================================================================
+// MARK: - IMG04 Test Suite
+// ============================================================================
+//
+// Coverage targets:
+//   - Every public function has at least one happy-path test.
+//   - Round-trip identities (double-flip, CW+CCW, rotate 0, affine identity).
+//   - Dimension assertions for all transforms that change canvas size.
+//   - Pixel-value assertions for lossless transforms.
+//   - Near-identity assertions (±2 per channel) for resampling transforms.
+//   - OOB mode smoke tests (no crash; sensible values).
+//   - Interpolation-specific tests (nearest exact, bilinear midpoint blend).
+
+import XCTest
+import PixelContainer
+@testable import ImageGeometricTransforms
+
+// ============================================================================
+// MARK: - Test Helpers
+// ============================================================================
+
+/// Create a 1×1 image with a single RGBA pixel.
+private func solid(_ r: UInt8, _ g: UInt8, _ b: UInt8, _ a: UInt8) -> PixelContainer {
+    var img = PixelContainer(width: 1, height: 1)
+    setPixel(&img, x: 0, y: 0, r: r, g: g, b: b, a: a)
+    return img
+}
+
+/// Read the single pixel from a 1×1 image.
+private func px(_ img: PixelContainer) -> (UInt8, UInt8, UInt8, UInt8) {
+    pixelAt(img, x: 0, y: 0)
+}
+
+/// Create a W×H image with a horizontal gradient: pixel (x, y) has R = x * 255 / (W-1).
+private func hGradient(width W: UInt32, height H: UInt32) -> PixelContainer {
+    var img = PixelContainer(width: W, height: H)
+    for y: UInt32 in 0..<H {
+        for x: UInt32 in 0..<W {
+            let v = W > 1 ? UInt8(UInt32(x) * 255 / (W - 1)) : UInt8(0)
+            setPixel(&img, x: x, y: y, r: v, g: 0, b: 0, a: 255)
+        }
+    }
+    return img
+}
+
+/// Create a small checkerboard: alternating white/black 1×1 tiles.
+private func checker(width W: UInt32, height H: UInt32) -> PixelContainer {
+    var img = PixelContainer(width: W, height: H)
+    for y: UInt32 in 0..<H {
+        for x: UInt32 in 0..<W {
+            let v: UInt8 = ((x + y) % 2 == 0) ? 255 : 0
+            setPixel(&img, x: x, y: y, r: v, g: v, b: v, a: 255)
+        }
+    }
+    return img
+}
+
+// ============================================================================
+// MARK: - Test Case
+// ============================================================================
+
+final class ImageGeometricTransformsTests: XCTestCase {
+
+    // ── flipHorizontal ────────────────────────────────────────────────────
+
+    /// After a horizontal flip the image dimensions are unchanged.
+    func testFlipHorizontalPreservesDimensions() {
+        let src = PixelContainer(width: 5, height: 3)
+        let out = flipHorizontal(src)
+        XCTAssertEqual(out.width, 5)
+        XCTAssertEqual(out.height, 3)
+    }
+
+    /// Left-most column of the source becomes the right-most column of the output.
+    func testFlipHorizontalMovesPixels() {
+        var src = PixelContainer(width: 4, height: 1)
+        setPixel(&src, x: 0, y: 0, r: 255, g: 0, b: 0, a: 255)
+        setPixel(&src, x: 3, y: 0, r: 0,   g: 0, b: 255, a: 255)
+        let out = flipHorizontal(src)
+        // src[0] → out[3], src[3] → out[0]
+        let (r0, _, b0, _) = pixelAt(out, x: 0, y: 0)
+        let (r3, _, b3, _) = pixelAt(out, x: 3, y: 0)
+        XCTAssertEqual(b0, 255)   // original right pixel moved to left
+        XCTAssertEqual(r3, 255)   // original left pixel moved to right
+        XCTAssertEqual(r0, 0)
+        XCTAssertEqual(b3, 0)
+    }
+
+    /// Applying flipHorizontal twice is the identity.
+    func testFlipHorizontalDoubleIdentity() {
+        let src = checker(width: 6, height: 4)
+        let restored = flipHorizontal(flipHorizontal(src))
+        for y: UInt32 in 0..<src.height {
+            for x: UInt32 in 0..<src.width {
+                let (r,  g,  b,  a)  = pixelAt(src,      x: x, y: y)
+                let (r2, g2, b2, a2) = pixelAt(restored, x: x, y: y)
+                XCTAssertEqual(r, r2, "r mismatch at (\(x),\(y))")
+                XCTAssertEqual(g, g2, "g mismatch at (\(x),\(y))")
+                XCTAssertEqual(b, b2, "b mismatch at (\(x),\(y))")
+                XCTAssertEqual(a, a2, "a mismatch at (\(x),\(y))")
+            }
+        }
+    }
+
+    // ── flipVertical ──────────────────────────────────────────────────────
+
+    /// Top row of the source becomes the bottom row of the output.
+    func testFlipVerticalMovesPixels() {
+        var src = PixelContainer(width: 1, height: 4)
+        setPixel(&src, x: 0, y: 0, r: 255, g: 0, b: 0, a: 255)
+        setPixel(&src, x: 0, y: 3, r: 0,   g: 0, b: 255, a: 255)
+        let out = flipVertical(src)
+        let (r0, _, b0, _) = pixelAt(out, x: 0, y: 0)
+        let (r3, _, b3, _) = pixelAt(out, x: 0, y: 3)
+        XCTAssertEqual(b0, 255)
+        XCTAssertEqual(r3, 255)
+        XCTAssertEqual(r0, 0)
+        XCTAssertEqual(b3, 0)
+    }
+
+    /// Applying flipVertical twice is the identity.
+    func testFlipVerticalDoubleIdentity() {
+        let src = checker(width: 5, height: 5)
+        let restored = flipVertical(flipVertical(src))
+        for y: UInt32 in 0..<src.height {
+            for x: UInt32 in 0..<src.width {
+                let (r, g, b, a)     = pixelAt(src,      x: x, y: y)
+                let (r2, g2, b2, a2) = pixelAt(restored, x: x, y: y)
+                XCTAssertEqual(r, r2); XCTAssertEqual(g, g2)
+                XCTAssertEqual(b, b2); XCTAssertEqual(a, a2)
+            }
+        }
+    }
+
+    // ── rotate90CW / rotate90CCW ──────────────────────────────────────────
+
+    /// A 90° CW rotation swaps width and height.
+    func testRotate90CWSwapsDimensions() {
+        let src = PixelContainer(width: 7, height: 3)
+        let out = rotate90CW(src)
+        XCTAssertEqual(out.width,  3)  // new width  = old height
+        XCTAssertEqual(out.height, 7)  // new height = old width
+    }
+
+    /// A 90° CCW rotation swaps width and height.
+    func testRotate90CCWSwapsDimensions() {
+        let src = PixelContainer(width: 7, height: 3)
+        let out = rotate90CCW(src)
+        XCTAssertEqual(out.width,  3)
+        XCTAssertEqual(out.height, 7)
+    }
+
+    /// CW followed by CCW returns the original image exactly.
+    func testRotate90CWThenCCWIsIdentity() {
+        let src = checker(width: 4, height: 6)
+        let restored = rotate90CCW(rotate90CW(src))
+        XCTAssertEqual(restored.width,  src.width)
+        XCTAssertEqual(restored.height, src.height)
+        for y: UInt32 in 0..<src.height {
+            for x: UInt32 in 0..<src.width {
+                let (r,  g,  b,  a)  = pixelAt(src,      x: x, y: y)
+                let (r2, g2, b2, a2) = pixelAt(restored, x: x, y: y)
+                XCTAssertEqual(r, r2); XCTAssertEqual(g, g2)
+                XCTAssertEqual(b, b2); XCTAssertEqual(a, a2)
+            }
+        }
+    }
+
+    /// Four 90° CW rotations return the original image.
+    func testRotate90CWFourTimesIsIdentity() {
+        let src = checker(width: 3, height: 3)
+        let restored = rotate90CW(rotate90CW(rotate90CW(rotate90CW(src))))
+        for y: UInt32 in 0..<src.height {
+            for x: UInt32 in 0..<src.width {
+                let (r,  g,  b,  a)  = pixelAt(src,      x: x, y: y)
+                let (r2, g2, b2, a2) = pixelAt(restored, x: x, y: y)
+                XCTAssertEqual(r, r2); XCTAssertEqual(g, g2)
+                XCTAssertEqual(b, b2); XCTAssertEqual(a, a2)
+            }
+        }
+    }
+
+    // ── rotate180 ─────────────────────────────────────────────────────────
+
+    /// Applying rotate180 twice is the identity.
+    func testRotate180TwiceIsIdentity() {
+        let src = checker(width: 5, height: 5)
+        let restored = rotate180(rotate180(src))
+        for y: UInt32 in 0..<src.height {
+            for x: UInt32 in 0..<src.width {
+                let (r,  g,  b,  a)  = pixelAt(src,      x: x, y: y)
+                let (r2, g2, b2, a2) = pixelAt(restored, x: x, y: y)
+                XCTAssertEqual(r, r2); XCTAssertEqual(g, g2)
+                XCTAssertEqual(b, b2); XCTAssertEqual(a, a2)
+            }
+        }
+    }
+
+    /// rotate180 is equivalent to flipH composed with flipV.
+    func testRotate180EqualsDoubleFlip() {
+        let src = checker(width: 4, height: 4)
+        let via180  = rotate180(src)
+        let viaFlip = flipVertical(flipHorizontal(src))
+        for y: UInt32 in 0..<src.height {
+            for x: UInt32 in 0..<src.width {
+                let (r1, g1, b1, a1) = pixelAt(via180,  x: x, y: y)
+                let (r2, g2, b2, a2) = pixelAt(viaFlip, x: x, y: y)
+                XCTAssertEqual(r1, r2); XCTAssertEqual(g1, g2)
+                XCTAssertEqual(b1, b2); XCTAssertEqual(a1, a2)
+            }
+        }
+    }
+
+    // ── crop ──────────────────────────────────────────────────────────────
+
+    /// Crop returns the requested dimensions.
+    func testCropDimensions() {
+        let src = PixelContainer(width: 10, height: 10)
+        let out = crop(src, x: 2, y: 3, w: 4, h: 5)
+        XCTAssertEqual(out.width,  4)
+        XCTAssertEqual(out.height, 5)
+    }
+
+    /// Crop preserves pixel values from the correct source location.
+    func testCropPixelValues() {
+        var src = PixelContainer(width: 5, height: 5)
+        // Paint a single distinguishable pixel at (3, 2).
+        setPixel(&src, x: 3, y: 2, r: 200, g: 100, b: 50, a: 255)
+        // Crop from (2, 1) with size 3×3 — the marked pixel is now at (1, 1).
+        let out = crop(src, x: 2, y: 1, w: 3, h: 3)
+        let (r, g, b, a) = pixelAt(out, x: 1, y: 1)
+        XCTAssertEqual(r, 200)
+        XCTAssertEqual(g, 100)
+        XCTAssertEqual(b, 50)
+        XCTAssertEqual(a, 255)
+    }
+
+    // ── pad ───────────────────────────────────────────────────────────────
+
+    /// Pad returns the correct expanded dimensions.
+    func testPadDimensions() {
+        let src = PixelContainer(width: 4, height: 4)
+        let out = pad(src, top: 1, right: 2, bottom: 3, left: 4)
+        XCTAssertEqual(out.width,  4 + 4 + 2)   // left + src + right
+        XCTAssertEqual(out.height, 1 + 4 + 3)   // top  + src + bottom
+    }
+
+    /// Border pixels have the fill colour.
+    func testPadFillBorder() {
+        let src = PixelContainer(width: 2, height: 2)
+        let out = pad(src, top: 1, right: 1, bottom: 1, left: 1,
+                      fill: (255, 0, 128, 255))
+        // Top-left corner is a border pixel.
+        let (r, g, b, a) = pixelAt(out, x: 0, y: 0)
+        XCTAssertEqual(r, 255)
+        XCTAssertEqual(g, 0)
+        XCTAssertEqual(b, 128)
+        XCTAssertEqual(a, 255)
+    }
+
+    /// Interior pixels are copied unchanged from the source.
+    func testPadInteriorPreserved() {
+        var src = PixelContainer(width: 2, height: 2)
+        setPixel(&src, x: 0, y: 0, r: 77, g: 88, b: 99, a: 200)
+        let out = pad(src, top: 2, right: 0, bottom: 0, left: 3,
+                      fill: (0, 0, 0, 255))
+        // The (0,0) source pixel is now at (3, 2) in the output.
+        let (r, g, b, a) = pixelAt(out, x: 3, y: 2)
+        XCTAssertEqual(r, 77)
+        XCTAssertEqual(g, 88)
+        XCTAssertEqual(b, 99)
+        XCTAssertEqual(a, 200)
+    }
+
+    // ── scale ─────────────────────────────────────────────────────────────
+
+    /// Scaling up doubles the dimensions.
+    func testScaleUpDoublesDimensions() {
+        let src = PixelContainer(width: 3, height: 5)
+        let out = scale(src, width: 6, height: 10)
+        XCTAssertEqual(out.width,  6)
+        XCTAssertEqual(out.height, 10)
+    }
+
+    /// Scaling down halves the dimensions.
+    func testScaleDownHalvesDimensions() {
+        let src = PixelContainer(width: 8, height: 6)
+        let out = scale(src, width: 4, height: 3)
+        XCTAssertEqual(out.width,  4)
+        XCTAssertEqual(out.height, 3)
+    }
+
+    /// Scaling with replicate OOB does not crash.
+    func testScaleReplicateOOBNoCrash() {
+        let src = solid(128, 64, 32, 255)
+        let out = scale(src, width: 3, height: 3, mode: .bilinear)
+        XCTAssertEqual(out.width, 3)
+        XCTAssertEqual(out.height, 3)
+    }
+
+    // ── rotate (arbitrary angle) ──────────────────────────────────────────
+
+    /// Rotating by 0 radians is approximately the identity (±2 per channel).
+    func testRotateZeroApproxIdentity() {
+        let src = checker(width: 5, height: 5)
+        let out = rotate(src, radians: 0.0, mode: .bilinear, bounds: .crop)
+        // With .crop bounds rotate(0) returns the same size.
+        XCTAssertEqual(out.width,  src.width)
+        XCTAssertEqual(out.height, src.height)
+        for y: UInt32 in 0..<src.height {
+            for x: UInt32 in 0..<src.width {
+                let (ir, ig, ib, _) = pixelAt(src, x: x, y: y)
+                let ( r,  g,  b, _) = pixelAt(out, x: x, y: y)
+                XCTAssertLessThanOrEqual(abs(Int(r) - Int(ir)), 2, "r at (\(x),\(y))")
+                XCTAssertLessThanOrEqual(abs(Int(g) - Int(ig)), 2, "g at (\(x),\(y))")
+                XCTAssertLessThanOrEqual(abs(Int(b) - Int(ib)), 2, "b at (\(x),\(y))")
+            }
+        }
+    }
+
+    /// Rotating by .fit expands the canvas (for a 45° rotation of a square).
+    func testRotateFitExpandsCanvas() {
+        let src = PixelContainer(width: 10, height: 10)
+        let out = rotate(src, radians: Float.pi / 4, bounds: .fit)
+        // Diagonal of a 10×10 is ~14.14, so both dimensions should be >10.
+        XCTAssertGreaterThan(out.width,  src.width)
+        XCTAssertGreaterThan(out.height, src.height)
+    }
+
+    // ── affine ────────────────────────────────────────────────────────────
+
+    /// Affine identity matrix returns an image approximately equal to the source.
+    func testAffineIdentityApproxIdentity() {
+        let src = checker(width: 4, height: 4)
+        let identity: [[Float]] = [[1, 0, 0], [0, 1, 0]]
+        let out = affine(src, matrix: identity, width: src.width, height: src.height,
+                         mode: .nearest, oob: .replicate)
+        for y: UInt32 in 0..<src.height {
+            for x: UInt32 in 0..<src.width {
+                let (ir, ig, ib, _) = pixelAt(src, x: x, y: y)
+                let ( r,  g,  b, _) = pixelAt(out, x: x, y: y)
+                XCTAssertLessThanOrEqual(abs(Int(r) - Int(ir)), 2)
+                XCTAssertLessThanOrEqual(abs(Int(g) - Int(ig)), 2)
+                XCTAssertLessThanOrEqual(abs(Int(b) - Int(ib)), 2)
+            }
+        }
+    }
+
+    /// Affine translate shifts pixels by the specified offset.
+    func testAffineTranslate() {
+        var src = PixelContainer(width: 5, height: 5)
+        setPixel(&src, x: 2, y: 2, r: 200, g: 0, b: 0, a: 255)
+        // Translate by (-1, -1): output pixel at (1,1) should sample source (2,2).
+        let translate: [[Float]] = [[1, 0, 1], [0, 1, 1]]
+        let out = affine(src, matrix: translate, width: 5, height: 5,
+                         mode: .nearest, oob: .zero)
+        let (r, _, _, _) = pixelAt(out, x: 1, y: 1)
+        XCTAssertEqual(r, 200)
+    }
+
+    // ── perspectiveWarp ───────────────────────────────────────────────────
+
+    /// A perspective identity matrix (bottom row [0,0,1]) is approximately identity.
+    func testPerspectiveIdentityApproxIdentity() {
+        let src = checker(width: 4, height: 4)
+        // Identity perspective: H = 3×3 with diagonal 1s.
+        let h: [[Float]] = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+        let out = perspectiveWarp(src, matrix: h, width: src.width, height: src.height,
+                                  mode: .nearest, oob: .replicate)
+        for y: UInt32 in 0..<src.height {
+            for x: UInt32 in 0..<src.width {
+                let (ir, ig, ib, _) = pixelAt(src, x: x, y: y)
+                let ( r,  g,  b, _) = pixelAt(out, x: x, y: y)
+                XCTAssertLessThanOrEqual(abs(Int(r) - Int(ir)), 2)
+                XCTAssertLessThanOrEqual(abs(Int(g) - Int(ig)), 2)
+                XCTAssertLessThanOrEqual(abs(Int(b) - Int(ib)), 2)
+            }
+        }
+    }
+
+    // ── Nearest-neighbour exact values ────────────────────────────────────
+
+    /// Nearest sampler returns exact (un-blended) source pixel values.
+    func testNearestReturnsExactValues() {
+        var src = PixelContainer(width: 3, height: 1)
+        setPixel(&src, x: 0, y: 0, r: 10,  g: 20,  b: 30,  a: 255)
+        setPixel(&src, x: 1, y: 0, r: 100, g: 110, b: 120, a: 255)
+        setPixel(&src, x: 2, y: 0, r: 200, g: 210, b: 220, a: 255)
+        // Scale 2× with nearest: output [0]=src[0], [1]=src[0], [2]=src[1], etc.
+        let out = scale(src, width: 6, height: 1, mode: .nearest)
+        // Output pixel 0 should be src pixel 0.
+        let (r0, g0, b0, _) = pixelAt(out, x: 0, y: 0)
+        XCTAssertEqual(r0, 10)
+        XCTAssertEqual(g0, 20)
+        XCTAssertEqual(b0, 30)
+        // Output pixel 4 or 5 should be src pixel 2.
+        let (r5, g5, b5, _) = pixelAt(out, x: 5, y: 0)
+        XCTAssertEqual(r5, 200)
+        XCTAssertEqual(g5, 210)
+        XCTAssertEqual(b5, 220)
+    }
+
+    // ── Bilinear midpoint blend ────────────────────────────────────────────
+
+    /// Bilinear interpolation at the midpoint of two pixels should blend them.
+    ///
+    /// For a 1×2 source [left=0, right=255] scaled to 1×4 with bilinear,
+    /// the middle output pixels should have intermediate values.
+    func testBilinearBlendsMidpoint() {
+        var src = PixelContainer(width: 2, height: 1)
+        setPixel(&src, x: 0, y: 0, r: 0,   g: 0, b: 0, a: 255)
+        setPixel(&src, x: 1, y: 0, r: 255, g: 0, b: 0, a: 255)
+        let out = scale(src, width: 4, height: 1, mode: .bilinear)
+        // The middle two output pixels should be between 0 and 255.
+        let (r1, _, _, _) = pixelAt(out, x: 1, y: 0)
+        let (r2, _, _, _) = pixelAt(out, x: 2, y: 0)
+        XCTAssertGreaterThan(r1, 0,   "bilinear blend should be > 0 at x=1")
+        XCTAssertLessThan   (r1, 255, "bilinear blend should be < 255 at x=1")
+        XCTAssertGreaterThan(r2, 0,   "bilinear blend should be > 0 at x=2")
+        XCTAssertLessThan   (r2, 255, "bilinear blend should be < 255 at x=2")
+    }
+
+    // ── OOB mode smoke tests ──────────────────────────────────────────────
+
+    /// Scaling a 1-pixel image with nearest sampler and all four OOB modes
+    /// does not crash and produces a valid image.
+    func testScaleOOBModesNoCrash() {
+        let src = solid(100, 150, 200, 255)
+        for oob: OutOfBounds in [.zero, .replicate, .reflect, .wrap] {
+            let identity: [[Float]] = [[1, 0, 0], [0, 1, 0]]
+            let out = affine(src, matrix: identity, width: 3, height: 3,
+                             mode: .nearest, oob: oob)
+            XCTAssertEqual(out.width, 3)
+            XCTAssertEqual(out.height, 3)
+        }
+    }
+
+    // ── Additional dimension / round-trip tests ───────────────────────────
+
+    /// rotate180 preserves dimensions.
+    func testRotate180PreservesDimensions() {
+        let src = PixelContainer(width: 7, height: 5)
+        let out = rotate180(src)
+        XCTAssertEqual(out.width, 7)
+        XCTAssertEqual(out.height, 5)
+    }
+
+    /// crop then pad round-trips the original content.
+    func testCropThenPadRoundTrip() {
+        var src = PixelContainer(width: 6, height: 6)
+        // Fill with a known pattern.
+        for y: UInt32 in 0..<6 {
+            for x: UInt32 in 0..<6 {
+                setPixel(&src, x: x, y: y, r: UInt8(x * 40), g: UInt8(y * 40), b: 0, a: 255)
+            }
+        }
+        // Crop out the centre 4×4 and then pad back to 6×6.
+        let cropped = crop(src, x: 1, y: 1, w: 4, h: 4)
+        let padded  = pad(cropped, top: 1, right: 1, bottom: 1, left: 1)
+        // Centre region should match source.
+        for y: UInt32 in 1..<5 {
+            for x: UInt32 in 1..<5 {
+                let (sr, sg, sb, _) = pixelAt(src, x: x, y: y)
+                let (pr, pg, pb, _) = pixelAt(padded, x: x, y: y)
+                XCTAssertEqual(sr, pr, "r at (\(x),\(y))")
+                XCTAssertEqual(sg, pg, "g at (\(x),\(y))")
+                XCTAssertEqual(sb, pb, "b at (\(x),\(y))")
+            }
+        }
+    }
+
+    /// scale with bicubic mode does not crash and returns correct dimensions.
+    func testScaleBicubicDimensions() {
+        let src = hGradient(width: 4, height: 4)
+        let out = scale(src, width: 8, height: 8, mode: .bicubic)
+        XCTAssertEqual(out.width, 8)
+        XCTAssertEqual(out.height, 8)
+    }
+
+    /// perspectiveWarp with a scale matrix halves dimensions of the content.
+    func testPerspectiveWarpScaleMatrix() {
+        let src = checker(width: 4, height: 4)
+        // Scale-by-2 perspective: sample from 2x source coords.
+        let h: [[Float]] = [[2, 0, 0], [0, 2, 0], [0, 0, 1]]
+        let out = perspectiveWarp(src, matrix: h, width: 4, height: 4,
+                                  mode: .nearest, oob: .replicate)
+        XCTAssertEqual(out.width,  4)
+        XCTAssertEqual(out.height, 4)
+    }
+
+    /// rotate 2π (full circle) is approximately identity.
+    func testRotateTwoPiApproxIdentity() {
+        let src = checker(width: 5, height: 5)
+        let out = rotate(src, radians: 2 * Float.pi, mode: .bilinear, bounds: .crop)
+        for y: UInt32 in 1..<4 {   // avoid corner pixels clipped by .crop
+            for x: UInt32 in 1..<4 {
+                let (ir, ig, ib, _) = pixelAt(src, x: x, y: y)
+                let ( r,  g,  b, _) = pixelAt(out, x: x, y: y)
+                XCTAssertLessThanOrEqual(abs(Int(r) - Int(ir)), 2)
+                XCTAssertLessThanOrEqual(abs(Int(g) - Int(ig)), 2)
+                XCTAssertLessThanOrEqual(abs(Int(b) - Int(ib)), 2)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

IMG04 Batch 2 of 5 — geometric transforms in Go, Ruby, and Swift.

- **Go**: 36 tests pass, `go vet` clean
- **Ruby**: 37 tests, 113 assertions, 0 failures
- **Swift**: 32 tests, `swift build` passes (tests run on CI with Xcode)

## Operations

| Category | Functions |
|---|---|
| Lossless | `flip_horizontal/FlipHorizontal`, `flip_vertical`, `rotate_90_cw`, `rotate_90_ccw`, `rotate_180`, `crop`, `pad` |
| Continuous | `scale`, `rotate`, `affine`, `perspective_warp/PerspectiveWarp` |
| Interpolation | Nearest, Bilinear, Bicubic (Catmull-Rom) |
| OOB | Zero, Replicate, Reflect, Wrap |

## Notable implementation notes

- **Go**: `RotateBounds` "crop" constant named `CropBounds` to avoid collision with the exported `Crop()` function — Go has no enum namespaces
- **Ruby**: `perspective_warp` computes the 3×3 adjugate inverse inline
- **Swift**: Fixed `rotate90CW/CCW` W/H swap bug on non-square images

## Batches

- [x] Batch 1: Rust, TypeScript, Python (PR #976, merged)
- [x] Batch 2: Go, Ruby, Swift (this PR)
- [ ] Batch 3: Elixir, Lua, F#
- [ ] Batch 4: Haskell, Java, Kotlin (+ pixel-container + IMG03)
- [ ] Batch 5: C# (+ IMG03)

🤖 Generated with [Claude Code](https://claude.com/claude-code)