### PR TITLE
feat(argon2-lua): add Argon2d/i/id Lua packages

### DIFF
--- a/code/packages/lua/argon2d/BUILD
+++ b/code/packages/lua/argon2d/BUILD
@@ -1,0 +1,1 @@
+cd tests && busted . --verbose --pattern=test_

--- a/code/packages/lua/argon2d/BUILD_windows
+++ b/code/packages/lua/argon2d/BUILD_windows
@@ -1,0 +1,1 @@
+cd tests && busted . --verbose --pattern=test_

--- a/code/packages/lua/argon2d/CHANGELOG.md
+++ b/code/packages/lua/argon2d/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog — coding-adventures-argon2d
+
+## 0.1.0 — 2026-04-20
+
+### Added
+- Initial pure-Lua implementation of Argon2d (RFC 9106).
+- `argon2d.argon2d(password, salt, t, m, p, T[, opts])` and
+  `argon2d.argon2d_hex(...)`.
+- Options: `key`, `associated_data`, `version`.
+- Implements Argon2 v1.3 (0x13) only.
+- RFC 9106 §5.1 gold-standard vector plus 18 parameter-edge tests
+  (19 total).

--- a/code/packages/lua/argon2d/README.md
+++ b/code/packages/lua/argon2d/README.md
@@ -1,0 +1,68 @@
+# coding-adventures-argon2d
+
+A pure-Lua, from-scratch implementation of **Argon2d** (RFC 9106) — the
+data-dependent member of the Argon2 family.
+
+## What is Argon2d?
+
+Argon2d picks the reference-block index from the first 64 bits of the
+previously computed block, making memory access patterns depend on the
+password. This maximises GPU/ASIC resistance but leaks a noisy side
+channel through memory-access timing. Pick this variant only when
+side-channel attacks are **not** in scope (e.g. proof-of-work). For
+password hashing, prefer [`argon2id`](../argon2id/).
+
+See the spec at [code/specs/KD03-argon2.md](../../../specs/KD03-argon2.md).
+
+## Usage
+
+```lua
+local argon2d = require("coding_adventures.argon2d")
+
+local tag = argon2d.argon2d("correct horse battery staple", "somesalt",
+                             3, 64, 1, 32)
+local hex = argon2d.argon2d_hex("password", "somesalt", 3, 64, 1, 32)
+```
+
+### Keyed / authenticated data
+
+```lua
+argon2d.argon2d(password, salt, 3, 64, 1, 32, {
+    key = server_secret,
+    associated_data = "user:alice",
+})
+```
+
+## API
+
+| Function | Returns |
+| -- | -- |
+| `argon2d(password, salt, t, m, p, T[, opts])` | `string` (`T` bytes) |
+| `argon2d_hex(password, salt, t, m, p, T[, opts])` | `string` (lowercase hex) |
+
+Parameters follow RFC 9106 §3.1: `t` = time cost (passes), `m` = memory
+in KiB, `p` = parallelism (lanes), `T` = tag length in bytes.
+
+## Security notes
+
+- **Trust boundary on `memory_cost` and `tag_length`.** RFC 9106 permits
+  both up to `2^32 - 1`, which translates to multi-TiB allocations.
+  If either value is caller-controlled from an untrusted source, clamp
+  it at the application layer.
+- **Verify in constant time.** When comparing a stored tag to a freshly
+  computed one, use a constant-time byte-compare (e.g. the classic
+  XOR-accumulate over both strings) rather than `==`.
+
+## Running the tests
+
+```bash
+cd code/packages/lua/argon2d
+cd tests && busted . --verbose --pattern=test_
+```
+
+Tests include the canonical RFC 9106 §5.1 gold-standard vector, plus 18
+parameter-edge tests (19 total).
+
+## Part of [coding-adventures](https://github.com/adhithyan15/coding-adventures)
+
+One of 30 Argon2 packages across 10 languages × 3 variants (d/i/id).

--- a/code/packages/lua/argon2d/coding-adventures-argon2d-0.1.0-1.rockspec
+++ b/code/packages/lua/argon2d/coding-adventures-argon2d-0.1.0-1.rockspec
@@ -1,0 +1,19 @@
+package = "coding-adventures-argon2d"
+version = "0.1.0-1"
+source = {
+    url = "git://github.com/adhithyan15/coding-adventures.git",
+}
+description = {
+    summary = "Pure Lua Argon2d (RFC 9106) -- data-dependent memory-hard KDF",
+    license = "MIT",
+}
+dependencies = {
+    "lua >= 5.3",
+    "coding-adventures-blake2b >= 0.1.0",
+}
+build = {
+    type = "builtin",
+    modules = {
+        ["coding_adventures.argon2d"] = "src/coding_adventures/argon2d/init.lua",
+    },
+}

