### PR TITLE
feat(aot-core): add ahead-of-time compilation engine — LANG04

### DIFF
--- a/code/packages/python/aot-core/BUILD
+++ b/code/packages/python/aot-core/BUILD
@@ -1,0 +1,3 @@
+uv venv --quiet --clear
+uv pip install -e ../interpreter-ir -e ../vm-core -e ../jit-core -e ".[dev]" --quiet
+python3.12 -m pytest tests/ -v --cov=aot_core --cov-report=term-missing

--- a/code/packages/python/aot-core/BUILD
+++ b/code/packages/python/aot-core/BUILD
@@ -1,3 +1,3 @@
 uv venv --quiet --clear
 uv pip install -e ../interpreter-ir -e ../vm-core -e ../jit-core -e ".[dev]" --quiet
-python3.12 -m pytest tests/ -v --cov=aot_core --cov-report=term-missing
+.venv/bin/python -m pytest tests/ -v --cov=aot_core --cov-report=term-missing

--- a/code/packages/python/aot-core/CHANGELOG.md
+++ b/code/packages/python/aot-core/CHANGELOG.md
@@ -1,0 +1,68 @@
+# Changelog — coding-adventures-aot-core
+
+All notable changes to this package are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+---
+
+## [0.1.0] — 2026-04-22
+
+### Added
+
+**Static type inference (`aot_core.infer`)**
+- `_literal_type(value)` — maps Python literals to LANG types (`bool`, `u8`–`u64`, `f64`, `str`, `any`).
+- `_promote(a, b)` — numeric rank promotion; `any` dominates; non-numeric combinations resolve to `any`; `str + str → any` (handled separately in `_infer_instr`).
+- `_resolve(src, env)` — resolves a source operand (literal or register name) to its inferred type.
+- `infer_types(fn)` — flow-insensitive single-pass inference over an `IIRFunction`; seeds the type environment from parameter declarations, then infers each instruction's destination type from its sources and opcode semantics.  Supports: `const`, arithmetic (`add`, `sub`, `mul`, `div`, `mod`), bitwise (`and`, `or`, `xor`, `shl`, `shr`), comparison (`cmp_lt`, `cmp_le`, `cmp_gt`, `cmp_ge`, `cmp_eq`, `cmp_ne`), and unary (`neg`, `not`) families.  Unknown opcodes produce `"any"`.
+
+**AOT specialization (`aot_core.specialise`)**
+- `_spec_type(instr, inferred)` — selects the concrete type for an instruction: explicit `type_hint` wins, else consults the inferred-type dict, else falls back to `"any"`.
+- `aot_specialise(fn, inferred?)` — lowers an `IIRFunction` to a flat `list[CIRInstr]` using the inferred-type map produced by `infer_types`.  Mirrors the structure of `jit_core.specialise` but driven by static inference rather than profiler observations.  Handles:
+  - `const` → `const_<type>` (picks type from literal when hint is absent)
+  - `ret` → `ret_<type>`; `ret_void` is passed through unchanged
+  - Arithmetic/bitwise/comparison: typed variant (e.g. `add_u8`, `cmp_lt_bool`) for known types, `call_runtime("generic_*")` for `"any"`; `str + str` emits `call_runtime("str_concat")`
+  - Unary: typed variant or `call_runtime("generic_*")` fallback
+  - `type_assert` guard emission when inferred type is known but source register is `"any"`
+  - Passthrough opcodes: `jmp`, `jmp_if_false`, `label`, `call`, `store_mem`, and any unrecognised opcode
+
+**`.aot` snapshot binary format (`aot_core.snapshot`)**
+- 26-byte header: `magic="AOT\x00"` (4 B), `version=0x0100` (2 B), `flags` (4 B), `entry_point_offset` (4 B), `vm_iir_table_offset` (4 B), `vm_iir_table_size` (4 B), `native_code_size` (4 B).
+- `FLAG_VM_RUNTIME = 0x01` — set when the snapshot contains an IIR table for the VM interpreter path.
+- `write(native_code, iir_table?, entry_point_offset?)` — serialises to bytes.
+- `read(data)` — deserialises; raises `ValueError` on truncated input, bad magic, or out-of-bounds sections.
+- `AOTSnapshot` dataclass with `has_vm_runtime` property.
+
+**Binary linker (`aot_core.link`)**
+- `link(fn_binaries)` — concatenates per-function native-code blobs, returning `(combined_code, byte_offset_map)`.
+- `entry_point_offset(offsets, entry="main")` — looks up `"main"` (or a caller-supplied name) in the offset map; returns 0 if not found.
+
+**VM runtime container (`aot_core.vm_runtime`)**
+- `VmRuntime(library_bytes?)` — wraps a pre-compiled interpreter library blob.
+- `serialise_iir_table(fns)` — encodes a list of `IIRFunction` objects as a JSON byte string; records `name`, `params`, `return_type`, `instructions` (with `op`, `dest`, `srcs`, `type_hint`, `observed_type`, `observation_count`, `deopt_anchor`), and `type_status`.
+- `deserialise_iir_table(data)` — inverse of the above.
+
+**AOT compilation controller (`aot_core.core`)**
+- `AOTCore(backend, optimization_level=1, vm_runtime?)` — orchestrates the full ahead-of-time pipeline.
+- `compile(module)` — for each function: `infer_types` → `aot_specialise` → optional constant-folding/DCE → `backend.compile`.  Functions for which the backend returns `None` (or raises) are routed to the IIR table for VM-fallback execution.  Writes a `.aot` snapshot, appending `vm_runtime.library_bytes` when an IIR table is present.
+- `compile_to_file(module, path)` — convenience wrapper that calls `compile` and writes the resulting bytes to disk.
+- `stats()` — returns an `AOTStats` snapshot capturing `functions_compiled`, `functions_untyped`, `total_binary_size`, `compilation_time_ns`, and `optimization_level`; accumulates across multiple `compile` calls and returns an independent copy each time.
+- `_compile_fn(fn)` — per-function pipeline step; returns `None` on any exception so the caller can fall back to the IIR table.
+- `_is_fully_typed(fn, inferred)` — returns `True` iff every instruction destination in the function is resolved to a concrete (non-`"any"`) type.
+- Optimization levels: 0 = no optimizations; 1 = constant folding + dead-code elimination (via `ir_optimizer`); 2 = same as 1 (reserved for future AOT-specific passes).
+
+**Compilation statistics (`aot_core.stats`)**
+- `AOTStats` dataclass: `functions_compiled`, `functions_untyped`, `compilation_time_ns`, `total_binary_size`, `optimization_level`.
+
+**Package surface (`aot_core.__init__`)**
+- Public exports: `AOTCore`, `AOTStats`, `AOTSnapshot`, `VmRuntime`, `infer_types`, `aot_specialise`.
+
+### Tests
+
+- 164 unit tests across 7 test modules; **100% line coverage**.
+- `tests/conftest.py` — shared helpers: `make_instr`, `make_fn`, `make_mod`, `make_cir`, `MockAOTBackend`.
+- `tests/test_infer.py` — 48 tests covering `_literal_type`, `_promote`, `_resolve`, and `infer_types` (const, arithmetic, promotion, comparison, unary, multi-instruction chains, typed hints).
+- `tests/test_specialise.py` — 37 tests covering `_spec_type`, const translation, `ret` translation, binary/unary ops (typed, inferred, generic, guard emission), passthrough ops, and fallback.
+- `tests/test_snapshot.py` — 20 tests covering write/read round-trips, header format, error handling, and `AOTSnapshot` properties.
+- `tests/test_link.py` — tests covering `link` and `entry_point_offset` for empty, single, and multiple function binaries.
+- `tests/test_vm_runtime.py` — tests covering `VmRuntime` construction, IIR table serialisation/deserialisation for functions with params, instructions, type status, and deopt anchors.
+- `tests/test_core.py` — integration tests for the full compile pipeline, untyped-function IIR routing, backend-failure fallback, optimization levels 0/1/2, `compile_to_file`, stats accumulation, and `_is_fully_typed`.

--- a/code/packages/python/aot-core/README.md
+++ b/code/packages/python/aot-core/README.md
@@ -1,0 +1,109 @@
+# aot-core
+
+Ahead-of-time compilation path for the LANG pipeline (LANG04).
+
+`aot-core` compiles an entire `IIRModule` to a self-contained `.aot` binary
+*before* any user runs the program.  Where `jit-core` (LANG03) compiles hot
+functions at runtime after observing their behaviour, `aot-core` compiles
+everything statically using type inference — no runtime feedback required.
+
+## Architecture
+
+```
+IIRModule (bytecode)
+    │
+    ├── infer_types(fn)          → env: dict[str, str]
+    │   (static Hindley-Milner-style, flow-insensitive)
+    │
+    ├── aot_specialise(fn, env)  → list[CIRInstr]
+    │   (same structure as jit-core's specialise; uses inferred types)
+    │
+    ├── optimizer.run(cir)       → list[CIRInstr]
+    │   (constant folding + DCE, reused from jit-core)
+    │
+    ├── backend.compile(cir)     → bytes | None
+    │   (architecture-neutral BackendProtocol from jit-core)
+    │
+    ├── link(fn_binaries)        → (native_code, offsets)
+    │
+    └── snapshot.write(...)      → .aot binary
+```
+
+## The `.aot` binary format
+
+```
+Header (26 bytes):
+  4 bytes  magic             "AOT\0"
+  2 bytes  version           0x01 0x00
+  4 bytes  flags             bit 0: IIR table present
+  4 bytes  entry_point_offset
+  4 bytes  vm_iir_table_offset
+  4 bytes  vm_iir_table_size
+  4 bytes  native_code_size
+
+Code section:
+  N bytes  native machine code (compiled functions concatenated)
+
+IIR table section (optional):
+  M bytes  JSON-encoded IIR for functions that could not be compiled
+```
+
+## Untyped functions and the vm-runtime
+
+Functions that remain fully polymorphic (`"any"` type) after static inference
+are placed in the **IIR table section** instead of the code section.  At
+execution time a vm-runtime can interpret them from the IIR table.
+
+```python
+rt = VmRuntime(library_bytes=prebuilt_runtime_lib)
+aot = AOTCore(backend=my_backend, vm_runtime=rt)
+binary = aot.compile(module)
+```
+
+## Optimization levels
+
+| Level | Passes applied                                     |
+|-------|----------------------------------------------------|
+| 0     | None (raw specialised CIR)                         |
+| 1     | Constant folding + dead-code elimination            |
+| 2     | Same as 1 (inlining + loop unrolling: future work) |
+
+## Usage
+
+```python
+from aot_core import AOTCore, VmRuntime
+
+aot = AOTCore(backend=my_backend, optimization_level=2)
+binary = aot.compile(iir_module)
+
+# Or write directly to disk:
+aot.compile_to_file(iir_module, "program.aot")
+
+# Inspect stats:
+s = aot.stats()
+print(s.functions_compiled, s.functions_untyped)
+```
+
+## Public surface
+
+| Symbol          | Purpose                                           |
+|-----------------|---------------------------------------------------|
+| `AOTCore`       | Top-level AOT controller                          |
+| `AOTStats`      | Compilation statistics snapshot                   |
+| `AOTSnapshot`   | Parsed `.aot` binary contents                     |
+| `VmRuntime`     | Pre-compiled vm-runtime library wrapper           |
+| `infer_types`   | Static type inference (IIRFunction → dict)        |
+| `aot_specialise`| AOT specialization pass (IIRFunction → CIRInstr)  |
+| `link`          | Linker module (concatenate per-function binaries) |
+| `snapshot`      | `.aot` binary writer/reader module                |
+
+## Stack position
+
+```
+LANG00  interpreter-ir   ← shared IR types
+LANG01  (reserved)
+LANG02  vm-core          ← interpreter + profiler
+LANG03  jit-core         ← JIT: runtime specialization
+LANG04  aot-core         ← this package: AOT compilation
+LANG05  backend-protocol ← backend interface specification
+```

