### PR TITLE
feat(argon2-haskell): port Argon2d/Argon2i/Argon2id to Haskell (RFC 9106)

### DIFF
--- a/code/packages/haskell/argon2d/.gitignore
+++ b/code/packages/haskell/argon2d/.gitignore
@@ -1,0 +1,5 @@
+dist-newstyle/
+dist/
+.ghc.environment.*
+*.hi
+*.o

--- a/code/packages/haskell/argon2d/BUILD
+++ b/code/packages/haskell/argon2d/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/argon2d/BUILD_windows
+++ b/code/packages/haskell/argon2d/BUILD_windows
@@ -1,0 +1,1 @@
+if exist "%ProgramFiles%\\cabal\\bin\\cabal.exe" (cabal test all) else (echo cabal not found -- skipping)

--- a/code/packages/haskell/argon2d/CHANGELOG.md
+++ b/code/packages/haskell/argon2d/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this package are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] — 2026-04-20
+
+### Added
+
+- Initial pure-Haskell Argon2d implementation following RFC 9106.
+- `argon2d` / `argon2dHex` high-level API returning the raw tag or a
+  lowercase-hex string.
+- `argon2Version` constant for the only approved v1.3 (0x13) version.
+- G-mixer with the full BLAKE2 quarter-round plus Argon2's
+  `2 * trunc32(a) * trunc32(b)` cross-term, using native `Word64`
+  wrap-on-overflow.
+- H' variable-length hash (RFC §3.3) with correct chain length —
+  `r = ceil(t/32) - 2` 64-byte blocks then a final `t - 32r`-byte
+  block.
+- Data-dependent `fillSegment`: reference-block indices derived from
+  the previous block's first 64 bits.
+- `index_alpha` biasing (RFC §3.4.1.1) toward more recently computed
+  blocks.
+- Input validation for password/salt/key/AD length (32-bit cap),
+  parallelism in `[1, 2^24-1]`, `memory_cost >= 8*parallelism`,
+  `time_cost >= 1`, `tag_length >= 4`, and version exactly `0x13`.
+- Hspec test suite covering the RFC 9106 §5.1 canonical vector,
+  validation rejections, determinism, input-binding, tag-length
+  variants (4 / 16 / 65 / 128 bytes) and multi-pass correctness.

--- a/code/packages/haskell/argon2d/README.md
+++ b/code/packages/haskell/argon2d/README.md
@@ -1,0 +1,67 @@
+# argon2d (Haskell)
+
+Pure-Haskell implementation of **Argon2d** (RFC 9106) — the
+data-dependent variant of the Argon2 memory-hard password-hashing and
+key-derivation function.
+
+Argon2 won the 2015 Password Hashing Competition. Argon2d is the
+"maximum ASIC resistance" variant: the index of every reference block
+is derived from the previous block's contents, which makes memory-access
+patterns correlated with the password. That wins cost per guess on
+GPUs/FPGAs but leaks a timing side channel — so use Argon2d only when
+side-channel attacks are outside the threat model. Prime example:
+proof-of-work style schedules where the inputs are public. For general
+password hashing prefer sibling `argon2id`.
+
+## Usage
+
+```haskell
+import Argon2d (argon2d, argon2dHex, argon2Version)
+
+main :: IO ()
+main = do
+    let password = replicate 32 0x01
+        salt     = replicate 16 0x02
+        key      = replicate 8  0x03
+        ad       = replicate 12 0x04
+    putStrLn $ argon2dHex password salt 3 32 4 32 key ad argon2Version
+    -- 512b391b6f1162975371d30919734294f868e3be3984f3c1a13a4db9fabe4acb
+```
+
+The API returns `[Word8]` (or hex via `argon2dHex`); use sibling
+`blake2b`'s helpers or your own encoder to convert to/from strings.
+
+### Parameters
+
+| Argument         | Meaning                                            |
+| ---------------- | -------------------------------------------------- |
+| `password`       | `[Word8]`; any length ≤ 2³²−1 bytes                |
+| `salt`           | `[Word8]`; **≥ 8 bytes** (16+ recommended)         |
+| `timeCost`       | Number of passes over memory (≥ 1)                 |
+| `memoryCost`     | KiB of memory (≥ `8 * parallelism`)                |
+| `parallelism`    | Lanes (`[1, 2²⁴−1]`)                               |
+| `tagLength`      | Output length in bytes (≥ 4)                       |
+| `key`            | Optional MAC secret (`[]` if none)                 |
+| `associatedData` | Optional context bytes (`[]` if none)              |
+| `version`        | Must be `argon2Version` (`0x13`)                   |
+
+## Trust boundary
+
+All length inputs must fit in 32 bits; this is validated at the entry
+points. DoS from oversized `memory_cost` or `time_cost` is the caller's
+responsibility — the library performs exactly the work requested.
+
+## Dependencies
+
+- `base`
+- `array` (for `UArray Word64` blocks and the boxed memory matrix)
+- sibling [`blake2b`](../blake2b) package
+
+## Fit in the stack
+
+This package is a leaf primitive under `code/packages/haskell/`. It
+powers the Haskell strand of higher-level constructions in Vault and
+any language-parity test harnesses. Siblings:
+
+- [`argon2i`](../argon2i) — data-independent variant
+- [`argon2id`](../argon2id) — hybrid, recommended default

--- a/code/packages/haskell/argon2d/argon2d.cabal
+++ b/code/packages/haskell/argon2d/argon2d.cabal
@@ -1,0 +1,27 @@
+cabal-version: 3.0
+name:          argon2d
+version:       0.1.0
+synopsis:      Argon2d (RFC 9106) data-dependent memory-hard KDF, from scratch
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  Argon2d
+    build-depends:    base >=4.14
+                    , array
+                    , blake2b
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    Argon2dSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , argon2d
+                    , array
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/argon2d/cabal.project
+++ b/code/packages/haskell/argon2d/cabal.project
@@ -1,0 +1,2 @@
+packages: .
+          ../blake2b

--- a/code/packages/haskell/argon2d/required_capabilities.json
+++ b/code/packages/haskell/argon2d/required_capabilities.json
@@ -1,0 +1,4 @@
+{
+  "capabilities": [],
+  "justification": "Pure computation over in-memory byte arrays; no filesystem, network, or process access."
+}

