### PR TITLE
feat(algol): lower array element by-name thunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added — ALGOL 60 WASM Pipeline
+- Advanced PL04 Phase 5 call-by-name lowering with integer array-element
+  eval/store thunk descriptors, including repeated re-location of subscripted
+  actuals on formal reads and assignments.
+
 ### Added — TypeScript Port + JavaScript/TypeScript Grammars (PR #14)
 - **31 TypeScript packages** — complete port of the computing stack to TypeScript
 - `javascript.tokens` + `javascript.grammar` — JavaScript grammar definitions

--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -26,6 +26,9 @@ All notable changes to this package will be documented in this file.
 - Lowered read-only integer expression actuals to tagged eval thunk descriptors
   with bounded call-scoped heap allocation and generated eval dispatch that
   re-evaluates against the caller frame on every formal read.
+- Lowered integer array-element by-name actuals to tagged descriptors with
+  generated eval/store helpers that re-compute the element address on every
+  formal read or assignment.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -28,12 +28,14 @@ so assignments to the formal write back to the caller slot while value
 parameters still remain isolated copies. Read-only integer expression actuals
 lower to tagged, bounded eval thunk descriptors. Formal reads dispatch through a
 generated helper that re-evaluates the expression against the caller frame each
-time. Array-element actuals, expression thunks that read arrays, expression
-thunks that call procedures, and stores through expression thunks still raise
-targeted `CompileError` diagnostics until Phase 5 grows full eval/store helper
-coverage.
+time. Integer array-element actuals lower to tagged descriptors as well; formal
+reads re-compute the element address through the eval helper, and writable
+formals call a generated store helper that re-locates the element before storing
+the new value. Expression thunks that read arrays, expression thunks that call
+procedures, and stores through read-only expression thunks still raise targeted
+`CompileError` diagnostics until Phase 5 grows full expression-helper coverage.
 
-This phase keeps ALGOL frame memory and its 20-byte runtime state bounded to
+This phase keeps ALGOL frame memory and its 28-byte runtime state bounded to
 one 64 KiB WASM page, and keeps array descriptors plus element storage inside a
 separate 64 KiB heap segment. Larger semantic frame plans raise `CompileError`
 before the WASM data encoder can materialize the memory image, dynamic

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -46,7 +46,8 @@ _RUNTIME_STACK_LIMIT_OFFSET = 8
 _RUNTIME_HEAP_POINTER_OFFSET = 12
 _RUNTIME_HEAP_LIMIT_OFFSET = 16
 _RUNTIME_THUNK_HEAP_MARK_OFFSET = 20
-_RUNTIME_STATE_BYTES = 24
+_RUNTIME_THUNK_FAILURE_OFFSET = 24
+_RUNTIME_STATE_BYTES = 28
 _STATIC_LINK_PARAM_REG = 2
 _THUNK_HEAP_MARK_PARAM_REG = 3
 _VALUE_PARAM_BASE_REG = 4
@@ -66,10 +67,13 @@ _ARRAY_MAX_ELEMENTS = 4096
 _VALUE_MODE = "value"
 _NAME_MODE = "name"
 _THUNK_EVAL_LABEL = "_fn_algol_eval_thunk"
-_THUNK_DESCRIPTOR_SIZE = 8
+_THUNK_STORE_LABEL = "_fn_algol_store_thunk"
+_THUNK_DESCRIPTOR_SIZE = 12
 _THUNK_CODE_ID_OFFSET = 0
 _THUNK_CALLER_FRAME_OFFSET = 4
+_THUNK_FLAGS_OFFSET = 8
 _THUNK_DESCRIPTOR_TAG = 1
+_THUNK_FLAG_STORE = 1
 _MAX_EVAL_THUNKS = 256
 
 
@@ -113,11 +117,13 @@ class _FrameScope:
 
 @dataclass(frozen=True)
 class _EvalThunk:
-    """A read-only by-name expression captured for helper dispatch."""
+    """A by-name expression captured for helper dispatch."""
 
     thunk_id: int
     expression: ASTNode
     block_id: int
