### PR TITLE
feat(algol): allow array reads in expression thunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Advanced PL04 Phase 5 call-by-name lowering with integer array-element
   eval/store thunk descriptors, including repeated re-location of subscripted
   actuals on formal reads and assignments.
+- Enabled read-only ALGOL expression thunks to read arrays, covering
+  Jensen's-device terms such as `a[i] * i` through the WASM runtime path.
 
 ### Added — TypeScript Port + JavaScript/TypeScript Grammars (PR #14)
 - **31 TypeScript packages** — complete port of the computing stack to TypeScript

--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -29,6 +29,8 @@ All notable changes to this package will be documented in this file.
 - Lowered integer array-element by-name actuals to tagged descriptors with
   generated eval/store helpers that re-compute the element address on every
   formal read or assignment.
+- Allowed read-only expression eval thunks to read integer arrays, including
+  helper-side bounds failure propagation back into the caller unwind path.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -31,9 +31,11 @@ generated helper that re-evaluates the expression against the caller frame each
 time. Integer array-element actuals lower to tagged descriptors as well; formal
 reads re-compute the element address through the eval helper, and writable
 formals call a generated store helper that re-locates the element before storing
-the new value. Expression thunks that read arrays, expression thunks that call
-procedures, and stores through read-only expression thunks still raise targeted
-`CompileError` diagnostics until Phase 5 grows full expression-helper coverage.
+the new value. Read-only expression thunks can also read array elements; helper
+bounds failures are reported back to the calling procedure before the normal
+frame and thunk-region unwind. Expression thunks that call procedures and stores
+through read-only expression thunks still raise targeted `CompileError`
+diagnostics until Phase 5 grows full expression-helper coverage.
 
 This phase keeps ALGOL frame memory and its 28-byte runtime state bounded to
 one 64 KiB WASM page, and keeps array descriptors plus element storage inside a

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -109,6 +109,7 @@ class _FrameScope:
     heap_mark_reg: int | None = None
     parent: _FrameScope | None = None
     active_thunk_heap_mark_reg: int | None = None
+    helper_failure: bool = False
 
     @property
     def block_id(self) -> int:
@@ -1144,20 +1145,6 @@ class AlgolIrCompiler:
                 "expression actual; eval thunk procedure-call lowering is not "
                 "implemented yet"
             )