--- a/code/packages/haskell/argon2d/src/Argon2d.hs
+++ b/code/packages/haskell/argon2d/src/Argon2d.hs
@@ -1,0 +1,350 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE FlexibleContexts #-}
+-- | Pure-Haskell Argon2d (RFC 9106) memory-hard password hashing.
+--
+-- Argon2d is the data-DEPENDENT variant of the Argon2 family: the index of
+-- every reference block comes from the first 64 bits of the previously
+-- computed block.  That correlation with the password maximises GPU/ASIC
+-- resistance but leaks a timing side channel through memory-access pattern.
+-- Use Argon2d only when side-channel attacks are NOT in the threat model
+-- (proof-of-work schemes, etc.).  For general password hashing prefer
+-- Argon2id.
+--
+-- Reference: <https://datatracker.ietf.org/doc/html/rfc9106>
+--
+-- == Haskell 64-bit notes
+--
+-- All 64-bit arithmetic uses 'Word64' with native wrap-on-overflow.  The
+-- G-mixer's @2 * trunc32(a) * trunc32(b)@ cross-term is computed on
+-- 'Word64' and wraps mod 2^64 automatically -- exactly what the spec wants.
+--
+-- The memory matrix is @Array (Int, Int) Block@ where 'Block' is a
+-- 128-word @UArray Int Word64@.  RFC test-sized vectors fit in a few KiB,
+-- so the O(n) cost of functional array updates is not a real concern.
+module Argon2d
+    ( -- * High-level API
+      argon2d
+    , argon2dHex
+      -- * Constants
+    , argon2Version
+    ) where
+
+import Blake2b (Params (..), blake2bWith, defaultParams)
+import qualified Data.Array as A
+import Data.Array.Unboxed (UArray, listArray, elems, (!), (//))
+import Data.Bits ((.&.), (.|.), rotateR, shiftL, shiftR, xor)
+import Data.Char (intToDigit)
+import Data.Word (Word8, Word64)
+
+-- ---------------------------------------------------------------------
+-- Constants (RFC 9106 §3)
+-- ---------------------------------------------------------------------
+blockSize :: Int
+blockSize = 1024             -- bytes per Argon2 memory block
+
+blockWords :: Int
+blockWords = 128             -- 64-bit words per block
+
+syncPoints :: Int
+syncPoints = 4               -- slices per pass
+
+-- | The only approved Argon2 version.
+argon2Version :: Int
+argon2Version = 0x13
+
+typeD :: Int
+typeD = 0                    -- primitive type code for Argon2d
+
+mask32 :: Word64
+mask32 = 0xFFFFFFFF
+
+type Block = UArray Int Word64
+
+-- ---------------------------------------------------------------------
+-- G-mixer (RFC 9106 §3.5).
+--
+-- BLAKE2's quarter-round PLUS the Argon2 @2 * trunc32(a) * trunc32(b)@
+-- cross-term per add.  Word64 arithmetic wraps naturally.
+-- ---------------------------------------------------------------------
+gMix :: Word64 -> Word64 -> Word64 -> Word64
+     -> (Word64, Word64, Word64, Word64)
+gMix va vb vc vd =
+    let va1 = va + vb + 2 * (va .&. mask32) * (vb .&. mask32)
+        vd1 = rotateR (vd `xor` va1) 32
+        vc1 = vc + vd1 + 2 * (vc .&. mask32) * (vd1 .&. mask32)
+        vb1 = rotateR (vb `xor` vc1) 24
+        va2 = va1 + vb1 + 2 * (va1 .&. mask32) * (vb1 .&. mask32)
+        vd2 = rotateR (vd1 `xor` va2) 16
+        vc2 = vc1 + vd2 + 2 * (vc1 .&. mask32) * (vd2 .&. mask32)
+        vb2 = rotateR (vb1 `xor` vc2) 63
+     in (va2, vb2, vc2, vd2)
+
+-- One 8-round permutation P across a 16-word slice.  Four "column" rounds
+-- on (0,4,8,12) etc. followed by four "diagonal" rounds on (0,5,10,15) etc.
+permutationP :: Block -> Int -> Block
+permutationP v off =
+    let step ary a b c d =
+            let (va', vb', vc', vd') =
+                    gMix (ary ! a) (ary ! b) (ary ! c) (ary ! d)
+             in ary // [(a, va'), (b, vb'), (c, vc'), (d, vd')]
+        v1 = step v  (off + 0) (off + 4) (off +  8) (off + 12)
+        v2 = step v1 (off + 1) (off + 5) (off +  9) (off + 13)
+        v3 = step v2 (off + 2) (off + 6) (off + 10) (off + 14)
+        v4 = step v3 (off + 3) (off + 7) (off + 11) (off + 15)
+        v5 = step v4 (off + 0) (off + 5) (off + 10) (off + 15)
+        v6 = step v5 (off + 1) (off + 6) (off + 11) (off + 12)
+        v7 = step v6 (off + 2) (off + 7) (off +  8) (off + 13)
+        v8 = step v7 (off + 3) (off + 4) (off +  9) (off + 14)
+     in v8
+
+-- | Compression function G: @r := x XOR y; row-pass; column-pass; r XOR q@.
+compress :: Block -> Block -> Block
+compress x y =
+    let r  = listArray (0, blockWords - 1)
+                [ (x ! i) `xor` (y ! i) | i <- [0 .. blockWords - 1] ]
+        q1 = foldl (\acc i -> permutationP acc (i * 16)) r [0 .. 7]
+        q2 = foldl columnPass q1 [0 .. 7]
+     in listArray (0, blockWords - 1)
+            [ (r ! i) `xor` (q2 ! i) | i <- [0 .. blockWords - 1] ]
+
+columnPass :: Block -> Int -> Block
+columnPass q c =
+    let col0 = listArray (0, 15)
+                 [ q ! (rr * 16 + 2 * c + k)
+                 | rr <- [0 .. 7], k <- [0, 1] ]
+        col1 = permutationP col0 0
+        writes =
+            [ (rr * 16 + 2 * c + k, col1 ! (2 * rr + k))
+            | rr <- [0 .. 7], k <- [0, 1] ]
+     in q // writes
+
+-- ---------------------------------------------------------------------
+-- Block <-> byte-string helpers.  Argon2 is little-endian everywhere.
+-- ---------------------------------------------------------------------
+blockToBytes :: Block -> [Word8]
+blockToBytes b = concatMap word64ToLeBytes (elems b)
+
+bytesToBlock :: [Word8] -> Block
+bytesToBlock bs = listArray (0, blockWords - 1)
+                           (map leBytesToWord64 (chunksOf 8 bs))
+
+word64ToLeBytes :: Word64 -> [Word8]
+word64ToLeBytes w =
+    [ fromIntegral ((w `shiftR` (8 * i)) .&. 0xFF) | i <- [0 .. 7 :: Int] ]
+
+leBytesToWord64 :: [Word8] -> Word64
+leBytesToWord64 bs =
+    foldr (\(i, b) acc -> acc .|. (fromIntegral b `shiftL` (8 * i))) 0
+          (zip [0 :: Int ..] bs)
+
+chunksOf :: Int -> [a] -> [[a]]
+chunksOf _ [] = []
+chunksOf n xs = let (h, t) = splitAt n xs in h : chunksOf n t
+
+le32 :: Int -> [Word8]
+le32 n =
+    let w = fromIntegral n :: Word64
+     in [ fromIntegral (w .&. 0xFF)
+        , fromIntegral ((w `shiftR` 8) .&. 0xFF)
+        , fromIntegral ((w `shiftR` 16) .&. 0xFF)
+        , fromIntegral ((w `shiftR` 24) .&. 0xFF)
+        ]
+
+-- ---------------------------------------------------------------------
+-- H' -- Argon2 variable-length hash (RFC 9106 §3.3).
+--
+-- For @t <= 64@: single BLAKE2b call of size @t@.  Otherwise: chain
+-- 64-byte BLAKE2b calls, take the first 32 bytes of each, and finish
+-- with a BLAKE2b call sized to fit exactly.  The initial input is
+-- @LE32(t) || x@.
+-- ---------------------------------------------------------------------
+blake2bLong :: Int -> [Word8] -> [Word8]
+blake2bLong t x
+    | t <= 0 = error "H' output length must be positive"
+    | t <= 64 =
+        blake2bWith defaultParams { digestSize = t } (le32 t ++ x)
+    | otherwise =
+        let r = (t + 31) `div` 32 - 2
+            v0 = blake2bWith defaultParams { digestSize = 64 } (le32 t ++ x)
+            -- Compute v_1 .. v_r (total r+1 blocks), taking the first 32
+            -- bytes of each of the first r blocks.  The final call is
+            -- sized to @finalSize = t - 32r@ and its FULL output is
+            -- appended to the running prefix.
+            go !i !v !accRev
+                | i > r = (v, accRev)
+                | otherwise =
+                    let v' = blake2bWith defaultParams { digestSize = 64 } v
+                     in go (i + 1) v' (take 32 v' : accRev)
+            (vR, middleRev) = go 2 v0 [take 32 v0]
+            finalSize = t - 32 * r
+            vLast = blake2bWith defaultParams { digestSize = finalSize } vR
+         in concat (reverse middleRev) ++ vLast
+
+-- ---------------------------------------------------------------------
+-- index_alpha (RFC 9106 §3.4.1.1).
+-- ---------------------------------------------------------------------
+indexAlpha :: Word64 -> Int -> Int -> Int -> Bool -> Int -> Int -> Int
+indexAlpha j1 r sl c sameLane q slLen =
+    let (w, start)
+          | r == 0 && sl == 0 = (c - 1, 0)
+          | r == 0 =
+                ( if sameLane then sl * slLen + c - 1
+                  else if c == 0 then sl * slLen - 1
+                  else sl * slLen
+                , 0)
+          | otherwise =
+                ( if sameLane then q - slLen + c - 1
+                  else if c == 0 then q - slLen - 1
+                  else q - slLen
+                , ((sl + 1) * slLen) `mod` q )
+        wU  = fromIntegral w :: Word64
+        xx  = (j1 * j1) `shiftR` 32
+        yy  = (wU * xx) `shiftR` 32
+        rel = fromIntegral (wU - 1 - yy) :: Int
+     in (start + rel) `mod` q
+
+-- ---------------------------------------------------------------------
+-- Memory matrix: @Array (Int, Int) Block@ indexed by (lane, column).
+-- ---------------------------------------------------------------------
+type Memory = A.Array (Int, Int) Block
+
+xorBlocks :: Block -> Block -> Block
+xorBlocks a b = listArray (0, blockWords - 1)
+                  [ (a ! i) `xor` (b ! i) | i <- [0 .. blockWords - 1] ]
+
+-- Fill one (pass, slice, lane) segment.  Argon2d is entirely data-
+-- dependent: the low / high 32 bits of the previous block's first word
+-- supply J1 / J2.
+fillSegment
+    :: Memory -> Int -> Int -> Int -> Int -> Int -> Int -> Memory
+fillSegment memory r lane sl q slLen p = foldl step memory [startingC .. slLen - 1]
+  where
+    startingC = if r == 0 && sl == 0 then 2 else 0
+    step mem i =
+        let col      = sl * slLen + i
+            prevCol  = if col == 0 then q - 1 else col - 1
+            prevBlock = mem A.! (lane, prevCol)
+            pseudo   = prevBlock ! 0
+            j1       = pseudo .&. mask32
+            j2       = (pseudo `shiftR` 32) .&. mask32
+            lPrime   = if r == 0 && sl == 0 then lane
+                       else fromIntegral j2 `mod` p
+            zPrime   = indexAlpha j1 r sl i (lPrime == lane) q slLen
+            refBlock = mem A.! (lPrime, zPrime)
+            newBlock = compress prevBlock refBlock
+            finalBlock
+              | r == 0    = newBlock
+              | otherwise = xorBlocks (mem A.! (lane, col)) newBlock
+         in mem A.// [((lane, col), finalBlock)]
+
+-- ---------------------------------------------------------------------
+-- Parameter validation (RFC 9106 §3.1).
+-- ---------------------------------------------------------------------
+validate
+    :: [Word8] -> [Word8] -> Int -> Int -> Int -> Int
+    -> [Word8] -> [Word8] -> Int -> ()
+validate password salt t m p tagLength key ad version
+    | fromIntegral (length password) > (mask32 :: Word64) =
+        error "password length must fit in 32 bits"
+    | length salt < 8 = error "salt must be at least 8 bytes"
+    | fromIntegral (length salt) > (mask32 :: Word64) =
+        error "salt length must fit in 32 bits"
+    | fromIntegral (length key) > (mask32 :: Word64) =
+        error "key length must fit in 32 bits"
+    | fromIntegral (length ad) > (mask32 :: Word64) =
+        error "associated_data length must fit in 32 bits"
+    | tagLength < 4 = error "tag_length must be >= 4"
+    | fromIntegral tagLength > (mask32 :: Word64) =
+        error "tag_length must fit in 32 bits"
+    | p < 1 || p > 0xFFFFFF = error "parallelism must be in [1, 2^24-1]"
+    | m < 8 * p = error "memory_cost must be >= 8*parallelism"
+    | fromIntegral m > (mask32 :: Word64) =
+        error "memory_cost must fit in 32 bits"
+    | t < 1 = error "time_cost must be >= 1"
+    | version /= argon2Version =
+        error "only Argon2 v1.3 (0x13) is supported"
+    | otherwise = ()
+
+-- ---------------------------------------------------------------------
+-- argon2d -- compute the Argon2d tag (RFC 9106 §3).
+--
+-- Parameters mirror the sibling ports:
+--
+-- @
+--   argon2d password salt timeCost memoryCost parallelism tagLength
+--           key associatedData version
+-- @
+--
+-- Use an empty list @[]@ for an absent key or associated-data input.
+-- 'argon2Version' is the canonical version constant (@0x13@).
+-- ---------------------------------------------------------------------
+argon2d
+    :: [Word8]   -- ^ password
+    -> [Word8]   -- ^ salt (>= 8 bytes, 16+ recommended)
+    -> Int       -- ^ timeCost (passes, >= 1)
+    -> Int       -- ^ memoryCost (KiB, >= 8 * parallelism)
+    -> Int       -- ^ parallelism (lanes, [1, 2^24-1])
+    -> Int       -- ^ tagLength (output bytes, >= 4)
+    -> [Word8]   -- ^ key (optional MAC secret)
+    -> [Word8]   -- ^ associatedData (optional context)
+    -> Int       -- ^ version (use 'argon2Version')
+    -> [Word8]
+argon2d password salt timeCost memoryCost parallelism tagLength
+        key ad version =
+    let !_ = validate password salt timeCost memoryCost parallelism
+                      tagLength key ad version
+        segmentLength = memoryCost `div` (syncPoints * parallelism)
+        mPrime        = segmentLength * syncPoints * parallelism
+        q             = mPrime `div` parallelism
+        slLen         = segmentLength
+        p             = parallelism
+        t             = timeCost
+
+        h0Input = concat
+            [ le32 p, le32 tagLength, le32 memoryCost, le32 t
+            , le32 version, le32 typeD
+            , le32 (length password), password
+            , le32 (length salt),     salt
+            , le32 (length key),      key
+            , le32 (length ad),       ad
+            ]
+        h0 = blake2bWith defaultParams { digestSize = 64 } h0Input
+
+        -- Seed blocks (i, 0) and (i, 1) for each lane i.
+        seedPairs =
+            [ ((i, 0), bytesToBlock (blake2bLong blockSize (h0 ++ le32 0 ++ le32 i)))
+            | i <- [0 .. p - 1] ]
+         ++ [ ((i, 1), bytesToBlock (blake2bLong blockSize (h0 ++ le32 1 ++ le32 i)))
+            | i <- [0 .. p - 1] ]
+
+        emptyCell = listArray (0, blockWords - 1) (replicate blockWords 0)
+        empty = A.listArray ((0, 0), (p - 1, q - 1))
+                          (replicate (p * q) emptyCell)
+        memory0 = empty A.// seedPairs
+
+        -- Sequentially run t passes × syncPoints slices × p lanes.
+        memoryFinal = foldl
+            (\mem (r, sl, lane) -> fillSegment mem r lane sl q slLen p)
+            memory0
+            [ (r, sl, lane)
+            | r  <- [0 .. t - 1]
+            , sl <- [0 .. syncPoints - 1]
+            , lane <- [0 .. p - 1]
+            ]
+
+        finalBlock = foldl xorBlocks (memoryFinal A.! (0, q - 1))
+                           [ memoryFinal A.! (lane, q - 1) | lane <- [1 .. p - 1] ]
+     in blake2bLong tagLength (blockToBytes finalBlock)
+
+-- | 'argon2d' as a lowercase hex string.
+argon2dHex
+    :: [Word8] -> [Word8] -> Int -> Int -> Int -> Int
+    -> [Word8] -> [Word8] -> Int -> String
+argon2dHex password salt t m p tagLength key ad version =
+    concatMap renderByte $
+        argon2d password salt t m p tagLength key ad version
+  where
+    renderByte b =
+        let hi = fromIntegral (b `shiftR` 4) :: Int
+            lo = fromIntegral (b .&. 0x0F)   :: Int
+         in [ intToDigit hi, intToDigit lo ]

--- a/code/packages/haskell/argon2d/test/Argon2dSpec.hs
+++ b/code/packages/haskell/argon2d/test/Argon2dSpec.hs
@@ -1,0 +1,117 @@
+-- | Test suite for the pure-Haskell Argon2d implementation.
+--
+-- The canonical vector comes from RFC 9106 §5.1: password = 32 bytes of
+-- 0x01, salt = 16 bytes of 0x02, secret = 8 bytes of 0x03, associated
+-- data = 12 bytes of 0x04, t = 3, m = 32 KiB, p = 4, T = 32 bytes.
+module Argon2dSpec (spec) where
+
+import Argon2d
+import Control.Exception (evaluate)
+import Data.Word (Word8)
+import Test.Hspec
+
+-- RFC 9106 §5.1 fixed inputs
+rfcPassword :: [Word8]
+rfcPassword = replicate 32 0x01
+
+rfcSalt :: [Word8]
+rfcSalt = replicate 16 0x02
+
+rfcKey :: [Word8]
+rfcKey = replicate 8 0x03
+
+rfcAd :: [Word8]
+rfcAd = replicate 12 0x04
+
+rfcExpected :: String
+rfcExpected = "512b391b6f1162975371d30919734294f868e3be3984f3c1a13a4db9fabe4acb"
+
+spec :: Spec
+spec = describe "Argon2d" $ do
+
+    describe "RFC 9106 §5.1 canonical vector" $ do
+
+        it "matches the expected 32-byte tag" $
+            argon2dHex rfcPassword rfcSalt 3 32 4 32 rfcKey rfcAd argon2Version
+                `shouldBe` rfcExpected
+
+        it "hex and binary outputs agree" $ do
+            let bs = argon2d rfcPassword rfcSalt 3 32 4 32 rfcKey rfcAd
+                              argon2Version
+                hx = argon2dHex rfcPassword rfcSalt 3 32 4 32 rfcKey rfcAd
+                                argon2Version
+            length bs `shouldBe` 32
+            length hx `shouldBe` 64
+
+    describe "input validation" $ do
+
+        let run pw sl t m p tl =
+                argon2d pw sl t m p tl [] [] argon2Version
+
+        it "rejects salt shorter than 8 bytes" $
+            evaluate (run [] (replicate 7 0x00) 1 8 1 32)
+                `shouldThrow` anyErrorCall
+
+        it "rejects tag length < 4" $
+            evaluate (run [] (replicate 16 0x00) 1 8 1 3)
+                `shouldThrow` anyErrorCall
+
+        it "rejects parallelism = 0" $
+            evaluate (run [] (replicate 16 0x00) 1 8 0 32)
+                `shouldThrow` anyErrorCall
+
+        it "rejects time_cost = 0" $
+            evaluate (run [] (replicate 16 0x00) 0 8 1 32)
+                `shouldThrow` anyErrorCall
+
+        it "rejects memory_cost < 8*parallelism" $
+            evaluate (run [] (replicate 16 0x00) 1 4 2 32)
+                `shouldThrow` anyErrorCall
+
+        it "rejects an unsupported version" $
+            evaluate
+                (argon2d [] (replicate 16 0x00) 1 8 1 32 [] [] 0x10)
+                `shouldThrow` anyErrorCall
+
+    describe "determinism and input binding" $ do
+
+        let base = argon2d rfcPassword rfcSalt 1 16 1 32 [] [] argon2Version
+
+        it "produces the same output for the same inputs" $
+            argon2d rfcPassword rfcSalt 1 16 1 32 [] [] argon2Version
+                `shouldBe` base
+
+        it "changes when the password changes" $
+            argon2d (replicate 32 0x05) rfcSalt 1 16 1 32 [] []
+                    argon2Version
+                `shouldNotBe` base
+
+        it "changes when the salt changes" $
+            argon2d rfcPassword (replicate 16 0x09) 1 16 1 32 [] []
+                    argon2Version
+                `shouldNotBe` base
+
+        it "changes when a key is added" $
+            argon2d rfcPassword rfcSalt 1 16 1 32 rfcKey [] argon2Version
+                `shouldNotBe` base
+
+        it "changes when associated data is added" $
+            argon2d rfcPassword rfcSalt 1 16 1 32 [] rfcAd argon2Version
+                `shouldNotBe` base
+
+    describe "tag length variants" $ do
+
+        let at tl = length
+                (argon2d rfcPassword rfcSalt 1 16 1 tl [] [] argon2Version)
+
+        it "returns exactly 4 bytes when requested"   $ at 4   `shouldBe` 4
+        it "returns exactly 16 bytes when requested"  $ at 16  `shouldBe` 16
+        it "returns exactly 65 bytes when requested"  $ at 65  `shouldBe` 65
+        it "returns exactly 128 bytes when requested" $ at 128 `shouldBe` 128
+
+    describe "multi-pass correctness" $ do
+
+        it "yields a different tag for t=2 vs t=1 (same other params)" $
+            argon2d rfcPassword rfcSalt 2 16 1 32 [] [] argon2Version
+                `shouldNotBe`
+                    argon2d rfcPassword rfcSalt 1 16 1 32 [] [] argon2Version

--- a/code/packages/haskell/argon2d/test/Spec.hs
+++ b/code/packages/haskell/argon2d/test/Spec.hs
@@ -1,0 +1,7 @@
+module Main (main) where
+
+import Argon2dSpec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/argon2i/.gitignore
+++ b/code/packages/haskell/argon2i/.gitignore
@@ -1,0 +1,5 @@
+dist-newstyle/
+dist/
+.ghc.environment.*
+*.hi
+*.o

--- a/code/packages/haskell/argon2i/BUILD
+++ b/code/packages/haskell/argon2i/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/argon2i/BUILD_windows
+++ b/code/packages/haskell/argon2i/BUILD_windows
@@ -1,0 +1,1 @@
+if exist "%ProgramFiles%\\cabal\\bin\\cabal.exe" (cabal test all) else (echo cabal not found -- skipping)

--- a/code/packages/haskell/argon2i/CHANGELOG.md
+++ b/code/packages/haskell/argon2i/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this package are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] — 2026-04-20
+
+### Added
+
+- Initial pure-Haskell Argon2i implementation following RFC 9106.
+- `argon2i` / `argon2iHex` high-level API.
+- `argon2Version` constant (`0x13`).
+- Data-independent `fillSegment` driven by a deterministic address
+  stream: `double-G(0, compress(0, (r, lane, slice, m', t_total,
+  TYPE_I, counter)))` with a 128-word chunk refreshed lazily.
+- Shared G-mixer, permutation P, compression G, H' variable-length
+  hash, `index_alpha`, and input validation identical to the sibling
+  `argon2d` package.
+- Hspec test suite matching the RFC 9106 §5.2 canonical vector and
+  covering validation, determinism, input-binding, tag-length variants,
+  and a side-channel sanity check.

