### PR TITLE
feat(logic): add scoped Prolog cut

### DIFF
--- a/code/packages/python/logic-builtins/CHANGELOG.md
+++ b/code/packages/python/logic-builtins/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.9.0] - 2026-04-22
+
+### Added
+
+- `cuto()` as the library spelling of Prolog cut backed by engine-level scoped
+  choicepoint pruning
+- builtin predicate metadata for `cuto/0`
+- tests distinguishing `cuto()` from `onceo(...)` and proving it commits the
+  surrounding search frame
+
 ## [0.8.0] - 2026-04-21
 
 ### Added

--- a/code/packages/python/logic-builtins/README.md
+++ b/code/packages/python/logic-builtins/README.md
@@ -12,6 +12,7 @@ ordinary logic goal expressions.
 - `callo(goal)`
 - `calltermo(term_goal)` for executing reified callable goal terms
 - `onceo(goal)`
+- `cuto()` as the library form of Prolog `!/0`
 - `noto(goal)` for negation as failure
 - `trueo()` and `failo()`
 - `iftheno(condition, then_goal)` and `ifthenelseo(condition, then_goal, else_goal)`
@@ -50,6 +51,7 @@ from logic_builtins import (
     clauseo,
     compare_termo,
     current_predicateo,
+    cuto,
     findallo,
     forallo,
     functoro,
@@ -67,6 +69,7 @@ from logic_builtins import (
 from logic_engine import (
     atom,
     conj,
+    disj,
     eq,
     fail,
     logic_list,
@@ -95,6 +98,11 @@ memo = relation("memo", 1)
 family = program(rule(child(X, Name), parent(Name, X)))
 
 assert solve_all(program(), X, onceo(eq(X, "first"))) == [atom("first")]
+assert solve_all(
+    program(),
+    X,
+    conj(disj(eq(X, "first"), eq(X, "second")), cuto()),
+) == [atom("first")]
 assert solve_all(program(), X, noto(fail())) == [X]
 assert solve_all(program(), X, conj(eq(X, term("box", "tea")), groundo(X))) == [
     term("box", "tea"),
@@ -168,12 +176,12 @@ Collections are observations over a nested proof search. `findallo` succeeds
 with an empty list when the inner goal fails, while `bagofo` and `setofo` fail
 for empty collections.
 
-Advanced control is intentionally honest about the current solver. `iftheno`
-and `ifthenelseo` commit to the first condition proof while allowing the chosen
-branch to keep backtracking. `forallo` checks every generated proof without
-leaking generator bindings to the outer query. Full Prolog cut is not included
-yet because it needs solver-level choicepoint pruning rather than a simple
-library predicate.
+Advanced control is intentionally honest about the solver. `cuto()` is real
+solver-level cut, not `onceo` in disguise: it prunes choicepoints made before it
+in the current search frame while allowing choices created after it to continue
+backtracking. `iftheno` and `ifthenelseo` commit to the first condition proof
+while allowing the chosen branch to keep backtracking. `forallo` checks every
+generated proof without leaking generator bindings to the outer query.
 
 Term metaprogramming treats terms as ordinary data. `univo` decomposes
 `box(tea, cake)` into `[box, tea, cake]` and can construct the term back from

--- a/code/packages/python/logic-builtins/pyproject.toml
+++ b/code/packages/python/logic-builtins/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-logic-builtins"
-version = "0.8.0"
-description = "Prolog-inspired dynamic database, callable-term, predicate-metadata, term-order, control, and metaprogramming builtins for Python"
+version = "0.9.0"
+description = "Prolog-inspired cut, dynamic database, callable-term, predicate-metadata, term-order, control, and metaprogramming builtins for Python"
 requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]
 readme = "README.md"
 dependencies = [
-    "coding-adventures-logic-engine>=0.8.0",
+    "coding-adventures-logic-engine>=0.9.0",
 ]
 
 [project.urls]

--- a/code/packages/python/logic-builtins/src/logic_builtins/__init__.py
+++ b/code/packages/python/logic-builtins/src/logic_builtins/__init__.py
@@ -21,6 +21,7 @@ from logic_builtins.builtins import (
     compoundo,
     copytermo,
     current_predicateo,
+    cuto,
     div,
     dynamico,
     failo,
@@ -79,6 +80,7 @@ __all__ = [
     "compare_termo",
     "copytermo",
     "current_predicateo",
+    "cuto",
     "div",
     "dynamico",
     "failo",
@@ -119,4 +121,4 @@ __all__ = [
     "varo",
 ]
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"

--- a/code/packages/python/logic-builtins/src/logic_builtins/builtins.py
+++ b/code/packages/python/logic-builtins/src/logic_builtins/builtins.py
@@ -33,6 +33,7 @@ from logic_engine import (
     clause_body,
     clause_from_term,
     conj,
+    cut,
     eq,
     freshen_clause,
     goal_as_term,
@@ -72,6 +73,7 @@ __all__ = [
     "compare_termo",
     "copytermo",
     "current_predicateo",
+    "cuto",
     "dynamico",
     "div",
     "failo",
@@ -140,6 +142,7 @@ _BUILTIN_PREDICATES: tuple[tuple[str, int], ...] = (
     ("compoundo", 1),
     ("copytermo", 2),
     ("current_predicateo", 2),
+    ("cuto", 0),
     ("dynamico", 2),
     ("failo", 0),
     ("findallo", 3),
@@ -431,6 +434,12 @@ def failo() -> GoalExpr:
     """Fail without yielding any successor states."""
 
     return engine_fail()
+
+
+def cuto() -> GoalExpr:
+    """Commit to choices made so far in the current search-control frame."""
+
+    return cut()
 
 
 def iftheno(condition: object, then_goal: object) -> GoalExpr:

--- a/code/packages/python/logic-builtins/tests/test_logic_builtins.py
+++ b/code/packages/python/logic-builtins/tests/test_logic_builtins.py
@@ -43,6 +43,7 @@ from logic_builtins import (
     compoundo,
     copytermo,
     current_predicateo,
+    cuto,
     div,
     dynamico,
     failo,
@@ -88,7 +89,7 @@ class TestVersion:
     """Verify the package is importable and versioned."""
 
     def test_version_exists(self) -> None:
-        assert __version__ == "0.8.0"
+        assert __version__ == "0.9.0"
 
 
 class TestAdvancedControlBuiltins:
@@ -479,6 +480,33 @@ class TestControlBuiltins:
         )
 
         assert answers == [atom("first")]
+
+    def test_cuto_commits_surrounding_search(self) -> None:
+        item = var("Item")
+
+        assert solve_all(
+            program(),
+            item,
+            conj(disj(eq(item, "first"), eq(item, "second")), cuto()),
+        ) == [atom("first")]
+
+    def test_cuto_is_not_onceo(self) -> None:
+        outer = var("Outer")
+        inner = var("Inner")
+
+        assert solve_all(
+            program(),
+            (outer, inner),
+            conj(
+                disj(eq(outer, "left"), eq(outer, "right")),
+                onceo(disj(eq(inner, "one"), eq(inner, "two"))),
+            ),
+        ) == [(atom("left"), atom("one")), (atom("right"), atom("one"))]
+        assert solve_all(
+            program(),
+            outer,
+            conj(disj(eq(outer, "left"), eq(outer, "right")), cuto()),
+        ) == [atom("left")]
 
     def test_noto_succeeds_when_goal_fails_and_fails_when_goal_succeeds(self) -> None:
         marker = var("Marker")

--- a/code/packages/python/logic-engine/CHANGELOG.md
+++ b/code/packages/python/logic-engine/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.9.0] - 2026-04-22
+
+### Added
+
+- `CutExpr` and `cut()` as the library representation of Prolog `!/0`
+- internal search-result cut propagation so conjunctions and disjunctions can
+  prune scoped choicepoints without changing the public `solve` iterator API
+- relation-call cut frames that consume cuts raised inside rule bodies while
+  still pruning later clauses for that predicate invocation
+- `goal_as_term`/`goal_from_term` support for encoding and lowering cut as
+  the atom `!`
+- tests proving cut prunes choices before it, keeps choices after it, commits
+  rule bodies and later clauses, and stays scoped to the callee relation
+
 ## [0.8.0] - 2026-04-21
 
 ### Added

--- a/code/packages/python/logic-engine/README.md
+++ b/code/packages/python/logic-engine/README.md
@@ -14,6 +14,7 @@ that make relational programs feel like programs:
 - persistent database updates via `asserta(...)`, `assertz(...)`, `retract_*`,
   and `abolish(...)`
 - dynamic predicate declarations and branch-local runtime database overlays
+- scoped search control via `cut()` as the library form of Prolog `!/0`
 - recursive solving with depth-first backtracking
 - deferred recursive goal builders via `defer(...)`
 - state-aware native goal hooks via `native_goal(...)` for library builtins
@@ -158,6 +159,30 @@ assert solve_all(family, Child, goal_from_term(term("parent", "homer", Child))) 
     atom("bart"),
     atom("lisa"),
 ]
+```
+
+## Search Control
+
+`cut()` succeeds once and commits to choices made earlier in the current query
+or predicate invocation. Choices created after the cut can still backtrack, and
+cuts inside a relation body are consumed by that relation call instead of
+leaking into the caller.
+
+```python
+from logic_engine import atom, conj, cut, disj, eq, program, solve_all, var
+
+X = var("X")
+
+assert solve_all(
+    program(),
+    X,
+    conj(disj(eq(X, "first"), eq(X, "second")), cut()),
+) == [atom("first")]
+assert solve_all(
+    program(),
+    X,
+    conj(cut(), disj(eq(X, "first"), eq(X, "second"))),
+) == [atom("first"), atom("second")]
 ```
 
 ## Dependencies

--- a/code/packages/python/logic-engine/pyproject.toml
+++ b/code/packages/python/logic-engine/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-logic-engine"
-version = "0.8.0"
-description = "Logic programming engine: relations, clauses, callable terms, dynamic runtime predicates, resolution, and disequality"
+version = "0.9.0"
+description = "Logic programming engine: relations, clauses, callable terms, dynamic runtime predicates, cut, resolution, and disequality"
 requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]

--- a/code/packages/python/logic-engine/src/logic_engine/__init__.py
+++ b/code/packages/python/logic-engine/src/logic_engine/__init__.py
@@ -11,6 +11,7 @@ from logic_engine.engine import (
     Clause,
     Compound,
     ConjExpr,
+    CutExpr,
     DeferredExpr,
     Disequality,
     DisjExpr,
@@ -42,6 +43,7 @@ from logic_engine.engine import (
     clause_from_term,
     clauses_matching,
     conj,
+    cut,
     declare_dynamic,
     defer,
     disj,
@@ -90,6 +92,7 @@ __all__ = [
     "Clause",
     "Compound",
     "ConjExpr",
+    "CutExpr",
     "DeferredExpr",
     "DynamicDatabase",
     "DisjExpr",
@@ -120,6 +123,7 @@ __all__ = [
     "clause_from_term",
     "clauses_matching",
     "conj",
+    "cut",
     "declare_dynamic",
     "defer",
     "disj",
@@ -161,4 +165,4 @@ __all__ = [
     "visible_predicate_keys",
 ]
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"

--- a/code/packages/python/logic-engine/src/logic_engine/engine.py
+++ b/code/packages/python/logic-engine/src/logic_engine/engine.py
@@ -53,6 +53,7 @@ __all__ = [
     "Clause",
     "Compound",
     "ConjExpr",
+    "CutExpr",
     "DeferredExpr",
     "DynamicDatabase",
     "DisjExpr",
@@ -84,6 +85,7 @@ __all__ = [
     "clause_from_term",
     "clauses_matching",
     "conj",
+    "cut",
     "declare_dynamic",
     "defer",
     "disj",
@@ -231,6 +233,11 @@ class FailExpr:
 
 
 @dataclass(frozen=True, slots=True)
+class CutExpr:
+    """A goal expression that commits to choices made in the current frame."""
+
+
+@dataclass(frozen=True, slots=True)
 class EqExpr:
     """A structured equality goal that delegates unification to LP00."""
 
@@ -307,6 +314,7 @@ type GoalExpr = (
     RelationCall
     | SucceedExpr
     | FailExpr
+    | CutExpr
     | EqExpr
     | NeqExpr
     | NativeGoalExpr
@@ -326,6 +334,7 @@ def _coerce_goal(goal: object) -> GoalExpr:
             RelationCall
             | SucceedExpr
             | FailExpr
+            | CutExpr
             | EqExpr
             | NeqExpr
             | NativeGoalExpr
@@ -351,6 +360,18 @@ def fail() -> GoalExpr:
     """Construct a failure goal expression."""
 
     return FailExpr()
+
+
+def cut() -> GoalExpr:
+    """Construct a scoped Prolog-style cut goal expression.
+
+    Cut succeeds once, then prunes choicepoints created earlier in the current
+    query or predicate invocation. Predicate calls consume cuts raised by their
+    own clause bodies, so a cut inside a relation commits that relation without
+    accidentally pruning the caller's surrounding search.
+    """
+
+    return CutExpr()
 
 
 def eq(left: object, right: object) -> GoalExpr:
@@ -525,6 +546,18 @@ class _VisibleClause:
     clause: Clause
     source: str
     index: int
+
+
+@dataclass(frozen=True, slots=True)
+class _SearchResult:
+    """One internal proof event plus whether a cut fired on that path.
+
+    ``state=None`` represents a failing path that still needs to propagate a
+    cut, such as the Prolog pattern ``!, fail``.
+    """
+
+    state: State | None
+    cut: bool = False
 
 
 def _normalize_relation_keys(keys: Iterable[RelationKey]) -> frozenset[RelationKey]:
@@ -772,6 +805,8 @@ def goal_as_term(goal_value: object) -> Term:
         return atom("true")
     if isinstance(goal, FailExpr):
         return atom("fail")
+    if isinstance(goal, CutExpr):
+        return atom("!")
     if isinstance(goal, EqExpr):
         return term("=", goal.left, goal.right)
     if isinstance(goal, NeqExpr):
@@ -829,6 +864,8 @@ def goal_from_term(term_value: object) -> GoalExpr:
             return succeed()
         if _is_plain_atom(callable_term, "fail"):
             return fail()
+        if _is_plain_atom(callable_term, "!"):
+            return cut()
         return RelationCall(
             relation=Relation(symbol=callable_term.symbol, arity=0),
             args=(),
@@ -1642,6 +1679,124 @@ def _instantiate_fresh(goal: FreshExpr, state: State) -> tuple[GoalExpr, State]:
     return renamed_body, next_state
 
 
+def _solve_goal_results(
+    program_value: Program,
+    goal: GoalExpr,
+    state: State,
+) -> Iterator[_SearchResult]:
+    """Interpret one goal expression and retain internal cut signals."""
+
+    if isinstance(goal, SucceedExpr):
+        yield _SearchResult(state)
+        return
+
+    if isinstance(goal, FailExpr):
+        return
+
+    if isinstance(goal, CutExpr):
+        yield _SearchResult(state, cut=True)
+        return
+
+    if isinstance(goal, EqExpr):
+        for next_state in core_eq(goal.left, goal.right)(state):
+            yield _SearchResult(next_state)
+        return
+
+    if isinstance(goal, NeqExpr):
+        for next_state in core_neq(goal.left, goal.right)(state):
+            yield _SearchResult(next_state)
+        return
+
+    if isinstance(goal, NativeGoalExpr):
+        for next_state in goal.runner(program_value, state, goal.args):
+            yield _SearchResult(next_state)
+        return
+
+    if isinstance(goal, ConjExpr):
+        yield from _solve_conjunction_results(program_value, goal.goals, state)
+        return
+
+    if isinstance(goal, DisjExpr):
+        for branch in goal.goals:
+            branch_cut = False
+            for result in _solve_goal_results(program_value, branch, state):
+                branch_cut = branch_cut or result.cut
+                yield result
+            if branch_cut:
+                break
+        return
+
+    if isinstance(goal, DeferredExpr):
+        expanded_goal = _coerce_goal(goal.builder(*goal.args))
+        yield from _solve_goal_results(program_value, expanded_goal, state)
+        return
+
+    if isinstance(goal, FreshExpr):
+        renamed_body, next_state = _instantiate_fresh(goal, state)
+        yield from _solve_goal_results(program_value, renamed_body, next_state)
+        return
+
+    for clause in visible_clauses_for(program_value, goal.relation, state):
+        clause_cut = False
+        fresh_clause, next_var_id = _freshen_clause(clause, state.next_var_id)
+        for unified_state in core_eq(goal.as_term(), fresh_clause.head.as_term())(
+            state,
+        ):
+            clause_state = _state_with_next_var_id(unified_state, next_var_id)
+            if fresh_clause.body is None:
+                yield _SearchResult(clause_state)
+            else:
+                for result in _solve_goal_results(
+                    program_value,
+                    fresh_clause.body,
+                    clause_state,
+                ):
+                    clause_cut = clause_cut or result.cut
+                    if result.state is not None:
+                        yield _SearchResult(result.state)
+                if clause_cut:
+                    break
+        if clause_cut:
+            break
+
+
+def _solve_conjunction_results(
+    program_value: Program,
+    goals: tuple[GoalExpr, ...],
+    state: State,
+) -> Iterator[_SearchResult]:
+    """Solve conjunctions left-to-right while propagating scoped cuts."""
+
+    if not goals:
+        yield _SearchResult(state)
+        return
+
+    first, *rest = goals
+    for first_result in _solve_goal_results(program_value, first, state):
+        cut_seen = first_result.cut
+        if first_result.state is None:
+            if cut_seen:
+                yield _SearchResult(None, cut=True)
+                break
+            continue
+        emitted_rest_result = False
+        for rest_result in _solve_conjunction_results(
+            program_value,
+            tuple(rest),
+            first_result.state,
+        ):
+            emitted_rest_result = True
+            cut_seen = cut_seen or rest_result.cut
+            if rest_result.state is None:
+                yield _SearchResult(None, cut=cut_seen)
+            else:
+                yield _SearchResult(rest_result.state, cut=cut_seen)
+        if first_result.cut and not emitted_rest_result:
+            yield _SearchResult(None, cut=True)
+        if cut_seen:
+            break
+
+
 def _solve_goal(
     program_value: Program,
     goal: GoalExpr,
@@ -1649,70 +1804,9 @@ def _solve_goal(
 ) -> Iterator[State]:
     """Interpret one goal expression against ``program_value``."""
 
-    if isinstance(goal, SucceedExpr):
-        yield state
-        return
-
-    if isinstance(goal, FailExpr):
-        return
-
-    if isinstance(goal, EqExpr):
-        yield from core_eq(goal.left, goal.right)(state)
-        return
-
-    if isinstance(goal, NeqExpr):
-        yield from core_neq(goal.left, goal.right)(state)
-        return
-
-    if isinstance(goal, NativeGoalExpr):
-        yield from goal.runner(program_value, state, goal.args)
-        return
-
-    if isinstance(goal, ConjExpr):
-        yield from _solve_conjunction(program_value, goal.goals, state)
-        return
-
-    if isinstance(goal, DisjExpr):
-        for branch in goal.goals:
-            yield from _solve_goal(program_value, branch, state)
-        return
-
-    if isinstance(goal, DeferredExpr):
-        expanded_goal = _coerce_goal(goal.builder(*goal.args))
-        yield from _solve_goal(program_value, expanded_goal, state)
-        return
-
-    if isinstance(goal, FreshExpr):
-        renamed_body, next_state = _instantiate_fresh(goal, state)
-        yield from _solve_goal(program_value, renamed_body, next_state)
-        return
-
-    for clause in visible_clauses_for(program_value, goal.relation, state):
-        fresh_clause, next_var_id = _freshen_clause(clause, state.next_var_id)
-        for unified_state in core_eq(goal.as_term(), fresh_clause.head.as_term())(
-            state,
-        ):
-            clause_state = _state_with_next_var_id(unified_state, next_var_id)
-            if fresh_clause.body is None:
-                yield clause_state
-            else:
-                yield from _solve_goal(program_value, fresh_clause.body, clause_state)
-
-
-def _solve_conjunction(
-    program_value: Program,
-    goals: tuple[GoalExpr, ...],
-    state: State,
-) -> Iterator[State]:
-    """Solve conjunctions left-to-right, threading substitutions through."""
-
-    if not goals:
-        yield state
-        return
-
-    first, *rest = goals
-    for next_state in _solve_goal(program_value, first, state):
-        yield from _solve_conjunction(program_value, tuple(rest), next_state)
+    for result in _solve_goal_results(program_value, goal, state):
+        if result.state is not None:
+            yield result.state
 
 
 def solve(program_value: Program, goal: object) -> Iterator[State]:

--- a/code/packages/python/logic-engine/tests/test_logic_engine.py
+++ b/code/packages/python/logic-engine/tests/test_logic_engine.py
@@ -30,6 +30,7 @@ from logic_engine import (
     clause_from_term,
     clauses_matching,
     conj,
+    cut,
     declare_dynamic,
     defer,
     disj,
@@ -68,7 +69,7 @@ class TestVersion:
     """Verify the package is importable and versioned."""
 
     def test_version_exists(self) -> None:
-        assert __version__ == "0.8.0"
+        assert __version__ == "0.9.0"
 
 
 class TestRelationsAndClauses:
@@ -412,6 +413,7 @@ class TestClauseTermIntrospection:
         assert goal_as_term(parent(x, y)) == term("parent", x, y)
         assert goal_as_term(succeed()) == atom("true")
         assert goal_as_term(fail()) == atom("fail")
+        assert goal_as_term(cut()) == atom("!")
         assert goal_as_term(eq(x, "homer")) == term("=", x, "homer")
         assert goal_as_term(neq(x, "homer")) == term("\\=", x, "homer")
         encoded_conjunction = goal_as_term(
@@ -480,6 +482,16 @@ class TestClauseTermIntrospection:
                 term(";", term("=", child, "tea"), term("=", child, "cake")),
             ),
         ) == [atom("tea"), atom("cake")]
+        assert solve_all(
+            program(),
+            child,
+            conj(
+                goal_from_term(
+                    term(";", term("=", child, "tea"), term("=", child, "cake")),
+                ),
+                goal_from_term(atom("!")),
+            ),
+        ) == [atom("tea")]
 
     def test_goal_from_term_lowers_callable_atoms_to_zero_arity_relations(self) -> None:
         ready = relation("ready", 0)
@@ -597,6 +609,97 @@ class TestRecursivePrograms:
             atom("c"),
             atom("d"),
         ]
+
+
+class TestSearchControl:
+    """Cut should prune scoped choicepoints without replacing ordinary search."""
+
+    def test_cut_prunes_prior_query_choicepoints(self) -> None:
+        item = var("Item")
+
+        assert solve_all(
+            program(),
+            item,
+            conj(disj(eq(item, "first"), eq(item, "second")), cut()),
+        ) == [atom("first")]
+
+    def test_cut_keeps_choices_created_after_it(self) -> None:
+        item = var("Item")
+
+        assert solve_all(
+            program(),
+            item,
+            conj(cut(), disj(eq(item, "first"), eq(item, "second"))),
+        ) == [atom("first"), atom("second")]
+
+    def test_cut_inside_rule_prunes_earlier_body_choices_and_later_clauses(
+        self,
+    ) -> None:
+        pick = relation("pick", 1)
+        x = var("X")
+        options = program(
+            rule(pick(x), conj(disj(eq(x, "first"), eq(x, "second")), cut())),
+            fact(pick("fallback")),
+        )
+
+        assert solve_all(options, x, pick(x)) == [atom("first")]
+
+    def test_cut_still_prunes_when_later_goal_fails(self) -> None:
+        pick = relation("pick", 1)
+        x = var("X")
+        options = program(
+            rule(pick("blocked"), conj(cut(), fail())),
+            fact(pick("fallback")),
+        )
+
+        assert solve_all(options, x, pick(x)) == []
+
+    def test_cut_inside_relation_does_not_prune_caller_choicepoints(self) -> None:
+        committed = relation("committed", 1)
+        side = var("Side")
+        value = var("Value")
+        x = var("X")
+        options = program(
+            rule(
+                committed(x),
+                conj(disj(eq(x, "inner-first"), eq(x, "inner-second")), cut()),
+            ),
+            fact(committed("later-clause")),
+        )
+
+        assert solve_all(
+            options,
+            (side, value),
+            disj(
+                conj(eq(side, "left"), committed(value)),
+                conj(eq(side, "right"), eq(value, "outside")),
+            ),
+        ) == [(atom("left"), atom("inner-first")), (atom("right"), atom("outside"))]
+
+    def test_cut_inside_recursive_predicate_commits_one_recursive_frame(
+        self,
+    ) -> None:
+        member_once = relation("member_once", 2)
+        item = var("Item")
+        head = var("Head")
+        tail = var("Tail")
+        marker = var("Marker")
+        members = program(
+            rule(member_once(item, term(".", item, tail)), cut()),
+            rule(
+                member_once(item, term(".", head, tail)),
+                member_once(item, tail),
+            ),
+        )
+
+        assert solve_all(
+            members,
+            marker,
+            conj(
+                member_once("b", logic_list(["a", "b", "b"])),
+                eq(marker, "hit"),
+            ),
+        ) == [atom("hit")]
 
 
 class TestQueryHelpers:

--- a/code/specs/LP18-logic-prolog-functionality-batches.md
+++ b/code/specs/LP18-logic-prolog-functionality-batches.md
@@ -59,17 +59,15 @@ LP14 advanced control builtins
 LP15 term metaprogramming builtins
 LP16 persistent clause database
 LP17 clause introspection builtins
+LP18 Batch A metaprogramming completion
+LP18 Batch B dynamic runtime database
+LP18 Batch C search control and real cut
 PR00 Prolog lexer
 ```
 
 Known future-extension items that still need implementation:
 
-- callable goal-term lowering
-- standard term ordering
-- predicate metadata and predicate-property inspection
-- dynamic predicate declarations
-- backtracking-safe runtime `assert` and `retract`
-- real Prolog cut with scoped choicepoint pruning
+- soft-cut variants if a concrete API need emerges
 - CLP(FD)-style finite-domain constraints
 
 ## Batch Plan
@@ -189,9 +187,10 @@ code/packages/python/logic-builtins
 Features:
 
 - scoped choicepoint frames in the solver protocol
-- `cuto()` as the library form of `!/0`
-- if-then-else lowering that commits to the chosen branch
-- soft-cut variants if the solver protocol supports them cleanly
+- `cut()` in `logic-engine` and `cuto()` in `logic-builtins` as the library
+  form of `!/0`
+- cut encoding/lowering through `goal_as_term(...)` and `goal_from_term(...)`
+  as the atom `!`
 - examples that distinguish real cut from `onceo`
 
 Why this is one batch:
@@ -206,6 +205,25 @@ Why this is one batch:
 Batch C should not fake cut by using `onceo`. LP14 explicitly deferred `cuto`
 because a correct implementation needs scoped pruning of surrounding clause and
 disjunction alternatives.
+
+Implementation shape:
+
+- the public solver still yields ordinary `State` objects, but the private
+  solver protocol threads a cut flag alongside each state
+- conjunctions propagate a cut signal to prune alternatives created by earlier
+  goals in the same conjunction
+- disjunctions stop exploring later branches after a branch raises cut
+- relation calls act as cut frames: a cut inside a rule body prunes later body
+  alternatives and later clauses for that predicate invocation, then the
+  relation consumes the cut before returning to the caller
+- cut succeeds once, so choices introduced after the cut remain backtrackable
+
+Deliberately deferred:
+
+- soft-cut remains out of scope until there is a concrete library API need
+- `calltermo(...)` and other native-goal boundaries currently execute nested
+  goals through the public solver API, so cut is scoped to the nested call
+  rather than propagated through meta-call boundaries
 
 ### Batch D - CLP(FD) Foundation
 
@@ -486,8 +504,6 @@ Future implementation PRs should keep these guardrails:
 LP18 says yes: the remaining Prolog-level functionality can be knocked out in a
 few big batches rather than many tiny PRs.
 
-The recommended next PR is Batch A, because it completes the pure
-metaprogramming loop and makes the library feel much closer to Prolog without
-changing mutable database or solver-control internals. Batch B then adds
-runtime dynamic predicates, Batch C adds real cut, and Batch D starts finite
-domain constraints as a focused constraint-solving track.
+Batch A completed the pure metaprogramming loop, Batch B added runtime dynamic
+predicates, and Batch C added real cut. Batch D starts finite-domain
+constraints as the next focused constraint-solving track.


### PR DESCRIPTION
## Summary

- add engine-level `CutExpr` / `cut()` with scoped cut propagation through conjunctions, disjunctions, and relation-call frames
- expose `cuto()` from `logic-builtins` and include `cuto/0` in predicate metadata
- document Batch C semantics in LP18 and package READMEs/changelogs
- add regression coverage for query cuts, rule cuts, `!, fail`, recursive cut frames, caller-scope isolation, and `cuto()` vs `onceo()`

## Verification

- `bash BUILD` in `code/packages/python/logic-engine`
- `bash BUILD` in `code/packages/python/logic-builtins`
- `.venv/bin/python -m ruff check .` in both packages
- `.venv/bin/python -m pytest tests/ -q` in both packages
- `.venv/bin/python -m mypy src tests` in `logic-builtins`

## Notes

`logic-engine` mypy still reports the existing baseline issues around untyped local deps plus pre-existing test/type-shape checks; no new Batch C-specific mypy errors were introduced.