### PR TITLE
Add embeddable TCP response mailbox

### DIFF
--- a/code/packages/rust/embeddable-tcp-server/CHANGELOG.md
+++ b/code/packages/rust/embeddable-tcp-server/CHANGELOG.md
@@ -17,3 +17,6 @@ All notable changes to this package will be documented in this file.
 - Updated the Mini Redis integration so Rust sends only opaque TCP byte jobs
   and writes opaque byte frames. The Python worker owns RESP framing,
   per-stream selected database state, and RESP response assembly.
+- Added a mailbox-style asynchronous worker path where TCP callbacks send
+  request jobs and return immediately while a response task posts worker output
+  back to the TCP runtime.

--- a/code/packages/rust/embeddable-tcp-server/README.md
+++ b/code/packages/rust/embeddable-tcp-server/README.md
@@ -23,6 +23,7 @@ client
   -> generic JobRequest<TcpBytesPayload>
   -> embedded language/application worker
   -> generic JobResponse<TcpWriteFrame>
+  -> TCP return mailbox
   -> Rust socket write
 ```
 
@@ -32,17 +33,20 @@ line. The important part is that the envelope comes from
 Application-specific data stays inside payload structs.
 
 The package tests use a Python Mini Redis worker as one example application:
-RESP bytes enter over TCP, Rust forwards opaque byte jobs, Python queues and
-parses RESP, Python assembles RESP replies, and Rust writes the returned opaque
-bytes. That proves the embeddable server with a real language worker without
-making Python, Redis, or RESP part of the crate's public identity.
+RESP bytes enter over TCP, Rust forwards opaque byte jobs, and the TCP callback
+immediately returns to the reactor. Python queues and parses RESP, Python
+assembles RESP replies, a Rust response task posts those replies to the TCP
+return mailbox, and the reactor writes the returned opaque bytes. That proves
+the embeddable server with a real language worker without making Python, Redis,
+or RESP part of the crate's public identity.
 
 ## Current Limitations
 
-- The worker call is synchronous inside the TCP read callback.
 - One worker process handles all delegated jobs.
 - The worker protocol uses the JSON-line `generic-job-protocol` codec over
   stdio for debuggability, not throughput.
+- Worker responses are asynchronous with respect to TCP reads, but still flow
+  through one stdio response reader.
 - The current payload structs are the first raw-byte transport shape; a later
   crate should make those stable for all language bridges.
 - This validates the runtime seam; it is not the final high-performance

--- a/code/packages/rust/embeddable-tcp-server/src/lib.rs
+++ b/code/packages/rust/embeddable-tcp-server/src/lib.rs
@@ -17,13 +17,15 @@
 //! through the generic job runtime so worker completion can happen
 //! asynchronously without blocking the reactor.
 
+use std::collections::BTreeMap;
 use std::fmt;
 use std::io::{self, BufRead, BufReader, Write};
 use std::marker::PhantomData;
 use std::net::SocketAddr;
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
+use std::thread;
 
 use generic_job_protocol::{
     decode_response_json_line, encode_request_json_line, JobCodecError, JobMetadata, JobRequest,
@@ -31,7 +33,7 @@ use generic_job_protocol::{
 };
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use tcp_runtime::{PlatformError, StopHandle, TcpHandlerResult};
+use tcp_runtime::{ConnectionId, PlatformError, StopHandle, TcpHandlerResult, TcpMailbox};
 use tcp_runtime::{TcpConnectionInfo, TcpRuntime, TcpRuntimeOptions};
 
 #[cfg(any(
@@ -103,6 +105,134 @@ pub struct StdioJobWorker<Request, Response> {
     next_job_id: u64,
     _request: PhantomData<Request>,
     _response: PhantomData<Response>,
+}
+
+pub struct StdioJobSubmitter<Request> {
+    stdin: Arc<Mutex<ChildStdin>>,
+    routes: Arc<Mutex<BTreeMap<String, ConnectionId>>>,
+    next_job_id: Arc<AtomicU64>,
+    _request: PhantomData<Request>,
+}
+
+impl<Request> Clone for StdioJobSubmitter<Request> {
+    fn clone(&self) -> Self {
+        Self {
+            stdin: Arc::clone(&self.stdin),
+            routes: Arc::clone(&self.routes),
+            next_job_id: Arc::clone(&self.next_job_id),
+            _request: PhantomData,
+        }
+    }
+}
+
+impl<Request> StdioJobSubmitter<Request>
+where
+    Request: Serialize,
+{
+    pub fn submit(
+        &self,
+        connection_id: ConnectionId,
+        payload: Request,
+    ) -> Result<String, WorkerError> {
+        self.submit_with_metadata(connection_id, JobMetadata::default(), payload)
+    }
+
+    pub fn submit_with_metadata(
+        &self,
+        connection_id: ConnectionId,
+        metadata: JobMetadata,
+        payload: Request,
+    ) -> Result<String, WorkerError> {
+        let id = format!("job-{}", self.next_job_id.fetch_add(1, Ordering::SeqCst));
+        let request = JobRequest::new(id.clone(), payload).with_metadata(metadata);
+        let encoded = encode_request_json_line(&request)?;
+
+        self.routes
+            .lock()
+            .expect("stdio worker route table mutex poisoned")
+            .insert(id.clone(), connection_id);
+
+        let write_result = {
+            let mut stdin = self
+                .stdin
+                .lock()
+                .expect("stdio worker stdin mutex poisoned");
+            stdin
+                .write_all(encoded.as_bytes())
+                .and_then(|_| stdin.flush())
+        };
+
+        if let Err(error) = write_result {
+            self.routes
+                .lock()
+                .expect("stdio worker route table mutex poisoned")
+                .remove(&id);
+            return Err(error.into());
+        }
+
+        Ok(id)
+    }
+}
+
+pub struct TcpMailboxFrame {
+    pub writes: Vec<Vec<u8>>,
+    pub close: bool,
+}
+
+impl TcpMailboxFrame {
+    pub fn write(bytes: impl Into<Vec<u8>>) -> Self {
+        Self {
+            writes: vec![bytes.into()],
+            close: false,
+        }
+    }
+
+    pub fn write_many(writes: impl Into<Vec<Vec<u8>>>) -> Self {
+        Self {
+            writes: writes.into(),
+            close: false,
+        }
+    }
+
+    pub fn close() -> Self {
+        Self {
+            writes: Vec::new(),
+            close: true,
+        }
+    }
+
+    pub fn write_and_close(bytes: impl Into<Vec<u8>>) -> Self {
+        Self {
+            writes: vec![bytes.into()],
+            close: true,
+        }
+    }
+
+    fn flatten_writes(self) -> Vec<u8> {
+        let total = self.writes.iter().map(Vec::len).sum();
+        let mut output = Vec::with_capacity(total);
+        for write in self.writes {
+            output.extend(write);
+        }
+        output
+    }
+}
+
+struct WorkerProcessGuard {
+    child: Arc<Mutex<Child>>,
+    response_thread: Option<thread::JoinHandle<()>>,
+}
+
+impl Drop for WorkerProcessGuard {
+    fn drop(&mut self) {
+        if let Ok(mut child) = self.child.lock() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        if let Some(thread) = self.response_thread.take() {
+            let _ = thread.join();
+        }
+    }
 }
 
 impl<Request, Response> StdioJobWorker<Request, Response>
@@ -237,6 +367,7 @@ impl From<JobCodecError> for WorkerError {
 #[derive(Clone)]
 pub struct EmbeddableTcpServer<State> {
     runtime: Arc<Mutex<Option<PlatformTcpRuntime<State>>>>,
+    _worker_process: Arc<Mutex<Option<WorkerProcessGuard>>>,
     local_addr: SocketAddr,
     stop_handle: StopHandle,
     serving: Arc<AtomicBool>,
@@ -277,6 +408,58 @@ where
 
         Ok(Self {
             runtime: Arc::new(Mutex::new(Some(runtime))),
+            _worker_process: Arc::new(Mutex::new(None)),
+            local_addr,
+            stop_handle,
+            serving: Arc::new(AtomicBool::new(false)),
+        })
+    }
+
+    pub fn new_mailbox<Request, Response, Init, Handler, Close, MapResponse>(
+        options: EmbeddableTcpServerOptions,
+        init: Init,
+        handler: Handler,
+        on_close: Close,
+        map_response: MapResponse,
+    ) -> io::Result<Self>
+    where
+        Request: Serialize + Send + Sync + 'static,
+        Response: DeserializeOwned + Send + 'static,
+        Init: Fn(TcpConnectionInfo) -> State + Send + Sync + 'static,
+        Handler: Fn(
+                TcpConnectionInfo,
+                &mut State,
+                &[u8],
+                &StdioJobSubmitter<Request>,
+            ) -> TcpHandlerResult
+            + Send
+            + Sync
+            + 'static,
+        Close: Fn(TcpConnectionInfo, State) + Send + Sync + 'static,
+        MapResponse: Fn(Response) -> Result<TcpMailboxFrame, WorkerError> + Send + Sync + 'static,
+    {
+        let (child, stdin, stdout) = spawn_worker_process(&options.worker)?;
+        let routes = Arc::new(Mutex::new(BTreeMap::new()));
+        let submitter = StdioJobSubmitter {
+            stdin,
+            routes: Arc::clone(&routes),
+            next_job_id: Arc::new(AtomicU64::new(1)),
+            _request: PhantomData,
+        };
+        let runtime = build_runtime_mailbox(&options, submitter, init, handler, on_close)
+            .map_err(into_io_error)?;
+        let local_addr = runtime.local_addr();
+        let stop_handle = runtime.stop_handle();
+        let mailbox = runtime.mailbox();
+        let response_thread =
+            spawn_response_router(stdout, routes, mailbox, Arc::new(map_response));
+
+        Ok(Self {
+            runtime: Arc::new(Mutex::new(Some(runtime))),
+            _worker_process: Arc::new(Mutex::new(Some(WorkerProcessGuard {
+                child,
+                response_thread: Some(response_thread),
+            }))),
             local_addr,
             stop_handle,
             serving: Arc::new(AtomicBool::new(false)),
@@ -313,6 +496,86 @@ where
     pub fn is_running(&self) -> bool {
         self.serving.load(Ordering::SeqCst)
     }
+}
+
+fn spawn_worker_process(
+    command: &WorkerCommand,
+) -> io::Result<(
+    Arc<Mutex<Child>>,
+    Arc<Mutex<ChildStdin>>,
+    BufReader<ChildStdout>,
+)> {
+    let mut child = Command::new(&command.program)
+        .args(&command.args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()?;
+
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "worker did not expose stdin"))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "worker did not expose stdout"))?;
+
+    Ok((
+        Arc::new(Mutex::new(child)),
+        Arc::new(Mutex::new(stdin)),
+        BufReader::new(stdout),
+    ))
+}
+
+fn spawn_response_router<Response, MapResponse>(
+    mut stdout: BufReader<ChildStdout>,
+    routes: Arc<Mutex<BTreeMap<String, ConnectionId>>>,
+    mailbox: TcpMailbox,
+    map_response: Arc<MapResponse>,
+) -> thread::JoinHandle<()>
+where
+    Response: DeserializeOwned + Send + 'static,
+    MapResponse: Fn(Response) -> Result<TcpMailboxFrame, WorkerError> + Send + Sync + 'static,
+{
+    thread::spawn(move || loop {
+        let mut line = String::new();
+        match stdout.read_line(&mut line) {
+            Ok(0) => break,
+            Ok(_) => {}
+            Err(_) => break,
+        }
+
+        let response: JobResponse<Response> = match decode_response_json_line(line.trim_end()) {
+            Ok(response) => response,
+            Err(_) => continue,
+        };
+        let Some(connection_id) = routes
+            .lock()
+            .expect("stdio worker route table mutex poisoned")
+            .remove(&response.id)
+        else {
+            continue;
+        };
+
+        match response.result {
+            JobResult::Ok { payload } => match map_response(payload) {
+                Ok(frame) => {
+                    let close = frame.close;
+                    let bytes = frame.flatten_writes();
+                    if close {
+                        mailbox.send_and_close(connection_id, bytes);
+                    } else if !bytes.is_empty() {
+                        mailbox.send(connection_id, bytes);
+                    }
+                }
+                Err(_) => mailbox.close(connection_id),
+            },
+            JobResult::Error { .. } | JobResult::Cancelled { .. } | JobResult::TimedOut { .. } => {
+                mailbox.close(connection_id)
+            }
+        }
+    })
 }
 
 fn validate_response_id<Response>(
@@ -377,6 +640,40 @@ where
     )
 }
 
+#[cfg(any(
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly"
+))]
+fn build_runtime_mailbox<State, Request, Init, Handler, Close>(
+    options: &EmbeddableTcpServerOptions,
+    submitter: StdioJobSubmitter<Request>,
+    init: Init,
+    handler: Handler,
+    on_close: Close,
+) -> Result<PlatformTcpRuntime<State>, PlatformError>
+where
+    State: Send + 'static,
+    Request: Serialize + Send + Sync + 'static,
+    Init: Fn(TcpConnectionInfo) -> State + Send + Sync + 'static,
+    Handler: Fn(TcpConnectionInfo, &mut State, &[u8], &StdioJobSubmitter<Request>) -> TcpHandlerResult
+        + Send
+        + Sync
+        + 'static,
+    Close: Fn(TcpConnectionInfo, State) + Send + Sync + 'static,
+{
+    let host = options.host.clone();
+    TcpRuntime::bind_kqueue_with_state(
+        (host.as_str(), options.port),
+        runtime_options(options),
+        init,
+        move |info, state, bytes| handler(info, state, bytes, &submitter),
+        on_close,
+    )
+}
+
 #[cfg(target_os = "linux")]
 fn build_runtime<State, Request, Response, Init, Handler, Close>(
     options: &EmbeddableTcpServerOptions,
@@ -414,6 +711,34 @@ where
     )
 }
 
+#[cfg(target_os = "linux")]
+fn build_runtime_mailbox<State, Request, Init, Handler, Close>(
+    options: &EmbeddableTcpServerOptions,
+    submitter: StdioJobSubmitter<Request>,
+    init: Init,
+    handler: Handler,
+    on_close: Close,
+) -> Result<PlatformTcpRuntime<State>, PlatformError>
+where
+    State: Send + 'static,
+    Request: Serialize + Send + Sync + 'static,
+    Init: Fn(TcpConnectionInfo) -> State + Send + Sync + 'static,
+    Handler: Fn(TcpConnectionInfo, &mut State, &[u8], &StdioJobSubmitter<Request>) -> TcpHandlerResult
+        + Send
+        + Sync
+        + 'static,
+    Close: Fn(TcpConnectionInfo, State) + Send + Sync + 'static,
+{
+    let host = options.host.clone();
+    TcpRuntime::bind_epoll_with_state(
+        (host.as_str(), options.port),
+        runtime_options(options),
+        init,
+        move |info, state, bytes| handler(info, state, bytes, &submitter),
+        on_close,
+    )
+}
+
 #[cfg(target_os = "windows")]
 fn build_runtime<State, Request, Response, Init, Handler, Close>(
     options: &EmbeddableTcpServerOptions,
@@ -447,6 +772,34 @@ where
             let mut worker = worker.lock().expect("embedded worker mutex poisoned");
             handler(info, state, bytes, &mut worker)
         },
+        on_close,
+    )
+}
+
+#[cfg(target_os = "windows")]
+fn build_runtime_mailbox<State, Request, Init, Handler, Close>(
+    options: &EmbeddableTcpServerOptions,
+    submitter: StdioJobSubmitter<Request>,
+    init: Init,
+    handler: Handler,
+    on_close: Close,
+) -> Result<PlatformTcpRuntime<State>, PlatformError>
+where
+    State: Send + 'static,
+    Request: Serialize + Send + Sync + 'static,
+    Init: Fn(TcpConnectionInfo) -> State + Send + Sync + 'static,
+    Handler: Fn(TcpConnectionInfo, &mut State, &[u8], &StdioJobSubmitter<Request>) -> TcpHandlerResult
+        + Send
+        + Sync
+        + 'static,
+    Close: Fn(TcpConnectionInfo, State) + Send + Sync + 'static,
+{
+    let host = options.host.clone();
+    TcpRuntime::bind_windows_with_state(
+        (host.as_str(), options.port),
+        runtime_options(options),
+        init,
+        move |info, state, bytes| handler(info, state, bytes, &submitter),
         on_close,
     )
 }
@@ -617,6 +970,39 @@ mod tests {
             },
             Err(_) => TcpHandlerResult::close(),
         }
+    }
+
+    fn handle_tcp_bytes_mailbox(
+        info: TcpConnectionInfo,
+        _state: &mut (),
+        data: &[u8],
+        submitter: &StdioJobSubmitter<TcpInputJob>,
+    ) -> TcpHandlerResult {
+        if data.len() > MAX_TCP_CHUNK_BYTES {
+            return TcpHandlerResult::close();
+        }
+
+        match submitter.submit(
+            info.id,
+            TcpInputJob {
+                stream_id: info.id.0.to_string(),
+                bytes_hex: hex_encode(data.to_vec()),
+            },
+        ) {
+            Ok(_) => TcpHandlerResult::default(),
+            Err(_) => TcpHandlerResult::close(),
+        }
+    }
+
+    fn map_tcp_output_frame(frame: TcpOutputFrame) -> Result<TcpMailboxFrame, WorkerError> {
+        let mut writes = Vec::with_capacity(frame.writes_hex.len());
+        for item in frame.writes_hex {
+            writes.push(hex_decode(&item).map_err(WorkerError::Protocol)?);
+        }
+        Ok(TcpMailboxFrame {
+            writes,
+            close: frame.close,
+        })
     }
 
     fn decode_writes(writes_hex: &[String]) -> Result<Vec<u8>, String> {
@@ -959,6 +1345,27 @@ print(json.dumps({"version":1,"kind":"response","body":{"id":body["id"],"result"
         stop_server(server, handle);
     }
 
+    fn start_async_test_server(
+        worker: WorkerCommand,
+    ) -> (EmbeddableTcpServer<()>, thread::JoinHandle<io::Result<()>>) {
+        let server = EmbeddableTcpServer::new_mailbox(
+            EmbeddableTcpServerOptions {
+                host: "127.0.0.1".to_string(),
+                port: 0,
+                max_connections: 64,
+                worker,
+            },
+            |_| (),
+            handle_tcp_bytes_mailbox,
+            |_, _| {},
+            map_tcp_output_frame,
+        )
+        .expect("create async mailbox server");
+        let background = server.clone();
+        let handle = thread::spawn(move || background.serve());
+        (server, handle)
+    }
+
     fn assert_scripted_worker_maps_control_results() {
         let error_script = r#"
 import json, sys
@@ -1145,5 +1552,49 @@ print(json.dumps({"version":1,"kind":"response","body":{"id":body["id"],"result"
             return;
         };
         run_python_worker_integration(worker);
+    }
+
+    #[test]
+    fn mailbox_server_does_not_block_tcp_reads_waiting_for_worker_responses() {
+        let Some(worker) = scripted_worker(
+            r#"
+import json, sys
+
+first = json.loads(sys.stdin.readline())
+second = json.loads(sys.stdin.readline())
+
+def emit(frame, text):
+    body = frame["body"]
+    payload = {"writes_hex": [text.encode("utf-8").hex()], "close": False}
+    print(json.dumps({"version": 1, "kind": "response", "body": {"id": body["id"], "result": {"status": "ok", "payload": payload}, "metadata": body["metadata"]}}), flush=True)
+
+emit(second, "second")
+emit(first, "first")
+"#,
+        ) else {
+            eprintln!("skipping test because no Python interpreter was found");
+            return;
+        };
+
+        let (server, handle) = start_async_test_server(worker);
+        let mut first = connect_client(&server);
+        let mut second = connect_client(&server);
+
+        first.write_all(b"one").expect("write first request");
+        second.write_all(b"two").expect("write second request");
+
+        let mut second_response = [0u8; 6];
+        second
+            .read_exact(&mut second_response)
+            .expect("read second response");
+        assert_eq!(&second_response, b"second");
+
+        let mut first_response = [0u8; 5];
+        first
+            .read_exact(&mut first_response)
+            .expect("read first response");
+        assert_eq!(&first_response, b"first");
+
+        stop_server(server, handle);
     }
 }

--- a/code/packages/rust/stream-reactor/CHANGELOG.md
+++ b/code/packages/rust/stream-reactor/CHANGELOG.md
@@ -25,3 +25,12 @@ All notable changes to this package will be documented in this file.
 
 - stabilized the stateful read/write test to tolerate delayed client-side
   readability on CI
+
+## [0.1.2] - 2026-04-21
+
+### Added
+
+- Added a thread-safe outbound mailbox so off-reactor worker threads can queue
+  writes or close requests by `ConnectionId`.
+- Added tests for delayed mailbox writes, write-and-close delivery, and stale
+  mailbox commands for already closed streams.

--- a/code/packages/rust/stream-reactor/README.md
+++ b/code/packages/rust/stream-reactor/README.md
@@ -17,6 +17,7 @@ The reactor owns:
 - per-connection application state
 - per-stream readable and writable progression
 - queued writes
+- a thread-safe outbound mailbox for delayed writes
 - close-after-flush handling
 - connection caps
 - queued-write budget caps
@@ -33,6 +34,7 @@ Phase one supports:
 - many concurrent streams
 - stateful or stateless handlers
 - neutral handler results in terms of bytes plus close intent
+- delayed write and close submissions through `StreamMailbox`
 - cooperative stop via a stop flag
 - macOS/BSD convenience binding through `transport_platform::bsd::KqueueTransportPlatform`
 

--- a/code/packages/rust/stream-reactor/src/lib.rs
+++ b/code/packages/rust/stream-reactor/src/lib.rs
@@ -5,10 +5,10 @@
 //! This crate owns listener acceptance, per-stream state, queued writes, and
 //! neutral byte-stream handler progression without committing to one protocol.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use transport_platform::{
     BindAddress, CloseKind, ListenerId, ListenerOptions, PlatformError, PlatformEvent, ReadOutcome,
@@ -90,6 +90,60 @@ impl StopHandle {
     }
 }
 
+#[derive(Clone, Default)]
+pub struct StreamMailbox {
+    commands: Arc<Mutex<VecDeque<StreamMailboxCommand>>>,
+}
+
+impl StreamMailbox {
+    pub fn send(&self, connection_id: ConnectionId, bytes: impl Into<Vec<u8>>) {
+        self.push(StreamMailboxCommand::Write {
+            connection_id,
+            bytes: bytes.into(),
+            close: false,
+        });
+    }
+
+    pub fn send_and_close(&self, connection_id: ConnectionId, bytes: impl Into<Vec<u8>>) {
+        self.push(StreamMailboxCommand::Write {
+            connection_id,
+            bytes: bytes.into(),
+            close: true,
+        });
+    }
+
+    pub fn close(&self, connection_id: ConnectionId) {
+        self.push(StreamMailboxCommand::Close { connection_id });
+    }
+
+    fn push(&self, command: StreamMailboxCommand) {
+        self.commands
+            .lock()
+            .expect("stream mailbox mutex poisoned")
+            .push_back(command);
+    }
+
+    fn drain(&self) -> Vec<StreamMailboxCommand> {
+        self.commands
+            .lock()
+            .expect("stream mailbox mutex poisoned")
+            .drain(..)
+            .collect()
+    }
+}
+
+#[derive(Debug)]
+enum StreamMailboxCommand {
+    Write {
+        connection_id: ConnectionId,
+        bytes: Vec<u8>,
+        close: bool,
+    },
+    Close {
+        connection_id: ConnectionId,
+    },
+}
+
 type StateInit<S> = Arc<dyn Fn(StreamConnectionInfo) -> S + Send + Sync + 'static>;
 type StatefulHandler<S> =
     Arc<dyn Fn(StreamConnectionInfo, &mut S, &[u8]) -> StreamHandlerResult + Send + Sync + 'static>;
@@ -108,8 +162,10 @@ pub struct StreamReactor<P, S = ()> {
     listener: ListenerId,
     listener_addr: SocketAddr,
     connections: BTreeMap<StreamId, ConnectionState<S>>,
+    connection_index: BTreeMap<ConnectionId, StreamId>,
     next_connection_id: u64,
     stop_flag: Arc<AtomicBool>,
+    mailbox: StreamMailbox,
     read_buffer_size: usize,
     max_connections: usize,
     max_pending_write_bytes: usize,
@@ -164,8 +220,10 @@ impl<P: TransportPlatform, S: Send + 'static> StreamReactor<P, S> {
             listener,
             listener_addr,
             connections: BTreeMap::new(),
+            connection_index: BTreeMap::new(),
             next_connection_id: 1,
             stop_flag: Arc::new(AtomicBool::new(false)),
+            mailbox: StreamMailbox::default(),
             read_buffer_size: options.read_buffer_size.max(1),
             max_connections: options.max_connections.max(1),
             max_pending_write_bytes: options.max_pending_write_bytes.max(1),
@@ -193,10 +251,15 @@ impl<P: TransportPlatform, S: Send + 'static> StreamReactor<P, S> {
         StopHandle(Arc::clone(&self.stop_flag))
     }
 
+    pub fn mailbox(&self) -> StreamMailbox {
+        self.mailbox.clone()
+    }
+
     pub fn serve(&mut self) -> Result<(), PlatformError> {
         self.stop_flag.store(false, Ordering::SeqCst);
         let mut events = Vec::new();
         while !self.stop_flag.load(Ordering::SeqCst) {
+            self.drain_mailbox()?;
             self.platform.poll(Some(self.poll_timeout), &mut events)?;
             for event in &events {
                 match event {
@@ -228,6 +291,7 @@ impl<P: TransportPlatform, S: Send + 'static> StreamReactor<P, S> {
                     _ => {}
                 }
             }
+            self.drain_mailbox()?;
         }
         self.shutdown_all()
     }
@@ -248,6 +312,7 @@ impl<P: TransportPlatform, S: Send + 'static> StreamReactor<P, S> {
 
                     let connection_id = ConnectionId(self.next_connection_id);
                     self.next_connection_id += 1;
+                    self.connection_index.insert(connection_id, accepted.stream);
                     self.connections.insert(
                         accepted.stream,
                         ConnectionState {
@@ -267,6 +332,61 @@ impl<P: TransportPlatform, S: Send + 'static> StreamReactor<P, S> {
                 }
                 None => return Ok(()),
             }
+        }
+    }
+
+    fn drain_mailbox(&mut self) -> Result<(), PlatformError> {
+        for command in self.mailbox.drain() {
+            self.apply_mailbox_command(command)?;
+        }
+        Ok(())
+    }
+
+    fn apply_mailbox_command(
+        &mut self,
+        command: StreamMailboxCommand,
+    ) -> Result<(), PlatformError> {
+        let connection_id = match &command {
+            StreamMailboxCommand::Write { connection_id, .. } => *connection_id,
+            StreamMailboxCommand::Close { connection_id } => *connection_id,
+        };
+
+        let Some(stream) = self.connection_index.get(&connection_id).copied() else {
+            return Ok(());
+        };
+        let Some(mut state) = self.connections.remove(&stream) else {
+            self.connection_index.remove(&connection_id);
+            return Ok(());
+        };
+
+        let mut close_now = false;
+        match command {
+            StreamMailboxCommand::Write { bytes, close, .. } => {
+                if !bytes.is_empty() {
+                    if state.pending_write.len().saturating_add(bytes.len())
+                        > self.max_pending_write_bytes
+                    {
+                        close_now = true;
+                    } else {
+                        state.pending_write.extend_from_slice(&bytes);
+                    }
+                }
+                if close {
+                    state.close_when_flushed = true;
+                }
+            }
+            StreamMailboxCommand::Close { .. } => {
+                state.close_when_flushed = true;
+            }
+        }
+
+        if close_now || self.should_close_after_io(&state) {
+            self.close_connection_with_state(stream, state)
+        } else {
+            self.platform
+                .set_stream_interest(stream, self.interest_for(&state))?;
+            self.connections.insert(stream, state);
+            Ok(())
         }
     }
 
@@ -409,6 +529,7 @@ impl<P: TransportPlatform, S: Send + 'static> StreamReactor<P, S> {
         stream: StreamId,
         state: ConnectionState<S>,
     ) -> Result<(), PlatformError> {
+        self.connection_index.remove(&state.info.id);
         (self.on_close)(state.info, state.app_state);
         self.close_stream_raw(stream)
     }
@@ -426,6 +547,7 @@ impl<P: TransportPlatform, S: Send + 'static> StreamReactor<P, S> {
         for stream in streams {
             self.close_connection(stream)?;
         }
+        self.connection_index.clear();
         match self.platform.close_listener(self.listener) {
             Ok(()) => Ok(()),
             Err(PlatformError::InvalidResource | PlatformError::ResourceClosed) => Ok(()),
@@ -781,6 +903,147 @@ mod tests {
         let observed = closed.lock().expect("close observer mutex poisoned");
         assert_eq!(observed.len(), 1, "close callback should run exactly once");
         assert_eq!(observed[0].1, b"bye".to_vec());
+    }
+
+    #[test]
+    fn mailbox_can_queue_delayed_writes_after_read_handler_returns() {
+        let seen = Arc::new(Mutex::new(Vec::<ConnectionId>::new()));
+        let seen_in_handler = Arc::clone(&seen);
+        let mut reactor = StreamReactor::bind_kqueue_with_state(
+            ("127.0.0.1", 0),
+            StreamReactorOptions::default(),
+            |_| (),
+            move |info, _, _| {
+                seen_in_handler
+                    .lock()
+                    .expect("seen mutex poisoned")
+                    .push(info.id);
+                StreamHandlerResult::default()
+            },
+            |_, _| {},
+        )
+        .expect("bind");
+        let mailbox = reactor.mailbox();
+        let addr = reactor.local_addr();
+
+        let mut client = TcpStream::connect(addr).expect("connect");
+        client.write_all(b"request").expect("write request");
+        for _ in 0..8 {
+            reactor.accept_ready().expect("accept client");
+            if reactor.connections.len() == 1 {
+                break;
+            }
+            thread::sleep(Duration::from_millis(5));
+        }
+
+        let stream = *reactor
+            .connections
+            .keys()
+            .next()
+            .expect("accepted connection stream");
+        let mut connection_id = None;
+        for _ in 0..20 {
+            reactor.read_ready(stream).expect("read request");
+            if let Some(id) = seen.lock().expect("seen mutex poisoned").first().copied() {
+                connection_id = Some(id);
+                break;
+            }
+            thread::sleep(Duration::from_millis(5));
+        }
+        let connection_id = connection_id.expect("handler should observe the request");
+
+        mailbox.send(connection_id, b"delayed-response".to_vec());
+        reactor.drain_mailbox().expect("drain mailbox");
+        reactor.write_ready(stream).expect("flush delayed response");
+
+        let mut response = [0u8; 16];
+        client
+            .read_exact(&mut response)
+            .expect("read delayed response");
+        assert_eq!(&response, b"delayed-response");
+    }
+
+    #[test]
+    fn mailbox_can_write_and_close_after_flush() {
+        let seen = Arc::new(Mutex::new(Vec::<ConnectionId>::new()));
+        let seen_in_handler = Arc::clone(&seen);
+        let closed = Arc::new(Mutex::new(Vec::<ConnectionId>::new()));
+        let closed_observer = Arc::clone(&closed);
+        let mut reactor = StreamReactor::bind_kqueue_with_state(
+            ("127.0.0.1", 0),
+            StreamReactorOptions::default(),
+            |_| (),
+            move |info, _, _| {
+                seen_in_handler
+                    .lock()
+                    .expect("seen mutex poisoned")
+                    .push(info.id);
+                StreamHandlerResult::default()
+            },
+            move |info, _| {
+                closed_observer
+                    .lock()
+                    .expect("closed mutex poisoned")
+                    .push(info.id);
+            },
+        )
+        .expect("bind");
+        let mailbox = reactor.mailbox();
+        let addr = reactor.local_addr();
+
+        let mut client = TcpStream::connect(addr).expect("connect");
+        client.write_all(b"request").expect("write request");
+        for _ in 0..8 {
+            reactor.accept_ready().expect("accept client");
+            if reactor.connections.len() == 1 {
+                break;
+            }
+            thread::sleep(Duration::from_millis(5));
+        }
+
+        let stream = *reactor
+            .connections
+            .keys()
+            .next()
+            .expect("accepted connection stream");
+        let mut connection_id = None;
+        for _ in 0..20 {
+            reactor.read_ready(stream).expect("read request");
+            if let Some(id) = seen.lock().expect("seen mutex poisoned").first().copied() {
+                connection_id = Some(id);
+                break;
+            }
+            thread::sleep(Duration::from_millis(5));
+        }
+        let connection_id = connection_id.expect("handler should observe the request");
+
+        mailbox.send_and_close(connection_id, b"last".to_vec());
+        reactor.drain_mailbox().expect("drain mailbox");
+        reactor.write_ready(stream).expect("flush and close");
+
+        let mut response = Vec::new();
+        client.read_to_end(&mut response).expect("read to eof");
+        assert_eq!(response, b"last");
+        assert_eq!(
+            closed.lock().expect("closed mutex poisoned").as_slice(),
+            &[connection_id]
+        );
+    }
+
+    #[test]
+    fn mailbox_ignores_unknown_or_stale_connection_ids() {
+        let mut reactor = StreamReactor::bind_kqueue(("127.0.0.1", 0), |_, bytes| {
+            StreamHandlerResult::write(bytes.to_vec())
+        })
+        .expect("bind");
+        let mailbox = reactor.mailbox();
+
+        mailbox.send(ConnectionId(999_999), b"nobody".to_vec());
+        mailbox.close(ConnectionId(999_999));
+        reactor
+            .drain_mailbox()
+            .expect("stale mailbox commands should be harmless");
+        assert!(reactor.connections.is_empty());
     }
 
     #[test]

--- a/code/packages/rust/tcp-runtime/CHANGELOG.md
+++ b/code/packages/rust/tcp-runtime/CHANGELOG.md
@@ -24,3 +24,12 @@ All notable changes to this package will be documented in this file.
 - close callbacks that observe final TCP connection state during teardown
 - tests proving stateful handlers preserve per-connection state across multiple
   reads
+
+## [0.1.2] - 2026-04-21
+
+### Added
+
+- Added a TCP outbound mailbox wrapper so worker threads can send delayed bytes
+  or close requests by `ConnectionId`.
+- Added tests proving TCP reads can return immediately while another thread
+  posts the eventual response.

--- a/code/packages/rust/tcp-runtime/README.md
+++ b/code/packages/rust/tcp-runtime/README.md
@@ -11,6 +11,7 @@ It owns:
 - TCP listener and stream option policy
 - TCP-flavored connection metadata for handlers
 - connection-local application state for protocol sessions
+- a TCP-flavored outbound mailbox for delayed worker responses
 - a runtime surface that Redis-, IRC-, and protocol-focused crates can bind to
 
 It deliberately delegates byte-stream progression to `stream-reactor` instead
@@ -24,6 +25,7 @@ Phase one supports:
 - many concurrent TCP connections
 - configurable backlog, `TCP_NODELAY`, keepalive, and socket buffer defaults
 - stateless and stateful handler variants
+- mailbox handles that can write or close TCP connections from worker threads
 - queued-write and connection caps inherited from `stream-reactor`
 - cooperative shutdown through a stop handle
 - host-OS convenience constructors for macOS / BSD, Linux, and Windows

--- a/code/packages/rust/tcp-runtime/src/lib.rs
+++ b/code/packages/rust/tcp-runtime/src/lib.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 
 pub use stream_reactor::{ConnectionId, StopHandle};
 use stream_reactor::{
-    StreamConnectionInfo, StreamHandlerResult, StreamReactor, StreamReactorOptions,
+    StreamConnectionInfo, StreamHandlerResult, StreamMailbox, StreamReactor, StreamReactorOptions,
 };
 use transport_platform::TransportPlatform;
 pub use transport_platform::{BindAddress, ListenerOptions, PlatformError, StreamOptions};
@@ -102,6 +102,31 @@ impl From<TcpRuntimeOptions> for StreamReactorOptions {
 pub struct TcpRuntime<P, S = ()> {
     reactor: StreamReactor<P, S>,
     local_addr: SocketAddr,
+}
+
+#[derive(Clone)]
+pub struct TcpMailbox {
+    inner: StreamMailbox,
+}
+
+impl TcpMailbox {
+    pub fn send(&self, connection_id: ConnectionId, bytes: impl Into<Vec<u8>>) {
+        self.inner.send(connection_id, bytes);
+    }
+
+    pub fn send_and_close(&self, connection_id: ConnectionId, bytes: impl Into<Vec<u8>>) {
+        self.inner.send_and_close(connection_id, bytes);
+    }
+
+    pub fn close(&self, connection_id: ConnectionId) {
+        self.inner.close(connection_id);
+    }
+}
+
+impl From<StreamMailbox> for TcpMailbox {
+    fn from(value: StreamMailbox) -> Self {
+        Self { inner: value }
+    }
 }
 
 impl<P: TransportPlatform> TcpRuntime<P, ()> {
@@ -219,6 +244,10 @@ impl<P: TransportPlatform, S: Send + 'static> TcpRuntime<P, S> {
 
     pub fn stop_handle(&self) -> StopHandle {
         self.reactor.stop_handle()
+    }
+
+    pub fn mailbox(&self) -> TcpMailbox {
+        self.reactor.mailbox().into()
     }
 
     pub fn serve(&mut self) -> Result<(), PlatformError> {
@@ -524,6 +553,56 @@ mod tests {
         let mut echoed = [0u8; 6];
         client.read_exact(&mut echoed).expect("read response");
         assert_eq!(&echoed, b"hello\n");
+
+        stop.stop();
+        let result = server.join().expect("server thread");
+        assert!(result.is_ok(), "server should exit cleanly: {result:?}");
+    }
+
+    #[test]
+    fn mailbox_can_send_delayed_response_after_handler_returns() {
+        let seen = Arc::new(Mutex::new(Vec::<ConnectionId>::new()));
+        let seen_in_handler = Arc::clone(&seen);
+        let mut runtime = TcpRuntime::bind_kqueue(
+            ("127.0.0.1", 0),
+            TcpRuntimeOptions::default(),
+            move |info, _| {
+                seen_in_handler
+                    .lock()
+                    .expect("seen mutex poisoned")
+                    .push(info.id);
+                TcpHandlerResult::default()
+            },
+        )
+        .expect("bind");
+        let addr = runtime.local_addr();
+        let mailbox = runtime.mailbox();
+        let stop = runtime.stop_handle();
+
+        let server = thread::spawn(move || runtime.serve());
+
+        let mut client = TcpStream::connect(addr).expect("connect");
+        client
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .expect("read timeout");
+        client.write_all(b"request").expect("write request");
+
+        let mut connection_id = None;
+        for _ in 0..200 {
+            if let Some(id) = seen.lock().expect("seen mutex poisoned").first().copied() {
+                connection_id = Some(id);
+                break;
+            }
+            thread::sleep(Duration::from_millis(5));
+        }
+        let connection_id = connection_id.expect("handler should observe the request");
+
+        mailbox.send(connection_id, b"delayed".to_vec());
+        let mut response = [0u8; 7];
+        client
+            .read_exact(&mut response)
+            .expect("read delayed response");
+        assert_eq!(&response, b"delayed");
 
         stop.stop();
         let result = server.join().expect("server thread");

--- a/code/specs/embeddable-tcp-server.md
+++ b/code/specs/embeddable-tcp-server.md
@@ -24,9 +24,9 @@ generic JobRequest<TcpBytesPayload> JSON line
     |
 embedded language/application worker
     |
-generic JobResponse<TcpWriteFrame> JSON line
+generic JobResponse<TcpWriteFrame> JSON line, read by worker response task
     |
-Rust TCP server writes response bytes
+TCP return mailbox writes response bytes
 ```
 
 Rust is responsible for:
@@ -35,8 +35,9 @@ Rust is responsible for:
 - Using the native platform transport selected by the workspace.
 - Owning connection lifecycle, routing metadata, and socket writes.
 - Sending opaque TCP byte jobs to the configured worker command.
-- Writing opaque byte frames returned by the worker.
-- Validating response id before routing worker results back to sockets.
+- Returning to the TCP event loop immediately after sending a job.
+- Providing a per-connection return mailbox for worker responses.
+- Routing opaque byte frames from the worker response task into that mailbox.
 
 The embedded worker is responsible for:
 
@@ -78,26 +79,28 @@ The current integration test uses Python Mini Redis as the first consumer:
 - RESP bytes enter over a real TCP socket.
 - `embeddable-tcp-server` sends raw TCP bytes to the Python worker as
   `JobRequest<TcpBytesPayload>`.
+- The TCP callback returns immediately after putting that job in the worker's
+  inbox.
 - Python queues the job, buffers bytes by stream id, parses RESP frames,
   executes commands, assembles RESP responses, and returns write frames inside
   `JobResponse<TcpWriteFrame>`.
-- Rust writes the returned opaque bytes to the original socket.
+- A Rust response task reads those frames and posts them to the TCP mailbox for
+  the original stream.
 
 This proves the cross-language seam without making Python or Redis part of the
 transport package identity.
 
 ## Current Limitations
 
