### PR TITLE
docs(specs): add LANG00–LANG05 generic language pipeline spec series

### DIFF
--- a/code/specs/LANG00-generic-language-pipeline.md
+++ b/code/specs/LANG00-generic-language-pipeline.md
@@ -17,7 +17,8 @@ Prolog, …) only needs to supply:
 4. A backend selection (Intel 4004, WASM, JVM, RISC-V, …)
 
 Everything else — the VM, the JIT, the optimization passes, the register
-allocator, the code-cache — is reused without modification.
+allocator, the code-cache, the debugger, the language server, the REPL,
+and the notebook kernel — is reused without modification.
 
 ---
 
@@ -91,19 +92,31 @@ is handed to the backend.
 ## Layer Map
 
 ```
-LANG00  (this spec)     Generic language pipeline architecture
-LANG01  interpreter-ir  Dynamic bytecode IR with feedback slots
-LANG02  vm-core         Generic interpreter: dispatch loop + profiler
-LANG03  jit-core        Specialization pass: InterpreterIR → CompilerIR
-LANG04  aot-core        AOT path: vm-core extracted as linkable library
-LANG05  backend-protocol  Contract every code-gen backend must satisfy
+Runtime core
+  LANG00  (this spec)     Generic language pipeline architecture
+  LANG01  interpreter-ir  Dynamic bytecode IR with feedback slots
+  LANG02  vm-core         Generic interpreter: dispatch loop + profiler
+  LANG03  jit-core        Specialization pass: InterpreterIR → CompilerIR
+  LANG04  aot-core        AOT path: vm-core extracted as linkable library
+  LANG05  backend-protocol  Contract every code-gen backend must satisfy
 
-Existing specs, unchanged:
-  05b-jit-compiler.md   JIT compilation concepts
+Tooling (built on top of LANG01–LANG05)
+  LANG06  debug-integration   VSCode debugger via DAP; breakpoints, stepping, inspect
+  LANG07  lsp-integration     Language Server Protocol; completions, hover, diagnostics
+  LANG08  repl-integration    Interactive REPL via PL00 framework
+  LANG09  notebook-kernel     Jupyter-compatible kernel; rich cell output
+
+Existing specs, referenced:
+  05d-debug-sidecar-format.md  offset → source location mapping (used by LANG06)
+  05e-debug-adapter.md         DAP bridge to VSCode (used by LANG06)
+  LS00-language-server-framework.md  generic LSP server (used by LANG07)
+  LS01-lsp-language-bridge.md  language plug-in for LSP (used by LANG07)
+  PL00-repl.md                 generic REPL framework (used by LANG08)
+  05b-jit-compiler.md          JIT compilation concepts
   05c-jit-compilation-pipeline.md  end-to-end pipeline design
-  IR00-semantic-ir.md   SemanticIR (higher-level; above CompilerIR)
-  compiler-ir package   CompilerIR definition
-  ir-optimizer package  SSA optimization passes
+  IR00-semantic-ir.md          SemanticIR (higher-level; above CompilerIR)
+  compiler-ir package          CompilerIR definition
+  ir-optimizer package         SSA optimization passes
 ```
 
 ---
@@ -140,10 +153,16 @@ Language frontend (per language)
 | Parser | Yes | — |
 | Type checker | Yes (optional) | `type-checker-protocol` |
 | Bytecode compiler | Yes | emits to `interpreter-ir` |
+| Debug sidecar emitter | Yes (3 lines) | `debug-sidecar` (05d) |
+| LSP bridge | Yes (10–50 lines) | `ls01` + `ls00` |
+| REPL plugin | Yes (20–30 lines) | `pl00` |
+| Notebook kernel | Yes (5 lines) | `lang09-kernel` |
 | Interpreter / VM | **No** | `vm-core` |
 | JIT | **No** | `jit-core` |
 | Optimization | **No** | `ir-optimizer` |
 | Backend | **No** | `backend-protocol` + existing backends |
+| Debugger (VSCode DAP) | **No** | `debug-adapter` (05e) |
+| Language server | **No** | `ls00` (generic LSP server) |
 
 ---
 
@@ -212,25 +231,40 @@ The LANG spec series is the specification layer.  Implementation proceeds in
 dependency order:
 
 ```
-LANG01 interpreter-ir   → defines the shared bytecode format
-LANG02 vm-core          → consumes interpreter-ir; hosts the profiler
-LANG03 jit-core         → consumes vm-core feedback; emits compiler-ir
-LANG04 aot-core         → headless vm-core path (no interpreter overhead)
-LANG05 backend-protocol → codifies what intel4004-backend etc. must implement
+Runtime core (implement first):
+  LANG01 interpreter-ir   → defines the shared bytecode format
+  LANG02 vm-core          → consumes interpreter-ir; hosts the profiler
+  LANG03 jit-core         → consumes vm-core feedback; emits compiler-ir
+  LANG04 aot-core         → headless vm-core path (no interpreter overhead)
+  LANG05 backend-protocol → codifies what intel4004-backend etc. must implement
+
+Tooling layer (implement after LANG01–LANG05):
+  LANG06 debug-integration  → vm-core debug hooks; DAP bridge via 05d/05e
+  LANG07 lsp-integration    → LS01 bridge; incremental re-parse; background infer
+  LANG08 repl-integration   → PL00 LanguagePlugin; incremental IIRModule state
+  LANG09 notebook-kernel    → JMP over ZeroMQ; cell execution; rich output
 ```
 
-After LANG01–LANG05 are implemented, each new language is a four-package
-addition (lexer, parser, type-checker, compiler) instead of a ten-package one.
+After LANG01–LANG09 are implemented, each new language is:
+- **4 packages** for the runtime (lexer, parser, type-checker, compiler)
+- **~100 lines** of glue code for the full tooling suite (debugger, LSP, REPL, notebook)
+
+A language author who has never written a compiler gets, for free:
+VSCode syntax highlighting, red squiggles, Go to Definition, rename, an
+interactive REPL, Jupyter notebook support, and a VSCode debugger with
+breakpoints and variable inspection.
 
 ---
 
 ## Non-goals
 
-- **Garbage collection** — out of scope for LANG00–LANG05.  The Intel 4004
-  has 160 bytes of RAM; a GC cannot fit.  Languages that need GC will be
-  addressed in a future spec series (GC00+).
+- **Garbage collection** — out of scope for LANG00–LANG09.  Languages that
+  need GC will be addressed in a future spec series (GC00+).
 - **Concurrency** — single-threaded execution only.
-- **Source maps / debugger integration** — see specs 05d and 05e for the
-  debug sidecar format and debug adapter protocol.
 - **AOT compilation of the VM itself** — `vm-core` runs interpreted on the
   host.  Compiling the VM to native is a future `aot-core` concern (LANG04).
+- **Custom notebook frontends** — LANG09 targets standard Jupyter/VS Code
+  frontends.  A custom notebook UI is out of scope.
+- **Multi-file project compilation** — the REPL and notebook kernel operate
+  on single-session state.  Multi-file project management (imports, modules)
+  is a language-specific concern outside this spec series.

--- a/code/specs/LANG00-generic-language-pipeline.md
+++ b/code/specs/LANG00-generic-language-pipeline.md
@@ -1,0 +1,236 @@
+# LANG00 — Generic Language Pipeline Architecture
+
+## Overview
+
+Tetrad showed that a complete language — lexer, parser, type checker, bytecode
+compiler, register VM, and Intel 4004 JIT — can be built end-to-end in this
+repository.  The pipeline works beautifully.  The problem is that every piece
+is coupled to Tetrad: `TetradVM`, `TetradJIT`, `CodeObject`, `Op`.
+
+This spec introduces a **two-IR architecture** that makes the interpreted
+half of the stack fully generic.  Any new language (BASIC, Lua, Python subset,
+Prolog, …) only needs to supply:
+
+1. A lexer + parser that produces an AST
+2. A bytecode compiler that emits `InterpreterIR`
+3. A type-checker plug-in (optional, enables earlier JIT compilation)
+4. A backend selection (Intel 4004, WASM, JVM, RISC-V, …)
+
+Everything else — the VM, the JIT, the optimization passes, the register
+allocator, the code-cache — is reused without modification.
+
+---
+
+## The Two-IR Model
+
+Prior to this generification, the pipeline had one IR per language:
+
+```
+Tetrad source → TetradBytecode (CodeObject / Op) → TetradVM → TetradJIT
+```
+
+The `tetrad-jit` package invented its own `IRInstr` SSA IR specifically
+for the 4004 backend.  That IR was good enough for Tetrad alone; it cannot
+be reused because it is defined inside `tetrad_jit.ir`.
+
+The generic pipeline separates concerns into two distinct IRs:
+
+```
+                ┌─ Interpreted path ─────────────────────────────────┐
+Source code     │                                                    │
+  → frontend    │   InterpreterIR          CompilerIR                │
+  → AST         │   (dynamic, typed        (static, SSA,             │
+  → bytecode ───┤    feedback slots,        typed, backend-          │
+    compiler    │    deopt anchors)         portable)                │
+                │         │                     ▲                    │
+                │         │    JIT-core         │                    │
+                │         └─── specializes ─────┘                    │
+                │              (with feedback)                        │
+                │                                                     │
+                │   vm-core executes InterpreterIR                   │
+                │   jit-core compiles hot frames → CompilerIR        │
+                │   backend-protocol emits native binary             │
+                └─────────────────────────────────────────────────────┘
+
+                ┌─ Compiled path (unchanged) ─────────────────────────┐
+Source code     │                                                    │
+  → frontend    │   CompilerIR → ir-optimizer → backend              │
+  → AST         │   (already generic; used by Nib, WASM, JVM, etc.) │
+  → compiler ───┘                                                     │
+                └─────────────────────────────────────────────────────┘
+```
+
+### InterpreterIR  (new — LANG01)
+
+A **dynamic** IR designed for interpreted execution and JIT feedback:
+
+- Operations expressed as simple named instructions with source/dest operands
+- Each instruction carries an optional **type observation slot** (filled by the
+  VM profiler on first execution, updated on subsequent calls)
+- **Deopt anchors** mark the instruction index where control must return to the
+  interpreter if a compiled assumption turns out to be wrong
+- Designed to be walked by `vm-core`'s interpreter loop without any additional
+  lowering step
+
+### CompilerIR  (existing — `compiler-ir` package)
+
+A **static** IR designed for code generation:
+
+- SSA form with explicit phi-nodes at join points
+- Every value is typed at the point of IR construction (no unknown types)
+- Consumed by `ir-optimizer` and then by backends (WASM, JVM, Intel 4004, …)
+- Already used by the compiled-language path (Nib, NIB01)
+
+The JIT-core (LANG03) is the bridge between the two IRs.  It reads
+`InterpreterIR` plus the feedback vectors gathered by `vm-core`'s profiler,
+specializes the code for the observed types, and emits `CompilerIR` that
+is handed to the backend.
+
+---
+
+## Layer Map
+
+```
+LANG00  (this spec)     Generic language pipeline architecture
+LANG01  interpreter-ir  Dynamic bytecode IR with feedback slots
+LANG02  vm-core         Generic interpreter: dispatch loop + profiler
+LANG03  jit-core        Specialization pass: InterpreterIR → CompilerIR
+LANG04  aot-core        AOT path: vm-core extracted as linkable library
+LANG05  backend-protocol  Contract every code-gen backend must satisfy
+
+Existing specs, unchanged:
+  05b-jit-compiler.md   JIT compilation concepts
+  05c-jit-compilation-pipeline.md  end-to-end pipeline design
+  IR00-semantic-ir.md   SemanticIR (higher-level; above CompilerIR)
+  compiler-ir package   CompilerIR definition
+  ir-optimizer package  SSA optimization passes
+```
+
+---
+
+## Package Map (post-generification)
+
+```
+Language frontend (per language)
+  ├── my-lang-lexer        tokeniser
+  ├── my-lang-parser       AST builder
+  ├── my-lang-type-checker type inference / annotation
+  └── my-lang-compiler     AST → InterpreterIR
+
+                 ↓  InterpreterIR
+
+  ├── vm-core              generic interpreter loop + profiler (LANG02)
+  └── jit-core             InterpreterIR → CompilerIR specializer (LANG03)
+
+                 ↓  CompilerIR
+
+  ├── ir-optimizer         constant folding, DCE, inlining
+  └── backend-protocol     contract for all backends (LANG05)
+          ├── intel4004-backend    Nib / Tetrad 4004 target
+          ├── wasm-backend         browser / WASI target
+          ├── jvm-backend          JVM class-file target
+          └── riscv-backend        RISC-V binary target
+```
+
+### What each language supplies
+
+| Component | Language-specific? | Generic package |
+|-----------|-------------------|-----------------|
+| Lexer | Yes | — |
+| Parser | Yes | — |
+| Type checker | Yes (optional) | `type-checker-protocol` |
+| Bytecode compiler | Yes | emits to `interpreter-ir` |
+| Interpreter / VM | **No** | `vm-core` |
+| JIT | **No** | `jit-core` |
+| Optimization | **No** | `ir-optimizer` |
+| Backend | **No** | `backend-protocol` + existing backends |
+
+---
+
+## Tetrad as a language-specific wrapper
+
+After the generification, the Tetrad packages shrink to:
+
+```
+tetrad-lexer        (unchanged)
+tetrad-parser       (unchanged)
+tetrad-type-checker (unchanged)
+tetrad-compiler     NEW: emits InterpreterIR instead of CodeObject/Op
+```
+
+`tetrad-vm` and `tetrad-jit` become thin **configuration wrappers**:
+
+```python
+# tetrad-vm becomes roughly:
+from vm_core import VMCore
+from tetrad_compiler import compile_program
+vm = VMCore(backend="intel4004")
+
+# tetrad-jit becomes:
+from jit_core import JITCore
+jit = JITCore(vm, threshold_fully_typed=0, threshold_partial=10, threshold_untyped=100)
+```
+
+The implementation work for `tetrad-vm` and `tetrad-jit` (the register VM,
+the nibble-pair codegen, the liveness-based register recycling, the tiered
+promotion) moves into `vm-core` and `jit-core` respectively and becomes
+available to every language for free.
+
+---
+
+## Historical context: why these tiers exist
+
+When we built Tetrad we discovered that hardware constraints force the language
+runtime tier to match hardware capability:
+
+| Hardware | Year | RAM | Stack | Where runtime lives |
+|----------|------|-----|-------|---------------------|
+| Intel 4004 | 1971 | 160 bytes | 3-level | Cannot host interpreter |
+| Intel 8008 | 1972 | up to 16 KB | 8-level hardware stack, no user SP | Cannot implement software call frames |
+| Intel 8080 | 1974 | 64 KB | proper SP, PUSH/POP | First chip where an interpreter is comfortable |
+| Motorola 6800 | 1974 | 64 KB | proper SP | Same tier as 8080 |
+| MOS 6502 | 1975 | 64 KB | 256-byte hw stack + SP | BASIC on Apple II |
+
+The Tetrad JIT targets the Intel 4004 **as the execution target**, not the
+hosting platform.  The interpreter (and JIT compiler itself) run on the host
+machine (modern hardware); only the compiled output is fed to the 4004
+simulator.  This distinction is fundamental to the architecture:
+
+- **Interpreter host** = the machine running `vm-core` (your laptop)
+- **Compiled target** = the ISA simulator (Intel 4004, WASM, JVM, …)
+
+BASIC became popular on the IBM PC not because the 8088 needed BASIC but
+because the 8088 *could finally host* the BASIC interpreter comfortably.
+Tetrad's VM has the same relationship: `vm-core` runs on modern hardware;
+the 4004 backend is where the *compiled output* executes.
+
+---
+
+## Roadmap
+
+The LANG spec series is the specification layer.  Implementation proceeds in
+dependency order:
+
+```
+LANG01 interpreter-ir   → defines the shared bytecode format
+LANG02 vm-core          → consumes interpreter-ir; hosts the profiler
+LANG03 jit-core         → consumes vm-core feedback; emits compiler-ir
+LANG04 aot-core         → headless vm-core path (no interpreter overhead)
+LANG05 backend-protocol → codifies what intel4004-backend etc. must implement
+```
+
+After LANG01–LANG05 are implemented, each new language is a four-package
+addition (lexer, parser, type-checker, compiler) instead of a ten-package one.
+
+---
+
+## Non-goals
+
+- **Garbage collection** — out of scope for LANG00–LANG05.  The Intel 4004
+  has 160 bytes of RAM; a GC cannot fit.  Languages that need GC will be
+  addressed in a future spec series (GC00+).
+- **Concurrency** — single-threaded execution only.
+- **Source maps / debugger integration** — see specs 05d and 05e for the
+  debug sidecar format and debug adapter protocol.
+- **AOT compilation of the VM itself** — `vm-core` runs interpreted on the
+  host.  Compiling the VM to native is a future `aot-core` concern (LANG04).

