### PR TITLE
feat(argon2-perl): add pure-Perl Argon2d/i/id ports

### DIFF
--- a/code/packages/perl/argon2d/BUILD
+++ b/code/packages/perl/argon2d/BUILD
@@ -1,0 +1,1 @@
+PERL5LIB=../blake2b/lib prove -l -v t/

--- a/code/packages/perl/argon2d/BUILD_windows
+++ b/code/packages/perl/argon2d/BUILD_windows
@@ -1,0 +1,1 @@
+echo Perl testing is not supported on Windows - skipping

--- a/code/packages/perl/argon2d/CHANGELOG.md
+++ b/code/packages/perl/argon2d/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.01] - 2026-04-20
+
+### Added
+
+- Initial pure-Perl port of Argon2d (RFC 9106).
+- `argon2d(...)` — raw binary tag.
+- `argon2d_hex(...)` — lowercase hex tag.
+- Validation of RFC 9106 parameter bounds (salt ≥ 8 bytes, tag ≥ 4 bytes,
+  parallelism in [1, 2²⁴-1], memory ≥ 8·parallelism, 32-bit length caps on
+  password/salt/key/associated_data/memory/tag).
+- Test suite with the RFC 9106 §5.1 gold-standard vector plus
+  parameter-edge coverage for tag length, key binding, associated-data
+  binding, multi-lane, and multi-pass cases.

--- a/code/packages/perl/argon2d/Makefile.PL
+++ b/code/packages/perl/argon2d/Makefile.PL
@@ -1,0 +1,28 @@
+use strict;
+use warnings;
+use ExtUtils::MakeMaker;
+
+WriteMakefile(
+    NAME             => 'CodingAdventures::Argon2d',
+    VERSION_FROM     => 'lib/CodingAdventures/Argon2d.pm',
+    ABSTRACT         => 'Pure Perl Argon2d (RFC 9106) data-dependent memory-hard KDF',
+    AUTHOR           => 'coding-adventures',
+    LICENSE          => 'mit',
+    MIN_PERL_VERSION => '5.026000',
+    PREREQ_PM        => {
+        'CodingAdventures::Blake2b' => 0,
+    },
+    TEST_REQUIRES    => {
+        'Test2::V0' => 0,
+    },
+    META_MERGE       => {
+        'meta-spec' => { version => 2 },
+        resources   => {
+            repository => {
+                type => 'git',
+                url  => 'https://github.com/adhithyan15/coding-adventures.git',
+                web  => 'https://github.com/adhithyan15/coding-adventures',
+            },
+        },
+    },
+);

--- a/code/packages/perl/argon2d/README.md
+++ b/code/packages/perl/argon2d/README.md
@@ -1,0 +1,83 @@
+# CodingAdventures::Argon2d
+
+Pure-Perl implementation of **Argon2d** (RFC 9106) — the data-dependent
+variant of the Argon2 memory-hard password hashing family.
+
+## What is Argon2d?
+
+Argon2d reads the reference-block index for every new block from the
+first 64 bits of the previously computed block. The memory-access
+pattern therefore depends on the password, which maximises resistance
+to GPU/ASIC cracking at the cost of leaking a side channel through
+memory-access timing.
+
+Use Argon2d only when side-channel attacks are **not** in the threat
+model (e.g. proof-of-work). For password hashing prefer
+[`CodingAdventures::Argon2id`](../argon2id/).
+
+## Installation
+
+```
+cpanm --installdeps .
+perl Makefile.PL
+make
+make test
+```
+
+The package depends on [`CodingAdventures::Blake2b`](../blake2b/) as
+the only runtime prerequisite.
+
+## Usage
+
+```perl
+use CodingAdventures::Argon2d;
+
+# Raw binary tag (32 bytes here).
+my $tag = CodingAdventures::Argon2d::argon2d(
+    $password, $salt,
+    3,      # time_cost  (passes)
+    65536,  # memory_cost (KiB)
+    4,      # parallelism (lanes)
+    32,     # tag_length  (bytes)
+    key             => $optional_mac_key,
+    associated_data => $optional_context,
+);
+
+# Or hex-encoded.
+my $hex = CodingAdventures::Argon2d::argon2d_hex(
+    $password, $salt, 3, 65536, 4, 32,
+);
+```
+
+All string inputs are treated as raw byte strings.
+
+## Parameter bounds (RFC 9106)
+
+| Parameter      | Constraint            |
+|----------------|-----------------------|
+| `salt`         | ≥ 8 bytes             |
+| `tag_length`   | ≥ 4 bytes             |
+| `parallelism`  | 1 … 2²⁴ − 1           |
+| `memory_cost`  | ≥ 8 × parallelism     |
+| `time_cost`    | ≥ 1                   |
+| `version`      | 0x13 only             |
+
+Password, salt, key, associated-data, memory-cost, and tag-length are
+capped at 2³² − 1 so that the RFC 9106 H₀ length fields stay valid.
+
+## Security
+
+Argon2 is **designed** to burn memory and CPU. Callers control that
+DoS boundary by picking the `memory_cost`, `time_cost`, and
+`parallelism` parameters. Do not expose them to untrusted input
+without bounds of your own.
+
+This module does **not** perform constant-time tag comparison. When
+verifying a tag you MUST use a constant-time equality check — a naïve
+`eq` leaks byte-level timing.
+
+## Where this fits
+
+Argon2d sits in the `KD03` key-derivation layer of this repo's
+cryptographic stack. It depends only on `CodingAdventures::Blake2b`
+(from `HF06`) and is used by higher-level key-schedule packages.

--- a/code/packages/perl/argon2d/cpanfile
+++ b/code/packages/perl/argon2d/cpanfile
@@ -1,0 +1,6 @@
+requires 'CodingAdventures::Blake2b';
+
+# Test dependencies
+on 'test' => sub {
+    requires 'Test2::V0';
+};

--- a/code/packages/perl/argon2d/lib/CodingAdventures/Argon2d.pm
+++ b/code/packages/perl/argon2d/lib/CodingAdventures/Argon2d.pm
@@ -27,6 +27,13 @@ use strict;
 use warnings;
 no warnings 'portable';   # Allow 64-bit hex literals (> 0xFFFFFFFF).
 
+use Config;
+BEGIN {
+    die "CodingAdventures::Argon2d requires 64-bit Perl (ivsize >= 8); "
+      . "this build has ivsize=$Config{ivsize}\n"
+        if $Config{ivsize} < 8;
+}
+
 use CodingAdventures::Blake2b ();
 
 our $VERSION = '0.01';
