### PR TITLE
feat(algol): allow procedure calls in expression thunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   actuals on formal reads and assignments.
 - Enabled read-only ALGOL expression thunks to read arrays, covering
   Jensen's-device terms such as `a[i] * i` through the WASM runtime path.
+- Enabled read-only ALGOL expression thunks to call integer procedures, with
+  nested procedure failures propagated through thunk helper state.
 
 ### Added — TypeScript Port + JavaScript/TypeScript Grammars (PR #14)
 - **31 TypeScript packages** — complete port of the computing stack to TypeScript

--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -31,6 +31,9 @@ All notable changes to this package will be documented in this file.
   formal read or assignment.
 - Allowed read-only expression eval thunks to read integer arrays, including
   helper-side bounds failure propagation back into the caller unwind path.
+- Allowed read-only expression eval thunks to call integer procedures, with a
+  runtime helper-depth marker for propagating nested procedure failures back to
+  the caller's by-name formal read.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -33,11 +33,13 @@ reads re-compute the element address through the eval helper, and writable
 formals call a generated store helper that re-locates the element before storing
 the new value. Read-only expression thunks can also read array elements; helper
 bounds failures are reported back to the calling procedure before the normal
-frame and thunk-region unwind. Expression thunks that call procedures and stores
-through read-only expression thunks still raise targeted `CompileError`
-diagnostics until Phase 5 grows full expression-helper coverage.
+frame and thunk-region unwind. Procedure calls inside read-only expression
+thunks are supported, including nested by-name descriptor allocation and runtime
+failure propagation from callees back to the by-name formal read. Stores through
+read-only expression thunks still raise targeted `CompileError` diagnostics
+until Phase 5 grows full store-helper coverage.
 
-This phase keeps ALGOL frame memory and its 28-byte runtime state bounded to
+This phase keeps ALGOL frame memory and its 32-byte runtime state bounded to
 one 64 KiB WASM page, and keeps array descriptors plus element storage inside a
 separate 64 KiB heap segment. Larger semantic frame plans raise `CompileError`
 before the WASM data encoder can materialize the memory image, dynamic

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -47,7 +47,8 @@ _RUNTIME_HEAP_POINTER_OFFSET = 12
 _RUNTIME_HEAP_LIMIT_OFFSET = 16
 _RUNTIME_THUNK_HEAP_MARK_OFFSET = 20
 _RUNTIME_THUNK_FAILURE_OFFSET = 24
-_RUNTIME_STATE_BYTES = 28
+_RUNTIME_THUNK_HELPER_DEPTH_OFFSET = 28
+_RUNTIME_STATE_BYTES = 32
 _STATIC_LINK_PARAM_REG = 2
 _THUNK_HEAP_MARK_PARAM_REG = 3
 _VALUE_PARAM_BASE_REG = 4
@@ -304,6 +305,7 @@ class AlgolIrCompiler:
         self._store_runtime_state(_RUNTIME_HEAP_LIMIT_OFFSET, self.heap_limit_reg)
         self._store_runtime_state(_RUNTIME_THUNK_HEAP_MARK_OFFSET, _ZERO_REG)
         self._store_runtime_state(_RUNTIME_THUNK_FAILURE_OFFSET, _ZERO_REG)
+        self._store_runtime_state(_RUNTIME_THUNK_HELPER_DEPTH_OFFSET, _ZERO_REG)
 
         block = _first_node(type_result.ast, "block")
         if block is None:
@@ -1044,6 +1046,8 @@ class AlgolIrCompiler:
             IrRegister(active_thunk_heap_mark),
             *(IrRegister(argument) for argument in call_arguments),
         )
+        if scope.helper_failure:
+            self._emit_helper_return_on_thunk_failure(scope)
         result = self._fresh_reg()
         self._copy_reg(dst=result, src=_RESULT_REG)
         if descriptor_heap_mark is not None:
@@ -1139,12 +1143,8 @@ class AlgolIrCompiler:
         argument: ASTNode,
         parameter: ProcedureParameter,
     ) -> None:
-        if _first_node(argument, "proc_call") is not None:
-            raise CompileError(
-                f"by-name parameter {parameter.name!r} received a procedure-call "
-                "expression actual; eval thunk procedure-call lowering is not "
-                "implemented yet"
-            )
+        # Read-only integer expression thunks now share the normal expression path.
+        del argument, parameter
 
     def _register_eval_thunk(
         self,
@@ -1267,6 +1267,7 @@ class AlgolIrCompiler:
                 IrRegister(self._const_reg(thunk.thunk_id)),
             )
             self._emit(IrOp.BRANCH_Z, IrRegister(matches), IrLabel(else_label))