--- a/code/specs/LANG01-interpreter-ir.md
+++ b/code/specs/LANG01-interpreter-ir.md
@@ -1,0 +1,351 @@
+# LANG01 — InterpreterIR: Dynamic Bytecode Intermediate Representation
+
+## Overview
+
+`interpreter-ir` defines the **shared bytecode format** that all interpreted
+languages in this repository compile to.  Before this package, each language
+had its own bytecode (`CodeObject`/`Op` for Tetrad, `LogicInstruction` for the
+logic engine, etc.).  After adoption, every language's bytecode compiler emits
+`InterpreterIR` and every language's VM is replaced by the generic `vm-core`
+(LANG02).
+
+This spec covers:
+
+1. The `IIRInstr` instruction dataclass
+2. The full instruction set
+3. Type observation slots (how the VM feeds back runtime types to the JIT)
+4. Deoptimisation anchors
+5. The `IIRFunction` and `IIRModule` container types
+6. Serialisation format
+
+---
+
+## Design goals
+
+| Goal | Rationale |
+|------|-----------|
+| **Interpreter-friendly** | Instructions are simple enough for a dispatch loop to execute without additional lowering |
+| **JIT-transparent** | Feedback slots are embedded in the IR so the JIT can read observations without a separate data structure |
+| **Language-agnostic** | No Tetrad-specific types; any language that compiles to u8/u16/u32/u64/bool/str values can use the same instruction set |
+| **Deopt-safe** | Every compiled frame can fall back to the interpreter at a marked anchor point |
+| **Serialisable** | `IIRModule` can be written to disk and read back, enabling AOT snapshot builds |
+
+---
+
+## Core dataclass: `IIRInstr`
+
+```python
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Any
+
+@dataclass
+class IIRInstr:
+    op: str              # instruction mnemonic (see table below)
+    dest: str | None     # destination variable name (SSA); None for void ops
+    srcs: list[str | int | float | bool]  # source operands (names or literals)
+    type_hint: str       # declared type: "u8", "u16", "u32", "u64", "bool", "str", "any"
+
+    # Runtime feedback (written by vm-core profiler, read by jit-core)
+    observed_type: str | None = field(default=None, repr=False)
+    observation_count: int    = field(default=0,    repr=False)
+
+    # Deopt anchor: if not None, jit-core must emit a guard that reverts to
+    # interpreter execution at this instruction index when the guard fails.
+    deopt_anchor: int | None  = field(default=None, repr=False)
+```
+
+### Field semantics
+
+**`op`** — the instruction mnemonic.  All mnemonics are lowercase strings
+(e.g., `"add"`, `"cmp_lt"`, `"jmp_if_false"`, `"call"`).
+
+**`dest`** — the name of the SSA variable produced by this instruction, or
+`None` for instructions that produce no value (returns, stores, branches).
+
+**`srcs`** — a list of operands.  Each element is either:
+- A `str` naming another SSA variable defined earlier in the same function
+- An `int`, `float`, or `bool` literal (immediate values)
+
+**`type_hint`** — the declared type.  For statically typed languages (Tetrad),
+this is filled in by the type-checker.  For dynamically typed languages
+(Lua, BASIC), this is `"any"` until the profiler fills in `observed_type`.
+
+**`observed_type`** — set by the `vm-core` profiler after seeing the actual
+runtime type of `dest`.  Initially `None`.  When filled in for a
+`type_hint="any"` instruction, the JIT can specialize to that type.
+
+**`observation_count`** — how many times this instruction has been profiled.
+Used by `jit-core` to decide whether it has enough observations to specialize.
+
+**`deopt_anchor`** — when the JIT specializes on `observed_type`, it emits a
+type guard before the specialized path.  If the guard fails at runtime, the
+compiled frame is abandoned and execution restarts at the interpreter from
+instruction index `deopt_anchor`.
+
+---
+
+## Instruction set
+
+### Arithmetic
+
+| Mnemonic | Operands | Description |
+|----------|----------|-------------|
+| `const`  | (literal,) | Load an immediate value into `dest` |
+| `add`    | (a, b) | `dest = a + b` |
+| `sub`    | (a, b) | `dest = a - b` |
+| `mul`    | (a, b) | `dest = a * b` |
+| `div`    | (a, b) | `dest = a / b` (integer division) |
+| `mod`    | (a, b) | `dest = a % b` |
+| `neg`    | (a,) | `dest = -a` |
+
+### Bitwise
+
+| Mnemonic | Operands | Description |
+|----------|----------|-------------|
+| `and`    | (a, b) | `dest = a & b` |
+| `or`     | (a, b) | `dest = a \| b` |
+| `xor`    | (a, b) | `dest = a ^ b` |
+| `not`    | (a,) | `dest = ~a` |
+| `shl`    | (a, n) | `dest = a << n` |
+| `shr`    | (a, n) | `dest = a >> n` |
+
+### Comparison
+
+| Mnemonic | Operands | Description |
+|----------|----------|-------------|
+| `cmp_eq` | (a, b) | `dest = a == b` |
+| `cmp_ne` | (a, b) | `dest = a != b` |
+| `cmp_lt` | (a, b) | `dest = a < b` |
+| `cmp_le` | (a, b) | `dest = a <= b` |
+| `cmp_gt` | (a, b) | `dest = a > b` |
+| `cmp_ge` | (a, b) | `dest = a >= b` |
+
+### Control flow
+
+| Mnemonic | `dest` | Operands | Description |
+|----------|--------|----------|-------------|
+| `jmp`      | None | (label,) | Unconditional jump to label |
+| `jmp_if_true`  | None | (cond, label) | Jump if cond is truthy |
+| `jmp_if_false` | None | (cond, label) | Jump if cond is falsy |
+| `label`    | None | (name,) | Define a branch target |
+| `ret`      | None | (value,) | Return value from function; value may be a variable name or literal |
+| `ret_void` | None | () | Return from a void function |
+
+### Memory / registers
+
+| Mnemonic | Operands | Description |
+|----------|----------|-------------|
+| `load_reg`  | (register_index,) | Load from a VM register into `dest` |
+| `store_reg` | (register_index, value) | Store a value into a VM register |
+| `load_mem`  | (address,) | Load from RAM address into `dest` |
+| `store_mem` | (address, value) | Store a value to a RAM address |
+
+### Function calls
+
+| Mnemonic | Operands | Description |
+|----------|----------|-------------|
+| `call`    | (fn_name_or_index, arg0, arg1, …) | Call a function; result in `dest` |
+| `call_builtin` | (builtin_name, arg0, …) | Call a host-provided built-in |
+
+### I/O
+
+| Mnemonic | Operands | Description |
+|----------|----------|-------------|
+| `io_in`   | (port,) | Read from I/O port into `dest` |
+| `io_out`  | (port, value) | Write value to I/O port |
+
+### Type coercions
+
+| Mnemonic | Operands | Description |
+|----------|----------|-------------|
+| `cast`    | (value, target_type) | Coerce value to target_type |
+| `type_assert` | (value, expected_type) | Guard: deopt if value is not expected_type |
+
+---
+
+## Type observation protocol
+
+When `vm-core` executes an `IIRInstr` whose `type_hint` is `"any"`, it records
+the runtime type of the produced value:
+
+```
+profile_instr(instr, result_value):
+    rt = runtime_type_of(result_value)   # "u8", "u16", "bool", "str", …
+    if instr.observed_type is None:
+        instr.observed_type = rt
+    elif instr.observed_type != rt:
+        instr.observed_type = "polymorphic"  # many types seen → don't specialize
+    instr.observation_count += 1
+```
+
+The profiler runs inline in the interpreter loop.  The overhead is one string
+comparison and one integer increment per profiled instruction — small enough to
+keep always-on in the base interpreter.
+
+The JIT reads `observed_type` during specialization.  Instructions where
+`observed_type == "polymorphic"` are **not** specialized; they emit a generic
+call to a runtime helper instead.
+
+### Specialization threshold
+
+The JIT-core (LANG03) specializes a function when:
+
+1. Every instruction in the function body has `observation_count >= min_observations`
+   (default: 5), **or**
+2. The function's `IIRFunction.type_status` is `FULLY_TYPED` (all `type_hint`s
+   are concrete, not `"any"`).
+
+---
+
+## Deoptimisation anchors
+
+When the JIT specializes on `observed_type`, it must be able to fall back to
+the interpreter if the guard fails at runtime.  The `deopt_anchor` field stores
+the interpreter instruction index to resume at.
+
+Example: a function that adds two values observed as `u8`:
+
+```
+IIRInstr(op="add", dest="v0", srcs=["a", "b"], type_hint="any",
+         observed_type="u8", deopt_anchor=2)
+```
+
+The JIT emits approximately:
+
+```
+; Guard: are both a and b u8?
+TEST_TYPE a, u8   ; jump to deopt_stub if not
+TEST_TYPE b, u8
+; Specialized path: 8-bit add
+FIM P1, a_hi:a_lo
+FIM P2, b_hi:b_lo
+… 4004 add sequence …
+JMP compiled_exit
+; Deopt stub: restart interpreter from instruction 2
+deopt_stub:
+  RESTORE_INTERPRETER_STATE(frame, instr_idx=2)
+  JUMP interpreter_loop
+```
+
+The interpreter state needed for deopt is maintained by `vm-core` in a
+**shadow frame**: a small structure that tracks the current register values
+and instruction pointer in a format the interpreter can resume from.
+
+---
+
+## Container types
+
+### `IIRFunction`
+
+```python
+@dataclass
+class IIRFunction:
+    name: str
+    params: list[tuple[str, str]]      # [(param_name, type_hint), …]
+    return_type: str                   # "u8", "void", "any", …
+    instructions: list[IIRInstr]
+    register_count: int = 8            # number of VM registers used
+    type_status: FunctionTypeStatus = FunctionTypeStatus.UNTYPED
+    call_count: int = 0                # updated by vm-core profiler
+```
+
+### `IIRModule`
+
+```python
+@dataclass
+class IIRModule:
+    name: str                          # typically the source file name
+    functions: list[IIRFunction]
+    entry_point: str = "main"          # name of the entry function
+    language: str = "unknown"          # "tetrad", "basic", "lua", …
+```
+
+---
+
+## Serialisation
+
+`IIRModule` can be serialised to a compact binary format for AOT snapshot
+builds.  The format is a simple length-prefixed encoding:
+
+```
+Header:
+  4 bytes  magic number  0x49 0x49 0x52 0x00  ("IIR\0")
+  2 bytes  version       0x01 0x00
+  4 bytes  function_count (little-endian u32)
+
+For each IIRFunction:
+  2 bytes  name_length
+  N bytes  name (UTF-8)
+  2 bytes  param_count
+  For each param:
+    2 bytes  name_length, N bytes name
+    2 bytes  type_length, N bytes type
+  2 bytes  return_type_length, N bytes return_type
+  4 bytes  instruction_count
+  For each IIRInstr:
+    2 bytes  op_length, N bytes op
+    1 byte   has_dest (0 or 1)
+    2 bytes  dest_length, N bytes dest (if has_dest)
+    1 byte   src_count
+    For each src:
+      1 byte   kind (0=str, 1=int, 2=float, 3=bool)
+      (variable-length encoding of the value)
+    2 bytes  type_hint_length, N bytes type_hint
+```
+
+The observation fields (`observed_type`, `observation_count`, `deopt_anchor`)
+are **not** serialised — they are runtime state that accumulates fresh on each
+run.
+
+---
+
+## Relationship to existing IRs
+
+| IR | Package | Layer | Use |
+|----|---------|-------|-----|
+| `InterpreterIR` | `interpreter-ir` (new) | dynamic | bytecode that the VM executes |
+| `CompilerIR` | `compiler-ir` | static SSA | input to optimizers and backends |
+| `SemanticIR` | `semantic-ir` | high-level | typed IR above CompilerIR; used by compiled-language path |
+
+The JIT-core (LANG03) is the only consumer that reads `InterpreterIR` and
+writes `CompilerIR`.  All other consumers (vm-core, backends) see only one IR.
+
+---
+
+## Package structure
+
+```
+interpreter-ir/
+  pyproject.toml
+  BUILD
+  README.md
+  CHANGELOG.md
+  src/interpreter_ir/
+    __init__.py        # exports IIRInstr, IIRFunction, IIRModule, FunctionTypeStatus
+    instr.py           # IIRInstr dataclass + type_hint constants
+    function.py        # IIRFunction dataclass
+    module.py          # IIRModule dataclass
+    opcodes.py         # frozenset constants: ARITHMETIC_OPS, CMP_OPS, etc.
+    serialise.py       # IIRModule → bytes / bytes → IIRModule
+  tests/
+    test_instr.py
+    test_serialise.py
+```
+
+---
+
+## Migration path for Tetrad
+
+The Tetrad pipeline migrates in three steps:
+
+1. **`tetrad-compiler`** emits `IIRModule` instead of `CodeObject`.
+   The mapping is straightforward: `CodeObject.instructions` → `IIRFunction.instructions`,
+   with each `Op` mapped to the corresponding `IIRInstr` mnemonic.
+
+2. **`tetrad-vm`** is replaced by `vm-core` configured for Tetrad's register
+   count and type status thresholds.  Existing tests verify identical results.
+
+3. **`tetrad-jit`** is replaced by `jit-core` with the `intel4004-backend`
+   selected.  Liveness-based register recycling and nibble-pair arithmetic
+   move into the backend.

