### PR TITLE
feat(riscv): add Brainfuck end-to-end execution

### DIFF
--- a/code/packages/go/brainfuck-riscv-compiler/BUILD
+++ b/code/packages/go/brainfuck-riscv-compiler/BUILD
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/brainfuck-riscv-compiler/CHANGELOG.md
+++ b/code/packages/go/brainfuck-riscv-compiler/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add Brainfuck to RISC-V assembly, assembler, and simulator orchestration.

--- a/code/packages/go/brainfuck-riscv-compiler/README.md
+++ b/code/packages/go/brainfuck-riscv-compiler/README.md
@@ -1,0 +1,18 @@
+# brainfuck-riscv-compiler
+
+End-to-end Brainfuck to RISC-V orchestration.
+
+```text
+Brainfuck source
+  -> brainfuck parser
+  -> brainfuck-ir-compiler
+  -> ir-optimizer
+  -> ir-to-riscv-compiler
+  -> riscv-assembler
+  -> riscv-simulator host syscalls
+```
+
+`CompileSource` returns the RISC-V assembly string and assembled bytes.
+`RunSource` executes those bytes in `riscv-simulator`. Brainfuck `.` and `,`
+use the simulator host syscall ABI: write byte (`a7=1`), read byte (`a7=2`),
+and exit (`a7=10`).

--- a/code/packages/go/brainfuck-riscv-compiler/compiler.go
+++ b/code/packages/go/brainfuck-riscv-compiler/compiler.go
@@ -1,0 +1,248 @@
+package brainfuckriscvcompiler
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/adhithyan15/coding-adventures/code/packages/go/brainfuck"
+	brainfuckircompiler "github.com/adhithyan15/coding-adventures/code/packages/go/brainfuck-ir-compiler"
+	ir "github.com/adhithyan15/coding-adventures/code/packages/go/compiler-ir"
+	iroptimizer "github.com/adhithyan15/coding-adventures/code/packages/go/ir-optimizer"
+	irtoriscvcompiler "github.com/adhithyan15/coding-adventures/code/packages/go/ir-to-riscv-compiler"
+	"github.com/adhithyan15/coding-adventures/code/packages/go/parser"
+	riscvassembler "github.com/adhithyan15/coding-adventures/code/packages/go/riscv-assembler"
+	riscv "github.com/adhithyan15/coding-adventures/code/packages/go/riscv-simulator"
+)
+
+const DefaultMemorySize = 65536
+
+type BrainfuckRiscVCompilerOptions struct {
+	BuildConfig *brainfuckircompiler.BuildConfig
+	OptimizeIR  *bool
+	MemorySize  int
+	Input       []byte
+}
+
+type PackageResult struct {
+	Source       string
+	AST          *parser.ASTNode
+	RawIR        *ir.IrProgram
+	Optimization iroptimizer.OptimizationResult
+	OptimizedIR  *ir.IrProgram
+	MachineCode  *irtoriscvcompiler.MachineCodeResult
+	Assembled    *riscvassembler.AssembleResult
+	Assembly     string
+	Binary       []byte
+	AssemblyPath string
+	BinaryPath   string
+}
+
+type RunResult struct {
+	Package    *PackageResult
+	Output     []byte
+	ExitCode   uint32
+	HostExited bool
+	Halted     bool
+	Steps      int
+	Host       *riscv.HostIO
+}
+
+func (r *RunResult) OutputString() string {
+	if r == nil {
+		return ""
+	}
+	return string(r.Output)
+}
+
+type PackageError struct {
+	Stage   string
+	Message string
+	Cause   error
+}
+
+func (e *PackageError) Error() string {
+	return e.Message
+}
+
+func (e *PackageError) Unwrap() error {
+	return e.Cause
+}
+
+type BrainfuckRiscVCompiler struct {
+	buildConfig brainfuckircompiler.BuildConfig
+	optimizer   *iroptimizer.IrOptimizer
+	memorySize  int
+	input       []byte
+}
+
+func NewBrainfuckRiscVCompiler(options *BrainfuckRiscVCompilerOptions) *BrainfuckRiscVCompiler {
+	config := brainfuckircompiler.ReleaseConfig()
+	optimize := true
+	memorySize := DefaultMemorySize
+	var input []byte
+	if options != nil {
+		if options.BuildConfig != nil {
+			config = *options.BuildConfig
+		}
+		if options.OptimizeIR != nil {
+			optimize = *options.OptimizeIR
+		}
+		if options.MemorySize > 0 {
+			memorySize = options.MemorySize
+		}
+		input = append([]byte(nil), options.Input...)
+	}
+
+	optimizer := iroptimizer.DefaultPasses()
+	if !optimize {
+		optimizer = iroptimizer.NoOp()
+	}
+
+	return &BrainfuckRiscVCompiler{
+		buildConfig: config,
+		optimizer:   optimizer,
+		memorySize:  memorySize,
+		input:       input,
+	}
+}
+
+func (c *BrainfuckRiscVCompiler) CompileSource(source string) (*PackageResult, error) {
+	ast, err := brainfuck.ParseBrainfuck(source)
+	if err != nil {
+		return nil, wrapStage("parse", err)
+	}
+
+	irResult, err := brainfuckircompiler.Compile(ast, "input.bf", c.buildConfig)
+	if err != nil {
+		return nil, wrapStage("compile-ir", err)
+	}
+
+	rawIR := irResult.Program
+	optimization := c.optimizer.Optimize(rawIR)
+	optimizedIR := optimization.Program
+
+	machineCode, err := irtoriscvcompiler.NewIrToRiscVCompiler().Compile(optimizedIR)
+	if err != nil {
+		return nil, wrapStage("lower-riscv", err)
+	}
+
+	assembled, err := riscvassembler.Assemble(machineCode.Assembly)
+	if err != nil {
+		return nil, wrapStage("assemble-riscv", err)
+	}
+	if !bytes.Equal(assembled.Bytes, machineCode.Bytes) {
+		return nil, wrapStage("assemble-riscv", errAssemblerMismatch)
+	}
+
+	return &PackageResult{
+		Source:       source,
+		AST:          ast,
+		RawIR:        rawIR,
+		Optimization: optimization,
+		OptimizedIR:  optimizedIR,
+		MachineCode:  machineCode,
+		Assembled:    assembled,
+		Assembly:     machineCode.Assembly,
+		Binary:       assembled.Bytes,
+	}, nil
+}
+
+func (c *BrainfuckRiscVCompiler) RunSource(source string) (*RunResult, error) {
+	return c.RunSourceWithInput(source, c.input)
+}
+
+func (c *BrainfuckRiscVCompiler) RunSourceWithInput(source string, input []byte) (*RunResult, error) {
+	result, err := c.CompileSource(source)
+	if err != nil {
+		return nil, err
+	}
+
+	host := riscv.NewHostIO(input)
+	sim := riscv.NewRiscVSimulatorWithHost(c.memorySize, host)
+	traces := sim.Run(result.Binary)
+
+	return &RunResult{
+		Package:    result,
+		Output:     append([]byte(nil), host.Output...),
+		ExitCode:   host.ExitCode,
+		HostExited: host.Exited,
+		Halted:     sim.CPU.Halted,
+		Steps:      len(traces),
+		Host:       host,
+	}, nil
+}
+
+func (c *BrainfuckRiscVCompiler) WriteAssemblyFile(source, outputPath string) (*PackageResult, error) {
+	result, err := c.CompileSource(source)
+	if err != nil {
+		return nil, err
+	}
+	if err := writeFile(outputPath, []byte(result.Assembly)); err != nil {
+		return nil, wrapStage("write", err)
+	}
+	result.AssemblyPath = outputPath
+	return result, nil
+}
+
+func (c *BrainfuckRiscVCompiler) WriteBinaryFile(source, outputPath string) (*PackageResult, error) {
+	result, err := c.CompileSource(source)
+	if err != nil {
+		return nil, err
+	}
+	if err := writeFile(outputPath, result.Binary); err != nil {
+		return nil, wrapStage("write", err)
+	}
+	result.BinaryPath = outputPath
+	return result, nil
+}
+
+func CompileSource(source string) (*PackageResult, error) {
+	return NewBrainfuckRiscVCompiler(nil).CompileSource(source)
+}
+
+func PackSource(source string) (*PackageResult, error) {
+	return CompileSource(source)
+}
+
+func RunSource(source string) (*RunResult, error) {
+	return NewBrainfuckRiscVCompiler(nil).RunSource(source)
+}
+
+func RunSourceWithInput(source string, input []byte) (*RunResult, error) {
+	return NewBrainfuckRiscVCompiler(nil).RunSourceWithInput(source, input)
+}
+
+func WriteAssemblyFile(source, outputPath string) (*PackageResult, error) {
+	return NewBrainfuckRiscVCompiler(nil).WriteAssemblyFile(source, outputPath)
+}
+
+func WriteBinaryFile(source, outputPath string) (*PackageResult, error) {
+	return NewBrainfuckRiscVCompiler(nil).WriteBinaryFile(source, outputPath)
+}
+
+func writeFile(outputPath string, data []byte) error {
+	if dir := filepath.Dir(outputPath); dir != "." && dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+	return os.WriteFile(outputPath, data, 0o644)
+}
+
+var errAssemblerMismatch = errors.New("assembler output does not match direct backend bytes")
+
+func wrapStage(stage string, err error) error {
+	if err == nil {
+		return nil
+	}
+	if packageErr, ok := err.(*PackageError); ok {
+		return packageErr
+	}
+	return &PackageError{
+		Stage:   stage,
+		Message: err.Error(),
+		Cause:   err,
+	}
+}

--- a/code/packages/go/brainfuck-riscv-compiler/compiler_test.go
+++ b/code/packages/go/brainfuck-riscv-compiler/compiler_test.go
@@ -1,0 +1,135 @@
+package brainfuckriscvcompiler
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCompileSourceReturnsAssemblyAndBytes(t *testing.T) {
+	result, err := CompileSource("+++[>++<-]>.")
+	if err != nil {
+		t.Fatalf("compile failed: %v", err)
+	}
+	if result.AST == nil {
+		t.Fatal("expected AST")
+	}
+	if len(result.RawIR.Instructions) == 0 {
+		t.Fatal("expected raw IR instructions")
+	}
+	if len(result.OptimizedIR.Instructions) == 0 {
+		t.Fatal("expected optimized IR instructions")
+	}
+	if !strings.Contains(result.Assembly, "_start:") {
+		t.Fatalf("expected assembly to contain _start label, got:\n%s", result.Assembly)
+	}
+	if !strings.Contains(result.Assembly, "tape:") {
+		t.Fatalf("expected assembly to contain tape data, got:\n%s", result.Assembly)
+	}
+	if len(result.Binary) == 0 {
+		t.Fatal("expected RISC-V binary bytes")
+	}
+}
+
+func TestPackSourceAliasesCompileSource(t *testing.T) {
+	compiled, err := CompileSource("+")
+	if err != nil {
+		t.Fatalf("compile failed: %v", err)
+	}
+	packed, err := PackSource("+")
+	if err != nil {
+		t.Fatalf("pack failed: %v", err)
+	}
+	if string(packed.Binary) != string(compiled.Binary) {
+		t.Fatal("expected pack source to match compile source")
+	}
+}
+
+func TestRunSourceExecutesBrainfuckOutputOnRiscVSimulator(t *testing.T) {
+	run, err := RunSource("+++++.")
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	if !run.Halted {
+		t.Fatal("expected simulator to halt")
+	}
+	if !run.HostExited {
+		t.Fatal("expected host exit syscall")
+	}
+	if got := run.Output; len(got) != 1 || got[0] != 5 {
+		t.Fatalf("expected single output byte 5, got %v", got)
+	}
+}
+
+func TestRunSourceWithInputEchoesByte(t *testing.T) {
+	run, err := RunSourceWithInput(",.", []byte("Z"))
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	if got := run.OutputString(); got != "Z" {
+		t.Fatalf("expected output %q, got %q", "Z", got)
+	}
+}
+
+func TestCompilerOptionsCanDisableOptimization(t *testing.T) {
+	optimize := false
+	result, err := NewBrainfuckRiscVCompiler(&BrainfuckRiscVCompilerOptions{OptimizeIR: &optimize}).
+		CompileSource("+++")
+	if err != nil {
+		t.Fatalf("compile failed: %v", err)
+	}
+	if result.Optimization.InstructionsBefore != result.Optimization.InstructionsAfter {
+		t.Fatalf("expected no-op optimizer counts to match, got before=%d after=%d",
+			result.Optimization.InstructionsBefore,
+			result.Optimization.InstructionsAfter)
+	}
+}
+
+func TestParseErrorsReportStage(t *testing.T) {
+	_, err := CompileSource("[")
+	if err == nil {
+		t.Fatal("expected parse failure")
+	}
+	packageErr, ok := err.(*PackageError)
+	if !ok {
+		t.Fatalf("expected PackageError, got %T", err)
+	}
+	if packageErr.Stage != "parse" {
+		t.Fatalf("expected parse stage, got %q", packageErr.Stage)
+	}
+}
+
+func TestWriteAssemblyFileWritesOutput(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), "program.s")
+	result, err := WriteAssemblyFile("+.", outputPath)
+	if err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	if string(data) != result.Assembly {
+		t.Fatal("written assembly does not match result")
+	}
+}
+
+func TestPackageErrorPreservesCause(t *testing.T) {
+	cause := errors.New("boom")
+	err := wrapStage("stage", cause)
+	packageErr, ok := err.(*PackageError)
+	if !ok {
+		t.Fatalf("expected PackageError, got %T", err)
+	}
+	if packageErr.Error() != "boom" {
+		t.Fatalf("unexpected error message %q", packageErr.Error())
+	}
+	if !errors.Is(packageErr, cause) {
+		t.Fatal("expected errors.Is to see wrapped cause")
+	}
+	if wrapStage("stage", packageErr) != packageErr {
+		t.Fatal("expected existing package errors to pass through")
+	}
+}

