### PR TITLE
feat(symbolic-vm): Phase 12 — polynomial × asin/acos(linear) integration via IBP

### DIFF
--- a/code/packages/python/macsyma-compiler/CHANGELOG.md
+++ b/code/packages/python/macsyma-compiler/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.4.0 — 2026-04-23
+
+- Added `"asin": ASIN` and `"acos": ACOS` to `_STANDARD_FUNCTIONS` in `compiler.py`,
+  mapping the MACSYMA names `asin`/`acos` to `IRSymbol("Asin")`/`IRSymbol("Acos")`.
+  Required by `symbolic-vm` Phase 12 so that `integrate(asin(ax+b), x)` and
+  `integrate(acos(ax+b), x)` are correctly compiled before evaluation.
+  Depends on `coding-adventures-symbolic-ir >= 0.4.0` which introduces the ASIN/ACOS heads.
+
 ## 0.3.0 — 2026-04-22
 
 - Added `"atan": ATAN` to `_STANDARD_FUNCTIONS` in `compiler.py`, mapping

--- a/code/packages/python/macsyma-compiler/pyproject.toml
+++ b/code/packages/python/macsyma-compiler/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-macsyma-compiler"
-version = "0.3.0"
+version = "0.4.0"
 description = "Lowers parsed MACSYMA ASTs to the universal symbolic IR."
 requires-python = ">=3.12"
 license = "MIT"