--- a/code/specs/LANG02-vm-core.md
+++ b/code/specs/LANG02-vm-core.md
@@ -1,0 +1,362 @@
+# LANG02 — vm-core: Generic Register VM Interpreter
+
+## Overview
+
+`vm-core` is a **language-agnostic register virtual machine** that executes
+`IIRModule` programs (LANG01).  It replaces `TetradVM`, `LogicVM`, and every
+other per-language interpreter in this repository with a single, tested,
+optimised dispatch loop.
+
+The key insight from building `TetradVM` is that the interesting part of a
+register VM is not the opcodes — it is the **dispatch loop** and the
+**profiler**.  The opcodes change per language (add, mul, string-concat, …);
+the dispatch infrastructure does not.  `vm-core` owns the dispatch infrastructure
+and receives the opcode set as a plug-in.
+
+This spec covers:
+
+1. The dispatch loop and register file
+2. The call-frame stack
+3. The profiler (feedback vectors)
+4. The builtins registry
+5. The metrics API consumed by `jit-core`
+6. Configuration and language-specific plug-ins
+
+---
+
+## Architecture
+
+```
+IIRModule
+   │
+   ▼
+VMCore.execute(module)
+   │
+   ├── Phase 1: compile FULLY_TYPED functions to InterpreterIR
+   │     (no-op for vm-core — compilation happens in jit-core)
+   │
+   ├── Phase 2: push entry-point frame onto call stack
+   │
+   └── dispatch_loop()
+         │
+         ├── fetch IIRInstr at frame.ip
+         ├── decode op → handler
+         ├── execute handler (mutates register file, pushes/pops frames)
+         ├── if profiling enabled: profile_instr(instr, result)
+         └── advance frame.ip
+```
+
+### Relationship to TetradVM
+
+`TetradVM` was a 350-line Python class implementing:
+
+- A 8-register file
+- A 4-frame call stack
+- An opcode dispatch table for ~20 Tetrad-specific opcodes
+- A metrics counter for function call counts
+
+`vm-core` generalises all four of those components.  After migration:
+
+```
+TetradVM                     →  VMCore(register_count=8, max_frames=4,
+                                        opcodes=tetrad_opcode_table)
+tetrad_vm.metrics()          →  vm_core.metrics()     (same structure)
+tetrad_vm.execute(code)      →  vm_core.execute(module)
+```
+
+---
+
+## Register file
+
+```python
+class RegisterFile:
+    """A flat array of 'any'-typed slots.
+
+    Languages with known types (Tetrad: u8) benefit from narrowing the slots
+    to int at construction time; dynamically typed languages leave them as Any.
+    """
+
+    def __init__(self, count: int = 8, dtype: type = int) -> None:
+        self._regs: list[Any] = [dtype(0)] * count
+
+    def __getitem__(self, idx: int) -> Any:
+        return self._regs[idx]
+
+    def __setitem__(self, idx: int, value: Any) -> None:
+        self._regs[idx] = value
+
+    def reset(self) -> None:
+        for i in range(len(self._regs)):
+            self._regs[i] = 0
+```
+
+---
+
+## Call frame
+
+```python
+@dataclass
+class VMFrame:
+    fn: IIRFunction          # the function being executed
+    ip: int = 0              # instruction pointer (index into fn.instructions)
+    registers: RegisterFile  # per-frame register file
+    return_dest: int | None  # register index to store return value in caller
+```
+
+The call stack is a bounded deque.  The maximum frame depth is configurable
+(default: `max_frames=64`, matching JVM defaults; Tetrad uses `max_frames=4`).
+
+When a `call` instruction is executed:
+
+1. A new `VMFrame` is allocated for the callee
+2. Arguments are copied from the caller's register file to the callee's registers
+3. The callee frame is pushed onto the call stack
+4. `dispatch_loop` continues with the callee's first instruction
+
+When a `ret` instruction is executed:
+
+1. The return value is placed in `frame.return_dest` of the *caller* frame
+2. The callee frame is popped
+3. The caller's `ip` is advanced past the `call` instruction
+
+---
+
+## Dispatch loop
+
+The dispatch loop is a tight `while True` cycle:
+
+```python
+def dispatch_loop(self) -> int | None:
+    while self._frames:
+        frame = self._frames[-1]          # current frame (top of stack)
+        if frame.ip >= len(frame.fn.instructions):
+            # Fell off the end of the function without a ret instruction.
+            # Treat as ret None.
+            self._frames.pop()
+            continue
+
+        instr = frame.fn.instructions[frame.ip]
+        result = self._dispatch(frame, instr)
+
+        if self._profiler_enabled:
+            self._profiler.observe(instr, result)
+
+        frame.ip += 1
+
+    return self._return_value
+```
+
+`_dispatch` is a dictionary from opcode string to handler callable:
+
+```python
+def _dispatch(self, frame: VMFrame, instr: IIRInstr) -> Any:
+    handler = self._opcode_table.get(instr.op)
+    if handler is None:
+        raise VMError(f"unknown opcode: {instr.op!r}")
+    return handler(self, frame, instr)
+```
+
+Each handler is a function:
+
+```python
+def handle_add(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> Any:
+    a = resolve(frame, instr.srcs[0])
+    b = resolve(frame, instr.srcs[1])
+    result = (a + b) & 0xFF   # u8 wrap for Tetrad; language-specific
+    frame.registers[dest_idx(instr.dest)] = result
+    return result
+```
+
+`resolve(frame, src)` returns `src` directly if it is a literal, or looks up
+`frame.registers[name_to_idx[src]]` if it is a string variable name.
+
+### Opcode table construction
+
+Each language supplies its opcode table at VM construction time:
+
+```python
+from vm_core import VMCore
+from tetrad_opcode_table import TETRAD_OPCODES
+
+vm = VMCore(
+    register_count=8,
+    max_frames=4,
+    opcodes=TETRAD_OPCODES,
+)
+```
+
+`TETRAD_OPCODES` is a `dict[str, Callable]` mapping mnemonic strings to
+handler functions.  The generic opcodes (`const`, `jmp`, `label`, `ret`,
+`load_reg`, `store_reg`, `call`) are provided by `vm-core` itself and do not
+need to be specified by the language.
+
+---
+
+## Profiler
+
+The profiler is an optional component that observes instruction results and
+fills in the `observed_type` and `observation_count` fields of `IIRInstr`.
+
+```python
+class VMProfiler:
+    def observe(self, instr: IIRInstr, result: Any) -> None:
+        if instr.type_hint != "any":
+            # Already statically typed — nothing to observe.
+            return
+        rt = _python_type_to_iir(type(result))
+        if instr.observed_type is None:
+            instr.observed_type = rt
+        elif instr.observed_type != rt:
+            instr.observed_type = "polymorphic"
+        instr.observation_count += 1
+```
+
+`_python_type_to_iir` maps Python types to IIR type strings:
+- `int` in range 0–255 → `"u8"`
+- `int` in range 0–65535 → `"u16"`
+- `int` larger → `"u32"` or `"u64"`
+- `bool` → `"bool"`
+- `str` → `"str"`
+- anything else → `"any"`
+
+The profiler overhead is constant per instruction and is always on.  It
+does not affect correctness — it only annotates the `IIRInstr` objects in
+place.
+
+---
+
+## Metrics API
+
+`vm-core` exposes a metrics snapshot consumed by `jit-core`:
+
+```python
+@dataclass
+class VMMetrics:
+    function_call_counts: dict[str, int]   # fn_name → call count
+    total_instructions_executed: int
+    total_frames_pushed: int
+    total_jit_hits: int                    # calls that bypassed interpreter
+```
+
+```python
+vm.metrics() -> VMMetrics
+```
+
+This is the same interface as `TetradVM.metrics()`.  `jit-core` reads
+`function_call_counts` to decide when a function crosses its promotion
+threshold.
+
+---
+
+## Builtins registry
+
+Languages need host-provided operations (I/O, string formatting, …) that
+cannot be expressed as `IIRInstr` sequences.  These are registered as
+**builtins**:
+
+```python
+vm.register_builtin("print", lambda args: print(args[0]))
+vm.register_builtin("input", lambda args: input())
+```
+
+`call_builtin` instructions in `IIRFunction` are dispatched to the registered
+Python callable.  This is the seam through which BASIC's `PRINT`, Lua's
+`print()`, and Python's `print()` are all handled without any VM modification.
+
+---
+
+## Shadow frames (for JIT deopt)
+
+When `jit-core` compiles a function, the interpreter's frame for that function
+becomes a **shadow frame** — it is suspended but kept alive so that a deopt can
+resume from it.
+
+`vm-core` exposes:
+
+```python
+vm.suspend_frame(fn_name: str) -> VMFrame   # pause interpreter; hand frame to JIT
+vm.resume_frame(frame: VMFrame, at_ip: int) # restart interpreter from deopt point
+```
+
+`jit-core` calls `suspend_frame` when entering a compiled function and
+`resume_frame` when a type guard fails.
+
+---
+
+## Configuration
+
+```python
+@dataclass
+class VMConfig:
+    register_count: int = 8          # registers per frame
+    max_frames: int = 64             # maximum call depth
+    opcodes: dict = field(default_factory=dict)   # language-specific handlers
+    builtins: dict = field(default_factory=dict)  # host-provided callables
+    profiler_enabled: bool = True    # always-on observation
+    u8_wrap: bool = False            # wrap arithmetic results to 0–255 (Tetrad)
+```
+
+`u8_wrap=True` applies `& 0xFF` to every arithmetic result — used by Tetrad to
+match its u8 semantics without putting the mask in every opcode handler.
+
+---
+
+## Package structure
+
+```
+vm-core/
+  pyproject.toml
+  BUILD
+  README.md
+  CHANGELOG.md
+  src/vm_core/
+    __init__.py       # exports VMCore, VMConfig, VMMetrics
+    core.py           # VMCore class — top-level API
+    frame.py          # VMFrame, RegisterFile
+    dispatch.py       # dispatch_loop, _dispatch, opcode table resolution
+    profiler.py       # VMProfiler — type observation
+    builtins.py       # built-in registry + standard builtins (no-op, io_in, io_out)
+    metrics.py        # VMMetrics dataclass
+    shadow.py         # shadow frame suspend / resume for JIT deopt
+    errors.py         # VMError, DeoptimizerError, FrameOverflowError
+  tests/
+    test_arithmetic.py
+    test_control_flow.py
+    test_call_frames.py
+    test_profiler.py
+    test_builtins.py
+    test_shadow_frames.py
+```
+
+---
+
+## What vm-core does NOT do
+
+- **Compile code** — `vm-core` executes `IIRModule`; compilation is the
+  frontend's job
+- **Generate native binaries** — that is `jit-core` + backend
+- **Manage garbage collection** — values live in register slots; GC is a
+  future `gc-core` concern (GC00+)
+- **Parse source** — lexer + parser are language-specific frontends
+
+---
+
+## Migration path
+
+### TetradVM → VMCore
+
+```python
+# Before
+from tetrad_vm import TetradVM
+vm = TetradVM()
+result = vm.execute(code_object)
+
+# After
+from vm_core import VMCore
+from tetrad_opcodes import TETRAD_OPCODES   # thin adapter over existing Op handlers
+vm = VMCore(register_count=8, max_frames=4, opcodes=TETRAD_OPCODES, u8_wrap=True)
+result = vm.execute(iir_module)
+```
+
+The `tetrad-vm` package retains its public API as a compatibility shim that
+constructs a `VMCore` with Tetrad defaults.  No existing Tetrad tests break.

