### PR TITLE
feat(interpreter-ir): add InterpreterIR package — LANG01 implementation

### DIFF
--- a/code/packages/python/interpreter-ir/BUILD
+++ b/code/packages/python/interpreter-ir/BUILD
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v --cov=interpreter_ir --cov-report=term-missing

--- a/code/packages/python/interpreter-ir/CHANGELOG.md
+++ b/code/packages/python/interpreter-ir/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog — coding-adventures-interpreter-ir
+
+## [0.1.0] — 2026-04-21
+
+### Added
+
+- `instr.py` — `IIRInstr` dataclass with `op`, `dest`, `srcs`, `type_hint`;
+  runtime feedback slots `observed_type`, `observation_count`, `deopt_anchor`;
+  `record_observation()`, `is_typed()`, `has_observation()`, `is_polymorphic()`,
+  `effective_type()` helpers.
+- `function.py` — `IIRFunction` dataclass with `name`, `params`, `return_type`,
+  `instructions`, `register_count`, `type_status`, `call_count`;
+  `FunctionTypeStatus` enum (FULLY_TYPED / PARTIALLY_TYPED / UNTYPED);
+  `infer_type_status()`, `label_index()`, `param_names()`, `param_types()`.
+- `module.py` — `IIRModule` dataclass with `name`, `functions`, `entry_point`,
+  `language`; `get_function()`, `function_names()`, `add_or_replace()`,
+  `validate()`.
+- `opcodes.py` — frozenset opcode category constants: `ARITHMETIC_OPS`,
+  `BITWISE_OPS`, `CMP_OPS`, `BRANCH_OPS`, `CONTROL_OPS`, `MEMORY_OPS`,
+  `CALL_OPS`, `IO_OPS`, `COERCION_OPS`, `VALUE_OPS`, `SIDE_EFFECT_OPS`,
+  `ALL_OPS`; type constants `CONCRETE_TYPES`, `DYNAMIC_TYPE`,
+  `POLYMORPHIC_TYPE`.
+- `serialise.py` — `serialise(IIRModule) → bytes` and
+  `deserialise(bytes) → IIRModule`; little-endian binary format with
+  `IIR\x00` magic, version byte, length-prefixed UTF-8 strings, and
+  per-operand kind tags; observation fields are intentionally not serialised
+  (they are runtime state).
+- `__init__.py` — re-exports all public types and opcode sets.
+
+### Design decisions
+
+- **Zero dependencies.** `interpreter-ir` is a leaf package.  No language
+  runtime, VM, or compiler dependency is introduced.  Any language compiler
+  can depend on this package without pulling in the full pipeline.
+- **Observation fields excluded from equality and serialisation.**  The
+  `observed_type`, `observation_count`, and `deopt_anchor` fields are runtime
+  state written by `vm-core`.  They are excluded from `__eq__` (via
+  `compare=False`) so that two logically identical programs compare equal
+  regardless of profiling history, and from serialisation so that `.iir`
+  snapshots always produce fresh, un-profiled state on load.
+- **`Operand = str | int | float | bool`** rather than `Any`.  Restricting
+  operand types to four concrete Python types makes serialisation deterministic
+  and allows the assembler to check literal ranges without runtime surprises.
+- **`add_or_replace()` for REPL sessions.**  The REPL integration (LANG08)
+  calls this method on each new user input.  By placing it on `IIRModule`
+  directly, the REPL plugin stays thin — it does not need to know about
+  module internals.
+- **`validate()` returns a list of error strings** rather than raising on the
+  first error.  This allows tooling (LSP, build system) to collect all errors
+  in one pass and report them together.

--- a/code/packages/python/interpreter-ir/README.md
+++ b/code/packages/python/interpreter-ir/README.md
@@ -1,0 +1,82 @@
+# interpreter-ir
+
+**InterpreterIR** — the shared dynamic bytecode IR for the generic language
+pipeline (spec LANG01).
+
+Any language whose compiler emits `IIRModule` automatically gains a generic
+VM (`vm-core`), JIT compiler (`jit-core`), VSCode debugger, language server,
+interactive REPL, and Jupyter notebook kernel — for free.
+
+## What it is
+
+`interpreter-ir` defines three core types:
+
+| Type | Role |
+|------|------|
+| `IIRInstr` | A single instruction with op, dest, srcs, type hint, and profiler feedback slots |
+| `IIRFunction` | A named, parameterised sequence of `IIRInstr` |
+| `IIRModule` | Top-level container: all functions + entry point |
+
+## Quick start
+
+```python
+from interpreter_ir import IIRInstr, IIRFunction, IIRModule, FunctionTypeStatus
+from interpreter_ir import serialise, deserialise
+
+instrs = [
+    IIRInstr("add", "v0", ["a", "b"], "u8"),
+    IIRInstr("ret",  None, ["v0"],    "u8"),
+]
+fn = IIRFunction(
+    name="add",
+    params=[("a", "u8"), ("b", "u8")],
+    return_type="u8",
+    instructions=instrs,
+    type_status=FunctionTypeStatus.FULLY_TYPED,
+)
+module = IIRModule(name="example", functions=[fn], entry_point="add")
+
+# Serialise to bytes (for AOT snapshots or disk caching)
+raw = serialise(module)
+restored = deserialise(raw)
+assert restored == module
+```
+
+## Type observation
+
+For dynamically typed languages, the VM profiler fills in `observed_type`:
+
+```python
+instr = IIRInstr("add", "v0", ["a", "b"], "any")
+# After vm-core executes this instruction:
+instr.record_observation("u8")   # first call: u8
+instr.record_observation("u8")   # second call: still u8
+assert instr.observed_type == "u8"
+assert instr.observation_count == 2
+
+instr.record_observation("str")  # different type!
+assert instr.observed_type == "polymorphic"  # don't specialise
+```
+
+## Opcode sets
+
+```python
+from interpreter_ir import ARITHMETIC_OPS, CMP_OPS, SIDE_EFFECT_OPS
+
+if instr.op in ARITHMETIC_OPS:
+    ...  # add, sub, mul, div, mod, neg
+```
+
+## Pipeline position
+
+```
+Language source
+  → lexer → parser → type-checker
+  → bytecode compiler  →  IIRModule   ← YOU ARE HERE
+  → vm-core (interprets)
+  → jit-core (compiles hot functions to CompilerIR → native binary)
+```
+
+## Dependencies
+
+None. `interpreter-ir` is a zero-dependency leaf package.

--- a/code/packages/python/interpreter-ir/pyproject.toml
+++ b/code/packages/python/interpreter-ir/pyproject.toml
@@ -1,0 +1,51 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-interpreter-ir"
+version = "0.1.0"
+description = "InterpreterIR: dynamic bytecode IR with feedback slots and deopt anchors for the generic language pipeline"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["compiler", "ir", "bytecode", "jit", "interpreter", "education"]
+dependencies = []
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Education",
+    "Topic :: Education",
+    "Topic :: Software Development :: Compilers",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://github.com/adhithyan15/coding-adventures"
+Repository = "https://github.com/adhithyan15/coding-adventures"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/interpreter_ir"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=interpreter_ir --cov-report=term-missing --cov-fail-under=95"
+
+[tool.coverage.run]
+source = ["src/interpreter_ir"]
+
+[tool.coverage.report]
+fail_under = 95
+show_missing = true