+            self._emit_enter_thunk_helper()
             thunk_scope = _FrameScope(
                 semantic_block=self.semantic_blocks_by_id[thunk.block_id],
                 frame_base_reg=caller_frame,
@@ -1292,6 +1293,7 @@ class AlgolIrCompiler:
             else:
                 value = self._compile_expr(thunk.expression, thunk_scope)
             self._copy_reg(dst=_RESULT_REG, src=value)
+            self._emit_leave_thunk_helper()
             self._emit(IrOp.RET)
             self._emit(IrOp.JUMP, IrLabel(end_label))
             self._label(else_label)
@@ -1333,6 +1335,7 @@ class AlgolIrCompiler:
                 IrRegister(self._const_reg(thunk.thunk_id)),
             )
             self._emit(IrOp.BRANCH_Z, IrRegister(matches), IrLabel(else_label))
+            self._emit_enter_thunk_helper()
             thunk_scope = _FrameScope(
                 semantic_block=self.semantic_blocks_by_id[thunk.block_id],
                 frame_base_reg=caller_frame,
@@ -1354,6 +1357,7 @@ class AlgolIrCompiler:
                 IrRegister(byte_offset),
             )
             self._emit(IrOp.LOAD_IMM, IrRegister(_RESULT_REG), IrImmediate(0))
+            self._emit_leave_thunk_helper()
             self._emit(IrOp.RET)
             self._emit(IrOp.JUMP, IrLabel(end_label))
             self._label(else_label)
@@ -1890,8 +1894,11 @@ class AlgolIrCompiler:
         else_label = f"if_{index}_else"
         end_label = f"if_{index}_end"
         self._emit(IrOp.BRANCH_Z, IrRegister(failed_reg), IrLabel(else_label))
+        self._emit_mark_thunk_failure_if_helper_active()
         self._emit(IrOp.LOAD_IMM, IrRegister(_RESULT_REG), IrImmediate(0))
         self._emit_unwind_for_return(scope)
+        if scope.helper_failure:
+            self._emit_leave_thunk_helper()
         self._emit_restore_active_thunk_heap_mark(scope)
         self._emit(IrOp.RET)
         self._emit(IrOp.JUMP, IrLabel(end_label))
@@ -1910,6 +1917,7 @@ class AlgolIrCompiler:
         self._emit(IrOp.BRANCH_Z, IrRegister(failed_reg), IrLabel(else_label))
         self._store_runtime_state(_RUNTIME_THUNK_FAILURE_OFFSET, self._const_reg(1))
         self._emit(IrOp.LOAD_IMM, IrRegister(_RESULT_REG), IrImmediate(0))
+        self._emit_leave_thunk_helper()
         self._emit_restore_active_thunk_heap_mark(scope)
         self._emit(IrOp.RET)
         self._emit(IrOp.JUMP, IrLabel(end_label))
@@ -1921,6 +1929,59 @@ class AlgolIrCompiler:
         self._load_runtime_state(_RUNTIME_THUNK_FAILURE_OFFSET, failed)
         self._store_runtime_state(_RUNTIME_THUNK_FAILURE_OFFSET, _ZERO_REG)
         self._emit_runtime_failure_guard(failed, scope)
