### PR TITLE
feat(logic): add finite-domain foundation

### DIFF
--- a/code/packages/python/logic-builtins/CHANGELOG.md
+++ b/code/packages/python/logic-builtins/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.10.0] - 2026-04-22
+
+### Added
+
+- finite-domain store types for branch-local CLP(FD)-style constraints
+- `fd_ino`, `fd_eqo`, `fd_neqo`, `fd_lto`, `fd_leqo`, `fd_gto`, and
+  `fd_geqo` for finite integer domains and binary comparisons
+- `labelingo` for deterministic ascending enumeration of finite-domain
+  assignments
+- tests covering domain formats, domain narrowing, order-independent
+  constraints, equality-domain intersection, rollback across disjunctions, and
+  explicit labeling
+
 ## [0.9.0] - 2026-04-22
 
 ### Added

--- a/code/packages/python/logic-builtins/README.md
+++ b/code/packages/python/logic-builtins/README.md
@@ -1,7 +1,8 @@
 # logic-builtins
 
-`logic-builtins` adds practical Prolog-inspired control, term inspection,
-arithmetic, and collection predicates to the Python logic stack.
+`logic-builtins` adds practical Prolog-inspired control, finite-domain
+constraints, term inspection, arithmetic, and collection predicates to the
+Python logic stack.
 
 These functions are library goals, not syntax. They compose with
 `logic-engine`, `logic-stdlib`, and the VM/bytecode layers because they return
@@ -34,6 +35,10 @@ ordinary logic goal expressions.
 - `dynamico(name, arity)`, `assertao(clause)`, `assertzo(clause)`,
   `retracto(clause)`, `retractallo(head)`, and `abolisho(name, arity)` for
   branch-local dynamic database mutation
+- `fd_ino(var, domain)`, `fd_eqo(left, right)`, `fd_neqo(left, right)`,
+  `fd_lto(left, right)`, `fd_leqo(left, right)`, `fd_gto(left, right)`,
+  `fd_geqo(left, right)`, and `labelingo(vars)` for finite-domain integer
+  constraints
 - arithmetic expression constructors: `add`, `sub`, `mul`, `div`, `floordiv`, `mod`, and `neg`
 - `iso(result, expression)` for Prolog-style evaluative arithmetic
 - `numeqo(left, right)`, `numneqo(left, right)`, `lto(left, right)`, `leqo(left, right)`, `gto(left, right)`, and `geqo(left, right)`
