### PR TITLE
feat(algol60): lower read-only expression thunks

### DIFF
--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -23,6 +23,9 @@ All notable changes to this package will be documented in this file.
 - Lowered scalar by-name actuals as storage pointers so by-name formal reads
   and writes execute through the caller's scalar slot, while expression and
   array-element actuals continue to report explicit future-thunk diagnostics.
+- Lowered read-only integer expression actuals to tagged eval thunk descriptors
+  with bounded call-scoped heap allocation and generated eval dispatch that
+  re-evaluates against the caller frame on every formal read.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -22,13 +22,16 @@ checked element loads/stores through the descriptor. Block and procedure exits
 restore the heap pointer to the activation's entry mark, so dynamic arrays keep
 ALGOL block lifetime instead of leaking through loops or recursive calls.
 
-Scalar by-name parameters lower through a one-word storage pointer in the
-callee frame. Passing a scalar variable as a by-name actual gives the callee a
-delayed load/store cell, so assignments to the formal write back to the caller
-slot while value parameters still remain isolated copies. General expression
-actuals and array-element actuals still raise targeted `CompileError`
-diagnostics until Phase 5 grows full eval/store thunk descriptors that
-re-evaluate the actual expression on each access.
+Scalar by-name parameters lower through a one-word cell in the callee frame.
+Passing a scalar variable as a by-name actual gives the callee a storage pointer,
+so assignments to the formal write back to the caller slot while value
+parameters still remain isolated copies. Read-only integer expression actuals
+lower to tagged, bounded eval thunk descriptors. Formal reads dispatch through a
+generated helper that re-evaluates the expression against the caller frame each
+time. Array-element actuals, expression thunks that read arrays, expression
+thunks that call procedures, and stores through expression thunks still raise
+targeted `CompileError` diagnostics until Phase 5 grows full eval/store helper
+coverage.
 
 This phase keeps ALGOL frame memory and its 20-byte runtime state bounded to
 one 64 KiB WASM page, and keeps array descriptors plus element storage inside a

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -45,9 +45,11 @@ _RUNTIME_STACK_POINTER_OFFSET = 4
 _RUNTIME_STACK_LIMIT_OFFSET = 8
 _RUNTIME_HEAP_POINTER_OFFSET = 12
 _RUNTIME_HEAP_LIMIT_OFFSET = 16
-_RUNTIME_STATE_BYTES = 20
+_RUNTIME_THUNK_HEAP_MARK_OFFSET = 20
+_RUNTIME_STATE_BYTES = 24
 _STATIC_LINK_PARAM_REG = 2
-_VALUE_PARAM_BASE_REG = 3
+_THUNK_HEAP_MARK_PARAM_REG = 3
+_VALUE_PARAM_BASE_REG = 4
 _FIRST_GENERAL_REG = 32
 _ARRAY_DESCRIPTOR_SIZE = 24
 _ARRAY_ELEMENT_TYPE_INTEGER = 1
@@ -63,6 +65,12 @@ _ARRAY_WORD_BYTES = 4
 _ARRAY_MAX_ELEMENTS = 4096
 _VALUE_MODE = "value"
 _NAME_MODE = "name"
+_THUNK_EVAL_LABEL = "_fn_algol_eval_thunk"
+_THUNK_DESCRIPTOR_SIZE = 8
+_THUNK_CODE_ID_OFFSET = 0
+_THUNK_CALLER_FRAME_OFFSET = 4
+_THUNK_DESCRIPTOR_TAG = 1
+_MAX_EVAL_THUNKS = 256
 
 
 @dataclass(frozen=True)
@@ -96,10 +104,20 @@ class _FrameScope:
     frame_base_reg: int
     heap_mark_reg: int | None = None
     parent: _FrameScope | None = None
+    active_thunk_heap_mark_reg: int | None = None
 
     @property
     def block_id(self) -> int:
         return self.semantic_block.block_id
+
+
+@dataclass(frozen=True)
+class _EvalThunk:
+    """A read-only by-name expression captured for helper dispatch."""
+
+    thunk_id: int
+    expression: ASTNode
+    block_id: int
 
 
 class AlgolIrCompiler:
@@ -138,6 +156,8 @@ class AlgolIrCompiler:
         self.variable_slots: dict[str, int] = {}
         self.legacy_variable_slots: dict[str, int] = {}
         self.procedure_signatures: dict[str, int] = {}
