### PR TITLE
feat(symbolic-vm): Phase 8 — power-of-composite u-substitution

### DIFF
--- a/code/packages/python/symbolic-vm/CHANGELOG.md
+++ b/code/packages/python/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 0.13.0 — 2026-04-22
+
+Phase 8 of the integration roadmap — power-of-composite u-substitution.
+
+Extends u-substitution (Phase 7) to handle integrands where the outer function
+is a **power** of a composite: `POW(f(g(x)), n) · c·g'(x)` and `POW(g(x), n) · c·g'(x)`.
+
+**Case A — `f(g(x))^n · c·g'(x)`**:
+- Substitute `u = g(x)`, integrate `∫ f(u)^n du` via Phase 5 (sin/cos/tan reduction
+  formulas for trig outers), back-substitute `u → g(x)`.
+- Guard: `g` must not be bare `x` (Phase 5 handles) or linear with a≠0 (Phase 5 handles).
+
+**Case B — `g(x)^n · c·g'(x)`**:
+- Substitute `u = g(x)`, integrate `∫ u^n du` via Phase 1 power rule,
+  back-substitute.
+- Special case n=−1: `∫ u⁻¹ du = log(u)` → `log(g(x))`.
+- Guard: `g` must not be bare `x` or linear with a≠0.
+
+**Bonus — `(ax+b)^n` in the single-factor POW branch**:
+- `∫ (ax+b)^n dx = (ax+b)^(n+1)/((n+1)·a)` for n≠−1.
+- `∫ (ax+b)^(−1) dx = log(ax+b)/a`.
+- Supports integer and symbolic exponents.
+
+**`_diff_ir` extensions** (enables Case B for sums of functions):
+- `NEG(f)`: `d/dx(−f) = −f'`
+- `ADD(f, g)`: `d/dx(f+g) = f' + g'` (zero terms simplified)
+- `SUB(f, g)`: `d/dx(f−g) = f' − g'`
+
+New helpers in `integrate.py`: `_try_u_sub_pow_one`, `_try_u_sub_pow`.
+Hook in MUL branch after Phase 7, before Phase 4c.
+
+New spec: `code/specs/phase8-power-composite-usub.md`.
+
+40 new tests (`tests/test_phase8.py`). Package at ~491 tests.
+
 ## 0.12.0 — 2026-04-20
 
 Phase 7 of the integration roadmap — u-substitution (chain-rule reversal).

--- a/code/packages/python/symbolic-vm/pyproject.toml
+++ b/code/packages/python/symbolic-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-symbolic-vm"
-version = "0.12.0"
+version = "0.13.0"
 description = "Pluggable symbolic VM — evaluates symbolic-ir trees through swappable backends (strict numeric vs. Mathematica-style symbolic rewriting)."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/integrate.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/integrate.py
@@ -1,4 +1,4 @@
-"""Symbolic integration — the ``Integrate`` handler (Phases 1–7).
+"""Symbolic integration — the ``Integrate`` handler (Phases 1–8).
 
 The handler tries two routes, in order:
 
@@ -41,7 +41,7 @@ What Phase 1 can do
 What this phase can't do (yet)
 ------------------------------
 
-- Integration by substitution beyond Phase 7 (two-arg outer functions).
+- Integration by substitution beyond Phase 8 (two-arg non-POW outer functions).
 - Rational × transcendental (e.g. ``(1/x)·eˣ``).
 - Products of two transcendentals (e.g. ``exp(x)·log(x)``).
 - Irreducible denominators of degree > 2 (e.g. ``1/(x³+x+1)``).
@@ -377,6 +377,10 @@ def _integrate(f: IRNode, x: IRSymbol) -> IRNode | None:
         result = _try_u_sub(a, b, x)
         if result is not None:
             return result
+        # Phase 8: u-substitution for POW(f(g(x)), n) · c·g'(x).
+        result = _try_u_sub_pow(a, b, x)
+        if result is not None:
+            return result
         # Phase 4c: exp × trig via double-IBP closed form.
         result = _try_exp_trig(a, b, x) or _try_exp_trig(b, a, x)
         if result is not None:
@@ -435,6 +439,26 @@ def _integrate(f: IRNode, x: IRSymbol) -> IRNode | None:
         result = _try_trig_power(base, exponent, x)
         if result is not None:
             return result
+        # Phase 8 bonus: ∫ (ax+b)^n dx = (ax+b)^(n+1)/((n+1)·a) or log(ax+b)/a.
+        lin = _try_linear(base, x)
+        if lin is not None:
+            a_lin, b_lin = lin
+            if a_lin != Fraction(0):
+                arg_ir = base
+                a_ir = _frac_ir(a_lin)
+                if _is_minus_one(exponent):
+                    # ∫ (ax+b)^(-1) dx = log(ax+b) / a
+                    return IRApply(DIV, (IRApply(LOG, (arg_ir,)), a_ir))
+                # ∫ (ax+b)^n dx = (ax+b)^(n+1) / ((n+1)·a)
+                if isinstance(exponent, IRInteger):
+                    new_n = exponent.value + 1
+                    new_exp = IRInteger(new_n)
+                    denom = IRApply(MUL, (IRInteger(new_n), a_ir))
+                    return IRApply(DIV, (IRApply(POW, (arg_ir, new_exp)), denom))
+                # Symbolic / rational exponent — use ADD form.
+                new_exp = IRApply(ADD, (exponent, ONE))
+                denom = IRApply(MUL, (new_exp, a_ir))
+                return IRApply(DIV, (IRApply(POW, (arg_ir, new_exp)), denom))
         return None
 
     # --- Elementary functions at x  (Phase 1: argument must be bare x)