@@ -19,7 +19,7 @@ dependencies = [
     "coding-adventures-macsyma-parser",
     "coding-adventures-parser",
     "coding-adventures-state-machine",
-    "coding-adventures-symbolic-ir",
+    "coding-adventures-symbolic-ir>=0.4.0",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/code/packages/python/macsyma-compiler/src/macsyma_compiler/compiler.py
+++ b/code/packages/python/macsyma-compiler/src/macsyma_compiler/compiler.py
@@ -33,7 +33,9 @@ from __future__ import annotations
 from lang_parser import ASTNode
 from lexer import Token
 from symbolic_ir import (
+    ACOS,
     ADD,
+    ASIN,
     ASSIGN,
     ATAN,
     COS,
@@ -114,6 +116,8 @@ _STANDARD_FUNCTIONS: dict[str, IRSymbol] = {
     "sin": SIN,
     "cos": COS,
     "tan": TAN,
+    "asin": ASIN,
+    "acos": ACOS,
     "atan": ATAN,
     "log": LOG,
     "exp": EXP,

--- a/code/packages/python/symbolic-ir/CHANGELOG.md
+++ b/code/packages/python/symbolic-ir/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.4.0 — 2026-04-22
+
+- Added `ASIN = IRSymbol("Asin")` and `ACOS = IRSymbol("Acos")` to the
+  elementary-functions group in `nodes.py` (after `ATAN`) and exported both
+  from `__init__.py`. Required by Phase 12 of the symbolic integration
+  roadmap (`∫ P(x)·asin(ax+b) dx` and `∫ P(x)·acos(ax+b) dx`). See
+  `phase12-poly-asin-acos.md`.
+
 ## 0.3.0 — 2026-04-20
 
 - Added `TAN = IRSymbol("Tan")` to the elementary-functions group in

--- a/code/packages/python/symbolic-ir/pyproject.toml
+++ b/code/packages/python/symbolic-ir/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-symbolic-ir"
-version = "0.3.0"
+version = "0.4.0"
 description = "Universal symbolic expression IR — the shared tree representation that every CAS frontend compiles to and every CAS backend consumes."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/symbolic-ir/src/symbolic_ir/__init__.py
+++ b/code/packages/python/symbolic-ir/src/symbolic_ir/__init__.py
@@ -28,8 +28,10 @@ Example::
 """
 
 from symbolic_ir.nodes import (
+    ACOS,
     ADD,
     AND,
+    ASIN,
     ASSIGN,
     ATAN,
     COS,
@@ -76,6 +78,8 @@ __all__ = [
     "IRString",
     "IRApply",
     # Standard head symbols
+    "ACOS",
+    "ASIN",
     "ATAN",
     "ADD",
     "SUB",

--- a/code/packages/python/symbolic-ir/src/symbolic_ir/nodes.py
+++ b/code/packages/python/symbolic-ir/src/symbolic_ir/nodes.py
@@ -187,6 +187,8 @@ COS = IRSymbol("Cos")
 TAN = IRSymbol("Tan")
 SQRT = IRSymbol("Sqrt")
 ATAN = IRSymbol("Atan")
+ASIN = IRSymbol("Asin")
+ACOS = IRSymbol("Acos")
 
 # Calculus
 D = IRSymbol("D")

--- a/code/packages/python/symbolic-vm/CHANGELOG.md
+++ b/code/packages/python/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## 0.17.0 — 2026-04-23
+
+Phase 12 of the integration roadmap — polynomial × asin/acos(linear) integration via IBP.
+
+**New capability**: `∫ P(x) · asin(ax+b) dx` and `∫ P(x) · acos(ax+b) dx` for any
+`P ∈ Q[x]` and `a ∈ Q \ {0}`, completing all three inverse-trig × polynomial families.
+
+**Algorithm** (integration by parts):
+
+- **asin IBP**: `u = asin(ax+b)`, `dv = P dx` → `du = a/√(1−(ax+b)²) dx`, `v = Q = ∫P dx`
+  - Residual: `a · ∫ Q/√(1−(ax+b)²) dx = ∫ Q̃(t)/√(1−t²) dt`  (t = ax+b substitution)
+  - Residual decomposed via reduction formula: `∫ Q̃/√(1−t²) dt = A(t)·√(1−t²) + B(t)·asin(t)`
+  - Final result: `[Q(x) − B(ax+b)]·asin(ax+b) − A(ax+b)·√(1−(ax+b)²)`
+
+- **acos IBP**: sign of `du` flips (`d/dx acos = −a/√`), giving
+  - Final result: `Q(x)·acos(ax+b) + A(ax+b)·√(1−(ax+b)²) + B(ax+b)·asin(ax+b)`
+  - The B·asin term is non-zero for deg(P) ≥ 1 — this is expected, not a bug.
+
+**New module** `asin_poly_integral.py`:
+- `asin_poly_integral(poly, a, b, x_sym)` — IBP closed-form for `∫ P(x)·asin(ax+b) dx`.
+- `acos_poly_integral(poly, a, b, x_sym)` — IBP closed-form for `∫ P(x)·acos(ax+b) dx`.
+- Private helpers: `_compose_to_t`, `_sqrt_integral_decompose`, `_poly_compose_linear`, `_compute_AB`.
+- Reduction formula is memoized per monomial degree for efficiency.
+
+**Dispatcher hooks** in `integrate.py`:
+- `_try_asin_product` / `_try_acos_product` — check ASIN/ACOS head, validate linear arg and polynomial coefficient.
+- Both hooks try both operand orders, inserted after Phase 11 in the MUL handler.
+- Bare `asin/acos(linear)` cases (P = 1) handled in the elementary-function branch.
+- Differentiation rules for `d/dx asin(u)` and `d/dx acos(u)` added to `_diff_ir`.
+
+**VM handlers** in `handlers.py`:
+- `asin(simplify)` and `acos(simplify)` handlers registered (numeric fold + symbolic passthrough).
+
+**symbolic-ir**: bumped dependency to `>=0.4.0` (requires ASIN/ACOS head symbols).
+
+**Limitations (future work)**:
+- `∫ asin(g(x))` for non-linear `g`.
+- `∫ asin(ax+b)^n dx` for `n ≥ 2`.
+- `∫ asin(ax+b) · exp(x) dx` (mixed inverse-trig × exponential).
+
 ## 0.16.0 — 2026-04-22
 
 Phase 11 of the integration roadmap — polynomial × arctan(linear) integration via IBP.

--- a/code/packages/python/symbolic-vm/pyproject.toml
+++ b/code/packages/python/symbolic-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-symbolic-vm"
-version = "0.16.0"
+version = "0.17.0"
 description = "Pluggable symbolic VM — evaluates symbolic-ir trees through swappable backends (strict numeric vs. Mathematica-style symbolic rewriting)."
 requires-python = ">=3.12"
 license = "MIT"
@@ -12,7 +12,7 @@ authors = [{ name = "Adhithya Rajasekaran" }]
 readme = "README.md"
 keywords = ["symbolic", "vm", "interpreter", "cas", "term-rewriting", "education"]
 dependencies = [
-    "coding-adventures-symbolic-ir>=0.3.0",
+    "coding-adventures-symbolic-ir>=0.4.0",
     "coding-adventures-polynomial",
     "coding-adventures-macsyma-parser",
     "coding-adventures-macsyma-compiler",

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/asin_poly_integral.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/asin_poly_integral.py
@@ -1,0 +1,363 @@
+"""Polynomial × asin/acos(linear) integration — Phase 12.
+
+Integrates ``P(x) · asin(ax+b)`` and ``P(x) · acos(ax+b)`` for
+``P ∈ Q[x]`` and ``a ∈ Q \\ {0}`` via integration by parts.
+
+**asin IBP:**
+
+    u = asin(ax+b),  dv = P(x) dx
+    du = a/√(1−(ax+b)²) dx,  v = Q(x) = ∫P dx
+
+    ∫ P·asin(ax+b) dx = Q(x)·asin(ax+b) − a · ∫ Q(x)/√(1−(ax+b)²) dx
+
+**Residual via substitution t = ax+b:**
+
+    a · ∫ Q(x)/√(1−(ax+b)²) dx  =  ∫ Q̃(t)/√(1−t²) dt
+
+where Q̃(t) = Q((t−b)/a) (same-degree polynomial in t).
+
+**Reduction formula** for monomials:
+
+    ∫ tⁿ/√(1−t²) dt = −tⁿ⁻¹·√(1−t²)/n + (n−1)/n · ∫ tⁿ⁻²/√(1−t²) dt
+    base: n=0 → asin(t),  n=1 → −√(1−t²)
+
+By linearity:  ∫ Q̃(t)/√(1−t²) dt = A(t)·√(1−t²) + B(t)·asin(t)
+
+where A(t) and B(t) are polynomials computed by ``_sqrt_integral_decompose``.
+
+**Final results after back-substituting t = ax+b:**
+
+    asin: [Q(x) − B(ax+b)] · asin(ax+b) − A(ax+b) · √(1−(ax+b)²)
+    acos: Q(x) · acos(ax+b) + A(ax+b) · √(1−(ax+b)²) + B(ax+b) · asin(ax+b)
+
+The acos result legitimately contains an asin term for deg(P) ≥ 1 because
+d/dx acos = −d/dx asin, so acos IBP flips the sign of the residual and
+the √ term also changes sign; the B·asin part survives as a separate term.
+
+See ``code/specs/phase12-poly-asin-acos.md`` for the full derivation and
+worked examples.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+from symbolic_ir import (
+    ACOS,
+    ADD,
+    ASIN,
+    MUL,
+    POW,
+    SQRT,
+    SUB,
+    IRApply,
+    IRInteger,
+    IRNode,
+    IRRational,
+    IRSymbol,
+)
+
+from symbolic_vm.polynomial_bridge import from_polynomial, linear_to_ir
+
+# Polynomial represented as a tuple of Fraction coefficients in ascending
+# degree order: (c₀, c₁, …, cₙ) encodes c₀ + c₁·t + … + cₙ·tⁿ.
+Poly = tuple[Fraction, ...]
+
+
+# ---------------------------------------------------------------------------
+# Public entry points
+# ---------------------------------------------------------------------------
+
+
+def asin_poly_integral(
+    poly: Poly,
+    a: Fraction,
+    b: Fraction,
+    x_sym: IRSymbol,
+) -> IRNode:
+    """Return the IR for ``∫ poly(x) · asin(ax+b) dx``.
+
+    Pre-conditions (caller's responsibility):
+    - ``a ≠ 0``
+    - ``poly`` is non-empty with Fraction coefficients.
+
+    Always returns a closed-form IR.
+
+    The result is:
+        [Q(x) − B(ax+b)] · asin(ax+b) − A(ax+b) · √(1−(ax+b)²)
+
+    where Q = ∫poly dx and A, B are computed from the residual integral
+    ∫ Q̃(t)/√(1−t²) dt = A(t)·√(1−t²) + B(t)·asin(t).
+    """
+    p = _normalize(poly)
+    if not p:
+        return IRInteger(0)
+
+    Q = _integrate_poly(p)
+    A_x, B_x = _compute_AB(Q, a, b)
+
+    arg_ir = linear_to_ir(a, b, x_sym)
+
+    # asin coefficient: Q(x) − B(ax+b)
+    # If B is zero, the coefficient is just Q(x).
+    Q_ir = from_polynomial(Q, x_sym)
+    B_x_norm = _normalize(B_x)
+    if B_x_norm:
+        B_ir = from_polynomial(B_x_norm, x_sym)
+        asin_coef = IRApply(SUB, (Q_ir, B_ir))
+    else:
+        asin_coef = Q_ir
+
+    asin_ir = IRApply(ASIN, (arg_ir,))
+    main_term = IRApply(MUL, (asin_coef, asin_ir))
+
+    # sqrt coefficient: A(ax+b) · √(1−(ax+b)²)
+    A_x_norm = _normalize(A_x)
+    sqrt_inner = IRApply(SUB, (IRInteger(1), IRApply(POW, (arg_ir, IRInteger(2)))))
+    sqrt_ir = IRApply(SQRT, (sqrt_inner,))
+
+    if A_x_norm:
+        A_ir = from_polynomial(A_x_norm, x_sym)
+        sqrt_term = IRApply(MUL, (A_ir, sqrt_ir))
+        return IRApply(SUB, (main_term, sqrt_term))
+
+    # A = 0 (can only happen for deg 0 poly): just the asin term.
+    return main_term
+
+
+def acos_poly_integral(
+    poly: Poly,
+    a: Fraction,
+    b: Fraction,
+    x_sym: IRSymbol,
+) -> IRNode:
+    """Return the IR for ``∫ poly(x) · acos(ax+b) dx``.
+
+    Pre-conditions same as :func:`asin_poly_integral`.
+
+    The result is:
+        Q(x) · acos(ax+b) + A(ax+b) · √(1−(ax+b)²) + B(ax+b) · asin(ax+b)
+
+    The sign flip from acos IBP (d/dx acos = −a/√(1−t²)) reverses the √
+    term and turns the B·asin term into an addition rather than subtraction.
+    When B = 0 (deg poly = 0) the asin term is omitted.
+    """
+    p = _normalize(poly)
+    if not p:
+        return IRInteger(0)
+
+    Q = _integrate_poly(p)
+    A_x, B_x = _compute_AB(Q, a, b)
+
+    arg_ir = linear_to_ir(a, b, x_sym)
+
+    # Main term: Q(x) · acos(ax+b)
+    Q_ir = from_polynomial(Q, x_sym)
+    acos_ir = IRApply(ACOS, (arg_ir,))
+    main_term = IRApply(MUL, (Q_ir, acos_ir))
+
+    sqrt_inner = IRApply(SUB, (IRInteger(1), IRApply(POW, (arg_ir, IRInteger(2)))))
+    sqrt_ir = IRApply(SQRT, (sqrt_inner,))
+
+    A_x_norm = _normalize(A_x)
+    B_x_norm = _normalize(B_x)
+
+    result: IRNode = main_term
+
+    # Add A(ax+b) · √(1−(ax+b)²)
+    if A_x_norm:
+        A_ir = from_polynomial(A_x_norm, x_sym)
+        sqrt_term = IRApply(MUL, (A_ir, sqrt_ir))
+        result = IRApply(ADD, (result, sqrt_term))
+
+    # Add B(ax+b) · asin(ax+b)  — only when B ≠ 0
+    if B_x_norm:
+        B_ir = from_polynomial(B_x_norm, x_sym)
+        asin_ir = IRApply(ASIN, (arg_ir,))
+        asin_term = IRApply(MUL, (B_ir, asin_ir))
+        result = IRApply(ADD, (result, asin_term))
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Shared computation
+# ---------------------------------------------------------------------------
+
+
+def _compute_AB(
+    Q: Poly,
+    a: Fraction,
+    b: Fraction,
+) -> tuple[Poly, Poly]:
+    """Return ``(A_x, B_x)`` such that
+
+        ∫ Q̃(t)/√(1−t²) dt = A(t)·√(1−t²) + B(t)·asin(t)
+
+    and then back-substituted as x-polynomials A(ax+b) and B(ax+b).
+
+    Steps:
+    1. Compose Q → Q̃(t) = Q((t−b)/a)   (change of variable)
+    2. Decompose ∫ Q̃/√(1−t²) dt = A(t)·√ + B(t)·asin
+    3. Compose A and B back: A_x(x) = A(ax+b), B_x(x) = B(ax+b)
+    """
+    Q_tilde = _compose_to_t(Q, a, b)
+    A_t, B_t = _sqrt_integral_decompose(Q_tilde)
+    A_x = _poly_compose_linear(A_t, a, b)
+    B_x = _poly_compose_linear(B_t, a, b)
+    return A_x, B_x
+
+
+# ---------------------------------------------------------------------------
+# Polynomial helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalize(p: Poly) -> Poly:
+    """Strip trailing zeros; return empty tuple for the zero polynomial."""
+    lst = list(p)
+    while lst and lst[-1] == Fraction(0):
+        lst.pop()
+    return tuple(lst)
+
+
+def _integrate_poly(p: Poly) -> Poly:
+    """Polynomial antiderivative (constant = 0): aᵢxⁱ → aᵢ/(i+1)·xⁱ⁺¹."""
+    if not p:
+        return ()
+    result: list[Fraction] = [Fraction(0)]
+    for i, c in enumerate(p):
+        result.append(Fraction(c) / Fraction(i + 1))
+    return _normalize(tuple(result))
+
+
+def _poly_mul(p: Poly, q: Poly) -> Poly:
+    """Multiply two polynomials."""
+    if not p or not q:
+        return ()
+    deg = len(p) + len(q) - 2
+    result = [Fraction(0)] * (deg + 1)
+    for i, ci in enumerate(p):
+        for j, cj in enumerate(q):
+            result[i + j] += ci * cj
+    return _normalize(tuple(result))
+
+
+def _poly_add(p: Poly, q: Poly) -> Poly:
+    """Add two polynomials."""
+    n = max(len(p), len(q))
+    result = [Fraction(0)] * n
+    for i, c in enumerate(p):
+        result[i] += c
+    for i, c in enumerate(q):
+        result[i] += c
+    return _normalize(tuple(result))
+
+
+def _poly_scale(c: Fraction, p: Poly) -> Poly:
+    """Multiply a polynomial by a scalar."""
+    return _normalize(tuple(c * ci for ci in p))
+
+
+def _compose_to_t(Q: Poly, a: Fraction, b: Fraction) -> Poly:
+    """Compute Q((t−b)/a) as a t-polynomial.
+
+    Uses Horner-like composition: substitute t → (t−b)/a into Q.
+    The substitution polynomial is linear: [(−b/a), (1/a)] in ascending order.
+    """
+    if not Q:
+        return ()
+    # sub(t) = (t − b) / a = (−b/a) + (1/a)·t
+    sub: Poly = (-b / a, Fraction(1) / a)
+    # Horner: evaluate Q at sub using Horner's method in polynomial arithmetic.
+    # Q(s) = c₀ + c₁·s + … + cₙ·sⁿ
+    # Compute iteratively: result = cₙ, then result = result·sub + cₙ₋₁, …
+    result: Poly = (Q[-1],)
+    for c in reversed(Q[:-1]):
+        result = _poly_add(_poly_mul(result, sub), (c,))
+    return result
+
+
+def _sqrt_integral_decompose(Q_tilde: Poly) -> tuple[Poly, Poly]:
+    """Return ``(A, B)`` such that
+
+        ∫ Q̃(t)/√(1−t²) dt = A(t)·√(1−t²) + B(t)·asin(t)
+
+    Uses the reduction formula for each monomial, accumulated linearly:
+
+        ∫ tⁿ/√(1−t²) dt = −tⁿ⁻¹/n · √(1−t²) + (n−1)/n · ∫ tⁿ⁻²/√(1−t²) dt
+
+        base cases: n=0 → asin(t) [i.e. B₀=1, A=0]
+                    n=1 → −√(1−t²) [i.e. A₋₁ monomial: const coeff −1, B=0]
+
+    Returns coefficient tuples A(t), B(t) in ascending degree order.
+    """
+    if not Q_tilde:
+        return (), ()
+
+    # Memoise monomial results (A_coefs, B_coefs) for tⁿ/√(1−t²).
+    memo: dict[int, tuple[Poly, Poly]] = {}
+
+    def _monomial(n: int) -> tuple[Poly, Poly]:
+        """∫ tⁿ/√(1−t²) dt = A_n(t)·√(1−t²) + B_n(t)·asin(t)."""
+        if n in memo:
+            return memo[n]
+        if n == 0:
+            # B = 1 (constant), A = 0.
+            result = (), (Fraction(1),)
+        elif n == 1:
+            # A = −1 (constant coefficient of √), B = 0.
+            result = (Fraction(-1),), ()
+        else:
+            # Reduction: ∫ tⁿ/√ = −tⁿ⁻¹/n·√ + (n−1)/n·∫ tⁿ⁻²/√
+            # A contribution from −tⁿ⁻¹/n:  a monomial −1/n at degree n−1.
+            A_new: Poly = (Fraction(0),) * (n - 1) + (Fraction(-1, n),)
+            A_new = _normalize(A_new)
+            A_rec, B_rec = _monomial(n - 2)
+            coef = Fraction(n - 1, n)
+            A_total = _poly_add(A_new, _poly_scale(coef, A_rec))
+            B_total = _poly_scale(coef, B_rec)
+            result = _normalize(A_total), _normalize(B_total)
+        memo[n] = result
+        return result
+
+    A_total: Poly = ()
+    B_total: Poly = ()
+    for deg, coef in enumerate(Q_tilde):
+        if coef == Fraction(0):
+            continue
+        A_n, B_n = _monomial(deg)
+        A_total = _poly_add(A_total, _poly_scale(coef, A_n))
+        B_total = _poly_add(B_total, _poly_scale(coef, B_n))
+
+    return _normalize(A_total), _normalize(B_total)
+
+
+def _poly_compose_linear(p: Poly, a: Fraction, b: Fraction) -> Poly:
+    """Compute p(ax+b) as an x-polynomial.
+
+    Uses Horner-like composition: substitute x → ax+b into p.
+    The substitution polynomial is [b, a] in ascending order.
+    """
+    if not p:
+        return ()
+    sub: Poly = (b, a)
+    result: Poly = (p[-1],)
+    for c in reversed(p[:-1]):
+        result = _poly_add(_poly_mul(result, sub), (c,))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# IR helpers
+# ---------------------------------------------------------------------------
+
+
+def _frac_ir(f: Fraction) -> IRNode:
+    """Convert a Fraction to IRInteger or IRRational."""
+    if f.denominator == 1:
+        return IRInteger(f.numerator)
+    return IRRational(f.numerator, f.denominator)
+
+
+__all__ = ["asin_poly_integral", "acos_poly_integral"]

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/handlers.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/handlers.py
@@ -24,8 +24,10 @@ import math
 from collections.abc import Mapping
 
 from symbolic_ir import (
+    ACOS,
     ADD,
     AND,
+    ASIN,
     ASSIGN,
     ATAN,
     COS,
@@ -299,6 +301,14 @@ def atan(simplify: bool) -> Handler:
     return _elementary("Atan", math.atan, {0: ZERO}, simplify)
 
 
+def asin(simplify: bool) -> Handler:
+    return _elementary("Asin", math.asin, {0: ZERO}, simplify)
+
+
+def acos(simplify: bool) -> Handler:
+    return _elementary("Acos", math.acos, {}, simplify)
+
+
 # ---------------------------------------------------------------------------
 # Comparisons
 # ---------------------------------------------------------------------------
@@ -531,6 +541,8 @@ def build_handler_table(simplify: bool) -> dict[str, Handler]:
         LOG.name: log(simplify),
         SQRT.name: sqrt(simplify),
         ATAN.name: atan(simplify),
+        ASIN.name: asin(simplify),
+        ACOS.name: acos(simplify),
         EQUAL.name: equal(simplify),
         NOT_EQUAL.name: not_equal(simplify),
         LESS.name: less(simplify),

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/integrate.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/integrate.py
@@ -1,4 +1,4 @@
-"""Symbolic integration — the ``Integrate`` handler (Phases 1–10).
+"""Symbolic integration — the ``Integrate`` handler (Phases 1–12).
 
 The handler tries two routes, in order:
 
@@ -76,7 +76,9 @@ from polynomial import (
     rational_roots,
 )
 from symbolic_ir import (
+    ACOS,
     ADD,
+    ASIN,
     ATAN,
     COS,
     DIV,
@@ -99,6 +101,7 @@ from symbolic_ir import (
 )
 
 from symbolic_vm.arctan_integral import arctan_integral
+from symbolic_vm.asin_poly_integral import acos_poly_integral, asin_poly_integral
 from symbolic_vm.atan_poly_integral import atan_poly_integral
 from symbolic_vm.backend import Handler
 from symbolic_vm.exp_integral import exp_integral
@@ -404,6 +407,13 @@ def _integrate(f: IRNode, x: IRSymbol) -> IRNode | None:
         result = _try_atan_product(a, b, x) or _try_atan_product(b, a, x)
         if result is not None:
             return result
+        # Phase 12: asin/acos(linear) × polynomial via IBP.
+        result = _try_asin_product(a, b, x) or _try_asin_product(b, a, x)
+        if result is not None:
+            return result
+        result = _try_acos_product(a, b, x) or _try_acos_product(b, a, x)
+        if result is not None:
+            return result
         # Phase 4b: trig × trig via product-to-sum identities.
         result = _try_trig_trig(a, b, x) or _try_trig_trig(b, a, x)
         if result is not None:
@@ -531,7 +541,7 @@ def _integrate(f: IRNode, x: IRSymbol) -> IRNode | None:
     # Generalises the Phase 1 rules above to any a·x + b argument.
     # Only fires when the argument is strictly linear with a ≠ 0 and
     # (a, b) ≠ (1, 0) — otherwise the Phase 1 rules above already fired.
-    if len(f.args) == 1 and head in {EXP, SIN, COS, LOG, TAN, ATAN}:
+    if len(f.args) == 1 and head in {EXP, SIN, COS, LOG, TAN, ATAN, ASIN, ACOS}:
         lin = _try_linear(f.args[0], x)
         if lin is not None:
             a_frac, b_frac = lin
@@ -578,6 +588,10 @@ def _integrate(f: IRNode, x: IRSymbol) -> IRNode | None:
                         ),
                     )
                     return IRApply(SUB, (IRApply(MUL, (coef_ir, f)), log_part))
+                if head in (ASIN, ACOS):
+                    # ∫ asin/acos(ax+b) dx — unit-polynomial IBP (Phase 12).
+                    fn = asin_poly_integral if head == ASIN else acos_poly_integral
+                    return fn((Fraction(1),), a_frac, b_frac, x)
 
     # Unknown shape — signal "no rule" to the caller.
     return None
@@ -781,6 +795,70 @@ def _try_atan_product(
     if not poly:
         return None
     return atan_poly_integral(poly, a_frac, b_frac, x)
+
+
+def _try_asin_product(
+    transcendental: IRNode, poly_candidate: IRNode, x: IRSymbol
+) -> IRNode | None:
+    """Return ``∫ poly_candidate · asin(linear) dx`` or ``None``.
+
+    Checks whether ``transcendental`` is ``Asin(linear)`` and
+    ``poly_candidate`` is a polynomial. Phase 12 IBP formula.
+    """
+    if not isinstance(transcendental, IRApply):
+        return None
+    if transcendental.head != ASIN:
+        return None
+    lin = _try_linear(transcendental.args[0], x)
+    if lin is None:
+        return None
+    a_frac, b_frac = lin
+    if a_frac == 0:
+        return None
+
+    r = to_rational(poly_candidate, x)
+    if r is None:
+        return None
+    num, den = r
+    from polynomial import normalize as _norm
+    if len(_norm(den)) > 1:
+        return None
+    poly = tuple(Fraction(c) for c in _norm(num))
+    if not poly:
+        return None
+    return asin_poly_integral(poly, a_frac, b_frac, x)
+
+
+def _try_acos_product(
+    transcendental: IRNode, poly_candidate: IRNode, x: IRSymbol
+) -> IRNode | None:
+    """Return ``∫ poly_candidate · acos(linear) dx`` or ``None``.
+
+    Checks whether ``transcendental`` is ``Acos(linear)`` and
+    ``poly_candidate`` is a polynomial. Phase 12 IBP formula.
+    """
+    if not isinstance(transcendental, IRApply):
+        return None
+    if transcendental.head != ACOS:
+        return None
+    lin = _try_linear(transcendental.args[0], x)
+    if lin is None:
+        return None
+    a_frac, b_frac = lin
+    if a_frac == 0:
+        return None
+
+    r = to_rational(poly_candidate, x)
+    if r is None:
+        return None
+    num, den = r
+    from polynomial import normalize as _norm
+    if len(_norm(den)) > 1:
+        return None
+    poly = tuple(Fraction(c) for c in _norm(num))
+    if not poly:
+        return None
+    return acos_poly_integral(poly, a_frac, b_frac, x)
 
 
 # ---------------------------------------------------------------------------
@@ -1317,6 +1395,25 @@ def _diff_ir(g: IRNode, x: IRSymbol) -> IRNode | None:
             # d/dx cos(u) = −sin(u)·u'
             neg_sin = IRApply(NEG, (IRApply(SIN, (arg,)),))
             return neg_sin if darg_is_one else IRApply(MUL, (neg_sin, darg))
+
+        if head == ASIN:
+            # d/dx asin(u) = u'/√(1−u²)
+            denom = IRApply(
+                SQRT, (IRApply(SUB, (ONE, IRApply(POW, (arg, TWO)))),)
+            )
+            if darg_is_one:
+                return IRApply(DIV, (ONE, denom))
+            return IRApply(DIV, (darg, denom))
+
+        if head == ACOS:
+            # d/dx acos(u) = −u'/√(1−u²)
+            denom = IRApply(
+                SQRT, (IRApply(SUB, (ONE, IRApply(POW, (arg, TWO)))),)
+            )
+            neg_inv = IRApply(NEG, (IRApply(DIV, (ONE, denom)),))
+            if darg_is_one:
+                return neg_inv
+            return IRApply(MUL, (IRApply(NEG, (darg,)), IRApply(DIV, (ONE, denom))))
 
         if head == EXP:
             # d/dx exp(u) = exp(u)·u'

--- a/code/packages/python/symbolic-vm/tests/test_phase12.py
+++ b/code/packages/python/symbolic-vm/tests/test_phase12.py
@@ -1,0 +1,602 @@
+"""Phase 12 integration tests — polynomial × asin/acos(linear) via IBP.
+
+Tests the formulae:
+
+    ∫ P(x) · asin(ax+b) dx
+        = [Q(x) − B(ax+b)] · asin(ax+b) − A(ax+b) · √(1−(ax+b)²)
+
+    ∫ P(x) · acos(ax+b) dx
+        = Q(x) · acos(ax+b) + A(ax+b) · √(1−(ax+b)²) + B(ax+b) · asin(ax+b)
+
+where Q = ∫P dx and A, B are computed from the residual integral
+    ∫ Q̃(t)/√(1−t²) dt = A(t)·√(1−t²) + B(t)·asin(t).
+
+Correctness is verified numerically: differentiate the antiderivative at test
+points and confirm the result matches the original integrand.
+
+Test points: x₀ = 0.3, x₁ = 0.6 — safely inside |ax+b| < 1 for all
+linear arguments used here.
+"""
+
+from __future__ import annotations
+
+import math
+
+from symbolic_ir import (
+    ACOS,
+    ADD,
+    ASIN,
+    ATAN,
+    DIV,
+    EXP,
+    INTEGRATE,
+    LOG,
+    MUL,
+    NEG,
+    POW,
+    SIN,
+    SUB,
+    IRApply,
+    IRFloat,
+    IRInteger,
+    IRNode,
+    IRRational,
+    IRSymbol,
+)
+
+from symbolic_vm.backends import SymbolicBackend
+from symbolic_vm.vm import VM
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+X = IRSymbol("x")
+_INT = IRInteger
+_RAT = lambda n, d: IRRational(n, d)  # noqa: E731
+
+# Test points safely inside |x| < 1 and |ax+b| < 1 for all test cases.
+_TP = (0.3, 0.6)
+
+
+def _make_vm() -> VM:
+    return VM(SymbolicBackend())
+
+
+def _eval_ir(node: IRNode, x_val: float) -> float:  # noqa: PLR0911
+    """Numerically evaluate an IR tree at x = x_val."""
+    if isinstance(node, IRInteger):
+        return float(node.value)
+    if isinstance(node, IRRational):
+        return node.numer / node.denom
+    if isinstance(node, IRFloat):
+        return node.value
+    if isinstance(node, IRSymbol):
+        if node.name == "x":
+            return x_val
+        raise ValueError(f"Unknown symbol: {node.name}")
+    if not isinstance(node, IRApply):
+        raise TypeError(f"Unexpected node: {node!r}")
+    head = node.head.name
+    if head == "Add":
+        return _eval_ir(node.args[0], x_val) + _eval_ir(node.args[1], x_val)
+    if head == "Sub":
+        return _eval_ir(node.args[0], x_val) - _eval_ir(node.args[1], x_val)
+    if head == "Mul":
+        return _eval_ir(node.args[0], x_val) * _eval_ir(node.args[1], x_val)
+    if head == "Div":
+        return _eval_ir(node.args[0], x_val) / _eval_ir(node.args[1], x_val)
+    if head == "Neg":
+        return -_eval_ir(node.args[0], x_val)
+    if head == "Inv":
+        return 1.0 / _eval_ir(node.args[0], x_val)
+    if head == "Log":
+        return math.log(abs(_eval_ir(node.args[0], x_val)))
+    if head == "Pow":
+        base = _eval_ir(node.args[0], x_val)
+        exp = _eval_ir(node.args[1], x_val)
+        return base ** exp
+    if head == "Sqrt":
+        return math.sqrt(_eval_ir(node.args[0], x_val))
+    if head == "Atan":
+        return math.atan(_eval_ir(node.args[0], x_val))
+    if head == "Asin":
+        return math.asin(_eval_ir(node.args[0], x_val))
+    if head == "Acos":
+        return math.acos(_eval_ir(node.args[0], x_val))
+    if head == "Exp":
+        return math.exp(_eval_ir(node.args[0], x_val))
+    if head == "Sin":
+        return math.sin(_eval_ir(node.args[0], x_val))
+    if head == "Cos":
+        return math.cos(_eval_ir(node.args[0], x_val))
+    raise ValueError(f"Unhandled head: {head}")
+
+
+def _numerical_deriv(node: IRNode, x_val: float, h: float = 1e-7) -> float:
+    return (_eval_ir(node, x_val + h) - _eval_ir(node, x_val - h)) / (2 * h)
+
+
+def _check_antiderivative(
+    integrand: IRNode,
+    antideriv: IRNode,
+    test_points: tuple[float, ...] = _TP,
+    atol: float = 1e-6,
+    rtol: float = 1e-6,
+) -> None:
+    """Verify F'(x) ≈ f(x) numerically at each test point."""
+    for x_val in test_points:
+        expected = _eval_ir(integrand, x_val)
+        actual = _numerical_deriv(antideriv, x_val)
+        tol = atol + rtol * abs(expected)
+        assert abs(actual - expected) < tol, (
+            f"At x={x_val}: F'={actual:.8f}, f={expected:.8f}, "
+            f"diff={abs(actual - expected):.2e}"
+        )
+
+
+def _integrate_ir(vm: VM, integrand_ir: IRNode) -> IRNode:
+    return vm.eval(IRApply(INTEGRATE, (integrand_ir, X)))
+
+
+def _was_evaluated(f: IRNode, F: IRNode) -> None:
+    assert IRApply(INTEGRATE, (f, X)) != F, (
+        "Expected a closed-form antiderivative, got an unevaluated Integrate"
+    )
+
+
+def _is_unevaluated(f: IRNode, F: IRNode) -> None:
+    assert IRApply(INTEGRATE, (f, X)) == F, (
+        "Expected an unevaluated Integrate, got a closed form"
+    )
+
+
+# ---------------------------------------------------------------------------
+# IR builder helpers
+# ---------------------------------------------------------------------------
+
+
+def _mul(a: IRNode, b: IRNode) -> IRNode:
+    return IRApply(MUL, (a, b))
+
+
+def _add(a: IRNode, b: IRNode) -> IRNode:
+    return IRApply(ADD, (a, b))
+
+
+def _sub(a: IRNode, b: IRNode) -> IRNode:
+    return IRApply(SUB, (a, b))
+
+
+def _neg(a: IRNode) -> IRNode:
+    return IRApply(NEG, (a,))
+
+
+def _div(a: IRNode, b: IRNode) -> IRNode:
+    return IRApply(DIV, (a, b))
+
+
+def _pow(a: IRNode, b: IRNode) -> IRNode:
+    return IRApply(POW, (a, b))
+
+
+def _asin(arg: IRNode) -> IRNode:
+    return IRApply(ASIN, (arg,))
+
+
+def _acos(arg: IRNode) -> IRNode:
+    return IRApply(ACOS, (arg,))
+
+
+# ---------------------------------------------------------------------------
+# Class 1: Asin canonical cases — ∫ xⁿ · asin(x) dx  (a=1, b=0)
+# ---------------------------------------------------------------------------
+
+
+class TestPhase12_AsinCanonical:
+    """Canonical asin cases: ∫ xⁿ · asin(x) dx and small combinations."""
+
+    def test_asin_x(self) -> None:
+        """∫ asin(x) dx = x·asin(x) + √(1−x²)."""
+        vm = _make_vm()
+        f = _asin(X)
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_x_asin_x(self) -> None:
+        """∫ x·asin(x) dx = (x²/2 − 1/4)·asin(x) + x/4·√(1−x²)."""
+        vm = _make_vm()
+        f = _mul(X, _asin(X))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_x_squared_asin_x(self) -> None:
+        """∫ x²·asin(x) dx."""
+        vm = _make_vm()
+        f = _mul(_pow(X, _INT(2)), _asin(X))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_x_cubed_asin_x(self) -> None:
+        """∫ x³·asin(x) dx."""
+        vm = _make_vm()
+        f = _mul(_pow(X, _INT(3)), _asin(X))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_x_fourth_asin_x(self) -> None:
+        """∫ x⁴·asin(x) dx."""
+        vm = _make_vm()
+        f = _mul(_pow(X, _INT(4)), _asin(X))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_x_plus1_asin_x(self) -> None:
+        """∫ (x+1)·asin(x) dx."""
+        vm = _make_vm()
+        f = _mul(_add(X, _INT(1)), _asin(X))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_x_squared_plus_x_asin_x(self) -> None:
+        """∫ (x²+x)·asin(x) dx."""
+        vm = _make_vm()
+        f = _mul(_add(_pow(X, _INT(2)), X), _asin(X))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_asin_x_times_x_commutativity(self) -> None:
+        """∫ asin(x)·x dx = ∫ x·asin(x) dx (commutativity of MUL args)."""
+        vm = _make_vm()
+        f1 = _mul(X, _asin(X))
+        f2 = _mul(_asin(X), X)
+        F1 = _integrate_ir(vm, f1)
+        F2 = _integrate_ir(vm, f2)
+        _check_antiderivative(f1, F1)
+        _check_antiderivative(f2, F2)
+
+    def test_negative_coeff_poly_asin_x(self) -> None:
+        """∫ (−x+2)·asin(x) dx."""
+        vm = _make_vm()
+        f = _mul(_add(_neg(X), _INT(2)), _asin(X))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_x_fifth_asin_x(self) -> None:
+        """∫ x⁵·asin(x) dx."""
+        vm = _make_vm()
+        f = _mul(_pow(X, _INT(5)), _asin(X))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_cubic_sum_asin_x(self) -> None:
+        """∫ (x³+x²+x)·asin(x) dx."""
+        vm = _make_vm()
+        p = _add(_add(_pow(X, _INT(3)), _pow(X, _INT(2))), X)
+        f = _mul(p, _asin(X))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_const_times_asin_x(self) -> None:
+        """∫ 3·asin(x) dx = 3·(x·asin(x) + √(1−x²))."""
+        vm = _make_vm()
+        f = _mul(_INT(3), _asin(X))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+
+# ---------------------------------------------------------------------------
+# Class 2: Acos canonical cases — ∫ xⁿ · acos(x) dx  (a=1, b=0)
+# ---------------------------------------------------------------------------
+
+
+class TestPhase12_AcosCanonical:
+    """Canonical acos cases: ∫ xⁿ · acos(x) dx."""
+
+    def test_acos_x(self) -> None:
+        """∫ acos(x) dx = x·acos(x) − √(1−x²)."""
+        vm = _make_vm()
+        f = _acos(X)
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_x_acos_x(self) -> None:
+        """∫ x·acos(x) dx = x²/2·acos(x) − x/4·√(1−x²) + 1/4·asin(x)."""
+        vm = _make_vm()
+        f = _mul(X, _acos(X))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_x_squared_acos_x(self) -> None:
+        """∫ x²·acos(x) dx."""
+        vm = _make_vm()
+        f = _mul(_pow(X, _INT(2)), _acos(X))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_x_cubed_acos_x(self) -> None:
+        """∫ x³·acos(x) dx."""
+        vm = _make_vm()
+        f = _mul(_pow(X, _INT(3)), _acos(X))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_x_plus1_acos_x(self) -> None:
+        """∫ (x+1)·acos(x) dx."""
+        vm = _make_vm()
+        f = _mul(_add(X, _INT(1)), _acos(X))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_const_factor_acos_x(self) -> None:
+        """∫ 2·acos(x) dx = 2·(x·acos(x) − √(1−x²))."""
+        vm = _make_vm()
+        f = _mul(_INT(2), _acos(X))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_acos_x_times_x_commutativity(self) -> None:
+        """∫ acos(x)·x dx = ∫ x·acos(x) dx (commutativity of MUL args)."""
+        vm = _make_vm()
+        f1 = _mul(X, _acos(X))
+        f2 = _mul(_acos(X), X)
+        F1 = _integrate_ir(vm, f1)
+        F2 = _integrate_ir(vm, f2)
+        _check_antiderivative(f1, F1)
+        _check_antiderivative(f2, F2)
+
+    def test_x_fourth_acos_x(self) -> None:
+        """∫ x⁴·acos(x) dx."""
+        vm = _make_vm()
+        f = _mul(_pow(X, _INT(4)), _acos(X))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+
+# ---------------------------------------------------------------------------
+# Class 3: Linear argument cases — asin/acos(ax+b) × polynomial
+# ---------------------------------------------------------------------------
+
+
+class TestPhase12_LinearArg:
+    """Cases with a ≠ 1 or b ≠ 0 in the asin/acos argument."""
+
+    def test_x_asin_2x(self) -> None:
+        """∫ x·asin(2x) dx — a=2, b=0."""
+        vm = _make_vm()
+        arg = _mul(_INT(2), X)
+        f = _mul(X, _asin(arg))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F, test_points=(0.3, 0.4))
+
+    def test_x_asin_half_x(self) -> None:
+        """∫ x·asin(x/2) dx — a=1/2, b=0."""
+        vm = _make_vm()
+        arg = _div(X, _INT(2))
+        f = _mul(X, _asin(arg))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_bare_asin_2x_plus1(self) -> None:
+        """∫ asin(2x+1) dx — a=2, b=1. Test points where |2x+1| < 1."""
+        vm = _make_vm()
+        arg = _add(_mul(_INT(2), X), _INT(1))
+        f = _asin(arg)
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        # |2*0.1+1| = 1.2 > 1 — choose points in (-1, 0).
+        _check_antiderivative(f, F, test_points=(-0.4, -0.1))
+
+    def test_x_squared_asin_half_x(self) -> None:
+        """∫ x²·asin(x/2) dx — a=1/2, b=0."""
+        vm = _make_vm()
+        arg = _div(X, _INT(2))
+        f = _mul(_pow(X, _INT(2)), _asin(arg))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_x_acos_2x(self) -> None:
+        """∫ x·acos(2x) dx — a=2, b=0."""
+        vm = _make_vm()
+        arg = _mul(_INT(2), X)
+        f = _mul(X, _acos(arg))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F, test_points=(0.3, 0.4))
+
+    def test_bare_acos_3x_minus1(self) -> None:
+        """∫ acos(3x−1) dx — a=3, b=−1. Test points where |3x−1| < 1."""
+        vm = _make_vm()
+        arg = _sub(_mul(_INT(3), X), _INT(1))
+        f = _acos(arg)
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        # |3*0.1−1| = 0.7 < 1, |3*0.3−1| = 0.1 < 1.
+        _check_antiderivative(f, F, test_points=(0.1, 0.3))
+
+    def test_x_asin_neg_x(self) -> None:
+        """∫ x·asin(−x) dx — a=−1, b=0."""
+        vm = _make_vm()
+        arg = _neg(X)
+        f = _mul(X, _asin(arg))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_x_acos_half_x(self) -> None:
+        """∫ x·acos(x/2) dx — a=1/2, b=0."""
+        vm = _make_vm()
+        arg = _div(X, _INT(2))
+        f = _mul(X, _acos(arg))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+
+# ---------------------------------------------------------------------------
+# Class 4: Fallthrough — Phase 12 must NOT evaluate these
+# ---------------------------------------------------------------------------
+
+
+class TestPhase12_Fallthrough:
+    """Integrands Phase 12 cannot handle — should remain unevaluated."""
+
+    def test_asin_nonlinear_arg(self) -> None:
+        """∫ asin(x²) dx — non-linear arg, should be unevaluated."""
+        vm = _make_vm()
+        f = _asin(_pow(X, _INT(2)))
+        F = _integrate_ir(vm, f)
+        _is_unevaluated(f, F)
+
+    def test_asin_squared(self) -> None:
+        """∫ asin(x)² dx — power of asin, should be unevaluated."""
+        vm = _make_vm()
+        f = _pow(_asin(X), _INT(2))
+        F = _integrate_ir(vm, f)
+        _is_unevaluated(f, F)
+
+    def test_rational_times_asin(self) -> None:
+        """∫ (1/x)·asin(x) dx — rational (non-polynomial) factor, unevaluated."""
+        vm = _make_vm()
+        f = _mul(_div(_INT(1), X), _asin(X))
+        F = _integrate_ir(vm, f)
+        _is_unevaluated(f, F)
+
+    def test_acos_nonlinear_arg(self) -> None:
+        """∫ acos(x²+1) dx — non-linear arg, should be unevaluated."""
+        vm = _make_vm()
+        f = _acos(_add(_pow(X, _INT(2)), _INT(1)))
+        F = _integrate_ir(vm, f)
+        _is_unevaluated(f, F)
+
+
+# ---------------------------------------------------------------------------
+# Class 5: Regressions — earlier phases must still work
+# ---------------------------------------------------------------------------
+
+
+class TestPhase12_Regressions:
+    """Verify Phase 12 does not break earlier integration phases."""
+
+    def test_phase11_x_atan_x(self) -> None:
+        """Phase 11: ∫ x·atan(x) dx."""
+        vm = _make_vm()
+        f = _mul(X, IRApply(ATAN, (X,)))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F, test_points=(0.3, 0.8))
+
+    def test_phase3e_poly_log(self) -> None:
+        """Phase 3e: ∫ x·log(x) dx = x²/2·log(x) − x²/4."""
+        vm = _make_vm()
+        f = _mul(X, IRApply(LOG, (X,)))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F, test_points=(0.5, 1.5))
+
+    def test_phase4a_poly_sin(self) -> None:
+        """Phase 4a: ∫ x·sin(x) dx = sin(x) − x·cos(x)."""
+        vm = _make_vm()
+        f = _mul(X, IRApply(SIN, (X,)))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F, test_points=(0.5, 1.2))
+
+    def test_phase1_polynomial(self) -> None:
+        """Phase 1: ∫ x³ dx = x⁴/4."""
+        vm = _make_vm()
+        f = _pow(X, _INT(3))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F, test_points=(0.5, 1.5))
+
+    def test_phase2e_arctan_rational(self) -> None:
+        """Phase 2e: ∫ 1/(x²+1) dx = atan(x)."""
+        vm = _make_vm()
+        f = _div(_INT(1), _add(_pow(X, _INT(2)), _INT(1)))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F, test_points=(0.3, 0.8))
+
+    def test_phase4a_poly_exp(self) -> None:
+        """Phase 4a: ∫ x·eˣ dx = eˣ(x−1)."""
+        vm = _make_vm()
+        f = _mul(X, IRApply(EXP, (X,)))
+        F = _integrate_ir(vm, f)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F, test_points=(0.5, 1.0))
+
+
+# ---------------------------------------------------------------------------
+# Class 6: Macsyma end-to-end string tests
+# ---------------------------------------------------------------------------
+
+
+class TestPhase12_Macsyma:
+    """End-to-end tests via the Macsyma string interface."""
+
+    @staticmethod
+    def _integrate_macsyma(integrand: str, var: str = "x") -> IRNode:
+        from macsyma_compiler import compile_macsyma
+        from macsyma_parser import parse_macsyma
+        vm = _make_vm()
+        ast = parse_macsyma(f"integrate({integrand}, {var});")
+        integrate_ir = compile_macsyma(ast)[0]
+        return vm.eval(integrate_ir)
+
+    def test_x_asin_x_macsyma(self) -> None:
+        """integrate(x*asin(x), x)."""
+        F = self._integrate_macsyma("x*asin(x)")
+        f = _mul(X, _asin(X))
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_acos_x_macsyma(self) -> None:
+        """integrate(acos(x), x)."""
+        F = self._integrate_macsyma("acos(x)")
+        f = _acos(X)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_x_squared_asin_x_macsyma(self) -> None:
+        """integrate(x^2*asin(x), x)."""
+        F = self._integrate_macsyma("x^2*asin(x)")
+        f = _mul(_pow(X, _INT(2)), _asin(X))
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)
+
+    def test_x_acos_2x_macsyma(self) -> None:
+        """integrate(x*acos(2*x), x)."""
+        F = self._integrate_macsyma("x*acos(2*x)")
+        arg = _mul(_INT(2), X)
+        f = _mul(X, _acos(arg))
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F, test_points=(0.3, 0.4))
+
+    def test_asin_x_macsyma(self) -> None:
+        """integrate(asin(x), x)."""
+        F = self._integrate_macsyma("asin(x)")
+        f = _asin(X)
+        _was_evaluated(f, F)
+        _check_antiderivative(f, F)

