### PR TITLE
test(algol): lock phase 5 by-name acceptance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   Jensen's-device terms such as `a[i] * i` through the WASM runtime path.
 - Enabled read-only ALGOL expression thunks to call integer procedures, with
   nested procedure failures propagated through thunk helper state.
+- Added Phase 5 wrap-up coverage and docs for the completed integer by-name
+  subset and its remaining full-ALGOL exclusions.
 
 ### Added — TypeScript Port + JavaScript/TypeScript Grammars (PR #14)
 - **31 TypeScript packages** — complete port of the computing stack to TypeScript

--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -34,6 +34,8 @@ All notable changes to this package will be documented in this file.
 - Allowed read-only expression eval thunks to call integer procedures, with a
   runtime helper-depth marker for propagating nested procedure failures back to
   the caller's by-name formal read.
+- Documented the completed integer Phase 5 by-name subset and its remaining
+  full-ALGOL exclusions.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -37,7 +37,10 @@ frame and thunk-region unwind. Procedure calls inside read-only expression
 thunks are supported, including nested by-name descriptor allocation and runtime
 failure propagation from callees back to the by-name formal read. Stores through
 read-only expression thunks still raise targeted `CompileError` diagnostics
-until Phase 5 grows full store-helper coverage.
+until Phase 5 grows full store-helper coverage. The supported integer by-name
+surface is covered by the WASM acceptance suite, while full ALGOL forms such as
+non-integer formals, whole-array by-name values, procedure-valued actuals,
+labels, switches, and escaping thunk descriptors remain future work.
 
 This phase keeps ALGOL frame memory and its 32-byte runtime state bounded to
 one 64 KiB WASM page, and keeps array descriptors plus element storage inside a

--- a/code/packages/python/algol-type-checker/CHANGELOG.md
+++ b/code/packages/python/algol-type-checker/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to this package will be documented in this file.
 - Added Phase 5 by-name parameter semantic metadata, conservative write
   analysis for assigned or transitively passed by-name formals, and call-site
   diagnostics for non-assignable by-name actual expressions.
+- Added explicit guard coverage for literal and procedure-call actuals passed
+  to written by-name formals.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-type-checker/README.md
+++ b/code/packages/python/algol-type-checker/README.md
@@ -27,7 +27,10 @@ Unsupported ALGOL 60 features, including real/Boolean/string arrays, array
 parameters, switches, procedure-valued parameters, labels, and `goto`, are
 reported as diagnostics instead of being silently accepted by the compiled
 pipeline. By-name parameters are accepted in the semantic model, while later
-lowering packages still reject them until thunk code generation lands.
+lowering packages now implement the integer call-by-name subset. The checker
+keeps guarding the remaining full-ALGOL gaps, including non-assignable actuals
+passed to written by-name formals, non-integer by-name types, whole-array
+parameters, procedure-valued parameters, labels, switches, and `goto`.
 
 ```python
 from algol_parser import parse_algol

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -359,6 +359,31 @@ class TestAlgolTypeChecker:
         assert not result.ok
         assert "actual expression is not assignable" in result.diagnostics[0].message
 
+    def test_rejects_literal_actual_for_written_by_name_parameter(self) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "procedure put(x); integer x; begin x := 7 end; "
+            "put(1) "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert "actual expression is not assignable" in result.diagnostics[0].message
+
+    def test_rejects_procedure_call_actual_for_written_by_name_parameter(self) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "integer procedure inc(n); value n; integer n; begin inc := n + 1 end; "
+            "procedure put(x); integer x; begin x := 7 end; "
+            "put(inc(1)) "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert "actual expression is not assignable" in result.diagnostics[0].message
+
     def test_accepts_array_element_actual_for_written_by_name_parameter(self) -> None:
         ast = parse_algol(
             "begin integer result; integer array a[1:2]; "

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -28,6 +28,8 @@ All notable changes to this package will be documented in this file.
 - Executed read-only expression thunks that call integer procedures, including
   nested by-name descriptor allocation and callee failure propagation through
   the caller's by-name formal read.
+- Added a consolidated integer by-name acceptance test covering scalar,
+  array-element, expression, nested procedure, and Jensen's-device behavior.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -35,7 +35,10 @@ Expression thunks can call procedures, including procedures that receive nested
 by-name descriptors, and runtime failures from those callees propagate through
 the by-name formal read. Expression thunk stores remain guarded by IR
 compile-stage diagnostics until full Phase 5 store-helper coverage is
-available.
+available. The integer by-name acceptance tests cover the supported scalar,
+array, expression, nested-procedure, and Jensen's-device surface; full ALGOL
+labels, switches, procedure-valued parameters, whole-array by-name values, and
+non-integer by-name formals remain later phases.
 
 ```python
 from algol_wasm_compiler import compile_source

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -236,6 +236,26 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [8]
 
