### PR TITLE
feat(music): add browser Web Audio sink

### DIFF
--- a/code/packages/typescript/web-audio-sink/BUILD
+++ b/code/packages/typescript/web-audio-sink/BUILD
@@ -1,0 +1,3 @@
+npm ci --quiet
+npm run build --silent
+npm test --silent

--- a/code/packages/typescript/web-audio-sink/BUILD_windows
+++ b/code/packages/typescript/web-audio-sink/BUILD_windows
@@ -1,0 +1,3 @@
+npm ci --quiet
+npm run build --silent
+npm test --silent

--- a/code/packages/typescript/web-audio-sink/CHANGELOG.md
+++ b/code/packages/typescript/web-audio-sink/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## [0.1.0] - 2026-04-22
+
+### Added
+
+- Browser Web Audio sink for mono signed 16-bit PCM buffers.
+- PCM validation, PCM-to-float conversion, `AudioBuffer` creation, and
+  promise-based playback scheduling.
+- Fake-`AudioContext` tests so CI can validate the browser sink without a real
+  audio device.

--- a/code/packages/typescript/web-audio-sink/README.md
+++ b/code/packages/typescript/web-audio-sink/README.md
@@ -1,0 +1,53 @@
+# web-audio-sink
+
+`web-audio-sink` is the browser playback seam for the music stack.
+
+It starts where the virtual audio pipeline ends:
+
+```text
+PCM samples -> Web Audio AudioBuffer -> browser speakers
+```
+
+The package does not parse notes or synthesize instruments. It accepts already
+rendered mono signed 16-bit PCM samples, converts them to Web Audio's
+floating-point format, and schedules them on an `AudioContext`.
+
+## Usage
+
+```typescript
+import { playPcmBuffer } from "@coding-adventures/web-audio-sink";
+
+await playPcmBuffer({
+  samples: new Int16Array([0, 4096, 8192, 4096, 0, -4096]),
+  format: {
+    sampleRateHz: 44100,
+    channelCount: 1,
+    bitDepth: 16,
+  },
+});
+```
+
+Most browsers require playback to start from a user gesture such as a button
+click. Pass an existing `AudioContext` if your app owns the gesture handling:
+
+```typescript
+button.addEventListener("click", async () => {
+  const audioContext = new AudioContext();
+  await playPcmBuffer(buffer, { audioContext, gain: 0.2 });
+});
+```
+
+## API
+
+| Export | Description |
+|--------|-------------|
+| `validatePcmBuffer` | Checks mono signed 16-bit PCM metadata and samples |
+| `pcmSamplesToFloat32` | Converts integer PCM samples into Web Audio floats |
+| `createAudioBufferFromPcm` | Copies PCM into an `AudioBuffer` |
+| `playPcmBuffer` | Schedules a complete buffer and resolves on `ended` |
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/typescript/web-audio-sink/package-lock.json
+++ b/code/packages/typescript/web-audio-sink/package-lock.json
@@ -1,0 +1,45 @@
+{
+  "name": "@coding-adventures/web-audio-sink",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/web-audio-sink",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^5.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true
+    }
+  }
+}

--- a/code/packages/typescript/web-audio-sink/package.json
+++ b/code/packages/typescript/web-audio-sink/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@coding-adventures/web-audio-sink",
+  "version": "0.1.0",
+  "description": "Browser Web Audio sink for mono signed 16-bit PCM buffers",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "node node_modules/typescript/bin/tsc",
+    "test": "node node_modules/typescript/bin/tsc -p tsconfig.test.json && node --test dist-test/tests/web-audio-sink.test.js"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/code/packages/typescript/web-audio-sink/required_capabilities.json
+++ b/code/packages/typescript/web-audio-sink/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/web-audio-sink",
+  "capabilities": [],
+  "justification": "No filesystem, network, process, or environment access. Runtime playback uses a caller-provided or browser-provided AudioContext."
+}

