### PR TITLE
feat(riscv): add assembler and Nib pipeline

### DIFF
--- a/code/packages/go/ir-to-riscv-compiler/BUILD
+++ b/code/packages/go/ir-to-riscv-compiler/BUILD
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/ir-to-riscv-compiler/CHANGELOG.md
+++ b/code/packages/go/ir-to-riscv-compiler/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Initial `ir-to-riscv-compiler` package.
+- Lowers compiler IR v1 to RV32I machine-code bytes.
+- Records label/data offsets and `IrToMachineCode` mappings.
+- Includes simulator-backed tests for arithmetic, memory, and branches.

--- a/code/packages/go/ir-to-riscv-compiler/README.md
+++ b/code/packages/go/ir-to-riscv-compiler/README.md
@@ -1,0 +1,34 @@
+# ir-to-riscv-compiler
+
+Go backend for the AOT compiler pipeline. It lowers `compiler-ir` programs to
+RV32I machine-code bytes that can run on the existing `riscv-simulator`.
+
+## Supported IR
+
+The first slice supports the current v1 IR used by the Brainfuck frontend:
+
+| Category | IR opcodes |
+|----------|------------|
+| Constants | `LOAD_IMM`, `LOAD_ADDR` |
+| Memory | `LOAD_BYTE`, `STORE_BYTE`, `LOAD_WORD`, `STORE_WORD` |
+| Arithmetic | `ADD`, `ADD_IMM`, `SUB`, `AND`, `AND_IMM` |
+| Comparison | `CMP_EQ`, `CMP_NE`, `CMP_LT`, `CMP_GT` |
+| Control flow | `LABEL`, `JUMP`, `BRANCH_Z`, `BRANCH_NZ`, `CALL`, `RET` |
+| System/meta | `SYSCALL`, `HALT`, `NOP`, `COMMENT` |
+
+## Usage
+
+```go
+backend := irtoriscvcompiler.NewIrToRiscVCompiler()
+result, err := backend.Compile(program)
+if err != nil {
+    panic(err)
+}
+
+sim := riscvsimulator.NewRiscVSimulator(65536)
+sim.Run(result.Bytes)
+```
+
+`MachineCodeResult.Bytes` contains the assembled text section followed by any
+declared IR data bytes. `DataOffsets` and `LabelOffsets` are absolute byte
+offsets from the beginning of the loaded program.