--- a/code/packages/haskell/argon2i/README.md
+++ b/code/packages/haskell/argon2i/README.md
@@ -1,0 +1,39 @@
+# argon2i (Haskell)
+
+Pure-Haskell implementation of **Argon2i** (RFC 9106) — the
+data-independent variant of the Argon2 memory-hard password-hashing
+and key-derivation function.
+
+Argon2i picks reference blocks from a deterministic address stream that
+only depends on public parameters (pass, lane, slice, m', total time,
+type, counter) — never on the password. That eliminates the timing side
+channel that Argon2d has, at the cost of some GPU/ASIC resistance.
+
+For general password hashing, prefer the hybrid
+[`argon2id`](../argon2id). Use this package when side-channel safety is
+explicitly required and you are comfortable with the performance
+trade-off.
+
+## Usage
+
+```haskell
+import Argon2i (argon2i, argon2iHex, argon2Version)
+
+main :: IO ()
+main = do
+    let password = replicate 32 0x01
+        salt     = replicate 16 0x02
+        key      = replicate 8  0x03
+        ad       = replicate 12 0x04
+    putStrLn $ argon2iHex password salt 3 32 4 32 key ad argon2Version
+    -- c814d9d1dc7f37aa13f0d77f2494bda1c8de6b016dd388d29952a4c4672b6ce8
+```
+
+Parameters, validation rules, and trust boundary match the sibling
+`argon2d` package.
+
+## Dependencies
+
+- `base`
+- `array`
+- sibling [`blake2b`](../blake2b)

