### PR TITLE
feat(ir-to-intel-8008-compiler): Layer 10 — lower IrProgram to Intel 8008 assembly

### DIFF
--- a/code/packages/python/ir-to-intel-8008-compiler/BUILD
+++ b/code/packages/python/ir-to-intel-8008-compiler/BUILD
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../compiler-ir -e ../intel-8008-ir-validator -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/ir-to-intel-8008-compiler/BUILD_windows
+++ b/code/packages/python/ir-to-intel-8008-compiler/BUILD_windows
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../compiler-ir -e ../intel-8008-ir-validator -e ".[dev]" --quiet
+.venv\Scripts\python -m pytest tests/ -v

--- a/code/packages/python/ir-to-intel-8008-compiler/CHANGELOG.md
+++ b/code/packages/python/ir-to-intel-8008-compiler/CHANGELOG.md
@@ -1,0 +1,67 @@
+# Changelog — ir-to-intel-8008-compiler
+
+All notable changes to this package are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [0.1.0] — 2026-04-20
+
+### Added
+
+- `CodeGenerator` — one-pass IR-to-8008 translator for all IR opcodes:
+  - `LABEL` → column-0 label definition
+  - `LOAD_IMM` → `MVI Rdst, imm`
+  - `LOAD_ADDR` → `MVI H, hi(sym); MVI L, lo(sym)` (sets H:L for memory ops)
+  - `LOAD_BYTE` → `MOV A, M; MOV Rdst, A` (reads from H:L)
+  - `STORE_BYTE` → `MOV A, Rsrc; MOV M, A` (writes to H:L)
+  - `ADD` → `MOV A, Ra; ADD Rb; MOV Rdst, A`
+  - `ADD_IMM` → `MOV A, Ra; ADI imm; MOV Rdst, A`; imm=0 optimised to pure
+    register copy (2 instructions, no ADI)
+  - `SUB` → `MOV A, Ra; SUB Rb; MOV Rdst, A`
+  - `AND` → `MOV A, Ra; ANA Rb; MOV Rdst, A`
+  - `OR` → `MOV A, Ra; ORA Rb; MOV Rdst, A`
+  - `XOR` → `MOV A, Ra; XRA Rb; MOV Rdst, A`
+  - `NOT` → `MOV A, Ra; XRI 0xFF; MOV Rdst, A` (8008 has no NOT; XOR-0xFF
+    is the canonical complement)
+  - `CMP_EQ` → 6-instruction optimistic-load/JTZ sequence with unique label
+  - `CMP_NE` → 6-instruction optimistic-load/JTZ sequence (inverted)
+  - `CMP_LT` → 6-instruction sequence using JTC (carry = unsigned borrow)
+  - `CMP_GT` → operand-swap trick: load Rb→A, CMP Ra; then JTC sequence
+  - `BRANCH_Z` → `MOV A, Rcond; CPI 0; JTZ label`
+  - `BRANCH_NZ` → `MOV A, Rcond; CPI 0; JFZ label`
+  - `JUMP` → `JMP label`
+  - `CALL` → `CAL label`
+  - `RET` → `MOV A, C; RFC` (copies return value from C to A, then returns)
+  - `HALT` → `HLT`
+  - `NOP` → comment (8008 has no dedicated NOP)
+  - `COMMENT` → `; text`
+  - `SYSCALL` → inline 8008 hardware intrinsics:
+    - 3 → `ADC` (add with carry, D+E+CY → C)
+    - 4 → `SBB` (subtract with borrow, D−E−CY → C)
+    - 11 → `RLC` (rotate A left circular)
+    - 12 → `RRC` (rotate A right circular)
+    - 13 → `RAL` (rotate left through carry)
+    - 14 → `RAR` (rotate right through carry)
+    - 15 → `MVI A, 0; ACI 0` (materialise carry flag into C)
+    - 16 → `ORA A; JFP` parity materialisation into C
+    - 20–27 → `IN p; MOV C, A` (read input port p)
+    - 40–63 → `MOV A, D; OUT p` (write output port p)
+  - Unknown opcodes → safe comment fallback (no crash)
+
+- `IrToIntel8008Compiler` (`Intel8008Backend` alias) — validate-then-generate
+  facade: runs `IrValidator` first; on error raises `IrValidationError` with
+  all violations concatenated; on success returns assembly text.
+
+- Module-level convenience functions:
+  - `validate(program)` → `list[IrValidationError]`
+  - `generate_asm(program)` → `str` (skips validation)
+
+- Physical register table (`_VREG_TO_PREG`): v0→B, v1→C, v2→D, v3→E, v4→H,
+  v5→L (matches `intel-8008-ir-validator` 6-register limit).
+
+- Unique label counter (`_label_count` on `CodeGenerator`) for comparison
+  materialisation labels (`cmp_0`, `cmp_1`, …) — prevents collisions in
+  programs with multiple comparisons or parity calls.
+
+- `tests/test_ir_to_intel_8008_compiler.py` — 130+ tests covering every
+  opcode, all 10 SYSCALL intrinsics, edge cases, and the compile facade.
+  Coverage > 95%.

--- a/code/packages/python/ir-to-intel-8008-compiler/README.md
+++ b/code/packages/python/ir-to-intel-8008-compiler/README.md
@@ -1,0 +1,124 @@
+# ir-to-intel-8008-compiler
+
+Translates a validated `IrProgram` (from `compiler-ir`) into Intel 8008 assembly text.
+
+## Pipeline Position
+
+```
+oct-lexer → oct-parser → oct-type-checker → oct-ir-compiler
+  → intel-8008-ir-validator → ir-to-intel-8008-compiler  ← YOU ARE HERE
+  → intel-8008-assembler → intel-8008-packager
+```
+
+## What it does
+
+The package lowers every IR opcode to the appropriate Intel 8008 instruction
+sequence.  The Intel 8008 (1972) is an 8-bit CPU with six 8-bit registers
+(A, B, C, D, E, H, L) and a 14-bit address space.
+
+### Virtual → Physical Register Mapping
+
+| Virtual | Physical | Role |
+|---------|----------|------|
+| v0 | B | zero constant / scratch |
+| v1 | C | scratch / return value |
+| v2 | D | 1st local / 1st syscall arg |
+| v3 | E | 2nd local / 2nd syscall arg |
+| v4 | H | 3rd local (also memory high byte) |
+| v5 | L | 4th local (also memory low byte) |
+| A | (implicit) | accumulator — never a virtual register |
+
+### Key Code-Generation Decisions
+
+- **Memory access** — `LOAD_ADDR` sets H:L; `LOAD_BYTE`/`STORE_BYTE` use M
+  (the pseudo-register for the byte at H:L).
+- **NOT** — implemented as `XRI 0xFF` (no dedicated NOT on the 8008).
+- **Comparisons** — materialise a boolean into a register via a 6-instruction
+  optimistic-load / conditional-branch sequence with unique labels.
+- **CMP_GT** — uses the operand-swap trick: Ra > Rb ⟺ Rb < Ra.
+- **RET** — copies C to A before RFC so the caller gets the return value.
+- **SYSCALL** — inlined as native 8008 instructions (ADC, SBB, rotations,
+  IN/OUT, parity).
+
+### Output Format
+
+```asm
+    ORG 0x0000
+_start:
+    MVI  B, 0
+    CAL  _fn_main
+    HLT
+_fn_main:
+    MVI  C, 42
+    MOV  A, C
+    RFC
+```
+
+- `ORG 0x0000` at the top (4-space indent)
+- Labels at column 0 with a colon suffix
+- Instructions indented by 4 spaces
+- Immediates in decimal; `0xFF` used for XRI constant
+
+## Installation
+
+```bash
+pip install coding-adventures-ir-to-intel-8008-compiler
+```
+
+Or in development mode (from this directory):
+
+```bash
+uv pip install -e ../compiler-ir -e ../intel-8008-ir-validator -e ".[dev]"
+```
+
+## Usage
+
+### Combined validate + generate
+
+```python
+from compiler_ir import IrProgram
+from ir_to_intel_8008_compiler import IrToIntel8008Compiler
+
+compiler = IrToIntel8008Compiler()
+try:
+    asm = compiler.compile(program)  # validates first
+    print(asm)
+except IrValidationError as e:
+    print("Validation failed:", e)
+```
+
+### Validate only
+
+```python
+from ir_to_intel_8008_compiler import validate
+
+errors = validate(program)
+for err in errors:
+    print(err.rule, err.message)
+```
+
+### Generate without validation
+
+```python
+from ir_to_intel_8008_compiler import generate_asm
+
+asm = generate_asm(program)  # skips validation
+```
+
+### Low-level API
+
+```python
+from ir_to_intel_8008_compiler import CodeGenerator
+
+gen = CodeGenerator()
+asm = gen.generate(program)
+```
+
+## Running Tests
+
+```bash
+bash BUILD
+```
+
+Tests are in `tests/test_ir_to_intel_8008_compiler.py` and cover all 24 IR
+opcodes, all 10 SYSCALL intrinsics, and the validate+compile facade.

