### PR TITLE
feat(canvas-text): implement TXT03d + render Markdown to canvas end-to-end

### DIFF
--- a/code/packages/typescript/layout-block/CHANGELOG.md
+++ b/code/packages/typescript/layout-block/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixed
 
 - Inline tokens (words sliced out of a text node during word-wrap) no longer carry the parent node's full text value. Previously each token's `content.value` was the entire string, which caused paint backends to render the whole paragraph at every word position. The token now carries just its own word — correct for PaintText backends (which would double-paint severely) and neater for PaintGlyphRun backends (which used to rely on per-glyph positioning to accidentally mask the bug).
+- Trailing whitespace on a text leaf (e.g. `"is "` in `"is **bold**"`) now produces `spaceAfter` on the last emitted token, so adjacent inline leaves are separated by a space instead of colliding into `"isbold"`.
+- Pure-whitespace text leaves (e.g. a `soft_break` with `value = " "`) now emit a single zero-width spacer token with `spaceAfter = spaceWidth`. Previously such leaves produced no tokens at all, silently dropping the space between words on either side (`"noDOMelements"`).
 
 ## [0.1.0] — 2026-04-04
 

--- a/code/packages/typescript/layout-block/CHANGELOG.md
+++ b/code/packages/typescript/layout-block/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog — @coding-adventures/layout-block
 
+## Unreleased
+
+### Fixed
+
+- Inline tokens (words sliced out of a text node during word-wrap) no longer carry the parent node's full text value. Previously each token's `content.value` was the entire string, which caused paint backends to render the whole paragraph at every word position. The token now carries just its own word — correct for PaintText backends (which would double-paint severely) and neater for PaintGlyphRun backends (which used to rely on per-glyph positioning to accidentally mask the bug).
+
 ## [0.1.0] — 2026-04-04
 
 ### Added

--- a/code/packages/typescript/layout-block/package-lock.json
+++ b/code/packages/typescript/layout-block/package-lock.json
@@ -736,9 +736,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -753,9 +750,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -770,9 +764,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -787,9 +778,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -804,9 +792,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -821,9 +806,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -838,9 +820,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -855,9 +834,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -872,9 +848,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -889,9 +862,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -906,9 +876,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -923,9 +890,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -940,9 +904,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/code/packages/typescript/layout-block/src/block.ts
+++ b/code/packages/typescript/layout-block/src/block.ts
@@ -284,12 +284,25 @@ function layoutInlineRun(
           break;
       }
 
+      // Tokens represent individual words sliced out of the node's full text
+      // content. The source content object carries the *whole* string, which
+      // would cause the paint layer to render the entire paragraph at every
+      // word position (catastrophic double-paint for PaintText backends, less
+      // visible but still wrong for PaintGlyphRun). Override the value with
+      // just this token's word so the paint layer sees what the layout engine
+      // actually decided to draw at this position.
+      const srcContent = token.node.content;
+      const tokenContent =
+        srcContent !== null && srcContent.kind === "text"
+          ? { ...srcContent, value: token.word }
+          : srcContent;
+
       positioned.push({
         x,
         y: tokenY,
         width: token.width,
         height: token.height,
-        content: token.node.content,
+        content: tokenContent,
         children: [],
         ext: token.node.ext,
       });

--- a/code/packages/typescript/layout-block/src/block.ts
+++ b/code/packages/typescript/layout-block/src/block.ts
@@ -210,12 +210,32 @@ function layoutInlineRun(
         const s = measurer.measure(text, font, Infinity);
         tokens.push({ node, word: text, width: s.width, height: s.height, spaceAfter: 0, verticalAlign });
       } else {
-        // Split on whitespace; each word is a separate token
+        // Split on whitespace; each word is a separate token. A trailing space
+        // on the original leaf (e.g. "is " in "is **bold**") must become a
+        // spaceAfter on the LAST token so the next leaf doesn't collide
+        // into this one (would render as "isbold").
         const words = text.split(/\s+/).filter(w => w.length > 0);
+        const hasTrailingSpace = /\s$/.test(text);
+        if (words.length === 0 && text.length > 0) {
+          // Leaf is pure whitespace (e.g. a soft_break " "). Emit a single
+          // zero-width spacer token so the space between sibling leaves is
+          // preserved. Paint backends render an empty string as a no-op.
+          tokens.push({
+            node,
+            word: "",
+            width: 0,
+            height: measurer.measure("x", font, Infinity).height,
+            spaceAfter: spaceWidth,
+            verticalAlign,
+          });
+        }
         for (let i = 0; i < words.length; i++) {
           const w = words[i];
           const s = measurer.measure(w, font, Infinity);
-          const spaceAfter = i < words.length - 1 ? spaceWidth : 0;
+          const isLast = i === words.length - 1;
+          const spaceAfter = isLast
+            ? (hasTrailingSpace ? spaceWidth : 0)
+            : spaceWidth;
           tokens.push({ node, word: w, width: s.width, height: s.height, spaceAfter, verticalAlign });
         }
       }

--- a/code/packages/typescript/layout-text-measure-canvas/CHANGELOG.md
+++ b/code/packages/typescript/layout-text-measure-canvas/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog — @coding-adventures/layout-text-measure-canvas
 
+## Unreleased
+
+### Fixed
+
+- Prefer `fontBoundingBoxAscent + fontBoundingBoxDescent` (constant per font+size) for the reported height instead of `actualBoundingBoxAscent + actualBoundingBoxDescent` (which varies with which glyphs appear in the word). The per-glyph envelope caused words like "Heading" (has an ascender 'd') and "on" (x-height only) to report different heights at the same font size, which the inline formatting context then aligned bottoms of — leaving jittery baselines across a line. Falls back to the actualBoundingBox on older engines that do not populate the fontBoundingBox fields.
+
 ## 0.1.0 — 2026-04-05
 
 Initial release.

--- a/code/packages/typescript/layout-text-measure-canvas/src/measurer.ts
+++ b/code/packages/typescript/layout-text-measure-canvas/src/measurer.ts
@@ -82,6 +82,13 @@ export interface TextMetricsLike {
   readonly width: number;
   readonly actualBoundingBoxAscent: number;
   readonly actualBoundingBoxDescent: number;
+  // Optional: populated by modern Chrome/Safari/Firefox. These are the font-
+  // wide ascent/descent (constant per font+size) rather than the per-string
+  // glyph envelope. Preferred for line-height and baseline math because
+  // measuring "Hi" and "hi" against a font-wide ascent gives the same line
+  // height — matching what browsers do internally.
+  readonly fontBoundingBoxAscent?: number;
+  readonly fontBoundingBoxDescent?: number;
 }
 
 // ============================================================================
@@ -118,15 +125,27 @@ function measureSingleLine(
 ): { width: number; height: number } {
   ctx.font = fontSpecToCss(font);
   const metrics = ctx.measureText(text);
-  // Note: typeof NaN === "number" — must also guard with isNaN.
-  const ascent = metrics.actualBoundingBoxAscent;
-  const descent = metrics.actualBoundingBoxDescent;
+  // Prefer fontBoundingBox* — constant per font, so two words in the same font
+  // report the same height regardless of which letters they contain. Using
+  // actualBoundingBox* would make "Heading" (has 'd' ascender) taller than
+  // "on" (x-height only), which misaligns their baselines on a shared line.
+  const fontAscent = metrics.fontBoundingBoxAscent;
+  const fontDescent = metrics.fontBoundingBoxDescent;
+  const actualAscent = metrics.actualBoundingBoxAscent;
+  const actualDescent = metrics.actualBoundingBoxDescent;
+
   const height =
-    typeof ascent === "number" && !isNaN(ascent) &&
-    typeof descent === "number" && !isNaN(descent)
-      ? ascent + descent
-      : font.size * font.lineHeight; // fallback if metrics unavailable
+    isFiniteNum(fontAscent) && isFiniteNum(fontDescent)
+      ? fontAscent + fontDescent
+      : isFiniteNum(actualAscent) && isFiniteNum(actualDescent)
+        ? actualAscent + actualDescent
+        : font.size * font.lineHeight; // last-resort fallback
+
   return { width: metrics.width, height };
+}
+
+function isFiniteNum(v: number | undefined): v is number {
+  return typeof v === "number" && !isNaN(v) && isFinite(v);
 }
 
 /**

--- a/code/packages/typescript/layout-to-paint/CHANGELOG.md
+++ b/code/packages/typescript/layout-to-paint/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog — @coding-adventures/layout-to-paint
 
+## Unreleased
+
+### Added
+
+- `textEmitMode: "glyph_run" | "text"` option on `LayoutToPaintOptions`. When `"text"` (new), `TextContent` nodes emit a single `PaintText` instruction per node with a `canvas:<family>@<size>:<weight>[:italic]` `font_ref` rather than a per-character `PaintGlyphRun`. Default remains `"glyph_run"` for backward compatibility. Pipelines driven by a canvas-backed `TextMeasurer` (TXT03d) should select `"text"`; pipelines driven by a font-parser or OS-native measurer should keep the default.
+
 ## [0.1.0] — 2026-04-04
 
 ### Added

--- a/code/packages/typescript/layout-to-paint/CHANGELOG.md
+++ b/code/packages/typescript/layout-to-paint/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `textEmitMode: "glyph_run" | "text"` option on `LayoutToPaintOptions`. When `"text"` (new), `TextContent` nodes emit a single `PaintText` instruction per node with a `canvas:<family>@<size>:<weight>[:italic]` `font_ref` rather than a per-character `PaintGlyphRun`. Default remains `"glyph_run"` for backward compatibility. Pipelines driven by a canvas-backed `TextMeasurer` (TXT03d) should select `"text"`; pipelines driven by a font-parser or OS-native measurer should keep the default.
 
+### Changed
+
+- Baseline offset in the `PaintText` emit path is now `font.size * 0.93` (was `0.8`). This matches `fontBoundingBoxAscent` for typical Latin fonts, which the canvas measurer now reports as the box height — the two numbers need to agree or tokens on the same line render at different baselines.
+
 ## [0.1.0] — 2026-04-04
 
 ### Added

--- a/code/packages/typescript/layout-to-paint/package-lock.json
+++ b/code/packages/typescript/layout-to-paint/package-lock.json
@@ -735,9 +735,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -752,9 +749,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -769,9 +763,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -786,9 +777,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -803,9 +791,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -820,9 +805,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -837,9 +819,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -854,9 +833,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -871,9 +847,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -888,9 +861,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -905,9 +875,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -922,9 +889,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -939,9 +903,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/code/packages/typescript/layout-to-paint/src/paint.ts
+++ b/code/packages/typescript/layout-to-paint/src/paint.ts
@@ -77,6 +77,7 @@ import type {
   PaintScene,
   PaintInstruction,
   PaintGlyphRun,
+  PaintText,
   PaintImage,
   PaintRect,
   PaintLayer,
@@ -115,6 +116,27 @@ export interface LayoutToPaintOptions {
    * Example: a node at x=10, y=20 with dpr=2.0 → PaintInstruction x=20, y=40.
    */
   devicePixelRatio?: number;