--- a/code/specs/LANG03-jit-core.md
+++ b/code/specs/LANG03-jit-core.md
@@ -1,0 +1,417 @@
+# LANG03 — jit-core: Generic JIT Specialization Engine
+
+## Overview
+
+`jit-core` is a **language-agnostic JIT compiler** that monitors a `vm-core`
+execution, detects hot functions, and compiles them to native code using any
+registered backend.
+
+The Tetrad JIT (`tetrad-jit`, TET05) demonstrated the full pipeline:
+
+```
+Tetrad bytecode → JIT IR → Intel 4004 binary → Intel4004Simulator
+```
+
+`jit-core` lifts that pipeline out of the Tetrad package and makes it generic:
+
+```
+InterpreterIR + feedback vectors
+    → specialization pass (InterpreterIR → CompilerIR)
+    → ir-optimizer (SSA optimization passes)
+    → backend (CompilerIR → native binary)
+    → execution (ISA simulator or native call)
+```
+
+The language-specific parts that `tetrad-jit` contained — nibble-pair
+arithmetic, liveness-based register recycling for the 4004's 6-pair limit,
+Intel 4004 assembly encoding — move into the `intel4004-backend` package.
+`jit-core` itself is pure IR manipulation and dispatch.
+
+This spec covers:
+
+1. Hot-function detection and tiered thresholds
+2. The specialization pass (InterpreterIR → CompilerIR)
+3. Type guards and deoptimisation
+4. The compiled-function cache (`JITCache`)
+5. The backend dispatch protocol
+6. Integration with `vm-core`'s shadow frames
+
+---
+
+## Tiered compilation
+
+`jit-core` implements three compilation tiers, matching the thresholds
+established by `TetradJIT`:
+
+| Tier | Trigger | Rationale |
+|------|---------|-----------|
+| `FULLY_TYPED` | Before first call | All types are statically known; no feedback needed |
+| `PARTIALLY_TYPED` | After N₁ calls (default: 10) | Some types known, some observed |
+| `UNTYPED` | After N₂ calls (default: 100) | All types from feedback; polymorphic → deopt |
+
+The thresholds are configurable at construction time:
+
+```python
+jit = JITCore(
+    vm,
+    backend=intel4004_backend,
+    threshold_fully_typed=0,      # compile before call 1
+    threshold_partial=10,
+    threshold_untyped=100,
+)
+```
+
+A threshold of `0` means "compile eagerly before the first interpreted call".
+This is the Tetrad behaviour for FULLY_TYPED functions.
+
+---
+
+## Architecture
+
+```
+vm-core running IIRModule
+    │
+    │  after each interpreted call
+    ▼
+JITCore._promote_hot_functions()
+    │
+    │  function crossed its threshold
+    ▼
+JITCore._compile_fn(fn: IIRFunction)
+    │
+    ├── specialise(fn, feedback_vectors)
+    │       IIRInstr list → CompilerIR block list
+    │
+    ├── ir-optimizer passes (constant folding, DCE)
+    │       CompilerIR → CompilerIR (optimized)
+    │
+    ├── backend.compile(compiler_ir)
+    │       CompilerIR → bytes (native binary)
+    │
+    └── JITCache.put(fn.name, binary)
+
+JITCore.execute(fn_name, args)
+    │
+    ├── cache hit  → backend.run(binary, args)
+    └── cache miss → vm.execute(fn) [interpreted fallback]
+                     _promote_hot_functions() [after fallback]
+```
+
+---
+
+## Specialization pass
+
+The specialization pass converts `IIRFunction` → `CompilerIR` using the
+observation slots filled by the `vm-core` profiler.
+
+### Pass overview
+
+```python
+def specialise(fn: IIRFunction, min_observations: int = 5) -> list[CIRBlock]:
+    """
+    Walk IIRInstr list; emit CompilerIR instructions.
+
+    For instructions whose type_hint == "any":
+      - If observed_type is concrete and observation_count >= min_observations:
+          emit a type guard (type_assert), then specialize the operation
+      - If observed_type == "polymorphic" or count < min_observations:
+          emit a generic (unspecialized) operation
+    """
+```
+
+### Type guard emission
+
+For an `add` instruction observed as `u8`:
+
+```
+IIRInstr:  op="add", dest="v0", srcs=["a","b"], type_hint="any",
+           observed_type="u8", deopt_anchor=3
+
+CompilerIR emitted:
+    ; type guards
+    type_assert a, u8   (deopt_to=3)
+    type_assert b, u8   (deopt_to=3)
+    ; specialized operation
+    v0 = add_u8 a, b
+```
+
+For the same `add` instruction with `observed_type="polymorphic"`:
+
+```
+CompilerIR emitted:
+    ; no guard; generic runtime call
+    v0 = call_runtime "generic_add" [a, b]
+```
+
+### Instruction mapping
+
+| IIRInstr op | Observed type | CompilerIR op |
+|-------------|---------------|---------------|
+| `add` | `u8` | `add_u8` |
+| `add` | `u16` | `add_u16` |
+| `add` | `str` | `call_runtime "str_concat"` |
+| `add` | `polymorphic` | `call_runtime "generic_add"` |
+| `cmp_lt` | `u8` | `cmp_lt_u8` |
+| `jmp_if_false` | `bool` | `br_false_bool` |
+| `const` | any | `const_<type>` |
+| `ret` | any | `ret_<type>` |
+
+The full mapping table is defined in `specialise.py` and is backend-independent.
+Backends see only typed `CompilerIR` operations.
+
+---
+
+## CompilerIR subset used by jit-core
+
+`jit-core` emits a subset of the full `CompilerIR` format — only the
+instructions that have direct backend representations:
+
+```python
+@dataclass
+class CIRInstr:
+    op: str                          # typed mnemonic, e.g. "add_u8"
+    dest: str | None
+    srcs: list[str | int | float | bool]
+    type: str                        # always a concrete type; never "any"
+    deopt_to: int | None = None      # interpreter instruction index for guards
+```
+
+SSA phi-nodes, loop induction variables, and other high-level CompilerIR
+constructs are not generated by `jit-core`.  They are generated by the
+compiled-language path (SemanticIR → CompilerIR → ir-optimizer → backend).
+
+---
+
+## Type guards and deoptimisation
+
+A type guard is a `type_assert` instruction in the emitted `CompilerIR`.
+The backend translates it to a conditional branch:
+
+```
+; Backend (Intel 4004 example):
+;   R(2p) must equal expected_hi, R(2p+1) must equal expected_lo
+;   If not, jump to deopt stub.
+FIM P7, 0x00       ; expected hi nibble = 0 (u8 guard: hi must be 0 for values 0–255)
+LD  R14            ; A = R14 (hi nibble of value in P7)
+XCH R(2p)         ; compare with actual hi nibble
+JNZ deopt_3       ; deopt to instruction 3 if hi nibble is wrong
+```
+
+The deopt stub saves the current register state, restores the interpreter
+shadow frame, and jumps to `vm.resume_frame(frame, at_ip=deopt_anchor)`.
+
+### Deopt frequency tracking
+
+The JIT cache entry tracks how many times each compiled function deopts:
+
+```python
+@dataclass
+class JITCacheEntry:
+    fn_name: str
+    binary: bytes
+    backend_name: str
+    param_count: int
+    ir: list[CIRInstr]             # post-optimization IR
+    compilation_time_ns: int
+    deopt_count: int = 0           # incremented by the deopt stub at runtime
+    exec_count: int = 0            # incremented on each compiled execution
+```
+
+If `deopt_count / exec_count > 0.1` (more than 10% deopt rate), `jit-core`
+**invalidates** the compiled version and marks the function as
+`UNSPECIALIZABLE`.  The function then runs interpreted forever.
+
+---
+
+## JITCache
+
+```python
+class JITCache:
+    """Dictionary-backed cache mapping function names to compiled binaries."""
+
+    def get(self, fn_name: str) -> JITCacheEntry | None: ...
+    def put(self, entry: JITCacheEntry) -> None: ...
+    def invalidate(self, fn_name: str) -> None: ...
+    def stats(self) -> dict[str, dict]: ...
+    @staticmethod
+    def now_ns() -> int: ...   # monotonic nanosecond timestamp
+```
+
+`invalidate` removes the entry and marks the function so it is never
+re-compiled (avoids thrashing for fundamentally polymorphic functions).
+
+---
+
+## Hot-function detection
+
+```python
+def _promote_hot_functions(self) -> None:
+    if self._module is None:
+        return
+    counts = self._vm.metrics().function_call_counts
+    for fn in self._module.functions:
+        if self.is_compiled(fn.name):
+            continue
+        if fn.name in self._unspecializable:
+            continue
+        threshold = self._thresholds.get(fn.type_status)
+        if threshold is None:
+            continue
+        if threshold == 0:
+            continue   # FULLY_TYPED functions are compiled eagerly in execute_with_jit
+        if counts.get(fn.name, 0) >= threshold:
+            self._compile_fn(fn)
+```
+
+This is identical in structure to `TetradJIT._promote_hot_functions()` (TET05),
+generalised to use `IIRFunction.type_status` instead of Tetrad-specific enums.
+
+---
+
+## Public API
+
+```python
+class JITCore:
+    def __init__(
+        self,
+        vm: VMCore,
+        backend: BackendProtocol,          # see LANG05
+        threshold_fully_typed: int = 0,
+        threshold_partial: int = 10,
+        threshold_untyped: int = 100,
+        min_observations: int = 5,
+    ) -> None: ...
+
+    def execute_with_jit(self, module: IIRModule) -> int | None:
+        """Run module under the interpreter; auto-compile hot functions.
+
+        Phase 1: compile all FULLY_TYPED functions before first interpreted call.
+        Phase 2: run main() via the interpreter.
+        Phase 3: promote any function that turned hot during Phase 2.
+        Returns the return value of main, or None if no main function.
+        """
+
+    def compile(self, fn_name: str) -> bool:
+        """Manually compile fn_name. Returns True on success, False on deopt."""
+
+    def execute(self, fn_name: str, args: list[int]) -> int | None:
+        """Execute fn_name (compiled or interpreted). Updates call counts."""
+
+    def is_compiled(self, fn_name: str) -> bool:
+        """Return True if fn_name has a cached native binary."""
+
+    def cache_stats(self) -> dict[str, dict]:
+        """Return per-function cache statistics."""
+
+    def dump_ir(self, fn_name: str) -> str:
+        """Return the post-optimization CompilerIR for fn_name as a string."""
+
+    def invalidate(self, fn_name: str) -> None:
+        """Remove the compiled version; mark as unspecializable."""
+```
+
+---
+
+## Integration with vm-core shadow frames
+
+When `jit-core` compiles a function, it registers a **JIT handler** with
+`vm-core`:
+
+```python
+vm.register_jit_handler(fn_name, lambda args: backend.run(binary, args))
+```
+
+`vm-core`'s dispatch loop checks for a registered JIT handler before running
+the interpreted path:
+
+```python
+def _dispatch_call(self, frame, instr):
+    fn_name = resolve_fn_name(instr)
+    handler = self._jit_handlers.get(fn_name)
+    if handler is not None:
+        result = handler(resolved_args)
+        self._metrics.total_jit_hits += 1
+        return result
+    return self._dispatch_call_interpreted(frame, instr)
+```
+
+This means the compiled path requires **zero overhead** in the dispatch loop for
+functions that are still interpreted — the `dict.get` check is O(1) and returns
+`None` most of the time.
+
+---
+
+## Compiler pipeline
+
+```python
+def _compile_fn(self, fn: IIRFunction) -> bool:
+    t0 = JITCache.now_ns()
+    try:
+        cir = specialise(fn, min_observations=self._min_observations)
+        cir = ir_optimizer.run(cir)      # constant folding, DCE
+        binary = self._backend.compile(cir)
+    except Exception:
+        return False
+
+    if binary is None:
+        return False
+
+    t1 = JITCache.now_ns()
+    self._cache.put(JITCacheEntry(
+        fn_name=fn.name,
+        binary=binary,
+        backend_name=self._backend.name,
+        param_count=len(fn.params),
+        ir=cir,
+        compilation_time_ns=t1 - t0,
+    ))
+    self._vm.register_jit_handler(fn.name, lambda args: self._backend.run(binary, args))
+    return True
+```
+
+---
+
+## Package structure
+
+```
+jit-core/
+  pyproject.toml
+  BUILD
+  README.md
+  CHANGELOG.md
+  src/jit_core/
+    __init__.py       # exports JITCore
+    core.py           # JITCore class — top-level API + hot-function promotion
+    specialise.py     # IIRFunction → list[CIRInstr] specialization pass
+    cir.py            # CIRInstr dataclass (jit-core's subset of CompilerIR)
+    cache.py          # JITCache, JITCacheEntry
+    errors.py         # DeoptimizerError, UnspecializableError
+  tests/
+    test_specialise.py
+    test_tiers.py
+    test_deopt.py
+    test_cache.py
+    test_integration.py  # end-to-end: IIRModule → JIT → native result
+```
+
+---
+
+## Relationship to tetrad-jit
+
+`tetrad-jit` implements every piece of this spec for the Tetrad language and
+Intel 4004 backend specifically.  The generalisation is:
+
+| `tetrad-jit` | `jit-core` equivalent |
+|--------------|----------------------|
+| `translate.py` (bytecode → JIT IR) | `specialise.py` (IIR → CIR) |
+| `passes.py` (constant folding, DCE) | `ir-optimizer` package |
+| `codegen_4004.py` (IR → 4004 binary) | `intel4004-backend` package |
+| `cache.py` | `jit_core.cache` |
+| `__init__.py` TetradJIT class | `jit_core.core` JITCore class |
+
+After `jit-core` is implemented:
+- `tetrad-jit` becomes a 30-line compatibility shim that constructs
+  `JITCore(vm_core_instance, backend=intel4004_backend)`
+- All the logic moves into `jit-core` and `intel4004-backend`
+- The existing `tetrad-jit` tests are re-run against the new implementation
+  with zero changes to the test assertions

