### PR TITLE
feat(argon2-swift): port Argon2d/Argon2i/Argon2id to Swift (RFC 9106)

### DIFF
--- a/code/packages/swift/argon2d/.gitignore
+++ b/code/packages/swift/argon2d/.gitignore
@@ -1,0 +1,4 @@
+.build/
+.swiftpm/
+Package.resolved
+*.xcodeproj/

--- a/code/packages/swift/argon2d/BUILD
+++ b/code/packages/swift/argon2d/BUILD
@@ -1,0 +1,1 @@
+if command -v xcrun >/dev/null 2>&1; then xcrun swift test --enable-code-coverage --verbose; else swift test --enable-code-coverage --verbose; fi

--- a/code/packages/swift/argon2d/BUILD_windows
+++ b/code/packages/swift/argon2d/BUILD_windows
@@ -1,0 +1,1 @@
+where swift >nul 2>nul && swift test --enable-code-coverage --verbose || echo Swift not available on this runner - skipping

--- a/code/packages/swift/argon2d/CHANGELOG.md
+++ b/code/packages/swift/argon2d/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## 0.1.0 — 2026-04-20
+
+- Initial from-scratch Swift implementation of Argon2d (RFC 9106).
+- G-mixer, permutation P, compression G, H' (`blake2bLong`),
+  `indexAlpha`, `fillSegment`, and top-level `argon2d` / `argon2dHex`.
+- Depends only on our sibling `Blake2b` Swift package.
+- Verified against the RFC 9106 §5.1 gold-standard vector
+  (`512b391b6f1162975371d30919734294f868e3be3984f3c1a13a4db9fabe4acb`).
+- Parameter validation matches RFC 9106 §3.1 bounds, raising
+  typed `Argon2d.ValidationError` values.

--- a/code/packages/swift/argon2d/Package.swift
+++ b/code/packages/swift/argon2d/Package.swift
@@ -1,0 +1,34 @@
+// swift-tools-version: 6.0
+// ============================================================================
+// Package.swift -- Argon2d (RFC 9106)
+// ============================================================================
+//
+// Swift Package Manager manifest for Argon2d, the data-dependent Argon2
+// variant. Depends on our sibling Blake2b package for the underlying hash.
+//
+// Part of the coding-adventures educational computing stack.
+// ============================================================================
+
+import PackageDescription
+
+let package = Package(
+    name: "Argon2d",
+    products: [
+        .library(name: "Argon2d", targets: ["Argon2d"]),
+    ],
+    dependencies: [
+        .package(path: "../blake2b"),
+    ],
+    targets: [
+        .target(
+            name: "Argon2d",
+            dependencies: [
+                .product(name: "Blake2b", package: "Blake2b"),
+            ]
+        ),
+        .testTarget(
+            name: "Argon2dTests",
+            dependencies: ["Argon2d"]
+        ),
+    ]
+)

--- a/code/packages/swift/argon2d/README.md
+++ b/code/packages/swift/argon2d/README.md
@@ -1,0 +1,67 @@
+# Argon2d (Swift)
+
+From-scratch Swift implementation of **Argon2d** (RFC 9106) — the
+data-dependent member of the Argon2 memory-hard KDF family.
+
+Depends only on our sibling `Blake2b` package for the underlying hash.
+
+See the spec at [../../specs/KD03-argon2.md](../../specs/KD03-argon2.md).
+
+## Usage
+
+```swift
+import Argon2d
+
+let tag = try Argon2d.argon2d(
+    password: Array("secret".utf8),
+    salt: Array("0123456789abcdef".utf8),
+    timeCost: 3, memoryCost: 32, parallelism: 4, tagLength: 32,
+    key: [], associatedData: []
+)
+
+let hex = try Argon2d.argon2dHex(
+    password: Array("secret".utf8),
+    salt: Array("0123456789abcdef".utf8),
+    timeCost: 3, memoryCost: 32, parallelism: 4, tagLength: 32
+)
+```
+
+## When to pick Argon2d
+
+| Use case                      | Argon2 variant |
+|-------------------------------|----------------|
+| Password hashing (any server) | **Argon2id**   |
+| Side-channel resistance only  | Argon2i        |
+| Proof-of-work, no secret input | **Argon2d**   |
+
+Argon2d chooses every reference block based on the password-derived state,
+so memory-access timing **is** a side channel. Don't feed Argon2d data that
+must be kept secret from anyone watching cache timings. For password
+hashing in adversarial environments use `Argon2id`.
+
+## Implementation notes
+
+- Swift's `UInt64` `&+`, `&*`, `>>`, `<<`, `^` are used directly — no
+  masking, no unsafe, no `Foundation`-heavy dependencies beyond
+  `String(format:)` for hex.
+- The memory matrix is modelled as `[[[UInt64]]]` (`lanes x columns x
+  block-words`). Argon2's rule "every block is 1 KiB of u64s" maps onto
+  this trivially.
+- Tag comparison is NOT provided here — callers MUST compare tags with
+  a constant-time helper (see our `ct-compare` crate in Rust; equivalent
+  helpers exist in the other languages).
+
+## Trust boundary
+
+Argon2 is designed to burn CPU and RAM on purpose. Callers control the
+DoS boundary via `timeCost`, `memoryCost`, and `parallelism`. Don't
+expose those to untrusted input without bounds.
+
+## Running the tests
+
+```bash
+swift test --enable-code-coverage
+```
+
+The gold-standard RFC 9106 §5.1 vector is verified along with validation,
+determinism, key/AD binding, tag-length boundary, and parallelism tests.