+    is_array_element: bool = False
+    store_capable: bool = False
 
 
 class AlgolIrCompiler:
@@ -230,6 +236,7 @@ class AlgolIrCompiler:
         }
         if self.has_by_name_parameters:
             self.procedure_signatures[_THUNK_EVAL_LABEL] = 2
+            self.procedure_signatures[_THUNK_STORE_LABEL] = 3
         self.frame_offsets = self._layout_frames(self.semantic_blocks)
         self.variable_slots = self._collect_variable_slots(self.semantic_blocks)
         self.legacy_variable_slots = self._collect_legacy_variable_slots(
@@ -295,6 +302,7 @@ class AlgolIrCompiler:
         self._store_runtime_state(_RUNTIME_HEAP_POINTER_OFFSET, self.heap_pointer_reg)
         self._store_runtime_state(_RUNTIME_HEAP_LIMIT_OFFSET, self.heap_limit_reg)
         self._store_runtime_state(_RUNTIME_THUNK_HEAP_MARK_OFFSET, _ZERO_REG)
+        self._store_runtime_state(_RUNTIME_THUNK_FAILURE_OFFSET, _ZERO_REG)
 
         block = _first_node(type_result.ast, "block")
         if block is None:
@@ -311,6 +319,7 @@ class AlgolIrCompiler:
         self._compile_procedures(type_result.semantic.procedures)
         if self.has_by_name_parameters:
             self._compile_eval_thunk_dispatcher()
+            self._compile_store_thunk_dispatcher()
 
         return CompileResult(
             program=self.program,
@@ -960,21 +969,23 @@ class AlgolIrCompiler:
                 f"procedure {procedure.name!r} expects "
                 f"{len(procedure.parameters)} argument(s), got {len(actuals)}"
             )
-        expression_actuals = [
+        thunk_actuals = [
             (index, argument, parameter)
             for index, (argument, parameter) in enumerate(
                 zip(actuals, procedure.parameters, strict=True)
             )
             if parameter.mode == _NAME_MODE
-            and _single_variable_expr(argument) is None
+            and self._requires_by_name_thunk_descriptor(argument)
         ]
-        for _, argument, parameter in expression_actuals:
-            if parameter.may_write:
+        for _, argument, parameter in thunk_actuals:
+            variable = _single_variable_expr(argument)
+            if variable is None and parameter.may_write:
                 raise CompileError(
                     f"by-name parameter {parameter.name!r} is assigned, but "
                     "expression actual has no store thunk lowering yet"
                 )
-            self._require_eval_thunk_expression(argument, parameter)
+            if variable is None:
+                self._require_eval_thunk_expression(argument, parameter)
 
         arguments: list[int | None] = [None] * len(actuals)
         for index, (argument, parameter) in enumerate(
@@ -984,8 +995,8 @@ class AlgolIrCompiler:
                 arguments[index] = self._compile_expr(argument, scope)
 
         descriptor_heap_mark = (
-            self._emit_reserve_eval_thunk_descriptors(len(expression_actuals), scope)
-            if expression_actuals
+            self._emit_reserve_eval_thunk_descriptors(len(thunk_actuals), scope)
+            if thunk_actuals
             else None
         )
         active_thunk_heap_mark = (
@@ -1000,7 +1011,7 @@ class AlgolIrCompiler:
         descriptor_offsets = {
             argument_index: descriptor_index * _THUNK_DESCRIPTOR_SIZE
             for descriptor_index, (argument_index, _, _) in enumerate(
-                expression_actuals
+                thunk_actuals
             )
         }
         for index, (argument, parameter) in enumerate(
@@ -1041,6 +1052,10 @@ class AlgolIrCompiler:
             )
         return result
 
+    def _requires_by_name_thunk_descriptor(self, argument: ASTNode) -> bool:
+        variable = _single_variable_expr(argument)
+        return variable is None or bool(_variable_subscripts(variable))
+
     def _compile_by_name_actual_pointer(
         self,
         argument: ASTNode,
@@ -1061,9 +1076,15 @@ class AlgolIrCompiler:
                 descriptor,
             )
         if _variable_subscripts(variable):
-            raise CompileError(
-                f"by-name parameter {parameter.name!r} received an array element "
-                "actual; re-evaluating element thunk lowering is not implemented yet"
+            if descriptor is None:
+                raise CompileError(
+                    "missing reserved eval thunk descriptor for by-name array element"
+                )
+            return self._compile_array_element_thunk_actual(
+                variable,
+                parameter,
+                scope,
+                descriptor,
             )
         name = _variable_name(variable)
         if name is None:
@@ -1079,6 +1100,29 @@ class AlgolIrCompiler:
         descriptor: int,
     ) -> int:
         thunk = self._register_eval_thunk(argument, scope.block_id)
+        self._emit_write_eval_thunk_descriptor(thunk, scope, descriptor)
+        tagged_descriptor = self._fresh_reg()
+        self._emit(
+            IrOp.ADD_IMM,
+            IrRegister(tagged_descriptor),
+            IrRegister(descriptor),
+            IrImmediate(_THUNK_DESCRIPTOR_TAG),
+        )
+        return tagged_descriptor
+
+    def _compile_array_element_thunk_actual(
+        self,
+        variable: ASTNode,
+        parameter: ProcedureParameter,
+        scope: _FrameScope,
+        descriptor: int,
+    ) -> int:
+        thunk = self._register_eval_thunk(
+            variable,
+            scope.block_id,
+            is_array_element=True,
+            store_capable=parameter.may_write,
+        )
         self._emit_write_eval_thunk_descriptor(thunk, scope, descriptor)
         tagged_descriptor = self._fresh_reg()
         self._emit(
@@ -1115,7 +1159,14 @@ class AlgolIrCompiler:
                 "is not implemented yet"
             )
 
-    def _register_eval_thunk(self, argument: ASTNode, block_id: int) -> _EvalThunk:
+    def _register_eval_thunk(
+        self,
+        argument: ASTNode,
+        block_id: int,
+        *,
+        is_array_element: bool = False,
+        store_capable: bool = False,
+    ) -> _EvalThunk:
         if len(self.eval_thunks) >= _MAX_EVAL_THUNKS:
             raise CompileError(
                 "ALGOL program requires more than "
@@ -1125,6 +1176,8 @@ class AlgolIrCompiler:
             thunk_id=len(self.eval_thunks) + 1,
             expression=argument,
             block_id=block_id,
+            is_array_element=is_array_element,
+            store_capable=store_capable,
         )
         self.eval_thunks.append(thunk)
         return thunk
@@ -1184,6 +1237,11 @@ class AlgolIrCompiler:
             base_reg=descriptor,
             offset=_THUNK_CALLER_FRAME_OFFSET,
         )
+        self._store_word_const(
+            descriptor,
+            _THUNK_FLAGS_OFFSET,
+            _THUNK_FLAG_STORE if thunk.store_capable else 0,
+        )
 
     def _compile_procedures(
         self, procedures: list[ProcedureDescriptor]
@@ -1229,12 +1287,89 @@ class AlgolIrCompiler:
                 parent=None,
                 active_thunk_heap_mark_reg=active_thunk_heap_mark,
             )
-            value = self._compile_expr(thunk.expression, thunk_scope)
+            if thunk.is_array_element:
+                data_pointer, byte_offset = self._compile_array_element_address(
+                    thunk.expression,
+                    thunk_scope,
+                    role="read",
+                    helper_failure=True,
+                )
+                value = self._fresh_reg()
+                self._emit(
+                    IrOp.LOAD_WORD,
+                    IrRegister(value),
+                    IrRegister(data_pointer),
+                    IrRegister(byte_offset),
+                )
+            else:
+                value = self._compile_expr(thunk.expression, thunk_scope)
             self._copy_reg(dst=_RESULT_REG, src=value)
             self._emit(IrOp.RET)
             self._emit(IrOp.JUMP, IrLabel(end_label))
             self._label(else_label)
             self._label(end_label)
+        self._emit(IrOp.LOAD_IMM, IrRegister(_RESULT_REG), IrImmediate(0))
+        self._emit(IrOp.RET)
+
+    def _compile_store_thunk_dispatcher(self) -> None:
+        self._label(_THUNK_STORE_LABEL)
+        descriptor = _STATIC_LINK_PARAM_REG
+        active_thunk_heap_mark = _THUNK_HEAP_MARK_PARAM_REG
+        value_reg = _VALUE_PARAM_BASE_REG
+        code_id = self._fresh_reg()
+        caller_frame = self._fresh_reg()
+        self._emit(
+            IrOp.LOAD_WORD,
+            IrRegister(code_id),
+            IrRegister(descriptor),
+            IrRegister(self._const_reg(_THUNK_CODE_ID_OFFSET)),
+        )
+        self._emit(
+            IrOp.LOAD_WORD,
+            IrRegister(caller_frame),
+            IrRegister(descriptor),
+            IrRegister(self._const_reg(_THUNK_CALLER_FRAME_OFFSET)),
+        )
+        for thunk in self.eval_thunks:
+            if not thunk.store_capable:
+                continue
+            index = self.if_count
+            self.if_count += 1
+            else_label = f"if_{index}_else"
+            end_label = f"if_{index}_end"
+            matches = self._fresh_reg()
+            self._emit(
+                IrOp.CMP_EQ,
+                IrRegister(matches),
+                IrRegister(code_id),
+                IrRegister(self._const_reg(thunk.thunk_id)),
+            )
+            self._emit(IrOp.BRANCH_Z, IrRegister(matches), IrLabel(else_label))
+            thunk_scope = _FrameScope(
+                semantic_block=self.semantic_blocks_by_id[thunk.block_id],
+                frame_base_reg=caller_frame,
+                heap_mark_reg=None,
+                parent=None,
+                active_thunk_heap_mark_reg=active_thunk_heap_mark,
+            )
+            data_pointer, byte_offset = self._compile_array_element_address(
+                thunk.expression,
+                thunk_scope,
+                role="write",
+                helper_failure=True,
+            )
+            self._emit(
+                IrOp.STORE_WORD,
+                IrRegister(value_reg),
+                IrRegister(data_pointer),
+                IrRegister(byte_offset),
+            )
+            self._emit(IrOp.LOAD_IMM, IrRegister(_RESULT_REG), IrImmediate(0))
+            self._emit(IrOp.RET)
+            self._emit(IrOp.JUMP, IrLabel(end_label))
+            self._label(else_label)
+            self._label(end_label)
+        self._store_runtime_state(_RUNTIME_THUNK_FAILURE_OFFSET, self._const_reg(1))
         self._emit(IrOp.LOAD_IMM, IrRegister(_RESULT_REG), IrImmediate(0))
         self._emit(IrOp.RET)
 
@@ -1321,6 +1456,7 @@ class AlgolIrCompiler:
         scope: _FrameScope,
         *,
         role: str,
+        helper_failure: bool = False,
     ) -> tuple[int, int]:
         name = _variable_head_name(variable)
         if name is None:
@@ -1377,14 +1513,20 @@ class AlgolIrCompiler:
                 IrRegister(lower),
                 IrRegister(subscript_reg),
             )
-            self._emit_runtime_failure_guard(below, scope)
+            if helper_failure:
+                self._emit_helper_runtime_failure_guard(below, scope)
+            else:
+                self._emit_runtime_failure_guard(below, scope)
             self._emit(
                 IrOp.CMP_GT,
                 IrRegister(above),
                 IrRegister(subscript_reg),
                 IrRegister(upper),
             )
-            self._emit_runtime_failure_guard(above, scope)
+            if helper_failure:
+                self._emit_helper_runtime_failure_guard(above, scope)
+            else:
+                self._emit_runtime_failure_guard(above, scope)
             self._emit(
                 IrOp.LOAD_WORD,
                 IrRegister(stride),
@@ -1475,6 +1617,7 @@ class AlgolIrCompiler:
             IrRegister(descriptor),
             IrRegister(active_thunk_heap_mark),
         )
+        self._emit_propagate_thunk_failure(scope)
         self._copy_reg(dst=dst, src=_RESULT_REG)
         self._emit(IrOp.JUMP, IrLabel(end_label))
         self._label(storage_label)
@@ -1522,13 +1665,69 @@ class AlgolIrCompiler:
         pointer = self._emit_reference_pointer(reference, scope)
         if self._is_by_name_reference(reference):
             tag = self._fresh_reg()
+            index = self.if_count
+            self.if_count += 1
+            storage_label = f"if_{index}_else"
+            end_label = f"if_{index}_end"
             self._emit(
                 IrOp.AND_IMM,
                 IrRegister(tag),
                 IrRegister(pointer),
                 IrImmediate(_THUNK_DESCRIPTOR_TAG),
             )
-            self._emit_runtime_failure_guard(tag, scope)
+            self._emit(IrOp.BRANCH_Z, IrRegister(tag), IrLabel(storage_label))
+            descriptor = self._fresh_reg()
+            self._emit(
+                IrOp.ADD_IMM,
+                IrRegister(descriptor),
+                IrRegister(pointer),
+                IrImmediate(-_THUNK_DESCRIPTOR_TAG),
+            )
+            flags = self._fresh_reg()
+            has_store = self._fresh_reg()
+            no_store = self._fresh_reg()
+            self._emit(
+                IrOp.LOAD_WORD,
+                IrRegister(flags),
+                IrRegister(descriptor),
+                IrRegister(self._const_reg(_THUNK_FLAGS_OFFSET)),
+            )
+            self._emit(
+                IrOp.AND_IMM,
+                IrRegister(has_store),
+                IrRegister(flags),
+                IrImmediate(_THUNK_FLAG_STORE),
+            )
+            self._emit(
+                IrOp.CMP_EQ,
+                IrRegister(no_store),
+                IrRegister(has_store),
+                IrRegister(_ZERO_REG),
+            )
+            self._emit_runtime_failure_guard(no_store, scope)
+            active_thunk_heap_mark = (
+                scope.active_thunk_heap_mark_reg
+                if scope.active_thunk_heap_mark_reg is not None
+                else self._const_reg(0)
+            )
+            self._emit(
+                IrOp.CALL,
+                IrLabel(_THUNK_STORE_LABEL),
+                IrRegister(descriptor),
+                IrRegister(active_thunk_heap_mark),
+                IrRegister(value_reg),
+            )
+            self._emit_propagate_thunk_failure(scope)
+            self._emit(IrOp.JUMP, IrLabel(end_label))
+            self._label(storage_label)
+            self._emit(
+                IrOp.STORE_WORD,
+                IrRegister(value_reg),
+                IrRegister(pointer),
+                IrRegister(self._const_reg(0)),
+            )
+            self._label(end_label)
+            return
         self._emit(
             IrOp.STORE_WORD,
             IrRegister(value_reg),
@@ -1708,6 +1907,30 @@ class AlgolIrCompiler:
         self._emit(IrOp.JUMP, IrLabel(end_label))
         self._label(else_label)
         self._label(end_label)
+
+    def _emit_helper_runtime_failure_guard(
+        self,
+        failed_reg: int,
+        scope: _FrameScope,
+    ) -> None:
+        index = self.if_count
+        self.if_count += 1
+        else_label = f"if_{index}_else"
+        end_label = f"if_{index}_end"
+        self._emit(IrOp.BRANCH_Z, IrRegister(failed_reg), IrLabel(else_label))
+        self._store_runtime_state(_RUNTIME_THUNK_FAILURE_OFFSET, self._const_reg(1))
+        self._emit(IrOp.LOAD_IMM, IrRegister(_RESULT_REG), IrImmediate(0))
+        self._emit_restore_active_thunk_heap_mark(scope)
+        self._emit(IrOp.RET)
+        self._emit(IrOp.JUMP, IrLabel(end_label))
+        self._label(else_label)
+        self._label(end_label)
+
+    def _emit_propagate_thunk_failure(self, scope: _FrameScope) -> None:
+        failed = self._fresh_reg()
+        self._load_runtime_state(_RUNTIME_THUNK_FAILURE_OFFSET, failed)
+        self._store_runtime_state(_RUNTIME_THUNK_FAILURE_OFFSET, _ZERO_REG)
+        self._emit_runtime_failure_guard(failed, scope)
 
     def _emit_restore_active_thunk_heap_mark(self, scope: _FrameScope) -> None:
         mark_reg = scope.active_thunk_heap_mark_reg

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -168,7 +168,7 @@ class TestAlgolIrCompiler:
                 )
         )
 