--- a/code/packages/lua/argon2d/required_capabilities.json
+++ b/code/packages/lua/argon2d/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "lua/argon2d",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/lua/argon2d/src/coding_adventures/argon2d/init.lua
+++ b/code/packages/lua/argon2d/src/coding_adventures/argon2d/init.lua
@@ -1,0 +1,304 @@
+-- coding_adventures.argon2d -- Argon2d (RFC 9106) in pure Lua.
+--
+-- Argon2d is the DATA-DEPENDENT member of the Argon2 family: the index
+-- of the reference block for every new block is derived from the first
+-- 64 bits of the previously computed block.  That makes the memory-
+-- access pattern password-dependent, which maximises GPU/ASIC
+-- resistance but leaks a noisy side channel.  Pick Argon2d only when
+-- timing side-channel attacks are NOT in scope (e.g. proof-of-work).
+-- For password hashing, prefer Argon2id.
+--
+-- Reference: https://datatracker.ietf.org/doc/html/rfc9106
+-- See also: code/specs/KD03-argon2.md
+--
+-- LUA 5.3+ ARITHMETIC NOTES
+-- -------------------------
+-- Lua 5.3+ uses native 64-bit signed integers whose `+` / `-` / `*`
+-- all wrap modulo 2^64, and whose `&`, `|`, `~`, `<<`, `>>` are all
+-- 64-bit operations (`>>` is logical, not arithmetic).  Unlike Python
+-- or Ruby we do NOT need to mask every 64-bit intermediate with
+-- 0xFFFFFFFFFFFFFFFF -- the hardware already does it.  The only mask
+-- we keep is MASK32 for the "truncate to 32 bits" step inside G.
+
+local blake2b = require("coding_adventures.blake2b")
+
+local M = {}
+
+M.VERSION = "0.1.0"
+
+local MASK32 = 0xFFFFFFFF
+local BLOCK_SIZE = 1024
+local BLOCK_WORDS = 128
+local SYNC_POINTS = 4
+local ARGON2_VERSION = 0x13
+local TYPE_D = 0
+
+-- 64-bit right rotation.
+local function rotr64(x, n)
+    return ((x >> n) | (x << (64 - n)))
+end
+
+-- Argon2 G mixer (RFC 9106 §3.5): BLAKE2 G round plus a `2*trunc32(a)*trunc32(b)`
+-- cross-term that makes memory-hard attacks quadratic in input size.
+-- `v` is a 1-indexed table; a/b/c/d are 1-based indices.
+local function g_mix(v, a, b, c, d)
+    local va, vb, vc, vd = v[a], v[b], v[c], v[d]
+
+    va = va + vb + 2 * (va & MASK32) * (vb & MASK32)
+    vd = rotr64(vd ~ va, 32)
+    vc = vc + vd + 2 * (vc & MASK32) * (vd & MASK32)
+    vb = rotr64(vb ~ vc, 24)
+    va = va + vb + 2 * (va & MASK32) * (vb & MASK32)
+    vd = rotr64(vd ~ va, 16)
+    vc = vc + vd + 2 * (vc & MASK32) * (vd & MASK32)
+    vb = rotr64(vb ~ vc, 63)
+
+    v[a], v[b], v[c], v[d] = va, vb, vc, vd
+end
+
+-- Argon2 permutation P: eight G-rounds over a 16-word slab starting
+-- at `off+1` (1-indexed).
+local function permutation_p(v, off)
+    g_mix(v, off + 1, off + 5, off + 9,  off + 13)
+    g_mix(v, off + 2, off + 6, off + 10, off + 14)
+    g_mix(v, off + 3, off + 7, off + 11, off + 15)
+    g_mix(v, off + 4, off + 8, off + 12, off + 16)
+    g_mix(v, off + 1, off + 6, off + 11, off + 16)
+    g_mix(v, off + 2, off + 7, off + 12, off + 13)
+    g_mix(v, off + 3, off + 8, off + 9,  off + 14)
+    g_mix(v, off + 4, off + 5, off + 10, off + 15)
+end
+
+-- Compression G(X, Y): first a row pass, then a column pass, with an
+-- outer XOR feed-forward (the "Davies-Meyer flavour" that hardens G
+-- against inversion).  X and Y are BLOCK_WORDS-length tables of u64.
+local function compress(x, y)
+    local r = {}
+    for i = 1, BLOCK_WORDS do r[i] = x[i] ~ y[i] end
+    local q = {}
+    for i = 1, BLOCK_WORDS do q[i] = r[i] end
+
+    for i = 0, 7 do
+        permutation_p(q, i * 16)
+    end
+
+    local col = {}
+    for c = 0, 7 do
+        for rr = 0, 7 do
+            col[2 * rr + 1] = q[rr * 16 + 2 * c + 1]
+            col[2 * rr + 2] = q[rr * 16 + 2 * c + 2]
+        end
+        permutation_p(col, 0)
+        for rr = 0, 7 do
+            q[rr * 16 + 2 * c + 1] = col[2 * rr + 1]
+            q[rr * 16 + 2 * c + 2] = col[2 * rr + 2]
+        end
+    end
+
+    local out = {}
+    for i = 1, BLOCK_WORDS do out[i] = r[i] ~ q[i] end
+    return out
+end
+
+local function block_to_bytes(block)
+    local parts = {}
+    for i = 1, BLOCK_WORDS do
+        parts[i] = string.pack("<I8", block[i])
+    end
+    return table.concat(parts)
+end
+
+local function bytes_to_block(data)
+    local block = {}
+    for i = 1, BLOCK_WORDS do
+        block[i] = string.unpack("<I8", data, (i - 1) * 8 + 1)
+    end
+    return block
+end
+
+local function le32(n)
+    return string.pack("<I4", n)
+end
+
+-- H' -- variable-length BLAKE2b extender (RFC 9106 §3.3).
+-- Emits exactly `t` bytes.  For `t <= 64` it's a single BLAKE2b call
+-- with digest_size=t; otherwise it chains 32-byte halves of 64-byte
+-- BLAKE2b outputs, sizing the last call exactly.
+local function blake2b_long(t, x)
+    assert(t > 0, "H' output length must be positive")
+    local input = le32(t) .. x
+
+    if t <= 64 then
+        return blake2b.digest(input, {digest_size = t})
+    end
+
+    local r = (t + 31) // 32 - 2
+    local v = blake2b.digest(input, {digest_size = 64})
+    local parts = {string.sub(v, 1, 32)}
+    for _ = 1, r - 1 do
+        v = blake2b.digest(v, {digest_size = 64})
+        parts[#parts + 1] = string.sub(v, 1, 32)
+    end
+    local final_size = t - 32 * r
+    v = blake2b.digest(v, {digest_size = final_size})
+    parts[#parts + 1] = v
+    return table.concat(parts)
+end
+
+-- indexAlpha -- map J1 to a reference-block column (RFC 9106 §3.4.1.1).
+local function index_alpha(j1, r, sl, c, same_lane, q, sl_len)
+    local w, start
+    if r == 0 and sl == 0 then
+        w = c - 1
+        start = 0
+    elseif r == 0 then
+        if same_lane then
+            w = sl * sl_len + c - 1
+        elseif c == 0 then
+            w = sl * sl_len - 1
+        else
+            w = sl * sl_len
+        end
+        start = 0
+    else
+        if same_lane then
+            w = q - sl_len + c - 1
+        elseif c == 0 then
+            w = q - sl_len - 1
+        else
+            w = q - sl_len
+        end
+        start = ((sl + 1) * sl_len) % q
+    end
+
+    local x = (j1 * j1) >> 32
+    local y = (w * x) >> 32
+    local rel = w - 1 - y
+    return (start + rel) % q
+end
+
+-- Fill one (pass, slice, lane) segment -- Argon2d's data-dependent
+-- variant: J1/J2 come from the first word of the previously computed
+-- block.
+local function fill_segment(memory, r, lane, sl, q, sl_len, p)
+    local starting_c = 0
+    if r == 0 and sl == 0 then starting_c = 2 end
+
+    for i = starting_c, sl_len - 1 do
+        local col = sl * sl_len + i
+        local prev_col
+        if col == 0 then prev_col = q - 1 else prev_col = col - 1 end
+        local prev_block = memory[lane][prev_col]
+
+        local pseudo_rand = prev_block[1]
+        local j1 = pseudo_rand & MASK32
+        local j2 = (pseudo_rand >> 32) & MASK32
+
+        local l_prime = lane
+        if not (r == 0 and sl == 0) then
+            l_prime = j2 % p
+        end
+
+        local z_prime = index_alpha(j1, r, sl, i, l_prime == lane, q, sl_len)
+        local ref_block = memory[l_prime][z_prime]
+
+        local new_block = compress(prev_block, ref_block)
+        if r == 0 then
+            memory[lane][col] = new_block
+        else
+            local existing = memory[lane][col]
+            local xored = {}
+            for k = 1, BLOCK_WORDS do xored[k] = existing[k] ~ new_block[k] end
+            memory[lane][col] = xored
+        end
+    end
+end
+
+local function validate(password, salt, t, m, p, tag_length, key, ad, version)
+    assert(#password <= MASK32, "password length must fit in 32 bits")
+    assert(#salt >= 8, "salt must be at least 8 bytes")
+    assert(#salt <= MASK32, "salt length must fit in 32 bits")
+    assert(#key <= MASK32, "key length must fit in 32 bits")
+    assert(#ad <= MASK32, "associated_data length must fit in 32 bits")
+    assert(tag_length >= 4, "tag_length must be >= 4")
+    assert(tag_length <= MASK32, "tag_length must fit in 32 bits")
+    assert(type(p) == "number" and p == math.floor(p) and p >= 1 and p <= 0xFFFFFF,
+           "parallelism must be in [1, 2^24-1]")
+    assert(m >= 8 * p, "memory_cost must be >= 8*parallelism")
+    assert(m <= MASK32, "memory_cost must fit in 32 bits")
+    assert(t >= 1, "time_cost must be >= 1")
+    assert(version == ARGON2_VERSION, "only Argon2 v1.3 (0x13) is supported")
+end
+
+-- argon2d(password, salt, t, m, p, T[, opts]) -- compute Argon2d tag.
+--   password     (string)  secret input (bytes)
+--   salt         (string)  >= 8 bytes, 16+ recommended
+--   time_cost    (int)     passes (t), >= 1
+--   memory_cost  (int)     KiB (m), >= 8*parallelism
+--   parallelism  (int)     lanes (p), 1..2^24-1
+--   tag_length   (int)     output bytes (T), >= 4
+--   opts.key             optional MAC key (K), default ""
+--   opts.associated_data optional context data (X), default ""
+--   opts.version         only 0x13 supported
+-- Returns T-byte binary tag.
+function M.argon2d(password, salt, time_cost, memory_cost, parallelism, tag_length, opts)
+    opts = opts or {}
+    local key = opts.key or ""
+    local ad = opts.associated_data or ""
+    local version = opts.version or ARGON2_VERSION
+
+    validate(password, salt, time_cost, memory_cost, parallelism, tag_length, key, ad, version)
+
+    local p = parallelism
+    local t = time_cost
+    local segment_length = memory_cost // (SYNC_POINTS * p)
+    local m_prime = segment_length * SYNC_POINTS * p
+    local q = m_prime // p
+    local sl_len = segment_length
+
+    local h0_in = table.concat({
+        le32(p), le32(tag_length), le32(memory_cost), le32(t),
+        le32(version), le32(TYPE_D),
+        le32(#password), password,
+        le32(#salt), salt,
+        le32(#key), key,
+        le32(#ad), ad,
+    })
+    local h0 = blake2b.digest(h0_in, {digest_size = 64})
+
+    local memory = {}
+    for i = 0, p - 1 do
+        memory[i] = {}
+        local b0 = blake2b_long(BLOCK_SIZE, h0 .. le32(0) .. le32(i))
+        local b1 = blake2b_long(BLOCK_SIZE, h0 .. le32(1) .. le32(i))
+        memory[i][0] = bytes_to_block(b0)
+        memory[i][1] = bytes_to_block(b1)
+    end
+
+    for r = 0, t - 1 do
+        for sl = 0, SYNC_POINTS - 1 do
+            for lane = 0, p - 1 do
+                fill_segment(memory, r, lane, sl, q, sl_len, p)
+            end
+        end
+    end
+
+    local final_block = {}
+    for k = 1, BLOCK_WORDS do final_block[k] = memory[0][q - 1][k] end
+    for lane = 1, p - 1 do
+        local lb = memory[lane][q - 1]
+        for k = 1, BLOCK_WORDS do final_block[k] = final_block[k] ~ lb[k] end
+    end
+
+    return blake2b_long(tag_length, block_to_bytes(final_block))
+end
+
+-- argon2d_hex -- like argon2d() but returns lowercase hex.
+function M.argon2d_hex(password, salt, time_cost, memory_cost, parallelism, tag_length, opts)
+    local raw = M.argon2d(password, salt, time_cost, memory_cost, parallelism, tag_length, opts)
+    local parts = {}
+    for i = 1, #raw do parts[i] = string.format("%02x", string.byte(raw, i)) end
+    return table.concat(parts)
+end
+
+return M

--- a/code/packages/lua/argon2d/tests/test_argon2d.lua
+++ b/code/packages/lua/argon2d/tests/test_argon2d.lua
@@ -1,0 +1,129 @@
+-- Tests for pure-Lua Argon2d (RFC 9106).
+
+package.path = "../src/?.lua;../src/?/init.lua;"
+            .. "../../blake2b/src/?.lua;../../blake2b/src/?/init.lua;"
+            .. package.path
+
+local argon2d = require("coding_adventures.argon2d")
+
+local function rep_byte(n, byte)
+    return string.rep(string.char(byte), n)
+end
+
+local RFC_PW = rep_byte(32, 0x01)
+local RFC_SALT = rep_byte(16, 0x02)
+local RFC_KEY = rep_byte(8, 0x03)
+local RFC_AD = rep_byte(12, 0x04)
+local RFC_EXPECTED = "512b391b6f1162975371d30919734294f868e3be3984f3c1a13a4db9fabe4acb"
+
+describe("argon2d", function()
+    it("RFC 9106 §5.1 gold-standard vector", function()
+        local hex = argon2d.argon2d_hex(RFC_PW, RFC_SALT, 3, 32, 4, 32,
+            {key = RFC_KEY, associated_data = RFC_AD})
+        assert.equals(RFC_EXPECTED, hex)
+    end)
+
+    it("hex matches binary", function()
+        local tag = argon2d.argon2d(RFC_PW, RFC_SALT, 3, 32, 4, 32,
+            {key = RFC_KEY, associated_data = RFC_AD})
+        local parts = {}
+        for i = 1, #tag do parts[i] = string.format("%02x", string.byte(tag, i)) end
+        assert.equals(RFC_EXPECTED, table.concat(parts))
+    end)
+
+    it("rejects short salt", function()
+        assert.has_error(function()
+            argon2d.argon2d("pw", "short", 1, 8, 1, 32)
+        end)
+    end)
+
+    it("rejects zero time_cost", function()
+        assert.has_error(function()
+            argon2d.argon2d("pw", string.rep("a", 8), 0, 8, 1, 32)
+        end)
+    end)
+
+    it("rejects tag_length under 4", function()
+        assert.has_error(function()
+            argon2d.argon2d("pw", string.rep("a", 8), 1, 8, 1, 3)
+        end)
+    end)
+
+    it("rejects memory below floor", function()
+        assert.has_error(function()
+            argon2d.argon2d("pw", string.rep("a", 8), 1, 7, 1, 32)
+        end)
+    end)
+
+    it("rejects zero parallelism", function()
+        assert.has_error(function()
+            argon2d.argon2d("pw", string.rep("a", 8), 1, 8, 0, 32)
+        end)
+    end)
+
+    it("rejects unsupported version", function()
+        assert.has_error(function()
+            argon2d.argon2d("pw", string.rep("a", 8), 1, 8, 1, 32, {version = 0x10})
+        end)
+    end)
+
+    it("deterministic", function()
+        local a = argon2d.argon2d_hex("pw", string.rep("a", 8), 1, 8, 1, 32)
+        local b = argon2d.argon2d_hex("pw", string.rep("a", 8), 1, 8, 1, 32)
+        assert.equals(a, b)
+    end)
+
+    it("differs on password", function()
+        local a = argon2d.argon2d_hex("pw1", string.rep("a", 8), 1, 8, 1, 32)
+        local b = argon2d.argon2d_hex("pw2", string.rep("a", 8), 1, 8, 1, 32)
+        assert.not_equals(a, b)
+    end)
+
+    it("differs on salt", function()
+        local a = argon2d.argon2d_hex("pw", string.rep("a", 8), 1, 8, 1, 32)
+        local b = argon2d.argon2d_hex("pw", string.rep("b", 8), 1, 8, 1, 32)
+        assert.not_equals(a, b)
+    end)
+
+    it("key binds", function()
+        local a = argon2d.argon2d_hex("pw", string.rep("a", 8), 1, 8, 1, 32)
+        local b = argon2d.argon2d_hex("pw", string.rep("a", 8), 1, 8, 1, 32, {key = "k1"})
+        local c = argon2d.argon2d_hex("pw", string.rep("a", 8), 1, 8, 1, 32, {key = "k2"})
+        assert.not_equals(a, b)
+        assert.not_equals(b, c)
+    end)
+
+    it("associated_data binds", function()
+        local a = argon2d.argon2d_hex("pw", string.rep("a", 8), 1, 8, 1, 32)
+        local b = argon2d.argon2d_hex("pw", string.rep("a", 8), 1, 8, 1, 32, {associated_data = "x"})
+        local c = argon2d.argon2d_hex("pw", string.rep("a", 8), 1, 8, 1, 32, {associated_data = "y"})
+        assert.not_equals(a, b)
+        assert.not_equals(b, c)
+    end)
+
+    it("tag_length 4", function()
+        assert.equals(4, #argon2d.argon2d("pw", string.rep("a", 8), 1, 8, 1, 4))
+    end)
+
+    it("tag_length 16", function()
+        assert.equals(16, #argon2d.argon2d("pw", string.rep("a", 8), 1, 8, 1, 16))
+    end)
+
+    it("tag_length 65 crosses H' boundary", function()
+        assert.equals(65, #argon2d.argon2d("pw", string.rep("a", 8), 1, 8, 1, 65))
+    end)
+
+    it("tag_length 128", function()
+        assert.equals(128, #argon2d.argon2d("pw", string.rep("a", 8), 1, 8, 1, 128))
+    end)
+
+    it("multi-lane", function()
+        assert.equals(32, #argon2d.argon2d("pw", string.rep("a", 8), 1, 16, 2, 32))
+    end)
+
+    it("multi-pass", function()
+        local a = argon2d.argon2d_hex("pw", string.rep("a", 8), 1, 8, 1, 32)
+        local b = argon2d.argon2d_hex("pw", string.rep("a", 8), 2, 8, 1, 32)
+        assert.not_equals(a, b)
+    end)
+end)

--- a/code/packages/lua/argon2i/BUILD
+++ b/code/packages/lua/argon2i/BUILD
@@ -1,0 +1,1 @@
+cd tests && busted . --verbose --pattern=test_

--- a/code/packages/lua/argon2i/BUILD_windows
+++ b/code/packages/lua/argon2i/BUILD_windows
@@ -1,0 +1,1 @@
+cd tests && busted . --verbose --pattern=test_

--- a/code/packages/lua/argon2i/CHANGELOG.md
+++ b/code/packages/lua/argon2i/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog — coding-adventures-argon2i
+
+## 0.1.0 — 2026-04-20
+
+### Added
+- Initial pure-Lua implementation of Argon2i (RFC 9106).
+- `argon2i.argon2i(password, salt, t, m, p, T[, opts])` and
+  `argon2i.argon2i_hex(...)`.
+- Options: `key`, `associated_data`, `version`.
+- Implements Argon2 v1.3 (0x13) only.
+- RFC 9106 §5.2 gold-standard vector plus 18 parameter-edge tests
+  (19 total).

--- a/code/packages/lua/argon2i/README.md
+++ b/code/packages/lua/argon2i/README.md
@@ -1,0 +1,55 @@
+# coding-adventures-argon2i
+
+A pure-Lua, from-scratch implementation of **Argon2i** (RFC 9106) — the
+data-independent member of the Argon2 family.
+
+## What is Argon2i?
+
+Argon2i derives reference-block indices from a pseudo-random address
+stream that depends only on the parameters, not on the password. The
+memory access pattern is identical for every password, eliminating the
+timing side-channel that Argon2d leaks at the cost of some GPU/ASIC
+resistance. Pick this variant when strict side-channel protection
+matters; otherwise prefer [`argon2id`](../argon2id/).
+
+See the spec at [code/specs/KD03-argon2.md](../../../specs/KD03-argon2.md).
+
+## Usage
+
+```lua
+local argon2i = require("coding_adventures.argon2i")
+
+local tag = argon2i.argon2i("correct horse battery staple", "somesalt",
+                             3, 64, 1, 32)
+local hex = argon2i.argon2i_hex("password", "somesalt", 3, 64, 1, 32)
+```
+
+## API
+
+| Function | Returns |
+| -- | -- |
+| `argon2i(password, salt, t, m, p, T[, opts])` | `string` (`T` bytes) |
+| `argon2i_hex(password, salt, t, m, p, T[, opts])` | `string` (lowercase hex) |
+
+## Security notes
+
+- **Trust boundary on `memory_cost` and `tag_length`.** RFC 9106 permits
+  both up to `2^32 - 1`, which translates to multi-TiB allocations.
+  If either value is caller-controlled from an untrusted source, clamp
+  it at the application layer.
+- **Verify in constant time.** When comparing a stored tag to a freshly
+  computed one, use a constant-time byte-compare rather than `==`.
+
+## Running the tests
+
+```bash
+cd code/packages/lua/argon2i
+cd tests && busted . --verbose --pattern=test_
+```
+
+Tests include the canonical RFC 9106 §5.2 gold-standard vector, plus 18
+parameter-edge tests (19 total).
+
+## Part of [coding-adventures](https://github.com/adhithyan15/coding-adventures)
+
+One of 30 Argon2 packages across 10 languages × 3 variants (d/i/id).

--- a/code/packages/lua/argon2i/coding-adventures-argon2i-0.1.0-1.rockspec
+++ b/code/packages/lua/argon2i/coding-adventures-argon2i-0.1.0-1.rockspec
@@ -1,0 +1,19 @@
+package = "coding-adventures-argon2i"
+version = "0.1.0-1"
+source = {
+    url = "git://github.com/adhithyan15/coding-adventures.git",
+}
+description = {
+    summary = "Pure Lua Argon2i (RFC 9106) -- data-independent memory-hard KDF",
+    license = "MIT",
+}
+dependencies = {
+    "lua >= 5.3",
+    "coding-adventures-blake2b >= 0.1.0",
+}
+build = {
+    type = "builtin",
+    modules = {
+        ["coding_adventures.argon2i"] = "src/coding_adventures/argon2i/init.lua",
+    },
+}

--- a/code/packages/lua/argon2i/required_capabilities.json
+++ b/code/packages/lua/argon2i/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "lua/argon2i",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/lua/argon2i/src/coding_adventures/argon2i/init.lua
+++ b/code/packages/lua/argon2i/src/coding_adventures/argon2i/init.lua
@@ -1,0 +1,273 @@
+-- coding_adventures.argon2i -- Argon2i (RFC 9106) in pure Lua.
+--
+-- Argon2i is the DATA-INDEPENDENT member of the Argon2 family: the
+-- index of the reference block for every new block is derived from a
+-- pseudo-random address stream that depends only on the parameters,
+-- NOT on the password.  This makes the memory access pattern identical
+-- for every password, eliminating the timing side-channel that Argon2d
+-- leaks at the cost of some GPU/ASIC resistance.  Pick Argon2i when
+-- strict side-channel protection matters; otherwise prefer Argon2id.
+--
+-- Reference: https://datatracker.ietf.org/doc/html/rfc9106
+-- See also: code/specs/KD03-argon2.md
+
+local blake2b = require("coding_adventures.blake2b")
+
+local M = {}
+
+M.VERSION = "0.1.0"
+
+local MASK32 = 0xFFFFFFFF
+local BLOCK_SIZE = 1024
+local BLOCK_WORDS = 128
+local SYNC_POINTS = 4
+local ARGON2_VERSION = 0x13
+local TYPE_I = 1
+
+local function rotr64(x, n)
+    return ((x >> n) | (x << (64 - n)))
+end
+
+local function g_mix(v, a, b, c, d)
+    local va, vb, vc, vd = v[a], v[b], v[c], v[d]
+    va = va + vb + 2 * (va & MASK32) * (vb & MASK32)
+    vd = rotr64(vd ~ va, 32)
+    vc = vc + vd + 2 * (vc & MASK32) * (vd & MASK32)
+    vb = rotr64(vb ~ vc, 24)
+    va = va + vb + 2 * (va & MASK32) * (vb & MASK32)
+    vd = rotr64(vd ~ va, 16)
+    vc = vc + vd + 2 * (vc & MASK32) * (vd & MASK32)
+    vb = rotr64(vb ~ vc, 63)
+    v[a], v[b], v[c], v[d] = va, vb, vc, vd
+end
+
+local function permutation_p(v, off)
+    g_mix(v, off + 1, off + 5, off + 9,  off + 13)
+    g_mix(v, off + 2, off + 6, off + 10, off + 14)
+    g_mix(v, off + 3, off + 7, off + 11, off + 15)
+    g_mix(v, off + 4, off + 8, off + 12, off + 16)
+    g_mix(v, off + 1, off + 6, off + 11, off + 16)
+    g_mix(v, off + 2, off + 7, off + 12, off + 13)
+    g_mix(v, off + 3, off + 8, off + 9,  off + 14)
+    g_mix(v, off + 4, off + 5, off + 10, off + 15)
+end
+
+local function compress(x, y)
+    local r = {}
+    for i = 1, BLOCK_WORDS do r[i] = x[i] ~ y[i] end
+    local q = {}
+    for i = 1, BLOCK_WORDS do q[i] = r[i] end
+    for i = 0, 7 do permutation_p(q, i * 16) end
+    local col = {}
+    for c = 0, 7 do
+        for rr = 0, 7 do
+            col[2 * rr + 1] = q[rr * 16 + 2 * c + 1]
+            col[2 * rr + 2] = q[rr * 16 + 2 * c + 2]
+        end
+        permutation_p(col, 0)
+        for rr = 0, 7 do
+            q[rr * 16 + 2 * c + 1] = col[2 * rr + 1]
+            q[rr * 16 + 2 * c + 2] = col[2 * rr + 2]
+        end
+    end
+    local out = {}
+    for i = 1, BLOCK_WORDS do out[i] = r[i] ~ q[i] end
+    return out
+end
+
+local function block_to_bytes(block)
+    local parts = {}
+    for i = 1, BLOCK_WORDS do parts[i] = string.pack("<I8", block[i]) end
+    return table.concat(parts)
+end
+
+local function bytes_to_block(data)
+    local block = {}
+    for i = 1, BLOCK_WORDS do
+        block[i] = string.unpack("<I8", data, (i - 1) * 8 + 1)
+    end
+    return block
+end
+
+local function le32(n) return string.pack("<I4", n) end
+
+local function blake2b_long(t, x)
+    assert(t > 0, "H' output length must be positive")
+    local input = le32(t) .. x
+    if t <= 64 then
+        return blake2b.digest(input, {digest_size = t})
+    end
+    local r = (t + 31) // 32 - 2
+    local v = blake2b.digest(input, {digest_size = 64})
+    local parts = {string.sub(v, 1, 32)}
+    for _ = 1, r - 1 do
+        v = blake2b.digest(v, {digest_size = 64})
+        parts[#parts + 1] = string.sub(v, 1, 32)
+    end
+    local final_size = t - 32 * r
+    v = blake2b.digest(v, {digest_size = final_size})
+    parts[#parts + 1] = v
+    return table.concat(parts)
+end
+
+local function index_alpha(j1, r, sl, c, same_lane, q, sl_len)
+    local w, start
+    if r == 0 and sl == 0 then
+        w = c - 1
+        start = 0
+    elseif r == 0 then
+        if same_lane then w = sl * sl_len + c - 1
+        elseif c == 0 then w = sl * sl_len - 1
+        else w = sl * sl_len end
+        start = 0
+    else
+        if same_lane then w = q - sl_len + c - 1
+        elseif c == 0 then w = q - sl_len - 1
+        else w = q - sl_len end
+        start = ((sl + 1) * sl_len) % q
+    end
+    local x = (j1 * j1) >> 32
+    local y = (w * x) >> 32
+    local rel = w - 1 - y
+    return (start + rel) % q
+end
+
+-- Argon2i address-stream helper.  Each segment is fed a zero_block and
+-- an "input block" encoding (r, lane, sl, m_prime, t, TYPE_I, counter)
+-- at positions 1..7 of `input`.  Running
+--   compress(zero_block, compress(zero_block, input))
+-- gives 128 pseudo-random u64 words -- enough for one 128-entry batch
+-- of (J1, J2) pairs.  Before each batch we bump input[7] (the 1-indexed
+-- counter slot = position [6] in the 0-indexed RFC) and regenerate.
+local function new_zero_block()
+    local z = {}
+    for i = 1, BLOCK_WORDS do z[i] = 0 end
+    return z
+end
+
+local function regenerate_addresses(zero_block, input)
+    input[7] = input[7] + 1
+    local z = compress(zero_block, input)
+    return compress(zero_block, z)
+end
+
+local function fill_segment(memory, r, lane, sl, q, sl_len, p, m_prime, t_total)
+    local starting_c = 0
+    if r == 0 and sl == 0 then starting_c = 2 end
+
+    local zero_block = new_zero_block()
+    local input = {}
+    for i = 1, BLOCK_WORDS do input[i] = 0 end
+    input[1] = r
+    input[2] = lane
+    input[3] = sl
+    input[4] = m_prime
+    input[5] = t_total
+    input[6] = TYPE_I
+    -- input[7] is the counter; regenerate_addresses bumps it before use
+    local address_block = nil
+
+    for i = starting_c, sl_len - 1 do
+        local col = sl * sl_len + i
+        local prev_col
+        if col == 0 then prev_col = q - 1 else prev_col = col - 1 end
+        local prev_block = memory[lane][prev_col]
+
+        if i % BLOCK_WORDS == 0 then
+            address_block = regenerate_addresses(zero_block, input)
+        end
+        local pseudo_rand = address_block[i % BLOCK_WORDS + 1]
+        local j1 = pseudo_rand & MASK32
+        local j2 = (pseudo_rand >> 32) & MASK32
+
+        local l_prime = lane
+        if not (r == 0 and sl == 0) then l_prime = j2 % p end
+
+        local z_prime = index_alpha(j1, r, sl, i, l_prime == lane, q, sl_len)
+        local ref_block = memory[l_prime][z_prime]
+
+        local new_block = compress(prev_block, ref_block)
+        if r == 0 then
+            memory[lane][col] = new_block
+        else
+            local existing = memory[lane][col]
+            local xored = {}
+            for k = 1, BLOCK_WORDS do xored[k] = existing[k] ~ new_block[k] end
+            memory[lane][col] = xored
+        end
+    end
+end
+
+local function validate(password, salt, t, m, p, tag_length, key, ad, version)
+    assert(#password <= MASK32, "password length must fit in 32 bits")
+    assert(#salt >= 8, "salt must be at least 8 bytes")
+    assert(#salt <= MASK32, "salt length must fit in 32 bits")
+    assert(#key <= MASK32, "key length must fit in 32 bits")
+    assert(#ad <= MASK32, "associated_data length must fit in 32 bits")
+    assert(tag_length >= 4, "tag_length must be >= 4")
+    assert(tag_length <= MASK32, "tag_length must fit in 32 bits")
+    assert(type(p) == "number" and p == math.floor(p) and p >= 1 and p <= 0xFFFFFF,
+           "parallelism must be in [1, 2^24-1]")
+    assert(m >= 8 * p, "memory_cost must be >= 8*parallelism")
+    assert(m <= MASK32, "memory_cost must fit in 32 bits")
+    assert(t >= 1, "time_cost must be >= 1")
+    assert(version == ARGON2_VERSION, "only Argon2 v1.3 (0x13) is supported")
+end
+
+function M.argon2i(password, salt, time_cost, memory_cost, parallelism, tag_length, opts)
+    opts = opts or {}
+    local key = opts.key or ""
+    local ad = opts.associated_data or ""
+    local version = opts.version or ARGON2_VERSION
+    validate(password, salt, time_cost, memory_cost, parallelism, tag_length, key, ad, version)
+
+    local p = parallelism
+    local t = time_cost
+    local segment_length = memory_cost // (SYNC_POINTS * p)
+    local m_prime = segment_length * SYNC_POINTS * p
+    local q = m_prime // p
+    local sl_len = segment_length
+
+    local h0_in = table.concat({
+        le32(p), le32(tag_length), le32(memory_cost), le32(t),
+        le32(version), le32(TYPE_I),
+        le32(#password), password,
+        le32(#salt), salt,
+        le32(#key), key,
+        le32(#ad), ad,
+    })
+    local h0 = blake2b.digest(h0_in, {digest_size = 64})
+
+    local memory = {}
+    for i = 0, p - 1 do
+        memory[i] = {}
+        memory[i][0] = bytes_to_block(blake2b_long(BLOCK_SIZE, h0 .. le32(0) .. le32(i)))
+        memory[i][1] = bytes_to_block(blake2b_long(BLOCK_SIZE, h0 .. le32(1) .. le32(i)))
+    end
+
+    for r = 0, t - 1 do
+        for sl = 0, SYNC_POINTS - 1 do
+            for lane = 0, p - 1 do
+                fill_segment(memory, r, lane, sl, q, sl_len, p, m_prime, t)
+            end
+        end
+    end
+
+    local final_block = {}
+    for k = 1, BLOCK_WORDS do final_block[k] = memory[0][q - 1][k] end
+    for lane = 1, p - 1 do
+        local lb = memory[lane][q - 1]
+        for k = 1, BLOCK_WORDS do final_block[k] = final_block[k] ~ lb[k] end
+    end
+
+    return blake2b_long(tag_length, block_to_bytes(final_block))
+end
+
+function M.argon2i_hex(password, salt, time_cost, memory_cost, parallelism, tag_length, opts)
+    local raw = M.argon2i(password, salt, time_cost, memory_cost, parallelism, tag_length, opts)
+    local parts = {}
+    for i = 1, #raw do parts[i] = string.format("%02x", string.byte(raw, i)) end
+    return table.concat(parts)
+end
+
+return M

--- a/code/packages/lua/argon2i/tests/test_argon2i.lua
+++ b/code/packages/lua/argon2i/tests/test_argon2i.lua
@@ -1,0 +1,111 @@
+-- Tests for pure-Lua Argon2i (RFC 9106).
+
+package.path = "../src/?.lua;../src/?/init.lua;"
+            .. "../../blake2b/src/?.lua;../../blake2b/src/?/init.lua;"
+            .. package.path
+
+local argon2i = require("coding_adventures.argon2i")
+
+local function rep_byte(n, byte)
+    return string.rep(string.char(byte), n)
+end
+
+local RFC_PW = rep_byte(32, 0x01)
+local RFC_SALT = rep_byte(16, 0x02)
+local RFC_KEY = rep_byte(8, 0x03)
+local RFC_AD = rep_byte(12, 0x04)
+local RFC_EXPECTED = "c814d9d1dc7f37aa13f0d77f2494bda1c8de6b016dd388d29952a4c4672b6ce8"
+
+describe("argon2i", function()
+    it("RFC 9106 §5.2 gold-standard vector", function()
+        local hex = argon2i.argon2i_hex(RFC_PW, RFC_SALT, 3, 32, 4, 32,
+            {key = RFC_KEY, associated_data = RFC_AD})
+        assert.equals(RFC_EXPECTED, hex)
+    end)
+
+    it("hex matches binary", function()
+        local tag = argon2i.argon2i(RFC_PW, RFC_SALT, 3, 32, 4, 32,
+            {key = RFC_KEY, associated_data = RFC_AD})
+        local parts = {}
+        for i = 1, #tag do parts[i] = string.format("%02x", string.byte(tag, i)) end
+        assert.equals(RFC_EXPECTED, table.concat(parts))
+    end)
+
+    it("rejects short salt", function()
+        assert.has_error(function() argon2i.argon2i("pw", "short", 1, 8, 1, 32) end)
+    end)
+    it("rejects zero time_cost", function()
+        assert.has_error(function() argon2i.argon2i("pw", string.rep("a", 8), 0, 8, 1, 32) end)
+    end)
+    it("rejects tag_length under 4", function()
+        assert.has_error(function() argon2i.argon2i("pw", string.rep("a", 8), 1, 8, 1, 3) end)
+    end)
+    it("rejects memory below floor", function()
+        assert.has_error(function() argon2i.argon2i("pw", string.rep("a", 8), 1, 7, 1, 32) end)
+    end)
+    it("rejects zero parallelism", function()
+        assert.has_error(function() argon2i.argon2i("pw", string.rep("a", 8), 1, 8, 0, 32) end)
+    end)
+    it("rejects unsupported version", function()
+        assert.has_error(function()
+            argon2i.argon2i("pw", string.rep("a", 8), 1, 8, 1, 32, {version = 0x10})
+        end)
+    end)
+
+    it("deterministic", function()
+        local a = argon2i.argon2i_hex("pw", string.rep("a", 8), 1, 8, 1, 32)
+        local b = argon2i.argon2i_hex("pw", string.rep("a", 8), 1, 8, 1, 32)
+        assert.equals(a, b)
+    end)
+
+    it("differs on password", function()
+        local a = argon2i.argon2i_hex("pw1", string.rep("a", 8), 1, 8, 1, 32)
+        local b = argon2i.argon2i_hex("pw2", string.rep("a", 8), 1, 8, 1, 32)
+        assert.not_equals(a, b)
+    end)
+
+    it("differs on salt", function()
+        local a = argon2i.argon2i_hex("pw", string.rep("a", 8), 1, 8, 1, 32)
+        local b = argon2i.argon2i_hex("pw", string.rep("b", 8), 1, 8, 1, 32)
+        assert.not_equals(a, b)
+    end)
+
+    it("key binds", function()
+        local a = argon2i.argon2i_hex("pw", string.rep("a", 8), 1, 8, 1, 32)
+        local b = argon2i.argon2i_hex("pw", string.rep("a", 8), 1, 8, 1, 32, {key = "k1"})
+        local c = argon2i.argon2i_hex("pw", string.rep("a", 8), 1, 8, 1, 32, {key = "k2"})
+        assert.not_equals(a, b)
+        assert.not_equals(b, c)
+    end)
+
+    it("associated_data binds", function()
+        local a = argon2i.argon2i_hex("pw", string.rep("a", 8), 1, 8, 1, 32)
+        local b = argon2i.argon2i_hex("pw", string.rep("a", 8), 1, 8, 1, 32, {associated_data = "x"})
+        local c = argon2i.argon2i_hex("pw", string.rep("a", 8), 1, 8, 1, 32, {associated_data = "y"})
+        assert.not_equals(a, b)
+        assert.not_equals(b, c)
+    end)
+
+    it("tag_length 4", function()
+        assert.equals(4, #argon2i.argon2i("pw", string.rep("a", 8), 1, 8, 1, 4))
+    end)
+    it("tag_length 16", function()
+        assert.equals(16, #argon2i.argon2i("pw", string.rep("a", 8), 1, 8, 1, 16))
+    end)
+    it("tag_length 65 crosses H' boundary", function()
+        assert.equals(65, #argon2i.argon2i("pw", string.rep("a", 8), 1, 8, 1, 65))
+    end)
+    it("tag_length 128", function()
+        assert.equals(128, #argon2i.argon2i("pw", string.rep("a", 8), 1, 8, 1, 128))
+    end)
+
+    it("multi-lane", function()
+        assert.equals(32, #argon2i.argon2i("pw", string.rep("a", 8), 1, 16, 2, 32))
+    end)
+
+    it("multi-pass", function()
+        local a = argon2i.argon2i_hex("pw", string.rep("a", 8), 1, 8, 1, 32)
+        local b = argon2i.argon2i_hex("pw", string.rep("a", 8), 2, 8, 1, 32)
+        assert.not_equals(a, b)
+    end)
+end)

--- a/code/packages/lua/argon2id/BUILD
+++ b/code/packages/lua/argon2id/BUILD
@@ -1,0 +1,1 @@
+cd tests && busted . --verbose --pattern=test_

--- a/code/packages/lua/argon2id/BUILD_windows
+++ b/code/packages/lua/argon2id/BUILD_windows
@@ -1,0 +1,1 @@
+cd tests && busted . --verbose --pattern=test_

--- a/code/packages/lua/argon2id/CHANGELOG.md
+++ b/code/packages/lua/argon2id/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog — coding-adventures-argon2id
+
+## 0.1.0 — 2026-04-21
+
+### Added
+- Initial pure-Lua implementation of Argon2id (RFC 9106).
+- `argon2id.argon2id(password, salt, t, m, p, T[, opts])` and
+  `argon2id.argon2id_hex(...)`.
+- Options: `key`, `associated_data`, `version`.
+- Implements Argon2 v1.3 (0x13) only.
+- RFC 9106 §5.3 gold-standard vector plus 18 parameter-edge tests
+  (19 total).

--- a/code/packages/lua/argon2id/README.md
+++ b/code/packages/lua/argon2id/README.md
@@ -1,0 +1,68 @@
+# coding-adventures-argon2id
+
+A pure-Lua, from-scratch implementation of **Argon2id** (RFC 9106) —
+the RFC-recommended memory-hard password hashing function.
+
+## What is Argon2id?
+
+Argon2id is the "hybrid" member of the Argon2 family: the first half
+of the first pass uses side-channel-resistant **data-independent**
+addressing (Argon2i), and everything afterwards uses GPU/ASIC-resistant
+**data-dependent** addressing (Argon2d). Pick this variant unless you
+have a specific reason to prefer [`argon2d`](../argon2d/) (proof-of-work,
+no side-channel threat) or [`argon2i`](../argon2i/) (strict side-channel
+requirements).
+
+See the spec at [code/specs/KD03-argon2.md](../../../specs/KD03-argon2.md).
+
+## Usage
+
+```lua
+local argon2id = require("coding_adventures.argon2id")
+
+local tag = argon2id.argon2id("correct horse battery staple", "somesalt",
+                                3, 64, 1, 32)
+local hex = argon2id.argon2id_hex("password", "somesalt", 3, 64, 1, 32)
+```
+
+### Keyed / authenticated data
+
+```lua
+argon2id.argon2id(password, salt, 3, 64, 1, 32, {
+    key = server_secret,
+    associated_data = "user:alice",
+})
+```
+
+## API
+
+| Function | Returns |
+| -- | -- |
+| `argon2id(password, salt, t, m, p, T[, opts])` | `string` (`T` bytes) |
+| `argon2id_hex(password, salt, t, m, p, T[, opts])` | `string` (lowercase hex) |
+
+Parameters follow RFC 9106 §3.1: `t` = time cost (passes), `m` = memory
+in KiB, `p` = parallelism (lanes), `T` = tag length in bytes.
+
+## Security notes
+
+- **Trust boundary on `memory_cost` and `tag_length`.** RFC 9106 permits
+  both up to `2^32 - 1`, which translates to multi-TiB allocations. If
+  either value is caller-controlled from an untrusted source, clamp it
+  at the application layer.
+- **Verify in constant time.** When comparing a stored tag to a freshly
+  computed one, use a constant-time byte-compare rather than `==`.
+
+## Running the tests
+
+```bash
+cd code/packages/lua/argon2id
+cd tests && busted . --verbose --pattern=test_
+```
+
+Tests include the canonical RFC 9106 §5.3 gold-standard vector, plus 18
+parameter-edge tests (19 total).
+
+## Part of [coding-adventures](https://github.com/adhithyan15/coding-adventures)
+
+One of 30 Argon2 packages across 10 languages × 3 variants (d/i/id).

--- a/code/packages/lua/argon2id/coding-adventures-argon2id-0.1.0-1.rockspec
+++ b/code/packages/lua/argon2id/coding-adventures-argon2id-0.1.0-1.rockspec
@@ -1,0 +1,19 @@
+package = "coding-adventures-argon2id"
+version = "0.1.0-1"
+source = {
+    url = "git://github.com/adhithyan15/coding-adventures.git",
+}
+description = {
+    summary = "Pure Lua Argon2id (RFC 9106) -- hybrid memory-hard KDF (recommended)",
+    license = "MIT",
+}
+dependencies = {
+    "lua >= 5.3",
+    "coding-adventures-blake2b >= 0.1.0",
+}
+build = {
+    type = "builtin",
+    modules = {
+        ["coding_adventures.argon2id"] = "src/coding_adventures/argon2id/init.lua",
+    },
+}

--- a/code/packages/lua/argon2id/required_capabilities.json
+++ b/code/packages/lua/argon2id/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "lua/argon2id",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/lua/argon2id/src/coding_adventures/argon2id/init.lua
+++ b/code/packages/lua/argon2id/src/coding_adventures/argon2id/init.lua
@@ -1,0 +1,277 @@
+-- coding_adventures.argon2id -- Argon2id (RFC 9106) in pure Lua.
+--
+-- Argon2id is the HYBRID member of the Argon2 family: the first half
+-- of the first pass uses Argon2i's data-independent addressing (for
+-- side-channel resistance during the most attack-vulnerable window),
+-- and everything afterwards uses Argon2d's data-dependent addressing
+-- (for maximum GPU/ASIC resistance).  Pick this variant unless you
+-- have a specific reason to prefer argon2d (proof-of-work, no
+-- side-channel threat) or argon2i (strict side-channel requirements).
+--
+-- Reference: https://datatracker.ietf.org/doc/html/rfc9106
+-- See also: code/specs/KD03-argon2.md
+
+local blake2b = require("coding_adventures.blake2b")
+
+local M = {}
+
+M.VERSION = "0.1.0"
+
+local MASK32 = 0xFFFFFFFF
+local BLOCK_SIZE = 1024
+local BLOCK_WORDS = 128
+local SYNC_POINTS = 4
+local ARGON2_VERSION = 0x13
+local TYPE_ID = 2
+
+local function rotr64(x, n)
+    return ((x >> n) | (x << (64 - n)))
+end
+
+local function g_mix(v, a, b, c, d)
+    local va, vb, vc, vd = v[a], v[b], v[c], v[d]
+    va = va + vb + 2 * (va & MASK32) * (vb & MASK32)
+    vd = rotr64(vd ~ va, 32)
+    vc = vc + vd + 2 * (vc & MASK32) * (vd & MASK32)
+    vb = rotr64(vb ~ vc, 24)
+    va = va + vb + 2 * (va & MASK32) * (vb & MASK32)
+    vd = rotr64(vd ~ va, 16)
+    vc = vc + vd + 2 * (vc & MASK32) * (vd & MASK32)
+    vb = rotr64(vb ~ vc, 63)
+    v[a], v[b], v[c], v[d] = va, vb, vc, vd
+end
+
+local function permutation_p(v, off)
+    g_mix(v, off + 1, off + 5, off + 9,  off + 13)
+    g_mix(v, off + 2, off + 6, off + 10, off + 14)
+    g_mix(v, off + 3, off + 7, off + 11, off + 15)
+    g_mix(v, off + 4, off + 8, off + 12, off + 16)
+    g_mix(v, off + 1, off + 6, off + 11, off + 16)
+    g_mix(v, off + 2, off + 7, off + 12, off + 13)
+    g_mix(v, off + 3, off + 8, off + 9,  off + 14)
+    g_mix(v, off + 4, off + 5, off + 10, off + 15)
+end
+
+local function compress(x, y)
+    local r = {}
+    for i = 1, BLOCK_WORDS do r[i] = x[i] ~ y[i] end
+    local q = {}
+    for i = 1, BLOCK_WORDS do q[i] = r[i] end
+    for i = 0, 7 do permutation_p(q, i * 16) end
+    local col = {}
+    for c = 0, 7 do
+        for rr = 0, 7 do
+            col[2 * rr + 1] = q[rr * 16 + 2 * c + 1]
+            col[2 * rr + 2] = q[rr * 16 + 2 * c + 2]
+        end
+        permutation_p(col, 0)
+        for rr = 0, 7 do
+            q[rr * 16 + 2 * c + 1] = col[2 * rr + 1]
+            q[rr * 16 + 2 * c + 2] = col[2 * rr + 2]
+        end
+    end
+    local out = {}
+    for i = 1, BLOCK_WORDS do out[i] = r[i] ~ q[i] end
+    return out
+end
+
+local function block_to_bytes(block)
+    local parts = {}
+    for i = 1, BLOCK_WORDS do parts[i] = string.pack("<I8", block[i]) end
+    return table.concat(parts)
+end
+
+local function bytes_to_block(data)
+    local block = {}
+    for i = 1, BLOCK_WORDS do
+        block[i] = string.unpack("<I8", data, (i - 1) * 8 + 1)
+    end
+    return block
+end
+
+local function le32(n) return string.pack("<I4", n) end
+
+local function blake2b_long(t, x)
+    assert(t > 0, "H' output length must be positive")
+    local input = le32(t) .. x
+    if t <= 64 then
+        return blake2b.digest(input, {digest_size = t})
+    end
+    local r = (t + 31) // 32 - 2
+    local v = blake2b.digest(input, {digest_size = 64})
+    local parts = {string.sub(v, 1, 32)}
+    for _ = 1, r - 1 do
+        v = blake2b.digest(v, {digest_size = 64})
+        parts[#parts + 1] = string.sub(v, 1, 32)
+    end
+    local final_size = t - 32 * r
+    v = blake2b.digest(v, {digest_size = final_size})
+    parts[#parts + 1] = v
+    return table.concat(parts)
+end
+
+local function index_alpha(j1, r, sl, c, same_lane, q, sl_len)
+    local w, start
+    if r == 0 and sl == 0 then
+        w = c - 1
+        start = 0
+    elseif r == 0 then
+        if same_lane then w = sl * sl_len + c - 1
+        elseif c == 0 then w = sl * sl_len - 1
+        else w = sl * sl_len end
+        start = 0
+    else
+        if same_lane then w = q - sl_len + c - 1
+        elseif c == 0 then w = q - sl_len - 1
+        else w = q - sl_len end
+        start = ((sl + 1) * sl_len) % q
+    end
+    local x = (j1 * j1) >> 32
+    local y = (w * x) >> 32
+    local rel = w - 1 - y
+    return (start + rel) % q
+end
+
+local function new_zero_block()
+    local z = {}
+    for i = 1, BLOCK_WORDS do z[i] = 0 end
+    return z
+end
+
+local function regenerate_addresses(zero_block, input)
+    input[7] = input[7] + 1
+    local z = compress(zero_block, input)
+    return compress(zero_block, z)
+end
+
+-- Argon2id switch: within the first pass AND the first two slices
+-- (r == 0, sl < 2) addressing is data-INdependent (like Argon2i);
+-- everywhere else it's data-dependent (like Argon2d).
+local function fill_segment(memory, r, lane, sl, q, sl_len, p, m_prime, t_total)
+    local data_independent = (r == 0 and sl < 2)
+    local starting_c = 0
+    if r == 0 and sl == 0 then starting_c = 2 end
+
+    local zero_block, input, address_block
+    if data_independent then
+        zero_block = new_zero_block()
+        input = {}
+        for i = 1, BLOCK_WORDS do input[i] = 0 end
+        input[1] = r
+        input[2] = lane
+        input[3] = sl
+        input[4] = m_prime
+        input[5] = t_total
+        input[6] = TYPE_ID
+    end
+
+    for i = starting_c, sl_len - 1 do
+        local col = sl * sl_len + i
+        local prev_col
+        if col == 0 then prev_col = q - 1 else prev_col = col - 1 end
+        local prev_block = memory[lane][prev_col]
+
+        local pseudo_rand
+        if data_independent then
+            if i % BLOCK_WORDS == 0 then
+                address_block = regenerate_addresses(zero_block, input)
+            end
+            pseudo_rand = address_block[i % BLOCK_WORDS + 1]
+        else
+            pseudo_rand = prev_block[1]
+        end
+
+        local j1 = pseudo_rand & MASK32
+        local j2 = (pseudo_rand >> 32) & MASK32
+
+        local l_prime = lane
+        if not (r == 0 and sl == 0) then l_prime = j2 % p end
+
+        local z_prime = index_alpha(j1, r, sl, i, l_prime == lane, q, sl_len)
+        local ref_block = memory[l_prime][z_prime]
+
+        local new_block = compress(prev_block, ref_block)
+        if r == 0 then
+            memory[lane][col] = new_block
+        else
+            local existing = memory[lane][col]
+            local xored = {}
+            for k = 1, BLOCK_WORDS do xored[k] = existing[k] ~ new_block[k] end
+            memory[lane][col] = xored
+        end
+    end
+end
+
+local function validate(password, salt, t, m, p, tag_length, key, ad, version)
+    assert(#password <= MASK32, "password length must fit in 32 bits")
+    assert(#salt >= 8, "salt must be at least 8 bytes")
+    assert(#salt <= MASK32, "salt length must fit in 32 bits")
+    assert(#key <= MASK32, "key length must fit in 32 bits")
+    assert(#ad <= MASK32, "associated_data length must fit in 32 bits")
+    assert(tag_length >= 4, "tag_length must be >= 4")
+    assert(tag_length <= MASK32, "tag_length must fit in 32 bits")
+    assert(type(p) == "number" and p == math.floor(p) and p >= 1 and p <= 0xFFFFFF,
+           "parallelism must be in [1, 2^24-1]")
+    assert(m >= 8 * p, "memory_cost must be >= 8*parallelism")
+    assert(m <= MASK32, "memory_cost must fit in 32 bits")
+    assert(t >= 1, "time_cost must be >= 1")
+    assert(version == ARGON2_VERSION, "only Argon2 v1.3 (0x13) is supported")
+end
+
+function M.argon2id(password, salt, time_cost, memory_cost, parallelism, tag_length, opts)
+    opts = opts or {}
+    local key = opts.key or ""
+    local ad = opts.associated_data or ""
+    local version = opts.version or ARGON2_VERSION
+    validate(password, salt, time_cost, memory_cost, parallelism, tag_length, key, ad, version)
+
+    local p = parallelism
+    local t = time_cost
+    local segment_length = memory_cost // (SYNC_POINTS * p)
+    local m_prime = segment_length * SYNC_POINTS * p
+    local q = m_prime // p
+    local sl_len = segment_length
+
+    local h0_in = table.concat({
+        le32(p), le32(tag_length), le32(memory_cost), le32(t),
+        le32(version), le32(TYPE_ID),
+        le32(#password), password,
+        le32(#salt), salt,
+        le32(#key), key,
+        le32(#ad), ad,
+    })
+    local h0 = blake2b.digest(h0_in, {digest_size = 64})
+
+    local memory = {}
+    for i = 0, p - 1 do
+        memory[i] = {}
+        memory[i][0] = bytes_to_block(blake2b_long(BLOCK_SIZE, h0 .. le32(0) .. le32(i)))
+        memory[i][1] = bytes_to_block(blake2b_long(BLOCK_SIZE, h0 .. le32(1) .. le32(i)))
+    end
+
+    for r = 0, t - 1 do
+        for sl = 0, SYNC_POINTS - 1 do
+            for lane = 0, p - 1 do
+                fill_segment(memory, r, lane, sl, q, sl_len, p, m_prime, t)
+            end
+        end
+    end
+
+    local final_block = {}
+    for k = 1, BLOCK_WORDS do final_block[k] = memory[0][q - 1][k] end
+    for lane = 1, p - 1 do
+        local lb = memory[lane][q - 1]
+        for k = 1, BLOCK_WORDS do final_block[k] = final_block[k] ~ lb[k] end
+    end
+
+    return blake2b_long(tag_length, block_to_bytes(final_block))
+end
+
+function M.argon2id_hex(password, salt, time_cost, memory_cost, parallelism, tag_length, opts)
+    local raw = M.argon2id(password, salt, time_cost, memory_cost, parallelism, tag_length, opts)
+    local parts = {}
+    for i = 1, #raw do parts[i] = string.format("%02x", string.byte(raw, i)) end
+    return table.concat(parts)
+end
+
+return M

--- a/code/packages/lua/argon2id/tests/test_argon2id.lua
+++ b/code/packages/lua/argon2id/tests/test_argon2id.lua
@@ -1,0 +1,111 @@
+-- Tests for pure-Lua Argon2id (RFC 9106).
+
+package.path = "../src/?.lua;../src/?/init.lua;"
+            .. "../../blake2b/src/?.lua;../../blake2b/src/?/init.lua;"
+            .. package.path
+
+local argon2id = require("coding_adventures.argon2id")
+
+local function rep_byte(n, byte)
+    return string.rep(string.char(byte), n)
+end
+
+local RFC_PW = rep_byte(32, 0x01)
+local RFC_SALT = rep_byte(16, 0x02)
+local RFC_KEY = rep_byte(8, 0x03)
+local RFC_AD = rep_byte(12, 0x04)
+local RFC_EXPECTED = "0d640df58d78766c08c037a34a8b53c9d01ef0452d75b65eb52520e96b01e659"
+
+describe("argon2id", function()
+    it("RFC 9106 §5.3 gold-standard vector", function()
+        local hex = argon2id.argon2id_hex(RFC_PW, RFC_SALT, 3, 32, 4, 32,
+            {key = RFC_KEY, associated_data = RFC_AD})
+        assert.equals(RFC_EXPECTED, hex)
+    end)
+
+    it("hex matches binary", function()
+        local tag = argon2id.argon2id(RFC_PW, RFC_SALT, 3, 32, 4, 32,
+            {key = RFC_KEY, associated_data = RFC_AD})
+        local parts = {}
+        for i = 1, #tag do parts[i] = string.format("%02x", string.byte(tag, i)) end
+        assert.equals(RFC_EXPECTED, table.concat(parts))
+    end)
+
+    it("rejects short salt", function()
+        assert.has_error(function() argon2id.argon2id("pw", "short", 1, 8, 1, 32) end)
+    end)
+    it("rejects zero time_cost", function()
+        assert.has_error(function() argon2id.argon2id("pw", string.rep("a", 8), 0, 8, 1, 32) end)
+    end)
+    it("rejects tag_length under 4", function()
+        assert.has_error(function() argon2id.argon2id("pw", string.rep("a", 8), 1, 8, 1, 3) end)
+    end)
+    it("rejects memory below floor", function()
+        assert.has_error(function() argon2id.argon2id("pw", string.rep("a", 8), 1, 7, 1, 32) end)
+    end)
+    it("rejects zero parallelism", function()
+        assert.has_error(function() argon2id.argon2id("pw", string.rep("a", 8), 1, 8, 0, 32) end)
+    end)
+    it("rejects unsupported version", function()
+        assert.has_error(function()
+            argon2id.argon2id("pw", string.rep("a", 8), 1, 8, 1, 32, {version = 0x10})
+        end)
+    end)
+
+    it("deterministic", function()
+        local a = argon2id.argon2id_hex("pw", string.rep("a", 8), 1, 8, 1, 32)
+        local b = argon2id.argon2id_hex("pw", string.rep("a", 8), 1, 8, 1, 32)
+        assert.equals(a, b)
+    end)
+
+    it("differs on password", function()
+        local a = argon2id.argon2id_hex("pw1", string.rep("a", 8), 1, 8, 1, 32)
+        local b = argon2id.argon2id_hex("pw2", string.rep("a", 8), 1, 8, 1, 32)
+        assert.not_equals(a, b)
+    end)
+
+    it("differs on salt", function()
+        local a = argon2id.argon2id_hex("pw", string.rep("a", 8), 1, 8, 1, 32)
+        local b = argon2id.argon2id_hex("pw", string.rep("b", 8), 1, 8, 1, 32)
+        assert.not_equals(a, b)
+    end)
+
+    it("key binds", function()
+        local a = argon2id.argon2id_hex("pw", string.rep("a", 8), 1, 8, 1, 32)
+        local b = argon2id.argon2id_hex("pw", string.rep("a", 8), 1, 8, 1, 32, {key = "k1"})
+        local c = argon2id.argon2id_hex("pw", string.rep("a", 8), 1, 8, 1, 32, {key = "k2"})
+        assert.not_equals(a, b)
+        assert.not_equals(b, c)
+    end)
+
+    it("associated_data binds", function()
+        local a = argon2id.argon2id_hex("pw", string.rep("a", 8), 1, 8, 1, 32)
+        local b = argon2id.argon2id_hex("pw", string.rep("a", 8), 1, 8, 1, 32, {associated_data = "x"})
+        local c = argon2id.argon2id_hex("pw", string.rep("a", 8), 1, 8, 1, 32, {associated_data = "y"})
+        assert.not_equals(a, b)
+        assert.not_equals(b, c)
+    end)
+
+    it("tag_length 4", function()
+        assert.equals(4, #argon2id.argon2id("pw", string.rep("a", 8), 1, 8, 1, 4))
+    end)
+    it("tag_length 16", function()
+        assert.equals(16, #argon2id.argon2id("pw", string.rep("a", 8), 1, 8, 1, 16))
+    end)
+    it("tag_length 65 crosses H' boundary", function()
+        assert.equals(65, #argon2id.argon2id("pw", string.rep("a", 8), 1, 8, 1, 65))
+    end)
+    it("tag_length 128", function()
+        assert.equals(128, #argon2id.argon2id("pw", string.rep("a", 8), 1, 8, 1, 128))
+    end)
+
+    it("multi-lane", function()
+        assert.equals(32, #argon2id.argon2id("pw", string.rep("a", 8), 1, 16, 2, 32))
+    end)
+
+    it("multi-pass", function()
+        local a = argon2id.argon2id_hex("pw", string.rep("a", 8), 1, 8, 1, 32)
+        local b = argon2id.argon2id_hex("pw", string.rep("a", 8), 2, 8, 1, 32)
+        assert.not_equals(a, b)
+    end)
+end)


### PR DESCRIPTION
## Summary
- Pure-Lua, from-scratch implementation of RFC 9106 for all three Argon2 variants (argon2d, argon2i, argon2id) — each a self-contained package depending only on `coding-adventures-blake2b`.
- Passes canonical RFC 9106 §5.{1,2,3} gold-standard vectors (including keyed + associated-data inputs) plus 18 parameter-edge tests per variant (19 total each).
- Enforces RFC 9106 §3.1 length caps on password/salt/key/AD/tag_length/memory_cost; READMEs document the DoS trust boundary and constant-time-compare guidance.
- Lua 5.3+ required for native 64-bit integer arithmetic with wrap-on-overflow addition — no masking emulation needed beyond the MASK32 truncation inside the G mixer.

## Test plan
- [x] `cd code/packages/lua/argon2d/tests && busted . --verbose --pattern=test_` → 19/19
- [x] `cd code/packages/lua/argon2i/tests && busted . --verbose --pattern=test_` → 19/19
- [x] `cd code/packages/lua/argon2id/tests && busted . --verbose --pattern=test_` → 19/19
- [x] Security review via sub-agent: PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)