### PR TITLE
feat(algol60): lower scalar by-name parameters

### DIFF
--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -20,8 +20,9 @@ All notable changes to this package will be documented in this file.
 - Lowered Phase 4 integer arrays to heap-backed descriptors with dynamic
   bound evaluation, row-major strides, checked element loads/stores, bounded
   aggregate element counts, and block-lifetime heap restoration.
-- Added an explicit Phase 5 guard so by-name parameters are rejected at IR
-  lowering until thunk descriptor eval/store code generation is implemented.
+- Lowered scalar by-name actuals as storage pointers so by-name formal reads
+  and writes execute through the caller's scalar slot, while expression and
+  array-element actuals continue to report explicit future-thunk diagnostics.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -22,10 +22,13 @@ checked element loads/stores through the descriptor. Block and procedure exits
 restore the heap pointer to the activation's entry mark, so dynamic arrays keep
 ALGOL block lifetime instead of leaking through loops or recursive calls.
 
-By-name parameters are recognized by the type checker but are not lowered here
-yet. Until Phase 5 thunk descriptors and eval/store helpers are implemented,
-programs containing by-name parameters raise `CompileError` instead of being
-silently compiled as value-parameter calls.
+Scalar by-name parameters lower through a one-word storage pointer in the
+callee frame. Passing a scalar variable as a by-name actual gives the callee a
+delayed load/store cell, so assignments to the formal write back to the caller
+slot while value parameters still remain isolated copies. General expression
+actuals and array-element actuals still raise targeted `CompileError`
+diagnostics until Phase 5 grows full eval/store thunk descriptors that
+re-evaluate the actual expression on each access.
 
 This phase keeps ALGOL frame memory and its 20-byte runtime state bounded to
 one 64 KiB WASM page, and keeps array descriptors plus element storage inside a

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from algol_type_checker import (
     ArrayDescriptor,
     ProcedureDescriptor,
+    ProcedureParameter,
     ResolvedArrayAccess,
     ResolvedProcedureCall,
     ResolvedReference,
@@ -60,6 +61,8 @@ _ARRAY_DATA_POINTER_OFFSET = 16
 _ARRAY_BOUNDS_POINTER_OFFSET = 20
 _ARRAY_WORD_BYTES = 4
 _ARRAY_MAX_ELEMENTS = 4096
+_VALUE_MODE = "value"
+_NAME_MODE = "name"
 
 
 @dataclass(frozen=True)
@@ -128,6 +131,7 @@ class AlgolIrCompiler:
         self.procedure_calls: dict[tuple[int, str], ResolvedProcedureCall] = {}
         self.array_accesses: dict[tuple[int, str], ResolvedArrayAccess] = {}
         self.procedures: dict[int, ProcedureDescriptor] = {}
+        self.parameters_by_symbol: dict[int, ProcedureParameter] = {}
         self.arrays: dict[int, ArrayDescriptor] = {}
         self.arrays_by_block: dict[int, list[ArrayDescriptor]] = {}
         self.frame_offsets: dict[int, int] = {}
@@ -182,7 +186,11 @@ class AlgolIrCompiler:
             procedure.procedure_id: procedure
             for procedure in type_result.semantic.procedures
         }
-        self._reject_by_name_procedures(type_result.semantic.procedures)
+        self.parameters_by_symbol = {
+            parameter.symbol_id: parameter
+            for procedure in type_result.semantic.procedures
+            for parameter in procedure.parameters
+        }
         self.arrays = {
             array.array_id: array for array in type_result.semantic.arrays
         }
@@ -301,17 +309,6 @@ class AlgolIrCompiler:
 
         self._emit_leave_frame(scope)
         return scope