--- a/code/packages/python/aot-core/pyproject.toml
+++ b/code/packages/python/aot-core/pyproject.toml
@@ -1,0 +1,58 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-aot-core"
+version = "0.1.0"
+description = "aot-core: ahead-of-time compilation path for the LANG pipeline (LANG04)"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["aot", "compiler", "ahead-of-time", "register-machine", "education"]
+dependencies = [
+    "coding-adventures-interpreter-ir",
+    "coding-adventures-jit-core",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Education",
+    "Topic :: Education",
+    "Topic :: Software Development :: Compilers",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://github.com/adhithyan15/coding-adventures"
+Repository = "https://github.com/adhithyan15/coding-adventures"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/aot_core"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["E501"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["tests"]
+addopts = "--cov=aot_core --cov-report=term-missing --cov-fail-under=95"
+
+[tool.coverage.run]
+source = ["src/aot_core"]
+
+[tool.coverage.report]
+fail_under = 95
+show_missing = true

--- a/code/packages/python/aot-core/src/aot_core/__init__.py
+++ b/code/packages/python/aot-core/src/aot_core/__init__.py
@@ -1,0 +1,29 @@
+"""aot-core: ahead-of-time compilation path for the LANG pipeline (LANG04).
+
+Public surface
+--------------
+``AOTCore``        — the top-level AOT compilation controller.
+``AOTStats``       — compilation statistics snapshot.
+``AOTSnapshot``    — parsed ``.aot`` binary contents.
+``VmRuntime``      — pre-compiled vm-runtime library wrapper.
+``infer_types``    — static type inference pass (IIRFunction → dict[str, str]).
+``aot_specialise`` — AOT specialization pass (IIRFunction → list[CIRInstr]).
+``link``           — linker module (concatenate per-function binaries).
+``snapshot``       — ``.aot`` binary writer/reader module.
+"""
+
+from aot_core.core import AOTCore
+from aot_core.infer import infer_types
+from aot_core.snapshot import AOTSnapshot
+from aot_core.specialise import aot_specialise
+from aot_core.stats import AOTStats
+from aot_core.vm_runtime import VmRuntime
+
+__all__ = [
+    "AOTCore",
+    "AOTStats",
+    "AOTSnapshot",
+    "VmRuntime",
+    "infer_types",
+    "aot_specialise",
+]

--- a/code/packages/python/aot-core/src/aot_core/core.py
+++ b/code/packages/python/aot-core/src/aot_core/core.py
@@ -1,0 +1,239 @@
+"""AOTCore — the ahead-of-time compilation controller.
+
+``AOTCore`` compiles an entire ``IIRModule`` to a ``.aot`` binary before any
+user runs the program.  Unlike ``JITCore``, it:
+
+- Runs **static type inference** (``infer.infer_types``) instead of consulting
+  runtime profiler feedback.
+- Compiles **every function** in the module (not just hot ones).
+- Writes the result to a ``.aot`` binary rather than registering JIT handlers.
+- Supports **cross-compilation** transparently via the backend protocol.
+
+Compilation pipeline
+--------------------
+::
+
+    IIRModule
+        │
+        ├── for each function:
+        │       infer_types(fn)          → env: dict[str, str]
+        │       aot_specialise(fn, env)  → list[CIRInstr]
+        │       _optimize(cir)           → list[CIRInstr]
+        │       backend.compile(cir)     → bytes | None
+        │
+        │   fully compiled  →  fn_binaries
+        │   uncompiled      →  untyped_fns  (→ vm-runtime IIR table)
+        │
+        ├── link(fn_binaries)            → (native_code, offsets)
+        │
+        ├── vm_runtime.serialise_iir_table(untyped_fns)  (if any)
+        │
+        └── snapshot.write(native_code, iir_table, entry_point)  → bytes
+
+Optimization levels
+-------------------
+0 — no optimization (raw specialised CIR)
+1 — constant folding + dead-code elimination (jit-core optimizer passes)
+2 — same as 1 plus AOT-specific passes (function inlining, loop unrolling)
+    Note: inlining and loop unrolling are future work; level 2 currently
+    performs the same as level 1.
+
+vm-runtime behaviour
+--------------------
+When a function cannot be fully specialized (all types remain ``"any"`` after
+inference), it is considered *untyped* and emitted into the IIR table section:
+
+- If ``vm_runtime`` is ``None``: the untyped function's IIR bytes are still
+  written to the IIR table (so a simulator with Python ``vm-core`` can
+  interpret them), but no pre-compiled runtime library is linked in.
+- If a ``VmRuntime`` instance is provided: its ``library_bytes`` are appended
+  after the IIR table so a native runtime can be linked at load time.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from interpreter_ir import IIRModule
+from interpreter_ir.function import FunctionTypeStatus
+from jit_core import optimizer
+from jit_core.backend import BackendProtocol
+
+from aot_core import link as link_module
+from aot_core import snapshot as snapshot_module
+from aot_core.infer import infer_types
+from aot_core.specialise import aot_specialise
+from aot_core.stats import AOTStats
+from aot_core.vm_runtime import VmRuntime
+
+
+class AOTCore:
+    """Ahead-of-time compilation controller.
+
+    Parameters
+    ----------
+    backend:
+        A backend implementing ``BackendProtocol``.  Responsible for
+        translating ``CIRInstr`` lists to native binaries.
+    vm_runtime:
+        A ``VmRuntime`` instance to link into the binary when untyped functions
+        are present.  ``None`` means no pre-compiled runtime is embedded
+        (untyped functions still appear in the IIR table, but no library bytes
+        are appended).
+    optimization_level:
+        0 = no optimization; 1 = constant fold + DCE; 2 = 1 + AOT passes.
+    debug_info:
+        Reserved for future use.  If ``True``, a debug section will be
+        written once the debug-info format is specified.
+    """
+
+    def __init__(
+        self,
+        backend: BackendProtocol,
+        vm_runtime: VmRuntime | None = None,
+        optimization_level: int = 2,
+        debug_info: bool = False,
+    ) -> None:
+        self._backend = backend
+        self._vm_runtime = vm_runtime
+        self._optimization_level = optimization_level
+        self._debug_info = debug_info
+        self._stats = AOTStats(optimization_level=optimization_level)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def compile(self, module: IIRModule) -> bytes:
+        """Compile the entire ``module`` to a ``.aot`` binary.
+
+        Parameters
+        ----------
+        module:
+            The module to compile.  All functions are processed; the
+            entry-point is assumed to be ``"main"``.
+
+        Returns
+        -------
+        bytes
+            Complete ``.aot`` binary (header + code section + optional IIR table).
+        """
+        t_start = time.monotonic_ns()
+
+        fn_binaries: list[tuple[str, bytes]] = []
+        untyped_fns = []
+
+        for iir_fn in module.functions:
+            binary = self._compile_fn(iir_fn)
+            if binary is not None:
+                fn_binaries.append((iir_fn.name, binary))
+                self._stats.functions_compiled += 1
+                self._stats.total_binary_size += len(binary)
+            else:
+                untyped_fns.append(iir_fn)
+                self._stats.functions_untyped += 1
+
+        # Link compiled functions into one code section.
+        if fn_binaries:
+            native_code, offsets = link_module.link(fn_binaries)
+            ep_offset = link_module.entry_point_offset(offsets)
+        else:
+            native_code = b""
+            ep_offset = 0
+
+        # Serialise untyped functions into the IIR table.
+        iir_table: bytes | None = None
+        if untyped_fns:
+            rt = self._vm_runtime or VmRuntime()
+            iir_table = rt.serialise_iir_table(untyped_fns)
+
+        self._stats.compilation_time_ns += time.monotonic_ns() - t_start
+
+        data = snapshot_module.write(native_code, iir_table, ep_offset)
+
+        # Append pre-compiled vm-runtime library bytes after the snapshot so a
+        # native linker can locate them.  The header's vm_iir_table_offset
+        # already points past the code section to the IIR table; the library
+        # bytes follow without additional header entries.
+        if iir_table is not None and self._vm_runtime and not self._vm_runtime.is_empty:
+            data = data + self._vm_runtime.library_bytes
+
+        return data
+
+    def compile_to_file(self, module: IIRModule, path: str) -> None:
+        """Compile ``module`` and write the ``.aot`` binary to ``path``.
+
+        Parameters
+        ----------
+        module:
+            The module to compile.
+        path:
+            Destination file path (e.g., ``"program.aot"``).
+        """
+        data = self.compile(module)
+        with open(path, "wb") as fh:
+            fh.write(data)
+
+    def stats(self) -> AOTStats:
+        """Return a snapshot of compilation statistics.
+
+        The snapshot is cumulative across all ``compile()`` calls since this
+        ``AOTCore`` instance was created.
+        """
+        return AOTStats(
+            functions_compiled=self._stats.functions_compiled,
+            functions_untyped=self._stats.functions_untyped,
+            compilation_time_ns=self._stats.compilation_time_ns,
+            total_binary_size=self._stats.total_binary_size,
+            optimization_level=self._stats.optimization_level,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _compile_fn(self, fn: Any) -> bytes | None:
+        """Infer, specialise, optimise, and compile one function.
+
+        Returns
+        -------
+        bytes
+            Native binary produced by the backend.
+        None
+            If the function could not be compiled (backend returned ``None``,
+            or an exception was raised).
+        """
+        try:
+            inferred = infer_types(fn)
+            cir = aot_specialise(fn, inferred)
+            cir = self._optimize(cir)
+            return self._backend.compile(cir)
+        except Exception:
+            return None
+
+    def _optimize(self, cir: list) -> list:
+        """Run optimizer passes according to ``optimization_level``."""
+        if self._optimization_level == 0:
+            return cir
+        # Level 1+: constant folding + DCE (same as jit-core).
+        cir = optimizer.run(cir)
+        # Level 2: AOT-specific passes (inlining, loop unrolling — future).
+        # Currently a no-op; structured so passes can be inserted here.
+        return cir
+
+    def _is_fully_typed(self, fn: Any, inferred: dict[str, str]) -> bool:
+        """Return True if all instruction types in ``fn`` can be resolved."""
+        from interpreter_ir import IIRFunction
+        if not isinstance(fn, IIRFunction):
+            return False
+        if fn.type_status == FunctionTypeStatus.FULLY_TYPED:
+            return True
+        # Check whether inference resolved all dest types.
+        for instr in fn.instructions:
+            if instr.dest is None:
+                continue
+            t = inferred.get(instr.dest, "any")
+            if t == "any" and instr.type_hint == "any":
+                return False
+        return True

--- a/code/packages/python/aot-core/src/aot_core/infer.py
+++ b/code/packages/python/aot-core/src/aot_core/infer.py
@@ -1,0 +1,200 @@
+"""Static type inference for IIRFunction — the first pass of AOT compilation.
+
+AOT cannot observe runtime types the way JIT can, so it runs a lightweight
+**flow-insensitive** Hindley-Milner-style inference pass over the
+``IIRInstr`` sequence.
+
+How it works
+------------
+The pass maintains an *environment* ``env: dict[str, str]`` mapping virtual
+variable names to their inferred IIR type strings.  It walks instructions in
+order, applying inference rules:
+
+1.  **Seed** — function parameters contribute ``name → type`` entries using
+    their declared types.
+
+2.  **Typed instructions** — if ``instr.type_hint != "any"``, the dest is
+    immediately bound to ``type_hint``.  No inference needed.
+
+3.  **const** — the dest type is derived from the Python literal in
+    ``srcs[0]``: ``bool → "bool"``, small ints → ``"u8"``/``"u16"``/etc.,
+    ``float → "f64"``, ``str → "str"``, anything else → ``"any"``.
+
+4.  **Arithmetic / bitwise ops** — both sources must resolve to numeric types;
+    the result is the *wider* of the two (numeric promotion):
+
+    ::
+
+        u8 + u8  → u8
+        u8 + u16 → u16    (promotion)
+        f64 + u8 → f64
+        str + u8 → any    (incompatible)
+
+    Numeric rank order: ``bool < u8 < u16 < u32 < u64 < f64``.
+    ``"add"`` on two ``"str"`` operands is a special case (string concatenation)
+    and infers ``"str"``.
+
+5.  **Comparison ops** — result is always ``"bool"`` when all sources have
+    known non-``"any"`` types; ``"any"`` otherwise.
+
+6.  **Unary ops** (``neg``, ``not``) — result is the same type as the source.
+
+7.  **Passthrough / unknown** — any instruction not covered above leaves the
+    dest as ``"any"``.
+
+Flow-insensitivity
+------------------
+The pass makes a single forward scan with no phi-node merging.  For code where
+two branches produce different types for the same variable (e.g., one branch
+stores ``u8``, another stores ``str``), the result type is ``"any"`` because
+the later assignment overwrites the earlier binding.  This is correct and
+conservative: we never claim a concrete type that might be violated at runtime.
+"""
+
+from __future__ import annotations
+
+from interpreter_ir import IIRFunction, IIRInstr
+
+# ---------------------------------------------------------------------------
+# Type rank for numeric promotion
+# ---------------------------------------------------------------------------
+
+_NUMERIC_RANK: dict[str, int] = {
+    "bool": 0,
+    "u8":   1,
+    "u16":  2,
+    "u32":  3,
+    "u64":  4,
+    "f64":  5,
+}
+
+# ---------------------------------------------------------------------------
+# Op classification
+# ---------------------------------------------------------------------------
+
+_ARITHMETIC_OPS: frozenset[str] = frozenset({"add", "sub", "mul", "div", "mod"})
+_BITWISE_OPS: frozenset[str] = frozenset({"and", "or", "xor", "shl", "shr"})
+_COMPARISON_OPS: frozenset[str] = frozenset({
+    "cmp_eq", "cmp_ne", "cmp_lt", "cmp_le", "cmp_gt", "cmp_ge",
+})
+_UNARY_OPS: frozenset[str] = frozenset({"neg", "not"})
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def infer_types(fn: IIRFunction) -> dict[str, str]:
+    """Infer variable types for an ``IIRFunction``.
+
+    Parameters
+    ----------
+    fn:
+        The function to analyze.  Its parameter types are used as seeds.
+
+    Returns
+    -------
+    dict[str, str]
+        A mapping from virtual variable name to its inferred IIR type string.
+        Variables that could not be typed are absent or map to ``"any"``.
+        Parameter names are always present.
+    """
+    env: dict[str, str] = {}
+
+    # Seed with declared parameter types.
+    for name, typ in fn.params:
+        env[name] = typ
+
+    for instr in fn.instructions:
+        if instr.dest is None:
+            continue
+        if instr.type_hint != "any":
+            env[instr.dest] = instr.type_hint
+            continue
+        env[instr.dest] = _infer_instr(instr, env)
+
+    return env
+
+
+# ---------------------------------------------------------------------------
+# Per-instruction inference
+# ---------------------------------------------------------------------------
+
+def _infer_instr(instr: IIRInstr, env: dict[str, str]) -> str:
+    op = instr.op
+
+    if op == "const":
+        value = instr.srcs[0] if instr.srcs else 0
+        return _literal_type(value)
+
+    if op in _ARITHMETIC_OPS or op in _BITWISE_OPS:
+        if len(instr.srcs) < 2:
+            return "any"
+        t0 = _resolve(instr.srcs[0], env)
+        t1 = _resolve(instr.srcs[1], env)
+        if op == "add" and t0 == "str" and t1 == "str":
+            return "str"
+        return _promote(t0, t1)
+
+    if op in _COMPARISON_OPS:
+        if len(instr.srcs) < 2:
+            return "any"
+        t0 = _resolve(instr.srcs[0], env)
+        t1 = _resolve(instr.srcs[1], env)
+        if t0 == "any" or t1 == "any":
+            return "any"
+        return "bool"
+
+    if op in _UNARY_OPS:
+        if not instr.srcs:
+            return "any"
+        return _resolve(instr.srcs[0], env)
+
+    return "any"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _resolve(src: object, env: dict[str, str]) -> str:
+    """Return the type of an IIR source operand."""
+    if isinstance(src, bool):
+        return "bool"
+    if isinstance(src, int):
+        return _literal_type(src)
+    if isinstance(src, float):
+        return "f64"
+    if isinstance(src, str):
+        return env.get(src, "any")
+    return "any"
+
+
+def _promote(a: str, b: str) -> str:
+    """Return the wider of two numeric types, or ``"any"`` if incompatible."""
+    if a == "any" or b == "any":
+        return "any"
+    rank_a = _NUMERIC_RANK.get(a)
+    rank_b = _NUMERIC_RANK.get(b)
+    if rank_a is None or rank_b is None:
+        return "any"
+    return a if rank_a >= rank_b else b
+
+
+def _literal_type(value: object) -> str:
+    """Infer an IIR type string from a Python literal value."""
+    if isinstance(value, bool):
+        return "bool"
+    if isinstance(value, int):
+        if 0 <= value <= 255:
+            return "u8"
+        if 0 <= value <= 65535:
+            return "u16"
+        if 0 <= value <= 0xFFFF_FFFF:
+            return "u32"
+        return "u64"
+    if isinstance(value, float):
+        return "f64"
+    if isinstance(value, str):
+        return "str"
+    return "any"

--- a/code/packages/python/aot-core/src/aot_core/link.py
+++ b/code/packages/python/aot-core/src/aot_core/link.py
@@ -1,0 +1,77 @@
+"""Linker — concatenate per-function native binaries into a single code section.
+
+The linker takes a sequence of ``(fn_name, binary)`` pairs (one per compiled
+function) and concatenates them.  It records the byte offset at which each
+function's code begins, producing a *function offset table*.
+
+Why a separate linker step?
+---------------------------
+The backend compiles one function at a time and produces independent byte
+blobs.  Before writing the ``.aot`` snapshot the blobs must be joined into a
+single code section, and the entry-point offset (the offset of ``"main"``) must
+be determined.  The linker handles both concerns.
+
+Cross-compilation note
+----------------------
+The linker is architecture-neutral: it performs no fixups or relocation.
+The backend is responsible for producing position-independent code (or
+relative-addressing code) so that concatenating blobs does not require
+relocation table entries.  Simulators (Intel 4004, RISC-V, etc.) load the
+entire code section at a fixed base address, so PI code is not needed for
+simulation targets.
+
+Example
+-------
+>>> binaries = [("main", b"\\x01\\x02"), ("helper", b"\\x03\\x04\\x05")]
+>>> code, offsets = link(binaries)
+>>> code
+b'\\x01\\x02\\x03\\x04\\x05'
+>>> offsets["main"]
+0
+>>> offsets["helper"]
+2
+"""
+
+from __future__ import annotations
+
+
+def link(fn_binaries: list[tuple[str, bytes]]) -> tuple[bytes, dict[str, int]]:
+    """Concatenate per-function binaries into a single code section.
+
+    Parameters
+    ----------
+    fn_binaries:
+        Ordered list of ``(function_name, native_binary)`` pairs.  Order
+        determines the layout of the code section.
+
+    Returns
+    -------
+    tuple[bytes, dict[str, int]]
+        ``(combined_code, offsets)`` where ``offsets`` maps each function name
+        to its byte offset within ``combined_code``.
+    """
+    combined = b""
+    offsets: dict[str, int] = {}
+    for name, binary in fn_binaries:
+        offsets[name] = len(combined)
+        combined += binary
+    return combined, offsets
+
+
+def entry_point_offset(offsets: dict[str, int], entry: str = "main") -> int:
+    """Return the byte offset of the entry-point function.
+
+    Parameters
+    ----------
+    offsets:
+        Offset table returned by ``link()``.
+    entry:
+        Name of the entry-point function (default: ``"main"``).
+
+    Returns
+    -------
+    int
+        Byte offset of the entry-point within the code section, or ``0`` if
+        the function was not found (e.g., the module has no ``"main"``).
+    """
+    return offsets.get(entry, 0)

--- a/code/packages/python/aot-core/src/aot_core/snapshot.py
+++ b/code/packages/python/aot-core/src/aot_core/snapshot.py
@@ -1,0 +1,225 @@
+"""AOT snapshot format: writer and reader for ``.aot`` binaries.
+
+The ``.aot`` file is a self-contained binary that can be executed on the
+target architecture.  Its layout:
+
+::
+
+    ┌─────────────────────────────────────────┐
+    │ Header (26 bytes)                       │
+    │   magic             4 bytes  "AOT\\0"   │
+    │   version           2 bytes  0x01 0x00  │
+    │   flags             4 bytes             │
+    │   entry_point_offset 4 bytes            │
+    │   vm_iir_table_offset 4 bytes           │
+    │   vm_iir_table_size  4 bytes            │
+    │   native_code_size  4 bytes             │
+    ├─────────────────────────────────────────┤
+    │ Code section                            │
+    │   N bytes  native machine code          │
+    ├─────────────────────────────────────────┤
+    │ IIR table section (optional)            │
+    │   M bytes  serialised IIR for dynamic   │
+    └─────────────────────────────────────────┘
+
+Flags
+-----
+bit 0 (``FLAG_VM_RUNTIME``)  — vm-runtime IIR table is present
+bit 1 (``FLAG_DEBUG_INFO``)  — debug section present (future; always 0 now)
+
+Endianness: little-endian throughout.
+
+Example
+-------
+Write and round-trip a simple snapshot:
+
+>>> code = b"\\xde\\xad\\xbe\\xef"
+>>> raw = write(code, entry_point_offset=0)
+>>> snap = read(raw)
+>>> snap.native_code == code
+True
+>>> snap.iir_table is None
+True
+"""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+MAGIC: bytes = b"AOT\x00"
+VERSION: int = 0x0100  # major=1, minor=0 packed as big-endian uint16
+
+FLAG_VM_RUNTIME: int = 0x01
+FLAG_DEBUG_INFO: int = 0x02
+
+# Header layout: magic(4) + version(2) + flags(4) + entry_point_offset(4)
+#                + vm_iir_table_offset(4) + vm_iir_table_size(4)
+#                + native_code_size(4)  = 26 bytes total
+_HEADER_FORMAT: str = "<4sHIIIII"
+HEADER_SIZE: int = struct.calcsize(_HEADER_FORMAT)  # 26
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class AOTSnapshot:
+    """Parsed contents of a ``.aot`` binary.
+
+    Attributes
+    ----------
+    version:
+        Packed version word (``0x0100`` = v1.0).
+    flags:
+        Bitmask of flags (see ``FLAG_*`` constants).
+    entry_point_offset:
+        Byte offset within ``native_code`` where the entry-point function begins.
+    native_code:
+        Raw native machine code bytes (all compiled functions concatenated).
+    iir_table:
+        Serialised IIR bytes for uncompiled functions, or ``None`` if the
+        vm-runtime section is absent.
+    """
+
+    version: int
+    flags: int
+    entry_point_offset: int
+    native_code: bytes
+    iir_table: bytes | None
+
+    @property
+    def has_vm_runtime(self) -> bool:
+        """True if the IIR table section is present."""
+        return bool(self.flags & FLAG_VM_RUNTIME)
+
+
+# ---------------------------------------------------------------------------
+# Writer
+# ---------------------------------------------------------------------------
+
+def write(
+    native_code: bytes,
+    iir_table: bytes | None = None,
+    entry_point_offset: int = 0,
+) -> bytes:
+    """Serialise a compiled module to the ``.aot`` binary format.
+
+    Parameters
+    ----------
+    native_code:
+        Combined native binary produced by the backend (all functions
+        concatenated, typically via ``link.link()``).
+    iir_table:
+        Serialised IIR bytes for functions that could not be compiled
+        (produced by ``vm_runtime.serialise_iir_table()``).  Pass ``None``
+        if all functions were compiled.
+    entry_point_offset:
+        Byte offset within ``native_code`` where the entry-point function
+        (``main``) starts.
+
+    Returns
+    -------
+    bytes
+        Complete ``.aot`` binary ready for writing to disk or passing to a
+        simulator.
+    """
+    flags = 0
+    iir_bytes = iir_table or b""
+    if iir_table is not None:
+        flags |= FLAG_VM_RUNTIME
+
+    native_code_size = len(native_code)
+    vm_iir_table_size = len(iir_bytes)
+
+    # IIR table lives immediately after the code section.
+    code_section_start = HEADER_SIZE
+    vm_iir_table_offset = (
+        code_section_start + native_code_size if iir_table is not None else 0
+    )
+
+    header = struct.pack(
+        _HEADER_FORMAT,
+        MAGIC,
+        VERSION,
+        flags,
+        entry_point_offset,
+        vm_iir_table_offset,
+        vm_iir_table_size,
+        native_code_size,
+    )
+    return header + native_code + iir_bytes
+
+
+# ---------------------------------------------------------------------------
+# Reader
+# ---------------------------------------------------------------------------
+
+def read(data: bytes) -> AOTSnapshot:
+    """Parse a ``.aot`` binary.
+
+    Parameters
+    ----------
+    data:
+        Raw bytes of the ``.aot`` file.
+
+    Returns
+    -------
+    AOTSnapshot
+        Parsed snapshot with all sections separated.
+
+    Raises
+    ------
+    ValueError
+        If the magic bytes are wrong, the data is too short, or the
+        declared section offsets are out of bounds.
+    """
+    if len(data) < HEADER_SIZE:
+        raise ValueError(f"data too short: {len(data)} < {HEADER_SIZE}")
+
+    (
+        magic,
+        version,
+        flags,
+        entry_point_offset,
+        vm_iir_table_offset,
+        vm_iir_table_size,
+        native_code_size,
+    ) = struct.unpack_from(_HEADER_FORMAT, data, 0)
+
+    if magic != MAGIC:
+        raise ValueError(f"bad magic: {magic!r} (expected {MAGIC!r})")
+
+    code_start = HEADER_SIZE
+    code_end = code_start + native_code_size
+    if code_end > len(data):
+        raise ValueError(
+            f"native_code section truncated: need {code_end} bytes, have {len(data)}"
+        )
+    native_code = data[code_start:code_end]
+
+    iir_table: bytes | None = None
+    if flags & FLAG_VM_RUNTIME:
+        if vm_iir_table_size == 0:
+            iir_table = b""
+        else:
+            iir_end = vm_iir_table_offset + vm_iir_table_size
+            if iir_end > len(data):
+                raise ValueError(
+                    f"iir_table section truncated: need {iir_end} bytes,"
+                    f" have {len(data)}"
+                )
+            iir_table = data[vm_iir_table_offset:iir_end]
+
+    return AOTSnapshot(
+        version=version,
+        flags=flags,
+        entry_point_offset=entry_point_offset,
+        native_code=native_code,
+        iir_table=iir_table,
+    )

--- a/code/packages/python/aot-core/src/aot_core/snapshot.py
+++ b/code/packages/python/aot-core/src/aot_core/snapshot.py
@@ -208,6 +208,12 @@ def read(data: bytes) -> AOTSnapshot:
         if vm_iir_table_size == 0:
             iir_table = b""
         else:
+            expected_offset = HEADER_SIZE + native_code_size
+            if vm_iir_table_offset < expected_offset:
+                raise ValueError(
+                    f"iir_table offset {vm_iir_table_offset} overlaps header"
+                    f" or code section (expected >= {expected_offset})"
+                )
             iir_end = vm_iir_table_offset + vm_iir_table_size
             if iir_end > len(data):
                 raise ValueError(

--- a/code/packages/python/aot-core/src/aot_core/specialise.py
+++ b/code/packages/python/aot-core/src/aot_core/specialise.py
@@ -1,0 +1,259 @@
+"""AOT specialization pass: IIRFunction + inferred types → list[CIRInstr].
+
+This pass is the AOT analog of ``jit-core``'s ``specialise()`` function.
+The two are structurally identical; the only difference is how the
+*specialization type* is determined:
+
+- **JIT**: consults ``IIRInstr.observed_type`` from the runtime profiler.
+- **AOT**: consults the ``inferred`` type map produced by ``infer.infer_types()``.
+
+In both cases, ``type_hint`` takes priority when it is concrete (not ``"any"``).
+
+How the spec type is chosen (``_spec_type``)
+--------------------------------------------
+1. If ``instr.type_hint != "any"`` → use it directly (statically typed source).
+2. Elif the instruction has a ``dest`` in ``inferred`` and its type is not
+   ``"any"`` → use the inferred type.
+3. Elif the instruction is ``ret`` and its first src resolves to a known type
+   in ``inferred`` → use that type.
+4. Otherwise → ``"any"`` → generic runtime call path.
+
+Guard emission
+--------------
+Type guards (``type_assert``) are emitted the same way as in jit-core:
+only when ``type_hint == "any"`` (statically untyped instruction) and the
+specialization type is concrete.  For AOT the backend is responsible for
+handling guard failures (typically a trap / abort rather than a JIT deopt).
+
+Passthrough ops
+---------------
+The same ``_PASSTHROUGH_OPS`` set from jit-core applies.  These ops carry no
+type information at the CIR level and are copied verbatim.
+"""
+
+from __future__ import annotations
+
+from interpreter_ir import IIRFunction, IIRInstr
+from jit_core.cir import CIRInstr
+
+# ---------------------------------------------------------------------------
+# Op tables (mirrors jit-core/specialise.py)
+# ---------------------------------------------------------------------------
+
+_BINARY_OPS: frozenset[str] = frozenset({
+    "add", "sub", "mul", "div", "mod",
+    "and", "or", "xor", "shl", "shr",
+    "cmp_eq", "cmp_ne", "cmp_lt", "cmp_le", "cmp_gt", "cmp_ge",
+})
+
+_UNARY_OPS: frozenset[str] = frozenset({"neg", "not"})
+
+_SPECIAL_OPS: dict[tuple[str, str], str] = {
+    ("add", "str"): "call_runtime",
+}
+
+_RUNTIME_NAMES: dict[tuple[str, str], str] = {
+    ("add", "str"): "str_concat",
+}
+
+_PASSTHROUGH_OPS: frozenset[str] = frozenset({
+    "label", "jmp", "jmp_if_true", "jmp_if_false",
+    "call", "call_builtin",
+    "cast", "type_assert",
+    "load_reg", "store_reg", "load_mem", "store_mem",
+    "io_in", "io_out",
+})
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def aot_specialise(
+    fn: IIRFunction,
+    inferred: dict[str, str] | None = None,
+) -> list[CIRInstr]:
+    """Translate ``fn``'s instructions into typed ``CIRInstr`` objects.
+
+    Parameters
+    ----------
+    fn:
+        The ``IIRFunction`` to specialize.
+    inferred:
+        Type map from ``infer.infer_types(fn)``.  If ``None``, only
+        ``type_hint`` fields are used; untyped instructions fall back to the
+        generic runtime-call path.
+
+    Returns
+    -------
+    list[CIRInstr]
+        Flat sequence of typed CIR instructions ready for the optimizer and
+        backend.
+    """
+    env = inferred or {}
+    result: list[CIRInstr] = []
+    for instr in fn.instructions:
+        result.extend(_translate(instr, env))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Per-instruction translation
+# ---------------------------------------------------------------------------
+
+def _translate(instr: IIRInstr, inferred: dict[str, str]) -> list[CIRInstr]:
+    op = instr.op
+
+    if op == "const":
+        return [_translate_const(instr, inferred)]
+
+    if op == "ret_void":
+        return [CIRInstr(op="ret_void", dest=None, srcs=[], type="void")]
+
+    if op == "ret":
+        return [_translate_ret(instr, inferred)]
+
+    if op in _PASSTHROUGH_OPS:
+        spec_type = _spec_type(instr, inferred)
+        return [CIRInstr(op=op, dest=instr.dest, srcs=list(instr.srcs), type=spec_type)]
+
+    if op in _BINARY_OPS:
+        return _translate_binary(instr, inferred)
+
+    if op in _UNARY_OPS:
+        return _translate_unary(instr, inferred)
+
+    spec_type = _spec_type(instr, inferred)
+    return [CIRInstr(op=op, dest=instr.dest, srcs=list(instr.srcs), type=spec_type)]
+
+
+def _translate_const(instr: IIRInstr, inferred: dict[str, str]) -> CIRInstr:
+    value = instr.srcs[0] if instr.srcs else 0
+    t = instr.type_hint if instr.type_hint != "any" else _literal_type(value)
+    return CIRInstr(op=f"const_{t}", dest=instr.dest, srcs=[value], type=t)
+
+
+def _translate_ret(instr: IIRInstr, inferred: dict[str, str]) -> CIRInstr:
+    spec_type = _spec_type(instr, inferred)
+    return CIRInstr(
+        op=f"ret_{spec_type}", dest=None, srcs=list(instr.srcs), type=spec_type
+    )
+
+
+def _translate_binary(instr: IIRInstr, inferred: dict[str, str]) -> list[CIRInstr]:
+    spec_type = _spec_type(instr, inferred)
+    result: list[CIRInstr] = []
+
+    if spec_type == "any":
+        result.append(CIRInstr(
+            op="call_runtime",
+            dest=instr.dest,
+            srcs=[f"generic_{instr.op}"] + list(instr.srcs),
+            type="any",
+        ))
+        return result
+
+    special_cir_op = _SPECIAL_OPS.get((instr.op, spec_type))
+    if special_cir_op == "call_runtime":
+        runtime_name = _RUNTIME_NAMES.get((instr.op, spec_type), f"generic_{instr.op}")
+        result.append(CIRInstr(
+            op="call_runtime",
+            dest=instr.dest,
+            srcs=[runtime_name] + list(instr.srcs),
+            type=spec_type,
+        ))
+        return result
+
+    if instr.type_hint == "any":
+        deopt = instr.deopt_anchor
+        for src in instr.srcs:
+            if isinstance(src, str):
+                result.append(CIRInstr(
+                    op="type_assert",
+                    dest=None,
+                    srcs=[src, spec_type],
+                    type="void",
+                    deopt_to=deopt,
+                ))
+
+    cir_op = special_cir_op if special_cir_op else f"{instr.op}_{spec_type}"
+    result.append(CIRInstr(
+        op=cir_op,
+        dest=instr.dest,
+        srcs=list(instr.srcs),
+        type=spec_type,
+    ))
+    return result
+
+
+def _translate_unary(instr: IIRInstr, inferred: dict[str, str]) -> list[CIRInstr]:
+    spec_type = _spec_type(instr, inferred)
+    result: list[CIRInstr] = []
+
+    if spec_type == "any":
+        result.append(CIRInstr(
+            op="call_runtime",
+            dest=instr.dest,
+            srcs=[f"generic_{instr.op}"] + list(instr.srcs),
+            type="any",
+        ))
+        return result
+
+    if instr.type_hint == "any":
+        deopt = instr.deopt_anchor
+        for src in instr.srcs:
+            if isinstance(src, str):
+                result.append(CIRInstr(
+                    op="type_assert",
+                    dest=None,
+                    srcs=[src, spec_type],
+                    type="void",
+                    deopt_to=deopt,
+                ))
+
+    result.append(CIRInstr(
+        op=f"{instr.op}_{spec_type}",
+        dest=instr.dest,
+        srcs=list(instr.srcs),
+        type=spec_type,
+    ))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _spec_type(instr: IIRInstr, inferred: dict[str, str]) -> str:
+    """Return the type to specialise on, or ``"any"`` for the generic path."""
+    if instr.type_hint != "any":
+        return instr.type_hint
+    if instr.dest and instr.dest in inferred:
+        t = inferred[instr.dest]
+        if t != "any":
+            return t
+    # ret has no dest — check the return value's type in the env.
+    if instr.op == "ret" and instr.srcs:
+        src = instr.srcs[0]
+        if isinstance(src, str) and src in inferred:
+            return inferred[src]
+    return "any"
+
+
+def _literal_type(value: object) -> str:
+    """Infer an IIR type string from a Python literal value."""
+    if isinstance(value, bool):
+        return "bool"
+    if isinstance(value, int):
+        if 0 <= value <= 255:
+            return "u8"
+        if 0 <= value <= 65535:
+            return "u16"
+        if 0 <= value <= 0xFFFF_FFFF:
+            return "u32"
+        return "u64"
+    if isinstance(value, float):
+        return "f64"
+    if isinstance(value, str):
+        return "str"
+    return "any"

--- a/code/packages/python/aot-core/src/aot_core/stats.py
+++ b/code/packages/python/aot-core/src/aot_core/stats.py
@@ -1,0 +1,54 @@
+"""AOTStats — compilation statistics returned by AOTCore.stats().
+
+After calling ``AOTCore.compile()``, the stats snapshot captures:
+
+- How many functions were fully compiled to native code.
+- How many functions remained untyped and were routed through the vm-runtime
+  stub path (serialized into the IIR table section of the .aot binary).
+- Total wall-clock compilation time in nanoseconds.
+- The combined size of all native code bytes produced by the backend.
+- The optimization level that was active during compilation.
+
+The stats object is a snapshot: it reflects the state at the time
+``AOTCore.stats()`` was called and is not updated retroactively.
+
+Example
+-------
+>>> aot = AOTCore(backend=my_backend)
+>>> aot.compile(module)
+>>> s = aot.stats()
+>>> print(s.functions_compiled, s.functions_untyped)
+3 1
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class AOTStats:
+    """Snapshot of AOT compilation statistics.
+
+    Attributes
+    ----------
+    functions_compiled:
+        Number of functions successfully compiled to native binary by the backend.
+    functions_untyped:
+        Number of functions that could not be fully specialized (remained "any"
+        after static inference) and were routed to the vm-runtime stub path.
+    compilation_time_ns:
+        Total wall-clock time spent in the AOT pipeline (infer + specialise +
+        optimize + backend.compile) across all functions, in nanoseconds.
+    total_binary_size:
+        Combined byte length of all native binaries produced by the backend.
+    optimization_level:
+        The optimization level that was active: 0=none, 1=basic (fold+DCE),
+        2=full (fold+DCE + AOT-specific passes).
+    """
+
+    functions_compiled: int = field(default=0)
+    functions_untyped: int = field(default=0)
+    compilation_time_ns: int = field(default=0)
+    total_binary_size: int = field(default=0)
+    optimization_level: int = field(default=2)

--- a/code/packages/python/aot-core/src/aot_core/vm_runtime.py
+++ b/code/packages/python/aot-core/src/aot_core/vm_runtime.py
@@ -1,0 +1,145 @@
+"""VmRuntime — pre-compiled vm-runtime library for linking into AOT binaries.
+
+When a program uses dynamic features (runtime polymorphism, closures, string
+operations, dynamic dispatch) that cannot be compiled to static native code,
+``aot-core`` falls back to including those functions in the **IIR table
+section** of the ``.aot`` binary.  At execution time, the vm-runtime library
+interprets those functions on demand.
+
+What is a vm-runtime?
+---------------------
+The vm-runtime is a compiled, linkable form of ``vm-core`` — the same
+interpreter dispatch loop that jit-core uses, but pre-compiled to the target
+architecture as a static library that can be embedded in the ``.aot`` binary.
+
+This package does **not** produce the vm-runtime library itself (that is
+the responsibility of ``vm-core``'s build system).  Instead, ``VmRuntime``
+wraps a pre-compiled byte payload and provides:
+
+1.  ``serialise_iir_table(fns)`` — serialise a list of ``IIRFunction`` objects
+    to bytes for the IIR table section of the ``.aot`` binary.
+
+2.  ``deserialise_iir_table(data)`` — reverse: parse IIR table bytes back into
+    plain ``dict`` records (for inspection and testing).
+
+Serialisation format
+--------------------
+The IIR table is JSON-encoded.  Each function is a JSON object:
+
+::
+
+    {
+        "name": "str",
+        "params": [["name", "type"], ...],
+        "instructions": [
+            {"op": "add", "dest": "r0", "srcs": [1, "x"],
+             "type_hint": "any", "deopt_anchor": null},
+            ...
+        ],
+        "type_status": 3
+    }
+
+JSON is chosen because it is self-describing and human-readable, which aids
+debugging on embedded targets.  A more compact binary encoding can be added
+later without changing the public API.
+
+Prebuilt paths (future)
+-----------------------
+In a production build system, pre-compiled vm-runtime libraries would live at::
+
+    vm-runtime/prebuilt/
+        vm_runtime_intel4004.a
+        vm_runtime_riscv32.a
+        vm_runtime_wasm32.a
+
+For now, ``VmRuntime`` is backend-neutral: the ``library_bytes`` can hold any
+opaque byte payload.
+"""
+
+from __future__ import annotations
+
+import json
+
+from interpreter_ir import IIRFunction, IIRInstr
+
+
+class VmRuntime:
+    """Wrapper for a pre-compiled vm-runtime library.
+
+    Parameters
+    ----------
+    library_bytes:
+        Pre-compiled vm-runtime static library bytes.  May be empty (``b""``)
+        for simulator targets that run the IIR table via Python ``vm-core``.
+    """
+
+    def __init__(self, library_bytes: bytes = b"") -> None:
+        self.library_bytes = library_bytes
+
+    @property
+    def is_empty(self) -> bool:
+        """True if no pre-compiled library was provided."""
+        return len(self.library_bytes) == 0
+
+    # ------------------------------------------------------------------
+    # IIR table serialisation
+    # ------------------------------------------------------------------
+
+    def serialise_iir_table(self, fns: list[IIRFunction]) -> bytes:
+        """Serialise a list of ``IIRFunction`` objects to IIR table bytes.
+
+        The result is suitable for embedding in the ``.aot`` snapshot's
+        IIR table section via ``snapshot.write(iir_table=...)``.
+
+        Parameters
+        ----------
+        fns:
+            Functions that could not be fully compiled and must be interpreted
+            by the vm-runtime at run time.
+
+        Returns
+        -------
+        bytes
+            UTF-8-encoded JSON payload.
+        """
+        records = [_serialise_fn(fn) for fn in fns]
+        return json.dumps(records, separators=(",", ":")).encode()
+
+    def deserialise_iir_table(self, data: bytes) -> list[dict]:
+        """Parse IIR table bytes back to plain dicts (for inspection/testing).
+
+        Parameters
+        ----------
+        data:
+            Bytes produced by ``serialise_iir_table()``.
+
+        Returns
+        -------
+        list[dict]
+            One dict per function, with the same structure as the JSON objects
+            written by ``serialise_iir_table()``.
+        """
+        return json.loads(data.decode())
+
+
+# ---------------------------------------------------------------------------
+# Serialisation helpers
+# ---------------------------------------------------------------------------
+
+def _serialise_instr(instr: IIRInstr) -> dict:
+    return {
+        "op": instr.op,
+        "dest": instr.dest,
+        "srcs": list(instr.srcs),
+        "type_hint": instr.type_hint,
+        "deopt_anchor": instr.deopt_anchor,
+    }
+
+
+def _serialise_fn(fn: IIRFunction) -> dict:
+    return {
+        "name": fn.name,
+        "params": list(fn.params),
+        "instructions": [_serialise_instr(i) for i in fn.instructions],
+        "type_status": fn.type_status.value,
+    }

--- a/code/packages/python/aot-core/tests/conftest.py
+++ b/code/packages/python/aot-core/tests/conftest.py
@@ -1,0 +1,103 @@
+"""Shared test helpers for aot-core tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from interpreter_ir import IIRFunction, IIRInstr, IIRModule
+from interpreter_ir.function import FunctionTypeStatus
+from jit_core.cir import CIRInstr
+
+# ---------------------------------------------------------------------------
+# IIR construction helpers
+# ---------------------------------------------------------------------------
+
+def make_instr(
+    op: str,
+    dest: str | None = None,
+    srcs: list | None = None,
+    type_hint: str = "any",
+    observed_type: str | None = None,
+    observation_count: int = 0,
+    deopt_anchor: int | None = None,
+) -> IIRInstr:
+    instr = IIRInstr(op=op, dest=dest, srcs=srcs or [], type_hint=type_hint)
+    if observed_type is not None:
+        for _ in range(observation_count):
+            instr.record_observation(observed_type)
+    if deopt_anchor is not None:
+        instr.deopt_anchor = deopt_anchor
+    return instr
+
+
+def make_fn(
+    name: str,
+    params: list[tuple[str, str]],
+    *instrs: IIRInstr,
+    return_type: str = "any",
+    type_status: FunctionTypeStatus = FunctionTypeStatus.FULLY_TYPED,
+) -> IIRFunction:
+    return IIRFunction(
+        name=name,
+        params=params,
+        return_type=return_type,
+        instructions=list(instrs),
+        register_count=max(8, len(params) + len(instrs)),
+        type_status=type_status,
+    )
+
+
+def make_mod(*fns: IIRFunction) -> IIRModule:
+    return IIRModule(name="test", functions=list(fns))
+
+
+# ---------------------------------------------------------------------------
+# CIR construction helper
+# ---------------------------------------------------------------------------
+
+def make_cir(
+    op: str,
+    dest: str | None = None,
+    srcs: list | None = None,
+    type: str = "any",
+    deopt_to: int | None = None,
+) -> CIRInstr:
+    return CIRInstr(op=op, dest=dest, srcs=srcs or [], type=type, deopt_to=deopt_to)
+
+
+# ---------------------------------------------------------------------------
+# Mock backend
+# ---------------------------------------------------------------------------
+
+class MockAOTBackend:
+    """Records compile() calls; returns configurable bytes or None."""
+
+    name: str = "mock-aot"
+
+    def __init__(self, return_value: bytes = b"\xde\xad", fail: bool = False) -> None:
+        self._return_value = return_value
+        self._fail = fail
+        self.compile_calls: list[list[CIRInstr]] = []
+
+    def fail_next(self) -> None:
+        self._fail = True
+
+    def compile(self, cir: list[CIRInstr]) -> bytes | None:
+        self.compile_calls.append(list(cir))
+        if self._fail:
+            self._fail = False
+            return None
+        return self._return_value
+
+    def run(self, binary: bytes, args: list[Any]) -> Any:
+        return sum(a for a in args if isinstance(a, int))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_backend() -> MockAOTBackend:
+    return MockAOTBackend()

--- a/code/packages/python/aot-core/tests/test_core.py
+++ b/code/packages/python/aot-core/tests/test_core.py
@@ -1,0 +1,387 @@
+"""Tests for aot_core.core — AOTCore compilation controller."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+
+from conftest import MockAOTBackend, make_fn, make_instr, make_mod
+from interpreter_ir.function import FunctionTypeStatus
+
+from aot_core.core import AOTCore
+from aot_core.snapshot import read as read_snap
+from aot_core.stats import AOTStats
+from aot_core.vm_runtime import VmRuntime
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fully_typed_fn(name: str = "main"):
+    return make_fn(
+        name,
+        [("x", "u8")],
+        make_instr("const", "one", [1], type_hint="u8"),
+        make_instr("add", "r", ["x", "one"], type_hint="u8"),
+        make_instr("ret", srcs=["r"], type_hint="u8"),
+        type_status=FunctionTypeStatus.FULLY_TYPED,
+    )
+
+
+def _untyped_fn(name: str = "dynamic"):
+    return make_fn(
+        name,
+        [("x", "any")],
+        make_instr("ret", srcs=["x"]),
+        type_status=FunctionTypeStatus.UNTYPED,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Basic compile() → .aot binary
+# ---------------------------------------------------------------------------
+
+class TestAOTCoreCompile:
+    def test_returns_bytes(self):
+        fn = _fully_typed_fn()
+        mod = make_mod(fn)
+        aot = AOTCore(backend=MockAOTBackend())
+        result = aot.compile(mod)
+        assert isinstance(result, bytes)
+
+    def test_binary_has_valid_magic(self):
+        mod = make_mod(_fully_typed_fn())
+        aot = AOTCore(backend=MockAOTBackend())
+        raw = aot.compile(mod)
+        snap = read_snap(raw)
+        assert snap.native_code == b"\xde\xad"  # MockAOTBackend default
+
+    def test_empty_module(self):
+        mod = make_mod()
+        aot = AOTCore(backend=MockAOTBackend())
+        raw = aot.compile(mod)
+        snap = read_snap(raw)
+        assert snap.native_code == b""
+        assert snap.iir_table is None
+
+    def test_backend_compile_called_per_fn(self):
+        backend = MockAOTBackend()
+        mod = make_mod(_fully_typed_fn("f1"), _fully_typed_fn("f2"))
+        AOTCore(backend=backend).compile(mod)
+        assert len(backend.compile_calls) == 2
+
+    def test_two_fns_code_concatenated(self):
+        backend = MockAOTBackend(return_value=b"\xAA\xBB")
+        mod = make_mod(_fully_typed_fn("f1"), _fully_typed_fn("f2"))
+        raw = AOTCore(backend=backend).compile(mod)
+        snap = read_snap(raw)
+        assert snap.native_code == b"\xAA\xBB\xAA\xBB"
+
+    def test_entry_point_offset_is_main(self):
+        backend = MockAOTBackend(return_value=b"\x01\x02")
+        mod = make_mod(_fully_typed_fn("helper"), _fully_typed_fn("main"))
+        raw = AOTCore(backend=backend).compile(mod)
+        snap = read_snap(raw)
+        # main is second fn, offset = len(b"\x01\x02") = 2
+        assert snap.entry_point_offset == 2
+
+
+# ---------------------------------------------------------------------------
+# Untyped functions → IIR table
+# ---------------------------------------------------------------------------
+
+class TestAOTCoreUntypedFns:
+    def test_untyped_fn_goes_to_iir_table(self):
+        # A backend that returns None (can't compile generic CIR) routes the
+        # function to the IIR table instead of the code section.
+        mod = make_mod(_untyped_fn())
+        aot = AOTCore(backend=MockAOTBackend(fail=True))
+        raw = aot.compile(mod)
+        snap = read_snap(raw)
+        assert snap.has_vm_runtime
+        assert snap.iir_table is not None
+
+    def test_iir_table_contains_fn_name(self):
+        mod = make_mod(_untyped_fn("dynamic_fn"))
+        # The backend returns None for untyped (can't compile "any" types).
+        backend = MockAOTBackend(fail=True)
+        aot = AOTCore(backend=backend)
+        raw = aot.compile(mod)
+        snap = read_snap(raw)
+        records = json.loads(snap.iir_table.decode())
+        names = [r["name"] for r in records]
+        assert "dynamic_fn" in names
+
+    def test_vm_runtime_library_appended_when_provided(self):
+        mod = make_mod(_untyped_fn())
+        backend = MockAOTBackend(fail=True)
+        rt = VmRuntime(library_bytes=b"\xFF\xFE\xFD")
+        aot = AOTCore(backend=backend, vm_runtime=rt)
+        raw = aot.compile(mod)
+        # vm-runtime bytes should appear somewhere in the binary.
+        assert b"\xFF\xFE\xFD" in raw
+
+    def test_mixed_module_partial_compile(self):
+        # One typed fn + one untyped fn.
+        typed = _fully_typed_fn("compiled")
+        untyped = _untyped_fn("dynamic")
+        mod = make_mod(typed, untyped)
+        # Backend succeeds for typed, fails for untyped.
+        call_count = [0]
+        class SelectiveBackend:
+            name = "selective"
+            def compile(self, cir):
+                call_count[0] += 1
+                # First call compiles typed fn; second fails (untyped → any).
+                if call_count[0] == 1:
+                    return b"\xCC"
+                return None
+            def run(self, binary, args):
+                return None
+
+        aot = AOTCore(backend=SelectiveBackend())
+        raw = aot.compile(mod)
+        snap = read_snap(raw)
+        assert snap.native_code == b"\xCC"
+        assert snap.has_vm_runtime
+
+
+# ---------------------------------------------------------------------------
+# Backend compile failure
+# ---------------------------------------------------------------------------
+
+class TestAOTCoreBackendFailure:
+    def test_backend_returns_none_routes_to_iir(self):
+        fn = _fully_typed_fn()
+        mod = make_mod(fn)
+        backend = MockAOTBackend(fail=True)
+        aot = AOTCore(backend=backend)
+        raw = aot.compile(mod)
+        snap = read_snap(raw)
+        assert snap.has_vm_runtime
+        assert snap.native_code == b""
+
+    def test_backend_exception_routes_to_iir(self):
+        fn = _fully_typed_fn()
+        mod = make_mod(fn)
+
+        class ExplodingBackend:
+            name = "exploding"
+            def compile(self, cir):
+                raise RuntimeError("kaboom")
+            def run(self, binary, args):
+                return None
+
+        aot = AOTCore(backend=ExplodingBackend())
+        raw = aot.compile(mod)
+        snap = read_snap(raw)
+        assert snap.has_vm_runtime
+
+
+# ---------------------------------------------------------------------------
+# Optimization levels
+# ---------------------------------------------------------------------------
+
+class TestAOTCoreOptimization:
+    def test_optimization_level_0_no_folding(self):
+        fn = make_fn(
+            "main", [],
+            make_instr("add", "r", [3, 4], type_hint="u8"),
+            make_instr("ret", srcs=["r"], type_hint="u8"),
+        )
+        mod = make_mod(fn)
+
+        received_cir = []
+        class CapturingBackend:
+            name = "cap"
+            def compile(self, cir):
+                received_cir.extend(cir)
+                return b"\x00"
+            def run(self, binary, args):
+                return None
+
+        AOTCore(backend=CapturingBackend(), optimization_level=0).compile(mod)
+        ops = [c.op for c in received_cir]
+        assert "add_u8" in ops  # not folded
+
+    def test_optimization_level_1_folds_constants(self):
+        fn = make_fn(
+            "main", [],
+            make_instr("add", "r", [3, 4], type_hint="u8"),
+            make_instr("ret", srcs=["r"], type_hint="u8"),
+        )
+        mod = make_mod(fn)
+
+        received_cir = []
+        class CapturingBackend:
+            name = "cap"
+            def compile(self, cir):
+                received_cir.extend(cir)
+                return b"\x00"
+            def run(self, binary, args):
+                return None
+
+        AOTCore(backend=CapturingBackend(), optimization_level=1).compile(mod)
+        ops = [c.op for c in received_cir]
+        assert "add_u8" not in ops
+        const_instrs = [c for c in received_cir if c.op == "const_u8"]
+        assert any(c.srcs == [7] for c in const_instrs)
+
+    def test_optimization_level_2_same_as_1(self):
+        fn = make_fn(
+            "main", [],
+            make_instr("add", "r", [3, 4], type_hint="u8"),
+            make_instr("ret", srcs=["r"], type_hint="u8"),
+        )
+        mod = make_mod(fn)
+
+        received_cir = []
+        class CapturingBackend:
+            name = "cap"
+            def compile(self, cir):
+                received_cir.extend(cir)
+                return b"\x00"
+            def run(self, binary, args):
+                return None
+
+        AOTCore(backend=CapturingBackend(), optimization_level=2).compile(mod)
+        ops = [c.op for c in received_cir]
+        assert "add_u8" not in ops
+
+
+# ---------------------------------------------------------------------------
+# compile_to_file
+# ---------------------------------------------------------------------------
+
+class TestAOTCoreCompileToFile:
+    def test_writes_valid_aot_file(self):
+        fn = _fully_typed_fn()
+        mod = make_mod(fn)
+        aot = AOTCore(backend=MockAOTBackend())
+        with tempfile.NamedTemporaryFile(suffix=".aot", delete=False) as f:
+            path = f.name
+        try:
+            aot.compile_to_file(mod, path)
+            with open(path, "rb") as f:
+                data = f.read()
+            snap = read_snap(data)
+            assert snap.native_code == b"\xde\xad"
+        finally:
+            os.unlink(path)
+
+    def test_file_is_non_empty(self):
+        fn = _fully_typed_fn()
+        mod = make_mod(fn)
+        aot = AOTCore(backend=MockAOTBackend())
+        with tempfile.NamedTemporaryFile(suffix=".aot", delete=False) as f:
+            path = f.name
+        try:
+            aot.compile_to_file(mod, path)
+            assert os.path.getsize(path) > 0
+        finally:
+            os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# stats()
+# ---------------------------------------------------------------------------
+
+class TestAOTCoreStats:
+    def test_stats_type(self):
+        aot = AOTCore(backend=MockAOTBackend())
+        s = aot.stats()
+        assert isinstance(s, AOTStats)
+
+    def test_functions_compiled_counted(self):
+        mod = make_mod(_fully_typed_fn("f1"), _fully_typed_fn("f2"))
+        aot = AOTCore(backend=MockAOTBackend())
+        aot.compile(mod)
+        s = aot.stats()
+        assert s.functions_compiled == 2
+
+    def test_functions_untyped_counted(self):
+        mod = make_mod(_untyped_fn())
+        backend = MockAOTBackend(fail=True)
+        aot = AOTCore(backend=backend)
+        aot.compile(mod)
+        s = aot.stats()
+        assert s.functions_untyped == 1
+
+    def test_total_binary_size(self):
+        backend = MockAOTBackend(return_value=b"\xAA\xBB\xCC")
+        mod = make_mod(_fully_typed_fn("f1"), _fully_typed_fn("f2"))
+        aot = AOTCore(backend=backend)
+        aot.compile(mod)
+        s = aot.stats()
+        assert s.total_binary_size == 6  # 3 bytes × 2 fns
+
+    def test_compilation_time_positive(self):
+        mod = make_mod(_fully_typed_fn())
+        aot = AOTCore(backend=MockAOTBackend())
+        aot.compile(mod)
+        s = aot.stats()
+        assert s.compilation_time_ns >= 0
+
+    def test_optimization_level_in_stats(self):
+        aot = AOTCore(backend=MockAOTBackend(), optimization_level=0)
+        assert aot.stats().optimization_level == 0
+
+    def test_stats_accumulate_across_compiles(self):
+        mod = make_mod(_fully_typed_fn())
+        aot = AOTCore(backend=MockAOTBackend())
+        aot.compile(mod)
+        aot.compile(mod)
+        s = aot.stats()
+        assert s.functions_compiled == 2
+
+    def test_stats_snapshot_is_independent(self):
+        mod = make_mod(_fully_typed_fn())
+        aot = AOTCore(backend=MockAOTBackend())
+        aot.compile(mod)
+        s1 = aot.stats()
+        aot.compile(mod)
+        s2 = aot.stats()
+        assert s1.functions_compiled == 1
+        assert s2.functions_compiled == 2
+
+
+# ---------------------------------------------------------------------------
+# _is_fully_typed helper
+# ---------------------------------------------------------------------------
+
+class TestIsFullyTyped:
+    def test_fully_typed_status(self):
+        fn = _fully_typed_fn()
+        from aot_core.infer import infer_types
+        env = infer_types(fn)
+        aot = AOTCore(backend=MockAOTBackend())
+        assert aot._is_fully_typed(fn, env)
+
+    def test_not_iir_function(self):
+        aot = AOTCore(backend=MockAOTBackend())
+        assert not aot._is_fully_typed("not_a_fn", {})
+
+    def test_untyped_fn_with_any_dest(self):
+        fn = make_fn(
+            "f", [("x", "any")],
+            make_instr("ret", srcs=["x"]),
+            type_status=FunctionTypeStatus.UNTYPED,
+        )
+        from aot_core.infer import infer_types
+        env = infer_types(fn)
+        aot = AOTCore(backend=MockAOTBackend())
+        # ret has no dest, so _is_fully_typed returns True (no unresolved dests).
+        assert aot._is_fully_typed(fn, env)
+
+    def test_untyped_fn_with_any_dest_instruction(self):
+        fn = make_fn(
+            "f", [("x", "any"), ("y", "any")],
+            make_instr("add", "r", ["x", "y"]),  # r will be "any"
+            make_instr("ret", srcs=["r"]),
+            type_status=FunctionTypeStatus.UNTYPED,
+        )
+        from aot_core.infer import infer_types
+        env = infer_types(fn)
+        aot = AOTCore(backend=MockAOTBackend())
+        assert not aot._is_fully_typed(fn, env)

--- a/code/packages/python/aot-core/tests/test_infer.py
+++ b/code/packages/python/aot-core/tests/test_infer.py
@@ -1,0 +1,381 @@
+"""Tests for aot_core.infer — static type inference."""
+
+from __future__ import annotations
+
+from conftest import make_fn, make_instr
+
+from aot_core.infer import _literal_type, _promote, _resolve, infer_types
+
+# ---------------------------------------------------------------------------
+# _literal_type
+# ---------------------------------------------------------------------------
+
+class TestLiteralType:
+    def test_bool_true(self):
+        assert _literal_type(True) == "bool"
+
+    def test_bool_false(self):
+        assert _literal_type(False) == "bool"
+
+    def test_u8(self):
+        assert _literal_type(0) == "u8"
+        assert _literal_type(255) == "u8"
+
+    def test_u16(self):
+        assert _literal_type(256) == "u16"
+        assert _literal_type(65535) == "u16"
+
+    def test_u32(self):
+        assert _literal_type(65536) == "u32"
+        assert _literal_type(0xFFFF_FFFF) == "u32"
+
+    def test_u64(self):
+        assert _literal_type(0x1_0000_0000) == "u64"
+
+    def test_float(self):
+        assert _literal_type(3.14) == "f64"
+
+    def test_str(self):
+        assert _literal_type("hello") == "str"
+
+    def test_none(self):
+        assert _literal_type(None) == "any"
+
+    def test_object(self):
+        assert _literal_type(object()) == "any"
+
+
+# ---------------------------------------------------------------------------
+# _promote
+# ---------------------------------------------------------------------------
+
+class TestPromote:
+    def test_same_type_u8(self):
+        assert _promote("u8", "u8") == "u8"
+
+    def test_u8_u16_promotes_to_u16(self):
+        assert _promote("u8", "u16") == "u16"
+
+    def test_u16_u8_promotes_to_u16(self):
+        assert _promote("u16", "u8") == "u16"
+
+    def test_u8_f64_promotes_to_f64(self):
+        assert _promote("u8", "f64") == "f64"
+
+    def test_bool_u8_promotes_to_u8(self):
+        assert _promote("bool", "u8") == "u8"
+
+    def test_any_propagates(self):
+        assert _promote("any", "u8") == "any"
+        assert _promote("u8", "any") == "any"
+
+    def test_str_with_numeric_is_any(self):
+        assert _promote("str", "u8") == "any"
+        assert _promote("u8", "str") == "any"
+
+    def test_str_with_str_is_any(self):
+        # _promote doesn't know about str+str → str; that's in _infer_instr
+        assert _promote("str", "str") == "any"
+
+    def test_u32_u64_promotes_to_u64(self):
+        assert _promote("u32", "u64") == "u64"
+
+
+# ---------------------------------------------------------------------------
+# _resolve
+# ---------------------------------------------------------------------------
+
+class TestResolve:
+    def test_bool_literal(self):
+        assert _resolve(True, {}) == "bool"
+
+    def test_int_literal(self):
+        assert _resolve(42, {}) == "u8"
+
+    def test_float_literal(self):
+        assert _resolve(1.0, {}) == "f64"
+
+    def test_str_var_in_env(self):
+        assert _resolve("x", {"x": "u16"}) == "u16"
+
+    def test_str_var_missing(self):
+        assert _resolve("x", {}) == "any"
+
+    def test_none_value(self):
+        assert _resolve(None, {}) == "any"
+
+
+# ---------------------------------------------------------------------------
+# infer_types — basic cases
+# ---------------------------------------------------------------------------
+
+class TestInferTypesBasic:
+    def test_params_seeded(self):
+        fn = make_fn("f", [("x", "u8"), ("y", "u16")])
+        env = infer_types(fn)
+        assert env["x"] == "u8"
+        assert env["y"] == "u16"
+
+    def test_typed_const_from_hint(self):
+        fn = make_fn(
+            "f", [],
+            make_instr("const", "v", [42], type_hint="u16"),
+        )
+        env = infer_types(fn)
+        assert env["v"] == "u16"
+
+    def test_untyped_const_literal_u8(self):
+        fn = make_fn(
+            "f", [],
+            make_instr("const", "v", [10]),
+        )
+        env = infer_types(fn)
+        assert env["v"] == "u8"
+
+    def test_untyped_const_literal_bool(self):
+        fn = make_fn(
+            "f", [],
+            make_instr("const", "v", [True]),
+        )
+        env = infer_types(fn)
+        assert env["v"] == "bool"
+
+    def test_untyped_const_literal_float(self):
+        fn = make_fn(
+            "f", [],
+            make_instr("const", "v", [3.14]),
+        )
+        env = infer_types(fn)
+        assert env["v"] == "f64"
+
+    def test_untyped_const_no_srcs(self):
+        fn = make_fn(
+            "f", [],
+            make_instr("const", "v"),
+        )
+        env = infer_types(fn)
+        assert env["v"] == "u8"  # 0 → u8
+
+    def test_untyped_const_literal_str(self):
+        fn = make_fn(
+            "f", [],
+            make_instr("const", "s", ["hello"]),
+        )
+        env = infer_types(fn)
+        assert env["s"] == "str"
+
+    def test_no_dest_skipped(self):
+        fn = make_fn(
+            "f", [("x", "u8")],
+            make_instr("ret", srcs=["x"]),
+        )
+        env = infer_types(fn)
+        assert "None" not in env
+        assert "x" in env
+
+
+# ---------------------------------------------------------------------------
+# infer_types — arithmetic / promotion
+# ---------------------------------------------------------------------------
+
+class TestInferTypesArithmetic:
+    def test_add_u8_u8(self):
+        fn = make_fn(
+            "f", [("a", "u8"), ("b", "u8")],
+            make_instr("add", "r", ["a", "b"]),
+        )
+        env = infer_types(fn)
+        assert env["r"] == "u8"
+
+    def test_add_u8_u16_promotes(self):
+        fn = make_fn(
+            "f", [("a", "u8"), ("b", "u16")],
+            make_instr("add", "r", ["a", "b"]),
+        )
+        env = infer_types(fn)
+        assert env["r"] == "u16"
+
+    def test_add_u8_f64_promotes_to_f64(self):
+        fn = make_fn(
+            "f", [("a", "u8"), ("b", "f64")],
+            make_instr("add", "r", ["a", "b"]),
+        )
+        env = infer_types(fn)
+        assert env["r"] == "f64"
+
+    def test_add_str_str_is_str(self):
+        fn = make_fn(
+            "f", [("a", "str"), ("b", "str")],
+            make_instr("add", "r", ["a", "b"]),
+        )
+        env = infer_types(fn)
+        assert env["r"] == "str"
+
+    def test_add_str_u8_is_any(self):
+        fn = make_fn(
+            "f", [("a", "str"), ("b", "u8")],
+            make_instr("add", "r", ["a", "b"]),
+        )
+        env = infer_types(fn)
+        assert env["r"] == "any"
+
+    def test_sub_u16_u8(self):
+        fn = make_fn(
+            "f", [("a", "u16"), ("b", "u8")],
+            make_instr("sub", "r", ["a", "b"]),
+        )
+        env = infer_types(fn)
+        assert env["r"] == "u16"
+
+    def test_mul_literal_literal(self):
+        fn = make_fn(
+            "f", [],
+            make_instr("mul", "r", [3, 4]),
+        )
+        env = infer_types(fn)
+        assert env["r"] == "u8"
+
+    def test_div_float_int(self):
+        fn = make_fn(
+            "f", [],
+            make_instr("div", "r", [3.0, 2]),
+        )
+        env = infer_types(fn)
+        assert env["r"] == "f64"
+
+    def test_arithmetic_with_any_src_gives_any(self):
+        fn = make_fn(
+            "f", [("a", "any"), ("b", "u8")],
+            make_instr("add", "r", ["a", "b"]),
+        )
+        env = infer_types(fn)
+        assert env["r"] == "any"
+
+    def test_bitwise_and(self):
+        fn = make_fn(
+            "f", [("a", "u8"), ("b", "u8")],
+            make_instr("and", "r", ["a", "b"]),
+        )
+        env = infer_types(fn)
+        assert env["r"] == "u8"
+
+    def test_shl_u16_u8(self):
+        fn = make_fn(
+            "f", [("a", "u16"), ("b", "u8")],
+            make_instr("shl", "r", ["a", "b"]),
+        )
+        env = infer_types(fn)
+        assert env["r"] == "u16"
+
+    def test_arithmetic_fewer_than_two_srcs(self):
+        fn = make_fn(
+            "f", [],
+            make_instr("add", "r", [1]),
+        )
+        env = infer_types(fn)
+        assert env["r"] == "any"
+
+
+# ---------------------------------------------------------------------------
+# infer_types — comparison ops
+# ---------------------------------------------------------------------------
+
+class TestInferTypesComparison:
+    def test_cmp_lt_u8_u8_gives_bool(self):
+        fn = make_fn(
+            "f", [("a", "u8"), ("b", "u8")],
+            make_instr("cmp_lt", "r", ["a", "b"]),
+        )
+        env = infer_types(fn)
+        assert env["r"] == "bool"
+
+    def test_cmp_eq_unknown_gives_any(self):
+        fn = make_fn(
+            "f", [("a", "any"), ("b", "u8")],
+            make_instr("cmp_eq", "r", ["a", "b"]),
+        )
+        env = infer_types(fn)
+        assert env["r"] == "any"
+
+    def test_cmp_ge_u32_u32_gives_bool(self):
+        fn = make_fn(
+            "f", [("a", "u32"), ("b", "u32")],
+            make_instr("cmp_ge", "r", ["a", "b"]),
+        )
+        env = infer_types(fn)
+        assert env["r"] == "bool"
+
+    def test_comparison_fewer_than_two_srcs(self):
+        fn = make_fn(
+            "f", [],
+            make_instr("cmp_eq", "r", [1]),
+        )
+        env = infer_types(fn)
+        assert env["r"] == "any"
+
+
+# ---------------------------------------------------------------------------
+# infer_types — unary ops
+# ---------------------------------------------------------------------------
+
+class TestInferTypesUnary:
+    def test_neg_u8(self):
+        fn = make_fn(
+            "f", [("x", "u8")],
+            make_instr("neg", "r", ["x"]),
+        )
+        env = infer_types(fn)
+        assert env["r"] == "u8"
+
+    def test_not_bool(self):
+        fn = make_fn(
+            "f", [("x", "bool")],
+            make_instr("not", "r", ["x"]),
+        )
+        env = infer_types(fn)
+        assert env["r"] == "bool"
+
+    def test_unary_no_srcs_gives_any(self):
+        fn = make_fn(
+            "f", [],
+            make_instr("neg", "r"),
+        )
+        env = infer_types(fn)
+        assert env["r"] == "any"
+
+
+# ---------------------------------------------------------------------------
+# infer_types — multi-instruction flow
+# ---------------------------------------------------------------------------
+
+class TestInferTypesFlow:
+    def test_chain_of_instructions(self):
+        """const → add → cmp: types should flow correctly."""
+        fn = make_fn(
+            "f", [("x", "u8")],
+            make_instr("const", "one", [1]),
+            make_instr("add", "sum", ["x", "one"]),
+            make_instr("const", "ten", [10]),
+            make_instr("cmp_lt", "flag", ["sum", "ten"]),
+        )
+        env = infer_types(fn)
+        assert env["one"] == "u8"
+        assert env["sum"] == "u8"
+        assert env["ten"] == "u8"
+        assert env["flag"] == "bool"
+
+    def test_unknown_op_gives_any(self):
+        fn = make_fn(
+            "f", [],
+            make_instr("load_mem", "v", ["ptr"]),
+        )
+        env = infer_types(fn)
+        assert env.get("v", "any") == "any"
+
+    def test_typed_hint_overrides_inference(self):
+        fn = make_fn(
+            "f", [("a", "u8"), ("b", "u8")],
+            make_instr("add", "r", ["a", "b"], type_hint="u16"),
+        )
+        env = infer_types(fn)
+        assert env["r"] == "u16"

--- a/code/packages/python/aot-core/tests/test_link.py
+++ b/code/packages/python/aot-core/tests/test_link.py
@@ -1,0 +1,64 @@
+"""Tests for aot_core.link — linker for per-function binaries."""
+
+from __future__ import annotations
+
+from aot_core.link import entry_point_offset, link
+
+
+class TestLink:
+    def test_single_fn(self):
+        code, offsets = link([("main", b"\x01\x02\x03")])
+        assert code == b"\x01\x02\x03"
+        assert offsets["main"] == 0
+
+    def test_two_fns_concatenated(self):
+        binaries = [("main", b"\x01\x02"), ("helper", b"\x03\x04\x05")]
+        code, offsets = link(binaries)
+        assert code == b"\x01\x02\x03\x04\x05"
+        assert offsets["main"] == 0
+        assert offsets["helper"] == 2
+
+    def test_three_fns(self):
+        binaries = [("a", b"\xAA"), ("b", b"\xBB\xBB"), ("c", b"\xCC\xCC\xCC")]
+        code, offsets = link(binaries)
+        assert code == b"\xAA\xBB\xBB\xCC\xCC\xCC"
+        assert offsets["a"] == 0
+        assert offsets["b"] == 1
+        assert offsets["c"] == 3
+
+    def test_empty_list(self):
+        code, offsets = link([])
+        assert code == b""
+        assert offsets == {}
+
+    def test_empty_binary_fn(self):
+        code, offsets = link([("main", b""), ("helper", b"\xFF")])
+        assert code == b"\xFF"
+        assert offsets["main"] == 0
+        assert offsets["helper"] == 0
+
+    def test_offset_values_match_cumulative_sizes(self):
+        sizes = [3, 5, 2]
+        binaries = [(str(i), bytes(n)) for i, n in enumerate(sizes)]
+        code, offsets = link(binaries)
+        assert len(code) == sum(sizes)
+        expected_offsets = [0, 3, 8]
+        for i, off in enumerate(expected_offsets):
+            assert offsets[str(i)] == off
+
+
+class TestEntryPointOffset:
+    def test_main_present(self):
+        _, offsets = link([("helper", b"\xAA\xBB"), ("main", b"\xCC")])
+        assert entry_point_offset(offsets) == 2
+
+    def test_main_absent_returns_zero(self):
+        _, offsets = link([("helper", b"\xAA")])
+        assert entry_point_offset(offsets) == 0
+
+    def test_custom_entry(self):
+        _, offsets = link([("init", b"\x01"), ("start", b"\x02")])
+        assert entry_point_offset(offsets, entry="start") == 1
+
+    def test_empty_offsets(self):
+        assert entry_point_offset({}) == 0

--- a/code/packages/python/aot-core/tests/test_snapshot.py
+++ b/code/packages/python/aot-core/tests/test_snapshot.py
@@ -1,0 +1,149 @@
+"""Tests for aot_core.snapshot — .aot binary writer and reader."""
+
+from __future__ import annotations
+
+import pytest
+
+from aot_core.snapshot import (
+    FLAG_VM_RUNTIME,
+    HEADER_SIZE,
+    MAGIC,
+    VERSION,
+    AOTSnapshot,
+    read,
+    write,
+)
+
+# ---------------------------------------------------------------------------
+# Basic write / read roundtrip
+# ---------------------------------------------------------------------------
+
+class TestWriteReadRoundtrip:
+    def test_empty_code(self):
+        raw = write(b"")
+        snap = read(raw)
+        assert snap.native_code == b""
+        assert snap.iir_table is None
+
+    def test_code_roundtrip(self):
+        code = b"\xde\xad\xbe\xef"
+        raw = write(code)
+        snap = read(raw)
+        assert snap.native_code == code
+
+    def test_code_with_iir_table(self):
+        code = b"\x01\x02\x03"
+        iir = b"[{\"name\":\"f\"}]"
+        raw = write(code, iir_table=iir)
+        snap = read(raw)
+        assert snap.native_code == code
+        assert snap.iir_table == iir
+
+    def test_entry_point_offset_preserved(self):
+        code = b"\x00" * 16
+        raw = write(code, entry_point_offset=8)
+        snap = read(raw)
+        assert snap.entry_point_offset == 8
+
+    def test_version_correct(self):
+        raw = write(b"")
+        snap = read(raw)
+        assert snap.version == VERSION
+
+    def test_flags_no_iir(self):
+        raw = write(b"")
+        snap = read(raw)
+        assert not snap.has_vm_runtime
+
+    def test_flags_with_iir(self):
+        raw = write(b"", iir_table=b"[]")
+        snap = read(raw)
+        assert snap.has_vm_runtime
+
+    def test_flags_vm_runtime_bit_set(self):
+        raw = write(b"", iir_table=b"[]")
+        snap = read(raw)
+        assert snap.flags & FLAG_VM_RUNTIME
+
+
+# ---------------------------------------------------------------------------
+# Header format details
+# ---------------------------------------------------------------------------
+
+class TestHeaderFormat:
+    def test_magic_bytes(self):
+        raw = write(b"")
+        assert raw[:4] == MAGIC
+
+    def test_total_length_no_iir(self):
+        code = b"\xAA\xBB"
+        raw = write(code)
+        assert len(raw) == HEADER_SIZE + len(code)
+
+    def test_total_length_with_iir(self):
+        code = b"\x01\x02"
+        iir = b"\x03\x04\x05"
+        raw = write(code, iir_table=iir)
+        assert len(raw) == HEADER_SIZE + len(code) + len(iir)
+
+    def test_header_size_is_26(self):
+        assert HEADER_SIZE == 26
+
+    def test_iir_table_offset_zero_when_absent(self):
+        raw = write(b"\x01\x02\x03")
+        snap = read(raw)
+        assert not snap.has_vm_runtime
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+class TestReadErrors:
+    def test_too_short_raises(self):
+        with pytest.raises(ValueError, match="too short"):
+            read(b"\x00" * 10)
+
+    def test_bad_magic_raises(self):
+        raw = write(b"")
+        bad = b"BAD\x00" + raw[4:]
+        with pytest.raises(ValueError, match="bad magic"):
+            read(bad)
+
+    def test_truncated_code_section_raises(self):
+        code = b"\x01\x02\x03\x04"
+        raw = write(code)
+        # Chop 2 bytes from the code section.
+        with pytest.raises(ValueError, match="truncated"):
+            read(raw[:-2])
+
+    def test_truncated_iir_table_raises(self):
+        code = b"\xAA"
+        iir = b"\xBB\xCC\xDD"
+        raw = write(code, iir_table=iir)
+        # Keep header + code but chop the IIR table.
+        with pytest.raises(ValueError, match="truncated"):
+            read(raw[:HEADER_SIZE + len(code) + 1])
+
+
+# ---------------------------------------------------------------------------
+# AOTSnapshot properties
+# ---------------------------------------------------------------------------
+
+class TestAOTSnapshotProperties:
+    def test_has_vm_runtime_false(self):
+        snap = AOTSnapshot(version=VERSION, flags=0, entry_point_offset=0,
+                           native_code=b"", iir_table=None)
+        assert not snap.has_vm_runtime
+
+    def test_has_vm_runtime_true(self):
+        snap = AOTSnapshot(version=VERSION, flags=FLAG_VM_RUNTIME, entry_point_offset=0,
+                           native_code=b"", iir_table=b"[]")
+        assert snap.has_vm_runtime
+
+    def test_empty_iir_table_with_flag(self):
+        raw = write(b"", iir_table=b"")
+        snap = read(raw)
+        # FLAG_VM_RUNTIME is set but iir_table has 0 bytes.
+        assert snap.has_vm_runtime
+        assert snap.iir_table == b""

--- a/code/packages/python/aot-core/tests/test_specialise.py
+++ b/code/packages/python/aot-core/tests/test_specialise.py
@@ -1,0 +1,287 @@
+"""Tests for aot_core.specialise — AOT specialization pass."""
+
+from __future__ import annotations
+
+from conftest import make_fn, make_instr
+
+from aot_core.specialise import _spec_type, aot_specialise
+
+# ---------------------------------------------------------------------------
+# _spec_type helper
+# ---------------------------------------------------------------------------
+
+class TestSpecType:
+    def test_type_hint_wins(self):
+        instr = make_instr("add", "r", ["a", "b"], type_hint="u8")
+        assert _spec_type(instr, {}) == "u8"
+
+    def test_inferred_dest_used_when_hint_is_any(self):
+        instr = make_instr("add", "r", ["a", "b"])
+        assert _spec_type(instr, {"r": "u16"}) == "u16"
+
+    def test_inferred_any_falls_back_to_any(self):
+        instr = make_instr("add", "r", ["a", "b"])
+        assert _spec_type(instr, {"r": "any"}) == "any"
+
+    def test_no_inferred_gives_any(self):
+        instr = make_instr("add", "r", ["a", "b"])
+        assert _spec_type(instr, {}) == "any"
+
+    def test_ret_uses_src_type(self):
+        instr = make_instr("ret", srcs=["x"])
+        assert _spec_type(instr, {"x": "u8"}) == "u8"
+
+    def test_ret_src_not_in_env(self):
+        instr = make_instr("ret", srcs=["x"])
+        assert _spec_type(instr, {}) == "any"
+
+    def test_ret_literal_src(self):
+        instr = make_instr("ret", srcs=[42])
+        assert _spec_type(instr, {}) == "any"  # literal ints are not str
+
+
+# ---------------------------------------------------------------------------
+# const translation
+# ---------------------------------------------------------------------------
+
+class TestAOTSpecialiseConst:
+    def test_typed_hint_const(self):
+        fn = make_fn("f", [], make_instr("const", "v", [10], type_hint="u16"))
+        cir = aot_specialise(fn)
+        assert len(cir) == 1
+        assert cir[0].op == "const_u16"
+        assert cir[0].srcs == [10]
+
+    def test_untyped_const_infer_u8(self):
+        fn = make_fn("f", [], make_instr("const", "v", [42]))
+        cir = aot_specialise(fn, {"v": "u8"})
+        assert cir[0].op == "const_u8"
+
+    def test_const_bool_literal(self):
+        fn = make_fn("f", [], make_instr("const", "v", [True]))
+        cir = aot_specialise(fn)
+        assert cir[0].op == "const_bool"
+
+    def test_const_float_literal(self):
+        fn = make_fn("f", [], make_instr("const", "v", [3.14]))
+        cir = aot_specialise(fn)
+        assert cir[0].op == "const_f64"
+
+    def test_const_str_literal(self):
+        fn = make_fn("f", [], make_instr("const", "v", ["hello"]))
+        cir = aot_specialise(fn)
+        assert cir[0].op == "const_str"
+
+    def test_const_no_srcs(self):
+        fn = make_fn("f", [], make_instr("const", "v"))
+        cir = aot_specialise(fn)
+        assert cir[0].op == "const_u8"
+        assert cir[0].srcs == [0]
+
+    def test_const_u16_literal(self):
+        fn = make_fn("f", [], make_instr("const", "v", [256]))
+        cir = aot_specialise(fn)
+        assert cir[0].op == "const_u16"
+
+    def test_const_u32_literal(self):
+        fn = make_fn("f", [], make_instr("const", "v", [65536]))
+        cir = aot_specialise(fn)
+        assert cir[0].op == "const_u32"
+
+    def test_const_u64_literal(self):
+        fn = make_fn("f", [], make_instr("const", "v", [0x1_0000_0000]))
+        cir = aot_specialise(fn)
+        assert cir[0].op == "const_u64"
+
+    def test_const_none_value_gives_any(self):
+        fn = make_fn("f", [], make_instr("const", "v", [None]))
+        cir = aot_specialise(fn)
+        assert cir[0].op == "const_any"
+
+
+# ---------------------------------------------------------------------------
+# ret translation
+# ---------------------------------------------------------------------------
+
+class TestAOTSpecialiseRet:
+    def test_ret_typed_hint(self):
+        fn = make_fn(
+            "f", [("x", "u8")],
+            make_instr("ret", srcs=["x"], type_hint="u8"),
+        )
+        cir = aot_specialise(fn)
+        assert cir[0].op == "ret_u8"
+
+    def test_ret_via_inferred(self):
+        fn = make_fn(
+            "f", [("x", "u8")],
+            make_instr("ret", srcs=["x"]),
+        )
+        cir = aot_specialise(fn, {"x": "u8"})
+        assert cir[0].op == "ret_u8"
+
+    def test_ret_void(self):
+        fn = make_fn("f", [], make_instr("ret_void"))
+        cir = aot_specialise(fn)
+        assert cir[0].op == "ret_void"
+        assert cir[0].type == "void"
+
+    def test_ret_any_when_unknown(self):
+        fn = make_fn(
+            "f", [],
+            make_instr("ret", srcs=["x"]),
+        )
+        cir = aot_specialise(fn)
+        assert cir[0].op == "ret_any"
+
+
+# ---------------------------------------------------------------------------
+# binary ops
+# ---------------------------------------------------------------------------
+
+class TestAOTSpecialiseBinary:
+    def test_typed_add(self):
+        fn = make_fn(
+            "f", [("a", "u8"), ("b", "u8")],
+            make_instr("add", "r", ["a", "b"], type_hint="u8"),
+        )
+        cir = aot_specialise(fn)
+        ops = [c.op for c in cir]
+        assert "add_u8" in ops
+
+    def test_inferred_add(self):
+        fn = make_fn(
+            "f", [("a", "u8"), ("b", "u8")],
+            make_instr("add", "r", ["a", "b"]),
+        )
+        cir = aot_specialise(fn, {"r": "u8"})
+        assert any(c.op == "add_u8" for c in cir)
+
+    def test_untyped_add_generic(self):
+        fn = make_fn(
+            "f", [("a", "any"), ("b", "any")],
+            make_instr("add", "r", ["a", "b"]),
+        )
+        cir = aot_specialise(fn)
+        assert cir[0].op == "call_runtime"
+        assert cir[0].srcs[0] == "generic_add"
+
+    def test_add_str_str_special(self):
+        fn = make_fn(
+            "f", [("a", "str"), ("b", "str")],
+            make_instr("add", "r", ["a", "b"], type_hint="str"),
+        )
+        cir = aot_specialise(fn)
+        assert cir[0].op == "call_runtime"
+        assert cir[0].srcs[0] == "str_concat"
+
+    def test_guards_emitted_when_hint_any(self):
+        fn = make_fn(
+            "f", [("a", "any"), ("b", "any")],
+            make_instr("add", "r", ["a", "b"]),
+        )
+        cir = aot_specialise(fn, {"r": "u8"})
+        guard_ops = [c.op for c in cir if c.op == "type_assert"]
+        assert len(guard_ops) == 2  # one per variable src
+
+    def test_no_guards_when_hint_typed(self):
+        fn = make_fn(
+            "f", [("a", "u8"), ("b", "u8")],
+            make_instr("add", "r", ["a", "b"], type_hint="u8"),
+        )
+        cir = aot_specialise(fn)
+        assert all(c.op != "type_assert" for c in cir)
+
+    def test_cmp_inferred_to_bool(self):
+        fn = make_fn(
+            "f", [("a", "u8"), ("b", "u8")],
+            make_instr("cmp_lt", "r", ["a", "b"]),
+        )
+        cir = aot_specialise(fn, {"r": "bool"})
+        assert any(c.op == "cmp_lt_bool" for c in cir)
+
+
+# ---------------------------------------------------------------------------
+# unary ops
+# ---------------------------------------------------------------------------
+
+class TestAOTSpecialiseUnary:
+    def test_typed_neg(self):
+        fn = make_fn(
+            "f", [("x", "u8")],
+            make_instr("neg", "r", ["x"], type_hint="u8"),
+        )
+        cir = aot_specialise(fn)
+        assert any(c.op == "neg_u8" for c in cir)
+
+    def test_inferred_neg(self):
+        fn = make_fn(
+            "f", [("x", "u8")],
+            make_instr("neg", "r", ["x"]),
+        )
+        cir = aot_specialise(fn, {"r": "u8"})
+        assert any(c.op == "neg_u8" for c in cir)
+
+    def test_untyped_not_generic(self):
+        fn = make_fn(
+            "f", [("x", "any")],
+            make_instr("not", "r", ["x"]),
+        )
+        cir = aot_specialise(fn)
+        assert cir[0].op == "call_runtime"
+        assert "generic_not" in cir[0].srcs
+
+    def test_unary_guard_emitted(self):
+        fn = make_fn(
+            "f", [("x", "any")],
+            make_instr("neg", "r", ["x"]),
+        )
+        cir = aot_specialise(fn, {"r": "u8"})
+        guard_ops = [c.op for c in cir if c.op == "type_assert"]
+        assert len(guard_ops) == 1
+
+
+# ---------------------------------------------------------------------------
+# passthrough ops
+# ---------------------------------------------------------------------------
+
+class TestAOTSpecialisePassthrough:
+    def test_jmp_passes_through(self):
+        fn = make_fn("f", [], make_instr("jmp", srcs=["loop_start"]))
+        cir = aot_specialise(fn)
+        assert cir[0].op == "jmp"
+
+    def test_label_passes_through(self):
+        fn = make_fn("f", [], make_instr("label", srcs=["top"]))
+        cir = aot_specialise(fn)
+        assert cir[0].op == "label"
+
+    def test_jmp_if_false_passes_through(self):
+        fn = make_fn("f", [], make_instr("jmp_if_false", srcs=["cond", "end"]))
+        cir = aot_specialise(fn)
+        assert cir[0].op == "jmp_if_false"
+
+    def test_call_passes_through(self):
+        fn = make_fn("f", [], make_instr("call", "r", ["fn_name"]))
+        cir = aot_specialise(fn)
+        assert cir[0].op == "call"
+
+    def test_store_mem_passes_through(self):
+        fn = make_fn("f", [], make_instr("store_mem", srcs=["addr", "val"]))
+        cir = aot_specialise(fn)
+        assert cir[0].op == "store_mem"
+
+
+# ---------------------------------------------------------------------------
+# fallback / unknown ops
+# ---------------------------------------------------------------------------
+
+class TestAOTSpecialiseFallback:
+    def test_unknown_op_emitted_as_is(self):
+        fn = make_fn("f", [], make_instr("exotic_op", "r", ["x"]))
+        cir = aot_specialise(fn)
+        assert cir[0].op == "exotic_op"
+
+    def test_none_inferred_arg(self):
+        cir = aot_specialise(make_fn("f", []), None)
+        assert cir == []

--- a/code/packages/python/aot-core/tests/test_vm_runtime.py
+++ b/code/packages/python/aot-core/tests/test_vm_runtime.py
@@ -1,0 +1,111 @@
+"""Tests for aot_core.vm_runtime — IIR table serialisation."""
+
+from __future__ import annotations
+
+import json
+
+from conftest import make_fn, make_instr
+from interpreter_ir.function import FunctionTypeStatus
+
+from aot_core.vm_runtime import VmRuntime
+
+
+class TestVmRuntime:
+    def test_default_is_empty(self):
+        rt = VmRuntime()
+        assert rt.is_empty
+
+    def test_non_empty(self):
+        rt = VmRuntime(b"\x01\x02")
+        assert not rt.is_empty
+        assert rt.library_bytes == b"\x01\x02"
+
+    def test_serialise_empty_list(self):
+        rt = VmRuntime()
+        data = rt.serialise_iir_table([])
+        records = json.loads(data.decode())
+        assert records == []
+
+    def test_serialise_single_fn(self):
+        fn = make_fn(
+            "foo",
+            [("x", "u8")],
+            make_instr("ret", srcs=["x"]),
+        )
+        rt = VmRuntime()
+        data = rt.serialise_iir_table([fn])
+        records = json.loads(data.decode())
+        assert len(records) == 1
+        assert records[0]["name"] == "foo"
+
+    def test_serialise_params_preserved(self):
+        fn = make_fn("bar", [("a", "u8"), ("b", "u16")])
+        rt = VmRuntime()
+        data = rt.serialise_iir_table([fn])
+        records = json.loads(data.decode())
+        assert records[0]["params"] == [["a", "u8"], ["b", "u16"]]
+
+    def test_serialise_instructions_preserved(self):
+        fn = make_fn(
+            "baz", [],
+            make_instr("const", "v", [42]),
+            make_instr("ret", srcs=["v"]),
+        )
+        rt = VmRuntime()
+        data = rt.serialise_iir_table([fn])
+        records = json.loads(data.decode())
+        instrs = records[0]["instructions"]
+        assert len(instrs) == 2
+        assert instrs[0]["op"] == "const"
+        assert instrs[0]["dest"] == "v"
+        assert instrs[0]["srcs"] == [42]
+        assert instrs[1]["op"] == "ret"
+
+    def test_serialise_multiple_fns(self):
+        f1 = make_fn("f1", [])
+        f2 = make_fn("f2", [("x", "u8")])
+        rt = VmRuntime()
+        data = rt.serialise_iir_table([f1, f2])
+        records = json.loads(data.decode())
+        assert len(records) == 2
+        assert records[0]["name"] == "f1"
+        assert records[1]["name"] == "f2"
+
+    def test_deserialise_roundtrip(self):
+        fn = make_fn(
+            "roundtrip",
+            [("x", "u8")],
+            make_instr("const", "c", [99]),
+            make_instr("add", "r", ["x", "c"]),
+        )
+        rt = VmRuntime()
+        data = rt.serialise_iir_table([fn])
+        records = rt.deserialise_iir_table(data)
+        assert len(records) == 1
+        assert records[0]["name"] == "roundtrip"
+        assert len(records[0]["instructions"]) == 2
+
+    def test_type_status_serialised(self):
+        fn = make_fn("f", [], type_status=FunctionTypeStatus.UNTYPED)
+        rt = VmRuntime()
+        data = rt.serialise_iir_table([fn])
+        records = json.loads(data.decode())
+        assert records[0]["type_status"] == FunctionTypeStatus.UNTYPED.value
+
+    def test_instr_with_none_dest(self):
+        fn = make_fn("f", [("x", "u8")], make_instr("ret", srcs=["x"]))
+        rt = VmRuntime()
+        data = rt.serialise_iir_table([fn])
+        records = json.loads(data.decode())
+        instr = records[0]["instructions"][0]
+        assert instr["dest"] is None
+
+    def test_deopt_anchor_preserved(self):
+        fn = make_fn(
+            "f", [],
+            make_instr("add", "r", ["a", "b"], deopt_anchor=3),
+        )
+        rt = VmRuntime()
+        data = rt.serialise_iir_table([fn])
+        records = json.loads(data.decode())
+        assert records[0]["instructions"][0]["deopt_anchor"] == 3

--- a/lessons.md
+++ b/lessons.md
@@ -3188,3 +3188,13 @@ the shorter duration assumed by the first test.
 **Rule:** For text-score fixtures, count tokens and beats from the same duration rules used by the
 parser before asserting rendered sample counts. Prefer assertions that make the musical math visible:
 event count, note count, total beats, tempo-derived seconds, and sample-rate-derived sample count.
+
+---
+
+## Python BUILD files must use .venv/bin/python, not system python3.12
+
+**Date:** 2026-04-22
+
+**What happened:** The aot-core BUILD file used `python3.12 -m pytest` (the system Python) instead of `.venv/bin/python -m pytest`. Locally this worked because the system Python had the packages installed globally. On CI runners, only the uv venv has pytest and the other dependencies — the system Python has none of them.
+
+**Rule:** Python BUILD files must always run pytest via `.venv/bin/python -m pytest`, matching the pattern used by jit-core, interpreter-ir, and every other Python package in the repo. Never use `python3.12` or `python3` directly in a BUILD file.


### PR DESCRIPTION
## Summary

- Implements the AOT compilation path for the LANG pipeline (LANG04)
- Compiles an entire `IIRModule` to a self-contained `.aot` binary before runtime
- Functions that cannot be fully typed statically fall back to an IIR table for VM interpretation

## Modules added

| Module | Purpose |
|--------|---------|
| `aot_core.infer` | Flow-insensitive single-pass static type inference |
| `aot_core.specialise` | Lowers IIR to typed CIR using inferred-type map |
| `aot_core.snapshot` | 26-byte `.aot` binary format (magic, flags, offsets) |
| `aot_core.link` | Concatenates per-function blobs, tracks byte offsets |
| `aot_core.vm_runtime` | Wraps pre-compiled interpreter library; JSON IIR table |
| `aot_core.core` | `AOTCore` controller: infer→specialise→optimize→compile |
| `aot_core.stats` | `AOTStats` dataclass accumulating per-compile metrics |

## Test plan

- [x] 164 unit tests across 7 test modules
- [x] 100% line coverage
- [x] `ruff check` passes (no lint violations)
- [x] Security review passed (2 rounds); MEDIUM finding fixed: validated `vm_iir_table_offset` lower bound in snapshot reader to prevent header/code-section aliasing

🤖 Generated with [Claude Code](https://claude.com/claude-code)