--- a/code/packages/python/ir-to-intel-8008-compiler/pyproject.toml
+++ b/code/packages/python/ir-to-intel-8008-compiler/pyproject.toml
@@ -1,0 +1,44 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-ir-to-intel-8008-compiler"
+version = "0.1.0"
+description = "IR to Intel 8008 compiler: lowers IrProgram to Intel 8008 assembly text"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+dependencies = [
+    "coding-adventures-compiler-ir",
+    "coding-adventures-intel-8008-ir-validator",
+]
+
+[tool.uv.sources]
+coding-adventures-compiler-ir = { path = "../compiler-ir", editable = true }
+coding-adventures-intel-8008-ir-validator = { path = "../intel-8008-ir-validator", editable = true }
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/ir_to_intel_8008_compiler"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM", "ANN"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=ir_to_intel_8008_compiler --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.run]
+source = ["src/ir_to_intel_8008_compiler"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/packages/python/ir-to-intel-8008-compiler/src/ir_to_intel_8008_compiler/__init__.py
+++ b/code/packages/python/ir-to-intel-8008-compiler/src/ir_to_intel_8008_compiler/__init__.py
@@ -1,0 +1,60 @@
+"""IR to Intel 8008 compiler package.
+
+Public API::
+
+    from ir_to_intel_8008_compiler import (
+        CodeGenerator,
+        IrToIntel8008Compiler,
+        Intel8008Backend,
+        IrValidationError,
+        IrValidator,
+        validate,
+        generate_asm,
+    )
+"""
+
+from intel_8008_ir_validator import IrValidationError, IrValidator
+
+from ir_to_intel_8008_compiler.backend import (
+    Intel8008Backend,
+    IrToIntel8008Compiler,
+)
+from ir_to_intel_8008_compiler.codegen import CodeGenerator
+
+
+def validate(program: object) -> list[IrValidationError]:
+    """Validate an IrProgram against Intel 8008 hardware constraints.
+
+    Args:
+        program: An ``IrProgram`` to validate.
+
+    Returns:
+        A list of ``IrValidationError`` objects; empty if program is valid.
+    """
+    return IrValidator().validate(program)  # type: ignore[arg-type]
+
+
+def generate_asm(program: object) -> str:
+    """Translate an IrProgram into Intel 8008 assembly text.
+
+    Does NOT run validation first.  Call ``validate()`` separately or use
+    ``IrToIntel8008Compiler.compile()`` for the combined validate+generate path.
+
+    Args:
+        program: A validated ``IrProgram``.
+
+    Returns:
+        Multi-line Intel 8008 assembly string.
+    """
+    return CodeGenerator().generate(program)  # type: ignore[arg-type]
+
+
+__all__ = [
+    "IrValidationError",
+    "IrValidator",
+    "CodeGenerator",
+    "IrToIntel8008Compiler",
+    "Intel8008Backend",
+    "validate",
+    "generate_asm",
+]

--- a/code/packages/python/ir-to-intel-8008-compiler/src/ir_to_intel_8008_compiler/backend.py
+++ b/code/packages/python/ir-to-intel-8008-compiler/src/ir_to_intel_8008_compiler/backend.py
@@ -1,0 +1,76 @@
+"""IrToIntel8008Compiler — validate-then-generate facade for the 8008 backend.
+
+This module provides the single entry point for the Intel 8008 code generation
+pipeline:
+
+  1. Validate the IrProgram against 8008 hardware constraints
+     (``intel_8008_ir_validator.IrValidator``).
+  2. If validation passes, emit Intel 8008 assembly text
+     (``ir_to_intel_8008_compiler.codegen.CodeGenerator``).
+  3. If validation fails, raise the combined error message as a single
+     ``IrValidationError`` so callers get a clear, one-exception result.
+
+Usage::
+
+    from compiler_ir import IrProgram
+    from ir_to_intel_8008_compiler import IrToIntel8008Compiler
+
+    compiler = IrToIntel8008Compiler()
+    asm = compiler.compile(program)   # raises IrValidationError on bad IR
+    print(asm)
+"""
+
+from __future__ import annotations
+
+from compiler_ir import IrProgram
+from intel_8008_ir_validator import IrValidationError, IrValidator
+
+from ir_to_intel_8008_compiler.codegen import CodeGenerator
+
+
+class IrToIntel8008Compiler:
+    """Validate an IrProgram and emit Intel 8008 assembly text.
+
+    The compiler wraps the validator and code generator in a single
+    ``compile()`` call.  Validation errors are surfaced as a single
+    ``IrValidationError`` whose message concatenates all individual
+    violations, making it easy to surface everything to the user at once.
+
+    Attributes:
+        validator: The ``IrValidator`` instance (can be replaced for testing).
+        codegen:   The ``CodeGenerator`` instance.
+    """
+
+    def __init__(self) -> None:
+        self.validator = IrValidator()
+        self.codegen = CodeGenerator()
+
+    def compile(self, program: IrProgram) -> str:
+        """Validate and compile an IrProgram to Intel 8008 assembly text.
+
+        Args:
+            program: The ``IrProgram`` to compile.  Must have been produced
+                     by ``oct-ir-compiler`` (or equivalent) and must not
+                     contain LOAD_WORD/STORE_WORD or out-of-range SYSCALLs.
+
+        Returns:
+            A multi-line string of Intel 8008 assembly text, starting with
+            ``ORG 0x0000`` and ending with a newline.
+
+        Raises:
+            IrValidationError: If any hardware-constraint check fails.
+                The error message lists all violations, separated by newlines.
+        """
+        errors = self.validator.validate(program)
+        if errors:
+            combined = "\n".join(str(e) for e in errors)
+            raise IrValidationError(
+                rule="multiple" if len(errors) > 1 else errors[0].rule,
+                message=combined,
+            )
+
+        return self.codegen.generate(program)
+
+
+# Alias so consumers can import either name.
+Intel8008Backend = IrToIntel8008Compiler

--- a/code/packages/python/ir-to-intel-8008-compiler/src/ir_to_intel_8008_compiler/codegen.py
+++ b/code/packages/python/ir-to-intel-8008-compiler/src/ir_to_intel_8008_compiler/codegen.py
@@ -1,0 +1,1114 @@
+"""CodeGenerator — translates IrProgram into Intel 8008 assembly text.
+
+Intel 8008 Architecture Primer
+-------------------------------
+
+The Intel 8008 (1972) is an 8-bit microprocessor — the world's first
+single-chip 8-bit CPU.  It has a small but capable register file:
+
+  A     — Accumulator: 8-bit implicit result register for all ALU ops.
+           Every arithmetic and logical instruction uses A as one operand
+           and places the result in A.  A is scratch — not preserved.
+  B, C, D, E — Four 8-bit general-purpose data registers.
+  H, L  — High and Low bytes of the 14-bit memory address register.
+           H:L = (H << 8) | L.  Used for all memory operations via M.
+  M     — Pseudo-register: the memory byte at address H:L.
+           MOV A, M reads; MOV M, A writes.  H:L must be set first.
+
+Key 8008 instructions:
+  MVI  r, d8    Load 8-bit immediate into register r (1 byte → A,B,C,D,E,H,L)
+  MOV  dst, src Copy register src into register dst
+  ADD  r        A ← A + r            (sets Z, S, P, CY)
+  ADC  r        A ← A + r + CY       (add with carry)
+  SUB  r        A ← A − r            (CY = borrow)
+  SBB  r        A ← A − r − CY      (subtract with borrow)
+  ANA  r        A ← A AND r         (CY = 0)
+  ORA  r        A ← A OR r          (CY = 0)
+  XRA  r        A ← A XOR r         (CY = 0)
+  CMP  r        flags ← A − r; A unchanged
+  ADI  d8       A ← A + d8
+  ACI  d8       A ← A + d8 + CY
+  CPI  d8       flags ← A − d8; A unchanged
+  XRI  d8       A ← A XOR d8
+  RLC           rotate A left circular:  CY ← bit7, bit0 ← old bit7
+  RRC           rotate A right circular: CY ← bit0, bit7 ← old bit0
+  RAL           rotate A left through carry:  CY ← bit7, bit0 ← old CY
+  RAR           rotate A right through carry: CY ← bit0, bit7 ← old CY
+  IN   p        A ← input port p (p ∈ 0–7)
+  OUT  p        output port p ← A (p ∈ 0–23)
+  JMP  a14      unconditional jump (3 bytes)
+  CAL  a14      call subroutine: push PC, jump to a14 (3 bytes)
+  RFC           return if carry false — standard unconditional return
+  JTZ  a14      jump if Z=1 (result was zero)
+  JFZ  a14      jump if Z=0 (result was non-zero)
+  JTC  a14      jump if CY=1 (carry set / borrow)
+  JFP  a14      jump if P=0 (parity odd)
+  HLT           halt the processor (0xFF)
+  ORG  addr     assembler directive: set location counter
+
+Physical Register Assignment
+-----------------------------
+
+Virtual registers (v0, v1, v2, ...) map to 8008 physical registers via a
+fixed, validation-enforced table (the validator rejects programs with more
+than 6 distinct virtual registers):
+
+  v0 → B   (constant zero, preloaded to 0 at _start)
+  v1 → C   (scratch / return value register)
+  v2 → D   (1st local / 1st argument slot)
+  v3 → E   (2nd local / 2nd argument slot)
+  v4 → H   (3rd local / 3rd argument slot — careful: memory ops use H:L)
+  v5 → L   (4th local / 4th argument slot — careful: memory ops use H:L)
+
+The accumulator A is implicit in all ALU operations.  A is never assigned
+a virtual register index — it is always scratch.
+
+Calling Convention (Oct → 8008)
+---------------------------------
+
+Arguments are passed in B, C, D, E (v0, v1, v2, v3 in the oct-ir-compiler's
+v-register numbering).  The oct-ir-compiler stages args into v2, v3, v4, v5
+before a CALL; because the calling convention uses the same register slots as
+the local variables, this works correctly.
+
+Return value: placed in C (v1) by the callee, then moved to A immediately
+before RFC so the caller reads it from A.  The caller may then MOV its
+destination register from A.
+
+LOAD_ADDR / LOAD_BYTE / STORE_BYTE Memory Access
+-------------------------------------------------
+
+Static variables live in the 8 KB RAM region (0x2000–0x3FFE).  The 8008
+accesses RAM only through the M pseudo-register (memory at H:L).
+
+The IR emits a LOAD_ADDR + LOAD_BYTE pair to read a static:
+
+  LOAD_ADDR v1, symbol    -- set H:L = address of symbol
+  LOAD_BYTE v1, v1, v0    -- v1 = RAM[H:L + 0] = RAM[H:L]
+
+The code generator:
+  1. For LOAD_ADDR  → emits  MVI H, hi(symbol); MVI L, lo(symbol)
+     (H and L are updated; the "destination register" operand is ignored
+      because H:L is the implicit address register on the 8008.)
+  2. For LOAD_BYTE  → emits  MOV A, M; MOV Rdst, A
+  3. For STORE_BYTE → emits  MOV A, Rsrc; MOV M, A
+
+hi(addr) = (addr >> 8) & 0x3F   (high 6 bits of 14-bit address)
+lo(addr) = addr & 0xFF           (low 8 bits)
+
+The assembler resolves symbolic addresses; the code generator emits
+``hi(symbol_name)`` and ``lo(symbol_name)`` as textual directives that the
+assembler expands.
+
+Comparison Materialisation
+---------------------------
+
+The 8008 CMP instruction sets flags but places no result in a register.
+To materialise a boolean result (0 or 1) into a destination register, the
+code generator emits an optimistic-load / conditional-branch sequence:
+
+  CMP_EQ Rdst, Ra, Rb:
+    MOV  A, Ra
+    CMP  Rb            ; Z=1 iff Ra == Rb
+    MVI  Rdst, 1       ; assume equal
+    JTZ  cmp_N_done    ; if Z (equal) → keep 1
+    MVI  Rdst, 0       ; else overwrite with 0
+  cmp_N_done:
+
+Each comparison gets a unique suffix ``N`` (monotonically incrementing)
+so labels do not collide within or across functions.
+
+Output Format
+-------------
+
+The output is a plain string.  One assembly line per line::
+
+    ORG 0x0000
+_start:
+    MVI  B, 0
+    CAL  _fn_main
+    HLT
+_fn_main:
+    MVI  D, 42
+    MOV  A, D
+    RFC
+
+  - ORG directive at address 0x0000 (4-space indent)
+  - Labels: column 0, colon suffix
+  - Instructions: 4-space indent, mnemonic left-aligned, operands after a space
+  - Immediate values: decimal (e.g. ``42``) or hex with ``0x`` prefix (e.g. ``0xFF``)
+  - Comments start with ``; ``
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from compiler_ir import (
+    IrImmediate,
+    IrInstruction,
+    IrLabel,
+    IrOp,
+    IrProgram,
+    IrRegister,
+)
+
+# ---------------------------------------------------------------------------
+# Physical register table
+# ---------------------------------------------------------------------------
+#
+# Virtual register index → 8008 physical register name.
+# v0=B (zero constant), v1=C (scratch/return), v2=D..v5=L.
+# A is the implicit accumulator and is never an IR register.
+
+_VREG_TO_PREG: dict[int, str] = {
+    0: "B",  # zero constant
+    1: "C",  # scratch / return value
+    2: "D",  # 1st local / 1st arg
+    3: "E",  # 2nd local / 2nd arg
+    4: "H",  # 3rd local / 3rd arg  (careful: H is also memory high byte)
+    5: "L",  # 4th local / 4th arg  (careful: L is also memory low byte)
+}
+
+# Fixed registers used in SYSCALL expansions.
+# ADC/SBB/rotation args are staged into v2=D, v3=E by the IR compiler.
+# Results land in v1=C.
+_REG_ARG0 = "D"   # v2 — first syscall argument
+_REG_ARG1 = "E"   # v3 — second syscall argument
+_REG_RESULT = "C"  # v1 — syscall result
+
+# Assembly indentation: 4 spaces.
+_INDENT = "    "
+
+
+def _preg(vreg_index: int) -> str:
+    """Return the physical 8008 register name for a virtual register index.
+
+    Args:
+        vreg_index: Virtual register index (0–5, or beyond for error cases).
+
+    Returns:
+        Physical register name, e.g. ``"D"`` for vReg 2.
+        Falls back to ``"B"`` for unmapped indices (should not happen on valid IR).
+    """
+    return _VREG_TO_PREG.get(vreg_index, "B")
+
+
+# ---------------------------------------------------------------------------
+# CodeGenerator
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CodeGenerator:
+    """Translate a validated IrProgram into Intel 8008 assembly text.
+
+    The generator is a one-pass, instruction-by-instruction translator.
+    It holds a label counter (``_label_count``) used to produce unique
+    local labels for comparison materialisation and the parity intrinsic.
+
+    Usage::
+
+        gen = CodeGenerator()
+        asm_text = gen.generate(prog)
+        # write asm_text to a .asm file or pass to intel-8008-assembler
+    """
+
+    _label_count: int = field(default=0, init=False)
+
+    def generate(self, program: IrProgram) -> str:
+        """Translate an IrProgram into Intel 8008 assembly text.
+
+        Walks the instruction list and emits 8008 assembly for each IR opcode.
+        Precedes the instruction stream with the ``ORG 0x0000`` origin directive.
+
+        Args:
+            program: A validated ``IrProgram``.  Calling ``generate()`` on an
+                     unvalidated program may produce incorrect or incomplete assembly.
+
+        Returns:
+            A multi-line string of Intel 8008 assembly.
+        """
+        lines: list[str] = []
+
+        # Every 8008 program begins at ROM address 0x0000.
+        # ORG tells the assembler the starting location counter.
+        lines.append(f"{_INDENT}ORG 0x0000")
+
+        for instr in program.instructions:
+            lines.extend(self._emit(instr))
+
+        return "\n".join(lines) + "\n"
+
+    # ------------------------------------------------------------------
+    # Instruction dispatch
+    # ------------------------------------------------------------------
+
+    def _emit(self, instr: IrInstruction) -> list[str]:
+        """Emit assembly lines for a single IR instruction.
+
+        Args:
+            instr: The IR instruction to translate.
+
+        Returns:
+            A list of assembly line strings (no trailing newline on each).
+        """
+        op = instr.opcode
+        ops = instr.operands
+
+        match op:
+            case IrOp.LABEL:
+                return self._emit_label(ops)
+            case IrOp.LOAD_IMM:
+                return self._emit_load_imm(ops)
+            case IrOp.LOAD_ADDR:
+                return self._emit_load_addr(ops)
+            case IrOp.LOAD_BYTE:
+                return self._emit_load_byte(ops)
+            case IrOp.STORE_BYTE:
+                return self._emit_store_byte(ops)
+            case IrOp.ADD:
+                return self._emit_add(ops)
+            case IrOp.ADD_IMM:
+                return self._emit_add_imm(ops)
+            case IrOp.SUB:
+                return self._emit_sub(ops)
+            case IrOp.AND:
+                return self._emit_and(ops)
+            case IrOp.OR:
+                return self._emit_or(ops)
+            case IrOp.XOR:
+                return self._emit_xor(ops)
+            case IrOp.NOT:
+                return self._emit_not(ops)
+            case IrOp.CMP_EQ:
+                return self._emit_cmp_eq(ops)
+            case IrOp.CMP_NE:
+                return self._emit_cmp_ne(ops)
+            case IrOp.CMP_LT:
+                return self._emit_cmp_lt(ops)
+            case IrOp.CMP_GT:
+                return self._emit_cmp_gt(ops)
+            case IrOp.BRANCH_Z:
+                return self._emit_branch_z(ops)
+            case IrOp.BRANCH_NZ:
+                return self._emit_branch_nz(ops)
+            case IrOp.JUMP:
+                return self._emit_jump(ops)
+            case IrOp.CALL:
+                return self._emit_call(ops)
+            case IrOp.RET:
+                return self._emit_ret()
+            case IrOp.HALT:
+                return self._emit_halt()
+            case IrOp.SYSCALL:
+                return self._emit_syscall(ops)
+            case IrOp.NOP:
+                return self._emit_nop()
+            case IrOp.COMMENT:
+                return self._emit_comment(ops)
+            case _:
+                # Unknown opcode — emit a comment and continue rather than crashing.
+                return [f"{_INDENT}; unsupported opcode: {op.name}"]
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _next_label(self) -> str:
+        """Generate a unique local label suffix and advance the counter."""
+        lbl = f"cmp_{self._label_count}"
+        self._label_count += 1
+        return lbl
+
+    # ------------------------------------------------------------------
+    # LABEL name  →  name:
+    # ------------------------------------------------------------------
+    #
+    # Labels sit at column 0 with a colon suffix.  They do not advance the
+    # address counter — the assembler records the current address for this label.
+
+    def _emit_label(self, ops: list) -> list[str]:  # noqa: ANN001
+        """Emit a label definition at column 0."""
+        if ops and isinstance(ops[0], IrLabel):
+            return [f"{ops[0].name}:"]
+        return []
+
+    # ------------------------------------------------------------------
+    # LOAD_IMM Rdst, imm  →  MVI Rdst, imm
+    # ------------------------------------------------------------------
+    #
+    # MVI (Move Immediate) loads an 8-bit constant into any named register.
+    # On the 8008 this is always a 2-byte instruction: opcode + byte operand.
+    #
+    # Example: LOAD_IMM v1, 42  →  MVI C, 42
+
+    def _emit_load_imm(self, ops: list) -> list[str]:  # noqa: ANN001
+        """Emit LOAD_IMM: MVI Rdst, imm."""
+        if len(ops) < 2:
+            return [f"{_INDENT}; LOAD_IMM: missing operands"]
+        dst, imm = ops[0], ops[1]
+        if not isinstance(dst, IrRegister) or not isinstance(imm, IrImmediate):
+            return [f"{_INDENT}; LOAD_IMM: unexpected operand types"]
+        return [f"{_INDENT}MVI  {_preg(dst.index)}, {imm.value}"]
+
+    # ------------------------------------------------------------------
+    # LOAD_ADDR Rdst, symbol  →  MVI H, hi(symbol)  /  MVI L, lo(symbol)
+    # ------------------------------------------------------------------
+    #
+    # Static variables live in the 8008 RAM region (0x2000–0x3FFE).  To
+    # access RAM, the code generator must load the 14-bit address into H:L.
+    #
+    # The IR instruction carries a destination virtual register (Rdst) that
+    # is conceptually "the address", but on the 8008 addresses must live in
+    # H:L — there is no way to store a 14-bit address in a single 8-bit
+    # register.  We ignore Rdst and write H:L directly.
+    #
+    # The assembler resolves ``hi(symbol)`` and ``lo(symbol)`` to the high
+    # and low bytes of the symbol's ROM address:
+    #   hi(addr) = (addr >> 8) & 0x3F   (upper 6 bits of 14-bit address)
+    #   lo(addr) = addr & 0xFF           (lower 8 bits)
+    #
+    # Example: LOAD_ADDR v1, counter
+    #   →  MVI H, hi(counter)
+    #      MVI L, lo(counter)
+
+    def _emit_load_addr(self, ops: list) -> list[str]:  # noqa: ANN001
+        """Emit LOAD_ADDR: MVI H, hi(symbol); MVI L, lo(symbol)."""
+        if len(ops) < 2:
+            return [f"{_INDENT}; LOAD_ADDR: missing operands"]
+        lbl = ops[1]
+        if not isinstance(lbl, IrLabel):
+            return [f"{_INDENT}; LOAD_ADDR: label operand expected"]
+        return [
+            f"{_INDENT}MVI  H, hi({lbl.name})",
+            f"{_INDENT}MVI  L, lo({lbl.name})",
+        ]
+
+    # ------------------------------------------------------------------
+    # LOAD_BYTE Rdst, Rbase, Rzero  →  MOV A, M  /  MOV Rdst, A
+    # ------------------------------------------------------------------
+    #
+    # The 8008 reads RAM through the M pseudo-register.  H:L must be
+    # pointing to the target address (set by the preceding LOAD_ADDR).
+    #
+    # The "base" and "offset" operands from the IR are ignored here because:
+    #   - The address is implicitly in H:L (set by LOAD_ADDR)
+    #   - The offset v0 is always 0 (no address arithmetic needed)
+    #   - H:L is the only address register on the 8008
+    #
+    # Steps:
+    #   1. MOV A, M   — read the byte at H:L into the accumulator
+    #   2. MOV Rdst, A — copy accumulator to the destination register
+    #
+    # Example: LOAD_BYTE v1, v1, v0  →  MOV A, M; MOV C, A
+
+    def _emit_load_byte(self, ops: list) -> list[str]:  # noqa: ANN001
+        """Emit LOAD_BYTE: MOV A, M; MOV Rdst, A."""
+        if not ops or not isinstance(ops[0], IrRegister):
+            return [f"{_INDENT}; LOAD_BYTE: missing destination register"]
+        rdst = _preg(ops[0].index)
+        lines = [f"{_INDENT}MOV  A, M"]
+        if rdst != "A":
+            lines.append(f"{_INDENT}MOV  {rdst}, A")
+        return lines
+
+    # ------------------------------------------------------------------
+    # STORE_BYTE Rsrc, Rbase, Rzero  →  MOV A, Rsrc  /  MOV M, A
+    # ------------------------------------------------------------------
+    #
+    # Writes a byte to RAM at H:L (set by the preceding LOAD_ADDR).
+    # Like LOAD_BYTE, Rbase and Rzero are ignored.
+    #
+    # Steps:
+    #   1. MOV A, Rsrc — load the value into the accumulator
+    #   2. MOV M, A    — write accumulator to RAM at H:L
+    #
+    # Example: STORE_BYTE v1, v1, v0  →  MOV A, C; MOV M, A
+
+    def _emit_store_byte(self, ops: list) -> list[str]:  # noqa: ANN001
+        """Emit STORE_BYTE: MOV A, Rsrc; MOV M, A."""
+        if not ops or not isinstance(ops[0], IrRegister):
+            return [f"{_INDENT}; STORE_BYTE: missing source register"]
+        rsrc = _preg(ops[0].index)
+        return [
+            f"{_INDENT}MOV  A, {rsrc}",
+            f"{_INDENT}MOV  M, A",
+        ]
+
+    # ------------------------------------------------------------------
+    # ADD Rdst, Ra, Rb  →  MOV A, Ra  /  ADD Rb  /  MOV Rdst, A
+    # ------------------------------------------------------------------
+    #
+    # The 8008 ADD instruction adds a register to the accumulator:
+    #   A ← A + Rb      (sets Z, S, P, CY)
+    #
+    # We must first load Ra into A, then add Rb.  The result in A is moved
+    # to Rdst.  If Rdst == A that final MOV is implicit — but since none
+    # of our virtual registers map to A, we always emit the MOV.
+
+    def _emit_add(self, ops: list) -> list[str]:  # noqa: ANN001
+        """Emit ADD: MOV A, Ra; ADD Rb; MOV Rdst, A."""
+        if len(ops) < 3:
+            return [f"{_INDENT}; ADD: missing operands"]
+        dst, ra, rb = ops[0], ops[1], ops[2]
+        if not all(isinstance(o, IrRegister) for o in [dst, ra, rb]):
+            return [f"{_INDENT}; ADD: unexpected operand types"]
+        rdst = _preg(dst.index)
+        rra = _preg(ra.index)
+        rrb = _preg(rb.index)
+        return [
+            f"{_INDENT}MOV  A, {rra}",
+            f"{_INDENT}ADD  {rrb}",
+            f"{_INDENT}MOV  {rdst}, A",
+        ]
+
+    # ------------------------------------------------------------------
+    # ADD_IMM Rdst, Ra, imm  →  MOV A, Ra  /  ADI imm  /  MOV Rdst, A
+    # ------------------------------------------------------------------
+    #
+    # ADI (Add Immediate) adds an 8-bit constant to the accumulator:
+    #   A ← A + d8      (sets Z, S, P, CY)
+    #
+    # Special case — imm == 0 (register copy):
+    #   This is the IR idiom for "move register to register" (the IR has no
+    #   dedicated MOV instruction for registers).  We can emit just two
+    #   instructions: MOV A, Ra; MOV Rdst, A.
+    #
+    # Example: ADD_IMM v2, v1, 0  →  MOV A, C; MOV D, A   (copy v1 → v2)
+    # Example: ADD_IMM v1, v2, 5  →  MOV A, D; ADI 5; MOV C, A
+
+    def _emit_add_imm(self, ops: list) -> list[str]:  # noqa: ANN001
+        """Emit ADD_IMM: MOV A, Ra; [ADI imm;] MOV Rdst, A."""
+        if len(ops) < 3:
+            return [f"{_INDENT}; ADD_IMM: missing operands"]
+        dst, src, imm = ops[0], ops[1], ops[2]
+        if not isinstance(dst, IrRegister) or not isinstance(src, IrRegister):
+            return [f"{_INDENT}; ADD_IMM: unexpected register operands"]
+        if not isinstance(imm, IrImmediate):
+            return [f"{_INDENT}; ADD_IMM: immediate operand expected"]
+
+        rdst = _preg(dst.index)
+        rsrc = _preg(src.index)
+
+        if imm.value == 0:
+            # Pure register copy — no arithmetic, no immediate.
+            # MOV A, Rsrc loads Rsrc into A; MOV Rdst, A stores it.
+            return [
+                f"{_INDENT}MOV  A, {rsrc}",
+                f"{_INDENT}MOV  {rdst}, A",
+            ]
+
+        return [
+            f"{_INDENT}MOV  A, {rsrc}",
+            f"{_INDENT}ADI  {imm.value}",
+            f"{_INDENT}MOV  {rdst}, A",
+        ]
+
+    # ------------------------------------------------------------------
+    # SUB Rdst, Ra, Rb  →  MOV A, Ra  /  SUB Rb  /  MOV Rdst, A
+    # ------------------------------------------------------------------
+    #
+    # The 8008 SUB instruction:  A ← A − Rb  (CY = borrow).
+    # The borrow semantics are used by CMP_LT and CMP_GT.
+
+    def _emit_sub(self, ops: list) -> list[str]:  # noqa: ANN001
+        """Emit SUB: MOV A, Ra; SUB Rb; MOV Rdst, A."""
+        if len(ops) < 3:
+            return [f"{_INDENT}; SUB: missing operands"]
+        dst, ra, rb = ops[0], ops[1], ops[2]
+        if not all(isinstance(o, IrRegister) for o in [dst, ra, rb]):
+            return [f"{_INDENT}; SUB: unexpected operand types"]
+        rdst = _preg(dst.index)
+        rra = _preg(ra.index)
+        rrb = _preg(rb.index)
+        return [
+            f"{_INDENT}MOV  A, {rra}",
+            f"{_INDENT}SUB  {rrb}",
+            f"{_INDENT}MOV  {rdst}, A",
+        ]
+
+    # ------------------------------------------------------------------
+    # AND Rdst, Ra, Rb  →  MOV A, Ra  /  ANA Rb  /  MOV Rdst, A
+    # ------------------------------------------------------------------
+    #
+    # ANA (AND register): A ← A AND Rb (CY cleared by AND ops on the 8008).
+    # Used for Oct's `&` bitwise AND operator.
+
+    def _emit_and(self, ops: list) -> list[str]:  # noqa: ANN001
+        """Emit AND: MOV A, Ra; ANA Rb; MOV Rdst, A."""
+        if len(ops) < 3:
+            return [f"{_INDENT}; AND: missing operands"]
+        dst, ra, rb = ops[0], ops[1], ops[2]
+        if not all(isinstance(o, IrRegister) for o in [dst, ra, rb]):
+            return [f"{_INDENT}; AND: unexpected operand types"]
+        rdst = _preg(dst.index)
+        rra = _preg(ra.index)
+        rrb = _preg(rb.index)
+        return [
+            f"{_INDENT}MOV  A, {rra}",
+            f"{_INDENT}ANA  {rrb}",
+            f"{_INDENT}MOV  {rdst}, A",
+        ]
+
+    # ------------------------------------------------------------------
+    # OR Rdst, Ra, Rb  →  MOV A, Ra  /  ORA Rb  /  MOV Rdst, A
+    # ------------------------------------------------------------------
+    #
+    # ORA (OR register): A ← A OR Rb (CY cleared).
+    # Used for Oct's `|` bitwise OR operator.
+
+    def _emit_or(self, ops: list) -> list[str]:  # noqa: ANN001
+        """Emit OR: MOV A, Ra; ORA Rb; MOV Rdst, A."""
+        if len(ops) < 3:
+            return [f"{_INDENT}; OR: missing operands"]
+        dst, ra, rb = ops[0], ops[1], ops[2]
+        if not all(isinstance(o, IrRegister) for o in [dst, ra, rb]):
+            return [f"{_INDENT}; OR: unexpected operand types"]
+        rdst = _preg(dst.index)
+        rra = _preg(ra.index)
+        rrb = _preg(rb.index)
+        return [
+            f"{_INDENT}MOV  A, {rra}",
+            f"{_INDENT}ORA  {rrb}",
+            f"{_INDENT}MOV  {rdst}, A",
+        ]
+
+    # ------------------------------------------------------------------
+    # XOR Rdst, Ra, Rb  →  MOV A, Ra  /  XRA Rb  /  MOV Rdst, A
+    # ------------------------------------------------------------------
+    #
+    # XRA (XOR register): A ← A XOR Rb (CY cleared).
+    # Used for Oct's `^` bitwise XOR operator.
+    #
+    # Historical note: the Nib/4004 backend had no XOR instruction and
+    # emulated it via SUB.  The 8008 has native XRA, so this is a 3-instruction
+    # sequence — no emulation needed.
+
+    def _emit_xor(self, ops: list) -> list[str]:  # noqa: ANN001
+        """Emit XOR: MOV A, Ra; XRA Rb; MOV Rdst, A."""
+        if len(ops) < 3:
+            return [f"{_INDENT}; XOR: missing operands"]
+        dst, ra, rb = ops[0], ops[1], ops[2]
+        if not all(isinstance(o, IrRegister) for o in [dst, ra, rb]):
+            return [f"{_INDENT}; XOR: unexpected operand types"]
+        rdst = _preg(dst.index)
+        rra = _preg(ra.index)
+        rrb = _preg(rb.index)
+        return [
+            f"{_INDENT}MOV  A, {rra}",
+            f"{_INDENT}XRA  {rrb}",
+            f"{_INDENT}MOV  {rdst}, A",
+        ]
+
+    # ------------------------------------------------------------------
+    # NOT Rdst, Ra  →  MOV A, Ra  /  XRI 0xFF  /  MOV Rdst, A
+    # ------------------------------------------------------------------
+    #
+    # The 8008 has no dedicated bitwise NOT instruction.  Instead:
+    #   XRI 0xFF = XOR A with all-ones = flip every bit (bitwise NOT).
+    #
+    # A ← A XOR 0xFF = ~A   (all 8 bits complemented)
+    #
+    # This maps directly to Oct's `~` bitwise NOT operator.
+
+    def _emit_not(self, ops: list) -> list[str]:  # noqa: ANN001
+        """Emit NOT: MOV A, Ra; XRI 0xFF; MOV Rdst, A."""
+        if len(ops) < 2:
+            return [f"{_INDENT}; NOT: missing operands"]
+        dst, ra = ops[0], ops[1]
+        if not isinstance(dst, IrRegister) or not isinstance(ra, IrRegister):
+            return [f"{_INDENT}; NOT: unexpected operand types"]
+        rdst = _preg(dst.index)
+        rra = _preg(ra.index)
+        return [
+            f"{_INDENT}MOV  A, {rra}",
+            f"{_INDENT}XRI  0xFF",
+            f"{_INDENT}MOV  {rdst}, A",
+        ]
+
+    # ------------------------------------------------------------------
+    # CMP_EQ Rdst, Ra, Rb
+    # ------------------------------------------------------------------
+    #
+    # Set Rdst = 1 if Ra == Rb, else 0.
+    #
+    # The 8008 CMP instruction sets Z=1 iff Ra == Rb (after A − Rb).
+    # We use an optimistic-load approach: assume equal (load 1), then
+    # branch past the "load 0" if Z was set.
+    #
+    # Truth table for CMP_EQ:
+    #   Ra == Rb → Z=1 → JTZ taken → Rdst stays 1  ✓
+    #   Ra != Rb → Z=0 → JTZ not taken → MVI Rdst, 0  ✓
+    #
+    # Assembly:
+    #   MOV  A, Ra
+    #   CMP  Rb          ; Z=1 iff Ra==Rb
+    #   MVI  Rdst, 1     ; assume equal
+    #   JTZ  cmp_N_done  ; if Z, skip the "not equal" path
+    #   MVI  Rdst, 0
+    # cmp_N_done:
+
+    def _emit_cmp_eq(self, ops: list) -> list[str]:  # noqa: ANN001
+        """Emit CMP_EQ: boolean equality materialisation."""
+        if len(ops) < 3:
+            return [f"{_INDENT}; CMP_EQ: missing operands"]
+        dst, ra, rb = ops[0], ops[1], ops[2]
+        if not all(isinstance(o, IrRegister) for o in [dst, ra, rb]):
+            return [f"{_INDENT}; CMP_EQ: unexpected operand types"]
+        rdst = _preg(dst.index)
+        rra = _preg(ra.index)
+        rrb = _preg(rb.index)
+        done = self._next_label()
+        return [
+            f"{_INDENT}MOV  A, {rra}",
+            f"{_INDENT}CMP  {rrb}",
+            f"{_INDENT}MVI  {rdst}, 1",
+            f"{_INDENT}JTZ  {done}",
+            f"{_INDENT}MVI  {rdst}, 0",
+            f"{done}:",
+        ]
+
+    # ------------------------------------------------------------------
+    # CMP_NE Rdst, Ra, Rb
+    # ------------------------------------------------------------------
+    #
+    # Set Rdst = 1 if Ra != Rb, else 0.
+    #
+    # Opposite of CMP_EQ: assume not-equal (load 0), branch if Z=1 (equal).
+    #
+    #   MOV  A, Ra
+    #   CMP  Rb          ; Z=1 iff Ra==Rb
+    #   MVI  Rdst, 0     ; assume not-equal
+    #   JTZ  cmp_N_done  ; if Z (equal) → skip, keep 0
+    #   MVI  Rdst, 1
+    # cmp_N_done:
+
+    def _emit_cmp_ne(self, ops: list) -> list[str]:  # noqa: ANN001
+        """Emit CMP_NE: boolean inequality materialisation."""
+        if len(ops) < 3:
+            return [f"{_INDENT}; CMP_NE: missing operands"]
+        dst, ra, rb = ops[0], ops[1], ops[2]
+        if not all(isinstance(o, IrRegister) for o in [dst, ra, rb]):
+            return [f"{_INDENT}; CMP_NE: unexpected operand types"]
+        rdst = _preg(dst.index)
+        rra = _preg(ra.index)
+        rrb = _preg(rb.index)
+        done = self._next_label()
+        return [
+            f"{_INDENT}MOV  A, {rra}",
+            f"{_INDENT}CMP  {rrb}",
+            f"{_INDENT}MVI  {rdst}, 0",
+            f"{_INDENT}JTZ  {done}",
+            f"{_INDENT}MVI  {rdst}, 1",
+            f"{done}:",
+        ]
+
+    # ------------------------------------------------------------------
+    # CMP_LT Rdst, Ra, Rb
+    # ------------------------------------------------------------------
+    #
+    # Set Rdst = 1 if Ra < Rb (unsigned), else 0.
+    #
+    # 8008 SUB/CMP semantics: A − Rb sets CY=1 (carry/borrow) iff A < Rb
+    # (unsigned subtraction borrows).  JTC = jump if carry true (CY=1).
+    #
+    #   MOV  A, Ra
+    #   CMP  Rb          ; CY=1 iff Ra < Rb (borrow = unsigned less-than)
+    #   MVI  Rdst, 1     ; assume less-than
+    #   JTC  cmp_N_done  ; if CY (Ra < Rb) → keep 1
+    #   MVI  Rdst, 0
+    # cmp_N_done:
+
+    def _emit_cmp_lt(self, ops: list) -> list[str]:  # noqa: ANN001
+        """Emit CMP_LT: unsigned less-than materialisation."""
+        if len(ops) < 3:
+            return [f"{_INDENT}; CMP_LT: missing operands"]
+        dst, ra, rb = ops[0], ops[1], ops[2]
+        if not all(isinstance(o, IrRegister) for o in [dst, ra, rb]):
+            return [f"{_INDENT}; CMP_LT: unexpected operand types"]
+        rdst = _preg(dst.index)
+        rra = _preg(ra.index)
+        rrb = _preg(rb.index)
+        done = self._next_label()
+        return [
+            f"{_INDENT}MOV  A, {rra}",
+            f"{_INDENT}CMP  {rrb}",
+            f"{_INDENT}MVI  {rdst}, 1",
+            f"{_INDENT}JTC  {done}",
+            f"{_INDENT}MVI  {rdst}, 0",
+            f"{done}:",
+        ]
+
+    # ------------------------------------------------------------------
+    # CMP_GT Rdst, Ra, Rb
+    # ------------------------------------------------------------------
+    #
+    # Set Rdst = 1 if Ra > Rb (unsigned), else 0.
+    #
+    # Trick: Ra > Rb ⟺ Rb < Ra.  So we swap the operands:
+    #   MOV A, Rb; CMP Ra → CY=1 iff Rb < Ra iff Ra > Rb.
+    #
+    #   MOV  A, Rb       ; Rb in accumulator (operand swap!)
+    #   CMP  Ra          ; CY=1 iff Rb < Ra i.e. Ra > Rb
+    #   MVI  Rdst, 1     ; assume greater-than
+    #   JTC  cmp_N_done  ; if CY → keep 1
+    #   MVI  Rdst, 0
+    # cmp_N_done:
+
+    def _emit_cmp_gt(self, ops: list) -> list[str]:  # noqa: ANN001
+        """Emit CMP_GT: unsigned greater-than via operand-swap trick."""
+        if len(ops) < 3:
+            return [f"{_INDENT}; CMP_GT: missing operands"]
+        dst, ra, rb = ops[0], ops[1], ops[2]
+        if not all(isinstance(o, IrRegister) for o in [dst, ra, rb]):
+            return [f"{_INDENT}; CMP_GT: unexpected operand types"]
+        rdst = _preg(dst.index)
+        rra = _preg(ra.index)
+        rrb = _preg(rb.index)
+        done = self._next_label()
+        return [
+            f"{_INDENT}MOV  A, {rrb}",   # note: Rb goes into A (swap!)
+            f"{_INDENT}CMP  {rra}",       # CY=1 iff Rb < Ra i.e. Ra > Rb
+            f"{_INDENT}MVI  {rdst}, 1",
+            f"{_INDENT}JTC  {done}",
+            f"{_INDENT}MVI  {rdst}, 0",
+            f"{done}:",
+        ]
+
+    # ------------------------------------------------------------------
+    # BRANCH_Z Rcond, lbl  →  MOV A, Rcond  /  CPI 0  /  JTZ lbl
+    # ------------------------------------------------------------------
+    #
+    # Jump to lbl if the condition register is zero.
+    #
+    # CPI 0 = compare accumulator with immediate 0.  Sets Z=1 iff A == 0.
+    # JTZ = jump if zero true (Z=1).
+    #
+    # Used for: if(!cond), while(!cond), the false branch of if/else.
+
+    def _emit_branch_z(self, ops: list) -> list[str]:  # noqa: ANN001
+        """Emit BRANCH_Z: MOV A, Rcond; CPI 0; JTZ lbl."""
+        if len(ops) < 2:
+            return [f"{_INDENT}; BRANCH_Z: missing operands"]
+        reg, lbl = ops[0], ops[1]
+        if not isinstance(reg, IrRegister) or not isinstance(lbl, IrLabel):
+            return [f"{_INDENT}; BRANCH_Z: unexpected operand types"]
+        rn = _preg(reg.index)
+        return [
+            f"{_INDENT}MOV  A, {rn}",
+            f"{_INDENT}CPI  0",
+            f"{_INDENT}JTZ  {lbl.name}",
+        ]
+
+    # ------------------------------------------------------------------
+    # BRANCH_NZ Rcond, lbl  →  MOV A, Rcond  /  CPI 0  /  JFZ lbl
+    # ------------------------------------------------------------------
+    #
+    # Jump to lbl if the condition register is non-zero.
+    #
+    # JFZ = jump if zero false (Z=0), i.e. result was not zero.
+    #
+    # Used for: loop-back jumps in while, logical OR short-circuit.
+
+    def _emit_branch_nz(self, ops: list) -> list[str]:  # noqa: ANN001
+        """Emit BRANCH_NZ: MOV A, Rcond; CPI 0; JFZ lbl."""
+        if len(ops) < 2:
+            return [f"{_INDENT}; BRANCH_NZ: missing operands"]
+        reg, lbl = ops[0], ops[1]
+        if not isinstance(reg, IrRegister) or not isinstance(lbl, IrLabel):
+            return [f"{_INDENT}; BRANCH_NZ: unexpected operand types"]
+        rn = _preg(reg.index)
+        return [
+            f"{_INDENT}MOV  A, {rn}",
+            f"{_INDENT}CPI  0",
+            f"{_INDENT}JFZ  {lbl.name}",
+        ]
+
+    # ------------------------------------------------------------------
+    # JUMP lbl  →  JMP lbl
+    # ------------------------------------------------------------------
+    #
+    # JMP is the 8008 unconditional branch — a 3-byte instruction with a
+    # 14-bit address.  Unlike the 4004's page-relative JCN, JMP can target
+    # any address in the full 16 KB ROM without alignment constraints.
+
+    def _emit_jump(self, ops: list) -> list[str]:  # noqa: ANN001
+        """Emit JUMP: JMP label."""
+        if ops and isinstance(ops[0], IrLabel):
+            return [f"{_INDENT}JMP  {ops[0].name}"]
+        return [f"{_INDENT}; JUMP: missing label operand"]
+
+    # ------------------------------------------------------------------
+    # CALL lbl  →  CAL lbl
+    # ------------------------------------------------------------------
+    #
+    # CAL (Call subroutine): push PC+3 onto the 8-level hardware stack and
+    # jump to the subroutine address.  The callee returns via RFC.
+    # CAL is a 3-byte instruction.
+
+    def _emit_call(self, ops: list) -> list[str]:  # noqa: ANN001
+        """Emit CALL: CAL label."""
+        if ops and isinstance(ops[0], IrLabel):
+            return [f"{_INDENT}CAL  {ops[0].name}"]
+        return [f"{_INDENT}; CALL: missing label operand"]
+
+    # ------------------------------------------------------------------
+    # RET  →  MOV A, C  /  RFC
+    # ------------------------------------------------------------------
+    #
+    # The Oct calling convention places the return value in v1=C.
+    # Before returning, we copy C to A (the 8008 return-value register).
+    # RFC (Return if Carry False) is the standard unconditional return —
+    # by convention the code generator never leaves CY=1 at a RET site.
+    #
+    # The assembler accepts both ``RET`` and ``RFC`` as synonyms; we emit
+    # ``RFC`` to be explicit about the opcode.
+    #
+    # For void functions, A will hold garbage — callers must ignore it.
+    # This is safe because callers only read A for non-void return types.
+
+    def _emit_ret(self) -> list[str]:
+        """Emit RET: MOV A, C; RFC."""
+        return [
+            f"{_INDENT}MOV  A, {_REG_RESULT}",
+            f"{_INDENT}RFC",
+        ]
+
+    # ------------------------------------------------------------------
+    # HALT  →  HLT
+    # ------------------------------------------------------------------
+    #
+    # HLT (0xFF) halts the Intel 8008 processor.  The program counter stops
+    # advancing and the CPU waits for a reset signal.  This is emitted at
+    # the end of _start after the main function returns.
+
+    def _emit_halt(self) -> list[str]:
+        """Emit HALT: HLT."""
+        return [f"{_INDENT}HLT"]
+
+    # ------------------------------------------------------------------
+    # NOP  →  (comment — 8008 has no NOP)
+    # ------------------------------------------------------------------
+    #
+    # The Intel 8008 has no dedicated NOP instruction.  The closest
+    # equivalent is ``MOV A, A`` (self-copy, 1 byte, no visible side effect
+    # except flag updates).  We emit a comment instead of polluting the
+    # binary with unnecessary instructions.
+
+    def _emit_nop(self) -> list[str]:
+        """Emit NOP: comment (8008 has no true NOP)."""
+        return [f"{_INDENT}; NOP (no-op; omitted on 8008)"]
+
+    # ------------------------------------------------------------------
+    # COMMENT  →  ; text
+    # ------------------------------------------------------------------
+
+    def _emit_comment(self, ops: list) -> list[str]:  # noqa: ANN001
+        """Emit a comment line."""
+        if ops and isinstance(ops[0], IrLabel):
+            return [f"{_INDENT}; {ops[0].name}"]
+        if ops and isinstance(ops[0], IrImmediate):
+            return [f"{_INDENT}; {ops[0].value}"]
+        return [f"{_INDENT};"]
+
+    # ------------------------------------------------------------------
+    # SYSCALL  →  inline 8008 hardware intrinsic
+    # ------------------------------------------------------------------
+    #
+    # The Oct IR uses SYSCALL to represent the 10 hardware intrinsics.
+    # Each SYSCALL number maps to a unique inline instruction sequence.
+    # The mapping (from the Oct specification, OCT00):
+    #
+    #   3  = adc(a, b)  → ADC (add with carry):
+    #          a is in v2=D, b is in v3=E, result lands in v1=C
+    #   4  = sbb(a, b)  → SBB (subtract with borrow):
+    #          same register layout as adc
+    #   11 = rlc(a)     → RLC rotate left circular;   a in v2=D
+    #   12 = rrc(a)     → RRC rotate right circular;  a in v2=D
+    #   13 = ral(a)     → RAL rotate left through carry;  a in v2=D
+    #   14 = rar(a)     → RAR rotate right through carry; a in v2=D
+    #   15 = carry()    → ACI 0 trick to materialise CY into A
+    #   16 = parity(a)  → ORA A + conditional branch;  a in v2=D
+    #   20+p = in(p)    → IN p instruction (p in 0–7)
+    #   40+p = out(p,v) → OUT p instruction (v in v2=D)
+    #
+    # All results land in v1=C (the scratch/return register).
+
+    def _emit_syscall(self, ops: list) -> list[str]:  # noqa: ANN001
+        """Emit SYSCALL: expand to the appropriate 8008 inline sequence."""
+        if not ops or not isinstance(ops[0], IrImmediate):
+            return [f"{_INDENT}; SYSCALL: missing number operand"]
+        num = ops[0].value
+
+        if num == 3:
+            return self._emit_syscall_adc()
+        if num == 4:
+            return self._emit_syscall_sbb()
+        if num == 11:
+            return self._emit_syscall_rotate("RLC")
+        if num == 12:
+            return self._emit_syscall_rotate("RRC")
+        if num == 13:
+            return self._emit_syscall_rotate("RAL")
+        if num == 14:
+            return self._emit_syscall_rotate("RAR")
+        if num == 15:
+            return self._emit_syscall_carry()
+        if num == 16:
+            return self._emit_syscall_parity()
+        if 20 <= num <= 27:
+            return self._emit_syscall_in(num - 20)
+        if 40 <= num <= 63:
+            return self._emit_syscall_out(num - 40)
+
+        # Unrecognised syscall — the validator should have caught this.
+        return [f"{_INDENT}; SYSCALL {num}: unrecognised (validator missed it?)"]
+
+    def _emit_syscall_adc(self) -> list[str]:
+        """SYSCALL 3 — adc(a, b): A ← D + E + CY → result in C.
+
+        The 8008 ADC (Add with Carry) instruction: A ← A + Rb + CY.
+        a is staged in v2=D, b in v3=E by the IR compiler.
+
+        Sequence:
+          MOV  A, D      ; load a into accumulator
+          ADC  E         ; A = a + b + CY (add with existing carry)
+          MOV  C, A      ; store result in v1=C
+        """
+        return [
+            f"{_INDENT}MOV  A, {_REG_ARG0}",
+            f"{_INDENT}ADC  {_REG_ARG1}",
+            f"{_INDENT}MOV  {_REG_RESULT}, A",
+        ]
+
+    def _emit_syscall_sbb(self) -> list[str]:
+        """SYSCALL 4 — sbb(a, b): A ← D − E − CY → result in C.
+
+        The 8008 SBB (Subtract with Borrow) instruction: A ← A − Rb − CY.
+        Used for multi-byte subtraction where the borrow from the low byte
+        propagates into the high byte.
+
+        Sequence:
+          MOV  A, D      ; load a
+          SBB  E         ; A = a - b - CY
+          MOV  C, A      ; result in v1=C
+        """
+        return [
+            f"{_INDENT}MOV  A, {_REG_ARG0}",
+            f"{_INDENT}SBB  {_REG_ARG1}",
+            f"{_INDENT}MOV  {_REG_RESULT}, A",
+        ]
+
+    def _emit_syscall_rotate(self, mnemonic: str) -> list[str]:
+        """SYSCALL 11–14 — rlc/rrc/ral/rar: rotate D → result in C.
+
+        All four rotations follow the same pattern:
+          1. Load the argument (v2=D) into A.
+          2. Apply the rotation to A.
+          3. Store A into the result register (v1=C).
+
+        The rotation updates CY with the bit that was rotated out, so a
+        subsequent ``carry()`` call reads the rotated bit.
+
+        Args:
+            mnemonic: One of ``"RLC"``, ``"RRC"``, ``"RAL"``, ``"RAR"``.
+        """
+        return [
+            f"{_INDENT}MOV  A, {_REG_ARG0}",
+            f"{_INDENT}{mnemonic}",
+            f"{_INDENT}MOV  {_REG_RESULT}, A",
+        ]
+
+    def _emit_syscall_carry(self) -> list[str]:
+        """SYSCALL 15 — carry(): materialise CY into C.
+
+        The 8008 has no "read carry to register" instruction.  The classic
+        trick uses ACI 0 (Add with Carry Immediate 0):
+
+          A ← A + 0 + CY = CY   (if we prime A = 0 first)
+
+        So: MVI A, 0; ACI 0 gives A = CY (either 0 or 1).
+
+        Note: ACI 0 itself sets CY=0 (no overflow of 0+0+CY for CY∈{0,1}
+        when A was 0), but that's fine — carry() is only valid immediately
+        after the arithmetic that set CY, before any other ALU op.
+
+        Sequence:
+          MVI  A, 0      ; prime accumulator
+          ACI  0         ; A = 0 + 0 + CY = CY
+          MOV  C, A      ; result (0 or 1) in v1=C
+        """
+        return [
+            f"{_INDENT}MVI  A, 0",
+            f"{_INDENT}ACI  0",
+            f"{_INDENT}MOV  {_REG_RESULT}, A",
+        ]
+
+    def _emit_syscall_parity(self) -> list[str]:
+        """SYSCALL 16 — parity(a): materialise parity flag from D into C.
+
+        The P flag is set by any ALU result:  P=1 iff popcount(A) is even.
+        The trick to refresh all flags from A without changing A is ORA A
+        (OR A with itself — result unchanged, flags updated).
+
+        Then we branch on the parity flag:
+          P=1 (even parity) → result = 1
+          P=0 (odd parity)  → result = 0
+
+        JFP (Jump if Parity False) = jump if P=0 (odd parity).
+
+        Sequence:
+          MOV  A, D          ; load argument into A
+          ORA  A             ; refresh flags from A; P=1 iff popcount even
+          MVI  C, 0          ; assume odd parity
+          JFP  par_N_done    ; if P=0 (odd) → keep 0, done
+          MVI  C, 1          ; even parity: set 1
+        par_N_done:
+        """
+        done = self._next_label()
+        return [
+            f"{_INDENT}MOV  A, {_REG_ARG0}",
+            f"{_INDENT}ORA  A",
+            f"{_INDENT}MVI  {_REG_RESULT}, 0",
+            f"{_INDENT}JFP  {done}",
+            f"{_INDENT}MVI  {_REG_RESULT}, 1",
+            f"{done}:",
+        ]
+
+    def _emit_syscall_in(self, port: int) -> list[str]:
+        """SYSCALL 20+p — in(p): read input port p → result in C.
+
+        The 8008 IN p instruction reads the 8-bit value on input port p
+        (p ∈ 0–7) into the accumulator.  The port number is encoded in
+        the opcode itself — no address bus cycle needed.
+
+        We then copy A to v1=C so the result is in the standard return
+        register for Oct intrinsics.
+
+        Sequence:
+          IN   p      ; A ← input port p
+          MOV  C, A   ; result in v1=C
+        """
+        return [
+            f"{_INDENT}IN   {port}",
+            f"{_INDENT}MOV  {_REG_RESULT}, A",
+        ]
+
+    def _emit_syscall_out(self, port: int) -> list[str]:
+        """SYSCALL 40+p — out(p, val): write D to output port p.
+
+        The 8008 OUT p instruction writes the accumulator to output port p
+        (p ∈ 0–23).  The port number is encoded in the opcode.
+
+        The value to write (val) is staged in v2=D by the IR compiler.
+        We copy D to A and then output.
+
+        Sequence:
+          MOV  A, D   ; load val from v2=D
+          OUT  p      ; output port p ← A
+        """
+        return [
+            f"{_INDENT}MOV  A, {_REG_ARG0}",
+            f"{_INDENT}OUT  {port}",
+        ]

--- a/code/packages/python/ir-to-intel-8008-compiler/tests/test_ir_to_intel_8008_compiler.py
+++ b/code/packages/python/ir-to-intel-8008-compiler/tests/test_ir_to_intel_8008_compiler.py
@@ -1,0 +1,1470 @@
+"""Tests for ir_to_intel_8008_compiler.
+
+This test suite verifies that the CodeGenerator correctly lowers every IR
+opcode into the expected Intel 8008 assembly sequence, and that the
+IrToIntel8008Compiler facade correctly orchestrates validation + generation.
+
+Test organisation:
+  1. TestCodeGeneratorHeader       — ORG directive, program header
+  2. TestEmitLabel                 — LABEL opcode
+  3. TestEmitLoadImm               — LOAD_IMM opcode → MVI
+  4. TestEmitLoadAddr              — LOAD_ADDR opcode → MVI H / MVI L
+  5. TestEmitLoadByte              — LOAD_BYTE opcode → MOV A, M
+  6. TestEmitStoreByte             — STORE_BYTE opcode → MOV M, A
+  7. TestEmitAdd                   — ADD opcode → MOV/ADD/MOV
+  8. TestEmitAddImm                — ADD_IMM opcode (including imm=0 copy)
+  9. TestEmitSub                   — SUB opcode
+  10. TestEmitAnd                  — AND opcode → ANA
+  11. TestEmitOr                   — OR opcode → ORA
+  12. TestEmitXor                  — XOR opcode → XRA
+  13. TestEmitNot                  — NOT opcode → XRI 0xFF
+  14. TestEmitCmpEq                — CMP_EQ → label-based materialisation
+  15. TestEmitCmpNe                — CMP_NE → label-based materialisation
+  16. TestEmitCmpLt                — CMP_LT → CY flag test
+  17. TestEmitCmpGt                — CMP_GT → operand-swap trick
+  18. TestEmitBranchZ              — BRANCH_Z → JTZ
+  19. TestEmitBranchNz             — BRANCH_NZ → JFZ
+  20. TestEmitJump                 — JUMP → JMP
+  21. TestEmitCall                 — CALL → CAL
+  22. TestEmitRet                  — RET → MOV A, C; RFC
+  23. TestEmitHalt                 — HALT → HLT
+  24. TestEmitNop                  — NOP → comment
+  25. TestEmitComment              — COMMENT → ; text
+  26. TestEmitSyscall              — SYSCALL expansions (all 10)
+  27. TestLabelCounter             — unique label generation across calls
+  28. TestUnknownOpcode            — graceful fallback for unknown opcodes
+  29. TestFullProgram              — end-to-end multi-instruction programs
+  30. TestIrToIntel8008Compiler    — facade: validate+generate, error handling
+  31. TestPublicApi                — module-level validate() and generate_asm()
+"""
+
+from __future__ import annotations
+
+import pytest
+from compiler_ir import (
+    IrImmediate,
+    IrInstruction,
+    IrLabel,
+    IrOp,
+    IrProgram,
+    IrRegister,
+)
+
+from ir_to_intel_8008_compiler import (
+    CodeGenerator,
+    Intel8008Backend,
+    IrToIntel8008Compiler,
+    IrValidationError,
+    generate_asm,
+    validate,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_INDENT = "    "
+
+
+def _reg(i: int) -> IrRegister:
+    """Shorthand: create IrRegister(index=i)."""
+    return IrRegister(index=i)
+
+
+def _imm(v: int) -> IrImmediate:
+    """Shorthand: create IrImmediate(value=v)."""
+    return IrImmediate(value=v)
+
+
+def _lbl(name: str) -> IrLabel:
+    """Shorthand: create IrLabel(name=name)."""
+    return IrLabel(name=name)
+
+
+def _instr(op: IrOp, *operands: object) -> IrInstruction:
+    """Shorthand: create IrInstruction(opcode=op, operands=[...])."""
+    return IrInstruction(opcode=op, operands=list(operands))
+
+
+def _prog(*instrs: IrInstruction) -> IrProgram:
+    """Build a minimal IrProgram with the given instructions."""
+    prog = IrProgram(entry_label="_start", version=1)
+    for instr in instrs:
+        prog.add_instruction(instr)
+    return prog
+
+
+def _gen_lines(*instrs: IrInstruction) -> list[str]:
+    """Generate assembly for given instructions and return lines (skip ORG line)."""
+    prog = _prog(*instrs)
+    asm = CodeGenerator().generate(prog)
+    # First line is the ORG directive; return the rest
+    return asm.strip().splitlines()[1:]
+
+
+def _gen(*instrs: IrInstruction) -> str:
+    """Generate full assembly for given instructions."""
+    return CodeGenerator().generate(_prog(*instrs))
+
+
+# Physical register mapping
+_PREG = {0: "B", 1: "C", 2: "D", 3: "E", 4: "H", 5: "L"}
+
+
+# ===========================================================================
+# 1. TestCodeGeneratorHeader
+# ===========================================================================
+
+
+class TestCodeGeneratorHeader:
+    """The generated assembly always starts with ORG 0x0000."""
+
+    def test_empty_program_starts_with_org(self) -> None:
+        """An empty program emits only the ORG directive."""
+        asm = CodeGenerator().generate(_prog())
+        assert asm.startswith(f"{_INDENT}ORG 0x0000\n")
+
+    def test_org_is_first_line(self) -> None:
+        """ORG is the very first line even when instructions follow."""
+        asm = _gen(_instr(IrOp.HALT))
+        lines = asm.splitlines()
+        assert lines[0] == f"{_INDENT}ORG 0x0000"
+
+    def test_output_ends_with_newline(self) -> None:
+        """Output must end with a newline (POSIX-compliant file)."""
+        asm = _gen(_instr(IrOp.HALT))
+        assert asm.endswith("\n")
+
+    def test_empty_program_ends_with_newline(self) -> None:
+        """Empty program ends with a newline."""
+        asm = CodeGenerator().generate(_prog())
+        assert asm.endswith("\n")
+
+
+# ===========================================================================
+# 2. TestEmitLabel
+# ===========================================================================
+
+
+class TestEmitLabel:
+    """LABEL opcode emits a column-0 label definition."""
+
+    def test_label_at_column_zero(self) -> None:
+        """Label definitions start at column 0 (no indentation)."""
+        lines = _gen_lines(_instr(IrOp.LABEL, _lbl("loop_start")))
+        assert lines == ["loop_start:"]
+
+    def test_label_name_preserved(self) -> None:
+        """The label name is emitted verbatim."""
+        lines = _gen_lines(_instr(IrOp.LABEL, _lbl("_fn_main")))
+        assert lines == ["_fn_main:"]
+
+    def test_label_with_underscores_and_digits(self) -> None:
+        """Labels with underscores and digits are passed through unchanged."""
+        lines = _gen_lines(_instr(IrOp.LABEL, _lbl("loop_0_end_42")))
+        assert lines == ["loop_0_end_42:"]
+
+    def test_label_missing_operand(self) -> None:
+        """LABEL with no operand emits nothing (defensive)."""
+        lines = _gen_lines(_instr(IrOp.LABEL))
+        assert lines == []
+
+    def test_label_wrong_operand_type(self) -> None:
+        """LABEL with non-label operand emits nothing."""
+        lines = _gen_lines(_instr(IrOp.LABEL, _imm(42)))
+        assert lines == []
+
+
+# ===========================================================================
+# 3. TestEmitLoadImm
+# ===========================================================================
+
+
+class TestEmitLoadImm:
+    """LOAD_IMM emits MVI Rdst, imm."""
+
+    @pytest.mark.parametrize("vreg,preg", _PREG.items())
+    def test_all_virtual_registers(self, vreg: int, preg: str) -> None:
+        """Each virtual register maps to the correct physical register."""
+        lines = _gen_lines(_instr(IrOp.LOAD_IMM, _reg(vreg), _imm(0)))
+        assert lines == [f"{_INDENT}MVI  {preg}, 0"]
+
+    def test_immediate_zero(self) -> None:
+        """MVI with value 0 is emitted correctly."""
+        lines = _gen_lines(_instr(IrOp.LOAD_IMM, _reg(2), _imm(0)))
+        assert lines == [f"{_INDENT}MVI  D, 0"]
+
+    def test_immediate_255(self) -> None:
+        """MVI with value 255 (max unsigned byte)."""
+        lines = _gen_lines(_instr(IrOp.LOAD_IMM, _reg(1), _imm(255)))
+        assert lines == [f"{_INDENT}MVI  C, 255"]
+
+    def test_immediate_42(self) -> None:
+        """MVI with a typical value."""
+        lines = _gen_lines(_instr(IrOp.LOAD_IMM, _reg(3), _imm(42)))
+        assert lines == [f"{_INDENT}MVI  E, 42"]
+
+    def test_missing_operands(self) -> None:
+        """LOAD_IMM with no operands emits a comment (defensive)."""
+        lines = _gen_lines(_instr(IrOp.LOAD_IMM))
+        assert len(lines) == 1
+        assert "LOAD_IMM" in lines[0]
+
+    def test_wrong_operand_types(self) -> None:
+        """LOAD_IMM with wrong types emits a comment (defensive)."""
+        lines = _gen_lines(_instr(IrOp.LOAD_IMM, _lbl("x"), _imm(1)))
+        assert len(lines) == 1
+        assert "LOAD_IMM" in lines[0]
+
+
+# ===========================================================================
+# 4. TestEmitLoadAddr
+# ===========================================================================
+
+
+class TestEmitLoadAddr:
+    """LOAD_ADDR emits MVI H, hi(sym); MVI L, lo(sym)."""
+
+    def test_basic_label(self) -> None:
+        """LOAD_ADDR expands to two MVI instructions."""
+        lines = _gen_lines(_instr(IrOp.LOAD_ADDR, _reg(1), _lbl("tape")))
+        assert lines == [
+            f"{_INDENT}MVI  H, hi(tape)",
+            f"{_INDENT}MVI  L, lo(tape)",
+        ]
+
+    def test_destination_register_ignored(self) -> None:
+        """The destination virtual register is ignored (H:L is always used)."""
+        lines_v1 = _gen_lines(_instr(IrOp.LOAD_ADDR, _reg(1), _lbl("buf")))
+        lines_v3 = _gen_lines(_instr(IrOp.LOAD_ADDR, _reg(3), _lbl("buf")))
+        assert lines_v1 == lines_v3
+
+    def test_label_name_preserved(self) -> None:
+        """The symbol name appears verbatim in hi() and lo()."""
+        lines = _gen_lines(_instr(IrOp.LOAD_ADDR, _reg(0), _lbl("my_symbol")))
+        assert "hi(my_symbol)" in lines[0]
+        assert "lo(my_symbol)" in lines[1]
+
+    def test_missing_operands(self) -> None:
+        """LOAD_ADDR with no operands emits a comment."""
+        lines = _gen_lines(_instr(IrOp.LOAD_ADDR))
+        assert len(lines) == 1
+        assert "LOAD_ADDR" in lines[0]
+
+    def test_non_label_operand(self) -> None:
+        """LOAD_ADDR with a register instead of label emits a comment."""
+        lines = _gen_lines(_instr(IrOp.LOAD_ADDR, _reg(1), _reg(2)))
+        assert len(lines) == 1
+        assert "LOAD_ADDR" in lines[0]
+
+
+# ===========================================================================
+# 5. TestEmitLoadByte
+# ===========================================================================
+
+
+class TestEmitLoadByte:
+    """LOAD_BYTE emits MOV A, M; MOV Rdst, A."""
+
+    @pytest.mark.parametrize("vreg,preg", _PREG.items())
+    def test_all_destination_registers(self, vreg: int, preg: str) -> None:
+        """Each destination virtual register receives the byte via A."""
+        lines = _gen_lines(
+            _instr(IrOp.LOAD_BYTE, _reg(vreg), _reg(0), _reg(0))
+        )
+        assert lines[0] == f"{_INDENT}MOV  A, M"
+        assert lines[1] == f"{_INDENT}MOV  {preg}, A"
+
+    def test_two_line_sequence(self) -> None:
+        """LOAD_BYTE always emits exactly two lines."""
+        lines = _gen_lines(_instr(IrOp.LOAD_BYTE, _reg(1), _reg(1), _reg(0)))
+        assert len(lines) == 2
+
+    def test_base_and_offset_operands_ignored(self) -> None:
+        """The base and offset operands are ignored (H:L is implicit)."""
+        lines_a = _gen_lines(_instr(IrOp.LOAD_BYTE, _reg(1), _reg(2), _reg(3)))
+        lines_b = _gen_lines(_instr(IrOp.LOAD_BYTE, _reg(1), _reg(4), _reg(5)))
+        assert lines_a == lines_b
+
+    def test_missing_operands(self) -> None:
+        """LOAD_BYTE with no operands emits a comment."""
+        lines = _gen_lines(_instr(IrOp.LOAD_BYTE))
+        assert len(lines) == 1
+        assert "LOAD_BYTE" in lines[0]
+
+
+# ===========================================================================
+# 6. TestEmitStoreByte
+# ===========================================================================
+
+
+class TestEmitStoreByte:
+    """STORE_BYTE emits MOV A, Rsrc; MOV M, A."""
+
+    @pytest.mark.parametrize("vreg,preg", _PREG.items())
+    def test_all_source_registers(self, vreg: int, preg: str) -> None:
+        """Each source virtual register is loaded into A before storing."""
+        lines = _gen_lines(
+            _instr(IrOp.STORE_BYTE, _reg(vreg), _reg(0), _reg(0))
+        )
+        assert lines == [
+            f"{_INDENT}MOV  A, {preg}",
+            f"{_INDENT}MOV  M, A",
+        ]
+
+    def test_two_line_sequence(self) -> None:
+        """STORE_BYTE always emits exactly two lines."""
+        lines = _gen_lines(_instr(IrOp.STORE_BYTE, _reg(2), _reg(0), _reg(0)))
+        assert len(lines) == 2
+
+    def test_missing_operands(self) -> None:
+        """STORE_BYTE with no operands emits a comment."""
+        lines = _gen_lines(_instr(IrOp.STORE_BYTE))
+        assert len(lines) == 1
+        assert "STORE_BYTE" in lines[0]
+
+
+# ===========================================================================
+# 7. TestEmitAdd
+# ===========================================================================
+
+
+class TestEmitAdd:
+    """ADD emits MOV A, Ra; ADD Rb; MOV Rdst, A."""
+
+    def test_basic_add(self) -> None:
+        """ADD v2, v1, v0 → MOV A, C; ADD B; MOV D, A."""
+        lines = _gen_lines(_instr(IrOp.ADD, _reg(2), _reg(1), _reg(0)))
+        assert lines == [
+            f"{_INDENT}MOV  A, C",
+            f"{_INDENT}ADD  B",
+            f"{_INDENT}MOV  D, A",
+        ]
+
+    def test_three_lines(self) -> None:
+        """ADD always emits exactly 3 lines."""
+        lines = _gen_lines(_instr(IrOp.ADD, _reg(1), _reg(2), _reg(3)))
+        assert len(lines) == 3
+
+    def test_add_same_registers(self) -> None:
+        """ADD v1, v1, v1 (self-add) emits valid assembly."""
+        lines = _gen_lines(_instr(IrOp.ADD, _reg(1), _reg(1), _reg(1)))
+        assert lines == [
+            f"{_INDENT}MOV  A, C",
+            f"{_INDENT}ADD  C",
+            f"{_INDENT}MOV  C, A",
+        ]
+
+    def test_missing_operands(self) -> None:
+        """ADD with fewer than 3 operands emits a comment."""
+        lines = _gen_lines(_instr(IrOp.ADD, _reg(1), _reg(2)))
+        assert len(lines) == 1
+        assert "ADD" in lines[0]
+
+    def test_wrong_operand_types(self) -> None:
+        """ADD with non-register operands emits a comment."""
+        lines = _gen_lines(_instr(IrOp.ADD, _reg(1), _imm(5), _reg(2)))
+        assert len(lines) == 1
+        assert "ADD" in lines[0]
+
+
+# ===========================================================================
+# 8. TestEmitAddImm
+# ===========================================================================
+
+
+class TestEmitAddImm:
+    """ADD_IMM emits MOV A, Ra; [ADI imm;] MOV Rdst, A.
+
+    Special case: imm == 0 is a pure register copy (no ADI).
+    """
+
+    def test_nonzero_immediate(self) -> None:
+        """ADD_IMM with imm != 0 emits 3 lines including ADI."""
+        lines = _gen_lines(_instr(IrOp.ADD_IMM, _reg(1), _reg(2), _imm(5)))
+        assert lines == [
+            f"{_INDENT}MOV  A, D",
+            f"{_INDENT}ADI  5",
+            f"{_INDENT}MOV  C, A",
+        ]
+
+    def test_immediate_zero_is_copy(self) -> None:
+        """ADD_IMM with imm == 0 emits 2 lines (register copy, no ADI)."""
+        lines = _gen_lines(_instr(IrOp.ADD_IMM, _reg(2), _reg(1), _imm(0)))
+        assert lines == [
+            f"{_INDENT}MOV  A, C",
+            f"{_INDENT}MOV  D, A",
+        ]
+
+    def test_immediate_255(self) -> None:
+        """ADD_IMM with max immediate value (255)."""
+        lines = _gen_lines(_instr(IrOp.ADD_IMM, _reg(1), _reg(1), _imm(255)))
+        assert f"{_INDENT}ADI  255" in lines
+
+    def test_copy_two_lines(self) -> None:
+        """Register copy (imm=0) always emits exactly 2 lines."""
+        lines = _gen_lines(_instr(IrOp.ADD_IMM, _reg(3), _reg(2), _imm(0)))
+        assert len(lines) == 2
+
+    def test_nonzero_three_lines(self) -> None:
+        """Non-zero ADD_IMM always emits exactly 3 lines."""
+        lines = _gen_lines(_instr(IrOp.ADD_IMM, _reg(1), _reg(2), _imm(1)))
+        assert len(lines) == 3
+
+    def test_missing_operands(self) -> None:
+        """ADD_IMM with fewer than 3 operands emits a comment."""
+        lines = _gen_lines(_instr(IrOp.ADD_IMM, _reg(1)))
+        assert len(lines) == 1
+        assert "ADD_IMM" in lines[0]
+
+
+# ===========================================================================
+# 9. TestEmitSub
+# ===========================================================================
+
+
+class TestEmitSub:
+    """SUB emits MOV A, Ra; SUB Rb; MOV Rdst, A."""
+
+    def test_basic_sub(self) -> None:
+        """SUB v1, v2, v3 → MOV A, D; SUB E; MOV C, A."""
+        lines = _gen_lines(_instr(IrOp.SUB, _reg(1), _reg(2), _reg(3)))
+        assert lines == [
+            f"{_INDENT}MOV  A, D",
+            f"{_INDENT}SUB  E",
+            f"{_INDENT}MOV  C, A",
+        ]
+
+    def test_three_lines(self) -> None:
+        """SUB always emits exactly 3 lines."""
+        lines = _gen_lines(_instr(IrOp.SUB, _reg(0), _reg(1), _reg(2)))
+        assert len(lines) == 3
+
+    def test_missing_operands(self) -> None:
+        """SUB with fewer than 3 operands emits a comment."""
+        lines = _gen_lines(_instr(IrOp.SUB))
+        assert len(lines) == 1
+        assert "SUB" in lines[0]
+
+
+# ===========================================================================
+# 10. TestEmitAnd
+# ===========================================================================
+
+
+class TestEmitAnd:
+    """AND emits MOV A, Ra; ANA Rb; MOV Rdst, A."""
+
+    def test_basic_and(self) -> None:
+        """AND v3, v1, v2 → MOV A, C; ANA D; MOV E, A."""
+        lines = _gen_lines(_instr(IrOp.AND, _reg(3), _reg(1), _reg(2)))
+        assert lines == [
+            f"{_INDENT}MOV  A, C",
+            f"{_INDENT}ANA  D",
+            f"{_INDENT}MOV  E, A",
+        ]
+
+    def test_mnemonic_is_ana(self) -> None:
+        """The 8008 AND instruction is ANA (not AND)."""
+        lines = _gen_lines(_instr(IrOp.AND, _reg(1), _reg(2), _reg(3)))
+        assert any("ANA" in line for line in lines)
+
+    def test_missing_operands(self) -> None:
+        """AND with missing operands emits a comment."""
+        lines = _gen_lines(_instr(IrOp.AND))
+        assert len(lines) == 1
+        assert "AND" in lines[0]
+
+
+# ===========================================================================
+# 11. TestEmitOr
+# ===========================================================================
+
+
+class TestEmitOr:
+    """OR emits MOV A, Ra; ORA Rb; MOV Rdst, A."""
+
+    def test_basic_or(self) -> None:
+        """OR v2, v0, v1 → MOV A, B; ORA C; MOV D, A."""
+        lines = _gen_lines(_instr(IrOp.OR, _reg(2), _reg(0), _reg(1)))
+        assert lines == [
+            f"{_INDENT}MOV  A, B",
+            f"{_INDENT}ORA  C",
+            f"{_INDENT}MOV  D, A",
+        ]
+
+    def test_mnemonic_is_ora(self) -> None:
+        """The 8008 OR instruction is ORA (not OR)."""
+        lines = _gen_lines(_instr(IrOp.OR, _reg(1), _reg(2), _reg(3)))
+        assert any("ORA" in line for line in lines)
+
+    def test_missing_operands(self) -> None:
+        """OR with missing operands emits a comment."""
+        lines = _gen_lines(_instr(IrOp.OR, _reg(1)))
+        assert len(lines) == 1
+        assert "OR" in lines[0]
+
+
+# ===========================================================================
+# 12. TestEmitXor
+# ===========================================================================
+
+
+class TestEmitXor:
+    """XOR emits MOV A, Ra; XRA Rb; MOV Rdst, A."""
+
+    def test_basic_xor(self) -> None:
+        """XOR v1, v2, v3 → MOV A, D; XRA E; MOV C, A."""
+        lines = _gen_lines(_instr(IrOp.XOR, _reg(1), _reg(2), _reg(3)))
+        assert lines == [
+            f"{_INDENT}MOV  A, D",
+            f"{_INDENT}XRA  E",
+            f"{_INDENT}MOV  C, A",
+        ]
+
+    def test_mnemonic_is_xra(self) -> None:
+        """The 8008 XOR instruction is XRA (not XOR)."""
+        lines = _gen_lines(_instr(IrOp.XOR, _reg(0), _reg(1), _reg(2)))
+        assert any("XRA" in line for line in lines)
+
+    def test_missing_operands(self) -> None:
+        """XOR with missing operands emits a comment."""
+        lines = _gen_lines(_instr(IrOp.XOR, _reg(1), _reg(2)))
+        assert len(lines) == 1
+        assert "XOR" in lines[0]
+
+
+# ===========================================================================
+# 13. TestEmitNot
+# ===========================================================================
+
+
+class TestEmitNot:
+    """NOT emits MOV A, Ra; XRI 0xFF; MOV Rdst, A.
+
+    The 8008 has no bitwise NOT — XOR with 0xFF flips all bits.
+    """
+
+    def test_basic_not(self) -> None:
+        """NOT v2, v1 → MOV A, C; XRI 0xFF; MOV D, A."""
+        lines = _gen_lines(_instr(IrOp.NOT, _reg(2), _reg(1)))
+        assert lines == [
+            f"{_INDENT}MOV  A, C",
+            f"{_INDENT}XRI  0xFF",
+            f"{_INDENT}MOV  D, A",
+        ]
+
+    def test_xri_0xff(self) -> None:
+        """XRI 0xFF is used for bitwise complement (flip all 8 bits)."""
+        lines = _gen_lines(_instr(IrOp.NOT, _reg(1), _reg(2)))
+        assert any("XRI  0xFF" in line for line in lines)
+
+    def test_three_lines(self) -> None:
+        """NOT always emits exactly 3 lines."""
+        lines = _gen_lines(_instr(IrOp.NOT, _reg(1), _reg(0)))
+        assert len(lines) == 3
+
+    def test_all_destination_registers(self) -> None:
+        """NOT writes to the correct destination for each virtual register."""
+        for vreg, preg in _PREG.items():
+            lines = _gen_lines(_instr(IrOp.NOT, _reg(vreg), _reg(0)))
+            assert lines[2] == f"{_INDENT}MOV  {preg}, A"
+
+    def test_missing_operands(self) -> None:
+        """NOT with fewer than 2 operands emits a comment."""
+        lines = _gen_lines(_instr(IrOp.NOT))
+        assert len(lines) == 1
+        assert "NOT" in lines[0]
+
+
+# ===========================================================================
+# 14. TestEmitCmpEq
+# ===========================================================================
+
+
+class TestEmitCmpEq:
+    """CMP_EQ materialises Ra==Rb into Rdst using a 6-line sequence."""
+
+    def test_exact_sequence(self) -> None:
+        """CMP_EQ v2, v1, v0 → exact 6-line optimistic-load pattern."""
+        gen = CodeGenerator()
+        prog = _prog(_instr(IrOp.CMP_EQ, _reg(2), _reg(1), _reg(0)))
+        lines = gen.generate(prog).strip().splitlines()[1:]  # skip ORG
+        assert len(lines) == 6
+        assert lines[0] == f"{_INDENT}MOV  A, C"
+        assert lines[1] == f"{_INDENT}CMP  B"
+        assert lines[2] == f"{_INDENT}MVI  D, 1"
+        assert lines[3].startswith(f"{_INDENT}JTZ  ")
+        assert lines[4] == f"{_INDENT}MVI  D, 0"
+        # Label definition at column 0
+        assert not lines[5].startswith(" ")
+        assert lines[5].endswith(":")
+
+    def test_label_on_jtz_matches_definition(self) -> None:
+        """The JTZ target label matches the label definition that follows."""
+        lines = _gen_lines(_instr(IrOp.CMP_EQ, _reg(1), _reg(2), _reg(3)))
+        jtz_line = next(line for line in lines if "JTZ" in line)
+        label_name = jtz_line.split("JTZ  ")[1].strip()
+        label_def = f"{label_name}:"
+        assert label_def in lines
+
+    def test_missing_operands(self) -> None:
+        """CMP_EQ with missing operands emits a comment."""
+        lines = _gen_lines(_instr(IrOp.CMP_EQ, _reg(1), _reg(2)))
+        assert len(lines) == 1
+        assert "CMP_EQ" in lines[0]
+
+
+# ===========================================================================
+# 15. TestEmitCmpNe
+# ===========================================================================
+
+
+class TestEmitCmpNe:
+    """CMP_NE materialises Ra!=Rb into Rdst (inverted logic from CMP_EQ)."""
+
+    def test_exact_sequence(self) -> None:
+        """CMP_NE v2, v1, v0 → loads 0 first, then overwrite with 1 if NE."""
+        lines = _gen_lines(_instr(IrOp.CMP_NE, _reg(2), _reg(1), _reg(0)))
+        # Sequence: MOV A, Ra; CMP Rb; MVI Rdst, 0; JTZ done; MVI Rdst, 1; done:
+        assert lines[0] == f"{_INDENT}MOV  A, C"
+        assert lines[1] == f"{_INDENT}CMP  B"
+        assert lines[2] == f"{_INDENT}MVI  D, 0"
+        assert "JTZ" in lines[3]
+        assert lines[4] == f"{_INDENT}MVI  D, 1"
+
+    def test_six_lines(self) -> None:
+        """CMP_NE emits exactly 6 lines."""
+        lines = _gen_lines(_instr(IrOp.CMP_NE, _reg(1), _reg(2), _reg(3)))
+        assert len(lines) == 6
+
+    def test_label_matches(self) -> None:
+        """JTZ target in CMP_NE matches the trailing label definition."""
+        lines = _gen_lines(_instr(IrOp.CMP_NE, _reg(1), _reg(2), _reg(3)))
+        jtz_line = next(line for line in lines if "JTZ" in line)
+        label_name = jtz_line.split("JTZ  ")[1].strip()
+        assert f"{label_name}:" in lines
+
+    def test_missing_operands(self) -> None:
+        """CMP_NE with missing operands emits a comment."""
+        lines = _gen_lines(_instr(IrOp.CMP_NE))
+        assert len(lines) == 1
+        assert "CMP_NE" in lines[0]
+
+
+# ===========================================================================
+# 16. TestEmitCmpLt
+# ===========================================================================
+
+
+class TestEmitCmpLt:
+    """CMP_LT materialises Ra<Rb (unsigned) using the CY flag."""
+
+    def test_exact_sequence(self) -> None:
+        """CMP_LT uses JTC (Jump if Carry True) to test unsigned less-than."""
+        lines = _gen_lines(_instr(IrOp.CMP_LT, _reg(2), _reg(1), _reg(0)))
+        assert lines[0] == f"{_INDENT}MOV  A, C"
+        assert lines[1] == f"{_INDENT}CMP  B"
+        assert lines[2] == f"{_INDENT}MVI  D, 1"
+        assert "JTC" in lines[3]  # JTC = Jump if Carry True (CY=1 = borrow)
+        assert lines[4] == f"{_INDENT}MVI  D, 0"
+
+    def test_six_lines(self) -> None:
+        """CMP_LT emits exactly 6 lines."""
+        lines = _gen_lines(_instr(IrOp.CMP_LT, _reg(1), _reg(2), _reg(3)))
+        assert len(lines) == 6
+
+    def test_uses_jtc_not_jtz(self) -> None:
+        """CMP_LT uses JTC (carry flag), not JTZ (zero flag)."""
+        lines = _gen_lines(_instr(IrOp.CMP_LT, _reg(1), _reg(2), _reg(3)))
+        branch_lines = [line for line in lines if "JTZ" in line or "JTC" in line]
+        assert all("JTC" in line for line in branch_lines)
+
+    def test_missing_operands(self) -> None:
+        """CMP_LT with missing operands emits a comment."""
+        lines = _gen_lines(_instr(IrOp.CMP_LT, _reg(1)))
+        assert len(lines) == 1
+        assert "CMP_LT" in lines[0]
+
+
+# ===========================================================================
+# 17. TestEmitCmpGt
+# ===========================================================================
+
+
+class TestEmitCmpGt:
+    """CMP_GT uses operand-swap: Ra > Rb ⟺ Rb < Ra (Rb in A, CMP Ra)."""
+
+    def test_operand_swap(self) -> None:
+        """CMP_GT v2, v1, v3 loads Rb (v3=E) into A, not Ra (v1=C)."""
+        lines = _gen_lines(_instr(IrOp.CMP_GT, _reg(2), _reg(1), _reg(3)))
+        # First MOV should load Rb (v3=E), not Ra (v1=C)
+        assert lines[0] == f"{_INDENT}MOV  A, E"   # Rb in accumulator
+        assert lines[1] == f"{_INDENT}CMP  C"       # CMP Ra
+
+    def test_six_lines(self) -> None:
+        """CMP_GT emits exactly 6 lines."""
+        lines = _gen_lines(_instr(IrOp.CMP_GT, _reg(1), _reg(2), _reg(3)))
+        assert len(lines) == 6
+
+    def test_uses_jtc(self) -> None:
+        """CMP_GT uses JTC (carry flag) for unsigned greater-than."""
+        lines = _gen_lines(_instr(IrOp.CMP_GT, _reg(1), _reg(2), _reg(3)))
+        branch_lines = [line for line in lines if "JTC" in line]
+        assert len(branch_lines) == 1
+
+    def test_different_from_cmp_lt(self) -> None:
+        """CMP_GT and CMP_LT produce different first two instructions."""
+        lt_lines = _gen_lines(_instr(IrOp.CMP_LT, _reg(2), _reg(1), _reg(3)))
+        gt_lines = _gen_lines(_instr(IrOp.CMP_GT, _reg(2), _reg(1), _reg(3)))
+        # LT: MOV A, Ra; CMP Rb  vs  GT: MOV A, Rb; CMP Ra (swapped)
+        assert lt_lines[0] != gt_lines[0]
+
+    def test_missing_operands(self) -> None:
+        """CMP_GT with missing operands emits a comment."""
+        lines = _gen_lines(_instr(IrOp.CMP_GT))
+        assert len(lines) == 1
+        assert "CMP_GT" in lines[0]
+
+
+# ===========================================================================
+# 18. TestEmitBranchZ
+# ===========================================================================
+
+
+class TestEmitBranchZ:
+    """BRANCH_Z emits MOV A, Rcond; CPI 0; JTZ lbl."""
+
+    def test_exact_sequence(self) -> None:
+        """BRANCH_Z v1, loop_end → 3-instruction sequence."""
+        lines = _gen_lines(_instr(IrOp.BRANCH_Z, _reg(1), _lbl("loop_end")))
+        assert lines == [
+            f"{_INDENT}MOV  A, C",
+            f"{_INDENT}CPI  0",
+            f"{_INDENT}JTZ  loop_end",
+        ]
+
+    def test_three_lines(self) -> None:
+        """BRANCH_Z always emits exactly 3 lines."""
+        lines = _gen_lines(_instr(IrOp.BRANCH_Z, _reg(2), _lbl("done")))
+        assert len(lines) == 3
+
+    def test_uses_jtz(self) -> None:
+        """BRANCH_Z uses JTZ (Jump if Zero True), not JFZ."""
+        lines = _gen_lines(_instr(IrOp.BRANCH_Z, _reg(1), _lbl("x")))
+        assert any("JTZ" in line for line in lines)
+        assert not any("JFZ" in line for line in lines)
+
+    def test_missing_operands(self) -> None:
+        """BRANCH_Z with missing operands emits a comment."""
+        lines = _gen_lines(_instr(IrOp.BRANCH_Z))
+        assert len(lines) == 1
+        assert "BRANCH_Z" in lines[0]
+
+    def test_wrong_operand_types(self) -> None:
+        """BRANCH_Z with wrong types emits a comment."""
+        lines = _gen_lines(_instr(IrOp.BRANCH_Z, _imm(0), _reg(1)))
+        assert len(lines) == 1
+
+
+# ===========================================================================
+# 19. TestEmitBranchNz
+# ===========================================================================
+
+
+class TestEmitBranchNz:
+    """BRANCH_NZ emits MOV A, Rcond; CPI 0; JFZ lbl."""
+
+    def test_exact_sequence(self) -> None:
+        """BRANCH_NZ v2, loop_body → 3-instruction sequence."""
+        lines = _gen_lines(_instr(IrOp.BRANCH_NZ, _reg(2), _lbl("loop_body")))
+        assert lines == [
+            f"{_INDENT}MOV  A, D",
+            f"{_INDENT}CPI  0",
+            f"{_INDENT}JFZ  loop_body",
+        ]
+
+    def test_uses_jfz(self) -> None:
+        """BRANCH_NZ uses JFZ (Jump if Zero False), not JTZ."""
+        lines = _gen_lines(_instr(IrOp.BRANCH_NZ, _reg(1), _lbl("x")))
+        assert any("JFZ" in line for line in lines)
+        assert not any("JTZ" in line for line in lines)
+
+    def test_missing_operands(self) -> None:
+        """BRANCH_NZ with missing operands emits a comment."""
+        lines = _gen_lines(_instr(IrOp.BRANCH_NZ))
+        assert len(lines) == 1
+        assert "BRANCH_NZ" in lines[0]
+
+
+# ===========================================================================
+# 20. TestEmitJump
+# ===========================================================================
+
+
+class TestEmitJump:
+    """JUMP emits JMP label (unconditional branch)."""
+
+    def test_basic_jump(self) -> None:
+        """JUMP loop_start → JMP loop_start."""
+        lines = _gen_lines(_instr(IrOp.JUMP, _lbl("loop_start")))
+        assert lines == [f"{_INDENT}JMP  loop_start"]
+
+    def test_one_line(self) -> None:
+        """JUMP always emits exactly 1 line."""
+        lines = _gen_lines(_instr(IrOp.JUMP, _lbl("somewhere")))
+        assert len(lines) == 1
+
+    def test_mnemonic_is_jmp(self) -> None:
+        """The 8008 unconditional branch is JMP (not JUMP or JA)."""
+        lines = _gen_lines(_instr(IrOp.JUMP, _lbl("x")))
+        assert lines[0].startswith(f"{_INDENT}JMP  ")
+
+    def test_missing_operand(self) -> None:
+        """JUMP with no label operand emits a comment."""
+        lines = _gen_lines(_instr(IrOp.JUMP))
+        assert len(lines) == 1
+        assert "JUMP" in lines[0]
+
+
+# ===========================================================================
+# 21. TestEmitCall
+# ===========================================================================
+
+
+class TestEmitCall:
+    """CALL emits CAL label (subroutine call)."""
+
+    def test_basic_call(self) -> None:
+        """CALL _fn_main → CAL _fn_main."""
+        lines = _gen_lines(_instr(IrOp.CALL, _lbl("_fn_main")))
+        assert lines == [f"{_INDENT}CAL  _fn_main"]
+
+    def test_one_line(self) -> None:
+        """CALL always emits exactly 1 line."""
+        lines = _gen_lines(_instr(IrOp.CALL, _lbl("sub")))
+        assert len(lines) == 1
+
+    def test_mnemonic_is_cal(self) -> None:
+        """The 8008 subroutine call is CAL (not CALL or JSR)."""
+        lines = _gen_lines(_instr(IrOp.CALL, _lbl("f")))
+        assert lines[0].startswith(f"{_INDENT}CAL  ")
+
+    def test_missing_operand(self) -> None:
+        """CALL with no label operand emits a comment."""
+        lines = _gen_lines(_instr(IrOp.CALL))
+        assert len(lines) == 1
+        assert "CALL" in lines[0]
+
+
+# ===========================================================================
+# 22. TestEmitRet
+# ===========================================================================
+
+
+class TestEmitRet:
+    """RET emits MOV A, C; RFC (copy return value, then return)."""
+
+    def test_exact_sequence(self) -> None:
+        """RET → MOV A, C; RFC."""
+        lines = _gen_lines(_instr(IrOp.RET))
+        assert lines == [
+            f"{_INDENT}MOV  A, C",
+            f"{_INDENT}RFC",
+        ]
+
+    def test_two_lines(self) -> None:
+        """RET always emits exactly 2 lines."""
+        lines = _gen_lines(_instr(IrOp.RET))
+        assert len(lines) == 2
+
+    def test_return_value_register_is_c(self) -> None:
+        """The return value register is C (v1), per the Oct calling convention."""
+        lines = _gen_lines(_instr(IrOp.RET))
+        assert lines[0] == f"{_INDENT}MOV  A, C"
+
+    def test_rfc_is_unconditional_return(self) -> None:
+        """RFC (Return if Carry False) is the standard unconditional return."""
+        lines = _gen_lines(_instr(IrOp.RET))
+        assert lines[1] == f"{_INDENT}RFC"
+
+
+# ===========================================================================
+# 23. TestEmitHalt
+# ===========================================================================
+
+
+class TestEmitHalt:
+    """HALT emits HLT (halt the processor)."""
+
+    def test_exact_instruction(self) -> None:
+        """HALT → HLT."""
+        lines = _gen_lines(_instr(IrOp.HALT))
+        assert lines == [f"{_INDENT}HLT"]
+
+    def test_one_line(self) -> None:
+        """HALT always emits exactly 1 line."""
+        lines = _gen_lines(_instr(IrOp.HALT))
+        assert len(lines) == 1
+
+
+# ===========================================================================
+# 24. TestEmitNop
+# ===========================================================================
+
+
+class TestEmitNop:
+    """NOP emits a comment (8008 has no dedicated NOP instruction)."""
+
+    def test_emits_comment(self) -> None:
+        """NOP produces a comment line, not a real instruction."""
+        lines = _gen_lines(_instr(IrOp.NOP))
+        assert len(lines) == 1
+        assert lines[0].startswith(f"{_INDENT};")
+
+    def test_mentions_nop(self) -> None:
+        """The NOP comment mentions 'NOP' so it's identifiable in disassembly."""
+        lines = _gen_lines(_instr(IrOp.NOP))
+        assert "NOP" in lines[0]
+
+
+# ===========================================================================
+# 25. TestEmitComment
+# ===========================================================================
+
+
+class TestEmitComment:
+    """COMMENT emits a semicolon comment line."""
+
+    def test_comment_with_label_operand(self) -> None:
+        """COMMENT with an IrLabel operand emits '; name'."""
+        lines = _gen_lines(_instr(IrOp.COMMENT, _lbl("load tape")))
+        assert lines == [f"{_INDENT}; load tape"]
+
+    def test_comment_with_immediate_operand(self) -> None:
+        """COMMENT with an IrImmediate operand emits '; value'."""
+        lines = _gen_lines(_instr(IrOp.COMMENT, _imm(42)))
+        assert lines == [f"{_INDENT}; 42"]
+
+    def test_empty_comment(self) -> None:
+        """COMMENT with no operands emits a bare semicolon line."""
+        lines = _gen_lines(_instr(IrOp.COMMENT))
+        assert lines == [f"{_INDENT};"]
+
+    def test_starts_with_semicolon(self) -> None:
+        """Every COMMENT line starts with '; '."""
+        lines = _gen_lines(_instr(IrOp.COMMENT, _lbl("test")))
+        assert lines[0].startswith(f"{_INDENT}; ")
+
+
+# ===========================================================================
+# 26. TestEmitSyscall
+# ===========================================================================
+
+
+class TestEmitSyscall:
+    """SYSCALL expands to the appropriate 8008 inline sequence."""
+
+    def test_syscall_3_adc(self) -> None:
+        """SYSCALL 3 (adc): MOV A, D; ADC E; MOV C, A."""
+        lines = _gen_lines(_instr(IrOp.SYSCALL, _imm(3)))
+        assert lines == [
+            f"{_INDENT}MOV  A, D",
+            f"{_INDENT}ADC  E",
+            f"{_INDENT}MOV  C, A",
+        ]
+
+    def test_syscall_4_sbb(self) -> None:
+        """SYSCALL 4 (sbb): MOV A, D; SBB E; MOV C, A."""
+        lines = _gen_lines(_instr(IrOp.SYSCALL, _imm(4)))
+        assert lines == [
+            f"{_INDENT}MOV  A, D",
+            f"{_INDENT}SBB  E",
+            f"{_INDENT}MOV  C, A",
+        ]
+
+    def test_syscall_11_rlc(self) -> None:
+        """SYSCALL 11 (rlc): MOV A, D; RLC; MOV C, A."""
+        lines = _gen_lines(_instr(IrOp.SYSCALL, _imm(11)))
+        assert lines == [
+            f"{_INDENT}MOV  A, D",
+            f"{_INDENT}RLC",
+            f"{_INDENT}MOV  C, A",
+        ]
+
+    def test_syscall_12_rrc(self) -> None:
+        """SYSCALL 12 (rrc): MOV A, D; RRC; MOV C, A."""
+        lines = _gen_lines(_instr(IrOp.SYSCALL, _imm(12)))
+        assert f"{_INDENT}RRC" in lines
+
+    def test_syscall_13_ral(self) -> None:
+        """SYSCALL 13 (ral): MOV A, D; RAL; MOV C, A."""
+        lines = _gen_lines(_instr(IrOp.SYSCALL, _imm(13)))
+        assert f"{_INDENT}RAL" in lines
+
+    def test_syscall_14_rar(self) -> None:
+        """SYSCALL 14 (rar): MOV A, D; RAR; MOV C, A."""
+        lines = _gen_lines(_instr(IrOp.SYSCALL, _imm(14)))
+        assert f"{_INDENT}RAR" in lines
+
+    def test_syscall_15_carry(self) -> None:
+        """SYSCALL 15 (carry): MVI A, 0; ACI 0; MOV C, A."""
+        lines = _gen_lines(_instr(IrOp.SYSCALL, _imm(15)))
+        assert lines == [
+            f"{_INDENT}MVI  A, 0",
+            f"{_INDENT}ACI  0",
+            f"{_INDENT}MOV  C, A",
+        ]
+
+    def test_syscall_16_parity(self) -> None:
+        """SYSCALL 16 (parity): ORA A + conditional branch sequence."""
+        lines = _gen_lines(_instr(IrOp.SYSCALL, _imm(16)))
+        assert lines[0] == f"{_INDENT}MOV  A, D"
+        assert lines[1] == f"{_INDENT}ORA  A"
+        assert lines[2] == f"{_INDENT}MVI  C, 0"
+        assert "JFP" in lines[3]  # Jump if Parity False (odd parity → skip)
+        assert lines[4] == f"{_INDENT}MVI  C, 1"
+
+    def test_syscall_parity_six_lines(self) -> None:
+        """SYSCALL 16 (parity) emits exactly 6 lines."""
+        lines = _gen_lines(_instr(IrOp.SYSCALL, _imm(16)))
+        assert len(lines) == 6
+
+    def test_syscall_parity_label_matches(self) -> None:
+        """JFP target in parity sequence matches the trailing label definition."""
+        lines = _gen_lines(_instr(IrOp.SYSCALL, _imm(16)))
+        jfp_line = next(line for line in lines if "JFP" in line)
+        label_name = jfp_line.split("JFP  ")[1].strip()
+        assert f"{label_name}:" in lines
+
+    @pytest.mark.parametrize("port", range(8))
+    def test_syscall_in_ports(self, port: int) -> None:
+        """SYSCALL 20+p (in): IN p; MOV C, A — for each port 0–7."""
+        lines = _gen_lines(_instr(IrOp.SYSCALL, _imm(20 + port)))
+        assert lines == [
+            f"{_INDENT}IN   {port}",
+            f"{_INDENT}MOV  C, A",
+        ]
+
+    @pytest.mark.parametrize("port", range(24))
+    def test_syscall_out_ports(self, port: int) -> None:
+        """SYSCALL 40+p (out): MOV A, D; OUT p — for each port 0–23."""
+        lines = _gen_lines(_instr(IrOp.SYSCALL, _imm(40 + port)))
+        assert lines == [
+            f"{_INDENT}MOV  A, D",
+            f"{_INDENT}OUT  {port}",
+        ]
+
+    def test_syscall_unknown_number(self) -> None:
+        """Unrecognised SYSCALL number emits a comment (defensive)."""
+        lines = _gen_lines(_instr(IrOp.SYSCALL, _imm(99)))
+        assert len(lines) == 1
+        assert "SYSCALL" in lines[0]
+        assert "99" in lines[0]
+
+    def test_syscall_missing_operand(self) -> None:
+        """SYSCALL with no operand emits a comment."""
+        lines = _gen_lines(_instr(IrOp.SYSCALL))
+        assert len(lines) == 1
+        assert "SYSCALL" in lines[0]
+
+    def test_rotation_three_lines(self) -> None:
+        """All rotation SYSCALLs emit exactly 3 lines."""
+        for num in (11, 12, 13, 14):
+            lines = _gen_lines(_instr(IrOp.SYSCALL, _imm(num)))
+            assert len(lines) == 3, f"SYSCALL {num} emitted {len(lines)} lines"
+
+
+# ===========================================================================
+# 27. TestLabelCounter
+# ===========================================================================
+
+
+class TestLabelCounter:
+    """The label counter generates unique labels across all calls.
+
+    Labels like cmp_0, cmp_1, ... must not collide when multiple comparison
+    or parity instructions appear in the same program.
+    """
+
+    def test_counter_starts_at_zero(self) -> None:
+        """The first generated label uses suffix 0."""
+        gen = CodeGenerator()
+        assert gen._label_count == 0
+
+    def test_counter_increments_per_comparison(self) -> None:
+        """Each comparison instruction advances the counter by one."""
+        gen = CodeGenerator()
+        prog = _prog(
+            _instr(IrOp.CMP_EQ, _reg(1), _reg(2), _reg(3)),
+            _instr(IrOp.CMP_EQ, _reg(1), _reg(2), _reg(3)),
+        )
+        gen.generate(prog)
+        assert gen._label_count == 2
+
+    def test_no_label_collisions(self) -> None:
+        """Multiple comparison instructions produce distinct labels."""
+        prog = _prog(
+            _instr(IrOp.CMP_EQ, _reg(1), _reg(2), _reg(3)),
+            _instr(IrOp.CMP_NE, _reg(1), _reg(2), _reg(3)),
+            _instr(IrOp.CMP_LT, _reg(1), _reg(2), _reg(3)),
+            _instr(IrOp.CMP_GT, _reg(1), _reg(2), _reg(3)),
+        )
+        asm = CodeGenerator().generate(prog)
+        # Extract all label definitions (lines that end with ':' and no indent)
+        label_defs = [
+            ln.rstrip(":")
+            for ln in asm.splitlines()
+            if ln.endswith(":") and not ln.startswith(" ")
+        ]
+        # All label definitions must be unique
+        assert len(label_defs) == len(set(label_defs))
+
+    def test_parity_label_distinct_from_cmp_label(self) -> None:
+        """Parity syscall and comparison labels are distinct."""
+        prog = _prog(
+            _instr(IrOp.SYSCALL, _imm(16)),   # parity — uses _next_label()
+            _instr(IrOp.CMP_EQ, _reg(1), _reg(2), _reg(3)),
+        )
+        asm = CodeGenerator().generate(prog)
+        label_defs = [
+            ln.rstrip(":")
+            for ln in asm.splitlines()
+            if ln.endswith(":") and not ln.startswith(" ")
+        ]
+        assert len(label_defs) == len(set(label_defs))
+
+    def test_generator_stateful_across_generate_calls(self) -> None:
+        """Calling generate() twice on the same CodeGenerator object
+        increments the counter across calls (no reset between programs).
+        """
+        gen = CodeGenerator()
+        prog1 = _prog(_instr(IrOp.CMP_EQ, _reg(1), _reg(2), _reg(3)))
+        prog2 = _prog(_instr(IrOp.CMP_EQ, _reg(1), _reg(2), _reg(3)))
+        gen.generate(prog1)
+        gen.generate(prog2)
+        # Counter should be at 2 after two comparisons
+        assert gen._label_count == 2
+
+
+# ===========================================================================
+# 28. TestUnknownOpcode
+# ===========================================================================
+
+
+class TestUnknownOpcode:
+    """Unknown opcodes produce a safe comment fallback rather than crashing."""
+
+    def test_known_fallback(self) -> None:
+        """The catch-all case in _emit produces a comment with the opcode name."""
+        # We patch a known opcode's dispatch by directly calling _emit with
+        # a non-matching enum.  Because IrOp is an IntEnum we can construct
+        # a custom value that won't match any case.
+        gen = CodeGenerator()
+        # Use IrOp.LOAD_WORD (value=4) which is unsupported by the 8008 backend
+        fake_instr = IrInstruction(opcode=IrOp.LOAD_WORD, operands=[])
+        lines = gen._emit(fake_instr)
+        # Should be a comment mentioning the opcode
+        assert len(lines) == 1
+        assert lines[0].startswith(f"{_INDENT};")
+
+
+# ===========================================================================
+# 29. TestFullProgram
+# ===========================================================================
+
+
+class TestFullProgram:
+    """End-to-end tests with realistic multi-instruction programs."""
+
+    def test_halt_only_program(self) -> None:
+        """Minimal program: ORG + HLT."""
+        asm = _gen(_instr(IrOp.HALT))
+        assert f"{_INDENT}ORG 0x0000" in asm
+        assert f"{_INDENT}HLT" in asm
+
+    def test_load_and_return(self) -> None:
+        """Program that loads a constant and returns it."""
+        asm = _gen(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(42)),
+            _instr(IrOp.RET),
+        )
+        assert f"{_INDENT}MVI  C, 42" in asm
+        assert f"{_INDENT}MOV  A, C" in asm
+        assert f"{_INDENT}RFC" in asm
+
+    def test_function_call_sequence(self) -> None:
+        """Main + function call sequence."""
+        asm = _gen(
+            _instr(IrOp.LABEL, _lbl("_start")),
+            _instr(IrOp.CALL, _lbl("_fn_add")),
+            _instr(IrOp.HALT),
+            _instr(IrOp.LABEL, _lbl("_fn_add")),
+            _instr(IrOp.ADD, _reg(1), _reg(2), _reg(3)),
+            _instr(IrOp.RET),
+        )
+        assert "_start:" in asm
+        assert f"{_INDENT}CAL  _fn_add" in asm
+        assert f"{_INDENT}HLT" in asm
+        assert "_fn_add:" in asm
+        assert f"{_INDENT}RFC" in asm
+
+    def test_memory_access_sequence(self) -> None:
+        """LOAD_ADDR + LOAD_BYTE sequence for reading a static."""
+        asm = _gen(
+            _instr(IrOp.LOAD_ADDR, _reg(1), _lbl("tape")),
+            _instr(IrOp.LOAD_BYTE, _reg(1), _reg(1), _reg(0)),
+        )
+        assert f"{_INDENT}MVI  H, hi(tape)" in asm
+        assert f"{_INDENT}MVI  L, lo(tape)" in asm
+        assert f"{_INDENT}MOV  A, M" in asm
+        assert f"{_INDENT}MOV  C, A" in asm
+
+    def test_store_sequence(self) -> None:
+        """LOAD_ADDR + STORE_BYTE sequence for writing a static."""
+        asm = _gen(
+            _instr(IrOp.LOAD_ADDR, _reg(1), _lbl("counter")),
+            _instr(IrOp.STORE_BYTE, _reg(2), _reg(1), _reg(0)),
+        )
+        assert f"{_INDENT}MVI  H, hi(counter)" in asm
+        assert f"{_INDENT}MVI  L, lo(counter)" in asm
+        assert f"{_INDENT}MOV  A, D" in asm
+        assert f"{_INDENT}MOV  M, A" in asm
+
+    def test_conditional_branch_loop(self) -> None:
+        """While-loop pattern: LABEL + BRANCH_Z + body + JUMP."""
+        asm = _gen(
+            _instr(IrOp.LABEL, _lbl("loop_top")),
+            _instr(IrOp.BRANCH_Z, _reg(1), _lbl("loop_end")),
+            _instr(IrOp.ADD_IMM, _reg(1), _reg(1), _imm(255)),  # decrement
+            _instr(IrOp.JUMP, _lbl("loop_top")),
+            _instr(IrOp.LABEL, _lbl("loop_end")),
+        )
+        assert "loop_top:" in asm
+        assert f"{_INDENT}JTZ  loop_end" in asm
+        assert f"{_INDENT}JMP  loop_top" in asm
+        assert "loop_end:" in asm
+
+    def test_syscall_in_out_sequence(self) -> None:
+        """Read from port 0, write to port 0 sequence."""
+        asm = _gen(
+            _instr(IrOp.SYSCALL, _imm(20)),   # in(0) → C
+            _instr(IrOp.ADD_IMM, _reg(2), _reg(1), _imm(0)),  # copy C → D
+            _instr(IrOp.SYSCALL, _imm(40)),   # out(0, D)
+        )
+        assert f"{_INDENT}IN   0" in asm
+        assert f"{_INDENT}MOV  C, A" in asm
+        assert f"{_INDENT}OUT  0" in asm
+
+    def test_instruction_ordering_preserved(self) -> None:
+        """Instructions appear in the program order in the output."""
+        asm = _gen(
+            _instr(IrOp.LOAD_IMM, _reg(1), _imm(1)),
+            _instr(IrOp.LOAD_IMM, _reg(2), _imm(2)),
+            _instr(IrOp.LOAD_IMM, _reg(3), _imm(3)),
+        )
+        idx_c = asm.index("MVI  C, 1")
+        idx_d = asm.index("MVI  D, 2")
+        idx_e = asm.index("MVI  E, 3")
+        assert idx_c < idx_d < idx_e
+
+    def test_arithmetic_chain(self) -> None:
+        """a + b - c using ADD and SUB."""
+        asm = _gen(
+            _instr(IrOp.LOAD_IMM, _reg(2), _imm(10)),
+            _instr(IrOp.LOAD_IMM, _reg(3), _imm(5)),
+            _instr(IrOp.ADD, _reg(1), _reg(2), _reg(3)),   # v1 = 10+5=15
+            _instr(IrOp.LOAD_IMM, _reg(3), _imm(3)),
+            _instr(IrOp.SUB, _reg(1), _reg(1), _reg(3)),   # v1 = 15-3=12
+            _instr(IrOp.RET),
+        )
+        assert f"{_INDENT}ADD  E" in asm
+        assert f"{_INDENT}SUB  E" in asm
+
+    def test_bitwise_operations(self) -> None:
+        """AND, OR, XOR, NOT all appear in the correct sequence."""
+        asm = _gen(
+            _instr(IrOp.AND, _reg(1), _reg(2), _reg(3)),
+            _instr(IrOp.OR, _reg(1), _reg(2), _reg(3)),
+            _instr(IrOp.XOR, _reg(1), _reg(2), _reg(3)),
+            _instr(IrOp.NOT, _reg(1), _reg(2)),
+        )
+        assert "ANA  E" in asm
+        assert "ORA  E" in asm
+        assert "XRA  E" in asm
+        assert "XRI  0xFF" in asm
+
+
+# ===========================================================================
+# 30. TestIrToIntel8008Compiler
+# ===========================================================================
+
+
+class TestIrToIntel8008Compiler:
+    """IrToIntel8008Compiler orchestrates validation then code generation."""
+
+    def _make_valid_prog(self) -> IrProgram:
+        """Build a simple valid program that passes all 8008 constraints."""
+        prog = IrProgram(entry_label="_start", version=1)
+        prog.add_instruction(
+            IrInstruction(IrOp.LOAD_IMM, [IrRegister(1), IrImmediate(42)])
+        )
+        prog.add_instruction(IrInstruction(IrOp.HALT, []))
+        return prog
+
+    def test_compile_valid_program(self) -> None:
+        """compile() returns assembly text for a valid program."""
+        compiler = IrToIntel8008Compiler()
+        asm = compiler.compile(self._make_valid_prog())
+        assert isinstance(asm, str)
+        assert "ORG 0x0000" in asm
+        assert "MVI  C, 42" in asm
+
+    def test_compile_raises_on_invalid(self) -> None:
+        """compile() raises IrValidationError for programs that fail validation."""
+        prog = IrProgram(entry_label="_start", version=1)
+        # LOAD_WORD is rejected by the validator (no word ops on 8008)
+        prog.add_instruction(IrInstruction(IrOp.LOAD_WORD, []))
+        compiler = IrToIntel8008Compiler()
+        with pytest.raises(IrValidationError):
+            compiler.compile(prog)
+
+    def test_compile_error_message_contains_rule(self) -> None:
+        """IrValidationError includes the violated rule name."""
+        prog = IrProgram(entry_label="_start", version=1)
+        prog.add_instruction(IrInstruction(IrOp.LOAD_WORD, []))
+        compiler = IrToIntel8008Compiler()
+        with pytest.raises(IrValidationError) as exc_info:
+            compiler.compile(prog)
+        assert exc_info.value.rule  # rule must not be empty
+
+    def test_compile_multiple_errors_combined(self) -> None:
+        """When multiple rules fail, errors are concatenated in the message."""
+        prog = IrProgram(entry_label="_start", version=1)
+        # LOAD_WORD (no_word_ops) + STORE_WORD (no_word_ops) — possibly 1 rule
+        # Let's use LOAD_WORD and also add too many virtual registers
+        prog.add_instruction(IrInstruction(IrOp.LOAD_WORD, []))
+        # Add 7 distinct virtual registers (v0–v6) to hit register_count
+        for i in range(7):
+            prog.add_instruction(
+                IrInstruction(IrOp.LOAD_IMM, [IrRegister(i), IrImmediate(0)])
+            )
+        compiler = IrToIntel8008Compiler()
+        with pytest.raises(IrValidationError) as exc_info:
+            compiler.compile(prog)
+        # The error is raised — message contains details
+        assert str(exc_info.value)
+
+    def test_intel8008_backend_alias(self) -> None:
+        """Intel8008Backend is an alias for IrToIntel8008Compiler."""
+        assert Intel8008Backend is IrToIntel8008Compiler
+
+    def test_compiler_has_validator_and_codegen(self) -> None:
+        """The compiler exposes validator and codegen attributes."""
+        compiler = IrToIntel8008Compiler()
+        assert hasattr(compiler, "validator")
+        assert hasattr(compiler, "codegen")
+
+    def test_compile_returns_string(self) -> None:
+        """compile() always returns a str (not bytes or None)."""
+        asm = IrToIntel8008Compiler().compile(self._make_valid_prog())
+        assert type(asm) is str
+
+    def test_compile_ends_with_newline(self) -> None:
+        """compile() output ends with a newline (POSIX convention)."""
+        asm = IrToIntel8008Compiler().compile(self._make_valid_prog())
+        assert asm.endswith("\n")
+
+    def test_multiple_compiles_from_same_instance(self) -> None:
+        """The same compiler can compile multiple programs sequentially."""
+        compiler = IrToIntel8008Compiler()
+        prog1 = self._make_valid_prog()
+        prog2 = self._make_valid_prog()
+        asm1 = compiler.compile(prog1)
+        asm2 = compiler.compile(prog2)
+        assert "ORG 0x0000" in asm1
+        assert "ORG 0x0000" in asm2
+
+
+# ===========================================================================
+# 31. TestPublicApi
+# ===========================================================================
+
+
+class TestPublicApi:
+    """Module-level validate() and generate_asm() convenience functions."""
+
+    def _valid_prog(self) -> IrProgram:
+        """Minimal valid program."""
+        prog = IrProgram(entry_label="_start", version=1)
+        prog.add_instruction(IrInstruction(IrOp.HALT, []))
+        return prog
+
+    def test_validate_valid_program(self) -> None:
+        """validate() returns an empty list for a valid program."""
+        errors = validate(self._valid_prog())
+        assert errors == []
+
+    def test_validate_invalid_program(self) -> None:
+        """validate() returns non-empty list for an invalid program."""
+        prog = IrProgram(entry_label="_start", version=1)
+        prog.add_instruction(IrInstruction(IrOp.LOAD_WORD, []))
+        errors = validate(prog)
+        assert len(errors) > 0
+
+    def test_generate_asm_valid_program(self) -> None:
+        """generate_asm() returns assembly text for a valid program."""
+        asm = generate_asm(self._valid_prog())
+        assert isinstance(asm, str)
+        assert "ORG 0x0000" in asm
+        assert "HLT" in asm
+
+    def test_generate_asm_does_not_validate(self) -> None:
+        """generate_asm() skips validation (may produce asm for invalid IR)."""
+        # A LOAD_WORD would fail validation but generate_asm skips it
+        prog = IrProgram(entry_label="_start", version=1)
+        prog.add_instruction(IrInstruction(IrOp.LOAD_WORD, []))
+        # Should not raise IrValidationError — fallback comment instead
+        asm = generate_asm(prog)
+        assert isinstance(asm, str)
+
+    def test_validate_returns_list_of_errors(self) -> None:
+        """validate() returns a list of IrValidationError objects."""
+        prog = IrProgram(entry_label="_start", version=1)
+        prog.add_instruction(IrInstruction(IrOp.LOAD_WORD, []))
+        errors = validate(prog)
+        assert all(isinstance(e, IrValidationError) for e in errors)
+
+    def test_generate_asm_ends_with_newline(self) -> None:
+        """generate_asm() output ends with a newline."""
+        asm = generate_asm(self._valid_prog())
+        assert asm.endswith("\n")
+
+
+# ===========================================================================
+# 32. TestRegisterMapping
+# ===========================================================================
+
+
+class TestRegisterMapping:
+    """Verify the complete virtual → physical register mapping."""
+
+    @pytest.mark.parametrize("vreg,expected_preg", [
+        (0, "B"),
+        (1, "C"),
+        (2, "D"),
+        (3, "E"),
+        (4, "H"),
+        (5, "L"),
+    ])
+    def test_vreg_mapping(self, vreg: int, expected_preg: str) -> None:
+        """Each virtual register maps to the documented physical register."""
+        lines = _gen_lines(_instr(IrOp.LOAD_IMM, _reg(vreg), _imm(0)))
+        assert f"MVI  {expected_preg}, 0" in lines[0]
+
+    def test_unknown_register_falls_back(self) -> None:
+        """Virtual registers beyond v5 fall back gracefully (no crash)."""
+        # v99 is not in the table; _preg() returns "B" as fallback
+        lines = _gen_lines(_instr(IrOp.LOAD_IMM, _reg(99), _imm(7)))
+        assert len(lines) == 1
+        assert "MVI  B, 7" in lines[0]


