### PR TITLE
feat(music): let music machine use instruments

### DIFF
--- a/code/packages/python/music-machine/BUILD
+++ b/code/packages/python/music-machine/BUILD
@@ -7,6 +7,7 @@ uv pip install --no-deps -e ../virtual-dac --quiet
 uv pip install --no-deps -e ../virtual-speaker --quiet
 uv pip install --no-deps -e ../wav-sink --quiet
 uv pip install --no-deps -e ../note-audio --quiet
+uv pip install --no-deps -e ../musical-instruments --quiet
 uv pip install --no-deps -e . --quiet
 uv pip install pytest pytest-cov ruff --quiet
 uv run --no-project ruff check src/ tests/

--- a/code/packages/python/music-machine/BUILD_windows
+++ b/code/packages/python/music-machine/BUILD_windows
@@ -7,6 +7,7 @@ uv pip install --no-deps -e ../virtual-dac --quiet
 uv pip install --no-deps -e ../virtual-speaker --quiet
 uv pip install --no-deps -e ../wav-sink --quiet
 uv pip install --no-deps -e ../note-audio --quiet
+uv pip install --no-deps -e ../musical-instruments --quiet
 uv pip install --no-deps -e . --quiet
 uv pip install pytest pytest-cov ruff --quiet
 uv run --no-project ruff check src/ tests/

--- a/code/packages/python/music-machine/CHANGELOG.md
+++ b/code/packages/python/music-machine/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Added the first text score parser for monophonic note/rest melodies.
 - Added score rendering that stitches note PCM buffers and rest silence into one
   reusable `PCMBuffer`.
+- Added `instrument:` and `program:` directives that render notes through the
+  `musical-instruments` package.
 - Added a Happy Birthday fixture that demonstrates a complete text-to-audio
   score.
 - Added lazy playback helpers that delegate to `audio-device-sink` only when

--- a/code/packages/python/music-machine/README.md
+++ b/code/packages/python/music-machine/README.md
@@ -5,12 +5,12 @@ stack. It lets a small text score become timed events and then signed 16-bit PCM
 audio.
 
 ```text
-text score -> note/rest events -> note-audio renders -> PCM buffer -> optional audio sink
+text score -> note/rest events -> instrument renderer -> PCM buffer -> optional audio sink
 ```
 
 The package intentionally starts with a tiny sheet-music language instead of a
-full notation system. V1 supports one melody line, one tempo, notes, rests,
-duration symbols, and visual barlines.
+full notation system. V1 supports one melody line, one tempo, one selected
+instrument, notes, rests, duration symbols, and visual barlines.
 
 ## Text Score Example
 
@@ -19,6 +19,7 @@ title: Tiny Melody
 tempo: 120
 meter: 4/4
 amplitude: 0.18
+instrument: flute_naive
 sample_rate: 44100
 
 C4/q D4/q E4/q R/q
@@ -36,6 +37,24 @@ Each music token is `pitch/duration`.
 
 A single dot makes a duration one-and-a-half times as long, so `q.` is `1.5`
 beats.
+
+## Instruments
+
+Scores can choose a naive instrument profile by id:
+
+```text
+instrument: violin_naive
+```
+
+Or they can choose a General-MIDI-style keyboard program number:
+
+```text
+program: 74
+```
+
+`program: 74` resolves to the current naive flute profile. `instrument:` and
+`program:` are mutually exclusive, and both must appear before the music tokens.
+If neither is provided, the score defaults to `instrument: sine`.
 
 ## Usage
 
@@ -67,15 +86,17 @@ to run.
 
 ## How It Fits
 
-`music-machine` does not synthesize notes itself. It parses a score, then sends
-each note event through `note-audio`, which exposes the lower layers:
+`music-machine` does not define instrument timbres itself. It parses a score,
+resolves the selected profile through `musical-instruments`, then renders each
+note through the lower layers:
 
 ```text
-note-frequency -> oscillator -> sampler -> pcm-audio -> virtual DAC -> speaker model
+note-frequency -> musical-instruments -> oscillator -> sampler -> pcm-audio
 ```
 
 Rests are simpler: the machine appends zero-valued PCM samples for the requested
-duration.
+duration. Instrument release tails are mixed into the timeline, so the rendered
+PCM buffer may be slightly longer than the sum of notated durations.
 
 ## Development
 