--- a/code/packages/swift/argon2d/Sources/Argon2d/Argon2d.swift
+++ b/code/packages/swift/argon2d/Sources/Argon2d/Argon2d.swift
@@ -1,0 +1,382 @@
+// Argon2d.swift -- Argon2d (RFC 9106), the data-dependent Argon2 variant.
+//
+// Argon2d picks every reference block from the low 64 bits of the previously
+// computed block.  That means the memory-access pattern is correlated with
+// the password, which maximises GPU/ASIC resistance but leaks a timing side
+// channel.  Use Argon2d only when side-channel attacks are NOT in the threat
+// model (proof-of-work schemes, etc.).  For password hashing prefer Argon2id.
+//
+// Reference: https://datatracker.ietf.org/doc/html/rfc9106
+// See also:  code/specs/KD03-argon2.md
+//
+// SWIFT 64-BIT NOTES
+// ------------------
+// Swift's UInt64 has native wrapping operators `&+`, `&*`, `&<<`, `&>>`.
+// We use `&+`/`&*` in the G-mixer's add-multiply cross term and plain `^`,
+// `|`, `&` for bitwise work.  The module is pure computation — no I/O, no
+// unsafe blocks, no randomness.  All byte packing is little-endian, matching
+// the RFC.
+
+import Foundation
+import Blake2b
+
+public enum Argon2d {
+    // ------------------------------------------------------------------
+    // Constants (RFC 9106 §3)
+    // ------------------------------------------------------------------
+    static let blockSize: Int = 1024            // bytes per Argon2 block
+    static let blockWords: Int = 128            // 64-bit words per block
+    static let syncPoints: Int = 4              // slices per pass
+    public static let argon2Version: Int = 0x13 // only v1.3 is approved
+    static let typeD: Int = 0                   // primitive type code
+
+    static let mask32: UInt64 = 0xFFFFFFFF
+
+    // ------------------------------------------------------------------
+    // Errors
+    // ------------------------------------------------------------------
+    public enum ValidationError: Error, Equatable {
+        case passwordTooLong
+        case saltTooShort
+        case saltTooLong
+        case keyTooLong
+        case associatedDataTooLong
+        case tagLengthTooSmall
+        case tagLengthTooLarge
+        case parallelismOutOfRange
+        case memoryCostTooSmall
+        case memoryCostTooLarge
+        case timeCostTooSmall
+        case unsupportedVersion
+    }
+
+    // ------------------------------------------------------------------
+    // _rotr64 -- right-rotate a 64-bit word by n bits.
+    // ------------------------------------------------------------------
+    @inline(__always)
+    static func rotr64(_ x: UInt64, _ n: UInt64) -> UInt64 {
+        return (x >> n) | (x << (64 - n))
+    }
+
+    // ------------------------------------------------------------------
+    // G-mixer (RFC 9106 §3.5).
+    //
+    // Identical to BLAKE2's quarter-round except each add carries an
+    // additional `2 * trunc32(a) * trunc32(b)` cross-term.  That term is
+    // what makes "prune and extend" attacks quadratic in block size.
+    // ------------------------------------------------------------------
+    @inline(__always)
+    static func gb(_ v: inout [UInt64], _ a: Int, _ b: Int, _ c: Int, _ d: Int) {
+        var va = v[a], vb = v[b], vc = v[c], vd = v[d]
+
+        va = va &+ vb &+ (2 &* (va & mask32) &* (vb & mask32))
+        vd = rotr64(vd ^ va, 32)
+        vc = vc &+ vd &+ (2 &* (vc & mask32) &* (vd & mask32))
+        vb = rotr64(vb ^ vc, 24)
+        va = va &+ vb &+ (2 &* (va & mask32) &* (vb & mask32))
+        vd = rotr64(vd ^ va, 16)
+        vc = vc &+ vd &+ (2 &* (vc & mask32) &* (vd & mask32))
+        vb = rotr64(vb ^ vc, 63)
+
+        v[a] = va; v[b] = vb; v[c] = vc; v[d] = vd
+    }
+
+    // Eight G-rounds over a 16-word slice.  Four "column" then four
+    // "diagonal" rounds -- the classic double-round layout.
+    @inline(__always)
+    static func permutationP(_ v: inout [UInt64], _ off: Int) {
+        gb(&v, off + 0, off + 4, off +  8, off + 12)
+        gb(&v, off + 1, off + 5, off +  9, off + 13)
+        gb(&v, off + 2, off + 6, off + 10, off + 14)
+        gb(&v, off + 3, off + 7, off + 11, off + 15)
+        gb(&v, off + 0, off + 5, off + 10, off + 15)
+        gb(&v, off + 1, off + 6, off + 11, off + 12)
+        gb(&v, off + 2, off + 7, off +  8, off + 13)
+        gb(&v, off + 3, off + 4, off +  9, off + 14)
+    }
+
+    // ------------------------------------------------------------------
+    // Compression G:  r := x XOR y; row-pass, column-pass; r XOR q.
+    //
+    // The column pass gathers 16-word "columns" (two words per row), permutes
+    // them, and scatters back -- flipping the 8x8 matrix of 128-bit registers
+    // along its diagonal.
+    // ------------------------------------------------------------------
+    static func compress(_ x: [UInt64], _ y: [UInt64]) -> [UInt64] {
+        var r = [UInt64](repeating: 0, count: blockWords)
+        for i in 0..<blockWords { r[i] = x[i] ^ y[i] }
+        var q = r
+
+        // Row pass
+        for i in 0..<8 { permutationP(&q, i * 16) }
+
+        // Column pass
+        var col = [UInt64](repeating: 0, count: 16)
+        for c in 0..<8 {
+            for rr in 0..<8 {
+                col[2 * rr]     = q[rr * 16 + 2 * c]
+                col[2 * rr + 1] = q[rr * 16 + 2 * c + 1]
+            }
+            permutationP(&col, 0)
+            for rr in 0..<8 {
+                q[rr * 16 + 2 * c]     = col[2 * rr]
+                q[rr * 16 + 2 * c + 1] = col[2 * rr + 1]
+            }
+        }
+
+        var out = [UInt64](repeating: 0, count: blockWords)
+        for i in 0..<blockWords { out[i] = r[i] ^ q[i] }
+        return out
+    }
+
+    // ------------------------------------------------------------------
+    // Byte <-> block helpers.  Argon2 is little-endian everywhere.
+    // ------------------------------------------------------------------
+    static func blockToBytes(_ block: [UInt64]) -> [UInt8] {
+        var out = [UInt8](repeating: 0, count: blockSize)
+        for i in 0..<blockWords {
+            let w = block[i]
+            for j in 0..<8 {
+                out[i * 8 + j] = UInt8((w >> (8 * j)) & 0xFF)
+            }
+        }
+        return out
+    }
+
+    static func bytesToBlock(_ data: [UInt8]) -> [UInt64] {
+        var out = [UInt64](repeating: 0, count: blockWords)
+        for i in 0..<blockWords {
+            var w: UInt64 = 0
+            for j in 0..<8 { w |= UInt64(data[i * 8 + j]) << (8 * j) }
+            out[i] = w
+        }
+        return out
+    }
+
+    static func le32(_ n: Int) -> [UInt8] {
+        let u = UInt32(truncatingIfNeeded: n)
+        return [
+            UInt8(u & 0xFF),
+            UInt8((u >> 8) & 0xFF),
+            UInt8((u >> 16) & 0xFF),
+            UInt8((u >> 24) & 0xFF),
+        ]
+    }
+
+    // ------------------------------------------------------------------
+    // blake2b_long -- Argon2's variable-length hash H' (RFC 9106 §3.3).
+    //
+    // Output = concat of 32-byte halves of repeated 64-byte BLAKE2b chains,
+    // with the last call sized to fit exactly.  The initial input prefix is
+    // LE32(t) || x.  For t <= 64 the standard BLAKE2b already produces
+    // exactly t bytes in one call.
+    // ------------------------------------------------------------------
+    static func blake2bLong(_ t: Int, _ x: [UInt8]) throws -> [UInt8] {
+        precondition(t > 0, "H' output length must be positive")
+        var input = le32(t)
+        input.append(contentsOf: x)
+
+        if t <= 64 {
+            return try Blake2b.hash(input, options: .init(digestSize: t))
+        }
+
+        let r = (t + 31) / 32 - 2
+        var v = try Blake2b.hash(input, options: .init(digestSize: 64))
+        var out = Array(v[0..<32])
+        if r > 1 {
+            for _ in 1..<r {
+                v = try Blake2b.hash(v, options: .init(digestSize: 64))
+                out.append(contentsOf: v[0..<32])
+            }
+        }
+        let finalSize = t - 32 * r
+        v = try Blake2b.hash(v, options: .init(digestSize: finalSize))
+        out.append(contentsOf: v)
+        return out
+    }
+
+    // ------------------------------------------------------------------
+    // index_alpha (RFC 9106 §3.4.1.1) -- map J1 to an eligible column.
+    //
+    // Window [start, start+W) names which already-filled columns may be
+    // referenced; J1 biases the pick toward recent blocks via (W * x) >> 32.
+    // ------------------------------------------------------------------
+    static func indexAlpha(_ j1: UInt64, _ r: Int, _ sl: Int, _ c: Int,
+                           _ sameLane: Bool, _ q: Int, _ slLen: Int) -> Int {
+        let w: Int
+        let start: Int
+        if r == 0 && sl == 0 {
+            w = c - 1
+            start = 0
+        } else if r == 0 {
+            if sameLane {
+                w = sl * slLen + c - 1
+            } else if c == 0 {
+                w = sl * slLen - 1
+            } else {
+                w = sl * slLen
+            }
+            start = 0
+        } else {
+            if sameLane {
+                w = q - slLen + c - 1
+            } else if c == 0 {
+                w = q - slLen - 1
+            } else {
+                w = q - slLen
+            }
+            start = ((sl + 1) * slLen) % q
+        }
+        let wU = UInt64(w)
+        let x = (j1 &* j1) >> 32
+        let y = (wU &* x) >> 32
+        let rel = Int(UInt64(w) &- 1 &- y)
+        return (start + rel) % q
+    }
+
+    // ------------------------------------------------------------------
+    // fill_segment -- one (pass, slice, lane) segment.  Argon2d is entirely
+    // data-dependent: the 64 low / high bits of the previous block supply
+    // J1 / J2.
+    // ------------------------------------------------------------------
+    static func fillSegment(_ memory: inout [[[UInt64]]],
+                            _ r: Int, _ lane: Int, _ sl: Int,
+                            _ q: Int, _ slLen: Int, _ p: Int) {
+        let startingC = (r == 0 && sl == 0) ? 2 : 0
+        for i in startingC..<slLen {
+            let col = sl * slLen + i
+            let prevCol = col == 0 ? q - 1 : col - 1
+            let prevBlock = memory[lane][prevCol]
+
+            let pseudoRand = prevBlock[0]
+            let j1 = pseudoRand & mask32
+            let j2 = (pseudoRand >> 32) & mask32
+
+            var lPrime = lane
+            if !(r == 0 && sl == 0) { lPrime = Int(j2) % p }
+
+            let zPrime = indexAlpha(j1, r, sl, i, lPrime == lane, q, slLen)
+            let refBlock = memory[lPrime][zPrime]
+
+            let newBlock = compress(prevBlock, refBlock)
+            if r == 0 {
+                memory[lane][col] = newBlock
+            } else {
+                var merged = [UInt64](repeating: 0, count: blockWords)
+                let existing = memory[lane][col]
+                for k in 0..<blockWords { merged[k] = existing[k] ^ newBlock[k] }
+                memory[lane][col] = merged
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Parameter validation (RFC 9106 §3.1 bounds).
+    // ------------------------------------------------------------------
+    static func validate(password: [UInt8], salt: [UInt8], timeCost: Int,
+                         memoryCost: Int, parallelism: Int, tagLength: Int,
+                         key: [UInt8], ad: [UInt8], version: Int) throws {
+        if UInt64(password.count) > mask32 { throw ValidationError.passwordTooLong }
+        if salt.count < 8  { throw ValidationError.saltTooShort }
+        if UInt64(salt.count) > mask32 { throw ValidationError.saltTooLong }
+        if UInt64(key.count)  > mask32 { throw ValidationError.keyTooLong }
+        if UInt64(ad.count)   > mask32 { throw ValidationError.associatedDataTooLong }
+        if tagLength < 4   { throw ValidationError.tagLengthTooSmall }
+        if UInt64(tagLength) > mask32 { throw ValidationError.tagLengthTooLarge }
+        if parallelism < 1 || parallelism > 0xFFFFFF {
+            throw ValidationError.parallelismOutOfRange
+        }
+        if memoryCost < 8 * parallelism { throw ValidationError.memoryCostTooSmall }
+        if UInt64(memoryCost) > mask32 { throw ValidationError.memoryCostTooLarge }
+        if timeCost < 1 { throw ValidationError.timeCostTooSmall }
+        if version != argon2Version { throw ValidationError.unsupportedVersion }
+    }
+
+    // ------------------------------------------------------------------
+    // argon2d -- compute the Argon2d tag (RFC 9106 §3).
+    //
+    // - password:       secret input, arbitrary byte length
+    // - salt:           >= 8 bytes, 16+ recommended
+    // - timeCost:       passes `t`, >= 1
+    // - memoryCost:     KiB `m`, >= 8 * parallelism
+    // - parallelism:    lanes `p`, 1..=2^24-1
+    // - tagLength:      output bytes `T`, >= 4
+    // - key, ad:        optional MAC / context binding, default empty
+    // - version:        only 0x13 supported
+    // ------------------------------------------------------------------
+    public static func argon2d(password: [UInt8], salt: [UInt8],
+                               timeCost: Int, memoryCost: Int,
+                               parallelism: Int, tagLength: Int,
+                               key: [UInt8] = [], associatedData: [UInt8] = [],
+                               version: Int = argon2Version) throws -> [UInt8] {
+        try validate(password: password, salt: salt, timeCost: timeCost,
+                     memoryCost: memoryCost, parallelism: parallelism,
+                     tagLength: tagLength, key: key, ad: associatedData,
+                     version: version)
+
+        let segmentLength = memoryCost / (syncPoints * parallelism)
+        let mPrime = segmentLength * syncPoints * parallelism
+        let q = mPrime / parallelism
+        let slLen = segmentLength
+        let p = parallelism
+        let t = timeCost
+
+        var h0Input = [UInt8]()
+        h0Input.append(contentsOf: le32(p))
+        h0Input.append(contentsOf: le32(tagLength))
+        h0Input.append(contentsOf: le32(memoryCost))
+        h0Input.append(contentsOf: le32(t))
+        h0Input.append(contentsOf: le32(version))
+        h0Input.append(contentsOf: le32(typeD))
+        h0Input.append(contentsOf: le32(password.count)); h0Input.append(contentsOf: password)
+        h0Input.append(contentsOf: le32(salt.count));     h0Input.append(contentsOf: salt)
+        h0Input.append(contentsOf: le32(key.count));      h0Input.append(contentsOf: key)
+        h0Input.append(contentsOf: le32(associatedData.count))
+        h0Input.append(contentsOf: associatedData)
+        let h0 = try Blake2b.hash(h0Input, options: .init(digestSize: 64))
+
+        var memory: [[[UInt64]]] = Array(
+            repeating: Array(repeating: [UInt64](repeating: 0, count: blockWords),
+                             count: q),
+            count: p
+        )
+        for i in 0..<p {
+            var seed0 = h0; seed0.append(contentsOf: le32(0)); seed0.append(contentsOf: le32(i))
+            var seed1 = h0; seed1.append(contentsOf: le32(1)); seed1.append(contentsOf: le32(i))
+            let b0 = try blake2bLong(blockSize, seed0)
+            let b1 = try blake2bLong(blockSize, seed1)
+            memory[i][0] = bytesToBlock(b0)
+            memory[i][1] = bytesToBlock(b1)
+        }
+
+        for r in 0..<t {
+            for sl in 0..<syncPoints {
+                for lane in 0..<p {
+                    fillSegment(&memory, r, lane, sl, q, slLen, p)
+                }
+            }
+        }
+
+        var finalBlock = memory[0][q - 1]
+        for lane in 1..<p {
+            let last = memory[lane][q - 1]
+            for k in 0..<blockWords { finalBlock[k] ^= last[k] }
+        }
+
+        return try blake2bLong(tagLength, blockToBytes(finalBlock))
+    }
+
+    // argon2d_hex -- lowercase hex convenience wrapper.
+    public static func argon2dHex(password: [UInt8], salt: [UInt8],
+                                  timeCost: Int, memoryCost: Int,
+                                  parallelism: Int, tagLength: Int,
+                                  key: [UInt8] = [], associatedData: [UInt8] = [],
+                                  version: Int = argon2Version) throws -> String {
+        let raw = try argon2d(password: password, salt: salt,
+                              timeCost: timeCost, memoryCost: memoryCost,
+                              parallelism: parallelism, tagLength: tagLength,
+                              key: key, associatedData: associatedData,
+                              version: version)
+        return raw.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/code/packages/swift/argon2d/Tests/Argon2dTests/Argon2dTests.swift
+++ b/code/packages/swift/argon2d/Tests/Argon2dTests/Argon2dTests.swift
@@ -1,0 +1,165 @@
+import XCTest
+@testable import Argon2d
+
+final class Argon2dTests: XCTestCase {
+    // --- helpers ---
+    func bytes(_ s: String) -> [UInt8] { return Array(s.utf8) }
+    func repeated(_ byte: UInt8, _ n: Int) -> [UInt8] {
+        return [UInt8](repeating: byte, count: n)
+    }
+
+    // RFC 9106 §5.1 gold-standard Argon2d vector.
+    func testRfc9106Section5_1Vector() throws {
+        let tag = try Argon2d.argon2dHex(
+            password: repeated(0x01, 32),
+            salt:     repeated(0x02, 16),
+            timeCost: 3, memoryCost: 32, parallelism: 4, tagLength: 32,
+            key: repeated(0x03, 8),
+            associatedData: repeated(0x04, 12)
+        )
+        XCTAssertEqual(tag,
+            "512b391b6f1162975371d30919734294f868e3be3984f3c1a13a4db9fabe4acb")
+    }
+
+    func testHexMatchesBinary() throws {
+        let raw = try Argon2d.argon2d(
+            password: repeated(0x01, 32), salt: repeated(0x02, 16),
+            timeCost: 3, memoryCost: 32, parallelism: 4, tagLength: 32,
+            key: repeated(0x03, 8), associatedData: repeated(0x04, 12))
+        let hex = try Argon2d.argon2dHex(
+            password: repeated(0x01, 32), salt: repeated(0x02, 16),
+            timeCost: 3, memoryCost: 32, parallelism: 4, tagLength: 32,
+            key: repeated(0x03, 8), associatedData: repeated(0x04, 12))
+        XCTAssertEqual(raw.map { String(format: "%02x", $0) }.joined(), hex)
+    }
+
+    // --- Validation rejections ---
+    func testRejectsShortSalt() {
+        XCTAssertThrowsError(try Argon2d.argon2d(
+            password: bytes("pw"), salt: bytes("short"),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32))
+    }
+
+    func testRejectsZeroTimeCost() {
+        XCTAssertThrowsError(try Argon2d.argon2d(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 0, memoryCost: 8, parallelism: 1, tagLength: 32))
+    }
+
+    func testRejectsTagLengthUnder4() {
+        XCTAssertThrowsError(try Argon2d.argon2d(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 3))
+    }
+
+    func testRejectsMemoryUnder8p() {
+        XCTAssertThrowsError(try Argon2d.argon2d(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 7, parallelism: 1, tagLength: 32))
+    }
+
+    func testRejectsZeroParallelism() {
+        XCTAssertThrowsError(try Argon2d.argon2d(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 0, tagLength: 32))
+    }
+
+    func testRejectsUnsupportedVersion() {
+        XCTAssertThrowsError(try Argon2d.argon2d(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32,
+            version: 0x10))
+    }
+
+    // --- Determinism and separation ---
+    func testDeterministic() throws {
+        let a = try Argon2d.argon2dHex(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32)
+        let b = try Argon2d.argon2dHex(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32)
+        XCTAssertEqual(a, b)
+    }
+
+    func testPasswordDifferentiates() throws {
+        let a = try Argon2d.argon2dHex(
+            password: bytes("pw1"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32)
+        let b = try Argon2d.argon2dHex(
+            password: bytes("pw2"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32)
+        XCTAssertNotEqual(a, b)
+    }
+
+    func testSaltDifferentiates() throws {
+        let a = try Argon2d.argon2dHex(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32)
+        let b = try Argon2d.argon2dHex(
+            password: bytes("pw"), salt: repeated(0x62, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32)
+        XCTAssertNotEqual(a, b)
+    }
+
+    // --- Key and AD binding ---
+    func testKeyBinds() throws {
+        let none = try Argon2d.argon2dHex(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32)
+        let k1 = try Argon2d.argon2dHex(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32,
+            key: bytes("k1"))
+        let k2 = try Argon2d.argon2dHex(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32,
+            key: bytes("k2"))
+        XCTAssertNotEqual(none, k1)
+        XCTAssertNotEqual(k1, k2)
+    }
+
+    func testAdBinds() throws {
+        let none = try Argon2d.argon2dHex(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32)
+        let a1 = try Argon2d.argon2dHex(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32,
+            associatedData: bytes("x"))
+        let a2 = try Argon2d.argon2dHex(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32,
+            associatedData: bytes("y"))
+        XCTAssertNotEqual(none, a1)
+        XCTAssertNotEqual(a1, a2)
+    }
+
+    // --- Tag length variants (exercises H' branches) ---
+    func testTagLengths() throws {
+        for t in [4, 16, 65, 128] {
+            let out = try Argon2d.argon2d(
+                password: bytes("pw"), salt: repeated(0x61, 8),
+                timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: t)
+            XCTAssertEqual(out.count, t, "tag length \(t)")
+        }
+    }
+
+    // --- Parallelism and multi-pass ---
+    func testMultiLaneTagSize() throws {
+        let out = try Argon2d.argon2d(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 16, parallelism: 2, tagLength: 32)
+        XCTAssertEqual(out.count, 32)
+    }
+
+    func testMultiPassDiffersFromSinglePass() throws {
+        let a = try Argon2d.argon2dHex(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32)
+        let b = try Argon2d.argon2dHex(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 2, memoryCost: 8, parallelism: 1, tagLength: 32)
+        XCTAssertNotEqual(a, b)
+    }
+}

--- a/code/packages/swift/argon2d/required_capabilities.json
+++ b/code/packages/swift/argon2d/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "swift/argon2d",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/swift/argon2i/.gitignore
+++ b/code/packages/swift/argon2i/.gitignore
@@ -1,0 +1,4 @@
+.build/
+.swiftpm/
+Package.resolved
+*.xcodeproj/

--- a/code/packages/swift/argon2i/BUILD
+++ b/code/packages/swift/argon2i/BUILD
@@ -1,0 +1,1 @@
+if command -v xcrun >/dev/null 2>&1; then xcrun swift test --enable-code-coverage --verbose; else swift test --enable-code-coverage --verbose; fi

--- a/code/packages/swift/argon2i/BUILD_windows
+++ b/code/packages/swift/argon2i/BUILD_windows
@@ -1,0 +1,1 @@
+where swift >nul 2>nul && swift test --enable-code-coverage --verbose || echo Swift not available on this runner - skipping

--- a/code/packages/swift/argon2i/CHANGELOG.md
+++ b/code/packages/swift/argon2i/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## 0.1.0 — 2026-04-20
+
+- Initial from-scratch Swift implementation of Argon2i (RFC 9106).
+- Data-independent fill_segment: deterministic address stream via
+  `double-G(0, compress(0, input_block))`, refreshed every 128 columns.
+- Depends only on our sibling `Blake2b` Swift package.
+- Verified against the RFC 9106 §5.2 gold-standard vector
+  (`c814d9d1dc7f37aa13f0d77f2494bda1c8de6b016dd388d29952a4c4672b6ce8`).
+- Parameter validation matches RFC 9106 §3.1 bounds, raising
+  typed `Argon2i.ValidationError` values.

--- a/code/packages/swift/argon2i/Package.swift
+++ b/code/packages/swift/argon2i/Package.swift
@@ -1,0 +1,34 @@
+// swift-tools-version: 6.0
+// ============================================================================
+// Package.swift -- Argon2i (RFC 9106)
+// ============================================================================
+//
+// Swift Package Manager manifest for Argon2i, the data-independent Argon2
+// variant. Depends on our sibling Blake2b package for the underlying hash.
+//
+// Part of the coding-adventures educational computing stack.
+// ============================================================================
+
+import PackageDescription
+
+let package = Package(
+    name: "Argon2i",
+    products: [
+        .library(name: "Argon2i", targets: ["Argon2i"]),
+    ],
+    dependencies: [
+        .package(path: "../blake2b"),
+    ],
+    targets: [
+        .target(
+            name: "Argon2i",
+            dependencies: [
+                .product(name: "Blake2b", package: "Blake2b"),
+            ]
+        ),
+        .testTarget(
+            name: "Argon2iTests",
+            dependencies: ["Argon2i"]
+        ),
+    ]
+)

--- a/code/packages/swift/argon2i/README.md
+++ b/code/packages/swift/argon2i/README.md
@@ -1,0 +1,59 @@
+# Argon2i (Swift)
+
+From-scratch Swift implementation of **Argon2i** (RFC 9106) — the
+data-independent member of the Argon2 memory-hard KDF family.
+
+Depends only on our sibling `Blake2b` package for the underlying hash.
+
+See the spec at [../../specs/KD03-argon2.md](../../specs/KD03-argon2.md).
+
+## Usage
+
+```swift
+import Argon2i
+
+let tag = try Argon2i.argon2i(
+    password: Array("secret".utf8),
+    salt: Array("0123456789abcdef".utf8),
+    timeCost: 3, memoryCost: 32, parallelism: 4, tagLength: 32
+)
+
+let hex = try Argon2i.argon2iHex(
+    password: Array("secret".utf8),
+    salt: Array("0123456789abcdef".utf8),
+    timeCost: 3, memoryCost: 32, parallelism: 4, tagLength: 32
+)
+```
+
+## When to pick Argon2i
+
+Argon2i avoids password-dependent memory accesses entirely, giving
+side-channel resistance. The price is weaker GPU/ASIC hardening than
+Argon2d. RFC 9106 explicitly recommends **Argon2id** as the general
+password-hashing default; use `Argon2i` only when side-channel
+resistance is paramount and hardware-cracking resistance is not (e.g.
+a constrained-channel embedded device).
+
+## Implementation notes
+
+The deterministic address stream is computed as `double-G(0,
+compress(0, input_block))` — exactly the construction in the RFC. The
+stream is refreshed every 128 columns, and `input_block[6]` is bumped
+each time. Nothing about the stream depends on the password, so there
+is no timing side channel on memory access.
+
+## Trust boundary
+
+Argon2 is designed to burn CPU and RAM on purpose. Callers control the
+DoS boundary via `timeCost`, `memoryCost`, and `parallelism`. Don't
+expose those to untrusted input without bounds. Tag comparison is NOT
+provided here — use a constant-time helper when verifying passwords.
+
+## Running the tests
+
+```bash
+swift test --enable-code-coverage
+```
+
+The RFC 9106 §5.2 gold-standard vector is verified along with validation,
+determinism, key/AD binding, and tag-length boundary tests.

--- a/code/packages/swift/argon2i/Sources/Argon2i/Argon2i.swift
+++ b/code/packages/swift/argon2i/Sources/Argon2i/Argon2i.swift
@@ -1,0 +1,319 @@
+// Argon2i.swift -- Argon2i (RFC 9106), the data-independent Argon2 variant.
+//
+// Argon2i generates reference-block indices from a deterministic public
+// address stream: double-G(0, compress(0, input_block)) where input_block
+// carries (pass r, lane, slice sl, m', t_total, TYPE_I, counter) in its
+// first seven words.  Because the indices don't depend on the password, the
+// memory-access pattern is independent of the secret -- giving side-channel
+// resistance at the cost of Argon2d's GPU/ASIC hardening.  For
+// general-purpose password hashing prefer Argon2id.
+//
+// Reference: https://datatracker.ietf.org/doc/html/rfc9106
+// See also:  code/specs/KD03-argon2.md
+//
+// Almost every line of this file is shared with Argon2d; the only real
+// difference is fill_segment, which pulls J1/J2 from a synthesised address
+// stream rather than from the previous block's payload.
+
+import Foundation
+import Blake2b
+
+public enum Argon2i {
+    static let blockSize: Int = 1024
+    static let blockWords: Int = 128
+    static let syncPoints: Int = 4
+    public static let argon2Version: Int = 0x13
+    static let typeI: Int = 1
+    static let addressesPerBlock: Int = 128   // = blockWords
+
+    static let mask32: UInt64 = 0xFFFFFFFF
+
+    public enum ValidationError: Error, Equatable {
+        case passwordTooLong
+        case saltTooShort
+        case saltTooLong
+        case keyTooLong
+        case associatedDataTooLong
+        case tagLengthTooSmall
+        case tagLengthTooLarge
+        case parallelismOutOfRange
+        case memoryCostTooSmall
+        case memoryCostTooLarge
+        case timeCostTooSmall
+        case unsupportedVersion
+    }
+
+    @inline(__always)
+    static func rotr64(_ x: UInt64, _ n: UInt64) -> UInt64 {
+        return (x >> n) | (x << (64 - n))
+    }
+
+    @inline(__always)
+    static func gb(_ v: inout [UInt64], _ a: Int, _ b: Int, _ c: Int, _ d: Int) {
+        var va = v[a], vb = v[b], vc = v[c], vd = v[d]
+        va = va &+ vb &+ (2 &* (va & mask32) &* (vb & mask32))
+        vd = rotr64(vd ^ va, 32)
+        vc = vc &+ vd &+ (2 &* (vc & mask32) &* (vd & mask32))
+        vb = rotr64(vb ^ vc, 24)
+        va = va &+ vb &+ (2 &* (va & mask32) &* (vb & mask32))
+        vd = rotr64(vd ^ va, 16)
+        vc = vc &+ vd &+ (2 &* (vc & mask32) &* (vd & mask32))
+        vb = rotr64(vb ^ vc, 63)
+        v[a] = va; v[b] = vb; v[c] = vc; v[d] = vd
+    }
+
+    @inline(__always)
+    static func permutationP(_ v: inout [UInt64], _ off: Int) {
+        gb(&v, off + 0, off + 4, off +  8, off + 12)
+        gb(&v, off + 1, off + 5, off +  9, off + 13)
+        gb(&v, off + 2, off + 6, off + 10, off + 14)
+        gb(&v, off + 3, off + 7, off + 11, off + 15)
+        gb(&v, off + 0, off + 5, off + 10, off + 15)
+        gb(&v, off + 1, off + 6, off + 11, off + 12)
+        gb(&v, off + 2, off + 7, off +  8, off + 13)
+        gb(&v, off + 3, off + 4, off +  9, off + 14)
+    }
+
+    static func compress(_ x: [UInt64], _ y: [UInt64]) -> [UInt64] {
+        var r = [UInt64](repeating: 0, count: blockWords)
+        for i in 0..<blockWords { r[i] = x[i] ^ y[i] }
+        var q = r
+        for i in 0..<8 { permutationP(&q, i * 16) }
+        var col = [UInt64](repeating: 0, count: 16)
+        for c in 0..<8 {
+            for rr in 0..<8 {
+                col[2 * rr]     = q[rr * 16 + 2 * c]
+                col[2 * rr + 1] = q[rr * 16 + 2 * c + 1]
+            }
+            permutationP(&col, 0)
+            for rr in 0..<8 {
+                q[rr * 16 + 2 * c]     = col[2 * rr]
+                q[rr * 16 + 2 * c + 1] = col[2 * rr + 1]
+            }
+        }
+        var out = [UInt64](repeating: 0, count: blockWords)
+        for i in 0..<blockWords { out[i] = r[i] ^ q[i] }
+        return out
+    }
+
+    static func blockToBytes(_ block: [UInt64]) -> [UInt8] {
+        var out = [UInt8](repeating: 0, count: blockSize)
+        for i in 0..<blockWords {
+            let w = block[i]
+            for j in 0..<8 { out[i * 8 + j] = UInt8((w >> (8 * j)) & 0xFF) }
+        }
+        return out
+    }
+
+    static func bytesToBlock(_ data: [UInt8]) -> [UInt64] {
+        var out = [UInt64](repeating: 0, count: blockWords)
+        for i in 0..<blockWords {
+            var w: UInt64 = 0
+            for j in 0..<8 { w |= UInt64(data[i * 8 + j]) << (8 * j) }
+            out[i] = w
+        }
+        return out
+    }
+
+    static func le32(_ n: Int) -> [UInt8] {
+        let u = UInt32(truncatingIfNeeded: n)
+        return [UInt8(u & 0xFF), UInt8((u >> 8) & 0xFF),
+                UInt8((u >> 16) & 0xFF), UInt8((u >> 24) & 0xFF)]
+    }
+
+    static func blake2bLong(_ t: Int, _ x: [UInt8]) throws -> [UInt8] {
+        precondition(t > 0, "H' output length must be positive")
+        var input = le32(t); input.append(contentsOf: x)
+        if t <= 64 {
+            return try Blake2b.hash(input, options: .init(digestSize: t))
+        }
+        let r = (t + 31) / 32 - 2
+        var v = try Blake2b.hash(input, options: .init(digestSize: 64))
+        var out = Array(v[0..<32])
+        if r > 1 {
+            for _ in 1..<r {
+                v = try Blake2b.hash(v, options: .init(digestSize: 64))
+                out.append(contentsOf: v[0..<32])
+            }
+        }
+        let finalSize = t - 32 * r
+        v = try Blake2b.hash(v, options: .init(digestSize: finalSize))
+        out.append(contentsOf: v)
+        return out
+    }
+
+    static func indexAlpha(_ j1: UInt64, _ r: Int, _ sl: Int, _ c: Int,
+                           _ sameLane: Bool, _ q: Int, _ slLen: Int) -> Int {
+        let w: Int
+        let start: Int
+        if r == 0 && sl == 0 { w = c - 1; start = 0 }
+        else if r == 0 {
+            if sameLane      { w = sl * slLen + c - 1 }
+            else if c == 0   { w = sl * slLen - 1 }
+            else             { w = sl * slLen }
+            start = 0
+        } else {
+            if sameLane      { w = q - slLen + c - 1 }
+            else if c == 0   { w = q - slLen - 1 }
+            else             { w = q - slLen }
+            start = ((sl + 1) * slLen) % q
+        }
+        let wU = UInt64(w)
+        let x = (j1 &* j1) >> 32
+        let y = (wU &* x) >> 32
+        let rel = Int(UInt64(w) &- 1 &- y)
+        return (start + rel) % q
+    }
+
+    // ------------------------------------------------------------------
+    // fill_segment (Argon2i-specific).
+    //
+    // J1/J2 come from a deterministic address stream: `address_block` is
+    // refreshed every 128 columns by computing compress(0, compress(0,
+    // input_block)), with input_block[6] bumped each time.  The stream is
+    // independent of the password -- that's the whole point of Argon2i.
+    // ------------------------------------------------------------------
+    static func fillSegment(_ memory: inout [[[UInt64]]],
+                            _ r: Int, _ lane: Int, _ sl: Int,
+                            _ q: Int, _ slLen: Int, _ p: Int,
+                            _ mPrime: Int, _ tTotal: Int) {
+        var input = [UInt64](repeating: 0, count: blockWords)
+        var address = [UInt64](repeating: 0, count: blockWords)
+        let zero = [UInt64](repeating: 0, count: blockWords)
+        input[0] = UInt64(r)
+        input[1] = UInt64(lane)
+        input[2] = UInt64(sl)
+        input[3] = UInt64(mPrime)
+        input[4] = UInt64(tTotal)
+        input[5] = UInt64(typeI)
+
+        func refresh() {
+            input[6] &+= 1
+            let z = compress(zero, input)
+            address = compress(zero, z)
+        }
+
+        let startingC = (r == 0 && sl == 0) ? 2 : 0
+        if startingC != 0 { refresh() }
+
+        for i in startingC..<slLen {
+            if i % addressesPerBlock == 0 && !(r == 0 && sl == 0 && i == 2) {
+                refresh()
+            }
+            let col = sl * slLen + i
+            let prevCol = col == 0 ? q - 1 : col - 1
+            let prevBlock = memory[lane][prevCol]
+
+            let pseudoRand = address[i % addressesPerBlock]
+            let j1 = pseudoRand & mask32
+            let j2 = (pseudoRand >> 32) & mask32
+
+            var lPrime = lane
+            if !(r == 0 && sl == 0) { lPrime = Int(j2) % p }
+
+            let zPrime = indexAlpha(j1, r, sl, i, lPrime == lane, q, slLen)
+            let refBlock = memory[lPrime][zPrime]
+
+            let newBlock = compress(prevBlock, refBlock)
+            if r == 0 {
+                memory[lane][col] = newBlock
+            } else {
+                var merged = [UInt64](repeating: 0, count: blockWords)
+                let existing = memory[lane][col]
+                for k in 0..<blockWords { merged[k] = existing[k] ^ newBlock[k] }
+                memory[lane][col] = merged
+            }
+        }
+    }
+
+    static func validate(password: [UInt8], salt: [UInt8], timeCost: Int,
+                         memoryCost: Int, parallelism: Int, tagLength: Int,
+                         key: [UInt8], ad: [UInt8], version: Int) throws {
+        if UInt64(password.count) > mask32 { throw ValidationError.passwordTooLong }
+        if salt.count < 8  { throw ValidationError.saltTooShort }
+        if UInt64(salt.count) > mask32 { throw ValidationError.saltTooLong }
+        if UInt64(key.count)  > mask32 { throw ValidationError.keyTooLong }
+        if UInt64(ad.count)   > mask32 { throw ValidationError.associatedDataTooLong }
+        if tagLength < 4   { throw ValidationError.tagLengthTooSmall }
+        if UInt64(tagLength) > mask32 { throw ValidationError.tagLengthTooLarge }
+        if parallelism < 1 || parallelism > 0xFFFFFF {
+            throw ValidationError.parallelismOutOfRange
+        }
+        if memoryCost < 8 * parallelism { throw ValidationError.memoryCostTooSmall }
+        if UInt64(memoryCost) > mask32 { throw ValidationError.memoryCostTooLarge }
+        if timeCost < 1 { throw ValidationError.timeCostTooSmall }
+        if version != argon2Version { throw ValidationError.unsupportedVersion }
+    }
+
+    public static func argon2i(password: [UInt8], salt: [UInt8],
+                               timeCost: Int, memoryCost: Int,
+                               parallelism: Int, tagLength: Int,
+                               key: [UInt8] = [], associatedData: [UInt8] = [],
+                               version: Int = argon2Version) throws -> [UInt8] {
+        try validate(password: password, salt: salt, timeCost: timeCost,
+                     memoryCost: memoryCost, parallelism: parallelism,
+                     tagLength: tagLength, key: key, ad: associatedData,
+                     version: version)
+
+        let segmentLength = memoryCost / (syncPoints * parallelism)
+        let mPrime = segmentLength * syncPoints * parallelism
+        let q = mPrime / parallelism
+        let slLen = segmentLength
+        let p = parallelism
+        let t = timeCost
+
+        var h0Input = [UInt8]()
+        h0Input.append(contentsOf: le32(p))
+        h0Input.append(contentsOf: le32(tagLength))
+        h0Input.append(contentsOf: le32(memoryCost))
+        h0Input.append(contentsOf: le32(t))
+        h0Input.append(contentsOf: le32(version))
+        h0Input.append(contentsOf: le32(typeI))
+        h0Input.append(contentsOf: le32(password.count)); h0Input.append(contentsOf: password)
+        h0Input.append(contentsOf: le32(salt.count));     h0Input.append(contentsOf: salt)
+        h0Input.append(contentsOf: le32(key.count));      h0Input.append(contentsOf: key)
+        h0Input.append(contentsOf: le32(associatedData.count))
+        h0Input.append(contentsOf: associatedData)
+        let h0 = try Blake2b.hash(h0Input, options: .init(digestSize: 64))
+
+        var memory: [[[UInt64]]] = Array(
+            repeating: Array(repeating: [UInt64](repeating: 0, count: blockWords),
+                             count: q),
+            count: p
+        )
+        for i in 0..<p {
+            var seed0 = h0; seed0.append(contentsOf: le32(0)); seed0.append(contentsOf: le32(i))
+            var seed1 = h0; seed1.append(contentsOf: le32(1)); seed1.append(contentsOf: le32(i))
+            memory[i][0] = bytesToBlock(try blake2bLong(blockSize, seed0))
+            memory[i][1] = bytesToBlock(try blake2bLong(blockSize, seed1))
+        }
+
+        for r in 0..<t {
+            for sl in 0..<syncPoints {
+                for lane in 0..<p {
+                    fillSegment(&memory, r, lane, sl, q, slLen, p, mPrime, t)
+                }
+            }
+        }
+
+        var finalBlock = memory[0][q - 1]
+        for lane in 1..<p {
+            let last = memory[lane][q - 1]
+            for k in 0..<blockWords { finalBlock[k] ^= last[k] }
+        }
+        return try blake2bLong(tagLength, blockToBytes(finalBlock))
+    }
+
+    public static func argon2iHex(password: [UInt8], salt: [UInt8],
+                                  timeCost: Int, memoryCost: Int,
+                                  parallelism: Int, tagLength: Int,
+                                  key: [UInt8] = [], associatedData: [UInt8] = [],
+                                  version: Int = argon2Version) throws -> String {
+        let raw = try argon2i(password: password, salt: salt,
+                              timeCost: timeCost, memoryCost: memoryCost,
+                              parallelism: parallelism, tagLength: tagLength,
+                              key: key, associatedData: associatedData,
+                              version: version)
+        return raw.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/code/packages/swift/argon2i/Tests/Argon2iTests/Argon2iTests.swift
+++ b/code/packages/swift/argon2i/Tests/Argon2iTests/Argon2iTests.swift
@@ -1,0 +1,130 @@
+import XCTest
+@testable import Argon2i
+
+final class Argon2iTests: XCTestCase {
+    func bytes(_ s: String) -> [UInt8] { return Array(s.utf8) }
+    func repeated(_ byte: UInt8, _ n: Int) -> [UInt8] {
+        return [UInt8](repeating: byte, count: n)
+    }
+
+    // RFC 9106 §5.2 gold-standard Argon2i vector.
+    func testRfc9106Section5_2Vector() throws {
+        let tag = try Argon2i.argon2iHex(
+            password: repeated(0x01, 32),
+            salt:     repeated(0x02, 16),
+            timeCost: 3, memoryCost: 32, parallelism: 4, tagLength: 32,
+            key: repeated(0x03, 8),
+            associatedData: repeated(0x04, 12)
+        )
+        XCTAssertEqual(tag,
+            "c814d9d1dc7f37aa13f0d77f2494bda1c8de6b016dd388d29952a4c4672b6ce8")
+    }
+
+    func testHexMatchesBinary() throws {
+        let raw = try Argon2i.argon2i(
+            password: repeated(0x01, 32), salt: repeated(0x02, 16),
+            timeCost: 3, memoryCost: 32, parallelism: 4, tagLength: 32,
+            key: repeated(0x03, 8), associatedData: repeated(0x04, 12))
+        let hex = try Argon2i.argon2iHex(
+            password: repeated(0x01, 32), salt: repeated(0x02, 16),
+            timeCost: 3, memoryCost: 32, parallelism: 4, tagLength: 32,
+            key: repeated(0x03, 8), associatedData: repeated(0x04, 12))
+        XCTAssertEqual(raw.map { String(format: "%02x", $0) }.joined(), hex)
+    }
+
+    func testRejectsShortSalt() {
+        XCTAssertThrowsError(try Argon2i.argon2i(
+            password: bytes("pw"), salt: bytes("short"),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32))
+    }
+
+    func testRejectsZeroTimeCost() {
+        XCTAssertThrowsError(try Argon2i.argon2i(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 0, memoryCost: 8, parallelism: 1, tagLength: 32))
+    }
+
+    func testRejectsTagLengthUnder4() {
+        XCTAssertThrowsError(try Argon2i.argon2i(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 3))
+    }
+
+    func testRejectsMemoryUnder8p() {
+        XCTAssertThrowsError(try Argon2i.argon2i(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 7, parallelism: 1, tagLength: 32))
+    }
+
+    func testRejectsZeroParallelism() {
+        XCTAssertThrowsError(try Argon2i.argon2i(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 0, tagLength: 32))
+    }
+
+    func testRejectsUnsupportedVersion() {
+        XCTAssertThrowsError(try Argon2i.argon2i(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32,
+            version: 0x10))
+    }
+
+    func testDeterministic() throws {
+        let a = try Argon2i.argon2iHex(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32)
+        let b = try Argon2i.argon2iHex(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32)
+        XCTAssertEqual(a, b)
+    }
+
+    func testPasswordAndSaltDifferentiate() throws {
+        let base = try Argon2i.argon2iHex(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32)
+        let diffPw = try Argon2i.argon2iHex(
+            password: bytes("pw2"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32)
+        let diffSalt = try Argon2i.argon2iHex(
+            password: bytes("pw"), salt: repeated(0x62, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32)
+        XCTAssertNotEqual(base, diffPw)
+        XCTAssertNotEqual(base, diffSalt)
+    }
+
+    func testKeyAndAdBind() throws {
+        let none = try Argon2i.argon2iHex(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32)
+        let keyed = try Argon2i.argon2iHex(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32,
+            key: bytes("k"))
+        let ad = try Argon2i.argon2iHex(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32,
+            associatedData: bytes("a"))
+        XCTAssertNotEqual(none, keyed)
+        XCTAssertNotEqual(none, ad)
+    }
+
+    func testTagLengths() throws {
+        for t in [4, 16, 65, 128] {
+            let out = try Argon2i.argon2i(
+                password: bytes("pw"), salt: repeated(0x61, 8),
+                timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: t)
+            XCTAssertEqual(out.count, t)
+        }
+    }
+
+    func testMultiLaneAndMultiPass() throws {
+        let a = try Argon2i.argon2iHex(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 16, parallelism: 2, tagLength: 32)
+        let b = try Argon2i.argon2iHex(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 2, memoryCost: 16, parallelism: 2, tagLength: 32)
+        XCTAssertNotEqual(a, b)
+    }
+}

--- a/code/packages/swift/argon2i/required_capabilities.json
+++ b/code/packages/swift/argon2i/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "swift/argon2i",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/swift/argon2id/.gitignore
+++ b/code/packages/swift/argon2id/.gitignore
@@ -1,0 +1,4 @@
+.build/
+.swiftpm/
+Package.resolved
+*.xcodeproj/

--- a/code/packages/swift/argon2id/BUILD
+++ b/code/packages/swift/argon2id/BUILD
@@ -1,0 +1,1 @@
+if command -v xcrun >/dev/null 2>&1; then xcrun swift test --enable-code-coverage --verbose; else swift test --enable-code-coverage --verbose; fi

--- a/code/packages/swift/argon2id/BUILD_windows
+++ b/code/packages/swift/argon2id/BUILD_windows
@@ -1,0 +1,1 @@
+where swift >nul 2>nul && swift test --enable-code-coverage --verbose || echo Swift not available on this runner - skipping

--- a/code/packages/swift/argon2id/CHANGELOG.md
+++ b/code/packages/swift/argon2id/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## 0.1.0 — 2026-04-20
+
+- Initial from-scratch Swift implementation of Argon2id (RFC 9106).
+- Hybrid fill_segment: data-independent in the first two slices of the
+  first pass, data-dependent thereafter.
+- Depends only on our sibling `Blake2b` Swift package.
+- Verified against the RFC 9106 §5.3 gold-standard vector
+  (`0d640df58d78766c08c037a34a8b53c9d01ef0452d75b65eb52520e96b01e659`).
+- Parameter validation matches RFC 9106 §3.1 bounds, raising
+  typed `Argon2id.ValidationError` values.

--- a/code/packages/swift/argon2id/Package.swift
+++ b/code/packages/swift/argon2id/Package.swift
@@ -1,0 +1,35 @@
+// swift-tools-version: 6.0
+// ============================================================================
+// Package.swift -- Argon2id (RFC 9106)
+// ============================================================================
+//
+// Swift Package Manager manifest for Argon2id, the hybrid Argon2 variant and
+// RFC 9106's recommended password-hashing default. Depends on our sibling
+// Blake2b package for the underlying hash.
+//
+// Part of the coding-adventures educational computing stack.
+// ============================================================================
+
+import PackageDescription
+
+let package = Package(
+    name: "Argon2id",
+    products: [
+        .library(name: "Argon2id", targets: ["Argon2id"]),
+    ],
+    dependencies: [
+        .package(path: "../blake2b"),
+    ],
+    targets: [
+        .target(
+            name: "Argon2id",
+            dependencies: [
+                .product(name: "Blake2b", package: "Blake2b"),
+            ]
+        ),
+        .testTarget(
+            name: "Argon2idTests",
+            dependencies: ["Argon2id"]
+        ),
+    ]
+)

--- a/code/packages/swift/argon2id/README.md
+++ b/code/packages/swift/argon2id/README.md
@@ -1,0 +1,61 @@
+# Argon2id (Swift)
+
+From-scratch Swift implementation of **Argon2id** (RFC 9106) — the
+hybrid Argon2 variant and **RFC 9106's recommended password-hashing
+default**.
+
+Depends only on our sibling `Blake2b` package for the underlying hash.
+
+See the spec at [../../specs/KD03-argon2.md](../../specs/KD03-argon2.md).
+
+## Usage
+
+```swift
+import Argon2id
+
+let tag = try Argon2id.argon2id(
+    password: Array("secret".utf8),
+    salt: Array("0123456789abcdef".utf8),
+    timeCost: 3, memoryCost: 32, parallelism: 4, tagLength: 32
+)
+
+let hex = try Argon2id.argon2idHex(
+    password: Array("secret".utf8),
+    salt: Array("0123456789abcdef".utf8),
+    timeCost: 3, memoryCost: 32, parallelism: 4, tagLength: 32
+)
+```
+
+## Why Argon2id is the default
+
+| Phase                   | Addressing      | What it buys you          |
+|-------------------------|-----------------|---------------------------|
+| First 2 slices of pass 1| **Data-indep.** | Side-channel resistance   |
+| Everything afterwards   | **Data-dep.**   | GPU/ASIC cracking cost    |
+
+The two regimes cover each other's weaknesses. Pick `Argon2d` only for
+proof-of-work where side channels don't matter; pick `Argon2i` only
+when side-channel resistance is the overriding concern.
+
+## Implementation notes
+
+The hybrid switch is purely local to `fillSegment`: when `r == 0 &&
+sl < 2` we run Argon2i's deterministic address stream; otherwise we
+run Argon2d's `prev_block[0]` lookup. All other machinery (H0, H',
+index_alpha, compression G, final XOR) is shared.
+
+## Trust boundary
+
+Argon2 is designed to burn CPU and RAM on purpose. Callers control the
+DoS boundary via `timeCost`, `memoryCost`, and `parallelism`. Don't
+expose those to untrusted input without bounds. Tag comparison is NOT
+provided here — use a constant-time helper when verifying passwords.
+
+## Running the tests
+
+```bash
+swift test --enable-code-coverage
+```
+
+The RFC 9106 §5.3 gold-standard vector is verified along with validation,
+determinism, key/AD binding, and tag-length boundary tests.

--- a/code/packages/swift/argon2id/Sources/Argon2id/Argon2id.swift
+++ b/code/packages/swift/argon2id/Sources/Argon2id/Argon2id.swift
@@ -1,0 +1,329 @@
+// Argon2id.swift -- Argon2id (RFC 9106) -- the RFC-recommended hybrid
+// memory-hard password hashing function.
+//
+// Argon2id is the "hybrid" member of the Argon2 family.  In the first two of
+// the four slices of the first pass it uses Argon2i (data-INDEPENDENT)
+// addressing, and everything afterwards uses Argon2d (data-DEPENDENT)
+// addressing.  That gives you side-channel resistance for the initial
+// memory-fill phase -- when an attacker has the best chance of observing a
+// timing leak -- together with Argon2d's GPU/ASIC resistance for the bulk of
+// the work.
+//
+// Pick this variant unless you have a specific reason to prefer Argon2d
+// (proof-of-work, no side-channel threat) or Argon2i (strict side-channel
+// requirements).
+//
+// Reference: https://datatracker.ietf.org/doc/html/rfc9106
+// See also:  code/specs/KD03-argon2.md
+
+import Foundation
+import Blake2b
+
+public enum Argon2id {
+    static let blockSize: Int = 1024
+    static let blockWords: Int = 128
+    static let syncPoints: Int = 4
+    public static let argon2Version: Int = 0x13
+    static let typeId: Int = 2
+    static let addressesPerBlock: Int = 128   // = blockWords
+
+    static let mask32: UInt64 = 0xFFFFFFFF
+
+    public enum ValidationError: Error, Equatable {
+        case passwordTooLong
+        case saltTooShort
+        case saltTooLong
+        case keyTooLong
+        case associatedDataTooLong
+        case tagLengthTooSmall
+        case tagLengthTooLarge
+        case parallelismOutOfRange
+        case memoryCostTooSmall
+        case memoryCostTooLarge
+        case timeCostTooSmall
+        case unsupportedVersion
+    }
+
+    @inline(__always)
+    static func rotr64(_ x: UInt64, _ n: UInt64) -> UInt64 {
+        return (x >> n) | (x << (64 - n))
+    }
+
+    @inline(__always)
+    static func gb(_ v: inout [UInt64], _ a: Int, _ b: Int, _ c: Int, _ d: Int) {
+        var va = v[a], vb = v[b], vc = v[c], vd = v[d]
+        va = va &+ vb &+ (2 &* (va & mask32) &* (vb & mask32))
+        vd = rotr64(vd ^ va, 32)
+        vc = vc &+ vd &+ (2 &* (vc & mask32) &* (vd & mask32))
+        vb = rotr64(vb ^ vc, 24)
+        va = va &+ vb &+ (2 &* (va & mask32) &* (vb & mask32))
+        vd = rotr64(vd ^ va, 16)
+        vc = vc &+ vd &+ (2 &* (vc & mask32) &* (vd & mask32))
+        vb = rotr64(vb ^ vc, 63)
+        v[a] = va; v[b] = vb; v[c] = vc; v[d] = vd
+    }
+
+    @inline(__always)
+    static func permutationP(_ v: inout [UInt64], _ off: Int) {
+        gb(&v, off + 0, off + 4, off +  8, off + 12)
+        gb(&v, off + 1, off + 5, off +  9, off + 13)
+        gb(&v, off + 2, off + 6, off + 10, off + 14)
+        gb(&v, off + 3, off + 7, off + 11, off + 15)
+        gb(&v, off + 0, off + 5, off + 10, off + 15)
+        gb(&v, off + 1, off + 6, off + 11, off + 12)
+        gb(&v, off + 2, off + 7, off +  8, off + 13)
+        gb(&v, off + 3, off + 4, off +  9, off + 14)
+    }
+
+    static func compress(_ x: [UInt64], _ y: [UInt64]) -> [UInt64] {
+        var r = [UInt64](repeating: 0, count: blockWords)
+        for i in 0..<blockWords { r[i] = x[i] ^ y[i] }
+        var q = r
+        for i in 0..<8 { permutationP(&q, i * 16) }
+        var col = [UInt64](repeating: 0, count: 16)
+        for c in 0..<8 {
+            for rr in 0..<8 {
+                col[2 * rr]     = q[rr * 16 + 2 * c]
+                col[2 * rr + 1] = q[rr * 16 + 2 * c + 1]
+            }
+            permutationP(&col, 0)
+            for rr in 0..<8 {
+                q[rr * 16 + 2 * c]     = col[2 * rr]
+                q[rr * 16 + 2 * c + 1] = col[2 * rr + 1]
+            }
+        }
+        var out = [UInt64](repeating: 0, count: blockWords)
+        for i in 0..<blockWords { out[i] = r[i] ^ q[i] }
+        return out
+    }
+
+    static func blockToBytes(_ block: [UInt64]) -> [UInt8] {
+        var out = [UInt8](repeating: 0, count: blockSize)
+        for i in 0..<blockWords {
+            let w = block[i]
+            for j in 0..<8 { out[i * 8 + j] = UInt8((w >> (8 * j)) & 0xFF) }
+        }
+        return out
+    }
+
+    static func bytesToBlock(_ data: [UInt8]) -> [UInt64] {
+        var out = [UInt64](repeating: 0, count: blockWords)
+        for i in 0..<blockWords {
+            var w: UInt64 = 0
+            for j in 0..<8 { w |= UInt64(data[i * 8 + j]) << (8 * j) }
+            out[i] = w
+        }
+        return out
+    }
+
+    static func le32(_ n: Int) -> [UInt8] {
+        let u = UInt32(truncatingIfNeeded: n)
+        return [UInt8(u & 0xFF), UInt8((u >> 8) & 0xFF),
+                UInt8((u >> 16) & 0xFF), UInt8((u >> 24) & 0xFF)]
+    }
+
+    static func blake2bLong(_ t: Int, _ x: [UInt8]) throws -> [UInt8] {
+        precondition(t > 0, "H' output length must be positive")
+        var input = le32(t); input.append(contentsOf: x)
+        if t <= 64 {
+            return try Blake2b.hash(input, options: .init(digestSize: t))
+        }
+        let r = (t + 31) / 32 - 2
+        var v = try Blake2b.hash(input, options: .init(digestSize: 64))
+        var out = Array(v[0..<32])
+        if r > 1 {
+            for _ in 1..<r {
+                v = try Blake2b.hash(v, options: .init(digestSize: 64))
+                out.append(contentsOf: v[0..<32])
+            }
+        }
+        let finalSize = t - 32 * r
+        v = try Blake2b.hash(v, options: .init(digestSize: finalSize))
+        out.append(contentsOf: v)
+        return out
+    }
+
+    static func indexAlpha(_ j1: UInt64, _ r: Int, _ sl: Int, _ c: Int,
+                           _ sameLane: Bool, _ q: Int, _ slLen: Int) -> Int {
+        let w: Int
+        let start: Int
+        if r == 0 && sl == 0 { w = c - 1; start = 0 }
+        else if r == 0 {
+            if sameLane      { w = sl * slLen + c - 1 }
+            else if c == 0   { w = sl * slLen - 1 }
+            else             { w = sl * slLen }
+            start = 0
+        } else {
+            if sameLane      { w = q - slLen + c - 1 }
+            else if c == 0   { w = q - slLen - 1 }
+            else             { w = q - slLen }
+            start = ((sl + 1) * slLen) % q
+        }
+        let wU = UInt64(w)
+        let x = (j1 &* j1) >> 32
+        let y = (wU &* x) >> 32
+        let rel = Int(UInt64(w) &- 1 &- y)
+        return (start + rel) % q
+    }
+
+    // ------------------------------------------------------------------
+    // fill_segment (Argon2id hybrid).
+    //
+    // Data-INDEPENDENT in the first two slices of the first pass (r == 0,
+    // sl < 2) -- i.e. during initial memory fill where a side-channel
+    // observer has the cleanest view of cache timing -- and data-DEPENDENT
+    // thereafter, which is the zone where GPU/ASIC cracking cost dominates.
+    // ------------------------------------------------------------------
+    static func fillSegment(_ memory: inout [[[UInt64]]],
+                            _ r: Int, _ lane: Int, _ sl: Int,
+                            _ q: Int, _ slLen: Int, _ p: Int,
+                            _ mPrime: Int, _ tTotal: Int) {
+        let dataIndependent = r == 0 && sl < 2
+
+        var input = [UInt64](repeating: 0, count: blockWords)
+        var address = [UInt64](repeating: 0, count: blockWords)
+        let zero = [UInt64](repeating: 0, count: blockWords)
+        if dataIndependent {
+            input[0] = UInt64(r)
+            input[1] = UInt64(lane)
+            input[2] = UInt64(sl)
+            input[3] = UInt64(mPrime)
+            input[4] = UInt64(tTotal)
+            input[5] = UInt64(typeId)
+        }
+
+        func refresh() {
+            input[6] &+= 1
+            let z = compress(zero, input)
+            address = compress(zero, z)
+        }
+
+        let startingC = (r == 0 && sl == 0) ? 2 : 0
+        if dataIndependent && startingC != 0 { refresh() }
+
+        for i in startingC..<slLen {
+            if dataIndependent
+                && i % addressesPerBlock == 0
+                && !(r == 0 && sl == 0 && i == 2) {
+                refresh()
+            }
+
+            let col = sl * slLen + i
+            let prevCol = col == 0 ? q - 1 : col - 1
+            let prevBlock = memory[lane][prevCol]
+
+            let pseudoRand = dataIndependent
+                ? address[i % addressesPerBlock]
+                : prevBlock[0]
+            let j1 = pseudoRand & mask32
+            let j2 = (pseudoRand >> 32) & mask32
+
+            var lPrime = lane
+            if !(r == 0 && sl == 0) { lPrime = Int(j2) % p }
+
+            let zPrime = indexAlpha(j1, r, sl, i, lPrime == lane, q, slLen)
+            let refBlock = memory[lPrime][zPrime]
+
+            let newBlock = compress(prevBlock, refBlock)
+            if r == 0 {
+                memory[lane][col] = newBlock
+            } else {
+                var merged = [UInt64](repeating: 0, count: blockWords)
+                let existing = memory[lane][col]
+                for k in 0..<blockWords { merged[k] = existing[k] ^ newBlock[k] }
+                memory[lane][col] = merged
+            }
+        }
+    }
+
+    static func validate(password: [UInt8], salt: [UInt8], timeCost: Int,
+                         memoryCost: Int, parallelism: Int, tagLength: Int,
+                         key: [UInt8], ad: [UInt8], version: Int) throws {
+        if UInt64(password.count) > mask32 { throw ValidationError.passwordTooLong }
+        if salt.count < 8  { throw ValidationError.saltTooShort }
+        if UInt64(salt.count) > mask32 { throw ValidationError.saltTooLong }
+        if UInt64(key.count)  > mask32 { throw ValidationError.keyTooLong }
+        if UInt64(ad.count)   > mask32 { throw ValidationError.associatedDataTooLong }
+        if tagLength < 4   { throw ValidationError.tagLengthTooSmall }
+        if UInt64(tagLength) > mask32 { throw ValidationError.tagLengthTooLarge }
+        if parallelism < 1 || parallelism > 0xFFFFFF {
+            throw ValidationError.parallelismOutOfRange
+        }
+        if memoryCost < 8 * parallelism { throw ValidationError.memoryCostTooSmall }
+        if UInt64(memoryCost) > mask32 { throw ValidationError.memoryCostTooLarge }
+        if timeCost < 1 { throw ValidationError.timeCostTooSmall }
+        if version != argon2Version { throw ValidationError.unsupportedVersion }
+    }
+
+    public static func argon2id(password: [UInt8], salt: [UInt8],
+                                timeCost: Int, memoryCost: Int,
+                                parallelism: Int, tagLength: Int,
+                                key: [UInt8] = [], associatedData: [UInt8] = [],
+                                version: Int = argon2Version) throws -> [UInt8] {
+        try validate(password: password, salt: salt, timeCost: timeCost,
+                     memoryCost: memoryCost, parallelism: parallelism,
+                     tagLength: tagLength, key: key, ad: associatedData,
+                     version: version)
+
+        let segmentLength = memoryCost / (syncPoints * parallelism)
+        let mPrime = segmentLength * syncPoints * parallelism
+        let q = mPrime / parallelism
+        let slLen = segmentLength
+        let p = parallelism
+        let t = timeCost
+
+        var h0Input = [UInt8]()
+        h0Input.append(contentsOf: le32(p))
+        h0Input.append(contentsOf: le32(tagLength))
+        h0Input.append(contentsOf: le32(memoryCost))
+        h0Input.append(contentsOf: le32(t))
+        h0Input.append(contentsOf: le32(version))
+        h0Input.append(contentsOf: le32(typeId))
+        h0Input.append(contentsOf: le32(password.count)); h0Input.append(contentsOf: password)
+        h0Input.append(contentsOf: le32(salt.count));     h0Input.append(contentsOf: salt)
+        h0Input.append(contentsOf: le32(key.count));      h0Input.append(contentsOf: key)
+        h0Input.append(contentsOf: le32(associatedData.count))
+        h0Input.append(contentsOf: associatedData)
+        let h0 = try Blake2b.hash(h0Input, options: .init(digestSize: 64))
+
+        var memory: [[[UInt64]]] = Array(
+            repeating: Array(repeating: [UInt64](repeating: 0, count: blockWords),
+                             count: q),
+            count: p
+        )
+        for i in 0..<p {
+            var seed0 = h0; seed0.append(contentsOf: le32(0)); seed0.append(contentsOf: le32(i))
+            var seed1 = h0; seed1.append(contentsOf: le32(1)); seed1.append(contentsOf: le32(i))
+            memory[i][0] = bytesToBlock(try blake2bLong(blockSize, seed0))
+            memory[i][1] = bytesToBlock(try blake2bLong(blockSize, seed1))
+        }
+
+        for r in 0..<t {
+            for sl in 0..<syncPoints {
+                for lane in 0..<p {
+                    fillSegment(&memory, r, lane, sl, q, slLen, p, mPrime, t)
+                }
+            }
+        }
+
+        var finalBlock = memory[0][q - 1]
+        for lane in 1..<p {
+            let last = memory[lane][q - 1]
+            for k in 0..<blockWords { finalBlock[k] ^= last[k] }
+        }
+        return try blake2bLong(tagLength, blockToBytes(finalBlock))
+    }
+
+    public static func argon2idHex(password: [UInt8], salt: [UInt8],
+                                   timeCost: Int, memoryCost: Int,
+                                   parallelism: Int, tagLength: Int,
+                                   key: [UInt8] = [], associatedData: [UInt8] = [],
+                                   version: Int = argon2Version) throws -> String {
+        let raw = try argon2id(password: password, salt: salt,
+                               timeCost: timeCost, memoryCost: memoryCost,
+                               parallelism: parallelism, tagLength: tagLength,
+                               key: key, associatedData: associatedData,
+                               version: version)
+        return raw.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/code/packages/swift/argon2id/Tests/Argon2idTests/Argon2idTests.swift
+++ b/code/packages/swift/argon2id/Tests/Argon2idTests/Argon2idTests.swift
@@ -1,0 +1,149 @@
+import XCTest
+@testable import Argon2id
+
+final class Argon2idTests: XCTestCase {
+    func bytes(_ s: String) -> [UInt8] { return Array(s.utf8) }
+    func repeated(_ byte: UInt8, _ n: Int) -> [UInt8] {
+        return [UInt8](repeating: byte, count: n)
+    }
+
+    // RFC 9106 §5.3 gold-standard Argon2id vector.
+    func testRfc9106Section5_3Vector() throws {
+        let tag = try Argon2id.argon2idHex(
+            password: repeated(0x01, 32),
+            salt:     repeated(0x02, 16),
+            timeCost: 3, memoryCost: 32, parallelism: 4, tagLength: 32,
+            key: repeated(0x03, 8),
+            associatedData: repeated(0x04, 12)
+        )
+        XCTAssertEqual(tag,
+            "0d640df58d78766c08c037a34a8b53c9d01ef0452d75b65eb52520e96b01e659")
+    }
+
+    func testHexMatchesBinary() throws {
+        let raw = try Argon2id.argon2id(
+            password: repeated(0x01, 32), salt: repeated(0x02, 16),
+            timeCost: 3, memoryCost: 32, parallelism: 4, tagLength: 32,
+            key: repeated(0x03, 8), associatedData: repeated(0x04, 12))
+        let hex = try Argon2id.argon2idHex(
+            password: repeated(0x01, 32), salt: repeated(0x02, 16),
+            timeCost: 3, memoryCost: 32, parallelism: 4, tagLength: 32,
+            key: repeated(0x03, 8), associatedData: repeated(0x04, 12))
+        XCTAssertEqual(raw.map { String(format: "%02x", $0) }.joined(), hex)
+    }
+
+    // ────────────────────────────────────────────────────────────────
+    // Hybrid distinction: with the same (password, salt, …) inputs,
+    // Argon2id must NOT collide with Argon2d's or Argon2i's RFC vectors.
+    // We don't import Argon2d/Argon2i here to keep the package
+    // standalone, so we just assert the known expected vectors differ.
+    // ────────────────────────────────────────────────────────────────
+    func testDistinctFromArgon2dAndArgon2iVectors() {
+        let idExpected =
+            "0d640df58d78766c08c037a34a8b53c9d01ef0452d75b65eb52520e96b01e659"
+        let dExpected  =
+            "512b391b6f1162975371d30919734294f868e3be3984f3c1a13a4db9fabe4acb"
+        let iExpected  =
+            "c814d9d1dc7f37aa13f0d77f2494bda1c8de6b016dd388d29952a4c4672b6ce8"
+        XCTAssertNotEqual(idExpected, dExpected)
+        XCTAssertNotEqual(idExpected, iExpected)
+    }
+
+    // --- Validation rejections ---
+    func testRejectsShortSalt() {
+        XCTAssertThrowsError(try Argon2id.argon2id(
+            password: bytes("pw"), salt: bytes("short"),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32))
+    }
+
+    func testRejectsZeroTimeCost() {
+        XCTAssertThrowsError(try Argon2id.argon2id(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 0, memoryCost: 8, parallelism: 1, tagLength: 32))
+    }
+
+    func testRejectsTagLengthUnder4() {
+        XCTAssertThrowsError(try Argon2id.argon2id(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 3))
+    }
+
+    func testRejectsMemoryUnder8p() {
+        XCTAssertThrowsError(try Argon2id.argon2id(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 7, parallelism: 1, tagLength: 32))
+    }
+
+    func testRejectsZeroParallelism() {
+        XCTAssertThrowsError(try Argon2id.argon2id(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 0, tagLength: 32))
+    }
+
+    func testRejectsUnsupportedVersion() {
+        XCTAssertThrowsError(try Argon2id.argon2id(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32,
+            version: 0x10))
+    }
+
+    // --- Determinism, key/AD binding, tag lengths ---
+    func testDeterministic() throws {
+        let a = try Argon2id.argon2idHex(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32)
+        let b = try Argon2id.argon2idHex(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32)
+        XCTAssertEqual(a, b)
+    }
+
+    func testPasswordAndSaltDifferentiate() throws {
+        let base = try Argon2id.argon2idHex(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32)
+        let diffPw = try Argon2id.argon2idHex(
+            password: bytes("pw2"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32)
+        let diffSalt = try Argon2id.argon2idHex(
+            password: bytes("pw"), salt: repeated(0x62, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32)
+        XCTAssertNotEqual(base, diffPw)
+        XCTAssertNotEqual(base, diffSalt)
+    }
+
+    func testKeyAndAdBind() throws {
+        let none = try Argon2id.argon2idHex(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32)
+        let keyed = try Argon2id.argon2idHex(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32,
+            key: bytes("k"))
+        let withAd = try Argon2id.argon2idHex(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: 32,
+            associatedData: bytes("a"))
+        XCTAssertNotEqual(none, keyed)
+        XCTAssertNotEqual(none, withAd)
+    }
+
+    func testTagLengths() throws {
+        for t in [4, 16, 65, 128] {
+            let out = try Argon2id.argon2id(
+                password: bytes("pw"), salt: repeated(0x61, 8),
+                timeCost: 1, memoryCost: 8, parallelism: 1, tagLength: t)
+            XCTAssertEqual(out.count, t)
+        }
+    }
+
+    func testMultiPassDiffers() throws {
+        let a = try Argon2id.argon2idHex(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 1, memoryCost: 16, parallelism: 2, tagLength: 32)
+        let b = try Argon2id.argon2idHex(
+            password: bytes("pw"), salt: repeated(0x61, 8),
+            timeCost: 2, memoryCost: 16, parallelism: 2, tagLength: 32)
+        XCTAssertNotEqual(a, b)
+    }
+}

--- a/code/packages/swift/argon2id/required_capabilities.json
+++ b/code/packages/swift/argon2id/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "swift/argon2id",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}


### PR DESCRIPTION
## Summary

- Adds three new Swift packages mirroring the existing argon2 ports in Ruby, Elixir, Lua, and Perl: `argon2d`, `argon2i`, `argon2id`.
- Each depends only on the sibling `Blake2b` Swift package — pure computation, no capabilities, no I/O, no unsafe.
- Each verifies against its RFC 9106 gold-standard vector:
  - argon2d  (§5.1) `512b391b6f1162975371d30919734294f868e3be3984f3c1a13a4db9fabe4acb`
  - argon2i  (§5.2) `c814d9d1dc7f37aa13f0d77f2494bda1c8de6b016dd388d29952a4c4672b6ce8`
  - argon2id (§5.3) `0d640df58d78766c08c037a34a8b53c9d01ef0452d75b65eb52520e96b01e659`

Uses native `UInt64` wrapping operators (`&+`, `&*`) in the G-mixer so the Swift source reads almost exactly like the Perl/Ruby/Lua ports.

## Test plan

- [x] `swift test` in `code/packages/swift/argon2d` (16 tests, incl. §5.1 gold vector)
- [x] `swift test` in `code/packages/swift/argon2i` (13 tests, incl. §5.2 gold vector)
- [x] `swift test` in `code/packages/swift/argon2id` (14 tests, incl. §5.3 gold vector)
- [x] `/security-review` passed on the diff — no findings
- [ ] CI green on Linux + macOS Swift runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)