-        with pytest.raises(CompileError, match="frame bytes plus 24 runtime bytes"):
+        with pytest.raises(CompileError, match="frame bytes plus 28 runtime bytes"):
             compile_algol(typed)
 
     def test_compiles_integer_array_descriptor_and_element_accesses(self) -> None:
@@ -309,18 +309,35 @@ class TestAlgolIrCompiler:
         assert result.procedure_signatures["_fn_algol_eval_thunk"] == 2
         assert any(call.operands[0].name == "_fn_algol_eval_thunk" for call in calls)
 
-    def test_rejects_array_element_by_name_until_relocating_thunks_exist(
+    def test_compiles_array_element_by_name_eval_and_store_thunks(
         self,
     ) -> None:
-        with pytest.raises(CompileError, match="array element"):
-            compile_algol(
-                parse_algol(
-                    "begin integer result; integer array a[1:2]; "
-                    "procedure put(x); integer x; begin x := 7 end; "
-                    "put(a[1]); result := a[1] "
-                    "end"
-                )
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; integer array a[1:2]; "
+                "procedure put(x); integer x; begin x := x + 1 end; "
+                "a[1] := 6; "
+                "put(a[1]); result := a[1] "
+                "end"
             )
+        )
+        labels = [
+            instruction.operands[0].name
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.LABEL
+        ]
+        calls = [
+            instruction.operands[0].name
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.CALL
+        ]
+
+        assert "_fn_algol_eval_thunk" in labels
+        assert "_fn_algol_store_thunk" in labels
+        assert "_fn_algol_eval_thunk" in calls
+        assert "_fn_algol_store_thunk" in calls
+        assert result.procedure_signatures["_fn_algol_eval_thunk"] == 2
+        assert result.procedure_signatures["_fn_algol_store_thunk"] == 3
 
     def test_rejects_array_read_inside_expression_eval_thunk(self) -> None:
         with pytest.raises(CompileError, match="array eval thunk"):

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -19,6 +19,9 @@ All notable changes to this package will be documented in this file.
 - Executed read-only integer expression actuals through tagged eval thunk
   descriptors, including repeated formal reads that observe caller-frame
   mutations between evaluations.