+        self.eval_thunks: list[_EvalThunk] = []
+        self.has_by_name_parameters = False
 
     def compile(self, typed: TypeCheckResult | ASTNode) -> CompileResult:
         type_result = (
@@ -161,6 +181,8 @@ class AlgolIrCompiler:
         self.heap_base_reg = -1
         self.heap_pointer_reg = -1
         self.heap_limit_reg = -1
+        self.eval_thunks = []
+        self.has_by_name_parameters = False
         self.semantic_blocks = list(type_result.semantic.blocks)
         self.semantic_blocks_by_ast = {
             block.ast_node_id: block
@@ -191,6 +213,11 @@ class AlgolIrCompiler:
             for procedure in type_result.semantic.procedures
             for parameter in procedure.parameters
         }
+        self.has_by_name_parameters = any(
+            parameter.mode == _NAME_MODE
+            for procedure in type_result.semantic.procedures
+            for parameter in procedure.parameters
+        )
         self.arrays = {
             array.array_id: array for array in type_result.semantic.arrays
         }
@@ -198,9 +225,11 @@ class AlgolIrCompiler:
         for array in type_result.semantic.arrays:
             self.arrays_by_block.setdefault(array.declaring_block_id, []).append(array)
         self.procedure_signatures = {
-            procedure.label: 1 + len(procedure.parameters)
+            procedure.label: 2 + len(procedure.parameters)
             for procedure in type_result.semantic.procedures
         }
+        if self.has_by_name_parameters:
+            self.procedure_signatures[_THUNK_EVAL_LABEL] = 2
         self.frame_offsets = self._layout_frames(self.semantic_blocks)
         self.variable_slots = self._collect_variable_slots(self.semantic_blocks)
         self.legacy_variable_slots = self._collect_legacy_variable_slots(
@@ -265,6 +294,7 @@ class AlgolIrCompiler:
         self._store_runtime_state(_RUNTIME_STACK_LIMIT_OFFSET, self.stack_limit_reg)
         self._store_runtime_state(_RUNTIME_HEAP_POINTER_OFFSET, self.heap_pointer_reg)
         self._store_runtime_state(_RUNTIME_HEAP_LIMIT_OFFSET, self.heap_limit_reg)
+        self._store_runtime_state(_RUNTIME_THUNK_HEAP_MARK_OFFSET, _ZERO_REG)
 
         block = _first_node(type_result.ast, "block")
         if block is None:
@@ -279,6 +309,8 @@ class AlgolIrCompiler:
         self._emit_load_symbol(result_symbol, root_scope, _RESULT_REG)
         self._emit(IrOp.HALT)
         self._compile_procedures(type_result.semantic.procedures)
+        if self.has_by_name_parameters:
+            self._compile_eval_thunk_dispatcher()
 
         return CompileResult(
             program=self.program,
@@ -300,6 +332,9 @@ class AlgolIrCompiler:
             frame_base_reg=frame_base_reg,
             heap_mark_reg=self._snapshot_heap_pointer(),
             parent=parent,
+            active_thunk_heap_mark_reg=(
+                parent.active_thunk_heap_mark_reg if parent is not None else None
+            ),
         )
 
         self._initialize_scalar_slots(scope)
@@ -925,22 +960,85 @@ class AlgolIrCompiler:
                 f"procedure {procedure.name!r} expects "
                 f"{len(procedure.parameters)} argument(s), got {len(actuals)}"
             )
-        arguments = []
-        for argument, parameter in zip(actuals, procedure.parameters, strict=True):
-            if parameter.mode == _VALUE_MODE:
-                arguments.append(self._compile_expr(argument, scope))
-            else:
-                arguments.append(
-                    self._compile_by_name_actual_pointer(argument, parameter, scope)
+        expression_actuals = [
+            (index, argument, parameter)
+            for index, (argument, parameter) in enumerate(
+                zip(actuals, procedure.parameters, strict=True)
+            )
+            if parameter.mode == _NAME_MODE
+            and _single_variable_expr(argument) is None
+        ]
+        for _, argument, parameter in expression_actuals:
+            if parameter.may_write:
+                raise CompileError(
+                    f"by-name parameter {parameter.name!r} is assigned, but "
+                    "expression actual has no store thunk lowering yet"
                 )
+            self._require_eval_thunk_expression(argument, parameter)
+
+        arguments: list[int | None] = [None] * len(actuals)
+        for index, (argument, parameter) in enumerate(
+            zip(actuals, procedure.parameters, strict=True)
+        ):
+            if parameter.mode == _VALUE_MODE:
+                arguments[index] = self._compile_expr(argument, scope)
+
+        descriptor_heap_mark = (
+            self._emit_reserve_eval_thunk_descriptors(len(expression_actuals), scope)
+            if expression_actuals
+            else None
+        )
+        active_thunk_heap_mark = (
+            descriptor_heap_mark
+            if descriptor_heap_mark is not None
+            else (
+                scope.active_thunk_heap_mark_reg
+                if scope.active_thunk_heap_mark_reg is not None
+                else self._const_reg(0)
+            )
+        )
+        descriptor_offsets = {
+            argument_index: descriptor_index * _THUNK_DESCRIPTOR_SIZE
+            for descriptor_index, (argument_index, _, _) in enumerate(
+                expression_actuals
+            )
+        }
+        for index, (argument, parameter) in enumerate(
+            zip(actuals, procedure.parameters, strict=True)
+        ):
+            if parameter.mode != _NAME_MODE:
+                continue
+            descriptor = None
+            if descriptor_heap_mark is not None and index in descriptor_offsets:
+                descriptor = self._emit_descriptor_at(
+                    descriptor_heap_mark,
+                    descriptor_offsets[index],
+                )
+            arguments[index] = self._compile_by_name_actual_pointer(
+                argument,
+                parameter,
+                scope,
+                descriptor,
+            )
+        call_arguments = [
+            argument
+            for argument in arguments
+            if argument is not None
+        ]
         self._emit(
             IrOp.CALL,
             IrLabel(call.label),
             IrRegister(static_link),
-            *(IrRegister(argument) for argument in arguments),
+            IrRegister(active_thunk_heap_mark),
+            *(IrRegister(argument) for argument in call_arguments),
         )
         result = self._fresh_reg()
         self._copy_reg(dst=result, src=_RESULT_REG)
+        if descriptor_heap_mark is not None:
+            self._store_runtime_state(
+                _RUNTIME_HEAP_POINTER_OFFSET,
+                descriptor_heap_mark,
+            )
         return result
 
     def _compile_by_name_actual_pointer(
@@ -948,12 +1046,19 @@ class AlgolIrCompiler:
         argument: ASTNode,
         parameter: ProcedureParameter,
         scope: _FrameScope,
+        descriptor: int | None,
     ) -> int:
         variable = _single_variable_expr(argument)
         if variable is None:
-            raise CompileError(
-                f"by-name parameter {parameter.name!r} received a read-only "
-                "expression actual; eval thunk lowering is not implemented yet"
+            if descriptor is None:
+                raise CompileError(
+                    "missing reserved eval thunk descriptor for by-name expression"
+                )
+            return self._compile_eval_thunk_actual(
+                argument,
+                parameter,
+                scope,
+                descriptor,
             )
         if _variable_subscripts(variable):
             raise CompileError(
@@ -966,11 +1071,172 @@ class AlgolIrCompiler:
         reference = self._require_reference(name, "read")
         return self._emit_reference_pointer(reference, scope)
 
+    def _compile_eval_thunk_actual(
+        self,
+        argument: ASTNode,
+        parameter: ProcedureParameter,
+        scope: _FrameScope,
+        descriptor: int,
+    ) -> int:
+        thunk = self._register_eval_thunk(argument, scope.block_id)
+        self._emit_write_eval_thunk_descriptor(thunk, scope, descriptor)
+        tagged_descriptor = self._fresh_reg()
+        self._emit(
+            IrOp.ADD_IMM,
+            IrRegister(tagged_descriptor),
+            IrRegister(descriptor),
+            IrImmediate(_THUNK_DESCRIPTOR_TAG),
+        )
+        return tagged_descriptor
+
+    def _require_eval_thunk_expression(
+        self,
+        argument: ASTNode,
+        parameter: ProcedureParameter,
+    ) -> None:
+        if _first_node(argument, "proc_call") is not None:
+            raise CompileError(
+                f"by-name parameter {parameter.name!r} received a procedure-call "
+                "expression actual; eval thunk procedure-call lowering is not "
+                "implemented yet"
+            )
+        array_variable = next(
+            (
+                variable
+                for variable in _nodes(argument, "variable")
+                if _variable_subscripts(variable)
+            ),
+            None,
+        )
+        if array_variable is not None:
+            raise CompileError(
+                f"by-name parameter {parameter.name!r} received an expression "
+                "actual that reads an array element; array eval thunk lowering "
+                "is not implemented yet"
+            )
+
+    def _register_eval_thunk(self, argument: ASTNode, block_id: int) -> _EvalThunk:
+        if len(self.eval_thunks) >= _MAX_EVAL_THUNKS:
+            raise CompileError(
+                "ALGOL program requires more than "
+                f"{_MAX_EVAL_THUNKS} by-name eval thunks"
+            )
+        thunk = _EvalThunk(
+            thunk_id=len(self.eval_thunks) + 1,
+            expression=argument,
+            block_id=block_id,
+        )
+        self.eval_thunks.append(thunk)
+        return thunk
+
+    def _emit_reserve_eval_thunk_descriptors(
+        self,
+        count: int,
+        scope: _FrameScope,
+    ) -> int:
+        descriptor_base = self._fresh_reg()
+        heap_limit = self._fresh_reg()
+        self._load_runtime_state(_RUNTIME_HEAP_POINTER_OFFSET, descriptor_base)
+        self._load_runtime_state(_RUNTIME_HEAP_LIMIT_OFFSET, heap_limit)
+        next_heap_pointer = self._fresh_reg()
+        self._emit(
+            IrOp.ADD_IMM,
+            IrRegister(next_heap_pointer),
+            IrRegister(descriptor_base),
+            IrImmediate(count * _THUNK_DESCRIPTOR_SIZE),
+        )
+        exhausted = self._fresh_reg()
+        self._emit(
+            IrOp.CMP_GT,
+            IrRegister(exhausted),
+            IrRegister(next_heap_pointer),
+            IrRegister(heap_limit),
+        )
+        self._emit_runtime_failure_guard(exhausted, scope)
+        self._store_runtime_state(_RUNTIME_HEAP_POINTER_OFFSET, next_heap_pointer)
+        return descriptor_base
+
+    def _emit_descriptor_at(self, descriptor_base: int, offset: int) -> int:
+        if offset == 0:
+            return descriptor_base
+        descriptor = self._fresh_reg()
+        self._emit(
+            IrOp.ADD_IMM,
+            IrRegister(descriptor),
+            IrRegister(descriptor_base),
+            IrImmediate(offset),
+        )
+        return descriptor
+
+    def _emit_write_eval_thunk_descriptor(
+        self,
+        thunk: _EvalThunk,
+        scope: _FrameScope,
+        descriptor: int,
+    ) -> None:
+        self._store_word_const(
+            descriptor,
+            _THUNK_CODE_ID_OFFSET,
+            thunk.thunk_id,
+        )
+        self._store_word_reg(
+            value_reg=scope.frame_base_reg,
+            base_reg=descriptor,
+            offset=_THUNK_CALLER_FRAME_OFFSET,
+        )
+
     def _compile_procedures(
         self, procedures: list[ProcedureDescriptor]
     ) -> None:
         for procedure in procedures:
             self._compile_procedure(procedure)
+
+    def _compile_eval_thunk_dispatcher(self) -> None:
+        self._label(_THUNK_EVAL_LABEL)
+        descriptor = _STATIC_LINK_PARAM_REG
+        active_thunk_heap_mark = _THUNK_HEAP_MARK_PARAM_REG
+        code_id = self._fresh_reg()
+        caller_frame = self._fresh_reg()
+        self._emit(
+            IrOp.LOAD_WORD,
+            IrRegister(code_id),
+            IrRegister(descriptor),
+            IrRegister(self._const_reg(_THUNK_CODE_ID_OFFSET)),
+        )
+        self._emit(
+            IrOp.LOAD_WORD,
+            IrRegister(caller_frame),
+            IrRegister(descriptor),
+            IrRegister(self._const_reg(_THUNK_CALLER_FRAME_OFFSET)),
+        )
+        for thunk in self.eval_thunks:
+            index = self.if_count
+            self.if_count += 1
+            else_label = f"if_{index}_else"
+            end_label = f"if_{index}_end"
+            matches = self._fresh_reg()
+            self._emit(
+                IrOp.CMP_EQ,
+                IrRegister(matches),
+                IrRegister(code_id),
+                IrRegister(self._const_reg(thunk.thunk_id)),
+            )
+            self._emit(IrOp.BRANCH_Z, IrRegister(matches), IrLabel(else_label))
+            thunk_scope = _FrameScope(
+                semantic_block=self.semantic_blocks_by_id[thunk.block_id],
+                frame_base_reg=caller_frame,
+                heap_mark_reg=None,
+                parent=None,
+                active_thunk_heap_mark_reg=active_thunk_heap_mark,
+            )
+            value = self._compile_expr(thunk.expression, thunk_scope)
+            self._copy_reg(dst=_RESULT_REG, src=value)
+            self._emit(IrOp.RET)
+            self._emit(IrOp.JUMP, IrLabel(end_label))
+            self._label(else_label)
+            self._label(end_label)
+        self._emit(IrOp.LOAD_IMM, IrRegister(_RESULT_REG), IrImmediate(0))
+        self._emit(IrOp.RET)
 
     def _compile_procedure(self, procedure: ProcedureDescriptor) -> None:
         body = self._find_ast_by_id(procedure.body_node_id)
@@ -987,6 +1253,7 @@ class AlgolIrCompiler:
             frame_base_reg=frame_base_reg,
             heap_mark_reg=self._snapshot_heap_pointer(),
             parent=None,
+            active_thunk_heap_mark_reg=_THUNK_HEAP_MARK_PARAM_REG,
         )
         self._initialize_scalar_slots(scope)
         for index, parameter in enumerate(procedure.parameters):
@@ -1159,6 +1426,8 @@ class AlgolIrCompiler:
     def _emit_load_reference(
         self, reference: ResolvedReference, scope: _FrameScope
     ) -> int:
+        if self._is_by_name_reference(reference):
+            return self._emit_load_by_name_reference(reference, scope)
         pointer = self._emit_reference_pointer(reference, scope)
         dst = self._fresh_reg()
         self._emit(
@@ -1167,6 +1436,55 @@ class AlgolIrCompiler:
             IrRegister(pointer),
             IrRegister(self._const_reg(0)),
         )
+        return dst
+
+    def _emit_load_by_name_reference(
+        self,
+        reference: ResolvedReference,
+        scope: _FrameScope,
+    ) -> int:
+        pointer = self._emit_reference_pointer(reference, scope)
+        tag = self._fresh_reg()
+        index = self.if_count
+        self.if_count += 1
+        storage_label = f"if_{index}_else"
+        end_label = f"if_{index}_end"
+        dst = self._fresh_reg()
+        self._emit(
+            IrOp.AND_IMM,
+            IrRegister(tag),
+            IrRegister(pointer),
+            IrImmediate(_THUNK_DESCRIPTOR_TAG),
+        )
+        self._emit(IrOp.BRANCH_Z, IrRegister(tag), IrLabel(storage_label))
+        descriptor = self._fresh_reg()
+        self._emit(
+            IrOp.ADD_IMM,
+            IrRegister(descriptor),
+            IrRegister(pointer),
+            IrImmediate(-_THUNK_DESCRIPTOR_TAG),
+        )
+        active_thunk_heap_mark = (
+            scope.active_thunk_heap_mark_reg
+            if scope.active_thunk_heap_mark_reg is not None
+            else self._const_reg(0)
+        )
+        self._emit(
+            IrOp.CALL,
+            IrLabel(_THUNK_EVAL_LABEL),
+            IrRegister(descriptor),
+            IrRegister(active_thunk_heap_mark),
+        )
+        self._copy_reg(dst=dst, src=_RESULT_REG)
+        self._emit(IrOp.JUMP, IrLabel(end_label))
+        self._label(storage_label)
+        self._emit(
+            IrOp.LOAD_WORD,
+            IrRegister(dst),
+            IrRegister(pointer),
+            IrRegister(self._const_reg(0)),
+        )
+        self._label(end_label)
         return dst
 
     def _emit_reference_pointer(
@@ -1202,6 +1520,15 @@ class AlgolIrCompiler:
         value_reg: int,
     ) -> None:
         pointer = self._emit_reference_pointer(reference, scope)
+        if self._is_by_name_reference(reference):
+            tag = self._fresh_reg()
+            self._emit(
+                IrOp.AND_IMM,
+                IrRegister(tag),
+                IrRegister(pointer),
+                IrImmediate(_THUNK_DESCRIPTOR_TAG),
+            )
+            self._emit_runtime_failure_guard(tag, scope)
         self._emit(
             IrOp.STORE_WORD,
             IrRegister(value_reg),
@@ -1376,7 +1703,30 @@ class AlgolIrCompiler:
         self._emit(IrOp.BRANCH_Z, IrRegister(failed_reg), IrLabel(else_label))
         self._emit(IrOp.LOAD_IMM, IrRegister(_RESULT_REG), IrImmediate(0))
         self._emit_unwind_for_return(scope)
+        self._emit_restore_active_thunk_heap_mark(scope)
         self._emit(IrOp.RET)
+        self._emit(IrOp.JUMP, IrLabel(end_label))
+        self._label(else_label)
+        self._label(end_label)
+
+    def _emit_restore_active_thunk_heap_mark(self, scope: _FrameScope) -> None:
+        mark_reg = scope.active_thunk_heap_mark_reg
+        if mark_reg is None:
+            return
+        index = self.if_count
+        self.if_count += 1
+        else_label = f"if_{index}_else"
+        end_label = f"if_{index}_end"
+        has_mark = self._fresh_reg()
+        self._emit(
+            IrOp.CMP_NE,
+            IrRegister(has_mark),
+            IrRegister(mark_reg),
+            IrRegister(_ZERO_REG),
+        )
+        self._emit(IrOp.BRANCH_Z, IrRegister(has_mark), IrLabel(else_label))
+        self._store_runtime_state(_RUNTIME_HEAP_POINTER_OFFSET, mark_reg)
+        self._store_runtime_state(_RUNTIME_THUNK_HEAP_MARK_OFFSET, _ZERO_REG)
         self._emit(IrOp.JUMP, IrLabel(end_label))
         self._label(else_label)
         self._label(end_label)
@@ -1535,6 +1885,15 @@ def _first_node(node: ASTNode, rule_name: str) -> ASTNode | None:
         if found is not None:
             return found
     return None
+
+
+def _nodes(node: ASTNode | None, rule_name: str) -> list[ASTNode]:
+    if node is None:
+        return []
+    found = [node] if node.rule_name == rule_name else []
+    for child in _node_children(node):
+        found.extend(_nodes(child, rule_name))
+    return found
 
 
 def _variable_name(node: ASTNode | None) -> Token | None:

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -168,7 +168,7 @@ class TestAlgolIrCompiler:
                 )
         )
 
-        with pytest.raises(CompileError, match="frame bytes plus 20 runtime bytes"):
+        with pytest.raises(CompileError, match="frame bytes plus 24 runtime bytes"):
             compile_algol(typed)
 
     def test_compiles_integer_array_descriptor_and_element_accesses(self) -> None:
@@ -225,9 +225,9 @@ class TestAlgolIrCompiler:
             if instruction.opcode == IrOp.LABEL
         ]
         assert calls[0].operands[0].name.startswith("_fn_algol_")
-        assert len(calls[0].operands) == 3
+        assert len(calls[0].operands) == 4
         assert any(label.startswith("_fn_algol_") for label in labels)
-        assert result.procedure_signatures[calls[0].operands[0].name] == 2
+        assert result.procedure_signatures[calls[0].operands[0].name] == 3
 
     def test_compiles_recursive_procedure_call(self) -> None:
         result = compile_algol(
@@ -279,24 +279,35 @@ class TestAlgolIrCompiler:
         ]
         opcodes = [instruction.opcode for instruction in result.program.instructions]
 
-        assert len(calls[0].operands) == 3
-        assert result.procedure_signatures[calls[0].operands[0].name] == 2
+        assert len(calls[0].operands) == 4
+        assert result.procedure_signatures[calls[0].operands[0].name] == 3
         assert IrOp.ADD_IMM in opcodes
         assert opcodes.count(IrOp.LOAD_WORD) >= 4
         assert opcodes.count(IrOp.STORE_WORD) >= 8
 
-    def test_rejects_read_only_by_name_expression_until_eval_thunks_exist(
-        self,
-    ) -> None:
-        with pytest.raises(CompileError, match="eval thunk lowering"):
-            compile_algol(
-                parse_algol(
-                    "begin integer result; "
-                    "integer procedure id(x); integer x; begin id := x end; "
-                    "result := id(1) "
-                    "end"
-                )
+    def test_compiles_read_only_by_name_expression_eval_thunk(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; "
+                "integer procedure id(x); integer x; begin id := x end; "
+                "result := id(1 + result) "
+                "end"
             )
+        )
+        calls = [
+            instruction
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.CALL
+        ]
+        labels = [
+            instruction.operands[0].name
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.LABEL
+        ]
+
+        assert "_fn_algol_eval_thunk" in labels
+        assert result.procedure_signatures["_fn_algol_eval_thunk"] == 2
+        assert any(call.operands[0].name == "_fn_algol_eval_thunk" for call in calls)
 
     def test_rejects_array_element_by_name_until_relocating_thunks_exist(
         self,
@@ -307,6 +318,30 @@ class TestAlgolIrCompiler:
                     "begin integer result; integer array a[1:2]; "
                     "procedure put(x); integer x; begin x := 7 end; "
                     "put(a[1]); result := a[1] "
+                    "end"
+                )
+            )
+
+    def test_rejects_array_read_inside_expression_eval_thunk(self) -> None:
+        with pytest.raises(CompileError, match="array eval thunk"):
+            compile_algol(
+                parse_algol(
+                    "begin integer result; integer array a[1:2]; "
+                    "integer procedure id(x); integer x; begin id := x end; "
+                    "result := id(a[1] + 1) "
+                    "end"
+                )
+            )
+
+    def test_rejects_procedure_call_inside_expression_eval_thunk(self) -> None:
+        with pytest.raises(CompileError, match="procedure-call expression"):
+            compile_algol(
+                parse_algol(
+                    "begin integer result; "
+                    "integer procedure inc(n); value n; integer n; "
+                    "begin inc := n + 1 end; "
+                    "integer procedure id(x); integer x; begin id := x end; "
+                    "result := id(inc(4)) "
                     "end"
                 )
             )

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to this package will be documented in this file.
 - Executed scalar by-name actuals through caller-slot storage pointers, while
   preserving IR compile-stage diagnostics for expression and array-element
   actuals that still need full eval/store thunk descriptors.