--- a/code/packages/go/brainfuck-riscv-compiler/go.mod
+++ b/code/packages/go/brainfuck-riscv-compiler/go.mod
@@ -1,0 +1,54 @@
+module github.com/adhithyan15/coding-adventures/code/packages/go/brainfuck-riscv-compiler
+
+go 1.26
+
+require (
+	github.com/adhithyan15/coding-adventures/code/packages/go/brainfuck v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/brainfuck-ir-compiler v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/compiler-ir v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/ir-optimizer v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/ir-to-riscv-compiler v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/parser v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/riscv-assembler v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/riscv-simulator v0.0.0
+)
+
+require (
+	github.com/adhithyan15/coding-adventures/code/packages/go/branch-predictor v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/cache v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/clock v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/compiler-source-map v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/core v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/cpu-pipeline v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/cpu-simulator v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/directed-graph v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/grammar-tools v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/hazard-detection v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/lexer v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/state-machine v0.0.0 // indirect
+	github.com/adhithyan15/coding-adventures/code/packages/go/virtual-machine v0.0.0 // indirect
+)
+
+replace (
+	github.com/adhithyan15/coding-adventures/code/packages/go/brainfuck => ../brainfuck
+	github.com/adhithyan15/coding-adventures/code/packages/go/brainfuck-ir-compiler => ../brainfuck-ir-compiler
+	github.com/adhithyan15/coding-adventures/code/packages/go/branch-predictor => ../branch-predictor
+	github.com/adhithyan15/coding-adventures/code/packages/go/cache => ../cache
+	github.com/adhithyan15/coding-adventures/code/packages/go/clock => ../clock
+	github.com/adhithyan15/coding-adventures/code/packages/go/compiler-ir => ../compiler-ir
+	github.com/adhithyan15/coding-adventures/code/packages/go/compiler-source-map => ../compiler-source-map
+	github.com/adhithyan15/coding-adventures/code/packages/go/core => ../core
+	github.com/adhithyan15/coding-adventures/code/packages/go/cpu-pipeline => ../cpu-pipeline
+	github.com/adhithyan15/coding-adventures/code/packages/go/cpu-simulator => ../cpu-simulator
+	github.com/adhithyan15/coding-adventures/code/packages/go/directed-graph => ../directed-graph
+	github.com/adhithyan15/coding-adventures/code/packages/go/grammar-tools => ../grammar-tools
+	github.com/adhithyan15/coding-adventures/code/packages/go/hazard-detection => ../hazard-detection
+	github.com/adhithyan15/coding-adventures/code/packages/go/ir-optimizer => ../ir-optimizer
+	github.com/adhithyan15/coding-adventures/code/packages/go/ir-to-riscv-compiler => ../ir-to-riscv-compiler
+	github.com/adhithyan15/coding-adventures/code/packages/go/lexer => ../lexer
+	github.com/adhithyan15/coding-adventures/code/packages/go/parser => ../parser
+	github.com/adhithyan15/coding-adventures/code/packages/go/riscv-assembler => ../riscv-assembler
+	github.com/adhithyan15/coding-adventures/code/packages/go/riscv-simulator => ../riscv-simulator
+	github.com/adhithyan15/coding-adventures/code/packages/go/state-machine => ../state-machine
+	github.com/adhithyan15/coding-adventures/code/packages/go/virtual-machine => ../virtual-machine
+)

--- a/code/packages/go/brainfuck-riscv-compiler/required_capabilities.json
+++ b/code/packages/go/brainfuck-riscv-compiler/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "go/brainfuck-riscv-compiler",
+  "capabilities": [],
+  "justification": "Pure compiler orchestration and in-memory simulator execution. Optional file writes are explicit API calls from the caller."
+}

--- a/code/packages/go/riscv-simulator/CHANGELOG.md
+++ b/code/packages/go/riscv-simulator/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.0] - Unreleased
+
+### Added
+- Added opt-in host byte I/O syscalls for compiler end-to-end tests.
+
 ## [0.3.0] - 2026-04-02
 
 ### Changed

--- a/code/packages/go/riscv-simulator/README.md
+++ b/code/packages/go/riscv-simulator/README.md
@@ -39,6 +39,9 @@ When `mtvec` is configured with a trap handler address:
 - `ecall` saves PC to `mepc`, sets `mcause` to 11 (M-mode environment call), disables interrupts, and jumps to `mtvec`
 - `mret` restores PC from `mepc` and re-enables interrupts
 - When `mtvec` is 0 (no handler), `ecall` halts the CPU (simple program behavior)
+- When `mtvec` is 0 and a `HostIO` object is attached, simple host syscalls
+  are handled directly: `a7=1` writes the low byte of `a0`, `a7=2` reads one
+  byte into `a0`, and `a7=10` exits.
 
 ## Architecture
 