--- a/code/packages/python/interpreter-ir/src/interpreter_ir/__init__.py
+++ b/code/packages/python/interpreter-ir/src/interpreter_ir/__init__.py
@@ -1,0 +1,90 @@
+"""interpreter-ir — dynamic bytecode IR with feedback slots for the LANG pipeline.
+
+This package defines ``IIRInstr``, ``IIRFunction``, and ``IIRModule``:
+the shared bytecode format that all interpreted languages in this repository
+compile to (spec LANG01).
+
+Any language whose compiler emits ``IIRModule`` automatically gains:
+
+- ``vm-core``         — a generic register VM interpreter (LANG02)
+- ``jit-core``        — a JIT compiler with tiered promotion (LANG03)
+- ``aot-core``        — ahead-of-time compilation (LANG04)
+- ``debug-integration`` — VSCode breakpoints and stepping (LANG06)
+- ``lsp-integration`` — language server for editor intelligence (LANG07)
+- ``repl-integration`` — interactive REPL sessions (LANG08)
+- ``notebook-kernel`` — Jupyter-compatible notebook kernel (LANG09)
+
+Quick start::
+
+    from interpreter_ir import IIRInstr, IIRFunction, IIRModule
+    from interpreter_ir import FunctionTypeStatus, serialise, deserialise
+
+    instrs = [
+        IIRInstr("add", "v0", ["a", "b"], "u8"),
+        IIRInstr("ret",  None, ["v0"],    "u8"),
+    ]
+    fn = IIRFunction(
+        name="add",
+        params=[("a", "u8"), ("b", "u8")],
+        return_type="u8",
+        instructions=instrs,
+        type_status=FunctionTypeStatus.FULLY_TYPED,
+    )
+    module = IIRModule(name="example", functions=[fn], entry_point="add")
+
+    raw = serialise(module)
+    restored = deserialise(raw)
+    assert restored == module
+"""
+
+from __future__ import annotations
+
+from interpreter_ir.function import FunctionTypeStatus, IIRFunction
+from interpreter_ir.instr import IIRInstr
+from interpreter_ir.module import IIRModule
+from interpreter_ir.opcodes import (
+    ALL_OPS,
+    ARITHMETIC_OPS,
+    BITWISE_OPS,
+    BRANCH_OPS,
+    CALL_OPS,
+    CMP_OPS,
+    COERCION_OPS,
+    CONCRETE_TYPES,
+    CONTROL_OPS,
+    DYNAMIC_TYPE,
+    IO_OPS,
+    MEMORY_OPS,
+    POLYMORPHIC_TYPE,
+    SIDE_EFFECT_OPS,
+    VALUE_OPS,
+)
+from interpreter_ir.serialise import deserialise, serialise
+
+__all__ = [
+    # Core types
+    "IIRInstr",
+    "IIRFunction",
+    "IIRModule",
+    "FunctionTypeStatus",
+    # Serialisation
+    "serialise",
+    "deserialise",
+    # Opcode sets
+    "ALL_OPS",
+    "ARITHMETIC_OPS",
+    "BITWISE_OPS",
+    "BRANCH_OPS",
+    "CALL_OPS",
+    "CMP_OPS",
+    "COERCION_OPS",
+    "CONTROL_OPS",
+    "IO_OPS",
+    "MEMORY_OPS",
+    "SIDE_EFFECT_OPS",
+    "VALUE_OPS",
+    # Type constants
+    "CONCRETE_TYPES",
+    "DYNAMIC_TYPE",
+    "POLYMORPHIC_TYPE",
+]