--- a/code/specs/LANG04-aot-core.md
+++ b/code/specs/LANG04-aot-core.md
@@ -1,0 +1,319 @@
+# LANG04 — aot-core: Ahead-of-Time Compilation Path
+
+## Overview
+
+`aot-core` is the **ahead-of-time compilation path** for interpreted languages.
+Where `jit-core` (LANG03) compiles hot functions *at runtime* after observing
+their behaviour, `aot-core` compiles the *entire program* at build time —
+before any user has run it.
+
+The distinction matters:
+
+| | JIT | AOT |
+|--|-----|-----|
+| When? | At runtime, after observing hot functions | At build time, before first run |
+| Input | InterpreterIR + runtime feedback | InterpreterIR alone |
+| Output | Binary resident in process memory | Binary written to disk |
+| Type information | From profiler (observed) | From type checker (static) |
+| Warmup time | Yes (interpreted until threshold) | Zero (always compiled) |
+| Portability | Runs on compilation host only | Cross-compilable (target ≠ host) |
+
+AOT makes sense when:
+- The source language is fully (or sufficiently) typed
+- Cold-start time matters (CLIs, embedded systems, IoT)
+- The target hardware cannot host a runtime (Intel 4004 with 160 bytes RAM)
+- A snapshot binary must be distributed to a user who has no language toolchain
+
+This spec covers:
+
+1. The AOT pipeline (IIR → CompilerIR → binary)
+2. Handling of untyped functions (type inference or deopt stubs)
+3. The `vm-runtime` linkable library (for AOT programs that need runtime support)
+4. Cross-compilation (host ≠ target)
+5. Snapshot format (`.aot` binary)
+6. Integration with the existing `ir-optimizer` passes
+
+---
+
+## Why AOT is possible for interpreted languages
+
+An interpreted language does not *require* a runtime interpreter at execution
+time — the interpreter is a **convenience tool** for the developer.  The
+program's semantics can be fully captured in a compiled binary if:
+
+1. All types are known (statically typed, or inferred to be monomorphic)
+2. All function calls can be statically resolved (no dynamic dispatch)
+3. All dynamic features used by the program (closures, first-class functions)
+   can be reduced to static equivalents by the compiler
+
+For programs that meet these conditions, `aot-core` emits a standalone binary
+with no dependency on the interpreter at all.
+
+For programs that use dynamic features, `aot-core` links in the **vm-runtime**
+library — a compiled form of the `vm-core` interpreter that is bundled into
+the binary.  The vm-runtime handles only the dynamic parts; static parts are
+compiled directly.
+
+This is exactly how CPython's `pyc` files work, how Java's AOT compilers work,
+and how BASIC implementations on early home computers worked: the BASIC
+interpreter was stored in ROM and the BASIC program could call back into it for
+dynamic features like `INPUT` and `PRINT`.
+
+---
+
+## The AOT pipeline
+
+```
+IIRModule (bytecode)
+    │
+    ├── Type inference (for UNTYPED functions)
+    │     aot-core runs a lightweight Hindley-Milner–style inference pass
+    │     over IIRInstr sequences.  Functions that remain polymorphic after
+    │     inference are compiled with vm-runtime call stubs (see below).
+    │
+    ├── Specialization (IIR → CompilerIR)
+    │     Same pass as jit-core's specialise.py, but without feedback vectors.
+    │     Observes type_hint fields only (not observed_type).
+    │     UNTYPED functions with inferred types → specialize normally.
+    │     UNTYPED functions that remain "any" → emit vm-runtime call stub.
+    │
+    ├── ir-optimizer passes (constant folding, DCE, inlining)
+    │
+    ├── Backend compilation (CompilerIR → native binary)
+    │     Same backend-protocol as jit-core.  The backend doesn't know whether
+    │     it is being called from JIT or AOT.
+    │
+    └── Linker (optional)
+          If any vm-runtime stubs are present, link the vm-runtime library.
+          The linker resolves stub addresses to vm-runtime function pointers.
+          Output: a single `.aot` file containing all functions + vm-runtime.
+```
+
+---
+
+## Type inference for UNTYPED functions
+
+AOT cannot observe runtime types, so it runs a **static inference pass** over
+the `IIRInstr` sequence:
+
+```
+Rule: if all srcs of an instruction have a known type, the dest type is inferred.
+
+Examples:
+  const 42        → u8  (literals in 0–255 range → u8)
+  add u8, u8      → u8
+  add u8, u16     → u16  (promotion)
+  cmp_lt u8, u8   → bool
+  jmp_if_false bool → (control, no result)
+```
+
+The inference is flow-insensitive (no SSA phi analysis) for simplicity.  It
+is correct for straight-line code and for code where all branches produce the
+same type.  For code where branches produce different types (e.g., an `if`
+returning `u8` on one branch and `str` on another), the result type is `"any"`
+and the function falls back to the vm-runtime stub path.
+
+---
+
+## vm-runtime: the linkable interpreter library
+
+`vm-runtime` is a **compiled, linkable form** of `vm-core`.  It provides the
+same dispatch loop as `vm-core`, but compiled to the target architecture as a
+static library that can be linked into an AOT binary.
+
+```
+vm-runtime.a  (target-arch static library)
+    │
+    ├── vm_execute(fn_index, args) → result
+    ├── vm_call_builtin(name, args) → result
+    └── vm_iir_table[]   (the IIR bytecode of all uncompiled functions)
+```
+
+The `vm_iir_table` is a compact binary encoding of all functions that were
+not fully compiled (i.e., those that had `"any"` types after inference).
+When an AOT binary calls a vm-runtime stub, it calls `vm_execute(fn_index, args)`,
+which interprets the function from `vm_iir_table` at runtime.
+
+This is analogous to:
+- The ROM BASIC interpreter on the Apple II (interpreter in ROM, calls from compiled code)
+- The JVM `invokedynamic` bootstrap mechanism
+- LLVM's `libFuzzer` runtime stubs for undefined behaviour handlers
+
+---
+
+## AOT snapshot format (`.aot`)
+
+The `.aot` file is a self-contained binary that can be executed on the target
+architecture:
+
+```
+Header:
+  4 bytes  magic     0x41 0x4F 0x54 0x00  ("AOT\0")
+  2 bytes  version   0x01 0x00
+  4 bytes  flags     bit 0: vm_runtime linked; bit 1: debug info present
+  4 bytes  entry_point_offset  (byte offset of the main function's code)
+  4 bytes  vm_iir_table_offset (0 if no vm-runtime)
+  4 bytes  vm_iir_table_size
+  4 bytes  native_code_size
+
+Code section:
+  N bytes  native machine code for all compiled functions
+
+IIR table section (optional):
+  M bytes  serialised IIRModule (LANG01 serialisation format) for dynamic fns
+
+Debug section (optional):
+  Mapping of native instruction offsets → IIR instruction indices → source lines
+```
+
+The file is directly executable on the target architecture (or loadable by
+the target simulator):
+
+```python
+# Execute an .aot file on the Intel 4004 simulator:
+from intel4004_simulator import Intel4004Simulator
+with open("program.aot", "rb") as f:
+    aot = f.read()
+sim = Intel4004Simulator()
+sim.load_rom(aot[header.native_code_offset:])
+result = sim.run()
+```
+
+---
+
+## Cross-compilation
+
+`aot-core` supports cross-compilation when the backend supports it.  The
+backend protocol (LANG05) includes a `target_arch` field that determines
+the instruction set of the emitted binary.  The host machine (running
+`aot-core`) can be x86-64 while the target is Intel 4004.
+
+This is how the existing Tetrad JIT already works: the 4004 binary is
+generated on a modern laptop, fed to `Intel4004Simulator`, and the result
+is returned.  The JIT is doing cross-compilation — it just doesn't call
+itself that.
+
+```python
+aot = AOTCore(
+    backend=intel4004_backend,   # target: Intel 4004
+    vm_runtime=None,             # no runtime needed for fully typed programs
+)
+binary = aot.compile(iir_module)
+with open("program.aot", "wb") as f:
+    f.write(binary)
+```
+
+For programs that need the vm-runtime on a real target (not a simulator),
+the vm-runtime must be pre-compiled for that target:
+
+```
+vm-runtime/
+  prebuilt/
+    vm_runtime_intel8080.a    # pre-compiled for Intel 8080
+    vm_runtime_riscv32.a      # pre-compiled for RISC-V 32-bit
+    vm_runtime_wasm32.a       # pre-compiled for WASM
+```
+
+---
+
+## Integration with ir-optimizer
+
+`aot-core` runs the same `ir-optimizer` passes as `jit-core`:
+
+1. **Constant folding** — evaluate `const + const` at compile time
+2. **Dead code elimination** — remove instructions whose `dest` is never used
+3. **Function inlining** — inline small callees into the caller (AOT-only; too
+   expensive to do at JIT time for first-call compilation)
+4. **Loop unrolling** — unroll small fixed-iteration loops (AOT-only)
+
+The inlining and loop unrolling passes are AOT-only because they increase
+binary size (acceptable for AOT) and take more compile time (acceptable offline;
+not acceptable during a hot JIT compile).
+
+---
+
+## Handling dynamic features
+
+Some language features cannot be compiled to static code:
+
+| Feature | AOT treatment |
+|---------|---------------|
+| `INPUT` (BASIC) | vm-runtime builtin call |
+| Eval / dynamic code execution | vm-runtime call |
+| First-class functions (closures over mutable state) | vm-runtime closure object |
+| `GOTO` with computed target | vm-runtime dispatch table |
+| Recursive types (linked lists) | vm-runtime heap allocation |
+| Dynamic string operations | vm-runtime string calls |
+
+A fully typed, non-recursive, no-eval program compiles to a pure native binary
+with zero vm-runtime dependency.  Tetrad programs are in this category because
+Tetrad's type system and restricted feature set guarantee it.
+
+---
+
+## Public API
+
+```python
+class AOTCore:
+    def __init__(
+        self,
+        backend: BackendProtocol,
+        vm_runtime: VmRuntime | None = None,
+        optimization_level: int = 2,        # 0=none, 1=basic, 2=full
+        debug_info: bool = False,
+    ) -> None: ...
+
+    def compile(self, module: IIRModule) -> bytes:
+        """Compile the entire module to a .aot binary. Returns the raw bytes."""
+
+    def compile_to_file(self, module: IIRModule, path: str) -> None:
+        """Compile and write to path."""
+
+    def stats(self) -> AOTStats:
+        """Return compilation statistics (functions compiled, inlined, etc.)."""
+```
+
+---
+
+## Package structure
+
+```
+aot-core/
+  pyproject.toml
+  BUILD
+  README.md
+  CHANGELOG.md
+  src/aot_core/
+    __init__.py       # exports AOTCore, AOTStats
+    core.py           # AOTCore class
+    infer.py          # static type inference for UNTYPED functions
+    specialise.py     # IIR → CIR (shared logic with jit-core; extracts to ir-specialise)
+    link.py           # linker: merge native code + vm_iir_table into .aot
+    snapshot.py       # .aot format writer / reader
+    vm_runtime.py     # vm-runtime library loader
+    stats.py          # AOTStats dataclass
+  tests/
+    test_infer.py
+    test_compile_full.py     # fully typed program → no vm-runtime
+    test_compile_partial.py  # partially typed → vm-runtime linked
+    test_snapshot.py         # write/read .aot roundtrip
+    test_cross_compile.py    # host != target (mocked backend)
+```
+
+---
+
+## When to use JIT vs AOT
+
+| Scenario | Recommendation |
+|----------|---------------|
+| Interactive REPL | JIT — user expects instant results |
+| Long-running server | JIT — warmup acceptable; benefits from runtime feedback |
+| CLI tool (cold-start critical) | AOT — warmup unacceptable |
+| Embedded target (no host runtime) | AOT — interpreter cannot run on target |
+| Full static types | AOT — no feedback needed; compile fully |
+| Dynamic / polymorphic code | JIT — better specialization from observed types |
+| Distribution without toolchain | AOT — `.aot` is self-contained |
+
+The Tetrad pipeline uses **both**: the `tetrad-jit` package is the JIT path;
+`aot-core` + `intel4004-backend` is the AOT path that produces `.aot` files
+that run directly on `Intel4004Simulator` with no Python required at run time.