@@ -46,12 +51,15 @@ from logic_builtins import (
     add,
     assertzo,
     argo,
-    dynamico,
     calltermo,
     clauseo,
     compare_termo,
     current_predicateo,
     cuto,
+    dynamico,
+    fd_ino,
+    fd_leqo,
+    fd_neqo,
     findallo,
     forallo,
     functoro,
@@ -59,6 +67,7 @@ from logic_builtins import (
     groundo,
     ifthenelseo,
     iso,
+    labelingo,
     noto,
     onceo,
     predicate_propertyo,
@@ -166,11 +175,22 @@ assert solve_all(
     X,
     conj(dynamico("memo", 1), assertzo(memo("cached")), memo(X)),
 ) == [atom("cached")]
+assert solve_all(
+    program(),
+    X,
+    conj(fd_ino(X, range(1, 6)), fd_leqo(X, 3), fd_neqo(X, 2), labelingo([X])),
+) == [num(1), num(3)]
 ```
 
 Arithmetic is evaluative, not a constraint system yet. `iso(Y, add(X, 1))`
 fails while `X` is unbound, and succeeds after a goal such as `eq(X, 4)` has
 instantiated it.
+
+Finite-domain constraints are branch-local and label explicitly. `fd_ino`
+stores a finite integer domain, comparison predicates narrow domains as soon as
+enough information exists, and `labelingo([X, Y])` enumerates concrete
+assignments in ascending order. This foundation intentionally does not include
+FD arithmetic propagation or global constraints yet.
 
 Collections are observations over a nested proof search. `findallo` succeeds
 with an empty list when the inner goal fails, while `bagofo` and `setofo` fail

--- a/code/packages/python/logic-builtins/pyproject.toml
+++ b/code/packages/python/logic-builtins/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-logic-builtins"
-version = "0.9.0"
-description = "Prolog-inspired cut, dynamic database, callable-term, predicate-metadata, term-order, control, and metaprogramming builtins for Python"
+version = "0.10.0"
+description = "Prolog-inspired finite-domain, cut, dynamic database, callable-term, predicate-metadata, term-order, control, and metaprogramming builtins for Python"
 requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]
 readme = "README.md"
 dependencies = [
-    "coding-adventures-logic-engine>=0.9.0",
+    "coding-adventures-logic-engine>=0.10.0",
 ]
 
 [project.urls]

--- a/code/packages/python/logic-builtins/src/logic_builtins/__init__.py
+++ b/code/packages/python/logic-builtins/src/logic_builtins/__init__.py
@@ -5,6 +5,8 @@ the first state-aware builtins layer for the library-first Prolog path.
 """
 
 from logic_builtins.builtins import (
+    FiniteDomainConstraint,
+    FiniteDomainStore,
     abolisho,
     add,
     argo,
@@ -25,6 +27,13 @@ from logic_builtins.builtins import (
     div,
     dynamico,
     failo,
+    fd_eqo,
+    fd_geqo,
+    fd_gto,
+    fd_ino,
+    fd_leqo,
+    fd_lto,
+    fd_neqo,
     findallo,
     floordiv,
     forallo,
@@ -35,6 +44,7 @@ from logic_builtins.builtins import (
     ifthenelseo,
     iftheno,
     iso,
+    labelingo,
     leqo,
     lto,
     mod,
@@ -82,8 +92,17 @@ __all__ = [
     "current_predicateo",
     "cuto",
     "div",
+    "fd_eqo",
+    "fd_geqo",
+    "fd_gto",
+    "fd_ino",
+    "fd_leqo",
+    "fd_lto",
+    "fd_neqo",
     "dynamico",
     "failo",
+    "FiniteDomainConstraint",
+    "FiniteDomainStore",
     "findallo",
     "floordiv",
     "forallo",
@@ -94,6 +113,7 @@ __all__ = [
     "ifthenelseo",
     "iftheno",
     "iso",
+    "labelingo",
     "leqo",
     "lto",
     "mod",
@@ -121,4 +141,4 @@ __all__ = [
     "varo",
 ]
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"

--- a/code/packages/python/logic-builtins/src/logic_builtins/builtins.py
+++ b/code/packages/python/logic-builtins/src/logic_builtins/builtins.py
@@ -14,7 +14,8 @@ keeps the user-facing predicates in a separate library layer.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterable, Iterator
+from dataclasses import dataclass
 
 from logic_engine import (
     Atom,
@@ -76,7 +77,16 @@ __all__ = [
     "cuto",
     "dynamico",
     "div",
+    "fd_eqo",
+    "fd_geqo",
+    "fd_gto",
+    "fd_ino",
+    "fd_leqo",
+    "fd_lto",
+    "fd_neqo",
     "failo",
+    "FiniteDomainConstraint",
+    "FiniteDomainStore",
     "findallo",
     "floordiv",
     "forallo",
@@ -88,6 +98,7 @@ __all__ = [
     "iftheno",
     "iso",
     "leqo",
+    "labelingo",
     "lto",
     "mod",
     "mul",
@@ -124,6 +135,27 @@ type NativeArgs = tuple[Term, ...]
 type NativeRunner = Callable[[Program, State, NativeArgs], Iterator[State]]
 type NumericValue = int | float
 type TermSortKey = tuple[object, ...]
+type FdOperator = str
+
+
+_MAX_FD_DOMAIN_SIZE = 10_000
+
+
+@dataclass(frozen=True, slots=True)
+class FiniteDomainConstraint:
+    """A residual integer-domain relation waiting for enough information."""
+
+    left: Term
+    operator: FdOperator
+    right: Term
+
+
+@dataclass(frozen=True, slots=True)
+class FiniteDomainStore:
+    """Branch-local finite domains and residual integer constraints."""
+
+    domains: dict[LogicVar, frozenset[int]]
+    constraints: tuple[FiniteDomainConstraint, ...] = ()
 
 
 _BUILTIN_PREDICATES: tuple[tuple[str, int], ...] = (
@@ -144,6 +176,13 @@ _BUILTIN_PREDICATES: tuple[tuple[str, int], ...] = (
     ("current_predicateo", 2),
     ("cuto", 0),
     ("dynamico", 2),
+    ("fd_eqo", 2),
+    ("fd_geqo", 2),
+    ("fd_gto", 2),
+    ("fd_ino", 2),
+    ("fd_leqo", 2),
+    ("fd_lto", 2),
+    ("fd_neqo", 2),
     ("failo", 0),
     ("findallo", 3),
     ("forallo", 2),
@@ -154,6 +193,7 @@ _BUILTIN_PREDICATES: tuple[tuple[str, int], ...] = (
     ("ifthenelseo", 3),
     ("iftheno", 2),
     ("iso", 2),
+    ("labelingo", 1),
     ("leqo", 2),
     ("lto", 2),
     ("nonvaro", 1),
@@ -285,7 +325,269 @@ def _state_with_next_var_id(state: State, next_var_id: int) -> State:
         constraints=state.constraints,
         next_var_id=next_var_id,
         database=state.database,
+        fd_store=state.fd_store,
     )
+
+
+def _empty_fd_store() -> FiniteDomainStore:
+    """Return an empty finite-domain overlay."""
+
+    return FiniteDomainStore(domains={})
+
+
+def _fd_store(state: State) -> FiniteDomainStore:
+    """Read the branch-local finite-domain store from ``state``."""
+
+    if state.fd_store is None:
+        return _empty_fd_store()
+    if isinstance(state.fd_store, FiniteDomainStore):
+        return state.fd_store
+    msg = "State.fd_store contains an unsupported finite-domain store"
+    raise TypeError(msg)
+
+
+def _state_with_fd_store(state: State, store: FiniteDomainStore) -> State:
+    """Return ``state`` with a normalized finite-domain store attached."""
+
+    return State(
+        substitution=state.substitution,
+        constraints=state.constraints,
+        next_var_id=state.next_var_id,
+        database=state.database,
+        fd_store=store,
+    )
+
+
+def _integer_value(term_value: object) -> int | None:
+    """Return a concrete finite-domain integer, rejecting floats and bools."""
+
+    if isinstance(term_value, Number):
+        raw_value = term_value.value
+        if isinstance(raw_value, bool) or not isinstance(raw_value, int):
+            return None
+        return raw_value
+    if isinstance(term_value, bool):
+        return None
+    if isinstance(term_value, int):
+        return term_value
+    return None
+
+
+def _domain_from_items(items: Iterable[object]) -> frozenset[int]:
+    """Normalize a finite collection of integers into a checked domain."""
+
+    values: set[int] = set()
+    for item in items:
+        integer = _integer_value(item)
+        if integer is None:
+            msg = "finite domains may contain only integer values"
+            raise TypeError(msg)
+        values.add(integer)
+        if len(values) > _MAX_FD_DOMAIN_SIZE:
+            msg = "finite domain exceeds the maximum supported size"
+            raise ValueError(msg)
+    return frozenset(values)
+
+
+def _range_domain(low: int, high: int) -> frozenset[int]:
+    """Build an inclusive finite integer range domain."""
+
+    if high < low:
+        return frozenset()
+    if high - low + 1 > _MAX_FD_DOMAIN_SIZE:
+        msg = "finite domain range exceeds the maximum supported size"
+        raise ValueError(msg)
+    return frozenset(range(low, high + 1))
+
+
+def _domain_values(domain: object) -> frozenset[int]:
+    """Normalize a Python or Prolog-shaped finite-domain description."""
+
+    integer = _integer_value(domain)
+    if integer is not None:
+        return frozenset({integer})
+    if isinstance(domain, range):
+        if len(domain) > _MAX_FD_DOMAIN_SIZE:
+            msg = "finite domain range exceeds the maximum supported size"
+            raise ValueError(msg)
+        return frozenset(domain)
+    if isinstance(domain, list | tuple | set | frozenset):
+        return _domain_from_items(domain)
+    if isinstance(domain, Atom | Compound):
+        items = _proper_list_items(domain)
+        if items is not None:
+            return _domain_from_items(items)
+    if (
+        isinstance(domain, Compound)
+        and domain.functor.namespace is None
+        and domain.functor.name == ".."
+        and len(domain.args) == 2
+    ):
+        low = _integer_value(domain.args[0])
+        high = _integer_value(domain.args[1])
+        if low is None or high is None:
+            msg = "finite range bounds must be integer values"
+            raise TypeError(msg)
+        return _range_domain(low, high)
+
+    msg = f"cannot use {type(domain).__name__} as a finite domain"
+    raise TypeError(msg)
+
+
+def _fd_compare(operator: FdOperator, left: int, right: int) -> bool:
+    """Evaluate one finite-domain binary relation over concrete integers."""
+
+    if operator == "eq":
+        return left == right
+    if operator == "neq":
+        return left != right
+    if operator == "lt":
+        return left < right
+    if operator == "le":
+        return left <= right
+    if operator == "gt":
+        return left > right
+    if operator == "ge":
+        return left >= right
+    msg = f"unknown finite-domain operator {operator}"
+    raise ValueError(msg)
+
+
+def _reified_fd_value(term_value: Term, state: State) -> LogicVar | int | None:
+    """Read a term as either an open variable or a concrete integer."""
+
+    reified_value = _reified(term_value, state)
+    if isinstance(reified_value, LogicVar):
+        return reified_value
+    return _integer_value(reified_value)
+
+
+def _normalize_fd_domains(
+    store: FiniteDomainStore,
+    state: State,
+) -> dict[LogicVar, frozenset[int]] | None:
+    """Merge domains for aliased variables and reject incompatible bindings."""
+
+    domains: dict[LogicVar, frozenset[int]] = {}
+    for variable, domain in store.domains.items():
+        reified_value = _reified(variable, state)
+        if isinstance(reified_value, LogicVar):
+            existing = domains.get(reified_value)
+            domains[reified_value] = domain if existing is None else existing & domain
+            if not domains[reified_value]:
+                return None
+            continue
+
+        integer = _integer_value(reified_value)
+        if integer is None or integer not in domain:
+            return None
+
+    return domains
+
+
+def _domain_for_fd_value(
+    value: LogicVar | int,
+    domains: dict[LogicVar, frozenset[int]],
+) -> frozenset[int] | None:
+    """Return a finite domain for a concrete value or known FD variable."""
+
+    if isinstance(value, LogicVar):
+        return domains.get(value)
+    return frozenset({value})
+
+
+def _revise_constraint_domains(
+    constraint: FiniteDomainConstraint,
+    state: State,
+    domains: dict[LogicVar, frozenset[int]],
+) -> tuple[dict[LogicVar, frozenset[int]] | None, bool]:
+    """Apply one round of arc-consistency pruning for a residual constraint."""
+
+    left_value = _reified_fd_value(constraint.left, state)
+    right_value = _reified_fd_value(constraint.right, state)
+    if left_value is None or right_value is None:
+        return None, False
+
+    left_domain = _domain_for_fd_value(left_value, domains)
+    right_domain = _domain_for_fd_value(right_value, domains)
+
+    if left_domain is None or right_domain is None:
+        return domains, False
+
+    allowed_left = frozenset(
+        left
+        for left in left_domain
+        if any(_fd_compare(constraint.operator, left, right) for right in right_domain)
+    )
+    allowed_right = frozenset(
+        right
+        for right in right_domain
+        if any(_fd_compare(constraint.operator, left, right) for left in left_domain)
+    )
+    if not allowed_left or not allowed_right:
+        return None, False
+
+    changed = False
+    updated = dict(domains)
+    if isinstance(left_value, LogicVar) and allowed_left != left_domain:
+        updated[left_value] = allowed_left
+        changed = True
+    if isinstance(right_value, LogicVar) and allowed_right != right_domain:
+        updated[right_value] = allowed_right
+        changed = True
+
+    return updated, changed
+
+
+def _normalize_fd_store(
+    store: FiniteDomainStore,
+    state: State,
+) -> FiniteDomainStore | None:
+    """Re-check FD domains and residual constraints after state changes."""
+
+    domains = _normalize_fd_domains(store, state)
+    if domains is None:
+        return None
+
+    kept_constraints: list[FiniteDomainConstraint] = []
+    for constraint in store.constraints:
+        left_value = _reified_fd_value(constraint.left, state)
+        right_value = _reified_fd_value(constraint.right, state)
+        if left_value is None or right_value is None:
+            return None
+        if isinstance(left_value, int) and isinstance(right_value, int):
+            if not _fd_compare(constraint.operator, left_value, right_value):
+                return None
+            continue
+        kept_constraints.append(constraint)
+
+    changed = True
+    while changed:
+        changed = False
+        for constraint in kept_constraints:
+            revised, revised_changed = _revise_constraint_domains(
+                constraint,
+                state,
+                domains,
+            )
+            if revised is None:
+                return None
+            domains = revised
+            changed = changed or revised_changed
+
+    return FiniteDomainStore(
+        domains=dict(domains),
+        constraints=tuple(kept_constraints),
+    )
+
+
+def _normalize_fd_state(state: State) -> State | None:
+    """Return ``state`` with its FD store reconciled against substitutions."""
+
+    store = _normalize_fd_store(_fd_store(state), state)
+    if store is None:
+        return None
+    return _state_with_fd_store(state, store)
 
 
 def _succeed_if(condition: bool, state: State) -> Iterator[State]:
@@ -440,6 +742,181 @@ def cuto() -> GoalExpr:
     """Commit to choices made so far in the current search-control frame."""
 
     return cut()
+
+
+def fd_ino(target: object, domain: object) -> GoalExpr:
+    """Constrain ``target`` to a finite integer domain.
+
+    Domains are intentionally concrete in the foundation layer: callers can use
+    Python ranges/iterables, a single integer, a proper logic list, or a
+    ``..(Low, High)`` compound term. The store narrows immediately, and normal
+    backtracking restores older domain snapshots.
+    """
+
+    domain_values = _domain_values(domain)
+
+    def run(_program: Program, state: State, args: NativeArgs) -> Iterator[State]:
+        (target_term,) = args
+        target_value = _reified_fd_value(target_term, state)
+        if target_value is None:
+            return
+        if isinstance(target_value, int):
+            if target_value in domain_values:
+                normalized_state = _normalize_fd_state(state)
+                if normalized_state is not None:
+                    yield normalized_state
+            return
+
+        store = _fd_store(state)
+        domains = dict(store.domains)
+        existing_domain = domains.get(target_value)
+        narrowed_domain = (
+            domain_values
+            if existing_domain is None
+            else existing_domain & domain_values
+        )
+        if not narrowed_domain:
+            return
+
+        updated_store = FiniteDomainStore(
+            domains={**domains, target_value: narrowed_domain},
+            constraints=store.constraints,
+        )
+        normalized_store = _normalize_fd_store(updated_store, state)
+        if normalized_store is not None:
+            yield _state_with_fd_store(state, normalized_store)
+
+    return native_goal(run, target)
+
+
+def fd_eqo(left: object, right: object) -> GoalExpr:
+    """Constrain two finite-domain terms to equal integer values."""
+
+    def run(program_value: Program, state: State, args: NativeArgs) -> Iterator[State]:
+        left_term, right_term = args
+        for unified_state in solve_from(
+            program_value,
+            eq(left_term, right_term),
+            state,
+        ):
+            normalized_state = _normalize_fd_state(unified_state)
+            if normalized_state is not None:
+                yield normalized_state
+
+    return native_goal(run, left, right)
+
+
+def _fd_constrainto(operator: FdOperator, left: object, right: object) -> GoalExpr:
+    """Create a residual finite-domain binary constraint goal."""
+
+    def run(_program: Program, state: State, args: NativeArgs) -> Iterator[State]:
+        left_term, right_term = args
+        store = _fd_store(state)
+        updated_store = FiniteDomainStore(
+            domains=dict(store.domains),
+            constraints=(
+                *store.constraints,
+                FiniteDomainConstraint(left_term, operator, right_term),
+            ),
+        )
+        normalized_store = _normalize_fd_store(updated_store, state)
+        if normalized_store is not None:
+            yield _state_with_fd_store(state, normalized_store)
+
+    return native_goal(run, left, right)
+
+
+def fd_neqo(left: object, right: object) -> GoalExpr:
+    """Constrain two finite-domain terms to different integer values."""
+
+    return _fd_constrainto("neq", left, right)
+
+
+def fd_lto(left: object, right: object) -> GoalExpr:
+    """Constrain ``left`` to be less than ``right``."""
+
+    return _fd_constrainto("lt", left, right)
+
+
+def fd_leqo(left: object, right: object) -> GoalExpr:
+    """Constrain ``left`` to be less than or equal to ``right``."""
+
+    return _fd_constrainto("le", left, right)
+
+
+def fd_gto(left: object, right: object) -> GoalExpr:
+    """Constrain ``left`` to be greater than ``right``."""
+
+    return _fd_constrainto("gt", left, right)
+
+
+def fd_geqo(left: object, right: object) -> GoalExpr:
+    """Constrain ``left`` to be greater than or equal to ``right``."""
+
+    return _fd_constrainto("ge", left, right)
+
+
+def _label_fd_terms(
+    program_value: Program,
+    state: State,
+    terms: tuple[Term, ...],
+    index: int = 0,
+) -> Iterator[State]:
+    """Enumerate concrete values for the requested FD variables."""
+
+    normalized_state = _normalize_fd_state(state)
+    if normalized_state is None:
+        return
+    if index == len(terms):
+        yield normalized_state
+        return
+
+    value = _reified_fd_value(terms[index], normalized_state)
+    if value is None:
+        return
+    if isinstance(value, int):
+        yield from _label_fd_terms(program_value, normalized_state, terms, index + 1)
+        return
+
+    store = _fd_store(normalized_state)
+    domain = store.domains.get(value)
+    if domain is None:
+        return
+
+    for choice in sorted(domain):
+        for assigned_state in solve_from(
+            program_value,
+            eq(value, num(choice)),
+            normalized_state,
+        ):
+            yield from _label_fd_terms(program_value, assigned_state, terms, index + 1)
+
+
+def labelingo(vars_value: object) -> GoalExpr:
+    """Enumerate concrete assignments for finite-domain variables."""
+
+    if isinstance(vars_value, list | tuple):
+        def run_sequence(
+            program_value: Program,
+            state: State,
+            args: NativeArgs,
+        ) -> Iterator[State]:
+            yield from _label_fd_terms(program_value, state, args)
+
+        return native_goal(run_sequence, *vars_value)
+
+    def run_logic_list(
+        program_value: Program,
+        state: State,
+        args: NativeArgs,
+    ) -> Iterator[State]:
+        (vars_term,) = args
+        items = _proper_list_items(_reified(vars_term, state))
+        if items is None:
+            return
+        yield from _label_fd_terms(program_value, state, tuple(items))
+
+    return native_goal(run_logic_list, vars_value)
 
 
 def iftheno(condition: object, then_goal: object) -> GoalExpr:

--- a/code/packages/python/logic-builtins/tests/test_logic_builtins.py
+++ b/code/packages/python/logic-builtins/tests/test_logic_builtins.py
@@ -47,6 +47,13 @@ from logic_builtins import (
     div,
     dynamico,
     failo,
+    fd_eqo,
+    fd_geqo,
+    fd_gto,
+    fd_ino,
+    fd_leqo,
+    fd_lto,
+    fd_neqo,
     findallo,
     floordiv,
     forallo,
@@ -57,6 +64,7 @@ from logic_builtins import (
     ifthenelseo,
     iftheno,
     iso,
+    labelingo,
     leqo,
     lto,
     mod,
@@ -89,7 +97,7 @@ class TestVersion:
     """Verify the package is importable and versioned."""
 
     def test_version_exists(self) -> None:
-        assert __version__ == "0.9.0"
+        assert __version__ == "0.10.0"
 
 
 class TestAdvancedControlBuiltins:
@@ -460,6 +468,131 @@ class TestArithmeticBuiltins:
             marker,
             conj(eq(marker, "ok"), noto(lto(add(2, 2), 3))),
         ) == [atom("ok")]
+
+
+class TestFiniteDomainBuiltins:
+    """Finite-domain constraints should narrow first and label explicitly."""
+
+    def test_fd_ino_and_labelingo_enumerate_domains_in_order(self) -> None:
+        value = var("Value")
+
+        assert solve_all(
+            program(),
+            value,
+            conj(fd_ino(value, range(1, 4)), labelingo([value])),
+        ) == [num(1), num(2), num(3)]
+
+    def test_fd_domains_can_be_logic_lists_or_inclusive_range_terms(self) -> None:
+        left = var("Left")
+        right = var("Right")
+
+        assert solve_all(
+            program(),
+            (left, right),
+            conj(
+                fd_ino(left, logic_list([2, 4])),
+                fd_ino(right, term("..", 3, 4)),
+                labelingo([left, right]),
+            ),
+        ) == [(num(2), num(3)), (num(2), num(4)), (num(4), num(3)), (num(4), num(4))]
+
+    def test_fd_constraints_narrow_before_labeling(self) -> None:
+        value = var("Value")
+
+        assert solve_all(
+            program(),
+            value,
+            conj(fd_ino(value, range(1, 6)), fd_lto(value, 3), labelingo([value])),
+        ) == [num(1), num(2)]
+
+    def test_fd_constraints_are_order_independent(self) -> None:
+        value = var("Value")
+
+        assert solve_all(
+            program(),
+            value,
+            conj(fd_lto(value, 3), fd_ino(value, range(1, 6)), labelingo([value])),
+        ) == [num(1), num(2)]
+
+    def test_fd_equality_intersects_aliased_domains(self) -> None:
+        left = var("Left")
+        right = var("Right")
+
+        assert solve_all(
+            program(),
+            (left, right),
+            conj(
+                fd_ino(left, [1, 2]),
+                fd_ino(right, [2, 3]),
+                fd_eqo(left, right),
+                labelingo([left, right]),
+            ),
+        ) == [(num(2), num(2))]
+
+    def test_fd_neq_and_comparisons_prune_binary_domains(self) -> None:
+        left = var("Left")
+        right = var("Right")
+
+        assert solve_all(
+            program(),
+            (left, right),
+            conj(
+                fd_ino(left, range(1, 4)),
+                fd_ino(right, range(1, 4)),
+                fd_neqo(left, right),
+                fd_leqo(left, right),
+                labelingo([left, right]),
+            ),
+        ) == [(num(1), num(2)), (num(1), num(3)), (num(2), num(3))]
+
+    def test_fd_greater_comparisons_check_concrete_terms(self) -> None:
+        marker = var("Marker")
+
+        assert solve_all(
+            program(),
+            marker,
+            conj(eq(marker, "ok"), fd_gto(4, 3), fd_geqo(4, 4)),
+        ) == [atom("ok")]
+        assert solve_all(program(), marker, conj(eq(marker, "ok"), fd_gto(3, 4))) == []
+
+    def test_labelingo_accepts_logic_list_of_variables(self) -> None:
+        left = var("Left")
+        right = var("Right")
+
+        assert solve_all(
+            program(),
+            (left, right),
+            conj(
+                fd_ino(left, [1]),
+                fd_ino(right, [2]),
+                labelingo(logic_list([left, right])),
+            ),
+        ) == [(num(1), num(2))]
+
+    def test_fd_store_rolls_back_across_disjunction_branches(self) -> None:
+        value = var("Value")
+
+        assert solve_all(
+            program(),
+            value,
+            disj(
+                conj(fd_ino(value, [1]), labelingo([value])),
+                labelingo([value]),
+            ),
+        ) == [num(1)]
+
+    def test_fd_ino_without_labeling_preserves_open_variables(self) -> None:
+        value = var("Value")
+
+        assert solve_all(program(), value, fd_ino(value, [1, 2])) == [value]
+
+    def test_fd_domain_validation_is_eager(self) -> None:
+        value = var("Value")
+
+        with pytest.raises(TypeError):
+            fd_ino(value, [1, 2.5])
+        with pytest.raises(ValueError):
+            fd_ino(value, range(0, 10_001))
 
 
 class TestControlBuiltins:

--- a/code/packages/python/logic-core/CHANGELOG.md
+++ b/code/packages/python/logic-core/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.4.0] - 2026-04-22
+
+### Added
+
+- `State.fd_store` extension slot for higher-level finite-domain constraint
+  stores
+- preservation of the finite-domain extension slot across equality,
+  disequality, and fresh-variable goals
+- tests covering preservation of both runtime extension slots
+
 ## [0.3.0] - 2026-04-21
 
 ### Added

--- a/code/packages/python/logic-core/README.md
+++ b/code/packages/python/logic-core/README.md
@@ -9,7 +9,8 @@ It deliberately starts with the reusable semantic pieces:
 - substitutions and unification
 - goals and backtracking search
 - delayed disequality constraints via `neq(...)`
-- an extension slot on `State` for higher layers such as runtime databases
+- extension slots on `State` for higher layers such as runtime databases and
+  finite-domain constraint stores
 - helpers like `fresh`, `conj`, `disj`, `run_all`, and `run_n`
 
 The later Prolog implementation should lower parsed clauses and queries into
@@ -33,6 +34,7 @@ assert run_all(
 state = list(neq(X, atom("homer"))(State()))[0]
 assert state.constraints
 assert State(database={"branch": "local"}).database == {"branch": "local"}
+assert State(fd_store={"domains": "local"}).fd_store == {"domains": "local"}
 ```
 
 ## Dependencies

--- a/code/packages/python/logic-core/pyproject.toml
+++ b/code/packages/python/logic-core/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-logic-core"
-version = "0.3.0"
-description = "Logic programming core: terms, unification, goals, search, disequality constraints, and extension state"
+version = "0.4.0"
+description = "Logic programming core: terms, unification, goals, search, disequality constraints, and extension slots"
 requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]

--- a/code/packages/python/logic-core/src/logic_core/__init__.py
+++ b/code/packages/python/logic-core/src/logic_core/__init__.py
@@ -55,7 +55,7 @@ __all__ = [
     "var",
 ]
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 
 @dataclass(frozen=True, slots=True)
@@ -283,6 +283,7 @@ class State:
     constraints: tuple[Disequality, ...] = ()
     next_var_id: int = 0
     database: object | None = None
+    fd_store: object | None = None
 
 
 type Goal = Callable[[State], Iterator[State]]
@@ -432,6 +433,7 @@ def eq(left: object, right: object) -> Goal:
             constraints=constraints,
             next_var_id=state.next_var_id,
             database=state.database,
+            fd_store=state.fd_store,
         )
 
     return goal