--- a/code/packages/typescript/web-audio-sink/src/index.ts
+++ b/code/packages/typescript/web-audio-sink/src/index.ts
@@ -1,0 +1,17 @@
+export {
+  createAudioBufferFromPcm,
+  pcmSamplesToFloat32,
+  playPcmBuffer,
+  validatePcmBuffer,
+} from "./web-audio-sink.js";
+
+export type {
+  AudioBufferLike,
+  AudioBufferSourceNodeLike,
+  AudioContextLike,
+  GainNodeLike,
+  PcmFormat,
+  PcmPlaybackBuffer,
+  PlaybackReport,
+  WebAudioSinkOptions,
+} from "./web-audio-sink.js";

--- a/code/packages/typescript/web-audio-sink/src/web-audio-sink.ts
+++ b/code/packages/typescript/web-audio-sink/src/web-audio-sink.ts
@@ -1,0 +1,245 @@
+export interface PcmFormat {
+  sampleRateHz: number;
+  channelCount?: number;
+  bitDepth?: 16;
+}
+
+export interface PcmPlaybackBuffer {
+  samples: Int16Array | readonly number[];
+  format: PcmFormat;
+}
+
+export interface PlaybackReport {
+  framesPlayed: number;
+  sampleRateHz: number;
+  channelCount: number;
+  durationSeconds: number;
+  backendName: "web-audio";
+}
+
+export interface AudioBufferLike {
+  readonly length: number;
+  readonly sampleRate: number;
+  readonly numberOfChannels: number;
+  getChannelData(channel: number): Float32Array;
+}
+
+export interface AudioBufferSourceNodeLike {
+  buffer: AudioBufferLike | null;
+  onended: ((this: unknown, event: Event) => void) | null;
+  connect(destination: unknown): unknown;
+  start(when?: number): void;
+}
+
+export interface GainNodeLike {
+  gain: { value: number };
+  connect(destination: unknown): unknown;
+}
+
+export interface AudioContextLike {
+  readonly sampleRate: number;
+  readonly currentTime: number;
+  readonly state?: string;
+  readonly destination: unknown;
+  createBuffer(
+    numberOfChannels: number,
+    length: number,
+    sampleRate: number,
+  ): AudioBufferLike;
+  createBufferSource(): AudioBufferSourceNodeLike;
+  createGain(): GainNodeLike;
+  resume?(): Promise<void> | void;
+  close?(): Promise<void> | void;
+}
+
+export interface WebAudioSinkOptions {
+  audioContext?: AudioContextLike;
+  gain?: number;
+  startTimeSeconds?: number;
+  closeContextWhenDone?: boolean;
+}
+
+export interface NormalizedPcmFormat {
+  sampleRateHz: number;
+  channelCount: 1;
+  bitDepth: 16;
+}
+
+const INT16_MIN = -32768;
+const INT16_MAX = 32767;
+
+export function validatePcmBuffer(buffer: PcmPlaybackBuffer): NormalizedPcmFormat {
+  if (buffer === null || typeof buffer !== "object") {
+    throw new TypeError("buffer must be an object");
+  }
+  if (!isSupportedSampleArray(buffer.samples)) {
+    throw new TypeError("buffer.samples must be an Int16Array or number array");
+  }
+  if (buffer.format === null || typeof buffer.format !== "object") {
+    throw new TypeError("buffer.format must be an object");
+  }
+
+  const sampleRateHz = buffer.format.sampleRateHz;
+  if (!Number.isInteger(sampleRateHz) || sampleRateHz <= 0) {
+    throw new RangeError("format.sampleRateHz must be a positive integer");
+  }
+
+  const channelCount = buffer.format.channelCount ?? 1;
+  if (channelCount !== 1) {
+    throw new RangeError("format.channelCount must be exactly 1 for V1");
+  }
+
+  const bitDepth = buffer.format.bitDepth ?? 16;
+  if (bitDepth !== 16) {
+    throw new RangeError("format.bitDepth must be exactly 16 for V1");
+  }
+
+  for (let index = 0; index < buffer.samples.length; index += 1) {
+    const sample = buffer.samples[index];
+    if (!Number.isInteger(sample) || sample < INT16_MIN || sample > INT16_MAX) {
+      throw new RangeError(
+        `buffer.samples[${index}] must be a signed 16-bit integer`,
+      );
+    }
+  }
+
+  return { sampleRateHz, channelCount: 1, bitDepth: 16 };
+}
+
+export function pcmSamplesToFloat32(
+  samples: Int16Array | readonly number[],
+  gain = 1.0,
+): Float32Array {
+  if (!isSupportedSampleArray(samples)) {
+    throw new TypeError("samples must be an Int16Array or number array");
+  }
+  validateGain(gain);
+
+  const floats = new Float32Array(samples.length);
+  for (let index = 0; index < samples.length; index += 1) {
+    const sample = samples[index];
+    if (!Number.isInteger(sample) || sample < INT16_MIN || sample > INT16_MAX) {
+      throw new RangeError(`samples[${index}] must be a signed 16-bit integer`);
+    }
+    floats[index] = int16ToFloat(sample) * gain;
+  }
+  return floats;
+}
+
+export function createAudioBufferFromPcm(
+  audioContext: AudioContextLike,
+  buffer: PcmPlaybackBuffer,
+  options: Pick<WebAudioSinkOptions, "gain"> = {},
+): AudioBufferLike {
+  if (audioContext === null || typeof audioContext !== "object") {
+    throw new TypeError("audioContext must be an AudioContext-like object");
+  }
+
+  const format = validatePcmBuffer(buffer);
+  const gain = options.gain ?? 1.0;
+  const floats = pcmSamplesToFloat32(buffer.samples, gain);
+  const audioBuffer = audioContext.createBuffer(
+    format.channelCount,
+    floats.length,
+    format.sampleRateHz,
+  );
+
+  audioBuffer.getChannelData(0).set(floats);
+  return audioBuffer;
+}
+
+export async function playPcmBuffer(
+  buffer: PcmPlaybackBuffer,
+  options: WebAudioSinkOptions = {},
+): Promise<PlaybackReport> {
+  const format = validatePcmBuffer(buffer);
+  const durationSeconds = buffer.samples.length / format.sampleRateHz;
+  const report: PlaybackReport = {
+    framesPlayed: buffer.samples.length,
+    sampleRateHz: format.sampleRateHz,
+    channelCount: format.channelCount,
+    durationSeconds,
+    backendName: "web-audio",
+  };
+
+  if (buffer.samples.length === 0) {
+    return report;
+  }
+
+  const audioContext = options.audioContext ?? createDefaultAudioContext();
+  if (audioContext.state === "suspended" && audioContext.resume) {
+    await audioContext.resume();
+  }
+
+  const gain = options.gain ?? 1.0;
+  validateGain(gain);
+  const audioBuffer = createAudioBufferFromPcm(audioContext, buffer);
+  const source = audioContext.createBufferSource();
+  const gainNode = audioContext.createGain();
+  const startTimeSeconds = options.startTimeSeconds ?? audioContext.currentTime;
+
+  source.buffer = audioBuffer;
+  gainNode.gain.value = gain;
+  source.connect(gainNode);
+  gainNode.connect(audioContext.destination);
+
+  return new Promise<PlaybackReport>((resolve, reject) => {
+    let settled = false;
+
+    const finish = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      Promise.resolve(
+        options.closeContextWhenDone && audioContext.close
+          ? audioContext.close()
+          : undefined,
+      ).then(
+        () => resolve(report),
+        (error: unknown) => reject(error),
+      );
+    };
+
+    source.onended = finish;
+
+    try {
+      source.start(startTimeSeconds);
+    } catch (error: unknown) {
+      settled = true;
+      reject(error);
+    }
+  });
+}
+
+function isSupportedSampleArray(value: unknown): value is Int16Array | number[] {
+  return value instanceof Int16Array || Array.isArray(value);
+}
+
+function validateGain(gain: number): void {
+  if (!Number.isFinite(gain) || gain < 0.0 || gain > 1.0) {
+    throw new RangeError("gain must be finite and in the range [0.0, 1.0]");
+  }
+}
+
+function int16ToFloat(sample: number): number {
+  if (sample < 0) {
+    return sample / 32768.0;
+  }
+  return sample / 32767.0;
+}
+
+function createDefaultAudioContext(): AudioContextLike {
+  type AudioContextConstructor = new () => AudioContextLike;
+  const browserGlobal = globalThis as unknown as {
+    AudioContext?: AudioContextConstructor;
+    webkitAudioContext?: AudioContextConstructor;
+  };
+  const Constructor = browserGlobal.AudioContext ?? browserGlobal.webkitAudioContext;
+
+  if (!Constructor) {
+    throw new Error("Web Audio API is not available in this environment");
+  }
+
+  return new Constructor();
+}