-- The TCP callback waits synchronously for the worker response.
 - The prototype uses one worker process.
 - Worker communication uses the JSON-line `generic-job-protocol` codec over
   standard streams, not a binary protocol.
-- The worker can queue jobs internally, but this prototype still waits for one
-  response frame before the TCP callback returns.
+- Mailbox delivery is bounded by the stream reactor's cooperative poll timeout
+  until the transport layer exposes a thread-safe wake handle.
 
 These limits are intentional for the first prototype. The next production seam
-should route byte jobs through the generic job runtime so language workers can
-run in a thread pool or process pool without blocking the reactor.
+should replace the single stdio worker process with the generic job runtime so
+language workers can run in a thread pool or process pool.
 
 ## Acceptance Criteria
 
@@ -112,5 +115,7 @@ run in a thread pool or process pool without blocking the reactor.
 - Rust tests launch the Python worker process as one consumer example.
 - Rust tests launch a real TCP listener, send RESP commands, and receive Redis
   replies generated entirely by the Python worker.
+- Rust tests prove the TCP callback can accept later reads while an earlier
+  worker response is still pending.
 - Documentation states that this is a prototype and not the final async worker
   architecture.

--- a/code/specs/stream-reactor.md
+++ b/code/specs/stream-reactor.md
@@ -71,16 +71,19 @@ Phase one of `stream-reactor` supports:
 - readable and writable event progression
 - per-connection application state owned by the reactor
 - per-stream queued outbound bytes