@@ -472,6 +474,7 @@ def neq(left: object, right: object) -> Goal:
             constraints=constraints,
             next_var_id=state.next_var_id,
             database=state.database,
+            fd_store=state.fd_store,
         )
 
     return goal
@@ -521,6 +524,7 @@ def fresh(count: int, fn: Callable[..., Goal]) -> Goal:
             constraints=state.constraints,
             next_var_id=state.next_var_id + count,
             database=state.database,
+            fd_store=state.fd_store,
         )
         produced_goal = fn(*variables)
         yield from produced_goal(next_state)

--- a/code/packages/python/logic-core/tests/test_logic_core.py
+++ b/code/packages/python/logic-core/tests/test_logic_core.py
@@ -44,7 +44,7 @@ class TestVersion:
     """Verify the package is importable and versioned."""
 
     def test_version_exists(self) -> None:
-        assert __version__ == "0.3.0"
+        assert __version__ == "0.4.0"
 
 
 class TestTermConstruction:
@@ -234,15 +234,20 @@ class TestGoalsAndSearch:
 
         assert seen_ids == [0]
 
-    def test_goals_preserve_runtime_database_extension_slot(self) -> None:
+    def test_goals_preserve_runtime_extension_slots(self) -> None:
         x = var("X")
-        initial = State(database={"dynamic": "snapshot"})
+        initial = State(
+            database={"dynamic": "snapshot"},
+            fd_store={"domains": "snapshot"},
+        )
 
         [state] = list(eq(x, atom("tea"))(initial))
         [fresh_state] = list(fresh(1, lambda _inner: succeed())(state))
 
         assert state.database == {"dynamic": "snapshot"}