+    def test_integer_by_name_acceptance_surface(self) -> None:
+        result = compile_source(
+            "begin integer result, s, i; integer array a[1:3]; "
+            "procedure bump(x); integer x; begin x := x + 1 end; "
+            "integer procedure probe(x); integer x; "
+            "begin probe := x; s := s + 10; probe := probe * 100 + x end; "
+            "integer procedure inc(n); value n; integer n; begin inc := n + 1 end; "
+            "integer procedure sum(k, lo, hi, term); "
+            "value lo, hi; integer k, lo, hi, term; "
+            "begin sum := 0; for k := lo step 1 until hi do sum := sum + term end; "
+            "a[1] := 2; a[2] := 3; a[3] := 5; "
+            "s := 1; bump(s); result := s; "
+            "i := 1; bump(a[i]); result := result * 10 + a[1]; "
+            "s := 4; result := result * 1000 + probe(s + 1); "
+            "result := result * 100 + inc(a[1]); "
+            "result := result * 100 + sum(i, 1, 3, a[i] * i) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [235150424]
+
     def test_jensens_device_sums_array_element_expression(self) -> None:
         result = compile_source(
             "begin integer result, i; integer array a[1:3]; "

--- a/code/specs/PL04-algol60-full-wasm-runtime.md
+++ b/code/specs/PL04-algol60-full-wasm-runtime.md
@@ -687,9 +687,9 @@ The descriptor allocation must be bounded. The compiler should enforce:
 - maximum call-site thunk descriptor bytes
 - no thunk descriptor escapes the receiving call
 
-### Phase 5 Subset
+### Phase 5 Integer Subset
 
-The first Phase 5 implementation should support:
+The completed integer-focused Phase 5 implementation supports:
 
 - `integer` by-name scalar formals
 - by-name integer expression actuals for read-only formals
@@ -698,8 +698,10 @@ The first Phase 5 implementation should support:
 - by-name actual expressions that reference variables in the caller's lexical
   ancestors
 - by-name actual expressions that reference Phase 4 integer arrays
+- by-name actual expressions that call integer procedures
+- Jensen's device over integer scalar and array expressions
 
-The first implementation should continue to reject:
+The integer-focused implementation still intentionally rejects:
 
 - non-integer by-name formals
 - by-name array descriptors as whole-array values
@@ -1313,6 +1315,7 @@ Acceptance:
 - array element actuals re-compute their element address on each use
 - read-only expression actuals work without store helpers
 - assigned read-only expression actuals are rejected before IR lowering
+- read-only expression actuals can read arrays and call integer procedures
 - Jensen's device works
 
 ### Phase 6: Labels and Local Goto


### PR DESCRIPTION
## Summary
- add a consolidated ALGOL integer by-name acceptance program covering scalar writeback, array-element relocation, expression re-evaluation, nested procedure calls, and Jensen's device
- pin explicit type-checker diagnostics for literal and procedure-call actuals passed to written by-name formals
- update PL04, package READMEs, and changelogs to document the completed integer Phase 5 subset and remaining full-ALGOL exclusions

## Tests
- `bash BUILD` (`code/packages/python/algol-type-checker`)
- `bash BUILD` (`code/packages/python/algol-ir-compiler`)
- `bash BUILD` (`code/packages/python/algol-wasm-compiler`)
- `PYTHONPATH=$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -) uv run --no-project --with ruff ruff check code/packages/python/algol-type-checker/tests code/packages/python/algol-ir-compiler/tests code/packages/python/algol-wasm-compiler/tests`

## Security review
- docs/tests-only change; no compiler or runtime behavior changes
- verified new acceptance coverage stays within the bounded integer by-name runtime path
- verified remaining unsupported full-ALGOL surfaces stay documented and guarded by diagnostics