-        array_variable = next(
-            (
-                variable
-                for variable in _nodes(argument, "variable")
-                if _variable_subscripts(variable)
-            ),
-            None,
-        )
-        if array_variable is not None:
-            raise CompileError(
-                f"by-name parameter {parameter.name!r} received an expression "
-                "actual that reads an array element; array eval thunk lowering "
-                "is not implemented yet"
-            )
 
     def _register_eval_thunk(
         self,
@@ -1286,6 +1273,7 @@ class AlgolIrCompiler:
                 heap_mark_reg=None,
                 parent=None,
                 active_thunk_heap_mark_reg=active_thunk_heap_mark,
+                helper_failure=True,
             )
             if thunk.is_array_element:
                 data_pointer, byte_offset = self._compile_array_element_address(
@@ -1351,6 +1339,7 @@ class AlgolIrCompiler:
                 heap_mark_reg=None,
                 parent=None,
                 active_thunk_heap_mark_reg=active_thunk_heap_mark,
+                helper_failure=True,
             )
             data_pointer, byte_offset = self._compile_array_element_address(
                 thunk.expression,
@@ -1422,6 +1411,7 @@ class AlgolIrCompiler:
             variable,
             scope,
             role="read",
+            helper_failure=scope.helper_failure,
         )
         dst = self._fresh_reg()
         self._emit(

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -339,16 +339,22 @@ class TestAlgolIrCompiler:
         assert result.procedure_signatures["_fn_algol_eval_thunk"] == 2
         assert result.procedure_signatures["_fn_algol_store_thunk"] == 3
 
-    def test_rejects_array_read_inside_expression_eval_thunk(self) -> None:
-        with pytest.raises(CompileError, match="array eval thunk"):
-            compile_algol(
-                parse_algol(
-                    "begin integer result; integer array a[1:2]; "
-                    "integer procedure id(x); integer x; begin id := x end; "
-                    "result := id(a[1] + 1) "
-                    "end"
-                )
+    def test_compiles_array_read_inside_expression_eval_thunk(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; integer array a[1:2]; "
+                "integer procedure id(x); integer x; begin id := x end; "
+                "result := id(a[1] + 1) "
+                "end"
             )
+        )
+        calls = [
+            instruction.operands[0].name
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.CALL
+        ]
+
+        assert "_fn_algol_eval_thunk" in calls
 
     def test_rejects_procedure_call_inside_expression_eval_thunk(self) -> None:
         with pytest.raises(CompileError, match="procedure-call expression"):

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -22,6 +22,9 @@ All notable changes to this package will be documented in this file.
 - Executed integer array-element by-name actuals through eval/store thunk
   helpers so repeated formal reads and assignments re-locate the current
   element, including Jensen-style index mutation between formal uses.
+- Executed read-only expression thunks that read integer arrays, including
+  Jensen's-device expressions and bounds failures propagated through the caller
+  unwind path.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -29,8 +29,9 @@ actuals now compile as tagged eval thunk descriptors, so each by-name formal
 read re-evaluates the expression using the caller frame captured at the call
 site. Integer array-element by-name actuals now compile as tagged descriptors
 with eval/store helpers, so reads and assignments re-compute the current element
-address every time the formal is used. Expression thunks that read arrays,
-expression thunks that call procedures, and expression thunk stores remain
+address every time the formal is used. Read-only expression thunks can also
+read array elements, including Jensen-style terms such as `a[i] * i`.
+Expression thunks that call procedures and expression thunk stores remain
 guarded by IR compile-stage diagnostics until full Phase 5 expression-helper
 coverage is available.
 

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -44,16 +44,6 @@ class TestAlgolWasmCompiler:
             compile_source("begin integer result; result := false end")
         assert raised.value.stage == "type-check"
 
-    def test_array_read_expression_by_name_waits_for_eval_thunk_stage(self) -> None:
-        with pytest.raises(AlgolWasmError) as raised:
-            compile_source(
-                "begin integer result; integer array a[1:2]; "
-                "integer procedure id(x); integer x; begin id := x end; "
-                "result := id(a[1] + 1) "
-                "end"
-            )
-        assert raised.value.stage == "ir-compile"
-
     def test_procedure_call_expression_by_name_waits_for_eval_thunk_stage(
         self,
     ) -> None:
@@ -182,6 +172,50 @@ class TestAlgolWasmCompiler:
             "end"
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [0]
+
+    def test_array_read_expression_by_name_re_evaluates_on_each_read(self) -> None:
+        result = compile_source(
+            "begin integer result, i; integer array a[1:2]; "
+            "integer procedure probe(x); integer x; "
+            "begin probe := x; a[1] := 9; probe := probe * 100 + x end; "
+            "a[1] := 3; i := 1; "
+            "result := probe(a[i] + 1) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [410]
+
+    def test_array_read_expression_by_name_bounds_failure_propagates(self) -> None:
+        result = compile_source(
+            "begin integer result, i; integer array a[1:2]; "
+            "integer procedure id(x); integer x; begin id := x end; "
+            "i := 3; result := id(a[i] + 1) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [0]
+
+    def test_jensens_device_sums_array_element_expression(self) -> None:
+        result = compile_source(
+            "begin integer result, i; integer array a[1:3]; "
+            "integer procedure sum(k, lo, hi, term); "
+            "value lo, hi; integer k, lo, hi, term; "
+            "begin sum := 0; for k := lo step 1 until hi do sum := sum + term end; "
+            "a[1] := 2; a[2] := 3; a[3] := 5; "
+            "result := sum(i, 1, 3, a[i]) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [10]
+
+    def test_jensens_device_sums_array_expression(self) -> None:
+        result = compile_source(
+            "begin integer result, i; integer array a[1:3]; "
+            "integer procedure sum(k, lo, hi, term); "
+            "value lo, hi; integer k, lo, hi, term; "
+            "begin sum := 0; for k := lo step 1 until hi do sum := sum + term end; "
+            "a[1] := 2; a[2] := 3; a[3] := 5; "
+            "result := sum(i, 1, 3, a[i] * i) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [23]
 
     def test_read_only_by_name_expression_re_evaluates_on_each_read(self) -> None:
         result = compile_source(

--- a/code/specs/PL04-algol60-full-wasm-runtime.md
+++ b/code/specs/PL04-algol60-full-wasm-runtime.md
@@ -737,6 +737,14 @@ helper that re-evaluates the original designator, including current subscript
 values, before storing. Helper-side bounds failures must be reported back to the
 calling procedure so the normal frame and thunk-region unwinding still runs.
 
+Current Phase 5d lowering may allow read-only expression descriptors to read
+integer arrays. The eval helper should mark its synthetic caller-frame scope as
+a helper context, so checked array loads inside expression thunks report bounds
+failures through the thunk failure flag and let the by-name formal read perform
+the caller's normal unwind. Procedure calls inside expression thunks remain
+rejected until helper calls can safely manage nested returns and failure
+propagation.
+
 ### Required Diagnostics
 
 The phase is not complete unless unsupported forms fail before WASM lowering


### PR DESCRIPTION
## Summary
- allow read-only ALGOL by-name expression thunks to read integer arrays
- route array bounds failures inside thunk helpers through the existing thunk failure propagation path
- add WASM coverage for array-reading expressions, bounds failures, and Jensen's-device terms
- update PL04 docs, package READMEs, and changelogs

## Tests
- bash BUILD (code/packages/python/algol-ir-compiler)
- bash BUILD (code/packages/python/algol-wasm-compiler)
- ruff check code/packages/python/algol-ir-compiler/src code/packages/python/algol-ir-compiler/tests code/packages/python/algol-wasm-compiler/tests

## Security review
- verified descriptor lifetime and allocation behavior are unchanged
- verified procedure-call expressions inside eval thunks remain rejected
- verified array bounds failures inside helpers propagate through the thunk failure flag before caller unwind