### PR TITLE
Add generic job runtime process pool

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -343,4 +343,5 @@ members = [
     "state-machine-markup-json-serializer",
     "embeddable-tcp-server",
     "generic-job-protocol",
+    "generic-job-runtime",
 ]

--- a/code/packages/rust/embeddable-tcp-server/CHANGELOG.md
+++ b/code/packages/rust/embeddable-tcp-server/CHANGELOG.md
@@ -20,3 +20,6 @@ All notable changes to this package will be documented in this file.
 - Added a mailbox-style asynchronous worker path where TCP callbacks send
   request jobs and return immediately while a response task posts worker output
   back to the TCP runtime.
+- Routed mailbox-mode worker execution through `generic-job-runtime` so the
+  embeddable TCP server can use a configurable stdio process pool instead of
+  owning one ad hoc child process.

--- a/code/packages/rust/embeddable-tcp-server/Cargo.toml
+++ b/code/packages/rust/embeddable-tcp-server/Cargo.toml
@@ -6,6 +6,7 @@ description = "Language-neutral embeddable TCP server for generic job-protocol w
 
 [dependencies]
 generic-job-protocol = { path = "../generic-job-protocol" }
+generic-job-runtime = { path = "../generic-job-runtime" }
 serde = { version = "1", features = ["derive"] }
 tcp-runtime = { path = "../tcp-runtime" }
 transport-platform = { path = "../transport-platform" }

--- a/code/packages/rust/embeddable-tcp-server/README.md
+++ b/code/packages/rust/embeddable-tcp-server/README.md
@@ -42,23 +42,26 @@ or RESP part of the crate's public identity.
 
 ## Current Limitations
 
-- One worker process handles all delegated jobs.
+- Mailbox mode can use a configurable stdio worker process pool through
+  `generic-job-runtime`; the default remains one worker for deterministic local
+  behavior.
 - The worker protocol uses the JSON-line `generic-job-protocol` codec over
   stdio for debuggability, not throughput.
 - Worker responses are asynchronous with respect to TCP reads, but still flow
-  through one stdio response reader.
+  through one response reader per worker process.
 - The current payload structs are the first raw-byte transport shape; a later
   crate should make those stable for all language bridges.
-- This validates the runtime seam; it is not the final high-performance
-  process-pool architecture.
+- This validates the runtime seam; it still needs production timeout,
+  cancellation, worker restart, and backpressure-to-read-pausing policies.
 
-The next production step is to route these protocol frames through a real job
-runtime so worker completion can happen asynchronously and language workers can
-be backed by threads, processes, or another host-specific scheduler.
+The next production step is to harden the process-pool path with timeouts,
+worker restart policy, response size enforcement, and TCP read pausing when the
+worker queue is saturated.
 
 ## Dependencies
 
 - generic-job-protocol
+- generic-job-runtime
 - tcp-runtime
 - transport-platform
 

--- a/code/packages/rust/embeddable-tcp-server/src/lib.rs
+++ b/code/packages/rust/embeddable-tcp-server/src/lib.rs
@@ -11,11 +11,9 @@
 //! is used only in tests as one concrete consumer of the same raw-byte seam
 //! other language bridges can implement.
 //!
-//! The current implementation is still synchronous: the TCP read callback waits
-//! for a worker response before returning bytes to write. That is enough to
-//! prove the portable embedding boundary. The next layer should route requests
-//! through the generic job runtime so worker completion can happen
-//! asynchronously without blocking the reactor.
+//! Mailbox mode routes requests through `generic-job-runtime` so TCP callbacks
+//! can submit jobs and return immediately. Worker responses are delivered later
+//! through the TCP mailbox owned by the Rust runtime.
 
 use std::collections::BTreeMap;
 use std::fmt;
@@ -26,10 +24,14 @@ use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
+use std::time::Duration;
 
 use generic_job_protocol::{
     decode_response_json_line, encode_request_json_line, JobCodecError, JobMetadata, JobRequest,
     JobResponse, JobResult,
+};
+use generic_job_runtime::{
+    ExecutorLimits, StdioProcessPool, StdioProcessPoolOptions, StdioWorkerCommand, SubmitError,
 };
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -73,6 +75,7 @@ pub struct EmbeddableTcpServerOptions {
     pub host: String,
     pub port: u16,
     pub max_connections: usize,
+    pub worker_processes: usize,
     pub worker: WorkerCommand,
 }
 
@@ -91,6 +94,7 @@ impl Default for EmbeddableTcpServerOptions {
             host: "127.0.0.1".to_string(),
             port: 0,
             max_connections: TcpRuntimeOptions::default().max_connections,
+            worker_processes: 1,
             worker: WorkerCommand::new("worker", Vec::<String>::new()),
         }
     }
@@ -107,27 +111,28 @@ pub struct StdioJobWorker<Request, Response> {
     _response: PhantomData<Response>,
 }
 