--- a/code/packages/haskell/argon2i/argon2i.cabal
+++ b/code/packages/haskell/argon2i/argon2i.cabal
@@ -1,0 +1,27 @@
+cabal-version: 3.0
+name:          argon2i
+version:       0.1.0
+synopsis:      Argon2i (RFC 9106) data-independent memory-hard KDF, from scratch
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  Argon2i
+    build-depends:    base >=4.14
+                    , array
+                    , blake2b
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    Argon2iSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , argon2i
+                    , array
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/argon2i/cabal.project
+++ b/code/packages/haskell/argon2i/cabal.project
@@ -1,0 +1,2 @@
+packages: .
+          ../blake2b

--- a/code/packages/haskell/argon2i/required_capabilities.json
+++ b/code/packages/haskell/argon2i/required_capabilities.json
@@ -1,0 +1,4 @@
+{
+  "capabilities": [],
+  "justification": "Pure computation over in-memory byte arrays; no filesystem, network, or process access."
+}

--- a/code/packages/haskell/argon2i/src/Argon2i.hs
+++ b/code/packages/haskell/argon2i/src/Argon2i.hs
@@ -1,0 +1,325 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE FlexibleContexts #-}
+-- | Pure-Haskell Argon2i (RFC 9106) memory-hard password hashing.
+--
+-- Argon2i is the data-INDEPENDENT variant of Argon2: reference-block
+-- indices are derived from a deterministic address stream that depends
+-- only on public parameters @(pass, lane, slice, m', t_total, TYPE_I,
+-- counter)@, NOT on the password.  That eliminates the timing side
+-- channel that Argon2d has but costs some GPU/ASIC resistance.  Use
+-- Argon2i when side-channel safety is required.  Prefer Argon2id as
+-- the general-purpose password-hashing default.
+--
+-- Reference: <https://datatracker.ietf.org/doc/html/rfc9106>
+module Argon2i
+    ( argon2i
+    , argon2iHex
+    , argon2Version
+    ) where
+
+import Blake2b (Params (..), blake2bWith, defaultParams)
+import qualified Data.Array as A
+import Data.Array.Unboxed (UArray, listArray, elems, (!), (//))
+import Data.Bits ((.&.), (.|.), rotateR, shiftL, shiftR, xor)
+import Data.Char (intToDigit)
+import Data.Word (Word8, Word64)
+
+-- ---------------------------------------------------------------------
+-- Constants (RFC 9106 §3)
+-- ---------------------------------------------------------------------
+blockSize, blockWords, syncPoints, addressesPerBlock, typeI :: Int
+blockSize         = 1024
+blockWords        = 128
+syncPoints        = 4
+addressesPerBlock = 128
+typeI             = 1
+
+argon2Version :: Int
+argon2Version = 0x13
+
+mask32 :: Word64
+mask32 = 0xFFFFFFFF
+
+type Block = UArray Int Word64
+
+-- ---------------------------------------------------------------------
+-- G-mixer, permutation P, compression G (same as Argon2d).
+-- ---------------------------------------------------------------------
+gMix :: Word64 -> Word64 -> Word64 -> Word64
+     -> (Word64, Word64, Word64, Word64)
+gMix va vb vc vd =
+    let va1 = va + vb + 2 * (va .&. mask32) * (vb .&. mask32)
+        vd1 = rotateR (vd `xor` va1) 32
+        vc1 = vc + vd1 + 2 * (vc .&. mask32) * (vd1 .&. mask32)
+        vb1 = rotateR (vb `xor` vc1) 24
+        va2 = va1 + vb1 + 2 * (va1 .&. mask32) * (vb1 .&. mask32)
+        vd2 = rotateR (vd1 `xor` va2) 16
+        vc2 = vc1 + vd2 + 2 * (vc1 .&. mask32) * (vd2 .&. mask32)
+        vb2 = rotateR (vb1 `xor` vc2) 63
+     in (va2, vb2, vc2, vd2)
+
+permutationP :: Block -> Int -> Block
+permutationP v off =
+    let step ary a b c d =
+            let (va', vb', vc', vd') =
+                    gMix (ary ! a) (ary ! b) (ary ! c) (ary ! d)
+             in ary // [(a, va'), (b, vb'), (c, vc'), (d, vd')]
+        v1 = step v  (off + 0) (off + 4) (off +  8) (off + 12)
+        v2 = step v1 (off + 1) (off + 5) (off +  9) (off + 13)
+        v3 = step v2 (off + 2) (off + 6) (off + 10) (off + 14)
+        v4 = step v3 (off + 3) (off + 7) (off + 11) (off + 15)
+        v5 = step v4 (off + 0) (off + 5) (off + 10) (off + 15)
+        v6 = step v5 (off + 1) (off + 6) (off + 11) (off + 12)
+        v7 = step v6 (off + 2) (off + 7) (off +  8) (off + 13)
+        v8 = step v7 (off + 3) (off + 4) (off +  9) (off + 14)
+     in v8
+
+compress :: Block -> Block -> Block
+compress x y =
+    let r  = listArray (0, blockWords - 1)
+                [ (x ! i) `xor` (y ! i) | i <- [0 .. blockWords - 1] ]
+        q1 = foldl (\acc i -> permutationP acc (i * 16)) r [0 .. 7]
+        q2 = foldl columnPass q1 [0 .. 7]
+     in listArray (0, blockWords - 1)
+            [ (r ! i) `xor` (q2 ! i) | i <- [0 .. blockWords - 1] ]
+
+columnPass :: Block -> Int -> Block
+columnPass q c =
+    let col0 = listArray (0, 15)
+                 [ q ! (rr * 16 + 2 * c + k)
+                 | rr <- [0 .. 7], k <- [0, 1] ]
+        col1 = permutationP col0 0
+        writes =
+            [ (rr * 16 + 2 * c + k, col1 ! (2 * rr + k))
+            | rr <- [0 .. 7], k <- [0, 1] ]
+     in q // writes
+
+-- ---------------------------------------------------------------------
+-- Byte helpers
+-- ---------------------------------------------------------------------
+blockToBytes :: Block -> [Word8]
+blockToBytes b = concatMap word64ToLeBytes (elems b)
+
+bytesToBlock :: [Word8] -> Block
+bytesToBlock bs = listArray (0, blockWords - 1)
+                           (map leBytesToWord64 (chunksOf 8 bs))
+
+word64ToLeBytes :: Word64 -> [Word8]
+word64ToLeBytes w =
+    [ fromIntegral ((w `shiftR` (8 * i)) .&. 0xFF) | i <- [0 .. 7 :: Int] ]
+
+leBytesToWord64 :: [Word8] -> Word64
+leBytesToWord64 bs =
+    foldr (\(i, b) acc -> acc .|. (fromIntegral b `shiftL` (8 * i))) 0
+          (zip [0 :: Int ..] bs)
+
+chunksOf :: Int -> [a] -> [[a]]
+chunksOf _ [] = []
+chunksOf n xs = let (h, t) = splitAt n xs in h : chunksOf n t
+
+le32 :: Int -> [Word8]
+le32 n =
+    let w = fromIntegral n :: Word64
+     in [ fromIntegral (w .&. 0xFF)
+        , fromIntegral ((w `shiftR` 8) .&. 0xFF)
+        , fromIntegral ((w `shiftR` 16) .&. 0xFF)
+        , fromIntegral ((w `shiftR` 24) .&. 0xFF)
+        ]
+
+-- ---------------------------------------------------------------------
+-- H' (same as Argon2d)
+-- ---------------------------------------------------------------------
+blake2bLong :: Int -> [Word8] -> [Word8]
+blake2bLong t x
+    | t <= 0 = error "H' output length must be positive"
+    | t <= 64 =
+        blake2bWith defaultParams { digestSize = t } (le32 t ++ x)
+    | otherwise =
+        let r = (t + 31) `div` 32 - 2
+            v0 = blake2bWith defaultParams { digestSize = 64 } (le32 t ++ x)
+            go !i !v !accRev
+                | i > r = (v, accRev)
+                | otherwise =
+                    let v' = blake2bWith defaultParams { digestSize = 64 } v
+                     in go (i + 1) v' (take 32 v' : accRev)
+            (vR, middleRev) = go 2 v0 [take 32 v0]
+            finalSize = t - 32 * r
+            vLast = blake2bWith defaultParams { digestSize = finalSize } vR
+         in concat (reverse middleRev) ++ vLast
+
+-- ---------------------------------------------------------------------
+-- index_alpha
+-- ---------------------------------------------------------------------
+indexAlpha :: Word64 -> Int -> Int -> Int -> Bool -> Int -> Int -> Int
+indexAlpha j1 r sl c sameLane q slLen =
+    let (w, start)
+          | r == 0 && sl == 0 = (c - 1, 0)
+          | r == 0 =
+                ( if sameLane then sl * slLen + c - 1
+                  else if c == 0 then sl * slLen - 1
+                  else sl * slLen
+                , 0)
+          | otherwise =
+                ( if sameLane then q - slLen + c - 1
+                  else if c == 0 then q - slLen - 1
+                  else q - slLen
+                , ((sl + 1) * slLen) `mod` q )
+        wU  = fromIntegral w :: Word64
+        xx  = (j1 * j1) `shiftR` 32
+        yy  = (wU * xx) `shiftR` 32
+        rel = fromIntegral (wU - 1 - yy) :: Int
+     in (start + rel) `mod` q
+
+-- ---------------------------------------------------------------------
+-- Memory matrix
+-- ---------------------------------------------------------------------
+type Memory = A.Array (Int, Int) Block
+
+xorBlocks :: Block -> Block -> Block
+xorBlocks a b = listArray (0, blockWords - 1)
+                  [ (a ! i) `xor` (b ! i) | i <- [0 .. blockWords - 1] ]
+
+zeroBlock :: Block
+zeroBlock = listArray (0, blockWords - 1) (replicate blockWords 0)
+
+-- Derive the @i@-th 128-word address chunk: @double-G(0, compress(0, input))@.
+addressBlock
+    :: Int -> Int -> Int -> Int -> Int -> Int -> Block
+addressBlock r lane sl mPrime tTotal counter =
+    let inputList =
+            [ fromIntegral r      :: Word64
+            , fromIntegral lane   :: Word64
+            , fromIntegral sl     :: Word64
+            , fromIntegral mPrime :: Word64
+            , fromIntegral tTotal :: Word64
+            , fromIntegral typeI  :: Word64
+            , fromIntegral counter:: Word64
+            ] ++ replicate (blockWords - 7) 0
+        inputBlk = listArray (0, blockWords - 1) inputList
+        z        = compress zeroBlock inputBlk
+     in compress zeroBlock z
+
+-- Fill one (pass, slice, lane) segment using the Argon2i address stream.
+fillSegment
+    :: Memory -> Int -> Int -> Int -> Int -> Int -> Int -> Int -> Int -> Memory
+fillSegment memory r lane sl q slLen p mPrime tTotal =
+    foldl step memory [startingC .. slLen - 1]
+  where
+    startingC = if r == 0 && sl == 0 then 2 else 0
+
+    -- Cache address blocks: addressChunk i returns the chunk for 128-aligned i.
+    addressFor i =
+        let chunkIdx = i `div` addressesPerBlock + 1
+         in addressBlock r lane sl mPrime tTotal chunkIdx
+
+    step mem i =
+        let addr      = addressFor i
+            pseudo    = addr ! (i `mod` addressesPerBlock)
+            j1        = pseudo .&. mask32
+            j2        = (pseudo `shiftR` 32) .&. mask32
+            col       = sl * slLen + i
+            prevCol   = if col == 0 then q - 1 else col - 1
+            prevBlock = mem A.! (lane, prevCol)
+            lPrime    = if r == 0 && sl == 0 then lane
+                        else fromIntegral j2 `mod` p
+            zPrime    = indexAlpha j1 r sl i (lPrime == lane) q slLen
+            refBlock  = mem A.! (lPrime, zPrime)
+            newBlock  = compress prevBlock refBlock
+            finalBlock
+              | r == 0    = newBlock
+              | otherwise = xorBlocks (mem A.! (lane, col)) newBlock
+         in mem A.// [((lane, col), finalBlock)]
+
+-- ---------------------------------------------------------------------
+-- Parameter validation
+-- ---------------------------------------------------------------------
+validate
+    :: [Word8] -> [Word8] -> Int -> Int -> Int -> Int
+    -> [Word8] -> [Word8] -> Int -> ()
+validate password salt t m p tagLength key ad version
+    | fromIntegral (length password) > (mask32 :: Word64) =
+        error "password length must fit in 32 bits"
+    | length salt < 8 = error "salt must be at least 8 bytes"
+    | fromIntegral (length salt) > (mask32 :: Word64) =
+        error "salt length must fit in 32 bits"
+    | fromIntegral (length key) > (mask32 :: Word64) =
+        error "key length must fit in 32 bits"
+    | fromIntegral (length ad) > (mask32 :: Word64) =
+        error "associated_data length must fit in 32 bits"
+    | tagLength < 4 = error "tag_length must be >= 4"
+    | fromIntegral tagLength > (mask32 :: Word64) =
+        error "tag_length must fit in 32 bits"
+    | p < 1 || p > 0xFFFFFF = error "parallelism must be in [1, 2^24-1]"
+    | m < 8 * p = error "memory_cost must be >= 8*parallelism"
+    | fromIntegral m > (mask32 :: Word64) =
+        error "memory_cost must fit in 32 bits"
+    | t < 1 = error "time_cost must be >= 1"
+    | version /= argon2Version =
+        error "only Argon2 v1.3 (0x13) is supported"
+    | otherwise = ()
+
+-- ---------------------------------------------------------------------
+-- argon2i
+-- ---------------------------------------------------------------------
+argon2i
+    :: [Word8] -> [Word8] -> Int -> Int -> Int -> Int
+    -> [Word8] -> [Word8] -> Int -> [Word8]
+argon2i password salt timeCost memoryCost parallelism tagLength
+        key ad version =
+    let !_ = validate password salt timeCost memoryCost parallelism
+                      tagLength key ad version
+        segmentLength = memoryCost `div` (syncPoints * parallelism)
+        mPrime        = segmentLength * syncPoints * parallelism
+        q             = mPrime `div` parallelism
+        slLen         = segmentLength
+        p             = parallelism
+        t             = timeCost
+
+        h0Input = concat
+            [ le32 p, le32 tagLength, le32 memoryCost, le32 t
+            , le32 version, le32 typeI
+            , le32 (length password), password
+            , le32 (length salt),     salt
+            , le32 (length key),      key
+            , le32 (length ad),       ad
+            ]
+        h0 = blake2bWith defaultParams { digestSize = 64 } h0Input
+
+        seedPairs =
+            [ ((i, 0), bytesToBlock
+                           (blake2bLong blockSize (h0 ++ le32 0 ++ le32 i)))
+            | i <- [0 .. p - 1] ]
+         ++ [ ((i, 1), bytesToBlock
+                           (blake2bLong blockSize (h0 ++ le32 1 ++ le32 i)))
+            | i <- [0 .. p - 1] ]
+
+        empty   = A.listArray ((0, 0), (p - 1, q - 1))
+                              (replicate (p * q) zeroBlock)
+        memory0 = empty A.// seedPairs
+
+        memoryFinal = foldl
+            (\mem (r, sl, lane) ->
+                 fillSegment mem r lane sl q slLen p mPrime t)
+            memory0
+            [ (r, sl, lane)
+            | r  <- [0 .. t - 1]
+            , sl <- [0 .. syncPoints - 1]
+            , lane <- [0 .. p - 1]
+            ]
+
+        finalBlock = foldl xorBlocks (memoryFinal A.! (0, q - 1))
+                           [ memoryFinal A.! (lane, q - 1)
+                           | lane <- [1 .. p - 1] ]
+     in blake2bLong tagLength (blockToBytes finalBlock)
+
+argon2iHex
+    :: [Word8] -> [Word8] -> Int -> Int -> Int -> Int
+    -> [Word8] -> [Word8] -> Int -> String
+argon2iHex password salt t m p tagLength key ad version =
+    concatMap renderByte $
+        argon2i password salt t m p tagLength key ad version
+  where
+    renderByte b =
+        let hi = fromIntegral (b `shiftR` 4) :: Int
+            lo = fromIntegral (b .&. 0x0F)   :: Int
+         in [ intToDigit hi, intToDigit lo ]

--- a/code/packages/haskell/argon2i/test/Argon2iSpec.hs
+++ b/code/packages/haskell/argon2i/test/Argon2iSpec.hs
@@ -1,0 +1,100 @@
+-- | Test suite for the pure-Haskell Argon2i implementation.
+--
+-- Canonical vector comes from RFC 9106 §5.2.
+module Argon2iSpec (spec) where
+
+import Argon2i
+import Control.Exception (evaluate)
+import Data.Word (Word8)
+import Test.Hspec
+
+rfcPassword, rfcSalt, rfcKey, rfcAd :: [Word8]
+rfcPassword = replicate 32 0x01
+rfcSalt     = replicate 16 0x02
+rfcKey      = replicate 8  0x03
+rfcAd       = replicate 12 0x04
+
+rfcExpected :: String
+rfcExpected = "c814d9d1dc7f37aa13f0d77f2494bda1c8de6b016dd388d29952a4c4672b6ce8"
+
+spec :: Spec
+spec = describe "Argon2i" $ do
+
+    describe "RFC 9106 §5.2 canonical vector" $ do
+
+        it "matches the expected 32-byte tag" $
+            argon2iHex rfcPassword rfcSalt 3 32 4 32 rfcKey rfcAd argon2Version
+                `shouldBe` rfcExpected
+
+    describe "input validation" $ do
+
+        let run pw sl t m p tl =
+                argon2i pw sl t m p tl [] [] argon2Version
+
+        it "rejects salt shorter than 8 bytes" $
+            evaluate (run [] (replicate 7 0x00) 1 8 1 32)
+                `shouldThrow` anyErrorCall
+
+        it "rejects tag length < 4" $
+            evaluate (run [] (replicate 16 0x00) 1 8 1 3)
+                `shouldThrow` anyErrorCall
+
+        it "rejects parallelism = 0" $
+            evaluate (run [] (replicate 16 0x00) 1 8 0 32)
+                `shouldThrow` anyErrorCall
+
+        it "rejects time_cost = 0" $
+            evaluate (run [] (replicate 16 0x00) 0 8 1 32)
+                `shouldThrow` anyErrorCall
+
+        it "rejects memory_cost < 8*parallelism" $
+            evaluate (run [] (replicate 16 0x00) 1 4 2 32)
+                `shouldThrow` anyErrorCall
+
+        it "rejects an unsupported version" $
+            evaluate
+                (argon2i [] (replicate 16 0x00) 1 8 1 32 [] [] 0x10)
+                `shouldThrow` anyErrorCall
+
+    describe "determinism and input binding" $ do
+
+        let base = argon2i rfcPassword rfcSalt 1 16 1 32 [] [] argon2Version
+
+        it "produces the same output for the same inputs" $
+            argon2i rfcPassword rfcSalt 1 16 1 32 [] [] argon2Version
+                `shouldBe` base
+
+        it "changes when the password changes" $
+            argon2i (replicate 32 0x05) rfcSalt 1 16 1 32 [] []
+                    argon2Version
+                `shouldNotBe` base
+
+        it "changes when a key is added" $
+            argon2i rfcPassword rfcSalt 1 16 1 32 rfcKey [] argon2Version
+                `shouldNotBe` base
+
+        it "changes when associated data is added" $
+            argon2i rfcPassword rfcSalt 1 16 1 32 [] rfcAd argon2Version
+                `shouldNotBe` base
+
+    describe "tag length variants" $ do
+
+        let at tl = length
+                (argon2i rfcPassword rfcSalt 1 16 1 tl [] [] argon2Version)
+
+        it "returns exactly 4 bytes"   $ at 4   `shouldBe` 4
+        it "returns exactly 16 bytes"  $ at 16  `shouldBe` 16
+        it "returns exactly 65 bytes"  $ at 65  `shouldBe` 65
+        it "returns exactly 128 bytes" $ at 128 `shouldBe` 128
+
+    describe "side-channel property" $ do
+
+        it "differs from argon2d by using data-independent indexing" $
+            -- Argon2i's address stream doesn't depend on the password,
+            -- so with the same parameters but different password we
+            -- should still get different tag bytes (no early exit).
+            argon2i (replicate 32 0x00) rfcSalt 1 16 1 32 [] []
+                    argon2Version
+                `shouldNotBe`
+                    argon2i (replicate 32 0x01) rfcSalt 1 16 1 32 [] []
+                            argon2Version

--- a/code/packages/haskell/argon2i/test/Spec.hs
+++ b/code/packages/haskell/argon2i/test/Spec.hs
@@ -1,0 +1,7 @@
+module Main (main) where
+
+import Argon2iSpec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/argon2id/.gitignore
+++ b/code/packages/haskell/argon2id/.gitignore
@@ -1,0 +1,5 @@
+dist-newstyle/
+dist/
+.ghc.environment.*
+*.hi
+*.o

--- a/code/packages/haskell/argon2id/BUILD
+++ b/code/packages/haskell/argon2id/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/argon2id/BUILD_windows
+++ b/code/packages/haskell/argon2id/BUILD_windows
@@ -1,0 +1,1 @@
+if exist "%ProgramFiles%\\cabal\\bin\\cabal.exe" (cabal test all) else (echo cabal not found -- skipping)

--- a/code/packages/haskell/argon2id/CHANGELOG.md
+++ b/code/packages/haskell/argon2id/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this package are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] — 2026-04-20
+
+### Added
+
+- Initial pure-Haskell Argon2id implementation following RFC 9106.
+- `argon2id` / `argon2idHex` high-level API.
+- `argon2Version` constant (`0x13`).
+- Hybrid `fillSegment` that picks data-INDEPENDENT addressing during
+  `r == 0 && sl < 2` and data-DEPENDENT addressing everywhere else,
+  matching the Argon2id specification.
+- Shared G-mixer, permutation P, compression G, H' variable-length
+  hash, `index_alpha`, and input validation identical to the sibling
+  `argon2d` / `argon2i` packages.
+- Hspec test suite matching the RFC 9106 §5.3 canonical vector plus
+  validation, determinism, input-binding, tag-length variants, and a
+  cross-variant distinctness check.

