### PR TITLE
Add Rust effectful state machine transducers

### DIFF
--- a/code/packages/rust/state-machine-markup-deserializer/CHANGELOG.md
+++ b/code/packages/rust/state-machine-markup-deserializer/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this package will be documented in this file.
 
 - Extended serializer/deserializer round-trip tests to reconstruct executable
   DFA, NFA, and PDA machines from parsed `StateMachineDefinition` values.
+- Added phase 1 transducer validation for `$any`, `$end`, transition actions,
+  and `consume = false` EOF transitions.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/rust/state-machine-markup-deserializer/README.md
+++ b/code/packages/rust/state-machine-markup-deserializer/README.md
@@ -58,6 +58,8 @@ The first reader intentionally accepts a strict subset:
 - repeated `[[states]]` tables with boolean marker fields
 - repeated `[[transitions]]` tables with `from`, `on`, `to`, `stack_pop`, and
   `stack_push`
+- transducer transition fields `actions` and `consume`, with `$any` and `$end`
+  reserved for any-input and EOF matchers
 
 Unsupported tables, duplicate keys, dotted keys, numbers, inline tables,
 includes, and malformed strings are rejected. That keeps the first

--- a/code/packages/rust/state-machine-markup-deserializer/src/lib.rs
+++ b/code/packages/rust/state-machine-markup-deserializer/src/lib.rs
@@ -13,7 +13,10 @@ use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::fmt;
 
-use state_machine::{MachineKind, StateDefinition, StateMachineDefinition, TransitionDefinition};
+use state_machine::{
+    MachineKind, StateDefinition, StateMachineDefinition, TransitionDefinition, ANY_INPUT,
+    END_INPUT,
+};
 
 /// The current State Machine Markup document version.
 pub const STATE_MACHINE_MARKUP_FORMAT: &str = "state-machine/v1";
@@ -111,6 +114,12 @@ pub enum StateMachineMarkupError {
     MissingInitialStack,
     /// PDA transitions must say which stack symbol they pop/read.
     MissingStackPop { from: String, on: String },
+    /// Transducer transitions must use an explicit matcher event.
+    MissingTransducerMatcher { from: String },
+    /// Transducer transitions must have exactly one target.
+    InvalidTransducerTargetCount { from: String },
+    /// EOF transitions cannot consume input.
+    ConsumingEndTransition { from: String },
 }
 
 impl fmt::Display for StateMachineMarkupError {
@@ -226,6 +235,17 @@ impl fmt::Display for StateMachineMarkupError {
                 f,
                 "PDA transition from `{from}` on `{on}` is missing `stack_pop`"
             ),
+            Self::MissingTransducerMatcher { from } => write!(
+                f,
+                "transducer transition from `{from}` must use `{END_INPUT}` for EOF, not null"
+            ),
+            Self::InvalidTransducerTargetCount { from } => write!(
+                f,
+                "transducer transition from `{from}` must have exactly one target"
+            ),
+            Self::ConsumingEndTransition { from } => {
+                write!(f, "EOF transition from `{from}` must not consume input")
+            }
         }
     }
 }
@@ -242,10 +262,10 @@ pub fn from_states_toml(source: &str) -> Result<StateMachineDefinition> {
     Ok(definition)
 }
 