-pub struct StdioJobSubmitter<Request> {
-    stdin: Arc<Mutex<ChildStdin>>,
+pub struct StdioJobSubmitter<Request, Response> {
+    pool: StdioProcessPool<Request, Response>,
     routes: Arc<Mutex<BTreeMap<String, ConnectionId>>>,
     next_job_id: Arc<AtomicU64>,
-    _request: PhantomData<Request>,
+    _types: PhantomData<fn() -> (Request, Response)>,
 }
 
-impl<Request> Clone for StdioJobSubmitter<Request> {
+impl<Request, Response> Clone for StdioJobSubmitter<Request, Response> {
     fn clone(&self) -> Self {
         Self {
-            stdin: Arc::clone(&self.stdin),
+            pool: self.pool.clone(),
             routes: Arc::clone(&self.routes),
             next_job_id: Arc::clone(&self.next_job_id),
-            _request: PhantomData,
+            _types: PhantomData,
         }
     }
 }
 
-impl<Request> StdioJobSubmitter<Request>
+impl<Request, Response> StdioJobSubmitter<Request, Response>
 where
-    Request: Serialize,
+    Request: Serialize + Send + 'static,
+    Response: DeserializeOwned + Send + 'static,
 {
     pub fn submit(
         &self,
@@ -144,25 +149,15 @@ where
         payload: Request,
     ) -> Result<String, WorkerError> {
         let id = format!("job-{}", self.next_job_id.fetch_add(1, Ordering::SeqCst));
-        let request = JobRequest::new(id.clone(), payload).with_metadata(metadata);
-        let encoded = encode_request_json_line(&request)?;
+        let request = JobRequest::new(id.clone(), payload)
+            .with_metadata(metadata.with_affinity_key(connection_id.0.to_string()));
 
         self.routes
             .lock()
             .expect("stdio worker route table mutex poisoned")
             .insert(id.clone(), connection_id);
 
-        let write_result = {
-            let mut stdin = self
-                .stdin
-                .lock()
-                .expect("stdio worker stdin mutex poisoned");
-            stdin
-                .write_all(encoded.as_bytes())
-                .and_then(|_| stdin.flush())
-        };
-
-        if let Err(error) = write_result {
+        if let Err(error) = self.pool.submit(request) {
             self.routes
                 .lock()
                 .expect("stdio worker route table mutex poisoned")
@@ -218,17 +213,14 @@ impl TcpMailboxFrame {
     }
 }
 
-struct WorkerProcessGuard {
-    child: Arc<Mutex<Child>>,
+struct WorkerPoolGuard {
+    stop: Arc<AtomicBool>,
     response_thread: Option<thread::JoinHandle<()>>,
 }
 
-impl Drop for WorkerProcessGuard {
+impl Drop for WorkerPoolGuard {
     fn drop(&mut self) {
-        if let Ok(mut child) = self.child.lock() {
-            let _ = child.kill();
-            let _ = child.wait();
-        }
+        self.stop.store(true, Ordering::SeqCst);
         if let Some(thread) = self.response_thread.take() {
             let _ = thread.join();
         }
@@ -363,11 +355,17 @@ impl From<JobCodecError> for WorkerError {
     }
 }
 
+impl From<SubmitError> for WorkerError {
+    fn from(value: SubmitError) -> Self {
+        Self::Protocol(value.to_string())
+    }
+}
+
 /// TCP server that embeds a generic job worker behind the Rust TCP runtime.
 #[derive(Clone)]
 pub struct EmbeddableTcpServer<State> {
     runtime: Arc<Mutex<Option<PlatformTcpRuntime<State>>>>,
-    _worker_process: Arc<Mutex<Option<WorkerProcessGuard>>>,
+    _worker_pool: Arc<Mutex<Option<WorkerPoolGuard>>>,
     local_addr: SocketAddr,
     stop_handle: StopHandle,
     serving: Arc<AtomicBool>,
@@ -408,7 +406,7 @@ where
 
         Ok(Self {
             runtime: Arc::new(Mutex::new(Some(runtime))),
-            _worker_process: Arc::new(Mutex::new(None)),
+            _worker_pool: Arc::new(Mutex::new(None)),
             local_addr,
             stop_handle,
             serving: Arc::new(AtomicBool::new(false)),
@@ -423,14 +421,14 @@ where
         map_response: MapResponse,
     ) -> io::Result<Self>
     where
-        Request: Serialize + Send + Sync + 'static,
+        Request: Serialize + Send + 'static,
         Response: DeserializeOwned + Send + 'static,
         Init: Fn(TcpConnectionInfo) -> State + Send + Sync + 'static,
         Handler: Fn(
                 TcpConnectionInfo,
                 &mut State,
                 &[u8],
-                &StdioJobSubmitter<Request>,
+                &StdioJobSubmitter<Request, Response>,
             ) -> TcpHandlerResult
             + Send
             + Sync
@@ -438,26 +436,38 @@ where
         Close: Fn(TcpConnectionInfo, State) + Send + Sync + 'static,
         MapResponse: Fn(Response) -> Result<TcpMailboxFrame, WorkerError> + Send + Sync + 'static,
     {
-        let (child, stdin, stdout) = spawn_worker_process(&options.worker)?;
+        let pool = StdioProcessPool::<Request, Response>::spawn(
+            StdioWorkerCommand::new(options.worker.program.clone(), options.worker.args.clone()),
+            StdioProcessPoolOptions {
+                worker_count: options.worker_processes.max(1),
+                limits: ExecutorLimits::default(),
+            },
+        )?;
         let routes = Arc::new(Mutex::new(BTreeMap::new()));
         let submitter = StdioJobSubmitter {
-            stdin,
+            pool: pool.clone(),
             routes: Arc::clone(&routes),
             next_job_id: Arc::new(AtomicU64::new(1)),
-            _request: PhantomData,
+            _types: PhantomData,
         };
         let runtime = build_runtime_mailbox(&options, submitter, init, handler, on_close)
             .map_err(into_io_error)?;
         let local_addr = runtime.local_addr();
         let stop_handle = runtime.stop_handle();
         let mailbox = runtime.mailbox();
-        let response_thread =
-            spawn_response_router(stdout, routes, mailbox, Arc::new(map_response));
+        let response_stop = Arc::new(AtomicBool::new(false));
+        let response_thread = spawn_response_router(
+            pool.clone(),
+            routes,
+            mailbox,
+            Arc::new(map_response),
+            Arc::clone(&response_stop),
+        );
 
         Ok(Self {
             runtime: Arc::new(Mutex::new(Some(runtime))),
-            _worker_process: Arc::new(Mutex::new(Some(WorkerProcessGuard {
-                child,
+            _worker_pool: Arc::new(Mutex::new(Some(WorkerPoolGuard {
+                stop: response_stop,
                 response_thread: Some(response_thread),
             }))),
             local_addr,
@@ -498,57 +508,27 @@ where
     }
 }
 
-fn spawn_worker_process(
-    command: &WorkerCommand,
-) -> io::Result<(
-    Arc<Mutex<Child>>,
-    Arc<Mutex<ChildStdin>>,
-    BufReader<ChildStdout>,
-)> {
-    let mut child = Command::new(&command.program)
-        .args(&command.args)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
-        .spawn()?;
-
-    let stdin = child
-        .stdin
-        .take()
-        .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "worker did not expose stdin"))?;
-    let stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "worker did not expose stdout"))?;
-
-    Ok((
-        Arc::new(Mutex::new(child)),
-        Arc::new(Mutex::new(stdin)),
-        BufReader::new(stdout),
-    ))
-}
-
-fn spawn_response_router<Response, MapResponse>(
-    mut stdout: BufReader<ChildStdout>,
+fn spawn_response_router<Request, Response, MapResponse>(
+    pool: StdioProcessPool<Request, Response>,
     routes: Arc<Mutex<BTreeMap<String, ConnectionId>>>,
     mailbox: TcpMailbox,
     map_response: Arc<MapResponse>,
+    stop: Arc<AtomicBool>,
 ) -> thread::JoinHandle<()>
 where
+    Request: Serialize + Send + 'static,
     Response: DeserializeOwned + Send + 'static,
     MapResponse: Fn(Response) -> Result<TcpMailboxFrame, WorkerError> + Send + Sync + 'static,
 {
     thread::spawn(move || loop {
-        let mut line = String::new();
-        match stdout.read_line(&mut line) {
-            Ok(0) => break,
-            Ok(_) => {}
-            Err(_) => break,
+        if stop.load(Ordering::SeqCst) {
+            break;
         }
-
-        let response: JobResponse<Response> = match decode_response_json_line(line.trim_end()) {
-            Ok(response) => response,
-            Err(_) => continue,
+        let Some(response) = pool
+            .recv_response_timeout(Duration::from_millis(10))
+            .unwrap_or(None)
+        else {
+            continue;
         };
         let Some(connection_id) = routes
             .lock()
@@ -647,18 +627,24 @@ where
     target_os = "netbsd",
     target_os = "dragonfly"
 ))]
-fn build_runtime_mailbox<State, Request, Init, Handler, Close>(
+fn build_runtime_mailbox<State, Request, Response, Init, Handler, Close>(
     options: &EmbeddableTcpServerOptions,
-    submitter: StdioJobSubmitter<Request>,
+    submitter: StdioJobSubmitter<Request, Response>,
     init: Init,
     handler: Handler,
     on_close: Close,
 ) -> Result<PlatformTcpRuntime<State>, PlatformError>
 where
     State: Send + 'static,
-    Request: Serialize + Send + Sync + 'static,
+    Request: Serialize + Send + 'static,
+    Response: DeserializeOwned + Send + 'static,
     Init: Fn(TcpConnectionInfo) -> State + Send + Sync + 'static,
-    Handler: Fn(TcpConnectionInfo, &mut State, &[u8], &StdioJobSubmitter<Request>) -> TcpHandlerResult
+    Handler: Fn(
+            TcpConnectionInfo,
+            &mut State,
+            &[u8],
+            &StdioJobSubmitter<Request, Response>,
+        ) -> TcpHandlerResult
         + Send
         + Sync
         + 'static,
@@ -712,18 +698,24 @@ where
 }
 
 #[cfg(target_os = "linux")]
-fn build_runtime_mailbox<State, Request, Init, Handler, Close>(
+fn build_runtime_mailbox<State, Request, Response, Init, Handler, Close>(
     options: &EmbeddableTcpServerOptions,
-    submitter: StdioJobSubmitter<Request>,
+    submitter: StdioJobSubmitter<Request, Response>,
     init: Init,
     handler: Handler,
     on_close: Close,
 ) -> Result<PlatformTcpRuntime<State>, PlatformError>
 where
     State: Send + 'static,
-    Request: Serialize + Send + Sync + 'static,
+    Request: Serialize + Send + 'static,
+    Response: DeserializeOwned + Send + 'static,
     Init: Fn(TcpConnectionInfo) -> State + Send + Sync + 'static,
-    Handler: Fn(TcpConnectionInfo, &mut State, &[u8], &StdioJobSubmitter<Request>) -> TcpHandlerResult
+    Handler: Fn(
+            TcpConnectionInfo,
+            &mut State,
+            &[u8],
+            &StdioJobSubmitter<Request, Response>,
+        ) -> TcpHandlerResult
         + Send
         + Sync
         + 'static,
@@ -777,18 +769,24 @@ where
 }
 
 #[cfg(target_os = "windows")]
-fn build_runtime_mailbox<State, Request, Init, Handler, Close>(
+fn build_runtime_mailbox<State, Request, Response, Init, Handler, Close>(
     options: &EmbeddableTcpServerOptions,
-    submitter: StdioJobSubmitter<Request>,
+    submitter: StdioJobSubmitter<Request, Response>,
     init: Init,
     handler: Handler,
     on_close: Close,
 ) -> Result<PlatformTcpRuntime<State>, PlatformError>
 where
     State: Send + 'static,
-    Request: Serialize + Send + Sync + 'static,
+    Request: Serialize + Send + 'static,
+    Response: DeserializeOwned + Send + 'static,
     Init: Fn(TcpConnectionInfo) -> State + Send + Sync + 'static,
-    Handler: Fn(TcpConnectionInfo, &mut State, &[u8], &StdioJobSubmitter<Request>) -> TcpHandlerResult
+    Handler: Fn(
+            TcpConnectionInfo,
+            &mut State,
+            &[u8],
+            &StdioJobSubmitter<Request, Response>,
+        ) -> TcpHandlerResult
         + Send
         + Sync
         + 'static,
@@ -976,7 +974,7 @@ mod tests {
         info: TcpConnectionInfo,
         _state: &mut (),
         data: &[u8],
-        submitter: &StdioJobSubmitter<TcpInputJob>,
+        submitter: &StdioJobSubmitter<TcpInputJob, TcpOutputFrame>,
     ) -> TcpHandlerResult {
         if data.len() > MAX_TCP_CHUNK_BYTES {
             return TcpHandlerResult::close();
@@ -1105,6 +1103,7 @@ print(json.dumps({"version":1,"kind":"response","body":{"id":body["id"],"result"
                 host: "127.0.0.1".to_string(),
                 port: 0,
                 max_connections: 64,
+                worker_processes: 1,
                 worker,
             },
             |_| (),
@@ -1353,6 +1352,7 @@ print(json.dumps({"version":1,"kind":"response","body":{"id":body["id"],"result"
                 host: "127.0.0.1".to_string(),
                 port: 0,
                 max_connections: 64,
+                worker_processes: 1,
                 worker,
             },
             |_| (),
@@ -1450,6 +1450,7 @@ print(json.dumps({"version":1,"kind":"response","body":{"id":body["id"],"result"
         assert_eq!(options.host, "127.0.0.1");
         assert_eq!(options.port, 0);
         assert_eq!(options.worker, worker);
+        assert_eq!(options.worker_processes, 1);
 
         let mut zero_connections = options.clone();
         zero_connections.max_connections = 0;

--- a/code/packages/rust/generic-job-runtime/BUILD
+++ b/code/packages/rust/generic-job-runtime/BUILD
@@ -1,0 +1,1 @@
+cargo test -p generic-job-runtime -- --nocapture

--- a/code/packages/rust/generic-job-runtime/CHANGELOG.md
+++ b/code/packages/rust/generic-job-runtime/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-04-21
+
+### Added
+
+- Added executor capability and limit types for generic job adapters.
+- Added a bounded stdio process-pool executor for JSON-line
+  `generic-job-protocol` workers.
+- Added affinity-based worker routing so related jobs stay on the same process.
+- Added tests for affinity routing and queue-full backpressure.

--- a/code/packages/rust/generic-job-runtime/Cargo.toml
+++ b/code/packages/rust/generic-job-runtime/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "generic-job-runtime"
+version = "0.1.0"
+edition = "2021"
+description = "Generic bounded job executors for language-neutral job protocol workers"
+
+[dependencies]
+generic-job-protocol = { path = "../generic-job-protocol" }
+serde = { version = "1", features = ["derive"] }

--- a/code/packages/rust/generic-job-runtime/README.md
+++ b/code/packages/rust/generic-job-runtime/README.md
@@ -1,0 +1,24 @@
+# generic-job-runtime
+
+Bounded job executors for `generic-job-protocol`.
+
+This crate is the runtime layer above the portable `JobRequest<T>` /
+`JobResponse<U>` envelope. The first executor is a stdio process pool for
+language workers such as Python, Ruby, Perl, Lua, or other bridge targets.
+
+## Current Scope
+
+- Bounded in-flight job submission with `queue_full` backpressure.
+- Stable affinity routing so related jobs, such as one TCP connection's bytes,
+  stay on the same worker process.
+- Async response collection from worker stdout.
+- Capability and limit metadata that adapters can inspect.
+
+The crate does not know about TCP, RESP, Redis, IRC, or sockets. Those adapters
+submit typed job payloads and decide how to apply responses.
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/rust/generic-job-runtime/required_capabilities.json
+++ b/code/packages/rust/generic-job-runtime/required_capabilities.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/generic-job-runtime",
+  "capabilities": [
+    {
+      "category": "proc",
+      "action": "exec",
+      "target": "*",
+      "justification": "The stdio process-pool executor launches configured language worker commands."
+    }
+  ],
+  "justification": "This crate owns generic child process worker-pool execution for language-neutral job runtime prototypes."
+}

--- a/code/packages/rust/generic-job-runtime/src/lib.rs
+++ b/code/packages/rust/generic-job-runtime/src/lib.rs
@@ -1,0 +1,585 @@
+//! # generic-job-runtime
+//!
+//! Bounded executors for `generic-job-protocol` jobs.
+//!
+//! The runtime is deliberately transport-neutral. TCP, UI event handling,
+//! parsing, image work, and future FFI bridges can all submit typed
+//! `JobRequest<T>` values and drain typed `JobResponse<U>` values without the
+//! executor knowing what the payload means.
+
+use std::collections::hash_map::DefaultHasher;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::io::{self, BufRead, BufReader, Write};
+use std::marker::PhantomData;
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use generic_job_protocol::{
+    decode_response_json_line_with_limit, encode_request_json_line, JobCodecError, JobRequest,
+    JobResponse,
+};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutorCapabilities {
+    pub supports_parallel_execution: bool,
+    pub supports_parallel_callbacks: bool,
+    pub requires_vm_lock: bool,
+    pub supports_process_isolation: bool,
+    pub supports_cancellation: bool,
+    pub supports_timeouts: bool,
+    pub supports_affinity: bool,
+    pub supports_ordered_responses: bool,
+    pub requires_serializable_payloads: bool,
+    pub max_workers: usize,
+    pub max_queue_depth: usize,
+    pub max_payload_bytes: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutorLimits {
+    pub max_queue_depth: usize,
+    pub max_payload_bytes: usize,
+    pub max_response_bytes: usize,
+}
+
+impl Default for ExecutorLimits {
+    fn default() -> Self {
+        Self {
+            max_queue_depth: 1024,
+            max_payload_bytes: 1024 * 1024,
+            max_response_bytes: 1024 * 1024,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StdioWorkerCommand {
+    pub program: String,
+    pub args: Vec<String>,
+}
+
+impl StdioWorkerCommand {
+    pub fn new(program: impl Into<String>, args: impl Into<Vec<String>>) -> Self {
+        Self {
+            program: program.into(),
+            args: args.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StdioProcessPoolOptions {
+    pub worker_count: usize,
+    pub limits: ExecutorLimits,
+}
+
+impl Default for StdioProcessPoolOptions {
+    fn default() -> Self {
+        Self {
+            worker_count: 1,
+            limits: ExecutorLimits::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SubmitError {
+    QueueFull,
+    ShuttingDown,
+    WorkerUnavailable,
+    PayloadTooLarge { actual: usize, max: usize },
+    Codec(String),
+    Io(String),
+}
+
+impl fmt::Display for SubmitError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::QueueFull => f.write_str("job queue is full"),
+            Self::ShuttingDown => f.write_str("job executor is shutting down"),
+            Self::WorkerUnavailable => f.write_str("no worker process is available"),
+            Self::PayloadTooLarge { actual, max } => {
+                write!(f, "job payload frame has {actual} bytes, exceeding {max}")
+            }
+            Self::Codec(message) => write!(f, "job codec error: {message}"),
+            Self::Io(message) => write!(f, "job I/O error: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for SubmitError {}
+
+impl From<JobCodecError> for SubmitError {
+    fn from(value: JobCodecError) -> Self {
+        Self::Codec(value.to_string())
+    }
+}
+
+impl From<io::Error> for SubmitError {
+    fn from(value: io::Error) -> Self {
+        Self::Io(value.to_string())
+    }
+}
+
+#[derive(Debug)]
+pub enum RuntimeError {
+    Io(io::Error),
+}
+
+impl fmt::Display for RuntimeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(error) => write!(f, "job runtime I/O error: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for RuntimeError {}
+
+pub trait JobExecutor<Request, Response> {
+    fn capabilities(&self) -> ExecutorCapabilities;
+    fn try_submit(&self, request: JobRequest<Request>) -> Result<(), SubmitError>;
+    fn drain_responses(&self, max: usize) -> Vec<JobResponse<Response>>;
+    fn shutdown(&self);
+}
+
+pub struct StdioProcessPool<Request, Response> {
+    inner: Arc<PoolInner<Response>>,
+    _request: PhantomData<fn() -> Request>,
+}
+
+impl<Request, Response> Clone for StdioProcessPool<Request, Response> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+            _request: PhantomData,
+        }
+    }
+}
+
+struct PoolInner<Response> {
+    workers: Vec<WorkerProcess>,
+    responses: Mutex<mpsc::Receiver<JobResponse<Response>>>,
+    next_worker: AtomicUsize,
+    in_flight: Arc<AtomicUsize>,
+    shutting_down: AtomicBool,
+    limits: ExecutorLimits,
+}
+
+struct WorkerProcess {
+    stdin: Arc<Mutex<ChildStdin>>,
+    child: Arc<Mutex<Child>>,
+    reader: Option<thread::JoinHandle<()>>,
+}
+
+impl Drop for WorkerProcess {
+    fn drop(&mut self) {
+        if let Ok(mut child) = self.child.lock() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        if let Some(reader) = self.reader.take() {
+            let _ = reader.join();
+        }
+    }
+}
+
+impl<Response> Drop for PoolInner<Response> {
+    fn drop(&mut self) {
+        self.shutting_down.store(true, Ordering::SeqCst);
+    }
+}
+
+impl<Request, Response> StdioProcessPool<Request, Response>
+where
+    Request: Serialize + Send + 'static,
+    Response: DeserializeOwned + Send + 'static,
+{
+    pub fn spawn(
+        command: StdioWorkerCommand,
+        options: StdioProcessPoolOptions,
+    ) -> io::Result<Self> {
+        let worker_count = options.worker_count.max(1);
+        let (sender, receiver) = mpsc::channel();
+        let mut workers = Vec::with_capacity(worker_count);
+        let in_flight = Arc::new(AtomicUsize::new(0));
+
+        for _ in 0..worker_count {
+            workers.push(spawn_worker::<Response>(
+                &command,
+                sender.clone(),
+                Arc::clone(&in_flight),
+                options.limits.max_response_bytes,
+            )?);
+        }
+
+        Ok(Self {
+            inner: Arc::new(PoolInner {
+                workers,
+                responses: Mutex::new(receiver),
+                next_worker: AtomicUsize::new(0),
+                in_flight,
+                shutting_down: AtomicBool::new(false),
+                limits: options.limits,
+            }),
+            _request: PhantomData,
+        })
+    }
+
+    pub fn submit(&self, request: JobRequest<Request>) -> Result<(), SubmitError> {
+        self.try_submit(request)
+    }
+
+    pub fn recv_response_timeout(
+        &self,
+        timeout: Duration,
+    ) -> Result<Option<JobResponse<Response>>, RuntimeError> {
+        let receiver = self
+            .inner
+            .responses
+            .lock()
+            .expect("job response receiver mutex poisoned");
+        match receiver.recv_timeout(timeout) {
+            Ok(response) => Ok(Some(response)),
+            Err(mpsc::RecvTimeoutError::Timeout) => Ok(None),
+            Err(mpsc::RecvTimeoutError::Disconnected) => Ok(None),
+        }
+    }
+
+    fn worker_index_for(&self, request: &JobRequest<Request>) -> Result<usize, SubmitError> {
+        let worker_len = self.inner.workers.len();
+        if worker_len == 0 {
+            return Err(SubmitError::WorkerUnavailable);
+        }
+        if let Some(affinity_key) = request.metadata.affinity_key.as_deref() {
+            let mut hasher = DefaultHasher::new();
+            affinity_key.hash(&mut hasher);
+            return Ok((hasher.finish() as usize) % worker_len);
+        }
+        Ok(self.inner.next_worker.fetch_add(1, Ordering::SeqCst) % worker_len)
+    }
+
+    fn reserve_slot(&self) -> Result<(), SubmitError> {
+        loop {
+            let current = self.inner.in_flight.load(Ordering::SeqCst);
+            if current >= self.inner.limits.max_queue_depth {
+                return Err(SubmitError::QueueFull);
+            }
+            if self
+                .inner
+                .in_flight
+                .compare_exchange(current, current + 1, Ordering::SeqCst, Ordering::SeqCst)
+                .is_ok()
+            {
+                return Ok(());
+            }
+        }
+    }
+}
+
+impl<Request, Response> JobExecutor<Request, Response> for StdioProcessPool<Request, Response>
+where
+    Request: Serialize + Send + 'static,
+    Response: DeserializeOwned + Send + 'static,
+{
+    fn capabilities(&self) -> ExecutorCapabilities {
+        ExecutorCapabilities {
+            supports_parallel_execution: self.inner.workers.len() > 1,
+            supports_parallel_callbacks: true,
+            requires_vm_lock: false,
+            supports_process_isolation: true,
+            supports_cancellation: false,
+            supports_timeouts: false,
+            supports_affinity: true,
+            supports_ordered_responses: false,
+            requires_serializable_payloads: true,
+            max_workers: self.inner.workers.len(),
+            max_queue_depth: self.inner.limits.max_queue_depth,
+            max_payload_bytes: self.inner.limits.max_payload_bytes,
+        }
+    }
+
+    fn try_submit(&self, request: JobRequest<Request>) -> Result<(), SubmitError> {
+        if self.inner.shutting_down.load(Ordering::SeqCst) {
+            return Err(SubmitError::ShuttingDown);
+        }
+
+        let encoded = encode_request_json_line(&request)?;
+        if encoded.len() > self.inner.limits.max_payload_bytes {
+            return Err(SubmitError::PayloadTooLarge {
+                actual: encoded.len(),
+                max: self.inner.limits.max_payload_bytes,
+            });
+        }
+
+        self.reserve_slot()?;
+        let worker_index = self.worker_index_for(&request)?;
+        let write_result = {
+            let mut stdin = self.inner.workers[worker_index]
+                .stdin
+                .lock()
+                .expect("stdio worker stdin mutex poisoned");
+            stdin
+                .write_all(encoded.as_bytes())
+                .and_then(|_| stdin.flush())
+        };
+
+        if let Err(error) = write_result {
+            self.inner.in_flight.fetch_sub(1, Ordering::SeqCst);
+            return Err(error.into());
+        }
+
+        Ok(())
+    }
+
+    fn drain_responses(&self, max: usize) -> Vec<JobResponse<Response>> {
+        let receiver = self
+            .inner
+            .responses
+            .lock()
+            .expect("job response receiver mutex poisoned");
+        let mut responses = Vec::new();
+        for _ in 0..max {
+            match receiver.try_recv() {
+                Ok(response) => responses.push(response),
+                Err(mpsc::TryRecvError::Empty | mpsc::TryRecvError::Disconnected) => break,
+            }
+        }
+        responses
+    }
+
+    fn shutdown(&self) {
+        self.inner.shutting_down.store(true, Ordering::SeqCst);
+    }
+}
+
+fn spawn_worker<Response>(
+    command: &StdioWorkerCommand,
+    sender: mpsc::Sender<JobResponse<Response>>,
+    in_flight: Arc<AtomicUsize>,
+    max_response_bytes: usize,
+) -> io::Result<WorkerProcess>
+where
+    Response: DeserializeOwned + Send + 'static,
+{
+    let mut child = Command::new(&command.program)
+        .args(&command.args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()?;
+
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "worker did not expose stdin"))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "worker did not expose stdout"))?;
+
+    let child = Arc::new(Mutex::new(child));
+    let reader = thread::spawn(move || {
+        let mut stdout = BufReader::new(stdout);
+        loop {
+            let mut line = String::new();
+            match stdout.read_line(&mut line) {
+                Ok(0) => break,
+                Ok(_) => {}
+                Err(_) => break,
+            }
+
+            match decode_response_json_line_with_limit::<Response>(&line, max_response_bytes) {
+                Ok(response) => {
+                    decrement_in_flight(&in_flight);
+                    if sender.send(response).is_err() {
+                        break;
+                    }
+                }
+                Err(JobCodecError::OversizedFrame { .. }) => break,
+                Err(_) if line.len() > max_response_bytes => break,
+                Err(_) => {}
+            }
+        }
+    });
+
+    Ok(WorkerProcess {
+        stdin: Arc::new(Mutex::new(stdin)),
+        child,
+        reader: Some(reader),
+    })
+}
+
+fn decrement_in_flight(in_flight: &AtomicUsize) {
+    let _ = in_flight.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |current| {
+        Some(current.saturating_sub(1))
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use generic_job_protocol::{JobMetadata, JobResult};
+    use serde::{Deserialize, Serialize};
+    use std::process::Command;
+
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    struct EchoJob {
+        stream_id: String,
+        text: String,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    struct EchoResponse {
+        stream_id: String,
+        counter: u64,
+        text: String,
+    }
+
+    fn python_candidates() -> Vec<String> {
+        let mut candidates = Vec::new();
+        if let Ok(value) = std::env::var("PYTHON") {
+            candidates.push(value);
+        }
+        if cfg!(windows) {
+            candidates.push("python".to_string());
+        } else {
+            candidates.push("python3".to_string());
+            candidates.push("python".to_string());
+        }
+        candidates.dedup();
+        candidates
+    }
+
+    fn python_interpreter() -> Option<String> {
+        python_candidates().into_iter().find(|candidate| {
+            Command::new(candidate)
+                .arg("-c")
+                .arg("import json, sys; raise SystemExit(0)")
+                .output()
+                .map(|output| output.status.success())
+                .unwrap_or(false)
+        })
+    }
+
+    fn scripted_worker(script: &str) -> Option<StdioWorkerCommand> {
+        python_interpreter().map(|program| {
+            StdioWorkerCommand::new(program, vec!["-c".to_string(), script.to_string()])
+        })
+    }
+
+    fn echo_worker_script(extra: &str) -> String {
+        format!(
+            r#"
+import json, sys, time
+counts = {{}}
+{extra}
+for line in sys.stdin:
+    frame = json.loads(line)
+    body = frame["body"]
+    payload = body["payload"]
+    stream_id = payload["stream_id"]
+    counts[stream_id] = counts.get(stream_id, 0) + 1
+    out = {{"stream_id": stream_id, "counter": counts[stream_id], "text": payload["text"]}}
+    print(json.dumps({{"version": 1, "kind": "response", "body": {{"id": body["id"], "result": {{"status": "ok", "payload": out}}, "metadata": body["metadata"]}}}}), flush=True)
+"#
+        )
+    }
+
+    #[test]
+    fn process_pool_routes_same_affinity_to_same_worker() {
+        let Some(command) = scripted_worker(&echo_worker_script("")) else {
+            eprintln!("skipping test because no Python interpreter was found");
+            return;
+        };
+        let pool = StdioProcessPool::<EchoJob, EchoResponse>::spawn(
+            command,
+            StdioProcessPoolOptions {
+                worker_count: 2,
+                limits: ExecutorLimits {
+                    max_queue_depth: 8,
+                    ..ExecutorLimits::default()
+                },
+            },
+        )
+        .expect("spawn process pool");
+
+        for index in 0..2 {
+            pool.try_submit(
+                JobRequest::new(
+                    format!("job-{index}"),
+                    EchoJob {
+                        stream_id: "stream-7".to_string(),
+                        text: format!("message-{index}"),
+                    },
+                )
+                .with_metadata(JobMetadata::default().with_affinity_key("stream-7")),
+            )
+            .expect("submit job");
+        }
+
+        let mut responses = Vec::new();
+        for _ in 0..100 {
+            responses.extend(pool.drain_responses(8));
+            if responses.len() == 2 {
+                break;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        assert_eq!(responses.len(), 2);
+        let counters = responses
+            .into_iter()
+            .map(|response| match response.result {
+                JobResult::Ok { payload } => payload.counter,
+                other => panic!("unexpected response: {other:?}"),
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(counters, vec![1, 2]);
+    }
+
+    #[test]
+    fn process_pool_rejects_jobs_when_in_flight_limit_is_full() {
+        let Some(command) = scripted_worker(&echo_worker_script("time.sleep(0.2)")) else {
+            eprintln!("skipping test because no Python interpreter was found");
+            return;
+        };
+        let pool = StdioProcessPool::<EchoJob, EchoResponse>::spawn(
+            command,
+            StdioProcessPoolOptions {
+                worker_count: 1,
+                limits: ExecutorLimits {
+                    max_queue_depth: 1,
+                    ..ExecutorLimits::default()
+                },
+            },
+        )
+        .expect("spawn process pool");
+
+        pool.try_submit(JobRequest::new(
+            "job-1",
+            EchoJob {
+                stream_id: "stream".to_string(),
+                text: "one".to_string(),
+            },
+        ))
+        .expect("first job is accepted");
+
+        let err = pool
+            .try_submit(JobRequest::new(
+                "job-2",
+                EchoJob {
+                    stream_id: "stream".to_string(),
+                    text: "two".to_string(),
+                },
+            ))
+            .expect_err("second job should hit backpressure");
+        assert_eq!(err, SubmitError::QueueFull);
+    }
+}

--- a/code/specs/JR00-generic-job-runtime.md
+++ b/code/specs/JR00-generic-job-runtime.md
@@ -809,7 +809,27 @@ Add the pure data model in every target language:
 
 Rust should land first because the TCP runtime will consume it.
 
-### Phase 2: Rust Thread-Pool Executor
+### Phase 2: Stdio Process-Pool Executor
+
+Status: first Rust slice landed with bounded in-flight submission, affinity
+routing, async response draining, and a TCP consumer in
+`embeddable-tcp-server`.
+
+Add a language-neutral process-pool executor using JSON lines first so Python,
+Ruby, Perl, Lua, and other process-backed hosts can share the same execution
+seam. This phase proves that CPU-bound callbacks can run outside one GIL or VM
+lock.
+
+Remaining hardening:
+
+- per-job timeout accounting
+- worker startup timeouts
+- restart policy for crashed workers
+- cancellation semantics
+- ordered response buffering by affinity where adapters need it
+- backpressure signals rich enough for TCP read pausing
+
+### Phase 3: Rust Thread-Pool Executor
 
 Add an in-process Rust executor with:
 
@@ -820,7 +840,7 @@ Add an in-process Rust executor with:
 - timeout accounting
 - affinity-aware ordering
 
-### Phase 3: TCP Job Runtime Adapter
+### Phase 4: TCP Job Runtime Adapter
 
 Add a TCP adapter that proves:
 
@@ -830,13 +850,6 @@ Add a TCP adapter that proves:
 
 Mini Redis and IRC can then choose between inline execution and job-backed
 execution.
-
-### Phase 4: Process-Pool Executor
-
-Add a language-neutral process-pool executor using length-prefixed JSON lines.
-
-This phase should include at least one worker implementation, preferably Python,
-because it proves that CPU-bound callbacks can run outside one GIL.
 
 ### Phase 5: Language Bindings
 

--- a/code/specs/embeddable-tcp-server.md
+++ b/code/specs/embeddable-tcp-server.md
@@ -92,15 +92,20 @@ transport package identity.
 
 ## Current Limitations
 
-- The prototype uses one worker process.
+- Mailbox mode can use a configurable stdio worker process pool through
+  `generic-job-runtime`; the default remains one process.
 - Worker communication uses the JSON-line `generic-job-protocol` codec over
   standard streams, not a binary protocol.
 - Mailbox delivery is bounded by the stream reactor's cooperative poll timeout
   until the transport layer exposes a thread-safe wake handle.
+- Process-pool hardening is still incomplete: timeouts, restart policy,
+  cancellation, and TCP read pausing on queue saturation need dedicated follow-up
+  work.
 
-These limits are intentional for the first prototype. The next production seam
-should replace the single stdio worker process with the generic job runtime so
-language workers can run in a thread pool or process pool.
+These limits are intentional for the first process-pool slice. The TCP package
+now consumes the generic job runtime, but the runtime still needs production
+supervision and backpressure policy before it should be treated as the final
+high-performance architecture.
 
 ## Acceptance Criteria
 


### PR DESCRIPTION
## Summary
- add a new Rust `generic-job-runtime` crate with a bounded stdio process-pool executor
- route embeddable TCP mailbox mode through the generic process pool instead of a one-off child process
- preserve TCP purity: Rust still only sees opaque byte jobs/responses, while workers own protocol parsing and response assembly
- update specs/docs to mark the process-pool seam as landed and call out the next hardening work

## Tests
- `bash BUILD` in `code/packages/rust/generic-job-runtime`
- `bash BUILD` in `code/packages/rust/generic-job-protocol`
- `bash BUILD` in `code/packages/rust/embeddable-tcp-server`
- `cargo check -p generic-job-runtime --tests --target x86_64-unknown-linux-gnu`
- `cargo check -p embeddable-tcp-server --tests --target x86_64-unknown-linux-gnu`
- `cargo check -p generic-job-runtime --tests --target x86_64-pc-windows-msvc`
- `cargo check -p embeddable-tcp-server --tests --target x86_64-pc-windows-msvc`

## Security
- no `unsafe` added
- process spawning uses `Command::new(program).args(args)` with no shell interpolation
- process-pool submissions are bounded by in-flight queue depth and payload/response frame size limits