### PR DESCRIPTION
## Summary

- Adds `ir-to-intel-8008-compiler`, the tenth layer of the Oct pipeline, which lowers a validated `IrProgram` into Intel 8008 assembly text
- Implements `CodeGenerator` (all 24 IR opcodes), `IrToIntel8008Compiler` (validate+generate facade), and module-level `validate()`/`generate_asm()` helpers
- 197 tests, 96.31% coverage, ruff clean

## Key code-generation decisions

- **Register mapping**: v0→B, v1→C, v2→D, v3→E, v4→H, v5→L (A is implicit accumulator)
- **NOT**: `XRI 0xFF` (8008 has no dedicated NOT instruction)
- **CMP_GT**: operand-swap trick — `MOV A, Rb; CMP Ra` since Ra > Rb ⟺ Rb < Ra
- **Comparisons**: 6-instruction optimistic-load/conditional-branch with unique `cmp_N` labels
- **RET**: `MOV A, C; RFC` (copies return value from v1=C to A before returning)
- **ADD_IMM imm=0**: optimised to 2-instruction register copy (no ADI)
- **LOAD_ADDR**: ignores virtual-register destination, always sets H:L via `MVI H, hi(sym); MVI L, lo(sym)`
- **SYSCALL**: inlined as native 8008 instructions (ADC, SBB, rotations, IN/OUT, parity)

## Test plan

- [x] 197 pytest tests pass (all IR opcodes, all 10 SYSCALL intrinsics, edge cases, facade)
- [x] 96.31% coverage (> 95% target)
- [x] `ruff check` passes — no lint errors
- [x] Security review passed (no vulnerabilities found)
- [x] BUILD and BUILD_windows scripts verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)