@@ -80,6 +83,26 @@ program := riscvsimulator.Assemble([]uint32{
 
 traces := sim.Run(program)
 // sim.CPU.Registers.Read(2) == 55
+```
+
+### Host Syscall Example
+
+```go
+host := riscvsimulator.NewHostIO([]byte("A"))
+sim := riscvsimulator.NewRiscVSimulatorWithHost(65536, host)
+
+program := riscvsimulator.Assemble([]uint32{
+    riscvsimulator.EncodeAddi(17, 0, riscvsimulator.SyscallReadByte),
+    riscvsimulator.EncodeEcall(), // a0 = 'A'
+    riscvsimulator.EncodeAddi(17, 0, riscvsimulator.SyscallWriteByte),
+    riscvsimulator.EncodeEcall(), // host.Output = "A"
+    riscvsimulator.EncodeAddi(10, 0, 0),
+    riscvsimulator.EncodeAddi(17, 0, riscvsimulator.SyscallExit),
+    riscvsimulator.EncodeEcall(),
+})
+
+sim.Run(program)
+// host.OutputString() == "A"
 ```
 
 ### Trap Handler Example

--- a/code/packages/go/riscv-simulator/execute.go
+++ b/code/packages/go/riscv-simulator/execute.go
@@ -172,7 +172,8 @@ func writeRd(registers *cpu.RegisterFile, rd int, value uint32) map[string]uint3
 // === I-type arithmetic executor ===
 //
 // Most I-type arithmetic instructions follow the same pattern:
-//   result = op(rs1_value, sign_extended_immediate)
+//
+//	result = op(rs1_value, sign_extended_immediate)
 //
 // This generic helper avoids duplicating the register read/write boilerplate.
 func (e *RiscVExecutor) execImmArith(decoded cpu.DecodeResult, registers *cpu.RegisterFile, pc int, name string, op func(int32, int32) uint32) cpu.ExecuteResult {
@@ -217,7 +218,8 @@ func (e *RiscVExecutor) execShiftImm(decoded cpu.DecodeResult, registers *cpu.Re
 // === R-type arithmetic executor ===
 //
 // R-type instructions operate on two registers:
-//   result = op(rs1_value, rs2_value)
+//
+//	result = op(rs1_value, rs2_value)
 func (e *RiscVExecutor) execRegArith(decoded cpu.DecodeResult, registers *cpu.RegisterFile, pc int, name string, op func(uint32, uint32) uint32) cpu.ExecuteResult {
 	rd := decoded.Fields["rd"]
 	rs1 := decoded.Fields["rs1"]
@@ -247,9 +249,9 @@ func (e *RiscVExecutor) execRegArith(decoded cpu.DecodeResult, registers *cpu.Re
 // When loading a byte (8 bits) into a 32-bit register, we need to decide
 // what goes in the upper 24 bits:
 //   - Sign extension (lb):  if the byte's MSB is 1, fill upper bits with 1s
-//                           0xFF -> 0xFFFFFFFF (-1 as int32)
+//     0xFF -> 0xFFFFFFFF (-1 as int32)
 //   - Zero extension (lbu): always fill upper bits with 0s
-//                           0xFF -> 0x000000FF (255 as uint32)
+//     0xFF -> 0x000000FF (255 as uint32)
 //
 // This distinction matters for signed arithmetic. If you load a -1 stored
 // as 0xFF and want to add it to something, you need sign extension.
@@ -383,7 +385,7 @@ func (e *RiscVExecutor) execBranch(decoded cpu.DecodeResult, registers *cpu.Regi
 // JAL stores the return address (PC + 4) in rd, then jumps to PC + offset.
 // This is the primary mechanism for calling functions:
 //
-//   jal ra, function_label
+//	jal ra, function_label
 //
 // Here "ra" is the return address register (x1 by convention). The function
 // can later return with: jalr x0, ra, 0 (jump to the saved return address).
@@ -409,8 +411,9 @@ func (e *RiscVExecutor) execJAL(decoded cpu.DecodeResult, registers *cpu.Registe
 // cleared. The bit-clearing ensures the target is always 2-byte aligned.
 //
 // Common uses:
-//   jalr x0, x1, 0   — return from function (jump to ra, discard link)
-//   jalr x1, x5, 0   — indirect call through function pointer in x5
+//
+//	jalr x0, x1, 0   — return from function (jump to ra, discard link)
+//	jalr x1, x5, 0   — indirect call through function pointer in x5
 func (e *RiscVExecutor) execJALR(decoded cpu.DecodeResult, registers *cpu.RegisterFile, pc int) cpu.ExecuteResult {
 	rd := decoded.Fields["rd"]
 	rs1 := decoded.Fields["rs1"]
@@ -434,13 +437,13 @@ func (e *RiscVExecutor) execJALR(decoded cpu.DecodeResult, registers *cpu.Regist
 // LUI places a 20-bit immediate into the upper 20 bits of rd, with the
 // lower 12 bits set to zero:
 //
-//   rd = imm << 12
+//	rd = imm << 12
 //
 // This is used as the first half of a two-instruction sequence to load
 // a full 32-bit constant:
 //
-//   lui  x1, 0x12345     // x1 = 0x12345000
-//   addi x1, x1, 0x678   // x1 = 0x12345678
+//	lui  x1, 0x12345     // x1 = 0x12345000
+//	addi x1, x1, 0x678   // x1 = 0x12345678
 func (e *RiscVExecutor) execLUI(decoded cpu.DecodeResult, registers *cpu.RegisterFile, pc int) cpu.ExecuteResult {
 	rd := decoded.Fields["rd"]
 	imm := decoded.Fields["imm"]
@@ -460,7 +463,7 @@ func (e *RiscVExecutor) execLUI(decoded cpu.DecodeResult, registers *cpu.Registe
 //
 // AUIPC adds a 20-bit immediate (shifted left 12) to the current PC:
 //
-//   rd = PC + (imm << 12)
+//	rd = PC + (imm << 12)
 //
 // This enables PC-relative addressing for data that is far away. Combined
 // with addi or load instructions, it can reach any address in the 32-bit
@@ -487,11 +490,15 @@ func (e *RiscVExecutor) execAUIPC(decoded cpu.DecodeResult, registers *cpu.Regis
 //
 // Behavior depends on whether a trap handler is configured:
 //
-//   If mtvec != 0:  Raise a proper trap — save PC to mepc, set mcause,
-//                   disable interrupts, jump to mtvec.
+//	If mtvec != 0:  Raise a proper trap — save PC to mepc, set mcause,
+//	                disable interrupts, jump to mtvec.
 //
-//   If mtvec == 0:  Halt the CPU (legacy behavior for simple programs
-//                   that don't set up a trap handler).
+//	If mtvec == 0 and HostIO is configured: Handle the small host syscall ABI
+//	                used by compiler end-to-end tests (write byte, read byte,
+//	                exit).
+//
+//	If mtvec == 0:  Halt the CPU (legacy behavior for simple programs
+//	                that don't set up a trap handler).
 func (e *RiscVExecutor) execEcall(decoded cpu.DecodeResult, registers *cpu.RegisterFile, pc int) cpu.ExecuteResult {
 	if e.CSR == nil {
 		// No CSR file configured — simple halt behavior
@@ -506,6 +513,9 @@ func (e *RiscVExecutor) execEcall(decoded cpu.DecodeResult, registers *cpu.Regis
 
 	mtvec := e.CSR.Read(CSRMtvec)
 	if mtvec == 0 {
+		if e.Host != nil {
+			return e.execHostSyscall(registers, pc)
+		}
 		// No trap handler configured — halt as fallback
 		return cpu.ExecuteResult{
 			Description:      "ecall: halt (mtvec=0, no trap handler)",
@@ -533,11 +543,54 @@ func (e *RiscVExecutor) execEcall(decoded cpu.DecodeResult, registers *cpu.Regis
 	}
 }
 
+func (e *RiscVExecutor) execHostSyscall(registers *cpu.RegisterFile, pc int) cpu.ExecuteResult {
+	syscallNumber := registers.Read(17)
+	switch syscallNumber {
+	case SyscallWriteByte:
+		value := byte(registers.Read(10) & 0xFF)
+		e.Host.WriteByte(value)
+		return cpu.ExecuteResult{
+			Description:      fmt.Sprintf("ecall: host write byte 0x%02x", value),
+			RegistersChanged: map[string]uint32{},
+			MemoryChanged:    map[int]byte{},
+			NextPC:           pc + 4,
+		}
+	case SyscallReadByte:
+		value := uint32(e.Host.ReadByte())
+		registers.Write(10, value)
+		return cpu.ExecuteResult{
+			Description:      fmt.Sprintf("ecall: host read byte 0x%02x", value),
+			RegistersChanged: map[string]uint32{"x10": value},
+			MemoryChanged:    map[int]byte{},
+			NextPC:           pc + 4,
+		}
+	case SyscallExit:
+		exitCode := registers.Read(10)
+		e.Host.Exited = true
+		e.Host.ExitCode = exitCode
+		return cpu.ExecuteResult{
+			Description:      fmt.Sprintf("ecall: host exit %d", exitCode),
+			RegistersChanged: map[string]uint32{},
+			MemoryChanged:    map[int]byte{},
+			NextPC:           pc,
+			Halted:           true,
+		}
+	default:
+		return cpu.ExecuteResult{
+			Description:      fmt.Sprintf("ecall: unknown host syscall %d", syscallNumber),
+			RegistersChanged: map[string]uint32{},
+			MemoryChanged:    map[int]byte{},
+			NextPC:           pc,
+			Halted:           true,
+		}
+	}
+}
+
 // === mret executor ===
 //
 // mret returns from a machine-mode trap handler by:
-//   1. Restoring PC from mepc CSR
-//   2. Re-enabling interrupts (set MIE bit in mstatus)
+//  1. Restoring PC from mepc CSR
+//  2. Re-enabling interrupts (set MIE bit in mstatus)
 //
 // After mret, execution resumes at the instruction that caused the trap
 // (or the next one, depending on the trap type). For ecall, the trap
@@ -569,9 +622,10 @@ func (e *RiscVExecutor) execMret(decoded cpu.DecodeResult, registers *cpu.Regist
 // === CSRRW (CSR Read-Write) executor ===
 //
 // Atomically swaps the value in rs1 with the CSR:
-//   old_csr = CSR[csr_addr]
-//   CSR[csr_addr] = rs1
-//   rd = old_csr
+//
+//	old_csr = CSR[csr_addr]
+//	CSR[csr_addr] = rs1
+//	rd = old_csr
 //
 // If rd=x0, the read is still performed but the result is discarded.
 func (e *RiscVExecutor) execCSRRW(decoded cpu.DecodeResult, registers *cpu.RegisterFile, pc int) cpu.ExecuteResult {
@@ -594,9 +648,10 @@ func (e *RiscVExecutor) execCSRRW(decoded cpu.DecodeResult, registers *cpu.Regis
 // === CSRRS (CSR Read-Set) executor ===
 //
 // Reads the CSR, then sets bits specified by rs1:
-//   old_csr = CSR[csr_addr]
-//   CSR[csr_addr] = old_csr | rs1
-//   rd = old_csr
+//
+//	old_csr = CSR[csr_addr]
+//	CSR[csr_addr] = old_csr | rs1
+//	rd = old_csr
 //
 // If rs1=x0 (value 0), no bits are set — this is a pure read (csrr pseudo-instruction).
 func (e *RiscVExecutor) execCSRRS(decoded cpu.DecodeResult, registers *cpu.RegisterFile, pc int) cpu.ExecuteResult {
@@ -619,9 +674,10 @@ func (e *RiscVExecutor) execCSRRS(decoded cpu.DecodeResult, registers *cpu.Regis
 // === CSRRC (CSR Read-Clear) executor ===
 //
 // Reads the CSR, then clears bits specified by rs1:
-//   old_csr = CSR[csr_addr]
-//   CSR[csr_addr] = old_csr & ~rs1
-//   rd = old_csr
+//
+//	old_csr = CSR[csr_addr]
+//	CSR[csr_addr] = old_csr & ~rs1
+//	rd = old_csr
 func (e *RiscVExecutor) execCSRRC(decoded cpu.DecodeResult, registers *cpu.RegisterFile, pc int) cpu.ExecuteResult {
 	rd := decoded.Fields["rd"]
 	rs1 := decoded.Fields["rs1"]

--- a/code/packages/go/riscv-simulator/host.go
+++ b/code/packages/go/riscv-simulator/host.go
@@ -1,0 +1,48 @@
+package riscvsimulator
+
+const (
+	SyscallWriteByte = 1
+	SyscallReadByte  = 2
+	SyscallExit      = 10
+)
+
+// HostIO provides tiny host services for source-language end-to-end tests.
+//
+// It is intentionally byte-oriented because the first users are Brainfuck and
+// other small compiler pipelines that only need stdin/stdout plus exit status.
+type HostIO struct {
+	Input  []byte
+	Output []byte
+
+	inputOffset int
+	Exited      bool
+	ExitCode    uint32
+}
+
+func NewHostIO(input []byte) *HostIO {
+	copied := append([]byte(nil), input...)
+	return &HostIO{Input: copied}
+}
+
+func (h *HostIO) ReadByte() byte {
+	if h == nil || h.inputOffset >= len(h.Input) {
+		return 0
+	}
+	value := h.Input[h.inputOffset]
+	h.inputOffset++
+	return value
+}
+
+func (h *HostIO) WriteByte(value byte) {
+	if h == nil {
+		return
+	}
+	h.Output = append(h.Output, value)
+}
+
+func (h *HostIO) OutputString() string {
+	if h == nil {
+		return ""
+	}
+	return string(h.Output)
+}

--- a/code/packages/go/riscv-simulator/simulator.go
+++ b/code/packages/go/riscv-simulator/simulator.go
@@ -28,22 +28,24 @@
 // === Register conventions ===
 //
 // RISC-V has 32 registers, each 32 bits wide. The most important quirk is:
-//     x0  = always 0 (hardwired — writes are ignored, reads always return 0)
+//
+//	x0  = always 0 (hardwired — writes are ignored, reads always return 0)
 //
 // Because x0 is always 0, it enables clever optimizations without dedicated instructions:
-//     addi x1, x0, 42    →    x1 = 0 + 42 = 42 (effectively a "load 42 into x1" operation)
+//
+//	addi x1, x0, 42    →    x1 = 0 + 42 = 42 (effectively a "load 42 into x1" operation)
 //
 // === Architecture ===
 //
 // This simulator bridges the gap between binary encoded bits and the generic
 // fetch-decode-execute cycle provided by the cpu-simulator package:
 //
-//   simulator.go  — top-level simulator struct and factory
-//   opcodes.go    — opcode and funct3/funct7 constants
-//   decode.go     — instruction decoder (binary → structured fields)
-//   execute.go    — instruction executor (structured fields → state changes)
-//   csr.go        — Control and Status Register file for M-mode
-//   encoding.go   — helpers to construct machine code for testing
+//	simulator.go  — top-level simulator struct and factory
+//	opcodes.go    — opcode and funct3/funct7 constants
+//	decode.go     — instruction decoder (binary → structured fields)
+//	execute.go    — instruction executor (structured fields → state changes)
+//	csr.go        — Control and Status Register file for M-mode
+//	encoding.go   — helpers to construct machine code for testing
 package riscvsimulator
 
 import (
@@ -65,7 +67,8 @@ type RiscVDecoder struct{}
 // handlers. The CSR field provides access to M-mode Control and Status Registers
 // for privileged operations (ecall trap handling, mret, CSR read/write).
 type RiscVExecutor struct {
-	CSR *CSRFile
+	CSR  *CSRFile
+	Host *HostIO
 }
 
 // RiscVSimulator encompasses the full RISC-V environment: decoder, executor,
@@ -75,6 +78,7 @@ type RiscVSimulator struct {
 	Executor *RiscVExecutor
 	CPU      *cpu.CPU
 	CSR      *CSRFile
+	Host     *HostIO
 }
 
 // NewRiscVSimulator creates a fully initialized RISC-V simulator with the
@@ -86,16 +90,26 @@ type RiscVSimulator struct {
 // Memory size should be large enough to hold both the program and any
 // data it accesses. 65536 (64 KiB) is a good default for testing.
 func NewRiscVSimulator(memorySize int) *RiscVSimulator {
+	return NewRiscVSimulatorWithHost(memorySize, nil)
+}
+
+// NewRiscVSimulatorWithHost creates a simulator with optional host syscall I/O.
+//
+// When host is nil, ecall keeps the legacy no-trap-handler behavior and halts.
+// When host is present and mtvec is unset, syscall numbers in x17 are handled
+// directly for simple language runtime tests.
+func NewRiscVSimulatorWithHost(memorySize int, host *HostIO) *RiscVSimulator {
 	result, _ := StartNew[*RiscVSimulator]("riscv-simulator.NewRiscVSimulator", nil,
 		func(op *Operation[*RiscVSimulator], rf *ResultFactory[*RiscVSimulator]) *OperationResult[*RiscVSimulator] {
 			decoder := &RiscVDecoder{}
 			csrFile := NewCSRFile()
-			executor := &RiscVExecutor{CSR: csrFile}
+			executor := &RiscVExecutor{CSR: csrFile, Host: host}
 			return rf.Generate(true, false, &RiscVSimulator{
 				Decoder:  decoder,
 				Executor: executor,
 				CPU:      cpu.NewCPU(decoder, executor, 32, 32, memorySize),
 				CSR:      csrFile,
+				Host:     host,
 			})
 		}).GetResult()
 	return result

--- a/code/packages/go/riscv-simulator/simulator_test.go
+++ b/code/packages/go/riscv-simulator/simulator_test.go
@@ -32,16 +32,45 @@ func expectRegSigned(t *testing.T, sim *RiscVSimulator, reg int, expected int32)
 	}
 }
 
+func TestHostSyscallsReadWriteAndExit(t *testing.T) {
+	host := NewHostIO([]byte{'A'})
+	sim := NewRiscVSimulatorWithHost(65536, host)
+	program := Assemble([]uint32{
+		EncodeAddi(17, 0, SyscallReadByte),  // a7 = read
+		EncodeEcall(),                       // a0 = 'A'
+		EncodeAddi(17, 0, SyscallWriteByte), // a7 = write
+		EncodeEcall(),                       // stdout += a0
+		EncodeAddi(10, 0, 0),                // a0 = exit code
+		EncodeAddi(17, 0, SyscallExit),      // a7 = exit
+		EncodeEcall(),
+	})
+
+	sim.Run(program)
+
+	if !sim.CPU.Halted {
+		t.Fatal("expected simulator to halt after host exit")
+	}
+	if !host.Exited {
+		t.Fatal("expected host to record exit")
+	}
+	if host.ExitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", host.ExitCode)
+	}
+	if got := host.OutputString(); got != "A" {
+		t.Fatalf("expected host output %q, got %q", "A", got)
+	}
+}
+
 // =============================================================================
 // I-type arithmetic instructions
 // =============================================================================
 
 func TestAddi(t *testing.T) {
 	sim := runProgram(t, []uint32{
-		EncodeAddi(1, 0, 42),  // x1 = 42
-		EncodeAddi(2, 1, 10),  // x2 = 42 + 10 = 52
-		EncodeAddi(3, 0, -5),  // x3 = -5
-		EncodeAddi(4, 3, 3),   // x4 = -5 + 3 = -2
+		EncodeAddi(1, 0, 42), // x1 = 42
+		EncodeAddi(2, 1, 10), // x2 = 42 + 10 = 52
+		EncodeAddi(3, 0, -5), // x3 = -5
+		EncodeAddi(4, 3, 3),  // x4 = -5 + 3 = -2
 		EncodeEcall(),
 	})
 	expectReg(t, sim, 1, 42)
@@ -52,12 +81,12 @@ func TestAddi(t *testing.T) {
 
 func TestSlti(t *testing.T) {
 	sim := runProgram(t, []uint32{
-		EncodeAddi(1, 0, 5),   // x1 = 5
-		EncodeSlti(2, 1, 10),  // x2 = (5 < 10) = 1
-		EncodeSlti(3, 1, 3),   // x3 = (5 < 3) = 0
-		EncodeSlti(4, 1, 5),   // x4 = (5 < 5) = 0
-		EncodeAddi(5, 0, -1),  // x5 = -1
-		EncodeSlti(6, 5, 0),   // x6 = (-1 < 0) = 1  (signed comparison)
+		EncodeAddi(1, 0, 5),  // x1 = 5
+		EncodeSlti(2, 1, 10), // x2 = (5 < 10) = 1
+		EncodeSlti(3, 1, 3),  // x3 = (5 < 3) = 0
+		EncodeSlti(4, 1, 5),  // x4 = (5 < 5) = 0
+		EncodeAddi(5, 0, -1), // x5 = -1
+		EncodeSlti(6, 5, 0),  // x6 = (-1 < 0) = 1  (signed comparison)
 		EncodeEcall(),
 	})
 	expectReg(t, sim, 2, 1)
@@ -68,11 +97,11 @@ func TestSlti(t *testing.T) {
 
 func TestSltiu(t *testing.T) {
 	sim := runProgram(t, []uint32{
-		EncodeAddi(1, 0, 5),     // x1 = 5
-		EncodeSltiu(2, 1, 10),   // x2 = (5 <u 10) = 1
-		EncodeSltiu(3, 1, 3),    // x3 = (5 <u 3) = 0
-		EncodeAddi(4, 0, -1),    // x4 = 0xFFFFFFFF
-		EncodeSltiu(5, 4, 1),    // x5 = (0xFFFFFFFF <u 1) = 0 (unsigned: huge > 1)
+		EncodeAddi(1, 0, 5),   // x1 = 5
+		EncodeSltiu(2, 1, 10), // x2 = (5 <u 10) = 1
+		EncodeSltiu(3, 1, 3),  // x3 = (5 <u 3) = 0
+		EncodeAddi(4, 0, -1),  // x4 = 0xFFFFFFFF
+		EncodeSltiu(5, 4, 1),  // x5 = (0xFFFFFFFF <u 1) = 0 (unsigned: huge > 1)
 		EncodeEcall(),
 	})
 	expectReg(t, sim, 2, 1)
@@ -82,8 +111,8 @@ func TestSltiu(t *testing.T) {
 
 func TestXori(t *testing.T) {
 	sim := runProgram(t, []uint32{
-		EncodeAddi(1, 0, 0xFF),  // x1 = 0xFF
-		EncodeXori(2, 1, 0x0F),  // x2 = 0xFF ^ 0x0F = 0xF0
+		EncodeAddi(1, 0, 0xFF), // x1 = 0xFF
+		EncodeXori(2, 1, 0x0F), // x2 = 0xFF ^ 0x0F = 0xF0
 		EncodeEcall(),
 	})
 	expectReg(t, sim, 2, 0xF0)
@@ -91,8 +120,8 @@ func TestXori(t *testing.T) {
 
 func TestOri(t *testing.T) {
 	sim := runProgram(t, []uint32{
-		EncodeAddi(1, 0, 0x50),  // x1 = 0x50
-		EncodeOri(2, 1, 0x0F),   // x2 = 0x50 | 0x0F = 0x5F
+		EncodeAddi(1, 0, 0x50), // x1 = 0x50
+		EncodeOri(2, 1, 0x0F),  // x2 = 0x50 | 0x0F = 0x5F
 		EncodeEcall(),
 	})
 	expectReg(t, sim, 2, 0x5F)
@@ -100,8 +129,8 @@ func TestOri(t *testing.T) {
 
 func TestAndi(t *testing.T) {
 	sim := runProgram(t, []uint32{
-		EncodeAddi(1, 0, 0xFF),  // x1 = 0xFF
-		EncodeAndi(2, 1, 0x0F),  // x2 = 0xFF & 0x0F = 0x0F
+		EncodeAddi(1, 0, 0xFF), // x1 = 0xFF
+		EncodeAndi(2, 1, 0x0F), // x2 = 0xFF & 0x0F = 0x0F
 		EncodeEcall(),
 	})
 	expectReg(t, sim, 2, 0x0F)
@@ -109,9 +138,9 @@ func TestAndi(t *testing.T) {
 
 func TestSlli(t *testing.T) {
 	sim := runProgram(t, []uint32{
-		EncodeAddi(1, 0, 1),     // x1 = 1
-		EncodeSlli(2, 1, 4),     // x2 = 1 << 4 = 16
-		EncodeSlli(3, 1, 31),    // x3 = 1 << 31 = 0x80000000
+		EncodeAddi(1, 0, 1),  // x1 = 1
+		EncodeSlli(2, 1, 4),  // x2 = 1 << 4 = 16
+		EncodeSlli(3, 1, 31), // x3 = 1 << 31 = 0x80000000
 		EncodeEcall(),
 	})
 	expectReg(t, sim, 2, 16)
@@ -120,9 +149,9 @@ func TestSlli(t *testing.T) {
 
 func TestSrli(t *testing.T) {
 	sim := runProgram(t, []uint32{
-		EncodeAddi(1, 0, -1),    // x1 = 0xFFFFFFFF
-		EncodeSrli(2, 1, 4),     // x2 = 0xFFFFFFFF >>> 4 = 0x0FFFFFFF (logical)
-		EncodeSrli(3, 1, 31),    // x3 = 0xFFFFFFFF >>> 31 = 1
+		EncodeAddi(1, 0, -1), // x1 = 0xFFFFFFFF
+		EncodeSrli(2, 1, 4),  // x2 = 0xFFFFFFFF >>> 4 = 0x0FFFFFFF (logical)
+		EncodeSrli(3, 1, 31), // x3 = 0xFFFFFFFF >>> 31 = 1
 		EncodeEcall(),
 	})
 	expectReg(t, sim, 2, 0x0FFFFFFF)
@@ -131,10 +160,10 @@ func TestSrli(t *testing.T) {
 
 func TestSrai(t *testing.T) {
 	sim := runProgram(t, []uint32{
-		EncodeAddi(1, 0, -16),   // x1 = 0xFFFFFFF0 (-16)
-		EncodeSrai(2, 1, 2),     // x2 = -16 >> 2 = -4 (arithmetic, preserves sign)
-		EncodeAddi(3, 0, 16),    // x3 = 16
-		EncodeSrai(4, 3, 2),     // x4 = 16 >> 2 = 4  (positive, same as logical)
+		EncodeAddi(1, 0, -16), // x1 = 0xFFFFFFF0 (-16)
+		EncodeSrai(2, 1, 2),   // x2 = -16 >> 2 = -4 (arithmetic, preserves sign)
+		EncodeAddi(3, 0, 16),  // x3 = 16
+		EncodeSrai(4, 3, 2),   // x4 = 16 >> 2 = 4  (positive, same as logical)
 		EncodeEcall(),
 	})
 	expectRegSigned(t, sim, 2, -4)
@@ -147,10 +176,10 @@ func TestSrai(t *testing.T) {
 
 func TestAddSub(t *testing.T) {
 	sim := runProgram(t, []uint32{
-		EncodeAddi(1, 0, 10),    // x1 = 10
-		EncodeAddi(2, 0, 20),    // x2 = 20
-		EncodeAdd(3, 1, 2),      // x3 = 10 + 20 = 30
-		EncodeSub(4, 1, 2),      // x4 = 10 - 20 = -10
+		EncodeAddi(1, 0, 10), // x1 = 10
+		EncodeAddi(2, 0, 20), // x2 = 20
+		EncodeAdd(3, 1, 2),   // x3 = 10 + 20 = 30
+		EncodeSub(4, 1, 2),   // x4 = 10 - 20 = -10
 		EncodeEcall(),
 	})
 	expectReg(t, sim, 3, 30)
@@ -159,9 +188,9 @@ func TestAddSub(t *testing.T) {
 
 func TestSll(t *testing.T) {
 	sim := runProgram(t, []uint32{
-		EncodeAddi(1, 0, 1),     // x1 = 1
-		EncodeAddi(2, 0, 8),     // x2 = 8
-		EncodeSll(3, 1, 2),      // x3 = 1 << 8 = 256
+		EncodeAddi(1, 0, 1), // x1 = 1
+		EncodeAddi(2, 0, 8), // x2 = 8
+		EncodeSll(3, 1, 2),  // x3 = 1 << 8 = 256
 		EncodeEcall(),
 	})
 	expectReg(t, sim, 3, 256)
@@ -169,10 +198,10 @@ func TestSll(t *testing.T) {
 
 func TestSlt(t *testing.T) {
 	sim := runProgram(t, []uint32{
-		EncodeAddi(1, 0, -5),    // x1 = -5
-		EncodeAddi(2, 0, 3),     // x2 = 3
-		EncodeSlt(3, 1, 2),      // x3 = (-5 < 3) = 1 (signed)
-		EncodeSlt(4, 2, 1),      // x4 = (3 < -5) = 0
+		EncodeAddi(1, 0, -5), // x1 = -5
+		EncodeAddi(2, 0, 3),  // x2 = 3
+		EncodeSlt(3, 1, 2),   // x3 = (-5 < 3) = 1 (signed)
+		EncodeSlt(4, 2, 1),   // x4 = (3 < -5) = 0
 		EncodeEcall(),
 	})
 	expectReg(t, sim, 3, 1)
@@ -181,10 +210,10 @@ func TestSlt(t *testing.T) {
 
 func TestSltu(t *testing.T) {
 	sim := runProgram(t, []uint32{
-		EncodeAddi(1, 0, -1),    // x1 = 0xFFFFFFFF
-		EncodeAddi(2, 0, 1),     // x2 = 1
-		EncodeSltu(3, 2, 1),     // x3 = (1 <u 0xFFFFFFFF) = 1
-		EncodeSltu(4, 1, 2),     // x4 = (0xFFFFFFFF <u 1) = 0
+		EncodeAddi(1, 0, -1), // x1 = 0xFFFFFFFF
+		EncodeAddi(2, 0, 1),  // x2 = 1
+		EncodeSltu(3, 2, 1),  // x3 = (1 <u 0xFFFFFFFF) = 1
+		EncodeSltu(4, 1, 2),  // x4 = (0xFFFFFFFF <u 1) = 0
 		EncodeEcall(),
 	})
 	expectReg(t, sim, 3, 1)
@@ -195,7 +224,7 @@ func TestXor(t *testing.T) {
 	sim := runProgram(t, []uint32{
 		EncodeAddi(1, 0, 0xFF),
 		EncodeAddi(2, 0, 0x0F),
-		EncodeXor(3, 1, 2),      // x3 = 0xFF ^ 0x0F = 0xF0
+		EncodeXor(3, 1, 2), // x3 = 0xFF ^ 0x0F = 0xF0
 		EncodeEcall(),
 	})
 	expectReg(t, sim, 3, 0xF0)
@@ -203,9 +232,9 @@ func TestXor(t *testing.T) {
 
 func TestSrl(t *testing.T) {
 	sim := runProgram(t, []uint32{
-		EncodeAddi(1, 0, -1),    // x1 = 0xFFFFFFFF
-		EncodeAddi(2, 0, 4),     // x2 = 4
-		EncodeSrl(3, 1, 2),      // x3 = 0xFFFFFFFF >>> 4 = 0x0FFFFFFF
+		EncodeAddi(1, 0, -1), // x1 = 0xFFFFFFFF
+		EncodeAddi(2, 0, 4),  // x2 = 4
+		EncodeSrl(3, 1, 2),   // x3 = 0xFFFFFFFF >>> 4 = 0x0FFFFFFF
 		EncodeEcall(),
 	})
 	expectReg(t, sim, 3, 0x0FFFFFFF)
@@ -213,9 +242,9 @@ func TestSrl(t *testing.T) {
 
 func TestSra(t *testing.T) {
 	sim := runProgram(t, []uint32{
-		EncodeAddi(1, 0, -16),   // x1 = -16
-		EncodeAddi(2, 0, 2),     // x2 = 2
-		EncodeSra(3, 1, 2),      // x3 = -16 >> 2 = -4
+		EncodeAddi(1, 0, -16), // x1 = -16
+		EncodeAddi(2, 0, 2),   // x2 = 2
+		EncodeSra(3, 1, 2),    // x3 = -16 >> 2 = -4
 		EncodeEcall(),
 	})
 	expectRegSigned(t, sim, 3, -4)
@@ -225,7 +254,7 @@ func TestOr(t *testing.T) {
 	sim := runProgram(t, []uint32{
 		EncodeAddi(1, 0, 0x50),
 		EncodeAddi(2, 0, 0x0F),
-		EncodeOr(3, 1, 2),       // x3 = 0x50 | 0x0F = 0x5F
+		EncodeOr(3, 1, 2), // x3 = 0x50 | 0x0F = 0x5F
 		EncodeEcall(),
 	})
 	expectReg(t, sim, 3, 0x5F)
@@ -235,7 +264,7 @@ func TestAnd(t *testing.T) {
 	sim := runProgram(t, []uint32{
 		EncodeAddi(1, 0, 0xFF),
 		EncodeAddi(2, 0, 0x0F),
-		EncodeAnd(3, 1, 2),      // x3 = 0xFF & 0x0F = 0x0F
+		EncodeAnd(3, 1, 2), // x3 = 0xFF & 0x0F = 0x0F
 		EncodeEcall(),
 	})
 	expectReg(t, sim, 3, 0x0F)
@@ -248,10 +277,10 @@ func TestAnd(t *testing.T) {
 func TestStoreWordLoadWord(t *testing.T) {
 	// Store a word to memory, then load it back
 	sim := runProgram(t, []uint32{
-		EncodeAddi(1, 0, 0x100),      // x1 = 0x100 (base address)
-		EncodeAddi(2, 0, 0x42),       // x2 = 0x42
-		EncodeSw(2, 1, 0),            // mem[0x100] = 0x42
-		EncodeLw(3, 1, 0),            // x3 = mem[0x100]
+		EncodeAddi(1, 0, 0x100), // x1 = 0x100 (base address)
+		EncodeAddi(2, 0, 0x42),  // x2 = 0x42
+		EncodeSw(2, 1, 0),       // mem[0x100] = 0x42
+		EncodeLw(3, 1, 0),       // x3 = mem[0x100]
 		EncodeEcall(),
 	})
 	expectReg(t, sim, 3, 0x42)
@@ -259,10 +288,10 @@ func TestStoreWordLoadWord(t *testing.T) {
 
 func TestStoreByteLoadByte(t *testing.T) {
 	sim := runProgram(t, []uint32{
-		EncodeAddi(1, 0, 0x200),      // x1 = base address
-		EncodeAddi(2, 0, 0xAB),       // x2 = 0xAB
-		EncodeSb(2, 1, 0),            // mem[0x200] = 0xAB (byte)
-		EncodeLbu(3, 1, 0),           // x3 = zero-extend(mem[0x200]) = 0xAB
+		EncodeAddi(1, 0, 0x200), // x1 = base address
+		EncodeAddi(2, 0, 0xAB),  // x2 = 0xAB
+		EncodeSb(2, 1, 0),       // mem[0x200] = 0xAB (byte)
+		EncodeLbu(3, 1, 0),      // x3 = zero-extend(mem[0x200]) = 0xAB
 		EncodeEcall(),
 	})
 	expectReg(t, sim, 3, 0xAB)
@@ -271,11 +300,11 @@ func TestStoreByteLoadByte(t *testing.T) {
 func TestLoadByteSignExtend(t *testing.T) {
 	// Store 0xFF (which is -1 as a signed byte), then load with sign extension
 	sim := runProgram(t, []uint32{
-		EncodeAddi(1, 0, 0x200),      // x1 = base address
-		EncodeAddi(2, 0, 0xFF),       // x2 = 0xFF
-		EncodeSb(2, 1, 0),            // mem[0x200] = 0xFF
-		EncodeLb(3, 1, 0),            // x3 = sign-extend(0xFF) = 0xFFFFFFFF = -1
-		EncodeLbu(4, 1, 0),           // x4 = zero-extend(0xFF) = 0x000000FF = 255
+		EncodeAddi(1, 0, 0x200), // x1 = base address
+		EncodeAddi(2, 0, 0xFF),  // x2 = 0xFF
+		EncodeSb(2, 1, 0),       // mem[0x200] = 0xFF
+		EncodeLb(3, 1, 0),       // x3 = sign-extend(0xFF) = 0xFFFFFFFF = -1
+		EncodeLbu(4, 1, 0),      // x4 = zero-extend(0xFF) = 0x000000FF = 255
 		EncodeEcall(),
 	})
 	expectRegSigned(t, sim, 3, -1) // lb sign-extends
@@ -284,11 +313,11 @@ func TestLoadByteSignExtend(t *testing.T) {
 
 func TestStoreHalfLoadHalf(t *testing.T) {
 	sim := runProgram(t, []uint32{
-		EncodeAddi(1, 0, 0x200),      // x1 = base address
-		EncodeLui(2, 0),              // x2 = 0
-		EncodeAddi(2, 0, 0x1FF),      // x2 = 0x1FF (511)
-		EncodeSh(2, 1, 0),            // mem[0x200] = 0x01FF (halfword)
-		EncodeLhu(3, 1, 0),           // x3 = zero-extend(0x01FF) = 511
+		EncodeAddi(1, 0, 0x200), // x1 = base address
+		EncodeLui(2, 0),         // x2 = 0
+		EncodeAddi(2, 0, 0x1FF), // x2 = 0x1FF (511)
+		EncodeSh(2, 1, 0),       // mem[0x200] = 0x01FF (halfword)
+		EncodeLhu(3, 1, 0),      // x3 = zero-extend(0x01FF) = 511
 		EncodeEcall(),
 	})
 	expectReg(t, sim, 3, 0x1FF)
@@ -298,10 +327,10 @@ func TestLoadHalfSignExtend(t *testing.T) {
 	// Store 0xFFFF as a halfword, then load with sign extension
 	sim := runProgram(t, []uint32{
 		EncodeAddi(1, 0, 0x200),
-		EncodeAddi(2, 0, -1),         // x2 = 0xFFFFFFFF
-		EncodeSh(2, 1, 0),            // mem[0x200] = 0xFFFF (low 16 bits)
-		EncodeLh(3, 1, 0),            // x3 = sign-extend(0xFFFF) = -1
-		EncodeLhu(4, 1, 0),           // x4 = zero-extend(0xFFFF) = 65535
+		EncodeAddi(2, 0, -1), // x2 = 0xFFFFFFFF
+		EncodeSh(2, 1, 0),    // mem[0x200] = 0xFFFF (low 16 bits)
+		EncodeLh(3, 1, 0),    // x3 = sign-extend(0xFFFF) = -1
+		EncodeLhu(4, 1, 0),   // x4 = zero-extend(0xFFFF) = 65535
 		EncodeEcall(),
 	})
 	expectRegSigned(t, sim, 3, -1)
@@ -311,10 +340,10 @@ func TestLoadHalfSignExtend(t *testing.T) {
 func TestStoreLoadWithOffset(t *testing.T) {
 	// Use non-zero offset in store/load
 	sim := runProgram(t, []uint32{
-		EncodeAddi(1, 0, 0x200),      // x1 = 0x200
-		EncodeAddi(2, 0, 99),         // x2 = 99
-		EncodeSw(2, 1, 4),            // mem[0x204] = 99
-		EncodeLw(3, 1, 4),            // x3 = mem[0x204] = 99
+		EncodeAddi(1, 0, 0x200), // x1 = 0x200
+		EncodeAddi(2, 0, 99),    // x2 = 99
+		EncodeSw(2, 1, 4),       // mem[0x204] = 99
+		EncodeLw(3, 1, 4),       // x3 = mem[0x204] = 99
 		EncodeEcall(),
 	})
 	expectReg(t, sim, 3, 99)
@@ -327,23 +356,23 @@ func TestStoreLoadWithOffset(t *testing.T) {
 func TestBeqTaken(t *testing.T) {
 	// beq: if x1 == x2, skip next instruction
 	sim := runProgram(t, []uint32{
-		EncodeAddi(1, 0, 5),          // x1 = 5        (PC=0)
-		EncodeAddi(2, 0, 5),          // x2 = 5        (PC=4)
-		EncodeBeq(1, 2, 8),           // beq: skip 2 instructions (PC=8, target=16)
-		EncodeAddi(3, 0, 999),        // SKIPPED        (PC=12)
-		EncodeAddi(4, 0, 42),         // x4 = 42       (PC=16, target)
+		EncodeAddi(1, 0, 5),   // x1 = 5        (PC=0)
+		EncodeAddi(2, 0, 5),   // x2 = 5        (PC=4)
+		EncodeBeq(1, 2, 8),    // beq: skip 2 instructions (PC=8, target=16)
+		EncodeAddi(3, 0, 999), // SKIPPED        (PC=12)
+		EncodeAddi(4, 0, 42),  // x4 = 42       (PC=16, target)
 		EncodeEcall(),
 	})
-	expectReg(t, sim, 3, 0)   // should be skipped
-	expectReg(t, sim, 4, 42)  // should execute
+	expectReg(t, sim, 3, 0)  // should be skipped
+	expectReg(t, sim, 4, 42) // should execute
 }
 
 func TestBeqNotTaken(t *testing.T) {
 	sim := runProgram(t, []uint32{
 		EncodeAddi(1, 0, 5),
 		EncodeAddi(2, 0, 10),
-		EncodeBeq(1, 2, 8),           // not taken (5 != 10)
-		EncodeAddi(3, 0, 42),         // should execute
+		EncodeBeq(1, 2, 8),   // not taken (5 != 10)
+		EncodeAddi(3, 0, 42), // should execute
 		EncodeEcall(),
 	})
 	expectReg(t, sim, 3, 42)
@@ -353,9 +382,9 @@ func TestBne(t *testing.T) {
 	sim := runProgram(t, []uint32{
 		EncodeAddi(1, 0, 5),
 		EncodeAddi(2, 0, 10),
-		EncodeBne(1, 2, 8),           // taken (5 != 10), skip to PC=16
-		EncodeAddi(3, 0, 999),        // SKIPPED
-		EncodeAddi(4, 0, 42),         // should execute
+		EncodeBne(1, 2, 8),    // taken (5 != 10), skip to PC=16
+		EncodeAddi(3, 0, 999), // SKIPPED
+		EncodeAddi(4, 0, 42),  // should execute
 		EncodeEcall(),
 	})
 	expectReg(t, sim, 3, 0)
@@ -364,11 +393,11 @@ func TestBne(t *testing.T) {
 
 func TestBlt(t *testing.T) {
 	sim := runProgram(t, []uint32{
-		EncodeAddi(1, 0, -5),         // x1 = -5 (signed)
-		EncodeAddi(2, 0, 3),          // x2 = 3
-		EncodeBlt(1, 2, 8),           // taken: -5 < 3 (signed), jump +8 from PC=8 -> PC=16
-		EncodeAddi(3, 0, 999),        // SKIPPED
-		EncodeAddi(4, 0, 42),         // should execute
+		EncodeAddi(1, 0, -5),  // x1 = -5 (signed)
+		EncodeAddi(2, 0, 3),   // x2 = 3
+		EncodeBlt(1, 2, 8),    // taken: -5 < 3 (signed), jump +8 from PC=8 -> PC=16
+		EncodeAddi(3, 0, 999), // SKIPPED
+		EncodeAddi(4, 0, 42),  // should execute
 		EncodeEcall(),
 	})
 	expectReg(t, sim, 3, 0)
@@ -379,8 +408,8 @@ func TestBge(t *testing.T) {
 	sim := runProgram(t, []uint32{
 		EncodeAddi(1, 0, 5),
 		EncodeAddi(2, 0, 5),
-		EncodeBge(1, 2, 8),           // taken: 5 >= 5
-		EncodeAddi(3, 0, 999),        // SKIPPED
+		EncodeBge(1, 2, 8),    // taken: 5 >= 5
+		EncodeAddi(3, 0, 999), // SKIPPED
 		EncodeAddi(4, 0, 42),
 		EncodeEcall(),
 	})
@@ -392,9 +421,9 @@ func TestBltu(t *testing.T) {
 	// In unsigned comparison, -1 (0xFFFFFFFF) is the largest value
 	sim := runProgram(t, []uint32{
 		EncodeAddi(1, 0, 1),
-		EncodeAddi(2, 0, -1),         // x2 = 0xFFFFFFFF
-		EncodeBltu(1, 2, 8),          // taken: 1 <u 0xFFFFFFFF
-		EncodeAddi(3, 0, 999),        // SKIPPED
+		EncodeAddi(2, 0, -1),  // x2 = 0xFFFFFFFF
+		EncodeBltu(1, 2, 8),   // taken: 1 <u 0xFFFFFFFF
+		EncodeAddi(3, 0, 999), // SKIPPED
 		EncodeAddi(4, 0, 42),
 		EncodeEcall(),
 	})
@@ -404,10 +433,10 @@ func TestBltu(t *testing.T) {
 
 func TestBgeu(t *testing.T) {
 	sim := runProgram(t, []uint32{
-		EncodeAddi(1, 0, -1),         // x1 = 0xFFFFFFFF
+		EncodeAddi(1, 0, -1), // x1 = 0xFFFFFFFF
 		EncodeAddi(2, 0, 1),
-		EncodeBgeu(1, 2, 8),          // taken: 0xFFFFFFFF >=u 1
-		EncodeAddi(3, 0, 999),        // SKIPPED
+		EncodeBgeu(1, 2, 8),   // taken: 0xFFFFFFFF >=u 1
+		EncodeAddi(3, 0, 999), // SKIPPED
 		EncodeAddi(4, 0, 42),
 		EncodeEcall(),
 	})
@@ -419,11 +448,11 @@ func TestBranchBackward(t *testing.T) {
 	// A simple loop: count from 0 to 3
 	// x1 = counter, x2 = limit (3)
 	sim := runProgram(t, []uint32{
-		EncodeAddi(1, 0, 0),          // x1 = 0          (PC=0)
-		EncodeAddi(2, 0, 3),          // x2 = 3          (PC=4)
-		EncodeAddi(1, 1, 1),          // x1++            (PC=8, loop target)
-		EncodeBne(1, 2, -4),          // if x1 != 3, jump back to PC=8 (offset=-4)
-		EncodeEcall(),                //                 (PC=16)
+		EncodeAddi(1, 0, 0), // x1 = 0          (PC=0)
+		EncodeAddi(2, 0, 3), // x2 = 3          (PC=4)
+		EncodeAddi(1, 1, 1), // x1++            (PC=8, loop target)
+		EncodeBne(1, 2, -4), // if x1 != 3, jump back to PC=8 (offset=-4)
+		EncodeEcall(),       //                 (PC=16)
 	})
 	expectReg(t, sim, 1, 3)
 }
@@ -435,23 +464,23 @@ func TestBranchBackward(t *testing.T) {
 func TestJal(t *testing.T) {
 	// jal: jump forward, saving return address
 	sim := runProgram(t, []uint32{
-		EncodeJal(1, 8),              // x1 = PC+4 = 4, jump to PC+8 = 8  (PC=0)
-		EncodeAddi(2, 0, 999),        // SKIPPED                           (PC=4)
-		EncodeAddi(3, 0, 42),         // should execute                    (PC=8)
+		EncodeJal(1, 8),       // x1 = PC+4 = 4, jump to PC+8 = 8  (PC=0)
+		EncodeAddi(2, 0, 999), // SKIPPED                           (PC=4)
+		EncodeAddi(3, 0, 42),  // should execute                    (PC=8)
 		EncodeEcall(),
 	})
-	expectReg(t, sim, 1, 4)   // return address = old PC + 4
-	expectReg(t, sim, 2, 0)   // skipped
-	expectReg(t, sim, 3, 42)  // executed
+	expectReg(t, sim, 1, 4)  // return address = old PC + 4
+	expectReg(t, sim, 2, 0)  // skipped
+	expectReg(t, sim, 3, 42) // executed
 }
 
 func TestJalr(t *testing.T) {
 	// jalr: indirect jump through register
 	sim := runProgram(t, []uint32{
-		EncodeAddi(5, 0, 12),         // x5 = 12 (target address)   (PC=0)
-		EncodeJalr(1, 5, 0),          // x1 = PC+4 = 8, jump to 12 (PC=4)
-		EncodeAddi(2, 0, 999),        // SKIPPED                    (PC=8)
-		EncodeAddi(3, 0, 42),         // should execute             (PC=12)
+		EncodeAddi(5, 0, 12),  // x5 = 12 (target address)   (PC=0)
+		EncodeJalr(1, 5, 0),   // x1 = PC+4 = 8, jump to 12 (PC=4)
+		EncodeAddi(2, 0, 999), // SKIPPED                    (PC=8)
+		EncodeAddi(3, 0, 42),  // should execute             (PC=12)
 		EncodeEcall(),
 	})
 	expectReg(t, sim, 1, 8)
@@ -461,10 +490,10 @@ func TestJalr(t *testing.T) {
 
 func TestJalrWithOffset(t *testing.T) {
 	sim := runProgram(t, []uint32{
-		EncodeAddi(5, 0, 8),          // x5 = 8
-		EncodeJalr(1, 5, 4),          // jump to (8+4)=12
-		EncodeAddi(2, 0, 999),        // SKIPPED
-		EncodeAddi(3, 0, 42),         // executed at PC=12
+		EncodeAddi(5, 0, 8),   // x5 = 8
+		EncodeJalr(1, 5, 4),   // jump to (8+4)=12
+		EncodeAddi(2, 0, 999), // SKIPPED
+		EncodeAddi(3, 0, 42),  // executed at PC=12
 		EncodeEcall(),
 	})
 	expectReg(t, sim, 1, 8)
@@ -480,11 +509,11 @@ func TestCallAndReturn(t *testing.T) {
 	//   PC=12: addi x10, 0, 42  (function body: x10 = 42)
 	//   PC=16: jalr x0, x1, 0   (return to x1=4, discard link)
 	sim := runProgram(t, []uint32{
-		EncodeJal(1, 12),             // call function at PC=12
-		EncodeAddi(11, 0, 99),        // x11 = 99 (after return)
+		EncodeJal(1, 12),      // call function at PC=12
+		EncodeAddi(11, 0, 99), // x11 = 99 (after return)
 		EncodeEcall(),
-		EncodeAddi(10, 0, 42),        // function body
-		EncodeJalr(0, 1, 0),          // return (jalr x0, x1, 0)
+		EncodeAddi(10, 0, 42), // function body
+		EncodeJalr(0, 1, 0),   // return (jalr x0, x1, 0)
 	})
 	expectReg(t, sim, 1, 4)   // return address
 	expectReg(t, sim, 10, 42) // function result
@@ -497,7 +526,7 @@ func TestCallAndReturn(t *testing.T) {
 
 func TestLui(t *testing.T) {
 	sim := runProgram(t, []uint32{
-		EncodeLui(1, 0x12345),        // x1 = 0x12345 << 12 = 0x12345000
+		EncodeLui(1, 0x12345), // x1 = 0x12345 << 12 = 0x12345000
 		EncodeEcall(),
 	})
 	expectReg(t, sim, 1, 0x12345000)
@@ -506,8 +535,8 @@ func TestLui(t *testing.T) {
 func TestLuiPlusAddi(t *testing.T) {
 	// Construct a full 32-bit constant: 0x12345678
 	sim := runProgram(t, []uint32{
-		EncodeLui(1, 0x12345),        // x1 = 0x12345000
-		EncodeAddi(1, 1, 0x678),      // x1 = 0x12345000 + 0x678 = 0x12345678
+		EncodeLui(1, 0x12345),   // x1 = 0x12345000
+		EncodeAddi(1, 1, 0x678), // x1 = 0x12345000 + 0x678 = 0x12345678
 		EncodeEcall(),
 	})
 	expectReg(t, sim, 1, 0x12345678)
@@ -516,7 +545,7 @@ func TestLuiPlusAddi(t *testing.T) {
 func TestAuipc(t *testing.T) {
 	// auipc at PC=0: x1 = PC + (imm << 12) = 0 + (1 << 12) = 0x1000
 	sim := runProgram(t, []uint32{
-		EncodeAuipc(1, 1),            // x1 = PC(0) + 1<<12 = 0x1000
+		EncodeAuipc(1, 1), // x1 = PC(0) + 1<<12 = 0x1000
 		EncodeEcall(),
 	})
 	expectReg(t, sim, 1, 0x1000)
@@ -525,8 +554,8 @@ func TestAuipc(t *testing.T) {
 func TestAuipcNonZeroPC(t *testing.T) {
 	// auipc at PC=4: x1 = 4 + (2 << 12) = 4 + 0x2000 = 0x2004
 	sim := runProgram(t, []uint32{
-		EncodeAddi(0, 0, 0),          // nop (PC=0)
-		EncodeAuipc(1, 2),            // x1 = PC(4) + 2<<12 = 0x2004 (PC=4)
+		EncodeAddi(0, 0, 0), // nop (PC=0)
+		EncodeAuipc(1, 2),   // x1 = PC(4) + 2<<12 = 0x2004 (PC=4)
 		EncodeEcall(),
 	})
 	expectReg(t, sim, 1, 0x2004)
@@ -538,7 +567,7 @@ func TestAuipcNonZeroPC(t *testing.T) {
 
 func TestRegisterZeroHardwired(t *testing.T) {
 	sim := runProgram(t, []uint32{
-		EncodeAddi(0, 0, 42),         // try to write 42 to x0
+		EncodeAddi(0, 0, 42), // try to write 42 to x0
 		EncodeEcall(),
 	})
 	expectReg(t, sim, 0, 0) // x0 must remain 0
@@ -548,7 +577,7 @@ func TestRegisterZeroOnRType(t *testing.T) {
 	sim := runProgram(t, []uint32{
 		EncodeAddi(1, 0, 5),
 		EncodeAddi(2, 0, 10),
-		EncodeAdd(0, 1, 2),           // try to write to x0
+		EncodeAdd(0, 1, 2), // try to write to x0
 		EncodeEcall(),
 	})
 	expectReg(t, sim, 0, 0)
@@ -562,9 +591,9 @@ func TestCsrrw(t *testing.T) {
 	sim := NewRiscVSimulator(65536)
 	// Write 0x100 to mscratch, then read it back
 	program := Assemble([]uint32{
-		EncodeAddi(1, 0, 0x100),                // x1 = 0x100
-		EncodeCsrrw(2, CSRMscratch, 1),         // x2 = old mscratch (0), mscratch = 0x100
-		EncodeCsrrw(3, CSRMscratch, 0),         // x3 = mscratch (0x100), mscratch = x0 (0)
+		EncodeAddi(1, 0, 0x100),        // x1 = 0x100
+		EncodeCsrrw(2, CSRMscratch, 1), // x2 = old mscratch (0), mscratch = 0x100
+		EncodeCsrrw(3, CSRMscratch, 0), // x3 = mscratch (0x100), mscratch = x0 (0)
 		EncodeEcall(),
 	})
 	sim.Run(program)
@@ -576,9 +605,9 @@ func TestCsrrs(t *testing.T) {
 	sim := NewRiscVSimulator(65536)
 	// Set bits in mstatus
 	program := Assemble([]uint32{
-		EncodeAddi(1, 0, 8),                    // x1 = 8 (MIE bit)
-		EncodeCsrrs(2, CSRMstatus, 1),          // x2 = old mstatus (0), mstatus |= 8
-		EncodeCsrrs(3, CSRMstatus, 0),          // x3 = mstatus (8), no bits set (x0=0)
+		EncodeAddi(1, 0, 8),           // x1 = 8 (MIE bit)
+		EncodeCsrrs(2, CSRMstatus, 1), // x2 = old mstatus (0), mstatus |= 8
+		EncodeCsrrs(3, CSRMstatus, 0), // x3 = mstatus (8), no bits set (x0=0)
 		EncodeEcall(),
 	})
 	sim.Run(program)
@@ -590,11 +619,11 @@ func TestCsrrc(t *testing.T) {
 	sim := NewRiscVSimulator(65536)
 	// Set bits then clear some
 	program := Assemble([]uint32{
-		EncodeAddi(1, 0, 0xFF),                 // x1 = 0xFF
-		EncodeCsrrw(0, CSRMscratch, 1),         // mscratch = 0xFF
-		EncodeAddi(2, 0, 0x0F),                 // x2 = 0x0F
-		EncodeCsrrc(3, CSRMscratch, 2),         // x3 = mscratch (0xFF), mscratch &^= 0x0F -> 0xF0
-		EncodeCsrrs(4, CSRMscratch, 0),         // x4 = mscratch (0xF0)
+		EncodeAddi(1, 0, 0xFF),         // x1 = 0xFF
+		EncodeCsrrw(0, CSRMscratch, 1), // mscratch = 0xFF
+		EncodeAddi(2, 0, 0x0F),         // x2 = 0x0F
+		EncodeCsrrc(3, CSRMscratch, 2), // x3 = mscratch (0xFF), mscratch &^= 0x0F -> 0xF0
+		EncodeCsrrs(4, CSRMscratch, 0), // x4 = mscratch (0xF0)
 		EncodeEcall(),
 	})
 	sim.Run(program)
@@ -635,13 +664,13 @@ func TestEcallTrapWithHandler(t *testing.T) {
 
 	// Main program at address 0
 	mainCode := []uint32{
-		EncodeAddi(1, 0, 0x100),                // x1 = 0x100 (trap handler addr)  (PC=0)
-		EncodeCsrrw(0, CSRMtvec, 1),            // mtvec = 0x100                   (PC=4)
-		EncodeEcall(),                           // trigger trap -> jump to 0x100   (PC=8)
-		EncodeAddi(11, 0, 77),                   // x11 = 77 (after return)         (PC=12)
+		EncodeAddi(1, 0, 0x100),     // x1 = 0x100 (trap handler addr)  (PC=0)
+		EncodeCsrrw(0, CSRMtvec, 1), // mtvec = 0x100                   (PC=4)
+		EncodeEcall(),               // trigger trap -> jump to 0x100   (PC=8)
+		EncodeAddi(11, 0, 77),       // x11 = 77 (after return)         (PC=12)
 		// Clear mtvec so next ecall halts
-		EncodeCsrrw(0, CSRMtvec, 0),            // mtvec = 0                       (PC=16)
-		EncodeEcall(),                           // halt                            (PC=20)
+		EncodeCsrrw(0, CSRMtvec, 0), // mtvec = 0                       (PC=16)
+		EncodeEcall(),               // halt                            (PC=20)
 	}
 
 	// Trap handler at address 0x100 (= 64 instructions * 4 bytes each)
@@ -656,11 +685,11 @@ func TestEcallTrapWithHandler(t *testing.T) {
 	// Trap handler code at 0x100:
 	//   Read mepc, add 4 (skip past the ecall), write back, then mret
 	trapHandler := []uint32{
-		EncodeAddi(10, 0, 99),                   // x10 = 99                       (PC=0x100)
-		EncodeCsrrs(20, CSRMepc, 0),             // x20 = mepc (read mepc)         (PC=0x104)
-		EncodeAddi(20, 20, 4),                    // x20 = mepc + 4                 (PC=0x108)
-		EncodeCsrrw(0, CSRMepc, 20),             // mepc = mepc + 4                (PC=0x10C)
-		EncodeMret(),                             // return from trap               (PC=0x110)
+		EncodeAddi(10, 0, 99),       // x10 = 99                       (PC=0x100)
+		EncodeCsrrs(20, CSRMepc, 0), // x20 = mepc (read mepc)         (PC=0x104)
+		EncodeAddi(20, 20, 4),       // x20 = mepc + 4                 (PC=0x108)
+		EncodeCsrrw(0, CSRMepc, 20), // mepc = mepc + 4                (PC=0x10C)
+		EncodeMret(),                // return from trap               (PC=0x110)
 	}
 	paddedMain = append(paddedMain, trapHandler...)
 
@@ -681,11 +710,11 @@ func TestEcallSetsCSRs(t *testing.T) {
 	// The trap handler at 0x200 clears mtvec first (so its own ecall halts),
 	// then we can inspect the CSR values that were set by the original ecall.
 	mainCode := []uint32{
-		EncodeAddi(1, 0, 0x200),                 // x1 = trap handler addr     (PC=0)
-		EncodeCsrrw(0, CSRMtvec, 1),             // mtvec = 0x200              (PC=4)
-		EncodeAddi(2, 0, 8),                     // x2 = MIE bit               (PC=8)
-		EncodeCsrrs(0, CSRMstatus, 2),           // mstatus |= MIE             (PC=12)
-		EncodeEcall(),                            // PC=16: triggers trap
+		EncodeAddi(1, 0, 0x200),       // x1 = trap handler addr     (PC=0)
+		EncodeCsrrw(0, CSRMtvec, 1),   // mtvec = 0x200              (PC=4)
+		EncodeAddi(2, 0, 8),           // x2 = MIE bit               (PC=8)
+		EncodeCsrrs(0, CSRMstatus, 2), // mstatus |= MIE             (PC=12)
+		EncodeEcall(),                 // PC=16: triggers trap
 	}
 
 	// Pad to 0x200
@@ -699,11 +728,11 @@ func TestEcallSetsCSRs(t *testing.T) {
 	// Trap handler at 0x200: save mepc and mcause to registers,
 	// then clear mtvec and halt.
 	trapHandler := []uint32{
-		EncodeCsrrs(20, CSRMepc, 0),             // x20 = mepc                 (PC=0x200)
-		EncodeCsrrs(21, CSRMcause, 0),            // x21 = mcause               (PC=0x204)
-		EncodeCsrrs(22, CSRMstatus, 0),           // x22 = mstatus              (PC=0x208)
-		EncodeCsrrw(0, CSRMtvec, 0),              // mtvec = 0 (so next ecall halts) (PC=0x20C)
-		EncodeEcall(),                             // halt                       (PC=0x210)
+		EncodeCsrrs(20, CSRMepc, 0),    // x20 = mepc                 (PC=0x200)
+		EncodeCsrrs(21, CSRMcause, 0),  // x21 = mcause               (PC=0x204)
+		EncodeCsrrs(22, CSRMstatus, 0), // x22 = mstatus              (PC=0x208)
+		EncodeCsrrw(0, CSRMtvec, 0),    // mtvec = 0 (so next ecall halts) (PC=0x20C)
+		EncodeEcall(),                  // halt                       (PC=0x210)
 	}
 	padded = append(padded, trapHandler...)
 
@@ -737,10 +766,10 @@ func TestMret(t *testing.T) {
 	sim.CSR.Write(CSRMepc, 12) // return to PC=12
 
 	program := Assemble([]uint32{
-		EncodeMret(),                 // jump to mepc=12     (PC=0)
-		EncodeAddi(1, 0, 999),        // SKIPPED             (PC=4)
-		EncodeAddi(2, 0, 999),        // SKIPPED             (PC=8)
-		EncodeAddi(3, 0, 42),         // should execute      (PC=12)
+		EncodeMret(),          // jump to mepc=12     (PC=0)
+		EncodeAddi(1, 0, 999), // SKIPPED             (PC=4)
+		EncodeAddi(2, 0, 999), // SKIPPED             (PC=8)
+		EncodeAddi(3, 0, 42),  // should execute      (PC=12)
 		EncodeEcall(),
 	})
 	sim.Run(program)
@@ -757,8 +786,8 @@ func TestMretReenablesInterrupts(t *testing.T) {
 	sim.CSR.Write(CSRMepc, 4) // return to PC=4
 
 	program := Assemble([]uint32{
-		EncodeMret(),                 // should re-enable MIE
-		EncodeEcall(),                // halt
+		EncodeMret(),  // should re-enable MIE
+		EncodeEcall(), // halt
 	})
 	sim.Run(program)
 
@@ -806,17 +835,17 @@ func TestFibonacci(t *testing.T) {
 	// x5 = limit (11, because we want counter to reach 10 inclusive,
 	//       and the loop exits when counter == limit, so limit = 10+1)
 	sim := runProgram(t, []uint32{
-		EncodeAddi(1, 0, 0),          // x1 = 0 (fib[0])       (PC=0)
-		EncodeAddi(2, 0, 1),          // x2 = 1 (fib[1])       (PC=4)
-		EncodeAddi(4, 0, 2),          // x4 = 2 (counter)      (PC=8)
-		EncodeAddi(5, 0, 11),         // x5 = 11 (limit)       (PC=12)
+		EncodeAddi(1, 0, 0),  // x1 = 0 (fib[0])       (PC=0)
+		EncodeAddi(2, 0, 1),  // x2 = 1 (fib[1])       (PC=4)
+		EncodeAddi(4, 0, 2),  // x4 = 2 (counter)      (PC=8)
+		EncodeAddi(5, 0, 11), // x5 = 11 (limit)       (PC=12)
 		// Loop body:                                            (PC=16)
-		EncodeAdd(3, 1, 2),           // x3 = x1 + x2          (PC=16)
-		EncodeAddi(1, 2, 0),          // x1 = x2               (PC=20)  (mv x1, x2)
-		EncodeAddi(2, 3, 0),          // x2 = x3               (PC=24)  (mv x2, x3)
-		EncodeAddi(4, 4, 1),          // x4++                   (PC=28)
-		EncodeBne(4, 5, -16),         // if x4 != 11, loop (PC=32, offset=-16 -> PC=16)
-		EncodeEcall(),                //                        (PC=36)
+		EncodeAdd(3, 1, 2),   // x3 = x1 + x2          (PC=16)
+		EncodeAddi(1, 2, 0),  // x1 = x2               (PC=20)  (mv x1, x2)
+		EncodeAddi(2, 3, 0),  // x2 = x3               (PC=24)  (mv x2, x3)
+		EncodeAddi(4, 4, 1),  // x4++                   (PC=28)
+		EncodeBne(4, 5, -16), // if x4 != 11, loop (PC=32, offset=-16 -> PC=16)
+		EncodeEcall(),        //                        (PC=36)
 	})
 	// After 9 iterations (counter 2..10): x2 holds fib(10) = 55
 	expectReg(t, sim, 2, 55)
@@ -833,10 +862,10 @@ func TestMemcpy(t *testing.T) {
 	sim.CPU.Memory.WriteByte(0x203, 0xEF)
 
 	program := Assemble([]uint32{
-		EncodeAddi(1, 0, 0x200),      // x1 = src
-		EncodeAddi(2, 0, 0x300),      // x2 = dst
-		EncodeLw(3, 1, 0),            // x3 = mem[src] (load word)
-		EncodeSw(3, 2, 0),            // mem[dst] = x3 (store word)
+		EncodeAddi(1, 0, 0x200), // x1 = src
+		EncodeAddi(2, 0, 0x300), // x2 = dst
+		EncodeLw(3, 1, 0),       // x3 = mem[src] (load word)
+		EncodeSw(3, 2, 0),       // mem[dst] = x3 (store word)
 		EncodeEcall(),
 	})
 	sim.Run(program)
@@ -855,25 +884,25 @@ func TestStackOperations(t *testing.T) {
 	// Simulate push/pop using a stack pointer (x2 = sp)
 	// Stack grows downward (conventional RISC-V behavior)
 	sim := runProgram(t, []uint32{
-		EncodeAddi(2, 0, 0x400),      // sp = 0x400 (top of stack)    (PC=0)
-		EncodeAddi(10, 0, 42),        // x10 = 42                     (PC=4)
-		EncodeAddi(11, 0, 99),        // x11 = 99                     (PC=8)
+		EncodeAddi(2, 0, 0x400), // sp = 0x400 (top of stack)    (PC=0)
+		EncodeAddi(10, 0, 42),   // x10 = 42                     (PC=4)
+		EncodeAddi(11, 0, 99),   // x11 = 99                     (PC=8)
 		// Push x10
-		EncodeAddi(2, 2, -4),         // sp -= 4                      (PC=12)
-		EncodeSw(10, 2, 0),           // mem[sp] = x10                (PC=16)
+		EncodeAddi(2, 2, -4), // sp -= 4                      (PC=12)
+		EncodeSw(10, 2, 0),   // mem[sp] = x10                (PC=16)
 		// Push x11
-		EncodeAddi(2, 2, -4),         // sp -= 4                      (PC=20)
-		EncodeSw(11, 2, 0),           // mem[sp] = x11                (PC=24)
+		EncodeAddi(2, 2, -4), // sp -= 4                      (PC=20)
+		EncodeSw(11, 2, 0),   // mem[sp] = x11                (PC=24)
 		// Pop into x12 (should get x11's value = 99)
-		EncodeLw(12, 2, 0),           // x12 = mem[sp]                (PC=28)
-		EncodeAddi(2, 2, 4),          // sp += 4                      (PC=32)
+		EncodeLw(12, 2, 0),  // x12 = mem[sp]                (PC=28)
+		EncodeAddi(2, 2, 4), // sp += 4                      (PC=32)
 		// Pop into x13 (should get x10's value = 42)
-		EncodeLw(13, 2, 0),           // x13 = mem[sp]                (PC=36)
-		EncodeAddi(2, 2, 4),          // sp += 4                      (PC=40)
+		EncodeLw(13, 2, 0),  // x13 = mem[sp]                (PC=36)
+		EncodeAddi(2, 2, 4), // sp += 4                      (PC=40)
 		EncodeEcall(),
 	})
-	expectReg(t, sim, 12, 99) // last pushed, first popped
-	expectReg(t, sim, 13, 42) // first pushed, last popped
+	expectReg(t, sim, 12, 99)   // last pushed, first popped
+	expectReg(t, sim, 13, 42)   // first pushed, last popped
 	expectReg(t, sim, 2, 0x400) // sp restored
 }
 
@@ -1032,9 +1061,9 @@ func TestCSRFileReadClear(t *testing.T) {
 
 func TestShiftAmountMasking(t *testing.T) {
 	sim := runProgram(t, []uint32{
-		EncodeAddi(1, 0, 1),          // x1 = 1
-		EncodeAddi(2, 0, 33),         // x2 = 33 (but shift uses only 33 & 0x1F = 1)
-		EncodeSll(3, 1, 2),           // x3 = 1 << 1 = 2
+		EncodeAddi(1, 0, 1),  // x1 = 1
+		EncodeAddi(2, 0, 33), // x2 = 33 (but shift uses only 33 & 0x1F = 1)
+		EncodeSll(3, 1, 2),   // x3 = 1 << 1 = 2
 		EncodeEcall(),
 	})
 	expectReg(t, sim, 3, 2)

--- a/code/specs/RV01-riscv-compiler-roadmap.md
+++ b/code/specs/RV01-riscv-compiler-roadmap.md
@@ -21,8 +21,8 @@ bytes. `riscv-assembler` assembles the text form into the byte image loaded by
 
 | Language | Current status | To run directly on RISC-V |
 |----------|----------------|---------------------------|
-| Nib | Go parser, type checker, IR compiler, and `nib-riscv-compiler` package exist. Simple `main` programs can lower to assembly and VM bytes. | Add stack-frame support so nested calls/recursion preserve `ra`; extend static variable reads if needed; add ABI tests for arguments/returns. |
-| Brainfuck | Go parser and `brainfuck-ir-compiler` already emit `compiler-ir` compatible with the RISC-V backend. | Add `brainfuck-riscv-compiler` orchestration; implement VM syscall/host handling for `.` and `,`, or limit first tests to non-I/O memory programs. |
+| Nib | Go parser, type checker, IR compiler, and `nib-riscv-compiler` package exist. Simple `main` programs lower to RISC-V assembly, assemble to bytes, and execute on `riscv-simulator`. | Add stack-frame support so nested calls/recursion preserve `ra`; extend static variable reads if needed; add ABI tests for arguments/returns. |
+| Brainfuck | Go parser, `brainfuck-ir-compiler`, and `brainfuck-riscv-compiler` package exist. Programs lower to RISC-V assembly, assemble to bytes, and execute on `riscv-simulator` with host byte I/O syscalls for `.` and `,`. | Add broader corpus tests, debug-mode bounds-check E2E tests, and richer host I/O controls if interactive execution is needed. |
 | Dartmouth BASIC | Go lexer/parser exist. Python has `dartmouth-basic-ir-compiler`, GE-225, WASM, and JVM-oriented pipelines. | Port or bridge the Python IR compiler to Go `compiler-ir`; add `MUL`/`DIV` to Go `compiler-ir` and the RISC-V backend or lower them to helper loops; implement PRINT syscalls/trap host output in the RISC-V VM. |
 | Oct | Python has lexer/parser/type-checker/IR compiler for the Intel 8008 pipeline. | Port or bridge Oct typed AST/IR into Go; add Go `compiler-ir` opcodes used by Oct but not yet present here (`OR`, `XOR`, `NOT`, and any target-specific syscall shapes); add RISC-V syscall host behavior for `in`, `out`, carry/parity/rotate intrinsics; add stack-frame support for nested calls. |
 | Starlark | Go compiler targets the Starlark VM bytecode, not `compiler-ir`. | Add a Starlark-to-`compiler-ir` lowerer or a direct RISC-V backend for its bytecode. |
@@ -36,9 +36,9 @@ bytes. `riscv-assembler` assembles the text form into the byte image loaded by
   functions that call other functions.
 - Stack and frames: needed for nested calls, recursion, spilled virtual
   registers, and local storage beyond the fixed physical-register map.
-- Syscalls: `riscv-simulator` treats `ecall` as halt when no trap handler is
-  installed. Language I/O needs a small host syscall layer or a standard trap
-  handler convention.
+- Syscalls: `riscv-simulator` now has an opt-in host syscall layer for simple
+  byte I/O and exit when no trap handler is installed. Richer language runtimes
+  still need a standard ABI for strings, numbers, files, and interactive input.
 - IR parity: Python-side languages already use extended IR ideas such as
   multiplication, division, OR, XOR, and NOT. The Go `compiler-ir` and RISC-V
   backend need those opcodes or canonical lowering passes.
@@ -47,9 +47,8 @@ bytes. `riscv-assembler` assembles the text form into the byte image loaded by
 
 ## Suggested sequence
 
-1. Stabilize Nib simple-program E2E tests.
-2. Add RISC-V stack-frame support for `CALL`/`RET`.
-3. Add a Brainfuck RISC-V orchestration package for a second Go frontend.
-4. Add a host syscall layer to `riscv-simulator`.
-5. Port/bridge Dartmouth BASIC IR to Go and add `MUL`/`DIV`.
-6. Port/bridge Oct IR to Go and add the remaining bitwise/syscall ABI support.
+1. Add RISC-V stack-frame support for `CALL`/`RET`.
+2. Add broader Nib and Brainfuck E2E corpus tests.
+3. Port/bridge Dartmouth BASIC IR to Go and add `MUL`/`DIV`.
+4. Port/bridge Oct IR to Go and add the remaining bitwise/syscall ABI support.
+5. Standardize a richer RISC-V language runtime ABI for text and numeric I/O.


### PR DESCRIPTION
## Summary
- add opt-in RISC-V host byte I/O syscalls for write/read/exit when no trap handler is installed
- add `brainfuck-riscv-compiler` to run Brainfuck through IR, RISC-V assembly, assembler bytes, and the simulator
- update the RISC-V roadmap to mark Brainfuck as directly executable and clarify remaining Dartmouth BASIC/Oct gaps

## Tests
- `go test -c -o /tmp/riscv-simulator.test` in `code/packages/go/riscv-simulator`
- `go test -c -o /tmp/brainfuck-riscv-compiler.test` in `code/packages/go/brainfuck-riscv-compiler`
- `go test -c -o /tmp/nib-riscv-compiler.test` in `code/packages/go/nib-riscv-compiler`
- `go test -c -o /tmp/ir-to-riscv-compiler.test` in `code/packages/go/ir-to-riscv-compiler`

Note: local `go test` execution still hangs in this macOS session before producing test output, so I used compile checks locally and left the runtime tests for CI.