--- a/code/packages/typescript/web-audio-sink/tests/web-audio-sink.test.ts
+++ b/code/packages/typescript/web-audio-sink/tests/web-audio-sink.test.ts
@@ -1,0 +1,241 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createAudioBufferFromPcm,
+  pcmSamplesToFloat32,
+  playPcmBuffer,
+  validatePcmBuffer,
+  type AudioBufferLike,
+  type AudioBufferSourceNodeLike,
+  type AudioContextLike,
+  type GainNodeLike,
+} from "../src/index.js";
+
+class FakeAudioBuffer implements AudioBufferLike {
+  readonly numberOfChannels: number;
+  readonly length: number;
+  readonly sampleRate: number;
+  readonly data: Float32Array[];
+
+  constructor(numberOfChannels: number, length: number, sampleRate: number) {
+    this.numberOfChannels = numberOfChannels;
+    this.length = length;
+    this.sampleRate = sampleRate;
+    this.data = Array.from(
+      { length: numberOfChannels },
+      () => new Float32Array(length),
+    );
+  }
+
+  getChannelData(channel: number): Float32Array {
+    return this.data[channel];
+  }
+}
+
+class FakeGainNode implements GainNodeLike {
+  readonly gain = { value: 1.0 };
+  readonly connections: unknown[] = [];
+
+  connect(destination: unknown): unknown {
+    this.connections.push(destination);
+    return destination;
+  }
+}
+
+class FakeSourceNode implements AudioBufferSourceNodeLike {
+  buffer: AudioBufferLike | null = null;
+  onended: ((this: unknown, event: Event) => void) | null = null;
+  readonly connections: unknown[] = [];
+  readonly startTimes: number[] = [];
+
+  connect(destination: unknown): unknown {
+    this.connections.push(destination);
+    return destination;
+  }
+
+  start(when?: number): void {
+    this.startTimes.push(when ?? 0);
+    this.onended?.(new Event("ended"));
+  }
+}
+
+class FakeAudioContext implements AudioContextLike {
+  readonly sampleRate = 48_000;
+  readonly currentTime = 12.5;
+  readonly destination = { kind: "speaker" };
+  state = "running";
+  resumeCount = 0;
+  closeCount = 0;
+  readonly buffers: FakeAudioBuffer[] = [];
+  readonly sources: FakeSourceNode[] = [];
+  readonly gains: FakeGainNode[] = [];
+
+  createBuffer(
+    numberOfChannels: number,
+    length: number,
+    sampleRate: number,
+  ): FakeAudioBuffer {
+    const buffer = new FakeAudioBuffer(numberOfChannels, length, sampleRate);
+    this.buffers.push(buffer);
+    return buffer;
+  }
+
+  createBufferSource(): FakeSourceNode {
+    const source = new FakeSourceNode();
+    this.sources.push(source);
+    return source;
+  }
+
+  createGain(): FakeGainNode {
+    const gain = new FakeGainNode();
+    this.gains.push(gain);
+    return gain;
+  }
+
+  async resume(): Promise<void> {
+    this.resumeCount += 1;
+    this.state = "running";
+  }
+
+  async close(): Promise<void> {
+    this.closeCount += 1;
+  }
+}
+
+test("validatePcmBuffer normalizes omitted mono 16-bit defaults", () => {
+  assert.deepEqual(
+    validatePcmBuffer({
+      samples: [0, 1, -1],
+      format: { sampleRateHz: 44_100 },
+    }),
+    { sampleRateHz: 44_100, channelCount: 1, bitDepth: 16 },
+  );
+});
+
+test("validatePcmBuffer rejects unsupported formats and samples", () => {
+  assert.throws(
+    () =>
+      validatePcmBuffer({
+        samples: [0],
+        format: { sampleRateHz: 0 },
+      }),
+    /sampleRateHz/,
+  );
+
+  assert.throws(
+    () =>
+      validatePcmBuffer({
+        samples: [0],
+        format: { sampleRateHz: 44_100, channelCount: 2 },
+      }),
+    /channelCount/,
+  );
+
+  assert.throws(
+    () =>
+      validatePcmBuffer({
+        samples: [32_768],
+        format: { sampleRateHz: 44_100 },
+      }),
+    /signed 16-bit/,
+  );
+});
+
+test("pcmSamplesToFloat32 converts signed 16-bit PCM to floats", () => {
+  const floats = pcmSamplesToFloat32(
+    new Int16Array([-32768, -16384, 0, 16384, 32767]),
+    0.5,
+  );
+
+  assert.deepEqual(Array.from(floats.slice(0, 3)), [-0.5, -0.25, 0]);
+  assert.ok(Math.abs(floats[3] - 0.250007629627369) < 0.00000001);
+  assert.equal(floats[4], 0.5);
+});
+
+test("pcmSamplesToFloat32 rejects invalid gain values", () => {
+  assert.throws(() => pcmSamplesToFloat32([0], 1.1), /gain/);
+  assert.throws(() => pcmSamplesToFloat32([0], Number.NaN), /gain/);
+});
+
+test("createAudioBufferFromPcm creates a mono AudioBuffer", () => {
+  const audioContext = new FakeAudioContext();
+  const audioBuffer = createAudioBufferFromPcm(
+    audioContext,
+    {
+      samples: [0, 32767, -32768],
+      format: { sampleRateHz: 22_050 },
+    },
+    { gain: 0.25 },
+  );
+
+  assert.equal(audioBuffer.numberOfChannels, 1);
+  assert.equal(audioBuffer.length, 3);
+  assert.equal(audioBuffer.sampleRate, 22_050);
+  assert.deepEqual(Array.from(audioBuffer.getChannelData(0)), [0, 0.25, -0.25]);
+});
+
+test("playPcmBuffer schedules a source and resolves a report", async () => {
+  const audioContext = new FakeAudioContext();
+
+  const report = await playPcmBuffer(
+    {
+      samples: [0, 32767, 0, -32768],
+      format: { sampleRateHz: 4 },
+    },
+    { audioContext, gain: 0.1, startTimeSeconds: 20.0 },
+  );
+
+  assert.deepEqual(report, {
+    framesPlayed: 4,
+    sampleRateHz: 4,
+    channelCount: 1,
+    durationSeconds: 1,
+    backendName: "web-audio",
+  });
+  assert.equal(audioContext.sources.length, 1);
+  assert.deepEqual(audioContext.sources[0].startTimes, [20.0]);
+  assert.equal(audioContext.sources[0].buffer, audioContext.buffers[0]);
+  assert.equal(audioContext.gains[0].gain.value, 0.1);
+  assert.deepEqual(audioContext.gains[0].connections, [audioContext.destination]);
+});
+
+test("playPcmBuffer resumes suspended contexts and can close them", async () => {
+  const audioContext = new FakeAudioContext();
+  audioContext.state = "suspended";
+
+  await playPcmBuffer(
+    {
+      samples: [0, 1],
+      format: { sampleRateHz: 2 },
+    },
+    { audioContext, closeContextWhenDone: true },
+  );
+
+  assert.equal(audioContext.resumeCount, 1);
+  assert.equal(audioContext.closeCount, 1);
+});
+
+test("playPcmBuffer returns immediately for empty buffers", async () => {
+  await assert.rejects(
+    playPcmBuffer({
+      samples: [1],
+      format: { sampleRateHz: 44_100 },
+    }),
+    /Web Audio API is not available/,
+  );
+
+  assert.deepEqual(
+    await playPcmBuffer({
+      samples: [],
+      format: { sampleRateHz: 44_100 },
+    }),
+    {
+      framesPlayed: 0,
+      sampleRateHz: 44_100,
+      channelCount: 1,
+      durationSeconds: 0,
+      backendName: "web-audio",
+    },
+  );
+});