--- a/code/packages/python/music-machine/pyproject.toml
+++ b/code/packages/python/music-machine/pyproject.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 dependencies = [
     "coding-adventures-note-frequency>=0.1.0",
     "coding-adventures-note-audio>=0.1.0",
+    "coding-adventures-musical-instruments>=0.1.0",
     "coding-adventures-oscillator>=0.1.0",
     "coding-adventures-pcm-audio>=0.1.0",
     "coding-adventures-trig>=0.1.0",
@@ -28,6 +29,7 @@ dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4"]
 [tool.uv.sources]
 coding-adventures-note-frequency = { path = "../note-frequency", editable = true }
 coding-adventures-note-audio = { path = "../note-audio", editable = true }
+coding-adventures-musical-instruments = { path = "../musical-instruments", editable = true }
 coding-adventures-oscillator = { path = "../oscillator", editable = true }
 coding-adventures-pcm-audio = { path = "../pcm-audio", editable = true }
 coding-adventures-trig = { path = "../trig", editable = true }

--- a/code/packages/python/music-machine/src/music_machine/__init__.py
+++ b/code/packages/python/music-machine/src/music_machine/__init__.py
@@ -2,6 +2,7 @@
 
 from .music_machine import (
     DEFAULT_AMPLITUDE,
+    DEFAULT_INSTRUMENT_ID,
     DEFAULT_MAX_EVENT_COUNT,
     DEFAULT_MAX_LINE_LENGTH,
     DEFAULT_MAX_SAMPLE_COUNT,
@@ -19,6 +20,7 @@ from .music_machine import (
     play_score,
     play_score_text,
     render_score_to_pcm,
+    resolve_instrument_id,
 )
 
 __version__ = "0.1.0"
@@ -30,6 +32,7 @@ __all__ = [
     "DEFAULT_MAX_SAMPLE_COUNT",
     "DEFAULT_MAX_SCORE_LENGTH",
     "DEFAULT_METER",
+    "DEFAULT_INSTRUMENT_ID",
     "DEFAULT_SAMPLE_RATE_HZ",
     "DEFAULT_TEMPO_BPM",
     "DURATION_BEATS",
@@ -39,6 +42,7 @@ __all__ = [
     "TextScore",
     "__version__",
     "beats_for_duration_symbol",
+    "resolve_instrument_id",
     "parse_score",
     "play_score",
     "play_score_text",

--- a/code/packages/python/music-machine/src/music_machine/music_machine.py
+++ b/code/packages/python/music-machine/src/music_machine/music_machine.py
@@ -22,11 +22,13 @@ from math import isfinite
 from numbers import Integral, Real
 from typing import Literal
 
-from note_audio import (
-    DEFAULT_MAX_SAMPLE_COUNT,
-    RenderedNote,
-    render_note_to_sound_chain,
+from musical_instruments import (
+    InstrumentNoteRender,
+    get_instrument,
+    instrument_for_gm_program,
+    render_instrument_note,
 )
+from note_audio import DEFAULT_MAX_SAMPLE_COUNT
 from note_frequency import parse_note
 from oscillator import sample_count_for_duration
 from pcm_audio import DEFAULT_SAMPLE_RATE_HZ, PCMBuffer, PCMFormat
@@ -34,6 +36,7 @@ from pcm_audio import DEFAULT_SAMPLE_RATE_HZ, PCMBuffer, PCMFormat
 DEFAULT_TEMPO_BPM = 120.0
 DEFAULT_METER = "4/4"
 DEFAULT_AMPLITUDE = 0.18
+DEFAULT_INSTRUMENT_ID = "sine"
 DEFAULT_MAX_SCORE_LENGTH = 1_000_000
 DEFAULT_MAX_LINE_LENGTH = 10_000
 DEFAULT_MAX_EVENT_COUNT = 10_000
@@ -53,6 +56,8 @@ DIRECTIVE_NAMES = frozenset(
         "meter",
         "amplitude",
         "sample_rate",
+        "instrument",
+        "program",
     }
 )
 
@@ -63,6 +68,7 @@ HAPPY_BIRTHDAY_TEXT = """title: Happy Birthday
 tempo: 120
 meter: 3/4
 amplitude: 0.18
+instrument: sine
 sample_rate: 44100
 
 G4/e G4/e | A4/q G4/q C5/q | B4/h R/q |
@@ -129,6 +135,17 @@ def _integer_valued_sample_rate(text: str) -> int:
     return _positive_integer("sample_rate", int(round(value)))
 
 
+def _integer_directive(name: str, text: str) -> int:
+    try:
+        value = float(text)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer, got {text!r}") from exc
+
+    if not isfinite(value) or value != round(value):
+        raise ValueError(f"{name} must be an integer, got {text!r}")
+    return _positive_integer(name, int(round(value)))
+
+
 def _parse_float_directive(name: str, text: str) -> float:
     try:
         return float(text)
@@ -141,6 +158,22 @@ def _validate_meter(text: str) -> str:
     if match is None:
         raise ValueError(f"meter must look like positive beats/beat-unit, got {text!r}")
     return text
+
+
+def resolve_instrument_id(
+    *,
+    instrument_id: str | None = None,
+    gm_program: int | None = None,
+) -> str:
+    """Resolve score instrument settings to a concrete profile id."""
+
+    if instrument_id is not None and gm_program is not None:
+        raise ValueError("score may specify instrument or program, not both")
+    if gm_program is not None:
+        return instrument_for_gm_program(gm_program).id
+    if instrument_id is None:
+        return DEFAULT_INSTRUMENT_ID
+    return get_instrument(instrument_id).id
 
 
 def beats_for_duration_symbol(symbol: str) -> float:
@@ -210,6 +243,8 @@ class TextScore:
     meter: str
     amplitude: float
     sample_rate_hz: int
+    instrument_id: str
+    gm_program: int | None
     events: tuple[ScoreEvent, ...]
 
     def __post_init__(self) -> None:
@@ -225,6 +260,23 @@ class TextScore:
             self,
             "sample_rate_hz",
             _positive_integer("sample_rate_hz", self.sample_rate_hz),
+        )
+        gm_program = None
+        if self.gm_program is not None:
+            gm_program = _positive_integer("gm_program", self.gm_program)
+            if gm_program > 128:
+                raise ValueError("gm_program must be in [1, 128]")
+        object.__setattr__(self, "gm_program", gm_program)
+        if gm_program is None:
+            resolved_instrument_id = resolve_instrument_id(
+                instrument_id=str(self.instrument_id),
+            )
+        else:
+            resolved_instrument_id = resolve_instrument_id(gm_program=gm_program)
+        object.__setattr__(
+            self,
+            "instrument_id",
+            resolved_instrument_id,
         )
         object.__setattr__(self, "events", tuple(self.events))
         if not self.events:
@@ -247,7 +299,7 @@ class RenderedScore:
 
     score: TextScore
     pcm_buffer: PCMBuffer
-    rendered_notes: tuple[RenderedNote, ...]
+    rendered_notes: tuple[InstrumentNoteRender, ...]
 
     def __post_init__(self) -> None:
         if not isinstance(self.score, TextScore):
@@ -256,9 +308,9 @@ class RenderedScore:
             raise ValueError("pcm_buffer must be a PCMBuffer")
         object.__setattr__(self, "rendered_notes", tuple(self.rendered_notes))
         for index, rendered_note in enumerate(self.rendered_notes):
-            if not isinstance(rendered_note, RenderedNote):
+            if not isinstance(rendered_note, InstrumentNoteRender):
                 raise ValueError(
-                    f"rendered_notes[{index}] must be a note_audio.RenderedNote"
+                    f"rendered_notes[{index}] must be an InstrumentNoteRender"
                 )
 
 
@@ -327,6 +379,9 @@ def parse_score(
     meter = DEFAULT_METER
     amplitude = DEFAULT_AMPLITUDE
     sample_rate_hz = int(DEFAULT_SAMPLE_RATE_HZ)
+    instrument_id = DEFAULT_INSTRUMENT_ID
+    instrument_directive_seen = False
+    gm_program: int | None = None
     events: list[ScoreEvent] = []
 
     for line_number, raw_line in enumerate(text.splitlines(), start=1):
@@ -368,6 +423,28 @@ def parse_score(
                 )
             elif name == "sample_rate":
                 sample_rate_hz = _integer_valued_sample_rate(value)
+            elif name == "instrument":
+                if gm_program is not None:
+                    raise ValueError(
+                        f"line {line_number}: score may specify instrument or "
+                        "program, not both"
+                    )
+                try:
+                    instrument_id = get_instrument(value).id
+                except ValueError as exc:
+                    raise ValueError(f"line {line_number}: {exc}") from exc
+                instrument_directive_seen = True
+            elif name == "program":
+                if instrument_directive_seen:
+                    raise ValueError(
+                        f"line {line_number}: score may specify instrument or "
+                        "program, not both"
+                    )
+                gm_program = _integer_directive("program", value)
+                try:
+                    instrument_id = instrument_for_gm_program(gm_program).id
+                except ValueError as exc:
+                    raise ValueError(f"line {line_number}: {exc}") from exc
             continue
 
         for token in line.split():
@@ -389,6 +466,8 @@ def parse_score(
         meter=meter,
         amplitude=amplitude,
         sample_rate_hz=sample_rate_hz,
+        instrument_id=instrument_id,
+        gm_program=gm_program,
         events=tuple(events),
     )
 
@@ -396,11 +475,21 @@ def parse_score(
 def _validate_total_sample_budget(
     events: tuple[ScoreEvent, ...],
     sample_rate_hz: int,
+    instrument_id: str,
     max_sample_count: int,
 ) -> None:
     limit = _positive_integer("max_sample_count", max_sample_count)
+    instrument = get_instrument(instrument_id)
     total = sum(
-        sample_count_for_duration(event.duration_seconds, sample_rate_hz)
+        sample_count_for_duration(
+            event.duration_seconds
+            + (
+                instrument.envelope_profile.release_seconds
+                if event.kind == "note"
+                else 0.0
+            ),
+            sample_rate_hz,
+        )
         for event in events
     )
     if total > limit:
@@ -419,12 +508,18 @@ def render_score_to_pcm(
     if not isinstance(score, TextScore):
         raise ValueError("score must be a TextScore")
 
-    _validate_total_sample_budget(score.events, score.sample_rate_hz, max_sample_count)
+    _validate_total_sample_budget(
+        score.events,
+        score.sample_rate_hz,
+        score.instrument_id,
+        max_sample_count,
+    )
 
     pcm_samples: list[int] = []
-    rendered_notes: list[RenderedNote] = []
+    rendered_notes: list[InstrumentNoteRender] = []
     clipped_sample_count = 0
     elapsed_seconds = 0.0
+    cursor_sample_index = 0
 
     for event in score.events:
         if event.kind == "rest":
@@ -432,19 +527,36 @@ def render_score_to_pcm(
                 event.duration_seconds,
                 score.sample_rate_hz,
             )
-            pcm_samples.extend(0 for _ in range(silence_count))
+            cursor_sample_index += silence_count
+            if len(pcm_samples) < cursor_sample_index:
+                pcm_samples.extend(
+                    0 for _ in range(cursor_sample_index - len(pcm_samples))
+                )
         else:
-            rendered_note = render_note_to_sound_chain(
+            rendered_note = render_instrument_note(
                 event.note,
                 event.duration_seconds,
+                instrument=score.instrument_id,
                 sample_rate_hz=score.sample_rate_hz,
                 amplitude=score.amplitude,
                 start_time_seconds=elapsed_seconds,
                 max_sample_count=max_sample_count,
             )
             rendered_notes.append(rendered_note)
-            pcm_samples.extend(rendered_note.pcm_buffer.samples)
+            required_count = (
+                cursor_sample_index + rendered_note.pcm_buffer.sample_count()
+            )
+            if len(pcm_samples) < required_count:
+                pcm_samples.extend(0 for _ in range(required_count - len(pcm_samples)))
+            for offset, sample in enumerate(rendered_note.pcm_buffer.samples):
+                sample_index = cursor_sample_index + offset
+                mixed = pcm_samples[sample_index] + sample
+                pcm_samples[sample_index] = max(-32_768, min(32_767, mixed))
             clipped_sample_count += rendered_note.pcm_buffer.clipped_sample_count
+            cursor_sample_index += sample_count_for_duration(
+                event.duration_seconds,
+                score.sample_rate_hz,
+            )
         elapsed_seconds += event.duration_seconds
 
     return RenderedScore(

--- a/code/packages/python/music-machine/tests/test_music_machine.py
+++ b/code/packages/python/music-machine/tests/test_music_machine.py
@@ -7,6 +7,7 @@ import pytest
 from pcm_audio import PCMBuffer, PCMFormat
 
 from music_machine import (
+    DEFAULT_INSTRUMENT_ID,
     HAPPY_BIRTHDAY_TEXT,
     RenderedScore,
     ScoreEvent,
@@ -16,6 +17,7 @@ from music_machine import (
     play_score,
     play_score_text,
     render_score_to_pcm,
+    resolve_instrument_id,
 )
 
 
@@ -47,6 +49,7 @@ def test_parse_score_reads_metadata_notes_rests_and_barlines() -> None:
         tempo: 120
         meter: 3/4
         amplitude: 0.25
+        instrument: flute_naive
         sample_rate: 8000
 
         C4/q D4/e | R/e rest/q
@@ -57,6 +60,8 @@ def test_parse_score_reads_metadata_notes_rests_and_barlines() -> None:
     assert score.tempo_bpm == 120.0
     assert score.meter == "3/4"
     assert score.amplitude == 0.25
+    assert score.instrument_id == "flute_naive"
+    assert score.gm_program is None
     assert score.sample_rate_hz == 8000
     assert score.seconds_per_beat() == 0.5
     assert score.total_duration_seconds() == 1.5
@@ -77,6 +82,8 @@ def test_parse_score_defaults_metadata() -> None:
     assert score.tempo_bpm == 120.0
     assert score.meter == "4/4"
     assert score.amplitude == 0.18
+    assert score.instrument_id == DEFAULT_INSTRUMENT_ID
+    assert score.gm_program is None
     assert score.sample_rate_hz == 44_100
 
 
@@ -105,6 +112,12 @@ def test_parse_score_uses_known_tempo_for_dotted_duration_math() -> None:
         ("amplitude: loud\nA4/q", "amplitude must be a number"),
         ("sample_rate: 44100.5\nA4/q", "sample_rate must be an integer"),
         ("sample_rate: fast\nA4/q", "sample_rate must be an integer"),
+        ("instrument: laser_harp\nA4/q", "unknown instrument"),
+        ("program: 0\nA4/q", "program must be > 0"),
+        ("program: 129\nA4/q", "program must be in"),
+        ("program: flute\nA4/q", "program must be an integer"),
+        ("instrument: sine\nprogram: 74\nA4/q", "instrument or program"),
+        ("program: 74\ninstrument: sine\nA4/q", "instrument or program"),
         ("meter: tomato\nA4/q", "meter must look"),
         ("dynamic: loud\nA4/q", "unknown directive"),
         ("title:\nA4/q", "directive 'title' is empty"),
@@ -201,6 +214,8 @@ def test_text_score_validates_settings_and_events() -> None:
             meter="4/4",
             amplitude=0.18,
             sample_rate_hz=8000,
+            instrument_id=DEFAULT_INSTRUMENT_ID,
+            gm_program=None,
             events=(),
         )
 
@@ -211,6 +226,8 @@ def test_text_score_validates_settings_and_events() -> None:
             meter="4/4",
             amplitude=0.18,
             sample_rate_hz=0,
+            instrument_id=DEFAULT_INSTRUMENT_ID,
+            gm_program=None,
             events=(event,),
         )
 
@@ -221,6 +238,8 @@ def test_text_score_validates_settings_and_events() -> None:
             meter="4/4",
             amplitude=0.18,
             sample_rate_hz=8000,
+            instrument_id=DEFAULT_INSTRUMENT_ID,
+            gm_program=None,
             events=(event,),
         )
 
@@ -231,6 +250,8 @@ def test_text_score_validates_settings_and_events() -> None:
             meter="4/4",
             amplitude=float("nan"),
             sample_rate_hz=8000,
+            instrument_id=DEFAULT_INSTRUMENT_ID,
+            gm_program=None,
             events=(event,),
         )
 
@@ -241,8 +262,41 @@ def test_text_score_validates_settings_and_events() -> None:
             meter="4/4",
             amplitude=0.18,
             sample_rate_hz=True,  # type: ignore[arg-type]
+            instrument_id=DEFAULT_INSTRUMENT_ID,
+            gm_program=None,
             events=(event,),
         )
+
+
+def test_text_score_resolves_gm_program() -> None:
+    event = ScoreEvent(
+        kind="note",
+        note="A4",
+        duration_symbol="q",
+        beat_count=1.0,
+        duration_seconds=0.5,
+        source_token="A4/q",
+    )
+    score = TextScore(
+        title="Flute",
+        tempo_bpm=120,
+        meter="4/4",
+        amplitude=0.18,
+        sample_rate_hz=8000,
+        instrument_id=DEFAULT_INSTRUMENT_ID,
+        gm_program=74,
+        events=(event,),
+    )
+
+    assert score.gm_program == 74
+    assert score.instrument_id == "flute_naive"
+
+
+def test_resolve_instrument_id_rejects_conflicting_settings() -> None:
+    assert resolve_instrument_id(gm_program=74) == "flute_naive"
+
+    with pytest.raises(ValueError, match="instrument or program"):
+        resolve_instrument_id(instrument_id="sine", gm_program=74)
 
 
 def test_rendered_score_validates_shape() -> None:
@@ -286,8 +340,42 @@ def test_render_score_to_pcm_joins_notes_and_zero_rest_samples() -> None:
 
     assert rendered.pcm_buffer.sample_count() == 20
     assert len(rendered.rendered_notes) == 1
-    assert rendered.rendered_notes[0].frequency_hz == pytest.approx(27.5)
-    assert rendered.pcm_buffer.samples[10:] == (0,) * 10
+    assert rendered.rendered_notes[0].fundamental_hz == pytest.approx(27.5)
+    assert any(rendered.pcm_buffer.samples[10:13])
+    assert rendered.pcm_buffer.samples[13:] == (0,) * 7
+
+
+def test_render_score_uses_selected_instrument() -> None:
+    flute = render_score_to_pcm(
+        parse_score(
+            """
+            tempo: 600
+            amplitude: 0.25
+            instrument: flute_naive
+            sample_rate: 8000
+
+            A4/q
+            """
+        )
+    )
+    violin = render_score_to_pcm(
+        parse_score(
+            """
+            tempo: 600
+            amplitude: 0.25
+            program: 41
+            sample_rate: 8000
+
+            A4/q
+            """
+        )
+    )
+
+    assert flute.score.instrument_id == "flute_naive"
+    assert violin.score.instrument_id == "violin_naive"
+    assert flute.rendered_notes[0].instrument.id == "flute_naive"
+    assert violin.rendered_notes[0].instrument.id == "violin_naive"
+    assert flute.pcm_buffer.samples != violin.pcm_buffer.samples
 
 
 def test_render_score_to_pcm_rejects_sample_budget_overflow() -> None:
@@ -319,9 +407,9 @@ def test_happy_birthday_fixture_parses_and_renders() -> None:
 
     rendered = render_score_to_pcm(score)
 
-    assert rendered.pcm_buffer.sample_count() == 595_350
+    assert rendered.pcm_buffer.sample_count() == 596_673
     assert len(rendered.rendered_notes) == 25
-    assert rendered.pcm_buffer.duration_seconds() == pytest.approx(13.5)
+    assert rendered.pcm_buffer.duration_seconds() == pytest.approx(13.53)
 
 
 def test_play_score_delegates_to_injected_sink() -> None:
@@ -341,7 +429,7 @@ def test_play_score_delegates_to_injected_sink() -> None:
         return "played"
 
     assert play_score(score, play_pcm_buffer=fake_sink) == "played"
-    assert seen == {"sample_count": 10, "sample_rate": 100.0}
+    assert seen == {"sample_count": 13, "sample_rate": 100.0}
 
 
 def test_play_score_text_delegates_to_injected_sink() -> None:
@@ -390,7 +478,7 @@ def test_play_score_text_imports_default_sink_lazily(
     )
 
     assert result == "lazy played"
-    assert seen == {"sample_count": 10}
+    assert seen == {"sample_count": 13}
 
 
 def test_play_score_text_rejects_non_callable_default_sink(


### PR DESCRIPTION
## Summary

- Add `instrument:` and `program:` directives to `music-machine` text scores.
- Resolve named naive profiles and General-MIDI-style program numbers through `musical-instruments`.
- Render notes through the selected instrument profile while preserving existing sine behavior as the default.
- Mix instrument release tails into the score timeline and count them against sample budgets.
- Update docs and tests for instrument parsing, conflict validation, GM program rendering, release tails, and playback delegation.

## Validation

- `bash BUILD` in `code/packages/python/music-machine`
- Rendered a short score through all 128 GM-style program numbers

## Notes

This PR keeps the score format monophonic. Multi-track instruments are intentionally left for a later PR so this integration stays small and reviewable.