### PR TITLE
feat(vm-core): add generic register VM interpreter — LANG02 implementation

### DIFF
--- a/code/packages/python/vm-core/BUILD
+++ b/code/packages/python/vm-core/BUILD
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../interpreter-ir -e ".[dev]" --quiet
+.venv/bin/python -m pytest tests/ -v --cov=vm_core --cov-report=term-missing

--- a/code/packages/python/vm-core/CHANGELOG.md
+++ b/code/packages/python/vm-core/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog — vm-core
+
+All notable changes to this package will be documented in this file.
+
+---
+
+## [0.1.0] — 2026-04-21
+
+### Added
+
+- **`VMCore`** — generic register VM interpreter (LANG02).  Executes `IIRModule`
+  objects produced by any language front-end that targets `interpreter-ir`.
+- **`RegisterFile`** — flat list of value slots with `snapshot()`/`restore()` for
+  REPL error-recovery rollback.
+- **`VMFrame`** — per-call-frame state: `fn`, `ip`, `registers`, `name_to_reg`,
+  `return_dest`.  `VMFrame.for_function()` pre-assigns parameter registers.
+- **`VMProfiler`** — inline type profiler.  Runs with constant overhead alongside
+  the dispatch loop; maps Python runtime values to IIR type strings and calls
+  `IIRInstr.record_observation()`.
+- **`VMMetrics`** — immutable snapshot of lifetime execution statistics.  Fields:
+  `function_call_counts`, `total_instructions_executed`, `total_frames_pushed`,
+  `total_jit_hits`.
+- **`BuiltinRegistry`** — maps builtin names to host-provided Python callables.
+  Pre-registers `noop` and `assert_eq`.  Used by the `call_builtin` opcode.
+- **`run_dispatch_loop()`** — tight `while frames:` dispatch loop with O(1) opcode
+  lookup, profiler observation, and interrupt-flag check.
+- **Standard opcode table** — 35 handlers covering all `interpreter_ir.ALL_OPS`
+  mnemonics plus `const`:
+  - Arithmetic: `add`, `sub`, `mul`, `div`, `mod`, `neg`
+  - Bitwise: `and`, `or`, `xor`, `not`, `shl`, `shr`
+  - Comparison: `cmp_eq`, `cmp_ne`, `cmp_lt`, `cmp_le`, `cmp_gt`, `cmp_ge`
+  - Control flow: `label`, `jmp`, `jmp_if_true`, `jmp_if_false`, `ret`, `ret_void`
+  - Memory: `load_reg`, `store_reg`, `load_mem`, `store_mem`
+  - Calls: `call` (interpreter + JIT paths), `call_builtin`
+  - I/O: `io_in`, `io_out`
+  - Coercions: `cast`, `type_assert`
+- **JIT handler integration** — `VMCore.register_jit_handler(fn_name, handler)`
+  short-circuits the interpreter.  Registered handlers are checked before any
+  frame is pushed; `total_jit_hits` is incremented on each hit.
+- **`u8_wrap` mode** — all arithmetic results masked with `& 0xFF` when
+  `VMCore(u8_wrap=True)`.  Required for Tetrad back-compat.
+- **`VMCore.interrupt()`** — sets a flag; the dispatch loop raises `VMInterrupt`
+  at the next cycle boundary.  Safe to call from other threads.
+- **`VMCore.reset()`** — clears frame stack, memory, and I/O ports between
+  independent program executions (lifetime metrics survive).
+- **Exception hierarchy**: `VMError`, `UnknownOpcodeError`, `FrameOverflowError`,
+  `UndefinedVariableError`, `VMInterrupt`.
+- **Test suite**: 124 tests, 97.58% line coverage.  All modules except `dispatch.py`
+  (96%) reach 100%.

--- a/code/packages/python/vm-core/README.md
+++ b/code/packages/python/vm-core/README.md
@@ -1,0 +1,140 @@
+# vm-core
+
+Generic register VM interpreter for the LANG pipeline (LANG02).
+
+`vm-core` executes **InterpreterIR** (`interpreter-ir`) modules — the dynamic,
+feedback-annotated IR produced by any language front-end in this pipeline.  It
+is the shared, language-agnostic execution engine that sits between the parser
+and the JIT compiler (`jit-core`, LANG03).
+
+## Where it fits
+
+```
+language source
+      │
+      ▼
+lexer → parser → type-checker
+      │
+      ▼
+  IIRModule  ◀─── interpreter-ir (LANG01)
+      │
+      ▼
+   VMCore    ◀─── vm-core (LANG02)  ← you are here
+      │
+      ├─ type feedback ──▶ jit-core (LANG03)
+      └─ metrics       ──▶ jit-core
+```
+
+## Key concepts
+
+### Register file
+
+Each function call gets a flat `RegisterFile` — a list of value slots.
+Parameters occupy slots 0..N-1; temporaries are allocated on demand.
+Named variables are resolved through a `name_to_reg` dict on `VMFrame`.
+
+### Dispatch loop
+
+The loop is a tight `while frames:` cycle:
+
+1. Fetch the current instruction (`frame.fn.instructions[frame.ip]`)
+2. Advance `frame.ip`
+3. Look up the handler in the opcode table (O(1) dict)
+4. Call the handler — reads registers, writes result
+5. If profiling is enabled, observe the result's runtime type
+
+### JIT integration
+
+Call `vm.register_jit_handler(fn_name, handler)` to bypass the interpreter
+for a compiled function.  The handler receives a list of resolved argument
+values and returns the result.  No frame is pushed; the interpreter path is
+skipped entirely.
+
+### Builtin functions
+
+Host-provided Python callables are registered via `vm.register_builtin()` or
+through the `BuiltinRegistry` directly.  `noop` and `assert_eq` are
+pre-registered.  The `call_builtin` instruction dispatches to these.
+
+### u8_wrap mode
+
+Pass `u8_wrap=True` to mask every arithmetic result with `& 0xFF`.  Required
+for Tetrad compatibility (8-bit register semantics).
+
+## Installation
+
+```bash
+pip install coding-adventures-vm-core
+```
+
+## Quick start
+
+```python
+from interpreter_ir import IIRFunction, IIRInstr, IIRModule
+from vm_core import VMCore
+
+# Build a trivial function: return 2 + 3
+fn = IIRFunction(
+    name="main",
+    params=[],
+    instructions=[
+        IIRInstr(op="const", dest="a", srcs=[2]),
+        IIRInstr(op="const", dest="b", srcs=[3]),
+        IIRInstr(op="add",   dest="r", srcs=["a", "b"]),
+        IIRInstr(op="ret",            srcs=["r"]),
+    ],
+    register_count=8,
+)
+module = IIRModule(functions={"main": fn})
+
+vm = VMCore()
+result = vm.execute(module)  # → 5
+print(result)
+
+# Inspect execution metrics.
+m = vm.metrics()
+print(m.total_instructions_executed)
+print(m.function_call_counts)
+```
+
+## API
+
+### `VMCore`
+
+```python
+VMCore(
+    *,
+    max_frames: int = 64,
+    opcodes: dict | None = None,   # override / extend the standard opcode table
+    builtins: BuiltinRegistry | None = None,
+    profiler_enabled: bool = True,
+    u8_wrap: bool = False,
+)
+```
+
+| Method | Description |
+|---|---|
+| `execute(module, *, fn="main", args=None)` | Run a function; return its result |
+| `metrics()` | Snapshot of execution statistics |
+| `register_builtin(name, fn)` | Add a host callable |
+| `register_jit_handler(fn_name, handler)` | Add a JIT shortcut |
+| `unregister_jit_handler(fn_name)` | Remove a JIT shortcut |
+| `interrupt()` | Signal the dispatch loop to stop |
+| `reset()` | Clear execution state (keep metrics) |
+
+### `VMMetrics`
+
+| Field | Type | Description |
+|---|---|---|
+| `function_call_counts` | `dict[str, int]` | Interpreted call count per function |
+| `total_instructions_executed` | `int` | Cumulative instruction dispatch count |
+| `total_frames_pushed` | `int` | Cumulative call frame count |
+| `total_jit_hits` | `int` | Calls intercepted by JIT handlers |
+
+## Running tests
+
+```bash
+uv venv
+uv pip install -e ../interpreter-ir -e ".[dev]"
+pytest tests/ -v
+```