--- a/code/specs/LANG05-backend-protocol.md
+++ b/code/specs/LANG05-backend-protocol.md
@@ -1,0 +1,405 @@
+# LANG05 — backend-protocol: Code Generation Backend Contract
+
+## Overview
+
+`backend-protocol` defines the **contract** that every code-generation backend
+in this repository must satisfy.  A backend is any component that converts
+`CompilerIR` (the typed, SSA intermediate representation) into a runnable
+binary for a specific instruction set or virtual machine.
+
+Existing backends:
+
+| Backend package | Target | Used by |
+|-----------------|--------|---------|
+| `intel4004-backend` | Intel 4004 | Tetrad JIT, Nib AOT |
+| `wasm-backend` | WebAssembly | Nib WASM, future languages |
+| `jvm-backend` | JVM class file | Java-family, Nib JVM |
+| `clr-backend` | .NET CIL | C#-family, .NET languages |
+| `riscv-backend` | RISC-V 32-bit | future systems languages |
+
+The `backend-protocol` package provides:
+
+1. The `BackendProtocol` abstract base class / Protocol that backends implement
+2. The `BackendCapabilities` dataclass describing what a backend supports
+3. The `BackendRegistry` for dynamic backend lookup
+4. Standard test fixtures that every backend implementation must pass
+
+This spec covers all five items and describes the Intel 4004 backend as a
+worked example showing how the Tetrad JIT's `codegen_4004.py` maps onto the
+protocol.
+
+---
+
+## BackendProtocol
+
+```python
+from abc import ABC, abstractmethod
+from typing import Protocol, runtime_checkable
+
+@runtime_checkable
+class BackendProtocol(Protocol):
+    """Protocol that every code-generation backend must implement."""
+
+    name: str                        # unique identifier, e.g. "intel4004"
+    target_arch: str                 # ISA name, e.g. "intel4004", "wasm32", "jvm8"
+    capabilities: BackendCapabilities
+
+    def compile(self, ir: list[CIRInstr]) -> bytes | None:
+        """
+        Compile a list of CompilerIR instructions to a native binary.
+
+        Returns bytes on success, or None if any instruction cannot be encoded
+        (deoptimisation — the function continues in the interpreter).
+
+        The returned bytes are in the format expected by run().
+        """
+        ...
+
+    def run(self, binary: bytes, args: list[int]) -> int:
+        """
+        Execute a compiled binary with the given arguments.
+
+        args are u8 integers (0–255).  The return value is u8.
+        The backend is responsible for loading binary onto the target
+        (simulator, native mmap, JVM ClassLoader, etc.).
+        """
+        ...
+
+    def disassemble(self, binary: bytes) -> str:
+        """
+        Return a human-readable disassembly of binary.
+
+        Used for debugging and spec validation.  Optional in the sense that
+        a backend may return an empty string, but MUST be implemented.
+        """
+        ...
+```
+
+### Protocol vs ABC
+
+`BackendProtocol` is defined as a `typing.Protocol` rather than an `ABC`.
+This means:
+
+- A backend class does not need to inherit from `BackendProtocol`
+- A backend satisfies the protocol if it has the right attributes and methods
+  (structural subtyping, a.k.a. duck typing)
+- `isinstance(backend, BackendProtocol)` works at runtime thanks to
+  `@runtime_checkable`
+
+This matches the style used by Python's `collections.abc` and makes it easy
+to wrap existing backends without modifying their source.
+
+---
+
+## BackendCapabilities
+
+```python
+@dataclass
+class BackendCapabilities:
+    """Describes what a backend can and cannot do."""
+
+    supports_add: bool = True
+    supports_sub: bool = True
+    supports_mul: bool = False      # Intel 4004 cannot; WASM can
+    supports_div: bool = False
+    supports_mod: bool = False
+    supports_bitwise: bool = False  # and, or, xor, not, shl, shr
+    supports_cmp: bool = True       # eq, ne, lt, le, gt, ge
+    supports_branches: bool = True  # jmp, jmp_if_true, jmp_if_false
+    supports_calls: bool = False    # function calls within compiled code
+    supports_io: bool = False       # io_in, io_out
+    supports_str: bool = False      # string operations
+    supports_u8: bool = True
+    supports_u16: bool = False
+    supports_u32: bool = False
+    supports_u64: bool = False
+    max_live_registers: int = 6     # 4004: 6 pairs (P0–P5); WASM: unlimited
+    max_code_bytes: int = 4096      # 4004: 4 KB ROM; WASM: unlimited
+    is_simulator: bool = True       # True if run() uses a software simulator
+    is_cross_compile: bool = True   # True if host != target ISA
+```
+
+`jit-core` queries `backend.capabilities` before calling `compile()`.  If the
+IR contains an instruction the backend cannot handle (e.g., `mul` on the 4004),
+`jit-core` returns `False` immediately without calling `compile()`.
+
+This is the generalisation of the `tetrad-jit` deopt check:
+
+```python
+# tetrad-jit codegen_4004.py (per-function deopt check)
+UNSUPPORTED_OPS = frozenset({"mul", "div", "mod", "and", "or", ...})
+if any(i.op in UNSUPPORTED_OPS for i in ir):
+    return None   # deopt
+
+# jit-core (capability-driven, no magic sets)
+def _can_compile(self, ir: list[CIRInstr]) -> bool:
+    caps = self._backend.capabilities
+    for instr in ir:
+        if instr.op.startswith("mul") and not caps.supports_mul:
+            return False
+        if instr.op.startswith("div") and not caps.supports_div:
+            return False
+        ...
+    return True
+```
+
+---
+
+## Worked example: Intel 4004 backend
+
+The existing `codegen_4004.py` in `tetrad-jit` maps directly onto the protocol:
+
+```python
+class Intel4004Backend:
+    name = "intel4004"
+    target_arch = "intel4004"
+    capabilities = BackendCapabilities(
+        supports_mul=False,
+        supports_div=False,
+        supports_mod=False,
+        supports_bitwise=False,
+        supports_calls=False,
+        supports_io=False,
+        supports_str=False,
+        supports_u16=False,
+        supports_u32=False,
+        supports_u64=False,
+        max_live_registers=6,
+        max_code_bytes=4096,
+        is_simulator=True,
+        is_cross_compile=True,
+    )
+
+    def compile(self, ir: list[CIRInstr]) -> bytes | None:
+        gen = CodeGenerator4004()
+        try:
+            gen.generate(ir)
+            return gen.assemble()   # two-pass assembler → bytes
+        except DeoptimizerError:
+            return None
+
+    def run(self, binary: bytes, args: list[int]) -> int:
+        return run_on_4004(binary, args)   # existing helper
+
+    def disassemble(self, binary: bytes) -> str:
+        return disassemble_4004(binary)    # nibble-by-nibble decoder
+```
+
+The migration from `tetrad-jit` to this protocol is a rename, not a rewrite.
+
+---
+
+## WASM backend capabilities (contrast)
+
+```python
+class WasmBackend:
+    name = "wasm32"
+    target_arch = "wasm32"
+    capabilities = BackendCapabilities(
+        supports_mul=True,
+        supports_div=True,
+        supports_mod=True,
+        supports_bitwise=True,
+        supports_calls=True,
+        supports_io=False,           # WASM I/O goes through WASI imports
+        supports_str=False,          # string ops need a WASM runtime
+        supports_u8=True,
+        supports_u16=True,
+        supports_u32=True,
+        supports_u64=True,
+        max_live_registers=1000,     # effectively unlimited (wasm locals)
+        max_code_bytes=2**32,        # 4 GB WASM module limit
+        is_simulator=True,           # we use wasm-simulator from this repo
+        is_cross_compile=True,
+    )
+```
+
+A language that targets WASM gets `mul`, `div`, and `bitwise` for free and
+never needs to deopt those operations.  The same `jit-core` specialization
+pass is used; the capability check is the only difference.
+
+---
+
+## Standard backend tests
+
+Every backend must pass a **standard test suite** provided by
+`backend-protocol`:
+
+```python
+# backend_protocol.testing
+def run_standard_tests(backend: BackendProtocol) -> None:
+    """Run the standard backend compliance test suite.
+
+    Call this in your backend's test file:
+        from backend_protocol.testing import run_standard_tests
+        run_standard_tests(Intel4004Backend())
+    """
+    _test_add(backend)
+    _test_sub(backend)
+    _test_cmp(backend)
+    _test_branch(backend)
+    _test_const(backend)
+    _test_ret(backend)
+    if backend.capabilities.supports_mul:
+        _test_mul(backend)
+    if backend.capabilities.supports_bitwise:
+        _test_bitwise(backend)
+    if backend.capabilities.supports_calls:
+        _test_calls(backend)
+    _test_deopt_unsupported(backend)   # unsupported ops return None
+    _test_disassemble(backend)         # returns non-empty string
+```
+
+The standard tests guarantee that any backend interoperates correctly with
+`jit-core` and `aot-core`.  A backend that passes these tests is drop-in
+compatible.
+
+---
+
+## BackendRegistry
+
+```python
+class BackendRegistry:
+    """Global registry of available backends."""
+
+    _backends: dict[str, BackendProtocol] = {}
+
+    @classmethod
+    def register(cls, backend: BackendProtocol) -> None:
+        cls._backends[backend.name] = backend
+
+    @classmethod
+    def get(cls, name: str) -> BackendProtocol:
+        if name not in cls._backends:
+            raise KeyError(f"unknown backend: {name!r}")
+        return cls._backends[name]
+
+    @classmethod
+    def list_backends(cls) -> list[str]:
+        return list(cls._backends.keys())
+```
+
+Usage:
+
+```python
+from backend_protocol import BackendRegistry
+from intel4004_backend import Intel4004Backend
+
+BackendRegistry.register(Intel4004Backend())
+
+# Later, in jit-core or aot-core:
+backend = BackendRegistry.get("intel4004")
+jit = JITCore(vm, backend=backend)
+```
+
+The registry is populated at import time by each backend package's
+`__init__.py`.
+
+---
+
+## CompilerIR subset (CIRInstr)
+
+The `CIRInstr` type used by backends is the same subset defined in `jit-core`
+(LANG03):
+
+```python
+@dataclass
+class CIRInstr:
+    op: str                          # typed mnemonic: "add_u8", "cmp_lt_u8", …
+    dest: str | None
+    srcs: list[str | int | float | bool]
+    type: str                        # always a concrete type
+    deopt_to: int | None = None      # interpreter index if guard fails
+```
+
+The full `CompilerIR` from the `compiler-ir` package is a superset of
+`CIRInstr`.  For compiled languages (Nib, etc.), `ir-optimizer` produces
+the full CompilerIR.  For interpreted languages (Tetrad, BASIC), `jit-core`
+produces only the `CIRInstr` subset.
+
+Backends must handle at minimum the subset.  Backends that also serve the
+compiled-language path (e.g., `wasm-backend` used by both Nib and BASIC)
+must handle the full CompilerIR.
+
+---
+
+## Adding a new backend
+
+Steps to add a new backend (e.g., `arm32-backend`):
+
+1. Create `code/packages/<language>/arm32-backend/`
+2. Implement `class Arm32Backend` satisfying `BackendProtocol`
+3. Fill in `BackendCapabilities` accurately
+4. Call `run_standard_tests(Arm32Backend())` in the test suite
+5. Register: `BackendRegistry.register(Arm32Backend())`
+6. Write a spec `07h-arm32-backend.md` (follows the ISA simulator spec naming)
+7. Add to the BUILD file with its dependencies
+
+No changes to `jit-core`, `aot-core`, or any language package are needed.
+The new backend becomes available to all languages immediately.
+
+---
+
+## Package structure
+
+```
+backend-protocol/
+  pyproject.toml
+  BUILD
+  README.md
+  CHANGELOG.md
+  src/backend_protocol/
+    __init__.py       # exports BackendProtocol, BackendCapabilities, BackendRegistry
+    protocol.py       # BackendProtocol (Protocol class)
+    capabilities.py   # BackendCapabilities dataclass
+    registry.py       # BackendRegistry
+    cir.py            # CIRInstr dataclass (shared with jit-core; one source of truth)
+    testing.py        # run_standard_tests() + individual _test_* helpers
+  tests/
+    test_protocol.py      # isinstance checks, capability validation
+    test_registry.py
+    test_standard_suite.py  # runs standard tests against a mock backend
+```
+
+---
+
+## Existing backend migration
+
+The backends that already exist but are not yet protocol-compliant:
+
+| Package | Status | Migration effort |
+|---------|--------|-----------------|
+| `codegen_4004.py` in `tetrad-jit` | Working, not protocol | Extract `Intel4004Backend` class; ~50 lines |
+| `ir_to_wasm_compiler` | Existing | Wrap in `WasmBackend`; ~30 lines |
+| `ir_to_jvm_class_file` | Existing | Wrap in `JvmBackend`; ~30 lines |
+| `ir_to_cil_bytecode` | Existing | Wrap in `ClrBackend`; ~30 lines |
+| `riscv_simulator` | Simulator, not a compiler | Add `compile()` pass; larger effort |
+
+All wrappers preserve the existing package's internal implementation.
+The `BackendProtocol` wrapper is a thin adapter (the Adapter pattern).
+
+---
+
+## Design decisions
+
+### Why a Protocol, not inheritance?
+
+Existing backend packages (`ir-to-wasm-compiler`, `ir-to-jvm-class-file`) were
+written before `backend-protocol` was specified.  Requiring them to inherit
+from a new base class would require modifying each package.  Structural
+subtyping (Protocol) lets them satisfy the contract without modification.
+
+### Why is `run()` part of the protocol?
+
+The alternative is a separate `Executor` protocol.  But separating `compile`
+from `run` means the registry would need to track two objects per backend.
+Every actual backend always needs both — the Intel 4004 compiler always uses
+`Intel4004Simulator` to run; the WASM compiler always uses `wasm-simulator`.
+Combining them keeps the API simple.
+
+### Why u8 for args/return in `run()`?
+
+`jit-core` currently targets Tetrad's u8 domain.  As languages with wider types
+are added (u16, u32), the `run()` signature will be extended to
+`run(binary, args: list[int], arg_types: list[str]) -> int`.  For now, u8 is
+the correct scope.

--- a/code/specs/LANG06-debug-integration.md
+++ b/code/specs/LANG06-debug-integration.md
@@ -1,0 +1,240 @@
+# LANG06 — Debug Integration: VSCode Debugger for Every Language
+
+## Overview
+
+Any language built on `vm-core` (LANG02) gets full VSCode debugger support —
+breakpoints, stepping, stack inspection, variable watching — for free.
+
+The existing specs `05d` (debug sidecar format) and `05e` (debug adapter
+protocol) define the mechanism.  This spec defines the **integration points**
+that `vm-core` and the language's bytecode compiler must expose so that the
+generic debug infrastructure can attach without language-specific modification.
+
+The result:
+
+```
+New language "BASIC" built on LANG pipeline
+  → tetrad-lexer  → tetrad-parser → tetrad-compiler (emits IIRModule)
+  → vm-core executes IIRModule
+  → LANG06 debug hooks active automatically
+  → VSCode can: set breakpoints, step in/out, inspect registers and call stack
+```
+
+No debug-specific code needed in the language's own packages.
+
+---
+
+## What the language must provide
+
+Only one thing: the **bytecode compiler must emit a debug sidecar** alongside
+the `IIRModule`.  The debug sidecar (spec `05d`) maps `IIRInstr` indices back
+to source file positions.
+
+```python
+from interpreter_ir import IIRModule
+from debug_sidecar import DebugSidecarWriter
+
+class MyLangCompiler:
+    def compile(self, ast, source_path: str) -> tuple[IIRModule, bytes]:
+        writer = DebugSidecarWriter(source_path)
+
+        # For each instruction emitted:
+        writer.record(instr_index=0, line=10, col=5, scope="main")
+
+        module = IIRModule(...)
+        sidecar = writer.finish()
+        return module, sidecar
+```
+
+That's the entire language-specific contribution.  Everything else is handled
+by `vm-core` and the generic debug adapter.
+
+---
+
+## vm-core debug hooks
+
+`vm-core` exposes a `DebugHooks` interface that the debug adapter attaches to:
+
+```python
+class DebugHooks:
+    """Callbacks the debug adapter registers with vm-core."""
+
+    def on_instruction(self, frame: VMFrame, instr: IIRInstr) -> None:
+        """Called before each instruction is dispatched.
+
+        The hook can call vm.pause() to suspend execution.
+        """
+
+    def on_call(self, caller: VMFrame, callee: IIRFunction) -> None:
+        """Called when a CALL instruction pushes a new frame."""
+
+    def on_return(self, frame: VMFrame, return_value: Any) -> None:
+        """Called when a RET instruction pops a frame."""
+
+    def on_exception(self, frame: VMFrame, error: Exception) -> None:
+        """Called when an unhandled exception is raised."""
+```
+
+```python
+# Attaching the debug adapter:
+vm = VMCore(...)
+adapter = GenericDebugAdapter(sidecar=sidecar_bytes, port=4711)
+vm.attach_debug_hooks(adapter.hooks)
+vm.execute(module)
+```
+
+When `vm.pause()` is called inside `on_instruction`, the dispatch loop
+suspends and the debug adapter takes control.
+
+### Pause / resume API
+
+```python
+vm.pause()          # suspend at current instruction
+vm.step_over()      # resume; pause at next instruction in same frame
+vm.step_in()        # resume; pause at first instruction of next called frame
+vm.step_out()       # resume; pause at return site of current frame
+vm.continue_()      # resume until next breakpoint or end
+vm.set_breakpoint(instr_idx: int, fn_name: str)
+vm.clear_breakpoint(instr_idx: int, fn_name: str)
+```
+
+These map directly to the DAP `next`, `stepIn`, `stepOut`, `continue`,
+`setBreakpoints` requests (spec `05e`).
+
+---
+
+## Stack inspection
+
+When paused, the debug adapter can inspect the full call stack:
+
+```python
+vm.call_stack() -> list[VMFrame]
+```
+
+Each `VMFrame` exposes:
+
+```python
+frame.fn.name          # function name
+frame.ip               # current instruction index
+frame.registers[i]     # current value of register i
+```
+
+The debug adapter uses the sidecar to translate `frame.ip` → `(source_line, column)`.
+
+### Variable names
+
+The sidecar (spec `05d`) maps each register index to the source-level variable
+name at the current scope.  The debug adapter reads this mapping and presents
+`registers[2]` as `x` (or whatever the source-level name is) in the VSCode
+Variables panel.
+
+```
+VSCode Variables panel:
+  Local variables:
+    a = 10         (register 0)
+    b = 20         (register 1)
+    result = 30    (register 2)
+```
+
+---
+
+## Breakpoint protocol
+
+Breakpoints are set at source lines.  The generic debug adapter resolves them
+to `IIRInstr` indices using the sidecar:
+
+```
+User sets breakpoint at line 42 of myprogram.basic
+  → adapter reads sidecar: line 42 → instr_index 17 in function "main"
+  → adapter calls vm.set_breakpoint(17, "main")
+  → vm.on_instruction checks: if ip == 17 and fn == "main": vm.pause()
+```
+
+Conditional breakpoints are supported:
+
+```python
+vm.set_breakpoint(17, "main", condition="a > 10")
+```
+
+The condition is evaluated as an expression over the current register file.
+The expression evaluator is a tiny interpreter over `IIRInstr` arithmetic —
+no language-specific parser needed.
+
+---
+
+## Hot-reload and live editing
+
+When the source is edited while paused:
+
+1. The language frontend re-compiles the changed function to a new `IIRFunction`
+2. `vm-core` patches the running module: `vm.patch_function(fn_name, new_fn)`
+3. Execution resumes with the new function body
+
+This is safe when the function is currently on the call stack only if:
+- The register count has not changed
+- The edit does not affect instructions already executed in the current frame
+
+If either condition is violated, `vm-core` raises `HotReloadConflict` and the
+debug adapter notifies the user that a full restart is required.
+
+---
+
+## Integration with JIT
+
+When a function is JIT-compiled (LANG03), the debug hooks become more complex
+because the compiled binary does not have per-instruction checkpoints.
+
+`jit-core` respects `vm.is_debug_mode()`:
+
+```python
+if vm.is_debug_mode():
+    # Do not compile this function; keep it interpreted.
+    return False
+```
+
+In debug mode, all functions remain interpreted so the `on_instruction` hook
+fires for every instruction.  Debugging and maximum performance are mutually
+exclusive — this is the same trade-off made by the JVM, V8, and CPython.
+
+---
+
+## VSCode extension
+
+A single generic VSCode extension (`coding-adventures-debug`) works for all
+languages built on `vm-core`.  It:
+
+1. Detects the language from the source file extension
+2. Launches the correct language's compiler to produce `IIRModule` + sidecar
+3. Launches `vm-core` with the debug adapter attached on port 4711
+4. Speaks DAP to VSCode
+
+The extension is configured via `.vscode/launch.json`:
+
+```json
+{
+  "type": "coding-adventures",
+  "request": "launch",
+  "name": "Debug BASIC program",
+  "program": "${file}",
+  "language": "basic"
+}
+```
+
+No language-specific extension needed.  A new language built on the LANG
+pipeline automatically works with this extension.
+
+---
+
+## Package additions
+
+The debug integration adds no new packages — it is a set of interfaces in
+existing packages:
+
+| Package | Addition |
+|---------|----------|
+| `vm-core` | `DebugHooks`, `pause/resume/step API`, `set_breakpoint`, `patch_function` |
+| `debug-sidecar` (05d) | unchanged — already language-agnostic |
+| `debug-adapter` (05e) | `GenericDebugAdapter` uses `IIRModule` + sidecar |
+
+The language bytecode compiler adds a `DebugSidecarWriter` call per emitted
+instruction — approximately 3 lines of code per compiler.