+        assert state.fd_store == {"domains": "snapshot"}
         assert fresh_state.database == {"dynamic": "snapshot"}
+        assert fresh_state.fd_store == {"domains": "snapshot"}
 
     def test_run_n_truncates_without_consuming_every_answer(self) -> None:
         x = var("X")

--- a/code/packages/python/logic-engine/CHANGELOG.md
+++ b/code/packages/python/logic-engine/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.10.0] - 2026-04-22
+
+### Added
+
+- preservation of the `State.fd_store` extension slot across engine state-copy
+  helpers so finite-domain builtins can compose with dynamic database overlays,
+  fresh variables, rules, and relation calls
+
 ## [0.9.0] - 2026-04-22
 
 ### Added

--- a/code/packages/python/logic-engine/README.md
+++ b/code/packages/python/logic-engine/README.md
@@ -14,6 +14,7 @@ that make relational programs feel like programs:
 - persistent database updates via `asserta(...)`, `assertz(...)`, `retract_*`,
   and `abolish(...)`
 - dynamic predicate declarations and branch-local runtime database overlays
+- finite-domain store preservation for CLP(FD)-style builtins
 - scoped search control via `cut()` as the library form of Prolog `!/0`
 - recursive solving with depth-first backtracking
 - deferred recursive goal builders via `defer(...)`