+- Executed integer array-element by-name actuals through eval/store thunk
+  helpers so repeated formal reads and assignments re-locate the current
+  element, including Jensen-style index mutation between formal uses.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -27,9 +27,12 @@ passing a storage pointer into the callee frame. A by-name formal assignment
 therefore writes back to the caller's scalar slot. Read-only integer expression
 actuals now compile as tagged eval thunk descriptors, so each by-name formal
 read re-evaluates the expression using the caller frame captured at the call
-site. Array-element actuals, expression thunks that read arrays, expression
-thunks that call procedures, and expression thunk stores remain guarded by IR
-compile-stage diagnostics until full Phase 5 store/helper coverage is available.
+site. Integer array-element by-name actuals now compile as tagged descriptors
+with eval/store helpers, so reads and assignments re-compute the current element
+address every time the formal is used. Expression thunks that read arrays,
+expression thunks that call procedures, and expression thunk stores remain
+guarded by IR compile-stage diagnostics until full Phase 5 expression-helper
+coverage is available.
 
 ```python
 from algol_wasm_compiler import compile_source

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -44,16 +44,6 @@ class TestAlgolWasmCompiler:
             compile_source("begin integer result; result := false end")
         assert raised.value.stage == "type-check"
 
-    def test_array_element_by_name_waits_for_relocating_thunk_stage(self) -> None:
-        with pytest.raises(AlgolWasmError) as raised:
-            compile_source(
-                "begin integer result; integer array a[1:2]; "
-                "procedure put(x); integer x; begin x := 7 end; "
-                "put(a[1]); result := a[1] "
-                "end"
-            )
-        assert raised.value.stage == "ir-compile"
-
     def test_array_read_expression_by_name_waits_for_eval_thunk_stage(self) -> None:
         with pytest.raises(AlgolWasmError) as raised:
             compile_source(
@@ -152,6 +142,46 @@ class TestAlgolWasmCompiler:
             "end"
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [12]
+
+    def test_array_element_by_name_parameter_assignment_writes_back(self) -> None:
+        result = compile_source(
+            "begin integer result; integer array a[1:2]; "
+            "procedure put(x); integer x; begin x := 7 end; "
+            "put(a[1]); result := a[1] "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
+    def test_array_element_by_name_relocates_on_each_access(self) -> None:
+        result = compile_source(
+            "begin integer result, i; integer array a[1:2]; "
+            "procedure bump(x); integer x; "
+            "begin x := x + 1; i := 2; x := x + 1 end; "
+            "a[1] := 10; a[2] := 20; i := 1; "
+            "bump(a[i]); result := a[1] * 100 + a[2] "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [1121]
+
+    def test_read_only_array_element_by_name_relocates_on_each_read(self) -> None:
+        result = compile_source(
+            "begin integer result, i; integer array a[1:2]; "
+            "integer procedure probe(x); integer x; "
+            "begin probe := x; i := 2; probe := probe * 100 + x end; "
+            "a[1] := 3; a[2] := 8; i := 1; "
+            "result := probe(a[i]) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [308]
+
+    def test_array_element_by_name_bounds_failure_propagates_from_eval(self) -> None:
+        result = compile_source(
+            "begin integer result, i; integer array a[1:2]; "
+            "integer procedure id(x); integer x; begin id := x end; "
+            "i := 3; result := id(a[i]) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [0]
 
     def test_read_only_by_name_expression_re_evaluates_on_each_read(self) -> None:
         result = compile_source(

--- a/code/specs/PL04-algol60-full-wasm-runtime.md
+++ b/code/specs/PL04-algol60-full-wasm-runtime.md
@@ -729,6 +729,14 @@ This slice should still reject expression thunks that read array elements or
 invoke procedure calls unless their helper can perform the correct runtime
 unwind and lifetime handling.
 
+Current Phase 5c lowering may add integer array-element descriptors for by-name
+actuals. Array-element descriptors reuse the tagged descriptor path, carry a
+store-capable flag only when the formal may be assigned, and dispatch reads
+through the eval helper. Writable formals dispatch assignments through a store
+helper that re-evaluates the original designator, including current subscript
+values, before storing. Helper-side bounds failures must be reported back to the
+calling procedure so the normal frame and thunk-region unwinding still runs.
+
 ### Required Diagnostics
 
 The phase is not complete unless unsupported forms fail before WASM lowering


### PR DESCRIPTION
## Summary
- lower ALGOL integer array-element by-name actuals as tagged thunk descriptors
- add eval/store helper dispatch for repeated element re-location on formal reads and assignments
- propagate helper-side bounds failures back into the caller unwind path
- update PL04 Phase 5c docs, package READMEs, and changelogs

## Tests
- bash BUILD (code/packages/python/algol-ir-compiler)
- bash BUILD (code/packages/python/algol-wasm-compiler)
- ruff check code/packages/python/algol-ir-compiler/src code/packages/python/algol-ir-compiler/tests code/packages/python/algol-wasm-compiler/tests

## Security review
- verified thunk descriptors remain call-scoped with preflight heap reservation and active thunk mark restoration
- verified stores through read-only expression descriptors fail before helper dispatch
- verified helper bounds failures set a thunk failure flag that the caller consumes through the normal runtime failure/unwind path