--- a/code/packages/python/interpreter-ir/src/interpreter_ir/function.py
+++ b/code/packages/python/interpreter-ir/src/interpreter_ir/function.py
@@ -1,0 +1,141 @@
+"""IIRFunction — a named, parameterised sequence of IIRInstr.
+
+A function is the unit of compilation in the LANG pipeline.  The JIT compiles
+one function at a time; the profiler tracks call counts per function.
+
+Type status
+-----------
+``FunctionTypeStatus`` mirrors the status used by Tetrad (TET02b) and will be
+the shared enum across all languages:
+
+- ``FULLY_TYPED``     — every instruction has a concrete ``type_hint``
+- ``PARTIALLY_TYPED`` — some instructions are typed, some are ``"any"``
+- ``UNTYPED``         — all instructions are ``"any"``
+
+The JIT uses this to decide *when* to compile:
+
+- ``FULLY_TYPED``     → compile before the first interpreted call
+- ``PARTIALLY_TYPED`` → compile after 10 interpreter calls
+- ``UNTYPED``         → compile after 100 interpreter calls
+
+Example::
+
+    fn = IIRFunction(
+        name="add",
+        params=[("a", "u8"), ("b", "u8")],
+        return_type="u8",
+        instructions=[
+            IIRInstr("add", "v0", ["a", "b"], "u8"),
+            IIRInstr("ret",  None, ["v0"],    "u8"),
+        ],
+        type_status=FunctionTypeStatus.FULLY_TYPED,
+    )
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum, auto
+
+from interpreter_ir.instr import IIRInstr
+
+
+class FunctionTypeStatus(Enum):
+    """Compilation tier based on how much type information is available."""
+
+    FULLY_TYPED = auto()
+    """All parameters and instructions carry concrete type hints."""
+
+    PARTIALLY_TYPED = auto()
+    """Some instructions are typed; others are ``"any"``."""
+
+    UNTYPED = auto()
+    """No static types; all type information must come from profiling."""
+
+
+@dataclass
+class IIRFunction:
+    """A single function in an IIRModule.
+
+    Parameters
+    ----------
+    name:
+        The function name, used as the key in the JIT cache and the vm-core
+        call-count metrics table.
+    params:
+        Ordered list of ``(param_name, type_hint)`` pairs.  The VM loads
+        arguments into the first ``len(params)`` registers before the first
+        instruction executes.
+    return_type:
+        Declared return type (``"u8"``, ``"void"``, ``"any"``, …).
+    instructions:
+        The body of the function as a flat list of ``IIRInstr``.  Labels are
+        also represented as instructions (op ``"label"``) so the index of each
+        instruction is its unique address within the function.
+    register_count:
+        Number of VM registers this function uses (including parameters).
+        ``vm-core`` allocates exactly this many register slots per frame.
+    type_status:
+        Compilation tier.  Derived automatically from ``params`` and
+        ``instructions`` if not supplied explicitly.
+    call_count:
+        Incremented by ``vm-core`` on each interpreted call.  Read by
+        ``jit-core`` to trigger tier promotion.
+    """
+
+    name: str
+    params: list[tuple[str, str]]   # [(param_name, type_hint), …]
+    return_type: str
+    instructions: list[IIRInstr]
+    register_count: int = 8
+    type_status: FunctionTypeStatus = FunctionTypeStatus.UNTYPED
+    call_count: int = field(default=0, repr=False, compare=False)
+
+    # -----------------------------------------------------------------------
+    # Helpers
+    # -----------------------------------------------------------------------
+
+    def param_names(self) -> list[str]:
+        """Return just the parameter names in order."""
+        return [name for name, _ in self.params]
+
+    def param_types(self) -> list[str]:
+        """Return just the parameter type hints in order."""
+        return [t for _, t in self.params]
+
+    def infer_type_status(self) -> FunctionTypeStatus:
+        """Derive type status from params and instruction type hints.
+
+        A function is FULLY_TYPED if every param type and every instruction
+        ``type_hint`` is a concrete type (not ``"any"``).  It is UNTYPED if
+        none of them are.  Otherwise PARTIALLY_TYPED.
+        """
+        from interpreter_ir.opcodes import CONCRETE_TYPES
+
+        all_hints: list[str] = [t for _, t in self.params] + [
+            i.type_hint for i in self.instructions
+        ]
+        typed = sum(1 for h in all_hints if h in CONCRETE_TYPES)
+        total = len(all_hints)
+        if total == 0 or typed == 0:
+            return FunctionTypeStatus.UNTYPED
+        if typed == total:
+            return FunctionTypeStatus.FULLY_TYPED
+        return FunctionTypeStatus.PARTIALLY_TYPED
+
+    def label_index(self, label_name: str) -> int:
+        """Return the instruction index of the named label, or raise KeyError."""
+        for idx, instr in enumerate(self.instructions):
+            if instr.op == "label" and instr.srcs and instr.srcs[0] == label_name:
+                return idx
+        raise KeyError(f"label {label_name!r} not found in function {self.name!r}")
+
+    def __repr__(self) -> str:
+        params_str = ", ".join(f"{n}: {t}" for n, t in self.params)
+        return (
+            f"IIRFunction({self.name!r}, "
+            f"params=[{params_str}], "
+            f"return={self.return_type!r}, "
+            f"instrs={len(self.instructions)}, "
+            f"status={self.type_status.name})"
+        )

--- a/code/packages/python/interpreter-ir/src/interpreter_ir/instr.py
+++ b/code/packages/python/interpreter-ir/src/interpreter_ir/instr.py
@@ -1,0 +1,132 @@
+"""IIRInstr — the single instruction of InterpreterIR.
+
+Design
+------
+Each instruction is a small, immutable-by-convention record with:
+
+- ``op``      — a mnemonic string identifying the operation (e.g. ``"add"``)
+- ``dest``    — the SSA variable produced, or ``None`` for void ops
+- ``srcs``    — source operands: variable names (str) or literals (int/float/bool)
+- ``type_hint`` — the declared type (``"u8"``, ``"bool"``, ``"any"``, …)
+
+At runtime, two extra fields are written by the ``vm-core`` profiler:
+
+- ``observed_type``    — the actual type seen so far (or ``"polymorphic"``)
+- ``observation_count`` — how many times the profiler has sampled this instruction
+
+A ``deopt_anchor`` marks the interpreter instruction index the JIT must revert
+to if a type guard fails.
+
+Example::
+
+    # Statically typed (Tetrad)
+    IIRInstr("add", "v0", ["a", "b"], "u8")
+
+    # Dynamically typed (before profiling)
+    IIRInstr("add", "v0", ["a", "b"], "any")
+
+    # After profiling
+    instr.observed_type = "u8"
+    instr.observation_count = 47
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# An operand is either a variable name reference or an immediate literal.
+Operand = str | int | float | bool
+
+
+@dataclass
+class IIRInstr:
+    """A single InterpreterIR instruction.
+
+    Parameters
+    ----------
+    op:
+        Instruction mnemonic.  Must be one of the strings in
+        ``interpreter_ir.opcodes.ALL_OPS`` plus ``"const"``.
+    dest:
+        Name of the SSA variable produced, or ``None`` for void instructions
+        (branches, stores, returns).
+    srcs:
+        Source operands.  Each element is either a ``str`` (variable name)
+        or a literal ``int``, ``float``, or ``bool``.
+    type_hint:
+        Declared type of ``dest``.  Use ``"any"`` for dynamically typed
+        languages where the type is unknown at compile time.
+    """
+
+    op: str
+    dest: str | None
+    srcs: list[Operand]
+    type_hint: str
+
+    # -----------------------------------------------------------------------
+    # Runtime feedback — written by vm-core profiler
+    # -----------------------------------------------------------------------
+
+    observed_type: str | None = field(default=None, repr=False, compare=False)
+    """Runtime type observed by the vm-core profiler.
+
+    ``None``           — not yet observed
+    ``"u8"`` etc.     — concrete single type observed on all calls so far
+    ``"polymorphic"`` — multiple different types seen; do not specialise
+    """
+
+    observation_count: int = field(default=0, repr=False, compare=False)
+    """Number of times this instruction has been profiled by vm-core."""
+
+    deopt_anchor: int | None = field(default=None, repr=False, compare=False)
+    """Instruction index to resume interpreter at if a JIT type guard fails.
+
+    Set by jit-core when emitting a type guard for this instruction.
+    ``None`` means no guard has been emitted yet.
+    """
+
+    # -----------------------------------------------------------------------
+    # Convenience helpers
+    # -----------------------------------------------------------------------
+
+    def is_typed(self) -> bool:
+        """Return True if this instruction has a concrete (non-dynamic) type hint."""
+        from interpreter_ir.opcodes import CONCRETE_TYPES
+        return self.type_hint in CONCRETE_TYPES
+
+    def has_observation(self) -> bool:
+        """Return True if the profiler has recorded at least one observation."""
+        return self.observation_count > 0
+
+    def is_polymorphic(self) -> bool:
+        """Return True if multiple types have been observed (do not specialise)."""
+        return self.observed_type == "polymorphic"
+
+    def effective_type(self) -> str:
+        """The best available type: concrete hint first, then observed, then 'any'."""
+        if self.is_typed():
+            return self.type_hint
+        if self.observed_type and self.observed_type != "polymorphic":
+            return self.observed_type
+        return "any"
+
+    def record_observation(self, runtime_type: str) -> None:
+        """Update the observation slot with a new runtime type.
+
+        Called by vm-core's profiler after each execution of this instruction.
+        Marks the slot as ``"polymorphic"`` if a second distinct type is seen.
+        """
+        if self.observed_type is None:
+            self.observed_type = runtime_type
+        elif self.observed_type != runtime_type:
+            self.observed_type = "polymorphic"
+        self.observation_count += 1
+
+    def __repr__(self) -> str:
+        dest_str = f"{self.dest} = " if self.dest is not None else ""
+        srcs_str = ", ".join(repr(s) for s in self.srcs)
+        type_str = f" : {self.type_hint}"
+        obs = ""
+        if self.observation_count > 0:
+            obs = f" [obs={self.observed_type!r}×{self.observation_count}]"
+        return f"IIRInstr({dest_str}{self.op}({srcs_str}){type_str}{obs})"