--- a/code/packages/python/logic-engine/pyproject.toml
+++ b/code/packages/python/logic-engine/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-logic-engine"
-version = "0.9.0"
-description = "Logic programming engine: relations, clauses, callable terms, dynamic runtime predicates, cut, resolution, and disequality"
+version = "0.10.0"
+description = "Logic programming engine: relations, clauses, callable terms, dynamic runtime predicates, finite-domain state, cut, resolution, and disequality"
 requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]
 readme = "README.md"
-dependencies = ["coding-adventures-logic-core>=0.3.0"]
+dependencies = ["coding-adventures-logic-core>=0.4.0"]
 keywords = ["logic-programming", "prolog", "resolution", "backtracking", "education"]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/code/packages/python/logic-engine/src/logic_engine/__init__.py
+++ b/code/packages/python/logic-engine/src/logic_engine/__init__.py
@@ -165,4 +165,4 @@ __all__ = [
     "visible_predicate_keys",
 ]
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"

--- a/code/packages/python/logic-engine/src/logic_engine/engine.py
+++ b/code/packages/python/logic-engine/src/logic_engine/engine.py
@@ -1181,6 +1181,7 @@ def _state_with_database(state: State, database: DynamicDatabase) -> State:
         constraints=state.constraints,
         next_var_id=state.next_var_id,
         database=database,