--- a/code/specs/phase12-poly-asin-acos.md
+++ b/code/specs/phase12-poly-asin-acos.md
@@ -1,0 +1,175 @@
+# Phase 12 — Polynomial × asin/acos Integration via IBP
+
+## Goal
+
+Add closed-form integration for `∫ P(x) · asin(ax+b) dx` and
+`∫ P(x) · acos(ax+b) dx`, where `P ∈ Q[x]` and `a ∈ Q \ {0}`.
+
+This completes all three inverse-trig × polynomial families (Phase 2e gave bare arctan; Phase 11 gave poly × arctan; Phase 12 gives poly × asin and poly × acos).
+
+---
+
+## Mathematical Derivation
+
+### asin IBP
+
+Integration by parts with `u = asin(ax+b)`, `dv = P(x) dx`:
+
+```
+du = a / √(1 − (ax+b)²) dx
+v  = Q(x) = ∫ P(x) dx     (polynomial antiderivative)
+```
+
+Applying IBP:
+
+```
+∫ P(x)·asin(ax+b) dx = Q(x)·asin(ax+b) − a · ∫ Q(x)/√(1−(ax+b)²) dx
+```
+
+### Resolving the Residual
+
+Substitute `t = ax+b`, so `x = (t−b)/a`, `dx = dt/a`:
+
+```
+a · ∫ Q(x)/√(1−(ax+b)²) dx = ∫ Q((t−b)/a)/√(1−t²) dt = ∫ Q̃(t)/√(1−t²) dt
+```
+
+where `Q̃(t) = Q((t−b)/a)` is a polynomial of the same degree in `t`.
+
+By linearity, each monomial `tⁿ/√(1−t²)` contributes independently. The reduction formula is:
+
+```
+∫ tⁿ/√(1−t²) dt = −tⁿ⁻¹/n · √(1−t²) + (n−1)/n · ∫ tⁿ⁻²/√(1−t²) dt
+
+Base cases:
+  n = 0 → asin(t)
+  n = 1 → −√(1−t²)
+```
+
+Applying this to `Q̃(t)` by linearity gives:
+
+```
+∫ Q̃(t)/√(1−t²) dt = A(t) · √(1−t²) + B(t) · asin(t)
+```
+
+where `A(t)` and `B(t)` are polynomials over Q.
+
+### asin Final Result
+
+Back-substituting `t = ax+b`:
+
+```
+∫ P(x) · asin(ax+b) dx
+    = Q(x) · asin(ax+b) − [A(ax+b) · √(1−(ax+b)²) + B(ax+b) · asin(ax+b)]
+    = [Q(x) − B(ax+b)] · asin(ax+b) − A(ax+b) · √(1−(ax+b)²)
+```
+
+### acos IBP
+
+For `u = acos(ax+b)`:  `du = −a/√(1−(ax+b)²) dx` — the sign flips.
+
+```
+∫ P(x) · acos(ax+b) dx = Q(x) · acos(ax+b) + a · ∫ Q(x)/√(1−(ax+b)²) dx
+```
+
+The residual is identical to the asin case (same `Q`, same sign change accounts for `−du` → `+`). After back-substitution:
+
+```
+∫ P(x) · acos(ax+b) dx
+    = Q(x) · acos(ax+b) + A(ax+b) · √(1−(ax+b)²) + B(ax+b) · asin(ax+b)
+```
+
+**Note:** The `B · asin` term is non-zero for `deg(P) ≥ 1`. This is mathematically correct — `∫ acos(x) dx` produces no `asin` term (B=0), but `∫ x·acos(x) dx = x²/2·acos(x) − x/4·√(1−x²) + 1/4·asin(x)` does.
+
+---
+
+## Worked Examples
+
+### ∫ asin(x) dx
+
+`P = 1`, `a = 1`, `b = 0`. `Q(x) = x`.
+
+`Q̃(t) = t`.  `_sqrt_integral_decompose((0, 1))`:
+- `n=1`: `A = (−1,)`, `B = ()`.
+
+Back-substitute (identity, `a=1`, `b=0`): `A_x = (−1,)`, `B_x = ()`.
+
+Result: `[x − 0] · asin(x) − (−1) · √(1−x²) = x·asin(x) + √(1−x²)` ✓
+
+### ∫ x·asin(x) dx
+
+`P = (0, 1)`, `Q = x²/2`.  `Q̃(t) = t²/2`.
+
+`_sqrt_integral_decompose((0, 0, 1/2))`:
+- `n=2`: `A_new = (0, −1/2)`, then add `(1/2)·A_rec = (1/2)·() = ()`.
+  So `A(t) = (1/2)·(0, −1/2) = (0, −1/4)`.
+  `B_t = (1/2)·(1/2,) = (1/4,)`.
+
+Back-substitute: `A_x = (0, −1/4)` → `−x/4`, `B_x = (1/4,)` → `1/4`.
+
+Result: `(x²/2 − 1/4)·asin(x) − (−x/4)·√(1−x²) = (x²/2−1/4)·asin(x) + x/4·√(1−x²)` ✓
+
+### ∫ acos(x) dx
+
+Same `Q`, `A_x`, `B_x` as `∫ asin(x) dx`. `B_x = ()`, so no asin term.
+
+Result: `x·acos(x) + (−1)·√(1−x²) = x·acos(x) − √(1−x²)` ✓
+
+### ∫ x·acos(x) dx
+
+`A_x = (0, −1/4)`, `B_x = (1/4,)`.
+
+Result: `x²/2·acos(x) + (−x/4)·√(1−x²) + 1/4·asin(x)` ✓
+
+---
+
+## Implementation
+
+### symbolic-ir 0.4.0
+
+Added to `nodes.py` (elementary-functions group, after ATAN):
+```python
+ASIN = IRSymbol("Asin")
+ACOS = IRSymbol("Acos")
+```
+
+Exported from `__init__.py`.
+
+### symbolic-vm 0.17.0
+
+**`handlers.py`** — two new `_elementary` handlers:
+```python
+def asin(simplify): return _elementary("Asin", math.asin, {0: ZERO}, simplify)
+def acos(simplify): return _elementary("Acos", math.acos, {}, simplify)
+```
+Registered in `build_handler_table` as `ASIN.name` and `ACOS.name`.
+
+**`asin_poly_integral.py`** — new module implementing:
+- `asin_poly_integral(poly, a, b, x_sym)` — IBP formula for asin family.
+- `acos_poly_integral(poly, a, b, x_sym)` — IBP formula for acos family.
+- Private: `_compose_to_t`, `_sqrt_integral_decompose` (with memoization), `_poly_compose_linear`, `_compute_AB`, `_integrate_poly`, `_poly_add`, `_poly_mul`, `_poly_scale`, `_normalize`.
+
+**`integrate.py`** — wired up as:
+- ASIN/ACOS added to the elementary-function dispatch set.
+- Bare `asin/acos(linear)` handled by calling `asin_poly_integral`/`acos_poly_integral` with `poly = (1,)`.
+- `_try_asin_product` / `_try_acos_product` dispatcher functions inserted after Phase 11.
+- `d/dx asin(u) = u'/√(1−u²)` and `d/dx acos(u) = −u'/√(1−u²)` added to `_diff_ir`.
+
+**`macsyma_compiler/compiler.py`** — added `"asin": ASIN` and `"acos": ACOS` to the standard function table so the Macsyma string interface recognizes `asin(...)` and `acos(...)`.
+
+---
+
+## Test Coverage
+
+`tests/test_phase12.py` — 43 tests across 6 classes:
+
+| Class | Count | Description |
+|-------|-------|-------------|
+| `TestPhase12_AsinCanonical` | 12 | `∫ xⁿ·asin(x) dx` (n=0..5), combinations, commutativity, constant factor |
+| `TestPhase12_AcosCanonical` | 8 | `∫ xⁿ·acos(x) dx` (n=0..4), combinations, commutativity, constant factor |
+| `TestPhase12_LinearArg` | 8 | `a≠1` or `b≠0` cases for both asin and acos |
+| `TestPhase12_Fallthrough` | 4 | Non-linear args, powers of asin, rational factor |
+| `TestPhase12_Regressions` | 6 | Phases 11, 3e, 4a, 1, 2e — earlier phases unaffected |
+| `TestPhase12_Macsyma` | 5 | End-to-end via Macsyma string interface |
+
+All correctness tests use numerical finite-difference verification: `F'(x) ≈ f(x)` at test points `(0.3, 0.6)` safely within `|ax+b| < 1`.


