### PR TITLE
Add Rust tokenizer profile runtime

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -341,6 +341,7 @@ members = [
     "state-machine-markup-json-serializer",
     "state-machine-markup-json-deserializer",
     "state-machine-source-compiler",
+    "state-machine-tokenizer",
     "embeddable-tcp-server",
     "generic-job-protocol",
     "generic-job-runtime",

--- a/code/packages/rust/state-machine-tokenizer/BUILD
+++ b/code/packages/rust/state-machine-tokenizer/BUILD
@@ -1,0 +1,2 @@
+cargo test -p state-machine-tokenizer -- --nocapture
+if [ "$(uname)" = "Linux" ]; then cargo tarpaulin -p state-machine-tokenizer --out Stdout --skip-clean; fi

--- a/code/packages/rust/state-machine-tokenizer/BUILD_windows
+++ b/code/packages/rust/state-machine-tokenizer/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p state-machine-tokenizer -- --nocapture

--- a/code/packages/rust/state-machine-tokenizer/CHANGELOG.md
+++ b/code/packages/rust/state-machine-tokenizer/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to the `state-machine-tokenizer` crate will be documented in this file.
+
+## [0.1.0] - 2026-04-23
+
+### Added
+
+- Added the initial tokenizer-profile runtime over `EffectfulStateMachine`.
+- Added fixed portable action interpretation for text buffering, start/end tag
+  construction, EOF emission, diagnostics, and cursor/position tracing.
+- Added a statically linked HTML skeleton tokenizer definition and fixture
+  coverage for text, tags, chunked input, EOF flushing, diagnostics, and
+  arbitrary Unicode text through `$any`.

--- a/code/packages/rust/state-machine-tokenizer/Cargo.toml
+++ b/code/packages/rust/state-machine-tokenizer/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "state-machine-tokenizer"
+version = "0.1.0"
+edition = "2021"
+description = "Tokenizer profile runtime on top of effectful state machines"
+
+[dependencies]
+state-machine = { path = "../state-machine" }

--- a/code/packages/rust/state-machine-tokenizer/README.md
+++ b/code/packages/rust/state-machine-tokenizer/README.md
@@ -1,0 +1,59 @@
+# state-machine-tokenizer
+
+Tokenizer profile runtime on top of `state-machine` effectful transducers.
+
+This crate is the first Rust wrapper layer for declarative tokenizer machines.
+The core `state-machine` crate executes ordered transitions and emits portable
+effect names. This crate interprets those effect names into tokenizer buffers,
+tokens, diagnostics, source positions, and traces.
+
+The package does not read TOML, JSON, or any other definition file at runtime.
+Production wrappers should link statically generated machine constructors, then
+pass the resulting `EffectfulStateMachine` into `Tokenizer::new`.
+
+## Example
+
+```rust
+use state_machine_tokenizer::{html_skeleton_tokenizer, Token};
+
+let mut tokenizer = html_skeleton_tokenizer().unwrap();
+tokenizer.push("<p>Hello</p>").unwrap();
+tokenizer.finish().unwrap();
+
+assert_eq!(
+    tokenizer.drain_tokens(),
+    vec![
+        Token::StartTag { name: "p".into(), attributes: vec![], self_closing: false },
+        Token::Text("Hello".into()),
+        Token::EndTag { name: "p".into() },
+        Token::Eof,
+    ]
+);
+```
+
+## Current Scope
+
+The first runtime supports the small fixed action vocabulary needed by the HTML
+skeleton:
+
+- `append_text(current)`
+- `append_text(literal)`
+- `append_text_replacement`
+- `flush_text`
+- `emit_current_as_text`
+- `create_start_tag`
+- `create_end_tag`
+- `append_tag_name(current)`
+- `append_tag_name(current_lowercase)`
+- `emit_current_token`
+- `emit(EOF)`
+- `parse_error(code)`
+
+It also enforces a per-input step limit so malformed reconsume-style machines
+cannot spin forever on one code point.
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/rust/state-machine-tokenizer/required_capabilities.json
+++ b/code/packages/rust/state-machine-tokenizer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/state-machine-tokenizer",
+  "capabilities": [],
+  "justification": "Pure tokenizer runtime. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/rust/state-machine-tokenizer/src/lib.rs
+++ b/code/packages/rust/state-machine-tokenizer/src/lib.rs
@@ -1,0 +1,545 @@
+//! Tokenizer profile runtime for effectful state machines.
+//!
+//! The core `state-machine` crate owns the generic transition engine. This
+//! crate owns tokenizer-specific state: buffers, current token construction,
+//! diagnostics, source positions, and action interpretation.
+
+use std::collections::{HashSet, VecDeque};
+use std::error::Error;
+use std::fmt;
+
+use state_machine::{EffectfulInput, EffectfulMatcher, EffectfulStateMachine, EffectfulTransition};
+
+/// Parsed token emitted by the tokenizer profile runtime.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Token {
+    /// Buffered character data.
+    Text(String),
+    /// Start tag token.
+    StartTag {
+        /// Lower-level definitions decide casing; this runtime stores the
+        /// already-interpreted name.
+        name: String,
+        /// Attributes collected on this start tag.
+        attributes: Vec<Attribute>,
+        /// Whether the source used self-closing syntax.
+        self_closing: bool,
+    },
+    /// End tag token.
+    EndTag {
+        /// Tag name.
+        name: String,
+    },
+    /// Comment token.
+    Comment(String),
+    /// Doctype token.
+    Doctype {
+        /// Optional doctype name.
+        name: Option<String>,
+        /// Whether parse errors should force quirks mode.
+        force_quirks: bool,
+    },
+    /// End-of-file token.
+    Eof,
+}
+
+/// Attribute attached to a start tag.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Attribute {
+    /// Attribute name.
+    pub name: String,
+    /// Attribute value.
+    pub value: String,
+}
+
+/// Source position before a transition runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SourcePosition {
+    /// UTF-8 byte offset from the beginning of the stream.
+    pub byte_offset: usize,
+    /// Unicode scalar offset from the beginning of the stream.
+    pub char_offset: usize,
+    /// One-based line number.
+    pub line: usize,
+    /// One-based column number.
+    pub column: usize,
+}
+
+impl Default for SourcePosition {
+    fn default() -> Self {
+        Self {
+            byte_offset: 0,
+            char_offset: 0,
+            line: 1,
+            column: 1,
+        }
+    }
+}
+
+/// Recoverable tokenizer diagnostic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Diagnostic {
+    /// Stable diagnostic code from the tokenizer definition.
+    pub code: String,
+    /// Position where the diagnostic was reported.
+    pub position: SourcePosition,
+    /// State that reported the diagnostic.
+    pub state: String,
+}
+
+/// Trace entry for one tokenizer loop iteration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TokenizerTraceEntry {
+    /// Position before this transition.
+    pub position: SourcePosition,
+    /// State before the transition.
+    pub from: String,
+    /// Current input code point, or `None` for EOF.
+    pub input: Option<char>,
+    /// State after the transition.
+    pub to: String,
+    /// Portable actions interpreted by this runtime.
+    pub actions: Vec<String>,
+    /// Whether the current input was consumed.
+    pub consume: bool,
+}
+
+/// Runtime errors for tokenizer execution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TokenizerError {
+    /// The underlying state machine rejected a transition.
+    Machine(String),
+    /// The definition emitted an action outside the fixed portable vocabulary.
+    UnknownAction(String),
+    /// An action required a current code point but ran at EOF.
+    MissingCurrentCodePoint { action: String },
+    /// An action required a current token but none exists.
+    MissingCurrentToken { action: String },
+    /// A transition loop exceeded the per-input step budget.
+    StepLimitExceeded {
+        /// Current state when the budget was exceeded.
+        state: String,
+        /// Current position when the budget was exceeded.
+        position: SourcePosition,
+        /// Configured step limit.
+        limit: usize,
+    },
+    /// Input was pushed after `finish`.
+    AlreadyFinished,
+}
+
+impl fmt::Display for TokenizerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Machine(error) => write!(f, "{error}"),
+            Self::UnknownAction(action) => write!(f, "unknown tokenizer action `{action}`"),
+            Self::MissingCurrentCodePoint { action } => {
+                write!(f, "action `{action}` requires a current code point")
+            }
+            Self::MissingCurrentToken { action } => {
+                write!(f, "action `{action}` requires a current token")
+            }
+            Self::StepLimitExceeded {
+                state,
+                position,
+                limit,
+            } => write!(
+                f,
+                "tokenizer exceeded {limit} steps at state `{state}` near char offset {}",
+                position.char_offset
+            ),
+            Self::AlreadyFinished => write!(f, "cannot push input after tokenizer finish"),
+        }
+    }
+}
+
+impl Error for TokenizerError {}
+
+/// Convenient result alias for tokenizer operations.
+pub type Result<T> = std::result::Result<T, TokenizerError>;
+
+/// Tokenizer profile runtime.
+pub struct Tokenizer {
+    machine: EffectfulStateMachine,
+    text_buffer: String,
+    current_token: Option<CurrentToken>,
+    tokens: VecDeque<Token>,
+    diagnostics: Vec<Diagnostic>,
+    trace: Vec<TokenizerTraceEntry>,
+    position: SourcePosition,
+    max_steps_per_input: usize,
+    finished: bool,
+}
+
+impl Tokenizer {
+    /// Create a tokenizer from a statically linked effectful state machine.
+    pub fn new(machine: EffectfulStateMachine) -> Self {
+        Self {
+            machine,
+            text_buffer: String::new(),
+            current_token: None,
+            tokens: VecDeque::new(),
+            diagnostics: Vec::new(),
+            trace: Vec::new(),
+            position: SourcePosition::default(),
+            max_steps_per_input: 64,
+            finished: false,
+        }
+    }
+
+    /// Set the per-input step limit used to catch non-consuming transition loops.
+    pub fn with_max_steps_per_input(mut self, limit: usize) -> Self {
+        self.max_steps_per_input = limit.max(1);
+        self
+    }
+
+    /// Push one chunk of Unicode text into the tokenizer.
+    pub fn push(&mut self, chunk: &str) -> Result<()> {
+        if self.finished {
+            return Err(TokenizerError::AlreadyFinished);
+        }
+
+        for ch in chunk.chars() {
+            self.process_code_point(ch)?;
+        }
+        Ok(())
+    }
+
+    /// Finish the stream and emit EOF.
+    pub fn finish(&mut self) -> Result<()> {
+        if self.finished {
+            return Ok(());
+        }
+
+        for _ in 0..self.max_steps_per_input {
+            let before = self.position;
+            let from = self.machine.current_state().to_string();
+            let step = self
+                .machine
+                .process(EffectfulInput::end())
+                .map_err(TokenizerError::Machine)?;
+            self.apply_actions(&step.effects, None, before, &from)?;
+            self.trace.push(TokenizerTraceEntry {
+                position: before,
+                from,
+                input: None,
+                to: step.to,
+                actions: step.effects,
+                consume: step.consume,
+            });
+            if self.machine.is_final() {
+                self.finished = true;
+                return Ok(());
+            }
+        }
+
+        Err(TokenizerError::StepLimitExceeded {
+            state: self.machine.current_state().to_string(),
+            position: self.position,
+            limit: self.max_steps_per_input,
+        })
+    }
+
+    /// Drain all currently queued tokens.
+    pub fn drain_tokens(&mut self) -> Vec<Token> {
+        self.tokens.drain(..).collect()
+    }
+
+    /// Pop the next queued token.
+    pub fn next_token(&mut self) -> Option<Token> {
+        self.tokens.pop_front()
+    }
+
+    /// Current state name from the underlying machine.
+    pub fn current_state(&self) -> &str {
+        self.machine.current_state()
+    }
+
+    /// Current source position.
+    pub fn position(&self) -> SourcePosition {
+        self.position
+    }
+
+    /// Recoverable diagnostics.
+    pub fn diagnostics(&self) -> &[Diagnostic] {
+        &self.diagnostics
+    }
+
+    /// Tokenizer transition trace.
+    pub fn trace(&self) -> &[TokenizerTraceEntry] {
+        &self.trace
+    }
+
+    /// Reset the tokenizer to its initial state.
+    pub fn reset(&mut self) {
+        self.machine.reset();
+        self.text_buffer.clear();
+        self.current_token = None;
+        self.tokens.clear();
+        self.diagnostics.clear();
+        self.trace.clear();
+        self.position = SourcePosition::default();
+        self.finished = false;
+    }
+
+    fn process_code_point(&mut self, ch: char) -> Result<()> {
+        let event = ch.to_string();
+        let mut steps = 0;
+        loop {
+            if steps >= self.max_steps_per_input {
+                return Err(TokenizerError::StepLimitExceeded {
+                    state: self.machine.current_state().to_string(),
+                    position: self.position,
+                    limit: self.max_steps_per_input,
+                });
+            }
+            steps += 1;
+
+            let before = self.position;
+            let from = self.machine.current_state().to_string();
+            let step = self
+                .machine
+                .process(EffectfulInput::event(&event))
+                .map_err(TokenizerError::Machine)?;
+            self.apply_actions(&step.effects, Some(ch), before, &from)?;
+            self.trace.push(TokenizerTraceEntry {
+                position: before,
+                from,
+                input: Some(ch),
+                to: step.to,
+                actions: step.effects,
+                consume: step.consume,
+            });
+
+            if step.consume {
+                self.advance(ch);
+                return Ok(());
+            }
+        }
+    }
+
+    fn apply_actions(
+        &mut self,
+        actions: &[String],
+        current: Option<char>,
+        position: SourcePosition,
+        state: &str,
+    ) -> Result<()> {
+        for action in actions {
+            match action.as_str() {
+                "append_text(current)" => self.text_buffer.push(current.ok_or_else(|| {
+                    TokenizerError::MissingCurrentCodePoint {
+                        action: action.clone(),
+                    }
+                })?),
+                "append_text_replacement" => self.text_buffer.push('\u{FFFD}'),
+                "flush_text" => self.flush_text(),
+                "emit_current_as_text" => {
+                    let ch = current.ok_or_else(|| TokenizerError::MissingCurrentCodePoint {
+                        action: action.clone(),
+                    })?;
+                    self.text_buffer.push(ch);
+                    self.flush_text();
+                }
+                "create_start_tag" => {
+                    self.current_token = Some(CurrentToken::StartTag {
+                        name: String::new(),
+                        attributes: Vec::new(),
+                        self_closing: false,
+                    });
+                }
+                "create_end_tag" => {
+                    self.current_token = Some(CurrentToken::EndTag {
+                        name: String::new(),
+                    });
+                }
+                "append_tag_name(current)" => {
+                    let ch = current.ok_or_else(|| TokenizerError::MissingCurrentCodePoint {
+                        action: action.clone(),
+                    })?;
+                    self.append_tag_name(action, ch, false)?;
+                }
+                "append_tag_name(current_lowercase)" => {
+                    let ch = current.ok_or_else(|| TokenizerError::MissingCurrentCodePoint {
+                        action: action.clone(),
+                    })?;
+                    self.append_tag_name(action, ch, true)?;
+                }
+                "emit_current_token" => self.emit_current_token(action)?,
+                "emit(EOF)" => self.tokens.push_back(Token::Eof),
+                _ if action.starts_with("append_text(") && action.ends_with(')') => {
+                    let literal = action
+                        .trim_start_matches("append_text(")
+                        .trim_end_matches(')');
+                    self.text_buffer.push_str(literal);
+                }
+                _ if action.starts_with("parse_error(") && action.ends_with(')') => {
+                    let code = action
+                        .trim_start_matches("parse_error(")
+                        .trim_end_matches(')')
+                        .to_string();
+                    self.diagnostics.push(Diagnostic {
+                        code,
+                        position,
+                        state: state.to_string(),
+                    });
+                }
+                _ => return Err(TokenizerError::UnknownAction(action.clone())),
+            }
+        }
+        Ok(())
+    }
+
+    fn flush_text(&mut self) {
+        if !self.text_buffer.is_empty() {
+            self.tokens
+                .push_back(Token::Text(std::mem::take(&mut self.text_buffer)));
+        }
+    }
+
+    fn append_tag_name(&mut self, action: &str, ch: char, lowercase: bool) -> Result<()> {
+        let current_token =
+            self.current_token
+                .as_mut()
+                .ok_or_else(|| TokenizerError::MissingCurrentToken {
+                    action: action.to_string(),
+                })?;
+        match current_token {
+            CurrentToken::StartTag { name, .. } | CurrentToken::EndTag { name } => {
+                if lowercase {
+                    for lowered in ch.to_lowercase() {
+                        name.push(lowered);
+                    }
+                } else {
+                    name.push(ch);
+                }
+                Ok(())
+            }
+        }
+    }
+
+    fn emit_current_token(&mut self, action: &str) -> Result<()> {
+        let token =
+            self.current_token
+                .take()
+                .ok_or_else(|| TokenizerError::MissingCurrentToken {
+                    action: action.to_string(),
+                })?;
+        match token {
+            CurrentToken::StartTag {
+                name,
+                attributes,
+                self_closing,
+            } => self.tokens.push_back(Token::StartTag {
+                name,
+                attributes,
+                self_closing,
+            }),
+            CurrentToken::EndTag { name } => self.tokens.push_back(Token::EndTag { name }),
+        }
+        Ok(())
+    }
+
+    fn advance(&mut self, ch: char) {
+        self.position.byte_offset += ch.len_utf8();
+        self.position.char_offset += 1;
+        if ch == '\n' {
+            self.position.line += 1;
+            self.position.column = 1;
+        } else {
+            self.position.column += 1;
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CurrentToken {
+    StartTag {
+        name: String,
+        attributes: Vec<Attribute>,
+        self_closing: bool,
+    },
+    EndTag {
+        name: String,
+    },
+}
+
+/// Build the first statically linked HTML-like tokenizer skeleton.
+pub fn html_skeleton_machine() -> std::result::Result<EffectfulStateMachine, String> {
+    EffectfulStateMachine::new(
+        set(&[
+            "data",
+            "tag_open",
+            "tag_name",
+            "end_tag_open",
+            "end_tag_name",
+            "done",
+        ]),
+        set(&["<", "/", ">"]),
+        vec![
+            EffectfulTransition::new("data", EffectfulMatcher::Event("<".to_string()), "tag_open")
+                .with_effects(&["flush_text"]),
+            EffectfulTransition::new("data", EffectfulMatcher::End, "done")
+                .with_effects(&["flush_text", "emit(EOF)"])
+                .consuming(false),
+            EffectfulTransition::new("data", EffectfulMatcher::Any, "data")
+                .with_effects(&["append_text(current)"]),
+            EffectfulTransition::new(
+                "tag_open",
+                EffectfulMatcher::Event("/".to_string()),
+                "end_tag_open",
+            ),
+            EffectfulTransition::new("tag_open", EffectfulMatcher::End, "done")
+                .with_effects(&[
+                    "parse_error(eof-in-tag-open-state)",
+                    "append_text(<)",
+                    "flush_text",
+                    "emit(EOF)",
+                ])
+                .consuming(false),
+            EffectfulTransition::new("tag_open", EffectfulMatcher::Any, "tag_name")
+                .with_effects(&["create_start_tag", "append_tag_name(current_lowercase)"]),
+            EffectfulTransition::new("tag_name", EffectfulMatcher::Event(">".to_string()), "data")
+                .with_effects(&["emit_current_token"]),
+            EffectfulTransition::new("tag_name", EffectfulMatcher::End, "done")
+                .with_effects(&[
+                    "parse_error(eof-in-tag-name-state)",
+                    "emit_current_token",
+                    "emit(EOF)",
+                ])
+                .consuming(false),
+            EffectfulTransition::new("tag_name", EffectfulMatcher::Any, "tag_name")
+                .with_effects(&["append_tag_name(current_lowercase)"]),
+            EffectfulTransition::new("end_tag_open", EffectfulMatcher::Any, "end_tag_name")
+                .with_effects(&["create_end_tag", "append_tag_name(current_lowercase)"]),
+            EffectfulTransition::new(
+                "end_tag_name",
+                EffectfulMatcher::Event(">".to_string()),
+                "data",
+            )
+            .with_effects(&["emit_current_token"]),
+            EffectfulTransition::new("end_tag_name", EffectfulMatcher::End, "done")
+                .with_effects(&[
+                    "parse_error(eof-in-end-tag-name-state)",
+                    "emit_current_token",
+                    "emit(EOF)",
+                ])
+                .consuming(false),
+            EffectfulTransition::new("end_tag_name", EffectfulMatcher::Any, "end_tag_name")
+                .with_effects(&["append_tag_name(current_lowercase)"]),
+        ],
+        "data".to_string(),
+        set(&["done"]),
+    )
+}
+
+/// Build a tokenizer over the statically linked HTML skeleton machine.
+pub fn html_skeleton_tokenizer() -> Result<Tokenizer> {
+    html_skeleton_machine()
+        .map(Tokenizer::new)
+        .map_err(TokenizerError::Machine)
+}
+
+fn set(values: &[&str]) -> HashSet<String> {
+    values.iter().map(|value| value.to_string()).collect()
+}

--- a/code/packages/rust/state-machine-tokenizer/tests/tokenizer_test.rs
+++ b/code/packages/rust/state-machine-tokenizer/tests/tokenizer_test.rs
@@ -1,0 +1,157 @@
+use std::collections::HashSet;
+
+use state_machine::{EffectfulMatcher, EffectfulStateMachine, EffectfulTransition, END_INPUT};
+use state_machine_tokenizer::{
+    html_skeleton_machine, html_skeleton_tokenizer, Token, Tokenizer, TokenizerError,
+};
+
+#[test]
+fn html_skeleton_tokenizes_text_start_tag_end_tag_and_eof() {
+    let mut tokenizer = html_skeleton_tokenizer().unwrap();
+
+    tokenizer.push("<p>Hello</p>").unwrap();
+    tokenizer.finish().unwrap();
+
+    assert_eq!(
+        tokenizer.drain_tokens(),
+        vec![
+            Token::StartTag {
+                name: "p".to_string(),
+                attributes: Vec::new(),
+                self_closing: false,
+            },
+            Token::Text("Hello".to_string()),
+            Token::EndTag {
+                name: "p".to_string()
+            },
+            Token::Eof,
+        ]
+    );
+    assert_eq!(tokenizer.current_state(), "done");
+}
+
+#[test]
+fn html_skeleton_supports_chunked_input_and_unicode_any_matcher() {
+    let mut tokenizer = html_skeleton_tokenizer().unwrap();
+
+    tokenizer.push("Hello ").unwrap();
+    tokenizer.push("<B>").unwrap();
+    tokenizer.push("snowman: \u{2603}").unwrap();
+    tokenizer.push("</B>").unwrap();
+    tokenizer.finish().unwrap();
+
+    assert_eq!(
+        tokenizer.drain_tokens(),
+        vec![
+            Token::Text("Hello ".to_string()),
+            Token::StartTag {
+                name: "b".to_string(),
+                attributes: Vec::new(),
+                self_closing: false,
+            },
+            Token::Text("snowman: \u{2603}".to_string()),
+            Token::EndTag {
+                name: "b".to_string()
+            },
+            Token::Eof,
+        ]
+    );
+    assert!(tokenizer
+        .trace()
+        .iter()
+        .any(|entry| entry.input == Some('\u{2603}')));
+}
+
+#[test]
+fn html_skeleton_flushes_text_at_eof() {
+    let mut tokenizer = html_skeleton_tokenizer().unwrap();
+
+    tokenizer.push("plain text").unwrap();
+    tokenizer.finish().unwrap();
+
+    assert_eq!(
+        tokenizer.drain_tokens(),
+        vec![Token::Text("plain text".to_string()), Token::Eof]
+    );
+}
+
+#[test]
+fn html_skeleton_reports_recoverable_eof_diagnostic() {
+    let mut tokenizer = html_skeleton_tokenizer().unwrap();
+
+    tokenizer.push("<").unwrap();
+    tokenizer.finish().unwrap();
+
+    assert_eq!(
+        tokenizer.drain_tokens(),
+        vec![Token::Text("<".to_string()), Token::Eof]
+    );
+    assert_eq!(tokenizer.diagnostics().len(), 1);
+    assert_eq!(tokenizer.diagnostics()[0].code, "eof-in-tag-open-state");
+}
+
+#[test]
+fn tokenizer_rejects_unknown_actions() {
+    let mut tokenizer = Tokenizer::new(
+        EffectfulStateMachine::new(
+            set(&["data"]),
+            HashSet::new(),
+            vec![
+                EffectfulTransition::new("data", EffectfulMatcher::Any, "data")
+                    .with_effects(&["host_callback()"]),
+            ],
+            "data".to_string(),
+            HashSet::new(),
+        )
+        .unwrap(),
+    );
+
+    let error = tokenizer.push("x").unwrap_err();
+
+    assert_eq!(
+        error,
+        TokenizerError::UnknownAction("host_callback()".to_string())
+    );
+}
+
+#[test]
+fn tokenizer_bounds_non_consuming_transition_loops() {
+    let mut tokenizer = Tokenizer::new(
+        EffectfulStateMachine::new(
+            set(&["data"]),
+            set(&["x"]),
+            vec![EffectfulTransition::new("data", EffectfulMatcher::Any, "data").consuming(false)],
+            "data".to_string(),
+            HashSet::new(),
+        )
+        .unwrap(),
+    )
+    .with_max_steps_per_input(3);
+
+    let error = tokenizer.push("x").unwrap_err();
+
+    assert!(matches!(
+        error,
+        TokenizerError::StepLimitExceeded { limit: 3, .. }
+    ));
+}
+
+#[test]
+fn html_skeleton_machine_exports_definition_with_eof_matcher() {
+    let definition = html_skeleton_machine()
+        .unwrap()
+        .to_definition("html-skeleton-tokenizer");
+
+    assert!(definition.transitions.iter().any(|transition| {
+        transition.on.as_deref() == Some(END_INPUT)
+            && transition
+                .actions
+                .iter()
+                .any(|action| action == "emit(EOF)")
+            && !transition.consume
+    }));
+}
+
+fn set(values: &[&str]) -> HashSet<String> {
+    values.iter().map(|value| value.to_string()).collect()
+}

--- a/code/packages/rust/state-machine/CHANGELOG.md
+++ b/code/packages/rust/state-machine/CHANGELOG.md
@@ -23,6 +23,9 @@ All notable changes to the `state-machine` crate will be documented in this file
   and definition round-tripping.
 - Added a minimal HTML tokenizer skeleton test covering text buffering,
   start/end tag emission, and EOF effects.
+- Allowed `$any` transitions to accept runtime events outside the declared
+  alphabet when the current state has an `Any` fallback, which lets tokenizer
+  wrappers process arbitrary Unicode text without declaring every code point.
 
 ### Changed
 

--- a/code/packages/rust/state-machine/src/transducer.rs
+++ b/code/packages/rust/state-machine/src/transducer.rs
@@ -369,7 +369,7 @@ impl EffectfulStateMachine {
     /// Process one input event or EOF sentinel and return the emitted effects.
     pub fn process(&mut self, input: EffectfulInput<'_>) -> Result<EffectfulStep, String> {
         if let EffectfulInput::Event(event) = input {
-            if !self.alphabet.contains(event) {
+            if !self.alphabet.contains(event) && !self.current_state_has_any_transition() {
                 return Err(format!("Event '{event}' is not in the alphabet"));
             }
         }
@@ -402,6 +402,12 @@ impl EffectfulStateMachine {
         self.current = transition.target;
         self.trace.push(step.clone());
         Ok(step)
+    }
+
+    fn current_state_has_any_transition(&self) -> bool {
+        self.transitions.iter().any(|transition| {
+            transition.source == self.current && matches!(transition.matcher, EffectfulMatcher::Any)
+        })
     }
 }
 

--- a/code/packages/rust/state-machine/tests/transducer_test.rs
+++ b/code/packages/rust/state-machine/tests/transducer_test.rs
@@ -177,3 +177,24 @@ fn effectful_machine_rejects_consuming_eof_transition() {
 
     assert!(error.contains("EOF"));
 }
+
+#[test]
+fn any_transition_accepts_events_outside_declared_alphabet() {
+    let mut machine = EffectfulStateMachine::new(
+        set(&["data"]),
+        set(&["<"]),
+        vec![
+            EffectfulTransition::new("data", EffectfulMatcher::Any, "data")
+                .with_effects(&["append_text(current)"]),
+        ],
+        "data".to_string(),
+        HashSet::new(),
+    )
+    .unwrap();
+
+    let step = machine
+        .process(EffectfulInput::event("unicode-snowman"))
+        .unwrap();
+
+    assert_eq!(step.effects, vec!["append_text(current)".to_string()]);
+}

--- a/code/specs/F08-declarative-tokenizer-state-machines.md
+++ b/code/specs/F08-declarative-tokenizer-state-machines.md
@@ -150,7 +150,7 @@ with typed events:
 
 - ordinary events match declared alphabet entries
 - `$any` matches any non-EOF event after earlier transitions have had a chance
-  to match
+  to match, including Unicode code points that are not declared in the alphabet
 - `$end` matches the EOF sentinel and must not consume input
 - `actions` is an ordered list of portable effect identifiers
 - `consume = false` models EOF, lookahead, and future reconsume-style behavior
@@ -159,6 +159,12 @@ That representation is deliberately smaller than the full tokenizer profile,
 but it is enough for generated source and wrapper packages to share one
 execution primitive while the tokenizer-specific matcher/action vocabulary
 continues to grow.
+
+The Rust `state-machine-tokenizer` package is the first profile wrapper over
+that primitive. It owns the tokenizer loop, source positions, text buffer,
+current token, diagnostics, trace entries, a bounded non-consuming step budget,
+and a fixed portable action vocabulary. Browser-specific packages can then wrap
+that runtime with friendlier token names and parser integration.
 
 ## File Format
 
@@ -617,13 +623,15 @@ web-platform-tests/html and run them through the same runtime.
    pipeline to preserve transition actions and consume flags.
 4. Add a minimal HTML tokenizer skeleton test that proves text buffering,
    start/end tag emission, EOF handling, and generated transducer source.
-5. Add `code/tokenizers/html/html1.tokenizer.states.toml`.
-6. Compile the tokenizer definition into static source code with the F09
+5. Add the Rust `state-machine-tokenizer` profile runtime that interprets
+   portable actions over a statically linked transducer definition.
+6. Add `code/tokenizers/html/html1.tokenizer.states.toml`.
+7. Compile the tokenizer definition into static source code with the F09
    compiler.
-7. Rebuild `html1.0-lexer` as a wrapper over the generated definition.
-8. Add conformance fixtures and transition traces.
-9. Expand toward `whatwg-html.tokenizer.states.toml` state by state.
-10. Create a later tree-construction spec for insertion modes, stack of open
+8. Rebuild `html1.0-lexer` as a wrapper over the generated definition.
+9. Add conformance fixtures and transition traces.
+10. Expand toward `whatwg-html.tokenizer.states.toml` state by state.
+11. Create a later tree-construction spec for insertion modes, stack of open
    elements, active formatting elements, foster parenting, template insertion
    modes, and the adoption agency algorithm.
 


### PR DESCRIPTION
## Summary

- Add a new `state-machine-tokenizer` Rust crate that interprets `EffectfulStateMachine` actions into tokenizer tokens, buffers, diagnostics, source positions, and traces.
- Add a statically linked HTML skeleton tokenizer machine covering text, start/end tags, EOF flushing, recoverable diagnostics, chunked input, and arbitrary Unicode through `$any`.
- Loosen `EffectfulStateMachine` so `$any` can match runtime events outside the declared alphabet when the current state has an Any fallback.
- Update the tokenizer spec to describe the Rust profile wrapper layer.

## Verification

- `cargo fmt --check -p state-machine -p state-machine-tokenizer`
- `cargo test -p state-machine-tokenizer --no-run`
- `cargo test -p state-machine --no-run`
- `cargo clippy -p state-machine -p state-machine-tokenizer --no-deps -- -D warnings`

Note: I also attempted `cargo test -p state-machine-tokenizer -- --nocapture`; local execution still hits the fresh Rust test-binary runtime issue seen on prior PRs, so focused test binaries are compile-verified locally and CI is the runtime source of truth.