-/// Validate a typed definition using the phase 1 DFA, NFA, and PDA rules.
+/// Validate a typed definition using the phase 1 DFA, NFA, PDA, and transducer rules.
 pub fn validate_definition(definition: &StateMachineDefinition) -> Result<()> {
     match definition.kind {
-        MachineKind::Dfa | MachineKind::Nfa | MachineKind::Pda => {}
+        MachineKind::Dfa | MachineKind::Nfa | MachineKind::Pda | MachineKind::Transducer => {}
         _ => {
             return Err(StateMachineMarkupError::UnsupportedKind {
                 kind: definition.kind.as_str().to_string(),
@@ -309,6 +329,13 @@ pub fn validate_definition(definition: &StateMachineDefinition) -> Result<()> {
     let stack_alphabet: HashSet<String> = definition.stack_alphabet.iter().cloned().collect();
     let mut dfa_keys = HashSet::new();
 
+    if !matches!(definition.kind, MachineKind::Pda)
+        && (!definition.stack_alphabet.is_empty() || definition.initial_stack.is_some())
+    {
+        return Err(StateMachineMarkupError::UnsupportedKind {
+            kind: format!("{} stack fields", definition.kind.as_str()),
+        });
+    }
     if matches!(definition.kind, MachineKind::Pda) {
         let initial_stack = definition
             .initial_stack
@@ -353,18 +380,28 @@ pub fn validate_definition(definition: &StateMachineDefinition) -> Result<()> {
             }
         }
         if let Some(event) = &transition.on {
-            if !alphabet.contains(event) {
+            let transducer_builtin = matches!(definition.kind, MachineKind::Transducer)
+                && (event == ANY_INPUT || event == END_INPUT);
+            if !transducer_builtin && !alphabet.contains(event) {
                 return Err(StateMachineMarkupError::UnknownAlphabetSymbol {
                     symbol: event.clone(),
                 });
             }
+        }
+        if !matches!(definition.kind, MachineKind::Transducer)
+            && (!transition.actions.is_empty() || !transition.consume)
+        {
+            return Err(StateMachineMarkupError::UnsupportedKind {
+                kind: format!("{} transition effects", definition.kind.as_str()),
+            });
         }
 
         match definition.kind {
             MachineKind::Dfa => validate_dfa_transition(transition, &mut dfa_keys)?,
             MachineKind::Nfa => validate_nfa_transition(transition)?,
             MachineKind::Pda => validate_pda_transition(transition, &stack_alphabet)?,
-            _ => unreachable!("phase 1 kinds are checked before transition validation"),
+            MachineKind::Transducer => validate_transducer_transition(transition)?,
+            _ => unreachable!("supported kinds are checked before transition validation"),
         }
     }
 
@@ -455,6 +492,30 @@ fn validate_pda_transition(
     Ok(())
 }
 
+fn validate_transducer_transition(transition: &TransitionDefinition) -> Result<()> {
+    let event = transition.on.as_ref().ok_or_else(|| {
+        StateMachineMarkupError::MissingTransducerMatcher {
+            from: transition.from.clone(),
+        }
+    })?;
+    if transition.to.len() != 1 {
+        return Err(StateMachineMarkupError::InvalidTransducerTargetCount {
+            from: transition.from.clone(),
+        });
+    }
+    if transition.stack_pop.is_some() || !transition.stack_push.is_empty() {
+        return Err(StateMachineMarkupError::StackEffectOnNonPda {
+            from: transition.from.clone(),
+        });
+    }
+    if event == END_INPUT && transition.consume {
+        return Err(StateMachineMarkupError::ConsumingEndTransition {
+            from: transition.from.clone(),
+        });
+    }
+    Ok(())
+}
+
 fn ensure_unique_values(field: &str, values: &[String]) -> Result<()> {
     let mut seen = HashSet::new();
     for value in values {
@@ -534,6 +595,8 @@ impl RawDocument {
                 to,
                 stack_pop: optional_string(transition, "stack_pop", &table)?,
                 stack_push: optional_array(transition, "stack_push", &table)?.unwrap_or_default(),
+                actions: optional_array(transition, "actions", &table)?.unwrap_or_default(),
+                consume: optional_bool(transition, "consume", &table)?.unwrap_or(true),
             });
         }
 
@@ -710,7 +773,10 @@ fn field_allowed(section: Section, field: &str) -> bool {
             "id" | "initial" | "accepting" | "final" | "external_entry"
         ),
         Section::Transition(_) => {
-            matches!(field, "from" | "on" | "to" | "stack_pop" | "stack_push")
+            matches!(
+                field,
+                "from" | "on" | "to" | "stack_pop" | "stack_push" | "actions" | "consume"
+            )
         }
     }
 }

--- a/code/packages/rust/state-machine-markup-json-deserializer/CHANGELOG.md
+++ b/code/packages/rust/state-machine-markup-json-deserializer/CHANGELOG.md
@@ -10,3 +10,5 @@ All notable changes to this package will be documented in this file.
 - Added bounded JSON profile parsing for typed state-machine definitions.
 - Added round-trip and validation coverage for DFA, NFA, PDA, epsilon,
   literal event, stack-effect, malformed JSON, and limit-enforcement behavior.
+- Added transition `actions` and `consume` field parsing for transducer
+  definitions.

--- a/code/packages/rust/state-machine-markup-json-deserializer/README.md
+++ b/code/packages/rust/state-machine-markup-json-deserializer/README.md
@@ -16,6 +16,9 @@ JSON files in production. This reader exists for build tools, tests, and source
 compiler pipelines that need to validate canonical snapshots before generating
 static code.
 
+The reader also accepts transducer transition `actions` and `consume` flags,
+then delegates semantic checks to the shared markup validator.
+
 ## Usage
 
 ```rust
@@ -48,7 +51,8 @@ assert!(machine.accepts(&["coin"]));
 The parser accepts only the phase 1 State Machine Markup JSON profile: objects,
 arrays, strings, booleans, and `null` for transition epsilon. It rejects numbers,
 unknown fields, duplicate object keys, excessive nesting, oversized sources, and
-oversized arrays before returning a typed definition.
+oversized arrays before returning a typed definition. For transducers, EOF is
+represented by the explicit `$end` matcher rather than JSON `null`.
 
 ## Dependencies
 

--- a/code/packages/rust/state-machine-markup-json-deserializer/src/lib.rs
+++ b/code/packages/rust/state-machine-markup-json-deserializer/src/lib.rs
@@ -205,7 +205,15 @@ fn json_value_to_definition(value: JsonValue) -> Result<StateMachineDefinition> 
         ensure_allowed_fields(
             &transition,
             &object,
-            &["from", "on", "to", "stack_pop", "stack_push"],
+            &[
+                "from",
+                "on",
+                "to",
+                "stack_pop",
+                "stack_push",
+                "actions",
+                "consume",
+            ],
         )?;
         definition.transitions.push(TransitionDefinition {
             from: required_string(&transition, "from", &object)?,
@@ -214,6 +222,8 @@ fn json_value_to_definition(value: JsonValue) -> Result<StateMachineDefinition> 
             stack_pop: optional_string(&transition, "stack_pop", &object)?,
             stack_push: optional_string_array(&transition, "stack_push", &object)?
                 .unwrap_or_default(),
+            actions: optional_string_array(&transition, "actions", &object)?.unwrap_or_default(),
+            consume: optional_bool(&transition, "consume", &object)?.unwrap_or(true),
         });
     }
 

--- a/code/packages/rust/state-machine-markup-json-deserializer/tests/json_test.rs
+++ b/code/packages/rust/state-machine-markup-json-deserializer/tests/json_test.rs
@@ -588,6 +588,8 @@ fn manual_definition_serializes_then_deserializes_flags() {
         to: vec!["q0".to_string()],
         stack_pop: Some("$".to_string()),
         stack_push: vec!["$".to_string()],
+        actions: Vec::new(),
+        consume: true,
     }];
 
     let parsed = from_states_json(&definition.to_states_json()).unwrap();

--- a/code/packages/rust/state-machine-markup-json-serializer/CHANGELOG.md
+++ b/code/packages/rust/state-machine-markup-json-serializer/CHANGELOG.md
@@ -10,3 +10,5 @@ All notable changes to this package will be documented in this file.
 - Added deterministic JSON output for typed `StateMachineDefinition` values.
 - Added golden coverage for DFA, NFA, PDA, epsilon, multi-target,
   stack-effect, and JSON string escaping behavior.
+- Added canonical JSON output for transition `actions` and non-default
+  `consume` flags used by transducer definitions.

--- a/code/packages/rust/state-machine-markup-json-serializer/README.md
+++ b/code/packages/rust/state-machine-markup-json-serializer/README.md
@@ -9,6 +9,10 @@ The core `state-machine` crate exposes executable automata and
 definitions into deterministic `.states.json` text for build tooling, source
 compiler snapshots, and cross-language package tests.
 
+Transducer transition `actions` and non-default `consume` flags are preserved in
+the canonical JSON output so tokenizer definitions can round-trip through the
+same typed model as DFA/NFA/PDA machines.
+
 This package intentionally only writes JSON. Reading JSON is a separate
 deserializer concern because parsed files are an untrusted boundary and need
 their own size limits, validation, and diagnostics.

--- a/code/packages/rust/state-machine-markup-json-serializer/src/lib.rs
+++ b/code/packages/rust/state-machine-markup-json-serializer/src/lib.rs
@@ -118,6 +118,8 @@ fn json_transition_array(definition: &StateMachineDefinition) -> String {
             &left.to,
             &left.stack_pop,
             &left.stack_push,
+            &left.actions,
+            left.consume,
         )
             .cmp(&(
                 &right.from,
@@ -125,6 +127,8 @@ fn json_transition_array(definition: &StateMachineDefinition) -> String {
                 &right.to,
                 &right.stack_pop,
                 &right.stack_push,
+                &right.actions,
+                right.consume,
             ))
     });
 
@@ -152,6 +156,12 @@ fn json_transition_array(definition: &StateMachineDefinition) -> String {
                 json_array(&transition.stack_push),
             ));
         }
+        if !transition.actions.is_empty() {
+            fields.push(json_property("actions", json_array(&transition.actions)));
+        }
+        if !transition.consume {
+            fields.push(json_property("consume", "false".to_string()));
+        }
         let comma = if index + 1 == transitions.len() {
             ""
         } else {
@@ -170,6 +180,8 @@ struct JsonTransition {
     to: Vec<String>,
     stack_pop: Option<String>,
     stack_push: Vec<String>,
+    actions: Vec<String>,
+    consume: bool,
 }
 
 impl JsonTransition {
@@ -186,6 +198,8 @@ impl JsonTransition {
             to,
             stack_pop: transition.stack_pop.clone(),
             stack_push: transition.stack_push.clone(),
+            actions: transition.actions.clone(),
+            consume: transition.consume,
         }
     }
 }

--- a/code/packages/rust/state-machine-markup-json-serializer/tests/json_test.rs
+++ b/code/packages/rust/state-machine-markup-json-serializer/tests/json_test.rs
@@ -207,6 +207,8 @@ fn json_serializer_canonicalizes_set_like_arrays() {
         to: vec!["q2".to_string(), "q1".to_string()],
         stack_pop: Some("base".to_string()),
         stack_push: vec!["top".to_string(), "base".to_string()],
+        actions: Vec::new(),
+        consume: true,
     }];
 
     let json = definition.to_states_json();

--- a/code/packages/rust/state-machine-markup-serializer/CHANGELOG.md
+++ b/code/packages/rust/state-machine-markup-serializer/CHANGELOG.md
@@ -11,3 +11,5 @@ All notable changes to this package will be documented in this file.
   `StateMachineDefinition` values.
 - Added snapshot coverage for DFA, NFA, PDA, epsilon, multi-target, stack-effect,
   and TOML string escaping behavior.
+- Added TOML output for transition `actions` and non-default `consume` flags
+  used by transducer definitions.

--- a/code/packages/rust/state-machine-markup-serializer/README.md
+++ b/code/packages/rust/state-machine-markup-serializer/README.md
@@ -9,6 +9,10 @@ The core `state-machine` crate exposes executable automata and
 definitions into deterministic `.states.toml` text. Runtime automata never need
 to know about TOML, JSON, SCXML, or files.
 
+The serializer preserves transducer transition effects as portable `actions`
+arrays and emits `consume = false` only when a transition does not advance the
+input cursor.
+
 Deserialization intentionally belongs in a separate sibling package so the read
 path can have its own validation, trust-boundary checks, and tests.
 

--- a/code/packages/rust/state-machine-markup-serializer/src/lib.rs
+++ b/code/packages/rust/state-machine-markup-serializer/src/lib.rs
@@ -79,6 +79,8 @@ pub fn to_states_toml(definition: &StateMachineDefinition) -> String {
             &a.to,
             &a.stack_pop,
             &a.stack_push,
+            &a.actions,
+            a.consume,
         )
             .cmp(&(
                 &b.from,
@@ -86,6 +88,8 @@ pub fn to_states_toml(definition: &StateMachineDefinition) -> String {
                 &b.to,
                 &b.stack_pop,
                 &b.stack_push,
+                &b.actions,
+                b.consume,
             ))
     });
     for transition in transitions {
@@ -109,6 +113,12 @@ pub fn to_states_toml(definition: &StateMachineDefinition) -> String {
                 "stack_push = {}",
                 toml_array(&transition.stack_push)
             ));
+        }
+        if !transition.actions.is_empty() {
+            lines.push(format!("actions = {}", toml_array(&transition.actions)));
+        }
+        if !transition.consume {
+            lines.push("consume = false".to_string());
         }
     }
 

--- a/code/packages/rust/state-machine-source-compiler/CHANGELOG.md
+++ b/code/packages/rust/state-machine-source-compiler/CHANGELOG.md
@@ -11,3 +11,5 @@
 - Added end-to-end generated-code tests that compile temporary Rust wrapper
   crates and exercise generated DFA, NFA, and PDA constructors when the local
   Rust toolchain can execute freshly built binaries.
+- Added Rust source generation for effectful transducer definitions, including
+  transition actions, consume flags, and an `EffectfulStateMachine` constructor.

--- a/code/packages/rust/state-machine-source-compiler/README.md
+++ b/code/packages/rust/state-machine-source-compiler/README.md
@@ -14,8 +14,8 @@ at runtime.
 The first backend emits Rust modules with two pieces:
 
 - a `<machine>_definition()` function that reconstructs the typed definition
-- a kind-specific convenience function such as `<machine>_dfa()` that calls the
-  corresponding executable automaton importer
+- a kind-specific convenience function such as `<machine>_dfa()` or
+  `<machine>_transducer()` that calls the corresponding executable importer
 
 Example:
 
@@ -38,7 +38,7 @@ StateMachineDefinition
         -> generated Rust module
         -> temporary wrapper crate
         -> cargo test
-        -> executable DFA/NFA/PDA behavior
+        -> executable DFA/NFA/PDA behavior and transducer effects
 ```
 
 Those temporary crates live only in tests. The public compiler API still returns
@@ -54,5 +54,7 @@ source text and does not read or write files.
         -> wrapper package links generated module
 ```
 
-Future slices can add Go, TypeScript, Python, Ruby, and tokenizer-specific
-backends while preserving the same typed definition input boundary.
+The Rust backend currently supports DFA, NFA, PDA, and effectful transducer
+definitions. Future slices can add Go, TypeScript, Python, Ruby, and
+tokenizer-specific wrapper generators while preserving the same typed
+definition input boundary.

--- a/code/packages/rust/state-machine-source-compiler/src/lib.rs
+++ b/code/packages/rust/state-machine-source-compiler/src/lib.rs
@@ -110,6 +110,9 @@ pub fn to_rust_source(definition: &StateMachineDefinition) -> Result<String> {
         MachineKind::Pda => {
             "MachineKind, PushdownAutomaton, StateDefinition, StateMachineDefinition, TransitionDefinition"
         }
+        MachineKind::Transducer => {
+            "EffectfulStateMachine, MachineKind, StateDefinition, StateMachineDefinition, TransitionDefinition"
+        }
         _ => unreachable!("unsupported kinds are rejected before source emission"),
     });
     source.push_str("};\n\n");
@@ -121,7 +124,7 @@ pub fn to_rust_source(definition: &StateMachineDefinition) -> Result<String> {
 
 fn ensure_supported_kind(definition: &StateMachineDefinition) -> Result<()> {
     match definition.kind {
-        MachineKind::Dfa | MachineKind::Nfa | MachineKind::Pda => Ok(()),
+        MachineKind::Dfa | MachineKind::Nfa | MachineKind::Pda | MachineKind::Transducer => Ok(()),
         _ => Err(StateMachineSourceError::UnsupportedKind {
             kind: definition.kind.as_str().to_string(),
         }),
@@ -209,6 +212,14 @@ fn emit_machine_constructor(
             source.push_str("_pda() -> std::result::Result<PushdownAutomaton, String> {\n");
             source.push_str("    PushdownAutomaton::from_definition(&");
         }
+        MachineKind::Transducer => {
+            source.push_str("pub fn ");
+            source.push_str(function_stem);
+            source.push_str(
+                "_transducer() -> std::result::Result<EffectfulStateMachine, String> {\n",
+            );
+            source.push_str("    EffectfulStateMachine::from_definition(&");
+        }
         _ => unreachable!("unsupported kinds are rejected before source emission"),
     }
     source.push_str(function_stem);
@@ -274,6 +285,12 @@ fn emit_transitions(source: &mut String, definition: &StateMachineDefinition) {
         source.push_str("            stack_push: ");
         source.push_str(&rust_string_vec(&transition.stack_push, 12));
         source.push_str(",\n");
+        source.push_str("            actions: ");
+        source.push_str(&rust_string_vec(&transition.actions, 12));
+        source.push_str(",\n");
+        source.push_str("            consume: ");
+        source.push_str(bool_literal(transition.consume));
+        source.push_str(",\n");
         source.push_str("        },\n");
     }
     source.push_str("    ];\n");
@@ -288,6 +305,8 @@ fn sorted_transitions(definition: &StateMachineDefinition) -> Vec<TransitionDefi
             &left.to,
             &left.stack_pop,
             &left.stack_push,
+            &left.actions,
+            left.consume,
         )
             .cmp(&(
                 &right.from,
@@ -295,6 +314,8 @@ fn sorted_transitions(definition: &StateMachineDefinition) -> Vec<TransitionDefi
                 &right.to,
                 &right.stack_pop,
                 &right.stack_push,
+                &right.actions,
+                right.consume,
             ))
     });
     transitions
@@ -305,6 +326,7 @@ fn machine_kind_variant(definition: &StateMachineDefinition) -> &'static str {
         MachineKind::Dfa => "Dfa",
         MachineKind::Nfa => "Nfa",
         MachineKind::Pda => "Pda",
+        MachineKind::Transducer => "Transducer",
         _ => unreachable!("unsupported kinds are rejected before source emission"),
     }
 }
@@ -314,6 +336,7 @@ fn machine_suffix(definition: &StateMachineDefinition) -> &'static str {
         MachineKind::Dfa => "dfa",
         MachineKind::Nfa => "nfa",
         MachineKind::Pda => "pda",
+        MachineKind::Transducer => "transducer",
         _ => unreachable!("unsupported kinds are rejected before source emission"),
     }
 }

--- a/code/packages/rust/state-machine-source-compiler/tests/rust_end_to_end_test.rs
+++ b/code/packages/rust/state-machine-source-compiler/tests/rust_end_to_end_test.rs
@@ -6,7 +6,10 @@ use std::process::{Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use state_machine::{PDATransition, PushdownAutomaton, DFA, EPSILON, NFA};
+use state_machine::{
+    MachineKind, PDATransition, PushdownAutomaton, StateDefinition, StateMachineDefinition,
+    TransitionDefinition, ANY_INPUT, DFA, END_INPUT, EPSILON, NFA,
+};
 use state_machine_source_compiler::to_rust_source;
 
 fn set(values: &[&str]) -> HashSet<String> {
@@ -74,12 +77,14 @@ fn generated_library_source(root: &Path) -> io::Result<String> {
     source.push_str("pub mod turnstile;\n");
     source.push_str("pub mod contains_ab;\n");
     source.push_str("pub mod balanced_parens;\n");
+    source.push_str("pub mod html_skeleton;\n");
     let src_dir = root.join("src");
 
     let modules = [
         ("turnstile", turnstile_source()?),
         ("contains_ab", contains_ab_source()?),
         ("balanced_parens", balanced_parens_source()?),
+        ("html_skeleton", html_skeleton_source()?),
     ];
     for (module, module_source) in modules {
         source.push_str("pub use ");
@@ -179,9 +184,42 @@ fn balanced_parens_source() -> io::Result<String> {
     to_rust_source(&pda.to_definition("balanced-parens")).map_err(io::Error::other)
 }
 
+fn html_skeleton_source() -> io::Result<String> {
+    let mut definition = StateMachineDefinition::new("html-skeleton", MachineKind::Transducer);
+    definition.initial = Some("data".to_string());
+    definition.alphabet = vec!["<".to_string(), "x".to_string()];
+    definition.states = vec![
+        StateDefinition {
+            initial: true,
+            ..StateDefinition::new("data")
+        },
+        StateDefinition {
+            final_state: true,
+            ..StateDefinition::new("done")
+        },
+    ];
+    let mut text = TransitionDefinition::new(
+        "data",
+        Some(ANY_INPUT.to_string()),
+        vec!["data".to_string()],
+    );
+    text.actions = vec!["append_text(current)".to_string()];
+    let mut eof = TransitionDefinition::new(
+        "data",
+        Some(END_INPUT.to_string()),
+        vec!["done".to_string()],
+    );
+    eof.actions = vec!["flush_text".to_string(), "emit(EOF)".to_string()];
+    eof.consume = false;
+    definition.transitions = vec![text, eof];
+    to_rust_source(&definition).map_err(io::Error::other)
+}
+
 fn behavior_tests() -> &'static str {
-    r#"use generated_state_machine_e2e::{
-    balanced_parens_pda, contains_ab_nfa, turnstile_dfa,
+    r#"use state_machine::EffectfulInput;
+
+use generated_state_machine_e2e::{
+    balanced_parens_pda, contains_ab_nfa, html_skeleton_transducer, turnstile_dfa,
 };
 
 #[test]
@@ -209,6 +247,19 @@ fn generated_pda_accepts_balanced_parentheses() {
     assert!(pda.accepts(&["(", "(", ")", ")"]));
     assert!(!pda.accepts(&["("]));
     assert!(!pda.accepts(&[")"]));
+}
+
+#[test]
+fn generated_transducer_emits_effects() {
+    let mut transducer = html_skeleton_transducer().expect("generated transducer should import");
+    let text = transducer.process(EffectfulInput::event("x")).unwrap();
+    assert_eq!(text.effects, vec!["append_text(current)".to_string()]);
+    assert!(text.consume);
+    let eof = transducer.process(EffectfulInput::end()).unwrap();
+    assert_eq!(eof.effects, vec!["flush_text".to_string(), "emit(EOF)".to_string()]);
+    assert!(!eof.consume);
+    assert_eq!(transducer.current_state(), "done");
+    assert!(transducer.is_final());
 }
 "#
 }

--- a/code/packages/rust/state-machine-source-compiler/tests/rust_source_test.rs
+++ b/code/packages/rust/state-machine-source-compiler/tests/rust_source_test.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use state_machine::{
     MachineKind, PDATransition, PushdownAutomaton, StateDefinition, StateMachineDefinition,
-    TransitionDefinition, DFA, EPSILON, NFA,
+    TransitionDefinition, DFA, END_INPUT, EPSILON, NFA,
 };
 use state_machine_source_compiler::{
     to_rust_source, StateMachineRustSourceCompiler, StateMachineSourceError,
@@ -105,6 +105,42 @@ fn pda_definition_emits_stack_tables_and_constructor() {
     assert!(source.contains("definition.initial_stack = Some(\"$\".to_string())"));
     assert!(source.contains("stack_pop: Some(\"$\".to_string())"));
     assert!(source.contains("\"(\".to_string()"));
+}
+
+#[test]
+fn transducer_definition_emits_effect_tables_and_constructor() {
+    let mut definition = StateMachineDefinition::new("html-skeleton", MachineKind::Transducer);
+    definition.initial = Some("data".to_string());
+    definition.alphabet = vec!["<".to_string()];
+    definition.states = vec![
+        StateDefinition {
+            initial: true,
+            ..StateDefinition::new("data")
+        },
+        StateDefinition {
+            final_state: true,
+            ..StateDefinition::new("done")
+        },
+    ];
+    definition.transitions = vec![TransitionDefinition {
+        from: "data".to_string(),
+        on: Some(END_INPUT.to_string()),
+        to: vec!["done".to_string()],
+        stack_pop: None,
+        stack_push: Vec::new(),
+        actions: vec!["flush_text".to_string(), "emit(EOF)".to_string()],
+        consume: false,
+    }];
+
+    let source = to_rust_source(&definition).unwrap();
+
+    assert!(source.contains("MachineKind::Transducer"));
+    assert!(source.contains(
+        "pub fn html_skeleton_transducer() -> std::result::Result<EffectfulStateMachine, String>"
+    ));
+    assert!(source.contains("EffectfulStateMachine::from_definition"));
+    assert!(source.contains("\"flush_text\".to_string()"));
+    assert!(source.contains("consume: false"));
 }
 
 #[test]

--- a/code/packages/rust/state-machine/CHANGELOG.md
+++ b/code/packages/rust/state-machine/CHANGELOG.md
@@ -18,11 +18,18 @@ All notable changes to the `state-machine` crate will be documented in this file
 - Added definition import tests covering language preservation and rejection of
   invalid machine-kind, transition-target, epsilon, empty-event, and
   stack-effect shapes.
+- Added an effectful transducer runtime for ordered tokenizer-style state
+  machines with portable actions, consume flags, EOF handling, trace records,
+  and definition round-tripping.
+- Added a minimal HTML tokenizer skeleton test covering text buffering,
+  start/end tag emission, and EOF effects.
 
 ### Changed
 
 - Moved State Machine Markup serialization out of this crate. Format-specific
   writers now belong in sibling serializer libraries.
+- Extended `TransitionDefinition` with `actions` and `consume` fields so the
+  shared typed definition layer can represent tokenizer/transducer effects.
 
 ## [0.1.0] - 2026-03-20
 

--- a/code/packages/rust/state-machine/README.md
+++ b/code/packages/rust/state-machine/README.md
@@ -12,6 +12,7 @@ Formal automata from DFA to PDA, implemented in Rust. A port of the Python `stat
 | `minimize` | Hopcroft's DFA minimization algorithm                     |
 | `pda`      | Pushdown Automaton (finite automaton + stack)              |
 | `modal`    | Modal State Machine (multiple DFA sub-machines with mode switching) |
+| `transducer` | Ordered effectful state machine for tokenizer-style runtimes |
 | `definitions` | Format-agnostic typed definitions for export/compiler inputs |
 
 ## Where it fits in the stack
@@ -20,12 +21,14 @@ Formal automata from DFA to PDA, implemented in Rust. A port of the Python `stat
 Layer D10: State Machines
 ├── DFA/NFA          — recognize regular languages (regex, tokenizers)
 ├── PDA              — recognize context-free languages (parsers)
-└── Modal            — context-sensitive tokenization (HTML mode switching)
+├── Modal            — context-sensitive mode switching
+└── Transducer       — emit effects while transitioning (HTML tokenization)
 ```
 
 The 2-bit branch predictor (D02) is a DFA. The CPU pipeline (D04) is a linear DFA.
 Regex engines convert patterns to NFAs, then to DFAs via subset construction.
-Parsers use PDAs. HTML tokenizers use modal state machines.
+Parsers use PDAs. HTML tokenizers use effectful transducers, with modal
+machines available for simpler mode-switching examples.
 
 The `definitions` module is the bridge between hand-built machines and the
 build-time compiler pipeline. It exports deterministic snapshots of DFAs, NFAs,
@@ -94,6 +97,40 @@ definition into `.states.toml` text. Use the sibling
 into a typed definition before calling `DFA::from_definition`,
 `NFA::from_definition`, or `PushdownAutomaton::from_definition`.
 
+## Effectful Transducers
+
+```rust
+use std::collections::HashSet;
+use state_machine::{
+    EffectfulInput, EffectfulMatcher, EffectfulStateMachine, EffectfulTransition,
+};
+
+let mut machine = EffectfulStateMachine::new(
+    HashSet::from(["data".into(), "done".into()]),
+    HashSet::from(["x".into()]),
+    vec![
+        EffectfulTransition::new("data", EffectfulMatcher::Any, "data")
+            .with_effects(&["append_text(current)"]),
+        EffectfulTransition::new("data", EffectfulMatcher::End, "done")
+            .with_effects(&["flush_text", "emit(EOF)"])
+            .consuming(false),
+    ],
+    "data".into(),
+    HashSet::from(["done".into()]),
+).unwrap();
+
+let text = machine.process(EffectfulInput::event("x")).unwrap();
+assert_eq!(text.effects, vec!["append_text(current)".to_string()]);
+
+let eof = machine.process(EffectfulInput::end()).unwrap();
+assert_eq!(eof.effects, vec!["flush_text".to_string(), "emit(EOF)".to_string()]);
+assert_eq!(machine.current_state(), "done");
+```
+
+This is the primitive we use for HTML-shaped tokenizer work: definitions name
+portable effects, while wrapper packages interpret those effects into concrete
+tokens and diagnostics.
+
 ## Building and testing
 
 ```bash
@@ -110,6 +147,8 @@ cargo test -p state-machine -- --nocapture
 - **pda**: 17 unit + 33 integration tests
 - **modal**: 13 unit + 23 integration tests
 - **definitions**: 18 integration tests
+- **transducer**: HTML-tokenizer skeleton and definition round-trip tests
 
 Classic examples tested: turnstile, binary divisibility-by-3, 2-bit branch predictor,
-balanced parentheses PDA, a^n b^n PDA, HTML tokenizer modal machine.
+balanced parentheses PDA, a^n b^n PDA, HTML tokenizer modal machine, and an
+effectful HTML tokenizer skeleton.

--- a/code/packages/rust/state-machine/src/definitions.rs
+++ b/code/packages/rust/state-machine/src/definitions.rs
@@ -90,6 +90,18 @@ pub struct TransitionDefinition {
     pub stack_pop: Option<String>,
     /// PDA stack symbols to push, ordered deepest-to-topmost.
     pub stack_push: Vec<String>,
+    /// Portable effect/action identifiers executed when this transition fires.
+    ///
+    /// Recognition-only machines such as DFA, NFA, and PDA definitions leave
+    /// this empty.  Tokenizers and other transducers use it to name effects
+    /// like `flush_text`, `append_tag_name(current)`, or `emit_current_token`
+    /// without embedding host-language callbacks in the definition layer.
+    pub actions: Vec<String>,
+    /// Whether this transition consumes the current input symbol.
+    ///
+    /// Traditional automata consume by default.  Tokenizer-style machines can
+    /// set this to `false` for EOF, lookahead, or reconsume-style transitions.
+    pub consume: bool,
 }
 
 impl TransitionDefinition {
@@ -101,6 +113,8 @@ impl TransitionDefinition {
             to,
             stack_pop: None,
             stack_push: Vec::new(),
+            actions: Vec::new(),
+            consume: true,
         }
     }
 }

--- a/code/packages/rust/state-machine/src/dfa.rs
+++ b/code/packages/rust/state-machine/src/dfa.rs
@@ -523,7 +523,7 @@ impl DFA {
 
         // Header row
         let mut header = format!("{:width$}", "", width = state_width);
-        header.push_str("|");
+        header.push('|');
         for event in &sorted_events {
             header.push_str(&format!(" {:width$} |", event, width = event_width));
         }
@@ -531,11 +531,11 @@ impl DFA {
 
         // Separator
         let mut sep = "\u{2500}".repeat(state_width);
-        sep.push_str("\u{253C}");
+        sep.push('\u{253C}');
         for (i, _) in sorted_events.iter().enumerate() {
             sep.push_str(&"\u{2500}".repeat(event_width + 2));
             if i < sorted_events.len() - 1 {
-                sep.push_str("\u{253C}");
+                sep.push('\u{253C}');
             }
         }
         lines.push(sep);
@@ -556,7 +556,7 @@ impl DFA {
             };
 
             let mut row = format!("{:width$}", label, width = state_width);
-            row.push_str("|");
+            row.push('|');
             for event in &sorted_events {
                 let target = self
                     .transitions

--- a/code/packages/rust/state-machine/src/lib.rs
+++ b/code/packages/rust/state-machine/src/lib.rs
@@ -9,6 +9,7 @@
 //! - **[`minimize`]** -- Hopcroft's DFA minimization algorithm
 //! - **[`pda`]** -- Pushdown Automaton (finite automaton + stack)
 //! - **[`modal`]** -- Modal State Machine (multiple DFA sub-machines with mode switching)
+//! - **[`transducer`]** -- ordered effectful state machines for tokenizers
 //!
 //! ## The Chomsky Hierarchy
 //!
@@ -18,9 +19,10 @@
 //! ```
 //!
 //! This crate covers the first two levels: DFA/NFA for regular languages,
-//! and PDA for context-free languages. The modal state machine sits between
-//! the two, providing context-sensitive tokenization (like HTML mode switching)
-//! without the full power of a pushdown automaton.
+//! and PDA for context-free languages.  It also exposes wider primitives such
+//! as modal machines and effectful transducers so tokenizer-style runtimes can
+//! share the same state-machine foundation instead of forcing every problem
+//! into a recognition-only automaton.
 //!
 //! ## Connection to the coding-adventures stack
 //!
@@ -34,6 +36,7 @@ pub mod minimize;
 pub mod modal;
 pub mod nfa;
 pub mod pda;
+pub mod transducer;
 pub mod types;
 
 pub use definitions::{MachineKind, StateDefinition, StateMachineDefinition, TransitionDefinition};
@@ -42,4 +45,8 @@ pub use minimize::minimize;
 pub use modal::{ModalStateMachine, ModeTransitionRecord};
 pub use nfa::{EPSILON, NFA};
 pub use pda::{PDATraceEntry, PDATransition, PushdownAutomaton};
+pub use transducer::{
+    EffectfulInput, EffectfulMatcher, EffectfulStateMachine, EffectfulStep, EffectfulTransition,
+    ANY_INPUT, END_INPUT,
+};
 pub use types::*;

--- a/code/packages/rust/state-machine/src/nfa.rs
+++ b/code/packages/rust/state-machine/src/nfa.rs
@@ -435,7 +435,7 @@ impl NFA {
             self.alphabet.clone(),
             dfa_transitions,
             state_set_name(
-                &state_map
+                state_map
                     .values()
                     .find(|v| {
                         let initial_set: HashSet<String> =

--- a/code/packages/rust/state-machine/src/transducer.rs
+++ b/code/packages/rust/state-machine/src/transducer.rs
@@ -1,0 +1,432 @@
+//! Effectful state machines for tokenizer-style runtimes.
+//!
+//! DFAs, NFAs, and PDAs answer recognition questions: did this input belong to
+//! a language?  Tokenizers need the same state/transition foundation, but each
+//! transition can also emit portable effects such as "append this character" or
+//! "emit the current tag token".  This module is that wider primitive: an
+//! ordered, deterministic, effectful state machine.
+
+use std::collections::HashSet;
+
+use crate::definitions::{
+    MachineKind, StateDefinition, StateMachineDefinition, TransitionDefinition,
+};
+
+/// Serialized transition event used for "match any non-EOF input".
+pub const ANY_INPUT: &str = "$any";
+/// Serialized transition event used for the end-of-input sentinel.
+pub const END_INPUT: &str = "$end";
+
+/// Input presented to an [`EffectfulStateMachine`] for one step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EffectfulInput<'a> {
+    /// A real input event or character class.
+    Event(&'a str),
+    /// End-of-input sentinel. This is not a byte and is not part of the
+    /// machine alphabet.
+    End,
+}
+
+impl<'a> EffectfulInput<'a> {
+    /// Create an ordinary input event.
+    pub fn event(value: &'a str) -> Self {
+        Self::Event(value)
+    }
+
+    /// Create the end-of-input sentinel.
+    pub fn end() -> Self {
+        Self::End
+    }
+}
+
+/// How an effectful transition matches the current input.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EffectfulMatcher {
+    /// Match one declared input event.
+    Event(String),
+    /// Match any non-EOF input event. Ordered transitions make this useful as
+    /// an `anything_else` fallback after specific cases.
+    Any,
+    /// Match the end-of-input sentinel.
+    End,
+}
+
+impl EffectfulMatcher {
+    /// Return the stable definition-layer event identifier for this matcher.
+    pub fn as_definition_event(&self) -> String {
+        match self {
+            Self::Event(event) => event.clone(),
+            Self::Any => ANY_INPUT.to_string(),
+            Self::End => END_INPUT.to_string(),
+        }
+    }
+
+    fn matches(&self, input: EffectfulInput<'_>) -> bool {
+        match (self, input) {
+            (Self::Event(expected), EffectfulInput::Event(actual)) => expected == actual,
+            (Self::Any, EffectfulInput::Event(_)) => true,
+            (Self::End, EffectfulInput::End) => true,
+            _ => false,
+        }
+    }
+}
+
+/// One ordered transition in an effectful machine.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EffectfulTransition {
+    /// Source state.
+    pub source: String,
+    /// Input matcher.
+    pub matcher: EffectfulMatcher,
+    /// Target state.
+    pub target: String,
+    /// Portable effect/action names emitted by this transition.
+    pub effects: Vec<String>,
+    /// Whether the caller should advance the input cursor.
+    pub consume: bool,
+}
+
+impl EffectfulTransition {
+    /// Create a transition with no effects that consumes ordinary input.
+    pub fn new(
+        source: impl Into<String>,
+        matcher: EffectfulMatcher,
+        target: impl Into<String>,
+    ) -> Self {
+        Self {
+            source: source.into(),
+            matcher,
+            target: target.into(),
+            effects: Vec::new(),
+            consume: true,
+        }
+    }
+
+    /// Attach portable effect/action names to this transition.
+    pub fn with_effects(mut self, effects: &[&str]) -> Self {
+        self.effects = effects.iter().map(|effect| effect.to_string()).collect();
+        self
+    }
+
+    /// Set whether this transition consumes input.
+    pub fn consuming(mut self, consume: bool) -> Self {
+        self.consume = consume;
+        self
+    }
+}
+
+/// Trace record returned for each effectful transition.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EffectfulStep {
+    /// State before the transition.
+    pub from: String,
+    /// Input seen by the transition. `None` means EOF.
+    pub input: Option<String>,
+    /// State after the transition.
+    pub to: String,
+    /// Effects emitted by the transition.
+    pub effects: Vec<String>,
+    /// Whether the transition consumed the input.
+    pub consume: bool,
+}
+
+/// Ordered deterministic state machine with transition effects.
+#[derive(Debug, Clone)]
+pub struct EffectfulStateMachine {
+    states: HashSet<String>,
+    alphabet: HashSet<String>,
+    transitions: Vec<EffectfulTransition>,
+    initial: String,
+    final_states: HashSet<String>,
+    current: String,
+    trace: Vec<EffectfulStep>,
+}
+
+impl EffectfulStateMachine {
+    /// Create a validated effectful state machine.
+    pub fn new(
+        states: HashSet<String>,
+        alphabet: HashSet<String>,
+        transitions: Vec<EffectfulTransition>,
+        initial: String,
+        final_states: HashSet<String>,
+    ) -> Result<Self, String> {
+        if states.is_empty() {
+            return Err("States set must be non-empty".to_string());
+        }
+        if !states.contains(&initial) {
+            return Err(format!(
+                "Initial state '{initial}' is not in the states set"
+            ));
+        }
+        for state in &final_states {
+            if !states.contains(state) {
+                return Err(format!("Final state '{state}' is not in the states set"));
+            }
+        }
+        for transition in &transitions {
+            if !states.contains(&transition.source) {
+                return Err(format!(
+                    "Transition source '{}' is not in the states set",
+                    transition.source
+                ));
+            }
+            if !states.contains(&transition.target) {
+                return Err(format!(
+                    "Transition target '{}' is not in the states set",
+                    transition.target
+                ));
+            }
+            if let EffectfulMatcher::Event(event) = &transition.matcher {
+                if !alphabet.contains(event) {
+                    return Err(format!("Transition event '{event}' is not in the alphabet"));
+                }
+            }
+            if matches!(transition.matcher, EffectfulMatcher::End) && transition.consume {
+                return Err(format!(
+                    "EOF transition from '{}' must not consume input",
+                    transition.source
+                ));
+            }
+        }
+
+        Ok(Self {
+            states,
+            alphabet,
+            transitions,
+            current: initial.clone(),
+            initial,
+            final_states,
+            trace: Vec::new(),
+        })
+    }
+
+    /// Import a typed transducer definition into an executable effectful
+    /// machine.
+    ///
+    /// The definition layer remains file-format agnostic.  This import only
+    /// interprets already-typed data: `$any` means any non-EOF input and `$end`
+    /// means the EOF sentinel.
+    pub fn from_definition(definition: &StateMachineDefinition) -> Result<Self, String> {
+        if definition.kind != MachineKind::Transducer {
+            return Err(format!(
+                "Definition kind mismatch: expected transducer, found {}",
+                definition.kind.as_str()
+            ));
+        }
+        let mut states = HashSet::new();
+        let mut final_states = HashSet::new();
+        let mut flagged_initials = Vec::new();
+        for state in &definition.states {
+            if state.id.is_empty() {
+                return Err("State identifiers must not be empty".to_string());
+            }
+            if !states.insert(state.id.clone()) {
+                return Err(format!("Duplicate state '{}'", state.id));
+            }
+            if state.initial {
+                flagged_initials.push(state.id.clone());
+            }
+            if state.final_state || state.accepting {
+                final_states.insert(state.id.clone());
+            }
+        }
+        let initial = definition
+            .initial
+            .clone()
+            .ok_or_else(|| "Definition must declare an initial state".to_string())?;
+        match flagged_initials.as_slice() {
+            [flagged] if flagged == &initial => {}
+            [] => return Err("Definition must flag exactly one initial state".to_string()),
+            [flagged] => {
+                let message = format!(
+                    "Initial state mismatch: root initial '{initial}' but state '{flagged}' is flagged"
+                );
+                return Err(message);
+            }
+            many => {
+                return Err(format!(
+                    "Definition must flag exactly one initial state, found {many:?}"
+                ))
+            }
+        }
+
+        let alphabet = unique_string_set("alphabet", &definition.alphabet)?;
+        if !definition.stack_alphabet.is_empty() || definition.initial_stack.is_some() {
+            return Err(
+                "Transducer definitions must not declare stack alphabet or initial stack"
+                    .to_string(),
+            );
+        }
+        let mut transitions = Vec::new();
+        for transition in &definition.transitions {
+            if transition.to.len() != 1 {
+                return Err(format!(
+                    "Transducer transition from '{}' must have exactly one target",
+                    transition.from
+                ));
+            }
+            if transition.stack_pop.is_some() || !transition.stack_push.is_empty() {
+                return Err(format!(
+                    "Transducer transition from '{}' must not contain stack effects",
+                    transition.from
+                ));
+            }
+            let matcher = match transition.on.as_deref() {
+                Some(ANY_INPUT) => EffectfulMatcher::Any,
+                Some(END_INPUT) => EffectfulMatcher::End,
+                Some(event) => EffectfulMatcher::Event(event.to_string()),
+                None => {
+                    return Err(format!(
+                        "Transducer transition from '{}' must use `$end` for EOF, not null",
+                        transition.from
+                    ))
+                }
+            };
+            transitions.push(EffectfulTransition {
+                source: transition.from.clone(),
+                matcher,
+                target: transition.to[0].clone(),
+                effects: transition.actions.clone(),
+                consume: transition.consume,
+            });
+        }
+
+        Self::new(states, alphabet, transitions, initial, final_states)
+    }
+
+    /// Export this machine into the shared typed definition model.
+    pub fn to_definition(&self, name: &str) -> StateMachineDefinition {
+        let mut definition = StateMachineDefinition::new(name, MachineKind::Transducer);
+        definition.initial = Some(self.initial.clone());
+        definition.alphabet = sorted_strings(&self.alphabet);
+        definition.states = sorted_strings(&self.states)
+            .into_iter()
+            .map(|id| StateDefinition {
+                initial: id == self.initial,
+                final_state: self.final_states.contains(&id),
+                ..StateDefinition::new(id)
+            })
+            .collect();
+        definition.transitions = self
+            .transitions
+            .iter()
+            .map(|transition| {
+                let mut entry = TransitionDefinition::new(
+                    transition.source.clone(),
+                    Some(transition.matcher.as_definition_event()),
+                    vec![transition.target.clone()],
+                );
+                entry.actions = transition.effects.clone();
+                entry.consume = transition.consume;
+                entry
+            })
+            .collect();
+        definition
+    }
+
+    /// The finite set of states.
+    pub fn states(&self) -> &HashSet<String> {
+        &self.states
+    }
+
+    /// The finite set of ordinary input events.
+    pub fn alphabet(&self) -> &HashSet<String> {
+        &self.alphabet
+    }
+
+    /// Ordered transition table.
+    pub fn transitions(&self) -> &[EffectfulTransition] {
+        &self.transitions
+    }
+
+    /// The initial state.
+    pub fn initial(&self) -> &str {
+        &self.initial
+    }
+
+    /// The current state.
+    pub fn current_state(&self) -> &str {
+        &self.current
+    }
+
+    /// Whether the current state is final.
+    pub fn is_final(&self) -> bool {
+        self.final_states.contains(&self.current)
+    }
+
+    /// Execution trace.
+    pub fn trace(&self) -> &[EffectfulStep] {
+        &self.trace
+    }
+
+    /// Reset the machine to its initial state and clear its trace.
+    pub fn reset(&mut self) {
+        self.current = self.initial.clone();
+        self.trace.clear();
+    }
+
+    /// Process one input event or EOF sentinel and return the emitted effects.
+    pub fn process(&mut self, input: EffectfulInput<'_>) -> Result<EffectfulStep, String> {
+        if let EffectfulInput::Event(event) = input {
+            if !self.alphabet.contains(event) {
+                return Err(format!("Event '{event}' is not in the alphabet"));
+            }
+        }
+
+        let transition = self
+            .transitions
+            .iter()
+            .find(|transition| {
+                transition.source == self.current && transition.matcher.matches(input)
+            })
+            .ok_or_else(|| {
+                format!(
+                    "No transition from state '{}' on {}",
+                    self.current,
+                    input_label(input)
+                )
+            })?
+            .clone();
+
+        let step = EffectfulStep {
+            from: self.current.clone(),
+            input: match input {
+                EffectfulInput::Event(event) => Some(event.to_string()),
+                EffectfulInput::End => None,
+            },
+            to: transition.target.clone(),
+            effects: transition.effects.clone(),
+            consume: transition.consume,
+        };
+        self.current = transition.target;
+        self.trace.push(step.clone());
+        Ok(step)
+    }
+}
+
+fn input_label(input: EffectfulInput<'_>) -> String {
+    match input {
+        EffectfulInput::Event(event) => format!("'{event}'"),
+        EffectfulInput::End => "EOF".to_string(),
+    }
+}
+
+fn unique_string_set(field: &str, values: &[String]) -> Result<HashSet<String>, String> {
+    let mut set = HashSet::new();
+    for value in values {
+        if value.is_empty() {
+            return Err(format!("{field} entries must not be empty"));
+        }
+        if !set.insert(value.clone()) {
+            return Err(format!("Duplicate {field} entry '{value}'"));
+        }
+    }
+    Ok(set)
+}
+
+fn sorted_strings(values: &HashSet<String>) -> Vec<String> {
+    let mut sorted: Vec<String> = values.iter().cloned().collect();
+    sorted.sort();
+    sorted
+}

--- a/code/packages/rust/state-machine/tests/transducer_test.rs
+++ b/code/packages/rust/state-machine/tests/transducer_test.rs
@@ -1,0 +1,179 @@
+use std::collections::HashSet;
+
+use state_machine::{
+    EffectfulInput, EffectfulMatcher, EffectfulStateMachine, EffectfulTransition, ANY_INPUT,
+    END_INPUT,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum HtmlToken {
+    Text(String),
+    StartTag(String),
+    EndTag(String),
+    Eof,
+}
+
+#[derive(Debug, Default)]
+struct MiniHtmlTokenizer {
+    text: String,
+    tag_name: String,
+    current_tag_is_end: bool,
+    tokens: Vec<HtmlToken>,
+}
+
+impl MiniHtmlTokenizer {
+    fn apply(&mut self, effects: &[String], current: Option<char>) {
+        for effect in effects {
+            match effect.as_str() {
+                "append_text(current)" => self.text.push(current.expect("current char")),
+                "flush_text" => {
+                    if !self.text.is_empty() {
+                        self.tokens
+                            .push(HtmlToken::Text(std::mem::take(&mut self.text)));
+                    }
+                }
+                "create_start_tag" => {
+                    self.current_tag_is_end = false;
+                    self.tag_name.clear();
+                }
+                "create_end_tag" => {
+                    self.current_tag_is_end = true;
+                    self.tag_name.clear();
+                }
+                "append_tag_name(current_lowercase)" => {
+                    for ch in current.expect("current char").to_lowercase() {
+                        self.tag_name.push(ch);
+                    }
+                }
+                "emit_current_tag" => {
+                    let name = std::mem::take(&mut self.tag_name);
+                    if self.current_tag_is_end {
+                        self.tokens.push(HtmlToken::EndTag(name));
+                    } else {
+                        self.tokens.push(HtmlToken::StartTag(name));
+                    }
+                }
+                "emit(EOF)" => self.tokens.push(HtmlToken::Eof),
+                other => panic!("unknown effect {other}"),
+            }
+        }
+    }
+}
+
+fn set(values: &[&str]) -> HashSet<String> {
+    values.iter().map(|value| value.to_string()).collect()
+}
+
+fn html_skeleton_machine() -> EffectfulStateMachine {
+    EffectfulStateMachine::new(
+        set(&[
+            "data",
+            "tag_open",
+            "tag_name",
+            "end_tag_open",
+            "end_tag_name",
+            "done",
+        ]),
+        set(&["<", "/", ">", "h", "e", "l", "o", "b", "x"]),
+        vec![
+            EffectfulTransition::new("data", EffectfulMatcher::Event("<".to_string()), "tag_open")
+                .with_effects(&["flush_text"]),
+            EffectfulTransition::new("data", EffectfulMatcher::End, "done")
+                .with_effects(&["flush_text", "emit(EOF)"])
+                .consuming(false),
+            EffectfulTransition::new("data", EffectfulMatcher::Any, "data")
+                .with_effects(&["append_text(current)"]),
+            EffectfulTransition::new(
+                "tag_open",
+                EffectfulMatcher::Event("/".to_string()),
+                "end_tag_open",
+            ),
+            EffectfulTransition::new("tag_open", EffectfulMatcher::Any, "tag_name")
+                .with_effects(&["create_start_tag", "append_tag_name(current_lowercase)"]),
+            EffectfulTransition::new("tag_name", EffectfulMatcher::Event(">".to_string()), "data")
+                .with_effects(&["emit_current_tag"]),
+            EffectfulTransition::new("tag_name", EffectfulMatcher::Any, "tag_name")
+                .with_effects(&["append_tag_name(current_lowercase)"]),
+            EffectfulTransition::new("end_tag_open", EffectfulMatcher::Any, "end_tag_name")
+                .with_effects(&["create_end_tag", "append_tag_name(current_lowercase)"]),
+            EffectfulTransition::new(
+                "end_tag_name",
+                EffectfulMatcher::Event(">".to_string()),
+                "data",
+            )
+            .with_effects(&["emit_current_tag"]),
+            EffectfulTransition::new("end_tag_name", EffectfulMatcher::Any, "end_tag_name")
+                .with_effects(&["append_tag_name(current_lowercase)"]),
+        ],
+        "data".to_string(),
+        set(&["done"]),
+    )
+    .unwrap()
+}
+
+#[test]
+fn effectful_machine_can_drive_html_tokenizer_skeleton() {
+    let mut machine = html_skeleton_machine();
+    let mut tokenizer = MiniHtmlTokenizer::default();
+
+    for ch in "hello<b>x</b>".chars() {
+        let event = ch.to_string();
+        let step = machine.process(EffectfulInput::event(&event)).unwrap();
+        assert!(step.consume);
+        tokenizer.apply(&step.effects, Some(ch));
+    }
+    let step = machine.process(EffectfulInput::end()).unwrap();
+    assert!(!step.consume);
+    tokenizer.apply(&step.effects, None);
+
+    assert_eq!(
+        tokenizer.tokens,
+        vec![
+            HtmlToken::Text("hello".to_string()),
+            HtmlToken::StartTag("b".to_string()),
+            HtmlToken::Text("x".to_string()),
+            HtmlToken::EndTag("b".to_string()),
+            HtmlToken::Eof,
+        ]
+    );
+    assert_eq!(machine.current_state(), "done");
+    assert!(machine.is_final());
+    assert_eq!(machine.trace().len(), "hello<b>x</b>".chars().count() + 1);
+}
+
+#[test]
+fn effectful_machine_round_trips_through_definition_layer() {
+    let machine = html_skeleton_machine();
+    let definition = machine.to_definition("html-skeleton");
+    let imported = EffectfulStateMachine::from_definition(&definition).unwrap();
+
+    assert_eq!(definition.kind.as_str(), "transducer");
+    assert!(definition
+        .transitions
+        .iter()
+        .any(|transition| transition.on.as_deref() == Some(ANY_INPUT)));
+    assert!(definition
+        .transitions
+        .iter()
+        .any(|transition| transition.on.as_deref() == Some(END_INPUT) && !transition.consume));
+    assert_eq!(imported.current_state(), "data");
+    assert_eq!(imported.transitions().len(), machine.transitions().len());
+}
+
+#[test]
+fn effectful_machine_rejects_consuming_eof_transition() {
+    let error = EffectfulStateMachine::new(
+        set(&["data", "done"]),
+        set(&["x"]),
+        vec![EffectfulTransition::new(
+            "data",
+            EffectfulMatcher::End,
+            "done",
+        )],
+        "data".to_string(),
+        set(&["done"]),
+    )
+    .unwrap_err();
+
+    assert!(error.contains("EOF"));
+}

--- a/code/specs/F01-state-machine.md
+++ b/code/specs/F01-state-machine.md
@@ -13,11 +13,12 @@ input Y, move to state Z." That's it. Yet this simple abstraction is powerful
 enough to model everything from a light switch (2 states) to the HTML
 tokenizer in your web browser (80+ states).
 
-This library provides formal, composable, traceable state machines — from the
-simplest deterministic finite automaton (DFA) all the way up to modal state
-machines that can switch between sub-machines based on context. Every
-transition is logged, every machine is visualizable, and every machine can be
-defined either in code or in a declarative `.states` file.
+This library provides formal, composable, traceable state machines. DFA, NFA,
+PDA, and modal machines are important specializations, but they are not the
+only primitives. The shared foundation also includes effectful transducers:
+ordered state machines whose transitions can emit portable effects while they
+move between states. That wider primitive is what tokenizer-style systems such
+as HTML need.
 
 ## Layer Position
 
@@ -106,6 +107,29 @@ single (state, input) pair can lead to **multiple** possible next states. We'll
 get to NFAs shortly — they are more expressive for defining machines, but DFAs
 are more efficient for executing them. The magic is that every NFA can be
 converted to an equivalent DFA.
+
+### Effectful Transducers
+
+Recognition-only automata answer yes/no questions about input languages. Many
+real systems need one more dimension: taking a transition should be able to
+produce outputs or update declared registers.
+
+An HTML tokenizer is the canonical browser example. In the `data` state, seeing
+`<` does not merely move to `tag_open`; it also flushes buffered text. In a tag
+name state, seeing `>` emits the current tag token. At EOF, the tokenizer emits
+an EOF token without consuming a real character. These are still state-machine
+transitions, but they are **effectful** transitions.
+
+The generic primitive is:
+
+```text
+state + ordered matcher -> next state + consume flag + effects
+```
+
+DFA transitions are the zero-effect, always-consuming subset of this model.
+NFA and PDA keep their own execution rules, but they share the same typed
+definition layer so generated source, serializers, visualizers, and validators
+can talk about state machines without assuming every machine is a DFA.
 
 ### A More Interesting Example: Binary Divisibility by 3
 

--- a/code/specs/F08-declarative-tokenizer-state-machines.md
+++ b/code/specs/F08-declarative-tokenizer-state-machines.md
@@ -21,6 +21,12 @@ tokens, append text, track temporary buffers, report parse errors, reconsume the
 current input character in a new state, and sometimes call a shared submachine
 such as character-reference parsing.
 
+The first Rust implementation slice widens the state-machine foundation with an
+effectful transducer runtime. That runtime is intentionally generic: it executes
+ordered transitions, emits named effects, and reports whether the transition
+consumed input. HTML tokenization then becomes a wrapper/interpreter over those
+effects rather than a custom automaton family bolted beside DFA/NFA/PDA.
+
 So the answer to "can the states and transitions live purely in a text file?"
 is:
 
@@ -138,6 +144,21 @@ Each loop iteration:
 The machine is deterministic because transition matching is ordered and
 `anything`/`anything_else` matchers are only valid as the last transition in a
 state.
+
+The lower-level Rust `EffectfulStateMachine` currently represents the same idea
+with typed events:
+
+- ordinary events match declared alphabet entries
+- `$any` matches any non-EOF event after earlier transitions have had a chance
+  to match
+- `$end` matches the EOF sentinel and must not consume input
+- `actions` is an ordered list of portable effect identifiers
+- `consume = false` models EOF, lookahead, and future reconsume-style behavior
+
+That representation is deliberately smaller than the full tokenizer profile,
+but it is enough for generated source and wrapper packages to share one
+execution primitive while the tokenizer-specific matcher/action vocabulary
+continues to grow.
 
 ## File Format
 
@@ -590,12 +611,12 @@ web-platform-tests/html and run them through the same runtime.
 ## Implementation Plan
 
 1. Add this spec.
-2. Add a `tokenizer-state-machine` package in Rust first, because Rust is the
-   browser implementation direction and gives us strong data modeling.
-3. Port the runtime to Go next, because Go is the other preferred systems
-   direction for this repo.
-4. Add TypeScript, Python, Ruby, and other ports only after the Rust and Go APIs
-   settle.
+2. Add a generic effectful transducer primitive to the Rust `state-machine`
+   package so tokenizer runtimes build on the same foundation as DFA/NFA/PDA.
+3. Teach the Rust definition, serializer/deserializer, and source compiler
+   pipeline to preserve transition actions and consume flags.
+4. Add a minimal HTML tokenizer skeleton test that proves text buffering,
+   start/end tag emission, EOF handling, and generated transducer source.
 5. Add `code/tokenizers/html/html1.tokenizer.states.toml`.
 6. Compile the tokenizer definition into static source code with the F09
    compiler.

--- a/code/specs/F09-state-machine-source-compiler.md
+++ b/code/specs/F09-state-machine-source-compiler.md
@@ -189,17 +189,23 @@ Rust end-to-end completion means the compiler test suite proves this full
 build-time chain:
 
 ```text
-manual DFA/NFA/PDA
+manual DFA/NFA/PDA/transducer
   -> StateMachineDefinition
   -> generated Rust module
   -> temporary Rust wrapper crate
   -> cargo test executes the generated constructors
-  -> executable automata accept/reject expected inputs
+  -> executable automata accept/reject expected inputs or emit expected effects
 ```
 
 The generated module itself still contains only typed table data and
 constructors. Test harnesses may write temporary crates to prove linkability,
 but the source compiler API remains file-format and file-system agnostic.
+
+For the first tokenizer-oriented Rust slice, transducer generation emits the
+same kind of typed table data as DFA/NFA/PDA generation, plus `actions` and
+`consume` fields on each transition. The generated constructor calls
+`EffectfulStateMachine::from_definition(...)`, so wrapper packages link static
+source and do not load tokenizer definitions from disk at runtime.
 
 ## Manual Machine Export Layer
 
@@ -284,6 +290,16 @@ and streaming input.
 
 ```text
 html1.tokenizer.states.toml -> generated tokenizer tables -> HtmlLexer wrapper
+```
+
+The Rust foundation starts with a smaller skeleton:
+
+```text
+manual html-skeleton transducer
+  -> StateMachineDefinition(actions, consume)
+  -> generated Rust module
+  -> EffectfulStateMachine
+  -> wrapper/interpreter emits Text, StartTag, EndTag, EOF tokens
 ```
 
 ### Example 6: WHATWG HTML Tokenizer


### PR DESCRIPTION
## Summary

- Specify effectful transducers as the generic state-machine primitive needed for HTML-style tokenizers.
- Add a Rust `EffectfulStateMachine` runtime with ordered transitions, `$any`/`$end` matchers, portable effects, consume flags, trace records, and definition round-tripping.
- Extend Rust state-machine markup TOML/JSON serializers/deserializers and source generation to preserve transducer `actions` and `consume` fields.
- Add generated-source coverage and a mini HTML tokenizer skeleton test for text, start/end tag, and EOF effects.

## Verification

- `cargo fmt --check -p state-machine -p state-machine-markup-serializer -p state-machine-markup-deserializer -p state-machine-markup-json-serializer -p state-machine-markup-json-deserializer -p state-machine-source-compiler`
- `cargo clippy -p state-machine -p state-machine-source-compiler -p state-machine-markup-serializer -p state-machine-markup-deserializer -p state-machine-markup-json-serializer -p state-machine-markup-json-deserializer --no-deps -- -D warnings`
- `cargo test -p state-machine --no-run && cargo test -p state-machine-source-compiler --no-run && cargo test -p state-machine-markup-serializer -p state-machine-markup-deserializer -p state-machine-markup-json-serializer -p state-machine-markup-json-deserializer --no-run`

Note: focused Rust test binaries compile locally. Full execution is still limited by the local fresh-Rust-binary runtime issue seen on earlier PRs, so CI remains the source of truth for runtime execution.