### PR TITLE
feat(intel-8008-ir-validator): pre-flight IR validator for Intel 8008 backend

### DIFF
--- a/code/packages/python/intel-8008-ir-validator/BUILD
+++ b/code/packages/python/intel-8008-ir-validator/BUILD
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../compiler-ir -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/intel-8008-ir-validator/BUILD_windows
+++ b/code/packages/python/intel-8008-ir-validator/BUILD_windows
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../compiler-ir -e ".[dev]" --quiet
+.venv\Scripts\python -m pytest tests/ -v

--- a/code/packages/python/intel-8008-ir-validator/CHANGELOG.md
+++ b/code/packages/python/intel-8008-ir-validator/CHANGELOG.md
@@ -1,0 +1,82 @@
+# Changelog
+
+All notable changes to `coding-adventures-intel-8008-ir-validator` will be documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+---
+
+## [0.1.0] — 2026-04-20
+
+### Added
+
+- **`IrValidator`** — single class with a `validate(program: IrProgram) -> list[IrValidationError]`
+  method.  Runs all six checks and returns every violation at once.
+
+- **`IrValidationError`** — dataclass/Exception with `rule: str` and `message: str`
+  fields.  Inherits from `Exception` so it can be raised by the backend as well as
+  collected into a list by the validator.
+
+- **Six validation rules** (all accumulated, never fail-fast):
+
+  1. **`no_word_ops`** — `LOAD_WORD` and `STORE_WORD` are forbidden.  The Intel 8008
+     has an 8-bit data bus; all memory accesses are byte-wide via the `M`
+     pseudo-register (memory at H:L).  WORD variants have no hardware instruction to
+     lower them to.
+
+  2. **`static_ram`** — Total size of all `IrDataDecl` entries must not exceed 8 191
+     bytes.  The 8008 RAM region is 0x2000–0x3FFF (8 192 bytes); one guard byte is
+     reserved, leaving 8 191 usable bytes for static variables.
+
+  3. **`call_depth`** — Static call graph depth must not exceed 7.  The 8008 has an
+     8-level hardware push-down stack.  Level 0 is always the current PC, leaving 7
+     levels for `CAL` instructions.  Recursive call graphs (cycles) are always rejected
+     before the depth measurement.
+
+  4. **`register_count`** — No more than 6 distinct virtual register indices may appear
+     across all instruction operands.  The Oct calling convention maps v0–v5 to the
+     8008's B, A, C, D, E registers (H and L are reserved for memory addressing).
+     Virtual registers v6 and above have no physical home without RAM spilling, which
+     the code generator does not implement.
+
+  5. **`imm_range`** — Every `LOAD_IMM` and `ADD_IMM` immediate must be in [0, 255].
+     The 8008 immediate instructions (`MVI`, `ADI`, `ACI`, etc.) encode their operand
+     in a single byte.  Values outside [0, 255] cannot be encoded.
+
+  6. **`syscall_whitelist`** — Every `SYSCALL` instruction must use a number from the
+     8008 intrinsic whitelist:
+     - 3–4: `adc`/`sbb` (ADC r / SBB r)
+     - 11–16: rotations (`rlc`, `rrc`, `ral`, `rar`), `carry()`, `parity()`
+     - 20–27: `in(p)` for ports 0–7 (IN p)
+     - 40–63: `out(p, v)` for ports 0–23 (OUT p)
+
+     Each invalid SYSCALL number is reported individually, but the same number
+     appearing multiple times is reported only once.
+
+- **Comprehensive test suite** (`tests/test_intel_8008_ir_validator.py`):
+  - 8 test classes, 60+ individual test cases
+  - Each rule tested with: passing case, failing case, boundary values, edge cases
+  - Full accumulation test (all six rules triggered simultaneously)
+  - Clean-program test (zero errors on a well-formed IR)
+  - `IrValidationError` type contract tests (equality, hash, raise, __str__)
+
+### Design Notes
+
+- **Structurally parallel to `intel-4004-ir-validator`**: same `IrValidator` /
+  `IrValidationError` pattern, same test layout.  The 8008 validator extends the
+  4004's 5 rules to 6 by splitting the old `operand_range` rule into `imm_range`
+  (which covers both `LOAD_IMM` and `ADD_IMM`) and adding `syscall_whitelist`
+  (specific to the 8008's port I/O model).
+
+- **Accumulate, never abort**: the validator always runs all six checks.  This
+  matches the design philosophy of the 4004 validator and gives the programmer a
+  complete error report in a single compilation.
+
+- **SYSCALL deduplication**: the same invalid SYSCALL number appearing N times in a
+  program produces exactly one error.  Different invalid numbers each get their own
+  error.  This prevents error floods in programs with many repeated bad syscalls.
+
+- **Call graph cycle detection**: done via a two-phase DFS (visiting/visited sets).
+  Cycles are caught before the depth DFS, because depth is undefined in a cyclic
+  graph.  The 8008 stack wraps without detection — a recursive program would
+  silently corrupt its own return addresses.

--- a/code/packages/python/intel-8008-ir-validator/README.md
+++ b/code/packages/python/intel-8008-ir-validator/README.md
@@ -1,0 +1,122 @@
+# coding-adventures-intel-8008-ir-validator
+
+Pre-flight hardware-constraint validation for Oct IR programs targeting the Intel 8008 CPU.
+
+## What Is This?
+
+This package is part of the **Intel 8008 backend** for the Oct compiler pipeline.
+It runs immediately after `oct-ir-compiler` and before `ir-to-intel-8008-compiler`,
+acting as a pre-flight check that confirms the IR program is physically feasible
+on real Intel 8008 hardware.
+
+```
+Source text
+    → oct-lexer
+    → oct-parser
+    → oct-type-checker
+    → oct-ir-compiler          (typed AST → IrProgram)
+    → intel-8008-ir-validator  ← this package
+    → ir-to-intel-8008-compiler
+    → intel-8008-assembler
+    → intel-8008-packager
+```
+
+The Oct type checker enforces language-level rules (types, scopes, arities).
+This validator enforces *hardware* rules that the type checker cannot know:
+
+| What | Why the type checker can't catch it |
+|------|-------------------------------------|
+| No LOAD_WORD / STORE_WORD | Language has no 16-bit type |
+| Static RAM ≤ 8 191 bytes | Hardware RAM size is invisible to the type system |
+| Call depth ≤ 7 | Stack overflow is a runtime phenomenon |
+| ≤ 6 virtual registers | Physical register count is a backend detail |
+| Immediates 0–255 | Literal range isn't constrained by the language |
+| Valid SYSCALL numbers | Port range is a hardware specification |
+
+## Validation Rules
+
+| Rule | Constraint |
+|------|-----------|
+| `no_word_ops` | No `LOAD_WORD` or `STORE_WORD` — 8008 is 8-bit only |
+| `static_ram` | Total static data ≤ 8 191 bytes (RAM: 0x2000–0x3FFE) |
+| `call_depth` | Static call graph depth ≤ 7 (8-level hardware stack; level 0 = current PC) |
+| `register_count` | ≤ 6 distinct virtual registers (v0–v5: zero, scratch, 4 locals) |
+| `imm_range` | `LOAD_IMM` and `ADD_IMM` immediates ∈ [0, 255] |
+| `syscall_whitelist` | SYSCALL numbers ∈ {3,4} ∪ {11–16} ∪ {20–27} ∪ {40–63} |
+
+All violations are accumulated in a single pass — you see every problem at once.
+
+## SYSCALL Whitelist
+
+The 8008 SYSCALL numbers and their hardware intrinsic mappings:
+
+| SYSCALL | Oct intrinsic | 8008 instruction |
+|---------|--------------|-----------------|
+| 3 | `adc(a, b)` | `ADC r` |
+| 4 | `sbb(a, b)` | `SBB r` |
+| 11 | `rlc(a)` | `RLC` |
+| 12 | `rrc(a)` | `RRC` |
+| 13 | `ral(a)` | `RAL` |
+| 14 | `rar(a)` | `RAR` |
+| 15 | `carry()` | `MVI A,0; ACI 0` |
+| 16 | `parity(a)` | `ORA A; JFP …` |
+| 20–27 | `in(p)` for p ∈ 0–7 | `IN p` |
+| 40–63 | `out(p, v)` for p ∈ 0–23 | `OUT p` |
+
+## Usage
+
+```python
+from compiler_ir import IrProgram
+from intel_8008_ir_validator import IrValidator, IrValidationError
+
+# Obtain an IrProgram from oct-ir-compiler
+prog: IrProgram = ...
+
+validator = IrValidator()
+errors = validator.validate(prog)
+
+if errors:
+    for e in errors:
+        print(e)   # prints "[rule] message"
+    raise RuntimeError("IR program is not feasible on Intel 8008 hardware")
+
+# Safe to proceed to ir-to-intel-8008-compiler
+```
+
+`IrValidationError` also inherits from `Exception`, so the backend can raise it:
+
+```python
+errors = IrValidator().validate(prog)
+if errors:
+    raise errors[0]   # raise the first violation
+```
+
+## Intel 8008 Hardware Constraints
+
+The Intel 8008 (1972) is an 8-bit microprocessor with:
+
+- **Registers**: A (accumulator), B, C, D, E (user data), H, L (memory address)
+- **Call stack**: 8-level hardware push-down; level 0 = current PC
+- **RAM**: 8 KB at 0x2000–0x3FFF (8 192 bytes; 8 191 usable)
+- **Input ports**: 8 (ports 0–7)
+- **Output ports**: 24 (ports 0–23)
+- **Immediate width**: 8 bits (0–255 for MVI, ADI, etc.)
+
+## How It Fits in the Stack
+
+```
+Layer 7: compiler-ir              — IrProgram, IrInstruction, IrOp
+Layer 8: oct-ir-compiler          — Oct typed AST → IrProgram
+Layer 9: intel-8008-ir-validator  ← HERE — IrProgram feasibility check
+Layer 10: ir-to-intel-8008-compiler (next) — IrProgram → 8008 assembly
+```
+
+## Building and Testing
+
+```bash
+./BUILD          # on Linux/macOS
+BUILD_windows    # on Windows
+```
+
+Creates a `.venv`, installs `compiler-ir` and dev dependencies, and runs `pytest`
+with coverage reporting.

--- a/code/packages/python/intel-8008-ir-validator/pyproject.toml
+++ b/code/packages/python/intel-8008-ir-validator/pyproject.toml
@@ -1,0 +1,42 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-intel-8008-ir-validator"
+version = "0.1.0"
+description = "Intel 8008 IR validator: checks IrProgram hardware feasibility before 8008 code generation"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+dependencies = [
+    "coding-adventures-compiler-ir",
+]
+
+[tool.uv.sources]
+coding-adventures-compiler-ir = { path = "../compiler-ir", editable = true }
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/intel_8008_ir_validator"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM", "ANN"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=intel_8008_ir_validator --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.run]
+source = ["src/intel_8008_ir_validator"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/packages/python/intel-8008-ir-validator/src/intel_8008_ir_validator/__init__.py
+++ b/code/packages/python/intel-8008-ir-validator/src/intel_8008_ir_validator/__init__.py
@@ -1,0 +1,13 @@
+"""Intel 8008 IR validator package.
+
+Pre-flight hardware-constraint validation for IrPrograms targeting the
+Intel 8008 processor.  Call ``IrValidator().validate(program)`` before
+passing the program to the code generator.
+"""
+
+from intel_8008_ir_validator.validator import IrValidationError, IrValidator
+
+__all__ = [
+    "IrValidationError",
+    "IrValidator",
+]

--- a/code/packages/python/intel-8008-ir-validator/src/intel_8008_ir_validator/validator.py
+++ b/code/packages/python/intel-8008-ir-validator/src/intel_8008_ir_validator/validator.py
@@ -1,0 +1,683 @@
+"""IrValidator — Intel 8008 hardware-constraint validation for IrPrograms.
+
+Why Validation?
+---------------
+
+The Intel 8008 (1972) is an 8-bit microprocessor — the world's first
+single-chip 8-bit CPU.  It targets real hardware that imposes constraints
+the Oct type checker can't know about:
+
+  - 8-level hardware call stack (only 7 levels available for user CAL)
+  - Only 4 user-data registers: B, C, D, E (accumulator A is scratch)
+  - 8-bit immediates only (MVI, ADI, etc. all take 8-bit literals)
+  - Input ports 0–7 only (IN p; 3-bit field in the opcode)
+  - Output ports 0–23 only (OUT p; 5-bit field in the opcode)
+  - SYSCALL numbers restricted to a specific hardware-supported set
+  - 8 KB RAM region: at most 8 191 static bytes (addresses 0x2000–0x3FFF)
+  - No 16-bit memory bus (LOAD_WORD / STORE_WORD impossible)
+
+The validator answers: "Can this IR program run on real 8008 hardware?"
+It collects *all* violations in one pass so the programmer sees every
+problem at once rather than fixing them one by one.
+
+Validation Rules
+----------------
+
++--------------------+-----------------------------------------------------------+
+| Rule               | Constraint                                                |
++====================+===========================================================+
+| no_word_ops        | LOAD_WORD and STORE_WORD opcodes are forbidden            |
++--------------------+-----------------------------------------------------------+
+| static_ram         | Sum of all IrDataDecl sizes ≤ 8 191 bytes                 |
++--------------------+-----------------------------------------------------------+
+| call_depth         | Static call-graph DFS depth ≤ 7                           |
+|                    | (8-level stack; level 0 = current PC, leaving 7 usable)  |
++--------------------+-----------------------------------------------------------+
+| register_count     | Distinct virtual register indices ≤ 6                     |
+|                    | (v0=zero, v1=scratch, v2–v5=locals/params)                |
++--------------------+-----------------------------------------------------------+
+| imm_range          | Every LOAD_IMM and ADD_IMM immediate fits in u8 (0–255)   |
++--------------------+-----------------------------------------------------------+
+| syscall_whitelist  | SYSCALL numbers ∈ {3,4} ∪ {11–16} ∪ {20–27} ∪ {40–63}  |
+|                    | (adc/sbb, rotations, carry/parity, in/out ports)          |
++--------------------+-----------------------------------------------------------+
+
+All rules are accumulated — we don't stop at the first error.
+
+Call Depth Calculation
+----------------------
+
+The 8008 hardware stack has 8 levels.  Level 0 is always the current PC,
+which is always occupied.  That leaves 7 levels for CAL instructions.  The
+validator does a DFS from every LABEL entry point and measures the longest
+call chain (in edges, not nodes)::
+
+    _start → main → foo → bar   (depth 3 from _start; 3 CAL edges)
+
+With 7 available levels, chains up to depth 7 are allowed.  Recursive call
+graphs are caught separately and always rejected — the 8008 push-down stack
+wraps without any overflow detection.
+
+SYSCALL Whitelist
+-----------------
+
+The 8008 intrinsic SYSCALL numbers and their hardware counterparts:
+
+  SYSCALL  3  → adc(a, b)   — ADC r instruction
+  SYSCALL  4  → sbb(a, b)   — SBB r instruction
+  SYSCALL 11  → rlc(a)      — RLC (rotate A left circular)
+  SYSCALL 12  → rrc(a)      — RRC (rotate A right circular)
+  SYSCALL 13  → ral(a)      — RAL (rotate A left through carry)
+  SYSCALL 14  → rar(a)      — RAR (rotate A right through carry)
+  SYSCALL 15  → carry()     — materialise carry flag via ACI 0
+  SYSCALL 16  → parity(a)   — materialise parity flag via ORA A + branch
+  SYSCALL 20+p → in(p)      — IN p instruction (p ∈ 0–7; 8 input ports)
+  SYSCALL 40+p → out(p, v)  — OUT p instruction (p ∈ 0–23; 24 output ports)
+
+Any other SYSCALL number has no hardware instruction to lower it to and is
+therefore invalid on the 8008.
+
+Register Count Limit
+--------------------
+
+The 8008 has 7 named registers: A, B, C, D, E, H, L.
+
+  A      = accumulator — scratch, managed by the code generator
+  H, L   = memory address registers — scratch, used for LOAD_ADDR/LOAD_BYTE/
+             STORE_BYTE sequences; not user-addressable
+  B, C, D, E = 4 user data registers
+
+The Oct calling convention maps virtual registers to physical registers:
+
+  v0  → B   (constant zero, preloaded at _start)
+  v1  → A   (scratch / return value; lives in accumulator)
+  v2  → C   (1st local / 1st argument slot)
+  v3  → D   (2nd local / 2nd argument slot)
+  v4  → E   (3rd local / 3rd argument slot)
+  v5  → ??? (4th local / 4th argument slot — see note below)
+
+  Note: With only B, C, D, E available as persistent storage (A is scratch;
+  H, L are reserved for addresses), 5 distinct persistent registers exist
+  (including v0=B).  The code generator must handle v5 carefully.  The
+  validator allows up to 6 distinct virtual register indices (v0–v5) to
+  match the Oct calling convention, even though the physical mapping is
+  tight.  Programs using v6 or higher cannot be expressed in 8008 assembly
+  without register spilling to RAM — which the current code generator does
+  not support.
+"""
+
+from __future__ import annotations
+
+from compiler_ir import (  # noqa: I001
+    IrImmediate,
+    IrLabel,
+    IrOp,
+    IrProgram,
+    IrRegister,
+)
+
+# ---------------------------------------------------------------------------
+# IrValidationError — describes a single validation failure
+# ---------------------------------------------------------------------------
+#
+# Inherits from Exception so it can be both collected into a list by the
+# validator AND raised directly by downstream backend stages.  Two roles,
+# one type — avoids a separate "ValidatorResult / error pair" dance.
+
+
+class IrValidationError(Exception):
+    """A single hardware-constraint violation detected by IrValidator.
+
+    Inherits from ``Exception`` so it can be raised by the Intel 8008
+    backend as well as collected into a list by ``IrValidator``.
+
+    Attributes:
+        rule:    Short identifier for the rule that was violated.
+                 One of: ``"no_word_ops"``, ``"static_ram"``,
+                 ``"call_depth"``, ``"register_count"``,
+                 ``"imm_range"``, ``"syscall_whitelist"``.
+        message: Human-readable description of the problem and how to fix it.
+
+    Example::
+
+        e = IrValidationError(rule="syscall_whitelist",
+                              message="SYSCALL 99 is not a valid 8008 syscall")
+        print(e.rule)     # "syscall_whitelist"
+        print(e.message)  # "SYSCALL 99 is not a valid 8008 syscall"
+        raise e           # also valid — it's an Exception
+    """
+
+    def __init__(self, rule: str, message: str) -> None:
+        """Create an IrValidationError.
+
+        Args:
+            rule:    Short rule identifier (e.g., ``"syscall_whitelist"``).
+            message: Human-readable description of the violation.
+        """
+        super().__init__(message)
+        self.rule = rule
+        self.message = message
+
+    def __str__(self) -> str:
+        """Return a printable one-line representation."""
+        return f"[{self.rule}] {self.message}"
+
+    def __eq__(self, other: object) -> bool:
+        """Two IrValidationError objects are equal if rule and message match."""
+        if not isinstance(other, IrValidationError):
+            return NotImplemented
+        return self.rule == other.rule and self.message == other.message
+
+    def __hash__(self) -> int:
+        """Hash based on rule and message."""
+        return hash((self.rule, self.message))
+
+
+# ---------------------------------------------------------------------------
+# Hardware constants
+# ---------------------------------------------------------------------------
+
+# Maximum bytes of static RAM.  The 8008 RAM region spans 0x2000–0x3FFF,
+# which is 8 192 bytes.  We reserve the last byte (0x3FFF) as a guard, so
+# the practical limit is 8 191 static variables.
+_MAX_RAM_BYTES: int = 8191
+
+# The 8008 hardware push-down stack has 8 levels.  Level 0 is always the
+# current program counter — it is never free.  That leaves 7 levels for
+# CAL (call) instructions.  A call chain of depth > 7 would wrap the stack,
+# silently corrupting the return address chain.
+_MAX_CALL_DEPTH: int = 7
+
+# Maximum number of distinct virtual register indices.
+# v0 (zero), v1 (scratch/return), v2–v5 (locals/params) = 6 total.
+# Index v6 and above have no physical home without RAM spilling.
+_MAX_VIRTUAL_REGISTERS: int = 6
+
+# Immediate value range for LOAD_IMM and ADD_IMM.
+# The 8008 encodes immediates in 8-bit fields (MVI, ADI, etc.).
+_MIN_IMM: int = 0
+_MAX_IMM: int = 255
+
+# SYSCALL numbers that have a valid 8008 hardware lowering.
+#
+#   3–4    : adc, sbb (ADC r / SBB r)
+#   11–14  : rlc, rrc, ral, rar (rotation instructions)
+#   15     : carry() (ACI 0 trick)
+#   16     : parity() (ORA A + conditional branch)
+#   20–27  : in(p) for ports 0–7 (IN p instruction)
+#   40–63  : out(p, v) for ports 0–23 (OUT p instruction)
+_VALID_SYSCALLS: frozenset[int] = frozenset(
+    [3, 4]                        # adc, sbb
+    + list(range(11, 17))         # 11=rlc, 12=rrc, 13=ral, 14=rar, 15=carry, 16=parity
+    + list(range(20, 28))         # in(0)..in(7)
+    + list(range(40, 64))         # out(0)..out(23)
+)
+
+
+# ---------------------------------------------------------------------------
+# IrValidator — runs all checks, accumulates errors
+# ---------------------------------------------------------------------------
+
+
+class IrValidator:
+    """Validates an IrProgram against Intel 8008 hardware constraints.
+
+    The validator checks six rules in a single pass (plus a DFS for call
+    depth).  All violations are accumulated and returned together so the
+    programmer can fix everything at once rather than discovering failures
+    one at a time.
+
+    Usage::
+
+        validator = IrValidator()
+        errors = validator.validate(prog)
+        if errors:
+            for e in errors:
+                print(e)
+        else:
+            print("Program is feasible on Intel 8008 hardware.")
+    """
+
+    def validate(self, program: IrProgram) -> list[IrValidationError]:
+        """Run all hardware-constraint checks on a program.
+
+        Checks are independent — a failure in one does not prevent the
+        others from running.  This gives the programmer a complete picture
+        of everything that must be fixed.
+
+        Args:
+            program: The ``IrProgram`` to validate.
+
+        Returns:
+            A list of ``IrValidationError`` objects.  An empty list means
+            the program passes all checks and can proceed to code generation.
+        """
+        errors: list[IrValidationError] = []
+
+        errors.extend(self._check_no_word_ops(program))
+        errors.extend(self._check_static_ram(program))
+        errors.extend(self._check_call_depth(program))
+        errors.extend(self._check_register_count(program))
+        errors.extend(self._check_imm_range(program))
+        errors.extend(self._check_syscall_whitelist(program))
+
+        return errors
+
+    # ------------------------------------------------------------------
+    # Rule 1: No 16-bit memory operations
+    # ------------------------------------------------------------------
+    #
+    # The 8008 is an 8-bit CPU with an 8-bit data bus.  Every memory access
+    # moves exactly one byte via the M pseudo-register (memory at H:L).
+    # There is no 16-bit move instruction, no double-byte fetch.
+    #
+    # LOAD_WORD / STORE_WORD would require two separate byte-wide accesses
+    # with manually managed H:L addressing — which is not what these opcodes
+    # are designed to represent in the IR.  If 16-bit quantities are needed,
+    # split them into two LOAD_BYTE/STORE_BYTE pairs with incremented
+    # addresses.
+
+    def _check_no_word_ops(self, program: IrProgram) -> list[IrValidationError]:
+        """Ensure no LOAD_WORD or STORE_WORD instructions are present.
+
+        These opcodes require a 16-bit memory bus the 8008 doesn't have.
+        The 8008 only supports byte-wide M (memory at H:L) accesses.
+
+        Returns:
+            A list of errors, at most one per forbidden opcode type.
+        """
+        errors: list[IrValidationError] = []
+        seen_load_word = False
+        seen_store_word = False
+
+        for instr in program.instructions:
+            if instr.opcode == IrOp.LOAD_WORD and not seen_load_word:
+                errors.append(
+                    IrValidationError(
+                        rule="no_word_ops",
+                        message=(
+                            "LOAD_WORD is not supported on Intel 8008 — the CPU has "
+                            "an 8-bit data bus and no 16-bit memory instruction.  "
+                            "Replace with two LOAD_BYTE instructions at consecutive "
+                            "addresses (low byte + high byte)."
+                        ),
+                    )
+                )
+                seen_load_word = True
+            elif instr.opcode == IrOp.STORE_WORD and not seen_store_word:
+                errors.append(
+                    IrValidationError(
+                        rule="no_word_ops",
+                        message=(
+                            "STORE_WORD is not supported on Intel 8008 — the CPU has "
+                            "an 8-bit data bus and no 16-bit memory instruction.  "
+                            "Replace with two STORE_BYTE instructions at consecutive "
+                            "addresses (low byte + high byte)."
+                        ),
+                    )
+                )
+                seen_store_word = True
+
+        return errors
+
+    # ------------------------------------------------------------------
+    # Rule 2: Static RAM usage ≤ 8 191 bytes
+    # ------------------------------------------------------------------
+    #
+    # The 8008 backend maps static variables into the RAM region starting
+    # at address 0x2000.  The RAM region runs to 0x3FFF, giving 8 192
+    # bytes total.  We reserve the last byte as a guard, so the practical
+    # limit is 8 191 bytes.
+    #
+    # Each Oct `static u8` variable occupies exactly 1 byte, so this limit
+    # is equivalent to "at most 8 191 static variables".  Programs declaring
+    # more static data than this cannot have their data segment fit in RAM.
+    #
+    # Analogy: think of the RAM as a 8 KB apartment.  Each `static` is a
+    # piece of furniture.  If you try to fit 8 200 pieces in, some will end
+    # up outside the apartment (in ROM space, which is read-only — crash).
+
+    def _check_static_ram(self, program: IrProgram) -> list[IrValidationError]:
+        """Ensure total static data does not exceed 8 191 bytes.
+
+        Sums all IrDataDecl.size values and compares against the 8 KB
+        RAM region limit (0x2000–0x3FFF minus one guard byte).
+
+        Returns:
+            A list containing at most one error with the actual usage.
+        """
+        total = sum(decl.size for decl in program.data)
+        if total > _MAX_RAM_BYTES:
+            return [
+                IrValidationError(
+                    rule="static_ram",
+                    message=(
+                        f"Static RAM usage {total} bytes exceeds the Intel 8008 "
+                        f"limit of {_MAX_RAM_BYTES} bytes "
+                        f"(RAM region 0x2000–0x3FFE).  "
+                        f"Reduce data declarations by at least "
+                        f"{total - _MAX_RAM_BYTES} bytes."
+                    ),
+                )
+            ]
+        return []
+
+    # ------------------------------------------------------------------
+    # Rule 3: Call graph depth ≤ 7
+    # ------------------------------------------------------------------
+    #
+    # The 8008 hardware stack is an 8-slot circular push-down register.
+    # Slot 0 always holds the current PC — it is never free.  That leaves
+    # 7 slots available for nested CAL (call) instructions.
+    #
+    # Think of it as an 8-deep stack of plates.  One plate is permanently
+    # on the bottom (current PC).  You can stack 7 more plates; an 8th CAL
+    # would slide the bottom plate out and corrupt the return chain.
+    #
+    # The validator builds a static call graph from LABEL and CALL opcodes,
+    # then runs a DFS to find the longest chain.  Recursive call graphs are
+    # caught first and always rejected — the 8008 has no runtime check for
+    # stack overflow.
+    #
+    # Example of a depth-3 chain (fine, within limit):
+    #   _start → main → encrypt → xor_byte
+    #
+    # Example of a depth-8 chain (rejected):
+    #   _start → a → b → c → d → e → f → g → h
+
+    def _check_call_depth(self, program: IrProgram) -> list[IrValidationError]:
+        """Ensure the static call graph depth does not exceed 7.
+
+        Builds a call graph from LABEL and CALL instructions, checks for
+        cycles (always rejected), then does a DFS to find the maximum
+        nesting depth.
+
+        Returns:
+            A list containing at most one error describing the violation.
+        """
+        # ---- Build call graph ----
+        # call_graph maps label_name → [callee_name, ...]
+        call_graph: dict[str, list[str]] = {}
+        current_label: str | None = None
+
+        for instr in program.instructions:
+            if instr.opcode == IrOp.LABEL:
+                lbl = instr.operands[0]
+                if isinstance(lbl, IrLabel):
+                    current_label = lbl.name
+                    if current_label not in call_graph:
+                        call_graph[current_label] = []
+            elif instr.opcode == IrOp.CALL:
+                callee = instr.operands[0]
+                if isinstance(callee, IrLabel) and current_label is not None:
+                    call_graph.setdefault(current_label, []).append(callee.name)
+                    if callee.name not in call_graph:
+                        call_graph[callee.name] = []
+
+        # ---- Cycle detection ----
+        # A cycle means recursion, which is impossible on the 8008's
+        # fixed-size hardware stack.  Find it before measuring depth,
+        # because DFS depth is undefined (infinite) in a cyclic graph.
+
+        def find_cycle() -> list[str] | None:
+            """Return one cycle path, or None if the graph is acyclic."""
+            visiting: set[str] = set()
+            visited: set[str] = set()
+            path: list[str] = []
+
+            def dfs_cycle(node: str) -> list[str] | None:
+                if node in visiting:
+                    # Back-edge found: extract cycle from path
+                    if node in path:
+                        start = path.index(node)
+                        return path[start:] + [node]
+                    return [node, node]
+                if node in visited:
+                    return None
+                visiting.add(node)
+                visited.add(node)
+                path.append(node)
+                for child in call_graph.get(node, []):
+                    cycle = dfs_cycle(child)
+                    if cycle is not None:
+                        return cycle
+                path.pop()
+                visiting.remove(node)
+                return None
+
+            for label in call_graph:
+                cycle = dfs_cycle(label)
+                if cycle is not None:
+                    return cycle
+            return None
+
+        cycle = find_cycle()
+        if cycle is not None:
+            cycle_str = " -> ".join(cycle)
+            return [
+                IrValidationError(
+                    rule="call_depth",
+                    message=(
+                        "Recursive call graphs are not supported on the Intel 8008 "
+                        "— the 8-level hardware stack wraps without overflow detection,"
+                        " silently corrupting return addresses.  "
+                        f"Found cycle: {cycle_str}.  "
+                        "Refactor the recursion into an iterative loop."
+                    ),
+                )
+            ]
+
+        # ---- Maximum depth DFS ----
+        # Count call edges (not nodes) from the deepest-reaching label.
+        # Depth 0 = a label that makes no calls; depth N = N nested CALs.
+
+        max_depth = 0
+
+        def dfs_depth(node: str, depth: int, visited: set[str]) -> int:
+            """Return maximum call depth reachable from node."""
+            if node in visited:
+                return depth
+            visited = visited | {node}
+            children = call_graph.get(node, [])
+            if not children:
+                return depth
+            return max(dfs_depth(child, depth + 1, visited) for child in children)
+
+        for label in call_graph:
+            d = dfs_depth(label, 0, set())
+            if d > max_depth:
+                max_depth = d
+
+        if max_depth > _MAX_CALL_DEPTH:
+            return [
+                IrValidationError(
+                    rule="call_depth",
+                    message=(
+                        f"Call graph depth {max_depth} exceeds the Intel 8008 "
+                        f"hardware stack limit of {_MAX_CALL_DEPTH} nested calls "
+                        f"(8-level push-down stack; level 0 = current PC).  "
+                        f"Reduce nesting by inlining functions or restructuring "
+                        f"the call graph."
+                    ),
+                )
+            ]
+        return []
+
+    # ------------------------------------------------------------------
+    # Rule 4: Virtual register count ≤ 6
+    # ------------------------------------------------------------------
+    #
+    # The 8008 has 7 named registers: A, B, C, D, E, H, L.
+    # Of these:
+    #
+    #   A      = accumulator — scratch, used implicitly by all ALU ops
+    #   H, L   = 14-bit memory address register — reserved for LOAD_ADDR /
+    #             LOAD_BYTE / STORE_BYTE sequences
+    #   B, C, D, E = 4 user data registers, persistent across instructions
+    #
+    # The Oct calling convention allocates virtual registers as:
+    #
+    #   v0  = constant zero (stored in a dedicated register)
+    #   v1  = scratch / return value (lives in A)
+    #   v2  = 1st local / 1st argument (→ C or similar)
+    #   v3  = 2nd local / 2nd argument
+    #   v4  = 3rd local / 3rd argument
+    #   v5  = 4th local / 4th argument
+    #
+    # That is 6 distinct virtual registers total (v0–v5).  Any virtual
+    # register index ≥ 6 cannot be assigned a physical home without
+    # spilling to RAM, which the current code generator does not support.
+    #
+    # A program that triggers live-register save-restore with more than 4
+    # locals may generate v6, v7, etc.  This validator catches that case
+    # and requires the programmer to refactor (fewer locals, inline helpers).
+
+    def _check_register_count(self, program: IrProgram) -> list[IrValidationError]:
+        """Ensure no more than 6 distinct virtual register indices are used.
+
+        Collects all IrRegister.index values from every instruction operand
+        and counts unique values.
+
+        Returns:
+            A list containing at most one error with the actual count.
+        """
+        seen: set[int] = set()
+        for instr in program.instructions:
+            for operand in instr.operands:
+                if isinstance(operand, IrRegister):
+                    seen.add(operand.index)
+
+        count = len(seen)
+        if count > _MAX_VIRTUAL_REGISTERS:
+            return [
+                IrValidationError(
+                    rule="register_count",
+                    message=(
+                        f"Program uses {count} distinct virtual registers but "
+                        f"Intel 8008 supports at most {_MAX_VIRTUAL_REGISTERS} "
+                        f"(v0–v5 mapping to B, A, C, D, E and one spare; "
+                        f"H and L are reserved for memory addressing).  "
+                        f"Reduce local variable count or avoid functions with "
+                        f"4 locals that call other functions."
+                    ),
+                )
+            ]
+        return []
+
+    # ------------------------------------------------------------------
+    # Rule 5: Immediate values in LOAD_IMM / ADD_IMM ∈ [0, 255]
+    # ------------------------------------------------------------------
+    #
+    # All Intel 8008 immediate instructions (MVI, ADI, ACI, SUI, ANI, XRI,
+    # ORI, CPI) encode their literal operand in a single byte following the
+    # opcode.  This means the immediate must fit in 8 bits: 0–255.
+    #
+    # LOAD_IMM lowers to MVI Rdst, imm.
+    # ADD_IMM  lowers to MOV A, Ra; ADI imm; MOV Rdst, A.
+    #
+    # A value of 256 would require two bytes — impossible to encode in a
+    # single MVI or ADI instruction.  Negative values are also out of range
+    # for the unsigned byte field.
+    #
+    # We check both LOAD_IMM and ADD_IMM, and report every out-of-range
+    # occurrence individually so the programmer can fix them all at once.
+
+    def _check_imm_range(self, program: IrProgram) -> list[IrValidationError]:
+        """Ensure every LOAD_IMM and ADD_IMM immediate fits in a u8 (0–255).
+
+        Checks both LOAD_IMM and ADD_IMM instructions for IrImmediate
+        operands outside [0, 255].
+
+        Returns:
+            A list of errors, one per out-of-range immediate found.
+        """
+        errors: list[IrValidationError] = []
+        checked_ops = {IrOp.LOAD_IMM, IrOp.ADD_IMM}
+
+        for instr in program.instructions:
+            if instr.opcode not in checked_ops:
+                continue
+            for operand in instr.operands:
+                if not isinstance(operand, IrImmediate):
+                    continue
+                val = operand.value
+                if val < _MIN_IMM or val > _MAX_IMM:
+                    op_name = instr.opcode.name
+                    errors.append(
+                        IrValidationError(
+                            rule="imm_range",
+                            message=(
+                                f"{op_name} immediate {val} is out of range for "
+                                f"Intel 8008.  Valid range is [{_MIN_IMM}, {_MAX_IMM}] "
+                                "(u8: one byte, matching MVI/ADI instruction format).  "
+                                f"Split large values or use a register load sequence."
+                            ),
+                        )
+                    )
+
+        return errors
+
+    # ------------------------------------------------------------------
+    # Rule 6: SYSCALL numbers in the 8008 whitelist
+    # ------------------------------------------------------------------
+    #
+    # The Oct IR uses SYSCALL to represent hardware intrinsic operations.
+    # Each SYSCALL number maps to a specific inline instruction sequence
+    # in the 8008 code generator.  SYSCALL numbers outside the whitelist
+    # have no defined 8008 assembly lowering and cannot be compiled.
+    #
+    # The whitelist (from OCT00 specification):
+    #
+    #    3  → adc(a, b)  ←  ADC r     (add with carry)
+    #    4  → sbb(a, b)  ←  SBB r     (subtract with borrow)
+    #   11  → rlc(a)     ←  RLC       (rotate left circular)
+    #   12  → rrc(a)     ←  RRC       (rotate right circular)
+    #   13  → ral(a)     ←  RAL       (rotate left through carry)
+    #   14  → rar(a)     ←  RAR       (rotate right through carry)
+    #   15  → carry()    ←  MVI A,0; ACI 0  (materialise carry flag)
+    #   16  → parity(a)  ←  ORA A; JFP ...  (materialise parity flag)
+    #  20–27 → in(p)     ←  IN p      (input port p, p ∈ 0–7)
+    #  40–63 → out(p,v)  ←  OUT p     (output port p, p ∈ 0–23)
+    #
+    # Any other SYSCALL number is rejected with a clear error message
+    # explaining which hardware intrinsic would need to be added to support
+    # the requested operation.
+
+    def _check_syscall_whitelist(self, program: IrProgram) -> list[IrValidationError]:
+        """Ensure every SYSCALL instruction uses a valid 8008 syscall number.
+
+        Collects all SYSCALL opcodes and checks their immediate operands
+        against the hardware whitelist.  Each invalid number is reported
+        individually.
+
+        Returns:
+            A list of errors, one per invalid SYSCALL number.
+        """
+        errors: list[IrValidationError] = []
+        seen_bad: set[int] = set()  # Report each bad number only once
+
+        for instr in program.instructions:
+            if instr.opcode != IrOp.SYSCALL:
+                continue
+            if not instr.operands:
+                continue
+            op = instr.operands[0]
+            if not isinstance(op, IrImmediate):
+                continue
+            num = op.value
+            if num not in _VALID_SYSCALLS and num not in seen_bad:
+                seen_bad.add(num)
+                errors.append(
+                    IrValidationError(
+                        rule="syscall_whitelist",
+                        message=(
+                            f"SYSCALL {num} is not a valid Intel 8008 intrinsic.  "
+                            f"Valid syscall numbers are: "
+                            f"3–4 (adc/sbb), 11–16 (rotations/carry/parity), "
+                            f"20–27 (in ports 0–7), 40–63 (out ports 0–23).  "
+                            f"Check the Oct intrinsic call that produced SYSCALL {num}."
+                        ),
+                    )
+                )
+
+        return errors

--- a/code/packages/python/intel-8008-ir-validator/tests/test_intel_8008_ir_validator.py
+++ b/code/packages/python/intel-8008-ir-validator/tests/test_intel_8008_ir_validator.py
@@ -1,0 +1,1036 @@
+"""Tests for IrValidator — Intel 8008 hardware constraint checking.
+
+Each test class focuses on one of the six validation rules:
+
+  1. no_word_ops    — LOAD_WORD / STORE_WORD are forbidden
+  2. static_ram     — total static data must not exceed 8 191 bytes
+  3. call_depth     — call graph depth must not exceed 7
+  4. register_count — at most 6 distinct virtual register indices
+  5. imm_range      — LOAD_IMM and ADD_IMM immediates must be in [0, 255]
+  6. syscall_whitelist — SYSCALL numbers must be 8008-valid
+
+Each class tests:
+  - Passing case (should return empty list or no errors for that rule)
+  - Failing case (should produce the correct error)
+  - Edge / boundary cases
+
+The validator accumulates ALL errors in a single pass; separate tests
+verify this accumulation property and the error type itself.
+"""
+
+from __future__ import annotations
+
+import pytest
+from compiler_ir import (
+    IDGenerator,
+    IrDataDecl,
+    IrImmediate,
+    IrInstruction,
+    IrLabel,
+    IrOp,
+    IrProgram,
+    IrRegister,
+)
+
+from intel_8008_ir_validator import IrValidationError, IrValidator
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_program(
+    *instructions: IrInstruction,
+    data: list[IrDataDecl] | None = None,
+) -> IrProgram:
+    """Build a minimal IrProgram with the given instructions."""
+    prog = IrProgram(entry_label="_start")
+    for instr in instructions:
+        prog.add_instruction(instr)
+    if data:
+        for decl in data:
+            prog.add_data(decl)
+    return prog
+
+
+def gen_id() -> IDGenerator:
+    """Return a fresh IDGenerator for unique instruction IDs."""
+    return IDGenerator()
+
+
+def make_call_chain(names: list[str]) -> IrProgram:
+    """Build a program with a linear call chain.
+
+    ``names = ["main", "foo", "bar"]`` means main calls foo, foo calls bar.
+    Each function has a LABEL and a RET; intermediate functions also have a CALL.
+    """
+    g = IDGenerator()
+    prog = IrProgram(entry_label=names[0])
+    for idx, name in enumerate(names):
+        prog.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel(name)], id=-1))
+        if idx + 1 < len(names):
+            prog.add_instruction(
+                IrInstruction(IrOp.CALL, [IrLabel(names[idx + 1])], id=g.next())
+            )
+        prog.add_instruction(IrInstruction(IrOp.RET, [], id=g.next()))
+    return prog
+
+
+# ---------------------------------------------------------------------------
+# Rule 1: no_word_ops
+# ---------------------------------------------------------------------------
+
+
+class TestNoWordOps:
+    """Rule: LOAD_WORD and STORE_WORD are not supported on Intel 8008."""
+
+    def test_load_word_produces_error(self) -> None:
+        """LOAD_WORD should produce a 'no_word_ops' error."""
+        g = gen_id()
+        prog = make_program(
+            IrInstruction(
+                IrOp.LOAD_WORD,
+                [IrRegister(2), IrRegister(0), IrRegister(1)],
+                id=g.next(),
+            )
+        )
+        errors = IrValidator().validate(prog)
+        assert any(e.rule == "no_word_ops" for e in errors)
+
+    def test_load_word_error_mentions_load_word(self) -> None:
+        """The error message for LOAD_WORD should mention 'LOAD_WORD'."""
+        g = gen_id()
+        prog = make_program(
+            IrInstruction(
+                IrOp.LOAD_WORD,
+                [IrRegister(2), IrRegister(0), IrRegister(1)],
+                id=g.next(),
+            )
+        )
+        errors = IrValidator().validate(prog)
+        word_errors = [e for e in errors if e.rule == "no_word_ops"]
+        assert len(word_errors) >= 1
+        assert "LOAD_WORD" in word_errors[0].message
+
+    def test_store_word_produces_error(self) -> None:
+        """STORE_WORD should produce a 'no_word_ops' error."""
+        g = gen_id()
+        prog = make_program(
+            IrInstruction(
+                IrOp.STORE_WORD,
+                [IrRegister(2), IrRegister(0), IrRegister(1)],
+                id=g.next(),
+            )
+        )
+        errors = IrValidator().validate(prog)
+        word_errors = [e for e in errors if e.rule == "no_word_ops"]
+        assert len(word_errors) == 1
+        assert "STORE_WORD" in word_errors[0].message
+
+    def test_both_load_and_store_word_reported(self) -> None:
+        """Both LOAD_WORD and STORE_WORD in the same program produce two errors."""
+        g = gen_id()
+        prog = make_program(
+            IrInstruction(
+                IrOp.LOAD_WORD,
+                [IrRegister(2), IrRegister(0), IrRegister(1)],
+                id=g.next(),
+            ),
+            IrInstruction(
+                IrOp.STORE_WORD,
+                [IrRegister(2), IrRegister(0), IrRegister(1)],
+                id=g.next(),
+            ),
+        )
+        errors = IrValidator().validate(prog)
+        word_errors = [e for e in errors if e.rule == "no_word_ops"]
+        assert len(word_errors) == 2
+
+    def test_multiple_load_word_reported_only_once(self) -> None:
+        """Multiple LOAD_WORD instructions produce only one no_word_ops error."""
+        g = gen_id()
+        prog = make_program(
+            IrInstruction(
+                IrOp.LOAD_WORD,
+                [IrRegister(2), IrRegister(0), IrRegister(1)],
+                id=g.next(),
+            ),
+            IrInstruction(
+                IrOp.LOAD_WORD,
+                [IrRegister(3), IrRegister(0), IrRegister(1)],
+                id=g.next(),
+            ),
+        )
+        errors = IrValidator().validate(prog)
+        word_errors = [e for e in errors if e.rule == "no_word_ops"]
+        assert len(word_errors) == 1
+
+    def test_load_byte_is_allowed(self) -> None:
+        """LOAD_BYTE is valid on the 8008 — only LOAD_WORD is forbidden."""
+        g = gen_id()
+        prog = make_program(
+            IrInstruction(
+                IrOp.LOAD_BYTE,
+                [IrRegister(2), IrRegister(3), IrRegister(0)],
+                id=g.next(),
+            )
+        )
+        errors = IrValidator().validate(prog)
+        word_errors = [e for e in errors if e.rule == "no_word_ops"]
+        assert word_errors == []
+
+    def test_store_byte_is_allowed(self) -> None:
+        """STORE_BYTE is valid on the 8008 — only STORE_WORD is forbidden."""
+        g = gen_id()
+        prog = make_program(
+            IrInstruction(
+                IrOp.STORE_BYTE,
+                [IrRegister(2), IrRegister(3), IrRegister(0)],
+                id=g.next(),
+            )
+        )
+        errors = IrValidator().validate(prog)
+        word_errors = [e for e in errors if e.rule == "no_word_ops"]
+        assert word_errors == []
+
+    def test_empty_program_has_no_word_ops_errors(self) -> None:
+        """An empty program trivially passes the no_word_ops check."""
+        errors = IrValidator().validate(IrProgram(entry_label="_start"))
+        word_errors = [e for e in errors if e.rule == "no_word_ops"]
+        assert word_errors == []
+
+
+# ---------------------------------------------------------------------------
+# Rule 2: static_ram
+# ---------------------------------------------------------------------------
+
+
+class TestStaticRam:
+    """Rule: total IrDataDecl sizes must not exceed 8 191 bytes."""
+
+    def test_exactly_8191_bytes_passes(self) -> None:
+        """8 191 bytes is exactly the 8008 limit — should pass."""
+        prog = IrProgram(entry_label="_start")
+        prog.add_data(IrDataDecl(label="buf", size=8191, init=0))
+        errors = IrValidator().validate(prog)
+        ram_errors = [e for e in errors if e.rule == "static_ram"]
+        assert ram_errors == []
+
+    def test_8192_bytes_fails(self) -> None:
+        """8 192 bytes exceeds the 8 191-byte limit."""
+        prog = IrProgram(entry_label="_start")
+        prog.add_data(IrDataDecl(label="buf", size=8192, init=0))
+        errors = IrValidator().validate(prog)
+        ram_errors = [e for e in errors if e.rule == "static_ram"]
+        assert len(ram_errors) == 1
+        assert "8192" in ram_errors[0].message
+
+    def test_sum_of_multiple_decls_too_large(self) -> None:
+        """Sum of declarations exceeding 8 191 bytes should fail."""
+        prog = IrProgram(entry_label="_start")
+        prog.add_data(IrDataDecl(label="a", size=5000, init=0))
+        prog.add_data(IrDataDecl(label="b", size=4000, init=0))
+        errors = IrValidator().validate(prog)
+        ram_errors = [e for e in errors if e.rule == "static_ram"]
+        assert len(ram_errors) == 1
+        assert "9000" in ram_errors[0].message
+
+    def test_sum_exactly_at_limit_passes(self) -> None:
+        """Two declarations summing to exactly 8 191 bytes should pass."""
+        prog = IrProgram(entry_label="_start")
+        prog.add_data(IrDataDecl(label="a", size=4000, init=0))
+        prog.add_data(IrDataDecl(label="b", size=4191, init=0))
+        errors = IrValidator().validate(prog)
+        ram_errors = [e for e in errors if e.rule == "static_ram"]
+        assert ram_errors == []
+
+    def test_no_data_declarations_passes(self) -> None:
+        """No data declarations means 0 bytes used — trivially passes."""
+        prog = IrProgram(entry_label="_start")
+        errors = IrValidator().validate(prog)
+        ram_errors = [e for e in errors if e.rule == "static_ram"]
+        assert ram_errors == []
+
+    def test_single_byte_passes(self) -> None:
+        """A single 1-byte static declaration should always pass."""
+        prog = IrProgram(entry_label="_start")
+        prog.add_data(IrDataDecl(label="x", size=1, init=0))
+        errors = IrValidator().validate(prog)
+        ram_errors = [e for e in errors if e.rule == "static_ram"]
+        assert ram_errors == []
+
+    def test_error_message_mentions_limit(self) -> None:
+        """The error message should mention the 8 191-byte limit."""
+        prog = IrProgram(entry_label="_start")
+        prog.add_data(IrDataDecl(label="big", size=10000, init=0))
+        errors = IrValidator().validate(prog)
+        ram_errors = [e for e in errors if e.rule == "static_ram"]
+        assert len(ram_errors) == 1
+        assert "8191" in ram_errors[0].message
+
+
+# ---------------------------------------------------------------------------
+# Rule 3: call_depth
+# ---------------------------------------------------------------------------
+
+
+class TestCallDepth:
+    """Rule: static call graph depth must not exceed 7."""
+
+    def test_depth_0_passes(self) -> None:
+        """A single function with no calls has depth 0 — passes."""
+        prog = make_call_chain(["main"])
+        errors = IrValidator().validate(prog)
+        depth_errors = [e for e in errors if e.rule == "call_depth"]
+        assert depth_errors == []
+
+    def test_depth_1_passes(self) -> None:
+        """main → foo is depth 1 — passes."""
+        prog = make_call_chain(["main", "foo"])
+        errors = IrValidator().validate(prog)
+        depth_errors = [e for e in errors if e.rule == "call_depth"]
+        assert depth_errors == []
+
+    def test_depth_7_passes(self) -> None:
+        """A chain of depth 7 is exactly at the limit — should pass."""
+        # main → f1 → f2 → f3 → f4 → f5 → f6 → f7 (7 call edges)
+        chain = ["main", "f1", "f2", "f3", "f4", "f5", "f6", "f7"]
+        prog = make_call_chain(chain)
+        errors = IrValidator().validate(prog)
+        depth_errors = [e for e in errors if e.rule == "call_depth"]
+        assert depth_errors == []
+
+    def test_depth_8_fails(self) -> None:
+        """A chain of depth 8 exceeds the 8008 hardware stack limit."""
+        # main → f1 → … → f8 (8 call edges)
+        chain = ["main", "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8"]
+        prog = make_call_chain(chain)
+        errors = IrValidator().validate(prog)
+        depth_errors = [e for e in errors if e.rule == "call_depth"]
+        assert len(depth_errors) == 1
+        assert depth_errors[0].rule == "call_depth"
+
+    def test_depth_8_error_mentions_limit(self) -> None:
+        """The depth-exceeded error should mention the 7-level limit."""
+        chain = ["main", "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8"]
+        prog = make_call_chain(chain)
+        errors = IrValidator().validate(prog)
+        depth_errors = [e for e in errors if e.rule == "call_depth"]
+        assert "7" in depth_errors[0].message
+
+    def test_no_calls_passes(self) -> None:
+        """A program with only labels and HALT but no CALL instructions passes."""
+        g = gen_id()
+        prog = make_program(
+            IrInstruction(IrOp.LABEL, [IrLabel("_start")], id=-1),
+            IrInstruction(IrOp.HALT, [], id=g.next()),
+        )
+        errors = IrValidator().validate(prog)
+        depth_errors = [e for e in errors if e.rule == "call_depth"]
+        assert depth_errors == []
+
+    def test_self_recursive_function_rejected(self) -> None:
+        """A self-recursive function is rejected as unsupported."""
+        g = gen_id()
+        prog = IrProgram(entry_label="recurse")
+        prog.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("recurse")], id=-1))
+        prog.add_instruction(
+            IrInstruction(IrOp.CALL, [IrLabel("recurse")], id=g.next())
+        )
+        prog.add_instruction(IrInstruction(IrOp.RET, [], id=g.next()))
+        errors = IrValidator().validate(prog)
+        depth_errors = [e for e in errors if e.rule == "call_depth"]
+        assert len(depth_errors) == 1
+        assert "recursive" in depth_errors[0].message.lower()
+
+    def test_mutual_recursion_rejected(self) -> None:
+        """A cyclic call graph (mutual recursion) is rejected."""
+        g = gen_id()
+        prog = IrProgram(entry_label="a")
+        prog.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("a")], id=-1))
+        prog.add_instruction(IrInstruction(IrOp.CALL, [IrLabel("b")], id=g.next()))
+        prog.add_instruction(IrInstruction(IrOp.RET, [], id=g.next()))
+        prog.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("b")], id=-1))
+        prog.add_instruction(IrInstruction(IrOp.CALL, [IrLabel("a")], id=g.next()))
+        prog.add_instruction(IrInstruction(IrOp.RET, [], id=g.next()))
+        errors = IrValidator().validate(prog)
+        depth_errors = [e for e in errors if e.rule == "call_depth"]
+        assert len(depth_errors) == 1
+        assert "cycle" in depth_errors[0].message.lower()
+
+    def test_branching_call_graph_depth_measured_correctly(self) -> None:
+        """Call depth is the longest path, not the total number of functions."""
+        # main calls both foo and bar; bar calls baz.
+        # Depth: main→foo = 1, main→bar→baz = 2.  Max = 2. Should pass.
+        g = gen_id()
+        prog = IrProgram(entry_label="main")
+        prog.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("main")], id=-1))
+        prog.add_instruction(IrInstruction(IrOp.CALL, [IrLabel("foo")], id=g.next()))
+        prog.add_instruction(IrInstruction(IrOp.CALL, [IrLabel("bar")], id=g.next()))
+        prog.add_instruction(IrInstruction(IrOp.RET, [], id=g.next()))
+        prog.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("foo")], id=-1))
+        prog.add_instruction(IrInstruction(IrOp.RET, [], id=g.next()))
+        prog.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("bar")], id=-1))
+        prog.add_instruction(IrInstruction(IrOp.CALL, [IrLabel("baz")], id=g.next()))
+        prog.add_instruction(IrInstruction(IrOp.RET, [], id=g.next()))
+        prog.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("baz")], id=-1))
+        prog.add_instruction(IrInstruction(IrOp.RET, [], id=g.next()))
+        errors = IrValidator().validate(prog)
+        depth_errors = [e for e in errors if e.rule == "call_depth"]
+        assert depth_errors == []
+
+    def test_depth_3_passes(self) -> None:
+        """main → foo → bar → baz (depth 3) is well within the 8008 limit of 7."""
+        prog = make_call_chain(["main", "foo", "bar", "baz"])
+        errors = IrValidator().validate(prog)
+        depth_errors = [e for e in errors if e.rule == "call_depth"]
+        assert depth_errors == []
+
+
+# ---------------------------------------------------------------------------
+# Rule 4: register_count
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterCount:
+    """Rule: at most 6 distinct virtual register indices (v0–v5)."""
+
+    def _make_prog_with_regs(self, n_regs: int) -> IrProgram:
+        """Build a program using v0..v(n_regs-1) each in a LOAD_IMM."""
+        prog = IrProgram(entry_label="_start")
+        g = IDGenerator()
+        for reg_idx in range(n_regs):
+            prog.add_instruction(
+                IrInstruction(
+                    IrOp.LOAD_IMM,
+                    [IrRegister(reg_idx), IrImmediate(0)],
+                    id=g.next(),
+                )
+            )
+        return prog
+
+    def test_6_registers_passes(self) -> None:
+        """Exactly 6 distinct registers (v0–v5) is at the limit — passes."""
+        prog = self._make_prog_with_regs(6)
+        errors = IrValidator().validate(prog)
+        reg_errors = [e for e in errors if e.rule == "register_count"]
+        assert reg_errors == []
+
+    def test_7_registers_fails(self) -> None:
+        """7 distinct registers (v0–v6) exceeds the limit."""
+        prog = self._make_prog_with_regs(7)
+        errors = IrValidator().validate(prog)
+        reg_errors = [e for e in errors if e.rule == "register_count"]
+        assert len(reg_errors) == 1
+        assert "7" in reg_errors[0].message
+
+    def test_1_register_passes(self) -> None:
+        """A single register (v0) is well within the limit."""
+        prog = self._make_prog_with_regs(1)
+        errors = IrValidator().validate(prog)
+        reg_errors = [e for e in errors if e.rule == "register_count"]
+        assert reg_errors == []
+
+    def test_duplicate_register_indices_count_once(self) -> None:
+        """The same register used multiple times is counted only once."""
+        g = gen_id()
+        prog = make_program(
+            IrInstruction(
+                IrOp.LOAD_IMM, [IrRegister(2), IrImmediate(5)], id=g.next()
+            ),
+            IrInstruction(
+                IrOp.LOAD_IMM, [IrRegister(2), IrImmediate(7)], id=g.next()
+            ),
+            IrInstruction(
+                IrOp.ADD, [IrRegister(2), IrRegister(2), IrRegister(2)], id=g.next()
+            ),
+        )
+        errors = IrValidator().validate(prog)
+        reg_errors = [e for e in errors if e.rule == "register_count"]
+        assert reg_errors == []
+
+    def test_no_registers_passes(self) -> None:
+        """A program with no register operands (HALT only) passes."""
+        g = gen_id()
+        prog = make_program(IrInstruction(IrOp.HALT, [], id=g.next()))
+        errors = IrValidator().validate(prog)
+        reg_errors = [e for e in errors if e.rule == "register_count"]
+        assert reg_errors == []
+
+    def test_5_registers_passes(self) -> None:
+        """5 distinct registers (v0–v4) is within the limit."""
+        prog = self._make_prog_with_regs(5)
+        errors = IrValidator().validate(prog)
+        reg_errors = [e for e in errors if e.rule == "register_count"]
+        assert reg_errors == []
+
+    def test_error_message_mentions_count(self) -> None:
+        """The register_count error message should mention the actual count."""
+        prog = self._make_prog_with_regs(10)
+        errors = IrValidator().validate(prog)
+        reg_errors = [e for e in errors if e.rule == "register_count"]
+        assert len(reg_errors) == 1
+        assert "10" in reg_errors[0].message
+
+    def test_registers_in_different_operand_positions(self) -> None:
+        """Registers appearing in any operand position are all counted."""
+        g = gen_id()
+        prog = make_program(
+            # v0 + v1 → v2
+            IrInstruction(
+                IrOp.ADD, [IrRegister(2), IrRegister(0), IrRegister(1)], id=g.next()
+            ),
+            # v3 in second operand
+            IrInstruction(
+                IrOp.ADD, [IrRegister(2), IrRegister(3), IrRegister(1)], id=g.next()
+            ),
+        )
+        # v0, v1, v2, v3 = 4 distinct registers — within limit
+        errors = IrValidator().validate(prog)
+        reg_errors = [e for e in errors if e.rule == "register_count"]
+        assert reg_errors == []
+
+
+# ---------------------------------------------------------------------------
+# Rule 5: imm_range
+# ---------------------------------------------------------------------------
+
+
+class TestImmRange:
+    """Rule: LOAD_IMM and ADD_IMM immediates must be in [0, 255]."""
+
+    # --- LOAD_IMM tests ---
+
+    def test_load_imm_0_passes(self) -> None:
+        """0 is the minimum valid value for LOAD_IMM."""
+        g = gen_id()
+        prog = make_program(
+            IrInstruction(
+                IrOp.LOAD_IMM, [IrRegister(2), IrImmediate(0)], id=g.next()
+            )
+        )
+        errors = IrValidator().validate(prog)
+        imm_errors = [e for e in errors if e.rule == "imm_range"]
+        assert imm_errors == []
+
+    def test_load_imm_255_passes(self) -> None:
+        """255 is the maximum valid value for LOAD_IMM."""
+        g = gen_id()
+        prog = make_program(
+            IrInstruction(
+                IrOp.LOAD_IMM, [IrRegister(2), IrImmediate(255)], id=g.next()
+            )
+        )
+        errors = IrValidator().validate(prog)
+        imm_errors = [e for e in errors if e.rule == "imm_range"]
+        assert imm_errors == []
+
+    def test_load_imm_256_fails(self) -> None:
+        """256 exceeds the 8-bit range for LOAD_IMM."""
+        g = gen_id()
+        prog = make_program(
+            IrInstruction(
+                IrOp.LOAD_IMM, [IrRegister(2), IrImmediate(256)], id=g.next()
+            )
+        )
+        errors = IrValidator().validate(prog)
+        imm_errors = [e for e in errors if e.rule == "imm_range"]
+        assert len(imm_errors) == 1
+        assert "256" in imm_errors[0].message
+
+    def test_load_imm_negative_fails(self) -> None:
+        """Negative values are out of range for LOAD_IMM."""
+        g = gen_id()
+        prog = make_program(
+            IrInstruction(
+                IrOp.LOAD_IMM, [IrRegister(2), IrImmediate(-1)], id=g.next()
+            )
+        )
+        errors = IrValidator().validate(prog)
+        imm_errors = [e for e in errors if e.rule == "imm_range"]
+        assert len(imm_errors) == 1
+        assert "-1" in imm_errors[0].message
+
+    # --- ADD_IMM tests ---
+
+    def test_add_imm_0_passes(self) -> None:
+        """0 is valid for ADD_IMM (used for register copy: ADI 0)."""
+        g = gen_id()
+        prog = make_program(
+            IrInstruction(
+                IrOp.ADD_IMM,
+                [IrRegister(2), IrRegister(1), IrImmediate(0)],
+                id=g.next(),
+            )
+        )
+        errors = IrValidator().validate(prog)
+        imm_errors = [e for e in errors if e.rule == "imm_range"]
+        assert imm_errors == []
+
+    def test_add_imm_255_passes(self) -> None:
+        """255 is the maximum valid value for ADD_IMM."""
+        g = gen_id()
+        prog = make_program(
+            IrInstruction(
+                IrOp.ADD_IMM,
+                [IrRegister(2), IrRegister(1), IrImmediate(255)],
+                id=g.next(),
+            )
+        )
+        errors = IrValidator().validate(prog)
+        imm_errors = [e for e in errors if e.rule == "imm_range"]
+        assert imm_errors == []
+
+    def test_add_imm_256_fails(self) -> None:
+        """256 exceeds the 8-bit range for ADD_IMM."""
+        g = gen_id()
+        prog = make_program(
+            IrInstruction(
+                IrOp.ADD_IMM,
+                [IrRegister(2), IrRegister(1), IrImmediate(256)],
+                id=g.next(),
+            )
+        )
+        errors = IrValidator().validate(prog)
+        imm_errors = [e for e in errors if e.rule == "imm_range"]
+        assert len(imm_errors) == 1
+        assert "ADD_IMM" in imm_errors[0].message
+
+    def test_add_imm_negative_fails(self) -> None:
+        """Negative ADD_IMM values are out of range."""
+        g = gen_id()
+        prog = make_program(
+            IrInstruction(
+                IrOp.ADD_IMM,
+                [IrRegister(2), IrRegister(1), IrImmediate(-5)],
+                id=g.next(),
+            )
+        )
+        errors = IrValidator().validate(prog)
+        imm_errors = [e for e in errors if e.rule == "imm_range"]
+        assert len(imm_errors) == 1
+
+    # --- Multiple violations ---
+
+    def test_multiple_out_of_range_all_reported(self) -> None:
+        """Multiple out-of-range immediates should all produce errors."""
+        g = gen_id()
+        prog = make_program(
+            IrInstruction(
+                IrOp.LOAD_IMM, [IrRegister(2), IrImmediate(300)], id=g.next()
+            ),
+            IrInstruction(
+                IrOp.LOAD_IMM, [IrRegister(3), IrImmediate(500)], id=g.next()
+            ),
+            IrInstruction(
+                IrOp.ADD_IMM,
+                [IrRegister(4), IrRegister(2), IrImmediate(1000)],
+                id=g.next(),
+            ),
+        )
+        errors = IrValidator().validate(prog)
+        imm_errors = [e for e in errors if e.rule == "imm_range"]
+        assert len(imm_errors) == 3
+
+    def test_sub_not_checked_for_imm_range(self) -> None:
+        """SUB does not have an immediate operand — imm_range does not apply."""
+        g = gen_id()
+        prog = make_program(
+            IrInstruction(
+                IrOp.SUB,
+                [IrRegister(2), IrRegister(3), IrRegister(4)],
+                id=g.next(),
+            )
+        )
+        errors = IrValidator().validate(prog)
+        imm_errors = [e for e in errors if e.rule == "imm_range"]
+        assert imm_errors == []
+
+    def test_load_imm_128_passes(self) -> None:
+        """128 is a common 8-bit value — should pass."""
+        g = gen_id()
+        prog = make_program(
+            IrInstruction(
+                IrOp.LOAD_IMM, [IrRegister(2), IrImmediate(128)], id=g.next()
+            )
+        )
+        errors = IrValidator().validate(prog)
+        imm_errors = [e for e in errors if e.rule == "imm_range"]
+        assert imm_errors == []
+
+
+# ---------------------------------------------------------------------------
+# Rule 6: syscall_whitelist
+# ---------------------------------------------------------------------------
+
+
+class TestSyscallWhitelist:
+    """Rule: SYSCALL numbers must be in the 8008 hardware whitelist."""
+
+    def _syscall_prog(self, num: int) -> IrProgram:
+        """Build a program containing a single SYSCALL instruction."""
+        g = IDGenerator()
+        return make_program(
+            IrInstruction(IrOp.SYSCALL, [IrImmediate(num)], id=g.next())
+        )
+
+    # --- Valid syscall numbers ---
+
+    def test_syscall_3_passes(self) -> None:
+        """SYSCALL 3 (adc) is valid on the 8008."""
+        errors = IrValidator().validate(self._syscall_prog(3))
+        sc_errors = [e for e in errors if e.rule == "syscall_whitelist"]
+        assert sc_errors == []
+
+    def test_syscall_4_passes(self) -> None:
+        """SYSCALL 4 (sbb) is valid on the 8008."""
+        errors = IrValidator().validate(self._syscall_prog(4))
+        sc_errors = [e for e in errors if e.rule == "syscall_whitelist"]
+        assert sc_errors == []
+
+    def test_syscall_11_passes(self) -> None:
+        """SYSCALL 11 (rlc) is valid."""
+        errors = IrValidator().validate(self._syscall_prog(11))
+        sc_errors = [e for e in errors if e.rule == "syscall_whitelist"]
+        assert sc_errors == []
+
+    def test_syscall_12_passes(self) -> None:
+        """SYSCALL 12 (rrc) is valid."""
+        errors = IrValidator().validate(self._syscall_prog(12))
+        sc_errors = [e for e in errors if e.rule == "syscall_whitelist"]
+        assert sc_errors == []
+
+    def test_syscall_13_passes(self) -> None:
+        """SYSCALL 13 (ral) is valid."""
+        errors = IrValidator().validate(self._syscall_prog(13))
+        sc_errors = [e for e in errors if e.rule == "syscall_whitelist"]
+        assert sc_errors == []
+
+    def test_syscall_14_passes(self) -> None:
+        """SYSCALL 14 (rar) is valid."""
+        errors = IrValidator().validate(self._syscall_prog(14))
+        sc_errors = [e for e in errors if e.rule == "syscall_whitelist"]
+        assert sc_errors == []
+
+    def test_syscall_15_passes(self) -> None:
+        """SYSCALL 15 (carry) is valid."""
+        errors = IrValidator().validate(self._syscall_prog(15))
+        sc_errors = [e for e in errors if e.rule == "syscall_whitelist"]
+        assert sc_errors == []
+
+    def test_syscall_16_passes(self) -> None:
+        """SYSCALL 16 (parity) is valid."""
+        errors = IrValidator().validate(self._syscall_prog(16))
+        sc_errors = [e for e in errors if e.rule == "syscall_whitelist"]
+        assert sc_errors == []
+
+    def test_all_in_ports_pass(self) -> None:
+        """SYSCALL 20–27 (in ports 0–7) are all valid."""
+        for num in range(20, 28):
+            errors = IrValidator().validate(self._syscall_prog(num))
+            sc_errors = [e for e in errors if e.rule == "syscall_whitelist"]
+            assert sc_errors == [], f"SYSCALL {num} should pass"
+
+    def test_all_out_ports_pass(self) -> None:
+        """SYSCALL 40–63 (out ports 0–23) are all valid."""
+        for num in range(40, 64):
+            errors = IrValidator().validate(self._syscall_prog(num))
+            sc_errors = [e for e in errors if e.rule == "syscall_whitelist"]
+            assert sc_errors == [], f"SYSCALL {num} should pass"
+
+    # --- Invalid syscall numbers ---
+
+    def test_syscall_0_rejected(self) -> None:
+        """SYSCALL 0 is not a valid 8008 intrinsic."""
+        errors = IrValidator().validate(self._syscall_prog(0))
+        sc_errors = [e for e in errors if e.rule == "syscall_whitelist"]
+        assert len(sc_errors) == 1
+
+    def test_syscall_1_rejected(self) -> None:
+        """SYSCALL 1 has no 8008 hardware mapping."""
+        errors = IrValidator().validate(self._syscall_prog(1))
+        sc_errors = [e for e in errors if e.rule == "syscall_whitelist"]
+        assert len(sc_errors) == 1
+
+    def test_syscall_2_rejected(self) -> None:
+        """SYSCALL 2 is not in the whitelist."""
+        errors = IrValidator().validate(self._syscall_prog(2))
+        sc_errors = [e for e in errors if e.rule == "syscall_whitelist"]
+        assert len(sc_errors) == 1
+
+    def test_syscall_5_rejected(self) -> None:
+        """SYSCALL 5 (between adc/sbb and rotations) is not a valid 8008 intrinsic."""
+        errors = IrValidator().validate(self._syscall_prog(5))
+        sc_errors = [e for e in errors if e.rule == "syscall_whitelist"]
+        assert len(sc_errors) == 1
+
+    def test_syscall_17_rejected(self) -> None:
+        """SYSCALL 17 (gap between parity and in-ports) is not valid."""
+        errors = IrValidator().validate(self._syscall_prog(17))
+        sc_errors = [e for e in errors if e.rule == "syscall_whitelist"]
+        assert len(sc_errors) == 1
+
+    def test_syscall_28_rejected(self) -> None:
+        """SYSCALL 28 (in port 8 — above the 8 input-port limit) is invalid."""
+        errors = IrValidator().validate(self._syscall_prog(28))
+        sc_errors = [e for e in errors if e.rule == "syscall_whitelist"]
+        assert len(sc_errors) == 1
+
+    def test_syscall_39_rejected(self) -> None:
+        """SYSCALL 39 (gap before out-ports) is not valid."""
+        errors = IrValidator().validate(self._syscall_prog(39))
+        sc_errors = [e for e in errors if e.rule == "syscall_whitelist"]
+        assert len(sc_errors) == 1
+
+    def test_syscall_64_rejected(self) -> None:
+        """SYSCALL 64 (out port 24 — above the 24 output-port limit) is invalid."""
+        errors = IrValidator().validate(self._syscall_prog(64))
+        sc_errors = [e for e in errors if e.rule == "syscall_whitelist"]
+        assert len(sc_errors) == 1
+
+    def test_syscall_99_rejected(self) -> None:
+        """SYSCALL 99 is not a valid 8008 intrinsic."""
+        errors = IrValidator().validate(self._syscall_prog(99))
+        sc_errors = [e for e in errors if e.rule == "syscall_whitelist"]
+        assert len(sc_errors) == 1
+
+    def test_error_message_mentions_syscall_number(self) -> None:
+        """The syscall_whitelist error message should mention the bad SYSCALL number."""
+        errors = IrValidator().validate(self._syscall_prog(99))
+        sc_errors = [e for e in errors if e.rule == "syscall_whitelist"]
+        assert "99" in sc_errors[0].message
+
+    def test_repeated_invalid_syscall_reported_once(self) -> None:
+        """The same invalid SYSCALL number appearing twice is reported only once."""
+        g = IDGenerator()
+        prog = make_program(
+            IrInstruction(IrOp.SYSCALL, [IrImmediate(99)], id=g.next()),
+            IrInstruction(IrOp.SYSCALL, [IrImmediate(99)], id=g.next()),
+        )
+        errors = IrValidator().validate(prog)
+        sc_errors = [e for e in errors if e.rule == "syscall_whitelist"]
+        assert len(sc_errors) == 1
+
+    def test_two_different_invalid_syscalls_both_reported(self) -> None:
+        """Two different invalid SYSCALL numbers each produce their own error."""
+        g = IDGenerator()
+        prog = make_program(
+            IrInstruction(IrOp.SYSCALL, [IrImmediate(0)], id=g.next()),
+            IrInstruction(IrOp.SYSCALL, [IrImmediate(99)], id=g.next()),
+        )
+        errors = IrValidator().validate(prog)
+        sc_errors = [e for e in errors if e.rule == "syscall_whitelist"]
+        assert len(sc_errors) == 2
+
+    def test_no_syscalls_passes(self) -> None:
+        """A program with no SYSCALL instructions trivially passes."""
+        g = gen_id()
+        prog = make_program(IrInstruction(IrOp.HALT, [], id=g.next()))
+        errors = IrValidator().validate(prog)
+        sc_errors = [e for e in errors if e.rule == "syscall_whitelist"]
+        assert sc_errors == []
+
+
+# ---------------------------------------------------------------------------
+# Error accumulation
+# ---------------------------------------------------------------------------
+
+
+class TestErrorAccumulation:
+    """Verify multiple rules can fail simultaneously and all errors are reported."""
+
+    def test_word_ops_and_static_ram_both_reported(self) -> None:
+        """A program with LOAD_WORD and too much RAM should produce both errors."""
+        g = gen_id()
+        prog = IrProgram(entry_label="_start")
+        prog.add_data(IrDataDecl(label="huge", size=10000, init=0))
+        prog.add_instruction(
+            IrInstruction(
+                IrOp.LOAD_WORD,
+                [IrRegister(2), IrRegister(0), IrRegister(1)],
+                id=g.next(),
+            )
+        )
+        errors = IrValidator().validate(prog)
+        rules = {e.rule for e in errors}
+        assert "no_word_ops" in rules
+        assert "static_ram" in rules
+
+    def test_all_six_rules_can_fail_at_once(self) -> None:
+        """A maximally broken program should trigger all six validation rules."""
+        # Construct a pathological program that violates every rule:
+        #  1. no_word_ops     — include LOAD_WORD and STORE_WORD
+        #  2. static_ram      — declare 10 000 bytes of static data
+        #  3. call_depth      — build a call chain of depth 8
+        #  4. register_count  — use virtual registers v0–v7 (8 distinct)
+        #  5. imm_range       — LOAD_IMM with value 300
+        #  6. syscall_whitelist — SYSCALL 99
+        g = IDGenerator()
+        prog = IrProgram(entry_label="_start")
+
+        # --- Rule 2: static_ram ---
+        prog.add_data(IrDataDecl(label="big", size=10000, init=0))
+
+        # --- Rule 1: no_word_ops ---
+        prog.add_instruction(
+            IrInstruction(
+                IrOp.LOAD_WORD,
+                [IrRegister(2), IrRegister(0), IrRegister(1)],
+                id=g.next(),
+            )
+        )
+        prog.add_instruction(
+            IrInstruction(
+                IrOp.STORE_WORD,
+                [IrRegister(2), IrRegister(0), IrRegister(1)],
+                id=g.next(),
+            )
+        )
+
+        # --- Rule 3: call_depth (depth 8) ---
+        chain = ["a", "b", "c", "d", "e", "f", "g", "h", "i"]  # 8 edges
+        for idx, name in enumerate(chain):
+            prog.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel(name)], id=-1))
+            if idx + 1 < len(chain):
+                prog.add_instruction(
+                    IrInstruction(IrOp.CALL, [IrLabel(chain[idx + 1])], id=g.next())
+                )
+            prog.add_instruction(IrInstruction(IrOp.RET, [], id=g.next()))
+
+        # --- Rule 4: register_count (8 distinct: v0–v7) ---
+        for reg_idx in range(8):
+            prog.add_instruction(
+                IrInstruction(
+                    IrOp.LOAD_IMM,
+                    [IrRegister(reg_idx), IrImmediate(0)],
+                    id=g.next(),
+                )
+            )
+
+        # --- Rule 5: imm_range ---
+        prog.add_instruction(
+            IrInstruction(
+                IrOp.LOAD_IMM, [IrRegister(2), IrImmediate(300)], id=g.next()
+            )
+        )
+
+        # --- Rule 6: syscall_whitelist ---
+        prog.add_instruction(
+            IrInstruction(IrOp.SYSCALL, [IrImmediate(99)], id=g.next())
+        )
+
+        errors = IrValidator().validate(prog)
+        rules = {e.rule for e in errors}
+        assert "no_word_ops" in rules
+        assert "static_ram" in rules
+        assert "call_depth" in rules
+        assert "register_count" in rules
+        assert "imm_range" in rules
+        assert "syscall_whitelist" in rules
+
+    def test_clean_program_has_no_errors(self) -> None:
+        """A well-formed program with no violations should have zero errors."""
+        g = IDGenerator()
+        prog = IrProgram(entry_label="_start")
+
+        # 1 static byte
+        prog.add_data(IrDataDecl(label="x", size=1, init=0))
+
+        # Simple entry stub
+        prog.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_start")], id=-1))
+        prog.add_instruction(
+            IrInstruction(
+                IrOp.LOAD_IMM, [IrRegister(0), IrImmediate(0)], id=g.next()
+            )
+        )
+        prog.add_instruction(
+            IrInstruction(IrOp.CALL, [IrLabel("_fn_main")], id=g.next())
+        )
+        prog.add_instruction(IrInstruction(IrOp.HALT, [], id=g.next()))
+
+        # Simple main function using 2 locals and a valid syscall
+        prog.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("_fn_main")], id=-1))
+        prog.add_instruction(
+            IrInstruction(
+                IrOp.LOAD_IMM, [IrRegister(1), IrImmediate(100)], id=g.next()
+            )
+        )
+        prog.add_instruction(
+            IrInstruction(
+                IrOp.ADD,
+                [IrRegister(2), IrRegister(0), IrRegister(1)],
+                id=g.next(),
+            )
+        )
+        # SYSCALL 20 = in(0)
+        prog.add_instruction(
+            IrInstruction(IrOp.SYSCALL, [IrImmediate(20)], id=g.next())
+        )
+        prog.add_instruction(IrInstruction(IrOp.RET, [], id=g.next()))
+
+        errors = IrValidator().validate(prog)
+        assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# IrValidationError type tests
+# ---------------------------------------------------------------------------
+
+
+class TestIrValidationError:
+    """Tests for the IrValidationError class itself."""
+
+    def test_str_representation(self) -> None:
+        """__str__ should format as '[rule] message'."""
+        e = IrValidationError(rule="static_ram", message="too many statics")
+        assert str(e) == "[static_ram] too many statics"
+
+    def test_is_exception_subclass(self) -> None:
+        """IrValidationError must be an Exception so the backend can raise it."""
+        e = IrValidationError(rule="no_word_ops", message="forbidden")
+        assert isinstance(e, Exception)
+
+    def test_can_be_raised(self) -> None:
+        """IrValidationError should be raise-able like any Exception."""
+        with pytest.raises(IrValidationError):
+            raise IrValidationError(rule="syscall_whitelist", message="bad syscall")
+
+    def test_equality(self) -> None:
+        """Two IrValidationError objects with same rule+message are equal."""
+        a = IrValidationError(rule="imm_range", message="value 300 out of range")
+        b = IrValidationError(rule="imm_range", message="value 300 out of range")
+        assert a == b
+
+    def test_inequality_by_rule(self) -> None:
+        """Different rules make errors unequal even with same message."""
+        a = IrValidationError(rule="imm_range", message="value 300")
+        b = IrValidationError(rule="syscall_whitelist", message="value 300")
+        assert a != b
+
+    def test_inequality_by_message(self) -> None:
+        """Same rule but different message means errors are unequal."""
+        a = IrValidationError(rule="call_depth", message="depth 8")
+        b = IrValidationError(rule="call_depth", message="depth 9")
+        assert a != b
+
+    def test_hash_equal_objects_have_equal_hash(self) -> None:
+        """Equal IrValidationError objects must have the same hash."""
+        a = IrValidationError(rule="register_count", message="too many regs")
+        b = IrValidationError(rule="register_count", message="too many regs")
+        assert hash(a) == hash(b)
+
+    def test_rule_attribute(self) -> None:
+        """The rule attribute should be readable."""
+        e = IrValidationError(rule="call_depth", message="too deep")
+        assert e.rule == "call_depth"
+
+    def test_message_attribute(self) -> None:
+        """The message attribute should be readable."""
+        e = IrValidationError(rule="call_depth", message="too deep")
+        assert e.message == "too deep"
+
+    def test_equality_with_non_error(self) -> None:
+        """Comparing with a non-IrValidationError returns NotImplemented."""
+        e = IrValidationError(rule="static_ram", message="big")
+        result = e.__eq__("not an error")
+        assert result is NotImplemented


