### PR TITLE
feat(img04-batch4): pixel-container + IMG03 + IMG04 for Haskell, Java, Kotlin

### DIFF
--- a/code/packages/haskell/image-geometric-transforms/BUILD
+++ b/code/packages/haskell/image-geometric-transforms/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/image-geometric-transforms/BUILD_windows
+++ b/code/packages/haskell/image-geometric-transforms/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/image-geometric-transforms/CHANGELOG.md
+++ b/code/packages/haskell/image-geometric-transforms/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## 0.1.0 — 2026-04-20
+
+- Initial release of IMG04 geometric transforms for Haskell.
+- Lossless: `flipHorizontal`, `flipVertical`, `rotate90CW`,
+  `rotate90CCW`, `rotate180`, `crop`.
+- Continuous: `scale`, `rotate` (with `RotateBounds = Fit | Crop`),
+  `translate`, `affine`, `perspectiveWarp`.
+- Interpolation: `Nearest`, `Bilinear`, `Bicubic` (Catmull-Rom).
+- Out-of-bounds policies: `Zero`, `Replicate`, `Reflect`, `Wrap`.
+- sRGB-aware sampling: bilinear and bicubic blend in linear light.
+- Hspec test suite.

--- a/code/packages/haskell/image-geometric-transforms/README.md
+++ b/code/packages/haskell/image-geometric-transforms/README.md
@@ -1,0 +1,55 @@
+# image-geometric-transforms (Haskell)
+
+IMG04 — Geometric transforms on a `PixelContainer`.
+
+## Overview
+
+All transforms share one core strategy: /inverse warping/.  For each output
+pixel `(x', y')` we compute the non-integer source coordinate `(u, v)` that
+maps to it and sample there.  This guarantees every output pixel is written
+exactly once and reduces "how do I transform an image?" to "how do I sample
+at a fractional coordinate?".
+
+### Lossless transforms
+
+- `flipHorizontal`, `flipVertical`
+- `rotate90CW`, `rotate90CCW`, `rotate180`
+- `crop`
+
+### Continuous transforms (take `Interpolation` and `OutOfBounds`)
+
+- `scale`
+- `rotate` (arbitrary degrees, with `RotateBounds = Fit | Crop`)
+- `translate`
+- `affine` (2x3 forward matrix)
+- `perspectiveWarp` (3x3 forward homography)
+
+### Interpolation
+
+- `Nearest`  — snap to closest pixel.
+- `Bilinear` — 4-neighbour blend in linear light.
+- `Bicubic`  — 16-neighbour Catmull-Rom in linear light.
+
+### Out-of-bounds policies
+
+- `Zero`, `Replicate`, `Reflect`, `Wrap`.
+
+## Usage
+
+```haskell
+import PixelContainer
+import ImageGeometricTransforms
+
+main :: IO ()
+main = do
+    let src = fillPixels (createPixelContainer 100 100) 128 128 128 255
+        out = rotate src 45 Fit Bilinear Replicate
+    print (pcWidth out, pcHeight out)
+```
+
+## Dependencies
+
+- `pixel-container` (IC00)
+
+(The sRGB decode/encode helpers are intentionally duplicated in this package
+so it does not take an unnecessary dependency on `image-point-ops`.)

--- a/code/packages/haskell/image-geometric-transforms/image-geometric-transforms.cabal
+++ b/code/packages/haskell/image-geometric-transforms/image-geometric-transforms.cabal
@@ -1,0 +1,33 @@
+cabal-version: 3.0
+name:          image-geometric-transforms
+version:       0.1.0
+synopsis:      IMG04: Geometric transforms on PixelContainer
+description:   Lossless and continuous geometric transforms: flip,
+               rotate-by-multiple-of-90, crop, scale, translate,
+               arbitrary rotate, affine, and perspective warp.  Supports
+               nearest / bilinear / bicubic interpolation and out-of-
+               bounds policies zero / replicate / reflect / wrap.
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  ImageGeometricTransforms
+    build-depends:    base >=4.14
+                    , bytestring
+                    , pixel-container
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    ImageGeometricTransformsSpec
+    build-depends:    base >=4.14
+                    , bytestring
+                    , pixel-container
+                    , image-geometric-transforms
+                    , hspec == 2.*
+    hs-source-dirs:   test
+    default-language: Haskell2010