--- a/code/packages/haskell/argon2id/README.md
+++ b/code/packages/haskell/argon2id/README.md
@@ -1,0 +1,36 @@
+# argon2id (Haskell)
+
+Pure-Haskell implementation of **Argon2id** (RFC 9106) — the hybrid
+variant of the Argon2 memory-hard password-hashing and key-derivation
+function, recommended by the RFC as the default for most password
+hashing use cases.
+
+Argon2id uses Argon2i's data-INDEPENDENT indexing for the first two
+slices of the first pass (where side-channel exposure is largest,
+because the attacker sees those derivations earliest) and Argon2d's
+data-DEPENDENT indexing for the remaining segments (which maximises
+GPU/ASIC resistance once the side-channel window has closed).
+
+## Usage
+
+```haskell
+import Argon2id (argon2id, argon2idHex, argon2Version)
+
+main :: IO ()
+main = do
+    let password = replicate 32 0x01
+        salt     = replicate 16 0x02
+        key      = replicate 8  0x03
+        ad       = replicate 12 0x04
+    putStrLn $ argon2idHex password salt 3 32 4 32 key ad argon2Version
+    -- 0d640df58d78766c08c037a34a8b53c9d01ef0452d75b65eb52520e96b01e659
+```
+
+Parameters, validation rules, and trust boundary match the sibling
+`argon2d` / `argon2i` packages.
+
+## Dependencies
+
+- `base`
+- `array`
+- sibling [`blake2b`](../blake2b)

