### PR TITLE
test(state-machine): prove generated Rust modules execute

### DIFF
--- a/code/packages/rust/state-machine-source-compiler/CHANGELOG.md
+++ b/code/packages/rust/state-machine-source-compiler/CHANGELOG.md
@@ -8,3 +8,6 @@
 - Added deterministic Rust output for DFA, NFA, and PDA definition modules.
 - Added snapshot and error-path tests covering generated helpers, escaping,
   semantic validation, and unsupported kinds.
+- Added end-to-end generated-code tests that compile temporary Rust wrapper
+  crates and exercise generated DFA, NFA, and PDA constructors when the local
+  Rust toolchain can execute freshly built binaries.

--- a/code/packages/rust/state-machine-source-compiler/README.md
+++ b/code/packages/rust/state-machine-source-compiler/README.md
@@ -29,6 +29,21 @@ assert!(source.contains("pub fn turnstile_definition()"));
 The generated source contains table data and constructors only. It does not
 perform file IO, dynamic evaluation, network access, or format parsing.
 
+## End-To-End Rust Proof
+
+The test suite also proves the Rust path as linked code:
+
+```text
+StateMachineDefinition
+        -> generated Rust module
+        -> temporary wrapper crate
+        -> cargo test
+        -> executable DFA/NFA/PDA behavior
+```
+
+Those temporary crates live only in tests. The public compiler API still returns
+source text and does not read or write files.
+
 ## Fit In The Stack
 
 ```text

--- a/code/packages/rust/state-machine-source-compiler/tests/rust_end_to_end_test.rs
+++ b/code/packages/rust/state-machine-source-compiler/tests/rust_end_to_end_test.rs
@@ -1,0 +1,309 @@
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use state_machine::{PDATransition, PushdownAutomaton, DFA, EPSILON, NFA};
+use state_machine_source_compiler::to_rust_source;
+
+fn set(values: &[&str]) -> HashSet<String> {
+    values.iter().map(|value| value.to_string()).collect()
+}
+
+#[test]
+fn generated_rust_modules_compile_and_execute_dfa_nfa_and_pda() -> io::Result<()> {
+    if !tool_runs("cargo", &["--version"])? || !tool_runs("rustc", &["--version"])? {
+        eprintln!("skipping generated Rust e2e test because cargo or rustc is not runnable");
+        return Ok(());
+    }
+    if !fresh_rust_binary_runs()? {
+        eprintln!(
+            "skipping generated Rust e2e test because freshly built Rust binaries do not run"
+        );
+        return Ok(());
+    }
+
+    let root = temp_project_dir("state-machine-generated-rust-e2e")?;
+    let result = (|| {
+        write_generated_crate(&root)?;
+        let status = run_with_timeout(
+            Command::new("cargo")
+                .arg("test")
+                .arg("--quiet")
+                .current_dir(&root),
+            Duration::from_secs(120),
+        )?;
+        assert!(
+            status.success,
+            "generated Rust crate tests failed\nstdout:\n{}\nstderr:\n{}",
+            status.stdout, status.stderr
+        );
+        Ok(())
+    })();
+    let _ = fs::remove_dir_all(&root);
+    result
+}
+
+fn write_generated_crate(root: &Path) -> io::Result<()> {
+    fs::create_dir_all(root.join("src"))?;
+    fs::create_dir_all(root.join("tests"))?;
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let state_machine_path = manifest_dir
+        .parent()
+        .expect("compiler crate should live beside state-machine")
+        .join("state-machine");
+
+    fs::write(
+        root.join("Cargo.toml"),
+        format!(
+            "[package]\nname = \"generated-state-machine-e2e\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\nstate-machine = {{ path = {} }}\n",
+            toml_string(&state_machine_path)
+        ),
+    )?;
+    fs::write(root.join("src/lib.rs"), generated_library_source(root)?)?;
+    fs::write(root.join("tests/generated_behavior.rs"), behavior_tests())?;
+    Ok(())
+}
+
+fn generated_library_source(root: &Path) -> io::Result<String> {
+    let mut source = String::new();
+    source.push_str("pub mod turnstile;\n");
+    source.push_str("pub mod contains_ab;\n");
+    source.push_str("pub mod balanced_parens;\n");
+    let src_dir = root.join("src");
+
+    let modules = [
+        ("turnstile", turnstile_source()?),
+        ("contains_ab", contains_ab_source()?),
+        ("balanced_parens", balanced_parens_source()?),
+    ];
+    for (module, module_source) in modules {
+        source.push_str("pub use ");
+        source.push_str(module);
+        source.push_str("::*;\n");
+        fs::write(src_dir.join(format!("{module}.rs")), module_source)?;
+    }
+    Ok(source)
+}
+
+fn turnstile_source() -> io::Result<String> {
+    let dfa = DFA::new(
+        set(&["locked", "unlocked"]),
+        set(&["coin", "push"]),
+        HashMap::from([
+            (
+                ("locked".to_string(), "coin".to_string()),
+                "unlocked".to_string(),
+            ),
+            (
+                ("locked".to_string(), "push".to_string()),
+                "locked".to_string(),
+            ),
+            (
+                ("unlocked".to_string(), "coin".to_string()),
+                "unlocked".to_string(),
+            ),
+            (
+                ("unlocked".to_string(), "push".to_string()),
+                "locked".to_string(),
+            ),
+        ]),
+        "locked".to_string(),
+        set(&["unlocked"]),
+    )
+    .map_err(io::Error::other)?;
+    to_rust_source(&dfa.to_definition("turnstile")).map_err(io::Error::other)
+}
+
+fn contains_ab_source() -> io::Result<String> {
+    let nfa = NFA::new(
+        set(&["q0", "q1", "q2"]),
+        set(&["a", "b"]),
+        HashMap::from([
+            (("q0".to_string(), "a".to_string()), set(&["q0", "q1"])),
+            (("q0".to_string(), "b".to_string()), set(&["q0"])),
+            (("q1".to_string(), "b".to_string()), set(&["q2"])),
+            (("q2".to_string(), EPSILON.to_string()), set(&["q2"])),
+        ]),
+        "q0".to_string(),
+        set(&["q2"]),
+    )
+    .map_err(io::Error::other)?;
+    to_rust_source(&nfa.to_definition("contains-ab")).map_err(io::Error::other)
+}
+
+fn balanced_parens_source() -> io::Result<String> {
+    let pda = PushdownAutomaton::new(
+        set(&["scan", "accept"]),
+        set(&["(", ")"]),
+        set(&["$", "("]),
+        vec![
+            PDATransition {
+                source: "scan".to_string(),
+                event: Some("(".to_string()),
+                stack_read: "$".to_string(),
+                target: "scan".to_string(),
+                stack_push: vec!["$".to_string(), "(".to_string()],
+            },
+            PDATransition {
+                source: "scan".to_string(),
+                event: Some("(".to_string()),
+                stack_read: "(".to_string(),
+                target: "scan".to_string(),
+                stack_push: vec!["(".to_string(), "(".to_string()],
+            },
+            PDATransition {
+                source: "scan".to_string(),
+                event: Some(")".to_string()),
+                stack_read: "(".to_string(),
+                target: "scan".to_string(),
+                stack_push: Vec::new(),
+            },
+            PDATransition {
+                source: "scan".to_string(),
+                event: None,
+                stack_read: "$".to_string(),
+                target: "accept".to_string(),
+                stack_push: vec!["$".to_string()],
+            },
+        ],
+        "scan".to_string(),
+        "$".to_string(),
+        set(&["accept"]),
+    )
+    .map_err(io::Error::other)?;
+    to_rust_source(&pda.to_definition("balanced-parens")).map_err(io::Error::other)
+}
+
+fn behavior_tests() -> &'static str {
+    r#"use generated_state_machine_e2e::{
+    balanced_parens_pda, contains_ab_nfa, turnstile_dfa,
+};
+
+#[test]
+fn generated_dfa_accepts_turnstile_sequences() {
+    let dfa = turnstile_dfa().expect("generated DFA should import");
+    assert!(dfa.accepts(&["coin"]));
+    assert!(dfa.accepts(&["coin", "coin"]));
+    assert!(!dfa.accepts(&["push"]));
+    assert!(!dfa.accepts(&["coin", "push"]));
+}
+
+#[test]
+fn generated_nfa_accepts_contains_ab_language() {
+    let nfa = contains_ab_nfa().expect("generated NFA should import");
+    assert!(nfa.accepts(&["a", "b"]));
+    assert!(nfa.accepts(&["b", "a", "b"]));
+    assert!(!nfa.accepts(&["a", "a"]));
+    assert!(!nfa.accepts(&["b", "b"]));
+}
+
+#[test]
+fn generated_pda_accepts_balanced_parentheses() {
+    let pda = balanced_parens_pda().expect("generated PDA should import");
+    assert!(pda.accepts(&["(", ")"]));
+    assert!(pda.accepts(&["(", "(", ")", ")"]));
+    assert!(!pda.accepts(&["("]));
+    assert!(!pda.accepts(&[")"]));
+}
+"#
+}
+
+fn fresh_rust_binary_runs() -> io::Result<bool> {
+    let root = temp_project_dir("state-machine-rust-probe")?;
+    let source = root.join("main.rs");
+    let binary = root.join(if cfg!(windows) { "probe.exe" } else { "probe" });
+    let result = (|| {
+        fs::write(&source, "fn main() { println!(\"probe-ok\"); }\n")?;
+        let compile = run_with_timeout(
+            Command::new("rustc").arg(&source).arg("-o").arg(&binary),
+            Duration::from_secs(30),
+        )?;
+        if !compile.success {
+            return Ok(false);
+        }
+        let run = run_with_timeout(&mut Command::new(&binary), Duration::from_secs(10))?;
+        Ok(run.success && run.stdout.contains("probe-ok"))
+    })();
+    let _ = fs::remove_dir_all(&root);
+    result
+}
+
+fn temp_project_dir(prefix: &str) -> io::Result<PathBuf> {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(io::Error::other)?
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("{prefix}-{}-{nanos}", std::process::id()));
+    fs::create_dir_all(&path)?;
+    Ok(path)
+}
+
+fn tool_runs(program: &str, args: &[&str]) -> io::Result<bool> {
+    let status = run_with_timeout(
+        Command::new(program)
+            .args(args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped()),
+        Duration::from_secs(10),
+    )?;
+    Ok(status.success)
+}
+
+fn run_with_timeout(command: &mut Command, timeout: Duration) -> io::Result<CommandResult> {
+    let mut child = command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    let started = Instant::now();
+    loop {
+        if child.try_wait()?.is_some() {
+            let output = child.wait_with_output()?;
+            return Ok(CommandResult {
+                success: output.status.success(),
+                stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+                stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            });
+        }
+        if started.elapsed() >= timeout {
+            let _ = child.kill();
+            let output = child.wait_with_output()?;
+            return Ok(CommandResult {
+                success: false,
+                stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+                stderr: format!(
+                    "{}\nprocess timed out after {} seconds",
+                    String::from_utf8_lossy(&output.stderr),
+                    timeout.as_secs()
+                ),
+            });
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+}
+
+struct CommandResult {
+    success: bool,
+    stdout: String,
+    stderr: String,
+}
+
+fn toml_string(path: &Path) -> String {
+    let mut out = String::from("\"");
+    for ch in path.to_string_lossy().chars() {
+        match ch {
+            '\\' => out.push('/'),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            ch => out.push(ch),
+        }
+    }
+    out.push('"');
+    out
+}

--- a/code/specs/F09-state-machine-source-compiler.md
+++ b/code/specs/F09-state-machine-source-compiler.md
@@ -185,6 +185,22 @@ Other languages should preserve the same structure in idiomatic form:
 The generated source must not contain file reads, dynamic eval, arbitrary code
 execution, or network access.
 
+Rust end-to-end completion means the compiler test suite proves this full
+build-time chain:
+
+```text
+manual DFA/NFA/PDA
+  -> StateMachineDefinition
+  -> generated Rust module
+  -> temporary Rust wrapper crate
+  -> cargo test executes the generated constructors
+  -> executable automata accept/reject expected inputs
+```
+
+The generated module itself still contains only typed table data and
+constructors. Test harnesses may write temporary crates to prove linkability,
+but the source compiler API remains file-format and file-system agnostic.
+
 ## Manual Machine Export Layer
 
 The state-machine libraries also need to export manually constructed machines
@@ -331,6 +347,7 @@ The compiler should warn about:
 - canonical TOML snapshot tests
 - canonical JSON snapshot tests once JSON export exists
 - generated Rust source snapshot tests
+- generated Rust compile-and-run tests for DFA, NFA, and PDA behavior
 - generated Go source snapshot tests
 - compile-and-run tests for generated simple machines
 - tokenizer profile tests before attempting full HTML


### PR DESCRIPTION
## Summary
- Defines Rust end-to-end completion in `F09` as `StateMachineDefinition -> generated Rust module -> temporary wrapper crate -> cargo test -> executable DFA/NFA/PDA behavior`.
- Adds an end-to-end generated-code test that writes generated DFA/NFA/PDA modules into a temporary Rust crate and verifies their generated constructors execute against real acceptance/rejection cases.
- Adds a fresh-Rust-binary probe and command timeouts so hosts that cannot execute freshly built test binaries skip the generated-crate execution path rather than hanging indefinitely.

## Verification
- `cargo fmt -p state-machine-source-compiler --check`
- `cargo build -p state-machine-source-compiler`
- `cargo test -p state-machine-source-compiler --no-run`
- `cargo clippy -p state-machine-source-compiler --no-deps -- -D warnings`
- `git diff --check origin/main...HEAD`
- Manual security review: no new file IO, process execution, network calls, dynamic eval, or `unsafe` in the compiler library. New filesystem/process usage is test-only, bounded to temporary crates and timed child processes.

## Local execution note
Full `cargo test` still cannot complete on this macOS host because freshly built Rust test binaries hang before reaching `main`; the new e2e test includes a probe to skip generated-crate execution on such hosts, while CI should exercise it normally on healthy runners.