--- a/code/packages/haskell/image-geometric-transforms/src/ImageGeometricTransforms.hs
+++ b/code/packages/haskell/image-geometric-transforms/src/ImageGeometricTransforms.hs
@@ -1,0 +1,427 @@
+-- | IMG04 — Geometric transforms on a 'PixelContainer'.
+--
+-- All transforms share the same core strategy: /inverse warping/.
+-- Rather than pushing each input pixel forward to a (possibly
+-- non-integer) output location, we iterate over the integer output
+-- grid and for each output pixel @(x', y')@ compute the non-integer
+-- source location @(u, v)@ that maps to it.  Sampling @(u, v)@ is a
+-- well-defined interpolation problem, and every output pixel is
+-- written exactly once.
+--
+-- == Pixel-centre convention
+--
+-- For continuous transforms we treat integer coordinate @n@ as the
+-- /centre/ of pixel @n@, so pixel centres live at @0.5, 1.5, 2.5, ...@
+-- in continuous space.  Inverse scale becomes
+-- @u = (x' + 0.5) \/ sx - 0.5@.  This avoids a half-pixel shift
+-- relative to "integer is top-left corner" conventions.
+module ImageGeometricTransforms
+    ( Interpolation(..)
+    , RotateBounds(..)
+    , OutOfBounds(..)
+    , flipHorizontal
+    , flipVertical
+    , rotate90CW
+    , rotate90CCW
+    , rotate180
+    , crop
+    , scale
+    , rotate
+    , translate
+    , affine
+    , perspectiveWarp
+    ) where
+
+import PixelContainer
+import Data.Word (Word8)
+import qualified Data.ByteString as BS
+
+-- ---------------------------------------------------------------------------
+-- Modes
+-- ---------------------------------------------------------------------------
+
+-- | Interpolation kernel used by continuous transforms.
+--
+-- * 'Nearest'  — snap to the closest pixel.  Fastest, blocky.
+-- * 'Bilinear' — weighted average of 4 nearest pixels.  Good default.
+-- * 'Bicubic'  — Catmull-Rom over 16 pixels.  Sharper, more expensive.
+data Interpolation = Nearest | Bilinear | Bicubic deriving (Show, Eq)
+
+-- | Canvas policy for arbitrary 'rotate'.
+--
+-- * 'Fit'  — expand output canvas to hold the rotated bounding box.
+-- * 'Crop' — keep the original canvas size, clipping corners.
+data RotateBounds = Fit | Crop deriving (Show, Eq)
+
+-- | Out-of-bounds policy when an inverse-warped coordinate falls
+-- outside the source image.  Every continuous transform takes one of
+-- these.
+--
+-- * 'Zero'      — return transparent black.
+-- * 'Replicate' — clamp to the nearest edge pixel.
+-- * 'Reflect'   — mirror back into bounds.
+-- * 'Wrap'      — toroidal modulo.
+data OutOfBounds = Zero | Replicate | Reflect | Wrap deriving (Show, Eq)
+
+-- ---------------------------------------------------------------------------
+-- sRGB <-> linear (duplicated from image-point-ops so this package
+-- stays independent — geometric transforms only need linear-light
+-- sampling, not the full point-ops catalogue).
+-- ---------------------------------------------------------------------------
+
+-- | Precomputed sRGB decode LUT (see 'decodeSrgb').
+srgbToLinear :: [Double]
+srgbToLinear =
+    [ let c = fromIntegral i / 255.0
+      in if c <= 0.04045
+         then c / 12.92
+         else ((c + 0.055) / 1.055) ** 2.4
+    | i <- [0..255 :: Int]
+    ]
+
+decodeSrgb :: Word8 -> Double
+decodeSrgb b = srgbToLinear !! fromIntegral b
+
+encodeSrgb :: Double -> Word8
+encodeSrgb linear =
+    let c    = max 0.0 (min 1.0 linear)
+        srgb = if c <= 0.0031308
+               then c * 12.92
+               else 1.055 * (c ** (1.0 / 2.4)) - 0.055
+    in round (srgb * 255.0)
+
+-- ---------------------------------------------------------------------------
+-- Coordinate resolution
+-- ---------------------------------------------------------------------------
+
+-- | Resolve an integer index to an in-bounds source index according to
+-- the requested 'OutOfBounds' policy.  'Nothing' means "sample is
+-- transparent black" and short-circuits the rest of the work.
+resolveCoord :: Int -> Int -> OutOfBounds -> Maybe Int
+resolveCoord x maxVal oob
+    | x >= 0 && x < maxVal = Just x
+    | otherwise = case oob of
+        Zero      -> Nothing
+        Replicate -> Just (max 0 (min (maxVal - 1) x))
+        Reflect   ->
+            let period = 2 * maxVal
+                xm     = x `mod` period
+                xm'    = if xm < 0 then xm + period else xm
+            in Just (if xm' >= maxVal then period - xm' - 1 else xm')
+        Wrap      ->
+            let xm = x `mod` maxVal
+            in Just (if xm < 0 then xm + maxVal else xm)
+
+-- ---------------------------------------------------------------------------
+-- Image builder
+-- ---------------------------------------------------------------------------
+
+-- | Construct a 'PixelContainer' of given dimensions by querying a
+-- per-pixel function.  One allocation, @O(w * h)@.
+buildImage :: Int -> Int
+           -> (Int -> Int -> (Word8, Word8, Word8, Word8))
+           -> PixelContainer
+buildImage w h f =
+    let pixList =
+            [ let (r, g, b, a) = f x y in [r, g, b, a]
+            | y <- [0 .. h - 1], x <- [0 .. w - 1]
+            ]
+    in PixelContainer w h (BS.pack (concat pixList))
+
+-- ---------------------------------------------------------------------------
+-- Lossless transforms
+-- ---------------------------------------------------------------------------
+
+-- | Mirror left-right.  Inverse warp: @src_x = width - 1 - x'@.
+flipHorizontal :: PixelContainer -> PixelContainer
+flipHorizontal src@(PixelContainer w h _) =
+    buildImage w h (\x y -> pixelAt src (w - 1 - x) y)
+
+-- | Mirror top-bottom.  Inverse warp: @src_y = height - 1 - y'@.
+flipVertical :: PixelContainer -> PixelContainer
+flipVertical src@(PixelContainer w h _) =
+    buildImage w h (\x y -> pixelAt src x (h - 1 - y))
+
+-- | Rotate 90 degrees clockwise.  Output dimensions swap: the new
+-- width is the old height and vice versa.
+--
+-- Forward map: @(x, y) -> (srcH - 1 - y, x)@.
+-- Inverse map: @src_x = y', src_y = srcH - 1 - x'@.
+rotate90CW :: PixelContainer -> PixelContainer
+rotate90CW src@(PixelContainer w h _) =
+    buildImage h w (\x y -> pixelAt src y (h - 1 - x))
+
+-- | Rotate 90 degrees counter-clockwise.  Output dimensions swap.
+--
+-- Forward map: @(x, y) -> (y, srcW - 1 - x)@.
+-- Inverse map: @src_x = srcW - 1 - y', src_y = x'@.
+rotate90CCW :: PixelContainer -> PixelContainer
+rotate90CCW src@(PixelContainer w h _) =
+    buildImage h w (\x y -> pixelAt src (w - 1 - y) x)
+
+-- | Rotate 180 degrees.  Same dimensions.  Equivalent to
+-- @flipHorizontal . flipVertical@ but done in one pass.
+rotate180 :: PixelContainer -> PixelContainer
+rotate180 src@(PixelContainer w h _) =
+    buildImage w h (\x y -> pixelAt src (w - 1 - x) (h - 1 - y))
+
+-- | Extract a rectangular sub-region starting at @(x0, y0)@ with size
+-- @w x h@.  Pixels outside the source are transparent black.  No
+-- interpolation — strict pixel copy.
+crop :: PixelContainer -> Int -> Int -> Int -> Int -> PixelContainer
+crop src x0 y0 w h = buildImage w h (\x y -> pixelAt src (x + x0) (y + y0))
+
+-- ---------------------------------------------------------------------------
+-- Interpolation kernels
+-- ---------------------------------------------------------------------------
+
+-- | Sample the source at the integer coordinate produced by rounding
+-- @(u, v)@.  If the resolved coordinate is out of bounds and the OOB
+-- policy is 'Zero', return transparent black.
+sampleNearest :: PixelContainer -> Double -> Double -> OutOfBounds
+              -> (Word8, Word8, Word8, Word8)
+sampleNearest src@(PixelContainer w h _) u v oob =
+    let x = round u :: Int
+        y = round v :: Int
+    in case (resolveCoord x w oob, resolveCoord y h oob) of
+        (Just rx, Just ry) -> pixelAt src rx ry
+        _                  -> (0, 0, 0, 0)
+
+-- | Fetch a resolved source pixel or transparent black.
+sampleClamp :: PixelContainer -> Int -> Int -> OutOfBounds
+            -> (Word8, Word8, Word8, Word8)
+sampleClamp src@(PixelContainer w h _) x y oob =
+    case (resolveCoord x w oob, resolveCoord y h oob) of
+        (Just rx, Just ry) -> pixelAt src rx ry
+        _                  -> (0, 0, 0, 0)
+
+-- | Bilinear interpolation.  Blending happens in linear light so that
+-- scaling a dark-on-light image does not darken the result.
+sampleBilinear :: PixelContainer -> Double -> Double -> OutOfBounds
+               -> (Word8, Word8, Word8, Word8)
+sampleBilinear src u v oob =
+    let x0 = floor u :: Int
+        y0 = floor v :: Int
+        fx = u - fromIntegral x0
+        fy = v - fromIntegral y0
+        p00 = sampleClamp src  x0       y0      oob
+        p10 = sampleClamp src (x0 + 1)  y0      oob
+        p01 = sampleClamp src  x0      (y0 + 1) oob
+        p11 = sampleClamp src (x0 + 1) (y0 + 1) oob
+        -- Per-channel blend in linear light.
+        blend chan =
+            let c00 = channelLinear chan p00
+                c10 = channelLinear chan p10
+                c01 = channelLinear chan p01
+                c11 = channelLinear chan p11
+                top = c00 * (1 - fx) + c10 * fx
+                bot = c01 * (1 - fx) + c11 * fx
+            in top * (1 - fy) + bot * fy
+        r = encodeSrgb (blend 0)
+        g = encodeSrgb (blend 1)
+        b = encodeSrgb (blend 2)
+        -- Alpha is blended in linear [0, 1] (treating the byte as
+        -- linear opacity, which matches how compositors blend alpha).
+        a = let a00 = fromIntegral (alphaOf p00) / 255 :: Double
+                a10 = fromIntegral (alphaOf p10) / 255
+                a01 = fromIntegral (alphaOf p01) / 255
+                a11 = fromIntegral (alphaOf p11) / 255
+                top = a00 * (1 - fx) + a10 * fx
+                bot = a01 * (1 - fx) + a11 * fx
+                aBlend = top * (1 - fy) + bot * fy
+            in round (max 0 (min 1 aBlend) * 255)
+    in (r, g, b, a)
+  where
+    channelLinear ch (r, g, b, _) = case ch of
+        0 -> decodeSrgb r
+        1 -> decodeSrgb g
+        _ -> decodeSrgb b
+    alphaOf (_, _, _, a) = a
+
+-- | Catmull-Rom cubic weighting kernel.
+catmullRom :: Double -> Double
+catmullRom dRaw =
+    let d = abs dRaw
+    in if d < 1.0
+       then 1.5 * d**3 - 2.5 * d**2 + 1.0
+       else if d < 2.0
+            then -0.5 * d**3 + 2.5 * d**2 - 4.0 * d + 2.0
+            else 0.0
+
+-- | Bicubic (Catmull-Rom) interpolation over a 4x4 neighbourhood.
+-- We apply the kernel separably: a 1D cubic across the row, then a
+-- 1D cubic across the resulting four column-intermediates.
+sampleBicubic :: PixelContainer -> Double -> Double -> OutOfBounds
+              -> (Word8, Word8, Word8, Word8)
+sampleBicubic src u v oob =
+    let x0 = floor u :: Int
+        y0 = floor v :: Int
+        fx = u - fromIntegral x0
+        fy = v - fromIntegral y0
+        wx = [catmullRom (fromIntegral (j - 1) - fx) | j <- [0..3 :: Int]]
+        wy = [catmullRom (fromIntegral (k - 1) - fy) | k <- [0..3 :: Int]]
+        cell kk jj =
+            sampleClamp src (x0 - 1 + jj) (y0 - 1 + kk) oob
+        row k = [cell k j | j <- [0..3 :: Int]]
+        accumChan chan =
+            let rowLin k = [channelLinear chan p | p <- row k]
+                hBlends  = [sum (zipWith (*) wx (rowLin k)) | k <- [0..3 :: Int]]
+                total    = sum (zipWith (*) wy hBlends)
+            in total
+        alphaLin p = fromIntegral (alphaOf p) / 255 :: Double
+        accumAlpha =
+            let rowLin k = [alphaLin p | p <- row k]
+                hBlends  = [sum (zipWith (*) wx (rowLin k)) | k <- [0..3 :: Int]]
+            in sum (zipWith (*) wy hBlends)
+        r = encodeSrgb (accumChan 0)
+        g = encodeSrgb (accumChan 1)
+        b = encodeSrgb (accumChan 2)
+        a = round (max 0 (min 1 accumAlpha) * 255)
+    in (r, g, b, a)
+  where
+    channelLinear ch (r, g, b, _) = case ch of
+        0 -> decodeSrgb r
+        1 -> decodeSrgb g
+        _ -> decodeSrgb b
+    alphaOf (_, _, _, a) = a
+
+-- | Dispatch on the interpolation mode.
+sample :: Interpolation -> PixelContainer -> Double -> Double -> OutOfBounds
+       -> (Word8, Word8, Word8, Word8)
+sample Nearest  = sampleNearest
+sample Bilinear = sampleBilinear
+sample Bicubic  = sampleBicubic
+
+-- ---------------------------------------------------------------------------
+-- Continuous transforms
+-- ---------------------------------------------------------------------------
+
+-- | Resample to new dimensions.  Pixel-centre convention:
+-- @u = (x' + 0.5) \/ sx - 0.5@ where @sx = outW \/ srcW@.
+scale :: PixelContainer -> Int -> Int -> Interpolation -> OutOfBounds
+      -> PixelContainer
+scale src@(PixelContainer sw sh _) outW outH interp oob =
+    let sx = fromIntegral outW / fromIntegral sw :: Double
+        sy = fromIntegral outH / fromIntegral sh
+    in buildImage outW outH $ \x y ->
+        let u = (fromIntegral x + 0.5) / sx - 0.5
+            v = (fromIntegral y + 0.5) / sy - 0.5
+        in sample interp src u v oob
+
+-- | Rotate counter-clockwise by @degrees@.  'Fit' expands the canvas
+-- to hold the rotated bounding box; 'Crop' keeps the original size
+-- and lets corners fall outside.
+--
+-- Rotation is centred on the image midpoint.  The forward map is
+-- standard 2D rotation; we inverse-warp by rotating by @-degrees@.
+rotate :: PixelContainer -> Double -> RotateBounds -> Interpolation
+       -> OutOfBounds -> PixelContainer
+rotate src@(PixelContainer sw sh _) degrees bounds interp oob =
+    let theta = degrees * pi / 180.0
+        c     = cos theta
+        s     = sin theta
+        sw'   = fromIntegral sw :: Double
+        sh'   = fromIntegral sh :: Double
+        (outW, outH) = case bounds of
+            Crop -> (sw, sh)
+            Fit  ->
+                -- Bounding box of the rotated canvas.  We subtract a
+                -- tiny epsilon before 'ceiling' so that numerically
+                -- exact results (e.g. a 90-degree rotation that gives
+                -- 2.0 + 6e-17) do not accidentally round up to the
+                -- next integer.
+                let newW = abs (sw' * c) + abs (sh' * s)
+                    newH = abs (sw' * s) + abs (sh' * c)
+                    eps  = 1e-9
+                in ( max 1 (ceiling (newW - eps))
+                   , max 1 (ceiling (newH - eps))
+                   )
+        cx = sw' / 2.0
+        cy = sh' / 2.0
+        ox = fromIntegral outW / 2.0 :: Double
+        oy = fromIntegral outH / 2.0 :: Double
+    in buildImage outW outH $ \x y ->
+        let dx = fromIntegral x + 0.5 - ox
+            dy = fromIntegral y + 0.5 - oy
+            -- Inverse rotation (rotate by -theta).
+            u  =  c * dx + s * dy + cx - 0.5
+            v  = -s * dx + c * dy + cy - 0.5
+        in sample interp src u v oob
+
+-- | Translate (shift) by @(tx, ty)@ in pixel units.  Fractional shifts
+-- go through the chosen interpolation kernel.
+translate :: PixelContainer -> Double -> Double -> Interpolation -> OutOfBounds
+          -> PixelContainer
+translate src@(PixelContainer sw sh _) tx ty interp oob =
+    buildImage sw sh $ \x y ->
+        let u = fromIntegral x - tx
+            v = fromIntegral y - ty
+        in sample interp src u v oob
+
+-- | Invert a 2x3 forward affine matrix @[[a,b,c],[d,e,f]]@ so we can
+-- inverse-warp.  The 2x2 part is inverted classically; the
+-- translation part is carried through separately when applying.
+invertAffine :: [[Double]] -> (Double, Double, Double, Double, Double, Double)
+invertAffine m =
+    let a = m !! 0 !! 0 ; b = m !! 0 !! 1 ; c = m !! 0 !! 2
+        d = m !! 1 !! 0 ; e = m !! 1 !! 1 ; f = m !! 1 !! 2
+        det = a * e - b * d
+        ia =  e / det
+        ib = -b / det
+        ic = -d / det
+        ie =  a / det
+    in (ia, ib, ic, ie, c, f)
+
+-- | Apply a 2x3 forward affine matrix to each output pixel.  The
+-- matrix is inverted internally for inverse-warp sampling.  Output
+-- has the same dimensions as the input; callers who want a different
+-- canvas size should follow up with 'crop' or 'scale'.
+affine :: PixelContainer -> [[Double]] -> Interpolation -> OutOfBounds
+       -> PixelContainer
+affine src@(PixelContainer sw sh _) m interp oob =
+    let (ia, ib, ic, ie, c, f) = invertAffine m
+    in buildImage sw sh $ \x y ->
+        let xp = fromIntegral x - c
+            yp = fromIntegral y - f
+            u  = ia * xp + ib * yp
+            v  = ic * xp + ie * yp
+        in sample interp src u v oob
+
+-- | Invert a 3x3 matrix by the cofactor / determinant rule.  Returns
+-- a fresh @[[Double]]@.
+invert3x3 :: [[Double]] -> [[Double]]
+invert3x3 m =
+    let a = m !! 0 !! 0 ; b = m !! 0 !! 1 ; c = m !! 0 !! 2
+        d = m !! 1 !! 0 ; e = m !! 1 !! 1 ; f = m !! 1 !! 2
+        g = m !! 2 !! 0 ; h = m !! 2 !! 1 ; i = m !! 2 !! 2
+        det = a * (e * i - f * h)
+            - b * (d * i - f * g)
+            + c * (d * h - e * g)
+    in [ [  (e * i - f * h) / det
+         , -(b * i - c * h) / det
+         ,  (b * f - c * e) / det ]
+       , [ -(d * i - f * g) / det
+         ,  (a * i - c * g) / det
+         , -(a * f - c * d) / det ]
+       , [  (d * h - e * g) / det
+         , -(a * h - b * g) / det
+         ,  (a * e - b * d) / det ]
+       ]
+
+-- | Apply a 3x3 forward perspective (homography) matrix.  Inverted
+-- internally for inverse-warp sampling; the homogeneous denominator
+-- @w_h@ is divided out per pixel to get the affine-looking
+-- @(u, v)@ coordinates.
+perspectiveWarp :: PixelContainer -> [[Double]] -> Interpolation -> OutOfBounds
+                -> PixelContainer
+perspectiveWarp src@(PixelContainer sw sh _) m interp oob =
+    let inv = invert3x3 m
+    in buildImage sw sh $ \x y ->
+        let xp = fromIntegral x :: Double
+            yp = fromIntegral y :: Double
+            uh = inv !! 0 !! 0 * xp + inv !! 0 !! 1 * yp + inv !! 0 !! 2
+            vh = inv !! 1 !! 0 * xp + inv !! 1 !! 1 * yp + inv !! 1 !! 2
+            wh = inv !! 2 !! 0 * xp + inv !! 2 !! 1 * yp + inv !! 2 !! 2
+        in if abs wh < 1e-12
+           then (0, 0, 0, 0)
+           else sample interp src (uh / wh) (vh / wh) oob

--- a/code/packages/haskell/image-geometric-transforms/test/ImageGeometricTransformsSpec.hs
+++ b/code/packages/haskell/image-geometric-transforms/test/ImageGeometricTransformsSpec.hs
@@ -1,0 +1,218 @@
+module ImageGeometricTransformsSpec (spec) where
+
+import Test.Hspec
+import PixelContainer
+import ImageGeometricTransforms
+import Data.Word (Word8)
+
+-- | Convenience: a small test image with each pixel uniquely colored
+-- by its coordinates so we can check transforms by inspecting pixels.
+mkGrad :: Int -> Int -> PixelContainer
+mkGrad w h =
+    foldl step (createPixelContainer w h) [(x, y) | y <- [0..h-1], x <- [0..w-1]]
+  where
+    step pc (x, y) =
+        let r = fromIntegral (x * 20) :: Word8
+            g = fromIntegral (y * 20) :: Word8
+            b = 0 :: Word8
+            a = 255 :: Word8
+        in setPixel pc x y r g b a
+
+-- | Tolerance-based pixel comparison for floating-point paths.
+near :: Word8 -> Word8 -> Int -> Bool
+near a b tol = abs (fromIntegral a - fromIntegral b :: Int) <= tol
+
+spec :: Spec
+spec = do
+    describe "flipHorizontal" $ do
+        it "preserves dimensions" $ do
+            let pc = flipHorizontal (mkGrad 4 3)
+            pcWidth pc  `shouldBe` 4
+            pcHeight pc `shouldBe` 3
+        it "mirrors columns" $ do
+            let src = mkGrad 4 3
+                pc  = flipHorizontal src
+            pixelAt pc 0 0 `shouldBe` pixelAt src 3 0
+            pixelAt pc 3 2 `shouldBe` pixelAt src 0 2
+        it "is an involution (twice = identity)" $ do
+            let src = mkGrad 4 3
+                pc  = flipHorizontal (flipHorizontal src)
+            pcPixels pc `shouldBe` pcPixels src
+
+    describe "flipVertical" $ do
+        it "preserves dimensions" $ do
+            let pc = flipVertical (mkGrad 4 3)
+            pcWidth pc  `shouldBe` 4
+            pcHeight pc `shouldBe` 3
+        it "mirrors rows" $ do
+            let src = mkGrad 4 3
+                pc  = flipVertical src
+            pixelAt pc 0 0 `shouldBe` pixelAt src 0 2
+            pixelAt pc 3 2 `shouldBe` pixelAt src 3 0
+        it "is an involution" $ do
+            let src = mkGrad 4 3
+                pc  = flipVertical (flipVertical src)
+            pcPixels pc `shouldBe` pcPixels src
+
+    describe "rotate90CW" $ do
+        it "swaps dimensions" $ do
+            let pc = rotate90CW (mkGrad 4 3)
+            pcWidth pc  `shouldBe` 3
+            pcHeight pc `shouldBe` 4
+        it "places (0,0) at the top-right of the source" $ do
+            let src = mkGrad 4 3
+                pc  = rotate90CW src
+            pixelAt pc 0 0 `shouldBe` pixelAt src 0 2
+        it "four applications is identity" $ do
+            let src = mkGrad 4 3
+                pc  = rotate90CW (rotate90CW (rotate90CW (rotate90CW src)))
+            pcPixels pc `shouldBe` pcPixels src
+
+    describe "rotate90CCW" $ do
+        it "swaps dimensions" $ do
+            let pc = rotate90CCW (mkGrad 4 3)
+            pcWidth pc  `shouldBe` 3
+            pcHeight pc `shouldBe` 4
+        it "CW then CCW is identity" $ do
+            let src = mkGrad 4 3
+                pc  = rotate90CCW (rotate90CW src)
+            pcPixels pc `shouldBe` pcPixels src
+
+    describe "rotate180" $ do
+        it "preserves dimensions" $ do
+            let pc = rotate180 (mkGrad 4 3)
+            pcWidth pc  `shouldBe` 4
+            pcHeight pc `shouldBe` 3
+        it "equals double rotate90CW" $ do
+            let src = mkGrad 4 3
+                a   = rotate180 src
+                b   = rotate90CW (rotate90CW src)
+            pcPixels a `shouldBe` pcPixels b
+        it "is an involution" $ do
+            let src = mkGrad 4 3
+                pc  = rotate180 (rotate180 src)
+            pcPixels pc `shouldBe` pcPixels src
+
+    describe "crop" $ do
+        it "extracts correct region" $ do
+            let src = mkGrad 4 4
+                pc  = crop src 1 1 2 2
+            pcWidth pc  `shouldBe` 2
+            pcHeight pc `shouldBe` 2
+            pixelAt pc 0 0 `shouldBe` pixelAt src 1 1
+            pixelAt pc 1 1 `shouldBe` pixelAt src 2 2
+        it "fills out-of-bounds with (0,0,0,0)" $ do
+            let src = mkGrad 2 2
+                pc  = crop src 0 0 4 4
+            pixelAt pc 3 3 `shouldBe` (0, 0, 0, 0)
+
+    describe "scale (nearest)" $ do
+        it "doubling preserves visual content approximately" $ do
+            let src = mkGrad 4 4
+                pc  = scale src 8 8 Nearest Zero
+            pcWidth pc  `shouldBe` 8
+            pcHeight pc `shouldBe` 8
+        it "identity scale is identity" $ do
+            let src = mkGrad 4 4
+                pc  = scale src 4 4 Nearest Zero
+            -- Nearest identity: each output pixel equals same source pixel.
+            pixelAt pc 0 0 `shouldBe` pixelAt src 0 0
+            pixelAt pc 3 3 `shouldBe` pixelAt src 3 3
+
+    describe "scale (bilinear)" $ do
+        it "approximately preserves uniform colour" $ do
+            let src = fillPixels (createPixelContainer 4 4) 100 150 200 255
+                pc  = scale src 8 8 Bilinear Replicate
+                (r, g, b, _) = pixelAt pc 4 4
+            near r 100 3 `shouldBe` True
+            near g 150 3 `shouldBe` True
+            near b 200 3 `shouldBe` True
+
+    describe "scale (bicubic)" $ do
+        it "preserves uniform colour" $ do
+            let src = fillPixels (createPixelContainer 4 4) 50 100 150 255
+                pc  = scale src 8 8 Bicubic Replicate
+                (r, g, b, _) = pixelAt pc 4 4
+            near r 50  4 `shouldBe` True
+            near g 100 4 `shouldBe` True
+            near b 150 4 `shouldBe` True
+
+    describe "rotate (arbitrary)" $ do
+        it "0 degrees Crop is approximately identity" $ do
+            let src = fillPixels (createPixelContainer 4 4) 200 100 50 255
+                pc  = rotate src 0 Crop Nearest Replicate
+                (r, g, b, _) = pixelAt pc 2 2
+            near r 200 1 `shouldBe` True
+            near g 100 1 `shouldBe` True
+            near b 50  1 `shouldBe` True
+        it "90 degrees Fit produces a canvas of swapped dimensions" $ do
+            let src = mkGrad 4 2
+                pc  = rotate src 90 Fit Nearest Zero
+            pcWidth pc  `shouldBe` 2
+            pcHeight pc `shouldBe` 4
+        it "Crop keeps canvas size" $ do
+            let pc = rotate (mkGrad 4 4) 45 Crop Bilinear Zero
+            pcWidth pc  `shouldBe` 4
+            pcHeight pc `shouldBe` 4
+
+    describe "translate" $ do
+        it "integer shift moves pixels" $ do
+            let src = mkGrad 4 4
+                pc  = translate src 1 0 Nearest Zero
+            pixelAt pc 1 0 `shouldBe` pixelAt src 0 0
+        it "negative shift with Zero OOB fills zeros" $ do
+            let src = fillPixels (createPixelContainer 4 4) 200 100 50 255
+                pc  = translate src 2 0 Nearest Zero
+            pixelAt pc 0 0 `shouldBe` (0, 0, 0, 0)
+        it "Replicate OOB extends edge" $ do
+            let src = fillPixels (createPixelContainer 4 4) 200 100 50 255
+                pc  = translate src 2 0 Nearest Replicate
+            pixelAt pc 0 0 `shouldBe` (200, 100, 50, 255)
+
+    describe "affine" $ do
+        it "identity matrix is (approximately) identity" $ do
+            let src = fillPixels (createPixelContainer 4 4) 123 45 67 255
+                m   = [[1,0,0],[0,1,0]]
+                pc  = affine src m Nearest Replicate
+            pixelAt pc 2 2 `shouldBe` (123, 45, 67, 255)
+        it "2x scale matrix zooms in" $ do
+            let src = mkGrad 4 4
+                -- Forward map (x,y) -> (2x, 2y).  Inverse samples at (x'/2, y'/2).
+                m   = [[2,0,0],[0,2,0]]
+                pc  = affine src m Nearest Replicate
+            -- Pixel (2, 2) of the output should read the source at
+            -- u = (x - c) * ia = (2 - 0) * 0.5 = 1, v = 1.
+            pixelAt pc 2 2 `shouldBe` pixelAt src 1 1
+
+    describe "perspectiveWarp" $ do
+        it "identity homography is (approximately) identity" $ do
+            let src = fillPixels (createPixelContainer 4 4) 30 60 90 255
+                m   = [[1,0,0],[0,1,0],[0,0,1]]
+                pc  = perspectiveWarp src m Nearest Replicate
+                (r, g, b, _) = pixelAt pc 2 2
+            (r, g, b) `shouldBe` (30, 60, 90)
+        it "pure scaling homography matches affine scaling" $ do
+            let src = mkGrad 4 4
+                m   = [[2,0,0],[0,2,0],[0,0,1]]
+                pc  = perspectiveWarp src m Nearest Replicate
+            pixelAt pc 2 2 `shouldBe` pixelAt src 1 1
+
+    describe "Out-of-bounds policies" $ do
+        it "Zero returns transparent black when crossing boundary" $ do
+            let src = fillPixels (createPixelContainer 4 4) 200 100 50 255
+                pc  = translate src 10 10 Nearest Zero
+            pixelAt pc 0 0 `shouldBe` (0, 0, 0, 0)
+        it "Replicate clamps to edge pixel" $ do
+            let src = fillPixels (createPixelContainer 4 4) 200 100 50 255
+                pc  = translate src 10 10 Nearest Replicate
+            pixelAt pc 0 0 `shouldBe` (200, 100, 50, 255)
+        it "Wrap tiles the image" $ do
+            let src = fillPixels (createPixelContainer 4 4) 200 100 50 255
+                pc  = translate src 4 0 Nearest Wrap
+            pixelAt pc 0 0 `shouldBe` (200, 100, 50, 255)
+        it "Reflect produces in-bounds samples" $ do
+            let src = mkGrad 4 4
+                pc  = translate src (-1) 0 Nearest Reflect
+                (_,_,_,a) = pixelAt pc 0 0
+            -- Should be opaque because sample was in-bounds.
+            a `shouldBe` 255

--- a/code/packages/haskell/image-geometric-transforms/test/Spec.hs
+++ b/code/packages/haskell/image-geometric-transforms/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import ImageGeometricTransformsSpec (spec)
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/image-point-ops/BUILD
+++ b/code/packages/haskell/image-point-ops/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/image-point-ops/BUILD_windows
+++ b/code/packages/haskell/image-point-ops/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/image-point-ops/CHANGELOG.md
+++ b/code/packages/haskell/image-point-ops/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## 0.1.0 — 2026-04-20
+
+- Initial release of IMG03 point operations for Haskell.
+- Index-remapping: `invert`, `threshold`, `thresholdLuminance`,
+  `posterize`, `swapRgbBgr`, `extractChannel`.
+- Tone: `brightness`, `contrast`, `gamma`, `exposure`.
+- Colour: `greyscale` (Rec709 / BT.601 / Average), `sepia`,
+  `colourMatrix`, `saturate`, `hueRotate`.
+- sRGB <-> linear: `srgbToLinearImage`, `linearToSrgbImage`.
+- 1D LUTs: `applyLut1dU8`, `buildLut1dU8`, `buildGammaLut`.
+- Hspec test suite.

--- a/code/packages/haskell/image-point-ops/README.md
+++ b/code/packages/haskell/image-point-ops/README.md
@@ -1,0 +1,41 @@
+# image-point-ops (Haskell)
+
+IMG03 — Per-pixel point operations on `PixelContainer`.
+
+## Overview
+
+A /point operation/ is any transform where the output pixel at `(x, y)`
+depends only on the input pixel at `(x, y)` — no neighbourhood, no history.
+This package provides the full catalogue.
+
+All arithmetic operations (gamma, exposure, greyscale, sepia, saturation,
+hue-rotate, colour matrix) are performed in linear-light space so they are
+physically correct.  Pure index-remapping ops (invert, threshold, swap, LUTs)
+stay in sRGB.
+
+## Usage
+
+```haskell
+import PixelContainer
+import ImagePointOps
+
+main :: IO ()
+main = do
+    let pc = fillPixels (createPixelContainer 8 8) 200 100 50 255
+    let result = gamma (greyscale pc Rec709) 2.2
+    print (pixelAt result 0 0)
+```
+
+## API
+
+- `invert`, `threshold`, `thresholdLuminance`, `posterize`
+- `swapRgbBgr`, `extractChannel`
+- `brightness`, `contrast`, `gamma`, `exposure`
+- `greyscale` with `GreyscaleMethod = Rec709 | Bt601 | Average`
+- `sepia`, `colourMatrix`, `saturate`, `hueRotate`
+- `srgbToLinearImage`, `linearToSrgbImage`
+- `applyLut1dU8`, `buildLut1dU8`, `buildGammaLut`
+
+## Dependencies
+
+- `pixel-container` (IC00)

--- a/code/packages/haskell/image-point-ops/image-point-ops.cabal
+++ b/code/packages/haskell/image-point-ops/image-point-ops.cabal
@@ -1,0 +1,32 @@
+cabal-version: 3.0
+name:          image-point-ops
+version:       0.1.0
+synopsis:      IMG03: Per-pixel point operations on PixelContainer
+description:   Point operations transform each pixel independently of its
+               neighbours: invert, threshold, posterize, brightness,
+               contrast, gamma, exposure, greyscale, sepia, colour matrix,
+               saturate, hue-rotate, sRGB <-> linear, and 1D LUTs.
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  ImagePointOps
+    build-depends:    base >=4.14
+                    , bytestring
+                    , pixel-container
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    ImagePointOpsSpec
+    build-depends:    base >=4.14
+                    , bytestring
+                    , pixel-container
+                    , image-point-ops
+                    , hspec == 2.*
+    hs-source-dirs:   test
+    default-language: Haskell2010

--- a/code/packages/haskell/image-point-ops/src/ImagePointOps.hs
+++ b/code/packages/haskell/image-point-ops/src/ImagePointOps.hs
@@ -1,0 +1,421 @@
+-- | IMG03 — Per-pixel point operations.
+--
+-- A /point operation/ is any image transform where the output pixel at
+-- @(x, y)@ depends only on the /input/ pixel at @(x, y)@.  No
+-- neighbourhood, no history, no context — just a pure function of one
+-- RGBA sample.  This makes the operations trivially parallel (we just
+-- map over pixels) and easy to reason about.
+--
+-- == sRGB vs. linear light
+--
+-- JPEG/PNG pixels are /gamma-encoded/: the 8-bit value is a power-law
+-- compressed version of the physical light intensity, roughly
+-- @byte = 255 * linear ** (1/2.4)@ with a small linear toe near black.
+-- Arithmetic (scaling, blending, averaging) should happen in /linear
+-- light/ to be physically correct; otherwise dark colours dominate.
+--
+-- We therefore:
+--
+-- * Pre-compute a 256-entry lookup table 'srgbToLinear' for the decode
+--   direction (the hot path).
+-- * Use 'encodeSrgb' for the encode direction (rarer, so we compute on
+--   the fly).
+--
+-- Operations that only re-index pixels (invert, threshold, swap, LUTs)
+-- stay in sRGB because they do not perform any arithmetic on intensity.
+-- Operations that scale or blend (gamma, exposure, greyscale, sepia,
+-- saturation, hue-rotate, colour matrix) round-trip through linear.
+module ImagePointOps
+    ( GreyscaleMethod(..)
+    , invert
+    , threshold
+    , thresholdLuminance
+    , posterize
+    , swapRgbBgr
+    , extractChannel
+    , brightness
+    , contrast
+    , gamma
+    , exposure
+    , greyscale
+    , sepia
+    , colourMatrix
+    , saturate
+    , hueRotate
+    , srgbToLinearImage
+    , linearToSrgbImage
+    , applyLut1dU8
+    , buildLut1dU8
+    , buildGammaLut
+    ) where
+
+import PixelContainer
+import Data.Word (Word8)
+import qualified Data.ByteString as BS
+
+-- ---------------------------------------------------------------------------
+-- sRGB <-> linear helpers
+-- ---------------------------------------------------------------------------
+
+-- | 256-entry LUT mapping a byte in sRGB space to a 'Double' in
+-- [0, 1] linear-light space.
+--
+-- The formal sRGB EOTF is:
+--
+-- @
+-- c = byte / 255
+-- linear = if c <= 0.04045
+--          then c / 12.92
+--          else ((c + 0.055) / 1.055) ** 2.4
+-- @
+srgbToLinear :: [Double]
+srgbToLinear =
+    [ let c = fromIntegral i / 255.0
+      in if c <= 0.04045
+         then c / 12.92
+         else ((c + 0.055) / 1.055) ** 2.4
+    | i <- [0..255 :: Int]
+    ]
+
+-- | Decode a single sRGB byte to linear-light [0, 1].
+decodeSrgb :: Word8 -> Double
+decodeSrgb b = srgbToLinear !! fromIntegral b
+
+-- | Encode a linear-light value in [0, 1] back to an sRGB byte.
+--
+-- Input is clamped before encoding so that downstream clipping never
+-- produces NaNs from @(negative)**2.4@.
+encodeSrgb :: Double -> Word8
+encodeSrgb linear =
+    let c    = max 0.0 (min 1.0 linear)
+        srgb = if c <= 0.0031308
+               then c * 12.92
+               else 1.055 * (c ** (1.0 / 2.4)) - 0.055
+    in round (srgb * 255.0)
+
+-- ---------------------------------------------------------------------------
+-- Generic per-pixel map
+-- ---------------------------------------------------------------------------
+
+-- | Apply a pure function to every pixel.  This is the single workhorse
+-- every point operation goes through.  Because 'BS.ByteString' is
+-- immutable, we compute the new contents as a list of lists of bytes
+-- and pack them in one go — one allocation, linear in the image size.
+mapPixels :: PixelContainer
+          -> (Word8 -> Word8 -> Word8 -> Word8 -> (Word8, Word8, Word8, Word8))
+          -> PixelContainer
+mapPixels src@(PixelContainer w h _) f =
+    let pixList =
+            [ let (r, g, b, a)     = pixelAt src x y
+                  (r', g', b', a') = f r g b a
+              in [r', g', b', a']
+            | y <- [0 .. h - 1], x <- [0 .. w - 1]
+            ]
+    in PixelContainer w h (BS.pack (concat pixList))
+
+-- | Clamp an 'Int' to the @[0, 255]@ range and cast to 'Word8'.
+clampByte :: Int -> Word8
+clampByte v = fromIntegral (max 0 (min 255 v))
+
+-- | Clamp a 'Double' to @[0, 255]@ and round to a 'Word8'.
+clampByteD :: Double -> Word8
+clampByteD v = fromIntegral (max 0 (min 255 (round v :: Int)))
+
+-- ---------------------------------------------------------------------------
+-- Simple index-remapping operations (stay in sRGB)
+-- ---------------------------------------------------------------------------
+
+-- | Invert RGB (photographic negative).  Alpha is preserved because it
+-- is not a colour — inverting transparency would be a bug, not a
+-- feature.
+invert :: PixelContainer -> PixelContainer
+invert pc = mapPixels pc (\r g b a -> (255 - r, 255 - g, 255 - b, a))
+
+-- | Binarise using the average of the three channels as the measure.
+-- Any pixel whose average meets or exceeds the threshold becomes
+-- white; anything darker becomes black.  Alpha is preserved.
+threshold :: PixelContainer -> Word8 -> PixelContainer
+threshold pc t = mapPixels pc $ \r g b a ->
+    let avg = (fromIntegral r + fromIntegral g + fromIntegral b) `div` (3 :: Int)
+    in if avg >= fromIntegral t
+       then (255, 255, 255, a)
+       else (0, 0, 0, a)
+
+-- | Binarise using Rec. 709 luminance
+-- (@Y = 0.2126 R + 0.7152 G + 0.0722 B@).  This matches how humans
+-- perceive brightness and is what you want for most "convert to B&W"
+-- use-cases — a bright yellow and a dark blue do not average to the
+-- same visual grey.
+thresholdLuminance :: PixelContainer -> Word8 -> PixelContainer
+thresholdLuminance pc t = mapPixels pc $ \r g b a ->
+    let y = 0.2126 * fromIntegral r
+          + 0.7152 * fromIntegral g
+          + 0.0722 * fromIntegral b
+    in if y >= fromIntegral t
+       then (255, 255, 255, a)
+       else (0, 0, 0, a)
+
+-- | Posterise to @levels@ discrete tones per channel.  Each input value
+-- is snapped to the nearest multiple of @255 \/ (levels - 1)@, giving a
+-- stepped "paint-by-numbers" look.  @levels < 2@ is clamped to 2.
+posterize :: PixelContainer -> Int -> PixelContainer
+posterize pc levelsRaw =
+    let levels = max 2 levelsRaw
+        step   = 255.0 / fromIntegral (levels - 1) :: Double
+        q v    = let vd = fromIntegral v / step
+                     snapped = fromIntegral (round vd :: Int) * step
+                 in clampByteD snapped
+    in mapPixels pc (\r g b a -> (q r, q g, q b, a))
+
+-- | Swap red and blue channels — RGBA -> BGRA.  Useful for debugging
+-- or interfacing with libraries that use BGR order.
+swapRgbBgr :: PixelContainer -> PixelContainer
+swapRgbBgr pc = mapPixels pc (\r g b a -> (b, g, r, a))
+
+-- | Extract a single channel as an opaque greyscale image.  @ch = 0,
+-- 1, 2, 3@ selects R, G, B, A respectively.  The chosen channel is
+-- replicated into all three colour channels and alpha is forced to
+-- fully opaque so the result is immediately viewable.  Any other value
+-- of @ch@ returns the image unchanged.
+extractChannel :: PixelContainer -> Int -> PixelContainer
+extractChannel pc ch = mapPixels pc $ \r g b a ->
+    let v = case ch of
+                0 -> r
+                1 -> g
+                2 -> b
+                3 -> a
+                _ -> 0
+    in case ch of
+        0 -> (v, v, v, 255)
+        1 -> (v, v, v, 255)
+        2 -> (v, v, v, 255)
+        3 -> (v, v, v, 255)
+        _ -> (r, g, b, a)
+
+-- ---------------------------------------------------------------------------
+-- Tone operations
+-- ---------------------------------------------------------------------------
+
+-- | Additive brightness in sRGB space.  Each RGB channel is shifted by
+-- @delta@ and clamped to @[0, 255]@.  Working in sRGB here matches the
+-- "brightness slider" in a naive image editor; use 'exposure' for a
+-- physically correct scale.
+brightness :: PixelContainer -> Int -> PixelContainer
+brightness pc delta = mapPixels pc $ \r g b a ->
+    ( clampByte (fromIntegral r + delta)
+    , clampByte (fromIntegral g + delta)
+    , clampByte (fromIntegral b + delta)
+    , a
+    )
+
+-- | GIMP-style contrast in sRGB.  @factor@ is in @[-1, 1]@: zero is
+-- identity, positive pushes away from mid-grey, negative compresses
+-- toward mid-grey.  The classic formula is:
+--
+-- @
+-- f   = (259 * (factor * 255 + 255)) / (255 * (259 - factor * 255))
+-- out = f * (in - 128) + 128
+-- @
+contrast :: PixelContainer -> Double -> PixelContainer
+contrast pc factor =
+    let f       = (259.0 * (factor * 255.0 + 255.0))
+                / (255.0 * (259.0 - factor * 255.0))
+        adjust v = clampByteD (f * (fromIntegral v - 128.0) + 128.0)
+    in mapPixels pc (\r g b a -> (adjust r, adjust g, adjust b, a))
+
+-- | Apply a gamma curve @y = x^g@ in linear light.  @g < 1@ brightens
+-- mid-tones, @g > 1@ darkens them.
+gamma :: PixelContainer -> Double -> PixelContainer
+gamma pc g = mapPixels pc $ \r gr b a ->
+    let rl = decodeSrgb r  ** g
+        gl = decodeSrgb gr ** g
+        bl = decodeSrgb b  ** g
+    in (encodeSrgb rl, encodeSrgb gl, encodeSrgb bl, a)
+
+-- | Physically correct exposure adjustment: multiply linear light by
+-- @2 ^ stops@.  @+1 stop@ doubles brightness, @-1 stop@ halves it.
+exposure :: PixelContainer -> Double -> PixelContainer
+exposure pc stops =
+    let scale = 2.0 ** stops
+    in mapPixels pc $ \r g b a ->
+        ( encodeSrgb (decodeSrgb r * scale)
+        , encodeSrgb (decodeSrgb g * scale)
+        , encodeSrgb (decodeSrgb b * scale)
+        , a
+        )
+
+-- ---------------------------------------------------------------------------
+-- Colour-space style operations
+-- ---------------------------------------------------------------------------
+
+-- | Algorithm family for converting colour to greyscale.
+--
+-- * 'Rec709' — modern HDTV weights, what most digital tools use today.
+-- * 'Bt601'  — older NTSC/PAL weights, what most legacy tools used.
+-- * 'Average' — plain @(R + G + B) \/ 3@, no perceptual correction.
+data GreyscaleMethod = Rec709 | Bt601 | Average deriving (Show, Eq)
+
+-- | Convert to greyscale using the requested weighting scheme.  Work
+-- in linear light so that two equally bright colours produce the same
+-- grey.  The alpha channel is preserved.
+greyscale :: PixelContainer -> GreyscaleMethod -> PixelContainer
+greyscale pc method =
+    let (wr, wg, wb) = case method of
+            Rec709  -> (0.2126, 0.7152, 0.0722)
+            Bt601   -> (0.299 , 0.587 , 0.114 )
+            Average -> (1/3   , 1/3   , 1/3   )
+    in mapPixels pc $ \r g b a ->
+        let yLin = wr * decodeSrgb r + wg * decodeSrgb g + wb * decodeSrgb b
+            y    = encodeSrgb yLin
+        in (y, y, y, a)
+
+-- | Sepia tone via the classic 3x3 linear-light matrix.  Warm yellows
+-- map to themselves, cool colours get pulled toward a brown-orange
+-- anchor.  The matrix is applied in linear light — applying it in sRGB
+-- produces a muddier result.
+sepia :: PixelContainer -> PixelContainer
+sepia pc = mapPixels pc $ \r g b a ->
+    let rl = decodeSrgb r
+        gl = decodeSrgb g
+        bl = decodeSrgb b
+        rOut = 0.393 * rl + 0.769 * gl + 0.189 * bl
+        gOut = 0.349 * rl + 0.686 * gl + 0.168 * bl
+        bOut = 0.272 * rl + 0.534 * gl + 0.131 * bl
+    in (encodeSrgb rOut, encodeSrgb gOut, encodeSrgb bOut, a)
+
+-- | Apply a generic 3x3 colour matrix in linear light.  The matrix is
+-- a list of rows @[[m00, m01, m02], [m10, m11, m12], [m20, m21, m22]]@;
+-- each output channel is a weighted sum of the three input channels.
+-- This subsumes sepia, hue-rotation via known matrices, and custom
+-- channel mixing.
+colourMatrix :: PixelContainer -> [[Double]] -> PixelContainer
+colourMatrix pc m = mapPixels pc $ \r g b a ->
+    let rl = decodeSrgb r
+        gl = decodeSrgb g
+        bl = decodeSrgb b
+        row i = m !! i
+        rOut = row 0 !! 0 * rl + row 0 !! 1 * gl + row 0 !! 2 * bl
+        gOut = row 1 !! 0 * rl + row 1 !! 1 * gl + row 1 !! 2 * bl
+        bOut = row 2 !! 0 * rl + row 2 !! 1 * gl + row 2 !! 2 * bl
+    in (encodeSrgb rOut, encodeSrgb gOut, encodeSrgb bOut, a)
+
+-- | Saturation.  @factor = 0@ produces pure greyscale, @1@ is identity,
+-- values above 1 push colours further from grey.  The operation is a
+-- linear interpolation between each pixel's linear luminance and its
+-- linear colour.
+saturate :: PixelContainer -> Double -> PixelContainer
+saturate pc factor = mapPixels pc $ \r g b a ->
+    let rl = decodeSrgb r
+        gl = decodeSrgb g
+        bl = decodeSrgb b
+        y  = 0.2126 * rl + 0.7152 * gl + 0.0722 * bl
+        lerp v = y + factor * (v - y)
+    in (encodeSrgb (lerp rl), encodeSrgb (lerp gl), encodeSrgb (lerp bl), a)
+
+-- | Hue rotation (degrees, counter-clockwise on the colour wheel).
+-- Converts RGB -> HSV, shifts hue, converts back.  Work is done in
+-- linear light so that the rotation is perceptually balanced.
+hueRotate :: PixelContainer -> Double -> PixelContainer
+hueRotate pc degrees = mapPixels pc $ \r g b a ->
+    let rl = decodeSrgb r
+        gl = decodeSrgb g
+        bl = decodeSrgb b
+        (h, s, v) = rgbToHsv rl gl bl
+        h'        = wrap360 (h + degrees)
+        (r', g', b') = hsvToRgb h' s v
+    in (encodeSrgb r', encodeSrgb g', encodeSrgb b', a)
+
+-- | Fold a hue in degrees into @[0, 360)@.
+wrap360 :: Double -> Double
+wrap360 h =
+    let x = h - 360.0 * fromIntegral (floor (h / 360.0) :: Int)
+    in if x < 0 then x + 360.0 else x
+
+-- | RGB (in [0, 1]) to HSV (H in degrees [0, 360), S and V in [0, 1]).
+rgbToHsv :: Double -> Double -> Double -> (Double, Double, Double)
+rgbToHsv r g b =
+    let cmax  = max r (max g b)
+        cmin  = min r (min g b)
+        delta = cmax - cmin
+        s     = if cmax < 1e-6 then 0 else delta / cmax
+        v     = cmax
+        h | delta < 1e-6 = 0
+          | cmax == r    = 60 * fmodD ((g - b) / delta) 6
+          | cmax == g    = 60 * (((b - r) / delta) + 2)
+          | otherwise    = 60 * (((r - g) / delta) + 4)
+    in (if h < 0 then h + 360 else h, s, v)
+
+-- | HSV back to RGB.  Inverse of 'rgbToHsv'.  The sector index picks
+-- one of six (R,G,B) permutations; each sector is a linear blend of
+-- two primaries.
+hsvToRgb :: Double -> Double -> Double -> (Double, Double, Double)
+hsvToRgb h s v =
+    let c      = v * s
+        hp     = h / 60.0
+        x      = c * (1.0 - abs (fmodD hp 2 - 1))
+        m      = v - c
+        sector = floor hp :: Int
+        (r1, g1, b1) = case sector `mod` 6 of
+            0 -> (c, x, 0)
+            1 -> (x, c, 0)
+            2 -> (0, c, x)
+            3 -> (0, x, c)
+            4 -> (x, 0, c)
+            _ -> (c, 0, x)
+    in (r1 + m, g1 + m, b1 + m)
+
+-- | Floating-point modulus that always returns a non-negative result,
+-- mirroring the behaviour of Python's @%@ operator.
+fmodD :: Double -> Double -> Double
+fmodD a b =
+    let r = a - b * fromIntegral (floor (a / b) :: Int)
+    in if r < 0 then r + b else r
+
+-- ---------------------------------------------------------------------------
+-- sRGB <-> linear image transforms
+-- ---------------------------------------------------------------------------
+
+-- | Treat each pixel byte as sRGB-encoded, decode to linear [0, 1],
+-- and re-pack as an 8-bit byte (@round(linear * 255)@).  Useful when
+-- downstream code assumes linear-light bytes — e.g. for blending.
+srgbToLinearImage :: PixelContainer -> PixelContainer
+srgbToLinearImage pc = mapPixels pc $ \r g b a ->
+    let toLin v = clampByteD (decodeSrgb v * 255.0)
+    in (toLin r, toLin g, toLin b, a)
+
+-- | Inverse of 'srgbToLinearImage': treat each byte as linear [0, 1]
+-- (@byte \/ 255@), encode with the sRGB curve, round back to a byte.
+linearToSrgbImage :: PixelContainer -> PixelContainer
+linearToSrgbImage pc = mapPixels pc $ \r g b a ->
+    let toSrgb v = encodeSrgb (fromIntegral v / 255.0)
+    in (toSrgb r, toSrgb g, toSrgb b, a)
+
+-- ---------------------------------------------------------------------------
+-- 1D LUTs
+-- ---------------------------------------------------------------------------
+
+-- | Apply three independent 1D LUTs to the R, G, B channels.  Each
+-- LUT must be 256 entries.  Alpha is left untouched.  Because the
+-- table is a pure value, LUT-based grading is embarrassingly simple
+-- to compose: chain two LUTs off-line and you get a single LUT.
+applyLut1dU8 :: PixelContainer -> [Word8] -> [Word8] -> [Word8] -> PixelContainer
+applyLut1dU8 pc lutR lutG lutB = mapPixels pc $ \r g b a ->
+    ( lutR !! fromIntegral r
+    , lutG !! fromIntegral g
+    , lutB !! fromIntegral b
+    , a
+    )
+
+-- | Build a 256-entry LUT from a linear-light function
+-- @f :: Double -> Double@ by decoding each byte to linear, applying
+-- @f@, and encoding back to sRGB.
+buildLut1dU8 :: (Double -> Double) -> [Word8]
+buildLut1dU8 f =
+    [ encodeSrgb (f (decodeSrgb (fromIntegral i)))
+    | i <- [0..255 :: Int]
+    ]
+
+-- | Convenience wrapper: build a gamma LUT (@y = x^g@ in linear
+-- light).  Equivalent to @buildLut1dU8 (** g)@.
+buildGammaLut :: Double -> [Word8]
+buildGammaLut g = buildLut1dU8 (\x -> x ** g)

--- a/code/packages/haskell/image-point-ops/src/ImagePointOps.hs
+++ b/code/packages/haskell/image-point-ops/src/ImagePointOps.hs
@@ -289,7 +289,10 @@ sepia pc = mapPixels pc $ \r g b a ->
 -- This subsumes sepia, hue-rotation via known matrices, and custom
 -- channel mixing.
 colourMatrix :: PixelContainer -> [[Double]] -> PixelContainer
-colourMatrix pc m = mapPixels pc $ \r g b a ->
+colourMatrix pc m
+    | length m /= 3 || any ((/= 3) . length) m =
+        error "colourMatrix: matrix must be exactly 3×3"
+    | otherwise = mapPixels pc $ \r g b a ->
     let rl = decodeSrgb r
         gl = decodeSrgb g
         bl = decodeSrgb b
@@ -399,12 +402,15 @@ linearToSrgbImage pc = mapPixels pc $ \r g b a ->
 -- table is a pure value, LUT-based grading is embarrassingly simple
 -- to compose: chain two LUTs off-line and you get a single LUT.
 applyLut1dU8 :: PixelContainer -> [Word8] -> [Word8] -> [Word8] -> PixelContainer
-applyLut1dU8 pc lutR lutG lutB = mapPixels pc $ \r g b a ->
-    ( lutR !! fromIntegral r
-    , lutG !! fromIntegral g
-    , lutB !! fromIntegral b
-    , a
-    )
+applyLut1dU8 pc lutR lutG lutB
+    | length lutR /= 256 || length lutG /= 256 || length lutB /= 256 =
+        error "applyLut1dU8: each LUT must have exactly 256 entries"
+    | otherwise = mapPixels pc $ \r g b a ->
+        ( lutR !! fromIntegral r
+        , lutG !! fromIntegral g
+        , lutB !! fromIntegral b
+        , a
+        )
 
 -- | Build a 256-entry LUT from a linear-light function
 -- @f :: Double -> Double@ by decoding each byte to linear, applying

--- a/code/packages/haskell/image-point-ops/test/ImagePointOpsSpec.hs
+++ b/code/packages/haskell/image-point-ops/test/ImagePointOpsSpec.hs
@@ -1,0 +1,191 @@
+module ImagePointOpsSpec (spec) where
+
+import Test.Hspec
+import PixelContainer
+import ImagePointOps
+import Data.Word (Word8)
+
+-- | Build a single-pixel image in one line.
+onePixel :: Word8 -> Word8 -> Word8 -> Word8 -> PixelContainer
+onePixel r g b a = setPixel (createPixelContainer 1 1) 0 0 r g b a
+
+-- | Tolerance for comparing round-tripped byte values that go through
+-- floating-point arithmetic.
+near :: Word8 -> Word8 -> Int -> Bool
+near a b tol = abs (fromIntegral a - fromIntegral b :: Int) <= tol
+
+spec :: Spec
+spec = do
+    describe "invert" $ do
+        it "inverts pure white to black" $
+            pixelAt (invert (onePixel 255 255 255 255)) 0 0
+                `shouldBe` (0, 0, 0, 255)
+        it "inverts pure black to white" $
+            pixelAt (invert (onePixel 0 0 0 128)) 0 0
+                `shouldBe` (255, 255, 255, 128)
+        it "preserves alpha" $
+            let (_, _, _, a) = pixelAt (invert (onePixel 10 20 30 200)) 0 0
+            in a `shouldBe` 200
+
+    describe "threshold" $ do
+        it "sends darks to black" $
+            pixelAt (threshold (onePixel 10 10 10 255) 128) 0 0
+                `shouldBe` (0, 0, 0, 255)
+        it "sends brights to white" $
+            pixelAt (threshold (onePixel 200 200 200 255) 128) 0 0
+                `shouldBe` (255, 255, 255, 255)
+
+    describe "thresholdLuminance" $ do
+        it "treats bright green as white" $
+            pixelAt (thresholdLuminance (onePixel 0 255 0 255) 128) 0 0
+                `shouldBe` (255, 255, 255, 255)
+        it "treats deep blue as black" $
+            pixelAt (thresholdLuminance (onePixel 0 0 255 255) 128) 0 0
+                `shouldBe` (0, 0, 0, 255)
+
+    describe "posterize" $ do
+        it "snaps values with levels=2 to 0 or 255" $ do
+            let (r, _, _, _) = pixelAt (posterize (onePixel 10 10 10 255) 2) 0 0
+            r `shouldBe` 0
+            let (r', _, _, _) = pixelAt (posterize (onePixel 200 200 200 255) 2) 0 0
+            r' `shouldBe` 255
+        it "clamps levels<2 to 2" $ do
+            let (r, _, _, _) = pixelAt (posterize (onePixel 200 200 200 255) 1) 0 0
+            r `shouldBe` 255
+
+    describe "swapRgbBgr" $ do
+        it "swaps R and B" $
+            pixelAt (swapRgbBgr (onePixel 10 20 30 40)) 0 0
+                `shouldBe` (30, 20, 10, 40)
+
+    describe "extractChannel" $ do
+        it "extracts red as greyscale" $
+            pixelAt (extractChannel (onePixel 100 50 25 255) 0) 0 0
+                `shouldBe` (100, 100, 100, 255)
+        it "extracts green" $
+            pixelAt (extractChannel (onePixel 100 50 25 255) 1) 0 0
+                `shouldBe` (50, 50, 50, 255)
+        it "extracts blue" $
+            pixelAt (extractChannel (onePixel 100 50 25 255) 2) 0 0
+                `shouldBe` (25, 25, 25, 255)
+        it "extracts alpha" $
+            pixelAt (extractChannel (onePixel 100 50 25 77) 3) 0 0
+                `shouldBe` (77, 77, 77, 255)
+
+    describe "brightness" $ do
+        it "adds positive delta and clamps" $
+            pixelAt (brightness (onePixel 200 200 200 255) 100) 0 0
+                `shouldBe` (255, 255, 255, 255)
+        it "subtracts and clamps to zero" $
+            pixelAt (brightness (onePixel 10 10 10 255) (-100)) 0 0
+                `shouldBe` (0, 0, 0, 255)
+        it "is identity at delta=0" $
+            pixelAt (brightness (onePixel 10 20 30 40) 0) 0 0
+                `shouldBe` (10, 20, 30, 40)
+
+    describe "contrast" $ do
+        it "is approximately identity at factor=0" $ do
+            let (r, _, _, _) = pixelAt (contrast (onePixel 128 128 128 255) 0) 0 0
+            near r 128 1 `shouldBe` True
+
+    describe "gamma" $ do
+        it "leaves black fixed" $
+            pixelAt (gamma (onePixel 0 0 0 255) 2.2) 0 0
+                `shouldBe` (0, 0, 0, 255)
+        it "leaves white fixed" $
+            pixelAt (gamma (onePixel 255 255 255 255) 2.2) 0 0
+                `shouldBe` (255, 255, 255, 255)
+
+    describe "exposure" $ do
+        it "doubles brightness at +1 stop" $ do
+            let (r, _, _, _) = pixelAt (exposure (onePixel 64 64 64 255) 1.0) 0 0
+            r > 64 `shouldBe` True
+        it "halves brightness at -1 stop" $ do
+            let (r, _, _, _) = pixelAt (exposure (onePixel 200 200 200 255) (-1.0)) 0 0
+            r < 200 `shouldBe` True
+
+    describe "greyscale" $ do
+        it "produces equal R=G=B" $ do
+            let (r, g, b, _) = pixelAt (greyscale (onePixel 200 100 50 255) Rec709) 0 0
+            r `shouldBe` g
+            g `shouldBe` b
+        it "average method treats channels equally" $ do
+            let (r1, _, _, _) = pixelAt (greyscale (onePixel 255 0 0 255) Average) 0 0
+                (r2, _, _, _) = pixelAt (greyscale (onePixel 0 255 0 255) Average) 0 0
+            r1 `shouldBe` r2
+
+    describe "sepia" $ do
+        it "tints white to a warm tone" $ do
+            let (r, g, b, _) = pixelAt (sepia (onePixel 255 255 255 255)) 0 0
+            r >= g `shouldBe` True
+            g >= b `shouldBe` True
+        it "leaves black black" $
+            pixelAt (sepia (onePixel 0 0 0 255)) 0 0
+                `shouldBe` (0, 0, 0, 255)
+
+    describe "colourMatrix" $ do
+        it "identity matrix is a round-trip" $ do
+            let m = [[1,0,0],[0,1,0],[0,0,1]]
+                (r, g, b, _) = pixelAt (colourMatrix (onePixel 100 150 200 255) m) 0 0
+            near r 100 1 `shouldBe` True
+            near g 150 1 `shouldBe` True
+            near b 200 1 `shouldBe` True
+
+    describe "saturate" $ do
+        it "factor=0 produces grey" $ do
+            let (r, g, b, _) = pixelAt (saturate (onePixel 200 50 25 255) 0) 0 0
+            r `shouldBe` g
+            g `shouldBe` b
+        it "factor=1 is approximately identity" $ do
+            let (r, _, _, _) = pixelAt (saturate (onePixel 200 50 25 255) 1) 0 0
+            near r 200 2 `shouldBe` True
+
+    describe "hueRotate" $ do
+        it "0 degrees is approximately identity" $ do
+            let (r, g, b, _) = pixelAt (hueRotate (onePixel 200 50 25 255) 0) 0 0
+            near r 200 2 `shouldBe` True
+            near g 50  2 `shouldBe` True
+            near b 25  2 `shouldBe` True
+        it "360 degrees is approximately identity" $ do
+            let (r, _, _, _) = pixelAt (hueRotate (onePixel 200 50 25 255) 360) 0 0
+            near r 200 2 `shouldBe` True
+        it "leaves greyscale unchanged" $ do
+            let (r, g, b, _) = pixelAt (hueRotate (onePixel 128 128 128 255) 90) 0 0
+            r `shouldBe` g
+            g `shouldBe` b
+
+    describe "srgbToLinearImage / linearToSrgbImage" $ do
+        it "round-trips approximately" $ do
+            let pc   = onePixel 128 200 50 255
+                pc'  = linearToSrgbImage (srgbToLinearImage pc)
+                (r, g, b, _) = pixelAt pc' 0 0
+            near r 128 3 `shouldBe` True
+            near g 200 3 `shouldBe` True
+            near b 50  3 `shouldBe` True
+
+    describe "applyLut1dU8" $ do
+        it "identity LUT is a no-op" $ do
+            let ident = [fromIntegral i :: Word8 | i <- [0..255 :: Int]]
+                (r, g, b, _) = pixelAt
+                    (applyLut1dU8 (onePixel 10 20 30 40) ident ident ident) 0 0
+            (r, g, b) `shouldBe` (10, 20, 30)
+        it "constant LUT overrides the channel" $ do
+            let zeroes = replicate 256 (0 :: Word8)
+                (r, _, _, _) = pixelAt
+                    (applyLut1dU8 (onePixel 200 200 200 255) zeroes zeroes zeroes) 0 0
+            r `shouldBe` 0
+
+    describe "buildLut1dU8" $ do
+        it "identity function yields identity LUT" $ do
+            let lut = buildLut1dU8 id
+            length lut `shouldBe` 256
+            -- Index 0 maps to 0; index 255 maps to 255.
+            head lut `shouldBe` 0
+            last lut `shouldBe` 255
+
+    describe "buildGammaLut" $ do
+        it "gamma=1 is approximately identity" $ do
+            let lut = buildGammaLut 1.0
+            length lut `shouldBe` 256
+            near (head lut) 0   1 `shouldBe` True
+            near (last lut) 255 1 `shouldBe` True

--- a/code/packages/haskell/image-point-ops/test/Spec.hs
+++ b/code/packages/haskell/image-point-ops/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import ImagePointOpsSpec (spec)
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/pixel-container/BUILD
+++ b/code/packages/haskell/pixel-container/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/pixel-container/BUILD_windows
+++ b/code/packages/haskell/pixel-container/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/pixel-container/CHANGELOG.md
+++ b/code/packages/haskell/pixel-container/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.1.0 — 2026-04-20
+
+- Initial release of IC00 `PixelContainer` for Haskell.
+- `PixelContainer` record with `pcWidth`, `pcHeight`, `pcPixels`.
+- `createPixelContainer`, `pixelAt`, `setPixel`, `fillPixels` primitives.
+- Abstract `ImageCodec` type class with `mimeType`, `encode`, `decode`.
+- Hspec test suite covering creation, bounds-checking, round-tripping,
+  fill, and zero-size edge cases.

--- a/code/packages/haskell/pixel-container/README.md
+++ b/code/packages/haskell/pixel-container/README.md
@@ -1,0 +1,53 @@
+# pixel-container (Haskell)
+
+IC00 — Universal RGBA8 pixel buffer for the coding-adventures image stack.
+
+## Overview
+
+`pixel-container` is the zero-dependency foundation every image codec and
+processing stage in the coding-adventures image pipeline depends on.  It
+provides a fixed-format RGBA8 buffer (4 channels, 8 bits each) stored row-major
+with the top-left origin, plus an abstract `ImageCodec` type class used by
+codec packages (PNG, BMP, PPM, …).
+
+By fixing the pixel format at the lowest layer we avoid a combinatorial
+explosion of format conversions higher up: point operations only need to
+reason about RGBA8, and geometric transforms only need to know how to sample
+and write back RGBA8 pixels.
+
+## Usage
+
+```haskell
+import PixelContainer
+
+main :: IO ()
+main = do
+    let pc  = createPixelContainer 4 4
+        pc' = setPixel pc 1 2 255 0 0 255
+    print (pixelAt pc' 1 2)  -- (255, 0, 0, 255)
+```
+
+## API
+
+- `data PixelContainer` — record with `pcWidth`, `pcHeight`, `pcPixels` (a
+  flat `ByteString` of `w * h * 4` bytes).
+- `createPixelContainer :: Int -> Int -> PixelContainer` — new, fully
+  transparent-black buffer.
+- `pixelAt :: PixelContainer -> Int -> Int -> (Word8, Word8, Word8, Word8)` —
+  read a pixel; out-of-bounds returns `(0,0,0,0)`.
+- `setPixel :: PixelContainer -> Int -> Int -> Word8 -> Word8 -> Word8 -> Word8
+   -> PixelContainer` — write a pixel; out-of-bounds is a no-op.
+- `fillPixels :: PixelContainer -> Word8 -> Word8 -> Word8 -> Word8
+   -> PixelContainer` — set every pixel to a colour.
+- `class ImageCodec` — `mimeType`, `encode`, `decode` contract for codec
+  packages.
+
+## Layout
+
+```
+offset = (y * width + x) * 4
+data[offset + 0] = R
+data[offset + 1] = G
+data[offset + 2] = B
+data[offset + 3] = A
+```

--- a/code/packages/haskell/pixel-container/pixel-container.cabal
+++ b/code/packages/haskell/pixel-container/pixel-container.cabal
@@ -1,0 +1,29 @@
+cabal-version: 3.0
+name:          pixel-container
+version:       0.1.0
+synopsis:      IC00: Universal RGBA8 pixel buffer
+description:   Zero-dependency foundation for the coding-adventures image
+               processing stack.  Provides a fixed-format RGBA8, row-major,
+               top-left-origin pixel buffer plus a minimal codec type class.
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  PixelContainer
+    build-depends:    base >=4.14
+                    , bytestring
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    PixelContainerSpec
+    build-depends:    base >=4.14
+                    , bytestring
+                    , pixel-container
+                    , hspec == 2.*
+    hs-source-dirs:   test
+    default-language: Haskell2010

--- a/code/packages/haskell/pixel-container/src/PixelContainer.hs
+++ b/code/packages/haskell/pixel-container/src/PixelContainer.hs
@@ -1,0 +1,117 @@
+-- | IC00 — Universal RGBA8 Pixel Buffer
+--
+-- 'PixelContainer' is the zero-dependency foundation for the
+-- coding-adventures image processing stack.  Every image codec and
+-- processing stage depends only on this module, which keeps the stack
+-- modular: codecs do not know about point operations, point operations
+-- do not know about codecs, and neither knows about the other.
+--
+-- == Layout
+--
+-- Pixels are stored row-major, top-left origin, RGBA interleaved:
+--
+-- @
+-- offset = (y * width + x) * 4
+-- data[offset + 0] = R
+-- data[offset + 1] = G
+-- data[offset + 2] = B
+-- data[offset + 3] = A
+-- @
+--
+-- Channel count and bit depth are fixed: 4 channels, 8 bits each (RGBA8).
+-- This is the same layout used by web canvases, most GPU textures, and
+-- the Paint-VM internal framebuffer.  By fixing the layout at the lowest
+-- layer we avoid a combinatorial explosion of pixel-format conversions
+-- further up the stack.
+module PixelContainer
+    ( PixelContainer(..)
+    , ImageCodec(..)
+    , createPixelContainer
+    , pixelAt
+    , setPixel
+    , fillPixels
+    ) where
+
+import qualified Data.ByteString as BS
+import Data.Word (Word8)
+
+-- | A fixed-format RGBA8 pixel buffer.
+--
+-- 'pcPixels' is a flat 'BS.ByteString' of @width × height × 4@ bytes.
+-- We use a strict 'BS.ByteString' rather than a list of tuples because
+-- the underlying memory is a single contiguous chunk: random access is
+-- O(1), memory footprint is predictable, and we can hand the buffer
+-- straight to a codec or the GPU without a conversion pass.
+data PixelContainer = PixelContainer
+    { pcWidth  :: !Int           -- ^ Image width in pixels.
+    , pcHeight :: !Int           -- ^ Image height in pixels.
+    , pcPixels :: !BS.ByteString -- ^ Raw RGBA bytes, row-major.
+    } deriving (Show, Eq)
+
+-- | Abstract codec interface.  Concrete codecs (PNG, BMP, PPM, …) live
+-- in their own packages and implement this class.  Keeping the type
+-- class in this module means there is a single, canonical contract:
+-- if you hold any @a@ with 'ImageCodec' you can encode or decode.
+class ImageCodec a where
+    -- | The IANA MIME type, e.g. @"image\/png"@.
+    mimeType :: a -> String
+    -- | Encode a 'PixelContainer' into raw codec bytes (file contents).
+    encode   :: a -> PixelContainer -> BS.ByteString
+    -- | Decode raw codec bytes back into a 'PixelContainer'.
+    decode   :: a -> BS.ByteString  -> PixelContainer
+
+-- | Create a new 'PixelContainer' filled with transparent black (all
+-- zeros).  This is the canonical empty canvas used by higher layers.
+--
+-- A zero-sized container (@0×0@, @0×h@, @w×0@) is legal and stores an
+-- empty 'BS.ByteString'.  This keeps edge cases (e.g. cropping to an
+-- empty region) uniform.
+createPixelContainer :: Int -> Int -> PixelContainer
+createPixelContainer w h =
+    PixelContainer w h (BS.replicate (w * h * 4) 0)
+
+-- | Read the RGBA components at pixel column @x@, row @y@.
+--
+-- Out-of-bounds coordinates return @(0, 0, 0, 0)@ — i.e. transparent
+-- black.  This sentinel is used by geometric transforms as a cheap OOB
+-- fallback; callers who need a different behaviour (clamp, reflect,
+-- wrap) should resolve coordinates themselves before calling.
+pixelAt :: PixelContainer -> Int -> Int -> (Word8, Word8, Word8, Word8)
+pixelAt (PixelContainer w h pixels) x y
+    | x < 0 || x >= w || y < 0 || y >= h = (0, 0, 0, 0)
+    | otherwise =
+        let i = (y * w + x) * 4
+        in ( BS.index pixels  i
+           , BS.index pixels (i + 1)
+           , BS.index pixels (i + 2)
+           , BS.index pixels (i + 3)
+           )
+
+-- | Write the RGBA components at pixel column @x@, row @y@.
+--
+-- No-op for out-of-bounds coordinates.  Returns a new 'PixelContainer'
+-- (the old one is unmodified) because 'BS.ByteString' is immutable.
+-- This is O(n) in the buffer size; callers doing bulk work should use
+-- 'mapPixels'-style helpers in higher-level packages, which build the
+-- new buffer once.
+setPixel :: PixelContainer
+         -> Int  -- ^ Column (x).
+         -> Int  -- ^ Row (y).
+         -> Word8 -> Word8 -> Word8 -> Word8
+         -> PixelContainer
+setPixel pc@(PixelContainer w h pixels) x y r g b a
+    | x < 0 || x >= w || y < 0 || y >= h = pc
+    | otherwise =
+        let i      = (y * w + x) * 4
+            before = BS.take i pixels
+            after  = BS.drop (i + 4) pixels
+        in PixelContainer w h (before <> BS.pack [r, g, b, a] <> after)
+
+-- | Set every pixel in the container to the given RGBA colour.  This
+-- is the standard "clear the canvas" primitive; we build the new
+-- 'BS.ByteString' by packing the 4-byte colour once and concatenating
+-- @w × h@ copies of it, which avoids re-encoding per pixel.
+fillPixels :: PixelContainer -> Word8 -> Word8 -> Word8 -> Word8 -> PixelContainer
+fillPixels (PixelContainer w h _) r g b a =
+    let pixel = BS.pack [r, g, b, a]
+    in PixelContainer w h (BS.concat (replicate (w * h) pixel))

--- a/code/packages/haskell/pixel-container/test/PixelContainerSpec.hs
+++ b/code/packages/haskell/pixel-container/test/PixelContainerSpec.hs
@@ -1,0 +1,105 @@
+module PixelContainerSpec (spec) where
+
+import Test.Hspec
+import PixelContainer
+import qualified Data.ByteString as BS
+
+spec :: Spec
+spec = do
+    describe "createPixelContainer" $ do
+        it "stores the requested width" $
+            pcWidth (createPixelContainer 4 3) `shouldBe` 4
+        it "stores the requested height" $
+            pcHeight (createPixelContainer 4 3) `shouldBe` 3
+        it "allocates width * height * 4 bytes" $
+            BS.length (pcPixels (createPixelContainer 4 3)) `shouldBe` 48
+        it "initialises every byte to zero" $
+            BS.all (== 0) (pcPixels (createPixelContainer 4 3)) `shouldBe` True
+        it "handles a 1x1 container" $ do
+            let pc = createPixelContainer 1 1
+            pcWidth pc `shouldBe` 1
+            pcHeight pc `shouldBe` 1
+            BS.length (pcPixels pc) `shouldBe` 4
+        it "handles a 0x0 container" $ do
+            let pc = createPixelContainer 0 0
+            pcWidth pc `shouldBe` 0
+            pcHeight pc `shouldBe` 0
+            BS.length (pcPixels pc) `shouldBe` 0
+        it "handles a 0 x h container" $
+            BS.length (pcPixels (createPixelContainer 0 5)) `shouldBe` 0
+        it "handles a w x 0 container" $
+            BS.length (pcPixels (createPixelContainer 5 0)) `shouldBe` 0
+
+    describe "pixelAt" $ do
+        it "returns (0,0,0,0) for a freshly created pixel" $
+            pixelAt (createPixelContainer 2 2) 0 0 `shouldBe` (0, 0, 0, 0)
+        it "returns (0,0,0,0) for negative x" $
+            pixelAt (createPixelContainer 2 2) (-1) 0 `shouldBe` (0, 0, 0, 0)
+        it "returns (0,0,0,0) for negative y" $
+            pixelAt (createPixelContainer 2 2) 0 (-1) `shouldBe` (0, 0, 0, 0)
+        it "returns (0,0,0,0) for x past right edge" $
+            pixelAt (createPixelContainer 2 2) 2 0 `shouldBe` (0, 0, 0, 0)
+        it "returns (0,0,0,0) for y past bottom edge" $
+            pixelAt (createPixelContainer 2 2) 0 2 `shouldBe` (0, 0, 0, 0)
+
+    describe "setPixel" $ do
+        it "round-trips via pixelAt" $ do
+            let pc  = createPixelContainer 3 3
+                pc' = setPixel pc 1 1 10 20 30 40
+            pixelAt pc' 1 1 `shouldBe` (10, 20, 30, 40)
+        it "does not disturb neighbouring pixels" $ do
+            let pc  = createPixelContainer 3 3
+                pc' = setPixel pc 1 1 10 20 30 40
+            pixelAt pc' 0 1 `shouldBe` (0, 0, 0, 0)
+            pixelAt pc' 2 1 `shouldBe` (0, 0, 0, 0)
+            pixelAt pc' 1 0 `shouldBe` (0, 0, 0, 0)
+            pixelAt pc' 1 2 `shouldBe` (0, 0, 0, 0)
+        it "is a no-op for negative x" $ do
+            let pc  = createPixelContainer 2 2
+                pc' = setPixel pc (-1) 0 1 2 3 4
+            pcPixels pc' `shouldBe` pcPixels pc
+        it "is a no-op for negative y" $ do
+            let pc  = createPixelContainer 2 2
+                pc' = setPixel pc 0 (-1) 1 2 3 4
+            pcPixels pc' `shouldBe` pcPixels pc
+        it "is a no-op for x past right edge" $ do
+            let pc  = createPixelContainer 2 2
+                pc' = setPixel pc 2 0 1 2 3 4
+            pcPixels pc' `shouldBe` pcPixels pc
+        it "is a no-op for y past bottom edge" $ do
+            let pc  = createPixelContainer 2 2
+                pc' = setPixel pc 0 2 1 2 3 4
+            pcPixels pc' `shouldBe` pcPixels pc
+        it "supports multiple round-trip writes" $ do
+            let pc0 = createPixelContainer 3 2
+                pc1 = setPixel pc0 0 0 11 12 13 14
+                pc2 = setPixel pc1 2 1 21 22 23 24
+            pixelAt pc2 0 0 `shouldBe` (11, 12, 13, 14)
+            pixelAt pc2 2 1 `shouldBe` (21, 22, 23, 24)
+            pixelAt pc2 1 0 `shouldBe` (0, 0, 0, 0)
+        it "overwrites an existing pixel" $ do
+            let pc0 = createPixelContainer 2 2
+                pc1 = setPixel pc0 1 1 10 20 30 40
+                pc2 = setPixel pc1 1 1 99 99 99 99
+            pixelAt pc2 1 1 `shouldBe` (99, 99, 99, 99)
+
+    describe "fillPixels" $ do
+        it "sets every pixel to the given colour" $ do
+            let pc  = createPixelContainer 3 2
+                pc' = fillPixels pc 7 8 9 10
+            mapM_ (\(x, y) -> pixelAt pc' x y `shouldBe` (7, 8, 9, 10))
+                  [(x, y) | y <- [0..1], x <- [0..2]]
+        it "preserves container dimensions" $ do
+            let pc' = fillPixels (createPixelContainer 4 5) 1 2 3 4
+            pcWidth  pc' `shouldBe` 4
+            pcHeight pc' `shouldBe` 5
+        it "emits width*height*4 bytes" $
+            BS.length (pcPixels (fillPixels (createPixelContainer 4 5) 1 2 3 4))
+                `shouldBe` 80
+        it "is idempotent when applied twice with the same colour" $ do
+            let pc1 = fillPixels (createPixelContainer 3 3) 1 2 3 4
+                pc2 = fillPixels pc1 1 2 3 4
+            pcPixels pc1 `shouldBe` pcPixels pc2
+        it "handles fill on a 0x0 container" $
+            pcPixels (fillPixels (createPixelContainer 0 0) 1 2 3 4)
+                `shouldBe` BS.empty

--- a/code/packages/haskell/pixel-container/test/Spec.hs
+++ b/code/packages/haskell/pixel-container/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec
+import PixelContainerSpec (spec)
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/java/image-geometric-transforms/.gitignore
+++ b/code/packages/java/image-geometric-transforms/.gitignore
@@ -1,0 +1,2 @@
+gradle-build/
+.gradle/

--- a/code/packages/java/image-geometric-transforms/BUILD
+++ b/code/packages/java/image-geometric-transforms/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/image-geometric-transforms/BUILD_windows
+++ b/code/packages/java/image-geometric-transforms/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/image-geometric-transforms/CHANGELOG.md
+++ b/code/packages/java/image-geometric-transforms/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## 0.1.0
+
+- Add initial Java `image-geometric-transforms` package (IMG04)
+- Lossless: `flipHorizontal`, `flipVertical`, `rotate90CW`, `rotate90CCW`,
+  `rotate180`, `crop`
+- Continuous: `scale`, `rotate` (FIT/CROP), `translate`, `affine`,
+  `perspectiveWarp`
+- Three interpolation modes (NEAREST, BILINEAR, BICUBIC Catmull-Rom)
+- Four out-of-bounds modes (ZERO, REPLICATE, REFLECT, WRAP)
+- Linear-light colour blending; u8 alpha blending

--- a/code/packages/java/image-geometric-transforms/README.md
+++ b/code/packages/java/image-geometric-transforms/README.md
@@ -1,0 +1,40 @@
+# Java Image Geometric Transforms
+
+IMG04 — geometric transforms on `PixelContainer`. Where IMG03 (point ops)
+changes a pixel's *value*, IMG04 changes a pixel's *position*. All
+spatial operations live here: flips, 90° rotations, crop, scale, free
+rotation, affine warp, and perspective warp.
+
+## Axes of variation
+
+1. **Lossless vs continuous**. Flips, 90° rotations, and crop are pure
+   byte reshuffles and need no sampling. Scale, rotate, translate,
+   affine, and perspective warp all need to sample at fractional
+   coordinates.
+2. **Interpolation**. `NEAREST`, `BILINEAR`, `BICUBIC` (Catmull-Rom). All
+   colour blending happens in linear light; alpha blends in u8.
+3. **Out-of-bounds**. `ZERO` (transparent black), `REPLICATE` (clamp),
+   `REFLECT` (mirror), `WRAP` (tile).
+
+## Warp model
+
+All continuous ops use *inverse* warps: for each output pixel, compute
+the source coordinate and sample. That avoids output holes you'd get
+from a forward warp, at the cost of an extra matrix inversion where
+matrices are involved.
+
+## Usage
+
+```java
+import com.codingadventures.imagegeometrictransforms.*;
+
+PixelContainer flipped = ImageGeometricTransforms.flipHorizontal(src);
+PixelContainer halved  = ImageGeometricTransforms.scale(
+    src, src.width/2, src.height/2, Interpolation.BILINEAR, OutOfBounds.REPLICATE);
+PixelContainer rotated = ImageGeometricTransforms.rotate(
+    src, 30, RotateBounds.FIT, Interpolation.BICUBIC, OutOfBounds.ZERO);
+```
+
+## Depends on
+
+- `pixel-container` (IC00).

--- a/code/packages/java/image-geometric-transforms/build.gradle.kts
+++ b/code/packages/java/image-geometric-transforms/build.gradle.kts
@@ -1,0 +1,29 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    api("com.codingadventures:pixel-container")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/image-geometric-transforms/settings.gradle.kts
+++ b/code/packages/java/image-geometric-transforms/settings.gradle.kts
@@ -1,0 +1,3 @@
+rootProject.name = "image-geometric-transforms"
+
+includeBuild("../pixel-container")

--- a/code/packages/java/image-geometric-transforms/src/main/java/com/codingadventures/imagegeometrictransforms/ImageGeometricTransforms.java
+++ b/code/packages/java/image-geometric-transforms/src/main/java/com/codingadventures/imagegeometrictransforms/ImageGeometricTransforms.java
@@ -1,0 +1,427 @@
+package com.codingadventures.imagegeometrictransforms;
+
+import com.codingadventures.pixelcontainer.PixelContainer;
+import com.codingadventures.pixelcontainer.PixelOps;
+
+/**
+ * IMG04 — Geometric Transforms on {@link PixelContainer}.
+ *
+ * <p>Where IMG03 (point ops) changes a pixel's <em>value</em>, IMG04
+ * changes a pixel's <em>position</em>. All spatial operations live here:
+ * flips, 90° rotations, crop, scale, free rotation, affine warp, and
+ * perspective warp.</p>
+ *
+ * <h2>Lossless vs continuous</h2>
+ * <p>Flips, 90° rotations, and crop are pure byte reshuffles — no
+ * sampling, no interpolation, no colour-space work. The continuous
+ * transforms ({@link #scale}, {@link #rotate}, {@link #translate},
+ * {@link #affine}, {@link #perspectiveWarp}) all need to sample at
+ * fractional source coordinates, so they pick up an interpolation mode
+ * and an out-of-bounds policy.</p>
+ *
+ * <h2>Inverse warps</h2>
+ * <p>Every continuous op walks the <em>output</em> pixels and computes
+ * the corresponding source coordinate, then samples. The alternative —
+ * forward warping — leaves holes and doubled pixels in the output. The
+ * price is that matrix-based transforms must invert their matrix once.</p>
+ *
+ * <h2>Linear light</h2>
+ * <p>Bilinear and bicubic blending is done in linear light for colour
+ * channels (decoded from sRGB via a 256-entry LUT). Alpha blends in u8
+ * because it carries no perceptual gamma.</p>
+ */
+public final class ImageGeometricTransforms {
+    private ImageGeometricTransforms() {}
+
+    /* ------------------------------------------------------------------ */
+    /* sRGB ↔ linear plumbing (duplicated from image-point-ops so this    */
+    /* package has no cross-IMG dependency).                              */
+    /* ------------------------------------------------------------------ */
+
+    private static final double[] SRGB_TO_LINEAR = new double[256];
+    static {
+        for (int i = 0; i < 256; i++) {
+            double c = i / 255.0;
+            SRGB_TO_LINEAR[i] = (c <= 0.04045) ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+        }
+    }
+
+    private static double decode(int b) {
+        return SRGB_TO_LINEAR[b & 0xFF];
+    }
+
+    private static int encode(double linear) {
+        double c = Math.max(0.0, Math.min(1.0, linear));
+        double s = (c <= 0.0031308) ? c * 12.92 : 1.055 * Math.pow(c, 1.0 / 2.4) - 0.055;
+        return (int) Math.round(s * 255);
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Out-of-bounds coordinate resolution.                               */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * Map an arbitrary integer coordinate to a valid index in [0, maxVal)
+     * according to the chosen policy. Returns {@code -1} when the
+     * caller should treat the sample as transparent black (the {@code ZERO}
+     * policy).
+     */
+    private static int resolveCoord(int x, int maxVal, OutOfBounds oob) {
+        if (x >= 0 && x < maxVal) return x;
+        switch (oob) {
+            case ZERO: return -1;
+            case REPLICATE: return Math.max(0, Math.min(maxVal - 1, x));
+            case REFLECT: {
+                // period = 2*maxVal; within one period the first half is
+                // forward, the second half mirrored.
+                int period = 2 * maxVal;
+                int xm = x % period;
+                if (xm < 0) xm += period;
+                return (xm >= maxVal) ? period - xm - 1 : xm;
+            }
+            case WRAP: {
+                int xm = x % maxVal;
+                if (xm < 0) xm += maxVal;
+                return xm;
+            }
+            default: return -1;
+        }
+    }
+
+    /** Fetch a pixel with OOB policy applied; returns {0,0,0,0} when ZERO. */
+    private static int[] getPixelOob(PixelContainer src, int x, int y, OutOfBounds oob) {
+        int xi = resolveCoord(x, src.width, oob);
+        int yi = resolveCoord(y, src.height, oob);
+        if (xi < 0 || yi < 0) return new int[]{0, 0, 0, 0};
+        return PixelOps.pixelAt(src, xi, yi);
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Sampling.                                                          */
+    /* ------------------------------------------------------------------ */
+
+    private static int[] samplePixel(PixelContainer src, double u, double v,
+                                     Interpolation interp, OutOfBounds oob) {
+        switch (interp) {
+            case NEAREST:  return sampleNearest(src, u, v, oob);
+            case BILINEAR: return sampleBilinear(src, u, v, oob);
+            case BICUBIC:  return sampleBicubic(src, u, v, oob);
+            default:       return new int[]{0, 0, 0, 0};
+        }
+    }
+
+    private static int[] sampleNearest(PixelContainer src, double u, double v, OutOfBounds oob) {
+        int xi = resolveCoord((int) Math.round(u), src.width, oob);
+        int yi = resolveCoord((int) Math.round(v), src.height, oob);
+        if (xi < 0 || yi < 0) return new int[]{0, 0, 0, 0};
+        return PixelOps.pixelAt(src, xi, yi);
+    }
+
+    /**
+     * Bilinear sample. Colour channels are decoded to linear light before
+     * blending to avoid the classic "muddy midtones" of blending in sRGB.
+     * Alpha blends linearly in [0, 255] because it has no perceptual gamma.
+     */
+    private static int[] sampleBilinear(PixelContainer src, double u, double v, OutOfBounds oob) {
+        int x0 = (int) Math.floor(u), x1 = x0 + 1;
+        int y0 = (int) Math.floor(v), y1 = y0 + 1;
+        double fx = u - x0, fy = v - y0;
+        int[] p00 = getPixelOob(src, x0, y0, oob);
+        int[] p10 = getPixelOob(src, x1, y0, oob);
+        int[] p01 = getPixelOob(src, x0, y1, oob);
+        int[] p11 = getPixelOob(src, x1, y1, oob);
+        int[] result = new int[4];
+        for (int c = 0; c < 3; c++) {
+            double v00 = decode(p00[c]), v10 = decode(p10[c]);
+            double v01 = decode(p01[c]), v11 = decode(p11[c]);
+            double top = v00 + fx * (v10 - v00);
+            double bot = v01 + fx * (v11 - v01);
+            result[c] = encode(top + fy * (bot - top));
+        }
+        double a00 = p00[3], a10 = p10[3], a01 = p01[3], a11 = p11[3];
+        double atop = a00 + fx * (a10 - a00);
+        double abot = a01 + fx * (a11 - a01);
+        int a = (int) Math.round(atop + fy * (abot - atop));
+        if (a < 0) a = 0;
+        if (a > 255) a = 255;
+        result[3] = a;
+        return result;
+    }
+
+    /**
+     * Catmull-Rom cubic kernel. Passes through sample points with
+     * continuous first derivative, giving sharper results than bilinear
+     * without the severity of a sinc.
+     */
+    private static double catmullRom(double d) {
+        d = Math.abs(d);
+        if (d < 1.0) return 1.5 * d * d * d - 2.5 * d * d + 1.0;
+        if (d < 2.0) return -0.5 * d * d * d + 2.5 * d * d - 4.0 * d + 2.0;
+        return 0.0;
+    }
+
+    /**
+     * Bicubic sample over a 4×4 neighbourhood with separable Catmull-Rom
+     * weights. Again, colour channels are blended in linear light.
+     */
+    private static int[] sampleBicubic(PixelContainer src, double u, double v, OutOfBounds oob) {
+        int x0 = (int) Math.floor(u);
+        int y0 = (int) Math.floor(v);
+        double fx = u - x0, fy = v - y0;
+        double[] wx = new double[4];
+        double[] wy = new double[4];
+        for (int k = 0; k < 4; k++) {
+            wx[k] = catmullRom(fx - (k - 1));
+            wy[k] = catmullRom(fy - (k - 1));
+        }
+        double[] acc = new double[4];
+        for (int ky = 0; ky < 4; ky++) {
+            for (int kx = 0; kx < 4; kx++) {
+                int[] pxv = getPixelOob(src, x0 - 1 + kx, y0 - 1 + ky, oob);
+                double w = wx[kx] * wy[ky];
+                for (int c = 0; c < 3; c++) acc[c] += decode(pxv[c]) * w;
+                acc[3] += pxv[3] * w;
+            }
+        }
+        int a = (int) Math.round(acc[3]);
+        if (a < 0) a = 0;
+        if (a > 255) a = 255;
+        return new int[]{encode(acc[0]), encode(acc[1]), encode(acc[2]), a};
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Lossless transforms — pure index shuffles, no sampling.            */
+    /* ------------------------------------------------------------------ */
+
+    /** Horizontal mirror: output column x reads source column width-1-x. */
+    public static PixelContainer flipHorizontal(PixelContainer src) {
+        PixelContainer out = new PixelContainer(src.width, src.height);
+        for (int y = 0; y < src.height; y++) {
+            for (int x = 0; x < src.width; x++) {
+                int[] p = PixelOps.pixelAt(src, src.width - 1 - x, y);
+                PixelOps.setPixel(out, x, y, p[0], p[1], p[2], p[3]);
+            }
+        }
+        return out;
+    }
+
+    /** Vertical mirror: output row y reads source row height-1-y. */
+    public static PixelContainer flipVertical(PixelContainer src) {
+        PixelContainer out = new PixelContainer(src.width, src.height);
+        for (int y = 0; y < src.height; y++) {
+            for (int x = 0; x < src.width; x++) {
+                int[] p = PixelOps.pixelAt(src, x, src.height - 1 - y);
+                PixelOps.setPixel(out, x, y, p[0], p[1], p[2], p[3]);
+            }
+        }
+        return out;
+    }
+
+    /**
+     * Rotate 90° clockwise. Output dimensions swap: outW=src.height,
+     * outH=src.width. The inverse index is
+     * {@code srcX = y', srcY = src.height - 1 - x'}.
+     */
+    public static PixelContainer rotate90CW(PixelContainer src) {
+        PixelContainer out = new PixelContainer(src.height, src.width);
+        for (int y = 0; y < out.height; y++) {
+            for (int x = 0; x < out.width; x++) {
+                int[] p = PixelOps.pixelAt(src, y, src.height - 1 - x);
+                PixelOps.setPixel(out, x, y, p[0], p[1], p[2], p[3]);
+            }
+        }
+        return out;
+    }
+
+    /** Rotate 90° counter-clockwise. Inverse: srcX = src.width-1-y', srcY = x'. */
+    public static PixelContainer rotate90CCW(PixelContainer src) {
+        PixelContainer out = new PixelContainer(src.height, src.width);
+        for (int y = 0; y < out.height; y++) {
+            for (int x = 0; x < out.width; x++) {
+                int[] p = PixelOps.pixelAt(src, src.width - 1 - y, x);
+                PixelOps.setPixel(out, x, y, p[0], p[1], p[2], p[3]);
+            }
+        }
+        return out;
+    }
+
+    /** Rotate 180°: (x', y') reads (w-1-x', h-1-y'). Dimensions unchanged. */
+    public static PixelContainer rotate180(PixelContainer src) {
+        PixelContainer out = new PixelContainer(src.width, src.height);
+        for (int y = 0; y < src.height; y++) {
+            for (int x = 0; x < src.width; x++) {
+                int[] p = PixelOps.pixelAt(src, src.width - 1 - x, src.height - 1 - y);
+                PixelOps.setPixel(out, x, y, p[0], p[1], p[2], p[3]);
+            }
+        }
+        return out;
+    }
+
+    /**
+     * Crop a rectangle starting at {@code (x0, y0)} with size {@code (w, h)}.
+     * Coordinates outside the source become transparent black.
+     */
+    public static PixelContainer crop(PixelContainer src, int x0, int y0, int w, int h) {
+        PixelContainer out = new PixelContainer(w, h);
+        for (int y = 0; y < h; y++) {
+            for (int x = 0; x < w; x++) {
+                int sx = x0 + x, sy = y0 + y;
+                if (sx >= 0 && sx < src.width && sy >= 0 && sy < src.height) {
+                    int[] p = PixelOps.pixelAt(src, sx, sy);
+                    PixelOps.setPixel(out, x, y, p[0], p[1], p[2], p[3]);
+                }
+            }
+        }
+        return out;
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Continuous transforms.                                             */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * Scale to {@code outW × outH} using the pixel-centre model — the
+     * centre of output pixel (x, y) maps to source coordinate
+     * {@code ((x+0.5)/sx - 0.5, (y+0.5)/sy - 0.5)}. The {@code -0.5} shift
+     * is what avoids the classic "half-pixel offset" artifact.
+     */
+    public static PixelContainer scale(PixelContainer src, int outW, int outH,
+                                       Interpolation interp, OutOfBounds oob) {
+        PixelContainer out = new PixelContainer(outW, outH);
+        double sx = (double) outW / src.width;
+        double sy = (double) outH / src.height;
+        for (int y = 0; y < outH; y++) {
+            for (int x = 0; x < outW; x++) {
+                double u = (x + 0.5) / sx - 0.5;
+                double v = (y + 0.5) / sy - 0.5;
+                int[] p = samplePixel(src, u, v, interp, oob);
+                PixelOps.setPixel(out, x, y, p[0], p[1], p[2], p[3]);
+            }
+        }
+        return out;
+    }
+
+    /**
+     * Rotate by {@code degrees} (counter-clockwise).
+     *
+     * <p>With {@link RotateBounds#FIT} the output canvas is sized to
+     * enclose the rotated rectangle; with {@link RotateBounds#CROP} the
+     * dimensions are preserved and corners are clipped.</p>
+     *
+     * <p>The rotation is implemented as an inverse warp: for each output
+     * pixel we apply the opposite rotation (CW by the same angle) to map
+     * back into source coordinates.</p>
+     */
+    public static PixelContainer rotate(PixelContainer src, double degrees,
+                                        RotateBounds bounds,
+                                        Interpolation interp, OutOfBounds oob) {
+        double rad = Math.toRadians(degrees);
+        double cosT = Math.cos(rad), sinT = Math.sin(rad);
+        int inW = src.width, inH = src.height;
+        int outW, outH;
+        if (bounds == RotateBounds.FIT) {
+            outW = (int) Math.ceil(Math.abs(inW * cosT) + Math.abs(inH * sinT));
+            outH = (int) Math.ceil(Math.abs(inH * cosT) + Math.abs(inW * sinT));
+        } else {
+            outW = inW; outH = inH;
+        }
+        double cxIn = inW / 2.0, cyIn = inH / 2.0;
+        double cxOut = outW / 2.0, cyOut = outH / 2.0;
+        PixelContainer out = new PixelContainer(outW, outH);
+        for (int y = 0; y < outH; y++) {
+            for (int x = 0; x < outW; x++) {
+                double dx = x - cxOut, dy = y - cyOut;
+                // Inverse rotation: CW by the same angle.
+                double u =  cosT * dx + sinT * dy + cxIn;
+                double v = -sinT * dx + cosT * dy + cyIn;
+                int[] p = samplePixel(src, u, v, interp, oob);
+                PixelOps.setPixel(out, x, y, p[0], p[1], p[2], p[3]);
+            }
+        }
+        return out;
+    }
+
+    /**
+     * Translate the image by {@code (tx, ty)}. Dimensions are preserved;
+     * uncovered output pixels follow the OOB policy.
+     */
+    public static PixelContainer translate(PixelContainer src, double tx, double ty,
+                                           Interpolation interp, OutOfBounds oob) {
+        PixelContainer out = new PixelContainer(src.width, src.height);
+        for (int y = 0; y < src.height; y++) {
+            for (int x = 0; x < src.width; x++) {
+                double u = x - tx, v = y - ty;
+                int[] p = samplePixel(src, u, v, interp, oob);
+                PixelOps.setPixel(out, x, y, p[0], p[1], p[2], p[3]);
+            }
+        }
+        return out;
+    }
+
+    /**
+     * Affine warp with a forward 2×3 matrix
+     * <pre>
+     *   [ m[0][0] m[0][1] m[0][2] ]   [ a b c ]
+     *   [ m[1][0] m[1][1] m[1][2] ] = [ d e f ]
+     * </pre>
+     * The implementation inverts the 2×2 part and uses an inverse warp.
+     */
+    public static PixelContainer affine(PixelContainer src, double[][] m,
+                                        Interpolation interp, OutOfBounds oob) {
+        double a = m[0][0], b = m[0][1], c = m[0][2];
+        double d = m[1][0], e = m[1][1], f = m[1][2];
+        double det = a * e - b * d;
+        double ia =  e / det, ib = -b / det;
+        double ic = -d / det, id =  a / det;
+        int outW = src.width, outH = src.height;
+        PixelContainer out = new PixelContainer(outW, outH);
+        for (int y = 0; y < outH; y++) {
+            for (int x = 0; x < outW; x++) {
+                double dx = x - c, dy = y - f;
+                double u = ia * dx + ib * dy;
+                double v = ic * dx + id * dy;
+                int[] p = samplePixel(src, u, v, interp, oob);
+                PixelOps.setPixel(out, x, y, p[0], p[1], p[2], p[3]);
+            }
+        }
+        return out;
+    }
+
+    /**
+     * Perspective warp with a 3×3 forward homography matrix. Each output
+     * pixel is unprojected through the matrix inverse, then sampled.
+     */
+    public static PixelContainer perspectiveWarp(PixelContainer src, double[][] m,
+                                                 Interpolation interp, OutOfBounds oob) {
+        double[][] inv = invert3x3(m);
+        int outW = src.width, outH = src.height;
+        PixelContainer out = new PixelContainer(outW, outH);
+        for (int y = 0; y < outH; y++) {
+            for (int x = 0; x < outW; x++) {
+                double uh = inv[0][0] * x + inv[0][1] * y + inv[0][2];
+                double vh = inv[1][0] * x + inv[1][1] * y + inv[1][2];
+                double wh = inv[2][0] * x + inv[2][1] * y + inv[2][2];
+                if (Math.abs(wh) < 1e-10) {
+                    PixelOps.setPixel(out, x, y, 0, 0, 0, 0);
+                    continue;
+                }
+                int[] p = samplePixel(src, uh / wh, vh / wh, interp, oob);
+                PixelOps.setPixel(out, x, y, p[0], p[1], p[2], p[3]);
+            }
+        }
+        return out;
+    }
+
+    /** Straightforward cofactor-based 3×3 inverse. */
+    private static double[][] invert3x3(double[][] m) {
+        double a = m[0][0], b = m[0][1], c = m[0][2];
+        double d = m[1][0], e = m[1][1], f = m[1][2];
+        double g = m[2][0], h = m[2][1], ii = m[2][2];
+        double det = a * (e * ii - f * h) - b * (d * ii - f * g) + c * (d * h - e * g);
+        return new double[][]{
+            { (e * ii - f * h) / det, -(b * ii - c * h) / det,  (b * f - c * e) / det },
+            {-(d * ii - f * g) / det,  (a * ii - c * g) / det, -(a * f - c * d) / det },
+            { (d * h  - e * g) / det, -(a * h  - b * g) / det,  (a * e - b * d) / det }
+        };
+    }
+}

--- a/code/packages/java/image-geometric-transforms/src/main/java/com/codingadventures/imagegeometrictransforms/ImageGeometricTransforms.java
+++ b/code/packages/java/image-geometric-transforms/src/main/java/com/codingadventures/imagegeometrictransforms/ImageGeometricTransforms.java
@@ -325,6 +325,8 @@ public final class ImageGeometricTransforms {
         } else {
             outW = inW; outH = inH;
         }
+        if ((long) outW * outH > Integer.MAX_VALUE / 4)
+            throw new IllegalArgumentException("Rotated canvas too large: " + outW + "×" + outH);
         double cxIn = inW / 2.0, cyIn = inH / 2.0;
         double cxOut = outW / 2.0, cyOut = outH / 2.0;
         PixelContainer out = new PixelContainer(outW, outH);

--- a/code/packages/java/image-geometric-transforms/src/main/java/com/codingadventures/imagegeometrictransforms/Interpolation.java
+++ b/code/packages/java/image-geometric-transforms/src/main/java/com/codingadventures/imagegeometrictransforms/Interpolation.java
@@ -1,0 +1,16 @@
+package com.codingadventures.imagegeometrictransforms;
+
+/**
+ * Interpolation strategy used when sampling at fractional coordinates.
+ *
+ * <ul>
+ *   <li>{@link #NEAREST} — pick the closest pixel. Fast, blocky.</li>
+ *   <li>{@link #BILINEAR} — linear blend of the four enclosing pixels.
+ *       Smooth but slightly blurry.</li>
+ *   <li>{@link #BICUBIC} — Catmull-Rom cubic over a 4×4 neighbourhood.
+ *       Sharper than bilinear, can introduce ringing on hard edges.</li>
+ * </ul>
+ */
+public enum Interpolation {
+    NEAREST, BILINEAR, BICUBIC
+}

--- a/code/packages/java/image-geometric-transforms/src/main/java/com/codingadventures/imagegeometrictransforms/OutOfBounds.java
+++ b/code/packages/java/image-geometric-transforms/src/main/java/com/codingadventures/imagegeometrictransforms/OutOfBounds.java
@@ -1,0 +1,15 @@
+package com.codingadventures.imagegeometrictransforms;
+
+/**
+ * Policy for samples that fall outside the source image.
+ *
+ * <ul>
+ *   <li>{@link #ZERO} — return transparent black.</li>
+ *   <li>{@link #REPLICATE} — clamp to the nearest edge pixel.</li>
+ *   <li>{@link #REFLECT} — mirror as if the edges were hinges.</li>
+ *   <li>{@link #WRAP} — tile the image; wraps around at each boundary.</li>
+ * </ul>
+ */
+public enum OutOfBounds {
+    ZERO, REPLICATE, REFLECT, WRAP
+}

--- a/code/packages/java/image-geometric-transforms/src/main/java/com/codingadventures/imagegeometrictransforms/RotateBounds.java
+++ b/code/packages/java/image-geometric-transforms/src/main/java/com/codingadventures/imagegeometrictransforms/RotateBounds.java
@@ -1,0 +1,15 @@
+package com.codingadventures.imagegeometrictransforms;
+
+/**
+ * How a free rotation sizes its output canvas.
+ *
+ * <ul>
+ *   <li>{@link #FIT} — grow the canvas to enclose the whole rotated
+ *       rectangle; nothing is clipped, but corners are transparent.</li>
+ *   <li>{@link #CROP} — keep the original dimensions; corners of the
+ *       rotated image that fall outside are clipped.</li>
+ * </ul>
+ */
+public enum RotateBounds {
+    FIT, CROP
+}

--- a/code/packages/java/image-geometric-transforms/src/test/java/com/codingadventures/imagegeometrictransforms/ImageGeometricTransformsTest.java
+++ b/code/packages/java/image-geometric-transforms/src/test/java/com/codingadventures/imagegeometrictransforms/ImageGeometricTransformsTest.java
@@ -1,0 +1,414 @@
+package com.codingadventures.imagegeometrictransforms;
+
+import com.codingadventures.pixelcontainer.PixelContainer;
+import com.codingadventures.pixelcontainer.PixelOps;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ImageGeometricTransformsTest {
+
+    /**
+     * Build a distinctive test image with unique colours per pixel, so tests
+     * can confirm placement instead of just value equality.
+     */
+    private static PixelContainer makeGrid(int w, int h) {
+        PixelContainer c = PixelOps.create(w, h);
+        for (int y = 0; y < h; y++)
+            for (int x = 0; x < w; x++)
+                PixelOps.setPixel(c, x, y, (x * 30) & 0xFF, (y * 30) & 0xFF, ((x + y) * 10) & 0xFF, 255);
+        return c;
+    }
+
+    private static int[] px(PixelContainer c, int x, int y) {
+        return PixelOps.pixelAt(c, x, y);
+    }
+
+    /* -------- Flips -------- */
+
+    @Test
+    void flipHorizontalRespectsDimensions() {
+        PixelContainer src = makeGrid(3, 2);
+        PixelContainer out = ImageGeometricTransforms.flipHorizontal(src);
+        assertEquals(3, out.width);
+        assertEquals(2, out.height);
+    }
+
+    @Test
+    void flipHorizontalSwapsLeftRight() {
+        PixelContainer src = makeGrid(4, 2);
+        PixelContainer out = ImageGeometricTransforms.flipHorizontal(src);
+        assertArrayEquals(px(src, 0, 0), px(out, 3, 0));
+        assertArrayEquals(px(src, 3, 0), px(out, 0, 0));
+    }
+
+    @Test
+    void flipHorizontalDoubleRestoresInput() {
+        PixelContainer src = makeGrid(5, 4);
+        PixelContainer twice = ImageGeometricTransforms.flipHorizontal(
+            ImageGeometricTransforms.flipHorizontal(src));
+        for (int y = 0; y < 4; y++)
+            for (int x = 0; x < 5; x++)
+                assertArrayEquals(px(src, x, y), px(twice, x, y));
+    }
+
+    @Test
+    void flipVerticalSwapsTopBottom() {
+        PixelContainer src = makeGrid(2, 4);
+        PixelContainer out = ImageGeometricTransforms.flipVertical(src);
+        assertArrayEquals(px(src, 0, 0), px(out, 0, 3));
+        assertArrayEquals(px(src, 0, 3), px(out, 0, 0));
+    }
+
+    @Test
+    void flipVerticalDoubleRestoresInput() {
+        PixelContainer src = makeGrid(3, 3);
+        PixelContainer twice = ImageGeometricTransforms.flipVertical(
+            ImageGeometricTransforms.flipVertical(src));
+        for (int y = 0; y < 3; y++)
+            for (int x = 0; x < 3; x++)
+                assertArrayEquals(px(src, x, y), px(twice, x, y));
+    }
+
+    /* -------- 90 rotations -------- */
+
+    @Test
+    void rotate90CwSwapsDimensions() {
+        PixelContainer src = makeGrid(4, 2);
+        PixelContainer out = ImageGeometricTransforms.rotate90CW(src);
+        assertEquals(2, out.width);
+        assertEquals(4, out.height);
+    }
+
+    @Test
+    void rotate90CwTopLeftGoesToTopRight() {
+        PixelContainer src = makeGrid(3, 2);
+        PixelContainer out = ImageGeometricTransforms.rotate90CW(src);
+        // (0,0) in src → (out.width-1, 0) = (1, 0) in out.
+        assertArrayEquals(px(src, 0, 0), px(out, 1, 0));
+    }
+
+    @Test
+    void rotate90CwFourTimesIsIdentity() {
+        PixelContainer src = makeGrid(3, 2);
+        PixelContainer r = src;
+        for (int i = 0; i < 4; i++) r = ImageGeometricTransforms.rotate90CW(r);
+        for (int y = 0; y < 2; y++)
+            for (int x = 0; x < 3; x++)
+                assertArrayEquals(px(src, x, y), px(r, x, y));
+    }
+
+    @Test
+    void rotate90CcwIsInverseOfCw() {
+        PixelContainer src = makeGrid(4, 3);
+        PixelContainer back = ImageGeometricTransforms.rotate90CCW(
+            ImageGeometricTransforms.rotate90CW(src));
+        for (int y = 0; y < 3; y++)
+            for (int x = 0; x < 4; x++)
+                assertArrayEquals(px(src, x, y), px(back, x, y));
+    }
+
+    @Test
+    void rotate180SwapsOppositeCorners() {
+        PixelContainer src = makeGrid(3, 2);
+        PixelContainer out = ImageGeometricTransforms.rotate180(src);
+        assertArrayEquals(px(src, 0, 0), px(out, 2, 1));
+        assertArrayEquals(px(src, 2, 1), px(out, 0, 0));
+    }
+
+    @Test
+    void rotate180EqualsTwoCw() {
+        PixelContainer src = makeGrid(3, 2);
+        PixelContainer a = ImageGeometricTransforms.rotate180(src);
+        PixelContainer b = ImageGeometricTransforms.rotate90CW(
+            ImageGeometricTransforms.rotate90CW(src));
+        for (int y = 0; y < 2; y++)
+            for (int x = 0; x < 3; x++)
+                assertArrayEquals(px(a, x, y), px(b, x, y));
+    }
+
+    /* -------- Crop -------- */
+
+    @Test
+    void cropExtractsRegion() {
+        PixelContainer src = makeGrid(5, 5);
+        PixelContainer out = ImageGeometricTransforms.crop(src, 1, 1, 2, 2);
+        assertEquals(2, out.width);
+        assertEquals(2, out.height);
+        assertArrayEquals(px(src, 1, 1), px(out, 0, 0));
+        assertArrayEquals(px(src, 2, 2), px(out, 1, 1));
+    }
+
+    @Test
+    void cropOutsideGivesTransparent() {
+        PixelContainer src = makeGrid(3, 3);
+        PixelContainer out = ImageGeometricTransforms.crop(src, 5, 5, 2, 2);
+        for (int y = 0; y < 2; y++)
+            for (int x = 0; x < 2; x++)
+                assertArrayEquals(new int[]{0, 0, 0, 0}, px(out, x, y));
+    }
+
+    @Test
+    void cropPartiallyOutside() {
+        PixelContainer src = makeGrid(3, 3);
+        // Region straddles the right edge.
+        PixelContainer out = ImageGeometricTransforms.crop(src, 2, 0, 3, 1);
+        assertArrayEquals(px(src, 2, 0), px(out, 0, 0));
+        assertArrayEquals(new int[]{0, 0, 0, 0}, px(out, 1, 0));
+    }
+
+    /* -------- Scale -------- */
+
+    @Test
+    void scaleToSameSizeIsApproximatelyIdentity() {
+        PixelContainer src = makeGrid(4, 4);
+        PixelContainer out = ImageGeometricTransforms.scale(
+            src, 4, 4, Interpolation.NEAREST, OutOfBounds.REPLICATE);
+        assertEquals(4, out.width);
+        assertEquals(4, out.height);
+        assertArrayEquals(px(src, 2, 2), px(out, 2, 2));
+    }
+
+    @Test
+    void scaleDoubleNearest() {
+        PixelContainer src = makeGrid(2, 2);
+        PixelContainer out = ImageGeometricTransforms.scale(
+            src, 4, 4, Interpolation.NEAREST, OutOfBounds.REPLICATE);
+        assertEquals(4, out.width);
+        assertEquals(4, out.height);
+    }
+
+    @Test
+    void scaleHalveBilinear() {
+        PixelContainer src = makeGrid(4, 4);
+        PixelContainer out = ImageGeometricTransforms.scale(
+            src, 2, 2, Interpolation.BILINEAR, OutOfBounds.REPLICATE);
+        assertEquals(2, out.width);
+        assertEquals(2, out.height);
+    }
+
+    @Test
+    void scaleBicubic() {
+        PixelContainer src = makeGrid(4, 4);
+        PixelContainer out = ImageGeometricTransforms.scale(
+            src, 8, 8, Interpolation.BICUBIC, OutOfBounds.REPLICATE);
+        assertEquals(8, out.width);
+        assertEquals(8, out.height);
+    }
+
+    /* -------- Translate -------- */
+
+    @Test
+    void translateZeroIsIdentity() {
+        PixelContainer src = makeGrid(3, 3);
+        PixelContainer out = ImageGeometricTransforms.translate(
+            src, 0, 0, Interpolation.NEAREST, OutOfBounds.ZERO);
+        for (int y = 0; y < 3; y++)
+            for (int x = 0; x < 3; x++)
+                assertArrayEquals(px(src, x, y), px(out, x, y));
+    }
+
+    @Test
+    void translateShiftRight() {
+        PixelContainer src = makeGrid(3, 1);
+        PixelContainer out = ImageGeometricTransforms.translate(
+            src, 1, 0, Interpolation.NEAREST, OutOfBounds.ZERO);
+        // New (1,0) should equal old (0,0).
+        assertArrayEquals(px(src, 0, 0), px(out, 1, 0));
+    }
+
+    @Test
+    void translateOutOfBoundsZero() {
+        PixelContainer src = makeGrid(3, 1);
+        PixelContainer out = ImageGeometricTransforms.translate(
+            src, 5, 0, Interpolation.NEAREST, OutOfBounds.ZERO);
+        for (int x = 0; x < 3; x++)
+            assertArrayEquals(new int[]{0, 0, 0, 0}, px(out, x, 0));
+    }
+
+    /* -------- Rotate free -------- */
+
+    @Test
+    void rotateZeroIsIdentity() {
+        PixelContainer src = makeGrid(3, 3);
+        PixelContainer out = ImageGeometricTransforms.rotate(
+            src, 0, RotateBounds.CROP, Interpolation.NEAREST, OutOfBounds.ZERO);
+        assertEquals(3, out.width);
+        assertEquals(3, out.height);
+        assertArrayEquals(px(src, 1, 1), px(out, 1, 1));
+    }
+
+    @Test
+    void rotateFitGrowsCanvas() {
+        PixelContainer src = makeGrid(4, 4);
+        PixelContainer out = ImageGeometricTransforms.rotate(
+            src, 45, RotateBounds.FIT, Interpolation.BILINEAR, OutOfBounds.ZERO);
+        assertTrue(out.width >= 4);
+        assertTrue(out.height >= 4);
+    }
+
+    @Test
+    void rotateCropKeepsDimensions() {
+        PixelContainer src = makeGrid(4, 4);
+        PixelContainer out = ImageGeometricTransforms.rotate(
+            src, 30, RotateBounds.CROP, Interpolation.BILINEAR, OutOfBounds.ZERO);
+        assertEquals(4, out.width);
+        assertEquals(4, out.height);
+    }
+
+    @Test
+    void rotate360IsApproximatelyIdentity() {
+        PixelContainer src = makeGrid(5, 5);
+        PixelContainer out = ImageGeometricTransforms.rotate(
+            src, 360, RotateBounds.CROP, Interpolation.BILINEAR, OutOfBounds.REPLICATE);
+        // Centre pixel should be very close to the original.
+        int[] a = px(src, 2, 2), b = px(out, 2, 2);
+        for (int i = 0; i < 3; i++) assertTrue(Math.abs(a[i] - b[i]) <= 5);
+    }
+
+    /* -------- Affine -------- */
+
+    @Test
+    void affineIdentity() {
+        PixelContainer src = makeGrid(3, 3);
+        double[][] id = { {1, 0, 0}, {0, 1, 0} };
+        PixelContainer out = ImageGeometricTransforms.affine(
+            src, id, Interpolation.NEAREST, OutOfBounds.ZERO);
+        for (int y = 0; y < 3; y++)
+            for (int x = 0; x < 3; x++)
+                assertArrayEquals(px(src, x, y), px(out, x, y));
+    }
+
+    @Test
+    void affineTranslate() {
+        PixelContainer src = makeGrid(3, 1);
+        double[][] t = { {1, 0, 1}, {0, 1, 0} };
+        PixelContainer out = ImageGeometricTransforms.affine(
+            src, t, Interpolation.NEAREST, OutOfBounds.ZERO);
+        // Forward shift by +1: output (1,0) should equal input (0,0).
+        assertArrayEquals(px(src, 0, 0), px(out, 1, 0));
+    }
+
+    @Test
+    void affineScale() {
+        PixelContainer src = makeGrid(4, 4);
+        double[][] s = { {2, 0, 0}, {0, 2, 0} };
+        PixelContainer out = ImageGeometricTransforms.affine(
+            src, s, Interpolation.NEAREST, OutOfBounds.REPLICATE);
+        // Output canvas size equals input; scale>1 forward → input (1,1) maps to output (2,2).
+        assertArrayEquals(px(src, 1, 1), px(out, 2, 2));
+    }
+
+    /* -------- Perspective -------- */
+
+    @Test
+    void perspectiveIdentity() {
+        PixelContainer src = makeGrid(3, 3);
+        double[][] id = { {1, 0, 0}, {0, 1, 0}, {0, 0, 1} };
+        PixelContainer out = ImageGeometricTransforms.perspectiveWarp(
+            src, id, Interpolation.NEAREST, OutOfBounds.ZERO);
+        for (int y = 0; y < 3; y++)
+            for (int x = 0; x < 3; x++)
+                assertArrayEquals(px(src, x, y), px(out, x, y));
+    }
+
+    @Test
+    void perspectiveDegenerateGivesZero() {
+        PixelContainer src = makeGrid(3, 3);
+        // Singular matrix with a row of zeros produces wh ≈ 0 for some pixels.
+        // We use a highly skewed matrix to force near-zero w.
+        double[][] m = { {1, 0, 0}, {0, 1, 0}, {1e12, 0, 1} };
+        PixelContainer out = ImageGeometricTransforms.perspectiveWarp(
+            src, m, Interpolation.NEAREST, OutOfBounds.ZERO);
+        // Just sanity: output dimensions preserved and no crash.
+        assertEquals(3, out.width);
+        assertEquals(3, out.height);
+    }
+
+    /* -------- Out-of-bounds modes -------- */
+
+    @Test
+    void oobZeroGivesTransparent() {
+        PixelContainer src = makeGrid(2, 2);
+        PixelContainer out = ImageGeometricTransforms.translate(
+            src, 10, 0, Interpolation.NEAREST, OutOfBounds.ZERO);
+        assertArrayEquals(new int[]{0, 0, 0, 0}, px(out, 0, 0));
+    }
+
+    @Test
+    void oobReplicateGivesEdge() {
+        PixelContainer src = makeGrid(2, 2);
+        PixelContainer out = ImageGeometricTransforms.translate(
+            src, 10, 0, Interpolation.NEAREST, OutOfBounds.REPLICATE);
+        // Translate +10 means output(x,y) samples source(x-10, y); far to the
+        // left of the source. REPLICATE clamps to column 0.
+        assertArrayEquals(px(src, 0, 0), px(out, 0, 0));
+    }
+
+    @Test
+    void oobWrapTiles() {
+        PixelContainer src = makeGrid(2, 1);
+        PixelContainer out = ImageGeometricTransforms.translate(
+            src, -2, 0, Interpolation.NEAREST, OutOfBounds.WRAP);
+        // Shift by -2 wraps back to the same image.
+        for (int x = 0; x < 2; x++)
+            assertArrayEquals(px(src, x, 0), px(out, x, 0));
+    }
+
+    @Test
+    void oobReflectMirrors() {
+        PixelContainer src = makeGrid(3, 1);
+        // Sample at x=-1 under REFLECT should fold back to x=0.
+        PixelContainer out = ImageGeometricTransforms.translate(
+            src, 1, 0, Interpolation.NEAREST, OutOfBounds.REFLECT);
+        assertArrayEquals(px(src, 0, 0), px(out, 0, 0));
+    }
+
+    /* -------- Interpolation mode coverage -------- */
+
+    @Test
+    void allInterpolationModesProduceSameSizedOutput() {
+        PixelContainer src = makeGrid(4, 4);
+        for (Interpolation i : Interpolation.values()) {
+            PixelContainer out = ImageGeometricTransforms.scale(
+                src, 6, 6, i, OutOfBounds.REPLICATE);
+            assertEquals(6, out.width);
+            assertEquals(6, out.height);
+        }
+    }
+
+    @Test
+    void allOobModesWorkInBicubic() {
+        PixelContainer src = makeGrid(3, 3);
+        for (OutOfBounds o : OutOfBounds.values()) {
+            PixelContainer out = ImageGeometricTransforms.scale(
+                src, 5, 5, Interpolation.BICUBIC, o);
+            assertEquals(5, out.width);
+            assertEquals(5, out.height);
+        }
+    }
+
+    /* -------- Alpha behaviour -------- */
+
+    @Test
+    void bilinearAlphaBlends() {
+        PixelContainer src = PixelOps.create(2, 1);
+        PixelOps.setPixel(src, 0, 0, 255, 0, 0, 0);
+        PixelOps.setPixel(src, 1, 0, 255, 0, 0, 255);
+        // Scale up so we sample between the two columns.
+        PixelContainer out = ImageGeometricTransforms.scale(
+            src, 4, 1, Interpolation.BILINEAR, OutOfBounds.REPLICATE);
+        int midAlpha = px(out, 2, 0)[3];
+        assertTrue(midAlpha > 0 && midAlpha < 255);
+    }
+
+    @Test
+    void doesNotMutateInput() {
+        PixelContainer src = makeGrid(3, 3);
+        int[] before = px(src, 1, 1).clone();
+        ImageGeometricTransforms.rotate180(src);
+        ImageGeometricTransforms.flipHorizontal(src);
+        ImageGeometricTransforms.scale(src, 2, 2, Interpolation.BILINEAR, OutOfBounds.ZERO);
+        assertArrayEquals(before, px(src, 1, 1));
+    }
+}

--- a/code/packages/java/image-point-ops/.gitignore
+++ b/code/packages/java/image-point-ops/.gitignore
@@ -1,0 +1,2 @@
+gradle-build/
+.gradle/

--- a/code/packages/java/image-point-ops/BUILD
+++ b/code/packages/java/image-point-ops/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/image-point-ops/BUILD_windows
+++ b/code/packages/java/image-point-ops/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/image-point-ops/CHANGELOG.md
+++ b/code/packages/java/image-point-ops/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 0.1.0
+
+- Add initial Java `image-point-ops` package (IMG03)
+- Implement u8-domain ops: `invert`, `threshold`, `thresholdLuminance`,
+  `posterize`, `swapRgbBgr`, `extractChannel`, `brightness`
+- Implement linear-light ops: `contrast`, `gamma`, `exposure`, `greyscale`,
+  `sepia`, `colourMatrix`, `saturate`, `hueRotate`
+- Provide sRGB/linear whole-image converters and 1D LUT helpers
+- Precompute sRGB → linear LUT at class load

--- a/code/packages/java/image-point-ops/README.md
+++ b/code/packages/java/image-point-ops/README.md
@@ -1,0 +1,45 @@
+# Java Image Point Ops
+
+IMG03 — per-pixel point operations on `PixelContainer`. Every method in
+this package transforms each pixel independently, using only that pixel's
+own value — no neighbourhood lookups, no frequency-domain tricks, no
+geometry. That orthogonality makes point ops trivially parallelisable and
+easy to reason about.
+
+## Two domains
+
+Point operations split cleanly by where they do their arithmetic:
+
+- **u8 domain** — `invert`, `threshold`, `posterize`, channel ops,
+  `brightness`. These work directly on the sRGB bytes.
+- **Linear-light domain** — `contrast`, `gamma`, `exposure`, `greyscale`,
+  `sepia`, `colourMatrix`, `saturate`, `hueRotate`. These decode sRGB to
+  linear light first, operate, and re-encode.
+
+Doing colour mixing in sRGB space produces the classic "muddy midtones"
+artifact; doing it in linear light is physically correct.
+
+## sRGB ↔ linear
+
+```
+decode: c = byte/255; c <= 0.04045 ? c/12.92 : ((c+0.055)/1.055)^2.4
+encode: c <= 0.0031308 ? c*12.92 : 1.055*c^(1/2.4)-0.055; round*255
+```
+
+A precomputed 256-entry LUT handles the sRGB → linear direction at class
+load time, since there are only 256 possible input bytes.
+
+## Usage
+
+```java
+import com.codingadventures.imagepointops.ImagePointOps;
+import com.codingadventures.imagepointops.GreyscaleMethod;
+
+PixelContainer inverted = ImagePointOps.invert(src);
+PixelContainer grey     = ImagePointOps.greyscale(src, GreyscaleMethod.REC709);
+PixelContainer brighter = ImagePointOps.exposure(src, +1.0);
+```
+
+## Depends on
+
+- `pixel-container` (IC00) — the underlying buffer format.

--- a/code/packages/java/image-point-ops/build.gradle.kts
+++ b/code/packages/java/image-point-ops/build.gradle.kts
@@ -1,0 +1,29 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    api("com.codingadventures:pixel-container")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/image-point-ops/settings.gradle.kts
+++ b/code/packages/java/image-point-ops/settings.gradle.kts
@@ -1,0 +1,3 @@
+rootProject.name = "image-point-ops"
+
+includeBuild("../pixel-container")

--- a/code/packages/java/image-point-ops/src/main/java/com/codingadventures/imagepointops/GreyscaleMethod.java
+++ b/code/packages/java/image-point-ops/src/main/java/com/codingadventures/imagepointops/GreyscaleMethod.java
@@ -1,0 +1,24 @@
+package com.codingadventures.imagepointops;
+
+/**
+ * Strategy for collapsing RGB into a single luminance value.
+ *
+ * <p>All three methods compute a weighted average of the linear-light RGB
+ * components. The weights differ because luminance perception is not
+ * uniform across spectra — the human eye is ~twice as sensitive to green
+ * as to red, and ~10× as sensitive to green as to blue.</p>
+ *
+ * <ul>
+ *   <li>{@link #REC709} — HDTV / sRGB standard: 0.2126 R + 0.7152 G + 0.0722 B.
+ *       Most accurate for modern displays.</li>
+ *   <li>{@link #BT601}  — older NTSC/PAL standard: 0.299 R + 0.587 G + 0.114 B.
+ *       Still common in JPEG and many image libraries.</li>
+ *   <li>{@link #AVERAGE} — 1/3 R + 1/3 G + 1/3 B. Cheap and physically
+ *       wrong; provided for parity with naive implementations and tests.</li>
+ * </ul>
+ */
+public enum GreyscaleMethod {
+    REC709,
+    BT601,
+    AVERAGE
+}

--- a/code/packages/java/image-point-ops/src/main/java/com/codingadventures/imagepointops/ImagePointOps.java
+++ b/code/packages/java/image-point-ops/src/main/java/com/codingadventures/imagepointops/ImagePointOps.java
@@ -1,0 +1,442 @@
+package com.codingadventures.imagepointops;
+
+import com.codingadventures.pixelcontainer.PixelContainer;
+import com.codingadventures.pixelcontainer.PixelOps;
+
+import java.util.function.DoubleUnaryOperator;
+
+/**
+ * IMG03 — Per-pixel point operations on {@link PixelContainer}.
+ *
+ * <p>Every method in this class is a <em>point operation</em>: it produces
+ * an output pixel from the corresponding input pixel alone, using no
+ * neighbourhood information. That makes all of them data-parallel and
+ * trivially vectorisable, and allows them to compose freely.</p>
+ *
+ * <h2>Two domains</h2>
+ * <ul>
+ *   <li><b>u8-domain</b>: {@link #invert}, {@link #threshold}, posterize,
+ *       channel ops, {@link #brightness}. These operate on the sRGB byte
+ *       directly.</li>
+ *   <li><b>Linear-light domain</b>: {@link #contrast}, {@link #gamma},
+ *       {@link #exposure}, {@link #greyscale}, {@link #sepia},
+ *       {@link #colourMatrix}, {@link #saturate}, {@link #hueRotate}.
+ *       These decode sRGB to linear light, operate, then re-encode.</li>
+ * </ul>
+ *
+ * <h2>sRGB ↔ linear</h2>
+ * <pre>
+ *   decode: c = byte/255; c <= 0.04045 ? c/12.92 : ((c+0.055)/1.055)^2.4
+ *   encode: c <= 0.0031308 ? c*12.92 : 1.055*c^(1/2.4)-0.055; round*255
+ * </pre>
+ *
+ * <p>A 256-entry LUT handles {@code decode} because there are only 256
+ * possible inputs.</p>
+ */
+public final class ImagePointOps {
+    private ImagePointOps() {}
+
+    /* ------------------------------------------------------------------ */
+    /* sRGB ↔ linear plumbing.                                            */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * Precomputed sRGB-byte → linear-float lookup table. Filled at class
+     * load because there are exactly 256 possible inputs and the per-call
+     * pow() is far more expensive than the array access.
+     */
+    private static final double[] SRGB_TO_LINEAR = new double[256];
+    static {
+        for (int i = 0; i < 256; i++) {
+            double c = i / 255.0;
+            SRGB_TO_LINEAR[i] = (c <= 0.04045) ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+        }
+    }
+
+    /** Decode an sRGB byte to linear-light [0, 1]. */
+    private static double decode(int b) {
+        return SRGB_TO_LINEAR[b & 0xFF];
+    }
+
+    /** Encode a linear-light value in [0, 1] back to an sRGB byte. */
+    private static int encode(double linear) {
+        double c = Math.max(0.0, Math.min(1.0, linear));
+        double srgb = (c <= 0.0031308) ? c * 12.92 : 1.055 * Math.pow(c, 1.0 / 2.4) - 0.055;
+        return (int) Math.round(srgb * 255.0);
+    }
+
+    /**
+     * Functional interface used to describe the per-pixel transform.
+     * Kept package-private — callers use the named ops.
+     */
+    @FunctionalInterface
+    interface PixelMapper {
+        int[] map(int r, int g, int b, int a);
+    }
+
+    /**
+     * Apply {@code f} independently to every pixel of {@code src},
+     * producing a new container. Input is never mutated.
+     */
+    private static PixelContainer mapPixels(PixelContainer src, PixelMapper f) {
+        PixelContainer out = new PixelContainer(src.width, src.height);
+        for (int y = 0; y < src.height; y++) {
+            for (int x = 0; x < src.width; x++) {
+                int[] px = PixelOps.pixelAt(src, x, y);
+                int[] outPx = f.map(px[0], px[1], px[2], px[3]);
+                PixelOps.setPixel(out, x, y, outPx[0], outPx[1], outPx[2], outPx[3]);
+            }
+        }
+        return out;
+    }
+
+    /** Clamp to an integer in [0, 255]. */
+    private static int clampByte(int v) {
+        return v < 0 ? 0 : (v > 255 ? 255 : v);
+    }
+
+    private static int clampByte(double v) {
+        if (v <= 0) return 0;
+        if (v >= 255) return 255;
+        return (int) Math.round(v);
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* u8-domain ops.                                                     */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * Photographic negative: {@code (255-r, 255-g, 255-b, a)}. Alpha is
+     * untouched because transparency is not a colour.
+     */
+    public static PixelContainer invert(PixelContainer src) {
+        return mapPixels(src, (r, g, b, a) -> new int[]{255 - r, 255 - g, 255 - b, a});
+    }
+
+    /**
+     * Binary threshold on the arithmetic mean of RGB. Pixels with a mean
+     * {@code >= t} become white, others black. Alpha preserved.
+     *
+     * <p>This uses the mean rather than perceptual luminance because it's
+     * the classical "Otsu-style" binarisation — see
+     * {@link #thresholdLuminance} for the perceptual version.</p>
+     */
+    public static PixelContainer threshold(PixelContainer src, int t) {
+        return mapPixels(src, (r, g, b, a) -> {
+            int avg = (r + g + b) / 3;
+            int v = (avg >= t) ? 255 : 0;
+            return new int[]{v, v, v, a};
+        });
+    }
+
+    /**
+     * Binary threshold on Rec. 709 luminance. More perceptually uniform
+     * than plain mean threshold.
+     */
+    public static PixelContainer thresholdLuminance(PixelContainer src, int t) {
+        return mapPixels(src, (r, g, b, a) -> {
+            double y = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+            int v = (y >= t) ? 255 : 0;
+            return new int[]{v, v, v, a};
+        });
+    }
+
+    /**
+     * Posterize — reduce each channel to {@code levels} evenly spaced
+     * values. With {@code levels = 2} you get a hard black/white per
+     * channel; with {@code levels = 256} you get the identity.
+     *
+     * <p>For each channel value v in [0, 255]:
+     * {@code step = 255 / (levels-1); out = round(round(v/step) * step)}.</p>
+     */
+    public static PixelContainer posterize(PixelContainer src, int levels) {
+        if (levels < 2) levels = 2;
+        final double step = 255.0 / (levels - 1);
+        return mapPixels(src, (r, g, b, a) -> new int[]{
+            (int) Math.round(Math.round(r / step) * step),
+            (int) Math.round(Math.round(g / step) * step),
+            (int) Math.round(Math.round(b / step) * step),
+            a
+        });
+    }
+
+    /** Swap red and blue channels. Handy for BGR ↔ RGB codec interop. */
+    public static PixelContainer swapRgbBgr(PixelContainer src) {
+        return mapPixels(src, (r, g, b, a) -> new int[]{b, g, r, a});
+    }
+
+    /**
+     * Extract channel {@code ch} (0=R, 1=G, 2=B, 3=A) into a greyscale
+     * RGBA image. Alpha is forced to 255 so the result is visible even
+     * when extracting the alpha channel itself.
+     */
+    public static PixelContainer extractChannel(PixelContainer src, int ch) {
+        return mapPixels(src, (r, g, b, a) -> {
+            int v = switch (ch) {
+                case 0 -> r;
+                case 1 -> g;
+                case 2 -> b;
+                case 3 -> a;
+                default -> 0;
+            };
+            return new int[]{v, v, v, 255};
+        });
+    }
+
+    /**
+     * Add {@code delta} to each colour channel in u8 space, clamping to
+     * [0, 255]. This is the naive brightness adjustment — for perceptually
+     * correct brightening use {@link #exposure}.
+     */
+    public static PixelContainer brightness(PixelContainer src, int delta) {
+        return mapPixels(src, (r, g, b, a) -> new int[]{
+            clampByte(r + delta),
+            clampByte(g + delta),
+            clampByte(b + delta),
+            a
+        });
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Linear-light domain ops.                                           */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * Classic "GIMP-style" contrast in u8 space around midpoint 128.
+     *
+     * <p>{@code factor} ∈ [-255, 255]: 0 = identity, positive stretches,
+     * negative flattens. The formula {@code f = 259*(factor+255) /
+     * (255*(259-factor))} was popularised by GIMP and produces the
+     * familiar "increase contrast" slider behaviour.</p>
+     */
+    public static PixelContainer contrast(PixelContainer src, double factor) {
+        final double f = (259.0 * (factor + 255.0)) / (255.0 * (259.0 - factor));
+        return mapPixels(src, (r, g, b, a) -> new int[]{
+            clampByte(f * (r - 128) + 128),
+            clampByte(f * (g - 128) + 128),
+            clampByte(f * (b - 128) + 128),
+            a
+        });
+    }
+
+    /**
+     * Raise the linear-light signal to a power. {@code g > 1} darkens
+     * midtones, {@code g < 1} brightens them.
+     */
+    public static PixelContainer gamma(PixelContainer src, double g) {
+        return mapPixels(src, (r, gg, b, a) -> new int[]{
+            encode(Math.pow(decode(r), g)),
+            encode(Math.pow(decode(gg), g)),
+            encode(Math.pow(decode(b), g)),
+            a
+        });
+    }
+
+    /**
+     * Exposure compensation in f-stops. Each stop doubles (or halves) the
+     * linear-light intensity. +1 stop = photograph taken with 2× the light.
+     */
+    public static PixelContainer exposure(PixelContainer src, double stops) {
+        final double scale = Math.pow(2.0, stops);
+        return mapPixels(src, (r, g, b, a) -> new int[]{
+            encode(decode(r) * scale),
+            encode(decode(g) * scale),
+            encode(decode(b) * scale),
+            a
+        });
+    }
+
+    /**
+     * Desaturate to greyscale using the chosen weights. All work is done
+     * in linear light so mixing is physically correct.
+     */
+    public static PixelContainer greyscale(PixelContainer src, GreyscaleMethod method) {
+        final double wr, wg, wb;
+        switch (method) {
+            case REC709  -> { wr = 0.2126; wg = 0.7152; wb = 0.0722; }
+            case BT601   -> { wr = 0.299;  wg = 0.587;  wb = 0.114;  }
+            case AVERAGE -> { wr = 1.0/3;  wg = 1.0/3;  wb = 1.0/3;  }
+            default      -> { wr = 1.0/3;  wg = 1.0/3;  wb = 1.0/3;  }
+        }
+        return mapPixels(src, (r, g, b, a) -> {
+            double y = wr * decode(r) + wg * decode(g) + wb * decode(b);
+            int v = encode(y);
+            return new int[]{v, v, v, a};
+        });
+    }
+
+    /**
+     * Classic sepia tone matrix, applied in linear light.
+     * <pre>
+     *   rOut = 0.393*r + 0.769*g + 0.189*b
+     *   gOut = 0.349*r + 0.686*g + 0.168*b
+     *   bOut = 0.272*r + 0.534*g + 0.131*b
+     * </pre>
+     */
+    public static PixelContainer sepia(PixelContainer src) {
+        return mapPixels(src, (r, g, b, a) -> {
+            double lr = decode(r), lg = decode(g), lb = decode(b);
+            double outR = 0.393 * lr + 0.769 * lg + 0.189 * lb;
+            double outG = 0.349 * lr + 0.686 * lg + 0.168 * lb;
+            double outB = 0.272 * lr + 0.534 * lg + 0.131 * lb;
+            return new int[]{encode(outR), encode(outG), encode(outB), a};
+        });
+    }
+
+    /**
+     * Apply an arbitrary 3×3 colour matrix to every pixel's linear RGB.
+     * Extremely general: greyscale, sepia, channel mixing, and many
+     * artistic LUTs can all be expressed as 3×3 matrices.
+     */
+    public static PixelContainer colourMatrix(PixelContainer src, double[][] m) {
+        return mapPixels(src, (r, g, b, a) -> {
+            double lr = decode(r), lg = decode(g), lb = decode(b);
+            double outR = m[0][0] * lr + m[0][1] * lg + m[0][2] * lb;
+            double outG = m[1][0] * lr + m[1][1] * lg + m[1][2] * lb;
+            double outB = m[2][0] * lr + m[2][1] * lg + m[2][2] * lb;
+            return new int[]{encode(outR), encode(outG), encode(outB), a};
+        });
+    }
+
+    /**
+     * Boost ({@code factor > 1}) or cut ({@code factor < 1}) saturation,
+     * blending each channel toward its luminance.
+     *
+     * <p>Implemented as a per-channel lerp toward Y with {@code factor}.
+     * {@code factor = 0} fully desaturates (greyscale); {@code factor = 1}
+     * is identity; {@code factor = 2} doubles chroma.</p>
+     */
+    public static PixelContainer saturate(PixelContainer src, double factor) {
+        return mapPixels(src, (r, g, b, a) -> {
+            double lr = decode(r), lg = decode(g), lb = decode(b);
+            double y = 0.2126 * lr + 0.7152 * lg + 0.0722 * lb;
+            // lerp(Y, c, factor) == Y + factor*(c - Y)
+            double outR = y + factor * (lr - y);
+            double outG = y + factor * (lg - y);
+            double outB = y + factor * (lb - y);
+            return new int[]{encode(outR), encode(outG), encode(outB), a};
+        });
+    }
+
+    /**
+     * Rotate hue by {@code degrees} degrees on the HSV hue circle.
+     * Conversion and arithmetic happen in linear light.
+     */
+    public static PixelContainer hueRotate(PixelContainer src, double degrees) {
+        return mapPixels(src, (r, g, b, a) -> {
+            double[] hsv = rgbToHsv(decode(r), decode(g), decode(b));
+            double h = hsv[0] + degrees;
+            h = ((h % 360) + 360) % 360;   // wrap to [0, 360)
+            double[] rgb = hsvToRgb(h, hsv[1], hsv[2]);
+            return new int[]{encode(rgb[0]), encode(rgb[1]), encode(rgb[2]), a};
+        });
+    }
+
+    /** Linear-light RGB (0..1) → HSV with H in degrees [0,360), S and V in [0,1]. */
+    private static double[] rgbToHsv(double r, double g, double b) {
+        double cmax = Math.max(r, Math.max(g, b));
+        double cmin = Math.min(r, Math.min(g, b));
+        double delta = cmax - cmin;
+        double h = 0;
+        if (delta > 1e-6) {
+            if (cmax == r)      h = 60 * (((g - b) / delta) % 6);
+            else if (cmax == g) h = 60 * ((b - r) / delta + 2);
+            else                h = 60 * ((r - g) / delta + 4);
+        }
+        if (h < 0) h += 360;
+        double s = (cmax < 1e-6) ? 0 : delta / cmax;
+        return new double[]{h, s, cmax};
+    }
+
+    /** HSV (H in degrees, S/V in [0,1]) → linear-light RGB in [0,1]. */
+    private static double[] hsvToRgb(double h, double s, double v) {
+        double c = v * s;
+        double x = c * (1 - Math.abs((h / 60.0) % 2 - 1));
+        double m = v - c;
+        double r1, g1, b1;
+        int sector = (int) (h / 60) % 6;
+        if (sector < 0) sector += 6;
+        switch (sector) {
+            case 0 -> { r1 = c; g1 = x; b1 = 0; }
+            case 1 -> { r1 = x; g1 = c; b1 = 0; }
+            case 2 -> { r1 = 0; g1 = c; b1 = x; }
+            case 3 -> { r1 = 0; g1 = x; b1 = c; }
+            case 4 -> { r1 = x; g1 = 0; b1 = c; }
+            default -> { r1 = c; g1 = 0; b1 = x; }
+        }
+        return new double[]{
+            Math.max(0, Math.min(1, r1 + m)),
+            Math.max(0, Math.min(1, g1 + m)),
+            Math.max(0, Math.min(1, b1 + m))
+        };
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Whole-image sRGB ↔ linear conversion.                              */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * Reinterpret each sRGB byte as if it were linear-light — i.e. the
+     * output bytes equal {@code round(decode(input) * 255)}. Useful when
+     * feeding a pipeline that expects linear bytes.
+     */
+    public static PixelContainer srgbToLinearImage(PixelContainer src) {
+        return mapPixels(src, (r, g, b, a) -> new int[]{
+            (int) Math.round(decode(r) * 255.0),
+            (int) Math.round(decode(g) * 255.0),
+            (int) Math.round(decode(b) * 255.0),
+            a
+        });
+    }
+
+    /**
+     * Inverse of {@link #srgbToLinearImage}: treat each byte as linear
+     * light in [0, 1] and re-encode to sRGB.
+     */
+    public static PixelContainer linearToSrgbImage(PixelContainer src) {
+        return mapPixels(src, (r, g, b, a) -> new int[]{
+            encode(r / 255.0),
+            encode(g / 255.0),
+            encode(b / 255.0),
+            a
+        });
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* 1-D LUTs.                                                           */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * Apply a per-channel 1-D LUT. Each byte of R, G, B is replaced by
+     * the corresponding LUT entry. Alpha is untouched.
+     *
+     * <p>LUTs must be 256 bytes each.</p>
+     */
+    public static PixelContainer applyLut1dU8(PixelContainer src, byte[] lutR, byte[] lutG, byte[] lutB) {
+        return mapPixels(src, (r, g, b, a) -> new int[]{
+            lutR[r] & 0xFF,
+            lutG[g] & 0xFF,
+            lutB[b] & 0xFF,
+            a
+        });
+    }
+
+    /**
+     * Build a 256-entry LUT that applies {@code f} in linear light.
+     * {@code lut[i] = encode(f(decode(i)))}. Handy for precomputing any
+     * monotone tonal curve and then applying it cheaply.
+     */
+    public static byte[] buildLut1dU8(DoubleUnaryOperator f) {
+        byte[] lut = new byte[256];
+        for (int i = 0; i < 256; i++) {
+            double y = f.applyAsDouble(decode(i));
+            lut[i] = (byte) encode(y);
+        }
+        return lut;
+    }
+
+    /** Convenience: build a LUT for {@code x -> x^g}, i.e. a gamma curve. */
+    public static byte[] buildGammaLut(double g) {
+        return buildLut1dU8(x -> Math.pow(x, g));
+    }
+}

--- a/code/packages/java/image-point-ops/src/main/java/com/codingadventures/imagepointops/ImagePointOps.java
+++ b/code/packages/java/image-point-ops/src/main/java/com/codingadventures/imagepointops/ImagePointOps.java
@@ -413,6 +413,8 @@ public final class ImagePointOps {
      * <p>LUTs must be 256 bytes each.</p>
      */
     public static PixelContainer applyLut1dU8(PixelContainer src, byte[] lutR, byte[] lutG, byte[] lutB) {
+        if (lutR.length < 256 || lutG.length < 256 || lutB.length < 256)
+            throw new IllegalArgumentException("Each LUT must have at least 256 entries");
         return mapPixels(src, (r, g, b, a) -> new int[]{
             lutR[r] & 0xFF,
             lutG[g] & 0xFF,

--- a/code/packages/java/image-point-ops/src/test/java/com/codingadventures/imagepointops/ImagePointOpsTest.java
+++ b/code/packages/java/image-point-ops/src/test/java/com/codingadventures/imagepointops/ImagePointOpsTest.java
@@ -1,0 +1,352 @@
+package com.codingadventures.imagepointops;
+
+import com.codingadventures.pixelcontainer.PixelContainer;
+import com.codingadventures.pixelcontainer.PixelOps;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ImagePointOpsTest {
+
+    /** Helper: a single-pixel container for tight checks. */
+    private static PixelContainer single(int r, int g, int b, int a) {
+        PixelContainer c = PixelOps.create(1, 1);
+        PixelOps.setPixel(c, 0, 0, r, g, b, a);
+        return c;
+    }
+
+    private static int[] px(PixelContainer c, int x, int y) {
+        return PixelOps.pixelAt(c, x, y);
+    }
+
+    /* ---------------- u8-domain ---------------- */
+
+    @Test
+    void invertBasic() {
+        PixelContainer out = ImagePointOps.invert(single(10, 20, 30, 128));
+        assertArrayEquals(new int[]{245, 235, 225, 128}, px(out, 0, 0));
+    }
+
+    @Test
+    void invertExtremes() {
+        PixelContainer out = ImagePointOps.invert(single(0, 255, 128, 255));
+        assertArrayEquals(new int[]{255, 0, 127, 255}, px(out, 0, 0));
+    }
+
+    @Test
+    void invertPreservesDimensions() {
+        PixelContainer src = PixelOps.create(4, 3);
+        PixelContainer out = ImagePointOps.invert(src);
+        assertEquals(4, out.width);
+        assertEquals(3, out.height);
+    }
+
+    @Test
+    void thresholdBelow() {
+        PixelContainer out = ImagePointOps.threshold(single(50, 50, 50, 255), 128);
+        assertArrayEquals(new int[]{0, 0, 0, 255}, px(out, 0, 0));
+    }
+
+    @Test
+    void thresholdAbove() {
+        PixelContainer out = ImagePointOps.threshold(single(200, 200, 200, 255), 128);
+        assertArrayEquals(new int[]{255, 255, 255, 255}, px(out, 0, 0));
+    }
+
+    @Test
+    void thresholdLuminanceIsPerceptual() {
+        // Pure green is brighter perceptually (Y=0.7152*255≈182) than mean-equivalent.
+        PixelContainer out = ImagePointOps.thresholdLuminance(single(0, 255, 0, 255), 150);
+        assertArrayEquals(new int[]{255, 255, 255, 255}, px(out, 0, 0));
+    }
+
+    @Test
+    void thresholdLuminanceBlueFails() {
+        // Pure blue has very low luminance (Y=0.0722*255≈18).
+        PixelContainer out = ImagePointOps.thresholdLuminance(single(0, 0, 255, 255), 50);
+        assertArrayEquals(new int[]{0, 0, 0, 255}, px(out, 0, 0));
+    }
+
+    @Test
+    void posterizeTwoLevels() {
+        PixelContainer out = ImagePointOps.posterize(single(100, 200, 10, 255), 2);
+        // step = 255, so each channel rounds to 0 or 255
+        int[] p = px(out, 0, 0);
+        for (int i = 0; i < 3; i++) assertTrue(p[i] == 0 || p[i] == 255);
+    }
+
+    @Test
+    void posterizeIdentityAt256Levels() {
+        PixelContainer out = ImagePointOps.posterize(single(42, 142, 242, 255), 256);
+        assertArrayEquals(new int[]{42, 142, 242, 255}, px(out, 0, 0));
+    }
+
+    @Test
+    void posterizeMinimumLevels() {
+        // levels < 2 should clamp to 2.
+        PixelContainer out = ImagePointOps.posterize(single(100, 200, 10, 255), 1);
+        int[] p = px(out, 0, 0);
+        for (int i = 0; i < 3; i++) assertTrue(p[i] == 0 || p[i] == 255);
+    }
+
+    @Test
+    void swapRgbBgr() {
+        PixelContainer out = ImagePointOps.swapRgbBgr(single(1, 2, 3, 4));
+        assertArrayEquals(new int[]{3, 2, 1, 4}, px(out, 0, 0));
+    }
+
+    @Test
+    void extractChannelRed() {
+        PixelContainer out = ImagePointOps.extractChannel(single(10, 20, 30, 40), 0);
+        assertArrayEquals(new int[]{10, 10, 10, 255}, px(out, 0, 0));
+    }
+
+    @Test
+    void extractChannelGreen() {
+        PixelContainer out = ImagePointOps.extractChannel(single(10, 20, 30, 40), 1);
+        assertArrayEquals(new int[]{20, 20, 20, 255}, px(out, 0, 0));
+    }
+
+    @Test
+    void extractChannelBlue() {
+        PixelContainer out = ImagePointOps.extractChannel(single(10, 20, 30, 40), 2);
+        assertArrayEquals(new int[]{30, 30, 30, 255}, px(out, 0, 0));
+    }
+
+    @Test
+    void extractChannelAlpha() {
+        PixelContainer out = ImagePointOps.extractChannel(single(10, 20, 30, 40), 3);
+        assertArrayEquals(new int[]{40, 40, 40, 255}, px(out, 0, 0));
+    }
+
+    @Test
+    void extractChannelInvalidReturnsZero() {
+        PixelContainer out = ImagePointOps.extractChannel(single(10, 20, 30, 40), 9);
+        assertArrayEquals(new int[]{0, 0, 0, 255}, px(out, 0, 0));
+    }
+
+    @Test
+    void brightnessPositiveClamps() {
+        PixelContainer out = ImagePointOps.brightness(single(200, 100, 50, 255), 100);
+        assertArrayEquals(new int[]{255, 200, 150, 255}, px(out, 0, 0));
+    }
+
+    @Test
+    void brightnessNegativeClamps() {
+        PixelContainer out = ImagePointOps.brightness(single(200, 100, 50, 255), -100);
+        assertArrayEquals(new int[]{100, 0, 0, 255}, px(out, 0, 0));
+    }
+
+    /* ---------------- linear-light ---------------- */
+
+    @Test
+    void contrastIdentityAtZero() {
+        PixelContainer out = ImagePointOps.contrast(single(100, 128, 200, 255), 0);
+        int[] p = px(out, 0, 0);
+        // f=1 so output equals input for each channel.
+        assertEquals(100, p[0]);
+        assertEquals(128, p[1]);
+        assertEquals(200, p[2]);
+    }
+
+    @Test
+    void contrastIncreaseStretchesAwayFrom128() {
+        PixelContainer out = ImagePointOps.contrast(single(100, 128, 200, 255), 100);
+        int[] p = px(out, 0, 0);
+        assertTrue(p[0] < 100);   // darks get darker
+        assertEquals(128, p[1]);  // midpoint unchanged
+        assertTrue(p[2] > 200);   // brights get brighter
+    }
+
+    @Test
+    void gammaIdentity() {
+        PixelContainer out = ImagePointOps.gamma(single(100, 150, 200, 255), 1.0);
+        int[] p = px(out, 0, 0);
+        for (int i = 0; i < 3; i++) assertTrue(Math.abs(p[i] - new int[]{100,150,200,255}[i]) <= 1);
+    }
+
+    @Test
+    void gammaDarkenMidtones() {
+        PixelContainer out = ImagePointOps.gamma(single(128, 128, 128, 255), 2.0);
+        // g>1 in linear space darkens midtones.
+        assertTrue(px(out, 0, 0)[0] < 128);
+    }
+
+    @Test
+    void exposureZeroIsIdentity() {
+        PixelContainer out = ImagePointOps.exposure(single(100, 150, 200, 255), 0);
+        int[] p = px(out, 0, 0);
+        for (int i = 0; i < 3; i++) assertTrue(Math.abs(p[i] - new int[]{100,150,200,255}[i]) <= 1);
+    }
+
+    @Test
+    void exposurePositiveBrightens() {
+        PixelContainer out = ImagePointOps.exposure(single(50, 50, 50, 255), 1.0);
+        assertTrue(px(out, 0, 0)[0] > 50);
+    }
+
+    @Test
+    void exposurePositiveClamps() {
+        PixelContainer out = ImagePointOps.exposure(single(200, 200, 200, 255), 5.0);
+        assertArrayEquals(new int[]{255, 255, 255, 255}, px(out, 0, 0));
+    }
+
+    @Test
+    void greyscaleRec709() {
+        // Pure red: Y = 0.2126, encoded back ~ small value.
+        PixelContainer out = ImagePointOps.greyscale(single(255, 0, 0, 255), GreyscaleMethod.REC709);
+        int[] p = px(out, 0, 0);
+        assertEquals(p[0], p[1]);
+        assertEquals(p[1], p[2]);
+        assertTrue(p[0] > 50 && p[0] < 170);
+    }
+
+    @Test
+    void greyscaleBt601DifferentFromRec709() {
+        PixelContainer r1 = ImagePointOps.greyscale(single(255, 0, 0, 255), GreyscaleMethod.REC709);
+        PixelContainer r2 = ImagePointOps.greyscale(single(255, 0, 0, 255), GreyscaleMethod.BT601);
+        assertNotEquals(px(r1, 0, 0)[0], px(r2, 0, 0)[0]);
+    }
+
+    @Test
+    void greyscaleAverage() {
+        PixelContainer out = ImagePointOps.greyscale(single(255, 255, 255, 255), GreyscaleMethod.AVERAGE);
+        assertEquals(255, px(out, 0, 0)[0]);
+    }
+
+    @Test
+    void sepiaWhiteBecomesWarm() {
+        PixelContainer out = ImagePointOps.sepia(single(255, 255, 255, 255));
+        int[] p = px(out, 0, 0);
+        // sepia matrix rows sum: r=1.351, g=1.203, b=0.937 → R clamps, G clamps, B doesn't.
+        assertEquals(255, p[0]);
+        assertEquals(255, p[1]);
+        assertTrue(p[2] < 255);
+    }
+
+    @Test
+    void colourMatrixIdentity() {
+        double[][] id = { {1,0,0}, {0,1,0}, {0,0,1} };
+        PixelContainer out = ImagePointOps.colourMatrix(single(100, 150, 200, 255), id);
+        int[] p = px(out, 0, 0);
+        for (int i = 0; i < 3; i++) assertTrue(Math.abs(p[i] - new int[]{100,150,200,255}[i]) <= 1);
+    }
+
+    @Test
+    void saturateZeroGivesGrey() {
+        PixelContainer out = ImagePointOps.saturate(single(200, 50, 10, 255), 0.0);
+        int[] p = px(out, 0, 0);
+        assertEquals(p[0], p[1]);
+        assertEquals(p[1], p[2]);
+    }
+
+    @Test
+    void saturateIdentityAtOne() {
+        PixelContainer out = ImagePointOps.saturate(single(100, 150, 200, 255), 1.0);
+        int[] p = px(out, 0, 0);
+        for (int i = 0; i < 3; i++) assertTrue(Math.abs(p[i] - new int[]{100,150,200,255}[i]) <= 1);
+    }
+
+    @Test
+    void hueRotate360IsIdentity() {
+        PixelContainer out = ImagePointOps.hueRotate(single(200, 50, 10, 255), 360);
+        int[] p = px(out, 0, 0);
+        for (int i = 0; i < 3; i++) assertTrue(Math.abs(p[i] - new int[]{200,50,10,255}[i]) <= 2);
+    }
+
+    @Test
+    void hueRotate180InvertsHue() {
+        // Red rotated 180 → cyan-ish.
+        PixelContainer out = ImagePointOps.hueRotate(single(255, 0, 0, 255), 180);
+        int[] p = px(out, 0, 0);
+        assertTrue(p[0] < p[1] || p[0] < p[2]);
+    }
+
+    @Test
+    void hueRotateNegative() {
+        // -120 should wrap to 240 and produce same result as +240.
+        PixelContainer a = ImagePointOps.hueRotate(single(255, 0, 0, 255), -120);
+        PixelContainer b = ImagePointOps.hueRotate(single(255, 0, 0, 255), 240);
+        int[] pa = px(a, 0, 0), pb = px(b, 0, 0);
+        for (int i = 0; i < 3; i++) assertTrue(Math.abs(pa[i] - pb[i]) <= 2);
+    }
+
+    @Test
+    void hueRotateGreyscaleUnchanged() {
+        // Saturation 0 → hue rotation should not change the colour.
+        PixelContainer out = ImagePointOps.hueRotate(single(128, 128, 128, 255), 90);
+        int[] p = px(out, 0, 0);
+        assertEquals(p[0], p[1]);
+        assertEquals(p[1], p[2]);
+    }
+
+    /* ---------------- whole-image sRGB ↔ linear ---------------- */
+
+    @Test
+    void srgbToLinearRoundTripApproximate() {
+        PixelContainer src = single(100, 150, 200, 255);
+        PixelContainer lin = ImagePointOps.srgbToLinearImage(src);
+        PixelContainer back = ImagePointOps.linearToSrgbImage(lin);
+        int[] p = px(back, 0, 0);
+        // Quantisation through 8-bit midtones loses a little precision.
+        for (int i = 0; i < 3; i++) assertTrue(Math.abs(p[i] - new int[]{100,150,200,255}[i]) <= 3);
+    }
+
+    /* ---------------- LUTs ---------------- */
+
+    @Test
+    void applyLut1dU8Identity() {
+        byte[] lut = new byte[256];
+        for (int i = 0; i < 256; i++) lut[i] = (byte) i;
+        PixelContainer out = ImagePointOps.applyLut1dU8(single(10, 20, 30, 40), lut, lut, lut);
+        assertArrayEquals(new int[]{10, 20, 30, 40}, px(out, 0, 0));
+    }
+
+    @Test
+    void applyLut1dU8Inverts() {
+        byte[] lut = new byte[256];
+        for (int i = 0; i < 256; i++) lut[i] = (byte) (255 - i);
+        PixelContainer out = ImagePointOps.applyLut1dU8(single(10, 20, 30, 40), lut, lut, lut);
+        assertArrayEquals(new int[]{245, 235, 225, 40}, px(out, 0, 0));
+    }
+
+    @Test
+    void buildLut1dU8Monotone() {
+        byte[] lut = ImagePointOps.buildLut1dU8(x -> x); // identity in linear
+        // Identity through decode/encode should approximately round-trip.
+        for (int i = 0; i < 256; i++) {
+            int v = lut[i] & 0xFF;
+            assertTrue(Math.abs(v - i) <= 1, "LUT[" + i + "] off: " + v);
+        }
+    }
+
+    @Test
+    void buildGammaLutIsDecreasing() {
+        byte[] lut = ImagePointOps.buildGammaLut(2.0);
+        // Gamma 2.0 in linear darkens, so LUT values should mostly be below input.
+        int below = 0;
+        for (int i = 1; i < 256; i++) if ((lut[i] & 0xFF) <= i) below++;
+        assertTrue(below > 200);
+    }
+
+    /* ---------------- multi-pixel correctness ---------------- */
+
+    @Test
+    void appliesToEveryPixel() {
+        PixelContainer src = PixelOps.create(3, 2);
+        for (int y = 0; y < 2; y++)
+            for (int x = 0; x < 3; x++)
+                PixelOps.setPixel(src, x, y, 10, 20, 30, 255);
+        PixelContainer out = ImagePointOps.invert(src);
+        for (int y = 0; y < 2; y++)
+            for (int x = 0; x < 3; x++)
+                assertArrayEquals(new int[]{245, 235, 225, 255}, px(out, x, y));
+    }
+
+    @Test
+    void doesNotMutateInput() {
+        PixelContainer src = single(10, 20, 30, 40);
+        ImagePointOps.invert(src);
+        assertArrayEquals(new int[]{10, 20, 30, 40}, px(src, 0, 0));
+    }
+}

--- a/code/packages/java/pixel-container/.gitignore
+++ b/code/packages/java/pixel-container/.gitignore
@@ -1,0 +1,2 @@
+gradle-build/
+.gradle/

--- a/code/packages/java/pixel-container/BUILD
+++ b/code/packages/java/pixel-container/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/pixel-container/BUILD_windows
+++ b/code/packages/java/pixel-container/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/pixel-container/CHANGELOG.md
+++ b/code/packages/java/pixel-container/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Add initial Java `pixel-container` package (IC00)
+- Provide `PixelContainer` RGBA8 buffer with row-major top-left layout
+- Provide `PixelOps` static helpers: `create`, `pixelAt`, `setPixel`, `fillPixels`
+- Provide `ImageCodec` interface for pluggable image encoders/decoders

--- a/code/packages/java/pixel-container/README.md
+++ b/code/packages/java/pixel-container/README.md
@@ -1,0 +1,48 @@
+# Java Pixel Container
+
+IC00 — the zero-dependency foundation of the coding-adventures image
+processing stack. Every image codec, point operation, geometric transform,
+and compositing stage builds on this one class.
+
+## What it provides
+
+- `PixelContainer` — a flat RGBA8 pixel buffer with `width`, `height`, and
+  a `byte[]` of pixels laid out row-major from the top-left.
+- `PixelOps` — static helpers to read, write, and fill pixels, plus a
+  convenience `create(width, height)` factory.
+- `ImageCodec` — the abstract interface every image codec (PNG, JPEG,
+  BMP, …) implements: `mimeType()`, `encode`, and `decode`.
+
+## Layout
+
+```
+offset = (y * width + x) * 4
+data[offset + 0] = R
+data[offset + 1] = G
+data[offset + 2] = B
+data[offset + 3] = A
+```
+
+All channels are unsigned 8-bit. The format is fixed by design — higher
+layers decode/encode to this universal representation.
+
+## Usage
+
+```java
+import com.codingadventures.pixelcontainer.PixelContainer;
+import com.codingadventures.pixelcontainer.PixelOps;
+
+PixelContainer img = PixelOps.create(16, 16);
+PixelOps.fillPixels(img, 255, 0, 0, 255);   // solid red
+PixelOps.setPixel(img, 0, 0, 0, 255, 0, 255); // one green pixel
+int[] rgba = PixelOps.pixelAt(img, 0, 0);
+```
+
+## Place in the stack
+
+| Layer | Depends on                |
+|-------|---------------------------|
+| IC00  | nothing                   |
+| IMG03 | IC00                      |
+| IMG04 | IC00                      |
+| PNG, JPEG, BMP codecs | IC00 (via ImageCodec) |

--- a/code/packages/java/pixel-container/build.gradle.kts
+++ b/code/packages/java/pixel-container/build.gradle.kts
@@ -1,0 +1,28 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/pixel-container/settings.gradle.kts
+++ b/code/packages/java/pixel-container/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "pixel-container"

--- a/code/packages/java/pixel-container/src/main/java/com/codingadventures/pixelcontainer/ImageCodec.java
+++ b/code/packages/java/pixel-container/src/main/java/com/codingadventures/pixelcontainer/ImageCodec.java
@@ -1,0 +1,32 @@
+package com.codingadventures.pixelcontainer;
+
+/**
+ * Abstract codec interface for encoding and decoding {@link PixelContainer}s.
+ *
+ * <p>Every image format (PNG, JPEG, BMP, WebP, …) that wants to interoperate
+ * with the coding-adventures image stack implements this three-method
+ * contract. Nothing in the core pixel container depends on any concrete
+ * codec, so adding a new format never forces a recompile of consumers.</p>
+ *
+ * <h2>Contract</h2>
+ * <ul>
+ *   <li>{@link #encode} serializes a PixelContainer to the format's byte
+ *       layout (e.g. a full PNG file).</li>
+ *   <li>{@link #decode} parses those bytes back to RGBA8.</li>
+ *   <li>{@link #mimeType} returns the canonical MIME string, used by
+ *       HTTP layers and registries that route by type.</li>
+ * </ul>
+ *
+ * <p>Implementations should be stateless and thread-safe where possible,
+ * so callers can share a single instance across threads.</p>
+ */
+public interface ImageCodec {
+    /** Canonical MIME type for this format, e.g. {@code "image/png"}. */
+    String mimeType();
+
+    /** Serialize the container into the format's on-disk byte layout. */
+    byte[] encode(PixelContainer container);
+
+    /** Parse bytes back into a fresh RGBA8 PixelContainer. */
+    PixelContainer decode(byte[] data);
+}

--- a/code/packages/java/pixel-container/src/main/java/com/codingadventures/pixelcontainer/PixelContainer.java
+++ b/code/packages/java/pixel-container/src/main/java/com/codingadventures/pixelcontainer/PixelContainer.java
@@ -1,0 +1,89 @@
+package com.codingadventures.pixelcontainer;
+
+/**
+ * IC00 — Universal RGBA8 Pixel Buffer.
+ *
+ * <p>PixelContainer is the zero-dependency foundation for the
+ * coding-adventures image processing stack. Every image codec and
+ * processing stage depends only on this class, never on a specific file
+ * format or library.</p>
+ *
+ * <h2>Why RGBA8, always?</h2>
+ * <p>The image stack deals with many formats — PNG, JPEG, BMP, GIF, WebP —
+ * each with its own quirks (palettes, grayscale, 16-bit channels, pre- vs
+ * post-multiplied alpha). Forcing every producer to decode down to a single
+ * canonical format means consumers never care where the pixels came from.
+ * RGBA8 was chosen because:</p>
+ * <ul>
+ *   <li>It's the overwhelmingly common screen representation, so rendering
+ *       is trivial.</li>
+ *   <li>It handles transparency, which the simpler RGB8 does not.</li>
+ *   <li>8 bits per channel is universally supported by every codec.</li>
+ * </ul>
+ *
+ * <h2>Layout</h2>
+ * <p>Pixels are stored row-major, top-left origin, RGBA interleaved:</p>
+ * <pre>
+ *   offset = (y * width + x) * 4
+ *   data[offset + 0] = R
+ *   data[offset + 1] = G
+ *   data[offset + 2] = B
+ *   data[offset + 3] = A
+ * </pre>
+ *
+ * <h2>Why public fields?</h2>
+ * <p>The container is a dumb data carrier — tight inner loops in point
+ * operations and geometric transforms benefit from direct field access
+ * (e.g. Hotspot can hoist {@code c.width} out of loop bodies easily). The
+ * trade-off is immutability is not enforced at the JVM level; we rely on
+ * discipline: codecs create containers once, processing stages produce
+ * new containers rather than mutating inputs.</p>
+ */
+public final class PixelContainer {
+    /** Image width in pixels. Never negative. */
+    public final int width;
+
+    /** Image height in pixels. Never negative. */
+    public final int height;
+
+    /**
+     * Flat RGBA8 byte buffer, length {@code width * height * 4}.
+     *
+     * <p>Bytes are <em>unsigned</em> in meaning, even though Java's
+     * {@code byte} is signed. Readers must mask with {@code & 0xFF} to get
+     * the intended 0..255 value.</p>
+     */
+    public final byte[] data;
+
+    /**
+     * Create a new container filled with transparent black (0, 0, 0, 0).
+     *
+     * <p>Java initialises byte arrays to zero, which happens to be our
+     * desired "empty" value — no extra work needed.</p>
+     *
+     * @param width  image width in pixels
+     * @param height image height in pixels
+     */
+    public PixelContainer(int width, int height) {
+        this.width = width;
+        this.height = height;
+        this.data = new byte[width * height * 4];
+    }
+
+    /**
+     * Create a container wrapping an existing byte buffer. Used by codecs
+     * that decode directly into a caller-supplied array, avoiding a copy.
+     *
+     * <p>The caller is responsible for ensuring {@code data.length ==
+     * width * height * 4}.</p>
+     *
+     * @param width  image width in pixels
+     * @param height image height in pixels
+     * @param data   backing RGBA8 buffer (not copied, not validated)
+     */
+    public PixelContainer(int width, int height, byte[] data) {
+        this.width = width;
+        this.height = height;
+        this.data = data;
+    }
+}

--- a/code/packages/java/pixel-container/src/main/java/com/codingadventures/pixelcontainer/PixelContainer.java
+++ b/code/packages/java/pixel-container/src/main/java/com/codingadventures/pixelcontainer/PixelContainer.java
@@ -65,9 +65,15 @@ public final class PixelContainer {
      * @param height image height in pixels
      */
     public PixelContainer(int width, int height) {
+        if (width < 0 || height < 0)
+            throw new IllegalArgumentException("Dimensions must be non-negative");
+        long size = (long) width * height * 4;
+        if (size > Integer.MAX_VALUE)
+            throw new IllegalArgumentException(
+                "Image too large: " + width + "×" + height + " exceeds 32-bit index range");
         this.width = width;
         this.height = height;
-        this.data = new byte[width * height * 4];
+        this.data = new byte[(int) size];
     }
 
     /**

--- a/code/packages/java/pixel-container/src/main/java/com/codingadventures/pixelcontainer/PixelOps.java
+++ b/code/packages/java/pixel-container/src/main/java/com/codingadventures/pixelcontainer/PixelOps.java
@@ -1,0 +1,100 @@
+package com.codingadventures.pixelcontainer;
+
+/**
+ * Static helpers for reading and writing pixels in a {@link PixelContainer}.
+ *
+ * <p>These utilities deliberately do <em>not</em> live as instance methods on
+ * PixelContainer because the container is meant to be a zero-behaviour data
+ * carrier. Behaviour (including ops that tempt reflection, subclassing, or
+ * mocking) lives in free functions that can be composed and tested in
+ * isolation.</p>
+ *
+ * <h2>Out-of-bounds policy</h2>
+ * <p>Reads return transparent black ({@code {0,0,0,0}}) for any
+ * {@code (x, y)} outside the image. Writes silently no-op. This "clamp to
+ * empty" convention is chosen over throwing exceptions because point and
+ * geometric operations frequently sample just outside the canvas, and
+ * throwing would force every caller to pre-check.</p>
+ */
+public final class PixelOps {
+    private PixelOps() {}
+
+    /**
+     * Factory: create a new PixelContainer filled with transparent
+     * black (0, 0, 0, 0).
+     *
+     * <p>Provided for callers that prefer a factory style over
+     * {@code new PixelContainer(w, h)}.</p>
+     *
+     * @param width  image width in pixels
+     * @param height image height in pixels
+     * @return a fresh container backed by a zeroed byte array
+     */
+    public static PixelContainer create(int width, int height) {
+        return new PixelContainer(width, height);
+    }
+
+    /**
+     * Read the RGBA components at {@code (x, y)}.
+     *
+     * <p>Returns a freshly allocated 4-int array {@code {R, G, B, A}} with
+     * each channel in {@code 0..255}. Out-of-bounds reads return
+     * {@code {0, 0, 0, 0}} — transparent black — rather than throwing.</p>
+     *
+     * <p>Why int[] and not a Pixel record? Hotspot inlines the array access
+     * extremely well, and a 4-int array lets the caller mutate/reuse values
+     * without boxing.</p>
+     *
+     * @return RGBA quad; {@code {0,0,0,0}} if {@code (x,y)} is outside
+     */
+    public static int[] pixelAt(PixelContainer c, int x, int y) {
+        if (x < 0 || x >= c.width || y < 0 || y >= c.height) {
+            return new int[]{0, 0, 0, 0};
+        }
+        int i = (y * c.width + x) * 4;
+        return new int[]{
+            c.data[i]     & 0xFF,
+            c.data[i + 1] & 0xFF,
+            c.data[i + 2] & 0xFF,
+            c.data[i + 3] & 0xFF
+        };
+    }
+
+    /**
+     * Write an RGBA pixel at {@code (x, y)}. No-op for out-of-bounds
+     * coordinates, matching the "clamp to empty" read policy.
+     *
+     * <p>Each channel value is masked to 8 bits before storing, so callers
+     * may pass values up to 32 bits without corrupting neighbouring
+     * channels.</p>
+     */
+    public static void setPixel(PixelContainer c, int x, int y, int r, int g, int b, int a) {
+        if (x < 0 || x >= c.width || y < 0 || y >= c.height) return;
+        int i = (y * c.width + x) * 4;
+        c.data[i]     = (byte) (r & 0xFF);
+        c.data[i + 1] = (byte) (g & 0xFF);
+        c.data[i + 2] = (byte) (b & 0xFF);
+        c.data[i + 3] = (byte) (a & 0xFF);
+    }
+
+    /**
+     * Fill every pixel of the container with the given RGBA colour.
+     *
+     * <p>Implemented as a tight loop over interleaved bytes rather than
+     * delegating to {@link #setPixel} per pixel — avoids per-call bounds
+     * checks and {@code y*width+x} arithmetic that the fill case doesn't
+     * need.</p>
+     */
+    public static void fillPixels(PixelContainer c, int r, int g, int b, int a) {
+        byte rb = (byte) (r & 0xFF);
+        byte gb = (byte) (g & 0xFF);
+        byte bb = (byte) (b & 0xFF);
+        byte ab = (byte) (a & 0xFF);
+        for (int i = 0; i < c.data.length; i += 4) {
+            c.data[i]     = rb;
+            c.data[i + 1] = gb;
+            c.data[i + 2] = bb;
+            c.data[i + 3] = ab;
+        }
+    }
+}

--- a/code/packages/java/pixel-container/src/test/java/com/codingadventures/pixelcontainer/PixelContainerTest.java
+++ b/code/packages/java/pixel-container/src/test/java/com/codingadventures/pixelcontainer/PixelContainerTest.java
@@ -1,0 +1,194 @@
+package com.codingadventures.pixelcontainer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests cover container construction, the full read/write surface, edge
+ * cases (out-of-bounds, zero-size, large values), and the {@link ImageCodec}
+ * interface contract via a stub implementation.
+ */
+class PixelContainerTest {
+
+    @Test
+    void constructorZeroesData() {
+        PixelContainer c = new PixelContainer(3, 2);
+        assertEquals(3, c.width);
+        assertEquals(2, c.height);
+        assertEquals(3 * 2 * 4, c.data.length);
+        for (byte b : c.data) assertEquals(0, b);
+    }
+
+    @Test
+    void constructorWithDataWrapsArray() {
+        byte[] raw = new byte[16];
+        raw[0] = 1; raw[1] = 2; raw[2] = 3; raw[3] = 4;
+        PixelContainer c = new PixelContainer(2, 2, raw);
+        assertSame(raw, c.data);
+        assertEquals(2, c.width);
+        assertEquals(2, c.height);
+    }
+
+    @Test
+    void factoryCreatesTransparentBlack() {
+        PixelContainer c = PixelOps.create(4, 4);
+        assertEquals(64, c.data.length);
+        int[] px = PixelOps.pixelAt(c, 0, 0);
+        assertArrayEquals(new int[]{0, 0, 0, 0}, px);
+    }
+
+    @Test
+    void setPixelThenReadRoundTrip() {
+        PixelContainer c = PixelOps.create(2, 2);
+        PixelOps.setPixel(c, 1, 1, 10, 20, 30, 40);
+        assertArrayEquals(new int[]{10, 20, 30, 40}, PixelOps.pixelAt(c, 1, 1));
+    }
+
+    @Test
+    void setPixelMasksChannelValues() {
+        PixelContainer c = PixelOps.create(1, 1);
+        PixelOps.setPixel(c, 0, 0, 0x1FF, 0x2AA, 0x355, 0xFFF);
+        assertArrayEquals(new int[]{0xFF, 0xAA, 0x55, 0xFF}, PixelOps.pixelAt(c, 0, 0));
+    }
+
+    @Test
+    void setPixelHandlesFullUnsignedRange() {
+        PixelContainer c = PixelOps.create(1, 1);
+        PixelOps.setPixel(c, 0, 0, 255, 255, 255, 255);
+        assertArrayEquals(new int[]{255, 255, 255, 255}, PixelOps.pixelAt(c, 0, 0));
+    }
+
+    @Test
+    void pixelAtOutOfBoundsNegativeX() {
+        PixelContainer c = PixelOps.create(2, 2);
+        assertArrayEquals(new int[]{0, 0, 0, 0}, PixelOps.pixelAt(c, -1, 0));
+    }
+
+    @Test
+    void pixelAtOutOfBoundsNegativeY() {
+        PixelContainer c = PixelOps.create(2, 2);
+        assertArrayEquals(new int[]{0, 0, 0, 0}, PixelOps.pixelAt(c, 0, -1));
+    }
+
+    @Test
+    void pixelAtOutOfBoundsXTooLarge() {
+        PixelContainer c = PixelOps.create(2, 2);
+        assertArrayEquals(new int[]{0, 0, 0, 0}, PixelOps.pixelAt(c, 2, 0));
+    }
+
+    @Test
+    void pixelAtOutOfBoundsYTooLarge() {
+        PixelContainer c = PixelOps.create(2, 2);
+        assertArrayEquals(new int[]{0, 0, 0, 0}, PixelOps.pixelAt(c, 0, 2));
+    }
+
+    @Test
+    void setPixelOutOfBoundsIsNoOp() {
+        PixelContainer c = PixelOps.create(2, 2);
+        PixelOps.setPixel(c, -1, 0, 1, 2, 3, 4);
+        PixelOps.setPixel(c, 0, -1, 1, 2, 3, 4);
+        PixelOps.setPixel(c, 2, 0, 1, 2, 3, 4);
+        PixelOps.setPixel(c, 0, 2, 1, 2, 3, 4);
+        for (byte b : c.data) assertEquals(0, b);
+    }
+
+    @Test
+    void fillPixelsFillsEveryPixel() {
+        PixelContainer c = PixelOps.create(3, 3);
+        PixelOps.fillPixels(c, 200, 100, 50, 255);
+        for (int y = 0; y < 3; y++) {
+            for (int x = 0; x < 3; x++) {
+                assertArrayEquals(new int[]{200, 100, 50, 255}, PixelOps.pixelAt(c, x, y));
+            }
+        }
+    }
+
+    @Test
+    void fillPixelsMasksToByte() {
+        PixelContainer c = PixelOps.create(1, 1);
+        PixelOps.fillPixels(c, 0x1FF, 0x200, 0x3AB, 0x4CD);
+        assertArrayEquals(new int[]{0xFF, 0x00, 0xAB, 0xCD}, PixelOps.pixelAt(c, 0, 0));
+    }
+
+    @Test
+    void zeroSizeContainer() {
+        PixelContainer c = PixelOps.create(0, 0);
+        assertEquals(0, c.data.length);
+        assertArrayEquals(new int[]{0, 0, 0, 0}, PixelOps.pixelAt(c, 0, 0));
+    }
+
+    @Test
+    void writeDoesNotBleedIntoNeighbours() {
+        PixelContainer c = PixelOps.create(3, 1);
+        PixelOps.setPixel(c, 1, 0, 100, 150, 200, 250);
+        assertArrayEquals(new int[]{0, 0, 0, 0},       PixelOps.pixelAt(c, 0, 0));
+        assertArrayEquals(new int[]{100, 150, 200, 250}, PixelOps.pixelAt(c, 1, 0));
+        assertArrayEquals(new int[]{0, 0, 0, 0},       PixelOps.pixelAt(c, 2, 0));
+    }
+
+    @Test
+    void rowMajorOrdering() {
+        PixelContainer c = PixelOps.create(2, 2);
+        // byte indices 0..3 = pixel (0,0), 4..7 = (1,0), 8..11 = (0,1), 12..15 = (1,1)
+        c.data[8] = (byte) 255;
+        assertArrayEquals(new int[]{255, 0, 0, 0}, PixelOps.pixelAt(c, 0, 1));
+    }
+
+    @Test
+    void overwriteExistingPixel() {
+        PixelContainer c = PixelOps.create(1, 1);
+        PixelOps.setPixel(c, 0, 0, 1, 2, 3, 4);
+        PixelOps.setPixel(c, 0, 0, 10, 20, 30, 40);
+        assertArrayEquals(new int[]{10, 20, 30, 40}, PixelOps.pixelAt(c, 0, 0));
+    }
+
+    @Test
+    void fillOverwritesPriorWrites() {
+        PixelContainer c = PixelOps.create(2, 2);
+        PixelOps.setPixel(c, 0, 0, 1, 2, 3, 4);
+        PixelOps.fillPixels(c, 9, 9, 9, 9);
+        assertArrayEquals(new int[]{9, 9, 9, 9}, PixelOps.pixelAt(c, 0, 0));
+    }
+
+    @Test
+    void dataLengthMatchesDimensions() {
+        PixelContainer c = PixelOps.create(7, 5);
+        assertEquals(7 * 5 * 4, c.data.length);
+    }
+
+    @Test
+    void rectangularShapesWorkBothWays() {
+        PixelContainer wide = PixelOps.create(5, 1);
+        PixelContainer tall = PixelOps.create(1, 5);
+        PixelOps.setPixel(wide, 4, 0, 1, 2, 3, 4);
+        PixelOps.setPixel(tall, 0, 4, 1, 2, 3, 4);
+        assertArrayEquals(new int[]{1, 2, 3, 4}, PixelOps.pixelAt(wide, 4, 0));
+        assertArrayEquals(new int[]{1, 2, 3, 4}, PixelOps.pixelAt(tall, 0, 4));
+    }
+
+    @Test
+    void imageCodecContract() {
+        ImageCodec codec = new ImageCodec() {
+            public String mimeType() { return "image/test"; }
+            public byte[] encode(PixelContainer c) { return c.data.clone(); }
+            public PixelContainer decode(byte[] data) {
+                return new PixelContainer(1, data.length / 4, data);
+            }
+        };
+        PixelContainer c = PixelOps.create(1, 2);
+        PixelOps.setPixel(c, 0, 1, 10, 20, 30, 40);
+        byte[] bytes = codec.encode(c);
+        PixelContainer round = codec.decode(bytes);
+        assertEquals("image/test", codec.mimeType());
+        assertArrayEquals(new int[]{10, 20, 30, 40}, PixelOps.pixelAt(round, 0, 1));
+    }
+
+    @Test
+    void fillPixelsOnZeroSize() {
+        PixelContainer c = PixelOps.create(0, 5);
+        // Width*height == 0 → no bytes to fill; should not throw.
+        PixelOps.fillPixels(c, 1, 2, 3, 4);
+        assertEquals(0, c.data.length);
+    }
+}

--- a/code/packages/kotlin/image-geometric-transforms/.gitignore
+++ b/code/packages/kotlin/image-geometric-transforms/.gitignore
@@ -1,0 +1,2 @@
+gradle-build/
+.gradle/

--- a/code/packages/kotlin/image-geometric-transforms/BUILD
+++ b/code/packages/kotlin/image-geometric-transforms/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/image-geometric-transforms/BUILD_windows
+++ b/code/packages/kotlin/image-geometric-transforms/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/image-geometric-transforms/CHANGELOG.md
+++ b/code/packages/kotlin/image-geometric-transforms/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## 0.1.0 — Initial release
+
+- Lossless transforms: `flipHorizontal`, `flipVertical`, `rotate90CW`,
+  `rotate90CCW`, `rotate180`, `crop`.
+- Continuous transforms: `scale`, `rotate`, `translate`, `affine`,
+  `perspectiveWarp`.
+- Enums: `Interpolation` (NEAREST/BILINEAR/BICUBIC),
+  `RotateBounds` (FIT/CROP), `OutOfBounds` (ZERO/REPLICATE/REFLECT/WRAP).
+- Bilinear and bicubic resampling in linear light via a 256-entry sRGB→
+  linear LUT; Catmull-Rom (B=0, C=0.5) kernel for bicubic.
+- Inverse-warp, pixel-centre sampling model.
+- `invert3x3` adjugate-method matrix inverse helper.

--- a/code/packages/kotlin/image-geometric-transforms/README.md
+++ b/code/packages/kotlin/image-geometric-transforms/README.md
@@ -1,0 +1,54 @@
+# image-geometric-transforms (Kotlin)
+
+**Spec:** IMG04 — Geometric transforms on `PixelContainer`.
+
+Flips, 90° rotations, crop, scale, arbitrary-angle rotate, translate, affine,
+and perspective warp — every operation that moves pixels rather than
+recolouring them.
+
+## What's implemented
+
+### Lossless, byte-level (no interpolation)
+
+- `flipHorizontal` / `flipVertical`
+- `rotate90CW` / `rotate90CCW` / `rotate180`
+- `crop(x, y, w, h)` — OOB areas fill transparent black
+
+### Continuous (interpolated)
+
+- `scale(w, h, interp)`
+- `rotate(radians, interp, bounds)` — `bounds` is `FIT` or `CROP`
+- `translate(tx, ty, interp)`
+- `affine(m: 2x3, interp, oob)` — `m` is forward; inverted internally
+- `perspectiveWarp(h: 3x3, interp, oob)` — `h` is the inverse map
+
+### Helpers
+
+- `invert3x3(m)` — for callers composing homographies by hand
+
+## Interpolation kernels
+
+`NEAREST`, `BILINEAR`, `BICUBIC` (Catmull-Rom, B=0 C=0.5).
+Bilinear/bicubic blend in **linear light** — sRGB bytes decoded, blended,
+re-encoded. Nearest neighbour does not blend, so it passes raw bytes.
+
+## OOB policies
+
+`ZERO`, `REPLICATE`, `REFLECT`, `WRAP`. Applied whenever a sample falls
+outside `[0, w) × [0, h)`.
+
+## Conventions
+
+- Inverse-warp / pull-based: every output pixel samples once; no holes.
+- Pixel-centre model: pixel `(x, y)` occupies `[x, x+1] × [y, y+1]`.
+  Resampling uses `u = (x' + 0.5) / sx - 0.5`.
+
+## Dependencies
+
+- `pixel-container` (IC00)
+
+## Tests
+
+```
+gradle test
+```

--- a/code/packages/kotlin/image-geometric-transforms/build.gradle.kts
+++ b/code/packages/kotlin/image-geometric-transforms/build.gradle.kts
@@ -1,0 +1,36 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    api("com.codingadventures:pixel-container")
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/image-geometric-transforms/settings.gradle.kts
+++ b/code/packages/kotlin/image-geometric-transforms/settings.gradle.kts
@@ -1,0 +1,3 @@
+rootProject.name = "image-geometric-transforms"
+
+includeBuild("../pixel-container")

--- a/code/packages/kotlin/image-geometric-transforms/src/main/kotlin/com/codingadventures/imagegeometrictransforms/ImageGeometricTransforms.kt
+++ b/code/packages/kotlin/image-geometric-transforms/src/main/kotlin/com/codingadventures/imagegeometrictransforms/ImageGeometricTransforms.kt
@@ -1,0 +1,510 @@
+package com.codingadventures.imagegeometrictransforms
+
+import com.codingadventures.pixelcontainer.PixelContainer
+import com.codingadventures.pixelcontainer.PixelOps
+import kotlin.math.abs
+import kotlin.math.ceil
+import kotlin.math.cos
+import kotlin.math.floor
+import kotlin.math.pow
+import kotlin.math.roundToInt
+import kotlin.math.sin
+
+/**
+ * IMG04 — Geometric transforms on [PixelContainer].
+ *
+ * Point ops (IMG03) change what a pixel *is*; geometric transforms change
+ * *where* a pixel is. Every transform here is a spatial warp: flips,
+ * rotations, crops, scaling, arbitrary-angle rotation, affine, perspective.
+ *
+ * ## Inverse-warp convention
+ *
+ * Every continuous transform is an **inverse warp** (pull mapping):
+ * ```
+ * for each output pixel (x', y'):
+ *     compute corresponding source coordinate (u, v)
+ *     sample the source at (u, v)
+ *     write the sample to output (x', y')
+ * ```
+ * Forward warps leave holes and need atomic writes for many-to-one mappings.
+ * Inverse warps visit every output pixel exactly once and sampling is always
+ * well-defined (with a chosen OOB policy for `(u, v)` outside the source).
+ *
+ * ## Pixel-centre model (+0.5 / -0.5)
+ *
+ * A pixel at integer `(x, y)` occupies a unit square centred at
+ * `(x + 0.5, y + 0.5)` in continuous space. When we scale by `sx`, the
+ * centre of output pixel `x'` maps to source coordinate
+ * `u = (x' + 0.5) / sx - 0.5`. Without this offset every resampled image
+ * would be shifted half a pixel — the source of more "slight blur" bugs
+ * than any other off-by-one in imaging.
+ *
+ * ## Linear-light resampling
+ *
+ * sRGB bytes are gamma-compressed. Averaging byte 0 and byte 255 naively
+ * gives 127, which looks noticeably darker than the mid-grey a camera would
+ * record. Bilinear and bicubic therefore decode to linear light before
+ * blending and re-encode afterwards. Nearest-neighbour doesn't blend, so it
+ * works directly on raw bytes.
+ *
+ * ## Catmull-Rom
+ *
+ * The bicubic kernel is Catmull-Rom: `(B=0, C=0.5)` in the Mitchell family.
+ * It interpolates (passes through the sample values), has compact `[-2, 2]`
+ * support, and C1 continuity. Negative lobes mean the result can overshoot
+ * `[0, 1]`, so [encode] clamps before converting back to bytes.
+ */
+object ImageGeometricTransforms {
+
+    // ----------------------------------------------------------------------
+    // Public enums
+    // ----------------------------------------------------------------------
+
+    /** Interpolation kernel for continuous sampling. */
+    enum class Interpolation { NEAREST, BILINEAR, BICUBIC }
+
+    /**
+     * Output size policy for [rotate].
+     *
+     * - [FIT]  — enlarge output to contain the entire rotated source.
+     * - [CROP] — keep the original dimensions, clipping rotated corners.
+     */
+    enum class RotateBounds { FIT, CROP }
+
+    /**
+     * Policy for sampling outside `[0, width) × [0, height)`:
+     *
+     * - [ZERO]      — return transparent black.
+     * - [REPLICATE] — clamp to the nearest border pixel.
+     * - [REFLECT]   — mirror the image at each border (period `2 * max`).
+     * - [WRAP]      — tile the image periodically.
+     */
+    enum class OutOfBounds { ZERO, REPLICATE, REFLECT, WRAP }
+
+    // ----------------------------------------------------------------------
+    // sRGB ↔ linear-light
+    //
+    // Identical to IMG03. We reproduce it here rather than depend on
+    // image-point-ops because geometric transforms should not inherit colour
+    // operations — the two packages are siblings, not a stack.
+    // ----------------------------------------------------------------------
+
+    private val SRGB_TO_LINEAR: DoubleArray = DoubleArray(256) { i ->
+        val c = i / 255.0
+        if (c <= 0.04045) c / 12.92 else ((c + 0.055) / 1.055).pow(2.4)
+    }
+
+    private fun decode(b: Int): Double = SRGB_TO_LINEAR[b and 0xFF]
+
+    private fun encode(linear: Double): Int {
+        val c = linear.coerceIn(0.0, 1.0)
+        val s = if (c <= 0.0031308) c * 12.92 else 1.055 * c.pow(1.0 / 2.4) - 0.055
+        return (s * 255.0).roundToInt()
+    }
+
+    // ----------------------------------------------------------------------
+    // OOB coordinate resolution
+    //
+    // `resolveCoord` returns -1 when the policy demands "return zero"; the
+    // caller then treats that as transparent black. Returning Int (not
+    // nullable) keeps the inner loops free of Int? box allocations.
+    // ----------------------------------------------------------------------
+
+    private fun resolveCoord(x: Int, maxVal: Int, oob: OutOfBounds): Int {
+        if (x in 0 until maxVal) return x
+        return when (oob) {
+            OutOfBounds.ZERO -> -1
+            OutOfBounds.REPLICATE -> x.coerceIn(0, maxVal - 1)
+            OutOfBounds.REFLECT -> {
+                // Mirror the image so it tiles the line with period 2*max;
+                // the fold at the edges creates the "bathroom tile" effect.
+                val period = 2 * maxVal
+                var xm = x % period
+                if (xm < 0) xm += period
+                if (xm >= maxVal) period - xm - 1 else xm
+            }
+            OutOfBounds.WRAP -> {
+                var xm = x % maxVal
+                if (xm < 0) xm += maxVal
+                xm
+            }
+        }
+    }
+
+    private fun getPixelOob(src: PixelContainer, x: Int, y: Int, oob: OutOfBounds): IntArray {
+        val xi = resolveCoord(x, src.width, oob)
+        val yi = resolveCoord(y, src.height, oob)
+        if (xi < 0 || yi < 0) return intArrayOf(0, 0, 0, 0)
+        return PixelOps.pixelAt(src, xi, yi)
+    }
+
+    // ----------------------------------------------------------------------
+    // Catmull-Rom kernel
+    //
+    // The (B=0, C=0.5) member of the Mitchell-Netravali family. Interpolates
+    // (w(0)=1, w(±1)=0, w(±2)=0), has support in [-2, 2], is C1-continuous,
+    // and has slight negative lobes — hence the clamp in encode().
+    // ----------------------------------------------------------------------
+
+    private fun catmullRom(d: Double): Double {
+        val ad = abs(d)
+        return when {
+            ad < 1.0 -> 1.5 * ad * ad * ad - 2.5 * ad * ad + 1.0
+            ad < 2.0 -> -0.5 * ad * ad * ad + 2.5 * ad * ad - 4.0 * ad + 2.0
+            else -> 0.0
+        }
+    }
+
+    // ----------------------------------------------------------------------
+    // Sampling
+    // ----------------------------------------------------------------------
+
+    private fun sampleNearest(src: PixelContainer, u: Double, v: Double, oob: OutOfBounds): IntArray {
+        val xi = u.roundToInt()
+        val yi = v.roundToInt()
+        return getPixelOob(src, xi, yi, oob)
+    }
+
+    private fun sampleBilinear(src: PixelContainer, u: Double, v: Double, oob: OutOfBounds): IntArray {
+        val x0 = floor(u).toInt()
+        val y0 = floor(v).toInt()
+        val wx1 = u - x0
+        val wx0 = 1.0 - wx1
+        val wy1 = v - y0
+        val wy0 = 1.0 - wy1
+
+        val p00 = getPixelOob(src, x0,     y0,     oob)
+        val p10 = getPixelOob(src, x0 + 1, y0,     oob)
+        val p01 = getPixelOob(src, x0,     y0 + 1, oob)
+        val p11 = getPixelOob(src, x0 + 1, y0 + 1, oob)
+
+        val out = IntArray(4)
+        for (c in 0..2) {
+            val lin = decode(p00[c]) * wx0 * wy0 +
+                      decode(p10[c]) * wx1 * wy0 +
+                      decode(p01[c]) * wx0 * wy1 +
+                      decode(p11[c]) * wx1 * wy1
+            out[c] = encode(lin)
+        }
+        // Alpha is linear coverage by definition; blend without sRGB decode.
+        out[3] = (p00[3] * wx0 * wy0 +
+                  p10[3] * wx1 * wy0 +
+                  p01[3] * wx0 * wy1 +
+                  p11[3] * wx1 * wy1).roundToInt().coerceIn(0, 255)
+        return out
+    }
+
+    private fun sampleBicubic(src: PixelContainer, u: Double, v: Double, oob: OutOfBounds): IntArray {
+        val x0 = floor(u).toInt()
+        val y0 = floor(v).toInt()
+
+        // Precompute 4 horizontal and 4 vertical Catmull-Rom weights.
+        val wu = DoubleArray(4) { i -> catmullRom(u - (x0 + (i - 1))) }
+        val wv = DoubleArray(4) { j -> catmullRom(v - (y0 + (j - 1))) }
+
+        val acc = DoubleArray(4)
+        for (dy in -1..2) {
+            val yrow = dy + 1
+            for (dx in -1..2) {
+                val p = getPixelOob(src, x0 + dx, y0 + dy, oob)
+                val w = wu[dx + 1] * wv[yrow]
+                acc[0] += decode(p[0]) * w
+                acc[1] += decode(p[1]) * w
+                acc[2] += decode(p[2]) * w
+                acc[3] += (p[3] / 255.0) * w
+            }
+        }
+        return intArrayOf(
+            encode(acc[0]),
+            encode(acc[1]),
+            encode(acc[2]),
+            (acc[3].coerceIn(0.0, 1.0) * 255.0).roundToInt()
+        )
+    }
+
+    private fun samplePixel(src: PixelContainer, u: Double, v: Double, interp: Interpolation, oob: OutOfBounds): IntArray =
+        when (interp) {
+            Interpolation.NEAREST  -> sampleNearest(src, u, v, oob)
+            Interpolation.BILINEAR -> sampleBilinear(src, u, v, oob)
+            Interpolation.BICUBIC  -> sampleBicubic(src, u, v, oob)
+        }
+
+    // ======================================================================
+    // LOSSLESS TRANSFORMS — byte-level, no interpolation, no colour conv.
+    // ======================================================================
+
+    /** Mirror the image left↔right. Double application is the identity. */
+    fun flipHorizontal(src: PixelContainer): PixelContainer {
+        val out = PixelContainer(src.width, src.height)
+        for (y in 0 until src.height)
+            for (x in 0 until src.width) {
+                val p = PixelOps.pixelAt(src, x, y)
+                PixelOps.setPixel(out, src.width - 1 - x, y, p[0], p[1], p[2], p[3])
+            }
+        return out
+    }
+
+    /** Mirror the image top↔bottom. Double application is the identity. */
+    fun flipVertical(src: PixelContainer): PixelContainer {
+        val out = PixelContainer(src.width, src.height)
+        for (y in 0 until src.height)
+            for (x in 0 until src.width) {
+                val p = PixelOps.pixelAt(src, x, y)
+                PixelOps.setPixel(out, x, src.height - 1 - y, p[0], p[1], p[2], p[3])
+            }
+        return out
+    }
+
+    /**
+     * Rotate 90° clockwise. Dimensions swap: `outW = srcH`, `outH = srcW`.
+     *
+     * Inverse warp: the output pixel `(x', y')` is supplied by source
+     * `(y', H - 1 - x')` — here `H = srcHeight`.
+     */
+    fun rotate90CW(src: PixelContainer): PixelContainer {
+        val out = PixelContainer(src.height, src.width)
+        for (yp in 0 until out.height)
+            for (xp in 0 until out.width) {
+                val p = PixelOps.pixelAt(src, yp, src.height - 1 - xp)
+                PixelOps.setPixel(out, xp, yp, p[0], p[1], p[2], p[3])
+            }
+        return out
+    }
+
+    /**
+     * Rotate 90° counter-clockwise. Dimensions swap.
+     *
+     * Inverse warp: output `(x', y')` comes from source `(W - 1 - y', x')`.
+     */
+    fun rotate90CCW(src: PixelContainer): PixelContainer {
+        val out = PixelContainer(src.height, src.width)
+        for (yp in 0 until out.height)
+            for (xp in 0 until out.width) {
+                val p = PixelOps.pixelAt(src, src.width - 1 - yp, xp)
+                PixelOps.setPixel(out, xp, yp, p[0], p[1], p[2], p[3])
+            }
+        return out
+    }
+
+    /** Rotate 180°. Equivalent to two 90° CW rotations, done in one pass. */
+    fun rotate180(src: PixelContainer): PixelContainer {
+        val out = PixelContainer(src.width, src.height)
+        for (y in 0 until src.height)
+            for (x in 0 until src.width) {
+                val p = PixelOps.pixelAt(src, src.width - 1 - x, src.height - 1 - y)
+                PixelOps.setPixel(out, x, y, p[0], p[1], p[2], p[3])
+            }
+        return out
+    }
+
+    /**
+     * Extract a `w × h` rectangle with top-left at `(x0, y0)`. Coordinates
+     * falling outside the source are filled with transparent black (the
+     * default OOB behaviour of [PixelOps.pixelAt]).
+     */
+    fun crop(src: PixelContainer, x0: Int, y0: Int, w: Int, h: Int): PixelContainer {
+        val out = PixelContainer(w, h)
+        for (y in 0 until h)
+            for (x in 0 until w) {
+                val p = PixelOps.pixelAt(src, x0 + x, y0 + y)
+                PixelOps.setPixel(out, x, y, p[0], p[1], p[2], p[3])
+            }
+        return out
+    }
+
+    // ======================================================================
+    // CONTINUOUS TRANSFORMS — interpolation in linear light
+    // ======================================================================
+
+    /**
+     * Resample the image to `outW × outH` using [interp].
+     *
+     * Uses the inverse-warp pixel-centre model: for each output pixel `x'`
+     * with scale factor `sx = outW / srcW`, the source coordinate is
+     * `u = (x' + 0.5) / sx - 0.5`. REPLICATE OOB keeps borders clean.
+     */
+    fun scale(
+        src: PixelContainer,
+        outW: Int,
+        outH: Int,
+        interp: Interpolation = Interpolation.BILINEAR
+    ): PixelContainer {
+        val out = PixelContainer(outW, outH)
+        val sx = outW.toDouble() / src.width
+        val sy = outH.toDouble() / src.height
+        for (yp in 0 until outH)
+            for (xp in 0 until outW) {
+                val u = (xp + 0.5) / sx - 0.5
+                val v = (yp + 0.5) / sy - 0.5
+                val p = samplePixel(src, u, v, interp, OutOfBounds.REPLICATE)
+                PixelOps.setPixel(out, xp, yp, p[0], p[1], p[2], p[3])
+            }
+        return out
+    }
+
+    /**
+     * Rotate by `radians` (positive = CCW in standard mathematical
+     * convention — here screen-y points down, so visually it looks CW).
+     *
+     * In [RotateBounds.FIT] the output is the smallest axis-aligned
+     * bounding box of the rotated source; in [RotateBounds.CROP] the
+     * output keeps the input dimensions and the rotated image may be
+     * clipped at the corners.
+     */
+    fun rotate(
+        src: PixelContainer,
+        radians: Double,
+        interp: Interpolation = Interpolation.BILINEAR,
+        bounds: RotateBounds = RotateBounds.FIT
+    ): PixelContainer {
+        val W = src.width; val H = src.height
+        val cosA = cos(radians); val sinA = sin(radians)
+
+        val outW: Int; val outH: Int
+        if (bounds == RotateBounds.FIT) {
+            outW = ceil(W * abs(cosA) + H * abs(sinA)).toInt()
+            outH = ceil(W * abs(sinA) + H * abs(cosA)).toInt()
+        } else {
+            outW = W; outH = H
+        }
+
+        val cxIn = W / 2.0; val cyIn = H / 2.0
+        val cxOut = outW / 2.0; val cyOut = outH / 2.0
+        val out = PixelContainer(outW, outH)
+
+        for (yp in 0 until outH)
+            for (xp in 0 until outW) {
+                val dx = xp - cxOut
+                val dy = yp - cyOut
+                // Inverse rotation matrix: [[cos, sin], [-sin, cos]].
+                val u = cxIn + cosA * dx + sinA * dy
+                val v = cyIn - sinA * dx + cosA * dy
+                val p = samplePixel(src, u, v, interp, OutOfBounds.ZERO)
+                PixelOps.setPixel(out, xp, yp, p[0], p[1], p[2], p[3])
+            }
+        return out
+    }
+
+    /** Shift the image by `(tx, ty)` pixels. Background fills with ZERO. */
+    fun translate(
+        src: PixelContainer,
+        tx: Double,
+        ty: Double,
+        interp: Interpolation = Interpolation.BILINEAR
+    ): PixelContainer {
+        val out = PixelContainer(src.width, src.height)
+        for (yp in 0 until src.height)
+            for (xp in 0 until src.width) {
+                val p = samplePixel(src, xp - tx, yp - ty, interp, OutOfBounds.ZERO)
+                PixelOps.setPixel(out, xp, yp, p[0], p[1], p[2], p[3])
+            }
+        return out
+    }
+
+    /**
+     * Apply a 2x3 affine transform given in forward form: for each source
+     * point `(x, y)` the destination is `m * [x, y, 1]^T`. This function
+     * inverts `m` internally and performs an inverse warp into an output of
+     * the same size as the input.
+     *
+     * ```
+     * [ a b c ] [x]   [x']
+     * [ d e f ] [y] = [y']
+     *           [1]
+     * ```
+     * Inverse (using `det = a*e - b*d`):
+     * ```
+     * [  e/det  -b/det  (b*f - c*e)/det ]
+     * [ -d/det   a/det  (c*d - a*f)/det ]
+     * ```
+     */
+    fun affine(
+        src: PixelContainer,
+        m: Array<DoubleArray>,
+        interp: Interpolation = Interpolation.BILINEAR,
+        oob: OutOfBounds = OutOfBounds.ZERO
+    ): PixelContainer {
+        require(m.size == 2 && m.all { it.size == 3 }) { "affine matrix must be 2x3" }
+        val a = m[0][0]; val b = m[0][1]; val c = m[0][2]
+        val d = m[1][0]; val e = m[1][1]; val f = m[1][2]
+        val det = a * e - b * d
+        require(abs(det) > 1e-12) { "affine matrix is singular" }
+        val ia =  e / det
+        val ib = -b / det
+        val ic = -d / det
+        val id =  a / det
+
+        val out = PixelContainer(src.width, src.height)
+        for (y in 0 until src.height)
+            for (x in 0 until src.width) {
+                val dx = x - c
+                val dy = y - f
+                val u = ia * dx + ib * dy
+                val v = ic * dx + id * dy
+                val p = samplePixel(src, u, v, interp, oob)
+                PixelOps.setPixel(out, x, y, p[0], p[1], p[2], p[3])
+            }
+        return out
+    }
+
+    /**
+     * Apply a 3x3 projective (homography) warp. Unlike [affine], the
+     * caller supplies `h` in *inverse* form — i.e. already the matrix that
+     * takes output coordinates to source coordinates. This is the more
+     * convenient convention when computing a homography from four point
+     * correspondences ("warp this quadrilateral back into a rectangle").
+     *
+     * The output size is the same as the source. For each output pixel
+     * `(x', y')`, the homogeneous source point is
+     * `[uh, vh, w]^T = h * [x', y', 1]^T`, and the Euclidean source is
+     * `(uh / w, vh / w)`. When `w == 0` the point is at infinity and we
+     * write transparent black.
+     */
+    fun perspectiveWarp(
+        src: PixelContainer,
+        h: Array<DoubleArray>,
+        interp: Interpolation = Interpolation.BILINEAR,
+        oob: OutOfBounds = OutOfBounds.ZERO
+    ): PixelContainer {
+        require(h.size == 3 && h.all { it.size == 3 }) { "homography must be 3x3" }
+        val out = PixelContainer(src.width, src.height)
+        for (y in 0 until src.height)
+            for (x in 0 until src.width) {
+                val uh = h[0][0] * x + h[0][1] * y + h[0][2]
+                val vh = h[1][0] * x + h[1][1] * y + h[1][2]
+                val w  = h[2][0] * x + h[2][1] * y + h[2][2]
+                if (abs(w) < 1e-12) {
+                    PixelOps.setPixel(out, x, y, 0, 0, 0, 0)
+                    continue
+                }
+                val u = uh / w
+                val v = vh / w
+                val p = samplePixel(src, u, v, interp, oob)
+                PixelOps.setPixel(out, x, y, p[0], p[1], p[2], p[3])
+            }
+        return out
+    }
+
+    // ----------------------------------------------------------------------
+    // 3x3 matrix inverse (helper, public — useful for callers composing
+    // homographies by hand).
+    // ----------------------------------------------------------------------
+
+    /**
+     * Invert a 3x3 matrix by the adjugate method. Throws if the matrix is
+     * singular (|det| below `1e-12`).
+     */
+    fun invert3x3(m: Array<DoubleArray>): Array<DoubleArray> {
+        require(m.size == 3 && m.all { it.size == 3 }) { "matrix must be 3x3" }
+        val a = m[0][0]; val b = m[0][1]; val c = m[0][2]
+        val d = m[1][0]; val e = m[1][1]; val f = m[1][2]
+        val g = m[2][0]; val h = m[2][1]; val i = m[2][2]
+        val det = a * (e * i - f * h) - b * (d * i - f * g) + c * (d * h - e * g)
+        require(abs(det) > 1e-12) { "matrix is singular" }
+        return arrayOf(
+            doubleArrayOf( (e * i - f * h) / det, -(b * i - c * h) / det,  (b * f - c * e) / det),
+            doubleArrayOf(-(d * i - f * g) / det,  (a * i - c * g) / det, -(a * f - c * d) / det),
+            doubleArrayOf( (d * h - e * g) / det, -(a * h - b * g) / det,  (a * e - b * d) / det)
+        )
+    }
+}

--- a/code/packages/kotlin/image-geometric-transforms/src/main/kotlin/com/codingadventures/imagegeometrictransforms/ImageGeometricTransforms.kt
+++ b/code/packages/kotlin/image-geometric-transforms/src/main/kotlin/com/codingadventures/imagegeometrictransforms/ImageGeometricTransforms.kt
@@ -367,6 +367,9 @@ object ImageGeometricTransforms {
         } else {
             outW = W; outH = H
         }
+        require(outW.toLong() * outH.toLong() <= Int.MAX_VALUE / 4) {
+            "Rotated canvas too large: ${outW}×${outH}"
+        }
 
         val cxIn = W / 2.0; val cyIn = H / 2.0
         val cxOut = outW / 2.0; val cyOut = outH / 2.0

--- a/code/packages/kotlin/image-geometric-transforms/src/test/kotlin/com/codingadventures/imagegeometrictransforms/ImageGeometricTransformsTest.kt
+++ b/code/packages/kotlin/image-geometric-transforms/src/test/kotlin/com/codingadventures/imagegeometrictransforms/ImageGeometricTransformsTest.kt
@@ -1,0 +1,408 @@
+package com.codingadventures.imagegeometrictransforms
+
+import com.codingadventures.pixelcontainer.PixelContainer
+import com.codingadventures.pixelcontainer.PixelOps
+import com.codingadventures.imagegeometrictransforms.ImageGeometricTransforms as IGT
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertTrue
+
+class ImageGeometricTransformsTest {
+
+    // ---- helpers --------------------------------------------------------
+
+    /**
+     * Build a 3x3 image with a distinct colour at each pixel so we can
+     * spot-check geometric operations by inspecting specific locations.
+     *
+     * Values are chosen so each channel is `10 * x + y + offset` — low
+     * enough to stay inside the sRGB "dark" (linear) region where decode is
+     * exactly `c / 12.92`, which lets us reason about linear-light
+     * operations without dragging pow() in.
+     */
+    private fun grid3x3(): PixelContainer {
+        val c = PixelContainer(3, 3)
+        for (y in 0 until 3)
+            for (x in 0 until 3)
+                PixelOps.setPixel(c, x, y, 10 * x + y, 10 * x + y + 1, 10 * x + y + 2, 255)
+        return c
+    }
+
+    private fun solid(w: Int, h: Int, r: Int, g: Int, b: Int, a: Int = 255): PixelContainer {
+        val c = PixelContainer(w, h)
+        PixelOps.fillPixels(c, r, g, b, a)
+        return c
+    }
+
+    private fun assertNear(actual: Int, expected: Int, tol: Int = 2) {
+        assertTrue(abs(actual - expected) <= tol, "expected ~$expected got $actual")
+    }
+
+    // ---- flips ---------------------------------------------------------
+
+    @Test fun flipHorizontalReversesRows() {
+        val src = grid3x3()
+        val out = IGT.flipHorizontal(src)
+        assertContentEquals(PixelOps.pixelAt(src, 0, 1), PixelOps.pixelAt(out, 2, 1))
+        assertContentEquals(PixelOps.pixelAt(src, 2, 1), PixelOps.pixelAt(out, 0, 1))
+    }
+
+    @Test fun flipHorizontalTwiceIsIdentity() {
+        val src = grid3x3()
+        val out = IGT.flipHorizontal(IGT.flipHorizontal(src))
+        for (y in 0 until 3) for (x in 0 until 3)
+            assertContentEquals(PixelOps.pixelAt(src, x, y), PixelOps.pixelAt(out, x, y))
+    }
+
+    @Test fun flipVerticalReversesColumns() {
+        val src = grid3x3()
+        val out = IGT.flipVertical(src)
+        assertContentEquals(PixelOps.pixelAt(src, 1, 0), PixelOps.pixelAt(out, 1, 2))
+    }
+
+    @Test fun flipVerticalTwiceIsIdentity() {
+        val src = grid3x3()
+        val out = IGT.flipVertical(IGT.flipVertical(src))
+        for (y in 0 until 3) for (x in 0 until 3)
+            assertContentEquals(PixelOps.pixelAt(src, x, y), PixelOps.pixelAt(out, x, y))
+    }
+
+    // ---- 90° rotations -------------------------------------------------
+
+    @Test fun rotate90CWSwapsDimensions() {
+        val src = PixelContainer(4, 3)
+        val out = IGT.rotate90CW(src)
+        assertEquals(3, out.width)
+        assertEquals(4, out.height)
+    }
+
+    @Test fun rotate90CWMovesTopLeftToTopRight() {
+        val src = PixelContainer(3, 3)
+        PixelOps.setPixel(src, 0, 0, 255, 0, 0, 255)
+        val out = IGT.rotate90CW(src)
+        // top-left of source goes to top-right of output
+        assertContentEquals(intArrayOf(255, 0, 0, 255), PixelOps.pixelAt(out, 2, 0))
+    }
+
+    @Test fun fourRotate90CWIsIdentity() {
+        val src = grid3x3()
+        var out = src
+        repeat(4) { out = IGT.rotate90CW(out) }
+        for (y in 0 until 3) for (x in 0 until 3)
+            assertContentEquals(PixelOps.pixelAt(src, x, y), PixelOps.pixelAt(out, x, y))
+    }
+
+    @Test fun rotate90CCWMovesTopLeftToBottomLeft() {
+        val src = PixelContainer(3, 3)
+        PixelOps.setPixel(src, 0, 0, 255, 0, 0, 255)
+        val out = IGT.rotate90CCW(src)
+        assertContentEquals(intArrayOf(255, 0, 0, 255), PixelOps.pixelAt(out, 0, 2))
+    }
+
+    @Test fun fourRotate90CCWIsIdentity() {
+        val src = grid3x3()
+        var out = src
+        repeat(4) { out = IGT.rotate90CCW(out) }
+        for (y in 0 until 3) for (x in 0 until 3)
+            assertContentEquals(PixelOps.pixelAt(src, x, y), PixelOps.pixelAt(out, x, y))
+    }
+
+    @Test fun rotate90CWAndCCWAreInverses() {
+        val src = grid3x3()
+        val out = IGT.rotate90CCW(IGT.rotate90CW(src))
+        for (y in 0 until 3) for (x in 0 until 3)
+            assertContentEquals(PixelOps.pixelAt(src, x, y), PixelOps.pixelAt(out, x, y))
+    }
+
+    @Test fun rotate180Twice() {
+        val src = grid3x3()
+        val out = IGT.rotate180(IGT.rotate180(src))
+        for (y in 0 until 3) for (x in 0 until 3)
+            assertContentEquals(PixelOps.pixelAt(src, x, y), PixelOps.pixelAt(out, x, y))
+    }
+
+    @Test fun rotate180MovesTopLeftToBottomRight() {
+        val src = PixelContainer(3, 3)
+        PixelOps.setPixel(src, 0, 0, 200, 100, 50, 255)
+        val out = IGT.rotate180(src)
+        assertContentEquals(intArrayOf(200, 100, 50, 255), PixelOps.pixelAt(out, 2, 2))
+    }
+
+    // ---- crop ----------------------------------------------------------
+
+    @Test fun cropProducesRequestedDimensions() {
+        val src = PixelContainer(10, 10)
+        val out = IGT.crop(src, 2, 3, 4, 5)
+        assertEquals(4, out.width)
+        assertEquals(5, out.height)
+    }
+
+    @Test fun cropPreservesContent() {
+        val src = grid3x3()
+        val out = IGT.crop(src, 1, 1, 2, 2)
+        assertContentEquals(PixelOps.pixelAt(src, 1, 1), PixelOps.pixelAt(out, 0, 0))
+        assertContentEquals(PixelOps.pixelAt(src, 2, 2), PixelOps.pixelAt(out, 1, 1))
+    }
+
+    @Test fun cropOutsideSourceFillsZero() {
+        val src = solid(2, 2, 255, 255, 255)
+        val out = IGT.crop(src, 0, 0, 4, 4)
+        assertContentEquals(intArrayOf(255, 255, 255, 255), PixelOps.pixelAt(out, 0, 0))
+        assertContentEquals(intArrayOf(0, 0, 0, 0), PixelOps.pixelAt(out, 3, 3))
+    }
+
+    // ---- scale ---------------------------------------------------------
+
+    @Test fun scaleIdentityPreservesImage() {
+        val src = grid3x3()
+        val out = IGT.scale(src, 3, 3, IGT.Interpolation.NEAREST)
+        for (y in 0 until 3) for (x in 0 until 3)
+            assertContentEquals(PixelOps.pixelAt(src, x, y), PixelOps.pixelAt(out, x, y))
+    }
+
+    @Test fun scaleDoublesSize() {
+        val src = solid(2, 2, 100, 150, 200)
+        val out = IGT.scale(src, 4, 4, IGT.Interpolation.NEAREST)
+        assertEquals(4, out.width)
+        assertEquals(4, out.height)
+        assertContentEquals(intArrayOf(100, 150, 200, 255), PixelOps.pixelAt(out, 2, 2))
+    }
+
+    @Test fun scaleHalvesSize() {
+        val src = solid(4, 4, 80, 120, 160)
+        val out = IGT.scale(src, 2, 2, IGT.Interpolation.BILINEAR)
+        assertEquals(2, out.width)
+        val p = PixelOps.pixelAt(out, 0, 0)
+        assertNear(p[0], 80, 3)
+        assertNear(p[1], 120, 3)
+        assertNear(p[2], 160, 3)
+    }
+
+    @Test fun scaleBicubicProducesValidImage() {
+        val src = solid(4, 4, 100, 100, 100)
+        val out = IGT.scale(src, 8, 8, IGT.Interpolation.BICUBIC)
+        assertEquals(8, out.width); assertEquals(8, out.height)
+        // Interior pixel should be close to source colour.
+        val p = PixelOps.pixelAt(out, 4, 4)
+        assertNear(p[0], 100, 5)
+    }
+
+    // ---- rotate (arbitrary angle) --------------------------------------
+
+    @Test fun rotateZeroIsNearIdentity() {
+        val src = grid3x3()
+        val out = IGT.rotate(src, 0.0, IGT.Interpolation.NEAREST, IGT.RotateBounds.CROP)
+        for (y in 0 until 3) for (x in 0 until 3) {
+            val sp = PixelOps.pixelAt(src, x, y)
+            val op = PixelOps.pixelAt(out, x, y)
+            assertNear(sp[0], op[0], 2)
+        }
+    }
+
+    @Test fun rotateFitEnlarges45Deg() {
+        val src = PixelContainer(10, 10)
+        val out = IGT.rotate(src, PI / 4, IGT.Interpolation.NEAREST, IGT.RotateBounds.FIT)
+        assertTrue(out.width >= 14 && out.height >= 14)
+    }
+
+    @Test fun rotateCropPreservesDimensions() {
+        val src = PixelContainer(10, 10)
+        val out = IGT.rotate(src, PI / 4, IGT.Interpolation.NEAREST, IGT.RotateBounds.CROP)
+        assertEquals(10, out.width)
+        assertEquals(10, out.height)
+    }
+
+    @Test fun rotateOutsideIsTransparent() {
+        val src = solid(4, 4, 255, 0, 0)
+        val out = IGT.rotate(src, PI / 4, IGT.Interpolation.NEAREST, IGT.RotateBounds.FIT)
+        // Corner of the output bounding box should be outside the rotated square.
+        val p = PixelOps.pixelAt(out, 0, 0)
+        assertEquals(0, p[3])
+    }
+
+    // ---- translate -----------------------------------------------------
+
+    @Test fun translateShiftsPixels() {
+        val src = PixelContainer(4, 4)
+        PixelOps.setPixel(src, 1, 1, 200, 100, 50, 255)
+        val out = IGT.translate(src, 1.0, 1.0, IGT.Interpolation.NEAREST)
+        val p = PixelOps.pixelAt(out, 2, 2)
+        assertContentEquals(intArrayOf(200, 100, 50, 255), p)
+    }
+
+    @Test fun translateZeroIsIdentity() {
+        val src = grid3x3()
+        val out = IGT.translate(src, 0.0, 0.0, IGT.Interpolation.NEAREST)
+        for (y in 0 until 3) for (x in 0 until 3)
+            assertContentEquals(PixelOps.pixelAt(src, x, y), PixelOps.pixelAt(out, x, y))
+    }
+
+    // ---- affine --------------------------------------------------------
+
+    @Test fun affineIdentityIsIdentity() {
+        val src = grid3x3()
+        val id = arrayOf(doubleArrayOf(1.0, 0.0, 0.0), doubleArrayOf(0.0, 1.0, 0.0))
+        val out = IGT.affine(src, id, IGT.Interpolation.NEAREST)
+        for (y in 0 until 3) for (x in 0 until 3)
+            assertContentEquals(PixelOps.pixelAt(src, x, y), PixelOps.pixelAt(out, x, y))
+    }
+
+    @Test fun affineTranslationMatchesTranslate() {
+        val src = PixelContainer(5, 5)
+        PixelOps.setPixel(src, 2, 2, 100, 150, 200, 255)
+        // Forward translate by (1, 1): m = [[1,0,1],[0,1,1]]
+        val m = arrayOf(doubleArrayOf(1.0, 0.0, 1.0), doubleArrayOf(0.0, 1.0, 1.0))
+        val out = IGT.affine(src, m, IGT.Interpolation.NEAREST)
+        assertContentEquals(intArrayOf(100, 150, 200, 255), PixelOps.pixelAt(out, 3, 3))
+    }
+
+    @Test fun affineRejectsBadShape() {
+        val src = PixelContainer(2, 2)
+        val bad = arrayOf(doubleArrayOf(1.0, 0.0))
+        assertFails { IGT.affine(src, bad) }
+    }
+
+    @Test fun affineRejectsSingular() {
+        val src = PixelContainer(2, 2)
+        val singular = arrayOf(doubleArrayOf(0.0, 0.0, 0.0), doubleArrayOf(0.0, 0.0, 0.0))
+        assertFails { IGT.affine(src, singular) }
+    }
+
+    // ---- perspectiveWarp ----------------------------------------------
+
+    @Test fun perspectiveIdentityIsIdentity() {
+        val src = grid3x3()
+        val id = arrayOf(
+            doubleArrayOf(1.0, 0.0, 0.0),
+            doubleArrayOf(0.0, 1.0, 0.0),
+            doubleArrayOf(0.0, 0.0, 1.0)
+        )
+        val out = IGT.perspectiveWarp(src, id, IGT.Interpolation.NEAREST)
+        for (y in 0 until 3) for (x in 0 until 3)
+            assertContentEquals(PixelOps.pixelAt(src, x, y), PixelOps.pixelAt(out, x, y))
+    }
+
+    @Test fun perspectiveDoublesWhenScalingHomographyUsed() {
+        val src = solid(4, 4, 90, 90, 90)
+        // Scale by 0.5 from output to source (inverse map): out coord -> out*0.5
+        val h = arrayOf(
+            doubleArrayOf(0.5, 0.0, 0.0),
+            doubleArrayOf(0.0, 0.5, 0.0),
+            doubleArrayOf(0.0, 0.0, 1.0)
+        )
+        val out = IGT.perspectiveWarp(src, h, IGT.Interpolation.NEAREST)
+        val p = PixelOps.pixelAt(out, 1, 1)
+        assertNear(p[0], 90, 5)
+    }
+
+    @Test fun perspectiveRejectsBadShape() {
+        val src = PixelContainer(2, 2)
+        val bad = arrayOf(doubleArrayOf(1.0))
+        assertFails { IGT.perspectiveWarp(src, bad) }
+    }
+
+    @Test fun perspectiveHandlesZeroW() {
+        val src = solid(2, 2, 100, 100, 100)
+        // Degenerate row 3 produces w == 0 for every output pixel.
+        val h = arrayOf(
+            doubleArrayOf(1.0, 0.0, 0.0),
+            doubleArrayOf(0.0, 1.0, 0.0),
+            doubleArrayOf(0.0, 0.0, 0.0)
+        )
+        val out = IGT.perspectiveWarp(src, h, IGT.Interpolation.NEAREST)
+        assertContentEquals(intArrayOf(0, 0, 0, 0), PixelOps.pixelAt(out, 0, 0))
+    }
+
+    // ---- invert3x3 -----------------------------------------------------
+
+    @Test fun invert3x3OfIdentityIsIdentity() {
+        val id = arrayOf(
+            doubleArrayOf(1.0, 0.0, 0.0),
+            doubleArrayOf(0.0, 1.0, 0.0),
+            doubleArrayOf(0.0, 0.0, 1.0)
+        )
+        val inv = IGT.invert3x3(id)
+        for (r in 0 until 3) for (c in 0 until 3)
+            assertTrue(abs(inv[r][c] - id[r][c]) < 1e-9)
+    }
+
+    @Test fun invert3x3Roundtrip() {
+        val m = arrayOf(
+            doubleArrayOf(2.0, 0.0, 1.0),
+            doubleArrayOf(0.0, 3.0, 2.0),
+            doubleArrayOf(0.0, 0.0, 1.0)
+        )
+        val inv = IGT.invert3x3(m)
+        // m * inv ≈ identity
+        for (r in 0 until 3) for (c in 0 until 3) {
+            var s = 0.0
+            for (k in 0 until 3) s += m[r][k] * inv[k][c]
+            val expected = if (r == c) 1.0 else 0.0
+            assertTrue(abs(s - expected) < 1e-9, "m*inv[$r][$c] = $s, expected $expected")
+        }
+    }
+
+    @Test fun invert3x3RejectsSingular() {
+        val singular = arrayOf(
+            doubleArrayOf(1.0, 2.0, 3.0),
+            doubleArrayOf(2.0, 4.0, 6.0),   // row2 = 2 * row1
+            doubleArrayOf(3.0, 6.0, 9.0)
+        )
+        assertFails { IGT.invert3x3(singular) }
+    }
+
+    // ---- OOB policies indirectly via rotate/perspective ---------------
+
+    @Test fun rotateReplicateDiffersFromZero() {
+        val src = solid(4, 4, 255, 0, 0)
+        // Build a homography that shifts way out: inverse map sends (0,0) to (-10,-10)
+        val shiftOut = arrayOf(
+            doubleArrayOf(1.0, 0.0, -10.0),
+            doubleArrayOf(0.0, 1.0, -10.0),
+            doubleArrayOf(0.0, 0.0,   1.0)
+        )
+        val zero = IGT.perspectiveWarp(src, shiftOut, IGT.Interpolation.NEAREST, IGT.OutOfBounds.ZERO)
+        val repl = IGT.perspectiveWarp(src, shiftOut, IGT.Interpolation.NEAREST, IGT.OutOfBounds.REPLICATE)
+        assertEquals(0, PixelOps.pixelAt(zero, 0, 0)[3])
+        assertEquals(255, PixelOps.pixelAt(repl, 0, 0)[0])
+    }
+
+    @Test fun oobReflectAndWrapStayInBounds() {
+        // Use perspectiveWarp with a pure shift so we hit OOB and check that
+        // reflect/wrap produce valid (non-zero) pixels from the original.
+        val src = solid(4, 4, 50, 100, 150)
+        val shift = arrayOf(
+            doubleArrayOf(1.0, 0.0, -2.0),
+            doubleArrayOf(0.0, 1.0, -2.0),
+            doubleArrayOf(0.0, 0.0,  1.0)
+        )
+        val reflect = IGT.perspectiveWarp(src, shift, IGT.Interpolation.NEAREST, IGT.OutOfBounds.REFLECT)
+        val wrap    = IGT.perspectiveWarp(src, shift, IGT.Interpolation.NEAREST, IGT.OutOfBounds.WRAP)
+        // All pixels in a uniform image should come back as the original colour.
+        assertContentEquals(intArrayOf(50, 100, 150, 255), PixelOps.pixelAt(reflect, 0, 0))
+        assertContentEquals(intArrayOf(50, 100, 150, 255), PixelOps.pixelAt(wrap, 0, 0))
+    }
+
+    // ---- interpolation selection --------------------------------------
+
+    @Test fun allInterpolationModesProduceValidOutputs() {
+        val src = solid(8, 8, 120, 60, 30)
+        for (interp in IGT.Interpolation.entries) {
+            val out = IGT.scale(src, 4, 4, interp)
+            assertEquals(4, out.width); assertEquals(4, out.height)
+        }
+    }
+
+    @Test fun transformsProduceCorrectOutputDimensions() {
+        val src = PixelContainer(5, 7)
+        assertEquals(5 to 7, IGT.flipHorizontal(src).let { it.width to it.height })
+        assertEquals(5 to 7, IGT.flipVertical(src).let { it.width to it.height })
+        assertEquals(7 to 5, IGT.rotate90CW(src).let { it.width to it.height })
+        assertEquals(7 to 5, IGT.rotate90CCW(src).let { it.width to it.height })
+        assertEquals(5 to 7, IGT.rotate180(src).let { it.width to it.height })
+    }
+}

--- a/code/packages/kotlin/image-point-ops/.gitignore
+++ b/code/packages/kotlin/image-point-ops/.gitignore
@@ -1,0 +1,2 @@
+gradle-build/
+.gradle/

--- a/code/packages/kotlin/image-point-ops/BUILD
+++ b/code/packages/kotlin/image-point-ops/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/image-point-ops/BUILD_windows
+++ b/code/packages/kotlin/image-point-ops/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/image-point-ops/CHANGELOG.md
+++ b/code/packages/kotlin/image-point-ops/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## 0.1.0 — Initial release
+
+- u8-domain point ops: `invert`, `threshold`, `thresholdLuminance`,
+  `posterize`, `swapRgbBgr`, `extractChannel`, `brightness`, `contrast`.
+- Linear-light point ops: `gamma`, `exposure`, `greyscale`, `sepia`,
+  `colourMatrix`, `saturate`, `hueRotate`, `srgbToLinearImage`,
+  `linearToSrgbImage`.
+- `GreyscaleMethod` enum (REC709 / BT601 / AVERAGE).
+- LUT helpers: `buildLut1dU8`, `buildGammaLut`, `applyLut1dU8`.
+- 256-entry sRGB→linear precomputed LUT at class-load time.

--- a/code/packages/kotlin/image-point-ops/README.md
+++ b/code/packages/kotlin/image-point-ops/README.md
@@ -1,0 +1,48 @@
+# image-point-ops (Kotlin)
+
+**Spec:** IMG03 — Per-pixel point operations on `PixelContainer`.
+
+This package implements every operation where the new value of a pixel is a
+function of only that pixel's own value. No neighbourhood, no frequency
+domain, no geometric resampling. Point ops are the simplest layer of the
+image pipeline and the one most frequently done wrong — almost always by
+omitting sRGB/linear conversion where it matters.
+
+## Two domains
+
+- **u8 domain** (fast, ignores photometry): `invert`, `threshold`,
+  `thresholdLuminance`, `posterize`, `swapRgbBgr`, `extractChannel`,
+  `brightness`, `contrast`.
+- **Linear-light domain** (decodes sRGB, works on actual intensity, re-encodes):
+  `gamma`, `exposure`, `greyscale`, `sepia`, `colourMatrix`, `saturate`,
+  `hueRotate`, `srgbToLinearImage`, `linearToSrgbImage`.
+
+`sRGB -> linear` uses a precomputed 256-entry lookup table. `linear -> sRGB`
+is computed per call (pow is unavoidable without quantisation).
+
+## LUTs
+
+`buildLut1dU8 { x -> ... }` builds a 256-entry u8 lookup table from a
+function over `[0, 1]`. `buildGammaLut(g)` is a convenience for `x^g`.
+`applyLut1dU8` applies independent R/G/B tables to an image.
+
+## Usage
+
+```kotlin
+import com.codingadventures.pixelcontainer.PixelContainer
+import com.codingadventures.imagepointops.ImagePointOps
+
+val grey = ImagePointOps.greyscale(src, ImagePointOps.GreyscaleMethod.REC709)
+val darker = ImagePointOps.gamma(src, 2.2)
+val warm = ImagePointOps.sepia(src)
+```
+
+## Dependencies
+
+- `pixel-container` (IC00)
+
+## Tests
+
+```
+gradle test
+```

--- a/code/packages/kotlin/image-point-ops/build.gradle.kts
+++ b/code/packages/kotlin/image-point-ops/build.gradle.kts
@@ -1,0 +1,36 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    api("com.codingadventures:pixel-container")
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/image-point-ops/settings.gradle.kts
+++ b/code/packages/kotlin/image-point-ops/settings.gradle.kts
@@ -1,0 +1,3 @@
+rootProject.name = "image-point-ops"
+
+includeBuild("../pixel-container")

--- a/code/packages/kotlin/image-point-ops/src/main/kotlin/com/codingadventures/imagepointops/ImagePointOps.kt
+++ b/code/packages/kotlin/image-point-ops/src/main/kotlin/com/codingadventures/imagepointops/ImagePointOps.kt
@@ -1,0 +1,437 @@
+package com.codingadventures.imagepointops
+
+import com.codingadventures.pixelcontainer.PixelContainer
+import com.codingadventures.pixelcontainer.PixelOps
+import kotlin.math.abs
+import kotlin.math.pow
+import kotlin.math.roundToInt
+
+/**
+ * IMG03 — Per-pixel point operations on [PixelContainer].
+ *
+ * Every method in this object transforms each pixel independently, using only
+ * that pixel's own value — no neighbourhood, no frequency domain, no geometric
+ * resampling. That is exactly what distinguishes "point ops" from the rest of
+ * the imaging pipeline, and it's what makes them trivially parallelisable in
+ * principle: any pixel can be computed before, after, or simultaneously with
+ * any other pixel.
+ *
+ * ## Two domains
+ *
+ * Point ops fall cleanly into two groups, and this split is load-bearing for
+ * correctness — not an academic nicety:
+ *
+ * - **u8 domain** — invert, threshold, posterize, channel shuffling,
+ *   brightness. Operate directly on the 0..255 byte values. Fast, exact,
+ *   and appropriate because the operation has no photometric meaning: you
+ *   are drawing on the encoded pixel values as a data structure.
+ *
+ * - **Linear-light domain** — gamma, exposure, greyscale, sepia, colour
+ *   matrices, saturation, hue rotation. Operate on the actual light
+ *   intensity that the display emitted. Pixels as they live in a PNG or
+ *   JPEG are sRGB-encoded (roughly gamma 2.2), so you first *decode* to
+ *   linear light, do the maths, then *re-encode* on the way out. Skipping
+ *   this step produces subtly wrong greyscale, muddy blurs, and weirdly
+ *   dim tinting — all the classic "web graphics look bad" bugs.
+ *
+ * ## sRGB ↔ linear
+ *
+ * ```
+ * decode: c8  -> c = c8 / 255
+ *         c <= 0.04045  ?  c / 12.92  :  ((c + 0.055) / 1.055)^2.4
+ *
+ * encode: l   -> l <= 0.0031308  ?  l * 12.92  :  1.055 * l^(1/2.4) - 0.055
+ *         out = round(encoded * 255)
+ * ```
+ *
+ * The sRGB-to-linear direction is evaluated once at class init into a
+ * 256-entry lookup table, because there are only 256 possible 8-bit inputs;
+ * computing [pow] per pixel per channel is a wasted billion floating-point
+ * ops for a 1024x1024 image.
+ */
+object ImagePointOps {
+
+    // ----------------------------------------------------------------------
+    // sRGB ↔ linear helpers
+    //
+    // SRGB_TO_LINEAR is a 256-entry LUT — all possible inputs to `decode` are
+    // bytes, so we precompute every answer once at class-load time.
+    // `encode` stays a per-call computation because its input is a continuous
+    // [0, 1] double and would need quantisation to be table-driven; we
+    // accept a pow() per encode rather than approximate.
+    // ----------------------------------------------------------------------
+
+    private val SRGB_TO_LINEAR: DoubleArray = DoubleArray(256) { i ->
+        val c = i / 255.0
+        if (c <= 0.04045) c / 12.92 else ((c + 0.055) / 1.055).pow(2.4)
+    }
+
+    private fun decode(b: Int): Double = SRGB_TO_LINEAR[b and 0xFF]
+
+    private fun encode(linear: Double): Int {
+        val c = linear.coerceIn(0.0, 1.0)
+        val srgb = if (c <= 0.0031308) c * 12.92 else 1.055 * c.pow(1.0 / 2.4) - 0.055
+        return (srgb * 255.0).roundToInt()
+    }
+
+    // ----------------------------------------------------------------------
+    // mapPixels — shared core. Every point op is "read pixel, compute new
+    // pixel, write pixel" — so we factor that walk into a single helper and
+    // let each op supply only the per-pixel lambda. Output is always a new
+    // PixelContainer; we never mutate the input.
+    // ----------------------------------------------------------------------
+
+    private inline fun mapPixels(
+        src: PixelContainer,
+        f: (Int, Int, Int, Int) -> IntArray
+    ): PixelContainer {
+        val out = PixelContainer(src.width, src.height)
+        for (y in 0 until src.height)
+            for (x in 0 until src.width) {
+                val p = PixelOps.pixelAt(src, x, y)
+                val q = f(p[0], p[1], p[2], p[3])
+                PixelOps.setPixel(out, x, y, q[0], q[1], q[2], q[3])
+            }
+        return out
+    }
+
+    // ======================================================================
+    // u8-DOMAIN OPERATIONS
+    // ======================================================================
+
+    /**
+     * Photographic negative — flip R, G, B about 127.5. Alpha passes
+     * through unchanged: inverting alpha would turn transparent pixels
+     * opaque, which is rarely what the user means.
+     */
+    fun invert(src: PixelContainer): PixelContainer =
+        mapPixels(src) { r, g, b, a -> intArrayOf(255 - r, 255 - g, 255 - b, a) }
+
+    /**
+     * Binary threshold on the unweighted mean of R, G, B. Pixels with mean
+     * strictly greater than [t] become white; the rest become black. Alpha
+     * is preserved. The threshold is compared with `>`, so `t = 255` always
+     * produces all-black output and `t = -1` always produces all-white.
+     */
+    fun threshold(src: PixelContainer, t: Int): PixelContainer =
+        mapPixels(src) { r, g, b, a ->
+            val avg = (r + g + b) / 3
+            val v = if (avg > t) 255 else 0
+            intArrayOf(v, v, v, a)
+        }
+
+    /**
+     * Binary threshold on Rec.709 luminance (Y = 0.2126R + 0.7152G + 0.0722B),
+     * computed in the u8 domain for speed. This is a conscious approximation:
+     * a photometrically rigorous luminance threshold would decode sRGB first,
+     * but threshold output is already a two-value stair-step — the
+     * difference is visually indistinguishable.
+     */
+    fun thresholdLuminance(src: PixelContainer, t: Int): PixelContainer =
+        mapPixels(src) { r, g, b, a ->
+            val y = 0.2126 * r + 0.7152 * g + 0.0722 * b
+            val v = if (y > t) 255 else 0
+            intArrayOf(v, v, v, a)
+        }
+
+    /**
+     * Posterize to [levels] discrete values per channel. Maps each 0..255
+     * input to the nearest of `levels` evenly spaced output values in
+     * 0..255. `levels = 2` gives pure black/white per channel (eight
+     * possible colours); `levels = 256` is a no-op.
+     *
+     * ```
+     * step = 255 / (levels - 1)
+     * out  = round(round(in / step) * step)
+     * ```
+     */
+    fun posterize(src: PixelContainer, levels: Int): PixelContainer {
+        require(levels >= 2) { "levels must be >= 2" }
+        val step = 255.0 / (levels - 1)
+        fun q(v: Int): Int = ((v / step).roundToInt() * step).roundToInt().coerceIn(0, 255)
+        return mapPixels(src) { r, g, b, a -> intArrayOf(q(r), q(g), q(b), a) }
+    }
+
+    /** Channel shuffle: swap R and B. Useful when bridging to BGR pipelines. */
+    fun swapRgbBgr(src: PixelContainer): PixelContainer =
+        mapPixels(src) { r, g, b, a -> intArrayOf(b, g, r, a) }
+
+    /**
+     * Replicate a single channel into R, G, B. The chosen channel index is
+     * `0 = R`, `1 = G`, `2 = B`, `3 = A`. Alpha in the output is always
+     * fully opaque (255), because a greyed-out visualisation of alpha only
+     * makes sense when the RGB carries the same info.
+     */
+    fun extractChannel(src: PixelContainer, ch: Int): PixelContainer {
+        require(ch in 0..3) { "channel must be 0..3" }
+        return mapPixels(src) { r, g, b, a ->
+            val v = intArrayOf(r, g, b, a)[ch]
+            intArrayOf(v, v, v, 255)
+        }
+    }
+
+    /** Additive brightness in u8 domain — clamped per channel. */
+    fun brightness(src: PixelContainer, delta: Int): PixelContainer =
+        mapPixels(src) { r, g, b, a ->
+            intArrayOf(
+                (r + delta).coerceIn(0, 255),
+                (g + delta).coerceIn(0, 255),
+                (b + delta).coerceIn(0, 255),
+                a
+            )
+        }
+
+    /**
+     * Photoshop-style contrast: pivots each channel about 128. `factor = 1.0`
+     * is a no-op, larger factors increase contrast, smaller decreases, and
+     * `0.0` flattens the whole image to mid-grey.
+     *
+     * ```
+     * out = clamp( (in - 128) * factor + 128 )
+     * ```
+     */
+    fun contrast(src: PixelContainer, factor: Double): PixelContainer =
+        mapPixels(src) { r, g, b, a ->
+            fun c(v: Int) = ((v - 128) * factor + 128).roundToInt().coerceIn(0, 255)
+            intArrayOf(c(r), c(g), c(b), a)
+        }
+
+    // ======================================================================
+    // LINEAR-LIGHT DOMAIN OPERATIONS
+    // ======================================================================
+
+    /**
+     * Gamma correction in linear light: decode sRGB → raise to the power
+     * `g` → re-encode. `g = 1.0` is a no-op, `g < 1` brightens midtones,
+     * `g > 1` darkens them.
+     */
+    fun gamma(src: PixelContainer, g: Double): PixelContainer =
+        mapPixels(src) { r, gg, b, a ->
+            intArrayOf(
+                encode(decode(r).pow(g)),
+                encode(decode(gg).pow(g)),
+                encode(decode(b).pow(g)),
+                a
+            )
+        }
+
+    /**
+     * Exposure in f-stops. Each stop doubles linear light, so the scale
+     * factor is `2^stops`. Negative stops darken. Saturates at 1.0 before
+     * re-encoding.
+     */
+    fun exposure(src: PixelContainer, stops: Double): PixelContainer {
+        val k = 2.0.pow(stops)
+        return mapPixels(src) { r, g, b, a ->
+            intArrayOf(
+                encode(decode(r) * k),
+                encode(decode(g) * k),
+                encode(decode(b) * k),
+                a
+            )
+        }
+    }
+
+    /** Luminance weightings for [greyscale]. */
+    enum class GreyscaleMethod { REC709, BT601, AVERAGE }
+
+    /**
+     * Desaturate to grey in linear light. The three methods differ only in
+     * their R, G, B weights:
+     *
+     * | method  | R       | G       | B       | notes                       |
+     * |---------|---------|---------|---------|-----------------------------|
+     * | REC709  | 0.2126  | 0.7152  | 0.0722  | modern HDTV / sRGB          |
+     * | BT601   | 0.299   | 0.587   | 0.114   | legacy NTSC / JPEG Y'CbCr   |
+     * | AVERAGE | 1/3     | 1/3     | 1/3     | naive, perceptually wrong   |
+     */
+    fun greyscale(src: PixelContainer, method: GreyscaleMethod): PixelContainer {
+        val (wr, wg, wb) = when (method) {
+            GreyscaleMethod.REC709  -> Triple(0.2126, 0.7152, 0.0722)
+            GreyscaleMethod.BT601   -> Triple(0.299,  0.587,  0.114)
+            GreyscaleMethod.AVERAGE -> Triple(1.0/3, 1.0/3, 1.0/3)
+        }
+        return mapPixels(src) { r, g, b, a ->
+            val y = decode(r) * wr + decode(g) * wg + decode(b) * wb
+            val v = encode(y)
+            intArrayOf(v, v, v, a)
+        }
+    }
+
+    /**
+     * Classic sepia matrix, applied in linear light:
+     * ```
+     * R' = 0.393 R + 0.769 G + 0.189 B
+     * G' = 0.349 R + 0.686 G + 0.168 B
+     * B' = 0.272 R + 0.534 G + 0.131 B
+     * ```
+     */
+    fun sepia(src: PixelContainer): PixelContainer =
+        colourMatrix(
+            src,
+            arrayOf(
+                doubleArrayOf(0.393, 0.769, 0.189),
+                doubleArrayOf(0.349, 0.686, 0.168),
+                doubleArrayOf(0.272, 0.534, 0.131)
+            )
+        )
+
+    /**
+     * Apply a 3×3 colour matrix to each pixel in linear light. Rows are
+     * "coefficients that produce R', G', B'" respectively; columns are
+     * "R, G, B contributions". Alpha is preserved.
+     */
+    fun colourMatrix(src: PixelContainer, m: Array<DoubleArray>): PixelContainer {
+        require(m.size == 3 && m.all { it.size == 3 }) { "matrix must be 3x3" }
+        return mapPixels(src) { r, g, b, a ->
+            val lr = decode(r); val lg = decode(g); val lb = decode(b)
+            val nr = m[0][0]*lr + m[0][1]*lg + m[0][2]*lb
+            val ng = m[1][0]*lr + m[1][1]*lg + m[1][2]*lb
+            val nb = m[2][0]*lr + m[2][1]*lg + m[2][2]*lb
+            intArrayOf(encode(nr), encode(ng), encode(nb), a)
+        }
+    }
+
+    /**
+     * Saturation adjustment. `factor = 0` collapses every pixel to its own
+     * luminance (perfect greyscale), `1` is identity, and values > 1 push
+     * each channel farther from grey.
+     *
+     * Implementation: compute Y in linear light, then lerp each channel
+     * between Y and itself by [factor].
+     */
+    fun saturate(src: PixelContainer, factor: Double): PixelContainer =
+        mapPixels(src) { r, g, b, a ->
+            val lr = decode(r); val lg = decode(g); val lb = decode(b)
+            val y = 0.2126 * lr + 0.7152 * lg + 0.0722 * lb
+            intArrayOf(
+                encode(y + (lr - y) * factor),
+                encode(y + (lg - y) * factor),
+                encode(y + (lb - y) * factor),
+                a
+            )
+        }
+
+    /**
+     * Rotate the hue of every pixel by [degrees] while preserving saturation
+     * and value. Done via round-trip RGB → HSV → shift H → HSV → RGB, all
+     * in linear light.
+     */
+    fun hueRotate(src: PixelContainer, degrees: Double): PixelContainer =
+        mapPixels(src) { r, g, b, a ->
+            val (h, s, v) = rgbToHsv(decode(r), decode(g), decode(b))
+            var nh = h + degrees
+            nh = ((nh % 360.0) + 360.0) % 360.0
+            val (nr, ng, nb) = hsvToRgb(nh, s, v)
+            intArrayOf(encode(nr), encode(ng), encode(nb), a)
+        }
+
+    /** Decode every pixel's RGB from sRGB to linear, stored as 0..255 bytes. */
+    fun srgbToLinearImage(src: PixelContainer): PixelContainer =
+        mapPixels(src) { r, g, b, a ->
+            intArrayOf(
+                (decode(r) * 255.0).roundToInt().coerceIn(0, 255),
+                (decode(g) * 255.0).roundToInt().coerceIn(0, 255),
+                (decode(b) * 255.0).roundToInt().coerceIn(0, 255),
+                a
+            )
+        }
+
+    /** Inverse of [srgbToLinearImage]: re-encode linear 0..255 back to sRGB. */
+    fun linearToSrgbImage(src: PixelContainer): PixelContainer =
+        mapPixels(src) { r, g, b, a ->
+            intArrayOf(
+                encode(r / 255.0),
+                encode(g / 255.0),
+                encode(b / 255.0),
+                a
+            )
+        }
+
+    // ======================================================================
+    // LUT helpers
+    // ======================================================================
+
+    /**
+     * Apply independent 1-D u8 look-up tables to R, G, B. Alpha untouched.
+     * Each LUT must have exactly 256 entries.
+     */
+    fun applyLut1dU8(
+        src: PixelContainer,
+        lutR: ByteArray,
+        lutG: ByteArray,
+        lutB: ByteArray
+    ): PixelContainer {
+        require(lutR.size == 256 && lutG.size == 256 && lutB.size == 256) {
+            "LUTs must have 256 entries"
+        }
+        return mapPixels(src) { r, g, b, a ->
+            intArrayOf(
+                lutR[r].toInt() and 0xFF,
+                lutG[g].toInt() and 0xFF,
+                lutB[b].toInt() and 0xFF,
+                a
+            )
+        }
+    }
+
+    /**
+     * Build a 256-entry u8 LUT from a function `f: [0, 1] -> [0, 1]`. The
+     * input index is mapped to `[0, 1]` by dividing by 255; the output is
+     * clamped and rounded back to u8.
+     */
+    fun buildLut1dU8(f: (Double) -> Double): ByteArray =
+        ByteArray(256) { i ->
+            val y = f(i / 255.0).coerceIn(0.0, 1.0)
+            (y * 255.0).roundToInt().toByte()
+        }
+
+    /** Gamma LUT: `x^g` over [0, 1]. */
+    fun buildGammaLut(g: Double): ByteArray = buildLut1dU8 { x -> x.pow(g) }
+
+    // ======================================================================
+    // HSV helpers
+    // ======================================================================
+
+    /**
+     * Convert linear-light RGB in `[0, 1]` to HSV with H in degrees.
+     *
+     * Edge cases follow the standard formulation: greys return `H = 0`,
+     * zero-value pixels return `S = 0`.
+     */
+    private fun rgbToHsv(r: Double, g: Double, b: Double): Triple<Double, Double, Double> {
+        val cmax = maxOf(r, g, b)
+        val cmin = minOf(r, g, b)
+        val delta = cmax - cmin
+        var h = when {
+            delta < 1e-6 -> 0.0
+            cmax == r -> 60.0 * (((g - b) / delta) % 6.0)
+            cmax == g -> 60.0 * ((b - r) / delta + 2.0)
+            else      -> 60.0 * ((r - g) / delta + 4.0)
+        }
+        if (h < 0) h += 360.0
+        val s = if (cmax < 1e-6) 0.0 else delta / cmax
+        return Triple(h, s, cmax)
+    }
+
+    /** Inverse of [rgbToHsv]. */
+    private fun hsvToRgb(h: Double, s: Double, v: Double): Triple<Double, Double, Double> {
+        val c = v * s
+        val x = c * (1.0 - abs((h / 60.0) % 2.0 - 1.0))
+        val m = v - c
+        val sector = ((h / 60.0).toInt() % 6 + 6) % 6
+        val (r1, g1, b1) = when (sector) {
+            0 -> Triple(c, x, 0.0)
+            1 -> Triple(x, c, 0.0)
+            2 -> Triple(0.0, c, x)
+            3 -> Triple(0.0, x, c)
+            4 -> Triple(x, 0.0, c)
+            else -> Triple(c, 0.0, x)
+        }
+        return Triple(
+            (r1 + m).coerceIn(0.0, 1.0),
+            (g1 + m).coerceIn(0.0, 1.0),
+            (b1 + m).coerceIn(0.0, 1.0)
+        )
+    }
+}

--- a/code/packages/kotlin/image-point-ops/src/test/kotlin/com/codingadventures/imagepointops/ImagePointOpsTest.kt
+++ b/code/packages/kotlin/image-point-ops/src/test/kotlin/com/codingadventures/imagepointops/ImagePointOpsTest.kt
@@ -1,0 +1,270 @@
+package com.codingadventures.imagepointops
+
+import com.codingadventures.pixelcontainer.PixelContainer
+import com.codingadventures.pixelcontainer.PixelOps
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertTrue
+import kotlin.test.assertNotEquals
+
+class ImagePointOpsTest {
+
+    // --- small helpers ---------------------------------------------------
+
+    private fun pix(r: Int, g: Int, b: Int, a: Int = 255): PixelContainer {
+        val c = PixelContainer(1, 1)
+        PixelOps.setPixel(c, 0, 0, r, g, b, a)
+        return c
+    }
+
+    private fun get(c: PixelContainer) = PixelOps.pixelAt(c, 0, 0)
+
+    private fun assertNear(a: Int, b: Int, tol: Int = 2) {
+        assertTrue(abs(a - b) <= tol, "expected ~$b got $a (tol=$tol)")
+    }
+
+    // --- invert ----------------------------------------------------------
+
+    @Test fun invertInvertsRGB() {
+        val out = ImagePointOps.invert(pix(10, 20, 30, 128))
+        assertContentEquals(intArrayOf(245, 235, 225, 128), get(out))
+    }
+
+    @Test fun invertTwiceIsIdentity() {
+        val once = ImagePointOps.invert(pix(50, 100, 150, 255))
+        val twice = ImagePointOps.invert(once)
+        assertContentEquals(intArrayOf(50, 100, 150, 255), get(twice))
+    }
+
+    // --- threshold -------------------------------------------------------
+
+    @Test fun thresholdBelow() {
+        val out = ImagePointOps.threshold(pix(10, 10, 10), 100)
+        assertContentEquals(intArrayOf(0, 0, 0, 255), get(out))
+    }
+
+    @Test fun thresholdAbove() {
+        val out = ImagePointOps.threshold(pix(200, 200, 200), 100)
+        assertContentEquals(intArrayOf(255, 255, 255, 255), get(out))
+    }
+
+    @Test fun thresholdLuminanceWeightsGreenMost() {
+        // pure green above threshold — white; pure red below — black
+        val g = ImagePointOps.thresholdLuminance(pix(0, 200, 0), 100)
+        val r = ImagePointOps.thresholdLuminance(pix(200, 0, 0), 100)
+        assertEquals(255, get(g)[0])
+        assertEquals(0, get(r)[0])
+    }
+
+    // --- posterize -------------------------------------------------------
+
+    @Test fun posterizeTwoLevelsGivesBlackOrWhite() {
+        val dark = ImagePointOps.posterize(pix(10, 10, 10), 2)
+        val light = ImagePointOps.posterize(pix(250, 250, 250), 2)
+        assertEquals(0, get(dark)[0])
+        assertEquals(255, get(light)[0])
+    }
+
+    @Test fun posterizeRejectsOneLevel() {
+        assertFails { ImagePointOps.posterize(pix(0, 0, 0), 1) }
+    }
+
+    // --- channel ops -----------------------------------------------------
+
+    @Test fun swapRgbBgr() {
+        val out = ImagePointOps.swapRgbBgr(pix(10, 20, 30))
+        assertContentEquals(intArrayOf(30, 20, 10, 255), get(out))
+    }
+
+    @Test fun extractChannelRed() {
+        val out = ImagePointOps.extractChannel(pix(100, 200, 50, 200), 0)
+        assertContentEquals(intArrayOf(100, 100, 100, 255), get(out))
+    }
+
+    @Test fun extractChannelAlpha() {
+        val out = ImagePointOps.extractChannel(pix(100, 200, 50, 77), 3)
+        assertContentEquals(intArrayOf(77, 77, 77, 255), get(out))
+    }
+
+    @Test fun extractChannelRejectsBadIndex() {
+        assertFails { ImagePointOps.extractChannel(pix(0, 0, 0), 4) }
+    }
+
+    // --- brightness / contrast ------------------------------------------
+
+    @Test fun brightnessPositiveSaturates() {
+        val out = ImagePointOps.brightness(pix(250, 250, 250), 50)
+        assertContentEquals(intArrayOf(255, 255, 255, 255), get(out))
+    }
+
+    @Test fun brightnessNegativeSaturates() {
+        val out = ImagePointOps.brightness(pix(10, 10, 10), -50)
+        assertContentEquals(intArrayOf(0, 0, 0, 255), get(out))
+    }
+
+    @Test fun contrastOneIsIdentity() {
+        val out = ImagePointOps.contrast(pix(40, 80, 200), 1.0)
+        assertContentEquals(intArrayOf(40, 80, 200, 255), get(out))
+    }
+
+    @Test fun contrastZeroCollapsesToMidGrey() {
+        val out = ImagePointOps.contrast(pix(0, 128, 255), 0.0)
+        assertContentEquals(intArrayOf(128, 128, 128, 255), get(out))
+    }
+
+    // --- gamma / exposure -----------------------------------------------
+
+    @Test fun gammaOneIsNearIdentity() {
+        val out = ImagePointOps.gamma(pix(50, 100, 150), 1.0)
+        val p = get(out)
+        assertNear(p[0], 50); assertNear(p[1], 100); assertNear(p[2], 150)
+    }
+
+    @Test fun gammaDarkensWithG2() {
+        val p = get(ImagePointOps.gamma(pix(128, 128, 128), 2.0))
+        assertTrue(p[0] < 128)
+    }
+
+    @Test fun exposureZeroIsNearIdentity() {
+        val out = ImagePointOps.exposure(pix(50, 100, 150), 0.0)
+        val p = get(out)
+        assertNear(p[0], 50); assertNear(p[1], 100); assertNear(p[2], 150)
+    }
+
+    @Test fun exposurePositiveBrightens() {
+        val p = get(ImagePointOps.exposure(pix(50, 50, 50), 1.0))
+        assertTrue(p[0] > 50)
+    }
+
+    @Test fun exposureNegativeDarkens() {
+        val p = get(ImagePointOps.exposure(pix(200, 200, 200), -1.0))
+        assertTrue(p[0] < 200)
+    }
+
+    // --- greyscale -------------------------------------------------------
+
+    @Test fun greyscaleRec709PureWhite() {
+        val p = get(ImagePointOps.greyscale(pix(255, 255, 255), ImagePointOps.GreyscaleMethod.REC709))
+        assertNear(p[0], 255, 1); assertEquals(p[0], p[1]); assertEquals(p[1], p[2])
+    }
+
+    @Test fun greyscaleBt601GivesEqualChannels() {
+        val p = get(ImagePointOps.greyscale(pix(200, 100, 50), ImagePointOps.GreyscaleMethod.BT601))
+        assertEquals(p[0], p[1]); assertEquals(p[1], p[2])
+    }
+
+    @Test fun greyscaleAverageGivesEqualChannels() {
+        val p = get(ImagePointOps.greyscale(pix(10, 20, 30), ImagePointOps.GreyscaleMethod.AVERAGE))
+        assertEquals(p[0], p[1]); assertEquals(p[1], p[2])
+    }
+
+    // --- matrix / sepia --------------------------------------------------
+
+    @Test fun sepiaShiftsTowardsBrown() {
+        val p = get(ImagePointOps.sepia(pix(255, 255, 255)))
+        // R > G > B is the sepia signature
+        assertTrue(p[0] >= p[1] && p[1] >= p[2])
+    }
+
+    @Test fun identityColourMatrixIsIdentity() {
+        val id = arrayOf(
+            doubleArrayOf(1.0, 0.0, 0.0),
+            doubleArrayOf(0.0, 1.0, 0.0),
+            doubleArrayOf(0.0, 0.0, 1.0)
+        )
+        val p = get(ImagePointOps.colourMatrix(pix(50, 100, 150), id))
+        assertNear(p[0], 50); assertNear(p[1], 100); assertNear(p[2], 150)
+    }
+
+    @Test fun colourMatrixRejectsBadShape() {
+        val bad = arrayOf(doubleArrayOf(1.0, 0.0))
+        assertFails { ImagePointOps.colourMatrix(pix(0, 0, 0), bad) }
+    }
+
+    // --- saturate --------------------------------------------------------
+
+    @Test fun saturateZeroGivesGrey() {
+        val p = get(ImagePointOps.saturate(pix(200, 50, 50), 0.0))
+        assertEquals(p[0], p[1]); assertEquals(p[1], p[2])
+    }
+
+    @Test fun saturateOneIsNearIdentity() {
+        val p = get(ImagePointOps.saturate(pix(100, 50, 20), 1.0))
+        assertNear(p[0], 100); assertNear(p[1], 50); assertNear(p[2], 20)
+    }
+
+    // --- hue rotate ------------------------------------------------------
+
+    @Test fun hueRotate360IsNearIdentity() {
+        val p = get(ImagePointOps.hueRotate(pix(200, 100, 50), 360.0))
+        assertNear(p[0], 200); assertNear(p[1], 100); assertNear(p[2], 50)
+    }
+
+    @Test fun hueRotate120PermutesPrimaries() {
+        // red at 0° rotates to green at 120°
+        val p = get(ImagePointOps.hueRotate(pix(255, 0, 0), 120.0))
+        assertTrue(p[1] > p[0] && p[1] > p[2])
+    }
+
+    // --- srgb<->linear image --------------------------------------------
+
+    @Test fun srgbToLinearRoundTripApproximate() {
+        val src = pix(128, 64, 200)
+        val lin = ImagePointOps.srgbToLinearImage(src)
+        val back = ImagePointOps.linearToSrgbImage(lin)
+        val p = get(back)
+        assertNear(p[0], 128, 3); assertNear(p[1], 64, 3); assertNear(p[2], 200, 3)
+    }
+
+    // --- LUTs ------------------------------------------------------------
+
+    @Test fun buildIdentityLutThenApplyIsNoOp() {
+        val id = ImagePointOps.buildLut1dU8 { it }
+        val out = ImagePointOps.applyLut1dU8(pix(10, 20, 30), id, id, id)
+        val p = get(out)
+        assertNear(p[0], 10, 1); assertNear(p[1], 20, 1); assertNear(p[2], 30, 1)
+    }
+
+    @Test fun gammaLutProducesReasonableValues() {
+        val lut = ImagePointOps.buildGammaLut(2.0)
+        assertEquals(0, lut[0].toInt() and 0xFF)
+        assertEquals(255, lut[255].toInt() and 0xFF)
+        // gamma 2.0 darkens mids
+        assertTrue((lut[128].toInt() and 0xFF) < 128)
+    }
+
+    @Test fun applyLutRejectsShortLut() {
+        assertFails {
+            ImagePointOps.applyLut1dU8(pix(0,0,0), ByteArray(10), ByteArray(256), ByteArray(256))
+        }
+    }
+
+    // --- multi-pixel shape ----------------------------------------------
+
+    @Test fun operationsProduceSameShape() {
+        val src = PixelContainer(3, 2)
+        PixelOps.fillPixels(src, 10, 20, 30, 40)
+        val out = ImagePointOps.invert(src)
+        assertEquals(src.width, out.width)
+        assertEquals(src.height, out.height)
+    }
+
+    @Test fun operationsDoNotMutateSource() {
+        val src = pix(10, 20, 30, 40)
+        val before = src.data.copyOf()
+        ImagePointOps.invert(src)
+        ImagePointOps.gamma(src, 2.0)
+        assertContentEquals(before, src.data)
+    }
+
+    @Test fun invertVsOriginalDiffers() {
+        val src = pix(10, 20, 30)
+        assertNotEquals(
+            get(src).toList(),
+            get(ImagePointOps.invert(src)).toList()
+        )
+    }
+}

--- a/code/packages/kotlin/pixel-container/.gitignore
+++ b/code/packages/kotlin/pixel-container/.gitignore
@@ -1,0 +1,2 @@
+gradle-build/
+.gradle/

--- a/code/packages/kotlin/pixel-container/BUILD
+++ b/code/packages/kotlin/pixel-container/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/pixel-container/BUILD_windows
+++ b/code/packages/kotlin/pixel-container/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/pixel-container/CHANGELOG.md
+++ b/code/packages/kotlin/pixel-container/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.1.0 — Initial release
+
+- `PixelContainer(width, height, data)` — RGBA8 row-major pixel buffer.
+- `PixelOps` singleton with `pixelAt`, `setPixel`, `fillPixels`.
+- `ImageCodec` interface defining `mimeType`, `encode`, `decode`.
+- Test suite covering default/explicit buffers, OOB policy, row-major
+  offsets, channel interleave order, `fillPixels`, and the `ImageCodec`
+  contract shape.

--- a/code/packages/kotlin/pixel-container/README.md
+++ b/code/packages/kotlin/pixel-container/README.md
@@ -1,0 +1,54 @@
+# pixel-container (Kotlin)
+
+**Spec:** IC00 — Universal RGBA8 Pixel Buffer
+
+A zero-dependency Kotlin port of `PixelContainer`, the narrow-waist data type
+that every image codec and processing stage in the coding-adventures stack
+shares. If you can turn your bytes into a `PixelContainer`, every downstream
+library can read them; if your library produces a `PixelContainer`, every
+encoder can write them out.
+
+## Layout
+
+```
+offset(x, y) = (y * width + x) * 4
+data[offset + 0] = R   (0..255)
+data[offset + 1] = G   (0..255)
+data[offset + 2] = B   (0..255)
+data[offset + 3] = A   (0..255)
+```
+
+Row-major, top-left origin, 4 channels x 8 bits each, no padding or stride.
+
+## Components
+
+- `PixelContainer(width, height, data = ZeroedBuffer)` — data holder.
+- `PixelOps` — `pixelAt`, `setPixel`, `fillPixels`.
+- `ImageCodec` — abstract `encode`/`decode`/`mimeType` for codecs to extend.
+
+## Usage
+
+```kotlin
+import com.codingadventures.pixelcontainer.PixelContainer
+import com.codingadventures.pixelcontainer.PixelOps
+
+val c = PixelContainer(64, 64)
+PixelOps.fillPixels(c, 255, 255, 255, 255)           // white canvas
+PixelOps.setPixel(c, 10, 10, 255, 0, 0, 255)         // one red pixel
+val rgba = PixelOps.pixelAt(c, 10, 10)               // -> [255, 0, 0, 255]
+```
+
+Out-of-bounds reads return `(0, 0, 0, 0)`; out-of-bounds writes are silently
+ignored. This keeps the read path safe inside geometric transforms whose
+sample coordinates can legitimately fall off the image.
+
+## Where it fits
+
+`pixel-container` has no dependencies. Libraries that depend on it include
+`image-point-ops` (IMG03) and `image-geometric-transforms` (IMG04).
+
+## Tests
+
+```
+gradle test
+```

--- a/code/packages/kotlin/pixel-container/build.gradle.kts
+++ b/code/packages/kotlin/pixel-container/build.gradle.kts
@@ -1,0 +1,35 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/pixel-container/settings.gradle.kts
+++ b/code/packages/kotlin/pixel-container/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "pixel-container"

--- a/code/packages/kotlin/pixel-container/src/main/kotlin/com/codingadventures/pixelcontainer/ImageCodec.kt
+++ b/code/packages/kotlin/pixel-container/src/main/kotlin/com/codingadventures/pixelcontainer/ImageCodec.kt
@@ -1,0 +1,29 @@
+package com.codingadventures.pixelcontainer
+
+/**
+ * Abstract codec interface for encoding and decoding [PixelContainer]s.
+ *
+ * Every concrete codec in the stack (PNG, JPEG, BMP, GIF, ...) implements
+ * this interface. Because the universe of raster formats is vast, this
+ * interface is deliberately tiny — just "turn bytes into pixels" and back —
+ * and every format-specific parameter (quality, filter choice, palette, ...)
+ * lives on the concrete implementation rather than here.
+ *
+ * ## Conventions
+ *
+ * - [mimeType] uses the canonical IANA media type (e.g. `"image/png"`).
+ * - [encode] must be the inverse of [decode] for any buffer the codec
+ *   produced, modulo lossy compression (JPEG etc.).
+ * - Implementations should raise a format-specific exception on malformed
+ *   input rather than silently returning a partial image.
+ */
+interface ImageCodec {
+    /** Canonical IANA media type, e.g. `"image/png"`. */
+    val mimeType: String
+
+    /** Encode a [PixelContainer] into the codec's wire format. */
+    fun encode(container: PixelContainer): ByteArray
+
+    /** Decode a wire-format byte array into a [PixelContainer]. */
+    fun decode(data: ByteArray): PixelContainer
+}

--- a/code/packages/kotlin/pixel-container/src/main/kotlin/com/codingadventures/pixelcontainer/PixelContainer.kt
+++ b/code/packages/kotlin/pixel-container/src/main/kotlin/com/codingadventures/pixelcontainer/PixelContainer.kt
@@ -1,0 +1,57 @@
+package com.codingadventures.pixelcontainer
+
+/**
+ * IC00 — Universal RGBA8 Pixel Buffer.
+ *
+ * `PixelContainer` is the zero-dependency foundation for the coding-adventures
+ * image-processing stack. Every image codec (PNG, JPEG, BMP, ...) and every
+ * processing stage (point-ops, geometric transforms, filters, ...) depends
+ * only on this class. The deliberate narrowness of the interface is the whole
+ * point: once a codec decodes into a `PixelContainer`, anything downstream can
+ * consume it, and once a processing stage produces one, any encoder can write
+ * it out. This is the "narrow waist" of the stack.
+ *
+ * ## Memory layout
+ *
+ * Pixels are stored **row-major**, top-left origin, with channels interleaved
+ * in RGBA order:
+ *
+ * ```
+ * offset(x, y) = (y * width + x) * 4
+ *
+ * data[offset + 0] = R   // red,   0..255
+ * data[offset + 1] = G   // green, 0..255
+ * data[offset + 2] = B   // blue,  0..255
+ * data[offset + 3] = A   // alpha, 0..255 (0 = transparent, 255 = opaque)
+ * ```
+ *
+ * ## Fixed format
+ *
+ * The container is deliberately restricted:
+ *
+ * - exactly 4 channels (R, G, B, A)
+ * - exactly 8 bits per channel (unsigned, stored as signed `Byte` with the
+ *   reader using `.toInt() and 0xFF` to widen to unsigned)
+ * - exactly top-left origin, row-major order
+ * - no padding / stride — rows are packed
+ *
+ * Restricting the format means callers never need to dispatch on channel
+ * order, byte order, or depth. More exotic formats (HDR, grey-only, planar)
+ * are a job for a different container at a different layer.
+ *
+ * ## Size invariant
+ *
+ * The backing [data] array must always have length `width * height * 4`. When
+ * an explicit array is supplied, it is the caller's responsibility to satisfy
+ * that invariant. The default constructor allocates a correctly sized, fully
+ * transparent (all zero) buffer.
+ *
+ * @property width  image width in pixels (must be non-negative)
+ * @property height image height in pixels (must be non-negative)
+ * @property data   packed RGBA bytes, length `width * height * 4`
+ */
+class PixelContainer(
+    val width: Int,
+    val height: Int,
+    val data: ByteArray = ByteArray(width * height * 4)
+)

--- a/code/packages/kotlin/pixel-container/src/main/kotlin/com/codingadventures/pixelcontainer/PixelContainer.kt
+++ b/code/packages/kotlin/pixel-container/src/main/kotlin/com/codingadventures/pixelcontainer/PixelContainer.kt
@@ -53,5 +53,12 @@ package com.codingadventures.pixelcontainer
 class PixelContainer(
     val width: Int,
     val height: Int,
-    val data: ByteArray = ByteArray(width * height * 4)
+    val data: ByteArray = run {
+        require(width >= 0 && height >= 0) { "Dimensions must be non-negative" }
+        val size = width.toLong() * height.toLong() * 4L
+        require(size <= Int.MAX_VALUE) {
+            "Image too large: ${width}×${height} exceeds 32-bit index range"
+        }
+        ByteArray(size.toInt())
+    }
 )

--- a/code/packages/kotlin/pixel-container/src/main/kotlin/com/codingadventures/pixelcontainer/PixelOps.kt
+++ b/code/packages/kotlin/pixel-container/src/main/kotlin/com/codingadventures/pixelcontainer/PixelOps.kt
@@ -1,0 +1,79 @@
+package com.codingadventures.pixelcontainer
+
+/**
+ * Static helpers for reading and writing individual pixels inside a
+ * [PixelContainer].
+ *
+ * These primitives are kept on a singleton rather than as methods on
+ * [PixelContainer] so the data class stays a pure, dumb memory holder —
+ * exactly the sort of container many different processing libraries can
+ * share without dragging behaviour in with it.
+ *
+ * ## Out-of-bounds policy
+ *
+ * - [pixelAt]    — returns `(0, 0, 0, 0)` (transparent black) for OOB reads.
+ * - [setPixel]   — silently ignores OOB writes.
+ * - [fillPixels] — never goes OOB (operates over the entire buffer).
+ *
+ * Returning zeros instead of throwing makes the read path safe to use inside
+ * geometric transforms where the sample coordinate can legitimately fall off
+ * the image and the caller then chooses a border policy explicitly.
+ */
+object PixelOps {
+
+    /**
+     * Read the RGBA quadruple at `(x, y)`.
+     *
+     * Each returned component is already widened to an unsigned 0..255 `Int`
+     * using `byte.toInt() and 0xFF`, so callers do not need to remember the
+     * sign-extension dance.
+     *
+     * Out-of-bounds coordinates return `intArrayOf(0, 0, 0, 0)`.
+     */
+    fun pixelAt(c: PixelContainer, x: Int, y: Int): IntArray {
+        if (x < 0 || x >= c.width || y < 0 || y >= c.height)
+            return intArrayOf(0, 0, 0, 0)
+        val i = (y * c.width + x) * 4
+        return intArrayOf(
+            c.data[i].toInt() and 0xFF,
+            c.data[i + 1].toInt() and 0xFF,
+            c.data[i + 2].toInt() and 0xFF,
+            c.data[i + 3].toInt() and 0xFF
+        )
+    }
+
+    /**
+     * Write the RGBA quadruple at `(x, y)`. Each component is truncated to
+     * its low 8 bits (`and 0xFF`) before storing, so callers may pass raw
+     * un-clamped values from arithmetic pipelines. Out-of-bounds coordinates
+     * are silently ignored (a no-op).
+     */
+    fun setPixel(c: PixelContainer, x: Int, y: Int, r: Int, g: Int, b: Int, a: Int) {
+        if (x < 0 || x >= c.width || y < 0 || y >= c.height) return
+        val i = (y * c.width + x) * 4
+        c.data[i]     = (r and 0xFF).toByte()
+        c.data[i + 1] = (g and 0xFF).toByte()
+        c.data[i + 2] = (b and 0xFF).toByte()
+        c.data[i + 3] = (a and 0xFF).toByte()
+    }
+
+    /**
+     * Overwrite every pixel with the given RGBA colour. The loop walks
+     * packed bytes rather than `(x, y)` pairs for cache-friendliness: a
+     * single forward sweep over `data` hits each cache line exactly once.
+     */
+    fun fillPixels(c: PixelContainer, r: Int, g: Int, b: Int, a: Int) {
+        val rb = (r and 0xFF).toByte()
+        val gb = (g and 0xFF).toByte()
+        val bb = (b and 0xFF).toByte()
+        val ab = (a and 0xFF).toByte()
+        var i = 0
+        while (i < c.data.size) {
+            c.data[i]     = rb
+            c.data[i + 1] = gb
+            c.data[i + 2] = bb
+            c.data[i + 3] = ab
+            i += 4
+        }
+    }
+}

--- a/code/packages/kotlin/pixel-container/src/test/kotlin/com/codingadventures/pixelcontainer/PixelContainerTest.kt
+++ b/code/packages/kotlin/pixel-container/src/test/kotlin/com/codingadventures/pixelcontainer/PixelContainerTest.kt
@@ -1,0 +1,240 @@
+package com.codingadventures.pixelcontainer
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.test.assertSame
+import kotlin.test.assertContentEquals
+
+class PixelContainerTest {
+
+    @Test
+    fun defaultConstructorAllocatesCorrectlySizedBuffer() {
+        val c = PixelContainer(4, 3)
+        assertEquals(4, c.width)
+        assertEquals(3, c.height)
+        assertEquals(4 * 3 * 4, c.data.size)
+    }
+
+    @Test
+    fun defaultConstructorZeroesAllPixels() {
+        val c = PixelContainer(5, 5)
+        assertTrue(c.data.all { it == 0.toByte() })
+    }
+
+    @Test
+    fun explicitBufferIsRetainedByReference() {
+        val buf = ByteArray(2 * 2 * 4)
+        val c = PixelContainer(2, 2, buf)
+        assertSame(buf, c.data)
+    }
+
+    @Test
+    fun zeroSizedContainerHasEmptyBuffer() {
+        val c = PixelContainer(0, 0)
+        assertEquals(0, c.data.size)
+    }
+
+    @Test
+    fun oneByOneContainerHasFourBytes() {
+        val c = PixelContainer(1, 1)
+        assertEquals(4, c.data.size)
+    }
+
+    @Test
+    fun setPixelAndReadBack() {
+        val c = PixelContainer(3, 3)
+        PixelOps.setPixel(c, 1, 1, 10, 20, 30, 40)
+        val px = PixelOps.pixelAt(c, 1, 1)
+        assertContentEquals(intArrayOf(10, 20, 30, 40), px)
+    }
+
+    @Test
+    fun setPixelAllChannelsFull() {
+        val c = PixelContainer(1, 1)
+        PixelOps.setPixel(c, 0, 0, 255, 255, 255, 255)
+        assertContentEquals(intArrayOf(255, 255, 255, 255), PixelOps.pixelAt(c, 0, 0))
+    }
+
+    @Test
+    fun setPixelTruncatesHighBits() {
+        val c = PixelContainer(1, 1)
+        PixelOps.setPixel(c, 0, 0, 0x1FF, 0x2AA, -1, 0x100)
+        val px = PixelOps.pixelAt(c, 0, 0)
+        assertContentEquals(intArrayOf(255, 0xAA, 255, 0), px)
+    }
+
+    @Test
+    fun pixelAtOutOfBoundsReturnsTransparentBlack() {
+        val c = PixelContainer(2, 2)
+        PixelOps.fillPixels(c, 100, 100, 100, 100)
+        assertContentEquals(intArrayOf(0, 0, 0, 0), PixelOps.pixelAt(c, -1, 0))
+        assertContentEquals(intArrayOf(0, 0, 0, 0), PixelOps.pixelAt(c, 0, -1))
+        assertContentEquals(intArrayOf(0, 0, 0, 0), PixelOps.pixelAt(c, 2, 0))
+        assertContentEquals(intArrayOf(0, 0, 0, 0), PixelOps.pixelAt(c, 0, 2))
+        assertContentEquals(intArrayOf(0, 0, 0, 0), PixelOps.pixelAt(c, 100, 100))
+    }
+
+    @Test
+    fun setPixelOutOfBoundsIsNoOp() {
+        val c = PixelContainer(2, 2)
+        PixelOps.fillPixels(c, 5, 6, 7, 8)
+        val before = c.data.copyOf()
+        PixelOps.setPixel(c, -1, 0, 99, 99, 99, 99)
+        PixelOps.setPixel(c, 0, -1, 99, 99, 99, 99)
+        PixelOps.setPixel(c, 2, 0, 99, 99, 99, 99)
+        PixelOps.setPixel(c, 0, 2, 99, 99, 99, 99)
+        assertContentEquals(before, c.data)
+    }
+
+    @Test
+    fun fillPixelsOverwritesEveryPixel() {
+        val c = PixelContainer(3, 4)
+        PixelOps.fillPixels(c, 1, 2, 3, 4)
+        for (y in 0 until 4)
+            for (x in 0 until 3)
+                assertContentEquals(intArrayOf(1, 2, 3, 4), PixelOps.pixelAt(c, x, y))
+    }
+
+    @Test
+    fun fillPixelsHandlesZeroSizeContainer() {
+        val c = PixelContainer(0, 0)
+        PixelOps.fillPixels(c, 1, 2, 3, 4)
+        assertEquals(0, c.data.size)
+    }
+
+    @Test
+    fun rowMajorLayout() {
+        val c = PixelContainer(3, 2)
+        // pixel (0,1) should be at byte offset (1*3+0)*4 = 12
+        PixelOps.setPixel(c, 0, 1, 11, 22, 33, 44)
+        assertEquals(11, c.data[12].toInt() and 0xFF)
+        assertEquals(22, c.data[13].toInt() and 0xFF)
+        assertEquals(33, c.data[14].toInt() and 0xFF)
+        assertEquals(44, c.data[15].toInt() and 0xFF)
+    }
+
+    @Test
+    fun channelInterleaveOrderIsRGBA() {
+        val c = PixelContainer(1, 1)
+        PixelOps.setPixel(c, 0, 0, 0x11, 0x22, 0x33, 0x44)
+        assertEquals(0x11.toByte(), c.data[0])
+        assertEquals(0x22.toByte(), c.data[1])
+        assertEquals(0x33.toByte(), c.data[2])
+        assertEquals(0x44.toByte(), c.data[3])
+    }
+
+    @Test
+    fun independentPixelWritesDoNotCorrupt() {
+        val c = PixelContainer(4, 4)
+        PixelOps.setPixel(c, 0, 0, 1, 2, 3, 4)
+        PixelOps.setPixel(c, 3, 3, 9, 8, 7, 6)
+        assertContentEquals(intArrayOf(1, 2, 3, 4), PixelOps.pixelAt(c, 0, 0))
+        assertContentEquals(intArrayOf(9, 8, 7, 6), PixelOps.pixelAt(c, 3, 3))
+        // all others still zero
+        for (y in 0 until 4)
+            for (x in 0 until 4)
+                if (!((x == 0 && y == 0) || (x == 3 && y == 3)))
+                    assertContentEquals(intArrayOf(0, 0, 0, 0), PixelOps.pixelAt(c, x, y))
+    }
+
+    @Test
+    fun fillThenOverwriteSinglePixel() {
+        val c = PixelContainer(2, 2)
+        PixelOps.fillPixels(c, 10, 20, 30, 40)
+        PixelOps.setPixel(c, 1, 1, 200, 150, 100, 50)
+        assertContentEquals(intArrayOf(200, 150, 100, 50), PixelOps.pixelAt(c, 1, 1))
+        assertContentEquals(intArrayOf(10, 20, 30, 40), PixelOps.pixelAt(c, 0, 0))
+    }
+
+    @Test
+    fun explicitBufferPreservesContent() {
+        val buf = ByteArray(4)
+        buf[0] = 50; buf[1] = 60; buf[2] = 70; buf[3] = 80
+        val c = PixelContainer(1, 1, buf)
+        assertContentEquals(intArrayOf(50, 60, 70, 80), PixelOps.pixelAt(c, 0, 0))
+    }
+
+    @Test
+    fun imageCodecInterfaceContractShape() {
+        val codec = object : ImageCodec {
+            override val mimeType = "image/test"
+            override fun encode(container: PixelContainer): ByteArray = container.data.copyOf()
+            override fun decode(data: ByteArray): PixelContainer =
+                PixelContainer(1, data.size / 4, data.copyOf())
+        }
+        val src = PixelContainer(1, 2)
+        PixelOps.setPixel(src, 0, 0, 1, 2, 3, 4)
+        PixelOps.setPixel(src, 0, 1, 5, 6, 7, 8)
+        val enc = codec.encode(src)
+        val dec = codec.decode(enc)
+        assertEquals("image/test", codec.mimeType)
+        assertEquals(1, dec.width)
+        assertEquals(2, dec.height)
+        assertContentEquals(intArrayOf(1, 2, 3, 4), PixelOps.pixelAt(dec, 0, 0))
+        assertContentEquals(intArrayOf(5, 6, 7, 8), PixelOps.pixelAt(dec, 0, 1))
+    }
+
+    @Test
+    fun largeContainerAllocationSucceeds() {
+        val c = PixelContainer(256, 256)
+        assertEquals(256 * 256 * 4, c.data.size)
+    }
+
+    @Test
+    fun sequentialWritesInScanOrder() {
+        val c = PixelContainer(2, 2)
+        var k = 0
+        for (y in 0 until 2) for (x in 0 until 2)
+            PixelOps.setPixel(c, x, y, k++, k++, k++, k++)
+        assertEquals(0, PixelOps.pixelAt(c, 0, 0)[0])
+        assertEquals(4, PixelOps.pixelAt(c, 1, 0)[0])
+        assertEquals(8, PixelOps.pixelAt(c, 0, 1)[0])
+        assertEquals(12, PixelOps.pixelAt(c, 1, 1)[0])
+    }
+
+    @Test
+    fun nonSquareDimensions() {
+        val c = PixelContainer(7, 3)
+        assertEquals(7 * 3 * 4, c.data.size)
+        PixelOps.setPixel(c, 6, 2, 100, 100, 100, 100)
+        assertContentEquals(intArrayOf(100, 100, 100, 100), PixelOps.pixelAt(c, 6, 2))
+    }
+
+    @Test
+    fun alphaChannelIndependenceFromRGB() {
+        val c = PixelContainer(1, 1)
+        PixelOps.setPixel(c, 0, 0, 0, 0, 0, 128)
+        assertContentEquals(intArrayOf(0, 0, 0, 128), PixelOps.pixelAt(c, 0, 0))
+    }
+
+    @Test
+    fun containersAreIndependent() {
+        val a = PixelContainer(2, 2)
+        val b = PixelContainer(2, 2)
+        PixelOps.fillPixels(a, 1, 1, 1, 1)
+        assertTrue(b.data.all { it == 0.toByte() })
+    }
+
+    @Test
+    fun pixelOpsSingletonIsStateless() {
+        // Repeated calls must behave identically.
+        val c = PixelContainer(1, 1)
+        PixelOps.setPixel(c, 0, 0, 10, 20, 30, 40)
+        val first = PixelOps.pixelAt(c, 0, 0)
+        val second = PixelOps.pixelAt(c, 0, 0)
+        assertContentEquals(first, second)
+    }
+
+    @Test
+    fun imageCodecImplementsMimeType() {
+        val codec = object : ImageCodec {
+            override val mimeType = "image/png"
+            override fun encode(container: PixelContainer) = ByteArray(0)
+            override fun decode(data: ByteArray) = PixelContainer(0, 0)
+        }
+        assertNotNull(codec.mimeType)
+        assertEquals("image/png", codec.mimeType)
+    }
+}


### PR DESCRIPTION
## Summary

Adds pixel-container (IC00), image-point-ops (IMG03), and image-geometric-transforms (IMG04) for three new languages: **Haskell**, **Java**, and **Kotlin**. These languages previously had no image stack support.

- **Haskell**: 3 packages using `bytestring` + `hspec`; 97 tests total
- **Java**: 3 packages using Gradle + JUnit 5; 103 tests total  
- **Kotlin**: 3 packages using Gradle + Kotlin test + JUnit 5; 102 tests total

**302 new tests** across all three languages.

### pixel-container (IC00)
`PixelContainer` RGBA8 buffer with `pixelAt`, `setPixel`, `fillPixels`, and `ImageCodec` interface. Kotlin/Java constructors guard against integer overflow (`width * height * 4` computed via `long`).

### image-point-ops (IMG03)
Full point-op catalogue: invert, threshold (average + Rec.709 luma), posterize, swapRgbBgr, extractChannel, brightness, contrast, gamma, exposure, greyscale (Rec709/BT601/Average), sepia, colourMatrix, saturate, hueRotate, sRGB↔linear image converters, 1D LUT application + builder + gamma LUT. Linear-light arithmetic for all colour-science operations.

### image-geometric-transforms (IMG04)
Lossless: flipHorizontal/Vertical, rotate90CW/CCW, rotate180, crop. Continuous (inverse-warp, pixel-centre model): scale, rotate (Fit/Crop bounds), translate, affine (2×3), perspectiveWarp (3×3). Interpolation: Nearest/Bilinear/Bicubic (Catmull-Rom). OOB: Zero/Replicate/Reflect/Wrap. Bilinear and bicubic blend in linear light.

### Security fixes (committed separately)
- Integer overflow guard in `PixelContainer` constructors (Java/Kotlin)
- Bounds guard on `applyLut1dU8` LUT arrays (Java/Haskell)
- Canvas size guard in `rotate()` FIT mode (Java/Kotlin)
- Shape validation in `colourMatrix` (Haskell)

## Test plan

- [ ] Haskell CI: `cabal test` in pixel-container, image-point-ops, image-geometric-transforms
- [ ] Java CI: `gradle test` in all three Java packages
- [ ] Kotlin CI: `gradle test` in all three Kotlin packages
- [ ] No regressions in existing packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)