+
+    def _emit_enter_thunk_helper(self) -> None:
+        depth = self._fresh_reg()
+        next_depth = self._fresh_reg()
+        self._load_runtime_state(_RUNTIME_THUNK_HELPER_DEPTH_OFFSET, depth)
+        self._emit(
+            IrOp.ADD_IMM,
+            IrRegister(next_depth),
+            IrRegister(depth),
+            IrImmediate(1),
+        )
+        self._store_runtime_state(_RUNTIME_THUNK_HELPER_DEPTH_OFFSET, next_depth)
+
+    def _emit_leave_thunk_helper(self) -> None:
+        depth = self._fresh_reg()
+        next_depth = self._fresh_reg()
+        self._load_runtime_state(_RUNTIME_THUNK_HELPER_DEPTH_OFFSET, depth)
+        self._emit(
+            IrOp.ADD_IMM,
+            IrRegister(next_depth),
+            IrRegister(depth),
+            IrImmediate(-1),
+        )
+        self._store_runtime_state(_RUNTIME_THUNK_HELPER_DEPTH_OFFSET, next_depth)
+
+    def _emit_mark_thunk_failure_if_helper_active(self) -> None:
+        depth = self._fresh_reg()
+        self._load_runtime_state(_RUNTIME_THUNK_HELPER_DEPTH_OFFSET, depth)
+        index = self.if_count
+        self.if_count += 1
+        else_label = f"if_{index}_else"
+        end_label = f"if_{index}_end"
+        self._emit(IrOp.BRANCH_Z, IrRegister(depth), IrLabel(else_label))
+        self._store_runtime_state(_RUNTIME_THUNK_FAILURE_OFFSET, self._const_reg(1))
+        self._emit(IrOp.JUMP, IrLabel(end_label))
+        self._label(else_label)
+        self._label(end_label)
+
+    def _emit_helper_return_on_thunk_failure(self, scope: _FrameScope) -> None:
+        failed = self._fresh_reg()
+        self._load_runtime_state(_RUNTIME_THUNK_FAILURE_OFFSET, failed)
+        index = self.if_count
+        self.if_count += 1
+        else_label = f"if_{index}_else"
+        end_label = f"if_{index}_end"
+        self._emit(IrOp.BRANCH_Z, IrRegister(failed), IrLabel(else_label))
+        self._emit(IrOp.LOAD_IMM, IrRegister(_RESULT_REG), IrImmediate(0))
+        self._emit_leave_thunk_helper()
+        self._emit_restore_active_thunk_heap_mark(scope)
+        self._emit(IrOp.RET)
+        self._emit(IrOp.JUMP, IrLabel(end_label))
+        self._label(else_label)
+        self._label(end_label)
 
     def _emit_restore_active_thunk_heap_mark(self, scope: _FrameScope) -> None:
         mark_reg = scope.active_thunk_heap_mark_reg

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -168,7 +168,7 @@ class TestAlgolIrCompiler:
                 )
         )
 
-        with pytest.raises(CompileError, match="frame bytes plus 28 runtime bytes"):
+        with pytest.raises(CompileError, match="frame bytes plus 32 runtime bytes"):
             compile_algol(typed)
 
     def test_compiles_integer_array_descriptor_and_element_accesses(self) -> None:
@@ -356,15 +356,22 @@ class TestAlgolIrCompiler:
 
         assert "_fn_algol_eval_thunk" in calls
 
-    def test_rejects_procedure_call_inside_expression_eval_thunk(self) -> None:
-        with pytest.raises(CompileError, match="procedure-call expression"):
-            compile_algol(
-                parse_algol(
-                    "begin integer result; "
-                    "integer procedure inc(n); value n; integer n; "
-                    "begin inc := n + 1 end; "
-                    "integer procedure id(x); integer x; begin id := x end; "
-                    "result := id(inc(4)) "
-                    "end"
-                )
+    def test_compiles_procedure_call_inside_expression_eval_thunk(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; "
+                "integer procedure inc(n); value n; integer n; "
+                "begin inc := n + 1 end; "
+                "integer procedure id(x); integer x; begin id := x end; "
+                "result := id(inc(4)) "
+                "end"
             )
+        )
+        calls = [
+            instruction.operands[0].name
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.CALL
+        ]
+
+        assert "_fn_algol_eval_thunk" in calls
+        assert any(label.startswith("_fn_algol_") for label in calls)

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -25,6 +25,9 @@ All notable changes to this package will be documented in this file.
 - Executed read-only expression thunks that read integer arrays, including
   Jensen's-device expressions and bounds failures propagated through the caller
   unwind path.
+- Executed read-only expression thunks that call integer procedures, including
+  nested by-name descriptor allocation and callee failure propagation through
+  the caller's by-name formal read.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -31,9 +31,11 @@ site. Integer array-element by-name actuals now compile as tagged descriptors
 with eval/store helpers, so reads and assignments re-compute the current element
 address every time the formal is used. Read-only expression thunks can also
 read array elements, including Jensen-style terms such as `a[i] * i`.