+        fd_store=state.fd_store,
     )
 
 
@@ -1192,6 +1193,7 @@ def _state_with_next_var_id(state: State, next_var_id: int) -> State:
         constraints=state.constraints,
         next_var_id=next_var_id,
         database=state.database,
+        fd_store=state.fd_store,
     )
 
 
@@ -1675,6 +1677,7 @@ def _instantiate_fresh(goal: FreshExpr, state: State) -> tuple[GoalExpr, State]:
         constraints=state.constraints,
         next_var_id=running_id,
         database=state.database,
+        fd_store=state.fd_store,
     )
     return renamed_body, next_state
 

--- a/code/packages/python/logic-engine/tests/test_logic_engine.py
+++ b/code/packages/python/logic-engine/tests/test_logic_engine.py
@@ -69,7 +69,7 @@ class TestVersion:
     """Verify the package is importable and versioned."""
 
     def test_version_exists(self) -> None:
-        assert __version__ == "0.9.0"
+        assert __version__ == "0.10.0"
 
 
 class TestRelationsAndClauses:

--- a/code/specs/LP18-logic-prolog-functionality-batches.md
+++ b/code/specs/LP18-logic-prolog-functionality-batches.md
@@ -62,13 +62,14 @@ LP17 clause introspection builtins
 LP18 Batch A metaprogramming completion
 LP18 Batch B dynamic runtime database
 LP18 Batch C search control and real cut