### PR DESCRIPTION
## Summary

- Adds `∫ P(x)·asin(ax+b) dx` and `∫ P(x)·acos(ax+b) dx` for `P ∈ Q[x]`, `a ∈ Q\{0}`, completing all three inverse-trig × polynomial families
- New `asin_poly_integral.py` module using IBP + `∫tⁿ/√(1−t²)dt` reduction formula with memoization
- 43 new tests (665 total, 88% coverage); security review passed
- Bumps symbolic-ir → 0.4.0 (ASIN/ACOS heads), symbolic-vm → 0.17.0, macsyma-compiler → 0.4.0

## Algorithm

**asin IBP:** `u=asin(ax+b)`, `v=Q=∫P` → residual `∫Q/√(1−(ax+b)²)dx` resolved via `t=ax+b` substitution and decomposition `∫Q̃/√(1−t²)dt = A(t)·√(1−t²) + B(t)·asin(t)`.

Final:
- `asin`: `[Q(x)−B(ax+b)]·asin(ax+b) − A(ax+b)·√(1−(ax+b)²)`
- `acos`: `Q(x)·acos(ax+b) + A(ax+b)·√(1−(ax+b)²) + B(ax+b)·asin(ax+b)`

The `B·asin` term in the acos result is mathematically correct for `deg(P)≥1`.

## Test plan

- [x] `TestPhase12_AsinCanonical` (12): `∫ xⁿ·asin(x) dx` n=0..5, combinations, commutativity
- [x] `TestPhase12_AcosCanonical` (8): `∫ xⁿ·acos(x) dx` n=0..4
- [x] `TestPhase12_LinearArg` (8): `a≠1` or `b≠0` cases
- [x] `TestPhase12_Fallthrough` (4): non-linear args remain unevaluated
- [x] `TestPhase12_Regressions` (6): phases 1, 2e, 3e, 4a, 11 still pass
- [x] `TestPhase12_Macsyma` (5): end-to-end via Macsyma string interface
- [x] All 665 tests pass; coverage 87.87% (>80%)
- [x] `ruff check` passes
- [x] Security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)