+- thread-safe outbound mailbox submissions keyed by `ConnectionId`
 - configurable connection caps
 - configurable queued-write budget caps
 - neutral handler output in terms of bytes and close intent
 - optional close callbacks for connection teardown
 - cooperative stop via a stop flag
 
-Phase one intentionally does not yet require:
+Phase two adds a mailbox for worker threads and other off-reactor producers to
+send bytes back to streams without blocking the readable callback.
+
+Phase one and two intentionally do not yet require:
 
 - timer-driven idle deadlines
-- cross-thread wakeup handles
 - listener adoption instead of bind-at-construction
 - UDP or Unix-domain sockets
 - protocol-specific framing
@@ -119,6 +122,24 @@ This keeps the runtime generic for protocols that:
 - emit one last frame and then close
 
 without forcing protocol knowledge into the reactor.
+
+### `StreamMailbox`
+
+Longer-running application work should not keep the reactor thread waiting for
+a response. `StreamMailbox` is the return address for that work.
+
+The handle is cloneable and thread-safe. Producers can submit:
+
+- bytes to write to a connection
+- bytes to write followed by close-after-flush
+- a close request with no bytes
+
+The reactor drains mailbox commands on its event-loop thread and applies the
+same queued-write budget rules as inline handler responses. Mail for already
+closed connections is discarded.
+
+Until `transport-platform` exposes a thread-safe wake handle, mailbox delivery
+is cooperative: the reactor notices queued commands on the next poll tick.
 
 ### Connection State
 