--- a/code/packages/python/interpreter-ir/src/interpreter_ir/module.py
+++ b/code/packages/python/interpreter-ir/src/interpreter_ir/module.py
@@ -1,0 +1,128 @@
+"""IIRModule — the top-level container for an InterpreterIR program.
+
+A module holds all functions compiled from a single source file (or REPL
+session).  It is the unit handed to ``vm-core.execute()`` and
+``jit-core.execute_with_jit()``.
+
+REPL sessions mutate the module incrementally: each new input appends new
+``IIRFunction`` objects or replaces existing ones by name.
+
+Example::
+
+    module = IIRModule(
+        name="hello.bas",
+        language="basic",
+        functions=[...],
+        entry_point="main",
+    )
+    result = vm.execute(module)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from interpreter_ir.function import IIRFunction
+
+
+@dataclass
+class IIRModule:
+    """Top-level container for an InterpreterIR program.
+
+    Parameters
+    ----------
+    name:
+        A human-readable name, typically the source file path.
+    functions:
+        All functions in the program, in definition order.
+    entry_point:
+        Name of the function to call when the module is executed.
+        ``None`` means no automatic entry point (useful for libraries).
+    language:
+        Source language identifier.  Used by tooling for display only;
+        not interpreted by ``vm-core``.
+    """
+
+    name: str
+    functions: list[IIRFunction] = field(default_factory=list)
+    entry_point: str | None = "main"
+    language: str = "unknown"
+
+    # -----------------------------------------------------------------------
+    # Lookup
+    # -----------------------------------------------------------------------
+
+    def get_function(self, fn_name: str) -> IIRFunction | None:
+        """Return the ``IIRFunction`` with the given name, or ``None``."""
+        for fn in self.functions:
+            if fn.name == fn_name:
+                return fn
+        return None
+
+    def function_names(self) -> list[str]:
+        """Return all function names in definition order."""
+        return [fn.name for fn in self.functions]
+
+    # -----------------------------------------------------------------------
+    # Mutation (used by REPL incremental compilation)
+    # -----------------------------------------------------------------------
+
+    def add_or_replace(self, fn: IIRFunction) -> None:
+        """Append ``fn`` or replace an existing function with the same name.
+
+        Called by the REPL integration (LANG08) when the user redefines a
+        function in a later input.
+        """
+        for i, existing in enumerate(self.functions):
+            if existing.name == fn.name:
+                self.functions[i] = fn
+                return
+        self.functions.append(fn)
+
+    # -----------------------------------------------------------------------
+    # Validation
+    # -----------------------------------------------------------------------
+
+    def validate(self) -> list[str]:
+        """Return a list of validation error strings (empty = valid).
+
+        Checks:
+        - No duplicate function names
+        - Entry point function exists (if entry_point is set)
+        - No instruction references an undefined label within its function
+        """
+        errors: list[str] = []
+        seen: set[str] = set()
+        for fn in self.functions:
+            if fn.name in seen:
+                errors.append(f"duplicate function name: {fn.name!r}")
+            seen.add(fn.name)
+
+        if self.entry_point is not None and self.entry_point not in seen:
+            errors.append(
+                f"entry_point {self.entry_point!r} not found in module functions"
+            )
+
+        for fn in self.functions:
+            defined_labels = {
+                instr.srcs[0]
+                for instr in fn.instructions
+                if instr.op == "label" and instr.srcs
+            }
+            for instr in fn.instructions:
+                if instr.op in {"jmp", "jmp_if_true", "jmp_if_false"}:
+                    label = instr.srcs[-1] if instr.srcs else None
+                    if isinstance(label, str) and label not in defined_labels:
+                        errors.append(
+                            f"function {fn.name!r}: branch to undefined "
+                            f"label {label!r}"
+                        )
+        return errors
+
+    def __repr__(self) -> str:
+        return (
+            f"IIRModule({self.name!r}, "
+            f"language={self.language!r}, "
+            f"functions={self.function_names()}, "
+            f"entry={self.entry_point!r})"
+        )

--- a/code/packages/python/interpreter-ir/src/interpreter_ir/opcodes.py
+++ b/code/packages/python/interpreter-ir/src/interpreter_ir/opcodes.py
@@ -1,0 +1,94 @@
+"""Opcode category frozensets for InterpreterIR.
+
+These sets let vm-core, jit-core, and passes classify instructions without
+comparing against long lists of mnemonic strings.
+
+Usage::
+
+    from interpreter_ir.opcodes import ARITHMETIC_OPS, CMP_OPS
+    if instr.op in ARITHMETIC_OPS:
+        ...
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Type constants
+# ---------------------------------------------------------------------------
+
+CONCRETE_TYPES: frozenset[str] = frozenset(
+    {"u8", "u16", "u32", "u64", "bool", "str"}
+)
+
+# The "unknown" type used by dynamically typed languages before profiling.
+DYNAMIC_TYPE = "any"
+
+# Sentinel placed by the vm-core profiler when multiple types are observed.
+POLYMORPHIC_TYPE = "polymorphic"
+
+# ---------------------------------------------------------------------------
+# Opcode categories
+# ---------------------------------------------------------------------------
+
+ARITHMETIC_OPS: frozenset[str] = frozenset(
+    {"add", "sub", "mul", "div", "mod", "neg"}
+)
+
+BITWISE_OPS: frozenset[str] = frozenset(
+    {"and", "or", "xor", "not", "shl", "shr"}
+)
+
+CMP_OPS: frozenset[str] = frozenset(
+    {"cmp_eq", "cmp_ne", "cmp_lt", "cmp_le", "cmp_gt", "cmp_ge"}
+)
+
+BRANCH_OPS: frozenset[str] = frozenset(
+    {"jmp", "jmp_if_true", "jmp_if_false"}
+)
+
+CONTROL_OPS: frozenset[str] = frozenset(
+    {"label", "ret", "ret_void"}
+)
+
+MEMORY_OPS: frozenset[str] = frozenset(
+    {"load_reg", "store_reg", "load_mem", "store_mem"}
+)
+
+CALL_OPS: frozenset[str] = frozenset(
+    {"call", "call_builtin"}
+)
+
+IO_OPS: frozenset[str] = frozenset(
+    {"io_in", "io_out"}
+)
+
+COERCION_OPS: frozenset[str] = frozenset(
+    {"cast", "type_assert"}
+)
+
+# All ops that produce a value (have a non-None dest).
+_VALUE_EXTRA: frozenset[str] = frozenset(
+    {"const", "load_reg", "load_mem", "call", "call_builtin", "io_in", "cast"}
+)
+VALUE_OPS: frozenset[str] = ARITHMETIC_OPS | BITWISE_OPS | CMP_OPS | _VALUE_EXTRA
+
+# All ops that have side effects beyond producing a value.
+SIDE_EFFECT_OPS: frozenset[str] = (
+    BRANCH_OPS
+    | CONTROL_OPS
+    | frozenset({"store_reg", "store_mem", "io_out", "type_assert"})
+)
+
+# All known opcodes.
+ALL_OPS: frozenset[str] = (
+    ARITHMETIC_OPS
+    | BITWISE_OPS
+    | CMP_OPS
+    | BRANCH_OPS
+    | CONTROL_OPS
+    | MEMORY_OPS
+    | CALL_OPS
+    | IO_OPS
+    | COERCION_OPS
+    | frozenset({"const"})
+)