@@ -292,8 +299,20 @@ sub argon2d {
     my $ad      = $opts{associated_data} // '';
     my $version = $opts{version}         // ARGON2_VERSION;
 
-    # Treat every input as a raw byte string.
-    for ($password, $salt, $key, $ad) { utf8::downgrade($_, 1) or 1; }
+    # Treat every input as a raw byte string.  A caller that hands us a
+    # scalar with wide (> 0xFF) codepoints is almost always a bug -- the
+    # alternative is to silently byte-encode it as UTF-8 and produce a
+    # tag that no reference Argon2 implementation can reproduce.  Refuse.
+    for my $name_and_val (
+        [ password        => \$password ],
+        [ salt            => \$salt     ],
+        [ key             => \$key      ],
+        [ associated_data => \$ad       ],
+    ) {
+        my ($name, $ref) = @$name_and_val;
+        utf8::downgrade($$ref, 1)
+            or die "$name must be a byte string; refusing wide characters\n";
+    }
 
     _validate($password, $salt, $time_cost, $memory_cost, $parallelism,
               $tag_length, $key, $ad, $version);

--- a/code/packages/perl/argon2d/lib/CodingAdventures/Argon2d.pm
+++ b/code/packages/perl/argon2d/lib/CodingAdventures/Argon2d.pm
@@ -1,0 +1,400 @@
+package CodingAdventures::Argon2d;
+
+# ============================================================================
+# CodingAdventures::Argon2d -- Pure Perl Argon2d (RFC 9106)
+# ============================================================================
+#
+# Argon2d is the data-DEPENDENT variant of the Argon2 memory-hard password
+# hashing family.  For every new block, the index of the reference block is
+# read from the first 64 bits of the previously computed block -- so the
+# memory-access pattern is correlated with the password.  That maximises
+# resistance against GPU/ASIC cracking but leaks a side channel through
+# memory-access timing.  Use Argon2d only when side-channel attacks are NOT
+# in the threat model (e.g. proof-of-work).  For password hashing prefer
+# CodingAdventures::Argon2id.
+#
+# Reference: https://datatracker.ietf.org/doc/html/rfc9106
+# See also:  code/specs/KD03-argon2.md
+#
+# PERL 64-BIT NOTES
+# -----------------
+# Every 64-bit arithmetic step is wrapped with `use integer` (signed 64-bit
+# wrap-on-overflow) and masked with MASK64 where unsigned semantics matter.
+# Bitwise ops (&, |, ^, >>, <<) already work natively on 64-bit integers.
+# `pack("Q<", $w)` and `unpack("Q<", $s)` give us little-endian 64-bit I/O.
+
+use strict;
+use warnings;
+no warnings 'portable';   # Allow 64-bit hex literals (> 0xFFFFFFFF).
+
+use CodingAdventures::Blake2b ();
+
+our $VERSION = '0.01';
+
+# --- Constants -------------------------------------------------------------
+use constant MASK32         => 0xFFFFFFFF;
+use constant MASK64         => 0xFFFFFFFFFFFFFFFF;
+use constant BLOCK_SIZE     => 1024;     # bytes per Argon2 memory block
+use constant BLOCK_WORDS    => 128;      # 64-bit words per block
+use constant SYNC_POINTS    => 4;        # slices per pass
+use constant ARGON2_VERSION => 0x13;     # v1.3 is the only approved version
+use constant TYPE_D         => 0;        # primitive type code for Argon2d
+
+# ---------------------------------------------------------------------------
+# _rotr64($x, $n) -- right-rotate a 64-bit word by $n bits.
+# ---------------------------------------------------------------------------
+sub _rotr64 {
+    my ($x, $n) = @_;
+    return ((($x >> $n) | ($x << (64 - $n))) & MASK64);
+}
+
+# ---------------------------------------------------------------------------
+# _gb(\@v, $a, $b, $c, $d) -- the Argon2 G-mixer (RFC 9106 §3.5).
+#
+# Identical to the BLAKE2 quarter-round EXCEPT each addition has an extra
+# `2 * trunc32(a) * trunc32(b)` term.  That cross-term is what makes
+# memory-hard attacks on Argon2 quadratic in block size, raising the cost
+# of any "prune-and-extend" strategy.
+# ---------------------------------------------------------------------------
+sub _gb {
+    my ($v, $a, $b, $c, $d) = @_;
+
+    my ($va, $vb, $vc, $vd) = ($v->[$a], $v->[$b], $v->[$c], $v->[$d]);
+
+    {
+        use integer;
+        $va = ($va + $vb + 2 * ($va & MASK32) * ($vb & MASK32)) & MASK64;
+    }
+    $vd = _rotr64($vd ^ $va, 32);
+    {
+        use integer;
+        $vc = ($vc + $vd + 2 * ($vc & MASK32) * ($vd & MASK32)) & MASK64;
+    }
+    $vb = _rotr64($vb ^ $vc, 24);
+    {
+        use integer;
+        $va = ($va + $vb + 2 * ($va & MASK32) * ($vb & MASK32)) & MASK64;
+    }
+    $vd = _rotr64($vd ^ $va, 16);
+    {
+        use integer;
+        $vc = ($vc + $vd + 2 * ($vc & MASK32) * ($vd & MASK32)) & MASK64;
+    }
+    $vb = _rotr64($vb ^ $vc, 63);
+
+    ($v->[$a], $v->[$b], $v->[$c], $v->[$d]) = ($va, $vb, $vc, $vd);
+}
+
+# ---------------------------------------------------------------------------
+# _permutation_p(\@v, $off) -- eight G-rounds across a 16-word slice.
+#
+# Four "column" rounds on (0,4,8,12) etc. followed by four "diagonal"
+# rounds on (0,5,10,15) etc. -- the classic double-round layout.
+# ---------------------------------------------------------------------------
+sub _permutation_p {
+    my ($v, $off) = @_;
+    $off //= 0;
+    _gb($v, $off + 0, $off + 4, $off +  8, $off + 12);
+    _gb($v, $off + 1, $off + 5, $off +  9, $off + 13);
+    _gb($v, $off + 2, $off + 6, $off + 10, $off + 14);
+    _gb($v, $off + 3, $off + 7, $off + 11, $off + 15);
+    _gb($v, $off + 0, $off + 5, $off + 10, $off + 15);
+    _gb($v, $off + 1, $off + 6, $off + 11, $off + 12);
+    _gb($v, $off + 2, $off + 7, $off +  8, $off + 13);
+    _gb($v, $off + 3, $off + 4, $off +  9, $off + 14);
+}
+
+# ---------------------------------------------------------------------------
+# _compress(\@x, \@y) -> \@out  --  the Argon2 compression function G.
+#
+# Treats the 128-word block as an 8x8 matrix of 128-bit registers.  First
+# performs a "row pass" by permuting each of the eight 16-word rows in
+# place; then a "column pass" by gathering offset-2c pairs across all
+# eight rows, permuting, and scattering back.  The result is XORed with
+# the original input (r := x XOR y) to make G a Davies-Meyer-style
+# one-way function.
+# ---------------------------------------------------------------------------
+sub _compress {
+    my ($x, $y) = @_;
+
+    my @r = map { $x->[$_] ^ $y->[$_] } 0 .. BLOCK_WORDS - 1;
+    my @q = @r;
+
+    # Row pass
+    for my $i (0 .. 7) {
+        _permutation_p(\@q, $i * 16);
+    }
+
+    # Column pass -- gather, permute, scatter.
+    my @col;
+    for my $c (0 .. 7) {
+        for my $rr (0 .. 7) {
+            $col[2 * $rr]     = $q[$rr * 16 + 2 * $c];
+            $col[2 * $rr + 1] = $q[$rr * 16 + 2 * $c + 1];
+        }
+        _permutation_p(\@col, 0);
+        for my $rr (0 .. 7) {
+            $q[$rr * 16 + 2 * $c]     = $col[2 * $rr];
+            $q[$rr * 16 + 2 * $c + 1] = $col[2 * $rr + 1];
+        }
+    }
+
+    return [ map { $r[$_] ^ $q[$_] } 0 .. BLOCK_WORDS - 1 ];
+}
+
+# --- Block <-> byte-string helpers ----------------------------------------
+sub _block_to_bytes { pack("Q<" . BLOCK_WORDS, @{$_[0]}) }
+sub _bytes_to_block { [ unpack("Q<" . BLOCK_WORDS, $_[0]) ] }
+sub _le32           { pack("V", $_[0]) }
+
+# ---------------------------------------------------------------------------
+# _blake2b_long($t, $x)  --  Argon2 variable-length hash H' (RFC 9106 §3.3).
+#
+# Produces $t output bytes by chaining 32-byte halves of repeated 64-byte
+# BLAKE2b calls, with the last call sized to fit exactly.  The initial
+# input is `LE32($t) || $x`.
+# ---------------------------------------------------------------------------
+sub _blake2b_long {
+    my ($t, $x) = @_;
+    die "H' output length must be positive\n" if $t <= 0;
+
+    my $input = _le32($t) . $x;
+
+    return CodingAdventures::Blake2b::blake2b($input, digest_size => $t)
+        if $t <= 64;
+
+    my $r = int(($t + 31) / 32) - 2;
+    my $v = CodingAdventures::Blake2b::blake2b($input, digest_size => 64);
+    my $out = substr($v, 0, 32);
+    for (1 .. $r - 1) {
+        $v = CodingAdventures::Blake2b::blake2b($v, digest_size => 64);
+        $out .= substr($v, 0, 32);
+    }
+    my $final_size = $t - 32 * $r;
+    $v = CodingAdventures::Blake2b::blake2b($v, digest_size => $final_size);
+    $out .= $v;
+    return $out;
+}
+
+# ---------------------------------------------------------------------------
+# _index_alpha($j1, $r, $sl, $c, $same_lane, $q, $sl_len)
+#
+# Maps the 32-bit pseudo-random J1 value to a reference-block column
+# inside the chosen lane (RFC 9106 §3.4.1.1).  The window [start, start+W)
+# describes which previously computed columns are eligible to be
+# referenced; J1 is biased toward recent blocks via `(W * x) >> 32`.
+# ---------------------------------------------------------------------------
+sub _index_alpha {
+    my ($j1, $r, $sl, $c, $same_lane, $q, $sl_len) = @_;
+    my ($w, $start);
+
+    if ($r == 0 && $sl == 0) {
+        # First slice of first pass: eligible columns are (0 .. c-1).
+        $w     = $c - 1;
+        $start = 0;
+    } elsif ($r == 0) {
+        # First pass, later slice: eligible = everything built so far,
+        # minus at most one spot depending on lane-locality edge cases.
+        $w = $same_lane ? $sl * $sl_len + $c - 1
+            : $c == 0   ? $sl * $sl_len - 1
+            :             $sl * $sl_len;
+        $start = 0;
+    } else {
+        # Later pass: always q - sl_len eligible blocks.
+        $w = $same_lane ? $q - $sl_len + $c - 1
+            : $c == 0   ? $q - $sl_len - 1
+            :             $q - $sl_len;
+        $start = (($sl + 1) * $sl_len) % $q;
+    }
+
+    my $x   = ($j1 * $j1) >> 32;
+    my $y   = ($w * $x)   >> 32;
+    my $rel = $w - 1 - $y;
+    return ($start + $rel) % $q;
+}
+
+# ---------------------------------------------------------------------------
+# _fill_segment(\%memory, $r, $lane, $sl, $q, $sl_len, $p)
+#
+# Fills one (pass, slice, lane) segment.  Argon2d is entirely
+# data-dependent: the 64 low/high bits of the previous block supply J1/J2.
+# ---------------------------------------------------------------------------
+sub _fill_segment {
+    my ($memory, $r, $lane, $sl, $q, $sl_len, $p) = @_;
+
+    my $starting_c = ($r == 0 && $sl == 0) ? 2 : 0;
+
+    for my $i ($starting_c .. $sl_len - 1) {
+        my $col = $sl * $sl_len + $i;
+        my $prev_col = $col == 0 ? $q - 1 : $col - 1;
+        my $prev_block = $memory->{$lane}[$prev_col];
+
+        my $pseudo_rand = $prev_block->[0];
+        my $j1 = $pseudo_rand & MASK32;
+        my $j2 = ($pseudo_rand >> 32) & MASK32;
+
+        my $l_prime = $lane;
+        $l_prime = $j2 % $p unless ($r == 0 && $sl == 0);
+
+        my $z_prime = _index_alpha($j1, $r, $sl, $i, $l_prime == $lane,
+                                   $q, $sl_len);
+        my $ref_block = $memory->{$l_prime}[$z_prime];
+
+        my $new_block = _compress($prev_block, $ref_block);
+        if ($r == 0) {
+            $memory->{$lane}[$col] = $new_block;
+        } else {
+            my $existing = $memory->{$lane}[$col];
+            $memory->{$lane}[$col] =
+                [ map { $existing->[$_] ^ $new_block->[$_] }
+                      0 .. BLOCK_WORDS - 1 ];
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# _validate(...) -- enforce the RFC 9106 parameter bounds.
+# ---------------------------------------------------------------------------
+sub _validate {
+    my ($password, $salt, $t, $m, $p, $tag_length, $key, $ad, $version) = @_;
+
+    die "password length must fit in 32 bits\n" if length($password) > MASK32;
+    die "salt must be at least 8 bytes\n"       if length($salt) < 8;
+    die "salt length must fit in 32 bits\n"     if length($salt) > MASK32;
+    die "key length must fit in 32 bits\n"      if length($key)  > MASK32;
+    die "associated_data length must fit in 32 bits\n"
+        if length($ad) > MASK32;
+    die "tag_length must be >= 4\n"             if $tag_length < 4;
+    die "tag_length must fit in 32 bits\n"      if $tag_length > MASK32;
+    die "parallelism must be in [1, 2^24-1]\n"
+        unless defined $p && $p =~ /\A\d+\z/ && $p >= 1 && $p <= 0xFFFFFF;
+    die "memory_cost must be >= 8*parallelism\n" if $m < 8 * $p;
+    die "memory_cost must fit in 32 bits\n"      if $m > MASK32;
+    die "time_cost must be >= 1\n"               if $t < 1;
+    die "only Argon2 v1.3 (0x13) is supported\n"
+        unless $version == ARGON2_VERSION;
+}
+
+# ---------------------------------------------------------------------------
+# argon2d($password, $salt, $time_cost, $memory_cost, $parallelism,
+#         $tag_length, %opts) -> raw tag bytes
+#
+# %opts keys:
+#   key              -- optional MAC secret (default '')
+#   associated_data  -- optional context bytes (default '')
+#   version          -- only 0x13 supported (default)
+# ---------------------------------------------------------------------------
+sub argon2d {
+    my ($password, $salt, $time_cost, $memory_cost, $parallelism,
+        $tag_length, %opts) = @_;
+
+    my $key     = $opts{key}             // '';
+    my $ad      = $opts{associated_data} // '';
+    my $version = $opts{version}         // ARGON2_VERSION;
+
+    # Treat every input as a raw byte string.
+    for ($password, $salt, $key, $ad) { utf8::downgrade($_, 1) or 1; }
+
+    _validate($password, $salt, $time_cost, $memory_cost, $parallelism,
+              $tag_length, $key, $ad, $version);
+
+    my $segment_length = int($memory_cost / (SYNC_POINTS * $parallelism));
+    my $m_prime        = $segment_length * SYNC_POINTS * $parallelism;
+    my $q              = int($m_prime / $parallelism);
+    my $sl_len         = $segment_length;
+    my $p              = $parallelism;
+    my $t              = $time_cost;
+
+    # H0 = BLAKE2b( LE32(p) || LE32(T) || LE32(m) || LE32(t) || LE32(v)
+    #             || LE32(type) || LE32(|P|)||P || LE32(|S|)||S
+    #             || LE32(|K|)||K || LE32(|X|)||X )
+    my $h0_in =
+          _le32($p) . _le32($tag_length) . _le32($memory_cost) . _le32($t)
+        . _le32($version) . _le32(TYPE_D)
+        . _le32(length $password) . $password
+        . _le32(length $salt)     . $salt
+        . _le32(length $key)      . $key
+        . _le32(length $ad)       . $ad;
+    my $h0 = CodingAdventures::Blake2b::blake2b($h0_in, digest_size => 64);
+
+    # Memory is addressed as memory{lane}[col].  Using a hash-of-arrays
+    # rather than an array-of-arrays avoids autovivification surprises.
+    my %memory;
+    for my $i (0 .. $p - 1) {
+        $memory{$i} = [];
+        my $b0 = _blake2b_long(BLOCK_SIZE, $h0 . _le32(0) . _le32($i));
+        my $b1 = _blake2b_long(BLOCK_SIZE, $h0 . _le32(1) . _le32($i));
+        $memory{$i}[0] = _bytes_to_block($b0);
+        $memory{$i}[1] = _bytes_to_block($b1);
+    }
+
+    for my $r (0 .. $t - 1) {
+        for my $sl (0 .. SYNC_POINTS - 1) {
+            for my $lane (0 .. $p - 1) {
+                _fill_segment(\%memory, $r, $lane, $sl, $q, $sl_len, $p);
+            }
+        }
+    }
+
+    # Final block = XOR of last column across all lanes.
+    my @final = @{ $memory{0}[$q - 1] };
+    for my $lane (1 .. $p - 1) {
+        my $last = $memory{$lane}[$q - 1];
+        for my $k (0 .. BLOCK_WORDS - 1) {
+            $final[$k] ^= $last->[$k];
+        }
+    }
+
+    return _blake2b_long($tag_length, _block_to_bytes(\@final));
+}
+
+# ---------------------------------------------------------------------------
+# argon2d_hex(...)  --  like argon2d but returns lowercase hex.
+# ---------------------------------------------------------------------------
+sub argon2d_hex {
+    return unpack("H*", argon2d(@_));
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+CodingAdventures::Argon2d - Pure Perl Argon2d password hashing (RFC 9106)
+
+=head1 SYNOPSIS
+
+  use CodingAdventures::Argon2d;
+
+  my $tag = CodingAdventures::Argon2d::argon2d(
+      $password, $salt, 3, 32, 4, 32,
+      key => $key, associated_data => $ad,
+  );
+
+  my $hex = CodingAdventures::Argon2d::argon2d_hex(
+      $password, $salt, 3, 32, 4, 32,
+  );
+
+=head1 DESCRIPTION
+
+Pure Perl implementation of Argon2d, the data-dependent Argon2 variant
+(RFC 9106).  Argon2d maximises resistance to GPU/ASIC cracking by
+choosing every reference block based on the password-derived state;
+this makes memory-access timing a side channel, so Argon2d is unsuited
+to password hashing in adversarial environments.  Use
+L<CodingAdventures::Argon2id> for password hashing.
+
+=head1 SECURITY
+
+This is a pure-Perl reference implementation.  Argon2 is designed to
+burn memory and CPU on purpose; callers control the DoS boundary via
+the C<memory_cost>, C<time_cost>, and C<parallelism> parameters.  The
+module does not attempt constant-time tag comparison -- callers MUST
+compare tags with a constant-time equality function of their own.
+
+=head1 SEE ALSO
+
+L<https://datatracker.ietf.org/doc/html/rfc9106>
+
+=cut

--- a/code/packages/perl/argon2d/required_capabilities.json
+++ b/code/packages/perl/argon2d/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "perl/argon2d",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/perl/argon2d/t/00-load.t
+++ b/code/packages/perl/argon2d/t/00-load.t
@@ -1,0 +1,12 @@
+use strict;
+use warnings;
+use Test2::V0;
+
+ok( eval { require CodingAdventures::Argon2d; 1 },
+    'CodingAdventures::Argon2d loads' );
+
+ok( CodingAdventures::Argon2d->VERSION, 'has a VERSION' );
+ok( defined &CodingAdventures::Argon2d::argon2d,     'argon2d defined' );
+ok( defined &CodingAdventures::Argon2d::argon2d_hex, 'argon2d_hex defined' );
+
+done_testing;

--- a/code/packages/perl/argon2d/t/01-argon2d.t
+++ b/code/packages/perl/argon2d/t/01-argon2d.t
@@ -1,0 +1,131 @@
+use strict;
+use warnings;
+use Test2::V0;
+
+use CodingAdventures::Argon2d;
+
+sub A_d     { CodingAdventures::Argon2d::argon2d(@_)     }
+sub A_d_hex { CodingAdventures::Argon2d::argon2d_hex(@_) }
+
+# ─── RFC 9106 §5.1 gold-standard vector ──────────────────────────────────
+#   password = 32 × 0x01
+#   salt     = 16 × 0x02
+#   key      =  8 × 0x03
+#   ad       = 12 × 0x04
+#   t=3, m=32, p=4, T=32
+#   tag      = 512b391b6f1162975371d30919734294f868e3be3984f3c1a13a4db9fabe4acb
+my $RFC_PASSWORD = "\x01" x 32;
+my $RFC_SALT     = "\x02" x 16;
+my $RFC_KEY      = "\x03" x 8;
+my $RFC_AD       = "\x04" x 12;
+my $RFC_EXPECTED =
+  '512b391b6f1162975371d30919734294f868e3be3984f3c1a13a4db9fabe4acb';
+
+is(
+    A_d_hex(
+        $RFC_PASSWORD, $RFC_SALT, 3, 32, 4, 32,
+        key => $RFC_KEY, associated_data => $RFC_AD,
+    ),
+    $RFC_EXPECTED,
+    'RFC 9106 §5.1 vector',
+);
+
+# ─── hex == binary ──────────────────────────────────────────────────────
+{
+    my $raw = A_d(
+        $RFC_PASSWORD, $RFC_SALT, 3, 32, 4, 32,
+        key => $RFC_KEY, associated_data => $RFC_AD,
+    );
+    my $hex = A_d_hex(
+        $RFC_PASSWORD, $RFC_SALT, 3, 32, 4, 32,
+        key => $RFC_KEY, associated_data => $RFC_AD,
+    );
+    is(unpack("H*", $raw), $hex, 'hex matches binary');
+}
+
+# ─── Validation rejections ──────────────────────────────────────────────
+like(
+    dies { A_d('pw', 'short', 1, 8, 1, 32) },
+    qr/salt/i,
+    'rejects short salt',
+);
+like(
+    dies { A_d('pw', 'a' x 8, 0, 8, 1, 32) },
+    qr/time_cost/i,
+    'rejects zero time_cost',
+);
+like(
+    dies { A_d('pw', 'a' x 8, 1, 8, 1, 3) },
+    qr/tag_length/i,
+    'rejects tag_length < 4',
+);
+like(
+    dies { A_d('pw', 'a' x 8, 1, 7, 1, 32) },
+    qr/memory_cost/i,
+    'rejects memory < 8*p',
+);
+like(
+    dies { A_d('pw', 'a' x 8, 1, 8, 0, 32) },
+    qr/parallelism/i,
+    'rejects zero parallelism',
+);
+like(
+    dies { A_d('pw', 'a' x 8, 1, 8, 1, 32, version => 0x10) },
+    qr/v1\.3|0x13/i,
+    'rejects unsupported version',
+);
+
+# ─── Determinism and separation ─────────────────────────────────────────
+is(
+    A_d_hex('pw', 'a' x 8, 1, 8, 1, 32),
+    A_d_hex('pw', 'a' x 8, 1, 8, 1, 32),
+    'deterministic',
+);
+
+isnt(
+    A_d_hex('pw1', 'a' x 8, 1, 8, 1, 32),
+    A_d_hex('pw2', 'a' x 8, 1, 8, 1, 32),
+    'differs on password',
+);
+
+isnt(
+    A_d_hex('pw', 'a' x 8, 1, 8, 1, 32),
+    A_d_hex('pw', 'b' x 8, 1, 8, 1, 32),
+    'differs on salt',
+);
+
+# ─── Key / AD binding ───────────────────────────────────────────────────
+{
+    my $no_key = A_d_hex('pw', 'a' x 8, 1, 8, 1, 32);
+    my $k1     = A_d_hex('pw', 'a' x 8, 1, 8, 1, 32, key => 'k1');
+    my $k2     = A_d_hex('pw', 'a' x 8, 1, 8, 1, 32, key => 'k2');
+    isnt($no_key, $k1, 'key binds (vs none)');
+    isnt($k1,     $k2, 'key binds (k1 vs k2)');
+}
+{
+    my $no_ad = A_d_hex('pw', 'a' x 8, 1, 8, 1, 32);
+    my $ad1   = A_d_hex('pw', 'a' x 8, 1, 8, 1, 32, associated_data => 'x');
+    my $ad2   = A_d_hex('pw', 'a' x 8, 1, 8, 1, 32, associated_data => 'y');
+    isnt($no_ad, $ad1, 'AD binds (vs none)');
+    isnt($ad1,   $ad2, 'AD binds (x vs y)');
+}
+
+# ─── Tag length variants ────────────────────────────────────────────────
+is(length A_d('pw', 'a' x 8, 1, 8, 1,   4),   4, 'tag_length 4');
+is(length A_d('pw', 'a' x 8, 1, 8, 1,  16),  16, 'tag_length 16');
+is(length A_d('pw', 'a' x 8, 1, 8, 1,  65),  65, 'tag_length 65 (H\' boundary)');
+is(length A_d('pw', 'a' x 8, 1, 8, 1, 128), 128, 'tag_length 128');
+
+# ─── Parallelism / multi-pass ───────────────────────────────────────────
+is(
+    length A_d('pw', 'a' x 8, 1, 16, 2, 32),
+    32,
+    'multi-lane tag size',
+);
+isnt(
+    A_d_hex('pw', 'a' x 8, 1, 8, 1, 32),
+    A_d_hex('pw', 'a' x 8, 2, 8, 1, 32),
+    'multi-pass differs from single-pass',
+);
+
+done_testing;

--- a/code/packages/perl/argon2i/BUILD
+++ b/code/packages/perl/argon2i/BUILD
@@ -1,0 +1,1 @@
+PERL5LIB=../blake2b/lib prove -l -v t/

--- a/code/packages/perl/argon2i/BUILD_windows
+++ b/code/packages/perl/argon2i/BUILD_windows
@@ -1,0 +1,1 @@
+echo Perl testing is not supported on Windows - skipping

--- a/code/packages/perl/argon2i/CHANGELOG.md
+++ b/code/packages/perl/argon2i/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.01] - 2026-04-20
+
+### Added
+
+- Initial pure-Perl port of Argon2i (RFC 9106).
+- `argon2i(...)` — raw binary tag.
+- `argon2i_hex(...)` — lowercase hex tag.
+- Validation of RFC 9106 parameter bounds (salt ≥ 8 bytes, tag ≥ 4 bytes,
+  parallelism in [1, 2²⁴-1], memory ≥ 8·parallelism, 32-bit length caps).
+- Test suite with the RFC 9106 §5.2 gold-standard vector and
+  parameter-edge coverage.

--- a/code/packages/perl/argon2i/Makefile.PL
+++ b/code/packages/perl/argon2i/Makefile.PL
@@ -1,0 +1,28 @@
+use strict;
+use warnings;
+use ExtUtils::MakeMaker;
+
+WriteMakefile(
+    NAME             => 'CodingAdventures::Argon2i',
+    VERSION_FROM     => 'lib/CodingAdventures/Argon2i.pm',
+    ABSTRACT         => 'Pure Perl Argon2i (RFC 9106) data-independent memory-hard KDF',
+    AUTHOR           => 'coding-adventures',
+    LICENSE          => 'mit',
+    MIN_PERL_VERSION => '5.026000',
+    PREREQ_PM        => {
+        'CodingAdventures::Blake2b' => 0,
+    },
+    TEST_REQUIRES    => {
+        'Test2::V0' => 0,
+    },
+    META_MERGE       => {
+        'meta-spec' => { version => 2 },
+        resources   => {
+            repository => {
+                type => 'git',
+                url  => 'https://github.com/adhithyan15/coding-adventures.git',
+                web  => 'https://github.com/adhithyan15/coding-adventures',
+            },
+        },
+    },
+);

--- a/code/packages/perl/argon2i/README.md
+++ b/code/packages/perl/argon2i/README.md
@@ -1,0 +1,59 @@
+# CodingAdventures::Argon2i
+
+Pure-Perl implementation of **Argon2i** (RFC 9106) — the
+data-independent variant of the Argon2 memory-hard password hashing
+family.
+
+## What is Argon2i?
+
+Argon2i derives every reference-block index from a deterministic
+pseudo-random stream seeded purely from public parameters (pass, lane,
+slice, total memory, total passes, type, counter). The memory-access
+pattern is therefore constant across secrets, which defeats
+memory-access side-channel observers at the cost of making the variant
+the easiest for GPUs/ASICs to parallelise.
+
+For general-purpose password hashing prefer
+[`CodingAdventures::Argon2id`](../argon2id/). Use Argon2i only when
+side-channel resistance is the dominant concern.
+
+## Installation
+
+```
+cpanm --installdeps .
+perl Makefile.PL
+make
+make test
+```
+
+Runtime dependency: [`CodingAdventures::Blake2b`](../blake2b/).
+
+## Usage
+
+```perl
+use CodingAdventures::Argon2i;
+
+my $tag = CodingAdventures::Argon2i::argon2i(
+    $password, $salt, 3, 65536, 4, 32,
+    key             => $optional_key,
+    associated_data => $optional_ad,
+);
+
+my $hex = CodingAdventures::Argon2i::argon2i_hex(
+    $password, $salt, 3, 65536, 4, 32,
+);
+```
+
+## Security
+
+Argon2 is designed to burn memory and CPU. Callers control the DoS
+boundary via `memory_cost`, `time_cost`, and `parallelism` — do not
+forward untrusted values.
+
+This module does **not** perform constant-time tag comparison. Use a
+constant-time equality primitive of your own when verifying a tag.
+
+## Where this fits
+
+Argon2i sits in the `KD03` key-derivation layer. It depends only on
+`CodingAdventures::Blake2b` (from `HF06`).

--- a/code/packages/perl/argon2i/cpanfile
+++ b/code/packages/perl/argon2i/cpanfile
@@ -1,0 +1,6 @@
+requires 'CodingAdventures::Blake2b';
+
+# Test dependencies
+on 'test' => sub {
+    requires 'Test2::V0';
+};

--- a/code/packages/perl/argon2i/lib/CodingAdventures/Argon2i.pm
+++ b/code/packages/perl/argon2i/lib/CodingAdventures/Argon2i.pm
@@ -1,0 +1,318 @@
+package CodingAdventures::Argon2i;
+
+# ============================================================================
+# CodingAdventures::Argon2i -- Pure Perl Argon2i (RFC 9106)
+# ============================================================================
+#
+# Argon2i is the data-INDEPENDENT variant.  Reference-block indices are
+# derived from a deterministic pseudo-random stream that is seeded purely
+# from public parameters: (pass, lane, slice, total memory, total passes,
+# type, counter).  The access pattern is therefore constant across secrets,
+# which defeats memory-access side channels at the cost of making Argon2i
+# the easiest variant for GPUs/ASICs to parallelise.
+#
+# For general password hashing prefer CodingAdventures::Argon2id.  Use
+# Argon2i only when side-channel resistance dominates the threat model.
+#
+# Reference: https://datatracker.ietf.org/doc/html/rfc9106
+# See also:  code/specs/KD03-argon2.md
+#
+# The arithmetic core (G mixer, permutation P, compression G, H', index
+# alpha, parameter validation) is identical to Argon2d -- only the
+# fill_segment routine differs.  The duplication is deliberate: each
+# package is self-contained and publishable on its own.
+
+use strict;
+use warnings;
+no warnings 'portable';
+
+use CodingAdventures::Blake2b ();
+
+our $VERSION = '0.01';
+
+use constant MASK32              => 0xFFFFFFFF;
+use constant MASK64              => 0xFFFFFFFFFFFFFFFF;
+use constant BLOCK_SIZE          => 1024;
+use constant BLOCK_WORDS         => 128;
+use constant ADDRESSES_PER_BLOCK => 128;   # = BLOCK_WORDS
+use constant SYNC_POINTS         => 4;
+use constant ARGON2_VERSION      => 0x13;
+use constant TYPE_I              => 1;
+
+sub _rotr64 {
+    my ($x, $n) = @_;
+    return ((($x >> $n) | ($x << (64 - $n))) & MASK64);
+}
+
+sub _gb {
+    my ($v, $a, $b, $c, $d) = @_;
+    my ($va, $vb, $vc, $vd) = ($v->[$a], $v->[$b], $v->[$c], $v->[$d]);
+    { use integer;
+      $va = ($va + $vb + 2 * ($va & MASK32) * ($vb & MASK32)) & MASK64; }
+    $vd = _rotr64($vd ^ $va, 32);
+    { use integer;
+      $vc = ($vc + $vd + 2 * ($vc & MASK32) * ($vd & MASK32)) & MASK64; }
+    $vb = _rotr64($vb ^ $vc, 24);
+    { use integer;
+      $va = ($va + $vb + 2 * ($va & MASK32) * ($vb & MASK32)) & MASK64; }
+    $vd = _rotr64($vd ^ $va, 16);
+    { use integer;
+      $vc = ($vc + $vd + 2 * ($vc & MASK32) * ($vd & MASK32)) & MASK64; }
+    $vb = _rotr64($vb ^ $vc, 63);
+    ($v->[$a], $v->[$b], $v->[$c], $v->[$d]) = ($va, $vb, $vc, $vd);
+}
+
+sub _permutation_p {
+    my ($v, $off) = @_;
+    $off //= 0;
+    _gb($v, $off + 0, $off + 4, $off +  8, $off + 12);
+    _gb($v, $off + 1, $off + 5, $off +  9, $off + 13);
+    _gb($v, $off + 2, $off + 6, $off + 10, $off + 14);
+    _gb($v, $off + 3, $off + 7, $off + 11, $off + 15);
+    _gb($v, $off + 0, $off + 5, $off + 10, $off + 15);
+    _gb($v, $off + 1, $off + 6, $off + 11, $off + 12);
+    _gb($v, $off + 2, $off + 7, $off +  8, $off + 13);
+    _gb($v, $off + 3, $off + 4, $off +  9, $off + 14);
+}
+
+sub _compress {
+    my ($x, $y) = @_;
+    my @r = map { $x->[$_] ^ $y->[$_] } 0 .. BLOCK_WORDS - 1;
+    my @q = @r;
+    for my $i (0 .. 7) { _permutation_p(\@q, $i * 16); }
+    my @col;
+    for my $c (0 .. 7) {
+        for my $rr (0 .. 7) {
+            $col[2 * $rr]     = $q[$rr * 16 + 2 * $c];
+            $col[2 * $rr + 1] = $q[$rr * 16 + 2 * $c + 1];
+        }
+        _permutation_p(\@col, 0);
+        for my $rr (0 .. 7) {
+            $q[$rr * 16 + 2 * $c]     = $col[2 * $rr];
+            $q[$rr * 16 + 2 * $c + 1] = $col[2 * $rr + 1];
+        }
+    }
+    return [ map { $r[$_] ^ $q[$_] } 0 .. BLOCK_WORDS - 1 ];
+}
+
+sub _block_to_bytes { pack("Q<" . BLOCK_WORDS, @{$_[0]}) }
+sub _bytes_to_block { [ unpack("Q<" . BLOCK_WORDS, $_[0]) ] }
+sub _le32           { pack("V", $_[0]) }
+
+sub _blake2b_long {
+    my ($t, $x) = @_;
+    die "H' output length must be positive\n" if $t <= 0;
+    my $input = _le32($t) . $x;
+    return CodingAdventures::Blake2b::blake2b($input, digest_size => $t)
+        if $t <= 64;
+    my $r = int(($t + 31) / 32) - 2;
+    my $v = CodingAdventures::Blake2b::blake2b($input, digest_size => 64);
+    my $out = substr($v, 0, 32);
+    for (1 .. $r - 1) {
+        $v = CodingAdventures::Blake2b::blake2b($v, digest_size => 64);
+        $out .= substr($v, 0, 32);
+    }
+    my $final_size = $t - 32 * $r;
+    $v = CodingAdventures::Blake2b::blake2b($v, digest_size => $final_size);
+    $out .= $v;
+    return $out;
+}
+
+sub _index_alpha {
+    my ($j1, $r, $sl, $c, $same_lane, $q, $sl_len) = @_;
+    my ($w, $start);
+    if ($r == 0 && $sl == 0) {
+        $w = $c - 1; $start = 0;
+    } elsif ($r == 0) {
+        $w = $same_lane ? $sl * $sl_len + $c - 1
+            : $c == 0   ? $sl * $sl_len - 1
+            :             $sl * $sl_len;
+        $start = 0;
+    } else {
+        $w = $same_lane ? $q - $sl_len + $c - 1
+            : $c == 0   ? $q - $sl_len - 1
+            :             $q - $sl_len;
+        $start = (($sl + 1) * $sl_len) % $q;
+    }
+    my $x   = ($j1 * $j1) >> 32;
+    my $y   = ($w * $x)   >> 32;
+    my $rel = $w - 1 - $y;
+    return ($start + $rel) % $q;
+}
+
+# ---------------------------------------------------------------------------
+# _fill_segment  (Argon2i-specific)
+#
+# J1/J2 come from a deterministic address stream generated by
+# double-G(0, compress(0, input_block)), where input_block carries
+# (pass r, lane, slice sl, m', t_total, TYPE_I, counter) in its first
+# seven words.  The counter is bumped once per 128-word chunk of the
+# segment; the address block is re-derived lazily when the previous
+# chunk is exhausted.
+# ---------------------------------------------------------------------------
+sub _fill_segment {
+    my ($memory, $r, $lane, $sl, $q, $sl_len, $p, $m_prime, $t_total) = @_;
+
+    my @input   = (0) x BLOCK_WORDS;
+    my @address = (0) x BLOCK_WORDS;
+    my @zero    = (0) x BLOCK_WORDS;
+    $input[0] = $r;
+    $input[1] = $lane;
+    $input[2] = $sl;
+    $input[3] = $m_prime;
+    $input[4] = $t_total;
+    $input[5] = TYPE_I;
+
+    my $refresh = sub {
+        $input[6]++;
+        my $z = _compress(\@zero, \@input);
+        @address = @{ _compress(\@zero, $z) };
+    };
+
+    my $starting_c = ($r == 0 && $sl == 0) ? 2 : 0;
+    $refresh->() if $starting_c != 0;
+
+    for my $i ($starting_c .. $sl_len - 1) {
+        if ($i % ADDRESSES_PER_BLOCK == 0
+            && !($r == 0 && $sl == 0 && $i == 2))
+        {
+            $refresh->();
+        }
+
+        my $col = $sl * $sl_len + $i;
+        my $prev_col = $col == 0 ? $q - 1 : $col - 1;
+        my $prev_block = $memory->{$lane}[$prev_col];
+
+        my $pseudo_rand = $address[$i % ADDRESSES_PER_BLOCK];
+        my $j1 = $pseudo_rand & MASK32;
+        my $j2 = ($pseudo_rand >> 32) & MASK32;
+
+        my $l_prime = $lane;
+        $l_prime = $j2 % $p unless ($r == 0 && $sl == 0);
+
+        my $z_prime = _index_alpha($j1, $r, $sl, $i, $l_prime == $lane,
+                                   $q, $sl_len);
+        my $ref_block = $memory->{$l_prime}[$z_prime];
+
+        my $new_block = _compress($prev_block, $ref_block);
+        if ($r == 0) {
+            $memory->{$lane}[$col] = $new_block;
+        } else {
+            my $existing = $memory->{$lane}[$col];
+            $memory->{$lane}[$col] =
+                [ map { $existing->[$_] ^ $new_block->[$_] }
+                      0 .. BLOCK_WORDS - 1 ];
+        }
+    }
+}
+
+sub _validate {
+    my ($password, $salt, $t, $m, $p, $tag_length, $key, $ad, $version) = @_;
+    die "password length must fit in 32 bits\n" if length($password) > MASK32;
+    die "salt must be at least 8 bytes\n"       if length($salt) < 8;
+    die "salt length must fit in 32 bits\n"     if length($salt) > MASK32;
+    die "key length must fit in 32 bits\n"      if length($key)  > MASK32;
+    die "associated_data length must fit in 32 bits\n"
+        if length($ad) > MASK32;
+    die "tag_length must be >= 4\n"             if $tag_length < 4;
+    die "tag_length must fit in 32 bits\n"      if $tag_length > MASK32;
+    die "parallelism must be in [1, 2^24-1]\n"
+        unless defined $p && $p =~ /\A\d+\z/ && $p >= 1 && $p <= 0xFFFFFF;
+    die "memory_cost must be >= 8*parallelism\n" if $m < 8 * $p;
+    die "memory_cost must fit in 32 bits\n"      if $m > MASK32;
+    die "time_cost must be >= 1\n"               if $t < 1;
+    die "only Argon2 v1.3 (0x13) is supported\n"
+        unless $version == ARGON2_VERSION;
+}
+
+sub argon2i {
+    my ($password, $salt, $time_cost, $memory_cost, $parallelism,
+        $tag_length, %opts) = @_;
+
+    my $key     = $opts{key}             // '';
+    my $ad      = $opts{associated_data} // '';
+    my $version = $opts{version}         // ARGON2_VERSION;
+
+    for ($password, $salt, $key, $ad) { utf8::downgrade($_, 1) or 1; }
+
+    _validate($password, $salt, $time_cost, $memory_cost, $parallelism,
+              $tag_length, $key, $ad, $version);
+
+    my $segment_length = int($memory_cost / (SYNC_POINTS * $parallelism));
+    my $m_prime        = $segment_length * SYNC_POINTS * $parallelism;
+    my $q              = int($m_prime / $parallelism);
+    my $sl_len         = $segment_length;
+    my $p              = $parallelism;
+    my $t              = $time_cost;
+
+    my $h0_in =
+          _le32($p) . _le32($tag_length) . _le32($memory_cost) . _le32($t)
+        . _le32($version) . _le32(TYPE_I)
+        . _le32(length $password) . $password
+        . _le32(length $salt)     . $salt
+        . _le32(length $key)      . $key
+        . _le32(length $ad)       . $ad;
+    my $h0 = CodingAdventures::Blake2b::blake2b($h0_in, digest_size => 64);
+
+    my %memory;
+    for my $i (0 .. $p - 1) {
+        $memory{$i} = [];
+        my $b0 = _blake2b_long(BLOCK_SIZE, $h0 . _le32(0) . _le32($i));
+        my $b1 = _blake2b_long(BLOCK_SIZE, $h0 . _le32(1) . _le32($i));
+        $memory{$i}[0] = _bytes_to_block($b0);
+        $memory{$i}[1] = _bytes_to_block($b1);
+    }
+
+    for my $r (0 .. $t - 1) {
+        for my $sl (0 .. SYNC_POINTS - 1) {
+            for my $lane (0 .. $p - 1) {
+                _fill_segment(\%memory, $r, $lane, $sl, $q, $sl_len,
+                              $p, $m_prime, $t);
+            }
+        }
+    }
+
+    my @final = @{ $memory{0}[$q - 1] };
+    for my $lane (1 .. $p - 1) {
+        my $last = $memory{$lane}[$q - 1];
+        for my $k (0 .. BLOCK_WORDS - 1) {
+            $final[$k] ^= $last->[$k];
+        }
+    }
+
+    return _blake2b_long($tag_length, _block_to_bytes(\@final));
+}
+
+sub argon2i_hex {
+    return unpack("H*", argon2i(@_));
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+CodingAdventures::Argon2i - Pure Perl Argon2i password hashing (RFC 9106)
+
+=head1 SYNOPSIS
+
+  use CodingAdventures::Argon2i;
+
+  my $tag = CodingAdventures::Argon2i::argon2i(
+      $password, $salt, 3, 32, 4, 32,
+      key => $key, associated_data => $ad,
+  );
+
+=head1 DESCRIPTION
+
+Argon2i derives reference-block indices from a deterministic public
+stream, giving side-channel resistance at the cost of GPU/ASIC
+hardening.  For general-purpose password hashing prefer
+L<CodingAdventures::Argon2id>.
+
+=head1 SEE ALSO
+
+L<https://datatracker.ietf.org/doc/html/rfc9106>
+
+=cut

--- a/code/packages/perl/argon2i/lib/CodingAdventures/Argon2i.pm
+++ b/code/packages/perl/argon2i/lib/CodingAdventures/Argon2i.pm
@@ -26,6 +26,13 @@ use strict;
 use warnings;
 no warnings 'portable';
 
+use Config;
+BEGIN {
+    die "CodingAdventures::Argon2i requires 64-bit Perl (ivsize >= 8); "
+      . "this build has ivsize=$Config{ivsize}\n"
+        if $Config{ivsize} < 8;
+}
+
 use CodingAdventures::Blake2b ();
 
 our $VERSION = '0.01';
@@ -233,7 +240,18 @@ sub argon2i {
     my $ad      = $opts{associated_data} // '';
     my $version = $opts{version}         // ARGON2_VERSION;
 
-    for ($password, $salt, $key, $ad) { utf8::downgrade($_, 1) or 1; }
+    # Refuse wide-character input rather than silently UTF-8-encoding it
+    # into a tag that no reference Argon2 implementation can reproduce.
+    for my $name_and_val (
+        [ password        => \$password ],
+        [ salt            => \$salt     ],
+        [ key             => \$key      ],
+        [ associated_data => \$ad       ],
+    ) {
+        my ($name, $ref) = @$name_and_val;
+        utf8::downgrade($$ref, 1)
+            or die "$name must be a byte string; refusing wide characters\n";
+    }
 
     _validate($password, $salt, $time_cost, $memory_cost, $parallelism,
               $tag_length, $key, $ad, $version);

--- a/code/packages/perl/argon2i/required_capabilities.json
+++ b/code/packages/perl/argon2i/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "perl/argon2i",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/perl/argon2i/t/00-load.t
+++ b/code/packages/perl/argon2i/t/00-load.t
@@ -1,0 +1,12 @@
+use strict;
+use warnings;
+use Test2::V0;
+
+ok( eval { require CodingAdventures::Argon2i; 1 },
+    'CodingAdventures::Argon2i loads' );
+
+ok( CodingAdventures::Argon2i->VERSION, 'has a VERSION' );
+ok( defined &CodingAdventures::Argon2i::argon2i,     'argon2i defined' );
+ok( defined &CodingAdventures::Argon2i::argon2i_hex, 'argon2i_hex defined' );
+
+done_testing;

--- a/code/packages/perl/argon2i/t/01-argon2i.t
+++ b/code/packages/perl/argon2i/t/01-argon2i.t
@@ -1,0 +1,87 @@
+use strict;
+use warnings;
+use Test2::V0;
+
+use CodingAdventures::Argon2i;
+
+sub A     { CodingAdventures::Argon2i::argon2i(@_)     }
+sub A_hex { CodingAdventures::Argon2i::argon2i_hex(@_) }
+
+# ─── RFC 9106 §5.2 gold-standard vector ──────────────────────────────────
+my $RFC_PASSWORD = "\x01" x 32;
+my $RFC_SALT     = "\x02" x 16;
+my $RFC_KEY      = "\x03" x 8;
+my $RFC_AD       = "\x04" x 12;
+my $RFC_EXPECTED =
+  'c814d9d1dc7f37aa13f0d77f2494bda1c8de6b016dd388d29952a4c4672b6ce8';
+
+is(
+    A_hex(
+        $RFC_PASSWORD, $RFC_SALT, 3, 32, 4, 32,
+        key => $RFC_KEY, associated_data => $RFC_AD,
+    ),
+    $RFC_EXPECTED,
+    'RFC 9106 §5.2 vector',
+);
+
+{
+    my $raw = A(
+        $RFC_PASSWORD, $RFC_SALT, 3, 32, 4, 32,
+        key => $RFC_KEY, associated_data => $RFC_AD,
+    );
+    my $hex = A_hex(
+        $RFC_PASSWORD, $RFC_SALT, 3, 32, 4, 32,
+        key => $RFC_KEY, associated_data => $RFC_AD,
+    );
+    is(unpack("H*", $raw), $hex, 'hex matches binary');
+}
+
+# ─── Validation rejections ──────────────────────────────────────────────
+like(dies { A('pw', 'short',   1, 8, 1, 32) }, qr/salt/i,       'rejects short salt');
+like(dies { A('pw', 'a' x 8,   0, 8, 1, 32) }, qr/time_cost/i,  'rejects zero time_cost');
+like(dies { A('pw', 'a' x 8,   1, 8, 1,  3) }, qr/tag_length/i, 'rejects tag_length < 4');
+like(dies { A('pw', 'a' x 8,   1, 7, 1, 32) }, qr/memory_cost/i,'rejects memory < 8*p');
+like(dies { A('pw', 'a' x 8,   1, 8, 0, 32) }, qr/parallelism/i,'rejects zero parallelism');
+like(dies { A('pw', 'a' x 8,   1, 8, 1, 32, version => 0x10) },
+     qr/v1\.3|0x13/i, 'rejects unsupported version');
+
+# ─── Determinism and separation ─────────────────────────────────────────
+is(A_hex('pw', 'a' x 8, 1, 8, 1, 32),
+   A_hex('pw', 'a' x 8, 1, 8, 1, 32),
+   'deterministic');
+isnt(A_hex('pw1', 'a' x 8, 1, 8, 1, 32),
+     A_hex('pw2', 'a' x 8, 1, 8, 1, 32),
+     'differs on password');
+isnt(A_hex('pw', 'a' x 8, 1, 8, 1, 32),
+     A_hex('pw', 'b' x 8, 1, 8, 1, 32),
+     'differs on salt');
+
+# ─── Key / AD binding ───────────────────────────────────────────────────
+{
+    my $no_key = A_hex('pw', 'a' x 8, 1, 8, 1, 32);
+    my $k1     = A_hex('pw', 'a' x 8, 1, 8, 1, 32, key => 'k1');
+    my $k2     = A_hex('pw', 'a' x 8, 1, 8, 1, 32, key => 'k2');
+    isnt($no_key, $k1, 'key binds (vs none)');
+    isnt($k1,     $k2, 'key binds (k1 vs k2)');
+}
+{
+    my $no_ad = A_hex('pw', 'a' x 8, 1, 8, 1, 32);
+    my $ad1   = A_hex('pw', 'a' x 8, 1, 8, 1, 32, associated_data => 'x');
+    my $ad2   = A_hex('pw', 'a' x 8, 1, 8, 1, 32, associated_data => 'y');
+    isnt($no_ad, $ad1, 'AD binds (vs none)');
+    isnt($ad1,   $ad2, 'AD binds (x vs y)');
+}
+
+# ─── Tag length variants ────────────────────────────────────────────────
+is(length A('pw', 'a' x 8, 1, 8, 1,   4),   4, 'tag_length 4');
+is(length A('pw', 'a' x 8, 1, 8, 1,  16),  16, 'tag_length 16');
+is(length A('pw', 'a' x 8, 1, 8, 1,  65),  65, 'tag_length 65');
+is(length A('pw', 'a' x 8, 1, 8, 1, 128), 128, 'tag_length 128');
+
+# ─── Parallelism / multi-pass ───────────────────────────────────────────
+is(length A('pw', 'a' x 8, 1, 16, 2, 32), 32, 'multi-lane tag size');
+isnt(A_hex('pw', 'a' x 8, 1, 8, 1, 32),
+     A_hex('pw', 'a' x 8, 2, 8, 1, 32),
+     'multi-pass differs from single-pass');
+
+done_testing;

--- a/code/packages/perl/argon2id/BUILD
+++ b/code/packages/perl/argon2id/BUILD
@@ -1,0 +1,1 @@
+PERL5LIB=../blake2b/lib prove -l -v t/

--- a/code/packages/perl/argon2id/BUILD_windows
+++ b/code/packages/perl/argon2id/BUILD_windows
@@ -1,0 +1,1 @@
+echo Perl testing is not supported on Windows - skipping

--- a/code/packages/perl/argon2id/CHANGELOG.md
+++ b/code/packages/perl/argon2id/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.01] - 2026-04-20
+
+### Added
+
+- Initial pure-Perl port of Argon2id (RFC 9106) — hybrid variant and
+  the RFC-recommended default for password hashing.
+- `argon2id(...)` — raw binary tag.
+- `argon2id_hex(...)` — lowercase hex tag.
+- Validation of RFC 9106 parameter bounds (salt ≥ 8 bytes, tag ≥ 4 bytes,
+  parallelism in [1, 2²⁴-1], memory ≥ 8·parallelism, 32-bit length caps).
+- Test suite with the RFC 9106 §5.3 gold-standard vector and
+  parameter-edge coverage.

--- a/code/packages/perl/argon2id/Makefile.PL
+++ b/code/packages/perl/argon2id/Makefile.PL
@@ -1,0 +1,28 @@
+use strict;
+use warnings;
+use ExtUtils::MakeMaker;
+
+WriteMakefile(
+    NAME             => 'CodingAdventures::Argon2id',
+    VERSION_FROM     => 'lib/CodingAdventures/Argon2id.pm',
+    ABSTRACT         => 'Pure Perl Argon2id (RFC 9106) hybrid memory-hard KDF',
+    AUTHOR           => 'coding-adventures',
+    LICENSE          => 'mit',
+    MIN_PERL_VERSION => '5.026000',
+    PREREQ_PM        => {
+        'CodingAdventures::Blake2b' => 0,
+    },
+    TEST_REQUIRES    => {
+        'Test2::V0' => 0,
+    },
+    META_MERGE       => {
+        'meta-spec' => { version => 2 },
+        resources   => {
+            repository => {
+                type => 'git',
+                url  => 'https://github.com/adhithyan15/coding-adventures.git',
+                web  => 'https://github.com/adhithyan15/coding-adventures',
+            },
+        },
+    },
+);

--- a/code/packages/perl/argon2id/README.md
+++ b/code/packages/perl/argon2id/README.md
@@ -1,0 +1,65 @@
+# CodingAdventures::Argon2id
+
+Pure-Perl implementation of **Argon2id** (RFC 9106) — the hybrid
+Argon2 variant and the RFC-recommended default for password hashing.
+
+## What is Argon2id?
+
+Argon2id runs the Argon2**i** (data-independent) fill for the first
+pass over the first two slices, then switches to the Argon2**d**
+(data-dependent) fill for the rest of the computation. You get
+Argon2i's side-channel resistance over the memory region most
+accessible to a timing attacker, plus Argon2d's GPU/ASIC hardening
+everywhere else.
+
+**This is the variant you want for password hashing.**
+
+## Installation
+
+```
+cpanm --installdeps .
+perl Makefile.PL
+make
+make test
+```
+
+Runtime dependency: [`CodingAdventures::Blake2b`](../blake2b/).
+
+## Usage
+
+```perl
+use CodingAdventures::Argon2id;
+
+# Sensible defaults (adjust memory/time for your hardware).
+my $tag = CodingAdventures::Argon2id::argon2id(
+    $password, $salt,
+    3,       # time_cost
+    65536,   # memory_cost (KiB)
+    4,       # parallelism
+    32,      # tag_length
+);
+
+my $hex = CodingAdventures::Argon2id::argon2id_hex(
+    $password, $salt, 3, 65536, 4, 32,
+);
+```
+
+Optional arguments (hash-style):
+- `key             => $secret_mac_key`
+- `associated_data => $context_bytes`
+
+## Security
+
+Argon2 is designed to burn memory and CPU. Callers control the DoS
+boundary via `memory_cost`, `time_cost`, and `parallelism` — do not
+forward untrusted values.
+
+**Constant-time comparison**: this module does *not* constant-time-
+compare tags for you. When verifying an Argon2id tag against a stored
+value, use a constant-time equality helper to defeat byte-level timing
+oracles.
+
+## Where this fits
+
+Argon2id sits in the `KD03` key-derivation layer. It depends only on
+`CodingAdventures::Blake2b` (from `HF06`).

--- a/code/packages/perl/argon2id/cpanfile
+++ b/code/packages/perl/argon2id/cpanfile
@@ -1,0 +1,6 @@
+requires 'CodingAdventures::Blake2b';
+
+# Test dependencies
+on 'test' => sub {
+    requires 'Test2::V0';
+};

--- a/code/packages/perl/argon2id/lib/CodingAdventures/Argon2id.pm
+++ b/code/packages/perl/argon2id/lib/CodingAdventures/Argon2id.pm
@@ -1,0 +1,314 @@
+package CodingAdventures::Argon2id;
+
+# ============================================================================
+# CodingAdventures::Argon2id -- Pure Perl Argon2id (RFC 9106)
+# ============================================================================
+#
+# Argon2id is the HYBRID variant and the RFC 9106 default for password
+# hashing.  During the first pass (r == 0) and the first two slices
+# (sl < 2), the reference-block indices come from the same
+# data-independent address stream that Argon2i uses -- giving
+# side-channel resistance over the part of memory most accessible to a
+# timing attacker.  Thereafter the indices come from the previous
+# block's first word (Argon2d-style), giving GPU/ASIC hardening.
+#
+# Reference: https://datatracker.ietf.org/doc/html/rfc9106
+# See also:  code/specs/KD03-argon2.md
+
+use strict;
+use warnings;
+no warnings 'portable';
+
+use CodingAdventures::Blake2b ();
+
+our $VERSION = '0.01';
+
+use constant MASK32              => 0xFFFFFFFF;
+use constant MASK64              => 0xFFFFFFFFFFFFFFFF;
+use constant BLOCK_SIZE          => 1024;
+use constant BLOCK_WORDS         => 128;
+use constant ADDRESSES_PER_BLOCK => 128;
+use constant SYNC_POINTS         => 4;
+use constant ARGON2_VERSION      => 0x13;
+use constant TYPE_ID             => 2;
+
+sub _rotr64 {
+    my ($x, $n) = @_;
+    return ((($x >> $n) | ($x << (64 - $n))) & MASK64);
+}
+
+sub _gb {
+    my ($v, $a, $b, $c, $d) = @_;
+    my ($va, $vb, $vc, $vd) = ($v->[$a], $v->[$b], $v->[$c], $v->[$d]);
+    { use integer;
+      $va = ($va + $vb + 2 * ($va & MASK32) * ($vb & MASK32)) & MASK64; }
+    $vd = _rotr64($vd ^ $va, 32);
+    { use integer;
+      $vc = ($vc + $vd + 2 * ($vc & MASK32) * ($vd & MASK32)) & MASK64; }
+    $vb = _rotr64($vb ^ $vc, 24);
+    { use integer;
+      $va = ($va + $vb + 2 * ($va & MASK32) * ($vb & MASK32)) & MASK64; }
+    $vd = _rotr64($vd ^ $va, 16);
+    { use integer;
+      $vc = ($vc + $vd + 2 * ($vc & MASK32) * ($vd & MASK32)) & MASK64; }
+    $vb = _rotr64($vb ^ $vc, 63);
+    ($v->[$a], $v->[$b], $v->[$c], $v->[$d]) = ($va, $vb, $vc, $vd);
+}
+
+sub _permutation_p {
+    my ($v, $off) = @_;
+    $off //= 0;
+    _gb($v, $off + 0, $off + 4, $off +  8, $off + 12);
+    _gb($v, $off + 1, $off + 5, $off +  9, $off + 13);
+    _gb($v, $off + 2, $off + 6, $off + 10, $off + 14);
+    _gb($v, $off + 3, $off + 7, $off + 11, $off + 15);
+    _gb($v, $off + 0, $off + 5, $off + 10, $off + 15);
+    _gb($v, $off + 1, $off + 6, $off + 11, $off + 12);
+    _gb($v, $off + 2, $off + 7, $off +  8, $off + 13);
+    _gb($v, $off + 3, $off + 4, $off +  9, $off + 14);
+}
+
+sub _compress {
+    my ($x, $y) = @_;
+    my @r = map { $x->[$_] ^ $y->[$_] } 0 .. BLOCK_WORDS - 1;
+    my @q = @r;
+    for my $i (0 .. 7) { _permutation_p(\@q, $i * 16); }
+    my @col;
+    for my $c (0 .. 7) {
+        for my $rr (0 .. 7) {
+            $col[2 * $rr]     = $q[$rr * 16 + 2 * $c];
+            $col[2 * $rr + 1] = $q[$rr * 16 + 2 * $c + 1];
+        }
+        _permutation_p(\@col, 0);
+        for my $rr (0 .. 7) {
+            $q[$rr * 16 + 2 * $c]     = $col[2 * $rr];
+            $q[$rr * 16 + 2 * $c + 1] = $col[2 * $rr + 1];
+        }
+    }
+    return [ map { $r[$_] ^ $q[$_] } 0 .. BLOCK_WORDS - 1 ];
+}
+
+sub _block_to_bytes { pack("Q<" . BLOCK_WORDS, @{$_[0]}) }
+sub _bytes_to_block { [ unpack("Q<" . BLOCK_WORDS, $_[0]) ] }
+sub _le32           { pack("V", $_[0]) }
+
+sub _blake2b_long {
+    my ($t, $x) = @_;
+    die "H' output length must be positive\n" if $t <= 0;
+    my $input = _le32($t) . $x;
+    return CodingAdventures::Blake2b::blake2b($input, digest_size => $t)
+        if $t <= 64;
+    my $r = int(($t + 31) / 32) - 2;
+    my $v = CodingAdventures::Blake2b::blake2b($input, digest_size => 64);
+    my $out = substr($v, 0, 32);
+    for (1 .. $r - 1) {
+        $v = CodingAdventures::Blake2b::blake2b($v, digest_size => 64);
+        $out .= substr($v, 0, 32);
+    }
+    my $final_size = $t - 32 * $r;
+    $v = CodingAdventures::Blake2b::blake2b($v, digest_size => $final_size);
+    $out .= $v;
+    return $out;
+}
+
+sub _index_alpha {
+    my ($j1, $r, $sl, $c, $same_lane, $q, $sl_len) = @_;
+    my ($w, $start);
+    if ($r == 0 && $sl == 0) {
+        $w = $c - 1; $start = 0;
+    } elsif ($r == 0) {
+        $w = $same_lane ? $sl * $sl_len + $c - 1
+            : $c == 0   ? $sl * $sl_len - 1
+            :             $sl * $sl_len;
+        $start = 0;
+    } else {
+        $w = $same_lane ? $q - $sl_len + $c - 1
+            : $c == 0   ? $q - $sl_len - 1
+            :             $q - $sl_len;
+        $start = (($sl + 1) * $sl_len) % $q;
+    }
+    my $x   = ($j1 * $j1) >> 32;
+    my $y   = ($w * $x)   >> 32;
+    my $rel = $w - 1 - $y;
+    return ($start + $rel) % $q;
+}
+
+# ---------------------------------------------------------------------------
+# _fill_segment  (Argon2id-specific)
+#
+# data_independent := (r == 0 && sl < 2).  When true, J1/J2 come from the
+# Argon2i address stream; otherwise they come from the previous block's
+# first word (Argon2d-style).
+# ---------------------------------------------------------------------------
+sub _fill_segment {
+    my ($memory, $r, $lane, $sl, $q, $sl_len, $p, $m_prime, $t_total) = @_;
+
+    my $data_independent = ($r == 0 && $sl < 2);
+
+    my @input   = (0) x BLOCK_WORDS;
+    my @address = (0) x BLOCK_WORDS;
+    my @zero    = (0) x BLOCK_WORDS;
+    if ($data_independent) {
+        $input[0] = $r;
+        $input[1] = $lane;
+        $input[2] = $sl;
+        $input[3] = $m_prime;
+        $input[4] = $t_total;
+        $input[5] = TYPE_ID;
+    }
+
+    my $refresh = sub {
+        $input[6]++;
+        my $z = _compress(\@zero, \@input);
+        @address = @{ _compress(\@zero, $z) };
+    };
+
+    my $starting_c = ($r == 0 && $sl == 0) ? 2 : 0;
+    $refresh->() if $data_independent && $starting_c != 0;
+
+    for my $i ($starting_c .. $sl_len - 1) {
+        if ($data_independent
+            && $i % ADDRESSES_PER_BLOCK == 0
+            && !($r == 0 && $sl == 0 && $i == 2))
+        {
+            $refresh->();
+        }
+
+        my $col = $sl * $sl_len + $i;
+        my $prev_col = $col == 0 ? $q - 1 : $col - 1;
+        my $prev_block = $memory->{$lane}[$prev_col];
+
+        my $pseudo_rand = $data_independent
+            ? $address[$i % ADDRESSES_PER_BLOCK]
+            : $prev_block->[0];
+        my $j1 = $pseudo_rand & MASK32;
+        my $j2 = ($pseudo_rand >> 32) & MASK32;
+
+        my $l_prime = $lane;
+        $l_prime = $j2 % $p unless ($r == 0 && $sl == 0);
+
+        my $z_prime = _index_alpha($j1, $r, $sl, $i, $l_prime == $lane,
+                                   $q, $sl_len);
+        my $ref_block = $memory->{$l_prime}[$z_prime];
+
+        my $new_block = _compress($prev_block, $ref_block);
+        if ($r == 0) {
+            $memory->{$lane}[$col] = $new_block;
+        } else {
+            my $existing = $memory->{$lane}[$col];
+            $memory->{$lane}[$col] =
+                [ map { $existing->[$_] ^ $new_block->[$_] }
+                      0 .. BLOCK_WORDS - 1 ];
+        }
+    }
+}
+
+sub _validate {
+    my ($password, $salt, $t, $m, $p, $tag_length, $key, $ad, $version) = @_;
+    die "password length must fit in 32 bits\n" if length($password) > MASK32;
+    die "salt must be at least 8 bytes\n"       if length($salt) < 8;
+    die "salt length must fit in 32 bits\n"     if length($salt) > MASK32;
+    die "key length must fit in 32 bits\n"      if length($key)  > MASK32;
+    die "associated_data length must fit in 32 bits\n"
+        if length($ad) > MASK32;
+    die "tag_length must be >= 4\n"             if $tag_length < 4;
+    die "tag_length must fit in 32 bits\n"      if $tag_length > MASK32;
+    die "parallelism must be in [1, 2^24-1]\n"
+        unless defined $p && $p =~ /\A\d+\z/ && $p >= 1 && $p <= 0xFFFFFF;
+    die "memory_cost must be >= 8*parallelism\n" if $m < 8 * $p;
+    die "memory_cost must fit in 32 bits\n"      if $m > MASK32;
+    die "time_cost must be >= 1\n"               if $t < 1;
+    die "only Argon2 v1.3 (0x13) is supported\n"
+        unless $version == ARGON2_VERSION;
+}
+
+sub argon2id {
+    my ($password, $salt, $time_cost, $memory_cost, $parallelism,
+        $tag_length, %opts) = @_;
+
+    my $key     = $opts{key}             // '';
+    my $ad      = $opts{associated_data} // '';
+    my $version = $opts{version}         // ARGON2_VERSION;
+
+    for ($password, $salt, $key, $ad) { utf8::downgrade($_, 1) or 1; }
+
+    _validate($password, $salt, $time_cost, $memory_cost, $parallelism,
+              $tag_length, $key, $ad, $version);
+
+    my $segment_length = int($memory_cost / (SYNC_POINTS * $parallelism));
+    my $m_prime        = $segment_length * SYNC_POINTS * $parallelism;
+    my $q              = int($m_prime / $parallelism);
+    my $sl_len         = $segment_length;
+    my $p              = $parallelism;
+    my $t              = $time_cost;
+
+    my $h0_in =
+          _le32($p) . _le32($tag_length) . _le32($memory_cost) . _le32($t)
+        . _le32($version) . _le32(TYPE_ID)
+        . _le32(length $password) . $password
+        . _le32(length $salt)     . $salt
+        . _le32(length $key)      . $key
+        . _le32(length $ad)       . $ad;
+    my $h0 = CodingAdventures::Blake2b::blake2b($h0_in, digest_size => 64);
+
+    my %memory;
+    for my $i (0 .. $p - 1) {
+        $memory{$i} = [];
+        my $b0 = _blake2b_long(BLOCK_SIZE, $h0 . _le32(0) . _le32($i));
+        my $b1 = _blake2b_long(BLOCK_SIZE, $h0 . _le32(1) . _le32($i));
+        $memory{$i}[0] = _bytes_to_block($b0);
+        $memory{$i}[1] = _bytes_to_block($b1);
+    }
+
+    for my $r (0 .. $t - 1) {
+        for my $sl (0 .. SYNC_POINTS - 1) {
+            for my $lane (0 .. $p - 1) {
+                _fill_segment(\%memory, $r, $lane, $sl, $q, $sl_len,
+                              $p, $m_prime, $t);
+            }
+        }
+    }
+
+    my @final = @{ $memory{0}[$q - 1] };
+    for my $lane (1 .. $p - 1) {
+        my $last = $memory{$lane}[$q - 1];
+        for my $k (0 .. BLOCK_WORDS - 1) {
+            $final[$k] ^= $last->[$k];
+        }
+    }
+
+    return _blake2b_long($tag_length, _block_to_bytes(\@final));
+}
+
+sub argon2id_hex {
+    return unpack("H*", argon2id(@_));
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+CodingAdventures::Argon2id - Pure Perl Argon2id password hashing (RFC 9106)
+
+=head1 SYNOPSIS
+
+  use CodingAdventures::Argon2id;
+
+  my $tag = CodingAdventures::Argon2id::argon2id(
+      $password, $salt, 3, 65536, 4, 32,
+      key => $key, associated_data => $ad,
+  );
+
+=head1 DESCRIPTION
+
+Argon2id is the hybrid Argon2 variant and the RFC 9106 default for
+password hashing.  First pass, first two slices: data-independent (like
+Argon2i).  Everything after that: data-dependent (like Argon2d).
+
+=head1 SEE ALSO
+
+L<https://datatracker.ietf.org/doc/html/rfc9106>
+
+=cut

--- a/code/packages/perl/argon2id/lib/CodingAdventures/Argon2id.pm
+++ b/code/packages/perl/argon2id/lib/CodingAdventures/Argon2id.pm
@@ -19,6 +19,13 @@ use strict;
 use warnings;
 no warnings 'portable';
 
+use Config;
+BEGIN {
+    die "CodingAdventures::Argon2id requires 64-bit Perl (ivsize >= 8); "
+      . "this build has ivsize=$Config{ivsize}\n"
+        if $Config{ivsize} < 8;
+}
+
 use CodingAdventures::Blake2b ();
 
 our $VERSION = '0.01';
@@ -230,7 +237,18 @@ sub argon2id {
     my $ad      = $opts{associated_data} // '';
     my $version = $opts{version}         // ARGON2_VERSION;
 
-    for ($password, $salt, $key, $ad) { utf8::downgrade($_, 1) or 1; }
+    # Refuse wide-character input rather than silently UTF-8-encoding it
+    # into a tag that no reference Argon2 implementation can reproduce.
+    for my $name_and_val (
+        [ password        => \$password ],
+        [ salt            => \$salt     ],
+        [ key             => \$key      ],
+        [ associated_data => \$ad       ],
+    ) {
+        my ($name, $ref) = @$name_and_val;
+        utf8::downgrade($$ref, 1)
+            or die "$name must be a byte string; refusing wide characters\n";
+    }
 
     _validate($password, $salt, $time_cost, $memory_cost, $parallelism,
               $tag_length, $key, $ad, $version);

--- a/code/packages/perl/argon2id/required_capabilities.json
+++ b/code/packages/perl/argon2id/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "perl/argon2id",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/perl/argon2id/t/00-load.t
+++ b/code/packages/perl/argon2id/t/00-load.t
@@ -1,0 +1,12 @@
+use strict;
+use warnings;
+use Test2::V0;
+
+ok( eval { require CodingAdventures::Argon2id; 1 },
+    'CodingAdventures::Argon2id loads' );
+
+ok( CodingAdventures::Argon2id->VERSION, 'has a VERSION' );
+ok( defined &CodingAdventures::Argon2id::argon2id,     'argon2id defined' );
+ok( defined &CodingAdventures::Argon2id::argon2id_hex, 'argon2id_hex defined' );
+
+done_testing;

--- a/code/packages/perl/argon2id/t/01-argon2id.t
+++ b/code/packages/perl/argon2id/t/01-argon2id.t
@@ -1,0 +1,87 @@
+use strict;
+use warnings;
+use Test2::V0;
+
+use CodingAdventures::Argon2id;
+
+sub A     { CodingAdventures::Argon2id::argon2id(@_)     }
+sub A_hex { CodingAdventures::Argon2id::argon2id_hex(@_) }
+
+# ─── RFC 9106 §5.3 gold-standard vector ──────────────────────────────────
+my $RFC_PASSWORD = "\x01" x 32;
+my $RFC_SALT     = "\x02" x 16;
+my $RFC_KEY      = "\x03" x 8;
+my $RFC_AD       = "\x04" x 12;
+my $RFC_EXPECTED =
+  '0d640df58d78766c08c037a34a8b53c9d01ef0452d75b65eb52520e96b01e659';
+
+is(
+    A_hex(
+        $RFC_PASSWORD, $RFC_SALT, 3, 32, 4, 32,
+        key => $RFC_KEY, associated_data => $RFC_AD,
+    ),
+    $RFC_EXPECTED,
+    'RFC 9106 §5.3 vector',
+);
+
+{
+    my $raw = A(
+        $RFC_PASSWORD, $RFC_SALT, 3, 32, 4, 32,
+        key => $RFC_KEY, associated_data => $RFC_AD,
+    );
+    my $hex = A_hex(
+        $RFC_PASSWORD, $RFC_SALT, 3, 32, 4, 32,
+        key => $RFC_KEY, associated_data => $RFC_AD,
+    );
+    is(unpack("H*", $raw), $hex, 'hex matches binary');
+}
+
+# ─── Validation rejections ──────────────────────────────────────────────
+like(dies { A('pw', 'short',   1, 8, 1, 32) }, qr/salt/i,       'rejects short salt');
+like(dies { A('pw', 'a' x 8,   0, 8, 1, 32) }, qr/time_cost/i,  'rejects zero time_cost');
+like(dies { A('pw', 'a' x 8,   1, 8, 1,  3) }, qr/tag_length/i, 'rejects tag_length < 4');
+like(dies { A('pw', 'a' x 8,   1, 7, 1, 32) }, qr/memory_cost/i,'rejects memory < 8*p');
+like(dies { A('pw', 'a' x 8,   1, 8, 0, 32) }, qr/parallelism/i,'rejects zero parallelism');
+like(dies { A('pw', 'a' x 8,   1, 8, 1, 32, version => 0x10) },
+     qr/v1\.3|0x13/i, 'rejects unsupported version');
+
+# ─── Determinism and separation ─────────────────────────────────────────
+is(A_hex('pw', 'a' x 8, 1, 8, 1, 32),
+   A_hex('pw', 'a' x 8, 1, 8, 1, 32),
+   'deterministic');
+isnt(A_hex('pw1', 'a' x 8, 1, 8, 1, 32),
+     A_hex('pw2', 'a' x 8, 1, 8, 1, 32),
+     'differs on password');
+isnt(A_hex('pw', 'a' x 8, 1, 8, 1, 32),
+     A_hex('pw', 'b' x 8, 1, 8, 1, 32),
+     'differs on salt');
+
+# ─── Key / AD binding ───────────────────────────────────────────────────
+{
+    my $no_key = A_hex('pw', 'a' x 8, 1, 8, 1, 32);
+    my $k1     = A_hex('pw', 'a' x 8, 1, 8, 1, 32, key => 'k1');
+    my $k2     = A_hex('pw', 'a' x 8, 1, 8, 1, 32, key => 'k2');
+    isnt($no_key, $k1, 'key binds (vs none)');
+    isnt($k1,     $k2, 'key binds (k1 vs k2)');
+}
+{
+    my $no_ad = A_hex('pw', 'a' x 8, 1, 8, 1, 32);
+    my $ad1   = A_hex('pw', 'a' x 8, 1, 8, 1, 32, associated_data => 'x');
+    my $ad2   = A_hex('pw', 'a' x 8, 1, 8, 1, 32, associated_data => 'y');
+    isnt($no_ad, $ad1, 'AD binds (vs none)');
+    isnt($ad1,   $ad2, 'AD binds (x vs y)');
+}
+
+# ─── Tag length variants ────────────────────────────────────────────────
+is(length A('pw', 'a' x 8, 1, 8, 1,   4),   4, 'tag_length 4');
+is(length A('pw', 'a' x 8, 1, 8, 1,  16),  16, 'tag_length 16');
+is(length A('pw', 'a' x 8, 1, 8, 1,  65),  65, 'tag_length 65');
+is(length A('pw', 'a' x 8, 1, 8, 1, 128), 128, 'tag_length 128');
+
+# ─── Parallelism / multi-pass ───────────────────────────────────────────
+is(length A('pw', 'a' x 8, 1, 16, 2, 32), 32, 'multi-lane tag size');
+isnt(A_hex('pw', 'a' x 8, 1, 8, 1, 32),
+     A_hex('pw', 'a' x 8, 2, 8, 1, 32),
+     'multi-pass differs from single-pass');
+
+done_testing;


### PR DESCRIPTION
## Summary

- Adds three pure-Perl packages — `CodingAdventures::Argon2d`, `::Argon2i`, `::Argon2id` — porting the corresponding RFC 9106 variants on top of the existing `CodingAdventures::Blake2b`.
- Each package passes its RFC 9106 gold-standard test vector (§5.1 for Argon2d, §5.2 for Argon2i, §5.3 for Argon2id) plus 22 parameter-edge tests (tag-length boundaries across the H' extender, key + associated-data binding, multi-lane, multi-pass, validation rejections). 75 tests total, all passing locally.
- Each package is published-shape: `Makefile.PL`, `cpanfile`, `BUILD` / `BUILD_windows`, `CHANGELOG.md`, `README.md`, `required_capabilities.json` (zero capabilities — pure computation).

## Security review

Ran an internal security-review sub-agent before pushing. Two findings were addressed in the second commit:

- **MEDIUM** — `utf8::downgrade($_, 1) or 1` swallowed the failure return, so wide-character scalars could silently produce tags that diverge from reference implementations (interop/auth-correctness hazard). Replaced with a hard `die` that names the offending argument.
- **LOW** — no runtime assertion of 64-bit Perl. On a 32-bit build the `pack "Q<"` emission and `use integer` wrap-on-overflow semantics would yield silently wrong tags. Added a `BEGIN { die unless $Config{ivsize} >= 8 }` guard.

Documented Argon2d side-channel caveat and the fact that callers must constant-time-compare tags themselves.

## Test plan

- [x] `PERL5LIB=../blake2b/lib prove -l t/` in `argon2d` → 25/25 pass, RFC §5.1 vector matches
- [x] `PERL5LIB=../blake2b/lib prove -l t/` in `argon2i`  → 25/25 pass, RFC §5.2 vector matches
- [x] `PERL5LIB=../blake2b/lib prove -l t/` in `argon2id` → 25/25 pass, RFC §5.3 vector matches
- [ ] CI green across all affected jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)