### PR TITLE
feat(riscv): add assembler and Nib pipeline

### DIFF
--- a/code/packages/go/ir-to-riscv-compiler/README.md
+++ b/code/packages/go/ir-to-riscv-compiler/README.md
@@ -29,6 +29,7 @@ sim := riscvsimulator.NewRiscVSimulator(65536)
 sim.Run(result.Bytes)
 ```
 
-`MachineCodeResult.Bytes` contains the assembled text section followed by any
-declared IR data bytes. `DataOffsets` and `LabelOffsets` are absolute byte
-offsets from the beginning of the loaded program.
+`MachineCodeResult.Assembly` contains human-readable RISC-V assembly for the
+same image. `MachineCodeResult.Bytes` contains the assembled text section
+followed by any declared IR data bytes. `DataOffsets` and `LabelOffsets` are
+absolute byte offsets from the beginning of the loaded program.

--- a/code/packages/go/ir-to-riscv-compiler/assembly.go
+++ b/code/packages/go/ir-to-riscv-compiler/assembly.go
@@ -1,0 +1,269 @@
+package irtoriscvcompiler
+
+import (
+	"fmt"
+	"strings"
+
+	ir "github.com/adhithyan15/coding-adventures/code/packages/go/compiler-ir"
+)
+
+func (c *IrToRiscVCompiler) emitAssembly(program *ir.IrProgram, plan *compilePlan) (string, error) {
+	var builder strings.Builder
+	builder.WriteString(".text\n")
+	if plan.entryTrampoline {
+		builder.WriteString(fmt.Sprintf("  j %s\n", program.EntryLabel))
+	}
+
+	for _, instruction := range program.Instructions {
+		lines, err := c.emitAssemblyInstruction(instruction)
+		if err != nil {
+			return "", err
+		}
+		for _, line := range lines {
+			builder.WriteString(line)
+			builder.WriteByte('\n')
+		}
+	}
+
+	if len(program.Data) > 0 {
+		builder.WriteString("\n.data\n")
+		for _, decl := range program.Data {
+			builder.WriteString(fmt.Sprintf("%s:\n", decl.Label))
+			if decl.Size == 0 {
+				continue
+			}
+			if decl.Init == 0 {
+				builder.WriteString(fmt.Sprintf("  .zero %d\n", decl.Size))
+				continue
+			}
+			values := make([]string, decl.Size)
+			for index := range values {
+				values[index] = fmt.Sprintf("%d", decl.Init&0xFF)
+			}
+			builder.WriteString(fmt.Sprintf("  .byte %s\n", strings.Join(values, ", ")))
+		}
+	}
+
+	return builder.String(), nil
+}
+
+func (c *IrToRiscVCompiler) emitAssemblyInstruction(instruction ir.IrInstruction) ([]string, error) {
+	switch instruction.Opcode {
+	case ir.OpLabel:
+		label, err := labelOperand(instruction, 0)
+		if err != nil {
+			return nil, err
+		}
+		return []string{fmt.Sprintf("%s:", label.Name)}, nil
+	case ir.OpComment:
+		text := ""
+		if len(instruction.Operands) > 0 {
+			text = instruction.Operands[0].String()
+		}
+		return []string{fmt.Sprintf("  # %s", text)}, nil
+	case ir.OpLoadImm:
+		dst, err := physicalRegOperand(instruction, 0)
+		if err != nil {
+			return nil, err
+		}
+		imm, err := immOperand(instruction, 1)
+		if err != nil {
+			return nil, err
+		}
+		return []string{fmt.Sprintf("  li %s, %d", regName(dst), imm.Value)}, nil
+	case ir.OpLoadAddr:
+		dst, err := physicalRegOperand(instruction, 0)
+		if err != nil {
+			return nil, err
+		}
+		label, err := labelOperand(instruction, 1)
+		if err != nil {
+			return nil, err
+		}
+		return []string{fmt.Sprintf("  la %s, %s", regName(dst), label.Name)}, nil
+	case ir.OpLoadByte:
+		return c.emitLoadAssembly(instruction, "lbu")
+	case ir.OpLoadWord:
+		return c.emitLoadAssembly(instruction, "lw")
+	case ir.OpStoreByte:
+		return c.emitStoreAssembly(instruction, "sb")
+	case ir.OpStoreWord:
+		return c.emitStoreAssembly(instruction, "sw")
+	case ir.OpAdd:
+		return emitThreeRegAssembly(instruction, "add")
+	case ir.OpSub:
+		return emitThreeRegAssembly(instruction, "sub")
+	case ir.OpAnd:
+		return emitThreeRegAssembly(instruction, "and")
+	case ir.OpAddImm:
+		return emitRegImmAssembly(instruction, "addi", "add")
+	case ir.OpAndImm:
+		return emitRegImmAssembly(instruction, "andi", "and")
+	case ir.OpCmpEq:
+		return emitCmpEqNeAssembly(instruction, true)
+	case ir.OpCmpNe:
+		return emitCmpEqNeAssembly(instruction, false)
+	case ir.OpCmpLt:
+		return emitThreeRegAssembly(instruction, "slt")
+	case ir.OpCmpGt:
+		dst, left, right, err := threePhysicalRegs(instruction)
+		if err != nil {
+			return nil, err
+		}
+		return []string{fmt.Sprintf("  slt %s, %s, %s", regName(dst), regName(right), regName(left))}, nil
+	case ir.OpJump:
+		label, err := labelOperand(instruction, 0)
+		if err != nil {
+			return nil, err
+		}
+		return []string{fmt.Sprintf("  j %s", label.Name)}, nil
+	case ir.OpBranchZ, ir.OpBranchNz:
+		register, err := physicalRegOperand(instruction, 0)
+		if err != nil {
+			return nil, err
+		}
+		label, err := labelOperand(instruction, 1)
+		if err != nil {
+			return nil, err
+		}
+		opcode := "beq"
+		if instruction.Opcode == ir.OpBranchNz {
+			opcode = "bne"
+		}
+		return []string{fmt.Sprintf("  %s %s, zero, %s", opcode, regName(register), label.Name)}, nil
+	case ir.OpCall:
+		label, err := labelOperand(instruction, 0)
+		if err != nil {
+			return nil, err
+		}
+		return []string{fmt.Sprintf("  call %s", label.Name)}, nil
+	case ir.OpRet:
+		return []string{"  ret"}, nil
+	case ir.OpSyscall:
+		imm, err := immOperand(instruction, 0)
+		if err != nil {
+			return nil, err
+		}
+		return []string{
+			fmt.Sprintf("  li %s, %d", regName(xSyscallNumber), imm.Value),
+			"  ecall",
+		}, nil
+	case ir.OpHalt:
+		return []string{"  halt"}, nil
+	case ir.OpNop:
+		return []string{"  nop"}, nil
+	default:
+		return nil, loweringError(instruction, "unsupported opcode")
+	}
+}
+
+func (c *IrToRiscVCompiler) emitLoadAssembly(instruction ir.IrInstruction, opcode string) ([]string, error) {
+	dst, err := physicalRegOperand(instruction, 0)
+	if err != nil {
+		return nil, err
+	}
+	base, err := physicalRegOperand(instruction, 1)
+	if err != nil {
+		return nil, err
+	}
+	if imm, ok := thirdOperandAsImmediate(instruction); ok {
+		return []string{fmt.Sprintf("  %s %s, %d(%s)", opcode, regName(dst), imm.Value, regName(base))}, nil
+	}
+	offset, err := physicalRegOperand(instruction, 2)
+	if err != nil {
+		return nil, err
+	}
+	return []string{
+		fmt.Sprintf("  add %s, %s, %s", regName(xBackendScratch), regName(base), regName(offset)),
+		fmt.Sprintf("  %s %s, 0(%s)", opcode, regName(dst), regName(xBackendScratch)),
+	}, nil
+}
+
+func (c *IrToRiscVCompiler) emitStoreAssembly(instruction ir.IrInstruction, opcode string) ([]string, error) {
+	src, err := physicalRegOperand(instruction, 0)
+	if err != nil {
+		return nil, err
+	}
+	base, err := physicalRegOperand(instruction, 1)
+	if err != nil {
+		return nil, err
+	}
+	if imm, ok := thirdOperandAsImmediate(instruction); ok {
+		return []string{fmt.Sprintf("  %s %s, %d(%s)", opcode, regName(src), imm.Value, regName(base))}, nil
+	}
+	offset, err := physicalRegOperand(instruction, 2)
+	if err != nil {
+		return nil, err
+	}
+	return []string{
+		fmt.Sprintf("  add %s, %s, %s", regName(xBackendScratch), regName(base), regName(offset)),
+		fmt.Sprintf("  %s %s, 0(%s)", opcode, regName(src), regName(xBackendScratch)),
+	}, nil
+}
+
+func emitThreeRegAssembly(instruction ir.IrInstruction, opcode string) ([]string, error) {
+	dst, left, right, err := threePhysicalRegs(instruction)
+	if err != nil {
+		return nil, err
+	}
+	return []string{fmt.Sprintf("  %s %s, %s, %s", opcode, regName(dst), regName(left), regName(right))}, nil
+}
+
+func emitRegImmAssembly(instruction ir.IrInstruction, immOpcode string, regOpcode string) ([]string, error) {
+	dst, err := physicalRegOperand(instruction, 0)
+	if err != nil {
+		return nil, err
+	}
+	src, err := physicalRegOperand(instruction, 1)
+	if err != nil {
+		return nil, err
+	}
+	imm, err := immOperand(instruction, 2)
+	if err != nil {
+		return nil, err
+	}
+	if fitsSigned(imm.Value, 12) {
+		return []string{fmt.Sprintf("  %s %s, %s, %d", immOpcode, regName(dst), regName(src), imm.Value)}, nil
+	}
+	return []string{
+		fmt.Sprintf("  li %s, %d", regName(xBackendScratch), imm.Value),
+		fmt.Sprintf("  %s %s, %s, %s", regOpcode, regName(dst), regName(src), regName(xBackendScratch)),
+	}, nil
+}
+
+func emitCmpEqNeAssembly(instruction ir.IrInstruction, equal bool) ([]string, error) {
+	dst, left, right, err := threePhysicalRegs(instruction)
+	if err != nil {
+		return nil, err
+	}
+	if equal {
+		return []string{
+			fmt.Sprintf("  xor %s, %s, %s", regName(dst), regName(left), regName(right)),
+			fmt.Sprintf("  sltiu %s, %s, 1", regName(dst), regName(dst)),
+		}, nil
+	}
+	return []string{
+		fmt.Sprintf("  xor %s, %s, %s", regName(dst), regName(left), regName(right)),
+		fmt.Sprintf("  sltu %s, zero, %s", regName(dst), regName(dst)),
+	}, nil
+}
+
+func threePhysicalRegs(instruction ir.IrInstruction) (int, int, int, error) {
+	dst, err := physicalRegOperand(instruction, 0)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	left, err := physicalRegOperand(instruction, 1)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	right, err := physicalRegOperand(instruction, 2)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	return dst, left, right, nil
+}
+
+func regName(index int) string {
+	return fmt.Sprintf("x%d", index)
+}

--- a/code/packages/go/ir-to-riscv-compiler/compiler.go
+++ b/code/packages/go/ir-to-riscv-compiler/compiler.go
@@ -18,6 +18,7 @@ const (
 // MachineCodeResult is the output of lowering IR to a flat RISC-V image.
 type MachineCodeResult struct {
 	Bytes           []byte
+	Assembly        string
 	Instructions    []uint32
 	LabelOffsets    map[string]int
 	DataOffsets     map[string]int
@@ -86,9 +87,14 @@ func (c *IrToRiscVCompiler) Compile(program *ir.IrProgram) (*MachineCodeResult, 
 
 	image := riscv.Assemble(words)
 	image = append(image, dataBytes(program.Data)...)
+	assembly, err := c.emitAssembly(program, plan)
+	if err != nil {
+		return nil, err
+	}
 
 	return &MachineCodeResult{
 		Bytes:           image,
+		Assembly:        assembly,
 		Instructions:    words,
 		LabelOffsets:    plan.labelOffsets,
 		DataOffsets:     plan.dataOffsets,

--- a/code/packages/go/ir-to-riscv-compiler/compiler_test.go
+++ b/code/packages/go/ir-to-riscv-compiler/compiler_test.go
@@ -1,9 +1,12 @@
 package irtoriscvcompiler
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 
 	ir "github.com/adhithyan15/coding-adventures/code/packages/go/compiler-ir"
+	riscvassembler "github.com/adhithyan15/coding-adventures/code/packages/go/riscv-assembler"
 	riscv "github.com/adhithyan15/coding-adventures/code/packages/go/riscv-simulator"
 )
 
@@ -30,6 +33,17 @@ func TestCompileRunsArithmeticOnRiscVSimulator(t *testing.T) {
 	}
 	if offset, length := result.IrToMachineCode.LookupByIrID(3); offset != 8 || length != 4 {
 		t.Fatalf("expected ADD mapping at offset=8 length=4, got offset=%d length=%d", offset, length)
+	}
+	if !strings.Contains(result.Assembly, "add x7, x5, x6") {
+		t.Fatalf("expected assembly to contain lowered add, got:\n%s", result.Assembly)
+	}
+
+	assembled, err := riscvassembler.Assemble(result.Assembly)
+	if err != nil {
+		t.Fatalf("assemble emitted assembly failed: %v\n%s", err, result.Assembly)
+	}
+	if !bytes.Equal(assembled.Bytes, result.Bytes) {
+		t.Fatalf("expected emitted assembly to reassemble to compiler bytes")
 	}
 }
 

--- a/code/packages/go/nib-riscv-compiler/BUILD
+++ b/code/packages/go/nib-riscv-compiler/BUILD
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/nib-riscv-compiler/CHANGELOG.md
+++ b/code/packages/go/nib-riscv-compiler/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add Nib to RISC-V assembly, assembler, and simulator orchestration.

--- a/code/packages/go/nib-riscv-compiler/README.md
+++ b/code/packages/go/nib-riscv-compiler/README.md
@@ -1,0 +1,26 @@
+# nib-riscv-compiler
+
+End-to-end Nib to RISC-V orchestration.
+
+```text
+Nib source
+  -> nib-parser
+  -> nib-type-checker
+  -> nib-ir-compiler
+  -> ir-optimizer
+  -> ir-to-riscv-compiler
+  -> riscv-assembler
+  -> riscv-simulator
+```
+
+`CompileSource` returns the RISC-V assembly string and assembled bytes.
+`RunSource` executes those bytes in `riscv-simulator` and reports the Nib return
+value from physical register `x6`, the RISC-V register currently used for Nib's
+`v1` return slot.
+
+## Current scope
+
+This first path is intended for simple Nib programs whose `main` does not make
+nested function calls. The current starter calling convention uses `ra` directly,
+so a function that calls another function needs stack-frame support before it can
+return reliably.

--- a/code/packages/go/nib-riscv-compiler/compiler.go
+++ b/code/packages/go/nib-riscv-compiler/compiler.go
@@ -1,0 +1,235 @@
+package nibriscvcompiler
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+
+	ir "github.com/adhithyan15/coding-adventures/code/packages/go/compiler-ir"
+	iroptimizer "github.com/adhithyan15/coding-adventures/code/packages/go/ir-optimizer"
+	irtoriscvcompiler "github.com/adhithyan15/coding-adventures/code/packages/go/ir-to-riscv-compiler"
+	nibircompiler "github.com/adhithyan15/coding-adventures/code/packages/go/nib-ir-compiler"
+	nibparser "github.com/adhithyan15/coding-adventures/code/packages/go/nib-parser"
+	nibtypechecker "github.com/adhithyan15/coding-adventures/code/packages/go/nib-type-checker"
+	"github.com/adhithyan15/coding-adventures/code/packages/go/parser"
+	riscvassembler "github.com/adhithyan15/coding-adventures/code/packages/go/riscv-assembler"
+	riscv "github.com/adhithyan15/coding-adventures/code/packages/go/riscv-simulator"
+)
+
+const (
+	DefaultMemorySize       = 65536
+	NibReturnValueRegisterX = 6
+)
+
+type NibRiscVCompilerOptions struct {
+	BuildConfig *nibircompiler.BuildConfig
+	OptimizeIR  *bool
+	MemorySize  int
+}
+
+type PackageResult struct {
+	Source       string
+	AST          *parser.ASTNode
+	TypedAST     *nibtypechecker.TypedAST
+	RawIR        *ir.IrProgram
+	Optimization iroptimizer.OptimizationResult
+	OptimizedIR  *ir.IrProgram
+	MachineCode  *irtoriscvcompiler.MachineCodeResult
+	Assembled    *riscvassembler.AssembleResult
+	Assembly     string
+	Binary       []byte
+	AssemblyPath string
+	BinaryPath   string
+}
+
+type RunResult struct {
+	Package     *PackageResult
+	ReturnValue uint32
+	ExitValue   uint32
+	Halted      bool
+	Steps       int
+}
+
+type PackageError struct {
+	Stage   string
+	Message string
+	Cause   error
+}
+
+func (e *PackageError) Error() string {
+	return e.Message
+}
+
+func (e *PackageError) Unwrap() error {
+	return e.Cause
+}
+
+type NibRiscVCompiler struct {
+	buildConfig *nibircompiler.BuildConfig
+	optimizer   *iroptimizer.IrOptimizer
+	memorySize  int
+}
+
+func NewNibRiscVCompiler(options *NibRiscVCompilerOptions) *NibRiscVCompiler {
+	optimize := true
+	memorySize := DefaultMemorySize
+	var config *nibircompiler.BuildConfig
+	if options != nil {
+		config = options.BuildConfig
+		if options.OptimizeIR != nil {
+			optimize = *options.OptimizeIR
+		}
+		if options.MemorySize > 0 {
+			memorySize = options.MemorySize
+		}
+	}
+
+	optimizer := iroptimizer.DefaultPasses()
+	if !optimize {
+		optimizer = iroptimizer.NoOp()
+	}
+
+	return &NibRiscVCompiler{
+		buildConfig: config,
+		optimizer:   optimizer,
+		memorySize:  memorySize,
+	}
+}
+
+func (c *NibRiscVCompiler) CompileSource(source string) (*PackageResult, error) {
+	ast, err := nibparser.ParseNib(source)
+	if err != nil {
+		return nil, wrapStage("parse", err)
+	}
+
+	typeResult := nibtypechecker.CheckNib(ast)
+	if !typeResult.OK {
+		messages := make([]string, len(typeResult.Errors))
+		for index, diagnostic := range typeResult.Errors {
+			messages[index] = diagnostic.Message
+		}
+		return nil, wrapStage("type-check", errors.New(strings.Join(messages, "\n")))
+	}
+
+	config := nibircompiler.ReleaseConfig()
+	if c.buildConfig != nil {
+		config = *c.buildConfig
+	}
+	irResult := nibircompiler.CompileNib(typeResult.TypedAST, config)
+	rawIR := irResult.Program
+	optimization := c.optimizer.Optimize(rawIR)
+	optimizedIR := optimization.Program
+
+	machineCode, err := irtoriscvcompiler.NewIrToRiscVCompiler().Compile(optimizedIR)
+	if err != nil {
+		return nil, wrapStage("lower-riscv", err)
+	}
+
+	assembled, err := riscvassembler.Assemble(machineCode.Assembly)
+	if err != nil {
+		return nil, wrapStage("assemble-riscv", err)
+	}
+	if !bytes.Equal(assembled.Bytes, machineCode.Bytes) {
+		return nil, wrapStage("assemble-riscv", errors.New("assembler output does not match direct backend bytes"))
+	}
+
+	return &PackageResult{
+		Source:       source,
+		AST:          ast,
+		TypedAST:     typeResult.TypedAST,
+		RawIR:        rawIR,
+		Optimization: optimization,
+		OptimizedIR:  optimizedIR,
+		MachineCode:  machineCode,
+		Assembled:    assembled,
+		Assembly:     machineCode.Assembly,
+		Binary:       assembled.Bytes,
+	}, nil
+}
+
+func (c *NibRiscVCompiler) RunSource(source string) (*RunResult, error) {
+	result, err := c.CompileSource(source)
+	if err != nil {
+		return nil, err
+	}
+
+	sim := riscv.NewRiscVSimulator(c.memorySize)
+	traces := sim.Run(result.Binary)
+
+	return &RunResult{
+		Package:     result,
+		ReturnValue: sim.CPU.Registers.Read(NibReturnValueRegisterX),
+		ExitValue:   sim.CPU.Registers.Read(10),
+		Halted:      sim.CPU.Halted,
+		Steps:       len(traces),
+	}, nil
+}
+
+func (c *NibRiscVCompiler) WriteAssemblyFile(source, outputPath string) (*PackageResult, error) {
+	result, err := c.CompileSource(source)
+	if err != nil {
+		return nil, err
+	}
+	if err := writeFile(outputPath, []byte(result.Assembly)); err != nil {
+		return nil, wrapStage("write", err)
+	}
+	result.AssemblyPath = outputPath
+	return result, nil
+}
+
+func (c *NibRiscVCompiler) WriteBinaryFile(source, outputPath string) (*PackageResult, error) {
+	result, err := c.CompileSource(source)
+	if err != nil {
+		return nil, err
+	}
+	if err := writeFile(outputPath, result.Binary); err != nil {
+		return nil, wrapStage("write", err)
+	}
+	result.BinaryPath = outputPath
+	return result, nil
+}
+
+func CompileSource(source string) (*PackageResult, error) {
+	return NewNibRiscVCompiler(nil).CompileSource(source)
+}
+
+func PackSource(source string) (*PackageResult, error) {
+	return CompileSource(source)
+}
+
+func RunSource(source string) (*RunResult, error) {
+	return NewNibRiscVCompiler(nil).RunSource(source)
+}
+
+func WriteAssemblyFile(source, outputPath string) (*PackageResult, error) {
+	return NewNibRiscVCompiler(nil).WriteAssemblyFile(source, outputPath)
+}
+
+func WriteBinaryFile(source, outputPath string) (*PackageResult, error) {
+	return NewNibRiscVCompiler(nil).WriteBinaryFile(source, outputPath)
+}
+
+func writeFile(outputPath string, data []byte) error {
+	if dir := filepath.Dir(outputPath); dir != "." && dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+	return os.WriteFile(outputPath, data, 0o644)
+}
+
+func wrapStage(stage string, err error) error {
+	if err == nil {
+		return nil
+	}
+	if packageErr, ok := err.(*PackageError); ok {
+		return packageErr
+	}
+	return &PackageError{
+		Stage:   stage,
+		Message: err.Error(),
+		Cause:   err,
+	}
+}

--- a/code/packages/go/nib-riscv-compiler/compiler_test.go
+++ b/code/packages/go/nib-riscv-compiler/compiler_test.go
@@ -1,0 +1,133 @@
+package nibriscvcompiler
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCompileSourceReturnsPipelineArtifacts(t *testing.T) {
+	result, err := CompileSource("fn main() -> u4 { return 7; }")
+	if err != nil {
+		t.Fatalf("compile failed: %v", err)
+	}
+	if result.TypedAST == nil {
+		t.Fatal("expected typed AST")
+	}
+	if len(result.RawIR.Instructions) == 0 {
+		t.Fatal("expected raw IR instructions")
+	}
+	if len(result.OptimizedIR.Instructions) == 0 {
+		t.Fatal("expected optimized IR instructions")
+	}
+	if !strings.Contains(result.Assembly, "_fn_main:") {
+		t.Fatalf("expected assembly to contain main label, got:\n%s", result.Assembly)
+	}
+	if len(result.Binary) == 0 {
+		t.Fatal("expected RISC-V binary bytes")
+	}
+}
+
+func TestPackSourceAliasesCompileSource(t *testing.T) {
+	compiled, err := CompileSource("fn main() -> u4 { return 7; }")
+	if err != nil {
+		t.Fatalf("compile failed: %v", err)
+	}
+	packed, err := PackSource("fn main() -> u4 { return 7; }")
+	if err != nil {
+		t.Fatalf("pack failed: %v", err)
+	}
+	if string(packed.Binary) != string(compiled.Binary) {
+		t.Fatal("expected pack source to match compile source")
+	}
+}
+
+func TestRunSourceExecutesNibOnRiscVSimulator(t *testing.T) {
+	run, err := RunSource("fn main() -> u4 { return 7; }")
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	if !run.Halted {
+		t.Fatal("expected simulator to halt")
+	}
+	if run.ReturnValue != 7 {
+		t.Fatalf("expected return value 7, got %d", run.ReturnValue)
+	}
+}
+
+func TestTypeErrorsReportStage(t *testing.T) {
+	_, err := CompileSource("fn main() { let flag: bool = 1; }")
+	if err == nil {
+		t.Fatal("expected type-check failure")
+	}
+	packageErr, ok := err.(*PackageError)
+	if !ok {
+		t.Fatalf("expected PackageError, got %T", err)
+	}
+	if packageErr.Stage != "type-check" {
+		t.Fatalf("expected type-check stage, got %q", packageErr.Stage)
+	}
+}
+
+func TestParseErrorsReportStage(t *testing.T) {
+	_, err := CompileSource("fn main(")
+	if err == nil {
+		t.Fatal("expected parse failure")
+	}
+	packageErr, ok := err.(*PackageError)
+	if !ok {
+		t.Fatalf("expected PackageError, got %T", err)
+	}
+	if packageErr.Stage != "parse" {
+		t.Fatalf("expected parse stage, got %q", packageErr.Stage)
+	}
+}
+
+func TestWriteAssemblyFileWritesOutput(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), "program.s")
+	result, err := WriteAssemblyFile("fn main() -> u4 { return 7; }", outputPath)
+	if err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	if string(data) != result.Assembly {
+		t.Fatal("written assembly does not match result")
+	}
+}
+
+func TestCompilerOptionsCanDisableOptimization(t *testing.T) {
+	optimize := false
+	result, err := NewNibRiscVCompiler(&NibRiscVCompilerOptions{OptimizeIR: &optimize}).
+		CompileSource("fn main() -> u4 { return 7; }")
+	if err != nil {
+		t.Fatalf("compile failed: %v", err)
+	}
+	if result.Optimization.InstructionsBefore != result.Optimization.InstructionsAfter {
+		t.Fatalf("expected no-op optimizer counts to match, got before=%d after=%d",
+			result.Optimization.InstructionsBefore,
+			result.Optimization.InstructionsAfter)
+	}
+}
+
+func TestPackageErrorPreservesCause(t *testing.T) {
+	cause := errors.New("boom")
+	err := wrapStage("stage", cause)
+	packageErr, ok := err.(*PackageError)
+	if !ok {
+		t.Fatalf("expected PackageError, got %T", err)
+	}
+	if packageErr.Error() != "boom" {
+		t.Fatalf("unexpected error message %q", packageErr.Error())
+	}
+	if !errors.Is(packageErr, cause) {
+		t.Fatal("expected errors.Is to see wrapped cause")
+	}
+	if wrapStage("stage", packageErr) != packageErr {
+		t.Fatal("expected existing package errors to pass through")
+	}
+}

--- a/code/packages/go/nib-riscv-compiler/go.mod
+++ b/code/packages/go/nib-riscv-compiler/go.mod
@@ -1,10 +1,15 @@
-module github.com/adhithyan15/coding-adventures/code/packages/go/ir-to-riscv-compiler
+module github.com/adhithyan15/coding-adventures/code/packages/go/nib-riscv-compiler
 
 go 1.26
 
 require (
 	github.com/adhithyan15/coding-adventures/code/packages/go/compiler-ir v0.0.0
-	github.com/adhithyan15/coding-adventures/code/packages/go/compiler-source-map v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/ir-optimizer v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/ir-to-riscv-compiler v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/nib-ir-compiler v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/nib-parser v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/nib-type-checker v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/parser v0.0.0
 	github.com/adhithyan15/coding-adventures/code/packages/go/riscv-assembler v0.0.0
 	github.com/adhithyan15/coding-adventures/code/packages/go/riscv-simulator v0.0.0
 )
@@ -13,12 +18,17 @@ require (
 	github.com/adhithyan15/coding-adventures/code/packages/go/branch-predictor v0.0.0 // indirect
 	github.com/adhithyan15/coding-adventures/code/packages/go/cache v0.0.0 // indirect
 	github.com/adhithyan15/coding-adventures/code/packages/go/clock v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/compiler-source-map v0.0.0 // indirect
 	github.com/adhithyan15/coding-adventures/code/packages/go/core v0.0.0 // indirect
 	github.com/adhithyan15/coding-adventures/code/packages/go/cpu-pipeline v0.0.0 // indirect
 	github.com/adhithyan15/coding-adventures/code/packages/go/cpu-simulator v0.0.0 // indirect
 	github.com/adhithyan15/coding-adventures/code/packages/go/directed-graph v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/grammar-tools v0.0.0 // indirect
 	github.com/adhithyan15/coding-adventures/code/packages/go/hazard-detection v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/lexer v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/nib-lexer v0.0.0 // indirect
 	github.com/adhithyan15/coding-adventures/code/packages/go/state-machine v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/type-checker-protocol v0.0.0 // indirect
 )
 
 replace (
@@ -31,8 +41,18 @@ replace (
 	github.com/adhithyan15/coding-adventures/code/packages/go/cpu-pipeline => ../cpu-pipeline
 	github.com/adhithyan15/coding-adventures/code/packages/go/cpu-simulator => ../cpu-simulator
 	github.com/adhithyan15/coding-adventures/code/packages/go/directed-graph => ../directed-graph
+	github.com/adhithyan15/coding-adventures/code/packages/go/grammar-tools => ../grammar-tools
 	github.com/adhithyan15/coding-adventures/code/packages/go/hazard-detection => ../hazard-detection
+	github.com/adhithyan15/coding-adventures/code/packages/go/ir-optimizer => ../ir-optimizer
+	github.com/adhithyan15/coding-adventures/code/packages/go/ir-to-riscv-compiler => ../ir-to-riscv-compiler
+	github.com/adhithyan15/coding-adventures/code/packages/go/lexer => ../lexer
+	github.com/adhithyan15/coding-adventures/code/packages/go/nib-ir-compiler => ../nib-ir-compiler
+	github.com/adhithyan15/coding-adventures/code/packages/go/nib-lexer => ../nib-lexer
+	github.com/adhithyan15/coding-adventures/code/packages/go/nib-parser => ../nib-parser
+	github.com/adhithyan15/coding-adventures/code/packages/go/nib-type-checker => ../nib-type-checker
+	github.com/adhithyan15/coding-adventures/code/packages/go/parser => ../parser
 	github.com/adhithyan15/coding-adventures/code/packages/go/riscv-assembler => ../riscv-assembler
 	github.com/adhithyan15/coding-adventures/code/packages/go/riscv-simulator => ../riscv-simulator
 	github.com/adhithyan15/coding-adventures/code/packages/go/state-machine => ../state-machine
+	github.com/adhithyan15/coding-adventures/code/packages/go/type-checker-protocol => ../type-checker-protocol
 )

--- a/code/packages/go/nib-riscv-compiler/required_capabilities.json
+++ b/code/packages/go/nib-riscv-compiler/required_capabilities.json
@@ -1,0 +1,3 @@
+{
+  "capabilities": []
+}

--- a/code/packages/go/riscv-assembler/BUILD
+++ b/code/packages/go/riscv-assembler/BUILD
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/riscv-assembler/CHANGELOG.md
+++ b/code/packages/go/riscv-assembler/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add RV32I assembler with labels, data directives, and compiler-friendly
+  pseudo-instructions.

--- a/code/packages/go/riscv-assembler/README.md
+++ b/code/packages/go/riscv-assembler/README.md
@@ -1,0 +1,29 @@
+# riscv-assembler
+
+Assembles a small, compiler-friendly RV32I assembly syntax into bytes for
+`riscv-simulator`.
+
+## Supported input
+
+- RV32I integer instructions implemented by `riscv-simulator`
+- CSR instructions: `csrrw`, `csrrs`, `csrrc`, `mret`
+- Labels and `.text` / `.data` sections
+- Data directives: `.byte`, `.word`, `.zero`, `.space`
+- Pseudo-instructions used by compiler output: `li`, `la`, `mv`, `j`, `call`,
+  `ret`, `nop`, `halt`
+
+## Example
+
+```go
+result, err := riscvassembler.Assemble(`
+_start:
+  li a0, 42
+  halt
+`)
+if err != nil {
+    panic(err)
+}
+
+sim := riscvsimulator.NewRiscVSimulator(4096)
+sim.Run(result.Bytes)
+```

--- a/code/packages/go/riscv-assembler/assembler.go
+++ b/code/packages/go/riscv-assembler/assembler.go
@@ -864,12 +864,9 @@ func parseNumber(operand string) (int, bool, error) {
 	if start == len(text) || !(unicode.IsDigit(rune(text[start]))) {
 		return 0, false, nil
 	}
-	value, err := strconv.ParseInt(text, 0, 64)
+	value, err := strconv.ParseInt(text, 0, strconv.IntSize)
 	if err != nil {
 		return 0, true, err
-	}
-	if value < minIntValue || value > maxIntValue {
-		return 0, true, fmt.Errorf("integer literal %q is outside int range", text)
 	}
 	return int(value), true, nil
 }
@@ -960,8 +957,3 @@ var registerNames = map[string]int{
 	"s2": 18, "s3": 19, "s4": 20, "s5": 21, "s6": 22, "s7": 23, "s8": 24, "s9": 25, "s10": 26, "s11": 27,
 	"t3": 28, "t4": 29, "t5": 30, "t6": 31,
 }
-
-const (
-	maxIntValue = int64(1<<(strconv.IntSize-1) - 1)
-	minIntValue = -maxIntValue - 1
-)

--- a/code/packages/go/riscv-assembler/assembler.go
+++ b/code/packages/go/riscv-assembler/assembler.go
@@ -868,6 +868,9 @@ func parseNumber(operand string) (int, bool, error) {
 	if err != nil {
 		return 0, true, err
 	}
+	if value < minIntValue || value > maxIntValue {
+		return 0, true, fmt.Errorf("integer literal %q is outside int range", text)
+	}
 	return int(value), true, nil
 }
 
@@ -957,3 +960,8 @@ var registerNames = map[string]int{
 	"s2": 18, "s3": 19, "s4": 20, "s5": 21, "s6": 22, "s7": 23, "s8": 24, "s9": 25, "s10": 26, "s11": 27,
 	"t3": 28, "t4": 29, "t5": 30, "t6": 31,
 }
+
+const (
+	maxIntValue = int64(1<<(strconv.IntSize-1) - 1)
+	minIntValue = -maxIntValue - 1
+)

--- a/code/packages/go/riscv-assembler/assembler.go
+++ b/code/packages/go/riscv-assembler/assembler.go
@@ -1,0 +1,959 @@
+package riscvassembler
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+
+	riscv "github.com/adhithyan15/coding-adventures/code/packages/go/riscv-simulator"
+)
+
+type AssembleResult struct {
+	Bytes        []byte
+	Instructions []uint32
+	Data         []byte
+	LabelOffsets map[string]int
+	DataOffsets  map[string]int
+	TextSize     int
+}
+
+type AssemblyError struct {
+	Line    int
+	Message string
+}
+
+func (e *AssemblyError) Error() string {
+	if e.Line > 0 {
+		return fmt.Sprintf("line %d: %s", e.Line, e.Message)
+	}
+	return e.Message
+}
+
+type Assembler struct{}
+
+func NewAssembler() *Assembler {
+	return &Assembler{}
+}
+
+func Assemble(source string) (*AssembleResult, error) {
+	return NewAssembler().Assemble(source)
+}
+
+type segment int
+
+const (
+	segmentText segment = iota
+	segmentData
+)
+
+type sourceItem struct {
+	lineNo     int
+	segment    segment
+	opcode     string
+	operands   []string
+	textOffset int
+	dataOffset int
+}
+
+type labelDef struct {
+	segment segment
+	offset  int
+}
+
+type assemblyPlan struct {
+	items    []sourceItem
+	labels   map[string]labelDef
+	textSize int
+	dataSize int
+}
+
+func (a *Assembler) Assemble(source string) (*AssembleResult, error) {
+	plan, err := a.plan(source)
+	if err != nil {
+		return nil, err
+	}
+
+	textLabels := map[string]int{}
+	dataLabels := map[string]int{}
+	allLabels := map[string]int{}
+	for name, def := range plan.labels {
+		offset := def.offset
+		if def.segment == segmentData {
+			offset = plan.textSize + def.offset
+			dataLabels[name] = offset
+		} else {
+			textLabels[name] = offset
+		}
+		allLabels[name] = offset
+	}
+
+	words := []uint32{}
+	data := []byte{}
+	for _, item := range plan.items {
+		if item.segment == segmentData {
+			emitted, err := emitData(item, allLabels)
+			if err != nil {
+				return nil, err
+			}
+			data = append(data, emitted...)
+			continue
+		}
+		emitted, err := encodeInstruction(item, allLabels)
+		if err != nil {
+			return nil, err
+		}
+		words = append(words, emitted...)
+	}
+
+	textBytes := riscv.Assemble(words)
+	image := append([]byte{}, textBytes...)
+	image = append(image, data...)
+
+	return &AssembleResult{
+		Bytes:        image,
+		Instructions: words,
+		Data:         data,
+		LabelOffsets: textLabels,
+		DataOffsets:  dataLabels,
+		TextSize:     plan.textSize,
+	}, nil
+}
+
+func (a *Assembler) plan(source string) (*assemblyPlan, error) {
+	current := segmentText
+	textOffset := 0
+	dataOffset := 0
+	labels := map[string]labelDef{}
+	items := []sourceItem{}
+
+	for index, raw := range strings.Split(source, "\n") {
+		lineNo := index + 1
+		line := stripComment(raw)
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		for {
+			label, rest, ok := splitLeadingLabel(line)
+			if !ok {
+				break
+			}
+			if _, exists := labels[label]; exists {
+				return nil, lineError(lineNo, "duplicate label %q", label)
+			}
+			offset := textOffset
+			if current == segmentData {
+				offset = dataOffset
+			}
+			labels[label] = labelDef{segment: current, offset: offset}
+			line = strings.TrimSpace(rest)
+			if line == "" {
+				break
+			}
+		}
+		if line == "" {
+			continue
+		}
+
+		opcode, operands := splitOpcodeAndOperands(line)
+		opcode = strings.ToLower(opcode)
+		item := sourceItem{
+			lineNo:     lineNo,
+			segment:    current,
+			opcode:     opcode,
+			operands:   operands,
+			textOffset: textOffset,
+			dataOffset: dataOffset,
+		}
+
+		if strings.HasPrefix(opcode, ".") {
+			switch opcode {
+			case ".text":
+				current = segmentText
+				continue
+			case ".data":
+				current = segmentData
+				continue
+			case ".globl", ".global":
+				continue
+			}
+			if current != segmentData {
+				return nil, lineError(lineNo, "directive %s is only supported in .data", opcode)
+			}
+			size, err := dataDirectiveSize(item)
+			if err != nil {
+				return nil, err
+			}
+			item.segment = segmentData
+			item.dataOffset = dataOffset
+			items = append(items, item)
+			dataOffset += size
+			continue
+		}
+
+		if current != segmentText {
+			return nil, lineError(lineNo, "instruction %s is only supported in .text", opcode)
+		}
+		size, err := instructionSize(item)
+		if err != nil {
+			return nil, err
+		}
+		item.textOffset = textOffset
+		items = append(items, item)
+		textOffset += size * 4
+	}
+
+	return &assemblyPlan{
+		items:    items,
+		labels:   labels,
+		textSize: textOffset,
+		dataSize: dataOffset,
+	}, nil
+}
+
+func stripComment(line string) string {
+	cut := len(line)
+	for _, marker := range []string{";", "#", "//"} {
+		if index := strings.Index(line, marker); index >= 0 && index < cut {
+			cut = index
+		}
+	}
+	return line[:cut]
+}
+
+func splitLeadingLabel(line string) (string, string, bool) {
+	colon := strings.Index(line, ":")
+	if colon < 0 {
+		return "", line, false
+	}
+	candidate := strings.TrimSpace(line[:colon])
+	if !isIdentifier(candidate) {
+		return "", line, false
+	}
+	return candidate, line[colon+1:], true
+}
+
+func splitOpcodeAndOperands(line string) (string, []string) {
+	line = strings.TrimSpace(line)
+	for index, r := range line {
+		if unicode.IsSpace(r) {
+			opcode := line[:index]
+			rest := strings.TrimSpace(line[index:])
+			return opcode, splitOperands(rest)
+		}
+	}
+	return line, nil
+}
+
+func splitOperands(rest string) []string {
+	if rest == "" {
+		return nil
+	}
+	parts := strings.Split(rest, ",")
+	operands := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			operands = append(operands, trimmed)
+		}
+	}
+	return operands
+}
+
+func isIdentifier(value string) bool {
+	if value == "" {
+		return false
+	}
+	for index, r := range value {
+		if index == 0 {
+			if !(unicode.IsLetter(r) || r == '_' || r == '.') {
+				return false
+			}
+			continue
+		}
+		if !(unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '.' || r == '$') {
+			return false
+		}
+	}
+	return true
+}
+
+func instructionSize(item sourceItem) (int, error) {
+	switch item.opcode {
+	case "li":
+		if err := requireOperands(item, 2); err != nil {
+			return 0, err
+		}
+		imm, err := parseNumberOperand(item, item.operands[1])
+		if err != nil {
+			return 0, err
+		}
+		return loadConstSize(imm), nil
+	case "la":
+		if err := requireOperands(item, 2); err != nil {
+			return 0, err
+		}
+		return 2, nil
+	case "halt":
+		if err := requireOperands(item, 0); err != nil {
+			return 0, err
+		}
+		return 2, nil
+	case "mv", "j", "call", "ret", "nop",
+		"add", "sub", "sll", "slt", "sltu", "xor", "srl", "sra", "or", "and",
+		"addi", "slti", "sltiu", "xori", "ori", "andi", "slli", "srli", "srai",
+		"lb", "lh", "lw", "lbu", "lhu",
+		"sb", "sh", "sw",
+		"beq", "bne", "blt", "bge", "bltu", "bgeu",
+		"jal", "jalr", "lui", "auipc", "ecall", "mret", "csrrw", "csrrs", "csrrc":
+		return 1, nil
+	default:
+		return 0, lineError(item.lineNo, "unsupported instruction %q", item.opcode)
+	}
+}
+
+func dataDirectiveSize(item sourceItem) (int, error) {
+	switch item.opcode {
+	case ".byte":
+		if len(item.operands) == 0 {
+			return 0, lineError(item.lineNo, ".byte requires at least one value")
+		}
+		return len(item.operands), nil
+	case ".word":
+		if len(item.operands) == 0 {
+			return 0, lineError(item.lineNo, ".word requires at least one value")
+		}
+		return len(item.operands) * 4, nil
+	case ".zero", ".space":
+		if err := requireOperands(item, 1); err != nil {
+			return 0, err
+		}
+		size, err := parseNumberOperand(item, item.operands[0])
+		if err != nil {
+			return 0, err
+		}
+		if size < 0 {
+			return 0, lineError(item.lineNo, "%s size must be non-negative", item.opcode)
+		}
+		return size, nil
+	default:
+		return 0, lineError(item.lineNo, "unsupported directive %q", item.opcode)
+	}
+}
+
+func encodeInstruction(item sourceItem, labels map[string]int) ([]uint32, error) {
+	switch item.opcode {
+	case "li":
+		if err := requireOperands(item, 2); err != nil {
+			return nil, err
+		}
+		rd, err := parseRegisterOperand(item, item.operands[0])
+		if err != nil {
+			return nil, err
+		}
+		imm, err := parseNumberOperand(item, item.operands[1])
+		if err != nil {
+			return nil, err
+		}
+		return emitLoadConst(rd, imm), nil
+	case "la":
+		if err := requireOperands(item, 2); err != nil {
+			return nil, err
+		}
+		rd, err := parseRegisterOperand(item, item.operands[0])
+		if err != nil {
+			return nil, err
+		}
+		address, err := parseLabelOperand(item, item.operands[1], labels)
+		if err != nil {
+			return nil, err
+		}
+		return emitLoadAddress(rd, address), nil
+	case "mv":
+		if err := requireOperands(item, 2); err != nil {
+			return nil, err
+		}
+		rd, rs, err := parseTwoRegs(item)
+		if err != nil {
+			return nil, err
+		}
+		return []uint32{riscv.EncodeAddi(rd, rs, 0)}, nil
+	case "j":
+		if err := requireOperands(item, 1); err != nil {
+			return nil, err
+		}
+		offset, err := branchTargetOffset(item, item.operands[0], labels, 21)
+		if err != nil {
+			return nil, err
+		}
+		return []uint32{riscv.EncodeJal(0, offset)}, nil
+	case "call":
+		if err := requireOperands(item, 1); err != nil {
+			return nil, err
+		}
+		offset, err := branchTargetOffset(item, item.operands[0], labels, 21)
+		if err != nil {
+			return nil, err
+		}
+		return []uint32{riscv.EncodeJal(1, offset)}, nil
+	case "ret":
+		if err := requireOperands(item, 0); err != nil {
+			return nil, err
+		}
+		return []uint32{riscv.EncodeJalr(0, 1, 0)}, nil
+	case "nop":
+		if err := requireOperands(item, 0); err != nil {
+			return nil, err
+		}
+		return []uint32{riscv.EncodeAddi(0, 0, 0)}, nil
+	case "halt":
+		if err := requireOperands(item, 0); err != nil {
+			return nil, err
+		}
+		return []uint32{riscv.EncodeAddi(17, 0, 10), riscv.EncodeEcall()}, nil
+	case "add":
+		return encodeThreeReg(item, riscv.EncodeAdd)
+	case "sub":
+		return encodeThreeReg(item, riscv.EncodeSub)
+	case "sll":
+		return encodeThreeReg(item, riscv.EncodeSll)
+	case "slt":
+		return encodeThreeReg(item, riscv.EncodeSlt)
+	case "sltu":
+		return encodeThreeReg(item, riscv.EncodeSltu)
+	case "xor":
+		return encodeThreeReg(item, riscv.EncodeXor)
+	case "srl":
+		return encodeThreeReg(item, riscv.EncodeSrl)
+	case "sra":
+		return encodeThreeReg(item, riscv.EncodeSra)
+	case "or":
+		return encodeThreeReg(item, riscv.EncodeOr)
+	case "and":
+		return encodeThreeReg(item, riscv.EncodeAnd)
+	case "addi":
+		return encodeRegImm(item, riscv.EncodeAddi)
+	case "slti":
+		return encodeRegImm(item, riscv.EncodeSlti)
+	case "sltiu":
+		return encodeRegImm(item, riscv.EncodeSltiu)
+	case "xori":
+		return encodeRegImm(item, riscv.EncodeXori)
+	case "ori":
+		return encodeRegImm(item, riscv.EncodeOri)
+	case "andi":
+		return encodeRegImm(item, riscv.EncodeAndi)
+	case "slli":
+		return encodeShiftImm(item, riscv.EncodeSlli)
+	case "srli":
+		return encodeShiftImm(item, riscv.EncodeSrli)
+	case "srai":
+		return encodeShiftImm(item, riscv.EncodeSrai)
+	case "lb":
+		return encodeLoad(item, riscv.EncodeLb)
+	case "lh":
+		return encodeLoad(item, riscv.EncodeLh)
+	case "lw":
+		return encodeLoad(item, riscv.EncodeLw)
+	case "lbu":
+		return encodeLoad(item, riscv.EncodeLbu)
+	case "lhu":
+		return encodeLoad(item, riscv.EncodeLhu)
+	case "sb":
+		return encodeStore(item, riscv.EncodeSb)
+	case "sh":
+		return encodeStore(item, riscv.EncodeSh)
+	case "sw":
+		return encodeStore(item, riscv.EncodeSw)
+	case "beq":
+		return encodeBranch(item, labels, riscv.EncodeBeq)
+	case "bne":
+		return encodeBranch(item, labels, riscv.EncodeBne)
+	case "blt":
+		return encodeBranch(item, labels, riscv.EncodeBlt)
+	case "bge":
+		return encodeBranch(item, labels, riscv.EncodeBge)
+	case "bltu":
+		return encodeBranch(item, labels, riscv.EncodeBltu)
+	case "bgeu":
+		return encodeBranch(item, labels, riscv.EncodeBgeu)
+	case "jal":
+		return encodeJal(item, labels)
+	case "jalr":
+		return encodeJalr(item)
+	case "lui":
+		return encodeUpper(item, riscv.EncodeLui)
+	case "auipc":
+		return encodeUpper(item, riscv.EncodeAuipc)
+	case "ecall":
+		if err := requireOperands(item, 0); err != nil {
+			return nil, err
+		}
+		return []uint32{riscv.EncodeEcall()}, nil
+	case "mret":
+		if err := requireOperands(item, 0); err != nil {
+			return nil, err
+		}
+		return []uint32{riscv.EncodeMret()}, nil
+	case "csrrw":
+		return encodeCSR(item, riscv.EncodeCsrrw)
+	case "csrrs":
+		return encodeCSR(item, riscv.EncodeCsrrs)
+	case "csrrc":
+		return encodeCSR(item, riscv.EncodeCsrrc)
+	default:
+		return nil, lineError(item.lineNo, "unsupported instruction %q", item.opcode)
+	}
+}
+
+func encodeThreeReg(item sourceItem, encode func(rd, rs1, rs2 int) uint32) ([]uint32, error) {
+	if err := requireOperands(item, 3); err != nil {
+		return nil, err
+	}
+	rd, rs1, rs2, err := parseThreeRegs(item)
+	if err != nil {
+		return nil, err
+	}
+	return []uint32{encode(rd, rs1, rs2)}, nil
+}
+
+func encodeRegImm(item sourceItem, encode func(rd, rs1, imm int) uint32) ([]uint32, error) {
+	if err := requireOperands(item, 3); err != nil {
+		return nil, err
+	}
+	rd, rs1, err := parseTwoRegs(item)
+	if err != nil {
+		return nil, err
+	}
+	imm, err := parseNumberOperand(item, item.operands[2])
+	if err != nil {
+		return nil, err
+	}
+	if !fitsSigned(imm, 12) {
+		return nil, lineError(item.lineNo, "immediate %d is outside signed 12-bit range", imm)
+	}
+	return []uint32{encode(rd, rs1, imm)}, nil
+}
+
+func encodeShiftImm(item sourceItem, encode func(rd, rs1, imm int) uint32) ([]uint32, error) {
+	if err := requireOperands(item, 3); err != nil {
+		return nil, err
+	}
+	rd, rs1, err := parseTwoRegs(item)
+	if err != nil {
+		return nil, err
+	}
+	shamt, err := parseNumberOperand(item, item.operands[2])
+	if err != nil {
+		return nil, err
+	}
+	if shamt < 0 || shamt > 31 {
+		return nil, lineError(item.lineNo, "shift amount %d is outside 0..31", shamt)
+	}
+	return []uint32{encode(rd, rs1, shamt)}, nil
+}
+
+func encodeLoad(item sourceItem, encode func(rd, rs1, imm int) uint32) ([]uint32, error) {
+	if err := requireOperands(item, 2); err != nil {
+		return nil, err
+	}
+	rd, err := parseRegisterOperand(item, item.operands[0])
+	if err != nil {
+		return nil, err
+	}
+	imm, rs1, err := parseMemoryOperand(item, item.operands[1])
+	if err != nil {
+		return nil, err
+	}
+	return []uint32{encode(rd, rs1, imm)}, nil
+}
+
+func encodeStore(item sourceItem, encode func(rs2, rs1, imm int) uint32) ([]uint32, error) {
+	if err := requireOperands(item, 2); err != nil {
+		return nil, err
+	}
+	rs2, err := parseRegisterOperand(item, item.operands[0])
+	if err != nil {
+		return nil, err
+	}
+	imm, rs1, err := parseMemoryOperand(item, item.operands[1])
+	if err != nil {
+		return nil, err
+	}
+	return []uint32{encode(rs2, rs1, imm)}, nil
+}
+
+func encodeBranch(item sourceItem, labels map[string]int, encode func(rs1, rs2, offset int) uint32) ([]uint32, error) {
+	if err := requireOperands(item, 3); err != nil {
+		return nil, err
+	}
+	rs1, rs2, err := parseTwoRegs(item)
+	if err != nil {
+		return nil, err
+	}
+	offset, err := branchTargetOffset(item, item.operands[2], labels, 13)
+	if err != nil {
+		return nil, err
+	}
+	return []uint32{encode(rs1, rs2, offset)}, nil
+}
+
+func encodeJal(item sourceItem, labels map[string]int) ([]uint32, error) {
+	if len(item.operands) != 1 && len(item.operands) != 2 {
+		return nil, lineError(item.lineNo, "jal expects 1 or 2 operands")
+	}
+	rd := 1
+	target := item.operands[0]
+	if len(item.operands) == 2 {
+		parsed, err := parseRegisterOperand(item, item.operands[0])
+		if err != nil {
+			return nil, err
+		}
+		rd = parsed
+		target = item.operands[1]
+	}
+	offset, err := branchTargetOffset(item, target, labels, 21)
+	if err != nil {
+		return nil, err
+	}
+	return []uint32{riscv.EncodeJal(rd, offset)}, nil
+}
+
+func encodeJalr(item sourceItem) ([]uint32, error) {
+	if len(item.operands) == 2 {
+		rd, err := parseRegisterOperand(item, item.operands[0])
+		if err != nil {
+			return nil, err
+		}
+		imm, rs1, err := parseMemoryOperand(item, item.operands[1])
+		if err != nil {
+			return nil, err
+		}
+		return []uint32{riscv.EncodeJalr(rd, rs1, imm)}, nil
+	}
+	if err := requireOperands(item, 3); err != nil {
+		return nil, err
+	}
+	rd, rs1, err := parseTwoRegs(item)
+	if err != nil {
+		return nil, err
+	}
+	imm, err := parseNumberOperand(item, item.operands[2])
+	if err != nil {
+		return nil, err
+	}
+	if !fitsSigned(imm, 12) {
+		return nil, lineError(item.lineNo, "jalr immediate %d is outside signed 12-bit range", imm)
+	}
+	return []uint32{riscv.EncodeJalr(rd, rs1, imm)}, nil
+}
+
+func encodeUpper(item sourceItem, encode func(rd, imm int) uint32) ([]uint32, error) {
+	if err := requireOperands(item, 2); err != nil {
+		return nil, err
+	}
+	rd, err := parseRegisterOperand(item, item.operands[0])
+	if err != nil {
+		return nil, err
+	}
+	imm, err := parseNumberOperand(item, item.operands[1])
+	if err != nil {
+		return nil, err
+	}
+	if !fitsSigned(imm, 32) {
+		return nil, lineError(item.lineNo, "upper immediate %d is outside 32-bit range", imm)
+	}
+	return []uint32{encode(rd, imm)}, nil
+}
+
+func encodeCSR(item sourceItem, encode func(rd, csr, rs1 int) uint32) ([]uint32, error) {
+	if err := requireOperands(item, 3); err != nil {
+		return nil, err
+	}
+	rd, err := parseRegisterOperand(item, item.operands[0])
+	if err != nil {
+		return nil, err
+	}
+	csr, err := parseCSR(item, item.operands[1])
+	if err != nil {
+		return nil, err
+	}
+	rs1, err := parseRegisterOperand(item, item.operands[2])
+	if err != nil {
+		return nil, err
+	}
+	return []uint32{encode(rd, csr, rs1)}, nil
+}
+
+func emitData(item sourceItem, labels map[string]int) ([]byte, error) {
+	out := []byte{}
+	switch item.opcode {
+	case ".byte":
+		for _, operand := range item.operands {
+			value, err := parseImmediateOrLabel(item, operand, labels)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, byte(value&0xFF))
+		}
+	case ".word":
+		for _, operand := range item.operands {
+			value, err := parseImmediateOrLabel(item, operand, labels)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, byte(value&0xFF), byte((value>>8)&0xFF), byte((value>>16)&0xFF), byte((value>>24)&0xFF))
+		}
+	case ".zero", ".space":
+		size, err := parseNumberOperand(item, item.operands[0])
+		if err != nil {
+			return nil, err
+		}
+		out = make([]byte, size)
+	default:
+		return nil, lineError(item.lineNo, "unsupported directive %q", item.opcode)
+	}
+	return out, nil
+}
+
+func parseThreeRegs(item sourceItem) (int, int, int, error) {
+	rd, err := parseRegisterOperand(item, item.operands[0])
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	rs1, err := parseRegisterOperand(item, item.operands[1])
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	rs2, err := parseRegisterOperand(item, item.operands[2])
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	return rd, rs1, rs2, nil
+}
+
+func parseTwoRegs(item sourceItem) (int, int, error) {
+	first, err := parseRegisterOperand(item, item.operands[0])
+	if err != nil {
+		return 0, 0, err
+	}
+	second, err := parseRegisterOperand(item, item.operands[1])
+	if err != nil {
+		return 0, 0, err
+	}
+	return first, second, nil
+}
+
+func parseRegisterOperand(item sourceItem, operand string) (int, error) {
+	reg, ok := registerNames[strings.ToLower(strings.TrimSpace(operand))]
+	if !ok {
+		return 0, lineError(item.lineNo, "unknown register %q", operand)
+	}
+	return reg, nil
+}
+
+func parseMemoryOperand(item sourceItem, operand string) (int, int, error) {
+	open := strings.Index(operand, "(")
+	close := strings.LastIndex(operand, ")")
+	if open < 0 || close != len(operand)-1 || close < open {
+		return 0, 0, lineError(item.lineNo, "memory operand %q must look like imm(reg)", operand)
+	}
+	immText := strings.TrimSpace(operand[:open])
+	baseText := strings.TrimSpace(operand[open+1 : close])
+	imm := 0
+	if immText != "" {
+		parsed, err := parseNumberOperand(item, immText)
+		if err != nil {
+			return 0, 0, err
+		}
+		imm = parsed
+	}
+	if !fitsSigned(imm, 12) {
+		return 0, 0, lineError(item.lineNo, "memory immediate %d is outside signed 12-bit range", imm)
+	}
+	base, err := parseRegisterOperand(item, baseText)
+	if err != nil {
+		return 0, 0, err
+	}
+	return imm, base, nil
+}
+
+func branchTargetOffset(item sourceItem, operand string, labels map[string]int, bits int) (int, error) {
+	if value, ok, err := parseNumber(operand); err != nil {
+		return 0, lineError(item.lineNo, "invalid immediate %q", operand)
+	} else if ok {
+		if err := validateRelativeOffset(item, value, bits); err != nil {
+			return 0, err
+		}
+		return value, nil
+	}
+
+	target, err := parseLabelOperand(item, operand, labels)
+	if err != nil {
+		return 0, err
+	}
+	offset := target - item.textOffset
+	if err := validateRelativeOffset(item, offset, bits); err != nil {
+		return 0, err
+	}
+	return offset, nil
+}
+
+func validateRelativeOffset(item sourceItem, offset int, bits int) error {
+	if offset%2 != 0 {
+		return lineError(item.lineNo, "relative offset %d is not 2-byte aligned", offset)
+	}
+	if !fitsSigned(offset, bits) {
+		return lineError(item.lineNo, "relative offset %d is outside signed %d-bit range", offset, bits)
+	}
+	return nil
+}
+
+func parseLabelOperand(item sourceItem, operand string, labels map[string]int) (int, error) {
+	label := strings.TrimSpace(operand)
+	value, ok := labels[label]
+	if !ok {
+		return 0, lineError(item.lineNo, "unknown label %q", operand)
+	}
+	return value, nil
+}
+
+func parseImmediateOrLabel(item sourceItem, operand string, labels map[string]int) (int, error) {
+	if value, ok, err := parseNumber(operand); err != nil {
+		return 0, lineError(item.lineNo, "invalid immediate %q", operand)
+	} else if ok {
+		return value, nil
+	}
+	return parseLabelOperand(item, operand, labels)
+}
+
+func parseNumberOperand(item sourceItem, operand string) (int, error) {
+	value, ok, err := parseNumber(operand)
+	if err != nil {
+		return 0, lineError(item.lineNo, "invalid immediate %q", operand)
+	}
+	if !ok {
+		return 0, lineError(item.lineNo, "expected numeric immediate, got %q", operand)
+	}
+	return value, nil
+}
+
+func parseNumber(operand string) (int, bool, error) {
+	text := strings.TrimSpace(operand)
+	if text == "" {
+		return 0, false, nil
+	}
+	if strings.HasPrefix(text, "'") && strings.HasSuffix(text, "'") && len(text) >= 3 {
+		unquoted, err := strconv.Unquote(text)
+		if err != nil {
+			return 0, true, err
+		}
+		runes := []rune(unquoted)
+		if len(runes) != 1 {
+			return 0, true, fmt.Errorf("character literal must contain one rune")
+		}
+		return int(runes[0]), true, nil
+	}
+
+	start := 0
+	if text[0] == '-' || text[0] == '+' {
+		start = 1
+	}
+	if start == len(text) || !(unicode.IsDigit(rune(text[start]))) {
+		return 0, false, nil
+	}
+	value, err := strconv.ParseInt(text, 0, 64)
+	if err != nil {
+		return 0, true, err
+	}
+	return int(value), true, nil
+}
+
+func parseCSR(item sourceItem, operand string) (int, error) {
+	switch strings.ToLower(strings.TrimSpace(operand)) {
+	case "mstatus":
+		return riscv.CSRMstatus, nil
+	case "mtvec":
+		return riscv.CSRMtvec, nil
+	case "mscratch":
+		return riscv.CSRMscratch, nil
+	case "mepc":
+		return riscv.CSRMepc, nil
+	case "mcause":
+		return riscv.CSRMcause, nil
+	default:
+		return parseNumberOperand(item, operand)
+	}
+}
+
+func emitLoadConst(rd int, value int) []uint32 {
+	if fitsSigned(value, 12) {
+		return []uint32{riscv.EncodeAddi(rd, 0, value)}
+	}
+	upper, lower := splitUpperLower(value)
+	words := []uint32{riscv.EncodeLui(rd, upper)}
+	if lower != 0 {
+		words = append(words, riscv.EncodeAddi(rd, rd, lower))
+	}
+	return words
+}
+
+func emitLoadAddress(rd int, address int) []uint32 {
+	upper, lower := splitUpperLower(address)
+	return []uint32{
+		riscv.EncodeLui(rd, upper),
+		riscv.EncodeAddi(rd, rd, lower),
+	}
+}
+
+func loadConstSize(value int) int {
+	if fitsSigned(value, 12) {
+		return 1
+	}
+	_, lower := splitUpperLower(value)
+	if lower == 0 {
+		return 1
+	}
+	return 2
+}
+
+func splitUpperLower(value int) (upper, lower int) {
+	upper = (value + 0x800) >> 12
+	lower = value - (upper << 12)
+	return upper, lower
+}
+
+func fitsSigned(value, bits int) bool {
+	min := -(1 << (bits - 1))
+	max := (1 << (bits - 1)) - 1
+	return value >= min && value <= max
+}
+
+func requireOperands(item sourceItem, count int) error {
+	if len(item.operands) != count {
+		return lineError(item.lineNo, "%s expects %d operands, got %d", item.opcode, count, len(item.operands))
+	}
+	return nil
+}
+
+func lineError(line int, format string, args ...any) error {
+	return &AssemblyError{
+		Line:    line,
+		Message: fmt.Sprintf(format, args...),
+	}
+}
+
+var registerNames = map[string]int{
+	"x0": 0, "x1": 1, "x2": 2, "x3": 3, "x4": 4, "x5": 5, "x6": 6, "x7": 7,
+	"x8": 8, "x9": 9, "x10": 10, "x11": 11, "x12": 12, "x13": 13, "x14": 14, "x15": 15,
+	"x16": 16, "x17": 17, "x18": 18, "x19": 19, "x20": 20, "x21": 21, "x22": 22, "x23": 23,
+	"x24": 24, "x25": 25, "x26": 26, "x27": 27, "x28": 28, "x29": 29, "x30": 30, "x31": 31,
+
+	"zero": 0, "ra": 1, "sp": 2, "gp": 3, "tp": 4,
+	"t0": 5, "t1": 6, "t2": 7, "s0": 8, "fp": 8, "s1": 9,
+	"a0": 10, "a1": 11, "a2": 12, "a3": 13, "a4": 14, "a5": 15, "a6": 16, "a7": 17,
+	"s2": 18, "s3": 19, "s4": 20, "s5": 21, "s6": 22, "s7": 23, "s8": 24, "s9": 25, "s10": 26, "s11": 27,
+	"t3": 28, "t4": 29, "t5": 30, "t6": 31,
+}

--- a/code/packages/go/riscv-assembler/assembler_test.go
+++ b/code/packages/go/riscv-assembler/assembler_test.go
@@ -1,0 +1,89 @@
+package riscvassembler
+
+import (
+	"testing"
+
+	riscv "github.com/adhithyan15/coding-adventures/code/packages/go/riscv-simulator"
+)
+
+func TestAssembleRunsProgramOnSimulator(t *testing.T) {
+	result, err := Assemble(`
+.text
+_start:
+  li a0, 40
+  addi a0, a0, 2
+  halt
+`)
+	if err != nil {
+		t.Fatalf("assemble failed: %v", err)
+	}
+
+	sim := riscv.NewRiscVSimulator(4096)
+	sim.Run(result.Bytes)
+
+	if got := sim.CPU.Registers.Read(10); got != 42 {
+		t.Fatalf("expected a0 to contain 42, got %d", got)
+	}
+	if result.LabelOffsets["_start"] != 0 {
+		t.Fatalf("expected _start at 0, got %d", result.LabelOffsets["_start"])
+	}
+}
+
+func TestAssembleResolvesLabelsAndData(t *testing.T) {
+	result, err := Assemble(`
+.text
+_start:
+  la t0, value
+  lbu a0, 0(t0)
+  j done
+  li a0, 99
+done:
+  halt
+
+.data
+value:
+  .byte 65
+  .zero 3
+`)
+	if err != nil {
+		t.Fatalf("assemble failed: %v", err)
+	}
+
+	sim := riscv.NewRiscVSimulator(4096)
+	sim.Run(result.Bytes)
+
+	if got := sim.CPU.Registers.Read(10); got != 65 {
+		t.Fatalf("expected a0 to load data byte 65, got %d", got)
+	}
+	if got := result.DataOffsets["value"]; got != result.TextSize {
+		t.Fatalf("expected value at text size %d, got %d", result.TextSize, got)
+	}
+}
+
+func TestAssembleBackwardBranch(t *testing.T) {
+	result, err := Assemble(`
+_start:
+  li t0, 3
+loop:
+  addi t0, t0, -1
+  bne t0, zero, loop
+  halt
+`)
+	if err != nil {
+		t.Fatalf("assemble failed: %v", err)
+	}
+
+	sim := riscv.NewRiscVSimulator(4096)
+	sim.Run(result.Bytes)
+
+	if got := sim.CPU.Registers.Read(5); got != 0 {
+		t.Fatalf("expected t0 to count down to 0, got %d", got)
+	}
+}
+
+func TestAssembleRejectsUnknownLabel(t *testing.T) {
+	_, err := Assemble("j missing")
+	if err == nil {
+		t.Fatal("expected unknown label error")
+	}
+}

--- a/code/packages/go/riscv-assembler/go.mod
+++ b/code/packages/go/riscv-assembler/go.mod
@@ -1,13 +1,8 @@
-module github.com/adhithyan15/coding-adventures/code/packages/go/ir-to-riscv-compiler
+module github.com/adhithyan15/coding-adventures/code/packages/go/riscv-assembler
 
 go 1.26
 
-require (
-	github.com/adhithyan15/coding-adventures/code/packages/go/compiler-ir v0.0.0
-	github.com/adhithyan15/coding-adventures/code/packages/go/compiler-source-map v0.0.0
-	github.com/adhithyan15/coding-adventures/code/packages/go/riscv-assembler v0.0.0
-	github.com/adhithyan15/coding-adventures/code/packages/go/riscv-simulator v0.0.0
-)
+require github.com/adhithyan15/coding-adventures/code/packages/go/riscv-simulator v0.0.0
 
 require (
 	github.com/adhithyan15/coding-adventures/code/packages/go/branch-predictor v0.0.0 // indirect
@@ -25,14 +20,11 @@ replace (
 	github.com/adhithyan15/coding-adventures/code/packages/go/branch-predictor => ../branch-predictor
 	github.com/adhithyan15/coding-adventures/code/packages/go/cache => ../cache
 	github.com/adhithyan15/coding-adventures/code/packages/go/clock => ../clock
-	github.com/adhithyan15/coding-adventures/code/packages/go/compiler-ir => ../compiler-ir
-	github.com/adhithyan15/coding-adventures/code/packages/go/compiler-source-map => ../compiler-source-map
 	github.com/adhithyan15/coding-adventures/code/packages/go/core => ../core
 	github.com/adhithyan15/coding-adventures/code/packages/go/cpu-pipeline => ../cpu-pipeline
 	github.com/adhithyan15/coding-adventures/code/packages/go/cpu-simulator => ../cpu-simulator
 	github.com/adhithyan15/coding-adventures/code/packages/go/directed-graph => ../directed-graph
 	github.com/adhithyan15/coding-adventures/code/packages/go/hazard-detection => ../hazard-detection
-	github.com/adhithyan15/coding-adventures/code/packages/go/riscv-assembler => ../riscv-assembler
 	github.com/adhithyan15/coding-adventures/code/packages/go/riscv-simulator => ../riscv-simulator
 	github.com/adhithyan15/coding-adventures/code/packages/go/state-machine => ../state-machine
 )

--- a/code/packages/go/riscv-assembler/required_capabilities.json
+++ b/code/packages/go/riscv-assembler/required_capabilities.json
@@ -1,0 +1,3 @@
+{
+  "capabilities": []
+}

--- a/code/specs/RV01-riscv-compiler-roadmap.md
+++ b/code/specs/RV01-riscv-compiler-roadmap.md
@@ -1,0 +1,55 @@
+# RV01 RISC-V Compiler Roadmap
+
+## Current RISC-V path
+
+The Go toolchain now has the core pieces for a direct RISC-V path:
+
+```text
+source language
+  -> language frontend
+  -> compiler-ir
+  -> ir-to-riscv-compiler
+  -> riscv-assembler
+  -> riscv-simulator
+```
+
+`ir-to-riscv-compiler` emits both human-readable RV32I assembly and machine-code
+bytes. `riscv-assembler` assembles the text form into the byte image loaded by
+`riscv-simulator`.
+
+## Language readiness
+
+| Language | Current status | To run directly on RISC-V |
+|----------|----------------|---------------------------|
+| Nib | Go parser, type checker, IR compiler, and `nib-riscv-compiler` package exist. Simple `main` programs can lower to assembly and VM bytes. | Add stack-frame support so nested calls/recursion preserve `ra`; extend static variable reads if needed; add ABI tests for arguments/returns. |
+| Brainfuck | Go parser and `brainfuck-ir-compiler` already emit `compiler-ir` compatible with the RISC-V backend. | Add `brainfuck-riscv-compiler` orchestration; implement VM syscall/host handling for `.` and `,`, or limit first tests to non-I/O memory programs. |
+| Dartmouth BASIC | Go lexer/parser exist. Python has `dartmouth-basic-ir-compiler`, GE-225, WASM, and JVM-oriented pipelines. | Port or bridge the Python IR compiler to Go `compiler-ir`; add `MUL`/`DIV` to Go `compiler-ir` and the RISC-V backend or lower them to helper loops; implement PRINT syscalls/trap host output in the RISC-V VM. |
+| Oct | Python has lexer/parser/type-checker/IR compiler for the Intel 8008 pipeline. | Port or bridge Oct typed AST/IR into Go; add Go `compiler-ir` opcodes used by Oct but not yet present here (`OR`, `XOR`, `NOT`, and any target-specific syscall shapes); add RISC-V syscall host behavior for `in`, `out`, carry/parity/rotate intrinsics; add stack-frame support for nested calls. |
+| Starlark | Go compiler targets the Starlark VM bytecode, not `compiler-ir`. | Add a Starlark-to-`compiler-ir` lowerer or a direct RISC-V backend for its bytecode. |
+| Mosaic | Go analyzer produces Mosaic-specific IR for UI/component emitters. | Add a Mosaic-to-`compiler-ir` lowering only if there is a meaningful native runtime target; otherwise it is not a natural RISC-V candidate. |
+| Parser-only languages | Many languages currently have lexers/parsers only. | Add semantic analysis plus a `compiler-ir` lowering before the common RISC-V backend can be reused. |
+
+## Backend gaps
+
+- Calling convention: current IR-to-RISC-V uses a starter fixed register mapping
+  and raw `ra`. This works for a single `_start -> main` call but not for
+  functions that call other functions.
+- Stack and frames: needed for nested calls, recursion, spilled virtual
+  registers, and local storage beyond the fixed physical-register map.
+- Syscalls: `riscv-simulator` treats `ecall` as halt when no trap handler is
+  installed. Language I/O needs a small host syscall layer or a standard trap
+  handler convention.
+- IR parity: Python-side languages already use extended IR ideas such as
+  multiplication, division, OR, XOR, and NOT. The Go `compiler-ir` and RISC-V
+  backend need those opcodes or canonical lowering passes.
+- Runtime ABI: each frontend needs a documented result/argument convention. Nib
+  currently returns through virtual `v1`, which maps to RISC-V `x6`.
+
+## Suggested sequence
+
+1. Stabilize Nib simple-program E2E tests.
+2. Add RISC-V stack-frame support for `CALL`/`RET`.
+3. Add a Brainfuck RISC-V orchestration package for a second Go frontend.
+4. Add a host syscall layer to `riscv-simulator`.
+5. Port/bridge Dartmouth BASIC IR to Go and add `MUL`/`DIV`.
+6. Port/bridge Oct IR to Go and add the remaining bitwise/syscall ABI support.


### PR DESCRIPTION
## Summary
- add readable RISC-V assembly output to the IR -> RISC-V compiler
- add a reusable `riscv-assembler` package for RV32I text assembly, labels, data directives, and compiler-friendly pseudos
- add `nib-riscv-compiler` for Nib -> IR -> RISC-V assembly -> assembler bytes -> simulator orchestration
- document the readiness/gaps for Nib, Brainfuck, Dartmouth BASIC, Oct, and other language families on the RISC-V path

## Tests
- `go test -c -o /tmp/riscv-assembler.test` in `code/packages/go/riscv-assembler`
- `go test -c -o /tmp/ir-to-riscv-compiler.test` in `code/packages/go/ir-to-riscv-compiler`
- `go test -c -o /tmp/nib-riscv-compiler.test` in `code/packages/go/nib-riscv-compiler`

Note: full `go test` execution currently hangs launching Go test binaries in this local macOS session, even for a trivial temporary Go module, so I verified compilation with `go test -c` and left runtime tests in place for CI/normal local runs.