### PR DESCRIPTION
## Summary

- Adds `intel-8008-ir-validator` (Layer 9 of the Oct pipeline): pre-flight hardware-constraint validation for `IrProgram` objects before 8008 code generation
- Six accumulated validation rules: `no_word_ops`, `static_ram`, `call_depth`, `register_count`, `imm_range`, `syscall_whitelist`
- Structurally parallel to `intel-4004-ir-validator` with 8008-specific limits (8 KB RAM, 7-level call stack, 8008 port whitelist)
- 80 tests, 97% coverage, ruff clean

## Rules enforced

| Rule | Constraint |
|------|-----------|
| `no_word_ops` | No `LOAD_WORD`/`STORE_WORD` — 8008 is 8-bit only |
| `static_ram` | Total static data ≤ 8 191 bytes (RAM region 0x2000–0x3FFE) |
| `call_depth` | Call graph depth ≤ 7 (8-level hardware stack; recursive graphs always rejected) |
| `register_count` | ≤ 6 distinct virtual registers (v0–v5 mapping to B, A, C, D, E) |
| `imm_range` | `LOAD_IMM` and `ADD_IMM` immediates ∈ [0, 255] |
| `syscall_whitelist` | SYSCALL numbers ∈ {3,4} ∪ {11–16} ∪ {20–27} ∪ {40–63} |

## Test plan

- [x] 80 tests across 8 test classes — all passing
- [x] Each rule tested with: passing case, failing case, boundary values, edge cases
- [x] Full accumulation test (all six rules triggered simultaneously)
- [x] Clean-program test (zero errors on a well-formed IR program)
- [x] `IrValidationError` type contract: equality, hash, raise, `__str__`
- [x] ruff clean (zero lint errors)
- [x] 97% coverage (>80% threshold)
- [x] Security review passed (pure in-memory AST walker, no I/O)

🤖 Generated with [Claude Code](https://claude.com/claude-code)