--- a/code/specs/LANG07-lsp-integration.md
+++ b/code/specs/LANG07-lsp-integration.md
@@ -1,0 +1,228 @@
+# LANG07 — LSP Integration: Editor Intelligence for Every Language
+
+## Overview
+
+Any language built on the LANG pipeline gets a high-performance Language Server
+Protocol (LSP) implementation with minimal effort.  The existing specs `LS00`
+(generic LSP server framework) and `LS01` (language bridge) define the
+infrastructure.  This spec defines the **integration points** that make a
+LANG-pipeline language plug into that infrastructure in under 50 lines.
+
+A fully featured LSP server provides:
+
+- **Diagnostics** — red/yellow squiggles as you type, reported from the parser
+- **Semantic tokens** — accurate syntax highlighting beyond regex patterns
+- **Hover** — type and documentation on cursor hover
+- **Go to Definition** — jump to where a function or variable is defined
+- **Find References** — find all uses of a symbol
+- **Rename** — rename across the whole file or project
+- **Auto-complete** — context-aware completions
+- **Code actions** — quick-fix suggestions for errors
+- **Inlay hints** — inline type annotations for dynamically typed languages
+- **Signature help** — function parameter hints as you type a call
+
+---
+
+## What the language must provide
+
+A language built on the LANG pipeline already has a lexer, parser, and
+(optionally) a type checker.  The LSP bridge (LS01) wraps these three
+components:
+
+```python
+from ls01 import LSLanguageBridge
+from my_lang_lexer import tokenise
+from my_lang_parser import parse
+from my_lang_type_checker import infer  # optional
+
+bridge = LSLanguageBridge(
+    tokenise=tokenise,               # str → list[Token]
+    parse=parse,                     # list[Token] → AST | ParseError
+    infer=infer,                     # AST → TypedAST (optional; None = untyped)
+    language_id="mylang",            # must match VS Code language ID
+    file_extensions=[".ml", ".my"],
+)
+```
+
+That is the entire language-specific contribution.  The LS00 framework handles
+all protocol boilerplate, incremental re-parsing, document state, and feature
+dispatch.
+
+---
+
+## Performance requirements
+
+An LSP server that is slow is worse than no LSP server — a 500ms hover delay
+destroys the editing experience.  The LANG LSP integration is designed for
+sub-100ms response times on files up to 10,000 lines.
+
+### Incremental parsing
+
+The LS00 framework maintains a **document cache** per open file:
+
+```
+Document cache entry:
+  source_text: str          (current document content)
+  tokens: list[Token]       (from last tokenise() call)
+  ast: AST                  (from last parse() call)
+  typed_ast: TypedAST       (from last infer() call, if available)
+  version: int              (LSP document version counter)
+```
+
+On each edit, the framework calls `tokenise` only over the changed region
+(using the `contentChanges` delta from the LSP `didChange` notification)
+and merges the new tokens into the cached token list.  A full re-parse runs
+only when the changed region crosses a statement boundary.
+
+This keeps re-parse cost proportional to the size of the edit, not the size
+of the file.
+
+### Type-checker latency budget
+
+Type checking is the most expensive phase.  The framework runs it on a
+**background thread** with a 200ms debounce:
+
+```
+User types a character
+  → tokenise (< 5ms for 1000 lines) — on keystroke thread
+  → parse    (< 20ms for 1000 lines) — on keystroke thread
+  → schedule type check in 200ms (debounced)
+  → ...user types more characters (debounce resets)...
+  → 200ms of silence → infer() runs on background thread
+  → diagnostics pushed to editor
+```
+
+This pattern ensures the editor never stalls waiting for type inference.
+Completions and hovers that need type information use the most recent typed
+AST, which may be slightly stale — a deliberate trade-off.
+
+---
+
+## Feature implementation map
+
+| LSP feature | Source in LANG pipeline |
+|-------------|------------------------|
+| Diagnostics | Parser error list + type checker error list |
+| Semantic tokens | Lexer `Token.type` mapped to LSP token types |
+| Hover | Type checker symbol table: symbol at cursor → type string |
+| Go to Definition | Type checker: name resolution → `IIRFunction.name` → source location |
+| Find References | Type checker symbol table: reverse lookup |
+| Rename | Find References + text edit on each location |
+| Auto-complete | Parser: list of names in scope at cursor position |
+| Signature help | Type checker: function type at call site → parameter names + types |
+| Inlay hints | Type checker: inferred type of each expression → annotation |
+
+Languages without a type checker get diagnostics, semantic tokens, and basic
+completion (names in scope).  Languages with a type checker get the full set.
+
+---
+
+## Semantic token mapping
+
+The lexer produces typed tokens (e.g., `Token(type="KEYWORD", value="fn")`).
+The LS01 bridge must declare a mapping from language token types to LSP semantic
+token types:
+
+```python
+bridge = LSLanguageBridge(
+    ...
+    semantic_token_map={
+        "KEYWORD":    "keyword",
+        "IDENT":      "variable",
+        "FN_NAME":    "function",
+        "NUMBER":     "number",
+        "STRING":     "string",
+        "COMMENT":    "comment",
+        "TYPE_NAME":  "type",
+        "PARAM_NAME": "parameter",
+    }
+)
+```
+
+This mapping is declared once per language; the framework handles the LSP
+`textDocument/semanticTokens/full` encoding automatically.
+
+---
+
+## Go to Definition via IIRModule
+
+When the language has a bytecode compiler, Definition lookup can also work
+through the compiled module:
+
+```
+User: Go to Definition of "add" at call site
+  → type checker looks up "add" in symbol table → not found (untyped language)
+  → fall back: IIRModule.functions → find IIRFunction(name="add")
+  → sidecar: IIRFunction "add" → compiled from source lines 1–5
+  → editor jumps to line 1
+```
+
+This fallback means even dynamically typed languages without full type checkers
+get Go to Definition — as long as they have a bytecode compiler that emits
+a named `IIRFunction`.
+
+---
+
+## Workspace-wide features
+
+Rename and Find References work across the entire project by running the
+bridge's `tokenise` + `parse` + `infer` pipeline on every file in the workspace
+in parallel.  The LS00 framework manages the workspace index and invalidates
+per-file on save.
+
+For large projects (>500 files), the workspace index is built lazily: only
+files that have been opened or that are transitively imported by an open file
+are indexed eagerly.
+
+---
+
+## VSCode extension
+
+The same generic `coding-adventures-lsp` extension serves all languages.  It
+launches the correct language server based on the file extension:
+
+```json
+// package.json contributes
+"languages": [
+  { "id": "tetrad", "extensions": [".tet"] },
+  { "id": "basic",  "extensions": [".bas", ".basic"] },
+  { "id": "mylang", "extensions": [".ml"] }
+],
+"languageServerCommand": "coding-adventures-lsp --language ${languageId}"
+```
+
+The server executable is a thin dispatcher that instantiates the correct
+`LSLanguageBridge` and hands it to the LS00 framework.
+
+---
+
+## Integration with vm-core (runtime diagnostics)
+
+When `vm-core` encounters a runtime error (division by zero, stack overflow,
+type mismatch), it can push a **runtime diagnostic** to the LSP client:
+
+```python
+vm.on_runtime_error(lambda err, frame:
+    lsp_server.push_diagnostic(
+        file=sidecar.offset_to_source(frame.ip).file,
+        line=sidecar.offset_to_source(frame.ip).line,
+        message=str(err),
+        severity="error",
+        source="runtime",
+    )
+)
+```
+
+This creates a live feedback loop: errors encountered during execution appear
+as editor squiggles in real time, even for dynamically typed languages that
+cannot catch them statically.
+
+---
+
+## Package additions
+
+| Package | Addition |
+|---------|----------|
+| `ls00` (LS00) | Incremental re-parse, background type check thread, document cache |
+| `ls01` (LS01) | `LSLanguageBridge` semantic token map; IIRModule fallback for Definition |
+| Language packages | 10–50 lines: instantiate `LSLanguageBridge` with lexer/parser/infer |

--- a/code/specs/LANG08-repl-integration.md
+++ b/code/specs/LANG08-repl-integration.md
@@ -1,0 +1,278 @@
+# LANG08 — REPL Integration: Interactive Sessions for Every Language
+
+## Overview
+
+Any language built on the LANG pipeline can be wired into the `PL00` generic
+REPL framework in under 30 lines.  The result is a fully featured interactive
+session with history, multi-line input, syntax error recovery, and (optionally)
+a rich async waiting experience.
+
+This spec defines the three integration points between the LANG pipeline and
+PL00:
+
+1. The **language plugin** — wraps the LANG compiler + vm-core into a single
+   `eval(input) → result` callable
+2. The **incremental state model** — how the REPL accumulates definitions across
+   successive inputs without restarting the VM
+3. The **multi-line input protocol** — how the parser signals that a statement
+   is incomplete so the REPL can read more lines before evaluating
+
+---
+
+## What the language must provide
+
+```python
+from pl00 import REPL, LanguagePlugin, PromptPlugin
+from my_lang_lexer import tokenise
+from my_lang_parser import parse, ParseIncomplete
+from my_lang_compiler import compile_module
+from interpreter_ir import IIRModule
+from vm_core import VMCore
+
+class MyLangREPLPlugin(LanguagePlugin):
+    def __init__(self):
+        self._vm = VMCore(register_count=8, max_frames=64,
+                          opcodes=MY_LANG_OPCODES, u8_wrap=False)
+        self._module = IIRModule(name="repl", functions=[], entry_point=None)
+
+    def eval(self, source: str) -> str:
+        try:
+            tokens = tokenise(source)
+            ast = parse(tokens)
+        except ParseIncomplete:
+            # Signal to the REPL to read another line before evaluating.
+            raise LanguagePlugin.NeedsMoreInput
+        except SyntaxError as e:
+            return f"SyntaxError: {e}"
+
+        new_fns, result_expr = compile_module(ast, existing=self._module)
+        self._module.functions.extend(new_fns)
+
+        if result_expr is not None:
+            result = self._vm.execute_expr(result_expr, self._module)
+            return repr(result)
+        return ""   # definition-only input (e.g. "fn add(a, b) = a + b")
+
+repl = REPL(
+    language=MyLangREPLPlugin(),
+    prompt=PromptPlugin(global_prompt=">>> ", continuation_prompt="... "),
+)
+repl.run()
+```
+
+That is the complete language-specific REPL implementation.
+
+---
+
+## The incremental state model
+
+A REPL session accumulates state: functions defined in earlier inputs must be
+available in later ones.  The LANG pipeline handles this naturally because
+`IIRModule` is a mutable container of `IIRFunction` objects.
+
+The pattern is:
+
+1. Start with an empty `IIRModule` (no functions)
+2. On each `eval` call, compile the new input into `new_fns` (new function
+   definitions) and `result_expr` (the expression to evaluate, if any)
+3. Append `new_fns` to the persistent `IIRModule`
+4. Evaluate `result_expr` in the context of the full accumulated `IIRModule`
+
+```
+Session:
+  Input 1: "fn double(x) = x + x"
+    → new_fns = [IIRFunction("double", ...)]
+    → module.functions = [double]
+    → result = ""   (no expression to print)
+
+  Input 2: "double(21)"
+    → new_fns = []
+    → result_expr = IIRInstr sequence for "call double [21]"
+    → vm evaluates in context of module (double is defined)
+    → result = "42"
+    → prints: 42
+```
+
+### Re-defining functions
+
+If the user re-defines a function that already exists, the new definition
+replaces the old one in `module.functions`:
+
+```python
+def _update_module(self, new_fns: list[IIRFunction]) -> None:
+    existing = {fn.name: i for i, fn in enumerate(self._module.functions)}
+    for fn in new_fns:
+        if fn.name in existing:
+            self._module.functions[existing[fn.name]] = fn  # replace
+        else:
+            self._module.functions.append(fn)
+```
+
+The vm-core JIT cache entry for the old version is invalidated automatically
+when `jit-core` is in use (via `jit.invalidate(fn.name)`).
+
+---
+
+## Multi-line input protocol
+
+Some language constructs span multiple lines:
+
+```
+>>> fn factorial(n) =
+...   if n == 0 then 1
+...   else n * factorial(n - 1)
+```
+
+The `PL00` framework handles multi-line input via the `NeedsMoreInput`
+exception.  When the parser encounters an incomplete token stream (e.g., an
+unclosed `if` or an unterminated function body), it raises `ParseIncomplete`.
+The REPL plugin converts this to `NeedsMoreInput`, and the framework reads
+another line, appends it, and retries `eval`.
+
+The framework switches from `global_prompt` (`>>>`) to `continuation_prompt`
+(`...`) automatically when `NeedsMoreInput` is raised.
+
+### Detecting incompleteness
+
+The parser must be able to distinguish:
+
+- **Complete but invalid** — `fn 123 = abc` → `SyntaxError` (do not request more lines)
+- **Incomplete** — `fn factorial(n) =` → `ParseIncomplete` (read more)
+
+Most LL/recursive-descent parsers can detect incompleteness naturally: if the
+parser is waiting for a token that would complete a production rule and reaches
+EOF, that is `ParseIncomplete`.
+
+```python
+class MyLangParser:
+    def parse(self, tokens: list[Token]) -> AST:
+        try:
+            return self._parse_program(tokens)
+        except UnexpectedEOF:
+            raise ParseIncomplete("unexpected end of input")
+        except SyntaxError:
+            raise   # real error, not incompleteness
+```
+
+---
+
+## JIT integration in REPL sessions
+
+When `jit-core` is used, the REPL benefits from JIT compilation across
+successive invocations of the same function:
+
+```
+>>> fn fib(n) = if n <= 1 then n else fib(n-1) + fib(n-2)
+>>> fib(10)    # interpreted; call count = 1
+55
+>>> fib(20)    # call count = 2
+6765
+...
+>>> fib(30)    # after 10 calls, jit-core compiles fib to native code
+832040         # subsequent calls run at native speed
+```
+
+No REPL-specific code is needed — `jit-core`'s tier promotion runs
+automatically because the `VMCore` instance persists across REPL inputs.
+
+---
+
+## Error recovery
+
+A good REPL does not crash on errors.  The LANG plugin catches all exceptions
+and formats them for display:
+
+```python
+def eval(self, source: str) -> str:
+    try:
+        ...
+        result = self._vm.execute_expr(result_expr, self._module)
+        return repr(result)
+    except ParseIncomplete:
+        raise LanguagePlugin.NeedsMoreInput
+    except SyntaxError as e:
+        return f"SyntaxError at line {e.lineno}: {e.msg}"
+    except VMError as e:
+        return f"RuntimeError: {e}"
+    except Exception as e:
+        return f"InternalError: {e}"
+```
+
+The VM's register state after an error is undefined.  To prevent stale state
+from corrupting subsequent inputs, vm-core's `execute_expr` runs in a
+**snapshot frame**: a shallow copy of the current register file is used for
+evaluation; on success it is committed back; on error it is discarded.
+
+```python
+with vm.snapshot():
+    result = vm.execute_expr(result_expr, module)
+# On exception: snapshot is rolled back automatically.
+# On success: snapshot is committed.
+```
+
+---
+
+## Rich REPL features via prompt plugin
+
+The `PL00` framework's `PromptPlugin` interface handles history and line
+editing.  The LANG REPL inherits:
+
+- **Command history** — up/down arrows navigate previous inputs
+- **Reverse search** — Ctrl-R searches history
+- **Line editing** — Ctrl-A (start of line), Ctrl-E (end), Ctrl-K (kill to end)
+- **Tab completion** — pluggable; can be wired to the LSP completion provider
+
+### Tab completion via LSP
+
+When `lsp-integration` (LANG07) is active, the REPL can route tab-completion
+requests to the LSP server:
+
+```python
+class MyLangREPLPlugin(LanguagePlugin):
+    def completions(self, partial_input: str, cursor: int) -> list[str]:
+        return self._lsp_client.complete(partial_input, cursor)
+```
+
+This gives the REPL the same completion intelligence as the editor — defined
+functions, in-scope variables, and language keywords — without duplicating
+the completion logic.
+
+---
+
+## Async waiting experience
+
+For long-running computations, the `PL00` async mode shows a waiting animation.
+The LANG plugin opts in by implementing `WaitingPlugin`:
+
+```python
+from pl00 import WaitingPlugin
+
+class MyLangWaiting(WaitingPlugin):
+    _frames = ["⠋", "⠙", "⠸", "⠴", "⠦", "⠇"]
+
+    def start(self) -> dict:
+        return {"frame": 0, "start_time": time.monotonic()}
+
+    def tick(self, state: dict) -> dict:
+        state["frame"] = (state["frame"] + 1) % len(self._frames)
+        sys.stdout.write(f"\r{self._frames[state['frame']]} thinking...")
+        sys.stdout.flush()
+        return state
+
+    def tick_ms(self) -> int:
+        return 80   # spinner speed
+
+    def stop(self, state: dict) -> None:
+        elapsed = time.monotonic() - state["start_time"]
+        sys.stdout.write(f"\r  ({elapsed:.2f}s)\n")
+```
+
+---
+
+## Package additions
+
+| Package | Addition |
+|---------|----------|
+| `pl00` (PL00) | No changes — interface is already language-agnostic |
+| `vm-core` | `execute_expr()` for single-expression evaluation; `snapshot()` context manager |
+| Language packages | 20–30 lines: `LanguagePlugin` subclass connecting lexer/parser/compiler/vm |

