### PR TITLE
feat(logic): add finite-domain sum constraint

### DIFF
--- a/code/packages/python/logic-builtins/CHANGELOG.md
+++ b/code/packages/python/logic-builtins/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.13.0] - 2026-04-22
+
+### Added
+
+- `fd_sumo(terms, total)` for CLP(FD)-style n-ary sum constraints over Python
+  sequences or proper logic lists
+- domain-pruning tests for concrete totals, result variables, empty sums, and
+  a resource-allocation example that reads like a small planning model
+
 ## [0.12.0] - 2026-04-22
 
 ### Added

--- a/code/packages/python/logic-builtins/README.md
+++ b/code/packages/python/logic-builtins/README.md
@@ -39,8 +39,8 @@ ordinary logic goal expressions.
   `fd_lto(left, right)`, `fd_leqo(left, right)`, `fd_gto(left, right)`,
   `fd_geqo(left, right)`, `fd_addo(left, right, result)`,
   `fd_subo(left, right, result)`, `fd_mulo(left, right, result)`,
-  `all_differento(vars)`, and `labelingo(vars)` for finite-domain integer
-  constraints
+  `fd_sumo(vars, total)`, `all_differento(vars)`, and `labelingo(vars)` for
+  finite-domain integer constraints
 - arithmetic expression constructors: `add`, `sub`, `mul`, `div`, `floordiv`, `mod`, and `neg`
 - `iso(result, expression)` for Prolog-style evaluative arithmetic
 - `numeqo(left, right)`, `numneqo(left, right)`, `lto(left, right)`, `leqo(left, right)`, `gto(left, right)`, and `geqo(left, right)`
@@ -63,7 +63,9 @@ from logic_builtins import (
     fd_addo,
     fd_ino,
     fd_leqo,
+    fd_lto,
     fd_neqo,
+    fd_sumo,
     findallo,
     forallo,
     functoro,
@@ -196,6 +198,17 @@ assert solve_all(
         labelingo([X, Y]),
     ),
 ) == [(num(1), num(4)), (num(2), num(3)), (num(3), num(2)), (num(4), num(1))]
+assert solve_all(
+    program(),
+    (X, Y),
+    conj(
+        fd_ino(X, range(1, 5)),
+        fd_ino(Y, range(1, 5)),
+        fd_sumo([X, Y, 1], 6),
+        fd_lto(X, Y),
+        labelingo([X, Y]),
+    ),
+) == [(num(1), num(4)), (num(2), num(3))]
 ```
 
 Arithmetic is evaluative, not a constraint system yet. `iso(Y, add(X, 1))`
@@ -207,8 +220,9 @@ stores a finite integer domain; comparison, arithmetic, and all-different
 predicates narrow domains as soon as enough information exists; and
 `labelingo([X, Y])` enumerates concrete assignments in ascending order.
 Arithmetic constraints currently cover addition, subtraction, and
-multiplication. `all_differento` includes duplicate checks and singleton
-pruning, while deeper Hall-set global-constraint pruning remains future work.
+multiplication, plus `fd_sumo` for n-ary sums. `all_differento` includes
+duplicate checks and singleton pruning, while deeper Hall-set global-constraint
+pruning remains future work.
 `labelingo` chooses the smallest current finite domain first and uses the
 caller-provided variable order as a stable tie-breaker.
 
@@ -248,9 +262,10 @@ assert solve_n(
 ) == [(num(1), num(2), num(3), num(1), num(2), num(1), num(1))]
 ```
 
-Scheduling and puzzle-style problems use the same ingredients: finite start
-times, arithmetic relations for durations, ordering constraints for
-dependencies, and `labelingo(...)` to enumerate concrete assignments.
+Scheduling, budgeting, and puzzle-style problems use the same ingredients:
+finite start times, arithmetic relations for durations, `fd_sumo(...)` for
+resource totals, ordering constraints for dependencies, and `labelingo(...)` to
+enumerate concrete assignments.
 
 Collections are observations over a nested proof search. `findallo` succeeds
 with an empty list when the inner goal fails, while `bagofo` and `setofo` fail

--- a/code/packages/python/logic-builtins/pyproject.toml
+++ b/code/packages/python/logic-builtins/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-logic-builtins"
-version = "0.12.0"
-description = "Prolog-inspired finite-domain examples, arithmetic, cut, dynamic database, callable-term, predicate-metadata, term-order, control, and metaprogramming builtins for Python"
+version = "0.13.0"
+description = "Prolog-inspired finite-domain sum constraints, examples, arithmetic, cut, dynamic database, callable-term, predicate-metadata, term-order, control, and metaprogramming builtins for Python"
 requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]