--- a/code/packages/go/ir-to-riscv-compiler/compiler.go
+++ b/code/packages/go/ir-to-riscv-compiler/compiler.go
@@ -1,0 +1,613 @@
+package irtoriscvcompiler
+
+import (
+	"fmt"
+
+	ir "github.com/adhithyan15/coding-adventures/code/packages/go/compiler-ir"
+	sm "github.com/adhithyan15/coding-adventures/code/packages/go/compiler-source-map"
+	riscv "github.com/adhithyan15/coding-adventures/code/packages/go/riscv-simulator"
+)
+
+const (
+	x0              = 0
+	xRa             = 1
+	xSyscallNumber  = 17
+	xBackendScratch = 31
+)
+
+// MachineCodeResult is the output of lowering IR to a flat RISC-V image.
+type MachineCodeResult struct {
+	Bytes           []byte
+	Instructions    []uint32
+	LabelOffsets    map[string]int
+	DataOffsets     map[string]int
+	IrToMachineCode *sm.IrToMachineCode
+}
+
+// LoweringError reports an IR instruction that could not be lowered.
+type LoweringError struct {
+	IrID    int
+	Opcode  ir.IrOp
+	Message string
+}
+
+func (e LoweringError) Error() string {
+	if e.IrID >= 0 {
+		return fmt.Sprintf("lower %s #%d: %s", e.Opcode, e.IrID, e.Message)
+	}
+	return fmt.Sprintf("lower %s: %s", e.Opcode, e.Message)
+}
+
+type compilePlan struct {
+	labelOffsets    map[string]int
+	dataOffsets     map[string]int
+	textSize        int
+	entryTrampoline bool
+}
+
+// IrToRiscVCompiler lowers compiler IR to RV32I machine code.
+type IrToRiscVCompiler struct{}
+
+func NewIrToRiscVCompiler() *IrToRiscVCompiler {
+	return &IrToRiscVCompiler{}
+}
+
+func (c *IrToRiscVCompiler) Compile(program *ir.IrProgram) (*MachineCodeResult, error) {
+	if program == nil {
+		return nil, fmt.Errorf("program is nil")
+	}
+
+	plan, err := c.plan(program)
+	if err != nil {
+		return nil, err
+	}
+
+	words := make([]uint32, 0, plan.textSize/4)
+	if plan.entryTrampoline {
+		entryOffset := plan.labelOffsets[program.EntryLabel]
+		if err := validateJalOffset(entryOffset); err != nil {
+			return nil, err
+		}
+		words = append(words, riscv.EncodeJal(x0, entryOffset))
+	}
+
+	irToMC := &sm.IrToMachineCode{}
+	for _, instruction := range program.Instructions {
+		pc := len(words) * 4
+		emitted, err := c.emitInstruction(instruction, pc, plan)
+		if err != nil {
+			return nil, err
+		}
+		if instruction.ID >= 0 && len(emitted) > 0 {
+			irToMC.Add(instruction.ID, pc, len(emitted)*4)
+		}
+		words = append(words, emitted...)
+	}
+
+	image := riscv.Assemble(words)
+	image = append(image, dataBytes(program.Data)...)
+
+	return &MachineCodeResult{
+		Bytes:           image,
+		Instructions:    words,
+		LabelOffsets:    plan.labelOffsets,
+		DataOffsets:     plan.dataOffsets,
+		IrToMachineCode: irToMC,
+	}, nil
+}
+
+func (c *IrToRiscVCompiler) plan(program *ir.IrProgram) (*compilePlan, error) {
+	labelOffsets := map[string]int{}
+	pc := 0
+	for _, instruction := range program.Instructions {
+		if instruction.Opcode == ir.OpLabel {
+			label, err := labelOperand(instruction, 0)
+			if err != nil {
+				return nil, err
+			}
+			if _, exists := labelOffsets[label.Name]; exists {
+				return nil, loweringError(instruction, "duplicate label %q", label.Name)
+			}
+			labelOffsets[label.Name] = pc
+		}
+
+		size, err := c.instructionSize(instruction)
+		if err != nil {
+			return nil, err
+		}
+		pc += size * 4
+	}
+
+	entryTrampoline := false
+	if program.EntryLabel != "" {
+		if entryOffset, ok := labelOffsets[program.EntryLabel]; ok && entryOffset != 0 {
+			entryTrampoline = true
+			for name, offset := range labelOffsets {
+				labelOffsets[name] = offset + 4
+			}
+			pc += 4
+		}
+	}
+
+	dataOffsets := map[string]int{}
+	dataPC := pc
+	for _, decl := range program.Data {
+		if decl.Size < 0 {
+			return nil, fmt.Errorf("data %q has negative size %d", decl.Label, decl.Size)
+		}
+		if _, exists := dataOffsets[decl.Label]; exists {
+			return nil, fmt.Errorf("duplicate data label %q", decl.Label)
+		}
+		dataOffsets[decl.Label] = dataPC
+		dataPC += decl.Size
+	}
+
+	return &compilePlan{
+		labelOffsets:    labelOffsets,
+		dataOffsets:     dataOffsets,
+		textSize:        pc,
+		entryTrampoline: entryTrampoline,
+	}, nil
+}
+
+func (c *IrToRiscVCompiler) instructionSize(instruction ir.IrInstruction) (int, error) {
+	switch instruction.Opcode {
+	case ir.OpLabel, ir.OpComment:
+		return 0, nil
+	case ir.OpLoadImm:
+		imm, err := immOperand(instruction, 1)
+		if err != nil {
+			return 0, err
+		}
+		return loadConstSize(imm.Value), nil
+	case ir.OpLoadAddr:
+		return 2, nil
+	case ir.OpLoadByte, ir.OpLoadWord, ir.OpStoreByte, ir.OpStoreWord:
+		if _, ok := thirdOperandAsImmediate(instruction); ok {
+			return 1, nil
+		}
+		return 2, nil
+	case ir.OpAdd, ir.OpSub, ir.OpAnd, ir.OpCmpLt, ir.OpCmpGt:
+		return 1, nil
+	case ir.OpCmpEq, ir.OpCmpNe:
+		return 2, nil
+	case ir.OpAddImm, ir.OpAndImm:
+		imm, err := immOperand(instruction, 2)
+		if err != nil {
+			return 0, err
+		}
+		if fitsSigned(imm.Value, 12) {
+			return 1, nil
+		}
+		return loadConstSize(imm.Value) + 1, nil
+	case ir.OpJump, ir.OpBranchZ, ir.OpBranchNz, ir.OpCall, ir.OpRet, ir.OpNop:
+		return 1, nil
+	case ir.OpSyscall:
+		imm, err := immOperand(instruction, 0)
+		if err != nil {
+			return 0, err
+		}
+		return loadConstSize(imm.Value) + 1, nil
+	case ir.OpHalt:
+		return 2, nil
+	default:
+		return 0, loweringError(instruction, "unsupported opcode")
+	}
+}
+
+func (c *IrToRiscVCompiler) emitInstruction(instruction ir.IrInstruction, pc int, plan *compilePlan) ([]uint32, error) {
+	switch instruction.Opcode {
+	case ir.OpLabel, ir.OpComment:
+		return nil, nil
+	case ir.OpLoadImm:
+		dst, err := physicalRegOperand(instruction, 0)
+		if err != nil {
+			return nil, err
+		}
+		imm, err := immOperand(instruction, 1)
+		if err != nil {
+			return nil, err
+		}
+		return emitLoadConst(dst, imm.Value), nil
+	case ir.OpLoadAddr:
+		dst, err := physicalRegOperand(instruction, 0)
+		if err != nil {
+			return nil, err
+		}
+		label, err := labelOperand(instruction, 1)
+		if err != nil {
+			return nil, err
+		}
+		offset, ok := plan.dataOffsets[label.Name]
+		if !ok {
+			offset, ok = plan.labelOffsets[label.Name]
+		}
+		if !ok {
+			return nil, loweringError(instruction, "unknown label %q", label.Name)
+		}
+		return emitLoadAddress(dst, offset), nil
+	case ir.OpLoadByte:
+		return c.emitLoad(instruction, riscv.EncodeLbu)
+	case ir.OpLoadWord:
+		return c.emitLoad(instruction, riscv.EncodeLw)
+	case ir.OpStoreByte:
+		return c.emitStore(instruction, riscv.EncodeSb)
+	case ir.OpStoreWord:
+		return c.emitStore(instruction, riscv.EncodeSw)
+	case ir.OpAdd:
+		return emitThreeReg(instruction, riscv.EncodeAdd)
+	case ir.OpSub:
+		return emitThreeReg(instruction, riscv.EncodeSub)
+	case ir.OpAnd:
+		return emitThreeReg(instruction, riscv.EncodeAnd)
+	case ir.OpAddImm:
+		return emitRegImm(instruction, riscv.EncodeAddi, riscv.EncodeAdd)
+	case ir.OpAndImm:
+		return emitRegImm(instruction, riscv.EncodeAndi, riscv.EncodeAnd)
+	case ir.OpCmpEq:
+		return emitCmpEqNe(instruction, true)
+	case ir.OpCmpNe:
+		return emitCmpEqNe(instruction, false)
+	case ir.OpCmpLt:
+		return emitThreeReg(instruction, riscv.EncodeSlt)
+	case ir.OpCmpGt:
+		return emitCmpGt(instruction)
+	case ir.OpJump:
+		label, err := labelOperand(instruction, 0)
+		if err != nil {
+			return nil, err
+		}
+		offset, err := jalOffset(instruction, label, pc, plan)
+		if err != nil {
+			return nil, err
+		}
+		return []uint32{riscv.EncodeJal(x0, offset)}, nil
+	case ir.OpBranchZ, ir.OpBranchNz:
+		return emitBranch(instruction, pc, plan)
+	case ir.OpCall:
+		label, err := labelOperand(instruction, 0)
+		if err != nil {
+			return nil, err
+		}
+		offset, err := jalOffset(instruction, label, pc, plan)
+		if err != nil {
+			return nil, err
+		}
+		return []uint32{riscv.EncodeJal(xRa, offset)}, nil
+	case ir.OpRet:
+		return []uint32{riscv.EncodeJalr(x0, xRa, 0)}, nil
+	case ir.OpSyscall:
+		imm, err := immOperand(instruction, 0)
+		if err != nil {
+			return nil, err
+		}
+		words := emitLoadConst(xSyscallNumber, imm.Value)
+		words = append(words, riscv.EncodeEcall())
+		return words, nil
+	case ir.OpHalt:
+		return []uint32{riscv.EncodeAddi(xSyscallNumber, x0, 10), riscv.EncodeEcall()}, nil
+	case ir.OpNop:
+		return []uint32{riscv.EncodeAddi(x0, x0, 0)}, nil
+	default:
+		return nil, loweringError(instruction, "unsupported opcode")
+	}
+}
+
+func (c *IrToRiscVCompiler) emitLoad(instruction ir.IrInstruction, encode func(rd, rs1, imm int) uint32) ([]uint32, error) {
+	dst, err := physicalRegOperand(instruction, 0)
+	if err != nil {
+		return nil, err
+	}
+	base, err := physicalRegOperand(instruction, 1)
+	if err != nil {
+		return nil, err
+	}
+	if imm, ok := thirdOperandAsImmediate(instruction); ok {
+		if !fitsSigned(imm.Value, 12) {
+			return nil, loweringError(instruction, "memory immediate %d is outside signed 12-bit range", imm.Value)
+		}
+		return []uint32{encode(dst, base, imm.Value)}, nil
+	}
+	offset, err := physicalRegOperand(instruction, 2)
+	if err != nil {
+		return nil, err
+	}
+	return []uint32{
+		riscv.EncodeAdd(xBackendScratch, base, offset),
+		encode(dst, xBackendScratch, 0),
+	}, nil
+}
+
+func (c *IrToRiscVCompiler) emitStore(instruction ir.IrInstruction, encode func(rs2, rs1, imm int) uint32) ([]uint32, error) {
+	src, err := physicalRegOperand(instruction, 0)
+	if err != nil {
+		return nil, err
+	}
+	base, err := physicalRegOperand(instruction, 1)
+	if err != nil {
+		return nil, err
+	}
+	if imm, ok := thirdOperandAsImmediate(instruction); ok {
+		if !fitsSigned(imm.Value, 12) {
+			return nil, loweringError(instruction, "memory immediate %d is outside signed 12-bit range", imm.Value)
+		}
+		return []uint32{encode(src, base, imm.Value)}, nil
+	}
+	offset, err := physicalRegOperand(instruction, 2)
+	if err != nil {
+		return nil, err
+	}
+	return []uint32{
+		riscv.EncodeAdd(xBackendScratch, base, offset),
+		encode(src, xBackendScratch, 0),
+	}, nil
+}
+
+func emitThreeReg(instruction ir.IrInstruction, encode func(rd, rs1, rs2 int) uint32) ([]uint32, error) {
+	dst, err := physicalRegOperand(instruction, 0)
+	if err != nil {
+		return nil, err
+	}
+	left, err := physicalRegOperand(instruction, 1)
+	if err != nil {
+		return nil, err
+	}
+	right, err := physicalRegOperand(instruction, 2)
+	if err != nil {
+		return nil, err
+	}
+	return []uint32{encode(dst, left, right)}, nil
+}
+
+func emitRegImm(instruction ir.IrInstruction, encodeImm func(rd, rs1, imm int) uint32, encodeReg func(rd, rs1, rs2 int) uint32) ([]uint32, error) {
+	dst, err := physicalRegOperand(instruction, 0)
+	if err != nil {
+		return nil, err
+	}
+	src, err := physicalRegOperand(instruction, 1)
+	if err != nil {
+		return nil, err
+	}
+	imm, err := immOperand(instruction, 2)
+	if err != nil {
+		return nil, err
+	}
+	if fitsSigned(imm.Value, 12) {
+		return []uint32{encodeImm(dst, src, imm.Value)}, nil
+	}
+	words := emitLoadConst(xBackendScratch, imm.Value)
+	words = append(words, encodeReg(dst, src, xBackendScratch))
+	return words, nil
+}
+
+func emitCmpEqNe(instruction ir.IrInstruction, equal bool) ([]uint32, error) {
+	dst, err := physicalRegOperand(instruction, 0)
+	if err != nil {
+		return nil, err
+	}
+	left, err := physicalRegOperand(instruction, 1)
+	if err != nil {
+		return nil, err
+	}
+	right, err := physicalRegOperand(instruction, 2)
+	if err != nil {
+		return nil, err
+	}
+	if equal {
+		return []uint32{
+			riscv.EncodeXor(dst, left, right),
+			riscv.EncodeSltiu(dst, dst, 1),
+		}, nil
+	}
+	return []uint32{
+		riscv.EncodeXor(dst, left, right),
+		riscv.EncodeSltu(dst, x0, dst),
+	}, nil
+}
+
+func emitCmpGt(instruction ir.IrInstruction) ([]uint32, error) {
+	dst, err := physicalRegOperand(instruction, 0)
+	if err != nil {
+		return nil, err
+	}
+	left, err := physicalRegOperand(instruction, 1)
+	if err != nil {
+		return nil, err
+	}
+	right, err := physicalRegOperand(instruction, 2)
+	if err != nil {
+		return nil, err
+	}
+	return []uint32{riscv.EncodeSlt(dst, right, left)}, nil
+}
+
+func emitBranch(instruction ir.IrInstruction, pc int, plan *compilePlan) ([]uint32, error) {
+	register, err := physicalRegOperand(instruction, 0)
+	if err != nil {
+		return nil, err
+	}
+	label, err := labelOperand(instruction, 1)
+	if err != nil {
+		return nil, err
+	}
+	target, ok := plan.labelOffsets[label.Name]
+	if !ok {
+		return nil, loweringError(instruction, "unknown label %q", label.Name)
+	}
+	offset := target - pc
+	if err := validateBranchOffset(offset); err != nil {
+		return nil, loweringError(instruction, "%v", err)
+	}
+	if instruction.Opcode == ir.OpBranchZ {
+		return []uint32{riscv.EncodeBeq(register, x0, offset)}, nil
+	}
+	return []uint32{riscv.EncodeBne(register, x0, offset)}, nil
+}
+
+func jalOffset(instruction ir.IrInstruction, label ir.IrLabel, pc int, plan *compilePlan) (int, error) {
+	target, ok := plan.labelOffsets[label.Name]
+	if !ok {
+		return 0, loweringError(instruction, "unknown label %q", label.Name)
+	}
+	offset := target - pc
+	if err := validateJalOffset(offset); err != nil {
+		return 0, loweringError(instruction, "%v", err)
+	}
+	return offset, nil
+}
+
+func emitLoadConst(rd, value int) []uint32 {
+	if fitsSigned(value, 12) {
+		return []uint32{riscv.EncodeAddi(rd, x0, value)}
+	}
+	upper, lower := splitUpperLower(value)
+	words := []uint32{riscv.EncodeLui(rd, upper)}
+	if lower != 0 {
+		words = append(words, riscv.EncodeAddi(rd, rd, lower))
+	}
+	return words
+}
+
+func emitLoadAddress(rd, address int) []uint32 {
+	upper, lower := splitUpperLower(address)
+	return []uint32{
+		riscv.EncodeLui(rd, upper),
+		riscv.EncodeAddi(rd, rd, lower),
+	}
+}
+
+func loadConstSize(value int) int {
+	if fitsSigned(value, 12) {
+		return 1
+	}
+	_, lower := splitUpperLower(value)
+	if lower == 0 {
+		return 1
+	}
+	return 2
+}
+
+func splitUpperLower(value int) (upper, lower int) {
+	upper = (value + 0x800) >> 12
+	lower = value - (upper << 12)
+	return upper, lower
+}
+
+func physicalRegOperand(instruction ir.IrInstruction, index int) (int, error) {
+	reg, err := regOperand(instruction, index)
+	if err != nil {
+		return 0, err
+	}
+	physical, ok := physicalRegister(reg.Index)
+	if !ok {
+		return 0, loweringError(instruction, "virtual register v%d has no physical mapping in the starter allocator", reg.Index)
+	}
+	return physical, nil
+}
+
+func physicalRegister(index int) (int, bool) {
+	fixed := map[int]int{
+		0: 5,  // tape/data base
+		1: 6,  // tape/data offset
+		2: 7,  // temp
+		3: 28, // temp2
+		4: 10, // a0, syscall arg/result
+		5: 29, // temp3
+		6: 30, // zero/bounds-check temp
+	}
+	if physical, ok := fixed[index]; ok {
+		return physical, true
+	}
+	extra := []int{11, 12, 13, 14, 15, 16, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27}
+	extraIndex := index - 7
+	if extraIndex >= 0 && extraIndex < len(extra) {
+		return extra[extraIndex], true
+	}
+	return 0, false
+}
+
+func regOperand(instruction ir.IrInstruction, index int) (ir.IrRegister, error) {
+	if index >= len(instruction.Operands) {
+		return ir.IrRegister{}, loweringError(instruction, "missing register operand %d", index)
+	}
+	reg, ok := instruction.Operands[index].(ir.IrRegister)
+	if !ok {
+		return ir.IrRegister{}, loweringError(instruction, "operand %d is %T, expected IrRegister", index, instruction.Operands[index])
+	}
+	return reg, nil
+}
+
+func immOperand(instruction ir.IrInstruction, index int) (ir.IrImmediate, error) {
+	if index >= len(instruction.Operands) {
+		return ir.IrImmediate{}, loweringError(instruction, "missing immediate operand %d", index)
+	}
+	imm, ok := instruction.Operands[index].(ir.IrImmediate)
+	if !ok {
+		return ir.IrImmediate{}, loweringError(instruction, "operand %d is %T, expected IrImmediate", index, instruction.Operands[index])
+	}
+	return imm, nil
+}
+
+func labelOperand(instruction ir.IrInstruction, index int) (ir.IrLabel, error) {
+	if index >= len(instruction.Operands) {
+		return ir.IrLabel{}, loweringError(instruction, "missing label operand %d", index)
+	}
+	label, ok := instruction.Operands[index].(ir.IrLabel)
+	if !ok {
+		return ir.IrLabel{}, loweringError(instruction, "operand %d is %T, expected IrLabel", index, instruction.Operands[index])
+	}
+	return label, nil
+}
+
+func thirdOperandAsImmediate(instruction ir.IrInstruction) (ir.IrImmediate, bool) {
+	if len(instruction.Operands) < 3 {
+		return ir.IrImmediate{}, false
+	}
+	imm, ok := instruction.Operands[2].(ir.IrImmediate)
+	return imm, ok
+}
+
+func dataBytes(data []ir.IrDataDecl) []byte {
+	var out []byte
+	for _, decl := range data {
+		init := byte(decl.Init & 0xFF)
+		for i := 0; i < decl.Size; i++ {
+			out = append(out, init)
+		}
+	}
+	return out
+}
+
+func fitsSigned(value, bits int) bool {
+	min := -(1 << (bits - 1))
+	max := (1 << (bits - 1)) - 1
+	return value >= min && value <= max
+}
+
+func validateBranchOffset(offset int) error {
+	if offset%2 != 0 {
+		return fmt.Errorf("branch offset %d is not 2-byte aligned", offset)
+	}
+	if !fitsSigned(offset, 13) {
+		return fmt.Errorf("branch offset %d is outside signed 13-bit range", offset)
+	}
+	return nil
+}
+
+func validateJalOffset(offset int) error {
+	if offset%2 != 0 {
+		return fmt.Errorf("jal offset %d is not 2-byte aligned", offset)
+	}
+	if !fitsSigned(offset, 21) {
+		return fmt.Errorf("jal offset %d is outside signed 21-bit range", offset)
+	}
+	return nil
+}
+
+func loweringError(instruction ir.IrInstruction, format string, args ...any) error {
+	return LoweringError{
+		IrID:    instruction.ID,
+		Opcode:  instruction.Opcode,
+		Message: fmt.Sprintf(format, args...),
+	}
+}