--- a/code/packages/python/interpreter-ir/src/interpreter_ir/serialise.py
+++ b/code/packages/python/interpreter-ir/src/interpreter_ir/serialise.py
@@ -1,0 +1,263 @@
+"""Binary serialisation for IIRModule.
+
+Format (little-endian throughout)
+----------------------------------
+
+Header (12 bytes):
+    4 bytes  magic      0x49 0x49 0x52 0x00  (b"IIR\\x00")
+    2 bytes  version    0x01 0x00
+    4 bytes  fn_count   number of IIRFunction records
+    2 bytes  name_len   length of module name in bytes
+    N bytes  name       module name (UTF-8)
+    2 bytes  lang_len   length of language string
+    M bytes  language
+    2 bytes  ep_len     length of entry_point string (0 = no entry point)
+    P bytes  entry_point
+
+For each IIRFunction:
+    2 bytes  name_len, N bytes name
+    2 bytes  return_type_len, N bytes return_type
+    1 byte   param_count
+    For each param:
+        2 bytes name_len, N bytes param_name
+        2 bytes type_len, N bytes type_hint
+    4 bytes  instr_count
+    1 byte   register_count
+    1 byte   type_status  (0=UNTYPED, 1=PARTIALLY_TYPED, 2=FULLY_TYPED)
+    For each IIRInstr:
+        2 bytes  op_len, N bytes op
+        1 byte   has_dest (0 or 1)
+        If has_dest: 2 bytes dest_len, N bytes dest
+        2 bytes  type_hint_len, N bytes type_hint
+        1 byte   src_count
+        For each src operand:
+            1 byte  kind  (0=str, 1=int, 2=float, 3=bool)
+            If kind==0: 2 bytes len, N bytes str
+            If kind==1: 8 bytes signed int64
+            If kind==2: 8 bytes IEEE 754 float64
+            If kind==3: 1 byte (0=False, 1=True)
+
+Note: observation fields (observed_type, observation_count, deopt_anchor)
+are NOT serialised — they are runtime state that accumulates fresh each run.
+
+Usage::
+
+    raw = serialise(module)
+    module2 = deserialise(raw)
+    assert module == module2
+"""
+
+from __future__ import annotations
+
+import struct
+
+from interpreter_ir.function import FunctionTypeStatus, IIRFunction
+from interpreter_ir.instr import IIRInstr
+from interpreter_ir.module import IIRModule
+
+_MAGIC = b"IIR\x00"
+_VERSION = (1, 0)
+
+_STATUS_TO_BYTE = {
+    FunctionTypeStatus.UNTYPED: 0,
+    FunctionTypeStatus.PARTIALLY_TYPED: 1,
+    FunctionTypeStatus.FULLY_TYPED: 2,
+}
+_BYTE_TO_STATUS = {v: k for k, v in _STATUS_TO_BYTE.items()}
+
+
+# ---------------------------------------------------------------------------
+# Serialise
+# ---------------------------------------------------------------------------
+
+class _Writer:
+    def __init__(self) -> None:
+        self._buf: list[bytes] = []
+
+    def u8(self, v: int) -> None:
+        self._buf.append(struct.pack("<B", v))
+
+    def u16(self, v: int) -> None:
+        self._buf.append(struct.pack("<H", v))
+
+    def u32(self, v: int) -> None:
+        self._buf.append(struct.pack("<I", v))
+
+    def i64(self, v: int) -> None:
+        self._buf.append(struct.pack("<q", v))
+
+    def f64(self, v: float) -> None:
+        self._buf.append(struct.pack("<d", v))
+
+    def str_(self, s: str) -> None:
+        encoded = s.encode("utf-8")
+        self.u16(len(encoded))
+        self._buf.append(encoded)
+
+    def bytes_(self) -> bytes:
+        return b"".join(self._buf)
+
+
+def serialise(module: IIRModule) -> bytes:
+    """Serialise an ``IIRModule`` to bytes."""
+    w = _Writer()
+    w._buf.append(_MAGIC)
+    w.u8(_VERSION[0])
+    w.u8(_VERSION[1])
+    w.u32(len(module.functions))
+    w.str_(module.name)
+    w.str_(module.language)
+    ep = module.entry_point or ""
+    w.str_(ep)
+
+    for fn in module.functions:
+        _write_function(w, fn)
+
+    return w.bytes_()
+
+
+def _write_function(w: _Writer, fn: IIRFunction) -> None:
+    w.str_(fn.name)
+    w.str_(fn.return_type)
+    w.u8(len(fn.params))
+    for param_name, param_type in fn.params:
+        w.str_(param_name)
+        w.str_(param_type)
+    w.u32(len(fn.instructions))
+    w.u8(fn.register_count)
+    w.u8(_STATUS_TO_BYTE[fn.type_status])
+    for instr in fn.instructions:
+        _write_instr(w, instr)
+
+
+def _write_instr(w: _Writer, instr: IIRInstr) -> None:
+    w.str_(instr.op)
+    if instr.dest is not None:
+        w.u8(1)
+        w.str_(instr.dest)
+    else:
+        w.u8(0)
+    w.str_(instr.type_hint)
+    w.u8(len(instr.srcs))
+    for src in instr.srcs:
+        if isinstance(src, bool):
+            w.u8(3)
+            w.u8(1 if src else 0)
+        elif isinstance(src, int):
+            w.u8(1)
+            w.i64(src)
+        elif isinstance(src, float):
+            w.u8(2)
+            w.f64(src)
+        else:
+            w.u8(0)
+            w.str_(src)
+
+
+# ---------------------------------------------------------------------------
+# Deserialise
+# ---------------------------------------------------------------------------
+
+class _Reader:
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+        self._pos = 0
+
+    def _read(self, n: int) -> bytes:
+        if self._pos + n > len(self._data):
+            raise ValueError(
+                f"unexpected end of data at offset {self._pos} "
+                f"(need {n} bytes, have {len(self._data) - self._pos})"
+            )
+        chunk = self._data[self._pos : self._pos + n]
+        self._pos += n
+        return chunk
+
+    def u8(self) -> int:
+        return struct.unpack("<B", self._read(1))[0]
+
+    def u16(self) -> int:
+        return struct.unpack("<H", self._read(2))[0]
+
+    def u32(self) -> int:
+        return struct.unpack("<I", self._read(4))[0]
+
+    def i64(self) -> int:
+        return struct.unpack("<q", self._read(8))[0]
+
+    def f64(self) -> float:
+        return struct.unpack("<d", self._read(8))[0]
+
+    def str_(self) -> str:
+        length = self.u16()
+        return self._read(length).decode("utf-8")
+
+
+def deserialise(data: bytes) -> IIRModule:
+    """Deserialise bytes produced by :func:`serialise` back to an ``IIRModule``."""
+    r = _Reader(data)
+
+    magic = r._read(4)
+    if magic != _MAGIC:
+        raise ValueError(f"invalid magic bytes: {magic!r} (expected {_MAGIC!r})")
+
+    major = r.u8()
+    minor = r.u8()
+    if (major, minor) != _VERSION:
+        raise ValueError(f"unsupported version {major}.{minor}")
+
+    fn_count = r.u32()
+    name = r.str_()
+    language = r.str_()
+    ep_raw = r.str_()
+    entry_point = ep_raw if ep_raw else None
+
+    functions = [_read_function(r) for _ in range(fn_count)]
+
+    return IIRModule(
+        name=name,
+        functions=functions,
+        entry_point=entry_point,
+        language=language,
+    )
+
+
+def _read_function(r: _Reader) -> IIRFunction:
+    name = r.str_()
+    return_type = r.str_()
+    param_count = r.u8()
+    params = [(r.str_(), r.str_()) for _ in range(param_count)]
+    instr_count = r.u32()
+    register_count = r.u8()
+    type_status = _BYTE_TO_STATUS[r.u8()]
+    instructions = [_read_instr(r) for _ in range(instr_count)]
+    return IIRFunction(
+        name=name,
+        params=params,
+        return_type=return_type,
+        instructions=instructions,
+        register_count=register_count,
+        type_status=type_status,
+    )
+
+
+def _read_instr(r: _Reader) -> IIRInstr:
+    op = r.str_()
+    has_dest = r.u8()
+    dest = r.str_() if has_dest else None
+    type_hint = r.str_()
+    src_count = r.u8()
+    srcs: list = []
+    for _ in range(src_count):
+        kind = r.u8()
+        if kind == 0:
+            srcs.append(r.str_())
+        elif kind == 1:
+            srcs.append(r.i64())
+        elif kind == 2:
+            srcs.append(r.f64())
+        elif kind == 3:
+            srcs.append(bool(r.u8()))
+        else:
+            raise ValueError(f"unknown operand kind byte: {kind}")
+    return IIRInstr(op=op, dest=dest, srcs=srcs, type_hint=type_hint)