--- a/code/packages/python/logic-builtins/src/logic_builtins/__init__.py
+++ b/code/packages/python/logic-builtins/src/logic_builtins/__init__.py
@@ -38,6 +38,7 @@ from logic_builtins.builtins import (
     fd_mulo,
     fd_neqo,
     fd_subo,
+    fd_sumo,
     findallo,
     floordiv,
     forallo,
@@ -107,6 +108,7 @@ __all__ = [
     "fd_mulo",
     "fd_neqo",
     "fd_subo",
+    "fd_sumo",
     "dynamico",
     "failo",
     "FiniteDomainConstraint",
@@ -149,4 +151,4 @@ __all__ = [
     "varo",
 ]
 
-__version__ = "0.12.0"
+__version__ = "0.13.0"

--- a/code/packages/python/logic-builtins/src/logic_builtins/builtins.py
+++ b/code/packages/python/logic-builtins/src/logic_builtins/builtins.py
@@ -88,6 +88,7 @@ __all__ = [
     "fd_mulo",
     "fd_neqo",
     "fd_subo",
+    "fd_sumo",
     "failo",
     "FiniteDomainConstraint",
     "FiniteDomainStore",
@@ -190,6 +191,7 @@ _BUILTIN_PREDICATES: tuple[tuple[str, int], ...] = (
     ("fd_mulo", 3),
     ("fd_neqo", 2),
     ("fd_subo", 3),
+    ("fd_sumo", 2),
     ("failo", 0),
     ("findallo", 3),
     ("forallo", 2),
@@ -483,6 +485,9 @@ def _fd_tuple_satisfies(
     if constraint.operator == "mul":
         left, right, result = values
         return left * right == result
+    if constraint.operator == "sum":
+        *terms_value, result = values
+        return sum(terms_value) == result
     if constraint.operator == "all_different":
         return len(set(values)) == len(values)
     msg = f"unknown finite-domain constraint {constraint.operator}"
@@ -696,6 +701,52 @@ def _revise_arithmetic_constraint_domains(
     return updated, changed
 
 
+def _revise_sum_constraint_domains(
+    values: tuple[LogicVar | int, ...],
+    value_domains: tuple[frozenset[int], ...],
+    domains: dict[LogicVar, frozenset[int]],
+) -> tuple[dict[LogicVar, frozenset[int]] | None, bool]:
+    """Prune sum domains by checking each candidate against interval bounds."""
+
+    term_domains = value_domains[:-1]
+    result_domain = value_domains[-1]
+    updated = dict(domains)
+    changed = False
+    term_mins = tuple(min(domain) for domain in term_domains)
+    term_maxes = tuple(max(domain) for domain in term_domains)
+    min_total = sum(term_mins)
+    max_total = sum(term_maxes)
+
+    for index, value in enumerate(values):
+        if not isinstance(value, LogicVar):
+            continue
+        current_domain = value_domains[index]
+        if index == len(values) - 1:
+            allowed = frozenset(
+                candidate
+                for candidate in current_domain
+                if min_total <= candidate <= max_total
+            )
+        else:
+            other_min = min_total - term_mins[index]
+            other_max = max_total - term_maxes[index]
+            allowed = frozenset(
+                candidate
+                for candidate in current_domain
+                if any(
+                    other_min <= result - candidate <= other_max
+                    for result in result_domain
+                )
+            )
+        if not allowed:
+            return None, False
+        if allowed != current_domain:
+            updated[value] = allowed
+            changed = True
+
+    return updated, changed
+
+
 def _revise_all_different_domains(
     values: tuple[LogicVar | int, ...],
     value_domains: tuple[frozenset[int] | None, ...],
@@ -778,6 +829,8 @@ def _revise_constraint_domains(
             known_domains,
             domains,
         )
+    if constraint.operator == "sum":
+        return _revise_sum_constraint_domains(values, known_domains, domains)
 
     msg = f"unknown finite-domain constraint {constraint.operator}"
     raise ValueError(msg)
@@ -1125,6 +1178,36 @@ def fd_mulo(left: object, right: object, result: object) -> GoalExpr:
     """Constrain three finite-domain terms so ``left * right == result``."""
 
     return _fd_constrainto("mul", left, right, result)
+
+
+def _sum_terms_goal(terms_value: tuple[Term, ...], result: object) -> GoalExpr:
+    """Create a sum goal for already materialized finite-domain terms."""
+
+    return _fd_constrainto("sum", *terms_value, result)
+
+
+def fd_sumo(terms_value: object, result: object) -> GoalExpr:
+    """Constrain finite-domain terms so their sum equals ``result``."""
+
+    if isinstance(terms_value, list | tuple):
+        return _sum_terms_goal(tuple(terms_value), result)
+
+    def run_logic_list(
+        program_value: Program,
+        state: State,
+        args: NativeArgs,
+    ) -> Iterator[State]:
+        terms_term, result_term = args
+        items = _proper_list_items(_reified(terms_term, state))
+        if items is None:
+            return
+        yield from solve_from(
+            program_value,
+            _sum_terms_goal(tuple(items), result_term),
+            state,
+        )
+
+    return native_goal(run_logic_list, terms_value, result)
 
 
 def _all_different_terms_goal(terms_value: tuple[Term, ...]) -> GoalExpr:

--- a/code/packages/python/logic-builtins/tests/test_logic_builtins.py
+++ b/code/packages/python/logic-builtins/tests/test_logic_builtins.py
@@ -58,6 +58,7 @@ from logic_builtins import (
     fd_mulo,
     fd_neqo,
     fd_subo,
+    fd_sumo,
     findallo,
     floordiv,
     forallo,
@@ -101,7 +102,7 @@ class TestVersion:
     """Verify the package is importable and versioned."""
 
     def test_version_exists(self) -> None:
-        assert __version__ == "0.12.0"
+        assert __version__ == "0.13.0"
 
 
 class TestAdvancedControlBuiltins:
@@ -661,6 +662,76 @@ class TestFiniteDomainBuiltins:
             ),
         ) == [(num(2), num(6)), (num(3), num(4))]
 
+    def test_fd_sumo_solves_n_ary_sum_constraints(self) -> None:
+        left = var("Left")
+        middle = var("Middle")
+        right = var("Right")
+        values = (left, middle, right)
+
+        assert solve_all(
+            program(),
+            values,
+            conj(
+                *(fd_ino(value, range(1, 5)) for value in values),
+                fd_sumo(values, 6),
+                all_differento(values),
+                labelingo(values),
+            ),
+        ) == [
+            (num(1), num(2), num(3)),
+            (num(1), num(3), num(2)),
+            (num(2), num(1), num(3)),
+            (num(2), num(3), num(1)),
+            (num(3), num(1), num(2)),
+            (num(3), num(2), num(1)),
+        ]
+
+    def test_fd_sumo_accepts_logic_lists_and_result_variables(self) -> None:
+        left = var("Left")
+        right = var("Right")
+        total = var("Total")
+
+        assert solve_all(
+            program(),
+            (left, right, total),
+            conj(
+                fd_ino(left, range(1, 4)),
+                fd_ino(right, range(1, 4)),
+                fd_ino(total, [4]),
+                fd_sumo(logic_list([left, right]), total),
+                fd_lto(left, right),
+                labelingo([left, right, total]),
+            ),
+        ) == [(num(1), num(3), num(4))]
+
+    def test_fd_sumo_prunes_result_domain_before_labeling(self) -> None:
+        total = var("Total")
+
+        assert solve_all(
+            program(),
+            total,
+            conj(
+                fd_ino(total, range(0, 10)),
+                fd_sumo([1, 2, 3], total),
+                labelingo([total]),
+            ),
+        ) == [num(6)]
+
+    def test_fd_sumo_handles_empty_sums(self) -> None:
+        total = var("Total")
+        marker = var("Marker")
+
+        assert solve_all(
+            program(),
+            total,
+            conj(fd_ino(total, range(0, 3)), fd_sumo([], total), labelingo([total])),
+        ) == [num(0)]
+        assert solve_all(
+            program(),
+            marker,
+            conj(eq(marker, "ok"), fd_sumo([], 1)),
+        ) == []
+
     def test_all_differento_prunes_singleton_assignments(self) -> None:
         left = var("Left")
         middle = var("Middle")
@@ -821,13 +892,37 @@ class TestFiniteDomainBuiltins:
             conj(
                 *(fd_ino(time, range(0, 7)) for time in all_times),
                 fd_ino(test, range(0, 5)),
-                fd_addo(design, 1, design_done),
+                fd_sumo([design, 1], design_done),
                 fd_leqo(design_done, build),
-                fd_addo(build, 2, build_done),
+                fd_sumo([build, 2], build_done),
                 fd_leqo(build_done, test),
                 labelingo(starts),
             ),
         ) == [(num(0), num(1), num(3))]
+
+    def test_fd_sumo_models_resource_allocation(self) -> None:
+        design_hours = var("DesignHours")
+        build_hours = var("BuildHours")
+        test_hours = var("TestHours")
+        hours = (design_hours, build_hours, test_hours)
+
+        assert solve_n(
+            program(),
+            3,
+            hours,
+            conj(
+                fd_ino(design_hours, range(1, 4)),
+                fd_ino(build_hours, range(2, 5)),
+                fd_ino(test_hours, range(1, 3)),
+                fd_sumo(hours, 7),
+                fd_geqo(build_hours, design_hours),
+                labelingo(hours),
+            ),
+        ) == [
+            (num(2), num(4), num(1)),
+            (num(3), num(3), num(1)),
+            (num(1), num(4), num(2)),
+        ]
 
 
 class TestControlBuiltins:

--- a/code/specs/LP18-logic-prolog-functionality-batches.md
+++ b/code/specs/LP18-logic-prolog-functionality-batches.md
@@ -65,6 +65,7 @@ LP18 Batch C search control and real cut
 LP18 Batch D1 CLP(FD) foundation
 LP18 Batch D2/D3 CLP(FD) arithmetic and all-different
 LP18 Batch D4 CLP(FD) examples and labeling ergonomics
+LP18 Batch D5 CLP(FD) n-ary sum ergonomics
 PR00 Prolog lexer
 ```
 
@@ -265,6 +266,7 @@ CLP(FD) is being delivered in a few sub-batches:
 - D2: arithmetic expression constraints
 - D3: global constraints such as `all_differento`
 - D4: real-world examples, solver ergonomics, and performance tuning
+- D5: modeling ergonomics such as n-ary sums for allocation and scheduling
 
 ## Detailed Batch A Semantics
 
@@ -525,6 +527,23 @@ D4 non-goals:
 - no search strategy API beyond the default smallest-domain labeling heuristic
 - no global-constraint algorithms beyond the current singleton pruning
 
+D5 implementation shape:
+
+- `fd_sumo(terms, total)` constrains a Python sequence or proper logic list of
+  finite-domain terms so their sum equals `total`
+- the sum relation should support concrete totals, finite-domain result
+  variables, and the empty-sum identity where `sum([]) = 0`
+- the propagator may use safe interval pruning for broad domains, while
+  concrete assignments are checked exactly
+- examples should show resource-allocation or scheduling-style models that are
+  much clearer with an n-ary sum than with nested binary `fd_addo` helpers
+
+D5 non-goals:
+
+- no symbolic linear-expression DSL yet
+- no weighted scalar-product API yet
+- no complete subset-sum or pseudo-Boolean propagator
+
 ## PR Sizing Recommendation
 
 Use this implementation sequence:
@@ -536,7 +555,8 @@ PR 3: Batch C - real cut and search control
 PR 4: Batch D1 - CLP(FD) foundation
 PR 5: Batch D2/D3 - arithmetic propagation and all-different
 PR 6: Batch D4 - larger examples and labeling ergonomics
-PR 7+: later CLP(FD) extensions, parser integration, or advanced propagation
+PR 7: Batch D5 - n-ary sum ergonomics
+PR 8+: later CLP(FD) extensions, parser integration, or advanced propagation
 ```
 
 This is the fewest practical set of large PRs without forcing unrelated solver
@@ -568,6 +588,8 @@ Batch-specific tests:
 - Batch D: labeling enumerates only assignments that satisfy all constraints
 - Batch D2/D3: arithmetic constraints prune domains before labeling
 - Batch D2/D3: `all_differento` solves a small Latin-square-style problem
+- Batch D5: `fd_sumo` handles Python sequences, logic lists, result variables,
+  empty sums, and a resource-allocation example
 
 ## Security and Robustness Notes
 
@@ -590,6 +612,6 @@ few big batches rather than many tiny PRs.
 
 Batch A completed the pure metaprogramming loop, Batch B added runtime dynamic
 predicates, Batch C added real cut, and Batch D now covers finite domains,
-arithmetic constraints, all-different, and practical examples. Later CLP(FD)
-work can deepen propagation, add reification, or connect parser syntax onto the
-same Python-first runtime.
+arithmetic constraints, all-different, practical examples, and n-ary sums.
+Later CLP(FD) work can deepen propagation, add reification, or connect parser
+syntax onto the same Python-first runtime.


### PR DESCRIPTION
## Summary
- add fd_sumo(terms, total) for n-ary finite-domain sum constraints over Python sequences and proper logic lists
- add interval-safe pruning for sum constraints plus exact concrete assignment checks
- cover result variables, empty sums, scheduling/resource-allocation examples, docs, LP18 D5 spec updates, and logic-builtins 0.13.0

## Verification
- bash BUILD
- /opt/homebrew/bin/ruff check .
- .venv/bin/python -m compileall -q src tests
- git diff --check HEAD~1 HEAD