+- Executed read-only integer expression actuals through tagged eval thunk
+  descriptors, including repeated formal reads that observe caller-frame
+  mutations between evaluations.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -24,9 +24,12 @@ in a bounded ALGOL heap segment, and every element access performs runtime
 bounds checks before touching WASM memory.
 Scalar by-name parameters now execute through the same WASM memory path by
 passing a storage pointer into the callee frame. A by-name formal assignment
-therefore writes back to the caller's scalar slot. Expression actuals and array
-element actuals remain guarded by IR compile-stage diagnostics until the full
-Phase 5 eval/store thunk descriptors are available.
+therefore writes back to the caller's scalar slot. Read-only integer expression
+actuals now compile as tagged eval thunk descriptors, so each by-name formal
+read re-evaluates the expression using the caller frame captured at the call
+site. Array-element actuals, expression thunks that read arrays, expression
+thunks that call procedures, and expression thunk stores remain guarded by IR
+compile-stage diagnostics until full Phase 5 store/helper coverage is available.
 
 ```python
 from algol_wasm_compiler import compile_source

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -44,22 +44,36 @@ class TestAlgolWasmCompiler:
             compile_source("begin integer result; result := false end")
         assert raised.value.stage == "type-check"
 
-    def test_by_name_expression_waits_for_eval_thunk_stage(self) -> None:
-        with pytest.raises(AlgolWasmError) as raised:
-            compile_source(
-                "begin integer result; "
-                "integer procedure id(x); integer x; begin id := x end; "
-                "result := id(1) "
-                "end"
-            )
-        assert raised.value.stage == "ir-compile"
-
     def test_array_element_by_name_waits_for_relocating_thunk_stage(self) -> None:
         with pytest.raises(AlgolWasmError) as raised:
             compile_source(
                 "begin integer result; integer array a[1:2]; "
                 "procedure put(x); integer x; begin x := 7 end; "
                 "put(a[1]); result := a[1] "
+                "end"
+            )
+        assert raised.value.stage == "ir-compile"
+
+    def test_array_read_expression_by_name_waits_for_eval_thunk_stage(self) -> None:
+        with pytest.raises(AlgolWasmError) as raised:
+            compile_source(
+                "begin integer result; integer array a[1:2]; "
+                "integer procedure id(x); integer x; begin id := x end; "
+                "result := id(a[1] + 1) "
+                "end"
+            )
+        assert raised.value.stage == "ir-compile"
+
+    def test_procedure_call_expression_by_name_waits_for_eval_thunk_stage(
+        self,
+    ) -> None:
+        with pytest.raises(AlgolWasmError) as raised:
+            compile_source(
+                "begin integer result; "
+                "integer procedure inc(n); value n; integer n; "
+                "begin inc := n + 1 end; "
+                "integer procedure id(x); integer x; begin id := x end; "
+                "result := id(inc(4)) "
                 "end"
             )
         assert raised.value.stage == "ir-compile"
@@ -138,6 +152,25 @@ class TestAlgolWasmCompiler:
             "end"
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [12]
+
+    def test_read_only_by_name_expression_re_evaluates_on_each_read(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "integer procedure probe(x); integer x; "
+            "begin probe := x; result := 10; probe := probe * 100 + x end; "
+            "result := 3; result := probe(result + 1) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [411]
+
+    def test_read_only_by_name_literal_expression_runs_through_eval_thunk(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "integer procedure id(x); integer x; begin id := x end; "
+            "result := id(7) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
 
     def test_nested_by_name_parameter_forwards_original_storage_pointer(self) -> None:
         result = compile_source(

--- a/code/specs/PL04-algol60-full-wasm-runtime.md
+++ b/code/specs/PL04-algol60-full-wasm-runtime.md
@@ -717,6 +717,18 @@ continue to reject read-only expression actuals and array-element actuals until
 the full eval/store descriptor helpers can re-evaluate or re-locate the actual
 on every formal access.
 
+Current Phase 5b lowering may add read-only integer expression eval descriptors
+without store helpers. Descriptor pointers should be distinguishable from the
+Phase 5a scalar storage pointers, for example by tagging aligned descriptor
+addresses before passing them through the by-name formal slot. A by-name formal
+read checks the tag: untagged values are scalar storage pointers, while tagged
+values dispatch to a bounded eval helper that receives the descriptor, restores
+the caller frame for the captured expression, and returns the freshly evaluated
+integer. Assigning to a tagged descriptor must fail until store helpers exist.
+This slice should still reject expression thunks that read array elements or
+invoke procedure calls unless their helper can perform the correct runtime
+unwind and lifetime handling.
+
 ### Required Diagnostics
 
 The phase is not complete unless unsupported forms fail before WASM lowering


### PR DESCRIPTION
## Summary

Implements the next ALGOL 60 Phase 5 slice for call-by-name:

- specifies the Phase 5b read-only eval descriptor boundary in PL04
- lowers read-only integer expression actuals to tagged eval thunk descriptors
- keeps scalar by-name storage pointers untagged and compatible with the prior write-back path
- generates `_fn_algol_eval_thunk` dispatch that re-evaluates captured expressions against the caller frame on every formal read
- reserves descriptor storage in one bounded call-scoped heap preflight, restores it after the call, and threads a hidden active thunk heap mark through procedure/eval helper calls for failure cleanup
- preserves targeted IR compile diagnostics for array-element actuals, expression thunks that read arrays, procedure-call expression thunks, and stores through expression descriptors

## Residual Risk / Scope

- Unknown thunk ids currently return `0`; descriptor corruption therefore fails open rather than trapping. This is unchanged in scope for this limited descriptor slice and should be tightened when the descriptor runtime grows validation/failure codes.
- The ALGOL procedure ABI now includes a hidden active thunk heap-mark argument after the static link. Future direct `CALL` emitters or external IR consumers must preserve that argument.
- Phase 5b is intentionally limited to read-only scalar/literal/arithmetic expression thunks. Array-reading thunks, procedure-calling thunks, and store-capable thunks remain unsupported until their unwind and lifetime handling is implemented.

## Verification

- `bash BUILD` in `code/packages/python/algol-ir-compiler`
- `bash BUILD` in `code/packages/python/algol-wasm-compiler`
- `.venv/bin/python -m ruff check src tests` in both changed Python packages
- `git diff --check origin/main...HEAD`
- security review sub-agent: initial heap-lifetime findings fixed; final review found no security issues