@@ -165,8 +186,12 @@ Phase-one public API:
 - `StreamReactor::serve()`
 - `StreamReactor::local_addr()`
 - `StreamReactor::stop_handle()`
+- `StreamReactor::mailbox()`
 - `StreamReactor::set_max_connections(max)`
 - `StreamReactor::set_max_pending_write_bytes(max)`
+- `StreamMailbox::send(connection_id, bytes)`
+- `StreamMailbox::send_and_close(connection_id, bytes)`
+- `StreamMailbox::close(connection_id)`
 - macOS/BSD convenience: `StreamReactor::bind_kqueue(addr, handler)`
 
 ## Event Progression
@@ -196,6 +221,15 @@ Writable side:
 3. if queue drains fully and the peer already closed or the handler requested
    close-after-flush, close the stream
 4. otherwise fall back to readable-only interest
+
+Mailbox side:
+
+1. drain queued mailbox commands on the reactor thread
+2. find the active stream for each `ConnectionId`
+3. append write bytes to that stream's pending-write queue
+4. mark close-after-flush when requested
+5. enable writable interest for streams that now have pending bytes
+6. close streams that exceed the queued-write budget
 
 ## Error Handling
 


### PR DESCRIPTION
## Summary
- specify the non-blocking request/response mailbox seam for embeddable TCP workers
- add StreamMailbox and TcpMailbox handles for delayed writes and close requests by ConnectionId
- add an async embeddable TCP worker path that submits jobs immediately and routes later JobResponse frames back to TCP sockets
- cover the post-office behavior with a Python worker test that waits for two requests before responding out of order

## Tests
- bash BUILD (code/packages/rust/stream-reactor)
- bash BUILD (code/packages/rust/tcp-runtime)
- bash BUILD (code/packages/rust/embeddable-tcp-server)

## Security
- No unsafe code added
- Worker spawning continues to use Command::new(program).args(args), with no shell interpolation or eval