-Expression thunks that call procedures and expression thunk stores remain
-guarded by IR compile-stage diagnostics until full Phase 5 expression-helper
-coverage is available.
+Expression thunks can call procedures, including procedures that receive nested
+by-name descriptors, and runtime failures from those callees propagate through
+the by-name formal read. Expression thunk stores remain guarded by IR
+compile-stage diagnostics until full Phase 5 store-helper coverage is
+available.
 
 ```python
 from algol_wasm_compiler import compile_source

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -44,19 +44,18 @@ class TestAlgolWasmCompiler:
             compile_source("begin integer result; result := false end")
         assert raised.value.stage == "type-check"
 
-    def test_procedure_call_expression_by_name_waits_for_eval_thunk_stage(
+    def test_procedure_call_expression_by_name_runs_through_eval_thunk(
         self,
     ) -> None:
-        with pytest.raises(AlgolWasmError) as raised:
-            compile_source(
-                "begin integer result; "
-                "integer procedure inc(n); value n; integer n; "
-                "begin inc := n + 1 end; "
-                "integer procedure id(x); integer x; begin id := x end; "
-                "result := id(inc(4)) "
-                "end"
-            )
-        assert raised.value.stage == "ir-compile"
+        result = compile_source(
+            "begin integer result; "
+            "integer procedure inc(n); value n; integer n; "
+            "begin inc := n + 1 end; "
+            "integer procedure id(x); integer x; begin id := x end; "
+            "result := id(inc(4)) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [5]
 
     def test_runtime_smoke_returns_result(self) -> None:
         result = compile_source(
@@ -192,6 +191,50 @@ class TestAlgolWasmCompiler:
             "end"
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [0]
+
+    def test_procedure_expression_by_name_re_evaluates_on_each_read(self) -> None:
+        result = compile_source(
+            "begin integer result, count; "
+            "integer procedure next(n); value n; integer n; "
+            "begin count := count + 1; next := n + count end; "
+            "integer procedure probe(x); integer x; "
+            "begin probe := x; probe := probe * 100 + x end; "
+            "count := 0; result := probe(next(3)) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [405]
+
+    def test_procedure_expression_by_name_can_allocate_nested_thunks(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "integer procedure use(x); integer x; begin use := x end; "
+            "integer procedure probe(x); integer x; "
+            "begin probe := x; result := 10; probe := probe * 100 + x end; "
+            "result := 3; result := probe(use(result + 1)) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [411]
+
+    def test_procedure_expression_by_name_bounds_failure_propagates(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "integer procedure bad(n); value n; integer n; "
+            "begin integer array a[1:1]; bad := a[2] end; "
+            "integer procedure id(x); integer x; begin id := x end; "
+            "result := id(bad(1) + 1) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [0]
+
+    def test_procedure_expression_by_name_reads_array_value_argument(self) -> None:
+        result = compile_source(
+            "begin integer result, i; integer array a[1:2]; "
+            "integer procedure inc(n); value n; integer n; begin inc := n + 1 end; "
+            "integer procedure id(x); integer x; begin id := x end; "
+            "a[1] := 7; i := 1; result := id(inc(a[i])) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [8]
 
     def test_jensens_device_sums_array_element_expression(self) -> None:
         result = compile_source(

--- a/code/specs/PL04-algol60-full-wasm-runtime.md
+++ b/code/specs/PL04-algol60-full-wasm-runtime.md
@@ -741,9 +741,15 @@ Current Phase 5d lowering may allow read-only expression descriptors to read
 integer arrays. The eval helper should mark its synthetic caller-frame scope as
 a helper context, so checked array loads inside expression thunks report bounds
 failures through the thunk failure flag and let the by-name formal read perform
-the caller's normal unwind. Procedure calls inside expression thunks remain
-rejected until helper calls can safely manage nested returns and failure
-propagation.
+the caller's normal unwind.
+
+Current Phase 5e lowering may allow procedure calls inside read-only expression
+descriptors. Eval and store helpers should maintain a runtime helper-depth
+counter while thunk code executes. Runtime failures in procedures called from a
+helper set the thunk failure flag, and procedure-call lowering in helper scopes
+returns immediately to the helper caller when that flag is set. This keeps
+nested procedure frames and call-scoped thunk descriptors bounded while letting
+normal, non-helper procedure failures keep their existing return-`0` behavior.
 
 ### Required Diagnostics
 


### PR DESCRIPTION
## Summary
- allow read-only ALGOL by-name expression thunks to call integer procedures
- add runtime helper-depth tracking so nested procedure failures propagate through the thunk failure flag
- cover repeated procedure-call re-evaluation, nested by-name descriptor allocation, callee bounds failure propagation, and array value arguments
- update PL04 docs, package READMEs, and changelogs

## Tests
- bash BUILD (code/packages/python/algol-ir-compiler)
- bash BUILD (code/packages/python/algol-wasm-compiler)
- ruff check code/packages/python/algol-ir-compiler/src code/packages/python/algol-ir-compiler/tests code/packages/python/algol-wasm-compiler/tests

## Security review
- verified descriptor lifetimes and allocation caps remain bounded
- verified helper-depth state is initialized and unwound on normal and failure helper exits
- verified nested procedure failures only set thunk failure state while a helper is active, preserving normal procedure failure behavior