--- a/code/specs/LANG09-notebook-kernel.md
+++ b/code/specs/LANG09-notebook-kernel.md
@@ -1,0 +1,322 @@
+# LANG09 — Notebook Kernel: Jupyter-Compatible Kernels for Every Language
+
+## Overview
+
+A **notebook kernel** is a long-running process that executes code cells on
+behalf of a notebook frontend (Jupyter, JupyterLab, VS Code Notebooks, Marimo,
+Quarto, etc.).  Kernels speak the **Jupyter Messaging Protocol** (JMP) over
+ZeroMQ sockets.
+
+Any language built on the LANG pipeline can be exposed as a notebook kernel
+with minimal effort.  The kernel wraps the same `LanguagePlugin` used by the
+REPL (LANG08) and adds:
+
+1. **Cell execution** — run a code cell, return rich output (text, HTML, images)
+2. **Kernel info** — language name, version, file extension, MIME type
+3. **Interrupt handling** — cancel a running cell without killing the kernel
+4. **Inspection** — hover-equivalent for `?obj` syntax
+5. **Completions** — tab-completion inside a cell
+6. **State persistence** — variable state accumulates across cells (same as REPL)
+
+---
+
+## What the language must provide
+
+Exactly the same `LanguagePlugin` as LANG08.  The notebook kernel is a thin
+adapter over the REPL plugin:
+
+```python
+from lang09_kernel import NotebookKernel
+from my_lang_repl import MyLangREPLPlugin
+
+kernel = NotebookKernel(
+    language=MyLangREPLPlugin(),
+    kernel_name="mylang",
+    display_name="My Language",
+    language_version="1.0.0",
+    file_extension=".ml",
+    mimetype="text/x-mylang",
+    pygments_lexer="text",      # for syntax highlighting in output
+)
+kernel.start()    # blocks; listens on ZeroMQ sockets
+```
+
+That is the complete kernel implementation.  No Jupyter internals need to be
+understood by the language author.
+
+---
+
+## Architecture
+
+```
+Notebook frontend (Jupyter, VS Code, Marimo)
+    │
+    │  Jupyter Messaging Protocol (JMP)
+    │  ZeroMQ: shell socket, iopub socket, stdin socket, control socket
+    │
+    ▼
+NotebookKernel (LANG09)
+    │
+    ├── Shell handler: execute_request, inspect_request, complete_request
+    ├── Control handler: interrupt_request, shutdown_request
+    ├── IOPub publisher: stream, execute_result, display_data, error
+    │
+    ▼
+LanguagePlugin (LANG08)
+    │
+    ├── eval(source) → result
+    ├── completions(partial, cursor) → list[str]
+    └── inspect(source, cursor) → InspectResult
+    │
+    ▼
+vm-core + jit-core
+    (same runtime as REPL and debug sessions)
+```
+
+---
+
+## Jupyter Messaging Protocol integration
+
+JMP defines message types over four ZeroMQ sockets:
+
+| Socket | Direction | Purpose |
+|--------|-----------|---------|
+| `shell` | frontend → kernel | execute, complete, inspect requests |
+| `iopub` | kernel → all frontends | stream output, results, status |
+| `stdin` | kernel → frontend | input() requests |
+| `control` | frontend → kernel | interrupt, shutdown |
+
+The `NotebookKernel` class handles all four sockets.  Message routing:
+
+```
+execute_request → LanguagePlugin.eval() → execute_result or error on iopub
+complete_request → LanguagePlugin.completions() → complete_reply on shell
+inspect_request  → LanguagePlugin.inspect() → inspect_reply on shell
+interrupt_request → vm.interrupt() → kernel pauses current eval
+shutdown_request → kernel.stop() → clean shutdown
+```
+
+### execute_request
+
+```python
+def handle_execute_request(self, msg: dict) -> None:
+    source = msg["content"]["code"]
+    self._publish_status("busy")
+    try:
+        result = self._plugin.eval(source)
+        if result:
+            self._publish_execute_result(result, execution_count=self._count)
+    except LanguagePlugin.NeedsMoreInput:
+        self._publish_stream("stderr", "Incomplete input — submit complete statements.")
+    except Exception as e:
+        self._publish_error(ename=type(e).__name__, evalue=str(e), traceback=[])
+    finally:
+        self._count += 1
+        self._publish_status("idle")
+```
+
+### Rich output
+
+Results are not restricted to plain text.  The `LanguagePlugin` can return a
+`RichOutput` object with multiple MIME representations:
+
+```python
+@dataclass
+class RichOutput:
+    plain: str                          # text/plain — always required
+    html: str | None = None            # text/html — optional rich rendering
+    image_png: bytes | None = None     # image/png — for plot output
+    json: dict | None = None           # application/json — for structured data
+    latex: str | None = None           # text/latex — for math rendering
+```
+
+```python
+# Example: a language that can produce SVG plots
+def eval(self, source: str) -> str | RichOutput:
+    ...
+    if result_is_a_plot:
+        return RichOutput(
+            plain="<Plot: 320x240>",
+            image_png=render_png(plot),
+        )
+    return repr(result)
+```
+
+The notebook frontend displays the richest representation it supports.
+VS Code Notebooks renders `image_png`; classic Jupyter renders `text/html`.
+
+---
+
+## State persistence across cells
+
+The kernel uses the same incremental state model as the REPL (LANG08):
+
+- A single `VMCore` instance persists for the kernel's lifetime
+- A single `IIRModule` accumulates all function definitions
+- Cell `N+1` sees all definitions from cells `1` through `N`
+
+This is identical to how IPython/Jupyter kernels work: every cell shares the
+same Python namespace.
+
+### Kernel restart
+
+When the user restarts the kernel (Kernel → Restart), the `NotebookKernel`:
+
+1. Calls `vm.reset()` to clear register state
+2. Replaces `IIRModule` with a fresh empty module
+3. Clears the JIT cache
+4. Publishes a `kernel_info_reply` to confirm readiness
+
+---
+
+## Cell interrupt handling
+
+Long-running cells (e.g., a recursive Fibonacci call that takes 30 seconds)
+must be interruptible without killing the kernel process.
+
+```python
+def handle_interrupt_request(self) -> None:
+    self._vm.interrupt()   # new vm-core API
+```
+
+`vm.interrupt()` sets an `_interrupted` flag that the dispatch loop checks
+between instructions:
+
+```python
+# In dispatch_loop:
+if self._interrupted:
+    self._interrupted = False
+    raise VMInterrupt("execution interrupted by kernel")
+```
+
+`VMInterrupt` is caught by `handle_execute_request`, which publishes an
+`error` message with `ename="KeyboardInterrupt"` — the same presentation
+Jupyter uses for Python's `KeyboardInterrupt`.
+
+---
+
+## Inspection (`?`)
+
+Jupyter notebooks support `obj?` and `obj??` syntax for quick documentation.
+The `inspect_request` message is routed to `LanguagePlugin.inspect()`:
+
+```python
+class MyLangREPLPlugin(LanguagePlugin):
+    def inspect(self, source: str, cursor_pos: int) -> InspectResult:
+        word = extract_word_at(source, cursor_pos)
+        fn = self._module.get_function(word)
+        if fn is None:
+            return InspectResult(found=False)
+        return InspectResult(
+            found=True,
+            plain=f"{fn.name}({', '.join(p for p, _ in fn.params)}) -> {fn.return_type}",
+            html=f"<b>{fn.name}</b>({', '.join(f'<i>{p}</i>: {t}' for p, t in fn.params)}) → {fn.return_type}",
+        )
+```
+
+If the LSP server (LANG07) is running, `inspect()` can delegate to the LSP
+`textDocument/hover` handler, getting documentation from doc-comments.
+
+---
+
+## Kernel spec file
+
+Jupyter discovers kernels via a `kernel.json` file installed in a well-known
+directory.  The `NotebookKernel.install()` class method writes this file:
+
+```python
+NotebookKernel.install(
+    kernel_name="mylang",
+    display_name="My Language",
+    language="mylang",
+    argv=["python", "-m", "my_lang_kernel", "--connection-file", "{connection_file}"],
+)
+```
+
+This writes to `~/.local/share/jupyter/kernels/mylang/kernel.json`:
+
+```json
+{
+  "display_name": "My Language",
+  "language": "mylang",
+  "argv": ["python", "-m", "my_lang_kernel", "--connection-file", "{connection_file}"]
+}
+```
+
+After installation, the kernel appears in Jupyter's kernel selector.
+
+---
+
+## VS Code Notebook integration
+
+VS Code Notebooks speak JMP via the `jupyter` extension.  The generic kernel
+works out of the box — no VS Code extension needed beyond the standard
+Jupyter extension.
+
+For a richer experience (syntax highlighting, cell-level diagnostics from the
+LSP), the `coding-adventures-lsp` extension (LANG07) adds VS Code Notebook
+cell language support:
+
+```json
+// package.json contributes
+"notebookRenderer": [
+  { "id": "mylang", "displayName": "My Language", "mimeTypes": ["text/x-mylang"] }
+]
+```
+
+---
+
+## Pipeline hooks summary
+
+The notebook kernel uses every layer of the LANG pipeline:
+
+| Pipeline layer | Role in notebook |
+|----------------|-----------------|
+| Frontend (lexer + parser) | Parses each cell on submission |
+| Type checker | Provides hover info and completion |
+| Bytecode compiler | Compiles cell to `IIRModule` additions |
+| `vm-core` | Executes cells; persists state across cells |
+| `jit-core` | Automatically compiles hot functions after repeated cell execution |
+| `debug-integration` (LANG06) | Breakpoints inside cells via the VS Code DAP extension |
+| `lsp-integration` (LANG07) | Tab-completion and hover inside cells |
+| `repl-integration` (LANG08) | `LanguagePlugin` re-used directly; state model shared |
+
+---
+
+## Package structure
+
+```
+lang09-kernel/
+  pyproject.toml
+  BUILD
+  README.md
+  CHANGELOG.md
+  src/lang09_kernel/
+    __init__.py       # exports NotebookKernel, RichOutput, InspectResult
+    kernel.py         # NotebookKernel class — main entry point
+    messaging.py      # JMP message encoding / decoding
+    sockets.py        # ZeroMQ socket setup (shell, iopub, stdin, control)
+    handlers.py       # per-message-type handlers
+    install.py        # NotebookKernel.install() — kernel spec writer
+    rich_output.py    # RichOutput dataclass + MIME bundle encoding
+  tests/
+    test_execute.py       # cell execution round-trips (mocked sockets)
+    test_interrupt.py     # interrupt during long-running cell
+    test_completions.py
+    test_inspect.py
+    test_rich_output.py
+    test_install.py
+```
+
+---
+
+## Non-goals
+
+- **Distributed / multi-kernel execution** — out of scope; each kernel is
+  a single process
+- **Kernel gateway** — routing multiple clients to the same kernel is handled
+  by Jupyter Server, not by this package
+- **Custom frontend** — this spec targets standard Jupyter/VS Code frontends;
+  a custom notebook UI is a future concern
+- **Persistent kernel state across Python process restarts** — restoring state
+  from a saved `.ipynb` file is the notebook frontend's responsibility


### PR DESCRIPTION
## Summary

- **LANG00** — Architecture overview: two-IR model (InterpreterIR → JIT → CompilerIR → backend), positions Tetrad as reference, explains why Intel 4004 is the *target* not the *host*, historical context on why interpreters couldn't run until the 8080 era
- **LANG01** — `interpreter-ir` spec: `IIRInstr` dataclass with observation slots and deopt anchors, full instruction set, `IIRFunction`/`IIRModule` containers, binary serialisation
- **LANG02** — `vm-core` spec: generic register VM (dispatch loop, profiler, shadow frames, builtins registry); generalises `TetradVM` to all languages via an opcode-table plug-in
- **LANG03** — `jit-core` spec: specialization pass (InterpreterIR → CompilerIR subset), three-tier promotion (0/10/100 calls), type guards + deopt stubs, deopt-rate tracking, maps every `tetrad-jit` module to its generic equivalent
- **LANG04** — `aot-core` spec: ahead-of-time path with static type inference, same specialization pass, `vm-runtime` linkable library for dynamic features, `.aot` snapshot format, cross-compilation
- **LANG05** — `backend-protocol` spec: `BackendProtocol` (structural subtyping), `BackendCapabilities` (capability-driven deopt), `BackendRegistry`, standard compliance test suite, Intel 4004 worked example, migration table for existing backends

## Test plan

- [ ] Specs are markdown-only — no code changes, no BUILD, no tests needed this PR
- [ ] Verify all 6 LANG files present: `LANG00` through `LANG05`
- [ ] Read LANG00 architecture diagram to confirm two-IR model is clear
- [ ] Read LANG03 jit-core and verify it maps to existing `tetrad-jit` correctly
- [ ] CI should pass (no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)