@@ -1142,6 +1166,39 @@ def _diff_ir(g: IRNode, x: IRSymbol) -> IRNode | None:
         # Rational function derivatives deferred (quotient rule not needed yet).
         return None
 
+    # Additive / negation rules — linearity of differentiation.
+    if head == NEG:
+        # d/dx(−f) = −f'
+        da = _diff_ir(g.args[0], x)
+        if da is None:
+            return None
+        if isinstance(da, IRInteger) and da.value == 0:
+            return IRInteger(0)
+        return IRApply(NEG, (da,))
+
+    if head == ADD:
+        # d/dx(f+g) = f' + g'
+        da = _diff_ir(g.args[0], x)
+        db = _diff_ir(g.args[1], x)
+        if da is None or db is None:
+            return None
+        zero = IRInteger(0)
+        if da == zero:
+            return db
+        if db == zero:
+            return da
+        return IRApply(ADD, (da, db))
+
+    if head == SUB:
+        # d/dx(f−g) = f' − g'
+        da = _diff_ir(g.args[0], x)
+        db = _diff_ir(g.args[1], x)
+        if da is None or db is None:
+            return None
+        if isinstance(db, IRInteger) and db.value == 0:
+            return da
+        return IRApply(SUB, (da, db))
+
     # Single-argument functions — apply chain rule.
     if len(g.args) == 1:
         arg = g.args[0]
@@ -1357,6 +1414,94 @@ def _try_u_sub(fa: IRNode, fb: IRNode, x: IRSymbol) -> IRNode | None:
     if result is not None:
         return result
     return _try_u_sub_one(fb, fa, x)
+
+
+# ---------------------------------------------------------------------------
+# Phase 8 helpers — power-of-composite u-substitution
+# ---------------------------------------------------------------------------
+
+
+def _try_u_sub_pow_one(
+    pow_node: IRNode, gp_candidate: IRNode, x: IRSymbol
+) -> IRNode | None:
+    """Try u-sub for ``POW(base, n) · c·g'(x)``, returning the antiderivative or None.
+
+    Two cases:
+
+    Case A — ``base = f(g(x))`` where ``f`` is a single-arg function:
+      Substitute u = g, integrate ``POW(f(u), n)`` (delegated to Phase 5 for
+      SIN/COS/TAN powers), back-substitute.
+
+    Case B — ``base = g(x)`` (polynomial, sums, etc.):
+      Substitute u = base, integrate ``u^n`` via Phase 1 power rule,
+      back-substitute.
+    """
+    if not isinstance(pow_node, IRApply) or pow_node.head != POW:
+        return None
+    base, exp_node = pow_node.args
+    if _depends_on(exp_node, x) or not _depends_on(base, x):
+        return None
+
+    u = IRSymbol("__u__")
+
+    # Case A: base is a single-arg function of some inner g(x).
+    if isinstance(base, IRApply) and len(base.args) == 1:
+        g = base.args[0]
+        # Skip f(x)^n — Phase 5 _try_trig_power handles it via the POW branch.
+        if g == x:
+            return None
+        # Skip f(ax+b)^n — Phase 5 handles linear-arg trig powers.
+        lin = _try_linear(g, x)
+        if lin is not None and lin[0] != Fraction(0):
+            return None
+        gprime = _diff_ir(g, x)
+        if gprime is None:
+            return None
+        c = _ratio_const(gp_candidate, gprime, x)
+        if c is None or c == Fraction(0):
+            return None
+        # Replace g → u inside the base function, keeping the outer POW.
+        base_u = _subst(base, g, u)
+        G_u = _integrate(IRApply(POW, (base_u, exp_node)), u)
+        if G_u is None:
+            return None
+        G_gx = _subst(G_u, u, g)
+        if c == Fraction(1):
+            return G_gx
+        return IRApply(MUL, (_frac_ir(c), G_gx))
+
+    # Case B: base is a general expression g(x) — treat the whole base as g.
+    # Skip bare x (Phase 1) and linear base (Phase 8 bonus in POW branch).
+    if base == x:
+        return None
+    lin = _try_linear(base, x)
+    if lin is not None and lin[0] != Fraction(0):
+        return None
+    gprime = _diff_ir(base, x)
+    if gprime is None:
+        return None
+    c = _ratio_const(gp_candidate, gprime, x)
+    if c is None or c == Fraction(0):
+        return None
+    # ∫ u^n du — Phase 1 power rule applies since u is now bare.
+    G_u = _integrate(IRApply(POW, (u, exp_node)), u)
+    if G_u is None:
+        return None
+    G_gx = _subst(G_u, u, base)
+    if c == Fraction(1):
+        return G_gx
+    return IRApply(MUL, (_frac_ir(c), G_gx))
+
+
+def _try_u_sub_pow(fa: IRNode, fb: IRNode, x: IRSymbol) -> IRNode | None:
+    """Return ``∫ fa·fb dx`` via power-of-composite u-sub, or ``None``.
+
+    Tries both orderings: (fa as pow_node, fb as g') and (fb as pow_node, fa as g').
+    """
+    result = _try_u_sub_pow_one(fa, fb, x)
+    if result is not None:
+        return result
+    return _try_u_sub_pow_one(fb, fa, x)
 
 
 def _depends_on(node: IRNode, var: IRSymbol) -> bool:

--- a/code/packages/python/symbolic-vm/tests/test_phase8.py
+++ b/code/packages/python/symbolic-vm/tests/test_phase8.py
@@ -1,0 +1,592 @@
+"""Phase 8 integration tests — power-of-composite u-substitution.
+
+∫ f(g(x))ⁿ · c·g'(x) dx = c · F(g(x)) + C
+
+Two main families:
+  Case A: outer = f(g(x))^n where f is a 1-arg function (SIN, COS, TAN)
+  Case B: outer = g(x)^n   where g is a general non-linear expression
+
+Bonus: single-factor (ax+b)^n in the POW branch.
+
+Correctness is verified numerically: differentiate the antiderivative at test
+points and confirm the result matches the original integrand.
+
+Test points: x₀ = 0.4, x₁ = 0.7 — safely away from trig/log singularities.
+"""
+
+from __future__ import annotations
+
+import math
+
+from symbolic_ir import (
+    ADD,
+    COS,
+    EXP,
+    INTEGRATE,
+    LOG,
+    MUL,
+    NEG,
+    POW,
+    SIN,
+    SUB,
+    TAN,
+    IRApply,
+    IRFloat,
+    IRInteger,
+    IRNode,
+    IRRational,
+    IRSymbol,
+)
+
+from symbolic_vm.backends import SymbolicBackend
+from symbolic_vm.vm import VM
+
+# ---------------------------------------------------------------------------
+# Shared helpers (same pattern as Phase 7 tests)
+# ---------------------------------------------------------------------------
+
+X = IRSymbol("x")
+
+
+def _make_vm() -> VM:
+    return VM(SymbolicBackend())
+
+
+def _eval_ir(node: IRNode, x_val: float) -> float:  # noqa: PLR0911
+    """Numerically evaluate an IR tree at x = x_val."""
+    if isinstance(node, IRInteger):
+        return float(node.value)
+    if isinstance(node, IRRational):
+        return node.numer / node.denom
+    if isinstance(node, IRFloat):
+        return node.value
+    if isinstance(node, IRSymbol):
+        if node.name == "x":
+            return x_val
+        raise ValueError(f"Unknown symbol: {node.name}")
+    if not isinstance(node, IRApply):
+        raise TypeError(f"Unexpected node: {node!r}")
+    head = node.head.name
+    if head == "Add":
+        return _eval_ir(node.args[0], x_val) + _eval_ir(node.args[1], x_val)
+    if head == "Sub":
+        return _eval_ir(node.args[0], x_val) - _eval_ir(node.args[1], x_val)
+    if head == "Mul":
+        return _eval_ir(node.args[0], x_val) * _eval_ir(node.args[1], x_val)
+    if head == "Div":
+        return _eval_ir(node.args[0], x_val) / _eval_ir(node.args[1], x_val)
+    if head == "Neg":
+        return -_eval_ir(node.args[0], x_val)
+    if head == "Inv":
+        return 1.0 / _eval_ir(node.args[0], x_val)
+    if head == "Exp":
+        return math.exp(_eval_ir(node.args[0], x_val))
+    if head == "Log":
+        return math.log(abs(_eval_ir(node.args[0], x_val)))
+    if head == "Sin":
+        return math.sin(_eval_ir(node.args[0], x_val))
+    if head == "Cos":
+        return math.cos(_eval_ir(node.args[0], x_val))
+    if head == "Tan":
+        return math.tan(_eval_ir(node.args[0], x_val))
+    if head == "Pow":
+        return _eval_ir(node.args[0], x_val) ** _eval_ir(node.args[1], x_val)
+    if head == "Sqrt":
+        return math.sqrt(abs(_eval_ir(node.args[0], x_val)))
+    if head == "Atan":
+        return math.atan(_eval_ir(node.args[0], x_val))
+    raise ValueError(f"Unhandled head: {head}")
+
+
+def _numerical_deriv(node: IRNode, x_val: float, h: float = 1e-7) -> float:
+    return (_eval_ir(node, x_val + h) - _eval_ir(node, x_val - h)) / (2 * h)
+
+
+def _check_antiderivative(
+    integrand: IRNode,
+    antideriv: IRNode,
+    test_points: tuple[float, ...] = (0.4, 0.7),
+    atol: float = 1e-6,
+    rtol: float = 1e-6,
+) -> None:
+    """Verify F'(x) ≈ f(x) numerically at each test point."""
+    for x_val in test_points:
+        expected = _eval_ir(integrand, x_val)
+        actual = _numerical_deriv(antideriv, x_val)
+        tol = atol + rtol * abs(expected)
+        assert abs(actual - expected) < tol, (
+            f"At x={x_val}: F'={actual:.8f}, f={expected:.8f}, "
+            f"diff={abs(actual-expected):.2e}"
+        )
+
+
+def _integrate_ir(vm: VM, integrand_ir: IRNode) -> IRNode:
+    return vm.eval(IRApply(INTEGRATE, (integrand_ir, X)))
+
+
+def _was_evaluated(f: IRNode, F: IRNode) -> None:
+    """Assert the integral was not left unevaluated."""
+    assert IRApply(INTEGRATE, (f, X)) != F, (
+        "Expected a closed-form antiderivative, got an unevaluated Integrate"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Small IR builder helpers
+# ---------------------------------------------------------------------------
+
+
+def _mul(a: IRNode, b: IRNode) -> IRNode:
+    return IRApply(MUL, (a, b))
+
+
+def _add(a: IRNode, b: IRNode) -> IRNode:
+    return IRApply(ADD, (a, b))
+
+
+def _sub(a: IRNode, b: IRNode) -> IRNode:
+    return IRApply(SUB, (a, b))
+
+
+def _neg(a: IRNode) -> IRNode:
+    return IRApply(NEG, (a,))
+
+
+def _sin(arg: IRNode) -> IRNode:
+    return IRApply(SIN, (arg,))
+
+
+def _cos(arg: IRNode) -> IRNode:
+    return IRApply(COS, (arg,))
+
+
+def _exp(arg: IRNode) -> IRNode:
+    return IRApply(EXP, (arg,))
+
+
+def _log(arg: IRNode) -> IRNode:
+    return IRApply(LOG, (arg,))
+
+
+def _tan(arg: IRNode) -> IRNode:
+    return IRApply(TAN, (arg,))
+
+
+def _pow(base: IRNode, n: int) -> IRNode:
+    return IRApply(POW, (base, IRInteger(n)))
+
+
+def _xn(n: int) -> IRNode:
+    """x^n as IR."""
+    if n == 1:
+        return X
+    return IRApply(POW, (X, IRInteger(n)))
+
+
+def _cx(c: int) -> IRNode:
+    """c·x as IR."""
+    return IRApply(MUL, (IRInteger(c), X))
+
+
+def _linear(a: int, b: int) -> IRNode:
+    """a·x + b as IR."""
+    return _add(_cx(a), IRInteger(b))
+
+
+# ---------------------------------------------------------------------------
+# TestPhase8_CaseA_Trig — POW(f(g(x)), n) · g'(x) for trig/poly inner g
+# ---------------------------------------------------------------------------
+
+
+class TestPhase8_CaseA_Trig:
+    """∫ f(g(x))^n · g'(x) dx via u = g(x), inner = Phase 5b/5c."""
+
+    def test_cos_sin2_sin(self):
+        """∫ cos(x)·sin²(sin(x)) dx — n=2, g=sin(x)"""
+        vm = _make_vm()
+        f = _mul(_cos(X), _pow(_sin(_sin(X)), 2))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_cos_sin3_sin(self):
+        """∫ cos(x)·sin³(sin(x)) dx — n=3, g=sin(x)"""
+        vm = _make_vm()
+        f = _mul(_cos(X), _pow(_sin(_sin(X)), 3))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_cos_sin4_sin(self):
+        """∫ cos(x)·sin⁴(sin(x)) dx — n=4"""
+        vm = _make_vm()
+        f = _mul(_cos(X), _pow(_sin(_sin(X)), 4))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_neg_sin_cos2_cos(self):
+        """∫ −sin(x)·cos²(cos(x)) dx — cos outer, g=cos(x), g'=−sin(x)"""
+        vm = _make_vm()
+        f = _mul(_neg(_sin(X)), _pow(_cos(_cos(X)), 2))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_cos_cos3_sin(self):
+        """∫ cos(x)·cos³(sin(x)) dx — cos outer, sin inner"""
+        vm = _make_vm()
+        f = _mul(_cos(X), _pow(_cos(_sin(X)), 3))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_cos_tan2_sin(self):
+        """∫ cos(x)·tan²(sin(x)) dx — tan outer, Phase 5c inner integral"""
+        vm = _make_vm()
+        f = _mul(_cos(X), _pow(_tan(_sin(X)), 2))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_2x_sin2_x2(self):
+        """∫ 2x·sin²(x²) dx — polynomial inner g=x²"""
+        vm = _make_vm()
+        f = _mul(_cx(2), _pow(_sin(_xn(2)), 2))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_2x_cos2_x2(self):
+        """∫ 2x·cos²(x²) dx — polynomial inner g=x²"""
+        vm = _make_vm()
+        f = _mul(_cx(2), _pow(_cos(_xn(2)), 2))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_3x2_sin2_x3(self):
+        """∫ 3x²·sin²(x³) dx — polynomial inner g=x³"""
+        vm = _make_vm()
+        f = _mul(_mul(IRInteger(3), _xn(2)), _pow(_sin(_xn(3)), 2))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_2cos2x_sin2_sin2x(self):
+        """∫ 2·cos(2x)·sin²(sin(2x)) dx — scaled linear arg, g=sin(2x)"""
+        vm = _make_vm()
+        two_x = _cx(2)
+        f = _mul(_mul(IRInteger(2), _cos(two_x)), _pow(_sin(_sin(two_x)), 2))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+
+# ---------------------------------------------------------------------------
+# TestPhase8_CaseB_Poly — POW(g(x), n) · c·g'(x) for various g
+# ---------------------------------------------------------------------------
+
+
+class TestPhase8_CaseB_Poly:
+    """∫ g(x)^n · c·g'(x) dx via u = g(x), inner = Phase 1 power rule."""
+
+    def test_2x_x2p1_cube(self):
+        """∫ 2x·(x²+1)³ dx = (x²+1)⁴/4"""
+        vm = _make_vm()
+        g = _add(_xn(2), IRInteger(1))
+        f = _mul(_cx(2), _pow(g, 3))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_2x_x2p1_inv(self):
+        """∫ 2x·(x²+1)⁻¹ dx = log(x²+1)  [n=−1 special case]"""
+        vm = _make_vm()
+        g = _add(_xn(2), IRInteger(1))
+        f = _mul(_cx(2), _pow(g, -1))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_3x2_x3p5_quad(self):
+        """∫ 3x²·(x³+5)⁴ dx = (x³+5)⁵/5"""
+        vm = _make_vm()
+        g = _add(_xn(3), IRInteger(5))
+        f = _mul(_mul(IRInteger(3), _xn(2)), _pow(g, 4))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_3x2_x3p5_neg2(self):
+        """∫ 3x²·(x³+5)⁻² dx = −1/(x³+5)"""
+        vm = _make_vm()
+        g = _add(_xn(3), IRInteger(5))
+        f = _mul(_mul(IRInteger(3), _xn(2)), _pow(g, -2))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_x_x2p1_cube_half(self):
+        """∫ x·(x²+1)³ dx = (x²+1)⁴/8  [c=1/2 rational scale]"""
+        vm = _make_vm()
+        g = _add(_xn(2), IRInteger(1))
+        f = _mul(X, _pow(g, 3))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_4x3_x4m1_sq(self):
+        """∫ 4x³·(x⁴−1)² dx = (x⁴−1)³/3"""
+        vm = _make_vm()
+        g = _sub(_xn(4), IRInteger(1))
+        f = _mul(_mul(IRInteger(4), _xn(3)), _pow(g, 2))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_cos_sinp1_cube(self):
+        """∫ cos(x)·(sin(x)+1)³ dx = (sin(x)+1)⁴/4  [trig inner g]"""
+        vm = _make_vm()
+        g = _add(_sin(X), IRInteger(1))
+        f = _mul(_cos(X), _pow(g, 3))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_exp_expp1_quad(self):
+        """∫ exp(x)·(exp(x)+1)⁴ dx = (exp(x)+1)⁵/5  [tests ADD diff extension]"""
+        vm = _make_vm()
+        g = _add(_exp(X), IRInteger(1))
+        f = _mul(_exp(X), _pow(g, 4))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_exp_expm1_sq(self):
+        """∫ exp(x)·(exp(x)−1)² dx = (exp(x)−1)³/3  [tests SUB diff extension]"""
+        vm = _make_vm()
+        g = _sub(_exp(X), IRInteger(1))
+        f = _mul(_exp(X), _pow(g, 2))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_2x_x2p3_fifth(self):
+        """∫ 2x·(x²+3)⁵ dx = (x²+3)⁶/6"""
+        vm = _make_vm()
+        g = _add(_xn(2), IRInteger(3))
+        f = _mul(_cx(2), _pow(g, 5))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+
+# ---------------------------------------------------------------------------
+# TestPhase8_LinearPow — single-factor (ax+b)^n in the POW branch
+# ---------------------------------------------------------------------------
+
+
+class TestPhase8_LinearPow:
+    """∫ (ax+b)^n dx — POW branch linear-base extension."""
+
+    def test_2xp1_cube(self):
+        """∫ (2x+1)³ dx = (2x+1)⁴/8"""
+        vm = _make_vm()
+        f = _pow(_linear(2, 1), 3)
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_3xm2_quad(self):
+        """∫ (3x−2)⁴ dx = (3x−2)⁵/15"""
+        vm = _make_vm()
+        f = _pow(_sub(_cx(3), IRInteger(2)), 4)
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_xp5_inv(self):
+        """∫ (x+5)⁻¹ dx = log(x+5)"""
+        vm = _make_vm()
+        f = _pow(_add(X, IRInteger(5)), -1)
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        # Shift test points to avoid x=-5 singularity (0.4, 0.7 are fine)
+        _check_antiderivative(f, F)
+
+    def test_2xp1_neg2(self):
+        """∫ (2x+1)⁻² dx = −1/(2·(2x+1))"""
+        vm = _make_vm()
+        f = _pow(_linear(2, 1), -2)
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_half_xp1_cube(self):
+        """∫ (x/2+1)³ dx = (x/2+1)⁴/2"""
+        vm = _make_vm()
+        half_x_p1 = _add(IRApply(MUL, (IRRational(1, 2), X)), IRInteger(1))
+        f = _pow(half_x_p1, 3)
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_const_factor_linear_pow(self):
+        """∫ 3·(2x+1)² dx — constant factor rule + linear POW branch"""
+        vm = _make_vm()
+        lin_pow = _pow(_linear(2, 1), 2)
+        f = _mul(IRInteger(3), lin_pow)
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+
+# ---------------------------------------------------------------------------
+# TestPhase8_Fallthrough — cases Phase 8 should decline
+# ---------------------------------------------------------------------------
+
+
+class TestPhase8_Fallthrough:
+    """Phase 8 must return None for these cases; earlier phases may handle them."""
+
+    def test_sin_x_sin_x2_unevaluated(self):
+        """∫ sin(x)·sin(x²) dx — different args, no ratio match → unevaluated"""
+        vm = _make_vm()
+        f = _mul(_sin(X), _sin(_xn(2)))
+        F = _integrate_ir(vm, f)
+        # No phase handles sin(x)·sin(x²): product-to-sum needs both linear args.
+        assert IRApply(INTEGRATE, (f, X)) == F, (
+            "Expected unevaluated Integrate for sin(x)·sin(x²)"
+        )
+
+    def test_sin_cos_same_arg_phase6(self):
+        """∫ sin²(x)·cos(x) dx — Phase 6 (sinⁿ·cosᵐ) handles this, not Phase 8."""
+        vm = _make_vm()
+        f = _mul(_pow(_sin(X), 2), _cos(X))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_poly_pow_alone_unevaluated(self):
+        """∫ (x²+1)³ dx — no g' factor; POW branch can't simplify → unevaluated."""
+        vm = _make_vm()
+        g = _add(_xn(2), IRInteger(1))
+        f = _pow(g, 3)
+        F = _integrate_ir(vm, f)
+        assert IRApply(INTEGRATE, (f, X)) == F, (
+            "Expected unevaluated Integrate for (x²+1)³ alone"
+        )
+
+    def test_exp_sin3_unevaluated(self):
+        """∫ exp(x)·sin³(x) dx — no phase handles exp × sin^n → unevaluated."""
+        vm = _make_vm()
+        f = _mul(_exp(X), _pow(_sin(X), 3))
+        F = _integrate_ir(vm, f)
+        assert IRApply(INTEGRATE, (f, X)) == F, (
+            "Expected unevaluated Integrate for exp(x)·sin³(x)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestPhase8_Regressions — verify earlier phases still work
+# ---------------------------------------------------------------------------
+
+
+class TestPhase8_Regressions:
+    """Ensure Phases 1–7 are unaffected by Phase 8 additions."""
+
+    def test_phase7_x_sin_x2(self):
+        """Phase 7 regression: ∫ x·sin(x²) dx"""
+        vm = _make_vm()
+        f = _mul(X, _sin(_xn(2)))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_phase7_cos_exp_sin(self):
+        """Phase 7 regression: ∫ cos(x)·exp(sin(x)) dx"""
+        vm = _make_vm()
+        f = _mul(_cos(X), _exp(_sin(X)))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_phase6_sin3_cos2(self):
+        """Phase 6 regression: ∫ sin³(x)·cos²(x) dx"""
+        vm = _make_vm()
+        f = _mul(_pow(_sin(X), 3), _pow(_cos(X), 2))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_phase5_sin2(self):
+        """Phase 5 regression: ∫ sin²(x) dx"""
+        vm = _make_vm()
+        f = _pow(_sin(X), 2)
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_phase5_sin2_linear_arg(self):
+        """Phase 5 regression: ∫ sin²(2x+1) dx"""
+        vm = _make_vm()
+        f = _pow(_sin(_linear(2, 1)), 2)
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_phase3_exp_linear(self):
+        """Phase 3 regression: ∫ exp(2x+1) dx"""
+        vm = _make_vm()
+        f = _exp(_linear(2, 1))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+
+# ---------------------------------------------------------------------------
+# TestPhase8_Macsyma — end-to-end MACSYMA string tests
+# ---------------------------------------------------------------------------
+
+
+class TestPhase8_Macsyma:
+    """MACSYMA string → IR → Integrate → numerical verification."""
+
+    def _parse_and_integrate(
+        self, expr: str
+    ) -> tuple[IRNode, IRNode, IRNode]:
+        """Parse ``integrate(expr, x);``, evaluate, return (f_ir, F, integrate_ir)."""
+        from macsyma_compiler import compile_macsyma
+        from macsyma_parser import parse_macsyma
+
+        vm = _make_vm()
+        src = f"integrate({expr}, x);"
+        integrate_ir = compile_macsyma(parse_macsyma(src))[0]
+        F = vm.eval(integrate_ir)
+        f_ir = integrate_ir.args[0]
+        return f_ir, F, integrate_ir
+
+    def test_macsyma_case_a_trig(self):
+        """MACSYMA: integrate(cos(x)*sin(sin(x))^2, x)"""
+        f, F, _ = self._parse_and_integrate("cos(x)*sin(sin(x))^2")
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_macsyma_case_b_poly(self):
+        """MACSYMA: integrate(2*x*(x^2+1)^3, x)"""
+        f, F, _ = self._parse_and_integrate("2*x*(x^2+1)^3")
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_macsyma_case_b_exp(self):
+        """MACSYMA: integrate(exp(x)*(exp(x)+1)^4, x)"""
+        f, F, _ = self._parse_and_integrate("exp(x)*(exp(x)+1)^4")
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_macsyma_linear_pow(self):
+        """MACSYMA: integrate((2*x+1)^3, x)"""
+        f, F, _ = self._parse_and_integrate("(2*x+1)^3")
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)

--- a/code/specs/phase8-power-composite-usub.md
+++ b/code/specs/phase8-power-composite-usub.md
@@ -1,0 +1,234 @@
+# Phase 8 — Power-of-Composite U-Substitution
+
+## Motivation
+
+Phases 1–7 of the symbolic integrator handle rational functions, transcendentals,
+individual trig powers, mixed sinⁿ·cosᵐ, and u-substitution for **single-argument**
+outer functions (SIN, COS, EXP, LOG, TAN, SQRT).  Phase 7's core guard rejects any
+outer function with more than one argument — in particular `POW(base, n)` — because
+the power rule and trig-power rules (Phases 1 and 5) already cover the most
+common power integrals.
+
+Phase 8 closes the remaining gap: **integrands of the form `f(g(x))ⁿ · c·g'(x)`**
+where the outer layer is a power of a composite expression.
+
+Representative examples that Phase 7 cannot handle:
+
+| Integrand | g(x) | n | Result |
+|---|---|---|---|
+| `cos(x)·sin²(sin(x))` | `sin(x)` | 2 | `sin(x)/2 − sin(2sin(x))/4` |
+| `2x·(x²+1)³` | `x²+1` | 3 | `(x²+1)⁴/4` |
+| `exp(x)·(exp(x)+1)⁴` | `exp(x)+1` | 4 | `(exp(x)+1)⁵/5` |
+| `3x²·(x³+5)⁻²` | `x³+5` | −2 | `−1/(x³+5)` |
+
+---
+
+## Mathematical Foundation
+
+### Chain-Rule Reversal for Power Composites
+
+The fundamental theorem underlying Phase 8 is:
+
+```
+∫ h(g(x))ⁿ · c·g'(x) dx  =  c · ∫ h(u)ⁿ du  evaluated at u = g(x)
+```
+
+This is the standard u-substitution `u = g(x)`, `du = g'(x) dx`.
+
+The result `∫ h(u)ⁿ du` is computed by recursive delegation to existing phases:
+
+- `h = SIN`  →  `∫ sinⁿ(u) du`  — Phase 5b (sinⁿ reduction formula)
+- `h = COS`  →  `∫ cosⁿ(u) du`  — Phase 5b (cosⁿ reduction formula)
+- `h = TAN`  →  `∫ tanⁿ(u) du`  — Phase 5c (tanⁿ reduction formula)
+- `h = identity` (base = g(x)) →  `∫ uⁿ du`  — Phase 1 power rule
+
+### Worked Example — Case A (1-arg outer function raised to a power)
+
+`∫ cos(x)·sin²(sin(x)) dx`
+
+Let `u = sin(x)`, `du = cos(x) dx`.
+
+```
+∫ sin²(u) du  =  u/2 − sin(2u)/4    (Phase 5b, n=2, a=1, b=0)
+```
+
+Back-substitute `u = sin(x)`:
+
+```
+sin(x)/2 − sin(2·sin(x))/4
+```
+
+### Worked Example — Case B (base is the substitution itself)
+
+`∫ 2x·(x²+1)³ dx`
+
+Let `u = x²+1`, `du = 2x dx`.
+
+```
+∫ u³ du  =  u⁴/4    (Phase 1 power rule)
+```
+
+Back-substitute `u = x²+1`:
+
+```
+(x²+1)⁴/4
+```
+
+### Special sub-case n = −1 in Case B
+
+`∫ 2x·(x²+1)⁻¹ dx`
+
+`u = x²+1`, `∫ u⁻¹ du = log(u)`.  Result: `log(x²+1)`.
+
+### Linear-base single-factor integral (POW branch extension)
+
+A natural companion: `∫ (ax+b)^n dx` where only one factor exists.  Previously
+the POW branch only handled `base == x`.  With a linear base:
+
+```
+n ≠ −1:   ∫ (ax+b)^n dx = (ax+b)^(n+1) / ((n+1)·a)
+n = −1:   ∫ (ax+b)^(−1) dx = log(ax+b) / a
+```
+
+This is separate from the MUL-branch u-sub but completes the picture for
+polynomial-composition integrals.
+
+---
+
+## Algorithm
+
+### Extending `_diff_ir`
+
+Phase 7 added symbolic differentiation for constants, polynomials, single-arg
+functions (SIN/COS/EXP/LOG/SQRT), and integer-exponent POW.  Phase 8 adds:
+
+| New case | Rule |
+|---|---|
+| `NEG(f)` | `d/dx(−f) = −f'`; returns `NEG(f')` (or 0 if f'=0) |
+| `ADD(f, g)` | `d/dx(f+g) = f' + g'`; returns `f'` if g'=0, `g'` if f'=0 |
+| `SUB(f, g)` | `d/dx(f−g) = f' − g'`; returns `f'` if g'=0 |
+
+These rules enable differentiating `exp(x)+1 → exp(x)`, `sin(x)−x → cos(x)−1`,
+etc., which are required for Case B with non-polynomial bases.
+
+### `_try_u_sub_pow_one(pow_node, gp_candidate, x)`
+
+```
+1. Confirm pow_node = POW(base, exp_node).
+2. Require not _depends_on(exp_node, x)  — exponent must be x-free.
+3. Require _depends_on(base, x)          — base must involve x.
+
+CASE A — base is a 1-arg IRApply:
+  4a. Extract g = base.args[0].
+  5a. Skip if g == x              (Phase 5 handles f(x)^n via _try_trig_power).
+  6a. Skip if g is linear a≠0     (Phase 5 handles f(ax+b)^n).
+  7a. Compute gprime = _diff_ir(g, x).  If None → skip.
+  8a. Check c = _ratio_const(gp_candidate, gprime, x).  If None or 0 → skip.
+  9a. Introduce dummy u = IRSymbol("__u__").
+ 10a. Build base_u = _subst(base, g, u)  [replaces g→u inside f].
+ 11a. Compute G_u = _integrate(POW(base_u, exp_node), u).  If None → skip.
+ 12a. Back-substitute: G_gx = _subst(G_u, u, g).
+ 13a. Return c·G_gx  (or G_gx if c=1).
+
+CASE B — base is not a 1-arg IRApply:
+  4b. Skip if base == x            (Phase 1 handles x^n).
+  5b. Skip if base is linear a≠0   (new linear POW branch handles (ax+b)^n).
+  6b. Compute gprime = _diff_ir(base, x).  If None → skip.
+  7b. Check c = _ratio_const(gp_candidate, gprime, x).  If None or 0 → skip.
+  8b. Introduce dummy u = IRSymbol("__u__").
+  9b. Compute G_u = _integrate(POW(u, exp_node), u).  If None → skip.
+ 10b. Back-substitute: G_gx = _subst(G_u, u, base).
+ 11b. Return c·G_gx  (or G_gx if c=1).
+```
+
+### `_try_u_sub_pow(fa, fb, x)`
+
+Tries both orderings (fa as pow_node, fb as gp) then (fb as pow_node, fa as gp).
+
+### MUL Branch Hook
+
+Placed after Phase 7 (`_try_u_sub`) and before Phase 4c (`_try_exp_trig`):
+
+```python
+# Phase 8: u-substitution for POW(f(g(x)), n) · c·g'(x).
+result = _try_u_sub_pow(a, b, x)
+if result is not None:
+    return result
+```
+
+---
+
+## Scope and Limitations
+
+### What Phase 8 handles
+
+| Pattern | Example |
+|---|---|
+| `POW(SIN(g(x)), n) · c·g'(x)` | `cos(x)·sin²(sin(x))` |
+| `POW(COS(g(x)), n) · c·g'(x)` | `−sin(x)·cos³(cos(x))` |
+| `POW(TAN(g(x)), n) · c·g'(x)` | `(1/cos²(x))·tan²(tan(x))` |
+| `POW(g(x), n) · c·g'(x)` | `2x·(x²+1)^n` |
+| `POW(EXP(g(x)), n) · c·g'(x)` | falls through if inner `∫ exp(u)^n du` unsolvable |
+| `POW(LOG(g(x)), n) · c·g'(x)` | falls through (log^n not in Phase 5) |
+| Single-factor `(ax+b)^n` | POW branch — no second factor needed |
+
+### What remains deferred (Phase 9+)
+
+- `DIV(g'(x), g(x))` → `log(g(x))` (quotient form of n=−1; needs DIV branch extension)
+- `POW(f(g(x)), n)` where `∫ f(u)^n du` is unknown (EXP^n, LOG^n, SQRT^n for arbitrary n)
+- Product rule / IBP for polynomials × arbitrary functions
+- Two-argument outer functions (e.g., `POW(g₁(x), g₂(x))` where both depend on x)
+
+---
+
+## Implementation Notes
+
+### Dummy symbol safety
+
+The dummy integration variable `IRSymbol("__u__")` is safe because valid user
+symbols are single lowercase letters.  The same `__u__` is shared between Phase 7
+and Phase 8 calls; there is no nesting because `_try_u_sub_pow_one` calls
+`_integrate(POW(base_u, n), u)` where `base_u` contains `__u__` but not `x`,
+so no further u-sub hook fires.
+
+### Interaction with `_try_trig_power`
+
+When Case A encounters `POW(SIN(g), n)` with `g = __u__` (the dummy), the call
+`_integrate(POW(SIN(__u__), n), __u__)` enters the POW branch, which calls
+`_try_trig_power(SIN(__u__), n, __u__)`.  Since `_try_linear(__u__, __u__) = (1, 0)`
+(linear with a=1, b=0), the trig power helper fires correctly.
+
+### Interaction with Phase 7
+
+Phase 7 already handles `f(g(x))¹ · g'(x)` (power 1 is unwrapped by the
+`exponent.value == 1` case in the POW dispatch before `_try_trig_power` fires).
+Phase 8 handles exponents ≥ 2 (and negative exponents).  No overlap.
+
+### Guard priority
+
+The MUL dispatch order ensures:
+1. Constant factor (x-free operand) — always first
+2. Phase 3 (exp/log products)
+3. Phase 4b (trig × trig product-to-sum)
+4. Phase 6 (sinⁿ·cosᵐ)
+5. Phase 7 (single-arg u-sub)
+6. **Phase 8 (power-of-composite u-sub)**  ← new
+7. Phase 4c (exp × trig double-IBP)
+8. Phase 4a (polynomial × trig tabular IBP)
+
+---
+
+## Tests
+
+`tests/test_phase8.py` — ≥40 tests across 6 classes.  All correctness tests use
+`_check_antiderivative` (numerical re-differentiation at x=0.4 and x=0.7, same
+pattern as Phases 5–7).
+
+| Class | Count | Focus |
+|---|---|---|
+| `TestPhase8_CaseA_Trig` | 10 | `POW(SIN/COS/TAN(g(x)), n) · g'` — polynomial and trig inner g |
+| `TestPhase8_CaseB_Poly` | 10 | `POW(g(x), n) · g'` — polynomial, trig inner, exp inner |
+| `TestPhase8_LinearPow` | 6 | Single-factor `(ax+b)^n` in POW branch |
+| `TestPhase8_Fallthrough` | 4 | Guard rejection cases |
+| `TestPhase8_Regressions` | 6 | Earlier phases unaffected |
+| `TestPhase8_Macsyma` | 4 | End-to-end MACSYMA string tests |


### PR DESCRIPTION
## Summary

- **Phase 8, Case A**: `∫ f(g(x))^n · c·g'(x) dx` — outer POW of a 1-arg function (`SIN`, `COS`, `TAN`) of a non-trivial inner. Substitutes `u = g(x)`, delegates `∫ f(u)^n du` to Phase 5b/5c, back-substitutes.
- **Phase 8, Case B**: `∫ g(x)^n · c·g'(x) dx` — outer POW of a general expression (`x²+1`, `exp(x)+1`, etc.). Substitutes `u = g(x)`, integrates `∫ u^n du` via Phase 1 power rule (or `log(g(x))` when n=−1).
- **Bonus linear-base POW branch**: `∫ (ax+b)^n dx` now handled in the single-factor POW branch, covering the gap Phase 1 left.
- **`_diff_ir` extension**: Added NEG/ADD/SUB differentiation rules enabling derivatives of composite sums like `exp(x)+1`.
- Version bumped 0.12.0 → 0.13.0; 40 new tests; 490 total pass; 88% coverage; ruff clean.

## Test plan

- [ ] All 490 tests pass (`pytest tests/ -q`)
- [ ] Coverage ≥ 80% (`--cov-fail-under=80`)
- [ ] `ruff check src/ tests/` zero errors
- [ ] Case A trig: `cos(x)·sin²(sin(x))`, `cos(x)·tan²(sin(x))`, `2x·sin²(x²)`
- [ ] Case B poly: `2x·(x²+1)³`, `2x·(x²+1)⁻¹` → `log(x²+1)`, `exp(x)·(exp(x)+1)⁴`
- [ ] Linear POW: `(2x+1)³`, `(x+5)⁻¹`, `(2x+1)⁻²`
- [ ] Regressions: Phases 3, 5, 6, 7 still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)