--- a/code/packages/python/vm-core/pyproject.toml
+++ b/code/packages/python/vm-core/pyproject.toml
@@ -1,0 +1,51 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-vm-core"
+version = "0.1.0"
+description = "vm-core: generic register VM interpreter for the LANG pipeline (LANG02)"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["vm", "interpreter", "register-machine", "compiler", "education"]
+dependencies = ["coding-adventures-interpreter-ir"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Education",
+    "Topic :: Education",
+    "Topic :: Software Development :: Interpreters",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://github.com/adhithyan15/coding-adventures"
+Repository = "https://github.com/adhithyan15/coding-adventures"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/vm_core"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=vm_core --cov-report=term-missing --cov-fail-under=95"
+
+[tool.coverage.run]
+source = ["src/vm_core"]
+
+[tool.coverage.report]
+fail_under = 95
+show_missing = true

--- a/code/packages/python/vm-core/src/vm_core/__init__.py
+++ b/code/packages/python/vm-core/src/vm_core/__init__.py
@@ -1,0 +1,40 @@
+"""vm-core: generic register VM interpreter for the LANG pipeline.
+
+Public surface
+--------------
+``VMCore``          — the main interpreter (register VM).
+``VMFrame``         — per-call-frame state (frame stack entry).
+``VMMetrics``       — execution statistics snapshot.
+``VMProfiler``      — inline type profiler.
+``BuiltinRegistry`` — maps builtin names to host callables.
+``VMError``         — base exception.
+``UnknownOpcodeError``, ``FrameOverflowError``, ``UndefinedVariableError``,
+``VMInterrupt``     — specific error types.
+"""
+
+from vm_core.builtins import BuiltinRegistry
+from vm_core.core import VMCore
+from vm_core.errors import (
+    FrameOverflowError,
+    UndefinedVariableError,
+    UnknownOpcodeError,
+    VMError,
+    VMInterrupt,
+)
+from vm_core.frame import RegisterFile, VMFrame
+from vm_core.metrics import VMMetrics
+from vm_core.profiler import VMProfiler
+
+__all__ = [
+    "VMCore",
+    "VMFrame",
+    "RegisterFile",
+    "VMMetrics",
+    "VMProfiler",
+    "BuiltinRegistry",
+    "VMError",
+    "UnknownOpcodeError",
+    "FrameOverflowError",
+    "UndefinedVariableError",
+    "VMInterrupt",
+]

--- a/code/packages/python/vm-core/src/vm_core/builtins.py
+++ b/code/packages/python/vm-core/src/vm_core/builtins.py
@@ -1,0 +1,64 @@
+"""Builtin registry for vm-core.
+
+Languages register host-provided callables here so that ``call_builtin``
+instructions can invoke Python functions without any VM modification.
+
+Usage::
+
+    from vm_core.builtins import BuiltinRegistry
+    registry = BuiltinRegistry()
+    registry.register("print", lambda args: print(*args))
+    registry.register("input", lambda args: input(args[0] if args else ""))
+
+    # In the dispatch handler for "call_builtin":
+    result = registry.call("print", [42])
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+
+class BuiltinRegistry:
+    """Maps builtin names to host-provided Python callables.
+
+    Each callable receives a single argument: a list of resolved values.
+    It should return a value (or None for void builtins).
+    """
+
+    def __init__(self) -> None:
+        self._table: dict[str, Callable[[list[Any]], Any]] = {}
+        self._install_standard_builtins()
+
+    def _install_standard_builtins(self) -> None:
+        """Pre-register a minimal set of standard builtins."""
+        self._table["noop"] = lambda _args: None
+        self._table["assert_eq"] = lambda args: (
+            None if args[0] == args[1]
+            else (_ for _ in ()).throw(  # type: ignore[attr-defined]
+                AssertionError(f"assert_eq failed: {args[0]!r} != {args[1]!r}")
+            )
+        )
+
+    def register(self, name: str, fn: Callable[[list[Any]], Any]) -> None:
+        """Register a builtin callable under ``name``."""
+        self._table[name] = fn
+
+    def call(self, name: str, args: list[Any]) -> Any:
+        """Invoke the builtin named ``name`` with ``args``.
+
+        Raises KeyError if the name is not registered.
+        """
+        fn = self._table.get(name)
+        if fn is None:
+            raise KeyError(f"undefined builtin: {name!r}")
+        return fn(args)
+
+    def is_registered(self, name: str) -> bool:
+        """Return True if a builtin with this name is registered."""
+        return name in self._table
+
+    def registered_names(self) -> list[str]:
+        """Return all registered builtin names in insertion order."""
+        return list(self._table)

--- a/code/packages/python/vm-core/src/vm_core/core.py
+++ b/code/packages/python/vm-core/src/vm_core/core.py
@@ -1,0 +1,301 @@
+"""VMCore — the public API for the vm-core register interpreter.
+
+VMCore is a generic, language-agnostic register VM that executes
+InterpreterIR (IIR) modules.  A language front-end produces an
+``IIRModule`` containing ``IIRFunction`` objects; calling ``execute()``
+runs the nominated function and returns the result.
+
+Architecture overview
+---------------------
+                 ┌─────────────┐
+   IIRModule ──▶ │  VMCore     │ ──▶  return value
+                 │             │
+                 │ ┌─────────┐ │
+                 │ │ frame   │ │  ← VMFrame stack (one per call)
+                 │ │ stack   │ │
+                 │ └─────────┘ │
+                 │ ┌─────────┐ │
+                 │ │ opcode  │ │  ← handler lookup dict (O(1))
+                 │ │ table   │ │
+                 │ └─────────┘ │
+                 │ ┌─────────┐ │
+                 │ │profiler │ │  ← type observations → jit-core
+                 │ └─────────┘ │
+                 └─────────────┘
+
+Key configuration knobs
+-----------------------
+u8_wrap:
+    When True, all arithmetic results are masked with ``& 0xFF``.
+    Required for Tetrad compatibility (8-bit register semantics).
+
+profiler_enabled:
+    Toggle the inline type profiler.  Disable for benchmarks where
+    the profiling overhead is not desired.
+
+max_frames:
+    Hard limit on call-stack depth.  Prevents stack overflow from
+    runaway recursion — raises ``FrameOverflowError`` instead.
+
+opcodes:
+    Language-specific opcode handlers.  Entries here shadow the
+    standard table, allowing languages to override or extend any
+    mnemonic without subclassing VMCore.
+
+builtins:
+    Pre-configured ``BuiltinRegistry``.  If None, a fresh registry
+    with only ``noop`` and ``assert_eq`` is created.
+
+JIT integration
+---------------
+Call ``register_jit_handler(fn_name, handler)`` to short-circuit
+the interpreter for a compiled function.  The handler receives a
+list of resolved argument values and returns the result.  The
+interpreter path is bypassed entirely — no frame is pushed.
+
+Thread safety
+-------------
+VMCore is NOT thread-safe.  Each executing thread must own its
+own VMCore instance.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from interpreter_ir import IIRModule
+
+from vm_core.builtins import BuiltinRegistry
+from vm_core.dispatch import STANDARD_OPCODES, run_dispatch_loop
+from vm_core.frame import VMFrame
+from vm_core.metrics import VMMetrics
+from vm_core.profiler import VMProfiler
+
+
+class VMCore:
+    """Generic register VM interpreter.
+
+    Parameters
+    ----------
+    max_frames:
+        Maximum call-stack depth before ``FrameOverflowError`` is raised.
+    opcodes:
+        Optional dict of extra / override opcode handlers.  Entries shadow
+        the standard table; the standard table is always the fallback.
+    builtins:
+        Optional pre-configured ``BuiltinRegistry``.  Created fresh if None.
+    profiler_enabled:
+        Whether to run the inline type profiler.
+    u8_wrap:
+        Mask arithmetic results to 8 bits (Tetrad / u8 mode).
+    """
+
+    def __init__(
+        self,
+        *,
+        max_frames: int = 64,
+        opcodes: dict[str, Any] | None = None,
+        builtins: BuiltinRegistry | None = None,
+        profiler_enabled: bool = True,
+        u8_wrap: bool = False,
+    ) -> None:
+        self._max_frames = max_frames
+        self._u8_wrap = u8_wrap
+        self._profiler_enabled = profiler_enabled
+
+        # Merge standard table with any language-supplied overrides.
+        self._opcode_table: dict[str, Any] = dict(STANDARD_OPCODES)
+        if opcodes:
+            self._opcode_table.update(opcodes)
+
+        self._builtins: BuiltinRegistry = (
+            builtins if builtins is not None else BuiltinRegistry()
+        )
+        self._profiler: VMProfiler = VMProfiler()
+
+        # JIT handlers — registered by jit-core after compilation.
+        self._jit_handlers: dict[str, Callable[[list[Any]], Any]] = {}
+
+        # Execution state — reset between execute() calls.
+        self._frames: list[VMFrame] = []
+        self._module: IIRModule | None = None
+        self._interrupted: bool = False
+
+        # Addressable memory and I/O ports.
+        self._memory: dict[int, Any] = {}
+        self._io_ports: dict[int, Any] = {}
+
+        # Metrics accumulators — never reset; aggregate lifetime stats.
+        self._metrics_instrs: int = 0
+        self._metrics_frames: int = 0
+        self._metrics_jit_hits: int = 0
+        self._fn_call_counts: dict[str, int] = {}
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def execute(
+        self,
+        module: IIRModule,
+        *,
+        fn: str = "main",
+        args: list[Any] | None = None,
+    ) -> Any:
+        """Execute function ``fn`` in ``module`` and return its result.
+
+        Parameters
+        ----------
+        module:
+            The ``IIRModule`` containing the function to execute.
+        fn:
+            Name of the entry-point function.  Defaults to ``"main"``.
+        args:
+            Positional arguments passed to the entry-point function.
+            Must match the function's parameter list in order.
+
+        Raises
+        ------
+        KeyError
+            If ``fn`` is not defined in ``module``.
+        FrameOverflowError
+            If the call stack exceeds ``max_frames``.
+        UnknownOpcodeError
+            If the function uses an opcode with no registered handler.
+        VMInterrupt
+            If ``interrupt()`` is called during execution.
+        """
+        entry = module.get_function(fn)
+        if entry is None:
+            raise KeyError(f"function {fn!r} not found in module")
+
+        self._module = module
+        self._frames = []
+        self._interrupted = False
+
+        root_frame = VMFrame.for_function(entry, return_dest=None)
+
+        # Copy positional arguments into the root frame's registers.
+        if args:
+            for i, value in enumerate(args[: len(entry.params)]):
+                root_frame.registers[i] = value
+
+        self._frames.append(root_frame)
+        self._metrics_frames += 1
+        self._fn_call_counts[fn] = self._fn_call_counts.get(fn, 0) + 1
+
+        return run_dispatch_loop(self)
+
+    def metrics(self) -> VMMetrics:
+        """Return a point-in-time snapshot of execution statistics.
+
+        The snapshot is immutable — it does not update after creation.
+        Designed for consumption by jit-core to decide which functions
+        to promote to the compiled tier.
+        """
+        return VMMetrics(
+            function_call_counts=dict(self._fn_call_counts),
+            total_instructions_executed=self._metrics_instrs,
+            total_frames_pushed=self._metrics_frames,
+            total_jit_hits=self._metrics_jit_hits,
+        )
+
+    def register_builtin(self, name: str, fn: Callable[[list[Any]], Any]) -> None:
+        """Register a host callable under ``name`` in the builtin registry.
+
+        The callable receives a single argument: a list of resolved values.
+        It should return a value (or None for void builtins).
+
+        Example::
+
+            vm.register_builtin("print", lambda args: print(*args))
+        """
+        self._builtins.register(name, fn)
+
+    def register_jit_handler(
+        self, fn_name: str, handler: Callable[[list[Any]], Any]
+    ) -> None:
+        """Register a JIT handler for ``fn_name``.
+
+        When the interpreter encounters a ``call fn_name`` instruction,
+        it calls ``handler(args)`` instead of pushing a new frame.
+        The handler bypasses the interpreter completely — no frame is
+        pushed, no instructions are executed, and the profiler is not
+        updated.
+
+        This is the primary integration point for jit-core.
+        """
+        self._jit_handlers[fn_name] = handler
+
+    def unregister_jit_handler(self, fn_name: str) -> None:
+        """Remove the JIT handler for ``fn_name``, reverting to interpreted calls."""
+        self._jit_handlers.pop(fn_name, None)
+
+    def interrupt(self) -> None:
+        """Signal the dispatch loop to raise ``VMInterrupt`` at the next cycle.
+
+        Safe to call from a different thread.  The interrupt is delivered
+        asynchronously — the current instruction completes before the
+        exception is raised.
+        """
+        self._interrupted = True
+
+    def reset(self) -> None:
+        """Reset per-execution state.
+
+        Clears the frame stack, memory, I/O ports, and the interrupted
+        flag.  Lifetime metrics (instruction counts, JIT hits) are NOT
+        reset — they accumulate across all executions.
+
+        Call this between independent programs when reusing a VMCore
+        instance (e.g., in a REPL).
+        """
+        self._frames = []
+        self._module = None
+        self._interrupted = False
+        self._memory = {}
+        self._io_ports = {}
+
+    # ------------------------------------------------------------------
+    # Properties — read-only access to internal state for tooling
+    # ------------------------------------------------------------------
+
+    @property
+    def builtins(self) -> BuiltinRegistry:
+        """The builtin registry.  Register host callables here."""
+        return self._builtins
+
+    @property
+    def profiler(self) -> VMProfiler:
+        """The inline type profiler.  Read by jit-core to inspect observations."""
+        return self._profiler
+
+    @property
+    def io_ports(self) -> dict[int, Any]:
+        """The I/O port map.  Read/write by the host or device drivers."""
+        return self._io_ports
+
+    @property
+    def memory(self) -> dict[int, Any]:
+        """The addressable memory map.  Sparse; unwritten addresses default to 0."""
+        return self._memory
+
+    @property
+    def u8_wrap(self) -> bool:
+        """Whether arithmetic results are masked to 8 bits."""
+        return self._u8_wrap
+
+    @property
+    def profiler_enabled(self) -> bool:
+        """Whether the inline type profiler is active."""
+        return self._profiler_enabled
+
+    @profiler_enabled.setter
+    def profiler_enabled(self, value: bool) -> None:
+        self._profiler_enabled = value
+
+    @property
+    def is_executing(self) -> bool:
+        """True while a dispatch loop is running (frames are on the stack)."""
+        return bool(self._frames)

--- a/code/packages/python/vm-core/src/vm_core/dispatch.py
+++ b/code/packages/python/vm-core/src/vm_core/dispatch.py
@@ -1,0 +1,511 @@
+"""Dispatch loop and standard opcode handlers for vm-core.
+
+The dispatch loop is a tight ``while`` cycle:
+
+1. Peek at the current frame's instruction
+2. Look up the handler in the opcode table
+3. Call the handler — it reads from ``frame.registers`` / ``frame.name_to_reg``
+   and writes results back
+4. If profiling is enabled, observe the result
+5. Advance ``frame.ip``
+
+Handlers are plain Python functions with the signature::
+
+    def handle_XXX(vm: "VMCore", frame: VMFrame, instr: IIRInstr) -> Any:
+        ...
+
+They return the value stored in ``instr.dest`` (or None for void ops).
+
+Standard opcodes
+----------------
+The standard opcode table covers every mnemonic in ``interpreter_ir.ALL_OPS``
+plus ``"const"``.  Languages may override individual handlers by passing a
+``opcodes`` dict to VMCore — entries in that dict shadow the standard table.
+
+u8_wrap
+-------
+When ``VMCore`` is constructed with ``u8_wrap=True`` (Tetrad mode), every
+arithmetic result is masked with ``& 0xFF`` before being stored.  This
+mask is applied by the arithmetic handlers, not the dispatch loop itself.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from interpreter_ir import IIRInstr
+
+from vm_core.errors import FrameOverflowError, UnknownOpcodeError, VMInterrupt
+from vm_core.frame import VMFrame
+
+if TYPE_CHECKING:
+    from vm_core.core import VMCore
+
+
+# ---------------------------------------------------------------------------
+# Dispatch loop
+# ---------------------------------------------------------------------------
+
+def run_dispatch_loop(vm: VMCore) -> Any:
+    """Execute instructions until the frame stack is empty.
+
+    Returns the last value produced by a ``ret`` instruction in the root frame,
+    or ``None`` if no ``ret`` was executed.
+    """
+    return_value: Any = None
+
+    while vm._frames:
+        frame = vm._frames[-1]
+
+        if frame.ip >= len(frame.fn.instructions):
+            vm._frames.pop()
+            continue
+
+        if vm._interrupted:
+            vm._interrupted = False
+            raise VMInterrupt("execution interrupted")
+
+        instr = frame.fn.instructions[frame.ip]
+        frame.ip += 1
+
+        result = _dispatch_one(vm, frame, instr)
+        vm._metrics_instrs += 1
+
+        if vm._profiler_enabled and instr.dest is not None and result is not None:
+            vm._profiler.observe(instr, result)
+
+        if instr.op in {"ret", "ret_void"}:
+            return_value = result
+
+    return return_value
+
+
+def _dispatch_one(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> Any:
+    handler = vm._opcode_table.get(instr.op)
+    if handler is None:
+        raise UnknownOpcodeError(
+            f"no handler for opcode {instr.op!r} in function {frame.fn.name!r}"
+        )
+    return handler(vm, frame, instr)
+
+
+# ---------------------------------------------------------------------------
+# Standard opcode handlers
+# ---------------------------------------------------------------------------
+
+def _wrap(vm: VMCore, v: int) -> int:
+    return v & 0xFF if vm._u8_wrap else v
+
+
+# --- Constant ---
+
+def handle_const(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> Any:
+    value = instr.srcs[0]
+    if instr.dest:
+        frame.assign(instr.dest, value)
+    return value
+
+
+# --- Arithmetic ---
+
+def handle_add(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> Any:
+    a = frame.resolve(instr.srcs[0])
+    b = frame.resolve(instr.srcs[1])
+    result = _wrap(vm, a + b)
+    if instr.dest:
+        frame.assign(instr.dest, result)
+    return result
+
+
+def handle_sub(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> Any:
+    a = frame.resolve(instr.srcs[0])
+    b = frame.resolve(instr.srcs[1])
+    result = _wrap(vm, a - b)
+    if instr.dest:
+        frame.assign(instr.dest, result)
+    return result
+
+
+def handle_mul(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> Any:
+    a = frame.resolve(instr.srcs[0])
+    b = frame.resolve(instr.srcs[1])
+    result = _wrap(vm, a * b)
+    if instr.dest:
+        frame.assign(instr.dest, result)
+    return result
+
+
+def handle_div(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> Any:
+    a = frame.resolve(instr.srcs[0])
+    b = frame.resolve(instr.srcs[1])
+    result = _wrap(vm, a // b)
+    if instr.dest:
+        frame.assign(instr.dest, result)
+    return result
+
+
+def handle_mod(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> Any:
+    a = frame.resolve(instr.srcs[0])
+    b = frame.resolve(instr.srcs[1])
+    result = _wrap(vm, a % b)
+    if instr.dest:
+        frame.assign(instr.dest, result)
+    return result
+
+
+def handle_neg(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> Any:
+    a = frame.resolve(instr.srcs[0])
+    result = _wrap(vm, -a)
+    if instr.dest:
+        frame.assign(instr.dest, result)
+    return result
+
+
+# --- Bitwise ---
+
+def handle_and(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> Any:
+    a = frame.resolve(instr.srcs[0])
+    b = frame.resolve(instr.srcs[1])
+    result = a & b
+    if instr.dest:
+        frame.assign(instr.dest, result)
+    return result
+
+
+def handle_or(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> Any:
+    a = frame.resolve(instr.srcs[0])
+    b = frame.resolve(instr.srcs[1])
+    result = a | b
+    if instr.dest:
+        frame.assign(instr.dest, result)
+    return result
+
+
+def handle_xor(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> Any:
+    a = frame.resolve(instr.srcs[0])
+    b = frame.resolve(instr.srcs[1])
+    result = a ^ b
+    if instr.dest:
+        frame.assign(instr.dest, result)
+    return result
+
+
+def handle_not(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> Any:
+    a = frame.resolve(instr.srcs[0])
+    result = ~a
+    if instr.dest:
+        frame.assign(instr.dest, result)
+    return result
+
+
+def handle_shl(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> Any:
+    a = frame.resolve(instr.srcs[0])
+    n = frame.resolve(instr.srcs[1])
+    result = a << n
+    if instr.dest:
+        frame.assign(instr.dest, result)
+    return result
+
+
+def handle_shr(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> Any:
+    a = frame.resolve(instr.srcs[0])
+    n = frame.resolve(instr.srcs[1])
+    result = a >> n
+    if instr.dest:
+        frame.assign(instr.dest, result)
+    return result
+
+
+# --- Comparisons ---
+
+def handle_cmp_eq(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> bool:
+    r = frame.resolve(instr.srcs[0]) == frame.resolve(instr.srcs[1])
+    if instr.dest:
+        frame.assign(instr.dest, r)
+    return r
+
+
+def handle_cmp_ne(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> bool:
+    r = frame.resolve(instr.srcs[0]) != frame.resolve(instr.srcs[1])
+    if instr.dest:
+        frame.assign(instr.dest, r)
+    return r
+
+
+def handle_cmp_lt(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> bool:
+    r = frame.resolve(instr.srcs[0]) < frame.resolve(instr.srcs[1])
+    if instr.dest:
+        frame.assign(instr.dest, r)
+    return r
+
+
+def handle_cmp_le(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> bool:
+    r = frame.resolve(instr.srcs[0]) <= frame.resolve(instr.srcs[1])
+    if instr.dest:
+        frame.assign(instr.dest, r)
+    return r
+
+
+def handle_cmp_gt(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> bool:
+    r = frame.resolve(instr.srcs[0]) > frame.resolve(instr.srcs[1])
+    if instr.dest:
+        frame.assign(instr.dest, r)
+    return r
+
+
+def handle_cmp_ge(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> bool:
+    r = frame.resolve(instr.srcs[0]) >= frame.resolve(instr.srcs[1])
+    if instr.dest:
+        frame.assign(instr.dest, r)
+    return r
+
+
+# --- Control flow ---
+
+def handle_label(_vm: VMCore, _frame: VMFrame, _instr: IIRInstr) -> None:
+    """Labels are no-ops at runtime; they only exist for branch resolution."""
+    return None
+
+
+def handle_jmp(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> None:
+    label = instr.srcs[0]
+    frame.ip = frame.fn.label_index(str(label))
+    return None
+
+
+def handle_jmp_if_true(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> None:
+    cond = frame.resolve(instr.srcs[0])
+    if cond:
+        label = instr.srcs[1]
+        frame.ip = frame.fn.label_index(str(label))
+    return None
+
+
+def handle_jmp_if_false(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> None:
+    cond = frame.resolve(instr.srcs[0])
+    if not cond:
+        label = instr.srcs[1]
+        frame.ip = frame.fn.label_index(str(label))
+    return None
+
+
+def handle_ret(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> Any:
+    value = frame.resolve(instr.srcs[0]) if instr.srcs else None
+    caller_frame = _pop_frame(vm, frame)
+    if caller_frame is not None and frame.return_dest is not None:
+        caller_frame.registers[frame.return_dest] = value
+        if instr.dest and frame.return_dest < len(frame.registers):
+            pass  # dest is in caller
+    return value
+
+
+def handle_ret_void(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> None:
+    _pop_frame(vm, frame)
+    return None
+
+
+def _pop_frame(vm: VMCore, frame: VMFrame) -> VMFrame | None:
+    """Pop the current frame; return the new top frame (caller), or None."""
+    vm._frames.pop()
+    return vm._frames[-1] if vm._frames else None
+
+
+# --- Memory / registers ---
+
+def handle_load_reg(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> Any:
+    idx = int(frame.resolve(instr.srcs[0]))
+    value = frame.registers[idx]
+    if instr.dest:
+        frame.assign(instr.dest, value)
+    return value
+
+
+def handle_store_reg(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> None:
+    idx = int(frame.resolve(instr.srcs[0]))
+    value = frame.resolve(instr.srcs[1])
+    frame.registers[idx] = value
+    return None
+
+
+def handle_load_mem(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> Any:
+    addr = int(frame.resolve(instr.srcs[0]))
+    value = vm._memory.get(addr, 0)
+    if instr.dest:
+        frame.assign(instr.dest, value)
+    return value
+
+
+def handle_store_mem(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> None:
+    addr = int(frame.resolve(instr.srcs[0]))
+    value = frame.resolve(instr.srcs[1])
+    vm._memory[addr] = value
+    return None
+
+
+# --- Function calls ---
+
+def handle_call(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> Any:
+    fn_name = str(instr.srcs[0])
+
+    # JIT handler takes priority.
+    jit_handler = vm._jit_handlers.get(fn_name)
+    if jit_handler is not None:
+        args = [frame.resolve(s) for s in instr.srcs[1:]]
+        result = jit_handler(args)
+        vm._metrics_jit_hits += 1
+        if instr.dest:
+            frame.assign(instr.dest, result)
+        return result
+
+    # Interpreter path.
+    if vm._module is None or (callee := vm._module.get_function(fn_name)) is None:
+        raise UnknownOpcodeError(f"function {fn_name!r} not found in module")
+
+    if len(vm._frames) >= vm._max_frames:
+        raise FrameOverflowError(
+            f"call stack depth {vm._max_frames} exceeded calling {fn_name!r}"
+        )
+
+    # Allocate return-value register in caller.
+    ret_reg: int | None = None
+    if instr.dest:
+        if instr.dest not in frame.name_to_reg:
+            ret_reg = len(frame.name_to_reg)
+            frame.name_to_reg[instr.dest] = ret_reg
+        else:
+            ret_reg = frame.name_to_reg[instr.dest]
+
+    callee_frame = VMFrame.for_function(callee, return_dest=ret_reg)
+
+    # Copy arguments into callee registers (params 0..N-1).
+    args = instr.srcs[1:]
+    for i, arg_src in enumerate(args[: len(callee.params)]):
+        callee_frame.registers[i] = frame.resolve(arg_src)
+
+    vm._frames.append(callee_frame)
+    vm._metrics_frames += 1
+    vm._fn_call_counts[fn_name] = vm._fn_call_counts.get(fn_name, 0) + 1
+    return None  # result stored when callee executes ret
+
+
+def handle_call_builtin(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> Any:
+    name = str(instr.srcs[0])
+    args = [frame.resolve(s) for s in instr.srcs[1:]]
+    result = vm._builtins.call(name, args)
+    if instr.dest:
+        frame.assign(instr.dest, result)
+    return result
+
+
+# --- I/O ---
+
+def handle_io_in(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> Any:
+    port = int(frame.resolve(instr.srcs[0]))
+    value = vm._io_ports.get(port, 0)
+    if instr.dest:
+        frame.assign(instr.dest, value)
+    return value
+
+
+def handle_io_out(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> None:
+    port = int(frame.resolve(instr.srcs[0]))
+    value = frame.resolve(instr.srcs[1])
+    vm._io_ports[port] = value
+    return None
+
+
+# --- Coercions ---
+
+def handle_cast(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> Any:
+    value = frame.resolve(instr.srcs[0])
+    target = str(instr.srcs[1]) if len(instr.srcs) > 1 else instr.type_hint
+    if target in {"u8", "u16", "u32", "u64"}:
+        value = int(value)
+        if target == "u8":
+            value &= 0xFF
+        elif target == "u16":
+            value &= 0xFFFF
+        elif target == "u32":
+            value &= 0xFFFFFFFF
+    elif target == "bool":
+        value = bool(value)
+    elif target == "str":
+        value = str(value)
+    if instr.dest:
+        frame.assign(instr.dest, value)
+    return value
+
+
+def handle_type_assert(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> None:
+    """Runtime type assertion — raises VMError if the value is the wrong type."""
+    from vm_core.errors import VMError
+    value = frame.resolve(instr.srcs[0])
+    expected = str(instr.srcs[1]) if len(instr.srcs) > 1 else instr.type_hint
+    actual = _runtime_type(value)
+    if actual != expected:
+        raise VMError(
+            f"type_assert failed in {frame.fn.name!r}: "
+            f"expected {expected!r}, got {actual!r} ({value!r})"
+        )
+    return None
+
+
+def _runtime_type(value: Any) -> str:
+    if isinstance(value, bool):
+        return "bool"
+    if isinstance(value, int):
+        if 0 <= value <= 255:
+            return "u8"
+        if 0 <= value <= 65535:
+            return "u16"
+        if 0 <= value <= 0xFFFF_FFFF:
+            return "u32"
+        return "u64"
+    if isinstance(value, float):
+        return "f64"
+    if isinstance(value, str):
+        return "str"
+    return "any"
+
+
+# ---------------------------------------------------------------------------
+# Standard opcode table
+# ---------------------------------------------------------------------------
+
+STANDARD_OPCODES: dict[str, Any] = {
+    "const": handle_const,
+    "add": handle_add,
+    "sub": handle_sub,
+    "mul": handle_mul,
+    "div": handle_div,
+    "mod": handle_mod,
+    "neg": handle_neg,
+    "and": handle_and,
+    "or": handle_or,
+    "xor": handle_xor,
+    "not": handle_not,
+    "shl": handle_shl,
+    "shr": handle_shr,
+    "cmp_eq": handle_cmp_eq,
+    "cmp_ne": handle_cmp_ne,
+    "cmp_lt": handle_cmp_lt,
+    "cmp_le": handle_cmp_le,
+    "cmp_gt": handle_cmp_gt,
+    "cmp_ge": handle_cmp_ge,
+    "label": handle_label,
+    "jmp": handle_jmp,
+    "jmp_if_true": handle_jmp_if_true,
+    "jmp_if_false": handle_jmp_if_false,
+    "ret": handle_ret,
+    "ret_void": handle_ret_void,
+    "load_reg": handle_load_reg,
+    "store_reg": handle_store_reg,
+    "load_mem": handle_load_mem,
+    "store_mem": handle_store_mem,
+    "call": handle_call,
+    "call_builtin": handle_call_builtin,
+    "io_in": handle_io_in,
+    "io_out": handle_io_out,
+    "cast": handle_cast,
+    "type_assert": handle_type_assert,
+}

--- a/code/packages/python/vm-core/src/vm_core/errors.py
+++ b/code/packages/python/vm-core/src/vm_core/errors.py
@@ -1,0 +1,26 @@
+"""Exception hierarchy for vm-core."""
+
+from __future__ import annotations
+
+
+class VMError(Exception):
+    """Base class for all vm-core errors."""
+
+
+class UnknownOpcodeError(VMError):
+    """Raised when the dispatch table has no handler for an opcode."""
+
+
+class FrameOverflowError(VMError):
+    """Raised when a CALL instruction would exceed the maximum frame depth."""
+
+
+class UndefinedVariableError(VMError):
+    """Raised when an instruction references a variable name not in scope."""
+
+
+class VMInterrupt(VMError):
+    """Raised by the dispatch loop when vm.interrupt() is called.
+
+    Caught by VMCore.execute() and reported as a KeyboardInterrupt-equivalent.
+    """

--- a/code/packages/python/vm-core/src/vm_core/frame.py
+++ b/code/packages/python/vm-core/src/vm_core/frame.py
@@ -1,0 +1,140 @@
+"""VMFrame and RegisterFile — the per-call-frame state of vm-core.
+
+Each function call in vm-core creates a fresh VMFrame.  The frame holds:
+
+- ``fn``          — the IIRFunction being executed
+- ``ip``          — instruction pointer (index into fn.instructions)
+- ``registers``   — a flat register file (one slot per virtual variable)
+- ``return_dest`` — register index in the *caller* frame where the return
+                    value will be stored (None for the root frame)
+
+The RegisterFile is a plain Python list, which gives O(1) reads and writes.
+Named variables are resolved by a ``name_to_reg`` dict built once per frame
+from the function's parameter list — parameters occupy the first N registers,
+with indices assigned in parameter order.
+
+Example::
+
+    fn = IIRFunction(name="add", params=[("a", "u8"), ("b", "u8")], ...)
+    # a → register 0, b → register 1
+    frame = VMFrame.for_function(fn)
+    frame.registers[0] = 10   # a = 10
+    frame.registers[1] = 20   # b = 20
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from interpreter_ir import IIRFunction
+
+
+class RegisterFile:
+    """A flat array of value slots, one per virtual variable.
+
+    The file is pre-sized to ``register_count`` slots, all initialised to 0.
+    Named-variable access goes through VMFrame.resolve(); direct integer-index
+    access is used by the argument-passing code.
+    """
+
+    __slots__ = ("_slots",)
+
+    def __init__(self, count: int = 8) -> None:
+        self._slots: list[Any] = [0] * count
+
+    def __getitem__(self, idx: int) -> Any:
+        return self._slots[idx]
+
+    def __setitem__(self, idx: int, value: Any) -> None:
+        self._slots[idx] = value
+
+    def __len__(self) -> int:
+        return len(self._slots)
+
+    def reset(self) -> None:
+        """Zero all slots (used by REPL snapshot rollback)."""
+        for i in range(len(self._slots)):
+            self._slots[i] = 0
+
+    def snapshot(self) -> list[Any]:
+        """Return a shallow copy of all slots."""
+        return list(self._slots)
+
+    def restore(self, saved: list[Any]) -> None:
+        """Restore slots from a snapshot."""
+        for i, v in enumerate(saved):
+            self._slots[i] = v
+
+
+@dataclass
+class VMFrame:
+    """State for a single function call.
+
+    Parameters
+    ----------
+    fn:
+        The function being executed.
+    registers:
+        The register file for this frame.
+    name_to_reg:
+        Maps variable names to register indices.  Populated from fn.params
+        at frame creation; extended by the dispatch loop as new dest names
+        appear.
+    ip:
+        Current instruction pointer.
+    return_dest:
+        Register index in the *caller* frame where the return value will be
+        stored, or None for the root frame.
+    """
+
+    fn: IIRFunction
+    registers: RegisterFile
+    name_to_reg: dict[str, int] = field(default_factory=dict)
+    ip: int = 0
+    return_dest: int | None = None
+
+    @classmethod
+    def for_function(
+        cls,
+        fn: IIRFunction,
+        return_dest: int | None = None,
+    ) -> VMFrame:
+        """Allocate a fresh VMFrame for ``fn``.
+
+        Parameter names are pre-assigned to registers 0..len(params)-1.
+        """
+        regs = RegisterFile(max(fn.register_count, len(fn.params), 1))
+        name_to_reg = {name: i for i, (name, _) in enumerate(fn.params)}
+        return cls(
+            fn=fn,
+            registers=regs,
+            name_to_reg=name_to_reg,
+            return_dest=return_dest,
+        )
+
+    def resolve(self, operand: Any) -> Any:
+        """Resolve an operand to its current value.
+
+        - ``str`` → look up the variable in ``name_to_reg`` and read the register
+        - anything else → return as a literal
+        """
+        if isinstance(operand, str):
+            idx = self.name_to_reg.get(operand)
+            if idx is None:
+                from vm_core.errors import UndefinedVariableError
+                raise UndefinedVariableError(
+                    f"variable {operand!r} not defined in function {self.fn.name!r}"
+                )
+            return self.registers[idx]
+        return operand
+
+    def assign(self, dest: str, value: Any) -> None:
+        """Assign ``value`` to the variable named ``dest``.
+
+        Allocates a new register slot if this is the first assignment to ``dest``.
+        """
+        if dest not in self.name_to_reg:
+            next_idx = len(self.name_to_reg)
+            self.name_to_reg[dest] = next_idx
+        self.registers[self.name_to_reg[dest]] = value

--- a/code/packages/python/vm-core/src/vm_core/metrics.py
+++ b/code/packages/python/vm-core/src/vm_core/metrics.py
@@ -1,0 +1,37 @@
+"""VMMetrics — a point-in-time snapshot of vm-core execution statistics.
+
+Consumed by jit-core to decide when to promote a function to the compiled tier.
+
+The metrics object is produced by ``VMCore.metrics()`` and is a plain dataclass
+snapshot — it does not update after creation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class VMMetrics:
+    """Execution statistics snapshot.
+
+    Parameters
+    ----------
+    function_call_counts:
+        Maps function name → number of times that function has been called
+        through the interpreter.  Functions that were JIT-compiled and called
+        via the JIT handler are NOT counted here — only interpreted calls.
+    total_instructions_executed:
+        Cumulative count of IIRInstr dispatch cycles across all functions.
+    total_frames_pushed:
+        Cumulative count of call frames pushed (one per CALL instruction
+        executed by the interpreter).
+    total_jit_hits:
+        Cumulative count of calls intercepted by a registered JIT handler
+        (i.e. calls that bypassed the interpreter).
+    """
+
+    function_call_counts: dict[str, int] = field(default_factory=dict)
+    total_instructions_executed: int = 0
+    total_frames_pushed: int = 0
+    total_jit_hits: int = 0

--- a/code/packages/python/vm-core/src/vm_core/profiler.py
+++ b/code/packages/python/vm-core/src/vm_core/profiler.py
@@ -1,0 +1,86 @@
+"""VMProfiler — runtime type observation for InterpreterIR instructions.
+
+The profiler watches each instruction execute and fills in the
+``observed_type`` / ``observation_count`` fields on the IIRInstr object.
+These fields are later read by jit-core to decide which type to specialise
+on and whether a function is worth compiling.
+
+The profiler only records observations for instructions whose ``type_hint``
+is ``"any"`` — statically typed instructions already know their type and
+don't need profiling.
+
+Type mapping
+------------
+The profiler maps Python runtime types to IIR type strings:
+
+    Python type / value             IIR type
+    ──────────────────────────────  ────────
+    bool                            "bool"
+    int in 0..255                   "u8"
+    int in 256..65535               "u16"
+    int in 65536..2^32-1            "u32"
+    int >= 2^32 or negative         "u64"
+    float                           "f64"
+    str                             "str"
+    anything else                   "any"
+
+Note: bool is checked before int because ``isinstance(True, int)`` is True
+in Python (bool is a subclass of int).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from interpreter_ir import IIRInstr
+
+
+def _python_type_to_iir(value: Any) -> str:
+    """Map a Python runtime value to an IIR type string."""
+    if isinstance(value, bool):
+        return "bool"
+    if isinstance(value, int):
+        if 0 <= value <= 255:
+            return "u8"
+        if 0 <= value <= 65535:
+            return "u16"
+        if 0 <= value <= 0xFFFF_FFFF:
+            return "u32"
+        return "u64"
+    if isinstance(value, float):
+        return "f64"
+    if isinstance(value, str):
+        return "str"
+    return "any"
+
+
+class VMProfiler:
+    """Observes instruction results and annotates IIRInstr feedback slots.
+
+    The profiler is always-on: it runs inline in the dispatch loop with
+    constant overhead (one isinstance check + one dict lookup per profiled
+    instruction).
+
+    Only instructions with ``type_hint == "any"`` are profiled.  Concrete
+    type instructions are skipped.
+    """
+
+    def __init__(self) -> None:
+        self._total_observations: int = 0
+
+    def observe(self, instr: IIRInstr, result: Any) -> None:
+        """Record the runtime type of ``result`` on ``instr``.
+
+        Called by the dispatch loop after each instruction that produces a
+        value (i.e. ``instr.dest is not None``).
+        """
+        if instr.type_hint != "any":
+            return
+        rt = _python_type_to_iir(result)
+        instr.record_observation(rt)
+        self._total_observations += 1
+
+    @property
+    def total_observations(self) -> int:
+        """Total number of profiling events recorded this session."""
+        return self._total_observations

--- a/code/packages/python/vm-core/tests/test_vm_core.py
+++ b/code/packages/python/vm-core/tests/test_vm_core.py
@@ -1,0 +1,1139 @@
+"""Comprehensive tests for vm-core.
+
+Coverage targets: 95%+ across all modules.
+
+Test organisation
+-----------------
+Each section targets a specific subsystem:
+
+    TestRegisterFile        — RegisterFile slot operations
+    TestVMFrame             — VMFrame construction, resolve, assign
+    TestVMProfiler          — type observation and mapping
+    TestBuiltinRegistry     — registration, call, error paths
+    TestVMMetrics           — dataclass construction
+    TestVMCoreInit          — constructor defaults and overrides
+    TestExecuteArithmetic   — add/sub/mul/div/mod/neg
+    TestExecuteBitwise      — and/or/xor/not/shl/shr
+    TestExecuteComparisons  — cmp_eq/ne/lt/le/gt/ge
+    TestExecuteControlFlow  — jmp, jmp_if_true, jmp_if_false, labels
+    TestExecuteMemory       — load_mem, store_mem, load_reg, store_reg
+    TestExecuteCalls        — call (interpreter path), call_builtin
+    TestExecuteIO           — io_in, io_out
+    TestExecuteCoercions    — cast, type_assert
+    TestJITHandler          — register_jit_handler, priority, metrics
+    TestMetricsAccumulation — instruction/frame/JIT hit counters
+    TestInterrupt           — interrupt() signal delivery
+    TestReset               — reset() clears execution state
+    TestU8Wrap              — arithmetic wraps to 8 bits
+    TestFrameOverflow       — FrameOverflowError on deep recursion
+    TestErrors              — UnknownOpcodeError, UndefinedVariableError
+    TestRepl                — incremental module + add_or_replace pattern
+    TestMultiFunction       — cross-function calls, return values
+"""
+
+from __future__ import annotations
+
+import pytest
+from interpreter_ir import IIRFunction, IIRInstr, IIRModule
+
+from vm_core import (
+    BuiltinRegistry,
+    FrameOverflowError,
+    RegisterFile,
+    UndefinedVariableError,
+    UnknownOpcodeError,
+    VMCore,
+    VMError,
+    VMFrame,
+    VMInterrupt,
+    VMMetrics,
+    VMProfiler,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fn(
+    name: str,
+    params: list[tuple[str, str]],
+    *instrs: IIRInstr,
+    return_type: str = "any",
+) -> IIRFunction:
+    """Build an IIRFunction with auto-computed register_count."""
+    return IIRFunction(
+        name=name,
+        params=params,
+        return_type=return_type,
+        instructions=list(instrs),
+        register_count=max(8, len(params) + len(instrs)),
+    )
+
+
+def _mod(*fns: IIRFunction) -> IIRModule:
+    return IIRModule(name="test", functions=list(fns))
+
+
+def _i(op: str, dest: str | None = None, srcs: list | None = None,
+       type_hint: str = "any") -> IIRInstr:
+    return IIRInstr(op=op, dest=dest, srcs=srcs or [], type_hint=type_hint)
+
+
+def _const(dest: str, value) -> IIRInstr:
+    return _i("const", dest=dest, srcs=[value])
+
+
+def _ret(src: str) -> IIRInstr:
+    return _i("ret", srcs=[src])
+
+
+def _ret_void() -> IIRInstr:
+    return _i("ret_void")
+
+
+def _simple_fn(name: str, *instrs: IIRInstr) -> IIRFunction:
+    return _fn(name, [], *instrs)
+
+
+def run(fn: IIRFunction, args: list | None = None, **kwargs) -> object:
+    """Convenience: create VMCore, execute a single-function module."""
+    vm = VMCore(**kwargs)
+    mod = _mod(fn)
+    return vm.execute(mod, fn=fn.name, args=args)
+
+
+# ---------------------------------------------------------------------------
+# TestRegisterFile
+# ---------------------------------------------------------------------------
+
+class TestRegisterFile:
+    def test_initial_slots_are_zero(self):
+        rf = RegisterFile(4)
+        for i in range(4):
+            assert rf[i] == 0
+
+    def test_set_and_get(self):
+        rf = RegisterFile(4)
+        rf[2] = 42
+        assert rf[2] == 42
+
+    def test_len(self):
+        rf = RegisterFile(6)
+        assert len(rf) == 6
+
+    def test_snapshot_is_copy(self):
+        rf = RegisterFile(3)
+        rf[0] = 10
+        rf[1] = 20
+        rf[2] = 30
+        snap = rf.snapshot()
+        rf[0] = 99
+        assert snap == [10, 20, 30]
+
+    def test_restore(self):
+        rf = RegisterFile(3)
+        rf[0] = 1
+        rf[1] = 2
+        rf[2] = 3
+        snap = rf.snapshot()
+        rf[0] = 99
+        rf.restore(snap)
+        assert rf[0] == 1
+
+    def test_reset_zeros_all_slots(self):
+        rf = RegisterFile(4)
+        rf[0] = 5
+        rf[3] = 7
+        rf.reset()
+        for i in range(4):
+            assert rf[i] == 0
+
+
+# ---------------------------------------------------------------------------
+# TestVMFrame
+# ---------------------------------------------------------------------------
+
+class TestVMFrame:
+    def _make_fn(self) -> IIRFunction:
+        return _fn("f", [("x", "u8"), ("y", "u8")])
+
+    def test_for_function_assigns_params(self):
+        fn = self._make_fn()
+        frame = VMFrame.for_function(fn)
+        assert frame.name_to_reg == {"x": 0, "y": 1}
+
+    def test_resolve_literal(self):
+        fn = self._make_fn()
+        frame = VMFrame.for_function(fn)
+        assert frame.resolve(42) == 42
+        assert frame.resolve(3.14) == 3.14
+        assert frame.resolve(True) is True
+
+    def test_resolve_variable(self):
+        fn = self._make_fn()
+        frame = VMFrame.for_function(fn)
+        frame.registers[0] = 10
+        assert frame.resolve("x") == 10
+
+    def test_resolve_undefined_raises(self):
+        fn = self._make_fn()
+        frame = VMFrame.for_function(fn)
+        with pytest.raises(UndefinedVariableError, match="z"):
+            frame.resolve("z")
+
+    def test_assign_new_variable(self):
+        fn = self._make_fn()
+        frame = VMFrame.for_function(fn)
+        frame.assign("z", 99)
+        assert frame.resolve("z") == 99
+
+    def test_assign_overwrites(self):
+        fn = self._make_fn()
+        frame = VMFrame.for_function(fn)
+        frame.registers[0] = 10
+        frame.assign("x", 20)
+        assert frame.resolve("x") == 20
+
+    def test_return_dest_stored(self):
+        fn = self._make_fn()
+        frame = VMFrame.for_function(fn, return_dest=5)
+        assert frame.return_dest == 5
+
+    def test_ip_starts_at_zero(self):
+        fn = self._make_fn()
+        frame = VMFrame.for_function(fn)
+        assert frame.ip == 0
+
+
+# ---------------------------------------------------------------------------
+# TestVMProfiler
+# ---------------------------------------------------------------------------
+
+class TestVMProfiler:
+    def _make_instr(self, type_hint="any") -> IIRInstr:
+        return IIRInstr(op="add", dest="r", srcs=["a", "b"], type_hint=type_hint)
+
+    def test_observe_bool(self):
+        p = VMProfiler()
+        instr = self._make_instr()
+        p.observe(instr, True)
+        assert instr.observed_type == "bool"
+
+    def test_observe_small_int_u8(self):
+        p = VMProfiler()
+        instr = self._make_instr()
+        p.observe(instr, 100)
+        assert instr.observed_type == "u8"
+
+    def test_observe_u16(self):
+        p = VMProfiler()
+        instr = self._make_instr()
+        p.observe(instr, 1000)
+        assert instr.observed_type == "u16"
+
+    def test_observe_u32(self):
+        p = VMProfiler()
+        instr = self._make_instr()
+        p.observe(instr, 100_000)
+        assert instr.observed_type == "u32"
+
+    def test_observe_large_int_u64(self):
+        p = VMProfiler()
+        instr = self._make_instr()
+        p.observe(instr, 2**33)
+        assert instr.observed_type == "u64"
+
+    def test_observe_float(self):
+        p = VMProfiler()
+        instr = self._make_instr()
+        p.observe(instr, 3.14)
+        assert instr.observed_type == "f64"
+
+    def test_observe_str(self):
+        p = VMProfiler()
+        instr = self._make_instr()
+        p.observe(instr, "hello")
+        assert instr.observed_type == "str"
+
+    def test_observe_unknown(self):
+        p = VMProfiler()
+        instr = self._make_instr()
+        p.observe(instr, [1, 2, 3])
+        assert instr.observed_type == "any"
+
+    def test_skips_typed_instructions(self):
+        p = VMProfiler()
+        instr = self._make_instr(type_hint="u8")
+        p.observe(instr, 42)
+        assert instr.observed_type is None
+        assert p.total_observations == 0
+
+    def test_total_observations_increments(self):
+        p = VMProfiler()
+        instr = self._make_instr()
+        p.observe(instr, 1)
+        p.observe(instr, 2)
+        assert p.total_observations == 2
+
+    def test_negative_int_maps_to_u64(self):
+        p = VMProfiler()
+        instr = self._make_instr()
+        p.observe(instr, -1)
+        assert instr.observed_type == "u64"
+
+
+# ---------------------------------------------------------------------------
+# TestBuiltinRegistry
+# ---------------------------------------------------------------------------
+
+class TestBuiltinRegistry:
+    def test_noop_pre_registered(self):
+        r = BuiltinRegistry()
+        assert r.is_registered("noop")
+        assert r.call("noop", []) is None
+
+    def test_assert_eq_passes(self):
+        r = BuiltinRegistry()
+        assert r.call("assert_eq", [42, 42]) is None
+
+    def test_assert_eq_fails(self):
+        r = BuiltinRegistry()
+        with pytest.raises(AssertionError, match="assert_eq"):
+            r.call("assert_eq", [1, 2])
+
+    def test_register_and_call(self):
+        r = BuiltinRegistry()
+        r.register("double", lambda args: args[0] * 2)
+        assert r.call("double", [5]) == 10
+
+    def test_call_unknown_raises_key_error(self):
+        r = BuiltinRegistry()
+        with pytest.raises(KeyError, match="undefined builtin"):
+            r.call("undefined", [])
+
+    def test_is_registered_false(self):
+        r = BuiltinRegistry()
+        assert not r.is_registered("missing")
+
+    def test_registered_names_includes_builtins(self):
+        r = BuiltinRegistry()
+        names = r.registered_names()
+        assert "noop" in names
+        assert "assert_eq" in names
+
+    def test_register_overwrites(self):
+        r = BuiltinRegistry()
+        r.register("noop", lambda _: 42)
+        assert r.call("noop", []) == 42
+
+
+# ---------------------------------------------------------------------------
+# TestVMMetrics
+# ---------------------------------------------------------------------------
+
+class TestVMMetrics:
+    def test_defaults(self):
+        m = VMMetrics()
+        assert m.function_call_counts == {}
+        assert m.total_instructions_executed == 0
+        assert m.total_frames_pushed == 0
+        assert m.total_jit_hits == 0
+
+    def test_snapshot_is_independent(self):
+        vm = VMCore()
+        fn = _simple_fn("main", _const("x", 1), _ret("x"))
+        vm.execute(_mod(fn), fn="main")
+        m = vm.metrics()
+        # Modifying the snapshot does not affect the VM's internal state.
+        m.function_call_counts["main"] = 999
+        m2 = vm.metrics()
+        assert m2.function_call_counts["main"] == 1
+
+
+# ---------------------------------------------------------------------------
+# TestVMCoreInit
+# ---------------------------------------------------------------------------
+
+class TestVMCoreInit:
+    def test_defaults(self):
+        vm = VMCore()
+        assert vm.u8_wrap is False
+        assert vm.profiler_enabled is True
+        assert not vm.is_executing
+
+    def test_u8_wrap(self):
+        vm = VMCore(u8_wrap=True)
+        assert vm.u8_wrap is True
+
+    def test_profiler_disabled(self):
+        vm = VMCore(profiler_enabled=False)
+        assert vm.profiler_enabled is False
+
+    def test_profiler_enabled_setter(self):
+        vm = VMCore(profiler_enabled=True)
+        vm.profiler_enabled = False
+        assert vm.profiler_enabled is False
+
+    def test_custom_builtins(self):
+        r = BuiltinRegistry()
+        r.register("custom", lambda _: 77)
+        vm = VMCore(builtins=r)
+        assert vm.builtins.call("custom", []) == 77
+
+    def test_execute_unknown_fn_raises(self):
+        vm = VMCore()
+        mod = _mod(_simple_fn("main", _ret_void()))
+        with pytest.raises(KeyError, match="missing"):
+            vm.execute(mod, fn="missing")
+
+
+# ---------------------------------------------------------------------------
+# TestExecuteArithmetic
+# ---------------------------------------------------------------------------
+
+class TestExecuteArithmetic:
+    def test_add(self):
+        fn = _simple_fn("main",
+            _const("a", 3), _const("b", 4),
+            _i("add", "c", ["a", "b"]), _ret("c"))
+        assert run(fn) == 7
+
+    def test_sub(self):
+        fn = _simple_fn("main",
+            _const("a", 10), _const("b", 3),
+            _i("sub", "c", ["a", "b"]), _ret("c"))
+        assert run(fn) == 7
+
+    def test_mul(self):
+        fn = _simple_fn("main",
+            _const("a", 6), _const("b", 7),
+            _i("mul", "c", ["a", "b"]), _ret("c"))
+        assert run(fn) == 42
+
+    def test_div(self):
+        fn = _simple_fn("main",
+            _const("a", 10), _const("b", 3),
+            _i("div", "c", ["a", "b"]), _ret("c"))
+        assert run(fn) == 3
+
+    def test_mod(self):
+        fn = _simple_fn("main",
+            _const("a", 10), _const("b", 3),
+            _i("mod", "c", ["a", "b"]), _ret("c"))
+        assert run(fn) == 1
+
+    def test_neg(self):
+        fn = _simple_fn("main",
+            _const("a", 5),
+            _i("neg", "b", ["a"]), _ret("b"))
+        assert run(fn) == -5
+
+    def test_u8_wrap_add(self):
+        fn = _simple_fn("main",
+            _const("a", 250), _const("b", 10),
+            _i("add", "c", ["a", "b"]), _ret("c"))
+        assert run(fn, u8_wrap=True) == 4  # 260 & 0xFF
+
+    def test_u8_wrap_sub(self):
+        fn = _simple_fn("main",
+            _const("a", 0), _const("b", 1),
+            _i("sub", "c", ["a", "b"]), _ret("c"))
+        assert run(fn, u8_wrap=True) == 255  # -1 & 0xFF
+
+    def test_u8_wrap_mul(self):
+        fn = _simple_fn("main",
+            _const("a", 16), _const("b", 16),
+            _i("mul", "c", ["a", "b"]), _ret("c"))
+        assert run(fn, u8_wrap=True) == 0  # 256 & 0xFF
+
+    def test_u8_wrap_neg(self):
+        fn = _simple_fn("main",
+            _const("a", 1),
+            _i("neg", "b", ["a"]), _ret("b"))
+        assert run(fn, u8_wrap=True) == 255
+
+    def test_no_dest_add(self):
+        # Handler still returns value; frame not updated.
+        fn = _simple_fn("main",
+            _const("a", 5), _const("b", 3),
+            _i("add", None, ["a", "b"]),
+            _const("r", 0), _ret("r"))
+        assert run(fn) == 0
+
+
+# ---------------------------------------------------------------------------
+# TestExecuteBitwise
+# ---------------------------------------------------------------------------
+
+class TestExecuteBitwise:
+    def test_and(self):
+        fn = _simple_fn("main",
+            _const("a", 0b1010), _const("b", 0b1100),
+            _i("and", "c", ["a", "b"]), _ret("c"))
+        assert run(fn) == 0b1000
+
+    def test_or(self):
+        fn = _simple_fn("main",
+            _const("a", 0b1010), _const("b", 0b0101),
+            _i("or", "c", ["a", "b"]), _ret("c"))
+        assert run(fn) == 0b1111
+
+    def test_xor(self):
+        fn = _simple_fn("main",
+            _const("a", 0b1010), _const("b", 0b1100),
+            _i("xor", "c", ["a", "b"]), _ret("c"))
+        assert run(fn) == 0b0110
+
+    def test_not(self):
+        fn = _simple_fn("main",
+            _const("a", 0),
+            _i("not", "b", ["a"]), _ret("b"))
+        assert run(fn) == -1
+
+    def test_shl(self):
+        fn = _simple_fn("main",
+            _const("a", 1), _const("n", 4),
+            _i("shl", "c", ["a", "n"]), _ret("c"))
+        assert run(fn) == 16
+
+    def test_shr(self):
+        fn = _simple_fn("main",
+            _const("a", 16), _const("n", 2),
+            _i("shr", "c", ["a", "n"]), _ret("c"))
+        assert run(fn) == 4
+
+
+# ---------------------------------------------------------------------------
+# TestExecuteComparisons
+# ---------------------------------------------------------------------------
+
+class TestExecuteComparisons:
+    def _cmp(self, op, a, b):
+        fn = _simple_fn("main",
+            _const("a", a), _const("b", b),
+            _i(op, "c", ["a", "b"]), _ret("c"))
+        return run(fn)
+
+    def test_cmp_eq_true(self):
+        assert self._cmp("cmp_eq", 5, 5) is True
+
+    def test_cmp_eq_false(self):
+        assert self._cmp("cmp_eq", 5, 6) is False
+
+    def test_cmp_ne_true(self):
+        assert self._cmp("cmp_ne", 1, 2) is True
+
+    def test_cmp_ne_false(self):
+        assert self._cmp("cmp_ne", 2, 2) is False
+
+    def test_cmp_lt_true(self):
+        assert self._cmp("cmp_lt", 3, 5) is True
+
+    def test_cmp_lt_false(self):
+        assert self._cmp("cmp_lt", 5, 3) is False
+
+    def test_cmp_le_equal(self):
+        assert self._cmp("cmp_le", 5, 5) is True
+
+    def test_cmp_le_less(self):
+        assert self._cmp("cmp_le", 4, 5) is True
+
+    def test_cmp_le_greater(self):
+        assert self._cmp("cmp_le", 6, 5) is False
+
+    def test_cmp_gt_true(self):
+        assert self._cmp("cmp_gt", 7, 3) is True
+
+    def test_cmp_gt_false(self):
+        assert self._cmp("cmp_gt", 2, 3) is False
+
+    def test_cmp_ge_equal(self):
+        assert self._cmp("cmp_ge", 5, 5) is True
+
+    def test_cmp_ge_greater(self):
+        assert self._cmp("cmp_ge", 6, 5) is True
+
+    def test_cmp_ge_less(self):
+        assert self._cmp("cmp_ge", 4, 5) is False
+
+
+# ---------------------------------------------------------------------------
+# TestExecuteControlFlow
+# ---------------------------------------------------------------------------
+
+class TestExecuteControlFlow:
+    def test_label_is_noop(self):
+        # Labels don't change execution flow on their own.
+        fn = _simple_fn("main",
+            _i("label", None, ["start"]),
+            _const("r", 42),
+            _ret("r"))
+        assert run(fn) == 42
+
+    def test_jmp_unconditional(self):
+        # Jump over the "bad" const to the "good" one.
+        fn = _simple_fn("main",
+            _i("jmp", None, ["done"]),
+            _const("r", 0),      # skipped
+            _i("label", None, ["done"]),
+            _const("r", 99),
+            _ret("r"))
+        assert run(fn) == 99
+
+    def test_jmp_if_true_taken(self):
+        fn = _simple_fn("main",
+            _const("cond", True),
+            _i("jmp_if_true", None, ["cond", "yes"]),
+            _const("r", 0),
+            _i("label", None, ["yes"]),
+            _const("r", 1),
+            _ret("r"))
+        assert run(fn) == 1
+
+    def test_jmp_if_true_not_taken(self):
+        fn = _simple_fn("main",
+            _const("cond", False),
+            _i("jmp_if_true", None, ["cond", "yes"]),
+            _const("r", 0),
+            _i("jmp", None, ["done"]),
+            _i("label", None, ["yes"]),
+            _const("r", 1),
+            _i("label", None, ["done"]),
+            _ret("r"))
+        assert run(fn) == 0
+
+    def test_jmp_if_false_taken(self):
+        fn = _simple_fn("main",
+            _const("cond", False),
+            _i("jmp_if_false", None, ["cond", "no"]),
+            _const("r", 0),
+            _i("label", None, ["no"]),
+            _const("r", 2),
+            _ret("r"))
+        assert run(fn) == 2
+
+    def test_jmp_if_false_not_taken(self):
+        fn = _simple_fn("main",
+            _const("cond", True),
+            _i("jmp_if_false", None, ["cond", "no"]),
+            _const("r", 5),
+            _i("jmp", None, ["done"]),
+            _i("label", None, ["no"]),
+            _const("r", 0),
+            _i("label", None, ["done"]),
+            _ret("r"))
+        assert run(fn) == 5
+
+    def test_ret_void_returns_none(self):
+        fn = _simple_fn("main", _ret_void())
+        assert run(fn) is None
+
+    def test_function_falls_off_end_returns_none(self):
+        # No ret instruction — frame is popped when ip exceeds instructions.
+        fn = _simple_fn("main", _const("r", 7))
+        assert run(fn) is None
+
+
+# ---------------------------------------------------------------------------
+# TestExecuteMemory
+# ---------------------------------------------------------------------------
+
+class TestExecuteMemory:
+    def test_store_and_load_mem(self):
+        fn = _simple_fn("main",
+            _const("addr", 100), _const("val", 42),
+            _i("store_mem", None, ["addr", "val"]),
+            _i("load_mem", "r", ["addr"]),
+            _ret("r"))
+        assert run(fn) == 42
+
+    def test_load_mem_unwritten_is_zero(self):
+        fn = _simple_fn("main",
+            _const("addr", 999),
+            _i("load_mem", "r", ["addr"]),
+            _ret("r"))
+        assert run(fn) == 0
+
+    def test_store_and_load_reg(self):
+        fn = _simple_fn("main",
+            _const("val", 55),
+            _i("store_reg", None, [0, "val"]),
+            _i("load_reg", "r", [0]),
+            _ret("r"))
+        assert run(fn) == 55
+
+    def test_memory_persists_across_calls(self):
+        vm = VMCore()
+        fn = _simple_fn("main",
+            _const("addr", 0), _const("val", 7),
+            _i("store_mem", None, ["addr", "val"]),
+            _ret_void())
+        mod = _mod(fn)
+        vm.execute(mod)
+        assert vm.memory[0] == 7
+
+    def test_io_out_and_io_in(self):
+        fn = _simple_fn("main",
+            _const("port", 3), _const("val", 0xAB),
+            _i("io_out", None, ["port", "val"]),
+            _i("io_in", "r", ["port"]),
+            _ret("r"))
+        assert run(fn) == 0xAB
+
+    def test_io_in_unwritten_is_zero(self):
+        fn = _simple_fn("main",
+            _const("port", 42),
+            _i("io_in", "r", ["port"]),
+            _ret("r"))
+        assert run(fn) == 0
+
+
+# ---------------------------------------------------------------------------
+# TestExecuteCalls
+# ---------------------------------------------------------------------------
+
+class TestExecuteCalls:
+    def test_call_simple_function(self):
+        double = _fn("double", [("x", "u8")],
+            _const("two", 2),
+            _i("mul", "r", ["x", "two"]),
+            _ret("r"))
+        main = _simple_fn("main",
+            _const("arg", 5),
+            _i("call", "result", ["double", "arg"]),
+            _ret("result"))
+        vm = VMCore()
+        mod = _mod(double, main)
+        assert vm.execute(mod, fn="main") == 10
+
+    def test_call_updates_fn_call_counts(self):
+        add = _fn("add", [("a", "u8"), ("b", "u8")],
+            _i("add", "r", ["a", "b"]),
+            _ret("r"))
+        main = _simple_fn("main",
+            _const("a", 1), _const("b", 2),
+            _i("call", "r", ["add", "a", "b"]),
+            _ret("r"))
+        vm = VMCore()
+        mod = _mod(add, main)
+        vm.execute(mod, fn="main")
+        m = vm.metrics()
+        assert m.function_call_counts["add"] == 1
+
+    def test_call_builtin(self):
+        fn = _simple_fn("main",
+            _const("a", 10),
+            _i("call_builtin", None, ["noop", "a"]),
+            _const("r", 1), _ret("r"))
+        vm = VMCore()
+        mod = _mod(fn)
+        assert vm.execute(mod, fn="main") == 1
+
+    def test_call_builtin_with_result(self):
+        fn = _simple_fn("main",
+            _const("a", 5), _const("b", 5),
+            _i("call_builtin", None, ["assert_eq", "a", "b"]),
+            _const("r", 0), _ret("r"))
+        vm = VMCore()
+        mod = _mod(fn)
+        assert vm.execute(mod, fn="main") == 0
+
+    def test_call_unknown_function_raises(self):
+        fn = _simple_fn("main",
+            _i("call", "r", ["missing"]),
+            _ret("r"))
+        vm = VMCore()
+        mod = _mod(fn)
+        with pytest.raises(UnknownOpcodeError, match="missing"):
+            vm.execute(mod, fn="main")
+
+    def test_call_with_args_passed_from_execute(self):
+        fn = _fn("main", [("x", "u8")], _ret("x"))
+        vm = VMCore()
+        mod = _mod(fn)
+        assert vm.execute(mod, fn="main", args=[99]) == 99
+
+
+# ---------------------------------------------------------------------------
+# TestJITHandler
+# ---------------------------------------------------------------------------
+
+class TestJITHandler:
+    def test_jit_handler_called(self):
+        called_with = []
+        def jit_handler(args):
+            called_with.append(args)
+            return args[0] * 2
+
+        vm = VMCore()
+        vm.register_jit_handler("double", jit_handler)
+
+        double = _fn("double", [("x", "u8")],
+            _const("two", 2), _i("mul", "r", ["x", "two"]), _ret("r"))
+        main = _simple_fn("main",
+            _const("a", 7),
+            _i("call", "r", ["double", "a"]),
+            _ret("r"))
+
+        mod = _mod(double, main)
+        result = vm.execute(mod, fn="main")
+        assert result == 14
+        assert called_with == [[7]]
+
+    def test_jit_handler_bypasses_interpreter(self):
+        # If JIT fires, the interpreter instructions in "add" never execute.
+        def jit_add(args):
+            return args[0] + args[1]
+
+        vm = VMCore()
+        vm.register_jit_handler("add", jit_add)
+
+        add_fn = _fn("add", [("a", "u8"), ("b", "u8")],
+            _const("bogus", 999), _ret("bogus"))  # would return 999 if interpreted
+        main = _simple_fn("main",
+            _const("a", 3), _const("b", 4),
+            _i("call", "r", ["add", "a", "b"]),
+            _ret("r"))
+
+        mod = _mod(add_fn, main)
+        assert vm.execute(mod, fn="main") == 7  # JIT path
+
+    def test_jit_hit_metric_increments(self):
+        vm = VMCore()
+        vm.register_jit_handler("noop_fn", lambda _: None)
+
+        noop_fn = _fn("noop_fn", [], _ret_void())
+        main = _simple_fn("main",
+            _i("call", None, ["noop_fn"]),
+            _i("call", None, ["noop_fn"]),
+            _ret_void())
+
+        mod = _mod(noop_fn, main)
+        vm.execute(mod, fn="main")
+        assert vm.metrics().total_jit_hits == 2
+
+    def test_unregister_jit_handler(self):
+        vm = VMCore()
+        vm.register_jit_handler("fn", lambda _: 99)
+        vm.unregister_jit_handler("fn")
+
+        fn = _fn("fn", [], _const("r", 1), _ret("r"))
+        main = _simple_fn("main",
+            _i("call", "r", ["fn"]),
+            _ret("r"))
+        mod = _mod(fn, main)
+        # After unregister, interpreter path is used (returns 1, not 99).
+        assert vm.execute(mod, fn="main") == 1
+
+
+# ---------------------------------------------------------------------------
+# TestMetricsAccumulation
+# ---------------------------------------------------------------------------
+
+class TestMetricsAccumulation:
+    def test_instruction_count_accumulates(self):
+        vm = VMCore()
+        fn = _simple_fn("main", _const("r", 1), _ret("r"))
+        mod = _mod(fn)
+        vm.execute(mod)
+        first = vm.metrics().total_instructions_executed
+        vm.execute(mod)
+        second = vm.metrics().total_instructions_executed
+        assert second == first * 2
+
+    def test_frame_count_includes_root(self):
+        vm = VMCore()
+        fn = _simple_fn("main", _ret_void())
+        vm.execute(_mod(fn))
+        assert vm.metrics().total_frames_pushed >= 1
+
+    def test_fn_call_counts_accumulate(self):
+        vm = VMCore()
+        fn = _simple_fn("main", _ret_void())
+        mod = _mod(fn)
+        vm.execute(mod)
+        vm.execute(mod)
+        assert vm.metrics().function_call_counts["main"] == 2
+
+
+# ---------------------------------------------------------------------------
+# TestInterrupt
+# ---------------------------------------------------------------------------
+
+class TestInterrupt:
+    def test_interrupt_raises_vm_interrupt(self):
+        # Build an infinite loop; interrupt it externally via a builtin side-effect.
+        vm = VMCore()
+        vm.register_builtin("do_interrupt", lambda args: vm.interrupt())
+
+        fn = _simple_fn("main",
+            _i("label", None, ["loop"]),
+            _i("call_builtin", None, ["do_interrupt"]),
+            _i("jmp", None, ["loop"]))
+
+        mod = _mod(fn)
+        with pytest.raises(VMInterrupt):
+            vm.execute(mod, fn="main")
+
+    def test_interrupt_flag_cleared_after_raise(self):
+        vm = VMCore()
+        vm.register_builtin("stop", lambda args: vm.interrupt())
+        fn = _simple_fn("main", _i("call_builtin", None, ["stop"]), _ret_void())
+        mod = _mod(fn)
+        with pytest.raises(VMInterrupt):
+            vm.execute(mod, fn="main")
+        # After exception, internal flag should be False.
+        assert vm._interrupted is False
+
+
+# ---------------------------------------------------------------------------
+# TestReset
+# ---------------------------------------------------------------------------
+
+class TestReset:
+    def test_reset_clears_memory(self):
+        vm = VMCore()
+        fn = _simple_fn("main",
+            _const("addr", 0), _const("val", 42),
+            _i("store_mem", None, ["addr", "val"]),
+            _ret_void())
+        vm.execute(_mod(fn))
+        assert vm.memory[0] == 42
+        vm.reset()
+        assert vm.memory == {}
+
+    def test_reset_clears_io_ports(self):
+        vm = VMCore()
+        fn = _simple_fn("main",
+            _const("p", 1), _const("v", 7),
+            _i("io_out", None, ["p", "v"]),
+            _ret_void())
+        vm.execute(_mod(fn))
+        assert vm.io_ports[1] == 7
+        vm.reset()
+        assert vm.io_ports == {}
+
+    def test_metrics_survive_reset(self):
+        vm = VMCore()
+        fn = _simple_fn("main", _const("r", 1), _ret("r"))
+        vm.execute(_mod(fn))
+        before = vm.metrics().total_instructions_executed
+        vm.reset()
+        assert vm.metrics().total_instructions_executed == before
+
+
+# ---------------------------------------------------------------------------
+# TestFrameOverflow
+# ---------------------------------------------------------------------------
+
+class TestFrameOverflow:
+    def test_deep_recursion_raises(self):
+        recurse = _fn("recurse", [],
+            _i("call", None, ["recurse"]),
+            _ret_void())
+        mod = _mod(recurse)
+        vm = VMCore(max_frames=10)
+        with pytest.raises(FrameOverflowError, match="10"):
+            vm.execute(mod, fn="recurse")
+
+
+# ---------------------------------------------------------------------------
+# TestErrors
+# ---------------------------------------------------------------------------
+
+class TestErrors:
+    def test_unknown_opcode_raises(self):
+        fn = _simple_fn("main", _i("bogus_op"))
+        vm = VMCore()
+        with pytest.raises(UnknownOpcodeError, match="bogus_op"):
+            vm.execute(_mod(fn), fn="main")
+
+    def test_undefined_variable_raises(self):
+        fn = _simple_fn("main", _ret("undefined_var"))
+        vm = VMCore()
+        with pytest.raises(UndefinedVariableError, match="undefined_var"):
+            vm.execute(_mod(fn), fn="main")
+
+    def test_vm_error_is_base(self):
+        assert issubclass(UnknownOpcodeError, VMError)
+        assert issubclass(FrameOverflowError, VMError)
+        assert issubclass(UndefinedVariableError, VMError)
+        assert issubclass(VMInterrupt, VMError)
+
+
+# ---------------------------------------------------------------------------
+# TestExecuteCoercions
+# ---------------------------------------------------------------------------
+
+class TestExecuteCoercions:
+    def test_cast_to_u8(self):
+        fn = _simple_fn("main",
+            _const("v", 300),
+            _i("cast", "r", ["v", "u8"]),
+            _ret("r"))
+        assert run(fn) == 44  # 300 & 0xFF
+
+    def test_cast_to_u16(self):
+        fn = _simple_fn("main",
+            _const("v", 70000),
+            _i("cast", "r", ["v", "u16"]),
+            _ret("r"))
+        assert run(fn) == 70000 & 0xFFFF
+
+    def test_cast_to_u32(self):
+        fn = _simple_fn("main",
+            _const("v", 2**33),
+            _i("cast", "r", ["v", "u32"]),
+            _ret("r"))
+        assert run(fn) == (2**33) & 0xFFFFFFFF
+
+    def test_cast_to_bool(self):
+        fn = _simple_fn("main",
+            _const("v", 0),
+            _i("cast", "r", ["v", "bool"]),
+            _ret("r"))
+        assert run(fn) is False
+
+    def test_cast_to_str(self):
+        fn = _simple_fn("main",
+            _const("v", 42),
+            _i("cast", "r", ["v", "str"]),
+            _ret("r"))
+        assert run(fn) == "42"
+
+    def test_type_assert_passes(self):
+        fn = _simple_fn("main",
+            _const("v", 100),
+            _i("type_assert", None, ["v", "u8"]),
+            _ret("v"))
+        assert run(fn) == 100
+
+    def test_type_assert_fails(self):
+        fn = _simple_fn("main",
+            _const("v", 3.14),
+            _i("type_assert", None, ["v", "u8"]),
+            _ret("v"))
+        with pytest.raises(VMError, match="type_assert"):
+            run(fn)
+
+    def test_cast_uses_type_hint_when_no_second_src(self):
+        fn = _simple_fn("main",
+            _const("v", 300),
+            IIRInstr(op="cast", dest="r", srcs=["v"], type_hint="u8"),
+            _ret("r"))
+        assert run(fn) == 44
+
+
+# ---------------------------------------------------------------------------
+# TestRepl (incremental module pattern)
+# ---------------------------------------------------------------------------
+
+class TestRepl:
+    def test_execute_different_functions_sequentially(self):
+        """Simulate REPL: define two functions, call them in sequence."""
+        add = _fn("add", [("a", "u8"), ("b", "u8")],
+            _i("add", "r", ["a", "b"]), _ret("r"))
+        sub = _fn("sub", [("a", "u8"), ("b", "u8")],
+            _i("sub", "r", ["a", "b"]), _ret("r"))
+
+        vm = VMCore()
+        mod = _mod(add, sub)
+
+        assert vm.execute(mod, fn="add", args=[10, 3]) == 13
+        assert vm.execute(mod, fn="sub", args=[10, 3]) == 7
+
+    def test_add_or_replace_function(self):
+        """Simulate re-defining a function in the REPL."""
+        fn_v1 = _fn("compute", [], _const("r", 1), _ret("r"))
+        fn_v2 = _fn("compute", [], _const("r", 2), _ret("r"))
+
+        mod = _mod(fn_v1)
+        vm = VMCore()
+        assert vm.execute(mod, fn="compute") == 1
+
+        mod.add_or_replace(fn_v2)
+        assert vm.execute(mod, fn="compute") == 2
+
+
+# ---------------------------------------------------------------------------
+# TestMultiFunction
+# ---------------------------------------------------------------------------
+
+class TestMultiFunction:
+    def test_nested_calls(self):
+        """a(b(x)) — two levels of call."""
+        inner = _fn("inner", [("x", "u8")],
+            _const("two", 2),
+            _i("mul", "r", ["x", "two"]),
+            _ret("r"))
+        outer = _fn("outer", [("x", "u8")],
+            _i("call", "r", ["inner", "x"]),
+            _const("three", 3),
+            _i("add", "r2", ["r", "three"]),
+            _ret("r2"))
+        main = _simple_fn("main",
+            _const("a", 4),
+            _i("call", "result", ["outer", "a"]),
+            _ret("result"))
+
+        vm = VMCore()
+        mod = _mod(inner, outer, main)
+        assert vm.execute(mod, fn="main") == 11  # (4*2)+3
+
+    def test_multiple_callee_args(self):
+        add3 = _fn("add3", [("a", "u8"), ("b", "u8"), ("c", "u8")],
+            _i("add", "ab", ["a", "b"]),
+            _i("add", "r", ["ab", "c"]),
+            _ret("r"))
+        main = _simple_fn("main",
+            _const("x", 1), _const("y", 2), _const("z", 3),
+            _i("call", "r", ["add3", "x", "y", "z"]),
+            _ret("r"))
+
+        vm = VMCore()
+        mod = _mod(add3, main)
+        assert vm.execute(mod, fn="main") == 6
+
+    def test_profiler_observes_results(self):
+        fn = _simple_fn("main",
+            _const("a", 5), _const("b", 3),
+            _i("add", "r", ["a", "b"]),
+            _ret("r"))
+        vm = VMCore(profiler_enabled=True)
+        vm.execute(_mod(fn))
+        assert vm.profiler.total_observations > 0
+
+    def test_profiler_disabled_makes_no_observations(self):
+        fn = _simple_fn("main",
+            _const("a", 5), _const("b", 3),
+            _i("add", "r", ["a", "b"]),
+            _ret("r"))
+        vm = VMCore(profiler_enabled=False)
+        vm.execute(_mod(fn))
+        assert vm.profiler.total_observations == 0
+
+    def test_custom_opcode_overrides_standard(self):
+        """Language-specific handler takes priority over standard table."""
+        calls = []
+        def custom_add(vm, frame, instr):
+            calls.append("custom_add")
+            a = frame.resolve(instr.srcs[0])
+            b = frame.resolve(instr.srcs[1])
+            result = a + b + 1000  # adds 1000 to distinguish
+            if instr.dest:
+                frame.assign(instr.dest, result)
+            return result
+
+        fn = _simple_fn("main",
+            _const("a", 1), _const("b", 2),
+            _i("add", "r", ["a", "b"]),
+            _ret("r"))
+        vm = VMCore(opcodes={"add": custom_add})
+        assert vm.execute(_mod(fn), fn="main") == 1003
+        assert calls == ["custom_add"]
+
+    def test_is_executing_false_after_done(self):
+        vm = VMCore()
+        fn = _simple_fn("main", _ret_void())
+        vm.execute(_mod(fn))
+        assert not vm.is_executing


### PR DESCRIPTION
## Summary

- Implements **vm-core** (LANG02) — the language-agnostic register VM that executes `InterpreterIR` modules produced by any LANG pipeline front-end
- Sits between `interpreter-ir` (LANG01) and `jit-core` (LANG03); any language targeting this pipeline gets a working interpreter with zero additional glue code
- 14 files, 2 587 lines

## Key components

| Module | Purpose |
|---|---|
| `VMCore` | Public API: `execute()`, `metrics()`, `register_builtin()`, `register_jit_handler()`, `interrupt()`, `reset()` |
| `RegisterFile` | Flat slot array with `snapshot()`/`restore()` for REPL error-recovery rollback |
| `VMFrame` | Per-call-frame state; `for_function()` pre-assigns param registers |
| `run_dispatch_loop()` | Tight `while-frames` loop, O(1) opcode dispatch, profiler observation, interrupt-flag check |
| `VMProfiler` | Inline type profiler; calls `IIRInstr.record_observation()` — feeds jit-core |
| `VMMetrics` | Immutable snapshot of lifetime execution statistics |
| `BuiltinRegistry` | Host-callable registry; `noop` + `assert_eq` pre-registered |
| 35 opcode handlers | Covers all `interpreter_ir.ALL_OPS` mnemonics plus `const` |

## JIT integration

`VMCore.register_jit_handler(fn_name, handler)` bypasses the interpreter for compiled functions — no frame is pushed, `total_jit_hits` is incremented. This is the zero-overhead hook that jit-core (LANG03) will use.

## Test plan

- [x] 124 tests, 97.58% line coverage (all modules ≥96%)
- [x] Arithmetic, bitwise, comparison, control flow, memory, I/O, coercions
- [x] JIT handler priority, metrics accumulation, interrupt delivery, reset
- [x] u8_wrap mode, FrameOverflowError, UndefinedVariableError, UnknownOpcodeError
- [x] REPL incremental module pattern (`add_or_replace`)
- [x] Nested cross-function calls and argument passing
- [x] `ruff check` passes, 0 warnings

🤖 Generated with [Claude Code](https://claude.ai/claude-code)