--- a/code/packages/python/interpreter-ir/tests/test_interpreter_ir.py
+++ b/code/packages/python/interpreter-ir/tests/test_interpreter_ir.py
@@ -1,0 +1,640 @@
+"""Tests for interpreter-ir package.
+
+Covers IIRInstr, IIRFunction, IIRModule, opcode sets, and serialisation.
+Target: ≥95% coverage.
+"""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from interpreter_ir import (
+    ALL_OPS,
+    ARITHMETIC_OPS,
+    BITWISE_OPS,
+    BRANCH_OPS,
+    CALL_OPS,
+    CMP_OPS,
+    COERCION_OPS,
+    CONCRETE_TYPES,
+    CONTROL_OPS,
+    DYNAMIC_TYPE,
+    IO_OPS,
+    MEMORY_OPS,
+    POLYMORPHIC_TYPE,
+    SIDE_EFFECT_OPS,
+    VALUE_OPS,
+    FunctionTypeStatus,
+    IIRFunction,
+    IIRInstr,
+    IIRModule,
+    deserialise,
+    serialise,
+)
+
+# ===========================================================================
+# Helpers
+# ===========================================================================
+
+def make_add_fn(type_hint: str = "u8") -> IIRFunction:
+    return IIRFunction(
+        name="add",
+        params=[("a", type_hint), ("b", type_hint)],
+        return_type=type_hint,
+        instructions=[
+            IIRInstr("add", "v0", ["a", "b"], type_hint),
+            IIRInstr("ret", None, ["v0"], type_hint),
+        ],
+        type_status=FunctionTypeStatus.FULLY_TYPED,
+    )
+
+
+def make_module(*fns: IIRFunction, entry: str = "main") -> IIRModule:
+    return IIRModule(name="test.ml", functions=list(fns), entry_point=entry)
+
+
+# ===========================================================================
+# IIRInstr tests
+# ===========================================================================
+
+class TestIIRInstr:
+    def test_basic_construction(self):
+        instr = IIRInstr("add", "v0", ["a", "b"], "u8")
+        assert instr.op == "add"
+        assert instr.dest == "v0"
+        assert instr.srcs == ["a", "b"]
+        assert instr.type_hint == "u8"
+
+    def test_void_dest(self):
+        instr = IIRInstr("ret", None, ["v0"], "u8")
+        assert instr.dest is None
+
+    def test_literal_srcs(self):
+        instr = IIRInstr("const", "k", [42], "u8")
+        assert instr.srcs == [42]
+
+    def test_float_literal_src(self):
+        instr = IIRInstr("const", "k", [3.14], "any")
+        assert instr.srcs == [3.14]
+
+    def test_bool_literal_src(self):
+        instr = IIRInstr("const", "k", [True], "bool")
+        assert instr.srcs == [True]
+
+    def test_default_observation_fields(self):
+        instr = IIRInstr("add", "v0", ["a", "b"], "u8")
+        assert instr.observed_type is None
+        assert instr.observation_count == 0
+        assert instr.deopt_anchor is None
+
+    def test_is_typed_concrete(self):
+        instr = IIRInstr("add", "v0", ["a", "b"], "u8")
+        assert instr.is_typed() is True
+
+    def test_is_typed_dynamic(self):
+        instr = IIRInstr("add", "v0", ["a", "b"], "any")
+        assert instr.is_typed() is False
+
+    def test_has_observation_false(self):
+        instr = IIRInstr("add", "v0", ["a", "b"], "u8")
+        assert instr.has_observation() is False
+
+    def test_has_observation_true(self):
+        instr = IIRInstr("add", "v0", ["a", "b"], "any")
+        instr.record_observation("u8")
+        assert instr.has_observation() is True
+
+    def test_is_polymorphic_false(self):
+        instr = IIRInstr("add", "v0", ["a", "b"], "any")
+        assert instr.is_polymorphic() is False
+
+    def test_is_polymorphic_after_two_types(self):
+        instr = IIRInstr("add", "v0", ["a", "b"], "any")
+        instr.record_observation("u8")
+        instr.record_observation("u16")
+        assert instr.is_polymorphic() is True
+        assert instr.observed_type == "polymorphic"
+
+    def test_record_observation_same_type(self):
+        instr = IIRInstr("add", "v0", ["a", "b"], "any")
+        instr.record_observation("u8")
+        instr.record_observation("u8")
+        instr.record_observation("u8")
+        assert instr.observed_type == "u8"
+        assert instr.observation_count == 3
+        assert not instr.is_polymorphic()
+
+    def test_record_observation_stays_polymorphic(self):
+        instr = IIRInstr("add", "v0", ["a", "b"], "any")
+        instr.record_observation("u8")
+        instr.record_observation("str")
+        instr.record_observation("u8")   # already polymorphic
+        assert instr.observed_type == "polymorphic"
+        assert instr.observation_count == 3
+
+    def test_effective_type_concrete_hint(self):
+        instr = IIRInstr("add", "v0", ["a", "b"], "u8")
+        assert instr.effective_type() == "u8"
+
+    def test_effective_type_observed(self):
+        instr = IIRInstr("add", "v0", ["a", "b"], "any")
+        instr.record_observation("u16")
+        assert instr.effective_type() == "u16"
+
+    def test_effective_type_polymorphic_returns_any(self):
+        instr = IIRInstr("add", "v0", ["a", "b"], "any")
+        instr.record_observation("u8")
+        instr.record_observation("str")
+        assert instr.effective_type() == "any"
+
+    def test_effective_type_no_observation(self):
+        instr = IIRInstr("add", "v0", ["a", "b"], "any")
+        assert instr.effective_type() == "any"
+
+    def test_deopt_anchor(self):
+        instr = IIRInstr("add", "v0", ["a", "b"], "any", deopt_anchor=5)
+        assert instr.deopt_anchor == 5
+
+    def test_repr_no_observation(self):
+        instr = IIRInstr("add", "v0", ["a", "b"], "u8")
+        r = repr(instr)
+        assert "add" in r
+        assert "v0" in r
+
+    def test_repr_with_observation(self):
+        instr = IIRInstr("add", "v0", ["a", "b"], "any")
+        instr.record_observation("u8")
+        r = repr(instr)
+        assert "obs=" in r
+
+    def test_repr_void_dest(self):
+        instr = IIRInstr("ret", None, ["v0"], "u8")
+        r = repr(instr)
+        assert "ret" in r
+        assert "= " not in r  # no "dest = " prefix
+
+    def test_equality_ignores_observation(self):
+        a = IIRInstr("add", "v0", ["a", "b"], "u8")
+        b = IIRInstr("add", "v0", ["a", "b"], "u8")
+        b.record_observation("u8")
+        assert a == b   # compare=False for observation fields
+
+
+# ===========================================================================
+# IIRFunction tests
+# ===========================================================================
+
+class TestIIRFunction:
+    def test_basic_construction(self):
+        fn = make_add_fn()
+        assert fn.name == "add"
+        assert fn.return_type == "u8"
+        assert len(fn.instructions) == 2
+
+    def test_param_names(self):
+        fn = make_add_fn()
+        assert fn.param_names() == ["a", "b"]
+
+    def test_param_types(self):
+        fn = make_add_fn()
+        assert fn.param_types() == ["u8", "u8"]
+
+    def test_infer_type_status_fully_typed(self):
+        fn = make_add_fn("u8")
+        assert fn.infer_type_status() == FunctionTypeStatus.FULLY_TYPED
+
+    def test_infer_type_status_untyped(self):
+        fn = IIRFunction(
+            name="f",
+            params=[("x", "any")],
+            return_type="any",
+            instructions=[IIRInstr("ret", None, ["x"], "any")],
+        )
+        assert fn.infer_type_status() == FunctionTypeStatus.UNTYPED
+
+    def test_infer_type_status_partially_typed(self):
+        fn = IIRFunction(
+            name="f",
+            params=[("x", "u8")],
+            return_type="any",
+            instructions=[IIRInstr("ret", None, ["x"], "any")],
+        )
+        assert fn.infer_type_status() == FunctionTypeStatus.PARTIALLY_TYPED
+
+    def test_infer_type_status_no_instructions(self):
+        fn = IIRFunction(name="f", params=[], return_type="void", instructions=[])
+        assert fn.infer_type_status() == FunctionTypeStatus.UNTYPED
+
+    def test_label_index_found(self):
+        fn = IIRFunction(
+            name="f",
+            params=[],
+            return_type="void",
+            instructions=[
+                IIRInstr("const", "v0", [1], "u8"),
+                IIRInstr("label", None, ["loop_start"], "void"),
+                IIRInstr("ret", None, ["v0"], "u8"),
+            ],
+        )
+        assert fn.label_index("loop_start") == 1
+
+    def test_label_index_not_found(self):
+        fn = make_add_fn()
+        with pytest.raises(KeyError, match="missing"):
+            fn.label_index("missing")
+
+    def test_call_count_default(self):
+        fn = make_add_fn()
+        assert fn.call_count == 0
+
+    def test_repr(self):
+        fn = make_add_fn()
+        r = repr(fn)
+        assert "add" in r
+        assert "FULLY_TYPED" in r
+
+    def test_type_status_enum_values(self):
+        assert FunctionTypeStatus.FULLY_TYPED != FunctionTypeStatus.UNTYPED
+        assert FunctionTypeStatus.PARTIALLY_TYPED != FunctionTypeStatus.FULLY_TYPED
+
+
+# ===========================================================================
+# IIRModule tests
+# ===========================================================================
+
+class TestIIRModule:
+    def test_basic_construction(self):
+        fn = make_add_fn()
+        m = IIRModule(name="prog.ml", functions=[fn], entry_point="add")
+        assert m.name == "prog.ml"
+        assert m.entry_point == "add"
+
+    def test_get_function_found(self):
+        fn = make_add_fn()
+        m = IIRModule(name="x", functions=[fn])
+        assert m.get_function("add") is fn
+
+    def test_get_function_not_found(self):
+        m = IIRModule(name="x", functions=[])
+        assert m.get_function("missing") is None
+
+    def test_function_names(self):
+        a = make_add_fn()
+        b = IIRFunction(name="sub", params=[], return_type="void", instructions=[])
+        m = IIRModule(name="x", functions=[a, b])
+        assert m.function_names() == ["add", "sub"]
+
+    def test_add_or_replace_new(self):
+        m = IIRModule(name="x", functions=[])
+        fn = make_add_fn()
+        m.add_or_replace(fn)
+        assert m.get_function("add") is fn
+
+    def test_add_or_replace_existing(self):
+        old = make_add_fn("u8")
+        new = make_add_fn("u16")
+        m = IIRModule(name="x", functions=[old])
+        m.add_or_replace(new)
+        assert len(m.functions) == 1
+        assert m.get_function("add") is new
+
+    def test_validate_clean(self):
+        fn = make_add_fn()
+        m = IIRModule(name="x", functions=[fn], entry_point="add")
+        assert m.validate() == []
+
+    def test_validate_no_entry_point(self):
+        fn = make_add_fn()
+        m = IIRModule(name="x", functions=[fn], entry_point=None)
+        assert m.validate() == []
+
+    def test_validate_duplicate_function(self):
+        fn1 = make_add_fn()
+        fn2 = make_add_fn()
+        m = IIRModule(name="x", functions=[fn1, fn2], entry_point="add")
+        errors = m.validate()
+        assert any("duplicate" in e for e in errors)
+
+    def test_validate_missing_entry_point(self):
+        fn = make_add_fn()
+        m = IIRModule(name="x", functions=[fn], entry_point="nonexistent")
+        errors = m.validate()
+        assert any("entry_point" in e for e in errors)
+
+    def test_validate_undefined_label(self):
+        fn = IIRFunction(
+            name="main",
+            params=[],
+            return_type="void",
+            instructions=[
+                IIRInstr("jmp", None, ["does_not_exist"], "void"),
+            ],
+        )
+        m = IIRModule(name="x", functions=[fn], entry_point="main")
+        errors = m.validate()
+        assert any("does_not_exist" in e for e in errors)
+
+    def test_validate_defined_label_no_error(self):
+        fn = IIRFunction(
+            name="main",
+            params=[],
+            return_type="void",
+            instructions=[
+                IIRInstr("label", None, ["loop"], "void"),
+                IIRInstr("jmp", None, ["loop"], "void"),
+            ],
+        )
+        m = IIRModule(name="x", functions=[fn], entry_point="main")
+        errors = m.validate()
+        assert errors == []
+
+    def test_validate_branch_with_no_srcs(self):
+        fn = IIRFunction(
+            name="main",
+            params=[],
+            return_type="void",
+            instructions=[
+                IIRInstr("jmp", None, [], "void"),  # empty srcs — no label to check
+            ],
+        )
+        m = IIRModule(name="x", functions=[fn], entry_point="main")
+        errors = m.validate()
+        assert errors == []
+
+    def test_repr(self):
+        fn = make_add_fn()
+        m = IIRModule(
+            name="test.ml", functions=[fn], entry_point="add", language="tetrad"
+        )
+        r = repr(m)
+        assert "test.ml" in r
+        assert "tetrad" in r
+
+    def test_default_language(self):
+        m = IIRModule(name="x")
+        assert m.language == "unknown"
+
+    def test_default_entry_point(self):
+        m = IIRModule(name="x")
+        assert m.entry_point == "main"
+
+
+# ===========================================================================
+# Opcode set tests
+# ===========================================================================
+
+class TestOpcodeSets:
+    def test_arithmetic_ops_contents(self):
+        assert "add" in ARITHMETIC_OPS
+        assert "sub" in ARITHMETIC_OPS
+        assert "mul" in ARITHMETIC_OPS
+        assert "div" in ARITHMETIC_OPS
+        assert "mod" in ARITHMETIC_OPS
+        assert "neg" in ARITHMETIC_OPS
+
+    def test_bitwise_ops_contents(self):
+        assert "and" in BITWISE_OPS
+        assert "or" in BITWISE_OPS
+        assert "xor" in BITWISE_OPS
+        assert "not" in BITWISE_OPS
+        assert "shl" in BITWISE_OPS
+        assert "shr" in BITWISE_OPS
+
+    def test_cmp_ops_contents(self):
+        for op in ["cmp_eq", "cmp_ne", "cmp_lt", "cmp_le", "cmp_gt", "cmp_ge"]:
+            assert op in CMP_OPS
+
+    def test_branch_ops(self):
+        assert "jmp" in BRANCH_OPS
+        assert "jmp_if_true" in BRANCH_OPS
+        assert "jmp_if_false" in BRANCH_OPS
+
+    def test_control_ops(self):
+        assert "label" in CONTROL_OPS
+        assert "ret" in CONTROL_OPS
+        assert "ret_void" in CONTROL_OPS
+
+    def test_memory_ops(self):
+        assert "load_reg" in MEMORY_OPS
+        assert "store_reg" in MEMORY_OPS
+        assert "load_mem" in MEMORY_OPS
+        assert "store_mem" in MEMORY_OPS
+
+    def test_call_ops(self):
+        assert "call" in CALL_OPS
+        assert "call_builtin" in CALL_OPS
+
+    def test_io_ops(self):
+        assert "io_in" in IO_OPS
+        assert "io_out" in IO_OPS
+
+    def test_coercion_ops(self):
+        assert "cast" in COERCION_OPS
+        assert "type_assert" in COERCION_OPS
+
+    def test_value_ops_includes_arithmetic(self):
+        assert ARITHMETIC_OPS.issubset(VALUE_OPS)
+
+    def test_side_effect_ops_includes_branches(self):
+        assert BRANCH_OPS.issubset(SIDE_EFFECT_OPS)
+
+    def test_all_ops_is_superset(self):
+        for op_set in [ARITHMETIC_OPS, BITWISE_OPS, CMP_OPS, BRANCH_OPS,
+                       CONTROL_OPS, MEMORY_OPS, CALL_OPS, IO_OPS, COERCION_OPS]:
+            assert op_set.issubset(ALL_OPS)
+
+    def test_concrete_types(self):
+        for t in ["u8", "u16", "u32", "u64", "bool", "str"]:
+            assert t in CONCRETE_TYPES
+
+    def test_dynamic_type_not_concrete(self):
+        assert DYNAMIC_TYPE not in CONCRETE_TYPES
+
+    def test_polymorphic_constant(self):
+        assert POLYMORPHIC_TYPE == "polymorphic"
+
+
+# ===========================================================================
+# Serialisation tests
+# ===========================================================================
+
+class TestSerialise:
+    def _roundtrip(self, module: IIRModule) -> IIRModule:
+        return deserialise(serialise(module))
+
+    def test_empty_module(self):
+        m = IIRModule(name="empty", functions=[], entry_point=None, language="test")
+        m2 = self._roundtrip(m)
+        assert m2.name == "empty"
+        assert m2.functions == []
+        assert m2.entry_point is None
+        assert m2.language == "test"
+
+    def test_simple_function(self):
+        fn = make_add_fn()
+        m = IIRModule(name="x", functions=[fn], entry_point="add", language="tetrad")
+        m2 = self._roundtrip(m)
+        assert m2.name == "x"
+        assert len(m2.functions) == 1
+        fn2 = m2.functions[0]
+        assert fn2.name == "add"
+        assert fn2.params == [("a", "u8"), ("b", "u8")]
+        assert fn2.return_type == "u8"
+        assert len(fn2.instructions) == 2
+        assert fn2.type_status == FunctionTypeStatus.FULLY_TYPED
+
+    def test_instruction_str_src(self):
+        instr = IIRInstr("add", "v0", ["a", "b"], "u8")
+        fn = IIRFunction(name="f", params=[], return_type="u8", instructions=[instr])
+        m = self._roundtrip(IIRModule(name="x", functions=[fn]))
+        assert m.functions[0].instructions[0].srcs == ["a", "b"]
+
+    def test_instruction_int_src(self):
+        instr = IIRInstr("const", "v0", [42], "u8")
+        fn = IIRFunction(name="f", params=[], return_type="u8", instructions=[instr])
+        m = self._roundtrip(IIRModule(name="x", functions=[fn]))
+        assert m.functions[0].instructions[0].srcs == [42]
+
+    def test_instruction_float_src(self):
+        instr = IIRInstr("const", "v0", [3.14], "any")
+        fn = IIRFunction(name="f", params=[], return_type="any", instructions=[instr])
+        m = self._roundtrip(IIRModule(name="x", functions=[fn]))
+        restored_val = m.functions[0].instructions[0].srcs[0]
+        assert abs(restored_val - 3.14) < 1e-10
+
+    def test_instruction_bool_src_true(self):
+        instr = IIRInstr("const", "v0", [True], "bool")
+        fn = IIRFunction(name="f", params=[], return_type="bool", instructions=[instr])
+        m = self._roundtrip(IIRModule(name="x", functions=[fn]))
+        assert m.functions[0].instructions[0].srcs == [True]
+
+    def test_instruction_bool_src_false(self):
+        instr = IIRInstr("const", "v0", [False], "bool")
+        fn = IIRFunction(name="f", params=[], return_type="bool", instructions=[instr])
+        m = self._roundtrip(IIRModule(name="x", functions=[fn]))
+        assert m.functions[0].instructions[0].srcs == [False]
+
+    def test_void_dest_preserved(self):
+        instr = IIRInstr("ret", None, ["v0"], "u8")
+        fn = IIRFunction(name="f", params=[], return_type="u8", instructions=[instr])
+        m = self._roundtrip(IIRModule(name="x", functions=[fn]))
+        assert m.functions[0].instructions[0].dest is None
+
+    def test_multiple_functions(self):
+        fn1 = make_add_fn()
+        fn2 = IIRFunction(
+            name="sub",
+            params=[("a", "u8"), ("b", "u8")],
+            return_type="u8",
+            instructions=[
+                IIRInstr("sub", "v0", ["a", "b"], "u8"),
+                IIRInstr("ret", None, ["v0"], "u8"),
+            ],
+            type_status=FunctionTypeStatus.FULLY_TYPED,
+        )
+        m = IIRModule(name="x", functions=[fn1, fn2])
+        m2 = self._roundtrip(m)
+        assert [f.name for f in m2.functions] == ["add", "sub"]
+
+    def test_type_status_untyped(self):
+        fn = IIRFunction(
+            name="f",
+            params=[("x", "any")],
+            return_type="any",
+            instructions=[IIRInstr("ret", None, ["x"], "any")],
+            type_status=FunctionTypeStatus.UNTYPED,
+        )
+        m = self._roundtrip(IIRModule(name="x", functions=[fn]))
+        assert m.functions[0].type_status == FunctionTypeStatus.UNTYPED
+
+    def test_type_status_partially_typed(self):
+        fn = IIRFunction(
+            name="f",
+            params=[("x", "u8")],
+            return_type="any",
+            instructions=[IIRInstr("ret", None, ["x"], "any")],
+            type_status=FunctionTypeStatus.PARTIALLY_TYPED,
+        )
+        m = self._roundtrip(IIRModule(name="x", functions=[fn]))
+        assert m.functions[0].type_status == FunctionTypeStatus.PARTIALLY_TYPED
+
+    def test_register_count_preserved(self):
+        fn = IIRFunction(
+            name="f", params=[], return_type="void",
+            instructions=[], register_count=16,
+        )
+        m = self._roundtrip(IIRModule(name="x", functions=[fn]))
+        assert m.functions[0].register_count == 16
+
+    def test_invalid_magic(self):
+        raw = b"BAD\x00" + b"\x00" * 100
+        with pytest.raises(ValueError, match="magic"):
+            deserialise(raw)
+
+    def test_invalid_version(self):
+        raw = serialise(IIRModule(name="x"))
+        # Overwrite version bytes (offset 4,5) with 99.0
+        raw2 = raw[:4] + struct.pack("<BB", 99, 0) + raw[6:]
+        with pytest.raises(ValueError, match="version"):
+            deserialise(raw2)
+
+    def test_truncated_data(self):
+        raw = serialise(IIRModule(name="x", functions=[make_add_fn()]))
+        with pytest.raises(ValueError, match="end of data"):
+            deserialise(raw[:20])
+
+    def test_observation_fields_not_serialised(self):
+        instr = IIRInstr("add", "v0", ["a", "b"], "any")
+        instr.record_observation("u8")
+        instr.deopt_anchor = 3
+        fn = IIRFunction(name="f", params=[], return_type="any", instructions=[instr])
+        m = self._roundtrip(IIRModule(name="x", functions=[fn]))
+        restored_instr = m.functions[0].instructions[0]
+        assert restored_instr.observed_type is None
+        assert restored_instr.observation_count == 0
+        assert restored_instr.deopt_anchor is None
+
+    def test_unicode_names(self):
+        fn = IIRFunction(
+            name="добавить",
+            params=[("а", "u8"), ("б", "u8")],
+            return_type="u8",
+            instructions=[IIRInstr("ret", None, ["а"], "u8")],
+        )
+        m = IIRModule(name="тест.ml", functions=[fn], language="test")
+        m2 = self._roundtrip(m)
+        assert m2.name == "тест.ml"
+        assert m2.functions[0].name == "добавить"
+
+    def test_negative_int_src(self):
+        instr = IIRInstr("const", "v0", [-100], "u8")
+        fn = IIRFunction(name="f", params=[], return_type="u8", instructions=[instr])
+        m = self._roundtrip(IIRModule(name="x", functions=[fn]))
+        assert m.functions[0].instructions[0].srcs == [-100]
+
+    def test_large_int_src(self):
+        instr = IIRInstr("const", "v0", [2**32], "u64")
+        fn = IIRFunction(name="f", params=[], return_type="u64", instructions=[instr])
+        m = self._roundtrip(IIRModule(name="x", functions=[fn]))
+        assert m.functions[0].instructions[0].srcs == [2**32]
+
+    def test_unknown_operand_kind_raises(self):
+        # Build a raw payload with an unknown kind byte
+        raw = serialise(IIRModule(name="x", functions=[make_add_fn()]))
+        # Find the operand kind byte for "a" src and corrupt it.
+        # We'll just manually craft a bad reader state by patching bytes.
+        # Instead, test via direct reader call:
+        from interpreter_ir.serialise import _Reader
+        r = _Reader(b"\x09")  # kind=9, unknown
+        r.u8()  # consume it
+        # Can't call _read_instr directly easily, so test deserialise of bad data:
+        # Build a module with one instr, then corrupt the kind byte.
+        raw2 = bytearray(raw)
+        # Locate and corrupt the first src kind byte — fragile but effective.
+        # The serialise format is deterministic; we just test the error path.
+        with pytest.raises((ValueError, struct.error)):
+            # Corrupt last few bytes to force a bad kind
+            bad = bytes(raw2[:-5]) + b"\x09\x00\x00\x00\x00"
+            deserialise(bad)


### PR DESCRIPTION
## Summary

- Implements `interpreter-ir` (spec LANG01) — the zero-dependency shared dynamic bytecode IR for the generic language pipeline
- **`IIRInstr`** — instruction with op/dest/srcs/type_hint + runtime feedback slots (`observed_type`, `observation_count`, `deopt_anchor`); `record_observation()` protocol for vm-core profiler
- **`IIRFunction`** — named parameterised instruction sequence; `FunctionTypeStatus` enum (FULLY_TYPED / PARTIALLY_TYPED / UNTYPED); `infer_type_status()`, `label_index()`
- **`IIRModule`** — top-level container; `add_or_replace()` for REPL incremental state; `validate()` for structural correctness checks
- **`opcodes.py`** — frozenset constants for all opcode categories; type constants `CONCRETE_TYPES`, `DYNAMIC_TYPE`, `POLYMORPHIC_TYPE`
- **`serialise.py`** — little-endian binary format (`IIR\x00` magic); observation fields intentionally excluded (runtime state, always fresh on load)

## Test plan

- [ ] 86 tests, 100% line coverage
- [ ] All ruff checks pass
- [ ] `uv venv && uv pip install -e ".[dev]" && python -m pytest tests/ -v` — all green
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)