--- a/code/packages/haskell/argon2id/argon2id.cabal
+++ b/code/packages/haskell/argon2id/argon2id.cabal
@@ -1,0 +1,27 @@
+cabal-version: 3.0
+name:          argon2id
+version:       0.1.0
+synopsis:      Argon2id (RFC 9106) hybrid memory-hard KDF, from scratch
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+
+library
+    exposed-modules:  Argon2id
+    build-depends:    base >=4.14
+                    , array
+                    , blake2b
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    Argon2idSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14
+                    , argon2id
+                    , array
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/argon2id/cabal.project
+++ b/code/packages/haskell/argon2id/cabal.project
@@ -1,0 +1,2 @@
+packages: .
+          ../blake2b

--- a/code/packages/haskell/argon2id/required_capabilities.json
+++ b/code/packages/haskell/argon2id/required_capabilities.json
@@ -1,0 +1,4 @@
+{
+  "capabilities": [],
+  "justification": "Pure computation over in-memory byte arrays; no filesystem, network, or process access."
+}

--- a/code/packages/haskell/argon2id/src/Argon2id.hs
+++ b/code/packages/haskell/argon2id/src/Argon2id.hs
@@ -1,0 +1,301 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE FlexibleContexts #-}
+-- | Pure-Haskell Argon2id (RFC 9106) memory-hard password hashing.
+--
+-- Argon2id is the recommended default for most password-hashing uses.
+-- It combines Argon2i's data-INDEPENDENT indexing for the first two
+-- slices of the first pass (where side-channel leaks are most dangerous
+-- because the attacker sees the earliest derivations) with Argon2d's
+-- data-DEPENDENT indexing for the remaining segments (maximising
+-- GPU/ASIC resistance once the side-channel window has closed).
+--
+-- Reference: <https://datatracker.ietf.org/doc/html/rfc9106>
+module Argon2id
+    ( argon2id
+    , argon2idHex
+    , argon2Version
+    ) where
+
+import Blake2b (Params (..), blake2bWith, defaultParams)
+import qualified Data.Array as A
+import Data.Array.Unboxed (UArray, listArray, elems, (!), (//))
+import Data.Bits ((.&.), (.|.), rotateR, shiftL, shiftR, xor)
+import Data.Char (intToDigit)
+import Data.Word (Word8, Word64)
+
+blockSize, blockWords, syncPoints, addressesPerBlock, typeID :: Int
+blockSize         = 1024
+blockWords        = 128
+syncPoints        = 4
+addressesPerBlock = 128
+typeID            = 2
+
+argon2Version :: Int
+argon2Version = 0x13
+
+mask32 :: Word64
+mask32 = 0xFFFFFFFF
+
+type Block = UArray Int Word64
+
+gMix :: Word64 -> Word64 -> Word64 -> Word64
+     -> (Word64, Word64, Word64, Word64)
+gMix va vb vc vd =
+    let va1 = va + vb + 2 * (va .&. mask32) * (vb .&. mask32)
+        vd1 = rotateR (vd `xor` va1) 32
+        vc1 = vc + vd1 + 2 * (vc .&. mask32) * (vd1 .&. mask32)
+        vb1 = rotateR (vb `xor` vc1) 24
+        va2 = va1 + vb1 + 2 * (va1 .&. mask32) * (vb1 .&. mask32)
+        vd2 = rotateR (vd1 `xor` va2) 16
+        vc2 = vc1 + vd2 + 2 * (vc1 .&. mask32) * (vd2 .&. mask32)
+        vb2 = rotateR (vb1 `xor` vc2) 63
+     in (va2, vb2, vc2, vd2)
+
+permutationP :: Block -> Int -> Block
+permutationP v off =
+    let step ary a b c d =
+            let (va', vb', vc', vd') =
+                    gMix (ary ! a) (ary ! b) (ary ! c) (ary ! d)
+             in ary // [(a, va'), (b, vb'), (c, vc'), (d, vd')]
+        v1 = step v  (off + 0) (off + 4) (off +  8) (off + 12)
+        v2 = step v1 (off + 1) (off + 5) (off +  9) (off + 13)
+        v3 = step v2 (off + 2) (off + 6) (off + 10) (off + 14)
+        v4 = step v3 (off + 3) (off + 7) (off + 11) (off + 15)
+        v5 = step v4 (off + 0) (off + 5) (off + 10) (off + 15)
+        v6 = step v5 (off + 1) (off + 6) (off + 11) (off + 12)
+        v7 = step v6 (off + 2) (off + 7) (off +  8) (off + 13)
+        v8 = step v7 (off + 3) (off + 4) (off +  9) (off + 14)
+     in v8
+
+compress :: Block -> Block -> Block
+compress x y =
+    let r  = listArray (0, blockWords - 1)
+                [ (x ! i) `xor` (y ! i) | i <- [0 .. blockWords - 1] ]
+        q1 = foldl (\acc i -> permutationP acc (i * 16)) r [0 .. 7]
+        q2 = foldl columnPass q1 [0 .. 7]
+     in listArray (0, blockWords - 1)
+            [ (r ! i) `xor` (q2 ! i) | i <- [0 .. blockWords - 1] ]
+
+columnPass :: Block -> Int -> Block
+columnPass q c =
+    let col0 = listArray (0, 15)
+                 [ q ! (rr * 16 + 2 * c + k)
+                 | rr <- [0 .. 7], k <- [0, 1] ]
+        col1 = permutationP col0 0
+        writes =
+            [ (rr * 16 + 2 * c + k, col1 ! (2 * rr + k))
+            | rr <- [0 .. 7], k <- [0, 1] ]
+     in q // writes
+
+blockToBytes :: Block -> [Word8]
+blockToBytes b = concatMap word64ToLeBytes (elems b)
+
+bytesToBlock :: [Word8] -> Block
+bytesToBlock bs = listArray (0, blockWords - 1)
+                           (map leBytesToWord64 (chunksOf 8 bs))
+
+word64ToLeBytes :: Word64 -> [Word8]
+word64ToLeBytes w =
+    [ fromIntegral ((w `shiftR` (8 * i)) .&. 0xFF) | i <- [0 .. 7 :: Int] ]
+
+leBytesToWord64 :: [Word8] -> Word64
+leBytesToWord64 bs =
+    foldr (\(i, b) acc -> acc .|. (fromIntegral b `shiftL` (8 * i))) 0
+          (zip [0 :: Int ..] bs)
+
+chunksOf :: Int -> [a] -> [[a]]
+chunksOf _ [] = []
+chunksOf n xs = let (h, t) = splitAt n xs in h : chunksOf n t
+
+le32 :: Int -> [Word8]
+le32 n =
+    let w = fromIntegral n :: Word64
+     in [ fromIntegral (w .&. 0xFF)
+        , fromIntegral ((w `shiftR` 8) .&. 0xFF)
+        , fromIntegral ((w `shiftR` 16) .&. 0xFF)
+        , fromIntegral ((w `shiftR` 24) .&. 0xFF)
+        ]
+
+blake2bLong :: Int -> [Word8] -> [Word8]
+blake2bLong t x
+    | t <= 0 = error "H' output length must be positive"
+    | t <= 64 =
+        blake2bWith defaultParams { digestSize = t } (le32 t ++ x)
+    | otherwise =
+        let r = (t + 31) `div` 32 - 2
+            v0 = blake2bWith defaultParams { digestSize = 64 } (le32 t ++ x)
+            go !i !v !accRev
+                | i > r = (v, accRev)
+                | otherwise =
+                    let v' = blake2bWith defaultParams { digestSize = 64 } v
+                     in go (i + 1) v' (take 32 v' : accRev)
+            (vR, middleRev) = go 2 v0 [take 32 v0]
+            finalSize = t - 32 * r
+            vLast = blake2bWith defaultParams { digestSize = finalSize } vR
+         in concat (reverse middleRev) ++ vLast
+
+indexAlpha :: Word64 -> Int -> Int -> Int -> Bool -> Int -> Int -> Int
+indexAlpha j1 r sl c sameLane q slLen =
+    let (w, start)
+          | r == 0 && sl == 0 = (c - 1, 0)
+          | r == 0 =
+                ( if sameLane then sl * slLen + c - 1
+                  else if c == 0 then sl * slLen - 1
+                  else sl * slLen
+                , 0)
+          | otherwise =
+                ( if sameLane then q - slLen + c - 1
+                  else if c == 0 then q - slLen - 1
+                  else q - slLen
+                , ((sl + 1) * slLen) `mod` q )
+        wU  = fromIntegral w :: Word64
+        xx  = (j1 * j1) `shiftR` 32
+        yy  = (wU * xx) `shiftR` 32
+        rel = fromIntegral (wU - 1 - yy) :: Int
+     in (start + rel) `mod` q
+
+type Memory = A.Array (Int, Int) Block
+
+xorBlocks :: Block -> Block -> Block
+xorBlocks a b = listArray (0, blockWords - 1)
+                  [ (a ! i) `xor` (b ! i) | i <- [0 .. blockWords - 1] ]
+
+zeroBlock :: Block
+zeroBlock = listArray (0, blockWords - 1) (replicate blockWords 0)
+
+addressBlock
+    :: Int -> Int -> Int -> Int -> Int -> Int -> Block
+addressBlock r lane sl mPrime tTotal counter =
+    let inputList =
+            [ fromIntegral r      :: Word64
+            , fromIntegral lane   :: Word64
+            , fromIntegral sl     :: Word64
+            , fromIntegral mPrime :: Word64
+            , fromIntegral tTotal :: Word64
+            , fromIntegral typeID :: Word64
+            , fromIntegral counter:: Word64
+            ] ++ replicate (blockWords - 7) 0
+        inputBlk = listArray (0, blockWords - 1) inputList
+        z        = compress zeroBlock inputBlk
+     in compress zeroBlock z
+
+-- | The Argon2id hybrid rule (RFC 9106 §3.4.1.2): data-INDEPENDENT
+-- addressing for @(r == 0) && (sl < 2)@, data-DEPENDENT elsewhere.
+fillSegment
+    :: Memory -> Int -> Int -> Int -> Int -> Int -> Int -> Int -> Int -> Memory
+fillSegment memory r lane sl q slLen p mPrime tTotal =
+    foldl step memory [startingC .. slLen - 1]
+  where
+    startingC = if r == 0 && sl == 0 then 2 else 0
+    dataIndependent = r == 0 && sl < 2
+
+    addressFor i =
+        let chunkIdx = i `div` addressesPerBlock + 1
+         in addressBlock r lane sl mPrime tTotal chunkIdx
+
+    step mem i =
+        let col       = sl * slLen + i
+            prevCol   = if col == 0 then q - 1 else col - 1
+            prevBlock = mem A.! (lane, prevCol)
+            pseudo    = if dataIndependent
+                           then addressFor i ! (i `mod` addressesPerBlock)
+                           else prevBlock ! 0
+            j1        = pseudo .&. mask32
+            j2        = (pseudo `shiftR` 32) .&. mask32
+            lPrime    = if r == 0 && sl == 0 then lane
+                        else fromIntegral j2 `mod` p
+            zPrime    = indexAlpha j1 r sl i (lPrime == lane) q slLen
+            refBlock  = mem A.! (lPrime, zPrime)
+            newBlock  = compress prevBlock refBlock
+            finalBlock
+              | r == 0    = newBlock
+              | otherwise = xorBlocks (mem A.! (lane, col)) newBlock
+         in mem A.// [((lane, col), finalBlock)]
+
+validate
+    :: [Word8] -> [Word8] -> Int -> Int -> Int -> Int
+    -> [Word8] -> [Word8] -> Int -> ()
+validate password salt t m p tagLength key ad version
+    | fromIntegral (length password) > (mask32 :: Word64) =
+        error "password length must fit in 32 bits"
+    | length salt < 8 = error "salt must be at least 8 bytes"
+    | fromIntegral (length salt) > (mask32 :: Word64) =
+        error "salt length must fit in 32 bits"
+    | fromIntegral (length key) > (mask32 :: Word64) =
+        error "key length must fit in 32 bits"
+    | fromIntegral (length ad) > (mask32 :: Word64) =
+        error "associated_data length must fit in 32 bits"
+    | tagLength < 4 = error "tag_length must be >= 4"
+    | fromIntegral tagLength > (mask32 :: Word64) =
+        error "tag_length must fit in 32 bits"
+    | p < 1 || p > 0xFFFFFF = error "parallelism must be in [1, 2^24-1]"
+    | m < 8 * p = error "memory_cost must be >= 8*parallelism"
+    | fromIntegral m > (mask32 :: Word64) =
+        error "memory_cost must fit in 32 bits"
+    | t < 1 = error "time_cost must be >= 1"
+    | version /= argon2Version =
+        error "only Argon2 v1.3 (0x13) is supported"
+    | otherwise = ()
+
+argon2id
+    :: [Word8] -> [Word8] -> Int -> Int -> Int -> Int
+    -> [Word8] -> [Word8] -> Int -> [Word8]
+argon2id password salt timeCost memoryCost parallelism tagLength
+         key ad version =
+    let !_ = validate password salt timeCost memoryCost parallelism
+                      tagLength key ad version
+        segmentLength = memoryCost `div` (syncPoints * parallelism)
+        mPrime        = segmentLength * syncPoints * parallelism
+        q             = mPrime `div` parallelism
+        slLen         = segmentLength
+        p             = parallelism
+        t             = timeCost
+
+        h0Input = concat
+            [ le32 p, le32 tagLength, le32 memoryCost, le32 t
+            , le32 version, le32 typeID
+            , le32 (length password), password
+            , le32 (length salt),     salt
+            , le32 (length key),      key
+            , le32 (length ad),       ad
+            ]
+        h0 = blake2bWith defaultParams { digestSize = 64 } h0Input
+
+        seedPairs =
+            [ ((i, 0), bytesToBlock
+                           (blake2bLong blockSize (h0 ++ le32 0 ++ le32 i)))
+            | i <- [0 .. p - 1] ]
+         ++ [ ((i, 1), bytesToBlock
+                           (blake2bLong blockSize (h0 ++ le32 1 ++ le32 i)))
+            | i <- [0 .. p - 1] ]
+
+        empty   = A.listArray ((0, 0), (p - 1, q - 1))
+                              (replicate (p * q) zeroBlock)
+        memory0 = empty A.// seedPairs
+
+        memoryFinal = foldl
+            (\mem (r, sl, lane) ->
+                 fillSegment mem r lane sl q slLen p mPrime t)
+            memory0
+            [ (r, sl, lane)
+            | r  <- [0 .. t - 1]
+            , sl <- [0 .. syncPoints - 1]
+            , lane <- [0 .. p - 1]
+            ]
+
+        finalBlock = foldl xorBlocks (memoryFinal A.! (0, q - 1))
+                           [ memoryFinal A.! (lane, q - 1)
+                           | lane <- [1 .. p - 1] ]
+     in blake2bLong tagLength (blockToBytes finalBlock)
+
+argon2idHex
+    :: [Word8] -> [Word8] -> Int -> Int -> Int -> Int
+    -> [Word8] -> [Word8] -> Int -> String
+argon2idHex password salt t m p tagLength key ad version =
+    concatMap renderByte $
+        argon2id password salt t m p tagLength key ad version
+  where
+    renderByte b =
+        let hi = fromIntegral (b `shiftR` 4) :: Int
+            lo = fromIntegral (b .&. 0x0F)   :: Int
+         in [ intToDigit hi, intToDigit lo ]

--- a/code/packages/haskell/argon2id/test/Argon2idSpec.hs
+++ b/code/packages/haskell/argon2id/test/Argon2idSpec.hs
@@ -1,0 +1,103 @@
+-- | Test suite for the pure-Haskell Argon2id implementation.
+--
+-- Canonical vector comes from RFC 9106 §5.3.
+module Argon2idSpec (spec) where
+
+import Argon2id
+import Control.Exception (evaluate)
+import Data.Word (Word8)
+import Test.Hspec
+
+rfcPassword, rfcSalt, rfcKey, rfcAd :: [Word8]
+rfcPassword = replicate 32 0x01
+rfcSalt     = replicate 16 0x02
+rfcKey      = replicate 8  0x03
+rfcAd       = replicate 12 0x04
+
+rfcExpected :: String
+rfcExpected = "0d640df58d78766c08c037a34a8b53c9d01ef0452d75b65eb52520e96b01e659"
+
+spec :: Spec
+spec = describe "Argon2id" $ do
+
+    describe "RFC 9106 §5.3 canonical vector" $ do
+
+        it "matches the expected 32-byte tag" $
+            argon2idHex rfcPassword rfcSalt 3 32 4 32 rfcKey rfcAd argon2Version
+                `shouldBe` rfcExpected
+
+    describe "input validation" $ do
+
+        let run pw sl t m p tl =
+                argon2id pw sl t m p tl [] [] argon2Version
+
+        it "rejects salt shorter than 8 bytes" $
+            evaluate (run [] (replicate 7 0x00) 1 8 1 32)
+                `shouldThrow` anyErrorCall
+
+        it "rejects tag length < 4" $
+            evaluate (run [] (replicate 16 0x00) 1 8 1 3)
+                `shouldThrow` anyErrorCall
+
+        it "rejects parallelism = 0" $
+            evaluate (run [] (replicate 16 0x00) 1 8 0 32)
+                `shouldThrow` anyErrorCall
+
+        it "rejects time_cost = 0" $
+            evaluate (run [] (replicate 16 0x00) 0 8 1 32)
+                `shouldThrow` anyErrorCall
+
+        it "rejects memory_cost < 8*parallelism" $
+            evaluate (run [] (replicate 16 0x00) 1 4 2 32)
+                `shouldThrow` anyErrorCall
+
+        it "rejects an unsupported version" $
+            evaluate
+                (argon2id [] (replicate 16 0x00) 1 8 1 32 [] [] 0x10)
+                `shouldThrow` anyErrorCall
+
+    describe "determinism and input binding" $ do
+
+        let base = argon2id rfcPassword rfcSalt 1 16 1 32 [] [] argon2Version
+
+        it "produces the same output for the same inputs" $
+            argon2id rfcPassword rfcSalt 1 16 1 32 [] [] argon2Version
+                `shouldBe` base
+
+        it "changes when the password changes" $
+            argon2id (replicate 32 0x05) rfcSalt 1 16 1 32 [] []
+                     argon2Version
+                `shouldNotBe` base
+
+        it "changes when the salt changes" $
+            argon2id rfcPassword (replicate 16 0x09) 1 16 1 32 [] []
+                     argon2Version
+                `shouldNotBe` base
+
+        it "changes when a key is added" $
+            argon2id rfcPassword rfcSalt 1 16 1 32 rfcKey [] argon2Version
+                `shouldNotBe` base
+
+        it "changes when associated data is added" $
+            argon2id rfcPassword rfcSalt 1 16 1 32 [] rfcAd argon2Version
+                `shouldNotBe` base
+
+    describe "tag length variants" $ do
+
+        let at tl = length
+                (argon2id rfcPassword rfcSalt 1 16 1 tl [] [] argon2Version)
+
+        it "returns exactly 4 bytes"   $ at 4   `shouldBe` 4
+        it "returns exactly 16 bytes"  $ at 16  `shouldBe` 16
+        it "returns exactly 65 bytes"  $ at 65  `shouldBe` 65
+        it "returns exactly 128 bytes" $ at 128 `shouldBe` 128
+
+    describe "hybrid distinctness" $ do
+
+        it "produces a different tag than argon2d/i for the RFC inputs" $
+            -- If our hybrid rule were off we'd trivially collide with
+            -- one of the siblings; the §5.3 vector pins argon2id down.
+            argon2idHex rfcPassword rfcSalt 3 32 4 32 rfcKey rfcAd
+                        argon2Version
+                `shouldNotBe`
+                    "512b391b6f1162975371d30919734294f868e3be3984f3c1a13a4db9fabe4acb"

--- a/code/packages/haskell/argon2id/test/Spec.hs
+++ b/code/packages/haskell/argon2id/test/Spec.hs
@@ -1,0 +1,7 @@
+module Main (main) where
+
+import Argon2idSpec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec


### PR DESCRIPTION
## Summary

- Three new pure-Haskell packages — `argon2d`, `argon2i`, `argon2id` — under `code/packages/haskell/`, each matching the RFC 9106 canonical gold vectors (§5.1 / §5.2 / §5.3)
- Shared primitives: G-mixer (BLAKE2 quarter-round + `2·trunc32(a)·trunc32(b)` cross-term on wrapping `Word64`), compression G (row + column passes over an 8×8 UArray of 128-word blocks), H' variable-length hash, `index_alpha` biasing, 32-bit length caps + all other RFC §3.1 validation
- Depends only on sibling [`blake2b`](../blake2b); each package is `required_capabilities: []` (pure computation, no I/O)
- 51 hspec tests total (18 + 16 + 17), all passing

## Test plan

- [x] `cabal test` passes in each of `argon2d`, `argon2i`, `argon2id`
- [x] RFC 9106 §5.1 vector matches: `512b391b6f1162975371d30919734294f868e3be3984f3c1a13a4db9fabe4acb`
- [x] RFC 9106 §5.2 vector matches: `c814d9d1dc7f37aa13f0d77f2494bda1c8de6b016dd388d29952a4c4672b6ce8`
- [x] RFC 9106 §5.3 vector matches: `0d640df58d78766c08c037a34a8b53c9d01ef0452d75b65eb52520e96b01e659`
- [x] Validation rejects: short salt, tag < 4 B, parallelism 0, time_cost 0, memory_cost < 8·p, unsupported version
- [x] Tag-length variants 4 / 16 / 65 / 128 bytes all return correct lengths (verifies the H' chaining edge cases)
- [x] Security review sub-agent passed — no vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)