--- a/code/packages/typescript/web-audio-sink/tsconfig.json
+++ b/code/packages/typescript/web-audio-sink/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["tests", "dist", "node_modules", "vitest.config.ts"]
+}

--- a/code/packages/typescript/web-audio-sink/tsconfig.test.json
+++ b/code/packages/typescript/web-audio-sink/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist-test",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"],
+  "exclude": ["dist", "dist-test", "node_modules"]
+}

--- a/code/specs/MUS06-web-audio-sink.md
+++ b/code/specs/MUS06-web-audio-sink.md
@@ -1,0 +1,122 @@
+# MUS06: Browser Web Audio Sink
+
+## 1. Overview
+
+`MUS02` defines the native audio-device sink:
+
+```text
+PCM buffer -> native audio sink -> operating-system audio API -> speakers
+```
+
+Browsers have a different final box. They do not load the Rust native sink
+directly, and they should not pretend to have Core Audio, WASAPI, or ALSA.
+Instead, the browser playback path is:
+
+```text
+PCM buffer -> Web Audio sink -> AudioContext -> browser/OS audio stack
+```
+
+This spec defines the first browser-friendly sink for already-rendered PCM
+samples. It does not parse notes, render instruments, or mix tracks. Those
+belong below `music-machine`.
+
+## 2. Beginner Mental Model
+
+The music machine eventually hands us a list of signed integers:
+
+```text
+0, 1024, 2048, 1024, 0, -1024, ...
+```
+
+Those are PCM samples. A browser `AudioContext` wants floating-point samples
+instead:
+
+```text
+-1.0 <= sample <= 1.0
+```
+
+The Web Audio sink's job is therefore small and very visible:
+
+1. Validate the PCM metadata.
+2. Convert signed 16-bit integers into floats.
+3. Copy those floats into an `AudioBuffer`.
+4. Schedule an `AudioBufferSourceNode` to play through the context destination.
+
+## 3. V1 Contract
+
+Input format:
+
+```text
+PcmPlaybackBuffer(
+    samples = signed 16-bit PCM integers,
+    format = PcmFormat(
+        sample_rate_hz,
+        channel_count = 1,
+        bit_depth = 16,
+    ),
+)
+```
+
+V1 requirements:
+
+- mono only
+- signed 16-bit PCM only
+- finite positive integer sample rate
+- optional gain in `[0.0, 1.0]`
+- no filesystem, process, or network access
+- no dependency on a native audio crate
+
+Empty buffers are valid. Playing an empty buffer is a no-op report.
+
+## 4. API Shape
+
+Browser package:
+
+```text
+typescript/web-audio-sink
+```
+
+Required exports:
+
+```text
+validatePcmBuffer(buffer) -> normalized format
+pcmSamplesToFloat32(samples, gain) -> Float32Array
+createAudioBufferFromPcm(audio_context, buffer, options) -> AudioBuffer
+playPcmBuffer(buffer, options) -> Promise<PlaybackReport>
+```
+
+`playPcmBuffer` accepts an optional injected `AudioContext`-like object. Tests
+must use this seam so CI does not need real speakers.
+
+## 5. Playback Report
+
+Playback returns:
+
+```text
+PlaybackReport(
+    frames_played,
+    sample_rate_hz,
+    channel_count,
+    duration_seconds,
+    backend_name = "web-audio",
+)
+```
+
+For mono V1:
+
+```text
+frames_played == samples.length
+```
+
+## 6. Relationship to Future Web Music Packages
+
+This sink is deliberately below the browser music machine.
+
+Future packages can choose between:
+
+- rendering PCM in TypeScript and passing it to this sink
+- receiving PCM from a WebAssembly music renderer and passing it to this sink
+- streaming chunks later through an `AudioWorklet`
+
+V1 only schedules complete buffers. Streaming, low-latency keyboard input, and
+`AudioWorklet` clocks should arrive after the buffer sink is easy to inspect.


### PR DESCRIPTION
## Summary

- Add `MUS06` for the browser Web Audio playback boundary.
- Add a TypeScript `web-audio-sink` package that validates mono signed 16-bit PCM, converts samples to Web Audio floats, creates `AudioBuffer`s, and schedules playback through an `AudioContext`.
- Add fake-`AudioContext` tests so browser playback behavior can be validated without real speakers in CI.

## Tests

- `bash BUILD` in `code/packages/typescript/web-audio-sink`