-
-    def _reject_by_name_procedures(
-        self, procedures: list[ProcedureDescriptor]
-    ) -> None:
-        for procedure in procedures:
-            for parameter in procedure.parameters:
-                if parameter.mode != "value":
-                    raise CompileError(
-                        f"call-by-name parameter {parameter.name!r} requires "
-                        "thunk lowering, not implemented by algol-ir-compiler"
-                    )
 
     def _emit_enter_frame(
         self,
@@ -920,13 +917,22 @@ class AlgolIrCompiler:
             raise CompileError("procedure call is missing a name")
         role = "statement" if node.rule_name == "proc_stmt" else "expression"
         call = self._require_procedure_call(name, role)
+        procedure = self.procedures[call.procedure_id]
         static_link = self._emit_static_link_for_call(call, scope)
-        arguments = [
-            self._compile_expr(argument, scope)
-            for argument in _direct_nodes(
-                _first_direct_node(node, "actual_params"), "expression"
+        actuals = _direct_nodes(_first_direct_node(node, "actual_params"), "expression")
+        if len(actuals) != len(procedure.parameters):
+            raise CompileError(
+                f"procedure {procedure.name!r} expects "
+                f"{len(procedure.parameters)} argument(s), got {len(actuals)}"
             )
-        ]
+        arguments = []
+        for argument, parameter in zip(actuals, procedure.parameters, strict=True):
+            if parameter.mode == _VALUE_MODE:
+                arguments.append(self._compile_expr(argument, scope))
+            else:
+                arguments.append(
+                    self._compile_by_name_actual_pointer(argument, parameter, scope)
+                )
         self._emit(
             IrOp.CALL,
             IrLabel(call.label),
@@ -936,6 +942,29 @@ class AlgolIrCompiler:
         result = self._fresh_reg()
         self._copy_reg(dst=result, src=_RESULT_REG)
         return result
+
+    def _compile_by_name_actual_pointer(
+        self,
+        argument: ASTNode,
+        parameter: ProcedureParameter,
+        scope: _FrameScope,
+    ) -> int:
+        variable = _single_variable_expr(argument)
+        if variable is None:
+            raise CompileError(
+                f"by-name parameter {parameter.name!r} received a read-only "
+                "expression actual; eval thunk lowering is not implemented yet"
+            )
+        if _variable_subscripts(variable):
+            raise CompileError(
+                f"by-name parameter {parameter.name!r} received an array element "
+                "actual; re-evaluating element thunk lowering is not implemented yet"
+            )
+        name = _variable_name(variable)
+        if name is None:
+            raise CompileError("by-name scalar actual is missing a name")
+        reference = self._require_reference(name, "read")
+        return self._emit_reference_pointer(reference, scope)
 
     def _compile_procedures(
         self, procedures: list[ProcedureDescriptor]
@@ -1130,16 +1159,41 @@ class AlgolIrCompiler:
     def _emit_load_reference(
         self, reference: ResolvedReference, scope: _FrameScope
     ) -> int:
+        pointer = self._emit_reference_pointer(reference, scope)
         dst = self._fresh_reg()
-        frame_reg = self._emit_frame_for_reference(reference, scope)
-        offset_reg = self._const_reg(reference.slot_offset)
         self._emit(
             IrOp.LOAD_WORD,
             IrRegister(dst),
-            IrRegister(frame_reg),
-            IrRegister(offset_reg),
+            IrRegister(pointer),
+            IrRegister(self._const_reg(0)),
         )
         return dst
+
+    def _emit_reference_pointer(
+        self, reference: ResolvedReference, scope: _FrameScope
+    ) -> int:
+        frame_reg = self._emit_frame_for_reference(reference, scope)
+        if self._is_by_name_reference(reference):
+            pointer = self._fresh_reg()
+            self._emit(
+                IrOp.LOAD_WORD,
+                IrRegister(pointer),
+                IrRegister(frame_reg),
+                IrRegister(self._const_reg(reference.slot_offset)),
+            )
+            return pointer
+        pointer = self._fresh_reg()
+        self._emit(
+            IrOp.ADD_IMM,
+            IrRegister(pointer),
+            IrRegister(frame_reg),
+            IrImmediate(reference.slot_offset),
+        )
+        return pointer
+
+    def _is_by_name_reference(self, reference: ResolvedReference) -> bool:
+        parameter = self.parameters_by_symbol.get(reference.symbol_id)
+        return parameter is not None and parameter.mode == _NAME_MODE
 
     def _emit_store_reference(
         self,
@@ -1147,11 +1201,12 @@ class AlgolIrCompiler:
         scope: _FrameScope,
         value_reg: int,
     ) -> None:
-        frame_reg = self._emit_frame_for_reference(reference, scope)
-        self._store_word_reg(
-            value_reg=value_reg,
-            base_reg=frame_reg,
-            offset=reference.slot_offset,
+        pointer = self._emit_reference_pointer(reference, scope)
+        self._emit(
+            IrOp.STORE_WORD,
+            IrRegister(value_reg),
+            IrRegister(pointer),
+            IrRegister(self._const_reg(0)),
         )
 
     def _emit_frame_for_reference(
@@ -1492,6 +1547,17 @@ def _variable_name(node: ASTNode | None) -> Token | None:
         return None
     names = [token for token in _tokens(variable) if token.type_name == "NAME"]
     return names[0] if len(names) == 1 else None
+
+
+def _single_variable_expr(node: ASTNode | None) -> ASTNode | None:
+    if node is None:
+        return None
+    if node.rule_name == "variable":
+        return node
+    meaningful = _meaningful_children(node)
+    if len(meaningful) != 1 or not isinstance(meaningful[0], ASTNode):
+        return None
+    return _single_variable_expr(meaningful[0])
 
 
 def _variable_head_name(node: ASTNode | None) -> Token | None:

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -263,13 +263,50 @@ class TestAlgolIrCompiler:
         with pytest.raises(CompileError):
             compile_algol(parse_algol("begin integer result; result := 2 ** 3 end"))
 
-    def test_rejects_by_name_parameters_until_thunk_lowering_exists(self) -> None:
-        with pytest.raises(CompileError, match="call-by-name parameter"):
+    def test_compiles_scalar_by_name_parameter_as_storage_pointer(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; "
+                "procedure bump(x); integer x; begin x := x + 1 end; "
+                "result := 4; bump(result) "
+                "end"
+            )
+        )
+        calls = [
+            instruction
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.CALL
+        ]
+        opcodes = [instruction.opcode for instruction in result.program.instructions]
+
+        assert len(calls[0].operands) == 3
+        assert result.procedure_signatures[calls[0].operands[0].name] == 2
+        assert IrOp.ADD_IMM in opcodes
+        assert opcodes.count(IrOp.LOAD_WORD) >= 4
+        assert opcodes.count(IrOp.STORE_WORD) >= 8
+
+    def test_rejects_read_only_by_name_expression_until_eval_thunks_exist(
+        self,
+    ) -> None:
+        with pytest.raises(CompileError, match="eval thunk lowering"):
             compile_algol(
                 parse_algol(
                     "begin integer result; "
                     "integer procedure id(x); integer x; begin id := x end; "
                     "result := id(1) "
+                    "end"
+                )
+            )
+
+    def test_rejects_array_element_by_name_until_relocating_thunks_exist(
+        self,
+    ) -> None:
+        with pytest.raises(CompileError, match="array element"):
+            compile_algol(
+                parse_algol(
+                    "begin integer result; integer array a[1:2]; "
+                    "procedure put(x); integer x; begin x := 7 end; "
+                    "put(a[1]); result := a[1] "
                     "end"
                 )
             )

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -13,8 +13,9 @@ All notable changes to this package will be documented in this file.
 - Compiled Phase 4 integer arrays through heap-backed descriptors with dynamic
   bounds, multidimensional row-major indexing, runtime bounds checks, and
   zero-result failure for invalid bounds or out-of-bounds accesses.
-- Reported by-name procedures as an IR compile-stage gap until Phase 5 thunk
-  lowering is implemented, avoiding silent value-parameter behavior.
+- Executed scalar by-name actuals through caller-slot storage pointers, while
+  preserving IR compile-stage diagnostics for expression and array-element
+  actuals that still need full eval/store thunk descriptors.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -22,9 +22,11 @@ Integer arrays compile through the Phase 4 descriptor path: bounds are
 evaluated at block entry, descriptors live in frame slots, element storage lives
 in a bounded ALGOL heap segment, and every element access performs runtime
 bounds checks before touching WASM memory.
-By-name parameters are parsed and typed by the frontend, but this package still
-reports an IR compile error for them until the Phase 5 thunk-lowering pass is
-implemented.
+Scalar by-name parameters now execute through the same WASM memory path by
+passing a storage pointer into the callee frame. A by-name formal assignment
+therefore writes back to the caller's scalar slot. Expression actuals and array
+element actuals remain guarded by IR compile-stage diagnostics until the full
+Phase 5 eval/store thunk descriptors are available.
 
 ```python
 from algol_wasm_compiler import compile_source

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -44,12 +44,22 @@ class TestAlgolWasmCompiler:
             compile_source("begin integer result; result := false end")
         assert raised.value.stage == "type-check"
 
-    def test_by_name_waits_for_thunk_lowering_stage(self) -> None:
+    def test_by_name_expression_waits_for_eval_thunk_stage(self) -> None:
         with pytest.raises(AlgolWasmError) as raised:
             compile_source(
                 "begin integer result; "
                 "integer procedure id(x); integer x; begin id := x end; "
                 "result := id(1) "
+                "end"
+            )
+        assert raised.value.stage == "ir-compile"
+
+    def test_array_element_by_name_waits_for_relocating_thunk_stage(self) -> None:
+        with pytest.raises(AlgolWasmError) as raised:
+            compile_source(
+                "begin integer result; integer array a[1:2]; "
+                "procedure put(x); integer x; begin x := 7 end; "
+                "put(a[1]); result := a[1] "
                 "end"
             )
         assert raised.value.stage == "ir-compile"
@@ -110,6 +120,37 @@ class TestAlgolWasmCompiler:
             "end"
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [65]
+
+    def test_scalar_by_name_parameter_assignment_writes_back(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "procedure bump(x); integer x; begin x := x + 1 end; "
+            "result := 4; bump(result) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [5]
+
+    def test_scalar_by_name_parameter_reads_forwarded_pointer(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "integer procedure id(x); integer x; begin id := x end; "
+            "result := 12; result := id(result) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [12]
+
+    def test_nested_by_name_parameter_forwards_original_storage_pointer(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "procedure outer(x); integer x; "
+            "begin "
+            "procedure inner(y); integer y; begin y := y + 1 end; "
+            "inner(x) "
+            "end; "
+            "result := 4; outer(result) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [5]
 
     def test_recursive_factorial_runs_with_fresh_frames(self) -> None:
         result = compile_source(

--- a/code/specs/PL04-algol60-full-wasm-runtime.md
+++ b/code/specs/PL04-algol60-full-wasm-runtime.md
@@ -708,6 +708,15 @@ The first implementation should continue to reject:
 - escaping thunk descriptors
 - by-name actuals that require nonlocal `goto`, switches, or procedure values
 
+Current Phase 5a lowering may use a storage-pointer fast path for scalar
+variable actuals before general descriptor helpers exist. In that slice, the
+callee frame stores the caller scalar slot address in the by-name formal slot,
+and formal reads/writes dereference that address. This is executable for scalar
+variable actuals and useful for validating the WASM calling path, but it must
+continue to reject read-only expression actuals and array-element actuals until
+the full eval/store descriptor helpers can re-evaluate or re-locate the actual
+on every formal access.
+
 ### Required Diagnostics
 
 The phase is not complete unless unsupported forms fail before WASM lowering


### PR DESCRIPTION
## Summary

Implements the first executable Phase 5a slice for ALGOL 60 call-by-name lowering:

- passes scalar by-name actuals as caller-slot storage pointers through the existing procedure calling convention
- dereferences by-name formals for scalar reads and writes so assignments write back to the caller variable
- forwards an existing by-name pointer when a by-name formal is passed onward to another by-name formal
- keeps unsupported expression and array-element actuals guarded by targeted IR compile diagnostics until full eval/store thunk descriptors exist
- updates PL04, package READMEs, changelogs, and IR/WASM tests for the new supported/unsupported boundary

## Residual Risk

This is intentionally not full ALGOL call-by-name yet. Read-only expression actuals and array-element actuals still reach IR compilation before they are rejected. That boundary is explicit in the docs and tests so they do not silently lower as by-reference behavior before real eval/store thunk descriptors are implemented.

## Verification

- `bash BUILD` in `code/packages/python/algol-ir-compiler`
- `bash BUILD` in `code/packages/python/algol-wasm-compiler`
- `.venv/bin/python -m ruff check src tests` in both changed Python packages
- `git diff --check`
- security review sub-agent: no security issues found

Note: the Go build tool was tried with this worktree, but it does not recognize a Git worktree `.git` file as the repo root and fell back to a full 2,798-package hash-cache build. I stopped that and cleaned its generated artifacts; focused affected package checks are green.