+
+  /**
+   * How TextContent nodes are emitted. Default: `"glyph_run"`.
+   *
+   * - `"glyph_run"` — emit PaintGlyphRun, one glyph per character, using a
+   *   `font.size × 0.6` advance approximation. Works with every paint
+   *   backend, including those that consume glyph IDs (Metal, Direct2D).
+   *   This is the historical behaviour.
+   *
+   * - `"text"` — emit a single PaintText instruction per TextContent,
+   *   carrying the literal string and a `canvas:<family>@<size>...`
+   *   font_ref. The paint backend (paint-vm-canvas) sets `ctx.font` and
+   *   calls `ctx.fillText(str, x, y_baseline)` at dispatch time, letting
+   *   the browser handle shaping + fallback. See spec TXT03d and the
+   *   P2D00 "GlyphRun vs Text" section.
+   *
+   * Pipelines driven by a canvas-backed TextMeasurer (TXT03d) should use
+   * `"text"`; pipelines driven by a font-parser or OS-native measurer
+   * (TXT01/02/04, TXT03a/b/c) should use `"glyph_run"`.
+   */
+  textEmitMode?: "glyph_run" | "text";
 }
 
 // ============================================================================
@@ -182,11 +204,12 @@ export function layout_to_paint(
 ): PaintScene {
   const dpr = options.devicePixelRatio ?? 1.0;
   const bg = options.background ? colorToCss(options.background) : "transparent";
+  const textMode = options.textEmitMode ?? "glyph_run";
 
   const instructions: PaintInstruction[] = [];
 
   for (const node of nodes) {
-    emitNode(node, 0, 0, dpr, instructions);
+    emitNode(node, 0, 0, dpr, textMode, instructions);
   }
 
   return {
@@ -206,6 +229,7 @@ function emitNode(
   parentAbsX: number,
   parentAbsY: number,
   dpr: number,
+  textMode: "glyph_run" | "text",
   out: PaintInstruction[]
 ): void {
   const absX = parentAbsX + node.x;
@@ -218,7 +242,7 @@ function emitNode(
   // If opacity < 1, wrap everything in a PaintLayer for correct compositing.
   if (hasOpacity) {
     const layerChildren: PaintInstruction[] = [];
-    emitNodeInstructions(node, absX, absY, dpr, layerChildren);
+    emitNodeInstructions(node, absX, absY, dpr, textMode, layerChildren);
     const layer: PaintLayer = {
       kind: "layer",
       opacity,
@@ -228,7 +252,7 @@ function emitNode(
     return;
   }
 
-  emitNodeInstructions(node, absX, absY, dpr, out);
+  emitNodeInstructions(node, absX, absY, dpr, textMode, out);
 }
 
 function emitNodeInstructions(
@@ -236,6 +260,7 @@ function emitNodeInstructions(
   absX: number,
   absY: number,
   dpr: number,
+  textMode: "glyph_run" | "text",
   out: PaintInstruction[]
 ): void {
   const paintExt = (node.ext["paint"] ?? {}) as PaintExt;
@@ -285,8 +310,8 @@ function emitNodeInstructions(
   if (paintExt.cornerRadius && (node.content !== null || node.children.length > 0)) {
     // Clip content and children to rounded rect bounds.
     const clipped: PaintInstruction[] = [];
-    emitContent(node, absX, absY, dpr, clipped);
-    emitChildren(node, absX, absY, dpr, clipped);
+    emitContent(node, absX, absY, dpr, textMode, clipped);
+    emitChildren(node, absX, absY, dpr, textMode, clipped);
 
     const clip: PaintClip = {
       kind: "clip",
@@ -298,8 +323,8 @@ function emitNodeInstructions(
     };
     out.push(clip);
   } else {
-    emitContent(node, absX, absY, dpr, out);
-    emitChildren(node, absX, absY, dpr, out);
+    emitContent(node, absX, absY, dpr, textMode, out);
+    emitChildren(node, absX, absY, dpr, textMode, out);
   }
 }
 
@@ -312,12 +337,17 @@ function emitContent(
   absX: number,
   absY: number,
   dpr: number,
+  textMode: "glyph_run" | "text",
   out: PaintInstruction[]
 ): void {
   if (node.content === null) return;
 
   if (node.content.kind === "text") {
-    emitText(node.content, absX, absY, node.width, dpr, out);
+    if (textMode === "text") {
+      emitTextAsPaintText(node.content, absX, absY, node.width, dpr, out);
+    } else {
+      emitText(node.content, absX, absY, node.width, dpr, out);
+    }
   } else if (node.content.kind === "image") {
     emitImage(node.content, absX, absY, node.width, node.height, dpr, out);
   }
@@ -381,6 +411,64 @@ function emitText(
 }
 
 /**
+ * Convert `TextContent` to a single `PaintText` instruction (canvas-native path).
+ *
+ * This emits one PaintText per TextContent node, carrying the literal string
+ * and a `canvas:` font_ref that encodes family, size, weight, and style per
+ * spec TXT03d. Line wrapping is expected to have happened in the layout phase
+ * (via CanvasTextMeasurer in UI09). At paint time, the browser re-shapes and
+ * rasterizes via `ctx.fillText`.
+ *
+ * This does NOT split per-glyph — Canvas has no addressable glyph IDs. Font
+ * fallback (e.g. Apple Color Emoji for a single emoji inside a Latin run) is
+ * delegated to the browser and is invisible at the paint IR level.
+ *
+ * Trade-off: we lose per-character hit-testing information. A future
+ * enhancement can populate `cluster_positions` by walking each character and
+ * calling `ctx.measureText` to build a cluster→x offset map.
+ */
+function emitTextAsPaintText(
+  content: TextContent,
+  absX: number,
+  absY: number,
+  nodeWidth: number,
+  dpr: number,
+  out: PaintInstruction[]
+): void {
+  if (content.value.length === 0) return;
+
+  const font = content.font;
+  // Approximate the baseline from the top of the node. Canvas's default
+  // textBaseline is "alphabetic"; 0.8 × font.size places the baseline at a
+  // realistic offset for most Latin fonts. A proper layout measurer would
+  // compute this from font metrics (ascent).
+  const baselineY = absY + font.size * 0.8;
+
+  const family = font.family || "sans-serif";
+  // Build "canvas:<family>@<size>:<weight>[:italic]" per TXT03d grammar.
+  // The family string is encoded as-is; paint-vm-canvas sanitizes it before
+  // interpolating into ctx.font.
+  let fontRef = `canvas:${family}@${font.size}:${font.weight}`;
+  if (font.italic) fontRef += ":italic";
+
+  const paintText: PaintText = {
+    kind: "text",
+    x: absX * dpr,
+    y: baselineY * dpr,
+    text: content.value,
+    font_ref: fontRef,
+    font_size: font.size * dpr,
+    fill: colorToCss(content.color),
+    metadata: {
+      "layout:maxWidth": nodeWidth * dpr,
+      "layout:textAlign": content.textAlign,
+    },
+  };
+
+  out.push(paintText);
+}
+
+/**
  * Convert `ImageContent` to a `PaintImage`.
  */
 function emitImage(
@@ -411,9 +499,10 @@ function emitChildren(
   absX: number,
   absY: number,
   dpr: number,
+  textMode: "glyph_run" | "text",
   out: PaintInstruction[]
 ): void {
   for (const child of node.children) {
-    emitNode(child, absX, absY, dpr, out);
+    emitNode(child, absX, absY, dpr, textMode, out);
   }
 }

--- a/code/packages/typescript/layout-to-paint/src/paint.ts
+++ b/code/packages/typescript/layout-to-paint/src/paint.ts
@@ -438,11 +438,12 @@ function emitTextAsPaintText(
   if (content.value.length === 0) return;
 
   const font = content.font;
-  // Approximate the baseline from the top of the node. Canvas's default
-  // textBaseline is "alphabetic"; 0.8 × font.size places the baseline at a
-  // realistic offset for most Latin fonts. A proper layout measurer would
-  // compute this from font metrics (ascent).
-  const baselineY = absY + font.size * 0.8;
+  // Baseline offset from the top of the node box. The measurer reports height
+  // using fontBoundingBoxAscent + fontBoundingBoxDescent, which for typical
+  // Latin fonts matches font.size × 1.15 — with ascent ≈ font.size × 0.93
+  // and descent ≈ font.size × 0.22. Using 0.93 here places the baseline
+  // inside the reported box consistently across same-font tokens on a line.
+  const baselineY = absY + font.size * 0.93;
 
   const family = font.family || "sans-serif";
   // Build "canvas:<family>@<size>:<weight>[:italic]" per TXT03d grammar.

--- a/code/packages/typescript/layout-to-paint/tests/paint.test.ts
+++ b/code/packages/typescript/layout-to-paint/tests/paint.test.ts
@@ -9,7 +9,7 @@ import { describe, it, expect } from "vitest";
 import { layout_to_paint, colorToCss } from "../src/index.js";
 import type { PositionedNode } from "@coding-adventures/layout-ir";
 import { rgb, rgba, font_spec } from "@coding-adventures/layout-ir";
-import type { PaintRect, PaintGlyphRun, PaintImage, PaintLayer, PaintClip } from "@coding-adventures/paint-instructions";
+import type { PaintRect, PaintGlyphRun, PaintText, PaintImage, PaintLayer, PaintClip } from "@coding-adventures/paint-instructions";
 
 // ============================================================================
 // Helpers
@@ -195,6 +195,91 @@ describe("text nodes", () => {
     });
     const run = scene.instructions[0] as PaintGlyphRun;
     expect(run.font_size).toBe(32); // 16 × 2
+  });
+});
+
+// ============================================================================
+// TXT03d — textEmitMode: "text" emits PaintText instead of PaintGlyphRun
+// ============================================================================
+
+describe("textEmitMode \"text\" (canvas-native path)", () => {
+  it("emits a PaintText, not a PaintGlyphRun, for text content", () => {
+    const scene = layout_to_paint(
+      [textNode(10, 5, 100, 20, "Hello")],
+      { width: 100, height: 20, textEmitMode: "text" },
+    );
+    expect(scene.instructions).toHaveLength(1);
+    const t = scene.instructions[0] as PaintText;
+    expect(t.kind).toBe("text");
+    expect(t.text).toBe("Hello");
+  });
+
+  it("emits exactly one PaintText per TextContent node (no per-glyph splitting)", () => {
+    const scene = layout_to_paint(
+      [textNode(0, 0, 200, 20, "Hello world")],
+      { width: 200, height: 20, textEmitMode: "text" },
+    );
+    const texts = scene.instructions.filter((i) => i.kind === "text");
+    expect(texts).toHaveLength(1);
+  });
+
+  it("font_ref uses canvas: scheme with family@size:weight", () => {
+    const scene = layout_to_paint(
+      [textNode(0, 0, 100, 20, "X")],
+      { width: 100, height: 20, textEmitMode: "text" },
+    );
+    const t = scene.instructions[0] as PaintText;
+    expect(t.font_ref).toMatch(/^canvas:[A-Za-z][A-Za-z0-9 ]*@\d+:\d+$/);
+    expect(t.font_ref).toContain("Arial");
+    expect(t.font_ref).toContain("@16");
+    expect(t.font_ref).toContain(":400");
+  });
+
+  it("italic font appends :italic to font_ref", () => {
+    const italicFont = { ...font, italic: true };
+    const node: PositionedNode = {
+      ...textNode(0, 0, 100, 20, "X"),
+      content: { kind: "text", value: "X", font: italicFont, color: black, maxLines: null, textAlign: "start" },
+    };
+    const scene = layout_to_paint([node], { width: 100, height: 20, textEmitMode: "text" });
+    const t = scene.instructions[0] as PaintText;
+    expect(t.font_ref).toMatch(/:italic$/);
+  });
+
+  it("fill color comes from text content color", () => {
+    const node: PositionedNode = {
+      ...textNode(0, 0, 100, 20, "X"),
+      content: { kind: "text", value: "X", font, color: red, maxLines: null, textAlign: "start" },
+    };
+    const scene = layout_to_paint([node], { width: 100, height: 20, textEmitMode: "text" });
+    const t = scene.instructions[0] as PaintText;
+    expect(t.fill).toBe("rgba(255,0,0,1)");
+  });
+
+  it("position and font_size scale with dpr", () => {
+    const scene = layout_to_paint(
+      [textNode(10, 5, 100, 20, "X")],
+      { width: 100, height: 20, devicePixelRatio: 2.0, textEmitMode: "text" },
+    );
+    const t = scene.instructions[0] as PaintText;
+    expect(t.x).toBe(20); // 10 × 2
+    expect(t.font_size).toBe(32); // 16 × 2
+  });
+
+  it("empty text does not emit a PaintText", () => {
+    const scene = layout_to_paint(
+      [textNode(0, 0, 100, 20, "")],
+      { width: 100, height: 20, textEmitMode: "text" },
+    );
+    expect(scene.instructions).toHaveLength(0);
+  });
+
+  it("default textEmitMode is glyph_run (backward compat)", () => {
+    const scene = layout_to_paint(
+      [textNode(0, 0, 100, 20, "X")],
+      { width: 100, height: 20 },
+    );
+    expect(scene.instructions[0].kind).toBe("glyph_run");
   });
 });
 

--- a/code/packages/typescript/paint-instructions/CHANGELOG.md
+++ b/code/packages/typescript/paint-instructions/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Added
+
+- `PaintText` instruction — string-level text rendering for runtimes that own shaping at paint time (HTML Canvas 2D, and future SVG / CSS targets). Carries `{text, font_ref, font_size, x, y, fill}`; the `font_ref` scheme prefix (`canvas:`) routes dispatch. Companion to `PaintGlyphRun` (which stays the instruction for glyph-ID-addressable backends like Metal / Direct2D). See spec TXT03d and the revised P2D00 "GlyphRun vs Text" section.
+- `paintText(x, y, text, font_ref, font_size, fill, options?)` factory helper.
+
 ### Fixed
 
 - import the `PixelContainer` type locally as well as re-exporting it so sibling TypeScript packages can type-check against `paintImage()` and `PaintImage.src`

--- a/code/packages/typescript/paint-instructions/src/index.ts
+++ b/code/packages/typescript/paint-instructions/src/index.ts
@@ -371,6 +371,61 @@ export interface PaintGlyphRun extends PaintBase {
 }
 
 /**
+ * PaintText — a string of text with a font descriptor, positioned at a baseline.
+ *
+ * The sibling of PaintGlyphRun for runtimes that do their own shaping at paint
+ * time and do NOT expose glyph IDs to the caller. The primary consumer is HTML
+ * Canvas 2D (`ctx.fillText(text, x, y)`), which accepts only strings — see
+ * spec TXT03d and the P2D00 "GlyphRun vs Text" section.
+ *
+ * Why two instructions, not one?
+ * ------------------------------
+ *
+ * The font-binding invariant from TXT00 says: glyph IDs are opaque tokens bound
+ * to the shaper that produced them. A Canvas backend cannot consume synthesized
+ * glyph IDs — there is no `ctx.drawGlyphs(ids[])` API. Forcing a PaintGlyphRun
+ * through canvas means mapping glyph_id back to a codepoint and guessing, which
+ * breaks the invariant.
+ *
+ * PaintText is the honest representation for canvas: the layout engine has
+ * measured the line (via `ctx.measureText`) to decide line wraps and positions,
+ * but final shaping + fallback + rasterization happen inside `fillText` at
+ * dispatch time. The browser's text stack owns that last mile.
+ *
+ * The font-binding invariant still holds — on a coarser grain. A PaintText
+ * with `font_ref: "canvas:Helvetica@16"` is bindable only to a canvas-capable
+ * backend. Routing it to paint-vm-metal or paint-vm-direct2d MUST throw
+ * UnsupportedFontBindingError. The binding is the runtime, not the glyph index.
+ *
+ * Which instruction does layout-to-paint emit?
+ * --------------------------------------------
+ *
+ *   Font-parser (TXT01) + naive/HarfBuzz shaper (TXT02/04) → PaintGlyphRun
+ *   CoreText measurer (TXT03a)                             → PaintGlyphRun
+ *   DirectWrite / Pango (TXT03b/c)                         → PaintGlyphRun
+ *   Canvas measurer (TXT03d)                               → PaintText
+ *
+ * A pipeline picks one emitter at configuration time; instructions of both
+ * kinds may coexist in one scene only if both backends are available
+ * (uncommon).
+ */
+export interface PaintText extends PaintBase {
+  kind: "text";
+  x: number;         // baseline origin x — the left edge of the first character's advance
+  y: number;         // baseline origin y — NOT the top of the text, but the baseline
+  text: string;      // the literal text to render (UTF-16 in TypeScript)
+  font_ref: string;  // opaque font reference; e.g. "canvas:Helvetica@16:700"
+                     // the scheme prefix (canvas:, css:, svg:) routes dispatch
+  font_size: number; // in user-space units (same units as x, y)
+  fill: string;      // color of the text — required (no default)
+
+  // Optional: map from cluster (string index) to pen x-offset, computed by the
+  // layout engine via its TextMeasurer. Enables hit-testing and selection
+  // without re-measuring at paint time. Omit for simple rendering.
+  cluster_positions?: Array<{ cluster: number; x: number }>;
+}
+
+/**
  * PaintGroup — logical container for transform and state inheritance.
  *
  * A group renders directly into the parent surface — no separate buffer is
@@ -560,6 +615,7 @@ export interface PaintImage extends PaintBase {
  *     case "ellipse":   // PaintEllipse
  *     case "path":      // PaintPath
  *     case "glyph_run": // PaintGlyphRun
+ *     case "text":      // PaintText (Canvas-runtime string-level text; see TXT03d)
  *     case "group":     // PaintGroup
  *     case "layer":     // PaintLayer
  *     case "line":      // PaintLine
@@ -573,6 +629,7 @@ export type PaintInstruction =
   | PaintEllipse
   | PaintPath
   | PaintGlyphRun
+  | PaintText
   | PaintGroup
   | PaintLayer
   | PaintLine
@@ -792,4 +849,32 @@ export function paintImage(
   options?: Omit<PaintImage, "kind" | "x" | "y" | "width" | "height" | "src">,
 ): PaintImage {
   return { kind: "image", x, y, width, height, src, ...options };
+}
+
+/**
+ * Create a PaintText instruction.
+ *
+ * Use this when the paint backend is a runtime that does its own shaping at
+ * paint time (HTML Canvas 2D via `ctx.fillText`). For backends that consume
+ * pre-shaped glyph indices (Metal, Direct2D with DirectWrite), use
+ * PaintGlyphRun instead.
+ *
+ * font_ref is an opaque string with a scheme prefix that routes dispatch:
+ *   "canvas:<family>@<size>[:<weight>[:<style>]]"  — HTML Canvas
+ *   "css:<css-font-shorthand>"                      — deferred
+ *   "svg:<family>@<size>"                           — deferred
+ *
+ * Example:
+ *   paintText(20, 40, "Hello world", "canvas:Helvetica@16", 16, "#111")
+ */
+export function paintText(
+  x: number,
+  y: number,
+  text: string,
+  font_ref: string,
+  font_size: number,
+  fill: string,
+  options?: Omit<PaintText, "kind" | "x" | "y" | "text" | "font_ref" | "font_size" | "fill">,
+): PaintText {
+  return { kind: "text", x, y, text, font_ref, font_size, fill, ...options };
 }

--- a/code/packages/typescript/paint-instructions/tests/paint-instructions.test.ts
+++ b/code/packages/typescript/paint-instructions/tests/paint-instructions.test.ts
@@ -11,6 +11,7 @@ import {
   paintClip,
   paintGradient,
   paintImage,
+  paintText,
   type PaintInstruction,
   type PaintScene,
   type PaintRect,
@@ -392,6 +393,40 @@ describe("paintImage", () => {
   it("supports opacity", () => {
     const img = paintImage(0, 0, 100, 100, "file:///x.png", { opacity: 0.8 });
     expect(img.opacity).toBe(0.8);
+  });
+});
+
+// ============================================================================
+// paintText builder
+// ============================================================================
+
+describe("paintText", () => {
+  it("creates a text instruction with the required fields", () => {
+    const t = paintText(10, 20, "Hello", "canvas:Helvetica@16", 16, "#111");
+    expect(t.kind).toBe("text");
+    expect(t.x).toBe(10);
+    expect(t.y).toBe(20);
+    expect(t.text).toBe("Hello");
+    expect(t.font_ref).toBe("canvas:Helvetica@16");
+    expect(t.font_size).toBe(16);
+    expect(t.fill).toBe("#111");
+  });
+
+  it("passes through optional cluster_positions", () => {
+    const t = paintText(0, 0, "Hi", "canvas:Arial@16", 16, "#000", {
+      cluster_positions: [{ cluster: 0, x: 0 }, { cluster: 1, x: 8 }],
+    });
+    expect(t.cluster_positions).toHaveLength(2);
+    expect(t.cluster_positions?.[1].x).toBe(8);
+  });
+
+  it("passes through optional metadata and id from PaintBase", () => {
+    const t = paintText(0, 0, "X", "canvas:Arial@16", 16, "#000", {
+      id: "tag-1",
+      metadata: { "layout:align": "start" },
+    });
+    expect(t.id).toBe("tag-1");
+    expect(t.metadata?.["layout:align"]).toBe("start");
   });
 });
 

--- a/code/packages/typescript/paint-vm-canvas/CHANGELOG.md
+++ b/code/packages/typescript/paint-vm-canvas/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog — @coding-adventures/paint-vm-canvas
 
+## Unreleased
+
+### Added
+
+- `PaintText` handler — dispatches the new `PaintText` instruction from P2D00 using `ctx.fillText`. Parses `canvas:<family>@<size>[:<weight>[:<style>]]` font_refs into CSS font shorthand, validates and sanitizes the family string, clamps out-of-range weights to 400, and throws `UnsupportedFontBindingError` for any non-`canvas:` scheme (enforcing the font-binding invariant from TXT00/TXT03d).
+- `UnsupportedFontBindingError` export — thrown when `PaintText.font_ref` uses a scheme that this backend cannot consume (e.g. `coretext:`, `directwrite:`).
+- Handler count increased from 10 to 11 (new `text` kind registered alongside `glyph_run`).
+
 ## [0.1.0] — 2026-04-03
 
 ### Added

--- a/code/packages/typescript/paint-vm-canvas/src/index.ts
+++ b/code/packages/typescript/paint-vm-canvas/src/index.ts
@@ -68,6 +68,7 @@ import type {
   PaintEllipse,
   PaintPath,
   PaintGlyphRun,
+  PaintText,
   PaintGroup,
   PaintLayer,
   PaintLine,
@@ -383,6 +384,100 @@ function handleGlyphRun(
   }
 }
 
+/**
+ * UnsupportedFontBindingError — thrown when a PaintText instruction carries a
+ * font_ref scheme that this backend cannot consume. Matches the font-binding
+ * invariant from TXT00 / P2D00: a font_ref is opaque token bound to a
+ * specific shaper/runtime, and the paint backend must refuse mismatches
+ * rather than guess.
+ */
+export class UnsupportedFontBindingError extends Error {
+  constructor(fontRef: string) {
+    super(
+      `PaintVM Canvas: unsupported font_ref scheme "${fontRef}". ` +
+        `This backend only accepts scheme "canvas:" (see spec TXT03d). ` +
+        `Routing a PaintText with a different scheme (e.g. "coretext:", ` +
+        `"directwrite:") would violate the font-binding invariant.`,
+    );
+    this.name = "UnsupportedFontBindingError";
+  }
+}
+
+/**
+ * Parse a "canvas:" font_ref into a CSS font shorthand that ctx.font accepts.
+ *
+ * Grammar (from spec TXT03d):
+ *
+ *   font_ref := "canvas:" <family> "@" <px_size> [ ":" <weight> [ ":" <style> ] ]
+ *
+ * Examples:
+ *
+ *   "canvas:Helvetica@16"              → "400 16px 'Helvetica'"
+ *   "canvas:Helvetica@16:700"          → "700 16px 'Helvetica'"
+ *   "canvas:Helvetica@16:700:italic"   → "italic 700 16px 'Helvetica'"
+ *   "canvas:system-ui@14"              → "400 14px 'system-ui'"
+ *
+ * Security: family is run through sanitizeFontRef to strip any CSS-injection
+ * characters. Weight is validated as a number in [1, 1000]. Style is checked
+ * against an allowlist. Any malformed input falls back to "16px sans-serif".
+ *
+ * The font_size argument overrides the size encoded in font_ref — the layout
+ * engine is the source of truth for size at paint time.
+ */
+function canvasFontRefToCss(fontRef: string, fontSize: number): string {
+  if (!fontRef.startsWith("canvas:")) {
+    throw new UnsupportedFontBindingError(fontRef);
+  }
+  const body = fontRef.slice("canvas:".length);
+
+  // Split family from size/weight/style
+  const atIdx = body.indexOf("@");
+  const family = atIdx >= 0 ? body.slice(0, atIdx) : body;
+  const rest = atIdx >= 0 ? body.slice(atIdx + 1) : "";
+  const parts = rest.split(":");
+  // parts[0] is size (we ignore it in favour of the authoritative font_size arg)
+  const weightStr = parts[1];
+  const styleStr = parts[2];
+
+  const safeFamily = sanitizeFontRef(family) || "sans-serif";
+
+  let weight = "400";
+  if (weightStr !== undefined) {
+    const w = Number(weightStr);
+    if (Number.isFinite(w) && w >= 1 && w <= 1000) {
+      weight = String(Math.round(w));
+    }
+  }
+
+  let style = "";
+  if (styleStr === "italic" || styleStr === "oblique") {
+    style = `${styleStr} `;
+  }
+
+  return `${style}${weight} ${fontSize}px '${safeFamily}'`;
+}
+
+function handleText(
+  instr: PaintText,
+  ctx: CanvasRenderingContext2D,
+): void {
+  // Validate font_size first — it goes directly into the CSS font shorthand.
+  if (!Number.isFinite(instr.font_size)) {
+    throw new RangeError(
+      `PaintVM Canvas: font_size must be a finite number, got ${instr.font_size}`,
+    );
+  }
+  ctx.save();
+  ctx.font = canvasFontRefToCss(instr.font_ref, instr.font_size);
+  ctx.fillStyle = instr.fill;
+  // PaintText coordinates are a baseline origin (same semantics as PaintGlyphRun).
+  // Canvas default textBaseline is "alphabetic", which aligns to the baseline —
+  // exactly what we want.
+  ctx.textBaseline = "alphabetic";
+  ctx.fillText(instr.text, instr.x, instr.y);
+  ctx.restore();
+}
+
 function handleGroup(
   instr: PaintGroup,
   ctx: CanvasRenderingContext2D,
@@ -660,6 +755,9 @@ export function createCanvasVM(): PaintVM<CanvasRenderingContext2D> {
   });
   vm.register("glyph_run", (instr, ctx) => {
     if (instr.kind === "glyph_run") handleGlyphRun(instr as PaintGlyphRun, ctx);
+  });
+  vm.register("text", (instr, ctx) => {
+    if (instr.kind === "text") handleText(instr as PaintText, ctx);
   });
   vm.register("group", (instr, ctx, vm) => {
     if (instr.kind === "group") handleGroup(instr as PaintGroup, ctx, vm);

--- a/code/packages/typescript/paint-vm-canvas/tests/paint-vm-canvas.test.ts
+++ b/code/packages/typescript/paint-vm-canvas/tests/paint-vm-canvas.test.ts
@@ -31,9 +31,11 @@ import {
   paintClip,
   paintGradient,
   paintImage,
+  paintText,
   type PixelContainer,
 } from "@coding-adventures/paint-instructions";
 import { ExportNotSupportedError } from "@coding-adventures/paint-vm";
+import { UnsupportedFontBindingError } from "../src/index.js";
 
 // ============================================================================
 // Global Path2D mock
@@ -109,6 +111,7 @@ function makeCtx(): CanvasRenderingContext2D {
     globalCompositeOperation: "source-over" as GlobalCompositeOperation,
     filter: "none",
     font: "",
+    textBaseline: "alphabetic" as CanvasTextBaseline,
 
     // --- methods (tracked by spies) ---
     clearRect: vi.fn(),
@@ -161,12 +164,12 @@ describe("VERSION", () => {
 // ============================================================================
 
 describe("createCanvasVM()", () => {
-  it("returns a VM with all 10 instruction kinds registered", () => {
+  it("returns a VM with all 11 instruction kinds registered", () => {
     const vm = createCanvasVM();
     const kinds = vm.registeredKinds().sort();
     expect(kinds).toEqual([
       "clip", "ellipse", "glyph_run", "gradient", "group",
-      "image", "layer", "line", "path", "rect",
+      "image", "layer", "line", "path", "rect", "text",
     ]);
   });
 });
@@ -1121,5 +1124,131 @@ describe("Canvas filter string", () => {
       ctx,
     );
     expect(ctx.filter).toBe("none");
+  });
+});
+
+// ============================================================================
+// PaintText — TXT03d canvas-native text path
+// ============================================================================
+
+describe("PaintText dispatch", () => {
+  it("sets ctx.font from a minimal canvas: font_ref and calls fillText", () => {
+    const vm = createCanvasVM();
+    const ctx = makeCtx();
+    vm.execute(
+      paintScene(400, 100, "transparent", [
+        paintText(20, 40, "Hello", "canvas:Helvetica@16", 16, "#111"),
+      ]),
+      ctx,
+    );
+    // font shorthand: weight 400 is the default when no weight suffix is present
+    expect(ctx.font).toBe("400 16px 'Helvetica'");
+    expect(ctx.fillStyle).toBe("#111");
+    expect(ctx.textBaseline).toBe("alphabetic");
+    expect(ctx.fillText).toHaveBeenCalledWith("Hello", 20, 40);
+  });
+
+  it("parses weight from canvas:<family>@<size>:<weight>", () => {
+    const vm = createCanvasVM();
+    const ctx = makeCtx();
+    vm.execute(
+      paintScene(400, 100, "transparent", [
+        paintText(0, 20, "Bold", "canvas:Helvetica@16:700", 16, "#000"),
+      ]),
+      ctx,
+    );
+    expect(ctx.font).toBe("700 16px 'Helvetica'");
+  });
+
+  it("parses italic style from canvas:<family>@<size>:<weight>:italic", () => {
+    const vm = createCanvasVM();
+    const ctx = makeCtx();
+    vm.execute(
+      paintScene(400, 100, "transparent", [
+        paintText(0, 20, "Oblique", "canvas:Georgia@14:400:italic", 14, "#000"),
+      ]),
+      ctx,
+    );
+    expect(ctx.font).toBe("italic 400 14px 'Georgia'");
+  });
+
+  it("ignores the size encoded in font_ref — font_size argument wins", () => {
+    const vm = createCanvasVM();
+    const ctx = makeCtx();
+    // font_ref says 16; but font_size is the authoritative size from the layout engine
+    vm.execute(
+      paintScene(400, 100, "transparent", [
+        paintText(0, 40, "Sized", "canvas:Helvetica@16:700", 32, "#000"),
+      ]),
+      ctx,
+    );
+    expect(ctx.font).toBe("700 32px 'Helvetica'");
+  });
+
+  it("sanitizes a family name that contains CSS-injection characters", () => {
+    const vm = createCanvasVM();
+    const ctx = makeCtx();
+    // Adversarial family with characters that could break out of the string
+    vm.execute(
+      paintScene(400, 100, "transparent", [
+        paintText(0, 20, "X", "canvas:Helvetica'; color: red;@16:400", 16, "#000"),
+      ]),
+      ctx,
+    );
+    // Semicolons, apostrophes, and braces stripped; only alnum/space/hyphen/comma
+    // remain inside the quoted family name.
+    expect(ctx.font).toMatch(/^400 16px '[A-Za-z ]+'$/);
+    expect(ctx.font).not.toContain(";");
+    expect(ctx.font).not.toContain("'; ");
+  });
+
+  it("clamps a nonsense weight to the default 400", () => {
+    const vm = createCanvasVM();
+    const ctx = makeCtx();
+    vm.execute(
+      paintScene(400, 100, "transparent", [
+        paintText(0, 20, "X", "canvas:Helvetica@16:99999", 16, "#000"),
+      ]),
+      ctx,
+    );
+    expect(ctx.font).toBe("400 16px 'Helvetica'");
+  });
+
+  it("throws UnsupportedFontBindingError for non-canvas scheme", () => {
+    const vm = createCanvasVM();
+    const ctx = makeCtx();
+    expect(() =>
+      vm.execute(
+        paintScene(400, 100, "transparent", [
+          paintText(0, 20, "X", "coretext:Helvetica-Bold@16", 16, "#000"),
+        ]),
+        ctx,
+      ),
+    ).toThrow(UnsupportedFontBindingError);
+  });
+
+  it("throws RangeError when font_size is not a finite number", () => {
+    const vm = createCanvasVM();
+    const ctx = makeCtx();
+    expect(() =>
+      vm.execute(
+        paintScene(400, 100, "transparent", [
+          paintText(0, 20, "X", "canvas:Helvetica@16", NaN, "#000"),
+        ]),
+        ctx,
+      ),
+    ).toThrow(RangeError);
+  });
+
+  it("falls back to sans-serif when family portion is empty", () => {
+    const vm = createCanvasVM();
+    const ctx = makeCtx();
+    vm.execute(
+      paintScene(400, 100, "transparent", [
+        paintText(0, 20, "X", "canvas:@16:400", 16, "#000"),
+      ]),
+      ctx,
+    );
+    expect(ctx.font).toBe("400 16px 'sans-serif'");
   });
 });

--- a/code/programs/typescript/markdown-canvas-demo/CHANGELOG.md
+++ b/code/programs/typescript/markdown-canvas-demo/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog — markdown-canvas-demo
+
+## Unreleased
+
+### Added
+
+- Initial implementation. Parses CommonMark, lays out via `layout-block` with
+  `CanvasTextMeasurer`, emits `PaintText` via `layout-to-paint` with
+  `textEmitMode: "text"`, and paints into a `<canvas>` through
+  `paint-vm-canvas`. Zero DOM for output.
+- Live re-render on every keystroke; stats overlay shows instruction count,
+  PaintText count, and frame time.
+- Small normalization helper that coerces `LayoutNode.width: null` →
+  `size_fill()` and `LayoutNode.height: null` → `size_wrap()` so the demo
+  can run against the current document-ast-to-layout output (which emits
+  null sizes by default).

--- a/code/programs/typescript/markdown-canvas-demo/CHANGELOG.md
+++ b/code/programs/typescript/markdown-canvas-demo/CHANGELOG.md
@@ -11,6 +11,11 @@
 - Live re-render on every keystroke; stats overlay shows instruction count,
   PaintText count, and frame time.
 - Small normalization helper that coerces `LayoutNode.width: null` →
-  `size_fill()` and `LayoutNode.height: null` → `size_wrap()` so the demo
-  can run against the current document-ast-to-layout output (which emits
-  null sizes by default).
+  `size_fill()` (block) or `size_wrap()` (inline) and `LayoutNode.height:
+  null` → `size_wrap()` so the demo can run against the current
+  document-ast-to-layout output (which emits null sizes by default).
+- List-item adapter: flex-row containers from `document-ast-to-layout` are
+  flattened into an inline sequence of text leaves. Layout-block does not
+  implement flex, so without this adapter "1." and the list body would
+  stack vertically. A proper fix lives in a future layout-flexbox
+  integration; this keeps the demo readable now.

--- a/code/programs/typescript/markdown-canvas-demo/README.md
+++ b/code/programs/typescript/markdown-canvas-demo/README.md
@@ -1,0 +1,50 @@
+# markdown-canvas-demo
+
+Live Markdown → Canvas demo. Type Markdown on the left, watch it render
+directly into an HTML canvas on the right — **no DOM for output**. Every
+pixel of the rendered document lives inside a single `<canvas>` element.
+
+## What it does
+
+- Split-pane UI: Markdown editor on the left, canvas renderer on the right.
+- Re-renders the canvas on every keystroke.
+- Shows instruction counts and frame time in the footer.
+- Demonstrates the full TXT03d pipeline:
+  - Parse CommonMark → Document AST
+  - Document AST → LayoutNode
+  - `layout-block` + `CanvasTextMeasurer` → PositionedNode
+  - `layout-to-paint` with `textEmitMode: "text"` → PaintScene of `PaintText`
+    instructions
+  - `paint-vm-canvas` dispatches each `PaintText` via `ctx.fillText`
+
+## Why canvas, not DOM?
+
+Canvas 2D is an imperative rasterizer — no retained tree, no layout engine
+of its own, no HTML parsing. That makes it the right target for fully
+custom layout, animations, very large documents, and offscreen / worker
+rendering. But canvas has no `drawGlyphs(glyph_ids[])` API — it can only
+draw strings via `ctx.fillText`. That constraint is what `PaintText`
+(spec P2D00 amendment + TXT03d) encodes: when the paint backend does its
+own shaping internally, the IR speaks in strings, not glyph indices.
+
+## Running locally
+
+```bash
+cd code/programs/typescript/markdown-canvas-demo
+npm install
+npm run dev
+```
+
+Then open http://localhost:5173/.
+
+## Related packages
+
+- [`@coding-adventures/paint-instructions`](../../packages/typescript/paint-instructions) — the `PaintText` instruction is defined here.
+- [`@coding-adventures/paint-vm-canvas`](../../packages/typescript/paint-vm-canvas) — the canvas-side handler.
+- [`@coding-adventures/layout-to-paint`](../../packages/typescript/layout-to-paint) — emits `PaintText` when `textEmitMode: "text"` is set.
+- [`@coding-adventures/layout-text-measure-canvas`](../../packages/typescript/layout-text-measure-canvas) — measures text via `ctx.measureText` for layout.
+
+## Spec
+
+- [TXT03d — Canvas Text Backend](../../../specs/TXT03d-canvas-text-backend.md)
+- [P2D00 — Paint Instructions](../../../specs/P2D00-paint-instructions.md) (see the "GlyphRun vs Text" section)

--- a/code/programs/typescript/markdown-canvas-demo/index.html
+++ b/code/programs/typescript/markdown-canvas-demo/index.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Markdown → Canvas</title>
+    <style>
+      * { box-sizing: border-box; }
+      html, body { margin: 0; height: 100%; font-family: system-ui, -apple-system, sans-serif; }
+      body { display: grid; grid-template-rows: auto 1fr; background: #0e1116; color: #e6edf3; }
+      header { padding: 10px 16px; border-bottom: 1px solid #30363d; background: #161b22; font-size: 14px; }
+      header strong { color: #79c0ff; }
+      main { display: grid; grid-template-columns: 1fr 2fr; overflow: hidden; }
+      #editor {
+        margin: 0; padding: 16px; border: none; outline: none; resize: none;
+        background: #0d1117; color: #c9d1d9; font-family: ui-monospace, monospace;
+        font-size: 14px; line-height: 1.5;
+      }
+      #stage { position: relative; overflow: auto; background: #0d1117; padding: 16px; }
+      #canvas { background: #ffffff; display: block; box-shadow: 0 0 0 1px #30363d; }
+      #stats { position: absolute; top: 8px; right: 16px; font-size: 12px; color: #8b949e; }
+    </style>
+  </head>
+  <body>
+    <header>
+      <strong>Markdown → Canvas</strong> — CommonMark parsed in TS, laid out via <code>layout-block</code> +
+      <code>CanvasTextMeasurer</code> (TXT03d), emitted as <code>PaintText</code> instructions, dispatched
+      by <code>paint-vm-canvas</code>. No DOM for output.
+    </header>
+    <main>
+      <textarea id="editor" spellcheck="false"></textarea>
+      <div id="stage">
+        <div id="stats"></div>
+        <canvas id="canvas" width="800" height="1200"></canvas>
+      </div>
+    </main>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/code/programs/typescript/markdown-canvas-demo/package-lock.json
+++ b/code/programs/typescript/markdown-canvas-demo/package-lock.json
@@ -1,0 +1,1330 @@
+{
+  "name": "markdown-canvas-demo",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "markdown-canvas-demo",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/commonmark": "file:../../../packages/typescript/commonmark",
+        "@coding-adventures/commonmark-parser": "file:../../../packages/typescript/commonmark-parser",
+        "@coding-adventures/directed-graph": "file:../../../packages/typescript/directed-graph",
+        "@coding-adventures/document-ast": "file:../../../packages/typescript/document-ast",
+        "@coding-adventures/document-ast-to-html": "file:../../../packages/typescript/document-ast-to-html",
+        "@coding-adventures/document-ast-to-layout": "file:../../../packages/typescript/document-ast-to-layout",
+        "@coding-adventures/layout-block": "file:../../../packages/typescript/layout-block",
+        "@coding-adventures/layout-ir": "file:../../../packages/typescript/layout-ir",
+        "@coding-adventures/layout-text-measure-canvas": "file:../../../packages/typescript/layout-text-measure-canvas",
+        "@coding-adventures/layout-text-measure-estimated": "file:../../../packages/typescript/layout-text-measure-estimated",
+        "@coding-adventures/layout-to-paint": "file:../../../packages/typescript/layout-to-paint",
+        "@coding-adventures/paint-instructions": "file:../../../packages/typescript/paint-instructions",
+        "@coding-adventures/paint-vm": "file:../../../packages/typescript/paint-vm",
+        "@coding-adventures/paint-vm-canvas": "file:../../../packages/typescript/paint-vm-canvas",
+        "@coding-adventures/pixel-container": "file:../../../packages/typescript/pixel-container",
+        "@coding-adventures/state-machine": "file:../../../packages/typescript/state-machine"
+      },
+      "devDependencies": {
+        "typescript": "~5.7.0",
+        "vite": "^6.0.0"
+      }
+    },
+    "../../../packages/typescript/commonmark": {
+      "version": "0.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/commonmark-parser": "file:../commonmark-parser",
+        "@coding-adventures/directed-graph": "file:../directed-graph",
+        "@coding-adventures/document-ast": "file:../document-ast",
+        "@coding-adventures/document-ast-to-html": "file:../document-ast-to-html",
+        "@coding-adventures/state-machine": "file:../state-machine"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/commonmark-parser": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/directed-graph": "file:../directed-graph",
+        "@coding-adventures/document-ast": "file:../document-ast",
+        "@coding-adventures/document-ast-to-html": "file:../document-ast-to-html",
+        "@coding-adventures/state-machine": "file:../state-machine"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/directed-graph": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/document-ast": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/document-ast-to-html": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/document-ast": "file:../document-ast"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/document-ast-to-layout": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/document-ast": "file:../document-ast",
+        "@coding-adventures/layout-ir": "file:../layout-ir"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/layout-block": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/layout-ir": "file:../layout-ir"
+      },
+      "devDependencies": {
+        "@coding-adventures/layout-text-measure-estimated": "file:../layout-text-measure-estimated",
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/layout-ir": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/layout-text-measure-canvas": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/layout-ir": "file:../layout-ir"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/layout-text-measure-estimated": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/layout-ir": "file:../layout-ir"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/layout-to-paint": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/layout-ir": "file:../layout-ir",
+        "@coding-adventures/paint-instructions": "file:../paint-instructions"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/paint-instructions": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/pixel-container": "file:../pixel-container"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/paint-vm": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/paint-instructions": "file:../paint-instructions"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/paint-vm-canvas": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/paint-instructions": "file:../paint-instructions",
+        "@coding-adventures/paint-vm": "file:../paint-vm"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "jsdom": "^26.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/pixel-container": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/state-machine": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/directed-graph": "file:../directed-graph"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@coding-adventures/commonmark": {
+      "resolved": "../../../packages/typescript/commonmark",
+      "link": true
+    },
+    "node_modules/@coding-adventures/commonmark-parser": {
+      "resolved": "../../../packages/typescript/commonmark-parser",
+      "link": true
+    },
+    "node_modules/@coding-adventures/directed-graph": {
+      "resolved": "../../../packages/typescript/directed-graph",
+      "link": true
+    },
+    "node_modules/@coding-adventures/document-ast": {
+      "resolved": "../../../packages/typescript/document-ast",
+      "link": true
+    },
+    "node_modules/@coding-adventures/document-ast-to-html": {
+      "resolved": "../../../packages/typescript/document-ast-to-html",
+      "link": true
+    },
+    "node_modules/@coding-adventures/document-ast-to-layout": {
+      "resolved": "../../../packages/typescript/document-ast-to-layout",
+      "link": true
+    },
+    "node_modules/@coding-adventures/layout-block": {
+      "resolved": "../../../packages/typescript/layout-block",
+      "link": true
+    },
+    "node_modules/@coding-adventures/layout-ir": {
+      "resolved": "../../../packages/typescript/layout-ir",
+      "link": true
+    },
+    "node_modules/@coding-adventures/layout-text-measure-canvas": {
+      "resolved": "../../../packages/typescript/layout-text-measure-canvas",
+      "link": true
+    },
+    "node_modules/@coding-adventures/layout-text-measure-estimated": {
+      "resolved": "../../../packages/typescript/layout-text-measure-estimated",
+      "link": true
+    },
+    "node_modules/@coding-adventures/layout-to-paint": {
+      "resolved": "../../../packages/typescript/layout-to-paint",
+      "link": true
+    },
+    "node_modules/@coding-adventures/paint-instructions": {
+      "resolved": "../../../packages/typescript/paint-instructions",
+      "link": true
+    },
+    "node_modules/@coding-adventures/paint-vm": {
+      "resolved": "../../../packages/typescript/paint-vm",
+      "link": true
+    },
+    "node_modules/@coding-adventures/paint-vm-canvas": {
+      "resolved": "../../../packages/typescript/paint-vm-canvas",
+      "link": true
+    },
+    "node_modules/@coding-adventures/pixel-container": {
+      "resolved": "../../../packages/typescript/pixel-container",
+      "link": true
+    },
+    "node_modules/@coding-adventures/state-machine": {
+      "resolved": "../../../packages/typescript/state-machine",
+      "link": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/code/programs/typescript/markdown-canvas-demo/package.json
+++ b/code/programs/typescript/markdown-canvas-demo/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "markdown-canvas-demo",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Live Markdown → Canvas demo — parses CommonMark and renders directly to an HTML canvas via the TXT03d pipeline, avoiding the DOM for output.",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@coding-adventures/commonmark": "file:../../../packages/typescript/commonmark",
+    "@coding-adventures/commonmark-parser": "file:../../../packages/typescript/commonmark-parser",
+    "@coding-adventures/directed-graph": "file:../../../packages/typescript/directed-graph",
+    "@coding-adventures/document-ast": "file:../../../packages/typescript/document-ast",
+    "@coding-adventures/document-ast-to-html": "file:../../../packages/typescript/document-ast-to-html",
+    "@coding-adventures/document-ast-to-layout": "file:../../../packages/typescript/document-ast-to-layout",
+    "@coding-adventures/layout-block": "file:../../../packages/typescript/layout-block",
+    "@coding-adventures/layout-ir": "file:../../../packages/typescript/layout-ir",
+    "@coding-adventures/layout-text-measure-canvas": "file:../../../packages/typescript/layout-text-measure-canvas",
+    "@coding-adventures/layout-text-measure-estimated": "file:../../../packages/typescript/layout-text-measure-estimated",
+    "@coding-adventures/layout-to-paint": "file:../../../packages/typescript/layout-to-paint",
+    "@coding-adventures/paint-instructions": "file:../../../packages/typescript/paint-instructions",
+    "@coding-adventures/paint-vm": "file:../../../packages/typescript/paint-vm",
+    "@coding-adventures/paint-vm-canvas": "file:../../../packages/typescript/paint-vm-canvas",
+    "@coding-adventures/pixel-container": "file:../../../packages/typescript/pixel-container",
+    "@coding-adventures/state-machine": "file:../../../packages/typescript/state-machine"
+  },
+  "devDependencies": {
+    "typescript": "~5.7.0",
+    "vite": "^6.0.0"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT"
+}

--- a/code/programs/typescript/markdown-canvas-demo/src/main.ts
+++ b/code/programs/typescript/markdown-canvas-demo/src/main.ts
@@ -1,0 +1,172 @@
+/**
+ * Markdown → Canvas demo
+ *
+ * Pipeline:
+ *
+ *   1. Parse CommonMark            → Document AST              (@coding-adventures/commonmark)
+ *   2. Document AST → LayoutNode   (document_ast_to_layout)
+ *   3. LayoutNode → PositionedNode (layout_block + CanvasTextMeasurer, TXT03d)
+ *   4. PositionedNode → PaintScene (layout_to_paint, textEmitMode: "text")
+ *   5. PaintScene → canvas pixels  (paint-vm-canvas handling PaintText)
+ *
+ * The output does NOT touch the DOM. The only DOM elements in the page are
+ * the editor <textarea> (input) and the <canvas> (output). Every pixel of
+ * the rendered markdown lives inside the canvas.
+ */
+
+import { parse } from "@coding-adventures/commonmark";
+import {
+  document_ast_to_layout,
+  document_default_theme,
+} from "@coding-adventures/document-ast-to-layout";
+import { layout_block } from "@coding-adventures/layout-block";
+import { size_wrap, size_fill, type LayoutNode, type SizeValue } from "@coding-adventures/layout-ir";
+import { createCanvasMeasurer } from "@coding-adventures/layout-text-measure-canvas";
+import { layout_to_paint } from "@coding-adventures/layout-to-paint";
+import { createCanvasVM } from "@coding-adventures/paint-vm-canvas";
+
+/**
+ * Document-ast-to-layout may emit nodes with `width: null` / `height: null`
+ * (meaning "no hint from this property"). Layout-block's core loop always
+ * dereferences `.kind`, which crashes on null. We normalize to `size_wrap()`
+ * for height and `size_fill()` for width, matching the "wrap to content" /
+ * "fill parent" defaults that match CSS block-flow. This is a compatibility
+ * shim until layout-block is patched upstream.
+ */
+function normalizeNulls(node: LayoutNode): LayoutNode {
+  const width: SizeValue = node.width ?? size_fill();
+  const height: SizeValue = node.height ?? size_wrap();
+  return {
+    ...node,
+    width,
+    height,
+    children: node.children.map(normalizeNulls),
+  };
+}
+
+const SAMPLE_MARKDOWN = `# Markdown on Canvas
+
+This document is **rendered directly into an HTML canvas** — no DOM
+elements, no \`<h1>\` or \`<p>\` tags. The browser's Canvas 2D context
+handles the final text rasterization via \`ctx.fillText\`.
+
+## The pipeline
+
+1. Parse CommonMark into a Document AST
+2. Convert the Document AST to a LayoutNode tree
+3. Run layout-block with a CanvasTextMeasurer (spec TXT03d)
+4. Emit PaintText instructions via layout-to-paint
+5. Dispatch through paint-vm-canvas onto the canvas
+
+## Why a new paint instruction?
+
+Canvas 2D does not expose glyph IDs to JavaScript — only strings go
+into fillText. The usual PaintGlyphRun instruction carries pre-shaped
+glyph indices, which canvas cannot consume without violating the
+font-binding invariant. PaintText is the honest representation: the
+layout engine measures, but shaping happens inside the browser at
+paint time.
+
+Arrows → work, and so do emoji 🎉. The browser handles font fallback
+internally; the paint IR never sees it.
+
+Try editing this markdown on the left.
+`;
+
+async function main() {
+  const editor = document.getElementById("editor") as HTMLTextAreaElement;
+  const canvas = document.getElementById("canvas") as HTMLCanvasElement;
+  const stats = document.getElementById("stats") as HTMLDivElement;
+  const ctx = canvas.getContext("2d")!;
+
+  // Wait for browser-loaded fonts before measuring — otherwise metrics reflect
+  // the fallback font and line wraps are wrong when the real font arrives.
+  if (document.fonts && document.fonts.ready) {
+    await document.fonts.ready;
+  }
+
+  // A dedicated 1×1 canvas used only for measurement. Separating measurement
+  // from the render context keeps ctx.font mutations from competing with the
+  // paint VM's own ctx.font writes.
+  const measureCanvas = document.createElement("canvas");
+  measureCanvas.width = 1;
+  measureCanvas.height = 1;
+  const measureCtx = measureCanvas.getContext("2d")!;
+  const measurer = createCanvasMeasurer(measureCtx);
+
+  const vm = createCanvasVM();
+  const theme = document_default_theme();
+
+  function render(markdown: string) {
+    const t0 = performance.now();
+
+    // 1. Parse
+    const doc = parse(markdown);
+
+    // 2. Document AST → LayoutNode (then normalize null sizes)
+    const rawTree = document_ast_to_layout(doc, theme);
+    const tree = normalizeNulls(rawTree);
+
+    // 3. Run block layout using the canvas-backed measurer
+    const maxWidth = canvas.clientWidth || 800;
+    const positioned = layout_block(
+      tree,
+      { maxWidth, maxHeight: Infinity, minWidth: 0, minHeight: 0 },
+      measurer,
+    );
+
+    // Grow the canvas to fit the laid-out height — keeps scrolling sensible
+    // for long documents.
+    const laidOutHeight = Math.ceil(positioned.height + 32);
+    if (canvas.height !== laidOutHeight) {
+      canvas.height = laidOutHeight;
+    }
+    if (canvas.width !== maxWidth) {
+      canvas.width = maxWidth;
+    }
+
+    // 4. Layout → PaintScene with the canvas-native emitter
+    const scene = layout_to_paint([positioned], {
+      width: canvas.width,
+      height: canvas.height,
+      background: { r: 255, g: 255, b: 255, a: 255 },
+      devicePixelRatio: 1.0,
+      textEmitMode: "text",
+    });
+
+    // 5. Paint
+    vm.execute(scene, ctx);
+
+    const elapsed = performance.now() - t0;
+    const textCount = countKind(scene.instructions, "text");
+    stats.textContent =
+      `${scene.instructions.length} instructions · ${textCount} PaintText · ${elapsed.toFixed(1)}ms`;
+  }
+
+  editor.value = SAMPLE_MARKDOWN;
+  render(editor.value);
+
+  // Re-render on input. Debounce is unnecessary for a demo — layout is fast
+  // enough at this document size.
+  editor.addEventListener("input", () => render(editor.value));
+  window.addEventListener("resize", () => render(editor.value));
+}
+
+function countKind(instructions: readonly { kind: string; children?: unknown }[], kind: string): number {
+  let n = 0;
+  for (const i of instructions) {
+    if (i.kind === kind) n++;
+    // Recurse into groups/layers/clips for accurate counts.
+    const anyI = i as { children?: { kind: string }[] };
+    if (Array.isArray(anyI.children)) {
+      n += countKind(anyI.children, kind);
+    }
+  }
+  return n;
+}
+
+main().catch((err) => {
+  console.error(err);
+  const stats = document.getElementById("stats");
+  if (stats) stats.textContent = `error: ${(err as Error).message}`;
+});

--- a/code/programs/typescript/markdown-canvas-demo/src/main.ts
+++ b/code/programs/typescript/markdown-canvas-demo/src/main.ts
@@ -28,20 +28,62 @@ import { createCanvasVM } from "@coding-adventures/paint-vm-canvas";
 /**
  * Document-ast-to-layout may emit nodes with `width: null` / `height: null`
  * (meaning "no hint from this property"). Layout-block's core loop always
- * dereferences `.kind`, which crashes on null. We normalize to `size_wrap()`
- * for height and `size_fill()` for width, matching the "wrap to content" /
- * "fill parent" defaults that match CSS block-flow. This is a compatibility
- * shim until layout-block is patched upstream.
+ * dereferences `.kind`, which crashes on null. We normalize to sensible
+ * defaults matching CSS block/inline flow:
+ *
+ *   - block nodes:  width → size_fill(), height → size_wrap()
+ *   - inline nodes: width → size_wrap(), height → size_wrap()
+ *
+ * Inline nodes MUST NOT take size_fill() — that would make each word claim
+ * the full container width and stack vertically, destroying the inline
+ * formatting context. This is a compatibility shim until layout-block is
+ * patched upstream.
  */
 function normalizeNulls(node: LayoutNode): LayoutNode {
-  const width: SizeValue = node.width ?? size_fill();
+  const ext = node.ext as {
+    block?: { display?: string };
+    flex?: { direction?: string };
+  } | undefined;
+  const blockExt = ext?.block;
+  const isInline = blockExt?.display === "inline";
+  const width: SizeValue = node.width ?? (isInline ? size_wrap() : size_fill());
   const height: SizeValue = node.height ?? size_wrap();
+
+  // Flex-row containers (list item "bullet + body" rows from document-ast-to-
+  // layout) don't have a layout-block implementation — layout-block would
+  // stack their children vertically. For the demo we coerce the row into an
+  // inline formatting context by flattening the subtree: every text leaf
+  // (from any depth) becomes a direct inline child of the row. The bullet
+  // and body then flow side-by-side on one line exactly as CSS flex-row
+  // would, because layout-block tokenizes inline text leaves word-by-word.
+  const isFlexRow = ext?.flex?.direction === "row";
+  if (isFlexRow) {
+    const leaves: LayoutNode[] = [];
+    for (const child of node.children) collectTextLeaves(child, leaves);
+    return { ...node, width, height, children: leaves };
+  }
+
   return {
     ...node,
     width,
     height,
     children: node.children.map(normalizeNulls),
   };
+}
+
+function collectTextLeaves(node: LayoutNode, out: LayoutNode[]): void {
+  if (node.content !== null && node.content.kind === "text") {
+    // Make sure this leaf is explicitly inline — layout-block's wrapInlineRuns
+    // keys off ext.block.display.
+    const existingExt = (node.ext ?? {}) as Record<string, unknown>;
+    const nextExt = {
+      ...existingExt,
+      block: { ...(existingExt["block"] as object | undefined), display: "inline" },
+    };
+    out.push({ ...node, width: node.width ?? size_wrap(), height: node.height ?? size_wrap(), ext: nextExt });
+    return;
+  }
+  for (const child of node.children) collectTextLeaves(child, out);
 }
 
 const SAMPLE_MARKDOWN = `# Markdown on Canvas

--- a/code/programs/typescript/markdown-canvas-demo/tsconfig.json
+++ b/code/programs/typescript/markdown-canvas-demo/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": false,
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"]
+  },
+  "include": ["src"]
+}

--- a/code/programs/typescript/markdown-canvas-demo/vite.config.ts
+++ b/code/programs/typescript/markdown-canvas-demo/vite.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  server: { port: 5173 },
+  resolve: {
+    // Preserve symlinks so that imports inside local file: dependencies
+    // resolve against this app's node_modules (where npm installed all the
+    // transitive deps) rather than the real package directory's (empty)
+    // node_modules. This is required for the chained file: deps pattern
+    // used repo-wide.
+    preserveSymlinks: true,
+  },
+});


### PR DESCRIPTION
## Summary

Implements the spec merged in [#985](https://github.com/adhithyan15/coding-adventures/pull/985) (TXT03d Canvas Text Backend + P2D00 \`PaintText\` amendment) and ships a working **Markdown → Canvas** demo with **zero DOM for output**.

![screenshot](https://via.placeholder.com/0) <!-- will attach after -->

## What's in the box

### Packages

- **paint-instructions** — \`PaintText\` interface + \`paintText()\` factory. Sits next to \`PaintGlyphRun\` in the instruction union. Scheme prefix (\`canvas:\`) routes dispatch.
- **paint-vm-canvas** — \`handleText\` + \`UnsupportedFontBindingError\`. Parses \`canvas:<family>@<size>[:<weight>[:<style>]]\` into CSS font shorthand, sanitizes family, clamps weight to [1,1000], allowlists italic/oblique. Throws on non-\`canvas:\` schemes to preserve the font-binding invariant. +10 tests.
- **layout-to-paint** — new \`textEmitMode: \"glyph_run\" | \"text\"\` option (default \`glyph_run\`). +8 tests.
- **layout-block** — fixes a real bug: inline word-wrap tokens were carrying the parent node's full \`content.value\`, causing paint backends to double-paint the whole paragraph at every word position. Tokens now carry just their own word. All 39 existing tests still pass.

### Demo

- **[markdown-canvas-demo](code/programs/typescript/markdown-canvas-demo)** (new) — live Markdown editor + canvas renderer. CommonMark → AST → LayoutNode → PositionedNode (via \`CanvasTextMeasurer\`) → PaintScene → canvas pixels. Every pixel of the rendered doc lives inside one \`<canvas>\`. Re-renders in ~4ms on every keystroke on the sample document. Arrows (→) and emoji (🎉) render via the browser's native font-fallback path.

## Test plan

- [x] \`cargo test\` / \`npm test\` across affected packages — 196 total passing (paint-instructions 43, paint-vm-canvas 71, layout-to-paint 43, layout-block 39).
- [x] End-to-end verified in headless Chromium via the Claude Preview tool: 165 PaintInstructions, 160 PaintText emitted for the sample markdown, rendered correctly with h1/h2 sizing, bold, italic, inline code colors, numbered list, emoji, arrows.
- [x] Security review passed in one round (font_ref sanitization resists CSS injection; no eval/innerHTML/postMessage in demo).
- [ ] Manual verification: \`cd code/programs/typescript/markdown-canvas-demo && npm install && npm run dev\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)