+LP18 Batch D1 CLP(FD) foundation
 PR00 Prolog lexer
 ```
 
 Known future-extension items that still need implementation:
 
 - soft-cut variants if a concrete API need emerges
-- CLP(FD)-style finite-domain constraints
+- CLP(FD) arithmetic propagation and global constraints
 
 ## Batch Plan
 
@@ -238,7 +239,7 @@ code/packages/python/logic-engine
 code/packages/python/logic-builtins
 ```
 
-Features:
+Track features:
 
 - finite-domain variables and domain stores
 - domain constraints such as membership, equality, disequality, ordering, and
@@ -255,10 +256,10 @@ Why this is not bundled with A, B, or C:
 - useful examples, like Sudoku or scheduling, need a broader surface than one
   or two predicates
 
-CLP(FD) can still be delivered in a few sub-batches:
+CLP(FD) is being delivered in a few sub-batches:
 
-- D1: finite domains, domain narrowing, and labeling
-- D2: arithmetic and ordering constraints
+- D1: finite domains, domain narrowing, ordering constraints, and labeling
+- D2: arithmetic expression constraints
 - D3: global constraints such as `all_differento`
 - D4: real-world examples and performance tuning
 
@@ -426,7 +427,11 @@ CLP(FD) should extend the solver state with a finite-domain store. Domain
 narrowing should occur before enumeration whenever possible, and labeling
 should be the explicit bridge from constraints to concrete answers.
 