--- a/code/packages/go/ir-to-riscv-compiler/compiler_test.go
+++ b/code/packages/go/ir-to-riscv-compiler/compiler_test.go
@@ -1,0 +1,139 @@
+package irtoriscvcompiler
+
+import (
+	"testing"
+
+	ir "github.com/adhithyan15/coding-adventures/code/packages/go/compiler-ir"
+	riscv "github.com/adhithyan15/coding-adventures/code/packages/go/riscv-simulator"
+)
+
+func TestCompileRunsArithmeticOnRiscVSimulator(t *testing.T) {
+	program := ir.NewIrProgram("_start")
+	program.Instructions = []ir.IrInstruction{
+		label("_start"),
+		instr(1, ir.OpLoadImm, ir.IrRegister{Index: 0}, ir.IrImmediate{Value: 2}),
+		instr(2, ir.OpLoadImm, ir.IrRegister{Index: 1}, ir.IrImmediate{Value: 40}),
+		instr(3, ir.OpAdd, ir.IrRegister{Index: 2}, ir.IrRegister{Index: 0}, ir.IrRegister{Index: 1}),
+		instr(4, ir.OpHalt),
+	}
+
+	result, err := NewIrToRiscVCompiler().Compile(program)
+	if err != nil {
+		t.Fatalf("compile failed: %v", err)
+	}
+
+	sim := riscv.NewRiscVSimulator(4096)
+	sim.Run(result.Bytes)
+
+	if got := sim.CPU.Registers.Read(7); got != 42 {
+		t.Fatalf("expected v2/x7 to contain 42, got %d", got)
+	}
+	if offset, length := result.IrToMachineCode.LookupByIrID(3); offset != 8 || length != 4 {
+		t.Fatalf("expected ADD mapping at offset=8 length=4, got offset=%d length=%d", offset, length)
+	}
+}
+
+func TestCompileLowersDataAddressAndMemoryOps(t *testing.T) {
+	program := ir.NewIrProgram("_start")
+	program.Data = []ir.IrDataDecl{{Label: "tape", Size: 4, Init: 0}}
+	program.Instructions = []ir.IrInstruction{
+		label("_start"),
+		instr(1, ir.OpLoadAddr, ir.IrRegister{Index: 0}, ir.IrLabel{Name: "tape"}),
+		instr(2, ir.OpLoadImm, ir.IrRegister{Index: 1}, ir.IrImmediate{Value: 0}),
+		instr(3, ir.OpLoadImm, ir.IrRegister{Index: 2}, ir.IrImmediate{Value: 65}),
+		instr(4, ir.OpStoreByte, ir.IrRegister{Index: 2}, ir.IrRegister{Index: 0}, ir.IrRegister{Index: 1}),
+		instr(5, ir.OpLoadByte, ir.IrRegister{Index: 3}, ir.IrRegister{Index: 0}, ir.IrRegister{Index: 1}),
+		instr(6, ir.OpHalt),
+	}
+
+	result, err := NewIrToRiscVCompiler().Compile(program)
+	if err != nil {
+		t.Fatalf("compile failed: %v", err)
+	}
+
+	sim := riscv.NewRiscVSimulator(4096)
+	sim.Run(result.Bytes)
+
+	tapeOffset := result.DataOffsets["tape"]
+	if got := sim.CPU.Registers.Read(28); got != 65 {
+		t.Fatalf("expected v3/x28 to reload byte 65, got %d", got)
+	}
+	if got := sim.CPU.Memory.ReadByte(tapeOffset); got != 65 {
+		t.Fatalf("expected tape byte at %d to be 65, got %d", tapeOffset, got)
+	}
+}
+
+func TestCompileResolvesBackwardBranch(t *testing.T) {
+	program := ir.NewIrProgram("_start")
+	program.Instructions = []ir.IrInstruction{
+		label("_start"),
+		instr(1, ir.OpLoadImm, ir.IrRegister{Index: 0}, ir.IrImmediate{Value: 3}),
+		label("loop"),
+		instr(2, ir.OpAddImm, ir.IrRegister{Index: 0}, ir.IrRegister{Index: 0}, ir.IrImmediate{Value: -1}),
+		instr(3, ir.OpBranchNz, ir.IrRegister{Index: 0}, ir.IrLabel{Name: "loop"}),
+		instr(4, ir.OpHalt),
+	}
+
+	result, err := NewIrToRiscVCompiler().Compile(program)
+	if err != nil {
+		t.Fatalf("compile failed: %v", err)
+	}
+
+	sim := riscv.NewRiscVSimulator(4096)
+	sim.Run(result.Bytes)
+
+	if got := sim.CPU.Registers.Read(5); got != 0 {
+		t.Fatalf("expected loop to count v0/x5 down to 0, got %d", got)
+	}
+	if result.LabelOffsets["loop"] != 4 {
+		t.Fatalf("expected loop label at byte offset 4, got %d", result.LabelOffsets["loop"])
+	}
+}
+
+func TestCompileHonorsEntryLabelWithTrampoline(t *testing.T) {
+	program := ir.NewIrProgram("_start")
+	program.Instructions = []ir.IrInstruction{
+		label("helper"),
+		instr(1, ir.OpLoadImm, ir.IrRegister{Index: 0}, ir.IrImmediate{Value: 99}),
+		instr(2, ir.OpHalt),
+		label("_start"),
+		instr(3, ir.OpLoadImm, ir.IrRegister{Index: 0}, ir.IrImmediate{Value: 7}),
+		instr(4, ir.OpHalt),
+	}
+
+	result, err := NewIrToRiscVCompiler().Compile(program)
+	if err != nil {
+		t.Fatalf("compile failed: %v", err)
+	}
+
+	sim := riscv.NewRiscVSimulator(4096)
+	sim.Run(result.Bytes)
+
+	if got := sim.CPU.Registers.Read(5); got != 7 {
+		t.Fatalf("expected entry trampoline to skip helper code and set v0/x5 to 7, got %d", got)
+	}
+	if result.LabelOffsets["_start"] == 0 {
+		t.Fatal("expected _start to live after the entry trampoline")
+	}
+}
+
+func TestCompileRejectsUnknownLabel(t *testing.T) {
+	program := ir.NewIrProgram("_start")
+	program.Instructions = []ir.IrInstruction{
+		label("_start"),
+		instr(1, ir.OpJump, ir.IrLabel{Name: "missing"}),
+	}
+
+	_, err := NewIrToRiscVCompiler().Compile(program)
+	if err == nil {
+		t.Fatal("expected missing label error")
+	}
+}
+
+func instr(id int, opcode ir.IrOp, operands ...ir.IrOperand) ir.IrInstruction {
+	return ir.IrInstruction{ID: id, Opcode: opcode, Operands: operands}
+}
+
+func label(name string) ir.IrInstruction {
+	return ir.IrInstruction{ID: -1, Opcode: ir.OpLabel, Operands: []ir.IrOperand{ir.IrLabel{Name: name}}}
+}

--- a/code/packages/go/ir-to-riscv-compiler/go.mod
+++ b/code/packages/go/ir-to-riscv-compiler/go.mod
@@ -1,0 +1,36 @@
+module github.com/adhithyan15/coding-adventures/code/packages/go/ir-to-riscv-compiler
+
+go 1.26
+
+require (
+	github.com/adhithyan15/coding-adventures/code/packages/go/compiler-ir v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/compiler-source-map v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/riscv-simulator v0.0.0
+)
+
+require (
+	github.com/adhithyan15/coding-adventures/code/packages/go/branch-predictor v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/cache v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/clock v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/core v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/cpu-pipeline v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/cpu-simulator v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/directed-graph v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/hazard-detection v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/state-machine v0.0.0 // indirect
+)
+
+replace (
+	github.com/adhithyan15/coding-adventures/code/packages/go/branch-predictor => ../branch-predictor
+	github.com/adhithyan15/coding-adventures/code/packages/go/cache => ../cache
+	github.com/adhithyan15/coding-adventures/code/packages/go/clock => ../clock
+	github.com/adhithyan15/coding-adventures/code/packages/go/compiler-ir => ../compiler-ir
+	github.com/adhithyan15/coding-adventures/code/packages/go/compiler-source-map => ../compiler-source-map
+	github.com/adhithyan15/coding-adventures/code/packages/go/core => ../core
+	github.com/adhithyan15/coding-adventures/code/packages/go/cpu-pipeline => ../cpu-pipeline
+	github.com/adhithyan15/coding-adventures/code/packages/go/cpu-simulator => ../cpu-simulator
+	github.com/adhithyan15/coding-adventures/code/packages/go/directed-graph => ../directed-graph
+	github.com/adhithyan15/coding-adventures/code/packages/go/hazard-detection => ../hazard-detection
+	github.com/adhithyan15/coding-adventures/code/packages/go/riscv-simulator => ../riscv-simulator
+	github.com/adhithyan15/coding-adventures/code/packages/go/state-machine => ../state-machine
+)