-Initial predicates:
+Batch D is intentionally split into implementation slices. The foundation PR
+should establish a branch-local finite-domain store and the integer relations
+that are useful without arithmetic expression propagation.
+
+Foundation predicates:
 
 ```python
 fd_ino(var, domain)
@@ -436,15 +441,44 @@ fd_lto(left, right)
 fd_leqo(left, right)
 fd_gto(left, right)
 fd_geqo(left, right)
+labelingo(vars)
+```
+
+Deferred predicates:
+
+```python
 fd_addo(left, right, result)
 fd_subo(left, right, result)
 fd_mulo(left, right, result)
-labelingo(vars)
 all_differento(vars)
 ```
 
 The first CLP(FD) batch should prefer correctness and clear semantics over
 advanced propagation performance.
+
+Foundation implementation shape:
+
+- `State` grows a branch-local `fd_store` extension slot alongside the dynamic
+  database slot, and all solver state-copying helpers must preserve it.
+- The FD store maps open logic variables to finite integer domain sets and
+  keeps residual binary constraints for variables that are not labeled yet.
+- FD predicates narrow domains immediately when possible. If both sides are
+  concrete integers, they behave as deterministic checks. If one or both sides
+  are open variables, they retain enough residual constraint state for later
+  narrowing and labeling.
+- `labelingo(vars)` is the bridge from constraints to concrete answers. It
+  enumerates the current finite domains in deterministic ascending order,
+  commits each assignment through normal unification, and re-checks the FD
+  store after every binding.
+- Domains in the Python API may be supplied as a `range`, an iterable of
+  integers, a single integer, a numeric term, a proper logic list of integer
+  terms, or a `..(Low, High)` compound term.
+
+Explicit non-goals for the foundation PR:
+
+- no arithmetic FD propagation yet (`fd_addo`, `fd_subo`, `fd_mulo`)
+- no global constraints yet (`all_differento`)
+- no infinite domains; every domain must be finite before labeling
 
 ## PR Sizing Recommendation
 
@@ -454,7 +488,8 @@ Use this implementation sequence:
 PR 1: Batch A - metaprogramming completion
 PR 2: Batch B - dynamic runtime database
 PR 3: Batch C - real cut and search control
-PR 4+: Batch D - CLP(FD) foundation and follow-up constraint batches
+PR 4: Batch D1 - CLP(FD) foundation
+PR 5+: Batch D2/D3 - arithmetic propagation and global constraints
 ```
 
 This is the fewest practical set of large PRs without forcing unrelated solver


### PR DESCRIPTION
## Summary

- add a branch-local finite-domain store slot to logic-core state and preserve it through core/engine state transitions
- add CLP(FD) foundation builtins for finite integer domains, equality/disequality, ordering constraints, and explicit labeling
- document LP18 Batch D1 boundaries plus README/changelog/version updates for the affected Python packages

## Verification

- bash BUILD in code/packages/python/logic-core: 30 passed
- bash BUILD in code/packages/python/logic-engine: 62 passed
- bash BUILD in code/packages/python/logic-builtins: 91 passed
- ruff check in logic-core, logic-engine, logic-builtins
- mypy src tests in logic-builtins
- git diff --check
- security diff scan for eval/exec/process/network/deserialization additions

## Notes

- mypy still has pre-existing baseline failures in logic-core and logic-engine, unrelated to this branch; logic-builtins passes mypy cleanly.
- Deferred CLP(FD) work remains arithmetic expression propagation and global constraints such as all_differento.