--- a/code/packages/go/ir-to-riscv-compiler/required_capabilities.json
+++ b/code/packages/go/ir-to-riscv-compiler/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "go/ir-to-riscv-compiler",
+  "capabilities": [],
+  "justification": "Pure computation. Lowers compiler IR to RISC-V machine code in memory."
+}


### PR DESCRIPTION
## Summary
- add a Go `ir-to-riscv-compiler` package that lowers `compiler-ir` v1 to RV32I bytes and readable RISC-V assembly
- add a reusable `riscv-assembler` package for RV32I text assembly, labels, data directives, and compiler-friendly pseudos
- add `nib-riscv-compiler` to compose Nib -> IR -> RISC-V assembly -> assembler bytes -> simulator, plus a RISC-V language readiness roadmap

## Tests
- `go test -c -o /tmp/riscv-assembler.test` in `code/packages/go/riscv-assembler`
- `go test -c -o /tmp/ir-to-riscv-compiler.test` in `code/packages/go/ir-to-riscv-compiler`
- `go test -c -o /tmp/nib-riscv-compiler.test` in `code/packages/go/nib-riscv-compiler`

Note: full `go test` execution currently hangs launching Go test binaries in this local macOS session, even for a trivial temporary Go module, so I verified compilation with `go test -c` and left the runtime tests in place for CI/normal local runs.